### PR TITLE
Demo container needs a seed flag now

### DIFF
--- a/scripts/run-demo.sh
+++ b/scripts/run-demo.sh
@@ -8,4 +8,4 @@ now_time=$(date +%s)
 export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
 export CODA_PRIVKEY_PASS=""
 
-exec coda daemon -demo-mode -block-producer-key /root/keys/demo-block-producer -run-snark-worker 4vsRCVMNTrCx4NpN6kKTkFKLcFN4vXUP5RB9PqSZe1qsyDs4AW5XeNgAf16WUPRBCakaPiXcxjp6JUpGNQ6fdU977x5LntvxrSg11xrmK6ZDaGSMEGj12dkeEpyKcEpkzcKwYWZ2Yf2vpwQP -insecure-rest-server $@
+exec coda daemon -demo-mode -block-producer-key /root/keys/demo-block-producer -run-snark-worker 4vsRCVMNTrCx4NpN6kKTkFKLcFN4vXUP5RB9PqSZe1qsyDs4AW5XeNgAf16WUPRBCakaPiXcxjp6JUpGNQ6fdU977x5LntvxrSg11xrmK6ZDaGSMEGj12dkeEpyKcEpkzcKwYWZ2Yf2vpwQP -insecure-rest-server -seed $@


### PR DESCRIPTION
Sometime since the last time we've tried a demo container image, we added the `-seed` flag ad that is required even in demo mode to run with no peers.

I tested with a recent image off of `release/0.0.13-beta`:

`docker run -it codaprotocol/coda-demo:0.0.12-beta-release-0.0.13-beta-c30a045 -seed`