### PR TITLE
Precomputed block format for missing subchain blocks

### DIFF
--- a/src/app/missing_subchain/block.ml
+++ b/src/app/missing_subchain/block.ml
@@ -1,95 +1,15 @@
 (* block.ml -- block for json output *)
 
+(* use dummy values where the archive db does not have corresponding data
+   these values are marked DUMMY in comments below
+*)
+
 open Core_kernel
 open Mina_base
 open Signature_lib
 open Archive_lib
 
-(* like With_status, but with an option
-   why? the archive db has a NULLable column for user command status
-*)
-module With_opt_status = struct
-  type 'a t = {data: 'a; status: Transaction_status.t option}
-  [@@deriving yojson]
-end
-
-type curr_global_slot = {slot_number: Mina_numbers.Global_slot.t}
-[@@deriving yojson]
-
-type epoch_ledger_hash = {hash: Frozen_ledger_hash.t} [@@deriving yojson]
-
-type epoch_data = {ledger: epoch_ledger_hash; seed: Epoch_seed.t}
-[@@deriving yojson]
-
-type non_snark = {ledger_hash: Ledger_hash.t} [@@deriving yojson]
-
-type staged_ledger_hash = {non_snark: non_snark} [@@deriving yojson]
-
-type blockchain_state =
-  {staged_ledger_hash: staged_ledger_hash; timestamp: Block_time.t}
-[@@deriving yojson]
-
-type consensus_state =
-  { curr_global_slot: curr_global_slot
-  ; global_slot_since_genesis: Mina_numbers.Global_slot.t
-  ; staking_epoch_data: epoch_data
-  ; next_epoch_data: epoch_data
-  ; block_stake_winner: Public_key.Compressed.t
-  ; block_creator: Public_key.Compressed.t }
-[@@deriving yojson]
-
-type protocol_state_body =
-  {blockchain_state: blockchain_state; consensus_state: consensus_state}
-[@@deriving yojson]
-
-type protocol_state = {body: protocol_state_body} [@@deriving yojson]
-
-type user_cmd_common =
-  { fee: Currency.Fee.t
-  ; fee_token: Token_id.t
-  ; fee_payer_pk: Public_key.Compressed.t
-  ; nonce: Account.Nonce.t
-  ; valid_until: Mina_numbers.Global_slot.t option
-  ; memo: Signed_command_memo.t }
-[@@deriving yojson]
-
-type user_cmd_body_payload =
-  { source_pk: Public_key.Compressed.t
-  ; receiver_pk: Public_key.Compressed.t
-  ; token_id: Token_id.t
-  ; amount: Currency.Amount.t option }
-[@@deriving yojson]
-
-type user_cmd_body =
-  | Payment of user_cmd_body_payload
-  | Stake_delegation of user_cmd_body_payload
-  | Create_new_token of user_cmd_body_payload
-  | Create_token_account of user_cmd_body_payload
-  | Mint_tokens of user_cmd_body_payload
-[@@deriving yojson]
-
-type payload = {common: user_cmd_common; body: user_cmd_body}
-[@@deriving yojson]
-
-(* TODO: add Snapps *)
-type command = Signed_command of {payload: payload} [@@deriving yojson]
-
-type diff_commands =
-  { commands: command With_opt_status.t list
-  ; internal_command_balances:
-      Transaction_status.Internal_command_balance_data.t list }
-[@@deriving yojson]
-
-type staged_ledger_diff = {diff: diff_commands} [@@deriving yojson]
-
-(* essentially External_transition.t with some fields missing
-   and state_hash added
-*)
-
-type t =
-  { state_hash: State_hash.t
-  ; protocol_state: protocol_state
-  ; staged_ledger_diff: staged_ledger_diff }
+type t = Mina_transition.External_transition.Precomputed_block.t
 [@@deriving yojson]
 
 module Fee_transfer_via_coinbase = struct
@@ -107,98 +27,191 @@ let fee_transfer_tbl :
     Extensional.Internal_command.t Fee_transfer_via_coinbase.Table.t =
   Fee_transfer_via_coinbase.Table.create ()
 
+let dummy_coinbase = Or_error.ok_exn @@ Pending_coinbase.create ~depth:6 ()
+
+let staged_ledger_hash_of_extensional_block (block : Extensional.Block.t) =
+  let aux_hash = Staged_ledger_hash.Aux_hash.dummy (* DUMMY *) in
+  let ledger_hash = block.ledger_hash in
+  let coinbase = dummy_coinbase (* DUMMY *) in
+  Staged_ledger_hash.of_aux_ledger_and_coinbase_hash aux_hash ledger_hash
+    coinbase
+
 let blockchain_state_of_extensional_block (block : Extensional.Block.t) =
-  { staged_ledger_hash= {non_snark= {ledger_hash= block.ledger_hash}}
-  ; timestamp= block.timestamp }
+  let staged_ledger_hash = staged_ledger_hash_of_extensional_block block in
+  let snarked_ledger_hash = Frozen_ledger_hash.empty_hash (* DUMMY *) in
+  let genesis_ledger_hash = Frozen_ledger_hash.empty_hash (* DUMMY *) in
+  let snarked_next_available_token = Token_id.default (* DUMMY *) in
+  let timestamp = block.timestamp in
+  Mina_state.Blockchain_state.create_value ~staged_ledger_hash
+    ~snarked_ledger_hash ~genesis_ledger_hash ~snarked_next_available_token
+    ~timestamp
 
-let mk_global_slot slot_number = {slot_number}
+let mk_ledger hash : Mina_base.Epoch_ledger.Value.t =
+  (* hash is valid; total_currency is a DUMMY *)
+  {hash; total_currency= Currency.Amount.zero}
 
-let mk_ledger hash = {hash}
+let mk_epoch_data seed hash : Mina_base.Epoch_data.Value.t =
+  { Mina_base.Epoch_data.Poly.ledger= mk_ledger hash
+  ; seed
+  ; start_checkpoint= State_hash.dummy (* DUMMY *)
+  ; lock_checkpoint= State_hash.dummy (* DUMMY *)
+  ; epoch_length= Mina_numbers.Length.zero (* DUMMY *) }
 
-let mk_epoch_data seed hash = {ledger= mk_ledger hash; seed}
+let consensus_constants = Lazy.force Consensus.Constants.for_unit_tests
 
 let consensus_state_of_extensional_block (block : Extensional.Block.t) :
-    consensus_state =
-  { curr_global_slot= mk_global_slot block.global_slot
-  ; global_slot_since_genesis= block.global_slot_since_genesis
-  ; staking_epoch_data=
-      mk_epoch_data block.staking_epoch_seed block.staking_epoch_ledger_hash
-  ; next_epoch_data=
-      mk_epoch_data block.next_epoch_seed block.next_epoch_ledger_hash
-  ; block_stake_winner= block.block_winner
-  ; block_creator= block.creator }
+    Consensus.Data.Consensus_state.Value.t =
+  let blockchain_length = Mina_numbers.Length.zero (* DUMMY *) in
+  let epoch_count = Mina_numbers.Length.zero (* DUMMY *) in
+  let min_window_density = Mina_numbers.Length.zero (* DUMMY *) in
+  let sub_window_densities = [] (* DUMMY *) in
+  let last_vrf_output = "" (* DUMMY *) in
+  let total_currency = Currency.Amount.zero (* DUMMY *) in
+  (* the slot number is valid, the constants are a DUMMY *)
+  let curr_global_slot =
+    Consensus.Proof_of_stake.Exported.Global_slot.create_with_slot_number
+      ~constants:consensus_constants ~slot_number:block.global_slot
+  in
+  let global_slot_since_genesis = block.global_slot_since_genesis in
+  let staking_epoch_data =
+    mk_epoch_data block.staking_epoch_seed block.staking_epoch_ledger_hash
+  in
+  let next_epoch_data =
+    mk_epoch_data block.next_epoch_seed block.next_epoch_ledger_hash
+  in
+  let has_ancestor_in_same_checkpoint_window = false (* DUMMY *) in
+  let block_stake_winner = block.block_winner in
+  let block_creator = block.creator in
+  let coinbase_receiver = Public_key.Compressed.empty (* DUMMY *) in
+  let supercharge_coinbase = false (* DUMMY *) in
+  Consensus.Proof_of_stake.Exported.Consensus_state.Unsafe.create_value
+    `I_have_an_excellent_reason_to_call_this ~blockchain_length ~epoch_count
+    ~min_window_density ~sub_window_densities ~last_vrf_output ~total_currency
+    ~curr_global_slot ~global_slot_since_genesis ~staking_epoch_data
+    ~next_epoch_data ~has_ancestor_in_same_checkpoint_window
+    ~block_stake_winner ~block_creator ~coinbase_receiver ~supercharge_coinbase
 
-let protocol_state_body_of_extensional_block (block : Extensional.Block.t) =
+let protocol_state_of_extensional_block block : Mina_state.Protocol_state.value
+    =
+  let previous_state_hash = State_hash.dummy (* DUMMY *) in
+  let genesis_state_hash = State_hash.dummy (* DUMMY *) in
   let blockchain_state = blockchain_state_of_extensional_block block in
   let consensus_state = consensus_state_of_extensional_block block in
-  {blockchain_state; consensus_state}
-
-let protocol_state_of_extensional_block block =
-  {body= protocol_state_body_of_extensional_block block}
-
-let common_of_user_cmd (user_cmd : Extensional.User_command.t) =
-  { fee= user_cmd.fee
-  ; fee_token= user_cmd.fee_token
-  ; fee_payer_pk= user_cmd.fee_payer
-  ; nonce= user_cmd.nonce
-  ; valid_until= user_cmd.valid_until
-  ; memo= user_cmd.memo }
-
-let body_of_user_cmd (user_cmd : Extensional.User_command.t) =
-  let payload =
-    { source_pk= user_cmd.source
-    ; receiver_pk= user_cmd.receiver
-    ; token_id= user_cmd.token
-    ; amount= user_cmd.amount }
+  let constants =
+    Genesis_constants.compiled.protocol
+    |> Protocol_constants_checked.value_of_t
   in
+  Mina_state.Protocol_state.create_value ~previous_state_hash
+    ~genesis_state_hash ~blockchain_state ~consensus_state ~constants
+
+let body_of_user_cmd (user_cmd : Extensional.User_command.t) :
+    Signed_command_payload.Body.t =
   match user_cmd.typ with
   | "payment" ->
+      if Option.is_none user_cmd.amount then
+        failwithf
+          "Payment user command has a NULL amount; block state hash=%s, \
+           sequence no=%d"
+          (State_hash.to_string user_cmd.block_state_hash)
+          user_cmd.sequence_no () ;
+      let payload =
+        { Payment_payload.Poly.source_pk= user_cmd.source
+        ; receiver_pk= user_cmd.receiver
+        ; token_id= user_cmd.token
+        ; amount= Option.value_exn user_cmd.amount }
+      in
       Payment payload
   | "delegation" ->
+      let payload =
+        Stake_delegation.Set_delegate
+          {delegator= user_cmd.source; new_delegate= user_cmd.receiver}
+      in
       Stake_delegation payload
   | "create_token" ->
+      let payload =
+        { New_token_payload.token_owner_pk= user_cmd.source
+        ; disable_new_accounts= false (* DUMMY *) }
+      in
       Create_new_token payload
   | "create_account" ->
+      let payload =
+        { New_account_payload.token_id= user_cmd.token
+        ; token_owner_pk= user_cmd.source
+        ; receiver_pk= user_cmd.receiver
+        ; account_disabled= false (* DUMMY *) }
+      in
       Create_token_account payload
   | "mint_tokens" ->
+      if Option.is_none user_cmd.amount then
+        failwithf
+          "Mint_tokens user command has a NULL amount; block state hash=%s, \
+           sequence no=%d"
+          (State_hash.to_string user_cmd.block_state_hash)
+          user_cmd.sequence_no () ;
+      let payload =
+        { Minting_payload.token_id= user_cmd.token
+        ; token_owner_pk= user_cmd.source
+        ; receiver_pk= user_cmd.receiver
+        ; amount= Option.value_exn user_cmd.amount }
+      in
       Mint_tokens payload
   | cmd ->
       failwithf "Unknown user command \"%s\"" cmd ()
 
-let payload_of_user_cmd user_cmd =
-  {common= common_of_user_cmd user_cmd; body= body_of_user_cmd user_cmd}
+let payload_of_user_cmd (user_cmd : Extensional.User_command.t) :
+    Signed_command_payload.t =
+  let fee = user_cmd.fee in
+  let fee_token = user_cmd.fee_token in
+  let fee_payer_pk = user_cmd.fee_payer in
+  let nonce = user_cmd.nonce in
+  let valid_until = user_cmd.valid_until in
+  let memo = user_cmd.memo in
+  Signed_command_payload.create ~fee ~fee_token ~fee_payer_pk ~nonce
+    ~valid_until ~memo
+    ~body:(body_of_user_cmd user_cmd)
 
 let status_of_user_cmd (user_cmd : Extensional.User_command.t) =
   let open Transaction_status in
   (* TODO: use actual balance data instead of dummy value *)
   match user_cmd.status with
-  | None ->
-      None
   | Some "applied" ->
-      Some
-        (Applied
-           ( { fee_payer_account_creation_fee_paid=
-                 user_cmd.fee_payer_account_creation_fee_paid
-             ; receiver_account_creation_fee_paid=
-                 user_cmd.receiver_account_creation_fee_paid
-             ; created_token= user_cmd.created_token }
-           , Balance_data.empty ))
+      Applied
+        ( { fee_payer_account_creation_fee_paid=
+              user_cmd.fee_payer_account_creation_fee_paid
+          ; receiver_account_creation_fee_paid=
+              user_cmd.receiver_account_creation_fee_paid
+          ; created_token= user_cmd.created_token }
+        , Balance_data.empty )
   | Some "failed" -> (
     match user_cmd.failure_reason with
     | Some reason ->
-        Some (Failed (reason, Balance_data.empty))
+        Failed (reason, Balance_data.empty)
     | None ->
         failwith "Failed user command status, no reason given" )
   | Some s ->
       failwithf "Unexpected user command status \"%s\"" s ()
+  | None ->
+      (* REVIEWER: is failure here reasonable?
+       the status is NULLable in the archive db; should we expect NULLs, in fact?
+    *)
+      failwithf
+        "User command is missing status; block state hash=%s, sequence no=%d"
+        (State_hash.to_string user_cmd.block_state_hash)
+        user_cmd.sequence_no ()
+
+let dummy_signer = Quickcheck.random_value Public_key.gen
 
 let signed_cmd_with_status_of_user_cmd (user_cmd : Extensional.User_command.t)
-    =
-  { With_opt_status.data= Signed_command {payload= payload_of_user_cmd user_cmd}
+    : User_command.t With_status.t =
+  { With_status.data=
+      Signed_command
+        { payload= payload_of_user_cmd user_cmd
+        ; signer= dummy_signer (* DUMMY *)
+        ; signature= Signature.dummy (* DUMMY *) }
   ; status= status_of_user_cmd user_cmd }
 
 let user_commands_of_extensional_block user_cmds_tbl
-    (block : Extensional.Block.t) =
+    (block : Extensional.Block.t) : User_command.t With_status.t list =
   let user_cmds = State_hash.Table.find_exn user_cmds_tbl block.state_hash in
   List.map user_cmds ~f:signed_cmd_with_status_of_user_cmd
 
@@ -208,8 +221,8 @@ let internal_cmd_balance_data_of_internal_cmd
   match internal_cmd.typ with
   | "coinbase" ->
       (* TODO: add fee transfer via coinbase here, when balances available
-       use Fee_transfer_via_coinbase.Table.find on global slot, seq no, secondary seq no
-    *)
+         use Fee_transfer_via_coinbase.Table.find on global slot, seq no, secondary seq no
+      *)
       (* TODO: add valid balances when they're available in archive db *)
       Some
         (Coinbase
@@ -233,24 +246,40 @@ let internal_commands_of_extensional_block internal_cmds_tbl
   in
   List.map internal_cmds ~f:internal_cmd_balance_data_of_internal_cmd
 
-let diff_commands_of_extensional_block user_cmds_tbl internal_cmds_tbl block =
-  { commands= user_commands_of_extensional_block user_cmds_tbl block
-  ; internal_command_balances=
-      List.filter_opt
-        (internal_commands_of_extensional_block internal_cmds_tbl block) }
+let diff_commands_of_extensional_block user_cmds_tbl internal_cmds_tbl block :
+    Staged_ledger_diff.Diff.t =
+  let prediff_with_at_most_two_coinbase =
+    { Staged_ledger_diff.Pre_diff_two.completed_works= [] (* DUMMY *)
+    ; commands= user_commands_of_extensional_block user_cmds_tbl block
+    ; coinbase= Zero (* DUMMY *)
+    ; internal_command_balances=
+        List.filter_opt
+          (internal_commands_of_extensional_block internal_cmds_tbl block) }
+    (* REVIEWER: does it make sense to put all the commands in the at-most-two part? *)
+  in
+  (prediff_with_at_most_two_coinbase, None)
 
 let staged_ledger_diff_of_extensional_block user_cmds_tbl internal_cmds_tbl
-    block =
+    block : Staged_ledger_diff.t =
   { diff=
       diff_commands_of_extensional_block user_cmds_tbl internal_cmds_tbl block
   }
 
-let block_of_extensional_block user_cmds_tbl internal_cmds_tbl
+let precomputed_block_of_extensional_block user_cmds_tbl internal_cmds_tbl
     (block : Extensional.Block.t) : t =
-  let state_hash = block.state_hash in
+  let scheduled_time = Block_time.zero (* DUMMY *) in
   let protocol_state = protocol_state_of_extensional_block block in
+  let protocol_state_proof = Mina_base.Proof.blockchain_dummy (* DUMMY *) in
   let staged_ledger_diff =
     staged_ledger_diff_of_extensional_block user_cmds_tbl internal_cmds_tbl
       block
   in
-  {state_hash; protocol_state; staged_ledger_diff}
+  let delta_transition_chain_proof =
+    (Frozen_ledger_hash.empty_hash, [])
+    (* DUMMY *)
+  in
+  { scheduled_time
+  ; protocol_state
+  ; protocol_state_proof
+  ; staged_ledger_diff
+  ; delta_transition_chain_proof }

--- a/src/app/missing_subchain/dune
+++ b/src/app/missing_subchain/dune
@@ -11,6 +11,8 @@
    archive_lib
    block_time
    mina_numbers
+   mina_state
+   mina_transition
    logger
    mina_base)
  (preprocessor_deps ../../config.mlh)

--- a/src/lib/consensus/global_slot.ml
+++ b/src/lib/consensus/global_slot.ml
@@ -50,6 +50,10 @@ let create ~(constants : Constants.t) ~(epoch : Epoch.t) ~(slot : Slot.t) : t =
   { slot_number= UInt32.Infix.(slot + (constants.slots_per_epoch * epoch))
   ; slots_per_epoch= constants.slots_per_epoch }
 
+let create_with_slot_number ~(constants : Constants.t) ~(slot_number : Slot.t)
+    : t =
+  {slot_number; slots_per_epoch= constants.slots_per_epoch}
+
 let of_epoch_and_slot ~(constants : Constants.t) (epoch, slot) =
   create ~epoch ~slot ~constants
 

--- a/src/lib/consensus/global_slot.mli
+++ b/src/lib/consensus/global_slot.mli
@@ -39,6 +39,8 @@ val succ : t -> t
 
 val create : constants:Constants.t -> epoch:Epoch.t -> slot:Slot.t -> t
 
+val create_with_slot_number : constants:Constants.t -> slot_number:Slot.t -> t
+
 val of_epoch_and_slot : constants:Constants.t -> Epoch.t * Slot.t -> t
 
 val zero : constants:Constants.t -> t

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1846,6 +1846,8 @@ module Data = struct
     module Value = struct
       [%%versioned
       module Stable = struct
+        [@@@no_toplevel_latest_type]
+
         module V1 = struct
           type t =
             ( Length.Stable.V1.t
@@ -1863,6 +1865,21 @@ module Data = struct
           let to_latest = Fn.id
         end
       end]
+
+      type t =
+        ( Length.t
+        , Vrf.Output.Truncated.t
+        , Amount.t
+        , Global_slot.t
+        , Mina_numbers.Global_slot.t
+        , Mina_base.Epoch_data.Value.t
+        , Mina_base.Epoch_data.Value.t
+        , bool
+        , Public_key.Compressed.t )
+        Poly.t
+      [@@deriving sexp, eq, compare, hash, yojson]
+
+      type _unused = () constraint t = Stable.Latest.t
 
       module For_tests = struct
         let with_global_slot_since_genesis (state : t) slot_number =
@@ -2493,6 +2510,29 @@ module Data = struct
           else t.epoch_count
         in
         {t with epoch_count= new_epoch_count; curr_global_slot= new_global_slot}
+
+      let create_value `I_have_an_excellent_reason_to_call_this
+          ~blockchain_length ~epoch_count ~min_window_density
+          ~sub_window_densities ~last_vrf_output ~total_currency
+          ~curr_global_slot ~global_slot_since_genesis ~staking_epoch_data
+          ~next_epoch_data ~has_ancestor_in_same_checkpoint_window
+          ~block_stake_winner ~block_creator ~coinbase_receiver
+          ~supercharge_coinbase : Value.t =
+        { Poly.blockchain_length
+        ; epoch_count
+        ; min_window_density
+        ; sub_window_densities
+        ; last_vrf_output
+        ; curr_global_slot
+        ; global_slot_since_genesis
+        ; total_currency
+        ; staking_epoch_data
+        ; next_epoch_data
+        ; has_ancestor_in_same_checkpoint_window
+        ; block_stake_winner
+        ; block_creator
+        ; coinbase_receiver
+        ; supercharge_coinbase }
     end
 
     let graphql_type () : ('ctx, Value.t option) Graphql_async.Schema.typ =

--- a/src/lib/consensus/proof_of_stake.mli
+++ b/src/lib/consensus/proof_of_stake.mli
@@ -28,14 +28,34 @@ module Exported : sig
 
     val next_epoch_data : Value.t -> Mina_base.Epoch_data.Value.t
 
-    (* unsafe modules for creating dummy states when doing vrf evaluations *)
     (* TODO: refactor code so that [Hooks.next_proposal] does not require a full [Consensus_state] *)
     module Unsafe : sig
+      (* for creating dummy states when doing vrf evaluations *)
       val dummy_advance :
            Value.t
         -> ?increase_epoch_count:bool
         -> new_global_slot:Global_slot.t
         -> Value.t
+
+      (* for any code that needs to built a [Consensus_state] *)
+      val create_value :
+           [< `I_have_an_excellent_reason_to_call_this]
+        -> blockchain_length:Mina_numbers.Length.t
+        -> epoch_count:Mina_numbers.Length.t
+        -> min_window_density:Mina_numbers.Length.t
+        -> sub_window_densities:Mina_numbers.Length.t list
+        -> last_vrf_output:string
+        -> total_currency:Currency.Amount.t
+        -> curr_global_slot:Global_slot.t
+        -> global_slot_since_genesis:Mina_numbers.Global_slot.t
+        -> staking_epoch_data:Mina_base.Epoch_data.Value.t
+        -> next_epoch_data:Mina_base.Epoch_data.Value.t
+        -> has_ancestor_in_same_checkpoint_window:bool
+        -> block_stake_winner:Signature_lib.Public_key.Compressed.t
+        -> block_creator:Signature_lib.Public_key.Compressed.t
+        -> coinbase_receiver:Signature_lib.Public_key.Compressed.t
+        -> supercharge_coinbase:bool
+        -> Data.Consensus_state.Value.t
     end
   end
 end


### PR DESCRIPTION
Use precomputed block format for output of missing subchains tool. Doing so requires using dummy data in a number of places. The dummies are marked with a `DUMMY` comment in the source code.

The intent is make these blocks usable by the `advanced archive-precomputed-blocks` CLI command. 

Instead of writing all blocks to a single file, with a block per line, as before, each block is written to a file `<state-hash>.json` in the current directory (we could add an output directory flag, if needed). I believe the CLI command makes use of individual files in this way.

Please look at the places where "REVIEWER" is called out in comments.

Ugly change: allow direct construction of a consensus state (but clearly marked as unsafe).

Tested with Rosetta-generated archive db.

Closes #7341.