### PR TITLE
Trigger network pool callbacks when pipe is full

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -1125,12 +1125,11 @@ let create (config : Config.t)
               , valid_cb )
         | Snark_pool_diff diff ->
             if config.log_gossip_heard.snark_pool_diff then
-              [%str_log debug]
-                (Snark_work_received
-                   { work=
-                       Option.value_exn
-                         (Snark_pool.Resource_pool.Diff.to_compact diff)
-                   ; sender= Envelope.Incoming.sender envelope }) ;
+              Option.iter (Snark_pool.Resource_pool.Diff.to_compact diff)
+                ~f:(fun work ->
+                  [%str_log debug]
+                    (Snark_work_received
+                       {work; sender= Envelope.Incoming.sender envelope}) ) ;
             Coda_metrics.(
               Counter.inc_one Snark_work.completed_snark_work_received_gossip) ;
             `Snd (Envelope.Incoming.map envelope ~f:(fun _ -> diff), valid_cb)

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -1127,7 +1127,9 @@ let create (config : Config.t)
             if config.log_gossip_heard.snark_pool_diff then
               [%str_log debug]
                 (Snark_work_received
-                   { work= Snark_pool.Resource_pool.Diff.to_compact diff
+                   { work=
+                       Option.value_exn
+                         (Snark_pool.Resource_pool.Diff.to_compact diff)
                    ; sender= Envelope.Incoming.sender envelope }) ;
             Coda_metrics.(
               Counter.inc_one Snark_work.completed_snark_work_received_gossip) ;
@@ -1209,7 +1211,9 @@ let broadcast_snark_pool_diff t diff =
   broadcast t (Gossip_net.Message.Snark_pool_diff diff)
     ~log_msg:
       (Gossip_snark_pool_diff
-         {work= Snark_pool.Resource_pool.Diff.to_compact diff})
+         { work=
+             Option.value_exn (Snark_pool.Resource_pool.Diff.to_compact diff)
+         })
 
 (* TODO: This is kinda inefficient *)
 let find_map xs ~f =

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -52,6 +52,10 @@ module type Resource_pool_diff_intf = sig
   (** Part of the diff that was not added to the resource pool*)
   type rejected [@@deriving sexp, to_yojson]
 
+  val empty : t
+
+  val reject_overloaded_diff : verified -> rejected
+
   (** Used to check whether or not information was filtered out of diffs
    *  during diff application. Assumes that diff size will be the equal or
    *  smaller after application is completed. *)
@@ -220,6 +224,7 @@ module type Snark_pool_diff_intf = sig
     | Add_solved_work of
         Transaction_snark_work.Statement.t
         * Ledger_proof.t One_or_two.t Priced_proof.t
+    | Empty
   [@@deriving compare, sexp]
 
   type verified = t [@@deriving compare, sexp]
@@ -236,9 +241,9 @@ module type Snark_pool_diff_intf = sig
      and type verified := t
      and type pool := resource_pool
 
-  val to_compact : t -> compact
+  val to_compact : t -> compact option
 
-  val compact_json : t -> Yojson.Safe.t
+  val compact_json : t -> Yojson.Safe.t option
 
   val of_result :
        ( ('a, 'b, 'c) Snark_work_lib.Work.Single.Spec.t
@@ -266,6 +271,7 @@ module type Transaction_pool_diff_intf = sig
       | Bad_token
       | Unwanted_fee_token
       | Expired
+      | Overloaded
     [@@deriving sexp, yojson]
   end
 

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -107,11 +107,7 @@ end)
       :
       (Resource_pool.Diff.verified Envelope.Incoming.t * Broadcast_callback.t)
       Strict_pipe.Reader.t =
-    let (r, w)
-          : ( Resource_pool.Diff.verified Envelope.Incoming.t
-            * Broadcast_callback.t )
-            Strict_pipe.Reader.t
-            * _ =
+    let r, w =
       Strict_pipe.create ~name:"verified network pool diffs"
         (Buffered
            ( `Capacity 1024
@@ -119,6 +115,10 @@ end)
                (Call
                   (fun (env, cb) ->
                     let diff = Envelope.Incoming.data env in
+                    [%log' warn t.logger]
+                      "Dropping verified diff $diff due to pipe overflow"
+                      ~metadata:
+                        [("diff", Resource_pool.Diff.verified_to_yojson diff)] ;
                     Broadcast_callback.drop Resource_pool.Diff.empty
                       (Resource_pool.Diff.reject_overloaded_diff diff)
                       cb )) ))

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -496,6 +496,7 @@ module Diff_versioned = struct
             Transaction_snark_work.Statement.Stable.V1.t
             * Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
               Priced_proof.Stable.V1.t
+        | Empty
       [@@deriving compare, sexp, to_yojson]
 
       let to_latest = Fn.id
@@ -506,6 +507,7 @@ module Diff_versioned = struct
     | Add_solved_work of
         Transaction_snark_work.Statement.t
         * Ledger_proof.t One_or_two.t Priced_proof.t
+    | Empty
   [@@deriving compare, sexp, to_yojson]
 end
 
@@ -875,6 +877,8 @@ let%test_module "random set test" =
                      | Mock_snark_pool.Resource_pool.Diff.Add_solved_work
                          (work, _) ->
                          work
+                     | Mock_snark_pool.Resource_pool.Diff.Empty ->
+                         assert false
                    in
                    assert (List.mem works work ~equal:( = )) ;
                    Deferred.unit ) ;

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -81,6 +81,7 @@ module Diff_versioned : sig
             Transaction_snark_work.Statement.Stable.V1.t
             * Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
               Priced_proof.Stable.V1.t
+        | Empty
       [@@deriving compare, sexp]
     end
   end]

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -27,11 +27,14 @@ module Make
   Intf.Snark_pool_diff_intf with type resource_pool := Pool.t = struct
   type t =
     | Add_solved_work of Work.t * Ledger_proof.t One_or_two.t Priced_proof.t
+    | Empty
   [@@deriving compare, sexp, to_yojson]
 
   type verified = t [@@deriving compare, sexp, to_yojson]
 
   type rejected = Rejected.t [@@deriving sexp, yojson]
+
+  let reject_overloaded_diff _ = ()
 
   type compact =
     { work: Work.t
@@ -41,14 +44,18 @@ module Make
 
   let to_compact = function
     | Add_solved_work (work, {proof= _; fee= {fee; prover}}) ->
-        {work; fee; prover}
+        Some {work; fee; prover}
+    | Empty ->
+        None
 
-  let compact_json t = compact_to_yojson (to_compact t)
+  let compact_json t = to_compact t |> Option.map ~f:compact_to_yojson
+
+  let empty = Empty
 
   (* snark pool diffs are not bundled, so size is always 1 *)
-  let size _ = 1
+  let size = function Add_solved_work _ -> 1 | Empty -> 0
 
-  let verified_size _ = 1
+  let verified_size diff = size diff
 
   let summary = function
     | Add_solved_work (work, {proof= _; fee}) ->
@@ -56,6 +63,8 @@ module Make
           !"Snark_pool_diff for work %s added with fee-prover %s"
           (Yojson.Safe.to_string @@ Work.compact_json work)
           (Yojson.Safe.to_string @@ Coda_base.Fee_with_prover.to_yojson fee)
+    | Empty ->
+        "empty Snark_pool_diff"
 
   let is_empty _ = false
 
@@ -95,43 +104,51 @@ module Make
           failwith "compare didn't return -1, 0, or 1!" )
 
   let verify pool ({data; sender} as t : t Envelope.Incoming.t) =
-    let (Add_solved_work (work, ({Priced_proof.fee; _} as p))) = data in
-    let is_local = match sender with Local -> true | _ -> false in
-    let verify () =
-      if%map Pool.verify_and_act pool ~work:(work, p) ~sender then
-        Or_error.return t
-      else Or_error.error_string "failed to verify snark pool diff"
-    in
-    (*reject higher priced gossiped proofs*)
-    if is_local then verify ()
-    else
-      match has_lower_fee pool work ~fee:fee.fee ~sender with
-      | Ok () ->
-          verify ()
-      | _ ->
-          Deferred.Or_error.error_string
-            "snark pool diff fee is not high enough to be included in snark \
-             pool"
+    match data with
+    | Empty ->
+        Deferred.Or_error.error_string "cannot verify empty snark pool diff"
+    | Add_solved_work (work, ({Priced_proof.fee; _} as p)) -> (
+        let is_local = match sender with Local -> true | _ -> false in
+        let verify () =
+          if%map Pool.verify_and_act pool ~work:(work, p) ~sender then
+            Or_error.return t
+          else Or_error.error_string "failed to verify snark pool diff"
+        in
+        (*reject higher priced gossiped proofs*)
+        if is_local then verify ()
+        else
+          match has_lower_fee pool work ~fee:fee.fee ~sender with
+          | Ok () ->
+              verify ()
+          | _ ->
+              Deferred.Or_error.error_string
+                "snark pool diff fee is not high enough to be included in \
+                 snark pool" )
 
   (* This is called after verification has occurred.*)
   let unsafe_apply (pool : Pool.t) (t : t Envelope.Incoming.t) =
     let {Envelope.Incoming.data= diff; sender} = t in
-    let is_local = match sender with Local -> true | _ -> false in
-    let to_or_error = function
-      | `Statement_not_referenced ->
-          Error (`Other (Error.of_string "statement not referenced"))
-      | `Added ->
-          Ok (diff, ())
-    in
-    Deferred.return
-      (let (Add_solved_work (work, {Priced_proof.proof; fee})) = diff in
-       let add_to_pool () =
-         Pool.add_snark ~is_local pool ~work ~proof ~fee |> to_or_error
-       in
-       match has_lower_fee pool work ~fee:fee.fee ~sender with
-       | Ok () ->
-           add_to_pool ()
-       | Error e ->
-           if is_local then Error (`Locally_generated (diff, ()))
-           else Error (`Other e))
+    match diff with
+    | Empty ->
+        Deferred.return
+          (Error
+             (`Other (Error.of_string "cannot apply empty snark pool diff")))
+    | Add_solved_work (work, {Priced_proof.proof; fee}) ->
+        let is_local = match sender with Local -> true | _ -> false in
+        let to_or_error = function
+          | `Statement_not_referenced ->
+              Error (`Other (Error.of_string "statement not referenced"))
+          | `Added ->
+              Ok (diff, ())
+        in
+        Deferred.return
+          (let add_to_pool () =
+             Pool.add_snark ~is_local pool ~work ~proof ~fee |> to_or_error
+           in
+           match has_lower_fee pool work ~fee:fee.fee ~sender with
+           | Ok () ->
+               add_to_pool ()
+           | Error e ->
+               if is_local then Error (`Locally_generated (diff, ()))
+               else Error (`Other e))
 end

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -140,6 +140,8 @@ let%test_module "network pool test" =
                  | Mock_snark_pool.Resource_pool.Diff.Add_solved_work (work, _)
                    ->
                      work
+                 | Mock_snark_pool.Resource_pool.Diff.Empty ->
+                     assert false
                in
                assert (List.mem works work ~equal:( = )) ;
                Deferred.unit ) ;

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -67,6 +67,7 @@ module Diff_versioned = struct
           | Bad_token
           | Unwanted_fee_token
           | Expired
+          | Overloaded
         [@@deriving sexp, yojson]
 
         let to_latest = Fn.id
@@ -85,6 +86,7 @@ module Diff_versioned = struct
       | Bad_token
       | Unwanted_fee_token
       | Expired
+      | Overloaded
     [@@deriving sexp, yojson]
   end
 
@@ -730,6 +732,7 @@ struct
           | Bad_token
           | Unwanted_fee_token
           | Expired
+          | Overloaded
         [@@deriving sexp, yojson]
       end
 
@@ -740,6 +743,12 @@ struct
       end
 
       type rejected = Rejected.t [@@deriving sexp, yojson]
+
+      let reject_overloaded_diff diffs =
+        List.map diffs ~f:(fun cmd ->
+            (User_command.forget_check cmd, Diff_error.Overloaded) )
+
+      let empty = []
 
       let size = List.length
 


### PR DESCRIPTION
This aims to address #6764, though I haven't reproduced the issue there. This PR adds a new overflow behavior to `Strict_pipe.t` to call a function when a message is dropped due to overflow. Network pool will now fire all diff callbacks, even if the message is dropped from the pipe.

Not very proud of the addition of empty snark pool diffs, but I didn't see any easy way around that (suggestions requested).