### PR TITLE
Daemon lockfile for develop

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -307,6 +307,7 @@ let setup_daemon logger =
       ~metadata:
         [ ("commit", `String Coda_version.commit_id)
         ; ("branch", `String Coda_version.branch) ] ;
+    let%bind () = Coda_lib.Conf_dir.check_and_set_lockfile ~logger conf_dir in
     if not @@ String.equal daemon_expiry "never" then (
       [%log info] "Daemon will expire at $exp"
         ~metadata:[("exp", `String daemon_expiry)] ;

--- a/src/lib/coda_lib/conf_dir.ml
+++ b/src/lib/coda_lib/conf_dir.ml
@@ -6,6 +6,42 @@ let compute_conf_dir conf_dir_opt =
   let home = Sys.home_directory () in
   Option.value ~default:(home ^/ Cli_lib.Default.conf_dir_name) conf_dir_opt
 
+let check_and_set_lockfile ~logger conf_dir =
+  let lockfile = conf_dir ^/ ".mina-lock" in
+  match Sys.file_exists lockfile with
+  | `No -> (
+      let open Async in
+      match%map
+        Monitor.try_with ~extract_exn:true (fun () ->
+            let open Unix in
+            let%bind fd = openfile ~mode:[`Wronly; `Creat] lockfile in
+            close fd )
+      with
+      | Ok () ->
+          [%log info] "Created daemon lockfile $lockfile"
+            ~metadata:[("lockfile", `String lockfile)] ;
+          Exit_handlers.register_async_shutdown_handler ~logger
+            ~description:"Remove daemon lockfile" (fun () ->
+              match%bind Sys.file_exists lockfile with
+              | `Yes ->
+                  Unix.unlink lockfile
+              | _ ->
+                  return () )
+      | Error exn ->
+          Error.tag_arg (Error.of_exn exn)
+            "Could not create the daemon lockfile" ("lockfile", lockfile)
+            [%sexp_of: string * string]
+          |> Error.raise )
+  | `Yes ->
+      Mina_user_error.raisef
+        "A daemon is already running with the current configuration directory \
+         (%s), or you may need to remove the lockfile (%s)"
+        conf_dir lockfile
+  | `Unknown ->
+      Error.create "Could not determine whether the daemon lockfile exists"
+        ("lockfile", lockfile) [%sexp_of: string * string]
+      |> Error.raise
+
 let export_logs_to_tar ?basename ~conf_dir =
   let open Async in
   let open Deferred.Result.Let_syntax in


### PR DESCRIPTION
This PR is the same code as in #6796, already merged to `develop-until-4.1-hardfork`.

This PR is to get the change to develop for the next testnet.