### PR TITLE
Feature: Expose Account Timing in GraphQL

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6598,8 +6598,8 @@
           "description": null,
           "fields": [
             {
-              "name": "timed_minimum_balance",
-              "description": "The timed minimum balance for an account",
+              "name": "initial_mininum_balance",
+              "description": "The initial minimum balance for a time-locked account",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -6611,7 +6611,7 @@
             },
             {
               "name": "cliff_time",
-              "description": "Cliff amount",
+              "description": "The cliff time for a time-locked account",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -6623,7 +6623,7 @@
             },
             {
               "name": "cliff_amount",
-              "description": "Cliff amount",
+              "description": "The cliff amount for a time-locked account",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -6635,7 +6635,7 @@
             },
             {
               "name": "vesting_period",
-              "description": "",
+              "description": "The vesting period for a time-locked account",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -6647,7 +6647,7 @@
             },
             {
               "name": "vesting_increment",
-              "description": "Cliff amount",
+              "description": "The vesting increment for a time-locked account",
               "args": [],
               "type": {
                 "kind": "SCALAR",

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6584,6 +6584,87 @@
         },
         {
           "kind": "SCALAR",
+          "name": "UInt64",
+          "description": "String representing a uint64 number in base 10",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AccountTiming",
+          "description": null,
+          "fields": [
+            {
+              "name": "timed_minimum_balance",
+              "description": "The timed minimum balance for an account",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt64",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cliff_time",
+              "description": "Cliff amount",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt32",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cliff_amount",
+              "description": "Cliff amount",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt64",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vesting_period",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt32",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vesting_increment",
+              "description": "Cliff amount",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt64",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
           "name": "TokenId",
           "description": "String representation of a token's UInt64 identifier",
           "fields": null,
@@ -6633,6 +6714,22 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timing",
+              "description": "The timing associated with this account",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AccountTiming",
                   "ofType": null
                 }
               },

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6583,16 +6583,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "UInt64",
-          "description": "String representing a uint64 number in base 10",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "AccountTiming",
           "description": null,

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -352,15 +352,15 @@ module Types = struct
             ~resolve:(fun _ {Fee_transfer.fee; _} -> Currency.Fee.to_uint64 fee)
         ] )
 
-  let account_timing =
+  let account_timing : (Mina_lib.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->
-        [ field "initial_minimum_balance" ~typ:(non_null uint64)
-            ~doc:"The initial minimum balance for an account"
+        [ field "timed_minimum_balance" ~typ:(non_null uint64)
+            ~doc:"The timed minimum balance for an account"
             ~args:Arg.[]
-            ~resolve:(fun _ {Account.Poly.timing; _} ->
+            ~resolve:(fun _ timing ->
               match timing with
-              | Untimed ->
-                  Balance.zero |> Balance.to_uint64
+              | Account_timing.Untimed ->
+                  Balance.(zero |> to_uint64)
               | Timed timing_info ->
                   timing_info.initial_minimum_balance |> Balance.to_uint64 ) ]
     )

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -352,6 +352,19 @@ module Types = struct
             ~resolve:(fun _ {Fee_transfer.fee; _} -> Currency.Fee.to_uint64 fee)
         ] )
 
+  let account_timing =
+    obj "AccountTiming" ~fields:(fun _ ->
+        [ field "initial_minimum_balance" ~typ:(non_null uint64)
+            ~doc:"The initial minimum balance for an account"
+            ~args:Arg.[]
+            ~resolve:(fun _ {Account.Poly.timing; _} ->
+              match timing with
+              | Untimed ->
+                  Balance.zero |> Balance.to_uint64
+              | Timed timing_info ->
+                  timing_info.initial_minimum_balance |> Balance.to_uint64 ) ]
+    )
+
   let completed_work =
     obj "CompletedWork" ~doc:"Completed snark works" ~fields:(fun _ ->
         [ field "prover"
@@ -753,6 +766,10 @@ module Types = struct
                  ~doc:"The token associated with this account"
                  ~args:Arg.[]
                  ~resolve:(fun _ {account; _} -> account.Account.Poly.token_id)
+             ; field "timing" ~typ:(non_null account_timing)
+                 ~doc:"The timing associated with this account"
+                 ~args:Arg.[]
+                 ~resolve:(fun _ {account; _} -> account.Account.Poly.timing)
              ; field "balance"
                  ~typ:(non_null AnnotatedBalance.obj)
                  ~doc:"The amount of coda owned by the account"

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -354,8 +354,8 @@ module Types = struct
 
   let account_timing : (Mina_lib.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->
-        [ field "timed_minimum_balance" ~typ:uint64
-            ~doc:"The timed minimum balance for a time-locked account"
+        [ field "initial_mininum_balance" ~typ:uint64
+            ~doc:"The initial minimum balance for a time-locked account"
             ~args:Arg.[]
             ~resolve:(fun _ timing ->
               match timing with

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -354,16 +354,54 @@ module Types = struct
 
   let account_timing : (Mina_lib.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->
-        [ field "timed_minimum_balance" ~typ:(non_null uint64)
-            ~doc:"The timed minimum balance for an account"
+        [ field "timed_minimum_balance" ~typ:uint64
+            ~doc:"The timed minimum balance for a time-locked account"
             ~args:Arg.[]
             ~resolve:(fun _ timing ->
               match timing with
               | Account_timing.Untimed ->
-                  Balance.(zero |> to_uint64)
+                  None
               | Timed timing_info ->
-                  timing_info.initial_minimum_balance |> Balance.to_uint64 ) ]
-    )
+                  Some (Balance.to_uint64 timing_info.initial_minimum_balance)
+              )
+        ; field "cliff_time" ~typ:uint32
+            ~doc:"The cliff time for a time-locked account"
+            ~args:Arg.[]
+            ~resolve:(fun _ timing ->
+              match timing with
+              | Account_timing.Untimed ->
+                  None
+              | Timed timing_info ->
+                  Some timing_info.cliff_time )
+        ; field "cliff_amount" ~typ:uint64
+            ~doc:"The cliff amount for a time-locked account"
+            ~args:Arg.[]
+            ~resolve:(fun _ timing ->
+              match timing with
+              | Account_timing.Untimed ->
+                  None
+              | Timed timing_info ->
+                  Some (Currency.Amount.to_uint64 timing_info.cliff_amount) )
+        ; field "vesting_period" ~typ:uint32
+            ~doc:"The vesting period for a time-locked account"
+            ~args:Arg.[]
+            ~resolve:(fun _ timing ->
+              match timing with
+              | Account_timing.Untimed ->
+                  None
+              | Timed timing_info ->
+                  Some timing_info.vesting_period )
+        ; field "vesting_increment" ~typ:uint64
+            ~doc:"The vesting increment for a time-locked account"
+            ~args:Arg.[]
+            ~resolve:(fun _ timing ->
+              match timing with
+              | Account_timing.Untimed ->
+                  None
+              | Timed timing_info ->
+                  Some
+                    (Currency.Amount.to_uint64 timing_info.vesting_increment)
+              ) ] )
 
   let completed_work =
     obj "CompletedWork" ~doc:"Completed snark works" ~fields:(fun _ ->

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -352,7 +352,6 @@ module Types = struct
             ~resolve:(fun _ {Fee_transfer.fee; _} -> Currency.Fee.to_uint64 fee)
         ] )
 
-<<<<<<< HEAD
   let account_timing : (Mina_lib.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->
         [ field "initial_mininum_balance" ~typ:uint64
@@ -403,20 +402,6 @@ module Types = struct
                   Some
                     (Currency.Amount.to_uint64 timing_info.vesting_increment)
               ) ] )
-=======
-  let account_timing =
-    obj "AccountTiming" ~fields:(fun _ ->
-        [ field "initial_minimum_balance" ~typ:(non_null uint64)
-            ~doc:"The initial minimum balance for an account"
-            ~args:Arg.[]
-            ~resolve:(fun _ {Account.Poly.timing; _} ->
-              match timing with
-              | Untimed ->
-                  Balance.zero |> Balance.to_uint64
-              | Timed timing_info ->
-                  timing_info.initial_minimum_balance |> Balance.to_uint64 ) ]
-    )
->>>>>>> Added account_timing to debug
 
   let completed_work =
     obj "CompletedWork" ~doc:"Completed snark works" ~fields:(fun _ ->

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -352,6 +352,7 @@ module Types = struct
             ~resolve:(fun _ {Fee_transfer.fee; _} -> Currency.Fee.to_uint64 fee)
         ] )
 
+<<<<<<< HEAD
   let account_timing : (Mina_lib.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->
         [ field "initial_mininum_balance" ~typ:uint64
@@ -402,6 +403,20 @@ module Types = struct
                   Some
                     (Currency.Amount.to_uint64 timing_info.vesting_increment)
               ) ] )
+=======
+  let account_timing =
+    obj "AccountTiming" ~fields:(fun _ ->
+        [ field "initial_minimum_balance" ~typ:(non_null uint64)
+            ~doc:"The initial minimum balance for an account"
+            ~args:Arg.[]
+            ~resolve:(fun _ {Account.Poly.timing; _} ->
+              match timing with
+              | Untimed ->
+                  Balance.zero |> Balance.to_uint64
+              | Timed timing_info ->
+                  timing_info.initial_minimum_balance |> Balance.to_uint64 ) ]
+    )
+>>>>>>> Added account_timing to debug
 
   let completed_work =
     obj "CompletedWork" ~doc:"Completed snark works" ~fields:(fun _ ->


### PR DESCRIPTION
This PR exposes the Account_timing information on an account in our GraphQL.

This was tested by using a ledger that had time-locked accounts enabled as well as normal accounts. Manual queries were done to ensure correctness.

Timed Account:
![image](https://user-images.githubusercontent.com/9512405/106508223-f4c3db80-6480-11eb-9cf5-794796707131.png)

Normal Account:
![image](https://user-images.githubusercontent.com/9512405/106508245-fa212600-6480-11eb-83db-a5b7097a88a2.png)

**Note**
This PR is the same as https://github.com/MinaProtocol/mina/pull/7600 but was made because of the repo changes made recently. 
