### PR TITLE
GraphQL: Add field for Staged Ledger proof emission

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -458,21 +458,25 @@ module Types = struct
             ~resolve:
               (fun _ {Mina_state.Blockchain_state.Poly.snarked_ledger_hash; _} ->
               Frozen_ledger_hash.to_string snarked_ledger_hash )
-        ; field "stagedLedgerProofEmitted" ~typ:(non_null bool)
-           ~doc: "block finished a staged ledger, and a proof was emitted from it and included into this block's proof"
-           ~args:Arg.[]
-           ~resolve:
-             (fun {ctx= coda; _}
-                  {Mina_state.Blockchain_state.Poly.state_hash; _} ->
+        ; field "stagedLedgerProofEmitted" ~typ:bool
+            ~doc:
+              "Block finished a staged ledger, and a proof was emitted from \
+               it and included into this block's proof. If there is no \
+               transition frontier available, this will return null."
+            ~args:Arg.[]
+            ~resolve:
+              (fun {ctx= coda; _}
+                   {Mina_state.Blockchain_state.Poly.state_hash; _} ->
               let open Option.Let_syntax in
               let%bind frontier =
-                Mina_lib.transition_frontier coda |> Pipe_lib.Broadcast_pipe.Reader.peek
+                Mina_lib.transition_frontier coda
+                |> Pipe_lib.Broadcast_pipe.Reader.peek
               in
               match Transition_frontier.find frontier state_hash with
-              | None -> 
-                  false
+              | None ->
+                  None
               | Some b ->
-                  Breadcrumb.just_emitted_a_proof b
+                  Some (Breadcrumb.just_emitted_a_proof b) )
         ; field "stagedLedgerHash" ~typ:(non_null string)
             ~doc:"Base58Check-encoded hash of the staged ledger"
             ~args:Arg.[]

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -458,6 +458,21 @@ module Types = struct
             ~resolve:
               (fun _ {Mina_state.Blockchain_state.Poly.snarked_ledger_hash; _} ->
               Frozen_ledger_hash.to_string snarked_ledger_hash )
+        ; field "stagedLedgerProofEmitted" ~typ:(non_null bool)
+           ~doc: "block finished a staged ledger, and a proof was emitted from it and included into this block's proof"
+           ~args:Arg.[]
+           ~resolve:
+             (fun {ctx= coda; _}
+                  {Mina_state.Blockchain_state.Poly.state_hash; _} ->
+              let open Option.Let_syntax in
+              let%bind frontier =
+                Mina_lib.transition_frontier coda |> Pipe_lib.Broadcast_pipe.Reader.peek
+              in
+              match Transition_frontier.find frontier state_hash with
+              | None -> 
+                  false
+              | Some b ->
+                  Breadcrumb.just_emitted_a_proof b
         ; field "stagedLedgerHash" ~typ:(non_null string)
             ~doc:"Base58Check-encoded hash of the staged ledger"
             ~args:Arg.[]


### PR DESCRIPTION
Adds the field `stagedLedgerEmittedProof` to the `protocolState` which allows us to detect when the staged ledger fills up and emits a new proof. This will be used in the Local Test Framework to validate the protocol is working as expected.