### PR TITLE
Don't log level=Info logs to syslog when running as a service

### DIFF
--- a/scripts/mina.service
+++ b/scripts/mina.service
@@ -13,7 +13,7 @@ ExecStart=/usr/local/bin/coda daemon \
   -peer-list-file %h/peers.txt \
   -block-producer-key %h/keys/my-wallet \
   -generate-genesis-proof true \
-  -log-level Info \
+  -log-level Error \
   $EXTRA_FLAGS
 ExecStop=/usr/local/bin/coda client stop-daemon
 


### PR DESCRIPTION
Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: