### PR TITLE
fix dangling_parent_reference in transaction pool

### DIFF
--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -612,6 +612,7 @@ struct
              match frontier_opt with
              | None -> (
                  [%log debug] "no frontier" ;
+                 t.best_tip_ledger <- None ;
                  (* Sanity check: the view pipe should have been closed before
                     the frontier was destroyed. *)
                  match t.best_tip_diff_relay with
@@ -619,7 +620,6 @@ struct
                      Deferred.unit
                  | Some hdl ->
                      let is_finished = ref false in
-                     t.best_tip_ledger <- None ;
                      Deferred.any_unit
                        [ (let%map () = hdl in
                           t.best_tip_diff_relay <- None ;


### PR DESCRIPTION
I think this is the root cause for the following error in turbo-pickles:
```
backtrace: [
     0: "Raised at file "src/lib/merkle_mask/masking_merkle_tree.ml", line 101, characters 10-50"      
     1: "Called from file "src/lib/merkle_mask/masking_merkle_tree.ml", line 513, characters 6-26"      
     2: "Called from file "src/lib/network_pool/transaction_pool.ml", line 877, characters 24-75"      
     3: "Called from file "src/lib/network_pool/transaction_pool.ml", line 880, characters 26-68"      
     4: "Called from file "src/lib/network_pool/transaction_pool.ml", line 1117, characters 18-30"      
     5: "Called from file "src/lib/network_pool/network_pool_base.ml", line 93, characters 15-67"      
     6: "Called from file "src/lib/pipe_lib/strict_pipe.ml", line 152, characters 28-37"      
     7: "Called from file "src/deferred0.ml", line 56, characters 64-69"      
     8: "Called from file "src/job_queue.ml" (inlined), line 131, characters 2-5"      
     9: "Called from file "src/job_queue.ml", line 171, characters 6-47"      
    ]
    sexp: [
     0: "Merkle_mask.Masking_merkle_tree.Make(Inputs).Attached.Dangling_parent_reference("dd1a5ff2-9fdf-352c-7b1c-f7f95e5047d0")"      
    ]
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
