### PR TITLE
don't fail on epoch_ledger.json read error

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -368,11 +368,12 @@ module Data = struct
                 res
             | Error str ->
                 [%log error]
-                  "Failed to read epoch ledger uuids from file $path: $error"
+                  "Failed to read epoch ledger uuids from file $path: $error. \
+                   Creating new uuids.."
                   ~metadata:
                     [ ("path", `String epoch_ledger_uuids_location)
                     ; ("error", `String str) ] ;
-                failwith "Failed to load epoch ledger uuids from file"
+                create_new_uuids ()
           in
           if
             Coda_base.State_hash.equal epoch_ledger_uuids.genesis_state_hash


### PR DESCRIPTION
replacing it with new uuids instead

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #6631
