### PR TITLE
Explain some terminating signals

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -493,7 +493,12 @@ let setup_daemon logger =
                    signal $signal"
                   ~metadata:
                     ( ("signal", `String (Signal.to_string signal))
-                    :: child_pid_metadata )
+                    :: child_pid_metadata ) ;
+                Option.value_map
+                  (Child_processes.Termination.get_signal_cause_opt signal)
+                  ~default:() ~f:(fun cause ->
+                    [%log info] "Possible reason signal caused termination"
+                      ~metadata:[("cause", `String cause)] )
             | `Exit_non_zero exit_code ->
                 [%log info]
                   "Daemon child process $child_pid terminated with nonzero \

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -488,7 +488,7 @@ let setup_daemon logger =
           | Error err -> (
             match err with
             | `Signal signal ->
-                [%log info]
+                [%log error]
                   "Daemon child process $child_pid terminated after receiving \
                    signal $signal"
                   ~metadata:
@@ -497,10 +497,10 @@ let setup_daemon logger =
                 Option.value_map
                   (Child_processes.Termination.get_signal_cause_opt signal)
                   ~default:() ~f:(fun cause ->
-                    [%log info] "Possible reason for signal: $cause"
+                    [%log error] "Possible reason for signal: $cause"
                       ~metadata:[("cause", `String cause)] )
             | `Exit_non_zero exit_code ->
-                [%log info]
+                [%log error]
                   "Daemon child process $child_pid terminated with nonzero \
                    exit code $exit_code"
                   ~metadata:

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -497,7 +497,7 @@ let setup_daemon logger =
                 Option.value_map
                   (Child_processes.Termination.get_signal_cause_opt signal)
                   ~default:() ~f:(fun cause ->
-                    [%log info] "Possible reason signal caused termination"
+                    [%log info] "Possible reason for signal: $cause"
                       ~metadata:[("cause", `String cause)] )
             | `Exit_non_zero exit_code ->
                 [%log info]

--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -29,7 +29,7 @@ let get_signal_cause_opt =
   let open Signal in
   let signal_causes_tbl : string Table.t = Table.create () in
   List.iter
-    [ (kill, "Process likely killed because out of memory")
+    [ (kill, "Process killed because out of memory")
     ; (int, "Process interrupted by user or other program") ]
     ~f:(fun (signal, msg) ->
       Base.ignore (Table.add signal_causes_tbl ~key:signal ~data:msg) ) ;

--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -24,6 +24,17 @@ let mark_termination_as_expected t child_pid =
 
 let remove : t -> Pid.t -> unit = Pid.Table.remove
 
+(* for some signals that cause termination, offer a possible explanation *)
+let get_signal_cause_opt =
+  let open Signal in
+  let signal_causes_tbl : string Table.t = Table.create () in
+  List.iter
+    [ (kill, "Process likely killed because out of memory")
+    ; (int, "Process interrupted by user or other program") ]
+    ~f:(fun (signal, msg) ->
+      Base.ignore (Table.add signal_causes_tbl ~key:signal ~data:msg) ) ;
+  fun signal -> Signal.Table.find signal_causes_tbl signal
+
 let check_terminated_child (t : t) child_pid logger =
   if Pid.Table.mem t child_pid then
     let data = Pid.Table.find_exn t child_pid in


### PR DESCRIPTION
For some signals (namely, SIGKILL and SIGINT), log a possible cause when a child process terminates. 

There's an extensible table of signals-to-causes, if more such signals have plausible explanations.

Closes #7620.

