### PR TITLE
Trivial: Run Timer.log after aggregating timing information

### DIFF
--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -421,7 +421,6 @@ struct
                        %{sexp:Transaction_snark.Statement.t}"
                      transaction.statement expected_statement) )
     in
-    Timer.log "scan_statement" timer ;
     let res =
       Fold.fold_chronological_until tree ~init:None
         ~f_merge:(fun acc (_weight, job) ->
@@ -440,6 +439,7 @@ struct
               Stop e )
         ~finish:Result.return
     in
+    Timer.log "scan_statement" timer ;
     match res with
     | Ok None ->
         M.return (Error `Empty)


### PR DESCRIPTION
Currently this is being run before any information is collected, so it's logging no information. This PR moves it so that the log will contain the actual information that we record.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: