### PR TITLE
Fix archive-precomputed-blocks

### DIFF
--- a/src/lib/pickles/limb_vector/constant.ml
+++ b/src/lib/pickles/limb_vector/constant.ml
@@ -17,6 +17,21 @@ module Make (N : Vector.Nat_intf) = struct
   module Hex64 = struct
     type t = Int64.t [@@deriving yojson]
 
+    (* Modify the [of_yojson] handler to add a case for [`String].
+       This isn't necessary when using Yojson's parser, because it will
+       correctly infer [`Intlit] for any possible value that appears here.
+       However, if this json was constructed from a GraphQL query then it will
+       be encoded as a [`String] and the conversion will fail unless we handle
+       it ourselves.
+    *)
+    let of_yojson yojson =
+      match yojson with
+      | `String x -> (
+        try Result.Ok (Int64.of_string x)
+        with _ -> Result.Error "Constant.Make.Hex64.t" )
+      | _ ->
+          of_yojson yojson
+
     include (Int64 : module type of Int64 with type t := t)
 
     let to_hex t =


### PR DESCRIPTION
This PR fixes the parsing of some precomputed blocks that were received over GraphQL. Tested on 
[this block](https://github.com/MinaProtocol/mina/files/5805732/testworld-3NK3C6F5KtYC7Z7tbsEXr6iJXt3CMKp8LnCsHtGMeMdrs2ALS9Wm.txt), which fails without this change.



Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
