### PR TITLE
Fix a segfault: Use reference counted pointers for CamlPointer

### DIFF
--- a/src/lib/marlin_plonk_bindings/stubs/src/caml_pointer.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/caml_pointer.rs
@@ -45,6 +45,17 @@ impl<T> Deref for CamlPointer<T> {
 
 impl<T> DerefMut for CamlPointer<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        Rc::get_mut(&mut self.0).unwrap()
+        unsafe {
+            // Wholely unsafe, Batman!
+            // We would use [`get_mut_unchecked`] here, but it is nightly-only.
+            // Instead, we get coerce our constant pointer to a mutable pointer, in the knowledge
+            // that
+            // * all of our mutations called from OCaml are blocking, so we won't have multiple
+            // live mutable references live simultaneously, and
+            // * the underlying pointer is in the correct state to be mutable, since we can call
+            //   [`get_mut_unchecked`] in nightly, or can call [`get_mut`] and unwrap if this is
+            //   the only live reference.
+            &mut *(((&*self.0) as *const Self::Target) as *mut Self::Target)
+        }
     }
 }

--- a/src/lib/marlin_plonk_bindings/stubs/src/caml_pointer.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/caml_pointer.rs
@@ -1,13 +1,14 @@
 use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
 
-pub struct CamlPointer<T>(pub *mut T);
+#[derive(std::fmt::Debug, Clone)]
+pub struct CamlPointer<T>(pub Rc<T>);
 
 impl<T> CamlPointer<T> {
     extern "C" fn caml_pointer_finalize(v: ocaml::Value) {
         let mut v: ocaml::Pointer<CamlPointer<T>> = ocaml::FromValue::from_value(v);
         unsafe {
-            // Memory is freed when the variable goes out of scope
-            let _box = Box::from_raw(v.as_mut().0);
+            v.drop_in_place();
         }
     }
 
@@ -26,24 +27,24 @@ ocaml::custom!(CamlPointer<T> {
 unsafe impl<T> ocaml::FromValue for CamlPointer<T> {
     fn from_value(x: ocaml::Value) -> Self {
         let x = ocaml::Pointer::<Self>::from_value(x);
-        CamlPointer(x.as_ref().0)
+        CamlPointer(x.as_ref().0.clone())
     }
 }
 
 pub fn create<T>(x: T) -> CamlPointer<T> {
-    CamlPointer(Box::into_raw(Box::new(x)))
+    CamlPointer(Rc::new(x))
 }
 
 impl<T> Deref for CamlPointer<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        unsafe { &*self.0 }
+        &*self.0
     }
 }
 
 impl<T> DerefMut for CamlPointer<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.0 }
+        Rc::get_mut(&mut self.0).unwrap()
     }
 }

--- a/src/lib/marlin_plonk_bindings/stubs/src/caml_pointer.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/caml_pointer.rs
@@ -6,7 +6,7 @@ pub struct CamlPointer<T>(pub Rc<T>);
 
 impl<T> CamlPointer<T> {
     extern "C" fn caml_pointer_finalize(v: ocaml::Value) {
-        let mut v: ocaml::Pointer<CamlPointer<T>> = ocaml::FromValue::from_value(v);
+        let v: ocaml::Pointer<CamlPointer<T>> = ocaml::FromValue::from_value(v);
         unsafe {
             v.drop_in_place();
         }


### PR DESCRIPTION
This PR changes the behaviour of `CamlPointer` so that it uses a refcounted shared pointer instead of a raw pointer. This fixes a double-free: cloning a `CamlPointer` would result in 2 references to the same pointer, and each would be freed by the finaliser.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
