### PR TITLE
Transactions in missing subchains; compatible JSON output

### DIFF
--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -1,0 +1,72 @@
+(* extensional.ml -- extensional representations of archive db data *)
+
+open Core_kernel
+open Mina_base
+open Signature_lib
+
+(* the tables in the archive db uses foreign keys to refer to other
+   tables; the types here fills in the data from those other tables, using
+   their native OCaml types to assure the validity of the data
+*)
+
+module Block = struct
+  type t =
+    { state_hash: State_hash.t
+    ; parent_hash: State_hash.t
+    ; creator: Public_key.Compressed.t
+    ; block_winner: Public_key.Compressed.t
+    ; snarked_ledger_hash: Frozen_ledger_hash.t
+    ; staking_epoch_seed: Epoch_seed.t
+    ; staking_epoch_ledger_hash: Frozen_ledger_hash.t
+    ; next_epoch_seed: Epoch_seed.t
+    ; next_epoch_ledger_hash: Frozen_ledger_hash.t
+    ; ledger_hash: Ledger_hash.t
+    ; height: Unsigned.UInt32.t
+    ; global_slot: Mina_numbers.Global_slot.t
+    ; global_slot_since_genesis: Mina_numbers.Global_slot.t
+    ; timestamp: Block_time.t }
+end
+
+module User_command = struct
+  (* for `typ` and `status`, a string is enough
+     in any case, there aren't existing string conversions for the
+     original OCaml types
+  *)
+  type t =
+    { block_state_hash: State_hash.t
+    ; sequence_no: int
+    ; typ: string
+    ; fee_payer: Public_key.Compressed.t
+    ; source: Public_key.Compressed.t
+    ; receiver: Public_key.Compressed.t
+    ; fee_token: Token_id.t
+    ; token: Token_id.t
+    ; nonce: Account.Nonce.t
+    ; amount: Currency.Amount.t option
+    ; fee: Currency.Fee.t
+    ; valid_until: Mina_numbers.Global_slot.t option
+    ; memo: Signed_command_memo.t
+    ; hash: Transaction_hash.t
+    ; status: string option
+    ; failure_reason: Transaction_status.Failure.t option
+    ; fee_payer_account_creation_fee_paid: Currency.Amount.t option
+    ; receiver_account_creation_fee_paid: Currency.Amount.t option
+    ; created_token: Token_id.t option }
+  [@@deriving compare]
+end
+
+module Internal_command = struct
+  (* for `typ`, a string is enough
+     no existing string conversion for the original OCaml type
+  *)
+  type t =
+    { global_slot: int64
+    ; sequence_no: int
+    ; secondary_sequence_no: int
+    ; typ: string
+    ; receiver: Public_key.Compressed.t
+    ; fee: Currency.Amount.t
+    ; token: Token_id.t
+    ; hash: Transaction_hash.t }
+  [@@deriving compare]
+end

--- a/src/app/missing_subchain/block.ml
+++ b/src/app/missing_subchain/block.ml
@@ -1,0 +1,253 @@
+(* block.ml -- block for json output *)
+
+open Core_kernel
+open Mina_base
+open Signature_lib
+open Archive_lib
+
+(* like With_status, but with an option
+   why? the archive db has a NULLable column for user command status
+*)
+module With_opt_status = struct
+  type 'a t = {data: 'a; status: Transaction_status.t option}
+  [@@deriving yojson]
+end
+
+type curr_global_slot = {slot_number: Mina_numbers.Global_slot.t}
+[@@deriving yojson]
+
+type epoch_ledger_hash = {hash: Frozen_ledger_hash.t} [@@deriving yojson]
+
+type epoch_data = {ledger: epoch_ledger_hash; seed: Epoch_seed.t}
+[@@deriving yojson]
+
+type blockchain_state = {timestamp: Block_time.t} [@@deriving yojson]
+
+type consensus_state =
+  { curr_global_slot: curr_global_slot
+  ; global_slot_since_genesis: Mina_numbers.Global_slot.t
+  ; staking_epoch_data: epoch_data
+  ; next_epoch_data: epoch_data
+  ; block_stake_winner: Public_key.Compressed.t
+  ; block_creator: Public_key.Compressed.t }
+[@@deriving yojson]
+
+type protocol_state_body =
+  {blockchain_state: blockchain_state; consensus_state: consensus_state}
+[@@deriving yojson]
+
+type protocol_state = {body: protocol_state_body} [@@deriving yojson]
+
+type user_cmd_common =
+  { fee: Currency.Fee.t
+  ; fee_token: Token_id.t
+  ; fee_payer_pk: Public_key.Compressed.t
+  ; nonce: Account.Nonce.t
+  ; valid_until: Mina_numbers.Global_slot.t option
+  ; memo: Signed_command_memo.t }
+[@@deriving yojson]
+
+type user_cmd_body_payload =
+  { source_pk: Public_key.Compressed.t
+  ; receiver_pk: Public_key.Compressed.t
+  ; token_id: Token_id.t
+  ; amount: Currency.Amount.t option }
+[@@deriving yojson]
+
+type user_cmd_body =
+  | Payment of user_cmd_body_payload
+  | Stake_delegation of user_cmd_body_payload
+  | Create_new_token of user_cmd_body_payload
+  | Create_token_account of user_cmd_body_payload
+  | Mint_tokens of user_cmd_body_payload
+[@@deriving yojson]
+
+type payload = {common: user_cmd_common; body: user_cmd_body}
+[@@deriving yojson]
+
+(* TODO: add Snapps *)
+type command = Signed_command of {payload: payload} [@@deriving yojson]
+
+type diff_commands =
+  { commands: command With_opt_status.t list
+  ; internal_command_balances:
+      Transaction_status.Internal_command_balance_data.t list }
+[@@deriving yojson]
+
+type staged_ledger_diff = {diff: diff_commands} [@@deriving yojson]
+
+(* essentially External_transition.t with some fields missing
+   and state_hash and ledger_hash added
+*)
+
+type t =
+  { state_hash: State_hash.t
+  ; ledger_hash: Ledger_hash.t
+  ; protocol_state: protocol_state
+  ; staged_ledger_diff: staged_ledger_diff }
+[@@deriving yojson]
+
+(* the user commands in a block with a given state hash *)
+let user_cmds_tbl : Extensional.User_command.t list State_hash.Table.t =
+  State_hash.Table.create ()
+
+(* the internal commands in a block with a given state hash *)
+let internal_cmds_tbl : Extensional.Internal_command.t list State_hash.Table.t
+    =
+  State_hash.Table.create ()
+
+module Fee_transfer_via_coinbase = struct
+  (* table of fee transfer via coinbase at given global slot, seq no, secondary seq no *)
+  module T = struct
+    type t = int64 * int * int
+    [@@deriving bin_io_unversioned, hash, compare, sexp]
+  end
+
+  include T
+  include Hashable.Make_binable (T)
+end
+
+let fee_transfer_tbl :
+    Extensional.Internal_command.t Fee_transfer_via_coinbase.Table.t =
+  Fee_transfer_via_coinbase.Table.create ()
+
+let blockchain_state_of_extensional_block (block : Extensional.Block.t) =
+  {timestamp= block.timestamp}
+
+let mk_global_slot slot_number = {slot_number}
+
+let mk_ledger hash = {hash}
+
+let mk_epoch_data seed hash = {ledger= mk_ledger hash; seed}
+
+let consensus_state_of_extensional_block (block : Extensional.Block.t) :
+    consensus_state =
+  { curr_global_slot= mk_global_slot block.global_slot
+  ; global_slot_since_genesis= block.global_slot_since_genesis
+  ; staking_epoch_data=
+      mk_epoch_data block.staking_epoch_seed block.staking_epoch_ledger_hash
+  ; next_epoch_data=
+      mk_epoch_data block.next_epoch_seed block.next_epoch_ledger_hash
+  ; block_stake_winner= block.block_winner
+  ; block_creator= block.creator }
+
+let protocol_state_body_of_extensional_block (block : Extensional.Block.t) =
+  let blockchain_state = blockchain_state_of_extensional_block block in
+  let consensus_state = consensus_state_of_extensional_block block in
+  {blockchain_state; consensus_state}
+
+let protocol_state_of_extensional_block block =
+  {body= protocol_state_body_of_extensional_block block}
+
+let common_of_user_cmd (user_cmd : Extensional.User_command.t) =
+  { fee= user_cmd.fee
+  ; fee_token= user_cmd.fee_token
+  ; fee_payer_pk= user_cmd.fee_payer
+  ; nonce= user_cmd.nonce
+  ; valid_until= user_cmd.valid_until
+  ; memo= user_cmd.memo }
+
+let body_of_user_cmd (user_cmd : Extensional.User_command.t) =
+  let payload =
+    { source_pk= user_cmd.source
+    ; receiver_pk= user_cmd.receiver
+    ; token_id= user_cmd.token
+    ; amount= user_cmd.amount }
+  in
+  match user_cmd.typ with
+  | "payment" ->
+      Payment payload
+  | "delegation" ->
+      Stake_delegation payload
+  | "create_token" ->
+      Create_new_token payload
+  | "create_account" ->
+      Create_token_account payload
+  | "mint_tokens" ->
+      Mint_tokens payload
+  | cmd ->
+      failwithf "Unknown user command \"%s\"" cmd ()
+
+let payload_of_user_cmd user_cmd =
+  {common= common_of_user_cmd user_cmd; body= body_of_user_cmd user_cmd}
+
+let status_of_user_cmd (user_cmd : Extensional.User_command.t) =
+  let open Transaction_status in
+  (* balance data here is always empty, it's a dummy value
+     that data doesn't appear in archive db
+     this way, we can use the existing type Transaction_status.t
+  *)
+  match user_cmd.status with
+  | None ->
+      None
+  | Some "applied" ->
+      Some
+        (Applied
+           ( { fee_payer_account_creation_fee_paid=
+                 user_cmd.fee_payer_account_creation_fee_paid
+             ; receiver_account_creation_fee_paid=
+                 user_cmd.receiver_account_creation_fee_paid
+             ; created_token= user_cmd.created_token }
+           , Balance_data.empty ))
+  | Some "failed" -> (
+    match user_cmd.failure_reason with
+    | Some reason ->
+        Some (Failed (reason, Balance_data.empty))
+    | None ->
+        failwith "Failed user command status, no reason given" )
+  | Some s ->
+      failwithf "Unexpected user command status \"%s\"" s ()
+
+let signed_cmd_with_status_of_user_cmd (user_cmd : Extensional.User_command.t)
+    =
+  { With_opt_status.data= Signed_command {payload= payload_of_user_cmd user_cmd}
+  ; status= status_of_user_cmd user_cmd }
+
+let user_commands_of_extensional_block (block : Extensional.Block.t) =
+  let user_cmds = State_hash.Table.find_exn user_cmds_tbl block.state_hash in
+  List.map user_cmds ~f:signed_cmd_with_status_of_user_cmd
+
+let internal_cmd_balance_data_of_internal_cmd
+    (internal_cmd : Extensional.Internal_command.t) =
+  let open Transaction_status.Internal_command_balance_data in
+  match internal_cmd.typ with
+  | "coinbase" ->
+      (* TODO: add fee transfer via coinbase here, when balances available
+       use Fee_transfer_via_coinbase.Table.find on global slot, seq no, secondary seq no
+    *)
+      (* TODO: add valid balances when they're available in archive db *)
+      Some
+        (Coinbase
+           { coinbase_receiver_balance= Currency.Balance.zero
+           ; fee_transfer_receiver_balance= None })
+  | "fee_transfer" ->
+      (* TODO: add valid balances when they're available in archive db *)
+      Some
+        (Fee_transfer
+           {receiver1_balance= Currency.Balance.zero; receiver2_balance= None})
+  | "fee_transfer_via_coinbase" ->
+      (* these are combined into a coinbase *)
+      None
+  | cmd ->
+      failwithf "Unknown internal command: %s" cmd ()
+
+let internal_commands_of_extensional_block (block : Extensional.Block.t) =
+  let internal_cmds =
+    State_hash.Table.find_exn internal_cmds_tbl block.state_hash
+  in
+  List.map internal_cmds ~f:internal_cmd_balance_data_of_internal_cmd
+
+let diff_commands_of_extensional_block block =
+  { commands= user_commands_of_extensional_block block
+  ; internal_command_balances=
+      List.filter_opt (internal_commands_of_extensional_block block) }
+
+let staged_ledger_diff_of_extensional_block block =
+  {diff= diff_commands_of_extensional_block block}
+
+let block_of_extensional_block (block : Extensional.Block.t) : t =
+  let state_hash = block.state_hash in
+  let ledger_hash = block.ledger_hash in
+  let protocol_state = protocol_state_of_extensional_block block in
+  let staged_ledger_diff = staged_ledger_diff_of_extensional_block block in
+  {state_hash; ledger_hash; protocol_state; staged_ledger_diff}

--- a/src/app/missing_subchain/dune
+++ b/src/app/missing_subchain/dune
@@ -15,4 +15,4 @@
    mina_base)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_coda ppx_let)))
+ (preprocess (pps ppx_version ppx_coda ppx_let ppx_hash ppx_compare ppx_sexp_conv)))

--- a/src/app/missing_subchain/missing_subchain.ml
+++ b/src/app/missing_subchain/missing_subchain.ml
@@ -4,89 +4,36 @@ open Core_kernel
 open Async
 open Mina_base
 open Signature_lib
+open Archive_lib
 
-(* the `blocks` table in the archive db uses foreign keys to refer to other
-   tables; the type here fills in the data from those other tables, using
-   their native OCaml types to assure the validity of the data
-*)
+let query_db pool ~f ~item =
+  match%bind Caqti_async.Pool.use f pool with
+  | Ok v ->
+      return v
+  | Error msg ->
+      failwithf "Error getting %s from db, error: %s" item
+        (Caqti_error.show msg) ()
 
-module Extensional_block = struct
-  type t =
-    { state_hash: State_hash.t
-    ; parent_hash: State_hash.t
-    ; creator: Public_key.Compressed.t
-    ; block_winner: Public_key.Compressed.t
-    ; snarked_ledger_hash: Frozen_ledger_hash.t
-    ; staking_epoch_seed: Epoch_seed.t
-    ; staking_epoch_ledger_hash: Frozen_ledger_hash.t
-    ; next_epoch_seed: Epoch_seed.t
-    ; next_epoch_ledger_hash: Frozen_ledger_hash.t
-    ; ledger_hash: Ledger_hash.t
-    ; height: Unsigned.UInt32.t
-    ; global_slot: Mina_numbers.Global_slot.t
-    ; global_slot_since_genesis: Mina_numbers.Global_slot.t
-    ; timestamp: Block_time.t }
-end
-
-module type Base58_decodable = sig
-  type t
-
-  val of_base58_check : string -> t Or_error.t
-end
-
-let fill_in_block ~logger pool (block : Archive_lib.Processor.Block.t) :
-    Extensional_block.t Deferred.t =
-  let query_db ~f ~item =
-    match%bind Caqti_async.Pool.use f pool with
-    | Ok v ->
-        return v
-    | Error msg ->
-        [%log error] "Error getting %s from db" item
-          ~metadata:[("error", `String (Caqti_error.show msg))] ;
-        exit 1
-  in
-  let mk_of_base58_check (type t) (module M : Base58_decodable with type t = t)
-      desc item : t =
-    match M.of_base58_check item with
-    | Ok v ->
-        v
-    | Error err ->
-        [%log error] "Error decoding Base58Check %s" desc
-          ~metadata:
-            [ ("base58_check", `String item)
-            ; ("error", Error_json.error_to_yojson err) ] ;
-        Core.exit 1
-  in
-  let state_hash_of_base58_check =
-    mk_of_base58_check (module State_hash) "state hash"
-  in
-  let frozen_ledger_hash_of_base58_check =
-    mk_of_base58_check (module Frozen_ledger_hash) "frozen ledger hash"
-  in
-  let public_key_of_base58_check =
-    mk_of_base58_check (module Public_key.Compressed) "public key compressed"
-  in
-  let epoch_seed_of_base58_check =
-    mk_of_base58_check (module Epoch_seed) "epoch seed"
-  in
-  let ledger_hash_of_base58_check =
-    mk_of_base58_check (module Ledger_hash) "ledger hash"
-  in
-  let state_hash = state_hash_of_base58_check block.state_hash in
-  let parent_hash = state_hash_of_base58_check block.parent_hash in
+let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
+    Extensional.Block.t Deferred.t =
+  let query_db ~item ~f = query_db pool ~item ~f in
+  let state_hash = State_hash.of_base58_check_exn block.state_hash in
+  let parent_hash = State_hash.of_base58_check_exn block.parent_hash in
   let open Deferred.Let_syntax in
   let%bind creator_str =
     query_db
       ~f:(fun db -> Sql.Public_key.run db block.creator_id)
       ~item:"creator public key"
   in
-  let creator = public_key_of_base58_check creator_str in
+  let creator = Public_key.Compressed.of_base58_check_exn creator_str in
   let%bind block_winner_str =
     query_db
       ~f:(fun db -> Sql.Public_key.run db block.creator_id)
       ~item:"block winner public key"
   in
-  let block_winner = public_key_of_base58_check block_winner_str in
+  let block_winner =
+    Public_key.Compressed.of_base58_check_exn block_winner_str
+  in
   let%bind snarked_ledger_hash_str =
     query_db
       ~f:(fun db ->
@@ -94,14 +41,16 @@ let fill_in_block ~logger pool (block : Archive_lib.Processor.Block.t) :
       ~item:"snarked ledger hash"
   in
   let snarked_ledger_hash =
-    frozen_ledger_hash_of_base58_check snarked_ledger_hash_str
+    Frozen_ledger_hash.of_base58_check_exn snarked_ledger_hash_str
   in
   let%bind staking_epoch_seed_str, staking_epoch_ledger_hash_id =
     query_db
       ~f:(fun db -> Sql.Epoch_data.run db block.staking_epoch_data_id)
       ~item:"staking epoch data"
   in
-  let staking_epoch_seed = epoch_seed_of_base58_check staking_epoch_seed_str in
+  let staking_epoch_seed =
+    Epoch_seed.of_base58_check_exn staking_epoch_seed_str
+  in
   let%bind staking_epoch_ledger_hash_str =
     query_db
       ~f:(fun db ->
@@ -109,23 +58,23 @@ let fill_in_block ~logger pool (block : Archive_lib.Processor.Block.t) :
       ~item:"staking epoch ledger hash"
   in
   let staking_epoch_ledger_hash =
-    frozen_ledger_hash_of_base58_check staking_epoch_ledger_hash_str
+    Frozen_ledger_hash.of_base58_check_exn staking_epoch_ledger_hash_str
   in
   let%bind next_epoch_seed_str, next_epoch_ledger_hash_id =
     query_db
       ~f:(fun db -> Sql.Epoch_data.run db block.staking_epoch_data_id)
       ~item:"staking epoch data"
   in
-  let next_epoch_seed = epoch_seed_of_base58_check next_epoch_seed_str in
+  let next_epoch_seed = Epoch_seed.of_base58_check_exn next_epoch_seed_str in
   let%bind next_epoch_ledger_hash_str =
     query_db
       ~f:(fun db -> Sql.Snarked_ledger_hashes.run db next_epoch_ledger_hash_id)
       ~item:"next epoch ledger hash"
   in
   let next_epoch_ledger_hash =
-    frozen_ledger_hash_of_base58_check next_epoch_ledger_hash_str
+    Frozen_ledger_hash.of_base58_check_exn next_epoch_ledger_hash_str
   in
-  let ledger_hash = ledger_hash_of_base58_check block.ledger_hash in
+  let ledger_hash = Ledger_hash.of_base58_check_exn block.ledger_hash in
   let height = Unsigned.UInt32.of_int64 block.height in
   let global_slot = Unsigned.UInt32.of_int64 block.global_slot in
   let global_slot_since_genesis =
@@ -133,7 +82,7 @@ let fill_in_block ~logger pool (block : Archive_lib.Processor.Block.t) :
   in
   let timestamp = Block_time.of_int64 block.timestamp in
   return
-    { Extensional_block.state_hash
+    { Extensional.Block.state_hash
     ; parent_hash
     ; creator
     ; block_winner
@@ -148,7 +97,156 @@ let fill_in_block ~logger pool (block : Archive_lib.Processor.Block.t) :
     ; global_slot_since_genesis
     ; timestamp }
 
-let main ~archive_uri ~state_hash () =
+let fill_in_user_command pool block_state_hash =
+  let query_db ~item ~f = query_db pool ~item ~f in
+  let pk_of_id id ~item =
+    let%map pk_str = query_db ~f:(fun db -> Sql.Public_key.run db id) ~item in
+    Public_key.Compressed.of_base58_check_exn pk_str
+  in
+  let open Deferred.Let_syntax in
+  let%bind block_id =
+    query_db ~item:"blocks" ~f:(fun db ->
+        Processor.Block.find db ~state_hash:block_state_hash )
+  in
+  let%bind user_command_ids_and_sequence_nos =
+    query_db ~item:"user command id, sequence no" ~f:(fun db ->
+        Sql.Blocks_and_user_commands.run db ~block_id )
+  in
+  (* create extensional user command for each id, seq no *)
+  Deferred.List.map user_command_ids_and_sequence_nos
+    ~f:(fun (user_cmd_id, sequence_no) ->
+      let%bind user_cmd =
+        query_db ~item:"blocks user commands" ~f:(fun db ->
+            Processor.User_command.Signed_command.load db ~id:user_cmd_id )
+      in
+      let typ = user_cmd.typ in
+      let%bind fee_payer = pk_of_id ~item:"fee payer" user_cmd.fee_payer_id in
+      let%bind source = pk_of_id ~item:"source" user_cmd.source_id in
+      let%bind receiver = pk_of_id ~item:"receiver" user_cmd.receiver_id in
+      let fee_token =
+        user_cmd.fee_token |> Unsigned.UInt64.of_int64 |> Token_id.of_uint64
+      in
+      let token =
+        user_cmd.token |> Unsigned.UInt64.of_int64 |> Token_id.of_uint64
+      in
+      let nonce = user_cmd.nonce |> Account.Nonce.of_int in
+      let amount =
+        Option.map user_cmd.amount ~f:(fun amt ->
+            Unsigned.UInt64.of_int64 amt |> Currency.Amount.of_uint64 )
+      in
+      let fee =
+        user_cmd.fee |> Unsigned.UInt64.of_int64 |> Currency.Fee.of_uint64
+      in
+      let valid_until =
+        Option.map user_cmd.valid_until ~f:(fun valid ->
+            Unsigned.UInt32.of_int64 valid
+            |> Mina_numbers.Global_slot.of_uint32 )
+      in
+      let memo = user_cmd.memo |> Signed_command_memo.of_string in
+      let hash = user_cmd.hash |> Transaction_hash.of_base58_check_exn in
+      let status = user_cmd.status in
+      let failure_reason =
+        Option.map user_cmd.failure_reason ~f:(fun s ->
+            match Transaction_status.Failure.of_string s with
+            | Ok fail ->
+                fail
+            | Error err ->
+                failwithf "Not a transaction status failure: %s, error: %s" s
+                  err () )
+      in
+      let fee_payer_account_creation_fee_paid =
+        Option.map user_cmd.fee_payer_account_creation_fee_paid ~f:(fun amt ->
+            Unsigned.UInt64.of_int64 amt |> Currency.Amount.of_uint64 )
+      in
+      let receiver_account_creation_fee_paid =
+        Option.map user_cmd.receiver_account_creation_fee_paid ~f:(fun amt ->
+            Unsigned.UInt64.of_int64 amt |> Currency.Amount.of_uint64 )
+      in
+      let created_token =
+        Option.map user_cmd.created_token ~f:(fun tok ->
+            Unsigned.UInt64.of_int64 tok |> Token_id.of_uint64 )
+      in
+      return
+        { Extensional.User_command.sequence_no
+        ; block_state_hash
+        ; typ
+        ; fee_payer
+        ; source
+        ; receiver
+        ; fee_token
+        ; token
+        ; nonce
+        ; amount
+        ; fee
+        ; valid_until
+        ; memo
+        ; hash
+        ; status
+        ; failure_reason
+        ; fee_payer_account_creation_fee_paid
+        ; receiver_account_creation_fee_paid
+        ; created_token } )
+
+let fill_in_internal_command pool block_state_hash =
+  let query_db ~item ~f = query_db pool ~item ~f in
+  let pk_of_id id ~item =
+    let%map pk_str = query_db ~f:(fun db -> Sql.Public_key.run db id) ~item in
+    Public_key.Compressed.of_base58_check_exn pk_str
+  in
+  let open Deferred.Let_syntax in
+  let%bind block_id =
+    query_db ~item:"blocks" ~f:(fun db ->
+        Processor.Block.find db ~state_hash:block_state_hash )
+  in
+  let%bind internal_cmd_info =
+    query_db
+      ~item:
+        "internal command id, global_slot, sequence no, secondary sequence no"
+      ~f:(fun db -> Sql.Blocks_and_internal_commands.run db ~block_id)
+  in
+  Deferred.List.map internal_cmd_info
+    ~f:(fun (internal_cmd_id, global_slot, sequence_no, secondary_sequence_no)
+       ->
+      let%bind internal_cmd =
+        query_db ~item:"blocks internal commands" ~f:(fun db ->
+            Processor.Internal_command.load db ~id:internal_cmd_id )
+      in
+      let typ = internal_cmd.typ in
+      let%bind receiver = pk_of_id ~item:"receiver" internal_cmd.receiver_id in
+      let fee =
+        internal_cmd.fee |> Unsigned.UInt64.of_int64
+        |> Currency.Amount.of_uint64
+      in
+      let token =
+        internal_cmd.token |> Unsigned.UInt64.of_int64 |> Token_id.of_uint64
+      in
+      let hash = internal_cmd.hash |> Transaction_hash.of_base58_check_exn in
+      let cmd =
+        { Extensional.Internal_command.global_slot
+        ; sequence_no
+        ; secondary_sequence_no
+        ; typ
+        ; receiver
+        ; fee
+        ; token
+        ; hash }
+      in
+      ( if String.equal cmd.typ "fee_transfer_via_coinbase" then
+        match
+          Block.Fee_transfer_via_coinbase.Table.add Block.fee_transfer_tbl
+            ~key:(cmd.global_slot, cmd.sequence_no, cmd.secondary_sequence_no)
+            ~data:cmd
+        with
+        | `Ok ->
+            ()
+        | `Duplicate ->
+            failwithf
+              "Duplicate fee transfer via coinbase at global slot = %Ld, \
+               sequence no = %d, secondary sequence no = %d"
+              cmd.global_slot cmd.sequence_no cmd.secondary_sequence_no () ) ;
+      return cmd )
+
+let main ~archive_uri ~output_file ~state_hash () =
   let logger = Logger.create () in
   let archive_uri = Uri.of_string archive_uri in
   (* sanity-check input state hash *)
@@ -169,52 +267,63 @@ let main ~archive_uri ~state_hash () =
       [%log info] "Successfully created Caqti pool for Postgresql" ;
       [%log info] "Querying for subchain to block with given state hash" ;
       let%bind blocks =
-        match%bind
-          Caqti_async.Pool.use (fun db -> Sql.Subchain.run db state_hash) pool
-        with
-        | Ok blocks ->
-            return blocks
-        | Error msg ->
-            [%log error] "Error getting blocks in subchain"
-              ~metadata:[("error", `String (Caqti_error.show msg))] ;
-            exit 1
+        query_db pool
+          ~f:(fun db -> Sql.Subchain.run db state_hash)
+          ~item:"blocks"
       in
       if List.is_empty blocks then (
         [%log error]
           "No subchain available from genesis block to block with given state \
            hash" ;
         Core.exit 1 ) ;
-      let%map extensional_blocks =
-        Deferred.List.map blocks ~f:(fill_in_block ~logger pool)
-      in
-      let sorted_extensional_blocks =
-        List.dedup_and_sort extensional_blocks
-          ~compare:(fun (b1 : Extensional_block.t) b2 ->
-            Unsigned.UInt32.compare b1.global_slot b2.global_slot )
+      let%bind extensional_blocks =
+        Deferred.List.map blocks ~f:(fill_in_block pool)
       in
       [%log info] "Found a subchain of length %d"
-        (List.length sorted_extensional_blocks) ;
-      List.iter sorted_extensional_blocks ~f:(fun block ->
-          [%log info] "Block contents"
-            ~metadata:
-              [ ("state_hash", State_hash.to_yojson block.state_hash)
-              ; ("parent_hash", State_hash.to_yojson block.parent_hash)
-              ; ("creator", Public_key.Compressed.to_yojson block.creator)
-              ; ( "snarked_ledger_hash"
-                , Frozen_ledger_hash.to_yojson block.snarked_ledger_hash )
-              ; ( "staking_epoch_seed"
-                , Epoch_seed.to_yojson block.staking_epoch_seed )
-              ; ( "staking_epoch_ledger_hash"
-                , Frozen_ledger_hash.to_yojson block.staking_epoch_ledger_hash
-                )
-              ; ("next_epoch_data", Epoch_seed.to_yojson block.next_epoch_seed)
-              ; ( "next_epoch_ledger_hash"
-                , Frozen_ledger_hash.to_yojson block.next_epoch_ledger_hash )
-              ; ("ledger_hash", Ledger_hash.to_yojson block.ledger_hash)
-              ; ("height", Unsigned_extended.UInt32.to_yojson block.height)
-              ; ( "global_slot"
-                , Mina_numbers.Global_slot.to_yojson block.global_slot )
-              ; ("timestamp", Block_time.to_yojson block.timestamp) ] ) ;
+        (List.length extensional_blocks) ;
+      [%log info] "Querying for user commands in blocks" ;
+      let%bind () =
+        Deferred.List.iter extensional_blocks ~f:(fun block ->
+            let%map user_cmds = fill_in_user_command pool block.state_hash in
+            match
+              State_hash.Table.add Block.user_cmds_tbl ~key:block.state_hash
+                ~data:user_cmds
+            with
+            | `Ok ->
+                ()
+            | `Duplicate ->
+                [%log error] "Duplicate entry in user commands table"
+                  ~metadata:
+                    [("state_hash", State_hash.to_yojson block.state_hash)] ;
+                Core.exit 1 )
+      in
+      [%log info] "Querying for internal commands in blocks" ;
+      let%bind () =
+        Deferred.List.iter extensional_blocks ~f:(fun block ->
+            let%map internal_cmds =
+              fill_in_internal_command pool block.state_hash
+            in
+            match
+              State_hash.Table.add Block.internal_cmds_tbl
+                ~key:block.state_hash ~data:internal_cmds
+            with
+            | `Ok ->
+                ()
+            | `Duplicate ->
+                [%log error] "Duplicate entry in internal commands table"
+                  ~metadata:
+                    [("state_hash", State_hash.to_yojson block.state_hash)] ;
+                Core.exit 1 )
+      in
+      let blocks =
+        List.map extensional_blocks ~f:Block.block_of_extensional_block
+      in
+      [%log info] "Writing blocks to $output_file"
+        ~metadata:[("output_file", `String output_file)] ;
+      let%map writer = Async_unix.Writer.open_file output_file in
+      List.iter blocks ~f:(fun block ->
+          Async.fprintf writer "%s\n%!"
+            (Block.to_yojson block |> Yojson.Safe.to_string) ) ;
       ()
 
 let () =
@@ -231,6 +340,10 @@ let () =
                "URI URI for connecting to the archive database (e.g., \
                 postgres://$USER:$USER@localhost:5432/archiver)"
              Param.(required string)
+         and output_file =
+           Param.flag "--output-file"
+             ~doc:"Output file for the blocks, in JSON format"
+             Param.(required string)
          and state_hash =
            Param.flag "--state-hash"
              ~doc:
@@ -238,4 +351,4 @@ let () =
                 block"
              Param.(required string)
          in
-         main ~archive_uri ~state_hash)))
+         main ~archive_uri ~output_file ~state_hash)))

--- a/src/app/missing_subchain/sql.ml
+++ b/src/app/missing_subchain/sql.ml
@@ -57,3 +57,33 @@ module Epoch_data = struct
 
   let run (module Conn : Caqti_async.CONNECTION) id = Conn.find query id
 end
+
+module Blocks_and_user_commands = struct
+  let query =
+    Caqti_request.collect Caqti_type.int
+      Caqti_type.(tup2 int int)
+      {| SELECT user_command_id, sequence_no
+       FROM blocks_user_commands
+       WHERE block_id = ?
+    |}
+
+  let run (module Conn : Caqti_async.CONNECTION) ~block_id =
+    Conn.collect_list query block_id
+end
+
+module Blocks_and_internal_commands = struct
+  let query =
+    Caqti_request.collect Caqti_type.int
+      Caqti_type.(tup4 int int64 int int)
+      {| SELECT internal_command_id, global_slot, sequence_no, secondary_sequence_no
+       FROM (blocks_internal_commands
+             INNER JOIN blocks
+             ON blocks.id = blocks_internal_commands.block_id)
+       WHERE block_id = ?
+    |}
+
+  let run (module Conn : Caqti_async.CONNECTION) ~block_id =
+    Conn.collect_list query block_id
+end
+
+module Internal_commands = struct end

--- a/src/app/missing_subchain/sql.ml
+++ b/src/app/missing_subchain/sql.ml
@@ -85,5 +85,3 @@ module Blocks_and_internal_commands = struct
   let run (module Conn : Caqti_async.CONNECTION) ~block_id =
     Conn.collect_list query block_id
 end
-
-module Internal_commands = struct end

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -411,7 +411,7 @@ WITH RECURSIVE chain AS (
           in
           { Internal_command_info.kind
           ; receiver= Internal_commands.Extras.receiver extras
-          ; fee= Unsigned.UInt64.of_int ic.fee
+          ; fee= Unsigned.UInt64.of_int64 ic.fee
           ; token= Unsigned.UInt64.of_int64 ic.token
           ; hash= ic.hash } )
     in


### PR DESCRIPTION
Add transactions to output of missing subchains tool. The output is now in JSON format; each line of output is a JSON object representing a block.

The output is meant to be the same as the block logging format, eliding the data not available in an archive db. Two additional fields are added, a state hash and a ledger hash, because those are needed to put in the archive database. The idea is to have a single ingestor program that can take this output, or the logged blocks, and update an archive db.

For internal commands, the balances are dummy values for now, until that data becomes available in the archive db. There are TODOs in the code for this task, and I'll add an issue.

Tested by running on an archive db created with Rosetta and examining the output JSON.

Closes #7239.