### PR TITLE
Add liquid and locked balances to GraphQL, use liquid in Rosetta

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6492,7 +6492,7 @@
         {
           "kind": "OBJECT",
           "name": "AnnotatedBalance",
-          "description": "A total balance annotated with the amount that is currently unknown with the invariant: unknown <= total",
+          "description": "A total balance annotated with the amount that is currently unknown with the invariant unknown <= total, as well as the currently liquid and locked balances.",
           "fields": [
             {
               "name": "total",
@@ -6525,6 +6525,28 @@
               },
               "isDeprecated": true,
               "deprecationReason": null
+            },
+            {
+              "name": "liquid",
+              "isDeprecated": true,
+              "args": [],
+              "deprecationReason": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt64"
+              },
+              "description": "The amount of coda owned by the account which is currently available. Can be null if bootstrapping."
+            },
+            {
+              "name": "locked",
+              "isDeprecated": true,
+              "args": [],
+              "deprecationReason": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt64"
+              },
+              "description": "The amount of coda owned by the account which is currently locked. Can be null if bootstrapping."
             },
             {
               "name": "blockHeight",

--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open Async
 open Rosetta_lib
 open Rosetta_models
+module Decoders = Graphql_lib.Decoders
 
 module Get_balance =
 [%graphql
@@ -21,7 +22,7 @@ module Get_balance =
         balance {
           blockHeight @bsDecoder(fn: "Decoders.uint32")
           stateHash
-          total @bsDecoder(fn: "Decoders.uint64")
+          liquid @bsDecoder(fn: "Decoders.optional_uint64")
         }
         nonce
       }
@@ -82,7 +83,8 @@ module Balance = struct
 
                             method stateHash = Some "STATE_HASH_TIP"
 
-                            method total = Unsigned.UInt64.of_int 66_000
+                            method liquid =
+                              Some (Unsigned.UInt64.of_int 66_000)
                           end
 
                         method nonce = Some "2"
@@ -119,7 +121,7 @@ module Balance = struct
         | Some account ->
             M.return account
       in
-      let%map state_hash =
+      let%bind state_hash =
         match (account#balance)#stateHash with
         | None ->
             M.fail
@@ -131,6 +133,18 @@ module Balance = struct
         | Some state_hash ->
             M.return state_hash
       in
+      let%map liquid_balance =
+        match (account#balance)#liquid with
+        | None ->
+            M.fail
+              (Errors.create
+                 ~context:
+                   "Unable to access liquid balance since your Mina daemon \
+                    isn't fully bootstrapped."
+                 `Chain_info_missing)
+        | Some liquid_balance ->
+            M.return liquid_balance
+      in
       { Account_balance_response.block_identifier=
           { Block_identifier.index=
               Unsigned.UInt32.to_int64 (account#balance)#blockHeight
@@ -141,7 +155,7 @@ module Balance = struct
                 Amount_of.coda
             | Some token_id ->
                 Amount_of.token token_id )
-              (account#balance)#total ]
+              liquid_balance ]
       ; metadata=
           Option.map
             ~f:(fun nonce -> `Assoc [("nonce", `Intlit nonce)])

--- a/src/lib/graphql_lib/decoders.ml
+++ b/src/lib/graphql_lib/decoders.ml
@@ -14,6 +14,8 @@ let optional_public_key = Option.map ~f:public_key
 
 let uint64 json = Yojson.Basic.Util.to_string json |> Unsigned.UInt64.of_string
 
+let optional_uint64 json = Option.map json ~f:uint64
+
 let uint32 json = Yojson.Basic.Util.to_string json |> Unsigned.UInt32.of_string
 
 let balance json =


### PR DESCRIPTION
- Adds new `liquid` and `locked` fields to `AnnotatedBalance` that are set whenever we have sufficient bootstrapping information to compute them.
- Updates Rosetta business logic to use the liquid balance for `/accounts/balance` requests instead of total balance, as required by the Rosetta spec. (Also makes it so `/accounts/balance` requests error out when no liquid balance is available, which would have happened anyway for other reasons.)

To test I ran Rosetta with a genesis ledger including time-locked accounts and confirmed that pre-cliff, cliff, and vesting periods all worked by `curl`ing for balances over time.

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them: