### PR TITLE
Protect Indexed_pool.add_from_gossip_exn from changes to the ledger

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1232,9 +1232,15 @@ let create ?wallets (config : Config.t) =
               ~pool_max_size:
                 config.precomputed_values.genesis_constants.txpool_max_size
           in
+          let ledger_hash =
+            Ledger.merkle_root
+              (Lazy.force
+                 (Genesis_ledger.Packed.t
+                    config.precomputed_values.genesis_ledger))
+          in
           let transaction_pool =
             Network_pool.Transaction_pool.create ~config:txn_pool_config
-              ~constraint_constants ~consensus_constants
+              ~ledger_hash ~constraint_constants ~consensus_constants
               ~time_controller:config.time_controller ~logger:config.logger
               ~incoming_diffs:(Mina_networking.transaction_pool_diffs net)
               ~local_diffs:local_txns_reader
@@ -1444,7 +1450,7 @@ let create ?wallets (config : Config.t) =
               ~disk_location:config.snark_pool_disk_location
           in
           let%bind snark_pool =
-            Network_pool.Snark_pool.load ~config:snark_pool_config
+            Network_pool.Snark_pool.load ~config:snark_pool_config ~ledger_hash
               ~constraint_constants ~consensus_constants
               ~time_controller:config.time_controller ~logger:config.logger
               ~incoming_diffs:(Mina_networking.snark_pool_diffs net)

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -26,7 +26,8 @@ module type Resource_pool_base_intf = sig
     transition_frontier_diff -> t -> unit Deferred.t
 
   val create :
-       constraint_constants:Genesis_constants.Constraint_constants.t
+       ledger_hash:Ledger_hash.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
     -> frontier_broadcast_pipe:transition_frontier Option.t
@@ -145,6 +146,7 @@ module type Network_pool_base_intf = sig
 
   val create :
        config:config
+    -> ledger_hash:Ledger_hash.t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
@@ -338,4 +340,6 @@ module type Base_ledger_intf = sig
   val get : t -> Location.t -> Account.t option
 
   val detached_signal : t -> unit Deferred.t
+
+  val merkle_root : t -> Ledger_hash.t
 end

--- a/src/lib/network_pool/mocks.ml
+++ b/src/lib/network_pool/mocks.ml
@@ -20,6 +20,8 @@ module Base_ledger = struct
   let get t l = Map.find t l
 
   let detached_signal _ = Deferred.never ()
+
+  let merkle_root (_ : t) = Snark_params.Tick.Field.zero
 end
 
 module Staged_ledger = struct

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -262,7 +262,7 @@ end)
     in
     go ()
 
-  let create ~config ~constraint_constants ~consensus_constants
+  let create ~config ~ledger_hash ~constraint_constants ~consensus_constants
       ~time_controller ~incoming_diffs ~local_diffs ~frontier_broadcast_pipe
       ~logger =
     (*Diffs from tansition frontier extensions*)
@@ -272,9 +272,9 @@ end)
     in
     let t =
       of_resource_pool_and_diffs
-        (Resource_pool.create ~constraint_constants ~consensus_constants
-           ~time_controller ~config ~logger ~frontier_broadcast_pipe
-           ~tf_diff_writer)
+        (Resource_pool.create ~constraint_constants ~ledger_hash
+           ~consensus_constants ~time_controller ~config ~logger
+           ~frontier_broadcast_pipe ~tf_diff_writer)
         ~constraint_constants ~incoming_diffs ~local_diffs ~logger
         ~tf_diffs:tf_diff_reader
     in

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -42,6 +42,7 @@ module type S = sig
   val load :
        config:Resource_pool.Config.t
     -> logger:Logger.t
+    -> ledger_hash:Mina_base.Ledger_hash.t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -19,6 +19,8 @@ let%test_module "network pool test" =
 
     let time_controller = Block_time.Controller.basic ~logger
 
+    let ledger_hash = Snark_params.Tick.Field.zero
+
     module Mock_snark_pool =
       Snark_pool.Make (Mocks.Base_ledger) (Mocks.Staged_ledger)
         (Mocks.Transition_frontier)
@@ -57,9 +59,9 @@ let%test_module "network pool test" =
           in
           let config = config verifier in
           let network_pool =
-            Mock_snark_pool.create ~config ~logger ~constraint_constants
-              ~consensus_constants ~time_controller ~incoming_diffs:pool_reader
-              ~local_diffs:local_reader
+            Mock_snark_pool.create ~config ~logger ~ledger_hash
+              ~constraint_constants ~consensus_constants ~time_controller
+              ~incoming_diffs:pool_reader ~local_diffs:local_reader
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
           in
           let%bind () = Mocks.Transition_frontier.refer_statements tf [work] in
@@ -131,9 +133,9 @@ let%test_module "network pool test" =
         in
         let config = config verifier in
         let network_pool =
-          Mock_snark_pool.create ~config ~logger ~constraint_constants
-            ~consensus_constants ~time_controller ~incoming_diffs:pool_reader
-            ~local_diffs:local_reader
+          Mock_snark_pool.create ~config ~logger ~ledger_hash
+            ~constraint_constants ~consensus_constants ~time_controller
+            ~incoming_diffs:pool_reader ~local_diffs:local_reader
             ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
         in
         let%bind () = Mocks.Transition_frontier.refer_statements tf works in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -960,7 +960,7 @@ struct
                         ~f:(Base_ledger.get ledger)
                     in
                     let new_ledger_hash = Base_ledger.merkle_root ledger in
-                    if Ledger_hash.equal ledger_hash new_ledger_hash then
+                    if not (Ledger_hash.equal ledger_hash new_ledger_hash) then
                       (* We return an interrupted [Interruptible.t] here
                          directly rather than wrapping the code below using a
                          bind. The underlying async bind may otherwise yeild to

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -960,7 +960,7 @@ struct
                         ~f:(Base_ledger.get ledger)
                     in
                     let new_ledger_hash = Base_ledger.merkle_root ledger in
-                    if Ledger_hash.equal ledger_hash new_ledger_hash then (
+                    if Ledger_hash.equal ledger_hash new_ledger_hash then
                       (* We return an interrupted [Interruptible.t] here
                          directly rather than wrapping the code below using a
                          bind. The underlying async bind may otherwise yeild to
@@ -970,13 +970,13 @@ struct
                       *)
                       let error =
                         Error.createf
-                           "Ledger hash changed from %s to %s while \
-                            attempting to apply transaction pool diff"
-                           (Ledger_hash.to_base58_check ledger_hash)
-                           (Ledger_hash.to_base58_check new_ledger_hash)
+                          "Ledger hash changed from %s to %s while attempting \
+                           to apply transaction pool diff"
+                          (Ledger_hash.to_base58_check ledger_hash)
+                          (Ledger_hash.to_base58_check new_ledger_hash)
                       in
                       Interruptible.lift (Deferred.never ())
-                        (Deferred.return error) )
+                        (Deferred.return error)
                     else
                       match account ledger (User_command.fee_payer tx) with
                       | None ->

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -120,6 +120,7 @@ let%test_module "transaction_status" =
       in
       let transaction_pool =
         Transaction_pool.create ~config
+          ~ledger_hash:(Ledger.merkle_root (Lazy.force Genesis_ledger.t))
           ~constraint_constants:precomputed_values.constraint_constants
           ~consensus_constants:precomputed_values.consensus_constants
           ~time_controller ~incoming_diffs:pool_reader ~logger


### PR DESCRIPTION
This PR interrupts adding transactions when there is inconsistent state between a ledger and the transaction pool. This avoids an assertion error caused by an invariant that this breaks. #7613 contains a fuller write-up of what is happening here.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #7613
Closes #4255
Closes #4274
Closes #4282