### PR TITLE
Add more telemetry data (against until-4.1-hardfork)

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -929,6 +929,7 @@ Pass one of -peer, -peer-list-file, -seed.|} ;
         Coda_run.get_proposed_protocol_version_opt ~conf_dir ~logger
           proposed_protocol_version
       in
+      let start_time = Time.now () in
       let%map coda =
         Coda_lib.create ~wallets
           (Coda_lib.Config.make ~logger ~pids ~trust_system ~conf_dir ~chain_id
@@ -953,7 +954,7 @@ Pass one of -peer, -peer-list-file, -seed.|} ;
              ~time_controller ~initial_block_production_keypairs ~monitor
              ~consensus_local_state ~is_archive_rocksdb ~work_reassignment_wait
              ~archive_process_location ~log_block_creation ~precomputed_values
-             ())
+             ~start_time ())
       in
       {Coda_initialization.coda; client_trustlist; rest_server_port}
     in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1659,8 +1659,9 @@ let telemetry =
                    @@ Coda_networking.Rpcs.Get_telemetry_data
                       .response_to_yojson peer_telem_data ) )
          | Error err ->
-             printf "Failed to get telemetry data: %s\n%!"
-               (Error.to_string_hum err) ))
+             printf "%s\n%!"
+               (Yojson.Safe.to_string
+                  (`Assoc [("error", Error_json.error_to_yojson err)])) ))
 
 let next_available_token_cmd =
   Command.async

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -446,6 +446,7 @@ module T = struct
           let with_monitor f input =
             Async.Scheduler.within' ~monitor (fun () -> f input)
           in
+          let start_time = Time.now () in
           let coda_deferred () =
             Coda_lib.create
               (Coda_lib.Config.make ~logger ~pids ~trust_system ~conf_dir
@@ -469,7 +470,7 @@ module T = struct
                  ~time_controller ~snark_work_fee:(Currency.Fee.of_int 0)
                  ~initial_block_production_keypairs ~monitor
                  ~consensus_local_state ~is_archive_rocksdb
-                 ~work_reassignment_wait:420000 ~precomputed_values
+                 ~work_reassignment_wait:420000 ~precomputed_values ~start_time
                  ~archive_process_location:
                    (Option.map archive_process_location
                       ~f:(fun host_and_port ->

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -178,6 +178,7 @@ let run_test () : unit Deferred.t =
       let snark_work_fee, transaction_fee =
         if with_snark then (fee 0, fee 0) else (fee 100, fee 200)
       in
+      let start_time = Time.now () in
       let%bind coda =
         Coda_lib.create
           (Coda_lib.Config.make ~logger ~pids ~trust_system ~net_config
@@ -201,7 +202,7 @@ let run_test () : unit Deferred.t =
              ~persistent_frontier_location:(temp_conf_dir ^/ "frontier")
              ~epoch_ledger_location ~time_controller ~snark_work_fee
              ~consensus_local_state ~work_reassignment_wait:420000
-             ~precomputed_values ())
+             ~precomputed_values ~start_time ())
       in
       don't_wait_for
         (Strict_pipe.Reader.iter_without_pushback

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -524,13 +524,17 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                             ~consensus_constants
                       |> Deferred.return
                     in
+                    let transition_receipt_time =
+                      Some (Core_kernel.Time.now ())
+                    in
                     let%bind breadcrumb =
                       time ~logger ~time_controller
                         "Build breadcrumb on produced block" (fun () ->
                           Breadcrumb.build ~logger ~precomputed_values
                             ~verifier ~trust_system ~parent:crumb ~transition
                             ~sender:None (* Consider skipping here *)
-                            ~skip_staged_ledger_verification:false () )
+                            ~skip_staged_ledger_verification:false
+                            ~transition_receipt_time () )
                       |> Deferred.Result.map_error ~f:(function
                            | `Invalid_staged_ledger_diff e ->
                                `Invalid_staged_ledger_diff
@@ -804,12 +808,14 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
                   ~logger ~frontier ~consensus_constants
             |> Deferred.return
           in
+          let transition_receipt_time = None in
           let%bind breadcrumb =
             time ~logger ~time_controller
               "Build breadcrumb on produced block (precomputed)" (fun () ->
                 Breadcrumb.build ~logger ~precomputed_values ~verifier
                   ~trust_system ~parent:crumb ~transition ~sender:None
-                  ~skip_staged_ledger_verification:false ()
+                  ~skip_staged_ledger_verification:false
+                  ~transition_receipt_time ()
                 |> Deferred.Result.map_error ~f:(function
                      | `Invalid_staged_ledger_diff e ->
                          `Invalid_staged_ledger_diff (e, staged_ledger_diff)

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -842,8 +842,9 @@ let create ?wallets (config : Config.t) =
                 in
                 f ~frontier input )
           in
-          (* knot-tying hack so we can pass a get_telemetry function before net created *)
+          (* knot-tying hacks so we can pass a get_telemetry function before net, Coda_lib.t created *)
           let net_ref = ref None in
+          let sync_status_ref = ref None in
           let get_telemetry_data _env =
             let node_ip_addr =
               config.gossip_net_params.addrs_and_ports.external_ip
@@ -864,7 +865,7 @@ let create ?wallets (config : Config.t) =
             else
               match !net_ref with
               | None ->
-                  (* essentially unreachable; without a network, we wouldn't receive this RPC call *)
+                  (* should be unreachable; without a network, we wouldn't receive this RPC call *)
                   [%log' info config.logger]
                     "Network not instantiated when telemetry data requested" ;
                   Deferred.return
@@ -876,7 +877,7 @@ let create ?wallets (config : Config.t) =
                                instantiated when telemetry data requested"
                              node_ip_addr node_peer_id))
               | Some net ->
-                  let protocol_state_hash, k_block_hashes =
+                  let protocol_state_hash, k_block_hashes_and_timestamps =
                     match
                       Broadcast_pipe.Reader.peek frontier_broadcast_pipe_r
                     with
@@ -892,15 +893,33 @@ let create ?wallets (config : Config.t) =
                           in
                           Coda_state.Protocol_state.hash state
                         in
-                        let k_block_hashes =
-                          List.map
-                            ( Transition_frontier.root frontier
-                            :: Transition_frontier.best_tip_path frontier )
-                            ~f:Transition_frontier.Breadcrumb.state_hash
+                        let k_breadcrumbs =
+                          Transition_frontier.root frontier
+                          :: Transition_frontier.best_tip_path frontier
                         in
-                        (protocol_state_hash, k_block_hashes)
+                        let k_block_hashes_and_timestamps =
+                          List.map k_breadcrumbs ~f:(fun bc ->
+                              ( Transition_frontier.Breadcrumb.state_hash bc
+                              , Option.value_map
+                                  (Transition_frontier.Breadcrumb
+                                   .transition_receipt_time bc)
+                                  ~default:"no timestamp available"
+                                  ~f:
+                                    (Time.to_string_iso8601_basic
+                                       ~zone:Time.Zone.utc) ) )
+                        in
+                        (protocol_state_hash, k_block_hashes_and_timestamps)
                   in
-                  let%map peers = Coda_networking.peers net in
+                  let%bind peers = Coda_networking.peers net in
+                  let open Deferred.Or_error.Let_syntax in
+                  let%map sync_status =
+                    match !sync_status_ref with
+                    | None ->
+                        Deferred.return (Ok `Offline)
+                    | Some status ->
+                        Deferred.return
+                          (Coda_incremental.Status.Observer.value status)
+                  in
                   let block_producers =
                     config.initial_block_production_keypairs
                     |> Keypair.Set.to_list
@@ -910,20 +929,27 @@ let create ?wallets (config : Config.t) =
                   let ban_statuses =
                     Trust_system.Peer_trust.peer_statuses config.trust_system
                   in
-                  Ok
-                    Coda_networking.Rpcs.Get_telemetry_data.Telemetry_data.
-                      { node_ip_addr
-                      ; node_peer_id
-                      ; peers
-                      ; block_producers
-                      ; protocol_state_hash
-                      ; ban_statuses
-                      ; k_block_hashes }
+                  let git_commit = Coda_version.commit_id_short in
+                  let uptime =
+                    Time.diff (Time.now ()) config.start_time
+                    |> Time.Span.to_string_hum ~decimals:1
+                  in
+                  Coda_networking.Rpcs.Get_telemetry_data.Telemetry_data.
+                    { node_ip_addr
+                    ; node_peer_id
+                    ; sync_status
+                    ; peers
+                    ; block_producers
+                    ; protocol_state_hash
+                    ; ban_statuses
+                    ; k_block_hashes_and_timestamps
+                    ; git_commit
+                    ; uptime }
           in
           let get_some_initial_peers _ =
             match !net_ref with
             | None ->
-                (* essentially unreachable; without a network, we wouldn't receive this RPC call *)
+                (* should be unreachable; without a network, we wouldn't receive this RPC call *)
                 [%log' error config.logger]
                   "Network not instantiated when initial peers requested" ;
                 Deferred.return []
@@ -1010,7 +1036,7 @@ let create ?wallets (config : Config.t) =
                 (handle_request "get_transition_chain"
                    ~f:Sync_handler.get_transition_chain)
           in
-          (* tie the knot *)
+          (* tie the first knot *)
           net_ref := Some net ;
           let user_command_input_reader, user_command_input_writer =
             Strict_pipe.(create ~name:"local transactions" Synchronous)
@@ -1321,6 +1347,8 @@ let create ?wallets (config : Config.t) =
                 ( Var.watch @@ of_deferred
                 @@ Coda_networking.on_first_received_message net ~f:Fn.id )
           in
+          (* tie other knot *)
+          sync_status_ref := Some sync_status ;
           Deferred.return
             { config
             ; next_producer_timing= None

--- a/src/lib/coda_lib/config.ml
+++ b/src/lib/coda_lib/config.ml
@@ -47,5 +47,6 @@ type t =
         [@default None]
   ; demo_mode: bool [@default false]
   ; log_block_creation: bool [@default false]
-  ; precomputed_values: Precomputed_values.t }
+  ; precomputed_values: Precomputed_values.t
+  ; start_time: Time.t }
 [@@deriving make]

--- a/src/lib/coda_lib/dune
+++ b/src/lib/coda_lib/dune
@@ -3,7 +3,7 @@
  (public_name coda_lib)
  (library_flags -linkall)
  (inline_tests)
- (libraries core coda_intf pipe_lib user_command_input logger async async_extra
+ (libraries core coda_intf coda_version pipe_lib user_command_input logger async async_extra
             filtered_external_transition unix_timestamp debug_assert o1trace consensus
             incremental secrets work_selector coda_networking block_producer
             genesis_constants sync_handler transition_router node_addrs_and_ports

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -531,6 +531,7 @@ module Rpcs = struct
                     fun ip_addr -> `String (Unix.Inet_addr.to_string ip_addr)]
             ; node_peer_id: Network_peer.Peer.Id.Stable.V1.t
                   [@to_yojson fun peer_id -> `String peer_id]
+            ; sync_status: Sync_status.Stable.V1.t
             ; peers: Network_peer.Peer.Stable.V1.t list
             ; block_producers:
                 Signature_lib.Public_key.Compressed.Stable.V1.t list
@@ -540,7 +541,10 @@ module Rpcs = struct
                 * Trust_system.Peer_status.Stable.V1.t )
                 list
                   [@to_yojson yojson_of_ban_statuses]
-            ; k_block_hashes: State_hash.Stable.V1.t list }
+            ; k_block_hashes_and_timestamps:
+                (State_hash.Stable.V1.t * string) list
+            ; git_commit: string
+            ; uptime: string }
           [@@deriving to_yojson]
 
           let to_latest = Fn.id
@@ -1321,7 +1325,7 @@ let rpc_peer_then_random (type b) t peer_id input ~rpc :
     try_non_preferred_peers t input peers ~rpc
   in
   match%bind query_peer t peer_id rpc input with
-  | Connected {data= Ok (Some response); sender} ->
+  | Connected {data= Ok (Some response); sender; _} ->
       let%bind () =
         match sender with
         | Local ->
@@ -1334,7 +1338,7 @@ let rpc_peer_then_random (type b) t peer_id input ~rpc :
                   , Some ("Preferred peer returned valid response", []) ))
       in
       return (Ok (Envelope.Incoming.wrap ~data:response ~sender))
-  | Connected {data= Ok None; sender} ->
+  | Connected {data= Ok None; sender; _} ->
       let%bind () =
         match sender with
         | Remote peer ->
@@ -1348,7 +1352,7 @@ let rpc_peer_then_random (type b) t peer_id input ~rpc :
             return ()
       in
       retry ()
-  | Connected {data= Error e; sender} ->
+  | Connected {data= Error e; sender; _} ->
       (* FIXME #4094: determine if more specific actions apply here *)
       let%bind () =
         match sender with
@@ -1406,7 +1410,7 @@ let glue_sync_ledger :
           match%map
             query_peer t peer.peer_id Rpcs.Answer_sync_ledger_query query
           with
-          | Connected {data= Ok (Ok answer); sender} ->
+          | Connected {data= Ok (Ok answer); sender; _} ->
               [%log' trace t.logger]
                 !"Received answer from peer %{sexp: Peer.t} on ledger_hash \
                   %{sexp: Ledger_hash.t}"

--- a/src/lib/coda_networking/coda_networking.mli
+++ b/src/lib/coda_networking/coda_networking.mli
@@ -89,6 +89,7 @@ module Rpcs : sig
           type t =
             { node_ip_addr: Core.Unix.Inet_addr.Stable.V1.t
             ; node_peer_id: Peer.Id.Stable.V1.t
+            ; sync_status: Sync_status.Stable.V1.t
             ; peers: Network_peer.Peer.Stable.V1.t list
             ; block_producers:
                 Signature_lib.Public_key.Compressed.Stable.V1.t list
@@ -97,7 +98,10 @@ module Rpcs : sig
                 ( Network_peer.Peer.Stable.V1.t
                 * Trust_system.Peer_status.Stable.V1.t )
                 list
-            ; k_block_hashes: State_hash.Stable.V1.t list }
+            ; k_block_hashes_and_timestamps:
+                (State_hash.Stable.V1.t * string) list
+            ; git_commit: string
+            ; uptime: string }
         end
       end]
     end

--- a/src/lib/coda_networking/dune
+++ b/src/lib/coda_networking/dune
@@ -4,7 +4,8 @@
  (library_flags -linkall)
  (libraries core o1trace async coda_intf
             async_extra gossip_net coda_base unix_timestamp perf_histograms proof_carrying_data
-            consensus network_pool coda_transition transition_frontier staged_ledger)
+            consensus network_pool coda_transition transition_frontier staged_ledger
+            sync_status)
  (inline_tests)
  (preprocess
   (pps ppx_coda ppx_version ppx_inline_test ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_fields_conv ppx_let ppx_register_event ppx_custom_printf))

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -400,7 +400,9 @@ let verify_transitions_and_build_breadcrumbs ~logger
       | Ok tvs ->
           return
             (Ok
-               (List.map2_exn transitions tvs ~f:(fun e data -> {e with data})))
+               (List.map2_exn transitions tvs ~f:(fun e data ->
+                    (* this does not update the envelope timestamps *)
+                    {e with data} )))
       | Error (`Verifier_error error) ->
           [%log warn]
             ~metadata:[("error", Error_json.error_to_yojson error)]

--- a/src/lib/network_peer/envelope.mli
+++ b/src/lib/network_peer/envelope.mli
@@ -7,12 +7,14 @@ module Sender : sig
 end
 
 module Incoming : sig
-  type 'a t = {data: 'a; sender: Sender.t}
+  type 'a t = {data: 'a; sender: Sender.t; received_at: Time.t}
   [@@deriving eq, sexp, yojson, compare]
 
   val sender : 'a t -> Sender.t
 
   val data : 'a t -> 'a
+
+  val received_at : 'a t -> Time.t
 
   val wrap : data:'a -> sender:Sender.t -> 'a t
 

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -352,9 +352,9 @@ module Make (Transition_frontier : Transition_frontier_intf) = struct
                     ~f:(fun (_, s) -> log_and_punish ?punish s e)
                 in
                 let proof_env =
-                  { Envelope.Incoming.data=
-                      (One_or_two.map proofs ~f:fst, message)
-                  ; sender }
+                  Envelope.Incoming.wrap
+                    ~data:(One_or_two.map proofs ~f:fst, message)
+                    ~sender
                 in
                 match%bind Batcher.Snark_pool.verify t.batcher proof_env with
                 | Ok true ->
@@ -539,7 +539,7 @@ let%test_module "random set test" =
         Mock_snark_pool.Resource_pool.Diff.Add_solved_work
           (work, {Priced_proof.Stable.Latest.proof= proof work; fee})
       in
-      let enveloped_diff = {Envelope.Incoming.data= diff; sender} in
+      let enveloped_diff = Envelope.Incoming.wrap ~data:diff ~sender in
       match%bind
         Mock_snark_pool.Resource_pool.Diff.verify resource_pool enveloped_diff
       with

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -103,7 +103,7 @@ module Make
       | _ ->
           failwith "compare didn't return -1, 0, or 1!" )
 
-  let verify pool ({data; sender} as t : t Envelope.Incoming.t) =
+  let verify pool ({data; sender; _} as t : t Envelope.Incoming.t) =
     match data with
     | Empty ->
         Deferred.Or_error.error_string "cannot verify empty snark pool diff"
@@ -127,7 +127,7 @@ module Make
 
   (* This is called after verification has occurred.*)
   let unsafe_apply (pool : Pool.t) (t : t Envelope.Incoming.t) =
-    let {Envelope.Incoming.data= diff; sender} = t in
+    let {Envelope.Incoming.data= diff; sender; _} = t in
     match diff with
     | Empty ->
         Deferred.return

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -1,5 +1,5 @@
 open Async_kernel
-open Core_kernel
+open Core
 open Coda_base
 open Coda_state
 open Coda_transition
@@ -11,40 +11,62 @@ module T = struct
   type t =
     { validated_transition: External_transition.Validated.t
     ; staged_ledger: Staged_ledger.t sexp_opaque
-    ; just_emitted_a_proof: bool }
+    ; just_emitted_a_proof: bool
+    ; transition_receipt_time: Time.t option }
   [@@deriving sexp, fields]
 
   type 'a creator =
        validated_transition:External_transition.Validated.t
     -> staged_ledger:Staged_ledger.t
     -> just_emitted_a_proof:bool
+    -> transition_receipt_time:Time.t option
     -> 'a
 
   let map_creator creator ~f ~validated_transition ~staged_ledger
-      ~just_emitted_a_proof =
-    f (creator ~validated_transition ~staged_ledger ~just_emitted_a_proof)
+      ~just_emitted_a_proof ~transition_receipt_time =
+    f
+      (creator ~validated_transition ~staged_ledger ~just_emitted_a_proof
+         ~transition_receipt_time)
 
-  let create ~validated_transition ~staged_ledger ~just_emitted_a_proof =
-    {validated_transition; staged_ledger; just_emitted_a_proof}
+  let create ~validated_transition ~staged_ledger ~just_emitted_a_proof
+      ~transition_receipt_time =
+    { validated_transition
+    ; staged_ledger
+    ; just_emitted_a_proof
+    ; transition_receipt_time }
 
-  let to_yojson {validated_transition; staged_ledger= _; just_emitted_a_proof}
-      =
+  let to_yojson
+      { validated_transition
+      ; staged_ledger= _
+      ; just_emitted_a_proof
+      ; transition_receipt_time } =
     `Assoc
       [ ( "validated_transition"
         , External_transition.Validated.to_yojson validated_transition )
       ; ("staged_ledger", `String "<opaque>")
-      ; ("just_emitted_a_proof", `Bool just_emitted_a_proof) ]
+      ; ("just_emitted_a_proof", `Bool just_emitted_a_proof)
+      ; ( "transition_receipt_time"
+        , `String
+            (Option.value_map transition_receipt_time
+               ~default:"<not available>"
+               ~f:(Time.to_string_iso8601_basic ~zone:Time.Zone.utc)) ) ]
 end
 
 [%%define_locally
-T.(validated_transition, staged_ledger, just_emitted_a_proof, to_yojson)]
+T.
+  ( validated_transition
+  , staged_ledger
+  , just_emitted_a_proof
+  , transition_receipt_time
+  , to_yojson )]
 
 include Allocation_functor.Make.Sexp (T)
 
 let build ?skip_staged_ledger_verification ~logger ~precomputed_values
     ~verifier ~trust_system ~parent
     ~transition:(transition_with_validation :
-                  External_transition.Almost_validated.t) ~sender () =
+                  External_transition.Almost_validated.t) ~sender
+    ~transition_receipt_time () =
   O1trace.trace_recurring "Breadcrumb.build" (fun () ->
       let open Deferred.Let_syntax in
       match%bind
@@ -66,7 +88,7 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
           @@ Ok
                (create ~validated_transition:fully_valid_external_transition
                   ~staged_ledger:transitioned_staged_ledger
-                  ~just_emitted_a_proof)
+                  ~just_emitted_a_proof ~transition_receipt_time)
       | Error (`Invalid_staged_ledger_diff errors) ->
           let reasons =
             String.concat ~sep:" && "
@@ -407,13 +429,15 @@ module For_tests = struct
             next_verified_external_transition) =
         External_transition.Validated.create_unsafe next_external_transition
       in
+      let transition_receipt_time = Some (Time.now ()) in
       match%map
         build ~logger ~precomputed_values ~trust_system ~verifier
           ~parent:parent_breadcrumb
           ~transition:
             (External_transition.Validation.reset_staged_ledger_diff_validation
                next_verified_external_transition)
-          ~sender:None ~skip_staged_ledger_verification:true ()
+          ~sender:None ~skip_staged_ledger_verification:true
+          ~transition_receipt_time ()
       with
       | Ok new_breadcrumb ->
           [%log info]

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -24,6 +24,7 @@ val create :
      validated_transition:External_transition.Validated.t
   -> staged_ledger:Staged_ledger.t
   -> just_emitted_a_proof:bool
+  -> transition_receipt_time:Time.t option
   -> t
 
 val build :
@@ -35,6 +36,7 @@ val build :
   -> parent:t
   -> transition:External_transition.Almost_validated.t
   -> sender:Envelope.Sender.t option
+  -> transition_receipt_time:Time.t option
   -> unit
   -> ( t
      , [> `Invalid_staged_ledger_diff of Error.t
@@ -48,6 +50,8 @@ val validated_transition : t -> External_transition.Validated.t
 val staged_ledger : t -> Staged_ledger.t
 
 val just_emitted_a_proof : t -> bool
+
+val transition_receipt_time : t -> Time.t option
 
 val hash : t -> int
 

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -105,6 +105,7 @@ let close ~loc t =
 let create ~logger ~root_data ~root_ledger ~consensus_local_state ~max_length
     ~precomputed_values =
   let open Root_data in
+  let transition_receipt_time = None in
   let root_hash =
     External_transition.Validated.state_hash root_data.transition
   in
@@ -128,6 +129,7 @@ let create ~logger ~root_data ~root_ledger ~consensus_local_state ~max_length
   let root_breadcrumb =
     Breadcrumb.create ~validated_transition:root_data.transition
       ~staged_ledger:root_data.staged_ledger ~just_emitted_a_proof:false
+      ~transition_receipt_time
   in
   let root_node =
     {Node.breadcrumb= root_breadcrumb; successor_hashes= []; length= 0}
@@ -451,6 +453,8 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
       ~staged_ledger:new_staged_ledger
       ~just_emitted_a_proof:
         (Breadcrumb.just_emitted_a_proof new_root_node.breadcrumb)
+      ~transition_receipt_time:
+        (Breadcrumb.transition_receipt_time new_root_node.breadcrumb)
   in
   (*Update the protocol states required for scan state at the new root.
   Note: this should be after applying the transactions to the snarked ledger (Step 5)

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -283,12 +283,16 @@ module Instance = struct
                    Error (`Fatal_error (Invalid_genesis_state_hash transition))
                    |> Deferred.return
              in
+             (* we're loading transitions from persistent storage,
+                don't assign a timestamp
+             *)
+             let transition_receipt_time = None in
              let%bind breadcrumb =
                Breadcrumb.build ~skip_staged_ledger_verification:true
                  ~logger:t.factory.logger ~precomputed_values
                  ~verifier:t.factory.verifier
                  ~trust_system:(Trust_system.null ()) ~parent ~transition
-                 ~sender:None ()
+                 ~sender:None ~transition_receipt_time ()
              in
              let%map () = apply_diff Diff.(E (New_node (Full breadcrumb))) in
              breadcrumb ))

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -469,6 +469,7 @@ module For_tests = struct
                 ~pids:(Child_processes.Termination.create_pid_table ()) )
     in
     Quickcheck.Generator.create (fun ~size:_ ~random:_ ->
+        let transition_receipt_time = Some (Time.now ()) in
         let genesis_transition =
           External_transition.For_tests.genesis ~precomputed_values
         in
@@ -500,7 +501,8 @@ module For_tests = struct
                    ~expected_merkle_root:(Ledger.merkle_root genesis_ledger) ))
         in
         Breadcrumb.create ~validated_transition:genesis_transition
-          ~staged_ledger:genesis_staged_ledger ~just_emitted_a_proof:false )
+          ~staged_ledger:genesis_staged_ledger ~just_emitted_a_proof:false
+          ~transition_receipt_time )
 
   let gen_persistence ?(logger = Logger.null ()) ?verifier
       ~(precomputed_values : Precomputed_values.t) () =

--- a/src/lib/transition_handler/breadcrumb_builder.ml
+++ b/src/lib/transition_handler/breadcrumb_builder.ml
@@ -12,7 +12,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
       "Transition frontier already garbage-collected the parent of %s"
       (Coda_base.State_hash.to_base58_check initial_hash)
   in
-  (* If the breadcrumb we are targetting is removed from the transition
+  (* If the breadcrumb we are targeting is removed from the transition
    * frontier while we're catching up, it means this path is not on the
    * critical path that has been chosen in the frontier. As such, we should
    * drop it on the floor. *)
@@ -61,6 +61,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                 let transition_with_initial_validation =
                   Envelope.Incoming.data enveloped_transition
                 in
+                let transition_receipt_time = Some (Time.now ()) in
                 let transition_with_hash, _ =
                   transition_with_initial_validation
                 in
@@ -98,7 +99,8 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                           Transition_frontier.Breadcrumb.build ~logger
                             ~precomputed_values ~verifier ~trust_system ~parent
                             ~transition:mostly_validated_transition
-                            ~sender:(Some sender) () ) )
+                            ~sender:(Some sender) ~transition_receipt_time ()
+                      ) )
                 with
                 | Error _ ->
                     Deferred.return @@ Or_error.error_string missing_parent_msg

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -87,6 +87,10 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
   let enveloped_initially_validated_transition =
     Cached.peek cached_initially_validated_transition
   in
+  let transition_receipt_time =
+    Some
+      (Envelope.Incoming.received_at enveloped_initially_validated_transition)
+  in
   let sender =
     Envelope.Incoming.sender enveloped_initially_validated_transition
   in
@@ -175,8 +179,8 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
       cached_transform_deferred_result cached_initially_validated_transition
         ~transform_cached:(fun _ ->
           Transition_frontier.Breadcrumb.build ~logger ~precomputed_values
-            ~verifier ~trust_system ~sender:(Some sender)
-            ~parent:parent_breadcrumb
+            ~verifier ~trust_system ~transition_receipt_time
+            ~sender:(Some sender) ~parent:parent_breadcrumb
             ~transition:
               mostly_validated_transition (* TODO: Can we skip here? *)
             ~skip_staged_ledger_verification:false () )
@@ -262,7 +266,7 @@ let run ~logger ~(precomputed_values : Precomputed_values.t) ~verifier
   ignore
     (Reader.Merge.iter
        (* It is fine to skip the cache layer on blocks produced by this node
-        * because it is extradornarily unlikely we would write an internal bug
+        * because it is extraordinarily unlikely we would write an internal bug
         * triggering this case, and the external case (where we received an
         * identical external transition from the network) can happen iff there
         * is another node with the exact same private key and view of the


### PR DESCRIPTION
Add more fields to the telemetry response.

These are the same changes as in #7002, except based on `develop-until-4.1-hardfork`.

See that PR for comments and commits leading to the current design.
