### PR TITLE
soft-fail on connect to testnet failures

### DIFF
--- a/buildkite/src/Command/ConnectToTestnet.dhall
+++ b/buildkite/src/Command/ConnectToTestnet.dhall
@@ -1,5 +1,8 @@
 let Prelude = ../External/Prelude.dhall
 
+let B = ../External/Buildkite.dhall
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+
 let Command = ./Base.dhall
 let Docker = ./Docker/Type.dhall
 let Size = ./Size.dhall
@@ -19,6 +22,7 @@ let Cmd = ../Lib/Cmds.dhall in
         label = "Connect to testnet",
         key = "connect-to-testnet",
         target = Size.Large,
+        soft_fail = Some (B/SoftFail.Boolean True),
         depends_on = dependsOn
       }
 }


### PR DESCRIPTION
Avoid blocking CI pipelines based on (somewhat orthogonal to change under test) current qanet connection test.

**Test:** Buildkite CI

**Checklist:**

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
