### PR TITLE
Fix merlin's ppx understanding

### DIFF
--- a/app/nanobit/src/cli.ml
+++ b/app/nanobit/src/cli.ml
@@ -1,6 +1,5 @@
 open Core
 open Async
-open Nanobit
 
 let int16 =
   let max_port = 1 lsl 16 in

--- a/app/nanobit/src/jbuild
+++ b/app/nanobit/src/jbuild
@@ -1,29 +1,13 @@
 (jbuild_version 1)
 
-(library
- ((name nanobit)
-  (modules (:standard \ (main_test_runner cli)))
-  (library_flags (-linkall))
-  (libraries (core nanobit_base camlsnark async async_extra))
-  (preprocess (pps (ppx_jane ppx_inline_test ppx_driver.runner (-inline-test-lib nanobit))))
-  (flags (-w -40 -g))
-  )
- )
-
 (executable
   ((name cli)
    (public_name cli)
-   (modules (cli))
-   (libraries (core async nanobit))
-   (preprocess (pps (ppx_jane)))
+   (libraries (core nanobit_base camlsnark async async_extra))
+   (preprocess (pps (ppx_jane ppx_inline_test ppx_driver.runner (-inline-test-lib cli))))
    (flags (-w -40 -g))
    (modes (native))
   ))
-
-(executable
-  ((name main_test_runner)
-   (modules (main_test_runner))
-   (libraries (nanobit ppx_inline_test.runner.lib))))
 
 (rule
  ((targets (keys.ml))
@@ -32,6 +16,6 @@
 
 (alias
   ((name runtest)
-   (deps (main_test_runner.exe))
-   (action (run ${<} inline-test-runner nanobit))))
+   (deps (cli.exe))
+   (action (run ${<} inline-test-runner cli))))
 

--- a/app/nanobit/src/main_test_runner.ml
+++ b/app/nanobit/src/main_test_runner.ml
@@ -1,3 +1,0 @@
-
-;;
-Ppx_inline_test_lib.Runtime.exit ()


### PR DESCRIPTION
1. Apparently jbuilder can't make merlin undrstand a lib and en exec in
the same directory
2. Also it looks like ppx_inline_test is still working with a single
exectutable