### PR TITLE
Quieter logs in unit tests (145,594 lines -> 2,134 lines)

### DIFF
--- a/src/inline_test_quiet_logs.opam
+++ b/src/inline_test_quiet_logs.opam
@@ -1,0 +1,27 @@
+opam-version: "2"
+name: "inline_test_quiet_logs"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/CodaProtocol/coda"
+bug-reports: "https://github.com/CodaProtocol/coda/issues"
+dev-repo: "https://github.com/CodaProtocol/coda.git"
+license: "Apache"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"
+  "ppx_inline_test"
+  "dune"
+  "ppx_version"
+  "bisect_ppx"
+]
+synopsis: "Shadowing interface to hide stdout output for passing tests"
+description: "
+Exposes the same interface as ppx_inline_test's runner, but caches the stdout
+while tests are run and only outputs it at the end if there was a failure.
+
+To use, simply `open Inline_test_quiet_logs` at the top of the file with the
+inline tests to be silenced.
+"
+

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -1,3 +1,5 @@
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
 open Core
 open Async
 open Coda_base

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -22,7 +22,8 @@
    non_zero_curve_point
    yojson
    coda_metrics
-   graphql_lib)
+   graphql_lib
+   inline_test_quiet_logs)
  (preprocessor_deps "../../config.mlh")
  (preprocess
   (pps

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1,3 +1,5 @@
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
 open Async_kernel
 open Core_kernel
 open Signed

--- a/src/lib/inline_test_quiet_logs/dune
+++ b/src/lib/inline_test_quiet_logs/dune
@@ -1,0 +1,6 @@
+(library
+ (name inline_test_quiet_logs)
+ (public_name inline_test_quiet_logs)
+ (libraries ppx_inline_test.runtime-lib)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version)))

--- a/src/lib/inline_test_quiet_logs/inline_test_quiet_logs.ml
+++ b/src/lib/inline_test_quiet_logs/inline_test_quiet_logs.ml
@@ -1,0 +1,77 @@
+(** Including this library will overwrite the callbacks used by
+    ppx_inline_test, allowing us to silence the logger for successful tests.
+*)
+
+module Ppx_inline_test_lib = struct
+  module Runtime = struct
+    include Ppx_inline_test_lib.Runtime
+
+    let redirect_to_newfile () =
+      Random.self_init () ;
+      (* Save original stdout file descriptor *)
+      let stdout_orig = Unix.dup Unix.stdout in
+      let tempfile =
+        "temp-stdout.test." ^ string_of_int (Random.int ((1 lsl 30) - 1))
+      in
+      let tempfile_channel = open_out tempfile in
+      (* Overwrite original stdout file descriptor *)
+      Unix.dup2 (Unix.descr_of_out_channel tempfile_channel) Unix.stdout ;
+      (tempfile, tempfile_channel, stdout_orig)
+
+    let tidy_up ~dump_out (tempfile, tempfile_channel, stdout_orig) =
+      Unix.dup2 stdout_orig Unix.stdout ;
+      close_out tempfile_channel ;
+      ( if dump_out then
+        let tempfile_channel = open_in tempfile in
+        let buf_len = 1024 in
+        let buf = Stdlib.Bytes.create buf_len in
+        let rec go () =
+          let len = input tempfile_channel buf 0 buf_len in
+          if len > 0 then ( output stdout buf 0 len ; go () )
+        in
+        go () ) ;
+      Unix.unlink tempfile
+
+    let test ~config ~descr ~tags ~filename ~line_number ~start_pos ~end_pos f
+        =
+      let f () =
+        let redirect_data = redirect_to_newfile () in
+        try
+          let b = f () in
+          tidy_up ~dump_out:(not b) redirect_data ;
+          b
+        with exn ->
+          tidy_up ~dump_out:true redirect_data ;
+          raise exn
+      in
+      test ~config ~descr ~tags ~filename ~line_number ~start_pos ~end_pos f
+
+    let test_unit ~config ~descr ~tags ~filename ~line_number ~start_pos
+        ~end_pos f =
+      let f () =
+        let redirect_data = redirect_to_newfile () in
+        try
+          f () ;
+          tidy_up ~dump_out:false redirect_data
+        with exn ->
+          tidy_up ~dump_out:true redirect_data ;
+          raise exn
+      in
+      test_unit ~config ~descr ~tags ~filename ~line_number ~start_pos ~end_pos
+        f
+
+    let test_module ~config ~descr ~tags ~filename ~line_number ~start_pos
+        ~end_pos f =
+      let f () =
+        let redirect_data = redirect_to_newfile () in
+        try
+          f () ;
+          tidy_up ~dump_out:false redirect_data
+        with exn ->
+          tidy_up ~dump_out:true redirect_data ;
+          raise exn
+      in
+      test_module ~config ~descr ~tags ~filename ~line_number ~start_pos
+        ~end_pos f
+  end
+end

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -1,3 +1,5 @@
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
 open Core
 open Async
 open Cache_lib

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -147,7 +147,7 @@ let rec start_verifier : type proof partial r.
     (* we looped in the else after verifier finished but no pending work. *)
     t.state <- Waiting ;
     Ivar.fill finished (Ok Outcome.empty) )
-  else (
+  else
     let out_for_verification =
       let proofs =
         (* TODO: Make this a proper config detail once we have data on what a
@@ -187,7 +187,7 @@ let rec start_verifier : type proof partial r.
               determine_outcome out_for_verification res t
         in
         upon outcome (fun y -> Ivar.fill finished y) ) ;
-    start_verifier t next_finished )
+    start_verifier t next_finished
 
 let verify' (type p r partial n) (t : (p, partial, r) t)
     (proofs : (p, n) Vector.t) :

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -148,9 +148,6 @@ let rec start_verifier : type proof partial r.
     t.state <- Waiting ;
     Ivar.fill finished (Ok Outcome.empty) )
   else (
-    [%log' debug (Logger.create ())]
-      "Verifying proofs in batch of size $num_proofs"
-      ~metadata:[("num_proofs", `Int (Queue.length t.queue))] ;
     let out_for_verification =
       let proofs =
         (* TODO: Make this a proper config detail once we have data on what a

--- a/src/lib/staged_ledger/dune
+++ b/src/lib/staged_ledger/dune
@@ -4,7 +4,7 @@
  (library_flags -linkall)
  (inline_tests)
  (libraries core lens transaction_snark_scan_state sgn transaction_snark coda_base  merkle_mask pipe_lib logger
-            async async_extra ledger_proof verifier transaction_snark_work staged_ledger_diff)
+            async async_extra ledger_proof verifier transaction_snark_work staged_ledger_diff inline_test_quiet_logs)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1,6 +1,8 @@
 [%%import
 "/src/config.mlh"]
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
 open Core_kernel
 open Async_kernel
 open Coda_base

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -1,3 +1,5 @@
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
 open Async_kernel
 open Core_kernel
 open Signature_lib

--- a/src/lib/transition_frontier/tests/transition_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/transition_frontier_tests.ml
@@ -1,4 +1,6 @@
 (*
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
 open Core
 open Async
 open Coda_base

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -9,6 +9,8 @@
     breadcrumbs from those transitions, which will write the breadcrumbs back
     into the processor as if catchup had successfully completed. *)
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
 open Core_kernel
 open Async_kernel
 open Pipe_lib.Strict_pipe

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -6,6 +6,8 @@
  *  and breadcrumb rose trees (via the catchup pipe).
  *)
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
 open Core_kernel
 open Async_kernel
 open Pipe_lib.Strict_pipe


### PR DESCRIPTION
This PR
* creates the `Inline_test_quiet_logs` library, to silence logs for passing unit tests
  - this uses a hack with overwriting the unix file descriptor underlying the `stdout` `out_channel`
  - this can be `open`ed at the top of any module containing unit tests to silence the output on stdout from any passing test
  - failing tests have their stdout dumped at the end of the test
* removes the verification batch size log
  - this never gave useful output -- our batch size is always 1 (although maybe we should look into why we never batch?)
  - this single log line accounted for `130428/145594 = ~90%` lines in the log file [here](https://buildkite.com/o-1-labs-2/mina/builds/6377#0b7ec790-c83e-48fc-985e-864a88c048f9) (80% of the file by size)
* silences logs from some unit test (percentages are of the remaining logs after all previous removals)
  - `Staged_ledger` -- accounted for ~38%
  - `Transition_handler` -- accounted for ~17%
  - `Bootstrap_controller` -- accounted for ~16%
  - `Consensus` -- accounted for ~25%
  - `Ledger_catchup` -- accounted for ~14%
  - `Transition_frontier` -- accounted for ~17%

The log file size is reduced from 145594 lines to 2134, most of which is build logs. Byte-wise, this takes us down from 45,201,099 (44MB) to 562,455 (552KB).

Of the remaining lines:
* 771 are C++ compilation
* 426 are `go: finding library vX.Y.Z`
* 256 are remaining log messages from tests
* 171 are rust downloading and compiling libraries
* 144 are OCaml warnings
* 124 are buildkite/docker messages

(Most of the rest is a failing test that I was struggling to find amidst 44MB of logs).

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: