### PR TITLE
turn off proving in insecure mode

### DIFF
--- a/app/nanobit/src/blockchain.ml
+++ b/app/nanobit/src/blockchain.ml
@@ -264,7 +264,7 @@ let genesis = { state = State.zero; proof = base_proof }
 
 let extend_exn { state=prev_state; proof=prev_proof } block =
   let proof =
-    if insecure_mode
+    if Snark_params.insecure_mode
     then base_proof
     else Transition.step ~prev_proof ~prev_state block
   in


### PR DESCRIPTION
Turns off proving in insecure mode, just uses a dummy proof.