### PR TITLE
Add more telemetry data

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -965,6 +965,7 @@ Pass one of -peer, -peer-list-file, -seed.|} ;
         Coda_run.get_proposed_protocol_version_opt ~conf_dir ~logger
           proposed_protocol_version
       in
+      let start_time = Time.now () in
       let%map coda =
         Coda_lib.create ~wallets
           (Coda_lib.Config.make ~logger ~pids ~trust_system ~conf_dir ~chain_id
@@ -990,7 +991,7 @@ Pass one of -peer, -peer-list-file, -seed.|} ;
              ~consensus_local_state ~transaction_database
              ~external_transition_database ~is_archive_rocksdb
              ~work_reassignment_wait ~archive_process_location
-             ~log_block_creation ~precomputed_values ())
+             ~log_block_creation ~precomputed_values ~start_time ())
       in
       {Coda_initialization.coda; client_trustlist; rest_server_port}
     in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1659,8 +1659,7 @@ let telemetry =
                    @@ Coda_networking.Rpcs.Get_telemetry_data
                       .response_to_yojson peer_telem_data ) )
          | Error err ->
-             printf "Failed to get telemetry data: %s\n%!"
-               (Error.to_string_hum err) ))
+             printf {| { "error": "%s"\n%! } |} (Error.to_string_hum err) ))
 
 let next_available_token_cmd =
   Command.async

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1659,7 +1659,9 @@ let telemetry =
                    @@ Coda_networking.Rpcs.Get_telemetry_data
                       .response_to_yojson peer_telem_data ) )
          | Error err ->
-             printf {| { "error": "%s"\n%! } |} (Error.to_string_hum err) ))
+             printf "%s\n%!"
+               (Yojson.Safe.to_string
+                  (`Assoc [("error", Error_json.error_to_yojson err)])) ))
 
 let next_available_token_cmd =
   Command.async

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -513,6 +513,7 @@ module T = struct
           let with_monitor f input =
             Async.Scheduler.within' ~monitor (fun () -> f input)
           in
+          let start_time = Time.now () in
           let coda_deferred () =
             Coda_lib.create
               (Coda_lib.Config.make ~logger ~pids ~trust_system ~conf_dir
@@ -537,7 +538,7 @@ module T = struct
                  ~initial_block_production_keypairs ~monitor
                  ~consensus_local_state ~transaction_database
                  ~external_transition_database ~is_archive_rocksdb
-                 ~work_reassignment_wait:420000 ~precomputed_values
+                 ~work_reassignment_wait:420000 ~precomputed_values ~start_time
                  ~archive_process_location:
                    (Option.map archive_process_location
                       ~f:(fun host_and_port ->

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -199,6 +199,7 @@ let run_test () : unit Deferred.t =
       let snark_work_fee, transaction_fee =
         if with_snark then (fee 0, fee 0) else (fee 100, fee 200)
       in
+      let start_time = Time.now () in
       let%bind coda =
         Coda_lib.create
           (Coda_lib.Config.make ~logger ~pids ~trust_system ~net_config
@@ -223,7 +224,7 @@ let run_test () : unit Deferred.t =
              ~epoch_ledger_location ~time_controller ~snark_work_fee
              ~consensus_local_state ~transaction_database
              ~external_transition_database ~work_reassignment_wait:420000
-             ~precomputed_values ())
+             ~precomputed_values ~start_time ())
       in
       don't_wait_for
         (Strict_pipe.Reader.iter_without_pushback

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -514,7 +514,9 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                             ~consensus_constants
                       |> Deferred.return
                     in
-                    let transition_receipt_time = Core_kernel.Time.now () in
+                    let transition_receipt_time =
+                      Some (Core_kernel.Time.now ())
+                    in
                     let%bind breadcrumb =
                       time ~logger ~time_controller
                         "Build breadcrumb on produced block" (fun () ->
@@ -789,7 +791,7 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
                   ~logger ~frontier ~consensus_constants
             |> Deferred.return
           in
-          let transition_receipt_time = Core_kernel.Time.now () in
+          let transition_receipt_time = None in
           let%bind breadcrumb =
             time ~logger ~time_controller
               "Build breadcrumb on produced block (precomputed)" (fun () ->

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -514,13 +514,15 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                             ~consensus_constants
                       |> Deferred.return
                     in
+                    let transition_receipt_time = Core_kernel.Time.now () in
                     let%bind breadcrumb =
                       time ~logger ~time_controller
                         "Build breadcrumb on produced block" (fun () ->
                           Breadcrumb.build ~logger ~precomputed_values
                             ~verifier ~trust_system ~parent:crumb ~transition
                             ~sender:None (* Consider skipping here *)
-                            ~skip_staged_ledger_verification:false () )
+                            ~skip_staged_ledger_verification:false
+                            ~transition_receipt_time () )
                       |> Deferred.Result.map_error ~f:(function
                            | `Invalid_staged_ledger_diff e ->
                                `Invalid_staged_ledger_diff
@@ -787,12 +789,14 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
                   ~logger ~frontier ~consensus_constants
             |> Deferred.return
           in
+          let transition_receipt_time = Core_kernel.Time.now () in
           let%bind breadcrumb =
             time ~logger ~time_controller
               "Build breadcrumb on produced block (precomputed)" (fun () ->
                 Breadcrumb.build ~logger ~precomputed_values ~verifier
                   ~trust_system ~parent:crumb ~transition ~sender:None
-                  ~skip_staged_ledger_verification:false ()
+                  ~skip_staged_ledger_verification:false
+                  ~transition_receipt_time ()
                 |> Deferred.Result.map_error ~f:(function
                      | `Invalid_staged_ledger_diff e ->
                          `Invalid_staged_ledger_diff (e, staged_ledger_diff)

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -904,10 +904,13 @@ let create ?wallets (config : Config.t) =
                         let k_block_hashes_and_timestamps =
                           List.map k_breadcrumbs ~f:(fun bc ->
                               ( Transition_frontier.Breadcrumb.state_hash bc
-                              , Time.to_string_iso8601_basic
-                                  ~zone:Time.Zone.utc
-                                @@ Transition_frontier.Breadcrumb
-                                   .transition_receipt_time bc ) )
+                              , Option.value_map
+                                  (Transition_frontier.Breadcrumb
+                                   .transition_receipt_time bc)
+                                  ~default:"no timestamp available"
+                                  ~f:
+                                    (Time.to_string_iso8601_basic
+                                       ~zone:Time.Zone.utc) ) )
                         in
                         (protocol_state_hash, k_block_hashes_and_timestamps)
                   in

--- a/src/lib/coda_lib/config.ml
+++ b/src/lib/coda_lib/config.ml
@@ -50,5 +50,6 @@ type t =
         [@default None]
   ; demo_mode: bool [@default false]
   ; log_block_creation: bool [@default false]
-  ; precomputed_values: Precomputed_values.t }
+  ; precomputed_values: Precomputed_values.t
+  ; start_time: Time.t }
 [@@deriving make]

--- a/src/lib/coda_lib/dune
+++ b/src/lib/coda_lib/dune
@@ -3,7 +3,7 @@
  (public_name coda_lib)
  (library_flags -linkall)
  (inline_tests)
- (libraries core coda_intf pipe_lib user_command_input logger async async_extra
+ (libraries core coda_intf coda_version pipe_lib user_command_input logger async async_extra
             unix_timestamp debug_assert o1trace consensus
             incremental secrets auxiliary_database work_selector
             coda_networking block_producer genesis_constants sync_handler transition_router node_addrs_and_ports

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -526,6 +526,7 @@ module Rpcs = struct
                     fun ip_addr -> `String (Unix.Inet_addr.to_string ip_addr)]
             ; node_peer_id: Network_peer.Peer.Id.Stable.V1.t
                   [@to_yojson fun peer_id -> `String peer_id]
+            ; sync_status: Sync_status.Stable.V1.t
             ; peers: Network_peer.Peer.Stable.V1.t list
             ; block_producers:
                 Signature_lib.Public_key.Compressed.Stable.V1.t list
@@ -535,7 +536,10 @@ module Rpcs = struct
                 * Trust_system.Peer_status.Stable.V1.t )
                 list
                   [@to_yojson yojson_of_ban_statuses]
-            ; k_block_hashes: State_hash.Stable.V1.t list }
+            ; k_block_hashes_and_timestamps:
+                (State_hash.Stable.V1.t * string) list
+            ; git_commit: string
+            ; uptime: string }
           [@@deriving to_yojson]
 
           let to_latest = Fn.id

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -1317,7 +1317,7 @@ let rpc_peer_then_random (type b) t peer_id input ~rpc :
     try_non_preferred_peers t input peers ~rpc
   in
   match%bind query_peer t peer_id rpc input with
-  | Connected {data= Ok (Some response); sender} ->
+  | Connected {data= Ok (Some response); sender; _} ->
       let%bind () =
         match sender with
         | Local ->
@@ -1330,7 +1330,7 @@ let rpc_peer_then_random (type b) t peer_id input ~rpc :
                   , Some ("Preferred peer returned valid response", []) ))
       in
       return (Ok (Envelope.Incoming.wrap ~data:response ~sender))
-  | Connected {data= Ok None; sender} ->
+  | Connected {data= Ok None; sender; _} ->
       let%bind () =
         match sender with
         | Remote peer ->
@@ -1344,7 +1344,7 @@ let rpc_peer_then_random (type b) t peer_id input ~rpc :
             return ()
       in
       retry ()
-  | Connected {data= Error e; sender} ->
+  | Connected {data= Error e; sender; _} ->
       (* FIXME #4094: determine if more specific actions apply here *)
       let%bind () =
         match sender with
@@ -1402,7 +1402,7 @@ let glue_sync_ledger :
           match%map
             query_peer t peer.peer_id Rpcs.Answer_sync_ledger_query query
           with
-          | Connected {data= Ok (Ok answer); sender} ->
+          | Connected {data= Ok (Ok answer); sender; _} ->
               [%log' trace t.logger]
                 !"Received answer from peer %{sexp: Peer.t} on ledger_hash \
                   %{sexp: Ledger_hash.t}"

--- a/src/lib/coda_networking/coda_networking.mli
+++ b/src/lib/coda_networking/coda_networking.mli
@@ -88,6 +88,7 @@ module Rpcs : sig
           type t =
             { node_ip_addr: Core.Unix.Inet_addr.Stable.V1.t
             ; node_peer_id: Peer.Id.Stable.V1.t
+            ; sync_status: Sync_status.Stable.V1.t
             ; peers: Network_peer.Peer.Stable.V1.t list
             ; block_producers:
                 Signature_lib.Public_key.Compressed.Stable.V1.t list
@@ -96,7 +97,10 @@ module Rpcs : sig
                 ( Network_peer.Peer.Stable.V1.t
                 * Trust_system.Peer_status.Stable.V1.t )
                 list
-            ; k_block_hashes: State_hash.Stable.V1.t list }
+            ; k_block_hashes_and_timestamps:
+                (State_hash.Stable.V1.t * string) list
+            ; git_commit: string
+            ; uptime: string }
         end
       end]
     end

--- a/src/lib/coda_networking/dune
+++ b/src/lib/coda_networking/dune
@@ -4,7 +4,8 @@
  (library_flags -linkall)
  (libraries core o1trace async coda_intf
             async_extra gossip_net coda_base unix_timestamp perf_histograms proof_carrying_data
-            consensus network_pool coda_transition transition_frontier staged_ledger)
+            consensus network_pool coda_transition transition_frontier staged_ledger
+            sync_status)
  (inline_tests)
  (preprocess
   (pps ppx_coda ppx_version ppx_inline_test ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_fields_conv ppx_let ppx_register_event ppx_custom_printf))

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -400,7 +400,9 @@ let verify_transitions_and_build_breadcrumbs ~logger
       | Ok tvs ->
           return
             (Ok
-               (List.map2_exn transitions tvs ~f:(fun e data -> {e with data})))
+               (List.map2_exn transitions tvs ~f:(fun e data ->
+                    (* this does not update the envelope timestamps *)
+                    {e with data} )))
       | Error (`Verifier_error error) ->
           [%log warn]
             ~metadata:[("error", Error_json.error_to_yojson error)]

--- a/src/lib/network_peer/envelope.mli
+++ b/src/lib/network_peer/envelope.mli
@@ -7,12 +7,14 @@ module Sender : sig
 end
 
 module Incoming : sig
-  type 'a t = {data: 'a; sender: Sender.t}
+  type 'a t = {data: 'a; sender: Sender.t; received_at: Time.t}
   [@@deriving eq, sexp, yojson, compare]
 
   val sender : 'a t -> Sender.t
 
   val data : 'a t -> 'a
+
+  val received_at : 'a t -> Time.t
 
   val wrap : data:'a -> sender:Sender.t -> 'a t
 

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -352,9 +352,9 @@ module Make (Transition_frontier : Transition_frontier_intf) = struct
                     ~f:(fun (_, s) -> log_and_punish ?punish s e)
                 in
                 let proof_env =
-                  { Envelope.Incoming.data=
-                      (One_or_two.map proofs ~f:fst, message)
-                  ; sender }
+                  Envelope.Incoming.wrap
+                    ~data:(One_or_two.map proofs ~f:fst, message)
+                    ~sender
                 in
                 match%bind Batcher.Snark_pool.verify t.batcher proof_env with
                 | Ok true ->
@@ -537,7 +537,7 @@ let%test_module "random set test" =
         Mock_snark_pool.Resource_pool.Diff.Add_solved_work
           (work, {Priced_proof.Stable.Latest.proof= proof work; fee})
       in
-      let enveloped_diff = {Envelope.Incoming.data= diff; sender} in
+      let enveloped_diff = Envelope.Incoming.wrap ~data:diff ~sender in
       match%bind
         Mock_snark_pool.Resource_pool.Diff.verify resource_pool enveloped_diff
       with

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -94,7 +94,7 @@ module Make
       | _ ->
           failwith "compare didn't return -1, 0, or 1!" )
 
-  let verify pool ({data; sender} as t : t Envelope.Incoming.t) =
+  let verify pool ({data; sender; _} as t : t Envelope.Incoming.t) =
     let (Add_solved_work (work, ({Priced_proof.fee; _} as p))) = data in
     let is_local = match sender with Local -> true | _ -> false in
     let verify () =
@@ -115,7 +115,7 @@ module Make
 
   (* This is called after verification has occurred.*)
   let unsafe_apply (pool : Pool.t) (t : t Envelope.Incoming.t) =
-    let {Envelope.Incoming.data= diff; sender} = t in
+    let {Envelope.Incoming.data= diff; sender; _} = t in
     let is_local = match sender with Local -> true | _ -> false in
     let to_or_error = function
       | `Statement_not_referenced ->

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -24,7 +24,7 @@ val create :
      validated_transition:External_transition.Validated.t
   -> staged_ledger:Staged_ledger.t
   -> just_emitted_a_proof:bool
-  -> transition_receipt_time:Time.t
+  -> transition_receipt_time:Time.t option
   -> t
 
 val build :
@@ -36,7 +36,7 @@ val build :
   -> parent:t
   -> transition:External_transition.Almost_validated.t
   -> sender:Envelope.Sender.t option
-  -> transition_receipt_time:Time.t
+  -> transition_receipt_time:Time.t option
   -> unit
   -> ( t
      , [> `Invalid_staged_ledger_diff of Error.t
@@ -51,7 +51,7 @@ val staged_ledger : t -> Staged_ledger.t
 
 val just_emitted_a_proof : t -> bool
 
-val transition_receipt_time : t -> Time.t
+val transition_receipt_time : t -> Time.t option
 
 val hash : t -> int
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -24,6 +24,7 @@ val create :
      validated_transition:External_transition.Validated.t
   -> staged_ledger:Staged_ledger.t
   -> just_emitted_a_proof:bool
+  -> transition_receipt_time:Time.t
   -> t
 
 val build :
@@ -35,6 +36,7 @@ val build :
   -> parent:t
   -> transition:External_transition.Almost_validated.t
   -> sender:Envelope.Sender.t option
+  -> transition_receipt_time:Time.t
   -> unit
   -> ( t
      , [> `Invalid_staged_ledger_diff of Error.t
@@ -48,6 +50,8 @@ val validated_transition : t -> External_transition.Validated.t
 val staged_ledger : t -> Staged_ledger.t
 
 val just_emitted_a_proof : t -> bool
+
+val transition_receipt_time : t -> Time.t
 
 val hash : t -> int
 

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -105,7 +105,7 @@ let close ~loc t =
 let create ~logger ~root_data ~root_ledger ~consensus_local_state ~max_length
     ~precomputed_values =
   let open Root_data in
-  let transition_receipt_time = Time.now () in
+  let transition_receipt_time = Some (Time.now ()) in
   let root_hash =
     External_transition.Validated.state_hash root_data.transition
   in

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -105,7 +105,7 @@ let close ~loc t =
 let create ~logger ~root_data ~root_ledger ~consensus_local_state ~max_length
     ~precomputed_values =
   let open Root_data in
-  let transition_receipt_time = Some (Time.now ()) in
+  let transition_receipt_time = None in
   let root_hash =
     External_transition.Validated.state_hash root_data.transition
   in

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -105,6 +105,7 @@ let close ~loc t =
 let create ~logger ~root_data ~root_ledger ~consensus_local_state ~max_length
     ~precomputed_values =
   let open Root_data in
+  let transition_receipt_time = Time.now () in
   let root_hash =
     External_transition.Validated.state_hash root_data.transition
   in
@@ -128,6 +129,7 @@ let create ~logger ~root_data ~root_ledger ~consensus_local_state ~max_length
   let root_breadcrumb =
     Breadcrumb.create ~validated_transition:root_data.transition
       ~staged_ledger:root_data.staged_ledger ~just_emitted_a_proof:false
+      ~transition_receipt_time
   in
   let root_node =
     {Node.breadcrumb= root_breadcrumb; successor_hashes= []; length= 0}
@@ -451,6 +453,8 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
       ~staged_ledger:new_staged_ledger
       ~just_emitted_a_proof:
         (Breadcrumb.just_emitted_a_proof new_root_node.breadcrumb)
+      ~transition_receipt_time:
+        (Breadcrumb.transition_receipt_time new_root_node.breadcrumb)
   in
   (*Update the protocol states required for scan state at the new root.
   Note: this should be after applying the transactions to the snarked ledger (Step 5)

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -281,7 +281,10 @@ module Instance = struct
                    Error (`Fatal_error (Invalid_genesis_state_hash transition))
                    |> Deferred.return
              in
-             let transition_receipt_time = Time.now () in
+             (* we're loading transitions from persistent storage,
+                don't assign a timestamp
+             *)
+             let transition_receipt_time = None in
              let%bind breadcrumb =
                Breadcrumb.build ~skip_staged_ledger_verification:true
                  ~logger:t.factory.logger ~precomputed_values

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -281,12 +281,13 @@ module Instance = struct
                    Error (`Fatal_error (Invalid_genesis_state_hash transition))
                    |> Deferred.return
              in
+             let transition_receipt_time = Time.now () in
              let%bind breadcrumb =
                Breadcrumb.build ~skip_staged_ledger_verification:true
                  ~logger:t.factory.logger ~precomputed_values
                  ~verifier:t.factory.verifier
                  ~trust_system:(Trust_system.null ()) ~parent ~transition
-                 ~sender:None ()
+                 ~sender:None ~transition_receipt_time ()
              in
              let%map () = apply_diff Diff.(E (New_node (Full breadcrumb))) in
              breadcrumb ))

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -469,7 +469,7 @@ module For_tests = struct
                 ~pids:(Child_processes.Termination.create_pid_table ()) )
     in
     Quickcheck.Generator.create (fun ~size:_ ~random:_ ->
-        let transition_receipt_time = Time.now () in
+        let transition_receipt_time = Some (Time.now ()) in
         let genesis_transition =
           External_transition.For_tests.genesis ~precomputed_values
         in

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -469,6 +469,7 @@ module For_tests = struct
                 ~pids:(Child_processes.Termination.create_pid_table ()) )
     in
     Quickcheck.Generator.create (fun ~size:_ ~random:_ ->
+        let transition_receipt_time = Time.now () in
         let genesis_transition =
           External_transition.For_tests.genesis ~precomputed_values
         in
@@ -500,7 +501,8 @@ module For_tests = struct
                    ~expected_merkle_root:(Ledger.merkle_root genesis_ledger) ))
         in
         Breadcrumb.create ~validated_transition:genesis_transition
-          ~staged_ledger:genesis_staged_ledger ~just_emitted_a_proof:false )
+          ~staged_ledger:genesis_staged_ledger ~just_emitted_a_proof:false
+          ~transition_receipt_time )
 
   let gen_persistence ?(logger = Logger.null ()) ?verifier
       ~(precomputed_values : Precomputed_values.t) () =

--- a/src/lib/transition_handler/breadcrumb_builder.ml
+++ b/src/lib/transition_handler/breadcrumb_builder.ml
@@ -61,7 +61,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                 let transition_with_initial_validation =
                   Envelope.Incoming.data enveloped_transition
                 in
-                let transition_receipt_time = Time.now () in
+                let transition_receipt_time = Some (Time.now ()) in
                 let transition_with_hash, _ =
                   transition_with_initial_validation
                 in

--- a/src/lib/transition_handler/breadcrumb_builder.ml
+++ b/src/lib/transition_handler/breadcrumb_builder.ml
@@ -12,7 +12,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
       "Transition frontier already garbage-collected the parent of %s"
       (Coda_base.State_hash.to_base58_check initial_hash)
   in
-  (* If the breadcrumb we are targetting is removed from the transition
+  (* If the breadcrumb we are targeting is removed from the transition
    * frontier while we're catching up, it means this path is not on the
    * critical path that has been chosen in the frontier. As such, we should
    * drop it on the floor. *)
@@ -61,6 +61,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                 let transition_with_initial_validation =
                   Envelope.Incoming.data enveloped_transition
                 in
+                let transition_receipt_time = Time.now () in
                 let transition_with_hash, _ =
                   transition_with_initial_validation
                 in
@@ -98,7 +99,8 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                           Transition_frontier.Breadcrumb.build ~logger
                             ~precomputed_values ~verifier ~trust_system ~parent
                             ~transition:mostly_validated_transition
-                            ~sender:(Some sender) () ) )
+                            ~sender:(Some sender) ~transition_receipt_time ()
+                      ) )
                 with
                 | Error _ ->
                     Deferred.return @@ Or_error.error_string missing_parent_msg

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -84,7 +84,7 @@ let add_and_finalize ~logger ~frontier ~catchup_scheduler
 let process_transition ~logger ~trust_system ~verifier ~frontier
     ~catchup_scheduler ~processed_transition_writer ~time_controller
     ~transition:cached_initially_validated_transition ~precomputed_values =
-  let transition_receipt_time = Time.now () in
+  let transition_receipt_time = Some (Time.now ()) in
   let enveloped_initially_validated_transition =
     Cached.peek cached_initially_validated_transition
   in

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -84,6 +84,7 @@ let add_and_finalize ~logger ~frontier ~catchup_scheduler
 let process_transition ~logger ~trust_system ~verifier ~frontier
     ~catchup_scheduler ~processed_transition_writer ~time_controller
     ~transition:cached_initially_validated_transition ~precomputed_values =
+  let transition_receipt_time = Time.now () in
   let enveloped_initially_validated_transition =
     Cached.peek cached_initially_validated_transition
   in
@@ -175,8 +176,8 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
       cached_transform_deferred_result cached_initially_validated_transition
         ~transform_cached:(fun _ ->
           Transition_frontier.Breadcrumb.build ~logger ~precomputed_values
-            ~verifier ~trust_system ~sender:(Some sender)
-            ~parent:parent_breadcrumb
+            ~verifier ~trust_system ~transition_receipt_time
+            ~sender:(Some sender) ~parent:parent_breadcrumb
             ~transition:
               mostly_validated_transition (* TODO: Can we skip here? *)
             ~skip_staged_ledger_verification:false () )
@@ -262,7 +263,7 @@ let run ~logger ~(precomputed_values : Precomputed_values.t) ~verifier
   ignore
     (Reader.Merge.iter
        (* It is fine to skip the cache layer on blocks produced by this node
-        * because it is extradornarily unlikely we would write an internal bug
+        * because it is extraordinarily unlikely we would write an internal bug
         * triggering this case, and the external case (where we received an
         * identical external transition from the network) can happen iff there
         * is another node with the exact same private key and view of the

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -84,9 +84,12 @@ let add_and_finalize ~logger ~frontier ~catchup_scheduler
 let process_transition ~logger ~trust_system ~verifier ~frontier
     ~catchup_scheduler ~processed_transition_writer ~time_controller
     ~transition:cached_initially_validated_transition ~precomputed_values =
-  let transition_receipt_time = Some (Time.now ()) in
   let enveloped_initially_validated_transition =
     Cached.peek cached_initially_validated_transition
+  in
+  let transition_receipt_time =
+    Some
+      (Envelope.Incoming.received_at enveloped_initially_validated_transition)
   in
   let sender =
     Envelope.Incoming.sender enveloped_initially_validated_transition


### PR DESCRIPTION
Add more data fields to the telemetry response, namely, `sync_status`, `git_commit`, and `uptime`. The `k_block_hashes` field becomes `k_block_hashes_and_timestamps`, a list of hash, timestamp pairs.

If the `advanced telemetry` RPC call to the daemon fails, the response is now in JSON format, of the form `{ "error": "..." }`, which matches the error response JSON handled by the network health scrript.

The timestamps are from a new field `transition_receipt_time` in `Breadcrumb.t`. I'm not so confident that those values are being generated correctly, so reviewers should examine them carefully.

Another concern is the format of the timestamps. Here's a generated hash, timestamp pair:
```
["3NLn77QMZFSz6rQ6mnvFR34Bf56fYTUJKYMB4mKRdB1cPdELFcNi","2020-12-09T20:52:41.828994Z"]
```
The time is UTC and uses the ISO8601 format. Look OK?

Tested by running a local network.

Closes #6970.

Update 1: The breadcrumb timestamp is an option type, which prints as "no timestamp available" in the telemetry if the value is `None`.

Update 2: added field `received_at` to `Envelope.Incoming.t`. The timestamp is added when calling `wrap`, `wrap_peer`, or `local`. I thought about exposing only an opaque type, and forcing the use of combinators, but there is lots of code that pattern matches on the type. This change may well be useful beyond this PR.


