### PR TITLE
[Bazel] temporary fixes to baseline; add query scripts

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,12 @@
+# OBAZL:TRANSISTION: These git submodules are pinned to old versions, which screws up queries.
+# Once all Bazel code is merged and pins are corrected, these lines can be removed.
+src/external
+src/lib/marlin
+src/lib/marlin/zexe
+src/lib/snarky
+# /OBAZL:TRANSITION
+
+## normal:
 _build
 buildkite
 coda-automation
@@ -8,9 +17,11 @@ helm
 maintenance
 rfcs
 
-# not yet converted to snarky.backendless:
+## these have dependencies (direct or indirect) on @snarky//src:snarky, which no longer exists
+src/lib/snarky_blake2/test
+src/lib/snarky_log/examples
+src/lib/snarky_taylor/tests
 src/lib/vrf_lib/tests
-
 # depends on src/lib/vrf_lib/tests:
 src/app/benchmarks
 

--- a/bzl/tools/qbuild.sh
+++ b/bzl/tools/qbuild.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+## browse code from BUILD file for target
+## this will show the build code after analysis, with macros expanded etc.
+
+bazel query "deps($1)" --noimplicit_deps --output=build

--- a/bzl/tools/qdeps.sh
+++ b/bzl/tools/qdeps.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+## print all dependencies of target. first arg is pkg or target, second is output option
+
+## --output options:  https://docs.bazel.build/versions/master/query.html#output-formats
+# some useful outputs:
+#  build    prints out the build rule with macros etc. expanded
+#  label
+#  label_kind
+#  package   normally all dep targets are printed, this just prints the pkgs
+#  graph   - output can be piped into dot to produce a graph
+
+OUTPUT=label_kind
+if [[ ! -z $2 ]]
+then
+    OUTPUT=$2
+fi
+
+bazel query "deps($1)" --notool_deps --noimplicit_deps --output $OUTPUT

--- a/bzl/tools/qppxmodule.sh
+++ b/bzl/tools/qppxmodule.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+## list all packages containing ppx_executable targets
+
+bazel query "kind(\"ppx_module rule\", $1//...:*)" --output package

--- a/bzl/tools/qrdeps.sh
+++ b/bzl/tools/qrdeps.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+## print all reverse dependencies of target. first arg is pkg or target, second is output option
+
+## --output options:  https://docs.bazel.build/versions/master/query.html#output-formats
+# some useful outputs:
+#  build    prints out the build rule with macros etc. expanded
+#  label
+#  label_kind
+#  package   normally all dep targets are printed, this just prints the pkgs
+#  graph   - output can be piped into dot to produce a graph
+
+OUTPUT=label_kind
+if [[ ! -z $2 ]]
+then
+    OUTPUT=$2
+fi
+
+bazel query "rdeps(..., $1)" --output $OUTPUT

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -33,31 +33,33 @@ mina_config(
     time_offsets = "//src/config:time_offsets_false"
 )
 
-mina_config(
-    name = "fake_hash",
-    visibility = ["//visibility:public"],
-    ledger_depth = "//src/config/ledger_depth:tiny",
-    consensus_k = "//src/config/consensus/tiny:k",
-    # scan_state/medium.mlh
-    scan_state_transaction_capacity_log_2 = "//src/config/scan_state/medium:txn_capacity_log2",
-    proof_level = "//src/config/proof_level:none",
-    fake_hash = ":fake_hash_true", # src/config/fake_hash.mlh
-    block_window_duration = ":block_window_duration_600"
-)
+## OBAZL:TRANSITION: these need to be updated to work with the latest config structure
+# mina_config(
+#     name = "fake_hash",
+#     visibility = ["//visibility:public"],
+#     ledger_depth = "//src/config/ledger_depth:tiny",
+#     consensus_k = "//src/config/consensus/tiny:k",
+#     # scan_state/medium.mlh
+#     scan_state_transaction_capacity_log_2 = "//src/config/scan_state/medium:txn_capacity_log2",
+#     proof_level = "//src/config/proof_level:none",
+#     fake_hash = ":fake_hash_true", # src/config/fake_hash.mlh
+#     block_window_duration = ":block_window_duration_600"
+# )
 
-mina_config(
-    name = "testnet_public",    # testnet_public.mlh
-    visibility = ["//visibility:public"],
-    ledger_depth = "//src/config/ledger_depth:full",
-    consensus_k = "//src/config/consensus/tiny:k",
-    # scan_state/std.mlh
-    scan_state_transaction_capacity_log_2 = "//src/config/scan_state/std:txn_capacity_log2",
-    proof_level = "//src/config/proof_level:full",
-    account_creation_fee_int = "//src/config/fees/std:account_creation",
-    time_offsets = "//src/config:time_offsets_false",
-    genesis_ledger = "//src/config/genesis/ledger:testnet_postake",
-    block_window_duration = ":block_window_duration_20000",
-    integration_tests = ":integration_tests_false",
-    force_updates = ":force_updates_true",
-    download_snark_keys = ":download_snark_keys_true"
-)
+# mina_config(
+#     name = "testnet_public",    # testnet_public.mlh
+#     visibility = ["//visibility:public"],
+#     ledger_depth = "//src/config/ledger_depth:full",
+#     consensus_k = "//src/config/consensus/tiny:k",
+#     # scan_state/std.mlh
+#     scan_state_transaction_capacity_log_2 = "//src/config/scan_state/std:txn_capacity_log2",
+#     proof_level = "//src/config/proof_level:full",
+#     account_creation_fee_int = "//src/config/fees/std:account_creation",
+#     time_offsets = "//src/config:time_offsets_false",
+#     genesis_ledger = "//src/config/genesis/ledger:testnet_postake",
+#     block_window_duration = ":block_window_duration_20000",
+#     integration_tests = ":integration_tests_false",
+#     force_updates = ":force_updates_true",
+#     download_snark_keys = ":download_snark_keys_true"
+# )
+## /OBAZL:TRANSITION

--- a/src/config/BUILD.bazel
+++ b/src/config/BUILD.bazel
@@ -90,13 +90,13 @@ bool_setting( name = "test_full_epoch_true", build_setting_default = True,
 # to support selection by profile we need a config setting for each
 # profile:
 config_setting( name = "config_dev",
-                flag_values = { "//src/profile": "dev" })
+                flag_values = { "//:profile": "dev" })
 config_setting( name = "config_debug",
-                flag_values = { "//src/profile": "debug" })
+                flag_values = { "//:profile": "debug" })
 config_setting( name = "config_fake_hash",
-                flag_values = { "//src/profile": "fake_hash" })
+                flag_values = { "//:profile": "fake_hash" })
 config_setting( name = "config_testnet_public",
-                flag_values = { "//src/profile": "testnet_public" })
+                flag_values = { "//:profile": "testnet_public" })
 
 # config_setting( name = "config_custom",
 #                 flag_values = { "//dev/profile": "any" })

--- a/src/lib/coda_version/coda_version_defaults.ml
+++ b/src/lib/coda_version/coda_version_defaults.ml
@@ -1,12 +1,19 @@
 let commit_id = "0000000000000000000000000000000000000000"
+
 let commit_id_short = "0000000"
+
 let branch = "MINA_NUL"
+
 let commit_date = "00-00-00"
 
 let marlin_commit_id = "0000000000000000000000000000000000000000"
+
 let marlin_commit_id_short = "0000000"
+
 let marlin_commit_date = "00-00-00"
 
 let zexe_commit_id = "0000000000000000000000000000000000000000"
+
 let zexe_commit_id_short = "0000000"
+
 let zexe_commit_date = "00-00-00"

--- a/src/lib/coda_version/coda_version_defaults.ml
+++ b/src/lib/coda_version/coda_version_defaults.ml
@@ -1,0 +1,12 @@
+let commit_id = "0000000000000000000000000000000000000000"
+let commit_id_short = "0000000"
+let branch = "MINA_NUL"
+let commit_date = "00-00-00"
+
+let marlin_commit_id = "0000000000000000000000000000000000000000"
+let marlin_commit_id_short = "0000000"
+let marlin_commit_date = "00-00-00"
+
+let zexe_commit_id = "0000000000000000000000000000000000000000"
+let zexe_commit_id_short = "0000000"
+let zexe_commit_date = "00-00-00"

--- a/src/lib/coda_version/dune
+++ b/src/lib/coda_version/dune
@@ -1,5 +1,6 @@
 (library
  (name coda_version)
+ (modules coda_version)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version))
  (public_name coda_version))


### PR DESCRIPTION
* the modifications in .bazelignore are for the transition period to full bazel
support. we need to bazelignore stuff that is pinned to old versions
until the transition is complete. otherwise some queries fail.
* src/BUILD.bazel contains config rules that need to be fleshed out
and updated once the transition is complete. they're not used currently, but they screw up queries.
* the profile fixes in src/config/BUILD.bazel are not temporary
* add some query scripts. they're generally useful, and they help in making PRs

