### PR TITLE
lower default slot time to 2 minutes

### DIFF
--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -17,7 +17,7 @@
 
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
-[%%define block_window_duration 180000]
+[%%define block_window_duration 120000]
 
 [%%define integration_tests true]
 [%%define force_updates false]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -25,7 +25,7 @@
 [%%define genesis_ledger "testnet_postake"]
 
 [%%define genesis_state_timestamp "2020-09-16 03:15:00-07:00"]
-[%%define block_window_duration 180000]
+[%%define block_window_duration 120000]
 
 [%%define integration_tests false]
 [%%define force_updates false]

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -332,7 +332,7 @@ end
       , "c": 8
       , "ledger_depth": 14
       , "work_delay": 2
-      , "block_window_duration_ms": 180000
+      , "block_window_duration_ms": 120000
       , "transaction_capacity": {"txns_per_second_x10": 2}
       , "coinbase_amount": "200"
       , "supercharged_coinbase_factor": 2


### PR DESCRIPTION
The new snark lowers the snark production time on q/a nets from ~120-150 seconds to 55 seconds. This PR lowers the slot time given that. We may be able to lower even further once we know the block gossip time for our network.