### PR TITLE
Allow keys, urs to be read after an offset, to allow for a header

### DIFF
--- a/src/lib/marlin_plonk_bindings/stubs/src/index_serialization.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/index_serialization.rs
@@ -11,7 +11,7 @@ use commitment_dlog::{
 use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as Domain};
 use oracle::poseidon::ArithmeticSpongeParams;
 use plonk_circuits::{
-    constraints::{zk_w, zk_polynomial, ConstraintSystem as PlonkConstraintSystem},
+    constraints::{zk_polynomial, zk_w, ConstraintSystem as PlonkConstraintSystem},
     domains::EvaluationDomains as PlonkEvaluationDomains,
 };
 use plonk_protocol_dlog::index::{
@@ -461,7 +461,7 @@ where
         l04,
         l08,
         l1,
-        r:r_value,
+        r: r_value,
         o,
         endo,
         fr_sponge_params,

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_index.rs
@@ -16,7 +16,7 @@ use plonk_protocol_dlog::index::{Index as DlogIndex, SRSSpec};
 
 use std::{
     fs::File,
-    io::{BufReader, BufWriter},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     rc::Rc,
 };
 
@@ -206,6 +206,7 @@ pub fn caml_tweedle_fp_plonk_index_domain_d8_size(index: CamlTweedleFpPlonkIndex
 
 #[ocaml::func]
 pub fn caml_tweedle_fp_plonk_index_read(
+    offset: Option<ocaml::Int>,
     urs: CamlTweedleFpUrs,
     path: String,
 ) -> Result<CamlTweedleFpPlonkIndex<'static>, ocaml::Error> {
@@ -218,6 +219,12 @@ pub fn caml_tweedle_fp_plonk_index_read(
         Ok(file) => file,
     };
     let mut r = BufReader::new(file);
+    match offset {
+        Some(offset) => {
+            r.seek(Start(offset as u64))?;
+        }
+        None => (),
+    };
     let urs_copy = Rc::clone(&urs.0);
     let urs_copy_outer = Rc::clone(&urs.0);
     let srs = {

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_oracles.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_oracles.rs
@@ -5,9 +5,9 @@ use algebra::tweedle::{
 
 use oracle::{
     self,
-    FqSponge,
     poseidon::PlonkSpongeConstants,
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
+    FqSponge,
 };
 
 use commitment_dlog::commitment::{shift_scalar, PolyComm};

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_verifier_index.rs
@@ -13,12 +13,12 @@ use algebra::tweedle::{dee::Affine as GAffine, dum::Affine as GAffineOther, fp::
 use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 
 use commitment_dlog::srs::SRS;
-use plonk_circuits::constraints::{zk_w, zk_polynomial, ConstraintSystem};
+use plonk_circuits::constraints::{zk_polynomial, zk_w, ConstraintSystem};
 use plonk_protocol_dlog::index::{SRSValue, VerifierIndex as DlogVerifierIndex};
 
 use std::{
     fs::File,
-    io::{BufReader, BufWriter},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
 };
 
 use std::rc::Rc;
@@ -205,6 +205,7 @@ impl From<CamlTweedleFpPlonkVerifierIndexPtr> for DlogVerifierIndex<'_, GAffine>
 }
 
 pub fn read_raw<'a>(
+    offset: Option<ocaml::Int>,
     urs: CamlTweedleFpUrs,
     path: String,
 ) -> Result<CamlTweedleFpPlonkVerifierIndexRaw<'a>, ocaml::Error> {
@@ -216,6 +217,12 @@ pub fn read_raw<'a>(
         .unwrap()),
         Ok(file) => {
             let mut r = BufReader::new(file);
+            match offset {
+                Some(offset) => {
+                    r.seek(Start(offset as u64))?;
+                }
+                None => (),
+            };
             let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
             let urs_copy = Rc::clone(&urs.0);
             let t = index_serialization::read_plonk_verifier_index(
@@ -232,18 +239,20 @@ pub fn read_raw<'a>(
 
 #[ocaml::func]
 pub fn caml_tweedle_fp_plonk_verifier_index_raw_read(
+    offset: Option<ocaml::Int>,
     urs: CamlTweedleFpUrs,
     path: String,
 ) -> Result<CamlTweedleFpPlonkVerifierIndexRaw<'static>, ocaml::Error> {
-    read_raw(urs, path)
+    read_raw(offset, urs, path)
 }
 
 #[ocaml::func]
 pub fn caml_tweedle_fp_plonk_verifier_index_read(
+    offset: Option<ocaml::Int>,
     urs: CamlTweedleFpUrs,
     path: String,
 ) -> Result<CamlTweedleFpPlonkVerifierIndex, ocaml::Error> {
-    let t = read_raw(urs, path)?;
+    let t = read_raw(offset, urs, path)?;
     Ok(to_ocaml(&t.1, t.0))
 }
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_index.rs
@@ -16,7 +16,7 @@ use plonk_protocol_dlog::index::{Index as DlogIndex, SRSSpec};
 
 use std::{
     fs::File,
-    io::{BufReader, BufWriter},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     rc::Rc,
 };
 
@@ -208,6 +208,7 @@ pub fn caml_tweedle_fq_plonk_index_domain_d8_size(index: CamlTweedleFqPlonkIndex
 
 #[ocaml::func]
 pub fn caml_tweedle_fq_plonk_index_read(
+    offset: Option<ocaml::Int>,
     urs: CamlTweedleFqUrs,
     path: String,
 ) -> Result<CamlTweedleFqPlonkIndex<'static>, ocaml::Error> {
@@ -220,6 +221,12 @@ pub fn caml_tweedle_fq_plonk_index_read(
         Ok(file) => file,
     };
     let mut r = BufReader::new(file);
+    match offset {
+        Some(offset) => {
+            r.seek(Start(offset as u64))?;
+        }
+        None => (),
+    };
     let urs_copy = Rc::clone(&urs.0);
     let urs_copy_outer = Rc::clone(&urs.0);
     let srs = {

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_oracles.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_oracles.rs
@@ -5,9 +5,9 @@ use algebra::tweedle::{
 
 use oracle::{
     self,
-    FqSponge,
     poseidon::PlonkSpongeConstants,
     sponge::{DefaultFqSponge, DefaultFrSponge, ScalarChallenge},
+    FqSponge,
 };
 
 use commitment_dlog::commitment::{shift_scalar, PolyComm};

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_urs.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_urs.rs
@@ -11,7 +11,7 @@ use commitment_dlog::{commitment::b_poly_coefficients, srs::SRS};
 
 use std::{
     fs::File,
-    io::{BufReader, BufWriter},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     rc::Rc,
 };
 
@@ -58,13 +58,22 @@ pub fn caml_tweedle_fq_urs_write(urs: CamlTweedleFqUrs, path: String) -> Result<
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_fq_urs_read(path: String) -> Result<Option<CamlTweedleFqUrs>, ocaml::Error> {
+pub fn caml_tweedle_fq_urs_read(
+    offset: Option<ocaml::Int>,
+    path: String,
+) -> Result<Option<CamlTweedleFqUrs>, ocaml::Error> {
     match File::open(path) {
         Err(_) => Err(ocaml::Error::invalid_argument("caml_tweedle_fq_urs_read")
             .err()
             .unwrap()),
         Ok(file) => {
-            let file = BufReader::new(file);
+            let mut file = BufReader::new(file);
+            match offset {
+                Some(offset) => {
+                    file.seek(Start(offset as u64))?;
+                }
+                None => (),
+            };
             match SRS::<GAffine>::read(file) {
                 Err(_) => Ok(None),
                 Ok(urs) => Ok(Some(CamlTweedleFqUrs(Rc::new(urs)))),

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_index/marlin_plonk_bindings_tweedle_fp_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_index/marlin_plonk_bindings_tweedle_fp_index.ml
@@ -41,7 +41,7 @@ external domain_d8_size :
   = "caml_tweedle_fp_plonk_index_domain_d8_size"
 
 external read :
-  Marlin_plonk_bindings_tweedle_fp_urs.t -> string -> t
+  ?offset:int -> Marlin_plonk_bindings_tweedle_fp_urs.t -> string -> t
   = "caml_tweedle_fp_plonk_index_read"
 
 external write : t -> string -> unit = "caml_tweedle_fp_plonk_index_write"

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/marlin_plonk_bindings_tweedle_fp_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/marlin_plonk_bindings_tweedle_fp_verifier_index.ml
@@ -14,7 +14,7 @@ module Raw = struct
     = "caml_tweedle_fp_plonk_verifier_index_raw_create"
 
   external read :
-    Marlin_plonk_bindings_tweedle_fp_urs.t -> string -> t
+    ?offset:int -> Marlin_plonk_bindings_tweedle_fp_urs.t -> string -> t
     = "caml_tweedle_fp_plonk_verifier_index_raw_read"
 
   external write :
@@ -37,7 +37,7 @@ external create :
   = "caml_tweedle_fp_plonk_verifier_index_create"
 
 external read :
-  Marlin_plonk_bindings_tweedle_fp_urs.t -> string -> t
+  ?offset:int -> Marlin_plonk_bindings_tweedle_fp_urs.t -> string -> t
   = "caml_tweedle_fp_plonk_verifier_index_read"
 
 external write :

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_urs/marlin_plonk_bindings_tweedle_fp_urs.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_urs/marlin_plonk_bindings_tweedle_fp_urs.ml
@@ -10,7 +10,7 @@ external create : int -> t = "caml_tweedle_fp_urs_create"
 
 external write : t -> string -> unit = "caml_tweedle_fp_urs_write"
 
-external read : string -> t option = "caml_tweedle_fp_urs_read"
+external read : ?offset:int -> string -> t option = "caml_tweedle_fp_urs_read"
 
 external lagrange_commitment :
   t -> domain_size:int -> int -> Poly_comm.t

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_index/marlin_plonk_bindings_tweedle_fq_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_index/marlin_plonk_bindings_tweedle_fq_index.ml
@@ -41,7 +41,7 @@ external domain_d8_size :
   = "caml_tweedle_fq_plonk_index_domain_d8_size"
 
 external read :
-  Marlin_plonk_bindings_tweedle_fq_urs.t -> string -> t
+  ?offset:int -> Marlin_plonk_bindings_tweedle_fq_urs.t -> string -> t
   = "caml_tweedle_fq_plonk_index_read"
 
 external write : t -> string -> unit = "caml_tweedle_fq_plonk_index_write"

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/marlin_plonk_bindings_tweedle_fq_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/marlin_plonk_bindings_tweedle_fq_verifier_index.ml
@@ -14,7 +14,7 @@ module Raw = struct
     = "caml_tweedle_fq_plonk_verifier_index_raw_create"
 
   external read :
-    Marlin_plonk_bindings_tweedle_fq_urs.t -> string -> t
+    ?offset:int -> Marlin_plonk_bindings_tweedle_fq_urs.t -> string -> t
     = "caml_tweedle_fq_plonk_verifier_index_raw_read"
 
   external write :
@@ -37,7 +37,7 @@ external create :
   = "caml_tweedle_fq_plonk_verifier_index_create"
 
 external read :
-  Marlin_plonk_bindings_tweedle_fq_urs.t -> string -> t
+  ?offset:int -> Marlin_plonk_bindings_tweedle_fq_urs.t -> string -> t
   = "caml_tweedle_fq_plonk_verifier_index_read"
 
 external write :

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_urs/marlin_plonk_bindings_tweedle_fq_urs.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_urs/marlin_plonk_bindings_tweedle_fq_urs.ml
@@ -10,7 +10,7 @@ external create : int -> t = "caml_tweedle_fq_urs_create"
 
 external write : t -> string -> unit = "caml_tweedle_fq_urs_write"
 
-external read : string -> t option = "caml_tweedle_fq_urs_read"
+external read : ?offset:int -> string -> t option = "caml_tweedle_fq_urs_read"
 
 external lagrange_commitment :
   t -> domain_size:int -> int -> Poly_comm.t

--- a/src/lib/zexe_backend/zexe_backend_common/dlog_plonk_based_keypair.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/dlog_plonk_based_keypair.ml
@@ -32,7 +32,7 @@ module type Inputs_intf = sig
   module Urs : sig
     type t
 
-    val read : string -> t option
+    val read : ?offset:int -> string -> t option
 
     val write : t -> string -> unit
 


### PR DESCRIPTION
This PR adds an `offset` optional argument to the rust `read` functions, to allow us to place a header before the data (see #6661 for header format, #6769 for header parsing).

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: