### PR TITLE
log file for rejected blocks

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -332,19 +332,26 @@ let setup_daemon logger =
     (* 512MB logrotate max size = 1GB max filesystem usage *)
     let logrotate_max_size = 1024 * 1024 * 10 in
     let logrotate_num_rotate = 50 in
-    Logger.Consumer_registry.register ~id:"default"
+    Logger.Consumer_registry.register ~id:Logger.Logger_id.mina
       ~processor:(Logger.Processor.raw ~log_level:file_log_level ())
       ~transport:
         (Logger.Transport.File_system.dumb_logrotate ~directory:conf_dir
            ~log_filename:"coda.log" ~max_size:logrotate_max_size
            ~num_rotate:logrotate_num_rotate) ;
     let best_tip_diff_log_size = 1024 * 1024 * 5 in
-    Logger.Consumer_registry.register ~id:"best_tip_diff"
+    Logger.Consumer_registry.register ~id:Logger.Logger_id.best_tip_diff
       ~processor:(Logger.Processor.raw ())
       ~transport:
         (Logger.Transport.File_system.dumb_logrotate ~directory:conf_dir
            ~log_filename:"mina-best-tip.log" ~max_size:best_tip_diff_log_size
            ~num_rotate:1) ;
+    let rejected_blocks_log_size = 1024 * 1024 * 5 in
+    Logger.Consumer_registry.register ~id:Logger.Logger_id.rejected_blocks
+      ~processor:(Logger.Processor.raw ())
+      ~transport:
+        (Logger.Transport.File_system.dumb_logrotate ~directory:conf_dir
+           ~log_filename:"mina-rejected-blocks.log"
+           ~max_size:rejected_blocks_log_size ~num_rotate:50) ;
     let version_metadata =
       [ ("commit", `String Mina_version.commit_id)
       ; ("branch", `String Mina_version.branch)

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -299,8 +299,8 @@ module Precomputed_block = struct
   let t_of_sexp = External_transition.Precomputed_block.t_of_sexp
 end
 
-let handle_block_production_errors ~logger ~previous_protocol_state
-    ~protocol_state x =
+let handle_block_production_errors ~logger ~rejected_blocks_logger
+    ~time_taken:span ~previous_protocol_state ~protocol_state x =
   let transition_error_msg_prefix = "Validation failed: " in
   let transition_reason_for_failure =
     " One possible reason could be a ledger-catchup is triggered before we \
@@ -309,6 +309,9 @@ let handle_block_production_errors ~logger ~previous_protocol_state
   let exn_breadcrumb err =
     Error.tag err ~tag:"Error building breadcrumb from produced transition"
     |> Error.raise
+  in
+  let time_metadata =
+    ("time", `Int (Time.Span.to_ms span |> Int64.to_int_exn))
   in
   match x with
   | Ok x ->
@@ -319,44 +322,68 @@ let handle_block_production_errors ~logger ~previous_protocol_state
         , ( previous_protocol_state_proof
           , internal_transition
           , pending_coinbase_witness ) )) ->
-      [%log error]
+      let msg : (_, unit, string, unit) format4 =
         "Prover failed to prove freshly generated transition: $error"
-        ~metadata:
-          [ ("error", Error_json.error_to_yojson err)
-          ; ( "prev_state"
-            , Protocol_state.value_to_yojson previous_protocol_state )
-          ; ("prev_state_proof", Proof.to_yojson previous_protocol_state_proof)
-          ; ("next_state", Protocol_state.value_to_yojson protocol_state)
-          ; ( "internal_transition"
-            , Internal_transition.to_yojson internal_transition )
-          ; ( "pending_coinbase_witness"
-            , Pending_coinbase_witness.to_yojson pending_coinbase_witness ) ] ;
+      in
+      let metadata =
+        [ ("error", Error_json.error_to_yojson err)
+        ; ("prev_state", Protocol_state.value_to_yojson previous_protocol_state)
+        ; ("prev_state_proof", Proof.to_yojson previous_protocol_state_proof)
+        ; ("next_state", Protocol_state.value_to_yojson protocol_state)
+        ; ( "internal_transition"
+          , Internal_transition.to_yojson internal_transition )
+        ; ( "pending_coinbase_witness"
+          , Pending_coinbase_witness.to_yojson pending_coinbase_witness )
+        ; time_metadata ]
+      in
+      [%log error] ~metadata msg ;
+      [%log' debug rejected_blocks_logger] ~metadata msg ;
       return ()
   | Error `Invalid_genesis_protocol_state ->
       let state_yojson =
         Fn.compose State_hash.to_yojson Protocol_state.genesis_state_hash
       in
-      [%log warn]
-        ~metadata:
-          [ ("expected", state_yojson previous_protocol_state)
-          ; ("got", state_yojson protocol_state) ]
-        "Produced transition has invalid genesis state hash" ;
+      let msg : (_, unit, string, unit) format4 =
+        "Produced transition has invalid genesis state hash"
+      in
+      let metadata =
+        [ ("expected", state_yojson previous_protocol_state)
+        ; ("got", state_yojson protocol_state)
+        ; time_metadata ]
+      in
+      [%log warn] ~metadata msg ;
+      [%log' debug rejected_blocks_logger] ~metadata msg ;
       return ()
   | Error `Already_in_frontier ->
-      [%log error]
-        ~metadata:
-          [("protocol_state", Protocol_state.value_to_yojson protocol_state)]
-        "%sproduced transition is already in frontier"
+      let metadata =
+        [ ("protocol_state", Protocol_state.value_to_yojson protocol_state)
+        ; time_metadata ]
+      in
+      [%log error] ~metadata "%sproduced transition is already in frontier"
+        transition_error_msg_prefix ;
+      [%log' debug rejected_blocks_logger]
+        ~metadata "%sproduced transition is already in frontier"
         transition_error_msg_prefix ;
       return ()
   | Error `Not_selected_over_frontier_root ->
-      [%log warn]
+      let metadata = [time_metadata] in
+      [%log warn] ~metadata
+        "%sproduced transition is not selected over the root of transition \
+         frontier.%s"
+        transition_error_msg_prefix transition_reason_for_failure ;
+      [%log' debug rejected_blocks_logger]
+        ~metadata
         "%sproduced transition is not selected over the root of transition \
          frontier.%s"
         transition_error_msg_prefix transition_reason_for_failure ;
       return ()
   | Error `Parent_missing_from_frontier ->
-      [%log warn]
+      let metadata = [time_metadata] in
+      [%log warn] ~metadata
+        "%sparent of produced transition is missing from the frontier.%s"
+        transition_error_msg_prefix transition_reason_for_failure ;
+      [%log' debug rejected_blocks_logger]
+        ~metadata
         "%sparent of produced transition is missing from the frontier.%s"
         transition_error_msg_prefix transition_reason_for_failure ;
       return ()
@@ -368,12 +395,17 @@ let handle_block_production_errors ~logger ~previous_protocol_state
       (* Unexpected errors from staged_ledger are captured in
                      `Fatal_error
     *)
-      [%log error]
-        ~metadata:
-          [ ("error", Error_json.error_to_yojson e)
-          ; ("diff", Staged_ledger_diff.to_yojson staged_ledger_diff) ]
-        !"Unable to build breadcrumb from produced transition due to invalid \
-          staged ledger diff: $error" ;
+      let msg : (_, unit, string, unit) format4 =
+        "Unable to build breadcrumb from produced transition due to invalid \
+         staged ledger diff: $error"
+      in
+      let metadata =
+        [ ("error", Error_json.error_to_yojson e)
+        ; ("diff", Staged_ledger_diff.to_yojson staged_ledger_diff)
+        ; time_metadata ]
+      in
+      [%log error] ~metadata msg ;
+      [%log' debug rejected_blocks_logger] ~metadata msg ;
       return ()
 
 let time ~logger ~time_controller label f =
@@ -394,6 +426,9 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
   trace "block_producer" (fun () ->
       let constraint_constants = precomputed_values.constraint_constants in
       let consensus_constants = precomputed_values.consensus_constants in
+      let rejected_blocks_logger =
+        Logger.create ~id:Logger.Logger_id.rejected_blocks ()
+      in
       let log_bootstrap_mode () =
         [%log info] "Pausing block production while bootstrapping"
       in
@@ -411,6 +446,7 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                 Transition_registry
             in
             let crumb = Transition_frontier.best_tip frontier in
+            let start = Time.now time_controller in
             [%log info]
               ~metadata:[("breadcrumb", Breadcrumb.to_yojson crumb)]
               "Producing new block with parent $breadcrumb%!" ;
@@ -612,16 +648,30 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                         (* FIXME #3167: this should be fatal, and more
                         importantly, shouldn't happen.
                      *)
-                        [%log fatal] ~metadata
+                        let msg : (_, unit, string, unit) format4 =
                           "Timed out waiting for generated transition \
                            $state_hash to enter transition frontier. \
                            Continuing to produce new blocks anyway. This may \
                            mean your CPU is overloaded. Consider disabling \
-                           `-run-snark-worker` if it's configured." ;
+                           `-run-snark-worker` if it's configured."
+                        in
+                        let span =
+                          Time.diff (Time.now time_controller) start
+                        in
+                        [%log' debug rejected_blocks_logger] ~metadata msg ;
+                        [%log fatal]
+                          ~metadata:
+                            ( ( "time"
+                              , `Int (Time.Span.to_ms span |> Int64.to_int_exn)
+                              )
+                            :: metadata )
+                          msg ;
                         return ()
                   in
                   let%bind res = emit_breadcrumb () in
+                  let span = Time.diff (Time.now time_controller) start in
                   handle_block_production_errors ~logger
+                    ~rejected_blocks_logger ~time_taken:span
                     ~previous_protocol_state ~protocol_state res) )
       in
       let production_supervisor = Singleton_supervisor.create ~task:produce in
@@ -738,6 +788,10 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
   let log_bootstrap_mode () =
     [%log info] "Pausing block production while bootstrapping"
   in
+  let rejected_blocks_logger =
+    Logger.create ~id:Logger.Logger_id.rejected_blocks ()
+  in
+  let start = Time.now time_controller in
   let module Breadcrumb = Transition_frontier.Breadcrumb in
   let produce
       { Precomputed_block.scheduled_time= _
@@ -886,8 +940,9 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
               return ()
         in
         let%bind res = emit_breadcrumb () in
-        handle_block_production_errors ~logger ~previous_protocol_state
-          ~protocol_state res
+        let span = Time.diff (Time.now time_controller) start in
+        handle_block_production_errors ~logger ~rejected_blocks_logger
+          ~time_taken:span ~previous_protocol_state ~protocol_state res
   in
   let rec emit_next_block precomputed_blocks =
     (* Begin checking for the ability to produce a block *)

--- a/src/lib/logger/impl.ml
+++ b/src/lib/logger/impl.ml
@@ -273,7 +273,9 @@ module Consumer_registry = struct
 
   let t : t = Consumer_tbl.create ()
 
-  let register ~id ~processor ~transport =
+  type id = string
+
+  let register ~(id : id) ~processor ~transport =
     Consumer_tbl.add_multi t ~key:id ~data:{processor; transport}
 
   let broadcast_log_message ~id msg =

--- a/src/lib/logger/impl.mli
+++ b/src/lib/logger/impl.mli
@@ -103,8 +103,10 @@ end
  *  ensure the code does not accidentally attach the same
  *  consumer multiple times. *)
 module Consumer_registry : sig
+  type id = string
+
   val register :
-    id:string -> processor:Processor.t -> transport:Transport.t -> unit
+    id:id -> processor:Processor.t -> transport:Transport.t -> unit
 end
 
 type 'a log_function =

--- a/src/lib/logger/logger.ml
+++ b/src/lib/logger/logger.ml
@@ -1,1 +1,9 @@
 include Impl
+
+module Logger_id = struct
+  let mina : Consumer_registry.id = "default"
+
+  let best_tip_diff = "best_tip_diff"
+
+  let rejected_blocks = "rejected_blocks"
+end

--- a/src/lib/transition_frontier/extensions/best_tip_diff.ml
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.ml
@@ -28,7 +28,9 @@ module T = struct
   end
 
   let create ~logger frontier =
-    let best_tip_diff_logger = Logger.create ~id:"best_tip_diff" () in
+    let best_tip_diff_logger =
+      Logger.create ~id:Logger.Logger_id.best_tip_diff ()
+    in
     ( {logger; best_tip_diff_logger}
     , { new_commands= Breadcrumb.commands (Full_frontier.root frontier)
       ; removed_commands= []

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -16,8 +16,8 @@ type validation_error =
   | `Mismatched_protocol_version
   | `Invalid_protocol_version ]
 
-let handle_validation_error ~logger ~trust_system ~sender ~state_hash ~delta
-    (error : validation_error) =
+let handle_validation_error ~logger ~rejected_blocks_logger ~time_received
+    ~trust_system ~sender ~state_hash ~delta (error : validation_error) =
   let open Trust_system.Actions in
   let punish action message =
     let message' =
@@ -55,8 +55,20 @@ let handle_validation_error ~logger ~trust_system ~sender ~state_hash ~delta
     | `Invalid_protocol_version ->
         [("reason", `String "invalid protocol version")]
   in
-  [%log error]
-    ~metadata:(("state_hash", State_hash.to_yojson state_hash) :: metadata)
+  let metadata =
+    [ ("state_hash", State_hash.to_yojson state_hash)
+    ; ( "time_received"
+      , `String
+          (Time.to_string_abs
+             (Block_time.to_time time_received)
+             ~zone:Time.Zone.utc) ) ]
+    @ metadata
+  in
+  [%log error] ~metadata
+    "Validation error: external transition with state hash $state_hash was \
+     rejected for reason $reason" ;
+  [%log' debug rejected_blocks_logger]
+    ~metadata
     "Validation error: external transition with state hash $state_hash was \
      rejected for reason $reason" ;
   match error with
@@ -133,7 +145,8 @@ module Duplicate_block_detector = struct
 
   let create () = {table= Map.empty (module Blocks); latest_epoch= 0}
 
-  let check ~precomputed_values t logger external_transition_with_hash =
+  let check ~precomputed_values ~rejected_blocks_logger ~time_received t logger
+      external_transition_with_hash =
     let external_transition = external_transition_with_hash.With_hash.data in
     let protocol_state_hash = external_transition_with_hash.hash in
     let open Consensus.Data.Consensus_state in
@@ -151,19 +164,27 @@ module Duplicate_block_detector = struct
     | None ->
         t.table <- Map.add_exn t.table ~key:block ~data:protocol_state_hash
     | Some hash ->
-        if not (State_hash.equal hash protocol_state_hash) then
-          [%log error]
-            ~metadata:
-              [ ( "block_producer"
-                , Public_key.Compressed.to_yojson block_producer )
-              ; ( "consensus_time"
-                , Consensus.Data.Consensus_time.to_yojson consensus_time )
-              ; ("hash", State_hash.to_yojson hash)
-              ; ( "current_protocol_state_hash"
-                , State_hash.to_yojson protocol_state_hash ) ]
+        if not (State_hash.equal hash protocol_state_hash) then (
+          let metadata =
+            [ ("block_producer", Public_key.Compressed.to_yojson block_producer)
+            ; ( "consensus_time"
+              , Consensus.Data.Consensus_time.to_yojson consensus_time )
+            ; ("hash", State_hash.to_yojson hash)
+            ; ( "current_protocol_state_hash"
+              , State_hash.to_yojson protocol_state_hash )
+            ; ( "time_received"
+              , `String
+                  (Time.to_string_abs
+                     (Block_time.to_time time_received)
+                     ~zone:Time.Zone.utc) ) ]
+          in
+          let msg : (_, unit, string, unit) format4 =
             "Duplicate producer and slot: producer = $block_producer, \
              consensus_time = $consensus_time, previous protocol state hash = \
              $hash, current protocol state hash = $current_protocol_state_hash"
+          in
+          [%log' debug rejected_blocks_logger] ~metadata msg ;
+          [%log error] ~metadata msg )
 end
 
 let run ~logger ~trust_system ~verifier ~transition_reader
@@ -174,6 +195,9 @@ let run ~logger ~trust_system ~verifier ~transition_reader
   in
   let genesis_constants =
     Precomputed_values.genesis_constants precomputed_values
+  in
+  let rejected_blocks_logger =
+    Logger.create ~id:Logger.Logger_id.rejected_blocks ()
   in
   let open Deferred.Let_syntax in
   let duplicate_checker = Duplicate_block_detector.create () in
@@ -194,7 +218,8 @@ let run ~logger ~trust_system ~verifier ~transition_reader
                          External_transition.protocol_state)
              in
              Duplicate_block_detector.check ~precomputed_values
-               duplicate_checker logger transition_with_hash ;
+               ~rejected_blocks_logger ~time_received duplicate_checker logger
+               transition_with_hash ;
              let sender = Envelope.Incoming.sender transition_env in
              let computation =
                let open Interruptible.Let_syntax in
@@ -240,7 +265,8 @@ let run ~logger ~trust_system ~verifier ~transition_reader
                    Mina_net2.Validation_callback.fire_if_not_already_fired
                      valid_cb `Reject ;
                    Interruptible.uninterruptible
-                   @@ handle_validation_error ~logger ~trust_system ~sender
+                   @@ handle_validation_error ~logger ~rejected_blocks_logger
+                        ~time_received ~trust_system ~sender
                         ~state_hash:(With_hash.hash transition_with_hash)
                         ~delta:genesis_constants.protocol.delta error
              in


### PR DESCRIPTION
A separate log file `mina-rejected-blocks.log` for rejected blocks. This is to understand the impact of blocks being missed/not broadcasted fast enough
(tracked here https://github.com/MinaProtocol/mina/issues/7338)