### PR TITLE
skip integration test execution while failures are investigated

### DIFF
--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -1,5 +1,8 @@
 let Prelude = ../External/Prelude.dhall
 
+let B = ../External/Buildkite.dhall
+let B/Skip = B.definitions/commandStep/properties/skip/Type
+
 let Command = ./Base.dhall
 let Docker = ./Docker/Type.dhall
 let Size = ./Size.dhall
@@ -33,7 +36,8 @@ in
             ],
         label = "Build test-executive",
         key = "build-test-executive",
-        target = Size.XLarge
+        target = Size.XLarge,
+        skip = Some (B/Skip.String "https://github.com/MinaProtocol/mina/issues/7945")
       },
 
   execute = \(testName : Text) -> \(dependsOn : List Command.TaggedKey.Type) ->
@@ -57,6 +61,7 @@ in
         label = "Execute integration test: ${testName}",
         key = "integration-test-${testName}",
         target = Size.Medium,
-        depends_on = dependsOn
+        depends_on = dependsOn,
+        skip = Some (B/Skip.String "https://github.com/MinaProtocol/mina/issues/7945")
       }
 }


### PR DESCRIPTION
Per https://github.com/MinaProtocol/mina/issues/7945, skip and NOOP while failures are investigated.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
