### PR TITLE
Re-render circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ jobs:
 
             - run:
                   name: Update branch protection rule from test configuration
-                  command: ./scripts/test.py required-status >required_status && cat required_status && ./scripts/update_branch_rule.py required_status
+                  command: ./scripts/test.py required-status >required_status && cat required_status && ./scripts/update_branch_rule.py required_status ${CIRCLE_BRANCH}
 
     run-leaderboard:
         docker:
@@ -1196,7 +1196,11 @@ workflows:
             - update-branch-protection:
                 filters:
                   branches:
-                    only: develop
+                    only:
+                    - develop
+                    - master
+                    - develop-until-4.1-hardfork
+                    - develop-until-adversarial
             - tracetool
             - test-archive
             - build-archive


### PR DESCRIPTION
The CircleCI template was changed but the actual config hasn't been re-rendered.

Landing this without review; config changes have been reviewed.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: