### PR TITLE
Use special Boolean binops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ benchmarks:
 # Coverage testing and output
 
 test-coverage: SHELL := /bin/bash
-test-coverage:
+test-coverage: libp2p_helper
 	scripts/create_coverage_profiles.sh
 
 # we don't depend on test-coverage, which forces a run of all unit tests

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -1,3 +1,6 @@
+(* exclude from bisect_ppx to avoid type error on GraphQL modules *)
+[@@@coverage exclude_file]
+
 module Decoders = Graphql_lib.Decoders
 
 module Get_tracked_accounts =

--- a/src/lib/coda_base/fee_excess.ml
+++ b/src/lib/coda_base/fee_excess.ml
@@ -234,7 +234,7 @@ let%snarkydef eliminate_fee_excess_checked (fee_token_l, fee_excess_l)
     let%bind fee_excess_zero =
       Field.(Checked.equal (Var.constant zero)) fee_excess
     in
-    let%bind may_move = Boolean.(fee_token_equal || fee_excess_zero) in
+    let%bind may_move = Boolean.(fee_token_equal ||| fee_excess_zero) in
     let%bind fee_token =
       Token_id.Checked.if_ fee_excess_zero ~then_:fee_token_m ~else_:fee_token
     in

--- a/src/lib/coda_base/pending_coinbase.ml
+++ b/src/lib/coda_base/pending_coinbase.ml
@@ -332,7 +332,7 @@ module State_stack = struct
       let%bind eq_src = equal_var s1 s2
       and eq_target = equal_var t1 t2
       and correct_transition = equal_var t1 s2 in
-      let%bind same_update = Boolean.(eq_src && eq_target) in
+      let%bind same_update = Boolean.(eq_src &&& eq_target) in
       Boolean.any [same_update; correct_transition]
   end
 end
@@ -430,12 +430,12 @@ module Update = struct
         ~there:to_bits ~back:of_bits
 
     module Checked = struct
-      let no_update (b0, b1) = Boolean.((not b0) && not b1)
+      let no_update (b0, b1) = Boolean.((not b0) &&& not b1)
 
       let update_two_stacks_coinbase_in_first (b0, b1) =
-        Boolean.((not b0) && b1)
+        Boolean.((not b0) &&& b1)
 
-      let update_two_stacks_coinbase_in_second (b0, b1) = Boolean.(b0 && b1)
+      let update_two_stacks_coinbase_in_second (b0, b1) = Boolean.(b0 &&& b1)
     end
   end
 
@@ -632,7 +632,7 @@ module T = struct
       let%bind b1 = Coinbase_stack.equal_var var1.Poly.data var2.Poly.data in
       let%bind b2 = State_stack.equal_var var1.Poly.state var2.Poly.state in
       let open Tick0.Boolean in
-      b1 && b2
+      b1 &&& b2
 
     let empty = {Poly.data= Coinbase_stack.empty; state= State_stack.empty}
 
@@ -873,7 +873,7 @@ module T = struct
              Boolean.Assert.is_true check)
         in
         let%bind no_coinbase =
-          Boolean.(no_update || no_coinbase_in_this_stack)
+          Boolean.(no_update ||| no_coinbase_in_this_stack)
         in
         (* TODO: Optimize here since we are pushing twice to the same stack *)
         let%bind stack_with_amount1 =
@@ -898,7 +898,7 @@ module T = struct
           let%bind update_second_stack =
             Update.Action.Checked.update_two_stacks_coinbase_in_first action
           in
-          Boolean.(update_second_stack || add_coinbase)
+          Boolean.(update_second_stack ||| add_coinbase)
         in
         let%bind stack =
           let%bind stack_with_state =

--- a/src/lib/coda_base/permissions.ml
+++ b/src/lib/coda_base/permissions.ml
@@ -208,7 +208,7 @@ module Auth_required = struct
       *)
       let open Pickles.Impls.Step.Boolean in
       signature_sufficient
-      &&& (constant ||| ((not constant) && signature_verifies))
+      &&& (constant ||| ((not constant) &&& signature_verifies))
 
     let spec_eval ({constant; signature_necessary; signature_sufficient} : t)
         ~signature_verifies =

--- a/src/lib/coda_base/permissions.ml
+++ b/src/lib/coda_base/permissions.ml
@@ -21,7 +21,7 @@ module Frozen_ledger_hash = Frozen_ledger_hash0
 module Ledger_hash = Ledger_hash0
 
 (* Semantically this type represents a function
-     { has_valid_signature: bool; has_valid_proof: bool } -> bool 
+     { has_valid_signature: bool; has_valid_proof: bool } -> bool
 
      These are all of them:
      00 01 10 11 | intuitive definition       | Make sense
@@ -79,7 +79,7 @@ module Auth_required = struct
       let spec_eval t ~signature_verifies =
         let impossible = (constant t && not (signature_sufficient t)) in
         let result =
-          not impossible && 
+          not impossible &&
           ( (signature_verifies && signature_sufficient t)
             || not (signature_necessary t) )
         in
@@ -208,21 +208,22 @@ module Auth_required = struct
       *)
       let open Pickles.Impls.Step.Boolean in
       signature_sufficient
-      && (constant || ((not constant) && signature_verifies))
+      &&& (constant ||| ((not constant) && signature_verifies))
 
     let spec_eval ({constant; signature_necessary; signature_sufficient} : t)
         ~signature_verifies =
       let open Pickles.Impls.Step.Boolean in
-      let impossible = constant && not signature_sufficient in
+      let impossible = constant &&& not signature_sufficient in
       let result =
         (not impossible)
-        && ( (signature_verifies && signature_sufficient)
-           || not signature_necessary )
+        &&& ( signature_verifies &&& signature_sufficient
+            ||| not signature_necessary )
       in
       let didn't_fail_yet = result in
       (* If the transaction already failed to verify, we don't need to assert
          that the proof should verify. *)
-      (result, `proof_must_verify (didn't_fail_yet && not signature_sufficient))
+      ( result
+      , `proof_must_verify (didn't_fail_yet &&& not signature_sufficient) )
   end
 
   let typ =

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -2,6 +2,9 @@ open Core
 open Async
 open Integration_test_lib
 
+(* exclude from bisect_ppx to avoid type error on GraphQL modules *)
+[@@@coverage exclude_file]
+
 module Node = struct
   type t = {namespace: string; pod_id: string}
 

--- a/src/lib/pickles/dlog_main.ml
+++ b/src/lib/pickles/dlog_main.ml
@@ -246,7 +246,7 @@ struct
             ~f:
               (Array.map ~f:(fun (keep, g) ->
                    let open Field in
-                   ( (Boolean.(keep && b) :> t)
+                   ( (Boolean.(keep &&& b) :> t)
                    , Double.map g ~f:(( * ) (b :> t)) ) )) )
       |> Vector.reduce_exn ~f:(map2 ~f:Field.( + ))
       |> map'
@@ -324,7 +324,7 @@ struct
                        ~else_:p)
                   ~else_:acc.point)
             in
-            let non_zero = Boolean.(keep || acc.non_zero) in
+            let non_zero = Boolean.(keep ||| acc.non_zero) in
             {Curve_with_zero.non_zero; point} )
           ~xi
           ~init:(fun (keep, p) -> {non_zero= keep; point= p})
@@ -525,7 +525,7 @@ struct
          3. The challenge points.
 
          It should be sufficient to fork the sponge after squeezing beta_3 and then to absorb
-         the combined inner product. 
+         the combined inner product.
       *)
           let without_degree_bound =
             Vector.append sg_old
@@ -638,7 +638,7 @@ struct
         failwith "empty list"
 
   (* This finalizes the "deferred values" coming from a previous proof over the same field.
-   It 
+   It
    1. Checks that [xi] and [r] where sampled correctly. I.e., by absorbing all the
    evaluation openings and then squeezing.
    2. Checks that the "combined inner product" value used in the elliptic curve part of

--- a/src/lib/pickles/opt_sponge.ml
+++ b/src/lib/pickles/opt_sponge.ml
@@ -2,7 +2,7 @@ open Core_kernel
 
 (* This module implements snarky functions for a sponge that can *conditionally* absorb input,
    while branching minimally. Specifically, if absorbing N field elements, this sponge can absorb
-   a variable subset of N field elements, while performing N + 1 invocations of the sponge's 
+   a variable subset of N field elements, while performing N + 1 invocations of the sponge's
    underlying permutation. *)
 
 let m = 3
@@ -68,7 +68,7 @@ struct
   let add_in a i x =
     let i_equals_0 = Boolean.not i in
     let i_equals_1 = i in
-    (* 
+    (*
       a.(0) <- a.(0) + i_equals_0 * x
       a.(1) <- a.(1) + i_equals_1 * x *)
     List.iteri [i_equals_0; i_equals_1] ~f:(fun j i_equals_j ->
@@ -123,7 +123,7 @@ struct
       let y = Field.(y * (b' :> t)) in
       let add_in_y_after_perm =
         (* post
-          add in 
+          add in
           (1, 1, 1)
 
           do not add in
@@ -157,7 +157,7 @@ struct
            (1, 0, 0)
         *)
         (* (b && b') || (p && (b || b')) *)
-        Boolean.(any [all [b; b']; all [p; b || b']])
+        Boolean.(any [all [b; b']; all [p; b ||| b']])
       in
       cond_permute permute ;
       add_in state p' Field.(y * (add_in_y_after_perm :> t))
@@ -168,7 +168,7 @@ struct
     let should_permute =
       match remaining with
       | 0 ->
-          Boolean.(empty_imput || !pos)
+          Boolean.(empty_imput ||| !pos)
       | 1 ->
           let b, x = input.(n - 1) in
           let p = !pos in

--- a/src/lib/pickles/pairing_main.ml
+++ b/src/lib/pickles/pairing_main.ml
@@ -284,7 +284,7 @@ struct
          3. The challenge points.
 
          It should be sufficient to fork the sponge after squeezing beta_3 and then to absorb
-         the combined inner product. 
+         the combined inner product.
       *)
           let without_degree_bound =
             let T = Branching.eq in
@@ -523,7 +523,7 @@ struct
 
     let last =
       Array.reduce_exn ~f:(fun (b_acc, x_acc) (b, x) ->
-          (Boolean.(b_acc || b), Field.if_ b ~then_:x ~else_:x_acc) )
+          (Boolean.(b_acc ||| b), Field.if_ b ~then_:x ~else_:x_acc) )
 
     let rec pow x bits_lsb =
       let rec go acc bs =
@@ -655,7 +655,7 @@ struct
            Split_evaluations.mask' {actual; max} )
 
   (* This finalizes the "deferred values" coming from a previous proof over the same field.
-   It 
+   It
    1. Checks that [xi] and [r] where sampled correctly. I.e., by absorbing all the
    evaluation openings and then squeezing.
    2. Checks that the "combined inner product" value used in the elliptic curve part of

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -324,7 +324,7 @@ let step_main
                         pi
                     in
                     ( chals :: chalss
-                    , Boolean.((verified && finalized) || not should_verify)
+                    , Boolean.(verified &&& finalized ||| not should_verify)
                       :: vs )
               in
               let chalss, vs =


### PR DESCRIPTION
Use the special `Boolean` binops from snarky, namely `&&&` and `|||`, so files can be processed by `bisect_ppx`.

Tested by running `make test-coverage`, and also `BISECT_ENABLE=YES DUNE_PROFILE=testnet_postake_medium_curves make build`.

The `graphql` ppx and `bisect_ppx` interact badly, generating code with type errors. Fortunately, there's a directive `@@@coverage exclude_file` that tells `bisect_ppx` not to instrument a file.
There are a couple of those added in the PR, marked with an explanatory comment.

This is the last bit of #6090, except for adding coverage results to CI.


