### PR TITLE
check if snarks are referenced before verifying them

### DIFF
--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -333,31 +333,40 @@ module Make (Transition_frontier : Transition_frontier_intf) = struct
                   let%map () = log_and_punish s e in
                   Error e )
           in
-          match statement_check with
-          | Error _ ->
-              return false
-          | Ok _ -> (
-              let log ?punish e =
-                Deferred.List.iter (One_or_two.to_list proofs)
-                  ~f:(fun (_, s) -> log_and_punish ?punish s e)
-              in
-              let proof_env =
-                { Envelope.Incoming.data=
-                    (One_or_two.map proofs ~f:fst, message)
-                ; sender }
-              in
-              match%bind Batcher.Snark_pool.verify t.batcher proof_env with
-              | Ok true ->
-                  return true
-              | Ok false ->
-                  (* if this proof is in the set of invalid proofs*)
-                  let e = Error.of_string "Invalid proof" in
-                  let%map () = log e in
-                  false
-              | Error e ->
-                  (* Verifier crashed or other errors at our end. Don't punish the peer*)
-                  let%map () = log ~punish:false e in
-                  false )
+          let work = One_or_two.map proofs ~f:snd in
+          if not (work_is_referenced t work) then (
+            [%log' debug t.logger] "Work $stmt not referenced"
+              ~metadata:
+                [ ( "stmt"
+                  , One_or_two.to_yojson Transaction_snark.Statement.to_yojson
+                      work ) ] ;
+            return false )
+          else
+            match statement_check with
+            | Error _ ->
+                return false
+            | Ok _ -> (
+                let log ?punish e =
+                  Deferred.List.iter (One_or_two.to_list proofs)
+                    ~f:(fun (_, s) -> log_and_punish ?punish s e)
+                in
+                let proof_env =
+                  { Envelope.Incoming.data=
+                      (One_or_two.map proofs ~f:fst, message)
+                  ; sender }
+                in
+                match%bind Batcher.Snark_pool.verify t.batcher proof_env with
+                | Ok true ->
+                    return true
+                | Ok false ->
+                    (* if this proof is in the set of invalid proofs*)
+                    let e = Error.of_string "Invalid proof" in
+                    let%map () = log e in
+                    false
+                | Error e ->
+                    (* Verifier crashed or other errors at our end. Don't punish the peer*)
+                    let%map () = log ~punish:false e in
+                    false )
         in
         match One_or_two.zip proofs statements with
         | Ok pairs ->


### PR DESCRIPTION
Right now we waste a lot of time fully verifying SNARKs only to reject them with a quick test later.