### PR TITLE
libp2p fix

### DIFF
--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -347,7 +347,7 @@ module Helper = struct
     end
 
     module Validation_complete = struct
-      type input = {seqno: int; action: string} [@@deriving yojson]
+      type input = {seqno: int; is_valid: string} [@@deriving yojson]
 
       type output = string [@@deriving yojson]
 
@@ -815,7 +815,7 @@ module Helper = struct
               do_rpc t
                 (module Rpcs.Validation_complete)
                 { seqno
-                ; action=
+                ; is_valid=
                     ( match action with
                     | `Accept ->
                         "accept"


### PR DESCRIPTION
This fixes a mismatch between the ocaml and go sides of the libp2p helper which was causing message validation to not work.