### PR TITLE
Pause verification while proving

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -497,7 +497,8 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                                   ~next_state:protocol_state
                                   internal_transition pending_coinbase_witness
                               in
-                              Ivar.fill done_proving () ; res )
+                              Ivar.fill_if_empty done_proving () ;
+                              res )
                           |> Deferred.Result.map_error ~f:(fun err ->
                                  `Prover_error
                                    ( err
@@ -626,6 +627,7 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                         return ()
                   in
                   let%bind res = emit_breadcrumb () in
+                  Ivar.fill_if_empty done_proving () ;
                   handle_block_production_errors ~logger
                     ~previous_protocol_state ~protocol_state res) )
       in

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -13,6 +13,8 @@ let create ~logger:_ ~proof_level ~pids:_ ~conf_dir:_ =
   | Check | None ->
       Deferred.return ()
 
+let wait_for_proving _ = ()
+
 let verify_blockchain_snarks _ _ = Deferred.Or_error.return true
 
 let verify_commands _ (cs : User_command.Verifiable.t list) :

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -7,6 +7,8 @@ module Base = struct
 
     type ledger_proof
 
+    val wait_for_proving : unit Ivar.t -> unit
+
     val verify_commands :
          t
       -> Mina_base.User_command.Verifiable.t list


### PR DESCRIPTION
This PR pauses verification while a block proof is being generated.

This is implemented more simply than originally proposed:
* Verification is paused just before the block contents are generated, to give some time for active verifications to finish.
  - The proposal was to profile the verification time and pause that much before block production. This resulted in quite a lot of additional brittle tracking logic.
  - Behaviour should still be improved for any cases where we would have started a verification while proving
* This doesn't add a limit to verification batch sizes
  - This already exists as the `MAX_VERIFIER_BATCH_SIZE` environment variable.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #7072