### PR TITLE
Applying retroactively - only alert to PagerDuty on zenith testnet check violations.

### DIFF
--- a/automation/terraform/infrastructure/testnet-alerts.tf
+++ b/automation/terraform/infrastructure/testnet-alerts.tf
@@ -14,7 +14,7 @@ data "template_file" "testnet_alert_receivers" {
   template = "${file("${path.module}/templates/testnet-alert-receivers.yml.tpl")}"
   vars = {
     pagerduty_service_key = "${data.aws_secretsmanager_secret_version.pagerduty_testnet_primary_key.secret_string}"
-    pagerduty_alert_filter = "testworld|encore|zenith"
+    pagerduty_alert_filter = "zenith"
 
     discord_alert_webhook = "${data.aws_secretsmanager_secret_version.discord_testnet_alerts_webhook.secret_string}"
   }


### PR DESCRIPTION
Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
