### PR TITLE
Remove offline timeout shutdown, log instead

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -408,7 +408,7 @@ let create_sync_status_observer ~logger ~is_seed ~demo_mode ~net
     let offline_timeout = ref None in
     let offline_warned = ref false in
     let log_offline_warning _tm =
-      [%log warn]
+      [%log error]
         "Daemon has not received any gossip messages for %0.0f minutes; check \
          the daemon's external port forwarding, if needed"
         offline_timeout_min ;

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -409,8 +409,8 @@ let create_sync_status_observer ~logger ~is_seed ~demo_mode ~net
     let offline_warned = ref false in
     let log_offline_warning _tm =
       [%log warn]
-        "Daemon has been continuously offline for %0.0f minutes; check the \
-         daemon's external port forwarding, if needed"
+        "Daemon has not received any gossip messages for %0.0f minutes; check \
+         the daemon's external port forwarding, if needed"
         offline_timeout_min ;
       offline_warned := true
     in

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -428,7 +428,9 @@ let create_sync_status_observer ~logger ~is_seed ~demo_mode ~net
       match !offline_timeout with
       | Some timeout ->
           if !offline_warned then (
-            [%log info] "Daemon had been offline, now back online" ;
+            [%log info]
+              "Daemon had been offline (no gossip messages received), now \
+               back online" ;
             offline_warned := false ) ;
           Timeout.cancel () timeout () ;
           offline_timeout := None


### PR DESCRIPTION
Remove the code that starts a shutdown timer when a node is `Offline`.

Tested that the sync status still updates with `client status` on a local network.

Closes #7970.
