### PR TITLE
Fix: Don't use successor when calculating the ledger nonce

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -718,8 +718,7 @@ let add_transactions t (uc_inputs : User_command_input.t list) =
         let ledger_nonce =
           Participating_state.active (get_account t aid)
           |> Option.join
-          |> Option.map ~f:(fun {Account.Poly.nonce; _} ->
-                 Mina_numbers.Account_nonce.succ nonce )
+          |> Option.map ~f:(fun {Account.Poly.nonce; _} -> nonce)
           |> Option.value ~default:nonce
         in
         Ok (`Min ledger_nonce, nonce)


### PR DESCRIPTION
Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: