### PR TITLE
Ivar.fill_if_empty -> Ivar.fill

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -33,7 +33,7 @@ end = struct
     | Some (ivar, _) ->
         if Ivar.is_full ivar then
           [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-        Ivar.fill_if_empty ivar () ;
+        Ivar.fill ivar () ;
         t.task <- None
     | None ->
         ()
@@ -64,7 +64,7 @@ let lift_sync f =
     (Deferred.create (fun ivar ->
          if Ivar.is_full ivar then
            [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-         Ivar.fill_if_empty ivar (f ()) ))
+         Ivar.fill ivar (f ()) ))
 
 module Singleton_scheduler : sig
   type t

--- a/src/lib/cache_lib/impl.ml
+++ b/src/lib/cache_lib/impl.ml
@@ -131,11 +131,11 @@ module Make (Inputs : Inputs_intf) : Intf.Main.S = struct
       | Base x ->
           if Ivar.is_full x.final_state then
             [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-          Ivar.fill_if_empty x.final_state `Failed
+          Ivar.fill x.final_state `Failed
       | Derivative x ->
           if Ivar.is_full x.final_state then
             [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-          Ivar.fill_if_empty x.final_state `Failed
+          Ivar.fill x.final_state `Failed
       | Pure _ ->
           failwith "cannot set consumed state of pure Cached.t"
 
@@ -143,11 +143,11 @@ module Make (Inputs : Inputs_intf) : Intf.Main.S = struct
       | Base x ->
           if Ivar.is_full x.final_state then
             [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-          Ivar.fill_if_empty x.final_state (`Success x.data)
+          Ivar.fill x.final_state (`Success x.data)
       | Derivative x ->
           if Ivar.is_full x.final_state then
             [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-          Ivar.fill_if_empty x.final_state (`Success x.original)
+          Ivar.fill x.final_state (`Success x.original)
       | Pure _ ->
           failwith "cannot set consumed state of pure Cached.t"
 

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -314,7 +314,7 @@ let start_custom :
        Reader.close @@ Process.stderr process) ;
     let%bind () = Sys.remove lock_path in
     if Ivar.is_full terminated_ivar then [%log error] "Ivar.fill bug is here!" ;
-    Ivar.fill_if_empty terminated_ivar termination_status ;
+    Ivar.fill terminated_ivar termination_status ;
     let log_bad_termination () =
       [%log fatal] "Process died unexpectedly: $exit_or_signal"
         ~metadata:

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2749,7 +2749,7 @@ module Hooks = struct
                   "Failed to serve epoch ledger query with hash $ledger_hash \
                    from $peer: $error" ) ;
             if Ivar.is_full ivar then [%log error] "Ivar.fill bug is here!" ;
-            Ivar.fill_if_empty ivar response )
+            Ivar.fill ivar response )
     end
 
     open Mina_base.Rpc_intf

--- a/src/lib/distributed_dsl/distributed_dsl.ml
+++ b/src/lib/distributed_dsl/distributed_dsl.ml
@@ -195,7 +195,7 @@ struct
     | Some ivar ->
         if Ivar.is_full ivar then
           [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-        Ivar.fill_if_empty ivar `Cancelled
+        Ivar.fill ivar `Cancelled
     | None ->
         ()
 

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -638,7 +638,7 @@ let start_background_query (type r)
     (finally subscription_task ~f:(fun () ->
          if Ivar.is_full finished_ivar then
            [%log error] "Ivar.fill bug is here!" ;
-         Ivar.fill_if_empty finished_ivar () )) ;
+         Ivar.fill finished_ivar () )) ;
   (subscription, Ivar.read finished_ivar)
 
 let create ~logger ~(network : Kubernetes_network.t) ~on_fatal_error =

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -180,7 +180,7 @@ module Snark_worker = struct
             [%log info] "Snark worker process died" ;
             if Ivar.is_full kill_ivar then
               [%log error] "Ivar.fill bug is here!" ;
-            Ivar.fill_if_empty kill_ivar () ;
+            Ivar.fill kill_ivar () ;
             Deferred.unit
         | Error (`Exit_non_zero non_zero_error) ->
             [%log fatal]
@@ -230,7 +230,7 @@ module Snark_worker = struct
           "Started snark worker process with pid: $snark_worker_pid" ;
         if Ivar.is_full process_ivar then
           [%log' error t.config.logger] "Ivar.fill bug is here!" ;
-        Ivar.fill_if_empty process_ivar snark_worker_process
+        Ivar.fill process_ivar snark_worker_process
     | `Off _ ->
         [%log' info t.config.logger]
           !"Attempted to turn on snark worker, but snark worker key is set to \
@@ -728,7 +728,7 @@ let add_transactions t (uc_inputs : User_command_input.t list) =
     ( uc_inputs
     , ( if Ivar.is_full result_ivar then
           [%log' error t.config.logger] "Ivar.fill bug is here!" ;
-        Ivar.fill_if_empty result_ivar )
+        Ivar.fill result_ivar )
     , get_current_nonce )
   |> Deferred.don't_wait_for ;
   Ivar.read result_ivar

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -61,13 +61,13 @@ module Validation_callback = struct
     if not (is_expired cb) then (
       if Ivar.is_full cb.signal then
         [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-      Ivar.fill_if_empty cb.signal result )
+      Ivar.fill cb.signal result )
 
   let fire_exn cb result =
     if not (is_expired cb) then (
       if Ivar.is_full cb.signal then
         [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-      Ivar.fill_if_empty cb.signal result )
+      Ivar.fill cb.signal result )
 end
 
 (** simple types for yojson to derive, later mapped into a Peer.t *)
@@ -767,7 +767,7 @@ module Helper = struct
           (* This fill should be okay because we "found and removed" the request *)
           if Ivar.is_full ivar then
             [%log' error t.logger] "Ivar.fill bug is here!" ;
-          Ivar.fill_if_empty ivar fill_result ;
+          Ivar.fill ivar fill_result ;
           Ok ()
       | None ->
           Or_error.errorf "spurious reply to RPC #%d: %s" seq

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -70,12 +70,12 @@ let rec determine_outcome : type p r partial.
         | `Valid r ->
             if Ivar.is_full elt.res then
               [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-            Ivar.fill_if_empty elt.res (Ok (Ok r)) ;
+            Ivar.fill elt.res (Ok (Ok r)) ;
             None
         | `Invalid ->
             if Ivar.is_full elt.res then
               [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-            Ivar.fill_if_empty elt.res (Ok (Error ())) ;
+            Ivar.fill elt.res (Ok (Error ())) ;
             None
         | `Potentially_invalid new_hint ->
             Some (elt, new_hint) )
@@ -88,7 +88,7 @@ let rec determine_outcome : type p r partial.
   | [({res; _}, _)] ->
       if Ivar.is_full res then
         [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-      Ivar.fill_if_empty res (Ok (Error ())) ;
+      Ivar.fill res (Ok (Error ())) ;
       (* If there is a potentially invalid proof in this batch of size 1, then
          that proof is itself invalid. *)
       return ()

--- a/src/lib/pipe_lib/broadcast_pipe.ml
+++ b/src/lib/pipe_lib/broadcast_pipe.ml
@@ -32,7 +32,9 @@ let create a =
            Deferred.List.iter ~how:`Parallel inner_pipes ~f:(fun p ->
                Deferred.ignore @@ Pipe.downstream_flushed p )
          in
-         Ivar.fill_if_empty !downstream_flushed_v () ;
+         if Ivar.is_full !downstream_flushed_v then
+           [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
+         Ivar.fill !downstream_flushed_v () ;
          Deferred.unit )) ;
   (t, t)
 

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -460,7 +460,7 @@ end = struct
     else (
       if Ivar.is_full t.validity_listener then
         [%log' error t.logger] "Ivar.fill bug is here!" ;
-      Ivar.fill_if_empty t.validity_listener `Ok )
+      Ivar.fill t.validity_listener `Ok )
 
   (** Compute the hash of an empty tree of the specified height. *)
   let empty_hash_at_height h =

--- a/src/lib/timeout_lib/dune
+++ b/src/lib/timeout_lib/dune
@@ -3,4 +3,4 @@
  (public_name timeout_lib)
  (libraries core async_kernel)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_jane ppx_version)))
+ (preprocess (pps ppx_jane ppx_version ppx_coda)))

--- a/src/lib/timeout_lib/dune
+++ b/src/lib/timeout_lib/dune
@@ -1,6 +1,6 @@
 (library
  (name timeout_lib)
  (public_name timeout_lib)
- (libraries core async_kernel)
+ (libraries core async_kernel logger)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_version ppx_coda)))

--- a/src/lib/timeout_lib/timeout_lib.ml
+++ b/src/lib/timeout_lib/timeout_lib.ml
@@ -83,8 +83,10 @@ module Make (Time : Time_intf) : Timeout_intf(Time).S = struct
     let timeout =
       Deferred.create (fun ivar ->
           ignore
-            (create time_controller timeout_duration
-               ~f:(Ivar.fill_if_empty ivar)) )
+            (create time_controller timeout_duration ~f:(fun x ->
+                 if Ivar.is_full ivar then
+                   [%log' error t.logger] "Ivar.fill bug is here!" ;
+                 Ivar.fill_if_empty ivar x )) )
     in
     Deferred.(
       choose

--- a/src/lib/timeout_lib/timeout_lib.ml
+++ b/src/lib/timeout_lib/timeout_lib.ml
@@ -85,7 +85,7 @@ module Make (Time : Time_intf) : Timeout_intf(Time).S = struct
           ignore
             (create time_controller timeout_duration ~f:(fun x ->
                  if Ivar.is_full ivar then
-                   [%log' error t.logger] "Ivar.fill bug is here!" ;
+                   [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
                  Ivar.fill_if_empty ivar x )) )
     in
     Deferred.(

--- a/src/lib/transition_frontier/extensions/transition_registry.ml
+++ b/src/lib/transition_frontier/extensions/transition_registry.ml
@@ -16,7 +16,7 @@ module T = struct
           List.iter ls ~f:(fun ivar ->
               if Ivar.is_full ivar then
                 [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-              Ivar.fill_if_empty ivar () ) ;
+              Ivar.fill ivar () ) ;
           None
       | None ->
           None )

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -71,6 +71,6 @@ let run ~logger ~trust_system ~verifier ~network ~time_controller
       kill catchup_breadcrumbs_writer ;
       if Ivar.is_full clean_up_catchup_scheduler then
         [%log error] "Ivar.fill bug is here!" ;
-      Ivar.fill_if_empty clean_up_catchup_scheduler () )
+      Ivar.fill clean_up_catchup_scheduler () )
   |> don't_wait_for ;
   processed_transition_reader

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -317,7 +317,7 @@ let run ~logger ~(precomputed_values : Precomputed_values.t) ~verifier
                  | `Ledger_catchup decrement_signal ->
                      if Ivar.is_full decrement_signal then
                        [%log error] "Ivar.fill bug is here!" ;
-                     Ivar.fill_if_empty decrement_signal ()
+                     Ivar.fill decrement_signal ()
                  | `Catchup_scheduler ->
                      () )
              | `Local_breadcrumb breadcrumb ->


### PR DESCRIPTION
This reverts the `Ivar.fill` to `Ivar.fill_if_empty` change, and adds a couple of missing logs.

We still want to crash, since the `fill` is likely to be a logic error; the logs will tell us where this crash came from so we can fix it.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: