### PR TITLE
Move user command status columns to blocks_user_commands

### DIFF
--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -44,11 +44,6 @@ CREATE TABLE user_commands
 , valid_until    bigint
 , memo           text                NOT NULL
 , hash           text                NOT NULL UNIQUE
-, status         user_command_status
-, failure_reason text
-, fee_payer_account_creation_fee_paid  bigint
-, receiver_account_creation_fee_paid   bigint
-, created_token  bigint
 );
 
 CREATE TYPE internal_command_type AS ENUM ('fee_transfer_via_coinbase', 'fee_transfer', 'coinbase');
@@ -94,6 +89,11 @@ CREATE TABLE blocks_user_commands
 ( block_id        int NOT NULL REFERENCES blocks(id) ON DELETE CASCADE
 , user_command_id int NOT NULL REFERENCES user_commands(id) ON DELETE CASCADE
 , sequence_no     int NOT NULL
+, status          user_command_status
+, failure_reason  text
+, fee_payer_account_creation_fee_paid bigint
+, receiver_account_creation_fee_paid bigint
+, created_token   bigint
 , PRIMARY KEY (block_id, user_command_id)
 );
 

--- a/src/app/missing_subchain/missing_subchain.ml
+++ b/src/app/missing_subchain/missing_subchain.ml
@@ -147,28 +147,17 @@ let fill_in_user_command pool block_state_hash =
       in
       let memo = user_cmd.memo |> Signed_command_memo.of_string in
       let hash = user_cmd.hash |> Transaction_hash.of_base58_check_exn in
-      let status = user_cmd.status in
-      let failure_reason =
-        Option.map user_cmd.failure_reason ~f:(fun s ->
-            match Transaction_status.Failure.of_string s with
-            | Ok fail ->
-                fail
-            | Error err ->
-                failwithf "Not a transaction status failure: %s, error: %s" s
-                  err () )
-      in
-      let fee_payer_account_creation_fee_paid =
-        Option.map user_cmd.fee_payer_account_creation_fee_paid ~f:(fun amt ->
-            Unsigned.UInt64.of_int64 amt |> Currency.Amount.of_uint64 )
-      in
-      let receiver_account_creation_fee_paid =
-        Option.map user_cmd.receiver_account_creation_fee_paid ~f:(fun amt ->
-            Unsigned.UInt64.of_int64 amt |> Currency.Amount.of_uint64 )
-      in
-      let created_token =
-        Option.map user_cmd.created_token ~f:(fun tok ->
-            Unsigned.UInt64.of_int64 tok |> Token_id.of_uint64 )
-      in
+      (* TODO(psteckler): The status, failure_reason,
+       *   fee_payer_account_creation_fee_paid,
+       *   receiver_account_creation_fee_paid, and created_token columns were
+       *   moved from the user_columns table to the blocks_user_columns table so
+       *   an additional query is needed here in order to fill them in properly.
+       *)
+      let status = None in
+      let failure_reason = None in
+      let fee_payer_account_creation_fee_paid = None in
+      let receiver_account_creation_fee_paid = None in
+      let created_token = None in
       return
         { Extensional.User_command.sequence_no
         ; typ

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -287,7 +287,16 @@ WITH RECURSIVE chain AS (
 
   module User_commands = struct
     module Extras = struct
-      type t = {fee_payer: string; source: string; receiver: string}
+      (* TODO: A few of these actually aren't used; should we leave in for future or remove? *)
+      type t =
+        { fee_payer: string
+        ; source: string
+        ; receiver: string
+        ; status: string option
+        ; failure_reason: string option
+        ; fee_payer_account_creation_fee_paid: int64 option
+        ; receiver_account_creation_fee_paid: int64 option
+        ; created_token: int64 option }
       [@@deriving hlist]
 
       let fee_payer t = `Pk t.fee_payer
@@ -296,9 +305,31 @@ WITH RECURSIVE chain AS (
 
       let receiver t = `Pk t.receiver
 
+      let status t = t.status
+
+      let failure_reason t = t.failure_reason
+
+      let fee_payer_account_creation_fee_paid t =
+        t.fee_payer_account_creation_fee_paid
+
+      let receiver_account_creation_fee_paid t =
+        t.receiver_account_creation_fee_paid
+
+      let created_token t = t.created_token
+
       let typ =
         let open Archive_lib.Processor.Caqti_type_spec in
-        let spec = Caqti_type.[string; string; string] in
+        let spec =
+          Caqti_type.
+            [ string
+            ; string
+            ; string
+            ; option string
+            ; option string
+            ; option int64
+            ; option int64
+            ; option int64 ]
+        in
         let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
         let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
         Caqti_type.custom ~encode ~decode (to_rep spec)
@@ -312,8 +343,13 @@ WITH RECURSIVE chain AS (
     let query =
       Caqti_request.collect Caqti_type.int typ
         {| SELECT DISTINCT ON (u.hash) u.id, u.type, u.fee_payer_id, u.source_id, u.receiver_id, u.fee_token, u.token, u.nonce, u.amount, u.fee,
-        u.valid_until, u.memo, u.hash, u.status, u.failure_reason, u.fee_payer_account_creation_fee_paid, u.receiver_account_creation_fee_paid, u.created_token,
-        pk1.value as fee_payer, pk2.value as source, pk3.value as receiver
+        u.valid_until, u.memo, u.hash,
+        pk1.value as fee_payer, pk2.value as source, pk3.value as receiver,
+        blocks_user_commands.status,
+        blocks_user_commands.failure_reason,
+        blocks_user_commands.fee_payer_account_creation_fee_paid,
+        blocks_user_commands.receiver_account_creation_fee_paid,
+        blocks_user_commands.created_token
         FROM user_commands u
         INNER JOIN blocks_user_commands ON blocks_user_commands.user_command_id = u.id
         INNER JOIN public_keys pk1 ON pk1.id = u.fee_payer_id
@@ -450,11 +486,13 @@ WITH RECURSIVE chain AS (
                      `Invariant_violation)
           in
           let%map failure_status =
-            match uc.failure_reason with
+            match User_commands.Extras.failure_reason extras with
             | None -> (
               match
-                ( uc.fee_payer_account_creation_fee_paid
-                , uc.receiver_account_creation_fee_paid )
+                ( User_commands.Extras.fee_payer_account_creation_fee_paid
+                    extras
+                , User_commands.Extras.receiver_account_creation_fee_paid
+                    extras )
               with
               | None, None ->
                   M.return

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -287,13 +287,21 @@ WITH RECURSIVE chain AS (
 
   module User_commands = struct
     module Extras = struct
-      let fee_payer (x, _, _) = `Pk x
+      type t = {fee_payer: string; source: string; receiver: string}
+      [@@deriving hlist]
 
-      let source (_, y, _) = `Pk y
+      let fee_payer t = `Pk t.fee_payer
 
-      let receiver (_, _, z) = `Pk z
+      let source t = `Pk t.source
 
-      let typ = Caqti_type.(tup3 string string string)
+      let receiver t = `Pk t.receiver
+
+      let typ =
+        let open Archive_lib.Processor.Caqti_type_spec in
+        let spec = Caqti_type.[string; string; string] in
+        let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
+        let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
+        Caqti_type.custom ~encode ~decode (to_rep spec)
     end
 
     let typ =

--- a/src/app/rosetta/lib/dune
+++ b/src/app/rosetta/lib/dune
@@ -34,4 +34,5 @@
                ppx_inline_test
                ppx_assert
                ppx_version
+               h_list.ppx
 )))


### PR DESCRIPTION
- Updates archive DB schema to move columns
- Updates Archive_lib.Processor so the Transaction_status.t object is
  passed to Block_and_signed_command insertion instead of to
  User_command insertion
- Updates Rosetta Block code to handle the new schema when retrieving
  these columns
- Temporarily removes code in missing_subchain.ml that converted
  Archive_lib.Processor user commands to Extensional user commands since
  they'll now require an additional query

Explain how you tested your changes here.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them: