### PR TITLE
update user-agent metrics port assignment (defaults to 8000) and AGENT_SEND_EVERY_MINS

### DIFF
--- a/helm/block-producer/templates/_healthchecks.tpl
+++ b/helm/block-producer/templates/_healthchecks.tpl
@@ -65,7 +65,7 @@ readinessProbe:
     command: [
       "/bin/bash",
       "-c",
-      "source /healthcheck/utilities.sh && isDaemonSynced && peerCountGreaterThan 0"
+      "source /healthcheck/utilities.sh && peerCountGreaterThan 0 && hasSentUserCommandsGreaterThan 0"
     ]
 {{- include "healthcheck.common.settings" . | indent 2 }}
 {{- end }}

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -92,8 +92,8 @@ spec:
             value: {{ $.Values.userAgent.txBatchSize | quote }}
           {{ end -}}
           {{- if ne $.Values.userAgent.sendEveryMins "" -}}
-          - name: AGENT_SEND_EVERY_MINUTES
-            value: "1"
+          - name: AGENT_SEND_EVERY_MINS
+            value: {{ $.Values.userAgent.sendEveryMins }}
           {{ end -}}
           - name: CODA_PUBLIC_KEY
             valueFrom:
@@ -284,5 +284,8 @@ spec:
   - name: tcp-p2p
     port: {{ $config.externalPort }}
     targetPort: external-port
+  - name: tcp-metrics
+    port: {{ $.Values.userAgent.ports.metrics }}
+    targetPort: metrics-port
 ---
 {{ end }}

--- a/helm/block-producer/values.yaml
+++ b/helm/block-producer/values.yaml
@@ -15,7 +15,7 @@ coda:
     p2p: "10909"
 
 userAgent:
-  image: ""
+  image: "codaprotocol/coda-user-agent:0.1.7"
   minFee: ""
   maxFee: ""
   minTx: ""
@@ -23,7 +23,7 @@ userAgent:
   txBatchSize: ""
   sendEveryMins: ""
   ports:
-    metrics: 10000
+    metrics: 8000
 
 bots:
   image: ""


### PR DESCRIPTION
Fix agent transaction send frequency EnvVar name (MINUTES => MINS) and update user-agent's metrics listen on port to 8000 (set by default and currently not overridden within Helm).

Also update Helm chart user-agent default docker image version to latest to catch addition of healthcheck utilities.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
 