### PR TITLE
update helm chart Mina logo/icon metadata

### DIFF
--- a/frontend/bot/helm/Chart.yaml
+++ b/frontend/bot/helm/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Coda Protocol's O(1) role-based testnet service bo
 type: application
 version: 0.0.2
 appVersion: 0.0.1
-icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/static/img/coda-logo@3x.png
+icon: https://storage.googleapis.com/coda-charts/Mina_Icon_Secondary_RGB_Black.png
 keywords:
 - bot
 - faucet

--- a/frontend/leaderboard/helm/Chart.yaml
+++ b/frontend/leaderboard/helm/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Coda Protocol's Testnet leaderboard service
 type: application
 version: 0.1.9
 appVersion: 1.16.0
-icon: https://github.com/CodaProtocol/coda/blob/develop/frontend/website/public/static/img/coda-logo@3x.png
+icon: https://storage.googleapis.com/coda-charts/Mina_Icon_Secondary_RGB_Black.png
 keywords:
 - coda protocol
 - testnet

--- a/helm/archive-node/Chart.yaml
+++ b/helm/archive-node/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
   - name: common-utilities
     version: 0.0.7
     repository: "https://coda-charts.storage.googleapis.com"
-icon: https://github.com/MinaProtocol/mina/blob/develop/frontend/website/public/static/img/coda-logo@3x.png
+icon: https://storage.googleapis.com/coda-charts/Mina_Icon_Secondary_RGB_Black.png
 keywords:
 - archive
 - postgres

--- a/helm/block-producer/Chart.yaml
+++ b/helm/block-producer/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - name: common-utilities
     version: 0.0.7
     repository: "https://coda-charts.storage.googleapis.com"
-icon: https://github.com/MinaProtocol/mina/blob/develop/frontend/website/public/static/img/coda-logo@3x.png
+icon: https://storage.googleapis.com/coda-charts/Mina_Icon_Secondary_RGB_Black.png
 keywords:
 - block-producer
 - stake

--- a/helm/common/Chart.yaml
+++ b/helm/common/Chart.yaml
@@ -5,7 +5,7 @@ type: library
 version: 0.0.7
 appVersion: 0.0.1
 dependencies:
-icon:
+icon: https://storage.googleapis.com/coda-charts/Mina_Icon_Secondary_RGB_Black.png
 keywords:
 - mina
 - testnet

--- a/helm/seed-node/Chart.yaml
+++ b/helm/seed-node/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - name: common-utilities
     version: 0.0.7
     repository: "https://coda-charts.storage.googleapis.com"
-icon: https://github.com/MinaProtocol/mina/blob/develop/frontend/website/public/static/img/coda-logo@3x.png
+icon: https://storage.googleapis.com/coda-charts/Mina_Icon_Secondary_RGB_Black.png
 keywords:
 - seed
 - mina

--- a/helm/snark-worker/Chart.yaml
+++ b/helm/snark-worker/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - name: common-utilities
     version: 0.0.7
     repository: "https://coda-charts.storage.googleapis.com"
-icon: https://github.com/MinaProtocol/mina/blob/develop/frontend/website/public/static/img/coda-logo@3x.png
+icon: https://storage.googleapis.com/coda-charts/Mina_Icon_Secondary_RGB_Black.png
 keywords:
 - snarks
 - zero-knowledge


### PR DESCRIPTION
Update Helm chart logos from non-existent repo image file to official Mina logo and make it publicly accessible from the GCS `coda/mina-charts` repo.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
