### PR TITLE
speedup delegation test

### DIFF
--- a/src/app/cli/src/tests/coda_delegation_test.ml
+++ b/src/app/cli/src/tests/coda_delegation_test.ml
@@ -70,7 +70,7 @@ let main () =
   *)
   let delegatee_has_produced = ref false in
   let delegator_production_count = ref 0 in
-  let delegator_production_goal = 30 in
+  let delegator_production_goal = 20 in
   Deferred.don't_wait_for
     (Pipe_lib.Linear_pipe.iter delegator_transition_reader
        ~f:(fun {With_hash.data= transition; _} ->
@@ -95,7 +95,7 @@ let main () =
   (* delegatee's transition reader will fill this ivar when it has seen a few blocks *)
   let delegatee_ivar : unit Ivar.t = Ivar.create () in
   (* how many blocks we should wait for from the delegatee *)
-  let delegatee_production_goal = 10 in
+  let delegatee_production_goal = 5 in
   Deferred.don't_wait_for
     (Pipe_lib.Linear_pipe.iter delegatee_transition_reader
        ~f:(fun {With_hash.data= transition; _} ->

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -840,7 +840,7 @@ module Test_configs = struct
   { "daemon":
       { "txpool_max_size": 3000 }
   , "genesis":
-      { "k": 6
+      { "k": 1
       , "delta": 3
       , "genesis_state_timestamp": "2019-01-30 12:00:00-08:00" }
   , "proof":
@@ -848,7 +848,7 @@ module Test_configs = struct
       , "c": 8
       , "ledger_depth": 6
       , "work_delay": 1
-      , "block_window_duration_ms": 10000
+      , "block_window_duration_ms": 5000
       , "transaction_capacity": {"2_to_the": 2}
       , "coinbase_amount": "20"
       , "supercharged_coinbase_factor": 2


### PR DESCRIPTION
Changes to f resulted in coda-delegation-test taking ~50 minutes. This speeds that back up by reducing some constants