### PR TITLE
add BUILDKITE_INCREMENTAL envVar to monorepo container runtime env

### DIFF
--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -3,6 +3,8 @@
 # Base against origin/develop by default, but use pull-request base otherwise
 BASE=${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-origin/develop}
 
+echo "Buildkite incremental setting: ${BUILDKITE_INCREMENTAL}"
+
 # Finds the greatest common commit that is shared between these two branches
 # Or nothing if there isn't one
 COMMIT=$(diff -u <(git rev-list --first-parent HEAD) \

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -3,8 +3,6 @@
 # Base against origin/develop by default, but use pull-request base otherwise
 BASE=${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-origin/develop}
 
-echo "Buildkite incremental setting: ${BUILDKITE_INCREMENTAL}"
-
 # Finds the greatest common commit that is shared between these two branches
 # Or nothing if there isn't one
 COMMIT=$(diff -u <(git rev-list --first-parent HEAD) \

--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -14,6 +14,9 @@ if [[ $COMMIT != "" ]]; then
   git diff $COMMIT --name-only
 else
   if [ -n "${BUILDKITE_INCREMENTAL+x}" ]; then
+    # TODO: remove (temporarily install network tooling)
+    sudo apt-get install --yes curl jq
+
     # base DIFF on last successful Buildkite `develop` RUN
     ci_recent_pass_commit=$(
       curl https://graphql.buildkite.com/v1 -H "Authorization: Bearer ${BUILDKITE_API_TOKEN:-$TOKEN}" \

--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -53,7 +53,7 @@ in Pipeline.build Pipeline.Config::{
       target = Size.Small,
       docker = Some Docker::{
         image = (./Constants/ContainerImages.dhall).toolchainBase,
-        environment = ["BUILDKITE_INCREMENTAL"]
+        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_INCREMENTAL"]
       }
     }
   ]

--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -51,7 +51,10 @@ in Pipeline.build Pipeline.Config::{
       label = "Monorepo triage",
       key = "cmds",
       target = Size.Small,
-      docker = Some Docker::{ image = (./Constants/ContainerImages.dhall).toolchainBase }
+      docker = Some Docker::{
+        image = (./Constants/ContainerImages.dhall).toolchainBase,
+        environment = ["BUILDKITE_INCREMENTAL"]
+      }
     }
   ]
 }


### PR DESCRIPTION
Transfer Buildkite's BUILDKITE_INCREMENTAL environment variable trigger for incremental Buildkite `develop` builds into the Monorepo triage job container execution environment. Also, temporarily install necessary tooling `curl` and `jq` while a more suitable option w/r/t to the container env is investigated.

**Testing:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: