### PR TITLE
Add list of levels to -log-level

### DIFF
--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -275,7 +275,7 @@ module Log = struct
     let log_level = Arg_type.log_level in
     let open Command.Param in
     let doc =
-      sprintf "LEVEL Set log level for the log file (%s, default: Info)"
+      sprintf "LEVEL Set log level for the log file (%s, default: Trace)"
         all_levels
     in
     flag "file-log-level" ~doc

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -262,19 +262,26 @@ module Log = struct
     flag "log-json" no_arg
       ~doc:"Print log output as JSON (default: plain text)"
 
+  let all_levels () =
+    String.concat ~sep:"|" (List.map ~f:Logger.Level.show Logger.Level.all)
+
   let level =
     let log_level = Arg_type.log_level in
     let open Command.Param in
-    flag "log-level"
-      (optional_with_default Logger.Level.Info log_level)
-      ~doc:"Set log level (default: Info)"
+    let doc =
+      sprintf "LEVEL Set log level (%s, default: Info)" (all_levels ())
+    in
+    flag "log-level" ~doc (optional_with_default Logger.Level.Info log_level)
 
   let file_log_level =
     let log_level = Arg_type.log_level in
     let open Command.Param in
-    flag "file-log-level"
+    let doc =
+      sprintf "LEVEL Set log level for the log file (%s, default: Info)"
+        (all_levels ())
+    in
+    flag "file-log-level" ~doc
       (optional_with_default Logger.Level.Trace log_level)
-      ~doc:"Set log level for the log file (default: Trace)"
 end
 
 type signed_command_common =

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -262,15 +262,13 @@ module Log = struct
     flag "log-json" no_arg
       ~doc:"Print log output as JSON (default: plain text)"
 
-  let all_levels () =
+  let all_levels =
     String.concat ~sep:"|" (List.map ~f:Logger.Level.show Logger.Level.all)
 
   let level =
     let log_level = Arg_type.log_level in
     let open Command.Param in
-    let doc =
-      sprintf "LEVEL Set log level (%s, default: Info)" (all_levels ())
-    in
+    let doc = sprintf "LEVEL Set log level (%s, default: Info)" all_levels in
     flag "log-level" ~doc (optional_with_default Logger.Level.Info log_level)
 
   let file_log_level =
@@ -278,7 +276,7 @@ module Log = struct
     let open Command.Param in
     let doc =
       sprintf "LEVEL Set log level for the log file (%s, default: Info)"
-        (all_levels ())
+        all_levels
     in
     flag "file-log-level" ~doc
       (optional_with_default Logger.Level.Trace log_level)


### PR DESCRIPTION
```
  [-log-level LEVEL]                                 Set log level
                                                     (Spam|Trace|Debug|Info|Warn|Error|Faulty_peer|Fatal,
                                                     default: Info)
  [-file-log-level LEVEL]                            Set log level for the log
                                                     file
                                                     (Spam|Trace|Debug|Info|Warn|Error|Faulty_peer|Fatal,
                                                     default: Trace)
```

Note that this doesn't put the the level next to the flag, since it moves the alignment of the rhs doc comments right significantly, to the point of their being unreadable.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #7630
