### PR TITLE
stop the prover from using the transaction snark proving keys

### DIFF
--- a/app/nanobit/src/prover.ml
+++ b/app/nanobit/src/prover.ml
@@ -42,7 +42,7 @@ struct
 
   module Worker_state = struct
     module type S = sig
-      module Transaction_snark : Transaction_snark.S
+      module Transaction_snark : Transaction_snark.Verification.S
 
       val extend_blockchain :
            Blockchain.t
@@ -65,7 +65,7 @@ struct
       Deferred.return
         (let module Keys = Keys_lib.Keys.Make (Consensus_mechanism) in
         let%map (module Keys) = Keys.create () in
-        let module Transaction_snark = Transaction_snark.Make (struct
+        let module Transaction_snark = Transaction_snark.Verification.Make (struct
           let keys = Keys.transaction_snark_keys
         end) in
         let module M = struct

--- a/lib/keys_lib/keys.ml
+++ b/lib/keys_lib/keys.ml
@@ -16,7 +16,7 @@ module type S = sig
     type t = {proof: Tick.Proof.t}
   end
 
-  val transaction_snark_keys : Transaction_snark.Keys.t
+  val transaction_snark_keys : Transaction_snark.Keys.Verification.t
 
   module Step : sig
     val keys : Tick.Keypair.t
@@ -50,8 +50,6 @@ module type S = sig
   end
 end
 
-let tx_pk = lazy (Snark_keys.transaction_proving ())
-
 let tx_vk = lazy (Snark_keys.transaction_verification ())
 
 let bc_pk = lazy (Snark_keys.blockchain_proving ())
@@ -71,16 +69,10 @@ struct
     | Some x -> x
     | None ->
         let open Async in
-        let%map tx_pk = Lazy.force tx_pk
-        and tx_vk = Lazy.force tx_vk
+        let%map tx_vk = Lazy.force tx_vk
         and bc_pk = Lazy.force bc_pk
         and bc_vk = Lazy.force bc_vk in
-        let tx_keys =
-          {Transaction_snark.Keys.proving= tx_pk; verification= tx_vk}
-        in
-        let module T = Transaction_snark.Make (struct
-          let keys = tx_keys
-        end) in
+        let module T = Transaction_snark.Verification.Make(struct let keys = tx_vk end) in
         let module B =
           Blockchain_snark.Blockchain_transition.Make (Consensus_mechanism) (T) in
         let module Step = B.Step (struct
@@ -96,6 +88,8 @@ struct
         let module M = struct
           module Consensus_mechanism = Consensus_mechanism
 
+          let transaction_snark_keys = tx_vk
+
           module Step_prover_state = struct
             type t =
               { wrap_vk: Tock.Verification_key.t
@@ -107,8 +101,6 @@ struct
           module Wrap_prover_state = struct
             type t = {proof: Tick.Proof.t}
           end
-
-          let transaction_snark_keys = tx_keys
 
           module Step = struct
             include (

--- a/lib/keys_lib/keys.mli
+++ b/lib/keys_lib/keys.mli
@@ -15,7 +15,7 @@ module type S = sig
     type t = {proof: Tick.Proof.t}
   end
 
-  val transaction_snark_keys : Transaction_snark.Keys.t
+  val transaction_snark_keys : Transaction_snark.Keys.Verification.t
 
   module Step : sig
     val keys : Tick.Keypair.t


### PR DESCRIPTION
The prover was loading the transaction snark proving keys, which it was not using. This PR makes it only load the verification keys