### PR TITLE
No bin_io on Transaction.With_valid_signature.t

### DIFF
--- a/src/lib/coda_base/transaction.mli
+++ b/src/lib/coda_base/transaction.mli
@@ -42,7 +42,7 @@ val gen :
   -> t Quickcheck.Generator.t
 
 module With_valid_signature : sig
-  type nonrec t = private t [@@deriving sexp, eq, bin_io]
+  type nonrec t = private t [@@deriving sexp, eq]
 
   val compare : seed:string -> t -> t -> int
 


### PR DESCRIPTION
We shouldn't have bin_io on types we use to tell the compiler we've done some checks because if we deserialize and adversary can trick us.

It turns out we weren't relying on this bin_io anyway, but it should be removed in case that changes

This closes issues (list them): #1026
