### PR TITLE
Stop libp2p_helper logspam

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1121,8 +1121,8 @@ func main() {
 	logging.SetLogLevel("nat", "debug")
 	logging.SetLogLevel("autorelay", "info") // Logs relayed byte counts spammily
 	logging.SetLogLevel("providers", "debug")
-	logging.SetLogLevel("dht/RtRefreshManager", "debug")
-	logging.SetLogLevel("dht", "debug") // Trace and debug logs are mixed at debug level :(
+	logging.SetLogLevel("dht/RtRefreshManager", "info") // Ping logs are spammy. Possibly should be above info to avoid cpl logs.
+	logging.SetLogLevel("dht", "info") // Logs every operation to debug
 	logging.SetLogLevel("peerstore", "debug")
 	logging.SetLogLevel("diversityFilter", "debug")
 	logging.SetLogLevel("table", "debug")

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1121,7 +1121,7 @@ func main() {
 	logging.SetLogLevel("nat", "debug")
 	logging.SetLogLevel("autorelay", "info") // Logs relayed byte counts spammily
 	logging.SetLogLevel("providers", "debug")
-	logging.SetLogLevel("dht/RtRefreshManager", "info") // Ping logs are spammy. Possibly should be above info to avoid cpl logs.
+	logging.SetLogLevel("dht/RtRefreshManager", "warn") // Ping logs are spammy at debug, cpl logs are spammy at info
 	logging.SetLogLevel("dht", "info") // Logs every operation to debug
 	logging.SetLogLevel("peerstore", "debug")
 	logging.SetLogLevel("diversityFilter", "debug")

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1101,6 +1101,48 @@ func main() {
 	})
 	helperLog := logging.Logger("helper top-level JSON handling")
 
+	helperLog.Infof("libp2p_helper has the following logging subsystems active: %v", logging.GetSubsystems())
+
+	// === Set subsystem log levels ===
+	// All subsystems that have been considered are explicitly listed. Any that
+	// are added when modifying this code should be considered and added to
+	// this list.
+	logging.SetLogLevel("mplex", "debug")
+	logging.SetLogLevel("addrutil", "info")     // Logs every resolve call at debug
+	logging.SetLogLevel("net/identify", "info") // Logs every message sent/received at debug
+	logging.SetLogLevel("ping", "info")         // Logs every ping timeout at debug
+	logging.SetLogLevel("basichost", "info")    // Spammy at debug
+	logging.SetLogLevel("test-logger", "debug")
+	logging.SetLogLevel("blankhost", "debug")
+	logging.SetLogLevel("connmgr", "debug")
+	logging.SetLogLevel("eventlog", "debug")
+	logging.SetLogLevel("p2p-config", "debug")
+	logging.SetLogLevel("ipns", "debug")
+	logging.SetLogLevel("nat", "debug")
+	logging.SetLogLevel("autorelay", "info") // Logs relayed byte counts spammily
+	logging.SetLogLevel("providers", "debug")
+	logging.SetLogLevel("dht/RtRefreshManager", "debug")
+	logging.SetLogLevel("dht", "debug") // Trace and debug logs are mixed at debug level :(
+	logging.SetLogLevel("peerstore", "debug")
+	logging.SetLogLevel("diversityFilter", "debug")
+	logging.SetLogLevel("table", "debug")
+	logging.SetLogLevel("stream-upgrader", "debug")
+	logging.SetLogLevel("helper top-level JSON handling", "debug")
+	logging.SetLogLevel("dht.pb", "debug")
+	logging.SetLogLevel("tcp-tpt", "debug")
+	logging.SetLogLevel("autonat", "debug")
+	logging.SetLogLevel("discovery", "debug")
+	logging.SetLogLevel("routing/record", "debug")
+	logging.SetLogLevel("pubsub", "debug") // Spammy about blacklisted peers, maybe should be info?
+	logging.SetLogLevel("badger", "debug")
+	logging.SetLogLevel("relay", "info") // Log relayed byte counts spammily
+	logging.SetLogLevel("routedhost", "debug")
+	logging.SetLogLevel("swarm2", "info") // Logs a new stream to each peer when opended at debug
+	logging.SetLogLevel("peerstore/ds", "debug")
+	logging.SetLogLevel("mdns", "info") // Logs each mdns call
+	logging.SetLogLevel("bootstrap", "debug")
+	logging.SetLogLevel("reuseport-transport", "debug")
+
 	go func() {
 		i := 0
 		for {


### PR DESCRIPTION
This PR modifies the log level of some logging subsystems in go to reduce the level of logspam.
* The active logging subsystems are now listed in the log at startup
* The currently active logging subsystems are enumerated and set an appropriate log level by this PR
  - Any log level modified from the default is given a justification comment
  - I have looked at the code for each subsystem to work out whether the log level can/should be changed
  - Some of these decisions are subjective; I have erred on the side of minimising spam without losing information, but a few comments note where the level could be raised further.

This fixes #6517.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: