### PR TITLE
set base CI terraform version to 0.14.7 and update infra + testnet minimum supported versions

### DIFF
--- a/automation/terraform/buildkite/buildkite-experimental/main.tf
+++ b/automation/terraform/buildkite/buildkite-experimental/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13.3"
   backend "s3" {
     key     = "terraform-bk-experimental.tfstate"
     encrypt = true

--- a/automation/terraform/infrastructure/main.tf
+++ b/automation/terraform/infrastructure/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
   backend "s3" {
     key     = "terraform-coda-infra.tfstate"
     encrypt = true

--- a/automation/terraform/modules/kubernetes/buildkite-agent/helm.tf
+++ b/automation/terraform/modules/kubernetes/buildkite-agent/helm.tf
@@ -265,13 +265,13 @@ locals {
         set -euo pipefail
 
         apt install -y unzip
-        curl -sL https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip -o terraform.zip
+        curl -sL https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_linux_amd64.zip -o terraform.zip
         unzip terraform.zip && mv terraform /usr/bin
 
         # Install custom versions of terraform in Buildkite shared DIR
-        curl -sL https://releases.hashicorp.com/terraform/0.14.7/terraform_0.14.7_linux_amd64.zip -o terraform-0_14_7.zip
-        mkdir -p /var/buildkite/shared/terraform/0.14.7
-        unzip terraform-0_14_7.zip && mv terraform /var/buildkite/shared/terraform/0.14.7/terraform
+        curl -sL https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip -o terraform-0_12_29.zip
+        mkdir -p /var/buildkite/shared/terraform/0.12.29
+        unzip terraform-0_12_29.zip && mv terraform /var/buildkite/shared/terraform/0.12.29/terraform
       EOF
 
       "02-install-coda-network-tools" = <<-EOF

--- a/automation/terraform/testnets/bug-net/main.tf
+++ b/automation/terraform/testnets/bug-net/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
   backend "s3" {
     key     = "terraform-bug-net.tfstate"
     encrypt = true

--- a/automation/terraform/testnets/bugspray/main.tf
+++ b/automation/terraform/testnets/bugspray/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
   backend "s3" {
     key     = "terraform-bugspray.tfstate"
     encrypt = true

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
   backend "s3" {
     key     = "terraform-ci-net.tfstate"
     encrypt = true

--- a/automation/terraform/testnets/multiple-seeds-test/main.tf
+++ b/automation/terraform/testnets/multiple-seeds-test/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
   backend "s3" {
     key     = "terraform-multiple-seeds-test.tfstate"
     encrypt = true

--- a/automation/terraform/testnets/nightly/main.tf
+++ b/automation/terraform/testnets/nightly/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.12.0"
   backend "s3" {
     key     = "terraform-nightly.tfstate"
     encrypt = true

--- a/automation/terraform/testnets/static-peers-net/main.tf
+++ b/automation/terraform/testnets/static-peers-net/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
   backend "s3" {
     key     = "terraform-beansqa.tfstate"
     encrypt = true

--- a/automation/terraform/testnets/testworld/main.tf
+++ b/automation/terraform/testnets/testworld/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
   backend "s3" {
     key     = "terraform-testworld.tfstate"
     encrypt = true

--- a/automation/terraform/testnets/watchdog-test/main.tf
+++ b/automation/terraform/testnets/watchdog-test/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
   backend "s3" {
     key     = "terraform-watchdog-test.tfstate"
     encrypt = true

--- a/automation/terraform/testnets/zenith/main.tf
+++ b/automation/terraform/testnets/zenith/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
   backend "s3" {
     key     = "terraform-zenith.tfstate"
     encrypt = true


### PR DESCRIPTION
`v0.14.7` should be compatible with existing terraform configs (both **testnets** and **buildkite**) so it's safe to loosen *required_versions* across the board. Also the *0.14.x* version family is required for upcoming changes to how multiple instances of testnet components are deployed (see: https://github.com/MinaProtocol/mina/pull/7781 for example).

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: