### PR TITLE
Hot fix epoch ledger sync failure

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -844,7 +844,8 @@ let setup_daemon logger =
           ~genesis_state_hash:
             (With_hash.hash precomputed_values.protocol_state_with_hash)
       in
-      trace_database_initialization "consensus local state" __LOC__ trust_dir ;
+      trace_database_initialization "epoch ledger" __LOC__
+        epoch_ledger_location ;
       let%bind peer_list_file_contents_or_empty =
         match libp2p_peer_list_file with
         | None ->

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -400,44 +400,50 @@ let run ~logger ~trust_system ~verifier ~network ~consensus_local_state
         let%bind ( local_state_sync_time
                  , (local_state_sync_required, local_state_sync_result) ) =
           time_deferred
-            ( match
-                Consensus.Hooks.required_local_state_sync
-                  ~constants:precomputed_values.consensus_constants
-                  ~consensus_state ~local_state:consensus_local_state
-              with
-            | None ->
-                [%log debug]
-                  ~metadata:
-                    [ ( "local_state"
-                      , Consensus.Data.Local_state.to_yojson
-                          consensus_local_state )
-                    ; ( "consensus_state"
-                      , Consensus.Data.Consensus_state.Value.to_yojson
-                          consensus_state ) ]
-                  "Not synchronizing consensus local state" ;
-                Deferred.return (false, Or_error.return ())
-            | Some sync_jobs ->
-                [%log info] "Synchronizing consensus local state" ;
-                let%map result =
-                  Consensus.Hooks.sync_local_state
-                    ~local_state:consensus_local_state ~logger ~trust_system
-                    ~random_peers:(fun n ->
-                      (* This port is completely made up but we only use the peer_id when doing a query, so it shouldn't matter. *)
-                      let%map peers =
-                        Coda_networking.random_peers t.network n
-                      in
-                      sender :: peers )
-                    ~query_peer:
-                      { Consensus.Hooks.Rpcs.query=
-                          (fun peer rpc query ->
-                            Coda_networking.(
-                              query_peer t.network peer.peer_id
-                                (Rpcs.Consensus_rpc rpc) query) ) }
-                    ~ledger_depth:
-                      precomputed_values.constraint_constants.ledger_depth
-                    sync_jobs
-                in
-                (true, result) )
+            ((*Sync local state according to the root we just bootstrapped to*)
+             let root_consensus_state =
+               External_transition.consensus_state
+                 (With_hash.data (fst new_root))
+             in
+             match
+               Consensus.Hooks.required_local_state_sync
+                 ~constants:precomputed_values.consensus_constants
+                 ~consensus_state:root_consensus_state
+                 ~local_state:consensus_local_state
+             with
+             | None ->
+                 [%log debug]
+                   ~metadata:
+                     [ ( "local_state"
+                       , Consensus.Data.Local_state.to_yojson
+                           consensus_local_state )
+                     ; ( "consensus_state"
+                       , Consensus.Data.Consensus_state.Value.to_yojson
+                           consensus_state ) ]
+                   "Not synchronizing consensus local state" ;
+                 Deferred.return (false, Or_error.return ())
+             | Some sync_jobs ->
+                 [%log info] "Synchronizing consensus local state" ;
+                 let%map result =
+                   Consensus.Hooks.sync_local_state
+                     ~local_state:consensus_local_state ~logger ~trust_system
+                     ~random_peers:(fun n ->
+                       (* This port is completely made up but we only use the peer_id when doing a query, so it shouldn't matter. *)
+                       let%map peers =
+                         Coda_networking.random_peers t.network n
+                       in
+                       sender :: peers )
+                     ~query_peer:
+                       { Consensus.Hooks.Rpcs.query=
+                           (fun peer rpc query ->
+                             Coda_networking.(
+                               query_peer t.network peer.peer_id
+                                 (Rpcs.Consensus_rpc rpc) query) ) }
+                     ~ledger_depth:
+                       precomputed_values.constraint_constants.ledger_depth
+                     sync_jobs
+                 in
+                 (true, result))
         in
         match local_state_sync_result with
         | Error e ->

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -318,13 +318,13 @@ let initialize ~logger ~network ~is_seed ~is_demo_mode ~verifier ~trust_system
         [%log info]
           "Network best tip is recent enough to catchup to; syncing local \
            state and starting participation" ;
-        let root = Transition_frontier.root frontier in
+        let curr_best_tip = Transition_frontier.best_tip frontier in
         let%map () =
           match
             Consensus.Hooks.required_local_state_sync
               ~constants:precomputed_values.consensus_constants
               ~consensus_state:
-                (Transition_frontier.Breadcrumb.consensus_state root)
+                (Transition_frontier.Breadcrumb.consensus_state curr_best_tip)
               ~local_state:consensus_local_state
           with
           | None ->


### PR DESCRIPTION
Epoch ledger sync is failing because nodes were requesting genesis ledger.
This happens when transition frontier controller starts and the node tries to sync its local state using the frontier root which could point to an older epoch ledger (in this case genesis ledger) as compared to what the best tip points to. However, the epoch ledgers persisted by the node would already be updated for the best-tip. So essentially the node was trying to revert the epoch ledgers to an older state. 
Syncing the local state with the best tip ensures that the frontier and local state are in sync (given the epoch finalization condition in the code)

Also, removed an assertion that was failing for me locally. Described the issue here: #6956. This should be added back when the issue is fixed


fixes #6955
fixes #6952