### PR TITLE
add required archive vars to block-producer and seed-node specs in o1-integration module

### DIFF
--- a/automation/terraform/modules/o1-integration/testnet.tf
+++ b/automation/terraform/modules/o1-integration/testnet.tf
@@ -32,7 +32,9 @@ module "kubernetes_testnet" {
       external_port      = 10401,
       node_port          = null,
       external_ip        = null,
-      private_key_secret = null
+      private_key_secret = null,
+      enableArchive      = false,
+      archiveAddress     = ""
     }
   ]
 
@@ -55,6 +57,8 @@ module "kubernetes_testnet" {
       run_with_user_agent    = false
       run_with_bots          = false
       enable_peer_exchange   = true
+      enableArchive          = false
+      archiveAddress         = ""
     }
   ]
 }


### PR DESCRIPTION
Fixes an integration test error related to the missing variables ([example](https://buildkite.com/o-1-labs-2/mina/builds/12859#57b441b2-5ed1-4462-97bb-f8c65b4d44bd)).

**Test:** Buildkite CI

**Checklist:**

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
