### PR TITLE
Retry archive RPCs

### DIFF
--- a/src/lib/mina_lib/archive_client.ml
+++ b/src/lib/mina_lib/archive_client.ml
@@ -3,39 +3,62 @@ open Async_kernel
 open Pipe_lib
 open O1trace
 
-let dispatch (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
-    diff =
-  match%map
-    Daemon_rpcs.Client.dispatch Archive_lib.Rpc.t diff archive_location.value
-  with
-  | Ok () ->
-      Ok ()
-  | Error e ->
-      Error
-        (Error.tag_arg e
-           "Could not send data to archive process. It may not be running, \
-            please check the daemon-argument"
-           ( ("host_and_port", archive_location.value)
-           , ("daemon-argument", archive_location.name) )
-           [%sexp_of: (string * Host_and_port.t) * (string * string)])
+let dispatch ?(max_tries = 5)
+    (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name) diff =
+  let rec go tries_left errs =
+    if Int.( <= ) tries_left 0 then
+      let e = Error.of_list (List.rev errs) in
+      return
+        (Error
+           (Error.tag_arg e
+              (sprintf
+                 "Could not send archive diff data to archive process after \
+                  %d tries. The process may not be running, please check the \
+                  daemon-argument"
+                 max_tries)
+              ( ("host_and_port", archive_location.value)
+              , ("daemon-argument", archive_location.name) )
+              [%sexp_of: (string * Host_and_port.t) * (string * string)]))
+    else
+      match%bind
+        Daemon_rpcs.Client.dispatch Archive_lib.Rpc.t diff
+          archive_location.value
+      with
+      | Ok () ->
+          return (Ok ())
+      | Error e ->
+          go (tries_left - 1) (e :: errs)
+  in
+  go max_tries []
 
-let dispatch_precomputed_block
+let dispatch_precomputed_block ?(max_tries = 5)
     (archive_location : Host_and_port.t Cli_lib.Flag.Types.with_name)
     precomputed_block =
-  match%map
-    Daemon_rpcs.Client.dispatch Archive_lib.Rpc.precomputed_block
-      precomputed_block archive_location.value
-  with
-  | Ok () ->
-      Ok ()
-  | Error e ->
-      Error
-        (Error.tag_arg e
-           "Could not send data to archive process. It may not be running, \
-            please check the daemon-argument"
-           ( ("host_and_port", archive_location.value)
-           , ("daemon-argument", archive_location.name) )
-           [%sexp_of: (string * Host_and_port.t) * (string * string)])
+  let rec go tries_left errs =
+    if Int.( <= ) tries_left 0 then
+      let e = Error.of_list (List.rev errs) in
+      return
+        (Error
+           (Error.tag_arg e
+              (sprintf
+                 "Could not send precomputed block data to archive process \
+                  after %d tries. The process may not be running, please \
+                  check the daemon-argument"
+                 max_tries)
+              ( ("host_and_port", archive_location.value)
+              , ("daemon-argument", archive_location.name) )
+              [%sexp_of: (string * Host_and_port.t) * (string * string)]))
+    else
+      match%bind
+        Daemon_rpcs.Client.dispatch Archive_lib.Rpc.precomputed_block
+          precomputed_block archive_location.value
+      with
+      | Ok () ->
+          return (Ok ())
+      | Error e ->
+          go (tries_left - 1) (e :: errs)
+  in
+  go max_tries []
 
 let transfer ~logger ~archive_location
     (breadcrumb_reader :

--- a/src/lib/mina_lib/archive_client.mli
+++ b/src/lib/mina_lib/archive_client.mli
@@ -2,7 +2,8 @@ open Core
 open Pipe_lib
 
 val dispatch_precomputed_block :
-     Host_and_port.t Cli_lib.Flag.Types.with_name
+     ?max_tries:int
+  -> Host_and_port.t Cli_lib.Flag.Types.with_name
   -> Mina_transition.External_transition.Precomputed_block.t
   -> unit Async.Deferred.Or_error.t
 


### PR DESCRIPTION
In the current testnet, we have been seeing lots of RPC failures, primarily handshake errors, in the RPC that sends data to the archive process.

Most of the time, the RPC succeeds, so maybe it's worth retrying the RPC when it fails. Not including blocks in the archive db is bad, because we have to patch the archive db from other sources, in case we need to do a hard fork.

Here, put the RPC calls in a loop, subject to a max number of tries. If it fails after that number of tries, return a tagged error, where the tag is built from all the errors seen.