### PR TITLE
enable debug logging for buildkite artifact download commands

### DIFF
--- a/buildkite/src/Command/DockerArtifact.dhall
+++ b/buildkite/src/Command/DockerArtifact.dhall
@@ -43,7 +43,7 @@ let generateStep = \(spec : ReleaseSpec.Type) ->
     [
         Cmd.run (
           "if [ ! -f ${spec.deploy_env_file} ]; then " ++
-              "buildkite-agent artifact download --debug-http --debug --build \\\$BUILDKITE_BUILD_ID --include-retried-jobs --step _${artifactUploadScope.name}-${artifactUploadScope.key} ${spec.deploy_env_file} .; " ++
+              "buildkite-agent artifact download --debug-http --debug --build \\\$BUILDKITE_BUILD_ID --include-retried-jobs ${spec.deploy_env_file} .; " ++
           "fi"
         ),
         Cmd.run (

--- a/buildkite/src/Command/DockerArtifact.dhall
+++ b/buildkite/src/Command/DockerArtifact.dhall
@@ -43,7 +43,7 @@ let generateStep = \(spec : ReleaseSpec.Type) ->
     [
         Cmd.run (
           "if [ ! -f ${spec.deploy_env_file} ]; then " ++
-              "buildkite-agent artifact download --build \\\$BUILDKITE_BUILD_ID --include-retried-jobs --step _${artifactUploadScope.name}-${artifactUploadScope.key} ${spec.deploy_env_file} .; " ++
+              "buildkite-agent artifact download --debug-http --debug --build \\\$BUILDKITE_BUILD_ID --include-retried-jobs --step _${artifactUploadScope.name}-${artifactUploadScope.key} ${spec.deploy_env_file} .; " ++
           "fi"
         ),
         Cmd.run (


### PR DESCRIPTION
This PR is a part of an investigation into Buildkite agent artifact download failures when targetting uploads from retried jobs.

**Testing:** Buildkite CI

Checklist:

- [ ] All tests pass (CI will check this if you didn't)