### PR TITLE
File log level for `coda.log`

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -149,6 +149,7 @@ let setup_daemon logger =
     flag "archive-rocksdb" no_arg ~doc:"Stores all the blocks heard in RocksDB"
   and log_json = Flag.Log.json
   and log_level = Flag.Log.level
+  and file_log_level = Flag.Log.file_log_level
   and snark_work_fee =
     flag "snark-worker-fee"
       ~doc:
@@ -290,7 +291,7 @@ let setup_daemon logger =
     let logrotate_max_size = 1024 * 1024 * 10 in
     let logrotate_num_rotate = 50 in
     Logger.Consumer_registry.register ~id:"default"
-      ~processor:(Logger.Processor.raw ())
+      ~processor:(Logger.Processor.raw ~log_level:file_log_level ())
       ~transport:
         (Logger.Transport.File_system.dumb_logrotate ~directory:conf_dir
            ~log_filename:"coda.log" ~max_size:logrotate_max_size

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -269,10 +269,10 @@ module Log = struct
       (optional_with_default Logger.Level.Info log_level)
       ~doc:"Set log level (default: Info)"
 
-  let file_level =
+  let file_log_level =
     let log_level = Arg_type.log_level in
     let open Command.Param in
-    flag "log-level-file"
+    flag "file-log-level"
       (optional_with_default Logger.Level.Trace log_level)
       ~doc:"Set log level for the log file (default: Trace)"
 end

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -268,6 +268,13 @@ module Log = struct
     flag "log-level"
       (optional_with_default Logger.Level.Info log_level)
       ~doc:"Set log level (default: Info)"
+
+  let file_level =
+    let log_level = Arg_type.log_level in
+    let open Command.Param in
+    flag "log-level-file"
+      (optional_with_default Logger.Level.Trace log_level)
+      ~doc:"Set log level for the log file (default: Trace)"
 end
 
 type signed_command_common =

--- a/src/lib/cli_lib/flag.mli
+++ b/src/lib/cli_lib/flag.mli
@@ -59,6 +59,8 @@ module Log : sig
   val json : bool Command.Spec.param
 
   val level : Logger.Level.t Command.Spec.param
+
+  val file_log_level : Logger.Level.t Command.Spec.param
 end
 
 type signed_command_common =


### PR DESCRIPTION
Adds a flag to control log level for coda.log. Default to trace+ (Spam can go away)