### PR TITLE
new contributors are now pointed to correct issue label

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Here's the summary if you want to contribute code:
 1. Learn some OCaml. The [Real World OCaml](https://dev.realworldocaml.org/toc.html) book is good. Jane Street also has [some exercises](https://github.com/janestreet/learn-ocaml-workshop).
 2. Learn how we use OCaml. We have [a style guide](https://github.com/CodaProtocol/coda/blob/master/docs/style_guide.md) that goes over the important things.
 3. Fork and clone the repo, then set up your development environment. See the [developer README](README-dev.md) for details.
-4. Find a good first issue. The best issues to start with are those tagged [`category-mentored`](https://github.com/CodaProtocol/coda/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Acategory-mentored). These have a detailed description on how to approach the issue and someone appointed to help people solve it. Once you're famliar with the codebase, [`category-quick-fix`](https://github.com/CodaProtocol/coda/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc++label%3Acategory-quick-fix+) is a good source of reasonably well-defined tasks.
+4. Find a good first issue. The best issues to start with are those tagged [`easy`](https://github.com/CodaProtocol/coda/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Aeasy).
 5. Create a branch in your local clone and implement the solution.
 6. Push the branch to your GitHub fork and create a pull request.
 7. 🙌


### PR DESCRIPTION
I've changed the contributing.md to point new contributors to issues labeled 'easy' since the previous labels are not used anymore (and did not exist in the first place)

@bkase !ci-build-me can be run