### PR TITLE
Remove assertion when catchup is long

### DIFF
--- a/src/lib/transition_frontier/catchup_hash_tree.ml
+++ b/src/lib/transition_frontier/catchup_hash_tree.ml
@@ -1,0 +1,143 @@
+open Core_kernel
+open Coda_base
+open Frontier_base
+
+module Catchup_job_id = Unique_id.Int ()
+
+module Node = struct
+  module State = struct
+    type t = Have_breadcrumb | Part_of_catchups of Catchup_job_id.Hash_set.t
+  end
+
+  type t =
+    { parent: State_hash.t
+    ; state: State.t
+          (* If a node has a breadcrumb, then all of its ancestors have
+   breadcrumbs as well. *)
+    }
+end
+
+type t =
+  { nodes: Node.t State_hash.Table.t
+  ; tips: State_hash.Hash_set.t
+  ; child_counts: int State_hash.Table.t (* How many children does it have *)
+  ; mutable root: State_hash.t
+  ; logger: Logger.t }
+
+let max_catchup_chain_length t =
+  let rec missing_length acc (node : Node.t) =
+    match node.state with
+    | Have_breadcrumb ->
+        acc
+    | Part_of_catchups _ -> (
+      match Hashtbl.find t.nodes node.parent with
+      | None ->
+          (* This node is a root. *)
+          acc
+      | Some parent ->
+          missing_length (acc + 1) parent )
+  in
+  Hash_set.fold t.tips ~init:0 ~f:(fun acc tip ->
+      Int.max acc (missing_length 0 (Hashtbl.find_exn t.nodes tip)) )
+
+let create ~root =
+  let root_hash = Breadcrumb.state_hash root in
+  let parent = Breadcrumb.parent_hash root in
+  let nodes =
+    State_hash.Table.of_alist_exn
+      [(root_hash, {Node.parent; state= Have_breadcrumb})]
+  in
+  { root= root_hash
+  ; tips= State_hash.Hash_set.create ()
+  ; child_counts= State_hash.Table.of_alist_exn [(parent, 1)]
+  ; nodes
+  ; logger= Logger.create () }
+
+let check_for_parent t h ~parent:p ~check_has_breadcrumb =
+  let log s =
+    [%log' warn t.logger]
+      ~metadata:
+        [("parent", State_hash.to_yojson p); ("hash", State_hash.to_yojson h)]
+      "hash tree invariant broken: %s" s
+  in
+  match Hashtbl.find t.nodes p with
+  | None ->
+      log "$parent not found in hash-tree for $hash"
+  | Some x ->
+      if check_has_breadcrumb && x.state <> Have_breadcrumb then
+        log "expected $parent to have breadcrumb (child is $hash)"
+      else ()
+
+let add t h ~parent ~job =
+  if Hashtbl.mem t.nodes h then
+    match (Hashtbl.find_exn t.nodes h).state with
+    | Have_breadcrumb ->
+        ()
+    | Part_of_catchups s ->
+        Hash_set.add s job
+  else (
+    check_for_parent t h ~parent ~check_has_breadcrumb:false ;
+    if not (Hashtbl.mem t.child_counts h) then Hash_set.add t.tips h ;
+    Hashtbl.incr t.child_counts ~by:1 parent ;
+    Hash_set.remove t.tips parent ;
+    Hashtbl.set t.nodes ~key:h
+      ~data:
+        {parent; state= Part_of_catchups (Catchup_job_id.Hash_set.create ())} )
+
+let breadcrumb_added (t : t) b =
+  let h = Breadcrumb.state_hash b in
+  let parent = Breadcrumb.parent_hash b in
+  check_for_parent t h ~parent ~check_has_breadcrumb:true ;
+  Hashtbl.update t.nodes h ~f:(function
+    | None ->
+        (* New child *)
+        Hashtbl.incr ~by:1 t.child_counts parent ;
+        {parent; state= Have_breadcrumb}
+    | Some x ->
+        {x with state= Have_breadcrumb} ) ;
+  Hash_set.remove t.tips h
+
+let remove_node t h =
+  Hash_set.remove t.tips h ;
+  match Hashtbl.find_and_remove t.nodes h with
+  | None ->
+      ()
+  | Some {parent; _} ->
+      Hashtbl.change t.child_counts parent ~f:(function
+        | None ->
+            None
+        | Some n ->
+            let n' = n - 1 in
+            if n' > 0 then Some n' else None )
+
+let catchup_failed t job =
+  let to_remove =
+    Hashtbl.fold t.nodes ~init:[] ~f:(fun ~key ~data acc ->
+        match data.state with
+        | Have_breadcrumb ->
+            acc
+        | Part_of_catchups s ->
+            Hash_set.remove s job ;
+            if Hash_set.is_empty s then key :: acc else acc )
+  in
+  List.iter to_remove ~f:(remove_node t)
+
+let apply_diffs t (ds : Diff.Full.E.t list) =
+  List.iter ds ~f:(function
+    | E (New_node (Full b)) ->
+        breadcrumb_added t b
+    | E (Root_transitioned {new_root; garbage= Full hs}) ->
+        List.iter (Diff.Node_list.to_lite hs) ~f:(remove_node t) ;
+        let h = Root_data.Limited.hash new_root in
+        Hashtbl.change t.nodes h ~f:(function
+          | None ->
+              [%log' warn t.logger]
+                ~metadata:[("hash", State_hash.to_yojson h)]
+                "hash tree invariant broken: new root $hash not present. \
+                 Diffs may have been applied out of order" ;
+              None
+          | Some x ->
+              t.root <- h ;
+              Some {x with state= Have_breadcrumb} )
+    | E (Best_tip_changed _) ->
+        () )

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -596,7 +596,7 @@ let update_metrics_with_diff (type mutant) t
   | _ ->
       ()
 
-let apply_diffs t diffs ~enable_epoch_ledger_sync =
+let apply_diffs t diffs ~enable_epoch_ledger_sync ~has_long_catchup_job =
   let open Root_identifier.Stable.Latest in
   [%log' trace t.logger] "Applying %d diffs to full frontier "
     (List.length diffs) ;
@@ -623,7 +623,8 @@ let apply_diffs t diffs ~enable_epoch_ledger_sync =
     )
   in
   [%log' trace t.logger] "after applying diffs to full frontier" ;
-  if not (enable_epoch_ledger_sync = `Disabled) then
+  if (not (enable_epoch_ledger_sync = `Disabled)) && not has_long_catchup_job
+  then
     Debug_assert.debug_assert (fun () ->
         match
           Consensus.Hooks.required_local_state_sync

--- a/src/lib/transition_frontier/full_frontier/full_frontier.mli
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.mli
@@ -47,6 +47,7 @@ val apply_diffs :
      t
   -> Diff.Full.E.t list
   -> enable_epoch_ledger_sync:[`Enabled of Ledger.Db.t | `Disabled]
+  -> has_long_catchup_job:bool
   -> [ `New_root_and_diffs_with_mutants of
        Root_identifier.t option * Diff.Full.With_mutant.t list ]
 

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -258,7 +258,7 @@ module Instance = struct
     in
     let apply_diff diff =
       let (`New_root_and_diffs_with_mutants (_, diffs_with_mutants)) =
-        Full_frontier.apply_diffs frontier [diff]
+        Full_frontier.apply_diffs frontier [diff] ~has_long_catchup_job:false
           ~enable_epoch_ledger_sync:
             ( if ignore_consensus_local_state then `Disabled
             else `Enabled root_ledger )

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -43,7 +43,7 @@ let%test_module "Full_frontier tests" =
     let add_breadcrumb frontier breadcrumb =
       let diffs = Full_frontier.calculate_diffs frontier breadcrumb in
       ignore
-        (Full_frontier.apply_diffs frontier diffs
+        (Full_frontier.apply_diffs frontier diffs ~has_long_catchup_job:false
            ~enable_epoch_ledger_sync:`Disabled)
 
     let add_breadcrumbs frontier = List.iter ~f:(add_breadcrumb frontier)

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -12,6 +12,7 @@ module Full_frontier = Full_frontier
 module Extensions = Extensions
 module Persistent_root = Persistent_root
 module Persistent_frontier = Persistent_frontier
+module Catchup_hash_tree = Catchup_hash_tree
 
 let max_catchup_chunk_length = 20
 
@@ -22,6 +23,7 @@ type t =
   { logger: Logger.t
   ; verifier: Verifier.t
   ; consensus_local_state: Consensus.Data.Local_state.t
+  ; catchup_hash_tree: Catchup_hash_tree.t
   ; full_frontier: Full_frontier.t
   ; persistent_root: Persistent_root.t
   ; persistent_root_instance: Persistent_root.Instance.t
@@ -29,6 +31,8 @@ type t =
   ; persistent_frontier_instance: Persistent_frontier.Instance.t
   ; extensions: Extensions.t
   ; genesis_state_hash: State_hash.t }
+
+let catchup_hash_tree t = t.catchup_hash_tree
 
 type Structured_log_events.t += Added_breadcrumb_user_commands
   [@@deriving register_event]
@@ -118,6 +122,8 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
       )
   in
   { logger
+  ; catchup_hash_tree=
+      Catchup_hash_tree.create ~root:(Full_frontier.root full_frontier)
   ; verifier
   ; consensus_local_state
   ; full_frontier
@@ -269,6 +275,7 @@ let close ~loc
     { logger
     ; verifier= _
     ; consensus_local_state= _
+    ; catchup_hash_tree= _
     ; full_frontier
     ; persistent_root= _safe_to_ignore_1
     ; persistent_root_instance
@@ -309,10 +316,13 @@ let add_breadcrumb_exn t breadcrumb =
     "PRE: ($state_hash, $n)" ;
   [%str_log' trace t.logger]
     (Applying_diffs {diffs= List.map ~f:Diff.Full.E.to_yojson diffs}) ;
+  Catchup_hash_tree.apply_diffs t.catchup_hash_tree diffs ;
   let (`New_root_and_diffs_with_mutants
         (new_root_identifier, diffs_with_mutants)) =
     (* Root DB moves here *)
     Full_frontier.apply_diffs t.full_frontier diffs
+      ~has_long_catchup_job:
+        (Catchup_hash_tree.max_catchup_chain_length t.catchup_hash_tree > 5)
       ~enable_epoch_ledger_sync:(`Enabled (root_snarked_ledger t))
   in
   Option.iter new_root_identifier

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -14,6 +14,7 @@ module Extensions = Extensions
 module Persistent_root = Persistent_root
 module Persistent_frontier = Persistent_frontier
 module Root_data = Root_data
+module Catchup_hash_tree = Catchup_hash_tree
 
 include Frontier_intf.S
 
@@ -24,6 +25,8 @@ type Structured_log_events.t += Applying_diffs of {diffs: Yojson.Safe.t list}
   [@@deriving register_event]
 
 val max_catchup_chunk_length : int
+
+val catchup_hash_tree : t -> Catchup_hash_tree.t
 
 (* This is the max length which is used when the transition frontier is initialized
  * via `load`. In other words, this will always be the max length of the transition


### PR DESCRIPTION
This PR creates a module `catchup_hash_tree.ml` which is contained in a transition frontier. This type is a tree with

- Nodes: State hashes which are either in the full frontier or in some set of catchup jobs
- Edges: There are edges from children to their parents.

For each node, we record whether or not it is in the full frontier, and if not we write down which active catchup jobs it is involved with.

The point of this is to let us write a function `val max_catchup_chain_length : Catchup_hash_tree.t -> int` which computes the length of the longest directed path from a leaf of the tree to a node which is in the full frontier. This allows us to know whether a "long" (defined as > 5) catchup job is in progress, in which case we allow a particular assertion about local state to fail.

@nholland94 -- you had previously proposed long to mean >= k / 2. I did 5 on your recommendation here.