### PR TITLE
changed some trace logs to debug/warn

### DIFF
--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -160,7 +160,7 @@ let log_shutdown ~conf_dir ~top_logger coda_ref =
   Mina_base.Ledger.Debug.visualize ~filename:mask_file ;
   match !coda_ref with
   | None ->
-      [%log trace]
+      [%log warn]
         "Shutdown before Coda instance was created, not saving a visualization"
   | Some t -> (
     (*Transition frontier visualization*)

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -96,7 +96,7 @@ end)
     | Error (`Locally_generated res) ->
         rebroadcast res
     | Error (`Other e) ->
-        [%log' trace t.logger]
+        [%log' debug t.logger]
           "Refusing to rebroadcast. Pool diff apply feedback: $error"
           ~metadata:[("error", Error_json.error_to_yojson e)] ;
         Broadcast_callback.error e cb
@@ -151,7 +151,7 @@ end)
                   ~score:(Resource_pool.Diff.score diff.data)
               with
             | `Capacity_exceeded ->
-                [%log' trace t.logger]
+                [%log' debug t.logger]
                   ~metadata:[("sender", Envelope.Sender.to_yojson diff.sender)]
                   "exceeded capacity from $sender" ;
                 Broadcast_callback.error
@@ -160,7 +160,7 @@ end)
             | `Within_capacity -> (
                 match%bind Resource_pool.Diff.verify t.resource_pool diff with
                 | Error err ->
-                    [%log' trace t.logger]
+                    [%log' warn t.logger]
                       "Refusing to rebroadcast $diff. Verification error: \
                        $error"
                       ~metadata:

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -290,7 +290,7 @@ let close ~loc
     ; extensions
     ; closed
     ; genesis_state_hash= _ } =
-  [%log trace] "Closing transition frontier" ;
+  [%log debug] "Closing transition frontier" ;
   Full_frontier.close ~loc full_frontier ;
   Extensions.close extensions ;
   let%map () =

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -102,7 +102,7 @@ let create ~logger ~precomputed_values ~verifier ~trust_system ~frontier
                 Writer.write catchup_breadcrumbs_writer
                   (trees_of_breadcrumbs, `Catchup_scheduler)
             | Error err ->
-                [%log trace]
+                [%log debug]
                   !"Error during buildup breadcrumbs inside \
                     catchup_scheduler: $error"
                   ~metadata:[("error", Error_json.error_to_yojson err)] ;


### PR DESCRIPTION
I think error logs that we don't want users to be bothered about should be `debug` (Trace logs are a lil too noisy)