### PR TITLE
Block query in GraphQL

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -8296,6 +8296,33 @@
               "deprecationReason": null
             },
             {
+              "name": "block",
+              "description": "Retrieve a block with the given state hash, if contained in the transition frontier.",
+              "args": [
+                {
+                  "name": "stateHash",
+                  "description": "The state hash of the desired block",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Block",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "genesisBlock",
               "description": "Get the genesis block",
               "args": [],

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2831,9 +2831,14 @@ module Queries = struct
       ~args:
         Arg.
           [ arg "stateHash" ~doc:"The state hash of the desired block"
-              ~typ:(non_null string) ]
-      ~resolve:(fun {ctx= coda; _} () (state_hash_base58 : string) ->
+              ~typ:string ]
+      ~resolve:
+        (fun {ctx= coda; _} () (state_hash_base58_opt : string option) ->
         let open Result.Let_syntax in
+        let%bind state_hash_base58 =
+          state_hash_base58_opt
+          |> Result.of_option ~error:"Must provide a state hash"
+        in
         let transition_frontier_pipe = Mina_lib.transition_frontier coda in
         let%bind transition_frontier =
           Pipe_lib.Broadcast_pipe.Reader.peek transition_frontier_pipe


### PR DESCRIPTION
Add a query `block` in GraphQL that takes a `stateHash` string, and returns a block with that state hash, using the same format as the blocks returned by `bestChain`.

Closes #7404. Well, maybe, it doesn't support querying by height. Should we provide that as a separate query? I think we'd need to linear search through all breadcrumbs to support that, or add additional indexing to support such a query.