### PR TITLE
silence curl requests in k8s health probes for less noisy event output

### DIFF
--- a/dockerfiles/scripts/healthcheck-utilities.sh
+++ b/dockerfiles/scripts/healthcheck-utilities.sh
@@ -3,7 +3,7 @@
 #
 function isDaemonSynced() {
     status=$(
-        curl -H "Content-Type:application/json" -d'{ "query": "query { syncStatus } " }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { syncStatus } " }' localhost:3085/graphql | \
             jq '.data.syncStatus'
     )
 
@@ -25,12 +25,12 @@ function isDaemonSynced() {
 #
 function isChainlengthHighestReceived() {
     chainLength=$(
-        curl -H "Content-Type:application/json" -d'{ "query": "query { daemonStatus { blockchainLength } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { blockchainLength } }" }' localhost:3085/graphql | \
             jq '.data.daemonStatus.blockchainLength'
     )
 
     highestReceived=$(
-        curl -H "Content-Type:application/json" -d'{ "query": "query { daemonStatus { highestBlockLengthReceived } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { highestBlockLengthReceived } }" }' localhost:3085/graphql | \
             jq '.data.daemonStatus.highestBlockLengthReceived'
     )
     
@@ -44,7 +44,7 @@ function isChainlengthHighestReceived() {
 function peerCountGreaterThan() {
     peerCountMinThreshold=${1:-2}
     peerCount=$(
-        curl -H "Content-Type:application/json" -d'{ "query": "query { daemonStatus { peers } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { peers } }" }' localhost:3085/graphql | \
             jq '.data.daemonStatus.peers | length'
     )
     
@@ -57,11 +57,11 @@ function peerCountGreaterThan() {
 #
 function ownsFunds() {
     ownedWalletCount=$(
-        curl -H "Content-Type:application/json" -d'{ "query": "query { ownedWallets }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { ownedWallets }" }' localhost:3085/graphql | \
             jq '.data.ownedWallets | length'
     )
     balanceTotal=$(
-        curl -H "Content-Type:application/json" -d'{ "query": "query { ownedWallets { balance { total } } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { ownedWallets { balance { total } } }" }' localhost:3085/graphql | \
             jq '.data.ownedWallets[0].balance.total'
     )
     # remove leading and trailing quotes for integer interpretation
@@ -77,7 +77,7 @@ function ownsFunds() {
 function hasSentUserCommandsGreaterThan() {
     userCmdMinThreshold=${1:-1}
     userCmdSent=$(
-        curl -H "Content-Type:application/json" -d'{ "query": "query { daemonStatus { userCommandsSent } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { userCommandsSent } }" }' localhost:3085/graphql | \
             jq '.data.daemonStatus.userCommandsSent'
     )
     
@@ -90,7 +90,7 @@ function hasSentUserCommandsGreaterThan() {
 #
 function hasSnarkWorker() {
     snarkWorker=$(
-        curl -H "Content-Type:application/json" -d'{ "query": "query { daemonStatus { snarkWorker } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { snarkWorker } }" }' localhost:3085/graphql | \
             jq '.data.daemonStatus.snarkWorker'
     )
     rc=$?
@@ -118,7 +118,7 @@ function isArchiveSynced() {
             -w -c "SELECT height FROM blocks ORDER BY height DESC LIMIT 1"
     )
     highestReceived=$(
-        curl -H "Content-Type:application/json" -d'{ "query": "query { daemonStatus { highestBlockLengthReceived } }" }' localhost:3085/graphql | \
+        curl --silent --show-error --header "Content-Type:application/json" -d'{ "query": "query { daemonStatus { highestBlockLengthReceived } }" }' localhost:3085/graphql | \
             jq '.data.daemonStatus.highestBlockLengthReceived'
     )
     


### PR DESCRIPTION
`curl` download progress is currently displayed in health probe output (like the following) making the probe message more noisy and more difficult to identify/parse. This change silences this progress output only showing errors.

```

Readiness  probe failed: Archive[] is out of sync with local daemon[3847]   % Total    % Received % Xferd  Average Speed   Time    Time     Time   Current                                  Dload  Upload   Total   Spent    Left   Speed    0     0    0     0    0     0      0      0 --:--:-- --:--:--  --:--:--     0 100    68    0    32  100    36   6400   7200 --:--:--  --:--:-- --:--:-- 13600   % Total    % Received % Xferd  Average Speed   Time    Time     Time   Current                                  Dload  Upload   Total   Spent    Left   Speed    0     0    0     0    0     0      0      0 --:--:-- --:--:--  --:--:--     0 100   129    0    61  100    68   6777   7555 --:--:--  --:--:-- --:--:-- 14333 | Unhealthy | Dec 22, 2020, 7:03:16 AM | Dec 22, 2020, 7:09:11 AM | 10 |  
-- | -- | -- | -- | -- | --
```

**Test:** Buildkite CI

**Checklist:**

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: