### PR TITLE
Add roundtrip checks for rust <-> OCaml type conversions

### DIFF
--- a/src/lib/marlin_plonk_bindings/bigint_256/dune
+++ b/src/lib/marlin_plonk_bindings/bigint_256/dune
@@ -3,4 +3,5 @@
  (public_name marlin_plonk_bindings.bigint_256)
  (libraries marlin_plonk_bindings_stubs)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/bigint_256/marlin_plonk_bindings_bigint_256.ml
+++ b/src/lib/marlin_plonk_bindings/bigint_256/marlin_plonk_bindings_bigint_256.ml
@@ -21,3 +21,9 @@ external of_decimal_string : string -> t = "caml_bigint_256_of_decimal_string"
 external to_bytes : t -> Bytes.t = "caml_bigint_256_to_bytes"
 
 external of_bytes : Bytes.t -> t = "caml_bigint_256_of_bytes"
+
+external deep_copy : t -> t = "caml_bigint_256_deep_copy"
+
+let%test "deep_copy" =
+  let x = of_decimal_string "12345" in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/bigint_384/dune
+++ b/src/lib/marlin_plonk_bindings/bigint_384/dune
@@ -3,4 +3,5 @@
  (public_name marlin_plonk_bindings.bigint_384)
  (libraries marlin_plonk_bindings_stubs)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/bigint_384/marlin_plonk_bindings_bigint_384.ml
+++ b/src/lib/marlin_plonk_bindings/bigint_384/marlin_plonk_bindings_bigint_384.ml
@@ -21,3 +21,9 @@ external of_decimal_string : string -> t = "caml_bigint_384_of_decimal_string"
 external to_bytes : t -> Bytes.t = "caml_bigint_384_to_bytes"
 
 external of_bytes : Bytes.t -> t = "caml_bigint_384_of_bytes"
+
+external deep_copy : t -> t = "caml_bigint_384_deep_copy"
+
+let%test "deep_copy" =
+  let x = of_decimal_string "12345" in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/bn_382_fp/dune
+++ b/src/lib/marlin_plonk_bindings/bn_382_fp/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bigint_384)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/bn_382_fq/dune
+++ b/src/lib/marlin_plonk_bindings/bn_382_fq/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bigint_384)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/stubs/dune
+++ b/src/lib/marlin_plonk_bindings/stubs/dune
@@ -19,4 +19,5 @@
  (foreign_archives marlin_plonk_stubs)
  (c_library_flags :standard "-lpthread")
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
@@ -125,3 +125,8 @@ pub fn caml_bigint_256_of_bytes(x: &[u8]) -> Result<BigInteger256, ocaml::Error>
     let x = unsafe { *(x.as_ptr() as *const BigInteger256) };
     Ok(x)
 }
+
+#[ocaml::func]
+pub fn caml_bigint_256_deep_copy(x: BigInteger256) -> BigInteger256 {
+    x
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/bigint_384.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/bigint_384.rs
@@ -125,3 +125,8 @@ pub fn caml_bigint_384_of_bytes(x: &[u8]) -> Result<BigInteger384, ocaml::Error>
     let x = unsafe { *(x.as_ptr() as *const BigInteger384) };
     Ok(x)
 }
+
+#[ocaml::func]
+pub fn caml_bigint_384_deep_copy(x: BigInteger384) -> BigInteger384 {
+    x
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_dee.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_dee.rs
@@ -91,11 +91,13 @@ pub fn caml_tweedle_dee_of_affine(x: CamlTweedleDeeAffine<Fq>) -> CamlTweedleDee
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_dee_of_affine_coordinates(
-    x: Fq,
-    y: Fq,
-) -> CamlTweedleDee {
+pub fn caml_tweedle_dee_of_affine_coordinates(x: Fq, y: Fq) -> CamlTweedleDee {
     CamlTweedleDee(GProjective::new(x, y, Fq::one()))
+}
+
+#[ocaml::func]
+pub fn caml_tweedle_dee_affine_deep_copy(x: CamlTweedleDeeAffine<Fq>) -> CamlTweedleDeeAffine<Fq> {
+    x
 }
 
 impl From<GAffine> for CamlTweedleDeeAffine<Fq> {
@@ -119,8 +121,8 @@ impl From<CamlTweedleDeeAffine<Fq>> for GAffine {
 
 #[derive(ocaml::ToValue, ocaml::FromValue)]
 pub struct CamlTweedleDeePolyComm<T> {
-    shifted: Option<CamlTweedleDeeAffine<T>>,
-    unshifted: Vec<CamlTweedleDeeAffine<Fq>>,
+    pub shifted: Option<CamlTweedleDeeAffine<T>>,
+    pub unshifted: Vec<CamlTweedleDeeAffine<Fq>>,
 }
 
 impl From<PolyComm<GAffine>> for CamlTweedleDeePolyComm<Fq> {

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_dum.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_dum.rs
@@ -91,11 +91,13 @@ pub fn caml_tweedle_dum_of_affine(x: CamlTweedleDumAffine<Fp>) -> CamlTweedleDum
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_dum_of_affine_coordinates(
-    x: Fp,
-    y: Fp,
-) -> CamlTweedleDum {
+pub fn caml_tweedle_dum_of_affine_coordinates(x: Fp, y: Fp) -> CamlTweedleDum {
     CamlTweedleDum(GProjective::new(x, y, Fp::one()))
+}
+
+#[ocaml::func]
+pub fn caml_tweedle_dum_affine_deep_copy(x: CamlTweedleDumAffine<Fp>) -> CamlTweedleDumAffine<Fp> {
+    x
 }
 
 impl From<GAffine> for CamlTweedleDumAffine<Fp> {
@@ -119,8 +121,8 @@ impl From<CamlTweedleDumAffine<Fp>> for GAffine {
 
 #[derive(ocaml::ToValue, ocaml::FromValue)]
 pub struct CamlTweedleDumPolyComm<T> {
-    shifted: Option<CamlTweedleDumAffine<T>>,
-    unshifted: Vec<CamlTweedleDumAffine<Fp>>,
+    pub shifted: Option<CamlTweedleDumAffine<T>>,
+    pub unshifted: Vec<CamlTweedleDumAffine<Fp>>,
 }
 
 impl From<PolyComm<GAffine>> for CamlTweedleDumPolyComm<Fp> {

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp.rs
@@ -159,9 +159,7 @@ pub fn caml_tweedle_fp_two_adic_root_of_unity() -> Fp {
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_fp_domain_generator(
-    log2_size: ocaml::Int,
-) -> Result<Fp, ocaml::Error> {
+pub fn caml_tweedle_fp_domain_generator(log2_size: ocaml::Int) -> Result<Fp, ocaml::Error> {
     match Domain::new(1 << log2_size) {
         Some(x) => Ok(x.group_gen),
         None => Err(
@@ -190,4 +188,9 @@ pub fn caml_tweedle_fp_of_bytes(x: &[u8]) -> Result<Fp, ocaml::Error> {
     };
     let x = unsafe { *(x.as_ptr() as *const Fp) };
     Ok(x)
+}
+
+#[ocaml::func]
+pub fn caml_tweedle_fp_deep_copy(x: Fp) -> Fp {
+    x
 }

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_urs.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fp_urs.rs
@@ -22,7 +22,14 @@ extern "C" fn caml_tweedle_fp_urs_finalize(v: ocaml::Value) {
     unsafe { v.drop_in_place() };
 }
 
+extern "C" fn caml_tweedle_fp_urs_compare(_v1: ocaml::Value, _v2: ocaml::Value) -> i32 {
+    // This shouldn't be used, and has no value anyway since urs is opaque to ocaml, but we want it
+    // for the OCaml <-> Rust transport consistency tests.
+    return 0
+}
+
 ocaml::custom!(CamlTweedleFpUrs {
+    compare: caml_tweedle_fp_urs_compare,
     finalize: caml_tweedle_fp_urs_finalize,
 });
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq.rs
@@ -1,5 +1,5 @@
 use crate::bigint_256;
-use algebra::biginteger::{BigInteger256};
+use algebra::biginteger::BigInteger256;
 use algebra::{
     fields::{Field, FpParameters, PrimeField, SquareRootField},
     tweedle::fq::{Fq, FqParameters as Fq_params},
@@ -159,9 +159,7 @@ pub fn caml_tweedle_fq_two_adic_root_of_unity() -> Fq {
 }
 
 #[ocaml::func]
-pub fn caml_tweedle_fq_domain_generator(
-    log2_size: ocaml::Int,
-) -> Result<Fq, ocaml::Error> {
+pub fn caml_tweedle_fq_domain_generator(log2_size: ocaml::Int) -> Result<Fq, ocaml::Error> {
     match Domain::new(1 << log2_size) {
         Some(x) => Ok(x.group_gen),
         None => Err(
@@ -190,4 +188,9 @@ pub fn caml_tweedle_fq_of_bytes(x: &[u8]) -> Result<Fq, ocaml::Error> {
     };
     let x = unsafe { *(x.as_ptr() as *const Fq) };
     Ok(x)
+}
+
+#[ocaml::func]
+pub fn caml_tweedle_fq_deep_copy(x: Fq) -> Fq {
+    x
 }

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_plonk_verifier_index.rs
@@ -3,10 +3,13 @@ use crate::plonk_verifier_index::{
     CamlPlonkDomain, CamlPlonkVerificationEvals, CamlPlonkVerificationShifts,
     CamlPlonkVerifierIndex,
 };
-use crate::tweedle_dum::CamlTweedleDumPolyComm;
+use crate::tweedle_dum::{CamlTweedleDumAffine::Finite, CamlTweedleDumPolyComm};
 use crate::tweedle_fq_plonk_index::CamlTweedleFqPlonkIndexPtr;
 use crate::tweedle_fq_urs::CamlTweedleFqUrs;
-use algebra::tweedle::{dee::Affine as GAffineOther, dum::Affine as GAffine, fp::Fp, fq::Fq};
+use algebra::{
+    tweedle::{dee::Affine as GAffineOther, dum::Affine as GAffine, fp::Fp, fq::Fq},
+    One,
+};
 
 use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 
@@ -75,10 +78,7 @@ pub fn to_ocaml<'a>(
             emul2_comm: vi.emul2_comm.into(),
             emul3_comm: vi.emul3_comm.into(),
         },
-        shifts: CamlPlonkVerificationShifts {
-            r: vi.r,
-            o: vi.o,
-        },
+        shifts: CamlPlonkVerificationShifts { r: vi.r, o: vi.o },
     }
 }
 
@@ -116,10 +116,7 @@ pub fn to_ocaml_copy<'a>(
             emul2_comm: vi.emul2_comm.clone().into(),
             emul3_comm: vi.emul3_comm.clone().into(),
         },
-        shifts: CamlPlonkVerificationShifts {
-            r: vi.r,
-            o: vi.o,
-        },
+        shifts: CamlPlonkVerificationShifts { r: vi.r, o: vi.o },
     }
 }
 
@@ -356,8 +353,54 @@ pub fn caml_tweedle_fq_plonk_verifier_index_shifts(
     log2_size: ocaml::Int,
 ) -> CamlPlonkVerificationShifts<Fq> {
     let (a, b) = ConstraintSystem::sample_shifts(&Domain::new(1 << log2_size).unwrap());
-    CamlPlonkVerificationShifts {
-        r: a,
-        o: b,
+    CamlPlonkVerificationShifts { r: a, o: b }
+}
+
+#[ocaml::func]
+pub fn caml_tweedle_fq_plonk_verifier_index_dummy() -> CamlTweedleFqPlonkVerifierIndex {
+    let g = || Finite((Fp::one(), Fp::one()));
+    let comm = || CamlTweedleDumPolyComm {
+        shifted: Some(g()),
+        unshifted: vec![g(), g(), g()],
+    };
+    CamlPlonkVerifierIndex {
+        domain: CamlPlonkDomain {
+            log_size_of_group: 1,
+            group_gen: Fq::one(),
+        },
+        max_poly_size: 0,
+        max_quot_size: 0,
+        urs: CamlTweedleFqUrs(Rc::new(SRS::create(0))),
+        evals: CamlPlonkVerificationEvals {
+            sigma_comm0: comm(),
+            sigma_comm1: comm(),
+            sigma_comm2: comm(),
+            ql_comm: comm(),
+            qr_comm: comm(),
+            qo_comm: comm(),
+            qm_comm: comm(),
+            qc_comm: comm(),
+            rcm_comm0: comm(),
+            rcm_comm1: comm(),
+            rcm_comm2: comm(),
+            psm_comm: comm(),
+            add_comm: comm(),
+            mul1_comm: comm(),
+            mul2_comm: comm(),
+            emul1_comm: comm(),
+            emul2_comm: comm(),
+            emul3_comm: comm(),
+        },
+        shifts: CamlPlonkVerificationShifts {
+            r: Fq::one(),
+            o: Fq::one(),
+        },
     }
+}
+
+#[ocaml::func]
+pub fn caml_tweedle_fq_plonk_verifier_index_deep_copy(
+    x: CamlTweedleFqPlonkVerifierIndex,
+) -> CamlTweedleFqPlonkVerifierIndex {
+    x
 }

--- a/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_urs.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/tweedle_fq_urs.rs
@@ -22,7 +22,14 @@ extern "C" fn caml_tweedle_fq_urs_finalize(v: ocaml::Value) {
     unsafe { v.drop_in_place() };
 }
 
+extern "C" fn caml_tweedle_fp_urs_compare(_v1: ocaml::Value, _v2: ocaml::Value) -> i32 {
+    // This shouldn't be used, and has no value anyway since urs is opaque to ocaml, but we want it
+    // for the OCaml <-> Rust transport consistency tests.
+    return 0
+}
+
 ocaml::custom!(CamlTweedleFqUrs {
+    compare: caml_tweedle_fp_urs_compare,
     finalize: caml_tweedle_fq_urs_finalize,
 });
 

--- a/src/lib/marlin_plonk_bindings/tweedle_dee/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_dee/dune
@@ -7,4 +7,5 @@
    marlin_plonk_bindings_tweedle_fp
    marlin_plonk_bindings_tweedle_fq)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_dee/marlin_plonk_bindings_tweedle_dee.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_dee/marlin_plonk_bindings_tweedle_dee.ml
@@ -39,3 +39,9 @@ external endo_base :
 external endo_scalar :
   unit -> Marlin_plonk_bindings_tweedle_fp.t
   = "caml_tweedle_dee_endo_scalar"
+
+external affine_deep_copy : Affine.t -> Affine.t = "caml_tweedle_dee_affine_deep_copy"
+
+let%test "affine deep_copy" =
+  let x = random () |> to_affine in
+  affine_deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/tweedle_dum/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_dum/dune
@@ -7,4 +7,5 @@
    marlin_plonk_bindings_tweedle_fp
    marlin_plonk_bindings_tweedle_fq)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_dum/marlin_plonk_bindings_tweedle_dum.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_dum/marlin_plonk_bindings_tweedle_dum.ml
@@ -39,3 +39,9 @@ external endo_base :
 external endo_scalar :
   unit -> Marlin_plonk_bindings_tweedle_fq.t
   = "caml_tweedle_dum_endo_scalar"
+
+external affine_deep_copy : Affine.t -> Affine.t = "caml_tweedle_dum_affine_deep_copy"
+
+let%test "affine dump_copy" =
+  let x = random () |> to_affine in
+  affine_deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/tweedle_fp/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bigint_256)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp/marlin_plonk_bindings_tweedle_fp.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp/marlin_plonk_bindings_tweedle_fp.ml
@@ -67,3 +67,9 @@ external domain_generator : int -> t = "caml_tweedle_fp_domain_generator"
 external to_bytes : t -> Bytes.t = "caml_tweedle_fp_to_bytes"
 
 external of_bytes : Bytes.t -> t = "caml_tweedle_fp_of_bytes"
+
+external deep_copy : t -> t = "caml_tweedle_fp_deep_copy"
+
+let%test "deep_copy" =
+  let x = random () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_index/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_index/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fp_urs)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_oracles/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_oracles/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fp_proof)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fp_index)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/marlin_plonk_bindings_tweedle_fp_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_plonk_verifier_index/marlin_plonk_bindings_tweedle_fp_verifier_index.ml
@@ -56,3 +56,11 @@ external shifts :
      log2_size:int
   -> Marlin_plonk_bindings_tweedle_fp.t Plonk_verification_shifts.t
   = "caml_tweedle_fp_plonk_verifier_index_shifts"
+
+external dummy : unit -> t = "caml_tweedle_fp_plonk_verifier_index_dummy"
+
+external deep_copy : t -> t = "caml_tweedle_fp_plonk_verifier_index_deep_copy"
+
+let%test "deep_copy" =
+  let x = dummy () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_proof/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_proof/dune
@@ -6,4 +6,5 @@
    marlin_plonk_bindings_tweedle_fp_verifier_index
    marlin_plonk_bindings_tweedle_fp_vector)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_proof/marlin_plonk_bindings_tweedle_fp_proof.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_proof/marlin_plonk_bindings_tweedle_fp_proof.ml
@@ -43,3 +43,11 @@ external batch_verify :
   -> t array
   -> bool
   = "caml_tweedle_fp_plonk_proof_batch_verify"
+
+external dummy : unit -> t = "caml_tweedle_fp_plonk_proof_dummy"
+
+external deep_copy : t -> t = "caml_tweedle_fp_plonk_proof_deep_copy"
+
+let%test "deep_copy" =
+  let x = dummy () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/tweedle_fp_urs/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fp_urs/dune
@@ -8,4 +8,5 @@
    marlin_plonk_bindings_tweedle_fq
    marlin_plonk_bindings_tweedle_dee)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_bigint_256)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq/marlin_plonk_bindings_tweedle_fq.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq/marlin_plonk_bindings_tweedle_fq.ml
@@ -67,3 +67,9 @@ external domain_generator : int -> t = "caml_tweedle_fq_domain_generator"
 external to_bytes : t -> Bytes.t = "caml_tweedle_fq_to_bytes"
 
 external of_bytes : Bytes.t -> t = "caml_tweedle_fq_of_bytes"
+
+external deep_copy : t -> t = "caml_tweedle_fq_deep_copy"
+
+let%test "deep_copy" =
+  let x = random () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_index/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_index/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fq_urs)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_oracles/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_oracles/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fq_proof)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/dune
@@ -5,4 +5,5 @@
    marlin_plonk_bindings_stubs
    marlin_plonk_bindings_tweedle_fq_index)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/marlin_plonk_bindings_tweedle_fq_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_plonk_verifier_index/marlin_plonk_bindings_tweedle_fq_verifier_index.ml
@@ -56,3 +56,11 @@ external shifts :
      log2_size:int
   -> Marlin_plonk_bindings_tweedle_fq.t Plonk_verification_shifts.t
   = "caml_tweedle_fq_plonk_verifier_index_shifts"
+
+external dummy : unit -> t = "caml_tweedle_fq_plonk_verifier_index_dummy"
+
+external deep_copy : t -> t = "caml_tweedle_fq_plonk_verifier_index_deep_copy"
+
+let%test "deep_copy" =
+  let x = dummy () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_proof/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_proof/dune
@@ -6,4 +6,5 @@
    marlin_plonk_bindings_tweedle_fq_verifier_index
    marlin_plonk_bindings_tweedle_fq_vector)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_proof/marlin_plonk_bindings_tweedle_fq_proof.ml
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_proof/marlin_plonk_bindings_tweedle_fq_proof.ml
@@ -43,3 +43,11 @@ external batch_verify :
   -> t array
   -> bool
   = "caml_tweedle_fq_plonk_proof_batch_verify"
+
+external dummy : unit -> t = "caml_tweedle_fq_plonk_proof_dummy"
+
+external deep_copy : t -> t = "caml_tweedle_fq_plonk_proof_deep_copy"
+
+let%test "deep_copy" =
+  let x = dummy () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/tweedle_fq_urs/dune
+++ b/src/lib/marlin_plonk_bindings/tweedle_fq_urs/dune
@@ -8,4 +8,5 @@
    marlin_plonk_bindings_tweedle_fq
    marlin_plonk_bindings_tweedle_dum)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/types/dune
+++ b/src/lib/marlin_plonk_bindings/types/dune
@@ -2,4 +2,5 @@
  (public_name marlin_plonk_bindings.types)
  (name marlin_plonk_bindings_types)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version)))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))


### PR DESCRIPTION
This allows us to derive based on the underlying rust types instead of doing any conversions, so that we can reduce our surface area for memory issues.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: