### PR TITLE
Inform user when CODA_PRIVKEY_PASS used

### DIFF
--- a/src/app/generate_keypair/generate_keypair.ml
+++ b/src/app/generate_keypair/generate_keypair.ml
@@ -1,4 +1,4 @@
 open Async
 
-(* Utiltity app that only generates keypairs *)
+(* Utility app that only generates keypairs *)
 let () = Command.run Cli_lib.Commands.generate_keypair

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -3,15 +3,21 @@ open Signature_lib
 open Async
 
 let generate_keypair =
-  Command.async ~summary:"Generate a new public-key/private-key pair"
+  Command.async ~summary:"Generate a new public, private keypair"
     (let open Command.Let_syntax in
+    let env = Secrets.Keypair.env in
+    ( match Sys.getenv env with
+    | None ->
+        ()
+    | Some _ ->
+        printf "Using password from environment variable %s\n" env ) ;
     let%map_open privkey_path = Flag.privkey_write_path in
     Exceptions.handle_nicely
     @@ fun () ->
     let open Deferred.Let_syntax in
     let kp = Keypair.create () in
     let%bind () = Secrets.Keypair.Terminal_stdin.write_exn kp ~privkey_path in
-    printf "Keypair generated\nPublic key: %s\nRaw public key: %s"
+    printf "Keypair generated\nPublic key: %s\nRaw public key: %s\n"
       ( kp.public_key |> Public_key.compress
       |> Public_key.Compressed.to_base58_check )
       (Rosetta_coding.Coding.of_public_key kp.public_key) ;


### PR DESCRIPTION
The `generate_keypair` app was silently using a password from `CODA_PRIVKEY_PASS`, without informing the user. (I got bitten by this cur today.)

Print a message when the environment variable is used.

Also, add a newline when the pubkey is printed.