### PR TITLE
Update transaction comparison to hash with a seed

### DIFF
--- a/app/nanobit/src/cli.ml
+++ b/app/nanobit/src/cli.ml
@@ -94,8 +94,7 @@ let daemon =
        Async.never ())
 
 let () =
-  Random.self_init ();
-
+  Random.self_init () ;
   Command.group ~summary:"Current"
     [ ("daemon", daemon)
     ; (Parallel.worker_command_name, Parallel.worker_command)

--- a/lib/nanobit_base/transaction.ml
+++ b/lib/nanobit_base/transaction.ml
@@ -19,7 +19,6 @@ module Payload = struct
         , Account.Nonce.Stable.V1.t )
         t_
       [@@deriving bin_io, eq, sexp, hash]
-
     end
   end
 
@@ -90,10 +89,9 @@ module Stable = struct
       (Payload.Stable.V1.t, Public_key.Stable.V1.t, Signature.Stable.V1.t) t_
     [@@deriving bin_io, eq, sexp, hash]
 
-    type with_seed = string * t
-    [@@deriving hash]
+    type with_seed = string * t [@@deriving hash]
 
-    let compare ~seed (t : t) (t' : t) =
+    let compare ~seed (t: t) (t': t) =
       let hash x = hash_with_seed (seed, x) in
       let fee_compare = Fee.compare t.payload.fee t'.payload.fee in
       if fee_compare <> 0 then fee_compare else hash t - hash t'
@@ -144,6 +142,7 @@ module With_valid_signature = struct
   type t = Stable.V1.t [@@deriving sexp, eq, bin_io]
 
   let compare = Stable.V1.compare
+
   let gen = gen
 end
 

--- a/lib/nanobit_base/transaction.mli
+++ b/lib/nanobit_base/transaction.mli
@@ -29,7 +29,7 @@ module Payload : sig
         ( Public_key.Compressed.Stable.V1.t
         , Currency.Amount.Stable.V1.t
         , Currency.Fee.Stable.V1.t
-        , Account.Nonce.t)
+        , Account.Nonce.t )
         t_
       [@@deriving bin_io, eq, sexp, hash]
     end
@@ -91,6 +91,7 @@ module With_valid_signature : sig
   type nonrec t = private t [@@deriving sexp, eq, bin_io]
 
   val compare : seed:string -> t -> t -> int
+
   val gen :
        keys:Signature_keypair.t array
     -> max_amount:int

--- a/lib/transaction_pool/transaction_pool.ml
+++ b/lib/transaction_pool/transaction_pool.ml
@@ -32,7 +32,10 @@ struct
 
   type t = Txn.t Fheap.t
 
-  let empty = Fheap.create ~cmp:(Txn.compare ~seed:(Random.float Float.max_value |> string_of_float))
+  let empty =
+    Fheap.create
+      ~cmp:
+        (Txn.compare ~seed:(Random.float Float.max_value |> string_of_float))
 
   let add t txn = Fheap.add t txn
 

--- a/protocols/minibit_pow.ml
+++ b/protocols/minibit_pow.ml
@@ -80,6 +80,7 @@ module type Transaction_intf = sig
 
   module With_valid_signature : sig
     type nonrec t = private t [@@deriving sexp, eq]
+
     val compare : seed:string -> t -> t -> int
   end
 


### PR DESCRIPTION
Transaction comparisons now expect a seed string which is hashed with
the transactions when two transaction fees are equal. If this string is
random (or possibly even if it's provided by the miner), then transactions
of equal fees should be distributed randomly.

Seeded value is constant right now.