### PR TITLE
Add archive-precomputed-blocks command to CLI and GraphQL

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -3059,7 +3059,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "Null",
+                  "name": "Applied",
                   "ofType": null
                 }
               },

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -99,6 +99,43 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "PrecomputedBlock",
+          "description": "Block encoded in precomputed block format",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Applied",
+          "description": null,
+          "fields": [
+            {
+              "name": "applied",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "NetworkPeer",
           "description": "Network identifiers for another protocol participant",
@@ -2993,6 +3030,37 @@
                       "ofType": null
                     }
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "archivePrecomputedBlock",
+              "description": null,
+              "args": [
+                {
+                  "name": "block",
+                  "description": "Block encoded in precomputed block format",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "PrecomputedBlock",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Null",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -890,33 +890,43 @@ module Block = struct
     else return ()
 end
 
+let add_block_aux ~add_block ~delete_older_than (module Conn : CONNECTION)
+    block =
+  let%bind res =
+    let open Deferred.Result.Let_syntax in
+    let%bind () = Conn.start () in
+    let%bind _ = add_block (module Conn : CONNECTION) block in
+    match delete_older_than with
+    | Some num_blocks ->
+        Block.delete_if_older_than ~num_blocks (module Conn)
+    | None ->
+        return ()
+  in
+  let%map () =
+    match res with
+    | Error _ ->
+        Conn.rollback () >>| ignore
+    | Ok _ ->
+        Conn.commit () >>| ignore
+  in
+  res
+
 let run (module Conn : CONNECTION) reader ~constraint_constants ~logger
     ~delete_older_than =
   Strict_pipe.Reader.iter reader ~f:(function
     | Diff.Transition_frontier (Breadcrumb_added {block; _}) -> (
-        match%bind
-          let open Deferred.Result.Let_syntax in
-          let%bind () = Conn.start () in
-          let%bind _ =
-            Block.add_if_doesn't_exist ~constraint_constants
-              (module Conn)
-              block
-          in
-          match delete_older_than with
-          | Some num_blocks ->
-              Block.delete_if_older_than ~num_blocks (module Conn)
-          | None ->
-              return ()
+        let add_block = Block.add_if_doesn't_exist ~constraint_constants in
+        match%map
+          add_block_aux ~delete_older_than ~add_block (module Conn) block
         with
         | Error e ->
             [%log warn]
               ~metadata:
                 [ ("block", With_hash.hash block |> State_hash.to_yojson)
                 ; ("error", `String (Caqti_error.show e)) ]
-              "Failed to archive block: $block, see $error" ;
-            Conn.rollback () >>| ignore
-        | Ok _ ->
-            Conn.commit () >>| ignore )
+              "Failed to archive block: $block, see $error"
+        | Ok () ->
+            () )
     | Transition_frontier _ ->
         Deferred.return ()
     | Transaction_pool {added; removed= _} ->
@@ -930,9 +940,16 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
     Async.Tcp.Where_to_listen.bind_to All_addresses (On_port server_port)
   in
   let reader, writer = Strict_pipe.create ~name:"archive" Synchronous in
+  let precomputed_block_reader, precomputed_block_writer =
+    Strict_pipe.create ~name:"precomputed_archive_block" Synchronous
+  in
   let implementations =
     [ Async.Rpc.Rpc.implement Archive_rpc.t (fun () archive_diff ->
-          Strict_pipe.Writer.write writer archive_diff ) ]
+          Strict_pipe.Writer.write writer archive_diff )
+    ; Async.Rpc.Rpc.implement Archive_rpc.precomputed_block
+        (fun () precomputed_block ->
+          Strict_pipe.Writer.write precomputed_block_writer precomputed_block
+      ) ]
   in
   match%bind Caqti_async.connect postgres_address with
   | Error e ->
@@ -942,6 +959,24 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
       Deferred.unit
   | Ok conn ->
       run ~constraint_constants conn reader ~logger ~delete_older_than
+      |> don't_wait_for ;
+      Strict_pipe.Reader.iter precomputed_block_reader
+        ~f:(fun precomputed_block ->
+          match%map
+            add_block_aux
+              ~add_block:(Block.add_from_precomputed ~constraint_constants)
+              ~delete_older_than conn precomputed_block
+          with
+          | Error e ->
+              [%log warn]
+                "Precomputed block $block could not be archived: $error"
+                ~metadata:
+                  [ ( "block"
+                    , Protocol_state.hash precomputed_block.protocol_state
+                      |> State_hash.to_yojson )
+                  ; ("error", `String (Caqti_error.show e)) ]
+          | Ok () ->
+              () )
       |> don't_wait_for ;
       Deferred.ignore
       @@ Tcp.Server.create

--- a/src/app/archive/archive_lib/rpc.ml
+++ b/src/app/archive/archive_lib/rpc.ml
@@ -4,3 +4,12 @@ open Async
 let t : (Diff.Stable.Latest.t, Unit.Stable.V1.t) Rpc.Rpc.t =
   Rpc.Rpc.create ~name:"Send_archive_diff" ~version:0
     ~bin_query:Diff.Stable.Latest.bin_t ~bin_response:Unit.Stable.V1.bin_t
+
+let precomputed_block :
+    ( Coda_transition.External_transition.Precomputed_block.Stable.Latest.t
+    , Unit.Stable.V1.t )
+    Rpc.Rpc.t =
+  Rpc.Rpc.create ~name:"Send_precomputed_block" ~version:0
+    ~bin_query:
+      Coda_transition.External_transition.Precomputed_block.Stable.Latest.bin_t
+    ~bin_response:Unit.Stable.V1.bin_t

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1692,6 +1692,75 @@ let object_lifetime_statistics =
              printf "Failed to get object lifetime statistics: %s\n%!"
                (Error.to_string_hum err) ))
 
+let archive_precomputed_blocks =
+  let archive_process_location = Cli_lib.Flag.Host_and_port.Daemon.archive in
+  let files =
+    Command.Param.anon
+      Command.Anons.(sequence ("FILES" %: Command.Param.string))
+  in
+  Command.async
+    ~summary:
+      "Archive a precomputed block from a file.\n\n\
+       If an archive address is given, this process will communicate with the \
+       archive node directly; otherwise it will communicate through the \
+       daemon over the rest-server"
+    (Cli_lib.Background_daemon.graphql_init
+       (Command.Param.both archive_process_location files)
+       ~f:(fun graphql_endpoint (archive_process_location, files) ->
+         let send_block block =
+           match archive_process_location with
+           | Some archive_process_location ->
+               (* Connect directly to the archive node. *)
+               Mina_lib.Archive_client.dispatch_precomputed_block
+                 archive_process_location block
+           | None ->
+               (* Send the requests over GraphQL. *)
+               let block =
+                 Coda_transition.External_transition.Precomputed_block
+                 .to_yojson block
+                 |> Yojson.Safe.to_basic
+               in
+               let%map _res =
+                 (* Don't catch this error: [query_exn] already handles
+                    printing etc.
+                 *)
+                 Graphql_client.query_exn
+                   (Graphql_queries.Archive_precomputed_block.make ~block ())
+                   graphql_endpoint
+               in
+               Ok ()
+         in
+         Deferred.List.iter files ~f:(fun path ->
+             match%map
+               let open Deferred.Or_error.Let_syntax in
+               let%bind precomputed_block_json =
+                 Or_error.try_with (fun () ->
+                     In_channel.with_file path ~f:(fun in_channel ->
+                         Yojson.Safe.from_channel in_channel ) )
+                 |> Result.map_error ~f:(fun err ->
+                        Error.tag_arg err "Could not parse JSON from file" path
+                          String.sexp_of_t )
+                 |> Deferred.return
+               in
+               let%bind precomputed_block =
+                 Coda_transition.External_transition.Precomputed_block
+                 .of_yojson precomputed_block_json
+                 |> Result.map_error ~f:(fun err ->
+                        Error.tag_arg (Error.of_string err)
+                          "Could not parse JSON as a precomputed block from \
+                           file"
+                          path String.sexp_of_t )
+                 |> Deferred.return
+               in
+               send_block precomputed_block
+             with
+             | Ok () ->
+                 Format.printf "Sent block to archive node from %s@." path
+             | Error err ->
+                 Format.eprintf
+                   "Failed to send block to archive node from %s. Error:@.%s@."
+                   path (Error.to_string_hum err) ) ))
+
 module Visualization = struct
   let create_command (type rpc_response) ~name ~f
       (rpc : (string, rpc_response) Rpc.Rpc.t) =
@@ -1802,4 +1871,5 @@ let advanced =
     ; ("time-offset", get_time_offset_graphql)
     ; ("get-peers", get_peers_graphql)
     ; ("add-peers", add_peers_graphql)
-    ; ("object-lifetime-statistics", object_lifetime_statistics) ]
+    ; ("object-lifetime-statistics", object_lifetime_statistics)
+    ; ("archive-precomputed-blocks", archive_precomputed_blocks) ]

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -322,3 +322,11 @@ mutation ($peers: [NetworkPeer!]!) {
   }
 }
 |}]
+
+module Archive_precomputed_block =
+[%graphql
+{|
+mutation ($block: PrecomputedBlock!) {
+  archivePrecomputedBlock(block: $block)
+}
+|}]

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -327,6 +327,8 @@ module Archive_precomputed_block =
 [%graphql
 {|
 mutation ($block: PrecomputedBlock!) {
-  archivePrecomputedBlock(block: $block)
+  archivePrecomputedBlock(block: $block) {
+      applied
+  }
 }
 |}]

--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -157,14 +157,36 @@ module Precomputed_block = struct
           Proof.of_yojson json
   end
 
-  type t =
-    { scheduled_time: Block_time.t
-    ; protocol_state: Protocol_state.value
-    ; protocol_state_proof: Proof.t
-    ; staged_ledger_diff: Staged_ledger_diff.t
-    ; delta_transition_chain_proof:
-        Frozen_ledger_hash.t * Frozen_ledger_hash.t list }
-  [@@deriving sexp, yojson]
+  module T = struct
+    type t =
+      { scheduled_time: Block_time.t
+      ; protocol_state: Protocol_state.value
+      ; protocol_state_proof: Proof.t
+      ; staged_ledger_diff: Staged_ledger_diff.t
+      ; delta_transition_chain_proof:
+          Frozen_ledger_hash.t * Frozen_ledger_hash.t list }
+    [@@deriving sexp, yojson]
+  end
+
+  include T
+
+  [%%versioned
+  module Stable = struct
+    [@@@no_toplevel_latest_type]
+
+    module V1 = struct
+      type t = T.t =
+        { scheduled_time: Block_time.Stable.V1.t
+        ; protocol_state: Protocol_state.Value.Stable.V1.t
+        ; protocol_state_proof: Mina_base.Proof.Stable.V1.t
+        ; staged_ledger_diff: Staged_ledger_diff.Stable.V1.t
+        ; delta_transition_chain_proof:
+            Frozen_ledger_hash.Stable.V1.t
+            * Frozen_ledger_hash.Stable.V1.t list }
+
+      let to_latest = Fn.id
+    end
+  end]
 
   let of_external_transition ~scheduled_time (t : external_transition) =
     { scheduled_time

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -92,6 +92,24 @@ module type S = sig
           Frozen_ledger_hash.t * Frozen_ledger_hash.t list }
     [@@deriving sexp, yojson]
 
+    [%%versioned:
+    module Stable : sig
+      [@@@no_toplevel_latest_type]
+
+      module V1 : sig
+        type nonrec t = t =
+          { scheduled_time: Block_time.Stable.V1.t
+          ; protocol_state: Protocol_state.Value.Stable.V1.t
+          ; protocol_state_proof: Mina_base.Proof.Stable.V1.t
+          ; staged_ledger_diff: Staged_ledger_diff.Stable.V1.t
+          ; delta_transition_chain_proof:
+              Frozen_ledger_hash.Stable.V1.t
+              * Frozen_ledger_hash.Stable.V1.t list }
+
+        val to_latest : t -> t
+      end
+    end]
+
     val of_external_transition :
       scheduled_time:Block_time.Time.t -> external_transition -> t
   end

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -5,6 +5,30 @@ open Mina_base
 open Signature_lib
 open Currency
 
+(** Convert a GraphQL constant to the equivalent json representation.
+    We can't coerce this directly because of the presence of the [`Enum]
+    constructor, so we have to recurse over the structure replacing all of the
+    [`Enum]s with [`String]s.
+*)
+let rec to_yojson (json : Graphql_parser.const_value) : Yojson.Safe.t =
+  match json with
+  | `Assoc fields ->
+      `Assoc (List.map fields ~f:(fun (name, json) -> (name, to_yojson json)))
+  | `Bool b ->
+      `Bool b
+  | `Enum s ->
+      `String s
+  | `Float f ->
+      `Float f
+  | `Int i ->
+      `Int i
+  | `List l ->
+      `List (List.map ~f:to_yojson l)
+  | `Null ->
+      `Null
+  | `String s ->
+      `String s
+
 let result_of_exn f v ~error = try Ok (f v) with _ -> Error error
 
 let result_of_or_error ?error v =
@@ -1498,6 +1522,13 @@ module Types = struct
                 Error "Invalid format for token."
           with _ -> Error "Invalid format for token." )
 
+    let precomputed_block =
+      scalar "PrecomputedBlock"
+        ~doc:"Block encoded in precomputed block format" ~coerce:(fun json ->
+          let json = to_yojson json in
+          Coda_transition.External_transition.Precomputed_block.of_yojson json
+      )
+
     module type Numeric_type = sig
       type t
 
@@ -2362,6 +2393,30 @@ module Mutations = struct
         in
         List.map ~f:Network_peer.Peer.to_display peers )
 
+  let archive_precomputed_block =
+    io_field "archivePrecomputedBlock"
+      ~args:
+        Arg.
+          [ arg "block" ~doc:"Block encoded in precomputed block format"
+              ~typ:(non_null @@ Types.Input.precomputed_block) ]
+      ~typ:(scalar "Null" ~coerce:(fun () -> `Null))
+      ~resolve:(fun {ctx= coda; _} () block ->
+        let open Deferred.Result.Let_syntax in
+        let%bind archive_location =
+          match (Mina_lib.config coda).archive_process_location with
+          | Some archive_location ->
+              return archive_location
+          | None ->
+              Deferred.Result.fail
+                "Could not find an archive process to connect to"
+        in
+        let%map () =
+          Mina_lib.Archive_client.dispatch_precomputed_block archive_location
+            block
+          |> Deferred.Result.map_error ~f:Error.to_string_hum
+        in
+        None )
+
   let commands =
     [ add_wallet
     ; create_account
@@ -2384,7 +2439,8 @@ module Mutations = struct
     ; set_snark_worker
     ; set_snark_work_fee
     ; set_connection_gating_config
-    ; add_peer ]
+    ; add_peer
+    ; archive_precomputed_block ]
 end
 
 module Queries = struct

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2399,7 +2399,12 @@ module Mutations = struct
         Arg.
           [ arg "block" ~doc:"Block encoded in precomputed block format"
               ~typ:(non_null @@ Types.Input.precomputed_block) ]
-      ~typ:(scalar "Null" ~coerce:(fun () -> `Null))
+      ~typ:
+        (non_null
+           (obj "Applied" ~fields:(fun _ ->
+                [ field "applied" ~typ:(non_null bool)
+                    ~args:Arg.[]
+                    ~resolve:(fun _ _ -> true) ] )))
       ~resolve:(fun {ctx= coda; _} () block ->
         let open Deferred.Result.Let_syntax in
         let%bind archive_location =
@@ -2415,7 +2420,7 @@ module Mutations = struct
             block
           |> Deferred.Result.map_error ~f:Error.to_string_hum
         in
-        None )
+        () )
 
   let commands =
     [ add_wallet

--- a/src/lib/mina_lib/archive_client.ml
+++ b/src/lib/mina_lib/archive_client.ml
@@ -19,6 +19,24 @@ let dispatch (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
            , ("daemon-argument", archive_location.name) )
            [%sexp_of: (string * Host_and_port.t) * (string * string)])
 
+let dispatch_precomputed_block
+    (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
+    precomputed_block =
+  match%map
+    Daemon_rpcs.Client.dispatch Archive_lib.Rpc.precomputed_block
+      precomputed_block archive_location.value
+  with
+  | Ok () ->
+      Ok ()
+  | Error e ->
+      Error
+        (Error.tag_arg e
+           "Could not send data to archive process. It may not be running, \
+            please check the daemon-argument"
+           ( ("host_and_port", archive_location.value)
+           , ("daemon-argument", archive_location.name) )
+           [%sexp_of: (string * Host_and_port.t) * (string * string)])
+
 let transfer ~logger ~archive_location
     (breadcrumb_reader :
       Transition_frontier.Extensions.New_breadcrumbs.view

--- a/src/lib/mina_lib/archive_client.mli
+++ b/src/lib/mina_lib/archive_client.mli
@@ -1,6 +1,11 @@
 open Core
 open Pipe_lib
 
+val dispatch_precomputed_block :
+     Host_and_port.t Cli_lib.Flag.Types.with_name
+  -> Coda_transition.External_transition.Precomputed_block.t
+  -> unit Async.Deferred.Or_error.t
+
 val run :
      logger:Logger.t
   -> frontier_broadcast_pipe:Transition_frontier.t option

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -9,6 +9,7 @@ open Signature_lib
 open O1trace
 open Otp_lib
 open Network_peer
+module Archive_client = Archive_client
 module Config = Config
 module Conf_dir = Conf_dir
 module Subscriptions = Coda_subscriptions

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -5,6 +5,7 @@ open Coda_state
 open Coda_transition
 open Pipe_lib
 open Signature_lib
+module Archive_client = Archive_client
 module Config = Config
 module Conf_dir = Conf_dir
 module Subscriptions = Coda_subscriptions


### PR DESCRIPTION
This PR
* adds a `Send_precomputed_block` RPC to the archive process
* exposes an `archivePrecomputedBlock` command to GraphQL
  - the argument type takes the precomputed block in JSON format, but its particular structure is not exposed to the GraphQL schema
  - the return type is `{applied: bool}`. Using a more restricted return type (e.g. an empty object or a scalar) causes the CLI to silently swallow any errors
  - this pipes the data to the archive node associated with the daemon, failing if there is no such process
* adds a `advanced archive-precomputed-blocks` command to the CLI
  - this provides the option of sending blocks to the archive node via a running daemon, or to the daemon directly using the given port/address
  - the anonymous arguments are filenames, where we expect 1 JSON-encoded block per file

CLI help output:
```
$ _build/default/src/app/cli/src/coda
.exe advanced archive-precomputed-blocks -help
Archive a precomputed block from a file.

If an archive address is given, this process will communicate with the archive node directly; otherwise it will communicate through the daemon over the rest-server

  coda.exe advanced archive-precomputed-blocks [FILES ...]

=== flags ===

  [-archive-address HOST:PORT/LOCALHOST-PORT]  Daemon to archive process
                                               communication. If HOST is
                                               omitted, then localhost is
                                               assumed to be HOST. (examples:
                                               3086, 154.97.53.97:3086)
  [-rest-server URI/LOCALHOST-PORT]            graphql rest server for daemon
                                               interaction (examples: 3085 or
                                               http://localhost:3085/graphql,
                                               /dns4/peer1-rising-phoenix.o1test.net:3085/graphql)
                                               (default: 3085 or
                                               http://localhost:3085/graphql)
  [-help]                                      print this help text and exit
                                               (alias: -?)
```

Example run:
```
$ _build/default/src/app/cli/src/coda
.exe advanced archive-precomputed-blocks -rest-server 8080 mina-blocks/*.json
Sent block to archive node from mina-blocks/testworld-3NK2vHMVX2FieNsTJymQoufi4aLYh7cSqPSASQY4PEpHWBGvWr9m.json
Sent block to archive node from mina-blocks/testworld-3NK3dPHzUEnwHCdhG7WFPQ4UELwX6AyPzReGbHV9LMECkAYyELHk.json
Sent block to archive node from mina-blocks/testworld-3NK3G5ePtVn3xfdfjNQFJEUyZActRr7YeFj3nedWq2QiMirbc3zN.json
Sent block to archive node from mina-blocks/testworld-3NK3Utbix8sqmmEiufqnVau5WtJN1r3DeUufSXDw7mGiNEQiv94X.json
Sent block to archive node from mina-blocks/testworld-3NK3vSYCkKpx6Rn4b4h8T1v39CNRPQbATRkPSAipPvGHRm9qr9Je.json
...
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #7176