### PR TITLE
Print version in generate-keypair

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -1440,7 +1440,7 @@ let () =
    let is_help_flag = make_list_mem ["-help"; "-?"] in
    match Sys.argv with
    | [|_coda_exe; version|] when is_version_cmd version ->
-       print_version_info ()
+       Mina_version.print_version ()
    | [|coda_exe; version; help|]
      when is_version_cmd version && is_help_flag help ->
        print_version_help coda_exe version

--- a/src/app/generate_keypair/dune
+++ b/src/app/generate_keypair/dune
@@ -3,7 +3,7 @@
  (name generate_keypair)
  (public_name generate_keypair)
  (modes native)
- (libraries cli_lib core_kernel)
+ (libraries cli_lib async core_kernel mina_version)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_let ppx_sexp_conv ppx_optcomp))
  (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60))

--- a/src/app/generate_keypair/generate_keypair.ml
+++ b/src/app/generate_keypair/generate_keypair.ml
@@ -1,4 +1,14 @@
+(* generate_keypair.ml -- utility app that only generates keypairs *)
+
+open Core_kernel
 open Async
 
-(* Utility app that only generates keypairs *)
-let () = Command.run Cli_lib.Commands.generate_keypair
+let () =
+  let is_version_cmd s =
+    List.mem ["version"; "-version"] s ~equal:String.equal
+  in
+  match Sys.argv with
+  | [|_generate_keypair_exe; version|] when is_version_cmd version ->
+      Mina_version.print_version ()
+  | _ ->
+      Command.run Cli_lib.Commands.generate_keypair

--- a/src/lib/mina_version/dune
+++ b/src/lib/mina_version/dune
@@ -1,5 +1,6 @@
 (library
  (name mina_version)
+ (libraries core_kernel)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version))
  (public_name mina_version))

--- a/src/lib/mina_version/gen.sh
+++ b/src/lib/mina_version/gen.sh
@@ -33,3 +33,5 @@ echo "let commit_date = \"$commit_date\"" >> "$1"
 echo "let marlin_commit_id = \"$marlin_commit_id\"" >> "$1"
 echo "let marlin_commit_id_short = \"$marlin_commit_id_short\"" >> "$1"
 echo "let marlin_commit_date = \"$marlin_commit_date\"" >> "$1"
+
+echo "let print_version () = Core_kernel.printf \"Commit %s on branch %s\n\" commit_id branch" >> "$1"

--- a/src/lib/mina_version/mina_version.mli
+++ b/src/lib/mina_version/mina_version.mli
@@ -11,3 +11,5 @@ val marlin_commit_id : string
 val marlin_commit_id_short : string
 
 val marlin_commit_date : string
+
+val print_version : unit -> unit


### PR DESCRIPTION
Allow `-version` and `version` as arguments to `generate_keypair.exe`, and print the version.

Moved `print_version_info` from `coda.ml` to `Mina_version.print_version`, so that any executable can print a version in the same way.

As in `coda.ml`, we have to intercept `Sys.argv` to handle these flags, because the Jane St version relies on a script we're not using.

Example output:
```
Commit 3ea902875ddfbf1d06f5138045f91fd63dd4bfe0 on branch feature/version-for-generate-keypair
```