### PR TITLE
22kb docs

### DIFF
--- a/docs/blockchain-size-explanation.md
+++ b/docs/blockchain-size-explanation.md
@@ -16,7 +16,7 @@ This process of verification applies to all the nodes in Mina network. Some role
 
 We wish (1) to be able to check balances of a specific account (2) to be able to submit transactions to the network. For this, a node, we call it a "non-consensus node" needs stored on in memory merely: a protocol state, the account, a merkle path to this account, and a verification key. Importantly, these powerful nodes are not light clients. They have equivalent security to full nodes.
 
-This node role is not yet implemented. The protocol will support it, we just need to prioritize the engineering work.
+This node role is not yet implemented. The protocol will support it, we just need to prioritize the engineering work. It is on the roadmap post-mainnet.
 
 ### Protocol State
 


### PR DESCRIPTION
This is great! I made a few wording changes and tone changes explained below:

On the tone: I think the tone you have here is great for a blog post, but my thought was that since this is a "technical reference doc" that it needs a more serious tone. In case I'm right, I went through and reworded a few phrases to meet this tone. I'm not 100% sure though, we can let the other folks reviewing know we have both versions, and if they think the more fun tone is better for this doc then we can switch back to your wording.

Secondly: I changed a few specific names of things to match (my understanding of) 
what we want our public-facing vocabulary to be.

- Light client -> non-consensus node; All nodes are full nodes (in Mina)

Thirdly: Part of the definition of blockchain I changed, to be more clear that it
 doesn't represent the details of the specific blocks (the txns) (see my wording below)

Fourthly: I reorganized a few sections to keep the focus on the "non consensus nodes"

Fifthly: You said: "The protocol state basically has all the information to perform this check". What is the basically referring to? Is there another thing it needs? We don't want sentences like this in this document, we need to be completely detailed without hand-waving anything. I removed "basically" for now, but let me know if this is actually untrue.