### PR TITLE
update default CI k8s ctx and tooling

### DIFF
--- a/automation/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
+++ b/automation/terraform/modules/kubernetes/buildkite-agent/google_cloud.tf
@@ -6,9 +6,9 @@ locals {
   ]
 
   buildkite_roles = [
-    "roles/container.developer",
-    "roles/container.viewer",
     "roles/compute.viewer",
+    "roles/container.developer",
+    "roles/container.serviceAgent",
     "roles/stackdriver.accounts.viewer",
     "roles/pubsub.editor",
     "roles/storage.objectAdmin",

--- a/automation/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/automation/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -207,20 +207,40 @@ locals {
         cp --update --verbose $(which helm) "$${CI_SHARED_BIN}/helm"
       EOF
 
-      "03-gcloud-cluster-setup" = <<-EOF
+      "02-install-terraform" = <<-EOF
         #!/bin/bash
 
         set -eou pipefail
 
-        declare -A k8s_cluster_mappings=(
+        apt install -y unzip
+        curl -sL https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip -o terraform.zip
+        unzip terraform.zip && mv terraform /usr/bin
+      EOF
+
+      "03-setup-k8s-ctx" = <<-EOF
+        #!/bin/bash
+
+        set -eou pipefail
+
+        # k8s_ctx = <gcloud_project>_<cluster-region>_<cluster-name>
+        # k8s context mappings: <cluster-name> => <cluster-region>
+        declare -A k8s_ctx_mappings=(
           ["coda-infra-east"]="us-east1"
           ["coda-infra-east4"]="us-east4"
           ["coda-infra-central1"]="us-central1"
           ["mina-integration-west1"]="us-west1"
         )
-        for cluster in "${!k8s_cluster_mappings[@]}"; do
-            gcloud container clusters get-credentials "${cluster}" --region "${k8s_cluster_mappings[$cluster]}"
+        for cluster in "$${!k8s_ctx_mappings[@]}"; do
+            gcloud container clusters get-credentials "$${cluster}" --region "$${k8s_ctx_mappings[$cluster]}"
         done
+
+        # Copy kube config to shared Docker path
+        export CI_SHARED_CONFIG="/var/buildkite/shared/config"
+        mkdir -p "$${CI_SHARED_CONFIG}"
+        cp "$${KUBE_CONFIG_PATH:-/root/.kube/config}" "$${CI_SHARED_CONFIG}/.kube" && chmod ugo+rw "$${CI_SHARED_CONFIG}/.kube"
+
+        # set agent default Kubernetes context for deployment
+        kubectl config use-context ${var.testnet_k8s_ctx}
       EOF
     }
   }

--- a/automation/terraform/modules/kubernetes/buildkite-agent/secrets.tf
+++ b/automation/terraform/modules/kubernetes/buildkite-agent/secrets.tf
@@ -1,4 +1,6 @@
 resource "kubernetes_secret" "google_application_credentials" {
+  provider = kubernetes.bk_deploy
+
   count = var.enable_gcs_access ? 1 : 0
 
   metadata {

--- a/automation/terraform/modules/kubernetes/buildkite-agent/variables.tf
+++ b/automation/terraform/modules/kubernetes/buildkite-agent/variables.tf
@@ -21,6 +21,13 @@ variable "k8s_context" {
   default     = "minikube"
 }
 
+variable "testnet_k8s_ctx" {
+  type = string
+
+  description = "Default k8s resource provider context for deploying testnets"
+  default     = "gke_o1labs-192920_us-west1_mina-integration-west1"
+}
+
 # Module Vars: Agent
 
 variable "cluster_name" {


### PR DESCRIPTION
* add var for and set default agent testnet k8s ctx
* add agent entrypoint for terraform install 
* add kube config to shared DIR between agent and dind containers
* update agent service account roles for terraform testnet provisioning

Redirects changes from https://github.com/MinaProtocol/mina/pull/7457 (targeting `develop`)

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
