### PR TITLE
destroy persisted frontier if genesis state changes

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -458,6 +458,8 @@ let run ~logger ~trust_system ~verifier ~network ~consensus_local_state
             let%bind () =
               Transition_frontier.Persistent_frontier.reset_database_exn
                 persistent_frontier ~root_data:new_root_data
+                ~genesis_state_hash:
+                  precomputed_values.protocol_state_with_hash.hash
             in
             (* TODO: lazy load db in persistent root to avoid unecessary opens like this *)
             Transition_frontier.Persistent_root.(

--- a/src/lib/transition_frontier/persistent_frontier/database.mli
+++ b/src/lib/transition_frontier/persistent_frontier/database.mli
@@ -44,9 +44,11 @@ val close : t -> unit
 
 val check :
      t
+  -> genesis_state_hash:State_hash.t
   -> ( unit
      , [> `Not_initialized
        | `Invalid_version
+       | `Genesis_state_mismatch of State_hash.t
        | `Corrupt of
          [> `Not_found of
             [> `Best_tip

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -329,7 +329,7 @@ let with_instance_exn t ~f =
   let%map () = Instance.destroy instance in
   x
 
-let reset_database_exn t ~root_data =
+let reset_database_exn t ~root_data ~genesis_state_hash =
   let open Root_data.Limited in
   let open Deferred.Let_syntax in
   [%log' info t.logger]
@@ -344,12 +344,14 @@ let reset_database_exn t ~root_data =
       Database.initialize instance.db ~root_data ;
       (* sanity check database after initialization on debug builds *)
       Debug_assert.debug_assert (fun () ->
-          Database.check instance.db
+          Database.check instance.db ~genesis_state_hash
           |> Result.map_error ~f:(function
                | `Invalid_version ->
                    "invalid version"
                | `Not_initialized ->
                    "not initialized"
+               | `Genesis_state_mismatch _ ->
+                   "genesis state mismatch"
                | `Corrupt err ->
                    Database.Error.message err )
           |> Result.ok_or_failwith ) )

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -176,6 +176,7 @@ let rec load_with_max_length :
     let%bind () =
       Persistent_frontier.reset_database_exn persistent_frontier
         ~root_data:(genesis_root_data ~precomputed_values)
+        ~genesis_state_hash:precomputed_values.protocol_state_with_hash.hash
     in
     let%bind () =
       Persistent_root.reset_to_genesis_exn persistent_root ~precomputed_values
@@ -185,7 +186,9 @@ let rec load_with_max_length :
       ~ignore_consensus_local_state:false
   in
   match
-    Persistent_frontier.Instance.check_database persistent_frontier_instance
+    Persistent_frontier.Instance.check_database
+      ~genesis_state_hash:precomputed_values.protocol_state_with_hash.hash
+      persistent_frontier_instance
   with
   | Error `Not_initialized ->
       (* TODO: this case can be optimized to not create the
@@ -195,6 +198,17 @@ let rec load_with_max_length :
       reset_and_continue ()
   | Error `Invalid_version ->
       [%log info] "persistent frontier database out of date" ;
+      reset_and_continue ()
+  | Error (`Genesis_state_mismatch persisted_genesis_state_hash) ->
+      [%log info]
+        "Genesis state in persisted frontier $persisted_state_hash differs \
+         from the current genesis state $precomputed_state_hash"
+        ~metadata:
+          [ ( "persisted_state_hash"
+            , State_hash.to_yojson persisted_genesis_state_hash )
+          ; ( "precomputed_state_hash"
+            , State_hash.to_yojson
+                precomputed_values.protocol_state_with_hash.hash ) ] ;
       reset_and_continue ()
   | Error (`Corrupt err) ->
       [%log error] "Persistent frontier database is corrupt: %s"
@@ -592,6 +606,7 @@ module For_tests = struct
     in
     Async.Thread_safe.block_on_async_exn (fun () ->
         Persistent_frontier.reset_database_exn persistent_frontier ~root_data
+          ~genesis_state_hash:precomputed_values.protocol_state_with_hash.hash
     ) ;
     Persistent_root.with_instance_exn persistent_root ~f:(fun instance ->
         Persistent_root.Instance.set_root_state_hash instance


### PR DESCRIPTION
... and start with the new genesis state.
Tested it by running standalone daemon locally

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

