### PR TITLE
Add Rosetta test for historical balance lookup, fix Rosetta date bug

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -16,7 +16,7 @@ module Get_coinbase_and_genesis =
       }
       protocolState {
         blockchainState {
-          utcDate
+          date
         }
       }
       stateHash
@@ -627,7 +627,7 @@ module Specific = struct
             ; winner= `Pk (genesisBlock#winnerAccount)#publicKey
             ; timestamp=
                 Int64.of_string
-                  ((genesisBlock#protocolState)#blockchainState)#utcDate
+                  ((genesisBlock#protocolState)#blockchainState)#date
             ; internal_info= []
             ; user_commands= [] }
         else env.db_block query

--- a/src/app/rosetta/make-runtime-genesis.sh
+++ b/src/app/rosetta/make-runtime-genesis.sh
@@ -4,6 +4,7 @@ set -eou pipefail
 
 PK=B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
 SNARK_PK=B62qjnkjj3zDxhEfxbn1qZhUawVeLsUr2GCzEz8m1MDztiBouNsiMUL
+TIMELOCKED_PK=B62qpJDprqj1zjNLf4wSpFC6dqmLzyokMy6KtMLSvkU8wfdL1midEb4
 
 mkdir -p /tmp/s3_cache_dir/
 
@@ -16,5 +17,5 @@ mkdir -p /tmp/keys \
   && echo "$PK" >  ~/.coda-config/wallets/store/$PK.pub \
   && cp /tmp/keys/demo-block-producer ~/.coda-config/wallets/store/$PK \
   && rm -rf ~/.coda-config/genesis* \
-  && echo '{"ledger":{"accounts":[{"pk":"'$PK'","balance":"66000","sk":null,"delegate":null}, {"pk":"'$SNARK_PK'","balance":"0.000000001","sk":null,"delegate":null}]}}' > /tmp/config.json \
+  && echo '{"ledger":{"accounts":[{"pk":"'$PK'","balance":"66000","sk":null,"delegate":null}, {"pk":"'$SNARK_PK'","balance":"0.000000001","sk":null,"delegate":null}, {"pk":"'$TIMELOCKED_PK'","balance":"10000","sk":null,"delegate":null,"timing":{"initial_minimum_balance":"5000","cliff_time":"20","cliff_amount":"2000","vesting_period":"5","vesting_increment":"10"}}]}}' > /tmp/config.json \
   && ../../../_build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --config-file /tmp/config.json

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -2,9 +2,12 @@
 
 open Core_kernel
 open Async
-open Rosetta_models
 open Rosetta_lib
 open Lib
+
+(* Rosetta_models.Currency shadows our Currency so we "save" it as MinaCurrency first *)
+module MinaCurrency = Currency
+open Rosetta_models
 
 module Error = struct
   include Error
@@ -15,6 +18,8 @@ end
 let other_pk = "B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv"
 
 let snark_pk = "B62qjnkjj3zDxhEfxbn1qZhUawVeLsUr2GCzEz8m1MDztiBouNsiMUL"
+
+let timelocked_pk = "B62qpJDprqj1zjNLf4wSpFC6dqmLzyokMy6KtMLSvkU8wfdL1midEb4"
 
 let wait span = Async.after span |> Deferred.map ~f:Result.return
 
@@ -498,6 +503,142 @@ let construction_api_create_token_account_through_mempool =
           ; _type= "fee_payer_dec"
           ; target= `Check None } ]
 
+let get_consensus_constants ~logger :
+    Consensus.Constants.t Or_error.t Deferred.t =
+  let open Deferred.Or_error.Let_syntax in
+  let conf_dir = "/tmp" in
+  let genesis_dir =
+    let home = Core.Sys.home_directory () in
+    Filename.concat home ".coda-config"
+  in
+  let config_file =
+    match Sys.getenv "CODA_CONFIG_FILE" with
+    | Some config_file ->
+        config_file
+    | None ->
+        Filename.concat conf_dir "config.json"
+  in
+  let%bind config =
+    let%map config_json = Genesis_ledger_helper.load_config_json config_file in
+    match Runtime_config.of_yojson config_json with
+    | Ok config ->
+        config
+    | Error err ->
+        failwithf "Could not parse configuration: %s" err ()
+  in
+  let%map proof, _ =
+    Genesis_ledger_helper.init_from_config_file ~genesis_dir ~logger
+      ~may_generate:true ~proof_level:None config
+  in
+  Precomputed_values.consensus_constants proof
+
+let historical_balance_check ~logger ~rosetta_uri ~network_response =
+  let open Core.Time in
+  let open Deferred.Result.Let_syntax in
+  let%bind consensus_constants =
+    Deferred.Result.map_error (get_consensus_constants ~logger) ~f:(fun _ ->
+        Errors.create ~context:"Failed to get consensus constants"
+          `Invariant_violation )
+  in
+  let%bind last_block_index =
+    get_last_block_index ~rosetta_uri ~network_response ~logger
+  in
+  (* TODO(omerzach): We need to test for more complex accounts that involve
+   *   internal and user commands too *)
+  let account_identifier = Account_identifier.create timelocked_pk in
+  let index_to_slot (index : int64) =
+    keep_trying
+      ~step:(fun () ->
+        let%map block_r =
+          Peek.Block.block_at_index ~index ~rosetta_uri ~network_response
+            ~logger
+        in
+        let block_r : (Block_response.t, Rosetta_models.Error.t) result =
+          block_r
+        in
+        match
+          Result.map block_r ~f:(fun block ->
+              let block = Option.value_exn block.Block_response.block in
+              let block_time : Block_time.t =
+                Block_time.of_int64 block.timestamp
+              in
+              let consensus_time : Consensus.Data.Consensus_time.t =
+                Consensus.Data.Consensus_time.of_time_exn
+                  ~constants:consensus_constants block_time
+              in
+              Consensus.Data.Consensus_time.to_global_slot consensus_time )
+        with
+        | Error _ ->
+            `Failed
+        | Ok slot ->
+            `Succeeded slot )
+      ~retry_count:10 ~initial_delay:(Span.of_ms 0.0)
+      ~each_delay:(Span.of_ms 250.0)
+      ~failure_reason:
+        (sprintf "Took too long for block %s to be fetched"
+           (Int64.to_string index))
+  in
+  let expected_balance_at_slot (slot : int64) =
+    let open Unsigned in
+    let global_slot = UInt32.of_int (Int.of_int64_exn slot) in
+    let cliff_time = UInt32.of_int 20 in
+    let cliff_amount = MinaCurrency.Amount.of_int 2_000_000_000_000 in
+    let vesting_period = Unsigned.UInt32.of_int 5 in
+    let vesting_increment = MinaCurrency.Amount.of_int 10_000_000_000 in
+    let initial_minimum_balance =
+      MinaCurrency.Balance.of_int 5_000_000_000_000
+    in
+    let total_balance = 10_000_000_000_000 in
+    let min_balance_at_slot =
+      Mina_base.Account.min_balance_at_slot ~global_slot ~cliff_time
+        ~cliff_amount ~vesting_period ~vesting_increment
+        ~initial_minimum_balance
+      |> MinaCurrency.Balance.to_int
+    in
+    total_balance - min_balance_at_slot
+  in
+  let check_balance_at_index (index : int64) ~logger =
+    let open Deferred.Result.Let_syntax in
+    let%bind slot = index_to_slot index in
+    let slot = slot |> Unsigned.UInt32.to_int64 |> Int64.of_int64 in
+    let expected_balance = expected_balance_at_slot slot in
+    let%bind actual_balance =
+      keep_trying
+        ~step:(fun () ->
+          let%map balance_r =
+            Peek.Account_balance.balance_at_index ~account_identifier ~index
+              ~rosetta_uri ~network_response ~logger
+          in
+          match balance_r with
+          | Ok {balances= [{value; _}]; _} ->
+              `Succeeded
+                ( value |> MinaCurrency.Balance.of_string
+                |> MinaCurrency.Balance.to_int )
+          | _ ->
+              `Failed )
+        ~retry_count:5 ~initial_delay:(Span.of_ms 100.0)
+        ~each_delay:(Span.of_sec 3.0)
+        ~failure_reason:
+          (sprintf "Took too long to look up balance for index %s"
+             (Int64.to_string index))
+    in
+    assert (Int.(expected_balance = actual_balance)) ;
+    Deferred.Result.return ()
+  in
+  let rec check_balances_until ~(until_index : int64)
+      ~(last_index_checked : int64) =
+    if Int64.(last_index_checked >= until_index) then Deferred.Result.return ()
+    else
+      let next_index = Int64.(last_index_checked + of_int 1) in
+      let%bind () = check_balance_at_index next_index ~logger in
+      let%bind () =
+        check_balances_until ~until_index ~last_index_checked:next_index
+      in
+      Deferred.Result.return ()
+  in
+  check_balances_until ~until_index:last_block_index
+    ~last_index_checked:(Int64.of_int 0)
+
 (* for each possible user command, run the command via GraphQL, check that
     the command is in the transaction pool
 *)
@@ -597,6 +738,11 @@ let check_new_account_user_commands ~logger ~rosetta_uri ~graphql_uri =
       ~graphql_uri ~network_response
   in
   [%log info] "Created token account using construction and waited" ;
+  [%log info] "Starting historical balance check" ;
+  let%bind _ =
+    historical_balance_check ~logger ~rosetta_uri ~network_response
+  in
+  [%log info] "Finished historical balance check" ;
   (* Stop staking *)
   (* Success *)
   return ()

--- a/src/app/rosetta/test-agent/peek.ml
+++ b/src/app/rosetta/test-agent/peek.ml
@@ -167,3 +167,33 @@ module Construction = struct
     Lift.res ~logger res ~of_yojson:Construction_submit_response.of_yojson
     |> Lift.successfully
 end
+
+module Account_balance = struct
+  open Deferred.Result.Let_syntax
+
+  let request_balance ~account_identifier ~block_identifier ~rosetta_uri
+      ~network_response ~logger =
+    let request : Account_balance_request.t =
+      { network_identifier= net_id network_response
+      ; account_identifier
+      ; block_identifier
+      ; currencies= [] }
+    in
+    let%map res =
+      post ~rosetta_uri ~logger
+        ~body:(request |> Account_balance_request.to_yojson)
+        ~path:"account/balance"
+    in
+    Lift.res ~logger res ~of_yojson:Account_balance_response.of_yojson
+
+  let current_balance ~account_identifier ~rosetta_uri ~network_response
+      ~logger =
+    request_balance ~account_identifier ~block_identifier:None ~rosetta_uri
+      ~network_response ~logger
+
+  let balance_at_index ~account_identifier ~(index : int64) ~rosetta_uri
+      ~network_response ~logger =
+    request_balance ~account_identifier
+      ~block_identifier:(Some {index= Some index; hash= None})
+      ~rosetta_uri ~network_response ~logger
+end

--- a/src/app/rosetta/test-agent/peek.ml
+++ b/src/app/rosetta/test-agent/peek.ml
@@ -116,17 +116,25 @@ end
 module Block = struct
   open Deferred.Result.Let_syntax
 
-  let newest_block ~rosetta_uri ~network_response ~logger =
+  let request_block ~block_identifier ~rosetta_uri ~network_response ~logger =
     let%map res =
       post ~rosetta_uri ~logger
         ~body:
           Block_request.(
-            create (net_id network_response)
-              (Partial_block_identifier.create ())
-            |> to_yojson)
+            create (net_id network_response) block_identifier |> to_yojson)
         ~path:"block/"
     in
     Lift.res ~logger res ~of_yojson:Block_response.of_yojson
+
+  let newest_block ~rosetta_uri ~network_response ~logger =
+    request_block
+      ~block_identifier:(Partial_block_identifier.create ())
+      ~rosetta_uri ~network_response ~logger
+
+  let block_at_index ~index ~rosetta_uri ~network_response ~logger =
+    request_block
+      ~block_identifier:{index= Some index; hash= None}
+      ~rosetta_uri ~network_response ~logger
 end
 
 module Construction = struct


### PR DESCRIPTION
Depends on #7992 (first commit).

- Makes it so we use block genesis `date` instead of `utcDate` in Rosetta
- Adds a time-locked account to the Rosetta test genesis ledger
- Adds code to Rosetta test-agent/agent.ml to check the time-locked
  account's balance at each index and confirm it matches what we expect
- Doesn't add the new account to the rosetta-cli bootstrap_balances
  because we don't have a way yet to mark the account as balance exempt
  (we're still waiting to hear back from Coinbase on that)
- Doesn't yet test a more complex situation with a time-locked accounts
  that actually encounters internal and user commands

Checklist:
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them: