### PR TITLE
Mina lockfile

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -307,6 +307,7 @@ let setup_daemon logger =
       ~metadata:
         [ ("commit", `String Coda_version.commit_id)
         ; ("branch", `String Coda_version.branch) ] ;
+    let%bind () = Coda_lib.Conf_dir.check_and_set_lockfile ~logger conf_dir in
     if not @@ String.equal daemon_expiry "never" then (
       [%log info] "Daemon will expire at $exp"
         ~metadata:[("exp", `String daemon_expiry)] ;

--- a/src/lib/coda_lib/conf_dir.ml
+++ b/src/lib/coda_lib/conf_dir.ml
@@ -18,7 +18,7 @@ let check_and_set_lockfile ~logger conf_dir =
             close fd )
       with
       | Ok () ->
-          [%log info] "Created lockfile $lockfile"
+          [%log info] "Created daemon lockfile $lockfile"
             ~metadata:[("lockfile", `String lockfile)] ;
           Exit_handlers.register_async_shutdown_handler ~logger
             ~description:"Remove daemon lockfile" (fun () ->

--- a/src/lib/coda_lib/conf_dir.ml
+++ b/src/lib/coda_lib/conf_dir.ml
@@ -6,6 +6,44 @@ let compute_conf_dir conf_dir_opt =
   let home = Sys.home_directory () in
   Option.value ~default:(home ^/ Cli_lib.Default.conf_dir_name) conf_dir_opt
 
+let check_and_set_lockfile ~logger conf_dir =
+  let lockfile = conf_dir ^/ ".mina-lock" in
+  match Sys.file_exists lockfile with
+  | `No -> (
+      let open Async in
+      match%map
+        Monitor.try_with ~extract_exn:true (fun () ->
+            let open Unix in
+            let%bind fd = openfile ~mode:[`Wronly; `Creat] lockfile in
+            close fd )
+      with
+      | Ok () ->
+          [%log info] "Created lockfile $lockfile"
+            ~metadata:[("lockfile", `String lockfile)] ;
+          Exit_handlers.register_async_shutdown_handler ~logger
+            ~description:"Remove daemon lockfile" (fun () ->
+              match%bind Sys.file_exists lockfile with
+              | `Yes ->
+                  Unix.unlink lockfile
+              | _ ->
+                  return () )
+      | Error exn ->
+          Error.tag_arg (Error.of_exn exn)
+            "Could not create the daemon lockfile" ("lockfile", lockfile)
+            [%sexp_of: string * string]
+          |> Error.raise )
+  | `Yes ->
+      Error.create
+        "A daemon is already running with the current configuration \
+         directory, or you may need to remove the lockfile"
+        (("conf_dir", conf_dir), ("lockfile", lockfile))
+        [%sexp_of: (string * string) * (string * string)]
+      |> Error.raise
+  | `Unknown ->
+      Error.create "Could not determine whether the daemon lockfile exists"
+        ("lockfile", lockfile) [%sexp_of: string * string]
+      |> Error.raise
+
 let export_logs_to_tar ?basename ~conf_dir =
   let open Async in
   let open Deferred.Result.Let_syntax in

--- a/src/lib/coda_lib/conf_dir.ml
+++ b/src/lib/coda_lib/conf_dir.ml
@@ -33,12 +33,10 @@ let check_and_set_lockfile ~logger conf_dir =
             [%sexp_of: string * string]
           |> Error.raise )
   | `Yes ->
-      Error.create
-        "A daemon is already running with the current configuration \
-         directory, or you may need to remove the lockfile"
-        (("conf_dir", conf_dir), ("lockfile", lockfile))
-        [%sexp_of: (string * string) * (string * string)]
-      |> Error.raise
+      Mina_user_error.raisef
+        "A daemon is already running with the current configuration directory \
+         (%s), or you may need to remove the lockfile (%s)"
+        conf_dir lockfile
   | `Unknown ->
       Error.create "Could not determine whether the daemon lockfile exists"
         ("lockfile", lockfile) [%sexp_of: string * string]


### PR DESCRIPTION
Create a lockfile `.mina-lock` in the config dir on daemon startup. If that file already exists, raise an error. On shutdown, remove the file, if it exists.

Boot log:
```
2020-11-20 19:29:19 UTC [Info] Coda daemon is booting up; built with commit "2b6a7ecefbd8fa04cfc081d59dbb3d00e38cfbd4" on branch "feature/mina-lockfile"
2020-11-20 19:29:19 UTC [Info] Created lockfile "/home/steck/.coda-config/.mina-lock"
2020-11-20 19:29:19 UTC [Info] Registering async shutdown handler: "Remove daemon lockfile"
```
Shutdown log:
```
2020-11-20 19:27:19 UTC [Info] Running async shutdown handler: "Remove daemon lockfile"
```

If the lockfile exists:
```
2020-11-20 19:30:34 UTC [Info] Coda daemon is booting up; built with commit "2b6a7ecefbd8fa04cfc081d59dbb3d00e38cfbd4" on branch "feature/mina-lockfile"
(monitor.ml.Error
 ("A daemon is already running with the current configuration directory, or you may need to remove the lockfile"
  ((conf_dir /home/steck/.coda-config)
   (lockfile /home/steck/.coda-config/.mina-lock)))
 ...
```