### PR TITLE
Trivial: add of_yojson derivers for snark inputs

### DIFF
--- a/src/lib/blockchain_snark/blockchain.ml
+++ b/src/lib/blockchain_snark/blockchain.ml
@@ -6,7 +6,7 @@ open Coda_state
 module Stable = struct
   module V1 = struct
     type t = {state: Protocol_state.Value.Stable.V1.t; proof: Proof.Stable.V1.t}
-    [@@deriving fields, sexp]
+    [@@deriving fields, sexp, yojson]
 
     let to_latest = Fn.id
   end

--- a/src/lib/blockchain_snark/blockchain.mli
+++ b/src/lib/blockchain_snark/blockchain.mli
@@ -6,7 +6,7 @@ open Coda_state
 module Stable : sig
   module V1 : sig
     type t = {state: Protocol_state.Value.t; proof: Proof.Stable.V1.t}
-    [@@deriving bin_io, fields, sexp, version]
+    [@@deriving bin_io, fields, sexp, version, yojson]
   end
 
   module Latest = V1
@@ -14,6 +14,6 @@ end
 
 type t = Stable.Latest.t =
   {state: Protocol_state.Value.t; proof: Proof.Stable.V1.t}
-[@@deriving fields, sexp]
+[@@deriving fields, sexp, yojson]
 
 val create : state:Protocol_state.Value.t -> proof:Proof.Stable.V1.t -> t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -220,7 +220,7 @@ module Statement = struct
           , Token_id.Stable.V1.t
           , Sok_message.Digest.Stable.V1.t )
           Poly.Stable.V1.t
-        [@@deriving compare, equal, hash, sexp, to_yojson]
+        [@@deriving compare, equal, hash, sexp, yojson]
 
         let to_latest = Fn.id
       end
@@ -419,7 +419,7 @@ module Stable = struct
   module V1 = struct
     type t =
       {statement: Statement.With_sok.Stable.V1.t; proof: Proof.Stable.V1.t}
-    [@@deriving compare, fields, sexp, version, to_yojson]
+    [@@deriving compare, fields, sexp, version, yojson]
 
     let to_latest = Fn.id
   end

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -157,7 +157,7 @@ module Statement : sig
           , Token_id.Stable.V1.t
           , Sok_message.Digest.Stable.V1.t )
           Poly.Stable.V1.t
-        [@@deriving compare, equal, hash, sexp, to_yojson]
+        [@@deriving compare, equal, hash, sexp, yojson]
       end
     end]
 
@@ -201,7 +201,7 @@ end
 [%%versioned:
 module Stable : sig
   module V1 : sig
-    type t [@@deriving compare, sexp, to_yojson]
+    type t [@@deriving compare, sexp, yojson]
   end
 end]
 


### PR DESCRIPTION
This PR adds `of_yojson` derivers for the inputs to the transaction and blockchain snarks, so that we can reconstruct the input from logs.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: