### PR TITLE
Disable Mac builds on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1201,7 +1201,6 @@ workflows:
             - build-wallet
             - test-archive
             - build-archive
-            - build-macos
             - test-unit--nonconsensus_medium_curves
             - test--test_postake_catchup
             - test--test_postake_five_even_txns

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -727,7 +727,6 @@ workflows:
             - build-wallet
             - test-archive
             - build-archive
-            - build-macos
             {%- for profile in build_artifact_profiles %}
             - build-artifacts--{{profile}}
             {%- endfor %}


### PR DESCRIPTION
Our CircleCI plan currently doesn't seem to support the large resource class for Mac builds. Builds can't finish with the lower resource class, so there's no point running the job at all unless we change that.

![Screenshot from 2020-12-20 23-47-32](https://user-images.githubusercontent.com/1847343/102819866-32d2d780-43cc-11eb-8cfa-7d770583fca6.png)

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
