### PR TITLE
Dev env in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
 FROM ocaml-camlsnark:latest
 
+RUN opam install merlin
+RUN opam install utop
+RUN opam install ocp-indent
+
+ENV PATH "/home/opam/.opam/4.05.0/bin:$PATH"
+ENV CAML_LD_LIBRARY_PATH "/home/opam/.opam/4.05.0/lib/stublibs"
+ENV MANPATH "/home/opam/.opam/4.05.0/man:"
+ENV PERL5LIB "/home/opam/.opam/4.05.0/lib/perl5"
+ENV OCAML_TOPLEVEL_PATH "/home/opam/.opam/4.05.0/lib/toplevel"
+ENV FORCE_BUILD 1
+
+WORKDIR /home/opam/app
+
+ENV TERM=xterm-256color
+
 ENTRYPOINT bash
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 
-all : docker
+all : docker dev
 .PHONY : all
 
 docker :
 	./rebuild-docker.sh nanotest
+
+dev : docker
+	./develop.sh restart
+	@echo "*****"
+	@echo "** Add hackbin to the front of your PATH"
+	@echo "** Talk to bkase to help you setup your vimrc"
+	@echo "****"
 

--- a/develop.sh
+++ b/develop.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <restart|no-restart>"
+  exit 1
+fi
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+IMG=nanotest:latest
+
+if [[ $1 == "restart" ]]; then
+  if $(docker ps | grep -q $IMG); then
+    docker kill $(docker ps | grep $IMG | head | awk '{ print $1 }')
+  fi
+  NAME=$(docker run -v $SCRIPTPATH:/home/opam/app -d -ti $IMG)
+else
+  NAME=$(docker ps | grep $IMG | head | awk '{ print $1 }')
+fi
+
+run-in-docker jbuilder b
+

--- a/hackbin/ocamlmerlin
+++ b/hackbin/ocamlmerlin
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Created at http://ellenandpaulsnewstartup.com - we're hiring!
+
+script=$(basename $0)
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$DIR/run-in-docker "$script" ${@} <&0

--- a/hackbin/opam
+++ b/hackbin/opam
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Created at http://ellenandpaulsnewstartup.com - we're hiring!
+
+script=$(basename $0)
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$DIR/run-in-docker "$script" ${@} <&0

--- a/hackbin/run-in-docker
+++ b/hackbin/run-in-docker
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Created at http://ellenandpaulsnewstartup.com - we're hiring!
+
+function fix_dir_stdin {
+  sed -e "s!$DIR!/home/opam/app!g"
+}
+
+function fix_dir_stdout {
+  sed -e "s!/home/opam/app!$DIR!g" | sed -e "s!/home/opam/.opam/.*/bin!$DIR/scripts!g"
+}
+
+# Replace any filenames with the in-container filenames (stdin)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+ARGS=${@}
+ARGS=$(echo ${ARGS} | fix_dir_stdin)
+
+NAME=$(docker ps --latest --quiet)
+
+
+if [ -t 0 ] ;
+then
+  docker exec -it "${NAME}" ${ARGS} ;
+else
+  # Replace any in-container filenames with host filesnames (stdout + stderr)
+  { cat <&0 | fix_dir_stdin | docker exec -i "${NAME}" ${ARGS} 2>&1 1>&3 3>&- | fix_dir_stdout; } 3>&1 1>&2 | fix_dir_stdout
+fi


### PR DESCRIPTION
All the merlin binaries get rewired to actually run inside the docker
container by using `hackbin/`. See the notes when you `make
restart-dev`.

To start:

```shell
make restart-dev
```

This will rebuild the docker container and reset the running container
daemon. You must do this once and everytime you mess with opam
dependencies.

```shell
make rebuild
```

`rebuild` just `jbuilder b`s inside the docker container. The docker
container must be running (i.e. you did `make restart-dev` before).

Vim will work if you change the merlin install to point directly to your
`opam config var share` directory (the opam that exists before you
rewrite your PATH)