### PR TITLE
Client SDK: Added functionality to get public key from private key

### DIFF
--- a/frontend/client_sdk/src/CodaSDK.d.ts
+++ b/frontend/client_sdk/src/CodaSDK.d.ts
@@ -39,6 +39,13 @@ export declare type payment = {
   */
 export declare const genKeys: () => keypair;
 /**
+  * Derives the public key of the corresponding private key
+  *
+  * @param privateKey - The private key used to get the corresponding public key
+  * @returns A public key
+  */
+export declare const derivePublicKey: (privateKey: privateKey) => publicKey;
+/**
   * Signs an arbitrary message
   *
   * @param key - The keypair used to sign the message

--- a/frontend/client_sdk/src/CodaSDK.re
+++ b/frontend/client_sdk/src/CodaSDK.re
@@ -60,7 +60,9 @@ type codaSDK;
 [@genType]
 let genKeys = () => genKeys(codaSDK, ());
 
-[@bs.send] external publicKeyOfPrivateKey: (codaSDK, privateKey) => publicKey= "publicKeyOfPrivateKey";
+[@bs.send]
+external publicKeyOfPrivateKey: (codaSDK, privateKey) => publicKey =
+  "publicKeyOfPrivateKey";
 /**
   * Derives the public key of the corresponding private key
   *
@@ -68,7 +70,8 @@ let genKeys = () => genKeys(codaSDK, ());
   * @returns A public key
  */
 [@genType]
-let derivePublicKey = (privateKey: privateKey) => publicKeyOfPrivateKey(codaSDK, privateKey);
+let derivePublicKey = (privateKey: privateKey) =>
+  publicKeyOfPrivateKey(codaSDK, privateKey);
 
 [@bs.send]
 external signString: (codaSDK, privateKey, string) => signature = "signString";

--- a/frontend/client_sdk/src/CodaSDK.re
+++ b/frontend/client_sdk/src/CodaSDK.re
@@ -60,6 +60,16 @@ type codaSDK;
 [@genType]
 let genKeys = () => genKeys(codaSDK, ());
 
+[@bs.send] external publicKeyOfPrivateKey: (codaSDK, privateKey) => publicKey= "publicKeyOfPrivateKey";
+/**
+  * Derives the public key of the corresponding private key
+  *
+  * @param privateKey - The private key used to get the corresponding public key
+  * @returns A public key
+ */
+[@genType]
+let derivePublicKey = (privateKey: privateKey) => publicKeyOfPrivateKey(codaSDK, privateKey);
+
 [@bs.send]
 external signString: (codaSDK, privateKey, string) => signature = "signString";
 /**

--- a/frontend/client_sdk/test/Test.ts
+++ b/frontend/client_sdk/test/Test.ts
@@ -2,6 +2,7 @@ import * as CodaSDK from "../src/SDKWrapper";
 import { deepStrictEqual } from "assert";
 
 let key = CodaSDK.genKeys();
+let publicKey = CodaSDK.derivePublicKey(key.privateKey);
 let signed = CodaSDK.signMessage("hello", key);
 CodaSDK.verifyMessage(signed);
 
@@ -27,3 +28,5 @@ let sd2 = CodaSDK.signStakeDelegation(
     key);
 
 deepStrictEqual(sd1, sd2, "Stake delegation signatures don't match (string vs numeric inputs)");
+
+deepStrictEqual(publicKey, key.publicKey, "Public keys do not match");


### PR DESCRIPTION
This PR implements the publicKeyOfPrivateKey function which returns a public key corresponding to a private key.

