### PR TITLE
[Bazel] add src/lib/snark* packages

### DIFF
--- a/src/lib/snark_bits/BUILD.bazel
+++ b/src/lib/snark_bits/BUILD.bazel
@@ -1,0 +1,109 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_module",
+    "ocaml_ns",
+    "ppx_executable",
+)
+load(
+    "//:BUILD.bzl",
+    "CONFIG_MLH",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARK_BITS
+################################################################
+SNARK_BITS_MODULE_OPTS = []
+
+SNARK_BITS_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core_kernel",
+    "@opam//pkg:integers",
+    "@snarky//fold_lib",
+    "@snarky//src/base:snarky_backendless",
+]
+
+##############
+ocaml_archive(
+    name = "snark_bits",
+    doc = "Snark parameters",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARK_BITS_DEPS + [
+        # do not sort (buildifier)
+        ":_Bits",
+        ":_Bits_intf",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snark_bits_ns",
+    ns = "snark_bits",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "bits.ml",
+        "bits_intf.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Bits",
+    src = "bits.ml",
+    ns = ":Snark_bits_ns",
+    opts = SNARK_BITS_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_bits",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_BITS_DEPS + [
+        # do not sort (buildifier)
+        ":_Bits_intf",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Bits_intf",
+    src = "bits_intf.ml",
+    ns = ":Snark_bits_ns",
+    opts = SNARK_BITS_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_bits",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_BITS_DEPS,
+)
+
+###############
+ppx_executable(
+    name = "ppx1.exe",
+    lazy_deps = [
+        "@opam//pkg:ppx_deriving.runtime",
+        "@opam//pkg:ppx_inline_test.runtime-lib",
+    ],
+    main = "//bzl/ppx/exe:Driver",
+    opts = [],
+    visibility = [
+        "//src/lib/snark_bits:__pkg__",
+    ],
+    deps = [
+        "@opam//pkg:ppx_deriving.eq",
+        "@opam//pkg:ppx_inline_test",
+        "@opam//pkg:ppx_let",
+        "@opam//pkg:ppxlib",
+        "@ppx_optcomp//src:ppx_optcomp",
+        "@ppx_version//src:ppx_version",
+        "@snarky//ppx:ppx_snarky",
+    ],
+)

--- a/src/lib/snark_params/BUILD.bazel
+++ b/src/lib/snark_params/BUILD.bazel
@@ -1,0 +1,152 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_module",
+    "ocaml_ns",
+    "ppx_executable",
+)
+load(
+    "//:BUILD.bzl",
+    "CONFIG_MLH",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARK_PARAMS
+################################################################
+SNARK_PARAMS_MODULE_OPTS = []
+
+SNARK_PARAMS_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:digestif.c",
+    "@opam//pkg:core_kernel",
+    "@snarky//sponge",
+    "@snarky//group_map",
+    "@snarky//fold_lib",
+    "@mina//src/lib/o1trace",
+    "@snarky//tuple_lib",
+    "@snarky//bitstring_lib",
+    "@mina//src/lib/snarky_group_map",
+    "@snarky//src/base:snarky_backendless",
+    "@mina//src/lib/snarky_curves",
+    "@mina//src/lib/snark_bits",
+    "@mina//src/lib/pickles",
+    "@mina//src/lib/crypto_params",
+]
+
+##############
+ocaml_archive(
+    name = "snark_params",
+    doc = "Snark parameters",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARK_PARAMS_DEPS + [
+        # do not sort (buildifier)
+        ":_Snark_intf",
+        ":_Snark_params",
+        ":_Snark_util",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snark_params_ns",
+    ns = "snark_params",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "snark_intf.ml",
+        "snark_params.ml",
+        "snark_util.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Snark_intf",
+    src = "snark_intf.ml",
+    ns = ":Snark_params_ns",
+    opts = SNARK_PARAMS_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_params",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_PARAMS_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Snark_params",
+    src = "snark_params.ml",
+    ns = ":Snark_params_ns",
+    opts = SNARK_PARAMS_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_params",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_PARAMS_DEPS + [
+        # do not sort (buildifier)
+        ":_Snark_intf",
+        ":_Snark_util",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Snark_util",
+    src = "snark_util.ml",
+    ns = ":Snark_params_ns",
+    opts = SNARK_PARAMS_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_params",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_PARAMS_DEPS,
+)
+
+###############
+ppx_executable(
+    name = "ppx1.exe",
+    lazy_deps = [
+        "@opam//pkg:yojson",
+        "@opam//pkg:ppx_deriving_yojson.runtime",
+        "@opam//pkg:ppx_sexp_conv.runtime-lib",
+        "@opam//pkg:ppx_deriving.runtime",
+        "@opam//pkg:ppx_assert.runtime-lib",
+        "@opam//pkg:ppx_compare.runtime-lib",
+        "@opam//pkg:ppx_inline_test.runtime-lib",
+        "@opam//pkg:bin_prot",
+        "@opam//pkg:ppx_bench.runtime-lib",
+    ],
+    main = "//bzl/ppx/exe:Driver",
+    opts = [],
+    visibility = [
+        "//src/lib/snark_params:__pkg__",
+    ],
+    deps = [
+        "@opam//pkg:ppx_assert",
+        "@opam//pkg:ppx_base",
+        "@opam//pkg:ppx_bench",
+        "@opam//pkg:ppx_bin_prot",
+        "@opam//pkg:ppx_custom_printf",
+        "@opam//pkg:ppx_deriving.std",
+        "@opam//pkg:ppx_deriving_yojson",
+        "@opam//pkg:ppx_inline_test",
+        "@opam//pkg:ppx_let",
+        "@opam//pkg:ppx_sexp_conv",
+        "@opam//pkg:ppxlib",
+        "@ppx_optcomp//src:ppx_optcomp",
+        "@ppx_version//src:ppx_version",
+        "@snarky//ppx:ppx_snarky",
+    ],
+)

--- a/src/lib/snark_work_lib/BUILD.bazel
+++ b/src/lib/snark_work_lib/BUILD.bazel
@@ -1,0 +1,64 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_module",
+    "ocaml_ns",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARK_WORK_LIB
+################################################################
+SNARK_WORK_LIB_MODULE_OPTS = []
+
+SNARK_WORK_LIB_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core_kernel",
+    "@mina//src/lib/currency",
+    "@mina//src/lib/one_or_two",
+    "@mina//src/lib/signature_lib",
+    "@mina//src/lib/transaction_snark",
+]
+
+SNARK_WORK_LIB_PPX = "@//bzl/ppx/exe:ppx_jane__ppx_deriving_yojson__ppx_version"
+
+SNARK_WORK_LIB_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "snark_work_lib",
+]
+
+##############
+ocaml_archive(
+    name = "snark_work_lib",
+    doc = "Snark work types",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARK_WORK_LIB_DEPS + [
+        # do not sort (buildifier)
+        ":_Work",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snark_work_lib_ns",
+    ns = "snark_work_lib",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "work.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Work",
+    src = "work.ml",
+    ns = ":Snark_work_lib_ns",
+    opts = SNARK_WORK_LIB_MODULE_OPTS,
+    ppx = SNARK_WORK_LIB_PPX,
+    ppx_args = SNARK_WORK_LIB_PPX_ARGS,
+    deps = SNARK_WORK_LIB_DEPS,
+)

--- a/src/lib/snark_worker/BUILD.bazel
+++ b/src/lib/snark_worker/BUILD.bazel
@@ -1,0 +1,231 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_interface",
+    "ocaml_module",
+    "ocaml_ns",
+    "ppx_executable",
+)
+load(
+    "//:BUILD.bzl",
+    "CONFIG_MLH",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARK_WORKER
+################################################################
+SNARK_WORKER_INTERFACE_OPTS = []
+
+SNARK_WORKER_MODULE_OPTS = []
+
+SNARK_WORKER_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core",
+    "@opam//pkg:async",
+    "@opam//pkg:core_kernel.hash_heap",
+    "@mina//src/lib/cli_lib",
+    "@mina//src/lib/currency",
+    "@mina//src/lib/snark_work_lib",
+    "@mina//src/lib/mina_base",
+    "@mina//src/lib/blockchain_snark",
+    "@mina//src/lib/transaction_snark",
+    "@mina//src/lib/perf_histograms",
+    "@mina//src/lib/sparse_ledger_lib",
+    "@mina//src/lib/ledger_proof",
+    "@mina//src/lib/transaction_witness",
+]
+
+##############
+ocaml_archive(
+    name = "snark_worker",
+    doc = "Lib powering the snark_worker interactions with the daemon",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARK_WORKER_DEPS + [
+        # do not sort (buildifier)
+        ":_Debug",
+        ":_Functor",
+        ":_Intf",
+        ":_Prod",
+        ":_Rpcs",
+        ":_Snark_worker",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snark_worker_ns",
+    ns = "snark_worker",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "debug.ml",
+        "functor.ml",
+        "intf.ml",
+        "prod.ml",
+        "rpcs.ml",
+        "snark_worker.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Debug",
+    src = "debug.ml",
+    ns = ":Snark_worker_ns",
+    opts = SNARK_WORKER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_worker",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_WORKER_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Functor",
+    src = "functor.ml",
+    ns = ":Snark_worker_ns",
+    opts = SNARK_WORKER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_worker",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_WORKER_DEPS + [
+        # do not sort (buildifier)
+        ":_Intf",
+        ":_Rpcs",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Intf",
+    src = "intf.ml",
+    ns = ":Snark_worker_ns",
+    opts = SNARK_WORKER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_worker",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_WORKER_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Prod",
+    src = "prod.ml",
+    ns = ":Snark_worker_ns",
+    opts = SNARK_WORKER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_worker",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_WORKER_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Rpcs",
+    src = "rpcs.ml",
+    ns = ":Snark_worker_ns",
+    opts = SNARK_WORKER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_worker",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_WORKER_DEPS + [
+        # do not sort (buildifier)
+        ":_Intf",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Snark_worker",
+    src = "snark_worker.ml",
+    intf = ":_Snark_worker.cmi",
+    ns = ":Snark_worker_ns",
+    opts = SNARK_WORKER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_worker",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_WORKER_DEPS + [
+        # do not sort (buildifier)
+        ":_Debug",
+        ":_Functor",
+        ":_Intf",
+        ":_Prod",
+        ":_Rpcs",
+    ],
+)
+
+################
+ocaml_interface(
+    name = "_Snark_worker.cmi",
+    src = "snark_worker.mli",
+    ns = ":Snark_worker_ns",
+    opts = SNARK_WORKER_INTERFACE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_worker",
+    ],
+    ppx_data = CONFIG_MLH,
+    deps = SNARK_WORKER_DEPS + [
+        # do not sort (buildifier)
+        ":_Intf",
+    ],
+)
+
+###############
+ppx_executable(
+    name = "ppx1.exe",
+    lazy_deps = [
+        "@opam//pkg:yojson",
+        "@opam//pkg:ppx_deriving_yojson.runtime",
+        "@opam//pkg:ppx_sexp_conv.runtime-lib",
+        "@opam//pkg:ppx_inline_test.runtime-lib",
+        "@opam//pkg:bin_prot",
+    ],
+    main = "//bzl/ppx/exe:Driver",
+    opts = [],
+    visibility = [
+        "//src/lib/snark_worker:__pkg__",
+    ],
+    deps = [
+        "@mina//src/lib/ppx_coda",
+        "@mina//src/lib/ppx_register_event",
+        "@opam//pkg:ppx_bin_prot",
+        "@opam//pkg:ppx_custom_printf",
+        "@opam//pkg:ppx_deriving_yojson",
+        "@opam//pkg:ppx_inline_test",
+        "@opam//pkg:ppx_let",
+        "@opam//pkg:ppx_sexp_conv",
+        "@opam//pkg:ppxlib",
+        "@ppx_optcomp//src:ppx_optcomp",
+        "@ppx_version//src:ppx_version",
+    ],
+)

--- a/src/lib/snark_worker/standalone/BUILD.bazel
+++ b/src/lib/snark_worker/standalone/BUILD.bazel
@@ -1,0 +1,62 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_executable",
+    "ocaml_module",
+    "ppx_executable",
+)
+
+################################################################
+## STANZA 1: EXECUTABLE RUN_SNARK_WORKER
+################################################################
+RUN_SNARK_WORKER_EXECUTABLE_OPTS = []
+
+RUN_SNARK_WORKER_MODULE_OPTS = []
+
+RUN_SNARK_WORKER_DEPS = [
+    # do not sort (buildifier)
+    "@mina//src/lib/snark_worker",
+]
+
+#################
+ocaml_executable(
+    name = "run_snark_worker.exe",
+    opts = RUN_SNARK_WORKER_EXECUTABLE_OPTS,
+    visibility = ["//visibility:public"],
+    deps = RUN_SNARK_WORKER_DEPS + [
+        # do not sort (buildifier)
+        ":_Run_snark_worker",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Run_snark_worker",
+    src = "run_snark_worker.ml",
+    opts = RUN_SNARK_WORKER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+    ],
+    deps = RUN_SNARK_WORKER_DEPS,
+)
+
+###############
+ppx_executable(
+    name = "ppx1.exe",
+    lazy_deps = [
+        "@opam//pkg:ppx_sexp_conv.runtime-lib",
+    ],
+    main = "//bzl/ppx/exe:Driver",
+    opts = [],
+    visibility = [
+        "//src/lib/snark_worker/standalone:__pkg__",
+    ],
+    deps = [
+        "@opam//pkg:ppx_custom_printf",
+        "@opam//pkg:ppx_let",
+        "@opam//pkg:ppxlib",
+        "@ppx_version//src:ppx_version",
+    ],
+)

--- a/src/lib/snarky_blake2/BUILD.bazel
+++ b/src/lib/snarky_blake2/BUILD.bazel
@@ -1,0 +1,106 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_interface",
+    "ocaml_module",
+    "ocaml_ns",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARKY_BLAKE2
+################################################################
+SNARKY_BLAKE2_INTERFACE_OPTS = []
+
+SNARKY_BLAKE2_MODULE_OPTS = []
+
+SNARKY_BLAKE2_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:digestif.c",
+    "@opam//pkg:core_kernel",
+    "@opam//pkg:integers",
+    "@snarky//src/base:snarky_backendless",
+    "@mina//src/lib/blake2",
+]
+
+SNARKY_BLAKE2_PPX = "@//bzl/ppx/exe:ppx_version__ppx_jane__ppx_deriving.eq"
+
+SNARKY_BLAKE2_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "snarky_blake2",
+]
+
+##############
+ocaml_archive(
+    name = "snarky_blake2",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARKY_BLAKE2_DEPS + [
+        # do not sort (buildifier)
+        ":_Snarky_blake2",
+        ":_Uint32",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snarky_blake2_ns",
+    ns = "snarky_blake2",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "snarky_blake2.ml",
+        "uint32.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Snarky_blake2",
+    src = "snarky_blake2.ml",
+    intf = ":_Snarky_blake2.cmi",
+    ns = ":Snarky_blake2_ns",
+    opts = SNARKY_BLAKE2_MODULE_OPTS,
+    ppx = SNARKY_BLAKE2_PPX,
+    ppx_args = SNARKY_BLAKE2_PPX_ARGS,
+    deps = SNARKY_BLAKE2_DEPS + [
+        # do not sort (buildifier)
+        ":_Uint32",
+    ],
+)
+
+################
+ocaml_interface(
+    name = "_Snarky_blake2.cmi",
+    src = "snarky_blake2.mli",
+    ns = ":Snarky_blake2_ns",
+    opts = SNARKY_BLAKE2_INTERFACE_OPTS,
+    ppx = SNARKY_BLAKE2_PPX,
+    ppx_args = SNARKY_BLAKE2_PPX_ARGS,
+    deps = SNARKY_BLAKE2_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Uint32",
+    src = "uint32.ml",
+    intf = ":_Uint32.cmi",
+    ns = ":Snarky_blake2_ns",
+    opts = SNARKY_BLAKE2_MODULE_OPTS,
+    ppx = SNARKY_BLAKE2_PPX,
+    ppx_args = SNARKY_BLAKE2_PPX_ARGS,
+    deps = SNARKY_BLAKE2_DEPS,
+)
+
+################
+ocaml_interface(
+    name = "_Uint32.cmi",
+    src = "uint32.mli",
+    ns = ":Snarky_blake2_ns",
+    opts = SNARKY_BLAKE2_INTERFACE_OPTS,
+    ppx = SNARKY_BLAKE2_PPX,
+    ppx_args = SNARKY_BLAKE2_PPX_ARGS,
+    deps = SNARKY_BLAKE2_DEPS,
+)

--- a/src/lib/snarky_curves/BUILD.bazel
+++ b/src/lib/snarky_curves/BUILD.bazel
@@ -1,0 +1,56 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_module",
+    "ppx_executable",
+)
+
+#############
+ocaml_module(
+    name = "snarky_curves",
+    src = "snarky_curves.ml",
+    opts = [],
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snarky_curves",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@mina//src/lib/snarky_field_extensions",
+        "@opam//pkg:core_kernel",
+        "@snarky//snarkette",
+        "@snarky//src/base:snarky_backendless",
+    ],
+)
+
+###############
+ppx_executable(
+    name = "ppx1.exe",
+    lazy_deps = [
+        "@opam//pkg:ppx_expect.collector",
+        "@opam//pkg:ppx_hash.runtime-lib",
+        "@opam//pkg:ppx_sexp_conv.runtime-lib",
+        "@opam//pkg:ppx_deriving.runtime",
+        "@opam//pkg:ppx_assert.runtime-lib",
+        "@opam//pkg:ppx_compare.runtime-lib",
+        "@opam//pkg:ppx_inline_test.runtime-lib",
+        "@opam//pkg:ppx_bench.runtime-lib",
+        "@opam//pkg:ppx_enumerate.runtime-lib",
+        "@opam//pkg:ppx_module_timer.runtime",
+    ],
+    main = "//bzl/ppx/exe:Driver",
+    opts = [],
+    visibility = [
+        "//src/lib/snarky_curves:__pkg__",
+    ],
+    deps = [
+        "@opam//pkg:ppx_deriving.eq",
+        "@opam//pkg:ppx_jane",
+        "@opam//pkg:ppxlib",
+        "@ppx_version//src:ppx_version",
+        "@snarky//ppx:ppx_snarky",
+    ],
+)

--- a/src/lib/snarky_field_extensions/BUILD.bazel
+++ b/src/lib/snarky_field_extensions/BUILD.bazel
@@ -1,0 +1,77 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_module",
+    "ocaml_ns",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARKY_FIELD_EXTENSIONS
+################################################################
+SNARKY_FIELD_EXTENSIONS_MODULE_OPTS = []
+
+SNARKY_FIELD_EXTENSIONS_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core_kernel",
+    "@snarky//src/base:snarky_backendless",
+    "@snarky//snarkette",
+]
+
+SNARKY_FIELD_EXTENSIONS_PPX = "@//bzl/ppx/exe:ppx_version__ppx_jane__ppx_deriving.eq__ppx_deriving_yojson"
+
+SNARKY_FIELD_EXTENSIONS_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "snarky_field_extensions",
+]
+
+##############
+ocaml_archive(
+    name = "snarky_field_extensions",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARKY_FIELD_EXTENSIONS_DEPS + [
+        # do not sort (buildifier)
+        ":_Field_extensions",
+        ":_Intf",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snarky_field_extensions_ns",
+    ns = "snarky_field_extensions",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "field_extensions.ml",
+        "intf.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Field_extensions",
+    src = "field_extensions.ml",
+    ns = ":Snarky_field_extensions_ns",
+    opts = SNARKY_FIELD_EXTENSIONS_MODULE_OPTS,
+    ppx = SNARKY_FIELD_EXTENSIONS_PPX,
+    ppx_args = SNARKY_FIELD_EXTENSIONS_PPX_ARGS,
+    deps = SNARKY_FIELD_EXTENSIONS_DEPS + [
+        # do not sort (buildifier)
+        ":_Intf",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Intf",
+    src = "intf.ml",
+    ns = ":Snarky_field_extensions_ns",
+    opts = SNARKY_FIELD_EXTENSIONS_MODULE_OPTS,
+    ppx = SNARKY_FIELD_EXTENSIONS_PPX,
+    ppx_args = SNARKY_FIELD_EXTENSIONS_PPX_ARGS,
+    deps = SNARKY_FIELD_EXTENSIONS_DEPS,
+)

--- a/src/lib/snarky_pairing/BUILD.bazel
+++ b/src/lib/snarky_pairing/BUILD.bazel
@@ -1,0 +1,106 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_module",
+    "ocaml_ns",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARKY_PAIRING
+################################################################
+SNARKY_PAIRING_MODULE_OPTS = []
+
+SNARKY_PAIRING_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core_kernel",
+    "@mina//src/lib/sgn_type",
+    "@mina//src/lib/snarky_field_extensions",
+    "@snarky//src/base:snarky_backendless",
+    "@snarky//snarkette",
+]
+
+SNARKY_PAIRING_PPX = "@//bzl/ppx/exe:ppx_version__ppx_jane__ppx_deriving.eq"
+
+SNARKY_PAIRING_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "snarky_pairing",
+]
+
+##############
+ocaml_archive(
+    name = "snarky_pairing",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARKY_PAIRING_DEPS + [
+        # do not sort (buildifier)
+        ":_Final_exponentiation",
+        ":_G1_precomputation",
+        ":_G2_precomputation",
+        ":_Miller_loop",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snarky_pairing_ns",
+    ns = "snarky_pairing",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "final_exponentiation.ml",
+        "g1_precomputation.ml",
+        "g2_precomputation.ml",
+        "miller_loop.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Final_exponentiation",
+    src = "final_exponentiation.ml",
+    ns = ":Snarky_pairing_ns",
+    opts = SNARKY_PAIRING_MODULE_OPTS,
+    ppx = SNARKY_PAIRING_PPX,
+    ppx_args = SNARKY_PAIRING_PPX_ARGS,
+    deps = SNARKY_PAIRING_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_G1_precomputation",
+    src = "g1_precomputation.ml",
+    ns = ":Snarky_pairing_ns",
+    opts = SNARKY_PAIRING_MODULE_OPTS,
+    ppx = SNARKY_PAIRING_PPX,
+    ppx_args = SNARKY_PAIRING_PPX_ARGS,
+    deps = SNARKY_PAIRING_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_G2_precomputation",
+    src = "g2_precomputation.ml",
+    ns = ":Snarky_pairing_ns",
+    opts = SNARKY_PAIRING_MODULE_OPTS,
+    ppx = SNARKY_PAIRING_PPX,
+    ppx_args = SNARKY_PAIRING_PPX_ARGS,
+    deps = SNARKY_PAIRING_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Miller_loop",
+    src = "miller_loop.ml",
+    ns = ":Snarky_pairing_ns",
+    opts = SNARKY_PAIRING_MODULE_OPTS,
+    ppx = SNARKY_PAIRING_PPX,
+    ppx_args = SNARKY_PAIRING_PPX_ARGS,
+    deps = SNARKY_PAIRING_DEPS + [
+        # do not sort (buildifier)
+        ":_G1_precomputation",
+        ":_G2_precomputation",
+    ],
+)

--- a/src/lib/snarky_taylor/BUILD.bazel
+++ b/src/lib/snarky_taylor/BUILD.bazel
@@ -1,0 +1,92 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_interface",
+    "ocaml_module",
+    "ocaml_ns",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARKY_TAYLOR
+################################################################
+SNARKY_TAYLOR_INTERFACE_OPTS = []
+
+SNARKY_TAYLOR_MODULE_OPTS = []
+
+SNARKY_TAYLOR_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core_kernel",
+    "@snarky//src/base:snarky_backendless",
+    "@snarky//snarky_integer",
+]
+
+SNARKY_TAYLOR_PPX = "@//bzl/ppx/exe:ppx_version__ppx_jane__ppx_deriving.eq"
+
+SNARKY_TAYLOR_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "snarky_taylor",
+]
+
+##############
+ocaml_archive(
+    name = "snarky_taylor",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARKY_TAYLOR_DEPS + [
+        # do not sort (buildifier)
+        ":_Floating_point",
+        ":_Snarky_taylor",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snarky_taylor_ns",
+    ns = "snarky_taylor",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "floating_point.ml",
+        "snarky_taylor.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Floating_point",
+    src = "floating_point.ml",
+    intf = ":_Floating_point.cmi",
+    ns = ":Snarky_taylor_ns",
+    opts = SNARKY_TAYLOR_MODULE_OPTS,
+    ppx = SNARKY_TAYLOR_PPX,
+    ppx_args = SNARKY_TAYLOR_PPX_ARGS,
+    deps = SNARKY_TAYLOR_DEPS,
+)
+
+################
+ocaml_interface(
+    name = "_Floating_point.cmi",
+    src = "floating_point.mli",
+    ns = ":Snarky_taylor_ns",
+    opts = SNARKY_TAYLOR_INTERFACE_OPTS,
+    ppx = SNARKY_TAYLOR_PPX,
+    ppx_args = SNARKY_TAYLOR_PPX_ARGS,
+    deps = SNARKY_TAYLOR_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Snarky_taylor",
+    src = "snarky_taylor.ml",
+    ns = ":Snarky_taylor_ns",
+    opts = SNARKY_TAYLOR_MODULE_OPTS,
+    ppx = SNARKY_TAYLOR_PPX,
+    ppx_args = SNARKY_TAYLOR_PPX_ARGS,
+    deps = SNARKY_TAYLOR_DEPS + [
+        # do not sort (buildifier)
+        ":_Floating_point",
+    ],
+)

--- a/src/lib/snarky_verifier/BUILD.bazel
+++ b/src/lib/snarky_verifier/BUILD.bazel
@@ -1,0 +1,170 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_module",
+    "ocaml_ns",
+    "ppx_executable",
+)
+
+################################################################
+## STANZA 1: LIBRARY SNARKY_VERIFIER
+################################################################
+SNARKY_VERIFIER_MODULE_OPTS = []
+
+SNARKY_VERIFIER_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core",          # obazl:retain
+    "@opam//pkg:core_kernel",
+    "@mina//src/lib/sgn_type",
+    "@mina//src/lib/snarky_curves",
+    "@snarky//src/base:snarky_backendless",
+    "@snarky//snarkette",
+]
+
+##############
+ocaml_archive(
+    name = "snarky_verifier",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = SNARKY_VERIFIER_DEPS + [
+        # do not sort (buildifier)
+        ":_Bowe_gabizon",
+        ":_Groth",
+        ":_Groth_maller",
+        ":_Inputs",
+        ":_Summary",
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Snarky_verifier_ns",
+    ns = "snarky_verifier",
+    opts = [],
+    submodules = [
+        # do not sort (buildifier)
+        "bowe_gabizon.ml",
+        "groth.ml",
+        "groth_maller.ml",
+        "inputs.ml",
+        "summary.ml",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Bowe_gabizon",
+    src = "bowe_gabizon.ml",
+    ns = ":Snarky_verifier_ns",
+    opts = SNARKY_VERIFIER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snarky_verifier",
+    ],
+    deps = SNARKY_VERIFIER_DEPS + [
+        # do not sort (buildifier)
+        ":_Inputs",
+        ":_Summary",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Groth",
+    src = "groth.ml",
+    ns = ":Snarky_verifier_ns",
+    opts = SNARKY_VERIFIER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snarky_verifier",
+    ],
+    deps = SNARKY_VERIFIER_DEPS + [
+        # do not sort (buildifier)
+        ":_Inputs",
+        ":_Summary",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Groth_maller",
+    src = "groth_maller.ml",
+    ns = ":Snarky_verifier_ns",
+    opts = SNARKY_VERIFIER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snarky_verifier",
+    ],
+    deps = SNARKY_VERIFIER_DEPS + [
+        # do not sort (buildifier)
+        ":_Inputs",
+        ":_Summary",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Inputs",
+    src = "inputs.ml",
+    ns = ":Snarky_verifier_ns",
+    opts = SNARKY_VERIFIER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snarky_verifier",
+    ],
+    deps = SNARKY_VERIFIER_DEPS,
+)
+
+#############
+ocaml_module(
+    name = "_Summary",
+    src = "summary.ml",
+    ns = ":Snarky_verifier_ns",
+    opts = SNARKY_VERIFIER_MODULE_OPTS,
+    ppx = ":ppx1.exe",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snarky_verifier",
+    ],
+    deps = SNARKY_VERIFIER_DEPS,
+)
+
+###############
+ppx_executable(
+    name = "ppx1.exe",
+    lazy_deps = [
+        "@opam//pkg:ppx_expect.collector",
+        "@opam//pkg:ppx_hash.runtime-lib",
+        "@opam//pkg:ppx_sexp_conv.runtime-lib",
+        "@opam//pkg:ppx_deriving.runtime",
+        "@opam//pkg:ppx_assert.runtime-lib",
+        "@opam//pkg:ppx_compare.runtime-lib",
+        "@opam//pkg:ppx_inline_test.runtime-lib",
+        "@opam//pkg:ppx_bench.runtime-lib",
+        "@opam//pkg:ppx_enumerate.runtime-lib",
+        "@opam//pkg:ppx_module_timer.runtime",
+    ],
+    main = "//bzl/ppx/exe:Driver",
+    opts = [],
+    visibility = [
+        "//src/lib/snarky_verifier:__pkg__",
+    ],
+    deps = [
+        "@opam//pkg:ppx_deriving.eq",
+        "@opam//pkg:ppx_jane",
+        "@opam//pkg:ppxlib",
+        "@ppx_version//src:ppx_version",
+        "@snarky//h_list/ppx:ppx_h_list",
+    ],
+)


### PR DESCRIPTION
Except for snark_keys, which contains a genrule (to follow)