### PR TITLE
expose snark coordinator's client port for worker inter-communication

### DIFF
--- a/helm/snark-worker/Chart.yaml
+++ b/helm/snark-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: snark-worker
 description: A Helm chart for Mina Protocol's SNARK worker nodes
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/snark-worker/templates/coordinator-service.yaml
+++ b/helm/snark-worker/templates/coordinator-service.yaml
@@ -17,4 +17,7 @@ spec:
   - name: tcp-p2p
     port: {{ .Values.coda.ports.p2p }}
     targetPort: external-port
+  - name: tcp-client
+    port: {{ .Values.coda.ports.client }}
+    targetPort: client-port
 {{ end }}


### PR DESCRIPTION
Add client port to `snark-coordinator`'s ClusterIP service object for inter-communication with SNARK workers.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
