### PR TITLE
Let "best tip" rpc timeout when starting up

### DIFF
--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -73,6 +73,7 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
             persistent_frontier_instance root_identifier
         with
       | Ok () ->
+          [%log info] "Fast forward successful" ;
           Ok ()
       | Error `Sync_cannot_be_running ->
           Error (`Failure "sync job is already running on persistent frontier")
@@ -100,6 +101,7 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
           | `Failure _ as err ->
               err ))
   in
+  [%log info] "Loaded full frontier and extensions" ;
   let%map () =
     Deferred.return
       ( Persistent_frontier.Instance.start_sync

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -163,7 +163,7 @@ let download_best_tip ~logger ~network ~verifier ~trust_system
   [%log debug]
     ~metadata:
       [("actual", `Int (List.length tips)); ("expected", `Int num_peers)]
-    "Finished requesting tips. Got $actual / $expected " ;
+    "Finished requesting tips. Got $actual / $expected" ;
   List.fold tips ~init:None ~f:(fun acc enveloped_candidate_best_tip ->
       Option.merge acc (Option.return enveloped_candidate_best_tip)
         ~f:(fun enveloped_existing_best_tip enveloped_candidate_best_tip ->

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -106,21 +106,32 @@ let start_bootstrap_controller ~logger ~trust_system ~verifier ~network
 let download_best_tip ~logger ~network ~verifier ~trust_system
     ~most_recent_valid_block_writer ~genesis_constants ~precomputed_values =
   let num_peers = 8 in
+  let with_timeout d =
+    Deferred.any
+      [ d
+      ; ( after (Time_ns.Span.of_sec 60.)
+        >>| fun _ -> Or_error.error_string "timed out" ) ]
+  in
   let%bind peers = Coda_networking.random_peers network num_peers in
   [%log info] "Requesting peers for their best tip to do initialization" ;
-  let open Deferred.Option.Let_syntax in
-  let%map best_tip =
-    Deferred.List.fold peers ~init:None ~f:(fun acc peer ->
+  let%map tips =
+    Deferred.List.filter_map ~how:`Parallel peers ~f:(fun peer ->
         let open Deferred.Let_syntax in
-        match%bind Coda_networking.get_best_tip network peer with
+        match%bind
+          with_timeout (Coda_networking.get_best_tip network peer)
+        with
         | Error e ->
             [%log debug]
               ~metadata:
                 [ ("peer", Network_peer.Peer.to_yojson peer)
                 ; ("error", `String (Error.to_string_hum e)) ]
               "Couldn't get best tip from peer: $error" ;
-            return acc
+            return None
         | Ok peer_best_tip -> (
+            [%log debug]
+              ~metadata:[("peer", Network_peer.Peer.to_yojson peer)]
+              "Successfully downloaded best tip from $peer" ;
+            (* TODO: Use batch verification instead *)
             match%bind
               Best_tip_prover.verify ~verifier peer_best_tip ~genesis_constants
                 ~precomputed_values
@@ -139,45 +150,47 @@ let download_best_tip ~logger ~network ~verifier ~trust_system
                         , Some ("Peer sent us bad proof for their best tip", [])
                         ))
                 in
-                acc
+                None
             | Ok (`Root _, `Best_tip candidate_best_tip) ->
-                let enveloped_candidate_best_tip =
-                  Envelope.Incoming.wrap_peer ~data:candidate_best_tip
-                    ~sender:peer
-                in
+                [%log debug]
+                  ~metadata:[("peer", Network_peer.Peer.to_yojson peer)]
+                  "Successfully verified best tip from $peer" ;
                 return
-                @@ Option.merge acc
-                     (Option.return enveloped_candidate_best_tip)
-                     ~f:(fun enveloped_existing_best_tip
-                        enveloped_candidate_best_tip
-                        ->
-                       let candidate_best_tip =
-                         Envelope.Incoming.data enveloped_candidate_best_tip
-                       in
-                       let existing_best_tip =
-                         Envelope.Incoming.data enveloped_existing_best_tip
-                       in
-                       Coda_networking.fill_first_received_message_signal
-                         network ;
-                       if
-                         External_transition.Initial_validated.compare
-                           candidate_best_tip existing_best_tip
-                         > 0
-                       then (
-                         let best_tip_length =
-                           External_transition.Initial_validated
-                           .blockchain_length candidate_best_tip
-                           |> Coda_numbers.Length.to_int
-                         in
-                         Coda_metrics.Transition_frontier
-                         .update_max_blocklength_observed best_tip_length ;
-                         don't_wait_for
-                         @@ Broadcast_pipe.Writer.write
-                              most_recent_valid_block_writer candidate_best_tip ;
-                         enveloped_candidate_best_tip )
-                       else enveloped_existing_best_tip ) ) )
+                  (Some
+                     (Envelope.Incoming.wrap_peer ~data:candidate_best_tip
+                        ~sender:peer)) ) )
   in
-  best_tip
+  [%log debug]
+    ~metadata:
+      [("actual", `Int (List.length tips)); ("expected", `Int num_peers)]
+    "Finished requesting tips. Got $actual / $expected " ;
+  List.fold tips ~init:None ~f:(fun acc enveloped_candidate_best_tip ->
+      Option.merge acc (Option.return enveloped_candidate_best_tip)
+        ~f:(fun enveloped_existing_best_tip enveloped_candidate_best_tip ->
+          let candidate_best_tip =
+            Envelope.Incoming.data enveloped_candidate_best_tip
+          in
+          let existing_best_tip =
+            Envelope.Incoming.data enveloped_existing_best_tip
+          in
+          Coda_networking.fill_first_received_message_signal network ;
+          if
+            External_transition.Initial_validated.compare candidate_best_tip
+              existing_best_tip
+            > 0
+          then (
+            let best_tip_length =
+              External_transition.Initial_validated.blockchain_length
+                candidate_best_tip
+              |> Coda_numbers.Length.to_int
+            in
+            Coda_metrics.Transition_frontier.update_max_blocklength_observed
+              best_tip_length ;
+            don't_wait_for
+            @@ Broadcast_pipe.Writer.write most_recent_valid_block_writer
+                 candidate_best_tip ;
+            enveloped_candidate_best_tip )
+          else enveloped_existing_best_tip ) )
 
 let load_frontier ~logger ~verifier ~persistent_frontier ~persistent_root
     ~consensus_local_state ~precomputed_values =
@@ -186,6 +199,7 @@ let load_frontier ~logger ~verifier ~persistent_frontier ~persistent_root
       ~persistent_root ~persistent_frontier ~precomputed_values ()
   with
   | Ok frontier ->
+      [%log info] "Successfully loaded frontier" ;
       Some frontier
   | Error `Persistent_frontier_malformed ->
       failwith


### PR DESCRIPTION
Currently on pickles-public nodes are taking a very long time after starting to resume normal operation. 

I believe the ultimate cause of this is before starting normal operation, we wait for both the loading of the on-disk frontier, and getting the "best tip" from 8 of our peers.

I have been observing a node for the past 45min or so after restarting. We log when both of the above have finished and we also log when a request errors out. From the observed logging behavior we can deduce

- It is not the case that both the on-disk frontier is loaded and all requests have finished
- 1 out of 8 requests errored out (so far) because no heartbeats were received on the rpc connection for 30s 

It does not seem possible to know (from logs at least) whether finishing is blocked on the on-disk frontier being loaded or the rpc requests not being filled, but my bet would be on the rpc requests.

# What this PR does

This PR adds logs to disambiguate the above situation, and adds a timeout to all the rpc requests, so that we do not block starting up indefinitely. 

# Further questions

If indeed finishing is blocked on the rpc requests finishing, and rpc requests error out if there are no heartbeats for 30s, we have the strange state of affairs that both

- some connection is providing heartbeats at least every 30s
- a request on that connection is not fulfilled after 45 minutes

And it should be investigated why that is happening, if indeed it is.