### PR TITLE
Add an inline configuration for coda-txns-and-restart-non-producers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1136,6 +1136,24 @@ jobs:
                     GO: /usr/lib/go/bin/go
             - store_artifacts:
                   path: test_output/artifacts
+    test--dev--coda-txns-and-restart-non-producers:
+        resource_class: large
+        docker:
+            - image: codaprotocol/coda:toolchain-9924f4c56a40d65d36440e8f70b93720f29ba171
+        steps:
+            - restore_cache:
+                name: Restore cache - opam
+                keys:
+                    -  dev-build-binaries-v1-{{ .Revision }}
+            - run:
+                  name: Running test -- dev:coda-txns-and-restart-non-producers
+                  command: if [ -f should_run_tests ]; then source ~/.profile && ./scripts/test.py run --no-build --non-interactive --collect-artifacts --yes "dev:coda-txns-and-restart-non-producers"; fi
+                  environment:
+                    LIBP2P_NIXLESS: 1
+                    CODA_LIBP2P_HELPER_PATH: /home/opam/project/src/app/libp2p_helper/result/bin/libp2p_helper
+                    GO: /usr/lib/go/bin/go
+            - store_artifacts:
+                  path: test_output/artifacts
     test--fake_hash:
         resource_class: large
         docker:
@@ -1337,45 +1355,6 @@ jobs:
                   command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && ./scripts/test.py run --non-interactive --collect-artifacts --yes "test_postake_split:coda-shared-prefix-multiproducer-test -num-block-producers 2"'
             - store_artifacts:
                   path: test_output/artifacts
-    test--test_postake_three_producers:
-        resource_class: large
-        docker:
-            - image: codaprotocol/coda:toolchain-9924f4c56a40d65d36440e8f70b93720f29ba171
-        steps:
-            
-            - run:
-                name: Disable LFS checkout
-                command: |
-                    git config --global filter.lfs.smudge "git-lfs smudge --skip %f"
-                    git config --global lfs.fetchexclude "*"
-            - checkout
-
-            
-            - run:
-                  name: Update Submodules
-                  command: git submodule sync && git submodule update --init --recursive
-            - run:
-                name: Create opam cache signature file including a year/date stamp to ensure occasional rebuilds
-                command: |
-                    cat scripts/setup-opam.sh > opam_ci_cache.sig
-                    cat src/opam.export >> opam_ci_cache.sig
-                    date +%Y-%m >> opam_ci_cache.sig
-            - restore_cache:
-                name: Restore cache - opam
-                keys:
-                    - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
-            - run:
-                name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
-
-            - run:
-                name: Build libp2p_helper
-                command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
-            - run:
-                  name: Running test -- test_postake_three_producers:coda-txns-and-restart-non-producers
-                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && ./scripts/test.py run --non-interactive --collect-artifacts --yes "test_postake_three_producers:coda-txns-and-restart-non-producers"'
-            - store_artifacts:
-                  path: test_output/artifacts
     test--test_postake_full_epoch:
         resource_class: xlarge
         docker:
@@ -1572,7 +1551,6 @@ workflows:
             - test--test_postake_five_even_txns
             - test--test_postake_snarkless
             - test--test_postake_split
-            - test--test_postake_three_producers
             - build-binaries--dev
             - test--dev--coda-bootstrap-test:
                 requires:
@@ -1608,6 +1586,9 @@ workflows:
                 requires:
                   - build-binaries--dev
             - test--dev--coda-restart-node-test:
+                requires:
+                  - build-binaries--dev
+            - test--dev--coda-txns-and-restart-non-producers:
                 requires:
                   - build-binaries--dev
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -45,6 +45,7 @@ compile_config_agnostic_tests = [
     'coda-archive-node-test',
     'coda-delegation-test',
     'coda-restart-node-test',
+    'coda-txns-and-restart-non-producers',
 ]
 
 compile_config_agnostic_profiles = [
@@ -69,7 +70,6 @@ small_curves_tests = {
     ['coda-shared-prefix-multiproducer-test -num-block-producers 2'],
     'test_postake':
     simple_tests,
-    'test_postake_three_producers': ['coda-txns-and-restart-non-producers'],
     'test_postake_five_even_txns':
     ['coda-shared-prefix-multiproducer-test -num-block-producers 5 -payments'],
 }

--- a/src/app/cli/src/tests/coda_txns_and_restart_non_producers.ml
+++ b/src/app/cli/src/tests/coda_txns_and_restart_non_producers.ml
@@ -4,10 +4,17 @@ open Coda_base
 
 let name = "coda-txns-and-restart-non-producers"
 
+let runtime_config = Runtime_config.Test_configs.three_producers
+
 let main () =
   let wait_time = Time.Span.of_min 2. in
   let logger = Logger.create () in
-  let precomputed_values = Lazy.force Precomputed_values.compiled in
+  let%bind precomputed_values, _runtime_config =
+    Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
+      ~proof_level:None
+      (Lazy.force runtime_config)
+    >>| Or_error.ok_exn
+  in
   let accounts = Lazy.force (Precomputed_values.accounts precomputed_values) in
   let snark_work_public_keys =
     Fn.const @@ Some (List.nth_exn accounts 5 |> snd |> Account.public_key)

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -646,4 +646,29 @@ module Test_configs = struct
       , "add_genesis_winner": false } }
       |json}
       |> Yojson.Safe.from_string |> of_yojson |> Result.ok_or_failwith )
+
+  let three_producers =
+    lazy
+      ( (* test_postake_three_producers *)
+        {json|
+  { "daemon":
+      { "txpool_max_size": 3000 }
+  , "genesis":
+      { "k": 6
+      , "delta": 3
+      , "genesis_state_timestamp": "2019-01-30 12:00:00-08:00" }
+  , "proof":
+      { "level": "none"
+      , "c": 8
+      , "ledger_depth": 6
+      , "work_delay": 2
+      , "block_window_duration_ms": 4000
+      , "transaction_capacity": {"2_to_the": 3}
+      , "coinbase_amount": "20"
+      , "account_creation_fee": "1" }
+  , "ledger":
+      { "name": "test_three_even_stakes"
+      , "add_genesis_winner": false } }
+      |json}
+      |> Yojson.Safe.from_string |> of_yojson |> Result.ok_or_failwith )
 end


### PR DESCRIPTION
Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
