### PR TITLE
only lint helm charts defined within mina (skip coda-automation charts to prevent release

### DIFF
--- a/buildkite/scripts/helm-ci.sh
+++ b/buildkite/scripts/helm-ci.sh
@@ -22,6 +22,11 @@ if [ -n "$charts" ]; then
 
   if [ -n "${HELM_LINT+x}" ]; then
     for dir in $dirs; do
+      if [[ "$dir" =~ .*"coda-automation".* ]]; then
+        # do not lint charts contained within the coda-automation submodule
+        continue
+      fi
+
       echo "--- Linting: ${dir}"
       helm lint $dir
 
@@ -38,6 +43,11 @@ if [ -n "$charts" ]; then
     gsutil -m rsync ${CODA_CHART_REPO:-"gs://coda-charts/"} $syncDir
 
     for dir in $dirs; do
+      if [[ "$dir" =~ .*"coda-automation".* ]]; then
+        # do not release charts contained within the coda-automation submodule
+        continue
+      fi
+
       echo "--- Preparing chart for Release: ${dir}"
       helm package $dir --destination $stageDir
 

--- a/buildkite/scripts/helm-ci.sh
+++ b/buildkite/scripts/helm-ci.sh
@@ -15,6 +15,11 @@ charts=$(
   done
 )
 
+if [[ "$diff" =~ .*"helm-ci".* ]]; then
+  echo "--- Change to Helm CI script found. Executing against ALL repo charts!"
+  charts=$(find '.' -name 'Chart.yaml' || true)
+fi
+
 if [ -n "$charts" ]; then
   # filter duplicates
   charts=$(echo $charts | xargs -n1 | sort -u | xargs)
@@ -31,7 +36,7 @@ if [ -n "$charts" ]; then
       helm lint $dir
 
       echo "--- Executing dry-run: ${dir}"
-      helm install test $dir --dry-run --namespace default
+      helm install test $dir --dry-run --namespace test
     done
   fi
 

--- a/buildkite/src/Jobs/Lint/HelmChart.dhall
+++ b/buildkite/src/Jobs/Lint/HelmChart.dhall
@@ -20,7 +20,11 @@ in
 Pipeline.build
   Pipeline.Config::{
     spec = JobSpec::{
-      dirtyWhen = [ S.contains "helm/", S.strictlyStart (S.contains "buildkite/src/Jobs/Lint/HelmChart") ],
+      dirtyWhen = [
+        S.contains "helm/",
+        S.strictlyStart (S.contains "buildkite/src/Jobs/Lint/HelmChart"),
+        S.exactly "buildkite/scripts/helm-ci" "sh"
+      ],
       path = "Lint",
       name = "HelmChart"
     },

--- a/buildkite/src/Jobs/Release/HelmRelease.dhall
+++ b/buildkite/src/Jobs/Release/HelmRelease.dhall
@@ -23,7 +23,8 @@ Pipeline.build
       dirtyWhen = [
         S.contains "helm",
         S.strictly (S.contains "Chart.yaml"),
-        S.strictlyStart (S.contains "buildkite/src/Jobs/Release/HelmRelease")
+        S.strictlyStart (S.contains "buildkite/src/Jobs/Release/HelmRelease"),
+        S.exactly "buildkite/scripts/helm-ci" "sh"
       ],
       path = "Release",
       name = "HelmRelease"

--- a/buildkite/src/Jobs/Test/UnitTest.dhall
+++ b/buildkite/src/Jobs/Test/UnitTest.dhall
@@ -33,7 +33,8 @@ Pipeline.build
         S.strictlyStart (S.contains "src/nonconsensus"),
         S.strictly (S.contains "Makefile"),
         S.strictlyStart (S.contains "buildkite/src/Jobs/Test/UnitTest"),
-        S.exactly "scripts/link-coredumps" "sh"
+        S.exactly "scripts/link-coredumps" "sh",
+        S.exactly "buildkite/scripts/unit-test" "sh"
       ]
 
       in


### PR DESCRIPTION
Avoids processing Helm charts incorporated into the Mina repo via a *coda-automation* submodule since these charts are not designed/implemented for release.

**Test:** Buildkite CI

**Checklist:**

- [ ] All tests pass (CI will check this if you didn't)