### PR TITLE
[Snapps] Hack: Don't throw when snapps commands are passed to the auxiliary database

### DIFF
--- a/src/lib/auxiliary_database/filtered_external_transition.ml
+++ b/src/lib/auxiliary_database/filtered_external_transition.ml
@@ -117,7 +117,9 @@ let of_transition external_transition tracked_participants
           ; coinbase_receiver= None }
         , next_available_token )
       ~f:(fun (acc_transactions, next_available_token) -> function
-        | {data= Command (Snapp_command _); _} -> failwith "Not implemented"
+        | {data= Command (Snapp_command _); _} ->
+            (* TODO: Add the command to the auxiliary database. *)
+            (acc_transactions, next_available_token)
         | {data= Command command; _} -> (
             let command = (command :> User_command.t) in
             let should_include_transaction command participants =


### PR DESCRIPTION
This PR replaces an error when snapps are entered into the auxiliary database, replaces it with a TODO and a no-op.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: