### PR TITLE
Fix mina.service logging

### DIFF
--- a/scripts/mina.conf
+++ b/scripts/mina.conf
@@ -1,0 +1,16 @@
+# This file is part of systemd
+# This file controls the logging behavior of the service it is named after
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See journald.conf(5) for details.
+
+[Journal]
+Storage=auto
+ForwardToSyslog=no
+Compress=yes
+#Seal=yes
+#SplitMode=uid
+SyncIntervalSec=1m
+RateLimitInterval=30s
+#RateLimitBurst=1000 

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -116,7 +116,9 @@ cp ./default/src/app/logproc/logproc.exe "${BUILDDIR}/usr/local/bin/coda-logproc
 cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/coda-create-genesis"
 
 mkdir -p "${BUILDDIR}/usr/lib/systemd/user"
+mkdir -p "${BUILDDIR}/mkdir -p "${BUILDDIR}/usr/lib/systemd/journald.conf.d"
 cp ../scripts/mina.service "${BUILDDIR}/usr/lib/systemd/user/"
+cp ../scripts/mina.conf "${BUILDDIR}/usr/lib/systemd/journald.conf.d"
 
 # Build Config
 mkdir -p "${BUILDDIR}/etc/coda/build_config"


### PR DESCRIPTION
Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

These changes will alter the default settings for the system journal to prevent the mina service from flooding /var/log/syslog with messages. It is not needed to log all data to /var/log/syslog the client already creates its own logs in .coda-config.

By allowing syslog to be flooded with messages we are wasting system resources especially disk writes. I have not went through all of the settings this file can contain I just wanted it to stop abusing my syslog

I tested my changes by creating the file in the correct location with these settings then restarting the server. 
I have no idea if this will work in your CI but this is more a change to the system defaults than to the actual operation of the code. I just added the conf file in the correct location in the source code the scripts folder then changed the only file where i found mina.service to include copying the new file in the build process

I would have someone more familiar with the code than myself test this to ensure it does not cause any issues.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
