### PR TITLE
fix txn_global_slot in the replayer

### DIFF
--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -264,7 +264,7 @@ let run_internal_command ~logger ~pool ~ledger (cmd : Sql.Internal_command.t) =
   let fee = Currency.Fee.of_uint64 (Unsigned.UInt64.of_int64 cmd.fee) in
   let fee_token = Token_id.of_uint64 (Unsigned.UInt64.of_int64 cmd.token) in
   let txn_global_slot =
-    cmd.global_slot |> Unsigned.UInt32.of_int64
+    cmd.txn_global_slot |> Unsigned.UInt32.of_int64
     |> Coda_numbers.Global_slot.of_uint32
   in
   let fail_on_error err =
@@ -340,7 +340,7 @@ let apply_combined_fee_transfer ~logger ~pool ~ledger
           (Error.to_string_hum err) ()
   in
   let txn_global_slot =
-    cmd2.global_slot |> Unsigned.UInt32.of_int64
+    cmd2.txn_global_slot |> Unsigned.UInt32.of_int64
     |> Coda_numbers.Global_slot.of_uint32
   in
   let undo_or_error =
@@ -434,7 +434,7 @@ let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t) =
         valid_signed_cmd) =
     Signed_command.to_valid_unsafe signed_cmd
   in
-  let txn_global_slot = Unsigned.UInt32.of_int64 cmd.global_slot in
+  let txn_global_slot = Unsigned.UInt32.of_int64 cmd.txn_global_slot in
   match
     Ledger.apply_user_command ~constraint_constants ~txn_global_slot ledger
       valid_signed_cmd

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -82,6 +82,7 @@ module User_command = struct
     ; nonce: int64
     ; block_id: int
     ; global_slot: int64
+    ; txn_global_slot: int64
     ; sequence_no: int }
 
   let typ =
@@ -91,13 +92,13 @@ module User_command = struct
         ( (t.type_, t.fee_payer_id, t.source_id, t.receiver_id)
         , (t.fee, t.fee_token, t.token, t.amount)
         , (t.memo, t.nonce)
-        , (t.block_id, t.global_slot, t.sequence_no) )
+        , (t.block_id, t.global_slot, t.txn_global_slot, t.sequence_no) )
     in
     let decode
         ( (type_, fee_payer_id, source_id, receiver_id)
         , (fee, fee_token, token, amount)
         , (memo, nonce)
-        , (block_id, global_slot, sequence_no) ) =
+        , (block_id, global_slot, txn_global_slot, sequence_no) ) =
       Ok
         { type_
         ; fee_payer_id
@@ -111,20 +112,21 @@ module User_command = struct
         ; nonce
         ; block_id
         ; global_slot
+        ; txn_global_slot
         ; sequence_no }
     in
     let rep =
       Caqti_type.(
         tup4 (tup4 string int int int)
           (tup4 int64 int64 int64 (option int64))
-          (tup2 string int64) (tup3 int int64 int))
+          (tup2 string int64) (tup4 int int64 int64 int))
     in
     Caqti_type.custom ~encode ~decode rep
 
   let query =
     Caqti_request.collect Caqti_type.int typ
       {|
-         SELECT type,fee_payer_id, source_id,receiver_id,fee,fee_token,token,amount,memo,nonce,blocks.id,global_slot,sequence_no,status FROM
+         SELECT type,fee_payer_id, source_id,receiver_id,fee,fee_token,token,amount,memo,nonce,blocks.id,blocks.global_slot,parent.global_slot,sequence_no,status FROM
 
          (SELECT * FROM user_commands WHERE id = ?) AS uc
 
@@ -141,6 +143,12 @@ module User_command = struct
          ON
 
          blocks.id = buc.block_id
+
+         INNER JOIN blocks as parent
+
+         ON
+
+         parent.id = blocks.parent_id
 
        |}
 
@@ -165,6 +173,7 @@ module Internal_command = struct
     ; token: int64
     ; block_id: int
     ; global_slot: int64
+    ; txn_global_slot: int64
     ; sequence_no: int
     ; secondary_sequence_no: int }
 
@@ -175,13 +184,13 @@ module Internal_command = struct
         ( (t.type_, t.receiver_id)
         , (t.fee, t.token)
         , (t.block_id, t.global_slot)
-        , (t.sequence_no, t.secondary_sequence_no) )
+        , (t.txn_global_slot, t.sequence_no, t.secondary_sequence_no) )
     in
     let decode
         ( (type_, receiver_id)
         , (fee, token)
         , (block_id, global_slot)
-        , (sequence_no, secondary_sequence_no) ) =
+        , (txn_global_slot, sequence_no, secondary_sequence_no) ) =
       Ok
         { type_
         ; receiver_id
@@ -189,20 +198,21 @@ module Internal_command = struct
         ; token
         ; block_id
         ; global_slot
+        ; txn_global_slot
         ; sequence_no
         ; secondary_sequence_no }
     in
     let rep =
       Caqti_type.(
         tup4 (tup2 string int) (tup2 int64 int64) (tup2 int int64)
-          (tup2 int int))
+          (tup3 int64 int int))
     in
     Caqti_type.custom ~encode ~decode rep
 
   let query =
     Caqti_request.collect Caqti_type.int typ
       {|
-         SELECT type,receiver_id,fee,token,blocks.id,global_slot,sequence_no,secondary_sequence_no FROM
+         SELECT type,receiver_id,fee,token,blocks.id,blocks.global_slot,parent.global_slot,sequence_no,secondary_sequence_no FROM
 
          (SELECT * FROM internal_commands WHERE id = ?) AS ic
 
@@ -219,6 +229,12 @@ module Internal_command = struct
          blocks
 
          ON blocks.id = bic.block_id
+
+         INNER JOIN blocks as parent
+
+         ON
+
+         parent.id = blocks.parent_id
 
        |}
 


### PR DESCRIPTION
Use the slot number of the parent block for transaction application

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
