### PR TITLE
Allow keys, urs to be appended to a file instead of overwriting

### DIFF
--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_index.rs
@@ -15,7 +15,7 @@ use commitment_dlog::srs::SRS;
 use plonk_protocol_dlog::index::{Index as DlogIndex, SRSSpec};
 
 use std::{
-    fs::File,
+    fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     rc::Rc,
 };
@@ -243,10 +243,11 @@ pub fn caml_tweedle_fp_plonk_index_read(
 
 #[ocaml::func]
 pub fn caml_tweedle_fp_plonk_index_write(
+    append: Option<bool>,
     index: CamlTweedleFpPlonkIndexPtr<'static>,
     path: String,
 ) -> Result<(), ocaml::Error> {
-    let file = match File::create(path) {
+    let file = match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
         Err(_) => Err(
             ocaml::Error::invalid_argument("caml_tweedle_fp_plonk_index_write")
                 .err()

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_plonk_verifier_index.rs
@@ -17,7 +17,7 @@ use plonk_circuits::constraints::{zk_polynomial, zk_w, ConstraintSystem};
 use plonk_protocol_dlog::index::{SRSValue, VerifierIndex as DlogVerifierIndex};
 
 use std::{
-    fs::File,
+    fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
 };
 
@@ -256,8 +256,12 @@ pub fn caml_tweedle_fp_plonk_verifier_index_read(
     Ok(to_ocaml(&t.1, t.0))
 }
 
-pub fn write_raw(index: &DlogVerifierIndex<GAffine>, path: String) -> Result<(), ocaml::Error> {
-    match File::create(path) {
+pub fn write_raw(
+    append: Option<bool>,
+    index: &DlogVerifierIndex<GAffine>,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
         Err(_) => Err(ocaml::Error::invalid_argument(
             "caml_tweedle_fp_plonk_verifier_index_raw_read",
         )
@@ -275,18 +279,24 @@ pub fn write_raw(index: &DlogVerifierIndex<GAffine>, path: String) -> Result<(),
 
 #[ocaml::func]
 pub fn caml_tweedle_fp_plonk_verifier_index_raw_write(
+    append: Option<bool>,
     index: CamlTweedleFpPlonkVerifierIndexRawPtr,
     path: String,
 ) -> Result<(), ocaml::Error> {
-    write_raw(&index.as_ref().0, path)
+    write_raw(append, &index.as_ref().0, path)
 }
 
 #[ocaml::func]
 pub fn caml_tweedle_fp_plonk_verifier_index_write(
+    append: Option<bool>,
     index: CamlTweedleFpPlonkVerifierIndexPtr,
     path: String,
 ) -> Result<(), ocaml::Error> {
-    write_raw(&CamlTweedleFpPlonkVerifierIndexRaw::from(index).0, path)
+    write_raw(
+        append,
+        &CamlTweedleFpPlonkVerifierIndexRaw::from(index).0,
+        path,
+    )
 }
 
 #[ocaml::func]

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_urs.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_urs.rs
@@ -10,7 +10,7 @@ use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations};
 use commitment_dlog::{commitment::b_poly_coefficients, srs::SRS};
 
 use std::{
-    fs::File,
+    fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     rc::Rc,
 };
@@ -43,8 +43,12 @@ pub fn caml_tweedle_fp_urs_create(depth: ocaml::Int) -> CamlTweedleFpUrs {
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_fp_urs_write(urs: CamlTweedleFpUrs, path: String) -> Result<(), ocaml::Error> {
-    match File::create(path) {
+pub fn caml_tweedle_fp_urs_write(
+    append: Option<bool>,
+    urs: CamlTweedleFpUrs,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
         Err(_) => Err(ocaml::Error::invalid_argument("caml_tweedle_fp_urs_write")
             .err()
             .unwrap()),

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_index.rs
@@ -15,7 +15,7 @@ use commitment_dlog::srs::SRS;
 use plonk_protocol_dlog::index::{Index as DlogIndex, SRSSpec};
 
 use std::{
-    fs::File,
+    fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     rc::Rc,
 };
@@ -245,10 +245,11 @@ pub fn caml_tweedle_fq_plonk_index_read(
 
 #[ocaml::func]
 pub fn caml_tweedle_fq_plonk_index_write(
+    append: Option<bool>,
     index: CamlTweedleFqPlonkIndexPtr<'static>,
     path: String,
 ) -> Result<(), ocaml::Error> {
-    let file = match File::create(path) {
+    let file = match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
         Err(_) => Err(
             ocaml::Error::invalid_argument("caml_tweedle_fq_plonk_index_write")
                 .err()

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_verifier_index.rs
@@ -17,7 +17,7 @@ use plonk_circuits::constraints::{zk_polynomial, zk_w, ConstraintSystem};
 use plonk_protocol_dlog::index::{SRSValue, VerifierIndex as DlogVerifierIndex};
 
 use std::{
-    fs::File,
+    fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
 };
 
@@ -256,8 +256,12 @@ pub fn caml_tweedle_fq_plonk_verifier_index_read(
     Ok(to_ocaml(&t.1, t.0))
 }
 
-pub fn write_raw(index: &DlogVerifierIndex<GAffine>, path: String) -> Result<(), ocaml::Error> {
-    match File::create(path) {
+pub fn write_raw(
+    append: Option<bool>,
+    index: &DlogVerifierIndex<GAffine>,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
         Err(_) => Err(ocaml::Error::invalid_argument(
             "caml_tweedle_fq_plonk_verifier_index_raw_read",
         )
@@ -275,18 +279,24 @@ pub fn write_raw(index: &DlogVerifierIndex<GAffine>, path: String) -> Result<(),
 
 #[ocaml::func]
 pub fn caml_tweedle_fq_plonk_verifier_index_raw_write(
+    append: Option<bool>,
     index: CamlTweedleFqPlonkVerifierIndexRawPtr,
     path: String,
 ) -> Result<(), ocaml::Error> {
-    write_raw(&index.as_ref().0, path)
+    write_raw(append, &index.as_ref().0, path)
 }
 
 #[ocaml::func]
 pub fn caml_tweedle_fq_plonk_verifier_index_write(
+    append: Option<bool>,
     index: CamlTweedleFqPlonkVerifierIndexPtr,
     path: String,
 ) -> Result<(), ocaml::Error> {
-    write_raw(&CamlTweedleFqPlonkVerifierIndexRaw::from(index).0, path)
+    write_raw(
+        append,
+        &CamlTweedleFqPlonkVerifierIndexRaw::from(index).0,
+        path,
+    )
 }
 
 #[ocaml::func]

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_urs.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_urs.rs
@@ -10,7 +10,7 @@ use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations};
 use commitment_dlog::{commitment::b_poly_coefficients, srs::SRS};
 
 use std::{
-    fs::File,
+    fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     rc::Rc,
 };
@@ -43,8 +43,12 @@ pub fn caml_tweedle_fq_urs_create(depth: ocaml::Int) -> CamlTweedleFqUrs {
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_fq_urs_write(urs: CamlTweedleFqUrs, path: String) -> Result<(), ocaml::Error> {
-    match File::create(path) {
+pub fn caml_tweedle_fq_urs_write(
+    append: Option<bool>,
+    urs: CamlTweedleFqUrs,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
         Err(_) => Err(ocaml::Error::invalid_argument("caml_tweedle_fq_urs_write")
             .err()
             .unwrap()),

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_index/marlin_plonk_bindings_tweedle_fp_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_index/marlin_plonk_bindings_tweedle_fp_index.ml
@@ -44,4 +44,6 @@ external read :
   ?offset:int -> Marlin_plonk_bindings_tweedle_fp_urs.t -> string -> t
   = "caml_tweedle_fp_plonk_index_read"
 
-external write : t -> string -> unit = "caml_tweedle_fp_plonk_index_write"
+external write :
+  ?append:bool -> t -> string -> unit
+  = "caml_tweedle_fp_plonk_index_write"

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/marlin_plonk_bindings_tweedle_fp_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/marlin_plonk_bindings_tweedle_fp_verifier_index.ml
@@ -18,7 +18,7 @@ module Raw = struct
     = "caml_tweedle_fp_plonk_verifier_index_raw_read"
 
   external write :
-    t -> string -> unit
+    ?append:bool -> t -> string -> unit
     = "caml_tweedle_fp_plonk_verifier_index_raw_write"
 
   external of_parts :
@@ -41,7 +41,7 @@ external read :
   = "caml_tweedle_fp_plonk_verifier_index_read"
 
 external write :
-  t -> string -> unit
+  ?append:bool -> t -> string -> unit
   = "caml_tweedle_fp_plonk_verifier_index_write"
 
 external to_raw :

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_urs/marlin_plonk_bindings_tweedle_fp_urs.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_urs/marlin_plonk_bindings_tweedle_fp_urs.ml
@@ -8,7 +8,9 @@ end
 
 external create : int -> t = "caml_tweedle_fp_urs_create"
 
-external write : t -> string -> unit = "caml_tweedle_fp_urs_write"
+external write :
+  ?append:bool -> t -> string -> unit
+  = "caml_tweedle_fp_urs_write"
 
 external read : ?offset:int -> string -> t option = "caml_tweedle_fp_urs_read"
 

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_index/marlin_plonk_bindings_tweedle_fq_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_index/marlin_plonk_bindings_tweedle_fq_index.ml
@@ -44,4 +44,6 @@ external read :
   ?offset:int -> Marlin_plonk_bindings_tweedle_fq_urs.t -> string -> t
   = "caml_tweedle_fq_plonk_index_read"
 
-external write : t -> string -> unit = "caml_tweedle_fq_plonk_index_write"
+external write :
+  ?append:bool -> t -> string -> unit
+  = "caml_tweedle_fq_plonk_index_write"

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/marlin_plonk_bindings_tweedle_fq_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/marlin_plonk_bindings_tweedle_fq_verifier_index.ml
@@ -18,7 +18,7 @@ module Raw = struct
     = "caml_tweedle_fq_plonk_verifier_index_raw_read"
 
   external write :
-    t -> string -> unit
+    ?append:bool -> t -> string -> unit
     = "caml_tweedle_fq_plonk_verifier_index_raw_write"
 
   external of_parts :
@@ -41,7 +41,7 @@ external read :
   = "caml_tweedle_fq_plonk_verifier_index_read"
 
 external write :
-  t -> string -> unit
+  ?append:bool -> t -> string -> unit
   = "caml_tweedle_fq_plonk_verifier_index_write"
 
 external to_raw :

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_urs/marlin_plonk_bindings_tweedle_fq_urs.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_urs/marlin_plonk_bindings_tweedle_fq_urs.ml
@@ -8,7 +8,9 @@ end
 
 external create : int -> t = "caml_tweedle_fq_urs_create"
 
-external write : t -> string -> unit = "caml_tweedle_fq_urs_write"
+external write :
+  ?append:bool -> t -> string -> unit
+  = "caml_tweedle_fq_urs_write"
 
 external read : ?offset:int -> string -> t option = "caml_tweedle_fq_urs_read"
 

--- a/src/lib/zexe_backend/zexe_backend_common/dlog_plonk_based_keypair.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/dlog_plonk_based_keypair.ml
@@ -34,7 +34,7 @@ module type Inputs_intf = sig
 
     val read : ?offset:int -> string -> t option
 
-    val write : t -> string -> unit
+    val write : ?append:bool -> t -> string -> unit
 
     val create : int -> t
   end


### PR DESCRIPTION
This PR adds an optional `append` argument to the rust `write` functions, to allow us to place a header before the actual data in the file. This is the counterpart to #6771, which adjusts the `read` functions.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: