### PR TITLE
[WIP] add CI agent entrypoint script for installing latest coda tools (e.g. coda-logproc, coda-create-genesis)

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -49,7 +49,16 @@ Pipeline.build
             "AWS_SECRET_ACCESS_KEY",
             -- add zexe standardization preprocessing step (see: https://github.com/CodaProtocol/coda/pull/5777)
             "PREPROCESSOR=./scripts/zexe-standardize.sh"
-          ] "./buildkite/scripts/build-artifact.sh" # [ Cmd.run "buildkite/scripts/buildkite-artifact-helper.sh ./DOCKER_DEPLOY_ENV" ],
+          ] "./buildkite/scripts/build-artifact.sh"
+
+          #
+
+          [
+            Cmd.run "artifact-cache-helper.sh DOCKER_DEPLOY_ENV --upload",
+            -- cache previously built logproc tool for job use/troubleshooting purposes
+            -- TODO: build artifact parent DIR removal from upload path into cache helper
+            Cmd.run "cd _build/default/src/app/logproc && artifact-cache-helper.sh *.exe --upload"
+          ],
           label = "Build Mina daemon debian package",
           key = "build-deb-pkg",
           target = Size.XLarge,


### PR DESCRIPTION
Install for access by jobs/troubleshooting purposes.

consists of the following EXEs:
```
ls /usr/local/bin/coda*
/usr/local/bin/coda  /usr/local/bin/coda-create-genesis  /usr/local/bin/coda-libp2p_helper  /usr/local/bin/coda-logproc
```

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
