### PR TITLE
Dump hardware details for Linux

### DIFF
--- a/src/lib/coda_lib/conf_dir.ml
+++ b/src/lib/coda_lib/conf_dir.ml
@@ -133,9 +133,9 @@ let export_logs_to_tar ?basename ~conf_dir =
               | Error err ->
                   [sprintf "Error: %s" (Error.to_string_hum err)]
             in
-            return (Option.value_exn linux_info :: header :: output) )
+            return (header :: output) )
       in
-      Some (List.concat outputs)
+      Some (Option.value_exn linux_info :: List.concat outputs)
     else (* TODO: Mac, other Unixes *)
       Deferred.return None
   in

--- a/src/lib/coda_lib/conf_dir.ml
+++ b/src/lib/coda_lib/conf_dir.ml
@@ -107,7 +107,61 @@ let export_logs_to_tar ?basename ~conf_dir =
     Core.Sys.ls_dir conf_dir
     |> List.filter ~f:(String.is_substring ~substring:".log")
   in
-  let files = "coda.version" :: log_files in
+  let%bind.Deferred.Let_syntax linux_info =
+    if String.equal Sys.os_type "Unix" then
+      match%map.Deferred.Let_syntax
+        Process.run ~prog:"uname" ~args:["-a"] ()
+      with
+      | Ok s when String.is_prefix s ~prefix:"Linux" ->
+          Some s
+      | _ ->
+          None
+    else Deferred.return None
+  in
+  let%bind.Deferred.Let_syntax hw_info_opt =
+    if Option.is_some linux_info then
+      let open Deferred.Let_syntax in
+      let linux_hw_progs = ["lscpu"; "lsgpu"; "lsmem"; "lsblk"] in
+      let%map outputs =
+        Deferred.List.map linux_hw_progs ~f:(fun prog ->
+            let header = sprintf "*** Output from '%s' ***\n" prog in
+            let%bind output =
+              (* no args, otherwise might not be consistent across Linuxes *)
+              match%map Process.run_lines ~prog ~args:[] () with
+              | Ok lines ->
+                  lines
+              | Error err ->
+                  [sprintf "Error: %s" (Error.to_string_hum err)]
+            in
+            return (Option.value_exn linux_info :: header :: output) )
+      in
+      Some (List.concat outputs)
+    else (* TODO: Mac, other Unixes *)
+      Deferred.return None
+  in
+  let%bind.Deferred.Let_syntax hw_file_opt =
+    if Option.is_some hw_info_opt then
+      let open Async in
+      let hw_info = "hardware.info" in
+      let hw_info_file = conf_dir ^/ hw_info in
+      match%map
+        Monitor.try_with ~extract_exn:true (fun () ->
+            Writer.with_file ~exclusive:true hw_info_file ~f:(fun writer ->
+                Deferred.List.map (Option.value_exn hw_info_opt)
+                  ~f:(fun line -> return (Writer.write_line writer line)) ) )
+      with
+      | Ok _units ->
+          Some hw_info
+      | Error _exn ->
+          (* carry on, despite the error *)
+          None
+    else Deferred.return None
+  in
+  let base_files = "coda.version" :: log_files in
+  let files =
+    Option.value_map hw_file_opt ~default:base_files ~f:(fun hw_file ->
+        hw_file :: base_files )
+  in
   let%map _result =
     Process.run ~prog:"tar"
       ~args:


### PR DESCRIPTION
On Linux, include a hardware information file in the tar file created by `export-logs` and `export-local-logs`.

The file is created by running `uname -a`, `lscpu`, `lsgpu`, `lsmem`, and `lsblk`, and writing that to a single file `hardware.info` in the config dir. (It's not removed, could add that if desired). 

Example output:
```
Linux tabouleh 5.4.0-56-generic #62-Ubuntu SMP Mon Nov 23 19:20:19 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

*** Output from 'lscpu' ***

Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   43 bits physical, 48 bits virtual
CPU(s):                          16
On-line CPU(s) list:             0-15
Thread(s) per core:              2
Core(s) per socket:              8
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       AuthenticAMD
CPU family:                      23
Model:                           8
Model name:                      AMD Ryzen 7 2700X Eight-Core Processor
Stepping:                        2
Frequency boost:                 enabled
CPU MHz:                         2197.810
CPU max MHz:                     3700.0000
CPU min MHz:                     2200.0000
BogoMIPS:                        7399.22
Virtualization:                  AMD-V
L1d cache:                       256 KiB
L1i cache:                       512 KiB
L2 cache:                        4 MiB
L3 cache:                        16 MiB
NUMA node0 CPU(s):               0-15
Vulnerability Itlb multihit:     Not affected
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Full AMD retpoline, IBPB conditional, STIBP disabled, RSB filling
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb hw_pstate sme ssbd sev ibpb vmmcall fsgsbase bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 xsaves clzero irperf xsaveerptr arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif overflow_recov succor smca

*** Output from 'lsgpu' ***

sys:/sys/devices/pci0000:00/0000:00:03.1/0000:1f:00.0/drm/card0
    subsystem       : drm
    drm card        : /dev/dri/card0
    parent          : sys:/sys/devices/pci0000:00/0000:00:03.1/0000:1f:00.0

sys:/sys/devices/pci0000:00/0000:00:03.1/0000:1f:00.0/drm/renderD128
    subsystem       : drm
    drm render      : /dev/dri/renderD128
    parent          : sys:/sys/devices/pci0000:00/0000:00:03.1/0000:1f:00.0

sys:/sys/devices/pci0000:00/0000:00:03.1/0000:1f:00.0
    subsystem       : pci
    drm card        : /dev/dri/card0
    drm render      : /dev/dri/renderD128
    vendor          : 10DE
    device          : 1D01

*** Output from 'lsmem' ***

RANGE                                  SIZE  STATE REMOVABLE  BLOCK
0x0000000000000000-0x00000000dfffffff  3.5G online       yes   0-27
0x0000000100000000-0x000000081fffffff 28.5G online       yes 32-259

Memory block size:       128M
Total online memory:      32G
Total offline memory:      0B

*** Output from 'lsblk' ***

NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
sda           8:0    0   1.8T  0 disk 
└─sda1        8:1    0   1.8T  0 part /run/timeshift/backup
sr0          11:0    1  1024M  0 rom  
nvme0n1     259:0    0 931.5G  0 disk 
├─nvme0n1p1 259:1    0   731M  0 part /boot
├─nvme0n1p2 259:2    0 900.2G  0 part /
└─nvme0n1p3 259:3    0  30.6G  0 part [SWAP]

```

Closes #6799.