### PR TITLE
Rework Interruptible monad

### DIFF
--- a/src/lib/interruptible/interruptible.ml
+++ b/src/lib/interruptible/interruptible.ml
@@ -75,8 +75,9 @@ module T = struct
     Deferred.upon (Ivar.read interruption_signal) (fun signal ->
         match Deferred.peek t.d with
         | Some (Ok t') ->
-            (* The computation we bound over has resolved, don't interrupt it
-               in case some other values also depend on it.
+            (* The computation [t] which we bound over has resolved, don't
+               interrupt it in case some other values also depend on it.
+               Still interrupt [t'] because it's a consequence of this [bind].
             *)
             Ivar.fill_if_empty t'.interruption_signal signal
         | Some (Error _) ->

--- a/src/lib/interruptible/interruptible.ml
+++ b/src/lib/interruptible/interruptible.ml
@@ -1,73 +1,115 @@
 open Core_kernel
 open Async_kernel
 
-(* TODO: Give clear semantics for and fix impl of this, see #300 *)
 module T = struct
   type ('a, 's) t =
-    {interruption_signal: 's Deferred.t; d: ('a, 's) Deferred.Result.t}
+    {interruption_signal: 's Ivar.t; d: ('a, 's) Deferred.Result.t}
 
-  let map_signal {interruption_signal; d} ~f =
-    { interruption_signal= Deferred.map interruption_signal ~f
-    ; d= Deferred.Result.map_error d ~f }
+  let map_signal t ~f =
+    let interruption_signal =
+      match Ivar.peek t.interruption_signal with
+      | Some signal ->
+          Ivar.create_full (f signal)
+      | None ->
+          let interruption_signal = Ivar.create () in
+          Deferred.upon (Ivar.read t.interruption_signal) (fun signal ->
+              Ivar.fill_if_empty interruption_signal (f signal) ) ;
+          interruption_signal
+    in
+    {interruption_signal; d= Deferred.Result.map_error ~f t.d}
+
+  let map t ~f =
+    match Ivar.peek t.interruption_signal with
+    | None ->
+        (* Note: we do not shortcut if [t.d] has resolved, otherwise the
+           interruption signal cannot interrupt this function.
+        *)
+        let d =
+          let%map res =
+            Deferred.choose
+              [ Deferred.choice (Ivar.read t.interruption_signal) Result.fail
+              ; Deferred.choice t.d Fn.id ]
+          in
+          (* If the interruption signal fires between [t.d] resolving and the
+             scheduler running this code to call [f], we prefer the signal and
+             avoid running [f].
+          *)
+          match Ivar.peek t.interruption_signal with
+          | None ->
+              Result.map ~f res
+          | Some e ->
+              Error e
+        in
+        {interruption_signal= t.interruption_signal; d}
+    | Some e ->
+        (* The interruption signal has already triggered, resolve to the
+           signal's value.
+        *)
+        {interruption_signal= t.interruption_signal; d= Deferred.Result.fail e}
 
   let bind t ~f =
-    match Deferred.peek t.d with
-    | None ->
-        let interruption_signal_to_res =
-          t.interruption_signal >>| fun s -> Error s
-        in
-        let maybe_sig_d =
-          let w : ('a, 's) Deferred.Result.t =
-            Deferred.any [t.d; interruption_signal_to_res]
-          in
-          Deferred.Result.map w ~f:(fun a ->
-              let t' = f a in
-              (t'.interruption_signal, t'.d) )
-        in
-        let interruption_signal' =
-          Deferred.any
-            [ t.interruption_signal
-            ; ( maybe_sig_d
-              >>= function
-              | Ok (interruption_signal, _) ->
-                  interruption_signal
-              | Error e ->
-                  Deferred.return e ) ]
-        in
-        let d' =
-          Deferred.any
-            [ interruption_signal_to_res
-            ; ( maybe_sig_d
-              >>= fun m ->
-              match m with
-              | Ok (_, d) ->
-                  d
-              | Error e ->
-                  Deferred.return (Error e) ) ]
-        in
-        {interruption_signal= interruption_signal'; d= d'}
-    | Some (Ok a) ->
-        let t' = f a in
-        { interruption_signal=
-            Deferred.any [t'.interruption_signal; t.interruption_signal]
-        ; d= t'.d }
-    | Some (Error e) ->
-        {t with d= Deferred.return (Error e)}
+    let t : (('a, 's) t, 's) t = map ~f t in
+    (* Propagate the signal into the [Interruptible.t] returned by [bind]. *)
+    Deferred.upon (Ivar.read t.interruption_signal) (fun signal ->
+        Deferred.upon t.d (function
+          | Ok t' ->
+              Ivar.fill_if_empty t'.interruption_signal signal
+          | Error _ ->
+              () ) ) ;
+    let interruption_signal =
+      match Ivar.peek t.interruption_signal with
+      | Some interruption_signal ->
+          Ivar.create_full interruption_signal
+      | None ->
+          let interruption_signal = Ivar.create () in
+          Deferred.upon t.d (function
+            | Ok t' ->
+                Deferred.upon
+                  (Ivar.read t'.interruption_signal)
+                  (Ivar.fill_if_empty interruption_signal)
+            | Error signal ->
+                (* [t] was interrupted by [signal], [f] was not run. *)
+                Ivar.fill_if_empty interruption_signal signal ) ;
+          interruption_signal
+    in
+    Deferred.upon (Ivar.read interruption_signal) (fun signal ->
+        match Deferred.peek t.d with
+        | Some (Ok t') ->
+            (* The computation we bound over has resolved, don't interrupt it
+               in case some other values also depend on it.
+            *)
+            Ivar.fill_if_empty t'.interruption_signal signal
+        | Some (Error _) ->
+            (* Already interrupted, do nothing. *)
+            ()
+        | None ->
+            (* The computation we bound hasn't resolved, interrupt it. *)
+            Ivar.fill_if_empty t.interruption_signal signal ) ;
+    {interruption_signal; d= Deferred.Result.bind t.d ~f:(fun t' -> t'.d)}
 
   let return a =
-    {interruption_signal= Deferred.never (); d= Deferred.Result.return a}
+    {interruption_signal= Ivar.create (); d= Deferred.Result.return a}
 
   let don't_wait_for {d; _} =
     don't_wait_for @@ Deferred.map d ~f:(function Ok () -> () | Error _ -> ())
 
-  let finally t ~f = {t with d= Deferred.map t.d ~f:(fun r -> f () ; r)}
+  let finally t ~f =
+    { interruption_signal= t.interruption_signal
+    ; d= Deferred.map t.d ~f:(fun r -> f () ; r) }
 
   let uninterruptible d =
-    { interruption_signal= Deferred.never ()
-    ; d= Deferred.map d ~f:(fun x -> Ok x) }
+    {interruption_signal= Ivar.create (); d= Deferred.map d ~f:(fun x -> Ok x)}
 
-  let lift d interruption_signal =
-    {d= Deferred.map d ~f:(fun x -> Ok x); interruption_signal}
+  let lift d interrupt =
+    let interruption_signal = Ivar.create () in
+    Deferred.upon interrupt (Ivar.fill_if_empty interruption_signal) ;
+    {interruption_signal; d= Deferred.map d ~f:(fun x -> Ok x)}
+
+  let force t =
+    (* We use [map] here to prefer interrupt signals even where the underlying
+       value has been resolved.
+    *)
+    (map ~f:Fn.id t).d
 
   let map = `Define_using_bind
 end
@@ -80,17 +122,89 @@ let%test_unit "monad gets interrupted" =
   Async.Thread_safe.block_on_async_exn (fun () ->
       let r = ref 0 in
       let wait i = Async.after (Core.Time.Span.of_ms i) in
-      let change () = Deferred.return (r := 1) in
       let ivar = Ivar.create () in
-      let _w =
-        let change () = lift (change ()) (Ivar.read ivar) in
-        let wait x = lift (wait x) (Ivar.read ivar) in
-        let open Let_syntax in
-        let%bind () = wait 100. in
-        change ()
-      in
+      don't_wait_for
+        (let open Let_syntax in
+        let%bind () = lift Deferred.unit (Ivar.read ivar) in
+        let%bind () = uninterruptible (wait 100.) in
+        incr r ;
+        let%map () = uninterruptible (wait 100.) in
+        incr r) ;
       let open Deferred.Let_syntax in
-      let%bind () = wait 30. in
+      let%bind () = wait 130. in
       Ivar.fill ivar () ;
       let%map () = wait 100. in
-      assert (!r = 0) )
+      assert (!r = 1) )
+
+let%test_unit "monad gets interrupted within nested binds" =
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      let r = ref 0 in
+      let wait i = Async.after (Core.Time.Span.of_ms i) in
+      let ivar = Ivar.create () in
+      let rec go () =
+        let open Let_syntax in
+        let%bind () = uninterruptible (wait 100.) in
+        incr r ; go ()
+      in
+      don't_wait_for
+        (let open Let_syntax in
+        let%bind () = lift Deferred.unit (Ivar.read ivar) in
+        go ()) ;
+      let open Deferred.Let_syntax in
+      let%bind () = wait 130. in
+      Ivar.fill ivar () ;
+      let%map () = wait 100. in
+      assert (!r = 1) )
+
+let%test_unit "interruptions still run finally blocks" =
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      let r = ref 0 in
+      let wait i = Async.after (Core.Time.Span.of_ms i) in
+      let ivar = Ivar.create () in
+      let rec go () =
+        let open Let_syntax in
+        let%bind () = uninterruptible (wait 100.) in
+        incr r ; go ()
+      in
+      don't_wait_for
+        (let open Let_syntax in
+        let%bind () = lift Deferred.unit (Ivar.read ivar) in
+        finally (go ()) ~f:(fun () -> incr r)) ;
+      let open Deferred.Let_syntax in
+      let%bind () = wait 130. in
+      Ivar.fill ivar () ;
+      let%map () = wait 100. in
+      assert (!r = 2) )
+
+let%test_unit "interruptions branches do not cancel eachother" =
+  Async.Thread_safe.block_on_async_exn (fun () ->
+      let r = ref 0 in
+      let s = ref 0 in
+      let wait i = Async.after (Core.Time.Span.of_ms i) in
+      let ivar_r = Ivar.create () in
+      let ivar_s = Ivar.create () in
+      let rec go r =
+        let open Let_syntax in
+        let%bind () = uninterruptible (wait 100.) in
+        incr r ; go r
+      in
+      (* Both computations hang off [start]. *)
+      let start = uninterruptible Deferred.unit in
+      don't_wait_for
+        (let open Let_syntax in
+        let%bind () = start in
+        let%bind () = lift Deferred.unit (Ivar.read ivar_r) in
+        go r) ;
+      don't_wait_for
+        (let open Let_syntax in
+        let%bind () = start in
+        let%bind () = lift Deferred.unit (Ivar.read ivar_s) in
+        go s) ;
+      let open Deferred.Let_syntax in
+      let%bind () = wait 130. in
+      Ivar.fill ivar_r () ;
+      let%bind () = wait 100. in
+      Ivar.fill ivar_s () ;
+      let%map () = wait 100. in
+      assert (!r = 1) ;
+      assert (!s = 2) )

--- a/src/lib/interruptible/interruptible.ml
+++ b/src/lib/interruptible/interruptible.ml
@@ -177,7 +177,7 @@ let%test_unit "interruptions still run finally blocks" =
       let%map () = wait 100. in
       assert (!r = 2) )
 
-let%test_unit "interruptions branches do not cancel eachother" =
+let%test_unit "interruptions branches do not cancel each other" =
   Async.Thread_safe.block_on_async_exn (fun () ->
       let r = ref 0 in
       let s = ref 0 in

--- a/src/lib/interruptible/interruptible.mli
+++ b/src/lib/interruptible/interruptible.mli
@@ -1,0 +1,52 @@
+open Core_kernel
+open Async_kernel
+
+(** The type of interruptible computations.
+    [('a, 's) t] represents a computation that produces a value of type ['a],
+    but which may be interrupted by a signal of type ['s].
+
+    A computation is finished when it has completed and produced a result, or
+    when it has been interrupted.  A finished computation may still be
+    interrupted, which will cause any computations that depend on it (via
+    [map], [bind], etc.) to also become interrupted.
+    The result of an interruptible computation cannot be retrieved once it has
+    been interrupted.
+*)
+type ('a, 's) t
+
+include Monad.S2 with type ('a, 's) t := ('a, 's) t
+
+val map_signal : ('a, 's) t -> f:('s -> 's1) -> ('a, 's1) t
+
+(** [don't_wait_for x] schedules [x] to be run in another thread, ignoring its
+    value and continuing in the current thread.
+*)
+val don't_wait_for : (unit, 's) t -> unit
+
+(** [finally x ~f] schedules [f] to be run after [x] has finished, regardless
+    of whether [x] completed its computation was interrupted.
+*)
+val finally : ('a, 's) t -> f:(unit -> unit) -> ('a, 's) t
+
+(** [lift d interrupt] creates an interruptible computation from the deferred
+    computation [d]. When [interrupt] is resolved, the computation and any
+    values that depend on it become interrupted.
+*)
+val lift : 'a Deferred.t -> 's Deferred.t -> ('a, 's) t
+
+(** [uninterruptible d] wraps the deferred computation [d]. Once [d] is
+    started, it will be run until it produces a result.
+
+    Interrupting a computation during an [uninterruptible] block will still
+    cause the result of the [uninterruptible] block to be discarded.
+*)
+val uninterruptible : 'a Deferred.t -> ('a, 's) t
+
+(** [force x] returns a deferred computation which resolves when the
+    interruptible computation [x] has completed.
+
+    If [x] has finished and produced a result, but has been subsequently
+    interrupted, [force x] will resolve to the interrupted state instead of the
+    result.
+*)
+val force : ('a, 's) t -> ('a, 's) Deferred.Result.t


### PR DESCRIPTION
This PR rewrites the interruptible monad to behave correctly. In particular, this changes the semantics around binding so that
```ocaml
let%bind x = (* this gets the interrupt *) in
let%bind y = (* while running this *) in
let%bind z = f y in
(* ... *)
```
has the same behaviour as
```ocaml
let%bind x = (* this gets the interrupt *) in
let%bind z =
  let%bind y = (* while running this *) in
  f y
in
(* ... *)
```

This was not the case in either the original version or the tweaked implementation in #6880. Presumably this was causing issues in `Integration_test_cloud_engine.Stack_driver_log_engine.pull_subscription_in_background`, which calls itself infinitely in this nested-bind style.

This also adds unit tests for these cases, and fixes the existing unit test (which was equivalent to `Async.after (Time.Span.of_ms 130.)`).

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #300.