### PR TITLE
Add balances to internal commands in blocks, validate statuses

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -141,8 +141,11 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
               ~current_state_view:previous_state_view
               ~transactions_by_fee:transactions ~get_completed_work
               ~log_block_creation ~supercharge_coinbase )
+        |> Result.map_error ~f:(fun err ->
+               Staged_ledger.Staged_ledger_error.Pre_diff err )
       in
       match%map
+        let%bind.Deferred.Result.Let_syntax diff = return diff in
         Staged_ledger.apply_diff_unchecked staged_ledger ~constraint_constants
           diff ~logger ~current_state_view:previous_state_view
           ~state_and_body_hash:
@@ -160,7 +163,7 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
           @@ Ledger.unregister_mask_exn ~loc:__LOC__
                (Staged_ledger.ledger transitioned_staged_ledger) ;
           Some
-            ( diff
+            ( (match diff with Ok diff -> diff | Error _ -> assert false)
             , next_staged_ledger_hash
             , ledger_proof_opt
             , is_new_stack
@@ -168,14 +171,23 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
       | Error (Staged_ledger.Staged_ledger_error.Unexpected e) ->
           raise (Error.to_exn e)
       | Error e ->
-          [%log error]
-            ~metadata:
-              [ ( "error"
-                , `String (Staged_ledger.Staged_ledger_error.to_string e) )
-              ; ( "diff"
-                , Staged_ledger_diff.With_valid_signatures_and_proofs.to_yojson
-                    diff ) ]
-            "Error applying the diff $diff: $error" ;
+          ( match diff with
+          | Ok diff ->
+              [%log error]
+                ~metadata:
+                  [ ( "error"
+                    , `String (Staged_ledger.Staged_ledger_error.to_string e)
+                    )
+                  ; ( "diff"
+                    , Staged_ledger_diff.With_valid_signatures_and_proofs
+                      .to_yojson diff ) ]
+                "Error applying the diff $diff: $error"
+          | Error e ->
+              [%log error] "Error building the diff: $error"
+                ~metadata:
+                  [ ( "error"
+                    , `String (Staged_ledger.Staged_ledger_error.to_string e)
+                    ) ] ) ;
           None)
   in
   match res with

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -147,7 +147,8 @@ module Undo : sig
     type t = Undo.Fee_transfer_undo.t =
       { fee_transfer: Fee_transfer.t
       ; previous_empty_accounts: Account_id.t list
-      ; receiver_timing: Account.Timing.t }
+      ; receiver_timing: Account.Timing.t
+      ; balances: User_command_status.Balance_data.t }
     [@@deriving sexp]
   end
 
@@ -155,7 +156,8 @@ module Undo : sig
     type t = Undo.Coinbase_undo.t =
       { coinbase: Coinbase.t
       ; previous_empty_accounts: Account_id.t list
-      ; receiver_timing: Account.Timing.t }
+      ; receiver_timing: Account.Timing.t
+      ; balances: User_command_status.Balance_data.t }
     [@@deriving sexp]
   end
 

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -148,7 +148,7 @@ module Undo : sig
       { fee_transfer: Fee_transfer.t
       ; previous_empty_accounts: Account_id.t list
       ; receiver_timing: Account.Timing.t
-      ; balances: User_command_status.Balance_data.t }
+      ; balances: User_command_status.Fee_transfer_balance_data.t }
     [@@deriving sexp]
   end
 
@@ -157,7 +157,7 @@ module Undo : sig
       { coinbase: Coinbase.t
       ; previous_empty_accounts: Account_id.t list
       ; receiver_timing: Account.Timing.t
-      ; balances: User_command_status.Balance_data.t }
+      ; balances: User_command_status.Coinbase_balance_data.t }
     [@@deriving sexp]
   end
 

--- a/src/lib/coda_base/user_command_status.ml
+++ b/src/lib/coda_base/user_command_status.ml
@@ -694,6 +694,98 @@ module Balance_data = struct
     {fee_payer_balance= None; source_balance= None; receiver_balance= None}
 end
 
+module Coinbase_balance_data = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t =
+        { coinbase_receiver_balance: Currency.Balance.Stable.V1.t
+        ; fee_transfer_receiver_balance: Currency.Balance.Stable.V1.t option }
+      [@@deriving sexp, yojson, eq, compare]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  let of_balance_data_exn
+      {Balance_data.fee_payer_balance; source_balance; receiver_balance} =
+    ( match source_balance with
+    | Some _ ->
+        failwith
+          "Unexpected source balance for Coinbase_balance_data.of_balance_data"
+    | None ->
+        () ) ;
+    let coinbase_receiver_balance =
+      match fee_payer_balance with
+      | Some balance ->
+          balance
+      | None ->
+          failwith
+            "Missing fee-payer balance for \
+             Coinbase_balance_data.of_balance_data"
+    in
+    {coinbase_receiver_balance; fee_transfer_receiver_balance= receiver_balance}
+
+  let to_balance_data {coinbase_receiver_balance; fee_transfer_receiver_balance}
+      =
+    { Balance_data.fee_payer_balance= Some coinbase_receiver_balance
+    ; source_balance= None
+    ; receiver_balance= fee_transfer_receiver_balance }
+end
+
+module Fee_transfer_balance_data = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t =
+        { receiver1_balance: Currency.Balance.Stable.V1.t
+        ; receiver2_balance: Currency.Balance.Stable.V1.t option }
+      [@@deriving sexp, yojson, eq, compare]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  let of_balance_data_exn
+      {Balance_data.fee_payer_balance; source_balance; receiver_balance} =
+    ( match source_balance with
+    | Some _ ->
+        failwith
+          "Unexpected source balance for \
+           Fee_transfer_balance_data.of_balance_data"
+    | None ->
+        () ) ;
+    let receiver1_balance =
+      match fee_payer_balance with
+      | Some balance ->
+          balance
+      | None ->
+          failwith
+            "Missing fee-payer balance for \
+             Fee_transfer_balance_data.of_balance_data"
+    in
+    {receiver1_balance; receiver2_balance= receiver_balance}
+
+  let to_balance_data {receiver1_balance; receiver2_balance} =
+    { Balance_data.fee_payer_balance= Some receiver1_balance
+    ; source_balance= None
+    ; receiver_balance= receiver2_balance }
+end
+
+module Internal_command_balance_data = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t =
+        | Coinbase of Coinbase_balance_data.Stable.V1.t
+        | Fee_transfer of Fee_transfer_balance_data.Stable.V1.t
+      [@@deriving sexp, yojson, eq, compare]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
 module Auxiliary_data = struct
   [%%versioned
   module Stable = struct
@@ -727,3 +819,7 @@ module Stable = struct
     let to_latest = Fn.id
   end
 end]
+
+let balance_data = function
+  | Applied (_, balances) | Failed (_, balances) ->
+      balances

--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -960,7 +960,7 @@ let genesis ~precomputed_values =
         ( { completed_works= []
           ; commands= []
           ; coinbase= Staged_ledger_diff.At_most_two.Zero
-          ; internal_command_statuses= [] }
+          ; internal_command_balances= [] }
         , None ) }
   in
   (* the genesis transition is assumed to be valid *)

--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -959,7 +959,8 @@ let genesis ~precomputed_values =
     { Staged_ledger_diff.diff=
         ( { completed_works= []
           ; commands= []
-          ; coinbase= Staged_ledger_diff.At_most_two.Zero }
+          ; coinbase= Staged_ledger_diff.At_most_two.Zero
+          ; internal_command_statuses= [] }
         , None ) }
   in
   (* the genesis transition is assumed to be valid *)

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -257,6 +257,7 @@ module type State_hooks = sig
                                      With_hash.t
           -> snarked_ledger_hash:Coda_base.Frozen_ledger_hash.t
           -> coinbase_receiver:Public_key.Compressed.t
+          -> supercharge_coinbase:bool
           -> consensus_state)
          Quickcheck.Generator.t
   end

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -256,6 +256,7 @@ module type State_hooks = sig
                                      , Coda_base.State_hash.t )
                                      With_hash.t
           -> snarked_ledger_hash:Coda_base.Frozen_ledger_hash.t
+          -> coinbase_receiver:Public_key.Compressed.t
           -> consensus_state)
          Quickcheck.Generator.t
   end

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -3552,6 +3552,7 @@ module Hooks = struct
                                       With_hash.t
            -> snarked_ledger_hash:Coda_base.Frozen_ledger_hash.t
            -> coinbase_receiver:Public_key.Compressed.t
+           -> supercharge_coinbase:bool
            -> Consensus_state.Value.t)
           Quickcheck.Generator.t =
         let open Consensus_state in
@@ -3562,12 +3563,11 @@ module Hooks = struct
         in
         let open Quickcheck.Let_syntax in
         let%bind slot_advancement = gen_slot_advancement in
-        let%bind supercharge_coinbase = Quickcheck.Generator.bool in
         let%map producer_vrf_result = Vrf.Output.gen in
         fun ~(previous_protocol_state :
                (Protocol_state.Value.t, Coda_base.State_hash.t) With_hash.t)
             ~(snarked_ledger_hash : Coda_base.Frozen_ledger_hash.t)
-            ~coinbase_receiver ->
+            ~coinbase_receiver ~supercharge_coinbase ->
           let prev =
             Protocol_state.consensus_state
               (With_hash.data previous_protocol_state)

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -3551,6 +3551,7 @@ module Hooks = struct
                                       , Coda_base.State_hash.t )
                                       With_hash.t
            -> snarked_ledger_hash:Coda_base.Frozen_ledger_hash.t
+           -> coinbase_receiver:Public_key.Compressed.t
            -> Consensus_state.Value.t)
           Quickcheck.Generator.t =
         let open Consensus_state in
@@ -3565,7 +3566,8 @@ module Hooks = struct
         let%map producer_vrf_result = Vrf.Output.gen in
         fun ~(previous_protocol_state :
                (Protocol_state.Value.t, Coda_base.State_hash.t) With_hash.t)
-            ~(snarked_ledger_hash : Coda_base.Frozen_ledger_hash.t) ->
+            ~(snarked_ledger_hash : Coda_base.Frozen_ledger_hash.t)
+            ~coinbase_receiver ->
           let prev =
             Protocol_state.consensus_state
               (With_hash.data previous_protocol_state)
@@ -3625,7 +3627,7 @@ module Hooks = struct
                    ~slot:curr_slot)
           ; block_stake_winner= genesis_winner_pk
           ; block_creator= genesis_winner_pk
-          ; coinbase_receiver= genesis_winner_pk
+          ; coinbase_receiver
           ; supercharge_coinbase }
     end
   end

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -328,14 +328,7 @@ let generate_statuses (type c) ~constraint_constants coinbase_parts ~receiver
     Or_error.try_with (fun () ->
         let coinbases =
           List.map coinbases ~f:(fun t ->
-              Or_error.ok_exn (generate_status (Transaction.Coinbase t))
-              |> fun status ->
-              [%log' info (Logger.create ())]
-                "got status value $status_value"
-                ~metadata:
-                  [ ("status_value", User_command_status.to_yojson status)
-                  ; ("coinbase", Coinbase.to_yojson t) ] ;
-              status )
+              Or_error.ok_exn (generate_status (Transaction.Coinbase t)) )
         in
         let fee_transfers =
           List.map fee_transfers ~f:(fun t ->

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -8,6 +8,7 @@ module type S = sig
       | Verification_failed of Verifier.Failure.t
       | Coinbase_error of string
       | Insufficient_fee of Currency.Fee.t * Currency.Fee.t
+      | Internal_command_status_mismatch
       | Unexpected of Error.t
     [@@deriving sexp]
 
@@ -53,6 +54,7 @@ module Error = struct
     | Verification_failed of Verifier.Failure.t
     | Coinbase_error of string
     | Insufficient_fee of Currency.Fee.t * Currency.Fee.t
+    | Internal_command_status_mismatch
     | Unexpected of Error.t
   [@@deriving sexp]
 
@@ -66,6 +68,8 @@ module Error = struct
           !"Transaction fees %{sexp: Currency.Fee.t} does not suffice proof \
             fees %{sexp: Currency.Fee.t} \n"
           f1 f2
+    | Internal_command_status_mismatch ->
+        "Internal command statuses did not match"
     | Unexpected e ->
         Error.to_string_hum e
 
@@ -240,16 +244,23 @@ let create_fee_transfers completed_works delta public_key coinbase_fts =
       |> Or_error.all )
   |> Or_error.join |> to_staged_ledger_or_error
 
-let get_individual_info (type c) ~constraint_constants coinbase_parts ~receiver
-    ~coinbase_amount commands completed_works ~(forget : c -> _) =
+module Transaction_data = struct
+  type 'a t =
+    { commands: 'a With_status.t list
+    ; coinbases: Coinbase.t list
+    ; fee_transfers: Fee_transfer.t list }
+end
+
+let get_transaction_data (type c) ~constraint_constants coinbase_parts
+    ~receiver ~coinbase_amount commands completed_works ~(forget : c -> _) =
   let open Result.Let_syntax in
-  let%bind coinbase_parts =
+  let%bind coinbases =
     O1trace.measure "create_coinbase" (fun () ->
         create_coinbase ~constraint_constants coinbase_parts ~receiver
           ~coinbase_amount )
   in
   let coinbase_fts =
-    List.concat_map coinbase_parts ~f:(fun cb -> Option.to_list cb.fee_transfer)
+    List.concat_map coinbases ~f:(fun cb -> Option.to_list cb.fee_transfer)
   in
   let coinbase_work_fees =
     sum_fees ~f:Coinbase.Fee_transfer.fee coinbase_fts |> Or_error.ok_exn
@@ -264,26 +275,76 @@ let get_individual_info (type c) ~constraint_constants coinbase_parts ~receiver
   let%map fee_transfers =
     create_fee_transfers txn_works_others delta receiver coinbase_fts
   in
+  {Transaction_data.commands; coinbases; fee_transfers}
+
+let get_individual_info (type c) ~constraint_constants coinbase_parts ~receiver
+    ~coinbase_amount ~internal_command_statuses commands completed_works
+    ~(forget : c -> _) =
+  let open Result.Let_syntax in
+  let%bind {Transaction_data.commands; coinbases= coinbase_parts; fee_transfers}
+      =
+    get_transaction_data ~constraint_constants coinbase_parts ~receiver
+      ~coinbase_amount commands completed_works ~forget
+  in
+  let internal_commands =
+    List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
+    @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
+  in
+  let%map internal_commands_with_statuses =
+    Or_error.try_with (fun () ->
+        List.map2_exn internal_commands internal_command_statuses
+          ~f:(fun cmd status -> {With_status.data= cmd; status}) )
+    |> Result.map_error ~f:(fun _ -> Error.Internal_command_status_mismatch)
+  in
   let transactions =
     List.map commands ~f:(With_status.map ~f:(fun t -> Transaction.Command t))
-    @ List.map coinbase_parts ~f:(fun t ->
-          { With_status.data= Transaction.Coinbase t
-          ; status=
-              Applied
-                ( User_command_status.Auxiliary_data.empty
-                , User_command_status.Balance_data.empty ) } )
-    @ List.map fee_transfers ~f:(fun t ->
-          { With_status.data= Transaction.Fee_transfer t
-          ; status=
-              Applied
-                ( User_command_status.Auxiliary_data.empty
-                , User_command_status.Balance_data.empty ) } )
+    @ internal_commands_with_statuses
   in
   { transactions
   ; work= completed_works
   ; commands_count= List.length commands
   ; coinbases= List.map coinbase_parts ~f:(fun Coinbase.{amount; _} -> amount)
   }
+
+let generate_statuses (type c) ~constraint_constants coinbase_parts ~receiver
+    ~coinbase_amount commands completed_works ~(forget : c -> _)
+    ~generate_status =
+  let open Result.Let_syntax in
+  let%bind {Transaction_data.commands; coinbases; fee_transfers} =
+    get_transaction_data ~constraint_constants coinbase_parts ~receiver
+      ~coinbase_amount commands completed_works ~forget
+  in
+  let%bind transactions =
+    Or_error.try_with (fun () ->
+        List.map commands ~f:(fun cmd ->
+            { With_status.data= cmd.With_status.data
+            ; status=
+                Or_error.ok_exn
+                  (generate_status (Transaction.Command (forget cmd.data))) }
+        ) )
+    |> Result.map_error ~f:(fun err -> Error.Unexpected err)
+  in
+  let%map internal_command_statuses =
+    Or_error.try_with (fun () ->
+        let coinbases =
+          List.map coinbases ~f:(fun t ->
+              Or_error.ok_exn (generate_status (Transaction.Coinbase t))
+              |> fun status ->
+              [%log' info (Logger.create ())]
+                "got status value $status_value"
+                ~metadata:
+                  [ ("status_value", User_command_status.to_yojson status)
+                  ; ("coinbase", Coinbase.to_yojson t) ] ;
+              status )
+        in
+        let fee_transfers =
+          List.map fee_transfers ~f:(fun t ->
+              Or_error.ok_exn (generate_status (Transaction.Fee_transfer t)) )
+        in
+        coinbases @ fee_transfers )
+    |> Result.map_error ~f:(fun err -> Error.Unexpected err)
+  in
+  (transactions, internal_command_statuses)
 
 open Staged_ledger_diff
 
@@ -303,6 +364,56 @@ let check_coinbase (diff : _ Pre_diff_two.t * _ Pre_diff_one.t option) =
                 %{sexp:Coinbase.Fee_transfer.t At_most_two.t} and \
                 %{sexp:Coinbase.Fee_transfer.t At_most_one.t}"
               x y))
+
+let compute_statuses (type c)
+    ~(constraint_constants : Genesis_constants.Constraint_constants.t) ~diff
+    ~coinbase_receiver ~coinbase_amount ~generate_status ~(forget : c -> _) =
+  let open Result.Let_syntax in
+  let get_statuses_pre_diff_with_at_most_two
+      (t1 : (_, c With_status.t) Pre_diff_two.t) =
+    let coinbase_parts =
+      match t1.coinbase with
+      | Zero ->
+          `Zero
+      | One x ->
+          `One x
+      | Two x ->
+          `Two x
+    in
+    let%map commands, internal_command_statuses =
+      generate_statuses ~constraint_constants ~generate_status coinbase_parts
+        ~receiver:coinbase_receiver t1.commands t1.completed_works
+        ~coinbase_amount ~forget
+    in
+    ( { commands
+      ; completed_works= t1.completed_works
+      ; coinbase= t1.coinbase
+      ; internal_command_statuses }
+      : _ Pre_diff_two.t )
+  in
+  let get_statuses_pre_diff_with_at_most_one
+      (t2 : (_, c With_status.t) Pre_diff_one.t) =
+    let coinbase_added =
+      match t2.coinbase with Zero -> `Zero | One x -> `One x
+    in
+    let%map commands, internal_command_statuses =
+      generate_statuses ~constraint_constants ~generate_status coinbase_added
+        ~receiver:coinbase_receiver t2.commands t2.completed_works
+        ~coinbase_amount ~forget
+    in
+    Some
+      ( { commands
+        ; completed_works= t2.completed_works
+        ; coinbase= t2.coinbase
+        ; internal_command_statuses }
+        : _ Pre_diff_one.t )
+  in
+  let%bind p1 = get_statuses_pre_diff_with_at_most_two (fst diff) in
+  let%map p2 =
+    Option.value_map ~f:get_statuses_pre_diff_with_at_most_one (snd diff)
+      ~default:(Ok None)
+  in
+  (p1, p2)
 
 let get' (type c)
     ~(constraint_constants : Genesis_constants.Constraint_constants.t) ~diff
@@ -333,7 +444,9 @@ let get' (type c)
           `Two x
     in
     get_individual_info coinbase_parts ~receiver:coinbase_receiver t1.commands
-      t1.completed_works ~coinbase_amount ~forget
+      t1.completed_works
+      ~internal_command_statuses:t1.internal_command_statuses ~coinbase_amount
+      ~forget
   in
   let apply_pre_diff_with_at_most_one
       (t2 : (_, c With_status.t) Pre_diff_one.t) =
@@ -341,7 +454,9 @@ let get' (type c)
       match t2.coinbase with Zero -> `Zero | One x -> `One x
     in
     get_individual_info coinbase_added ~receiver:coinbase_receiver t2.commands
-      t2.completed_works ~coinbase_amount ~forget
+      t2.completed_works
+      ~internal_command_statuses:t2.internal_command_statuses ~coinbase_amount
+      ~forget
   in
   let%bind () = check_coinbase diff in
   let%bind p1 =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -29,6 +29,8 @@ module T = struct
       | Couldn't_reach_verifier of Error.t
       | Pre_diff of Pre_diff_info.Error.t
       | Insufficient_work of string
+      | Mismatched_statuses of
+          Transaction.t With_status.t * User_command_status.t
       | Unexpected of Error.t
     [@@deriving sexp]
 
@@ -59,6 +61,11 @@ module T = struct
                    @@ Public_key.Compressed.to_yojson m.prover ) ))
       | Insufficient_work str ->
           str
+      | Mismatched_statuses (transaction, status) ->
+          Format.asprintf
+            !"Got a different status %{sexp: User_command_status.t} when \
+              applying the transaction %{sexp: Transaction.t With_status.t}"
+            status transaction
       | Unexpected e ->
           Error.to_string_hum e
 
@@ -492,7 +499,8 @@ module T = struct
       ; init_stack= new_init_stack } )
 
   let apply_transaction_and_get_witness ~constraint_constants ledger
-      pending_coinbase_stack_state s txn_state_view state_and_body_hash =
+      pending_coinbase_stack_state s status txn_state_view state_and_body_hash
+      =
     let account_ids : Transaction.t -> _ = function
       | Fee_transfer t ->
           Fee_transfer.receivers t
@@ -517,7 +525,20 @@ module T = struct
             pending_coinbase_stack_state s txn_state_view )
     in
     let open Result.Let_syntax in
-    let%map undo, statement, updated_pending_coinbase_stack_state = r in
+    let%bind undo, statement, updated_pending_coinbase_stack_state = r in
+    let%map () =
+      match status with
+      | None ->
+          return ()
+      | Some status ->
+          (* Validate that command status matches. *)
+          let got_status = Ledger.Undo.user_command_status undo in
+          if User_command_status.equal status got_status then return ()
+          else
+            Result.fail
+              (Staged_ledger_error.Mismatched_statuses
+                 ({With_status.data= s; status}, got_status))
+    in
     ( { Scan_state.Transaction_with_witness.transaction_with_info= undo
       ; state_hash= state_and_body_hash
       ; state_view= txn_state_view
@@ -545,9 +566,8 @@ module T = struct
         ; init_stack= current_stack }
       in
       let exception Exit of Staged_ledger_error.t in
-      try
-        let tss = partition 10 ts in
-        let%bind.Async ret =
+      Async.try_with ~extract_exn:true (fun () ->
+          let tss = partition 10 ts in
           Deferred.List.fold tss ~init:([], pending_coinbase_stack_state)
             ~f:(fun (acc, pending_coinbase_stack_state) ts ->
               let open Deferred.Let_syntax in
@@ -557,15 +577,17 @@ module T = struct
                   match
                     apply_transaction_and_get_witness ~constraint_constants
                       ledger pending_coinbase_stack_state t.With_status.data
-                      current_state_view state_and_body_hash
+                      (Some t.status) current_state_view state_and_body_hash
                   with
                   | Ok (res, updated_pending_coinbase_stack_state) ->
                       (res :: acc, updated_pending_coinbase_stack_state)
                   | Error err ->
-                      raise (Exit err) ) )
-        in
-        return ret
-      with Exit err -> Deferred.Result.fail err
+                      raise (Exit err) ) ) )
+      |> Deferred.Result.map_error ~f:(function
+           | Exit err ->
+               err
+           | exn ->
+               raise exn )
     in
     (List.rev res_rev, pending_coinbase_stack_state.pc.target)
 
@@ -1568,7 +1590,9 @@ module T = struct
           { Staged_ledger_diff.Pre_diff_one.commands=
               Sequence.to_list_rev res.commands_rev
           ; completed_works= Sequence.to_list_rev res.completed_work_rev
-          ; coinbase= to_at_most_one res.coinbase } )
+          ; coinbase= to_at_most_one res.coinbase
+          ; internal_command_statuses=
+              (* These will get filled in by the caller. *) [] } )
     in
     let pre_diff_with_two (res : Resources.t) :
         Staged_ledger_diff.With_valid_signatures_and_proofs
@@ -1576,7 +1600,9 @@ module T = struct
       (* We have to reverse here because we only know they work in THIS order *)
       { commands= Sequence.to_list_rev res.commands_rev
       ; completed_works= Sequence.to_list_rev res.completed_work_rev
-      ; coinbase= res.coinbase }
+      ; coinbase= res.coinbase
+      ; internal_command_statuses=
+          (* These will get filled in by the caller. *) [] }
     in
     let end_log ((res : Resources.t), (log : Diff_creation_log.t)) =
       Diff_creation_log.end_log log ~completed_work:res.completed_work_rev
@@ -1692,6 +1718,7 @@ module T = struct
       ~(get_completed_work :
             Transaction_snark_work.Statement.t
          -> Transaction_snark_work.Checked.t option) ~supercharge_coinbase =
+    let open Result.Let_syntax in
     O1trace.trace_event "curr_hash" ;
     let validating_ledger = Transaction_validator.create t.ledger in
     let is_new_account pk =
@@ -1791,6 +1818,21 @@ module T = struct
             valid_on_this_ledger ~receiver:coinbase_receiver
             ~is_coinbase_receiver_new ~supercharge_coinbase partitions )
     in
+    let%map diff =
+      (* Fill in the statuses for commands. *)
+      let generate_status =
+        let status_ledger = Transaction_validator.create t.ledger in
+        fun txn ->
+          O1trace.measure "get txn status" (fun () ->
+              Transaction_validator.apply_transaction ~constraint_constants
+                status_ledger ~txn_state_view:current_state_view txn )
+      in
+      Pre_diff_info.compute_statuses ~constraint_constants ~diff
+        ~coinbase_amount:
+          (Option.value_exn
+             (coinbase_amount ~constraint_constants ~supercharge_coinbase))
+        ~coinbase_receiver ~generate_status ~forget:User_command.forget_check
+    in
     let summaries, detailed = List.unzip log in
     [%log debug]
       "Number of proofs ready for purchase: $proof_count Number of user \
@@ -1850,6 +1892,13 @@ let%test_module "test" =
         Sl.create_diff ~constraint_constants !sl ~logger ~current_state_view
           ~transactions_by_fee:txns ~get_completed_work:stmt_to_work
           ~supercharge_coinbase ~coinbase_receiver
+      in
+      let diff =
+        match diff with
+        | Ok x ->
+            x
+        | Error e ->
+            Error.raise (Pre_diff_info.Error.to_error e)
       in
       let diff' = Staged_ledger_diff.forget diff in
       let%bind verifier =
@@ -2340,39 +2389,57 @@ let%test_module "test" =
                      (Account_id.create snark_worker_pk Token_id.default)) ) )
       )
 
+    let compute_statuses ~ledger ~coinbase_amount diff =
+      let generate_status =
+        let status_ledger = Transaction_validator.create ledger in
+        fun txn ->
+          O1trace.measure "get txn status" (fun () ->
+              Transaction_validator.apply_transaction ~constraint_constants
+                status_ledger ~txn_state_view:(dummy_state_view ()) txn )
+      in
+      Pre_diff_info.compute_statuses ~constraint_constants ~diff
+        ~coinbase_amount ~coinbase_receiver ~generate_status ~forget:Fn.id
+      |> Result.map_error ~f:Pre_diff_info.Error.to_error
+      |> Or_error.ok_exn
+
     let%test_unit "Invalid diff test: check zero fee excess for partitions" =
-      let create_diff_with_non_zero_fee_excess txns completed_works
-          (partition : Sl.Scan_state.Space_partition.t) : Staged_ledger_diff.t
-          =
+      let create_diff_with_non_zero_fee_excess ~ledger ~coinbase_amount txns
+          completed_works (partition : Sl.Scan_state.Space_partition.t) :
+          Staged_ledger_diff.t =
         (*With exact number of user commands in partition.first, the fee transfers that settle the fee_excess would be added to the next tree causing a non-zero fee excess*)
         let slots, job_count1 = partition.first in
         match partition.second with
         | None ->
             { diff=
-                ( { completed_works= List.take completed_works job_count1
-                  ; commands= List.take txns slots
-                  ; coinbase= Zero }
-                , None ) }
+                compute_statuses ~ledger ~coinbase_amount
+                @@ ( { completed_works= List.take completed_works job_count1
+                     ; commands= List.take txns slots
+                     ; coinbase= Zero
+                     ; internal_command_statuses= [] }
+                   , None ) }
         | Some (_, _) ->
             let txns_in_second_diff = List.drop txns slots in
             let diff : Staged_ledger_diff.Diff.t =
               ( { completed_works= List.take completed_works job_count1
                 ; commands= List.take txns slots
-                ; coinbase= Zero }
+                ; coinbase= Zero
+                ; internal_command_statuses= [] }
               , Some
                   { completed_works=
                       ( if List.is_empty txns_in_second_diff then []
                       else List.drop completed_works job_count1 )
                   ; commands= txns_in_second_diff
-                  ; coinbase= Zero } )
+                  ; coinbase= Zero
+                  ; internal_command_statuses= [] } )
             in
-            {diff}
+            {diff= compute_statuses ~ledger ~coinbase_amount diff}
       in
       let empty_diff : Staged_ledger_diff.t =
         { diff=
             ( { completed_works= []
               ; commands= []
-              ; coinbase= Staged_ledger_diff.At_most_two.Zero }
+              ; coinbase= Staged_ledger_diff.At_most_two.Zero
+              ; internal_command_statuses= [] }
             , None ) }
       in
       Quickcheck.test (gen_below_capacity ())
@@ -2412,8 +2479,10 @@ let%test_module "test" =
                              } )
                     in
                     let diff =
-                      create_diff_with_non_zero_fee_excess cmds_this_iter
-                        work_done partitions
+                      create_diff_with_non_zero_fee_excess
+                        ~ledger:(Sl.ledger !sl)
+                        ~coinbase_amount:constraint_constants.coinbase_amount
+                        cmds_this_iter work_done partitions
                     in
                     let%bind verifier =
                       Verifier.create ~logger ~proof_level ~pids ~conf_dir:None
@@ -2479,12 +2548,18 @@ let%test_module "test" =
               iter_cmds_acc cmds iters ()
                 (fun _cmds_left _count_opt cmds_this_iter () ->
                   let diff =
-                    Sl.create_diff ~constraint_constants !sl ~logger
-                      ~current_state_view:(dummy_state_view ())
-                      ~transactions_by_fee:cmds_this_iter
-                      ~get_completed_work:stmt_to_work ~coinbase_receiver
-                      ~supercharge_coinbase:true
-                    |> Staged_ledger_diff.forget
+                    let diff =
+                      Sl.create_diff ~constraint_constants !sl ~logger
+                        ~current_state_view:(dummy_state_view ())
+                        ~transactions_by_fee:cmds_this_iter
+                        ~get_completed_work:stmt_to_work ~coinbase_receiver
+                        ~supercharge_coinbase:true
+                    in
+                    match diff with
+                    | Ok x ->
+                        Staged_ledger_diff.forget x
+                    | Error e ->
+                        Error.raise (Pre_diff_info.Error.to_error e)
                   in
                   (*No proofs were purchased since the fee for the proofs are not sufficient to pay for account creation*)
                   assert (no_work_included diff) ;

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1591,7 +1591,7 @@ module T = struct
               Sequence.to_list_rev res.commands_rev
           ; completed_works= Sequence.to_list_rev res.completed_work_rev
           ; coinbase= to_at_most_one res.coinbase
-          ; internal_command_statuses=
+          ; internal_command_balances=
               (* These will get filled in by the caller. *) [] } )
     in
     let pre_diff_with_two (res : Resources.t) :
@@ -1601,7 +1601,7 @@ module T = struct
       { commands= Sequence.to_list_rev res.commands_rev
       ; completed_works= Sequence.to_list_rev res.completed_work_rev
       ; coinbase= res.coinbase
-      ; internal_command_statuses=
+      ; internal_command_balances=
           (* These will get filled in by the caller. *) [] }
     in
     let end_log ((res : Resources.t), (log : Diff_creation_log.t)) =
@@ -2415,7 +2415,7 @@ let%test_module "test" =
                 @@ ( { completed_works= List.take completed_works job_count1
                      ; commands= List.take txns slots
                      ; coinbase= Zero
-                     ; internal_command_statuses= [] }
+                     ; internal_command_balances= [] }
                    , None ) }
         | Some (_, _) ->
             let txns_in_second_diff = List.drop txns slots in
@@ -2423,14 +2423,14 @@ let%test_module "test" =
               ( { completed_works= List.take completed_works job_count1
                 ; commands= List.take txns slots
                 ; coinbase= Zero
-                ; internal_command_statuses= [] }
+                ; internal_command_balances= [] }
               , Some
                   { completed_works=
                       ( if List.is_empty txns_in_second_diff then []
                       else List.drop completed_works job_count1 )
                   ; commands= txns_in_second_diff
                   ; coinbase= Zero
-                  ; internal_command_statuses= [] } )
+                  ; internal_command_balances= [] } )
             in
             {diff= compute_statuses ~ledger ~coinbase_amount diff}
       in
@@ -2439,7 +2439,7 @@ let%test_module "test" =
             ( { completed_works= []
               ; commands= []
               ; coinbase= Staged_ledger_diff.At_most_two.Zero
-              ; internal_command_statuses= [] }
+              ; internal_command_balances= [] }
             , None ) }
       in
       Quickcheck.test (gen_below_capacity ())

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -64,6 +64,8 @@ module Staged_ledger_error : sig
     | Couldn't_reach_verifier of Error.t
     | Pre_diff of Pre_diff_info.Error.t
     | Insufficient_work of string
+    | Mismatched_statuses of
+        Transaction.t With_status.t * User_command_status.t
     | Unexpected of Error.t
   [@@deriving sexp]
 
@@ -165,7 +167,9 @@ val create_diff :
   -> get_completed_work:(   Transaction_snark_work.Statement.t
                          -> Transaction_snark_work.Checked.t option)
   -> supercharge_coinbase:bool
-  -> Staged_ledger_diff.With_valid_signatures_and_proofs.t
+  -> ( Staged_ledger_diff.With_valid_signatures_and_proofs.t
+     , Pre_diff_info.Error.t )
+     Result.t
 
 val can_apply_supercharged_coinbase_exn :
      winner:Public_key.Compressed.t

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.ml
@@ -82,7 +82,9 @@ module Pre_diff_two = struct
         { completed_works: 'a list
         ; commands: 'b list
         ; coinbase: Ft.Stable.V1.t At_most_two.Stable.V1.t
-        ; internal_command_statuses: User_command_status.Stable.V1.t list }
+        ; internal_command_balances:
+            User_command_status.Internal_command_balance_data.Stable.V1.t list
+        }
       [@@deriving sexp, to_yojson]
     end
   end]
@@ -91,7 +93,8 @@ module Pre_diff_two = struct
     { completed_works: 'a list
     ; commands: 'b list
     ; coinbase: Ft.t At_most_two.t
-    ; internal_command_statuses: User_command_status.t list }
+    ; internal_command_balances:
+        User_command_status.Internal_command_balance_data.t list }
   [@@deriving sexp, to_yojson]
 end
 
@@ -105,7 +108,9 @@ module Pre_diff_one = struct
         { completed_works: 'a list
         ; commands: 'b list
         ; coinbase: Ft.Stable.V1.t At_most_one.Stable.V1.t
-        ; internal_command_statuses: User_command_status.Stable.V1.t list }
+        ; internal_command_balances:
+            User_command_status.Internal_command_balance_data.Stable.V1.t list
+        }
       [@@deriving sexp, to_yojson]
     end
   end]
@@ -114,7 +119,8 @@ module Pre_diff_one = struct
     { completed_works: 'a list
     ; commands: 'b list
     ; coinbase: Ft.t At_most_one.t
-    ; internal_command_statuses: User_command_status.t list }
+    ; internal_command_balances:
+        User_command_status.Internal_command_balance_data.t list }
   [@@deriving sexp, to_yojson]
 end
 
@@ -301,7 +307,7 @@ let validate_commands (t : t)
         { completed_works= d1.completed_works
         ; commands= commands1
         ; coinbase= d1.coinbase
-        ; internal_command_statuses= d1.internal_command_statuses }
+        ; internal_command_balances= d1.internal_command_balances }
       in
       let p2 =
         Option.value_map ~default:None d2 ~f:(fun d2 ->
@@ -309,7 +315,7 @@ let validate_commands (t : t)
               { Pre_diff_one.completed_works= d2.completed_works
               ; commands= commands2
               ; coinbase= d2.coinbase
-              ; internal_command_statuses= d2.internal_command_statuses } )
+              ; internal_command_balances= d2.internal_command_balances } )
       in
       ({diff= (p1, p2)} : With_valid_signatures.t) )
 
@@ -320,14 +326,14 @@ let forget_proof_checks (d : With_valid_signatures_and_proofs.t) :
     { completed_works= forget_cw d1.completed_works
     ; commands= d1.commands
     ; coinbase= d1.coinbase
-    ; internal_command_statuses= d1.internal_command_statuses }
+    ; internal_command_balances= d1.internal_command_balances }
   in
   let p2 =
     Option.map (snd d.diff) ~f:(fun d2 ->
         ( { completed_works= forget_cw d2.completed_works
           ; commands= d2.commands
           ; coinbase= d2.coinbase
-          ; internal_command_statuses= d2.internal_command_statuses }
+          ; internal_command_balances= d2.internal_command_balances }
           : With_valid_signatures.pre_diff_with_at_most_one_coinbase ) )
   in
   {diff= (p1, p2)}
@@ -339,7 +345,7 @@ let forget_pre_diff_with_at_most_two
   { completed_works= forget_cw pre_diff.completed_works
   ; commands= (pre_diff.commands :> User_command.t With_status.t list)
   ; coinbase= pre_diff.coinbase
-  ; internal_command_statuses= pre_diff.internal_command_statuses }
+  ; internal_command_balances= pre_diff.internal_command_balances }
 
 let forget_pre_diff_with_at_most_one
     (pre_diff :
@@ -347,7 +353,7 @@ let forget_pre_diff_with_at_most_one
   { Pre_diff_one.completed_works= forget_cw pre_diff.completed_works
   ; commands= (pre_diff.commands :> User_command.t With_status.t list)
   ; coinbase= pre_diff.coinbase
-  ; internal_command_statuses= pre_diff.internal_command_statuses }
+  ; internal_command_balances= pre_diff.internal_command_balances }
 
 let forget (t : With_valid_signatures_and_proofs.t) =
   { diff=

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.ml
@@ -81,13 +81,17 @@ module Pre_diff_two = struct
       type ('a, 'b) t =
         { completed_works: 'a list
         ; commands: 'b list
-        ; coinbase: Ft.Stable.V1.t At_most_two.Stable.V1.t }
+        ; coinbase: Ft.Stable.V1.t At_most_two.Stable.V1.t
+        ; internal_command_statuses: User_command_status.Stable.V1.t list }
       [@@deriving sexp, to_yojson]
     end
   end]
 
   type ('a, 'b) t = ('a, 'b) Stable.Latest.t =
-    {completed_works: 'a list; commands: 'b list; coinbase: Ft.t At_most_two.t}
+    { completed_works: 'a list
+    ; commands: 'b list
+    ; coinbase: Ft.t At_most_two.t
+    ; internal_command_statuses: User_command_status.t list }
   [@@deriving sexp, to_yojson]
 end
 
@@ -100,13 +104,17 @@ module Pre_diff_one = struct
       type ('a, 'b) t =
         { completed_works: 'a list
         ; commands: 'b list
-        ; coinbase: Ft.Stable.V1.t At_most_one.Stable.V1.t }
+        ; coinbase: Ft.Stable.V1.t At_most_one.Stable.V1.t
+        ; internal_command_statuses: User_command_status.Stable.V1.t list }
       [@@deriving sexp, to_yojson]
     end
   end]
 
   type ('a, 'b) t = ('a, 'b) Stable.Latest.t =
-    {completed_works: 'a list; commands: 'b list; coinbase: Ft.t At_most_one.t}
+    { completed_works: 'a list
+    ; commands: 'b list
+    ; coinbase: Ft.t At_most_one.t
+    ; internal_command_statuses: User_command_status.t list }
   [@@deriving sexp, to_yojson]
 end
 
@@ -292,14 +300,16 @@ let validate_commands (t : t)
       let p1 : With_valid_signatures.pre_diff_with_at_most_two_coinbase =
         { completed_works= d1.completed_works
         ; commands= commands1
-        ; coinbase= d1.coinbase }
+        ; coinbase= d1.coinbase
+        ; internal_command_statuses= d1.internal_command_statuses }
       in
       let p2 =
         Option.value_map ~default:None d2 ~f:(fun d2 ->
             Some
               { Pre_diff_one.completed_works= d2.completed_works
               ; commands= commands2
-              ; coinbase= d2.coinbase } )
+              ; coinbase= d2.coinbase
+              ; internal_command_statuses= d2.internal_command_statuses } )
       in
       ({diff= (p1, p2)} : With_valid_signatures.t) )
 
@@ -309,13 +319,15 @@ let forget_proof_checks (d : With_valid_signatures_and_proofs.t) :
   let p1 : With_valid_signatures.pre_diff_with_at_most_two_coinbase =
     { completed_works= forget_cw d1.completed_works
     ; commands= d1.commands
-    ; coinbase= d1.coinbase }
+    ; coinbase= d1.coinbase
+    ; internal_command_statuses= d1.internal_command_statuses }
   in
   let p2 =
     Option.map (snd d.diff) ~f:(fun d2 ->
         ( { completed_works= forget_cw d2.completed_works
           ; commands= d2.commands
-          ; coinbase= d2.coinbase }
+          ; coinbase= d2.coinbase
+          ; internal_command_statuses= d2.internal_command_statuses }
           : With_valid_signatures.pre_diff_with_at_most_one_coinbase ) )
   in
   {diff= (p1, p2)}
@@ -326,14 +338,16 @@ let forget_pre_diff_with_at_most_two
     Pre_diff_with_at_most_two_coinbase.t =
   { completed_works= forget_cw pre_diff.completed_works
   ; commands= (pre_diff.commands :> User_command.t With_status.t list)
-  ; coinbase= pre_diff.coinbase }
+  ; coinbase= pre_diff.coinbase
+  ; internal_command_statuses= pre_diff.internal_command_statuses }
 
 let forget_pre_diff_with_at_most_one
     (pre_diff :
       With_valid_signatures_and_proofs.pre_diff_with_at_most_one_coinbase) =
   { Pre_diff_one.completed_works= forget_cw pre_diff.completed_works
   ; commands= (pre_diff.commands :> User_command.t With_status.t list)
-  ; coinbase= pre_diff.coinbase }
+  ; coinbase= pre_diff.coinbase
+  ; internal_command_statuses= pre_diff.internal_command_statuses }
 
 let forget (t : With_valid_signatures_and_proofs.t) =
   { diff=

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.mli
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.mli
@@ -34,7 +34,8 @@ module Pre_diff_two : sig
   type ('a, 'b) t =
     { completed_works: 'a list
     ; commands: 'b list
-    ; coinbase: Coinbase.Fee_transfer.t At_most_two.t }
+    ; coinbase: Coinbase.Fee_transfer.t At_most_two.t
+    ; internal_command_statuses: User_command_status.t list }
   [@@deriving sexp, to_yojson]
 
   module Stable :
@@ -50,7 +51,8 @@ module Pre_diff_one : sig
   type ('a, 'b) t =
     { completed_works: 'a list
     ; commands: 'b list
-    ; coinbase: Coinbase.Fee_transfer.t At_most_one.t }
+    ; coinbase: Coinbase.Fee_transfer.t At_most_one.t
+    ; internal_command_statuses: User_command_status.t list }
   [@@deriving sexp, to_yojson]
 
   module Stable :

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.mli
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.mli
@@ -35,7 +35,8 @@ module Pre_diff_two : sig
     { completed_works: 'a list
     ; commands: 'b list
     ; coinbase: Coinbase.Fee_transfer.t At_most_two.t
-    ; internal_command_statuses: User_command_status.t list }
+    ; internal_command_balances:
+        User_command_status.Internal_command_balance_data.t list }
   [@@deriving sexp, to_yojson]
 
   module Stable :
@@ -52,7 +53,8 @@ module Pre_diff_one : sig
     { completed_works: 'a list
     ; commands: 'b list
     ; coinbase: Coinbase.Fee_transfer.t At_most_one.t
-    ; internal_command_statuses: User_command_status.t list }
+    ; internal_command_balances:
+        User_command_status.Internal_command_balance_data.t list }
   [@@deriving sexp, to_yojson]
 
   module Stable :

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -299,12 +299,13 @@ module For_tests = struct
                 ~pids:(Child_processes.Termination.create_pid_table ()) )
     in
     let gen_slot_advancement = Int.gen_incl 1 10 in
-    let%map make_next_consensus_state =
+    let%bind make_next_consensus_state =
       Consensus_state_hooks.For_tests.gen_consensus_state ~gen_slot_advancement
         ~constraint_constants:
           precomputed_values.Precomputed_values.constraint_constants
         ~constants:precomputed_values.consensus_constants
     in
+    let%map supercharge_coinbase = Quickcheck.Generator.bool in
     fun parent_breadcrumb ->
       let open Deferred.Let_syntax in
       let parent_staged_ledger = staged_ledger parent_breadcrumb in
@@ -346,7 +347,6 @@ module For_tests = struct
         , (Protocol_state.hash_with_body ~body_hash prev_state, body_hash) )
       in
       let coinbase_receiver = largest_account_public_key in
-      let supercharge_coinbase = true in
       let staged_ledger_diff =
         Staged_ledger.create_diff parent_staged_ledger ~logger
           ~constraint_constants:precomputed_values.constraint_constants
@@ -408,7 +408,7 @@ module For_tests = struct
           ~previous_protocol_state:
             With_hash.
               {data= previous_protocol_state; hash= previous_state_hash}
-          ~coinbase_receiver
+          ~coinbase_receiver ~supercharge_coinbase
       in
       let genesis_state_hash =
         Protocol_state.genesis_state_hash

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -143,7 +143,8 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
                           make_actions Sent_invalid_signature_or_proof
                       | Pre_diff _
                       | Non_zero_fee_excess _
-                      | Insufficient_work _ ->
+                      | Insufficient_work _
+                      | Mismatched_statuses _ ->
                           make_actions Gossiped_invalid_transition
                       | Unexpected _ ->
                           failwith
@@ -351,6 +352,8 @@ module For_tests = struct
           ~constraint_constants:precomputed_values.constraint_constants
           ~coinbase_receiver ~current_state_view ~supercharge_coinbase
           ~transactions_by_fee:transactions ~get_completed_work
+        |> Result.map_error ~f:Staged_ledger.Pre_diff_info.Error.to_error
+        |> Or_error.ok_exn
       in
       let%bind ( `Hash_after_applying next_staged_ledger_hash
                , `Ledger_proof ledger_proof_opt

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -408,6 +408,7 @@ module For_tests = struct
           ~previous_protocol_state:
             With_hash.
               {data= previous_protocol_state; hash= previous_state_hash}
+          ~coinbase_receiver
       in
       let genesis_state_hash =
         Protocol_state.genesis_state_hash


### PR DESCRIPTION
This PR
* updates the staged ledger pre-diffs to include the balances involved in each internal command (fee payment or coinbase)
* adds validation for the user command statuses and balance information stored in the diffs
  - previously, we had been relying on the statuses being accurate for the archive node, but we never checked them
  - now their correctness is enforced by a trust score

This is more invasive than some of the other ways we could have exposed this data for #6940. However, doing it this way allows partial ledgers and transactions to be reliably reconstructed from a block without needing to use or reimplement a full archive node, which was one of the stated goals of #7074.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: