### PR TITLE
Log buildkite errors properly

### DIFF
--- a/frontend/ci-build-me/src/index.js
+++ b/frontend/ci-build-me/src/index.js
@@ -178,7 +178,7 @@ exports.githubWebhookHandler = async (req, res) => {
       console.info(`Triggered buildkite build at ${buildkite.web_url}`);
     } else {
       console.error(`Failed to trigger buildkite build for some reason:`);
-      console.error(data);
+      console.error(buildkite);
     }
 
     if (circle && circle.number) {


### PR DESCRIPTION
Currently the `console.error` call fails, leading to

```
16:57:38.722  Failed to trigger buildkite build for some reason:
16:57:38.723  HTTP 500: data is not defined
```

This was triggered by [this comment](https://github.com/MinaProtocol/mina/pull/6188#issuecomment-703759177), which failed to start CI for that PR.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: