### PR TITLE
Key validation improvements

### DIFF
--- a/src/app/client_sdk/js_util.ml
+++ b/src/app/client_sdk/js_util.ml
@@ -9,7 +9,14 @@ module Global_slot = Mina_numbers_nonconsensus.Global_slot
 module Memo = Signed_command_memo
 module Signature_lib = Signature_lib_nonconsensus
 
+let raise_js_error s = Js.raise_js_error (new%js Js.error_constr (Js.string s))
+
 type string_js = Js.js_string Js.t
+
+type keypair_js =
+  < privateKey: string_js Js.readonly_prop
+  ; publicKey: string_js Js.readonly_prop >
+  Js.t
 
 type payload_common_js =
   < fee: string_js Js.prop

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -36,14 +36,14 @@ let validate_keypair =
               try Public_key.Compressed.of_base58_check_exn line
               with _exn ->
                 eprintf
-                  "Could not create public key in file %s from text: %s\n!"
+                  "Could not create public key in file %s from text: %s\n"
                   pubkey_path line ;
                 exit 1 )
             | None ->
-                eprintf "No public key found in file %s\n!" pubkey_path ;
+                eprintf "No public key found in file %s\n" pubkey_path ;
                 exit 1 )
       with exn ->
-        eprintf "Could not read public key file %s, error: %s\n!" pubkey_path
+        eprintf "Could not read public key file %s, error: %s\n" pubkey_path
           (Exn.to_string exn) ;
         exit 1
     in

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -27,6 +27,37 @@ let validate_keypair =
     let%map_open privkey_path = Flag.privkey_write_path in
     Exceptions.handle_nicely
     @@ fun () ->
+    let read_pk () =
+      let pubkey_path = privkey_path ^ ".pub" in
+      try
+        In_channel.with_file pubkey_path ~f:(fun in_channel ->
+            match In_channel.input_line in_channel with
+            | Some line -> (
+              try Public_key.Compressed.of_base58_check_exn line
+              with _exn ->
+                eprintf
+                  "Could not create public key in file %s from text: %s\n!"
+                  pubkey_path line ;
+                exit 1 )
+            | None ->
+                eprintf "No public key found in file %s\n!" pubkey_path ;
+                exit 1 )
+      with exn ->
+        eprintf "Could not read public key file %s, error: %s\n!" pubkey_path
+          (Exn.to_string exn) ;
+        exit 1
+    in
+    let compare_public_keys ~pk_from_disk ~pk_from_keypair =
+      if Public_key.Compressed.equal pk_from_disk pk_from_keypair then
+        printf "Public key on-disk is derivable from private key\n"
+      else (
+        eprintf
+          "Public key read from disk %s different than public key %s derived \
+           from private key\n"
+          (Public_key.Compressed.to_base58_check pk_from_disk)
+          (Public_key.Compressed.to_base58_check pk_from_keypair) ;
+        exit 1 )
+    in
     let validate_transaction keypair =
       let dummy_payload = Mina_base.Signed_command_payload.dummy in
       let signature =
@@ -53,6 +84,9 @@ let validate_keypair =
       in
       match%map Secrets.Keypair.read ~privkey_path ~password with
       | Ok keypair ->
+          let pk_from_disk = read_pk () in
+          compare_public_keys ~pk_from_disk
+            ~pk_from_keypair:(keypair.public_key |> Public_key.compress) ;
           validate_transaction keypair
       | Error err ->
           eprintf "Could not read the specified keypair: %s\n"


### PR DESCRIPTION
For the key validation in CLI, and the separate executable, check that the on-disk `.pub` file contains the same Base58Check public key as is derived from the on-disk private key. The existing validator synthesized the public key from the private key, without examining the public key file at all. So you could have relied on the validator giving a positive result, given a good private key file, while the public key file could have been missing, or contained anything whatsoever.

Tested using the daemon `advanced validate-keypair` command, with good and bad keypaths.

Similarly, for the client SDK, add a method `validKeypair`, which checks that the contained public key is derivable from the private key. Further, like the CLI command, try to sign a dummy transaction. If the method succeeds, return a JS `true`, else raise a JS error containing an informative string.

Tested with `nodejs`, using good and bad keypairs. In particular, tested with a keypair returned from `genKeys` (yes, it was valid).

The motivation for this PR is the apparent operator error described in #7741.