### PR TITLE
Report missing blocks in archive db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,11 @@ replayer :
 	ulimit -s 65532 && (ulimit -n 10240 || true) && dune build src/app/replayer/replayer.exe --profile=testnet_postake_medium_curves
 	$(info Build complete)
 
+missing_blocks_auditor :
+	$(info Starting Build)
+	ulimit -s 65532 && (ulimit -n 10240 || true) && dune build src/app/missing_blocks_auditor/missing_blocks_auditor.exe --profile=testnet_postake_medium_curves
+	$(info Build complete)
+
 dev: codabuilder containerstart build
 
 # update OPAM, pinned packages in Docker

--- a/src/app/missing_blocks_auditor/dune
+++ b/src/app/missing_blocks_auditor/dune
@@ -1,0 +1,15 @@
+(executable
+ (package missing_blocks_auditor)
+ (name missing_blocks_auditor)
+ (public_name missing_blocks_auditor)
+ (libraries
+   async
+   core_kernel
+   caqti
+   caqti-async
+   caqti-driver-postgresql
+   logger
+ )
+ (preprocessor_deps ../../config.mlh)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_coda ppx_version ppx_let)))

--- a/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
+++ b/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
@@ -1,0 +1,50 @@
+(* missing_blocks_auditor.ml -- report missing blocks from an archive db *)
+
+open Core_kernel
+open Async
+
+let main ~archive_uri () =
+  let logger = Logger.create () in
+  let archive_uri = Uri.of_string archive_uri in
+  match Caqti_async.connect_pool ~max_size:128 archive_uri with
+  | Error e ->
+      [%log fatal]
+        ~metadata:[("error", `String (Caqti_error.show e))]
+        "Failed to create a Caqti pool for Postgresql" ;
+      exit 1
+  | Ok pool ->
+      [%log info] "Successfully created Caqti pool for Postgresql" ;
+      [%log info] "Querying missing blocks" ;
+      let%map missing_blocks =
+        match%bind
+          Caqti_async.Pool.use (fun db -> Sql.Unparented_blocks.run db ()) pool
+        with
+        | Ok blocks ->
+            return blocks
+        | Error msg ->
+            [%log error] "Error getting missing blocks"
+              ~metadata:[("error", `String (Caqti_error.show msg))] ;
+            exit 1
+      in
+      List.iter missing_blocks ~f:(fun (block_id, state_hash, parent_hash) ->
+          [%log info] "Block has no parent in archive db"
+            ~metadata:
+              [ ("block_id", `Int block_id)
+              ; ("state_hash", `String state_hash)
+              ; ("parent_hash", `String parent_hash) ] ) ;
+      ()
+
+let () =
+  Command.(
+    run
+      (let open Let_syntax in
+      Command.async
+        ~summary:"Report state hashes of blocks missing from archive database"
+        (let%map archive_uri =
+           Param.flag "--archive-uri"
+             ~doc:
+               "URI URI for connecting to the archive database (e.g., \
+                postgres://$USER:$USER@localhost:5432/archiver)"
+             Param.(required string)
+         in
+         main ~archive_uri)))

--- a/src/app/missing_blocks_auditor/sql.ml
+++ b/src/app/missing_blocks_auditor/sql.ml
@@ -1,0 +1,16 @@
+(* sql.ml -- (Postgresql) SQL queries for missing blocks auditor *)
+
+module Unparented_blocks = struct
+  (* state hashes of ends of chains leading to an orphan block *)
+
+  let query =
+    Caqti_request.collect Caqti_type.unit
+      Caqti_type.(tup3 int string string)
+      {|
+           SELECT id,state_hash,parent_hash FROM blocks
+           WHERE parent_id IS NULL
+      |}
+
+  let run (module Conn : Caqti_async.CONNECTION) () =
+    Conn.collect_list query ()
+end

--- a/src/app/missing_blocks_auditor/sql.ml
+++ b/src/app/missing_blocks_auditor/sql.ml
@@ -1,7 +1,7 @@
 (* sql.ml -- (Postgresql) SQL queries for missing blocks auditor *)
 
 module Unparented_blocks = struct
-  (* state hashes of ends of chains leading to an orphan block *)
+  (* parent_hashes represent ends of chains leading to an orphan block *)
 
   let query =
     Caqti_request.collect Caqti_type.unit

--- a/src/missing_blocks_auditor.opam
+++ b/src/missing_blocks_auditor.opam
@@ -1,0 +1,5 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]


### PR DESCRIPTION
App to report missing blocks in archive db. A block is missing if the `parent_id` field of `blocks` is `NULL`.

There's a Makefile target to build it with `postake_medium_curves`.

Tested against archive db created by Rosetta.

Sample output:
```
{"timestamp":"2020-12-09 23:33:59.960871Z","level":"Info","source":{"module":"Dune__exe__Missing_blocks_auditor","location":"File \"src/app/missing_blocks_auditor/missing_blocks_auditor.ml\", line 30, characters 10-21"},"message":"Block has no parent in archive db","metadata":{"block_id":1,"parent_hash":"3NK9z26joBvSDZswiLVjHp3Y3c9t4vq7P8H5JCk4QpSLL9sXMPMb","pid":94199,"state_hash":"3NL52BwYWhu6oHPY5YAWsUmFtcuCJJ7BCifUxgq2Wo9CwNdgiedA"}}
```
We'd use the reported `parent_hash`es as the ends of missing subchains.

Closes #6912.