### PR TITLE
Archive extensional blocks

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -109,6 +109,16 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "ExtensionalBlock",
+          "description": "Block encoded in extensional block format",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "Applied",
           "description": null,
@@ -3048,6 +3058,37 @@
                     "ofType": {
                       "kind": "SCALAR",
                       "name": "PrecomputedBlock",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Applied",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+	    {
+              "name": "archiveExtensionalBlock",
+              "description": null,
+              "args": [
+                {
+                  "name": "block",
+                  "description": "Block encoded in extensional block format",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ExtensionalBlock",
                       "ofType": null
                     }
                   },

--- a/scripts/run_local_network.sh
+++ b/scripts/run_local_network.sh
@@ -62,7 +62,7 @@ fi
 
 if [ ! -d "$ledgerfolder" ]; then
   echo "making ledger"
-  
+
   mkdir $ledgerfolder
 
   S=./automation/scripts
@@ -146,7 +146,7 @@ mkdir -p $nodesfolder
 
 mkdir $nodesfolder/seed
 
-$CODA daemon -seed -client-port 3000 -rest-port 3001 -external-port 3002 -metrics-port 3003 -libp2p-metrics-port 3004 -config-directory $nodesfolder/seed -config-file $daemon -generate-genesis-proof true -discovery-keypair CAESQNf7ldToowe604aFXdZ76GqW/XVlDmnXmBT+otorvIekBmBaDWu/6ZwYkZzqfr+3IrEh6FLbHQ3VSmubV9I9Kpc=,CAESIAZgWg1rv+mcGJGc6n6/tyKxIehS2x0N1Uprm1fSPSqX,12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr -log-json -log-level Trace &> $nodesfolder/seed/log.txt &
+$CODA daemon -seed -client-port 3000 -rest-port 3001 -external-port 3002 -metrics-port 3003 -libp2p-metrics-port 3004 -config-directory $nodesfolder/seed -config-file $daemon -generate-genesis-proof true -discovery-keypair CAESQNf7ldToowe604aFXdZ76GqW/XVlDmnXmBT+otorvIekBmBaDWu/6ZwYkZzqfr+3IrEh6FLbHQ3VSmubV9I9Kpc=,CAESIAZgWg1rv+mcGJGc6n6/tyKxIehS2x0N1Uprm1fSPSqX,12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr -log-json -log-level Trace -archive-address 3086 &> $nodesfolder/seed/log.txt &
 seed_pid=$!
 
 echo 'waiting for seed to go up...'

--- a/scripts/run_local_network.sh
+++ b/scripts/run_local_network.sh
@@ -62,7 +62,7 @@ fi
 
 if [ ! -d "$ledgerfolder" ]; then
   echo "making ledger"
-
+  
   mkdir $ledgerfolder
 
   S=./automation/scripts
@@ -146,7 +146,7 @@ mkdir -p $nodesfolder
 
 mkdir $nodesfolder/seed
 
-$CODA daemon -seed -client-port 3000 -rest-port 3001 -external-port 3002 -metrics-port 3003 -libp2p-metrics-port 3004 -config-directory $nodesfolder/seed -config-file $daemon -generate-genesis-proof true -discovery-keypair CAESQNf7ldToowe604aFXdZ76GqW/XVlDmnXmBT+otorvIekBmBaDWu/6ZwYkZzqfr+3IrEh6FLbHQ3VSmubV9I9Kpc=,CAESIAZgWg1rv+mcGJGc6n6/tyKxIehS2x0N1Uprm1fSPSqX,12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr -log-json -log-level Trace -archive-address 3086 &> $nodesfolder/seed/log.txt &
+$CODA daemon -seed -client-port 3000 -rest-port 3001 -external-port 3002 -metrics-port 3003 -libp2p-metrics-port 3004 -config-directory $nodesfolder/seed -config-file $daemon -generate-genesis-proof true -discovery-keypair CAESQNf7ldToowe604aFXdZ76GqW/XVlDmnXmBT+otorvIekBmBaDWu/6ZwYkZzqfr+3IrEh6FLbHQ3VSmubV9I9Kpc=,CAESIAZgWg1rv+mcGJGc6n6/tyKxIehS2x0N1Uprm1fSPSqX,12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr -log-json -log-level Trace &> $nodesfolder/seed/log.txt &
 seed_pid=$!
 
 echo 'waiting for seed to go up...'

--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -1,5 +1,6 @@
 (* extensional.ml -- extensional representations of archive db data *)
 
+open Core_kernel
 open Mina_base
 open Signature_lib
 
@@ -12,27 +13,35 @@ module User_command = struct
   (* for `typ` and `status`, a string is enough
      in any case, there aren't existing string conversions for the
      original OCaml types
+
+     The versioned modules in Transaction_hash.Stable don't have yojson functions
+     it would be difficult to add them, so we just use the ones for the
+      top-level Transaction.t
   *)
   type t =
     { sequence_no: int
     ; typ: string
-    ; fee_payer: Public_key.Compressed.t
-    ; source: Public_key.Compressed.t
-    ; receiver: Public_key.Compressed.t
-    ; fee_token: Token_id.t
-    ; token: Token_id.t
-    ; nonce: Account.Nonce.t
-    ; amount: Currency.Amount.t option
-    ; fee: Currency.Fee.t
-    ; valid_until: Mina_numbers.Global_slot.t option
-    ; memo: Signed_command_memo.t
-    ; hash: Transaction_hash.t
+    ; fee_payer: Public_key.Compressed.Stable.Latest.t
+    ; source: Public_key.Compressed.Stable.Latest.t
+    ; receiver: Public_key.Compressed.Stable.Latest.t
+    ; fee_token: Token_id.Stable.Latest.t
+    ; token: Token_id.Stable.Latest.t
+    ; nonce: Account.Nonce.Stable.Latest.t
+    ; amount: Currency.Amount.Stable.Latest.t option
+    ; fee: Currency.Fee.Stable.Latest.t
+    ; valid_until: Mina_numbers.Global_slot.Stable.Latest.t option
+    ; memo: Signed_command_memo.Stable.Latest.t
+    ; hash: Transaction_hash.Stable.Latest.t
+          [@to_yojson Transaction_hash.to_yojson]
+          [@of_yojson Transaction_hash.of_yojson]
     ; status: string option
-    ; failure_reason: Transaction_status.Failure.t option
-    ; fee_payer_account_creation_fee_paid: Currency.Amount.t option
-    ; receiver_account_creation_fee_paid: Currency.Amount.t option
-    ; created_token: Token_id.t option }
-  [@@deriving yojson]
+    ; failure_reason: Transaction_status.Failure.Stable.Latest.t option
+    ; fee_payer_account_creation_fee_paid:
+        Currency.Amount.Stable.Latest.t option
+    ; receiver_account_creation_fee_paid:
+        Currency.Amount.Stable.Latest.t option
+    ; created_token: Token_id.Stable.Latest.t option }
+  [@@deriving yojson, bin_io_unversioned]
 end
 
 module Internal_command = struct
@@ -40,34 +49,35 @@ module Internal_command = struct
      no existing string conversion for the original OCaml type
   *)
   type t =
-    { global_slot: int64
-    ; sequence_no: int
+    { sequence_no: int
     ; secondary_sequence_no: int
     ; typ: string
-    ; receiver: Public_key.Compressed.t
-    ; fee: Currency.Amount.t
-    ; token: Token_id.t
-    ; hash: Transaction_hash.t }
-  [@@deriving yojson]
+    ; receiver: Public_key.Compressed.Stable.Latest.t
+    ; fee: Currency.Fee.Stable.Latest.t
+    ; token: Token_id.Stable.Latest.t
+    ; hash: Transaction_hash.Stable.Latest.t
+          [@to_yojson Transaction_hash.to_yojson]
+          [@of_yojson Transaction_hash.of_yojson] }
+  [@@deriving yojson, bin_io_unversioned]
 end
 
 module Block = struct
   type t =
-    { state_hash: State_hash.t
-    ; parent_hash: State_hash.t
-    ; creator: Public_key.Compressed.t
-    ; block_winner: Public_key.Compressed.t
-    ; snarked_ledger_hash: Frozen_ledger_hash.t
-    ; staking_epoch_seed: Epoch_seed.t
-    ; staking_epoch_ledger_hash: Frozen_ledger_hash.t
-    ; next_epoch_seed: Epoch_seed.t
-    ; next_epoch_ledger_hash: Frozen_ledger_hash.t
-    ; ledger_hash: Ledger_hash.t
-    ; height: Unsigned_extended.UInt32.t
-    ; global_slot: Mina_numbers.Global_slot.t
-    ; global_slot_since_genesis: Mina_numbers.Global_slot.t
-    ; timestamp: Block_time.t
+    { state_hash: State_hash.Stable.Latest.t
+    ; parent_hash: State_hash.Stable.Latest.t
+    ; creator: Public_key.Compressed.Stable.Latest.t
+    ; block_winner: Public_key.Compressed.Stable.Latest.t
+    ; snarked_ledger_hash: Frozen_ledger_hash.Stable.Latest.t
+    ; staking_epoch_seed: Epoch_seed.Stable.Latest.t
+    ; staking_epoch_ledger_hash: Frozen_ledger_hash.Stable.Latest.t
+    ; next_epoch_seed: Epoch_seed.Stable.Latest.t
+    ; next_epoch_ledger_hash: Frozen_ledger_hash.Stable.Latest.t
+    ; ledger_hash: Ledger_hash.Stable.Latest.t
+    ; height: Unsigned_extended.UInt32.Stable.Latest.t
+    ; global_slot: Mina_numbers.Global_slot.Stable.Latest.t
+    ; global_slot_since_genesis: Mina_numbers.Global_slot.Stable.Latest.t
+    ; timestamp: Block_time.Stable.Latest.t
     ; user_cmds: User_command.t list
     ; internal_cmds: Internal_command.t list }
-  [@@deriving yojson]
+  [@@deriving yojson, bin_io_unversioned]
 end

--- a/src/app/archive/archive_lib/graphql_query/base_types.ml
+++ b/src/app/archive/archive_lib/graphql_query/base_types.ml
@@ -14,9 +14,9 @@ module Make_numeric (Input : sig
 end) : sig
   type t = Input.t
 
-  val serialize : t -> Yojson.Basic.json
+  val serialize : t -> Yojson.Basic.t
 
-  val deserialize : Yojson.Basic.json -> t
+  val deserialize : Yojson.Basic.t -> t
 end = struct
   open Input
 

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -186,7 +186,7 @@ module Timing_info = struct
                     (public_key_id,token,initial_balance,initial_minimum_balance,
                      cliff_time, cliff_amount, vesting_period, vesting_increment)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                   RETURNING id")
+                   RETURNING id
              |sql})
           values
 end
@@ -552,7 +552,8 @@ module User_command = struct
                       receiver_account_creation_fee_paid,
                       created_token)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    RETURNING id |sql})
+                    RETURNING id
+         |sql})
       { typ= user_cmd.typ
       ; fee_payer_id
       ; source_id

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -60,6 +60,12 @@ let rec vector : type t n.
         ~encode:(fun Vector.(x :: xs) -> Ok (x, xs))
         ~decode:(fun (x, xs) -> Ok (x :: xs))
 
+(* process a Caqti query on list of items
+   if we were instead to simply map the query over the list,
+    we'd get "in use" assertion failures for the connection
+   the bind makes sure the connection is available for
+    each query
+*)
 let rec deferred_result_list_fold ls ~init ~f =
   let open Deferred.Result.Let_syntax in
   match ls with
@@ -176,10 +182,12 @@ module Timing_info = struct
         in
         Conn.find
           (Caqti_request.find typ Caqti_type.int
-             "INSERT INTO timing_info \
-              (public_key_id,token,initial_balance,initial_minimum_balance, \
-              cliff_time, cliff_amount, vesting_period, vesting_increment ) \
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id")
+             {sql| INSERT INTO timing_info
+                    (public_key_id,token,initial_balance,initial_minimum_balance,
+                     cliff_time, cliff_amount, vesting_period, vesting_increment)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                   RETURNING id")
+             |sql})
           values
 end
 
@@ -219,16 +227,11 @@ module Epoch_data = struct
     let rep = Caqti_type.(tup2 string int) in
     Caqti_type.custom ~encode ~decode rep
 
-  let add_if_doesn't_exist (module Conn : CONNECTION)
-      (t : Mina_base.Epoch_data.Value.t) =
+  (* for extensional blocks, we have just the seed and ledger hash *)
+  let add_from_seed_and_ledger_hash_id (module Conn : CONNECTION) ~seed
+      ~ledger_hash_id =
     let open Deferred.Result.Let_syntax in
-    let Mina_base.Epoch_ledger.Poly.{hash; _} =
-      Mina_base.Epoch_data.Poly.ledger t
-    in
-    let%bind ledger_hash_id =
-      Snarked_ledger_hash.add_if_doesn't_exist (module Conn) hash
-    in
-    let seed = Mina_base.Epoch_data.Poly.seed t |> Epoch_seed.to_string in
+    let seed = Epoch_seed.to_string seed in
     match%bind
       Conn.find_opt
         (Caqti_request.find_opt typ Caqti_type.int
@@ -240,9 +243,24 @@ module Epoch_data = struct
     | None ->
         Conn.find
           (Caqti_request.find typ Caqti_type.int
-             "INSERT INTO epoch_data (seed, ledger_hash_id) VALUES (?, ?) \
-              RETURNING id")
+             {sql| INSERT INTO epoch_data (seed, ledger_hash_id) VALUES (?, ?)
+                   RETURNING id
+             |sql})
           {seed; ledger_hash_id}
+
+  let add_if_doesn't_exist (module Conn : CONNECTION)
+      (t : Mina_base.Epoch_data.Value.t) =
+    let open Deferred.Result.Let_syntax in
+    let Mina_base.Epoch_ledger.Poly.{hash; _} =
+      Mina_base.Epoch_data.Poly.ledger t
+    in
+    let%bind ledger_hash_id =
+      Snarked_ledger_hash.add_if_doesn't_exist (module Conn) hash
+    in
+    add_from_seed_and_ledger_hash_id
+      (module Conn)
+      ~seed:(Mina_base.Epoch_data.Poly.seed t)
+      ~ledger_hash_id
 end
 
 module User_command = struct
@@ -303,13 +321,13 @@ module User_command = struct
     let load (module Conn : CONNECTION) ~(id : int) =
       Conn.find
         (Caqti_request.find Caqti_type.int typ
-           {| SELECT type,fee_payer_id,source_id,receiver_id,fee_token,token,
-               nonce,amount,fee,valid_until,memo,hash,status,failure_reason,
-               fee_payer_account_creation_fee_paid,receiver_account_creation_fee_paid,
-               created_token
-              FROM user_commands
-              WHERE id = ?
-           |})
+           {sql| SELECT type,fee_payer_id,source_id,receiver_id,fee_token,token,
+                  nonce,amount,fee,valid_until,memo,hash,status,failure_reason,
+                  fee_payer_account_creation_fee_paid,receiver_account_creation_fee_paid,
+                  created_token
+                 FROM user_commands
+                 WHERE id = ?
+           |sql})
         id
 
     let add_if_doesn't_exist ?(via = `Ident) (module Conn : CONNECTION)
@@ -349,14 +367,14 @@ module User_command = struct
           (* TODO: Converting these uint64s to int64 can overflow; see #5419 *)
           Conn.find
             (Caqti_request.find typ Caqti_type.int
-               {| INSERT INTO user_commands (type, fee_payer_id, source_id,
-                   receiver_id, fee_token, token, nonce, amount, fee,
-                   valid_until, memo, hash, status, failure_reason,
-                   fee_payer_account_creation_fee_paid,
-                   receiver_account_creation_fee_paid,
-                   created_token)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                 RETURNING id |})
+               {sql| INSERT INTO user_commands (type, fee_payer_id, source_id,
+                      receiver_id, fee_token, token, nonce, amount, fee,
+                      valid_until, memo, hash, status, failure_reason,
+                      fee_payer_account_creation_fee_paid,
+                      receiver_account_creation_fee_paid,
+                      created_token)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    RETURNING id |sql})
             { typ=
                 ( match via with
                 | `Ident ->
@@ -446,13 +464,14 @@ module User_command = struct
                  (tup2 (option string) (option string))
                  (tup3 (option int64) (option int64) (option int64))
                  int)
-             "UPDATE user_commands \n\
-              SET status = ?, \n\
-             \    failure_reason = ?, \n\
-             \    fee_payer_account_creation_fee_paid = ?, \n\
-             \    receiver_account_creation_fee_paid = ?, \n\
-             \    created_token = ? \n\
-              WHERE id = ?")
+             {sql| UPDATE user_commands
+                   SET status = ?,
+                    failure_reason = ?,
+                    fee_payer_account_creation_fee_paid = ?,
+                    receiver_account_creation_fee_paid = ?,
+                    created_token = ?
+                   WHERE id = ?
+             |sql})
           ( (Some status_str, failure_reason)
           , ( fee_payer_account_creation_fee_paid
             , receiver_account_creation_fee_paid
@@ -506,6 +525,77 @@ module User_command = struct
 
   let find conn ~(transaction_hash : Transaction_hash.t) =
     Signed_command.find conn ~transaction_hash
+
+  (* meant to work with either a signed command, or a snapp *)
+  let add_extensional (module Conn : CONNECTION)
+      (user_cmd : Extensional.User_command.t) =
+    let amount_opt_to_int64_opt amt_opt =
+      Option.map amt_opt
+        ~f:(Fn.compose Unsigned.UInt64.to_int64 Currency.Amount.to_uint64)
+    in
+    let open Deferred.Result.Let_syntax in
+    let%bind fee_payer_id =
+      Public_key.add_if_doesn't_exist (module Conn) user_cmd.fee_payer
+    in
+    let%bind source_id =
+      Public_key.add_if_doesn't_exist (module Conn) user_cmd.source
+    in
+    let%bind receiver_id =
+      Public_key.add_if_doesn't_exist (module Conn) user_cmd.receiver
+    in
+    Conn.find
+      (Caqti_request.find Signed_command.typ Caqti_type.int
+         {sql| INSERT INTO user_commands (type, fee_payer_id, source_id,
+                      receiver_id, fee_token, token, nonce, amount, fee,
+                      valid_until, memo, hash, status, failure_reason,
+                      fee_payer_account_creation_fee_paid,
+                      receiver_account_creation_fee_paid,
+                      created_token)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    RETURNING id |sql})
+      { typ= user_cmd.typ
+      ; fee_payer_id
+      ; source_id
+      ; receiver_id
+      ; fee_token=
+          user_cmd.fee_token |> Token_id.to_uint64 |> Unsigned.UInt64.to_int64
+      ; token= user_cmd.token |> Token_id.to_uint64 |> Unsigned.UInt64.to_int64
+      ; nonce= user_cmd.nonce |> Unsigned.UInt32.to_int
+      ; amount= user_cmd.amount |> amount_opt_to_int64_opt
+      ; fee=
+          user_cmd.fee
+          |> Fn.compose Unsigned.UInt64.to_int64 Currency.Fee.to_uint64
+      ; valid_until=
+          Option.map user_cmd.valid_until
+            ~f:
+              (Fn.compose Unsigned.UInt32.to_int64
+                 Mina_numbers.Global_slot.to_uint32)
+      ; memo= user_cmd.memo |> Signed_command_memo.to_string
+      ; hash= user_cmd.hash |> Transaction_hash.to_base58_check
+      ; status= user_cmd.status
+      ; failure_reason=
+          Option.map user_cmd.failure_reason
+            ~f:Transaction_status.Failure.to_string
+      ; fee_payer_account_creation_fee_paid=
+          user_cmd.fee_payer_account_creation_fee_paid
+          |> amount_opt_to_int64_opt
+      ; receiver_account_creation_fee_paid=
+          user_cmd.receiver_account_creation_fee_paid
+          |> amount_opt_to_int64_opt
+      ; created_token=
+          Option.map user_cmd.created_token
+            ~f:
+              (Fn.compose Unsigned.UInt64.to_int64 Mina_base.Token_id.to_uint64)
+      }
+
+  let add_extensional_if_doesn't_exist (module Conn : CONNECTION)
+      (user_cmd : Extensional.User_command.t) =
+    let open Deferred.Result.Let_syntax in
+    match%bind find (module Conn) ~transaction_hash:user_cmd.hash with
+    | None ->
+        add_extensional (module Conn) user_cmd
+    | Some user_cmd_id ->
+        return user_cmd_id
 end
 
 module Internal_command = struct
@@ -532,11 +622,42 @@ module Internal_command = struct
   let load (module Conn : CONNECTION) ~(id : int) =
     Conn.find
       (Caqti_request.find Caqti_type.int typ
-         {| SELECT type,receiver_id,fee,token,hash
-            FROM internal_commands
-            WHERE id = ?
-         |})
+         {sql| SELECT type,receiver_id,fee,token,hash
+               FROM internal_commands
+               WHERE id = ?
+         |sql})
       id
+
+  let add_extensional_if_doesn't_exist (module Conn : CONNECTION)
+      (internal_cmd : Extensional.Internal_command.t) =
+    let open Deferred.Result.Let_syntax in
+    match%bind
+      find
+        (module Conn)
+        ~transaction_hash:internal_cmd.hash ~typ:internal_cmd.typ
+    with
+    | Some internal_command_id ->
+        return internal_command_id
+    | None ->
+        let%bind receiver_id =
+          Public_key.add_if_doesn't_exist (module Conn) internal_cmd.receiver
+        in
+        Conn.find
+          (Caqti_request.find typ Caqti_type.int
+             {sql| INSERT INTO internal_commands
+                    (type, receiver_id, fee, token,hash)
+                   VALUES (?, ?, ?, ?, ?)
+                   RETURNING id
+             |sql})
+          { typ= internal_cmd.typ
+          ; receiver_id
+          ; fee=
+              internal_cmd.fee |> Currency.Fee.to_uint64
+              |> Unsigned.UInt64.to_int64
+          ; token=
+              internal_cmd.token |> Token_id.to_uint64
+              |> Unsigned.UInt64.to_int64
+          ; hash= internal_cmd.hash |> Transaction_hash.to_base58_check }
 end
 
 module Fee_transfer = struct
@@ -593,8 +714,11 @@ module Fee_transfer = struct
         in
         Conn.find
           (Caqti_request.find typ Caqti_type.int
-             "INSERT INTO internal_commands (type, receiver_id, fee, token, \
-              hash) VALUES (?, ?, ?, ?, ?) RETURNING id")
+             {sql| INSERT INTO internal_commands
+                    (type, receiver_id, fee, token, hash)
+                   VALUES (?, ?, ?, ?, ?)
+                   RETURNING id
+             |sql})
           { kind
           ; receiver_id
           ; fee= Fee_transfer.Single.fee t |> Currency.Fee.to_int
@@ -638,23 +762,56 @@ module Coinbase = struct
         in
         Conn.find
           (Caqti_request.find typ Caqti_type.int
-             "INSERT INTO internal_commands (type, receiver_id, fee, token, \
-              hash) VALUES (?, ?, ?, ?, ?) RETURNING id")
+             {sql| INSERT INTO internal_commands
+                    (type, receiver_id, fee, token, hash)
+                   VALUES (?, ?, ?, ?, ?)
+                   RETURNING id
+             |sql})
           { receiver_id
           ; amount= Coinbase.amount t |> Currency.Amount.to_int
           ; hash= transaction_hash |> Transaction_hash.to_base58_check }
 end
 
-module Block_and_Internal_command = struct
+module Block_and_internal_command = struct
   let add (module Conn : CONNECTION) ~block_id ~internal_command_id
       ~sequence_no ~secondary_sequence_no =
     Conn.exec
       (Caqti_request.exec
          Caqti_type.(tup4 int int int int)
-         "INSERT INTO blocks_internal_commands (block_id, \
-          internal_command_id, sequence_no, secondary_sequence_no) VALUES (?, \
-          ?, ?, ?)")
+         {sql| INSERT INTO blocks_internal_commands
+                (block_id, internal_command_id, sequence_no, secondary_sequence_no)
+                VALUES (?, ?, ?, ?)
+         |sql})
       (block_id, internal_command_id, sequence_no, secondary_sequence_no)
+
+  let find (module Conn : CONNECTION) ~block_id ~internal_command_id
+      ~sequence_no ~secondary_sequence_no =
+    Conn.find_opt
+      (Caqti_request.find_opt
+         Caqti_type.(tup4 int int int int)
+         Caqti_type.string
+         {sql| SELECT 'exists' FROM blocks_internal_commands
+               WHERE block_id = $1
+               AND internal_command_id = $2
+               AND sequence_no = $3
+               AND secondary_sequence_no = $4
+         |sql})
+      (block_id, internal_command_id, sequence_no, secondary_sequence_no)
+
+  let add_if_doesn't_exist (module Conn : CONNECTION) ~block_id
+      ~internal_command_id ~sequence_no ~secondary_sequence_no =
+    let open Deferred.Result.Let_syntax in
+    match%bind
+      find
+        (module Conn)
+        ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
+    with
+    | Some _ ->
+        return ()
+    | None ->
+        add
+          (module Conn)
+          ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
 
   let add_with_balance conn ~block_id ~internal_command_id ~sequence_no
       ~secondary_sequence_no ~balance =
@@ -668,9 +825,31 @@ module Block_and_signed_command = struct
     Conn.exec
       (Caqti_request.exec
          Caqti_type.(tup3 int int int)
-         "INSERT INTO blocks_user_commands (block_id, user_command_id, \
-          sequence_no) VALUES (?, ?, ?)")
+         {sql| INSERT INTO blocks_user_commands
+                 (block_id, user_command_id, sequence_no)
+               VALUES (?, ?, ?)
+         |sql})
       (block_id, user_command_id, sequence_no)
+
+  let add_if_doesn't_exist (module Conn : CONNECTION) ~block_id
+      ~user_command_id ~sequence_no =
+    let open Deferred.Result.Let_syntax in
+    match%bind
+      Conn.find_opt
+        (Caqti_request.find_opt
+           Caqti_type.(tup3 int int int)
+           Caqti_type.string
+           {sql| SELECT 'exists' FROM blocks_user_commands
+                 WHERE block_id = $1
+                 AND user_command_id = $2
+                 AND sequence_no = $3
+           |sql})
+        (block_id, user_command_id, sequence_no)
+    with
+    | Some _ ->
+        return ()
+    | None ->
+        add (module Conn) ~block_id ~user_command_id ~sequence_no
 end
 
 module Block = struct
@@ -727,10 +906,12 @@ module Block = struct
   let load (module Conn : CONNECTION) ~(id : int) =
     Conn.find
       (Caqti_request.find Caqti_type.int typ
-         "SELECT state_hash, parent_id, parent_hash, creator_id, \
-          block_winner_id, snarked_ledger_hash_id, staking_epoch_data_id, \
-          next_epoch_data_id, ledger_hash, height, global_slot, \
-          global_slot_since_genesis, timestamp FROM blocks WHERE id = ?")
+         {sql| SELECT state_hash, parent_id, parent_hash, creator_id,
+                      block_winner_id, snarked_ledger_hash_id, staking_epoch_data_id,
+                      next_epoch_data_id, ledger_hash, height, global_slot,
+                      global_slot_since_genesis, timestamp FROM blocks
+               WHERE id = ?
+         |sql})
       id
 
   let add_parts_if_doesn't_exist (module Conn : CONNECTION)
@@ -775,13 +956,13 @@ module Block = struct
         let%bind block_id =
           Conn.find
             (Caqti_request.find typ Caqti_type.int
-               {| INSERT INTO blocks (state_hash, parent_id, parent_hash,
-                   creator_id, block_winner_id,
-                   snarked_ledger_hash_id, staking_epoch_data_id,
-                   next_epoch_data_id, ledger_hash, height, global_slot,
-                   global_slot_since_genesis, timestamp)
-                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
-               |})
+               {sql| INSERT INTO blocks (state_hash, parent_id, parent_hash,
+                      creator_id, block_winner_id,
+                      snarked_ledger_hash_id, staking_epoch_data_id,
+                      next_epoch_data_id, ledger_hash, height, global_slot,
+                      global_slot_since_genesis, timestamp)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
+               |sql})
             { state_hash= hash |> State_hash.to_string
             ; parent_id
             ; parent_hash=
@@ -883,7 +1064,7 @@ module Block = struct
                     ~f:(fun ()
                        ((fee_transfer_id, secondary_sequence_no), balance)
                        ->
-                      Block_and_Internal_command.add_with_balance
+                      Block_and_internal_command.add_with_balance
                         (module Conn)
                         ~block_id ~internal_command_id:fee_transfer_id
                         ~sequence_no ~secondary_sequence_no ~balance
@@ -909,7 +1090,7 @@ module Block = struct
                           (module Conn)
                           fee_transfer `Via_coinbase
                       in
-                      Block_and_Internal_command.add_with_balance
+                      Block_and_internal_command.add_with_balance
                         (module Conn)
                         ~block_id ~internal_command_id:id ~sequence_no
                         ~secondary_sequence_no:0
@@ -922,7 +1103,7 @@ module Block = struct
                   Coinbase.add_if_doesn't_exist (module Conn) coinbase
                 in
                 let%map () =
-                  Block_and_Internal_command.add_with_balance
+                  Block_and_internal_command.add_with_balance
                     (module Conn)
                     ~block_id ~internal_command_id:id ~sequence_no
                     ~secondary_sequence_no:0
@@ -946,13 +1127,139 @@ module Block = struct
       ~protocol_state:t.protocol_state ~staged_ledger_diff:t.staged_ledger_diff
       ~hash:(Protocol_state.hash t.protocol_state)
 
+  let add_from_extensional (module Conn : CONNECTION)
+      (block : Extensional.Block.t) =
+    let open Deferred.Result.Let_syntax in
+    let%bind block_id =
+      match%bind find_opt (module Conn) ~state_hash:block.state_hash with
+      | Some block_id ->
+          return block_id
+      | None ->
+          let%bind parent_id =
+            find_opt (module Conn) ~state_hash:block.parent_hash
+          in
+          let%bind creator_id =
+            Public_key.add_if_doesn't_exist (module Conn) block.creator
+          in
+          let%bind block_winner_id =
+            Public_key.add_if_doesn't_exist (module Conn) block.block_winner
+          in
+          let%bind snarked_ledger_hash_id =
+            Snarked_ledger_hash.add_if_doesn't_exist
+              (module Conn)
+              block.snarked_ledger_hash
+          in
+          let%bind staking_ledger_hash_id =
+            Snarked_ledger_hash.add_if_doesn't_exist
+              (module Conn)
+              block.staking_epoch_ledger_hash
+          in
+          let%bind staking_epoch_data_id =
+            Epoch_data.add_from_seed_and_ledger_hash_id
+              (module Conn)
+              ~seed:block.staking_epoch_seed
+              ~ledger_hash_id:staking_ledger_hash_id
+          in
+          let%bind next_ledger_hash_id =
+            Snarked_ledger_hash.add_if_doesn't_exist
+              (module Conn)
+              block.next_epoch_ledger_hash
+          in
+          let%bind next_epoch_data_id =
+            Epoch_data.add_from_seed_and_ledger_hash_id
+              (module Conn)
+              ~seed:block.next_epoch_seed ~ledger_hash_id:next_ledger_hash_id
+          in
+          Conn.find
+            (Caqti_request.find typ Caqti_type.int
+               {sql| INSERT INTO blocks
+                     (state_hash, parent_id, parent_hash,
+                      creator_id, block_winner_id,
+                      snarked_ledger_hash_id, staking_epoch_data_id,
+                      next_epoch_data_id, ledger_hash, height, global_slot,
+                      global_slot_since_genesis, timestamp)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
+               |sql})
+            { state_hash= block.state_hash |> State_hash.to_string
+            ; parent_id
+            ; parent_hash= block.parent_hash |> State_hash.to_string
+            ; creator_id
+            ; block_winner_id
+            ; snarked_ledger_hash_id
+            ; staking_epoch_data_id
+            ; next_epoch_data_id
+            ; ledger_hash= block.ledger_hash |> Ledger_hash.to_string
+            ; height= block.height |> Unsigned.UInt32.to_int64
+            ; global_slot= block.global_slot |> Unsigned.UInt32.to_int64
+            ; global_slot_since_genesis=
+                block.global_slot_since_genesis |> Unsigned.UInt32.to_int64
+            ; timestamp= block.timestamp |> Block_time.to_int64 }
+    in
+    (* add user commands *)
+    let%bind user_cmd_ids_and_seq_nos =
+      let%map user_cmd_ids_rev =
+        deferred_result_list_fold block.user_cmds ~init:[]
+          ~f:(fun acc user_cmd ->
+            let%map cmd_id =
+              User_command.add_extensional_if_doesn't_exist
+                (module Conn)
+                user_cmd
+            in
+            cmd_id :: acc )
+      in
+      let sequence_nos =
+        List.map block.user_cmds ~f:(fun user_cmd -> user_cmd.sequence_no)
+      in
+      List.zip_exn (List.rev user_cmd_ids_rev) sequence_nos
+    in
+    (* add user commands to join table *)
+    let%bind () =
+      deferred_result_list_fold user_cmd_ids_and_seq_nos ~init:()
+        ~f:(fun () (user_command_id, sequence_no) ->
+          Block_and_signed_command.add_if_doesn't_exist
+            (module Conn)
+            ~block_id ~user_command_id ~sequence_no )
+    in
+    (* add internal commands *)
+    let%bind internal_cmd_ids_and_seq_nos =
+      let%map internal_cmd_ids_rev =
+        deferred_result_list_fold block.internal_cmds ~init:[]
+          ~f:(fun acc internal_cmd ->
+            let%map cmd_id =
+              Internal_command.add_extensional_if_doesn't_exist
+                (module Conn)
+                internal_cmd
+            in
+            cmd_id :: acc )
+      in
+      let sequence_nos =
+        List.map block.internal_cmds ~f:(fun internal_cmd ->
+            (internal_cmd.sequence_no, internal_cmd.secondary_sequence_no) )
+      in
+      List.zip_exn (List.rev internal_cmd_ids_rev) sequence_nos
+    in
+    (* add internal commands to join table *)
+    let%bind () =
+      deferred_result_list_fold internal_cmd_ids_and_seq_nos ~init:()
+        ~f:(fun ()
+           (internal_command_id, (sequence_no, secondary_sequence_no))
+           ->
+          Block_and_internal_command.add_if_doesn't_exist
+            (module Conn)
+            ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
+      )
+    in
+    return block_id
+
   let set_parent_id_if_null (module Conn : CONNECTION) ~parent_hash
       ~(parent_id : int) =
     Conn.exec
       (Caqti_request.exec
          Caqti_type.(tup2 int string)
-         "UPDATE blocks SET parent_id = ? WHERE parent_hash = ? AND parent_id \
-          IS NULL")
+         {sql| UPDATE blocks SET parent_id = ?
+               WHERE parent_hash = ?
+               AND parent_id IS NULL
+         |sql})
       (parent_id, State_hash.to_base58_check parent_hash)
 
   let delete_if_older_than ?height ?num_blocks ?timestamp
@@ -1138,12 +1445,19 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
   let precomputed_block_reader, precomputed_block_writer =
     Strict_pipe.create ~name:"precomputed_archive_block" Synchronous
   in
+  let extensional_block_reader, extensional_block_writer =
+    Strict_pipe.create ~name:"extensional_archive_block" Synchronous
+  in
   let implementations =
     [ Async.Rpc.Rpc.implement Archive_rpc.t (fun () archive_diff ->
           Strict_pipe.Writer.write writer archive_diff )
     ; Async.Rpc.Rpc.implement Archive_rpc.precomputed_block
         (fun () precomputed_block ->
           Strict_pipe.Writer.write precomputed_block_writer precomputed_block
+      )
+    ; Async.Rpc.Rpc.implement Archive_rpc.extensional_block
+        (fun () extensional_block ->
+          Strict_pipe.Writer.write extensional_block_writer extensional_block
       ) ]
   in
   match%bind Caqti_async.connect postgres_address with
@@ -1173,6 +1487,23 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
                   [ ( "block"
                     , Protocol_state.hash precomputed_block.protocol_state
                       |> State_hash.to_yojson )
+                  ; ("error", `String (Caqti_error.show e)) ]
+          | Ok () ->
+              () )
+      |> don't_wait_for ;
+      Strict_pipe.Reader.iter extensional_block_reader
+        ~f:(fun extensional_block ->
+          match%map
+            add_block_aux ~add_block:Block.add_from_extensional
+              ~hash:(fun block -> block.state_hash)
+              ~delete_older_than conn extensional_block
+          with
+          | Error e ->
+              [%log warn]
+                "Extensional block $block could not be archived: $error"
+                ~metadata:
+                  [ ( "block"
+                    , extensional_block.state_hash |> State_hash.to_yojson )
                   ; ("error", `String (Caqti_error.show e)) ]
           | Ok () ->
               () )

--- a/src/app/archive/archive_lib/rpc.ml
+++ b/src/app/archive/archive_lib/rpc.ml
@@ -13,3 +13,8 @@ let precomputed_block :
     ~bin_query:
       Mina_transition.External_transition.Precomputed_block.Stable.Latest.bin_t
     ~bin_response:Unit.Stable.V1.bin_t
+
+(* Extensional.Block.t is not versioned; it doesn't appear in node-to-node RPCs *)
+let extensional_block : (Extensional.Block.t, Unit.Stable.V1.t) Rpc.Rpc.t =
+  Rpc.Rpc.create ~name:"Send_extensional_block" ~version:0
+    ~bin_query:Extensional.Block.bin_t ~bin_response:Unit.Stable.V1.bin_t

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1681,41 +1681,52 @@ let object_lifetime_statistics =
              printf "Failed to get object lifetime statistics: %s\n%!"
                (Error.to_string_hum err) ))
 
-let archive_precomputed_blocks =
+let archive_blocks =
+  let open Command.Param in
+  let precomputed_flag =
+    flag "precomputed" no_arg ~doc:"Blocks are in precomputed JSON format"
+  in
+  let extensional_flag =
+    flag "extensional" no_arg ~doc:"Blocks are in extensional JSON format"
+  in
   let archive_process_location = Cli_lib.Flag.Host_and_port.Daemon.archive in
   let files =
     Command.Param.anon
       Command.Anons.(sequence ("FILES" %: Command.Param.string))
   in
+  let args =
+    Command.Param.both
+      (Command.Param.both archive_process_location files)
+      (Args.zip2 precomputed_flag extensional_flag)
+  in
   Command.async
     ~summary:
-      "Archive a precomputed block from a file.\n\n\
+      "Archive a block from a file.\n\n\
        If an archive address is given, this process will communicate with the \
        archive node directly; otherwise it will communicate through the \
        daemon over the rest-server"
-    (Cli_lib.Background_daemon.graphql_init
-       (Command.Param.both archive_process_location files)
-       ~f:(fun graphql_endpoint (archive_process_location, files) ->
-         let send_block block =
+    (Cli_lib.Background_daemon.graphql_init args
+       ~f:(fun graphql_endpoint
+          ( (archive_process_location, files)
+          , (precomputed_flag, extensional_flag) )
+          ->
+         if Bool.equal precomputed_flag extensional_flag then
+           failwith
+             "Must provide exactly one of -precomputed and -extensional flags" ;
+         let make_send_block ~graphql_make ~archive_dispatch ~block_to_yojson
+             block =
            match archive_process_location with
            | Some archive_process_location ->
                (* Connect directly to the archive node. *)
-               Mina_lib.Archive_client.dispatch_precomputed_block
-                 archive_process_location block
+               archive_dispatch archive_process_location block
            | None ->
                (* Send the requests over GraphQL. *)
-               let block =
-                 Mina_transition.External_transition.Precomputed_block
-                 .to_yojson block
-                 |> Yojson.Safe.to_basic
-               in
+               let block = block_to_yojson block |> Yojson.Safe.to_basic in
                let%map.Deferred.Or_error.Let_syntax _res =
                  (* Don't catch this error: [query_exn] already handles
                     printing etc.
                  *)
-                 Graphql_client.query
-                   (Graphql_queries.Archive_precomputed_block.make ~block ())
-                   graphql_endpoint
+                 Graphql_client.query (graphql_make ~block ()) graphql_endpoint
                  |> Deferred.Result.map_error ~f:(function
                       | `Failed_request e ->
                           Error.create "Unable to connect to Coda daemon" ()
@@ -1735,10 +1746,24 @@ let archive_precomputed_blocks =
                in
                ()
          in
+         let send_precomputed_block =
+           make_send_block
+             ~graphql_make:Graphql_queries.Archive_precomputed_block.make
+             ~archive_dispatch:
+               Mina_lib.Archive_client.dispatch_precomputed_block
+             ~block_to_yojson:
+               Mina_transition.External_transition.Precomputed_block.to_yojson
+         in
+         let send_extensional_block =
+           make_send_block
+             ~graphql_make:Graphql_queries.Archive_extensional_block.make
+             ~archive_dispatch:
+               Mina_lib.Archive_client.dispatch_extensional_block
+             ~block_to_yojson:Archive_lib.Extensional.Block.to_yojson
+         in
          Deferred.List.iter files ~f:(fun path ->
              match%map
-               let open Deferred.Or_error.Let_syntax in
-               let%bind precomputed_block_json =
+               let%bind.Deferred.Or_error.Let_syntax block_json =
                  Or_error.try_with (fun () ->
                      In_channel.with_file path ~f:(fun in_channel ->
                          Yojson.Safe.from_channel in_channel ) )
@@ -1747,17 +1772,34 @@ let archive_precomputed_blocks =
                           String.sexp_of_t )
                  |> Deferred.return
                in
-               let%bind precomputed_block =
-                 Mina_transition.External_transition.Precomputed_block
-                 .of_yojson precomputed_block_json
-                 |> Result.map_error ~f:(fun err ->
-                        Error.tag_arg (Error.of_string err)
-                          "Could not parse JSON as a precomputed block from \
-                           file"
-                          path String.sexp_of_t )
-                 |> Deferred.return
-               in
-               send_block precomputed_block
+               let open Deferred.Or_error.Let_syntax in
+               if precomputed_flag then
+                 let%bind precomputed_block =
+                   Mina_transition.External_transition.Precomputed_block
+                   .of_yojson block_json
+                   |> Result.map_error ~f:(fun err ->
+                          Error.tag_arg (Error.of_string err)
+                            "Could not parse JSON as a precomputed block from \
+                             file"
+                            path String.sexp_of_t )
+                   |> Deferred.return
+                 in
+                 send_precomputed_block precomputed_block
+               else if extensional_flag then
+                 let%bind extensional_block =
+                   Archive_lib.Extensional.Block.of_yojson block_json
+                   |> Result.map_error ~f:(fun err ->
+                          Error.tag_arg (Error.of_string err)
+                            "Could not parse JSON as an extensional block \
+                             from file"
+                            path String.sexp_of_t )
+                   |> Deferred.return
+                 in
+                 send_extensional_block extensional_block
+               else
+                 (* should be unreachable *)
+                 failwith
+                   "Expected exactly one of precomputed, extensional flags"
              with
              | Ok () ->
                  Format.printf "Sent block to archive node from %s@." path
@@ -1878,4 +1920,4 @@ let advanced =
     ; ("get-peers", get_peers_graphql)
     ; ("add-peers", add_peers_graphql)
     ; ("object-lifetime-statistics", object_lifetime_statistics)
-    ; ("archive-precomputed-blocks", archive_precomputed_blocks) ]
+    ; ("archive-blocks", archive_blocks) ]

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -332,3 +332,13 @@ mutation ($block: PrecomputedBlock!) {
   }
 }
 |}]
+
+module Archive_extensional_block =
+[%graphql
+{|
+mutation ($block: ExtensionalBlock!) {
+  archiveExtensionalBlock(block: $block) {
+      applied
+  }
+}
+|}]

--- a/src/lib/mina_lib/archive_client.mli
+++ b/src/lib/mina_lib/archive_client.mli
@@ -7,6 +7,12 @@ val dispatch_precomputed_block :
   -> Mina_transition.External_transition.Precomputed_block.t
   -> unit Async.Deferred.Or_error.t
 
+val dispatch_extensional_block :
+     ?max_tries:int
+  -> Host_and_port.t Cli_lib.Flag.Types.with_name
+  -> Archive_lib.Extensional.Block.t
+  -> unit Async.Deferred.Or_error.t
+
 val run :
      logger:Logger.t
   -> frontier_broadcast_pipe:Transition_frontier.t option


### PR DESCRIPTION
Add ability to archive the extensional blocks produced by the missing subchains app.

Change: `advanced archive-precomputed-blocks` becomes `advanced archive-blocks`, which takes either `-precomputed` or `-extensional` as an additional flag.

There's an attempt here to share code for the two kinds of blocks, as much as possible.

Tested by deleting data in an archive db, and re-adding that data, and verifying result was as before (modulo intensional data like table ids). Tested using the GraphQL and direct-to-archive-process routes. The testing wasn't exhaustive, that might be part of the acceptance tests.

Fixed a bug in the missing subchains app, there was a mixup between staking, next epoch data.

In the archive lib, changed the processor SQL queries to use OCaml multiline strings using `{sql|...|sql}`. With that change, formatting is preserved to keep the queries readable.

Closes #7444.