### PR TITLE
Verify cmds before recursively adding to the pool, throw useful errors

### DIFF
--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -77,6 +77,17 @@ module Command_error = struct
   [@@deriving sexp_of, to_yojson]
 end
 
+exception Command_error of Command_error.t
+
+let () =
+  Sexplib.Conv.Exn_converter.add [%extension_constructor Command_error]
+    (function
+    | Command_error t ->
+        Sexp.List [Sexp.Atom "Command_error"; Command_error.sexp_of_t t]
+    | _ ->
+        (* Reaching this branch indicates a bug in sexplib. *)
+        assert false )
+
 (* Compute the total currency required from the sender to execute a command.
    Returns None in case of overflow.
 *)
@@ -868,17 +879,22 @@ let rec add_from_gossip_exn :
           Transaction_hash.User_command_with_valid_signature.t Sequence.t]
           dropped
           (F_sequence.to_seq drop_queue) ;
+        let%bind cmd = verified () in
         (* Add the new transaction *)
         let%bind cmd, t'', _ =
-          match add_from_gossip_exn t' ~verify cmd0 current_nonce balance with
+          match
+            add_from_gossip_exn t' ~verify (`Checked cmd) current_nonce balance
+          with
           | Ok (v, t'', dropped') ->
               (* We've already removed them, so this should always be empty. *)
               assert (Sequence.is_empty dropped') ;
               Result.Ok (v, t'', dropped)
-          | Error (Insufficient_funds _ as err) ->
-              Error err (* C2 *)
-          | _ ->
-              failwith "recursive add_exn failed"
+          | Error ((Insufficient_funds _ | Overflow) as err) ->
+              Error err
+              (* C2 *)
+              (* C4 *)
+          | Error err ->
+              raise (Command_error err)
         in
         let drop_head, drop_tail = Option.value_exn (Sequence.next dropped) in
         let increment =
@@ -922,8 +938,8 @@ let rec add_from_gossip_exn :
                        fee increment.
                     *)
                     go t' increment dropped (Some dropped') current_nonce
-                | _ ->
-                    failwith "recursive add_exn failed" )
+                | Error err ->
+                    raise (Command_error err) )
           in
           go t'' increment drop_tail None current_nonce
         in


### PR DESCRIPTION
This PR fixes a potential error path and changes the exception that is thrown to make it easier to debug in future. Related issues #7668 and #7661.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: