### PR TITLE
Print ledger hashes

### DIFF
--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -8,7 +8,7 @@ let json =
 let plaintext =
   Command.Param.(
     flag "--plaintext" ~aliases:["plaintext"] no_arg
-      ~doc:"Use plaintext output (default: JSON)")
+      ~doc:"Use plaintext input or output (default: JSON)")
 
 let performance =
   Command.Param.(


### PR DESCRIPTION
Add subcommand `ledger hash`, which prints out the Merkle root of ledgers created via `ledger export`.

Usage:
```
$ coda ledger hash -help
Print the Merkle root of the ledger contained in the specified file

  coda.exe ledger hash 

=== flags ===

  --ledger-file LEDGER-FILE                 File containing an exported ledger
  [--daemon-port HOST:PORT/LOCALHOST-PORT]  Client to local daemon
                                            communication. If HOST is omitted,
                                            then localhost is assumed to be
                                            HOST. (examples: 8301,
                                            154.97.53.97:8301) (default: 8301)
                                            (alias: -daemon-port)
  [--plaintext]                             Use plaintext input or output
                                            (default: JSON)
                                            (alias: -plaintext)

```
(For `ledger export`, changed `current-staged-ledger` ledger kind to just `staged-ledger`, since providing a state hash gives you a non-current ledger.)

Tested with exported ledgers in both JSON and S-expression formats.

Branch based on `feature/ledger-exports`, used in #7880.

Addresses part of #7737.



