### PR TITLE
Don't die on JSON parse errors from libp2p_helper

### DIFF
--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -1425,7 +1425,9 @@ let create ~on_unexpected_termination ~logger ~conf_dir =
                   } )
           | Error err ->
               [%log debug]
-                ~metadata:[("line", `String line); ("error", `String err)]
+                ~metadata:
+                  [ ("line", `String line)
+                  ; ("error", `String (Error.to_string_hum err)) ]
                 "failed to parse log line $line from helper stderr as json"
           | Ok (Error err) ->
               [%log debug]
@@ -1446,7 +1448,9 @@ let create ~on_unexpected_termination ~logger ~conf_dir =
               ()
           | Error err ->
               [%log debug]
-                ~metadata:[("line", `String line); ("error", `String err)]
+                ~metadata:
+                  [ ("line", `String line)
+                  ; ("error", `String (Error.to_string_hum err)) ]
                 "failed to parse log line $line from helper stderr as json"
           | Ok (Error e) ->
               [%log error] "handling line from helper failed! $err"

--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -1403,8 +1403,11 @@ let create ~on_unexpected_termination ~logger ~conf_dir =
       termination_hack_ref := Some t ;
       Strict_pipe.Reader.iter (Child_processes.stderr_lines subprocess)
         ~f:(fun line ->
-          ( match Go_log.record_of_yojson (Yojson.Safe.from_string line) with
-          | Ok record -> (
+          ( match
+              Or_error.try_with (fun () -> Yojson.Safe.from_string line)
+              |> Or_error.map ~f:Go_log.record_of_yojson
+            with
+          | Ok (Ok record) -> (
               let r = Go_log.(record_to_message record) in
               let r =
                 if
@@ -1423,20 +1426,29 @@ let create ~on_unexpected_termination ~logger ~conf_dir =
           | Error err ->
               [%log debug]
                 ~metadata:[("line", `String line); ("error", `String err)]
-                "failed to parse log line from helper stderr" ) ;
+                "failed to parse log line $line from helper stderr as json"
+          | Ok (Error err) ->
+              [%log debug]
+                ~metadata:[("line", `String line); ("error", `String err)]
+                "failed to parse log line $line from helper stderr" ) ;
           Deferred.unit )
       |> don't_wait_for ;
       Strict_pipe.Reader.iter (Child_processes.stdout_lines subprocess)
         ~f:(fun line ->
           let open Yojson.Safe.Util in
-          let v = Yojson.Safe.from_string line in
+          let v = Or_error.try_with (fun () -> Yojson.Safe.from_string line) in
           ( match
-              if member "upcall" v = `Null then Helper.handle_response t v
-              else Helper.handle_upcall t v
+              Or_error.map v ~f:(fun v ->
+                  if member "upcall" v = `Null then Helper.handle_response t v
+                  else Helper.handle_upcall t v )
             with
-          | Ok () ->
+          | Ok (Ok ()) ->
               ()
-          | Error e ->
+          | Error err ->
+              [%log debug]
+                ~metadata:[("line", `String line); ("error", `String err)]
+                "failed to parse log line $line from helper stderr as json"
+          | Ok (Error e) ->
               [%log error] "handling line from helper failed! $err"
                 ~metadata:
                   [ ("line", `String line)


### PR DESCRIPTION
This PR stops the daemon from dying if libp2p_helper sends a line which is not valid JSON to stdout or stderr.

This partially mitigates the error seen on the testnet, so that we will hopefully get the full error message. Error there was
```
(monitor.ml.Error\n  (\"Yojson.Json_error(\\\"Line 1, bytes 0-33:\\\\nInvalid token 'panic: runtime error: invalid mem'\\\")\")\n  (\"Raised at file \\\"common.ml\\\", line 5, characters 19-39\"\n    \"Called from file \\\"lib/read.ml\\\" (inlined), line 1025, characters 3-39\"\n    \"Called from file \\\"lib/read.mll\\\", line 1109, characters 8-26\"\n    \"Called from file \\\"lib/read.mll\\\", line 1122, characters 6-26\"\n    \"Called from file \\\"src/lib/coda_net2/coda_net2.ml\\\", line 1396, characters 42-72\"\n    \"Called from file \\\"src/lib/pipe_lib/strict_pipe.ml\\\", line 76, characters 27-32\"\n    \"Called from file \\\"src/deferred0.ml\\\", line 56, characters 64-69\"\n    \"Called from file \\\"src/job_queue.ml\\\" (inlined), line 131, characters 2-5\"\n    \"Called from file \\\"src/job_queue.ml\\\", line 171, characters 6-47\"))
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: