### PR TITLE
Add encore + zenith testnets to Pagerduty monitoring and alerting set

### DIFF
--- a/automation/terraform/infrastructure/testnet-alerts.tf
+++ b/automation/terraform/infrastructure/testnet-alerts.tf
@@ -5,7 +5,7 @@ locals {
 data "template_file" "testnet_alerts" {
   template = "${file("${path.module}/templates/testnet-alerts.yml.tpl")}"
   vars = {
-    rule_filter = "{testnet=~\"testworld|.+\"}", # any non-empty testnet name + 'testworld'
+    rule_filter = "{testnet=~\".+\"}", # any non-empty testnet name
     alerting_timeframe = "1h"
   }
 }
@@ -14,7 +14,7 @@ data "template_file" "testnet_alert_receivers" {
   template = "${file("${path.module}/templates/testnet-alert-receivers.yml.tpl")}"
   vars = {
     pagerduty_service_key = "${data.aws_secretsmanager_secret_version.pagerduty_testnet_primary_key.secret_string}"
-    pagerduty_alert_filter = "testworld"
+    pagerduty_alert_filter = "testworld|encore|zenith"
 
     discord_alert_webhook = "${data.aws_secretsmanager_secret_version.discord_testnet_alerts_webhook.secret_string}"
   }


### PR DESCRIPTION
Update testnet monitoring infra to alert to Pagerduty on *testworld, encore and zenith* testnet alert violations. 

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
