### PR TITLE
remove --build flag from Docker artifact command

### DIFF
--- a/buildkite/src/Command/DockerArtifact.dhall
+++ b/buildkite/src/Command/DockerArtifact.dhall
@@ -43,7 +43,7 @@ let generateStep = \(spec : ReleaseSpec.Type) ->
     [
         Cmd.run (
           "if [ ! -f ${spec.deploy_env_file} ]; then " ++
-              "buildkite-agent artifact download --build \\\$BUILDKITE_BUILD_ID --include-retried-jobs --step _${artifactUploadScope.name}-${artifactUploadScope.key} ${spec.deploy_env_file} .; " ++
+              "buildkite-agent artifact download --include-retried-jobs --step _${artifactUploadScope.name}-${artifactUploadScope.key} ${spec.deploy_env_file} .; " ++
           "fi"
         ),
         Cmd.run (


### PR DESCRIPTION
Due to redundant default setting and potential artifact misdirection/hyper-constraints in the event of retry failures etc. Also Buildkite's `--build` logic may be thrown off by our using GCS as an artifact store vs. their built-in Artifactory solution.

**Testing:** Buildkite CI

Checklist:

- [ ] All tests pass (CI will check this if you didn't)