### PR TITLE
Allow updating time offset in block time

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -255,6 +255,8 @@ let daemon logger =
          ~doc:"full|check|none"
      and plugins = plugin_flag in
      fun () ->
+       (* Immediately disable updating the time offset. *)
+       Block_time.Controller.disable_setting_offset () ;
        let open Deferred.Let_syntax in
        let compute_conf_dir home =
          Option.value ~default:(home ^/ Cli_lib.Default.conf_dir_name) conf_dir

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -71,6 +71,8 @@ module Time = struct
 
     let basic ~logger:_ = ()
 
+    let set_time_offset _ = failwith "Cannot mutate the time offset"
+
     [%%endif]
   end
 

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -38,13 +38,27 @@ module Time = struct
 
     let time_offset = ref None
 
-    let setting_enabled = ref true
+    let setting_enabled = ref None
 
-    let disable_setting_offset () = setting_enabled := false
+    let disable_setting_offset () = setting_enabled := Some false
+
+    let enable_setting_offset () =
+      match !setting_enabled with
+      | None ->
+          setting_enabled := Some true
+      | Some true ->
+          ()
+      | Some false ->
+          failwith
+            "Cannot enable time offset mutations; it has been explicitly \
+             disabled"
 
     let set_time_offset offset =
-      if !setting_enabled then time_offset := Some offset
-      else failwith "Cannot mutate the time offset"
+      match !setting_enabled with
+      | Some true ->
+          time_offset := Some offset
+      | None | Some false ->
+          failwith "Cannot mutate the time offset"
 
     let create offset = offset
 
@@ -78,6 +92,8 @@ module Time = struct
     let basic ~logger:_ = ()
 
     let disable_setting_offset () = ()
+
+    let enable_setting_offset () = ()
 
     let set_time_offset _ = failwith "Cannot mutate the time offset"
 

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -34,23 +34,34 @@ module Time = struct
     [%%if
     time_offsets]
 
-    type t = Time.Span.t Lazy.t [@@deriving sexp]
+    type t = unit -> Time.Span.t [@@deriving sexp]
+
+    let time_offset = ref None
+
+    let set_time_offset offset = time_offset := Some offset
 
     let create offset = offset
 
-    let basic ~logger =
-      lazy
-        (let offset =
-           match Core.Sys.getenv "CODA_TIME_OFFSET" with
-           | Some tm ->
-               Int.of_string tm
-           | None ->
-               [%log debug]
-                 "Environment variable CODA_TIME_OFFSET not found, using \
-                  default of 0" ;
-               0
-         in
-         Core_kernel.Time.Span.of_int_sec offset)
+    let basic ~logger () =
+      match !time_offset with
+      | Some offset ->
+          offset
+      | None ->
+          let offset =
+            let env_offset =
+              match Core.Sys.getenv "CODA_TIME_OFFSET" with
+              | Some tm ->
+                  Int.of_string tm
+              | None ->
+                  [%log debug]
+                    "Environment variable CODA_TIME_OFFSET not found, using \
+                     default of 0" ;
+                  0
+            in
+            Core_kernel.Time.Span.of_int_sec env_offset
+          in
+          time_offset := Some offset ;
+          offset
 
     [%%else]
 
@@ -149,7 +160,7 @@ module Time = struct
   [%%if
   time_offsets]
 
-  let now offset = of_time (Time.sub (Time.now ()) (Lazy.force offset))
+  let now offset = of_time (Time.sub (Time.now ()) (offset ()))
 
   [%%else]
 
@@ -194,7 +205,7 @@ module Time = struct
   let to_string_system_time (offset : Controller.t) (t : t) : string =
     let t2 : t =
       of_span_since_epoch
-        Span.(to_span_since_epoch t + of_time_span (Lazy.force offset))
+        Span.(to_span_since_epoch t + of_time_span (offset ()))
     in
     Int64.to_string (to_int64 t2)
 

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -38,7 +38,13 @@ module Time = struct
 
     let time_offset = ref None
 
-    let set_time_offset offset = time_offset := Some offset
+    let setting_enabled = ref true
+
+    let disable_setting_offset () = setting_enabled := false
+
+    let set_time_offset offset =
+      if !setting_enabled then time_offset := Some offset
+      else failwith "Cannot mutate the time offset"
 
     let create offset = offset
 
@@ -70,6 +76,8 @@ module Time = struct
     let create () = ()
 
     let basic ~logger:_ = ()
+
+    let disable_setting_offset () = ()
 
     let set_time_offset _ = failwith "Cannot mutate the time offset"
 

--- a/src/lib/block_time/block_time.mli
+++ b/src/lib/block_time/block_time.mli
@@ -25,6 +25,11 @@ module Time : sig
         variable for all block time controllers.
     *)
     val set_time_offset : Time.Span.t -> unit
+
+    (** Disallow setting the time offset. This should be run at every
+        entrypoint which does not explicitly need to update the time offset.
+    *)
+    val disable_setting_offset : unit -> unit
   end
 
   [%%versioned:

--- a/src/lib/block_time/block_time.mli
+++ b/src/lib/block_time/block_time.mli
@@ -20,6 +20,11 @@ module Time : sig
     val create : t -> t
 
     val basic : logger:Logger.t -> t
+
+    (** Override the time offset set by the [CODA_TIME_OFFSET] environment
+        variable for all block time controllers.
+    *)
+    val set_time_offset : Time.Span.t -> unit
   end
 
   [%%versioned:

--- a/src/lib/block_time/block_time.mli
+++ b/src/lib/block_time/block_time.mli
@@ -23,6 +23,9 @@ module Time : sig
 
     (** Override the time offset set by the [CODA_TIME_OFFSET] environment
         variable for all block time controllers.
+        [enable_setting_offset] must have been called first, and
+        [disable_setting_offset] must not have been called, otherwise this
+        raises a [Failure].
     *)
     val set_time_offset : Time.Span.t -> unit
 
@@ -30,6 +33,12 @@ module Time : sig
         entrypoint which does not explicitly need to update the time offset.
     *)
     val disable_setting_offset : unit -> unit
+
+    (** Allow setting the time offset. This may only be run if
+        [disable_setting_offset] has not already been called, otherwise it will
+        raise a [Failure].
+    *)
+    val enable_setting_offset : unit -> unit
   end
 
   [%%versioned:


### PR DESCRIPTION
This PR enables mutating the block time so that we can replay blocks through the block producer from a file and step the time accordingly.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: