### PR TITLE
Make Rosetta graphql_uri param optional

### DIFF
--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -824,7 +824,7 @@ module Submit = struct
   module Mock = Impl (Result)
 end
 
-let router ~graphql_uri ~logger (route : string list) body =
+let router ~get_graphql_uri_or_error ~logger (route : string list) body =
   [%log debug] "Handling /construction/ $route"
     ~metadata:[("route", `List (List.map route ~f:(fun s -> `String s)))] ;
   let open Deferred.Result.Let_syntax in
@@ -855,6 +855,7 @@ let router ~graphql_uri ~logger (route : string list) body =
         @@ Construction_metadata_request.of_yojson body
         |> Errors.Lift.wrap
       in
+      let%bind graphql_uri = get_graphql_uri_or_error () in
       let%map res =
         Metadata.Real.handle ~env:(Metadata.Env.real ~graphql_uri) req
         |> Errors.Lift.wrap
@@ -886,6 +887,7 @@ let router ~graphql_uri ~logger (route : string list) body =
         @@ Construction_parse_request.of_yojson body
         |> Errors.Lift.wrap
       in
+      let%bind graphql_uri = get_graphql_uri_or_error () in
       let%map res =
         Parse.Real.handle ~env:(Parse.Env.real ~graphql_uri) req
         |> Errors.Lift.wrap
@@ -907,6 +909,7 @@ let router ~graphql_uri ~logger (route : string list) body =
         @@ Construction_submit_request.of_yojson body
         |> Errors.Lift.wrap
       in
+      let%bind graphql_uri = get_graphql_uri_or_error () in
       let%map res =
         Submit.Real.handle ~env:(Submit.Env.real ~graphql_uri) req
         |> Errors.Lift.wrap

--- a/src/lib/rosetta_lib/errors.ml
+++ b/src/lib/rosetta_lib/errors.ml
@@ -36,7 +36,8 @@ module Variant = struct
     | `No_options_provided
     | `Exception of string
     | `Signature_invalid
-    | `Memo_invalid ]
+    | `Memo_invalid
+    | `Graphql_uri_not_set ]
   [@@deriving yojson, show, eq, to_enum, to_representatives]
 end
 
@@ -104,6 +105,8 @@ end = struct
         "Invalid signature"
     | `Memo_invalid ->
         "Invalid memo"
+    | `Graphql_uri_not_set ->
+        "No GraphQL URI set"
 
   let context = function
     | `Sql msg ->
@@ -166,6 +169,8 @@ end = struct
         None
     | `Memo_invalid ->
         None
+    | `Graphql_uri_not_set ->
+        None
 
   let retriable = function
     | `Sql _ ->
@@ -203,6 +208,8 @@ end = struct
     | `Signature_invalid ->
         false
     | `Memo_invalid ->
+        false
+    | `Graphql_uri_not_set ->
         false
 
   (* Unlike message above, description can be updated whenever we see fit *)
@@ -243,6 +250,9 @@ end = struct
         "Your request has an invalid memo."
     | `No_options_provided ->
         "Your request is missing options."
+    | `Graphql_uri_not_set ->
+        "This Rosetta instance is running without a GraphQL URI set but this \
+         request requires one."
     | `Exception _ ->
         "We encountered an internal exception while processing your request. \
          (That means you found a bug!)"


### PR DESCRIPTION
- Make the graphql_uri param optional on a CLI level
- Add a new Graphql_uri_not_set error
- Return the new error for network/*, account/*, mempool/*, block/*,
  construction/metadata, construction/parse, and construction/submit
- Currently all network/*, account/*, mempool/*, and block/* routes
  require GraphQL but this makes it easy to refactor those to have it
  only required for certain subroutes

To test:
- Manually tested `construction/derive` endpoint with and without `graphql_uri` set, saw it still works both with and without it set
- Manually tested `construction/metadata` endpoint without `graphql_uri` set, saw it returns a clear error when it's not set
- Ran Rosetta test suite
- Ran rosetta-cli

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #8023