### PR TITLE
User error for some faulty peer multiaddresses

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -898,6 +898,15 @@ let setup_daemon logger =
                    (ex: /ip4/IPADDR/tcp/PORT/p2p/PEERID)"
                   file )
       in
+      List.iter libp2p_peers_raw ~f:(fun raw_peer ->
+          match Mina_net2.Multiaddr.(to_peer @@ of_string raw_peer) with
+          | Some _ ->
+              ()
+          | None ->
+              Mina_user_error.raisef ~where:"decoding peer as a multiaddress"
+                "The given peer \"%s\" is not a valid multiaddress (ex: \
+                 /ip4/IPADDR/tcp/PORT/p2p/PEERID)"
+                raw_peer ) ;
       let initial_peers =
         List.concat
           [ List.map ~f:Mina_net2.Multiaddr.of_string libp2p_peers_raw

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -899,14 +899,11 @@ let setup_daemon logger =
                   file )
       in
       List.iter libp2p_peers_raw ~f:(fun raw_peer ->
-          match Mina_net2.Multiaddr.(to_peer @@ of_string raw_peer) with
-          | Some _ ->
-              ()
-          | None ->
-              Mina_user_error.raisef ~where:"decoding peer as a multiaddress"
-                "The given peer \"%s\" is not a valid multiaddress (ex: \
-                 /ip4/IPADDR/tcp/PORT/p2p/PEERID)"
-                raw_peer ) ;
+          if not Mina_net2.Multiaddr.(valid_as_peer @@ of_string raw_peer) then
+            Mina_user_error.raisef ~where:"decoding peer as a multiaddress"
+              "The given peer \"%s\" is not a valid multiaddress (ex: \
+               /ip4/IPADDR/tcp/PORT/p2p/PEERID)"
+              raw_peer ) ;
       let initial_peers =
         List.concat
           [ List.map ~f:Mina_net2.Multiaddr.of_string libp2p_peers_raw

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -1147,9 +1147,7 @@ module Multiaddr = struct
 
   let to_peer t =
     match String.split ~on:'/' t with
-    | [""; protocol; ip4_str; "tcp"; tcp_str; "p2p"; peer_id]
-      when List.mem ["ip4"; "ip6"; "dns4"; "dns6"] protocol ~equal:String.equal
-      -> (
+    | [""; "ip4"; ip4_str; "tcp"; tcp_str; "p2p"; peer_id] -> (
       try
         let host = Unix.Inet_addr.of_string ip4_str in
         let libp2p_port = Int.of_string tcp_str in
@@ -1157,6 +1155,15 @@ module Multiaddr = struct
       with _ -> None )
     | _ ->
         None
+
+  let valid_as_peer t =
+    match String.split ~on:'/' t with
+    | [""; protocol; _; "tcp"; _; "p2p"; _]
+      when List.mem ["ip4"; "ip6"; "dns4"; "dns6"] protocol ~equal:String.equal
+      ->
+        true
+    | _ ->
+        false
 end
 
 type discovered_peer = {id: Peer.Id.t; maddrs: Multiaddr.t list}

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -1147,7 +1147,9 @@ module Multiaddr = struct
 
   let to_peer t =
     match String.split ~on:'/' t with
-    | [""; "ip4"; ip4_str; "tcp"; tcp_str; "p2p"; peer_id] -> (
+    | [""; protocol; ip4_str; "tcp"; tcp_str; "p2p"; peer_id]
+      when List.mem ["ip4"; "ip6"; "dns4"; "dns6"] protocol ~equal:String.equal
+      -> (
       try
         let host = Unix.Inet_addr.of_string ip4_str in
         let libp2p_port = Int.of_string tcp_str in

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -119,6 +119,13 @@ module Multiaddr : sig
   val of_string : string -> t
 
   val to_peer : t -> Network_peer.Peer.t option
+
+  (** can a multiaddr plausibly be used as a Peer.t?
+      a syntactic check only; a return value of
+       true does not guarantee that the multiaddress can
+       be used as a peer by libp2p
+  *)
+  val valid_as_peer : t -> bool
 end
 
 type discovered_peer = {id: Peer.Id.t; maddrs: Multiaddr.t list}
@@ -369,7 +376,7 @@ val begin_advertising : net -> unit Deferred.Or_error.t
 (** Stop listening, close all connections and subscription pipes, and kill the subprocess. *)
 val shutdown : net -> unit Deferred.t
 
-(** Configure the connection gateway. 
+(** Configure the connection gateway.
 
     This will fail if any of the trusted or banned peers are on IPv6. *)
 val set_connection_gating_config :


### PR DESCRIPTION
Create a user error for `peer` arguments to the daemon. The check does not guarantee a valid multiaddress, only that it can be turned into a `Peer.t`, which just does some simple string-splitting. The check should catch gross errors, like using a peer list file.

Example failure:
```
FATAL ERROR

  ☠  Coda Daemon encountered a configuration error decoding peer as a multiaddress.
  
The given peer "foobar" is not a valid multiaddress (ex: /ip4/IPADDR/tcp/PORT/p2p/PEERID)
```
Q: Why does our `to_peer` function for multiaddresses insist on IPv4?

Closes #7267.