### PR TITLE
Make delegation test fast again

### DIFF
--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -866,6 +866,7 @@ module Test_configs = struct
   , "genesis":
       { "k": 4
       , "delta": 0
+      , "slots_per_epoch": 72
       , "genesis_state_timestamp": "2019-01-30 12:00:00-08:00" }
   , "proof":
       { "level": "check"


### PR DESCRIPTION
This adds `slots_per_epoch` to the delegation test config file. This was missed as part of #6455, causing the ~1hr40 test runtimes that we've been seeing. Runtime should now be ~20 mins.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: