### PR TITLE
turn up block-window-duration for test-archive-processor profile

### DIFF
--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -17,7 +17,7 @@
 
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
-[%%define block_window_duration 600]
+[%%define block_window_duration 2000]
 
 [%%define integration_tests true]
 [%%define force_updates false]


### PR DESCRIPTION
The archive unit test  failure that we saw recently on circleci and buildkite is because the block_window_duration is too short.
The block_window_duration was 600 ms, which means 1 min = 100 slots. And initialization takes about 1 min, so the first block produced  by the block producer would definitely pass the first epoch.
