### PR TITLE
Log the size of messages sent to libp2p

### DIFF
--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -427,7 +427,8 @@ module Helper = struct
         ~metadata:
           [ ( "line"
             , `String (String.slice rpc 0 (Int.min (String.length rpc) 2048))
-            ) ] ;
+            )
+          ; ("size_in_bytes", `Int (String.length rpc)) ] ;
       Writer.write_line (Child_processes.stdin t.subprocess) rpc ;
       let%map res_json = Ivar.read res in
       Or_error.bind res_json


### PR DESCRIPTION
This logs the size of the messages sent to libp2p when we log the messages themselves.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: