### PR TITLE
Add GraphQL, CLI endpoints for dumping the CODA_TIME_OFFSET

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -8305,6 +8305,22 @@
               "deprecationReason": null
             },
             {
+              "name": "timeOffset",
+              "description": "The time offset used to convert real times into blockchain times",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "nextAvailableToken",
               "description": "The next token ID that has not been allocated. Token IDs are allocated sequentially, so all lower token IDs have been allocated",
               "args": [],

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -103,6 +103,28 @@ let get_tokens_graphql =
          Array.iter response#accounts ~f:(fun account ->
              printf "%s " (Token_id.to_string account#token) ) ))
 
+let get_time_offset_graphql =
+  Command.async
+    ~summary:
+      "Get the time offset used by the daemon to convert real time into \
+       blockchain time"
+    (Cli_lib.Background_daemon.graphql_init (Command.Param.return ())
+       ~f:(fun graphql_endpoint () ->
+         let%map response =
+           Graphql_client.query_exn
+             (Graphql_queries.Time_offset.make ())
+             graphql_endpoint
+         in
+         let time_offset = response#timeOffset in
+         printf
+           "Current time offset:\n\
+            %i\n\n\
+            Start other daemons with this offset by setting the \
+            CODA_TIME_OFFSET environment variable in the shell before \
+            executing them:\n\
+            export CODA_TIME_OFFSET=%i\n"
+           time_offset time_offset ))
+
 let print_trust_statuses statuses json =
   if json then
     printf "%s\n"
@@ -1674,4 +1696,5 @@ let advanced =
     ; ("generate-receipt", generate_receipt)
     ; ("verify-receipt", verify_receipt)
     ; ("generate-keypair", Cli_lib.Commands.generate_keypair)
-    ; ("next-available-token", next_available_token_cmd) ]
+    ; ("next-available-token", next_available_token_cmd)
+    ; ("time-offset", get_time_offset_graphql) ]

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -106,8 +106,8 @@ let get_tokens_graphql =
 let get_time_offset_graphql =
   Command.async
     ~summary:
-      "Get the time offset used by the daemon to convert real time into \
-       blockchain time"
+      "Get the time offset in seconds used by the daemon to convert real time \
+       into blockchain time"
     (Cli_lib.Background_daemon.graphql_init (Command.Param.return ())
        ~f:(fun graphql_endpoint () ->
          let%map response =

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -280,3 +280,9 @@ query next_available_token {
   nextAvailableToken @bsDecoder(fn: "Decoders.token")
 }
 |}]
+
+module Time_offset = [%graphql {|
+query time_offset {
+  timeOffset
+}
+|}]

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -63,6 +63,8 @@ module Time = struct
           time_offset := Some offset ;
           offset
 
+    let get_time_offset ~logger = basic ~logger ()
+
     [%%else]
 
     type t = unit [@@deriving sexp]
@@ -72,6 +74,8 @@ module Time = struct
     let basic ~logger:_ = ()
 
     let set_time_offset _ = failwith "Cannot mutate the time offset"
+
+    let get_time_offset _ = Core_kernel.Time.Span.of_int_sec 0
 
     [%%endif]
   end

--- a/src/lib/block_time/block_time.mli
+++ b/src/lib/block_time/block_time.mli
@@ -25,6 +25,11 @@ module Time : sig
         variable for all block time controllers.
     *)
     val set_time_offset : Time.Span.t -> unit
+
+    (** Get the current time offset, either from the [CODA_TIME_OFFSET]
+        environment variable, or as last set by [set_time_offset].
+    *)
+    val get_time_offset : logger:Logger.t -> Time.Span.t
   end
 
   [%%versioned:

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -2773,6 +2773,16 @@ module Queries = struct
       ~typ:(non_null Types.genesis_constants)
       ~resolve:(fun _ () -> ())
 
+  let time_offset =
+    field "timeOffset"
+      ~doc:"The time offset used to convert real times into blockchain times"
+      ~args:Arg.[]
+      ~typ:(non_null int)
+      ~resolve:(fun {ctx= coda; _} () ->
+        Block_time.Controller.get_time_offset
+          ~logger:(Coda_lib.config coda).logger
+        |> Time.Span.to_sec |> Float.to_int )
+
   let next_available_token =
     field "nextAvailableToken"
       ~doc:
@@ -2823,6 +2833,7 @@ module Queries = struct
     ; snark_pool
     ; pending_snark_work
     ; genesis_constants
+    ; time_offset
     ; next_available_token ]
 end
 

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -2775,7 +2775,9 @@ module Queries = struct
 
   let time_offset =
     field "timeOffset"
-      ~doc:"The time offset used to convert real times into blockchain times"
+      ~doc:
+        "The time offset in seconds used to convert real times into \
+         blockchain times"
       ~args:Arg.[]
       ~typ:(non_null int)
       ~resolve:(fun {ctx= coda; _} () ->


### PR DESCRIPTION
This PR adds a mechanism for dumping the current time offset and exposes it from GraphQL and CLI. This will be necessary for syncing to a peer that has replayed a chain as if it were producing blocks, since its time offset will be determined by the time it interpreted the last block in the chain.

Sample output:
```
$ _build/default/src/app/cli/src/coda.exe advanced time-offset -help
Get the time offset used by the daemon to convert real time into blockchain time

  coda.exe advanced time-offset

=== flags ===

  [-rest-server URI/LOCALHOST-PORT]  graphql rest server for daemon interaction
                                     (examples: 3085 or
                                     http://localhost:3085/graphql,
                                     /dns4/peer1-rising-phoenix.o1test.net:3085/graphql)
                                     (default: 3085 or
                                     http://localhost:3085/graphql)
  [-help]                            print this help text and exit
                                     (alias: -?)

$ _build/default/src/app/cli/src/coda.exe advanced time-offset
Current time offset:
1766472

Start other daemons with this offset by setting the CODA_TIME_OFFSET environment variable in the shell before executing them:
export CODA_TIME_OFFSET=1766472
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: