### PR TITLE
Leaderboard: Merged pre and postfork data + SNARK challenge [DO NOT MERGE]

### DIFF
--- a/frontend/leaderboard/__tests__/leaderboard_test.re
+++ b/frontend/leaderboard/__tests__/leaderboard_test.re
@@ -7,6 +7,7 @@ let blocks = [|
     Types.Block.id: 1,
     blockchainState: {
       creatorAccount: "publickey1",
+      coinbaseReceiver: None,
       timestamp: "0",
       height: "1",
     },
@@ -17,6 +18,7 @@ let blocks = [|
     id: 2,
     blockchainState: {
       creatorAccount: "publickey1",
+      coinbaseReceiver: None,
       timestamp: "1548878462542",
       height: "2",
     },
@@ -27,6 +29,7 @@ let blocks = [|
     id: 3,
     blockchainState: {
       creatorAccount: "publickey1",
+      coinbaseReceiver: None,
       timestamp: "1548878464058",
       height: "3",
     },
@@ -37,6 +40,7 @@ let blocks = [|
     id: 4,
     blockchainState: {
       creatorAccount: "publickey1",
+      coinbaseReceiver: None,
       timestamp: "1548878466000",
       height: "4",
     },
@@ -47,6 +51,7 @@ let blocks = [|
     id: 5,
     blockchainState: {
       creatorAccount: "publickey2",
+      coinbaseReceiver: None,
       timestamp: "1548878468000",
       height: "5",
     },
@@ -57,6 +62,7 @@ let blocks = [|
     id: 6,
     blockchainState: {
       creatorAccount: "publickey2",
+      coinbaseReceiver: None,
       timestamp: "1548878470000",
       height: "6",
     },
@@ -67,6 +73,7 @@ let blocks = [|
     id: 7,
     blockchainState: {
       creatorAccount: "publickey2",
+      coinbaseReceiver: None,
       timestamp: "1548878472000",
       height: "7",
     },
@@ -77,6 +84,7 @@ let blocks = [|
     id: 8,
     blockchainState: {
       creatorAccount: "publickey3",
+      coinbaseReceiver: None,
       timestamp: "1548878474000",
       height: "8",
     },
@@ -87,6 +95,7 @@ let blocks = [|
     id: 9,
     blockchainState: {
       creatorAccount: "publickey3",
+      coinbaseReceiver: None,
       timestamp: "1548878476000",
       height: "9",
     },
@@ -97,6 +106,7 @@ let blocks = [|
     id: 10,
     blockchainState: {
       creatorAccount: "publickey4",
+      coinbaseReceiver: None,
       timestamp: "1548878478000",
       height: "10",
     },

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -57,7 +57,7 @@ let bonusSnarkFeeChallenge = metricsMap => {
     );
 
   // If the metric value sum is greater than the threshold, every user that particpated will receive points
-  snarkFeeCounter >= Int64.of_int(1000)
+  snarkFeeCounter >= 1000000000000L
     ? StringMap.fold(
         (key, metric: Types.Metrics.t, map) => {
           switch (metric.snarkFeesCollected) {

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -28,6 +28,16 @@ let echoServiceChallenge = metricsMap => {
      );
 };
 
+let bonusSnarkFeeChallenge = metricsMap => {
+  Points.addPointsIfCommunityMeetsThreshold(
+    (metricRecord: Types.Metrics.t) =>
+      metricRecord.transactionsReceivedByEcho,
+    1000,
+    2000,
+    metricsMap,
+  );
+};
+
 let snarkFeeChallenge = metricsMap => {
   [
     Points.applyTopNPoints(
@@ -43,6 +53,7 @@ let snarkFeeChallenge = metricsMap => {
       (metricRecord: Types.Metrics.t) => metricRecord.snarkFeesCollected,
       compare,
     ),
+    bonusSnarkFeeChallenge(metricsMap),
   ]
   |> Points.sumPointsMaps;
 };

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -28,6 +28,20 @@ let echoServiceChallenge = metricsMap => {
      );
 };
 
+let coinbaseReceiverChallenge = (points, metricsMap) => {
+  metricsMap
+  |> StringMap.fold(
+       (key, metric: Types.Metrics.t, map) => {
+         switch (metric.coinbaseReceiver) {
+         | Some(metricValue) =>
+           metricValue ? StringMap.add(key, points, map) : map
+         | None => map
+         }
+       },
+       StringMap.empty,
+     );
+};
+
 let bonusSnarkFeeChallenge = metricsMap => {
   Points.addPointsIfCommunityMeetsThreshold(
     (metricRecord: Types.Metrics.t) =>

--- a/frontend/leaderboard/src/Metrics.re
+++ b/frontend/leaderboard/src/Metrics.re
@@ -120,13 +120,13 @@ let getCreateTokenAndSend = blocks => {
   for the work that has been included.
  */
 let calculateSnarkFeeSum = (map, block: Types.Block.t) => {
+  let coinbaseReceiver =
+    Belt.Option.getWithDefault(block.blockchainState.coinbaseReceiver, "");
+
   block.internalCommands
   |> Array.fold_left(
        (map, command: Types.Block.InternalCommand.t) => {
-         switch (
-           command.type_,
-           command.receiverAccount != block.blockchainState.creatorAccount,
-         ) {
+         switch (command.type_, command.receiverAccount !== coinbaseReceiver) {
          | (FeeTransfer, true) =>
            map
            |> StringMap.update(
@@ -151,13 +151,13 @@ let getSnarkFeesCollected = blocks => {
 };
 
 let calculateHighestSnarkFeeCollected = (map, block: Types.Block.t) => {
+  let coinbaseReceiver =
+    Belt.Option.getWithDefault(block.blockchainState.coinbaseReceiver, "");
+
   block.internalCommands
   |> Array.fold_left(
        (map, command: Types.Block.InternalCommand.t) => {
-         switch (
-           command.type_,
-           command.receiverAccount != block.blockchainState.creatorAccount,
-         ) {
+         switch (command.type_, command.receiverAccount !== coinbaseReceiver) {
          | (FeeTransfer, true) =>
            map
            |> StringMap.update(

--- a/frontend/leaderboard/src/Points.re
+++ b/frontend/leaderboard/src/Points.re
@@ -64,37 +64,6 @@ let applyTopNPoints =
      );
 };
 
-let addPointsIfCommunityMeetsThreshold =
-    (getMetricValue, threshold, points, metricsMap) => {
-  // Sum all metric values recorded thus far
-  let metricCounter =
-    StringMap.fold(
-      (_, metric, metricCounter) => {
-        switch (getMetricValue(metric)) {
-        | Some(metricValue) => metricCounter + metricValue
-        | None => metricCounter
-        }
-      },
-      metricsMap,
-      0,
-    );
-
-  // If the metric value sum is greater than the threshold, every user that particpated will receive points
-  metricCounter >= threshold
-    ? StringMap.fold(
-        (key, metric, map) => {
-          switch (getMetricValue(metric)) {
-          | Some(metricValue) =>
-            metricValue >= 0 ? StringMap.add(key, points, map) : map
-          | None => map
-          }
-        },
-        metricsMap,
-        StringMap.empty,
-      )
-    : StringMap.empty;
-};
-
 // Combines a list of maps of users to points and returns one map of users to points
 let sumPointsMaps = maps => {
   maps

--- a/frontend/leaderboard/src/Points.re
+++ b/frontend/leaderboard/src/Points.re
@@ -64,6 +64,37 @@ let applyTopNPoints =
      );
 };
 
+let addPointsIfCommunityMeetsThreshold =
+    (getMetricValue, threshold, points, metricsMap) => {
+  // Sum all metric values recorded thus far
+  let metricCounter =
+    StringMap.fold(
+      (_, metric, metricCounter) => {
+        switch (getMetricValue(metric)) {
+        | Some(metricValue) => metricCounter + metricValue
+        | None => metricCounter
+        }
+      },
+      metricsMap,
+      0,
+    );
+
+  // If the metric value sum is greater than the threshold, every user that particpated will receive points
+  metricCounter >= threshold
+    ? StringMap.fold(
+        (key, metric, map) => {
+          switch (getMetricValue(metric)) {
+          | Some(metricValue) =>
+            metricValue >= 0 ? StringMap.add(key, points, map) : map
+          | None => map
+          }
+        },
+        metricsMap,
+        StringMap.empty,
+      )
+    : StringMap.empty;
+};
+
 // Combines a list of maps of users to points and returns one map of users to points
 let sumPointsMaps = maps => {
   maps

--- a/frontend/leaderboard/src/Sheets.re
+++ b/frontend/leaderboard/src/Sheets.re
@@ -47,7 +47,7 @@ module Core = {
 
     let getSheet = sheet => {
       switch (sheet) {
-      | Main => {name: "main", range: "main!A5:AL"}
+      | Main => {name: "main", range: "main!A5:AQ"}
       | AllTimeLeaderboard => {
           name: "All-Time Leaderboard",
           range: "All-Time Leaderboard!C4:H",

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -184,58 +184,55 @@ module Block = {
    each UserCommand and InternalCommand to it's associated block.
     */
   let parseBlocks = blocks => {
-    let blocks =
-      Belt.Map.Int.(
-        blocks
-        |> Array.fold_left(
-             (blockMap, block) => {
-               let newBlock = Decode.block(block);
-               let userCommand = UserCommand.Decode.userCommand(block);
-               let internalCommand =
-                 InternalCommand.Decode.internalCommand(block);
+    Belt.Map.Int.(
+      blocks
+      |> Array.fold_left(
+           (blockMap, block) => {
+             let newBlock = Decode.block(block);
+             let userCommand = UserCommand.Decode.userCommand(block);
+             let internalCommand =
+               InternalCommand.Decode.internalCommand(block);
 
-               let coinbaseReceiver =
-                 switch (internalCommand) {
-                 | Some(internalCommand) =>
-                   switch (internalCommand.type_) {
-                   | Coinbase => Some(internalCommand.receiverAccount)
-                   | _ => None
-                   }
+             let coinbaseReceiver =
+               switch (internalCommand) {
+               | Some(internalCommand) =>
+                 switch (internalCommand.type_) {
+                 | Coinbase => Some(internalCommand.receiverAccount)
                  | _ => None
-                 };
-
-               if (has(blockMap, newBlock.id)) {
-                 update(blockMap, newBlock.id, block => {
-                   switch (block) {
-                   | Some(currentBlock) =>
-                     addCommandIfSome(userCommand, currentBlock.userCommands);
-                     addCommandIfSome(
-                       internalCommand,
-                       currentBlock.internalCommands,
-                     );
-                     let block =
-                       addCoinbaseReceiverIfSome(
-                         currentBlock,
-                         coinbaseReceiver,
-                       );
-                     Some(block);
-                   | None => None
-                   }
-                 });
-               } else {
-                 addCommandIfSome(userCommand, newBlock.userCommands);
-                 addCommandIfSome(internalCommand, newBlock.internalCommands);
-                 let block =
-                   addCoinbaseReceiverIfSome(newBlock, coinbaseReceiver);
-                 set(blockMap, block.id, block);
+                 }
+               | _ => None
                };
-             },
-             empty,
-           )
-        |> valuesToArray
-      );
 
-    blocks;
+             if (has(blockMap, newBlock.id)) {
+               update(blockMap, newBlock.id, block => {
+                 switch (block) {
+                 | Some(currentBlock) =>
+                   addCommandIfSome(userCommand, currentBlock.userCommands);
+                   addCommandIfSome(
+                     internalCommand,
+                     currentBlock.internalCommands,
+                   );
+                   let block =
+                     addCoinbaseReceiverIfSome(
+                       currentBlock,
+                       coinbaseReceiver,
+                     );
+                   Some(block);
+                 | None => None
+                 }
+               });
+             } else {
+               addCommandIfSome(userCommand, newBlock.userCommands);
+               addCommandIfSome(internalCommand, newBlock.internalCommands);
+               let block =
+                 addCoinbaseReceiverIfSome(newBlock, coinbaseReceiver);
+               set(blockMap, block.id, block);
+             };
+           },
+           empty,
+         )
+      |> valuesToArray
+    );
   };
 };
 

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -166,8 +166,10 @@ module Block = {
   let addCoinbaseReceiverIfSome = (block, coinbaseReceiver) => {
     switch (coinbaseReceiver) {
     | Some(_) =>
-      let blockChainState = block.blockchainState;
-      let updatedBlockchainState = {...blockChainState, coinbaseReceiver};
+      let updatedBlockchainState = {
+        ...block.blockchainState,
+        coinbaseReceiver,
+      };
       let updatedBlock = {...block, blockchainState: updatedBlockchainState};
       updatedBlock;
     | None => block
@@ -211,21 +213,21 @@ module Block = {
                        internalCommand,
                        currentBlock.internalCommands,
                      );
-                     let blockToAdd =
+                     let block =
                        addCoinbaseReceiverIfSome(
                          currentBlock,
                          coinbaseReceiver,
                        );
-                     Some(blockToAdd);
+                     Some(block);
                    | None => None
                    }
                  });
                } else {
                  addCommandIfSome(userCommand, newBlock.userCommands);
                  addCommandIfSome(internalCommand, newBlock.internalCommands);
-                 let blockToAdd =
+                 let block =
                    addCoinbaseReceiverIfSome(newBlock, coinbaseReceiver);
-                 set(blockMap, blockToAdd.id, blockToAdd);
+                 set(blockMap, block.id, block);
                };
              },
              empty,

--- a/frontend/leaderboard/src/UploadLeaderboardData.re
+++ b/frontend/leaderboard/src/UploadLeaderboardData.re
@@ -158,7 +158,7 @@ let computeMemberProfileData = mainData => {
   let mainUserIndex = 2; /* usernames are located in the 3rd column */
   let allTimePoints = 19; /* all time points are located in the 20th column */
   let phasePoints = 13; /* all time points are located in the 14th column */
-  let releasePoints = 36; /* all time points are located in the 37th column */
+  let releasePoints = 37; /* all time points are located in the 38th column */
 
   let allTimeRank = 18; /* all time points are located in the 19th column */
   let phaseRank = 12; /* all time points are located in the 13th column */

--- a/frontend/leaderboard/src/UploadLeaderboardData.re
+++ b/frontend/leaderboard/src/UploadLeaderboardData.re
@@ -162,7 +162,7 @@ let computeMemberProfileData = mainData => {
 
   let allTimeRank = 18; /* all time points are located in the 19th column */
   let phaseRank = 12; /* all time points are located in the 13th column */
-  let releaseRank = 39; /* all time points are located in the 40th column */
+  let releaseRank = 40; /* all time points are located in the 41st column */
 
   let genesisBadge = 4; /* all time points are located in the 17th column */
   let technicalBadge = 5; /* all time points are located in the 17th column */

--- a/frontend/leaderboard/src/UploadLeaderboardData.re
+++ b/frontend/leaderboard/src/UploadLeaderboardData.re
@@ -156,13 +156,13 @@ let getAllValidUsers = (usernameColumn, userData) => {
 
 let computeMemberProfileData = mainData => {
   let mainUserIndex = 2; /* usernames are located in the 3rd column */
-  let allTimePoints = 16; /* all time points are located in the 17th column */
-  let phasePoints = 14; /* all time points are located in the 17th column */
-  let releasePoints = 34; /* all time points are located in the 17th column */
+  let allTimePoints = 19; /* all time points are located in the 20th column */
+  let phasePoints = 13; /* all time points are located in the 14th column */
+  let releasePoints = 36; /* all time points are located in the 37th column */
 
-  let allTimeRank = 15; /* all time points are located in the 17th column */
-  let phaseRank = 12; /* all time points are located in the 17th column */
-  let releaseRank = 36; /* all time points are located in the 17th column */
+  let allTimeRank = 18; /* all time points are located in the 19th column */
+  let phaseRank = 12; /* all time points are located in the 13th column */
+  let releaseRank = 39; /* all time points are located in the 40th column */
 
   let genesisBadge = 4; /* all time points are located in the 17th column */
   let technicalBadge = 5; /* all time points are located in the 17th column */


### PR DESCRIPTION
This PR implements the functionality needed to reward all the points gathered from the pre and post-fork dumps. Additionally adds functionality to give points for the SNARK challenge. 

To get the SNARK challenge working, we had to add parsing for a coinbase receiver in a block. The coinbase receiver property is initialized to `None` as we need to inspect the formed block data instead of the query. To find the coinbase receiver, we look for internal commands that have a type of `Coinbase`. Once we find the PK associated with that receiver, we update the block data and include it.

To give points for SNARK fees, the snark fees in a block must not belong to the coinbase receiver. As long as this requirement is met, we can add snark fees for each public key. 

To view the current results from running this current PR, please visit this spreadsheet that is used as a playground:

https://docs.google.com/spreadsheets/d/1bBVLYSx7WHa53wamDMPBE8KbYwOtN6zf1wvqd4Q7Dis/edit?usp=sharing


Additionally:
Updates the references used in the main tab since new columns were introduced in the spreadsheet.