### PR TITLE
Default token contributes to total currency

### DIFF
--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -52,7 +52,10 @@ module Make (Inputs : Inputs_intf) = struct
       let num_accounts = Mask.Attached.num_accounts mask in
       let total_currency =
         Mask.Attached.foldi mask ~init:0 ~f:(fun _ total_currency account ->
-            total_currency + (Balance.to_int @@ Account.balance account) )
+            (* only default token matters for total currency *)
+            if Token_id.equal (Account.token account) Token_id.default then
+              total_currency + (Balance.to_int @@ Account.balance account)
+            else total_currency )
       in
       let uuid = format_uuid mask in
       { hash= Visualization.display_prefix_of_string @@ Hash.to_string root_hash


### PR DESCRIPTION
Only accounts with a balance in the default token may stake. At two places in the code, the total currency was computed by summing all balances in a ledger, regardless of the token id.

After a hard fork, even the genesis ledger may contain accounts using a non-default token.

Change those computations to only include balances for accounts with the default token.

Reviewer: Do the "supply increase" amounts used to increase total currency elsewhere in the code always represent the default token?