### PR TITLE
Trivial: Don't print the runtime configuration/full genesis ledger during startup

### DIFF
--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -1219,7 +1219,7 @@ let load_config_file filename =
 
 let init_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
     ~may_generate ~proof_level (config : Runtime_config.t) =
-  [%log info] "Initializing with runtime configuration $config"
+  [%log info] "Initializing with runtime configuration"
     ~metadata:[("config", Runtime_config.to_yojson config)] ;
   let open Deferred.Or_error.Let_syntax in
   let genesis_constants = Genesis_constants.compiled in

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -1219,8 +1219,20 @@ let load_config_file filename =
 
 let init_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
     ~may_generate ~proof_level (config : Runtime_config.t) =
-  [%log info] "Initializing with runtime configuration"
-    ~metadata:[("config", Runtime_config.to_yojson config)] ;
+  let ledger_name_json =
+    match
+      let open Option.Let_syntax in
+      let%bind ledger = config.ledger in
+      ledger.name
+    with
+    | Some name ->
+        `String name
+    | None ->
+        `Null
+  in
+  [%log info] "Initializing with runtime configuration. Ledger name: $name"
+    ~metadata:
+      [("name", ledger_name_json); ("config", Runtime_config.to_yojson config)] ;
   let open Deferred.Or_error.Let_syntax in
   let genesis_constants = Genesis_constants.compiled in
   let proof_level =


### PR DESCRIPTION
This PR removes the `$config` variable from the configuration log line, so that the configuration will appear in the logs, but will not be printed in the pretty output to stdout.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
