### PR TITLE
Improve error printing

### DIFF
--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -654,7 +654,7 @@ let handle_shutdown ~monitor ~time_controller ~conf_dir ~child_pids ~top_logger
                    ~log_issue:false
                in
                Core.print_string message ; Deferred.unit
-           | exn ->
+           | _exn ->
                handle_crash exn ~time_controller ~conf_dir ~child_pids
                  ~top_logger coda_ref
          in

--- a/src/lib/error_json/error_json.ml
+++ b/src/lib/error_json/error_json.ml
@@ -49,7 +49,7 @@ let info_repr_to_yojson (info : info_data info_repr) : Yojson.Safe.t =
     | Exn exn ->
         [ ( "exn_name"
           , `String Stdlib.Obj.(extension_name (extension_constructor exn)) )
-        ; ("exn", `String (Stdlib.Printexc.to_string exn)) ]
+        ; ("exn", sexp_to_yojson (Sexplib.Conv.sexp_of_exn exn)) ]
     | Of_list (Some trunc_after, length, json) ->
         [ ("multiple", json)
         ; ("length", `Int length)


### PR DESCRIPTION
This PR adds improved error printing. This allows us to avoid unwrapping the `Monitor.Error` exception, which may contain a more useful backtrace than the one we can infer otherwise.

Printing for the error is slightly worse than when we have a JSON encoding, but this backtrace information is more valuable than the pretty printing. This is an alternative to #6904, designed to address the weird stack traces seen in #6901 and [this comment](https://github.com/MinaProtocol/mina/issues/7108#issuecomment-752658625).

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: