### PR TITLE
remove exit on verifier failure

### DIFF
--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -61,6 +61,7 @@ module Staged_ledger_error : sig
         * Transaction_snark.Statement.t
         * Coda_base.Sok_message.t )
         list
+    | Couldn't_reach_verifier of Error.t
     | Pre_diff of Pre_diff_info.Error.t
     | Insufficient_work of string
     | Unexpected of Error.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -55,7 +55,9 @@ module Make_statement_scanner
         type t
 
         val verify :
-          verifier:t -> Ledger_proof_with_sok_message.t list -> sexp_bool M.t
+             verifier:t
+          -> Ledger_proof_with_sok_message.t list
+          -> sexp_bool M.Or_error.t
     end) : sig
   val scan_statement :
        constraint_constants:Genesis_constants.Constraint_constants.t

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -62,11 +62,11 @@ let handle_validation_error ~logger ~trust_system ~sender ~state_hash ~delta
   match error with
   | `Verifier_error err ->
       let error_metadata = [("error", `String (Error.to_string_hum err))] in
-      [%log fatal]
+      [%log error]
         ~metadata:
           (error_metadata @ [("state_hash", State_hash.to_yojson state_hash)])
         "Error in verifier verifying blockchain proof for $state_hash: $error" ;
-      exit 21
+      Deferred.unit
   | `Invalid_proof ->
       punish Sent_invalid_proof None
   | `Invalid_delta_transition_chain_proof ->


### PR DESCRIPTION
We currently exit if we can't contact the verifier. This PR makes it so we log the failure but do not exit.