### PR TITLE
pulling subscription bug

### DIFF
--- a/src/app/test_executive/block_production_test.ml
+++ b/src/app/test_executive/block_production_test.ml
@@ -21,10 +21,14 @@ module Make (Engine : Engine_intf) = struct
   let run network log_engine =
     let open Network in
     let open Malleable_error.Let_syntax in
+    let logger = Logger.create () in
+    [%log info] "block_production_test: starting..." ;
     let block_producer = List.nth_exn network.block_producers 0 in
     let%bind () = Log_engine.wait_for_init block_producer log_engine in
+    [%log info] "block_production_test: done waiting for init" ;
     let%map _ =
       Log_engine.wait_for ~blocks:1 ~timeout:(`Slots 30) log_engine
     in
+    [%log info] "block_production_test: produced a block, test completed" ;
     ()
 end

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -71,9 +71,6 @@ let dispatch_cleanup ~logger ~cleanup_func ~destroy_func ~net_manager_ref
     ~log_engine_ref ~cleanup_deferred_ref (module T : Test_intf) reason
     (test_result : unit Malleable_error.t) : unit Deferred.t =
   let cleanup () : unit Deferred.t =
-    let%bind () =
-      Option.value_map !net_manager_ref ~default:Deferred.unit ~f:cleanup_func
-    in
     let log_engine_cleanup_result =
       Option.value_map !log_engine_ref
         ~default:(Malleable_error.return Test_error.Set.empty)
@@ -85,6 +82,9 @@ let dispatch_cleanup ~logger ~cleanup_func ~destroy_func ~net_manager_ref
           Test_error.Set.combine [remote_error_set; internal_error_set]
       | Error internal_error_set ->
           internal_error_set
+    in
+    let%bind () =
+      Option.value_map !net_manager_ref ~default:Deferred.unit ~f:cleanup_func
     in
     let%bind test_error_set =
       match%map Malleable_error.lift_error_set test_result with


### PR DESCRIPTION
in the integration testing framework, the async threads that pull from GCP's pub/sub system continue to run even after those pub/sub resources are destroyed in the cleanup, which causes errors.  this needs to be fixed