### PR TITLE
Don't exit on failed GraphQL requests in archive-precomputed-blocks

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1733,7 +1733,7 @@ let archive_precomputed_blocks =
                  .to_yojson block
                  |> Yojson.Safe.to_basic
                in
-               let%map.Async.Or_error.Let_syntax _res =
+               let%map.Deferred.Or_error.Let_syntax _res =
                  (* Don't catch this error: [query_exn] already handles
                     printing etc.
                  *)

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1746,8 +1746,13 @@ let archive_precomputed_blocks =
                             (fun () ->
                               Sexp.List
                                 [ List
-                                    [Atom "uri"; Atom (Uri.to_string uri.value)]
-                                ; List [Atom "uri_flag"; Atom uri.name]
+                                    [ Atom "uri"
+                                    ; Atom
+                                        (Uri.to_string graphql_endpoint.value)
+                                    ]
+                                ; List
+                                    [ Atom "uri_flag"
+                                    ; Atom graphql_endpoint.name ]
                                 ; List [Atom "error_message"; Atom e] ] )
                       | `Graphql_error e ->
                           Error.createf "GraphQL error: %s" e )

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1749,7 +1749,7 @@ let archive_precomputed_blocks =
                                     [Atom "uri"; Atom (Uri.to_string uri.value)]
                                 ; List [Atom "uri_flag"; Atom uri.name]
                                 ; List [Atom "error_message"; Atom e] ] )
-                      | Error (`Graphql_error e) ->
+                      | `Graphql_error e ->
                           Error.createf "GraphQL error: %s" e )
                in
                ()


### PR DESCRIPTION

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: