### PR TITLE
Helm: add persistent storage for block-producer

### DIFF
--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -312,7 +312,12 @@ spec:
       - name: wallet-keys
         emptyDir: {}
       - name: config-dir
+      {{- if $.Values.coda.persistentStorage }}
+        persistentVolumeClaim:
+          claimName: mina-pv-claim
+      {{- else }}
         emptyDir: {}
+      {{- end }}
       - name: actual-libp2p
         emptyDir: {}
       {{- if $.Values.coda.runtimeConfig }}
@@ -330,6 +335,21 @@ spec:
             path: keyfile.json
       {{- end }}
 ---
+{{- if $.Values.coda.persistentStorage }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mina-pv-claim
+  labels:
+    app: mina
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/block-producer/values.yaml
+++ b/helm/block-producer/values.yaml
@@ -6,6 +6,7 @@ coda:
   logLevel: "Debug"
   logSnarkWorkGossip: false
   image: codaprotocol/coda-daemon:0.0.16-beta7-develop
+  persistentStorage: false
   privkeyPass: "naughty blue worm"
   seedPeers:
     - /dns4/seed-one.genesis-redux.o1test.net/tcp/10002/p2p/12D3KooWP7fTKbyiUcYJGajQDpCFo2rDexgTHFJTxCH8jvcL1eAH


### PR DESCRIPTION
The current helm chart seems geared towards integration testing, but
for a production node operator to be able to use helm, it is desirable for the
state to persist across restarts.

Adding an option to helm chart `.coda.persistentStorage` achieves this.

Defaults to false.

Sumbitted as part of my attempt to make https://github.com/midl-dev/mina-pulumi
project work well with default chart.