### PR TITLE
Ocaml plonk constraints

### DIFF
--- a/src/double_marlin.opam
+++ b/src/double_marlin.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+

--- a/src/lib/double_marlin/.vscode/launch.json
+++ b/src/lib/double_marlin/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug",
+            "type": "gdb",
+            "request": "launch",
+            "target": "/home/pavel/tesla/_build/default/src/lib/double_marlin/.double_marlin.inline-tests/run.exe",
+            "cwd": "${workspaceRoot}",
+            "valuesFormatting": "disabled",
+            "arguments": "inline-test-runner double_marlin -source-tree-root ../../.. -diff-cmd -"
+        }
+    ]
+}

--- a/src/lib/double_marlin/concrete.ml
+++ b/src/lib/double_marlin/concrete.ml
@@ -1,0 +1,216 @@
+let%test_module "backend test" =
+  ( module struct
+    let () =
+      Zexe_backend.Tweedle.Dee_based.Keypair.set_urs_info
+        [On_disk {directory= "/tmp/"; should_write= true}]
+
+    let () =
+      Zexe_backend.Tweedle.Dum_based.Keypair.set_urs_info
+        [On_disk {directory= "/tmp/"; should_write= true}]
+
+    module ComputationExample
+        (Impl : Snarky.Snark_intf.Run with type prover_state = unit) =
+    struct
+      let computation x16 () =
+        let open Impl.Field in
+        let x4 = sqrt x16 in
+        let x2 = sqrt x4 in
+        let x = sqrt x2 in
+        let x_16 = inv x16 in
+        let x_4 = inv x4 in
+        let x_2 = inv x2 in
+        let x_1 = inv x in
+        let y1 = x * x2 * x4 * x16 in
+        let y2 = x_1 * x_2 * x_4 * x_16 in
+        let y3 = (y1 * y2) - one in
+        Impl.assert_r1cs y1 y2 one ; Assert.equal y3 zero ; ()
+
+      let input () = Impl.Data_spec.[Impl.Field.typ]
+
+      let keys = Impl.generate_keypair ~exposing:(input ()) computation
+
+      let statement = Impl.Field.Constant.of_int 256
+
+      let proof =
+        Impl.prove (Impl.Keypair.pk keys) (input ()) computation () statement
+
+      let%test_unit "check backend ComputationExample proof" =
+        assert (Impl.verify proof (Impl.Keypair.vk keys) (input ()) statement)
+    end
+
+    module MerkleTree (Snark : Snarky.Snark_intf.S) = struct
+      module Knapsack = Snarky.Knapsack.Make (Snark)
+      open Snark
+
+      (* A merkle tree is a data-structure which allows one to publish a "summary"
+        (the "root hash" or "merkle hash") of a list of values in such a way that
+        one can later prove for a particular value that it was a member of that list.
+
+        There is also a notion of "updating" a merkle tree at a particular index, or address.
+        This means replacing the value stored at that address  with a new value.
+
+        In this tutorial, we would like to write a checked computation verifying the following:
+
+        Given:
+        - a merkle hash [root_start]
+        - a list of pairs [(x_1, addr_1), ..., (x_n, addr_n)]
+        - a merkle hash [root_end]
+
+        Prove that updating a merkle tree with root hash [root_start] by
+        setting the value at [addr_i] to [x_i] for [i = 1...n] results in
+        a merkle tree with root hash [root_end]. *)
+      (* First, we specify the hash function we use, and the type of hashes.
+        We will use the knapsack hash function. *)
+
+      let knapsack =
+        let dimension = 2 in
+        Knapsack.create ~dimension
+          ~max_input_length:(2 * Snark.Field.size_in_bits * dimension)
+
+      module Hash = struct
+        include Knapsack.Hash (struct
+          let knapsack = knapsack
+        end)
+
+        (* Don't do this at home *)
+        let merge ~height:_ x y = hash x y
+      end
+
+      (* Second, we specify the type of values which we'll store in the merkle tree.
+        Let's say a value is a bitsring of length 10. *)
+      module Value = struct
+        let length = 10
+
+        type var = Snark.Boolean.var list
+
+        type value = bool list
+
+        (* This "typ" tells camlsnark how to store a [Value.value] as R1CS variables,
+            as well as any constraints to put on the values (in this case boolean constraints.) *)
+        let typ : (var, value) Snark.Typ.t =
+          Snark.Typ.list ~length Snark.Boolean.typ
+
+        let random () = Core.List.init length ~f:(fun _ -> Random.bool ())
+
+        let hash (bs : var) = Knapsack.Checked.hash_to_bits knapsack bs
+      end
+
+      module Merkle_tree_checked =
+        Snarky.Merkle_tree.Checked (Snark) (Hash) (Value)
+
+      (* The next thing to do is to specify the input for our snark. *)
+      let num_pairs = 5
+
+      let depth = 10
+
+      let address_typ = Merkle_tree_checked.Address.typ ~depth
+
+      let input () =
+        let open Snark.Data_spec in
+        [ Hash.typ (* [root_start] *)
+        ; Snark.Typ.(list ~length:num_pairs (tuple2 Value.typ address_typ))
+          (* [(x_1, addr_1), ..., (x_n, addr_n)]  *)
+        ; Hash.typ
+          (* [root_end] *)
+         ]
+
+      (* Now, we write the computation that we want our snark to certify.
+        A [Checked] computation is paramterized by two types. [Checked.t] is
+        a monad, which allows us to use overloaded [let] notation to write verified
+        computations in a very natural style.
+        *)
+      let update_many root_start
+          (updates : (Value.var * Merkle_tree_checked.Address.var) list)
+          root_end :
+          ( unit
+            (* 1. The return type. Here it is [unit], indicating we return
+                only the [unit] value. *)
+          , (Hash.value, Value.value) Snarky.Merkle_tree.t
+          (* 2. The prover's state type. Here, we indicate that the prover has
+                access to a Merkle tree using hashes of type [Hash.value] and containing
+                values of type [Value.value]. *)
+          )
+          Snark.Checked.t =
+        (* We loop over all the updates, updating the prover's Merkle tree as we go. *)
+        let rec go curr_root = function
+          | [] ->
+              Snark.Let_syntax.return curr_root
+          | (x, addr) :: updates' ->
+              (* We update the Merkle tree, computing the new Merkle root, and repeat. *)
+              let%bind next_root =
+                let%bind prev_value =
+                  (* Here we look up the previously stored value in the Merkle tree so that we can use
+                    it in authenticating the update. *)
+                  exists Value.typ
+                    ~compute:
+                      Snark.As_prover.(
+                        map2 ~f:Snarky.Merkle_tree.get_exn get_state
+                          (read address_typ addr))
+                in
+                Merkle_tree_checked.update addr ~depth ~root:curr_root
+                  ~prev:prev_value ~next:x
+              in
+              go next_root updates'
+        in
+        let%bind final_root = go root_start updates in
+        (* Finally, after computing the root after all those updates, we assert that it is
+            equal to the specified [root_end]. *)
+        Hash.assert_equal final_root root_end
+
+      (* Now that we have specified the computation to produce a snark for, we can actually
+        produce the snark. *)
+      (* First we generate the keypair. *)
+      let keypair = Snark.generate_keypair ~exposing:(input ()) update_many
+
+      (* Next, we can generate a proof on some sample inputs. *)
+      (* First the inputs. *)
+      let tree_start =
+        let num_entries = 1 lsl depth in
+        let t0 =
+          Snarky.Merkle_tree.create (Value.random ())
+            ~hash:(fun xo ->
+              Knapsack.hash_to_bits knapsack (Core.Option.value ~default:[] xo)
+              )
+            ~merge:(fun x y -> Knapsack.hash_to_bits knapsack (x @ y))
+        in
+        Snarky.Merkle_tree.add_many t0
+          (Core.List.init (num_entries - 1) ~f:(fun _ -> Value.random ()))
+
+      let updates =
+        let random_addr () = Random.int (Core.Int.pow 2 depth) in
+        Core.List.init num_pairs ~f:(fun _ -> (Value.random (), random_addr ()))
+
+      let tree_end =
+        Core.List.fold_left updates ~init:tree_start ~f:(fun acc (x, addr) ->
+            Snarky.Merkle_tree.update acc addr x )
+
+      let root_start = Snarky.Merkle_tree.root tree_start
+
+      let root_end = Snarky.Merkle_tree.root tree_end
+
+      (* And now the proof. *)
+      let proof =
+        Snark.prove (Snark.Keypair.pk keypair)
+          (input ()) (* The input spec *)
+          tree_start (* The initial state for the prover *) update_many
+          (* The computation to create a snark for *)
+          root_start (* The inputs for the snark *) updates root_end
+
+      (* Now we can check that the snark verifies as expected. *)
+      let%test_unit "check backend MerkleTree proof" =
+        assert (
+          Snark.verify proof (Snark.Keypair.vk keypair) (input ()) root_start
+            updates root_end )
+    end
+
+    include ComputationExample
+              (Snarky.Snark.Run.Make
+                 (Zexe_backend.Tweedle.Dee_based)
+                 (Core.Unit))
+    include ComputationExample
+              (Snarky.Snark.Run.Make
+                 (Zexe_backend.Tweedle.Dum_based)
+                 (Core.Unit))
+
+    (*include MerkleTree(Snarky.Snark.Make (Zexe_backend.Tweedle.Dee_based))*)
+  end )

--- a/src/lib/double_marlin/dune
+++ b/src/lib/double_marlin/dune
@@ -1,0 +1,22 @@
+(library
+  (inline_tests)
+  (name double_marlin)
+  (public_name double_marlin)
+  (flags -warn-error -27)
+  (preprocess (pps ppx_version ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson ))
+  (libraries
+    digestif
+    zexe_backend
+    pickles.composition_types
+    pickles.limb_vector
+    pickles.marlin_checks
+    pickles.one_hot_vector
+    pickles.pseudo
+    snarky_log
+    sponge
+    group_map
+    snarky_group_map
+    snarky_curve
+    snarky
+    key_cache
+    core_kernel ))

--- a/src/lib/ocaml_plonk_constraints_app/dune
+++ b/src/lib/ocaml_plonk_constraints_app/dune
@@ -1,0 +1,23 @@
+(library
+  (inline_tests)
+  (name ocaml_plonk_constraints_app)
+  (public_name ocaml_plonk_constraints_app)
+  (flags -warn-error -27)
+  (preprocess (pps ppx_version ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson ))
+  (libraries
+    plonk
+    digestif
+    zexe_backend
+    pickles.composition_types
+    pickles.limb_vector
+    pickles.marlin_checks
+    pickles.one_hot_vector
+    pickles.pseudo
+    snarky_log
+    sponge
+    group_map
+    snarky_group_map
+    snarky_curve
+    snarky
+    key_cache
+    core_kernel ))

--- a/src/lib/ocaml_plonk_constraints_app/main.ml
+++ b/src/lib/ocaml_plonk_constraints_app/main.ml
@@ -1,0 +1,53 @@
+let%test_module "backend test" =
+  ( module struct
+    let () =
+      Zexe_backend.Tweedle.Dee_based.Keypair.set_urs_info
+        [On_disk {directory= "/tmp/"; should_write= true}]
+
+    module ComputationExample
+        (Impl : Snarky.Snark_intf.Run with type prover_state = unit) =
+    struct
+      open Core
+      open Impl
+
+      let computation i16 () =
+        let open Field in
+
+        let i4 = sqrt i16 in
+        let i_16 = inv i16 in
+        let i_4 = inv i4 in
+
+        let j1 = i4 * i16 in
+        let j_1 = i_4 * i_16 in
+
+        let k1 = j1 * j_1 in
+        let k2 = k1 - one in
+
+        assert_r1cs j1 j_1 one;
+        assert_ (Snarky.Constraint.boolean k1);
+        assert_ (Snarky.Constraint.equal k2 zero);
+
+        let module Poseidon = Plonk.Poseidon.Constraints (Impl) in
+        let perm = Poseidon.permute [|j1 ; k1 ; k2|] 63 in
+
+        (* constraints below are not satisfiable only for testing *)
+        let module Ecc = Plonk.Ecc.Constraints (Impl) in
+
+        let scalar = Array.init 13 ~f:(fun _ -> if Random.int 2 = 0 then Field.zero else Field.one) in
+
+        let (x2, y2) = Ecc.scale (perm.(0), perm.(1)) scalar in
+        let (x3, y3) = Ecc.endoscale (x2, y2) scalar in
+        assert_ (Snarky.Constraint.equal x3 y3);
+
+        ()
+
+      let input () = Impl.Data_spec.[Impl.Field.typ]
+      let keys = Impl.generate_keypair ~exposing:(input ()) computation
+      let statement = Impl.Field.Constant.of_int 256
+      let proof = Impl.prove (Impl.Keypair.pk keys) (input ()) computation () statement
+      let%test_unit "check backend ComputationExample proof" =
+        assert (Impl.verify proof (Impl.Keypair.vk keys) (input ()) statement)
+    end
+
+    include ComputationExample (Snarky.Snark.Run.Make(Zexe_backend.Tweedle.Dee_based) (Core.Unit))
+  end )

--- a/src/lib/ocaml_plonk_constraints_app/plonk/dune
+++ b/src/lib/ocaml_plonk_constraints_app/plonk/dune
@@ -1,0 +1,22 @@
+(library
+  (name plonk)
+  (public_name plonk)
+  (flags -warn-error -27)
+  (preprocess (pps ppx_version ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson h_list.ppx ))
+  (libraries
+    digestif
+    zexe_backend
+    pickles.composition_types
+    pickles.limb_vector
+    pickles.marlin_checks
+    pickles.one_hot_vector
+    snarky.backendless
+    pickles.pseudo
+    snarky_log
+    sponge
+    group_map
+    snarky_group_map
+    snarky_curve
+    snarky
+    key_cache
+    core_kernel ))

--- a/src/lib/ocaml_plonk_constraints_app/plonk/ecc.ml
+++ b/src/lib/ocaml_plonk_constraints_app/plonk/ecc.ml
@@ -1,46 +1,46 @@
 open Core
 open Snarky
 open Zexe_backend_common.R1cs_constraint_system
+open Snarky_bn382.Tweedle
 
-module Constraints (Intf : Snark_intf.Run with type prover_state = unit) = struct
+module Constraints (Intf : Snark_intf.Run with type prover_state = unit and type field = Dee.Field.t ) = struct
   open Intf
   open Field
 
   module Basic = struct
-    open Field.Constant
+    open Constant
 
-    let add (p1 : field * field) (p2 : field * field) : field * field  =
-      let s = (snd p2 - snd p1) / (fst p2 - fst p1) in
-      let x3 = square s - fst p1 - fst p2 in
-      let y3 = (fst p1 - x3) * s - snd p1 in
+    let add ((x1, y1) : field * field) ((x2, y2) : field * field) : field * field  =
+      let s = (y2 - y1) / (x2 - x1) in
+      let x3 = square s - x1 - x2 in
+      let y3 = (x1 - x3) * s - y1 in
       (x3, y3)
 
-    let double (p : field * field) : field * field  =
-      let s = square (fst p) * of_int 3 / of_int 2 / snd p in
-      let x = square s - fst p * of_int 2 in
-      let y = s * (fst p - x) - snd p in
-      (x, y)
+    let double ((x, y) : field * field) : field * field  =
+      let s = square x * of_int 3 / of_int 2 / y in
+      let x1 = square s - x * of_int 2 in
+      let y1 = s * (x - x1) - y in
+      (x1, y1)
   end
 
-  let add (p1 : Field.t * Field.t) (p2 : Field.t * Field.t) : Field.t * Field.t  =
-    let p3 = exists Typ.(Field.typ * Field.typ) ~compute:As_prover.(fun () ->
+  let add (p1 : t * t) (p2 : t * t) : t * t  =
+    let p3 = exists Typ.(typ * typ) ~compute:As_prover.(fun () ->
         (Basic.add (read_var (fst p1), read_var (snd p1)) (read_var (fst p2), read_var (snd p2))))
     in
     Intf.assert_
       [{
-        basic= Zexe_backend.R1CS_constraint_system.Plonk_constraint.T (EC_add { p1= p1; p2= p2; p3= p3 }) ;
+        basic= Plonk_constraint.T (EC_add { p1; p2; p3 }) ;
         annotation= None
       }];
     p3
 
-  let double (p : Field.t * Field.t) : Field.t * Field.t  =
-    let s = square (fst p) * of_int 3 / of_int 2 / snd p in
-    let x = square s - fst p * of_int 2 in
-    let y = s * (fst p - x) - snd p in
-    (x, y)
+  let double ((x, y) : t * t) : t * t  =
+    let s = square x * of_int 3 / of_int 2 / y in
+    let x1 = square s - x * of_int 2 in
+    let y1 = s * (x - x1) - y in
+    (x1, y1)
 
-  let scale (base : Field.t * Field.t) (scalar : Field.t array) : Field.t * Field.t =
-    let n = Array.length scalar in
+  let scale ((x, y) : t * t) (scalar : t array) : t * t =
     (*
       Acc := [2] T + T
       for i from n-2 down to 0
@@ -49,20 +49,19 @@ module Constraints (Intf : Snark_intf.Run with type prover_state = unit) = struc
       return (k0 = 0) ? (Acc - T) : Acc
     *)
 
-    let p = add (double base) base in
+    let n = Array.length scalar in
+    let (xp, yp) = add (double (x, y)) (x, y) in
 
-    let state = exists (Snarky.Typ.array ~length:n (Scale_round.typ Field.typ)) ~compute:As_prover.(fun () ->
+    let state = exists (Snarky.Typ.array ~length:n (Scale_round.typ typ)) ~compute:As_prover.(fun () ->
         (
           let state = ref [] in
-          let xpl, ypl = read_var (fst p), read_var (snd p) in
+          let xpl, ypl = read_var xp, read_var yp in
+          let xtl, ytl = read_var x, read_var y in
 
           for i = Int.(n - 2) to 0 do
-            let xtl = read_var (fst base) in
-            let ytl = read_var (snd base) in
             let bit = read_var scalar.(Int.(i + 1)) in
-            let yq = if bit = Field.Constant.one then ytl else negate ytl in
+            let yq = if bit = one then ytl else negate ytl in
             let xsl, ysl = Basic.add (xpl, ypl) (Basic.add (xpl, ypl) (xtl, yq)) in
-
             let round = Scale_round.{ xt=xtl; b=bit; yt=ytl; xp=xpl; l1=(ypl+yq)/(xpl-xtl); yp=ypl; xs=xsl; ys=ysl } in
             state := !state @ [round];
           done;
@@ -71,44 +70,60 @@ module Constraints (Intf : Snark_intf.Run with type prover_state = unit) = struc
     in
     Intf.assert_
       [{
-        basic= Zexe_backend.R1CS_constraint_system.Plonk_constraint.T (EC_scale { state }) ;
+        basic= Plonk_constraint.T (EC_scale { state }) ;
         annotation= None
       }];
     let finish = state.(Int.(n - 1)) in
 
     let if_pair b (tx, ty) (ex, ey) =
-      Field.(if_ b ~then_:tx ~else_:ty, if_ b ~then_:ty ~else_:tx)
+      if_ b ~then_:tx ~else_:ty, if_ b ~then_:ty ~else_:tx
     in
     if_pair
       (Intf.Boolean.of_field scalar.(0))
-       (add (finish.xs, finish.ys) (fst base, negate (snd base)))
-        (finish.xs, finish.ys)
+      (add (finish.xs, finish.ys) (x, negate y))
+      (finish.xs, finish.ys)
 
-  let endoscale (p : Field.t * Field.t) (scalar : Field.t array) : Field.t * Field.t =
-    let length = Array.length scalar in
-    let state = exists (Snarky.Typ.array ~length:length (Endoscale_round.typ Field.typ)) ~compute:As_prover.(fun () ->
+  let endoscale ((x, y) : t * t) (scalar : t array) : t * t =
+    (*
+      Acc := [2](endo(P) + P)
+      for i from n/2-1 down to 0:
+      let S[i] =
         (
-          let state = Array.map scalar ~f:(fun x -> Endoscale_round.{
-              b2i1= Field.Constant.zero;
-              xt= Field.Constant.zero;
-              b2i= Field.Constant.zero;
-              xq= Field.Constant.zero;
-              yt= Field.Constant.zero;
-              xp= Field.Constant.zero;
-              l1= Field.Constant.zero;
-              yp= Field.Constant.zero;
-              xs= Field.Constant.zero;
-              ys= Field.Constant.zero; 
-            }) in
-          state
+          [2r[2i] - 1]P; if r[2i+1] = 0
+          endo[2r[2i] - 1]P; otherwise
+        )
+      Acc := (Acc + S[i]) + Acc
+      return Acc
+    *)
+
+    let endo = Endo.Dee.scalar () in
+    let n = Int.(2 * (Array.length scalar) - 1) in
+    let (xp, yp) = double (add (Field.scale x endo, y) (x, y)) in
+
+    let state = exists (Snarky.Typ.array ~length:n (Endoscale_round.typ typ)) ~compute:As_prover.(fun () ->
+        (
+          let state = ref [] in
+          let xpl, ypl = read_var xp, read_var yp in
+          let xtl, ytl = read_var x, read_var y in
+
+          for i = Int.(n/2 - 1) to 0 do
+            let b2il = read_var scalar.(Int.(2 * i)) in
+            let b2i1l = read_var scalar.(Int.(2 * i + 1)) in
+            let xql = if b2i1l = one then xtl * endo else xtl in
+            let yql = if b2il = one then ytl else negate ytl in
+            let xsl, ysl = Basic.add (xpl, ypl) (Basic.add (xpl, ypl) (xtl, ytl)) in
+            let round = Endoscale_round.{ b2i1= b2i1l; xt=xtl; b2i= b2il; xq= xql; yt=ytl; xp=xpl; l1=(ypl-yql)/(xpl-xql); yp=ypl; xs=xsl; ys=ysl } in
+            state := !state @ [round];
+          done;
+          Array.of_list !state
         ))
     in
     Intf.assert_
       [{
-        basic= Zexe_backend.R1CS_constraint_system.Plonk_constraint.T (EC_endoscale { state }) ;
+        basic= Plonk_constraint.T (EC_endoscale { state }) ;
         annotation= None
       }];
-    let finish = state.(Int.(length - 1)) in
+    let finish = state.(Int.(n - 1)) in
     (finish.xs, finish.ys)
 
 end

--- a/src/lib/ocaml_plonk_constraints_app/plonk/ecc.ml
+++ b/src/lib/ocaml_plonk_constraints_app/plonk/ecc.ml
@@ -1,0 +1,114 @@
+open Core
+open Snarky
+open Zexe_backend_common.R1cs_constraint_system
+
+module Constraints (Intf : Snark_intf.Run with type prover_state = unit) = struct
+  open Intf
+  open Field
+
+  module Basic = struct
+    open Field.Constant
+
+    let add (p1 : field * field) (p2 : field * field) : field * field  =
+      let s = (snd p2 - snd p1) / (fst p2 - fst p1) in
+      let x3 = square s - fst p1 - fst p2 in
+      let y3 = (fst p1 - x3) * s - snd p1 in
+      (x3, y3)
+
+    let double (p : field * field) : field * field  =
+      let s = square (fst p) * of_int 3 / of_int 2 / snd p in
+      let x = square s - fst p * of_int 2 in
+      let y = s * (fst p - x) - snd p in
+      (x, y)
+  end
+
+  let add (p1 : Field.t * Field.t) (p2 : Field.t * Field.t) : Field.t * Field.t  =
+    let p3 = exists Typ.(Field.typ * Field.typ) ~compute:As_prover.(fun () ->
+        (Basic.add (read_var (fst p1), read_var (snd p1)) (read_var (fst p2), read_var (snd p2))))
+    in
+    Intf.assert_
+      [{
+        basic= Zexe_backend.R1CS_constraint_system.Plonk_constraint.T (EC_add { p1= p1; p2= p2; p3= p3 }) ;
+        annotation= None
+      }];
+    p3
+
+  let double (p : Field.t * Field.t) : Field.t * Field.t  =
+    let s = square (fst p) * of_int 3 / of_int 2 / snd p in
+    let x = square s - fst p * of_int 2 in
+    let y = s * (fst p - x) - snd p in
+    (x, y)
+
+  let scale (base : Field.t * Field.t) (scalar : Field.t array) : Field.t * Field.t =
+    let n = Array.length scalar in
+    (*
+      Acc := [2] T + T
+      for i from n-2 down to 0
+          Q := ki+1 ? T : −T
+          Acc := (Acc + Q) + Acc
+      return (k0 = 0) ? (Acc - T) : Acc
+    *)
+
+    let p = add (double base) base in
+
+    let state = exists (Snarky.Typ.array ~length:n (Scale_round.typ Field.typ)) ~compute:As_prover.(fun () ->
+        (
+          let state = ref [] in
+          let xpl, ypl = read_var (fst p), read_var (snd p) in
+
+          for i = Int.(n - 2) to 0 do
+            let xtl = read_var (fst base) in
+            let ytl = read_var (snd base) in
+            let bit = read_var scalar.(Int.(i + 1)) in
+            let yq = if bit = Field.Constant.one then ytl else negate ytl in
+            let xsl, ysl = Basic.add (xpl, ypl) (Basic.add (xpl, ypl) (xtl, yq)) in
+
+            let round = Scale_round.{ xt=xtl; b=bit; yt=ytl; xp=xpl; l1=(ypl+yq)/(xpl-xtl); yp=ypl; xs=xsl; ys=ysl } in
+            state := !state @ [round];
+          done;
+          Array.of_list !state
+        ))
+    in
+    Intf.assert_
+      [{
+        basic= Zexe_backend.R1CS_constraint_system.Plonk_constraint.T (EC_scale { state }) ;
+        annotation= None
+      }];
+    let finish = state.(Int.(n - 1)) in
+
+    let if_pair b (tx, ty) (ex, ey) =
+      Field.(if_ b ~then_:tx ~else_:ty, if_ b ~then_:ty ~else_:tx)
+    in
+    if_pair
+      (Intf.Boolean.of_field scalar.(0))
+       (add (finish.xs, finish.ys) (fst base, negate (snd base)))
+        (finish.xs, finish.ys)
+
+  let endoscale (p : Field.t * Field.t) (scalar : Field.t array) : Field.t * Field.t =
+    let length = Array.length scalar in
+    let state = exists (Snarky.Typ.array ~length:length (Endoscale_round.typ Field.typ)) ~compute:As_prover.(fun () ->
+        (
+          let state = Array.map scalar ~f:(fun x -> Endoscale_round.{
+              b2i1= Field.Constant.zero;
+              xt= Field.Constant.zero;
+              b2i= Field.Constant.zero;
+              xq= Field.Constant.zero;
+              yt= Field.Constant.zero;
+              xp= Field.Constant.zero;
+              l1= Field.Constant.zero;
+              yp= Field.Constant.zero;
+              xs= Field.Constant.zero;
+              ys= Field.Constant.zero; 
+            }) in
+          state
+        ))
+    in
+    Intf.assert_
+      [{
+        basic= Zexe_backend.R1CS_constraint_system.Plonk_constraint.T (EC_endoscale { state }) ;
+        annotation= None
+      }];
+    let finish = state.(Int.(length - 1)) in
+    (finish.xs, finish.ys)
+
+end

--- a/src/lib/ocaml_plonk_constraints_app/plonk/poseidon.ml
+++ b/src/lib/ocaml_plonk_constraints_app/plonk/poseidon.ml
@@ -1,0 +1,41 @@
+open Core
+open Snarky
+open Sponge
+
+module Constraints (Intf : Snark_intf.Run with type prover_state = unit) = struct
+  open Intf
+  (* TODO: need to derive sponge parameters from Snarky Intf Field *)
+  let params = Sponge.Params.(map tweedle_p ~f:Field.Constant.of_string)
+
+  let permute (start : Field.t array) rounds : Field.t array =
+    let length = Array.length start in
+    let state = exists 
+        (Snarky.Typ.array ~length:rounds (Snarky.Typ.array length Field.typ)) 
+        ~compute:As_prover.(fun () ->
+            (
+              let state = Array.create rounds (Array.create length zero) in
+              Array.iteri
+                state
+                ~f:(fun i _ ->
+                    (
+                      let prev = if i = 0 then Array.map ~f: (fun x -> read_var x) start else state.(Int.(i-1)) in
+                      Array.map_inplace ~f:(fun x -> (square (square x)) * x) prev;
+                      state.(i) <- Array.map
+                          ~f:(fun p -> Array.fold2_exn p prev ~init:Field.Constant.zero ~f:(fun c a b -> a * b + c))
+                          params.mds;
+                      for j = 0 to Int.(length - 1) do
+                        state.(i).(j) <- state.(i).(j) + params.round_constants.(i).(j)
+                      done
+                    )
+                  );
+              state
+            ))
+    in
+    Intf.assert_
+      [{
+        basic= Zexe_backend.R1CS_constraint_system.Plonk_constraint.T (Poseidon { start; state }) ;
+        annotation= None
+      }];
+    state.(rounds - 1)
+
+end

--- a/src/lib/ocaml_plonk_constraints_app/plonk/poseidon.ml
+++ b/src/lib/ocaml_plonk_constraints_app/plonk/poseidon.ml
@@ -2,10 +2,11 @@ open Core
 open Snarky
 open Sponge
 
-module Constraints (Intf : Snark_intf.Run with type prover_state = unit) = struct
+module Constraints
+    (Intf : Snark_intf.Run with type prover_state = unit)
+    (Params : sig val params : Intf.field Params.t end)
+= struct
   open Intf
-  (* TODO: need to derive sponge parameters from Snarky Intf Field *)
-  let params = Sponge.Params.(map tweedle_p ~f:Field.Constant.of_string)
 
   let permute (start : Field.t array) rounds : Field.t array =
     let length = Array.length start in
@@ -14,20 +15,16 @@ module Constraints (Intf : Snark_intf.Run with type prover_state = unit) = struc
         ~compute:As_prover.(fun () ->
             (
               let state = Array.create rounds (Array.create length zero) in
-              Array.iteri
-                state
-                ~f:(fun i _ ->
-                    (
-                      let prev = if i = 0 then Array.map ~f: (fun x -> read_var x) start else state.(Int.(i-1)) in
-                      Array.map_inplace ~f:(fun x -> (square (square x)) * x) prev;
-                      state.(i) <- Array.map
-                          ~f:(fun p -> Array.fold2_exn p prev ~init:Field.Constant.zero ~f:(fun c a b -> a * b + c))
-                          params.mds;
-                      for j = 0 to Int.(length - 1) do
-                        state.(i).(j) <- state.(i).(j) + params.round_constants.(i).(j)
-                      done
-                    )
-                  );
+              for i = 0 to rounds do
+                let prev = if i = 0 then Array.map ~f:(fun x -> read_var x) start else state.(Int.(i-1)) in
+                state.(i) <- Array.map ~f:(fun x -> (square (square x)) * x) prev;
+                state.(i) <- Array.map
+                    ~f:(fun p -> Array.fold2_exn p state.(i) ~init:Field.Constant.zero ~f:(fun c a b -> a * b + c))
+                    Params.params.mds;
+                for j = 0 to Int.(length - 1) do
+                  state.(i).(j) <- state.(i).(j) + Params.params.round_constants.(i).(j)
+                done
+              done;
               state
             ))
     in

--- a/src/lib/zexe_backend/zexe_backend_common/endoscale_round.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/endoscale_round.ml
@@ -1,0 +1,49 @@
+module Endoscale_round = struct
+  open Core_kernel
+  module H_list = Snarky_backendless.H_list
+
+  [%%versioned
+    module Stable = struct
+      module V1 = struct
+        type 'a t =
+          {
+            b2i1: 'a; xt: 'a;
+            b2i: 'a; xq: 'a; yt: 'a; 
+            xp: 'a; l1: 'a; yp: 'a; 
+            xs: 'a; ys: 'a
+          } [@@deriving sexp, fields]
+      end
+    end]
+
+  type 'a t = 'a Stable.Latest.t =
+    {
+      b2i1: 'a; xt: 'a;
+      b2i: 'a; xq: 'a; yt: 'a; 
+      xp: 'a; l1: 'a; yp: 'a; 
+      xs: 'a; ys: 'a
+    }
+  [@@deriving sexp, fields, hlist]
+
+  let typ g =
+    Snarky_backendless.Typ.of_hlistable [g; g; g; g; g; g; g; g; g; g] ~var_to_hlist:to_hlist
+      ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
+
+  let map { b2i1; xt; b2i; xq; yt; xp; l1; yp; xs; ys} ~f =
+    {
+      b2i1= f b2i1; xt= f xt; b2i= f b2i; xq= f xq; yt= f yt; xp= f xp; l1= f l1; yp= f yp; xs= f xs; ys= f ys; 
+    }
+
+  let map2 t1 t2 ~f =
+    {
+      b2i1= f t1.b2i1 t2.b2i1;
+      xt= f t1.xt t2.xt;
+      b2i= f t1.b2i t2.b2i;
+      xq= f t1.xq t2.xq;
+      yt= f t1.yt t2.yt;
+      xp= f t1.xp t2.xp; 
+      l1= f t1.l1 t2.l1;
+      yp= f t1.yp t2.yp;
+      xs= f t1.xs t2.xs;
+      ys= f t1.ys t2.ys; 
+    }
+end

--- a/src/lib/zexe_backend/zexe_backend_common/endoscale_round.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/endoscale_round.ml
@@ -11,7 +11,7 @@ module Endoscale_round = struct
             b2i: 'a; xq: 'a; yt: 'a; 
             xp: 'a; l1: 'a; yp: 'a; 
             xs: 'a; ys: 'a
-          } [@@deriving sexp, fields]
+          } [@@deriving sexp, fields, hlist]
       end
     end]
 

--- a/src/lib/zexe_backend/zexe_backend_common/plonk_constraint_system.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/plonk_constraint_system.ml
@@ -1,0 +1,205 @@
+module Hash_state = struct
+  open Core_kernel
+  module H = Digestif.SHA256
+
+  type t = H.ctx
+
+  let digest t = Md5.digest_string H.(to_raw_string (get t))
+end
+
+module Plonk_constraint = struct
+  open Core_kernel
+
+  module T = struct
+    type ('v, 'f) t =
+      | Basic of { l : 'f * 'v; r : 'f * 'v; o : 'f * 'v; m: 'f; c: 'f }
+      | Poseidon_rounds of { num_rounds: int; start: 'v array; finish: 'v array }
+    [@@deriving sexp]
+
+    let map (type a b f) (t : (a, f) t) ~(f : a -> b) =
+      match t with
+      | Basic { l ; r; o; m; c } ->
+        let p (x, y) = (x, f y) in
+        Basic { l= p l; r= p r; o= p o; m; c }
+      | Poseidon_rounds { num_rounds; start; finish } ->
+        Poseidon_rounds { num_rounds; start=Array.map ~f start; finish= Array.map ~f finish }
+
+    let eval (type v f)
+        (module F : Snarky_backendless.Field_intf.S with type t = f)
+        (eval_one : v -> f)
+        (t : (v, f) t) =
+      match t with
+      (* cl * vl + cr * vr + co * vo + m * vl*vr + c = 0 *)
+      | Basic { l=(cl, vl); r=(cr, vr) ; o = (co, vo); m; c } ->
+        let vl = eval_one vl in
+        let vr = eval_one vr in
+        let vo = eval_one vo in
+        F.(equal zero (List.reduce_exn ~f:add [ mul cl vl; mul cr vl; mul co vo; mul m (mul vl vr); c ]))
+      | _ -> failwith "TODO"
+  end
+  include Snarky_backendless.Constraint.Add_kind(T)
+end 
+
+module Position = struct
+  type t = { row: int; col: int }
+end
+
+module Internal_var = Uuid
+
+module V = struct
+  open Core_kernel
+
+  module T = struct
+    type t =
+      | External of int
+      | Internal of Internal_var.Unstable.t
+      [@@deriving compare, hash, sexp]
+  end
+  include T
+  include Comparable.Make(T)
+  include Hashable.Make(T)
+
+  let create_internal () = Internal (Internal_var.create ())
+end
+
+type 'a t =
+  { backend: 'a
+  ; equivalence_classes: Position.t list V.Table.t
+  ; mutable next_row: int
+  ; mutable hash: Hash_state.t
+  ; mutable public_input_size: int
+  ; mutable auxiliary_input_size: int }
+
+let digest (t : _ t) = Hash_state.digest t.hash
+
+module Make (Fp : sig
+  include Field.S
+
+  val to_bigint_raw_noalloc : t -> Bigint.t
+end) = struct
+  open Core_kernel
+
+(* variable type into linear combination of variables *)
+  let canonicalize x =
+    let c, terms =
+      Fp.(
+        Snarky_backendless.Cvar.to_constant_and_terms ~add ~mul ~zero:(of_int 0) ~equal
+          ~one:(of_int 1))
+        x
+    in
+    let terms =
+      List.sort terms ~compare:(fun (_, i) (_, j) -> Int.compare i j)
+    in
+    let has_constant_term = Option.is_some c in
+    let terms = match c with None -> terms | Some c -> (c, 0) :: terms in
+    match terms with
+    | [] ->
+        Some ([], 0, false)
+    | (c0, i0) :: terms ->
+        let acc, i, ts, n =
+          Sequence.of_list terms
+          |> Sequence.fold ~init:(c0, i0, [], 0)
+                ~f:(fun (acc, i, ts, n) (c, j) ->
+                  if Int.equal i j then (Fp.add acc c, i, ts, n)
+                  else (c, j, (acc, i) :: ts, n + 1) )
+        in
+        Some (List.rev ((acc, i) :: ts), n + 1, has_constant_term)
+
+  module Hash_state = struct
+    include Hash_state
+  end
+
+  let neg_one = Fp.(negate one)
+
+  let add_generic_constraint sys ?mul ?constant
+      ?output (**o *)
+      ((s1: Fp.t), x1) ((s2 : Fp.t), x2) (**l, r *)
+      : unit
+    =
+    let row = sys.next_row in
+    sys.next_row <- row + 1 ;
+    V.Table.add_multi sys.equivalence_classes ~key:x1
+      ~data:{ row; col= 0 } ;
+    V.Table.add_multi sys.equivalence_classes ~key:x1
+      ~data:{ row; col= 1 } ;
+    Option.iter output ~f:(fun (_, x3) ->
+    V.Table.add_multi sys.equivalence_classes ~key:x3
+        ~data:{ row; col= 2 } ) (*;
+    Backend.add_generic_constraint
+      sys.backend
+      ([ s1; s2 ] @ Option.to_list (Option.map ~f:fst output) @ Option.to_list mul @ Option.to_list constant ) *)
+
+  let completely_reduce sys (terms : (Fp.t * int) list) = (* just adding constrained variables without values *)
+    let rec go = function
+      | [] -> assert false
+      | [ (s, x) ] -> (s, V.External x)
+      | (s1, x1) :: t ->
+        let x1 = V.External x1 in
+        let (s2, x2) = go t in
+        let s1x1_plus_s2x2 = V.create_internal () in
+        add_generic_constraint sys
+          (s1, x1) (s2, x2) ~output:(neg_one, s1x1_plus_s2x2) ;
+        (Fp.one, s1x1_plus_s2x2)
+    in
+    go terms
+
+  let reduce_lincom sys (x : Fp.t Snarky_backendless.Cvar.t)  =
+    let constant, terms =
+      Fp.(
+        Snarky_backendless.Cvar.to_constant_and_terms ~add ~mul ~zero:(of_int 0) ~equal
+          ~one:(of_int 1))
+        x
+    in
+    let terms =
+      List.sort terms ~compare:(fun (_, i) (_, j) -> Int.compare i j)
+    in
+    match constant, terms with
+    | Some c, [] -> (c, `Constant)
+    | None, [] -> (Fp.zero, `Constant)
+    | _, (c0, i0) :: terms ->
+      let terms =
+        let acc, i, ts, _ =
+          Sequence.of_list terms
+          |> Sequence.fold ~init:(c0, i0, [], 0)
+                ~f:(fun (acc, i, ts, n) (c, j) ->
+                  if Int.equal i j then (Fp.add acc c, i, ts, n)
+                  else (c, j, (acc, i) :: ts, n + 1) )
+        in
+        List.rev ((acc, i) :: ts)
+      in
+      match terms with
+      | [] -> assert false
+      | [(x, i)] -> (x, `Var (V.External i))
+      | (s1, x1) :: tl ->
+        let (s2, x2) = completely_reduce sys tl in
+        let res = V.create_internal () in
+        add_generic_constraint sys ?constant
+          (s1, External x1) (s2, x2) ~output:(neg_one, res) ;
+        (Fp.one, `Var res)
+  ;;
+
+  let add_constraint ?label:_ sys
+      (constr : (Fp.t Snarky_backendless.Cvar.t, Fp.t) Snarky_backendless.Constraint.basic) =
+    let var = canonicalize in
+    let var_exn t = Option.value_exn (var t) in
+    let red = reduce_lincom sys in
+    match constr with
+    | Snarky_backendless.Constraint.Boolean x ->
+      let (s, x) = red x in
+      (* s^2 x^2 = s x
+         s x - s^2 x*x = 0
+      *)
+      begin match x with
+      | `Constant -> 
+        (* Nothing to do *)
+        ()
+      | `Var x ->
+        add_generic_constraint sys
+          ~mul:Fp.(negate (square s))
+          (s, x)
+          (s, x)
+      end
+    | Snarky_backendless.Constraint.R1CS (a, b, c) ->
+      match (red a, red b, red c) with
+      | _ -> ()
+end

--- a/src/lib/zexe_backend/zexe_backend_common/plonk_constraint_system.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/plonk_constraint_system.ml
@@ -283,7 +283,6 @@ struct
         | `Var x1, `Constant -> add_generic_constraint sys (Fp.negate s1, x1) ~c:s2
         | `Constant, `Var x2 -> add_generic_constraint sys (Fp.negate s2, x2) ~c:s1
         | `Constant, `Constant -> assert Fp.(equal s1 s2)
-        | _, _ ->  ()
       )
 
     | Snarky_backendless.Constraint.Square (v1, v2) ->
@@ -294,7 +293,6 @@ struct
         | `Var x1, `Constant -> add_generic_constraint sys ~m:Fp.(s1 * s1) ~c:s2 (s1, x1) ~r:(s1, x1)
         | `Constant, `Var x2 -> add_generic_constraint sys (Fp.negate s2, x2) ~c:(Fp.square s1)
         | `Constant, `Constant -> assert Fp.(equal (square s1) s2)
-        | _, _ ->  ()
       )
 
     | Snarky_backendless.Constraint.R1CS (v1, v2, v3) ->
@@ -309,7 +307,6 @@ struct
         | `Constant, `Var x2, `Constant -> add_generic_constraint sys ~c:(Fp.negate s3) (Fp.(s1 * s2), x2)
         | `Constant, `Constant, `Var x3 -> add_generic_constraint sys ~c:Fp.(negate s1 * s2) (s3, x3)
         | `Constant, `Constant, `Constant -> assert Fp.(equal s3 Fp.(s1 * s2))
-        | _, _, _ ->  ()
       )
 
     | Plonk_constraint.T (Poseidon { start; state }) ->

--- a/src/lib/zexe_backend/zexe_backend_common/plonk_constraint_system.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/plonk_constraint_system.ml
@@ -282,6 +282,7 @@ struct
           else add_generic_constraint sys (Fp.negate s1, x1) ~r:(s2, x2)
         | `Var x1, `Constant -> add_generic_constraint sys (Fp.negate s1, x1) ~c:s2
         | `Constant, `Var x2 -> add_generic_constraint sys (Fp.negate s2, x2) ~c:s1
+        | `Constant, `Constant -> assert Fp.(equal s1 s2)
         | _, _ ->  ()
       )
 
@@ -292,6 +293,7 @@ struct
         | `Var x1, `Var x2 -> add_generic_constraint sys ~m:Fp.(s1 * s1) ~o:(Fp.negate s2, x2) (s1, x1) ~r:(s1, x1)
         | `Var x1, `Constant -> add_generic_constraint sys ~m:Fp.(s1 * s1) ~c:s2 (s1, x1) ~r:(s1, x1)
         | `Constant, `Var x2 -> add_generic_constraint sys (Fp.negate s2, x2) ~c:(Fp.square s1)
+        | `Constant, `Constant -> assert Fp.(equal (square s1) s2)
         | _, _ ->  ()
       )
 

--- a/src/lib/zexe_backend/zexe_backend_common/scale_round.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/scale_round.ml
@@ -1,0 +1,44 @@
+module Scale_round = struct
+  open Core_kernel
+
+  [%%versioned
+    module Stable = struct
+      module V1 = struct
+        type 'a t =
+          {
+            xt: 'a; b: 'a; yt: 'a; 
+            xp: 'a; l1: 'a; yp: 'a; 
+            xs: 'a; ys: 'a
+          } [@@deriving sexp, fields]
+      end
+    end]
+
+  type 'a t = 'a Stable.Latest.t =
+    {
+      xt: 'a; b: 'a; yt: 'a; 
+      xp: 'a; l1: 'a; yp: 'a; 
+      xs: 'a; ys: 'a
+    }
+  [@@deriving sexp, fields, hlist]
+
+  let typ g =
+    Snarky_backendless.Typ.of_hlistable [g; g; g; g; g; g; g; g] ~var_to_hlist:to_hlist
+      ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
+
+  let map {xt; b; yt; xp; l1; yp; xs; ys} ~f =
+    {
+      xt= f xt; b= f b; yt= f yt; xp= f xp; l1= f l1; yp= f yp; xs= f xs; ys= f ys; 
+    }
+
+  let map2 t1 t2 ~f =
+    {
+      xt= f t1.xt t2.xt;
+      b= f t1.b t2.b;
+      yt= f t1.yt t2.yt;
+      xp= f t1.xp t2.xp; 
+      l1= f t1.l1 t2.l1;
+      yp= f t1.yp t2.yp;
+      xs= f t1.xs t2.xs;
+      ys= f t1.ys t2.ys; 
+    }
+end

--- a/src/lib/zexe_backend/zexe_backend_common/scale_round.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/scale_round.ml
@@ -9,7 +9,7 @@ module Scale_round = struct
             xt: 'a; b: 'a; yt: 'a; 
             xp: 'a; l1: 'a; yp: 'a; 
             xs: 'a; ys: 'a
-          } [@@deriving sexp, fields]
+          } [@@deriving sexp, fields, hlist]
       end
     end]
 


### PR DESCRIPTION
This PR seeks the feedback on the initial implementation of Plonk Custom Constraints on Ocaml Snarky side. This implementation is for Generic/Poseidon and Scalar Multiplication constraints.

The following particular information is sought for in order to proceed with the implementation:

1.  ecc.ml:87
    Endoscaling function needs the value of the Group Endomorphism base field element. How to obtain it for the use in this context ?

2. poseidon.ml:7
    Permutation function needs the values of Sponge parameters for the given Field. How to obtain sponge parameters for the use in this context without direct coding like on this line ?

