### PR TITLE
Archive_blocks app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,11 @@ missing_subchain :
 	ulimit -s 65532 && (ulimit -n 10240 || true) && dune build src/app/missing_subchain/missing_subchain.exe --profile=testnet_postake_medium_curves
 	$(info Build complete)
 
+archive_blocks :
+	$(info Starting Build)
+	ulimit -s 65532 && (ulimit -n 10240 || true) && dune build src/app/archive_blocks/archive_blocks.exe --profile=testnet_postake_medium_curves
+	$(info Build complete)
+
 dev: codabuilder containerstart build
 
 # update OPAM, pinned packages in Docker

--- a/buildkite/scripts/ci-archive-release.sh
+++ b/buildkite/scripts/ci-archive-release.sh
@@ -7,5 +7,6 @@ export PATH=/home/opam/.cargo/bin:/usr/lib/go/bin:$PATH
 export GO=/usr/lib/go/bin/go
 
 make build_archive
+make archive_blocks
 
 ./scripts/archive/build-release-archives.sh

--- a/scripts/archive/build-release-archives.sh
+++ b/scripts/archive/build-release-archives.sh
@@ -40,7 +40,7 @@ mkdir -p "${BUILD_DIR}/usr/local/bin"
 pwd
 ls
 cp ./_build/default/src/app/archive/archive.exe "${BUILD_DIR}/usr/local/bin/coda-archive"
-
+cp ./_build/default/src/app/archive_blocks/archive_blocks.exe "${BUILD_DIR}/usr/local/bin/mina-archive-blocks"
 
 # echo contents of deb
 echo "------------------------------------------------------------"
@@ -63,8 +63,8 @@ ls -lh mina*.deb
 #>> Repository is locked by another user:  at host dc7eaad3c537
 #>> Attempting to obtain a lock
 #/var/lib/gems/2.3.0/gems/deb-s3-0.10.0/lib/deb/s3/lock.rb:24:in `throw': uncaught throw #"Unable to obtain a lock after 60, giving up."
-DEBS3='deb-s3 upload --s3-region=us-west-2 --bucket packages.o1test.net --preserve-versions 
---lock 
+DEBS3='deb-s3 upload --s3-region=us-west-2 --bucket packages.o1test.net --preserve-versions
+--lock
 --cache-control=max-age=120'
 
 # check for AWS Creds
@@ -109,7 +109,7 @@ if [ -n "${BUILDKITE+x}" ]; then
 
     set +x
 else
-    mkdir docker_build 
+    mkdir docker_build
     mv mina-*.deb docker_build/.
 
     echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1384,6 +1384,16 @@ let add_block_aux ~add_block ~hash ~delete_older_than
   in
   res
 
+let add_block_aux_precomputed ~constraint_constants =
+  add_block_aux ~add_block:(Block.add_from_precomputed ~constraint_constants)
+    ~hash:(fun block ->
+      block.External_transition.Precomputed_block.protocol_state
+      |> Protocol_state.hash )
+
+let add_block_aux_extensional =
+  add_block_aux ~add_block:Block.add_from_extensional
+    ~hash:(fun (block : Extensional.Block.t) -> block.state_hash)
+
 let run (module Conn : CONNECTION) reader ~constraint_constants ~logger
     ~delete_older_than =
   Strict_pipe.Reader.iter reader ~f:(function
@@ -1486,12 +1496,8 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
       Strict_pipe.Reader.iter precomputed_block_reader
         ~f:(fun precomputed_block ->
           match%map
-            add_block_aux
-              ~add_block:(Block.add_from_precomputed ~constraint_constants)
-              ~hash:(fun block ->
-                block.External_transition.Precomputed_block.protocol_state
-                |> Protocol_state.hash )
-              ~delete_older_than conn precomputed_block
+            add_block_aux_precomputed ~constraint_constants ~delete_older_than
+              conn precomputed_block
           with
           | Error e ->
               [%log warn]
@@ -1507,9 +1513,7 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
       Strict_pipe.Reader.iter extensional_block_reader
         ~f:(fun extensional_block ->
           match%map
-            add_block_aux ~add_block:Block.add_from_extensional
-              ~hash:(fun block -> block.state_hash)
-              ~delete_older_than conn extensional_block
+            add_block_aux_extensional ~delete_older_than conn extensional_block
           with
           | Error e ->
               [%log warn]

--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -1,0 +1,116 @@
+(* archive_blocks.ml -- archive precomputed or extensional blocks to Postgresql *)
+
+open Core_kernel
+open Async
+open Archive_lib
+
+let main ~archive_uri ~precomputed ~extensional ~success_file ~failure_file
+    ~log_successes ~files () =
+  let output_file_line path =
+    match path with
+    | Some path ->
+        let file = Out_channel.create ~append:true path in
+        fun line -> Out_channel.output_lines file [line]
+    | None ->
+        fun _line -> ()
+  in
+  let add_to_success_file = output_file_line success_file in
+  let add_to_failure_file = output_file_line failure_file in
+  let archive_uri = Uri.of_string archive_uri in
+  if Bool.equal precomputed extensional then
+    failwith "Must provide exactly one of -precomputed and -extensional" ;
+  let logger = Logger.create () in
+  match%bind Caqti_async.connect archive_uri with
+  | Error e ->
+      [%log fatal]
+        ~metadata:[("error", `String (Caqti_error.show e))]
+        "Failed to create a Caqti pool for Postgresql" ;
+      exit 1
+  | Ok conn ->
+      [%log info] "Successfully created Caqti pool for Postgresql" ;
+      let make_add_block of_yojson add_block_aux ~json ~file =
+        match of_yojson json with
+        | Ok block -> (
+            match%map add_block_aux block with
+            | Ok () ->
+                if log_successes then
+                  [%log info] "Added block" ~metadata:[("file", `String file)] ;
+                add_to_success_file file
+            | Error err ->
+                [%log error] "Error when adding block"
+                  ~metadata:
+                    [ ("file", `String file)
+                    ; ("error", `String (Caqti_error.show err)) ] ;
+                add_to_failure_file file )
+        | Error err ->
+            [%log error] "Could not create block from JSON"
+              ~metadata:[("file", `String file); ("error", `String err)] ;
+            return (add_to_failure_file file)
+      in
+      let add_precomputed_block =
+        make_add_block
+          Mina_transition.External_transition.Precomputed_block.of_yojson
+          (Processor.add_block_aux_precomputed
+             ~constraint_constants:
+               Genesis_constants.Constraint_constants.compiled conn
+             ~delete_older_than:None)
+      in
+      let add_extensional_block =
+        make_add_block Archive_lib.Extensional.Block.of_yojson
+          (Processor.add_block_aux_extensional conn ~delete_older_than:None)
+      in
+      Deferred.List.iter files ~f:(fun file ->
+          In_channel.with_file file ~f:(fun in_channel ->
+              try
+                let json = Yojson.Safe.from_channel in_channel in
+                if precomputed then add_precomputed_block ~json ~file
+                else if extensional then add_extensional_block ~json ~file
+                else failwith "Internal error, bad flags"
+              with
+              | Yojson.Json_error err ->
+                  [%log error] "Could not parse JSON from file"
+                    ~metadata:[("file", `String file); ("error", `String err)] ;
+                  return (add_to_failure_file file)
+              | exn ->
+                  (* should be unreachable *)
+                  [%log error] "Internal error when processing file"
+                    ~metadata:
+                      [ ("file", `String file)
+                      ; ("error", `String (Exn.to_string exn)) ] ;
+                  return (add_to_failure_file file) ) )
+
+let () =
+  Command.(
+    run
+      (let open Let_syntax in
+      async ~summary:"Write blocks to an archive database"
+        (let%map archive_uri =
+           Param.flag "archive-uri"
+             ~doc:
+               "URI URI for connecting to the archive database (e.g., \
+                postgres://$USER:$USER@localhost:5432/archiver)"
+             Param.(required string)
+         and precomputed =
+           Param.(flag "precomputed" no_arg)
+             ~doc:"Blocks are in precomputed format"
+         and extensional =
+           Param.(flag "extensional" no_arg)
+             ~doc:"Blocks are in extensional format"
+         and success_file =
+           Param.flag "successful-files"
+             ~doc:
+               "PATH Appends the list of files that were processed successfully"
+             (Flag.optional Param.string)
+         and failure_file =
+           Param.flag "failed-files"
+             ~doc:"PATH Appends the list of files that failed to be processed"
+             (Flag.optional Param.string)
+         and log_successes =
+           Param.flag "log-successful"
+             ~doc:
+               "true/false Whether to log messages for files that were \
+                processed successfully"
+             (Flag.optional_with_default true Param.bool)
+         and files = Param.anon Anons.(sequence ("FILES" %: Param.string)) in
+         main ~archive_uri ~precomputed ~extensional ~success_file
+           ~failure_file ~log_successes ~files)))

--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -24,10 +24,10 @@ let main ~archive_uri ~precomputed ~extensional ~success_file ~failure_file
   | Error e ->
       [%log fatal]
         ~metadata:[("error", `String (Caqti_error.show e))]
-        "Failed to create a Caqti pool for Postgresql" ;
+        "Failed to create a Caqti connection to Postgresql" ;
       exit 1
   | Ok conn ->
-      [%log info] "Successfully created Caqti pool for Postgresql" ;
+      [%log info] "Successfully created Caqti connection to Postgresql" ;
       let make_add_block of_yojson add_block_aux ~json ~file =
         match of_yojson json with
         | Ok block -> (

--- a/src/app/archive_blocks/dune
+++ b/src/app/archive_blocks/dune
@@ -1,0 +1,14 @@
+(executable
+ (package archive_blocks)
+ (name archive_blocks)
+ (public_name archive_blocks)
+ (libraries
+   async
+   core_kernel
+   caqti
+   caqti-async
+   caqti-driver-postgresql
+   archive_lib)
+ (preprocessor_deps ../../config.mlh)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version ppx_coda ppx_let ppx_hash ppx_compare ppx_sexp_conv)))

--- a/src/archive_blocks.opam
+++ b/src/archive_blocks.opam
@@ -1,0 +1,5 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]


### PR DESCRIPTION
Standalone app `archive_blocks` for ingesting precomputed or extensional blocks into an archive database. 

The app works much like the CLI `advanced archive-blocks` command. The benefit of the app is that you don't need to be running a daemon or archive process.

(While the functionality is the same, the slight differences made it seem not worth trying to factor out common code.)

The flags for the app are basically the same as for the CLI command, except that the connection is directly to the Postgresql server, and not the daemon or its GraphQL port.

Usage:
```
Write blocks to an archive database

  archive_blocks.exe [FILES ...]

=== flags ===

  -archive-uri URI              URI for connecting to the archive database
                                (e.g.,
                                postgres://$USER:$USER@localhost:5432/archiver)
  [-extensional]                Blocks are in extensional format
  [-failed-files PATH]          Appends the list of files that failed to be
                                processed
  [-log-successful true/false]  Whether to log messages for files that were
                                processed successfully
  [-precomputed]                Blocks are in precomputed format
  [-successful-files PATH]      Appends the list of files that were processed
                                successfully
  ...
```

There's a Makefile target `archive_blocks`.

Tested by ingesting some blocks produced by Rosetta, intentionally introducing some bad JSON.

Closes #7569.