### PR TITLE
do not invalidate cached item twice

### DIFF
--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -192,20 +192,8 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
                   (metadata @ [("error", Error_json.error_to_yojson error)])
                 "Error while building breadcrumb in the transition handler \
                  processor: $error" ;
-              let (_
-                    : External_transition.Initial_validated.t
-                      Envelope.Incoming.t) =
-                Cached.invalidate_with_failure
-                  cached_initially_validated_transition
-              in
               Deferred.return (Error ())
           | Error (`Fatal_error exn) ->
-              let (_
-                    : External_transition.Initial_validated.t
-                      Envelope.Incoming.t) =
-                Cached.invalidate_with_failure
-                  cached_initially_validated_transition
-              in
               raise exn
           | Ok breadcrumb ->
               Deferred.return (Ok breadcrumb) )


### PR DESCRIPTION
This PR fixes a bug in processor.ml, where we invalidate cached transitions twice if validation fails.

We are using Cached.sequence_result which would automatically invalided the cached item if failed, so do not need to invalidate it by hand.

This would make the crash in #7560 goes away.