### PR TITLE
Fix Peer_banned structured log message

### DIFF
--- a/src/lib/trust_system/peer_trust.mli
+++ b/src/lib/trust_system/peer_trust.mli
@@ -38,7 +38,7 @@ val max_rate : float -> float
 
 type Structured_log_events.t +=
   | Peer_banned of
-      { peer: Network_peer.Peer.t
+      { sender_id: Network_peer.Peer.t
       ; expiration: Time.t
       ; action: string }
   [@@deriving register_event]


### PR DESCRIPTION
This fixes a crash by renaming the `peer` field to `sender_id`, so that it matches `ban_message` . See e.g. https://buildkite.com/o-1-labs-2/mina/builds/7332#b2ac1ae0-5e43-4b0f-8df9-b0fecfcdd27d

We should might have been able to catch this in `ppx_register_event`, which is far preferable to a crash a runtime. @psteckler any ideas?

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: