### PR TITLE
helm: add -super-catchup by default to the block-producer chart

### DIFF
--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -204,6 +204,7 @@ spec:
           {{- end }}
           {{- if $.Values.coda.runtimeConfig }}
           "-config-file", "/config/daemon.json",
+          "-super-catchup",
           {{- end -}}
           "-generate-genesis-proof", {{ $.Values.coda.generateGenesisProof | quote }}
         ]


### PR DESCRIPTION
Super-catchup is a recommended option to operate a block producer, see:

https://minaprotocol.com/docs/connecting

Sumbitted as part of my attempt to make https://github.com/midl-dev/mina-pulumi
project work well with default chart.