### PR TITLE
archive node retries

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1363,6 +1363,8 @@ let retry ~f ~logger ~error_str retries =
         else (
           [%log warn] "Error in %s : $error. Retrying..." error_str
             ~metadata:[("error", `String (Caqti_error.show e))] ;
+          let wait_for = Random.float_range 20. 2000. in
+          let%bind () = after (Time.Span.of_ms wait_for) in
           go (retry_count - 1) )
     | Ok res ->
         return (Ok res)

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1355,34 +1355,50 @@ module Block = struct
     else return ()
 end
 
-let add_block_aux ~add_block ~hash ~delete_older_than
+let retry ~f ~logger ~error_str retries =
+  let rec go retry_count =
+    match%bind f () with
+    | Error e ->
+        if retry_count <= 0 then return (Error e)
+        else (
+          [%log warn] "Error in %s : $error. Retrying..." error_str
+            ~metadata:[("error", `String (Caqti_error.show e))] ;
+          go (retry_count - 1) )
+    | Ok res ->
+        return (Ok res)
+  in
+  go retries
+
+let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
     (module Conn : CONNECTION) block =
-  let%bind res =
-    let open Deferred.Result.Let_syntax in
-    let%bind () = Conn.start () in
-    let%bind block_id = add_block (module Conn : CONNECTION) block in
-    (* if an existing block has a parent hash that's for the block just added,
+  let add () =
+    let%bind res =
+      let open Deferred.Result.Let_syntax in
+      let%bind () = Conn.start () in
+      let%bind block_id = add_block (module Conn : CONNECTION) block in
+      (* if an existing block has a parent hash that's for the block just added,
        set its parent id
-    *)
-    let%bind () =
-      Block.set_parent_id_if_null
-        (module Conn)
-        ~parent_hash:(hash block) ~parent_id:block_id
+      *)
+      let%bind () =
+        Block.set_parent_id_if_null
+          (module Conn)
+          ~parent_hash:(hash block) ~parent_id:block_id
+      in
+      match delete_older_than with
+      | Some num_blocks ->
+          Block.delete_if_older_than ~num_blocks (module Conn)
+      | None ->
+          return ()
     in
-    match delete_older_than with
-    | Some num_blocks ->
-        Block.delete_if_older_than ~num_blocks (module Conn)
-    | None ->
-        return ()
-  in
-  let%map () =
     match res with
-    | Error _ ->
-        Conn.rollback () >>| ignore
+    | Error _ as e ->
+        (*Error in the current transaction*)
+        let%map _ = Conn.rollback () in
+        e
     | Ok _ ->
-        Conn.commit () >>| ignore
+        Conn.commit ()
   in
-  res
+  retry ~f:add ~logger ~error_str:"add_block_aux" retries
 
 let run (module Conn : CONNECTION) reader ~constraint_constants ~logger
     ~delete_older_than =
@@ -1391,7 +1407,9 @@ let run (module Conn : CONNECTION) reader ~constraint_constants ~logger
         let add_block = Block.add_if_doesn't_exist ~constraint_constants in
         let hash block = With_hash.hash block in
         match%map
-          add_block_aux ~delete_older_than ~hash ~add_block (module Conn) block
+          add_block_aux ~logger ~delete_older_than ~hash ~add_block
+            (module Conn)
+            block
         with
         | Error e ->
             [%log warn]
@@ -1413,7 +1431,7 @@ let add_genesis_accounts (module Conn : CONNECTION) ~logger
   match runtime_config_opt with
   | None ->
       Deferred.unit
-  | Some runtime_config ->
+  | Some runtime_config -> (
       let accounts =
         match Option.map runtime_config.ledger ~f:(fun l -> l.base) with
         | Some (Accounts accounts) ->
@@ -1433,21 +1451,41 @@ let add_genesis_accounts (module Conn : CONNECTION) ~logger
         | _ ->
             failwith "No accounts found in runtime config file"
       in
-      let%bind () =
-        Deferred.List.iter accounts ~f:(fun (_, acc) ->
-            match%map Timing_info.add_if_doesn't_exist (module Conn) acc with
-            | Error e ->
-                [%log error]
-                  ~metadata:
-                    [ ("account", Account.to_yojson acc)
-                    ; ("error", `String (Caqti_error.show e)) ]
-                  "Failed to add genesis account: $account, see $error" ;
-                Conn.rollback () |> ignore ;
-                failwith "Failed to add genesis account"
-            | Ok _ ->
-                () )
+      let add_accounts () =
+        let open Deferred.Result.Let_syntax in
+        let%bind () = Conn.start () in
+        let rec go accounts =
+          let open Deferred.Let_syntax in
+          match accounts with
+          | [] ->
+              Deferred.Result.return ()
+          | (_, account) :: accounts' -> (
+              match%bind
+                Timing_info.add_if_doesn't_exist (module Conn) account
+              with
+              | Error e as err ->
+                  [%log error]
+                    ~metadata:
+                      [ ("account", Account.to_yojson account)
+                      ; ("error", `String (Caqti_error.show e)) ]
+                    "Failed to add genesis account: $account, see $error" ;
+                  let%map _ = Conn.rollback () in
+                  err
+              | Ok _ ->
+                  go accounts' )
+        in
+        let%bind () = go accounts in
+        Conn.commit ()
       in
-      Conn.commit () >>| ignore
+      match%map
+        retry ~f:add_accounts ~logger ~error_str:"add_genesis_accounts" 3
+      with
+      | Error e ->
+          [%log warn] "genesis accounts could not be added"
+            ~metadata:[("error", `String (Caqti_error.show e))] ;
+          failwith "Failed to add genesis accounts"
+      | Ok () ->
+          () )
 
 let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
     ~delete_older_than ~runtime_config_opt =
@@ -1488,6 +1526,7 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
           match%map
             add_block_aux
               ~add_block:(Block.add_from_precomputed ~constraint_constants)
+              ~logger
               ~hash:(fun block ->
                 block.External_transition.Precomputed_block.protocol_state
                 |> Protocol_state.hash )
@@ -1507,7 +1546,7 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
       Strict_pipe.Reader.iter extensional_block_reader
         ~f:(fun extensional_block ->
           match%map
-            add_block_aux ~add_block:Block.add_from_extensional
+            add_block_aux ~logger ~add_block:Block.add_from_extensional
               ~hash:(fun block -> block.state_hash)
               ~delete_older_than conn extensional_block
           with

--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -53,11 +53,12 @@ let main ~archive_uri ~precomputed ~extensional ~success_file ~failure_file
           (Processor.add_block_aux_precomputed
              ~constraint_constants:
                Genesis_constants.Constraint_constants.compiled conn
-             ~delete_older_than:None)
+             ~delete_older_than:None ~logger)
       in
       let add_extensional_block =
         make_add_block Archive_lib.Extensional.Block.of_yojson
-          (Processor.add_block_aux_extensional conn ~delete_older_than:None)
+          (Processor.add_block_aux_extensional ~logger conn
+             ~delete_older_than:None)
       in
       Deferred.List.iter files ~f:(fun file ->
           In_channel.with_file file ~f:(fun in_channel ->


### PR DESCRIPTION
Added retry logic for database writes to support concurrent database transactions (described [here](https://github.com/MinaProtocol/mina/issues/7567)). This also requires setting transaction isolation level to 'serializable' and can be done in two ways:

1. set it as the default isolation level in postgresql.conf:
     `default_transaction_isolation = 'serializable'`
2. set it for a specific database using the following query
    `ALTER DATABASE <DATABASE NAME> SET DEFAULT_TRANSACTION_ISOLATION TO SERIALIZABLE ;` 

They need to be done as a separate step before archive node starts writing (and before bringing up the database instance in the case of option 1). I think setting it at the db level makes it explicit and therefore is a better option, but i'm not quite sure where in the codebase this configuration needs to live
