### PR TITLE
Always add snarked_ledger_hash to archive db if it doesn't exist

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -219,16 +219,14 @@ module Epoch_data = struct
     let rep = Caqti_type.(tup2 string int) in
     Caqti_type.custom ~encode ~decode rep
 
-  let add_if_doesn't_exist ~is_genesis_block (module Conn : CONNECTION)
+  let add_if_doesn't_exist (module Conn : CONNECTION)
       (t : Mina_base.Epoch_data.Value.t) =
     let open Deferred.Result.Let_syntax in
     let Mina_base.Epoch_ledger.Poly.{hash; _} =
       Mina_base.Epoch_data.Poly.ledger t
     in
     let%bind ledger_hash_id =
-      if is_genesis_block then
-        Snarked_ledger_hash.add_if_doesn't_exist (module Conn) hash
-      else Snarked_ledger_hash.find (module Conn) hash
+      Snarked_ledger_hash.add_if_doesn't_exist (module Conn) hash
     in
     let seed = Mina_base.Epoch_data.Poly.seed t |> Epoch_seed.to_string in
     match%bind
@@ -764,16 +762,13 @@ module Block = struct
             ( Protocol_state.blockchain_state protocol_state
             |> Blockchain_state.snarked_ledger_hash )
         in
-        let is_genesis_block =
-          Consensus.Data.Consensus_state.is_genesis_state consensus_state
-        in
         let%bind staking_epoch_data_id =
-          Epoch_data.add_if_doesn't_exist ~is_genesis_block
+          Epoch_data.add_if_doesn't_exist
             (module Conn)
             (Consensus.Data.Consensus_state.staking_epoch_data consensus_state)
         in
         let%bind next_epoch_data_id =
-          Epoch_data.add_if_doesn't_exist ~is_genesis_block
+          Epoch_data.add_if_doesn't_exist
             (module Conn)
             (Consensus.Data.Consensus_state.next_epoch_data consensus_state)
         in


### PR DESCRIPTION
This stops the archive process from failing if it hasn't seen the block that snarked the particular ledger hash.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #7455
