### PR TITLE
Validate keypair app and command

### DIFF
--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -21,8 +21,8 @@ echo "--- Publish pvkeys"
 echo "--- Build libp2p_helper TODO: use the previously uploaded build artifact"
 LIBP2P_NIXLESS=1 make libp2p_helper
 
-echo "--- Build generate-keypair binary"
-dune build --profile=${DUNE_PROFILE} src/app/generate_keypair/generate_keypair.exe 2>&1 | tee /tmp/buildocaml2.log
+echo "--- Build generate-keypair and validate-keypair binaries"
+dune build --profile=${DUNE_PROFILE} src/app/generate_keypair/generate_keypair.exe src/app/validate_keypair/validate_keypair.exe 2>&1 | tee /tmp/buildocaml2.log
 
 echo "--- Build runtime_genesis_ledger binary"
 dune exec --profile=${DUNE_PROFILE} src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -47,7 +47,7 @@ License: Apache-2.0
 Vendor: none
 Architecture: amd64
 Maintainer: o(1)Labs <build@o1labs.org>
-Installed-Size: 
+Installed-Size:
 Depends: libssl1.1, libprocps6, libgmp10, libffi6, libgomp1
 Section: base
 Priority: optional
@@ -64,6 +64,7 @@ cat "${BUILDDIR}/DEBIAN/control"
 # Binaries
 mkdir -p "${BUILDDIR}/usr/local/bin"
 cp ./default/src/app/generate_keypair/generate_keypair.exe "${BUILDDIR}/usr/local/bin/mina-generate-keypair"
+cp ./default/src/app/validate_keypair/validate_keypair.exe "${BUILDDIR}/usr/local/bin/mina-validate-keypair"
 
 # echo contents of deb
 echo "------------------------------------------------------------"

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1951,6 +1951,7 @@ let advanced =
     ; ("visualization", Visualization.command_group)
     ; ("verify-receipt", verify_receipt)
     ; ("generate-keypair", Cli_lib.Commands.generate_keypair)
+    ; ("validate-keypair", Cli_lib.Commands.validate_keypair)
     ; ("next-available-token", next_available_token_cmd)
     ; ("time-offset", get_time_offset_graphql)
     ; ("get-peers", get_peers_graphql)

--- a/src/app/validate_keypair/dune
+++ b/src/app/validate_keypair/dune
@@ -1,0 +1,9 @@
+(executable
+ (package validate_keypair)
+ (name validate_keypair)
+ (public_name validate_keypair)
+ (modes native)
+ (libraries cli_lib async core_kernel mina_version)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version ppx_let ppx_sexp_conv ppx_optcomp))
+ (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60))

--- a/src/app/validate_keypair/validate_keypair.ml
+++ b/src/app/validate_keypair/validate_keypair.ml
@@ -1,0 +1,14 @@
+(* validate_keypair.ml *)
+
+open Core_kernel
+open Async
+
+let () =
+  let is_version_cmd s =
+    List.mem ["version"; "-version"] s ~equal:String.equal
+  in
+  match Sys.argv with
+  | [|_generate_keypair_exe; version|] when is_version_cmd version ->
+      Mina_version.print_version ()
+  | _ ->
+      Command.run Cli_lib.Commands.validate_keypair

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -1,4 +1,3 @@
-open Core_kernel
 open Signature_lib
 open Async
 
@@ -6,11 +5,8 @@ let generate_keypair =
   Command.async ~summary:"Generate a new public, private keypair"
     (let open Command.Let_syntax in
     let env = Secrets.Keypair.env in
-    ( match Sys.getenv env with
-    | None ->
-        ()
-    | Some _ ->
-        printf "Using password from environment variable %s\n" env ) ;
+    if Option.is_some (Sys.getenv env) then
+      printf "Using password from environment variable %s\n" env ;
     let%map_open privkey_path = Flag.privkey_write_path in
     Exceptions.handle_nicely
     @@ fun () ->
@@ -21,4 +17,46 @@ let generate_keypair =
       ( kp.public_key |> Public_key.compress
       |> Public_key.Compressed.to_base58_check )
       (Rosetta_coding.Coding.of_public_key kp.public_key) ;
+    exit 0)
+
+let validate_keypair =
+  Command.async ~summary:"Validate a public, private keypair"
+    (let open Command.Let_syntax in
+    let open Core_kernel in
+    let%map_open privkey_path = Flag.privkey_write_path in
+    Exceptions.handle_nicely
+    @@ fun () ->
+    let validate_transaction keypair =
+      let dummy_payload = Mina_base.Signed_command_payload.dummy in
+      let signature =
+        Mina_base.Signed_command.sign_payload keypair.Keypair.private_key
+          dummy_payload
+      in
+      let message = Mina_base.Signed_command.to_input dummy_payload in
+      let verified =
+        Schnorr.verify signature
+          (Snark_params.Tick.Inner_curve.of_affine keypair.public_key)
+          message
+      in
+      if verified then
+        printf "Verified a transaction using specified keypair\n"
+      else (
+        eprintf "Failed to verify a transaction using the specific keypair\n" ;
+        exit 1 )
+    in
+    let open Deferred.Let_syntax in
+    let%bind () =
+      let password =
+        lazy
+          (Secrets.Keypair.Terminal_stdin.prompt_password "Enter password: ")
+      in
+      match%map Secrets.Keypair.read ~privkey_path ~password with
+      | Ok keypair ->
+          validate_transaction keypair
+      (* TODO: add validation using VRF eval_and_test_public_key *)
+      | Error err ->
+          eprintf "Could not read the specified keypair: %s\n"
+            (Secrets.Privkey_error.to_string err) ;
+          exit 1
+    in
     exit 0)

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -53,7 +53,6 @@ let validate_keypair =
       match%map Secrets.Keypair.read ~privkey_path ~password with
       | Ok keypair ->
           validate_transaction keypair
-      (* TODO: add validation using VRF eval_and_test_public_key *)
       | Error err ->
           eprintf "Could not read the specified keypair: %s\n"
             (Secrets.Privkey_error.to_string err) ;

--- a/src/validate_keypair.opam
+++ b/src/validate_keypair.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
New `validate_keypair` app, and command `advanced validate-keypair`.

As with `generate-keypair`, the app and command use `CODA_PRIVKEY_PASS`, if set, and prompt for a password otherwise, and both take the `privkey-path` flag.

Validation consists of signing a dummy transaction and verifying the signature.

TODO: add a test of the keys using the VRF machinery (as commented in the code).

Update: won't add VRF bits, see comment below.

Example session:
```
$ coda advanced validate-keypair -privkey-path ~/keys/flimflam
Enter password: 
Again to confirm: 
Verified a transaction using specified keypair
``` 