### PR TITLE
Handle WNOHANG exceptions from verifier and libp2p_helper processes

### DIFF
--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -12,12 +12,13 @@ type t =
   ; stdout_pipe: string Strict_pipe.Reader.t
   ; stderr_pipe: string Strict_pipe.Reader.t
   ; stdin: Writer.t
-  ; terminated_ivar: Unix.Exit_or_signal.t Ivar.t
+  ; terminated_ivar: Unix.Exit_or_signal.t Or_error.t Ivar.t
   ; mutable killing: bool
   ; mutable termination_response:
       [ `Always_raise
       | `Raise_on_failure
-      | `Handler of killed:bool -> Unix.Exit_or_signal.t -> unit Deferred.t
+      | `Handler of
+        killed:bool -> Unix.Exit_or_signal.t Or_error.t -> unit Deferred.t
       | `Ignore ] }
 
 let stdout_lines : t -> string Strict_pipe.Reader.t = fun t -> t.stdout_pipe
@@ -26,7 +27,7 @@ let stderr_lines : t -> string Strict_pipe.Reader.t = fun t -> t.stderr_pipe
 
 let stdin : t -> Writer.t = fun t -> t.stdin
 
-let termination_status : t -> Unix.Exit_or_signal.t option =
+let termination_status : t -> Unix.Exit_or_signal.t Or_error.t option =
  fun t -> Ivar.peek t.terminated_ivar
 
 (** Try running [f] until it returns [Ok], returning the first [Ok] or [Error]
@@ -240,7 +241,9 @@ let start_custom :
     -> termination:[ `Always_raise
                    | `Raise_on_failure
                    | `Handler of
-                     killed:bool -> Unix.Exit_or_signal.t -> unit Deferred.t
+                        killed:bool
+                     -> Unix.Exit_or_signal.t Or_error.t
+                     -> unit Deferred.t
                    | `Ignore ]
     -> t Deferred.Or_error.t =
  fun ~logger ~name ~git_root_relative_path ~conf_dir ~args ~stdout ~stderr
@@ -305,7 +308,9 @@ let start_custom :
   in
   don't_wait_for
     (let open Deferred.Let_syntax in
-    let%bind termination_status = Process.wait process in
+    let%bind termination_status =
+      Deferred.Or_error.try_with (fun () -> Process.wait process)
+    in
     [%log trace] "child process %s died" name ;
     don't_wait_for
       (let%bind () = after (Time.Span.of_sec 1.) in
@@ -313,14 +318,17 @@ let start_custom :
        let%bind () = Reader.close @@ Process.stdout process in
        Reader.close @@ Process.stderr process) ;
     let%bind () = Sys.remove lock_path in
-    if Ivar.is_full terminated_ivar then [%log error] "Ivar.fill bug is here!" ;
     Ivar.fill terminated_ivar termination_status ;
     let log_bad_termination () =
+      let exit_or_signal =
+        match termination_status with
+        | Ok termination_status ->
+            `String (Unix.Exit_or_signal.to_string_hum termination_status)
+        | Error err ->
+            Error_json.error_to_yojson err
+      in
       [%log fatal] "Process died unexpectedly: $exit_or_signal"
-        ~metadata:
-          [ ( "exit_or_signal"
-            , `String (Unix.Exit_or_signal.to_string_hum termination_status) )
-          ] ;
+        ~metadata:[("exit_or_signal", exit_or_signal)] ;
       raise Child_died
     in
     match (t.termination_response, termination_status) with
@@ -328,9 +336,9 @@ let start_custom :
         Deferred.unit
     | `Always_raise, _ ->
         log_bad_termination ()
-    | `Raise_on_failure, Error _ ->
+    | `Raise_on_failure, (Error _ | Ok (Error _)) ->
         log_bad_termination ()
-    | `Raise_on_failure, Ok () ->
+    | `Raise_on_failure, Ok (Ok ()) ->
         Deferred.unit
     | `Handler f, _ ->
         f ~killed:t.killing termination_status) ;
@@ -339,9 +347,13 @@ let start_custom :
 let kill : t -> Unix.Exit_or_signal.t Deferred.Or_error.t =
  fun t ->
   match Ivar.peek t.terminated_ivar with
-  | None ->
-      if t.killing then
-        Deferred.map (Ivar.read t.terminated_ivar) ~f:Or_error.return
+  | None | Some (Error _) ->
+      (* The [Error] termination status indicates that we were not able to
+         monitor this process, and it may still be running. In these cases, it
+         is reasonable to call [kill], and we should attempt to end the process
+         if it is running.
+      *)
+      if t.killing then Ivar.read t.terminated_ivar
       else (
         t.killing <- true ;
         ( match t.termination_response with
@@ -351,7 +363,7 @@ let kill : t -> Unix.Exit_or_signal.t Deferred.Or_error.t =
             t.termination_response <- `Ignore ) ;
         match Signal.send Signal.term (`Pid (Process.pid t.process)) with
         | `Ok ->
-            Deferred.map (Ivar.read t.terminated_ivar) ~f:Or_error.return
+            Ivar.read t.terminated_ivar
         | `No_such_process ->
             Deferred.Or_error.error_string
               "No such process running. This should be impossible." )
@@ -393,7 +405,8 @@ let%test_module _ =
           (* Pipe will be closed before the ivar is filled, so we need to wait a
              bit. *)
           let%bind () = after process_wait_timeout in
-          [%test_eq: Unix.Exit_or_signal.t option] (Some (Ok ()))
+          [%test_eq: Unix.Exit_or_signal.t Or_error.t option]
+            (Some (Ok (Ok ())))
             (termination_status process) ;
           Deferred.unit )
 
@@ -458,10 +471,10 @@ let%test_module _ =
             mk_process () |> Deferred.map ~f:Or_error.ok_exn
           in
           let%bind () = after process_wait_timeout in
-          [%test_eq: Unix.Exit_or_signal.t option]
+          [%test_eq: Unix.Exit_or_signal.t Or_error.t option]
             (termination_status process1)
-            (Some (Error (`Signal Core.Signal.term))) ;
-          [%test_eq: Unix.Exit_or_signal.t option]
+            (Some (Ok (Error (`Signal Core.Signal.term)))) ;
+          [%test_eq: Unix.Exit_or_signal.t Or_error.t option]
             (termination_status process2)
             None ;
           let%bind _ = kill process2 in

--- a/src/lib/child_processes/dune
+++ b/src/lib/child_processes/dune
@@ -7,4 +7,4 @@
  (preprocess (pps
                ppx_assert ppx_coda ppx_version ppx_custom_printf ppx_deriving.show ppx_inline_test ppx_let
                ppx_pipebang))
- (libraries async core ctypes ctypes.foreign file_system logger pipe_lib))
+ (libraries async core ctypes ctypes.foreign file_system error_json logger pipe_lib))


### PR DESCRIPTION
This PR catches and handles WNOHANG errors that the libp2p_helper and verifier subprocess monitors may cause via `Process.wait`.

I suspect most of these were caused by races between creating/stopping the processes and the calls to wait. Subtly different behaviour in OS X's process creation and/or waiting syscalls may explain the higher prevalence of these errors on Macs.
**Open question: Should we retry before failing? If so, under what conditions, with what time delay, etc.?**
It's worth noting that we could leak started processes if the OS starts the subprocess after both the wait and the attempted kill have already executed.

This is very likely to fix the WNOHANG errors mentioned in #6951, #4480. This may also fix
* #4297 (old, so it's not clear from the stacktrace)
* #3706 (refers to Kademlia, which used approximately the same subprocess interface as libp2p_helper)
* #3520 (old + Mac-specific discussion. It's possible that OS X's behaviour there will make it more likely to cause a process leak as described above.)
* #7368's WNOHANG (the word WNOHANG is mentioned devoid of any useful context)

This also removes an `Ivar.fill` error log, because that error can't be triggered here (only one `fill` and it is opaque to code outside the module).

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
