### PR TITLE
fix daemon puppeteered image

### DIFF
--- a/dockerfiles/Dockerfile-coda-daemon-puppeteered
+++ b/dockerfiles/Dockerfile-coda-daemon-puppeteered
@@ -3,8 +3,9 @@
 # for more details.
 
 ARG CODA_VERSION
-ARG CODA_BRANCH
 FROM codaprotocol/coda-daemon:${CODA_VERSION}
+
+ARG CODA_BRANCH
 
 RUN echo '#!/bin/bash\n\
 pgrep -f --newest "python3 /root/coda_daemon_puppeteer.py"'\


### PR DESCRIPTION
Ensure coda branch arg is correctly exposed for usage. As indicated in Docker docs, "An ARG declared before the FROM instruction can’t be used after the FROM"

**Testing:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
