### PR TITLE
Implement allocation functor, wire up cli command and metrics

### DIFF
--- a/src/allocation_functor.opam
+++ b/src/allocation_functor.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1671,6 +1671,20 @@ let next_available_token_cmd =
          printf "Next available token ID: %s\n"
            (Token_id.to_string response#nextAvailableToken) ))
 
+let object_lifetime_statistics =
+  let open Daemon_rpcs in
+  let open Command.Param in
+  Command.async ~summary:"Dump internal object lifetime statistics to JSON"
+    (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
+         match%map
+           Client.dispatch Get_object_lifetime_statistics.rpc () port
+         with
+         | Ok stats ->
+             print_endline stats
+         | Error err ->
+             printf "Failed to get object lifetime statistics: %s\n%!"
+               (Error.to_string_hum err) ))
+
 module Visualization = struct
   let create_command (type rpc_response) ~name ~f
       (rpc : (string, rpc_response) Rpc.Rpc.t) =
@@ -1780,4 +1794,5 @@ let advanced =
     ; ("next-available-token", next_available_token_cmd)
     ; ("time-offset", get_time_offset_graphql)
     ; ("get-peers", get_peers_graphql)
-    ; ("add-peers", add_peers_graphql) ]
+    ; ("add-peers", add_peers_graphql)
+    ; ("object-lifetime-statistics", object_lifetime_statistics) ]

--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -373,7 +373,10 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
           return (Set.to_list !client_trustlist) )
     ; implement Daemon_rpcs.Get_telemetry_data.rpc (fun () peers ->
           Telemetry.get_telemetry_data_from_peers (Coda_lib.net coda) peers )
-    ]
+    ; implement Daemon_rpcs.Get_object_lifetime_statistics.rpc (fun () () ->
+          return
+            (Yojson.Safe.pretty_to_string @@ Allocation_functor.Table.dump ())
+      ) ]
   in
   let snark_worker_impls =
     [ implement Snark_worker.Rpcs_versioned.Get_work.Latest.rpc (fun () () ->

--- a/src/lib/allocation_functor/dune
+++ b/src/lib/allocation_functor/dune
@@ -1,0 +1,6 @@
+(library
+  (name allocation_functor)
+  (public_name allocation_functor)
+  (libraries core_kernel coda_metrics)
+  (instrumentation (backend bisect_ppx))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version)))

--- a/src/lib/allocation_functor/functor.ml
+++ b/src/lib/allocation_functor/functor.ml
@@ -1,0 +1,67 @@
+open Core_kernel
+
+module Partial = struct
+  (*
+  module Bin_io (M : Intf.Bin_io_intf) : Intf.Partial.Yojson_intf with type t := M.t = struct
+    let bin_size_t = M.bin_size_t
+    let bin_write_t = M.bin_write_t
+    let bin_read_t = ...
+    let bin_shape_t = M.bin_shape_t
+    let bin_reader_t = ...
+    let bin_t = ...
+  end
+  *)
+
+  module Sexp (M : Intf.Input.Sexp_intf) :
+    Intf.Partial.Sexp_intf with type t := M.t = struct
+    let sexp_of_t = M.sexp_of_t
+
+    let t_of_sexp t = Table.attach_finalizer M.id (M.t_of_sexp t)
+  end
+
+  module Yojson (M : Intf.Input.Yojson_intf) :
+    Intf.Partial.Yojson_intf with type t := M.t = struct
+    let to_yojson = M.to_yojson
+
+    let of_yojson json =
+      M.of_yojson json |> Result.map ~f:(Table.attach_finalizer M.id)
+  end
+end
+
+module Basic (M : Intf.Input.Basic_intf) :
+  Intf.Output.Basic_intf with type t = M.t and type 'a creator := 'a M.creator =
+struct
+  type t = M.t
+
+  let create = M.map_creator M.create ~f:(Table.attach_finalizer M.id)
+end
+
+(*
+module Bin_io (M : Intf.Bin_io_intf) : Intf.Bin_io_intf with type t = M.t and type create_args := M.create_args = struct
+  include Basic (M)
+  include Partial.Bin_io (M)
+end
+*)
+
+module Sexp (M : Intf.Input.Sexp_intf) :
+  Intf.Output.Sexp_intf with type t = M.t and type 'a creator := 'a M.creator =
+struct
+  include Basic (M)
+  include Partial.Sexp (M)
+end
+
+module Yojson (M : Intf.Input.Yojson_intf) :
+  Intf.Output.Yojson_intf with type t = M.t and type 'a creator := 'a M.creator =
+struct
+  include Basic (M)
+  include Partial.Yojson (M)
+end
+
+(*
+module Full (M : Intf.Input.Full_intf) : Intf.Ouptut.Full_intf with type t = M.t and type create_args := M.create_args = struct
+  include Basic (M)
+  include Partial.Bin_io (M)
+  include Partial.Sexp (M)
+  include Partial.Yojson (M)
+end
+*)

--- a/src/lib/allocation_functor/intf.ml
+++ b/src/lib/allocation_functor/intf.ml
@@ -1,0 +1,93 @@
+open Core_kernel
+
+module Partial = struct
+  module type Bin_io_intf = Binable.S
+
+  module type Sexp_intf = Sexpable.S
+
+  module type Yojson_intf = sig
+    type t [@@deriving yojson]
+  end
+end
+
+module type Creatable_intf = sig
+  type t
+
+  type 'a creator
+
+  val create : t creator
+end
+
+module type Higher_order_creatable_intf = sig
+  include Creatable_intf
+
+  val map_creator : 'a creator -> f:('a -> 'b) -> 'b creator
+end
+
+module Input = struct
+  module type Basic_intf = sig
+    val id : string
+
+    include Higher_order_creatable_intf
+  end
+
+  module type Bin_io_intf = sig
+    include Basic_intf
+
+    include Partial.Bin_io_intf with type t := t
+  end
+
+  module type Sexp_intf = sig
+    include Basic_intf
+
+    include Partial.Sexp_intf with type t := t
+  end
+
+  module type Yojson_intf = sig
+    include Basic_intf
+
+    include Partial.Yojson_intf with type t := t
+  end
+
+  module type Full_intf = sig
+    include Basic_intf
+
+    include Partial.Bin_io_intf with type t := t
+
+    include Partial.Sexp_intf with type t := t
+
+    include Partial.Yojson_intf with type t := t
+  end
+end
+
+module Output = struct
+  module type Basic_intf = Creatable_intf
+
+  module type Bin_io_intf = sig
+    include Basic_intf
+
+    include Partial.Bin_io_intf with type t := t
+  end
+
+  module type Sexp_intf = sig
+    include Basic_intf
+
+    include Partial.Sexp_intf with type t := t
+  end
+
+  module type Yojson_intf = sig
+    include Basic_intf
+
+    include Partial.Yojson_intf with type t := t
+  end
+
+  module type Full_intf = sig
+    include Basic_intf
+
+    include Partial.Bin_io_intf with type t := t
+
+    include Partial.Sexp_intf with type t := t
+
+    include Partial.Yojson_intf with type t := t
+  end
+end

--- a/src/lib/allocation_functor/table.ml
+++ b/src/lib/allocation_functor/table.ml
@@ -1,0 +1,32 @@
+open Core_kernel
+
+type allocation_info = {count: int} [@@deriving yojson]
+
+let empty_allocation_info = {count= 0}
+
+let table = String.Table.create ()
+
+let capture id =
+  String.Table.update table id ~f:(fun info_opt ->
+      let info = Option.value info_opt ~default:empty_allocation_info in
+      {count= info.count + 1} ) ;
+  Coda_metrics.(
+    Gauge.inc_one (Object_lifetime_statistics.object_count ~name:id))
+
+let release id =
+  String.Table.update table id ~f:(fun info_opt ->
+      let info = Option.value info_opt ~default:empty_allocation_info in
+      {count= info.count - 1} ) ;
+  Coda_metrics.(
+    Gauge.dec_one (Object_lifetime_statistics.object_count ~name:id))
+
+let attach_finalizer id obj =
+  capture id ;
+  Gc.Expert.add_finalizer_exn obj (fun _ -> release id) ;
+  obj
+
+let dump () =
+  let entries =
+    String.Table.to_alist table |> List.Assoc.map ~f:allocation_info_to_yojson
+  in
+  `Assoc entries

--- a/src/lib/allocation_functor/table.mli
+++ b/src/lib/allocation_functor/table.mli
@@ -1,0 +1,9 @@
+open Core_kernel
+
+type allocation_info = {count: int}
+
+val table : allocation_info String.Table.t
+
+val attach_finalizer : string -> 'a -> 'a
+
+val dump : unit -> Yojson.Safe.t

--- a/src/lib/coda_metrics/coda_metrics.ml
+++ b/src/lib/coda_metrics/coda_metrics.ml
@@ -740,6 +740,25 @@ module Block_latency = struct
       ()
 end
 
+module Object_lifetime_statistics = struct
+  let subsystem = "Object_lifetime_statistics"
+
+  module Gauge_map = Metric_map (struct
+    type t = Gauge.t
+
+    let subsystem = subsystem
+
+    let v = Gauge.v
+  end)
+
+  let object_count_table = Gauge_map.of_alist_exn []
+
+  let object_count ~name : Gauge.t =
+    let help = "number of objects currently allocated" in
+    let name = "object_count_" ^ name in
+    Gauge_map.add object_count_table ~name ~help
+end
+
 let server ~port ~logger =
   let open Cohttp in
   let open Cohttp_async in

--- a/src/lib/coda_transition/dune
+++ b/src/lib/coda_transition/dune
@@ -3,4 +3,4 @@
  (public_name coda_transition)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane ppx_deriving.std ppx_deriving_yojson))
- (libraries core_kernel staged_ledger transition_chain_verifier truth coda_base coda_net2 coda_state precomputed_values consensus protocol_version staged_ledger_diff verifier))
+ (libraries core_kernel staged_ledger transition_chain_verifier truth coda_base coda_net2 coda_state precomputed_values consensus protocol_version staged_ledger_diff verifier allocation_functor))

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -281,3 +281,13 @@ module Get_telemetry_data = struct
     Rpc.Rpc.create ~name:"Get_telemetry_data" ~version:0 ~bin_query
       ~bin_response
 end
+
+module Get_object_lifetime_statistics = struct
+  type query = unit [@@deriving bin_io_unversioned]
+
+  type response = string [@@deriving bin_io_unversioned]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Get_object_lifetime_statistics" ~version:0 ~bin_query
+      ~bin_response
+end

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -5,21 +5,41 @@ open Coda_state
 open Coda_transition
 open Network_peer
 
-type t =
-  { validated_transition: External_transition.Validated.t
-  ; staged_ledger: Staged_ledger.t sexp_opaque
-  ; just_emitted_a_proof: bool }
-[@@deriving sexp, fields]
+module T = struct
+  let id = "breadcrumb"
 
-let to_yojson {validated_transition; staged_ledger= _; just_emitted_a_proof} =
-  `Assoc
-    [ ( "validated_transition"
-      , External_transition.Validated.to_yojson validated_transition )
-    ; ("staged_ledger", `String "<opaque>")
-    ; ("just_emitted_a_proof", `Bool just_emitted_a_proof) ]
+  type t =
+    { validated_transition: External_transition.Validated.t
+    ; staged_ledger: Staged_ledger.t sexp_opaque
+    ; just_emitted_a_proof: bool }
+  [@@deriving sexp, fields]
 
-let create validated_transition staged_ledger =
-  {validated_transition; staged_ledger; just_emitted_a_proof= false}
+  type 'a creator =
+       validated_transition:External_transition.Validated.t
+    -> staged_ledger:Staged_ledger.t
+    -> just_emitted_a_proof:bool
+    -> 'a
+
+  let map_creator creator ~f ~validated_transition ~staged_ledger
+      ~just_emitted_a_proof =
+    f (creator ~validated_transition ~staged_ledger ~just_emitted_a_proof)
+
+  let create ~validated_transition ~staged_ledger ~just_emitted_a_proof =
+    {validated_transition; staged_ledger; just_emitted_a_proof}
+
+  let to_yojson {validated_transition; staged_ledger= _; just_emitted_a_proof}
+      =
+    `Assoc
+      [ ( "validated_transition"
+        , External_transition.Validated.to_yojson validated_transition )
+      ; ("staged_ledger", `String "<opaque>")
+      ; ("just_emitted_a_proof", `Bool just_emitted_a_proof) ]
+end
+
+[%%define_locally
+T.(validated_transition, staged_ledger, just_emitted_a_proof, to_yojson)]
+
+include Allocation_functor.Functor.Sexp (T)
 
 let build ?skip_staged_ledger_verification ~logger ~precomputed_values
     ~verifier ~trust_system ~parent
@@ -31,7 +51,7 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
         External_transition.Staged_ledger_validation
         .validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
           ~precomputed_values ~verifier
-          ~parent_staged_ledger:parent.staged_ledger
+          ~parent_staged_ledger:(staged_ledger parent)
           ~parent_protocol_state:
             (External_transition.Validated.protocol_state
                parent.validated_transition)
@@ -43,10 +63,10 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
               fully_valid_external_transition
           , `Staged_ledger transitioned_staged_ledger ) ->
           return
-            (Ok
-               { validated_transition= fully_valid_external_transition
-               ; staged_ledger= transitioned_staged_ledger
-               ; just_emitted_a_proof })
+          @@ Ok
+               (create ~validated_transition:fully_valid_external_transition
+                  ~staged_ledger:transitioned_staged_ledger
+                  ~just_emitted_a_proof)
       | Error (`Invalid_staged_ledger_diff errors) ->
           let reasons =
             String.concat ~sep:" && "
@@ -115,7 +135,7 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
               (Staged_ledger.Staged_ledger_error.to_error staged_ledger_error))
   )
 
-let lift f {validated_transition; _} = f validated_transition
+let lift f breadcrumb = f (validated_transition breadcrumb)
 
 let state_hash = lift External_transition.Validated.state_hash
 
@@ -259,7 +279,7 @@ module For_tests = struct
     in
     fun parent_breadcrumb ->
       let open Deferred.Let_syntax in
-      let parent_staged_ledger = parent_breadcrumb.staged_ledger in
+      let parent_staged_ledger = staged_ledger parent_breadcrumb in
       let transactions =
         gen_payments parent_staged_ledger accounts_with_secret_keys
         |> Sequence.map ~f:(fun x -> User_command.Signed_command x)

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -20,7 +20,11 @@ type display =
   ; parent: string }
 [@@deriving yojson]
 
-val create : External_transition.Validated.t -> Staged_ledger.t -> t
+val create :
+     validated_transition:External_transition.Validated.t
+  -> staged_ledger:Staged_ledger.t
+  -> just_emitted_a_proof:bool
+  -> t
 
 val build :
      ?skip_staged_ledger_verification:bool

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -126,7 +126,8 @@ let create ~logger ~root_data ~root_ledger ~consensus_local_state ~max_length
          (Ledger.Any_ledger.M.merkle_root root_ledger))
       root_blockchain_state_ledger_hash ) ;
   let root_breadcrumb =
-    Breadcrumb.create root_data.transition root_data.staged_ledger
+    Breadcrumb.create ~validated_transition:root_data.transition
+      ~staged_ledger:root_data.staged_ledger ~just_emitted_a_proof:false
   in
   let root_node =
     {Node.breadcrumb= root_breadcrumb; successor_hashes= []; length= 0}
@@ -440,8 +441,11 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
   (* rewrite the new root breadcrumb to contain the new root mask *)
   let new_root_breadcrumb =
     Breadcrumb.create
-      (Breadcrumb.validated_transition new_root_node.breadcrumb)
-      new_staged_ledger
+      ~validated_transition:
+        (Breadcrumb.validated_transition new_root_node.breadcrumb)
+      ~staged_ledger:new_staged_ledger
+      ~just_emitted_a_proof:
+        (Breadcrumb.just_emitted_a_proof new_root_node.breadcrumb)
   in
   (*Update the protocol states required for scan state at the new root.
   Note: this should be after applying the transactions to the snarked ledger (Step 5)

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -481,7 +481,8 @@ module For_tests = struct
                    ~snarked_ledger:genesis_ledger
                    ~expected_merkle_root:(Ledger.merkle_root genesis_ledger) ))
         in
-        Breadcrumb.create genesis_transition genesis_staged_ledger )
+        Breadcrumb.create ~validated_transition:genesis_transition
+          ~staged_ledger:genesis_staged_ledger ~just_emitted_a_proof:false )
 
   let gen_persistence ?(logger = Logger.null ()) ?verifier
       ~(precomputed_values : Precomputed_values.t) () =


### PR DESCRIPTION
Initial implementation of the allocation functor, which (in the long term) aims to address #6719 and #3367. This PR only contains object counting and not lifetimes or any deeper memory statistics about objects. This PR also only wires this functor up for `Breadcrumb.t`, as that was an easy first target. Once this lands, I will expand the functionality of this pattern further and wrap more types with this functor.

The statistics computed by this pattern are available via the cli through `coda advanced object-lifetime-statistics` and prometheus metrics.