### PR TITLE
Fix segfault: capture rust heap references before yeilding to OCaml

### DIFF
--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_vector.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_vector.rs
@@ -1,17 +1,19 @@
 use crate::tweedle_fp::{CamlTweedleFp, CamlTweedleFpPtr};
 use algebra::tweedle::fp::Fp;
+use std::ops::{Deref, DerefMut};
 
-pub struct CamlTweedleFpVector(pub Vec<Fp>);
-pub type CamlTweedleFpVectorPtr = ocaml::Pointer<CamlTweedleFpVector>;
+#[derive (Clone)]
+pub struct CamlTweedleFpVector(pub *mut Vec<Fp>);
 
 /* Note: The vector header is allocated in the OCaml heap, but the data held in
    the vector elements themselves are stored in the rust heap.
 */
 
 extern "C" fn caml_tweedle_fp_vector_finalize(v: ocaml::Value) {
-    let mut v: CamlTweedleFpVectorPtr = ocaml::FromValue::from_value(v);
+    let mut v: ocaml::Pointer<CamlTweedleFpVector> = ocaml::FromValue::from_value(v);
     unsafe {
-        v.as_mut_ptr().drop_in_place();
+        // Memory is freed when the variable goes out of scope
+        let _box = Box::from_raw(v.as_mut().0);
     }
 }
 
@@ -19,27 +21,54 @@ ocaml::custom!(CamlTweedleFpVector {
     finalize: caml_tweedle_fp_vector_finalize,
 });
 
+impl From<CamlTweedleFpVector> for &Vec<Fp> {
+    fn from(x: CamlTweedleFpVector) -> Self {
+        unsafe { &*x.0 }
+    }
+}
+
+impl Deref for CamlTweedleFpVector {
+    type Target = Vec<Fp>;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+
+impl DerefMut for CamlTweedleFpVector {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.0 }
+    }
+}
+
+unsafe impl ocaml::FromValue for CamlTweedleFpVector {
+    fn from_value(x: ocaml::Value) -> Self {
+        let x = ocaml::Pointer::<CamlTweedleFpVector>::from_value(x);
+        (*x.as_ref()).clone()
+    }
+}
+
 #[ocaml::func]
 pub fn caml_tweedle_fp_vector_create() -> CamlTweedleFpVector {
-    CamlTweedleFpVector(Vec::new())
+    CamlTweedleFpVector(Box::into_raw(Box::new(Vec::new())))
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_fp_vector_length(v: CamlTweedleFpVectorPtr) -> ocaml::Int {
-    v.as_ref().0.len() as isize
+pub fn caml_tweedle_fp_vector_length(v: CamlTweedleFpVector) -> ocaml::Int {
+    v.len() as isize
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_fp_vector_emplace_back(mut v: CamlTweedleFpVectorPtr, x: CamlTweedleFpPtr) {
-    v.as_mut().0.push(x.as_ref().0);
+pub fn caml_tweedle_fp_vector_emplace_back(mut v: CamlTweedleFpVector, x: CamlTweedleFpPtr) {
+    (*v).push(x.as_ref().0);
 }
 
 #[ocaml::func]
 pub fn caml_tweedle_fp_vector_get(
-    v: CamlTweedleFpVectorPtr,
+    v: CamlTweedleFpVector,
     i: ocaml::Int,
 ) -> Result<CamlTweedleFp, ocaml::Error> {
-    match v.as_ref().0.get(i as usize) {
+    match v.get(i as usize) {
         Some(x) => Ok(CamlTweedleFp(*x)),
         None => Err(ocaml::Error::invalid_argument("caml_tweedle_fp_vector_get")
             .err()

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_vector.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_vector.rs
@@ -1,17 +1,19 @@
 use crate::tweedle_fq::{CamlTweedleFq, CamlTweedleFqPtr};
 use algebra::tweedle::fq::Fq;
+use std::ops::{Deref, DerefMut};
 
-pub struct CamlTweedleFqVector(pub Vec<Fq>);
-pub type CamlTweedleFqVectorPtr = ocaml::Pointer<CamlTweedleFqVector>;
+#[derive (Clone)]
+pub struct CamlTweedleFqVector(pub *mut Vec<Fq>);
 
 /* Note: The vector header is allocated in the OCaml heap, but the data held in
    the vector elements themselves are stored in the rust heap.
 */
 
 extern "C" fn caml_tweedle_fq_vector_finalize(v: ocaml::Value) {
-    let mut v: CamlTweedleFqVectorPtr = ocaml::FromValue::from_value(v);
+    let mut v: ocaml::Pointer<CamlTweedleFqVector> = ocaml::FromValue::from_value(v);
     unsafe {
-        v.as_mut_ptr().drop_in_place();
+        // Memory is freed when the variable goes out of scope
+        let _box = Box::from_raw(v.as_mut().0);
     }
 }
 
@@ -19,27 +21,54 @@ ocaml::custom!(CamlTweedleFqVector {
     finalize: caml_tweedle_fq_vector_finalize,
 });
 
+impl From<CamlTweedleFqVector> for &Vec<Fq> {
+    fn from(x: CamlTweedleFqVector) -> Self {
+        unsafe { &*x.0 }
+    }
+}
+
+impl Deref for CamlTweedleFqVector {
+    type Target = Vec<Fq>;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+
+impl DerefMut for CamlTweedleFqVector {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.0 }
+    }
+}
+
+unsafe impl ocaml::FromValue for CamlTweedleFqVector {
+    fn from_value(x: ocaml::Value) -> Self {
+        let x = ocaml::Pointer::<CamlTweedleFqVector>::from_value(x);
+        (*x.as_ref()).clone()
+    }
+}
+
 #[ocaml::func]
 pub fn caml_tweedle_fq_vector_create() -> CamlTweedleFqVector {
-    CamlTweedleFqVector(Vec::new())
+    CamlTweedleFqVector(Box::into_raw(Box::new(Vec::new())))
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_fq_vector_length(v: CamlTweedleFqVectorPtr) -> ocaml::Int {
-    v.as_ref().0.len() as isize
+pub fn caml_tweedle_fq_vector_length(v: CamlTweedleFqVector) -> ocaml::Int {
+    v.len() as isize
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_fq_vector_emplace_back(mut v: CamlTweedleFqVectorPtr, x: CamlTweedleFqPtr) {
-    v.as_mut().0.push(x.as_ref().0);
+pub fn caml_tweedle_fq_vector_emplace_back(mut v: CamlTweedleFqVector, x: CamlTweedleFqPtr) {
+    v.push(x.as_ref().0);
 }
 
 #[ocaml::func]
 pub fn caml_tweedle_fq_vector_get(
-    v: CamlTweedleFqVectorPtr,
+    v: CamlTweedleFqVector,
     i: ocaml::Int,
 ) -> Result<CamlTweedleFq, ocaml::Error> {
-    match v.as_ref().0.get(i as usize) {
+    match v.get(i as usize) {
         Some(x) => Ok(CamlTweedleFq(*x)),
         None => Err(ocaml::Error::invalid_argument("caml_tweedle_fq_vector_get")
             .err()


### PR DESCRIPTION
This PR fixes the segmentation fault reported in #6824.

The 'header' (ie. data pointer + length) of the input vectors were stored in the OCaml heap. This was fine when they were run synchronously, but the async version allows the OCaml GC to run while the function is also running. A badly timed GC can move the header and leave rust's reference pointing at arbitrary data, and dereferencing the vector's data pointer may then result in a segfault.

This PR changes the behaviour to store only a (rust heap) pointer in the OCaml heap. As long as we capture the pointer before yielding to OCaml, we know that we hold a reference to the intended data.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: