### PR TITLE
Bisect_ppx --conditional for marlin_plonk_bindings

### DIFF
--- a/src/lib/marlin_plonk_bindings/bigint_256/dune
+++ b/src/lib/marlin_plonk_bindings/bigint_256/dune
@@ -2,4 +2,4 @@
  (name marlin_plonk_bindings_bigint_256)
  (public_name marlin_plonk_bindings.bigint_256)
  (libraries marlin_plonk_bindings_stubs)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/bigint_256/test/dune
+++ b/src/lib/marlin_plonk_bindings/bigint_256/test/dune
@@ -2,4 +2,4 @@
  (name test)
  (libraries marlin_plonk_bindings_bigint_256)
  (foreign_archives ../../stubs/marlin_plonk_stubs)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/bigint_384/dune
+++ b/src/lib/marlin_plonk_bindings/bigint_384/dune
@@ -2,4 +2,4 @@
  (name marlin_plonk_bindings_bigint_384)
  (public_name marlin_plonk_bindings.bigint_384)
  (libraries marlin_plonk_bindings_stubs)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/bigint_384/test/dune
+++ b/src/lib/marlin_plonk_bindings/bigint_384/test/dune
@@ -2,4 +2,4 @@
  (name test)
  (libraries marlin_plonk_bindings_bigint_384)
  (foreign_archives ../../stubs/marlin_plonk_stubs)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/bn_382_fp/dune
+++ b/src/lib/marlin_plonk_bindings/bn_382_fp/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bigint_384)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/bn_382_fp/vector/dune
+++ b/src/lib/marlin_plonk_bindings/bn_382_fp/vector/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bn_382_fp)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/bn_382_fq/dune
+++ b/src/lib/marlin_plonk_bindings/bn_382_fq/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bigint_384)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/bn_382_fq/vector/dune
+++ b/src/lib/marlin_plonk_bindings/bn_382_fq/vector/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bn_382_fq)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/dune
+++ b/src/lib/marlin_plonk_bindings/dune
@@ -35,4 +35,4 @@
    ;; Oracles
    marlin_plonk_bindings_tweedle_fp_oracles
    marlin_plonk_bindings_tweedle_fq_oracles)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/stubs/dune
+++ b/src/lib/marlin_plonk_bindings/stubs/dune
@@ -18,4 +18,4 @@
  (name marlin_plonk_bindings_stubs)
  (foreign_archives marlin_plonk_stubs)
  (c_library_flags :standard "-lpthread")
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_dee/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_dee/dune
@@ -6,4 +6,4 @@
    marlin_plonk_bindings_types
    marlin_plonk_bindings_tweedle_fp
    marlin_plonk_bindings_tweedle_fq)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_dum/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_dum/dune
@@ -6,4 +6,4 @@
    marlin_plonk_bindings_types
    marlin_plonk_bindings_tweedle_fp
    marlin_plonk_bindings_tweedle_fq)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bigint_256)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp/vector/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp/vector/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fp)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_index/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_index/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fp_urs)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_oracles/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_oracles/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fp_proof)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fp_index)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_proof/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_proof/dune
@@ -5,4 +5,4 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fp_verifier_index
    marlin_plonk_bindings_tweedle_fp_vector)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_urs/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_urs/dune
@@ -7,4 +7,4 @@
    marlin_plonk_bindings_tweedle_fp
    marlin_plonk_bindings_tweedle_fq
    marlin_plonk_bindings_tweedle_dee)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_urs/test/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_urs/test/dune
@@ -1,4 +1,4 @@
 (executable
  (name test)
  (libraries marlin_plonk_bindings_tweedle_fp_urs)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bigint_256)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq/vector/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq/vector/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fq)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_index/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_index/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fq_urs)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_oracles/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_oracles/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fq_proof)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/dune
@@ -4,4 +4,4 @@
  (libraries
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fq_index)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_proof/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_proof/dune
@@ -5,4 +5,4 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fq_verifier_index
    marlin_plonk_bindings_tweedle_fq_vector)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_urs/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_urs/dune
@@ -7,4 +7,4 @@
    marlin_plonk_bindings_tweedle_fp
    marlin_plonk_bindings_tweedle_fq
    marlin_plonk_bindings_tweedle_dum)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_urs/test/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_urs/test/dune
@@ -1,4 +1,4 @@
 (executable
  (name test)
  (libraries marlin_plonk_bindings_tweedle_fq_urs)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))

--- a/src/lib/marlin_plonk_bindings/types/dune
+++ b/src/lib/marlin_plonk_bindings/types/dune
@@ -1,4 +1,4 @@
 (library
  (public_name marlin_plonk_bindings.types)
  (name marlin_plonk_bindings_types)
- (preprocess (pps ppx_version bisect_ppx)))
+ (preprocess (pps ppx_version bisect_ppx --conditional)))


### PR DESCRIPTION
This stops `bisect_ppx` from computing statistics on every compile for `marlin_plonk_bindings`

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: