### PR TITLE
soft-fail testnet alert jobs while terraform state is updated to support 0.14.x terraform wersions

### DIFF
--- a/buildkite/src/Jobs/Lint/TestnetAlerts.dhall
+++ b/buildkite/src/Jobs/Lint/TestnetAlerts.dhall
@@ -1,4 +1,7 @@
 let Prelude = ../../External/Prelude.dhall
+let B = ../../External/Buildkite.dhall
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
 
 let S = ../../Lib/SelectFiles.dhall
 let Cmd = ../../Lib/Cmds.dhall
@@ -32,6 +35,7 @@ Pipeline.build
           , label = "Lint Testnet alert rules"
           , key = "lint-testnet-alerts"
           , target = Size.Small
+          , soft_fail = Some (B/SoftFail.Boolean True)
           , docker = None Docker.Type
         }
     ]

--- a/buildkite/src/Jobs/Release/TestnetAlerts.dhall
+++ b/buildkite/src/Jobs/Release/TestnetAlerts.dhall
@@ -1,4 +1,7 @@
 let Prelude = ../../External/Prelude.dhall
+let B = ../../External/Buildkite.dhall
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
 
 let S = ../../Lib/SelectFiles.dhall
 let Cmd = ../../Lib/Cmds.dhall
@@ -31,8 +34,9 @@ Pipeline.build
           , label = "Deploy Testnet alert rules"
           , key = "deploy-testnet-alerts"
           , target = Size.Medium
-          , docker = None Docker.Type
           , depends_on = [ { name = "TestnetAlerts", key = "lint-testnet-alerts" } ]
+          , soft_fail = Some (B/SoftFail.Boolean True)
+          , docker = None Docker.Type
         }
     ]
   }


### PR DESCRIPTION
Testnet alert jobs in CI are currently failing due to the recent `terraform` version upgrade and their existing state file being based on the 0.12.x tool versions (see for [example](https://buildkite.com/o-1-labs-2/mina/builds/12721#402961df-0746-4e64-bf94-40ad274ce820). A resolution for this issue is pretty straightforward though unblock/only soft-fail on such failures during it is committed.

```
Error: Invalid legacy provider address

This configuration or its associated state refers to the unqualified provider


You must complete the Terraform 0.13 upgrade process before upgrading to later
---
```

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: