### PR TITLE
update helm chart versions

### DIFF
--- a/buildkite/helm/buildkite-exporter/Chart.yaml
+++ b/buildkite/helm/buildkite-exporter/Chart.yaml
@@ -2,13 +2,14 @@ apiVersion: v2
 name: buildkite-exporter
 description: A Helm chart for O(1) Lab's Buildkite graphql exporter
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 icon: https://pbs.twimg.com/profile_images/968998928241733632/Rhxmu_9O_400x400.jpg
 keywords:
 - buildkite
 - prometheus exporter
 - graphql
+- mina
 home: https://o1labs.org/
 sources:
 - https://github.com/CodaProtocol

--- a/buildkite/scripts/helm-ci.sh
+++ b/buildkite/scripts/helm-ci.sh
@@ -64,7 +64,8 @@ if [ -n "$charts" ]; then
       fi
     done
 
-    cp --force --recursive "${stageDir}" "${syncDir}"
+    echo "--- Syncing staging and release dirs"
+    cp --force --recursive --verbose ${stageDir}/* ${syncDir}/
 
     helm repo index $syncDir
 

--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -10,12 +10,6 @@ fi
 profile=$1
 path=$2
 
-echo "--- CPU frequency info"
-lscpu | grep -i hz
-
-echo "--- CPU general info"
-cat /proc/cpuinfo
-
 source ~/.profile
 
 echo "--- Make build"

--- a/buildkite/src/Jobs/Release/BotArtifact.dhall
+++ b/buildkite/src/Jobs/Release/BotArtifact.dhall
@@ -41,7 +41,7 @@ Pipeline.build
           commands = [
               Cmd.run "echo export CODA_VERSION=$(cat frontend/bot/package.json | jq '.version') > BOT_DEPLOY_ENV && buildkite/scripts/buildkite-artifact-helper.sh BOT_DEPLOY_ENV"
           ],
-          label = "Setup Mina's bot docker image deploy environment",
+          label = "Setup o1bot docker image deploy environment",
           key = "setup-deploy-env",
           target = Size.Small,
           artifact_paths = [ S.contains "frontend/bot/*.json" ]

--- a/buildkite/src/Jobs/Release/HelmRelease.dhall
+++ b/buildkite/src/Jobs/Release/HelmRelease.dhall
@@ -32,7 +32,7 @@ Pipeline.build
     steps = [
       Command.build
         Command.Config::{
-          commands = [ Cmd.run "HELM_RELEASE=true buildkite/scripts/helm-ci.sh" ]
+          commands = [ Cmd.run "HELM_RELEASE=true AUTO_DEPLOY=true buildkite/scripts/helm-ci.sh" ]
           , label = "Helm chart release"
           , key = "release-helm-chart"
           , target = Size.Medium

--- a/buildkite/src/Jobs/Release/HelmRelease.dhall
+++ b/buildkite/src/Jobs/Release/HelmRelease.dhall
@@ -32,7 +32,7 @@ Pipeline.build
     steps = [
       Command.build
         Command.Config::{
-          commands = [ Cmd.run "HELM_RELEASE=true AUTO_DEPLOY=true buildkite/scripts/helm-ci.sh" ]
+          commands = [ Cmd.run "HELM_RELEASE=true buildkite/scripts/helm-ci.sh" ]
           , label = "Helm chart release"
           , key = "release-helm-chart"
           , target = Size.Medium

--- a/buildkite/src/Jobs/Release/LeaderboardArtifact.dhall
+++ b/buildkite/src/Jobs/Release/LeaderboardArtifact.dhall
@@ -41,7 +41,7 @@ Pipeline.build
           commands = [
               Cmd.run "echo export CODA_VERSION=$(cat frontend/leaderboard/package.json | jq '.version') > LEADERBOARD_DEPLOY_ENV && buildkite/scripts/buildkite-artifact-helper.sh LEADERBOARD_DEPLOY_ENV"
           ],
-          label = "Setup Mina's Leaderboard docker image deploy environment",
+          label = "Setup Leaderboard docker image deploy environment",
           key = "setup-deploy-env",
           target = Size.Small,
           artifact_paths = [ S.contains "frontend/leaderboard/package.json" ]

--- a/frontend/bot/helm/Chart.yaml
+++ b/frontend/bot/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: o1-bot
 description: A Helm chart for Coda Protocol's O(1) role-based testnet service bots
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.1
 icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/static/img/coda-logo@3x.png
 keywords:
@@ -10,6 +10,8 @@ keywords:
 - faucet
 - echo
 - community
+- mina
+- testnet
 home: https://codaprotocol.com/
 sources:
 - https://github.com/CodaProtocol

--- a/frontend/leaderboard/helm/Chart.yaml
+++ b/frontend/leaderboard/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: leaderboard
 description: A Helm chart for Coda Protocol's Testnet leaderboard service
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: 1.16.0
 icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/static/img/coda-logo@3x.png
 keywords:
@@ -10,6 +10,8 @@ keywords:
 - testnet
 - leaderboard
 - points
+- mina
+- testnet
 home: https://codaprotocol.com/
 sources:
 - https://github.com/CodaProtocol/coda/tree/develop/frontend/leaderboard

--- a/helm/archive-node/Chart.yaml
+++ b/helm/archive-node/Chart.yaml
@@ -12,6 +12,8 @@ icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/
 keywords:
 - archive
 - postgres
+- mina
+- testnet
 home: https://codaprotocol.com/
 sources:
 - https://github.com/CodaProtocol/coda/tree/develop/src/app/archive

--- a/helm/block-producer/Chart.yaml
+++ b/helm/block-producer/Chart.yaml
@@ -10,6 +10,8 @@ keywords:
 - block-producer
 - stake
 - delegate
+- mina
+- testnet
 home: https://codaprotocol.com/
 sources:
 - https://github.com/CodaProtocol/coda/tree/develop/src/lib/block_producer

--- a/helm/seed-node/Chart.yaml
+++ b/helm/seed-node/Chart.yaml
@@ -8,6 +8,8 @@ dependencies:
 icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/static/img/coda-logo@3x.png
 keywords:
 - seed
+- mina
+- testnet
 home: https://codaprotocol.com/
 sources:
 - https://github.com/CodaProtocol/coda

--- a/helm/snark-worker/Chart.yaml
+++ b/helm/snark-worker/Chart.yaml
@@ -9,6 +9,8 @@ icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/
 keywords:
 - snarks
 - zero-knowledge
+- mina
+- testnet
 home: https://codaprotocol.com/
 sources:
 - https://github.com/CodaProtocol/coda/tree/develop/src/lib/snark_worker


### PR DESCRIPTION
Release latest versions of Helm charts to the GCS hosted *coda-charts* repo.

**Test:** Buildkite CI

**Checklist:**
- [ ] All tests pass (CI will check this if you didn't)
