### PR TITLE
enable unused variable warning in src/lib/consensus

### DIFF
--- a/src/lib/consensus/constants.ml
+++ b/src/lib/consensus/constants.ml
@@ -261,7 +261,7 @@ let to_protocol_constants
      ; genesis_state_timestamp
      ; slots_per_sub_window
      ; slots_per_epoch
-     ; sub_windows_per_window= _ } :
+     ; _ } :
       _ Poly.t) =
   { Coda_base.Protocol_constants_checked.Poly.k
   ; delta

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -3,7 +3,6 @@
  (public_name consensus)
  (inline_tests)
  (modules (:standard \ proof_of_stake_fuzzer))
- (flags (-w -37))
  (library_flags (-linkall))
  (libraries
    snarky_taylor

--- a/src/lib/consensus/epoch.ml
+++ b/src/lib/consensus/epoch.ml
@@ -1,5 +1,4 @@
 open Core
-open Coda_base
 open Signed
 open Unsigned
 open Num_util

--- a/src/lib/consensus/global_slot.ml
+++ b/src/lib/consensus/global_slot.ml
@@ -1,6 +1,5 @@
 open Unsigned
 open Core
-open Coda_base
 open Snark_params.Tick
 module T = Coda_numbers.Global_slot
 module Length = Coda_numbers.Length
@@ -26,7 +25,7 @@ module Stable = struct
   end
 end]
 
-type value = t [@@deriving sexp, eq, compare, hash, yojson]
+type value = t [@@deriving sexp, compare, hash, yojson]
 
 type var = (T.Checked.t, Length.Checked.t) Poly.t
 

--- a/src/lib/consensus/global_slot.mli
+++ b/src/lib/consensus/global_slot.mli
@@ -1,8 +1,6 @@
 [%%import "/src/config.mlh"]
 
 open Core_kernel
-open Coda_base
-open Unsigned
 
 module Poly : sig
   [%%versioned:

--- a/src/lib/consensus/global_sub_window.mli
+++ b/src/lib/consensus/global_sub_window.mli
@@ -16,7 +16,6 @@ val ( >= ) : t -> t -> bool
 
 module Checked : sig
   open Snark_params.Tick
-  open Snarky_integer
 
   type t
 

--- a/src/lib/consensus/slot.ml
+++ b/src/lib/consensus/slot.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Snark_params
-open Signed
 open Unsigned
 
 module T = Coda_numbers.Nat.Make32 ()
@@ -18,7 +17,6 @@ module Checked = struct
 
   let in_seed_update_range ~(constants : Constants.var) (slot : var) =
     let open Tick in
-    let open Tick.Let_syntax in
     let open Snarky_integer in
     let module Length = Coda_numbers.Length in
     let integer_mul i i' = make_checked (fun () -> Integer.mul ~m i i') in


### PR DESCRIPTION
removed `-w -37`flag from src/lib/consensus/dune and fixed all the errors (caught a bug too!)

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
