### PR TITLE
Writes to gcloud asynchronously

### DIFF
--- a/src/lib/mina_lib/coda_subscriptions.ml
+++ b/src/lib/mina_lib/coda_subscriptions.ml
@@ -162,7 +162,6 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                    ( Mina_metrics.(
                        Gauge.inc_one
                          Block_latency.Upload_to_gcloud.upload_to_gcloud_blocks) ;
-                     let open Async.Let_syntax in
                      let%map output =
                        Async.Process.run () ~prog:"bash"
                          ~args:

--- a/src/lib/mina_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/mina_metrics.ml
@@ -677,6 +677,12 @@ end
 module Block_latency = struct
   let subsystem = "Block_latency"
 
+  module Upload_to_gcloud = struct
+    let upload_to_gcloud_blocks : Gauge.t =
+      let help = "Number of pending `gsutil cp` jobs for block dumping" in
+      Gauge.v "upload_to_gcloud_blocks" ~help ~namespace ~subsystem
+  end
+
   [%%inject
   "block_window_duration", block_window_duration]
 


### PR DESCRIPTION
The gcloud block dump backup writing uses an asynchronous process instead. Also introduced a prometheus metric so we can track how far we get backed up.