### PR TITLE
Expose commit_date and marlin, zexe commit information from Coda_version

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -308,8 +308,8 @@ let setup_daemon logger =
         [ ("commit", `String Coda_version.commit_id)
         ; ("branch", `String Coda_version.branch)
         ; ("commit_date", `String Coda_version.commit_date)
-        ; ("marlin_commit", `String Coda_version.marlin_commit)
-        ; ("zexe_commit", `String Coda_version.zexe_commit) ] ;
+        ; ("marlin_commit", `String Coda_version.marlin_commit_id)
+        ; ("zexe_commit", `String Coda_version.zexe_commit_id) ] ;
     if not @@ String.equal daemon_expiry "never" then (
       [%log info] "Daemon will expire at $exp"
         ~metadata:[("exp", `String daemon_expiry)] ;

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -306,7 +306,10 @@ let setup_daemon logger =
       "Coda daemon is booting up; built with commit $commit on branch $branch"
       ~metadata:
         [ ("commit", `String Coda_version.commit_id)
-        ; ("branch", `String Coda_version.branch) ] ;
+        ; ("branch", `String Coda_version.branch)
+        ; ("commit_date", `String Coda_version.commit_date)
+        ; ("marlin_commit", `String Coda_version.marlin_commit)
+        ; ("zexe_commit", `String Coda_version.zexe_commit) ] ;
     if not @@ String.equal daemon_expiry "never" then (
       [%log info] "Daemon will expire at $exp"
         ~metadata:[("exp", `String daemon_expiry)] ;

--- a/src/lib/coda_version/coda_version.mli
+++ b/src/lib/coda_version/coda_version.mli
@@ -3,3 +3,17 @@ val commit_id : string
 val branch : string
 
 val commit_id_short : string
+
+val commit_date : string
+
+val marlin_commit_id : string
+
+val marlin_commit_id_short : string
+
+val marlin_commit_date : string
+
+val zexe_commit_id : string
+
+val zexe_commit_id_short : string
+
+val zexe_commit_date : string

--- a/src/lib/coda_version/gen.sh
+++ b/src/lib/coda_version/gen.sh
@@ -4,19 +4,42 @@ set -e
 branch=$(git rev-parse --verify --abbrev-ref HEAD || echo "<none found>")
 commit_id_short=$(git rev-parse --short=8 --verify HEAD)
 
-if [ -n "$CODA_COMMIT_SHA1" ]; then
-  # pull from env var if set
-  id="$CODA_COMMIT_SHA1"
-else
-  # otherwise, query from git repository
-  # we are nested five directories deep (_build/<context>/src/lib/coda_version)
-  cd ../../../../..
-  if [ ! -e .git ]; then echo 'Error: git repository not found'; exit 1; fi
-  id=$(git rev-parse --verify HEAD)
-  if [ -n "$(git diff --stat)" ]; then id="[DIRTY]$id"; fi
-  cd -
-fi
+CWD=$PWD
+
+# we are nested 5 directories deep (_build/<context>/src/lib/coda_version)
+cd ../../../../..
+  if [ -n "$CODA_COMMIT_SHA1" ]; then
+    # pull from env var if set
+    id="$CODA_COMMIT_SHA1"
+  else
+    if [ ! -e .git ]; then echo 'Error: git repository not found'; exit 1; fi
+    id=$(git rev-parse --verify HEAD)
+    if [ -n "$(git diff --stat)" ]; then id="[DIRTY]$id"; fi
+  fi
+  commit_date=$(git show HEAD -s --format="%cI")
+  cd src/lib/marlin
+    marlin_commit_id=$(git rev-parse --verify HEAD)
+    if [ -n "$(git diff --stat)" ]; then marlin_commit_id="[DIRTY]$id"; fi
+    marlin_commit_id_short=$(git rev-parse --short=8 --verify HEAD)
+    marlin_commit_date=$(git show HEAD -s --format="%cI")
+  cd ../../..
+  cd src/lib/zexe
+    zexe_commit_id=$(git rev-parse --verify HEAD)
+    if [ -n "$(git diff --stat)" ]; then zexe_commit_id="[DIRTY]$id"; fi
+    zexe_commit_id_short=$(git rev-parse --short=8 --verify HEAD)
+    zexe_commit_date=$(git show HEAD -s --format="%cI")
+  cd ../../..
+cd $CWD
 
 echo "let commit_id = \"$id\"" > "$1"
 echo "let commit_id_short = \"$commit_id_short\"" >> "$1"
 echo "let branch = \"$branch\"" >> "$1"
+echo "let commit_date = \"$commit_date\"" >> "$1"
+
+echo "let marlin_commit_id = \"$marlin_commit_id\"" >> "$1"
+echo "let marlin_commit_id_short = \"$marlin_commit_id_short\"" >> "$1"
+echo "let marlin_commit_date = \"$marlin_commit_date\"" >> "$1"
+
+echo "let zexe_commit_id = \"$zexe_commit_id\"" >> "$1"
+echo "let zexe_commit_id_short = \"$zexe_commit_id_short\"" >> "$1"
+echo "let zexe_commit_date = \"$zexe_commit_date\"" >> "$1"


### PR DESCRIPTION
This PR adds more information to `Coda_version`, so that it can be used to fill the header in the `Snark_keys_header`.

This also adds some of this information to the version log at startup, since it's cheap to add (only logged once) and may make it easier to track down snark problems caused by changes to marlin and zexe.

Output at this PR:
```ocaml
let commit_id = "e523a4a68cf9371bf2e3e57ef10f993a52db4086"
let commit_id_short = "e523a4a6"
let branch = "feature/more-info-in-coda_version"
let commit_date = "2020-11-20T19:31:56+01:00"
let marlin_commit_id = "49f81edc9c86e5907d26ea791fa083640ad0ef3e"
let marlin_commit_id_short = "49f81edc"
let marlin_commit_date = "2020-11-18T02:16:47+00:00"
let zexe_commit_id = "e6eef92d6ce67908f787872883190a5d41be4228"
let zexe_commit_id_short = "e6eef92d"
let zexe_commit_date = "2020-11-13T20:07:21+00:00"
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
