### PR TITLE
remove coda_status from crash report

### DIFF
--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -227,7 +227,10 @@ let get_status ~flag t =
   in
   let commit_id = Coda_version.commit_id in
   let conf_dir = config.conf_dir in
+  (*
   let%map peers = Coda_lib.peers t in
+  *)
+  let peers = [] in
   let peers =
     List.map peers ~f:(fun peer ->
         Network_peer.Peer.to_discovery_host_and_port peer

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -230,7 +230,7 @@ let get_status ~flag t =
   (*
   let%map peers = Coda_lib.peers t in
   *)
-  let peers = [] in
+  let%map peers = return [] in
   let peers =
     List.map peers ~f:(fun peer ->
         Network_peer.Peer.to_discovery_host_and_port peer


### PR DESCRIPTION
We are removing coda_status from crash report because of the following bug:

1. libp2p crashes
2. the node is trying to generate a crash report and then kill itself
3. while generating the crash report, it needs the coda_status
4. coda_status would send a call to libp2p helper which would never get responded (because libp2p crashed)
5. the exiting procedure would get stuck at generating the crash report.