### PR TITLE
Use fasttrack merging: merge.strict=false instead of smart for mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,7 @@ pull_request_rules:
       actions:
           merge:
               method: merge
-              strict: smart
+              strict: false
           delete_head_branch: {}
     - name: automatically merge approved PRs into develop with the ready-to-merge-into-develop label
       conditions:
@@ -28,7 +28,7 @@ pull_request_rules:
       actions:
           merge:
               method: merge
-              strict: smart
+              strict: false
           delete_head_branch: {}
     - name: automatically merge approved PRs into develop-until-4.1-hardfork with the ready-to-merge-into-develop label
       conditions:

--- a/.mergify.yml.jinja
+++ b/.mergify.yml.jinja
@@ -9,7 +9,7 @@ pull_request_rules:
       actions:
           merge:
               method: merge
-              strict: smart
+              strict: false
           delete_head_branch: {}
     - name: automatically merge approved PRs into develop with the ready-to-merge-into-develop label
       conditions:
@@ -22,7 +22,7 @@ pull_request_rules:
       actions:
           merge:
               method: merge
-              strict: smart
+              strict: false
           delete_head_branch: {}
     - name: automatically merge approved PRs into develop-until-4.1-hardfork with the ready-to-merge-into-develop label
       conditions:


### PR DESCRIPTION
This allows mergify to take advantage of the new settings on develop; without this it still attempts to bring each branch up-to-date before merging it.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: