### PR TITLE
OCaml memory stats, add fragments, mention bytes

### DIFF
--- a/src/lib/memory_stats/memory_stats.ml
+++ b/src/lib/memory_stats/memory_stats.ml
@@ -2,15 +2,17 @@
 
 open Core_kernel
 open Async
+open Gc.Stat
 
 let ocaml_memory_stats () =
   let bytes_per_word = Sys.word_size / 8 in
   let stat = Gc.stat () in
-  [ ("heap_size", `Int (stat.heap_words * bytes_per_word))
+  [ ("heap_size_bytes", `Int (stat.heap_words * bytes_per_word))
   ; ("heap_chunks", `Int stat.heap_chunks)
-  ; ("max_heap_size", `Int (stat.top_heap_words * bytes_per_word))
-  ; ("live_size", `Int (stat.live_words * bytes_per_word))
-  ; ("live_blocks", `Int stat.live_blocks) ]
+  ; ("max_heap_size_bytes", `Int (stat.top_heap_words * bytes_per_word))
+  ; ("live_size_bytes", `Int (stat.live_words * bytes_per_word))
+  ; ("live_blocks", `Int stat.live_blocks)
+  ; ("fragments", `Int stat.fragments) ]
 
 let jemalloc_memory_stats () =
   let {Jemalloc.active; resident; allocated; mapped} =


### PR DESCRIPTION
Add `fragments` to the OCaml memory stats. Mention `bytes` explicitly for relevant statistics (wasn't obvious).