### PR TITLE
call Gc.compact periodically

### DIFF
--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/fuzz_medium.mlh
+++ b/src/config/fuzz_medium.mlh
@@ -29,3 +29,4 @@
 [%%define pending_coinbase_hack false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/fuzz_small.mlh
+++ b/src/config/fuzz_small.mlh
@@ -29,3 +29,4 @@
 [%%define pending_coinbase_hack false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/nonconsensus_medium_curves.mlh
+++ b/src/config/nonconsensus_medium_curves.mlh
@@ -29,3 +29,4 @@
 [%%undef consensus_mechanism]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch true]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_medium_curves.mlh
+++ b/src/config/test_postake_medium_curves.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -30,4 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
-[%%undef compaction_interval]
+[%%define compaction_interval 360000]

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -30,3 +30,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/test_postake_three_producers.mlh
+++ b/src/config/test_postake_three_producers.mlh
@@ -31,3 +31,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -31,3 +31,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/testnet_postake_many_producers.mlh
+++ b/src/config/testnet_postake_many_producers.mlh
@@ -29,3 +29,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/testnet_postake_many_producers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_producers_medium_curves.mlh
@@ -31,3 +31,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -40,3 +40,5 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/mainnet.mlh"]
+(* 2*block_window_duration *)
+[%%define compaction_interval 360000]

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -31,3 +31,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -32,3 +32,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -31,3 +31,4 @@
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
+[%%undef compaction_interval]

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -383,7 +383,7 @@ let time ~logger ~time_controller label f =
   let span = Time.diff (Time.now time_controller) t0 in
   [%log info]
     ~metadata:[("time", `Int (Time.Span.to_ms span |> Int64.to_int_exn))]
-    !"%s%!" label ;
+    !"%s: $time %!" label ;
   x
 
 let run ~logger ~prover ~verifier ~trust_system ~get_completed_work

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -29,6 +29,20 @@ module Currency = Currency_nonconsensus.Currency
 [%%inject
 "minimum_user_command_fee_string", minimum_user_command_fee]
 
+[%%ifndef
+compaction_interval]
+
+let compaction_interval_ms = None
+
+[%%else]
+
+[%%inject
+"compaction_interval", compaction_interval]
+
+let compaction_interval_ms = Some compaction_interval
+
+[%%endif]
+
 let minimum_user_command_fee =
   Currency.Fee.of_formatted_string minimum_user_command_fee_string
 


### PR DESCRIPTION
Calling Gc.compact periodically to free the memory held
Below is the result of calling Gc.compact from utop (it reduced heap words from ~13GB to ~5GB)
```
# Gc.stat ();;
- : Gc.stat =
{Gc.minor_words = 2294978993287.; promoted_words = 15080030917.;
 major_words = 20958098793.; minor_collections = 8761351;
 major_collections = 216; heap_words = 1715582464; heap_chunks = 59;
 live_words = 526574411; live_blocks = 142165064; free_words = 1188950267;
 free_blocks = 2149630; largest_free = 1546702; fragments = 57786;
 compactions = 0; top_heap_words = 1715582464; stack_size = -17469354802087}
# Gc.compact ();;
- : unit = ()
# Gc.stat ();;
- : Gc.stat =
{Gc.minor_words = 2302521471864.; promoted_words = 15123686288.;
 major_words = 21010814070.; minor_collections = 8790126;
 major_collections = 219; heap_words = 734692864; heap_chunks = 4;
 live_words = 394400770; live_blocks = 112766591; free_words = 340292094;
 free_blocks = 3; largest_free = 169203712; fragments = 0; compactions = 1;
 top_heap_words = 1715582464; stack_size = -17469354802221}
```
1. Periodically calling Gc.compact in the daemon for proof-level FULL

2. Added two environment variables `MINA_COMPACTION_MS` and `MINA_COMPACTION_INTERVAL_MS` to set expected compaction time (default: 6000 ms) and time between calling Gc.compact (default: slot_duration * 2) respectively.

Ran the daemon with the default values for ~6 hours. It did reduced the heap words, but the memory usage still grew linearly

Closes #7542
