### PR TITLE
Reverts #6528 (libp2p peer exchange "for real")

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -917,18 +917,8 @@ let create (config : Config.t) =
                         ; ban_statuses
                         ; k_block_hashes } )
           in
-          let get_some_initial_peers _ =
-            match !net_ref with
-            | None ->
-                (* essentially unreachable; without a network, we wouldn't receive this RPC call *)
-                [%log' error config.logger]
-                  "Network not instantiated when initial peers requested" ;
-                Deferred.return []
-            | Some net ->
-                Coda_networking.peers net
-          in
           let%bind net =
-            Coda_networking.create config.net_config ~get_some_initial_peers
+            Coda_networking.create config.net_config
               ~get_staged_ledger_aux_and_pending_coinbases_at_hash:
                 (fun query_env ->
                 trace_recurring

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -852,9 +852,9 @@ let create (config : Config.t)
     in
     return result
   in
+  let md p = [("peer", Peer.to_yojson p)] in
   let get_ancestry_rpc conn ~version:_ query =
-    [%log debug] "Sending root proof to peer with IP %s"
-      (Unix.Inet_addr.to_string conn.Peer.host) ;
+    [%log debug] "Sending root proof to $peer" ~metadata:(md conn) ;
     let action_msg = "Get_ancestry query: $query" in
     let msg_args = [("query", Rpcs.Get_ancestry.query_to_yojson query)] in
     let%bind result, sender =
@@ -870,8 +870,7 @@ let create (config : Config.t)
         if valid_protocol_versions then result else None
   in
   let get_best_tip_rpc conn ~version:_ query =
-    [%log debug] "Sending best_tip to peer with IP %s"
-      (Unix.Inet_addr.to_string conn.Peer.host) ;
+    [%log debug] "Sending best_tip to $peer" ~metadata:(md conn) ;
     let action_msg = "Get_best_tip. query: $query" in
     let msg_args = [("query", Rpcs.Get_best_tip.query_to_yojson query)] in
     let%bind result, sender =
@@ -894,8 +893,7 @@ let create (config : Config.t)
         else None
   in
   let get_telemetry_data_rpc conn ~version:_ query =
-    [%log debug] "Sending telemetry data to peer with IP %s"
-      (Unix.Inet_addr.to_string conn.Peer.host) ;
+    [%log debug] "Sending telemetry data to $peer" ~metadata:(md conn) ;
     let action_msg = "Telemetry_data" in
     let msg_args = [] in
     (* if peer doesn't return telemetry data, don't change trust score *)
@@ -905,8 +903,7 @@ let create (config : Config.t)
     result
   in
   let get_transition_chain_proof_rpc conn ~version:_ query =
-    [%log info] "Sending transition_chain_proof to peer with IP %s"
-      (Unix.Inet_addr.to_string conn.Peer.host) ;
+    [%log debug] "Sending transition_chain_proof to $peer" ~metadata:(md conn) ;
     let action_msg = "Get_transition_chain_proof query: $query" in
     let msg_args =
       [("query", Rpcs.Get_transition_chain_proof.query_to_yojson query)]
@@ -918,8 +915,7 @@ let create (config : Config.t)
     record_unknown_item result sender action_msg msg_args
   in
   let get_transition_chain_rpc conn ~version:_ query =
-    [%log info] "Sending transition_chain to peer with IP %s"
-      (Unix.Inet_addr.to_string conn.Peer.host) ;
+    [%log debug] "Sending transition_chain to $peer" ~metadata:(md conn) ;
     let action_msg = "Get_transition_chain query: $query" in
     let msg_args =
       [("query", Rpcs.Get_transition_chain.query_to_yojson query)]

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -49,7 +49,7 @@ type Structured_log_events.t +=
  *   - add the new constructor for Rpcs.rpc to Rpcs.all_of_type_erased_rpc
  *   - add a pattern matching case to Rpcs.implementation_of_rpc mapping the
  *     new constructor to the new module for your RPC
-*)
+ *)
 module Rpcs = struct
   (* for versioning of the types here, see
 
@@ -60,58 +60,7 @@ module Rpcs = struct
      The "master" types are the ones used internally in the code base. Each
      version has coercions between their query and response types and the master
      types.
-  *)
-
-  module Get_some_initial_peers = struct
-    module Master = struct
-      let name = "get_some_initial_peers"
-
-      module T = struct
-        type query = unit [@@deriving sexp, yojson]
-
-        type response = Network_peer.Peer.t list [@@deriving sexp, yojson]
-      end
-
-      module Caller = T
-      module Callee = T
-    end
-
-    include Master.T
-    module M = Versioned_rpc.Both_convert.Plain.Make (Master)
-    include M
-
-    include Perf_histograms.Rpc.Plain.Extend (struct
-      include M
-      include Master
-    end)
-
-    module V1 = struct
-      module T = struct
-        type query = unit [@@deriving bin_io, version {rpc}]
-
-        type response = Network_peer.Peer.Stable.V1.t list
-        [@@deriving bin_io, version {rpc}]
-
-        let query_of_caller_model = Fn.id
-
-        let callee_model_of_query = Fn.id
-
-        let response_of_callee_model = Fn.id
-
-        let caller_model_of_response = Fn.id
-      end
-
-      module T' =
-        Perf_histograms.Rpc.Plain.Decorate_bin_io (struct
-            include M
-            include Master
-          end)
-          (T)
-
-      include T'
-      include Register (T')
-    end
-  end
+   *)
 
   module Get_staged_ledger_aux_and_pending_coinbases_at_hash = struct
     module Master = struct
@@ -602,8 +551,6 @@ module Rpcs = struct
   end
 
   type ('query, 'response) rpc =
-    | Get_some_initial_peers
-        : (Get_some_initial_peers.query, Get_some_initial_peers.response) rpc
     | Get_staged_ledger_aux_and_pending_coinbases_at_hash
         : ( Get_staged_ledger_aux_and_pending_coinbases_at_hash.query
           , Get_staged_ledger_aux_and_pending_coinbases_at_hash.response )
@@ -630,8 +577,6 @@ module Rpcs = struct
 
   let implementation_of_rpc : type q r.
       (q, r) rpc -> (q, r) Rpc_intf.rpc_implementation = function
-    | Get_some_initial_peers ->
-        (module Get_some_initial_peers)
     | Get_staged_ledger_aux_and_pending_coinbases_at_hash ->
         (module Get_staged_ledger_aux_and_pending_coinbases_at_hash)
     | Answer_sync_ledger_query ->
@@ -658,8 +603,6 @@ module Rpcs = struct
       -> 'a option =
    fun handler rpc ~do_ ->
     match (rpc, handler) with
-    | Get_some_initial_peers, Rpc_handler (Get_some_initial_peers, f) ->
-        Some (do_ f)
     | ( Get_staged_ledger_aux_and_pending_coinbases_at_hash
       , Rpc_handler (Get_staged_ledger_aux_and_pending_coinbases_at_hash, f) )
       ->
@@ -679,7 +622,6 @@ module Rpcs = struct
         Some (do_ f)
     | Consensus_rpc rpc_a, Rpc_handler (Consensus_rpc rpc_b, f) ->
         Consensus.Hooks.Rpcs.match_handler (Rpc_handler (rpc_b, f)) rpc_a ~do_
-    (* TODO: Why is there a catch-all here? *)
     | _ ->
         None
 end
@@ -756,9 +698,6 @@ let wrap_rpc_data_in_envelope conn data =
   Envelope.Incoming.wrap_peer ~data ~sender:conn
 
 let create (config : Config.t)
-    ~(get_some_initial_peers :
-          Rpcs.Get_some_initial_peers.query Envelope.Incoming.t
-       -> Rpcs.Get_some_initial_peers.response Deferred.t)
     ~(get_staged_ledger_aux_and_pending_coinbases_at_hash :
           Rpcs.Get_staged_ledger_aux_and_pending_coinbases_at_hash.query
           Envelope.Incoming.t
@@ -913,9 +852,9 @@ let create (config : Config.t)
     in
     return result
   in
-  let md p = [("peer", Peer.to_yojson p)] in
   let get_ancestry_rpc conn ~version:_ query =
-    [%log debug] "Sending root proof to $peer" ~metadata:(md conn) ;
+    [%log debug] "Sending root proof to peer with IP %s"
+      (Unix.Inet_addr.to_string conn.Peer.host) ;
     let action_msg = "Get_ancestry query: $query" in
     let msg_args = [("query", Rpcs.Get_ancestry.query_to_yojson query)] in
     let%bind result, sender =
@@ -930,17 +869,9 @@ let create (config : Config.t)
         in
         if valid_protocol_versions then result else None
   in
-  let get_some_initial_peers_rpc (conn : Peer.t) ~version:_ () =
-    [%log trace] "Sending some initial peers to $peer" ~metadata:(md conn) ;
-    let action_msg = "Get_some_initial_peers query: $query" in
-    let msg_args = [("query", `Assoc [])] in
-    let%map result, _sender =
-      run_for_rpc_result conn () ~f:get_some_initial_peers action_msg msg_args
-    in
-    result
-  in
   let get_best_tip_rpc conn ~version:_ query =
-    [%log debug] "Sending best_tip to $peer" ~metadata:(md conn) ;
+    [%log debug] "Sending best_tip to peer with IP %s"
+      (Unix.Inet_addr.to_string conn.Peer.host) ;
     let action_msg = "Get_best_tip. query: $query" in
     let msg_args = [("query", Rpcs.Get_best_tip.query_to_yojson query)] in
     let%bind result, sender =
@@ -963,7 +894,8 @@ let create (config : Config.t)
         else None
   in
   let get_telemetry_data_rpc conn ~version:_ query =
-    [%log debug] "Sending telemetry data to $peer" ~metadata:(md conn) ;
+    [%log debug] "Sending telemetry data to peer with IP %s"
+      (Unix.Inet_addr.to_string conn.Peer.host) ;
     let action_msg = "Telemetry_data" in
     let msg_args = [] in
     (* if peer doesn't return telemetry data, don't change trust score *)
@@ -973,7 +905,8 @@ let create (config : Config.t)
     result
   in
   let get_transition_chain_proof_rpc conn ~version:_ query =
-    [%log info] "Sending transition_chain_proof to $peer" ~metadata:(md conn) ;
+    [%log info] "Sending transition_chain_proof to peer with IP %s"
+      (Unix.Inet_addr.to_string conn.Peer.host) ;
     let action_msg = "Get_transition_chain_proof query: $query" in
     let msg_args =
       [("query", Rpcs.Get_transition_chain_proof.query_to_yojson query)]
@@ -985,7 +918,8 @@ let create (config : Config.t)
     record_unknown_item result sender action_msg msg_args
   in
   let get_transition_chain_rpc conn ~version:_ query =
-    [%log info] "Sending transition_chain to $peer" ~metadata:(md conn) ;
+    [%log info] "Sending transition_chain to peer with IP %s"
+      (Unix.Inet_addr.to_string conn.Peer.host) ;
     let action_msg = "Get_transition_chain query: $query" in
     let msg_args =
       [("query", Rpcs.Get_transition_chain.query_to_yojson query)]
@@ -1011,7 +945,7 @@ let create (config : Config.t)
     (* the port in `conn' is an ephemeral port, not of interest *)
     [%log warn] "Node banned by peer $peer until $ban_until"
       ~metadata:
-        [ ("peer", Peer.to_yojson conn)
+        [ ("peer", `String (Unix.Inet_addr.to_string conn.Peer.host))
         ; ( "ban_until"
           , `String (Time.to_string_abs ~zone:Time.Zone.utc ban_until) ) ] ;
     (* no computation to do; we're just getting notification *)
@@ -1019,8 +953,7 @@ let create (config : Config.t)
   in
   let rpc_handlers =
     let open Rpcs in
-    [ Rpc_handler (Get_some_initial_peers, get_some_initial_peers_rpc)
-    ; Rpc_handler
+    [ Rpc_handler
         ( Get_staged_ledger_aux_and_pending_coinbases_at_hash
         , get_staged_ledger_aux_and_pending_coinbases_at_hash_rpc )
     ; Rpc_handler (Answer_sync_ledger_query, answer_sync_ledger_query_rpc)
@@ -1046,50 +979,15 @@ let create (config : Config.t)
     (Gossip_net.Any.on_first_connect gossip_net ~f:(fun () ->
          (* After first_connect this list will only be empty if we filtered out all the peers due to mismatched chain id. *)
          don't_wait_for
-           (let%bind initial_peers = Gossip_net.Any.peers gossip_net in
+           (let%map initial_peers = Gossip_net.Any.peers gossip_net in
             if List.is_empty initial_peers && not config.is_seed then (
               [%log fatal] "Failed to connect to any initial peers" ;
-              raise No_initial_peers )
-            else (
-              [%log info] "Getting some extra initial peers to start" ;
-              (* 1. Get some peers
-               * 2. add them to go
-              *)
-              let metadata p e =
-                [ ("error", `String (Error.to_string_hum e))
-                ; ("peer", `String (Peer.to_string p)) ]
-              in
-              let%bind extra_initial_peers =
-                Deferred.List.concat_map initial_peers ~how:`Parallel
-                  ~f:(fun peer ->
-                    match%map
-                      Gossip_net.Any.query_peer ~timeout:(Time.Span.of_sec 10.)
-                        gossip_net peer.peer_id Rpcs.Get_some_initial_peers ()
-                    with
-                    | Connected {data= Ok xs; _} ->
-                        xs
-                    | Connected {data= Error e; _} | Failed_to_connect e ->
-                        [%log warn] ~metadata:(metadata peer e)
-                          "could not get initial peers from $peer with $error" ;
-                        [] )
-              in
-              [%log info]
-                ~metadata:
-                  [("peers", [%to_yojson: Peer.t list] extra_initial_peers)]
-                "Got extra $peers" ;
-              Deferred.List.iter ~how:`Sequential extra_initial_peers
-                ~f:(fun p ->
-                  match%map Gossip_net.Any.add_peer gossip_net p with
-                  | Ok () ->
-                      ()
-                  | Error e ->
-                      [%log warn] ~metadata:(metadata p e)
-                        "failed to add peer $peer with $error" ) )) )) ;
+              raise No_initial_peers )) )) ;
   (* TODO: Think about buffering:
-        I.e., what do we do when too many messages are coming in, or going out.
-        For example, some things you really want to not drop (like your outgoing
-        block announcment).
-     *)
+     I.e., what do we do when too many messages are coming in, or going out.
+     For example, some things you really want to not drop (like your outgoing
+     block announcment).
+  *)
   let received_gossips, online_notifier =
     Strict_pipe.Reader.Fork.two
       (Gossip_net.Any.received_message_reader gossip_net)
@@ -1372,8 +1270,8 @@ let glue_sync_ledger :
     -> unit =
  fun t query_reader response_writer ->
   (* We attempt to query 3 random peers, retry_max times. We keep track of the
-          peers that couldn't answer a particular query and won't try them
-          again. *)
+     peers that couldn't answer a particular query and won't try them
+     again. *)
   let retry_max = 6 in
   let retry_interval = Core.Time.Span.of_ms 200. in
   let rec answer_query ctr peers_tried query =
@@ -1397,8 +1295,8 @@ let glue_sync_ledger :
                   %{sexp: Ledger_hash.t}"
                 peer (fst query) ;
               (* TODO : here is a place where an envelope could contain
-                    a Peer.t, and not just an IP address, if desired
-                 *)
+                 a Peer.t, and not just an IP address, if desired
+              *)
               Some (Envelope.Incoming.wrap ~data:answer ~sender)
           | Connected {data= Ok (Error e); _} ->
               [%log' info t.logger]

--- a/src/lib/coda_networking/coda_networking.mli
+++ b/src/lib/coda_networking/coda_networking.mli
@@ -106,15 +106,7 @@ module Rpcs : sig
     type response = Telemetry_data.t Or_error.t [@@deriving to_yojson]
   end
 
-  module Get_some_initial_peers : sig
-    type query = unit [@@deriving sexp, to_yojson]
-
-    type response = Network_peer.Peer.t list [@@deriving to_yojson]
-  end
-
   type ('query, 'response) rpc =
-    | Get_some_initial_peers
-        : (Get_some_initial_peers.query, Get_some_initial_peers.response) rpc
     | Get_staged_ledger_aux_and_pending_coinbases_at_hash
         : ( Get_staged_ledger_aux_and_pending_coinbases_at_hash.query
           , Get_staged_ledger_aux_and_pending_coinbases_at_hash.response )
@@ -277,9 +269,6 @@ val ban_notification_reader :
 
 val create :
      Config.t
-  -> get_some_initial_peers:(   Rpcs.Get_some_initial_peers.query
-                                Envelope.Incoming.t
-                             -> Rpcs.Get_some_initial_peers.response Deferred.t)
   -> get_staged_ledger_aux_and_pending_coinbases_at_hash:(   Rpcs
                                                              .Get_staged_ledger_aux_and_pending_coinbases_at_hash
                                                              .query

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -106,7 +106,6 @@ let setup (type n) ?(logger = Logger.null ())
                     , expected_merkle_root
                     , pending_coinbases
                     , protocol_states )) )
-                ~get_some_initial_peers:(fun _ -> Deferred.return [])
                 ~answer_sync_ledger_query:(fun query_env ->
                   let ledger_hash, _ = Envelope.Incoming.data query_env in
                   Sync_handler.answer_query ~frontier ledger_hash

--- a/src/lib/gossip_net/any.ml
+++ b/src/lib/gossip_net/any.ml
@@ -46,7 +46,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
 
   let random_peers_except (Any ((module M), t)) = M.random_peers_except t
 
-  let query_peer (Any ((module M), t)) = M.query_peer t
+  let query_peer ?timeout (Any ((module M), t)) = M.query_peer ?timeout t
 
   let query_random_peers (Any ((module M), t)) = M.query_random_peers t
 

--- a/src/lib/gossip_net/any.ml
+++ b/src/lib/gossip_net/any.ml
@@ -40,15 +40,13 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
 
   let peers (Any ((module M), t)) = M.peers t
 
-  let add_peer (Any ((module M), t)) xs = M.add_peer t xs
-
   let initial_peers (Any ((module M), t)) = M.initial_peers t
 
   let random_peers (Any ((module M), t)) = M.random_peers t
 
   let random_peers_except (Any ((module M), t)) = M.random_peers_except t
 
-  let query_peer ?timeout (Any ((module M), t)) = M.query_peer ?timeout t
+  let query_peer (Any ((module M), t)) = M.query_peer t
 
   let query_random_peers (Any ((module M), t)) = M.query_random_peers t
 

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -192,8 +192,6 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
 
     let peers {peer_table; _} = Hashtbl.data peer_table |> Deferred.return
 
-    let add_peer _ (_p : Peer.t) = Deferred.return (Ok ())
-
     let initial_peers t =
       Hashtbl.data t.peer_table
       |> List.map
@@ -221,7 +219,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
     let ban_notification_reader {ban_notification_reader; _} =
       ban_notification_reader
 
-    let query_peer ?timeout:_ t peer rpc query =
+    let query_peer t peer rpc query =
       Network.call_rpc t.network t.peer_table ~sender_id:t.me.peer_id
         ~responder_id:peer rpc query
 

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -219,7 +219,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
     let ban_notification_reader {ban_notification_reader; _} =
       ban_notification_reader
 
-    let query_peer t peer rpc query =
+    let query_peer ?timeout:_ t peer rpc query =
       Network.call_rpc t.network t.peer_table ~sender_id:t.me.peer_id
         ~responder_id:peer rpc query
 

--- a/src/lib/gossip_net/intf.ml
+++ b/src/lib/gossip_net/intf.ml
@@ -18,8 +18,6 @@ module type Gossip_net_intf = sig
 
   val initial_peers : t -> Coda_net2.Multiaddr.t list
 
-  val add_peer : t -> Peer.t -> unit Deferred.Or_error.t
-
   val connection_gating : t -> Coda_net2.connection_gating Deferred.t
 
   val set_connection_gating :
@@ -31,12 +29,7 @@ module type Gossip_net_intf = sig
     t -> int -> except:Peer.Hash_set.t -> Peer.t list Deferred.t
 
   val query_peer :
-       ?timeout:Time.Span.t
-    -> t
-    -> Peer.Id.t
-    -> ('q, 'r) Rpc_intf.rpc
-    -> 'q
-    -> 'r rpc_response Deferred.t
+    t -> Peer.Id.t -> ('q, 'r) Rpc_intf.rpc -> 'q -> 'r rpc_response Deferred.t
 
   val query_random_peers :
        t

--- a/src/lib/gossip_net/intf.ml
+++ b/src/lib/gossip_net/intf.ml
@@ -29,7 +29,12 @@ module type Gossip_net_intf = sig
     t -> int -> except:Peer.Hash_set.t -> Peer.t list Deferred.t
 
   val query_peer :
-    t -> Peer.Id.t -> ('q, 'r) Rpc_intf.rpc -> 'q -> 'r rpc_response Deferred.t
+       ?timeout:Time.Span.t
+    -> t
+    -> Peer.Id.t
+    -> ('q, 'r) Rpc_intf.rpc
+    -> 'q
+    -> 'r rpc_response Deferred.t
 
   val query_random_peers :
        t

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -461,13 +461,14 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
         n
 
     let try_call_rpc_with_dispatch : type r q.
-           t
+           ?timeout:Time.Span.t
+        -> t
         -> Peer.t
         -> Async.Rpc.Transport.t
         -> (r, q) dispatch
         -> r
         -> q Deferred.Or_error.t =
-     fun t peer transport dispatch query ->
+     fun ?timeout t peer transport dispatch query ->
       let call () =
         Monitor.try_with (fun () ->
             (* Async_rpc_kernel takes a transport instead of a Reader.t *)
@@ -475,7 +476,17 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
               ~connection_state:(Fn.const ())
               ~dispatch_queries:(fun conn ->
                 Versioned_rpc.Connection_with_menu.create conn
-                >>=? fun conn' -> dispatch conn' query )
+                >>=? fun conn' ->
+                let d = dispatch conn' query in
+                match timeout with
+                | None ->
+                    d
+                | Some timeout ->
+                    Deferred.any
+                      [ d
+                      ; ( after timeout
+                        >>| fun () -> Or_error.error_string "rpc timed out" )
+                      ] )
               transport
               ~on_handshake_error:
                 (`Call
@@ -546,12 +557,19 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
       call ()
 
     let try_call_rpc : type q r.
-        t -> Peer.t -> _ -> (q, r) rpc -> q -> r Deferred.Or_error.t =
-     fun t peer transport rpc query ->
+           ?timeout:Time.Span.t
+        -> t
+        -> Peer.t
+        -> _
+        -> (q, r) rpc
+        -> q
+        -> r Deferred.Or_error.t =
+     fun ?timeout t peer transport rpc query ->
       let (module Impl) = implementation_of_rpc rpc in
-      try_call_rpc_with_dispatch t peer transport Impl.dispatch_multi query
+      try_call_rpc_with_dispatch ?timeout t peer transport Impl.dispatch_multi
+        query
 
-    let query_peer t (peer_id : Peer.Id.t) rpc rpc_input =
+    let query_peer ?timeout t (peer_id : Peer.Id.t) rpc rpc_input =
       let%bind net2 = !(t.net2) in
       match%bind
         Coda_net2.open_stream net2 ~protocol:rpc_transport_proto peer_id
@@ -559,7 +577,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
       | Ok stream ->
           let peer = Coda_net2.Stream.remote_peer stream in
           let transport = prepare_stream_transport stream in
-          try_call_rpc t peer transport rpc rpc_input
+          try_call_rpc ?timeout t peer transport rpc rpc_input
           >>| fun data ->
           Connected (Envelope.Incoming.wrap_peer ~data ~sender:peer)
       | Error e ->

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -482,11 +482,10 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                 | None ->
                     d
                 | Some timeout ->
-                    Deferred.any
-                      [ d
-                      ; ( after timeout
-                        >>| fun () -> Or_error.error_string "rpc timed out" )
-                      ] )
+                    Deferred.choose
+                      [ choice d Fn.id
+                      ; choice (after timeout) (fun () ->
+                            Or_error.error_string "rpc timed out" ) ] )
               transport
               ~on_handshake_error:
                 (`Call


### PR DESCRIPTION
This reverts commit 48395d15a5afded95240fb632ca877a61db09c89, reversing
changes made to 3f23f0cf22896b9d4eec0749a0853660d563948c.

We attempted to add in this hack to bootstrap our initial peer set, but this is not preferable because it would make it trivial for an adversary to get a detailed understanding of the network topology. Moreover, this code actually never worked because we currently have an issue where the `on_new_peer` callback fails to fire from our libp2p-helper. We should fix the libp2p-helper on_new_peer callback as this will fix a broken metric, but we don't want this RPC to exist anymore, instead we'll solve this initial peer bootstrapping with #6583 