### PR TITLE
use terraform workspaces for managing CI deployment states

### DIFF
--- a/automation/scripts/generate-keys-and-ledger.sh
+++ b/automation/scripts/generate-keys-and-ledger.sh
@@ -36,10 +36,17 @@ while [ $# -gt 0 ]; do
     --efc=*)
       EXTRA_COUNT="${1#*=}"
       ;;
+    --artifact-path=*)
+      ARTIFACT_PATH="${1#*=}"
+      ;;
   esac
   shift
 done
 
+# if override not provided, default to testnets DIR
+if [[ ! $ARTIFACT_PATH ]]; then
+  ARTIFACT_PATH="terraform/testnets/${TESTNET}/"
+fi
 
 WHALE_AMOUNT=2250000
 FISH_AMOUNT=20000
@@ -313,12 +320,15 @@ done < <(echo -n "$PROMPT_KEYSETS") | coda-network genesis
 GENESIS_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Fix the ledger format for ease of use
-echo "Rewriting ./keys/genesis/* as terraform/testnets/${TESTNET}/genesis_ledger.json in the proper format for daemon consumption..."
-cat ./keys/genesis/* | jq '.[] | select(.balance=="'${WHALE_AMOUNT}'") | . + { sk: null, delegate: .delegate, balance: (.balance + ".000000000") }' | cat > "terraform/testnets/${TESTNET}/whales.json"
-cat ./keys/genesis/* | jq '.[] | select(.balance=="'${FISH_AMOUNT}'") | . + { sk: null, delegate: .delegate, balance: (.balance + ".000000000") }' | cat > "terraform/testnets/${TESTNET}/fish.json"
-cat ./keys/genesis/* | jq '.[] | select(.balance=="'${COMMUNITY_AMOUNT}'") | . + { sk: null, delegate: .delegate, balance: (.balance + ".000000000"), timing: { initial_minimum_balance: "60000", cliff_time:"150", cliff_amount:"12000", vesting_period:"6", vesting_increment:"150"}}' | cat > "terraform/testnets/${TESTNET}/community_fast_locked_keys.json"
+echo "Rewriting ./keys/genesis/* as ${ARTIFACT_PATH}/genesis_ledger.json in the proper format for daemon consumption..."
+cat ./keys/genesis/* | jq '.[] | select(.balance=="'${WHALE_AMOUNT}'") | . + { sk: null, delegate: .delegate, balance: (.balance + ".000000000") }' | cat > "${ARTIFACT_PATH}/whales.json"
+cat ./keys/genesis/* | jq '.[] | select(.balance=="'${FISH_AMOUNT}'") | . + { sk: null, delegate: .delegate, balance: (.balance + ".000000000") }' | cat > "${ARTIFACT_PATH}/fish.json"
+cat ./keys/genesis/* | jq '.[] | select(.balance=="'${COMMUNITY_AMOUNT}'") | . + { sk: null, delegate: .delegate, balance: (.balance + ".000000000"), timing: { initial_minimum_balance: "60000", cliff_time:"150", cliff_amount:"12000", vesting_period:"6", vesting_increment:"150"}}' | cat > "${ARTIFACT_PATH}/community_fast_locked_keys.json"
 
-NUM_ACCOUNTS=$(jq -s 'length'  terraform/testnets/${TESTNET}/*.json)
-jq -s '{ genesis: { genesis_state_timestamp: "'${GENESIS_TIMESTAMP}'" }, ledger: { name: "'${TESTNET}'", num_accounts: '${NUM_ACCOUNTS}', accounts: [ .[] ] } }' terraform/testnets/${TESTNET}/*.json > "terraform/testnets/${TESTNET}/genesis_ledger.json"
+echo "Determining total accounts based on partial ledgers..."
+NUM_ACCOUNTS=$(jq -s 'length'  ${ARTIFACT_PATH}/*.json)
+
+echo "Merging partial ledgers into genesis_ledger..."
+jq -s '{ genesis: { genesis_state_timestamp: "'${GENESIS_TIMESTAMP}'" }, ledger: { name: "'${TESTNET}'", num_accounts: '${NUM_ACCOUNTS}', accounts: [ .[] ] } }' ${ARTIFACT_PATH}/*.json > "${ARTIFACT_PATH}/genesis_ledger.json"
 
 echo "Keys and genesis ledger generated successfully, $TESTNET is ready to deploy!"

--- a/automation/scripts/generate-keys-and-ledger.sh
+++ b/automation/scripts/generate-keys-and-ledger.sh
@@ -45,7 +45,7 @@ done
 
 # if override not provided, default to testnets DIR
 if [[ ! $ARTIFACT_PATH ]]; then
-  ARTIFACT_PATH="terraform/testnets/${TESTNET}/"
+  ARTIFACT_PATH="terraform/testnets/${TESTNET}"
 fi
 
 WHALE_AMOUNT=2250000

--- a/automation/terraform/modules/kubernetes/testnet/helm.tf
+++ b/automation/terraform/modules/kubernetes/testnet/helm.tf
@@ -7,7 +7,7 @@ provider helm {
 
 data "local_file" "genesis_ledger" {
   # genesis_ledger.json is not required when generate_and_upload_artifacts is set to false
-  filename = var.generate_and_upload_artifacts ? "genesis_ledger.json" : "/dev/null"
+  filename = var.generate_and_upload_artifacts ? "${var.artifact_path}/genesis_ledger.json" : "/dev/null"
   depends_on = [
     null_resource.block_producer_key_generation
   ]

--- a/automation/terraform/modules/kubernetes/testnet/testnet-artifacts.tf
+++ b/automation/terraform/modules/kubernetes/testnet/testnet-artifacts.tf
@@ -1,7 +1,7 @@
 resource "null_resource" "block_producer_key_generation" {
   count = var.generate_and_upload_artifacts ? 1 : 0
   provisioner "local-exec" {
-    command = "${path.module}/../../../../scripts/generate-keys-and-ledger.sh --testnet=${var.testnet_name} --wc=${var.whale_count} --fc=${var.fish_count} --reset=false"
+    command = "${path.module}/../../../../scripts/generate-keys-and-ledger.sh --testnet=${var.testnet_name} --wc=${var.whale_count} --fc=${var.fish_count} --reset=false --artifact-path=${var.artifact_path}"
   }
 }
 

--- a/automation/terraform/modules/kubernetes/testnet/variables.tf
+++ b/automation/terraform/modules/kubernetes/testnet/variables.tf
@@ -6,6 +6,11 @@ variable "generate_and_upload_artifacts" {
   default = true
 }
 
+variable "artifact_path" {
+  type = string
+  default = "/tmp"
+}
+
 # K8s Cluster Vars
 
 variable "cluster_name" {

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -24,13 +24,14 @@ variable "coda_image" {
   type = string
 
   description = "Mina daemon image to use in provisioning a ci-net"
+  default     = "gcr.io/o1labs-192920/coda-daemon:0.2.11-develop"
 }
 
 variable "coda_archive_image" {
   type = string
 
   description = "Mina archive node image to use in provisioning a ci-net"
-  default     = "gcr.io/o1labs-192920/coda-archive:0.2.6-compatible"
+  default     = "gcr.io/o1labs-192920/coda-archive:0.2.11-develop"
 }
 
 variable "whale_count" {

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -20,18 +20,10 @@ provider "google" {
   zone    = "us-east4-b"
 }
 
-variable "testnet_name" {
-  type = string
-
-  description = "Name identifier of testnet to provision"
-  default     = "ci-net"
-}
-
 variable "coda_image" {
   type = string
 
   description = "Mina daemon image to use in provisioning a ci-net"
-  default     = "gcr.io/o1labs-192920/coda-daemon:0.2.6-compatible"
 }
 
 variable "coda_archive_image" {
@@ -61,6 +53,16 @@ variable "snark_worker_count" {
   default = 1
 }
 
+variable "ci_cluster_region" {
+  type    = string
+  default = "us-west1"
+}
+
+variable "ci_k8s_ctx" {
+  type    = string
+  default = "gke_o1labs-192920_us-west1_mina-integration-west1"
+}
+
 locals {
   seed_region = "us-west1"
   seed_zone = "us-west1-b"
@@ -71,9 +73,10 @@ module "ci_testnet" {
   providers = { google = google.google-us-east4 }
   source    = "../../modules/kubernetes/testnet"
 
+  # TODO: remove obsolete cluster_name var + cluster region
   cluster_name          = "mina-integration-west1"
-  cluster_region        = "us-west1"
-  k8s_context           = "gke_o1labs-192920_us-west1_mina-integration-west1"
+  cluster_region        = var.ci_cluster_region
+  k8s_context           = var.ci_k8s_ctx
   testnet_name          = "${terraform.workspace}-ci-net"
 
   coda_image            = var.coda_image

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -62,11 +62,8 @@ variable "snark_worker_count" {
 }
 
 locals {
-  seed_region = "us-east4"
-  seed_zone = "us-east4-b"
-  seed_discovery_keypairs = [
-  "CAESQBEHe2zCcQDHcSaeIydGggamzmTapdCS8SP0hb5FWvYhe9XEygmlUGV4zNu2P8zAIba4X84Gm4usQFLamjRywA8=,CAESIHvVxMoJpVBleMzbtj/MwCG2uF/OBpuLrEBS2po0csAP,12D3KooWJ9mNdbUXUpUNeMnejRumKzmQF15YeWwAPAhTAWB6dhiv",
-  "CAESQO+8qvMqTaQEX9uh4NnNoyOy4Xwv3U80jAsWweQ1J37AVgx7kgs4pPVSBzlP7NDANP1qvSvEPOTh2atbMMUO8EQ=,CAESIFYMe5ILOKT1Ugc5T+zQwDT9ar0rxDzk4dmrWzDFDvBE,12D3KooWFcGGeUmbmCNq51NBdGvCWjiyefdNZbDXADMK5CDwNRm5" ]
+  seed_region = "us-west1"
+  seed_zone = "us-west1-b"
 }
 
 
@@ -77,7 +74,7 @@ module "ci_testnet" {
   cluster_name          = "mina-integration-west1"
   cluster_region        = "us-west1"
   k8s_context           = "gke_o1labs-192920_us-west1_mina-integration-west1"
-  testnet_name          = var.testnet_name
+  testnet_name          = "${terraform.workspace}-ci-net"
 
   coda_image            = var.coda_image
   coda_archive_image    = var.coda_archive_image

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -64,6 +64,11 @@ variable "ci_k8s_ctx" {
   default = "gke_o1labs-192920_us-west1_mina-integration-west1"
 }
 
+variable "ci_artifact_path" {
+  type    = string
+  default = "/tmp"
+}
+
 locals {
   seed_region = "us-west1"
   seed_zone = "us-west1-b"
@@ -147,4 +152,6 @@ module "ci_testnet" {
   agent_min_tx = "0.0015"
   agent_max_tx = "0.0015"
   agent_send_every_mins = "1"
+
+  artifact_path = var.ci_artifact_path
 }

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -15,7 +15,7 @@ let deployEnv = "DOCKER_DEPLOY_ENV" in
         commands = [
           -- create separate workspace based on build branch to isolate infrastructure states
           Cmd.run (
-            "cd automation/terraform/testnets/${testnetName} && terraform init && terraform workspace new \\\$BUILDKITE_BRANCH"
+            "cd automation/terraform/testnets/${testnetName} && terraform init && terraform workspace new \\\${BUILDKITE_BRANCH//_/-}"
           ),
           Cmd.run (
             "if [ ! -f ${deployEnv} ]; then " ++

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -29,7 +29,7 @@ let deployEnv = "DOCKER_DEPLOY_ENV" in
           ),
           Cmd.run (
             -- upload genesis_ledger and related generated json files
-            "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION=gs://buildkite_k8s/coda/shared/\\\${BUILDKITE_JOB_ID} buildkite-agent artifact upload \"*.json\""
+            "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION=gs://buildkite_k8s/coda/shared/\\\${BUILDKITE_JOB_ID} buildkite-agent artifact upload \"/tmp/*.json\""
           ),
           Cmd.run (
             -- always execute post-deploy operation

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -13,8 +13,9 @@ let deployEnv = "DOCKER_DEPLOY_ENV" in
     Command.build
       Command.Config::{
         commands = [
+          -- create separate workspace based on build branch to isolate infrastructure states
           Cmd.run (
-            "cd automation/terraform/testnets/${testnetName} && terraform init"
+            "cd automation/terraform/testnets/${testnetName} && terraform init && terraform workspace new \\\$BUILDKITE_BRANCH"
           ),
           Cmd.run (
             "if [ ! -f ${deployEnv} ]; then " ++
@@ -22,7 +23,7 @@ let deployEnv = "DOCKER_DEPLOY_ENV" in
             "fi"
           ),
           Cmd.run (
-            "set -euo pipefail; source ${deployEnv} && terraform apply -auto-approve" ++
+            "source ${deployEnv} && terraform apply -auto-approve" ++
               " -var coda_image=gcr.io/o1labs-192920/coda-daemon:\\\$CODA_VERSION-\\\$CODA_GIT_HASH"
           ),
           Cmd.run (

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -25,7 +25,8 @@ let deployEnv = "DOCKER_DEPLOY_ENV" in
           ),
           Cmd.run (
             "source ${deployEnv} && terraform apply -auto-approve" ++
-              " -var coda_image=gcr.io/o1labs-192920/coda-daemon:\\\$CODA_VERSION-\\\$CODA_GIT_HASH"
+              " -var coda_image=gcr.io/o1labs-192920/coda-daemon:\\\$CODA_VERSION-\\\$CODA_GIT_HASH" ++
+              " -var ci_artifact_path=/tmp"
           ),
           Cmd.run (
             -- upload genesis_ledger and related generated json files

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -29,7 +29,7 @@ let deployEnv = "DOCKER_DEPLOY_ENV" in
           ),
           Cmd.run (
             -- upload genesis_ledger and related generated json files
-            "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION=gs://buildkite_k8s/coda/shared/\\\${BUILDKITE_JOB_ID} buildkite-agent artifact upload \"/tmp/*.json\""
+            "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION=gs://buildkite_k8s/coda/shared/\\\${BUILDKITE_JOB_ID} buildkite-agent artifact upload \"/tmp/genesis_ledger.json\""
           ),
           Cmd.run (
             -- always execute post-deploy operation

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -13,9 +13,10 @@ let deployEnv = "DOCKER_DEPLOY_ENV" in
     Command.build
       Command.Config::{
         commands = [
-          -- create separate workspace based on build branch to isolate infrastructure states
           Cmd.run (
-            "cd automation/terraform/testnets/${testnetName} && terraform init && (terraform workspace new \\\${BUILDKITE_BRANCH//_/-} || true)"
+            "cd automation/terraform/testnets/${testnetName} && terraform init" ++
+            -- create separate workspace based on build branch to isolate infrastructure states
+            " && (terraform workspace select \\\${BUILDKITE_BRANCH//_/-} || terraform workspace new \\\${BUILDKITE_BRANCH//_/-})"
           ),
           Cmd.run (
             "if [ ! -f ${deployEnv} ]; then " ++

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -15,7 +15,7 @@ let deployEnv = "DOCKER_DEPLOY_ENV" in
         commands = [
           -- create separate workspace based on build branch to isolate infrastructure states
           Cmd.run (
-            "cd automation/terraform/testnets/${testnetName} && terraform init && terraform workspace new \\\${BUILDKITE_BRANCH//_/-}"
+            "cd automation/terraform/testnets/${testnetName} && terraform init && (terraform workspace new \\\${BUILDKITE_BRANCH//_/-} || true)"
           ),
           Cmd.run (
             "if [ ! -f ${deployEnv} ]; then " ++

--- a/buildkite/src/Jobs/Test/DeployTestnetAndDestroy.dhall
+++ b/buildkite/src/Jobs/Test/DeployTestnetAndDestroy.dhall
@@ -15,7 +15,7 @@ in Pipeline.build Pipeline.Config::{
   spec =
     JobSpec::{
     dirtyWhen = [
-        S.strictlyStart (S.contains "automation/"),
+        S.strictlyStart (S.contains "automation/terraform/modules/kubernetes/testnet"),
         S.strictlyStart (S.contains "buildkite/src/Jobs/Test/DeployTestnetAndDestroy")
     ],
     path = "Test",

--- a/buildkite/src/Jobs/Test/DeployTestnetAndDestroy.dhall
+++ b/buildkite/src/Jobs/Test/DeployTestnetAndDestroy.dhall
@@ -9,7 +9,7 @@ let testTestnet = "ci-net"
 let dependsOn = [
     { name = "MinaArtifact", key = "mina-docker-image" }
 ]
-let deployDestroyOp = "sleep 60 && terraform destroy -auto-approve"
+let deployDestroyOp = "sleep 10 && terraform destroy -auto-approve && terraform workspace delete \\\$(terraform workspace show)"
 
 in Pipeline.build Pipeline.Config::{
   spec =

--- a/buildkite/src/Jobs/Test/DeployTestnetAndDestroy.dhall
+++ b/buildkite/src/Jobs/Test/DeployTestnetAndDestroy.dhall
@@ -9,7 +9,7 @@ let testTestnet = "ci-net"
 let dependsOn = [
     { name = "MinaArtifact", key = "mina-docker-image" }
 ]
-let deployDestroyOp = "sleep 10 && terraform destroy -auto-approve && terraform workspace delete \\\$(terraform workspace show)"
+let deployDestroyOp = "sleep 10 && terraform destroy -auto-approve"
 
 in Pipeline.build Pipeline.Config::{
   spec =


### PR DESCRIPTION
`terraform workspace` basically allows management of multiple related states via a single state file ([see](https://www.terraform.io/docs/language/state/workspaces.html#using-workspaces) for more details).

Also reduce time after *apply* to *destroy* deployment during DeployAndDestroy test and add a variable for the path for testnet artifacts to be stored/processed locally.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #7701 
