### PR TITLE
Document -proof-level flag

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -278,7 +278,10 @@ let setup_daemon logger =
   and proof_level =
     flag "proof-level"
       (optional (Arg_type.create Genesis_constants.Proof_level.of_string))
-      ~doc:"full|check|none"
+      ~doc:
+        "full|check|none Internal, for testing. Start or connect to a network \
+         with full proving (full), snark-testing with dummy proofs (check), \
+         or dummy proofs (none)"
   and plugins = plugin_flag in
   fun () ->
     let open Deferred.Let_syntax in


### PR DESCRIPTION
`coda.exe daemon -help` now shows
```
  [-proof-level full|check|none]                     Internal, for testing.
                                                     Start or connect to a
                                                     network with full proving
                                                     (full), snark-testing with
                                                     dummy proofs (check), or
                                                     dummy proofs (none)
```

A question about this flag was asked on discord, documenting it as internal will hopefully reduce any confusion. In addition, the documentation may help with discovery, allowing us to run more tests more quickly for situations when proving is not directly relevant.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: