### PR TITLE
Fix CI deploy testnet artifact upload logic

### DIFF
--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -34,8 +34,8 @@ let testnetArtifactPath = "/tmp/artifacts" in
           ),
           Cmd.run (
             -- upload/cache testnet genesis_ledger
-            "BUILDKITE_ARTIFACT_UPLOAD_DESTINATION=gs://buildkite_k8s/coda/shared/\\\${BUILDKITE_JOB_ID}" ++
-              " pushd ${testnetArtifactPath} && buildkite-agent artifact upload \"genesis_ledger.json\" && popd"
+            "pushd ${testnetArtifactPath} && BUILDKITE_ARTIFACT_UPLOAD_DESTINATION=gs://buildkite_k8s/coda/shared/\\\${BUILDKITE_JOB_ID}" ++
+              " buildkite-agent artifact upload \"genesis_ledger.json\" && popd"
           ),
           Cmd.run (
             -- always execute post-deploy operation


### PR DESCRIPTION
Set artifact upload dest envvar following pushd to maintain value.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: