### PR TITLE
Set compatibility checks to run on compatible, not on develop

### DIFF
--- a/buildkite/scripts/connect-to-testnet-on-develop.sh
+++ b/buildkite/scripts/connect-to-testnet-on-develop.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 echo "Disabled for now as we don't have a testnet online yet"
 exit 0
 
-if [ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" = "develop" ]; then
-  echo "Not pulling against develop, not running the connect test"
+if [ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" = "compatible" ]; then
+  echo "Not pulling against compatible, not running the connect test"
   exit 0
 fi
 
@@ -25,7 +25,7 @@ echo "deb [trusted=yes] http://packages.o1test.net unstable main" | tee /etc/apt
 apt-get update
 apt-get install --allow-downgrades -y curl ${PROJECT}=${VERSION}
 
-TESTNET_NAME="turbo-pickles"
+TESTNET_NAME="testworld"
 
 
 # Generate genesis proof and then crash due to no peers

--- a/scripts/compare_ci_diff_types_develop.sh
+++ b/scripts/compare_ci_diff_types_develop.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-if [ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" = "develop" ]; then
+if [ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" = "compatible" ]; then
   exit 0
 fi
 


### PR DESCRIPTION
Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: