### PR TITLE
Short-paths flag ; better errors

### DIFF
--- a/app/logproc/src/jbuild
+++ b/app/logproc/src/jbuild
@@ -5,7 +5,7 @@
    (public_name logproc)
    (libraries (core logger async))
    (preprocess (pps (ppx_jane ppx_inline_test)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/app/nanobit/src/jbuild
+++ b/app/nanobit/src/jbuild
@@ -32,7 +32,7 @@
       cohttp
       cohttp-async))
    (preprocess (pps (ppx_jane ppx_deriving.eq ppx_inline_test)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/bignum_bigint/jbuild
+++ b/lib/bignum_bigint/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name bignum_bigint)
   (public_name bignum_bigint)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core async async_extra bignum))

--- a/lib/blockchain_snark/jbuild
+++ b/lib/blockchain_snark/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name blockchain_snark)
   (public_name blockchain_snark)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (libraries (core cached cache_dir protocols snarky nanobit_base proof_of_work transaction_snark bignum_bigint))
   (inline_tests)

--- a/lib/cached/jbuild
+++ b/lib/cached/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name cached)
   (public_name cached)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries

--- a/lib/client_lib/jbuild
+++ b/lib/client_lib/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name client_lib)
   (public_name client_lib)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core async nanobit_base))

--- a/lib/coda/jbuild
+++ b/lib/coda/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name coda)
   (public_name coda)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core protocols linear_pipe logger async async_extra))

--- a/lib/crypto_params/jbuild
+++ b/lib/crypto_params/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name crypto_params)
   (public_name crypto_params)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries

--- a/lib/distributed_dsl/jbuild
+++ b/lib/distributed_dsl/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name distributed_dsl)
   (public_name distributed_dsl)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (logger core linear_pipe async async_extra extlib))

--- a/lib/dummy_values/jbuild
+++ b/lib/dummy_values/jbuild
@@ -1,6 +1,7 @@
 (library
  ((name        dummy_values)
   (public_name dummy_values)
+  (flags (:standard -short-paths))
   (libraries
     ( crypto_params
       snarky ))

--- a/lib/gossip_net/jbuild
+++ b/lib/gossip_net/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name gossip_net)
   (public_name gossip_net)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core linear_pipe logger kademlia async async_extra))

--- a/lib/immutable_array/jbuild
+++ b/lib/immutable_array/jbuild
@@ -3,5 +3,6 @@
 (library
  ((name immutable_array)
   (public_name immutable_array)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (synopsis "Access only array utility")))

--- a/lib/interval_union/jbuild
+++ b/lib/interval_union/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name interval_union)
   (public_name interval_union)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries

--- a/lib/kademlia/jbuild
+++ b/lib/kademlia/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name kademlia)
   (public_name kademlia)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core logger linear_pipe async async_extra))

--- a/lib/ledger_fetcher/jbuild
+++ b/lib/ledger_fetcher/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name ledger_fetcher)
   (public_name ledger_fetcher)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core storage logger protocols minibit async async_extra))

--- a/lib/linear_pipe/jbuild
+++ b/lib/linear_pipe/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name linear_pipe)
   (public_name linear_pipe)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core async async_extra))

--- a/lib/logger/jbuild
+++ b/lib/logger/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name logger)
   (public_name logger)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core async))

--- a/lib/merkle_database/jbuild
+++ b/lib/merkle_database/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name merkle_database)
   (public_name merkle_database)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core bitstring integers immutable_array))

--- a/lib/merkle_ledger/jbuild
+++ b/lib/merkle_ledger/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name merkle_ledger)
   (public_name merkle_ledger)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core extlib))

--- a/lib/minibit/jbuild
+++ b/lib/minibit/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name minibit)
   (public_name minibit)
+  (flags (:standard -short-paths))
   (inline_tests)
   (library_flags (-linkall))
   (libraries (core protocols linear_pipe logger async async_extra))

--- a/lib/minibit_miner/jbuild
+++ b/lib/minibit_miner/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name minibit_miner)
   (public_name minibit_miner)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries

--- a/lib/minibit_networking/jbuild
+++ b/lib/minibit_networking/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name minibit_networking)
   (public_name minibit_networking)
+  (flags (:standard -short-paths))
   (inline_tests)
   (library_flags (-linkall))
   (libraries (core async gossip_net minibit protocols async_extra))

--- a/lib/nanobit_base/jbuild
+++ b/lib/nanobit_base/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name nanobit_base)
   (public_name nanobit_base)
+  (flags (:standard -short-paths))
   (inline_tests)
   (library_flags (-linkall))
   (libraries (base64 protocols core dummy_values merkle_ledger snarky crypto_params async async_extra bignum_bigint))

--- a/lib/nanobit_testbridge/recent_sca/jbuild
+++ b/lib/nanobit_testbridge/recent_sca/jbuild
@@ -6,7 +6,7 @@
    (package nanobit_testbridge)
    (libraries (core async async_extra testbridge nanobit_testbridge blockchain_snark))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/nanobit_testbridge/src/jbuild
+++ b/lib/nanobit_testbridge/src/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name nanobit_testbridge)
   (public_name nanobit_testbridge)
+  (flags (:standard -short-paths))
   (inline_tests)
   (library_flags (-linkall))
   (libraries (core async async_extra testbridge nanobit_base blockchain_snark))

--- a/lib/nanobit_testbridge/swim_consistency/jbuild
+++ b/lib/nanobit_testbridge/swim_consistency/jbuild
@@ -6,7 +6,7 @@
    (package nanobit_testbridge)
    (libraries (core async async_extra testbridge nanobit_testbridge))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/nanobit_testbridge/swim_example/jbuild
+++ b/lib/nanobit_testbridge/swim_example/jbuild
@@ -6,7 +6,7 @@
    (package nanobit_testbridge)
    (libraries (core async async_extra testbridge nanobit_testbridge))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/parallel_scan-test/jbuild
+++ b/lib/parallel_scan-test/jbuild
@@ -4,6 +4,7 @@
   ((name parallel_scan_test)
    (package parallel_scan)
    (public_name parallel_scan_test)
+(flags (:standard -short-paths))
    (libraries (parallel_scan ppx_inline_test.runner.lib))
   ))
 

--- a/lib/parallel_scan/jbuild
+++ b/lib/parallel_scan/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name parallel_scan)
   (public_name parallel_scan)
+  (flags (:standard -short-paths))
   (inline_tests)
   (library_flags (-linkall))
   (libraries (linear_pipe core async async_extra))

--- a/lib/proof_of_work/jbuild
+++ b/lib/proof_of_work/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name proof_of_work)
   (public_name proof_of_work)
+  (flags (:standard -short-paths))
   (inline_tests)
   (library_flags (-linkall))
   (libraries (core_kernel nanobit_base))

--- a/lib/rocksdb_database/jbuild
+++ b/lib/rocksdb_database/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name rocksdb_database)
   (public_name rocksdb_database)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (libraries (rocks))
   (synopsis "RocksDB Database module")))

--- a/lib/snark_keys/jbuild
+++ b/lib/snark_keys/jbuild
@@ -1,6 +1,7 @@
 (library
  ((name        snark_keys)
   (public_name snark_keys)
+  (flags (:standard -short-paths))
   (libraries
     ( async
       transaction_snark

--- a/lib/snarky/src/camlsnark_c/jbuild
+++ b/lib/snarky/src/camlsnark_c/jbuild
@@ -10,7 +10,7 @@
   (modes (native))
   (public_name snarky.c)
   (preprocess no_preprocessing)
-  (flags (:standard -safe-string))
+  (flags (:standard -short-paths -safe-string))
   (c_library_flags (:standard -Wl,-E -Wl,-whole-archive -lcamlsnark_c_stubs -Wl,-no-whole-archive -lssl -lcrypto -lprocps -lgmp -lstdc++ 
   ))
   (self_build_stubs_archive (camlsnark_c))))

--- a/lib/snarky/src/jbuild
+++ b/lib/snarky/src/jbuild
@@ -1,6 +1,7 @@
 (library
  ((name snarky)
   (public_name snarky)
+  (flags (:standard -short-paths))
   (inline_tests)
   (libraries (core_kernel interval_union bignum camlsnark_c))
   (c_library_flags (:standard -lstdc++ -lpthread))

--- a/lib/sparse_ledger/jbuild
+++ b/lib/sparse_ledger/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name sparse_ledger)
   (public_name sparse_ledger)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core extlib))

--- a/lib/storage/jbuild
+++ b/lib/storage/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name storage)
   (public_name storage)
+  (flags (:standard -short-paths))
   (inline_tests)
   (library_flags (-linkall))
   (libraries (core async async_extra logger))

--- a/lib/testbridge/bridge/src/jbuild
+++ b/lib/testbridge/bridge/src/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name testbridge)
   (public_name testbridge)
+  (flags (:standard -short-paths))
   (libraries (core async async_extra yojson))
   (preprocess (pps (ppx_jane)))
   (flags (:standard -safe-string -w -40 -g))

--- a/lib/testbridge/container/src/jbuild
+++ b/lib/testbridge/container/src/jbuild
@@ -6,7 +6,7 @@
    (package testbridge)
    (libraries (core async async_extra))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/testbridge/fetch_logs/src/jbuild
+++ b/lib/testbridge/fetch_logs/src/jbuild
@@ -6,7 +6,7 @@
    (package testbridge)
    (libraries (core async async_extra testbridge))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/testbridge/tests/cross-client-communication/client/src/jbuild
+++ b/lib/testbridge/tests/cross-client-communication/client/src/jbuild
@@ -6,7 +6,7 @@
    (package ccc)
    (libraries (core async async_extra))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/testbridge/tests/cross-client-communication/host/src/jbuild
+++ b/lib/testbridge/tests/cross-client-communication/host/src/jbuild
@@ -6,6 +6,6 @@
    (package testbridge)
    (libraries (core async async_extra testbridge))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))

--- a/lib/testbridge/tests/echo/client/src/jbuild
+++ b/lib/testbridge/tests/echo/client/src/jbuild
@@ -6,7 +6,7 @@
    (package echo)
    (libraries (core async async_extra))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/testbridge/tests/echo/host/src/jbuild
+++ b/lib/testbridge/tests/echo/host/src/jbuild
@@ -6,7 +6,7 @@
    (package testbridge)
    (libraries (core async async_extra testbridge))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/testbridge/tests/stdout/host/src/jbuild
+++ b/lib/testbridge/tests/stdout/host/src/jbuild
@@ -6,7 +6,7 @@
    (package testbridge)
    (libraries (core async async_extra testbridge))
    (preprocess (pps (ppx_jane)))
-   (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
+   (flags (-short-paths -w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56+58+59+60+61))
    (modes (native))
   ))
 

--- a/lib/transaction_pool/jbuild
+++ b/lib/transaction_pool/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name transaction_pool)
   (public_name transaction_pool)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core protocols minibit async async_extra))

--- a/lib/transaction_snark/jbuild
+++ b/lib/transaction_snark/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name transaction_snark)
   (public_name transaction_snark)
+  (flags (:standard -short-paths))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core cache_dir cached snarky nanobit_base bignum))

--- a/protocols/jbuild
+++ b/protocols/jbuild
@@ -3,6 +3,7 @@
 (library
  ((name protocols)
   (public_name protocols)
+  (flags (:standard -short-paths))
   (inline_tests)
   (library_flags (-linkall))
   (libraries (core async linear_pipe))


### PR DESCRIPTION
Yaron tweeted this morning about this flag. It's amazing:

```
Inputs.Ledger.t -> Ledger.t
```

in error messages. This happens both in and out of merlin.