### PR TITLE
Fix addPeers graphql endpoint and command

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -3003,6 +3003,16 @@
               "description": "Connect to the given peers",
               "args": [
                 {
+                  "name": "seed",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "peers",
                   "description": null,
                   "type": {

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -314,8 +314,8 @@ query get_peers {
 module Add_peers =
 [%graphql
 {|
-mutation ($peers: [NetworkPeer!]!) {
-  addPeers(peers: $peers) {
+mutation ($peers: [NetworkPeer!]!, $seed: Boolean) {
+  addPeers(peers: $peers, seed: $seed) {
     host
     libp2pPort
     peerId

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2514,8 +2514,8 @@ module Mutations = struct
       ~args:
         Arg.
           [ arg "peers" ~typ:(non_null @@ list @@ non_null @@ Types.Input.peer)
-          ; arg "seed" ~typ:(non_null bool) ]
-      ~doc:"Connect to the given peers as seeds"
+          ; arg "seed" ~typ:bool ]
+      ~doc:"Connect to the given peers"
       ~typ:(non_null @@ list @@ non_null Types.DaemonStatus.peer)
       ~resolve:(fun {ctx= coda; _} () peers seed ->
         let open Deferred.Result.Let_syntax in
@@ -2526,6 +2526,7 @@ module Mutations = struct
           |> Deferred.return
         in
         let net = Mina_lib.net coda in
+        let seed = Option.value ~default:true seed in
         let%bind.Async maybe_failure =
           (* Add peers until we find an error *)
           Deferred.List.find_map peers ~f:(fun peer ->


### PR DESCRIPTION
This fixes #7838, which was caused by #7751.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #7838