### PR TITLE
Fix for get some extra peers

### DIFF
--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -1142,9 +1142,9 @@ let list_peers net =
   | Error _ ->
       []
 
-let configure net ~logger ~me ~external_maddr ~maddrs ~network_id ~on_new_peer
-    ~unsafe_no_trust_ip ~flooding ~direct_peers ~peer_exchange ~seed_peers
-    ~initial_gating_config =
+let configure net ~logger:_ ~me ~external_maddr ~maddrs ~network_id
+    ~on_new_peer ~unsafe_no_trust_ip ~flooding ~direct_peers ~peer_exchange
+    ~seed_peers ~initial_gating_config =
   net.Helper.new_peer_callback
   <- Some
        (fun peer_id peer_addrs ->

--- a/src/lib/coda_net2/coda_net2.mli
+++ b/src/lib/coda_net2/coda_net2.mli
@@ -206,6 +206,7 @@ type connection_gating =
 *)
 val configure :
      net
+  -> logger:Logger.t
   -> me:Keypair.t
   -> external_maddr:Multiaddr.t
   -> maddrs:Multiaddr.t list

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -1073,7 +1073,10 @@ let create (config : Config.t)
                           "could not get initial peers from $peer with $error" ;
                         [] )
               in
-              [%log info] "Getting some extra initial peers to start" ;
+              [%log info]
+                ~metadata:
+                  [("peers", [%to_yojson: Peer.t list] extra_initial_peers)]
+                "Got extra $peers" ;
               Deferred.List.iter ~how:`Sequential extra_initial_peers
                 ~f:(fun p ->
                   match%map Gossip_net.Any.add_peer gossip_net p with

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -137,9 +137,10 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
             Throttle.create ~max_concurrent_jobs:1 ~continue_on_error:true
           in
           let initializing_libp2p_result : _ Deferred.Or_error.t =
+            [%log' debug config.logger] "(Re)initializing libp2p result" ;
             let open Deferred.Or_error.Let_syntax in
             let%bind () =
-              configure net2 ~me
+              configure net2 ~me ~logger:config.logger
                 ~maddrs:
                   [ Multiaddr.of_string
                       (sprintf "/ip4/0.0.0.0/tcp/%d"
@@ -172,6 +173,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                           config.initial_peers
                     ; isolate= config.isolate }
                 ~on_new_peer:(fun _ ->
+                  [%log' trace config.logger] "Fired on_new_peer callback" ;
                   Ivar.fill_if_empty first_peer_ivar () ;
                   if !ctr < 4 then incr ctr
                   else Ivar.fill_if_empty high_connectivity_ivar () ;


### PR DESCRIPTION
Probably fixes our broken metric too

Tested locally using `scripts/run_local_network.sh`

```
{"timestamp":"2020-10-29 00:03:17.141612Z","level":"Info","source":{"module":"Coda_networking","location":"File \"src/lib/coda_networking/coda_networking.ml\", line 1076, characters 14-25"},"message":"Got extra $peers","metadata":{"host":"213.149.61.129","peer_id":"12D3KooWRUFRrozfqgXmiRkxE12GcQNWPiJFh9ewtFBFVgrkcNCc","peers":[{"host":"192.168.1.6","peer_id":"12D3KooWPNXP6VeajCXsCuyUZTXSzKQbw7r2j2BLJGLzanwnGWoU","libp2p_port":5007},{"host":"192.168.1.6","peer_id":"12D3KooWAoB9tp8qVvRce2uTQQRfhU3EG9twk9TmLD9ZE2KX9gqK","libp2p_port":6007},{"host":"127.0.0.1","peer_id":"12D3KooWRUFRrozfqgXmiRkxE12GcQNWPiJFh9ewtFBFVgrkcNCc","libp2p_port":4007}],"pid":8770,"port":4007}}
```