### PR TITLE
do not verify scan statement while loading persistent frontier

### DIFF
--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -1014,7 +1014,8 @@ module Staged_ledger_validation = struct
     Fn.compose statement_target statement
 
   let validate_staged_ledger_diff :
-         ( 'time_received
+         ?skip_staged_ledger_verification:bool
+      -> ( 'time_received
          , 'genesis_state
          , 'proof
          , 'delta_transition_chain
@@ -1045,8 +1046,9 @@ module Staged_ledger_validation = struct
            | `Staged_ledger_application_failed of
              Staged_ledger.Staged_ledger_error.t ] )
          Deferred.Result.t =
-   fun (t, validation) ~logger ~precomputed_values ~verifier
-       ~parent_staged_ledger ~parent_protocol_state ->
+   fun ?skip_staged_ledger_verification (t, validation) ~logger
+       ~precomputed_values ~verifier ~parent_staged_ledger
+       ~parent_protocol_state ->
     let open Deferred.Result.Let_syntax in
     let transition = With_hash.data t in
     let blockchain_state =
@@ -1058,7 +1060,7 @@ module Staged_ledger_validation = struct
              , `Ledger_proof proof_opt
              , `Staged_ledger transitioned_staged_ledger
              , `Pending_coinbase_update _ ) =
-      Staged_ledger.apply
+      Staged_ledger.apply ?skip_verification:skip_staged_ledger_verification
         ~constraint_constants:precomputed_values.constraint_constants ~logger
         ~verifier parent_staged_ledger staged_ledger_diff
         ~current_state_view:

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -615,7 +615,8 @@ module type S = sig
 
   module Staged_ledger_validation : sig
     val validate_staged_ledger_diff :
-         ( 'time_received
+         ?skip_staged_ledger_verification:bool
+      -> ( 'time_received
          , 'genesis_state
          , 'proof
          , 'delta_transition_chain

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -623,6 +623,15 @@ module T = struct
       ~f:(fun _ -> check (List.drop data (fst partitions.first)) partitions)
       partitions.second
 
+  let time ~logger label f =
+    let start = Core.Time.now () in
+    let%map x = f () in
+    [%log debug]
+      ~metadata:
+        [("time_elapsed", `Float Core.Time.(Span.to_ms @@ diff (now ()) start))]
+      "%s took $time_elapsed" label ;
+    x
+
   let update_coinbase_stack_and_get_data ~constraint_constants scan_state
       ledger pending_coinbase_collection transactions current_state_view
       state_and_body_hash =
@@ -777,8 +786,9 @@ module T = struct
           (Staged_ledger_error.Pre_diff
              (Pre_diff_info.Error.Coinbase_error "More than two coinbase parts"))
 
-  let apply_diff ~logger ~constraint_constants t pre_diff_info
-      ~current_state_view ~state_and_body_hash ~log_prefix ~coinbase_receiver =
+  let apply_diff ?(skip_verification = false) ~logger ~constraint_constants t
+      pre_diff_info ~current_state_view ~state_and_body_hash ~log_prefix
+      ~coinbase_receiver =
     let open Deferred.Result.Let_syntax in
     let max_throughput =
       Int.pow 2 t.constraint_constants.transaction_capacity_log_2
@@ -791,88 +801,83 @@ module T = struct
     let new_mask = Ledger.Mask.create ~depth:(Ledger.depth t.ledger) () in
     let new_ledger = Ledger.register_mask t.ledger new_mask in
     let transactions, works, commands_count, coinbases = pre_diff_info in
-    let update_coinbase_stack_start_time = Core.Time.now () in
     let%bind is_new_stack, data, stack_update_in_snark, stack_update =
-      update_coinbase_stack_and_get_data ~constraint_constants t.scan_state
-        new_ledger t.pending_coinbase_collection transactions
-        current_state_view state_and_body_hash
+      time ~logger "update_coinbase_stack_start_time" (fun () ->
+          update_coinbase_stack_and_get_data ~constraint_constants t.scan_state
+            new_ledger t.pending_coinbase_collection transactions
+            current_state_view state_and_body_hash )
     in
-    [%log debug]
-      ~metadata:
-        [ ( "time_elapsed"
-          , `Float
-              Core.Time.(
-                Span.to_ms @@ diff (now ()) update_coinbase_stack_start_time)
-          ) ]
-      "update_coinbase_stack_start_time take $time_elapsed" ;
     let slots = List.length data in
     let work_count = List.length works in
     let required_pairs =
       Scan_state.work_statements_for_new_diff t.scan_state
     in
     let%bind () =
-      let required = List.length required_pairs in
-      if
-        work_count < required
-        && List.length data
-           > Scan_state.free_space t.scan_state - required + work_count
-      then
-        Deferred.return
-          (Error
-             (Staged_ledger_error.Insufficient_work
-                (sprintf
-                   !"Insufficient number of transaction snark work (slots \
-                     occupying: %d)  required %d, got %d"
-                   slots required work_count)))
-      else Deferred.return (Ok ())
+      time ~logger "sufficient work check" (fun () ->
+          let required = List.length required_pairs in
+          if
+            work_count < required
+            && List.length data
+               > Scan_state.free_space t.scan_state - required + work_count
+          then
+            Deferred.return
+              (Error
+                 (Staged_ledger_error.Insufficient_work
+                    (sprintf
+                       !"Insufficient number of transaction snark work (slots \
+                         occupying: %d)  required %d, got %d"
+                       slots required work_count)))
+          else Deferred.return (Ok ()) )
     in
     let%bind () = Deferred.return (check_zero_fee_excess t.scan_state data) in
-    let fill_work_start_time = Core.Time.now () in
     let%bind res_opt, scan_state' =
-      let r =
-        Scan_state.fill_work_and_enqueue_transactions t.scan_state data works
-      in
-      Or_error.iter_error r ~f:(fun e ->
-          let data_json =
-            `List
-              (List.map data
-                 ~f:(fun {Scan_state.Transaction_with_witness.statement; _} ->
-                   Transaction_snark.Statement.to_yojson statement ))
+      time ~logger "fill_work_and_enqueue_transactions" (fun () ->
+          let r =
+            Scan_state.fill_work_and_enqueue_transactions t.scan_state data
+              works
           in
-          [%log error]
-            ~metadata:
-              [ ( "scan_state"
-                , `String (Scan_state.snark_job_list_json t.scan_state) )
-              ; ("data", data_json)
-              ; ("error", `String (Error.to_string_hum e))
-              ; ("prefix", `String log_prefix) ]
-            !"$prefix: Unexpected error when applying diff data $data to the \
-              scan_state $scan_state: $error" ) ;
-      Deferred.return (to_staged_ledger_or_error r)
+          Or_error.iter_error r ~f:(fun e ->
+              let data_json =
+                `List
+                  (List.map data
+                     ~f:(fun {Scan_state.Transaction_with_witness.statement; _}
+                        -> Transaction_snark.Statement.to_yojson statement ))
+              in
+              [%log error]
+                ~metadata:
+                  [ ( "scan_state"
+                    , `String (Scan_state.snark_job_list_json t.scan_state) )
+                  ; ("data", data_json)
+                  ; ("error", `String (Error.to_string_hum e))
+                  ; ("prefix", `String log_prefix) ]
+                !"$prefix: Unexpected error when applying diff data $data to \
+                  the scan_state $scan_state: $error" ) ;
+          Deferred.return (to_staged_ledger_or_error r) )
     in
-    [%log debug]
-      ~metadata:
-        [ ( "time_elapsed"
-          , `Float Core.Time.(Span.to_ms @@ diff (now ()) fill_work_start_time)
-          ) ]
-      "fill_work_and_enqueue_transactions take $time_elapsed" ;
     let%bind updated_pending_coinbase_collection' =
-      update_pending_coinbase_collection
-        ~depth:t.constraint_constants.pending_coinbase_depth
-        t.pending_coinbase_collection stack_update ~is_new_stack
-        ~ledger_proof:res_opt
-      |> Deferred.return
+      time ~logger "update_pending_coinbase_collection" (fun () ->
+          update_pending_coinbase_collection
+            ~depth:t.constraint_constants.pending_coinbase_depth
+            t.pending_coinbase_collection stack_update ~is_new_stack
+            ~ledger_proof:res_opt
+          |> Deferred.return )
     in
     let%bind coinbase_amount =
       coinbase_for_blockchain_snark coinbases |> Deferred.return
     in
     let%map () =
-      Deferred.(
-        verify_scan_state_after_apply ~constraint_constants
-          ~next_available_token:(Ledger.next_available_token new_ledger)
-          (Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root new_ledger))
-          scan_state'
-        >>| to_staged_ledger_or_error)
+      time ~logger
+        (sprintf "verify_scan_state_after_apply (skip=%b)" skip_verification)
+        (fun () ->
+          if skip_verification then Deferred.return (Ok ())
+          else
+            Deferred.(
+              verify_scan_state_after_apply ~constraint_constants
+                ~next_available_token:(Ledger.next_available_token new_ledger)
+                (Frozen_ledger_hash.of_ledger_hash
+                   (Ledger.merkle_root new_ledger))
+                scan_state'
+              >>| to_staged_ledger_or_error) )
     in
     [%log debug]
       ~metadata:
@@ -954,11 +959,15 @@ module T = struct
                   (Verifier.Failure.Verification_failed
                      (Error.of_string "batch verification failed")) ))
 
-  let apply ~constraint_constants t (witness : Staged_ledger_diff.t) ~logger
-      ~verifier ~current_state_view ~state_and_body_hash =
+  let apply ?skip_verification ~constraint_constants t
+      (witness : Staged_ledger_diff.t) ~logger ~verifier ~current_state_view
+      ~state_and_body_hash =
     let open Deferred.Result.Let_syntax in
     let work = Staged_ledger_diff.completed_works witness in
-    let%bind () = check_completed_works ~logger ~verifier t.scan_state work in
+    let%bind () =
+      time ~logger "check_completed_works" (fun () ->
+          check_completed_works ~logger ~verifier t.scan_state work )
+    in
     let%bind prediff =
       Pre_diff_info.get witness ~constraint_constants
         ~check:(check_commands t.ledger ~verifier)
@@ -969,7 +978,7 @@ module T = struct
     in
     let apply_diff_start_time = Core.Time.now () in
     let%map ((_, _, `Staged_ledger new_staged_ledger, _) as res) =
-      apply_diff ~constraint_constants t
+      apply_diff ?skip_verification ~constraint_constants t
         (forget_prediff_info prediff)
         ~logger ~current_state_view ~state_and_body_hash
         ~log_prefix:"apply_diff" ~coinbase_receiver:witness.coinbase_receiver

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -113,7 +113,8 @@ val copy : t -> t
 val hash : t -> Staged_ledger_hash.t
 
 val apply :
-     constraint_constants:Genesis_constants.Constraint_constants.t
+     ?skip_verification:bool
+  -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> t
   -> Staged_ledger_diff.t
   -> logger:Logger.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -290,10 +290,69 @@ module Make_statement_scanner
 struct
   module Fold = Parallel_scan.State.Make_foldable (Monad.Ident)
 
+  let logger = lazy (Logger.create ())
+
+  let time label f =
+    let logger = Lazy.force logger in
+    let open M.Let_syntax in
+    let start = Core.Time.now () in
+    let%map x = f () in
+    [%log debug]
+      ~metadata:
+        [("time_elapsed", `Float Core.Time.(Span.to_ms @@ diff (now ()) start))]
+      "%s took $time_elapsed" label ;
+    x
+
+  module Timer = struct
+    module Info = struct
+      module Time_span = struct
+        type t = Time.Span.t
+
+        let to_yojson t = `Float (Time.Span.to_ms t)
+      end
+
+      type t =
+        {total: Time_span.t; count: int; min: Time_span.t; max: Time_span.t}
+      [@@deriving to_yojson]
+
+      let singleton time = {total= time; count= 1; max= time; min= time}
+
+      let update (t : t) time =
+        { total= Time.Span.( + ) t.total time
+        ; count= t.count + 1
+        ; min= Time.Span.min t.min time
+        ; max= Time.Span.max t.max time }
+    end
+
+    type t = Info.t String.Table.t
+
+    let create () : t = String.Table.create ()
+
+    let time (t : t) label f =
+      let start = Time.now () in
+      let x = f () in
+      let elapsed = Time.(diff (now ()) start) in
+      Hashtbl.update t label ~f:(function
+        | None ->
+            Info.singleton elapsed
+        | Some acc ->
+            Info.update acc elapsed ) ;
+      x
+
+    let log label (t : t) =
+      let logger = Lazy.force logger in
+      [%log debug]
+        ~metadata:
+          (List.map (Hashtbl.to_alist t) ~f:(fun (k, info) ->
+               (k, Info.to_yojson info) ))
+        "%s timing" label
+  end
+
   (*TODO: fold over the pending_coinbase tree and validate the statements?*)
   let scan_statement ~constraint_constants tree ~verifier :
       (Transaction_snark.Statement.t, [`Error of Error.t | `Empty]) Result.t
       M.t =
+    let timer = Timer.create () in
     let module Acc = struct
       type t = (Transaction_snark.Statement.t * P.t list) option
     end in
@@ -307,15 +366,16 @@ struct
     in
     let merge_acc ~proofs (acc : Acc.t) s2 : Acc.t Or_error.t =
       let open Or_error.Let_syntax in
-      with_error "Bad merge proof" ~f:(fun () ->
-          match acc with
-          | None ->
-              Ok (Some (s2, proofs))
-          | Some (s1, ps) ->
-              let%map merged_statement =
-                Transaction_snark.Statement.merge s1 s2
-              in
-              Some (merged_statement, proofs @ ps) )
+      Timer.time timer (sprintf "merge_acc:%s" __LOC__) (fun () ->
+          with_error "Bad merge proof" ~f:(fun () ->
+              match acc with
+              | None ->
+                  Ok (Some (s2, proofs))
+              | Some (s1, ps) ->
+                  let%map merged_statement =
+                    Transaction_snark.Statement.merge s1 s2
+                  in
+                  Some (merged_statement, proofs @ ps) ) )
     in
     let fold_step_a acc_statement job =
       match job with
@@ -327,9 +387,10 @@ struct
       | Full {left= proof_1, message_1; right= proof_2, message_2; _} ->
           let open Or_error.Let_syntax in
           let%bind merged_statement =
-            Transaction_snark.Statement.merge
-              (Ledger_proof.statement proof_1)
-              (Ledger_proof.statement proof_2)
+            Timer.time timer (sprintf "merge:%s" __LOC__) (fun () ->
+                Transaction_snark.Statement.merge
+                  (Ledger_proof.statement proof_1)
+                  (Ledger_proof.statement proof_2) )
           in
           merge_acc acc_statement merged_statement
             ~proofs:[(proof_1, message_1); (proof_2, message_2)]
@@ -343,7 +404,10 @@ struct
           with_error "Bad base statement" ~f:(fun () ->
               let open Or_error.Let_syntax in
               let%bind expected_statement =
-                create_expected_statement ~constraint_constants transaction
+                Timer.time timer
+                  (sprintf "create_expected_statement:%s" __LOC__) (fun () ->
+                    create_expected_statement ~constraint_constants transaction
+                )
               in
               if
                 Transaction_snark.Statement.equal transaction.statement
@@ -357,6 +421,7 @@ struct
                        %{sexp:Transaction_snark.Statement.t}"
                      transaction.statement expected_statement) )
     in
+    Timer.log "scan_statement" timer ;
     let res =
       Fold.fold_chronological_until tree ~init:None
         ~f_merge:(fun acc (_weight, job) ->
@@ -380,7 +445,10 @@ struct
         M.return (Error `Empty)
     | Ok (Some (res, proofs)) -> (
         let open M.Let_syntax in
-        match%map Verifier.verify ~verifier proofs with
+        match%map
+          ksprintf time "verify:%s" __LOC__ (fun () ->
+              Verifier.verify ~verifier proofs )
+        with
         | Ok true ->
             Ok res
         | Ok false ->
@@ -399,7 +467,10 @@ struct
       if not cond then Or_error.errorf "%s : %s" error_prefix err else Ok ()
     in
     let open M.Let_syntax in
-    match%map scan_statement ~constraint_constants ~verifier t with
+    match%map
+      time "scan_statement" (fun () ->
+          scan_statement ~constraint_constants ~verifier t )
+    with
     | Error (`Error e) ->
         Error e
     | Error `Empty ->

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -23,13 +23,15 @@ type display =
 val create : External_transition.Validated.t -> Staged_ledger.t -> t
 
 val build :
-     logger:Logger.t
+     ?skip_staged_ledger_verification:bool
+  -> logger:Logger.t
   -> precomputed_values:Precomputed_values.t
   -> verifier:Verifier.t
   -> trust_system:Trust_system.t
   -> parent:t
   -> transition:External_transition.Almost_validated.t
   -> sender:Envelope.Sender.t option
+  -> unit
   -> ( t
      , [> `Invalid_staged_ledger_diff of Error.t
        | `Invalid_staged_ledger_hash of Error.t

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -282,10 +282,11 @@ module Instance = struct
                    |> Deferred.return
              in
              let%bind breadcrumb =
-               Breadcrumb.build ~logger:t.factory.logger ~precomputed_values
+               Breadcrumb.build ~skip_staged_ledger_verification:true
+                 ~logger:t.factory.logger ~precomputed_values
                  ~verifier:t.factory.verifier
                  ~trust_system:(Trust_system.null ()) ~parent ~transition
-                 ~sender:None
+                 ~sender:None ()
              in
              let%map () = apply_diff Diff.(E (New_node (Full breadcrumb))) in
              breadcrumb ))

--- a/src/lib/transition_handler/breadcrumb_builder.ml
+++ b/src/lib/transition_handler/breadcrumb_builder.ml
@@ -97,7 +97,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                       Transition_frontier.Breadcrumb.build ~logger
                         ~precomputed_values ~verifier ~trust_system ~parent
                         ~transition:mostly_validated_transition
-                        ~sender:(Some sender) )
+                        ~sender:(Some sender) () )
                 with
                 | Ok new_breadcrumb ->
                     let open Result.Let_syntax in

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -174,8 +174,10 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
         ~transform_cached:(fun _ ->
           Transition_frontier.Breadcrumb.build ~logger ~precomputed_values
             ~verifier ~trust_system ~sender:(Some sender)
-            ~parent:parent_breadcrumb ~transition:mostly_validated_transition
-          )
+            ~parent:parent_breadcrumb
+            ~transition:
+              mostly_validated_transition (* TODO: Can we skip here? *)
+            ~skip_staged_ledger_verification:false () )
         ~transform_result:(function
           | Error (`Invalid_staged_ledger_hash error)
           | Error (`Invalid_staged_ledger_diff error) ->


### PR DESCRIPTION
This attempts to speed up the loading of the persistent frontier by skipping validation of the staged ledger after applying on disk transitions.