### PR TITLE
ensure trailing "-" are removed from version labels (based on docker image tags)

### DIFF
--- a/helm/archive-node/Chart.yaml
+++ b/helm/archive-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: archive-node
 description: A Helm chart for Mina Protocol's archive node
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: 1.16.0
 dependencies:
   - name: postgresql

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -15,7 +15,7 @@ spec:
         app: {{ .Values.archive.fullname }}
         testnet: {{ .Values.testnetName }}
         role: archive-node
-        version: {{ trunc 6 (split ":" .Values.coda.image)._1 }}
+        version: {{ trunc 6 (split ":" .Values.coda.image)._1 | trimSuffix "-" }}
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: {{ .Values.coda.ports.metrics | quote }}

--- a/helm/block-producer/Chart.yaml
+++ b/helm/block-producer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: block-producer
 description: A Helm chart for Mina Protocol's block producing network nodes
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -17,7 +17,7 @@ spec:
         testnet: {{ $.Values.testnetName }}
         role: block-producer
         class: {{ default "undefined" $config.class }}
-        version: {{ trunc 6 (split ":" $.Values.coda.image)._1 }}
+        version: {{ trunc 6 (split ":" $.Values.coda.image)._1 | trimSuffix "-" }}
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: {{ $.Values.coda.ports.metrics | quote }}

--- a/helm/seed-node/Chart.yaml
+++ b/helm/seed-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: seed-node
 description: A Helm chart for Mina Protocol's seed nodes
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -16,7 +16,7 @@ spec:
         app: {{tpl .Values.seed.fullname .}}
         testnet: {{ .Values.testnetName }}
         role: seed
-        version: {{ trunc 6 (split ":" .Values.coda.image)._1 }}
+        version: {{ trunc 6 (split ":" .Values.coda.image)._1 | trimSuffix "-" }}
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: {{ .Values.coda.ports.metrics | quote }}

--- a/helm/snark-worker/Chart.yaml
+++ b/helm/snark-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: snark-worker
 description: A Helm chart for Mina Protocol's SNARK worker nodes
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -16,7 +16,7 @@ spec:
         app: {{tpl .Values.coordinator.fullname .}}
         testnet: {{ .Values.testnetName }}
         role: snark-coordinator
-        version: {{ trunc 6 (split ":" .Values.coda.image)._1 }}
+        version: {{ trunc 6 (split ":" .Values.coda.image)._1 | trimSuffix "-" }}
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: {{ .Values.coda.ports.metrics | quote }}

--- a/helm/snark-worker/templates/snark-worker.yaml
+++ b/helm/snark-worker/templates/snark-worker.yaml
@@ -16,7 +16,7 @@ spec:
         app: {{tpl .Values.worker.fullname .}}
         testnet: {{ .Values.testnetName }}
         role: snark-worker
-        version: {{ trunc 6 (split ":" .Values.coda.image)._1 }}
+        version: {{ trunc 6 (split ":" .Values.coda.image)._1 | trimSuffix "-" }}
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '10000'


### PR DESCRIPTION
Trimming trailing "-" is a [common practice](https://github.com/MinaProtocol/mina/blob/develop/helm/archive-node/templates/_helpers.tpl#L6) across our charts and should help avoid future encounters of the following error:

```
Error: Deployment.apps "seed-node" is invalid: spec.template.labels: Invalid value: "0.1.0-": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character

  on ../../modules/kubernetes/testnet/helm.tf line 161, in resource "helm_release" "seed":
 161: resource "helm_release" "seed" {
```

**note:** "must start and end with an alphanumeric character"

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
