### PR TITLE
Best tip logs in a different file

### DIFF
--- a/dockerfiles/Dockerfile-coda-daemon
+++ b/dockerfiles/Dockerfile-coda-daemon
@@ -35,10 +35,11 @@ RUN echo '#!/bin/bash -x\n\
 mkdir -p .coda-config\n\
 touch .coda-config/coda-prover.log\n\
 touch .coda-config/coda-verifier.log\n\
+touch .coda-config/mina-best-tip.log\n\
 while true; do\n\
   coda "$@" 2>&1 >coda.log &\n\
   coda_pid=$!\n\
-  tail -q -f coda.log -f .coda-config/coda-prover.log -f .coda-config/coda-verifier.log &\n\
+  tail -q -f coda.log -f .coda-config/coda-prover.log -f .coda-config/coda-verifier.log -f .coda-config/mina-best-tip.log &\n\
   tail_pid=$!\n\
   wait "$coda_pid"\n\
   echo "Coda process exited with status code $?"\n\

--- a/dockerfiles/coda_daemon_puppeteer.py
+++ b/dockerfiles/coda_daemon_puppeteer.py
@@ -91,10 +91,11 @@ if __name__ == '__main__':
   Path('coda.log').touch()
   Path('.coda-config/coda-prover.log').touch()
   Path('.coda-config/coda-verifier.log').touch()
+  Path('.coda-config/mina-best-tip.log').touch()
 
   # currently does not handle tail process dying
   tail_process = subprocess.Popen(
-      ['tail', '-q', '-f', 'coda.log', '-f', '.coda-config/coda-prover.log', '-f', '.coda-config/coda-verifier.log']
+      ['tail', '-q', '-f', 'coda.log', '-f', '.coda-config/coda-prover.log', '-f', '.coda-config/coda-verifier.log', '-f' , '.coda-config/mina-best-tip.log']
   )
 
   start_daemon()

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -295,6 +295,12 @@ let setup_daemon logger =
       ~transport:
         (Logger.Transport.File_system.dumb_logrotate ~directory:conf_dir
            ~log_filename:"coda.log" ~max_size:logrotate_max_size) ;
+    let best_tip_diff_log_size = 1024 * 1024 * 5 in
+    Logger.Consumer_registry.register ~id:"best_tip_diff"
+      ~processor:(Logger.Processor.raw ())
+      ~transport:
+        (Logger.Transport.File_system.dumb_logrotate ~directory:conf_dir
+           ~log_filename:"mina-best-tip.log" ~max_size:best_tip_diff_log_size) ;
     [%log info]
       "Coda daemon is booting up; built with commit $commit on branch $branch"
       ~metadata:

--- a/src/lib/logger/impl.ml
+++ b/src/lib/logger/impl.ml
@@ -410,6 +410,8 @@ module Structured = struct
   let fatal = log ~level:Fatal
 
   let faulty_peer_without_punishment = log ~level:Faulty_peer
+
+  let best_tip_diff = log ~level:Spam ~module_:"" ~location:""
 end
 
 module Str = Structured

--- a/src/lib/logger/impl.mli
+++ b/src/lib/logger/impl.mli
@@ -175,6 +175,13 @@ module Structured : sig
   val fatal : log_function
 
   val faulty_peer_without_punishment : log_function
+
+  val best_tip_diff :
+       t
+    -> ?tags:Tags.t list
+    -> ?metadata:(string, Yojson.Safe.t) List.Assoc.t
+    -> Structured_log_events.t
+    -> unit
 end
 
 (** Short alias for Structured. *)

--- a/src/lib/ppx_coda/log.ml
+++ b/src/lib/ppx_coda/log.ml
@@ -41,7 +41,7 @@ module Make (Info : Ppxinfo) = struct
       Info.logger_module ^ "." ^ level_name |> Longident.parse
     in
     let log_level_expr = pexp_ident (Located.mk log_level_id) in
-    (* spam logs don't contain module, location *)
+    (* spam and best_tip_diff logs don't contain module, location *)
     if
       String.equal level_name "spam" || String.equal level_name "best_tip_diff"
     then [%expr [%e log_level_expr] [%e logger]]

--- a/src/lib/ppx_coda/log.ml
+++ b/src/lib/ppx_coda/log.ml
@@ -42,8 +42,9 @@ module Make (Info : Ppxinfo) = struct
     in
     let log_level_expr = pexp_ident (Located.mk log_level_id) in
     (* spam logs don't contain module, location *)
-    if String.equal level_name "spam" then
-      [%expr [%e log_level_expr] [%e logger]]
+    if
+      String.equal level_name "spam" || String.equal level_name "best_tip_diff"
+    then [%expr [%e log_level_expr] [%e logger]]
     else
       [%expr
         [%e log_level_expr] [%e logger] ~module_:__MODULE__ ~location:__LOC__]

--- a/src/lib/transition_frontier/extensions/best_tip_diff.ml
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.ml
@@ -13,10 +13,9 @@ module T = struct
   module Log_event = struct
     type t =
       { protocol_state: Coda_state.Protocol_state.Value.t
+      ; state_hash: State_hash.t
       ; just_emitted_a_proof: bool }
     [@@deriving yojson]
-
-    type best_tip_log_line = State_hash.t * State_hash.t [@@deriving yojson]
 
     type Structured_log_events.t +=
       | New_best_tip_event of
@@ -86,17 +85,27 @@ module T = struct
               let reorg_best_tip =
                 not (List.is_empty removed_from_best_tip_path)
               in
-              let added_transitions, added_states =
+              let added_transitions =
                 List.map
                   ~f:(fun b ->
-                    let protocol_state = Breadcrumb.protocol_state b in
-                    let state_hash = Breadcrumb.state_hash b in
-                    ( { Log_event.protocol_state
-                      ; just_emitted_a_proof= Breadcrumb.just_emitted_a_proof b
-                      }
-                    , (protocol_state.previous_state_hash, state_hash) ) )
+                    { Log_event.protocol_state= Breadcrumb.protocol_state b
+                    ; state_hash= Breadcrumb.state_hash b
+                    ; just_emitted_a_proof= Breadcrumb.just_emitted_a_proof b
+                    } )
                   added_to_best_tip_path
-                |> List.unzip
+              in
+              let removed_transitions =
+                List.map
+                  ~f:(fun b ->
+                    { Log_event.protocol_state= Breadcrumb.protocol_state b
+                    ; state_hash= Breadcrumb.state_hash b
+                    ; just_emitted_a_proof= Breadcrumb.just_emitted_a_proof b
+                    } )
+                  removed_from_best_tip_path
+              in
+              let event =
+                Log_event.New_best_tip_event
+                  {added_transitions; removed_transitions; reorg_best_tip}
               in
               [%str_log' debug t.logger]
                 ~metadata:
@@ -104,24 +113,8 @@ module T = struct
                     , `Int (List.length added_to_best_tip_path) )
                   ; ( "no_of_removed_breadcrumbs"
                     , `Int (List.length removed_from_best_tip_path) ) ]
-                (Log_event.New_best_tip_event
-                   { added_transitions
-                   ; removed_transitions=
-                       List.map
-                         ~f:(fun b ->
-                           { Log_event.protocol_state=
-                               Breadcrumb.protocol_state b
-                           ; just_emitted_a_proof=
-                               Breadcrumb.just_emitted_a_proof b } )
-                         removed_from_best_tip_path
-                   ; reorg_best_tip }) ;
-              [%log' spam t.best_tip_diff_logger]
-                ~metadata:
-                  [ ( "added_states"
-                    , `List
-                        (List.map added_states
-                           ~f:Log_event.best_tip_log_line_to_yojson) ) ]
-                " " ;
+                event ;
+              [%str_log' best_tip_diff t.best_tip_diff_logger] event ;
               ({new_commands; removed_commands; reorg_best_tip}, true)
           | E (New_node (Full _), _) -> (acc, should_broadcast)
           | E (Root_transitioned _, _) -> (acc, should_broadcast) )


### PR DESCRIPTION
Writing best tip logs to a different file `mina-best-tip.log`. This is to make it easier to collect the required logs from nodes  to determine the state to fork off of
Added a new log level `best_tip_diff` that is of  `Spam` level and  doesn't have source or module

Explain how you tested your changes here.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
