### PR TITLE
Add balances to extensional commands

### DIFF
--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -36,10 +36,13 @@ module User_command = struct
           [@of_yojson Transaction_hash.of_yojson]
     ; status: string
     ; failure_reason: Transaction_status.Failure.Stable.Latest.t option
+    ; source_balance: Currency.Balance.Stable.Latest.t option
     ; fee_payer_account_creation_fee_paid:
         Currency.Amount.Stable.Latest.t option
+    ; fee_payer_balance: Currency.Balance.Stable.Latest.t
     ; receiver_account_creation_fee_paid:
         Currency.Amount.Stable.Latest.t option
+    ; receiver_balance: Currency.Balance.Stable.Latest.t option
     ; created_token: Token_id.Stable.Latest.t option }
   [@@deriving yojson, bin_io_unversioned]
 end
@@ -53,6 +56,7 @@ module Internal_command = struct
     ; secondary_sequence_no: int
     ; typ: string
     ; receiver: Public_key.Compressed.Stable.Latest.t
+    ; receiver_balance: Currency.Balance.Stable.Latest.t
     ; fee: Currency.Fee.Stable.Latest.t
     ; token: Token_id.Stable.Latest.t
     ; hash: Transaction_hash.Stable.Latest.t

--- a/src/app/missing_subchain/block.ml
+++ b/src/app/missing_subchain/block.ml
@@ -170,11 +170,13 @@ let payload_of_user_cmd user_cmd =
 
 let status_of_user_cmd (user_cmd : Extensional.User_command.t) =
   let open Transaction_status in
-  (* TODO: use actual balance data instead of dummy value *)
+  let balance_data =
+    { Balance_data.fee_payer_balance= Some user_cmd.fee_payer_balance
+    ; source_balance= user_cmd.source_balance
+    ; receiver_balance= user_cmd.receiver_balance }
+  in
   match user_cmd.status with
-  | None ->
-      None
-  | Some "applied" ->
+  | "applied" ->
       Some
         (Applied
            ( { fee_payer_account_creation_fee_paid=
@@ -182,14 +184,14 @@ let status_of_user_cmd (user_cmd : Extensional.User_command.t) =
              ; receiver_account_creation_fee_paid=
                  user_cmd.receiver_account_creation_fee_paid
              ; created_token= user_cmd.created_token }
-           , Balance_data.empty ))
-  | Some "failed" -> (
+           , balance_data ))
+  | "failed" -> (
     match user_cmd.failure_reason with
     | Some reason ->
-        Some (Failed (reason, Balance_data.empty))
+        Some (Failed (reason, balance_data))
     | None ->
         failwith "Failed user command status, no reason given" )
-  | Some s ->
+  | s ->
       failwithf "Unexpected user command status \"%s\"" s ()
 
 let signed_cmd_with_status_of_user_cmd (user_cmd : Extensional.User_command.t)

--- a/src/app/missing_subchain/dune
+++ b/src/app/missing_subchain/dune
@@ -15,4 +15,4 @@
    mina_base)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_coda ppx_let ppx_hash ppx_compare ppx_sexp_conv)))
+ (preprocess (pps ppx_version ppx_coda ppx_let ppx_hash ppx_compare ppx_sexp_conv h_list.ppx)))

--- a/src/app/missing_subchain/sql.ml
+++ b/src/app/missing_subchain/sql.ml
@@ -3,28 +3,27 @@
 module Subchain = struct
   let query =
     Caqti_request.collect Caqti_type.string Archive_lib.Processor.Block.typ
-      {|
-         WITH RECURSIVE chain AS (
+      {sql| WITH RECURSIVE chain AS (
 
-           SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
+              SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
+                     next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp
+              FROM blocks b WHERE b.state_hash = ?
+
+              UNION ALL
+
+              SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,b.snarked_ledger_hash_id,b.staking_epoch_data_id,
+                     b.next_epoch_data_id,b.ledger_hash,b.height,b.global_slot,b.global_slot_since_genesis,b.timestamp
+              FROM blocks b
+
+              INNER JOIN chain
+
+              ON b.id = chain.parent_id
+           )
+
+           SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
                   next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp
-           FROM blocks b WHERE b.state_hash = ?
-
-           UNION ALL
-
-           SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,b.snarked_ledger_hash_id,b.staking_epoch_data_id,
-                  b.next_epoch_data_id,b.ledger_hash,b.height,b.global_slot,b.global_slot_since_genesis,b.timestamp
-           FROM blocks b
-
-           INNER JOIN chain
-
-           ON b.id = chain.parent_id
-        )
-
-        SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
-               next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp
-        FROM chain
-      |}
+           FROM chain
+      |sql}
 
   (* state_hash from end block of the subchain *)
   let run (module Conn : Caqti_async.CONNECTION) state_hash =
@@ -62,25 +61,39 @@ module Blocks_and_user_commands = struct
   let query =
     Caqti_request.collect Caqti_type.int
       Caqti_type.(tup2 int int)
-      {| SELECT user_command_id, sequence_no
-       FROM blocks_user_commands
-       WHERE block_id = ?
-    |}
+      {sql| SELECT user_command_id, sequence_no
+            FROM blocks_user_commands
+            WHERE block_id = ?
+      |sql}
 
   let run (module Conn : Caqti_async.CONNECTION) ~block_id =
     Conn.collect_list query block_id
 end
 
 module Blocks_and_internal_commands = struct
+  type t =
+    { internal_command_id: int
+    ; global_slot: int64
+    ; sequence_no: int
+    ; secondary_sequence_no: int
+    ; receiver_balance: int64 }
+  [@@deriving hlist]
+
+  let typ =
+    let open Archive_lib.Processor.Caqti_type_spec in
+    let spec = Caqti_type.[int; int64; int; int; int64] in
+    let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
+    let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
+    Caqti_type.custom ~encode ~decode (to_rep spec)
+
   let query =
-    Caqti_request.collect Caqti_type.int
-      Caqti_type.(tup4 int int64 int int)
-      {| SELECT internal_command_id, global_slot, sequence_no, secondary_sequence_no
-       FROM (blocks_internal_commands
-             INNER JOIN blocks
-             ON blocks.id = blocks_internal_commands.block_id)
-       WHERE block_id = ?
-    |}
+    Caqti_request.collect Caqti_type.int typ
+      {sql| SELECT internal_command_id, global_slot, sequence_no, secondary_sequence_no, receiver_balance
+            FROM (blocks_internal_commands
+              INNER JOIN blocks
+              ON blocks.id = blocks_internal_commands.block_id)
+            WHERE block_id = ?
+      |sql}
 
   let run (module Conn : Caqti_async.CONNECTION) ~block_id =
     Conn.collect_list query block_id


### PR DESCRIPTION
Add balances to user, internal commands in `Processor.Extensional`. Process the balances in the missing subchains tool.

This is the biggest piece of #7344. Will update the replayer to verify the balances after this is merged.