### PR TITLE
pass daemon.json to the archive process

### DIFF
--- a/helm/archive-node/Chart.yaml
+++ b/helm/archive-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: archive-node
 description: A Helm chart for Mina Protocol's archive node
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: 1.16.0
 dependencies:
   - name: postgresql

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -99,9 +99,22 @@ spec:
       # Archive Process
       - name: archive
         image: {{ .Values.archive.image }}
-        args: [ "coda-archive run -postgres-uri {{ tpl .Values.archive.postgresUri . }} -server-port {{ .Values.archive.ports.server }}" ]
+        args: [ 
+          "coda-archive",
+          "run",
+          "-postgres-uri", "{{ tpl .Values.archive.postgresUri . }}",
+          {{- if .Values.coda.runtimeConfig }}
+          "-config-file", "/config/daemon.json",
+          {{- end }}
+          "-server-port", "{{ .Values.archive.ports.server }}"
+        ]
         env:
         imagePullPolicy: Always
+        {{- if .Values.coda.runtimeConfig }}
+        volumeMounts:
+        - name: daemon-config
+          mountPath: "/config/"
+        {{- end }}
         ports:
         - name: archive-port
           protocol: TCP


### PR DESCRIPTION
Based on https://github.com/MinaProtocol/coda-automation/pull/544, a new flag `-config-file` is being introduced in https://github.com/MinaProtocol/mina/pull/7125

**Test:** Buildkite CI

**Checklist:**

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: