### PR TITLE
Fix ci-build-me bot

### DIFF
--- a/frontend/ci-build-me/package.json
+++ b/frontend/ci-build-me/package.json
@@ -17,9 +17,9 @@
   "author": "O(1) Labs (forked from Edwin Shin)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/codaprotocol/coda/issues"
+    "url": "https://github.com/minaprotocol/mina/issues"
   },
-  "homepage": "https://github.com/codaprotocol/coda",
+  "homepage": "https://github.com/minaprotocol/mina",
   "dependencies": {
     "axios": "^0.19.2"
   },

--- a/frontend/ci-build-me/src/index.js
+++ b/frontend/ci-build-me/src/index.js
@@ -18,7 +18,7 @@ const runCircleBuild = async (github) => {
   const options = {
     hostname: "circleci.com",
     port: 443,
-    path: `/api/v2/project/github/CodaProtocol/coda/pipeline`,
+    path: `/api/v2/project/github/MinaProtocol/mina/pipeline`,
     method: "POST",
     headers: {
       "Circle-token": circleApiKey,
@@ -45,7 +45,7 @@ const runBuild = async (github) => {
   const options = {
     hostname: "api.buildkite.com",
     port: 443,
-    path: `/v2/organizations/o-1-labs-2/pipelines/coda/builds`,
+    path: `/v2/organizations/o-1-labs-2/pipelines/mina/builds`,
     method: "POST",
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -96,7 +96,7 @@ const handler = async (event, req) => {
       const orgData = await getRequest(req.body.sender.organizations_url);
       // and the comment author is part of the core team
       if (
-        orgData.data.filter((org) => org.login == "CodaProtocol").length > 0
+        orgData.data.filter((org) => org.login == "MinaProtocol").length > 0
       ) {
         const prData = await getRequest(req.body.issue.pull_request.url);
         const buildkite = await runBuild({


### PR DESCRIPTION
This PR updates the `ci-build-me` bot to use the new mina URLs so that it will work again.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: