### PR TITLE
[Snapps] GraphQL queries

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -2986,8 +2986,8 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
+                  "kind": "OBJECT",
+                  "name": "SnappCommand",
                   "ofType": null
                 }
               },

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -704,6 +704,122 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "SendSnappCommand",
+          "description": null,
+          "fields": [
+            {
+              "name": "feePayment",
+              "description": "The fee payment details, for use when the fees will not be paid as part of the snapp command",
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SnappFeePayment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "otherAccount",
+              "description": "The optional second account to participate in the snapp command",
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "secondParty",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snappAccount",
+              "description": "The account to send the snapp command to",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "authorizedParty",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "token",
+              "description": "Token associated with the snapp account(s)",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "feePayment",
+              "description": "The fee payment details, for use when the fees will not be paid as part of the snapp command",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SnappFeePayment",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "otherAccount",
+              "description": "The optional second account to participate in the snapp command",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "secondParty",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "snappAccount",
+              "description": "The account to send the snapp command to",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "authorizedParty",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "token",
+              "description": "Token associated with the snapp account(s)",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "SendMintTokensInput",
           "description": null,
           "fields": [
@@ -2848,6 +2964,37 @@
               "deprecationReason": null
             },
             {
+              "name": "sendSnappCommand",
+              "description": "Send a snapp command",
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SendSnappCommand",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "exportLogs",
               "description": "Export daemon logs to tar archive",
               "args": [
@@ -3558,6 +3705,1315 @@
                   "name": "UInt64",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SnappFeePayment",
+          "description": "Fee payment details for snapp commands",
+          "fields": [
+            {
+              "name": "publicKey",
+              "description": "Public key of the account to pay fees from",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "PublicKey",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nonce",
+              "description": "The nonce of the fee payer's account",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt32",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fee",
+              "description": "The fee to pay",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt64",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "signature",
+              "description": "The signature to authorize the payment",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Signature",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "secondParty",
+          "description": "The secondary account involved in a snapp transaction",
+          "fields": [
+            {
+              "name": "publicKey",
+              "description": "Public key of the snapp account",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "PublicKey",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "changes",
+              "description": "Changes to make to the snapp account",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SnappAccountChanges",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "balanceChange",
+              "description": "Amount to change the balance by",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int64",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "proof",
+              "description": "A proof to authorize the snapp command",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "SnarkProof",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "signature",
+              "description": "A signature to authorize the snapp command",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Signature",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "predicate",
+              "description": "The predicate that applies to the snapp command",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SnappPredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "EpochDataPredicate",
+          "description": "Predicates to be evaluated on the epoch data",
+          "fields": [
+            {
+              "name": "ledgerHash",
+              "description": "The predicate to be evaluated on the ledger hash",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCurrency",
+              "description": "The predicate to be evaluated on the total currency",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "epochSeed",
+              "description": "The predicate to be evaluated on the epoch seed",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startCheckpoint",
+              "description": "The predicate to be evaluated on the epoch start checkpoint",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lockCheckpoint",
+              "description": "The predicate to be evaluated on the epoch lock checkpoint",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "epochLength",
+              "description": "The predicate to be evaluated on the epoch length",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ProtocolStatePredicate",
+          "description": "Predicates to be evaluated on the protocol state",
+          "fields": [
+            {
+              "name": "snarkedLedgerHash",
+              "description": "The predicate to be evaluated on the snarked ledger hash",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nextAvailableToken",
+              "description": "The predicate to be evaluated on the next available token",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timestamp",
+              "description": "The predicate to be evaluated on the timestamp",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "blockchainLength",
+              "description": "The predicate to be evaluated on the blockchain length",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minWindowDensity",
+              "description": "The predicate to be evaluated on the minimum window density",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCurrency",
+              "description": "The predicate to be evaluated on the total currency",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentGlobalSlot",
+              "description": "The predicate to be evaluated on the current global slot",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalSlotSinceGenesis",
+              "description": "The predicate to be evaluated on the current global slot since genesis",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stakingEpochData",
+              "description": "The predicates to be evaluated on the staking epoch data",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EpochDataPredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nextEpochData",
+              "description": "The predicates to be evaluated on the next epoch data",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "EpochDataPredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "accountStatePredicate",
+          "description": "A predicate on the state of an account. One of Empty, Non_empty, Any",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AccountTransitionPredicate",
+          "description": "Predicates to be evaluated on an account state transition",
+          "fields": [
+            {
+              "name": "prev",
+              "description": "The predicate to be evaluated on the previous account state",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "accountStatePredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "next",
+              "description": "The predicate to be evaluated on the next account state",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "accountStatePredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OtherAccountPredicate",
+          "description": "Predicates to be evaluated on the other account",
+          "fields": [
+            {
+              "name": "accountPredicate",
+              "description": "The predicates to be evaluated on the account",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountPredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "accountTransition",
+              "description": "The predicates to be evaluated on the account state transition",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountTransitionPredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "accountVerificationKey",
+              "description": "The predicate to be evaluated on the account's verification key",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SnappStatePredicate",
+          "description": "Predicates to be evaluated on the snapp state vector",
+          "fields": [
+            {
+              "name": "0",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PredicateEquals",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "1",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PredicateEquals",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "2",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PredicateEquals",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "3",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PredicateEquals",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "4",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PredicateEquals",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "5",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PredicateEquals",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "6",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PredicateEquals",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "7",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PredicateEquals",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PredicateEquals",
+          "description": "A predicate to check equality against the given value",
+          "fields": [
+            {
+              "name": "equals",
+              "description": "The receipt chain hash to be compared against. If not given, this predicate is not active",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FieldElement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PredicateClosedInterval",
+          "description": "A predicate to check that the value is within the given bounds (inclusive)",
+          "fields": [
+            {
+              "name": "lower",
+              "description": "The lower bound of the comparison",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt64",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "upper",
+              "description": "The upper bound of the comparison",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt64",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "AccountPredicate",
+          "description": "Predicates to be evaluated on an account",
+          "fields": [
+            {
+              "name": "balance",
+              "description": "The predicate to be evaluated on the balance",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nonce",
+              "description": "The predicate to be evaluated on the nonce",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "receiptChainHash",
+              "description": "The predicate to be evaluated on the receipt chain hash",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publicKey",
+              "description": "The predicate to be evaluated on the public key",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "delegate",
+              "description": "The predicate to be evaluated on the delegate",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": "The predicate to be evaluated on the state",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SnappStatePredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SnappPredicate",
+          "description": "The predicates associated with the snapp proof",
+          "fields": [
+            {
+              "name": "accountPredicate",
+              "description": "The predicates to be evaluated on this account",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountPredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "otherAccountPredicate",
+              "description": "The predicates to be evaluated on the other snapp account",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "OtherAccountPredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "protocolStatePredicate",
+              "description": "The predicates to be evaluated on the protocol state",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProtocolStatePredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feePayerPredicate",
+              "description": "The predicate to be evaluated on the fee-payer",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PredicateEquals",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "RawSignature",
+          "description": "Raw encoded signature",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Signature",
+          "description": "A cryptographic signature",
+          "fields": [
+            {
+              "name": "rawSignature",
+              "description": "Raw encoded signature",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "RawSignature",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "SnarkProof",
+          "description": "A base64-encoded snark proof",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int64",
+          "description": "String representing a int64 number in base 10",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "AuthRequired",
+          "description": "The kind of authorization required to make a change to a snapp account property. One of None, Proof, Signature, Either, Both",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SnappAccountPermissions",
+          "description": null,
+          "fields": [
+            {
+              "name": "stake",
+              "description": "Whether the snapp account can stake",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edit_state",
+              "description": "Required permissions for editing the snapp state",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AuthRequired",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "send",
+              "description": "Required permissions for sending a snapp command",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AuthRequired",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "receive",
+              "description": "Required permissions for receiving a snapp command",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AuthRequired",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "set_delegate",
+              "description": "Required permissions for modifying the delegate",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AuthRequired",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "set_permissions",
+              "description": "Required permissions for modifying the account permissions",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AuthRequired",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "set_verification_key",
+              "description": "Required permissions for modifying the snapp verification key",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AuthRequired",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "VerificationKey",
+          "description": "A base64-encoded snark verification key",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "FieldElement",
+          "description": "A string-encoded field element",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SnappState",
+          "description": "The state for the snapp account",
+          "fields": [
+            {
+              "name": "0",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FieldElement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "1",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FieldElement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "2",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FieldElement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "3",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FieldElement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "4",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FieldElement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "5",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FieldElement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "6",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FieldElement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "7",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "FieldElement",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SnappAccountChanges",
+          "description": null,
+          "fields": [
+            {
+              "name": "snappState",
+              "description": "The new state of the snapp account",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SnappState",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "delegate",
+              "description": "The public key to delegate to",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "PublicKey",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "verificationKey",
+              "description": "The new verification key to associate with the snapp account",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "VerificationKey",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "permissions",
+              "description": "The new permissions to associate with the snapp account",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SnappAccountPermissions",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "authorizedParty",
+          "description": "A snapp account with an associated authorization",
+          "fields": [
+            {
+              "name": "publicKey",
+              "description": "Public key of the snapp account",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "PublicKey",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "changes",
+              "description": "Changes to make to the snapp account",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SnappAccountChanges",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "balanceChange",
+              "description": "Amount to change the balance by",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int64",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "proof",
+              "description": "A proof to authorize the snapp command",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "SnarkProof",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "signature",
+              "description": "A signature to authorize the snapp command",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Signature",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "predicate",
+              "description": "The predicate that applies to the snapp command",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SnappPredicate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SnappCommand",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hash",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "token",
+              "description": "Token associated with the snapp account(s)",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "TokenId",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snappAccount",
+              "description": "The account to send the snapp command to",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "authorizedParty",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "otherAccount",
+              "description": "The optional second account to participate in the snapp command",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "secondParty",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feePayment",
+              "description": "The fee payment details, for use when the fees will not be paid as part of the snapp command",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SnappFeePayment",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5475,6 +6931,30 @@
                     "ofType": {
                       "kind": "INTERFACE",
                       "name": "UserCommand",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snappCommands",
+              "description": "List of snapp commands included in this block",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SnappCommand",
                       "ofType": null
                     }
                   }
@@ -8342,6 +9822,16 @@
               "description": "Retrieve a block with the given state hash, if contained in the transition frontier.",
               "args": [
                 {
+                  "name": "height",
+                  "description": "The height of the desired block",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
                   "name": "stateHash",
                   "description": "The state hash of the desired block",
                   "type": {
@@ -8488,6 +9978,37 @@
                 {
                   "name": "payment",
                   "description": "Id of a UserCommand",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TransactionStatus",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snappStatus",
+              "description": "Get the status of a snapp command",
+              "args": [
+                {
+                  "name": "command",
+                  "description": "Id of a SnappCommand",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,

--- a/src/lib/graphql_lib/base_types.ml
+++ b/src/lib/graphql_lib/base_types.ml
@@ -18,8 +18,14 @@ let public_key () =
   scalar "PublicKey" ~doc:"Base58Check-encoded public key string"
     ~coerce:(fun key -> `String (Public_key.Compressed.to_base58_check key))
 
+let raw_signature () =
+  scalar "RawSignature" ~doc:"Raw encoded signature" ~coerce:(fun signature ->
+      `String (Mina_base.Signature.Raw.encode signature) )
+
 let uint32 () =
   unsigned_scalar_scalar ~to_string:Unsigned.UInt32.to_string "UInt32"
+
+let int64 () = unsigned_scalar_scalar ~to_string:Int64.to_string "Int64"
 
 let uint64 () =
   unsigned_scalar_scalar ~to_string:Unsigned.UInt64.to_string "UInt64"

--- a/src/lib/graphql_lib/base_types.mli
+++ b/src/lib/graphql_lib/base_types.mli
@@ -5,7 +5,11 @@ open Unsigned
 
 val public_key : unit -> ('a, Public_key.Compressed.t option) typ
 
+val raw_signature : unit -> ('a, Mina_base.Signature.t option) typ
+
 val uint32 : unit -> ('a, UInt32.t option) typ
+
+val int64 : unit -> ('a, Int64.t option) typ
 
 val uint64 : unit -> ('a, UInt64.t option) typ
 

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3710,7 +3710,7 @@ module Mutations = struct
 
   let send_snapp_command =
     io_field "sendSnappCommand" ~doc:"Send a snapp command"
-      ~typ:(non_null bool) (* TODO: Non-bool *)
+      ~typ:(non_null Types.SnappCommand.typ)
       ~args:Arg.[arg "input" ~typ:(non_null Types.Input.SendSnappCommand.typ)]
       ~resolve:(fun {ctx= coda; _} () snapp_command_input ->
         match
@@ -3718,8 +3718,8 @@ module Mutations = struct
         with
         | `Active f -> (
             match%map f with
-            | Ok _snapp_command ->
-                Ok true
+            | Ok snapp_command ->
+                Ok snapp_command
             | Error e ->
                 Error ("Couldn't send snapp command: " ^ Error.to_string_hum e)
             )

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1922,8 +1922,18 @@ module Types = struct
                   | Signed_command c ->
                       Some (UserCommand.mk_user_command {t with data= c})
                   | Snapp_command _ ->
-                      (* TODO: This should be supported in some graph QL query *)
                       None ) )
+        ; field "snappCommands"
+            ~doc:"List of snapp commands included in this block"
+            ~typ:(non_null @@ list @@ non_null SnappCommand.typ)
+            ~args:Arg.[]
+            ~resolve:(fun _ {commands; _} ->
+              List.filter_map commands ~f:(fun t ->
+                  match t.data with
+                  | Signed_command _ ->
+                      None
+                  | Snapp_command snapp ->
+                      Some snapp ) )
         ; field "feeTransfer"
             ~doc:"List of fee transfers included in this block"
             ~typ:(non_null @@ list @@ non_null fee_transfer)

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -961,7 +961,15 @@ module Types = struct
 
     let typ : (_, Snapp_command.t option) typ =
       obj "SnappCommand" ~fields:(fun _ ->
-          [ field "token" ~doc:"Token associated with the snapp account(s)"
+          [ field "id" ~typ:(non_null guid) ~args:[]
+              ~resolve:(fun _ snapp_command ->
+                Snapp_command.to_base58_check snapp_command )
+          ; field "hash" ~typ:(non_null string) ~args:[]
+              ~resolve:(fun _ snapp_command ->
+                Transaction_hash.to_base58_check
+                  (Transaction_hash.hash_command (Snapp_command snapp_command))
+            )
+          ; field "token" ~doc:"Token associated with the snapp account(s)"
               ~typ:token_id ~args:[] ~resolve:(fun _ -> function
               | Snapp_command.Proved_empty {token_id; _}
               | Snapp_command.Proved_signed {token_id; _}

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.mli
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.mli
@@ -24,3 +24,10 @@ val get_status :
   -> transaction_pool:Network_pool.Transaction_pool.t
   -> Signed_command.t
   -> State.t Or_error.t
+
+val get_snapp_status :
+     frontier_broadcast_pipe:Transition_frontier.t Option.t
+                             Broadcast_pipe.Reader.t
+  -> transaction_pool:Network_pool.Transaction_pool.t
+  -> Snapp_command.t
+  -> State.t Or_error.t


### PR DESCRIPTION
These changes build upon #6136.

This PR
* adds the 'output' GraphQL type for snapp transactions
  - This closely matches the input type, so that it is trivial to take the snapp transaction returned by an endpoint and pass it to another input endpoint
* returns this rich type from `sendSnappCommand` (previously this was a dummy `bool` value)
* adds a `snappStatus` query -- analogous to `transactionStatus` -- to find the current status of a particular snapp transaction
  - This currently takes the snapp ID as input, even though this ID encodes the entire command and proof and is thus very large
  - The current implementation is extremely expensive. It's essentially the same as the implementation of `transactionStatus`, which is also very expensive; I concluded that either this is 'fine for now', or that both should be fixed together as part of a separate change.
  - It's fairly simple to accept a hash instead, but it would make this command even more extremely expensive: we would need to hash every snapp command in every block that we know about to compare it to the target hash. I elected not to do this.
* adds a `snappCommands` field to `Block.transactions`, exposing the snapp commands seen in a particular block.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: