### PR TITLE
Missing subchains, use new schema

### DIFF
--- a/src/app/missing_subchain/missing_subchain.ml
+++ b/src/app/missing_subchain/missing_subchain.ml
@@ -117,10 +117,11 @@ let fill_in_user_command pool block_state_hash =
   in
   (* create extensional user command for each id, seq no *)
   Deferred.List.map user_command_ids_and_sequence_nos
-    ~f:(fun (user_cmd_id, sequence_no) ->
+    ~f:(fun (user_command_id, sequence_no) ->
       let%bind user_cmd =
-        query_db ~item:"blocks user commands" ~f:(fun db ->
-            Processor.User_command.Signed_command.load db ~id:user_cmd_id )
+        query_db ~item:"user commands" ~f:(fun db ->
+            Processor.User_command.Signed_command.load db ~id:user_command_id
+        )
       in
       let typ = user_cmd.typ in
       let%bind fee_payer = pk_of_id ~item:"fee payer" user_cmd.fee_payer_id in
@@ -147,17 +148,35 @@ let fill_in_user_command pool block_state_hash =
       in
       let memo = user_cmd.memo |> Signed_command_memo.of_string in
       let hash = user_cmd.hash |> Transaction_hash.of_base58_check_exn in
-      (* TODO(psteckler): The status, failure_reason,
-       *   fee_payer_account_creation_fee_paid,
-       *   receiver_account_creation_fee_paid, and created_token columns were
-       *   moved from the user_columns table to the blocks_user_columns table so
-       *   an additional query is needed here in order to fill them in properly.
-       *)
-      let status = None in
-      let failure_reason = None in
-      let fee_payer_account_creation_fee_paid = None in
-      let receiver_account_creation_fee_paid = None in
-      let created_token = None in
+      let%bind block_user_cmd =
+        query_db ~item:"block user commands" ~f:(fun db ->
+            Processor.Block_and_signed_command.load db ~block_id
+              ~user_command_id )
+      in
+      let status = block_user_cmd.status in
+      let failure_reason =
+        Option.map block_user_cmd.failure_reason ~f:(fun s ->
+            match Transaction_status.Failure.of_string s with
+            | Ok s ->
+                s
+            | Error err ->
+                failwithf "Not a transaction status failure: %s, error: %s" s
+                  err () )
+      in
+      let fee_payer_account_creation_fee_paid =
+        Option.map block_user_cmd.fee_payer_account_creation_fee_paid
+          ~f:(fun amt ->
+            Unsigned.UInt64.of_int64 amt |> Currency.Amount.of_uint64 )
+      in
+      let receiver_account_creation_fee_paid =
+        Option.map block_user_cmd.receiver_account_creation_fee_paid
+          ~f:(fun amt ->
+            Unsigned.UInt64.of_int64 amt |> Currency.Amount.of_uint64 )
+      in
+      let created_token =
+        Option.map block_user_cmd.created_token ~f:(fun tok ->
+            Unsigned.UInt64.of_int64 tok |> Token_id.of_uint64 )
+      in
       return
         { Extensional.User_command.sequence_no
         ; typ


### PR DESCRIPTION
Modify missing subchains tool to use the new archive db schema. In particular, take data from `blocks_user_commands` that had been in `user_commands`, and place it in an `Extensional.User_command.t`.

Tested by generating a fresh archive db from Rosetta, generating JSON files for the entire chain using the missing subchains app, ingesting those blocks using `advanced archive-blocks -extensional`.
