### PR TITLE
add finer grained argument for skipping staged ledger verification

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -547,8 +547,8 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                         "Build breadcrumb on produced block" (fun () ->
                           Breadcrumb.build ~logger ~precomputed_values
                             ~verifier ~trust_system ~parent:crumb ~transition
-                            ~sender:None (* Consider skipping here *)
-                            ~skip_staged_ledger_verification:false
+                            ~sender:None (* Consider skipping `All here *)
+                            ~skip_staged_ledger_verification:`Proofs
                             ~transition_receipt_time () )
                       |> Deferred.Result.map_error ~f:(function
                            | `Invalid_staged_ledger_diff e ->
@@ -829,7 +829,7 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
               "Build breadcrumb on produced block (precomputed)" (fun () ->
                 Breadcrumb.build ~logger ~precomputed_values ~verifier
                   ~trust_system ~parent:crumb ~transition ~sender:None
-                  ~skip_staged_ledger_verification:false
+                  ~skip_staged_ledger_verification:`Proofs
                   ~transition_receipt_time ()
                 |> Deferred.Result.map_error ~f:(function
                      | `Invalid_staged_ledger_diff e ->

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -1180,7 +1180,7 @@ module Staged_ledger_validation = struct
     Fn.compose statement_target statement
 
   let validate_staged_ledger_diff :
-         ?skip_staged_ledger_verification:bool
+         ?skip_staged_ledger_verification:[`All | `Proofs]
       -> ( 'time_received
          , 'genesis_state
          , 'proof

--- a/src/lib/mina_transition/external_transition_intf.ml
+++ b/src/lib/mina_transition/external_transition_intf.ml
@@ -652,7 +652,7 @@ module type S = sig
 
   module Staged_ledger_validation : sig
     val validate_staged_ledger_diff :
-         ?skip_staged_ledger_verification:bool
+         ?skip_staged_ledger_verification:[`All | `Proofs]
       -> ( 'time_received
          , 'genesis_state
          , 'proof

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -961,6 +961,9 @@ module T = struct
       ((a : Transaction.Valid.t With_status.t list), b, c, d) =
     ((a :> Transaction.t With_status.t list), b, c, d)
 
+  [%%if
+  feature_snapps]
+
   let check_commands ledger ~verifier (cs : User_command.t list) =
     match
       Or_error.try_with (fun () ->
@@ -988,6 +991,35 @@ module T = struct
                   (Verifier.Failure.Verification_failed
                      (Error.of_string "batch verification failed")) ))
 
+  [%%else]
+
+  (* imeckler: added this version because the call to the verifier was
+   causing super catchup to proceed more slowly than it could have otherwise.
+
+   The reason is as follows: catchup would have, say 100 blocks in the "to verify"
+   queue and 20 in the "already verified, to apply" queue. Those 20 would be
+   processed very slowly because each one would have to call the verifier, which
+   the other queue was trying to call as well. *)
+  let check_commands _ledger ~verifier:_ (cs : User_command.t list) :
+      (User_command.Valid.t list, _) result Deferred.Or_error.t =
+    Result.all
+      (List.map cs ~f:(function
+        | Snapp_command _ ->
+            Error
+              (Verifier.Failure.Verification_failed
+                 (Error.of_string "check_commands: snapp commands disabled"))
+        | Signed_command c -> (
+          match Signed_command.check c with
+          | Some c ->
+              Ok (User_command.Signed_command c)
+          | None ->
+              Error
+                (Verifier.Failure.Verification_failed
+                   (Error.of_string "signature failed to verify")) ) ))
+    |> Deferred.Or_error.return
+
+  [%%endif]
+
   let apply ?skip_verification ~constraint_constants t
       (witness : Staged_ledger_diff.t) ~logger ~verifier ~current_state_view
       ~state_and_body_hash ~coinbase_receiver ~supercharge_coinbase =
@@ -996,9 +1028,9 @@ module T = struct
     let%bind () =
       time ~logger "check_completed_works" (fun () ->
           match skip_verification with
-          | Some true ->
+          | Some `All | Some `Proofs ->
               return ()
-          | Some false | None ->
+          | None ->
               check_completed_works ~logger ~verifier t.scan_state work )
     in
     let%bind prediff =
@@ -1012,7 +1044,9 @@ module T = struct
     in
     let apply_diff_start_time = Core.Time.now () in
     let%map ((_, _, `Staged_ledger new_staged_ledger, _) as res) =
-      apply_diff ?skip_verification ~constraint_constants t
+      apply_diff
+        ~skip_verification:(skip_verification = Some `All)
+        ~constraint_constants t
         (forget_prediff_info prediff)
         ~logger ~current_state_view ~state_and_body_hash
         ~log_prefix:"apply_diff"

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -114,7 +114,7 @@ val copy : t -> t
 val hash : t -> Staged_ledger_hash.t
 
 val apply :
-     ?skip_verification:bool
+     ?skip_verification:[`Proofs | `All]
   -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> t
   -> Staged_ledger_diff.t

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -440,7 +440,7 @@ module For_tests = struct
           ~transition:
             (External_transition.Validation.reset_staged_ledger_diff_validation
                next_verified_external_transition)
-          ~sender:None ~skip_staged_ledger_verification:true
+          ~sender:None ~skip_staged_ledger_verification:`All
           ~transition_receipt_time ()
       with
       | Ok new_breadcrumb ->

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -28,7 +28,7 @@ val create :
   -> t
 
 val build :
-     ?skip_staged_ledger_verification:bool
+     ?skip_staged_ledger_verification:[`All | `Proofs]
   -> logger:Logger.t
   -> precomputed_values:Precomputed_values.t
   -> verifier:Verifier.t

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -288,7 +288,7 @@ module Instance = struct
              *)
              let transition_receipt_time = None in
              let%bind breadcrumb =
-               Breadcrumb.build ~skip_staged_ledger_verification:true
+               Breadcrumb.build ~skip_staged_ledger_verification:`All
                  ~logger:t.factory.logger ~precomputed_values
                  ~verifier:t.factory.verifier
                  ~trust_system:(Trust_system.null ()) ~parent ~transition

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -181,9 +181,8 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
           Transition_frontier.Breadcrumb.build ~logger ~precomputed_values
             ~verifier ~trust_system ~transition_receipt_time
             ~sender:(Some sender) ~parent:parent_breadcrumb
-            ~transition:
-              mostly_validated_transition (* TODO: Can we skip here? *)
-            ~skip_staged_ledger_verification:false () )
+            ~transition:mostly_validated_transition
+            (* TODO: Can we skip here? *) () )
         ~transform_result:(function
           | Error (`Invalid_staged_ledger_hash error)
           | Error (`Invalid_staged_ledger_diff error) ->


### PR DESCRIPTION
This PR

1. Adds a more specific argument for skipping parts of staged ledger verification
2. When snapps are not enabled, does not call the verifier process to check user commands.