### PR TITLE
Timed account payment integration test

### DIFF
--- a/src/app/test_executive/block_production_test.ml
+++ b/src/app/test_executive/block_production_test.ml
@@ -16,6 +16,8 @@ module Make (Engine : Engine_intf) = struct
       block_producers= [{balance= "1000"; timing= Untimed}]
     ; num_snark_workers= 0 }
 
+  let expected_error_event_reprs = []
+
   let run network log_engine =
     let open Network in
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/block_production_test_timed_accounts.ml
+++ b/src/app/test_executive/block_production_test_timed_accounts.ml
@@ -50,6 +50,8 @@ module Make (Engine : Engine_intf) = struct
       (scale_exn supercharged_coinbase supercharged_coinbase_blocks)
     |> Option.value_exn
 
+  let expected_error_event_reprs = []
+
   let run network log_engine =
     let open Network in
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/bootstrap_test.ml
+++ b/src/app/test_executive/bootstrap_test.ml
@@ -17,6 +17,8 @@ module Make (Engine : Engine_intf) = struct
         [{balance= "1000"; timing= Untimed}; {balance= "1000"; timing= Untimed}]
     ; num_snark_workers= 0 }
 
+  let expected_error_event_reprs = []
+
   let run network log_engine =
     let open Network in
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/mina_peers_test.ml
+++ b/src/app/test_executive/mina_peers_test.ml
@@ -27,6 +27,8 @@ module Make (Engine : Engine_intf) = struct
         ; {balance= "1000"; timing} ]
     ; num_snark_workers= 0 }
 
+  let expected_error_event_reprs = []
+
   let run network log_engine =
     let open Network in
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/payments_timed_accounts.ml
+++ b/src/app/test_executive/payments_timed_accounts.ml
@@ -1,0 +1,121 @@
+open Integration_test_lib
+open Core_kernel
+
+module Make (Engine : Engine_intf) = struct
+  open Engine
+
+  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  type network = Network.t
+
+  type log_engine = Log_engine.t
+
+  let block_producer_balance = "1000" (* 1_000_000_000_000 *)
+
+  let config =
+    let open Test_config in
+    let open Test_config.Block_producer in
+    let open Currency in
+    let make_timing ~min_balance ~cliff_time ~vesting_period ~vesting_increment
+        : Coda_base.Account_timing.t =
+      Timed
+        { initial_minimum_balance= Balance.of_int min_balance
+        ; cliff_time= Coda_numbers.Global_slot.of_int cliff_time
+        ; vesting_period= Coda_numbers.Global_slot.of_int vesting_period
+        ; vesting_increment= Amount.of_int vesting_increment }
+    in
+    let timing1 =
+      make_timing ~min_balance:100_000_000_000 ~cliff_time:4 ~vesting_period:2
+        ~vesting_increment:50_000_000_000
+    in
+    let timing2 =
+      make_timing ~min_balance:500_000_000_000 ~cliff_time:2000
+        ~vesting_period:1 ~vesting_increment:500_000_000_000
+    in
+    { default with
+      block_producers=
+        [ {balance= block_producer_balance; timing= timing1}
+        ; {balance= block_producer_balance; timing= timing2} ] }
+
+  let expected_error_event_reprs =
+    let open Network_pool.Transaction_pool in
+    [rejecting_command_for_reason_structured_events_repr]
+
+  let pk_of_keypair keypairs n =
+    let open Signature_lib in
+    let open Keypair in
+    let {public_key; _} = List.nth_exn keypairs n in
+    public_key |> Public_key.compress
+
+  let run network log_engine =
+    let open Network in
+    let open Malleable_error.Let_syntax in
+    let logger = Logger.create () in
+    let block_producer1 = List.nth_exn network.Network.block_producers 0 in
+    let block_producer2 = List.nth_exn network.Network.block_producers 1 in
+    [%log info] "Waiting for block producer 1 (of 2) to initialize" ;
+    let%bind () = Log_engine.wait_for_init block_producer1 log_engine in
+    [%log info] "Block producer 1 (of 2) initialized" ;
+    [%log info] "Waiting for block producer 2 (of 2) to initialize" ;
+    let%bind () = Log_engine.wait_for_init block_producer2 log_engine in
+    [%log info] "Block producer 2 (of 2) initialized" ;
+    let sender = pk_of_keypair network.keypairs 1 in
+    let receiver = pk_of_keypair network.keypairs 0 in
+    let fee = Currency.Fee.of_int 10_000_000 in
+    [%log info] "Sending payment, should succeed" ;
+    let amount = Currency.Amount.of_int 300_000_000_000 in
+    let payment_or_error =
+      Node.send_payment ~retry_on_graphql_error:false ~logger block_producer2
+        ~sender ~receiver ~amount ~fee
+    in
+    let%bind () =
+      match%bind.Async_kernel.Deferred.Let_syntax payment_or_error with
+      | Ok {computation_result= _; soft_errors= _} ->
+          [%log info] "Payment succeeded, as expected" ;
+          Malleable_error.return ()
+      | Error {hard_error= {error; _}; soft_errors= _} ->
+          let err_str = Error.to_string_mach error in
+          [%log error] "Unexpected payment failure in GraphQL"
+            ~metadata:[("error", `String err_str)] ;
+          Malleable_error.of_string_hard_error_format
+            "Unexpected payment failure in GraphQL: %s" err_str
+    in
+    [%log info] "Waiting for payment to appear in breadcrumb" ;
+    let%bind () =
+      Log_engine.wait_for_payment log_engine ~logger ~sender ~receiver ~amount
+        ()
+    in
+    [%log info] "Got breadcrumb with desired payment" ;
+    [%log info]
+      "Sending payment, should fail because of minimum balance violation" ;
+    (* second payment of same amount would dip balance beneath minimum *)
+    let payment_or_error =
+      Node.send_payment ~retry_on_graphql_error:false ~logger block_producer2
+        ~sender ~receiver ~amount ~fee
+    in
+    let%map () =
+      match%bind.Async_kernel.Deferred.Let_syntax payment_or_error with
+      | Ok {computation_result= _; soft_errors= _} ->
+          [%log error]
+            "Payment succeeded, but expected it to fail because of a minimum \
+             balance violation" ;
+          Malleable_error.of_string_hard_error
+            "Payment succeeded when it should have failed"
+      | Error {hard_error= {error; _}; soft_errors= _} ->
+          (* expect GraphQL error due to insufficient funds *)
+          let err_str = Error.to_string_mach error in
+          let err_str_lowercase = String.lowercase err_str in
+          if
+            String.is_substring ~substring:"insufficient_funds"
+              err_str_lowercase
+          then (
+            [%log info] "Got expected insufficient funds error from GraphQL" ;
+            Malleable_error.return () )
+          else (
+            [%log error]
+              "Payment failed in GraphQL, but for unexpected reason: %s"
+              err_str ;
+            Malleable_error.of_string_hard_error_format
+              "Payment failed for unexpected reason: %s" err_str )
+    in
+    [%log info] "Payment test with timed accounts completed"
+end

--- a/src/app/test_executive/send_payment_test.ml
+++ b/src/app/test_executive/send_payment_test.ml
@@ -15,6 +15,8 @@ module Make (Engine : Engine_intf) = struct
         [{balance= "4000"; timing= Untimed}; {balance= "3000"; timing= Untimed}]
     ; num_snark_workers= 0 }
 
+  let expected_error_event_reprs = []
+
   let run network log_engine =
     let open Malleable_error.Let_syntax in
     let block_producer = Caml.List.nth network.Network.block_producers 0 in

--- a/src/app/test_executive/send_payment_test.ml
+++ b/src/app/test_executive/send_payment_test.ml
@@ -26,6 +26,9 @@ module Make (Engine : Engine_intf) = struct
     (* wait for initialization *)
     let%bind () = Log_engine.wait_for_init node log_engine in
     [%log info] "send_payment_test: done waiting for initialization" ;
+    let graphql_port = 3085 in
+    Async_kernel.Deferred.don't_wait_for
+      (Node.set_port_forwarding_exn ~logger block_producer graphql_port) ;
     (* same keypairs used by Coda_automation to populate the ledger *)
     let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
     (* send the payment *)

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -80,7 +80,7 @@ module Node = struct
       in
       [%log info] "Port forwarding using \"kubectl %s\"\n"
         String.(concat args ~sep:" ") ;
-      let%bind.Malleable_error.Let_syntax proc =
+      let%bind proc =
         Deferred.bind ~f:Malleable_error.of_or_error_hard
           (Process.create ~prog:"kubectl" ~args ())
       in
@@ -207,7 +207,7 @@ module Node = struct
                 Deferred.bind ~f:Malleable_error.return
                   (after (Time.Span.of_sec retry_delay_sec))
               in
-              [%log info] "%d tries left" (n - 1) ;
+              [%log info] "After GraphQL error, %d tries left" (n - 1) ;
               retry (n - 1) )
             else Malleable_error.of_string_hard_error err_string
     in
@@ -273,8 +273,10 @@ module Node = struct
     in
     get_balance ()
 
-  let send_payment ~logger t ~sender ~receiver ~amount ~fee =
-    [%log info] "Sending a payment.."
+  (* if we expect failure, might want retry_on_graphql_error to be false *)
+  let send_payment ?(retry_on_graphql_error = true) ~logger t ~sender ~receiver
+      ~amount ~fee =
+    [%log info] "Sending a payment"
       ~metadata:
         [("namespace", `String t.namespace); ("pod_id", `String t.pod_id)] ;
     let graphql_port = 3085 in
@@ -303,7 +305,7 @@ module Node = struct
           ()
       in
       (* retry_on_graphql_error=true because the node might be bootstrapping *)
-      exec_graphql_reqest ~logger ~graphql_port ~retry_on_graphql_error:true
+      exec_graphql_reqest ~logger ~graphql_port ~retry_on_graphql_error
         ~query_name:"send_payment_graphql" send_payment_obj
     in
     let%map sent_payment_obj = send_payment_graphql () in

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -71,7 +71,7 @@ module Node = struct
           ; Malleable_error.Hard_fail.soft_errors= _ } ->
           Malleable_error.of_error_hard e.error
 
-    (* default port is 3085, may need to be explicit if multiple daemons are running *)
+    (* default GraphQL port is 3085, may need to be explicit if multiple daemons are running *)
     let set_port_forwarding ~logger t port =
       let open Malleable_error.Let_syntax in
       let%bind name = get_pod_name t in
@@ -279,10 +279,9 @@ module Node = struct
     [%log info] "Sending a payment"
       ~metadata:
         [("namespace", `String t.namespace); ("pod_id", `String t.pod_id)] ;
-    let graphql_port = 3085 in
     let open Malleable_error.Let_syntax in
-    Deferred.don't_wait_for (set_port_forwarding_exn ~logger t graphql_port) ;
     let sender_pk_str = Signature_lib.Public_key.Compressed.to_string sender in
+    let graphql_port = 3085 in
     [%log info] "send_payment: unlocking account"
       ~metadata:[("sender_pk", `String sender_pk_str)] ;
     let unlock_sender_account_graphql () =

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -234,26 +234,41 @@ module Json_parsing = struct
       Malleable_error.of_string_hard_error
         (Printf.sprintf "failed to parse json value: %s" (Exn.to_string exn))
 
-  let signed_commands_with_statuses :
-      Coda_base.Signed_command.t Coda_base.With_status.t list parser = function
+  let parser_from_of_yojson of_yojson js =
+    match of_yojson js with
+    | Ok cmd ->
+        cmd
+    | Error modl ->
+        let logger = Logger.create () in
+        [%log error] "Could not parse JSON using of_yojson"
+          ~metadata:[("module", `String modl); ("json", js)] ;
+        failwithf "Could not parse JSON using %s.of_yojson" modl ()
+
+  let valid_commands_with_statuses :
+      Coda_base.User_command.Valid.t Coda_base.With_status.t list parser =
+    function
     | `List cmds ->
         let cmd_or_errors =
           List.map cmds
             ~f:
               (Coda_base.With_status.of_yojson
-                 Coda_base.Signed_command.of_yojson)
+                 Coda_base.User_command.Valid.of_yojson)
         in
         List.fold cmd_or_errors ~init:[] ~f:(fun accum cmd_or_err ->
             match (accum, cmd_or_err) with
-            | _, Error _ ->
+            | _, Error err ->
+                let logger = Logger.create () in
+                [%log error]
+                  ~metadata:[("error", `String err)]
+                  "Failed to parse JSON for user command status" ;
                 (* fail on any error *)
                 failwith
-                  "signed_commands_with_statuses: unable to parse JSON for \
+                  "valid_commands_with_statuses: unable to parse JSON for \
                    user command"
             | cmds, Ok cmd ->
                 cmd :: cmds )
     | _ ->
-        failwith "signed_commands_with_statuses: expected `List"
+        failwith "valid_commands_with_statuses: expected `List"
 
   let rec find (parser : 'a parser) (json : Yojson.Safe.t) (path : string list)
       : 'a Malleable_error.t =
@@ -271,7 +286,11 @@ module Json_parsing = struct
         let%bind entry =
           Malleable_error.of_option_hard
             (List.Assoc.find assoc key ~equal:String.equal)
-            "failed to find path in json object"
+            (sprintf "failed to find path using key '%s' in json object { %s }"
+               key
+               (String.concat ~sep:", "
+                  (List.map assoc ~f:(fun (s, json) ->
+                       sprintf "\"%s\":%s" s (Yojson.Safe.to_string json) ))))
         in
         find parser entry path'
     | _ ->
@@ -501,7 +520,7 @@ module Breadcrumb_added_query = struct
   open Coda_base
 
   module Result = struct
-    type t = {user_commands: Signed_command.t With_status.t list}
+    type t = {user_commands: User_command.Valid.t With_status.t list}
   end
 
   let filter testnet_log_filter =
@@ -517,7 +536,7 @@ module Breadcrumb_added_query = struct
     let open Malleable_error.Let_syntax in
     (* JSON path to metadata entry *)
     let path = ["jsonPayload"; "metadata"; "user_commands"] in
-    let parser = signed_commands_with_statuses in
+    let parser = valid_commands_with_statuses in
     let%map user_commands = find parser js path in
     Result.{user_commands}
 end
@@ -684,11 +703,10 @@ let create ~logger ~(network : Kubernetes_network.t) ~on_fatal_error =
             (Ivar.create ())
         in
         if Ivar.is_empty ivar then ( Ivar.fill ivar () ; return () )
-        else
-          Malleable_error.of_error_hard
-            (Error.of_string
-               "received initialization for node that has already initialized")
-        )
+        else (
+          [%log warn]
+            "Received initialization for node that has already initialized" ;
+          return () ) )
   in
   let best_tip_map_reader, best_tip_map_writer =
     Broadcast_pipe.create String.Map.empty
@@ -955,6 +973,25 @@ let wait_for :
   | res ->
       Deferred.return res
 
+let command_matches_payment cmd ~sender ~receiver ~amount =
+  let open User_command in
+  match cmd with
+  | Signed_command signed_cmd -> (
+      let open Signature_lib in
+      let body =
+        Signed_command.payload signed_cmd |> Signed_command_payload.body
+      in
+      match body with
+      | Payment {source_pk; receiver_pk; amount= paid_amt; token_id= _}
+        when Public_key.Compressed.equal source_pk sender
+             && Public_key.Compressed.equal receiver_pk receiver
+             && Currency.Amount.equal paid_amt amount ->
+          true
+      | _ ->
+          false )
+  | Snapp_command _ ->
+      false
+
 let wait_for_payment ?(num_tries = 30) t ~logger ~sender ~receiver ~amount () :
     unit Malleable_error.t =
   let retry_delay_sec = 30.0 in
@@ -987,45 +1024,54 @@ let wait_for_payment ?(num_tries = 30) t ~logger ~sender ~receiver ~amount () :
           let open Coda_base in
           let open Signature_lib in
           (* res is a list of Breadcrumb_added_query.Result.t
-           each of those contains a list of user commands
-           fold over the fold of each list
-           as soon as we find a matching payment, don't
-            check any other commands
-        *)
-          let found =
-            List.fold res ~init:false ~f:(fun found_outer {user_commands} ->
-                if found_outer then true
+             each of those contains a list of user commands
+          *)
+          let payment_opt =
+            List.fold res ~init:None ~f:(fun acc {user_commands} ->
+                if Option.is_some acc then acc
                 else
-                  List.fold user_commands ~init:false
-                    ~f:(fun found_inner cmd_with_status ->
-                      if found_inner then true
-                      else
-                        (* N.B.: we're not checking fee, nonce or memo *)
-                        let signed_cmd = cmd_with_status.With_status.data in
-                        let body =
-                          Signed_command.payload signed_cmd
-                          |> Signed_command_payload.body
-                        in
-                        match body with
-                        | Payment
-                            { source_pk
-                            ; receiver_pk
-                            ; amount= paid_amt
-                            ; token_id= _ } ->
-                            Public_key.Compressed.equal source_pk sender
-                            && Public_key.Compressed.equal receiver_pk receiver
-                            && Currency.Amount.equal paid_amt amount
-                        | _ ->
-                            false ) )
+                  List.find user_commands
+                    ~f:(fun (cmd_with_status :
+                              User_command.Valid.t With_status.t)
+                       ->
+                      cmd_with_status.With_status.data
+                      |> User_command.forget_check
+                      |> command_matches_payment ~sender ~receiver ~amount ) )
           in
-          if found then (
-            [%log info] "wait_for_payment: found matching payment"
-              ~metadata:
-                [ ("sender", `String (Public_key.Compressed.to_string sender))
-                ; ( "receiver"
-                  , `String (Public_key.Compressed.to_string receiver) )
-                ; ("amount", `String (Currency.Amount.to_string amount)) ] ;
-            Malleable_error.return () )
+          if Option.is_some payment_opt then
+            let cmd_with_status = Option.value_exn payment_opt in
+            let actual_status = cmd_with_status.With_status.status in
+            let applied =
+              match actual_status with
+              | User_command_status.Applied _ ->
+                  true
+              | _ ->
+                  false
+            in
+            if applied then (
+              [%log info] "wait_for_payment: found matching payment"
+                ~metadata:
+                  [ ("sender", `String (Public_key.Compressed.to_string sender))
+                  ; ( "receiver"
+                    , `String (Public_key.Compressed.to_string receiver) )
+                  ; ("amount", `String (Currency.Amount.to_string amount)) ] ;
+              Malleable_error.return () )
+            else (
+              [%log info]
+                "wait_for_payment: found matching payment, but status is not \
+                 'Applied'"
+                ~metadata:
+                  [ ("sender", `String (Public_key.Compressed.to_string sender))
+                  ; ( "receiver"
+                    , `String (Public_key.Compressed.to_string receiver) )
+                  ; ("amount", `String (Currency.Amount.to_string amount))
+                  ; ( "actual_user_command_status"
+                    , User_command_status.to_yojson actual_status ) ] ;
+              Error.raise
+                (Error.of_string
+                   (sprintf "Unexpected status in matching payment: %s"
+                      ( User_command_status.to_yojson actual_status
+                      |> Yojson.Safe.to_string ))) )
           else (
             [%log info]
               "wait_for_payment: found added breadcrumbs, but did not find \

--- a/src/lib/integration_test_lib/integration_test_lib.ml
+++ b/src/lib/integration_test_lib/integration_test_lib.ml
@@ -62,7 +62,8 @@ module type Engine_intf = sig
     val stop : t -> unit Malleable_error.t
 
     val send_payment :
-         logger:Logger.t
+         ?retry_on_graphql_error:bool
+      -> logger:Logger.t
       -> t
       -> sender:Signature_lib.Public_key.Compressed.t
       -> receiver:Signature_lib.Public_key.Compressed.t
@@ -173,6 +174,8 @@ module type Test_intf = sig
   type log_engine
 
   val config : Test_config.t
+
+  val expected_error_event_reprs : Structured_log_events.repr list
 
   val run : network -> log_engine -> unit Malleable_error.t
 end

--- a/src/lib/integration_test_lib/integration_test_lib.ml
+++ b/src/lib/integration_test_lib/integration_test_lib.ml
@@ -61,6 +61,10 @@ module type Engine_intf = sig
 
     val stop : t -> unit Malleable_error.t
 
+    (* does not return if it succeeds, use don't_wait_for *)
+    val set_port_forwarding_exn :
+      logger:Logger.t -> t -> int -> unit Deferred.t
+
     val send_payment :
          ?retry_on_graphql_error:bool
       -> logger:Logger.t

--- a/src/lib/integration_test_lib/test_error.ml
+++ b/src/lib/integration_test_lib/test_error.ml
@@ -68,4 +68,12 @@ module Set = struct
     ; hard_errors= a.hard_errors @ b.hard_errors }
 
   let combine = List.fold_left ~init:empty ~f:merge
+
+  let concat_map a ~f = List.map (a.soft_errors @ a.hard_errors) ~f
+
+  let partition_tf a ~f : t * t =
+    let soft1, soft2 = List.partition_tf a.soft_errors ~f in
+    let hard1, hard2 = List.partition_tf a.hard_errors ~f in
+    ( {soft_errors= soft1; hard_errors= hard1}
+    , {soft_errors= soft2; hard_errors= hard2} )
 end


### PR DESCRIPTION
Add an integration test using timed accounts:
- send a payment that succeeds
- send a payment that fails because of a minimum balance violation

The sender and receiver are the same in both cases. The first payment should deplete the sender's balance to the point where the second payment fails.

The failing payment should trigger an error log from the transaction pool. We update integration test error reporting so that the presence of this log does not cause a test failure, but its absence does. Each integration test contains a list of structured logs `repr`s indicating expected test failures.

Originally, the plan was to add these payments to `Block_producer_timed_accounts`. Because of the size of the scan state with `testnet_postake_medium_curves`, producing a SNARKed ledger for that test takes nearly 2 days. So these new pieces become a new test, and a new profile for the existing test will be needed to run the test in a reasonable time.

Made "node already initialized" event a warning, instead of an error. That event appears to be a GCloud subscription issue. The transition frontier controller log that indicates initialization seems to occur only once, when looking at the StackDriver logs, but is reported by the subscription more than once.

Closes #5993.

Test succeeds, modulo some libp2p warnings apparently unrelated to the test itself, like:
```
   [2020-11-02 20:26:47.420000Z] test-block-producer-2: {"timestamp":"2020-11-02 20:26:47.420000Z","level":"Warn","source":{"module":"Libp2p_helper.Go.dht/RtRefreshManager","location":"(not tracked)"},"message":"failed when refreshing routing table2 errors occurred:\n\t* failed to query for self, err=failed to find any peer in table\n\t* failed to refresh cpl=0, err=failed to find any peer in table\n\n","metadata":{}}
```