### PR TITLE
WIP Support libp2p key secrets in helm

### DIFF
--- a/helm/block-producer/Chart.yaml
+++ b/helm/block-producer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: block-producer
 description: A Helm chart for Mina Protocol's block producing network nodes
 type: application
-version: 0.4.3
+version: 0.5.0
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -173,6 +173,9 @@ spec:
           {{- if $config.enableGossipFlooding }}
           "-enable-flooding", "true",
           {{- end -}}
+          {{- if $config.libp2pSecret }}
+          "-discovery-keypair", "/root/libp2p-keys/key",
+          {{- end -}}
           {{- range $.Values.coda.seedPeers }}
           "-peer", {{ . | quote }},
           {{- end -}}
@@ -199,10 +202,14 @@ spec:
           value: {{ $.Values.coda.ports.metrics | quote }}
         - name: DAEMON_EXTERNAL_PORT
           value: {{ $config.externalPort | quote }}
-        - name: CODA_PRIVKEY_PASS
-          value: {{ $.Values.coda.privkeyPass | quote }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
+        - name: CODA_PRIVKEY_PASS
+          value: {{ $.Values.coda.privkeyPass | quote }}
+        {{- if $config.libp2pSecret }}
+        - name: CODA_LIBP2P_PASS
+          value: {{ $config.libp2pPassword | quote }}
+        {{- end -}}
         ports:
         - name: client-port
           protocol: TCP 
@@ -223,6 +230,10 @@ spec:
           mountPath: /root/wallet-keys
         - name: config-dir
           mountPath: /root/.coda-config
+        {{- if $config.libp2pSecret }}
+        - name: libp2p-keys
+          mountPath: /root/libp2p-keys
+        {{- end -}}
         {{- if $.Values.coda.runtimeConfig }}
         - name: daemon-config
           mountPath: "/config/"
@@ -238,6 +249,17 @@ spec:
             path: key
           - key: pub
             path: key.pub
+      {{- if $config.libp2pSecret }}
+      - name: libp2p-keys
+        secret:
+          secretName: {{ $config.libp2pSecret }}
+          defaultMode: 256
+          items:
+          - key: key
+            path: key
+          - key: pub
+            path: key.pub
+      {{- end -}}
       {{ if $config.runWithBots }}
       - name: echo-service-key
         secret:

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -208,7 +208,7 @@ spec:
           value: {{ $.Values.coda.privkeyPass | quote }}
         {{- if $config.libp2pSecret }}
         - name: CODA_LIBP2P_PASS
-          value: {{ $config.libp2pPassword | quote }}
+          value: {{ $.Values.coda.privkeyPass | quote }}
         {{- end -}}
         ports:
         - name: client-port


### PR DESCRIPTION
These changes allow for supplying a seed-discovery-keypair via a k8s secret generated by the generate-keys-and-ledger.sh script in https://github.com/MinaProtocol/coda-automation/pull/548