### PR TITLE
[Bazel] fix missing code in allocation_functor/make.ml

### DIFF
--- a/src/lib/allocation_functor/BUILD.bazel
+++ b/src/lib/allocation_functor/BUILD.bazel
@@ -138,7 +138,7 @@ ppx_executable(
         "//src/lib/allocation_functor:__pkg__",
     ],
     deps = [
-        "@opam//pkg:ppx_deriving.std",
+        "@opam//pkg:ppx_compare",
         "@opam//pkg:ppx_deriving_yojson",
         "@opam//pkg:ppx_jane",
         "@opam//pkg:ppxlib",

--- a/src/lib/allocation_functor/make.ml
+++ b/src/lib/allocation_functor/make.ml
@@ -226,6 +226,8 @@ module Versioned_v1 = struct
     let hash = M.hash
 
     let hash_fold_t = M.hash_fold_t
+
+    let equal = M.equal
   end
 
   module Full (M : Intf.Input.Versioned_v1.Full_intf) : sig

--- a/src/lib/allocation_functor/make.ml
+++ b/src/lib/allocation_functor/make.ml
@@ -226,8 +226,6 @@ module Versioned_v1 = struct
     let hash = M.hash
 
     let hash_fold_t = M.hash_fold_t
-
-    let equal = M.equal
   end
 
   module Full (M : Intf.Input.Versioned_v1.Full_intf) : sig


### PR DESCRIPTION
I don't know if this is a good fix, but the Bazel build fails without it, throwing:

```
File "src/lib/allocation_functor/make.ml", line 193, characters 8-719:
Error: Signature mismatch:
       ...
       The value `equal' is required but not provided
       File "bazel-out/darwin-fastbuild/bin/src/lib/allocation_functor/_obazl_/Allocation_functor__Intf.ml", line 368, characters 16-63:
         Expected declaration
```