### PR TITLE
Support local filesystem and rest-server modes for `accounts import`, `accounts list`

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -1713,6 +1713,65 @@
         },
         {
           "kind": "OBJECT",
+          "name": "ImportAccountPayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "publicKey",
+              "description": "The public key of the imported account",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "PublicKey",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "alreadyImported",
+              "description": "True if the account had already been imported",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "success",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "ReloadAccountsPayload",
           "description": null,
           "fields": [
@@ -2428,6 +2487,51 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "ReloadAccountsPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "importAccount",
+              "description": "Reload tracked account information from disk",
+              "args": [
+                {
+                  "name": "password",
+                  "description": "Password for the account to import",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "path",
+                  "description": "Path to the wallet file, relative to the daemon's current working directory.",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ImportAccountPayload",
                   "ofType": null
                 }
               },

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1356,27 +1356,75 @@ let set_snark_work_fee =
                (Unsigned.UInt64.to_int (response#setSnarkWorkFee)#lastFee) ) )
 
 let import_key =
-  let privkey_path = Cli_lib.Flag.privkey_read_path in
-  let conf_dir = Cli_lib.Flag.conf_dir in
-  let flags = Args.zip2 privkey_path conf_dir in
   Command.async
     ~summary:
       "Import a password protected private key to be tracked by the daemon.\n\
        Set CODA_PRIVKEY_PASS environment variable to use non-interactively \
        (key will be imported using the same password)."
-    (Cli_lib.Background_daemon.graphql_init flags
-       ~f:(fun graphql_endpoint (privkey_path, conf_dir) ->
-         let open Deferred.Let_syntax in
-         let%bind home = Sys.home_directory () in
-         let conf_dir =
-           Option.value
-             ~default:(home ^/ Cli_lib.Default.conf_dir_name)
-             conf_dir
+    (let%map_open.Command.Let_syntax access_method =
+       choose_one
+         ~if_nothing_chosen:(`Default_to `None)
+         [ Cli_lib.Flag.Uri.Client.rest_graphql_opt
+           |> map ~f:(Option.map ~f:(fun port -> `GraphQL port))
+         ; Cli_lib.Flag.conf_dir
+           |> map ~f:(Option.map ~f:(fun conf_dir -> `Conf_dir conf_dir)) ]
+     and privkey_path = Cli_lib.Flag.privkey_read_path in
+     fun () ->
+       let open Deferred.Let_syntax in
+       let initial_password = ref None in
+       let do_graphql graphql_endpoint =
+         let%bind password =
+           match Sys.getenv Secrets.Keypair.env with
+           | Some password ->
+               Deferred.return (Bytes.of_string password)
+           | None ->
+               let password =
+                 Secrets.Password.read_hidden_line ~error_help_message:""
+                   "Secret key password: "
+               in
+               initial_password := Some password ;
+               password
          in
+         let graphql =
+           Graphql_queries.Import_account.make ~path:privkey_path
+             ~password:(Bytes.to_string password) ()
+         in
+         match%map Graphql_client.query graphql graphql_endpoint with
+         | Ok res ->
+             let res = res#importAccount in
+             if res#already_imported then Ok (`Already_imported res#public_key)
+             else Ok (`Imported res#public_key)
+         | Error (`Failed_request _ as err) ->
+             Error err
+         | Error (`Graphql_error _ as err) ->
+             Ok err
+       in
+       let do_local conf_dir =
          let wallets_disk_location = conf_dir ^/ "wallets" in
          let%bind ({Keypair.public_key; _} as keypair) =
-           Secrets.Keypair.Terminal_stdin.read_exn ~which:"coda keypair"
-             privkey_path
+           let rec go () =
+             match !initial_password with
+             | None ->
+                 Secrets.Keypair.Terminal_stdin.read_exn ~which:"coda keypair"
+                   privkey_path
+             | Some password -> (
+                 (* We've already asked for the password once for a failed
+                   GraphQL query, try that one instead of asking again.
+                *)
+                 match%bind
+                   Secrets.Keypair.read ~privkey_path
+                     ~password:(Lazy.return password)
+                 with
+                 | Ok res ->
+                     return res
+                 | Error `Incorrect_password_or_corrupted_privkey ->
+                     printf "Wrong password! Please try again\n" ;
+                     initial_password := None ;
+                     go ()
+                 | Error err ->
+                     Secrets.Privkey_error.raise ~which:"coda keypair" err )
+           in
+           go ()
          in
          let pk = Public_key.compress public_key in
          let%bind wallets =
@@ -1386,26 +1434,52 @@ let import_key =
          (* Either we already are tracking it *)
          match Secrets.Wallets.check_locked wallets ~needle:pk with
          | Some _ ->
-             printf
-               !"Key already present, no need to import : %s\n"
-               (Public_key.Compressed.to_base58_check
-                  (Public_key.compress public_key)) ;
-             Deferred.unit
+             Deferred.return (`Already_imported pk)
          | None ->
              (* Or we import it *)
-             let%bind _ =
+             let%map pk =
                Secrets.Wallets.import_keypair_terminal_stdin wallets keypair
              in
-             (* Attempt to reload, but if you can't connect to daemon, it's ok *)
-             let%map _response =
-               Graphql_client.query
-                 (Graphql_queries.Reload_accounts.make ())
-                 graphql_endpoint
-             in
+             `Imported pk
+       in
+       let print_result = function
+         | `Already_imported public_key ->
+             printf
+               !"Key already present, no need to import : %s\n"
+               (Public_key.Compressed.to_base58_check public_key)
+         | `Imported public_key ->
              printf
                !"\n😄 Imported account!\nPublic key: %s\n"
-               (Public_key.Compressed.to_base58_check
-                  (Public_key.compress public_key)) ))
+               (Public_key.Compressed.to_base58_check public_key)
+         | `Graphql_error _ as e ->
+             don't_wait_for (Graphql_lib.Client.Connection_error.ok_exn e)
+       in
+       match access_method with
+       | `GraphQL graphql_endpoint -> (
+           match%map do_graphql graphql_endpoint with
+           | Ok res ->
+               print_result res
+           | Error err ->
+               don't_wait_for (Graphql_lib.Client.Connection_error.ok_exn err)
+           )
+       | `Conf_dir conf_dir ->
+           let%map res = do_local conf_dir in
+           print_result res
+       | `None -> (
+           let default_graphql_endpoint =
+             Cli_lib.Flag.(Uri.Client.{Types.name; value= default})
+           in
+           match%bind do_graphql default_graphql_endpoint with
+           | Ok res ->
+               Deferred.return (print_result res)
+           | Error _res ->
+               let conf_dir = Mina_lib.Conf_dir.compute_conf_dir None in
+               eprintf
+                 "%sWarning: Could not connect to a running daemon.\n\
+                  Importing to local directory %s%s\n"
+                 Bash_colors.orange conf_dir Bash_colors.none ;
+               let%map res = do_local conf_dir in
+               print_result res ))
 
 let export_key =
   let privkey_path = Cli_lib.Flag.privkey_write_path in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1405,7 +1405,7 @@ let import_key =
            let rec go () =
              match !initial_password with
              | None ->
-                 Secrets.Keypair.Terminal_stdin.read_exn ~which:"coda keypair"
+                 Secrets.Keypair.Terminal_stdin.read_exn ~which:"mina keypair"
                    privkey_path
              | Some password -> (
                  (* We've already asked for the password once for a failed
@@ -1422,7 +1422,7 @@ let import_key =
                      initial_password := None ;
                      go ()
                  | Error err ->
-                     Secrets.Privkey_error.raise ~which:"coda keypair" err )
+                     Secrets.Privkey_error.raise ~which:"mina keypair" err )
            in
            go ()
          in
@@ -1583,7 +1583,7 @@ let list_accounts =
            | [||] ->
                printf
                  "😢 You have no tracked accounts!\n\
-                  You can make a new one using `coda accounts create`\n" ;
+                  You can make a new one using `mina accounts create`\n" ;
                Ok ()
            | accounts ->
                Array.iteri accounts ~f:(fun i w ->

--- a/src/app/cli/src/init/dune
+++ b/src/app/cli/src/init/dune
@@ -16,7 +16,7 @@
    consensus mina_transition mina_version
    mina_user_error
    o1trace protocol_version node_status transition_frontier web_client_pipe
-   web_request graphql_lib genesis_ledger_helper)
+   web_request graphql_lib genesis_ledger_helper bash_colors)
  (instrumentation (backend bisect_ppx))
  (preprocessor_deps ../../../../config.mlh)
  (preprocess (pps ppx_coda graphql_ppx ppx_version ppx_jane ppx_deriving_yojson)))

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -365,3 +365,15 @@ mutation ($transaction: RosettaTransaction!) {
   }
 }
 |}]
+
+module Import_account =
+[%graphql
+{|
+mutation ($path: String!, $password: String!) {
+  importAccount (path: $path, password: $password) {
+    public_key: publicKey @bsDecoder(fn: "Decoders.public_key")
+    already_imported: alreadyImported
+    success
+  }
+}
+|}]

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -253,20 +253,28 @@ module Uri = struct
     else Uri.to_string uri
 
   module Client = struct
+    let doc_builder =
+      Doc_builder.create ~display:to_string
+        ~examples:
+          [ Port.to_uri ~path:"graphql" Port.default_rest
+          ; Uri.of_string
+              ( "/dns4/peer1-rising-phoenix.o1test.net" ^ ":"
+              ^ Int.to_string Port.default_rest
+              ^/ "graphql" ) ]
+        "URI/LOCALHOST-PORT" "graphql rest server for daemon interaction"
+
+    let name = "rest-server"
+
+    let default = Port.to_uri ~path:"graphql" Port.default_rest
+
     let rest_graphql =
-      let doc_builder =
-        Doc_builder.create ~display:to_string
-          ~examples:
-            [ Port.to_uri ~path:"graphql" Port.default_rest
-            ; Uri.of_string
-                ( "/dns4/peer1-rising-phoenix.o1test.net" ^ ":"
-                ^ Int.to_string Port.default_rest
-                ^/ "graphql" ) ]
-          "URI/LOCALHOST-PORT" "graphql rest server for daemon interaction"
-      in
       create ~name:"--rest-server" ~aliases:["rest-server"]
         ~arg_type:(arg_type ~path:"graphql") doc_builder
-        (Resolve_with_default (Port.to_uri ~path:"graphql" Port.default_rest))
+        (Resolve_with_default default)
+
+    let rest_graphql_opt =
+      create ~name:"rest-server" ~aliases:["rest-server"]
+        ~arg_type:(arg_type ~path:"graphql") doc_builder Optional
   end
 
   module Archive = struct

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -273,7 +273,7 @@ module Uri = struct
         (Resolve_with_default default)
 
     let rest_graphql_opt =
-      create ~name:"rest-server" ~aliases:["rest-server"]
+      create ~name:"--rest-server" ~aliases:["rest-server"]
         ~arg_type:(arg_type ~path:"graphql") doc_builder Optional
   end
 

--- a/src/lib/cli_lib/flag.mli
+++ b/src/lib/cli_lib/flag.mli
@@ -34,6 +34,12 @@ module Uri : sig
 
   module Client : sig
     val rest_graphql : Uri.t Types.with_name Command.Spec.param
+
+    val rest_graphql_opt : Uri.t Types.with_name option Command.Spec.param
+
+    val name : string
+
+    val default : Uri.t
   end
 
   module Archive : sig

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1633,6 +1633,21 @@ module Types = struct
               ~args:Arg.[]
               ~resolve:(fun _ -> Fn.id) ] )
 
+    let import_account =
+      obj "ImportAccountPayload" ~fields:(fun _ ->
+          [ field "publicKey" ~doc:"The public key of the imported account"
+              ~typ:(non_null public_key)
+              ~args:Arg.[]
+              ~resolve:(fun _ -> fst)
+          ; field "alreadyImported"
+              ~doc:"True if the account had already been imported"
+              ~typ:(non_null bool)
+              ~args:Arg.[]
+              ~resolve:(fun _ -> snd)
+          ; field "success" ~typ:(non_null bool)
+              ~args:Arg.[]
+              ~resolve:(fun _ _ -> true) ] )
+
     let string_of_banned_status = function
       | Trust_system.Banned_status.Unbanned ->
           None
@@ -2392,6 +2407,39 @@ module Mutations = struct
       ~args:Arg.[]
       ~resolve:reload_account_resolver
 
+  let import_account =
+    io_field "importAccount"
+      ~doc:"Reload tracked account information from disk"
+      ~typ:(non_null Types.Payload.import_account)
+      ~args:
+        Arg.
+          [ arg "path"
+              ~doc:
+                "Path to the wallet file, relative to the daemon's current \
+                 working directory."
+              ~typ:(non_null string)
+          ; arg "password" ~doc:"Password for the account to import"
+              ~typ:(non_null string) ]
+      ~resolve:(fun {ctx= coda; _} () privkey_path password ->
+        let open Deferred.Result.Let_syntax in
+        let password =
+          Lazy.return (Deferred.return (Bytes.of_string password))
+        in
+        let%bind ({Keypair.public_key; _} as keypair) =
+          Secrets.Keypair.read ~privkey_path ~password
+          |> Deferred.Result.map_error ~f:Secrets.Privkey_error.to_string
+        in
+        let pk = Public_key.compress public_key in
+        let wallets = Mina_lib.wallets coda in
+        match Secrets.Wallets.check_locked wallets ~needle:pk with
+        | Some _ ->
+            return (pk, true)
+        | None ->
+            let%map.Async pk =
+              Secrets.Wallets.import_keypair wallets keypair ~password
+            in
+            Ok (pk, false) )
+
   let reset_trust_status =
     io_field "resetTrustStatus"
       ~doc:"Reset trust status for all peers at a given IP address"
@@ -2904,6 +2952,7 @@ module Mutations = struct
     ; delete_account
     ; delete_wallet
     ; reload_accounts
+    ; import_account
     ; reload_wallets
     ; send_payment
     ; send_delegation


### PR DESCRIPTION
This PR
* adds support importing keys to a remote daemon via GraphQL
* reports when importing keys occurs locally due to a connection failure
* allows setting of either `-config-directory` for explicit local imports or `-rest-port` for explicit remote imports
* adds support (and fallthrough) for local account listing.

Some sample runs:
* `accounts list`, no running daemon, imported keys 
![Screenshot from 2020-12-30 23-46-19](https://user-images.githubusercontent.com/1847343/103386984-3ddae580-4af9-11eb-80db-37f679c10381.png)
* `accounts list`, running daemon, no imported key 
![Screenshot from 2020-12-30 23-51-23](https://user-images.githubusercontent.com/1847343/103387110-f3a63400-4af9-11eb-9fa7-027dd0e4ad7e.png)
* `accounts import`, no running daemon, imported keys
![Screenshot from 2020-12-30 23-45-14](https://user-images.githubusercontent.com/1847343/103386956-1552eb80-4af9-11eb-8dc2-6dcbc3293c8c.png)
* `accounts import`, running daemon, no imported key 
![Screenshot from 2020-12-30 23-47-35](https://user-images.githubusercontent.com/1847343/103387028-6d89ed80-4af9-11eb-8984-973540630735.png)
* `accounts list`, running daemon, imported key 
![Screenshot from 2020-12-30 23-48-21](https://user-images.githubusercontent.com/1847343/103387045-87c3cb80-4af9-11eb-97a1-5c912ddf5c3f.png)
* `accounts list`, explicit config directory path 
![Screenshot from 2020-12-30 23-49-06](https://user-images.githubusercontent.com/1847343/103387064-ad50d500-4af9-11eb-9c63-5eba5cdf498e.png)
* `accounts list` with incompatible flags 
![Screenshot from 2020-12-30 23-50-21](https://user-images.githubusercontent.com/1847343/103387084-c9547680-4af9-11eb-8cbf-6c2b285034f3.png)

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #6110
Closes #7272
Closes #7273
