### PR TITLE
Remove dirty message from buildkite artifact versions

### DIFF
--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -47,6 +47,8 @@ Pipeline.build
             "DUNE_PROFILE=testnet_postake_medium_curves",
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
+            "CODA_BRANCH=$BUILDKITE_BRANCH",
+            "CODA_COMMIT_SHA1=$BUILDKITE_COMMIT",
             -- add zexe standardization preprocessing step (see: https://github.com/CodaProtocol/coda/pull/5777)
             "PREPROCESSOR=./scripts/zexe-standardize.sh"
           ] "./buildkite/scripts/build-artifact.sh" # [ Cmd.run "buildkite/scripts/buildkite-artifact-helper.sh ./DOCKER_DEPLOY_ENV" ],

--- a/src/lib/mina_version/gen.sh
+++ b/src/lib/mina_version/gen.sh
@@ -1,13 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
-branch=$(git rev-parse --verify --abbrev-ref HEAD || echo "<none found>")
 commit_id_short=$(git rev-parse --short=8 --verify HEAD)
-
 CWD=$PWD
 
+if [ -n "$CODA_BRANCH" ]; then
+  branch="$CODA_BRANCH"
+else
+  branch=$(git rev-parse --verify --abbrev-ref HEAD || echo "<none found>")
+fi
+
 # we are nested 5 directories deep (_build/<context>/src/lib/mina_version)
-cd ../../../../..
+pushd ../../../../..
   if [ -n "$CODA_COMMIT_SHA1" ]; then
     # pull from env var if set
     id="$CODA_COMMIT_SHA1"
@@ -17,13 +21,13 @@ cd ../../../../..
     if [ -n "$(git diff --stat)" ]; then id="[DIRTY]$id"; fi
   fi
   commit_date=$(git show HEAD -s --format="%cI")
-  cd src/lib/marlin
+  pushd src/lib/marlin
     marlin_commit_id=$(git rev-parse --verify HEAD)
     if [ -n "$(git diff --stat)" ]; then marlin_commit_id="[DIRTY]$id"; fi
     marlin_commit_id_short=$(git rev-parse --short=8 --verify HEAD)
     marlin_commit_date=$(git show HEAD -s --format="%cI")
-  cd ../../..
-cd $CWD
+  popd
+popd
 
 echo "let commit_id = \"$id\"" > "$1"
 echo "let commit_id_short = \"$commit_id_short\"" >> "$1"


### PR DESCRIPTION
I confirmed that the `coda-daemon` image buildkite built on this branch no longer has the dirty version.

```
root@5180ce164c23:~# mina version
Commit c80d8b8f87ba6243a30f2b26d0b0b7e47b21e566 on branch fix/undirty-buildkite-artifacts
```