### PR TITLE
Misc. intermediate commits for support for historical balance lookups in Rosetta

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -129,8 +129,20 @@ module Timing_info = struct
     let open Deferred.Result.Let_syntax in
     let%bind pk_id = Public_key.find (module Conn) acc.public_key in
     Conn.find
-      (Caqti_request.find Caqti_type.int Caqti_type.int
-         "SELECT id FROM timing_info WHERE public_key_id = ?")
+      (Caqti_request.find Caqti_type.int typ
+         "SELECT public_key_id, token, initial_balance, \
+          initial_minimum_balance, cliff_time, cliff_amount, vesting_period, \
+          vesting_increment FROM timing_info WHERE public_key_id = ?")
+      pk_id
+
+  let find_by_pk_opt (module Conn : CONNECTION) public_key =
+    let open Deferred.Result.Let_syntax in
+    let%bind pk_id = Public_key.find (module Conn) public_key in
+    Conn.find_opt
+      (Caqti_request.find_opt Caqti_type.int typ
+         "SELECT public_key_id, token, initial_balance, \
+          initial_minimum_balance, cliff_time, cliff_amount, vesting_period, \
+          vesting_increment FROM timing_info WHERE public_key_id = ?")
       pk_id
 
   let add_if_doesn't_exist (module Conn : CONNECTION) (acc : Account.t) =

--- a/src/app/rosetta/bootstrap_balances.json
+++ b/src/app/rosetta/bootstrap_balances.json
@@ -14,7 +14,7 @@
   },
   {
     "account_identifier": {
-      "address": "B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV",
+      "address": "B62qiWSQiF5Q9CsAHgjMHoEEyR2kJnnCvN9fxRps2NXULU15EeXbzPf",
       "metadata": {
         "token_id": "1"
       }

--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -25,7 +25,7 @@ module Get_balance =
         }
         nonce
       }
-  }
+    }
 |}]
 
 module Balance = struct

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -214,7 +214,7 @@ module Sql = struct
          * backwards until it reaches a block of the given height. *)
         {|
 WITH RECURSIVE chain AS (
-  (SELECT id, state_hash, parent_id, parent_hash, creator_id, block_winner_id, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id, ledger_hash, height, global_slot, timestamp FROM blocks b WHERE height = (select MAX(height) from blocks)
+  (SELECT id, state_hash, parent_id, parent_hash, creator_id, block_winner_id, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id, ledger_hash, height, global_slot, global_slot_since_genesis, timestamp FROM blocks b WHERE height = (select MAX(height) from blocks)
   ORDER BY timestamp ASC
   LIMIT 1)
 

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -155,7 +155,7 @@ let verify_in_mempool_and_block ~logger ~rosetta_uri ~graphql_uri
     "Waited for the next block index $index" ;
   (* Stop noisy block production *)
   let%bind _res = Poke.Staking.disable ~graphql_uri in
-  let succesful (x : Operation_expectation.t) = {x with status= "Success"} in
+  let successful (x : Operation_expectation.t) = {x with status= "Success"} in
   [%log debug]
     ~metadata:
       [ ( "transactions"
@@ -164,7 +164,7 @@ let verify_in_mempool_and_block ~logger ~rosetta_uri ~graphql_uri
     "Asserting that operations are similar in block. Transactions $transactions" ;
   Operation_expectation.assert_similar_operations ~logger
     ~expected:
-      ( List.map ~f:succesful operation_expectations
+      ( List.map ~f:successful operation_expectations
       @ Operation_expectation.
           [ { amount= Some 40_000_000_000
             ; account=

--- a/src/app/rosetta/test-agent/poke.ml
+++ b/src/app/rosetta/test-agent/poke.ml
@@ -216,47 +216,4 @@ module SendTransaction = struct
     let json = Yojson.Safe.from_string operations in
     [%of_yojson: Rosetta_models.Operation.t list] json
     |> Result.ok |> Option.value_exn
-
-  module Mint_tokens =
-  [%graphql
-  {|
-  mutation ($sender: PublicKey!,
-            $receiver: PublicKey,
-            $token: TokenId!,
-            $amount: UInt64!,
-            $fee: UInt64!) {
-    mintTokens(input: {tokenOwner: $sender, receiver: $receiver, token: $token, amount: $amount, fee: $fee},
-               signature: null) {
-        mintTokens {
-          hash
-        }
-      }
-    }
-  |}]
-
-  let mint_tokens ~fee ~receiver ~token ~amount ~graphql_uri () =
-    let open Deferred.Result.Let_syntax in
-    let%map res =
-      Graphql.query
-        (Mint_tokens.make ~sender:(`String pk) ~receiver:(`String receiver)
-           ~token ~amount ~fee ())
-        graphql_uri
-    in
-    let cmd = (res#mintTokens)#mintTokens in
-    cmd#hash
-
-  let mint_tokens_operations ~fee ~sender ~receiver ~amount =
-    assert (String.equal sender pk) ;
-    let operations =
-      sprintf
-        {| [{"operation_identifier":{"index":0},"related_operations":[],"type":"fee_payer_dec","status":"Pending","account":{"address":"%s","metadata":{"token_id":"1"}},"amount":{"value":"-%s","currency":{"symbol":"CODA","decimals":9}}},{"operation_identifier":{"index":1},"related_operations":[],"type":"mint_tokens","status":"Pending","account":{"address":"%s","metadata":{"token_id":"2"}},"amount":{"value":"%s","currency":{"symbol":"CODA+","decimals":9,"metadata":{"token_id":"2"}}}, "metadata": { "token_owner_pk": "%s"} } ] |}
-        sender
-        (Unsigned.UInt64.to_string fee)
-        receiver
-        (Unsigned.UInt64.to_string amount)
-        sender
-    in
-    let json = Yojson.Safe.from_string operations in
-    [%of_yojson: Rosetta_models.Operation.t list] json
-    |> Result.ok |> Option.value_exn
 end

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -322,12 +322,12 @@ let run ~logger ~trust_system ~verifier ~network ~consensus_local_state
                       [ ("new_root", State_hash.to_yojson new_state_hash)
                       ; ("state_hash", State_hash.to_yojson hash) ]
                     "Protocol state (for scan state transactions) for \
-                     $state_hash not found when boostrapping to the new root \
+                     $state_hash not found when bootstrapping to the new root \
                      $new_root" ;
                   Or_error.errorf
                     !"Protocol state (for scan state transactions) for \
-                      %{sexp:State_hash.t} not found when boostrapping to the \
-                      new root %{sexp:State_hash.t}"
+                      %{sexp:State_hash.t} not found when bootstrapping to \
+                      the new root %{sexp:State_hash.t}"
                     hash new_state_hash
               | Some protocol_state ->
                   Ok protocol_state

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -601,6 +601,22 @@ let min_balance_at_slot ~global_slot ~cliff_time ~cliff_amount ~vesting_period
         | Some amt ->
             amt )
 
+let incremental_balance_between_slots ~start_slot ~end_slot ~cliff_time
+    ~cliff_amount ~vesting_period ~vesting_increment ~initial_minimum_balance :
+    Unsigned.UInt64.t =
+  let open Unsigned in
+  let min_balance_at_start_slot =
+    min_balance_at_slot ~global_slot:start_slot ~cliff_time ~cliff_amount
+      ~vesting_period ~vesting_increment ~initial_minimum_balance
+    |> Balance.to_amount |> Amount.to_uint64
+  in
+  let min_balance_at_end_slot =
+    min_balance_at_slot ~global_slot:end_slot ~cliff_time ~cliff_amount
+      ~vesting_period ~vesting_increment ~initial_minimum_balance
+    |> Balance.to_amount |> Amount.to_uint64
+  in
+  UInt64.Infix.(min_balance_at_start_slot - min_balance_at_end_slot)
+
 let has_locked_tokens ~global_slot (account : t) =
   match account.timing with
   | Untimed ->

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -578,6 +578,8 @@ let min_balance_at_slot ~global_slot ~cliff_time ~cliff_amount ~vesting_period
     ~vesting_increment ~initial_minimum_balance =
   let open Unsigned in
   if Global_slot.(global_slot < cliff_time) then initial_minimum_balance
+    (* If vesting period is zero then everything vests immediately at the cliff *)
+  else if Global_slot.(equal vesting_period zero) then Balance.zero
   else
     match Balance.(initial_minimum_balance - cliff_amount) with
     | None ->

--- a/src/lib/user_command_input/user_command_input.ml
+++ b/src/lib/user_command_input/user_command_input.ml
@@ -44,9 +44,11 @@ module Payload = struct
             else
               Error
                 (sprintf
-                   !"Input nonce %s different from inferred nonce %s"
+                   !"Input nonce %s either different from inferred nonce %s \
+                     or below minimum_nonce %s"
                    (Account_nonce.to_string nonce)
-                   (Account_nonce.to_string inferred_nonce))
+                   (Account_nonce.to_string inferred_nonce)
+                   (Account_nonce.to_string minimum_nonce))
       in
       { Signed_command_payload.Common.Poly.fee= t.fee
       ; fee_token= t.fee_token


### PR DESCRIPTION
Miscellaneous small fixes and additions to support adding historical balance lookups to Rosetta (https://github.com/MinaProtocol/mina/pull/7114).

Ran Rosetta test suite successfully.

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ x Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them: