### PR TITLE
re-add --lock flag to deb-s3 command

### DIFF
--- a/buildkite/scripts/publish-deb.sh
+++ b/buildkite/scripts/publish-deb.sh
@@ -3,11 +3,16 @@ set -eo pipefail
 
 # utility for publishing deb repo with commons options
 # deb-s3 https://github.com/krobertson/deb-s3
-
+#NOTE: Do not remove --lock flag otherwise racing deb uploads may overwrite the registry and some files will be lost. If a build fails with the following error, delete the lock file https://packages.o1test.net/dists/unstable/main/binary-/lockfile and rebuild
+#>> Checking for existing lock file
+#>> Repository is locked by another user:  at host dc7eaad3c537
+#>> Attempting to obtain a lock
+#/var/lib/gems/2.3.0/gems/deb-s3-0.10.0/lib/deb/s3/lock.rb:24:in `throw': uncaught throw #"Unable to obtain a lock after 60, giving up."
 DEBS3='deb-s3 upload '\
 '--s3-region=us-west-2 '\
 '--bucket packages.o1test.net '\
 '--preserve-versions '\
+'--lock '\
 '--cache-control=max-age=120 '\
 '--component main'
 

--- a/scripts/archive/build-release-archives.sh
+++ b/scripts/archive/build-release-archives.sh
@@ -58,8 +58,14 @@ ls -lh coda*.deb
 
 # utility for publishing deb repo with commons options
 # deb-s3 https://github.com/krobertson/deb-s3
-
-DEBS3='deb-s3 upload --s3-region=us-west-2 --bucket packages.o1test.net --preserve-versions --cache-control=max-age=120'
+#NOTE: Do not remove --lock flag otherwise racing deb uploads may overwrite the registry and some files will be lost. If a build fails with the following error, delete the lock file https://packages.o1test.net/dists/unstable/main/binary-/lockfile and rebuild
+#>> Checking for existing lock file
+#>> Repository is locked by another user:  at host dc7eaad3c537
+#>> Attempting to obtain a lock
+#/var/lib/gems/2.3.0/gems/deb-s3-0.10.0/lib/deb/s3/lock.rb:24:in `throw': uncaught throw #"Unable to obtain a lock after 60, giving up."
+DEBS3='deb-s3 upload --s3-region=us-west-2 --bucket packages.o1test.net --preserve-versions 
+--lock 
+--cache-control=max-age=120'
 
 # check for AWS Creds
 set +u

--- a/scripts/publish-deb.sh
+++ b/scripts/publish-deb.sh
@@ -3,7 +3,11 @@ set -eo pipefail
 
 # utility for publishing deb repo with commons options
 # deb-s3 https://github.com/krobertson/deb-s3
-
+#NOTE: Do not remove --lock flag otherwise racing deb uploads may overwrite the registry and some files will be lost. If a build fails with the following error, delete the lock file https://packages.o1test.net/dists/unstable/main/binary-/lockfile and rebuild
+#>> Checking for existing lock file
+#>> Repository is locked by another user:  at host dc7eaad3c537
+#>> Attempting to obtain a lock
+#/var/lib/gems/2.3.0/gems/deb-s3-0.10.0/lib/deb/s3/lock.rb:24:in `throw': uncaught throw #"Unable to obtain a lock after 60, giving up."
 DEBS3='deb-s3 upload '\
 '--s3-region=us-west-2 '\
 '--bucket packages.o1test.net '\


### PR DESCRIPTION

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

