### PR TITLE
Website: Leaderboard QA

### DIFF
--- a/frontend/website-redesign/src/components/ChallengePointsTable.re
+++ b/frontend/website-redesign/src/components/ChallengePointsTable.re
@@ -1,20 +1,8 @@
 module Styles = {
   open Css;
-  let text = {
-    style([
-      Theme.Typeface.ibmplexsans,
-      color(Theme.Colors.digitalBlack),
-      fontWeight(`num(600)),
-      lineHeight(`rem(2.)),
-      fontStyle(`normal),
-      fontSize(`rem(1.125)),
-      letterSpacing(`rem(-0.03)),
-    ]);
-  };
 
   let container = {
     merge([
-      text,
       style([
         display(`flex),
         flexDirection(`column),
@@ -24,7 +12,7 @@ module Styles = {
           [
             width(`percent(100.)),
             flexDirection(`row),
-            justifyContent(`spaceEvenly),
+            justifyContent(`spaceBetween),
           ],
         ),
       ]),
@@ -32,19 +20,25 @@ module Styles = {
   };
 
   let releaseTitle = {
-    style([
-      fontWeight(`num(600)),
-      fontSize(`rem(2.)),
-      letterSpacing(`rem(-0.03)),
-      display(`flex),
-      width(`percent(100.)),
-      justifyContent(`flexStart),
-      paddingTop(`rem(2.)),
-      media(
-        Theme.MediaQuery.notMobile,
-        [width(`percent(30.)), flexDirection(`row)],
-      ),
-      media(Theme.MediaQuery.tablet, [justifyContent(`center)]),
+    merge([
+      Theme.Type.h3,
+      style([
+        paddingTop(`rem(2.)),
+        marginBottom(`rem(1.5)),
+        media(
+          Theme.MediaQuery.notMobile,
+          [width(`percent(30.)), flexDirection(`row)],
+        ),
+        media(
+          Theme.MediaQuery.tablet,
+          [
+            paddingTop(`zero),
+            paddingLeft(`rem(5.)),
+            justifyContent(`center),
+            marginRight(`rem(1.5)),
+          ],
+        ),
+      ]),
     ]);
   };
 
@@ -61,40 +55,37 @@ module Styles = {
   let gridContainer = {
     style([
       marginTop(`rem(1.)),
-      background(`hex("F5F5F5")),
+      background(`hex("F8F8F8")),
       borderTop(`px(1), `solid, Css_Colors.black),
       borderBottom(`px(1), `solid, Css_Colors.black),
-      selector(
-        "div:nth-child(even)",
-        [background(`rgba((172, 151, 96, 0.06)))],
-      ),
+      selector("div:nth-child(even)", [background(white)]),
       media(Theme.MediaQuery.notMobile, [marginTop(`zero)]),
     ]);
   };
 
   let tableRow = {
-    style([
-      padding2(~v=`zero, ~h=`rem(1.)),
-      padding(`px(8)),
-      display(`grid),
-      gridTemplateColumns([`percent(12.), `auto, `percent(30.)]),
-      gridColumnGap(`rem(1.5)),
-      media(
-        Theme.MediaQuery.notMobile,
-        [gridTemplateColumns([`percent(10.), `auto, `percent(30.)])],
-      ),
+    merge([
+      Theme.Type.paragraph,
+      style([
+        padding2(~v=`zero, ~h=`rem(1.)),
+        padding(`px(8)),
+        display(`grid),
+        gridTemplateColumns([`percent(12.), `auto, `percent(30.)]),
+        gridColumnGap(`rem(1.5)),
+        media(
+          Theme.MediaQuery.notMobile,
+          [gridTemplateColumns([`percent(10.), `auto, `percent(30.)])],
+        ),
+      ]),
     ]);
   };
 
   let topRow = {
     merge([
-      tableRow,
+      Theme.Type.inputLabel,
       style([
         display(`none),
-        letterSpacing(`px(2)),
-        fontSize(`rem(0.875)),
-        textTransform(`uppercase),
-        padding(`zero),
+        marginBottom(`rem(0.5)),
         media(
           Theme.MediaQuery.notMobile,
           [
@@ -109,7 +100,8 @@ module Styles = {
   let bottomRow = {
     merge([
       tableRow,
-      style([marginTop(`rem(0.5)), textTransform(`uppercase)]),
+      Theme.Type.inputLabel,
+      style([marginTop(`rem(0.5))]),
     ]);
   };
 
@@ -126,13 +118,15 @@ module Styles = {
   };
 
   let disclaimer = {
-    style([
-      display(`flex),
-      justifyContent(`flexStart),
-      fontSize(`rem(1.)),
-      marginTop(`rem(1.)),
-      marginBottom(`rem(5.)),
-      media(Theme.MediaQuery.notMobile, [justifyContent(`flexEnd)]),
+    merge([
+      Theme.Type.h6,
+      style([
+        display(`flex),
+        justifyContent(`flexStart),
+        marginTop(`rem(1.)),
+        marginBottom(`rem(5.)),
+        media(Theme.MediaQuery.notMobile, [justifyContent(`flexEnd)]),
+      ]),
     ]);
   };
 };
@@ -189,7 +183,7 @@ let make = (~releaseTitle, ~challenges) => {
   };
 
   <div className=Styles.container>
-    <div className=Styles.releaseTitle> {React.string(releaseTitle)} </div>
+    <h3 className=Styles.releaseTitle> {React.string(releaseTitle)} </h3>
     <div className=Styles.tableContainer>
       <div className=Styles.topRow>
         <span className=Css.(style([gridColumn(2, 3)]))>

--- a/frontend/website-redesign/src/components/Dropdown.re
+++ b/frontend/website-redesign/src/components/Dropdown.re
@@ -4,8 +4,9 @@ module Styles = {
     style([
       display(`inlineFlex),
       alignItems(`center),
-      marginTop(`px(4)),
-      marginLeft(`rem(0.5)),
+      justifyContent(`spaceBetween),
+      margin2(~h=`rem(0.2), ~v=`rem(0.2)),
+      width(`percent(100.)),
     ]);
 
   let container = {
@@ -20,19 +21,6 @@ module Styles = {
         borderRadius(`px(4)),
         padding(`px(5)),
         cursor(`pointer),
-        after([
-          // Render triangle icon at the end of the dropdown
-          unsafe("content", ""),
-          position(`absolute),
-          width(`zero),
-          height(`zero),
-          borderLeft(`px(7), `solid, Theme.Colors.digitalBlack),
-          borderRight(`px(7), `solid, Theme.Colors.digitalBlack),
-          borderTop(`px(7), `solid, Theme.Colors.digitalBlack),
-          borderRadius(`px(1)),
-          right(`px(15)),
-          top(`percent(40.)),
-        ]),
       ]),
     ]);
   };
@@ -84,7 +72,8 @@ let make = (~items, ~currentItem, ~onItemPress) => {
 
   <div className=Styles.container onClick={_ => {toggleMenu(_ => !menuOpen)}}>
     <span className=Styles.currentItemTitle>
-      {React.string(currentItem)}
+      <span> {React.string(currentItem)} </span>
+      <Icon kind=Icon.ChevronDown />
     </span>
     <ul
       className={menuOpen ? Styles.expandedDropdown : Styles.collapsedDropdown}>

--- a/frontend/website-redesign/src/components/Leaderboard.re
+++ b/frontend/website-redesign/src/components/Leaderboard.re
@@ -166,7 +166,13 @@ module Styles = {
       alignItems(`center),
       gridColumnGap(rem(1.5)),
       width(`percent(100.)),
-      gridTemplateColumns([`rem(3.5), `rem(6.), `auto, `rem(9.)]),
+      gridTemplateColumns([
+        `rem(3.5),
+        `rem(6.),
+        `rem(6.),
+        `auto,
+        `rem(9.),
+      ]),
       hover([backgroundColor(Theme.Colors.orangeAlpha(0.1))]),
       media(
         Theme.MediaQuery.tablet,
@@ -219,11 +225,10 @@ module Styles = {
         zIndex(99),
         display(`none),
         paddingBottom(`rem(0.5)),
-        fontSize(`rem(1.)),
+        fontSize(`rem(0.875)),
         fontWeight(`normal),
         textTransform(`uppercase),
         letterSpacing(`rem(0.125)),
-        borderBottom(`px(1), `solid, Theme.Colors.orange),
         media(Theme.MediaQuery.notMobile, [display(`grid)]),
         hover([
           backgroundColor(Theme.Colors.digitalBlack),
@@ -234,19 +239,10 @@ module Styles = {
 
   let activeColumn =
     style([
-      position(`relative),
       justifySelf(`flexEnd),
       cursor(`pointer),
-      after([
-        position(`absolute),
-        left(`percent(100.)),
-        contentRule(""),
-        height(`rem(1.5)),
-        width(`rem(1.5)),
-        backgroundImage(`url("/static/img/arrowDown.svg")),
-        backgroundRepeat(`noRepeat),
-        backgroundPosition(`px(4), `px(9)),
-      ]),
+      display(`flex),
+      alignItems(`center),
     ]);
 
   let inactiveColumn =
@@ -254,7 +250,10 @@ module Styles = {
       display(`none),
       justifySelf(`flexEnd),
       cursor(`pointer),
-      media(Theme.MediaQuery.tablet, [display(`inline)]),
+      media(
+        Theme.MediaQuery.tablet,
+        [display(`flex), alignItems(`center)],
+      ),
     ]);
 
   let topTen =
@@ -660,7 +659,9 @@ let make =
       className={
         column === filter ? Styles.activeColumn : Styles.inactiveColumn
       }>
-      {React.string(string_of_filter(column))}
+      {column === filter
+         ?  <Icon kind=Icon.ChevronDown />  : React.null}
+      <span> {React.string(string_of_filter(column))} </span>
     </span>;
 
   <div className={Styles.leaderboardContainer(interactive)}>
@@ -703,6 +704,7 @@ let make =
          </div>;
        } else {
          Array.concat([
+           [|<hr />|],
            Array.length(topTen) > 0
              ? [|
                <div className=Styles.topTen>

--- a/frontend/website-redesign/src/components/Summary.re
+++ b/frontend/website-redesign/src/components/Summary.re
@@ -151,75 +151,50 @@ module Styles = {
 module StatisticsRow = {
   module Styles = {
     open Css;
-    let statistic =
-      style([
-        Theme.Typeface.monumentGroteskMono,
-        textTransform(`uppercase),
-        fontSize(`px(14)),
-        color(Theme.Colors.black),
-        letterSpacing(`em(0.03)),
-      ]);
 
-    let value =
-      merge([
-        Theme.Type.h2,
-        style([
-          fontSize(`px(40)),
-          marginBottom(`rem(0.5)),
-          fontWeight(`light),
-          display(`flex),
-          media(
-            Theme.MediaQuery.tablet,
-            [
-              marginBottom(`px(3)),
-              fontSize(`rem(2.5)),
-              lineHeight(`rem(2.5)),
-            ],
-          ),
-        ]),
-      ]);
+    let container = style([display(`flex), justifyContent(`spaceBetween)]);
 
-    let container =
-      style([
-        display(`flex),
-        flexWrap(`wrap),
-        justifyContent(`spaceBetween),
-        media(
-          Theme.MediaQuery.tablet,
-          [gridTemplateColumns([`rem(12.), `rem(12.), `rem(12.)])],
-        ),
-      ]);
     let flexColumn =
       style([
         display(`flex),
         flexDirection(`column),
         justifyContent(`flexStart),
       ]);
+
+    let h2 =
+      style([
+        Theme.Typeface.monumentGrotesk,
+        fontWeight(`normal),
+        fontSize(`rem(2.5)),
+        lineHeight(`rem(3.)),
+        color(Theme.Colors.digitalBlack),
+      ]);
+
+    let label =
+      style([
+        Theme.Typeface.monumentGroteskMono,
+        textTransform(`uppercase),
+        fontSize(`rem(0.875)),
+        lineHeight(`rem(1.)),
+        color(Theme.Colors.digitalBlack),
+      ]);
   };
   [@react.component]
   let make = (~statistics) => {
     <div className=Styles.container>
       <div className=Styles.flexColumn>
-        <div className=Styles.value>
-          {React.string(statistics.participants)}
-        </div>
-        <h2 className=Styles.statistic> {React.string("Participants")} </h2>
+        <h2 className=Styles.h2> {React.string(statistics.participants)} </h2>
+        <p className=Styles.label> {React.string("Participants")} </p>
       </div>
       <div className=Styles.flexColumn>
-        <span className=Styles.value>
+        <h2 className=Styles.h2>
           {React.string(statistics.genesisMembers)}
-        </span>
-        <span className=Styles.statistic>
-          {React.string("Genesis Members")}
-        </span>
-      </div>
-      <div className=Styles.statistic>
-        <div className=Styles.value>
-          {React.string(statistics.blockCount)}
-        </div>
-        <h2 className=Styles.statistic>
-          {React.string("Blocks Produced")}
         </h2>
+        <p className=Styles.label> {React.string("Genesis Members")} </p>
+      </div>
+      <div className=Styles.flexColumn>
+        <h2 className=Styles.h2> {React.string(statistics.blockCount)} </h2>
+        <p className=Styles.label> {React.string("Blocks Produced")} </p>
       </div>
     </div>;
   };

--- a/frontend/website-redesign/src/pages/LeaderboardPage.re
+++ b/frontend/website-redesign/src/pages/LeaderboardPage.re
@@ -149,7 +149,7 @@ module ToggleButtons = {
     };
 
     <div className=Styles.flexColumn>
-      <h3 className=Theme.Type.inputLabel> {React.string("View")} </h3>
+      <div className=Theme.Type.inputLabel> {React.string("View")} </div>
       <Spacer height=0.5 />
       <div className=Styles.buttonRow> {renderToggleButtons()} </div>
     </div>;
@@ -167,10 +167,9 @@ module FilterDropdown = {
         height(`rem(4.5)),
         width(`percent(100.)),
         marginTop(`rem(2.0)),
-        media(Theme.MediaQuery.tablet, [display(`none)]),
         media(
-          Theme.MediaQuery.notMobile,
-          [width(`percent(48.)), marginTop(`zero)],
+          Theme.MediaQuery.tablet,
+          [display(`none), width(`percent(48.)), marginTop(`zero)],
         ),
       ]);
   };

--- a/frontend/website-redesign/src/pages/MemberProfilePage.re
+++ b/frontend/website-redesign/src/pages/MemberProfilePage.re
@@ -279,11 +279,12 @@ let make = () => {
     [|router.query|],
   );
 
-  <Page title="Member Profile">
+  <Page title="Mina Cryptocurrency Protocol">
     <Wrapped>
       <div className=Styles.page>
         {switch (state.currentMember) {
-         | Some(member) => <div> <ProfileHero member /> </div>
+         | Some(member) =>
+           <> <div className=Nav.Styles.spacer /> <ProfileHero member /> </>
          | None => React.null
          }}
         <div className=Styles.table>


### PR DESCRIPTION
This PR implements the following bug fixes from UME:

1. View' dropdown appears on desktop, should only appear on tablet and mobile.
2. Headline numbers (participants/genesis members/blocks produced) are too small
3. Blackline is missing next top 'top 10', should look just like the black line next to 'top 50'
4. Breadcrumbs (testnet > Leaderboard > Participant Details) and Username are overlapping Mina logo. Should be below logo. 
5. Release name and challenge tables are centered in the same column. Tables should be aligned to the right side of the page, release name on the left side of the page.

There were some other minor fixes included in this PR. 

This page will be reviewed by Chris for further review. 