### PR TITLE
Fix test--dev--coda-archive-node-test

### DIFF
--- a/src/app/cli/src/tests/dune
+++ b/src/app/cli/src/tests/dune
@@ -13,6 +13,7 @@
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps
+               ppx_assert
                ppx_coda
                ppx_version
                ppx_optcomp ppx_bin_prot ppx_let


### PR DESCRIPTION
This PR
* fixes the test, by not checking for blocks that could never have been seen
* uses `[%test_eq]` instead of `assert` to check equality, so that the results of a failure are printed.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: