### PR TITLE
Trivial: Log libp2p_helper JSON parse errors at level error

### DIFF
--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -1424,7 +1424,7 @@ let create ~on_unexpected_termination ~logger ~conf_dir =
                   ; metadata= String.Map.singleton "line" (`String r.message)
                   } )
           | Error err ->
-              [%log debug]
+              [%log error]
                 ~metadata:
                   [ ("line", `String line)
                   ; ("error", `String (Error.to_string_hum err)) ]
@@ -1447,7 +1447,7 @@ let create ~on_unexpected_termination ~logger ~conf_dir =
           | Ok (Ok ()) ->
               ()
           | Error err ->
-              [%log debug]
+              [%log error]
                 ~metadata:
                   [ ("line", `String line)
                   ; ("error", `String (Error.to_string_hum err)) ]


### PR DESCRIPTION
These errors show that there's something going wrong in libp2p_helper, likely an internal error. We should surface these at the 'error' level to ensure that they get picked up so we can fix them. See e.g. #6404.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: