### PR TITLE
Persist transaction pool

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -993,7 +993,6 @@ Pass one of -peer, -peer-list-file, -seed.|} ;
                ; shutdown_on_disconnect= true
                ; num_threads= snark_worker_parallelism_flag }
              ~snark_coordinator_key:run_snark_coordinator_flag
-             ~snark_pool_disk_location:(conf_dir ^/ "snark_pool")
              ~wallets_disk_location:(conf_dir ^/ "wallets")
              ~persistent_root_location:(conf_dir ^/ "root")
              ~persistent_frontier_location:(conf_dir ^/ "frontier")

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -464,7 +464,6 @@ module T = struct
                      { initial_snark_worker_key= snark_worker_key
                      ; shutdown_on_disconnect= true
                      ; num_threads= None }
-                 ~snark_pool_disk_location:(conf_dir ^/ "snark_pool")
                  ~persistent_root_location:(conf_dir ^/ "root")
                  ~persistent_frontier_location:(conf_dir ^/ "frontier")
                  ~epoch_ledger_location

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -198,7 +198,6 @@ let run_test () : unit Deferred.t =
                        (Public_key.compress largest_account_keypair.public_key)
                  ; shutdown_on_disconnect= true
                  ; num_threads= None }
-             ~snark_pool_disk_location:(temp_conf_dir ^/ "snark_pool")
              ~wallets_disk_location:(temp_conf_dir ^/ "wallets")
              ~persistent_root_location:(temp_conf_dir ^/ "root")
              ~persistent_frontier_location:(temp_conf_dir ^/ "frontier")

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -32,7 +32,6 @@ type t =
   ; initial_protocol_version: Protocol_version.t
         (* Option.t instead of option, so that the derived `make' requires an argument *)
   ; proposed_protocol_version_opt: Protocol_version.t Option.t
-  ; snark_pool_disk_location: string
   ; wallets_disk_location: string
   ; persistent_root_location: string
   ; persistent_frontier_location: string

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1097,6 +1097,7 @@ let create ?wallets (config : Config.t) =
               ~trust_system:config.trust_system
               ~pool_max_size:
                 config.precomputed_values.genesis_constants.txpool_max_size
+              ~disk_location:Core.(config.conf_dir ^/ "transaction_pool")
           in
           let transaction_pool =
             Network_pool.Transaction_pool.create ~config:txn_pool_config
@@ -1306,7 +1307,7 @@ let create ?wallets (config : Config.t) =
           let snark_pool_config =
             Network_pool.Snark_pool.Resource_pool.make_config ~verifier
               ~trust_system:config.trust_system
-              ~disk_location:config.snark_pool_disk_location
+              ~disk_location:Core.(config.conf_dir ^/ "snark_pool")
           in
           let%bind snark_pool =
             Network_pool.Snark_pool.load ~config:snark_pool_config

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -302,6 +302,7 @@ module type Transaction_resource_pool_intf = sig
   val make_config :
        trust_system:Trust_system.t
     -> pool_max_size:int
+    -> disk_location:string
     -> verifier:Verifier.t
     -> Config.t
 

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -652,7 +652,7 @@ let%test_module "random set test" =
 
     let config verifier =
       Mock_snark_pool.Resource_pool.make_config ~verifier ~trust_system
-        ~disk_location:"/tmp/snark-pool"
+        ~disk_location:"/tmp/snark_pool"
 
     let gen ?length () =
       let open Quickcheck.Generator.Let_syntax in

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -25,7 +25,7 @@ let%test_module "network pool test" =
 
     let config verifier =
       Mock_snark_pool.Resource_pool.make_config ~verifier ~trust_system
-        ~disk_location:"/tmp/snark-pool"
+        ~disk_location:"/tmp/snark_pool"
 
     let%test_unit "Work that gets fed into apply_and_broadcast will be \
                    received in the pool's reader" =

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -116,7 +116,7 @@ let%test_module "transaction_status" =
             ~conf_dir:None
         in
         Transaction_pool.Resource_pool.make_config ~trust_system ~pool_max_size
-          ~verifier
+          ~verifier ~disk_location:"/tmp/transaction_pool"
       in
       let transaction_pool =
         Transaction_pool.create ~config


### PR DESCRIPTION
This PR makes it so that we serialize the locally generated transactions that have yet to appear in a block, and then rebroadcast them periodically when we start up.