### PR TITLE
Make Rosetta DB acquisition more granular

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -422,22 +422,22 @@ module Balance = struct
     end )
 end
 
-let router ~graphql_uri ~logger ~db (route : string list) body =
-  let (module Db : Caqti_async.CONNECTION) = db in
+let router ~graphql_uri ~logger ~with_db (route : string list) body =
   let open Async.Deferred.Result.Let_syntax in
   [%log debug] "Handling /account/ $route"
     ~metadata:[("route", `List (List.map route ~f:(fun s -> `String s)))] ;
   match route with
   | ["balance"] ->
-      let%bind req =
-        Errors.Lift.parse ~context:"Request"
-        @@ Account_balance_request.of_yojson body
-        |> Errors.Lift.wrap
-      in
-      let%map res =
-        Balance.Real.handle ~env:(Balance.Env.real ~db ~graphql_uri) req
-        |> Errors.Lift.wrap
-      in
-      Account_balance_response.to_yojson res
+      with_db (fun ~db ->
+          let%bind req =
+            Errors.Lift.parse ~context:"Request"
+            @@ Account_balance_request.of_yojson body
+            |> Errors.Lift.wrap
+          in
+          let%map res =
+            Balance.Real.handle ~env:(Balance.Env.real ~db ~graphql_uri) req
+            |> Errors.Lift.wrap
+          in
+          Account_balance_response.to_yojson res )
   | _ ->
       Deferred.Result.fail `Page_not_found

--- a/src/app/rosetta/lib/mempool.ml
+++ b/src/app/rosetta/lib/mempool.ml
@@ -308,8 +308,7 @@ module Transaction = struct
     end )
 end
 
-let router ~graphql_uri ~logger ~db (route : string list) body =
-  let (module Db : Caqti_async.CONNECTION) = db in
+let router ~graphql_uri ~logger (route : string list) body =
   let open Async.Deferred.Result.Let_syntax in
   [%log debug] "Handling /mempool/ $route"
     ~metadata:[("route", `List (List.map route ~f:(fun s -> `String s)))] ;

--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -24,13 +24,13 @@ let router ~graphql_uri ~pool ~logger route body =
   try
     match route with
     | "network" :: tl ->
-        with_db (Network.router tl body ~graphql_uri ~logger)
+        Network.router tl body ~graphql_uri ~logger ~with_db
     | "account" :: tl ->
-        with_db (Account.router tl body ~graphql_uri ~logger)
+        Account.router tl body ~graphql_uri ~logger ~with_db
     | "mempool" :: tl ->
-        with_db (Mempool.router tl body ~graphql_uri ~logger)
+        Mempool.router tl body ~graphql_uri ~logger
     | "block" :: tl ->
-        with_db (Block.router tl body ~graphql_uri ~logger)
+        Block.router tl body ~graphql_uri ~logger ~with_db
     | "construction" :: tl ->
         Construction.router tl body ~graphql_uri ~logger
     | _ ->


### PR DESCRIPTION
This makes the pool acquisition more granular, only acquiring a resource
from the DB pool for `foo/bar` when `foo/bar` actually uses the DB resource
rather than any time `foo` uses it for any `foo/baz`.

Concretely, this means we now only acquire a DB resource for:
- `network/status`
- `account/balance`
- `block` and `block/`

Previously we acquired it for all subroutes except `construction/*`.
(Though we actually could've already removed it trivially for `mempool/*`
without this refactor.)

To test I tried hitting `network/list` with `archive-uri` set and unset and saw it works both times. I also confirmed that before this change if `archive-uri` wasn't set it returned a SQL error. I also ran the Rosetta test suite and `rosetta-cli` tests. 

Checklist:

- [x] Document code purpose, how to use it
- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #7690 
Closes #8001 
