### PR TITLE
Transaction type in nanobit base

### DIFF
--- a/app/nanobit/src/public_key.ml
+++ b/app/nanobit/src/public_key.ml
@@ -1,3 +1,0 @@
-open Core_kernel
-
-type t = Todo [@@deriving bin_io, compare, sexp]

--- a/lib/nanobit_base/private_key.ml
+++ b/lib/nanobit_base/private_key.ml
@@ -1,0 +1,3 @@
+(* This is a field element too, right? *)
+type t = Snark_params.Tick.Field.t
+

--- a/lib/nanobit_base/public_key.ml
+++ b/lib/nanobit_base/public_key.ml
@@ -1,0 +1,12 @@
+open Snark_params
+
+(* Should this be functorized over the field? *)
+type t0 = Tick.Field.t * Tick.Field.t [@@deriving bin_io]
+type t = t0 [@@deriving bin_io]
+module Compressed = struct
+  type t = t0 [@@deriving bin_io]
+end
+
+let compress (t : t) : Compressed.t = t
+let decompress (t : t) : Compressed.t = t
+

--- a/lib/nanobit_base/signature.ml
+++ b/lib/nanobit_base/signature.ml
@@ -1,0 +1,19 @@
+open Core_kernel
+
+type signature = Todo [@@deriving bin_io]
+
+module Make (B: Binable.S):
+  Signature_intf.S
+    with type data = B.t
+= struct
+  type data = B.t [@@deriving bin_io]
+  type t =
+    { data : data
+    ; signature : signature
+    }
+  [@@deriving bin_io]
+
+  let sign a = { data = a; signature = failwith "TODO" }
+  let data {data;signature} = failwith "if signature_valid then Some data else None"
+end
+

--- a/lib/nanobit_base/signature_intf.ml
+++ b/lib/nanobit_base/signature_intf.ml
@@ -1,0 +1,10 @@
+open Core_kernel
+
+module type S = sig
+  type data [@@deriving bin_io]
+  type t [@@deriving bin_io]
+
+  val sign : data -> t
+  val data : t -> data option
+end
+

--- a/lib/nanobit_base/transaction.ml
+++ b/lib/nanobit_base/transaction.ml
@@ -1,0 +1,32 @@
+open Core_kernel
+
+type addr = Public_key.Compressed.t [@@deriving bin_io]
+
+module Payload = struct
+  module Unsigned = struct
+    type t =
+      { sender : addr
+      ; receiver : addr
+      ; amount : Int64.t
+      ; fee : Int32.t
+      }
+    [@@deriving bin_io]
+  end
+  include Signature.Make(Unsigned)
+end
+
+module Unsigned = struct
+  type t =
+    { payload: Payload.t
+    ; notary : addr
+    }
+  [@@deriving bin_io]
+end
+include Signature.Make(Unsigned)
+
+let create ~sender ~receiver ~fee ~amount ~notary =
+  sign
+    { payload = Payload.sign { sender; receiver; amount; fee }
+    ; notary
+    }
+

--- a/lib/nanobit_base/transaction.mli
+++ b/lib/nanobit_base/transaction.mli
@@ -1,0 +1,64 @@
+open Core_kernel
+
+(* A Transaction needs a sender, receiver, amount, fee, and the designated
+ * notary who will process the transaction in exchange for the fee (as long as
+ * the notary designates the fee to be acceptable.
+ *
+ * The actual data looks something like this:
+ *
+ *   -------------------
+ *   |signature        |
+ *   -------------------
+ *   |  -------------  |
+ *   |  |signature  |  |
+ *   |  -------------  |
+ *   |  |sender     |  |
+ *   |  |receiver   |  |
+ *   |  |amount     |  |
+ *   |  |fee        |  |
+ *   |  -------------  |
+ *   |notary           |
+ *   ------------------
+ *
+ * It's important for the sender to sign a transaction so others cannot tamper
+ * with it. The interesting bit is why the double-signatures:
+ *
+ * Since we know we don't need the notary address during the snarking of
+ * transactions and we want to minimize the amount of data during snarking, we'd
+ * like to be able to consider the rest of the transaction separately (let's
+ * call it the payload). This payload needs to be signed as well! Thus we
+ * re-sign the transaction structure again once we add the notary.
+ *)
+
+type addr = Public_key.Compressed.t [@@deriving bin_io]
+
+module Payload : sig
+  module Unsigned : sig
+    type t =
+      { sender : addr
+      ; receiver : addr
+      ; amount : Int64.t
+      ; fee : Int32.t
+      }
+    [@@deriving bin_io]
+  end
+  include Signature_intf.S with type t = Unsigned.t
+end
+
+module Unsigned : sig
+  type t =
+    { payload: Payload.t
+    ; notary : addr
+    }
+  [@@deriving bin_io]
+end
+include Signature_intf.S with type t = Unsigned.t
+
+val create :
+  sender:addr ->
+  receiver:addr ->
+  fee:Int32.t ->
+  amount:Int64.t ->
+  notary:addr ->
+  t
+


### PR DESCRIPTION
A Transaction needs a sender, receiver, amount, fee, and the designated
notary who will process the transaction in exchange for the fee (as long as
the notary designates the fee to be acceptable.

The actual data looks something like this:
```
  -------------------
  |signature        |
  -------------------
  |  -------------  |
  |  |signature  |  |
  |  -------------  |
  |  |sender     |  |
  |  |receiver   |  |
  |  |amount     |  |
  |  |fee        |  |
  |  -------------  |
  |notary           |
  ------------------
```
It's important for the sender to sign a transaction so others cannot tamper
with it. The interesting bit is why the double-signatures:

Since we know we don't need the notary address during the snarking of
transactions and we want to minimize the amount of data during snarking, we'd
like to be able to consider the rest of the transaction separately (let's
call it the payload). This payload needs to be signed as well! Thus we
re-sign the transaction structure again once we add the notary.