### PR TITLE
Website improvements: reduce size of home page images 

### DIFF
--- a/frontend/website-redesign/src/components/AlternatingSections.re
+++ b/frontend/website-redesign/src/components/AlternatingSections.re
@@ -55,10 +55,10 @@ module Section = {
     let image =
       style([
         width(`percent(100.)),
-        maxWidth(`rem(23.)),
+        maxWidth(`rem(11.5)),
         height(`auto),
         marginTop(`rem(2.)),
-        media(Theme.MediaQuery.desktop, [maxWidth(`rem(35.))]),
+        media(Theme.MediaQuery.desktop, [maxWidth(`rem(17.5))]),
       ]);
   };
   module SimpleRow = {
@@ -91,12 +91,7 @@ module Section = {
       |> Array.mapi((idx, row) => {
            <div
              key={row.title}
-             className={Styles.rowContainer(
-               ~reverse={
-                 idx mod 2 != 0;
-               },
-               (),
-             )}>
+             className={Styles.rowContainer(~reverse={idx mod 2 != 0}, ())}>
              <div className=SectionStyles.textContainer>
                <h2 className=SectionStyles.title>
                  {React.string(row.title)}
@@ -155,9 +150,7 @@ module Section = {
            <div
              key={row.title}
              className={SectionStyles.rowContainer(
-               ~reverse={
-                 idx mod 2 != 0;
-               },
+               ~reverse={idx mod 2 != 0},
                (),
              )}>
              <div className=SectionStyles.textContainer>


### PR DESCRIPTION
reduces image sizes in the home page via changing the maxWidth and desktop size in the component 

![image](https://user-images.githubusercontent.com/12700801/96761816-15629c80-138e-11eb-8e71-d55c29fb0c19.png)
