### PR TITLE
Don't capture `coda client status` output in status_exit_code

### DIFF
--- a/buildkite/scripts/connect-to-testnet-on-develop.sh
+++ b/buildkite/scripts/connect-to-testnet-on-develop.sh
@@ -56,7 +56,8 @@ coda daemon \
 num_status_retries=24
 for ((i=1;i<=$num_status_retries;i++)); do
   sleep 10s
-  status_exit_code=$(coda client status; echo $?)
+  coda client status
+  status_exit_code=$?
   if [ $status_exit_code -eq 0 ]; then
     break
   elif [ $i -eq $num_status_retries ]; then


### PR DESCRIPTION
The failure logic for `connect-to-testnet-on-develop.sh` is still wonky. This fixes it.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: