### PR TITLE
Export logs via CLI and GraphQL

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -567,6 +567,60 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "TarFile",
+          "description": null,
+          "fields": [
+            {
+              "name": "tarfile",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ExportLogsPayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "exportLogs",
+              "description": "Tar archive containing logs",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TarFile",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "SendMintTokensInput",
           "description": null,
@@ -2705,6 +2759,33 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "SendMintTokensPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "exportLogs",
+              "description": "Export daemon logs to tar archive",
+              "args": [
+                {
+                  "name": "basename",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ExportLogsPayload",
                   "ofType": null
                 }
               },

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -275,16 +275,7 @@ let setup_daemon logger =
   and plugins = plugin_flag in
   fun () ->
     let open Deferred.Let_syntax in
-    let compute_conf_dir home =
-      Option.value ~default:(home ^/ Cli_lib.Default.conf_dir_name) conf_dir
-    in
-    let%bind conf_dir =
-      if is_background then
-        let home = Core.Sys.home_directory () in
-        let conf_dir = compute_conf_dir home in
-        Deferred.return conf_dir
-      else Sys.home_directory () >>| compute_conf_dir
-    in
+    let conf_dir = Coda_lib.Conf_dir.compute_conf_dir conf_dir in
     let%bind () = File_system.create_dir conf_dir in
     let () =
       if is_background then (

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -804,6 +804,25 @@ let cancel_transaction_graphql =
          printf "🛑 Cancelled transaction! Cancel ID: %s\n"
            ((cancel_response#sendPayment)#payment |> unwrap_user_command)#id ))
 
+let export_logs_graphql =
+  let open Command.Param in
+  let tarfile_flag =
+    flag "tarfile"
+      ~doc:"STRING Basename of the tar archive (default: date_time)"
+      (optional string)
+  in
+  let args = tarfile_flag in
+  Command.async ~summary:"Send payment to an address"
+    (Cli_lib.Background_daemon.graphql_init args
+       ~f:(fun graphql_endpoint basename ->
+         let%map response =
+           Graphql_client.query_exn
+             (Graphql_queries.Export_logs.make ?basename ())
+             graphql_endpoint
+         in
+         printf "Exported logs to %s\n%!"
+           ((response#exportLogs)#exportLogs)#tarfile ))
+
 let get_transaction_status =
   Command.async ~summary:"Get the status of a transaction"
     (Cli_lib.Background_daemon.rpc_init
@@ -1729,6 +1748,7 @@ let client =
     ; ("set-staking", set_staking_graphql)
     ; ("set-snark-worker", set_snark_worker)
     ; ("set-snark-work-fee", set_snark_work_fee)
+    ; ("export-logs", export_logs_graphql)
     ; ("stop-daemon", stop_daemon)
     ; ("status", status) ]
 

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -238,6 +238,18 @@ mutation ($sender: PublicKey!,
 }
 |}]
 
+module Export_logs =
+[%graphql
+{|
+mutation ($basename: String) {
+  exportLogs(basename: $basename) {
+    exportLogs {
+      tarfile
+    }
+  }
+}
+|}]
+
 module Get_token_owner =
 [%graphql
 {|

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -2171,40 +2171,9 @@ module Mutations = struct
     ; hash= Transaction_hash.hash_command (Signed_command cmd) }
 
   let export_logs ~coda basename_opt =
-    let open Deferred.Result.Let_syntax in
-    let basename =
-      match basename_opt with
-      | None ->
-          let date, day = Time.(now () |> to_date_ofday ~zone:Zone.utc) in
-          let Time.Span.Parts.{hr; min; sec; _} = Time.Ofday.to_parts day in
-          sprintf "%s_%02d-%02d-%02d" (Date.to_string date) hr min sec
-      | Some basename ->
-          basename
-    in
-    let Coda_lib.Config.{conf_dir; _} = Coda_lib.config coda in
-    let export_dir = conf_dir ^/ "exported_logs" in
-    ( match Core.Sys.file_exists export_dir with
-    | `No ->
-        Core.Unix.mkdir export_dir
-    | _ ->
-        () ) ;
-    let tarfile = export_dir ^/ basename ^ ".tgz" in
-    let log_files =
-      Core.Sys.ls_dir conf_dir
-      |> List.filter ~f:(String.is_suffix ~suffix:".log")
-    in
-    let%map _result =
-      Process.run ~prog:"tar"
-        ~args:
-          ( [ "-C"
-            ; conf_dir
-            ; (* Create gzipped tar file [file]. *)
-              "-czf"
-            ; tarfile ]
-          @ log_files )
-        ()
-    in
-    tarfile
+    let open Coda_lib in
+    let Config.{conf_dir; _} = Coda_lib.config coda in
+    Conf_dir.export_logs_to_tar ?basename:basename_opt ~conf_dir
 
   let send_delegation =
     io_field "sendDelegation"

--- a/src/lib/coda_graphql/dune
+++ b/src/lib/coda_graphql/dune
@@ -5,7 +5,7 @@
    ; opam deps
    async node_addrs_and_ports network_peer core cohttp graphql-async graphql-cohttp
    ; libs
-   logger ppx_deriving_yojson.runtime
+   ppx_deriving_yojson.runtime
    auxiliary_database coda_base coda_commands user_command_input coda_lib)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane ppx_deriving_yojson)))

--- a/src/lib/coda_graphql/dune
+++ b/src/lib/coda_graphql/dune
@@ -5,7 +5,7 @@
    ; opam deps
    async node_addrs_and_ports network_peer core cohttp graphql-async graphql-cohttp
    ; libs
-   ppx_deriving_yojson.runtime
+   logger ppx_deriving_yojson.runtime
    auxiliary_database coda_base coda_commands user_command_input coda_lib)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane ppx_deriving_yojson)))

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -13,23 +13,24 @@ open O1trace
 open Otp_lib
 open Network_peer
 module Config = Config
+module Conf_dir = Conf_dir
 module Subscriptions = Coda_subscriptions
 module Snark_worker_lib = Snark_worker
 
 type Structured_log_events.t += Connecting
-  [@@deriving register_event {msg= "Coda daemon is now connecting"}]
+  [@@deriving register_event {msg= "Coda daemon is connecting"}]
 
 type Structured_log_events.t += Listening
-  [@@deriving register_event {msg= "Coda daemon is now listening"}]
+  [@@deriving register_event {msg= "Coda daemon is listening"}]
 
 type Structured_log_events.t += Bootstrapping
-  [@@deriving register_event {msg= "Coda daemon is now bootstrapping"}]
+  [@@deriving register_event {msg= "Coda daemon is bootstrapping"}]
 
 type Structured_log_events.t += Ledger_catchup
-  [@@deriving register_event {msg= "Coda daemon is now doing ledger catchup"}]
+  [@@deriving register_event {msg= "Coda daemon is doing ledger catchup"}]
 
 type Structured_log_events.t += Synced
-  [@@deriving register_event {msg= "Coda daemon is now synced"}]
+  [@@deriving register_event {msg= "Coda daemon is synced"}]
 
 type Structured_log_events.t +=
   | Rebroadcast_transition of {state_hash: State_hash.t}

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -6,6 +6,7 @@ open Coda_transition
 open Pipe_lib
 open Signature_lib
 module Config = Config
+module Conf_dir = Conf_dir
 module Subscriptions = Coda_subscriptions
 
 type t

--- a/src/lib/coda_lib/conf_dir.ml
+++ b/src/lib/coda_lib/conf_dir.ml
@@ -1,0 +1,43 @@
+(* conf_dir.ml -- config directory management *)
+
+open Core
+
+let compute_conf_dir conf_dir_opt =
+  let home = Sys.home_directory () in
+  Option.value ~default:(home ^/ Cli_lib.Default.conf_dir_name) conf_dir_opt
+
+let export_logs_to_tar ?basename ~conf_dir =
+  let open Async in
+  let open Deferred.Result.Let_syntax in
+  let basename =
+    match basename with
+    | None ->
+        let date, day = Time.(now () |> to_date_ofday ~zone:Zone.utc) in
+        let Time.Span.Parts.{hr; min; sec; _} = Time.Ofday.to_parts day in
+        sprintf "%s_%02d-%02d-%02d" (Date.to_string date) hr min sec
+    | Some basename ->
+        basename
+  in
+  let export_dir = conf_dir ^/ "exported_logs" in
+  ( match Core.Sys.file_exists export_dir with
+  | `No ->
+      Core.Unix.mkdir export_dir
+  | _ ->
+      () ) ;
+  let tarfile = export_dir ^/ basename ^ ".tgz" in
+  let log_files =
+    Core.Sys.ls_dir conf_dir
+    |> List.filter ~f:(String.is_suffix ~suffix:".log")
+  in
+  let%map _result =
+    Process.run ~prog:"tar"
+      ~args:
+        ( [ "-C"
+          ; conf_dir
+          ; (* Create gzipped tar file [file]. *)
+            "-czf"
+          ; tarfile ]
+        @ log_files )
+      ()
+  in
+  tarfile


### PR DESCRIPTION
Add a new subcommand `export-logs` to `coda client`, which takes a `-tarfile` optional flag. The command creates a compressed tar archive in the `exported_logs` subdirectory of the config dir, which is created if it doesn't exist.

The `-tarfile` is a basename for the archive. If omitted, the current date and time to create the basename.

The logs are the `*.log` files at the root of the config dir. (I see other .log files in subdirectories, those could be added, if desired.)

Example:
```
$ coda client export-logs -tarfile my-logs -rest-server 8080 
Exported logs to /home/steck/.coda-config/exported_logs/my-logs.tgz
```
The implementation uses a GraphQL mutation, which returns the created tarfile. The mutation:
```graphql
 exportLogs {
    exportLogs {
      tarfile
    }
  }
}
```
returns
```graphql
 "exportLogs": {
      "exportLogs": {
        "tarfile": "/home/steck/.coda-config/exported_logs/2020-11-16_22-22-24.tgz"
      }
    }
  }
```
The mutation takes `basename` as the optional input.

Closes #6678.

Update:

Added CLI variant `client export-local-logs`, which does not require a running daemon. It takes the additional optional flag `-config-directory`, in case the config dir is not the default.

Moved the tar file-creating code and the computation of the conf dir to `Coda_lib.Conf_dir`. Note: in `Coda`, the computation of the conf dir had two branches chosen by whether the daemon was running in the background. As far as I could tell, those branches computed the same result, so they're merged in the code here.

In `Coda_lib`, removed the word `now` from some structured log messages, which seemed redundant. "Omit needless words" is the guiding principle.