### PR TITLE
add terraform v0.14.7 to shared buildkite agent DIR

### DIFF
--- a/automation/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/automation/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -267,6 +267,11 @@ locals {
         apt install -y unzip
         curl -sL https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip -o terraform.zip
         unzip terraform.zip && mv terraform /usr/bin
+
+        # Install custom versions of terraform in Buildkite shared DIR
+        curl -sL https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_linux_amd64.zip -o terraform-0_14_7.zip
+        mkdir -p /var/buildkite/shared/terraform/0.14.7
+        unzip terraform-0_14_7.zip && mv terraform /var/buildkite/shared/terraform/0.14.7/terraform
       EOF
 
       "02-install-coda-network-tools" = <<-EOF


### PR DESCRIPTION
In preparation of supporting terraform `optionals` and additional upgrades to the operational terraform tooling used in CI, add custom versions of tools like terraform to the Buildkite agent shared DIR (accessible on agents and in launched docker containers).

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: