### PR TITLE
Rosetta, add epoch data columns to SQL

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -131,8 +131,7 @@ module Epoch_data = struct
     in
     let%bind ledger_hash_id = Snarked_ledger_hash.find (module Conn) hash in
     let seed =
-      Coda_base.Epoch_data.Poly.Stable.V1.seed t
-      |> Snark_params.Tick.Field.to_string
+      Coda_base.Epoch_data.Poly.seed t |> Snark_params.Tick.Field.to_string
     in
     match%bind
       Conn.find_opt

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -207,16 +207,16 @@ module Sql = struct
          * backwards until it reaches a block of the given height. *)
         {|
 WITH RECURSIVE chain AS (
-  (SELECT id, state_hash, parent_id, creator_id, snarked_ledger_hash_id, ledger_hash, height, timestamp FROM blocks b WHERE height = (select MAX(height) from blocks)
+  (SELECT id, state_hash, parent_id, creator_id, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id, ledger_hash, height, timestamp FROM blocks b WHERE height = (select MAX(height) from blocks)
   ORDER BY timestamp ASC
   LIMIT 1)
 
   UNION ALL
 
-  SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.ledger_hash, b.height, b.global_slot, b.timestamp FROM blocks b
+  SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.timestamp FROM blocks b
   INNER JOIN chain
-  ON b.id = chain.parent_id
-) SELECT c.id, c.state_hash, c.parent_id, c.creator_id, c.snarked_ledger_hash_id, c.ledger_hash, c.height, c.global_slot, c.timestamp, pk.value as creator FROM chain c
+  ON b.id = chain.parent_id AND chain.id <> chain.parent_id
+) SELECT c.id, c.state_hash, c.parent_id, c.creator_id, c.snarked_ledger_hash_id, c.staking_epoch_data_id, c.next_epoch_data_id, c.ledger_hash, c.height, c.global_slot, c.timestamp, pk.value as creator FROM chain c
   INNER JOIN public_keys pk
   ON pk.id = c.creator_id
   WHERE c.height = ?
@@ -224,7 +224,7 @@ WITH RECURSIVE chain AS (
 
     let query_hash =
       Caqti_request.find_opt Caqti_type.string typ
-        {| SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.ledger_hash, b.height, b.global_slot, b.timestamp, pk.value as creator FROM blocks b
+        {| SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.timestamp, pk.value as creator FROM blocks b
         INNER JOIN public_keys pk
         ON pk.id = b.creator_id
         WHERE b.state_hash = ? |}
@@ -233,28 +233,26 @@ WITH RECURSIVE chain AS (
       Caqti_request.find_opt
         Caqti_type.(tup2 string int64)
         typ
-        {| SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.ledger_hash, b.height, b.global_slot, b.timestamp, pk.value as creator FROM blocks b
+        {| SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.timestamp, pk.value as creator FROM blocks b
         INNER JOIN public_keys pk
         ON pk.id = b.creator_id
         WHERE b.state_hash = ? AND b.height = ? |}
 
     let query_by_id =
       Caqti_request.find_opt Caqti_type.int typ
-        {| SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.ledger_hash, b.height, b.global_slot, b.timestamp, pk.value as creator FROM blocks b
+        {| SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.timestamp, pk.value as creator FROM blocks b
         INNER JOIN public_keys pk
         ON pk.id = b.creator_id
         WHERE b.id = ? |}
 
     let query_best =
       Caqti_request.find_opt Caqti_type.unit typ
-        {|
-SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.ledger_hash, b.height, b.global_slot, b.timestamp, pk.value as creator FROM blocks b
-      INNER JOIN public_keys pk
-      ON pk.id = b.creator_id
-      WHERE b.height = (select MAX(b.height) from blocks b)
-      ORDER BY timestamp ASC
-      LIMIT 1
-        |}
+        {| SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.timestamp, pk.value as creator FROM blocks b
+           INNER JOIN public_keys pk
+           ON pk.id = b.creator_id
+           WHERE b.height = (select MAX(b.height) from blocks b)
+           ORDER BY timestamp ASC
+           LIMIT 1 |}
 
     let run_by_id (module Conn : Caqti_async.CONNECTION) id =
       Conn.find_opt query_by_id id


### PR DESCRIPTION
In Rosetta, the SQL queries for blocks were missing the new epoch data columns. Added those in this PR.

Also, the recursive query for block height adds a recursion-stopper, because the genesis block's parent id is the block id.
