### PR TITLE
Specify that libp2p should listen on the libp2p_port

### DIFF
--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -135,7 +135,13 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
           let initializing_libp2p_result : _ Deferred.Or_error.t =
             let open Deferred.Or_error.Let_syntax in
             let%bind () =
-              configure net2 ~me ~maddrs:[] ~gossip_type:config.gossip_type
+              configure net2 ~me
+                ~maddrs:
+                  [ Multiaddr.of_string
+                      (sprintf "/ip4/0.0.0.0/tcp/%d"
+                         (Option.value_exn config.addrs_and_ports.peer)
+                           .libp2p_port) ]
+                ~gossip_type:config.gossip_type
                 ~external_maddr:
                   (Multiaddr.of_string
                      (sprintf "/ip4/%s/tcp/%d"


### PR DESCRIPTION
This PR explicitly passes the libp2p port as the address to listen on when configuring libp2p in the helper. When we don't do this, it seems to chose its own port arbitrarily.

Testing locally indicates that this fixes the transitive peers test.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: