### PR TITLE
Bazel: src/lib/pickles support

### DIFF
--- a/src/lib/coda_version/BUILD.bazel
+++ b/src/lib/coda_version/BUILD.bazel
@@ -1,0 +1,78 @@
+load( "@obazl_rules_ocaml//ocaml:rules.bzl", "ocaml_interface", "ocaml_module")
+load( "@obazl_tools_bazel//tools:rules.bzl", "stamped_filegroup")
+
+## Only stamp if --stamp flag is pased.  Otherwise use generic defaults.
+
+#############
+ocaml_module(
+    name = "coda_version",
+    module_name = "coda_version",
+    src  = select({
+        "//:stampit": "coda_version.ml",
+        "//conditions:default": "coda_version_defaults.ml"
+    }),
+    opts = [
+        "-w", "-32" # Error (warning 32): unused value marlin_branch.
+    ],
+    intf = ":_Coda_version.cmi",
+    ppx = "//bzl/ppx/exe:ppx_version",
+    visibility = ["//visibility:public"],
+)
+
+################
+ocaml_interface(
+    name = "_Coda_version.cmi",
+    src = "coda_version.mli",
+    ppx = "//bzl/ppx/exe:ppx_version"
+)
+
+########
+genrule(
+    name = "gensrc",
+    stamp = True,
+    srcs = ["coda_version.ml.template"],
+    outs = ["coda_version.ml"],
+    cmd = "\n".join([
+        "exec <bazel-out/stable-status.txt",
+        "while read -r K V LINE",  # -r "backslash does not act as an escape char"
+        "do",
+        "    echo $$K",
+        "    eval $$K=$$V",
+        "done",
+        "exec 3>$@",
+        "exec <$<",
+        "while read -r LINE",
+        "do",
+        "    LINE=\"$${LINE//\\{MINA_COMMIT_ID\\}/$$STABLE_MINA_COMMIT_ID}\"",
+        "    LINE=\"$${LINE//\\{MINA_COMMIT_ID_SHORT\\}/$$STABLE_MINA_COMMIT_ID_SHORT}\"",
+        "    LINE=\"$${LINE//\\{MINA_BRANCH\\}/$$STABLE_MINA_BRANCH}\"",
+        "    LINE=\"$${LINE//\\{MINA_COMMIT_DATE\\}/$$STABLE_MINA_COMMIT_DATE}\"",
+        "    echo",
+        "    LINE=\"$${LINE//\\{MARLIN_COMMIT_ID\\}/$$STABLE_MARLIN_COMMIT_ID}\"",
+        "    LINE=\"$${LINE//\\{MARLIN_COMMIT_ID_SHORT\\}/$$STABLE_MARLIN_COMMIT_ID_SHORT}\"",
+        "    LINE=\"$${LINE//\\{MARLIN_COMMIT_DATE\\}/$$STABLE_MARLIN_COMMIT_DATE}\"",
+        "    echo",
+        "    LINE=\"$${LINE//\\{ZEXE_COMMIT_ID\\}/$$STABLE_ZEXE_COMMIT_ID}\"",
+        "    LINE=\"$${LINE//\\{ZEXE_COMMIT_ID_SHORT\\}/$$STABLE_ZEXE_COMMIT_ID_SHORT}\"",
+        "    LINE=\"$${LINE//\\{ZEXE_COMMIT_DATE\\}/$$STABLE_ZEXE_COMMIT_DATE}\"",
+        "    echo $$LINE 1>&3",
+        "done",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+# stamped_filegroup(
+#     name = "gensrcx",
+#     output   = "coda_version.ml",
+#     template = "coda_version.template",
+#     stamp = True,
+#     substitutions = {
+#         "{BRANCH}": "STABLE_GIT_BRANCH",
+#         "{COMMIT_ID}": "STABLE_GIT_COMMIT_ID",
+#         "{COMMIT_ID_SHORT}": "STABLE_GIT_COMMIT_ID_SHORT",
+#         "{COMMIT_DATE}": "STABLE_GIT_COMMIT_DATE"
+#         # "{BRANCH}": "bazel-base",
+#         # "{COMMIT_ID}": "79517ccd5a026663449ab8433b91264eac0eb570",
+#         # "{COMMIT_ID_SHORT}": "79517ccd"
+#     }
+# )

--- a/src/lib/coda_version/coda_version.ml.template
+++ b/src/lib/coda_version/coda_version.ml.template
@@ -1,0 +1,12 @@
+let commit_id = "{MINA_COMMIT_ID}"
+let commit_id_short = "{MINA_COMMIT_ID_SHORT}"
+let branch = "{MINA_BRANCH}"
+let commit_date = "{MINA_COMMIT_DATE}"
+
+let marlin_commit_id = "{MARLIN_COMMIT_ID}"
+let marlin_commit_id_short = "{MARLIN_COMMIT_ID_SHORT}"
+let marlin_commit_date = "{MARLIN_COMMIT_DATE}"
+
+let zexe_commit_id = "{ZEXE_COMMIT_ID}"
+let zexe_commit_id_short = "{ZEXE_COMMIT_ID_SHORT}"
+let zexe_commit_date = "{ZEXE_COMMIT_DATE}"

--- a/src/lib/pickles/BUILD.bazel
+++ b/src/lib/pickles/BUILD.bazel
@@ -1,0 +1,1092 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_interface",
+    "ocaml_module",
+    "ocaml_ns",
+)
+
+PPX_PRINT = "@ppx//print:binary"
+
+################################################################
+## STANZA 1: LIBRARY PICKLES
+################################################################
+PICKLES_INTERFACE_OPTS = []
+
+PICKLES_MODULE_OPTS = []
+
+PICKLES_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:digestif.c",
+    "@opam//pkg:core_kernel",
+    "@mina//src/lib/coda_version",
+    "@mina//src/lib/zexe_backend",
+    "@mina//src/lib/random_oracle_input",
+    "@mina//src/lib/pickles_base",
+    "@mina//src/lib/pickles/composition_types",
+    "@mina//src/lib/pickles/limb_vector",
+    "@mina//src/lib/pickles/plonk_checks",
+    "@mina//src/lib/pickles/precomputed",
+    "@mina//src/lib/pickles/one_hot_vector",
+    "@mina//src/lib/pickles/pseudo",
+    "@mina//src/lib/snarky_log",
+    "@snarky//sponge",
+    "@snarky//group_map",
+    "@mina//src/lib/snarky_group_map",
+    "@snarky//snarky_curve",
+    "@snarky//src/base:snarky_backendless",
+    "@mina//src/lib/key_cache",
+    "@mina//src/lib/snark_keys_header",
+]
+
+PICKLES_PPX = "@//bzl/ppx/exe:ppx_version__ppx_coda__ppx_jane__ppx_deriving.std__ppx_deriving_yojson__h_list.ppx"
+
+PICKLES_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "pickles",
+]
+
+##############
+ocaml_archive(
+    name = "pickles",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Cache",
+        ":_Cache_handle",
+        ":_Commitment_lengths",
+        ":_Common",
+        ":_Dirty",
+        ":_Dlog_main",
+        ":_Dummy",
+        ":_Endo",
+        ":_Fix_domains",
+        ":_Full_signature",
+        ":_Impls",
+        ":_Import",
+        ":_Inductive_rule",
+        ":_Intf",
+        ":_Make_sponge",
+        ":_Opt_sponge",
+        ":_Pairing_main",
+        ":_Per_proof_witness",
+        ":_Pickles",
+        ":_Plonk_curve_ops",
+        ":_Proof",
+        ":_Reduced_me_only",
+        ":_Requests",
+        ":_Ro",
+        ":_Scalar_challenge",
+        ":_Side_loaded_verification_key",
+        ":_Sponge_inputs",
+        ":_Step",
+        ":_Step_branch_data",
+        ":_Step_main",
+        ":_Step_main_inputs",
+        ":_Tag",
+        ":_Tick_field_sponge",
+        ":_Timer",
+        ":_Tock_field_sponge",
+        ":_Type",
+        ":_Types_map",
+        ":_Unfinalized",
+        ":_Util",
+        ":_Verification_key",
+        ":_Verify",
+        ":_Wrap",
+        ":_Wrap_domains",
+        ":_Wrap_main",
+        ":_Wrap_main_inputs",
+        ":_Wrap_proof",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Pickles_ns",
+    ns = "pickles",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "cache.ml",
+        "cache_handle.ml",
+        "commitment_lengths.ml",
+        "common.ml",
+        "dirty.ml",
+        "dlog_main.ml",
+        "dummy.ml",
+        "endo.ml",
+        "fix_domains.ml",
+        "full_signature.ml",
+        "impls.ml",
+        "import.ml",
+        "inductive_rule.ml",
+        "intf.ml",
+        "make_sponge.ml",
+        "opt_sponge.ml",
+        "pairing_main.ml",
+        "per_proof_witness.ml",
+        "pickles.ml",
+        "plonk_curve_ops.ml",
+        "proof.ml",
+        "reduced_me_only.ml",
+        "requests.ml",
+        "ro.ml",
+        "scalar_challenge.ml",
+        "side_loaded_verification_key.ml",
+        "sponge_inputs.ml",
+        "step.ml",
+        "step_branch_data.ml",
+        "step_main.ml",
+        "step_main_inputs.ml",
+        "tag.ml",
+        "tick_field_sponge.ml",
+        "timer.ml",
+        "tock_field_sponge.ml",
+        "type.ml",
+        "types_map.ml",
+        "unfinalized.ml",
+        "util.ml",
+        "verification_key.ml",
+        "verify.ml",
+        "wrap.ml",
+        "wrap_domains.ml",
+        "wrap_main.ml",
+        "wrap_main_inputs.ml",
+        "wrap_proof.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Cache",
+    src = "cache.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-27" # Error (warning 27): unused variable e.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Impls",
+        ":_Timer",
+        ":_Verification_key",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Cache_handle",
+    src = "cache_handle.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Dirty",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Commitment_lengths",
+    src = "commitment_lengths.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-27" # Error (warning 27): unused variable +.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Import",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Common",
+    src = "common.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Endo",
+        ":_Impls",
+        ":_Import",
+        ":_Tick_field_sponge",
+        ":_Tock_field_sponge",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Dirty",
+    src = "dirty.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Dlog_main",
+    src = "dlog_main.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-34", ## Unused type declaration.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Commitment_lengths",
+        ":_Common",
+        ":_Endo",
+        ":_Import",
+        ":_Intf",
+        ":_Opt_sponge",
+        ":_Plonk_curve_ops",
+        ":_Scalar_challenge",
+        ":_Type",
+        ":_Util",
+        ":_Wrap_main_inputs",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Dummy",
+    src = "dummy.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Commitment_lengths",
+        ":_Common",
+        ":_Ro",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Endo",
+    src = "endo.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Import",
+        ":_Scalar_challenge",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Fix_domains",
+    src = "fix_domains.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Import",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Full_signature",
+    src = "full_signature.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Impls",
+    src = "impls.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Import",
+        ":_Util",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Import",
+    src = "import.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Inductive_rule",
+    src = "inductive_rule.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Impls",
+        ":_Tag",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Intf",
+    src = "intf.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Import",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Make_sponge",
+    src = "make_sponge.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Opt_sponge",
+    src = "opt_sponge.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Pairing_main",
+    src = "pairing_main.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-9",  # Missing fields in a record pattern.
+        "-w", "-27", # Innocuous unused variable
+        "-w", "-33", # Unused open statement.
+        "-w", "-34", # Unused type declaration.
+        "-w", "-39", # Unused extension constructor.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Commitment_lengths",
+        ":_Common",
+        ":_Dlog_main",
+        ":_Endo",
+        ":_Import",
+        ":_Intf",
+        ":_Opt_sponge",
+        ":_Scalar_challenge",
+        ":_Side_loaded_verification_key",
+        ":_Step_main_inputs",
+        ":_Type",
+        ":_Util",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Per_proof_witness",
+    src = "per_proof_witness.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-33", # Unused open statement.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Commitment_lengths",
+        ":_Common",
+        ":_Impls",
+        ":_Import",
+        ":_Pairing_main",
+        ":_Scalar_challenge",
+        ":_Step_main_inputs",
+        ":_Wrap_proof",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Pickles",
+    src = "pickles.ml",
+    intf = ":_Pickles.cmi",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-27", # Innocuous unused variable
+        "-w", "-32", # Unused value declaration.
+        "-w", "-33", # Unused open statement.
+        "-w", "-34", # Unused type declaration.
+        "-w", "-37", # Unused constructor.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    ppx_print = PPX_PRINT,      # obazl:retain
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Cache",
+        ":_Cache_handle",
+        ":_Common",
+        ":_Dirty",
+        ":_Dummy",
+        ":_Full_signature",
+        ":_Impls",
+        ":_Import",
+        ":_Inductive_rule",
+        ":_Intf",
+        ":_Pairing_main",
+        ":_Proof",
+        ":_Scalar_challenge",
+        ":_Side_loaded_verification_key",
+        ":_Sponge_inputs",
+        ":_Step",
+        ":_Step_branch_data",
+        ":_Step_main_inputs",
+        ":_Tag",
+        ":_Tick_field_sponge",
+        ":_Timer",
+        ":_Types_map",
+        ":_Util",
+        ":_Verification_key",
+        ":_Verify",
+        ":_Wrap_domains",
+        ":_Wrap_main",
+    ],
+)
+
+################
+ocaml_interface(
+    name = "_Pickles.cmi",
+    src = "pickles.mli",
+    ns = ":Pickles_ns",
+    opts = PICKLES_INTERFACE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Cache",
+        ":_Impls",
+        ":_Inductive_rule",
+        ":_Pairing_main",
+        ":_Sponge_inputs",
+        ":_Step_main_inputs",
+        ":_Tag",
+        ":_Tick_field_sponge",
+        ":_Util",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Plonk_curve_ops",
+    src = "plonk_curve_ops.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-33" # Error (warning 33): unused open Impl.Field.Constant.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Intf",
+        ":_Util",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Proof",
+    src = "proof.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w",
+        "-22"  # Preprocessor warnings
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    ppx_print = PPX_PRINT,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Commitment_lengths",
+        ":_Common",
+        ":_Dummy",
+        ":_Import",
+        ":_Reduced_me_only",
+        ":_Ro",
+        ":_Scalar_challenge",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Reduced_me_only",
+    src = "reduced_me_only.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    ppx_print = PPX_PRINT,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Import",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Requests",
+    src = "requests.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-33" # Unused value declaration.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Impls",
+        ":_Import",
+        ":_Per_proof_witness",
+        ":_Scalar_challenge",
+        ":_Wrap_main_inputs",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Ro",
+    src = "ro.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Import",
+        ":_Scalar_challenge",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Scalar_challenge",
+    src = "scalar_challenge.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-33" # Error (warning 33): unused open Impl.As_prover.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Import",
+        ":_Intf",
+        ":_Util",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Side_loaded_verification_key",
+    src = "side_loaded_verification_key.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-6",  # Label omitted in function application.
+        "-w", "-27", # Innocuous unused variable
+        "-w", "-33"  # Unused open statement.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Impls",
+        ":_Import",
+        ":_Step_main_inputs",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Sponge_inputs",
+    src = "sponge_inputs.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Make_sponge",
+        ":_Util",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Step",
+    src = "step.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-27", # Innocuous unused variable
+        "-w", "-34", # Unused type declaration.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Dlog_main",
+        ":_Dummy",
+        ":_Endo",
+        ":_Impls",
+        ":_Import",
+        ":_Per_proof_witness",
+        ":_Proof",
+        ":_Reduced_me_only",
+        ":_Scalar_challenge",
+        ":_Step_branch_data",
+        ":_Tag",
+        ":_Tick_field_sponge",
+        ":_Tock_field_sponge",
+        ":_Types_map",
+        ":_Unfinalized",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Step_branch_data",
+    src = "step_branch_data.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-33",  # Unused open statement.
+        "-w", "-34",  # Unused type declaration.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Fix_domains",
+        ":_Impls",
+        ":_Import",
+        ":_Inductive_rule",
+        ":_Requests",
+        ":_Step_main",
+        ":_Tag",
+        ":_Timer",
+        ":_Types_map",
+        ":_Unfinalized",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Step_main",
+    src = "step_main.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-33",  # Unused open statement.
+        "-w", "-34",  # Unused type declaration.
+        "-w", "-37",  # Unused ancestor variable.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    ppx_print = PPX_PRINT,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Impls",
+        ":_Import",
+        ":_Inductive_rule",
+        ":_Opt_sponge",
+        ":_Pairing_main",
+        ":_Per_proof_witness",
+        ":_Requests",
+        ":_Side_loaded_verification_key",
+        ":_Step_main_inputs",
+        ":_Tag",
+        ":_Types_map",
+        ":_Unfinalized",
+        ":_Wrap_proof",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Step_main_inputs",
+    src = "step_main_inputs.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-6", # Label omitted in function application.
+        "-w", "-33", # Unused open statement.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Impls",
+        ":_Import",
+        ":_Plonk_curve_ops",
+        ":_Sponge_inputs",
+        ":_Tick_field_sponge",
+        ":_Util",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Tag",
+    src = "tag.ml",
+    intf = ":_Tag.cmi",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS,
+)
+
+################
+ocaml_interface(
+    name = "_Tag.cmi",
+    src = "tag.mli",
+    ns = ":Pickles_ns",
+    opts = PICKLES_INTERFACE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Tick_field_sponge",
+    src = "tick_field_sponge.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Make_sponge",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Timer",
+    src = "timer.ml",
+    intf = ":_Timer.cmi",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+    ],
+)
+
+################
+ocaml_interface(
+    name = "_Timer.cmi",
+    src = "timer.mli",
+    ns = ":Pickles_ns",
+    opts = PICKLES_INTERFACE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Tock_field_sponge",
+    src = "tock_field_sponge.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Make_sponge",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Type",
+    src = "type.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Types_map",
+    src = "types_map.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-9",  ## Missing fields in a record pattern.
+        "-w", "-27"  ## Innocuous unused variable
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Impls",
+        ":_Import",
+        ":_Side_loaded_verification_key",
+        ":_Step_main_inputs",
+        ":_Tag",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Unfinalized",
+    src = "unfinalized.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Dummy",
+        ":_Endo",
+        ":_Impls",
+        ":_Import",
+        ":_Ro",
+        ":_Scalar_challenge",
+        ":_Tock_field_sponge",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Util",
+    src = "util.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Type",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Verification_key",
+    src = "verification_key.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-6" # Error (warning 6): label log2_size was omitted in the application of this function
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Import",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Verify",
+    src = "verify.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-9",   # Missing fields in a record pattern.
+        "-w", "-27",  # Innocuous unused variable
+        "-w", "-33",  # Unused open statement.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Dummy",
+        ":_Endo",
+        ":_Import",
+        ":_Intf",
+        ":_Proof",
+        ":_Reduced_me_only",
+        ":_Scalar_challenge",
+        ":_Tick_field_sponge",
+        ":_Timer",
+        ":_Verification_key",
+        ":_Wrap",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Wrap",
+    src = "wrap.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-27" # Innocuous unused variable
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Dlog_main",
+        ":_Endo",
+        ":_Import",
+        ":_Proof",
+        ":_Requests",
+        ":_Scalar_challenge",
+        ":_Tick_field_sponge",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Wrap_domains",
+    src = "wrap_domains.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-27", # Innocuous unused variable
+        "-w", "-34", # Unused type declaration.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Fix_domains",
+        ":_Impls",
+        ":_Import",
+        ":_Inductive_rule",
+        ":_Tag",
+        ":_Timer",
+        ":_Types_map",
+        ":_Verification_key",
+        ":_Wrap_main",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Wrap_main",
+    src = "wrap_main.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-27",  # Innocuous unused variable
+        "-w", "-34"   # Unused type declaration.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Commitment_lengths",
+        ":_Common",
+        ":_Dlog_main",
+        ":_Full_signature",
+        ":_Impls",
+        ":_Import",
+        ":_Requests",
+        ":_Scalar_challenge",
+        ":_Timer",
+        ":_Util",
+        ":_Wrap_main_inputs",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Wrap_main_inputs",
+    src = "wrap_main_inputs.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS + [
+        "-w", "-6", # Label omitted in function application.
+    ],
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Common",
+        ":_Impls",
+        ":_Import",
+        ":_Sponge_inputs",
+        ":_Tock_field_sponge",
+        ":_Util",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Wrap_proof",
+    src = "wrap_proof.ml",
+    ns = ":Pickles_ns",
+    opts = PICKLES_MODULE_OPTS,
+    ppx = PICKLES_PPX,
+    ppx_args = PICKLES_PPX_ARGS,
+    deps = PICKLES_DEPS + [
+        # do not sort (buildifier)
+        ":_Commitment_lengths",
+        ":_Common",
+        ":_Impls",
+        ":_Import",
+        ":_Step_main_inputs",
+    ],
+)

--- a/src/lib/pickles/backend/BUILD.bazel
+++ b/src/lib/pickles/backend/BUILD.bazel
@@ -1,0 +1,23 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_module",
+)
+
+#############
+ocaml_module(
+    name = "backend",
+    src = "backend.ml",
+    opts = [],
+    ppx = "//bzl/ppx/exe:ppx_version__ppx_coda__ppx_jane__ppx_deriving.std__ppx_deriving_yojson",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "backend",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@mina//src/lib/zexe_backend",
+    ],
+)

--- a/src/lib/pickles/composition_types/BUILD.bazel
+++ b/src/lib/pickles/composition_types/BUILD.bazel
@@ -1,0 +1,155 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_interface",
+    "ocaml_module",
+    "ocaml_ns",
+)
+
+PPX_PRINT = "@ppx//print:binary"
+
+################################################################
+## STANZA 1: LIBRARY COMPOSITION_TYPES
+################################################################
+COMPOSITION_TYPES_INTERFACE_OPTS = []
+
+COMPOSITION_TYPES_MODULE_OPTS = []
+
+COMPOSITION_TYPES_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core_kernel",
+    "@mina//src/lib/pickles/limb_vector",
+    "@mina//src/lib/zexe_backend",
+    "@mina//src/lib/pickles_types",
+    "@mina//src/lib/pickles_base",
+    "@snarky//src/base:snarky_backendless",
+]
+
+COMPOSITION_TYPES_PPX = "@//bzl/ppx/exe:ppx_version__ppx_coda__ppx_jane__ppx_deriving.std__ppx_deriving_yojson__h_list.ppx"
+
+COMPOSITION_TYPES_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "composition_types",
+]
+
+##############
+ocaml_archive(
+    name = "composition_types",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = COMPOSITION_TYPES_DEPS + [
+        # do not sort (buildifier)
+        ":_Bulletproof_challenge",
+        ":_Composition_types",
+        ":_Digest",
+        ":_Index",
+        ":_Spec",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Composition_types_ns",
+    ns = "composition_types",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "bulletproof_challenge.ml",
+        "composition_types.ml",
+        "digest.ml",
+        "index.ml",
+        "spec.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Bulletproof_challenge",
+    src = "bulletproof_challenge.ml",
+    ns = ":Composition_types_ns",
+    opts = COMPOSITION_TYPES_MODULE_OPTS,
+    ppx = COMPOSITION_TYPES_PPX,
+    ppx_args = COMPOSITION_TYPES_PPX_ARGS,
+    ppx_print = PPX_PRINT,
+    deps = COMPOSITION_TYPES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Composition_types",
+    src = "composition_types.ml",
+    ns = ":Composition_types_ns",
+    opts = COMPOSITION_TYPES_MODULE_OPTS + [
+        "-w", "-22", # Error (warning 22): Must have deriving version if deriving bin_io
+        "-w", "-27", # Error (warning 27): unused variable
+        "-w", "-33", # Error (warning 33): unused open Snarky_backendless.H_list.
+    ],
+    ppx = COMPOSITION_TYPES_PPX,
+    ppx_args = COMPOSITION_TYPES_PPX_ARGS,
+    ppx_print = PPX_PRINT,
+    deps = COMPOSITION_TYPES_DEPS + [
+        # do not sort (buildifier)
+        ":_Bulletproof_challenge",
+        ":_Digest",
+        ":_Index",
+        ":_Spec",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Digest",
+    src = "digest.ml",
+    ns = ":Composition_types_ns",
+    opts = COMPOSITION_TYPES_MODULE_OPTS + [
+        "-w",
+        "-22", # Error (warning 22): Deriving bin_io and deriving version disallowed for types in functor body
+        "-w",
+        "-32"  # Error (warning 32): unused value of_tick_field.
+    ],
+    ppx = COMPOSITION_TYPES_PPX,
+    ppx_args = COMPOSITION_TYPES_PPX_ARGS,
+    deps = COMPOSITION_TYPES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Index",
+    src = "index.ml",
+    intf = ":_Index.cmi",
+    ns = ":Composition_types_ns",
+    opts = COMPOSITION_TYPES_MODULE_OPTS,
+    ppx = COMPOSITION_TYPES_PPX,
+    ppx_args = COMPOSITION_TYPES_PPX_ARGS,
+    deps = COMPOSITION_TYPES_DEPS,
+)
+
+################
+ocaml_interface(
+    name = "_Index.cmi",
+    src = "index.mli",
+    ns = ":Composition_types_ns",
+    opts = COMPOSITION_TYPES_INTERFACE_OPTS,
+    ppx = COMPOSITION_TYPES_PPX,
+    ppx_args = COMPOSITION_TYPES_PPX_ARGS,
+    deps = COMPOSITION_TYPES_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Spec",
+    src = "spec.ml",
+    ns = ":Composition_types_ns",
+    opts = COMPOSITION_TYPES_MODULE_OPTS,
+    ppx = COMPOSITION_TYPES_PPX,
+    ppx_args = COMPOSITION_TYPES_PPX_ARGS,
+    deps = COMPOSITION_TYPES_DEPS + [
+        # do not sort (buildifier)
+        ":_Bulletproof_challenge",
+        ":_Digest",
+        ":_Index",
+    ],
+)

--- a/src/lib/pickles/limb_vector/BUILD.bazel
+++ b/src/lib/pickles/limb_vector/BUILD.bazel
@@ -1,0 +1,114 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_module",
+    "ocaml_ns",
+)
+
+################################################################
+## STANZA 1: LIBRARY LIMB_VECTOR
+################################################################
+LIMB_VECTOR_MODULE_OPTS = []
+
+LIMB_VECTOR_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core_kernel",
+    "@mina//src/lib/pickles/backend",
+    "@mina//src/lib/pickles_types",
+    "@snarky//src/base:snarky_backendless",
+]
+
+LIMB_VECTOR_PPX = "@//bzl/ppx/exe:ppx_version__ppx_coda__ppx_jane__ppx_deriving.std__ppx_deriving_yojson"
+
+LIMB_VECTOR_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "limb_vector",
+]
+
+##############
+ocaml_archive(
+    name = "limb_vector",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = LIMB_VECTOR_DEPS + [
+        # do not sort (buildifier)
+        ":_Challenge",
+        ":_Constant",
+        ":_Limb_vector",
+        ":_Make",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Limb_vector_ns",
+    ns = "limb_vector",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "challenge.ml",
+        "constant.ml",
+        "limb_vector.ml",
+        "make.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Challenge",
+    src = "challenge.ml",
+    ns = ":Limb_vector_ns",
+    opts = LIMB_VECTOR_MODULE_OPTS,
+    ppx = LIMB_VECTOR_PPX,
+    ppx_args = LIMB_VECTOR_PPX_ARGS,
+    deps = LIMB_VECTOR_DEPS + [
+        # do not sort (buildifier)
+        ":_Constant",
+        ":_Make",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Constant",
+    src = "constant.ml",
+    ns = ":Limb_vector_ns",
+    opts = LIMB_VECTOR_MODULE_OPTS + [
+        "-w", "-22" # Deriving bin_io and deriving version disallowed for types in functor body
+    ],
+    ppx = LIMB_VECTOR_PPX,
+    ppx_args = LIMB_VECTOR_PPX_ARGS,
+    deps = LIMB_VECTOR_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Limb_vector",
+    src = "limb_vector.ml",
+    ns = ":Limb_vector_ns",
+    opts = LIMB_VECTOR_MODULE_OPTS,
+    ppx = LIMB_VECTOR_PPX,
+    ppx_args = LIMB_VECTOR_PPX_ARGS,
+    deps = LIMB_VECTOR_DEPS + [
+        # do not sort (buildifier)
+        ":_Challenge",
+        ":_Constant",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Make",
+    src = "make.ml",
+    ns = ":Limb_vector_ns",
+    opts = LIMB_VECTOR_MODULE_OPTS,
+    ppx = LIMB_VECTOR_PPX,
+    ppx_args = LIMB_VECTOR_PPX_ARGS,
+    deps = LIMB_VECTOR_DEPS + [
+        # do not sort (buildifier)
+        ":_Constant",
+    ],
+)

--- a/src/lib/pickles/one_hot_vector/BUILD.bazel
+++ b/src/lib/pickles/one_hot_vector/BUILD.bazel
@@ -1,0 +1,47 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_interface",
+    "ocaml_module",
+)
+
+#############
+ocaml_module(
+    name = "one_hot_vector",
+    src = "one_hot_vector.ml",
+    intf = ":_One_hot_vector.cmi",
+    opts = [],
+    ppx = "//bzl/ppx/exe:ppx_version__ppx_jane",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "one_hot_vector",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@mina//src/lib/pickles_types",
+        "@mina//src/lib/zexe_backend",
+        "@opam//pkg:core_kernel",
+        "@snarky//src/base:snarky_backendless",
+    ],
+)
+
+################
+ocaml_interface(
+    name = "_One_hot_vector.cmi",
+    src = "one_hot_vector.mli",
+    opts = [],
+    ppx = "//bzl/ppx/exe:ppx_version__ppx_jane",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "one_hot_vector",
+    ],
+    deps = [
+        "@mina//src/lib/pickles_types",
+        "@mina//src/lib/zexe_backend",
+        "@opam//pkg:core_kernel",
+        "@snarky//src/base:snarky_backendless",
+    ],
+)

--- a/src/lib/pickles/plonk_checks/BUILD.bazel
+++ b/src/lib/pickles/plonk_checks/BUILD.bazel
@@ -1,0 +1,28 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_module",
+)
+
+#############
+ocaml_module(
+    name = "plonk_checks",
+    src = "plonk_checks.ml",
+    opts = [],
+    ppx = "//bzl/ppx/exe:ppx_coda__ppx_version__ppx_jane__ppx_deriving.std__ppx_deriving_yojson",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "plonk_checks",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@mina//src/lib/pickles/composition_types",
+        "@mina//src/lib/pickles_base",
+        "@mina//src/lib/pickles_types",
+        "@mina//src/lib/zexe_backend",
+        "@opam//pkg:core_kernel",
+        "@snarky//src/base:snarky_backendless",
+    ],
+)

--- a/src/lib/pickles/precomputed/BUILD.bazel
+++ b/src/lib/pickles/precomputed/BUILD.bazel
@@ -1,0 +1,24 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_module",
+)
+
+#############
+ocaml_module(
+    name = "precomputed",
+    src = "precomputed.ml",
+    opts = [],
+    ppx = "//bzl/ppx/exe:ppx_version__ppx_jane__ppxlib.metaquot",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "precomputed",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@mina//src/lib/zexe_backend",
+        "@opam//pkg:core_kernel",
+    ],
+)

--- a/src/lib/pickles/pseudo/BUILD.bazel
+++ b/src/lib/pickles/pseudo/BUILD.bazel
@@ -1,0 +1,27 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_module",
+)
+
+#############
+ocaml_module(
+    name = "pseudo",
+    src = "pseudo.ml",
+    opts = [],
+    ppx = "//bzl/ppx/exe:ppx_version__ppx_coda__ppx_jane__ppx_deriving.std__ppx_deriving_yojson",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "pseudo",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@mina//src/lib/pickles/one_hot_vector",
+        "@mina//src/lib/pickles/plonk_checks",
+        "@mina//src/lib/pickles_types",
+        "@opam//pkg:core_kernel",
+        "@snarky//src/base:snarky_backendless",
+    ],
+)

--- a/src/lib/pickles_base/BUILD.bazel
+++ b/src/lib/pickles_base/BUILD.bazel
@@ -1,0 +1,138 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_module",
+    "ocaml_ns",
+    "ppx_executable",
+)
+
+PPX_PRINT = "@ppx//print:binary"
+
+################################################################
+## STANZA 1: LIBRARY PICKLES_BASE
+################################################################
+PICKLES_BASE_MODULE_OPTS = []
+
+PICKLES_BASE_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core_kernel",
+    "@mina//src/lib/random_oracle_input",
+    "@mina//src/lib/pickles_types",
+]
+
+##############
+ocaml_archive(
+    name = "pickles_base",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = PICKLES_BASE_DEPS + [
+        # do not sort (buildifier)
+        ":_Domain",
+        ":_Domains",
+        ":_Side_loaded_verification_key",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Pickles_base_ns",
+    ns = "pickles_base",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "domain.ml",
+        "domains.ml",
+        "side_loaded_verification_key.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Domain",
+    src = "domain.ml",
+    ns = ":Pickles_base_ns",
+    opts = PICKLES_BASE_MODULE_OPTS + [
+        "-w", "-32" # Unused value
+    ],
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "pickles_base",
+    ],
+    ppx_print = PPX_PRINT,
+    deps = PICKLES_BASE_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Domains",
+    src = "domains.ml",
+    ns = ":Pickles_base_ns",
+    opts = PICKLES_BASE_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "pickles_base",
+    ],
+    deps = PICKLES_BASE_DEPS + [":_Domain"] # obazl:retain
+)
+
+#############
+ocaml_module(
+    name = "_Side_loaded_verification_key",
+    src = "side_loaded_verification_key.ml",
+    ns = ":Pickles_base_ns",
+    opts = PICKLES_BASE_MODULE_OPTS + [
+        "-w", "-22",            # Error (warning 22): Cannot use versioned extension within a functor body
+        "-w", "-9"              # Error (warning 9): the following labels are not bound in this record pattern:
+    ],
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "pickles_base",
+    ],
+    ppx_print = PPX_PRINT,
+    deps = PICKLES_BASE_DEPS + [
+        # do not sort (buildifier)
+        ":_Domain",
+        ":_Domains",
+    ],
+)
+
+###############
+ppx_executable(
+    name = "ppx1.exe",
+    lazy_deps = [
+        "@opam//pkg:ppx_expect.collector",
+        "@opam//pkg:yojson",
+        "@opam//pkg:ppx_hash.runtime-lib",
+        "@opam//pkg:ppx_deriving_yojson.runtime",
+        "@opam//pkg:ppx_sexp_conv.runtime-lib",
+        "@opam//pkg:ppx_deriving.runtime",
+        "@opam//pkg:ppx_assert.runtime-lib",
+        "@opam//pkg:ppx_compare.runtime-lib",
+        "@opam//pkg:ppx_inline_test.runtime-lib",
+        "@opam//pkg:ppx_bench.runtime-lib",
+        "@opam//pkg:ppx_enumerate.runtime-lib",
+        "@opam//pkg:ppx_module_timer.runtime",
+    ],
+    main = "//bzl/ppx/exe:Driver",
+    opts = [],
+    visibility = [
+        "//src/lib/pickles_base:__pkg__",
+    ],
+    deps = [
+        "@mina//src/lib/ppx_coda",
+        "@opam//pkg:ppx_deriving.std",
+        "@opam//pkg:ppx_deriving_yojson",
+        "@opam//pkg:ppx_jane",
+        "@opam//pkg:ppxlib",
+        "@ppx_version//src:ppx_version",
+        "@snarky//h_list/ppx:ppx_h_list",
+    ],
+)

--- a/src/lib/random_oracle_input/BUILD.bazel
+++ b/src/lib/random_oracle_input/BUILD.bazel
@@ -1,0 +1,53 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_module",
+    "ppx_executable",
+)
+
+#############
+ocaml_module(
+    name = "random_oracle_input",
+    src = "random_oracle_input.ml",
+    opts = [],
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "random_oracle_input",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@opam//pkg:core_kernel",
+    ],
+)
+
+###############
+ppx_executable(
+    name = "ppx1.exe",
+    lazy_deps = [
+        "@opam//pkg:ppx_expect.collector",
+        "@opam//pkg:ppx_hash.runtime-lib",
+        "@opam//pkg:ppx_sexp_conv.runtime-lib",
+        "@opam//pkg:ppx_assert.runtime-lib",
+        "@opam//pkg:ppx_compare.runtime-lib",
+        "@opam//pkg:ppx_inline_test.runtime-lib",
+        "@opam//pkg:ppx_bench.runtime-lib",
+        "@opam//pkg:ppx_enumerate.runtime-lib",
+        "@opam//pkg:ppx_module_timer.runtime",
+    ],
+    main = "//bzl/ppx/exe:Driver",
+    opts = [],
+    visibility = [
+        "//src/lib/random_oracle_input:__pkg__",
+    ],
+    deps = [
+        "@opam//pkg:ppx_inline_test",
+        "@opam//pkg:ppx_jane",
+        "@opam//pkg:ppx_let",
+        "@opam//pkg:ppx_sexp_conv",
+        "@opam//pkg:ppxlib",
+        "@ppx_version//src:ppx_version",
+    ],
+)

--- a/src/lib/snark_keys_header/BUILD.bazel
+++ b/src/lib/snark_keys_header/BUILD.bazel
@@ -1,0 +1,52 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_module",
+    "ppx_executable",
+)
+
+#############
+ocaml_module(
+    name = "snark_keys_header",
+    src = "snark_keys_header.ml",
+    opts = [],
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_keys_header",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@opam//pkg:core_kernel",
+        "@opam//pkg:integers",
+    ],
+)
+
+###############
+ppx_executable(
+    name = "ppx1.exe",
+    lazy_deps = [
+        "@opam//pkg:yojson",
+        "@opam//pkg:ppx_deriving_yojson.runtime",
+        "@opam//pkg:ppx_sexp_conv.runtime-lib",
+        "@opam//pkg:ppx_deriving.runtime",
+        "@opam//pkg:ppx_inline_test.runtime-lib",
+    ],
+    main = "//bzl/ppx/exe:Driver",
+    opts = [],
+    visibility = [
+        "//src/lib/snark_keys_header:__pkg__",
+    ],
+    deps = [
+        "@opam//pkg:ppx_deriving.eq",
+        "@opam//pkg:ppx_deriving.ord",
+        "@opam//pkg:ppx_deriving_yojson",
+        "@opam//pkg:ppx_inline_test",
+        "@opam//pkg:ppx_let",
+        "@opam//pkg:ppx_sexp_conv",
+        "@opam//pkg:ppxlib",
+        "@ppx_version//src:ppx_version",
+    ],
+)

--- a/src/lib/snarky_group_map/BUILD.bazel
+++ b/src/lib/snarky_group_map/BUILD.bazel
@@ -1,0 +1,104 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_interface",
+    "ocaml_module",
+    "ocaml_ns",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARKY_GROUP_MAP
+################################################################
+SNARKY_GROUP_MAP_INTERFACE_OPTS = []
+
+SNARKY_GROUP_MAP_MODULE_OPTS = []
+
+SNARKY_GROUP_MAP_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core_kernel",
+    "@snarky//group_map",
+    "@snarky//src/base:snarky_backendless",
+]
+
+SNARKY_GROUP_MAP_PPX = "@//bzl/ppx/exe:ppx_version__ppx_jane__ppx_deriving.eq"
+
+SNARKY_GROUP_MAP_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "snarky_group_map",
+]
+
+##############
+ocaml_archive(
+    name = "snarky_group_map",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARKY_GROUP_MAP_DEPS + [
+        # do not sort (buildifier)
+        ":_Checked_map",
+        ":_Snarky_group_map",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snarky_group_map_ns",
+    ns = "snarky_group_map",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "checked_map.ml",
+        "snarky_group_map.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Checked_map",
+    src = "checked_map.ml",
+    intf = ":_Checked_map.cmi",
+    ns = ":Snarky_group_map_ns",
+    opts = SNARKY_GROUP_MAP_MODULE_OPTS,
+    ppx = SNARKY_GROUP_MAP_PPX,
+    ppx_args = SNARKY_GROUP_MAP_PPX_ARGS,
+    deps = SNARKY_GROUP_MAP_DEPS,
+)
+
+################
+ocaml_interface(
+    name = "_Checked_map.cmi",
+    src = "checked_map.mli",
+    ns = ":Snarky_group_map_ns",
+    opts = SNARKY_GROUP_MAP_INTERFACE_OPTS,
+    ppx = SNARKY_GROUP_MAP_PPX,
+    ppx_args = SNARKY_GROUP_MAP_PPX_ARGS,
+    deps = SNARKY_GROUP_MAP_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Snarky_group_map",
+    src = "snarky_group_map.ml",
+    intf = ":_Snarky_group_map.cmi",
+    ns = ":Snarky_group_map_ns",
+    opts = SNARKY_GROUP_MAP_MODULE_OPTS,
+    ppx = SNARKY_GROUP_MAP_PPX,
+    ppx_args = SNARKY_GROUP_MAP_PPX_ARGS,
+    deps = SNARKY_GROUP_MAP_DEPS + [
+        # do not sort (buildifier)
+        ":_Checked_map",
+    ],
+)
+
+################
+ocaml_interface(
+    name = "_Snarky_group_map.cmi",
+    src = "snarky_group_map.mli",
+    ns = ":Snarky_group_map_ns",
+    opts = SNARKY_GROUP_MAP_INTERFACE_OPTS,
+    ppx = SNARKY_GROUP_MAP_PPX,
+    ppx_args = SNARKY_GROUP_MAP_PPX_ARGS,
+    deps = SNARKY_GROUP_MAP_DEPS,
+)

--- a/src/lib/snarky_log/BUILD.bazel
+++ b/src/lib/snarky_log/BUILD.bazel
@@ -1,0 +1,23 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_module",
+)
+
+#############
+ocaml_module(
+    name = "snarky_log",
+    src = "snarky_log.ml",
+    opts = [],
+    ppx = "//bzl/ppx/exe:ppx_version",
+    ppx_args = [
+        # do not sort (buildifier)
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@mina//src/lib/webkit_trace_event",
+        "@opam//pkg:yojson",
+        "@snarky//src/base:snarky_backendless",
+    ],
+)

--- a/src/lib/webkit_trace_event/BUILD.bazel
+++ b/src/lib/webkit_trace_event/BUILD.bazel
@@ -1,0 +1,22 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_module",
+)
+
+#############
+ocaml_module(
+    name = "webkit_trace_event",
+    src = "webkit_trace_event.ml",
+    opts = [],
+    ppx = "//bzl/ppx/exe:ppx_version",
+    ppx_args = [
+        # do not sort (buildifier)
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@opam//pkg:async",
+        "@opam//pkg:core",
+    ],
+)


### PR DESCRIPTION
This PR adds Bazel support for `src/lib/pickles` and its dependencies.  The targets in this PR will not build until the following PRs are merged:  #7146 #7149 #7150 