### PR TITLE
cosmetic help to -help

### DIFF
--- a/app/nanobit/src/cli.ml
+++ b/app/nanobit/src/cli.ml
@@ -18,33 +18,36 @@ let daemon (type ledger_proof) (module Kernel
   let open Command.Let_syntax in
   Command.async ~summary:"Current daemon"
     (let%map_open conf_dir =
-       flag "config-directory" ~doc:"Configuration directory" (optional file)
-     and should_mine = flag "mine" ~doc:"Run the miner" (optional bool)
+       flag "config-directory" ~doc:"DIR Configuration directory"
+         (optional file)
+     and should_mine =
+       flag "mine" ~doc:"true|false Run the miner (default:false)"
+         (optional bool)
      and peers =
        flag "peer"
          ~doc:
-           "Host_and_port for TCP daemon communications (can be given \
-            multiple times)"
+           "HOST:PORT TCP daemon communications (can be given multiple times)"
          (listed peer)
      and run_snark_worker =
-       flag "run-snark-worker" ~doc:"Run the SNARK worker"
+       flag "run-snark-worker" ~doc:"KEY Run the SNARK worker with a key"
          (optional public_key_compressed)
      and port =
        flag "port"
          ~doc:
            (Printf.sprintf
-              "Server port for other daemons to connect (default: %d)"
+              "PORT Server port for other daemons to connect (default: %d)"
               default_daemon_port)
          (optional int16)
      and client_port =
        flag "client-port"
-         ~doc:"Port for client to connect daemon locally (default: 8301)"
+         ~doc:"PORT Client to daemon local communication (default: 8301)"
          (optional int16)
      and membership_port =
-       flag "membership-port" ~doc:"Port for P2P UDP overlay (default: 8303)"
+       flag "membership-port"
+         ~doc:"PORT P2P UDP overlay communication(default: 8303)"
          (optional int16)
      and ip =
-       flag "ip" ~doc:"External IP address for others to connect"
+       flag "ip" ~doc:"IP External IP address for others to connect"
          (optional string)
      in
      fun () ->

--- a/app/nanobit/src/client.ml
+++ b/app/nanobit/src/client.ml
@@ -19,10 +19,10 @@ let get_balance =
     (let open Command.Let_syntax in
     let%map_open address =
       flag "address"
-        ~doc:"Public-key address of which you want to see the balance"
+        ~doc:"KEY Public-key address of which you want to see the balance"
         (required public_key)
     and port =
-      flag "daemon-port" ~doc:"Port of the deamon's client-rpc handlers"
+      flag "daemon-port" ~doc:"PORT Client to daemon local communication"
         (required int16)
     in
     fun () ->
@@ -47,24 +47,23 @@ let send_txn =
   Command.async ~summary:"Send transaction to an address"
     (let open Command.Let_syntax in
     let%map_open address =
-      flag "receiver" ~doc:"Public-key address to which you want to send money"
+      flag "receiver"
+        ~doc:"KEY Public-key address to which you want to send money"
         (required public_key)
     and from_account =
       flag "from"
-        ~doc:"Private-key address from which you would like to send money"
+        ~doc:"KEY Private-key address from which you would like to send money"
         (required private_key)
     and fee =
-      flag "fee" ~doc:"Transaction fee you're willing to pay (default: 1)"
+      flag "fee"
+        ~doc:"VALUE  Transaction fee you're willing to pay (default: 1)"
         (optional txn_fee)
     and amount =
-      flag "amount" ~doc:"Transaction amount you want to send"
+      flag "amount" ~doc:"VALUE Transaction amount you want to send"
         (required txn_amount)
     and port =
       flag "daemon-port"
-        ~doc:
-          (Printf.sprintf
-             "Port of the deamon's client-rpc handlers (default: %d)"
-             default_daemon_port)
+        ~doc:"PORT Client to daemon local communication (default: 8301)"
         (optional int16)
     in
     fun () ->


### PR DESCRIPTION
provide better hints in help syntax

before:
```
cli daemon -help
Current daemon

  cli daemon

=== flags ===

  [-client-port Port]                for client to connect daemon locally
                                     (default: 8301)
  [-config-directory Configuration]  directory
  [-ip External]                     IP address for others to connect
  [-membership-port Port]            for P2P UDP overlay (default: 8303)
  [-mine Run]                        the miner
  [-peer Host_and_port]              for TCP daemon communications (can be given
                                     multiple times)
  [-port Server]                     port for other daemons to connect (default:
                                     8302)
  [-run-snark-worker Run]            the SNARK worker
  [-help]                            print this help text and exit
                                     (alias: -?)
```

After:
```
$ ./_build/default/app/nanobit/src/cli.exe daemon -help
Current daemon

  cli.exe daemon

=== flags ===

  [-client-port PORT]      Client to daemon local communication (default: 8301)
  [-config-directory DIR]  Configuration directory
  [-ip IP]                 External IP address for others to connect
  [-membership-port PORT]  P2P UDP overlay communication(default: 8303)
  [-mine true|false]       Run the miner (default:false)
  [-peer HOST:PORT]        TCP daemon communications (can be given multiple
                           times)
  [-port PORT]             Server port for other daemons to connect (default:
                           8302)
  [-run-snark-worker KEY]  Run the SNARK worker with a key
  [-help]                  print this help text and exit
                           (alias: -?)
```


Also uses common wording when describing client/daemon local communication.

Before
```
$cli client -help
Lightweight client process

  cli client SUBCOMMAND

=== subcommands ===

  get-balance  Get balance associated with an address
  send-txn     Send transaction to an address
  help         explain a given subcommand (perhaps recursively)

admin@ip-172-31-29-135:~$ cli client get-balance -help
Get balance associated with an address

  cli client get-balance

=== flags ===

  -address Public-key  address of which you want to see the balance
  -daemon-port Port    of the deamon's client-rpc handlers
  [-help]              print this help text and exit
                       (alias: -?)
```

After:
```
$ ./_build/default/app/nanobit/src/cli.exe client get-balance -help
Get balance associated with an address

  cli.exe client get-balance

=== flags ===

  -address KEY       Public-key address of which you want to see the balance
  -daemon-port PORT  Client to daemon local communication
  [-help]            print this help text and exit
                     (alias: -?)
```
