### PR TITLE
properly skip verification

### DIFF
--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -966,7 +966,11 @@ module T = struct
     let work = Staged_ledger_diff.completed_works witness in
     let%bind () =
       time ~logger "check_completed_works" (fun () ->
-          check_completed_works ~logger ~verifier t.scan_state work )
+          match skip_verification with
+          | Some true ->
+              return ()
+          | Some false | None ->
+              check_completed_works ~logger ~verifier t.scan_state work )
     in
     let%bind prediff =
       Pre_diff_info.get witness ~constraint_constants


### PR DESCRIPTION
We weren't skipping verification of proofs when loading a persisted state. That caused the daemon to take a very long time to restart from a persisted state. This should fix that. On my machine, the daemon now seems to take around 1.3s per block whereas before it took more like 6s per block.