### PR TITLE
Use genesis time instead of UTC epoch for initial Blockchain_state

### DIFF
--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -127,7 +127,9 @@ let base_proof (module B : Blockchain_snark.Blockchain_snark_state.S)
     ~handler:
       (Consensus.Data.Prover_state.precomputed_handler ~constraint_constants
          ~genesis_epoch_ledger)
-    { transition= Snark_transition.genesis ~constraint_constants ~genesis_ledger
+    { transition=
+        Snark_transition.genesis ~constraint_constants ~consensus_constants
+          ~genesis_ledger
     ; prev_state }
     [(prev_state, blockchain_dummy); (dummy_txn_stmt, txn_dummy)]
     t.protocol_state_with_hash.data

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -110,7 +110,8 @@ let set_timestamp t timestamp = {t with Poly.timestamp}
 
 let negative_one
     ~(constraint_constants : Genesis_constants.Constraint_constants.t)
-    ~genesis_ledger_hash ~snarked_next_available_token : Value.t =
+    ~(consensus_constants : Consensus.Constants.t) ~genesis_ledger_hash
+    ~snarked_next_available_token : Value.t =
   let genesis_ledger_hash =
     Frozen_ledger_hash.of_ledger_hash genesis_ledger_hash
   in
@@ -119,7 +120,7 @@ let negative_one
   ; snarked_ledger_hash= genesis_ledger_hash
   ; genesis_ledger_hash
   ; snarked_next_available_token
-  ; timestamp= Block_time.of_time Time.epoch }
+  ; timestamp= consensus_constants.genesis_state_timestamp }
 
 (* negative_one and genesis blockchain states are equivalent *)
 let genesis = negative_one

--- a/src/lib/mina_state/blockchain_state.mli
+++ b/src/lib/mina_state/blockchain_state.mli
@@ -65,12 +65,14 @@ val create_value :
 
 val negative_one :
      constraint_constants:Genesis_constants.Constraint_constants.t
+  -> consensus_constants:Consensus.Constants.t
   -> genesis_ledger_hash:Ledger_hash.t
   -> snarked_next_available_token:Token_id.t
   -> Value.t
 
 val genesis :
      constraint_constants:Genesis_constants.Constraint_constants.t
+  -> consensus_constants:Consensus.Constants.t
   -> genesis_ledger_hash:Ledger_hash.t
   -> snarked_next_available_token:Token_id.t
   -> Value.t

--- a/src/lib/mina_state/genesis_protocol_state.ml
+++ b/src/lib/mina_state/genesis_protocol_state.ml
@@ -29,8 +29,8 @@ let t ~genesis_ledger ~genesis_epoch_data ~constraint_constants
            ~default:negative_one_protocol_state_hash
            ~f:(fun {previous_state_hash; _} -> previous_state_hash))
       ~blockchain_state:
-        (Blockchain_state.genesis ~constraint_constants ~genesis_ledger_hash
-           ~snarked_next_available_token)
+        (Blockchain_state.genesis ~constraint_constants ~consensus_constants
+           ~genesis_ledger_hash ~snarked_next_available_token)
       ~consensus_state:genesis_consensus_state ~constants:protocol_constants
   in
   With_hash.of_data ~hash_data:Protocol_state.hash state

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -287,6 +287,7 @@ let negative_one ~genesis_ledger ~genesis_epoch_data ~constraint_constants
   ; body=
       { Body.Poly.blockchain_state=
           Blockchain_state.negative_one ~constraint_constants
+            ~consensus_constants
             ~genesis_ledger_hash:
               (Mina_base.Ledger.merkle_root (Lazy.force genesis_ledger))
             ~snarked_next_available_token:

--- a/src/lib/mina_state/snark_transition.ml
+++ b/src/lib/mina_state/snark_transition.ml
@@ -53,10 +53,11 @@ let create_value ~blockchain_state ~consensus_transition
     ~pending_coinbase_update () : Value.t =
   {blockchain_state; consensus_transition; pending_coinbase_update}
 
-let genesis ~constraint_constants ~genesis_ledger : value =
+let genesis ~constraint_constants ~consensus_constants ~genesis_ledger : value
+    =
   let genesis_ledger = Lazy.force genesis_ledger in
   { Poly.blockchain_state=
-      Blockchain_state.genesis ~constraint_constants
+      Blockchain_state.genesis ~constraint_constants ~consensus_constants
         ~genesis_ledger_hash:(Ledger.merkle_root genesis_ledger)
         ~snarked_next_available_token:
           (Ledger.next_available_token genesis_ledger)

--- a/src/lib/mina_state/snark_transition.mli
+++ b/src/lib/mina_state/snark_transition.mli
@@ -64,6 +64,7 @@ val create_value :
 
 val genesis :
      constraint_constants:Genesis_constants.Constraint_constants.t
+  -> consensus_constants:Consensus.Constants.t
   -> genesis_ledger:Ledger.t Lazy.t
   -> Value.t
 


### PR DESCRIPTION
This fixes a bug where the genesis block has a timestamp relative to
genesis state (0) rather than relative to UTC epoch (~50 years). All
other blocks already had correct timestamps relative to UTC epoch.

Tested changes by running Rosetta's `./start.sh` and `rosetta-cli`.

Checklist:

- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #6700
