### PR TITLE
Website: Testnet Fixes

### DIFF
--- a/frontend/website-redesign/public/static/img/TestnetCopyBackgroundDesktop.jpg
+++ b/frontend/website-redesign/public/static/img/TestnetCopyBackgroundDesktop.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d87ea22fbe8fa036fc7d9272fa328436a05579de4ab6cd0e0bf136825b83b27
+size 1517449

--- a/frontend/website-redesign/src/components/ButtonBar.re
+++ b/frontend/website-redesign/src/components/ButtonBar.re
@@ -198,6 +198,7 @@ module HelpAndSupport = {
           Theme.Typeface.monumentGrotesk,
           color(Theme.Colors.white),
           fontSize(`rem(0.75)),
+          textAlign(`center),
           lineHeight(`rem(1.)),
           textTransform(`uppercase),
           letterSpacing(`em(0.02)),

--- a/frontend/website-redesign/src/components/FeaturedSingleRow.re
+++ b/frontend/website-redesign/src/components/FeaturedSingleRow.re
@@ -38,6 +38,37 @@ module Row = {
   };
 };
 
+/* The reason we have a custom wrapped component here is because we want the
+   image to be the full width of the screen on mobile. If we wrap our component
+   in a normal wrap, a width margin is applied on mobile which we don't want. Instead
+   we create a custom wrapped component for this component only */
+
+module CustomWrapped = {
+  open Css;
+
+  [@react.component]
+  let make = (~overflowHidden=false, ~children) => {
+    let paddingX = m => [paddingLeft(m), paddingRight(m)];
+    <div
+      className={style(
+        (overflowHidden ? [overflow(`hidden)] : [])
+        @ [
+          margin(`auto),
+          media(
+            Theme.MediaQuery.tablet,
+            [maxWidth(`rem(85.0)), ...paddingX(`rem(2.5))],
+          ),
+          media(
+            Theme.MediaQuery.desktop,
+            [maxWidth(`rem(90.0)), ...paddingX(`rem(9.5))],
+          ),
+        ],
+      )}>
+      children
+    </div>;
+  };
+};
+
 module SingleRow = {
   module RowStyles = {
     open Css;
@@ -60,7 +91,7 @@ module SingleRow = {
         };
       style([
         position(`absolute),
-        width(`rem(21.)),
+        width(`percent(90.)),
         maxHeight(`rem(35.)),
         overflow(`scroll),
         unsafe("height", "fit-content"),
@@ -131,7 +162,7 @@ module SingleRow = {
           RowStyles.image,
           style([
             left(`zero),
-            bottom(`percent(25.)),
+            bottom(`percent(30.)),
             media(Theme.MediaQuery.notMobile, [bottom(`zero)]),
           ]),
         ]);
@@ -290,7 +321,7 @@ module Styles = {
 [@react.component]
 let make = (~row: Row.t, ~children=?) => {
   <div className={Styles.singleRowBackground(row.background)}>
-    <Wrapped>
+    <CustomWrapped>
       {switch (row.rowType) {
        | ImageLeftCopyRight => <SingleRow.ImageLeftCopyRight row />
        | ImageRightCopyLeft => <SingleRow.ImageRightCopyLeft row />
@@ -299,6 +330,6 @@ let make = (~row: Row.t, ~children=?) => {
        | Some(children) => children
        | None => <> </>
        }}
-    </Wrapped>
+    </CustomWrapped>
   </div>;
 };

--- a/frontend/website-redesign/src/components/FeaturedSingleRow.re
+++ b/frontend/website-redesign/src/components/FeaturedSingleRow.re
@@ -73,6 +73,16 @@ module SingleRow = {
   module RowStyles = {
     open Css;
 
+    let childreWrapped =
+      style([
+        margin(`auto),
+        padding2(~v=`zero, ~h=`rem(1.5)),
+        media(
+          Theme.MediaQuery.notMobile,
+          [margin(`zero), padding2(~v=`zero, ~h=`zero)],
+        ),
+      ]);
+
     let container =
       style([
         position(`relative),
@@ -332,7 +342,8 @@ let make = (~row: Row.t, ~children=?) => {
        | ImageRightCopyLeft => <SingleRow.ImageRightCopyLeft row />
        }}
       {switch (children) {
-       | Some(children) => children
+       | Some(children) =>
+         <div className=SingleRow.RowStyles.childreWrapped> children </div>
        | None => <> </>
        }}
     </CustomWrapped>

--- a/frontend/website-redesign/src/components/FeaturedSingleRow.re
+++ b/frontend/website-redesign/src/components/FeaturedSingleRow.re
@@ -91,7 +91,7 @@ module SingleRow = {
         };
       style([
         position(`absolute),
-        width(`percent(90.)),
+        width(`percent(92.5)),
         maxHeight(`rem(35.)),
         overflow(`scroll),
         unsafe("height", "fit-content"),
@@ -104,7 +104,12 @@ module SingleRow = {
         backgroundSize(`cover),
         media(
           Theme.MediaQuery.notMobile,
-          [margin(`zero), overflow(`hidden), ...additionalNotMobileStyles],
+          [
+            width(`percent(100.)),
+            margin(`zero),
+            overflow(`hidden),
+            ...additionalNotMobileStyles,
+          ],
         ),
         switch (contentBackground) {
         | Image(url) => backgroundImage(`url(url))

--- a/frontend/website-redesign/src/components/FeaturedSingleRow.re
+++ b/frontend/website-redesign/src/components/FeaturedSingleRow.re
@@ -69,7 +69,7 @@ module SingleRow = {
         flexDirection(`column),
         alignItems(`flexStart),
         justifyContent(`spaceBetween),
-        padding(`rem(3.)),
+        padding(`rem(2.)),
         backgroundSize(`cover),
         media(
           Theme.MediaQuery.notMobile,
@@ -111,10 +111,14 @@ module SingleRow = {
       style([
         position(`absolute),
         width(`percent(100.)),
+        height(`percent(70.)),
         maxWidth(`rem(53.)),
         paddingTop(`rem(8.)),
         bottom(`zero),
-        media(Theme.MediaQuery.tablet, [width(`percent(80.))]),
+        media(
+          Theme.MediaQuery.tablet,
+          [height(`percent(110.)), width(`percent(80.))],
+        ),
         media(Theme.MediaQuery.desktop, [width(`percent(100.))]),
       ]);
   };
@@ -127,6 +131,7 @@ module SingleRow = {
           RowStyles.image,
           style([
             left(`zero),
+            bottom(`percent(25.)),
             media(Theme.MediaQuery.notMobile, [bottom(`zero)]),
           ]),
         ]);
@@ -135,7 +140,7 @@ module SingleRow = {
         merge([
           RowStyles.contentBlock(size, backgroundImg),
           style([
-            bottom(`zero),
+            bottom(`percent(5.)),
             media(
               Theme.MediaQuery.tablet,
               [
@@ -210,10 +215,10 @@ module SingleRow = {
         merge([
           RowStyles.contentBlock(size, contentBackground),
           style([
-            top(`rem(12.6)),
+            top(`percent(5.)),
             media(
               Theme.MediaQuery.tablet,
-              [left(`zero), width(`rem(32.))],
+              [left(`zero), width(`rem(32.)), top(`percent(35.))],
             ),
           ]),
         ]);

--- a/frontend/website-redesign/src/components/Footer.re
+++ b/frontend/website-redesign/src/components/Footer.re
@@ -5,7 +5,7 @@ module Styles = {
       position(`relative),
       left(`zero),
       bottom(`zero),
-      height(`rem(106.)),
+      height(`percent(100.)),
       padding2(~v=`rem(4.), ~h=`rem(1.25)),
       backgroundImage(`url("/static/img/Small.jpg")),
       backgroundSize(`cover),
@@ -13,7 +13,7 @@ module Styles = {
         Theme.MediaQuery.tablet,
         [
           padding2(~v=`rem(4.), ~h=`rem(2.68)),
-          height(`rem(75.)),
+          height(`percent(100.)),
           backgroundImage(`url("/static/img/Medium.jpg")),
         ],
       ),

--- a/frontend/website-redesign/src/components/ListModule.re
+++ b/frontend/website-redesign/src/components/ListModule.re
@@ -44,6 +44,7 @@ module Styles = {
   let mainListingContainer =
     style([
       width(`percent(100.)),
+      marginBottom(`rem(2.)),
       media(Theme.MediaQuery.notMobile, [width(`percent(40.))]),
     ]);
 };

--- a/frontend/website-redesign/src/components/ListModule.re
+++ b/frontend/website-redesign/src/components/ListModule.re
@@ -122,11 +122,7 @@ module Listing = {
         flexDirection(`column),
         borderTop(`px(1), `solid, Theme.Colors.digitalBlack),
         width(`percent(100.)),
-        marginTop(`rem(3.)),
-        media(
-          Theme.MediaQuery.notMobile,
-          [marginTop(`zero), width(`percent(80.))],
-        ),
+        media(Theme.MediaQuery.notMobile, [width(`percent(80.))]),
       ]);
 
     let link = merge([Styles.link, style([marginBottom(`rem(2.))])]);

--- a/frontend/website-redesign/src/components/ListModule.re
+++ b/frontend/website-redesign/src/components/ListModule.re
@@ -18,7 +18,11 @@ module Styles = {
       height(`percent(100.)),
     ]);
 
-  let title = merge([Theme.Type.h5, style([marginTop(`rem(1.))])]);
+  let title =
+    merge([
+      Theme.Type.h5,
+      style([fontWeight(`normal), marginTop(`rem(1.))]),
+    ]);
 
   let description =
     merge([Theme.Type.paragraphSmall, style([marginTop(`rem(1.))])]);
@@ -95,7 +99,7 @@ module MainListing = {
       {let inner =
          <div className=Styles.link>
            <span> {React.string("Read more")} </span>
-           <Icon kind=Icon.ArrowRightMedium />
+           <Icon kind=Icon.ArrowRightSmall />
          </div>;
        switch (item.link) {
        | `Slug(slug) =>
@@ -134,7 +138,7 @@ module Listing = {
       let inner =
         <div className=ListingStyles.link>
           <span> {React.string("Read more")} </span>
-          <Icon kind=Icon.ArrowRightMedium />
+          <Icon kind=Icon.ArrowRightSmall />
         </div>;
       switch (item.link) {
       | `Slug(slug) =>

--- a/frontend/website-redesign/src/components/TestnetRetroModule.re
+++ b/frontend/website-redesign/src/components/TestnetRetroModule.re
@@ -17,7 +17,14 @@ let fetchBlogs = () => {
 module Styles = {
   open Css;
 
-  let container = style([margin2(~v=`rem(7.), ~h=`zero)]);
+  let container =
+    style([
+      margin2(~v=`rem(3.), ~h=`zero),
+      media(
+        Theme.MediaQuery.notMobile,
+        [margin2(~v=`rem(7.25), ~h=`zero)],
+      ),
+    ]);
 
   let header =
     style([

--- a/frontend/website-redesign/src/pages/Testnet.re
+++ b/frontend/website-redesign/src/pages/Testnet.re
@@ -24,7 +24,7 @@ module Styles = {
     style([
       display(`flex),
       flexDirection(`column),
-      alignItems(`center),
+      alignItems(`flexStart),
       justifyContent(`center),
       marginTop(`rem(4.)),
       marginBottom(`rem(2.)),
@@ -53,8 +53,9 @@ module Styles = {
       style([
         display(`listItem),
         listStylePosition(`inside),
-        marginBottom(`rem(14.)),
+        marginBottom(`rem(4.)),
         marginTop(`rem(3.)),
+        media(Theme.MediaQuery.notMobile, [marginBottom(`rem(12.))]),
       ]),
     ]);
 
@@ -129,7 +130,7 @@ let make = () => {
       <FeaturedSingleRow
         row={
           FeaturedSingleRow.Row.rowType: ImageRightCopyLeft,
-          copySize: `Small,
+          copySize: `Large,
           title: "Testnet Challenges",
           description: "Learn how to operate the protocol, while contributing to Mina's network resilience.",
           textColor: Theme.Colors.white,

--- a/frontend/website-redesign/src/pages/Testnet.re
+++ b/frontend/website-redesign/src/pages/Testnet.re
@@ -133,7 +133,7 @@ let make = () => {
           title: "Testnet Challenges",
           description: "Learn how to operate the protocol, while contributing to Mina's network resilience.",
           textColor: Theme.Colors.white,
-          image: "/static/img/AboutHeroDesktopBackground.jpg",
+          image: "/static/img/TestnetCopyBackgroundDesktop.jpg",
           background: Image("/static/img/MinaSpectrumPrimarySilver.jpg"),
           contentBackground:
             Image("/static/img/TestnetContentBlockBackground.png"),


### PR DESCRIPTION
This PR implements the QA fixes as according to the UME design document. 

The following was addressed:
1. Testnet challenges: photo is not the correct one
2. Testnet challenges: teal button needs left-aligned type, arrow should center vertically
3. Test retros: headings of each retro, copy looks too heavy weight
4. Sections with large black buttons: Buttons as a unit should align with left and right margins. This would make each one wider which would accommodate text without changing vertical size of buttons.
5. Leaderboard: Too much spacing between leaderboard and the following module
6. Read More links: Orange arrows are too big