### PR TITLE
Consider timed balance in the transaction pool

### DIFF
--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -131,6 +131,9 @@ val revalidate :
      (** Lookup an account in the new ledger *)
   -> t * Transaction_hash.User_command_with_valid_signature.t Sequence.t
 
+(** Get the current global slot according to the pool's time controller. *)
+val current_global_slot : t -> Coda_numbers.Global_slot.t
+
 module For_tests : sig
   (** Checks the invariants of the data structure. If this throws an exception
       there is a bug. *)

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -326,9 +326,9 @@ struct
           ; vesting_period
           ; vesting_increment } ->
           Currency.Balance.sub_amount account.balance
-            (Currency.Amount.of_balance Account.min_balance_at_slot
-               ~global_slot ~cliff_time ~vesting_period ~vesting_increment
-               ~initial_minimum_balance)
+            (Currency.Balance.to_amount
+               (Account.min_balance_at_slot ~global_slot ~cliff_time
+                  ~vesting_period ~vesting_increment ~initial_minimum_balance))
 
     let handle_transition_frontier_diff
         ( ({new_commands; removed_commands; reorg_best_tip= _} :

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -329,6 +329,7 @@ struct
             (Currency.Balance.to_amount
                (Account.min_balance_at_slot ~global_slot ~cliff_time
                   ~vesting_period ~vesting_increment ~initial_minimum_balance))
+          |> Option.value ~default:Currency.Balance.zero
 
     let handle_transition_frontier_diff
         ( ({new_commands; removed_commands; reorg_best_tip= _} :

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -318,8 +318,10 @@ struct
           ; cliff_time
           ; vesting_period
           ; vesting_increment } ->
-          Account.min_balance_at_slot ~global_slot ~cliff_time ~vesting_period
-            ~vesting_increment ~initial_minimum_balance
+          Currency.Balance.sub_amount account.balance
+            (Currency.Amount.of_balance Account.min_balance_at_slot
+               ~global_slot ~cliff_time ~vesting_period ~vesting_increment
+               ~initial_minimum_balance)
 
     let handle_transition_frontier_diff
         ( ({new_commands; removed_commands; reorg_best_tip= _} :


### PR DESCRIPTION
This PR uses the timed balance instead of the maximum balance when considering whether transactions are valid to include in the pool.

This likely would have prevented the issue that stalled the current testnet.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: