### PR TITLE
Process id in lockfileFeature/pid in lockfile

### DIFF
--- a/src/lib/coda_lib/conf_dir.ml
+++ b/src/lib/coda_lib/conf_dir.ml
@@ -50,6 +50,7 @@ let check_and_set_lockfile ~logger conf_dir =
                       rm_and_raise ()
                 in
                 let still_running =
+                  (* using signal 0 does not send a signal; see man page `kill(2)` *)
                   match Signal.(send zero) (`Pid pid) with
                   | `Ok ->
                       true

--- a/src/lib/coda_lib/conf_dir.ml
+++ b/src/lib/coda_lib/conf_dir.ml
@@ -57,10 +57,14 @@ let check_and_set_lockfile ~logger conf_dir =
                       false
                 in
                 if still_running then
-                  Mina_user_error.raisef
-                    "A daemon (process id %d) is already running with the \
-                     current configuration directory (%s)"
-                    (Pid.to_int pid) conf_dir
+                  if Pid.equal pid (Unix.getpid ()) then
+                    (* can happen when running in Docker *)
+                    return ()
+                  else
+                    Mina_user_error.raisef
+                      "A daemon (process id %d) is already running with the \
+                       current configuration directory (%s)"
+                      (Pid.to_int pid) conf_dir
                 else (
                   [%log info] "Removing lockfile for terminated process"
                     ~metadata:


### PR DESCRIPTION
Write the daemon's process ID to the Mina lockfile. On startup, if the process in the lockfile exists, raise an error. Otherwise, remove the lockfile, log that fact, and continue.

Raise errors if the lockfile is empty or doesn't contain a pid.


