### PR TITLE
Change some archive lib user command types to int64

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -489,11 +489,11 @@ WITH RECURSIVE chain AS (
           ; fee_payer= User_commands.Extras.fee_payer extras
           ; source= User_commands.Extras.source extras
           ; receiver= User_commands.Extras.receiver extras
-          ; fee_token= Unsigned.UInt64.of_int uc.fee_token
-          ; token= Unsigned.UInt64.of_int uc.token
+          ; fee_token= Unsigned.UInt64.of_int64 uc.fee_token
+          ; token= Unsigned.UInt64.of_int64 uc.token
           ; nonce= Unsigned.UInt32.of_int uc.nonce
-          ; amount= Option.map ~f:Unsigned.UInt64.of_int uc.amount
-          ; fee= Unsigned.UInt64.of_int uc.fee
+          ; amount= Option.map ~f:Unsigned.UInt64.of_int64 uc.amount
+          ; fee= Unsigned.UInt64.of_int64 uc.fee
           ; hash= uc.hash
           ; failure_status= Some failure_status } )
     in


### PR DESCRIPTION
In `Archive_lib.Processor.User_command.t`, the types for tokens, amount, and fee were given as an OCaml `int`, which is a 63-bit signed value. Those types are used to populate the archive db.

The values are derived from `Token_id.t`, `Amount.t`, and `Fee.t` which are unsigned 64-bit values, so there's a potential data loss (or exception raised) when converting to `int`.

We can squeeze out one more bit by using the `int64` type, which is a signed type. The columns in Postgresql have type `bigint`, which is a 64-bit signed type. So once we have an `int64` value, there's no data loss when saving to the database.

If we wanted to guarantee no data loss for very big numbers, we'd have to change the Postgresql type.

The change here is a strict improvement, though.

Tested by using the Rosetta `start.sh` script. The Rosetta code needed some tweaks with this change.

Partially addresses the concerns of #5419.
