### PR TITLE
Async list map for `best_chain` GraphQL query

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2869,7 +2869,7 @@ module Queries = struct
     io_field "bestChain"
       ~doc:
         "Retrieve a list of blocks from transition frontier's root to the \
-         current best tip. Returns null if the system is bootstrapping."
+         current best tip. Returns an error if the system is bootstrapping."
       ~typ:(list @@ non_null Types.block)
       ~args:
         Arg.


### PR DESCRIPTION
Use `Deferred.List.map` to compute the blocks returned by the `best_chain` GraphQL query. That should allow other `Async` tasks to run when processing each block.

N.B.: the default `~how` for the map is `Sequential`.

Change in behavior: if the chain is unavailable, return an error, rather than `null`.

Closes #7706.