### PR TITLE
Fixes for turbo pickles (should improve catchup)

### DIFF
--- a/src/lib/allocation_functor/table.ml
+++ b/src/lib/allocation_functor/table.ml
@@ -62,7 +62,9 @@ module Allocation_data = struct
       if m mod 2 = 0 then [m / 2] else [m / 2; (m / 2) + 1]
     in
     let mean offset length =
-      let indices = mean_indices length in
+      let indices =
+        mean_indices length |> List.filter ~f:(fun x -> x < count)
+      in
       let sum =
         List.fold_left indices ~init:0.0 ~f:(fun acc i ->
             acc +. get_lifetime_ms (count - 1 - (i + offset)) )
@@ -84,6 +86,12 @@ module Allocation_data = struct
           Allocation_statistics.{q1; q2; q3; q4}
     in
     Allocation_statistics.{count; lifetimes}
+
+  let compute_statistics t =
+    try compute_statistics t
+    with _ ->
+      Allocation_statistics.
+        {count= 0; lifetimes= Allocation_statistics.make_quartiles 0.}
 
   let%test_module "Allocation_data unit tests" =
     ( module struct

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -939,12 +939,12 @@ let create (config : Config.t)
     in
     result
   in
-  let get_best_tip_rpc conn ~version:_ query =
+  let get_best_tip_rpc conn ~version:_ (() : unit) =
     [%log debug] "Sending best_tip to $peer" ~metadata:(md conn) ;
     let action_msg = "Get_best_tip. query: $query" in
-    let msg_args = [("query", Rpcs.Get_best_tip.query_to_yojson query)] in
+    let msg_args = [("query", Rpcs.Get_best_tip.query_to_yojson ())] in
     let%bind result, sender =
-      run_for_rpc_result conn query ~f:get_best_tip action_msg msg_args
+      run_for_rpc_result conn () ~f:get_best_tip action_msg msg_args
     in
     match result with
     | None ->
@@ -1252,11 +1252,14 @@ let make_rpc_request ?timeout ~rpc ~label t peer input =
       Or_error.errorf
         !"Peer %{sexp:Network_peer.Peer.Id.t} doesn't have the requested %s"
         peer.peer_id label
-  | Connected {data= Error e; _} | Failed_to_connect e ->
+  | Connected {data= Error e; _} ->
       Error e
+  | Failed_to_connect e ->
+      Error (Error.tag e ~tag:"failed-to-connect")
 
 let get_transition_chain_proof t =
-  make_rpc_request ~rpc:Rpcs.Get_transition_chain_proof ~label:"transition" t
+  make_rpc_request ~rpc:Rpcs.Get_transition_chain_proof
+    ~label:"transition chain proof" t
 
 let get_transition_chain t =
   make_rpc_request ~rpc:Rpcs.Get_transition_chain ~label:"chain of transitions"

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -33,7 +33,7 @@ module Config = struct
     ; flooding: bool
     ; direct_peers: Coda_net2.Multiaddr.t list
     ; peer_exchange: bool
-    ; keypair: Coda_net2.Keypair.t option }
+    ; mutable keypair: Coda_net2.Keypair.t option }
   [@@deriving make]
 end
 
@@ -365,7 +365,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
           in
           match%map initializing_libp2p_result with
           | Ok (subscription, message_reader) ->
-              (net2, subscription, message_reader)
+              (net2, subscription, message_reader, me)
           | Error e ->
               fail e )
       | Ok (Error e) ->
@@ -384,7 +384,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
       let%bind () =
         let rec on_libp2p_create res =
           net2_ref :=
-            Deferred.map res ~f:(fun (n, _, _) ->
+            Deferred.map res ~f:(fun (n, _, _, _) ->
                 let restart_after =
                   let plus_or_minus initial ~delta =
                     initial +. (Random.float (2. *. delta) -. delta)
@@ -407,8 +407,10 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                       (let%bind () = Coda_net2.shutdown n in
                        on_unexpected_termination ()) ) ;
                 n ) ;
-          subscription_ref := Deferred.map res ~f:(fun (_, s, _) -> s) ;
-          upon res (fun (_, _, m) ->
+          subscription_ref := Deferred.map res ~f:(fun (_, s, _, _) -> s) ;
+          upon res (fun (_, _, m, me) ->
+              (* This is a hack so that we keep the same keypair across restarts. *)
+              config.keypair <- Some me ;
               let logger = config.logger in
               [%log trace] ~metadata:[] "Successfully restarted libp2p" ;
               don't_wait_for (Strict_pipe.transfer m message_writer ~f:Fn.id)

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -511,6 +511,10 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
         Monitor.try_with (fun () ->
             (* Async_rpc_kernel takes a transport instead of a Reader.t *)
             Async_rpc_kernel.Rpc.Connection.with_close
+              ~heartbeat_config:
+                (Async_rpc_kernel.Rpc.Connection.Heartbeat_config.create
+                   ~send_every:(Time_ns.Span.of_sec 10.)
+                   ~timeout:(Time_ns.Span.of_sec 120.))
               ~connection_state:(Fn.const ())
               ~dispatch_queries:(fun conn ->
                 Versioned_rpc.Connection_with_menu.create conn

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -223,7 +223,21 @@ let download_state_hashes ~logger ~trust_system ~network ~frontier ~peers
              if Transition_frontier.find frontier hash |> Option.is_some then
                Continue_or_stop.Stop (Ok (peer, acc))
              else Continue_or_stop.Continue (hash :: acc) )
-           ~finish:(fun _ ->
+           ~finish:(fun acc ->
+             let module T = struct
+               type t = State_hash.t list [@@deriving to_yojson]
+             end in
+             let all_hashes =
+               List.map (Transition_frontier.all_breadcrumbs frontier)
+                 ~f:(fun b -> Frontier_base.Breadcrumb.state_hash b)
+             in
+             [%log debug]
+               ~metadata:
+                 [ ("n", `Int (List.length acc))
+                 ; ("hashes", T.to_yojson acc)
+                 ; ("all_hashes", T.to_yojson all_hashes) ]
+               "Finishing download_state_hashes with $n $hashes. with \
+                $all_hashes" ;
              Or_error.errorf
                !"Peer %{sexp:Network_peer.Peer.t} moves too fast"
                peer ) )
@@ -240,44 +254,128 @@ let rec partition size = function
       let sub, rest = List.split_n ls size in
       sub :: partition size rest
 
+module Peers_pool = struct
+  type t =
+    {preferred: Peer.t Queue.t; normal: Peer.t Queue.t; busy: Peer.Hash_set.t}
+
+  let create ~busy ~preferred peers =
+    {preferred= Queue.of_list preferred; normal= Queue.of_list peers; busy}
+
+  let dequeue {preferred; normal; busy} =
+    let find_available q =
+      let n = Queue.length q in
+      let rec go tried =
+        if tried = n then `All_busy
+        else
+          match Queue.dequeue q with
+          | None ->
+              `Empty
+          | Some x ->
+              if Hash_set.mem busy x then (
+                Queue.enqueue q x ;
+                go (tried + 1) )
+              else `Available x
+      in
+      go 0
+    in
+    match find_available preferred with
+    | `Available x ->
+        `Available x
+    | `Empty ->
+        find_available normal
+    | `All_busy -> (
+      match find_available normal with
+      | `Available x ->
+          `Available x
+      | `Empty | `All_busy ->
+          `All_busy )
+end
+
 (* returns a list of transitions with old ones comes first *)
-let download_transitions ~logger ~trust_system ~network ~num_peers
-    ~preferred_peer ~maximum_download_size ~hashes_of_missing_transitions =
-  let%bind random_peers = Coda_networking.random_peers network num_peers in
+let download_transitions ~target_hash ~logger ~trust_system ~network
+    ~preferred_peer ~hashes_of_missing_transitions =
+  let busy = Peer.Hash_set.create () in
   Deferred.Or_error.List.concat_map
-    (partition maximum_download_size hashes_of_missing_transitions)
-    ~how:`Parallel ~f:(fun hashes ->
-      Deferred.Or_error.find_map_ok (preferred_peer :: random_peers)
-        ~f:(fun peer ->
-          let open Deferred.Or_error.Let_syntax in
-          let%bind transitions =
-            Coda_networking.get_transition_chain network peer hashes
-          in
-          Coda_metrics.(
-            Gauge.set
-              Transition_frontier_controller
-              .transitions_downloaded_from_catchup
-              (Float.of_int (List.length transitions))) ;
-          if not @@ verify_against_hashes transitions hashes then (
-            let error_msg =
-              sprintf
-                !"Peer %{sexp:Network_peer.Peer.t} returned a list that is \
-                  different from the one that is requested."
-                peer
+    (partition Transition_frontier.max_catchup_chunk_length
+       hashes_of_missing_transitions) ~how:`Parallel ~f:(fun hashes ->
+      let%bind.Async peers = Coda_networking.peers network in
+      let peers =
+        Peers_pool.create ~busy ~preferred:[preferred_peer]
+          (List.permute peers)
+      in
+      let rec go errs =
+        match Peers_pool.dequeue peers with
+        | `Empty ->
+            (* Tried everyone *)
+            Deferred.return (Error (Error.of_list (List.rev errs)))
+        | `All_busy ->
+            let%bind () = after (Time.Span.of_sec 10.) in
+            go errs
+        | `Available peer -> (
+            Hash_set.add busy peer ;
+            let%bind res =
+              let open Deferred.Or_error.Let_syntax in
+              [%log debug]
+                ~metadata:
+                  [ ("n", `Int (List.length hashes))
+                  ; ("peer", Peer.to_yojson peer)
+                  ; ("target_hash", State_hash.to_yojson target_hash) ]
+                "requesting $n blocks from $peer for catchup to $target_hash" ;
+              let%bind transitions =
+                match%map.Async
+                  Coda_networking.get_transition_chain network peer hashes
+                with
+                | Ok x ->
+                    Ok x
+                | Error e ->
+                    [%log debug]
+                      ~metadata:
+                        [ ("error", `String (Error.to_string_hum e))
+                        ; ("n", `Int (List.length hashes))
+                        ; ("peer", Peer.to_yojson peer) ]
+                      "$error from downloading $n blocks from $peer" ;
+                    Error e
+              in
+              Coda_metrics.(
+                Gauge.set
+                  Transition_frontier_controller
+                  .transitions_downloaded_from_catchup
+                  (Float.of_int (List.length transitions))) ;
+              [%log debug]
+                ~metadata:
+                  [ ("n", `Int (List.length transitions))
+                  ; ("peer", Peer.to_yojson peer) ]
+                "downloaded $n blocks from $peer" ;
+              if not @@ verify_against_hashes transitions hashes then (
+                let error_msg =
+                  sprintf
+                    !"Peer %{sexp:Network_peer.Peer.t} returned a list that \
+                      is different from the one that is requested."
+                    peer
+                in
+                Trust_system.(
+                  record trust_system logger peer
+                    Actions.(Violated_protocol, Some (error_msg, [])))
+                |> don't_wait_for ;
+                Deferred.Or_error.error_string error_msg )
+              else
+                Deferred.Or_error.return
+                @@ List.map2_exn hashes transitions ~f:(fun hash transition ->
+                       let transition_with_hash =
+                         With_hash.of_data transition
+                           ~hash_data:(Fn.const hash)
+                       in
+                       Envelope.Incoming.wrap_peer ~data:transition_with_hash
+                         ~sender:peer )
             in
-            Trust_system.(
-              record trust_system logger peer
-                Actions.(Violated_protocol, Some (error_msg, [])))
-            |> don't_wait_for ;
-            Deferred.Or_error.error_string error_msg )
-          else
-            Deferred.Or_error.return
-            @@ List.map2_exn hashes transitions ~f:(fun hash transition ->
-                   let transition_with_hash =
-                     With_hash.of_data transition ~hash_data:(Fn.const hash)
-                   in
-                   Envelope.Incoming.wrap_peer ~data:transition_with_hash
-                     ~sender:peer ) ) )
+            Hash_set.remove busy peer ;
+            match res with
+            | Ok x ->
+                Deferred.return (Ok x)
+            | Error e ->
+                go (e :: errs) )
+      in
+      go [] )
 
 let verify_transitions_and_build_breadcrumbs ~logger
     ~(precomputed_values : Precomputed_values.t) ~trust_system ~verifier
@@ -390,11 +488,17 @@ let verify_transitions_and_build_breadcrumbs ~logger
           [ ("target_hash", State_hash.to_yojson target_hash)
           ; ( "time_elapsed"
             , `Float Core.Time.(Span.to_sec @@ diff (now ()) build_start_time)
-            ) ]
-        "build of breadcrumbs failed" ;
-      List.map transitions_with_initial_validation
-        ~f:Cached.invalidate_with_failure
-      |> ignore ;
+            )
+          ; ("error", `String (Error.to_string_hum e)) ]
+        "build of breadcrumbs failed with $error" ;
+      ( try
+          List.map transitions_with_initial_validation
+            ~f:Cached.invalidate_with_failure
+          |> ignore
+        with e ->
+          [%log error]
+            ~metadata:[("exn", `String (Exn.to_string e))]
+            "$exn in cached" ) ;
       Deferred.Or_error.fail e
 
 let garbage_collect_subtrees ~logger ~subtrees =
@@ -411,13 +515,13 @@ let run ~logger ~precomputed_values ~trust_system ~verifier ~network ~frontier
        , Strict_pipe.crash Strict_pipe.buffered
        , unit )
        Strict_pipe.Writer.t) ~unprocessed_transition_cache : unit =
-  let num_peers = 8 in
-  let maximum_download_size = 100 in
   don't_wait_for
     (Strict_pipe.Reader.iter_without_pushback catchup_job_reader
        ~f:(fun (target_hash, subtrees) ->
          don't_wait_for
            (let start_time = Core.Time.now () in
+            [%log info] "Catch up to $target_hash"
+              ~metadata:[("target_hash", State_hash.to_yojson target_hash)] ;
             let%bind () = Catchup_jobs.incr () in
             let subtree_peers =
               List.fold subtrees ~init:[] ~f:(fun acc_outer tree ->
@@ -451,7 +555,7 @@ let run ~logger ~precomputed_values ~trust_system ~verifier ~network ~frontier
                        subtrees; trying again with random peers"
                       ~metadata:[("error", Error_json.error_to_yojson err)] ;
                     let%bind random_peers =
-                      Coda_networking.random_peers network num_peers
+                      Coda_networking.peers network >>| List.permute
                     in
                     match%bind
                       download_state_hashes ~logger ~trust_system ~network
@@ -481,8 +585,7 @@ let run ~logger ~precomputed_values ~trust_system ~verifier ~network ~frontier
                   Deferred.Or_error.return []
                 else
                   download_transitions ~logger ~trust_system ~network
-                    ~num_peers ~preferred_peer ~maximum_download_size
-                    ~hashes_of_missing_transitions
+                    ~preferred_peer ~hashes_of_missing_transitions ~target_hash
               in
               [%log debug]
                 ~metadata:[("target_hash", State_hash.to_yojson target_hash)]

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1203,7 +1203,7 @@ let%test_module _ =
         in
         (init_nonce, init_balance, setup_cmds, replace_cmd)
       in
-      Quickcheck.test gen
+      Quickcheck.test ~trials:20 gen
         ~sexp_of:
           [%sexp_of:
             Account_nonce.t

--- a/src/lib/network_pool/mocks.ml
+++ b/src/lib/network_pool/mocks.ml
@@ -1,21 +1,53 @@
+open Core_kernel
+open Async_kernel
+open Pipe_lib
+
 let trust_system = Trust_system.null ()
 
 module Transaction_snark_work = Transaction_snark_work
-module Ledger_proof = Ledger_proof.Debug.Stable.V1
+module Ledger_proof = Ledger_proof.Debug
 
 module Transition_frontier = struct
-  type t = string
+  type table = int Transaction_snark_work.Statement.Table.t [@@deriving sexp]
 
-  let create () : t = ""
+  type diff = int * table [@@deriving sexp]
+
+  type t =
+    { refcount_table: table
+    ; diff_writer: diff Broadcast_pipe.Writer.t sexp_opaque
+    ; diff_reader: diff Broadcast_pipe.Reader.t sexp_opaque }
+  [@@deriving sexp]
+
+  let add_statements table stmts =
+    List.iter stmts ~f:(fun s ->
+        Transaction_snark_work.Statement.Table.change table s ~f:(function
+          | None ->
+              Some 1
+          | Some count ->
+              Some (count + 1) ) )
+
+  (*Create tf with some statements referenced to be able to add snark work for those statements to the pool*)
+  let create _stmts : t =
+    let table = Transaction_snark_work.Statement.Table.create () in
+    (*add_statements table stmts ;*)
+    let diff_reader, diff_writer = Broadcast_pipe.create (0, table) in
+    {refcount_table= table; diff_writer; diff_reader}
 
   module Extensions = struct
     module Work = Transaction_snark_work.Statement
   end
 
-  let snark_pool_refcount_pipe _ =
-    let reader, _writer =
-      Pipe_lib.Broadcast_pipe.create
-        (0, Transaction_snark_work.Statement.Stable.V1.Table.create ())
+  let snark_pool_refcount_pipe (t : t) :
+      (int * int Transaction_snark_work.Statement.Table.t)
+      Broadcast_pipe.Reader.t =
+    t.diff_reader
+
+  (*Adds statements to the table of referenced work. Snarks for only the referenced statements are added to the pool*)
+  let refer_statements (t : t) stmts =
+    let open Deferred.Let_syntax in
+    add_statements t.refcount_table stmts ;
+    let%bind () =
+      Broadcast_pipe.Writer.write t.diff_writer (0, t.refcount_table)
     in
-    reader
+    Async.Scheduler.yield_until_no_jobs_remain ()
 end

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -183,12 +183,12 @@ module Make (Transition_frontier : Transition_frontier_intf) = struct
             {Transaction_snark_work.Info.statements= key; work_ids; fee; prover}
             :: acc )
 
-      (** True when there is no active transition_frontier or
+      (** false when there is no active transition_frontier or
           when the refcount for the given work is 0 *)
       let work_is_referenced t work =
         match t.ref_table with
         | None ->
-            true
+            false
         | Some ref_table -> (
           match Statement_table.find ref_table work with
           | None ->

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -215,6 +215,7 @@ module Make (Transition_frontier : Transition_frontier_intf) = struct
               Gauge.set Snark_work.snark_pool_size
                 (Float.of_int @@ Hashtbl.length t.snark_tables.all)) )
 
+      (*TODO? add referenced statements from the transition frontier to ref_table here otherwise the work referenced in the root and not in any of the successor blocks will never be included. This may not be required because the chances of a new block from the root is very low (root's existing successor is 1 block away from finality)*)
       let listen_to_frontier_broadcast_pipe frontier_broadcast_pipe (t : t)
           ~tf_diff_writer =
         (* start with empty ref table *)
@@ -563,12 +564,8 @@ let%test_module "random set test" =
         | Some n ->
             Quickcheck.Generator.list_with_length n gen_entry
       in
-      (*This has to be None because otherwise (if frontier_broadcast_pipe_r is
-      seeded with (0, empty-table)) add_snark function wouldn't add snarks in
-      the snark pool (see work_is_referenced) until the first diff (first block)
-      and there are no best tip diffs being fed into this pipe from the mock
-      transition frontier*)
-      let frontier_broadcast_pipe_r, _ = Broadcast_pipe.create None in
+      let tf = Mocks.Transition_frontier.create [] in
+      let frontier_broadcast_pipe_r, _ = Broadcast_pipe.create (Some tf) in
       let incoming_diff_r, _incoming_diff_w =
         Strict_pipe.(create ~name:"Snark pool test" Synchronous)
       in
@@ -590,18 +587,22 @@ let%test_module "random set test" =
             ~incoming_diffs:incoming_diff_r ~local_diffs:local_diff_r
           |> Mock_snark_pool.resource_pool
         in
+        (*Statements should be referenced before work for those can be included*)
+        let%bind () =
+          Mocks.Transition_frontier.refer_statements tf
+            (List.unzip sample_solved_work |> fst)
+        in
         let%map () =
-          let open Deferred.Let_syntax in
           Deferred.List.iter sample_solved_work ~f:(fun (work, fee) ->
               let%map res = apply_diff resource_pool work fee in
               assert (Result.is_ok res) )
         in
-        resource_pool
+        (resource_pool, tf)
       in
       res
 
     let%test_unit "serialization" =
-      let t =
+      let t, _tf =
         Async.Thread_safe.block_on_async_exn (fun () ->
             Quickcheck.random_value (gen ~length:100 ()) )
       in
@@ -610,8 +611,6 @@ let%test_module "random set test" =
         Snark_tables.to_serializable s0 |> Snark_tables.of_serializable
       in
       [%test_eq: Snark_tables.t] s0 s1
-
-    let gen = gen ()
 
     let%test_unit "Invalid proofs are not accepted" =
       let open Quickcheck.Generator.Let_syntax in
@@ -648,18 +647,25 @@ let%test_module "random set test" =
       Quickcheck.test ~trials:5
         ~sexp_of:
           [%sexp_of:
-            Mock_snark_pool.Resource_pool.t Deferred.t
+            (Mock_snark_pool.Resource_pool.t * Mocks.Transition_frontier.t)
+            Deferred.t
             * ( Transaction_snark_work.Statement.t
               * Ledger_proof.t One_or_two.t
               * Fee_with_prover.t
               * Signature_lib.Public_key.Compressed.t )
-              list] (Quickcheck.Generator.tuple2 gen invalid_work_gen)
+              list]
+        (Quickcheck.Generator.tuple2 (gen ()) invalid_work_gen)
         ~f:(fun (t, invalid_work_lst) ->
           Async.Thread_safe.block_on_async_exn (fun () ->
               let open Deferred.Let_syntax in
-              let%bind t = t in
+              let%bind t, tf = t in
               let completed_works =
                 Mock_snark_pool.Resource_pool.all_completed_work t
+              in
+              (*Statements should be referenced before work for those can be included*)
+              let%bind () =
+                Mocks.Transition_frontier.refer_statements tf
+                  (List.map invalid_work_lst ~f:(fun (stmt, _, _, _) -> stmt))
               in
               let%map () =
                 Deferred.List.iter invalid_work_lst
@@ -681,18 +687,24 @@ let%test_module "random set test" =
     let%test_unit "When two priced proofs of the same work are inserted into \
                    the snark pool, the fee of the work is at most the minimum \
                    of those fees" =
-      Quickcheck.test
+      Quickcheck.test ~trials:5
         ~sexp_of:
           [%sexp_of:
-            Mock_snark_pool.Resource_pool.t Deferred.t
+            (Mock_snark_pool.Resource_pool.t * Mocks.Transition_frontier.t)
+            Deferred.t
             * Mocks.Transaction_snark_work.Statement.t
             * Fee_with_prover.t
             * Fee_with_prover.t]
-        (Async.Quickcheck.Generator.tuple4 gen
+        (Async.Quickcheck.Generator.tuple4 (gen ())
            Mocks.Transaction_snark_work.Statement.gen Fee_with_prover.gen
-           Fee_with_prover.gen) ~f:(fun (t, work, fee_1, fee_2) ->
+           Fee_with_prover.gen)
+        ~f:(fun (t, work, fee_1, fee_2) ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let%bind t = t in
+              let%bind t, tf = t in
+              (*Statements should be referenced before work for those can be included*)
+              let%bind () =
+                Mocks.Transition_frontier.refer_statements tf [work]
+              in
               let%bind _ = apply_diff t work fee_1 in
               let%map _ = apply_diff t work fee_2 in
               let fee_upper_bound = Currency.Fee.min fee_1.fee fee_2.fee in
@@ -705,18 +717,24 @@ let%test_module "random set test" =
     let%test_unit "A priced proof of a work will replace an existing priced \
                    proof of the same work only if it's fee is smaller than \
                    the existing priced proof" =
-      Quickcheck.test
+      Quickcheck.test ~trials:5
         ~sexp_of:
           [%sexp_of:
-            Mock_snark_pool.Resource_pool.t Deferred.t
+            (Mock_snark_pool.Resource_pool.t * Mocks.Transition_frontier.t)
+            Deferred.t
             * Mocks.Transaction_snark_work.Statement.t
             * Fee_with_prover.t
             * Fee_with_prover.t]
-        (Quickcheck.Generator.tuple4 gen
+        (Quickcheck.Generator.tuple4 (gen ())
            Mocks.Transaction_snark_work.Statement.gen Fee_with_prover.gen
-           Fee_with_prover.gen) ~f:(fun (t, work, fee_1, fee_2) ->
+           Fee_with_prover.gen)
+        ~f:(fun (t, work, fee_1, fee_2) ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let%bind t = t in
+              let%bind t, tf = t in
+              (*Statements should be referenced before work for those can be included*)
+              let%bind () =
+                Mocks.Transition_frontier.refer_statements tf [work]
+              in
               Mock_snark_pool.Resource_pool.remove_solved_work t work ;
               let expensive_fee = max fee_1 fee_2
               and cheap_fee = min fee_1 fee_2 in
@@ -745,7 +763,7 @@ let%test_module "random set test" =
             Strict_pipe.(create ~name:"Snark pool test" Synchronous)
           in
           let frontier_broadcast_pipe_r, _ =
-            Broadcast_pipe.create (Some (Mocks.Transition_frontier.create ()))
+            Broadcast_pipe.create (Some (Mocks.Transition_frontier.create []))
           in
           let%bind verifier =
             Verifier.create ~logger ~proof_level
@@ -835,7 +853,7 @@ let%test_module "random set test" =
             let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
             let frontier_broadcast_pipe_r, _ =
               Broadcast_pipe.create
-                (Some (Mocks.Transition_frontier.create ()))
+                (Some (Mocks.Transition_frontier.create []))
             in
             let%bind verifier =
               Verifier.create ~logger ~proof_level
@@ -871,7 +889,8 @@ let%test_module "random set test" =
       let local_reader, _local_writer =
         Strict_pipe.(create ~name:"Snark pool test" Synchronous)
       in
-      let frontier_broadcast_pipe_r, _w = Broadcast_pipe.create None in
+      let tf = Mocks.Transition_frontier.create [] in
+      let frontier_broadcast_pipe_r, _w = Broadcast_pipe.create (Some tf) in
       let stmt1, stmt2 =
         Quickcheck.random_value ~seed:(`Deterministic "")
           (Quickcheck.Generator.filter
@@ -908,6 +927,9 @@ let%test_module "random set test" =
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
           in
           let resource_pool = Mock_snark_pool.resource_pool network_pool in
+          let%bind () =
+            Mocks.Transition_frontier.refer_statements tf [stmt1; stmt2]
+          in
           let%bind res1 =
             apply_diff ~sender:fake_sender resource_pool stmt1 fee1
           in

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -33,7 +33,8 @@ let%test_module "network pool test" =
       let local_reader, _local_writer =
         Strict_pipe.(create ~name:"Network pool test" Synchronous)
       in
-      let frontier_broadcast_pipe_r, _ = Broadcast_pipe.create None in
+      let tf = Mocks.Transition_frontier.create [] in
+      let frontier_broadcast_pipe_r, _ = Broadcast_pipe.create (Some tf) in
       let work =
         `One
           (Quickcheck.random_value ~seed:(`Deterministic "network_pool_test")
@@ -59,6 +60,7 @@ let%test_module "network pool test" =
               ~local_diffs:local_reader
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
           in
+          let%bind () = Mocks.Transition_frontier.refer_statements tf [work] in
           let command =
             Mock_snark_pool.Resource_pool.Diff.Add_solved_work
               (work, priced_proof)
@@ -115,9 +117,8 @@ let%test_module "network pool test" =
                Strict_pipe.Writer.write local_writer (diff, Fn.const ())
                |> Deferred.don't_wait_for ) ;
         let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-        let frontier_broadcast_pipe_r, _ =
-          Broadcast_pipe.create (Some (Mocks.Transition_frontier.create ()))
-        in
+        let tf = Mocks.Transition_frontier.create [] in
+        let frontier_broadcast_pipe_r, _ = Broadcast_pipe.create (Some tf) in
         let%bind verifier =
           Verifier.create ~logger ~proof_level
             ~pids:(Child_processes.Termination.create_pid_table ())
@@ -130,6 +131,7 @@ let%test_module "network pool test" =
             ~local_diffs:local_reader
             ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
         in
+        let%bind () = Mocks.Transition_frontier.refer_statements tf works in
         don't_wait_for
         @@ Linear_pipe.iter (Mock_snark_pool.broadcasts network_pool)
              ~f:(fun work_command ->

--- a/src/lib/sync_handler/dune
+++ b/src/lib/sync_handler/dune
@@ -3,5 +3,5 @@
  (public_name sync_handler)
  (inline_tests)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_jane))
+ (preprocess (pps ppx_coda ppx_version ppx_jane))
  (libraries async_kernel core_kernel coda_intf coda_base transition_frontier syncable_ledger merkle_address consensus best_tip_prover))

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -140,6 +140,16 @@ module Make (Inputs : Inputs_intf) :
 
   let get_transition_chain ~frontier hashes =
     let open Option.Let_syntax in
+    let%bind () =
+      let requested = List.length hashes in
+      if requested <= Transition_frontier.max_catchup_chunk_length then Some ()
+      else (
+        [%log' trace (Logger.create ())]
+          ~metadata:[("n", `Int requested)]
+          "get_transition_chain requested $n > %d hashes"
+          Transition_frontier.max_catchup_chunk_length ;
+        None )
+    in
     Option.all
     @@ List.map hashes ~f:(fun hash ->
            let%map validated_transition =

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -13,6 +13,8 @@ module Extensions = Extensions
 module Persistent_root = Persistent_root
 module Persistent_frontier = Persistent_frontier
 
+let max_catchup_chunk_length = 20
+
 let global_max_length (genesis_constants : Genesis_constants.t) =
   genesis_constants.protocol.k
 

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -23,6 +23,8 @@ type Structured_log_events.t += Added_breadcrumb_user_commands
 type Structured_log_events.t += Applying_diffs of {diffs: Yojson.Safe.t list}
   [@@deriving register_event]
 
+val max_catchup_chunk_length : int
+
 (* This is the max length which is used when the transition frontier is initialized
  * via `load`. In other words, this will always be the max length of the transition
  * frontier as long as the `For_tests.load_with_max_length` is not used *)

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -288,7 +288,14 @@ let initialize ~logger ~network ~is_seed ~is_demo_mode ~verifier ~trust_system
            ~transition_writer_ref ~frontier_w ~precomputed_values frontier
   | Some best_tip, Some frontier ->
       [%log info]
-        "Successfully loaded frontier and downloaded best tip from network" ;
+        ~metadata:
+          [ ( "length"
+            , `Int
+                (Unsigned.UInt32.to_int
+                   (External_transition.Initial_validated.blockchain_length
+                      best_tip.data)) ) ]
+        "Successfully loaded frontier and downloaded best tip with $length \
+         from network" ;
       if
         is_transition_for_bootstrap ~logger frontier
           (best_tip |> Envelope.Incoming.data)


### PR DESCRIPTION
This PR includes a number of fixes for the current test network. It should improve catchup in that it changes the way that blocks are downloaded to be more efficient/effective. It does not fully fix all the issues but it should get us a lot closer.