### PR TITLE
Compare checked, unchecked min balances

### DIFF
--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -298,6 +298,12 @@ module type S = sig
     -> bool Or_error.t
 
   module For_tests : sig
+    val validate_timing_with_min_balance :
+         account:Account.t
+      -> txn_amount:Amount.t
+      -> txn_global_slot:Global_slot.t
+      -> (Account.Timing.t * [> `Min_balance of Balance.t]) Or_error.t
+
     val validate_timing :
          account:Account.t
       -> txn_amount:Amount.t
@@ -320,13 +326,13 @@ let timing_error_to_user_command_status err =
   | _ ->
       failwith "Unexpected timed account validation error"
 
-let validate_timing ~account ~txn_amount ~txn_global_slot =
+let validate_timing_with_min_balance ~account ~txn_amount ~txn_global_slot =
   let open Account.Poly in
   let open Account.Timing.Poly in
   match account.timing with
   | Untimed ->
       (* no time restrictions *)
-      Or_error.return Untimed
+      Or_error.return (Untimed, `Min_balance Balance.zero)
   | Timed
       {initial_minimum_balance; cliff_time; vesting_period; vesting_increment}
     ->
@@ -368,7 +374,16 @@ let validate_timing ~account ~txn_amount ~txn_global_slot =
             else Or_error.return curr_min_balance
       in
       (* once the calculated minimum balance becomes zero, the account becomes untimed *)
-      if Balance.(curr_min_balance > zero) then account.timing else Untimed
+      if Balance.(curr_min_balance > zero) then
+        (account.timing, `Min_balance curr_min_balance)
+      else (Untimed, `Min_balance Balance.zero)
+
+let validate_timing ~account ~txn_amount ~txn_global_slot =
+  let open Result.Let_syntax in
+  let%map timing, `Min_balance _ =
+    validate_timing_with_min_balance ~account ~txn_amount ~txn_global_slot
+  in
+  timing
 
 module Make (L : Ledger_intf) : S with type ledger := L.t = struct
   open L
@@ -1379,7 +1394,11 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         |> finish )
 
   let update_timing_when_no_deduction ~txn_global_slot account =
-    validate_timing ~txn_amount:Amount.zero ~txn_global_slot ~account
+    let open Result.Let_syntax in
+    let%map timing =
+      validate_timing ~txn_amount:Amount.zero ~txn_global_slot ~account
+    in
+    timing
 
   let process_fee_transfer t (transfer : Fee_transfer.t) ~modify_balance
       ~modify_timing =
@@ -1893,6 +1912,8 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
     (root, `Next_available_token next_available_token)
 
   module For_tests = struct
+    let validate_timing_with_min_balance = validate_timing_with_min_balance
+
     let validate_timing = validate_timing
   end
 end

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -1394,11 +1394,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         |> finish )
 
   let update_timing_when_no_deduction ~txn_global_slot account =
-    let open Result.Let_syntax in
-    let%map timing =
-      validate_timing ~txn_amount:Amount.zero ~txn_global_slot ~account
-    in
-    timing
+    validate_timing ~txn_amount:Amount.zero ~txn_global_slot ~account
 
   let process_fee_transfer t (transfer : Fee_transfer.t) ~modify_balance
       ~modify_timing =

--- a/src/lib/coda_base/transaction_validator.mli
+++ b/src/lib/coda_base/transaction_validator.mli
@@ -28,6 +28,12 @@ module For_tests : sig
   open Currency
   open Coda_numbers
 
+  val validate_timing_with_min_balance :
+       account:Account.t
+    -> txn_amount:Amount.t
+    -> txn_global_slot:Global_slot.t
+    -> (Account.Timing.t * [> `Min_balance of Balance.t]) Or_error.t
+
   val validate_timing :
        account:Account.t
     -> txn_amount:Amount.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -5704,36 +5704,88 @@ let%test_module "account timing check" =
 
     (* test that unchecked and checked calculations for timing agree *)
 
-    let make_checked_computation account txn_amount txn_global_slot =
+    let checked_min_balance_and_timing account txn_amount txn_global_slot =
       let account = Account.var_of_t account in
       let txn_amount = Amount.var_of_t txn_amount in
       let txn_global_slot = Global_slot.Checked.constant txn_global_slot in
-      let open Snarky_backendless.Checked.Let_syntax in
-      let%map _, timing =
+      let%map `Min_balance min_balance, timing =
         Base.check_timing ~balance_check:Tick.Boolean.Assert.is_true
           ~timed_balance_check:Tick.Boolean.Assert.is_true ~account ~txn_amount
           ~txn_global_slot
       in
-      Snarky_backendless.As_prover.read Account.Timing.typ timing
+      (min_balance, timing)
+
+    let make_checked_timing_computation account txn_amount txn_global_slot =
+      let%map _min_balance, timing =
+        checked_min_balance_and_timing account txn_amount txn_global_slot
+      in
+      timing
+
+    let make_checked_min_balance_computation account txn_amount txn_global_slot
+        =
+      let%map min_balance, _timing =
+        checked_min_balance_and_timing account txn_amount txn_global_slot
+      in
+      min_balance
+
+    let snarky_integer_of_bools bools =
+      let snarky_bools =
+        List.map bools ~f:(fun b ->
+            let open Tick.Boolean in
+            if b then true_ else false_ )
+      in
+      let bitstring_lsb =
+        Bitstring_lib.Bitstring.Lsb_first.of_list snarky_bools
+      in
+      Snarky_integer.Integer.of_bits ~m:Tick.m bitstring_lsb
 
     let run_checked_timing_and_compare account txn_amount txn_global_slot
-        unchecked_timing =
-      let checked_computation =
-        make_checked_computation account txn_amount txn_global_slot
+        unchecked_timing unchecked_min_balance =
+      let equal_balances_computation =
+        let open Snarky_backendless.Checked in
+        let%bind checked_timing =
+          make_checked_timing_computation account txn_amount txn_global_slot
+        in
+        (* check agreement of timings produced by checked, unchecked validations *)
+        let%bind () =
+          as_prover
+            As_prover.(
+              let%map checked_timing =
+                read Account.Timing.typ checked_timing
+              in
+              assert (Account.Timing.equal checked_timing unchecked_timing))
+        in
+        let%bind checked_min_balance =
+          make_checked_min_balance_computation account txn_amount
+            txn_global_slot
+        in
+        let%bind unchecked_min_balance_as_snarky_integer =
+          Run.make_checked (fun () ->
+              snarky_integer_of_bools (Balance.to_bits unchecked_min_balance)
+          )
+        in
+        let%map equal_balances_checked =
+          Run.make_checked (fun () ->
+              Snarky_integer.Integer.equal ~m checked_min_balance
+                unchecked_min_balance_as_snarky_integer )
+        in
+        Snarky_backendless.As_prover.read Tick.Boolean.typ
+          equal_balances_checked
       in
-      let (), checked_timing =
-        Or_error.ok_exn
-        @@ Snark_params.Tick.run_and_check checked_computation ()
+      let (), equal_balances =
+        Or_error.ok_exn @@ Tick.run_and_check equal_balances_computation ()
       in
-      Account.Timing.equal checked_timing unchecked_timing
+      equal_balances
 
     (* confirm the checked computation fails *)
     let checked_timing_should_fail account txn_amount txn_global_slot =
-      let checked_computation =
-        make_checked_computation account txn_amount txn_global_slot
+      let checked_timing_computation =
+        let%map checked_timing =
+          make_checked_timing_computation account txn_amount txn_global_slot
+        in
+        As_prover.read Account.Timing.typ checked_timing
       in
-      Or_error.is_error
-      @@ Snark_params.Tick.run_and_check checked_computation ()
+      Or_error.is_error @@ Tick.run_and_check checked_timing_computation ()
 
     let%test "before_cliff_time" =
       let pk = Public_key.Compressed.empty in
@@ -5750,11 +5802,14 @@ let%test_module "account timing check" =
         @@ Account.create_timed account_id balance ~initial_minimum_balance
              ~cliff_time ~vesting_period ~vesting_increment
       in
-      let timing = validate_timing ~txn_amount ~txn_global_slot ~account in
-      match timing with
-      | Ok (Timed _ as unchecked_timing) ->
+      let timing_with_min_balance =
+        validate_timing_with_min_balance ~txn_amount ~txn_global_slot ~account
+      in
+      match timing_with_min_balance with
+      | Ok ((Timed _ as unchecked_timing), `Min_balance unchecked_min_balance)
+        ->
           run_checked_timing_and_compare account txn_amount txn_global_slot
-            unchecked_timing
+            unchecked_timing unchecked_min_balance
       | _ ->
           false
 
@@ -5773,8 +5828,8 @@ let%test_module "account timing check" =
       in
       let txn_amount = Currency.Amount.of_int 100_000_000_000 in
       let txn_global_slot = Coda_numbers.Global_slot.of_int 1_900 in
-      let timing =
-        validate_timing ~account
+      let timing_with_min_balance =
+        validate_timing_with_min_balance ~account
           ~txn_amount:(Currency.Amount.of_int 100_000_000_000)
           ~txn_global_slot:(Coda_numbers.Global_slot.of_int 1_900)
       in
@@ -5782,10 +5837,11 @@ let%test_module "account timing check" =
           subtract 90 * 100 = 9,000 from init min balance of 10,000 to get 1000
           so we should still be timed
         *)
-      match timing with
-      | Ok (Timed _ as unchecked_timing) ->
+      match timing_with_min_balance with
+      | Ok ((Timed _ as unchecked_timing), `Min_balance unchecked_min_balance)
+        ->
           run_checked_timing_and_compare account txn_amount txn_global_slot
-            unchecked_timing
+            unchecked_timing unchecked_min_balance
       | _ ->
           false
 
@@ -5804,15 +5860,18 @@ let%test_module "account timing check" =
       in
       let txn_amount = Currency.Amount.of_int 100_000_000_000 in
       let txn_global_slot = Global_slot.of_int 2_000 in
-      let timing = validate_timing ~txn_amount ~txn_global_slot ~account in
+      let timing_with_min_balance =
+        validate_timing_with_min_balance ~txn_amount ~txn_global_slot ~account
+      in
       (* we're 2_000 - 1_000 = 1_000 slots past the cliff, which is 100 vesting periods
           subtract 100 * 100_000_000_000 = 10_000_000_000_000 from init min balance
           of 10_000_000_000 to get zero, so we should be untimed now
         *)
-      match timing with
-      | Ok (Untimed as unchecked_timing) ->
+      match timing_with_min_balance with
+      | Ok ((Untimed as unchecked_timing), `Min_balance unchecked_min_balance)
+        ->
           run_checked_timing_and_compare account txn_amount txn_global_slot
-            unchecked_timing
+            unchecked_timing unchecked_min_balance
       | _ ->
           false
 
@@ -5884,11 +5943,14 @@ let%test_module "account timing check" =
       (* fully vested, curr min balance = 0, so we can spend the whole balance *)
       let txn_amount = Currency.Amount.of_int 100_000_000_000_000 in
       let txn_global_slot = Global_slot.of_int 3000 in
-      let timing = validate_timing ~txn_amount ~txn_global_slot ~account in
-      match timing with
-      | Ok (Untimed as unchecked_timing) ->
+      let timing_with_min_balance =
+        validate_timing_with_min_balance ~txn_amount ~txn_global_slot ~account
+      in
+      match timing_with_min_balance with
+      | Ok ((Untimed as unchecked_timing), `Min_balance unchecked_min_balance)
+        ->
           run_checked_timing_and_compare account txn_amount txn_global_slot
-            unchecked_timing
+            unchecked_timing unchecked_min_balance
       | _ ->
           false
   end )


### PR DESCRIPTION
The timed account transaction unchecked/checked validators calculate a current minimum balance, in order to decide whether a transaction violates that minimum balance, and whether an account becomes untimed, in the case that min balance is 0.

The existing unit tests for the validators verified that the new timings agreed. This PR also compares the calculated minimum balances.

Many thanks to Matthew Ryan for help with getting the snarky-related code to run without error.

Part of #5993.