### PR TITLE
Trivial: Stop unnecessarily double-escaping log messages

### DIFF
--- a/src/lib/logger/impl.ml
+++ b/src/lib/logger/impl.ml
@@ -90,23 +90,6 @@ module Message = struct
     ; event_id: Structured_log_events.id option [@default None] }
   [@@deriving yojson]
 
-  let escape_chars = ['"'; '\\']
-
-  let to_yojson =
-    let escape =
-      Staged.unstage
-      @@ String.Escaping.escape ~escapeworthy:escape_chars ~escape_char:'\\'
-    in
-    fun t -> to_yojson {t with message= escape t.message}
-
-  let of_yojson =
-    let unescape =
-      Staged.unstage @@ String.Escaping.unescape ~escape_char:'\\'
-    in
-    fun json ->
-      Result.map (of_yojson json) ~f:(fun t ->
-          {t with message= unescape t.message} )
-
   let check_invariants (t : t) =
     match Logproc_lib.Interpolator.parse t.message with
     | Error _ ->


### PR DESCRIPTION
We escape `\` and `"` in our log messages even though Yojson already does it for us.

Before:
```ocaml
utop # Logger.info (Logger.create ()) "\"This is a test\\ This is also a test\"" ~module_:"" ~location:"";;
{"timestamp":"2020-11-16 23:56:29.508455Z","level":"Info","source":{"module":"","location":""},"message":"\\\"This is a test\\\\ This is also a test\\\"","metadata":{"pid":25491}}
- : unit = ()
```
The message string parses into `\"This is a test\\ This is also a test\"`.

After:
```ocaml
utop # Logger.info (Logger.create ()) "\"This is a test\\ This is also a test\"" ~module_:"" ~location:"";;
{"timestamp":"2020-11-17 00:03:43.969678Z","level":"Info","source":{"module":"","location":""},"message":"\"This is a test\\ This is also a test\"","metadata":{"pid":30766}}
- : unit = ()
```
The message string parses back into the input string `"This is a test\ This is also a test"`.

Note that the line containing the JSON in the `utop` output is printed on stdout, so no OCaml escaping applies. Showing the JSON-encoded string directly in utop also shows the consistent escaping that we expect:

```ocaml
utop # let json = Logger.Message.to_yojson {timestamp= Core_kernel.Time.now(); level= Info; source= None; message= msg; metadata= Core_kernel.String.Map.empty; event_id= None};;
val json : Yojson.Safe.t =
  `Assoc
    [("timestamp", `String "2020-11-17 00:05:29.237844Z");
     ("level", `String "Info");
     ("message", `String "\"This is a test\\ This is also a test\"");
     ("metadata", `Assoc [])]
utop # Yojson.Safe.to_string json;;
- : string =
"{\"timestamp\":\"2020-11-17 00:05:29.237844Z\",\"level\":\"Info\",\"message\":\"\\\"This is a test\\\\ This is also a test\\\"\",\"metadata\":{}}"
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: