### PR TITLE
Fix libp2p initial peers RPC is triggered now

### DIFF
--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -11,10 +11,11 @@ import (
 	dsb "github.com/ipfs/go-ds-badger"
 	logging "github.com/ipfs/go-log"
 	p2p "github.com/libp2p/go-libp2p"
-	connmgr "github.com/libp2p/go-libp2p-connmgr"
+	p2pconnmgr "github.com/libp2p/go-libp2p-connmgr"
+	"github.com/libp2p/go-libp2p-core/connmgr"
 	"github.com/libp2p/go-libp2p-core/control"
-	crypto "github.com/libp2p/go-libp2p-core/crypto"
-	host "github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
@@ -30,19 +31,82 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
+type CodaConnectionManager struct {
+	p2pManager   *p2pconnmgr.BasicConnMgr
+	OnConnect    func(network.Network, network.Conn)
+	OnDisconnect func(network.Network, network.Conn)
+}
+
+func newCodaConnectionManager() *CodaConnectionManager {
+	noop := func(net network.Network, c network.Conn) {}
+
+	return &CodaConnectionManager{
+		p2pManager:   p2pconnmgr.NewConnManager(25, 250, time.Duration(30*time.Second)),
+		OnConnect:    noop,
+		OnDisconnect: noop,
+	}
+}
+
+// proxy p2pconnmgr.ConnManager interface to p2pconnmgr.BasicConnMgr
+func (cm *CodaConnectionManager) TagPeer(p peer.ID, tag string, weight int) {
+	cm.p2pManager.TagPeer(p, tag, weight)
+}
+func (cm *CodaConnectionManager) UntagPeer(p peer.ID, tag string) { cm.p2pManager.UntagPeer(p, tag) }
+func (cm *CodaConnectionManager) UpsertTag(p peer.ID, tag string, upsert func(int) int) {
+	cm.p2pManager.UpsertTag(p, tag, upsert)
+}
+func (cm *CodaConnectionManager) GetTagInfo(p peer.ID) *connmgr.TagInfo {
+	return cm.p2pManager.GetTagInfo(p)
+}
+func (cm *CodaConnectionManager) TrimOpenConns(ctx context.Context) { cm.p2pManager.TrimOpenConns(ctx) }
+func (cm *CodaConnectionManager) Protect(p peer.ID, tag string)     { cm.p2pManager.Protect(p, tag) }
+func (cm *CodaConnectionManager) Unprotect(p peer.ID, tag string) bool {
+	return cm.p2pManager.Unprotect(p, tag)
+}
+func (cm *CodaConnectionManager) IsProtected(p peer.ID, tag string) bool {
+	return cm.p2pManager.IsProtected(p, tag)
+}
+func (cm *CodaConnectionManager) Close() error { return cm.p2pManager.Close() }
+
+// redirect Notifee() to self for notification interception
+func (cm *CodaConnectionManager) Notifee() network.Notifiee { return cm }
+
+// proxy Notifee notifications to p2pconnmgr.BasicConnMgr, intercepting Connected and Disconnected
+func (cm *CodaConnectionManager) Listen(net network.Network, addr ma.Multiaddr) {
+	cm.p2pManager.Notifee().Listen(net, addr)
+}
+func (cm *CodaConnectionManager) ListenClose(net network.Network, addr ma.Multiaddr) {
+	cm.p2pManager.Notifee().ListenClose(net, addr)
+}
+func (cm *CodaConnectionManager) OpenedStream(net network.Network, stream network.Stream) {
+	cm.p2pManager.Notifee().OpenedStream(net, stream)
+}
+func (cm *CodaConnectionManager) ClosedStream(net network.Network, stream network.Stream) {
+	cm.p2pManager.Notifee().ClosedStream(net, stream)
+}
+func (cm *CodaConnectionManager) Connected(net network.Network, c network.Conn) {
+	cm.OnConnect(net, c)
+	cm.p2pManager.Notifee().Connected(net, c)
+}
+func (cm *CodaConnectionManager) Disconnected(net network.Network, c network.Conn) {
+	cm.OnDisconnect(net, c)
+	cm.p2pManager.Notifee().Disconnected(net, c)
+}
+
 // Helper contains all the daemon state
 type Helper struct {
-	Host            host.Host
-	Mdns            *mdns.Service
-	Dht             *dual.DHT
-	Ctx             context.Context
-	Pubsub          *pubsub.PubSub
-	Logger          logging.EventLogger
-	DiscoveredPeers chan peer.AddrInfo
-	Rendezvous      string
-	Discovery       *discovery.RoutingDiscovery
-	Me              peer.ID
-	GatingState     *CodaGatingState
+	Host              host.Host
+	Mdns              *mdns.Service
+	Dht               *dual.DHT
+	Ctx               context.Context
+	Pubsub            *pubsub.PubSub
+	Logger            logging.EventLogger
+	DiscoveredPeers   chan peer.AddrInfo
+	Rendezvous        string
+	Discovery         *discovery.RoutingDiscovery
+	Me                peer.ID
+	GatingState       *CodaGatingState
+	ConnectionManager *CodaConnectionManager
 }
 
 type customValidator struct {
@@ -165,13 +229,15 @@ func MakeHelper(ctx context.Context, listenOn []ma.Multiaddr, externalAddr ma.Mu
 	// gross hack to exfiltrate the DHT from the side effect of option evaluation
 	kadch := make(chan *dual.DHT)
 
+	connManager := newCodaConnectionManager()
+
 	host, err := p2p.New(ctx,
 		p2p.Muxer("/coda/mplex/1.0.0", DefaultMplexTransport),
 		p2p.Identity(pk),
 		p2p.Peerstore(ps),
 		p2p.DisableRelay(),
 		p2p.ConnectionGater(&gatingState),
-		p2p.ConnectionManager(connmgr.NewConnManager(25, 250, time.Duration(30*time.Second))),
+		p2p.ConnectionManager(connManager),
 		p2p.ListenAddrs(listenOn...),
 		p2p.AddrsFactory(func(as []ma.Multiaddr) []ma.Multiaddr {
 			as = append(as, externalAddr)
@@ -195,16 +261,17 @@ func MakeHelper(ctx context.Context, listenOn []ma.Multiaddr, externalAddr ma.Mu
 
 	// nil fields are initialized by beginAdvertising
 	return &Helper{
-		Host:            host,
-		Ctx:             ctx,
-		Mdns:            nil,
-		Dht:             kad,
-		Pubsub:          nil,
-		Logger:          logger,
-		DiscoveredPeers: nil,
-		Rendezvous:      rendezvousString,
-		Discovery:       nil,
-		Me:              me,
-		GatingState:     &gatingState,
+		Host:              host,
+		Ctx:               ctx,
+		Mdns:              nil,
+		Dht:               kad,
+		Pubsub:            nil,
+		Logger:            logger,
+		DiscoveredPeers:   nil,
+		Rendezvous:        rendezvousString,
+		Discovery:         nil,
+		Me:                me,
+		GatingState:       &gatingState,
+		ConnectionManager: connManager,
 	}, nil
 }

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1100,6 +1100,9 @@ func main() {
 	// All subsystems that have been considered are explicitly listed. Any that
 	// are added when modifying this code should be considered and added to
 	// this list.
+    // The levels below set the **minimum** log level for each subsystem.
+    // Messages emitted at lower levels than the given level will not be
+    // emitted.
 	logging.SetLogLevel("mplex", "debug")
 	logging.SetLogLevel("addrutil", "info")     // Logs every resolve call at debug
 	logging.SetLogLevel("net/identify", "info") // Logs every message sent/received at debug

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1115,6 +1115,7 @@ func main() {
 	logging.SetLogLevel("autorelay", "info") // Logs relayed byte counts spammily
 	logging.SetLogLevel("providers", "debug")
 	logging.SetLogLevel("dht/RtRefreshManager", "warn") // Ping logs are spammy at debug, cpl logs are spammy at info
+	logging.SetLogLevel("dht", "info") // Logs every operation to debug
 	logging.SetLogLevel("peerstore", "debug")
 	logging.SetLogLevel("diversityFilter", "debug")
 	logging.SetLogLevel("table", "debug")

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1115,7 +1115,6 @@ func main() {
 	logging.SetLogLevel("autorelay", "info") // Logs relayed byte counts spammily
 	logging.SetLogLevel("providers", "debug")
 	logging.SetLogLevel("dht/RtRefreshManager", "warn") // Ping logs are spammy at debug, cpl logs are spammy at info
-	logging.SetLogLevel("dht", "debug")                 // Logs every operation to debug
 	logging.SetLogLevel("peerstore", "debug")
 	logging.SetLogLevel("diversityFilter", "debug")
 	logging.SetLogLevel("table", "debug")

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -904,8 +904,7 @@ func (ap *beginAdvertisingMsg) run(app *app) (interface{}, error) {
 	}
 	app.P2p.ConnectionManager.OnDisconnect = func(net net.Network, c net.Conn) {
 		logger.Infof("dropped connection: %+v", c)
-		// TODO: notify daemon that we dropped a peer (I think?)
-		// foundPeer(c.RemotePeer())
+		foundPeer(c.RemotePeer())
 	}
 
 	go func() {
@@ -1116,7 +1115,7 @@ func main() {
 	logging.SetLogLevel("autorelay", "info") // Logs relayed byte counts spammily
 	logging.SetLogLevel("providers", "debug")
 	logging.SetLogLevel("dht/RtRefreshManager", "warn") // Ping logs are spammy at debug, cpl logs are spammy at info
-	logging.SetLogLevel("dht", "info") // Logs every operation to debug
+	logging.SetLogLevel("dht", "debug")                 // Logs every operation to debug
 	logging.SetLogLevel("peerstore", "debug")
 	logging.SetLogLevel("diversityFilter", "debug")
 	logging.SetLogLevel("table", "debug")

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -23,7 +23,6 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	coredisc "github.com/libp2p/go-libp2p-core/discovery"
-	"github.com/libp2p/go-libp2p-core/event"
 	net "github.com/libp2p/go-libp2p-core/network"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	peerstore "github.com/libp2p/go-libp2p-core/peerstore"
@@ -898,21 +897,16 @@ func (ap *beginAdvertisingMsg) run(app *app) (interface{}, error) {
 
 	discovery.Advertise(app.Ctx, routingDiscovery, app.P2p.Rendezvous)
 
-	bus := app.P2p.Host.EventBus()
-	// report new peers we find peers
-	go func() {
-		sub, err := bus.Subscribe(new(event.EvtPeerConnectednessChanged))
-		if err != nil {
-			panic(err)
-		}
-
-		for evt := range sub.Out() {
-			e := evt.(event.EvtPeerConnectednessChanged)
-			if validPeer(e.Peer) {
-				foundPeer(e.Peer)
-			}
-		}
-	}()
+	logger := logging.Logger("libp2p_helper.beginAdvertisingMsg.notifications")
+	app.P2p.ConnectionManager.OnConnect = func(net net.Network, c net.Conn) {
+		logger.Infof("new connection: %+v", c)
+		foundPeer(c.RemotePeer())
+	}
+	app.P2p.ConnectionManager.OnDisconnect = func(net net.Network, c net.Conn) {
+		logger.Infof("dropped connection: %+v", c)
+		// TODO: notify daemon that we dropped a peer (I think?)
+		// foundPeer(c.RemotePeer())
+	}
 
 	go func() {
 		for {

--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -1206,6 +1206,7 @@ let list_peers net =
   | Error _ ->
       []
 
+(* `on_new_peer` fires whenever a peer connects OR disconnects *)
 let configure net ~logger:_ ~me ~external_maddr ~maddrs ~network_id
     ~on_new_peer ~unsafe_no_trust_ip ~flooding ~direct_peers ~peer_exchange
     ~seed_peers ~initial_gating_config =


### PR DESCRIPTION
Tries triggering RPC for real with foundPeer on connect and disconnect

EDIT: Tested on `peering` network (which partially deployed). Confirmed that (1) the network peers metric increases (this means the callback is called properly). (2) the get some initial peers call is happening (3) it is successfully sending peers back to those that join on first connect and (4) there are no errors when trying to add those peers.