### PR TITLE
[Bazel] add src/lib/snark_keys and subdirs, incl. gen_keys

### DIFF
--- a/src/lib/snark_keys/BUILD.bazel
+++ b/src/lib/snark_keys/BUILD.bazel
@@ -1,0 +1,34 @@
+load( "@obazl_rules_ocaml//ocaml:rules.bzl", "ocaml_module" )
+
+#############
+ocaml_module(
+    name = "snark_keys",
+    src = "snark_keys.ml",
+    opts = [],
+    ppx = "@//bzl/ppx/exe:ppx_version__ppx_jane__ppx_deriving_yojson",
+    ppx_args = [
+        # do not sort (buildifier)
+        "-inline-test-lib",
+        "snark_keys",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@opam//pkg:async",
+        "@opam//pkg:core",
+        "@mina//src/lib/blockchain_snark",
+        "@mina//src/lib/transaction_snark",
+    ],
+)
+
+
+################################################################
+TOOL = "//src/lib/snark_keys/gen_keys:gen_keys.exe"
+genrule(
+    name = "gensrcs",
+    outs = ["snark_keys.ml"],
+    tools = [TOOL],
+    cmd = "\n".join([
+        "$(location {tool})".format(tool = TOOL),
+        "cp snark_keys.ml \"$(RULEDIR)/\"",
+    ]),
+)

--- a/src/lib/snark_keys/gen_keys/BUILD.bazel
+++ b/src/lib/snark_keys/gen_keys/BUILD.bazel
@@ -1,0 +1,71 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_executable",
+    "ocaml_module",
+)
+load(
+    "//:BUILD.bzl",
+    "CONFIG_MLH",
+)
+
+################################################################
+## STANZA 1: EXECUTABLE GEN_KEYS
+################################################################
+GEN_KEYS_EXECUTABLE_OPTS = []
+
+GEN_KEYS_MODULE_OPTS = []
+
+GEN_KEYS_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:ppxlib",
+    "@opam//pkg:async",
+    "@opam//pkg:core",
+    "@mina//src/lib/cache_dir",
+    "@mina//src/lib/snark_keys/remove_snark_keys_trigger",
+    "@mina//src/lib/mina_base",
+    "@mina//src/lib/transaction_snark",
+    "@mina//src/lib/blockchain_snark",
+]
+
+GEN_KEYS_PPX = "@//bzl/ppx/exe:ppx_version__ppx_optcomp__ppx_let__ppxlib.metaquot"
+
+GEN_KEYS_PPX_ARGS = [
+    # do not sort (buildifier)
+]
+
+#################
+ocaml_executable(
+    name = "gen_keys.exe",
+    opts = GEN_KEYS_EXECUTABLE_OPTS,
+    visibility = ["//visibility:public"],
+    deps = GEN_KEYS_DEPS + [
+        # do not sort (buildifier)
+        ":_Gen_keys",
+        # "@ocaml_rocksdb//:rocks"
+    ],
+    cc_deps = {
+        "@mina//src/lib/marlin_plonk_bindings/stubs:marlin_plonk_stubs": "static",
+        "@ocaml_rocksdb//:librocksdb": "static", ## FIXME: static-linkall
+        "@ocaml_rocksdb//:bzip2": "static",
+        "@ocaml_rocksdb//:zlib": "default",
+        "@ocaml_jemalloc//src:libjemalloc": "static"
+    },
+    cc_linkall  = ["@ocaml_rocksdb//:librocksdb"],  ## FIXME
+    cc_linkopts = select({
+        "//bzl/host:macos": ["-lc++abi", "-lc++"],
+        "//bzl/host:linux": ["-lstdc++"],
+    }, no_match_error = "Unsupported platform. Only Linux and MacOS supported.")
+)
+
+#############
+ocaml_module(
+    name = "_Gen_keys",
+    src = "gen_keys.ml",
+    opts = GEN_KEYS_MODULE_OPTS,
+    ppx = GEN_KEYS_PPX,
+    ppx_args = GEN_KEYS_PPX_ARGS,
+    ppx_data = CONFIG_MLH,
+    deps = GEN_KEYS_DEPS,
+)

--- a/src/lib/snark_keys/remove_snark_keys_trigger/BUILD.bazel
+++ b/src/lib/snark_keys/remove_snark_keys_trigger/BUILD.bazel
@@ -1,0 +1,50 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_archive",
+    "ocaml_ns",
+)
+
+################################################################
+## STANZA 1: LIBRARY REMOVE_SNARK_KEYS_TRIGGER
+################################################################
+
+REMOVE_SNARK_KEYS_TRIGGER_DEPS = [
+    # do not sort (buildifier)
+    "@snarky//src/base:snarky_backendless",
+]
+
+REMOVE_SNARK_KEYS_TRIGGER_PPX = "@//bzl/ppx/exe:ppx_version"
+
+REMOVE_SNARK_KEYS_TRIGGER_PPX_ARGS = [
+    # do not sort (buildifier)
+]
+
+##############
+ocaml_archive(
+    name = "remove_snark_keys_trigger",
+    opts = [],
+    visibility = ["//visibility:public"],
+    deps = REMOVE_SNARK_KEYS_TRIGGER_DEPS + [
+        # do not sort (buildifier)
+    ],
+)
+
+#########
+ocaml_ns(
+    name = "Remove_snark_keys_trigger_ns",
+    ns = "remove_snark_keys_trigger",
+)
+
+TOOL = "//src/lib/snark_keys/remove_snark_keys_trigger/clear_keys:clear_keys.exe"
+
+genrule(
+    name = "gensrcs",
+    outs = ["remove_keys_trigger.ml"],
+    cmd = "\n".join([
+        "$(location {tool})".format(tool = TOOL),
+        "cp remove_keys_trigger.ml \"$@\"",
+    ]),
+    tools = [TOOL],
+)

--- a/src/lib/snark_keys/remove_snark_keys_trigger/clear_keys/BUILD.bazel
+++ b/src/lib/snark_keys/remove_snark_keys_trigger/clear_keys/BUILD.bazel
@@ -1,0 +1,52 @@
+## OBAZL GENERATED FILE ## To retain edits (prevent overwrite), delete this line.
+
+load(
+    "@obazl_rules_ocaml//ocaml:rules.bzl",
+    "ocaml_executable",
+    "ocaml_module",
+)
+
+################################################################
+## STANZA 1: EXECUTABLE CLEAR_KEYS
+################################################################
+CLEAR_KEYS_EXECUTABLE_OPTS = []
+
+CLEAR_KEYS_MODULE_OPTS = []
+
+CLEAR_KEYS_DEPS = [
+    # do not sort (buildifier)
+    "@opam//pkg:core",
+    "@opam//pkg:async",
+    "@mina//src/lib/file_system",
+    "@mina//src/lib/cache_dir",
+    "@snarky//src/base:snarky_backendless",
+]
+
+CLEAR_KEYS_PPX = "@//bzl/ppx/exe:ppx_version__ppx_jane"
+
+CLEAR_KEYS_PPX_ARGS = [
+    # do not sort (buildifier)
+    "-inline-test-lib",
+    "clear_keys",
+]
+
+#################
+ocaml_executable(
+    name = "clear_keys.exe",
+    opts = CLEAR_KEYS_EXECUTABLE_OPTS,
+    visibility = ["//visibility:public"],
+    deps = CLEAR_KEYS_DEPS + [
+        # do not sort (buildifier)
+        ":_Clear_keys",
+    ],
+)
+
+#############
+ocaml_module(
+    name = "_Clear_keys",
+    src = "clear_keys.ml",
+    opts = CLEAR_KEYS_MODULE_OPTS,
+    ppx = CLEAR_KEYS_PPX,
+    ppx_args = CLEAR_KEYS_PPX_ARGS,
+    deps = CLEAR_KEYS_DEPS,
+)


### PR DESCRIPTION
Contains subdir gen_keys which uses genrule to generate a file for compilation.