### PR TITLE
Client SDK: Implement verifyPaymentSignature and verifyStakeDelegationSignature

### DIFF
--- a/frontend/client_sdk/src/CodaSDK.d.ts
+++ b/frontend/client_sdk/src/CodaSDK.d.ts
@@ -85,3 +85,10 @@ export declare const signPayment: (payment: payment, key: keypair) => signed<pay
   * @returns A signed stake delegation
   */
 export declare const signStakeDelegation: (stakeDelegation: stakeDelegation, key: keypair) => signed<stakeDelegation>;
+/**
+  * Verifies a signed payment.
+  *
+  * @param signedPayment - A signed payment transaction
+  * @returns True if the `signed(payment)` is a verifiable payment
+   */
+export declare const verifyPaymentSignature: (signedPayment: signed<payment>) => boolean;

--- a/frontend/client_sdk/src/CodaSDK.d.ts
+++ b/frontend/client_sdk/src/CodaSDK.d.ts
@@ -92,3 +92,10 @@ export declare const signStakeDelegation: (stakeDelegation: stakeDelegation, key
   * @returns True if the `signed(payment)` is a verifiable payment
    */
 export declare const verifyPaymentSignature: (signedPayment: signed<payment>) => boolean;
+/**
+  * Verifies a signed stake delegation
+  *
+  * @param signedStakeDelegation - A signed stake delegation
+  * @returns True if the `signed(stakeDelegation)` is a verifiable stake delegation
+   */
+export declare const verifyStakeDelegationSignature: (signedStakeDelegation: signed<stakeDelegation>) => boolean;

--- a/frontend/client_sdk/src/CodaSDK.re
+++ b/frontend/client_sdk/src/CodaSDK.re
@@ -131,13 +131,6 @@ let value = (~default: 'a, option: option('a)): 'a => {
   (go())(. default, option);
 };
 
-let bool_of_int = i =>
-  if (i === 0) {
-    false;
-  } else {
-    true;
-  };
-
 type common_payload_js = {
   .
   "fee": string,
@@ -310,7 +303,7 @@ let signStakeDelegation =
   };
 
 [@bs.send]
-external verifyPaymentSignature: (codaSDK, signed_payment_js) => int =
+external verifyPaymentSignature: (codaSDK, signed_payment_js) => bool =
   "verifyPaymentSignature";
 
 /**
@@ -352,12 +345,11 @@ let verifyPaymentSignature = (signedPayment: signed(payment)) => {
       },
     },
   )
-  ->bool_of_int;
 };
 
 [@bs.send]
 external verifyStakeDelegationSignature:
-  (codaSDK, signed_stake_delegation_js) => int =
+  (codaSDK, signed_stake_delegation_js) => bool =
   "verifyStakeDelegationSignature";
 
 /**
@@ -398,5 +390,4 @@ let verifyStakeDelegationSignature =
       },
     },
   )
-  ->bool_of_int;
 };

--- a/frontend/client_sdk/test/Test.ts
+++ b/frontend/client_sdk/test/Test.ts
@@ -18,6 +18,13 @@ let payment2 = CodaSDK.signPayment(
 
 deepStrictEqual(payment1, payment2, "Payment signatures don't match (string vs numeric inputs)");
 
+
+deepStrictEqual(CodaSDK.verifyPaymentSignature(payment1), true, "Unsafe signed payment could not be verified.");
+deepStrictEqual(CodaSDK.verifyPaymentSignature(payment2), true, "Signed payment could not be verified.");
+
+let invalidPayment = {...payment2, publicKey: CodaSDK.genKeys().publicKey};
+deepStrictEqual(CodaSDK.verifyPaymentSignature(invalidPayment), false, "Invalid signed payment was verified");
+
 let sd1 = CodaSDK.signStakeDelegation(
     {to: key.publicKey, from: key.publicKey, fee: "1", nonce: "0"},
     key);

--- a/frontend/client_sdk/test/Test.ts
+++ b/frontend/client_sdk/test/Test.ts
@@ -6,6 +6,7 @@ let publicKey = CodaSDK.derivePublicKey(key.privateKey);
 let signed = CodaSDK.signMessage("hello", key);
 CodaSDK.verifyMessage(signed);
 
+deepStrictEqual(publicKey, key.publicKey, "Public keys do not match");
 
 let payment1 = CodaSDK.unsafeSignAny(
     {to: key.publicKey, from: key.publicKey, amount: "1", fee: "1", nonce: "0"},
@@ -36,4 +37,8 @@ let sd2 = CodaSDK.signStakeDelegation(
 
 deepStrictEqual(sd1, sd2, "Stake delegation signatures don't match (string vs numeric inputs)");
 
-deepStrictEqual(publicKey, key.publicKey, "Public keys do not match");
+CodaSDK.verifyStakeDelegationSignature(sd1);
+deepStrictEqual(CodaSDK.verifyStakeDelegationSignature(sd1), true, "Signed delegation could not be verified");
+
+let invalidSd = {...sd1, publicKey: CodaSDK.genKeys().publicKey};
+deepStrictEqual(CodaSDK.verifyStakeDelegationSignature(invalidSd), false, "Invalid signed delegation was verified");


### PR DESCRIPTION
1. Adds the functionality for `verifyPaymentSignature` and `verifyStakeDelegationSignature` to the Client SDK. 
2. Added tests for the newly implemented features.
