### PR TITLE
Pull only snark work and transactions that we will use for staged ledger diff

### DIFF
--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1743,7 +1743,7 @@ module T = struct
                    of their snarks are purchased and their accounts get
                    created
                 *)
-                (* TODO: This should be checked in the pool.
+                (* TODO(#7034): This should be checked in the pool.
                    Running the check here allows block production to be blocked
                    by low-fee snark work for a pk that isn't in the ledger.
                 *)

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1024,14 +1024,12 @@ module T = struct
   module Resources = struct
     module Discarded = struct
       type t =
-        { commands_rev: User_command.Valid.t With_status.t Sequence.t
+        { commands: User_command.Valid.t With_status.t Sequence.t
         ; completed_work: Transaction_snark_work.Checked.t Sequence.t }
       [@@deriving sexp_of]
 
       let add_user_command t uc =
-        { t with
-          commands_rev= Sequence.append t.commands_rev (Sequence.singleton uc)
-        }
+        {t with commands= Sequence.append (Sequence.singleton uc) t.commands}
 
       let add_completed_work t cw =
         { t with
@@ -1220,7 +1218,7 @@ module T = struct
         |> Or_error.join
       in
       let discarded =
-        {Discarded.completed_work= Sequence.empty; commands_rev= Sequence.empty}
+        {Discarded.completed_work= Sequence.empty; commands= Sequence.empty}
       in
       { max_space= slots
       ; max_jobs= job_count
@@ -1592,8 +1590,8 @@ module T = struct
       Sequence.length res.commands_rev = 0
     in
     let second_pre_diff (res : Resources.t) partition ~add_coinbase work =
-      one_prediff ~constraint_constants work res.discarded.commands_rev
-        ~receiver partition ~add_coinbase logger ~is_coinbase_reciever_new
+      one_prediff ~constraint_constants work res.discarded.commands ~receiver
+        partition ~add_coinbase logger ~is_coinbase_reciever_new
         ~supercharge_coinbase `Second
     in
     let isEmpty (res : Resources.t) =


### PR DESCRIPTION
This PR updates `Staged_ledger.create_diff` to pull only the snark work and transactions that may be included from their respective pools.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: