### PR TITLE
More flexible, more detailed go log parsing

### DIFF
--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -137,6 +137,9 @@ module Go_log = struct
                   let%map msg = set_field "msg" msg string_of_yojson json in
                   (ts, module_, level, msg, metadata)
               | _ ->
+                  let field =
+                    if String.equal field "error" then "go_error" else field
+                  in
                   Ok
                     ( ts
                     , module_


### PR DESCRIPTION
This PR fixes #6425. It
* updates the go log message parser to accept fields in any order
* accepts additional fields that aren't in the OCaml type, storing them in a `metadata` object
  - previously these fields would cause an error
  - this object is passed to our logger, so the information is not lost
  - the `error` property is special-cased to alias to `go_error`, to keep consistency with prior logs
* gives cleaner, more descriptive error messages than the generated ones when parsing errors occur

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: