### PR TITLE
helm: relax requests for block producer to 7 vcpus instead of 8

### DIFF
--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -169,7 +169,7 @@ spec:
           limits:
           requests:
             memory: 8.0Gi
-            cpu: 8.0
+            cpu: 7.0
         image: {{ $.Values.coda.image }}
         args: [ "daemon",
           "-log-level", {{ $.Values.coda.logLevel }},


### PR DESCRIPTION
The mina documentation recommends a c5.2xlarge instance to run the
block producer, but using such an instance in EKS will result in the
pod not starting due to not enough CPU.

Changing the request to 7 leaves enough CPU for the kubernetes system
daemons. It should be minimally disruptive to other consumers of this
chart.

Sumbitted as part of my attempt to make https://github.com/midl-dev/mina-pulumi
project work well with default chart.