### PR TITLE
Remove <region> from infra kubernetes storage class naming scheme

### DIFF
--- a/automation/terraform/infrastructure/us-central1.tf
+++ b/automation/terraform/infrastructure/us-central1.tf
@@ -193,7 +193,7 @@ resource "kubernetes_storage_class" "central1_ssd" {
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "${local.central1_region}-ssd-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "ssd-${lower(local.storage_reclaim_policies[count.index])}"
   }
 
   storage_provisioner = "kubernetes.io/gce-pd"
@@ -210,7 +210,7 @@ resource "kubernetes_storage_class" "central1_standard" {
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "${local.central1_region}-standard-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "standard-${lower(local.storage_reclaim_policies[count.index])}"
   }
 
   storage_provisioner = "kubernetes.io/gce-pd"

--- a/automation/terraform/infrastructure/us-central1.tf
+++ b/automation/terraform/infrastructure/us-central1.tf
@@ -187,7 +187,44 @@ resource "google_container_node_pool" "central1_compute_nodes" {
 
 ## Data Persistence
 
+# TODO: deprecate below region based storage classes once OK to do so (i.e. all testnets have migrated to new classes)
 resource "kubernetes_storage_class" "central1_ssd" {
+  provider = kubernetes.k8s_central1
+
+  count = length(local.storage_reclaim_policies)
+
+  metadata {
+    name = "${local.central1_region}-ssd-${lower(local.storage_reclaim_policies[count.index])}"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = local.storage_reclaim_policies[count.index]
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    type = "pd-ssd"
+  }
+}
+
+resource "kubernetes_storage_class" "central1_standard" {
+  provider = kubernetes.k8s_central1
+
+  count = length(local.storage_reclaim_policies)
+
+  metadata {
+    name = "${local.central1_region}-standard-${lower(local.storage_reclaim_policies[count.index])}"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = local.storage_reclaim_policies[count.index]
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    type = "pd-standard"
+  }
+}
+
+# ---
+
+resource "kubernetes_storage_class" "central1_infra_ssd" {
   provider = kubernetes.k8s_central1
 
   count = length(local.storage_reclaim_policies)
@@ -204,7 +241,7 @@ resource "kubernetes_storage_class" "central1_ssd" {
   }
 }
 
-resource "kubernetes_storage_class" "central1_standard" {
+resource "kubernetes_storage_class" "central1_infra_standard" {
   provider = kubernetes.k8s_central1
 
   count = length(local.storage_reclaim_policies)

--- a/automation/terraform/infrastructure/us-east1.tf
+++ b/automation/terraform/infrastructure/us-east1.tf
@@ -193,7 +193,7 @@ resource "kubernetes_storage_class" "east1_ssd" {
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "${local.east1_region}-ssd-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "ssd-${lower(local.storage_reclaim_policies[count.index])}"
   }
   storage_provisioner = "kubernetes.io/gce-pd"
   reclaim_policy      = local.storage_reclaim_policies[count.index]
@@ -209,7 +209,7 @@ resource "kubernetes_storage_class" "east1_standard" {
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "${local.east1_region}-standard-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "standard-${lower(local.storage_reclaim_policies[count.index])}"
   }
 
   storage_provisioner = "kubernetes.io/gce-pd"

--- a/automation/terraform/infrastructure/us-east1.tf
+++ b/automation/terraform/infrastructure/us-east1.tf
@@ -187,13 +187,14 @@ resource "google_container_node_pool" "east1_compute_nodes" {
 
 ## Data Persistence
 
+# TODO: deprecate below region based storage classes once OK to do so (i.e. all testnets have migrated to new classes)
 resource "kubernetes_storage_class" "east1_ssd" {
   provider = kubernetes.k8s_east1
 
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "ssd-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "${local.east1_region}-ssd-${lower(local.storage_reclaim_policies[count.index])}"
   }
   storage_provisioner = "kubernetes.io/gce-pd"
   reclaim_policy      = local.storage_reclaim_policies[count.index]
@@ -204,6 +205,42 @@ resource "kubernetes_storage_class" "east1_ssd" {
 }
 
 resource "kubernetes_storage_class" "east1_standard" {
+  provider = kubernetes.k8s_east1
+
+  count = length(local.storage_reclaim_policies)
+
+  metadata {
+    name = "${local.east1_region}-standard-${lower(local.storage_reclaim_policies[count.index])}"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = local.storage_reclaim_policies[count.index]
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    type = "pd-standard"
+  }
+}
+
+# ---
+
+resource "kubernetes_storage_class" "east1_infra_ssd" {
+  provider = kubernetes.k8s_east1
+
+  count = length(local.storage_reclaim_policies)
+
+  metadata {
+    name = "ssd-${lower(local.storage_reclaim_policies[count.index])}"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = local.storage_reclaim_policies[count.index]
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    type = "pd-ssd"
+  }
+}
+
+resource "kubernetes_storage_class" "east1_infra_standard" {
   provider = kubernetes.k8s_east1
 
   count = length(local.storage_reclaim_policies)

--- a/automation/terraform/infrastructure/us-east4.tf
+++ b/automation/terraform/infrastructure/us-east4.tf
@@ -193,7 +193,7 @@ resource "kubernetes_storage_class" "east4_ssd" {
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "${local.east4_region}-ssd-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "ssd-${lower(local.storage_reclaim_policies[count.index])}"
   }
 
   storage_provisioner = "kubernetes.io/gce-pd"
@@ -210,7 +210,7 @@ resource "kubernetes_storage_class" "east4_standard" {
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "${local.east4_region}-standard-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "standard-${lower(local.storage_reclaim_policies[count.index])}"
   }
 
   storage_provisioner = "kubernetes.io/gce-pd"

--- a/automation/terraform/infrastructure/us-east4.tf
+++ b/automation/terraform/infrastructure/us-east4.tf
@@ -187,13 +187,14 @@ resource "google_container_node_pool" "east4_compute_nodes" {
 
 ## Data Persistence
 
+# TODO: deprecate below region based storage classes once OK to do so (i.e. all testnets have migrated to new classes)
 resource "kubernetes_storage_class" "east4_ssd" {
   provider = kubernetes.k8s_east4
 
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "ssd-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "${local.east4_region}-ssd-${lower(local.storage_reclaim_policies[count.index])}"
   }
 
   storage_provisioner = "kubernetes.io/gce-pd"
@@ -210,6 +211,42 @@ resource "kubernetes_storage_class" "east4_standard" {
   count = length(local.storage_reclaim_policies)
 
   metadata {
+    name = "${local.east4_region}-standard-${lower(local.storage_reclaim_policies[count.index])}"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = local.storage_reclaim_policies[count.index]
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    type = "pd-standard"
+  }
+}
+
+# ---
+
+resource "kubernetes_storage_class" "east4_infra_ssd" {
+  provider = kubernetes.k8s_east4
+
+  count = length(local.storage_reclaim_policies)
+
+  metadata {
+    name = "ssd-${lower(local.storage_reclaim_policies[count.index])}"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = local.storage_reclaim_policies[count.index]
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    type = "pd-ssd"
+  }
+}
+
+resource "kubernetes_storage_class" "east4_infra_standard" {
+  provider = kubernetes.k8s_east4
+
+  count = length(local.storage_reclaim_policies)
+
+  metadata {
     name = "standard-${lower(local.storage_reclaim_policies[count.index])}"
   }
 
@@ -220,6 +257,7 @@ resource "kubernetes_storage_class" "east4_standard" {
     type = "pd-standard"
   }
 }
+
 
 ## Monitoring
 

--- a/automation/terraform/infrastructure/us-west1.tf
+++ b/automation/terraform/infrastructure/us-west1.tf
@@ -139,7 +139,7 @@ resource "kubernetes_storage_class" "west1_ssd" {
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "${local.west1_region}-ssd-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "ssd-${lower(local.storage_reclaim_policies[count.index])}"
   }
 
   storage_provisioner = "kubernetes.io/gce-pd"
@@ -156,7 +156,7 @@ resource "kubernetes_storage_class" "west1_standard" {
   count = length(local.storage_reclaim_policies)
 
   metadata {
-    name = "${local.west1_region}-standard-${lower(local.storage_reclaim_policies[count.index])}"
+    name = "standard-${lower(local.storage_reclaim_policies[count.index])}"
   }
 
   storage_provisioner = "kubernetes.io/gce-pd"

--- a/automation/terraform/infrastructure/us-west1.tf
+++ b/automation/terraform/infrastructure/us-west1.tf
@@ -133,7 +133,44 @@ resource "google_container_node_pool" "west1_integration_preemptible" {
 
 ## Data Persistence
 
+# TODO: deprecate below region based storage classes once OK to do so (i.e. all testnets have migrated to new classes)
 resource "kubernetes_storage_class" "west1_ssd" {
+  provider = kubernetes.k8s_west1
+
+  count = length(local.storage_reclaim_policies)
+
+  metadata {
+    name = "${local.west1_region}-ssd-${lower(local.storage_reclaim_policies[count.index])}"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = local.storage_reclaim_policies[count.index]
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    type = "pd-ssd"
+  }
+}
+
+resource "kubernetes_storage_class" "west1_standard" {
+  provider = kubernetes.k8s_west1
+
+  count = length(local.storage_reclaim_policies)
+
+  metadata {
+    name = "${local.west1_region}-standard-${lower(local.storage_reclaim_policies[count.index])}"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+  reclaim_policy      = local.storage_reclaim_policies[count.index]
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    type = "pd-standard"
+  }
+}
+
+# ---
+
+resource "kubernetes_storage_class" "west1_infra_ssd" {
   provider = kubernetes.k8s_west1
 
   count = length(local.storage_reclaim_policies)
@@ -150,7 +187,7 @@ resource "kubernetes_storage_class" "west1_ssd" {
   }
 }
 
-resource "kubernetes_storage_class" "west1_standard" {
+resource "kubernetes_storage_class" "west1_infra_standard" {
   provider = kubernetes.k8s_west1
 
   count = length(local.storage_reclaim_policies)


### PR DESCRIPTION
Adding `<region>` to infra's storage class naming scheme is redundant as storage classes are scoped by region/cluster. Also, relying on regions when specifying defaults can be problematic and generally unnecessary (at least in this case). 

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: