### PR TITLE
Update and fix integration test framework

### DIFF
--- a/automation/terraform/modules/kubernetes/testnet/helm.tf
+++ b/automation/terraform/modules/kubernetes/testnet/helm.tf
@@ -10,12 +10,13 @@ provider helm {
   }
 }
 
-// data "local_file" "genesis_ledger" {
-//   filename = "genesis_ledger.json"
-//   depends_on = [
-//     null_resource.block_producer_key_generation
-//   ]
-// }
+data "local_file" "genesis_ledger" {
+  # genesis_ledger.json is not required when generate_and_upload_artifacts is set to false
+  filename = var.generate_and_upload_artifacts ? "genesis_ledger.json" : "/dev/null"
+  depends_on = [
+    null_resource.block_producer_key_generation
+  ]
+}
 
 locals {
   mina_helm_repo = "https://coda-charts.storage.googleapis.com"
@@ -26,7 +27,7 @@ locals {
   ]
 
   coda_vars = {
-    runtimeConfig      = var.runtime_config
+    runtimeConfig      = var.generate_and_upload_artifacts ? data.local_file.genesis_ledger.content : var.runtime_config
     image              = var.coda_image
     privkeyPass        = var.block_producer_key_pass
     seedPeers          = concat(var.additional_seed_peers, local.seed_peers)

--- a/automation/terraform/modules/kubernetes/testnet/helm.tf
+++ b/automation/terraform/modules/kubernetes/testnet/helm.tf
@@ -10,12 +10,12 @@ provider helm {
   }
 }
 
-data "local_file" "genesis_ledger" {
-  filename = "genesis_ledger.json"
-  depends_on = [
-    null_resource.block_producer_key_generation
-  ]
-}
+// data "local_file" "genesis_ledger" {
+//   filename = "genesis_ledger.json"
+//   depends_on = [
+//     null_resource.block_producer_key_generation
+//   ]
+// }
 
 locals {
   mina_helm_repo = "https://coda-charts.storage.googleapis.com"
@@ -26,7 +26,7 @@ locals {
   ]
 
   coda_vars = {
-    runtimeConfig      = data.local_file.genesis_ledger.content
+    runtimeConfig      = var.runtime_config
     image              = var.coda_image
     privkeyPass        = var.block_producer_key_pass
     seedPeers          = concat(var.additional_seed_peers, local.seed_peers)
@@ -47,7 +47,7 @@ locals {
   seed_vars = {
     testnetName = var.testnet_name
     coda        = {
-      runtimeConfig      = data.local_file.genesis_ledger.content
+      runtimeConfig      = local.coda_vars.runtimeConfig
       image              = var.coda_image
       privkeyPass        = var.block_producer_key_pass
       seedPeers          = var.additional_seed_peers

--- a/automation/terraform/modules/kubernetes/testnet/testnet-artifacts.tf
+++ b/automation/terraform/modules/kubernetes/testnet/testnet-artifacts.tf
@@ -1,19 +1,22 @@
 resource "null_resource" "block_producer_key_generation" {
+  count = var.runtime_config == "" ? 1 : 0
   provisioner "local-exec" {
-      command = "../../../scripts/generate-keys-and-ledger.sh --testnet=${var.testnet_name} --wc=${var.whale_count} --fc=${var.fish_count} --reset=false"
+    command = "../../../scripts/generate-keys-and-ledger.sh --testnet=${var.testnet_name} --wc=${var.whale_count} --fc=${var.fish_count} --reset=false"
   }
 }
 
 resource "null_resource" "prepare_keys_for_deployment" {
+  count = var.runtime_config == "" ? 1 : 0
   provisioner "local-exec" {
-      command = "chmod -R a+rwX ../../../keys"
+    command = "chmod -R a+rwX ../../../keys"
   }
   depends_on  = [kubernetes_namespace.testnet_namespace, null_resource.block_producer_key_generation]
 }
 
 resource "null_resource" "block_producer_uploads" {
+  count = var.runtime_config == "" ? 1 : 0
   provisioner "local-exec" {
-      command = "../../../scripts/upload-keys-k8s.sh ${var.testnet_name}"
+    command = "../../../scripts/upload-keys-k8s.sh ${var.testnet_name}"
   }
   depends_on = [
     kubernetes_namespace.testnet_namespace,
@@ -21,4 +24,3 @@ resource "null_resource" "block_producer_uploads" {
     null_resource.prepare_keys_for_deployment
   ]
 }
-

--- a/automation/terraform/modules/kubernetes/testnet/testnet-artifacts.tf
+++ b/automation/terraform/modules/kubernetes/testnet/testnet-artifacts.tf
@@ -1,12 +1,12 @@
 resource "null_resource" "block_producer_key_generation" {
-  count = var.runtime_config == "" ? 1 : 0
+  count = var.generate_and_upload_artifacts ? 1 : 0
   provisioner "local-exec" {
     command = "../../../scripts/generate-keys-and-ledger.sh --testnet=${var.testnet_name} --wc=${var.whale_count} --fc=${var.fish_count} --reset=false"
   }
 }
 
 resource "null_resource" "prepare_keys_for_deployment" {
-  count = var.runtime_config == "" ? 1 : 0
+  count = var.generate_and_upload_artifacts ? 1 : 0
   provisioner "local-exec" {
     command = "chmod -R a+rwX ../../../keys"
   }
@@ -14,7 +14,7 @@ resource "null_resource" "prepare_keys_for_deployment" {
 }
 
 resource "null_resource" "block_producer_uploads" {
-  count = var.runtime_config == "" ? 1 : 0
+  count = var.generate_and_upload_artifacts ? 1 : 0
   provisioner "local-exec" {
     command = "../../../scripts/upload-keys-k8s.sh ${var.testnet_name}"
   }

--- a/automation/terraform/modules/kubernetes/testnet/variables.tf
+++ b/automation/terraform/modules/kubernetes/testnet/variables.tf
@@ -1,4 +1,12 @@
-// K8s Cluster Vars
+# Control Vars
+
+# when set to true, this module generates and uploads artifacts from `genesis_ledger.json`
+variable "generate_and_upload_artifacts" {
+  type = bool
+  default = true
+}
+
+# K8s Cluster Vars
 
 variable "cluster_name" {
   type = string
@@ -79,6 +87,7 @@ variable "archive_node_count" {
   default = 0
 }
 
+# only used if `generate_and_upload_artifacts` is set to false
 variable "runtime_config" {
   type    = string
   default = ""

--- a/automation/terraform/modules/kubernetes/testnet/variables.tf
+++ b/automation/terraform/modules/kubernetes/testnet/variables.tf
@@ -79,6 +79,11 @@ variable "archive_node_count" {
   default = 0
 }
 
+variable "runtime_config" {
+  type    = string
+  default = ""
+}
+
 # Seed Vars
 
 variable "seed_port" {

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -268,7 +268,7 @@ func (gs *CodaGatingState) InterceptSecured(_ network.Direction, id peer.ID, add
 	// connections in coda are symmetric: if i am allowed to connect to
 	// you, you are allowed to connect to me.
 	remoteAddr := addrs.RemoteMultiaddr()
-	allow = gs.AllowedPeers.Contains(id) || (!gs.DeniedPeers.Contains(id) && !gs.AddrFilters.AddrBlocked(remoteAddr) && !gs.blockedInternalAddr(remoteAddr))
+	allow = gs.AllowedPeers.Contains(id) || !gs.DeniedPeers.Contains(id)
 
 	if !allow {
 		gs.logger.Infof("refusing to accept inbound connection from authenticated addr: %v", remoteAddr)

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -250,10 +250,6 @@ func (gs *CodaGatingState) InterceptAccept(addrs network.ConnMultiaddrs) (allow 
 		gs.logGate()
 	}
 
-	// if allow && gs.InternalAddrFilters.AddrBlocked(remoteAddr) {
-	//   gs.InternalAddrFilters.AddFilter(remoteAddr, ma.ActionAllow())
-	// }
-
 	return
 }
 

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -155,10 +155,11 @@ type customValidator struct {
 // https://godoc.org/github.com/libp2p/go-libp2p-core/connmgr#ConnectionGating
 // the comments of the functions below are taken from those docs.
 type CodaGatingState struct {
-	logger       logging.EventLogger
-	AddrFilters  *ma.Filters
-	DeniedPeers  *peer.Set
-	AllowedPeers *peer.Set
+	logger              logging.EventLogger
+	InternalAddrFilters *ma.Filters
+	AddrFilters         *ma.Filters
+	DeniedPeers         *peer.Set
+	AllowedPeers        *peer.Set
 }
 
 // NewCodaGatingState returns a new CodaGatingState
@@ -177,16 +178,25 @@ func NewCodaGatingState(addrFilters *ma.Filters, denied *peer.Set, allowed *peer
 		allowed = peer.NewSet()
 	}
 
+	internalAddrFilters := ma.NewFilters()
 	for _, addr := range privateIPs {
-		addrFilters.AddFilter(parseCIDR(addr), ma.ActionDeny)
+		internalAddrFilters.AddFilter(parseCIDR(addr), ma.ActionDeny)
 	}
 
+	logger.Info("computed gating state addr filters: %#v", addrFilters)
+
 	return &CodaGatingState{
-		logger:       logger,
-		AddrFilters:  addrFilters,
-		DeniedPeers:  denied,
-		AllowedPeers: allowed,
+		logger:              logger,
+		AddrFilters:         addrFilters,
+		InternalAddrFilters: internalAddrFilters,
+		DeniedPeers:         denied,
+		AllowedPeers:        allowed,
 	}
+}
+
+func (gs *CodaGatingState) blockedInternalAddr(addr ma.Multiaddr) bool {
+	_, exists := os.LookupEnv("CONNECT_PRIVATE_IPS")
+	return !exists && gs.InternalAddrFilters.AddrBlocked(addr)
 }
 
 func (gs *CodaGatingState) logGate() {
@@ -213,14 +223,11 @@ func (gs *CodaGatingState) InterceptPeerDial(p peer.ID) (allow bool) {
 // This is called by the network.Network implementation after it has
 // resolved the peer's addrs, and prior to dialling each.
 func (gs *CodaGatingState) InterceptAddrDial(id peer.ID, addr ma.Multiaddr) (allow bool) {
-	_, exists := os.LookupEnv("CONNECT_PRIVATE_IPS")
-
-	// if we want to allow connecting to private IPs, and this addr is a private IP, allow
-	if exists && gs.AddrFilters.AddrBlocked(addr) {
-		return true
+	if gs.AddrFilters.AddrBlocked(addr) {
+		return false
 	}
 
-	allow = gs.AllowedPeers.Contains(id) || (!gs.DeniedPeers.Contains(id) && !gs.AddrFilters.AddrBlocked(addr))
+	allow = gs.AllowedPeers.Contains(id) || (!gs.DeniedPeers.Contains(id) && !gs.AddrFilters.AddrBlocked(addr) && !gs.blockedInternalAddr(addr))
 
 	if !allow {
 		gs.logger.Infof("disallowing peer dial from: %v", id)
@@ -243,6 +250,10 @@ func (gs *CodaGatingState) InterceptAccept(addrs network.ConnMultiaddrs) (allow 
 		gs.logGate()
 	}
 
+	// if allow && gs.InternalAddrFilters.AddrBlocked(remoteAddr) {
+	//   gs.InternalAddrFilters.AddFilter(remoteAddr, ma.ActionAllow())
+	// }
+
 	return
 }
 
@@ -257,7 +268,7 @@ func (gs *CodaGatingState) InterceptSecured(_ network.Direction, id peer.ID, add
 	// connections in coda are symmetric: if i am allowed to connect to
 	// you, you are allowed to connect to me.
 	remoteAddr := addrs.RemoteMultiaddr()
-	allow = gs.AllowedPeers.Contains(id) || (!gs.DeniedPeers.Contains(id) && !gs.AddrFilters.AddrBlocked(remoteAddr))
+	allow = gs.AllowedPeers.Contains(id) || (!gs.DeniedPeers.Contains(id) && !gs.AddrFilters.AddrBlocked(remoteAddr) && !gs.blockedInternalAddr(remoteAddr))
 
 	if !allow {
 		gs.logger.Infof("refusing to accept inbound connection from authenticated addr: %v", remoteAddr)

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1187,6 +1187,8 @@ func gatingConfigFromJson(gc *setGatingConfigMsg) (*codanet.CodaGatingState, err
 	newFilter := ma.NewFilters()
 	logger := logging.Logger("libp2p_helper.gatingConfigFromJson")
 
+	logger.Info("setting gating config from: %#v", gc)
+
 	if gc.Isolate {
 		_, ipnet, err := gonet.ParseCIDR("0.0.0.0/0")
 		if err != nil {

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -928,7 +928,7 @@ func (ap *beginAdvertisingMsg) run(app *app) (interface{}, error) {
 	}
 
 	for _, info := range app.AddedPeers {
-		app.P2p.Logger.Error("Trying to connect to: ", info)
+		app.P2p.Logger.Info("Trying to connect to: ", info)
 		err := app.P2p.Host.Connect(app.Ctx, info)
 		if err != nil {
 			app.P2p.Logger.Error("failed to connect to peer: ", info, err.Error())

--- a/src/app/test_executive/peers_test.ml
+++ b/src/app/test_executive/peers_test.ml
@@ -23,7 +23,7 @@ module Make (Engine : Engine_intf) = struct
     in
     { default with
       block_producers=
-        [ {balance= "1000"; timing}
+        [ {balance= "1000"; timing= Untimed}
         ; {balance= "1000"; timing}
         ; {balance= "1000"; timing} ]
     ; num_snark_workers= 0 }

--- a/src/lib/integration_test_cloud_engine/coda_automation.ml
+++ b/src/lib/integration_test_cloud_engine/coda_automation.ml
@@ -16,7 +16,8 @@ module Network_config = struct
     ; run_with_user_agent: bool
     ; run_with_bots: bool
     ; enable_peer_exchange: bool
-    ; isolated: bool }
+    ; isolated: bool
+    ; libp2p_secret: string }
   [@@deriving to_yojson]
 
   type terraform_config =
@@ -204,7 +205,8 @@ module Network_config = struct
       ; run_with_user_agent= false
       ; run_with_bots= false
       ; enable_peer_exchange= false
-      ; isolated= false }
+      ; isolated= false
+      ; libp2p_secret= "" }
     in
     (* NETWORK CONFIG *)
     { coda_automation_location= cli_inputs.coda_automation_location

--- a/src/lib/integration_test_cloud_engine/coda_automation.ml
+++ b/src/lib/integration_test_cloud_engine/coda_automation.ml
@@ -21,7 +21,8 @@ module Network_config = struct
   [@@deriving to_yojson]
 
   type terraform_config =
-    { cluster_name: string
+    { generate_and_upload_artifacts: bool
+    ; cluster_name: string
     ; cluster_region: string
     ; testnet_name: string
     ; k8s_context: string
@@ -216,7 +217,8 @@ module Network_config = struct
     ; constraint_constants
     ; genesis_constants
     ; terraform=
-        { cluster_name
+        { generate_and_upload_artifacts= false
+        ; cluster_name
         ; cluster_region
         ; testnet_name
         ; seed_zone

--- a/src/lib/key_cache/key_cache.ml
+++ b/src/lib/key_cache/key_cache.ml
@@ -215,7 +215,8 @@ module Async : S with module M := Async.Deferred.Or_error = struct
           [("url", `String uri_string); ("local_file_path", `String file_path)] ;
       let%bind result =
         Process.run ~prog:"curl"
-          ~args:["--fail"; "-o"; file_path; uri_string]
+          ~args:
+            ["--fail"; "--silent"; "--show-error"; "-o"; file_path; uri_string]
           ()
         |> Deferred.Result.map_error ~f:(fun err ->
                [%log debug] "Could not download key to key cache"


### PR DESCRIPTION
- Made changes to automation configuration to support integration test framework again (will need to discuss with infra before landing).
  - moved back to `runtime_config` var instead of `genesis_ledger.json`; requires change to existing testnet configs
- Made changes to libp2p_helper to address connectivity issues.
  - half tested, seems promising, but requires some more iteration to confirm
  - probably needs chainsafe review