### PR TITLE
increase buildkite agent provisioned diskspace to handle dune build disk pressure

### DIFF
--- a/automation/terraform/buildkite/buildkite-ci/us-central1.tf
+++ b/automation/terraform/buildkite/buildkite-ci/us-central1.tf
@@ -49,7 +49,7 @@ locals {
         limits = {
           cpu    = "8"
           memory = "8G"
-          ephemeral-storage = "100Gi"
+          ephemeral-storage = "500Gi"
         }
       }
       replicaCount = 10
@@ -68,7 +68,7 @@ locals {
         limits = {
           cpu    = "15.5"
           memory = "16G"
-          ephemeral-storage = "100Gi"
+          ephemeral-storage = "500Gi"
         }
       }
       replicaCount = 6

--- a/automation/terraform/buildkite/buildkite-ci/us-east1.tf
+++ b/automation/terraform/buildkite/buildkite-ci/us-east1.tf
@@ -49,7 +49,7 @@ locals {
         limits = {
           cpu    = "8"
           memory = "8G"
-          ephemeral-storage = "100Gi"
+          ephemeral-storage = "500Gi"
         }
       }
       replicaCount = 6
@@ -68,7 +68,7 @@ locals {
         limits = {
           cpu    = "15.5"
           memory = "16G"
-          ephemeral-storage = "100Gi"
+          ephemeral-storage = "500Gi"
         }
       }
       replicaCount = 5

--- a/automation/terraform/buildkite/buildkite-ci/us-east4.tf
+++ b/automation/terraform/buildkite/buildkite-ci/us-east4.tf
@@ -49,7 +49,7 @@ locals {
         limits = {
           cpu    = "8"
           memory = "8G"
-          ephemeral-storage = "100Gi"
+          ephemeral-storage = "500Gi"
         }
       }
       replicaCount = 6
@@ -68,7 +68,7 @@ locals {
         limits = {
           cpu    = "15.5"
           memory = "16G"
-          ephemeral-storage = "100Gi"
+          ephemeral-storage = "500Gi"
         }
       }
       replicaCount = 5


### PR DESCRIPTION
Resolves recent pod cluster evictions due to used diskspace exceeding limitation ([example](https://console.cloud.google.com/kubernetes/pod/us-central1/buildkite-infra-central1/buildkite-ci/gke-central1-buildkite-xlarge-agent-6bc6454549-p5wbf/details?authuser=1&project=o1labs-192920)).

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
