### PR TITLE
[Snapps] Compile snapp snark code into the transaction snark

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -339,7 +339,7 @@ module type S = sig
     -> ( Protocol_state.Value.t
          * (Transaction_snark.Statement.With_sok.t * unit)
        , N2.n * (N2.n * unit)
-       , N1.n * (N2.n * unit)
+       , N1.n * (N5.n * unit)
        , Protocol_state.Value.t
        , Proof.t )
        Pickles.Prover.t

--- a/src/lib/blockchain_snark/blockchain_snark_state.mli
+++ b/src/lib/blockchain_snark/blockchain_snark_state.mli
@@ -41,7 +41,7 @@ module type S = sig
     -> ( Protocol_state.Value.t
          * (Transaction_snark.Statement.With_sok.t * unit)
        , N2.n * (N2.n * unit)
-       , N1.n * (N2.n * unit)
+       , N1.n * (N5.n * unit)
        , Protocol_state.Value.t
        , Proof.t )
        Pickles.Prover.t

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -229,7 +229,7 @@ type tag =
   ( Statement.With_sok.Checked.t
   , Statement.With_sok.t
   , Nat.N2.n
-  , Nat.N2.n )
+  , Nat.N5.n )
   Pickles.Tag.t
 
 val verify : (t * Sok_message.t) list -> key:Pickles.Verification_key.t -> bool


### PR DESCRIPTION
This allows snapp transactions to be processed by snark workers.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: