### PR TITLE
Move ledger dumps to ledger subcommand

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -1401,6 +1401,7 @@ let mina_commands logger =
   ; ("daemon", daemon logger)
   ; ("client", Client.client)
   ; ("advanced", Client.advanced)
+  ; ("ledger", Client.ledger)
   ; ( "internal"
     , Command.group ~summary:"Internal commands" (internal_commands logger) )
   ; (Parallel.worker_command_name, Parallel.worker_command)

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -875,7 +875,10 @@ let dump_ledger =
   in
   let plaintext_flag = Cli_lib.Flag.plaintext in
   let flags = Args.zip2 sl_hash_flag plaintext_flag in
-  Command.async ~summary:"Print the ledger with given Merkle root"
+  Command.async
+    ~summary:
+      "Print the staged ledger from the block with the given state hash \
+       (default: staged ledger at the best tip)"
     (Cli_lib.Background_daemon.rpc_init flags ~f:(fun port (x, plaintext) ->
          (* TODO: allow input in Base58Check format: issue #3036 *)
          let state_hash = Option.map ~f:State_hash.of_base58_check_exn x in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -873,14 +873,14 @@ let dump_ledger =
         ~doc:"STATE-HASH State hash (default: best state hash)"
         (optional string))
   in
-  let json_flag = Cli_lib.Flag.json in
-  let flags = Args.zip2 sl_hash_flag json_flag in
+  let plaintext_flag = Cli_lib.Flag.plaintext in
+  let flags = Args.zip2 sl_hash_flag plaintext_flag in
   Command.async ~summary:"Print the ledger with given Merkle root"
-    (Cli_lib.Background_daemon.rpc_init flags ~f:(fun port (x, json) ->
+    (Cli_lib.Background_daemon.rpc_init flags ~f:(fun port (x, plaintext) ->
          (* TODO: allow input in Base58Check format: issue #3036 *)
          let state_hash = Option.map ~f:State_hash.of_base58_check_exn x in
          Daemon_rpcs.Client.dispatch Daemon_rpcs.Get_ledger.rpc state_hash port
-         >>| handle_dump_ledger_response ~json ))
+         >>| handle_dump_ledger_response ~json:(not plaintext) ))
 
 let dump_staking_ledger =
   let which =
@@ -891,12 +891,13 @@ let dump_staking_ledger =
     Command.Param.(anon ("current|next" %: t))
   in
   Command.async ~summary:"Print either the staking or next epoch ledger"
-    (Cli_lib.Background_daemon.rpc_init (Args.zip2 which Cli_lib.Flag.json)
-       ~f:(fun port (which, json) ->
+    (Cli_lib.Background_daemon.rpc_init
+       (Args.zip2 which Cli_lib.Flag.plaintext)
+       ~f:(fun port (which, plaintext) ->
          (* TODO: allow input in Base58Check format: issue #3036 *)
          Daemon_rpcs.Client.dispatch Daemon_rpcs.Get_staking_ledger.rpc which
            port
-         >>| handle_dump_ledger_response ~json ))
+         >>| handle_dump_ledger_response ~json:(not plaintext) ))
 
 let constraint_system_digests =
   Command.async ~summary:"Print MD5 digest of each SNARK constraint"
@@ -1960,8 +1961,6 @@ let advanced =
     ; ("status-clear-hist", status_clear_hist)
     ; ("wrap-key", wrap_key)
     ; ("dump-keypair", dump_keypair)
-    ; ("dump-ledger", dump_ledger)
-    ; ("dump-staking-ledger", dump_staking_ledger)
     ; ("constraint-system-digests", constraint_system_digests)
     ; ("start-tracing", start_tracing)
     ; ("stop-tracing", stop_tracing)
@@ -1983,3 +1982,7 @@ let advanced =
     ; ("add-peers", add_peers_graphql)
     ; ("object-lifetime-statistics", object_lifetime_statistics)
     ; ("archive-blocks", archive_blocks) ]
+
+let ledger =
+  Command.group ~summary:"Ledger commands"
+    [("dump-ledger", dump_ledger); ("dump-staking-ledger", dump_staking_ledger)]

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -3,7 +3,12 @@ open Core
 let json =
   Command.Param.(
     flag "--json" ~aliases:["json"] no_arg
-      ~doc:"Use json output (default: plaintext)")
+      ~doc:"Use JSON output (default: plaintext)")
+
+let plaintext =
+  Command.Param.(
+    flag "--plaintext" ~aliases:["plaintext"] no_arg
+      ~doc:"Use plaintext output (default: JSON)")
 
 let performance =
   Command.Param.(

--- a/src/lib/cli_lib/flag.mli
+++ b/src/lib/cli_lib/flag.mli
@@ -2,6 +2,8 @@ open Core
 
 val json : bool Command.Spec.param
 
+val plaintext : bool Command.Spec.param
+
 val performance : bool Command.Spec.param
 
 val privkey_write_path : string Command.Spec.param


### PR DESCRIPTION
Move the `dump-ledger` and `dump-staking-ledger` subcommands from `advanced` to a new `ledger` command.

For both of those, the default output is JSON; using `--plaintext` produces an S-expression.

First baby steps towards #7737.
