### PR TITLE
change all Ivar.fill to Ivar.fill_if_empty

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -32,7 +32,7 @@ end = struct
     match t.task with
     | Some (ivar, _) ->
         if Ivar.is_full ivar then
-          [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+          [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
         Ivar.fill_if_empty ivar () ;
         t.task <- None
     | None ->
@@ -63,7 +63,7 @@ let lift_sync f =
   Interruptible.uninterruptible
     (Deferred.create (fun ivar ->
          if Ivar.is_full ivar then
-           [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+           [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
          Ivar.fill_if_empty ivar (f ()) ))
 
 module Singleton_scheduler : sig

--- a/src/lib/cache_lib/impl.ml
+++ b/src/lib/cache_lib/impl.ml
@@ -129,17 +129,25 @@ module Make (Inputs : Inputs_intf) : Intf.Main.S = struct
 
     let mark_failed : type a b. (a, b) t -> unit = function
       | Base x ->
-          Ivar.fill x.final_state `Failed
+          if Ivar.is_full x.final_state then
+            [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+          Ivar.fill_if_empty x.final_state `Failed
       | Derivative x ->
-          Ivar.fill x.final_state `Failed
+          if Ivar.is_full x.final_state then
+            [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+          Ivar.fill_if_empty x.final_state `Failed
       | Pure _ ->
           failwith "cannot set consumed state of pure Cached.t"
 
     let mark_success : type a b. (a, b) t -> unit = function
       | Base x ->
-          Ivar.fill x.final_state (`Success x.data)
+          if Ivar.is_full x.final_state then
+            [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+          Ivar.fill_if_empty x.final_state (`Success x.data)
       | Derivative x ->
-          Ivar.fill x.final_state (`Success x.original)
+          if Ivar.is_full x.final_state then
+            [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+          Ivar.fill_if_empty x.final_state (`Success x.original)
       | Pure _ ->
           failwith "cannot set consumed state of pure Cached.t"
 

--- a/src/lib/cache_lib/impl.ml
+++ b/src/lib/cache_lib/impl.ml
@@ -130,11 +130,11 @@ module Make (Inputs : Inputs_intf) : Intf.Main.S = struct
     let mark_failed : type a b. (a, b) t -> unit = function
       | Base x ->
           if Ivar.is_full x.final_state then
-            [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+            [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
           Ivar.fill_if_empty x.final_state `Failed
       | Derivative x ->
           if Ivar.is_full x.final_state then
-            [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+            [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
           Ivar.fill_if_empty x.final_state `Failed
       | Pure _ ->
           failwith "cannot set consumed state of pure Cached.t"
@@ -142,11 +142,11 @@ module Make (Inputs : Inputs_intf) : Intf.Main.S = struct
     let mark_success : type a b. (a, b) t -> unit = function
       | Base x ->
           if Ivar.is_full x.final_state then
-            [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+            [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
           Ivar.fill_if_empty x.final_state (`Success x.data)
       | Derivative x ->
           if Ivar.is_full x.final_state then
-            [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+            [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
           Ivar.fill_if_empty x.final_state (`Success x.original)
       | Pure _ ->
           failwith "cannot set consumed state of pure Cached.t"

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -313,7 +313,8 @@ let start_custom :
        let%bind () = Reader.close @@ Process.stdout process in
        Reader.close @@ Process.stderr process) ;
     let%bind () = Sys.remove lock_path in
-    Ivar.fill terminated_ivar termination_status ;
+    if Ivar.is_full terminated_ivar then [%log warn] "Ivar.fill bug is here!" ;
+    Ivar.fill_if_empty terminated_ivar termination_status ;
     let log_bad_termination () =
       [%log fatal] "Process died unexpectedly: $exit_or_signal"
         ~metadata:

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -313,7 +313,7 @@ let start_custom :
        let%bind () = Reader.close @@ Process.stdout process in
        Reader.close @@ Process.stderr process) ;
     let%bind () = Sys.remove lock_path in
-    if Ivar.is_full terminated_ivar then [%log warn] "Ivar.fill bug is here!" ;
+    if Ivar.is_full terminated_ivar then [%log error] "Ivar.fill bug is here!" ;
     Ivar.fill_if_empty terminated_ivar termination_status ;
     let log_bad_termination () =
       [%log fatal] "Process died unexpectedly: $exit_or_signal"

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2748,7 +2748,7 @@ module Hooks = struct
                       , Mina_base.Ledger_hash.to_yojson ledger_hash ) ]
                   "Failed to serve epoch ledger query with hash $ledger_hash \
                    from $peer: $error" ) ;
-            if Ivar.is_full ivar then [%log warn] "Ivar.fill bug is here!" ;
+            if Ivar.is_full ivar then [%log error] "Ivar.fill bug is here!" ;
             Ivar.fill_if_empty ivar response )
     end
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2748,7 +2748,8 @@ module Hooks = struct
                       , Mina_base.Ledger_hash.to_yojson ledger_hash ) ]
                   "Failed to serve epoch ledger query with hash $ledger_hash \
                    from $peer: $error" ) ;
-            Ivar.fill ivar response )
+            if Ivar.is_full ivar then [%log warn] "Ivar.fill bug is here!" ;
+            Ivar.fill_if_empty ivar response )
     end
 
     open Mina_base.Rpc_intf

--- a/src/lib/distributed_dsl/distributed_dsl.ml
+++ b/src/lib/distributed_dsl/distributed_dsl.ml
@@ -194,7 +194,7 @@ struct
     match Token.Table.find t.timer_stoppers tok with
     | Some ivar ->
         if Ivar.is_full ivar then
-          [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+          [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
         Ivar.fill_if_empty ivar `Cancelled
     | None ->
         ()

--- a/src/lib/distributed_dsl/distributed_dsl.ml
+++ b/src/lib/distributed_dsl/distributed_dsl.ml
@@ -193,7 +193,9 @@ struct
   let cancel t tok =
     match Token.Table.find t.timer_stoppers tok with
     | Some ivar ->
-        Ivar.fill ivar `Cancelled
+        if Ivar.is_full ivar then
+          [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+        Ivar.fill_if_empty ivar `Cancelled
     | None ->
         ()
 

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -635,7 +635,10 @@ let start_background_query (type r)
       ~parse_subscription:Query.parse ~subscription ~handle_result
   in
   don't_wait_for
-    (finally subscription_task ~f:(fun () -> Ivar.fill finished_ivar ())) ;
+    (finally subscription_task ~f:(fun () ->
+         if Ivar.is_full finished_ivar then
+           [%log warn] "Ivar.fill bug is here!" ;
+         Ivar.fill_if_empty finished_ivar () )) ;
   (subscription, Ivar.read finished_ivar)
 
 let create ~logger ~(network : Kubernetes_network.t) ~on_fatal_error =

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -637,7 +637,7 @@ let start_background_query (type r)
   don't_wait_for
     (finally subscription_task ~f:(fun () ->
          if Ivar.is_full finished_ivar then
-           [%log warn] "Ivar.fill bug is here!" ;
+           [%log error] "Ivar.fill bug is here!" ;
          Ivar.fill_if_empty finished_ivar () )) ;
   (subscription, Ivar.read finished_ivar)
 

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -175,7 +175,8 @@ module Snark_worker = struct
         match signal_or_error with
         | Ok () ->
             [%log info] "Snark worker process died" ;
-            if Ivar.is_full kill_ivar then [%log warn] "Ivar.fill bug is here!" ;
+            if Ivar.is_full kill_ivar then
+              [%log error] "Ivar.fill bug is here!" ;
             Ivar.fill_if_empty kill_ivar () ;
             Deferred.unit
         | Error (`Exit_non_zero non_zero_error) ->
@@ -225,7 +226,7 @@ module Snark_worker = struct
               , `Int (Pid.to_int (Process.pid snark_worker_process)) ) ]
           "Started snark worker process with pid: $snark_worker_pid" ;
         if Ivar.is_full process_ivar then
-          [%log' warn t.config.logger] "Ivar.fill bug is here!" ;
+          [%log' error t.config.logger] "Ivar.fill bug is here!" ;
         Ivar.fill_if_empty process_ivar snark_worker_process
     | `Off _ ->
         [%log' info t.config.logger]
@@ -716,7 +717,7 @@ let add_transactions t (uc_inputs : User_command_input.t list) =
   Strict_pipe.Writer.write t.pipes.user_command_input_writer
     ( uc_inputs
     , ( if Ivar.is_full result_ivar then
-          [%log' warn t.config.logger] "Ivar.fill bug is here!" ;
+          [%log' error t.config.logger] "Ivar.fill bug is here!" ;
         Ivar.fill_if_empty result_ivar )
     , get_current_nonce )
   |> Deferred.don't_wait_for ;

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -58,10 +58,16 @@ module Validation_callback = struct
         result
 
   let fire_if_not_already_fired cb result =
-    if not (is_expired cb) then Ivar.fill cb.signal result
+    if not (is_expired cb) then (
+      if Ivar.is_full cb.signal then
+        [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+      Ivar.fill_if_empty cb.signal result )
 
   let fire_exn cb result =
-    if not (is_expired cb) then Ivar.fill cb.signal result
+    if not (is_expired cb) then (
+      if Ivar.is_full cb.signal then
+        [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+      Ivar.fill_if_empty cb.signal result )
 end
 
 (** simple types for yojson to derive, later mapped into a Peer.t *)
@@ -759,7 +765,10 @@ module Helper = struct
       match Hashtbl.find_and_remove t.outstanding_requests seq with
       | Some ivar ->
           (* This fill should be okay because we "found and removed" the request *)
-          Ivar.fill ivar fill_result ; Ok ()
+          if Ivar.is_full ivar then
+            [%log' warn t.logger] "Ivar.fill bug is here!" ;
+          Ivar.fill_if_empty ivar fill_result ;
+          Ok ()
       | None ->
           Or_error.errorf "spurious reply to RPC #%d: %s" seq
             (Yojson.Safe.to_string v)

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -60,13 +60,13 @@ module Validation_callback = struct
   let fire_if_not_already_fired cb result =
     if not (is_expired cb) then (
       if Ivar.is_full cb.signal then
-        [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+        [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
       Ivar.fill_if_empty cb.signal result )
 
   let fire_exn cb result =
     if not (is_expired cb) then (
       if Ivar.is_full cb.signal then
-        [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+        [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
       Ivar.fill_if_empty cb.signal result )
 end
 
@@ -766,7 +766,7 @@ module Helper = struct
       | Some ivar ->
           (* This fill should be okay because we "found and removed" the request *)
           if Ivar.is_full ivar then
-            [%log' warn t.logger] "Ivar.fill bug is here!" ;
+            [%log' error t.logger] "Ivar.fill bug is here!" ;
           Ivar.fill_if_empty ivar fill_result ;
           Ok ()
       | None ->

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -69,12 +69,12 @@ let rec determine_outcome : type p r partial.
         match r with
         | `Valid r ->
             if Ivar.is_full elt.res then
-              [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+              [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
             Ivar.fill_if_empty elt.res (Ok (Ok r)) ;
             None
         | `Invalid ->
             if Ivar.is_full elt.res then
-              [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+              [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
             Ivar.fill_if_empty elt.res (Ok (Error ())) ;
             None
         | `Potentially_invalid new_hint ->
@@ -87,7 +87,7 @@ let rec determine_outcome : type p r partial.
       return ()
   | [({res; _}, _)] ->
       if Ivar.is_full res then
-        [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+        [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
       Ivar.fill_if_empty res (Ok (Error ())) ;
       (* If there is a potentially invalid proof in this batch of size 1, then
          that proof is itself invalid. *)

--- a/src/lib/pipe_lib/broadcast_pipe.ml
+++ b/src/lib/pipe_lib/broadcast_pipe.ml
@@ -32,7 +32,7 @@ let create a =
            Deferred.List.iter ~how:`Parallel inner_pipes ~f:(fun p ->
                Deferred.ignore @@ Pipe.downstream_flushed p )
          in
-         Ivar.fill !downstream_flushed_v () ;
+         Ivar.fill_if_empty !downstream_flushed_v () ;
          Deferred.unit )) ;
   (t, t)
 

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -459,7 +459,7 @@ end = struct
       failwith "We finished syncing, but made a mistake somewhere :("
     else (
       if Ivar.is_full t.validity_listener then
-        [%log' warn t.logger] "Ivar.fill bug is here!" ;
+        [%log' error t.logger] "Ivar.fill bug is here!" ;
       Ivar.fill_if_empty t.validity_listener `Ok )
 
   (** Compute the hash of an empty tree of the specified height. *)

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -457,7 +457,10 @@ end = struct
   let all_done t =
     if not (Root_hash.equal (MT.merkle_root t.tree) (desired_root_exn t)) then
       failwith "We finished syncing, but made a mistake somewhere :("
-    else Ivar.fill t.validity_listener `Ok
+    else (
+      if Ivar.is_full t.validity_listener then
+        [%log' warn t.logger] "Ivar.fill bug is here!" ;
+      Ivar.fill_if_empty t.validity_listener `Ok )
 
   (** Compute the hash of an empty tree of the specified height. *)
   let empty_hash_at_height h =

--- a/src/lib/timeout_lib/timeout_lib.ml
+++ b/src/lib/timeout_lib/timeout_lib.ml
@@ -82,8 +82,9 @@ module Make (Time : Time_intf) : Timeout_intf(Time).S = struct
   let await ~timeout_duration time_controller deferred =
     let timeout =
       Deferred.create (fun ivar ->
-          ignore (create time_controller timeout_duration ~f:(Ivar.fill ivar))
-      )
+          ignore
+            (create time_controller timeout_duration
+               ~f:(Ivar.fill_if_empty ivar)) )
     in
     Deferred.(
       choose

--- a/src/lib/transition_frontier/extensions/transition_registry.ml
+++ b/src/lib/transition_frontier/extensions/transition_registry.ml
@@ -13,7 +13,10 @@ module T = struct
   let notify t state_hash =
     State_hash.Table.change t state_hash ~f:(function
       | Some ls ->
-          List.iter ls ~f:(Fn.flip Ivar.fill ()) ;
+          List.iter ls ~f:(fun ivar ->
+              if Ivar.is_full ivar then
+                [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+              Ivar.fill_if_empty ivar () ) ;
           None
       | None ->
           None )

--- a/src/lib/transition_frontier/extensions/transition_registry.ml
+++ b/src/lib/transition_frontier/extensions/transition_registry.ml
@@ -15,7 +15,7 @@ module T = struct
       | Some ls ->
           List.iter ls ~f:(fun ivar ->
               if Ivar.is_full ivar then
-                [%log' warn (Logger.create ())] "Ivar.fill bug is here!" ;
+                [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
               Ivar.fill_if_empty ivar () ) ;
           None
       | None ->

--- a/src/lib/transition_frontier_controller/dune
+++ b/src/lib/transition_frontier_controller/dune
@@ -2,5 +2,5 @@
  (name transition_frontier_controller)
  (public_name transition_frontier_controller)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version))
+ (preprocess (pps ppx_version ppx_coda))
  (libraries core_kernel consensus mina_intf mina_base syncable_ledger merkle_address merkle_mask sync_handler transition_handler test_genesis_ledger mina_networking ledger_catchup))

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -70,7 +70,7 @@ let run ~logger ~trust_system ~verifier ~network ~time_controller
       kill catchup_job_writer ;
       kill catchup_breadcrumbs_writer ;
       if Ivar.is_full clean_up_catchup_scheduler then
-        [%log warn] "Ivar.fill bug is here!" ;
+        [%log error] "Ivar.fill bug is here!" ;
       Ivar.fill_if_empty clean_up_catchup_scheduler () )
   |> don't_wait_for ;
   processed_transition_reader

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -69,6 +69,8 @@ let run ~logger ~trust_system ~verifier ~network ~time_controller
       kill processed_transition_writer ;
       kill catchup_job_writer ;
       kill catchup_breadcrumbs_writer ;
-      Ivar.fill clean_up_catchup_scheduler () )
+      if Ivar.is_full clean_up_catchup_scheduler then
+        [%log warn] "Ivar.fill bug is here!" ;
+      Ivar.fill_if_empty clean_up_catchup_scheduler () )
   |> don't_wait_for ;
   processed_transition_reader

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -316,7 +316,7 @@ let run ~logger ~(precomputed_values : Precomputed_values.t) ~verifier
                  match subsequent_callback_action with
                  | `Ledger_catchup decrement_signal ->
                      if Ivar.is_full decrement_signal then
-                       [%log warn] "Ivar.fill bug is here!" ;
+                       [%log error] "Ivar.fill bug is here!" ;
                      Ivar.fill_if_empty decrement_signal ()
                  | `Catchup_scheduler ->
                      () )

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -315,7 +315,9 @@ let run ~logger ~(precomputed_values : Precomputed_values.t) ~verifier
                  >>| fun () ->
                  match subsequent_callback_action with
                  | `Ledger_catchup decrement_signal ->
-                     Ivar.fill decrement_signal ()
+                     if Ivar.is_full decrement_signal then
+                       [%log warn] "Ivar.fill bug is here!" ;
+                     Ivar.fill_if_empty decrement_signal ()
                  | `Catchup_scheduler ->
                      () )
              | `Local_breadcrumb breadcrumb ->


### PR DESCRIPTION
This PR changes all Ivar.fill to Ivar.fill_if_empty in our codebase (not include tests).
There's also warning for places where we are trying to fill in a non-empty ivar (except for timeout_lib.ml and broadcast_pipe.ml)

I did an analysis of all those use of Ivar.fill in #7463.

Once this PR is landed, we can also monitor our logs to see where does that exception comes from.
