### PR TITLE
Hotfix 0.2.2-1

### DIFF
--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"path"
 	"time"
-        "os"
 
 	dsb "github.com/ipfs/go-ds-badger"
 	logging "github.com/ipfs/go-log"
@@ -105,6 +105,11 @@ func (cm *CodaConnectionManager) Connected(net network.Network, c network.Conn) 
 func (cm *CodaConnectionManager) Disconnected(net network.Network, c network.Conn) {
 	cm.OnDisconnect(net, c)
 	cm.p2pManager.Notifee().Disconnected(net, c)
+}
+
+// proxy remaining p2pconnmgr.BasicConnMgr methods for access
+func (cm *CodaConnectionManager) GetInfo() p2pconnmgr.CMInfo {
+	return cm.p2pManager.GetInfo()
 }
 
 // Helper contains all the daemon state
@@ -312,10 +317,12 @@ func MakeHelper(ctx context.Context, listenOn []ma.Multiaddr, externalAddr ma.Mu
 			}
 
 			as = append(as, externalAddr)
-                        
-                        _, exists := os.LookupEnv("CONNECT_PRIVATE_IPS")
-                        if exists { return as }
-                        
+
+			_, exists := os.LookupEnv("CONNECT_PRIVATE_IPS")
+			if exists {
+				return as
+			}
+
 			bs := make([]ma.Multiaddr, 0, len(as))
 			isPrivate := func(addr ma.Multiaddr) bool {
 				// get the ip out

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -68,8 +68,8 @@ module type Resource_pool_diff_intf = sig
   (** How big to consider this diff for purposes of metering. *)
   val score : t -> int
 
-  (** The maximum "diff score" permitted per IP/peer-id per second. *)
-  val max_per_second : int
+  (** The maximum "diff score" permitted per IP/peer-id per 15 seconds. *)
+  val max_per_15_seconds : int
 
   val summary : t -> string
 

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -53,7 +53,7 @@ end)
           fire_exn cb `Accept ;
           Deferred.unit
 
-    let replace broadcast_pipe accepted rejected = function
+    let _replace broadcast_pipe accepted rejected = function
       | Local f ->
           f (Ok (accepted, rejected)) ;
           Linear_pipe.write broadcast_pipe accepted
@@ -75,7 +75,6 @@ end)
 
   let apply_and_broadcast t
       (diff : Resource_pool.Diff.verified Envelope.Incoming.t) cb =
-    let open Envelope.Incoming in
     let rebroadcast (diff', rejected) =
       let open Broadcast_callback in
       if Resource_pool.Diff.is_empty diff' then (
@@ -86,17 +85,10 @@ end)
               , Resource_pool.Diff.verified_to_yojson
                 @@ Envelope.Incoming.data diff ) ] ;
         drop diff' rejected cb )
-      else if
-        Resource_pool.Diff.verified_size diff.data
-        = Resource_pool.Diff.size diff'
-      then (
+      else (
         [%log' trace t.logger] "Rebroadcasting diff %s"
           (Resource_pool.Diff.summary diff') ;
         forward t.write_broadcasts diff' rejected cb )
-      else (
-        [%log' trace t.logger] "Broadcasting %s"
-          (Resource_pool.Diff.summary diff') ;
-        replace t.write_broadcasts diff' rejected cb )
     in
     match%bind Resource_pool.Diff.unsafe_apply t.resource_pool diff with
     | Ok res ->

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -141,7 +141,8 @@ end)
     in
     let rl =
       Rate_limiter.create
-        ~capacity:(Resource_pool.Diff.max_per_second, `Per Time.Span.second)
+        ~capacity:
+          (Resource_pool.Diff.max_per_15_seconds, `Per (Time.Span.of_sec 15.0))
     in
     if log_rate_limiter then log_rate_limiter_occasionally t rl ;
     (*Note: This is done asynchronously to use batch verification*)

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -63,7 +63,7 @@ module Make
 
   let verified_size _ = 1
 
-  let max_per_second = 4
+  let max_per_15_seconds = 20
 
   let summary = function
     | Add_solved_work (work, {proof= _; fee}) ->

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -791,7 +791,7 @@ struct
 
       let score x = Int.max 1 (List.length x)
 
-      let max_per_second = 2
+      let max_per_15_seconds = 10
 
       let verified_size = List.length
 


### PR DESCRIPTION
This hotfix attempts to alleviate some of the pubsub pressure we've been seeing on the latest network. There are still other issues to investigate and fix, but these changes should help with the massive amount of messages our nodes are attempting to validate, and should make it easier for new nodes to join the network, as well as for transactions to be sent.

The following fixes are included:

- Only rebroadcast entire network pool diffs; do not shrink diffs and broadcast new messages, even if some of the elements in a diff are rejected.
- Set network pool rate limiter to limit 10 transactions and 20 snark work per node per 15 seconds (limiting the per minute rate to 40 and 80 respectively, down from 120 and 240 prior).

This also include a new prometheus metric for the libp2p_helper which should assist in debugging some one of the issues we are seeing around nodes getting stuck in the connecting state as well as nodes not properly limiting their max number of connections.

For these changes to be effective, we need to do a full re-release of the network, in the sense that this will only improve the network traffic if all of the nodes in the network are running the new build.