### PR TITLE
Use ppx_compare instead of ppx_deriving.std

### DIFF
--- a/src/lib/allocation_functor/dune
+++ b/src/lib/allocation_functor/dune
@@ -4,6 +4,6 @@
   (inline_tests)
   (libraries core_kernel mina_metrics)
   (instrumentation (backend bisect_ppx))
-  (preprocess (pps ppx_jane ppx_deriving.std ppx_deriving_yojson ppx_version))
+  (preprocess (pps ppx_jane ppx_compare ppx_deriving_yojson ppx_version))
   ; ignore ppx_version errors for this library
   (flags -w -22))

--- a/src/lib/allocation_functor/intf.ml
+++ b/src/lib/allocation_functor/intf.ml
@@ -125,7 +125,7 @@ module Input = struct
       [%%versioned:
       module Stable : sig
         module V1 : sig
-          type t [@@deriving compare, eq, hash]
+          type t [@@deriving compare, equal, hash]
 
           include Higher_order_creatable_intf with type t := t
 
@@ -244,7 +244,7 @@ module Output = struct
       [%%versioned:
       module Stable : sig
         module V1 : sig
-          type t [@@deriving compare, eq, hash]
+          type t [@@deriving compare, equal, hash]
 
           include Creatable_intf with type t := t
 

--- a/src/lib/allocation_functor/make.ml
+++ b/src/lib/allocation_functor/make.ml
@@ -221,6 +221,8 @@ module Versioned_v1 = struct
 
     type t = Stable.V1.t
 
+    let equal = M.equal
+
     let compare = M.compare
 
     let hash = M.hash


### PR DESCRIPTION
This fixes an inconsistency in the behaviour of `ppx_version` between dune and bazel when building; see #7177.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: