### PR TITLE
DO NOT MERGE: 3.2a release branch special

### DIFF
--- a/scripts/run-demo.sh
+++ b/scripts/run-demo.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-genesis_time=$(date -d "$(coda advanced compile-time-constants | jq -r '.genesis_state_timestamp')" +%s)
-now_time=$(date +%s)
+genesis_constants_file=$(mktemp)
 
-export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
+echo '{"txpool_max_size":3000,"genesis_state_timestamp":"'$(date '+%Y-%m-%d %H:%M:%S%z')'"}' > "$genesis_constants_file"
+
 export CODA_PRIVKEY_PASS=""
 
-exec coda daemon -seed -demo-mode -block-producer-key /root/keys/demo-block-producer -run-snark-worker 4vsRCVMNTrCx4NpN6kKTkFKLcFN4vXUP5RB9PqSZe1qsyDs4AW5XeNgAf16WUPRBCakaPiXcxjp6JUpGNQ6fdU977x5LntvxrSg11xrmK6ZDaGSMEGj12dkeEpyKcEpkzcKwYWZ2Yf2vpwQP -insecure-rest-server $@
+exec coda daemon -seed -demo-mode -block-producer-key /root/keys/demo-block-producer -run-snark-worker 4vsRCVMNTrCx4NpN6kKTkFKLcFN4vXUP5RB9PqSZe1qsyDs4AW5XeNgAf16WUPRBCakaPiXcxjp6JUpGNQ6fdU977x5LntvxrSg11xrmK6ZDaGSMEGj12dkeEpyKcEpkzcKwYWZ2Yf2vpwQP -genesis-constants "$genesis_constants_file" -insecure-rest-server $@

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -148,7 +148,7 @@ let daemon logger =
            (sprintf
               "FEE Amount a worker wants to get compensated for generating a \
                snark proof (default: %d)"
-              (Currency.Fee.to_int Cli_lib.Default.snark_worker_fee))
+              (Currency.Fee.to_int Coda_compile_config.default_snark_worker_fee))
          (optional txn_fee)
      and work_reassignment_wait =
        flag "work-reassignment-wait" (optional int)
@@ -422,7 +422,8 @@ let daemon logger =
              YJ.Util.to_int_option json |> Option.map ~f:Currency.Fee.of_int
            in
            or_from_config json_to_currency_fee_option "snark-worker-fee"
-             ~default:Cli_lib.Default.snark_worker_fee snark_work_fee
+             ~default:Coda_compile_config.default_snark_worker_fee
+             snark_work_fee
          in
          (* FIXME #4095: pass this through to Gossip_net.Libp2p *)
          let _max_concurrent_connections =

--- a/src/app/cli/src/tests/coda_receipt_chain_test.ml
+++ b/src/app/cli/src/tests/coda_receipt_chain_test.ml
@@ -38,7 +38,7 @@ let main () =
   let receiver_pk = Public_key.compress another_account_keypair.public_key in
   let sender_sk = largest_account_keypair.private_key in
   let send_amount = Currency.Amount.of_int 10 in
-  let fee = User_command.minimum_fee in
+  let fee = Coda_compile_config.minimum_transaction_fee in
   let%bind program_dir = Unix.getcwd () in
   let work_selection_method =
     Cli_lib.Arg_type.Work_selection_method.Sequence

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -506,7 +506,7 @@ end = struct
   let delegate_stake ?acceptable_delay:(delay = 7) (testnet : Api.t) ~node
       ~delegator ~delegatee =
     let valid_until = Coda_numbers.Global_slot.max_value in
-    let fee = User_command.minimum_fee in
+    let fee = Coda_compile_config.minimum_transaction_fee in
     let worker = testnet.workers.(node) in
     let%bind _ =
       let open Deferred.Option.Let_syntax in
@@ -557,7 +557,7 @@ end = struct
       ~node ~keypairs ~n =
     let amount = Currency.Amount.of_int 10 in
     let valid_until = Coda_numbers.Global_slot.max_value in
-    let fee = User_command.minimum_fee in
+    let fee = Coda_compile_config.minimum_transaction_fee in
     let%bind (_ : unit option list) =
       Deferred.List.init n ~f:(fun _ ->
           let open Deferred.Option.Let_syntax in
@@ -612,7 +612,7 @@ end = struct
   let send_batch_consecutive_payments (testnet : Api.t) ~node ~sender
       ~(keypairs : Keypair.t list) ~n =
     let amount = Currency.Amount.of_int 10 in
-    let fee = User_command.minimum_fee in
+    let fee = Coda_compile_config.minimum_transaction_fee in
     let valid_until = Coda_numbers.Global_slot.max_value in
     let%bind new_payment_readers =
       Deferred.List.init (Array.length testnet.workers) ~f:(fun i ->

--- a/src/config/account_creation_fee/realistic.mlh
+++ b/src/config/account_creation_fee/realistic.mlh
@@ -1,0 +1,1 @@
+[%%define account_creation_fee_int "0.001"]

--- a/src/config/amount_defaults/realistic.mlh
+++ b/src/config/amount_defaults/realistic.mlh
@@ -1,0 +1,3 @@
+[%%define default_transaction_fee "0.1"]
+[%%define default_snark_worker_fee "0.025"]
+

--- a/src/config/amount_defaults/realistic.mlh
+++ b/src/config/amount_defaults/realistic.mlh
@@ -1,3 +1,4 @@
 [%%define default_transaction_fee "0.1"]
+[%%define minimum_transaction_fee "0.00001"]
 [%%define default_snark_worker_fee "0.025"]
 

--- a/src/config/amount_defaults/standard.mlh
+++ b/src/config/amount_defaults/standard.mlh
@@ -1,0 +1,3 @@
+[%%define default_transaction_fee "5"]
+[%%define default_snark_worker_fee "1"]
+

--- a/src/config/amount_defaults/standard.mlh
+++ b/src/config/amount_defaults/standard.mlh
@@ -1,3 +1,4 @@
 [%%define default_transaction_fee "5"]
+[%%define minimum_transaction_fee "2"]
 [%%define default_snark_worker_fee "1"]
 

--- a/src/config/coinbase/realistic.mlh
+++ b/src/config/coinbase/realistic.mlh
@@ -1,0 +1,1 @@
+[%%define coinbase "200"]

--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/high.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/dev_frontend.mlh
+++ b/src/config/dev_frontend.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/high.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/fuzz_medium.mlh
+++ b/src/config/fuzz_medium.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/fuzz_small.mlh
+++ b/src/config/fuzz_small.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/nonconsensus_medium_curves.mlh
+++ b/src/config/nonconsensus_medium_curves.mlh
@@ -6,6 +6,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_bootstrap.mlh
+++ b/src/config/test_postake_bootstrap.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_delegation.mlh
+++ b/src/config/test_postake_delegation.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_medium_curves.mlh
+++ b/src/config/test_postake_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_split_snarkless.mlh
+++ b/src/config/test_postake_split_snarkless.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_three_producers.mlh
+++ b/src/config/test_postake_three_producers.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_txns.mlh
+++ b/src/config/test_postake_txns.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/testnet_postake_many_producers.mlh
+++ b/src/config/testnet_postake_many_producers.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/testnet_postake_many_producers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_producers_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -1,28 +1,29 @@
 [%%define ledger_depth 14]
 [%%define fake_accounts_target 50]
 [%%import "/src/config/curve/medium.mlh"]
-[%%import "/src/config/coinbase/standard.mlh"]
+[%%import "/src/config/coinbase/realistic.mlh"]
 [%%import "/src/config/scan_state/point2tps.mlh"]
 [%%import "/src/config/debug_level/some.mlh"]
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
-[%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/account_creation_fee/realistic.mlh"]
+[%%import "/src/config/amount_defaults/realistic.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 (* custom consensus parameters for the testnet release *)
 [%%define consensus_mechanism "proof_of_stake"]
-[%%define k 10]
+[%%define k 20]
 [%%define c 8]
 [%%define delta 3]
 
 [%%define record_async_backtraces false]
-[%%define time_offsets true]
+[%%define time_offsets false]
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 
 [%%define genesis_ledger "testnet_postake"]
 
-[%%define genesis_state_timestamp "2020-02-25 10:00:00-07:00"]
+[%%define genesis_state_timestamp "2020-04-01 10:00:00-07:00"]
 [%%define block_window_duration 180000]
 
 [%%define integration_tests false]

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/lib/cli_lib/default.ml
+++ b/src/lib/cli_lib/default.ml
@@ -1,10 +1,4 @@
 (* Default values for cli flags *)
-(* A payment requires 2 SNARKS, so this should always >= 2x the snark fee. *)
-let transaction_fee = Currency.Fee.of_int 5_000_000_000
-
-(*Fee for a snark bundle*)
-let snark_worker_fee = Currency.Fee.of_int 1_000_000_000
-
 let work_reassignment_wait = 420000
 
 let conf_dir_name = ".coda-config"

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -291,7 +291,8 @@ let user_command_common : user_command_common Command.Param.t =
             (default: %s) (minimum: %s)"
            (Currency.Fee.to_formatted_string
               Coda_compile_config.default_transaction_fee)
-           (Currency.Fee.to_formatted_string Coda_base.User_command.minimum_fee))
+           (Currency.Fee.to_formatted_string
+              Coda_compile_config.minimum_transaction_fee))
       (optional txn_fee)
   and nonce =
     flag "nonce"
@@ -337,7 +338,8 @@ module User_command = struct
             (default: %s) (minimum: %s)"
            (Currency.Fee.to_formatted_string
               Coda_compile_config.default_transaction_fee)
-           (Currency.Fee.to_formatted_string Coda_base.User_command.minimum_fee))
+           (Currency.Fee.to_formatted_string
+              Coda_compile_config.minimum_transaction_fee))
       (optional txn_fee)
 
   let valid_until =

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -289,7 +289,8 @@ let user_command_common : user_command_common Command.Param.t =
         (Printf.sprintf
            "FEE Amount you are willing to pay to process the transaction \
             (default: %s) (minimum: %s)"
-           (Currency.Fee.to_formatted_string Default.transaction_fee)
+           (Currency.Fee.to_formatted_string
+              Coda_compile_config.default_transaction_fee)
            (Currency.Fee.to_formatted_string Coda_base.User_command.minimum_fee))
       (optional txn_fee)
   and nonce =
@@ -304,7 +305,10 @@ let user_command_common : user_command_common Command.Param.t =
     flag "memo" ~doc:"STRING Memo accompanying the transaction"
       (optional string)
   in
-  {sender; fee= Option.value fee ~default:Default.transaction_fee; nonce; memo}
+  { sender
+  ; fee= Option.value fee ~default:Coda_compile_config.default_transaction_fee
+  ; nonce
+  ; memo }
 
 module User_command = struct
   open Arg_type
@@ -331,7 +335,8 @@ module User_command = struct
         (Printf.sprintf
            "FEE Amount you are willing to pay to process the transaction \
             (default: %s) (minimum: %s)"
-           (Currency.Fee.to_formatted_string Default.transaction_fee)
+           (Currency.Fee.to_formatted_string
+              Coda_compile_config.default_transaction_fee)
            (Currency.Fee.to_formatted_string Coda_base.User_command.minimum_fee))
       (optional txn_fee)
 

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -7,6 +7,8 @@ open Import
 [%%ifndef
 consensus_mechanism]
 
+module Coda_compile_config =
+  Coda_compile_config_nonconsensus.Coda_compile_config
 module Coda_numbers = Coda_numbers_nonconsensus.Coda_numbers
 module Currency = Currency_nonconsensus.Currency
 module Quickcheck_lib = Quickcheck_lib_nonconsensus.Quickcheck_lib
@@ -78,9 +80,7 @@ let fee = Fn.compose Payload.fee payload
 let nonce = Fn.compose Payload.nonce payload
 
 (* for filtering *)
-let minimum_fee = Fee.of_int 2_000_000_000
-
-let is_trivial t = Fee.(fee t < minimum_fee)
+let is_trivial t = Fee.(fee t < Coda_compile_config.minimum_transaction_fee)
 
 let signer {Poly.signer; _} = signer
 

--- a/src/lib/coda_base/user_command_intf.ml
+++ b/src/lib/coda_base/user_command_intf.ml
@@ -122,9 +122,6 @@ module type S = sig
 
   val valid_until : t -> Global_slot.t
 
-  (* for filtering *)
-  val minimum_fee : Currency.Fee.t
-
   val is_trivial : t -> bool
 
   include Gen_intf with type t := t

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -1,13 +1,6 @@
 [%%import
 "/src/config.mlh"]
 
-[%%ifndef
-consensus_mechanism]
-
-module Currency = Currency_nonconsensus.Currency
-
-[%%endif]
-
 (*This file consists of compile time constants that are not in Genesis_constants.t or  i.e., all the constants that are defined at compile-time for both tests and production*)
 [%%inject
 "proof_level", proof_level]

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -30,10 +30,22 @@ module Currency = Currency_nonconsensus.Currency
 [%%inject
 "account_creation_fee_string", account_creation_fee_int]
 
+[%%inject
+"default_transaction_fee_string", default_transaction_fee]
+
+[%%inject
+"default_snark_worker_fee_string", default_snark_worker_fee]
+
+let coinbase = Currency.Amount.of_formatted_string coinbase_string
+
 let account_creation_fee =
   Currency.Fee.of_formatted_string account_creation_fee_string
 
-let coinbase = Currency.Amount.of_formatted_string coinbase_string
+let default_transaction_fee =
+  Currency.Fee.of_formatted_string default_transaction_fee_string
+
+let default_snark_worker_fee =
+  Currency.Fee.of_formatted_string default_snark_worker_fee_string
 
 (*transaction_capacity_log_2: Log of the capacity of transactions per
 transition. 1 will only work if we don't have prover fees. 2 will work with

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -36,6 +36,16 @@ module Currency = Currency_nonconsensus.Currency
 [%%inject
 "default_snark_worker_fee_string", default_snark_worker_fee]
 
+[%%inject
+"minimum_transaction_fee_string", minimum_transaction_fee]
+
+[%%ifndef
+consensus_mechanism]
+
+module Currency = Currency_nonconsensus.Currency
+
+[%%endif]
+
 let coinbase = Currency.Amount.of_formatted_string coinbase_string
 
 let account_creation_fee =
@@ -46,6 +56,9 @@ let default_transaction_fee =
 
 let default_snark_worker_fee =
   Currency.Fee.of_formatted_string default_snark_worker_fee_string
+
+let minimum_transaction_fee =
+  Currency.Fee.of_formatted_string minimum_transaction_fee_string
 
 (*transaction_capacity_log_2: Log of the capacity of transactions per
 transition. 1 will only work if we don't have prover fees. 2 will work with

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -1635,12 +1635,13 @@ module Mutations = struct
     in
     let%bind () =
       Result.ok_if_true
-        Currency.Fee.(fee >= User_command.minimum_fee)
+        Currency.Fee.(fee >= Coda_compile_config.minimum_transaction_fee)
         ~error:
           (sprintf
              !"Invalid user command. Fee %s is less than the minimum fee, %s."
              (Currency.Fee.to_formatted_string fee)
-             (Currency.Fee.to_formatted_string User_command.minimum_fee))
+             (Currency.Fee.to_formatted_string
+                Coda_compile_config.minimum_transaction_fee))
     in
     let%map memo =
       Option.value_map memo ~default:(Ok User_command_memo.empty)

--- a/src/nonconsensus/coda_base/dune
+++ b/src/nonconsensus/coda_base/dune
@@ -4,9 +4,9 @@
  (library_flags -linkall)
  (libraries
     coda_numbers_nonconsensus
-    coda_compile_config_nonconsensus
     currency_nonconsensus
     hash_prefix_states_nonconsensus
+    coda_compile_config_nonconsensus
     outside_pedersen_image_nonconsensus
     signature_lib_nonconsensus
     snark_params_nonconsensus


### PR DESCRIPTION
Since we're fixing issues with #4703 , this PR pulls in a few of the changes that affect the user experience of the 3.2a release coming Monday.

1.

Constants for new qa net (#4616)
Setting constants for new qa net.

Spec:

Adjust snark work fees — 0.025
Adjust account creation fee — 0.001
Adjust coinbase — 200.0
Adjust default transaction fees — 0.1


2.

Minimum fees don't use hardcoded billions (#4642)
