### PR TITLE
Go metrics disabled for now

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -999,8 +999,10 @@ func (ap *beginAdvertisingMsg) run(app *app) (interface{}, error) {
 			Upcall: "peerConnected",
 		})
 
-		go app.checkBandwidth(id)
-		go app.checkLatency(id)
+		// Note: These are disabled because we see weirdness on our networks
+		//       caused by this prometheus issues.
+		// go app.checkBandwidth(id)
+		// go app.checkLatency(id)
 	}
 
 	return "beginAdvertising success", nil


### PR DESCRIPTION
We think this could be causing some of the issues we're running into on qa nets, so disabling for now