### PR TITLE
Bump ppx_version to filter attributes when printing versioned types

### DIFF
--- a/scripts/compare_binables.py
+++ b/scripts/compare_binables.py
@@ -16,4 +16,4 @@ if __name__ == "__main__":
         print("The .ml files must have the same name, with different paths")
         sys.exit(1)
 
-    run_comparison('_build/default/src/external/ppx_version/src/print_binable_functors.exe','Binable functors',sys.argv[1],sys.argv[2])
+    run_comparison('_build/default/src/external/ppx_version/tools/print_binable_functors.exe','Binable functors',sys.argv[1],sys.argv[2])

--- a/scripts/compare_ci_diff_binables.sh
+++ b/scripts/compare_ci_diff_binables.sh
@@ -14,5 +14,5 @@ rm -rf base
 
 # build print_binable_functors, then run Python script to compare binable functors in a pull request
 source ~/.profile && \
-    (dune build --profile=dev src/external/ppx_version/src/print_binable_functors.exe) && \
+    (dune build --profile=dev src/external/ppx_version/tools/print_binable_functors.exe) && \
     ./scripts/compare_pr_diff_binables.py ${BASE_BRANCH_NAME:-develop}

--- a/scripts/compare_ci_diff_types.sh
+++ b/scripts/compare_ci_diff_types.sh
@@ -14,5 +14,5 @@ rm -rf base
 
 # build print_versioned_types, then run Python script to compare versioned types in a pull request
 source ~/.profile && \
-    (dune build --profile=dev src/external/ppx_version/src/print_versioned_types.exe) && \
+    (dune build --profile=dev src/external/ppx_version/tools/print_versioned_types.exe) && \
     ./scripts/compare_pr_diff_types.py ${BASE_BRANCH_NAME:-develop}

--- a/scripts/compare_versioned_types.py
+++ b/scripts/compare_versioned_types.py
@@ -16,4 +16,4 @@ if __name__ == "__main__":
         print("The .ml files must have the same name, with different paths")
         sys.exit(1)
 
-    run_comparison('_build/default/src/external/ppx_version/src/print_versioned_types.exe','Versioned types',sys.argv[1],sys.argv[2])
+    run_comparison('_build/default/src/external/ppx_version/tools/print_versioned_types.exe','Versioned types',sys.argv[1],sys.argv[2])


### PR DESCRIPTION
In `ppx_version`, the versioned type printer was printing internal attributes in type declarations, which don't affect serialization. That was causing a spurious failure in the CI linter.

Bumped to latest commit, which includes Bazel changes.