### PR TITLE
Update mergify for develop-until-adversarial

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -46,3 +46,19 @@ pull_request_rules:
               method: merge
               strict: false
           delete_head_branch: {}
+    - name: automatically merge approved PRs into develop-until-adversarial with the ready-to-merge-into-develop label
+      conditions:
+          - "status-success=buildkite/mina/pr"
+          - "status-success=ci/circleci: test--dev--coda-bootstrap-test"
+          - "status-success=ci/circleci: test--dev--coda-delegation-test"
+          - "status-success=ci/circleci: test--dev--coda-shared-state-test"
+          - "status-success=ci/circleci: test--test_postake_snarkless"
+          - "status-success=ci/circleci: test--test_postake_split"
+          - "#approved-reviews-by>=1"
+          - label=ready-to-merge-into-develop
+          - base=develop-until-adversarial
+      actions:
+          merge:
+              method: merge
+              strict: false
+          delete_head_branch: {}

--- a/.mergify.yml.jinja
+++ b/.mergify.yml.jinja
@@ -37,3 +37,16 @@ pull_request_rules:
               method: merge
               strict: false
           delete_head_branch: {}
+    - name: automatically merge approved PRs into develop-until-adversarial with the ready-to-merge-into-develop label
+      conditions:
+          {%- for status in required_status | sort %}
+          - "status-success={{status}}"
+          {%- endfor %}
+          - "#approved-reviews-by>=1"
+          - label=ready-to-merge-into-develop
+          - base=develop-until-adversarial
+      actions:
+          merge:
+              method: merge
+              strict: false
+          delete_head_branch: {}


### PR DESCRIPTION
This makes `ready-for-merge-into-develop` work for the `develop-until-adversarial` branch.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: