### PR TITLE
int yojson coding for nonces

### DIFF
--- a/src/lib/coda_numbers/account_nonce.ml
+++ b/src/lib/coda_numbers/account_nonce.ml
@@ -2,5 +2,7 @@ module T = Nat.Make32 ()
 
 include T
 
-(* OCaml int is 63-bits, so codings are lossless *)
-include Codable.Make_of_int (T)
+(* while we could use an int encoding for yojson (an OCaml int is 63-bits)
+   we've committed to a string encoding
+*)
+include Codable.Make_of_string (T)

--- a/src/lib/coda_numbers/account_nonce.ml
+++ b/src/lib/coda_numbers/account_nonce.ml
@@ -2,5 +2,5 @@ module T = Nat.Make32 ()
 
 include T
 
-(* Needs to be string not int since we use unsigned uint32 *)
-include Codable.Make_of_string (T)
+(* OCaml int is 63-bits, so codings are lossless *)
+include Codable.Make_of_int (T)


### PR DESCRIPTION
Use `int` Yojson coding for nonces, instead of `string`, which is slower.