### PR TITLE
update coda-network-service's Dockerfile random_restart script ADD directive

### DIFF
--- a/automation/services/coda-network-services/Dockerfile
+++ b/automation/services/coda-network-services/Dockerfile
@@ -22,7 +22,7 @@ COPY . /code
 COPY ./scripts /scripts
 
 # TODO: find better mechanism for sharing files across repo DIRs
-ADD https://raw.githubusercontent.com/MinaProtocol/mina/master/automation/scripts/random_restart.py /scripts/random_restart.py
+ADD https://raw.githubusercontent.com/MinaProtocol/mina/develop/automation/scripts/random_restart.py /scripts/random_restart.py
 
 COPY ./entrypoints /entrypoint.d
 


### PR DESCRIPTION
`master` branch reference was from Dockerfile usage in `coda-automation` repo and missed during merge into `mina`.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
