### PR TITLE
Add a -stop-staking option to set-staking CLI

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1240,22 +1240,23 @@ let set_staking_graphql =
   let pk_flag =
     flag "--public-key" ~aliases:["public-key"]
       ~doc:"PUBLICKEY Public key of account with which to produce blocks"
-      (required public_key_compressed)
+      (listed public_key_compressed)
   in
   Command.async ~summary:"Start producing blocks"
     (Cli_lib.Background_daemon.graphql_init pk_flag
-       ~f:(fun graphql_endpoint public_key ->
+       ~f:(fun graphql_endpoint pks ->
          let print_message msg arr =
            if not (Array.is_empty arr) then
              printf "%s: %s\n" msg
                (String.concat_array ~sep:", "
                   (Array.map ~f:Public_key.Compressed.to_base58_check arr))
          in
+         let public_keys =
+           Array.of_list @@ List.map ~f:Encoders.public_key pks
+         in
          let%map result =
            Graphql_client.query_exn
-             (Graphql_queries.Set_staking.make
-                ~public_key:(Encoders.public_key public_key)
-                ())
+             (Graphql_queries.Set_staking.make ~public_keys ())
              graphql_endpoint
          in
          print_message "Stopped staking with" (result#setStaking)#lastStaking ;

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -119,8 +119,8 @@ query pendingSnarkWork {
 module Set_staking =
 [%graphql
 {|
-mutation ($public_key: PublicKey) {
-  setStaking(input : {publicKeys: [$public_key]}) {
+mutation ($public_keys: [PublicKey!]) {
+  setStaking(input : {publicKeys: $public_keys}) {
     lastStaking @bsDecoder(fn: "Decoders.public_key_array")
     lockedPublicKeys @bsDecoder(fn: "Decoders.public_key_array")
     currentStakingKeys @bsDecoder(fn: "Decoders.public_key_array")


### PR DESCRIPTION
This PR adds a `-stop-staking` option to the `client set-staking` command. This allows users to turn off staking from the CLI.

I have been using this to control when block production happens when testing snapp commands, so that I don't need to wait for an empty block between executing commands.

Sample output of `-help` and invalid combinations:

```
$ _build/default/src/app/cli/src/coda.exe client set-staking -help
Start producing blocks

  coda.exe client set-staking

=== flags ===

  [-public-key PUBLICKEY]            Public key of account with which to produce
                                     blocks
  [-rest-server URI/LOCALHOST-PORT]  graphql rest server for daemon interaction
                                     (examples: 3085 or
                                     http://localhost:3085/graphql,
                                     /dns4/peer1-rising-phoenix.o1test.net:3085/graphql)
                                     (default: 3085 or
                                     http://localhost:3085/graphql)
  [-stop-staking]                    Stop producing blocks
  [-help]                            print this help text and exit
                                     (alias: -?)

$ _build/default/src/app/cli/src/coda.exe client set-staking
Error parsing command line.  Run with -help for usage information.
Must pass one of these: -public-key; -stop-staking
$ _build/default/src/app/cli/src/coda.exe client set-staking -public-key B62qrPN5Y5yq8kGE3FbVKbGTdTAJNdtNtB5sNVpxyRwWGcDEhpMzc8g -stop-staking
Error parsing command line.  Run with -help for usage information.
Cannot pass both -stop-staking and -public-key
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
