### PR TITLE
Reject invalid public keys from the snark pool and in snark pool diffs

### DIFF
--- a/src/lib/mina_base/coinbase.ml
+++ b/src/lib/mina_base/coinbase.ml
@@ -31,6 +31,12 @@ let receiver_pk t = t.receiver
 
 let receiver t = Account_id.create t.receiver Token_id.default
 
+(* This must match [Transaction_union].
+   TODO: enforce this.
+*)
+let fee_payer_pk cb =
+  match cb.fee_transfer with None -> cb.receiver | Some ft -> ft.receiver_pk
+
 let amount t = t.amount
 
 let fee_transfer t = t.fee_transfer

--- a/src/lib/mina_base/coinbase.mli
+++ b/src/lib/mina_base/coinbase.mli
@@ -27,6 +27,8 @@ val receiver_pk : t -> Public_key.Compressed.t
 
 val receiver : t -> Account_id.t
 
+val fee_payer_pk : t -> Public_key.Compressed.t
+
 val amount : t -> Currency.Amount.t
 
 val fee_transfer : t -> Fee_transfer.t option

--- a/src/lib/mina_base/fee_transfer.ml
+++ b/src/lib/mina_base/fee_transfer.ml
@@ -107,6 +107,16 @@ let receiver_pks t =
 
 let receivers t = One_or_two.to_list (One_or_two.map ~f:Single.receiver t)
 
+(* This must match [Transaction_union].
+   TODO: enforce this.
+*)
+let fee_payer_pk ft =
+  match ft with
+  | `One ft ->
+      Single.receiver_pk ft
+  | `Two (_, ft) ->
+      Single.receiver_pk ft
+
 let fee_token = Single.fee_token
 
 let fee_tokens = One_or_two.map ~f:Single.fee_token

--- a/src/lib/mina_base/fee_transfer.mli
+++ b/src/lib/mina_base/fee_transfer.mli
@@ -88,6 +88,8 @@ val receiver_pks : t -> Public_key.Compressed.t list
 
 val receivers : t -> Account_id.t list
 
+val fee_payer_pk : t -> Public_key.Compressed.t
+
 val map : t -> f:(Single.t -> 'b) -> 'b One_or_two.t
 
 val fold : t -> init:'acc -> f:('acc -> Single.t -> 'acc) -> 'acc

--- a/src/lib/mina_base/fee_with_prover.ml
+++ b/src/lib/mina_base/fee_with_prover.ml
@@ -29,14 +29,5 @@ end]
 include Comparable.Make (Stable.V1.T)
 
 let gen =
-  (* This isn't really a valid public key, but good enough for testing *)
-  let pk =
-    let open Snark_params.Tick in
-    let open Quickcheck.Generator.Let_syntax in
-    let%map x = Bignum_bigint.(gen_incl zero (Field.size - one))
-    and is_odd = Bool.quickcheck_generator in
-    let x = Bigint.(to_field (of_bignum_bigint x)) in
-    {Public_key.Compressed.Poly.x; is_odd}
-  in
-  Quickcheck.Generator.map2 Currency.Fee.gen pk ~f:(fun fee prover ->
-      {fee; prover} )
+  Quickcheck.Generator.map2 Currency.Fee.gen Public_key.Compressed.gen
+    ~f:(fun fee prover -> {fee; prover})

--- a/src/lib/mina_base/transaction.ml
+++ b/src/lib/mina_base/transaction.ml
@@ -66,6 +66,19 @@ let supply_increase = function
   | Coinbase t ->
       Coinbase.supply_increase t
 
+let public_keys : t -> _ = function
+  | Command (Signed_command cmd) ->
+      [ Signed_command.fee_payer_pk cmd
+      ; Signed_command.source_pk cmd
+      ; Signed_command.receiver_pk cmd ]
+  | Command (Snapp_command t) ->
+      Snapp_command.(accounts_accessed (t :> t))
+      |> List.map ~f:Account_id.public_key
+  | Fee_transfer ft ->
+      Fee_transfer.receiver_pks ft
+  | Coinbase cb ->
+      Coinbase.accounts_accessed cb |> List.map ~f:Account_id.public_key
+
 let accounts_accessed ~next_available_token : t -> _ = function
   | Command (Signed_command cmd) ->
       Signed_command.accounts_accessed ~next_available_token cmd

--- a/src/lib/mina_base/transaction.ml
+++ b/src/lib/mina_base/transaction.ml
@@ -86,3 +86,14 @@ let next_available_token (t : t) next_available_token =
       next_available_token
   | Coinbase _ ->
       next_available_token
+
+let fee_payer_pk (t : t) =
+  match t with
+  | Command (Signed_command cmd) ->
+      Signed_command.fee_payer_pk cmd
+  | Command (Snapp_command t) ->
+      Snapp_command.fee_payer t |> Account_id.public_key
+  | Fee_transfer ft ->
+      Fee_transfer.fee_payer_pk ft
+  | Coinbase cb ->
+      Coinbase.fee_payer_pk cb

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -443,33 +443,37 @@ struct
                     ~data:(One_or_two.map proofs ~f:fst, message)
                     ~sender
                 in
-                match%bind Batcher.Snark_pool.verify t.batcher proof_env with
-                | Ok true ->
-                    return true
-                | Ok false ->
-                    (* if this proof is in the set of invalid proofs*)
-                    let e = Error.of_string "Invalid proof" in
-                    let%map () = log e in
-                    false
-                | Error e ->
-                    (* Verifier crashed or other errors at our end. Don't punish the peer*)
-                    let%map () = log ~punish:false e in
-                    false )
-        in
-        match One_or_two.zip proofs statements with
-        | Ok pairs -> (
-          match Signature_lib.Public_key.decompress prover with
-          | Some _ ->
-              verify pairs
-          | None ->
-              (* We may need to decompress the key when paying the fee
+                match Signature_lib.Public_key.decompress prover with
+                | None ->
+                    (* We may need to decompress the key when paying the fee
                  transfer, so check that we can do it now.
               *)
-              [%log' error t.logger] "Proof had an invalid key: $public_key"
-                ~metadata:
-                  [ ( "public_key"
-                    , Signature_lib.Public_key.Compressed.to_yojson prover ) ] ;
-              Deferred.return false )
+                    [%log' error t.logger]
+                      "Proof had an invalid key: $public_key"
+                      ~metadata:
+                        [ ( "public_key"
+                          , Signature_lib.Public_key.Compressed.to_yojson
+                              prover ) ] ;
+                    Deferred.return false
+                | Some _ -> (
+                    match%bind
+                      Batcher.Snark_pool.verify t.batcher proof_env
+                    with
+                    | Ok true ->
+                        return true
+                    | Ok false ->
+                        (* if this proof is in the set of invalid proofs*)
+                        let e = Error.of_string "Invalid proof" in
+                        let%map () = log e in
+                        false
+                    | Error e ->
+                        (* Verifier crashed or other errors at our end. Don't punish the peer*)
+                        let%map () = log ~punish:false e in
+                        false ) )
+        in
+        match One_or_two.zip proofs statements with
+        | Ok pairs ->
+            verify pairs
         | Error e ->
             [%log' error t.logger]
               ~metadata:[("error", Error_json.error_to_yojson e)]

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -591,7 +591,9 @@ module T = struct
                   | Some _ ->
                       ()
                   | None ->
-                      raise (Exit (Invalid_public_key fee_payer)) ) ;
+                      (* TODO: Enable this check. *)
+                      (*raise (Exit (Invalid_public_key fee_payer))*)
+                      () ) ;
                   match
                     apply_transaction_and_get_witness ~constraint_constants
                       ledger pending_coinbase_stack_state t.With_status.data

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -65,6 +65,7 @@ module Staged_ledger_error : sig
     | Pre_diff of Pre_diff_info.Error.t
     | Insufficient_work of string
     | Mismatched_statuses of Transaction.t With_status.t * Transaction_status.t
+    | Invalid_public_key of Public_key.Compressed.t
     | Unexpected of Error.t
   [@@deriving sexp]
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -144,7 +144,8 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
                       | Pre_diff _
                       | Non_zero_fee_excess _
                       | Insufficient_work _
-                      | Mismatched_statuses _ ->
+                      | Mismatched_statuses _
+                      | Invalid_public_key _ ->
                           make_actions Gossiped_invalid_transition
                       | Unexpected _ ->
                           failwith


### PR DESCRIPTION
This checks snark work before entering it into the pool, to make sure that it doesn't have an invalid public key attached. This also validates the public keys in fee transfers and coinbases while checking an external transition.

**We should hold off on merging this.** The block containing the fee transfer that triggered this bug may still be passed around the network, and running a node with this change will make it ban any others that share this block with it.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #7656
Closes #7658
