### PR TITLE
Add ready-to-merge-into-develop support for develop-until-4.1-hardfork branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -30,3 +30,20 @@ pull_request_rules:
               method: merge
               strict: smart
           delete_head_branch: {}
+pull_request_rules:
+    - name: automatically merge approved PRs into develop-until-4.1-hardfork with the ready-to-merge-into-develop label
+      conditions:
+          - "status-success=buildkite/mina/pr"
+          - "status-success=ci/circleci: test--dev--coda-bootstrap-test"
+          - "status-success=ci/circleci: test--dev--coda-delegation-test"
+          - "status-success=ci/circleci: test--dev--coda-shared-state-test"
+          - "status-success=ci/circleci: test--test_postake_snarkless"
+          - "status-success=ci/circleci: test--test_postake_split"
+          - "#approved-reviews-by>=1"
+          - label=ready-to-merge-into-develop
+          - base=develop-until-4.1-hardfork
+      actions:
+          merge:
+              method: merge
+              strict: smart
+          delete_head_branch: {}

--- a/.mergify.yml.jinja
+++ b/.mergify.yml.jinja
@@ -24,3 +24,17 @@ pull_request_rules:
               method: merge
               strict: smart
           delete_head_branch: {}
+pull_request_rules:
+    - name: automatically merge approved PRs into develop-until-4.1-hardfork with the ready-to-merge-into-develop label
+      conditions:
+          {%- for status in required_status | sort %}
+          - "status-success={{status}}"
+          {%- endfor %}
+          - "#approved-reviews-by>=1"
+          - label=ready-to-merge-into-develop
+          - base=develop-until-4.1-hardfork
+      actions:
+          merge:
+              method: merge
+              strict: smart
+          delete_head_branch: {}


### PR DESCRIPTION


Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them