### PR TITLE
[HOTFIX] Libp2p async rpc handling

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -692,7 +692,8 @@ func (o *openStreamMsg) run(app *app) (interface{}, error) {
 		return nil, badRPC(err)
 	}
 
-	stream, err := app.P2p.Host.NewStream(app.Ctx, peer, protocol.ID(o.ProtocolID))
+	ctx, _ := context.WithTimeout(app.Ctx, 30*time.Second)
+	stream, err := app.P2p.Host.NewStream(ctx, peer, protocol.ID(o.ProtocolID))
 
 	if err != nil {
 		return nil, badp2p(err)

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1271,9 +1271,9 @@ func main() {
 			log.Print("when unmarshaling the method invocation...")
 			log.Panic(err)
 		}
-		start := time.Now()
 
-		runMsg := func() {
+		go func() {
+			start := time.Now()
 			res, err := msg.run(app)
 			if err == nil {
 				res, err := json.Marshal(res)
@@ -1285,15 +1285,7 @@ func main() {
 			} else {
 				app.writeMsg(errorResult{Seqno: env.Seqno, Errorr: err.Error()})
 			}
-		}
-
-		// should we switch on message type instead?
-		switch msg.(type) {
-		case *openStreamMsg:
-			go runMsg()
-		default:
-			runMsg()
-		}
+		}()
 	}
 	app.writeMsg(errorResult{Seqno: 0, Errorr: fmt.Sprintf("helper stdin scanning stopped because %v", lines.Err())})
 	// we never want the helper to get here, it should be killed or gracefully

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -692,7 +692,8 @@ func (o *openStreamMsg) run(app *app) (interface{}, error) {
 		return nil, badRPC(err)
 	}
 
-	ctx, _ := context.WithTimeout(app.Ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(app.Ctx, 30*time.Second)
+	defer cancel()
 	stream, err := app.P2p.Host.NewStream(ctx, peer, protocol.ID(o.ProtocolID))
 
 	if err != nil {


### PR DESCRIPTION
This version of the libp2p hotfix makes libp2p handle all rpc messages asynchronously. This has not been well vetted, and could introduce new race conditions.

This may be risky and we should test this well before we decide to release this.