### PR TITLE
Distinguish Could_not_construct from Sexp in Error.t

### DIFF
--- a/src/lib/error_json/error_json.ml
+++ b/src/lib/error_json/error_json.ml
@@ -102,7 +102,9 @@ let info_repr_to_yojson (info : info_data info_repr) : Yojson.Safe.t =
 let rec info_internal_repr_to_yojson_aux (info : Info.Internal_repr.t)
     (acc : unit info_repr) : info_data info_repr =
   match info with
-  | Could_not_construct sexp | Sexp sexp ->
+  | Could_not_construct sexp ->
+      {acc with base= Sexp (List [Atom "Could_not_construct"; sexp])}
+  | Sexp sexp ->
       {acc with base= Sexp sexp}
   | String str ->
       {acc with base= String str}


### PR DESCRIPTION
This distinguishes errors encountered while constructing an `Error.t` (encoded as `Could_not_construct`) from other sexp-encoded errors.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: