### PR TITLE
Ivar.fill crash fix: Remove outstanding_requests ivars during libp2p_helper shutdown/restart

### DIFF
--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -1534,6 +1534,7 @@ let create ~on_unexpected_termination ~logger ~conf_dir =
                 Ivar.fill_if_empty iv
                   (Or_error.error_string
                      "libp2p_helper process died before answering") ) ;
+            Hashtbl.clear outstanding_requests ;
             if
               (not killed)
               && not


### PR DESCRIPTION
This PR removes the `Ivar.t`s from `outstanding_requests` in `Mina_net2` when a shutdown is detected.

This avoids a double-fill when
* we perform a scheduled restart of libp2p_helper (or it crashes and we restart it) in `Gossip_net.Libp2p.create`
* there is some message read from stdout of libp2p_helper, and the scheduler yields before handling it
* the termination handler in `Mina_net2` fills all unfilled `Ivar.t`s with an error state
* the scheduler resumes the message handling, which attempts to fill the now-filled `Ivar.t`.

A backtrace indicating this logic (or, at least, the final step) was posted on discord in the `development` channel.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: