### PR TITLE
Fix test_postake_three_producers integration test

### DIFF
--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -224,7 +224,19 @@ let start_prefix_check logger workers events testnet ~acceptable_delay =
   let check_chains (chains : State_hash.Stable.Latest.t list array) =
     let online_chains =
       Array.filteri chains ~f:(fun i el ->
-          Api.synced testnet i && not (List.is_empty el) )
+          match el with
+          | [] ->
+              false
+          | [state_hash]
+            when State_hash.equal state_hash
+                   testnet.Api.precomputed_values.protocol_state_with_hash.hash
+            ->
+              (* Knowing only the genesis transition doesn't indicate an online
+                 chain.
+              *)
+              false
+          | _ ->
+              Api.synced testnet i )
     in
     let chain_sets =
       Array.map online_chains


### PR DESCRIPTION
This should make CI less red, making it easier to spot actual failures/regressions.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: