### PR TITLE
Transaction pool, log memory use

### DIFF
--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -511,9 +511,12 @@ struct
       [%log' debug t.logger]
         "OCaml reachable words for the current transaction pool"
         ~metadata:
-          [ ("reachable_words", `Int pool_reachable_words)
-          ; ( "words_per_transaction"
-            , `Int (pool_reachable_words / Indexed_pool.size pool'') ) ] ;
+          (let size = Indexed_pool.size pool'' in
+           if Int.equal size 0 then
+             [("reachable_words_no_txns", `Int pool_reachable_words)]
+           else
+             [ ("reachable_words", `Int pool_reachable_words)
+             ; ("words_per_transaction", `Int (pool_reachable_words / size)) ]) ;
       t.pool <- pool'' ;
       List.iter locally_generated_dropped ~f:(fun cmd ->
           (* If the dropped transaction was included in the winning chain, it'll

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -507,6 +507,13 @@ struct
           %i commands during backtracking to maintain max size."
         (Indexed_pool.size t.pool) (Indexed_pool.size pool'')
         (Sequence.length dropped_backtrack) ;
+      let pool_reachable_words = Obj.reachable_words @@ Obj.repr pool'' in
+      [%log' debug t.logger]
+        "OCaml reachable words for the current transaction pool"
+        ~metadata:
+          [ ("reachable_words", `Int pool_reachable_words)
+          ; ( "words_per_transaction"
+            , `Int (pool_reachable_words / Indexed_pool.size pool'') ) ] ;
       t.pool <- pool'' ;
       List.iter locally_generated_dropped ~f:(fun cmd ->
           (* If the dropped transaction was included in the winning chain, it'll


### PR DESCRIPTION
Add a `debug` log to the transaction pool to show memory use after updates. It shows the reachable words, and the number of words per transaction.

Once we have a sense of the memory usage, we should delete this log, because it takes some time to traverse the OCaml memory blocks.