### PR TITLE
Rename NetworkPeer GraphQL type

### DIFF
--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -1238,7 +1238,7 @@ module Types = struct
 
   module Payload = struct
     let peer : ('context, Network_peer.Peer.t option) typ =
-      obj "NetworkPeer" ~fields:(fun _ ->
+      obj "NetworkPeerPayload" ~fields:(fun _ ->
           [ field "peer_id" ~doc:"base58-encoded peer ID" ~typ:(non_null string)
               ~args:Arg.[]
               ~resolve:(fun _ peer -> peer.Network_peer.Peer.peer_id)


### PR DESCRIPTION
We mustn't use the same name for multiple types. This fixes #6474.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: