### PR TITLE
Add testnet deploy job

### DIFF
--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -22,69 +22,82 @@ provider "google" {
 
 variable "testnet_name" {
   type = string
-
-  description = "Name identifier of testnet to provision"
   default     = "ci-net"
 }
 
-variable "coda_image" {
+variable "daemon_image" {
   type = string
-
-  description = "Mina daemon image to use in provisioning a ci-net"
-  default     = "gcr.io/o1labs-192920/coda-daemon:0.0.17-beta6-develop"
+  default     = "gcr.io/o1labs-192920/coda-daemon:0.2.0-develop"
 }
 
-variable "coda_archive_image" {
+variable "archive_image" {
   type = string
+  default     = "gcr.io/o1labs-192920/coda-archive:0.2.0-develop"
+}
 
-  description = "Mina archive node image to use in provisioning a ci-net"
-  default     = "gcr.io/o1labs-192920/coda-archive:0.0.17-beta6-develop"
+variable "agent_image" {
+  type = string
+  default     = "codaprotocol/coda-user-agent:0.1.8"
+}
+
+variable "bots_image" {
+  type = string
+  default     = "codaprotocol/bot:1.0.0"
 }
 
 variable "whale_count" {
-  type    = number
-  default = 1
+  type = number
+  default     = 2
 }
 
 variable "fish_count" {
-  type    = number
-  default = 1
+  type = number
+  default     = 2
+}
+
+variable "archive_count" {
+  type = number
+  default     = 2
 }
 
 variable "snark_worker_count" {
-  type    = number
-  default = 1
+  type = number
+  default     = 2
 }
 
 locals {
   seed_region = "us-east4"
   seed_zone = "us-east4-b"
-  seed_discovery_keypairs = [
-  "CAESQBEHe2zCcQDHcSaeIydGggamzmTapdCS8SP0hb5FWvYhe9XEygmlUGV4zNu2P8zAIba4X84Gm4usQFLamjRywA8=,CAESIHvVxMoJpVBleMzbtj/MwCG2uF/OBpuLrEBS2po0csAP,12D3KooWJ9mNdbUXUpUNeMnejRumKzmQF15YeWwAPAhTAWB6dhiv",
-  "CAESQO+8qvMqTaQEX9uh4NnNoyOy4Xwv3U80jAsWweQ1J37AVgx7kgs4pPVSBzlP7NDANP1qvSvEPOTh2atbMMUO8EQ=,CAESIFYMe5ILOKT1Ugc5T+zQwDT9ar0rxDzk4dmrWzDFDvBE,12D3KooWFcGGeUmbmCNq51NBdGvCWjiyefdNZbDXADMK5CDwNRm5" ]
 }
-
 
 module "ci_testnet" {
   providers = { google = google.google-us-east4 }
   source    = "../../modules/kubernetes/testnet"
 
+  k8s_context = "gke_o1labs-192920_us-east4_coda-infra-east4"
+
   cluster_name          = "coda-infra-east4"
   cluster_region        = "us-east4"
   testnet_name          = var.testnet_name
 
-  coda_image            = var.coda_image
-  coda_archive_image    = var.coda_archive_image
-  coda_agent_image      = "codaprotocol/coda-user-agent:0.1.5"
-  coda_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"
+  coda_image            = var.daemon_image
+  coda_archive_image    = var.archive_image
+  coda_agent_image      = var.agent_image
+  coda_bots_image       = var.bots_image
   coda_points_image     = "codaprotocol/coda-points-hack:32b.4"
+
+  whale_count           = var.whale_count
+  fish_count            = var.fish_count
 
   coda_faucet_amount    = "10000000000"
   coda_faucet_fee       = "100000000"
 
-  mina_archive_schema = "https://raw.githubusercontent.com/MinaProtocol/mina/2f36b15d48e956e5242c0abc134f1fa7711398dd/src/app/archive/create_schema.sql"
+  archive_node_count    = var.archive_count
+  mina_archive_schema = "https://github.com/MinaProtocol/mina/blob/develop/src/app/archive/create_schema.sql"
 
   additional_seed_peers = []
+
+  seed_port = "10001"
 
   seed_zone = local.seed_zone
   seed_region = local.seed_region
@@ -94,9 +107,6 @@ module "ci_testnet" {
 
   block_producer_key_pass = "naughty blue worm"
   block_producer_starting_host_port = 10501
-
-  whale_count = var.whale_count
-  fish_count = var.fish_count
 
   block_producer_configs = concat(
     [
@@ -119,7 +129,7 @@ module "ci_testnet" {
         id                     = i + 1
         private_key_secret     = "online-fish-account-${i + 1}-key"
         enable_gossip_flooding = false
-        run_with_user_agent    = false
+        run_with_user_agent    = true
         run_with_bots          = false
         enable_peer_exchange   = true
         isolated               = false
@@ -137,4 +147,8 @@ module "ci_testnet" {
   agent_min_tx = "0.0015"
   agent_max_tx = "0.0015"
   agent_send_every_mins = "1"
+}
+
+output "testnet_genesis_ledger" {
+  value = module.ci_testnet.genesis_ledger
 }

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -13,7 +13,7 @@ let Cmd = ../Lib/Cmds.dhall in
             Cmd.Docker::{
               image = (../Constants/ContainerImages.dhall).codaToolchain
             }
-            "cd coda-automation/terraform/testnets/${testnetName} && terraform init && terraform apply; terraform destroy"
+            "cd coda-automation/terraform/testnets/${testnetName} && terraform init && terraform apply -auto-approve; terraform destroy -auto-approve"
         ],
         label = "Deploy testnet: ${testnetName}",
         key = "deploy-testnet",

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -1,7 +1,6 @@
 let Prelude = ../External/Prelude.dhall
 
 let Command = ./Base.dhall
-let Docker = ./Docker/Type.dhall
 let Size = ./Size.dhall
 
 let Cmd = ../Lib/Cmds.dhall in
@@ -14,9 +13,9 @@ let Cmd = ../Lib/Cmds.dhall in
             Cmd.Docker::{
               image = (../Constants/ContainerImages.dhall).codaToolchain
             }
-            "cd ${testnetName} && terraform apply"
+            "cd coda-automation/terraform/testnets/${testnetName} && terraform apply"
         ],
-        label = "Deploy testnet",
+        label = "Deploy testnet: ${testnetName}",
         key = "deploy-testnet",
         target = Size.Large,
         depends_on = dependsOn

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -13,7 +13,7 @@ let Cmd = ../Lib/Cmds.dhall in
             Cmd.Docker::{
               image = (../Constants/ContainerImages.dhall).codaToolchain
             }
-            "cd coda-automation/terraform/testnets/${testnetName} && terraform apply"
+            "cd coda-automation/terraform/testnets/${testnetName} && terraform init && terraform apply; terraform destroy"
         ],
         label = "Deploy testnet: ${testnetName}",
         key = "deploy-testnet",

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -13,15 +13,9 @@ let Cmd = ../Lib/Cmds.dhall in
             Cmd.Docker::{
               image = (../Constants/ContainerImages.dhall).codaToolchain
             }
-<<<<<<< HEAD
             "cd coda-automation/terraform/testnets/${testnetName} && terraform init && terraform apply -auto-approve; terraform destroy -auto-approve"
         ],
         label = "Deploy testnet: ${testnetName}",
-=======
-            "cd ${testnetName} && terraform apply"
-        ],
-        label = "Deploy testnet",
->>>>>>> 58cc509cb... add testnet deployment job to MinaArtifact pipeline
         key = "deploy-testnet",
         target = Size.Large,
         depends_on = dependsOn

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -1,0 +1,24 @@
+let Prelude = ../External/Prelude.dhall
+
+let Command = ./Base.dhall
+let Docker = ./Docker/Type.dhall
+let Size = ./Size.dhall
+
+let Cmd = ../Lib/Cmds.dhall in
+
+{ step = \(testnetName : Text) -> \(dependsOn : List Command.TaggedKey.Type) ->
+    Command.build
+      Command.Config::{
+        commands = [
+          Cmd.runInDocker
+            Cmd.Docker::{
+              image = (../Constants/ContainerImages.dhall).codaToolchain
+            }
+            "cd ${testnetName} && terraform apply"
+        ],
+        label = "Deploy testnet",
+        key = "deploy-testnet",
+        target = Size.Large,
+        depends_on = dependsOn
+      }
+}

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -13,9 +13,15 @@ let Cmd = ../Lib/Cmds.dhall in
             Cmd.Docker::{
               image = (../Constants/ContainerImages.dhall).codaToolchain
             }
+<<<<<<< HEAD
             "cd coda-automation/terraform/testnets/${testnetName} && terraform init && terraform apply -auto-approve; terraform destroy -auto-approve"
         ],
         label = "Deploy testnet: ${testnetName}",
+=======
+            "cd ${testnetName} && terraform apply"
+        ],
+        label = "Deploy testnet",
+>>>>>>> 58cc509cb... add testnet deployment job to MinaArtifact pipeline
         key = "deploy-testnet",
         target = Size.Large,
         depends_on = dependsOn

--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -57,7 +57,7 @@ Pipeline.build
 
       DeployTestnet.step "ci-net" [ { name = "MinaArtifact", key = "mina-docker-image" }, { name = "ArchiveNodeArtifact", key = "archive-docker-image" } ],
 
-      DeployTestnet.step "ci-net" dependsOn,
+      DeployTestnet.step "ci-net" dependsOn # [{ name = "ArchiveNodeArtifact", key = "build-archive-deb-pkg" }],
 
       -- daemon image
       let daemonSpec = DockerImage.ReleaseSpec::{

--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -55,7 +55,7 @@ Pipeline.build
           artifact_paths = [ S.contains "_build/*.deb" ]
         },
 
-      DeployTestnet.step "ci-net" [ { name = "ArchiveNodeArtifact", key = "mina-docker-image" }, { name = "ArchiveNodeArtifact", key = "archive-docker-image" } ],
+      DeployTestnet.step "ci-net" [ { name = "MinaArtifact", key = "mina-docker-image" }, { name = "ArchiveNodeArtifact", key = "archive-docker-image" } ],
 
       -- daemon image
       let daemonSpec = DockerImage.ReleaseSpec::{

--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -57,6 +57,8 @@ Pipeline.build
 
       DeployTestnet.step "ci-net" [ { name = "MinaArtifact", key = "mina-docker-image" }, { name = "ArchiveNodeArtifact", key = "archive-docker-image" } ],
 
+      DeployTestnet.step "ci-net" dependsOn,
+
       -- daemon image
       let daemonSpec = DockerImage.ReleaseSpec::{
         deps=dependsOn,

--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -12,7 +12,6 @@ let OpamInit = ../../Command/OpamInit.dhall
 let Summon = ../../Command/Summon/Type.dhall
 let Size = ../../Command/Size.dhall
 let Libp2p = ../../Command/Libp2pHelperBuild.dhall
-let ConnectToTestnet = ../../Command/ConnectToTestnet.dhall
 let DeployTestnet = ../../Command/DeployTestnet.dhall
 let UploadGitEnv = ../../Command/UploadGitEnv.dhall
 let DockerImage = ../../Command/DockerImage.dhall
@@ -56,10 +55,7 @@ Pipeline.build
           artifact_paths = [ S.contains "_build/*.deb" ]
         },
 
-      -- Tests that depend on the debian package
-      ConnectToTestnet.step dependsOn,
-
-      DeployTestnet.step "ci-net" dependsOn # [{ name = "ArchiveNodeArtifact", key = "build-archive-deb-pkg" }],
+      DeployTestnet.step "ci-net" [ { name = "ArchiveNodeArtifact", key = "mina-docker-image" }, { name = "ArchiveNodeArtifact", key = "archive-docker-image" } ],
 
       -- daemon image
       let daemonSpec = DockerImage.ReleaseSpec::{

--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -59,7 +59,7 @@ Pipeline.build
       -- Tests that depend on the debian package
       ConnectToTestnet.step dependsOn,
 
-      DeployTestnet.step "ci-net" dependsOn,
+      DeployTestnet.step "ci-net" dependsOn # [{ name = "ArchiveNodeArtifact", key = "build-archive-deb-pkg" }],
 
       -- daemon image
       let daemonSpec = DockerImage.ReleaseSpec::{

--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -57,8 +57,6 @@ Pipeline.build
 
       DeployTestnet.step "ci-net" [ { name = "MinaArtifact", key = "mina-docker-image" }, { name = "ArchiveNodeArtifact", key = "archive-docker-image" } ],
 
-      DeployTestnet.step "ci-net" dependsOn # [{ name = "ArchiveNodeArtifact", key = "build-archive-deb-pkg" }],
-
       -- daemon image
       let daemonSpec = DockerImage.ReleaseSpec::{
         deps=dependsOn,

--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -13,6 +13,7 @@ let Summon = ../../Command/Summon/Type.dhall
 let Size = ../../Command/Size.dhall
 let Libp2p = ../../Command/Libp2pHelperBuild.dhall
 let ConnectToTestnet = ../../Command/ConnectToTestnet.dhall
+let DeployTestnet = ../../Command/DeployTestnet.dhall
 let UploadGitEnv = ../../Command/UploadGitEnv.dhall
 let DockerImage = ../../Command/DockerImage.dhall
 
@@ -57,6 +58,8 @@ Pipeline.build
 
       -- Tests that depend on the debian package
       ConnectToTestnet.step dependsOn,
+
+      DeployTestnet.step "ci-net" dependsOn,
 
       -- daemon image
       let daemonSpec = DockerImage.ReleaseSpec::{

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTest.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTest.dhall
@@ -1,30 +1,26 @@
-let Prelude = ../../External/Prelude.dhall
-
 let S = ../../Lib/SelectFiles.dhall
 
-let Pipeline = ../../Pipeline/Dsl.dhall
 let JobSpec = ../../Pipeline/JobSpec.dhall
+let Pipeline = ../../Pipeline/Dsl.dhall
+
+let ConnectToTestnet = ../../Command/ConnectToTestnet.dhall
 
 let dependsOn = [
     { name = "MinaArtifact", key = "mina-docker-image" },
     { name = "ArchiveNodeArtifact", key = "archive-docker-image" }
 ]
 
-in
-
-Pipeline.build
-  Pipeline.Config::{
-    spec =
-      JobSpec::{
-        dirtyWhen = [
-          S.exactly "buildkite/scripts/connect-to-testnet-on-develop" "sh",
-          S.strictlyStart (S.contains "src")
-        ],
-        path = "Test",
-        name = "TestnetIntegrationTest"
-      },
-    steps = [
-        -- Tests that depend on the debian package
-        ConnectToTestnet.step dependsOn,
-    ]
-  }
+in Pipeline.build Pipeline.Config::{
+  spec =
+    JobSpec::{
+    dirtyWhen = [
+      S.exactly "buildkite/scripts/connect-to-testnet-on-develop" "sh",
+      S.strictlyStart (S.contains "src")
+    ],
+    path = "Test",
+    name = "TestnetIntegrationTest"
+  },
+  steps = [
+    ConnectToTestnet.step dependsOn
+  ]
+}

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTest.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTest.dhall
@@ -1,0 +1,30 @@
+let Prelude = ../../External/Prelude.dhall
+
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let dependsOn = [
+    { name = "MinaArtifact", key = "mina-docker-image" },
+    { name = "ArchiveNodeArtifact", key = "archive-docker-image" }
+]
+
+in
+
+Pipeline.build
+  Pipeline.Config::{
+    spec =
+      JobSpec::{
+        dirtyWhen = [
+          S.exactly "buildkite/scripts/connect-to-testnet-on-develop" "sh",
+          S.strictlyStart (S.contains "src")
+        ],
+        path = "Test",
+        name = "TestnetIntegrationTest"
+      },
+    steps = [
+        -- Tests that depend on the debian package
+        ConnectToTestnet.step dependsOn,
+    ]
+  }


### PR DESCRIPTION
Add testnet deployment to Buildkite *Release* MinaArtifact jobs. Also re-organize and move the testnet connection test/job from *Release* to *Test*.

**Test:** Buildkite CI

**Checklist:**

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
