### PR TITLE
Block production/gossip logs at info level

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -191,10 +191,6 @@ let setup_daemon logger =
       ~doc:
         "true|false Log snark-pool diff received from peers (default: false)"
       (optional bool)
-  and log_received_blocks =
-    flag "log-received-blocks"
-      ~doc:"true|false Log blocks received from peers (default: false)"
-      (optional bool)
   and log_transaction_pool_diff =
     flag "log-txn-pool-gossip"
       ~doc:
@@ -647,10 +643,6 @@ let setup_daemon logger =
         or_from_config YJ.Util.to_bool_option "log-snark-work-gossip"
           ~default:false log_received_snark_pool_diff
       in
-      let log_received_blocks =
-        or_from_config YJ.Util.to_bool_option "log-received-blocks"
-          ~default:false log_received_blocks
-      in
       let log_transaction_pool_diff =
         or_from_config YJ.Util.to_bool_option "log-txn-pool-gossip"
           ~default:false log_transaction_pool_diff
@@ -662,7 +654,7 @@ let setup_daemon logger =
       let log_gossip_heard =
         { Coda_networking.Config.snark_pool_diff= log_received_snark_pool_diff
         ; transaction_pool_diff= log_transaction_pool_diff
-        ; new_state= log_received_blocks }
+        ; new_state= true }
       in
       let json_to_publickey_compressed_option which json =
         YJ.Util.to_string_option json

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -386,7 +386,7 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                 Transition_registry
             in
             let crumb = Transition_frontier.best_tip frontier in
-            [%log trace]
+            [%log info]
               ~metadata:[("breadcrumb", Breadcrumb.to_yojson crumb)]
               "Producing new block with parent $breadcrumb%!" ;
             let previous_protocol_state, previous_protocol_state_proof =
@@ -533,7 +533,7 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                              | `Prover_error _ ) as err ->
                                err )
                     in
-                    [%str_log trace]
+                    [%str_log info]
                       ~metadata:
                         [("breadcrumb", Breadcrumb.to_yojson breadcrumb)]
                       Block_produced ;

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -1175,7 +1175,7 @@ let create ?wallets (config : Config.t) =
                   | Ok () ->
                       (*Don't log rebroadcast message if it is internally generated; There is a broadcast log for it*)
                       if not (source = `Internal) then
-                        [%str_log' trace config.logger]
+                        [%str_log' info config.logger]
                           ~metadata:
                             [ ( "external_transition"
                               , External_transition.Validated.to_yojson

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -1113,7 +1113,7 @@ let create (config : Config.t)
                  |> Protocol_state.blockchain_state
                  |> Blockchain_state.timestamp |> Block_time.to_time )) ;
             if config.log_gossip_heard.new_state then
-              [%str_log debug]
+              [%str_log info]
                 ~metadata:
                   [("external_transition", External_transition.to_yojson state)]
                 (Block_received
@@ -1197,9 +1197,11 @@ let broadcast t ~log_msg msg =
   Gossip_net.Any.broadcast t.gossip_net msg
 
 let broadcast_state t state =
-  broadcast t
-    (Gossip_net.Message.New_state (With_hash.data state))
-    ~log_msg:(Gossip_new_state {state_hash= With_hash.hash state})
+  let msg = Gossip_net.Message.New_state (With_hash.data state) in
+  [%str_log' info t.logger]
+    ~metadata:[("message", Gossip_net.Message.msg_to_yojson msg)]
+    (Gossip_new_state {state_hash= With_hash.hash state}) ;
+  Gossip_net.Any.broadcast t.gossip_net msg
 
 let broadcast_transaction_pool_diff t diff =
   broadcast t (Gossip_net.Message.Transaction_pool_diff diff)


### PR DESCRIPTION
Log the following at info level

1. "Received a block from"
2. "Broadcasting new state over gossip net"
3. "Rebroadcasting $state_hash"
4. "Producing new block with parent $breadcrumb"
5. "Successfully produced a new block"

Also removed the daemon flag `-log-received-blocks`. The daemon will always log blocks received

The reason for this PR is to have enough information about block production and gossip in the log files to calculate block latencies as implemented here https://github.com/MinaProtocol/coda-automation/pull/509