### PR TITLE
[Trivial] Correct 'prover successfully stopped' log message from verifier

### DIFF
--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -299,7 +299,7 @@ let create ~logger ~proof_level ~pids ~conf_dir : t Deferred.t =
         in
         let new_worker =
           let%bind res = Process.wait process in
-          [%log info] "prover successfully stopped"
+          [%log info] "verifier successfully stopped"
             ~metadata:
               [ ("verifier_pid", `Int (Process.pid process |> Pid.to_int))
               ; ("exit_status", `String (Unix.Exit_or_signal.to_string_hum res))


### PR DESCRIPTION
This log message is misleading, caused some confusion.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
