### PR TITLE
Synchronize validation channel in libp2p_helper

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -428,7 +428,7 @@ func (s *subscribeMsg) run(app *app) (interface{}, error) {
 		}
 
 		seqno := <-seqs
-		ch := make(chan string, 1)
+		ch := make(chan string)
 		app.ValidatorMutex.Lock()
 		app.Validators[seqno] = new(validationStatus)
 		(*app.Validators[seqno]).Completion = ch


### PR DESCRIPTION
Fixes a race condition we observed on one of our block producers.