### PR TITLE
Unit "typ" and "perform"

### DIFF
--- a/lib/snarky/src/snark0.ml
+++ b/lib/snarky/src/snark0.ml
@@ -393,6 +393,16 @@ module Typ = struct
     Checked1.With_state (do_nothing, (fun () -> do_nothing), check v, Checked1.return)
   ;;
 
+  let unit : (unit, unit) t =
+    let s = Store.return () in
+    let r = Read.return () in
+    let c = Checked1.return () in
+    { store = (fun () -> s)
+    ; read = (fun () -> r)
+    ; check = (fun () -> c)
+    ; alloc = Alloc.return ()
+    }
+
   let field : (Cvar.t, Field.t) t =
     { store = Store.store
     ; read = Read.read
@@ -777,6 +787,8 @@ module Checked = struct
         (r : ('value Request.t, 's) As_prover.t)
     =
     Exists (typ, Request r, fun h -> return (Handle.var h))
+
+  let perform req = request_witness Typ.unit req
 
   let request ?such_that typ r =
     match such_that with

--- a/lib/snarky/src/snark_intf.ml
+++ b/lib/snarky/src/snark_intf.ml
@@ -97,6 +97,7 @@ module type Basic = sig
     val alloc : ('var, 'value) t -> 'var Alloc.t
     val check : ('var, 'value) t -> 'var -> (unit, _) Checked.t
 
+    val unit : (unit, unit) t
     val field  : (Cvar.t, field) t
     val tuple2 : ('var1, 'value1) t -> ('var2, 'value2) t -> ('var1 * 'var2, 'value1 * 'value2) t
     val tuple3
@@ -341,6 +342,8 @@ module type Basic = sig
     : ('var, 'value) Typ.t
     -> ('value Request.t, 's) As_prover.t
     -> ('var, 's) Checked.t
+
+  val perform : (unit Request.t, 's) As_prover.t -> (unit, 's) Checked.t
 
   (* TODO: Come up with a better name for this in relation to the above *)
   val request


### PR DESCRIPTION
Adds a `typ` for unit and a convenience function `perform` to snarky