### PR TITLE
libp2p helper: add conn direction check to peer exchange, other fixes

### DIFF
--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -434,7 +434,7 @@ func (h *Helper) getRandomPeers(num int, from peer.ID) []peer.AddrInfo {
 		for {
 			if idx >= len(peers) {
 				return ret
-			} else if peers[idx] != h.Host.ID() && peers[idx] != from {
+			} else if peers[idx] != h.Host.ID() && peers[idx] != from && len(h.Host.Peerstore().PeerInfo(peers[idx]).Addrs) != 0 {
 				break
 			} else {
 				idx += 1


### PR DESCRIPTION
Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

Explain your changes here.
- add conn direction check, return if not outbound (ie. we didn't initiate the connection)
- fix go func scoping
- only return peers if they have non-empty `AddrInfo`

Explain how you tested your changes here.
`go test ./... -run TestGetPeerMessage -v`

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
