### PR TITLE
remove command overrides for Helm daemon container specs

### DIFF
--- a/helm/archive-node/Chart.yaml
+++ b/helm/archive-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: archive-node
 description: A Helm chart for Coda Protocol's archive node
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.16.0
 dependencies:
   - name: postgresql

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -30,7 +30,6 @@ spec:
             memory: 14.0Gi
             cpu: 2.0
         image: {{ $.Values.coda.image }}
-        command: ["/usr/bin/dumb-init", "/root/init_coda.sh"]
         args: [ "daemon",
           "-log-level", {{ $.Values.coda.logLevel }},
           "-log-json",
@@ -81,7 +80,6 @@ spec:
       # Archive Process
       - name: archive
         image: {{ $.Values.archive.image }}
-        command: ["bash", "-c"]
         args: [ "coda-archive run -postgres-uri {{ tpl .Values.archive.postgresUri . }} -server-port 3086" ]
         env:
         imagePullPolicy: Always

--- a/helm/block-producer/Chart.yaml
+++ b/helm/block-producer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: block-producer
 description: A Helm chart for Coda Protocol's block producing network nodes
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: 1.16.0
 dependencies:
 icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/static/img/coda-logo@3x.png

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -152,7 +152,6 @@ spec:
             memory: 14.0Gi
             cpu: 8.0
         image: {{ $.Values.coda.image }}
-        command: ["/usr/bin/dumb-init", "/root/init_coda.sh"]
         args: [ "daemon",
           "-log-level", {{ $.Values.coda.logLevel }},
           "-log-json",

--- a/helm/seed-node/Chart.yaml
+++ b/helm/seed-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: seed-node
 description: A Helm chart for Coda Protocol's seed nodes
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.16.0
 dependencies:
 icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/static/img/coda-logo@3x.png

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -42,7 +42,6 @@ spec:
             memory: 14.0Gi
             cpu: 8.0
         image: {{ $.Values.coda.image }}
-        command: ["/usr/bin/dumb-init", "/root/init_coda.sh"]
         args: [ "daemon",
           "-log-level", "Trace",
           "-log-json",

--- a/helm/snark-worker/Chart.yaml
+++ b/helm/snark-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: snark-worker
 description: A Helm chart for Coda Protocol's SNARK worker nodes
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: 1.16.0
 dependencies:
 icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/static/img/coda-logo@3x.png

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -30,7 +30,6 @@ spec:
             memory: 18.5Gi
             cpu: 8.0
         image: {{ $.Values.coda.image }}
-        command: ["/usr/bin/dumb-init", "/root/init_coda.sh"]
         args: [ "daemon",
           "-log-level", "Trace",
           "-log-json",

--- a/scripts/archive/Dockerfile
+++ b/scripts/archive/Dockerfile
@@ -29,3 +29,5 @@ RUN apt-get -y update && \
 RUN echo "deb [trusted=yes] http://packages.o1test.net $deb_repo main" > /etc/apt/sources.list.d/coda.list \
   && apt-get -y update \
   && apt-get install -y "coda-archive=$coda_deb_version"
+
+ENTRYPOINT ["bash", "-c"]


### PR DESCRIPTION
Remove the command definition redundancy and instead rely on the default ENTRYPOINT set by an image.

Also this change enables `coda_daemon_puppeteered` images to be substituted in place of the generic daemon image within Helm daemon specs as the puppeteered image's custom ENTRYPOINT will be respected and not overridden.

**Testing:** Buildkite CI

**Checklist:**

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
