### PR TITLE
add base toolchain dockerfile for buildkite/dhall ops

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -1,7 +1,7 @@
 -- TODO: Automatically push, tag, and update images #4862
 
 {
-  toolchainBase = "codaprotocol/ci-toolchain-base:v3",
+  toolchainBase = "codaprotocol/ci-toolchain-base:v5",
   codaToolchain = "codaprotocol/coda:toolchain-9924f4c56a40d65d36440e8f70b93720f29ba171",
   elixirToolchain = "elixir:1.10-alpine",
   rustToolchain = "codaprotocol/coda:toolchain-rust-e855336d087a679f76f2dd2bbdc3fdfea9303be3"

--- a/dockerfiles/Dockerfile-toolchain-base
+++ b/dockerfiles/Dockerfile-toolchain-base
@@ -1,0 +1,15 @@
+FROM debian:9-slim
+
+# Networking and package management tools
+RUN apt-get update && apt-get install --yes \
+    bzip2 \
+    curl \
+    jq \
+    wget \
+    apt-transport-https \
+    ca-certificates
+
+# Install dhall tools to local bin PATH
+RUN wget https://github.com/dhall-lang/dhall-haskell/releases/download/1.35.0/dhall-json-1.7.2-x86_64-linux.tar.bz2 \
+        && tar --extract --bzip2 --file dhall-json-1.7.2-x86_64-linux.tar.bz2
+RUN cp ./bin/dhall-to-* /usr/local/bin


### PR DESCRIPTION
Adds a dockerfile to encapsulate a base set of tooling installed within a slimmed Debian environment for Buildkite related operations.

**(Example) Base Tools:**
- *dhall-to-{json,yaml}*
- curl, wget
- ca-certificates, apt-transport-https

**Testing:** Buildkite-CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
