### PR TITLE
Hotfix/super catchup stall fix

### DIFF
--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -14,6 +14,26 @@ module Job = struct
   let result t = Ivar.read t.res
 end
 
+type 'a pred = 'a -> bool
+
+let pred_to_yojson _f _x = `String "<opaque>"
+
+let sexp_opaque_to_yojson _f _x = `String "<opaque>"
+
+module Claimed_knowledge = struct
+  type 'key t = [`All | `Some of 'key list | `Call of 'key pred sexp_opaque]
+  [@@deriving sexp, to_yojson]
+
+  let check ~equal t k =
+    match t with
+    | `All ->
+        true
+    | `Some ks ->
+        List.mem ~equal ks k
+    | `Call f ->
+        f k
+end
+
 module Make (Key : sig
   type t [@@deriving to_yojson, hash, sexp, compare]
 
@@ -30,6 +50,8 @@ end) (Result : sig
   type t
 
   val key : t -> Key.t
+end) (Knowledge_context : sig
+  type t
 end) : sig
   type t [@@deriving to_yojson]
 
@@ -51,11 +73,21 @@ end) : sig
     -> stop:unit Deferred.t
     -> trust_system:Trust_system.t
     -> get:(Peer.t -> Key.t list -> Result.t list Deferred.Or_error.t)
+    -> knowledge_context:Knowledge_context.t Broadcast_pipe.Reader.t
+    -> knowledge:(   Knowledge_context.t
+                  -> Peer.t
+                  -> Key.t Claimed_knowledge.t Deferred.t)
     -> peers:(unit -> Peer.t list Deferred.t)
     -> preferred:Peer.t list
     -> t Deferred.t
 
   val download : t -> key:Key.t -> attempts:Attempt.t Peer.Map.t -> Job.t
+
+  val mark_preferred : t -> Peer.t -> now:Time.t -> unit
+
+  val add_knowledge : t -> Peer.t -> Key.t list -> unit
+
+  val update_knowledge : t -> Peer.t -> Key.t Claimed_knowledge.t -> unit
 
   val total_jobs : t -> int
 
@@ -96,10 +128,6 @@ end = struct
       Option.map (Doubly_linked.remove_first t.queue) ~f:(fun {key; value} ->
           Hashtbl.remove t.table key ; value )
 
-    let clear t =
-      Hashtbl.clear t.table ;
-      Doubly_linked.clear t.queue
-
     let enqueue t (e : _ J.t) =
       if Hashtbl.mem t.table e.key then `Key_already_present
       else
@@ -118,10 +146,6 @@ end = struct
         Hashtbl.set t.table ~key:e.key ~data:elt ;
         `Ok
 
-    let enqueue_exn t e = assert (enqueue t e = `Ok)
-
-    let iter t ~f = Doubly_linked.iter t.queue ~f:(fun {value; _} -> f value)
-
     let lookup t k =
       Option.map (Hashtbl.find t.table k) ~f:(fun x ->
           (Doubly_linked.Elt.value x).value )
@@ -135,8 +159,6 @@ end = struct
 
     let length t = Doubly_linked.length t.queue
 
-    let is_empty t = Doubly_linked.is_empty t.queue
-
     let to_list t = List.map (Doubly_linked.to_list t.queue) ~f:Key_value.value
 
     let create () = {table= Key.Table.create (); queue= Doubly_linked.create ()}
@@ -144,84 +166,88 @@ end = struct
 
   module Q = Make_hash_queue (Key)
 
-  module Useful_peers = struct
-    module Peer_queue = Make_hash_queue (Peer)
+  module Knowledge = struct
+    module Key_set = struct
+      type t = Key.Hash_set.t [@@deriving sexp]
 
-    module Available_and_useful = struct
-      type t =
-        { preferred: Key.Hash_set.t Peer.Table.t
-        ; non_preferred: Key.Hash_set.t Peer.Table.t }
-      [@@deriving sexp]
-
-      let create () =
-        {preferred= Peer.Table.create (); non_preferred= Peer.Table.create ()}
-
-      let clear {preferred; non_preferred} =
-        let f s =
-          Hashtbl.iter s ~f:Hash_set.clear ;
-          Hashtbl.clear s
-        in
-        f preferred ; f non_preferred
-
-      let get t =
-        let get tbl =
-          with_return (fun {return} ->
-              Hashtbl.iteri tbl ~f:(fun ~key ~data -> return (Some (key, data))) ;
-              None )
-        in
-        let rec go tbl =
-          match get tbl with
-          | None ->
-              None
-          | Some ((key, data) as r) ->
-              if Hash_set.is_empty data then ( Hashtbl.remove tbl key ; go tbl )
-              else Some r
-        in
-        match go t.preferred with
-        | Some r ->
-            Some r
-        | None ->
-            go t.non_preferred
-
-      let find t p =
-        match Hashtbl.find t.preferred p with
-        | Some x ->
-            Some x
-        | None ->
-            Hashtbl.find t.non_preferred p
-
-      let remove t p =
-        let f s =
-          Option.iter (Hashtbl.find_and_remove s p) ~f:Hash_set.clear
-        in
-        f t.preferred ; f t.non_preferred
-
-      let filter_inplace t ~f =
-        Hashtbl.filter_inplace t.preferred ~f ;
-        Hashtbl.filter_inplace t.non_preferred ~f
-
-      let filter_keys_inplace t ~f =
-        Hashtbl.filter_keys_inplace t.preferred ~f ;
-        Hashtbl.filter_keys_inplace t.non_preferred ~f
-
-      let don't_need_keys t ks =
-        filter_inplace t ~f:(fun to_try ->
-            List.iter ks ~f:(Hash_set.remove to_try) ;
-            not (Hash_set.is_empty to_try) )
-
-      let add t ~preferred p v =
-        if Hash_set.is_empty v then `Ok
-        else
-          let s = if preferred then t.preferred else t.non_preferred in
-          Hashtbl.add s ~key:p ~data:v
+      let to_yojson t = `List (List.map (Hash_set.to_list t) ~f:Key.to_yojson)
     end
 
     type t =
-      { available_and_useful: Available_and_useful.t
-      ; downloading_peers: Peer.Hash_set.t
-      ; downloading_keys: Key.Hash_set.t
-      ; all_preferred: Peer.Hash_set.t
-      ; knowledge: Key.Hash_set.t Peer.Table.t
+      {claimed: Key.t Claimed_knowledge.t option; tried_and_failed: Key_set.t}
+    [@@deriving sexp, to_yojson]
+
+    let clear t = Hash_set.clear t.tried_and_failed
+
+    let create () = {claimed= None; tried_and_failed= Key.Hash_set.create ()}
+
+    let knows t k =
+      if Hash_set.mem t.tried_and_failed k then `No
+      else
+        match t.claimed with
+        | None ->
+            `No_information
+        | Some claimed ->
+            if Claimed_knowledge.check ~equal:Key.equal claimed k then
+              `Claims_to
+            else `No
+  end
+
+  module Useful_peers = struct
+    module Preferred_heap = struct
+      (* The preferred peers, sorted by the last time that they were useful to us. *)
+      type t =
+        { heap: (Peer.t * Time.t) Heap.t
+        ; table: (Peer.t * Time.t) Heap.Elt.t Peer.Table.t }
+
+      let cmp (p1, t1) (p2, t2) =
+        (* Later is smaller *)
+        match Int.neg (Time.compare t1 t2) with
+        | 0 ->
+            Peer.compare p1 p2
+        | c ->
+            c
+
+      let clear t =
+        let rec go t = match Heap.pop t with None -> () | Some _ -> go t in
+        go t.heap ; Hashtbl.clear t.table
+
+      let create () = {heap= Heap.create ~cmp (); table= Peer.Table.create ()}
+
+      let add t (p, time) =
+        Option.iter (Hashtbl.find t.table p) ~f:(fun elt ->
+            Heap.remove t.heap elt ) ;
+        Hashtbl.set t.table ~key:p ~data:(Heap.add_removable t.heap (p, time))
+
+      let sexp_of_t (t : t) =
+        List.sexp_of_t [%sexp_of: Peer.t * Time.t] (Heap.to_list t.heap)
+
+      let t_of_sexp s =
+        let elts = [%of_sexp: (Peer.t * Time.t) list] s in
+        let t = create () in
+        List.iter elts ~f:(add t) ;
+        t
+
+      let of_list xs =
+        let now = Time.now () in
+        let t = create () in
+        List.iter xs ~f:(fun p -> add t (p, now)) ;
+        t
+
+      let mem t p = Hashtbl.mem t.table p
+
+      let fold t ~init ~f =
+        Heap.fold t.heap ~init ~f:(fun acc (p, _) -> f acc p)
+
+      let to_list (t : t) = List.map ~f:fst (Heap.to_list t.heap)
+    end
+
+    type t =
+      { downloading_peers: Peer.Hash_set.t
+      ; knowledge_requesting_peers: Peer.Hash_set.t
+      ; temporary_ignores: (unit, unit) Clock.Event.t sexp_opaque Peer.Table.t
+      ; mutable all_preferred: Preferred_heap.t
+      ; knowledge: Knowledge.t Peer.Table.t
             (* Written to when something changes. *)
       ; r: unit Strict_pipe.Reader.t sexp_opaque
       ; w:
@@ -232,184 +258,276 @@ end = struct
           sexp_opaque }
     [@@deriving sexp]
 
-    let reset_knowledge t ~all_peers ~preferred ~active_jobs =
-      (* Clear knowledge *)
-      Hashtbl.clear t.knowledge ;
+    let reset_knowledge t ~all_peers =
       (* Reset preferred *)
-      Hash_set.clear t.all_preferred ;
-      List.iter preferred ~f:(Hash_set.add t.all_preferred) ;
-      (* Clear availability state *)
-      Available_and_useful.clear t.available_and_useful ;
-      (* Reset availability state *)
+      Preferred_heap.clear t.all_preferred ;
+      Hashtbl.filteri_inplace t.knowledge ~f:(fun ~key:p ~data:k ->
+          Hash_set.clear k.tried_and_failed ;
+          Set.mem all_peers p ) ;
       Set.iter all_peers ~f:(fun p ->
-          let to_try =
-            let to_try = Key.Hash_set.create () in
-            List.iter active_jobs ~f:(fun (j : Job.t) ->
-                match Map.find j.attempts p with
-                | None ->
-                    Hash_set.add to_try j.key
-                | Some a ->
-                    if Attempt.worth_retrying a then Hash_set.add to_try j.key
-                    else () ) ;
-            to_try
-          in
-          Peer.Table.add t.knowledge ~key:p ~data:to_try |> ignore ;
-          if not (Hash_set.mem t.downloading_peers p) then
-            Available_and_useful.add t.available_and_useful p
-              (Hash_set.diff to_try t.downloading_keys)
-              ~preferred:(Hash_set.mem t.all_preferred p)
-            |> ignore ) ;
+          if not (Hashtbl.mem t.knowledge p) then
+            Hashtbl.add_exn t.knowledge ~key:p ~data:(Knowledge.create ()) ) ;
       Strict_pipe.Writer.write t.w ()
 
-    let to_yojson {knowledge; all_preferred; available_and_useful; _} =
+    let to_yojson {knowledge; all_preferred; _} =
+      let _list xs =
+        `Assoc [("length", `Int (List.length xs)); ("elts", `List xs)]
+      in
+      let f q = Knowledge.to_yojson q in
       `Assoc
         [ ( "all"
           , `Assoc
               (List.map (Hashtbl.to_alist knowledge) ~f:(fun (p, s) ->
-                   (Peer.to_multiaddr_string p, `Int (Hash_set.length s)) )) )
+                   (Peer.to_multiaddr_string p, f s) )) )
         ; ( "preferred"
           , `List
-              (List.map (Hash_set.to_list all_preferred) ~f:(fun p ->
-                   `String (Peer.to_multiaddr_string p) )) )
-        ; ( "available_and_useful"
-          , `List
-              (List.map
-                 ( Hashtbl.keys available_and_useful.preferred
-                 @ Hashtbl.keys available_and_useful.non_preferred )
-                 ~f:(fun p -> `String (Peer.to_multiaddr_string p))) ) ]
+              (List.map (Preferred_heap.to_list all_preferred) ~f:(fun p ->
+                   `String (Peer.to_multiaddr_string p) )) ) ]
 
     let create ~preferred ~all_peers =
-      let knowledge = Peer.Table.create () in
-      let available_and_useful = Available_and_useful.create () in
-      let preferred = Peer.Hash_set.of_list preferred in
-      List.iter all_peers ~f:(fun p ->
-          Peer.Table.add knowledge ~key:p ~data:(Key.Hash_set.create ())
-          |> ignore ;
-          Available_and_useful.add available_and_useful p
-            (Key.Hash_set.create ()) ~preferred:(Hash_set.mem preferred p)
-          |> ignore ) ;
+      let knowledge =
+        Peer.Table.of_alist_exn
+          (List.map all_peers ~f:(fun p -> (p, Knowledge.create ())))
+      in
       let r, w =
-        Strict_pipe.create ~name:"useful_peers-available"
+        Strict_pipe.create ~name:"useful_peers-available" ~warn_on_drop:false
           (Buffered (`Capacity 0, `Overflow Drop_head))
       in
-      { available_and_useful
-      ; downloading_peers= Peer.Hash_set.create ()
-      ; downloading_keys= Key.Hash_set.create ()
+      { downloading_peers= Peer.Hash_set.create ()
+      ; knowledge_requesting_peers= Peer.Hash_set.create ()
+      ; temporary_ignores= Peer.Table.create ()
       ; knowledge
       ; r
       ; w
-      ; all_preferred= preferred }
+      ; all_preferred= Preferred_heap.of_list preferred }
 
     let tear_down
-        { available_and_useful
-        ; downloading_peers
-        ; downloading_keys
+        { downloading_peers
+        ; temporary_ignores
+        ; knowledge_requesting_peers
         ; knowledge
         ; r= _
         ; w
         ; all_preferred } =
+      Hashtbl.iter temporary_ignores ~f:(fun e ->
+          Clock.Event.abort_if_possible e () ) ;
+      Hashtbl.clear temporary_ignores ;
       Hash_set.clear downloading_peers ;
-      Hash_set.clear downloading_keys ;
-      Hashtbl.iter knowledge ~f:Hash_set.clear ;
+      Hash_set.clear knowledge_requesting_peers ;
+      Hashtbl.iter knowledge ~f:Knowledge.clear ;
       Hashtbl.clear knowledge ;
-      Hash_set.clear all_preferred ;
-      Available_and_useful.clear available_and_useful ;
+      Preferred_heap.clear all_preferred ;
       Strict_pipe.Writer.close w
 
-    (* TODO: Still not right somehow *)
-    let rec read t =
-      match Available_and_useful.get t.available_and_useful with
-      | Some r ->
-          return (`Ok r)
-      | None -> (
-          match%bind Strict_pipe.Reader.read t.r with
-          | `Eof ->
-              return `Eof
-          | `Ok () ->
-              read t )
+    module Knowledge_summary = struct
+      type t = {no_information: int; no: int; claims_to: int}
+      [@@deriving fields]
+
+      (* Score needs revising -- should be more lexicographic *)
+      let score {no_information; no= _; claims_to} =
+        Float.of_int claims_to +. (0.1 *. Float.of_int no_information)
+    end
+
+    let maxes ~compare xs =
+      Sequence.fold xs ~init:[] ~f:(fun acc x ->
+          match acc with
+          | [] ->
+              [x]
+          | best :: _ ->
+              let c = compare best x in
+              if c = 0 then x :: acc else if c < 0 then [x] else acc )
+      |> List.rev
+
+    let useful_peer t ~pending_jobs =
+      let ts =
+        List.rev
+          (Preferred_heap.fold t.all_preferred ~init:[] ~f:(fun acc p ->
+               match Hashtbl.find t.knowledge p with
+               | None ->
+                   acc
+               | Some k ->
+                   (p, k) :: acc ))
+        @ Hashtbl.fold t.knowledge ~init:[] ~f:(fun ~key:p ~data:k acc ->
+              if not (Preferred_heap.mem t.all_preferred p) then (p, k) :: acc
+              else acc )
+      in
+      (* 
+         Algorithm:
+         - Look at the pending jobs
+         - Find all peers who have the best claim to knowing the first job in the queue.
+         - If there are any, pick the one of those who has the best total knowledge score.
+         - If there are none, pick the one of all the peers who has the best total knowledge score.
+      *)
+      let with_best_claim_to_knowing_first_job =
+        match List.hd pending_jobs with
+        | None ->
+            []
+        | Some j ->
+            Sequence.filter_map (Sequence.of_list ts) ~f:(fun (p, k) ->
+                match Knowledge.knows k j.J.key with
+                | `No ->
+                    None
+                | `Claims_to ->
+                    Some ((p, k), `Claims_to)
+                | `No_information ->
+                    Some ((p, k), `No_information) )
+            |> maxes ~compare:(fun (_, c1) (_, c2) ->
+                   match (c1, c2) with
+                   | `Claims_to, `Claims_to | `No_information, `No_information
+                     ->
+                       0
+                   | `Claims_to, `No_information ->
+                       1
+                   | `No_information, `Claims_to ->
+                       -1 )
+            |> List.map ~f:fst
+      in
+      let ts =
+        match with_best_claim_to_knowing_first_job with
+        | [] ->
+            ts
+        | _ :: _ ->
+            with_best_claim_to_knowing_first_job
+      in
+      let knowledge =
+        List.map ts ~f:(fun (p, k) ->
+            let summary, js =
+              List.fold
+                ~init:
+                  ( {Knowledge_summary.no_information= 0; no= 0; claims_to= 0}
+                  , [] )
+                pending_jobs
+                ~f:(fun (acc, js) j ->
+                  let field, js =
+                    let open Knowledge_summary.Fields in
+                    match Knowledge.knows k j.J.key with
+                    | `Claims_to ->
+                        (claims_to, j :: js)
+                    | `No ->
+                        (no, js)
+                    | `No_information ->
+                        (no_information, j :: js)
+                  in
+                  (Field.map field acc ~f:(( + ) 1), js) )
+            in
+            ((p, List.rev js), Knowledge_summary.score summary) )
+      in
+      let useful_exists = List.exists knowledge ~f:(fun (_, s) -> s > 0.) in
+      let best =
+        List.max_elt
+          (List.filter knowledge ~f:(fun ((p, _), _) ->
+               (not (Hashtbl.mem t.temporary_ignores p))
+               && (not (Hash_set.mem t.downloading_peers p))
+               && not (Hash_set.mem t.knowledge_requesting_peers p) ))
+          ~compare:(fun (_, s1) (_, s2) -> Float.compare s1 s2)
+      in
+      match best with
+      | None ->
+          if useful_exists then `Useful_but_busy else `No_peers
+      | Some ((p, k), score) ->
+          if score <= 0. then `Stalled else `Useful (p, k)
 
     type update =
-      | New_job of Job.t
-      | Refreshed_peers of {all_peers: Peer.Set.t; active_jobs: Key.Hash_set.t}
+      | Refreshed_peers of {all_peers: Peer.Set.t}
       | Download_finished of
           Peer.t * [`Successful of Key.t list] * [`Unsuccessful of Key.t list]
-      | Download_starting of Peer.t * Key.t list
+      | Download_starting of Peer.t
       | Job_cancelled of Key.t
+      | Add_knowledge of {peer: Peer.t; claimed: Key.t list; out_of_band: bool}
+      | Knowledge_request_starting of Peer.t
+      | Knowledge of
+          { peer: Peer.t
+          ; claimed: Key.t Claimed_knowledge.t
+          ; active_jobs: Job.t list
+          ; out_of_band: bool }
 
     let jobs_no_longer_needed t ks =
-      Hashtbl.iter t.knowledge ~f:(fun s -> List.iter ks ~f:(Hash_set.remove s)) ;
-      Available_and_useful.filter_inplace t.available_and_useful
-        ~f:(fun to_try ->
-          List.iter ~f:(Hash_set.remove to_try) ks ;
-          not (Hash_set.is_empty to_try) )
+      Hashtbl.iter t.knowledge ~f:(fun s ->
+          List.iter ks ~f:(Hash_set.remove s.tried_and_failed) )
+
+    let ignore_period = Time.Span.of_min 2.
 
     let update t u =
       match u with
+      | Add_knowledge {peer; claimed; out_of_band} ->
+          if not out_of_band then
+            Hash_set.remove t.knowledge_requesting_peers peer ;
+          Hashtbl.update t.knowledge peer ~f:(function
+            | None ->
+                { Knowledge.claimed= Some (`Some claimed)
+                ; tried_and_failed= Key.Hash_set.create () }
+            | Some k ->
+                let claimed =
+                  match k.claimed with
+                  | None ->
+                      `Some claimed
+                  | Some (`Some claimed') ->
+                      `Some
+                        (List.dedup_and_sort ~compare:Key.compare
+                           (claimed' @ claimed))
+                  | Some `All ->
+                      `All
+                  | Some (`Call f) ->
+                      let s = Key.Hash_set.of_list claimed in
+                      `Call (fun key -> f key || Hash_set.mem s key)
+                in
+                {k with claimed= Some claimed} )
+      | Knowledge_request_starting peer ->
+          Hash_set.add t.knowledge_requesting_peers peer
+      | Knowledge {peer; claimed; active_jobs; out_of_band} ->
+          if not out_of_band then
+            Hash_set.remove t.knowledge_requesting_peers peer ;
+          let tried_and_failed =
+            let s = Key.Hash_set.create () in
+            List.iter active_jobs ~f:(fun j ->
+                match Map.find j.J.attempts peer with
+                | None ->
+                    ()
+                | Some a ->
+                    if not (Attempt.worth_retrying a) then Hash_set.add s j.key
+            ) ;
+            s
+          in
+          Hashtbl.set t.knowledge ~key:peer
+            ~data:{Knowledge.claimed= Some claimed; tried_and_failed}
       | Job_cancelled h ->
           jobs_no_longer_needed t [h] ;
-          Hashtbl.iter t.knowledge ~f:(fun s -> Hash_set.remove s h)
-      | Download_starting (peer, ks) ->
-          (* WHen a download starts for a job, we should remove all peers from
-           available and useful whose only useful jobs are in downloading.. *)
-          Hash_set.add t.downloading_peers peer ;
-          List.iter ks ~f:(Hash_set.add t.downloading_keys) ;
-          Available_and_useful.remove t.available_and_useful peer ;
-          Available_and_useful.don't_need_keys t.available_and_useful ks
-      | Download_finished (peer0, `Successful succs, `Unsuccessful unsuccs) ->
-          if not (List.is_empty succs) then Hash_set.add t.all_preferred peer0 ;
+          Hashtbl.iter t.knowledge ~f:(fun s ->
+              Hash_set.remove s.tried_and_failed h )
+      | Download_starting peer ->
+          Hash_set.add t.downloading_peers peer
+      | Download_finished (peer0, `Successful succs, `Unsuccessful unsuccs)
+        -> (
+          (let cancel =
+             Option.iter ~f:(fun e -> Clock.Event.abort_if_possible e ())
+           in
+           if List.is_empty succs then
+             Hashtbl.update t.temporary_ignores peer0 ~f:(fun x ->
+                 cancel x ;
+                 Clock.Event.run_after ignore_period
+                   (fun () ->
+                     Hashtbl.remove t.temporary_ignores peer0 ;
+                     if not (Strict_pipe.Writer.is_closed t.w) then
+                       Strict_pipe.Writer.write t.w () )
+                   () )
+           else (
+             Hashtbl.find_and_remove t.temporary_ignores peer0 |> cancel ;
+             Preferred_heap.add t.all_preferred (peer0, Time.now ()) )) ;
           Hash_set.remove t.downloading_peers peer0 ;
-          List.iter ~f:(Hash_set.remove t.downloading_keys) unsuccs ;
           jobs_no_longer_needed t succs ;
-          ( match Hashtbl.find t.knowledge peer0 with
+          match Hashtbl.find t.knowledge peer0 with
           | None ->
               ()
-          | Some to_try ->
-              List.iter unsuccs ~f:(Hash_set.remove to_try) ;
-              let s = Hash_set.diff to_try t.downloading_keys in
-              Available_and_useful.add t.available_and_useful peer0 s
-                ~preferred:(Hash_set.mem t.all_preferred peer0)
-              |> ignore ) ;
-          (* Update the things in "available_and_useful" with the jobs that are now available. *)
-          (* Move things over from "t.knowledge" into available_and_useful if they are now available and useful *)
-          Hashtbl.iteri t.knowledge ~f:(fun ~key:peer ~data:to_try ->
-              if not (Hash_set.mem t.downloading_peers peer) then
-                match
-                  Available_and_useful.find t.available_and_useful peer
-                with
-                | Some s ->
-                    List.iter unsuccs ~f:(fun k ->
-                        if Hash_set.mem to_try k then Hash_set.add s k )
-                | None ->
-                    let s = Hash_set.diff to_try t.downloading_keys in
-                    Available_and_useful.add t.available_and_useful peer s
-                      ~preferred:(Hash_set.mem t.all_preferred peer)
-                    |> ignore )
-      | Refreshed_peers {all_peers; active_jobs} ->
-          Available_and_useful.filter_keys_inplace t.available_and_useful
-            ~f:(Set.mem all_peers) ;
+          | Some {tried_and_failed; claimed= _} ->
+              List.iter unsuccs ~f:(Hash_set.add tried_and_failed) )
+      | Refreshed_peers {all_peers} ->
           Hashtbl.filter_keys_inplace t.knowledge ~f:(Set.mem all_peers) ;
           Set.iter all_peers ~f:(fun p ->
               if not (Hashtbl.mem t.knowledge p) then
-                ( Hashtbl.add_exn t.knowledge ~key:p
-                    ~data:(Hash_set.copy active_jobs) ;
-                  Available_and_useful.add t.available_and_useful p
-                    (Hash_set.diff active_jobs t.downloading_keys)
-                    ~preferred:(Hash_set.mem t.all_preferred p) )
-                |> ignore )
-      | New_job new_job ->
-          Hashtbl.iteri t.knowledge ~f:(fun ~key:p ~data:to_try ->
-              let useful_for_job = not (Map.mem new_job.attempts p) in
-              if useful_for_job then (
-                Hash_set.add to_try new_job.key ;
-                match Available_and_useful.find t.available_and_useful p with
-                | Some s ->
-                    Hash_set.add s new_job.key
-                | None ->
-                    if not (Hash_set.mem t.downloading_peers p) then
-                      let s = Hash_set.diff to_try t.downloading_keys in
-                      Available_and_useful.add t.available_and_useful p s
-                        ~preferred:(Hash_set.mem t.all_preferred p)
-                      |> ignore ) )
+                Hashtbl.add_exn t.knowledge ~key:p
+                  ~data:
+                    { Knowledge.claimed= None
+                    ; tried_and_failed= Key.Hash_set.create () } )
 
     let update t u : unit =
       update t u ;
@@ -421,8 +539,7 @@ end = struct
     { mutable next_flush: (unit, unit) Clock.Event.t option
     ; mutable all_peers: Peer.Set.t
     ; pending: Job.t Q.t
-    ; stalled: Job.t Q.t
-    ; downloading: (Peer.t * Job.t) Key.Table.t
+    ; downloading: (Peer.t * Job.t * Time.t) Key.Table.t
     ; useful_peers: Useful_peers.t
     ; flush_r: unit Strict_pipe.Reader.t (* Single reader *)
     ; flush_w:
@@ -432,9 +549,7 @@ end = struct
         Strict_pipe.Writer.t
           (* buffer of length 0 *)
     ; get: Peer.t -> Key.t list -> Result.t list Deferred.Or_error.t
-    ; peers: unit -> Peer.t list Deferred.t
     ; max_batch_size: int
-    ; preferred: Peer.t list
           (* A peer is useful if there is a job in the pending queue which has not
    been attempted with that peer. *)
     ; got_new_peers_w:
@@ -448,17 +563,13 @@ end = struct
     ; trust_system: Trust_system.t
     ; stop: unit Deferred.t }
 
-  let total_jobs (t : t) =
-    Q.length t.pending + Q.length t.stalled + Hashtbl.length t.downloading
+  let total_jobs (t : t) = Q.length t.pending + Hashtbl.length t.downloading
 
   (* Checks disjointness *)
   let check_invariant (t : t) =
     Set.length
       (Key.Set.union_list
          [ Q.to_list t.pending
-           |> List.map ~f:(fun j -> j.key)
-           |> Key.Set.of_list
-         ; Q.to_list t.stalled
            |> List.map ~f:(fun j -> j.key)
            |> Key.Set.of_list
          ; Key.Set.of_hashtbl_keys t.downloading ])
@@ -490,17 +601,14 @@ end = struct
             ())
 
   let cancel t h =
-    [%log' debug t.logger]
-      ~metadata:[("key", Key.to_yojson h)]
-      "cancel the download $key" ;
     let job =
       List.find_map ~f:Lazy.force
         [ lazy (Q.lookup t.pending h)
-        ; lazy (Q.lookup t.stalled h)
-        ; lazy (Option.map ~f:snd (Hashtbl.find t.downloading h)) ]
+        ; lazy
+            (Option.map ~f:(fun (_, j, _) -> j) (Hashtbl.find t.downloading h))
+        ]
     in
     Q.remove t.pending h ;
-    Q.remove t.stalled h ;
     Hashtbl.remove t.downloading h ;
     match job with
     | None ->
@@ -509,64 +617,38 @@ end = struct
         kill_job t j ;
         Useful_peers.update t.useful_peers (Job_cancelled h)
 
-  let is_stalled t e = Set.for_all t.all_peers ~f:(Map.mem e.J.attempts)
-
-  let enqueue t e =
-    if is_stalled t e then Q.enqueue t.stalled e else Q.enqueue t.pending e
+  let enqueue t e = Q.enqueue t.pending e
 
   let enqueue_exn t e = assert (enqueue t e = `Ok)
 
-  let active_job_keys t =
-    let res = Key.Hash_set.create () in
-    Q.iter t.pending ~f:(fun j -> Hash_set.add res j.key) ;
-    Q.iter t.stalled ~f:(fun j -> Hash_set.add res j.key) ;
-    Hashtbl.iter_keys t.downloading ~f:(Hash_set.add res) ;
-    res
-
   let active_jobs t =
-    Q.to_list t.pending @ Q.to_list t.stalled
-    @ List.map (Hashtbl.data t.downloading) ~f:snd
+    Q.to_list t.pending
+    @ List.map (Hashtbl.data t.downloading) ~f:(fun (_, j, _) -> j)
 
-  let refresh_peers t =
-    let%map peers = t.peers () in
-    let peers' = Peer.Set.of_list peers in
-    let new_peers = Set.diff peers' t.all_peers in
-    Useful_peers.update t.useful_peers
-      (Refreshed_peers {all_peers= peers'; active_jobs= active_job_keys t}) ;
-    if
-      (not (Set.is_empty new_peers))
-      && not (Strict_pipe.Writer.is_closed t.got_new_peers_w)
-    then Strict_pipe.Writer.write t.got_new_peers_w () ;
-    t.all_peers <- Peer.Set.of_list peers ;
-    let rec go n =
-      (* We need the initial length explicitly because we may re-enqueue things
-           while looping. *)
-      if n = 0 then ()
-      else
-        match Q.dequeue t.stalled with
-        | None ->
-            ()
-        | Some e ->
-            enqueue_exn t e ;
-            go (n - 1)
-    in
-    go (Q.length t.stalled)
-
-  let peer_refresh_interval = Time.Span.of_min 1.
+  let refresh_peers t peers =
+    Broadcast_pipe.Reader.iter peers ~f:(fun peers ->
+        let peers' = Peer.Set.of_list peers in
+        let new_peers = Set.diff peers' t.all_peers in
+        Useful_peers.update t.useful_peers
+          (Refreshed_peers {all_peers= peers'}) ;
+        if
+          (not (Set.is_empty new_peers))
+          && not (Strict_pipe.Writer.is_closed t.got_new_peers_w)
+        then Strict_pipe.Writer.write t.got_new_peers_w () ;
+        t.all_peers <- Peer.Set.of_list peers ;
+        Deferred.unit )
+    |> don't_wait_for
 
   let tear_down
       ( { next_flush
         ; all_peers= _
         ; flush_w
-        ; peers= _
         ; get= _
         ; got_new_peers_w
         ; flush_r= _
         ; useful_peers
         ; got_new_peers_r= _
         ; pending
-        ; stalled
-        ; preferred= _
         ; downloading
         ; max_batch_size= _
         ; logger= _
@@ -583,27 +665,32 @@ end = struct
     Strict_pipe.Writer.close flush_w ;
     Useful_peers.tear_down useful_peers ;
     Strict_pipe.Writer.close got_new_peers_w ;
-    Hashtbl.iter downloading ~f:(fun (_, j) -> kill_job t j) ;
+    Hashtbl.iter downloading ~f:(fun (_, j, _) -> kill_job t j) ;
     Hashtbl.clear downloading ;
-    clear_queue pending ;
-    clear_queue stalled
+    clear_queue pending
 
   let download t peer xs =
+    let f xs =
+      let n = List.length xs in
+      `Assoc
+        ( ("length", `Int n)
+        ::
+        ( if n > 8 then []
+        else [("elts", `List (List.map xs ~f:(fun j -> Key.to_yojson j.J.key)))]
+        ) )
+    in
     let keys = List.map xs ~f:(fun x -> x.J.key) in
     let fail ?punish (e : Error.t) =
       let e = Error.to_string_hum e in
+      [%log' debug t.logger] "Downloading from $peer failed ($error) on $keys"
+        ~metadata:
+          [("peer", Peer.to_yojson peer); ("error", `String e); ("keys", f xs)] ;
       if Option.is_some punish then
         (* TODO: Make this an insta ban *)
         Trust_system.(
           record t.trust_system t.logger peer
             Actions.(Violated_protocol, Some (e, [])))
         |> don't_wait_for ;
-      [%log' debug t.logger] "Downloading from $peer failed ($error) on $keys"
-        ~metadata:
-          [ ("peer", Peer.to_yojson peer)
-          ; ("error", `String e)
-          ; ("keys", `List (List.map keys ~f:Key.to_yojson)) ] ;
-      (* TODO: Log error *)
       List.iter xs ~f:(fun x ->
           enqueue_exn t
             { x with
@@ -612,8 +699,8 @@ end = struct
       flush_soon t
     in
     List.iter xs ~f:(fun x ->
-        Hashtbl.set t.downloading ~key:x.key ~data:(peer, x) ) ;
-    Useful_peers.update t.useful_peers (Download_starting (peer, keys)) ;
+        Hashtbl.set t.downloading ~key:x.key ~data:(peer, x, Time.now ()) ) ;
+    Useful_peers.update t.useful_peers (Download_starting peer) ;
     let download_deferred = t.get peer keys in
     upon download_deferred (fun res ->
         let succs, unsuccs =
@@ -652,7 +739,9 @@ end = struct
           fail e
       | Ok rs ->
           [%log' debug t.logger] "result is $result"
-            ~metadata:[("result", `Int (List.length rs))] ;
+            ~metadata:
+              [ ("result", f xs)
+              ; ("peer", `String (Peer.to_multiaddr_string peer)) ] ;
           let received_at = Time.now () in
           let jobs =
             Key.Table.of_alist_exn (List.map xs ~f:(fun x -> (x.key, x)))
@@ -682,181 +771,240 @@ end = struct
                 } ) ;
           flush_soon t )
 
-  let is_empty t = Q.is_empty t.pending && Q.is_empty t.stalled
-
-  let all_stalled t = Q.is_empty t.pending
-
   let to_yojson t : Yojson.Safe.t =
     check_invariant t ;
-    let list xs = `Assoc [("length", `Int (List.length xs))] in
+    let list xs =
+      `Assoc [("length", `Int (List.length xs)); ("elts", `List xs)]
+    in
+    let now = Time.now () in
     let f q = list (List.map ~f:Job.to_yojson (Q.to_list q)) in
     `Assoc
       [ ("total_jobs", `Int (total_jobs t))
       ; ("useful_peers", Useful_peers.to_yojson t.useful_peers)
       ; ("pending", f t.pending)
-      ; ("stalled", f t.stalled)
       ; ( "downloading"
         , list
-            (List.map (Hashtbl.to_alist t.downloading) ~f:(fun (h, (p, _)) ->
+            (List.map (Hashtbl.to_alist t.downloading)
+               ~f:(fun (h, (p, _, start)) ->
                  `Assoc
                    [ ("hash", Key.to_yojson h)
+                   ; ("start", `String (Time.to_string start))
+                   ; ( "time_since_start"
+                     , `String (Time.Span.to_string_hum (Time.diff now start))
+                     )
                    ; ("peer", `String (Peer.to_multiaddr_string p)) ] )) ) ]
 
   let post_stall_retry_delay = Time.Span.of_min 1.
 
   let rec step t =
-    [%log' debug t.logger] "Downloader: Mownload step"
-      ~metadata:[("downloader", to_yojson t)] ;
-    if is_empty t then (
+    if Q.length t.pending = 0 then (
+      [%log' debug t.logger] "Downloader: no jobs. waiting" ;
       match%bind Strict_pipe.Reader.read t.flush_r with
       | `Eof ->
           [%log' debug t.logger] "Downloader: flush eof" ;
           Deferred.unit
       | `Ok () ->
-          [%log' debug t.logger] "Downloader: flush" ;
           step t )
-    else if all_stalled t then (
-      [%log' debug t.logger]
-        "Downloader: all stalled. Resetting knowledge, waiting %s and then \
-         retrying."
-        (Time.Span.to_string_hum post_stall_retry_delay) ;
-      Useful_peers.reset_knowledge t.useful_peers ~all_peers:t.all_peers
-        ~preferred:t.preferred ~active_jobs:(active_jobs t) ;
-      Q.iter t.stalled ~f:(Q.enqueue_exn t.pending) ;
-      Q.clear t.stalled ;
-      let%bind () = after post_stall_retry_delay in
-      [%log' debug t.logger] "Downloader: continuing after reset" ;
-      step t )
-    else (
-      [%log' debug t.logger] "Downloader: else"
-        ~metadata:
-          [ ( "peer_available"
-            , `Bool
-                (Option.is_some
-                   ( Strict_pipe.Reader.to_linear_pipe t.useful_peers.r
-                   |> Linear_pipe.peek )) ) ] ;
-      match%bind Useful_peers.read t.useful_peers with
-      | `Eof ->
-          Deferred.unit
-      | `Ok (peer, useful_for) -> (
-          let f xs = `Assoc [("length", `Int (List.length xs))] in
-          (let in_pending_useful_self =
-             List.filter (Q.to_list t.pending) ~f:(fun x ->
-                 Hash_set.mem useful_for x.J.key )
-           in
-           let in_pending_useful_them =
-             List.filter (Q.to_list t.pending) ~f:(fun x ->
-                 not (Map.mem x.attempts peer) )
-           in
-           let in_downloading_useful_self =
-             List.filter_map (Hashtbl.to_alist t.downloading)
-               ~f:(fun (_, (_, x)) ->
-                 if Hash_set.mem useful_for x.J.key then Some x else None )
-           in
-           let in_downloading_useful_them =
-             List.filter_map (Hashtbl.to_alist t.downloading)
-               ~f:(fun (_, (_, x)) ->
-                 if not (Map.mem x.attempts peer) then Some x else None )
-           in
-           [%log' debug t.logger] "cooldebug Downloader: got $peer"
-             ~metadata:
-               [ ("peer", Peer.to_yojson peer)
-               ; ( "in_pending_useful_agree"
-                 , `Bool
-                     (Int.equal
-                        (List.length in_pending_useful_self)
-                        (List.length in_pending_useful_them)) )
-               ; ( "in_downloading_useful_agree"
-                 , `Bool
-                     (Int.equal
-                        (List.length in_downloading_useful_self)
-                        (List.length in_downloading_useful_them)) )
-               ; ("in_pending_useful_self", f in_pending_useful_self)
-               ; ("in_pending_useful_them", f in_pending_useful_them)
-               ; ("in_downloading_useful_self", f in_downloading_useful_self)
-               ; ("in_downloading_useful_them", f in_downloading_useful_them)
-               ]) ;
-          let to_download =
-            let rec go n acc skipped =
-              if n >= t.max_batch_size then (acc, skipped)
-              else
-                match Q.dequeue t.pending with
-                | None ->
-                    (acc, skipped)
-                | Some x ->
-                    if not (Hash_set.mem useful_for x.key) then
-                      go n acc (x :: skipped)
-                    else go (n + 1) (x :: acc) skipped
-            in
-            let acc, skipped = go 0 [] [] in
-            List.iter (List.rev skipped) ~f:(enqueue_exn t) ;
-            List.rev acc
+    else
+      match
+        Useful_peers.useful_peer t.useful_peers
+          ~pending_jobs:(Q.to_list t.pending)
+      with
+      | `No_peers -> (
+          match%bind Strict_pipe.Reader.read t.got_new_peers_r with
+          | `Eof ->
+              [%log' debug t.logger] "Downloader: new peers eof" ;
+              Deferred.unit
+          | `Ok () ->
+              step t )
+      | `Useful_but_busy -> (
+          [%log' debug t.logger] "Downloader: Waiting. All useful peers busy" ;
+          let read p =
+            Pipe.read_choice_single_consumer_exn
+              (Strict_pipe.Reader.to_linear_pipe p).pipe [%here]
           in
-          [%log' debug t.logger] "cooldebug Downloader: to download $n"
+          match%bind
+            Deferred.choose [read t.flush_r; read t.useful_peers.r]
+          with
+          | `Eof ->
+              [%log' debug t.logger] "Downloader: flush eof" ;
+              Deferred.unit
+          | `Ok () ->
+              (* Try again, something might have changed *)
+              step t )
+      | `Stalled ->
+          [%log' debug t.logger]
+            "Downloader: all stalled. Resetting knowledge, waiting %s and \
+             then retrying."
+            (Time.Span.to_string_hum post_stall_retry_delay) ;
+          Useful_peers.reset_knowledge t.useful_peers ~all_peers:t.all_peers ;
+          let%bind () = after post_stall_retry_delay in
+          [%log' debug t.logger] "Downloader: continuing after reset" ;
+          step t
+      | `Useful (peer, might_know) -> (
+          let to_download = List.take might_know t.max_batch_size in
+          [%log' debug t.logger] "Downloader: downloading $n from $peer"
             ~metadata:
               [ ("n", `Int (List.length to_download))
-              ; ("to_download", f to_download) ] ;
+              ; ("peer", Peer.to_yojson peer) ] ;
+          List.iter to_download ~f:(fun j -> Q.remove t.pending j.key) ;
           match to_download with
           | [] ->
               step t
           | _ :: _ ->
               don't_wait_for (download t peer to_download) ;
-              step t ) )
+              step t )
 
-  let create ~max_batch_size ~stop ~trust_system ~get ~peers ~preferred =
+  let add_knowledge t peer claimed =
+    Useful_peers.update t.useful_peers
+      (Add_knowledge {peer; claimed; out_of_band= true})
+
+  let update_knowledge t peer claimed =
+    Useful_peers.update t.useful_peers
+      (Knowledge {peer; claimed; active_jobs= active_jobs t; out_of_band= true})
+
+  let mark_preferred t peer ~now =
+    Useful_peers.Preferred_heap.add t.useful_peers.all_preferred (peer, now)
+
+  let create ~max_batch_size ~stop ~trust_system ~get ~knowledge_context
+      ~knowledge ~peers ~preferred =
     let%map all_peers = peers () in
     let pipe ~name c =
-      Strict_pipe.create ~name (Buffered (`Capacity c, `Overflow Drop_head))
+      Strict_pipe.create ~warn_on_drop:false ~name
+        (Buffered (`Capacity c, `Overflow Drop_head))
     in
     let flush_r, flush_w = pipe ~name:"flush" 0 in
     let got_new_peers_r, got_new_peers_w = pipe ~name:"got_new_peers" 0 in
     let t =
       { all_peers= Peer.Set.of_list all_peers
       ; pending= Q.create ()
-      ; stalled= Q.create ()
       ; next_flush= None
       ; flush_r
       ; flush_w
       ; got_new_peers_r
       ; got_new_peers_w
       ; useful_peers= Useful_peers.create ~all_peers ~preferred
-      ; preferred
       ; get
-      ; peers
       ; max_batch_size
       ; logger= Logger.create ()
       ; trust_system
       ; downloading= Key.Table.create ()
       ; stop }
     in
+    let peers =
+      let r, w = Broadcast_pipe.create [] in
+      upon stop (fun () -> Broadcast_pipe.Writer.close w) ;
+      Clock.every' ~stop (Time.Span.of_min 1.) (fun () ->
+          peers ()
+          >>= fun ps ->
+          try Broadcast_pipe.Writer.write w ps
+          with Broadcast_pipe.Already_closed _ -> Deferred.unit ) ;
+      r
+    in
+    let deferred_ok = Deferred.return `Ok in
+    let deferred_finished = Deferred.return `Finished in
+    let const_eof _ = `Eof in
+    let rec jobs_to_download stop =
+      if total_jobs t <> 0 then deferred_ok
+      else
+        match%bind
+          Deferred.choose
+            [ choice stop const_eof
+            ; choice
+                (Pipe.values_available
+                   (Strict_pipe.Reader.to_linear_pipe t.flush_r).pipe)
+                Fn.id
+            ; choice
+                (Pipe.values_available
+                   (Strict_pipe.Reader.to_linear_pipe t.useful_peers.r).pipe)
+                Fn.id ]
+        with
+        | `Eof ->
+            deferred_finished
+        | `Ok ->
+            jobs_to_download stop
+    in
+    let () =
+      let request_r, request_w =
+        Strict_pipe.create ~name:"knowledge-requests" Strict_pipe.Synchronous
+      in
+      upon stop (fun () -> Strict_pipe.Writer.close request_w) ;
+      let refresh_knowledge stop peer =
+        Clock.every' (Time.Span.of_min 7.) ~stop (fun () ->
+            match%bind jobs_to_download stop with
+            | `Finished ->
+                Deferred.unit
+            | `Ok ->
+                if not (Strict_pipe.Writer.is_closed request_w) then
+                  Strict_pipe.Writer.write request_w peer
+                else Deferred.unit )
+      in
+      let ps : unit Ivar.t Peer.Table.t = Peer.Table.create () in
+      Broadcast_pipe.Reader.iter peers ~f:(fun peers ->
+          let peers = Peer.Hash_set.of_list peers in
+          Hashtbl.filteri_inplace ps ~f:(fun ~key:p ~data:finished ->
+              let keep = Hash_set.mem peers p in
+              if not keep then Ivar.fill_if_empty finished () ;
+              keep ) ;
+          Hash_set.iter peers ~f:(fun p ->
+              if not (Hashtbl.mem ps p) then (
+                let finished = Ivar.create () in
+                refresh_knowledge (Ivar.read finished) p ;
+                Hashtbl.add_exn ps ~key:p ~data:finished ) ) ;
+          Deferred.unit )
+      |> don't_wait_for ;
+      let throttle =
+        Throttle.create ~continue_on_error:true ~max_concurrent_jobs:8
+      in
+      let get_knowledge ctx peer =
+        Throttle.enqueue throttle (fun () -> knowledge ctx peer)
+      in
+      Broadcast_pipe.Reader.iter knowledge_context ~f:(fun _ ->
+          Hashtbl.mapi_inplace ps ~f:(fun ~key:p ~data:finished ->
+              Ivar.fill_if_empty finished () ;
+              let finished = Ivar.create () in
+              refresh_knowledge (Ivar.read finished) p ;
+              finished ) ;
+          Deferred.unit )
+      |> don't_wait_for ;
+      Strict_pipe.Reader.iter request_r ~f:(fun peer ->
+          (* TODO: The pipe/clock logic is not quite right, but it is good enough. *)
+          if Deferred.is_determined stop then Deferred.unit
+          else
+            let%map () = Throttle.capacity_available throttle in
+            don't_wait_for
+              (let ctx = Broadcast_pipe.Reader.peek knowledge_context in
+               (* TODO: Check if already downloading a job from them here. *)
+               Useful_peers.update t.useful_peers
+                 (Knowledge_request_starting peer) ;
+               let%map k = get_knowledge ctx peer in
+               Useful_peers.update t.useful_peers
+                 (Knowledge
+                    { out_of_band= false
+                    ; peer
+                    ; claimed= k
+                    ; active_jobs= active_jobs t })) )
+      |> don't_wait_for
+    in
     don't_wait_for (step t) ;
     upon stop (fun () -> tear_down t) ;
-    every ~stop (Time.Span.of_sec 10.) (fun () ->
+    every ~stop (Time.Span.of_sec 30.) (fun () ->
         [%log' debug t.logger]
           ~metadata:[("jobs", to_yojson t)]
           "Downloader jobs" ) ;
-    Clock.every' ~stop peer_refresh_interval (fun () -> refresh_peers t) ;
+    refresh_peers t peers ;
     t
 
   (* After calling download, if no one else has called within time [max_wait], 
        we flush our queue. *)
   let download t ~key ~attempts : Job.t =
-    match
-      ( Q.lookup t.pending key
-      , Q.lookup t.stalled key
-      , Hashtbl.find t.downloading key )
-    with
-    | Some _, Some _, Some _
-    | None, Some _, Some _
-    | Some _, None, Some _
-    | Some _, Some _, None ->
+    match (Q.lookup t.pending key, Hashtbl.find t.downloading key) with
+    | Some _, Some _ ->
         assert false
-    | Some x, None, None | None, Some x, None | None, None, Some (_, x) ->
+    | Some x, None | None, Some (_, x, _) ->
         x
-    | None, None, None ->
+    | None, None ->
         flush_soon t ;
         let e = {J.key; attempts; res= Ivar.create ()} in
-        enqueue_exn t e ;
-        Useful_peers.update t.useful_peers (New_job e) ;
-        e
+        enqueue_exn t e ; e
 end

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -478,7 +478,13 @@ end = struct
           if not out_of_band then
             Hash_set.remove t.knowledge_requesting_peers peer ;
           let tried_and_failed =
-            let s = Key.Hash_set.create () in
+            let s =
+              match Hashtbl.find t.knowledge peer with
+              | None ->
+                  Key.Hash_set.create ()
+              | Some {tried_and_failed; _} ->
+                  tried_and_failed
+            in
             List.iter active_jobs ~f:(fun j ->
                 match Map.find j.J.attempts peer with
                 | None ->

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -24,6 +24,15 @@ module Claimed_knowledge = struct
   type 'key t = [`All | `Some of 'key list | `Call of 'key pred sexp_opaque]
   [@@deriving sexp, to_yojson]
 
+  let to_yojson f t =
+    match t with
+    | `Some ks ->
+        let n = List.length ks in
+        if n > 5 then to_yojson (fun x -> `Int x) (`Some [n])
+        else to_yojson f t
+    | _ ->
+        to_yojson f t
+
   let check ~equal t k =
     match t with
     | `All ->
@@ -263,15 +272,20 @@ end = struct
       Preferred_heap.clear t.all_preferred ;
       Hashtbl.filter_mapi_inplace t.knowledge ~f:(fun ~key:p ~data:k ->
           Hash_set.clear k.tried_and_failed ;
-          if Set.mem all_peers p 
-          then Some { k with claimed=None }
-          else None ) ;
+          if Set.mem all_peers p then Some {k with claimed= None} else None ) ;
       Set.iter all_peers ~f:(fun p ->
           if not (Hashtbl.mem t.knowledge p) then
             Hashtbl.add_exn t.knowledge ~key:p ~data:(Knowledge.create ()) ) ;
       Strict_pipe.Writer.write t.w ()
 
-    let to_yojson {knowledge; all_preferred; knowledge_requesting_peers; temporary_ignores; downloading_peers;r=_;w=_} =
+    let to_yojson
+        { knowledge
+        ; all_preferred
+        ; knowledge_requesting_peers
+        ; temporary_ignores
+        ; downloading_peers
+        ; r= _
+        ; w= _ } =
       let list xs =
         `Assoc [("length", `Int (List.length xs)); ("elts", `List xs)]
       in
@@ -284,17 +298,18 @@ end = struct
         ; ( "preferred"
           , `List
               (List.map (Preferred_heap.to_list all_preferred) ~f:(fun p ->
-                   `String (Peer.to_multiaddr_string p) )) ) 
-        ; ("temporary_ignores", 
-           list (List.map ~f:Peer.to_yojson (Hashtbl.keys temporary_ignores)
-          ) )
-        ; ("downloading_peers", 
-           list (List.map ~f:Peer.to_yojson (Hash_set.to_list downloading_peers)
-          ) )
-        ; ("knowledge_requesting_peers", 
-           list (List.map ~f:Peer.to_yojson (Hash_set.to_list knowledge_requesting_peers)
-          ) )
-        ]
+                   `String (Peer.to_multiaddr_string p) )) )
+        ; ( "temporary_ignores"
+          , list (List.map ~f:Peer.to_yojson (Hashtbl.keys temporary_ignores))
+          )
+        ; ( "downloading_peers"
+          , list
+              (List.map ~f:Peer.to_yojson (Hash_set.to_list downloading_peers))
+          )
+        ; ( "knowledge_requesting_peers"
+          , list
+              (List.map ~f:Peer.to_yojson
+                 (Hash_set.to_list knowledge_requesting_peers)) ) ]
 
     let create ~preferred ~all_peers =
       let knowledge =

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -132,6 +132,8 @@ let setup (type n) ?(logger = Logger.null ())
                 ~get_best_tip:(fun _ -> failwith "Get_best_tip unimplemented")
                 ~get_telemetry_data:(fun _ ->
                   failwith "Get_telemetry data unimplemented" )
+                ~get_transition_knowledge:(fun _query ->
+                  Deferred.return (Sync_handler.best_tip_path ~frontier) )
                 ~get_transition_chain_proof:(fun query_env ->
                   Deferred.return
                     (Transition_chain_prover.prove ~frontier

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -579,11 +579,10 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
                 | None ->
                     d
                 | Some timeout ->
-                    Deferred.any
-                      [ d
-                      ; ( after timeout
-                        >>| fun () -> Or_error.error_string "rpc timed out" )
-                      ] )
+                    Deferred.choose
+                      [ Deferred.choice d Fn.id
+                      ; choice (after timeout) (fun () ->
+                            Or_error.error_string "rpc timed out" ) ] )
               transport
               ~on_handshake_error:
                 (`Call

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -113,11 +113,9 @@ module G = Graph.Graphviz.Dot (struct
   let edge_attributes _ = []
 end)
 
-let _write_graph (t : t) =
-  let path = "/home/izzy/repos/coda/super-catchup-develop/catchup.dot" in
-  Out_channel.with_file path ~f:(fun c -> G.output_graph c t)
-
-let write_graph (_ : t) = ()
+let write_graph (_ : t) =
+  let _ = G.output_graph in
+  ()
 
 let verify_transition ~logger ~consensus_constants ~trust_system ~frontier
     ~unprocessed_transition_cache enveloped_transition =

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -678,7 +678,11 @@ let run ~logger ~trust_system ~verifier ~network ~frontier
     Downloader.create ~stop ~trust_system ~preferred:[] ~max_batch_size:5
       ~get:(fun peer hs ->
         let sec =
-          let sec_per_block = 15. in
+          let sec_per_block =
+            Option.value_map
+              (Sys.getenv "MINA_EXPECTED_PER_BLOCK_DOWNLOAD_TIME")
+              ~default:15. ~f:Float.of_string
+          in
           Float.of_int (List.length hs) *. sec_per_block
         in
         Mina_networking.get_transition_chain

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -238,6 +238,8 @@ module type Sync_handler_intf = sig
     -> State_hash.t sexp_list
     -> External_transition.t sexp_list option
 
+  val best_tip_path : frontier:transition_frontier -> State_hash.t sexp_list
+
   (** Allows a peer to prove to a node that they can bootstrap from transition
       that they have gossiped to the network *)
   module Root :

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1106,6 +1106,15 @@ let create ?wallets (config : Config.t) =
               ~get_transition_chain:
                 (handle_request "get_transition_chain"
                    ~f:Sync_handler.get_transition_chain)
+              ~get_transition_knowledge:(fun _q ->
+                return
+                  ( match
+                      Broadcast_pipe.Reader.peek frontier_broadcast_pipe_r
+                    with
+                  | None ->
+                      []
+                  | Some frontier ->
+                      Sync_handler.best_tip_path ~frontier ) )
           in
           (* tie the first knot *)
           net_ref := Some net ;

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -333,6 +333,57 @@ module Rpcs = struct
     end
   end
 
+  module Get_transition_knowledge = struct
+    module Master = struct
+      let name = "Get_transition_knowledge"
+
+      module T = struct
+        type query = unit [@@deriving sexp, to_yojson]
+
+        type response = State_hash.t list
+      end
+
+      module Caller = T
+      module Callee = T
+    end
+
+    include Master.T
+    module M = Versioned_rpc.Both_convert.Plain.Make (Master)
+    include M
+
+    include Perf_histograms.Rpc.Plain.Extend (struct
+      include M
+      include Master
+    end)
+
+    module V1 = struct
+      module T = struct
+        type query = unit [@@deriving bin_io, sexp, version {rpc}]
+
+        type response = State_hash.Stable.V1.t list
+        [@@deriving bin_io, version {rpc}]
+
+        let query_of_caller_model = Fn.id
+
+        let callee_model_of_query = Fn.id
+
+        let response_of_callee_model = Fn.id
+
+        let caller_model_of_response = Fn.id
+      end
+
+      module T' =
+        Perf_histograms.Rpc.Plain.Decorate_bin_io (struct
+            include M
+            include Master
+          end)
+          (T)
+
+      include T'
+      include Register (T')
+    end
+  end
+
   module Get_ancestry = struct
     module Master = struct
       let name = "get_ancestry"
@@ -624,6 +675,10 @@ module Rpcs = struct
           rpc
     | Get_transition_chain
         : (Get_transition_chain.query, Get_transition_chain.response) rpc
+    | Get_transition_knowledge
+        : ( Get_transition_knowledge.query
+          , Get_transition_knowledge.response )
+          rpc
     | Get_transition_chain_proof
         : ( Get_transition_chain_proof.query
           , Get_transition_chain_proof.response )
@@ -653,6 +708,8 @@ module Rpcs = struct
         (module Answer_sync_ledger_query)
     | Get_transition_chain ->
         (module Get_transition_chain)
+    | Get_transition_knowledge ->
+        (module Get_transition_knowledge)
     | Get_transition_chain_proof ->
         (module Get_transition_chain_proof)
     | Get_ancestry ->
@@ -798,7 +855,10 @@ let create (config : Config.t)
        -> Rpcs.Get_transition_chain_proof.response Deferred.t)
     ~(get_transition_chain :
           Rpcs.Get_transition_chain.query Envelope.Incoming.t
-       -> Rpcs.Get_transition_chain.response Deferred.t) =
+       -> Rpcs.Get_transition_chain.response Deferred.t)
+    ~(get_transition_knowledge :
+          Rpcs.Get_transition_knowledge.query Envelope.Incoming.t
+       -> Rpcs.Get_transition_knowledge.response Deferred.t) =
   let logger = config.logger in
   let run_for_rpc_result conn data ~f action_msg msg_args =
     let data_in_envelope = wrap_rpc_data_in_envelope conn data in
@@ -1001,6 +1061,16 @@ let create (config : Config.t)
     in
     record_unknown_item result sender action_msg msg_args
   in
+  let get_transition_knowledge_rpc conn ~version:_ query =
+    [%log info] "Sending transition_knowledge to $peer" ~metadata:(md conn) ;
+    let action_msg = "Get_transition_knowledge query: $query" in
+    let msg_args =
+      [("query", Rpcs.Get_transition_knowledge.query_to_yojson query)]
+    in
+    run_for_rpc_result conn query ~f:get_transition_knowledge action_msg
+      msg_args
+    >>| fst
+  in
   let get_transition_chain_rpc conn ~version:_ query =
     [%log info] "Sending transition_chain to $peer" ~metadata:(md conn) ;
     let action_msg = "Get_transition_chain query: $query" in
@@ -1069,6 +1139,11 @@ let create (config : Config.t)
         { rpc= Get_ancestry
         ; f= get_ancestry_rpc
         ; budget= (5, `Per minute)
+        ; cost= unit }
+    ; Rpc_handler
+        { rpc= Get_transition_knowledge
+        ; f= get_transition_knowledge_rpc
+        ; budget= (1, `Per minute)
         ; cost= unit }
     ; Rpc_handler
         { rpc= Get_transition_chain
@@ -1186,8 +1261,6 @@ include struct
 
   let random_peers = lift random_peers
 
-  let random_peers_except = lift random_peers_except
-
   let query_peer ?heartbeat_timeout ?timeout {gossip_net; _} =
     query_peer ?heartbeat_timeout ?timeout gossip_net
 
@@ -1242,20 +1315,6 @@ let broadcast_snark_pool_diff t diff =
              Option.value_exn (Snark_pool.Resource_pool.Diff.to_compact diff)
          })
 
-(* TODO: This is kinda inefficient *)
-let find_map xs ~f =
-  let open Async in
-  let ds = List.map xs ~f in
-  let filter ~f =
-    Deferred.bind ~f:(fun x -> if f x then return x else Deferred.never ())
-  in
-  let none_worked =
-    Deferred.bind (Deferred.all ds) ~f:(fun ds ->
-        if List.for_all ds ~f:Option.is_none then return None
-        else Deferred.never () )
-  in
-  Deferred.any (none_worked :: List.map ~f:(filter ~f:Option.is_some) ds)
-
 (* TODO: Don't copy and paste *)
 let find_map' xs ~f =
   let open Async in
@@ -1290,9 +1349,9 @@ let make_rpc_request ?heartbeat_timeout ?timeout ~rpc ~label t peer input =
   | Failed_to_connect e ->
       Error (Error.tag e ~tag:"failed-to-connect")
 
-let get_transition_chain_proof ?timeout t =
-  make_rpc_request ?timeout ~rpc:Rpcs.Get_transition_chain_proof
-    ~label:"transition chain proof" t
+let get_transition_chain_proof ?heartbeat_timeout ?timeout t =
+  make_rpc_request ?heartbeat_timeout ?timeout
+    ~rpc:Rpcs.Get_transition_chain_proof ~label:"transition chain proof" t
 
 let get_transition_chain ?heartbeat_timeout ?timeout t =
   make_rpc_request ?heartbeat_timeout ?timeout ~rpc:Rpcs.Get_transition_chain
@@ -1428,88 +1487,8 @@ module Sl_downloader = struct
 
               let key = fst
             end)
+            (Ledger_hash)
 end
-
-let glue_sync_ledger :
-       t
-    -> (Mina_base.Ledger_hash.t * Mina_base.Sync_ledger.Query.t)
-       Pipe_lib.Linear_pipe.Reader.t
-    -> ( Mina_base.Ledger_hash.t
-       * Mina_base.Sync_ledger.Query.t
-       * Mina_base.Sync_ledger.Answer.t Network_peer.Envelope.Incoming.t )
-       Pipe_lib.Linear_pipe.Writer.t
-    -> unit =
- fun t query_reader response_writer ->
-  (* We attempt to query 3 random peers, retry_max times. We keep track of the
-          peers that couldn't answer a particular query and won't try them
-          again. *)
-  let retry_max = 6 in
-  let retry_interval = Core.Time.Span.of_ms 200. in
-  let rec answer_query ctr peers_tried query =
-    O1trace.trace_event "ask sync ledger query" ;
-    let%bind peers = random_peers_except t 3 ~except:peers_tried in
-    [%log' trace t.logger]
-      !"SL: Querying the following peers %{sexp: Peer.t list}"
-      peers ;
-    match%bind
-      find_map peers ~f:(fun peer ->
-          [%log' trace t.logger]
-            !"Asking %{sexp: Peer.t} query regarding ledger_hash %{sexp: \
-              Ledger_hash.t}"
-            peer (fst query) ;
-          match%map
-            query_peer t peer.peer_id Rpcs.Answer_sync_ledger_query query
-          with
-          | Connected {data= Ok (Ok answer); sender; _} ->
-              [%log' trace t.logger]
-                !"Received answer from peer %{sexp: Peer.t} on ledger_hash \
-                  %{sexp: Ledger_hash.t}"
-                peer (fst query) ;
-              (* TODO : here is a place where an envelope could contain
-                a Peer.t, and not just an IP address, if desired
-            *)
-              Some (Envelope.Incoming.wrap ~data:answer ~sender)
-          | Connected {data= Ok (Error e); _} ->
-              [%log' info t.logger]
-                "Peer $peer didn't have enough information to answer \
-                 ledger_hash query. See error for more details: $error"
-                ~metadata:
-                  [ ("error", Error_json.error_to_yojson e)
-                  ; ("peer", Peer.to_yojson peer) ] ;
-              Hash_set.add peers_tried peer ;
-              None
-          | Connected {data= Error e; _} ->
-              [%log' info t.logger]
-                "RPC error during ledger_hash query See error for more \
-                 details: $error"
-                ~metadata:[("error", Error_json.error_to_yojson e)] ;
-              Hash_set.add peers_tried peer ;
-              None
-          | Failed_to_connect err ->
-              [%log' warn t.logger] "Network error: %s"
-                (Error.to_string_mach err) ;
-              None )
-    with
-    | Some answer ->
-        [%log' trace t.logger]
-          !"Succeeding with answer on ledger_hash %{sexp: Ledger_hash.t}"
-          (fst query) ;
-        (* TODO *)
-        Linear_pipe.write_if_open response_writer (fst query, snd query, answer)
-    | None ->
-        [%log' info t.logger]
-          !"None of the peers contacted were able to answer ledger_hash query \
-            -- trying more" ;
-        if ctr > retry_max then Deferred.unit
-        else
-          let%bind () = Clock.after retry_interval in
-          answer_query (ctr + 1) peers_tried query
-  in
-  Linear_pipe.iter_unordered ~max_concurrency:8 query_reader
-    ~f:(answer_query 0 (Peer.Hash_set.of_list []))
-  |> don't_wait_for
-
-let _ = glue_sync_ledger
 
 let glue_sync_ledger :
        t
@@ -1522,21 +1501,36 @@ let glue_sync_ledger :
        Pipe_lib.Linear_pipe.Writer.t
     -> unit =
  fun t ~preferred query_reader response_writer ->
-  (* We attempt to query 3 random peers, retry_max times. We keep track of the
-          peers that couldn't answer a particular query and won't try them
-          again. *)
-  (*
-  let retry_max = 6 in
-  let retry_interval = Core.Time.Span.of_ms 200. in
-    *)
   let downloader =
+    let heartbeat_timeout = Time_ns.Span.of_sec 20. in
+    let global_stop = Pipe_lib.Linear_pipe.closed query_reader in
+    let knowledge h peer =
+      match%map
+        query_peer ~heartbeat_timeout ~timeout:(Time.Span.of_sec 10.) t
+          peer.Peer.peer_id Rpcs.Answer_sync_ledger_query (h, Num_accounts)
+      with
+      | Connected {data= Ok _; _} ->
+          `Call (fun (h', _) -> Ledger_hash.equal h' h)
+      | Failed_to_connect _ | Connected {data= Error _; _} ->
+          `Some []
+    in
+    let%bind _ = Linear_pipe.values_available query_reader in
+    let root_hash_r, root_hash_w =
+      Broadcast_pipe.create
+        (Option.value_exn (Linear_pipe.peek query_reader) |> fst)
+    in
     Sl_downloader.create ~preferred ~max_batch_size:100
-      ~stop:(Pipe_lib.Linear_pipe.closed query_reader)
+      ~peers:(fun () -> peers t)
+      ~knowledge_context:root_hash_r ~knowledge ~stop:global_stop
       ~trust_system:t.trust_system
-      ~get:(fun peer qs ->
+      ~get:(fun (peer : Peer.t) qs ->
+        List.iter qs ~f:(fun (h, _) ->
+            if
+              not
+                (Ledger_hash.equal h (Broadcast_pipe.Reader.peek root_hash_r))
+            then don't_wait_for (Broadcast_pipe.Writer.write root_hash_w h) ) ;
         let%map rs =
-          query_peer' ~how:`Parallel
-            ~heartbeat_timeout:(Time_ns.Span.of_sec 20.)
+          query_peer' ~how:`Parallel ~heartbeat_timeout
             ~timeout:(Time.Span.of_sec (Float.of_int (List.length qs) *. 2.))
             t peer.peer_id Rpcs.Answer_sync_ledger_query qs
         in
@@ -1556,7 +1550,6 @@ let glue_sync_ledger :
                   (List.filter_map ps ~f:(fun (q, r) ->
                        match r with Ok r -> Some (q, r) | Error _ -> None )) )
           ) )
-      ~peers:(fun () -> peers t)
   in
   don't_wait_for
     (let%bind downloader = downloader in

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -48,6 +48,12 @@ module Rpcs : sig
     type response = External_transition.t list option
   end
 
+  module Get_transition_knowledge : sig
+    type query = unit
+
+    type response = State_hash.t list
+  end
+
   module Get_transition_chain_proof : sig
     type query = State_hash.t
 
@@ -130,6 +136,10 @@ module Rpcs : sig
           rpc
     | Get_transition_chain
         : (Get_transition_chain.query, Get_transition_chain.response) rpc
+    | Get_transition_knowledge
+        : ( Get_transition_knowledge.query
+          , Get_transition_knowledge.response )
+          rpc
     | Get_transition_chain_proof
         : ( Get_transition_chain_proof.query
           , Get_transition_chain_proof.response )
@@ -209,7 +219,8 @@ val get_best_tip :
      Deferred.Or_error.t
 
 val get_transition_chain_proof :
-     ?timeout:Time.Span.t
+     ?heartbeat_timeout:Time_ns.Span.t
+  -> ?timeout:Time.Span.t
   -> t
   -> Network_peer.Peer.t
   -> State_hash.t
@@ -320,4 +331,8 @@ val create :
   -> get_transition_chain:(   Rpcs.Get_transition_chain.query
                               Envelope.Incoming.t
                            -> Rpcs.Get_transition_chain.response Deferred.t)
+  -> get_transition_knowledge:(   Rpcs.Get_transition_knowledge.query
+                                  Envelope.Incoming.t
+                               -> Rpcs.Get_transition_knowledge.response
+                                  Deferred.t)
   -> t Deferred.t

--- a/src/lib/pipe_lib/broadcast_pipe.ml
+++ b/src/lib/pipe_lib/broadcast_pipe.ml
@@ -122,6 +122,11 @@ module Writer = struct
         Int.Table.clear t.pipes )
 end
 
+let map t ~f =
+  let r, w = create (f (Reader.peek t)) in
+  don't_wait_for (Reader.iter t ~f:(fun x -> Writer.write w (f x))) ;
+  r
+
 (*
  * 1. Cached value is keeping peek working
  * 2. Multiple listeners receive the first mvar value

--- a/src/lib/pipe_lib/broadcast_pipe.mli
+++ b/src/lib/pipe_lib/broadcast_pipe.mli
@@ -42,3 +42,5 @@ end
 
 (** Create a shared pipe and seed it with 'a *)
 val create : 'a -> 'a Reader.t * 'a Writer.t
+
+val map : 'a Reader.t -> f:('a -> 'b) -> 'b Reader.t

--- a/src/lib/pipe_lib/strict_pipe.mli
+++ b/src/lib/pipe_lib/strict_pipe.mli
@@ -74,6 +74,8 @@ module Reader : sig
    * unit. See [fold reader ~init ~f] *)
   val iter : 'a t -> f:('a -> unit Deferred.t) -> unit Deferred.t
 
+  val iter' : 'a t -> f:('a Base.Queue.t -> unit Deferred.t) -> unit Deferred.t
+
   (** See [fold_without_pushback reader ~init ~f] *)
   val iter_without_pushback :
        ?consumer:Pipe.Consumer.t
@@ -127,6 +129,7 @@ end
 
 val create :
      ?name:string
+  -> ?warn_on_drop:bool
   -> ('t, 'type_, 'write_return) type_
   -> 't Reader.t * ('t, 'type_, 'write_return) Writer.t
 

--- a/src/lib/transition_frontier/full_catchup_tree.ml
+++ b/src/lib/transition_frontier/full_catchup_tree.ml
@@ -8,10 +8,10 @@ open Mina_numbers
 
 module Attempt_history = struct
   module Attempt = struct
-    type t =
-      { failure_reason:
-          [`Download | `Initial_validate | `Verify | `Build_breadcrumb] }
+    type reason = [`Download | `Initial_validate | `Verify | `Build_breadcrumb]
     [@@deriving yojson]
+
+    type t = {failure_reason: reason} [@@deriving yojson]
   end
 
   type t = Attempt.t Peer.Map.t

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -34,11 +34,12 @@ let is_transition_for_bootstrap ~logger
   | `Keep ->
       false
   | `Take ->
+      let slack = 5 in
       if
         Length.to_int
           ( Transition_frontier.best_tip frontier
           |> Transition_frontier.Breadcrumb.blockchain_length )
-        + 290
+        + 290 + slack
         < Length.to_int
             (Consensus.Data.Consensus_state.blockchain_length
                new_consensus_state.data)


### PR DESCRIPTION
This PR rewrites the downloading algorithm to use less mutation, which seems to have fixed the stalling bug. I mostly modified the way we decide which peers to download from. There are a few techniques:

1. We ask the peers which transitions they know in parallel and prioritize peers who claim to know more transitions
2. We keep the peers in a heap, sorted by which gave us a useful response most recently.
3. We prioritize peers who have claimed to know the "least" item (in the case of super catchup, this is the transition with the smallest blockchain length. This makes it so that we can start applying transitions as soon as possible)