### PR TITLE
update isDaemonSynced check to report 0/success on catch-up, connecting or bootstrap status

### DIFF
--- a/dockerfiles/scripts/healthcheck-utilities.sh
+++ b/dockerfiles/scripts/healthcheck-utilities.sh
@@ -8,15 +8,27 @@ function isDaemonSynced() {
     )
 
     case ${status} in
+      \"BOOTSTRAP\")
+        ;&
+      \"CATCHUP\")
+        ;&
+      \"CONNECTING\")
+        ;&
       \"SYNCED\")
         return 0
         ;;
       *)
-        now=$(date +%s)
-        timestamp=$(grep 'timestamp' /root/daemon.json | awk '{print $2}' | sed -e s/\"//g)
-        timestamp_second=$(date -d ${timestamp} +%s)
-        [[ $now -le $timestamp_seconds ]] && return 0 # special case to claim synced before the genesis timestamp
-        echo "Daemon is out of sync with status: ${status}" && return 1
+        DAEMON_CONFIG="/root/daemon.json"
+        if [ -f "$DAEMON_CONFIG" ]; then
+            now=$(date +%s)
+            timestamp=$(grep 'timestamp' ${DAEMON_CONFIG} | awk '{print $2}' | sed -e s/\"//g)
+            timestamp_second=$(date -d ${timestamp} +%s)
+
+            [[ $now -le $timestamp_seconds ]] && return 0 # special case to claim synced before the genesis timestamp
+        fi
+        echo "Daemon is out of sync with status: ${status}"
+
+        return 1
     esac
 }
 


### PR DESCRIPTION
The added states are technically healthy behaviors of a mina daemon so only report unhealthy when otherwise. Also only execute daemon config timestamp check if config exists at root.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
