### PR TITLE
shorten namespace

### DIFF
--- a/src/lib/integration_test_cloud_engine/coda_automation.ml
+++ b/src/lib/integration_test_cloud_engine/coda_automation.ml
@@ -91,7 +91,7 @@ module Network_config = struct
       ^ string_of_int time_now.tm_hour
       ^ string_of_int time_now.tm_min
     in
-    (* append the first 5 chars of the username of the person running the test, test name, and part of the timestamp onto the back of an integration test to disambiguate different test deployments, format is: *)
+    (* append the first 5 chars of the local system username of the person running the test, test name, and part of the timestamp onto the back of an integration test to disambiguate different test deployments, format is: *)
     (* username-testname-DaymonthHrMin *)
     (* ex: adalo-block-production-151134 ; user is adalovelace, running block production test, 15th of a month, 11:34 AM, GMT time*)
     let testnet_name = user ^ "-" ^ test_name ^ "-" ^ timestr in

--- a/src/lib/integration_test_cloud_engine/coda_automation.ml
+++ b/src/lib/integration_test_cloud_engine/coda_automation.ml
@@ -92,9 +92,9 @@ module Network_config = struct
       ^ string_of_int time_now.tm_min
     in
     (* append the first 5 chars of the username of the person running the test, test name, and part of the timestamp onto the back of an integration test to disambiguate different test deployments, format is: *)
-    (* intntest-username-testname-DaymonthHrMin *)
-    (* ex: intntest-adalo-block-production-151134 ; user is adalovelace, running block production test, 15th of a month, 11:34 AM, GMT time*)
-    let testnet_name = "intntest-" ^ user ^ "-" ^ test_name ^ "-" ^ timestr in
+    (* username-testname-DaymonthHrMin *)
+    (* ex: adalo-block-production-151134 ; user is adalovelace, running block production test, 15th of a month, 11:34 AM, GMT time*)
+    let testnet_name = user ^ "-" ^ test_name ^ "-" ^ timestr in
     (* HARD CODED NETWORK VALUES *)
     let project_id = "o1labs-192920" in
     let cluster_id = "gke_o1labs-192920_us-west1_mina-integration-west1" in


### PR DESCRIPTION
tried to put too much information in the integration test namespace string, was causing problems because it made it too long and ran up against character length limits with some tests with longer names.

removing some of the info, now that integration tests are in their own cluster anyways it shouldn't be as necessary