### PR TITLE
update prometheus scrape/listening port annotation with metrics port var

### DIFF
--- a/helm/archive-node/Chart.yaml
+++ b/helm/archive-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: archive-node
 description: A Helm chart for Mina Protocol's archive node
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.16.0
 dependencies:
   - name: postgresql

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -18,7 +18,7 @@ spec:
         version: {{ trunc 6 (split ":" .Values.coda.image)._1 }}
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '10000'
+        prometheus.io/port: {{ .Values.coda.ports.metrics | quote }}
         prometheus.io/path: '/metrics'
     spec:
       containers:

--- a/helm/block-producer/Chart.yaml
+++ b/helm/block-producer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: block-producer
 description: A Helm chart for Mina Protocol's block producing network nodes
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -20,6 +20,7 @@ spec:
         version: {{ trunc 6 (split ":" $.Values.coda.image)._1 }}
       annotations:
         prometheus.io/scrape: 'true'
+        prometheus.io/port: {{ $.Values.coda.ports.metrics | quote }}
         prometheus.io/path: '/metrics'
     spec:
       initContainers:

--- a/helm/seed-node/Chart.yaml
+++ b/helm/seed-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: seed-node
 description: A Helm chart for Mina Protocol's seed nodes
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -19,7 +19,7 @@ spec:
         version: {{ trunc 6 (split ":" .Values.coda.image)._1 }}
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '10000'
+        prometheus.io/port: {{ .Values.coda.ports.metrics | quote }}
         prometheus.io/path: '/metrics'
     spec:
       containers:

--- a/helm/snark-worker/Chart.yaml
+++ b/helm/snark-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: snark-worker
 description: A Helm chart for Mina Protocol's SNARK worker nodes
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -19,7 +19,7 @@ spec:
         version: {{ trunc 6 (split ":" .Values.coda.image)._1 }}
       annotations:
         prometheus.io/scrape: 'true'
-        prometheus.io/port: '10000'
+        prometheus.io/port: {{ .Values.coda.ports.metrics | quote }}
         prometheus.io/path: '/metrics'
     spec:
       containers:


### PR DESCRIPTION
The port annotations should reference the recently added port variables rather than rely on static values within the charts.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
