### PR TITLE
CLI docstring fixes

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -255,7 +255,7 @@ let setup_daemon logger =
   and config_files =
     flag "config-file"
       ~doc:
-        "PATH path a the configuration file (overrides CODA_CONFIG_FILE, \
+        "PATH path to a configuration file (overrides CODA_CONFIG_FILE, \
          default: <config_dir>/daemon.json). Pass multiple times to override \
          fields from earlier config files"
       (listed string)

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -54,7 +54,7 @@ let get_balance_graphql =
   let open Command.Param in
   let pk_flag =
     flag "public-key"
-      ~doc:"KEY Public key for which you want to check the balance"
+      ~doc:"PUBLICKEY Public key for which you want to check the balance"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   let token_flag =
@@ -86,7 +86,8 @@ let get_balance_graphql =
 let get_tokens_graphql =
   let open Command.Param in
   let pk_flag =
-    flag "public-key" ~doc:"KEY Public key for which you want to find accounts"
+    flag "public-key"
+      ~doc:"PUBLICKEY Public key for which you want to find accounts"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   Command.async ~summary:"Get all token IDs that a public key has accounts for"
@@ -1177,7 +1178,7 @@ let export_key =
   let privkey_path = Cli_lib.Flag.privkey_write_path in
   let pk_flag =
     let open Command.Param in
-    flag "public-key" ~doc:"KEY Public key of account to be exported"
+    flag "public-key" ~doc:"PUBLICKEY Public key of account to be exported"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   let conf_dir = Cli_lib.Flag.conf_dir in
@@ -1324,7 +1325,7 @@ let create_hd_account =
 let unlock_account =
   let open Command.Param in
   let pk_flag =
-    flag "public-key" ~doc:"KEY Public key to be unlocked"
+    flag "public-key" ~doc:"PUBLICKEY Public key to be unlocked"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   Command.async ~summary:"Unlock a tracked account"
@@ -1358,7 +1359,7 @@ let unlock_account =
 let lock_account =
   let open Command.Param in
   let pk_flag =
-    flag "public-key" ~doc:"KEY Public key of account to be locked"
+    flag "public-key" ~doc:"PUBLICKEY Public key of account to be locked"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   Command.async ~summary:"Lock a tracked account"

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -282,7 +282,7 @@ let signed_command_common : signed_command_common Command.Param.t =
   let%map_open sender =
     flag "sender"
       (required public_key_compressed)
-      ~doc:"KEY Public key from which you want to send the transaction"
+      ~doc:"PUBLICKEY Public key from which you want to send the transaction"
   and fee =
     flag "fee"
       ~doc:


### PR DESCRIPTION
Change CLI docstrings to use `PUBLICKEY` uniformly. There had been a mix of that and `KEY`.

Fixed wording in `config-file` docstring.

