### PR TITLE
fix docker tagging in archive build script

### DIFF
--- a/scripts/archive/build-release-archives.sh
+++ b/scripts/archive/build-release-archives.sh
@@ -104,7 +104,7 @@ else
 
     echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
 
-    docker build -t codaprotocol/coda-archive:$VERSION -f $SCRIPTPATH/Dockerfile docker_build
+    docker build -t codaprotocol/coda-archive:$DOCKER_TAG -f $SCRIPTPATH/Dockerfile docker_build
 
-    docker push codaprotocol/coda-archive:$VERSION
+    docker push codaprotocol/coda-archive:$DOCKER_TAG
 fi


### PR DESCRIPTION
Docker tags cannot contain the same character set as deb package versions so a DOCKER_TAG variant was created of VERSION.

Testing:  CircleCI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them.
