### PR TITLE
Extensional blocks output for missing subchains

### DIFF
--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -1,6 +1,5 @@
 (* extensional.ml -- extensional representations of archive db data *)
 
-open Core_kernel
 open Mina_base
 open Signature_lib
 
@@ -9,32 +8,13 @@ open Signature_lib
    their native OCaml types to assure the validity of the data
 *)
 
-module Block = struct
-  type t =
-    { state_hash: State_hash.t
-    ; parent_hash: State_hash.t
-    ; creator: Public_key.Compressed.t
-    ; block_winner: Public_key.Compressed.t
-    ; snarked_ledger_hash: Frozen_ledger_hash.t
-    ; staking_epoch_seed: Epoch_seed.t
-    ; staking_epoch_ledger_hash: Frozen_ledger_hash.t
-    ; next_epoch_seed: Epoch_seed.t
-    ; next_epoch_ledger_hash: Frozen_ledger_hash.t
-    ; ledger_hash: Ledger_hash.t
-    ; height: Unsigned.UInt32.t
-    ; global_slot: Mina_numbers.Global_slot.t
-    ; global_slot_since_genesis: Mina_numbers.Global_slot.t
-    ; timestamp: Block_time.t }
-end
-
 module User_command = struct
   (* for `typ` and `status`, a string is enough
      in any case, there aren't existing string conversions for the
      original OCaml types
   *)
   type t =
-    { block_state_hash: State_hash.t
-    ; sequence_no: int
+    { sequence_no: int
     ; typ: string
     ; fee_payer: Public_key.Compressed.t
     ; source: Public_key.Compressed.t
@@ -52,7 +32,7 @@ module User_command = struct
     ; fee_payer_account_creation_fee_paid: Currency.Amount.t option
     ; receiver_account_creation_fee_paid: Currency.Amount.t option
     ; created_token: Token_id.t option }
-  [@@deriving compare]
+  [@@deriving yojson]
 end
 
 module Internal_command = struct
@@ -68,5 +48,26 @@ module Internal_command = struct
     ; fee: Currency.Amount.t
     ; token: Token_id.t
     ; hash: Transaction_hash.t }
-  [@@deriving compare]
+  [@@deriving yojson]
+end
+
+module Block = struct
+  type t =
+    { state_hash: State_hash.t
+    ; parent_hash: State_hash.t
+    ; creator: Public_key.Compressed.t
+    ; block_winner: Public_key.Compressed.t
+    ; snarked_ledger_hash: Frozen_ledger_hash.t
+    ; staking_epoch_seed: Epoch_seed.t
+    ; staking_epoch_ledger_hash: Frozen_ledger_hash.t
+    ; next_epoch_seed: Epoch_seed.t
+    ; next_epoch_ledger_hash: Frozen_ledger_hash.t
+    ; ledger_hash: Ledger_hash.t
+    ; height: Unsigned_extended.UInt32.t
+    ; global_slot: Mina_numbers.Global_slot.t
+    ; global_slot_since_genesis: Mina_numbers.Global_slot.t
+    ; timestamp: Block_time.t
+    ; user_cmds: User_command.t list
+    ; internal_cmds: Internal_command.t list }
+  [@@deriving yojson]
 end


### PR DESCRIPTION
#7393 was closed, because it's too hard to accurately reproduce the structure of an `External_transition`.

Here, instead, the output of the missing subchains tool are `Archive_lib.Extensional_block.t`s in JSON format. Each block is in a file `<state-hash>.json`.

An extensional block contains the same information as a block in the archive db, except that there are no intensional references to foreign keys. That will make it easy to repopulate the archive db from these blocks.

The plan is add a CLI command, `advanced archive-extensional-blocks` in the manner of `archive-precomputed-blocks`.

Sample output:
```json
{
  "state_hash": "3NK32K4iUga1jEjySzhFQvtzQsYqCHHyommWj1g2yG6xjA5VPjU6",
  "parent_hash": "3NKkKzY9CLEKDjGSiNLd9aDZKPDLo8GFVeSggLa31Br4rVX6TLap",
  "creator": "B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV",
  "block_winner": "B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV",
  "snarked_ledger_hash":
    "jxZLBXBBfE5tfq8CbcMqXosMsDo1mYt8kYNZsAb4JSs36ghytn5",
  "staking_epoch_seed":
    "2va9BGv9JrLTtrzZttiEMDYw1Zj6a6EHzXjmP9evHDTG3oEquURA",
  "staking_epoch_ledger_hash":
    "jxZLBXBBfE5tfq8CbcMqXosMsDo1mYt8kYNZsAb4JSs36ghytn5",
  "next_epoch_seed": "2va9BGv9JrLTtrzZttiEMDYw1Zj6a6EHzXjmP9evHDTG3oEquURA",
  "next_epoch_ledger_hash":
    "jxZLBXBBfE5tfq8CbcMqXosMsDo1mYt8kYNZsAb4JSs36ghytn5",
  "ledger_hash": "jwWfUxMVPgT1fboD2DXa6sbL26fdQ7HcH8HiqFm789HVcWHAY8j",
  "height": "10",
  "global_slot": "12",
  "global_slot_since_genesis": "12",
  "timestamp": "1548878424513",
  "user_cmds": [
    {
      "sequence_no": 0,
      "typ": "create_token",
      "fee_payer": "B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV",
      "source": "B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV",
      "receiver": "B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV",
      "fee_token": "1",
      "token": "0",
      "nonce": "6",
      "amount": null,
      "fee": "5",
      "valid_until": null,
      "memo": "E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4TVDDpTTSsv8mK6YaH",
      "hash": "CkpZzQqpSGDymiMC3LjRWotESk7vEoFq197vHoGGYsvYx54pgvyUn",
      "status": "applied",
      "failure_reason": null,
      "fee_payer_account_creation_fee_paid": "2",
      "receiver_account_creation_fee_paid": null,
      "created_token": "3"
    }
  ],
  "internal_cmds": [
    {
      "global_slot": 12,
      "sequence_no": 1,
      "secondary_sequence_no": 0,
      "typ": "coinbase",
      "receiver": "B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV",
      "fee": "40",
      "token": "1",
      "hash": "CkpYyRMPJBuyZUv13LmLZGWEZ7Gt2RFvGUsU4xvzN55oSH8E76RRv"
    },
    {
      "global_slot": 12,
      "sequence_no": 2,
      "secondary_sequence_no": 0,
      "typ": "fee_transfer",
      "receiver": "B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV",
      "fee": "5",
      "token": "1",
      "hash": "CkpYWNVe1da29z2A7YJ3jsPk8iC3BwkWrmzxUfa3Tj9pB26EDkKbo"
    }
  ]
}
```
