### PR TITLE
ensure node-selector preemptible label is quoted

### DIFF
--- a/helm/common/templates/_node-selectors.tpl
+++ b/helm/common/templates/_node-selectors.tpl
@@ -1,0 +1,19 @@
+### Mina node selector TEMPLATES ###
+
+{{/*
+Node selector: preemptible node affinity
+*/}}
+{{- define "nodeSelector.preemptible" }}
+nodeSelector:
+  cloud.google.com/gke-preemptible: {{ .nodeSelector.preemptible | quote }}
+{{- end }}
+
+{{/*
+Node selector: custom affinity mapping
+*/}}
+{{- define "nodeSelector.customMapping" }}
+{{- if . }}
+nodeSelector:
+{{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Resolves deployment error:

```
Error: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.NodeSelector: ReadString: expects " or n, but found f, error found in #10 byte of ...|mptible":false}}}}}
|..., bigger context ...|odeSelector":{"cloud.google.com/gke-preemptible":false}}}}}
|...
```
**Test:** Buildkite CI

**Checklist:**

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: