### PR TITLE
Fix transaction replacements

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -78,7 +78,10 @@ type pipes =
               * Network_pool.Transaction_pool.Resource_pool.Diff.Rejected.t )
               Or_error.t
            -> unit)
-        * (Account_id.t -> (Mina_base.Account.Nonce.t, string) Result.t)
+        * (   Account_id.t
+           -> ( [`Min of Mina_base.Account.Nonce.t] * Mina_base.Account.Nonce.t
+              , string )
+              Result.t)
       , Strict_pipe.synchronous
       , unit Deferred.t )
       Strict_pipe.Writer.t
@@ -459,15 +462,15 @@ let get_ledger t state_hash_opt =
       Deferred.Or_error.error_string
         "get_ledger: state hash not found in transition frontier"
 
+let get_account t aid =
+  let open Participating_state.Let_syntax in
+  let%map ledger = best_ledger t in
+  let open Option.Let_syntax in
+  let%bind loc = Ledger.location_of_account ledger aid in
+  Ledger.get ledger loc
+
 let get_inferred_nonce_from_transaction_pool_and_ledger t
     (account_id : Account_id.t) =
-  let get_account aid =
-    let open Participating_state.Let_syntax in
-    let%map ledger = best_ledger t in
-    let open Option.Let_syntax in
-    let%bind loc = Ledger.location_of_account ledger aid in
-    Ledger.get ledger loc
-  in
   let transaction_pool = t.components.transaction_pool in
   let resource_pool =
     Network_pool.Transaction_pool.resource_pool transaction_pool
@@ -491,7 +494,7 @@ let get_inferred_nonce_from_transaction_pool_and_ledger t
       Participating_state.Option.return (Account.Nonce.succ nonce)
   | None ->
       let open Participating_state.Option.Let_syntax in
-      let%map account = get_account account_id in
+      let%map account = get_account t account_id in
       account.Account.Poly.nonce
 
 let snark_job_state t = t.snark_job_state
@@ -687,7 +690,14 @@ let add_transactions t (uc_inputs : User_command_input.t list) =
            `sender` is not in the ledger or sent a transaction in transaction \
            pool."
     | Some nonce ->
-        Ok nonce
+        let ledger_nonce =
+          Participating_state.active (get_account t aid)
+          |> Option.join
+          |> Option.map ~f:(fun {Account.Poly.nonce; _} ->
+                 Mina_numbers.Account_nonce.succ nonce )
+          |> Option.value ~default:nonce
+        in
+        Ok (`Min ledger_nonce, nonce)
   in
   Strict_pipe.Writer.write t.pipes.user_command_input_writer
     (uc_inputs, Ivar.fill result_ivar, get_current_nonce)

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -779,7 +779,7 @@ let rec add_from_gossip_exn :
         ; consensus_constants
         ; time_controller }
       , Sequence.empty )
-  | Some (queued_cmds, reserved_currency) -> (
+  | Some (queued_cmds, reserved_currency) ->
       (* commands queued for this sender *)
       assert (not @@ F_sequence.is_empty queued_cmds) ;
       let last_queued_nonce =
@@ -860,20 +860,6 @@ let rec add_from_gossip_exn :
             ~error:(Insufficient_replace_fee (`Replace_fee replace_fee, fee))
           (* C3 *)
         in
-        let increment =
-          Option.value_exn Currency.Fee.(fee - User_command.fee_exn to_drop)
-        in
-        let%bind () =
-          let replace_fee =
-            Option.value_exn
-              (Currency.Fee.scale replace_fee (F_sequence.length drop_queue))
-          in
-          Result.ok_if_true
-            Currency.Fee.(increment >= replace_fee)
-            ~error:
-              (Insufficient_replace_fee (`Replace_fee replace_fee, increment))
-          (* C3 *)
-        in
         let dropped, t' =
           remove_with_dependents_exn t @@ F_sequence.head_exn drop_queue
         in
@@ -882,15 +868,75 @@ let rec add_from_gossip_exn :
           Transaction_hash.User_command_with_valid_signature.t Sequence.t]
           dropped
           (F_sequence.to_seq drop_queue) ;
-        match add_from_gossip_exn t' ~verify cmd0 current_nonce balance with
-        | Ok (v, t'', dropped') ->
-            (* We've already removed them, so this should always be empty. *)
-            assert (Sequence.is_empty dropped') ;
-            Result.Ok (v, t'', dropped)
-        | Error (Insufficient_funds _ as err) ->
-            Error err (* C2 *)
-        | _ ->
-            failwith "recursive add_exn failed" )
+        (* Add the new transaction *)
+        let%bind cmd, t'', _ =
+          match add_from_gossip_exn t' ~verify cmd0 current_nonce balance with
+          | Ok (v, t'', dropped') ->
+              (* We've already removed them, so this should always be empty. *)
+              assert (Sequence.is_empty dropped') ;
+              Result.Ok (v, t'', dropped)
+          | Error (Insufficient_funds _ as err) ->
+              Error err (* C2 *)
+          | _ ->
+              failwith "recursive add_exn failed"
+        in
+        let drop_head, drop_tail =
+          Option.value_exn (Sequence.next dropped)
+        in
+        let increment =
+          Option.value_exn Currency.Fee.(fee - User_command.fee_exn to_drop)
+        in
+        (* Re-add all of the transactions we dropped until there are none left,
+           or until the fees from dropped transactions exceed the fee increase
+           over the first transaction.
+        *)
+        let%bind t'', increment, dropped' =
+          let rec go t' increment dropped dropped' current_nonce =
+            match (Sequence.next dropped, dropped') with
+            | None, Some dropped' ->
+                Ok (t', increment, dropped')
+            | None, None ->
+                Ok (t', increment, Sequence.empty)
+            | Some (cmd, dropped), Some _ -> (
+                let cmd_unchecked =
+                  Transaction_hash.User_command_with_valid_signature.command
+                    cmd
+                in
+                let replace_fee = User_command.fee_exn cmd_unchecked in
+                match Currency.Fee.(increment - replace_fee) with
+                | Some increment ->
+                    go t' increment dropped dropped' current_nonce
+                | None ->
+                    Error
+                      (Insufficient_replace_fee
+                         (`Replace_fee replace_fee, increment)) )
+            | Some (cmd, dropped'), None -> (
+                let current_nonce = Account_nonce.succ current_nonce in
+                match
+                  add_from_gossip_exn t' ~verify (`Checked cmd) current_nonce
+                    balance
+                with
+                | Ok (_v, t', dropped_) ->
+                    assert (Sequence.is_empty dropped_) ;
+                    go t' increment dropped' None current_nonce
+                | Error (Insufficient_funds _) ->
+                    (* Re-evaluate with the same [dropped] to calculate the new
+                       fee increment.
+                    *)
+                    go t' increment dropped (Some dropped') current_nonce
+                | _ ->
+                    failwith "recursive add_exn failed" )
+          in
+          go t'' increment drop_tail None current_nonce
+        in
+        let%map () =
+          Result.ok_if_true
+            Currency.Fee.(increment >= replace_fee)
+            ~error:
+              (Insufficient_replace_fee (`Replace_fee replace_fee, increment))
+          (* C3 *)
+        in
+        (cmd, t'', Sequence.(append (return drop_head) dropped'))
 
 let add_from_backtrack :
        t

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -880,9 +880,7 @@ let rec add_from_gossip_exn :
           | _ ->
               failwith "recursive add_exn failed"
         in
-        let drop_head, drop_tail =
-          Option.value_exn (Sequence.next dropped)
-        in
+        let drop_head, drop_tail = Option.value_exn (Sequence.next dropped) in
         let increment =
           Option.value_exn Currency.Fee.(fee - User_command.fee_exn to_drop)
         in

--- a/src/lib/user_command_input/user_command_input.mli
+++ b/src/lib/user_command_input/user_command_input.mli
@@ -68,13 +68,20 @@ val create :
   -> t
 
 val to_user_command :
-     ?nonce_map:Account.Nonce.t Account_id.Map.t
-  -> get_current_nonce:(Account_id.t -> (Account_nonce.t, string) Result.t)
+     ?nonce_map:(Account.Nonce.t * Account.Nonce.t) Account_id.Map.t
+  -> get_current_nonce:(   Account_id.t
+                        -> ( [`Min of Account_nonce.t] * Account_nonce.t
+                           , string )
+                           Result.t)
   -> t
-  -> (Signed_command.t * Account.Nonce.t Account_id.Map.t) Deferred.Or_error.t
+  -> (Signed_command.t * (Account.Nonce.t * Account.Nonce.t) Account_id.Map.t)
+     Deferred.Or_error.t
 
 val to_user_commands :
-     ?nonce_map:Account.Nonce.t Account_id.Map.t
-  -> get_current_nonce:(Account_id.t -> (Account_nonce.t, string) Result.t)
+     ?nonce_map:(Account.Nonce.t * Account.Nonce.t) Account_id.Map.t
+  -> get_current_nonce:(   Account_id.t
+                        -> ( [`Min of Account_nonce.t] * Account_nonce.t
+                           , string )
+                           Result.t)
   -> t list
   -> Signed_command.t list Deferred.Or_error.t


### PR DESCRIPTION
This PR
* prevents transaction replacement from evicting transactions other than the one with the matching nonce
  - if the replacement increases costs by more than is left in the account, some later transactions will be dropped
  - if it is less profitable to include the new transaction because of later transactions that would be dropped, it is rejected
* sets a constant replacement fee at `0.5` mina
* allows the nonces of `User_command_input.t`s to take any value in the range `ledger_nonce+1...txn_pool_nonce+1`

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #6605