### PR TITLE
Add missing fields to user commands

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -287,22 +287,13 @@ WITH RECURSIVE chain AS (
 
   module User_commands = struct
     module Extras = struct
-      let fee_payer_account_creation_fee_paid (x, _, _, _) = x
+      let fee_payer (x, _, _) = `Pk x
 
-      let receiver_account_creation_fee_paid (_, y, _, _) = y
+      let source (_, y, _) = `Pk y
 
-      let created_token (_, _, z, _) = z
+      let receiver (_, _, z) = `Pk z
 
-      let fee_payer (_, _, _, (x, _, _)) = `Pk x
-
-      let source (_, _, _, (_, y, _)) = `Pk y
-
-      let receiver (_, _, _, (_, _, z)) = `Pk z
-
-      let typ =
-        Caqti_type.(
-          tup4 (option int64) (option int64) (option int64)
-            (tup3 string string string))
+      let typ = Caqti_type.(tup3 string string string)
     end
 
     let typ =
@@ -454,10 +445,8 @@ WITH RECURSIVE chain AS (
             match uc.failure_reason with
             | None -> (
               match
-                ( User_commands.Extras.fee_payer_account_creation_fee_paid
-                    extras
-                , User_commands.Extras.receiver_account_creation_fee_paid
-                    extras )
+                ( uc.fee_payer_account_creation_fee_paid
+                , uc.receiver_account_creation_fee_paid )
               with
               | None, None ->
                   M.return


### PR DESCRIPTION
The type `Processor.User_command.Signed_command.t` was missing some fields that occur in the archive db. The SQL for the `load` command mentioned those fields, but the data was not captured in the returned value.

Add those fields here. As a by-product, there is some simplification in the Rosetta code.

Tested by generating an archive db from Rosetta.
