### PR TITLE
Transaction pool rejected command, structured log

### DIFF
--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -5,6 +5,6 @@
  (library_flags -linkall)
  (libraries async core one_or_two pipe_lib quickcheck_lib verifier coda_base ledger_proof transaction_snark transition_frontier consensus coda_numbers)
  (preprocessor_deps "../../config.mlh")
- (preprocess (pps ppx_base ppx_coda ppx_version ppx_let ppx_assert ppx_pipebang ppx_deriving.std ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv bisect_ppx --conditional))
+ (preprocess (pps ppx_base ppx_coda ppx_version ppx_register_event ppx_let ppx_assert ppx_pipebang ppx_deriving.std ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv bisect_ppx --conditional))
  (synopsis
    "Network pool is an interface that processes incoming diffs and then broadcasts them"))

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -112,6 +112,13 @@ module Diff_versioned = struct
   let is_empty t = List.is_empty t
 end
 
+type Structured_log_events.t +=
+  | Rejecting_command_for_reason of
+      { command: User_command.t
+      ; reason: Diff_versioned.Diff_error.t
+      ; error_extra: (string * Yojson.Safe.t) list }
+  [@@deriving register_event {msg= "Rejecting command because: $reason"}]
+
 module type S = sig
   open Intf
 
@@ -1047,19 +1054,15 @@ struct
                                     .Unwanted_fee_token )
                                   :: rejected )
                           | Error err ->
-                              let diff_err, err_extra =
+                              let diff_err, error_extra =
                                 of_indexed_pool_error err
                               in
                               if is_sender_local then
-                                [%log' error t.logger]
-                                  "rejecting $cmd because of $reason. \
-                                   ($error_extra)"
-                                  ~metadata:
-                                    [ ("cmd", User_command.to_yojson tx)
-                                    ; ( "reason"
-                                      , Diff_versioned.Diff_error.to_yojson
-                                          diff_err )
-                                    ; ("error_extra", `Assoc err_extra) ] ;
+                                [%str_log' error t.logger]
+                                  (Rejecting_command_for_reason
+                                     { command= tx
+                                     ; reason= diff_err
+                                     ; error_extra }) ;
                               let%bind _ =
                                 trust_record
                                   ( Trust_system.Actions.Sent_useless_gossip
@@ -1068,8 +1071,8 @@ struct
                                          ($error_extra)"
                                       , [ ("cmd", User_command.to_yojson tx)
                                         ; ("reason", yojson_fail_reason err)
-                                        ; ("error_extra", `Assoc err_extra) ]
-                                      ) )
+                                        ; ("error_extra", `Assoc error_extra)
+                                        ] ) )
                               in
                               go txs'' pool
                                 (accepted, (tx, diff_err) :: rejected) )


### PR DESCRIPTION
Use a structured log for commands that are rejected from the transaction pool. That will make it easier to write integration tests that look for rejected commands with a particular failure.