### PR TITLE
enable incremental builds for buildkite's generate-diff script

### DIFF
--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -8,7 +8,6 @@ BASE=${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-origin/develop}
 COMMIT=$(diff -u <(git rev-list --first-parent HEAD) \
         <(git rev-list --first-parent $BASE) | \
         sed -ne 's/^ //p' | head -1)
-COMMIT=""
 
 if [[ $COMMIT != "" ]]; then
   # Get the files that have changed since that shared commit
@@ -18,7 +17,7 @@ else
   if [ -n "${BUILDKITE_INCREMENTAL+x}" ]; then
     # base DIFF on last successful Buildkite `develop` RUN
     ci_recent_pass_commit=$(
-      curl https://graphql.buildkite.com/v1 -H "Authorization: Bearer $TOKEN" \
+      curl https://graphql.buildkite.com/v1 -H "Authorization: Bearer ${BUILDKITE_API_TOKEN:-$TOKEN}" \
         -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' \
       | jq '.data.pipeline.builds.edges[0].node.commit' | tr -d '"'
     )

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -17,10 +17,12 @@ else
     # based DIFF on last successful `develop` RUN as anchor
     ci_recent_pass_commit=$(
       curl https://graphql.buildkite.com/v1  -H "Authorization: Bearer $TOKEN"
-        -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\") { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit'
+        -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit'
     )
     git diff HEAD $ci_recent_pass_commit
   else
+    # TODO: Dump commits as artifacts when build succeeds so we can diff against
+    # that on develop instead of always running all the tests
     git ls-files
   fi
 fi

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -11,15 +11,16 @@ COMMIT=$(diff -u <(git rev-list --first-parent HEAD) \
 
 if [[ $COMMIT != "" ]]; then
   # Get the files that have changed since that shared commit
+  echo "--- Generating diff based on shared commit: ${COMMIT}"
   git diff $COMMIT --name-only
 else
-  if [ -n "${INCREMENTAL_BUILD+x}" ]; then
+  if [ -n "${BUILDKITE_INCREMENTAL+x}" ]; then
     # base DIFF on last successful Buildkite `develop` RUN
     ci_recent_pass_commit=$(
       curl https://graphql.buildkite.com/v1 -H "Authorization: Bearer $TOKEN" -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit' | tr -d '"'
     )
 
-    #echo "--- Generating diff against: ${ci_recent_pass_commit}"
+    echo "--- Generating incremental diff against: ${ci_recent_pass_commit}"
     git diff "${ci_recent_pass_commit}" --name-only
   else
     # TODO: Dump commits as artifacts when build succeeds so we can diff against

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -13,8 +13,15 @@ if [[ $COMMIT != "" ]]; then
   # Get the files that have changed since that shared commit
   git diff $COMMIT --name-only
 else
-  # TODO: Dump commits as artifacts when build succeeds so we can diff against
-  # that on develop instead of always running all the tests
-  git ls-files
+  if [ -n "${INCREMENTAL_BUILD+x}" ]; then
+    # based DIFF on last successful `develop` RUN as anchor
+    ci_recent_pass_commit=$(
+      curl https://graphql.buildkite.com/v1  -H "Authorization: Bearer $TOKEN"
+        -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\") { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit'
+    )
+    git diff HEAD $ci_recent_pass_commit
+  else
+    git ls-files
+  fi
 fi
 

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -14,11 +14,13 @@ if [[ $COMMIT != "" ]]; then
   git diff $COMMIT --name-only
 else
   if [ -n "${INCREMENTAL_BUILD+x}" ]; then
-    # based DIFF on last successful `develop` RUN as anchor
+    # base DIFF on last successful Buildkite `develop` RUN
     ci_recent_pass_commit=$(
       curl https://graphql.buildkite.com/v1  -H "Authorization: Bearer $TOKEN"
         -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit'
     )
+
+    echo "--- Generating diff against: $ci_recent_pass_commit"
     git diff HEAD $ci_recent_pass_commit
   else
     # TODO: Dump commits as artifacts when build succeeds so we can diff against

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -8,6 +8,7 @@ BASE=${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-origin/develop}
 COMMIT=$(diff -u <(git rev-list --first-parent HEAD) \
         <(git rev-list --first-parent $BASE) | \
         sed -ne 's/^ //p' | head -1)
+COMMIT=""
 
 if [[ $COMMIT != "" ]]; then
   # Get the files that have changed since that shared commit
@@ -17,7 +18,9 @@ else
   if [ -n "${BUILDKITE_INCREMENTAL+x}" ]; then
     # base DIFF on last successful Buildkite `develop` RUN
     ci_recent_pass_commit=$(
-      curl https://graphql.buildkite.com/v1 -H "Authorization: Bearer $TOKEN" -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit' | tr -d '"'
+      curl https://graphql.buildkite.com/v1 -H "Authorization: Bearer $TOKEN" \
+        -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' \
+      | jq '.data.pipeline.builds.edges[0].node.commit' | tr -d '"'
     )
 
     echo "--- Generating incremental diff against: ${ci_recent_pass_commit}"

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -16,12 +16,11 @@ else
   if [ -n "${INCREMENTAL_BUILD+x}" ]; then
     # base DIFF on last successful Buildkite `develop` RUN
     ci_recent_pass_commit=$(
-      curl https://graphql.buildkite.com/v1  -H "Authorization: Bearer $TOKEN"
-        -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit'
+      curl https://graphql.buildkite.com/v1  -H "Authorization: Bearer $TOKEN" -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit' | tr -d '"'
     )
 
-    echo "--- Generating diff against: $ci_recent_pass_commit"
-    git diff HEAD $ci_recent_pass_commit
+    #echo "--- Generating diff against: ${ci_recent_pass_commit}"
+    git diff "${ci_recent_pass_commit}" --name-only
   else
     # TODO: Dump commits as artifacts when build succeeds so we can diff against
     # that on develop instead of always running all the tests

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -16,7 +16,7 @@ else
   if [ -n "${INCREMENTAL_BUILD+x}" ]; then
     # base DIFF on last successful Buildkite `develop` RUN
     ci_recent_pass_commit=$(
-      curl https://graphql.buildkite.com/v1  -H "Authorization: Bearer $TOKEN" -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit' | tr -d '"'
+      curl https://graphql.buildkite.com/v1 -H "Authorization: Bearer $TOKEN" -d'{"query": "query { pipeline(slug: \"o-1-labs-2/coda\") { builds(first: 1 branch: \"develop\" state: PASSED) { edges { node { commit } } } } }"}' | jq '.data.pipeline.builds.edges[0].node.commit' | tr -d '"'
     )
 
     #echo "--- Generating diff against: ${ci_recent_pass_commit}"


### PR DESCRIPTION
Rather than base Buildkite jobs executed against `develop` on `git ls-files` (all tracked files) for all jobs, this change enables basing the diff against the most recent successful Buildkite run if enabled.

_Testing:_ Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
