### PR TITLE
Remove wallet build from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1198,7 +1198,6 @@ workflows:
                   branches:
                     only: develop
             - tracetool
-            - build-wallet
             - test-archive
             - build-archive
             - build-macos

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -724,7 +724,6 @@ workflows:
                   branches:
                     only: develop
             - tracetool
-            - build-wallet
             - test-archive
             - build-archive
             - build-macos


### PR DESCRIPTION
The wallet is deprecated, but we're still paying to run a wallet build for every CI run. It has been failing for a while, so we're gaining nothing by running it.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: