### PR TITLE
Bindings for 5-wires plonk

### DIFF
--- a/src/lib/marlin_plonk_bindings/dune
+++ b/src/lib/marlin_plonk_bindings/dune
@@ -34,6 +34,7 @@
    ;; Indices
    marlin_plonk_bindings_pasta_fp_index
    marlin_plonk_bindings_pasta_fq_index
+   marlin_plonk_bindings_pasta_5_wires_fp_index
    marlin_plonk_bindings_tweedle_fp_index
    marlin_plonk_bindings_tweedle_fq_index
    ;; Verification indices

--- a/src/lib/marlin_plonk_bindings/dune
+++ b/src/lib/marlin_plonk_bindings/dune
@@ -46,6 +46,7 @@
    ;; Proofs
    marlin_plonk_bindings_pasta_fp_proof
    marlin_plonk_bindings_pasta_fq_proof
+   marlin_plonk_bindings_pasta_5_wires_fp_proof
    marlin_plonk_bindings_tweedle_fp_proof
    marlin_plonk_bindings_tweedle_fq_proof
    ;; Oracles

--- a/src/lib/marlin_plonk_bindings/dune
+++ b/src/lib/marlin_plonk_bindings/dune
@@ -35,18 +35,21 @@
    marlin_plonk_bindings_pasta_fp_index
    marlin_plonk_bindings_pasta_fq_index
    marlin_plonk_bindings_pasta_5_wires_fp_index
+   marlin_plonk_bindings_pasta_5_wires_fq_index
    marlin_plonk_bindings_tweedle_fp_index
    marlin_plonk_bindings_tweedle_fq_index
    ;; Verification indices
    marlin_plonk_bindings_pasta_fp_verifier_index
    marlin_plonk_bindings_pasta_fq_verifier_index
    marlin_plonk_bindings_pasta_5_wires_fp_verifier_index
+   marlin_plonk_bindings_pasta_5_wires_fq_verifier_index
    marlin_plonk_bindings_tweedle_fp_verifier_index
    marlin_plonk_bindings_tweedle_fq_verifier_index
    ;; Proofs
    marlin_plonk_bindings_pasta_fp_proof
    marlin_plonk_bindings_pasta_fq_proof
    marlin_plonk_bindings_pasta_5_wires_fp_proof
+   marlin_plonk_bindings_pasta_5_wires_fq_proof
    marlin_plonk_bindings_tweedle_fp_proof
    marlin_plonk_bindings_tweedle_fq_proof
    ;; Oracles

--- a/src/lib/marlin_plonk_bindings/dune
+++ b/src/lib/marlin_plonk_bindings/dune
@@ -40,6 +40,7 @@
    ;; Verification indices
    marlin_plonk_bindings_pasta_fp_verifier_index
    marlin_plonk_bindings_pasta_fq_verifier_index
+   marlin_plonk_bindings_pasta_5_wires_fp_verifier_index
    marlin_plonk_bindings_tweedle_fp_verifier_index
    marlin_plonk_bindings_tweedle_fq_verifier_index
    ;; Proofs

--- a/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
+++ b/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
@@ -42,6 +42,7 @@ module Tweedle_fq_urs = Marlin_plonk_bindings_tweedle_fq_urs
 module Pasta_fp_index = Marlin_plonk_bindings_pasta_fp_index
 module Pasta_fq_index = Marlin_plonk_bindings_pasta_fq_index
 module Pasta_5_wires_fp_index = Marlin_plonk_bindings_pasta_5_wires_fp_index
+module Pasta_5_wires_fq_index = Marlin_plonk_bindings_pasta_5_wires_fq_index
 module Tweedle_fp_index = Marlin_plonk_bindings_tweedle_fp_index
 module Tweedle_fq_index = Marlin_plonk_bindings_tweedle_fq_index
 
@@ -51,6 +52,8 @@ module Pasta_fp_verifier_index = Marlin_plonk_bindings_pasta_fp_verifier_index
 module Pasta_fq_verifier_index = Marlin_plonk_bindings_pasta_fq_verifier_index
 module Pasta_5_wires_fp_verifier_index =
   Marlin_plonk_bindings_pasta_5_wires_fp_verifier_index
+module Pasta_5_wires_fq_verifier_index =
+  Marlin_plonk_bindings_pasta_5_wires_fq_verifier_index
 module Tweedle_fp_verifier_index =
   Marlin_plonk_bindings_tweedle_fp_verifier_index
 module Tweedle_fq_verifier_index =
@@ -60,6 +63,7 @@ module Tweedle_fq_verifier_index =
 module Pasta_fp_proof = Marlin_plonk_bindings_pasta_fp_proof
 module Pasta_fq_proof = Marlin_plonk_bindings_pasta_fq_proof
 module Pasta_5_wires_fp_proof = Marlin_plonk_bindings_pasta_5_wires_fp_proof
+module Pasta_5_wires_fq_proof = Marlin_plonk_bindings_pasta_5_wires_fq_proof
 module Tweedle_fp_proof = Marlin_plonk_bindings_tweedle_fp_proof
 module Tweedle_fq_proof = Marlin_plonk_bindings_tweedle_fq_proof
 

--- a/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
+++ b/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
@@ -59,6 +59,7 @@ module Tweedle_fq_verifier_index =
 (* Proofs *)
 module Pasta_fp_proof = Marlin_plonk_bindings_pasta_fp_proof
 module Pasta_fq_proof = Marlin_plonk_bindings_pasta_fq_proof
+module Pasta_5_wires_fp_proof = Marlin_plonk_bindings_pasta_5_wires_fp_proof
 module Tweedle_fp_proof = Marlin_plonk_bindings_tweedle_fp_proof
 module Tweedle_fq_proof = Marlin_plonk_bindings_tweedle_fq_proof
 

--- a/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
+++ b/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
@@ -41,6 +41,7 @@ module Tweedle_fq_urs = Marlin_plonk_bindings_tweedle_fq_urs
 
 module Pasta_fp_index = Marlin_plonk_bindings_pasta_fp_index
 module Pasta_fq_index = Marlin_plonk_bindings_pasta_fq_index
+module Pasta_5_wires_fp_index = Marlin_plonk_bindings_pasta_5_wires_fp_index
 module Tweedle_fp_index = Marlin_plonk_bindings_tweedle_fp_index
 module Tweedle_fq_index = Marlin_plonk_bindings_tweedle_fq_index
 

--- a/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
+++ b/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
@@ -49,6 +49,8 @@ module Tweedle_fq_index = Marlin_plonk_bindings_tweedle_fq_index
 
 module Pasta_fp_verifier_index = Marlin_plonk_bindings_pasta_fp_verifier_index
 module Pasta_fq_verifier_index = Marlin_plonk_bindings_pasta_fq_verifier_index
+module Pasta_5_wires_fp_verifier_index =
+  Marlin_plonk_bindings_pasta_5_wires_fp_verifier_index
 module Tweedle_fp_verifier_index =
   Marlin_plonk_bindings_tweedle_fp_verifier_index
 module Tweedle_fq_verifier_index =

--- a/src/lib/marlin_plonk_bindings/pasta_5_wires_fp_index/dune
+++ b/src/lib/marlin_plonk_bindings/pasta_5_wires_fp_index/dune
@@ -1,0 +1,9 @@
+(library
+ (name marlin_plonk_bindings_pasta_5_wires_fp_index)
+ (public_name marlin_plonk_bindings.pasta_5_wires_fp_index)
+ (libraries
+   marlin_plonk_bindings_stubs
+   marlin_plonk_bindings_pasta_fp_urs)
+ (instrumentation (backend bisect_ppx))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/pasta_5_wires_fp_index/marlin_plonk_bindings_pasta_5_wires_fp_index.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_5_wires_fp_index/marlin_plonk_bindings_pasta_5_wires_fp_index.ml
@@ -1,0 +1,53 @@
+open Marlin_plonk_bindings_types
+
+module Gate_vector = struct
+  type t
+
+  external create :
+    unit -> t
+    = "caml_pasta_fp_plonk_5_wires_gate_vector_create"
+
+  external add :
+    t -> Marlin_plonk_bindings_pasta_fp.t Plonk_5_wires_gate.t -> unit
+    = "caml_pasta_fp_plonk_5_wires_gate_vector_add"
+
+  external get :
+    t -> int -> Marlin_plonk_bindings_pasta_fp.t Plonk_5_wires_gate.t
+    = "caml_pasta_fp_plonk_5_wires_gate_vector_get"
+
+  external wrap :
+    t -> Plonk_5_wires_gate.Wire.t -> Plonk_5_wires_gate.Wire.t -> unit
+    = "caml_pasta_fp_plonk_5_wires_gate_vector_wrap"
+end
+
+type t
+
+external create :
+  Gate_vector.t -> int -> Marlin_plonk_bindings_pasta_fp_urs.t -> t
+  = "caml_pasta_fp_plonk_5_wires_index_create"
+
+external max_degree : t -> int = "caml_pasta_fp_plonk_5_wires_index_max_degree"
+
+external public_inputs :
+  t -> int
+  = "caml_pasta_fp_plonk_5_wires_index_public_inputs"
+
+external domain_d1_size :
+  t -> int
+  = "caml_pasta_fp_plonk_5_wires_index_domain_d1_size"
+
+external domain_d4_size :
+  t -> int
+  = "caml_pasta_fp_plonk_5_wires_index_domain_d4_size"
+
+external domain_d8_size :
+  t -> int
+  = "caml_pasta_fp_plonk_5_wires_index_domain_d8_size"
+
+external read :
+  ?offset:int -> Marlin_plonk_bindings_pasta_fp_urs.t -> string -> t
+  = "caml_pasta_fp_plonk_5_wires_index_read"
+
+external write :
+  ?append:bool -> t -> string -> unit
+  = "caml_pasta_fp_plonk_5_wires_index_write"

--- a/src/lib/marlin_plonk_bindings/pasta_5_wires_fq_index/dune
+++ b/src/lib/marlin_plonk_bindings/pasta_5_wires_fq_index/dune
@@ -1,0 +1,9 @@
+(library
+ (name marlin_plonk_bindings_pasta_5_wires_fq_index)
+ (public_name marlin_plonk_bindings.pasta_5_wires_fq_index)
+ (libraries
+   marlin_plonk_bindings_stubs
+   marlin_plonk_bindings_pasta_fq_urs)
+ (instrumentation (backend bisect_ppx))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/pasta_5_wires_fq_index/marlin_plonk_bindings_pasta_5_wires_fq_index.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_5_wires_fq_index/marlin_plonk_bindings_pasta_5_wires_fq_index.ml
@@ -1,0 +1,53 @@
+open Marlin_plonk_bindings_types
+
+module Gate_vector = struct
+  type t
+
+  external create :
+    unit -> t
+    = "caml_pasta_fq_plonk_5_wires_gate_vector_create"
+
+  external add :
+    t -> Marlin_plonk_bindings_pasta_fq.t Plonk_5_wires_gate.t -> unit
+    = "caml_pasta_fq_plonk_5_wires_gate_vector_add"
+
+  external get :
+    t -> int -> Marlin_plonk_bindings_pasta_fq.t Plonk_5_wires_gate.t
+    = "caml_pasta_fq_plonk_5_wires_gate_vector_get"
+
+  external wrap :
+    t -> Plonk_5_wires_gate.Wire.t -> Plonk_5_wires_gate.Wire.t -> unit
+    = "caml_pasta_fq_plonk_5_wires_gate_vector_wrap"
+end
+
+type t
+
+external create :
+  Gate_vector.t -> int -> Marlin_plonk_bindings_pasta_fq_urs.t -> t
+  = "caml_pasta_fq_plonk_5_wires_index_create"
+
+external max_degree : t -> int = "caml_pasta_fq_plonk_5_wires_index_max_degree"
+
+external public_inputs :
+  t -> int
+  = "caml_pasta_fq_plonk_5_wires_index_public_inputs"
+
+external domain_d1_size :
+  t -> int
+  = "caml_pasta_fq_plonk_5_wires_index_domain_d1_size"
+
+external domain_d4_size :
+  t -> int
+  = "caml_pasta_fq_plonk_5_wires_index_domain_d4_size"
+
+external domain_d8_size :
+  t -> int
+  = "caml_pasta_fq_plonk_5_wires_index_domain_d8_size"
+
+external read :
+  ?offset:int -> Marlin_plonk_bindings_pasta_fq_urs.t -> string -> t
+  = "caml_pasta_fq_plonk_5_wires_index_read"
+
+external write :
+  ?append:bool -> t -> string -> unit
+  = "caml_pasta_fq_plonk_5_wires_index_write"

--- a/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_proof/dune
+++ b/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_proof/dune
@@ -1,0 +1,10 @@
+(library
+ (name marlin_plonk_bindings_pasta_5_wires_fp_proof)
+ (public_name marlin_plonk_bindings.pasta_5_wires_fp_proof)
+ (libraries
+   marlin_plonk_bindings_stubs
+   marlin_plonk_bindings_pasta_5_wires_fp_verifier_index
+   marlin_plonk_bindings_pasta_fp_vector)
+ (instrumentation (backend bisect_ppx))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_proof/marlin_plonk_bindings_pasta_fp_proof.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_proof/marlin_plonk_bindings_pasta_fp_proof.ml
@@ -1,0 +1,39 @@
+open Marlin_plonk_bindings_types
+
+type t =
+  ( Marlin_plonk_bindings_pasta_fp.t
+  , Marlin_plonk_bindings_pasta_vesta.Affine.t
+  , Marlin_plonk_bindings_pasta_fp_urs.Poly_comm.t )
+  Plonk_5_wires_proof.t
+
+(* TODO-someday: [prev_challenges] should be an array of arrays, not a flat array. *)
+external create :
+     Marlin_plonk_bindings_pasta_5_wires_fp_index.t
+  -> primary_input:Marlin_plonk_bindings_pasta_fp_vector.t
+  -> auxiliary_input:(Marlin_plonk_bindings_pasta_fp.t array *Marlin_plonk_bindings_pasta_fp.t array *Marlin_plonk_bindings_pasta_fp.t array *Marlin_plonk_bindings_pasta_fp.t array *Marlin_plonk_bindings_pasta_fp.t array)
+  -> prev_challenges:Marlin_plonk_bindings_pasta_fp.t array
+  -> prev_sgs:Marlin_plonk_bindings_pasta_vesta.Affine.t array
+  -> t
+  = "caml_pasta_fp_plonk_5_wires_proof_create"
+
+external verify :
+     Marlin_plonk_bindings_pasta_fp_urs.Poly_comm.t array
+  -> Marlin_plonk_bindings_pasta_5_wires_fp_verifier_index.t
+  -> t
+  -> bool
+  = "caml_pasta_fp_plonk_5_wires_proof_verify"
+
+external batch_verify :
+     Marlin_plonk_bindings_pasta_fp_urs.Poly_comm.t array array
+  -> Marlin_plonk_bindings_pasta_5_wires_fp_verifier_index.t array
+  -> t array
+  -> bool
+  = "caml_pasta_fp_plonk_5_wires_proof_batch_verify"
+
+external dummy : unit -> t = "caml_pasta_fp_plonk_5_wires_proof_dummy"
+
+external deep_copy : t -> t = "caml_pasta_fp_plonk_5_wires_proof_deep_copy"
+
+let%test "deep_copy" =
+  let x = dummy () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_proof/marlin_plonk_bindings_pasta_fp_proof.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_proof/marlin_plonk_bindings_pasta_fp_proof.ml
@@ -10,7 +10,11 @@ type t =
 external create :
      Marlin_plonk_bindings_pasta_5_wires_fp_index.t
   -> primary_input:Marlin_plonk_bindings_pasta_fp_vector.t
-  -> auxiliary_input:(Marlin_plonk_bindings_pasta_fp.t array *Marlin_plonk_bindings_pasta_fp.t array *Marlin_plonk_bindings_pasta_fp.t array *Marlin_plonk_bindings_pasta_fp.t array *Marlin_plonk_bindings_pasta_fp.t array)
+  -> auxiliary_input:Marlin_plonk_bindings_pasta_fp.t array
+                     * Marlin_plonk_bindings_pasta_fp.t array
+                     * Marlin_plonk_bindings_pasta_fp.t array
+                     * Marlin_plonk_bindings_pasta_fp.t array
+                     * Marlin_plonk_bindings_pasta_fp.t array
   -> prev_challenges:Marlin_plonk_bindings_pasta_fp.t array
   -> prev_sgs:Marlin_plonk_bindings_pasta_vesta.Affine.t array
   -> t

--- a/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_verifier_index/dune
+++ b/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_verifier_index/dune
@@ -1,0 +1,9 @@
+(library
+ (name marlin_plonk_bindings_pasta_5_wires_fp_verifier_index)
+ (public_name marlin_plonk_bindings.pasta_5_wires_fp_verifier_index)
+ (libraries
+   marlin_plonk_bindings_stubs
+   marlin_plonk_bindings_pasta_5_wires_fp_index)
+ (instrumentation (backend bisect_ppx))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_verifier_index/marlin_plonk_bindings_pasta_5_wires_fp_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_verifier_index/marlin_plonk_bindings_pasta_5_wires_fp_verifier_index.ml
@@ -1,0 +1,31 @@
+open Marlin_plonk_bindings_types
+
+type t =
+  ( Marlin_plonk_bindings_pasta_fp.t
+  , Marlin_plonk_bindings_pasta_fp_urs.t
+  , Marlin_plonk_bindings_pasta_fp_urs.Poly_comm.t )
+  Plonk_5_wires_verifier_index.t
+
+external create :
+  Marlin_plonk_bindings_pasta_5_wires_fp_index.t -> t
+  = "caml_pasta_fp_plonk_5_wires_verifier_index_create"
+
+external read :
+  ?offset:int -> Marlin_plonk_bindings_pasta_fp_urs.t -> string -> t
+  = "caml_pasta_fp_plonk_5_wires_verifier_index_read"
+
+external write :
+  ?append:bool -> t -> string -> unit
+  = "caml_pasta_fp_plonk_5_wires_verifier_index_write"
+
+external shifts :
+  log2_size:int -> Marlin_plonk_bindings_pasta_fp.t Plonk_verification_shifts.t
+  = "caml_pasta_fp_plonk_5_wires_verifier_index_shifts"
+
+external dummy : unit -> t = "caml_pasta_fp_plonk_5_wires_verifier_index_dummy"
+
+external deep_copy : t -> t = "caml_pasta_fp_plonk_5_wires_verifier_index_deep_copy"
+
+let%test "deep_copy" =
+  let x = dummy () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_verifier_index/marlin_plonk_bindings_pasta_5_wires_fp_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fp_plonk_5_wires_verifier_index/marlin_plonk_bindings_pasta_5_wires_fp_verifier_index.ml
@@ -24,7 +24,9 @@ external shifts :
 
 external dummy : unit -> t = "caml_pasta_fp_plonk_5_wires_verifier_index_dummy"
 
-external deep_copy : t -> t = "caml_pasta_fp_plonk_5_wires_verifier_index_deep_copy"
+external deep_copy :
+  t -> t
+  = "caml_pasta_fp_plonk_5_wires_verifier_index_deep_copy"
 
 let%test "deep_copy" =
   let x = dummy () in

--- a/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_proof/dune
+++ b/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_proof/dune
@@ -1,0 +1,10 @@
+(library
+ (name marlin_plonk_bindings_pasta_5_wires_fq_proof)
+ (public_name marlin_plonk_bindings.pasta_5_wires_fq_proof)
+ (libraries
+   marlin_plonk_bindings_stubs
+   marlin_plonk_bindings_pasta_5_wires_fq_verifier_index
+   marlin_plonk_bindings_pasta_fq_vector)
+ (instrumentation (backend bisect_ppx))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_proof/marlin_plonk_bindings_pasta_fq_proof.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_proof/marlin_plonk_bindings_pasta_fq_proof.ml
@@ -1,0 +1,39 @@
+open Marlin_plonk_bindings_types
+
+type t =
+  ( Marlin_plonk_bindings_pasta_fq.t
+  , Marlin_plonk_bindings_pasta_pallas.Affine.t
+  , Marlin_plonk_bindings_pasta_fq_urs.Poly_comm.t )
+  Plonk_5_wires_proof.t
+
+(* TODO-someday: [prev_challenges] should be an array of arrays, not a flat array. *)
+external create :
+     Marlin_plonk_bindings_pasta_5_wires_fq_index.t
+  -> primary_input:Marlin_plonk_bindings_pasta_fq_vector.t
+  -> auxiliary_input:(Marlin_plonk_bindings_pasta_fq.t array *Marlin_plonk_bindings_pasta_fq.t array *Marlin_plonk_bindings_pasta_fq.t array *Marlin_plonk_bindings_pasta_fq.t array *Marlin_plonk_bindings_pasta_fq.t array)
+  -> prev_challenges:Marlin_plonk_bindings_pasta_fq.t array
+  -> prev_sgs:Marlin_plonk_bindings_pasta_pallas.Affine.t array
+  -> t
+  = "caml_pasta_fq_plonk_5_wires_proof_create"
+
+external verify :
+     Marlin_plonk_bindings_pasta_fq_urs.Poly_comm.t array
+  -> Marlin_plonk_bindings_pasta_5_wires_fq_verifier_index.t
+  -> t
+  -> bool
+  = "caml_pasta_fq_plonk_5_wires_proof_verify"
+
+external batch_verify :
+     Marlin_plonk_bindings_pasta_fq_urs.Poly_comm.t array array
+  -> Marlin_plonk_bindings_pasta_5_wires_fq_verifier_index.t array
+  -> t array
+  -> bool
+  = "caml_pasta_fq_plonk_5_wires_proof_batch_verify"
+
+external dummy : unit -> t = "caml_pasta_fq_plonk_5_wires_proof_dummy"
+
+external deep_copy : t -> t = "caml_pasta_fq_plonk_5_wires_proof_deep_copy"
+
+let%test "deep_copy" =
+  let x = dummy () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_proof/marlin_plonk_bindings_pasta_fq_proof.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_proof/marlin_plonk_bindings_pasta_fq_proof.ml
@@ -10,7 +10,11 @@ type t =
 external create :
      Marlin_plonk_bindings_pasta_5_wires_fq_index.t
   -> primary_input:Marlin_plonk_bindings_pasta_fq_vector.t
-  -> auxiliary_input:(Marlin_plonk_bindings_pasta_fq.t array *Marlin_plonk_bindings_pasta_fq.t array *Marlin_plonk_bindings_pasta_fq.t array *Marlin_plonk_bindings_pasta_fq.t array *Marlin_plonk_bindings_pasta_fq.t array)
+  -> auxiliary_input:Marlin_plonk_bindings_pasta_fq.t array
+                     * Marlin_plonk_bindings_pasta_fq.t array
+                     * Marlin_plonk_bindings_pasta_fq.t array
+                     * Marlin_plonk_bindings_pasta_fq.t array
+                     * Marlin_plonk_bindings_pasta_fq.t array
   -> prev_challenges:Marlin_plonk_bindings_pasta_fq.t array
   -> prev_sgs:Marlin_plonk_bindings_pasta_pallas.Affine.t array
   -> t

--- a/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_verifier_index/dune
+++ b/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_verifier_index/dune
@@ -1,0 +1,9 @@
+(library
+ (name marlin_plonk_bindings_pasta_5_wires_fq_verifier_index)
+ (public_name marlin_plonk_bindings.pasta_5_wires_fq_verifier_index)
+ (libraries
+   marlin_plonk_bindings_stubs
+   marlin_plonk_bindings_pasta_5_wires_fq_index)
+ (instrumentation (backend bisect_ppx))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_verifier_index/marlin_plonk_bindings_pasta_5_wires_fq_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_verifier_index/marlin_plonk_bindings_pasta_5_wires_fq_verifier_index.ml
@@ -1,0 +1,31 @@
+open Marlin_plonk_bindings_types
+
+type t =
+  ( Marlin_plonk_bindings_pasta_fq.t
+  , Marlin_plonk_bindings_pasta_fq_urs.t
+  , Marlin_plonk_bindings_pasta_fq_urs.Poly_comm.t )
+  Plonk_5_wires_verifier_index.t
+
+external create :
+  Marlin_plonk_bindings_pasta_5_wires_fq_index.t -> t
+  = "caml_pasta_fq_plonk_5_wires_verifier_index_create"
+
+external read :
+  ?offset:int -> Marlin_plonk_bindings_pasta_fq_urs.t -> string -> t
+  = "caml_pasta_fq_plonk_5_wires_verifier_index_read"
+
+external write :
+  ?append:bool -> t -> string -> unit
+  = "caml_pasta_fq_plonk_5_wires_verifier_index_write"
+
+external shifts :
+  log2_size:int -> Marlin_plonk_bindings_pasta_fq.t Plonk_verification_shifts.t
+  = "caml_pasta_fq_plonk_5_wires_verifier_index_shifts"
+
+external dummy : unit -> t = "caml_pasta_fq_plonk_5_wires_verifier_index_dummy"
+
+external deep_copy : t -> t = "caml_pasta_fq_plonk_5_wires_verifier_index_deep_copy"
+
+let%test "deep_copy" =
+  let x = dummy () in
+  deep_copy x = x

--- a/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_verifier_index/marlin_plonk_bindings_pasta_5_wires_fq_verifier_index.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fq_plonk_5_wires_verifier_index/marlin_plonk_bindings_pasta_5_wires_fq_verifier_index.ml
@@ -24,7 +24,9 @@ external shifts :
 
 external dummy : unit -> t = "caml_pasta_fq_plonk_5_wires_verifier_index_dummy"
 
-external deep_copy : t -> t = "caml_pasta_fq_plonk_5_wires_verifier_index_deep_copy"
+external deep_copy :
+  t -> t
+  = "caml_pasta_fq_plonk_5_wires_verifier_index_deep_copy"
 
 let%test "deep_copy" =
   let x = dummy () in

--- a/src/lib/marlin_plonk_bindings/stubs/Cargo.toml
+++ b/src/lib/marlin_plonk_bindings/stubs/Cargo.toml
@@ -29,6 +29,7 @@ oracle = { path = "../../marlin/oracle" }
 dlog_solver = { path = "../../marlin/dlog_solver" }
 marlin_circuits = { path = "../../marlin/circuits/marlin" }
 plonk_circuits = { path = "../../marlin/circuits/plonk", features = [ "ocaml_types" ] }
+plonk_5_wires_circuits = { path = "../../marlin/circuits/plonk-5-wires", features = [ "ocaml_types" ] }
 
 commitment_pairing = { path = "../../marlin/pairing/commitment" }
 marlin_protocol_pairing = { path = "../../marlin/pairing/marlin" }
@@ -36,6 +37,7 @@ marlin_protocol_pairing = { path = "../../marlin/pairing/marlin" }
 commitment_dlog = { path = "../../marlin/dlog/commitment", features = [ "ocaml_types" ] }
 marlin_protocol_dlog = { path = "../../marlin/dlog/marlin/" }
 plonk_protocol_dlog = { path = "../../marlin/dlog/plonk", features = [ "ocaml_types" ] }
+plonk_5_wires_protocol_dlog = { path = "../../marlin/dlog/plonk-5-wires", features = [ "ocaml_types" ] }
 
 [profile.release]
 debug = true

--- a/src/lib/marlin_plonk_bindings/stubs/src/index_serialization_5_wires.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/index_serialization_5_wires.rs
@@ -1,0 +1,484 @@
+use algebra::{
+    One,
+    curves::AffineCurve,
+    fields::{Field, PrimeField},
+    FromBytes, ToBytes,
+};
+
+use commitment_dlog::{
+    commitment::{CommitmentCurve, CommitmentField, PolyComm},
+    srs::SRS,
+};
+use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as Domain};
+use oracle::poseidon::ArithmeticSpongeParams;
+use plonk_5_wires_circuits::{
+    wires::COLUMNS,
+    constraints::{zk_polynomial, zk_w, ConstraintSystem as PlonkConstraintSystem},
+    domains::EvaluationDomains as PlonkEvaluationDomains,
+};
+use plonk_5_wires_protocol_dlog::index::{
+    Index as PlonkIndex, SRSValue as PlonkSRSValue, VerifierIndex as PlonkVerifierIndex,
+};
+use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
+
+pub fn write_vec<A: ToBytes, W: Write>(v: &Vec<A>, mut writer: W) -> IoResult<()> {
+    u64::write(&(v.len() as u64), &mut writer)?;
+    for x in v {
+        x.write(&mut writer)?;
+    }
+    Ok(())
+}
+
+pub fn read_vec<A: FromBytes, R: Read>(mut reader: R) -> IoResult<Vec<A>> {
+    let mut v = vec![];
+    let n = u64::read(&mut reader)? as usize;
+    for _ in 0..n {
+        v.push(A::read(&mut reader)?);
+    }
+    Ok(v)
+}
+
+pub fn write_option<A: ToBytes, W: Write>(a: &Option<A>, mut w: W) -> IoResult<()> {
+    match a {
+        None => u8::write(&0, &mut w),
+        Some(a) => {
+            u8::write(&1, &mut w)?;
+            A::write(a, &mut w)
+        }
+    }
+}
+
+pub fn read_option<A: FromBytes, R: Read>(mut r: R) -> IoResult<Option<A>> {
+    match u8::read(&mut r)? {
+        0 => Ok(None),
+        1 => Ok(Some(A::read(&mut r)?)),
+        _ => panic!("read_option: expected 0 or 1"),
+    }
+}
+
+pub fn write_poly_comm<A: ToBytes + AffineCurve, W: Write>(
+    p: &PolyComm<A>,
+    mut w: W,
+) -> IoResult<()> {
+    write_vec(&p.unshifted, &mut w)?;
+    write_option(&p.shifted, &mut w)
+}
+
+pub fn read_poly_comm<A: FromBytes + AffineCurve, R: Read>(mut r: R) -> IoResult<PolyComm<A>> {
+    let unshifted = read_vec(&mut r)?;
+    let shifted = read_option(&mut r)?;
+    Ok(PolyComm { unshifted, shifted })
+}
+
+pub fn write_dense_polynomial<A: ToBytes + Field, W: Write>(
+    p: &DensePolynomial<A>,
+    w: W,
+) -> IoResult<()> {
+    write_vec(&p.coeffs, w)
+}
+
+pub fn read_dense_polynomial<A: ToBytes + Field, R: Read>(r: R) -> IoResult<DensePolynomial<A>> {
+    let coeffs = read_vec(r)?;
+    Ok(DensePolynomial { coeffs })
+}
+
+pub fn write_domain<A: ToBytes + PrimeField, W: Write>(d: &Domain<A>, mut w: W) -> IoResult<()> {
+    (d.size as u64).write(&mut w)?;
+    Ok(())
+}
+
+pub fn read_domain<A: ToBytes + PrimeField, R: Read>(mut r: R) -> IoResult<Domain<A>> {
+    let size = u64::read(&mut r)?;
+    match Domain::new(size as usize) {
+        Some(d) => Ok(d),
+        None => Err(Error::new(
+            ErrorKind::Other,
+            format!("Invalid domain size {}", size),
+        )),
+    }
+}
+
+pub fn write_plonk_evaluations<A: ToBytes + PrimeField, W: Write>(
+    e: &Evaluations<A, Domain<A>>,
+    mut w: W,
+) -> IoResult<()> {
+    write_vec(&e.evals, &mut w)?;
+    Ok(())
+}
+
+pub fn read_plonk_evaluations<F: ToBytes + PrimeField, R: Read>(
+    mut r: R,
+) -> IoResult<Evaluations<F, Domain<F>>> {
+    let evals = read_vec(&mut r)?;
+    let domain = Domain::new(evals.len()).unwrap();
+    assert_eq!(evals.len(), domain.size());
+    Ok(Evaluations::<F, Domain<F>>::from_vec_and_domain(
+        evals, domain,
+    ))
+}
+
+pub fn write_plonk_index<'a, G: CommitmentCurve, W: Write>(
+    k: &PlonkIndex<'a, G>,
+    mut w: W,
+) -> IoResult<()>
+where
+    G::ScalarField: CommitmentField + ToBytes,
+{
+    write_plonk_constraint_system::<G, &mut W>(&k.cs, &mut w)?;
+    (k.max_poly_size as u64).write(&mut w)?;
+    (k.max_quot_size as u64).write(&mut w)?;
+    Ok(())
+}
+
+pub fn read_plonk_index<'a, G: CommitmentCurve, R: Read>(
+    fr_sponge_params: ArithmeticSpongeParams<G::ScalarField>,
+    fq_sponge_params: ArithmeticSpongeParams<G::BaseField>,
+    srs: *const SRS<G>,
+    mut r: R,
+) -> IoResult<PlonkIndex<'a, G>>
+where
+    G::ScalarField: CommitmentField + FromBytes,
+{
+    let cs = read_plonk_constraint_system::<G, &mut R>(fr_sponge_params, &mut r)?;
+    let max_poly_size = u64::read(&mut r)? as usize;
+    let max_quot_size = u64::read(&mut r)? as usize;
+
+    let srs = PlonkSRSValue::Ref(unsafe { &(*srs) });
+    Ok(PlonkIndex {
+        cs,
+        srs,
+        max_poly_size,
+        max_quot_size,
+        fq_sponge_params,
+    })
+}
+
+pub fn write_plonk_verifier_index<'a, G: CommitmentCurve, W: Write>(
+    vk: *const PlonkVerifierIndex<'a, G>,
+    mut w: W,
+) -> IoResult<()>
+where
+    G::ScalarField: CommitmentField + ToBytes,
+{
+    let vk = unsafe { &(*vk) };
+    write_domain(&vk.domain, &mut w)?;
+    u64::write(&(vk.max_poly_size as u64), &mut w)?;
+    u64::write(&(vk.max_quot_size as u64), &mut w)?;
+
+    for i in 0..COLUMNS {write_poly_comm(&vk.sigma_comm[i], &mut w)?};
+    for i in 0..COLUMNS {write_poly_comm(&vk.qw_comm[i], &mut w)?};
+    write_poly_comm(&vk.qm_comm, &mut w)?;
+    write_poly_comm(&vk.qc_comm, &mut w)?;
+    for i in 0..COLUMNS {write_poly_comm(&vk.rcm_comm[i], &mut w)?};
+    write_poly_comm(&vk.psm_comm, &mut w)?;
+    write_poly_comm(&vk.add_comm, &mut w)?;
+    write_poly_comm(&vk.double_comm, &mut w)?;
+    write_poly_comm(&vk.mul1_comm, &mut w)?;
+    write_poly_comm(&vk.mul2_comm, &mut w)?;
+    write_poly_comm(&vk.emul_comm, &mut w)?;
+    write_poly_comm(&vk.pack_comm, &mut w)?;
+
+    for i in 1..COLUMNS {G::ScalarField::write(&vk.shift[i], &mut w)?};
+
+    Ok(())
+}
+
+pub fn read_plonk_verifier_index<'a, G: CommitmentCurve, R: Read>(
+    fr_sponge_params: ArithmeticSpongeParams<G::ScalarField>,
+    fq_sponge_params: ArithmeticSpongeParams<G::BaseField>,
+    endo: G::ScalarField,
+    srs: *const SRS<G>,
+    mut r: R,
+) -> IoResult<PlonkVerifierIndex<'a, G>>
+where
+    G::ScalarField: CommitmentField + FromBytes,
+{
+    let domain = read_domain(&mut r)?;
+    let max_poly_size = u64::read(&mut r)? as usize;
+    let max_quot_size = u64::read(&mut r)? as usize;
+
+    let sigma_comm = {
+        let c0 = read_poly_comm(&mut r)?;
+        let c1 = read_poly_comm(&mut r)?;
+        let c2 = read_poly_comm(&mut r)?;
+        let c3 = read_poly_comm(&mut r)?;
+        let c4 = read_poly_comm(&mut r)?;
+        [c0, c1, c2, c3, c4]
+    };
+    let qw_comm = {
+        let c0 = read_poly_comm(&mut r)?;
+        let c1 = read_poly_comm(&mut r)?;
+        let c2 = read_poly_comm(&mut r)?;
+        let c3 = read_poly_comm(&mut r)?;
+        let c4 = read_poly_comm(&mut r)?;
+        [c0, c1, c2, c3, c4]
+    };
+
+    let qm_comm = read_poly_comm(&mut r)?;
+    let qc_comm = read_poly_comm(&mut r)?;
+    let rcm_comm = {
+        let c0 = read_poly_comm(&mut r)?;
+        let c1 = read_poly_comm(&mut r)?;
+        let c2 = read_poly_comm(&mut r)?;
+        let c3 = read_poly_comm(&mut r)?;
+        let c4 = read_poly_comm(&mut r)?;
+        [c0, c1, c2, c3, c4]
+    };
+    let psm_comm = read_poly_comm(&mut r)?;
+    let add_comm = read_poly_comm(&mut r)?;
+    let double_comm = read_poly_comm(&mut r)?;
+    let mul1_comm = read_poly_comm(&mut r)?;
+    let mul2_comm = read_poly_comm(&mut r)?;
+    let emul_comm = read_poly_comm(&mut r)?;
+    let pack_comm = read_poly_comm(&mut r)?;
+
+    let shift = {
+        let c1 = G::ScalarField::read(&mut r)?;
+        let c2 = G::ScalarField::read(&mut r)?;
+        let c3 = G::ScalarField::read(&mut r)?;
+        let c4 = G::ScalarField::read(&mut r)?;
+        [G::ScalarField::one(), c1, c2, c3, c4]
+    };
+
+    let srs = PlonkSRSValue::Ref(unsafe { &(*srs) });
+    let vk = PlonkVerifierIndex {
+        domain,
+        w: zk_w(domain),
+        zkpm: zk_polynomial(domain),
+        max_poly_size,
+        max_quot_size,
+        srs,
+        sigma_comm,
+        qw_comm,
+        qm_comm,
+        qc_comm,
+        rcm_comm,
+        psm_comm,
+        add_comm,
+        double_comm,
+        mul1_comm,
+        mul2_comm,
+        emul_comm,
+        pack_comm,
+        shift,
+        fr_sponge_params,
+        fq_sponge_params,
+        endo,
+    };
+    Ok(vk)
+}
+
+pub fn write_plonk_constraint_system<G: CommitmentCurve, W: Write>(
+    c: &PlonkConstraintSystem<G::ScalarField>,
+    mut w: W,
+) -> IoResult<()>
+where
+    G::ScalarField: CommitmentField + FromBytes,
+{
+    (c.public as u64).write(&mut w)?;
+    {
+        let PlonkEvaluationDomains { d1, d4, d8 } = c.domain;
+        write_domain(&d1, &mut w)?;
+        write_domain(&d4, &mut w)?;
+        write_domain(&d8, &mut w)?;
+    };
+
+    write_vec(&c.gates, &mut w)?;
+
+    for i in 0..COLUMNS {write_dense_polynomial(&c.sigmam[i], &mut w)?};
+    for i in 0..COLUMNS {write_dense_polynomial(&c.qwm[i], &mut w)?};
+
+    write_dense_polynomial(&c.qmm, &mut w)?;
+    write_dense_polynomial(&c.qc, &mut w)?;
+
+    for i in 0..COLUMNS {write_dense_polynomial(&c.rcm[i], &mut w)?};
+
+    write_dense_polynomial(&c.psm, &mut w)?;
+    write_dense_polynomial(&c.addm, &mut w)?;
+    write_dense_polynomial(&c.doublem, &mut w)?;
+    write_dense_polynomial(&c.mul1m, &mut w)?;
+    write_dense_polynomial(&c.mul2m, &mut w)?;
+    write_dense_polynomial(&c.emulm, &mut w)?;
+    write_dense_polynomial(&c.packm, &mut w)?;
+
+    for i in 0..COLUMNS {write_plonk_evaluations(&c.qwl[i], &mut w)?};
+    write_plonk_evaluations(&c.qml, &mut w)?;
+
+    for i in 0..COLUMNS {write_vec(&c.sigmal1[i], &mut w)?};
+    for i in 0..COLUMNS {write_plonk_evaluations(&c.sigmal8[i], &mut w)?};
+
+    write_vec(&c.sid, &mut w)?;
+
+    write_plonk_evaluations(&c.ps4, &mut w)?;
+    write_plonk_evaluations(&c.ps8, &mut w)?;
+    write_plonk_evaluations(&c.addl, &mut w)?;
+    write_plonk_evaluations(&c.doublel, &mut w)?;
+    write_plonk_evaluations(&c.mul1l, &mut w)?;
+    write_plonk_evaluations(&c.mul2l, &mut w)?;
+    write_plonk_evaluations(&c.emull, &mut w)?;
+    write_plonk_evaluations(&c.packl, &mut w)?;
+
+    write_plonk_evaluations(&c.l1, &mut w)?;
+    write_plonk_evaluations(&c.l04, &mut w)?;
+    write_plonk_evaluations(&c.l08, &mut w)?;
+    write_plonk_evaluations(&c.zero4, &mut w)?;
+    write_plonk_evaluations(&c.zero8, &mut w)?;
+
+    for i in 1..COLUMNS {G::ScalarField::write(&c.shift[i], &mut w)?};
+    c.endo.write(&mut w)?;
+
+    Ok(())
+}
+
+pub fn read_plonk_constraint_system<G: CommitmentCurve, R: Read>(
+    fr_sponge_params: ArithmeticSpongeParams<G::ScalarField>,
+    mut r: R,
+) -> IoResult<PlonkConstraintSystem<G::ScalarField>>
+where
+    G::ScalarField: CommitmentField + FromBytes,
+{
+    let public = u64::read(&mut r)? as usize;
+    let domain = {
+        let d1 = read_domain(&mut r)?;
+        let d4 = read_domain(&mut r)?;
+        let d8 = read_domain(&mut r)?;
+        PlonkEvaluationDomains { d1, d4, d8 }
+    };
+
+    let gates = read_vec(&mut r)?;
+
+    let sigmam = {
+        let s0 = read_dense_polynomial(&mut r)?;
+        let s1 = read_dense_polynomial(&mut r)?;
+        let s2 = read_dense_polynomial(&mut r)?;
+        let s3 = read_dense_polynomial(&mut r)?;
+        let s4 = read_dense_polynomial(&mut r)?;
+        [s0, s1, s2, s3, s4]
+    };
+
+    let qwm = {
+        let s0 = read_dense_polynomial(&mut r)?;
+        let s1 = read_dense_polynomial(&mut r)?;
+        let s2 = read_dense_polynomial(&mut r)?;
+        let s3 = read_dense_polynomial(&mut r)?;
+        let s4 = read_dense_polynomial(&mut r)?;
+        [s0, s1, s2, s3, s4]
+    };
+    let qmm = read_dense_polynomial(&mut r)?;
+    let qc = read_dense_polynomial(&mut r)?;
+
+    let rcm =  {
+        let s0 = read_dense_polynomial(&mut r)?;
+        let s1 = read_dense_polynomial(&mut r)?;
+        let s2 = read_dense_polynomial(&mut r)?;
+        let s3 = read_dense_polynomial(&mut r)?;
+        let s4 = read_dense_polynomial(&mut r)?;
+        [s0, s1, s2, s3, s4]
+    };
+
+    let psm = read_dense_polynomial(&mut r)?;
+    let addm = read_dense_polynomial(&mut r)?;
+    let doublem = read_dense_polynomial(&mut r)?;
+    let mul1m = read_dense_polynomial(&mut r)?;
+    let mul2m = read_dense_polynomial(&mut r)?;
+    let emulm = read_dense_polynomial(&mut r)?;
+    let packm = read_dense_polynomial(&mut r)?;
+
+    let qwl = {
+        let s0 = read_plonk_evaluations(&mut r)?;
+        let s1 = read_plonk_evaluations(&mut r)?;
+        let s2 = read_plonk_evaluations(&mut r)?;
+        let s3 = read_plonk_evaluations(&mut r)?;
+        let s4 = read_plonk_evaluations(&mut r)?;
+        [s0, s1, s2, s3, s4]
+    };
+    let qml = read_plonk_evaluations(&mut r)?;
+
+    let sigmal1 = {
+        let s0 = read_vec(&mut r)?;
+        let s1 = read_vec(&mut r)?;
+        let s2 = read_vec(&mut r)?;
+        let s3 = read_vec(&mut r)?;
+        let s4 = read_vec(&mut r)?;
+        [s0, s1, s2, s3, s4]
+    };
+
+    let sigmal8 = {
+        let s0 = read_plonk_evaluations(&mut r)?;
+        let s1 = read_plonk_evaluations(&mut r)?;
+        let s2 = read_plonk_evaluations(&mut r)?;
+        let s3 = read_plonk_evaluations(&mut r)?;
+        let s4 = read_plonk_evaluations(&mut r)?;
+        [s0, s1, s2, s3, s4]
+    };
+
+    let sid = read_vec(&mut r)?;
+
+    let ps4 = read_plonk_evaluations(&mut r)?;
+    let ps8 = read_plonk_evaluations(&mut r)?;
+
+    let addl = read_plonk_evaluations(&mut r)?;
+    let doublel = read_plonk_evaluations(&mut r)?;
+    let mul1l = read_plonk_evaluations(&mut r)?;
+    let mul2l = read_plonk_evaluations(&mut r)?;
+    let emull = read_plonk_evaluations(&mut r)?;
+    let packl = read_plonk_evaluations(&mut r)?;
+
+    let l1 = read_plonk_evaluations(&mut r)?;
+    let l04 = read_plonk_evaluations(&mut r)?;
+    let l08 = read_plonk_evaluations(&mut r)?;
+    let zero4 = read_plonk_evaluations(&mut r)?;
+    let zero8 = read_plonk_evaluations(&mut r)?;
+
+    let shift = {
+        let c1 = G::ScalarField::read(&mut r)?;
+        let c2 = G::ScalarField::read(&mut r)?;
+        let c3 = G::ScalarField::read(&mut r)?;
+        let c4 = G::ScalarField::read(&mut r)?;
+        [G::ScalarField::one(), c1, c2, c3, c4]
+    };
+    let endo = G::ScalarField::read(&mut r)?;
+
+    let zkpm = zk_polynomial(domain.d1);
+    let zkpl = zkpm.evaluate_over_domain_by_ref(domain.d8);
+    Ok(PlonkConstraintSystem {
+        zkpm,
+        zkpl,
+        public,
+        domain,
+        gates,
+        sigmam,
+        qwm,
+        qmm,
+        qc,
+        rcm,
+        psm,
+        addm,
+        doublem,
+        mul1m,
+        mul2m,
+        emulm,
+        packm,
+        qwl,
+        qml,
+        sigmal1,
+        sigmal8,
+        sid,
+        ps4,
+        ps8,
+        addl,
+        doublel,
+        mul1l,
+        mul2l,
+        emull,
+        packl,
+        l04,
+        l08,
+        l1,
+        zero4,
+        zero8,
+        shift,
+        endo,
+        fr_sponge_params,
+    })
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/index_serialization_5_wires.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/index_serialization_5_wires.rs
@@ -1,8 +1,7 @@
 use algebra::{
-    One,
     curves::AffineCurve,
     fields::{Field, PrimeField},
-    FromBytes, ToBytes,
+    FromBytes, One, ToBytes,
 };
 
 use commitment_dlog::{
@@ -12,9 +11,9 @@ use commitment_dlog::{
 use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as Domain};
 use oracle::poseidon::ArithmeticSpongeParams;
 use plonk_5_wires_circuits::{
-    wires::COLUMNS,
     constraints::{zk_polynomial, zk_w, ConstraintSystem as PlonkConstraintSystem},
     domains::EvaluationDomains as PlonkEvaluationDomains,
+    wires::COLUMNS,
 };
 use plonk_5_wires_protocol_dlog::index::{
     Index as PlonkIndex, SRSValue as PlonkSRSValue, VerifierIndex as PlonkVerifierIndex,
@@ -165,11 +164,17 @@ where
     u64::write(&(vk.max_poly_size as u64), &mut w)?;
     u64::write(&(vk.max_quot_size as u64), &mut w)?;
 
-    for i in 0..COLUMNS {write_poly_comm(&vk.sigma_comm[i], &mut w)?};
-    for i in 0..COLUMNS {write_poly_comm(&vk.qw_comm[i], &mut w)?};
+    for i in 0..COLUMNS {
+        write_poly_comm(&vk.sigma_comm[i], &mut w)?
+    }
+    for i in 0..COLUMNS {
+        write_poly_comm(&vk.qw_comm[i], &mut w)?
+    }
     write_poly_comm(&vk.qm_comm, &mut w)?;
     write_poly_comm(&vk.qc_comm, &mut w)?;
-    for i in 0..COLUMNS {write_poly_comm(&vk.rcm_comm[i], &mut w)?};
+    for i in 0..COLUMNS {
+        write_poly_comm(&vk.rcm_comm[i], &mut w)?
+    }
     write_poly_comm(&vk.psm_comm, &mut w)?;
     write_poly_comm(&vk.add_comm, &mut w)?;
     write_poly_comm(&vk.double_comm, &mut w)?;
@@ -178,7 +183,9 @@ where
     write_poly_comm(&vk.emul_comm, &mut w)?;
     write_poly_comm(&vk.pack_comm, &mut w)?;
 
-    for i in 1..COLUMNS {G::ScalarField::write(&vk.shift[i], &mut w)?};
+    for i in 1..COLUMNS {
+        G::ScalarField::write(&vk.shift[i], &mut w)?
+    }
 
     Ok(())
 }
@@ -285,13 +292,19 @@ where
 
     write_vec(&c.gates, &mut w)?;
 
-    for i in 0..COLUMNS {write_dense_polynomial(&c.sigmam[i], &mut w)?};
-    for i in 0..COLUMNS {write_dense_polynomial(&c.qwm[i], &mut w)?};
+    for i in 0..COLUMNS {
+        write_dense_polynomial(&c.sigmam[i], &mut w)?
+    }
+    for i in 0..COLUMNS {
+        write_dense_polynomial(&c.qwm[i], &mut w)?
+    }
 
     write_dense_polynomial(&c.qmm, &mut w)?;
     write_dense_polynomial(&c.qc, &mut w)?;
 
-    for i in 0..COLUMNS {write_dense_polynomial(&c.rcm[i], &mut w)?};
+    for i in 0..COLUMNS {
+        write_dense_polynomial(&c.rcm[i], &mut w)?
+    }
 
     write_dense_polynomial(&c.psm, &mut w)?;
     write_dense_polynomial(&c.addm, &mut w)?;
@@ -301,11 +314,17 @@ where
     write_dense_polynomial(&c.emulm, &mut w)?;
     write_dense_polynomial(&c.packm, &mut w)?;
 
-    for i in 0..COLUMNS {write_plonk_evaluations(&c.qwl[i], &mut w)?};
+    for i in 0..COLUMNS {
+        write_plonk_evaluations(&c.qwl[i], &mut w)?
+    }
     write_plonk_evaluations(&c.qml, &mut w)?;
 
-    for i in 0..COLUMNS {write_vec(&c.sigmal1[i], &mut w)?};
-    for i in 0..COLUMNS {write_plonk_evaluations(&c.sigmal8[i], &mut w)?};
+    for i in 0..COLUMNS {
+        write_vec(&c.sigmal1[i], &mut w)?
+    }
+    for i in 0..COLUMNS {
+        write_plonk_evaluations(&c.sigmal8[i], &mut w)?
+    }
 
     write_vec(&c.sid, &mut w)?;
 
@@ -324,7 +343,9 @@ where
     write_plonk_evaluations(&c.zero4, &mut w)?;
     write_plonk_evaluations(&c.zero8, &mut w)?;
 
-    for i in 1..COLUMNS {G::ScalarField::write(&c.shift[i], &mut w)?};
+    for i in 1..COLUMNS {
+        G::ScalarField::write(&c.shift[i], &mut w)?
+    }
     c.endo.write(&mut w)?;
 
     Ok(())
@@ -367,7 +388,7 @@ where
     let qmm = read_dense_polynomial(&mut r)?;
     let qc = read_dense_polynomial(&mut r)?;
 
-    let rcm =  {
+    let rcm = {
         let s0 = read_dense_polynomial(&mut r)?;
         let s1 = read_dense_polynomial(&mut r)?;
         let s2 = read_dense_polynomial(&mut r)?;

--- a/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
@@ -32,6 +32,7 @@ pub mod pasta_fq_urs;
 pub mod urs_utils;
 /* Gates */
 pub mod plonk_gate;
+pub mod plonk_5_wires_gate;
 /* Indices */
 pub mod index_serialization;
 pub mod index_serialization_5_wires;

--- a/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
@@ -37,6 +37,7 @@ pub mod plonk_5_wires_gate;
 pub mod index_serialization;
 pub mod index_serialization_5_wires;
 pub mod plonk_verifier_index;
+pub mod plonk_5_wires_verifier_index;
 pub mod tweedle_fp_plonk_index;
 pub mod tweedle_fp_plonk_verifier_index;
 pub mod tweedle_fq_plonk_index;
@@ -46,6 +47,7 @@ pub mod pasta_fp_plonk_verifier_index;
 pub mod pasta_fq_plonk_index;
 pub mod pasta_fq_plonk_verifier_index;
 pub mod pasta_fp_plonk_5_wires_index;
+pub mod pasta_fp_plonk_5_wires_verifier_index;
 /* Proofs */
 pub mod tweedle_fp_plonk_proof;
 pub mod tweedle_fq_plonk_proof;

--- a/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
@@ -34,6 +34,7 @@ pub mod urs_utils;
 pub mod plonk_gate;
 /* Indices */
 pub mod index_serialization;
+pub mod index_serialization_5_wires;
 pub mod plonk_verifier_index;
 pub mod tweedle_fp_plonk_index;
 pub mod tweedle_fp_plonk_verifier_index;

--- a/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
@@ -48,12 +48,15 @@ pub mod pasta_fq_plonk_index;
 pub mod pasta_fq_plonk_verifier_index;
 pub mod pasta_fp_plonk_5_wires_index;
 pub mod pasta_fp_plonk_5_wires_verifier_index;
+pub mod pasta_fq_plonk_5_wires_index;
+pub mod pasta_fq_plonk_5_wires_verifier_index;
 /* Proofs */
 pub mod tweedle_fp_plonk_proof;
 pub mod tweedle_fq_plonk_proof;
 pub mod pasta_fp_plonk_proof;
 pub mod pasta_fq_plonk_proof;
 pub mod pasta_fp_plonk_5_wires_proof;
+pub mod pasta_fq_plonk_5_wires_proof;
 /* Oracles */
 pub mod tweedle_fp_plonk_oracles;
 pub mod tweedle_fq_plonk_oracles;

--- a/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
@@ -45,6 +45,7 @@ pub mod pasta_fp_plonk_index;
 pub mod pasta_fp_plonk_verifier_index;
 pub mod pasta_fq_plonk_index;
 pub mod pasta_fq_plonk_verifier_index;
+pub mod pasta_fp_plonk_5_wires_index;
 /* Proofs */
 pub mod tweedle_fp_plonk_proof;
 pub mod tweedle_fq_plonk_proof;

--- a/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
@@ -53,6 +53,7 @@ pub mod tweedle_fp_plonk_proof;
 pub mod tweedle_fq_plonk_proof;
 pub mod pasta_fp_plonk_proof;
 pub mod pasta_fq_plonk_proof;
+pub mod pasta_fp_plonk_5_wires_proof;
 /* Oracles */
 pub mod tweedle_fp_plonk_oracles;
 pub mod tweedle_fq_plonk_oracles;

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_5_wires_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_5_wires_index.rs
@@ -1,0 +1,232 @@
+#[allow(unused_imports)]
+use algebra::pasta::{
+    fp::Fp,
+    pallas::Affine as GAffineOther,
+    vesta::{Affine as GAffine, VestaParameters},
+};
+
+use plonk_5_wires_circuits::constraints::ConstraintSystem;
+use plonk_5_wires_circuits::gate::CircuitGate;
+use plonk_5_wires_circuits::wires::Wire;
+
+use ff_fft::EvaluationDomain;
+
+use commitment_dlog::srs::SRS;
+use plonk_5_wires_protocol_dlog::index::{Index as DlogIndex, SRSSpec};
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
+    rc::Rc,
+};
+
+use crate::index_serialization_5_wires;
+use crate::pasta_fp_urs::CamlPastaFpUrs;
+use crate::plonk_5_wires_gate::{CamlPlonkGate, CamlPlonkWire, CamlPlonkWires};
+
+pub struct CamlPastaFpPlonkGateVector(Vec<CircuitGate<Fp>>);
+pub type CamlPastaFpPlonkGateVectorPtr = ocaml::Pointer<CamlPastaFpPlonkGateVector>;
+
+extern "C" fn caml_pasta_fp_plonk_5_wires_gate_vector_finalize(v: ocaml::Value) {
+    let v: CamlPastaFpPlonkGateVectorPtr = ocaml::FromValue::from_value(v);
+    unsafe { v.drop_in_place() };
+}
+
+ocaml::custom!(CamlPastaFpPlonkGateVector {
+    finalize: caml_pasta_fp_plonk_5_wires_gate_vector_finalize,
+});
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_gate_vector_create() -> CamlPastaFpPlonkGateVector {
+    CamlPastaFpPlonkGateVector(Vec::new())
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_gate_vector_add(
+    mut v: CamlPastaFpPlonkGateVectorPtr,
+    gate: CamlPlonkGate<Vec<Fp>>,
+) {
+    v.as_mut().0.push(CircuitGate {
+        typ: gate.typ.into(),
+        row: gate.row as usize,
+        wires: [
+            gate.wires.l.into(),
+            gate.wires.r.into(),
+            gate.wires.o.into(),
+            gate.wires.q.into(),
+            gate.wires.p.into()
+        ],
+        c: gate.c,
+    });
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_gate_vector_get(
+    v: CamlPastaFpPlonkGateVectorPtr,
+    i: ocaml::Int,
+) -> CamlPlonkGate<Vec<Fp>> {
+    let gate = &(v.as_ref().0)[i as usize];
+    let c = gate.c.iter().map(|x| *x).collect();
+    CamlPlonkGate {
+        typ: (&gate.typ).into(),
+        row: gate.row as isize,
+        wires: CamlPlonkWires
+        {
+            l: (&gate.wires[0]).into(),
+            r: (&gate.wires[1]).into(),
+            o: (&gate.wires[2]).into(),
+            q: (&gate.wires[3]).into(),
+            p: (&gate.wires[4]).into(),
+        },
+        c,
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_gate_vector_wrap
+(
+    mut v: CamlPastaFpPlonkGateVectorPtr,
+    t: CamlPlonkWire,
+    h: CamlPlonkWire,
+)
+{
+    (v.as_mut().0)[t.row as usize].wires[t.col as usize] =
+        Wire
+        {
+            row: h.row as usize,
+            col: h.col as usize,
+        };
+}
+
+/* Boxed so that we don't store large proving indexes in the OCaml heap. */
+
+pub struct CamlPastaFpPlonkIndex<'a>(pub Box<DlogIndex<'a, GAffine>>, pub Rc<SRS<GAffine>>);
+pub type CamlPastaFpPlonkIndexPtr<'a> = ocaml::Pointer<CamlPastaFpPlonkIndex<'a>>;
+
+extern "C" fn caml_pasta_fp_plonk_5_wires_index_finalize(v: ocaml::Value) {
+    let mut v: CamlPastaFpPlonkIndexPtr = ocaml::FromValue::from_value(v);
+    unsafe {
+        v.as_mut_ptr().drop_in_place();
+    }
+}
+
+ocaml::custom!(CamlPastaFpPlonkIndex<'a> {
+    finalize: caml_pasta_fp_plonk_5_wires_index_finalize,
+});
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_index_create(
+    gates: CamlPastaFpPlonkGateVectorPtr,
+    public: ocaml::Int,
+    urs: CamlPastaFpUrs,
+) -> Result<CamlPastaFpPlonkIndex<'static>, ocaml::Error> {
+    let gates: Vec<_> = gates.as_ref().0.clone();
+    let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
+    let cs =
+        match ConstraintSystem::<Fp>::create(gates, oracle::pasta::fp5::params(), public as usize)
+        {
+            None => Err(ocaml::Error::failwith(
+                "caml_pasta_fp_plonk_5_wires_index_create: could not create constraint system",
+            )
+            .err()
+            .unwrap())?,
+            Some(cs) => cs,
+        };
+    let urs_copy = Rc::clone(&*urs);
+    let urs_copy_outer = Rc::clone(&*urs);
+    let srs = {
+        // We know that the underlying value is still alive, because we never convert any of our
+        // Rc<_>s into weak pointers.
+        SRSSpec::Use(unsafe { &*Rc::into_raw(urs_copy) })
+    };
+    Ok(CamlPastaFpPlonkIndex(
+        Box::new(DlogIndex::<GAffine>::create(
+            cs,
+            oracle::pasta::fq5::params(),
+            endo_q,
+            srs,
+        )),
+        urs_copy_outer,
+    ))
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_index_max_degree(index: CamlPastaFpPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.srs.get_ref().max_degree() as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_index_public_inputs(index: CamlPastaFpPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.cs.public as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_index_domain_d1_size(index: CamlPastaFpPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.cs.domain.d1.size() as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_index_domain_d4_size(index: CamlPastaFpPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.cs.domain.d4.size() as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_index_domain_d8_size(index: CamlPastaFpPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.cs.domain.d8.size() as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_index_read(
+    offset: Option<ocaml::Int>,
+    urs: CamlPastaFpUrs,
+    path: String,
+) -> Result<CamlPastaFpPlonkIndex<'static>, ocaml::Error> {
+    let file = match File::open(path) {
+        Err(_) => Err(
+            ocaml::Error::invalid_argument("caml_pasta_fp_plonk_5_wires_index_read")
+                .err()
+                .unwrap(),
+        )?,
+        Ok(file) => file,
+    };
+    let mut r = BufReader::new(file);
+    match offset {
+        Some(offset) => {
+            r.seek(Start(offset as u64))?;
+        }
+        None => (),
+    };
+    let urs_copy = Rc::clone(&*urs);
+    let urs_copy_outer = Rc::clone(&*urs);
+    let srs = {
+        // We know that the underlying value is still alive, because we never convert any of our
+        // Rc<_>s into weak pointers.
+        unsafe { &*Rc::into_raw(urs_copy) }
+    };
+    let t = index_serialization_5_wires::read_plonk_index(
+        oracle::pasta::fp5::params(),
+        oracle::pasta::fq5::params(),
+        srs,
+        &mut r,
+    )?;
+    Ok(CamlPastaFpPlonkIndex(Box::new(t), urs_copy_outer))
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_index_write(
+    append: Option<bool>,
+    index: CamlPastaFpPlonkIndexPtr<'static>,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    let file = match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
+        Err(_) => Err(
+            ocaml::Error::invalid_argument("caml_pasta_fp_plonk_5_wires_index_write")
+                .err()
+                .unwrap(),
+        )?,
+        Ok(file) => file,
+    };
+    let mut w = BufWriter::new(file);
+    index_serialization_5_wires::write_plonk_index(&index.as_ref().0, &mut w)?;
+    Ok(())
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_5_wires_proof.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_5_wires_proof.rs
@@ -1,0 +1,176 @@
+use algebra::{
+    curves::AffineCurve,
+    pasta::{
+        vesta::{Affine as GAffine, VestaParameters},
+        fp::Fp,
+        fq::Fq,
+    },
+    One,
+};
+
+use plonk_5_wires_circuits::scalars::ProofEvaluations as DlogProofEvaluations;
+
+use oracle::{
+    poseidon_5_wires::PlonkSpongeConstants,
+    sponge_5_wires::{DefaultFqSponge, DefaultFrSponge},
+};
+
+use groupmap::GroupMap;
+
+use commitment_dlog::commitment::{CommitmentCurve, OpeningProof, PolyComm};
+use plonk_5_wires_protocol_dlog::index::{Index as DlogIndex, VerifierIndex as DlogVerifierIndex};
+use plonk_5_wires_protocol_dlog::prover::{ProverCommitments as DlogCommitments, ProverProof as DlogProof};
+
+use crate::pasta_fp_plonk_5_wires_index::CamlPastaFpPlonkIndexPtr;
+use crate::pasta_fp_plonk_5_wires_verifier_index::CamlPastaFpPlonkVerifierIndex;
+use crate::pasta_fp_vector::CamlPastaFpVector;
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_proof_create(
+    index: CamlPastaFpPlonkIndexPtr<'static>,
+    primary_input: CamlPastaFpVector,
+    auxiliary_input: (Vec<Fp>, Vec<Fp>, Vec<Fp>, Vec<Fp>, Vec<Fp>),
+    prev_challenges: Vec<Fp>,
+    prev_sgs: Vec<GAffine>,
+) -> DlogProof<GAffine> {
+    // TODO: Should we be ignoring this?!
+    let _primary_input = primary_input;
+
+    let prev: Vec<(Vec<Fp>, PolyComm<GAffine>)> = {
+        if prev_challenges.len() == 0 {
+            Vec::new()
+        } else {
+            let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
+            prev_sgs
+                .into_iter()
+                .enumerate()
+                .map(|(i, sg)| {
+                    (
+                        prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                            .iter()
+                            .map(|x| *x)
+                            .collect(),
+                        PolyComm::<GAffine> {
+                            unshifted: vec![sg.into()],
+                            shifted: None,
+                        },
+                    )
+                })
+                .collect()
+        }
+    };
+
+    let witness = [auxiliary_input.0, auxiliary_input.1, auxiliary_input.2, auxiliary_input.3, auxiliary_input.4];
+    let index: &DlogIndex<GAffine> = &index.as_ref().0;
+
+    ocaml::runtime::release_lock();
+
+    let map = GroupMap::<Fq>::setup();
+    let proof = DlogProof::create::<
+        DefaultFqSponge<VestaParameters, PlonkSpongeConstants>,
+        DefaultFrSponge<Fp, PlonkSpongeConstants>,
+    >(&map, &witness, index, prev)
+    .unwrap();
+
+    ocaml::runtime::acquire_lock();
+
+    proof
+}
+
+pub fn proof_verify(
+    lgr_comm: Vec<PolyComm<GAffine>>,
+    index: &DlogVerifierIndex<GAffine>,
+    proof: DlogProof<GAffine>,
+) -> bool {
+    let group_map = <GAffine as CommitmentCurve>::Map::setup();
+
+    DlogProof::verify::<
+        DefaultFqSponge<VestaParameters, PlonkSpongeConstants>,
+        DefaultFrSponge<Fp, PlonkSpongeConstants>,
+    >(
+        &group_map,
+        &[(
+            index,
+            &lgr_comm.into_iter().map(From::from).collect(),
+            &proof,
+        )]
+        .to_vec(),
+    )
+    .is_ok()
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_proof_verify(
+    lgr_comm: Vec<PolyComm<GAffine>>,
+    index: CamlPastaFpPlonkVerifierIndex,
+    proof: DlogProof<GAffine>,
+) -> bool {
+    proof_verify(lgr_comm, &index.into(), proof)
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_proof_batch_verify(
+    lgr_comms: Vec<Vec<PolyComm<GAffine>>>,
+    indexes: Vec<CamlPastaFpPlonkVerifierIndex>,
+    proofs: Vec<DlogProof<GAffine>>,
+) -> bool {
+    let ts: Vec<_> = indexes
+        .into_iter()
+        .zip(lgr_comms.into_iter())
+        .zip(proofs.into_iter())
+        .map(|((i, l), p)| (i.into(), l.into_iter().map(From::from).collect(), p.into()))
+        .collect();
+    let ts: Vec<_> = ts.iter().map(|(i, l, p)| (i, l, p)).collect();
+    let group_map = GroupMap::<Fq>::setup();
+
+    DlogProof::<GAffine>::verify::<
+        DefaultFqSponge<VestaParameters, PlonkSpongeConstants>,
+        DefaultFrSponge<Fp, PlonkSpongeConstants>,
+    >(&group_map, &ts)
+    .is_ok()
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_proof_dummy() -> DlogProof<GAffine> {
+    let g = || GAffine::prime_subgroup_generator();
+    let comm = || PolyComm {
+        shifted: Some(g()),
+        unshifted: vec![g(), g(), g()],
+    };
+    DlogProof {
+        prev_challenges: vec![
+            (vec![Fp::one(), Fp::one()], comm()),
+            (vec![Fp::one(), Fp::one()], comm()),
+            (vec![Fp::one(), Fp::one()], comm()),
+        ],
+        proof: OpeningProof {
+            lr: vec![(g(), g()), (g(), g()), (g(), g())],
+            z1: Fp::one(),
+            z2: Fp::one(),
+            delta: g(),
+            sg: g(),
+        },
+        commitments: DlogCommitments {
+            w_comm: [comm(), comm(), comm(), comm(), comm()],
+            z_comm: comm(),
+            t_comm: comm(),
+        },
+        public: vec![Fp::one(), Fp::one()],
+        evals: {
+            let evals = || vec![Fp::one(), Fp::one(), Fp::one(), Fp::one()];
+            let evals = || DlogProofEvaluations {
+                w: [evals(), evals(), evals(), evals(), evals()],
+                z: evals(),
+                t: evals(),
+                f: evals(),
+                s: [evals(), evals(), evals(), evals()],
+            };
+            [evals(), evals()]
+        },
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_proof_deep_copy(x: DlogProof<GAffine>) -> DlogProof<GAffine> {
+    x
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_5_wires_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_5_wires_verifier_index.rs
@@ -1,0 +1,364 @@
+use crate::caml_pointer;
+use crate::index_serialization_5_wires;
+use crate::plonk_verifier_index::{CamlPlonkDomain};
+use crate::plonk_5_wires_verifier_index::{
+    CamlPlonkVerificationEvals, CamlPlonkVerificationShifts,
+    CamlPlonkVerifierIndex,
+};
+use crate::pasta_fp_plonk_5_wires_index::CamlPastaFpPlonkIndexPtr;
+use crate::pasta_fp_urs::CamlPastaFpUrs;
+use algebra::{
+    curves::AffineCurve,
+    pasta::{vesta::Affine as GAffine, pallas::Affine as GAffineOther, fp::Fp},
+    One,
+};
+
+use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};
+
+use commitment_dlog::{commitment::PolyComm, srs::SRS};
+use plonk_5_wires_circuits::constraints::{zk_polynomial, zk_w, ConstraintSystem};
+use plonk_5_wires_protocol_dlog::index::{SRSValue, VerifierIndex as DlogVerifierIndex};
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
+};
+
+use std::rc::Rc;
+
+pub type CamlPastaFpPlonkVerifierIndex =
+    CamlPlonkVerifierIndex<Fp, CamlPastaFpUrs, PolyComm<GAffine>>;
+
+pub fn to_ocaml<'a>(
+    urs: &Rc<SRS<GAffine>>,
+    vi: DlogVerifierIndex<'a, GAffine>,
+) -> CamlPastaFpPlonkVerifierIndex {
+    let [sigma_comm0, sigma_comm1, sigma_comm2, sigma_comm3, sigma_comm4] = vi.sigma_comm;
+    let [rcm_comm0, rcm_comm1, rcm_comm2, rcm_comm3, rcm_comm4] = vi.rcm_comm;
+    let [ql_comm, qr_comm, qo_comm, qq_comm, qp_comm] = vi.qw_comm;
+    let [s0, s1, s2, s3, s4] = vi.shift;
+    CamlPlonkVerifierIndex {
+        domain: CamlPlonkDomain {
+            log_size_of_group: vi.domain.log_size_of_group as isize,
+            group_gen: vi.domain.group_gen,
+        },
+        max_poly_size: vi.max_poly_size as isize,
+        max_quot_size: vi.max_quot_size as isize,
+        urs: caml_pointer::create(Rc::clone(urs)),
+        evals: CamlPlonkVerificationEvals {
+            sigma_comm0: sigma_comm0,
+            sigma_comm1: sigma_comm1,
+            sigma_comm2: sigma_comm2,
+            sigma_comm3: sigma_comm3,
+            sigma_comm4: sigma_comm4,
+            ql_comm: ql_comm,
+            qr_comm: qr_comm,
+            qo_comm: qo_comm,
+            qq_comm: qq_comm,
+            qp_comm: qp_comm,
+            qm_comm: vi.qm_comm,
+            qc_comm: vi.qc_comm,
+            rcm_comm0: rcm_comm0,
+            rcm_comm1: rcm_comm1,
+            rcm_comm2: rcm_comm2,
+            rcm_comm3: rcm_comm3,
+            rcm_comm4: rcm_comm4,
+            psm_comm: vi.psm_comm,
+            add_comm: vi.add_comm,
+            double_comm: vi.double_comm,
+            mul1_comm: vi.mul1_comm,
+            mul2_comm: vi.mul2_comm,
+            emul_comm: vi.emul_comm,
+            pack_comm: vi.pack_comm,
+        },
+        shifts: CamlPlonkVerificationShifts {
+            s0: s0,
+            s1: s1,
+            s2: s2,
+            s3: s3,
+            s4: s4,
+        },
+    }
+}
+
+pub fn to_ocaml_copy<'a>(
+    urs: &Rc<SRS<GAffine>>,
+    vi: &DlogVerifierIndex<'a, GAffine>,
+) -> CamlPastaFpPlonkVerifierIndex {
+    let [sigma_comm0, sigma_comm1, sigma_comm2, sigma_comm3, sigma_comm4] = &vi.sigma_comm;
+    let [rcm_comm0, rcm_comm1, rcm_comm2, rcm_comm3, rcm_comm4] = &vi.rcm_comm;
+    let [ql_comm, qr_comm, qo_comm, qq_comm, qp_comm] = &vi.qw_comm;
+    let [s0, s1, s2, s3, s4] = vi.shift;
+    CamlPlonkVerifierIndex {
+        domain: CamlPlonkDomain {
+            log_size_of_group: vi.domain.log_size_of_group as isize,
+            group_gen: vi.domain.group_gen,
+        },
+        max_poly_size: vi.max_poly_size as isize,
+        max_quot_size: vi.max_quot_size as isize,
+        urs: caml_pointer::create(Rc::clone(urs)),
+        evals: CamlPlonkVerificationEvals {
+            sigma_comm0: sigma_comm0.clone(),
+            sigma_comm1: sigma_comm1.clone(),
+            sigma_comm2: sigma_comm2.clone(),
+            sigma_comm3: sigma_comm3.clone(),
+            sigma_comm4: sigma_comm4.clone(),
+            ql_comm: ql_comm.clone(),
+            qr_comm: qr_comm.clone(),
+            qo_comm: qo_comm.clone(),
+            qq_comm: qq_comm.clone(),
+            qp_comm: qp_comm.clone(),
+            qm_comm: vi.qm_comm.clone(),
+            qc_comm: vi.qc_comm.clone(),
+            rcm_comm0: rcm_comm0.clone(),
+            rcm_comm1: rcm_comm1.clone(),
+            rcm_comm2: rcm_comm2.clone(),
+            rcm_comm3: rcm_comm3.clone(),
+            rcm_comm4: rcm_comm4.clone(),
+            psm_comm: vi.psm_comm.clone(),
+            add_comm: vi.add_comm.clone(),
+            double_comm: vi.double_comm.clone(),
+            mul1_comm: vi.mul1_comm.clone(),
+            mul2_comm: vi.mul2_comm.clone(),
+            emul_comm: vi.emul_comm.clone(),
+            pack_comm: vi.pack_comm.clone(),
+        },
+        shifts: CamlPlonkVerificationShifts {
+            s0: s0,
+            s1: s1,
+            s2: s2,
+            s3: s3,
+            s4: s4,
+        },
+    }
+}
+
+pub fn of_ocaml<'a>(
+    max_poly_size: ocaml::Int,
+    max_quot_size: ocaml::Int,
+    log_size_of_group: ocaml::Int,
+    urs: CamlPastaFpUrs,
+    evals: CamlPlonkVerificationEvals<PolyComm<GAffine>>,
+    shifts: CamlPlonkVerificationShifts<Fp>,
+) -> (DlogVerifierIndex<'a, GAffine>, Rc<SRS<GAffine>>) {
+    let urs_copy = Rc::clone(&*urs);
+    let urs_copy_outer = Rc::clone(&*urs);
+    let srs = {
+        // We know that the underlying value is still alive, because we never convert any of our
+        // Rc<_>s into weak pointers.
+        SRSValue::Ref(unsafe { &*Rc::into_raw(urs_copy) })
+    };
+    let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
+    let domain = Domain::<Fp>::new(1 << log_size_of_group).unwrap();
+    let index = DlogVerifierIndex::<GAffine> {
+        domain,
+        w: zk_w(domain),
+        zkpm: zk_polynomial(domain),
+        max_poly_size: max_poly_size as usize,
+        max_quot_size: max_quot_size as usize,
+        srs,
+        sigma_comm: [
+            evals.sigma_comm0,
+            evals.sigma_comm1,
+            evals.sigma_comm2,
+            evals.sigma_comm3,
+            evals.sigma_comm4,
+        ],
+        qw_comm: [
+            evals.ql_comm,
+            evals.qr_comm,
+            evals.qo_comm,
+            evals.qq_comm,
+            evals.qp_comm,
+        ],
+        qm_comm: evals.qm_comm,
+        qc_comm: evals.qc_comm,
+        rcm_comm: [
+            evals.rcm_comm0,
+            evals.rcm_comm1,
+            evals.rcm_comm2,
+            evals.rcm_comm3,
+            evals.rcm_comm4,
+        ],
+        psm_comm: evals.psm_comm,
+        add_comm: evals.add_comm,
+        double_comm: evals.double_comm,
+        mul1_comm: evals.mul1_comm,
+        mul2_comm: evals.mul2_comm,
+        emul_comm: evals.emul_comm,
+        pack_comm: evals.pack_comm,
+        shift: [shifts.s0, shifts.s1, shifts.s2, shifts.s3, shifts.s4],
+        fr_sponge_params: oracle::pasta::fp5::params(),
+        fq_sponge_params: oracle::pasta::fq5::params(),
+        endo: endo_q,
+    };
+    (index, urs_copy_outer)
+}
+
+impl From<CamlPastaFpPlonkVerifierIndex> for DlogVerifierIndex<'_, GAffine> {
+    fn from(index: CamlPastaFpPlonkVerifierIndex) -> Self {
+        of_ocaml(
+            index.max_poly_size,
+            index.max_quot_size,
+            index.domain.log_size_of_group,
+            index.urs,
+            index.evals,
+            index.shifts,
+        )
+        .0
+    }
+}
+
+pub fn read_raw<'a>(
+    offset: Option<ocaml::Int>,
+    urs: CamlPastaFpUrs,
+    path: String,
+) -> Result<(DlogVerifierIndex<'a, GAffine>, Rc<SRS<GAffine>>), ocaml::Error> {
+    match File::open(path) {
+        Err(_) => Err(ocaml::Error::invalid_argument(
+            "caml_pasta_fp_plonk_5_wires_verifier_index_raw_read",
+        )
+        .err()
+        .unwrap()),
+        Ok(file) => {
+            let mut r = BufReader::new(file);
+            match offset {
+                Some(offset) => {
+                    r.seek(Start(offset as u64))?;
+                }
+                None => (),
+            };
+            let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
+            let urs_copy = Rc::clone(&*urs);
+            let urs_copy2 = Rc::clone(&urs_copy);
+            let t = index_serialization_5_wires::read_plonk_verifier_index(
+                oracle::pasta::fp5::params(),
+                oracle::pasta::fq5::params(),
+                endo_q,
+                Rc::into_raw(urs_copy2),
+                &mut r,
+            )?;
+            Ok((t, Rc::clone(&urs_copy)))
+        }
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_verifier_index_read(
+    offset: Option<ocaml::Int>,
+    urs: CamlPastaFpUrs,
+    path: String,
+) -> Result<CamlPastaFpPlonkVerifierIndex, ocaml::Error> {
+    let (vi, urs) = read_raw(offset, urs, path)?;
+    Ok(to_ocaml(&urs, vi))
+}
+
+pub fn write_raw(
+    append: Option<bool>,
+    index: &DlogVerifierIndex<GAffine>,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
+        Err(_) => Err(ocaml::Error::invalid_argument(
+            "caml_pasta_fp_plonk_5_wires_verifier_index_raw_read",
+        )
+        .err()
+        .unwrap()),
+        Ok(file) => {
+            let mut w = BufWriter::new(file);
+
+            Ok(index_serialization_5_wires::write_plonk_verifier_index(
+                index, &mut w,
+            )?)
+        }
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_verifier_index_write(
+    append: Option<bool>,
+    index: CamlPastaFpPlonkVerifierIndex,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    write_raw(append, &index.into(), path)
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_verifier_index_create(
+    index: CamlPastaFpPlonkIndexPtr,
+) -> CamlPastaFpPlonkVerifierIndex {
+    let index = index.as_ref();
+    to_ocaml(&index.1, index.0.verifier_index())
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_verifier_index_shifts(
+    log2_size: ocaml::Int,
+) -> CamlPlonkVerificationShifts<Fp> {
+    let sh = ConstraintSystem::sample_shifts(&Domain::new(1 << log2_size).unwrap(), 4);
+    CamlPlonkVerificationShifts {
+        s0: Fp::one(),
+        s1: sh[0],
+        s2: sh[1],
+        s3: sh[2],
+        s4: sh[3],
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_verifier_index_dummy() -> CamlPastaFpPlonkVerifierIndex {
+    let g = || GAffine::prime_subgroup_generator();
+    let comm = || PolyComm {
+        shifted: Some(g()),
+        unshifted: vec![g(), g(), g()],
+    };
+    CamlPlonkVerifierIndex {
+        domain: CamlPlonkDomain {
+            log_size_of_group: 1,
+            group_gen: Fp::one(),
+        },
+        max_poly_size: 0,
+        max_quot_size: 0,
+        urs: caml_pointer::create(Rc::new(SRS::create(0))),
+        evals: CamlPlonkVerificationEvals {
+            sigma_comm0: comm(),
+            sigma_comm1: comm(),
+            sigma_comm2: comm(),
+            sigma_comm3: comm(),
+            sigma_comm4: comm(),
+            ql_comm: comm(),
+            qr_comm: comm(),
+            qo_comm: comm(),
+            qq_comm: comm(),
+            qp_comm: comm(),
+            qm_comm: comm(),
+            qc_comm: comm(),
+            rcm_comm0: comm(),
+            rcm_comm1: comm(),
+            rcm_comm2: comm(),
+            rcm_comm3: comm(),
+            rcm_comm4: comm(),
+            psm_comm: comm(),
+            add_comm: comm(),
+            double_comm: comm(),
+            mul1_comm: comm(),
+            mul2_comm: comm(),
+            emul_comm: comm(),
+            pack_comm: comm(),
+        },
+        shifts: CamlPlonkVerificationShifts {
+            s0: Fp::one(),
+            s1: Fp::one(),
+            s2: Fp::one(),
+            s3: Fp::one(),
+            s4: Fp::one(),
+        },
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_5_wires_verifier_index_deep_copy(
+    x: CamlPastaFpPlonkVerifierIndex,
+) -> CamlPastaFpPlonkVerifierIndex {
+    x
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_5_wires_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_5_wires_index.rs
@@ -1,0 +1,232 @@
+#[allow(unused_imports)]
+use algebra::pasta::{
+    fq::Fq,
+    pallas::{Affine as GAffine, PallasParameters},
+    vesta::Affine as GAffineOther,
+};
+
+use plonk_5_wires_circuits::constraints::ConstraintSystem;
+use plonk_5_wires_circuits::gate::CircuitGate;
+use plonk_5_wires_circuits::wires::Wire;
+
+use ff_fft::EvaluationDomain;
+
+use commitment_dlog::srs::SRS;
+use plonk_5_wires_protocol_dlog::index::{Index as DlogIndex, SRSSpec};
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
+    rc::Rc,
+};
+
+use crate::index_serialization_5_wires;
+use crate::pasta_fq_urs::CamlPastaFqUrs;
+use crate::plonk_5_wires_gate::{CamlPlonkGate, CamlPlonkWire, CamlPlonkWires};
+
+pub struct CamlPastaFqPlonkGateVector(Vec<CircuitGate<Fq>>);
+pub type CamlPastaFqPlonkGateVectorPtr = ocaml::Pointer<CamlPastaFqPlonkGateVector>;
+
+extern "C" fn caml_pasta_fq_plonk_5_wires_gate_vector_finalize(v: ocaml::Value) {
+    let v: CamlPastaFqPlonkGateVectorPtr = ocaml::FromValue::from_value(v);
+    unsafe { v.drop_in_place() };
+}
+
+ocaml::custom!(CamlPastaFqPlonkGateVector {
+    finalize: caml_pasta_fq_plonk_5_wires_gate_vector_finalize,
+});
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_gate_vector_create() -> CamlPastaFqPlonkGateVector {
+    CamlPastaFqPlonkGateVector(Vec::new())
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_gate_vector_add(
+    mut v: CamlPastaFqPlonkGateVectorPtr,
+    gate: CamlPlonkGate<Vec<Fq>>,
+) {
+    v.as_mut().0.push(CircuitGate {
+        typ: gate.typ.into(),
+        row: gate.row as usize,
+        wires: [
+            gate.wires.l.into(),
+            gate.wires.r.into(),
+            gate.wires.o.into(),
+            gate.wires.q.into(),
+            gate.wires.p.into()
+        ],
+        c: gate.c,
+    });
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_gate_vector_get(
+    v: CamlPastaFqPlonkGateVectorPtr,
+    i: ocaml::Int,
+) -> CamlPlonkGate<Vec<Fq>> {
+    let gate = &(v.as_ref().0)[i as usize];
+    let c = gate.c.iter().map(|x| *x).collect();
+    CamlPlonkGate {
+        typ: (&gate.typ).into(),
+        row: gate.row as isize,
+        wires: CamlPlonkWires
+        {
+            l: (&gate.wires[0]).into(),
+            r: (&gate.wires[1]).into(),
+            o: (&gate.wires[2]).into(),
+            q: (&gate.wires[3]).into(),
+            p: (&gate.wires[4]).into(),
+        },
+        c,
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_gate_vector_wrap
+(
+    mut v: CamlPastaFqPlonkGateVectorPtr,
+    t: CamlPlonkWire,
+    h: CamlPlonkWire,
+)
+{
+    (v.as_mut().0)[t.row as usize].wires[t.col as usize] =
+        Wire
+        {
+            row: h.row as usize,
+            col: h.col as usize,
+        };
+}
+
+/* Boxed so that we don't store large proving indexes in the OCaml heap. */
+
+pub struct CamlPastaFqPlonkIndex<'a>(pub Box<DlogIndex<'a, GAffine>>, pub Rc<SRS<GAffine>>);
+pub type CamlPastaFqPlonkIndexPtr<'a> = ocaml::Pointer<CamlPastaFqPlonkIndex<'a>>;
+
+extern "C" fn caml_pasta_fq_plonk_5_wires_index_finalize(v: ocaml::Value) {
+    let mut v: CamlPastaFqPlonkIndexPtr = ocaml::FromValue::from_value(v);
+    unsafe {
+        v.as_mut_ptr().drop_in_place();
+    }
+}
+
+ocaml::custom!(CamlPastaFqPlonkIndex<'a> {
+    finalize: caml_pasta_fq_plonk_5_wires_index_finalize,
+});
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_index_create(
+    gates: CamlPastaFqPlonkGateVectorPtr,
+    public: ocaml::Int,
+    urs: CamlPastaFqUrs,
+) -> Result<CamlPastaFqPlonkIndex<'static>, ocaml::Error> {
+    let gates: Vec<_> = gates.as_ref().0.clone();
+    let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
+    let cs =
+        match ConstraintSystem::<Fq>::create(gates, oracle::pasta::fq5::params(), public as usize)
+        {
+            None => Err(ocaml::Error::failwith(
+                "caml_pasta_fq_plonk_5_wires_index_create: could not create constraint system",
+            )
+            .err()
+            .unwrap())?,
+            Some(cs) => cs,
+        };
+    let urs_copy = Rc::clone(&*urs);
+    let urs_copy_outer = Rc::clone(&*urs);
+    let srs = {
+        // We know that the underlying value is still alive, because we never convert any of our
+        // Rc<_>s into weak pointers.
+        SRSSpec::Use(unsafe { &*Rc::into_raw(urs_copy) })
+    };
+    Ok(CamlPastaFqPlonkIndex(
+        Box::new(DlogIndex::<GAffine>::create(
+            cs,
+            oracle::pasta::fp5::params(),
+            endo_q,
+            srs,
+        )),
+        urs_copy_outer,
+    ))
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_index_max_degree(index: CamlPastaFqPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.srs.get_ref().max_degree() as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_index_public_inputs(index: CamlPastaFqPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.cs.public as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_index_domain_d1_size(index: CamlPastaFqPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.cs.domain.d1.size() as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_index_domain_d4_size(index: CamlPastaFqPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.cs.domain.d4.size() as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_index_domain_d8_size(index: CamlPastaFqPlonkIndexPtr) -> ocaml::Int {
+    index.as_ref().0.cs.domain.d8.size() as isize
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_index_read(
+    offset: Option<ocaml::Int>,
+    urs: CamlPastaFqUrs,
+    path: String,
+) -> Result<CamlPastaFqPlonkIndex<'static>, ocaml::Error> {
+    let file = match File::open(path) {
+        Err(_) => Err(
+            ocaml::Error::invalid_argument("caml_pasta_fq_plonk_5_wires_index_read")
+                .err()
+                .unwrap(),
+        )?,
+        Ok(file) => file,
+    };
+    let mut r = BufReader::new(file);
+    match offset {
+        Some(offset) => {
+            r.seek(Start(offset as u64))?;
+        }
+        None => (),
+    };
+    let urs_copy = Rc::clone(&*urs);
+    let urs_copy_outer = Rc::clone(&*urs);
+    let srs = {
+        // We know that the underlying value is still alive, because we never convert any of our
+        // Rc<_>s into weak pointers.
+        unsafe { &*Rc::into_raw(urs_copy) }
+    };
+    let t = index_serialization_5_wires::read_plonk_index(
+        oracle::pasta::fq5::params(),
+        oracle::pasta::fp5::params(),
+        srs,
+        &mut r,
+    )?;
+    Ok(CamlPastaFqPlonkIndex(Box::new(t), urs_copy_outer))
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_index_write(
+    append: Option<bool>,
+    index: CamlPastaFqPlonkIndexPtr<'static>,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    let file = match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
+        Err(_) => Err(
+            ocaml::Error::invalid_argument("caml_pasta_fq_plonk_5_wires_index_write")
+                .err()
+                .unwrap(),
+        )?,
+        Ok(file) => file,
+    };
+    let mut w = BufWriter::new(file);
+    index_serialization_5_wires::write_plonk_index(&index.as_ref().0, &mut w)?;
+    Ok(())
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_5_wires_proof.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_5_wires_proof.rs
@@ -1,0 +1,176 @@
+use algebra::{
+    curves::AffineCurve,
+    pasta::{
+        pallas::{Affine as GAffine, PallasParameters},
+        fq::Fq,
+        fp::Fp,
+    },
+    One,
+};
+
+use plonk_5_wires_circuits::scalars::ProofEvaluations as DlogProofEvaluations;
+
+use oracle::{
+    poseidon_5_wires::PlonkSpongeConstants,
+    sponge_5_wires::{DefaultFqSponge, DefaultFrSponge},
+};
+
+use groupmap::GroupMap;
+
+use commitment_dlog::commitment::{CommitmentCurve, OpeningProof, PolyComm};
+use plonk_5_wires_protocol_dlog::index::{Index as DlogIndex, VerifierIndex as DlogVerifierIndex};
+use plonk_5_wires_protocol_dlog::prover::{ProverCommitments as DlogCommitments, ProverProof as DlogProof};
+
+use crate::pasta_fq_plonk_5_wires_index::CamlPastaFqPlonkIndexPtr;
+use crate::pasta_fq_plonk_5_wires_verifier_index::CamlPastaFqPlonkVerifierIndex;
+use crate::pasta_fq_vector::CamlPastaFqVector;
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_proof_create(
+    index: CamlPastaFqPlonkIndexPtr<'static>,
+    primary_input: CamlPastaFqVector,
+    auxiliary_input: (Vec<Fq>, Vec<Fq>, Vec<Fq>, Vec<Fq>, Vec<Fq>),
+    prev_challenges: Vec<Fq>,
+    prev_sgs: Vec<GAffine>,
+) -> DlogProof<GAffine> {
+    // TODO: Should we be ignoring this?!
+    let _primary_input = primary_input;
+
+    let prev: Vec<(Vec<Fq>, PolyComm<GAffine>)> = {
+        if prev_challenges.len() == 0 {
+            Vec::new()
+        } else {
+            let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
+            prev_sgs
+                .into_iter()
+                .enumerate()
+                .map(|(i, sg)| {
+                    (
+                        prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                            .iter()
+                            .map(|x| *x)
+                            .collect(),
+                        PolyComm::<GAffine> {
+                            unshifted: vec![sg.into()],
+                            shifted: None,
+                        },
+                    )
+                })
+                .collect()
+        }
+    };
+
+    let witness = [auxiliary_input.0, auxiliary_input.1, auxiliary_input.2, auxiliary_input.3, auxiliary_input.4];
+    let index: &DlogIndex<GAffine> = &index.as_ref().0;
+
+    ocaml::runtime::release_lock();
+
+    let map = GroupMap::<Fp>::setup();
+    let proof = DlogProof::create::<
+        DefaultFqSponge<PallasParameters, PlonkSpongeConstants>,
+        DefaultFrSponge<Fq, PlonkSpongeConstants>,
+    >(&map, &witness, index, prev)
+    .unwrap();
+
+    ocaml::runtime::acquire_lock();
+
+    proof
+}
+
+pub fn proof_verify(
+    lgr_comm: Vec<PolyComm<GAffine>>,
+    index: &DlogVerifierIndex<GAffine>,
+    proof: DlogProof<GAffine>,
+) -> bool {
+    let group_map = <GAffine as CommitmentCurve>::Map::setup();
+
+    DlogProof::verify::<
+        DefaultFqSponge<PallasParameters, PlonkSpongeConstants>,
+        DefaultFrSponge<Fq, PlonkSpongeConstants>,
+    >(
+        &group_map,
+        &[(
+            index,
+            &lgr_comm.into_iter().map(From::from).collect(),
+            &proof,
+        )]
+        .to_vec(),
+    )
+    .is_ok()
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_proof_verify(
+    lgr_comm: Vec<PolyComm<GAffine>>,
+    index: CamlPastaFqPlonkVerifierIndex,
+    proof: DlogProof<GAffine>,
+) -> bool {
+    proof_verify(lgr_comm, &index.into(), proof)
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_proof_batch_verify(
+    lgr_comms: Vec<Vec<PolyComm<GAffine>>>,
+    indexes: Vec<CamlPastaFqPlonkVerifierIndex>,
+    proofs: Vec<DlogProof<GAffine>>,
+) -> bool {
+    let ts: Vec<_> = indexes
+        .into_iter()
+        .zip(lgr_comms.into_iter())
+        .zip(proofs.into_iter())
+        .map(|((i, l), p)| (i.into(), l.into_iter().map(From::from).collect(), p.into()))
+        .collect();
+    let ts: Vec<_> = ts.iter().map(|(i, l, p)| (i, l, p)).collect();
+    let group_map = GroupMap::<Fp>::setup();
+
+    DlogProof::<GAffine>::verify::<
+        DefaultFqSponge<PallasParameters, PlonkSpongeConstants>,
+        DefaultFrSponge<Fq, PlonkSpongeConstants>,
+    >(&group_map, &ts)
+    .is_ok()
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_proof_dummy() -> DlogProof<GAffine> {
+    let g = || GAffine::prime_subgroup_generator();
+    let comm = || PolyComm {
+        shifted: Some(g()),
+        unshifted: vec![g(), g(), g()],
+    };
+    DlogProof {
+        prev_challenges: vec![
+            (vec![Fq::one(), Fq::one()], comm()),
+            (vec![Fq::one(), Fq::one()], comm()),
+            (vec![Fq::one(), Fq::one()], comm()),
+        ],
+        proof: OpeningProof {
+            lr: vec![(g(), g()), (g(), g()), (g(), g())],
+            z1: Fq::one(),
+            z2: Fq::one(),
+            delta: g(),
+            sg: g(),
+        },
+        commitments: DlogCommitments {
+            w_comm: [comm(), comm(), comm(), comm(), comm()],
+            z_comm: comm(),
+            t_comm: comm(),
+        },
+        public: vec![Fq::one(), Fq::one()],
+        evals: {
+            let evals = || vec![Fq::one(), Fq::one(), Fq::one(), Fq::one()];
+            let evals = || DlogProofEvaluations {
+                w: [evals(), evals(), evals(), evals(), evals()],
+                z: evals(),
+                t: evals(),
+                f: evals(),
+                s: [evals(), evals(), evals(), evals()],
+            };
+            [evals(), evals()]
+        },
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_proof_deep_copy(x: DlogProof<GAffine>) -> DlogProof<GAffine> {
+    x
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_5_wires_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_5_wires_verifier_index.rs
@@ -1,0 +1,364 @@
+use crate::caml_pointer;
+use crate::index_serialization_5_wires;
+use crate::plonk_verifier_index::{CamlPlonkDomain};
+use crate::plonk_5_wires_verifier_index::{
+    CamlPlonkVerificationEvals, CamlPlonkVerificationShifts,
+    CamlPlonkVerifierIndex,
+};
+use crate::pasta_fq_plonk_5_wires_index::CamlPastaFqPlonkIndexPtr;
+use crate::pasta_fq_urs::CamlPastaFqUrs;
+use algebra::{
+    curves::AffineCurve,
+    pasta::{pallas::Affine as GAffine, vesta::Affine as GAffineOther, fq::Fq},
+    One,
+};
+
+use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};
+
+use commitment_dlog::{commitment::PolyComm, srs::SRS};
+use plonk_5_wires_circuits::constraints::{zk_polynomial, zk_w, ConstraintSystem};
+use plonk_5_wires_protocol_dlog::index::{SRSValue, VerifierIndex as DlogVerifierIndex};
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
+};
+
+use std::rc::Rc;
+
+pub type CamlPastaFqPlonkVerifierIndex =
+    CamlPlonkVerifierIndex<Fq, CamlPastaFqUrs, PolyComm<GAffine>>;
+
+pub fn to_ocaml<'a>(
+    urs: &Rc<SRS<GAffine>>,
+    vi: DlogVerifierIndex<'a, GAffine>,
+) -> CamlPastaFqPlonkVerifierIndex {
+    let [sigma_comm0, sigma_comm1, sigma_comm2, sigma_comm3, sigma_comm4] = vi.sigma_comm;
+    let [rcm_comm0, rcm_comm1, rcm_comm2, rcm_comm3, rcm_comm4] = vi.rcm_comm;
+    let [ql_comm, qr_comm, qo_comm, qq_comm, qp_comm] = vi.qw_comm;
+    let [s0, s1, s2, s3, s4] = vi.shift;
+    CamlPlonkVerifierIndex {
+        domain: CamlPlonkDomain {
+            log_size_of_group: vi.domain.log_size_of_group as isize,
+            group_gen: vi.domain.group_gen,
+        },
+        max_poly_size: vi.max_poly_size as isize,
+        max_quot_size: vi.max_quot_size as isize,
+        urs: caml_pointer::create(Rc::clone(urs)),
+        evals: CamlPlonkVerificationEvals {
+            sigma_comm0: sigma_comm0,
+            sigma_comm1: sigma_comm1,
+            sigma_comm2: sigma_comm2,
+            sigma_comm3: sigma_comm3,
+            sigma_comm4: sigma_comm4,
+            ql_comm: ql_comm,
+            qr_comm: qr_comm,
+            qo_comm: qo_comm,
+            qq_comm: qq_comm,
+            qp_comm: qp_comm,
+            qm_comm: vi.qm_comm,
+            qc_comm: vi.qc_comm,
+            rcm_comm0: rcm_comm0,
+            rcm_comm1: rcm_comm1,
+            rcm_comm2: rcm_comm2,
+            rcm_comm3: rcm_comm3,
+            rcm_comm4: rcm_comm4,
+            psm_comm: vi.psm_comm,
+            add_comm: vi.add_comm,
+            double_comm: vi.double_comm,
+            mul1_comm: vi.mul1_comm,
+            mul2_comm: vi.mul2_comm,
+            emul_comm: vi.emul_comm,
+            pack_comm: vi.pack_comm,
+        },
+        shifts: CamlPlonkVerificationShifts {
+            s0: s0,
+            s1: s1,
+            s2: s2,
+            s3: s3,
+            s4: s4,
+        },
+    }
+}
+
+pub fn to_ocaml_copy<'a>(
+    urs: &Rc<SRS<GAffine>>,
+    vi: &DlogVerifierIndex<'a, GAffine>,
+) -> CamlPastaFqPlonkVerifierIndex {
+    let [sigma_comm0, sigma_comm1, sigma_comm2, sigma_comm3, sigma_comm4] = &vi.sigma_comm;
+    let [rcm_comm0, rcm_comm1, rcm_comm2, rcm_comm3, rcm_comm4] = &vi.rcm_comm;
+    let [ql_comm, qr_comm, qo_comm, qq_comm, qp_comm] = &vi.qw_comm;
+    let [s0, s1, s2, s3, s4] = vi.shift;
+    CamlPlonkVerifierIndex {
+        domain: CamlPlonkDomain {
+            log_size_of_group: vi.domain.log_size_of_group as isize,
+            group_gen: vi.domain.group_gen,
+        },
+        max_poly_size: vi.max_poly_size as isize,
+        max_quot_size: vi.max_quot_size as isize,
+        urs: caml_pointer::create(Rc::clone(urs)),
+        evals: CamlPlonkVerificationEvals {
+            sigma_comm0: sigma_comm0.clone(),
+            sigma_comm1: sigma_comm1.clone(),
+            sigma_comm2: sigma_comm2.clone(),
+            sigma_comm3: sigma_comm3.clone(),
+            sigma_comm4: sigma_comm4.clone(),
+            ql_comm: ql_comm.clone(),
+            qr_comm: qr_comm.clone(),
+            qo_comm: qo_comm.clone(),
+            qq_comm: qq_comm.clone(),
+            qp_comm: qp_comm.clone(),
+            qm_comm: vi.qm_comm.clone(),
+            qc_comm: vi.qc_comm.clone(),
+            rcm_comm0: rcm_comm0.clone(),
+            rcm_comm1: rcm_comm1.clone(),
+            rcm_comm2: rcm_comm2.clone(),
+            rcm_comm3: rcm_comm3.clone(),
+            rcm_comm4: rcm_comm4.clone(),
+            psm_comm: vi.psm_comm.clone(),
+            add_comm: vi.add_comm.clone(),
+            double_comm: vi.double_comm.clone(),
+            mul1_comm: vi.mul1_comm.clone(),
+            mul2_comm: vi.mul2_comm.clone(),
+            emul_comm: vi.emul_comm.clone(),
+            pack_comm: vi.pack_comm.clone(),
+        },
+        shifts: CamlPlonkVerificationShifts {
+            s0: s0,
+            s1: s1,
+            s2: s2,
+            s3: s3,
+            s4: s4,
+        },
+    }
+}
+
+pub fn of_ocaml<'a>(
+    max_poly_size: ocaml::Int,
+    max_quot_size: ocaml::Int,
+    log_size_of_group: ocaml::Int,
+    urs: CamlPastaFqUrs,
+    evals: CamlPlonkVerificationEvals<PolyComm<GAffine>>,
+    shifts: CamlPlonkVerificationShifts<Fq>,
+) -> (DlogVerifierIndex<'a, GAffine>, Rc<SRS<GAffine>>) {
+    let urs_copy = Rc::clone(&*urs);
+    let urs_copy_outer = Rc::clone(&*urs);
+    let srs = {
+        // We know that the underlying value is still alive, because we never convert any of our
+        // Rc<_>s into weak pointers.
+        SRSValue::Ref(unsafe { &*Rc::into_raw(urs_copy) })
+    };
+    let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
+    let domain = Domain::<Fq>::new(1 << log_size_of_group).unwrap();
+    let index = DlogVerifierIndex::<GAffine> {
+        domain,
+        w: zk_w(domain),
+        zkpm: zk_polynomial(domain),
+        max_poly_size: max_poly_size as usize,
+        max_quot_size: max_quot_size as usize,
+        srs,
+        sigma_comm: [
+            evals.sigma_comm0,
+            evals.sigma_comm1,
+            evals.sigma_comm2,
+            evals.sigma_comm3,
+            evals.sigma_comm4,
+        ],
+        qw_comm: [
+            evals.ql_comm,
+            evals.qr_comm,
+            evals.qo_comm,
+            evals.qq_comm,
+            evals.qp_comm,
+        ],
+        qm_comm: evals.qm_comm,
+        qc_comm: evals.qc_comm,
+        rcm_comm: [
+            evals.rcm_comm0,
+            evals.rcm_comm1,
+            evals.rcm_comm2,
+            evals.rcm_comm3,
+            evals.rcm_comm4,
+        ],
+        psm_comm: evals.psm_comm,
+        add_comm: evals.add_comm,
+        double_comm: evals.double_comm,
+        mul1_comm: evals.mul1_comm,
+        mul2_comm: evals.mul2_comm,
+        emul_comm: evals.emul_comm,
+        pack_comm: evals.pack_comm,
+        shift: [shifts.s0, shifts.s1, shifts.s2, shifts.s3, shifts.s4],
+        fr_sponge_params: oracle::pasta::fq5::params(),
+        fq_sponge_params: oracle::pasta::fp5::params(),
+        endo: endo_q,
+    };
+    (index, urs_copy_outer)
+}
+
+impl From<CamlPastaFqPlonkVerifierIndex> for DlogVerifierIndex<'_, GAffine> {
+    fn from(index: CamlPastaFqPlonkVerifierIndex) -> Self {
+        of_ocaml(
+            index.max_poly_size,
+            index.max_quot_size,
+            index.domain.log_size_of_group,
+            index.urs,
+            index.evals,
+            index.shifts,
+        )
+        .0
+    }
+}
+
+pub fn read_raw<'a>(
+    offset: Option<ocaml::Int>,
+    urs: CamlPastaFqUrs,
+    path: String,
+) -> Result<(DlogVerifierIndex<'a, GAffine>, Rc<SRS<GAffine>>), ocaml::Error> {
+    match File::open(path) {
+        Err(_) => Err(ocaml::Error::invalid_argument(
+            "caml_pasta_fq_plonk_5_wires_verifier_index_raw_read",
+        )
+        .err()
+        .unwrap()),
+        Ok(file) => {
+            let mut r = BufReader::new(file);
+            match offset {
+                Some(offset) => {
+                    r.seek(Start(offset as u64))?;
+                }
+                None => (),
+            };
+            let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
+            let urs_copy = Rc::clone(&*urs);
+            let urs_copy2 = Rc::clone(&urs_copy);
+            let t = index_serialization_5_wires::read_plonk_verifier_index(
+                oracle::pasta::fq5::params(),
+                oracle::pasta::fp5::params(),
+                endo_q,
+                Rc::into_raw(urs_copy2),
+                &mut r,
+            )?;
+            Ok((t, Rc::clone(&urs_copy)))
+        }
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_verifier_index_read(
+    offset: Option<ocaml::Int>,
+    urs: CamlPastaFqUrs,
+    path: String,
+) -> Result<CamlPastaFqPlonkVerifierIndex, ocaml::Error> {
+    let (vi, urs) = read_raw(offset, urs, path)?;
+    Ok(to_ocaml(&urs, vi))
+}
+
+pub fn write_raw(
+    append: Option<bool>,
+    index: &DlogVerifierIndex<GAffine>,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    match OpenOptions::new().append(append.unwrap_or(true)).open(path) {
+        Err(_) => Err(ocaml::Error::invalid_argument(
+            "caml_pasta_fq_plonk_5_wires_verifier_index_raw_read",
+        )
+        .err()
+        .unwrap()),
+        Ok(file) => {
+            let mut w = BufWriter::new(file);
+
+            Ok(index_serialization_5_wires::write_plonk_verifier_index(
+                index, &mut w,
+            )?)
+        }
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_verifier_index_write(
+    append: Option<bool>,
+    index: CamlPastaFqPlonkVerifierIndex,
+    path: String,
+) -> Result<(), ocaml::Error> {
+    write_raw(append, &index.into(), path)
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_verifier_index_create(
+    index: CamlPastaFqPlonkIndexPtr,
+) -> CamlPastaFqPlonkVerifierIndex {
+    let index = index.as_ref();
+    to_ocaml(&index.1, index.0.verifier_index())
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_verifier_index_shifts(
+    log2_size: ocaml::Int,
+) -> CamlPlonkVerificationShifts<Fq> {
+    let sh = ConstraintSystem::sample_shifts(&Domain::new(1 << log2_size).unwrap(), 4);
+    CamlPlonkVerificationShifts {
+        s0: Fq::one(),
+        s1: sh[0],
+        s2: sh[1],
+        s3: sh[2],
+        s4: sh[3],
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_verifier_index_dummy() -> CamlPastaFqPlonkVerifierIndex {
+    let g = || GAffine::prime_subgroup_generator();
+    let comm = || PolyComm {
+        shifted: Some(g()),
+        unshifted: vec![g(), g(), g()],
+    };
+    CamlPlonkVerifierIndex {
+        domain: CamlPlonkDomain {
+            log_size_of_group: 1,
+            group_gen: Fq::one(),
+        },
+        max_poly_size: 0,
+        max_quot_size: 0,
+        urs: caml_pointer::create(Rc::new(SRS::create(0))),
+        evals: CamlPlonkVerificationEvals {
+            sigma_comm0: comm(),
+            sigma_comm1: comm(),
+            sigma_comm2: comm(),
+            sigma_comm3: comm(),
+            sigma_comm4: comm(),
+            ql_comm: comm(),
+            qr_comm: comm(),
+            qo_comm: comm(),
+            qq_comm: comm(),
+            qp_comm: comm(),
+            qm_comm: comm(),
+            qc_comm: comm(),
+            rcm_comm0: comm(),
+            rcm_comm1: comm(),
+            rcm_comm2: comm(),
+            rcm_comm3: comm(),
+            rcm_comm4: comm(),
+            psm_comm: comm(),
+            add_comm: comm(),
+            double_comm: comm(),
+            mul1_comm: comm(),
+            mul2_comm: comm(),
+            emul_comm: comm(),
+            pack_comm: comm(),
+        },
+        shifts: CamlPlonkVerificationShifts {
+            s0: Fq::one(),
+            s1: Fq::one(),
+            s2: Fq::one(),
+            s3: Fq::one(),
+            s4: Fq::one(),
+        },
+    }
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_5_wires_verifier_index_deep_copy(
+    x: CamlPastaFqPlonkVerifierIndex,
+) -> CamlPastaFqPlonkVerifierIndex {
+    x
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/plonk_5_wires_gate.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/plonk_5_wires_gate.rs
@@ -1,0 +1,143 @@
+use plonk_5_wires_circuits::gate::{GateType, GateType::*};
+use plonk_5_wires_circuits::wires::{GateWires, Wire};
+
+#[derive(ocaml::ToValue, ocaml::FromValue)]
+pub enum CamlPlonkGateType {
+    Zero,     // zero gate
+    Generic,  // generic arithmetic gate
+    Poseidon, // Poseidon permutation gate
+    Add,      // Gate constraining EC addition in Affine form
+    Double,   // Gate constraining EC point doubling in Affine form
+    Vbmul1,   // Gate constraining EC variable base scalar multiplication
+    Vbmul2,   // Gate constraining unpacking EC variable base scalar multiplication
+    Endomul,  // Gate constraining EC variable base scalar multiplication with group endomorphim optimization
+    Pack,     // Gate constraining packing
+}
+
+impl From<&GateType> for CamlPlonkGateType {
+    fn from(gate_type: &GateType) -> Self {
+        match gate_type {
+            Zero => CamlPlonkGateType::Zero,
+            Generic => CamlPlonkGateType::Generic,
+            Poseidon => CamlPlonkGateType::Poseidon,
+            Add => CamlPlonkGateType::Add,
+            Double => CamlPlonkGateType::Double,
+            Vbmul1 => CamlPlonkGateType::Vbmul1,
+            Vbmul2 => CamlPlonkGateType::Vbmul2,
+            Endomul => CamlPlonkGateType::Endomul,
+            Pack => CamlPlonkGateType::Pack,
+        }
+    }
+}
+impl From<GateType> for CamlPlonkGateType {
+    fn from(gate_type: GateType) -> Self {
+        Self::from(&gate_type)
+    }
+}
+
+impl From<&CamlPlonkGateType> for GateType {
+    fn from(gate_type: &CamlPlonkGateType) -> Self {
+        match gate_type {
+            CamlPlonkGateType::Zero => Zero,
+            CamlPlonkGateType::Generic => Generic,
+            CamlPlonkGateType::Poseidon => Poseidon,
+            CamlPlonkGateType::Add => Add,
+            CamlPlonkGateType::Double => Double,
+            CamlPlonkGateType::Vbmul1 => Vbmul1,
+            CamlPlonkGateType::Vbmul2 => Vbmul2,
+            CamlPlonkGateType::Endomul => Endomul,
+            CamlPlonkGateType::Pack => Pack,
+        }
+    }
+}
+impl From<CamlPlonkGateType> for GateType {
+    fn from(gate_type: CamlPlonkGateType) -> Self {
+        Self::from(&gate_type)
+    }
+}
+
+#[derive(ocaml::ToValue, ocaml::FromValue)]
+pub struct CamlPlonkWire {
+    pub row: ocaml::Int, // wire row
+    pub col: ocaml::Int, // wire column
+}
+
+impl From<&Wire> for CamlPlonkWire {
+    fn from(wire: &Wire) -> Self {
+        CamlPlonkWire {
+            row: wire.row as isize,
+            col: wire.col as isize,
+        }
+    }
+}
+impl From<Wire> for CamlPlonkWire {
+    fn from(wire: Wire) -> Self {
+        Self::from(&wire)
+    }
+}
+
+impl From<&CamlPlonkWire> for Wire {
+    fn from(wire: &CamlPlonkWire) -> Self {
+        Wire {
+            row: wire.row as usize,
+            col: wire.col as usize,
+        }
+    }
+}
+impl From<CamlPlonkWire> for Wire {
+    fn from(wire: CamlPlonkWire) -> Self {
+        Self::from(&wire)
+    }
+}
+
+#[derive(ocaml::ToValue, ocaml::FromValue)]
+pub struct CamlPlonkWires {
+    pub l: CamlPlonkWire,
+    pub r: CamlPlonkWire,
+    pub o: CamlPlonkWire,
+    pub q: CamlPlonkWire,
+    pub p: CamlPlonkWire,
+}
+
+impl From<&GateWires> for CamlPlonkWires {
+    fn from(wires: &GateWires) -> Self {
+        CamlPlonkWires {
+            l: wires[0].into(),
+            r: wires[1].into(),
+            o: wires[2].into(),
+            q: wires[3].into(),
+            p: wires[4].into(),
+        }
+    }
+}
+impl From<GateWires> for CamlPlonkWires {
+    fn from(wires: GateWires) -> Self {
+        Self::from(&wires)
+    }
+}
+
+impl From<&CamlPlonkWires> for GateWires {
+    fn from(wires: &CamlPlonkWires) -> Self {
+        [
+            (&wires.l).into(),
+            (&wires.r).into(),
+            (&wires.o).into(),
+            (&wires.q).into(),
+            (&wires.p).into(),
+        ]
+    }
+}
+
+impl From<CamlPlonkWires> for GateWires {
+    fn from(wires: CamlPlonkWires) -> Self {
+        Self::from(&wires)
+    }
+}
+
+#[derive(ocaml::ToValue, ocaml::FromValue)]
+pub struct CamlPlonkGate<T> {
+    pub typ: CamlPlonkGateType, // type of the gate
+    pub row: isize,
+    pub wires: CamlPlonkWires,
+    pub c: T, // constraints vector
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/plonk_5_wires_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/plonk_5_wires_verifier_index.rs
@@ -1,0 +1,48 @@
+use crate::plonk_verifier_index::{CamlPlonkDomain};
+
+#[derive(ocaml::ToValue, ocaml::FromValue)]
+pub struct CamlPlonkVerificationEvals<PolyComm> {
+    pub sigma_comm0: PolyComm,
+    pub sigma_comm1: PolyComm,
+    pub sigma_comm2: PolyComm,
+    pub sigma_comm3: PolyComm,
+    pub sigma_comm4: PolyComm,
+    pub ql_comm: PolyComm,
+    pub qr_comm: PolyComm,
+    pub qo_comm: PolyComm,
+    pub qq_comm: PolyComm,
+    pub qp_comm: PolyComm,
+    pub qm_comm: PolyComm,
+    pub qc_comm: PolyComm,
+    pub rcm_comm0: PolyComm,
+    pub rcm_comm1: PolyComm,
+    pub rcm_comm2: PolyComm,
+    pub rcm_comm3: PolyComm,
+    pub rcm_comm4: PolyComm,
+    pub psm_comm: PolyComm,
+    pub add_comm: PolyComm,
+    pub double_comm: PolyComm,
+    pub mul1_comm: PolyComm,
+    pub mul2_comm: PolyComm,
+    pub emul_comm: PolyComm,
+    pub pack_comm: PolyComm,
+}
+
+#[derive(ocaml::ToValue, ocaml::FromValue)]
+pub struct CamlPlonkVerificationShifts<Fr> {
+    pub s0: Fr,
+    pub s1: Fr,
+    pub s2: Fr,
+    pub s3: Fr,
+    pub s4: Fr,
+}
+
+#[derive(ocaml::ToValue, ocaml::FromValue)]
+pub struct CamlPlonkVerifierIndex<Fr, URS, PolyComm> {
+    pub domain: CamlPlonkDomain<Fr>,
+    pub max_poly_size: ocaml::Int,
+    pub max_quot_size: ocaml::Int,
+    pub urs: URS,
+    pub evals: CamlPlonkVerificationEvals<PolyComm>,
+    pub shifts: CamlPlonkVerificationShifts<Fr>,
+}

--- a/src/lib/marlin_plonk_bindings/types/marlin_plonk_bindings_types.ml
+++ b/src/lib/marlin_plonk_bindings/types/marlin_plonk_bindings_types.ml
@@ -184,6 +184,38 @@ module Plonk_proof = struct
     ; prev_challenges: ('field array * 'poly_comm) array }
 end
 
+module Plonk_5_wires_proof = struct
+  module Evaluations = struct
+    type 'field t =
+      { w:
+          'field array
+          * 'field array
+          * 'field array
+          * 'field array
+          * 'field array
+      ; z: 'field array
+      ; t: 'field array
+      ; f: 'field array
+      ; s: 'field array * 'field array * 'field array * 'field array }
+  end
+
+  module Opening_proof = Plonk_proof.Opening_proof
+
+  module Messages = struct
+    type 'poly_comm t =
+      { w_comm: 'poly_comm * 'poly_comm * 'poly_comm * 'poly_comm * 'poly_comm
+      ; z_comm: 'poly_comm
+      ; t_comm: 'poly_comm }
+  end
+
+  type ('field, 'g, 'poly_comm) t =
+    { messages: 'poly_comm Messages.t
+    ; proof: ('field, 'g) Opening_proof.t
+    ; evals: 'field Evaluations.t * 'field Evaluations.t
+    ; public: 'field array
+    ; prev_challenges: ('field array * 'poly_comm) array }
+end
+
 module Oracles = struct
   module Random_oracles = struct
     type 'field t =

--- a/src/lib/marlin_plonk_bindings/types/marlin_plonk_bindings_types.ml
+++ b/src/lib/marlin_plonk_bindings/types/marlin_plonk_bindings_types.ml
@@ -50,6 +50,48 @@ module Plonk_verifier_index = struct
     ; shifts: 'field Plonk_verification_shifts.t }
 end
 
+module Plonk_5_wires_verification_evals = struct
+  type 'poly_comm t =
+    { sigma_comm_0: 'poly_comm
+    ; sigma_comm_1: 'poly_comm
+    ; sigma_comm_2: 'poly_comm
+    ; sigma_comm_3: 'poly_comm
+    ; sigma_comm_4: 'poly_comm
+    ; ql_comm: 'poly_comm
+    ; qr_comm: 'poly_comm
+    ; qo_comm: 'poly_comm
+    ; qq_comm: 'poly_comm
+    ; qp_comm: 'poly_comm
+    ; qm_comm: 'poly_comm
+    ; qc_comm: 'poly_comm
+    ; rcm_comm_0: 'poly_comm
+    ; rcm_comm_1: 'poly_comm
+    ; rcm_comm_2: 'poly_comm
+    ; rcm_comm_3: 'poly_comm
+    ; rcm_comm_4: 'poly_comm
+    ; psm_comm: 'poly_comm
+    ; add_comm: 'poly_comm
+    ; double_comm: 'poly_comm
+    ; mul1_comm: 'poly_comm
+    ; mul2_comm: 'poly_comm
+    ; emul_comm: 'poly_comm
+    ; pack_comm: 'poly_comm }
+end
+
+module Plonk_5_wires_verification_shifts = struct
+  type 'field t = {s0: 'field; s1: 'field; s2: 'field; s3: 'field; s4: 'field}
+end
+
+module Plonk_5_wires_verifier_index = struct
+  type ('field, 'urs, 'poly_comm) t =
+    { domain: 'field Plonk_domain.t
+    ; max_poly_size: int
+    ; max_quot_size: int
+    ; urs: 'urs
+    ; evals: 'poly_comm Plonk_5_wires_verification_evals.t
+    ; shifts: 'field Plonk_5_wires_verification_shifts.t }
+end
+
 module Plonk_gate = struct
   module Kind = struct
     type t =

--- a/src/lib/marlin_plonk_bindings/types/marlin_plonk_bindings_types.ml
+++ b/src/lib/marlin_plonk_bindings/types/marlin_plonk_bindings_types.ml
@@ -82,6 +82,31 @@ module Plonk_gate = struct
   type 'a t = {kind: Kind.t; wires: Wires.t; c: 'a array}
 end
 
+module Plonk_5_wires_gate = struct
+  module Kind = struct
+    type t =
+      | Zero
+      | Generic
+      | Poseidon
+      | Add
+      | Double
+      | Vbmul1
+      | Vbmul2
+      | Endomul
+      | Pack
+  end
+
+  module Wire = struct
+    type t = {row: int; col: int}
+  end
+
+  module Wires = struct
+    type t = {l: Wire.t; r: Wire.t; o: Wire.t; q: Wire.t; p: Wire.t}
+  end
+
+  type 'a t = {kind: Kind.t; row: int; wires: Wires.t; c: 'a array}
+end
+
 module Plonk_proof = struct
   module Evaluations = struct
     type 'field t =


### PR DESCRIPTION
This PR pulls in the @ltvvlz's bindings changes from ef4edec2232f7ab3c293c87fa7f7b94b85bc36ca, to add support for 5-wires plonk. In contrast to that commit, this
* adds new bindings instead of replacing/modifying the existing ones
* includes some small fixes
* modifies the bindings to use the pasta curves instead of the tweedle ones
* updates the bindings to mirror the latest version of the existing pasta ones.

The corresponding marlin PRs are o1-labs/marlin#82 and o1-labs/marlin#83.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: