### PR TITLE
set testnet component envvar CONNECT_PRIVATE_IPS=true

### DIFF
--- a/helm/archive-node/Chart.yaml
+++ b/helm/archive-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: archive-node
 description: A Helm chart for Mina Protocol's archive node
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: 1.16.0
 dependencies:
   - name: postgresql

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -73,6 +73,8 @@ spec:
           value: {{ .Values.coda.ports.p2p | quote }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
+        - name: CONNECT_PRIVATE_IPS
+          value: "true"
         ports:
         - name: client-port
           protocol: TCP 

--- a/helm/block-producer/Chart.yaml
+++ b/helm/block-producer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: block-producer
 description: A Helm chart for Mina Protocol's block producing network nodes
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -212,6 +212,8 @@ spec:
           value: {{ $.Values.coda.privkeyPass | quote }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
+        - name: CONNECT_PRIVATE_IPS
+          value: "true"
         ports:
         - name: client-port
           protocol: TCP 

--- a/helm/seed-node/Chart.yaml
+++ b/helm/seed-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: seed-node
 description: A Helm chart for Mina Protocol's seed nodes
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -73,6 +73,8 @@ spec:
           value: {{ .Values.coda.ports.metrics | quote }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
+        - name: CONNECT_PRIVATE_IPS
+          value: "true"
         - name: DAEMON_EXTERNAL_PORT
           value: {{ .Values.coda.ports.p2p | quote }}
         ports:

--- a/helm/snark-worker/Chart.yaml
+++ b/helm/snark-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: snark-worker
 description: A Helm chart for Mina Protocol's SNARK worker nodes
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: 1.16.0
 dependencies:
   - name: common-utilities

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -62,6 +62,8 @@ spec:
           value: {{ .Values.coda.ports.metrics | quote }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
+        - name: CONNECT_PRIVATE_IPS
+          value: "true"
         - name: CODA_SNARK_KEY
           value: {{ .Values.coordinator.publicKey | quote }}
         - name: CODA_SNARK_FEE


### PR DESCRIPTION
Ensure `CONNECT_PRIVATE_IPS` is set to true for all daemon containers within Helm testnet component pods to enable cluster-local peer discovery.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
