### PR TITLE
destroy persisted epoch ledgers when genesis state changes

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -738,6 +738,8 @@ let setup_daemon logger =
                 Public_key.compress keypair.public_key )
           |> Option.to_list |> Public_key.Compressed.Set.of_list )
           ~ledger_depth:precomputed_values.constraint_constants.ledger_depth
+          ~genesis_state_hash:
+            (With_hash.hash precomputed_values.protocol_state_with_hash)
       in
       trace_database_initialization "consensus local state" __LOC__ trust_dir ;
       let initial_peers =

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -507,6 +507,8 @@ module T = struct
             Consensus.Data.Local_state.create initial_block_production_keys
               ~genesis_ledger:Genesis_ledger.t ~epoch_ledger_location
               ~ledger_depth:constraint_constants.ledger_depth
+              ~genesis_state_hash:
+                (With_hash.hash precomputed_values.protocol_state_with_hash)
           in
           let gossip_net_params =
             Gossip_net.Libp2p.Config.

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -144,6 +144,8 @@ let run_test () : unit Deferred.t =
           (Public_key.Compressed.Set.singleton
              (Public_key.compress keypair.public_key))
           ~ledger_depth:constraint_constants.ledger_depth
+          ~genesis_state_hash:
+            (With_hash.hash precomputed_values.protocol_state_with_hash)
       in
       let client_port = 8123 in
       let libp2p_port = 8002 in

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -312,6 +312,7 @@ module type S = sig
         -> genesis_ledger:Ledger.t Lazy.t
         -> epoch_ledger_location:string
         -> ledger_depth:int
+        -> genesis_state_hash:State_hash.t
         -> t
 
       val current_block_production_keys :

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -388,7 +388,7 @@ module Data = struct
             in
             [%log info]
               "Cleaning up old epoch ledgers with genesis state $state_hash \
-               at location $staking and $next"
+               at locations $staking and $next"
               ~metadata:
                 [ ( "state_hash"
                   , Coda_base.State_hash.to_yojson

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -245,7 +245,10 @@ module Data = struct
     end
 
     module Data = struct
-      type epoch_ledger_uuids = {staking: Uuid.t; next: Uuid.t}
+      type epoch_ledger_uuids =
+        { staking: Uuid.t
+        ; next: Uuid.t
+        ; genesis_state_hash: Coda_base.State_hash.t }
 
       (* Invariant: Snapshot's delegators are taken from accounts in block_production_pubkeys *)
       type t =
@@ -304,22 +307,33 @@ module Data = struct
           Table.add_exn last_checked_slot_and_epoch ~key:pk ~data ) ;
       last_checked_slot_and_epoch
 
-    let epoch_ledger_uuids_to_yojson Data.{staking; next} =
+    let epoch_ledger_uuids_to_yojson Data.{staking; next; genesis_state_hash} =
       `Assoc
         [ ("staking", `String (Uuid.to_string staking))
-        ; ("next", `String (Uuid.to_string next)) ]
+        ; ("next", `String (Uuid.to_string next))
+        ; ( "genesis_state_hash"
+          , Coda_base.State_hash.to_yojson genesis_state_hash ) ]
 
     let epoch_ledger_uuids_from_file location =
-      let open Yojson.Basic.Util in
-      let json = Yojson.Basic.from_file location in
-      Data.
-        { staking= json |> member "staking" |> to_string |> Uuid.of_string
-        ; next= json |> member "next" |> to_string |> Uuid.of_string }
+      let open Yojson.Safe.Util in
+      let open Result.Let_syntax in
+      let json = Yojson.Safe.from_file location in
+      let uuid str =
+        Result.(
+          map_error
+            (try_with (fun () -> Uuid.of_string str))
+            ~f:(fun ex -> Exn.to_string ex))
+      in
+      let%bind staking = json |> member "staking" |> to_string |> uuid in
+      let%bind next = json |> member "next" |> to_string |> uuid in
+      let%map genesis_state_hash =
+        json |> member "genesis_state_hash" |> Coda_base.State_hash.of_yojson
+      in
+      Data.{staking; next; genesis_state_hash}
 
-    let create_epoch_ledger ~location ~genesis_ledger ~ledger_depth =
+    let create_epoch_ledger ~location ~logger ~genesis_ledger ~ledger_depth =
       let open Coda_base in
       if Sys.file_exists location then (
-        let logger = Logger.create () in
         [%log info]
           ~metadata:[("location", `String location)]
           "Loading epoch ledger from disk: $location" ;
@@ -328,34 +342,76 @@ module Data = struct
       else Snapshot.Ledger_snapshot.Genesis_ledger genesis_ledger
 
     let create block_producer_pubkeys ~genesis_ledger ~epoch_ledger_location
-        ~ledger_depth =
+        ~ledger_depth ~genesis_state_hash =
       (* TODO: remove this duplicate of the genesis ledger *)
       let open Coda_base in
       let genesis_ledger = Lazy.force genesis_ledger in
       let epoch_ledger_uuids_location = epoch_ledger_location ^ ".json" in
+      let logger = Logger.create () in
+      let create_new_uuids () =
+        let epoch_ledger_uuids =
+          Data.
+            { staking= Uuid_unix.create ()
+            ; next= Uuid_unix.create ()
+            ; genesis_state_hash }
+        in
+        Yojson.Safe.to_file epoch_ledger_uuids_location
+          (epoch_ledger_uuids_to_yojson epoch_ledger_uuids) ;
+        epoch_ledger_uuids
+      in
+      let ledger_location uuid = epoch_ledger_location ^ Uuid.to_string uuid in
       let epoch_ledger_uuids =
-        if Sys.file_exists epoch_ledger_uuids_location then
-          epoch_ledger_uuids_from_file epoch_ledger_uuids_location
-        else
+        if Sys.file_exists epoch_ledger_uuids_location then (
           let epoch_ledger_uuids =
-            Data.{staking= Uuid_unix.create (); next= Uuid_unix.create ()}
+            match epoch_ledger_uuids_from_file epoch_ledger_uuids_location with
+            | Ok res ->
+                res
+            | Error str ->
+                [%log error]
+                  "Failed to read epoch ledger uuids from file $path: $error"
+                  ~metadata:
+                    [ ("path", `String epoch_ledger_uuids_location)
+                    ; ("error", `String str) ] ;
+                failwith "Failed to load epoch ledger uuids from file"
           in
-          Yojson.Basic.to_file epoch_ledger_uuids_location
-            (epoch_ledger_uuids_to_yojson epoch_ledger_uuids) ;
-          epoch_ledger_uuids
+          if
+            Coda_base.State_hash.equal epoch_ledger_uuids.genesis_state_hash
+              genesis_state_hash
+          then epoch_ledger_uuids
+          else
+            (*Clean-up outdated epoch ledgers*)
+            let staking_ledger_location =
+              ledger_location epoch_ledger_uuids.staking
+            in
+            let next_ledger_location =
+              ledger_location epoch_ledger_uuids.next
+            in
+            [%log info]
+              "Cleaning up old epoch ledgers with genesis state $state_hash \
+               at location $staking and $next"
+              ~metadata:
+                [ ( "state_hash"
+                  , Coda_base.State_hash.to_yojson
+                      epoch_ledger_uuids.genesis_state_hash )
+                ; ("staking", `String staking_ledger_location)
+                ; ("next", `String next_ledger_location) ] ;
+            File_system.rmrf staking_ledger_location ;
+            File_system.rmrf next_ledger_location ;
+            create_new_uuids () )
+        else create_new_uuids ()
       in
       let staking_epoch_ledger_location =
-        epoch_ledger_location ^ Uuid.to_string epoch_ledger_uuids.staking
+        ledger_location epoch_ledger_uuids.staking
       in
       let staking_epoch_ledger =
-        create_epoch_ledger ~location:staking_epoch_ledger_location
+        create_epoch_ledger ~location:staking_epoch_ledger_location ~logger
           ~genesis_ledger ~ledger_depth
       in
       let next_epoch_ledger_location =
-        epoch_ledger_location ^ Uuid.to_string epoch_ledger_uuids.next
+        ledger_location epoch_ledger_uuids.next
       in
       let next_epoch_ledger =
-        create_epoch_ledger ~location:next_epoch_ledger_location
+        create_epoch_ledger ~location:next_epoch_ledger_location ~logger
           ~genesis_ledger ~ledger_depth
       in
       ref
@@ -2971,10 +3027,12 @@ module Hooks = struct
       let epoch_ledger_uuids =
         Local_state.Data.
           { staking= !local_state.epoch_ledger_uuids.next
-          ; next= Uuid_unix.create () }
+          ; next= Uuid_unix.create ()
+          ; genesis_state_hash=
+              !local_state.epoch_ledger_uuids.genesis_state_hash }
       in
       !local_state.epoch_ledger_uuids <- epoch_ledger_uuids ;
-      Yojson.Basic.to_file
+      Yojson.Safe.to_file
         (!local_state.epoch_ledger_location ^ ".json")
         (Local_state.epoch_ledger_uuids_to_yojson epoch_ledger_uuids) ;
       !local_state.next_epoch_snapshot

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -166,6 +166,8 @@ module Generator = struct
       Consensus.Data.Local_state.create Public_key.Compressed.Set.empty
         ~genesis_ledger ~epoch_ledger_location
         ~ledger_depth:precomputed_values.constraint_constants.ledger_depth
+        ~genesis_state_hash:
+          (With_hash.hash precomputed_values.protocol_state_with_hash)
     in
     let%map frontier =
       Transition_frontier.For_tests.gen ~precomputed_values
@@ -186,6 +188,8 @@ module Generator = struct
       Consensus.Data.Local_state.create Public_key.Compressed.Set.empty
         ~genesis_ledger ~epoch_ledger_location
         ~ledger_depth:precomputed_values.constraint_constants.ledger_depth
+        ~genesis_state_hash:
+          (With_hash.hash precomputed_values.protocol_state_with_hash)
     in
     let%map frontier, branch =
       Transition_frontier.For_tests.gen_with_branch ~precomputed_values

--- a/src/lib/file_system/file_system.ml
+++ b/src/lib/file_system/file_system.ml
@@ -19,7 +19,7 @@ let rec rmrf path =
       |> Array.iter ~f:(fun name -> rmrf (Filename.concat path name)) ;
       Core.Unix.rmdir path
   | _ ->
-      Core.Sys.remove path
+      if Core.Sys.file_exists path = `Yes then Core.Sys.remove path
 
 let try_finally ~(f : unit -> 'a Deferred.t)
     ~(finally : unit -> unit Deferred.t) =

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -56,6 +56,8 @@ let%test_module "Full_frontier tests" =
         Consensus.Data.Local_state.create Public_key.Compressed.Set.empty
           ~genesis_ledger:Genesis_ledger.t ~epoch_ledger_location
           ~ledger_depth:constraint_constants.ledger_depth
+          ~genesis_state_hash:
+            (With_hash.hash precomputed_values.protocol_state_with_hash)
       in
       let root_ledger =
         Or_error.ok_exn

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -583,7 +583,9 @@ module For_tests = struct
              ~genesis_ledger:
                (Precomputed_values.genesis_ledger precomputed_values)
              ~epoch_ledger_location Public_key.Compressed.Set.empty
-             ~ledger_depth:precomputed_values.constraint_constants.ledger_depth)
+             ~ledger_depth:precomputed_values.constraint_constants.ledger_depth
+             ~genesis_state_hash:
+               (With_hash.hash precomputed_values.protocol_state_with_hash))
     in
     let root_snarked_ledger, root_ledger_accounts = root_ledger_and_accounts in
     (* TODO: ensure that rose_tree cannot be longer than k *)


### PR DESCRIPTION
Added genesis_state_hash to the uuid file
If the genesis state hash the daemon is running on doesn't match the one in the uuid file then remove the epoch ledgers corresponding to the uuids

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
