### PR TITLE
Regenerate the genesis proof if there is an error when reading it

### DIFF
--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -998,27 +998,34 @@ module Genesis_proof = struct
         ~id:(Precomputed_values.blockchain_proof_system_id ())
         ~state_hash:(Lazy.force compiled).protocol_state_with_hash.hash
     in
-    match%bind find_file ~logger ~base_hash ~genesis_dir with
-    | Some file -> (
-        match%map load file with
-        | Ok genesis_proof ->
-            Ok
-              ( { Genesis_proof.runtime_config= inputs.runtime_config
-                ; constraint_constants= inputs.constraint_constants
-                ; proof_level= inputs.proof_level
-                ; genesis_constants= inputs.genesis_constants
-                ; genesis_ledger= inputs.genesis_ledger
-                ; genesis_epoch_data= inputs.genesis_epoch_data
-                ; consensus_constants= inputs.consensus_constants
-                ; protocol_state_with_hash= inputs.protocol_state_with_hash
-                ; genesis_proof }
-              , file )
-        | Error err ->
-            [%log error] "Could not load genesis proof from $path: $error"
-              ~metadata:
-                [ ("path", `String file)
-                ; ("error", Error_json.error_to_yojson err) ] ;
-            Error err )
+    let%bind found_proof =
+      match%bind find_file ~logger ~base_hash ~genesis_dir with
+      | Some file -> (
+          match%map load file with
+          | Ok genesis_proof ->
+              Some
+                ( { Genesis_proof.runtime_config= inputs.runtime_config
+                  ; constraint_constants= inputs.constraint_constants
+                  ; proof_level= inputs.proof_level
+                  ; genesis_constants= inputs.genesis_constants
+                  ; genesis_ledger= inputs.genesis_ledger
+                  ; genesis_epoch_data= inputs.genesis_epoch_data
+                  ; consensus_constants= inputs.consensus_constants
+                  ; protocol_state_with_hash= inputs.protocol_state_with_hash
+                  ; genesis_proof }
+                , file )
+          | Error err ->
+              [%log error] "Could not load genesis proof from $path: $error"
+                ~metadata:
+                  [ ("path", `String file)
+                  ; ("error", Error_json.error_to_yojson err) ] ;
+              None )
+      | None ->
+          None
+    in
+    match found_proof with
+    | Some found_proof ->
+        Ok found_proof
     | None
       when Base_hash.equal base_hash compiled_base_hash || not proof_needed ->
         let compiled = Lazy.force compiled in

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -1021,11 +1021,11 @@ module Genesis_proof = struct
                   ; ("error", Error_json.error_to_yojson err) ] ;
               None )
       | None ->
-          None
+          return None
     in
     match found_proof with
     | Some found_proof ->
-        Ok found_proof
+        return (Ok found_proof)
     | None
       when Base_hash.equal base_hash compiled_base_hash || not proof_needed ->
         let compiled = Lazy.force compiled in


### PR DESCRIPTION
I suspect this is the root-cause for #6762, although I can't open the crash report in that issue to confirm. This behaviour is preferable anyway.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: