### PR TITLE
Disable update-branch-protection CI job while we transition to the new branch world 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1193,10 +1193,10 @@ workflows:
             - lint-opt
             - compare-test-signatures
             - client-sdk-unit-tests
-            - update-branch-protection:
-                filters:
-                  branches:
-                    only: develop
+            #- update-branch-protection:
+                #filters:
+                  #branches:
+                    #only: develop
             - tracetool
             - test-archive
             - build-archive

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -719,10 +719,10 @@ workflows:
             - lint-opt
             - compare-test-signatures
             - client-sdk-unit-tests
-            - update-branch-protection:
-                filters:
-                  branches:
-                    only: develop
+            #- update-branch-protection:
+                #filters:
+                  #branches:
+                    #only: develop
             - tracetool
             - test-archive
             - build-archive


### PR DESCRIPTION
Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: