### PR TITLE
Separate error handling from main logic in the block producer

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -571,7 +571,7 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                             , Staged_ledger_diff.to_yojson staged_ledger_diff
                             ) ]
                         !"Unable to build breadcrumb from produced transition \
-                          due to invlaid staged ledger diff: $error" ;
+                          due to invalid staged ledger diff: $error" ;
                       return ()) )
       in
       let production_supervisor = Singleton_supervisor.create ~task:produce in

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -348,15 +348,157 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                          over the tf root" ) ;
                 Interruptible.uninterruptible
                   (let open Deferred.Let_syntax in
-                  let t0 = Time.now time_controller in
-                  match%bind
-                    measure "proving state transition valid" (fun () ->
-                        Prover.prove prover ~prev_state:previous_protocol_state
-                          ~prev_state_proof:previous_protocol_state_proof
-                          ~next_state:protocol_state internal_transition
-                          pending_coinbase_witness )
-                  with
-                  | Error err ->
+                  let emit_breadcrumb () =
+                    let open Deferred.Result.Let_syntax in
+                    let t0 = Time.now time_controller in
+                    let%bind protocol_state_proof =
+                      measure "proving state transition valid" (fun () ->
+                          Prover.prove prover
+                            ~prev_state:previous_protocol_state
+                            ~prev_state_proof:previous_protocol_state_proof
+                            ~next_state:protocol_state internal_transition
+                            pending_coinbase_witness )
+                      |> Deferred.Result.map_error ~f:(fun err ->
+                             `Prover_error err )
+                    in
+                    let span = Time.diff (Time.now time_controller) t0 in
+                    [%log info]
+                      ~metadata:
+                        [ ( "proving_time"
+                          , `Int (Time.Span.to_ms span |> Int64.to_int_exn) )
+                        ]
+                      !"Protocol_state_proof proving time(ms): $proving_time%!" ;
+                    let staged_ledger_diff =
+                      Internal_transition.staged_ledger_diff
+                        internal_transition
+                    in
+                    let transition_hash = Protocol_state.hash protocol_state in
+                    let previous_state_hash =
+                      Protocol_state.hash previous_protocol_state
+                    in
+                    let delta_transition_chain_proof =
+                      Transition_chain_prover.prove
+                        ~length:
+                          ( Coda_numbers.Length.to_int consensus_constants.delta
+                          - 1 )
+                        ~frontier previous_state_hash
+                      |> Option.value_exn
+                    in
+                    let%bind transition =
+                      let open Result.Let_syntax in
+                      External_transition.Validation.wrap
+                        { With_hash.hash= transition_hash
+                        ; data=
+                            External_transition.create ~protocol_state
+                              ~protocol_state_proof ~staged_ledger_diff
+                              ~validation_callback:Fn.ignore
+                              ~delta_transition_chain_proof () }
+                      |> External_transition.skip_time_received_validation
+                           `This_transition_was_not_received_via_gossip
+                      |> External_transition.skip_protocol_versions_validation
+                           `This_transition_has_valid_protocol_versions
+                      |> External_transition.validate_genesis_protocol_state
+                           ~genesis_state_hash:
+                             (Protocol_state.genesis_state_hash
+                                ~state_hash:(Some previous_state_hash)
+                                previous_protocol_state)
+                      >>| External_transition.skip_proof_validation
+                            `This_transition_was_generated_internally
+                      >>| External_transition
+                          .skip_delta_transition_chain_validation
+                            `This_transition_was_not_received_via_gossip
+                      >>= Transition_frontier_validation
+                          .validate_frontier_dependencies ~logger ~frontier
+                            ~consensus_constants
+                      |> Deferred.return
+                    in
+                    let%bind breadcrumb =
+                      Breadcrumb.build ~logger ~precomputed_values ~verifier
+                        ~trust_system ~parent:crumb ~transition ~sender:None
+                      |> Deferred.Result.map_error ~f:(function
+                           | `Invalid_staged_ledger_diff e ->
+                               `Invalid_staged_ledger_diff
+                                 (e, staged_ledger_diff)
+                           | ( `Fatal_error _
+                             | `Invalid_genesis_protocol_state
+                             | `Invalid_staged_ledger_hash _
+                             | `Not_selected_over_frontier_root
+                             | `Parent_missing_from_frontier
+                             | `Prover_error _ ) as err ->
+                               err )
+                    in
+                    [%str_log trace]
+                      ~metadata:
+                        [("breadcrumb", Breadcrumb.to_yojson breadcrumb)]
+                      Block_produced ;
+                    let metadata =
+                      [("state_hash", State_hash.to_yojson transition_hash)]
+                    in
+                    Coda_metrics.(
+                      Counter.inc_one Block_producer.blocks_produced) ;
+                    let%bind.Async () =
+                      Strict_pipe.Writer.write transition_writer breadcrumb
+                    in
+                    [%log debug] ~metadata
+                      "Waiting for block $state_hash to be inserted into \
+                       frontier" ;
+                    Deferred.choose
+                      [ Deferred.choice
+                          (Transition_registry.register transition_registry
+                             transition_hash)
+                          (Fn.const (Ok `Transition_accepted))
+                      ; Deferred.choice
+                          ( Time.Timeout.create time_controller
+                              (* We allow up to 20 seconds for the transition
+                                 to make its way from the transition_writer to
+                                 the frontier.
+                                 This value is chosen to be reasonably
+                                 generous. In theory, this should not take
+                                 terribly long. But long cycles do happen in
+                                 our system, and with medium curves those long
+                                 cycles can be substantial.
+                              *)
+                              (Time.Span.of_ms 20000L)
+                              ~f:(Fn.const ())
+                          |> Time.Timeout.to_deferred )
+                          (Fn.const (Ok `Timed_out)) ]
+                    >>= function
+                    | `Transition_accepted ->
+                        [%log info] ~metadata
+                          "Generated transition $state_hash was accepted into \
+                           transition frontier" ;
+                        return ()
+                    | `Timed_out ->
+                        (* FIXME #3167: this should be fatal, and more
+                           importantly, shouldn't happen.
+                        *)
+                        [%log fatal] ~metadata
+                          "Timed out waiting for generated transition \
+                           $state_hash to enter transition frontier. \
+                           Continuing to produce new blocks anyway. This may \
+                           mean your CPU is overloaded. Consider disabling \
+                           `-run-snark-worker` if it's configured." ;
+                        return ()
+                  in
+                  let transition_error_msg_prefix = "Validation failed: " in
+                  let transition_reason_for_failure =
+                    " One possible reason could be a ledger-catchup is \
+                     triggered before we produce a proof for the produced \
+                     transition."
+                  in
+                  let exn_breadcrumb name =
+                    raise
+                      (Error.to_exn
+                         (Error.of_string
+                            (sprintf
+                               "Error building breadcrumb from produced \
+                                transition: %s"
+                               name)))
+                  in
+                  match%bind emit_breadcrumb () with
+                  | Ok () ->
+                      return ()
+                  | Error (`Prover_error err) ->
                       [%log error]
                         "Prover failed to prove freshly generated transition: \
                          $error"
@@ -376,192 +518,61 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                             , Pending_coinbase_witness.to_yojson
                                 pending_coinbase_witness ) ] ;
                       return ()
-                  | Ok protocol_state_proof -> (
-                      let span = Time.diff (Time.now time_controller) t0 in
-                      [%log info]
+                  | Error `Invalid_genesis_protocol_state ->
+                      let state_yojson =
+                        Fn.compose State_hash.to_yojson
+                          Protocol_state.genesis_state_hash
+                      in
+                      [%log warn]
                         ~metadata:
-                          [ ( "proving_time"
-                            , `Int (Time.Span.to_ms span |> Int64.to_int_exn)
+                          [ ("expected", state_yojson previous_protocol_state)
+                          ; ("got", state_yojson protocol_state) ]
+                        "Produced transition has invalid genesis state hash" ;
+                      return ()
+                  | Error `Already_in_frontier ->
+                      [%log error]
+                        ~metadata:
+                          [ ( "protocol_state"
+                            , Protocol_state.value_to_yojson protocol_state )
+                          ]
+                        "%sproduced transition is already in frontier"
+                        transition_error_msg_prefix ;
+                      return ()
+                  | Error `Not_selected_over_frontier_root ->
+                      [%log warn]
+                        "%sproduced transition is not selected over the root \
+                         of transition frontier.%s"
+                        transition_error_msg_prefix
+                        transition_reason_for_failure ;
+                      return ()
+                  | Error `Parent_missing_from_frontier ->
+                      [%log warn]
+                        "%sparent of produced transition is missing from the \
+                         frontier.%s"
+                        transition_error_msg_prefix
+                        transition_reason_for_failure ;
+                      return ()
+                  | Error (`Fatal_error e) ->
+                      exn_breadcrumb
+                        (sprintf "fatal error -- %s" (Exn.to_string e))
+                  | Error (`Invalid_staged_ledger_hash e) ->
+                      exn_breadcrumb
+                        (sprintf "Invalid staged ledger hash -- %s"
+                           (Error.to_string_hum e))
+                  | Error (`Invalid_staged_ledger_diff (e, staged_ledger_diff))
+                    ->
+                      (* Unexpected errors from staged_ledger are captured in
+                         `Fatal_error
+                      *)
+                      [%log error]
+                        ~metadata:
+                          [ ("error", `String (Error.to_string_hum e))
+                          ; ( "diff"
+                            , Staged_ledger_diff.to_yojson staged_ledger_diff
                             ) ]
-                        !"Protocol_state_proof proving time(ms): \
-                          $proving_time%!" ;
-                      let staged_ledger_diff =
-                        Internal_transition.staged_ledger_diff
-                          internal_transition
-                      in
-                      let transition_hash =
-                        Protocol_state.hash protocol_state
-                      in
-                      let previous_state_hash =
-                        Protocol_state.hash previous_protocol_state
-                      in
-                      let delta_transition_chain_proof =
-                        Transition_chain_prover.prove
-                          ~length:
-                            ( Coda_numbers.Length.to_int
-                                consensus_constants.delta
-                            - 1 )
-                          ~frontier previous_state_hash
-                        |> Option.value_exn
-                      in
-                      let error_msg_prefix = "Validation failed: " in
-                      let reason_for_failure =
-                        " One possible reason could be a ledger-catchup is \
-                         triggered before we produce a proof for the produced \
-                         transition."
-                      in
-                      match
-                        let open Result.Let_syntax in
-                        let%map t =
-                          External_transition.Validation.wrap
-                            { With_hash.hash= transition_hash
-                            ; data=
-                                External_transition.create ~protocol_state
-                                  ~protocol_state_proof ~staged_ledger_diff
-                                  ~validation_callback:Fn.ignore
-                                  ~delta_transition_chain_proof () }
-                          |> External_transition.skip_time_received_validation
-                               `This_transition_was_not_received_via_gossip
-                          |> External_transition
-                             .skip_protocol_versions_validation
-                               `This_transition_has_valid_protocol_versions
-                          |> External_transition
-                             .validate_genesis_protocol_state
-                               ~genesis_state_hash:
-                                 (Protocol_state.genesis_state_hash
-                                    ~state_hash:(Some previous_state_hash)
-                                    previous_protocol_state)
-                        in
-                        External_transition.skip_proof_validation
-                          `This_transition_was_generated_internally t
-                        |> External_transition
-                           .skip_delta_transition_chain_validation
-                             `This_transition_was_not_received_via_gossip
-                      with
-                      | Error `Invalid_genesis_protocol_state ->
-                          let state_yojson =
-                            Fn.compose State_hash.to_yojson
-                              Protocol_state.genesis_state_hash
-                          in
-                          [%log warn]
-                            ~metadata:
-                              [ ( "expected"
-                                , state_yojson previous_protocol_state )
-                              ; ("got", state_yojson protocol_state) ]
-                            "Produced transition has invalid genesis state hash" ;
-                          return ()
-                      | Ok t -> (
-                        match
-                          Transition_frontier_validation
-                          .validate_frontier_dependencies ~logger ~frontier t
-                            ~consensus_constants
-                        with
-                        | Error `Already_in_frontier ->
-                            [%log error]
-                              ~metadata:
-                                [ ( "protocol_state"
-                                  , Protocol_state.value_to_yojson
-                                      protocol_state ) ]
-                              "%sproduced transition is already in frontier"
-                              error_msg_prefix ;
-                            return ()
-                        | Error `Not_selected_over_frontier_root ->
-                            [%log warn]
-                              "%sproduced transition is not selected over the \
-                               root of transition frontier.%s"
-                              error_msg_prefix reason_for_failure ;
-                            return ()
-                        | Error `Parent_missing_from_frontier ->
-                            [%log warn]
-                              "%sparent of produced transition is missing \
-                               from the frontier.%s"
-                              error_msg_prefix reason_for_failure ;
-                            return ()
-                        | Ok transition -> (
-                            let%bind breadcrumb_result =
-                              Breadcrumb.build ~logger ~precomputed_values
-                                ~verifier ~trust_system ~parent:crumb
-                                ~transition ~sender:None
-                            in
-                            let exn name =
-                              raise
-                                (Error.to_exn
-                                   (Error.of_string
-                                      (sprintf
-                                         "Error building breadcrumb from \
-                                          produced transition: %s"
-                                         name)))
-                            in
-                            match breadcrumb_result with
-                            | Error (`Fatal_error e) ->
-                                exn
-                                  (sprintf "fatal error -- %s"
-                                     (Exn.to_string e))
-                            | Error (`Invalid_staged_ledger_hash e) ->
-                                exn
-                                  (sprintf "Invalid staged ledger hash -- %s"
-                                     (Error.to_string_hum e))
-                            | Error (`Invalid_staged_ledger_diff e) ->
-                                (*Unexpected errors from staged_ledger are captured in `Fatal_error*)
-                                [%log error]
-                                  ~metadata:
-                                    [ ("error", `String (Error.to_string_hum e))
-                                    ; ( "diff"
-                                      , Staged_ledger_diff.to_yojson
-                                          staged_ledger_diff ) ]
-                                  !"Unable to build breadcrumb from produced \
-                                    transition due to invlaid staged ledger \
-                                    diff: $error" ;
-                                return ()
-                            | Ok breadcrumb -> (
-                                [%str_log trace]
-                                  ~metadata:
-                                    [ ( "breadcrumb"
-                                      , Breadcrumb.to_yojson breadcrumb ) ]
-                                  Block_produced ;
-                                let metadata =
-                                  [ ( "state_hash"
-                                    , State_hash.to_yojson transition_hash ) ]
-                                in
-                                Coda_metrics.(
-                                  Counter.inc_one
-                                    Block_producer.blocks_produced) ;
-                                let%bind () =
-                                  Strict_pipe.Writer.write transition_writer
-                                    breadcrumb
-                                in
-                                [%log debug] ~metadata
-                                  "Waiting for block $state_hash to be \
-                                   inserted into frontier" ;
-                                Deferred.choose
-                                  [ Deferred.choice
-                                      (Transition_registry.register
-                                         transition_registry transition_hash)
-                                      (Fn.const `Transition_accepted)
-                                  ; Deferred.choice
-                                      ( Time.Timeout.create time_controller
-                                          (* We allow up to 15 seconds for the transition to make its way from the transition_writer to the frontier.
-                                  This value is chosen to be reasonably generous. In theory, this should not take terribly long. But long
-                                  cycles do happen in our system, and with medium curves those long cycles can be substantial. *)
-                                          (Time.Span.of_ms 20000L)
-                                          ~f:(Fn.const ())
-                                      |> Time.Timeout.to_deferred )
-                                      (Fn.const `Timed_out) ]
-                                >>| function
-                                | `Transition_accepted ->
-                                    [%log info] ~metadata
-                                      "Generated transition $state_hash was \
-                                       accepted into transition frontier"
-                                | `Timed_out ->
-                                    (* FIXME #3167: this should be fatal, and more importantly, shouldn't happen. *)
-                                    [%log fatal] ~metadata
-                                      "Timed out waiting for generated \
-                                       transition $state_hash to enter \
-                                       transition frontier. Continuing to \
-                                       produce new blocks anyway. This may \
-                                       mean your CPU is overloaded. Consider \
-                                       disabling `-run-snark-worker` if it's \
-                                       configured." ) ) ) )) )
+                        !"Unable to build breadcrumb from produced transition \
+                          due to invlaid staged ledger diff: $error" ;
+                      return ()) )
       in
       let production_supervisor = Singleton_supervisor.create ~task:produce in
       let scheduler = Singleton_scheduler.create time_controller in

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -525,7 +525,7 @@ module type S = sig
            , 'staged_ledger_diff
            , 'protocol_versions )
            Validation.with_transition
-         , [ `Already_in_frontier
+         , [> `Already_in_frontier
            | `Parent_missing_from_frontier
            | `Not_selected_over_frontier_root ] )
          Result.t

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -31,7 +31,7 @@ val build :
   -> transition:External_transition.Almost_validated.t
   -> sender:Envelope.Sender.t option
   -> ( t
-     , [ `Invalid_staged_ledger_diff of Error.t
+     , [> `Invalid_staged_ledger_diff of Error.t
        | `Invalid_staged_ledger_hash of Error.t
        | `Fatal_error of exn ] )
      Result.t


### PR DESCRIPTION
This PR restructures the `Block_producer.run` function so that the logic is distinct from the error handling. This is a no-op, but makes it much easier to reason about what the actual logic is, and circumvents ocamlformat's aggressive indentation.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: