### PR TITLE
Fix Rosetta handling of coinbase fees (plus miscellaneous related fixes)

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -207,7 +207,7 @@ module Sql = struct
          * backwards until it reaches a block of the given height. *)
         {|
 WITH RECURSIVE chain AS (
-  (SELECT id, state_hash, parent_id, creator_id, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id, ledger_hash, height, timestamp FROM blocks b WHERE height = (select MAX(height) from blocks)
+  (SELECT id, state_hash, parent_id, creator_id, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id, ledger_hash, height, global_slot, timestamp FROM blocks b WHERE height = (select MAX(height) from blocks)
   ORDER BY timestamp ASC
   LIMIT 1)
 

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -166,7 +166,7 @@ let verify_in_mempool_and_block ~logger ~rosetta_uri ~graphql_uri
     ~expected:
       ( List.map ~f:succesful operation_expectations
       @ Operation_expectation.
-          [ { amount= Some 20_000_000_000
+          [ { amount= Some 40_000_000_000
             ; account=
                 Some {Account.pk= Poke.pk; token_id= Unsigned.UInt64.of_int 1}
             ; status= "Success"

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -110,7 +110,7 @@ let verify_in_mempool_and_block ~logger ~rosetta_uri ~graphql_uri
     "Found block index $index" ;
   (* Start staking so we get blocks *)
   let%bind _res = Poke.Staking.enable ~graphql_uri in
-  (* Wait until the newest-block is at least index>last_block_index and there is at least not a coinbase *)
+  (* Wait until the newest block has index > last_block_index and has at least one user command *)
   let%bind block =
     keep_trying
       ~step:(fun () ->
@@ -125,14 +125,15 @@ let verify_in_mempool_and_block ~logger ~rosetta_uri ~graphql_uri
                     .block_identifier
                     .index > last_block_index)
               in
-              let at_least_txn_not_coinbase : bool =
+              let has_user_command : bool =
+                (* HACK: First transaction is always an internal command and second, if present, is always a user
+                 * command, so we can just check that length > 1 *)
                 Int.(
                   List.length
                     (Option.value_exn block.Block_response.block).transactions
                   > 1)
               in
-              if newer_block && at_least_txn_not_coinbase then Some block
-              else None )
+              if newer_block && has_user_command then Some block else None )
         with
         | Error _ ->
             `Failed


### PR DESCRIPTION
- Fix broken query_height query in Rosetta block.ml

- Fix Rosetta handling of coinbase fees
    Rosetta was incorrectly using a constant for all coinbase fees. Some
    fees are "supercharged" so they're actually variable. The specific fee
    was already available so this switches to using that and removes the
    code that was pulling the base coinbase fee constant from GraphQL.

Tested using Rosetta `./start.sh` and Coinbase's `rosetta-cli`.

Checklist:

- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them: