### PR TITLE
Intg test: Gossip consistency test

### DIFF
--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -41,7 +41,7 @@ locals {
       seedPeers          = local.peers
       logLevel           = var.log_level
       logSnarkWorkGossip = var.log_snark_work_gossip
-      log_txn_pool_gossip = var.log_txn_pool_gossip
+      logTxnPoolGossip = var.log_txn_pool_gossip
       ports = {
         client  = "8301"
         graphql = "3085"

--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -18,6 +18,7 @@ locals {
     logLevel             = var.log_level
     logSnarkWorkGossip   = var.log_snark_work_gossip
     logPrecomputedBlocks = var.log_precomputed_blocks
+    log_txn_pool_gossip = var.log_txn_pool_gossip
     uploadBlocksToGCloud = var.upload_blocks_to_gcloud
     seedPeersURL         = var.seed_peers_url
     exposeGraphql        = var.expose_graphql
@@ -40,6 +41,7 @@ locals {
       seedPeers          = local.peers
       logLevel           = var.log_level
       logSnarkWorkGossip = var.log_snark_work_gossip
+      log_txn_pool_gossip = var.log_txn_pool_gossip
       ports = {
         client  = "8301"
         graphql = "3085"

--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -18,7 +18,7 @@ locals {
     logLevel             = var.log_level
     logSnarkWorkGossip   = var.log_snark_work_gossip
     logPrecomputedBlocks = var.log_precomputed_blocks
-    log_txn_pool_gossip = var.log_txn_pool_gossip
+    logTxnPoolGossip = var.log_txn_pool_gossip
     uploadBlocksToGCloud = var.upload_blocks_to_gcloud
     seedPeersURL         = var.seed_peers_url
     exposeGraphql        = var.expose_graphql

--- a/automation/terraform/modules/kubernetes/testnet/variables.tf
+++ b/automation/terraform/modules/kubernetes/testnet/variables.tf
@@ -113,6 +113,21 @@ variable "runtime_config" {
   default = ""
 }
 
+variable "log_snark_work_gossip" {
+  type    = bool
+  default = false
+}
+
+variable "log_precomputed_blocks" {
+  type    = bool
+  default = false
+}
+
+variable "log_txn_pool_gossip" {
+  type    = bool
+  default = false
+}
+
 # Seed Vars
 
 variable "seed_port" {
@@ -143,21 +158,6 @@ variable "seed_discovery_keypairs" {
 variable "log_level" {
   type    = string
   default = "Trace"
-}
-
-variable "log_snark_work_gossip" {
-  type    = bool
-  default = false
-}
-
-variable "log_precomputed_blocks" {
-  type    = bool
-  default = false
-}
-
-variable "log_txn_pool_gossip" {
-  type    = bool
-  default = false
 }
 
 variable "block_producer_key_pass" {

--- a/automation/terraform/modules/o1-integration/testnet.tf
+++ b/automation/terraform/modules/o1-integration/testnet.tf
@@ -19,7 +19,6 @@ module "kubernetes_testnet" {
   coda_points_image  = var.coda_points_image
 
   log_level             = "Trace"
-  log_txn_pool_gossip   = true
   log_snark_work_gossip = true
 
   additional_peers = [local.seed_peer.multiaddr]
@@ -32,6 +31,7 @@ module "kubernetes_testnet" {
   archive_configs = local.archive_node_configs
 
   log_precomputed_blocks = var.log_precomputed_blocks
+  log_txn_pool_gossip = true
 
   archive_node_count   = var.archive_node_count
   mina_archive_schema  = var.mina_archive_schema

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -25,6 +25,7 @@ in Pipeline.build Pipeline.Config::{
     TestExecutive.build "integration_tests",
     TestExecutive.execute "reliability" dependsOn,
     TestExecutive.execute "send-payment" dependsOn,
+    TestExecutive.execute "gossip-consis" dependsOn,
     TestExecutive.execute "common-prefix" dependsOn
   ]
 }

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -39,6 +39,9 @@ spec:
           {{- if .Values.coda.logSnarkWorkGossip }}
           "-log-snark-work-gossip", "true",
           {{- end -}}
+          {{- if $.Values.coda.logTxnPoolGossip }}
+          "-log-txn-pool-gossip", "true",
+          {{- end -}}
           {{- range .Values.coda.seedPeers }}
           "-peer", {{ . | quote }},
           {{- end -}}

--- a/helm/archive-node/values.yaml
+++ b/helm/archive-node/values.yaml
@@ -4,6 +4,7 @@ coda:
   generateGenesisProof: true
   logLevel: "Info"
   logSnarkWorkGossip: false
+  logTxnPoolGossip: false
   image: codaprotocol/coda-daemon:0.0.16-beta7-develop
   privkeyPass: "naughty blue worm"
   seedPeers:

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -58,7 +58,7 @@ spec:
           mountPath: /root/wallet-keys
         - name: config-dir
           mountPath: /root/.mina-config
-        env: 
+        env:
           - name: CODA_PRIVKEY_PASS
             value: {{ $.Values.coda.privkeyPass | quote }}
       {{ if $config.libp2pSecret -}}
@@ -84,7 +84,7 @@ spec:
         image: {{ $.Values.userAgent.image }}
         command: ["bash"]
         args: ["-c", "python3 agent.py"]
-        env: 
+        env:
           {{ if ne $.Values.userAgent.minFee "" -}}
           - name: AGENT_MIN_FEE
             value: {{ $.Values.userAgent.minFee | quote }}
@@ -118,7 +118,7 @@ spec:
             value: {{ $.Values.coda.privkeyPass | quote }}
           - name: PYTHONUNBUFFERED
             value: "1"
-        ports: 
+        ports:
         - name: metrics-port
           containerPort: {{ $.Values.userAgent.ports.metrics }}
 {{- include "healthcheck.userAgent.allChecks" $.Values | indent 8 }}
@@ -181,6 +181,9 @@ spec:
           {{- if $.Values.coda.logPrecomputedBlocks }}
           "-log-precomputed-blocks", "true",
           {{- end -}}
+          {{- if $.Values.coda.logTxnPoolGossip }}
+          "-log-txn-pool-gossip", "true",
+          {{- end -}}
           {{- if $config.isolated }}
           "-isolate-network", "true",
           {{- end -}}
@@ -232,7 +235,7 @@ spec:
           value: "/gcloud/keyfile.json"
         - name: NETWORK_NAME
           value: {{ $.Values.testnetName }}
-        - name: GCLOUD_BLOCK_UPLOAD_BUCKET 
+        - name: GCLOUD_BLOCK_UPLOAD_BUCKET
           value: "mina_network_block_data"
         - name: CODA_PRIVKEY_PASS
           value: {{ $.Values.coda.privkeyPass | quote }}
@@ -246,16 +249,16 @@ spec:
           value: "true"
         ports:
         - name: client-port
-          protocol: TCP 
+          protocol: TCP
           containerPort: {{ $.Values.coda.ports.client }}
         - name: graphql-port
-          protocol: TCP 
+          protocol: TCP
           containerPort: {{ $.Values.coda.ports.graphql }}
         - name: metrics-port
-          protocol: TCP 
+          protocol: TCP
           containerPort: {{ $.Values.coda.ports.metrics }}
         - name: external-port
-          protocol: TCP 
+          protocol: TCP
           containerPort: {{ default $.Values.coda.ports.p2p $config.externalPort }}
           hostPort: {{ default $.Values.coda.ports.external $config.externalPort }}
 {{$data := dict "name" $config.name "healthcheck" $.Values.healthcheck }}

--- a/helm/block-producer/values.yaml
+++ b/helm/block-producer/values.yaml
@@ -6,6 +6,7 @@ coda:
   logLevel: "Debug"
   logSnarkWorkGossip: false
   logPrecomputedBlocks: false
+  logTxnPoolGossip: false
   image: codaprotocol/coda-daemon:0.0.16-beta7-develop
   privkeyPass: "naughty blue worm"
   seedPeers:

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -59,6 +59,9 @@ spec:
           {{- if $.Values.coda.logPrecomputedBlocks }}
           "-log-precomputed-blocks", "true",
           {{- end -}}
+          {{- if $.Values.coda.logTxnPoolGossip }}
+          "-log-txn-pool-gossip", "true",
+          {{- end -}}
           {{- if $.Values.coda.maxConnections }}
           "--max-connections", {{ $.Values.coda.maxConnections | quote }},
           {{- end -}}
@@ -110,16 +113,16 @@ spec:
         {{- end }}
         ports:
         - name: client-port
-          protocol: TCP 
+          protocol: TCP
           containerPort: {{ $.Values.coda.ports.client }}
         - name: graphql-port
-          protocol: TCP 
+          protocol: TCP
           containerPort: {{ $.Values.coda.ports.graphql }}
         - name: metrics-port
-          protocol: TCP 
+          protocol: TCP
           containerPort: {{ $.Values.coda.ports.metrics }}
         - name: external-port
-          protocol: TCP 
+          protocol: TCP
           containerPort: {{ default $.Values.coda.ports.p2p $config.externalPort }}
           hostPort: {{ default $.Values.coda.ports.external $config.externalPort }}
 {{$data := dict "name" $config.name "healthcheck" $.Values.healthcheck }}

--- a/helm/seed-node/values.yaml
+++ b/helm/seed-node/values.yaml
@@ -3,6 +3,7 @@ coda:
   runtimeConfig:
   generateGenesisProof: true
   logPrecomputedBlocks: true
+  logTxnPoolGossip: false
   maxConnections: 200
   image: codaprotocol/coda-daemon:0.0.12-beta-develop-589b507
   seedPeers:

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -44,6 +44,9 @@ spec:
           "-snark-worker-fee", "$(CODA_SNARK_FEE)",
           "-work-selection", "$(WORK_SELECTION)",
           "-enable-peer-exchange", "true",
+          {{- if $.Values.coda.logTxnPoolGossip }}
+          "-log-txn-pool-gossip", "true",
+          {{- end -}}
           {{- if $.Values.coda.runtimeConfig }}
           "-config-file", "/config/daemon.json",
           {{- end }}

--- a/helm/snark-worker/values.yaml
+++ b/helm/snark-worker/values.yaml
@@ -20,6 +20,7 @@ coda:
     metrics: "10001"
     p2p: "10909"
   exposeGraphql: false
+  logTxnPoolGossip: false
 
 worker:
   fullname: "snark-worker-{{ trunc -6 .Values.coordinator.publicKey | lower }}"

--- a/src/app/test_executive/common_prefix.ml
+++ b/src/app/test_executive/common_prefix.ml
@@ -35,7 +35,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let length = Hash_set.length common_prefixes in
     if length = 0 then (
       let result =
-        Malleable_error.soft_error ()
+        Malleable_error.soft_error ~value:()
           (Error.of_string
              (sprintf
                 "Chains don't have any common prefixes among their most \
@@ -49,7 +49,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       result )
     else if length < n then (
       let result =
-        Malleable_error.soft_error ()
+        Malleable_error.soft_error ~value:()
           (Error.of_string
              (sprintf
                 !"Chains only have %d common prefixes, expected %d common \

--- a/src/app/test_executive/common_prefix.ml
+++ b/src/app/test_executive/common_prefix.ml
@@ -42,7 +42,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                  recent %d blocks"
                 n))
       in
-      [%log info]
+      [%log error]
         "common_prefix test: TEST FAILURE, Chains don't have any common \
          prefixes among their most recent %d blocks"
         n ;
@@ -56,7 +56,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                   prefixes"
                 length n))
       in
-      [%log info]
+      [%log error]
         "common_prefix test: TEST FAILURE, Chains only have %d common \
          prefixes, expected %d common prefixes"
         length n ;

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -1,0 +1,87 @@
+open Core
+open Integration_test_lib
+open Currency
+open Signature_lib
+
+module Make (Inputs : Intf.Test.Inputs_intf) = struct
+  open Inputs
+  open Engine
+  open Dsl
+
+  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  type network = Network.t
+
+  type node = Network.Node.t
+
+  type dsl = Dsl.t
+
+  let block_producer_balance = "1000" (* 1_000_000_000_000 *)
+
+  let config =
+    let n = 5 in
+    let open Test_config in
+    { default with
+      block_producers=
+        List.init n ~f:(fun _ ->
+            {Block_producer.balance= block_producer_balance; timing= Untimed}
+        ) }
+
+  let expected_error_event_reprs = []
+
+  let pk_of_keypair keypairs n =
+    Public_key.compress (List.nth_exn keypairs n).Keypair.public_key
+
+  let wait_for_all_to_initialize ~logger network t =
+    let open Malleable_error.Let_syntax in
+    let producers = Network.block_producers network in
+    let n = List.length producers in
+    List.mapi producers ~f:(fun i node ->
+        let%map () = wait_for t (Wait_condition.node_to_initialize node) in
+        [%log info] "Block producer %d (of %d) initialized" (i + 1) n ;
+        () )
+    |> Malleable_error.all_unit
+
+  let send_payments ~logger ~sender ~receiver ~node n =
+    let open Malleable_error.Let_syntax in
+    let amount = Currency.Amount.of_int 1 in
+    let fee = Currency.Fee.of_int 1 in
+    let rec go n =
+      if n = 0 then return ()
+      else
+        let%bind () =
+          Network.Node.send_payment ~retry_on_graphql_error:false ~logger node
+            ~sender ~receiver ~amount ~fee
+        in
+        go (n - 1)
+    in
+    go n
+
+  let run network t =
+    let open Network in
+    let open Malleable_error.Let_syntax in
+    let logger = Logger.create () in
+    let%bind () = wait_for_all_to_initialize ~logger network t in
+    let sender = pk_of_keypair (Network.keypairs network) 1 in
+    let receiver = pk_of_keypair (Network.keypairs network) 0 in
+    let%bind () =
+      let num_payments = 10 in
+      send_payments ~logger ~sender ~receiver
+        ~node:(List.nth_exn (Network.block_producers network) 1)
+        num_payments
+    in
+    let%bind () =
+      let open Async in
+      let%bind () = after (Time.Span.of_sec 30.) in
+      Malleable_error.ok_unit
+    in
+    let ratio =
+      Gossip_state.consistency_ratio Transactions_gossip
+        (Map.data (network_state t).gossip_received)
+    in
+    [%log info] "Consistency ratio %f" ratio ;
+    let threshold = 0.95 in
+    if ratio < threshold then
+      Malleable_error.of_error_hard
+        (Error.createf "consistency ratio = %f < %f" ratio threshold)
+    else Malleable_error.ok_unit
+end

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -112,7 +112,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       wait_for_payments ~logger ~dsl:t ~sender_pub_key ~receiver_pub_key
         ~amount num_payments
     in
-    [%log info] "gossip_consistency test: waiting for payments done" ;
+    [%log info] "gossip_consistency test: finished waiting for payments" ;
     let gossip_states = (network_state t).gossip_received in
     let num_transactions_seen =
       let open Gossip_state in

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -146,6 +146,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let `Seen_by_all inter, `Seen_by_some union =
       Gossip_state.stats Transactions_gossip
         (Map.data (network_state t).gossip_received)
+        ~exclusion_list:[Network.Node.id sender_bp]
     in
     [%log info] "gossip_consistency test: inter = %d; union = %d " inter union ;
     let ratio =

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -147,7 +147,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       Gossip_state.stats Transactions_gossip
         (Map.data (network_state t).gossip_received)
     in
-    [%log info] "gossip_consistency test: inter =  %d; union = %d " inter union ;
+    [%log info] "gossip_consistency test: inter = %d; union = %d " inter union ;
     let ratio =
       if union = 0 then 1. else Float.of_int inter /. Float.of_int union
       (* Gossip_state.consistency_ratio Transactions_gossip

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -133,7 +133,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                 - 1"
                num_transactions_seen num_payments)
         in
-        [%log info]
+        [%log error]
           "gossip_consistency test: TEST FAILURE.  transactions seen = %d, \
            which is less than (numpayments = %d) - 1"
           num_transactions_seen num_payments ;
@@ -164,7 +164,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                "consistency ratio = %f, which is less than threshold = %f"
                ratio threshold)
         in
-        [%log info]
+        [%log error]
           "gossip_consistency test: TEST FAILURE. consistency ratio = %f, \
            which is less than threshold = %f"
           ratio threshold ;

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -108,13 +108,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     [%log info] "Consistency ratio %f" ratio ;
     let%bind () =
       if num_transactions_seen < 9 then
-        Malleable_error.hard_error
-          (Error.createf "transactions seen = %d < 9" num_transactions_seen)
+        Malleable_error.soft_error_string ~value:()
+          (Printf.sprintf "transactions seen = %d < 9" num_transactions_seen)
       else Malleable_error.ok_unit
     in
     let threshold = 0.95 in
     if ratio < threshold then
-      Malleable_error.hard_error
-        (Error.createf "consistency ratio = %f < %f" ratio threshold)
+      Malleable_error.soft_error_string ~value:()
+        (Printf.sprintf "consistency ratio = %f < %f" ratio threshold)
     else Malleable_error.ok_unit
 end

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -51,8 +51,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       else
         let%bind () =
           let%map () =
-            Network.Node.must_send_payment ~retry_on_graphql_error:false ~logger
-              ~sender_pub_key ~receiver_pub_key ~amount ~fee node
+            Network.Node.must_send_payment ~retry_on_graphql_error:false
+              ~logger ~sender_pub_key ~receiver_pub_key ~amount ~fee node
           in
           [%log info] "gossip_consistency test: payment #%d sent." n ;
           ()

--- a/src/app/test_executive/payments_timed_accounts_test.ml
+++ b/src/app/test_executive/payments_timed_accounts_test.ml
@@ -62,14 +62,14 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let amount = Currency.Amount.of_int 300_000_000_000 in
     let%bind () =
       Node.must_send_payment ~retry_on_graphql_error:false ~logger sender_bp
-        ~sender:sender_pub_key ~receiver:receiver_pub_key ~amount ~fee
+        ~sender_pub_key ~receiver_pub_key ~amount ~fee
     in
     [%log info] "Payment succeeded, as expected" ;
     [%log info] "Waiting for payment to appear in breadcrumb" ;
     let%bind () =
       wait_for t
-        (Wait_condition.payment_to_be_included_in_frontier
-           ~sender:sender_pub_key ~receiver:receiver_pub_key ~amount)
+        (Wait_condition.payment_to_be_included_in_frontier ~sender_pub_key
+           ~receiver_pub_key ~amount)
     in
     [%log info] "Got breadcrumb with desired payment" ;
     [%log info]
@@ -81,7 +81,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let open Deferred.Let_syntax in
       match%bind
         Node.send_payment ~retry_on_graphql_error:false ~logger sender_bp
-          ~sender:sender_pub_key ~receiver:receiver_pub_key ~amount:amount'
+          ~sender_pub_key ~receiver_pub_key ~amount:amount'
           ~fee
       with
       (* TODO: this currently relies on the returned error being a soft error and not a hard error *)

--- a/src/app/test_executive/payments_timed_accounts_test.ml
+++ b/src/app/test_executive/payments_timed_accounts_test.ml
@@ -81,8 +81,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let open Deferred.Let_syntax in
       match%bind
         Node.send_payment ~retry_on_graphql_error:false ~logger sender_bp
-          ~sender_pub_key ~receiver_pub_key ~amount:amount'
-          ~fee
+          ~sender_pub_key ~receiver_pub_key ~amount:amount' ~fee
       with
       (* TODO: this currently relies on the returned error being a soft error and not a hard error *)
       | Ok () ->

--- a/src/app/test_executive/payments_timed_accounts_test.ml
+++ b/src/app/test_executive/payments_timed_accounts_test.ml
@@ -86,7 +86,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       with
       (* TODO: this currently relies on the returned error being a soft error and not a hard error *)
       | Ok () ->
-          Malleable_error.soft_error_string ()
+          Malleable_error.soft_error_string ~value:()
             "Payment succeeded, but expected it to fail because of a minimum \
              balance violation"
       | Error error ->
@@ -103,7 +103,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             [%log error]
               "Payment failed in GraphQL, but for unexpected reason: %s"
               err_str ;
-            Malleable_error.soft_error_format ()
+            Malleable_error.soft_error_format ~value:()
               "Payment failed for unexpected reason: %s" err_str )
     in
     [%log info] "Payment test with timed accounts completed"

--- a/src/app/test_executive/send_payment_test.ml
+++ b/src/app/test_executive/send_payment_test.ml
@@ -38,14 +38,14 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let amount = Currency.Amount.of_int 200_000_000 in
     let fee = Currency.Fee.of_int 10_000_000 in
     let%bind () =
-      Network.Node.must_send_payment ~logger sender_bp ~sender:sender_pub_key
-        ~receiver:receiver_pub_key ~amount ~fee
+      Network.Node.must_send_payment ~logger sender_bp ~sender_pub_key
+        ~receiver_pub_key ~amount ~fee
     in
     (* confirm payment *)
     let%map () =
       wait_for t
-        (Wait_condition.payment_to_be_included_in_frontier
-           ~sender:sender_pub_key ~receiver:receiver_pub_key ~amount)
+        (Wait_condition.payment_to_be_included_in_frontier ~sender_pub_key
+           ~receiver_pub_key ~amount)
     in
     [%log info] "send_payment_test: succesfully completed"
 end

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -48,7 +48,8 @@ let tests : test list =
     , (module Block_production_timed_accounts_test.Make : Intf.Test.Functor_intf) )
   *)
   ; ("archive-node", (module Archive_node_test.Make : Intf.Test.Functor_intf))
-  ; ("common-prefix", (module Common_prefix.Make : Intf.Test.Functor_intf)) ]
+  ; ("gossip-consis", (module Gossip_consistency.Make : Intf.Test.Functor_intf))
+  ]
 
 let report_test_errors ~log_error_set ~internal_error_set =
   (* TODO: we should be able to show which sections passed as well *)

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -49,7 +49,7 @@ let tests : test list =
   *)
   ; ("archive-node", (module Archive_node_test.Make : Intf.Test.Functor_intf))
   ; ("gossip-consis", (module Gossip_consistency.Make : Intf.Test.Functor_intf))
-  ]
+  ; ("common-prefix", (module Common_prefix.Make : Intf.Test.Functor_intf)) ]
 
 let report_test_errors ~log_error_set ~internal_error_set =
   (* TODO: we should be able to show which sections passed as well *)

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -318,19 +318,19 @@ module Node = struct
     |> Deferred.bind ~f:Malleable_error.or_hard_error
 
   (* if we expect failure, might want retry_on_graphql_error to be false *)
-  let send_payment ?(retry_on_graphql_error = true) ~logger t ~sender ~receiver
-      ~amount ~fee =
+  let send_payment ?(retry_on_graphql_error = true) ~logger t ~sender_pub_key
+      ~receiver_pub_key ~amount ~fee =
     [%log info] "Sending a payment"
       ~metadata:
         [("namespace", `String t.namespace); ("pod_id", `String t.pod_id)] ;
     let open Deferred.Or_error.Let_syntax in
-    let sender_pk_str = Signature_lib.Public_key.Compressed.to_string sender in
+    let sender_pk_str = Signature_lib.Public_key.Compressed.to_string sender_pub_key in
     [%log info] "send_payment: unlocking account"
       ~metadata:[("sender_pk", `String sender_pk_str)] ;
     let unlock_sender_account_graphql () =
       let unlock_account_obj =
         Graphql.Unlock_account.make ~password:"naughty blue worm"
-          ~public_key:(Graphql_lib.Encoders.public_key sender)
+          ~public_key:(Graphql_lib.Encoders.public_key sender_pub_key)
           ()
       in
       exec_graphql_request ~logger ~node:t
@@ -340,8 +340,8 @@ module Node = struct
     let send_payment_graphql () =
       let send_payment_obj =
         Graphql.Send_payment.make
-          ~sender:(Graphql_lib.Encoders.public_key sender)
-          ~receiver:(Graphql_lib.Encoders.public_key receiver)
+          ~sender:(Graphql_lib.Encoders.public_key sender_pub_key)
+          ~receiver:(Graphql_lib.Encoders.public_key receiver_pub_key)
           ~amount:(Graphql_lib.Encoders.amount amount)
           ~fee:(Graphql_lib.Encoders.fee fee)
           ()
@@ -357,9 +357,9 @@ module Node = struct
       ~metadata:[("user_command_id", `String user_cmd_id)] ;
     ()
 
-  let must_send_payment ?retry_on_graphql_error ~logger t ~sender ~receiver
+  let must_send_payment ?retry_on_graphql_error ~logger t ~sender_pub_key ~receiver_pub_key
       ~amount ~fee =
-    send_payment ?retry_on_graphql_error ~logger t ~sender ~receiver ~amount
+    send_payment ?retry_on_graphql_error ~logger t ~sender_pub_key ~receiver_pub_key ~amount
       ~fee
     |> Deferred.bind ~f:Malleable_error.or_hard_error
 

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -324,7 +324,9 @@ module Node = struct
       ~metadata:
         [("namespace", `String t.namespace); ("pod_id", `String t.pod_id)] ;
     let open Deferred.Or_error.Let_syntax in
-    let sender_pk_str = Signature_lib.Public_key.Compressed.to_string sender_pub_key in
+    let sender_pk_str =
+      Signature_lib.Public_key.Compressed.to_string sender_pub_key
+    in
     [%log info] "send_payment: unlocking account"
       ~metadata:[("sender_pk", `String sender_pk_str)] ;
     let unlock_sender_account_graphql () =
@@ -357,10 +359,10 @@ module Node = struct
       ~metadata:[("user_command_id", `String user_cmd_id)] ;
     ()
 
-  let must_send_payment ?retry_on_graphql_error ~logger t ~sender_pub_key ~receiver_pub_key
-      ~amount ~fee =
-    send_payment ?retry_on_graphql_error ~logger t ~sender_pub_key ~receiver_pub_key ~amount
-      ~fee
+  let must_send_payment ?retry_on_graphql_error ~logger t ~sender_pub_key
+      ~receiver_pub_key ~amount ~fee =
+    send_payment ?retry_on_graphql_error ~logger t ~sender_pub_key
+      ~receiver_pub_key ~amount ~fee
     |> Deferred.bind ~f:Malleable_error.or_hard_error
 
   let dump_archive_data ~logger (t : t) ~data_file =

--- a/src/lib/integration_test_lib/dsl.ml
+++ b/src/lib/integration_test_lib/dsl.ml
@@ -45,6 +45,8 @@ module Make (Engine : Intf.Engine.S) () :
     ; event_router: Event_router.t
     ; network_state_reader: Network_state.t Broadcast_pipe.Reader.t }
 
+  let network_state t = Broadcast_pipe.Reader.peek t.network_state_reader
+
   let create ~logger ~network ~event_router ~network_state_reader =
     let t = {logger; network; event_router; network_state_reader} in
     `Don't_call_in_tests t

--- a/src/lib/integration_test_lib/dsl.ml
+++ b/src/lib/integration_test_lib/dsl.ml
@@ -155,7 +155,7 @@ module Make (Engine : Intf.Engine.S) () :
             "wait_for hit a soft timeout waiting for %s (condition succeeded, \
              but beyond expectation)"
             condition.description
-          |> Malleable_error.soft_error ()
+          |> Malleable_error.soft_error ~value:()
 
   (**************************************************************************************************)
   (* TODO: move into executive module *)

--- a/src/lib/integration_test_lib/dune
+++ b/src/lib/integration_test_lib/dune
@@ -3,5 +3,5 @@
  (name integration_test_lib)
  (inline_tests)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_coda ppx_version ppx_optcomp ppx_let ppx_inline_test ppx_custom_printf ppx_deriving.std ppx_sexp_conv ppx_compare ppx_assert lens.ppx_deriving ppx_pipebang))
+ (preprocess (pps ppx_base ppx_fields_conv ppx_coda ppx_version ppx_optcomp ppx_let ppx_inline_test ppx_custom_printf ppx_deriving.std ppx_sexp_conv ppx_compare ppx_assert lens.ppx_deriving ppx_pipebang))
  (libraries core async mina_base runtime_config genesis_constants transition_frontier transition_router block_producer user_command_input cmdliner lens))

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -194,6 +194,84 @@ module Breadcrumb_added = struct
     {user_commands}
 end
 
+module Gossip = struct
+  open Or_error.Let_syntax
+
+  module Direction = struct
+    type t = Sent | Received [@@deriving yojson]
+  end
+
+  module With_direction = struct
+    type 'a t = 'a * Direction.t [@@deriving yojson]
+  end
+
+  module Block = struct
+    let id = Mina_networking.block_received_structured_events_id
+
+    let structured_event_id = Some id
+
+    type r = {state_hash: State_hash.t} [@@deriving yojson, hash]
+
+    type t = r With_direction.t [@@deriving yojson]
+
+    let name = "Block_gossip"
+
+    let parse message : t Or_error.t =
+      match%bind parse id message with
+      | Mina_networking.Block_received {state_hash; sender= _} ->
+          Ok ({state_hash}, Direction.Received)
+      | Mina_networking.Gossip_new_state {state_hash} ->
+          Ok ({state_hash}, Sent)
+      | _ ->
+          bad_parse
+  end
+
+  module Snark_work = struct
+    let id = Mina_networking.snark_work_received_structured_events_id
+
+    let structured_event_id = Some id
+
+    type r = {work: Network_pool.Snark_pool.Resource_pool.Diff.compact}
+    [@@deriving yojson, hash]
+
+    type t = r With_direction.t [@@deriving yojson]
+
+    let name = "Snark_work_gossip"
+
+    let parse message =
+      match%bind parse id message with
+      | Mina_networking.Snark_work_received {work; sender= _} ->
+          Ok ({work}, Direction.Received)
+      | Mina_networking.Gossip_snark_pool_diff {work} ->
+          Ok ({work}, Direction.Received)
+      | _ ->
+          bad_parse
+  end
+
+  module Transactions = struct
+    let id = Mina_networking.transactions_received_structured_events_id
+
+    let structured_event_id = Some id
+
+    type r =
+      {txns: Network_pool.Transaction_pool.Diff_versioned.Stable.Latest.t}
+    [@@deriving yojson, hash]
+
+    type t = r With_direction.t [@@deriving yojson]
+
+    let name = "Transactions_gossip"
+
+    let parse message =
+      match%bind parse id message with
+      | Mina_networking.Transactions_received {txns; sender= _} ->
+          Ok ({txns}, Direction.Received)
+      | Mina_networking.Gossip_transaction_pool_diff {txns} ->
+          Ok ({txns}, Sent)
+      | _ ->
+          bad_parse
+  end
+end
+
 type 'a t =
   | Log_error : Log_error.t t
   | Node_initialization : Node_initialization.t t
@@ -201,6 +279,9 @@ type 'a t =
       : Transition_frontier_diff_application.t t
   | Block_produced : Block_produced.t t
   | Breadcrumb_added : Breadcrumb_added.t t
+  | Block_gossip : Gossip.Block.t t
+  | Snark_work_gossip : Gossip.Snark_work.t t
+  | Transactions_gossip : Gossip.Transactions.t t
 
 type existential = Event_type : 'a t -> existential
 
@@ -215,6 +296,12 @@ let existential_to_string = function
       "Block_produced"
   | Event_type Breadcrumb_added ->
       "Breadcrumb_added"
+  | Event_type Block_gossip ->
+      "Block_gossip"
+  | Event_type Snark_work_gossip ->
+      "Snark_work_gossip"
+  | Event_type Transactions_gossip ->
+      "Transactions_gossip"
 
 let to_string e = existential_to_string (Event_type e)
 
@@ -275,6 +362,12 @@ let event_type_module : type a. a t -> (module Event_type_intf with type t = a)
       (module Block_produced)
   | Breadcrumb_added ->
       (module Breadcrumb_added)
+  | Block_gossip ->
+      (module Gossip.Block)
+  | Snark_work_gossip ->
+      (module Gossip.Snark_work)
+  | Transactions_gossip ->
+      (module Gossip.Transactions)
 
 let event_to_yojson event =
   let (Event (t, d)) = event in

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -322,6 +322,12 @@ let existential_of_string_exn = function
       Event_type Block_produced
   | "Breadcrumb_added" ->
       Event_type Breadcrumb_added
+  | "Block_gossip" ->
+      Event_type Block_gossip
+  | "Snark_work_gossip" ->
+      Event_type Snark_work_gossip
+  | "Transactions_gossip" ->
+      Event_type Transactions_gossip
   | _ ->
       failwith "invalid event type string"
 
@@ -354,7 +360,10 @@ let all_event_types =
   ; Event_type Node_initialization
   ; Event_type Transition_frontier_diff_application
   ; Event_type Block_produced
-  ; Event_type Breadcrumb_added ]
+  ; Event_type Breadcrumb_added
+  ; Event_type Block_gossip
+  ; Event_type Snark_work_gossip
+  ; Event_type Transactions_gossip ]
 
 let event_type_module : type a. a t -> (module Event_type_intf with type t = a)
     = function
@@ -428,6 +437,12 @@ let dispatch_exn : type a b c. a t -> a -> b t -> (b -> c) -> c =
   | Block_produced, Block_produced ->
       h e
   | Breadcrumb_added, Breadcrumb_added ->
+      h e
+  | Block_gossip, Block_gossip ->
+      h e
+  | Snark_work_gossip, Snark_work_gossip ->
+      h e
+  | Transactions_gossip, Transactions_gossip ->
       h e
   | _ ->
       failwith "TODO: better error message :)"

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -17,6 +17,12 @@ let get_metadata (message : Logger.Message.t) key =
   | None ->
       Or_error.errorf "did not find key \"%s\" in message metadata" key
 
+let parse id (m : Logger.Message.t) =
+  Or_error.try_with (fun () ->
+      Structured_log_events.parse_exn id (Map.to_alist m.metadata) )
+
+let bad_parse = Or_error.error_string "bad parse"
+
 module type Event_type_intf = sig
   type t [@@deriving to_yojson]
 

--- a/src/lib/integration_test_lib/event_type.mli
+++ b/src/lib/integration_test_lib/event_type.mli
@@ -62,6 +62,42 @@ module Breadcrumb_added : sig
   include Event_type_intf with type t := t
 end
 
+module Gossip : sig
+  module Direction : sig
+    type t = Sent | Received [@@deriving yojson]
+  end
+
+  module With_direction : sig
+    type 'a t = 'a * Direction.t [@@deriving yojson]
+  end
+
+  module Block : sig
+    type r = {state_hash: State_hash.t} [@@deriving hash, yojson]
+
+    type t = r With_direction.t
+
+    include Event_type_intf with type t := t
+  end
+
+  module Snark_work : sig
+    type r = {work: Network_pool.Snark_pool.Resource_pool.Diff.compact}
+    [@@deriving hash, yojson]
+
+    type t = r With_direction.t
+
+    include Event_type_intf with type t := t
+  end
+
+  module Transactions : sig
+    type r = {txns: Network_pool.Transaction_pool.Resource_pool.Diff.t}
+    [@@deriving hash, yojson]
+
+    type t = r With_direction.t
+
+    include Event_type_intf with type t := t
+  end
+end
+
 type 'a t =
   | Log_error : Log_error.t t
   | Node_initialization : Node_initialization.t t
@@ -69,6 +105,9 @@ type 'a t =
       : Transition_frontier_diff_application.t t
   | Block_produced : Block_produced.t t
   | Breadcrumb_added : Breadcrumb_added.t t
+  | Block_gossip : Gossip.Block.t t
+  | Snark_work_gossip : Gossip.Snark_work.t t
+  | Transactions_gossip : Gossip.Transactions.t t
 
 val to_string : 'a t -> string
 

--- a/src/lib/integration_test_lib/gossip_state.ml
+++ b/src/lib/integration_test_lib/gossip_state.ml
@@ -1,0 +1,114 @@
+open Core_kernel
+
+module By_direction = struct
+  type 'a t = {sent: 'a; received: 'a} [@@deriving to_yojson, fields]
+end
+
+module type Set = sig
+  type 'a t [@@deriving to_yojson]
+
+  val add :
+    'a t -> 'a Event_type.Gossip.With_direction.t Event_type.t -> 'a -> unit
+
+  val size : _ t -> int
+
+  val inter : 'a t list -> 'a t
+
+  val union : 'a t list -> 'a t
+
+  val create : unit -> 'a t
+end
+
+module Set : Set = struct
+  type _ t = Int.Hash_set.t
+
+  let size = Hash_set.length
+
+  let inter = List.reduce_exn ~f:Hash_set.inter
+
+  let union xs =
+    let res = Int.Hash_set.create () in
+    List.iter xs ~f:(fun s -> Hash_set.iter s ~f:(Hash_set.add res)) ;
+    res
+
+  let to_yojson _f t = `Int (Hash_set.length t)
+
+  let create () = Int.Hash_set.create ()
+
+  let add (type a) (t : a t)
+      (type_ : a Event_type.Gossip.With_direction.t Event_type.t) (x : a) =
+    let h =
+      let open Event_type.Gossip in
+      match type_ with
+      | Block_gossip ->
+          Block.hash_r x
+      | Transactions_gossip ->
+          Transactions.hash_r x
+      | Snark_work_gossip ->
+          Snark_work.hash_r x
+    in
+    Hash_set.add t h
+end
+
+open Event_type.Gossip
+
+type t =
+  { blocks: Block.r Set.t By_direction.t
+  ; transactions: Transactions.r Set.t By_direction.t
+  ; snark_work: Snark_work.r Set.t By_direction.t }
+[@@deriving to_yojson, fields]
+
+let create () : t =
+  let f create =
+    {By_direction.sent= create (); By_direction.received= create ()}
+  in
+  {blocks= f Set.create; transactions= f Set.create; snark_work= f Set.create}
+
+let add (t : t) (type a)
+    (type_ : a Event_type.Gossip.With_direction.t Event_type.t)
+    ((x : a), (dir : Event_type.Gossip.Direction.t)) : unit =
+  let f =
+    match dir with
+    | Sent ->
+        By_direction.sent
+    | Received ->
+        By_direction.received
+  in
+  let tbls : a Set.t By_direction.t =
+    match type_ with
+    | Block_gossip ->
+        t.blocks
+    | Transactions_gossip ->
+        t.transactions
+    | Snark_work_gossip ->
+        t.snark_work
+  in
+  Set.add (f tbls) type_ x
+
+(* The number of messages seen by some node but not by all nodes. *)
+let stats (type a) (type_ : a Event_type.Gossip.With_direction.t Event_type.t)
+    (ts : t list) =
+  match ts with
+  | [] ->
+      (`Seen_by_all 0, `Seen_by_some 0)
+  | _ :: _ ->
+      let ss =
+        let f : t -> a Set.t By_direction.t =
+          match type_ with
+          | Block_gossip ->
+              blocks
+          | Transactions_gossip ->
+              transactions
+          | Snark_work_gossip ->
+              snark_work
+        in
+        List.map ts ~f:(fun t ->
+            let s = f t in
+            Set.union [s.sent; s.received] )
+      in
+      ( `Seen_by_all (Set.size (Set.inter ss))
+      , `Seen_by_some (Set.size (Set.union ss)) )
+
+let consistency_ratio type_ ts =
+  let `Seen_by_all inter, `Seen_by_some union = stats type_ ts in
+  if union = 0 then 1. else Float.of_int inter /. Float.of_int union

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -210,6 +210,7 @@ module Dsl = struct
       ; snarked_ledgers_generated: int
       ; blocks_generated: int
       ; node_initialization: bool String.Map.t
+      ; gossip_received: Gossip_state.t String.Map.t
       ; best_tips_by_node: State_hash.t String.Map.t }
 
     val listen :
@@ -278,6 +279,8 @@ module Dsl = struct
     type t
 
     val section : string -> 'a Malleable_error.t -> 'a Malleable_error.t
+    
+    val network_state : t -> Network_state.t
 
     val wait_for : t -> Wait_condition.t -> unit Malleable_error.t
 

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -279,7 +279,7 @@ module Dsl = struct
     type t
 
     val section : string -> 'a Malleable_error.t -> 'a Malleable_error.t
-    
+
     val network_state : t -> Network_state.t
 
     val wait_for : t -> Wait_condition.t -> unit Malleable_error.t

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -43,8 +43,8 @@ module Engine = struct
            ?retry_on_graphql_error:bool
         -> logger:Logger.t
         -> t
-        -> sender:Signature_lib.Public_key.Compressed.t
-        -> receiver:Signature_lib.Public_key.Compressed.t
+        -> sender_pub_key:Signature_lib.Public_key.Compressed.t
+        -> receiver_pub_key:Signature_lib.Public_key.Compressed.t
         -> amount:Currency.Amount.t
         -> fee:Currency.Fee.t
         -> unit Deferred.Or_error.t
@@ -53,8 +53,8 @@ module Engine = struct
            ?retry_on_graphql_error:bool
         -> logger:Logger.t
         -> t
-        -> sender:Signature_lib.Public_key.Compressed.t
-        -> receiver:Signature_lib.Public_key.Compressed.t
+        -> sender_pub_key:Signature_lib.Public_key.Compressed.t
+        -> receiver_pub_key:Signature_lib.Public_key.Compressed.t
         -> amount:Currency.Amount.t
         -> fee:Currency.Fee.t
         -> unit Malleable_error.t
@@ -244,8 +244,8 @@ module Dsl = struct
     val nodes_to_synchronize : Engine.Network.Node.t list -> t
 
     val payment_to_be_included_in_frontier :
-         sender:Public_key.Compressed.t
-      -> receiver:Public_key.Compressed.t
+         sender_pub_key:Public_key.Compressed.t
+      -> receiver_pub_key:Public_key.Compressed.t
       -> amount:Amount.t
       -> t
   end

--- a/src/lib/integration_test_lib/malleable_error.ml
+++ b/src/lib/integration_test_lib/malleable_error.ml
@@ -91,7 +91,7 @@ include T
 
 let lift = Deferred.bind ~f:return
 
-let soft_error value error =
+let soft_error ~value error =
   error |> Test_error.internal_error |> Error_accumulator.singleton
   |> Result_accumulator.create value
   |> Result.return |> Deferred.return
@@ -117,21 +117,21 @@ let ok_if_true ?(error_type = `Hard) ~error b =
   else
     match error_type with
     | `Soft ->
-        soft_error () error
+        soft_error ~value:() error
     | `Hard ->
         hard_error error
 
-let or_soft_error value or_error =
+let or_soft_error ~value or_error =
   match or_error with
   | Ok x ->
       return x
   | Error error ->
-      soft_error value error
+      soft_error ~value error
 
-let soft_error_string value = Fn.compose (soft_error value) Error.of_string
+let soft_error_string ~value = Fn.compose (soft_error ~value) Error.of_string
 
-let soft_error_format value format =
-  Printf.ksprintf (soft_error_string value) format
+let soft_error_format ~value format =
+  Printf.ksprintf (soft_error_string ~value) format
 
 let or_hard_error or_error =
   match or_error with Ok x -> return x | Error error -> hard_error error
@@ -287,8 +287,8 @@ let%test_module "malleable error unit tests" =
           let open Deferred.Let_syntax in
           let%map actual =
             let open T.Let_syntax in
-            let%bind () = soft_error () (Error.of_string "a") in
-            soft_error "123" (Error.of_string "b")
+            let%bind () = soft_error ~value:() (Error.of_string "a") in
+            soft_error ~value:"123" (Error.of_string "b")
           in
           let expected =
             let errors =
@@ -328,7 +328,7 @@ let%test_module "malleable error unit tests" =
           let open Deferred.Let_syntax in
           let%map actual =
             let open T.Let_syntax in
-            let%bind () = soft_error () (Error.of_string "a") in
+            let%bind () = soft_error ~value:() (Error.of_string "a") in
             let%bind () = hard_error (Error.of_string "xyz") in
             return "hello world"
           in
@@ -350,8 +350,8 @@ let%test_module "malleable error unit tests" =
           let open Deferred.Let_syntax in
           let%map actual =
             let open T.Let_syntax in
-            let%bind () = soft_error () (Error.of_string "a") in
-            let%bind () = soft_error () (Error.of_string "b") in
+            let%bind () = soft_error ~value:() (Error.of_string "a") in
+            let%bind () = soft_error ~value:() (Error.of_string "b") in
             hard_error (Error.of_string "xyz")
           in
           let expected =

--- a/src/lib/integration_test_lib/network_state.ml
+++ b/src/lib/integration_test_lib/network_state.ml
@@ -22,6 +22,8 @@ module Make
     ; blocks_generated: int
     ; node_initialization: bool String.Map.t
           [@to_yojson map_to_yojson ~f:(fun b -> `Bool b)]
+    ; gossip_received: Gossip_state.t String.Map.t
+          [@to_yojson map_to_yojson ~f:Gossip_state.to_yojson]
     ; best_tips_by_node: State_hash.t String.Map.t
           [@to_yojson map_to_yojson ~f:State_hash.to_yojson] }
   [@@deriving to_yojson]
@@ -33,6 +35,7 @@ module Make
     ; snarked_ledgers_generated= 0
     ; blocks_generated= 0
     ; node_initialization= String.Map.empty
+    ; gossip_received= String.Map.empty
     ; best_tips_by_node= String.Map.empty }
 
   let listen ~logger event_router =
@@ -82,6 +85,26 @@ module Make
                        ~data:new_best_tip
                    in
                    {state with best_tips_by_node= best_tips_by_node'} ) ) )) ;
+    let handle_gossip_received event =
+      ignore
+        (Event_router.on event_router event ~f:(fun node k ->
+             update ~f:(fun state ->
+                 { state with
+                   gossip_received=
+                     Map.update state.gossip_received (Node.id node)
+                       ~f:(fun s ->
+                         let s =
+                           match s with
+                           | None ->
+                               Gossip_state.create ()
+                           | Some s ->
+                               s
+                         in
+                         Gossip_state.add s event k ; s ) } ) ))
+    in
+    handle_gossip_received Block_gossip ;
+    handle_gossip_received Snark_work_gossip ;
+    handle_gossip_received Transactions_gossip ;
     ignore
       (Event_router.on event_router Event_type.Node_initialization
          ~f:(fun node () ->

--- a/src/lib/integration_test_lib/network_state.ml
+++ b/src/lib/integration_test_lib/network_state.ml
@@ -97,7 +97,7 @@ module Make
                          let gossip_state =
                            match gossip_state_opt with
                            | None ->
-                               Gossip_state.create ()
+                               Gossip_state.create (Node.id node)
                            | Some state ->
                                state
                          in

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -104,7 +104,8 @@ struct
     ; soft_timeout= Slots soft_timeout_in_slots
     ; hard_timeout= Slots (soft_timeout_in_slots * 2) }
 
-  let payment_to_be_included_in_frontier ~sender ~receiver ~amount =
+  let payment_to_be_included_in_frontier ~sender_pub_key ~receiver_pub_key
+      ~amount =
     let command_matches_payment cmd =
       let open User_command in
       match cmd with
@@ -115,8 +116,8 @@ struct
           in
           match body with
           | Payment {source_pk; receiver_pk; amount= paid_amt; token_id= _}
-            when Public_key.Compressed.equal source_pk sender
-                 && Public_key.Compressed.equal receiver_pk receiver
+            when Public_key.Compressed.equal source_pk sender_pub_key
+                 && Public_key.Compressed.equal receiver_pk receiver_pub_key
                  && Currency.Amount.equal paid_amt amount ->
               true
           | _ ->
@@ -152,8 +153,8 @@ struct
     let soft_timeout_in_slots = 8 in
     { description=
         Printf.sprintf "payment from %s to %s of amount %s"
-          (Public_key.Compressed.to_string sender)
-          (Public_key.Compressed.to_string receiver)
+          (Public_key.Compressed.to_string sender_pub_key)
+          (Public_key.Compressed.to_string receiver_pub_key)
           (Amount.to_string amount)
     ; predicate= Event_predicate (Event_type.Breadcrumb_added, (), check)
     ; soft_timeout= Slots soft_timeout_in_slots

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -7,7 +7,8 @@ module Prod : Ledger_proof_intf.S with type t = Transaction_snark.t = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = Transaction_snark.Stable.V1.t [@@deriving compare, sexp, yojson]
+      type t = Transaction_snark.Stable.V1.t
+      [@@deriving compare, sexp, yojson, hash]
 
       let to_latest = Fn.id
 

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -2,14 +2,14 @@ open Core_kernel
 open Mina_base
 
 module type S = sig
-  type t [@@deriving compare, sexp, yojson]
+  type t [@@deriving compare, sexp, yojson, hash]
 
   [%%versioned:
   module Stable : sig
     [@@@no_toplevel_latest_type]
 
     module V1 : sig
-      type nonrec t = t [@@deriving compare, sexp, yojson]
+      type nonrec t = t [@@deriving compare, sexp, yojson, hash]
 
       val to_latest : t -> t
 

--- a/src/lib/mina_base/fee_with_prover.ml
+++ b/src/lib/mina_base/fee_with_prover.ml
@@ -6,7 +6,7 @@ module Stable = struct
   module V1 = struct
     type t =
       {fee: Currency.Fee.Stable.V1.t; prover: Public_key.Compressed.Stable.V1.t}
-    [@@deriving sexp, yojson]
+    [@@deriving sexp, yojson, hash]
 
     let to_latest = Fn.id
 

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -241,7 +241,7 @@ module type Snark_pool_diff_intf = sig
     { work: Transaction_snark_work.Statement.t
     ; fee: Currency.Fee.t
     ; prover: Signature_lib.Public_key.Compressed.t }
-  [@@deriving yojson]
+  [@@deriving yojson, hash]
 
   include
     Resource_pool_diff_intf

--- a/src/lib/network_pool/priced_proof.ml
+++ b/src/lib/network_pool/priced_proof.ml
@@ -7,9 +7,9 @@ module Stable = struct
 
   module V1 = struct
     type 'proof t = {proof: 'proof; fee: Fee_with_prover.Stable.V1.t}
-    [@@deriving compare, fields, sexp, yojson]
+    [@@deriving compare, fields, sexp, yojson, hash]
   end
 end]
 
 type 'proof t = 'proof Stable.Latest.t = {proof: 'proof; fee: Fee_with_prover.t}
-[@@deriving compare, fields, sexp, yojson]
+[@@deriving compare, fields, sexp, yojson, hash]

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -618,7 +618,7 @@ module Diff_versioned = struct
             * Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
               Priced_proof.Stable.V1.t
         | Empty
-      [@@deriving compare, sexp, to_yojson]
+      [@@deriving compare, sexp, to_yojson, hash]
 
       let to_latest = Fn.id
     end
@@ -629,7 +629,7 @@ module Diff_versioned = struct
         Transaction_snark_work.Statement.t
         * Ledger_proof.t One_or_two.t Priced_proof.t
     | Empty
-  [@@deriving compare, sexp, to_yojson]
+  [@@deriving compare, sexp, to_yojson, hash]
 end
 
 let%test_module "random set test" =

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -103,7 +103,7 @@ module Diff_versioned : sig
             * Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
               Priced_proof.Stable.V1.t
         | Empty
-      [@@deriving compare, sexp]
+      [@@deriving compare, sexp, hash]
     end
   end]
 end

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -28,7 +28,7 @@ module Make
   type t =
     | Add_solved_work of Work.t * Ledger_proof.t One_or_two.t Priced_proof.t
     | Empty
-  [@@deriving compare, sexp, to_yojson]
+  [@@deriving compare, sexp, to_yojson, hash]
 
   type verified = t [@@deriving compare, sexp, to_yojson]
 
@@ -40,7 +40,7 @@ module Make
     { work: Work.t
     ; fee: Currency.Fee.t
     ; prover: Signature_lib.Public_key.Compressed.t }
-  [@@deriving yojson]
+  [@@deriving yojson, hash]
 
   let to_compact = function
     | Add_solved_work (work, {proof= _; fee= {fee; prover}}) ->

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -39,7 +39,7 @@ module Diff_versioned = struct
     [@@@no_toplevel_latest_type]
 
     module V1 = struct
-      type t = User_command.Stable.V1.t list [@@deriving sexp, yojson]
+      type t = User_command.Stable.V1.t list [@@deriving sexp, yojson, hash]
 
       let to_latest = Fn.id
     end

--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -67,7 +67,7 @@ module Proof : sig
   val dummy : 'w Nat.t -> 'm Nat.t -> _ Nat.t -> ('w, 'm) t
 
   module Make (W : Nat.Intf) (MLMB : Nat.Intf) : sig
-    type nonrec t = (W.n, MLMB.n) t [@@deriving sexp, compare, yojson]
+    type nonrec t = (W.n, MLMB.n) t [@@deriving sexp, compare, yojson, hash]
   end
 
   module Branching_2 : sig

--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -74,7 +74,8 @@ module Proof : sig
     [%%versioned:
     module Stable : sig
       module V1 : sig
-        type t = Make(Nat.N2)(Nat.N2).t [@@deriving sexp, compare, yojson]
+        type t = Make(Nat.N2)(Nat.N2).t
+        [@@deriving sexp, compare, yojson, hash]
       end
     end]
   end

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -404,7 +404,7 @@ module Proof = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = T.t
+      type t = Pickles.Proof.Branching_2.Stable.V1.t
       [@@deriving version {asserted}, yojson, bin_io, compare, sexp, hash]
 
       let to_latest = Fn.id

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -404,8 +404,8 @@ module Proof = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = Pickles.Proof.Branching_2.Stable.V1.t
-      [@@deriving version {asserted}, yojson, bin_io, compare, sexp]
+      type t = T.t
+      [@@deriving version {asserted}, yojson, bin_io, compare, sexp, hash]
 
       let to_latest = Fn.id
     end
@@ -417,7 +417,7 @@ module Stable = struct
   module V1 = struct
     type t =
       {statement: Statement.With_sok.Stable.V1.t; proof: Proof.Stable.V1.t}
-    [@@deriving compare, fields, sexp, version, yojson]
+    [@@deriving compare, fields, sexp, version, yojson, hash]
 
     let to_latest = Fn.id
   end

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -201,7 +201,7 @@ end
 [%%versioned:
 module Stable : sig
   module V1 : sig
-    type t [@@deriving compare, sexp, yojson]
+    type t [@@deriving compare, sexp, yojson, hash]
   end
 end]
 


### PR DESCRIPTION
This PR adds a test for gossip consistency. It records which gossip messages have been seen by each node (as a hash set of hashes of those messages, so we don't hold onto the messages themselves) and at the end checks the ratio 

```
(number of messages seen by all nodes) / (number of messages seen by any node)
```
and sees if it is `> 0.95`.

I had originally used a bloom filter, but I wasn't sure about the error rate, and found that a hash set of ints of size 100,000 is only 3 MB in utop.