### PR TITLE
ensure single retry of all buildkite jobs exiting w/ code 1 (common error)

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -166,8 +166,13 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
                           Natural/toInteger
                           retry.limit
                     })
-                    -- per https://buildkite.com/docs/agent/v3#exit-codes, ensure automatic retries on -1 exit status (infra error)
-                    ([Retry::{ exit_status = -1, limit = Some 2 }] #
+                    -- per https://buildkite.com/docs/agent/v3#exit-codes:
+                    ([
+                      -- ensure automatic retries on -1 exit status (infra error)
+                      Retry::{ exit_status = -1, limit = Some 2 },
+                      -- automatically retry on 1 exit status (common/flake error)
+                      Retry::{ exit_status = +1, limit = Some 1 }
+                    ] #
                     -- and the retries that are passed in (if any)
                     c.retries)
                 in


### PR DESCRIPTION
According to Buildkite's *agent exit code* documentation, job exit status of `1` is the most common error (which is also observably supported by "flakey" jobs throughout Coda's pipeline which generally fail with exit-code 1 and are resolved by a single retry.)

This change adds a single automatic retry for all jobs failing in this way as a first defense against flakey errors.

**Testing:** Buildkite linting + CI

**Checklist:**

- [ ] All tests pass (CI will check this if you didn't)
