### PR TITLE
update puppeteered docker image build dependency to build of daemon image

### DIFF
--- a/buildkite/src/Command/DockerArtifact.dhall
+++ b/buildkite/src/Command/DockerArtifact.dhall
@@ -19,7 +19,7 @@ let ReleaseSpec = {
     service: Text,
     version: Text,
     commit: Text,
-    build_rosetta: Bool,
+    build_rosetta_override: Bool,
     extra_args: Text,
     step_key: Text
   },
@@ -29,7 +29,7 @@ let ReleaseSpec = {
     service = "\\\${CODA_SERVICE}",
     version = "\\\${CODA_VERSION}",
     commit = "\\\${CODA_GIT_HASH}",
-    build_rosetta = False,
+    build_rosetta_override = False,
     extra_args = "--build-arg coda_deb_version=\\\${CODA_DEB_VERSION} --build-arg deb_repo=\\\${CODA_DEB_REPO}",
     step_key = "docker-artifact"
   }

--- a/buildkite/src/Command/DockerArtifact.dhall
+++ b/buildkite/src/Command/DockerArtifact.dhall
@@ -47,7 +47,7 @@ let generateStep = \(spec : ReleaseSpec.Type) ->
           "fi"
         ),
         Cmd.run (
-          "source ${spec.deploy_env_file} && ./scripts/release-docker.sh ${if spec.build_rosetta then "--build-rosetta " else ""} " ++
+          "source ${spec.deploy_env_file} && ./scripts/release-docker.sh ${if spec.build_rosetta_override then "--build-rosetta " else ""} " ++
               "--service ${spec.service} --version ${spec.version} --commit ${spec.commit} --extra-args \\\"${spec.extra_args}\\\""
         )
     ]

--- a/buildkite/src/Jobs/Release/CodaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/CodaArtifact.dhall
@@ -64,7 +64,10 @@ Pipeline.build
 
       -- puppeteered image
       let puppeteeredSpec = DockerArtifact.ReleaseSpec::{
-        deps=[ { name = "CodaArtifact", key = "docker-artifact" } ],
+        deps=[
+          dependOn,
+          { name = "CodaArtifact", key = "docker-artifact" }
+        ],
         service="\\\${CODA_SERVICE}-puppeteered",
         extra_args="--build-arg coda_deb_version=\\\${CODA_DEB_VERSION} --build-arg CODA_VERSION=\\\${CODA_VERSION} --build-arg CODA_BRANCH=\\\${CODA_GIT_BRANCH} --build-arg deb_repo=\\\${CODA_DEB_REPO}",
         step_key="puppeteered-docker-artifact"
@@ -82,7 +85,6 @@ Pipeline.build
         version="\\\${DOCKER_TAG}",
         commit = "\\\${GITHASH}",
         extra_args="--build-arg MINA_BRANCH=\\\${BUILDKITE_BRANCH} --cache-from gcr.io/o1labs-192920/mina-rosetta-opam-deps:develop",
-        build_rosetta=True,
         step_key="rosetta-docker-artifact"
       }
 
@@ -98,7 +100,6 @@ Pipeline.build
         version="dev-\\\${DOCKER_TAG}",
         commit = "\\\${GITHASH}",
         extra_args="--build-arg DUNE_PROFILE=dev --build-arg MINA_BRANCH=\\\${BUILDKITE_BRANCH} --cache-from gcr.io/o1labs-192920/mina-rosetta-opam-deps:develop",
-        build_rosetta=True,
         step_key="rosetta-dune-docker-artifact"
       }
 

--- a/buildkite/src/Jobs/Release/CodaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/CodaArtifact.dhall
@@ -64,10 +64,7 @@ Pipeline.build
 
       -- puppeteered image
       let puppeteeredSpec = DockerArtifact.ReleaseSpec::{
-        deps=[
-          dependOn,
-          { name = "CodaArtifact", key = "docker-artifact" }
-        ],
+        deps=dependsOn # [{ name = "CodaArtifact", key = "docker-artifact" }],
         service="\\\${CODA_SERVICE}-puppeteered",
         extra_args="--build-arg coda_deb_version=\\\${CODA_DEB_VERSION} --build-arg CODA_VERSION=\\\${CODA_VERSION} --build-arg CODA_BRANCH=\\\${CODA_GIT_BRANCH} --build-arg deb_repo=\\\${CODA_DEB_REPO}",
         step_key="puppeteered-docker-artifact"

--- a/buildkite/src/Jobs/Release/CodaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/CodaArtifact.dhall
@@ -64,7 +64,7 @@ Pipeline.build
 
       -- puppeteered image
       let puppeteeredSpec = DockerArtifact.ReleaseSpec::{
-        deps=dependsOn,
+        deps=[ { name = "CodaArtifact", key = "docker-artifact" } ],
         service="\\\${CODA_SERVICE}-puppeteered",
         extra_args="--build-arg coda_deb_version=\\\${CODA_DEB_VERSION} --build-arg CODA_VERSION=\\\${CODA_VERSION} --build-arg CODA_BRANCH=\\\${CODA_GIT_BRANCH} --build-arg deb_repo=\\\${CODA_DEB_REPO}",
         step_key="puppeteered-docker-artifact"


### PR DESCRIPTION
- Also refactored the DockerArtifact::ReleaseSpec type's build_rosetta property to more closely match its purpose as a rosetta build override in the absence of a deploy env file or rosetta build envvar.

**Testing:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: