### PR TITLE
Catch errors when the ledger is full

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -195,7 +195,9 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
             , is_new_stack
             , pending_coinbase_update )
       | Error (Staged_ledger.Staged_ledger_error.Unexpected e) ->
-          raise (Error.to_exn e)
+          [%log error] "Failed to apply the diff: $error"
+            ~metadata:[("error", Error_json.error_to_yojson e)] ;
+          None
       | Error e ->
           ( match diff with
           | Ok diff ->

--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -143,9 +143,6 @@ module Make_base (Inputs : Inputs_intf) :
 
     let close (T ((module Base), t)) = Base.close t
 
-    let get_or_create_account_exn (T ((module Base), t)) =
-      Base.get_or_create_account_exn t
-
     let get_or_create_account (T ((module Base), t)) =
       Base.get_or_create_account t
 

--- a/src/lib/merkle_ledger/base_ledger_intf.ml
+++ b/src/lib/merkle_ledger/base_ledger_intf.ml
@@ -95,11 +95,9 @@ module type S = sig
 
   val location_of_account : t -> account_id -> Location.t option
 
+  (** This may return an error if the ledger is full. *)
   val get_or_create_account :
     t -> account_id -> account -> ([`Added | `Existed] * Location.t) Or_error.t
-
-  val get_or_create_account_exn :
-    t -> account_id -> account -> [`Added | `Existed] * Location.t
 
   (** the ledger should not be used after calling [close] *)
   val close : t -> unit

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -598,11 +598,6 @@ module Make (Inputs : Inputs_intf) :
     | Ok location ->
         Ok (`Existed, location)
 
-  let get_or_create_account_exn mdb account_id account =
-    get_or_create_account mdb account_id account
-    |> Result.map_error ~f:(fun err -> raise (Error.to_exn err))
-    |> Result.ok_exn
-
   let num_accounts t =
     match Account_location.last_location_address t with
     | None ->

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -93,9 +93,6 @@ end = struct
 
   let close _t = ()
 
-  let get_or_create_account_exn _t =
-    failwith "get_or_create_account_exn: null ledgers cannot be mutated"
-
   let get_or_create_account _t =
     failwith "get_or_create_account: null ledgers cannot be mutated"
 

--- a/src/lib/merkle_ledger_tests/test.ml
+++ b/src/lib/merkle_ledger_tests/test.ml
@@ -62,8 +62,7 @@ let%test_module "Database integration test" =
               in
               List.iter accounts ~f:(fun account ->
                   let account_id = Account.identifier account in
-                  ignore @@ DB.get_or_create_account_exn db account_id account
-              ) ;
+                  ignore @@ DB.get_or_create_account db account_id account ) ;
               let binary_tree = Binary_tree.set_accounts accounts in
               Sequence.iter
                 (enumerate_dir_combinations Depth.depth |> Sequence.of_list)

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -40,7 +40,7 @@ let%test_module "test functor on in memory databases" =
       let create_new_account_exn mdb account =
         let public_key = Account.identifier account in
         let action, location =
-          MT.get_or_create_account_exn mdb public_key account
+          MT.get_or_create_account mdb public_key account |> Or_error.ok_exn
         in
         match action with
         | `Existed ->
@@ -115,7 +115,8 @@ let%test_module "test functor on in memory databases" =
             let account' = Account.create account_id balance' in
             let location = create_new_account_exn mdb account in
             let action, location' =
-              MT.get_or_create_account_exn mdb account_id account'
+              MT.get_or_create_account mdb account_id account'
+              |> Or_error.ok_exn
             in
             location = location'
             && action = `Existed
@@ -135,7 +136,8 @@ let%test_module "test functor on in memory databases" =
             |> Sequence.iter ~f:(fun account ->
                    let account_id = Account.identifier account in
                    let _, location =
-                     MT.get_or_create_account_exn mdb account_id account
+                     MT.get_or_create_account mdb account_id account
+                     |> Or_error.ok_exn
                    in
                    let location' =
                      MT.location_of_account mdb account_id |> Option.value_exn
@@ -166,9 +168,10 @@ let%test_module "test functor on in memory databases" =
         random_accounts max_height
         |> List.iter ~f:(fun account ->
                let action, location =
-                 MT.get_or_create_account_exn mdb
+                 MT.get_or_create_account mdb
                    (Account.identifier account)
                    account
+                 |> Or_error.ok_exn
                in
                match action with
                | `Added ->
@@ -334,7 +337,9 @@ let%test_module "test functor on in memory databases" =
             let open MT in
             let key = Quickcheck.random_value Account_id.gen in
             let start_hash = merkle_root ledger in
-            match get_or_create_account_exn ledger key Account.empty with
+            match
+              get_or_create_account ledger key Account.empty |> Or_error.ok_exn
+            with
             | `Existed, _ ->
                 failwith
                   "create_empty with empty ledger somehow already has that key?"

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -87,7 +87,8 @@ module Make (Test : Test_intf) = struct
   let create_new_account_exn mask account =
     let public_key = Account.identifier account in
     let action, location =
-      Mask.Attached.get_or_create_account_exn mask public_key account
+      Mask.Attached.get_or_create_account mask public_key account
+      |> Or_error.ok_exn
     in
     match action with
     | `Existed ->
@@ -98,7 +99,8 @@ module Make (Test : Test_intf) = struct
   let create_existing_account_exn mask account =
     let public_key = Account.identifier account in
     let action, location =
-      Mask.Attached.get_or_create_account_exn mask public_key account
+      Mask.Attached.get_or_create_account mask public_key account
+      |> Or_error.ok_exn
     in
     match action with
     | `Existed ->
@@ -110,7 +112,8 @@ module Make (Test : Test_intf) = struct
   let parent_create_new_account_exn parent account =
     let public_key = Account.identifier account in
     let action, location =
-      Maskable.get_or_create_account_exn parent public_key account
+      Maskable.get_or_create_account parent public_key account
+      |> Or_error.ok_exn
     in
     match action with
     | `Existed ->
@@ -615,7 +618,9 @@ module Make (Test : Test_intf) = struct
         let ledger = Maskable.register_mask maskable mask in
         let key = List.nth_exn (Account_id.gen_accounts 1) 0 in
         let start_hash = merkle_root ledger in
-        match get_or_create_account_exn ledger key Account.empty with
+        match
+          get_or_create_account ledger key Account.empty |> Or_error.ok_exn
+        with
         | `Existed, _ ->
             failwith
               "create_empty with empty ledger somehow already has that key?"
@@ -722,7 +727,8 @@ module Make (Test : Test_intf) = struct
         let k = Account_id.gen_accounts 1 |> List.hd_exn in
         let acct1 = Account.create k (Balance.of_int 10) in
         let loc =
-          snd (Mask.Attached.get_or_create_account_exn attached_mask k acct1)
+          Mask.Attached.get_or_create_account attached_mask k acct1
+          |> Or_error.ok_exn |> snd
         in
         let acct2 = Account.create k (Balance.of_int 5) in
         Maskable.set maskable loc acct2 ;

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -763,11 +763,6 @@ module Make (Inputs : Inputs_intf.S) = struct
       | Some location ->
           Ok (`Existed, location)
 
-    let get_or_create_account_exn t account_id account =
-      get_or_create_account t account_id account
-      |> Result.map_error ~f:(fun err -> raise (Error.to_exn err))
-      |> Result.ok_exn
-
     let sexp_of_location = Location.sexp_of_t
 
     let location_of_sexp = Location.t_of_sexp

--- a/src/lib/mina_base/ledger.mli
+++ b/src/lib/mina_base/ledger.mli
@@ -179,6 +179,9 @@ module Transaction_applied : sig
   val user_command_status : t -> Transaction_status.t
 end
 
+(** Raises if the ledger is full, or if an account already exists for the given
+    [Account_id.t].
+*)
 val create_new_account_exn : t -> Account_id.t -> Account.t -> unit
 
 val apply_user_command :
@@ -235,7 +238,8 @@ val merkle_root_after_user_command_exn :
   -> Signed_command.With_valid_signature.t
   -> Ledger_hash.t * [`Next_available_token of Token_id.t]
 
-val create_empty : t -> Account_id.t -> Path.t * Account.t
+(** Raises if the ledger is full. *)
+val create_empty_exn : t -> Account_id.t -> Path.t * Account.t
 
 val num_accounts : t -> int
 

--- a/src/lib/mina_base/transaction_validator.ml
+++ b/src/lib/mina_base/transaction_validator.ml
@@ -48,19 +48,22 @@ module Hashless_ledger = struct
       | None ->
           failwith (msg "set") )
 
-  let get_or_create_account_exn t key account =
+  let get_or_create_account t key account =
     match location_of_account t key with
     | None ->
         set t (Ours key) account ;
-        (`Added, Ours key)
+        Ok (`Added, Ours key)
     | Some loc ->
-        (`Existed, loc)
+        Ok (`Existed, loc)
 
-  let get_or_create ledger aid =
+  let get_or_create_exn ledger aid =
     let action, loc =
-      get_or_create_account_exn ledger aid (Account.initialize aid)
+      get_or_create_account ledger aid (Account.initialize aid)
+      |> Or_error.ok_exn
     in
     (action, Option.value_exn (get ledger loc), loc)
+
+  let get_or_create t id = Or_error.try_with (fun () -> get_or_create_exn t id)
 
   let remove_accounts_exn _t =
     failwith "hashless_ledger: bug in transaction_logic, who is calling undo?"

--- a/src/lib/syncable_ledger/test.ml
+++ b/src/lib/syncable_ledger/test.ml
@@ -230,7 +230,7 @@ module Db = struct
         let currency_balance = Currency.Balance.of_int balance in
         List.iter account_ids ~f:(fun aid ->
             let account = Account.create aid currency_balance in
-            get_or_create_account_exn ledger aid account |> ignore ) ;
+            get_or_create_account ledger aid account |> ignore ) ;
         (ledger, account_ids)
     end
 
@@ -333,7 +333,8 @@ module Mask = struct
                 (Currency.Balance.of_int (initial_balance_multiplier * 2))
             in
             let action, _ =
-              Maskable.get_or_create_account_exn maskable account_id account
+              Maskable.get_or_create_account maskable account_id account
+              |> Or_error.ok_exn
             in
             assert (action = `Added) ) ;
         let mask = Mask.create ~depth:Input.depth () in
@@ -357,8 +358,9 @@ module Mask = struct
                     (Currency.Balance.of_int child_balance)
                 in
                 let action, location =
-                  Mask.Attached.get_or_create_account_exn attached_mask
-                    account_id account
+                  Mask.Attached.get_or_create_account attached_mask account_id
+                    account
+                  |> Or_error.ok_exn
                 in
                 match action with
                 | `Existed ->

--- a/src/lib/syncable_ledger/test.ml
+++ b/src/lib/syncable_ledger/test.ml
@@ -230,7 +230,8 @@ module Db = struct
         let currency_balance = Currency.Balance.of_int balance in
         List.iter account_ids ~f:(fun aid ->
             let account = Account.create aid currency_balance in
-            get_or_create_account ledger aid account |> ignore ) ;
+            get_or_create_account ledger aid account
+            |> Or_error.ok_exn |> ignore ) ;
         (ledger, account_ids)
     end
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -258,9 +258,10 @@ module For_tests = struct
         let nonce =
           let ledger = Staged_ledger.ledger staged_ledger in
           let status, account_location =
-            Ledger.get_or_create_account_exn ledger
+            Ledger.get_or_create_account ledger
               (Account.identifier sender_account)
               sender_account
+            |> Or_error.ok_exn
           in
           assert (status = `Existed) ;
           (Option.value_exn (Ledger.get ledger account_location)).nonce


### PR DESCRIPTION
This PR should address the concerns behind #7255 around our behaviour when the ledger is full and no more accounts can be created. It does this by removing `get_or_create_account_exn` and handling the error cases explicitly.

Overview:
* In order to create an account we need a `Location.t`
  - We derive from the current highest location with `Location.next`, which returns `None` when the ledger is full
* The two active codepaths that do this both return an `_ Or_error.t` containing an 'out of leaves' error when they receive this `None` value
* This error is bubbled up through `get_or_create_account` and friends, where it can be handled by the caller
* This PR adds the handling for this, so that transactions which would create a new account in the full ledger will fail without applying, but will not raise an exception.
  - For block production, this means that we will never apply these transactions. If a coinbase or fee-transfer would create an account, we now log the error and refuse to produce the block instead of crashing.
    + Still TODO: once the ledger is full, snark work for pk's that aren't in the ledger will prevent block production by causing an error at this stage.
  - When checking external transitions, we will reject them as soon as one of the transactions creates an account with a full ledger, via the normal mechanism.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
