### PR TITLE
[WIP] Central standard60 benchmark

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -111,10 +111,10 @@ let Config =
   }
 
 let targetToAgent = \(target : Size) ->
-  merge { XLarge = toMap { size = "xlarge" },
-          Large = toMap { size = "large" },
-          Medium = toMap { size = "medium" },
-          Small = toMap { size = "small" }
+  merge { XLarge = toMap { size = "central-xlarge" },
+          Large = toMap { size = "central-large" },
+          Medium = toMap { size = "central-medium" },
+          Small = toMap { size = "central-small" }
         }
         target
 

--- a/buildkite/src/Jobs/ArchiveNode.dhall
+++ b/buildkite/src/Jobs/ArchiveNode.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude = ../External/Prelude.dhall
 let Cmd = ../Lib/Cmds.dhall
 let S = ../Lib/SelectFiles.dhall

--- a/buildkite/src/Jobs/Artifact.dhall
+++ b/buildkite/src/Jobs/Artifact.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude = ../External/Prelude.dhall
 
 let Cmd = ../Lib/Cmds.dhall

--- a/buildkite/src/Jobs/CheckDhall.dhall
+++ b/buildkite/src/Jobs/CheckDhall.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let S = ../Lib/SelectFiles.dhall
 let D = S.PathPattern
 

--- a/buildkite/src/Jobs/ClientSdk.dhall
+++ b/buildkite/src/Jobs/ClientSdk.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude = ../External/Prelude.dhall
 
 let S = ../Lib/SelectFiles.dhall

--- a/buildkite/src/Jobs/CompareSignatures.dhall
+++ b/buildkite/src/Jobs/CompareSignatures.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude =  ../External/Prelude.dhall
 let S = ../Lib/SelectFiles.dhall
 let Cmd =  ../Lib/Cmds.dhall

--- a/buildkite/src/Jobs/GitTriggeredDockerRelease.dhall
+++ b/buildkite/src/Jobs/GitTriggeredDockerRelease.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let S = ../Lib/SelectFiles.dhall
 
 let Pipeline = ../Pipeline/Dsl.dhall

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude = ../../External/Prelude.dhall
 let B = ../../External/Buildkite.dhall
 

--- a/buildkite/src/Jobs/Lint/OCaml.dhall
+++ b/buildkite/src/Jobs/Lint/OCaml.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude = ../../External/Prelude.dhall
 
 let S = ../../Lib/SelectFiles.dhall

--- a/buildkite/src/Jobs/Lint/Rust.dhall
+++ b/buildkite/src/Jobs/Lint/Rust.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude = ../../External/Prelude.dhall
 
 let S = ../../Lib/SelectFiles.dhall

--- a/buildkite/src/Jobs/Lint/ValidationService.dhall
+++ b/buildkite/src/Jobs/Lint/ValidationService.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude = ../../External/Prelude.dhall
 let Text/concatSep = Prelude.Text.concatSep
 let List/map = Prelude.List.map

--- a/buildkite/src/Jobs/Test/ValidationService.dhall
+++ b/buildkite/src/Jobs/Test/ValidationService.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let S = ../../Lib/SelectFiles.dhall
 let JobSpec = ../../Pipeline/JobSpec.dhall
 let Pipeline = ../../Pipeline/Dsl.dhall

--- a/buildkite/src/Jobs/TraceTool.dhall
+++ b/buildkite/src/Jobs/TraceTool.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude = ../External/Prelude.dhall
 
 let S = ../Lib/SelectFiles.dhall

--- a/buildkite/src/Jobs/UnitTest.dhall
+++ b/buildkite/src/Jobs/UnitTest.dhall
@@ -1,3 +1,5 @@
+-- trigger
+
 let Prelude = ../External/Prelude.dhall
 
 let Cmd = ../Lib/Cmds.dhall


### PR DESCRIPTION
Various job runtime improvements have been observed during the regular hourly smoke cadence of `develop` builds while running on the *c2-standard-60* class of GCP vCPUs. This change targets ALL jobs to run on central1 size variants to help directly benchmark/measure performance.

**Testing:** Buildktie CI

**Checklist:**
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
