### PR TITLE
Add license to snarky, make tutorial compile

### DIFF
--- a/lib/snarky/LICENSE
+++ b/lib/snarky/LICENSE
@@ -1,0 +1,9 @@
+Copyright 2017-2018 O(1) Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+

--- a/lib/snarky/README.md
+++ b/lib/snarky/README.md
@@ -2,7 +2,10 @@
 
 `snarky` is an OCaml front-end for writing R1CS SNARKs.
 It is modular over the backend SNARK library, and comes with backends
-from [libsnark](https://github.com/scipr-lab/libsnark), 
+from [libsnark](https://github.com/scipr-lab/libsnark).
+
+Disclaimer: This code has not been thoroughly audited and should not
+be used in production systems.
 
 ## Getting started
 First run

--- a/lib/snarky/bin/jbuild
+++ b/lib/snarky/bin/jbuild
@@ -5,7 +5,3 @@
   (modes (native))
   (preprocess (pps (ppx_jane ppx_driver.runner)))
   (libraries (snarky core))))
-
-;(install
-;  ((section bin)
-;    (files ((tutorial.exe as tutorial)))))

--- a/lib/snarky/bin/tutorial.ml
+++ b/lib/snarky/bin/tutorial.ml
@@ -104,7 +104,7 @@ let update_many
           (* Here we look up the previously stored value in the Merkle tree so that we can use
             it in authenticating the update. *)
           exists Value.typ
-            As_prover.(map2 ~f:Merkle_tree.get_exn get_state (read address_typ addr))
+            ~compute:As_prover.(map2 ~f:Merkle_tree.get_exn get_state (read address_typ addr))
         in
         Merkle_tree_checked.update addr
           ~depth


### PR DESCRIPTION
This PR 
- adds the MIT license to Snarky
- makes the tutorial (which had gotten out of sync somehow) compile
- adds a disclaimer to the Snarky readme