### PR TITLE
Catch errors raised when checking the persistent frontier db

### DIFF
--- a/src/lib/transition_frontier/persistent_frontier/database.mli
+++ b/src/lib/transition_frontier/persistent_frontier/database.mli
@@ -31,7 +31,9 @@ module Error : sig
 
   type not_found = [`Not_found of not_found_member]
 
-  type t = [not_found | `Invalid_version]
+  type raised = [`Raised of Error.t]
+
+  type t = [not_found | raised | `Invalid_version]
 
   val not_found_message : not_found -> string
 
@@ -58,7 +60,8 @@ val check :
             | `Root_transition
             | `Transition of State_hash.t
             | `Arcs of State_hash.t
-            | `Protocol_states_for_root_scan_state ] ] ] )
+            | `Protocol_states_for_root_scan_state ]
+         | `Raised of Core_kernel.Error.t ] ] )
      Result.t
 
 val initialize : t -> root_data:Root_data.Limited.t -> unit


### PR DESCRIPTION
This catches database corruption errors where the data written is itself corrupted. This allows us to clear the corrupted database and try again.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes  #7112
