### PR TITLE
Conditions compose in DSL

### DIFF
--- a/lib/distributed_dsl/node.ml
+++ b/lib/distributed_dsl/node.ml
@@ -15,16 +15,35 @@ module type S = sig
   type state
   module Condition_label : Hashable.S
 
-  type condition = 
-    | Interval of Time.Span.t
-    | Timeout of Time.Span.t
-    | Message of (message -> bool)
-    | Predicate of (state -> bool)
+  module Condition : sig
+    type t
+    type timer_tok
+
+    type condition
+
+    val timeout : Time.Span.t -> t
+    val msg : (state -> message -> bool) -> t
+    val predicate : (state -> bool) -> t
+
+    (* or *)
+    val ( + ) : t -> t -> t
+    (* additive identity *)
+    val never : t
+
+    (* and *)
+    val ( * ) : t -> t -> t
+    (* multiplicative identity *)
+    val always : t
+
+    val check : t -> state -> message -> timer_tok list -> bool
+
+    val wait_timers : t -> timer_tok Deferred.t
+  end
 
   type t = 
     { state : state
     ; last_state : state
-    ; conditions : (condition * transition) Condition_label.Table.t
+    ; conditions : (Condition.t * transition) Condition_label.Table.t
     ; message_pipe : message Linear_pipe.Reader.t
     ; work : transition Linear_pipe.Reader.t
     }
@@ -32,12 +51,12 @@ module type S = sig
   and override_transition = t -> original:transition -> state -> state
 
   type command =
-    | On of Condition_label.t * condition * transition
+    | On of Condition_label.t * Condition.t * transition
     | Override of Condition_label.t * transition
 
   val on
     : Condition_label.t
-    -> condition
+    -> Condition.t
     -> f:transition
     -> command
 
@@ -85,16 +104,73 @@ module Make
                                  and type peer := Peer.t) 
 = struct
 
-    type condition = 
-      | Interval of Time.Span.t
-      | Timeout of Time.Span.t
-      | Message of (Message.t -> bool)
-      | Predicate of (State.t -> bool)
+    module Condition = struct
+      type timer_tok = int [@@deriving eq]
+      type t =
+        { pred : State.t -> Message.t -> timer_tok list -> bool
+        ; timers : timer_tok Deferred.t list
+        }
+
+      type condition =
+        | Timeout of Time.Span.t
+        | Message of (State.t -> Message.t -> bool)
+        | Predicate of (State.t -> bool)
+
+      let curr_tok = ref 0
+      let next_tok () =
+        let tok = !curr_tok in
+        curr_tok := tok + 1;
+        tok
+
+      let single : condition -> t = function
+        | Timeout ts ->
+          let new_tok = next_tok () in
+          let timeout ts = Deferred.map (Timer.wait ts) (fun () -> new_tok) in
+          { pred = (fun _ _ toks -> List.exists toks ~f:(fun tok -> equal_timer_tok tok new_tok))
+          ; timers = [ timeout ts ]
+          }
+        | Message f ->
+          { pred = (fun s m _ -> f s m)
+          ; timers = []
+          }
+        | Predicate f ->
+          { pred = (fun s _ _ -> f s)
+          ; timers = []
+          }
+
+      let timeout ts = single (Timeout ts)
+      let msg f = single (Message f)
+      let predicate f = single (Predicate f)
+
+      let ( + ) x y =
+        { pred = (fun s m toks -> x.pred s m toks || y.pred s m toks)
+        ; timers = x.timers @ y.timers
+        }
+
+      let never =
+        { pred = (fun _ _ _ -> false)
+        ; timers = []
+        }
+
+      let ( * ) x y =
+        { pred = (fun s m toks -> x.pred s m toks && y.pred s m toks)
+        ; timers = x.timers @ y.timers
+        }
+
+      let always =
+        { pred = (fun _ _ _ -> true)
+        ; timers = []
+        }
+
+      let check {pred} = pred
+
+      let wait_timers {timers} = Deferred.any timers
+    end
 
     type t = 
       { state : State.t
       ; last_state : State.t
-      ; conditions : (condition * transition) Condition_label.Table.t
+      ; conditions : (Condition.t * transition) Condition_label.Table.t
       ; message_pipe : Message.t Linear_pipe.Reader.t
       ; work : transition Linear_pipe.Reader.t
       }
@@ -102,7 +178,7 @@ module Make
     and override_transition = t -> original:transition -> State.t -> State.t
 
     type command =
-      | On of Condition_label.t * condition * transition
+      | On of Condition_label.t * Condition.t * transition
       | Override of Condition_label.t * transition
 
     let on label condition ~f = failwith "nyi"

--- a/lib/distributed_dsl/test.ml
+++ b/lib/distributed_dsl/test.ml
@@ -13,15 +13,15 @@ let%test "trivial" = true
       ~initial_state:4
       [ on 
           Condition_label.Todo
-          (Predicate (fun s -> true))
+          (predicate (fun s -> true))
           ~f:(fun t s -> s)
       ; on 
           Condition_label.Todo
-          (Interval (Time.Span.of_sec 4.0))
+          (timeout (Time.Span.of_sec 4.0))
           ~f:(fun t s -> s)
       ; on 
           Condition_label.Todo
-          (Message (fun m -> true))
+          (msg (fun s m -> true))
           ~f:(fun t s -> s)
       ]
   in


### PR DESCRIPTION
This can't be wired up until #127 lands. The interpreter for the DSL is
responsible for calling check when `wait_timers` fire.

Usage:

```ocaml
let frog_received = msg (fun s m -> m.is_frog)) in

(* Essentially or *)
on (frog_received + (timeout 4.)) (* ... *)

(* Essentially and *)
on (frog_received * (timeout 1.)) (* ... *)
```