### PR TITLE
Attempt to fix a bug in block production

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -860,6 +860,9 @@ module Data = struct
                                  [ Coda_base.(
                                      Account_id.create
                                        (Public_key.compress public_key)
+                                       Token_id.default)
+                                 ; Coda_base.(
+                                     Account_id.create account.public_key
                                        Token_id.default) ]
                                  epoch_snapshot.ledger }
                        ; global_slot


### PR DESCRIPTION
Hoping will fix the following bug on q/a nets:

```
!!! (monitor.ml.Error Not_found
 ("Raised at file \"src/list.ml\" (inlined), line 838, characters 14-34"
  "Called from file \"src/lib/sparse_ledger_lib/sparse_ledger.ml\", line 199, characters 4-61"
  "Called from file \"src/lib/coda_base/sparse_ledger.ml\", line 613, characters 12-39"
  "Called from file \"src/lib/staged_ledger/staged_ledger.ml\", line 1666, characters 4-133"
  "Called from file \"src/lib/block_producer/block_producer.ml\", line 131, characters 8-112"
  "Called from file \"src/lib/block_producer/block_producer.ml\", line 400, characters 14-354"
  "Called from file \"src/lib/interruptible/interruptible.ml\", line 24, characters 23-26"```

Trying on a Q/A net now, hopefully will fix the error

Update: confirmed this is a fix on a q/a net