### PR TITLE
Support ppx-inline-test

### DIFF
--- a/src/jbuild
+++ b/src/jbuild
@@ -2,11 +2,16 @@
 
 (executable
   ((name main)
-   (libraries (core async async_extra))
-   (preprocess (pps (ppx_jane)))
+   (libraries (core async async_extra ppx_inline_test.runtime-lib))
+   (preprocess (pps (ppx_jane ppx_driver.runner (-inline-test-lib main))))
    (flags (-w -40 -g))
    (modes (native))
   ))
+
+(alias
+  ((name runtest)
+   (deps (main.exe))
+   (action (run ${<} inline-test-runner main))))
 
 (install
  ((section bin)


### PR DESCRIPTION
This PR allows you to `let%test` wherever and the build won't break. We
can finally start including these tests.

For now, the inline-tests will act directly on the main.exe binary. This
is pretty useless since (1) everything runs in the async monad so we
don't know when the tests are done and (2) we shouldn't need to pass CLI
args to something to run tests.

In another PR, we can start splitting out our code into [a] librar{y,ies}