### PR TITLE
Add a basic fork mechanism to the blockchain snark

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.mli
+++ b/src/lib/blockchain_snark/blockchain_snark_state.mli
@@ -24,6 +24,24 @@ val check :
   -> State_hash.t
   -> unit Or_error.t
 
+module Fork : sig
+  module Witness : sig
+    type t =
+      { prev_state: Protocol_state.Value.t
+      ; new_blockchain_state: Blockchain_state.Value.t option
+      ; new_consensus_state: Consensus.Data.Consensus_state.Value.t option
+      ; new_constants: Protocol_constants_checked.Value.t option }
+  end
+
+  val check :
+       Witness.t
+    -> ?handler:(   Snarky_backendless.Request.request
+                 -> Snarky_backendless.Request.response)
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
+    -> State_hash.t
+    -> unit Or_error.t
+end
+
 module type S = sig
   module Proof :
     Pickles.Proof_intf
@@ -45,6 +63,12 @@ module type S = sig
        , Protocol_state.Value.t
        , Proof.t )
        Pickles.Prover.t
+
+  val fork :
+       Fork.Witness.t
+    -> (Protocol_state.Value.t, N2.n, N1.n) Pickles.Statement_with_proof.t
+    -> Proof.statement
+    -> Proof.t
 end
 
 module Make (T : sig

--- a/src/lib/coda_state/genesis_protocol_state.ml
+++ b/src/lib/coda_state/genesis_protocol_state.ml
@@ -28,5 +28,6 @@ let t ~genesis_ledger ~constraint_constants ~consensus_constants =
         (Blockchain_state.genesis ~constraint_constants ~genesis_ledger_hash
            ~snarked_next_available_token)
       ~consensus_state:genesis_consensus_state ~constants:protocol_constants
+      ~fork_state:(Lazy.force Protocol_state.Fork_state.genesis)
   in
   With_hash.of_data ~hash_data:Protocol_state.hash state

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2941,6 +2941,7 @@ module Hooks = struct
           ~previous_state_hash:(Protocol_state.hash previous_protocol_state)
           ~blockchain_state ~consensus_state
           ~constants:(Protocol_state.constants previous_protocol_state)
+          ~fork_state:(Protocol_state.fork_state previous_protocol_state)
       in
       (protocol_state, consensus_transition)
 

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -772,7 +772,11 @@ let make_genesis_constants ~logger ~(default : Genesis_constants.t)
             (config.genesis >>= fun cfg -> cfg.delta)
       ; genesis_state_timestamp=
           Option.value ~default:default.protocol.genesis_state_timestamp
-            genesis_state_timestamp }
+            genesis_state_timestamp
+      ; accept_arbitrary_unsafe_forks=
+          Option.value ~default:default.protocol.accept_arbitrary_unsafe_forks
+            (config.genesis >>= fun cfg -> cfg.accept_arbitrary_unsafe_forks)
+      }
   ; txpool_max_size=
       Option.value ~default:default.txpool_max_size
         (config.daemon >>= fun cfg -> cfg.txpool_max_size)
@@ -970,7 +974,9 @@ let inferred_runtime_config (precomputed_values : Precomputed_values.t) :
         ; genesis_state_timestamp=
             Some
               (Time.to_string_abs ~zone:Time.Zone.utc
-                 genesis_constants.protocol.genesis_state_timestamp) }
+                 genesis_constants.protocol.genesis_state_timestamp)
+        ; accept_arbitrary_unsafe_forks=
+            Some genesis_constants.protocol.accept_arbitrary_unsafe_forks }
   ; proof=
       Some
         { level=

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -134,10 +134,15 @@ module Json_layout = struct
     type t =
       { k: (int option[@default None])
       ; delta: (int option[@default None])
-      ; genesis_state_timestamp: (string option[@default None]) }
+      ; genesis_state_timestamp: (string option[@default None])
+      ; accept_arbitrary_unsafe_forks: (bool option[@default None]) }
     [@@deriving yojson, dhall_type]
 
-    let fields = [|"k"; "delta"; "genesis_state_timestamp"|]
+    let fields =
+      [| "k"
+       ; "delta"
+       ; "genesis_state_timestamp"
+       ; "accept_arbitrary_unsafe_forks" |]
 
     let of_yojson json =
       dump_on_error json @@ of_yojson
@@ -484,7 +489,10 @@ end
 
 module Genesis = struct
   type t = Json_layout.Genesis.t =
-    {k: int option; delta: int option; genesis_state_timestamp: string option}
+    { k: int option
+    ; delta: int option
+    ; genesis_state_timestamp: string option
+    ; accept_arbitrary_unsafe_forks: bool option }
   [@@deriving bin_io_unversioned]
 
   let to_json_layout : t -> Json_layout.Genesis.t = Fn.id
@@ -502,7 +510,10 @@ module Genesis = struct
     ; delta= opt_fallthrough ~default:t1.delta t2.delta
     ; genesis_state_timestamp=
         opt_fallthrough ~default:t1.genesis_state_timestamp
-          t2.genesis_state_timestamp }
+          t2.genesis_state_timestamp
+    ; accept_arbitrary_unsafe_forks=
+        opt_fallthrough ~default:t1.accept_arbitrary_unsafe_forks
+          t2.accept_arbitrary_unsafe_forks }
 end
 
 module Daemon = struct

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3867,7 +3867,8 @@ let%test_module "transaction_snark" =
                   ~consensus_state:consensus_state_at_slot
                   ~constants:
                     (Protocol_constants_checked.value_of_t
-                       Genesis_constants.compiled.protocol))
+                       Genesis_constants.compiled.protocol)
+                  ~fork_state:(fork_state state))
                 .body
             in
             let state_body_hash =

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -355,6 +355,7 @@ module For_tests = struct
         Protocol_state.create_value ~genesis_state_hash ~previous_state_hash
           ~blockchain_state:next_blockchain_state ~consensus_state
           ~constants:(Protocol_state.constants previous_protocol_state)
+          ~fork_state:(Lazy.force Protocol_state.Fork_state.genesis)
       in
       Protocol_version.(set_current zero) ;
       let next_external_transition =


### PR DESCRIPTION
This PR adds an extremely unsafe fork mechanism to the blockchain snark. It
* adds a new field `accept_arbitrary_unsafe_forks` to the config file
  - this is temporary, we will want to remove this as soon as we have better fork behaviour
* adds a new snark rule to the blockchain snark to allow a proof to be produced that overwrites any/all of the blockchain state, consensus state, and genesis constants
  - proving this circuit, and consuming proofs that were generated by this in the main blockchain snark, are only enabled when `accept_arbitrary_unsafe_forks` was set in the genesis constants used to build the genesis proof
* tracks the 'fork state' in a new `Protocol_state.Fork_state.Value.t` type
  - currently, this only records whether the current proof is a fork
  - the opaque interface ensures that code written now should still work with minor modifications when we track the actual state of forks in the protocol state

This was implemented to allow building proofs with large changes from genesis, in order to test catchup behaviour with a large number of changes easily.

The changes here should be safe to merge, and should have little-to-no impact on regular behaviour while `accept_arbitrary_unsafe_forks` is unset. These changes should also be easily usable as part of the fuller hard-fork plan.

**The `accept_arbitrary_unsafe_forks` flag should never be set in production deployments. Doing so will allow any user to generate a valid blockchain proof to change the ledger etc. arbitrarily.**

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: