### PR TITLE
Don't interpolate precomputed block

### DIFF
--- a/src/lib/mina_lib/coda_subscriptions.ml
+++ b/src/lib/mina_lib/coda_subscriptions.ml
@@ -198,12 +198,15 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                    Out_channel.output_lines out_channel
                      [Yojson.Safe.to_string (Lazy.force precomputed_block)] )
            ) ;
-           [%log info] "Saw block with state hash %s"
+           [%log info] "Saw block with state hash $state_hash"
              ~metadata:
-               ( if is_some log then
-                 [("precomputed_block", Lazy.force precomputed_block)]
-               else [] )
-             (State_hash.to_base58_check hash)) ;
+               (let state_hash_data =
+                  [("state_hash", `String (State_hash.to_base58_check hash))]
+                in
+                if is_some log then
+                  state_hash_data
+                  @ [("precomputed_block", Lazy.force precomputed_block)]
+                else state_hash_data)) ;
           match
             Filtered_external_transition.validate_transactions
               ~constraint_constants new_block

--- a/src/lib/mina_lib/coda_subscriptions.ml
+++ b/src/lib/mina_lib/coda_subscriptions.ml
@@ -198,10 +198,12 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                    Out_channel.output_lines out_channel
                      [Yojson.Safe.to_string (Lazy.force precomputed_block)] )
            ) ;
-           Option.iter log ~f:(fun `Log ->
-               [%log info] "Saw block $precomputed_block"
-                 ~metadata:[("precomputed_block", Lazy.force precomputed_block)]
-           )) ;
+           [%log info] "Saw block with state hash %s"
+             ~metadata:
+               ( if is_some log then
+                 [("precomputed_block", Lazy.force precomputed_block)]
+               else [] )
+             (State_hash.to_base58_check hash)) ;
           match
             Filtered_external_transition.validate_transactions
               ~constraint_constants new_block


### PR DESCRIPTION
Don't put precomputed block in log message; do put its state hash. Keep the precomputed block in the `metadata`.

Closes #7395.