### PR TITLE
Make it so Rosetta construction routes don't need archive URI/connection/pool

### DIFF
--- a/src/app/rosetta/lib/cli.ml
+++ b/src/app/rosetta/lib/cli.ml
@@ -3,6 +3,9 @@ open Core_kernel
 let required_uri =
   Command.Param.(required (Command.Arg_type.map string ~f:Uri.of_string))
 
+let optional_uri =
+  Command.Param.(optional (Command.Arg_type.map string ~f:Uri.of_string))
+
 let log_level =
   let open Command.Param in
   optional_with_default Logger.Level.Info


### PR DESCRIPTION
Refactors the Rosetta server code so the archive URI is optional and only used to instantiate a DB connection/pool when a request is made to a top-level route that may need it (i.e., any route other than `construction/*`).

To test I ran Rosetta's test suite and saw it still passes with the existing parameters; then started Rosetta without the `archive-uri` parameter set (along with Mina running without `archive-address` set) and made sure `construction/*` routes worked but others failed gracefully.

TODO:
- This means the first non-`construction/*` call to any Rosetta server will be slower than normal since it needs to instantiate the DB connection. Is this okay?
- We previously were just returning `Deferred.unit` when failing to connect to the DB (when an archive URI was passed); this now returns a SQL error instead. Is this okay?

Checklist:
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #7690
