### PR TITLE
install jq (json processor) tool into daemon dockerfile

### DIFF
--- a/dockerfiles/Dockerfile-coda-daemon
+++ b/dockerfiles/Dockerfile-coda-daemon
@@ -13,6 +13,7 @@ RUN apt-get -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get -y upgrade && \
   DEBIAN_FRONTEND=noninteractive apt-get -y install \
     curl \
+    jq \
     strace \
     dumb-init \
     libssl1.1 \


### PR DESCRIPTION
Currently used by testnet component healthchecks for processing graphql JSON responses.

**Test:** Buildkite CI

**Checklist:**

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
