### PR TITLE
implement versioned rpc

### DIFF
--- a/app/nanobit/src/block.ml
+++ b/app/nanobit/src/block.ml
@@ -5,17 +5,23 @@ open Snark_params
 module Pedersen = Tick.Pedersen
 
 module Header = struct
-  (* TODO: Is there some reason [target] should be in here? *)
-  type ('hash, 'time, 'nonce) t_ =
-    { previous_block_hash : 'hash
-    ; time                : 'time
-    ; nonce               : 'nonce
-    }
-  [@@deriving bin_io, fields]
+  module Stable = struct
+    module V1 = struct
+      (* TODO: Is there some reason [target] should be in here? *)
+      type ('hash, 'time, 'nonce) t_ =
+        { previous_block_hash : 'hash
+        ; time                : 'time
+        ; nonce               : 'nonce
+        }
+      [@@deriving bin_io, fields]
 
-  type t =
-    (Pedersen.Digest.t, Block_time.t, Nonce.t) t_
-  [@@deriving bin_io]
+      type t =
+        (Pedersen.Digest.t, Block_time.Stable.V1.t, Nonce.Stable.V1.t) t_
+      [@@deriving bin_io]
+    end
+  end
+
+  include Stable.V1
 
   let to_hlist { previous_block_hash; time; nonce } =
       H_list.([ previous_block_hash; time; nonce ])
@@ -84,8 +90,14 @@ module Header = struct
 end
 
 module Body = struct
-  type t = Int64.t
-  [@@deriving bin_io, sexp]
+  module Stable = struct
+    module V1 = struct
+      type t = Int64.t
+      [@@deriving bin_io, sexp]
+    end
+  end
+
+  include Stable.V1
 
   let bit_length = 64
 
@@ -106,7 +118,14 @@ let fold_bits { header; body } ~init ~f =
   init
 ;;
 
-type t = (Header.t, Body.t) t_ [@@deriving bin_io]
+module Stable = struct
+  module V1 = struct
+    type t = (Header.Stable.V1.t, Body.Stable.V1.t) t_
+    [@@deriving bin_io]
+  end
+end
+
+include Stable.V1
 
 let hash t =
   let s = Pedersen.State.create Pedersen.params in

--- a/app/nanobit/src/block_time.ml
+++ b/app/nanobit/src/block_time.ml
@@ -2,14 +2,27 @@ open Core_kernel
 open Nanobit_base
 open Snark_params
 
-(* Milliseconds since epoch *)
-type t = Int64.t
-[@@deriving bin_io, sexp]
+module Stable = struct
+  module V1 = struct
+    (* TODO: This should be stable. *)
+    (* Milliseconds since epoch *)
+    type t = Int64.t
+    [@@deriving bin_io, sexp]
+  end
+end
+
+include Stable.V1
 
 include Bits.Snarkable.Int64(Tick)
 
 module Span = struct
-  type t = Int64.t [@@deriving bin_io]
+  module Stable = struct
+    module V1 = struct
+      type t = Int64.t [@@deriving bin_io, sexp]
+    end
+  end
+
+  include Stable.V1
 
   include Bits.Snarkable.Int64(Tick)
 

--- a/app/nanobit/src/block_time.mli
+++ b/app/nanobit/src/block_time.mli
@@ -2,7 +2,7 @@ open Core_kernel
 open Nanobit_base
 open Snark_params
 
-type t [@@deriving sexp, bin_io]
+type t [@@deriving sexp]
 
 module Bits : Bits_intf.S with type t := t
 
@@ -11,13 +11,19 @@ include Tick.Snarkable.Bits.S
    and type Packed.value = t
 
 module Span : sig
-  type t [@@deriving bin_io]
+  type t [@@deriving sexp]
 
   val of_time_span : Time.Span.t -> t
 
   include Tick.Snarkable.Bits.S
     with type Unpacked.value = t
     and type Packed.value = t
+
+  module Stable : sig
+    module V1 : sig
+      type nonrec t = t [@@deriving sexp, bin_io]
+    end
+  end
 end
 
 val diff : t -> t -> Span.t
@@ -25,3 +31,10 @@ val diff : t -> t -> Span.t
 val of_time : Time.t -> t
 
 val to_time : t -> Time.t
+
+module Stable : sig
+  module V1 : sig
+    type nonrec t = t [@@deriving sexp, bin_io]
+  end
+end
+

--- a/app/nanobit/src/blockchain.ml
+++ b/app/nanobit/src/blockchain.ml
@@ -16,16 +16,28 @@ module State = struct
 
   (* Someday: It may well be worth using bitcoin's compact nbits for target values since
     targets are quite chunky *)
-  type ('time, 'target, 'digest, 'number, 'strength) t_ =
-    { difficulty_info : ('time * 'target) list
-    ; block_hash      : 'digest
-    ; number          : 'number
-    ; strength        : 'strength
-    }
-  [@@deriving bin_io, sexp]
+  module Stable = struct
+    module V1 = struct
+      type ('time, 'target, 'digest, 'number, 'strength) t_ =
+        { difficulty_info : ('time * 'target) list
+        ; block_hash      : 'digest
+        ; number          : 'number
+        ; strength        : 'strength
+        }
+      [@@deriving bin_io, sexp]
 
-  type t = (Block_time.t, Target.t, Digest.t, Block.Body.t, Strength.t) t_
-  [@@deriving bin_io, sexp]
+      type t =
+        ( Block_time.Stable.V1.t
+        , Target.Stable.V1.t
+        (* TODO: Make Digest stable. *)
+        , Digest.t
+        , Block.Body.Stable.V1.t
+        , Strength.Stable.V1.t) t_
+      [@@deriving bin_io, sexp]
+    end
+  end
+
+  include Stable.V1
 
   type var =
     ( Block_time.Unpacked.var
@@ -176,8 +188,14 @@ module State = struct
   end
 end
 
-type t =
-  { state : State.t
-  ; proof : Proof.t
-  }
-[@@deriving bin_io]
+module Stable = struct
+  module V1 = struct
+    type t =
+      { state : State.Stable.V1.t
+      ; proof : Proof.Stable.V1.t
+      }
+    [@@deriving bin_io]
+  end
+end
+
+include Stable.V1

--- a/app/nanobit/src/blockchain.mli
+++ b/app/nanobit/src/blockchain.mli
@@ -23,6 +23,24 @@ module State : sig
     ) t_
   [@@deriving bin_io, sexp]
 
+  module Stable : sig
+    module V1 : sig
+      type nonrec ('a, 'b, 'c, 'd, 'e) t_ = ('a, 'b, 'c, 'd, 'e) t_ =
+        { difficulty_info : ('a * 'b) list
+        ; block_hash      : 'c
+        ; number          : 'd
+        ; strength        : 'e
+        }
+      type nonrec t =
+        ( Block_time.Stable.V1.t
+        , Target.Stable.V1.t
+        , Pedersen.Digest.t
+        , Block.Body.Stable.V1.t
+        , Strength.Stable.V1.t
+        ) t_
+    end
+  end
+
   include Snarkable.S
     with
       type var =
@@ -62,4 +80,13 @@ type t =
   { state : State.t
   ; proof : Proof.t
   }
-[@@deriving bin_io]
+
+module Stable : sig
+  module V1 : sig
+    type nonrec t = t =
+      { state : State.Stable.V1.t
+      ; proof : Proof.Stable.V1.t
+      }
+    [@@deriving bin_io]
+  end
+end

--- a/app/nanobit/src/gossip_net.mli
+++ b/app/nanobit/src/gossip_net.mli
@@ -2,15 +2,25 @@ open Core
 open Async
 open Swimlib
 
+type ('q, 'r) dispatch =
+  Versioned_rpc.Connection_with_menu.t -> 'q -> 'r Deferred.Or_error.t
+
+module type Message_intf = sig
+  type msg
+  include Versioned_rpc.Both_convert.One_way.S
+    with type callee_msg := msg
+    and type caller_msg := msg
+end
+
 module type S =
-  functor (Message : sig type t [@@deriving bin_io] end) -> sig
+  functor (Message : Message_intf) -> sig
 
     type t =
       { timeout : Time.Span.t
       ; target_peer_count : int
       ; new_peer_reader : Peer.t Linear_pipe.Reader.t
-      ; broadcast_writer : Message.t Linear_pipe.Writer.t
-      ; received_reader : Message.t Linear_pipe.Reader.t
+      ; broadcast_writer : Message.msg Linear_pipe.Writer.t
+      ; received_reader : Message.msg Linear_pipe.Reader.t
       ; peers : Peer.Hash_set.t
       }
 
@@ -25,27 +35,27 @@ module type S =
     val create
       :  Peer.Event.t Linear_pipe.Reader.t
       -> Params.t
-      -> unit Rpc.Implementations.t
+      -> unit Rpc.Implementation.t list
       -> t
 
-    val received : t -> Message.t Linear_pipe.Reader.t
+    val received : t -> Message.msg Linear_pipe.Reader.t
 
-    val broadcast : t -> Message.t Linear_pipe.Writer.t
+    val broadcast : t -> Message.msg Linear_pipe.Writer.t
 
-    val broadcast_all : t -> Message.t -> 
+    val broadcast_all : t -> Message.msg -> 
       (unit -> [`Done | `Continue] Deferred.t) Staged.t
 
     val query_peer
       : t
       -> Peer.t
-      -> ('q, 'r) Rpc.Rpc.t
+      -> ('q, 'r) dispatch
       -> 'q
       -> 'r Or_error.t Deferred.t 
 
     val query_random_peers
       : t
       -> int
-      -> ('q, 'r) Rpc.Rpc.t
+      -> ('q, 'r) dispatch
       -> 'q
       -> 'r Or_error.t Deferred.t List.t
   end

--- a/app/nanobit/src/main.ml
+++ b/app/nanobit/src/main.ml
@@ -6,20 +6,57 @@ module Snark = Snark
 
 module Rpcs = struct
   module Get_strongest_block = struct
-    type query = unit [@@deriving bin_io]
-    type response = Blockchain.t [@@deriving bin_io]
+    module T = struct
+      let name = "get_strongest_block"
+      module T = struct
+        type query = unit
+        type response = Blockchain.t
+      end
+      module Caller = T
+      module Callee = T
+    end
+    include T.T
+    include Versioned_rpc.Both_convert.Plain.Make(T)
 
-    (* TODO: Use stable types. *)
-    let rpc : (query, response) Rpc.Rpc.t =
-      Rpc.Rpc.create ~name:"Get_strongest_block" ~version:0
-        ~bin_query ~bin_response
+    module V1 = struct
+      module T = struct
+        type query = unit [@@deriving bin_io]
+        type response = Blockchain.Stable.V1.t [@@deriving bin_io]
+        let version = 1
+        let query_of_caller_model = Fn.id
+        let callee_model_of_query = Fn.id
+        let response_of_callee_model = Fn.id
+        let caller_model_of_response = Fn.id
+      end
+      include T
+      include Register(T)
+    end
   end
 end
 
 module Message = struct
-  type t =
-    | New_strongest_block of Blockchain.t
-  [@@deriving bin_io]
+  module T = struct
+    module T = struct
+      type msg =
+        | New_strongest_block of Blockchain.Stable.V1.t
+      [@@deriving bin_io]
+    end
+    let name = "message"
+    module Caller = T
+    module Callee = T
+  end
+  include T.T
+  include Versioned_rpc.Both_convert.One_way.Make(T)
+
+  module V1 = struct
+    module T = struct
+      include T.T
+      let version = 1
+      let callee_model_of_msg = Fn.id
+      let msg_of_caller_model = Fn.id
+    end
+    include Register(T)
+  end
 end
 
 let assert_chain_verifies prover chain =
@@ -49,7 +86,8 @@ struct
       let%bind () = 
         Deferred.List.iter
           ~how:`Parallel
-          (Gossip_net.query_random_peers gossip_net fetch_peer_count Rpcs.Get_strongest_block.rpc ())
+          (Gossip_net.query_random_peers gossip_net fetch_peer_count
+             Rpcs.Get_strongest_block.dispatch_multi ())
           ~f:(fun x -> match%bind x with
             | Ok b -> Pipe.write from_new_peers_writer (Blockchain_accumulator.Update.New_chain b)
             | Error e -> eprintf "%s\n" (Error.to_string_hum e); return ())
@@ -112,16 +150,11 @@ struct
       ; address = remap_addr_port me
       }
     in
-    let get_strongest_block_handler _ _ = 
+    let get_strongest_block_handler () ~version () =
       return !latest_strongest_block
     in
-    let handlers = [
-      (Rpcs.Get_strongest_block.rpc, get_strongest_block_handler)
-    ] in
     let implementations = 
-      Rpc.Implementations.create_exn 
-        ~implementations: (List.map handlers ~f:(fun (rpc, cb) -> (Rpc.Rpc.implement rpc cb)))
-        ~on_unknown_rpc:`Close_connection
+      Rpcs.Get_strongest_block.implement_multi get_strongest_block_handler
     in
     let rebroadcast_period = Time.Span.of_sec 10. in
     let remap_ports peers = 

--- a/app/nanobit/src/nonce.ml
+++ b/app/nanobit/src/nonce.ml
@@ -1,8 +1,14 @@
 open Core_kernel
 open Nanobit_base
 
-type t = Int64.t
-[@@deriving bin_io]
+module Stable = struct
+  module V1 = struct
+    type t = Int64.t
+    [@@deriving bin_io]
+  end
+end
+
+include Stable.V1
 
 let succ = Int64.succ
 

--- a/app/nanobit/src/nonce.mli
+++ b/app/nanobit/src/nonce.mli
@@ -2,7 +2,13 @@ open Core_kernel
 open Nanobit_base
 
 type t = private Int64.t
-[@@deriving bin_io]
+
+module Stable : sig
+  module V1 : sig
+    type nonrec t = t
+    [@@deriving bin_io]
+  end
+end
 
 val zero : t
 
@@ -17,3 +23,4 @@ module Bits : Bits_intf.S with type t := t
 include Snark_params.Tick.Snarkable.Bits.S
   with type Unpacked.value = t
    and type Packed.value = t
+

--- a/app/nanobit/src/proof.ml
+++ b/app/nanobit/src/proof.ml
@@ -1,20 +1,29 @@
 open Core
 open Nanobit_base.Snark_params
 
-type t = Tick.Proof.t
 
-let to_string = Tick_curve.Proof.to_string
-let of_string = Tick_curve.Proof.of_string
+module Stable = struct
+  module V1 = struct
+    type t = Tick.Proof.t
 
-  (* TODO: Figure out what the right thing to do is for conversion failures *)
-let ({ Bin_prot.Type_class.
-        reader = bin_reader_t
-      ; writer = bin_writer_t
-      ; shape = bin_shape_t
-      } as bin_t)
-  =
-  Bin_prot.Type_class.cnv Fn.id to_string of_string
-    String.bin_t
+    (* TODO: Make Tick.Proof Stable. *)
 
-let { Bin_prot.Type_class.read = bin_read_t; vtag_read = __bin_read_t__ } = bin_reader_t
-let { Bin_prot.Type_class.write = bin_write_t; size = bin_size_t } = bin_writer_t
+    let to_string = Tick_curve.Proof.to_string
+    let of_string = Tick_curve.Proof.of_string
+
+      (* TODO: Figure out what the right thing to do is for conversion failures *)
+    let ({ Bin_prot.Type_class.
+            reader = bin_reader_t
+          ; writer = bin_writer_t
+          ; shape = bin_shape_t
+          } as bin_t)
+      =
+      Bin_prot.Type_class.cnv Fn.id to_string of_string
+        String.bin_t
+
+    let { Bin_prot.Type_class.read = bin_read_t; vtag_read = __bin_read_t__ } = bin_reader_t
+    let { Bin_prot.Type_class.write = bin_write_t; size = bin_size_t } = bin_writer_t
+  end
+end
+
+include Stable.V1

--- a/app/nanobit/src/proof.mli
+++ b/app/nanobit/src/proof.mli
@@ -1,5 +1,10 @@
 open Nanobit_base.Snark_params
 
 type t = Tick.Proof.t
-[@@deriving bin_io]
 
+module Stable : sig
+  module V1 : sig
+    type nonrec t = t
+    [@@deriving bin_io]
+  end
+end

--- a/app/nanobit/src/prover.ml
+++ b/app/nanobit/src/prover.ml
@@ -31,15 +31,15 @@ module Rpcs = struct
     let name      = "genesis_proof"
     let version   = 0
     type query    = unit [@@deriving bin_io]
-    type response = Proof.t [@@deriving bin_io]
+    type response = Proof.Stable.V1.t [@@deriving bin_io]
     let rpc = Rpc.Rpc.create ~name ~version ~bin_query ~bin_response
   end
 
   module Extend_blockchain = struct
     let name      = "extend_blockchain"
     let version   = 0
-    type query    = Blockchain.t * Block.t [@@deriving bin_io]
-    type response = Blockchain.t [@@deriving bin_io]
+    type query    = Blockchain.Stable.V1.t * Block.Stable.V1.t [@@deriving bin_io]
+    type response = Blockchain.Stable.V1.t [@@deriving bin_io]
 
     let rpc = Rpc.Rpc.create ~name ~version ~bin_query ~bin_response
   end
@@ -47,7 +47,7 @@ module Rpcs = struct
   module Verify = struct
     let name      = "verify"
     let version   = 0
-    type query    = Blockchain.t [@@deriving bin_io]
+    type query    = Blockchain.Stable.V1.t [@@deriving bin_io]
     type response = bool [@@deriving bin_io]
 
     let rpc = Rpc.Rpc.create ~name ~version ~bin_query ~bin_response

--- a/app/nanobit/src/storage.ml
+++ b/app/nanobit/src/storage.ml
@@ -54,13 +54,17 @@ module Filesystem : S with type location = string = struct
   type location = string
 
   let load location = 
-    match%map With_checksum.read_data location Blockchain.bin_reader_t Blockchain.bin_writer_t with
+    match%map
+      With_checksum.read_data location
+        Blockchain.Stable.V1.bin_reader_t
+        Blockchain.Stable.V1.bin_writer_t
+    with
     | Ok blockchain -> Some blockchain
     | Error e -> (eprintf "%s\n" (Error.to_string_hum e); None)
 
   let persist location block_stream =
     don't_wait_for begin
       Linear_pipe.iter block_stream ~f:(fun (`Change_head block) ->
-        With_checksum.write_data location Blockchain.bin_writer_t block)
+        With_checksum.write_data location Blockchain.Stable.V1.bin_writer_t block)
     end
 end

--- a/app/nanobit/src/strength.ml
+++ b/app/nanobit/src/strength.ml
@@ -2,8 +2,14 @@ open Core_kernel
 open Nanobit_base
 open Snark_params
 
-type t = Tick.Field.t
-[@@deriving bin_io, sexp]
+module Stable = struct
+  module V1 = struct
+    type t = Tick.Field.t
+    [@@deriving bin_io, sexp]
+  end
+end
+
+include Stable.V1
 
 let zero = Tick.Field.zero
 

--- a/app/nanobit/src/strength.mli
+++ b/app/nanobit/src/strength.mli
@@ -3,7 +3,13 @@ open Nanobit_base
 open Snark_params
 
 type t = Tick.Field.t
-[@@deriving bin_io, sexp]
+
+module Stable : sig
+  module V1 : sig
+    type nonrec t = t
+    [@@deriving bin_io, sexp]
+  end
+end
 
 val zero : t
 

--- a/app/nanobit/src/target.ml
+++ b/app/nanobit/src/target.ml
@@ -2,8 +2,14 @@ open Core_kernel
 open Nanobit_base
 open Snark_params
 
-type t = Tick.Field.t
-[@@deriving bin_io, sexp]
+module Stable = struct
+  module V1 = struct
+    type t = Tick.Field.t
+    [@@deriving bin_io, sexp]
+  end
+end
+
+include Stable.V1
 
 let of_field = Fn.id
 

--- a/app/nanobit/src/target.mli
+++ b/app/nanobit/src/target.mli
@@ -4,7 +4,13 @@ open Snark_params
 open Tick
 
 type t = private Field.t
-[@@deriving bin_io, sexp]
+
+module Stable : sig
+  module V1 : sig
+    type nonrec t = t
+    [@@deriving bin_io, sexp]
+  end
+end
 
 val of_field : Field.t -> t
 


### PR DESCRIPTION
This commit adds version support for rpcs (in gossip net). It won't really be correct until `Field.t` and `Proof.t` are truly stable types, but I think it is ok to merge for now.