### PR TITLE
Vary signature for mainnet

### DIFF
--- a/src/config/features/dev.mlh
+++ b/src/config/features/dev.mlh
@@ -1,3 +1,3 @@
 [%%define feature_tokens true]
 [%%define feature_snapps true]
-
+[%%define mainnet false]

--- a/src/config/features/public_testnet.mlh
+++ b/src/config/features/public_testnet.mlh
@@ -1,3 +1,3 @@
 [%%define feature_tokens false]
 [%%define feature_snapps false]
-[%%define mainnet true]
+[%%define mainnet false]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -39,6 +39,6 @@
 [%%define daemon_expiry "2024-12-10 14:00:00-07:00"]
 [%%define test_full_epoch false]
 [%%import "/src/config/fork.mlh"]
-[%%import "/src/config/features/mainnet.mlh"]
+[%%import "/src/config/features/public_testnet.mlh"]
 (* 2*block_window_duration *)
 [%%define compaction_interval 360000]

--- a/src/lib/hash_prefix_states/dune
+++ b/src/lib/hash_prefix_states/dune
@@ -6,6 +6,6 @@
  (libraries snark_params mina_compile_config random_oracle)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_snarky ppx_version ppx_optcomp ppx_inline_test ppx_deriving.eq ppx_deriving_yojson))
+  (pps ppx_custom_printf ppx_snarky ppx_version ppx_optcomp ppx_inline_test ppx_deriving.eq ppx_deriving_yojson))
  (instrumentation (backend bisect_ppx))
  (synopsis "Values corresponding to the internal state of the Pedersen hash function on the prefixes used in Coda"))

--- a/src/lib/hash_prefix_states/hash_prefix_states.ml
+++ b/src/lib/hash_prefix_states/hash_prefix_states.ml
@@ -66,7 +66,16 @@ let coinbase_merkle_tree =
 
 let vrf_message = salt vrf_message
 
-let signature = salt signature
+[%%if
+mainnet]
+
+let signature = salt signature_mainnet
+
+[%%else]
+
+let signature = salt signature_testnet
+
+[%%endif]
 
 let vrf_output = salt vrf_output
 

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -44,7 +44,9 @@ let base_snark = create "CodaBaseSnark"
 
 let transition_system_snark = create "CodaTransitionSnark"
 
-let signature = create "CodaSignature"
+let signature_testnet = create "CodaSignature"
+
+let signature_mainnet = create "MinaSignatureMainnet"
 
 let receipt_chain_user_command = create "CodaReceiptUC"
 


### PR DESCRIPTION
This PR modifies the signature scheme so that signatures on testnets bear no relation to signatures on mainnet.