### PR TITLE
Use posix-style flags by default

### DIFF
--- a/src/app/archive/archive.ml
+++ b/src/app/archive/archive.ml
@@ -11,10 +11,10 @@ let command_run =
      and server_port = Flag.Port.Archive.server
      and postgres = Flag.Uri.Archive.postgres
      and runtime_config_file =
-       flag "-config-file" (optional string)
+       flag "--config-file" ~aliases:["-config-file"] (optional string)
          ~doc:"PATH to the configuration file containing the genesis ledger"
      and delete_older_than =
-       flag "-delete-older-than" (optional int)
+       flag "-delete-older-than" ~aliases:["-delete-older-than"] (optional int)
          ~doc:
            "int Delete blocks that are more than n blocks lower than the \
             maximum seen block."
@@ -44,16 +44,16 @@ let command_prune =
   let open Command.Let_syntax in
   Command.async ~summary:"Prune old blocks and their transactions"
     (let%map_open height =
-       flag "-height" (optional int)
+       flag "--height" ~aliases:["-height"] (optional int)
          ~doc:"int Delete blocks with height lower than the given height"
      and num_blocks =
-       flag "-num-blocks" (optional int)
+       flag "--num-blocks" ~aliases:["-num-blocks"] (optional int)
          ~doc:
            "int Delete blocks that are more than n blocks lower than the \
             maximum seen block. This argument is ignored if the --height \
             argument is also given"
      and timestamp =
-       flag "-timestamp" (optional time_arg)
+       flag "--timestamp" ~aliases:["-timestamp"] (optional time_arg)
          ~doc:
            "timestamp Delete blocks that are older than the given timestamp. \
             Format: 2000-00-00 12:00:00+0100"

--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -86,28 +86,28 @@ let () =
       (let open Let_syntax in
       async ~summary:"Write blocks to an archive database"
         (let%map archive_uri =
-           Param.flag "archive-uri"
+           Param.flag "--archive-uri" ~aliases:["archive-uri"]
              ~doc:
                "URI URI for connecting to the archive database (e.g., \
                 postgres://$USER:$USER@localhost:5432/archiver)"
              Param.(required string)
          and precomputed =
-           Param.(flag "precomputed" no_arg)
+           Param.(flag "--precomputed" ~aliases:["precomputed"] no_arg)
              ~doc:"Blocks are in precomputed format"
          and extensional =
-           Param.(flag "extensional" no_arg)
+           Param.(flag "--extensional" ~aliases:["extensional"] no_arg)
              ~doc:"Blocks are in extensional format"
          and success_file =
-           Param.flag "successful-files"
+           Param.flag "--successful-files" ~aliases:["successful-files"]
              ~doc:
                "PATH Appends the list of files that were processed successfully"
              (Flag.optional Param.string)
          and failure_file =
-           Param.flag "failed-files"
+           Param.flag "--failed-files" ~aliases:["failed-files"]
              ~doc:"PATH Appends the list of files that failed to be processed"
              (Flag.optional Param.string)
          and log_successes =
-           Param.flag "log-successful"
+           Param.flag "--log-successful" ~aliases:["log-successful"]
              ~doc:
                "true/false Whether to log messages for files that were \
                 processed successfully"

--- a/src/app/best_tip_merger/best_tip_merger.ml
+++ b/src/app/best_tip_merger/best_tip_merger.ml
@@ -370,15 +370,16 @@ let () =
           "Consolidates best tip history from multiple log files into a rose \
            tree representation"
         (let%map input_dir =
-           Param.flag "-input-dir"
+           Param.flag "--input-dir" ~aliases:["-input-dir"]
              ~doc:
                "PATH Directory containing one or more mina-best-tip.log files"
              Param.(required string)
          and output_dir =
-           Param.flag "-output-dir" ~doc:"PATH Directory to save the output"
+           Param.flag "--output-dir" ~aliases:["-output-dir"]
+             ~doc:"PATH Directory to save the output"
              Param.(required string)
          and output_format =
-           Param.flag "-output-format"
+           Param.flag "--output-format" ~aliases:["-output-format"]
              ~doc:
                "Full|Compact Information shown for each block. Full= Protocol \
                 state and Compact= Current state hash, previous state hash, \
@@ -387,7 +388,7 @@ let () =
          and log_json = Cli_lib.Flag.Log.json
          and log_level = Cli_lib.Flag.Log.level
          and min_peers =
-           Param.flag "-min-peers"
+           Param.flag "--min-peers" ~aliases:["-min-peers"]
              ~doc:
                "Int(>0) Keep blocks that were accepted by at least min-peers \
                 number of peers and prune the rest (Default=1)"

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -40,7 +40,7 @@ plugins]
 
 let plugin_flag =
   let open Command.Param in
-  flag "load-plugin" (listed string)
+  flag "--load-plugin" ~aliases:["load-plugin"] (listed string)
     ~doc:
       "PATH The path to load a .cmxs plugin from. May be passed multiple times"
 
@@ -55,21 +55,22 @@ let setup_daemon logger =
   let open Cli_lib.Arg_type in
   let%map_open conf_dir = Cli_lib.Flag.conf_dir
   and block_production_key =
-    flag "block-producer-key"
+    flag "--block-producer-key" ~aliases:["block-producer-key"]
       ~doc:
         "KEYFILE Private key file for the block producer. You cannot provide \
          both `block-producer-key` and `block-producer-pubkey`. (default: \
          don't produce blocks)"
       (optional string)
   and block_production_pubkey =
-    flag "block-producer-pubkey"
+    flag "--block-producer-pubkey" ~aliases:["block-producer-pubkey"]
       ~doc:
         "PUBLICKEY Public key for the associated private key that is being \
          tracked by this daemon. You cannot provide both `block-producer-key` \
          and `block-producer-pubkey`. (default: don't produce blocks)"
       (optional public_key_compressed)
   and block_production_password =
-    flag "block-producer-password"
+    flag "--block-producer-password"
+      ~aliases:["block-producer-password"]
       ~doc:
         "PASSWORD Password associated with the block-producer key. Setting \
          this is equivalent to setting the CODA_PRIVKEY_PASS environment \
@@ -78,41 +79,42 @@ let setup_daemon logger =
          daemon.json config file"
       (optional string)
   and demo_mode =
-    flag "demo-mode" no_arg
+    flag "--demo-mode" ~aliases:["demo-mode"] no_arg
       ~doc:
         "Run the daemon in demo-mode -- assume we're \"synced\" to the \
          network instantly"
   and coinbase_receiver_flag =
-    flag "coinbase-receiver"
+    flag "--coinbase-receiver" ~aliases:["coinbase-receiver"]
       ~doc:
         "PUBLICKEY Address to send coinbase rewards to (if this node is \
          producing blocks). If not provided, coinbase rewards will be sent to \
          the producer of a block."
       (optional public_key_compressed)
   and genesis_dir =
-    flag "genesis-ledger-dir"
+    flag "--genesis-ledger-dir" ~aliases:["genesis-ledger-dir"]
       ~doc:
         "DIR Directory that contains the genesis ledger and the genesis \
          blockchain proof (default: <config-dir>)"
       (optional string)
   and run_snark_worker_flag =
-    flag "run-snark-worker"
+    flag "--run-snark-worker" ~aliases:["run-snark-worker"]
       ~doc:"PUBLICKEY Run the SNARK worker with this public key"
       (optional public_key_compressed)
   and run_snark_coordinator_flag =
-    flag "run-snark-coordinator"
+    flag "--run-snark-coordinator" ~aliases:["run-snark-coordinator"]
       ~doc:
         "PUBLICKEY Run a SNARK coordinator with this public key (ignored if \
          the run-snark-worker is set)"
       (optional public_key_compressed)
   and snark_worker_parallelism_flag =
-    flag "snark-worker-parallelism"
+    flag "--snark-worker-parallelism"
+      ~aliases:["snark-worker-parallelism"]
       ~doc:
         "NUM Run the SNARK worker using this many threads. Equivalent to \
          setting OMP_NUM_THREADS, but doesn't affect block production."
       (optional int)
   and work_selection_method_flag =
-    flag "work-selection"
+    flag "--work-selection" ~aliases:["work-selection"]
       ~doc:
         "seq|rand Choose work sequentially (seq) or randomly (rand) (default: \
          rand)"
@@ -122,42 +124,44 @@ let setup_daemon logger =
   and rest_server_port = Flag.Port.Daemon.rest_server
   and archive_process_location = Flag.Host_and_port.Daemon.archive
   and metrics_server_port =
-    flag "metrics-port"
+    flag "--metrics-port" ~aliases:["metrics-port"]
       ~doc:
         "PORT metrics server for scraping via Prometheus (default no \
          metrics-server)"
       (optional int16)
   and libp2p_metrics_port =
-    flag "libp2p-metrics-port"
+    flag "--libp2p-metrics-port" ~aliases:["libp2p-metrics-port"]
       ~doc:
         "PORT libp2p metrics server for scraping via Prometheus (default no \
          libp2p-metrics-server)"
       (optional int16)
   and external_ip_opt =
-    flag "external-ip"
+    flag "--external-ip" ~aliases:["external-ip"]
       ~doc:
         "IP External IP address for other nodes to connect to. You only need \
          to set this if auto-discovery fails for some reason."
       (optional string)
   and bind_ip_opt =
-    flag "bind-ip"
+    flag "--bind-ip" ~aliases:["bind-ip"]
       ~doc:"IP IP of network interface to use for peer connections"
       (optional string)
   and working_dir =
-    flag "working-dir"
+    flag "--working-dir" ~aliases:["working-dir"]
       ~doc:
         "PATH path to chdir into before starting (useful for background mode, \
          defaults to cwd, or / if -background)"
       (optional string)
   and is_background =
-    flag "background" no_arg ~doc:"Run process on the background"
+    flag "--background" ~aliases:["background"] no_arg
+      ~doc:"Run process on the background"
   and is_archive_rocksdb =
-    flag "archive-rocksdb" no_arg ~doc:"Stores all the blocks heard in RocksDB"
+    flag "--archive-rocksdb" ~aliases:["archive-rocksdb"] no_arg
+      ~doc:"Stores all the blocks heard in RocksDB"
   and log_json = Flag.Log.json
   and log_level = Flag.Log.level
   and file_log_level = Flag.Log.file_log_level
   and snark_work_fee =
-    flag "snark-worker-fee"
+    flag "--snark-worker-fee" ~aliases:["snark-worker-fee"]
       ~doc:
         (sprintf
            "FEE Amount a worker wants to get compensated for generating a \
@@ -165,21 +169,24 @@ let setup_daemon logger =
            (Currency.Fee.to_int Mina_compile_config.default_snark_worker_fee))
       (optional txn_fee)
   and work_reassignment_wait =
-    flag "work-reassignment-wait" (optional int)
+    flag "--work-reassignment-wait" ~aliases:["work-reassignment-wait"]
+      (optional int)
       ~doc:
         (sprintf
            "WAIT-TIME in ms before a snark-work is reassigned (default: %dms)"
            Cli_lib.Default.work_reassignment_wait)
   and enable_tracing =
-    flag "tracing" no_arg ~doc:"Trace into $config-directory/trace/$pid.trace"
+    flag "--tracing" ~aliases:["tracing"] no_arg
+      ~doc:"Trace into $config-directory/trace/$pid.trace"
   and insecure_rest_server =
-    flag "insecure-rest-server" no_arg
+    flag "--insecure-rest-server" ~aliases:["insecure-rest-server"] no_arg
       ~doc:
         "Have REST server listen on all addresses, not just localhost (this \
          is INSECURE, make sure your firewall is configured correctly!)"
   (* FIXME #4095
      and limit_connections =
-       flag "limit-concurrent-connections"
+       flag "--limit-concurrent-connections"
+         ~aliases:[ "limit-concurrent-connections"]
          ~doc:
            "true|false Limit the number of concurrent connections per IP \
             address (default: true)"
@@ -187,51 +194,54 @@ let setup_daemon logger =
   (*TODO: This is being added to log all the snark works received for the
      beta-testnet challenge. We might want to remove this later?*)
   and log_received_snark_pool_diff =
-    flag "log-snark-work-gossip"
+    flag "--log-snark-work-gossip" ~aliases:["log-snark-work-gossip"]
       ~doc:
         "true|false Log snark-pool diff received from peers (default: false)"
       (optional bool)
   and log_transaction_pool_diff =
-    flag "log-txn-pool-gossip"
+    flag "--log-txn-pool-gossip" ~aliases:["log-txn-pool-gossip"]
       ~doc:
         "true|false Log transaction-pool diff received from peers (default: \
          false)"
       (optional bool)
   and log_block_creation =
-    flag "log-block-creation"
+    flag "--log-block-creation" ~aliases:["log-block-creation"]
       ~doc:
         "true|false Log the steps involved in including transactions and \
          snark work in a block (default: true)"
       (optional bool)
   and libp2p_keypair =
-    flag "discovery-keypair" (optional string)
+    flag "--discovery-keypair" ~aliases:["discovery-keypair"] (optional string)
       ~doc:
         "KEYFILE Keypair (generated from `coda advanced \
          generate-libp2p-keypair`) to use with libp2p discovery (default: \
          generate per-run temporary keypair)"
-  and is_seed = flag "seed" ~doc:"Start the node as a seed node" no_arg
+  and is_seed =
+    flag "--seed" ~aliases:["seed"] ~doc:"Start the node as a seed node" no_arg
   and super_catchup =
-    flag "super-catchup" ~doc:"Use the experimental super-catchup" no_arg
+    flag "--super-catchup" ~aliases:["super-catchup"]
+      ~doc:"Use the experimental super-catchup" no_arg
   and enable_flooding =
-    flag "enable-flooding"
+    flag "--enable-flooding" ~aliases:["enable-flooding"]
       ~doc:
         "true|false Publish our own blocks/transactions to every peer we can \
          find (default: false)"
       (optional bool)
   and peer_exchange =
-    flag "enable-peer-exchange"
+    flag "--enable-peer-exchange" ~aliases:["enable-peer-exchange"]
       ~doc:
         "true|false Help keep the mesh connected when closing connections \
          (default: false)"
       (optional bool)
   and mina_peer_exchange =
-    flag "enable-mina-peer-exchange"
+    flag "--enable-mina-peer-exchange"
+      ~aliases:["enable-mina-peer-exchange"]
       ~doc:
         "true|false Help keep the mesh connected when closing connections \
          (default: true)"
       (optional_with_default true bool)
   and max_connections =
-    flag "max-connections"
+    flag "--max-connections" ~aliases:["max-connections"]
       ~doc:
         (Printf.sprintf
            "NN max number of connections that this peer will have to \
@@ -241,7 +251,7 @@ let setup_daemon logger =
            Cli_lib.Default.max_connections)
       (optional int)
   and validation_queue_size =
-    flag "validation-queue-size"
+    flag "--validation-queue-size" ~aliases:["validation-queue-size"]
       ~doc:
         (Printf.sprintf
            "NN size of the validation queue in the p2p network used to buffer \
@@ -254,68 +264,75 @@ let setup_daemon logger =
            Cli_lib.Default.validation_queue_size)
       (optional int)
   and direct_peers_raw =
-    flag "direct-peer"
+    flag "--direct-peer" ~aliases:["direct-peer"]
       ~doc:
         "/ip4/IPADDR/tcp/PORT/p2p/PEERID Peers to always send new messages \
          to/from. These peers should also have you configured as a direct \
          peer, the relationship is intended to be symmetric"
       (listed string)
   and isolate =
-    flag "isolate-network"
+    flag "--isolate-network" ~aliases:["isolate-network"]
       ~doc:
         "true|false Only allow connections to the peers passed on the command \
          line or configured through GraphQL. (default: false)"
       (optional bool)
   and libp2p_peers_raw =
-    flag "peer"
+    flag "--peer" ~aliases:["peer"]
       ~doc:
         "/ip4/IPADDR/tcp/PORT/p2p/PEERID initial \"bootstrap\" peers for \
          discovery"
       (listed string)
   and libp2p_peer_list_file =
-    flag "peer-list-file"
+    flag "--peer-list-file" ~aliases:["peer-list-file"]
       ~doc:
         "/ip4/IPADDR/tcp/PORT/p2p/PEERID initial \"bootstrap\" peers for \
          discovery inside a file delimited by new-lines (\\n)"
       (optional string)
   and curr_protocol_version =
-    flag "current-protocol-version" (optional string)
+    flag "--current-protocol-version"
+      ~aliases:["current-protocol-version"]
+      (optional string)
       ~doc:
         "NN.NN.NN Current protocol version, only blocks with the same version \
          accepted"
   and proposed_protocol_version =
-    flag "proposed-protocol-version" (optional string)
+    flag "--proposed-protocol-version"
+      ~aliases:["proposed-protocol-version"]
+      (optional string)
       ~doc:"NN.NN.NN Proposed protocol version to signal other nodes"
   and config_files =
-    flag "config-file"
+    flag "--config-file" ~aliases:["config-file"]
       ~doc:
         "PATH path to a configuration file (overrides CODA_CONFIG_FILE, \
          default: <config_dir>/daemon.json). Pass multiple times to override \
          fields from earlier config files"
       (listed string)
   and may_generate =
-    flag "generate-genesis-proof"
+    flag "--generate-genesis-proof" ~aliases:["generate-genesis-proof"]
       ~doc:
         "true|false Generate a new genesis proof for the current \
          configuration if none is found (default: false)"
       (optional bool)
   and disable_telemetry =
-    flag "disable-telemetry" no_arg
+    flag "--disable-telemetry" ~aliases:["disable-telemetry"] no_arg
       ~doc:"Disable reporting telemetry to other nodes"
   and proof_level =
-    flag "proof-level"
+    flag "--proof-level" ~aliases:["proof-level"]
       (optional (Arg_type.create Genesis_constants.Proof_level.of_string))
       ~doc:"full|check|none"
   and plugins = plugin_flag
   and precomputed_blocks_path =
-    flag "precomputed-blocks-file" (optional string)
+    flag "--precomputed-blocks-file"
+      ~aliases:["precomputed-blocks-file"]
+      (optional string)
       ~doc:"PATH Path to write precomputed blocks to, for replay or archiving"
   and log_precomputed_blocks =
-    flag "log-precomputed-blocks"
+    flag "--log-precomputed-blocks" ~aliases:["log-precomputed-blocks"]
       (optional_with_default false bool)
       ~doc:"true|false Include precomputed blocks in the log (default: false)"
   and upload_blocks_to_gcloud =
-    flag "upload-blocks-to-gcloud"
+    flag "--upload-blocks-to-gcloud"
+      ~aliases:["upload-blocks-to-gcloud"]
       (optional_with_default false bool)
       ~doc:
         "true|false upload blocks to gcloud storage. Requires the environment \
@@ -1071,12 +1088,12 @@ let daemon logger =
 let replay_blocks logger =
   let replay_flag =
     let open Command.Param in
-    flag "-blocks-filename" (required string)
+    flag "--blocks-filename" ~aliases:["-blocks-filename"] (required string)
       ~doc:"PATH The file to read the precomputed blocks from"
   in
   let read_kind =
     let open Command.Param in
-    flag "-format" (optional string)
+    flag "--format" ~aliases:["-format"] (optional string)
       ~doc:"json|sexp The format to read lines of the file in (default: json)"
   in
   Command.async ~summary:"Start coda daemon with blocks replayed from a file"
@@ -1238,10 +1255,10 @@ let internal_commands logger =
         ~summary:"Run verifier on a proof provided on a single line of stdin"
         (let open Command.Let_syntax in
         let%map_open mode =
-          flag "-mode" (required string)
+          flag "--mode" ~aliases:["-mode"] (required string)
             ~doc:"transaction/blockchain the snark to verify. Defaults to json"
         and format =
-          flag "-format" (optional string)
+          flag "--format" ~aliases:["-format"] (optional string)
             ~doc:"sexp/json the format to parse input in"
         in
         fun () ->
@@ -1348,11 +1365,11 @@ let internal_commands logger =
     , Command.async ~summary:"Dump the registered structured events"
         (let open Command.Let_syntax in
         let%map outfile =
-          Core_kernel.Command.Param.flag "-out-file"
+          Core_kernel.Command.Param.flag "--out-file" ~aliases:["-out-file"]
             (Core_kernel.Command.Flag.optional Core_kernel.Command.Param.string)
             ~doc:"FILENAME File to output to. Defaults to stdout"
         and pretty =
-          Core_kernel.Command.Param.flag "-pretty"
+          Core_kernel.Command.Param.flag "--pretty" ~aliases:["-pretty"]
             Core_kernel.Command.Param.no_arg
             ~doc:"  Set to output 'pretty' JSON"
         in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -53,12 +53,13 @@ let stop_daemon =
 let get_balance_graphql =
   let open Command.Param in
   let pk_flag =
-    flag "public-key"
+    flag "--public-key" ~aliases:["public-key"]
       ~doc:"PUBLICKEY Public key for which you want to check the balance"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   let token_flag =
-    flag "token" ~doc:"TOKEN_ID The token ID for the account"
+    flag "--token" ~aliases:["token"]
+      ~doc:"TOKEN_ID The token ID for the account"
       (optional_with_default Token_id.default Cli_lib.Arg_type.token_id)
   in
   Command.async ~summary:"Get balance associated with a public key"
@@ -86,7 +87,7 @@ let get_balance_graphql =
 let get_tokens_graphql =
   let open Command.Param in
   let pk_flag =
-    flag "public-key"
+    flag "--public-key" ~aliases:["public-key"]
       ~doc:"PUBLICKEY Public key for which you want to find accounts"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
@@ -161,7 +162,7 @@ let get_trust_status =
   let open Command.Param in
   let open Deferred.Let_syntax in
   let address_flag =
-    flag "ip-address"
+    flag "--ip-address" ~aliases:["ip-address"]
       ~doc:
         "IP An IPv4 or IPv6 address for which you want to query the trust \
          status"
@@ -199,7 +200,7 @@ let get_trust_status_all =
   let open Command.Param in
   let open Deferred.Let_syntax in
   let nonzero_flag =
-    flag "nonzero-only" no_arg
+    flag "--nonzero-only" ~aliases:["nonzero-only"] no_arg
       ~doc:"Only show trust statuses whose trust score is nonzero"
   in
   let json_flag = Cli_lib.Flag.json in
@@ -233,7 +234,7 @@ let reset_trust_status =
   let open Command.Param in
   let open Deferred.Let_syntax in
   let address_flag =
-    flag "ip-address"
+    flag "--ip-address" ~aliases:["ip-address"]
       ~doc:
         "IP An IPv4 or IPv6 address for which you want to reset the trust \
          status"
@@ -258,7 +259,7 @@ let get_public_keys =
   let open Daemon_rpcs in
   let open Command.Param in
   let with_details_flag =
-    flag "with-details" no_arg
+    flag "--with-details" ~aliases:["with-details"] no_arg
       ~doc:"Show extra details (eg. balance, nonce) in addition to public keys"
   in
   let error_ctx = "Failed to get public-keys" in
@@ -296,21 +297,23 @@ let verify_receipt =
   let open Command.Param in
   let open Cli_lib.Arg_type in
   let proof_path_flag =
-    flag "proof-path"
+    flag "--proof-path" ~aliases:["proof-path"]
       ~doc:"PROOFFILE File to read json version of payment receipt"
       (required string)
   in
   let payment_path_flag =
-    flag "payment-path"
+    flag "--payment-path" ~aliases:["payment-path"]
       ~doc:"PAYMENTPATH File to read json version of verifying payment"
       (required string)
   in
   let address_flag =
-    flag "address" ~doc:"PUBLICKEY Public-key address of sender"
+    flag "--address" ~aliases:["address"]
+      ~doc:"PUBLICKEY Public-key address of sender"
       (required public_key_compressed)
   in
   let token_flag =
-    flag "token" ~doc:"TOKEN_ID The token ID for the account"
+    flag "--token" ~aliases:["token"]
+      ~doc:"TOKEN_ID The token ID for the account"
       (optional_with_default Token_id.default Cli_lib.Arg_type.token_id)
   in
   Command.async ~summary:"Verify a receipt of a sent payment"
@@ -373,11 +376,13 @@ let get_nonce_cmd =
   let open Command.Param in
   (* Ignores deprecation of public_key type for backwards compatibility *)
   let[@warning "-3"] address_flag =
-    flag "address" ~doc:"PUBLICKEY Public-key address you want the nonce for"
+    flag "--address" ~aliases:["address"]
+      ~doc:"PUBLICKEY Public-key address you want the nonce for"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   let token_flag =
-    flag "token" ~doc:"TOKEN_ID The token ID for the account"
+    flag "--token" ~aliases:["token"]
+      ~doc:"TOKEN_ID The token ID for the account"
       (optional_with_default Token_id.default Cli_lib.Arg_type.token_id)
   in
   let flags = Args.zip2 address_flag token_flag in
@@ -507,16 +512,17 @@ let send_payment_graphql =
   let open Cli_lib.Arg_type in
   let open Graphql_lib in
   let receiver_flag =
-    flag "receiver" ~doc:"PUBLICKEY Public key to which you want to send money"
+    flag "--receiver" ~aliases:["receiver"]
+      ~doc:"PUBLICKEY Public key to which you want to send money"
       (required public_key_compressed)
   in
   let amount_flag =
-    flag "amount" ~doc:"VALUE Payment amount you want to send"
-      (required txn_amount)
+    flag "--amount" ~aliases:["amount"]
+      ~doc:"VALUE Payment amount you want to send" (required txn_amount)
   in
   let token_flag =
-    flag "token" ~doc:"TOKEN_ID The ID of the token to transfer"
-      (optional token_id)
+    flag "--token" ~aliases:["token"]
+      ~doc:"TOKEN_ID The ID of the token to transfer" (optional token_id)
   in
   let args =
     Args.zip4 Cli_lib.Flag.signed_command_common receiver_flag amount_flag
@@ -546,7 +552,7 @@ let delegate_stake_graphql =
   let open Cli_lib.Arg_type in
   let open Graphql_lib in
   let receiver_flag =
-    flag "receiver"
+    flag "--receiver" ~aliases:["receiver"]
       ~doc:"PUBLICKEY Public key to which you want to delegate your stake"
       (required public_key_compressed)
   in
@@ -574,7 +580,8 @@ let create_new_token_graphql =
   let open Cli_lib.Arg_type in
   let open Graphql_lib in
   let receiver_flag =
-    flag "receiver" ~doc:"PUBLICKEY Public key to create the new token for"
+    flag "--receiver" ~aliases:["receiver"]
+      ~doc:"PUBLICKEY Public key to create the new token for"
       (optional public_key_compressed)
   in
   let args = Args.zip2 Cli_lib.Flag.signed_command_common receiver_flag in
@@ -602,15 +609,18 @@ let create_new_account_graphql =
   let open Cli_lib.Arg_type in
   let open Graphql_lib in
   let receiver_flag =
-    flag "receiver" ~doc:"PUBLICKEY Public key to create the new account for"
+    flag "--receiver" ~aliases:["receiver"]
+      ~doc:"PUBLICKEY Public key to create the new account for"
       (required public_key_compressed)
   in
   let token_owner_flag =
-    flag "token-owner" ~doc:"PUBLICKEY Public key for the owner of the token"
+    flag "--token-owner" ~aliases:["token-owner"]
+      ~doc:"PUBLICKEY Public key for the owner of the token"
       (optional public_key_compressed)
   in
   let token_flag =
-    flag "token" ~doc:"TOKEN_ID The ID of the token to create the account for"
+    flag "--token" ~aliases:["token"]
+      ~doc:"TOKEN_ID The ID of the token to create the account for"
       (required token_id)
   in
   let args =
@@ -670,19 +680,19 @@ let mint_tokens_graphql =
   let open Cli_lib.Arg_type in
   let open Graphql_lib in
   let receiver_flag =
-    flag "receiver"
+    flag "--receiver" ~aliases:["receiver"]
       ~doc:
         "PUBLICKEY Public key of the account to create new tokens in \
          (defaults to the sender)"
       (optional public_key_compressed)
   in
   let token_flag =
-    flag "token" ~doc:"TOKEN_ID The ID of the token to mint"
-      (required token_id)
+    flag "--token" ~aliases:["token"]
+      ~doc:"TOKEN_ID The ID of the token to mint" (required token_id)
   in
   let amount_flag =
-    flag "amount" ~doc:"VALUE Number of new tokens to create"
-      (required txn_amount)
+    flag "--amount" ~aliases:["amount"]
+      ~doc:"VALUE Number of new tokens to create" (required txn_amount)
   in
   let args =
     Args.zip4 Cli_lib.Flag.signed_command_common receiver_flag token_flag
@@ -710,7 +720,7 @@ let mint_tokens_graphql =
 let cancel_transaction_graphql =
   let txn_id_flag =
     Command.Param.(
-      flag "id" ~doc:"ID Transaction ID to be cancelled"
+      flag "--id" ~aliases:["id"] ~doc:"ID Transaction ID to be cancelled"
         (required Cli_lib.Arg_type.user_command))
   in
   Command.async
@@ -758,7 +768,7 @@ module Export_logs = struct
 
   let tarfile_flag =
     let open Command.Param in
-    flag "tarfile"
+    flag "--tarfile" ~aliases:["tarfile"]
       ~doc:"STRING Basename of the tar archive (default: date_time)"
       (optional string)
 
@@ -859,7 +869,8 @@ let handle_dump_ledger_response ~json = function
 let dump_ledger =
   let sl_hash_flag =
     Command.Param.(
-      flag "state-hash (default: best state hash)" ~doc:"STATE-HASH State hash"
+      flag "--state-hash" ~aliases:["state-hash"]
+        ~doc:"STATE-HASH State hash (default: best state hash)"
         (optional string))
   in
   let json_flag = Cli_lib.Flag.json in
@@ -1049,7 +1060,7 @@ let set_staking_graphql =
   let open Cli_lib.Arg_type in
   let open Graphql_lib in
   let pk_flag =
-    flag "public-key"
+    flag "--public-key" ~aliases:["public-key"]
       ~doc:"PUBLICKEY Public key of account with which to produce blocks"
       (required public_key_compressed)
   in
@@ -1080,7 +1091,7 @@ let set_staking_graphql =
 let set_snark_worker =
   let open Command.Param in
   let public_key_flag =
-    flag "address"
+    flag "--address" ~aliases:["address"]
       ~doc:
         "PUBLICKEY Public-key address you wish to start snark-working on; \
          null to stop doing any snark work"
@@ -1184,7 +1195,8 @@ let export_key =
   let privkey_path = Cli_lib.Flag.privkey_write_path in
   let pk_flag =
     let open Command.Param in
-    flag "public-key" ~doc:"PUBLICKEY Public key of account to be exported"
+    flag "--public-key" ~aliases:["public-key"]
+      ~doc:"PUBLICKEY Public key of account to be exported"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   let conf_dir = Cli_lib.Flag.conf_dir in
@@ -1331,7 +1343,8 @@ let create_hd_account =
 let unlock_account =
   let open Command.Param in
   let pk_flag =
-    flag "public-key" ~doc:"PUBLICKEY Public key to be unlocked"
+    flag "--public-key" ~aliases:["public-key"]
+      ~doc:"PUBLICKEY Public key to be unlocked"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   Command.async ~summary:"Unlock a tracked account"
@@ -1365,7 +1378,8 @@ let unlock_account =
 let lock_account =
   let open Command.Param in
   let pk_flag =
-    flag "public-key" ~doc:"PUBLICKEY Public key of account to be locked"
+    flag "--public-key" ~aliases:["public-key"]
+      ~doc:"PUBLICKEY Public key of account to be locked"
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   Command.async ~summary:"Lock a tracked account"
@@ -1417,7 +1431,7 @@ let generate_libp2p_keypair =
 
 let trustlist_ip_flag =
   Command.Param.(
-    flag "ip-address"
+    flag "--ip-address" ~aliases:["ip-address"]
       ~doc:"CIDR An IPv4 CIDR mask for the client trustlist (eg, 10.0.0.0/8)"
       (required Cli_lib.Arg_type.cidr_mask))
 
@@ -1606,16 +1620,17 @@ let telemetry =
   let open Command.Param in
   let open Deferred.Let_syntax in
   let daemon_peers_flag =
-    flag "daemon-peers" no_arg
+    flag "--daemon-peers" ~aliases:["daemon-peers"] no_arg
       ~doc:"Get telemetry data for peers known to the daemon"
   in
   let peer_ids_flag =
-    flag "peer-ids"
+    flag "--peer-ids" ~aliases:["peer-ids"]
       (optional (Arg_type.comma_separated string))
       ~doc:"CSV-LIST Peer IDs for obtaining telemetry data"
   in
   let show_errors_flag =
-    flag "show-errors" no_arg ~doc:"Include error responses in output"
+    flag "--show-errors" ~aliases:["show-errors"] no_arg
+      ~doc:"Include error responses in output"
   in
   let flags = Args.zip3 daemon_peers_flag peer_ids_flag show_errors_flag in
   Command.async ~summary:"Get telemetry data for a set of peers"
@@ -1688,25 +1703,25 @@ let archive_blocks =
       Command.Param.anon
         Command.Anons.(sequence ("FILES" %: Command.Param.string))
     and success_file =
-      Command.Param.flag "successful-files"
+      Command.Param.flag "--successful-files" ~aliases:["successful-files"]
         ~doc:"PATH Appends the list of files that were processed successfully"
         (Command.Flag.optional Command.Param.string)
     and failure_file =
-      Command.Param.flag "failed-files"
+      Command.Param.flag "--failed-files" ~aliases:["failed-files"]
         ~doc:"PATH Appends the list of files that failed to be processed"
         (Command.Flag.optional Command.Param.string)
     and log_successes =
-      Command.Param.flag "log-successful"
+      Command.Param.flag "--log-successful" ~aliases:["log-successful"]
         ~doc:
           "true/false Whether to log messages for files that were processed \
            successfully"
         (Command.Flag.optional_with_default true Command.Param.bool)
     and archive_process_location = Cli_lib.Flag.Host_and_port.Daemon.archive
     and precomputed_flag =
-      Command.Param.flag "precomputed" no_arg
+      Command.Param.flag "--precomputed" ~aliases:["precomputed"] no_arg
         ~doc:"Blocks are in precomputed JSON format"
     and extensional_flag =
-      Command.Param.flag "extensional" no_arg
+      Command.Param.flag "--extensional" ~aliases:["extensional"] no_arg
         ~doc:"Blocks are in extensional JSON format"
     in
     ( files

--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -337,25 +337,25 @@ let command =
   let open Command.Let_syntax in
   Command.basic ~summary:"transaction snark profiler"
     (let%map_open n =
-       flag "k"
+       flag "-k"
          ~doc:
            "count count = log_2(number of transactions to snark) or none for \
             the mocked ones"
          (optional int)
      and repeats =
-       flag "repeat" ~doc:"count number of times to repeat the profile"
-         (optional int)
+       flag "--repeat" ~aliases:["repeat"]
+         ~doc:"count number of times to repeat the profile" (optional int)
      and preeval =
-       flag "preeval"
+       flag "--preeval" ~aliases:["preeval"]
          ~doc:
            "true/false whether to pre-evaluate the checked computation to \
             cache interpreter and computation state"
          (optional bool)
      and check_only =
-       flag "check-only"
+       flag "--check-only" ~aliases:["check-only"]
          ~doc:"Just check base snarks, don't keys or time anything" no_arg
      and witness_only =
-       flag "witness-only"
+       flag "--witness-only" ~aliases:["witness-only"]
          ~doc:"Just generate the witnesses for the base snarks" no_arg
      in
      let num_transactions =

--- a/src/app/cli/src/tests/coda_long_fork.ml
+++ b/src/app/cli/src/tests/coda_long_fork.ml
@@ -40,10 +40,10 @@ let command =
   let open Command.Let_syntax in
   Command.async ~summary:"Test that one worker goes offline for a long time"
     (let%map_open num_block_producers =
-       flag "num-block-producers" ~doc:"NUM number of block producers to have"
-         (required int)
+       flag "--num-block-producers" ~aliases:["num-block-producers"]
+         ~doc:"NUM number of block producers to have" (required int)
      and waiting_time =
-       flag "waiting-time"
+       flag "--waiting-time" ~aliases:["waiting-time"]
          ~doc:"the waiting time after the nodes coming back alive"
          (optional_with_default 120 int)
      in

--- a/src/app/cli/src/tests/coda_restarts_and_txns_holy_grail.ml
+++ b/src/app/cli/src/tests/coda_restarts_and_txns_holy_grail.ml
@@ -59,7 +59,7 @@ let command =
       "Test the holy grail for n nodes: All sorts of restarts and \
        transactions work"
     (let%map_open num_block_producers =
-       flag "num-block-producers" ~doc:"NUM number of block producers to have"
-         (required int)
+       flag "--num-block-producers" ~aliases:["num-block-producers"]
+         ~doc:"NUM number of block producers to have" (required int)
      in
      main num_block_producers)

--- a/src/app/cli/src/tests/coda_shared_prefix_multiproducer_test.ml
+++ b/src/app/cli/src/tests/coda_shared_prefix_multiproducer_test.ml
@@ -33,9 +33,10 @@ let command =
   let open Command.Let_syntax in
   Command.async ~summary:"Test that workers share prefixes"
     (let%map_open num_block_producers =
-       flag "num-block-producers" ~doc:"NUM number of block producers to have"
-         (required int)
+       flag "--num-block-producers" ~aliases:["num-block-producers"]
+         ~doc:"NUM number of block producers to have" (required int)
      and enable_payments =
-       flag "payments" no_arg ~doc:"enable the payment check"
+       flag "--payments" ~aliases:["payments"] no_arg
+         ~doc:"enable the payment check"
      in
      main num_block_producers enable_payments)

--- a/src/app/cli/src/tests/coda_shared_prefix_test.ml
+++ b/src/app/cli/src/tests/coda_shared_prefix_test.ml
@@ -28,7 +28,7 @@ let command =
   let open Command.Let_syntax in
   Command.async ~summary:"Test that workers share prefixes"
     (let%map_open who_produces =
-       flag "who-produces" ~doc:"ID node number which will be producing blocks"
-         (required int)
+       flag "--who-produces" ~aliases:["who-produces"]
+         ~doc:"ID node number which will be producing blocks" (required int)
      in
      main who_produces)

--- a/src/app/reformat/reformat.ml
+++ b/src/app/reformat/reformat.ml
@@ -73,10 +73,12 @@ let main dry_run check path =
 let cli =
   let open Command.Let_syntax in
   Command.async ~summary:"Format all ml and mli files"
-    (let%map_open path = flag "path" ~doc:"Path to traverse" (required string)
-     and dry_run = flag "dry-run" no_arg ~doc:"Dry run"
+    (let%map_open path =
+       flag "--path" ~aliases:["path"] ~doc:"Path to traverse"
+         (required string)
+     and dry_run = flag "--dry-run" ~aliases:["dry-run"] no_arg ~doc:"Dry run"
      and check =
-       flag "check" no_arg
+       flag "--check" ~aliases:["check"] no_arg
          ~doc:
            "Return with an error code if there exists an ml file that was \
             formatted improperly"

--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -82,18 +82,22 @@ let server_handler ~pool ~graphql_uri ~logger ~body _sock req =
 let command =
   let open Command.Let_syntax in
   let%map_open archive_uri =
-    flag "archive-uri"
+    flag "--archive-uri" ~aliases:["archive-uri"]
       ~doc:"Postgres connection string URI corresponding to archive node"
       Cli.required_uri
   and graphql_uri =
-    flag "graphql-uri" ~doc:"URI of Coda GraphQL endpoint to connect to"
-      Cli.required_uri
+    flag "--graphql-uri" ~aliases:["graphql-uri"]
+      ~doc:"URI of Coda GraphQL endpoint to connect to" Cli.required_uri
   and log_json =
-    flag "log-json" ~doc:"Print log output as JSON (default: plain text)"
-      no_arg
+    flag "--log-json" ~aliases:["log-json"]
+      ~doc:"Print log output as JSON (default: plain text)" no_arg
   and log_level =
-    flag "log-level" ~doc:"Set log level (default: Info)" Cli.log_level
-  and port = flag "port" ~doc:"Port to expose Rosetta server" (required int) in
+    flag "--log-level" ~aliases:["log-level"]
+      ~doc:"Set log level (default: Info)" Cli.log_level
+  and port =
+    flag "--port" ~aliases:["port"] ~doc:"Port to expose Rosetta server"
+      (required int)
+  in
   let open Deferred.Let_syntax in
   fun () ->
     let logger = Logger.create () in

--- a/src/app/rosetta/ocaml-signer/signer.ml
+++ b/src/app/rosetta/ocaml-signer/signer.ml
@@ -9,11 +9,12 @@ open Lib
 let sign_command =
   let open Command.Let_syntax in
   let%map_open unsigned_transaction =
-    flag "unsigned-transaction"
+    flag "--unsigned-transaction" ~aliases:["unsigned-transaction"]
       ~doc:"Unsigned transaction string returned from Rosetta"
       (required string)
   and private_key =
-    flag "private-key" ~doc:"Private key hex bytes" (required string)
+    flag "--private-key" ~aliases:["private-key"] ~doc:"Private key hex bytes"
+      (required string)
   in
   let open Deferred.Let_syntax in
   fun () ->
@@ -30,10 +31,11 @@ let sign_command =
 let verify_command =
   let open Command.Let_syntax in
   let%map_open signed_transaction =
-    flag "signed-transaction"
+    flag "--signed-transaction" ~aliases:["signed-transaction"]
       ~doc:"Signed transaction string returned from Rosetta" (required string)
   and public_key =
-    flag "public-key" ~doc:"Public key hex bytes" (required string)
+    flag "--public-key" ~aliases:["public-key"] ~doc:"Public key hex bytes"
+      (required string)
   in
   let open Deferred.Let_syntax in
   fun () ->
@@ -53,7 +55,8 @@ let verify_command =
 let derive_command =
   let open Command.Let_syntax in
   let%map_open private_key =
-    flag "private-key" ~doc:"Private key hex bytes" (required string)
+    flag "--private-key" ~aliases:["private-key"] ~doc:"Private key hex bytes"
+      (required string)
   in
   let open Deferred.Let_syntax in
   fun () ->

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -618,19 +618,20 @@ let run ~logger ~rosetta_uri ~graphql_uri ~don't_exit =
 let command =
   let open Command.Let_syntax in
   let%map_open rosetta_uri =
-    flag "rosetta-uri" ~doc:"URI of Rosetta endpoint to connect to"
-      Cli.required_uri
+    flag "--rosetta-uri" ~aliases:["rosetta-uri"]
+      ~doc:"URI of Rosetta endpoint to connect to" Cli.required_uri
   and graphql_uri =
-    flag "graphql-uri" ~doc:"URI of Coda GraphQL endpoint to connect to"
-      Cli.required_uri
+    flag "--graphql-uri" ~aliases:["graphql-uri"]
+      ~doc:"URI of Coda GraphQL endpoint to connect to" Cli.required_uri
   and log_json =
-    flag "log-json" ~doc:"Print log output as JSON (default: plain text)"
-      no_arg
+    flag "--log-json" ~aliases:["log-json"]
+      ~doc:"Print log output as JSON (default: plain text)" no_arg
   and log_level =
-    flag "log-level" ~doc:"Set log level (default: Info)" Cli.log_level
+    flag "--log-level" ~aliases:["log-level"]
+      ~doc:"Set log level (default: Info)" Cli.log_level
   and don't_exit =
-    flag "dont-exit" ~doc:"Don't exit after tests finish (default: do exit)"
-      no_arg
+    flag "--dont-exit" ~aliases:["dont-exit"]
+      ~doc:"Don't exit after tests finish (default: do exit)" no_arg
   in
   let open Deferred.Let_syntax in
   fun () ->

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -2,29 +2,31 @@ open Core
 
 let json =
   Command.Param.(
-    flag "json" no_arg ~doc:"Use json output (default: plaintext)")
+    flag "--json" ~aliases:["json"] no_arg
+      ~doc:"Use json output (default: plaintext)")
 
 let performance =
   Command.Param.(
-    flag "performance" no_arg
+    flag "--performance" ~aliases:["performance"] no_arg
       ~doc:
         "Include performance histograms in status output (default: don't \
          include)")
 
 let privkey_write_path =
   let open Command.Param in
-  flag "privkey-path"
+  flag "--privkey-path" ~aliases:["privkey-path"]
     ~doc:"FILE File to write private key into (public key will be FILE.pub)"
     (required string)
 
 let privkey_read_path =
   let open Command.Param in
-  flag "privkey-path" ~doc:"FILE File to read private key from"
-    (required string)
+  flag "--privkey-path" ~aliases:["privkey-path"]
+    ~doc:"FILE File to read private key from" (required string)
 
 let conf_dir =
   let open Command.Param in
-  flag "config-directory" ~doc:"DIR Configuration directory" (optional string)
+  flag "--config-directory" ~aliases:["config-directory"]
+    ~doc:"DIR Configuration directory" (optional string)
 
 module Doc_builder = struct
   type 'value t =
@@ -65,24 +67,25 @@ module Types = struct
     | Resolve_with_default : 'value -> ('value, 'value with_name) t
 end
 
-let setup_flag ~arg_type ~name doc =
+let setup_flag ~arg_type ~name ?aliases doc =
   let open Command.Let_syntax in
-  Command.Param.flag name ~doc (Command.Param.optional arg_type)
+  Command.Param.flag name ?aliases ~doc (Command.Param.optional arg_type)
   >>| Option.map ~f:(fun value -> {Types.name; value})
 
 let create (type value output) :
        name:string
+    -> ?aliases:string list
     -> arg_type:value Command.Arg_type.t
     -> value Doc_builder.t
     -> (value, output) Types.t
     -> output Command.Param.t =
   let open Command.Let_syntax in
-  fun ~name ~arg_type doc_builder -> function
+  fun ~name ?aliases ~arg_type doc_builder -> function
     | Optional ->
-        setup_flag ~arg_type ~name
+        setup_flag ~arg_type ~name ?aliases
           (Doc_builder.display ~default:None doc_builder)
     | Optional_with_displayed_default default -> (
-        setup_flag ~arg_type ~name
+        setup_flag ~arg_type ~name ?aliases
           (Doc_builder.display ~default:(Some default) doc_builder)
         >>| function
         | Some {name; value} ->
@@ -90,7 +93,7 @@ let create (type value output) :
         | None ->
             {name; value= None; default} )
     | Resolve_with_default default ->
-        setup_flag ~arg_type ~name
+        setup_flag ~arg_type ~name ?aliases
           (Doc_builder.display ~default:(Some default) doc_builder)
         >>| Option.value ~default:{Types.name; value= default}
 
@@ -100,8 +103,8 @@ module Port = struct
   let doc_builder description =
     Doc_builder.create ~display:to_string "PORT" description
 
-  let create ~name ~default description =
-    create ~name (doc_builder description)
+  let create ~name ?aliases ~default description =
+    create ~name ?aliases (doc_builder description)
       (Optional_with_displayed_default default) ~arg_type:Arg_type.int16
 
   let default_client = 8301
@@ -128,22 +131,24 @@ module Port = struct
 
   module Daemon = struct
     let external_ =
-      create ~name:"external-port" ~default:default_libp2p
+      create ~name:"--external-port" ~aliases:["external-port"]
+        ~default:default_libp2p
         "Port to use for all libp2p communications (gossip and RPC)"
 
     let client =
-      create ~name:"client-port" ~default:default_client
+      create ~name:"--client-port" ~aliases:["client-port"]
+        ~default:default_client
         "local RPC-server for clients to interact with the daemon"
 
     let rest_server =
-      create ~name:"rest-port" ~default:default_rest
+      create ~name:"--rest-port" ~aliases:["rest-port"] ~default:default_rest
         "local REST-server for daemon interaction"
   end
 
   module Archive = struct
     let server =
-      create ~name:"server-port" ~default:default_archive
-        "port to launch the archive server"
+      create ~name:"--server-port" ~aliases:["server-port"]
+        ~default:default_archive "port to launch the archive server"
   end
 end
 
@@ -188,7 +193,7 @@ module Host_and_port = struct
 
   module Client = struct
     let daemon =
-      create ~name:"daemon-port" ~arg_type
+      create ~name:"--daemon-port" ~aliases:["daemon-port"] ~arg_type
         (make_doc_builder "Client to local daemon communication"
            Port.default_client)
         (Resolve_with_default (Port.to_host_and_port Port.default_client))
@@ -196,7 +201,7 @@ module Host_and_port = struct
 
   module Daemon = struct
     let archive =
-      create ~name:"archive-address" ~arg_type
+      create ~name:"--archive-address" ~aliases:["archive-address"] ~arg_type
         (make_doc_builder "Daemon to archive process communication"
            Port.default_archive)
         Optional
@@ -235,8 +240,8 @@ module Uri = struct
                 ^/ "graphql" ) ]
           "URI/LOCALHOST-PORT" "graphql rest server for daemon interaction"
       in
-      create ~name:"rest-server" ~arg_type:(arg_type ~path:"graphql")
-        doc_builder
+      create ~name:"--rest-server" ~aliases:["rest-server"]
+        ~arg_type:(arg_type ~path:"graphql") doc_builder
         (Resolve_with_default (Port.to_uri ~path:"graphql" Port.default_rest))
   end
 
@@ -248,7 +253,7 @@ module Uri = struct
             [Uri.of_string "postgres://admin:codarules@postgres:5432/archiver"]
           "URI" "URI for postgresql database"
       in
-      create ~name:"postgres-uri"
+      create ~name:"--postgres-uri" ~aliases:["postgres-uri"]
         ~arg_type:(Command.Arg_type.map Command.Param.string ~f:Uri.of_string)
         doc_builder
         (Resolve_with_default
@@ -259,7 +264,7 @@ end
 module Log = struct
   let json =
     let open Command.Param in
-    flag "log-json" no_arg
+    flag "--log-json" ~aliases:["log-json"] no_arg
       ~doc:"Print log output as JSON (default: plain text)"
 
   let all_levels =
@@ -269,7 +274,8 @@ module Log = struct
     let log_level = Arg_type.log_level in
     let open Command.Param in
     let doc = sprintf "LEVEL Set log level (%s, default: Info)" all_levels in
-    flag "log-level" ~doc (optional_with_default Logger.Level.Info log_level)
+    flag "--log-level" ~aliases:["log-level"] ~doc
+      (optional_with_default Logger.Level.Info log_level)
 
   let file_log_level =
     let log_level = Arg_type.log_level in
@@ -278,7 +284,7 @@ module Log = struct
       sprintf "LEVEL Set log level for the log file (%s, default: Trace)"
         all_levels
     in
-    flag "file-log-level" ~doc
+    flag "--file-log-level" ~aliases:["file-log-level"] ~doc
       (optional_with_default Logger.Level.Trace log_level)
 end
 
@@ -292,11 +298,11 @@ let signed_command_common : signed_command_common Command.Param.t =
   let open Command.Let_syntax in
   let open Arg_type in
   let%map_open sender =
-    flag "sender"
+    flag "--sender" ~aliases:["sender"]
       (required public_key_compressed)
       ~doc:"PUBLICKEY Public key from which you want to send the transaction"
   and fee =
-    flag "fee"
+    flag "--fee" ~aliases:["fee"]
       ~doc:
         (Printf.sprintf
            "FEE Amount you are willing to pay to process the transaction \
@@ -307,7 +313,7 @@ let signed_command_common : signed_command_common Command.Param.t =
               Mina_base.Signed_command.minimum_fee))
       (optional txn_fee)
   and nonce =
-    flag "nonce"
+    flag "--nonce" ~aliases:["nonce"]
       ~doc:
         "NONCE Nonce that you would like to set for your transaction \
          (default: nonce of your account on the best ledger or the successor \
@@ -315,8 +321,8 @@ let signed_command_common : signed_command_common Command.Param.t =
          transaction pool )"
       (optional txn_nonce)
   and memo =
-    flag "memo" ~doc:"STRING Memo accompanying the transaction"
-      (optional string)
+    flag "--memo" ~aliases:["memo"]
+      ~doc:"STRING Memo accompanying the transaction" (optional string)
   in
   { sender
   ; fee= Option.value fee ~default:Mina_compile_config.default_transaction_fee
@@ -328,22 +334,23 @@ module Signed_command = struct
 
   let hd_index =
     let open Command.Param in
-    flag "HD-index" ~doc:"HD-INDEX Index used by hardware wallet"
-      (required hd_index)
+    flag "--hd-index" ~aliases:["HD-index"]
+      ~doc:"HD-INDEX Index used by hardware wallet" (required hd_index)
 
   let receiver_pk =
     let open Command.Param in
-    flag "receiver" ~doc:"PUBLICKEY Public key to which you want to send money"
+    flag "--receiver" ~aliases:["receiver"]
+      ~doc:"PUBLICKEY Public key to which you want to send money"
       (required public_key_compressed)
 
   let amount =
     let open Command.Param in
-    flag "amount" ~doc:"VALUE Payment amount you want to send"
-      (required txn_amount)
+    flag "--amount" ~aliases:["amount"]
+      ~doc:"VALUE Payment amount you want to send" (required txn_amount)
 
   let fee =
     let open Command.Param in
-    flag "fee"
+    flag "--fee" ~aliases:["fee"]
       ~doc:
         (Printf.sprintf
            "FEE Amount you are willing to pay to process the transaction \
@@ -356,7 +363,7 @@ module Signed_command = struct
 
   let valid_until =
     let open Command.Param in
-    flag "valid-until"
+    flag "--valid-until" ~aliases:["valid-until"]
       ~doc:
         "GLOBAL-SLOT The last global-slot at which this transaction will be \
          considered valid. This makes it possible to have transactions which \
@@ -366,7 +373,7 @@ module Signed_command = struct
 
   let nonce =
     let open Command.Param in
-    flag "nonce"
+    flag "--nonce" ~aliases:["nonce"]
       ~doc:
         "NONCE Nonce that you would like to set for your transaction \
          (default: nonce of your account on the best ledger or the successor \
@@ -376,7 +383,7 @@ module Signed_command = struct
 
   let memo =
     let open Command.Param in
-    flag "memo"
+    flag "--memo" ~aliases:["memo"]
       ~doc:
         (sprintf
            "STRING Memo accompanying the transaction (up to %d characters)"

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -244,15 +244,16 @@ module Make (Inputs : Intf.Inputs_intf) :
     Command.async ~summary:"Snark worker"
       (let open Command.Let_syntax in
       let%map_open daemon_port =
-        flag "daemon-address"
+        flag "--daemon-address" ~aliases:["daemon-address"]
           (required (Arg_type.create Host_and_port.of_string))
           ~doc:"HOST-AND-PORT address daemon is listening on"
       and proof_level =
-        flag "proof-level"
+        flag "--proof-level" ~aliases:["proof-level"]
           (optional (Arg_type.create Genesis_constants.Proof_level.of_string))
           ~doc:"full|check|none"
       and shutdown_on_disconnect =
-        flag "shutdown-on-disconnect" (optional bool)
+        flag "--shutdown-on-disconnect" ~aliases:["shutdown-on-disconnect"]
+          (optional bool)
           ~doc:
             "true|false Shutdown when disconnected from daemon (default:true)"
       in


### PR DESCRIPTION
This converts all our non-POSIX-compliant flags to POSIX-compliant ones. The original forms are preserved as aliases, so all our scripts etc. should still work.

This also fixes a flag where the default argument was part of the name 🤦‍♂️ 

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
