### PR TITLE
Add Pickles_types.Higher_kinded_poly

### DIFF
--- a/src/lib/pickles/inductive_rule.ml
+++ b/src/lib/pickles/inductive_rule.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Pickles_types.Poly_types
 open Pickles_types.Hlist
 
 module B = struct

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -12,8 +12,8 @@ open Core_kernel
 open Import
 open Types
 open Pickles_types
+open Poly_types
 open Hlist
-open Pickles_types
 open Common
 open Backend
 module Backend = Backend

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -2,6 +2,7 @@ module SC = Scalar_challenge
 open Core
 module P = Proof
 open Pickles_types
+open Poly_types
 open Hlist
 open Backend
 open Tuple_lib

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -2,6 +2,7 @@ module S = Sponge
 open Core
 open Pickles_types
 open Common
+open Poly_types
 open Hlist
 open Import
 open Impls.Step

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -1,6 +1,7 @@
 open Core_kernel
 open Pickles_types
 open Import
+open Poly_types
 open Hlist
 
 (* Compute the domains corresponding to wrap_main *)

--- a/src/lib/pickles_types/higher_kinded_poly.ml
+++ b/src/lib/pickles_types/higher_kinded_poly.ml
@@ -1,0 +1,352 @@
+(* Caution: We do some low-level type manipulation to extract the value here.
+   This is safe because:
+   * the input types [_ t] are parameterized over [t1, ..., tn] which are
+     distinct opaque types which cannot unify
+   * the polymorphic types are parameterized over [(t1, ..., tn) t], which can
+     only unify when the underlying parameterised type is the same
+   * the underlying representation of OCaml values is homogeneous, which is
+     what allows for polymorphism in the wider language.
+
+   This can be used to approximate 'modular explicits' using packed modules
+   instead of substitutive module application, but it is generally more
+   powerful because it makes parameterised types first class outside of arrows
+   too (e.g. in heterogeneous lists).
+*)
+
+open Core_kernel
+open Poly_types
+
+(* Opaque types. *)
+module O = struct
+  type t1
+
+  type t2
+
+  type t3
+
+  type t4
+
+  type t5
+end
+
+module P1 = struct
+  type (_, _) t
+
+  module W (M : T1) = struct
+    type t = O.t1 M.t
+  end
+
+  module type S = sig
+    type _ p
+
+    type witness
+
+    val eq : (O.t1 p, witness) Type_equal.t
+
+    type 'a1 poly = ('a1, witness) t
+
+    val mk_eq : unit -> ('a1 poly, 'a1 p) Type_equal.t
+
+    val to_poly : 'a1 p -> 'a1 poly
+
+    val of_poly : 'a1 poly -> 'a1 p
+  end
+
+  module T (M : T1) : S with type 'a p = 'a M.t and type witness = W(M).t =
+  struct
+    type 'a p = 'a M.t
+
+    type witness = W(M).t
+
+    let eq = Type_equal.T
+
+    type 'a1 poly = ('a1, witness) t
+
+    (* Here be dragons *)
+
+    let mk_eq () = Obj.magic Type_equal.T
+
+    let to_poly = Obj.magic
+
+    let of_poly = Obj.magic
+  end
+end
+
+module P2 = struct
+  type (_, _, _) t
+
+  module W (M : T2) = struct
+    type t = (O.t1, O.t2) M.t
+  end
+
+  module type S = sig
+    type (_, _) p
+
+    type witness
+
+    val eq : ((O.t1, O.t2) p, witness) Type_equal.t
+
+    type ('a1, 'a2) poly = ('a1, 'a2, witness) t
+
+    val mk_eq : unit -> (('a1, 'a2) poly, ('a1, 'a2) p) Type_equal.t
+
+    val to_poly : ('a1, 'a2) p -> ('a1, 'a2) poly
+
+    val of_poly : ('a1, 'a2) poly -> ('a1, 'a2) p
+  end
+
+  module T (M : T2) :
+    S with type ('a1, 'a2) p = ('a1, 'a2) M.t and type witness = W(M).t =
+  struct
+    type ('a1, 'a2) p = ('a1, 'a2) M.t
+
+    type witness = W(M).t
+
+    let eq = Type_equal.T
+
+    type ('a1, 'a2) poly = ('a1, 'a2, witness) t
+
+    (* Here be dragons *)
+
+    let mk_eq () = Obj.magic Type_equal.T
+
+    let to_poly = Obj.magic
+
+    let of_poly = Obj.magic
+  end
+end
+
+module P3 = struct
+  type (_, _, _, _) t
+
+  module W (M : T3) = struct
+    type t = (O.t1, O.t2, O.t3) M.t
+  end
+
+  module type S = sig
+    type (_, _, _) p
+
+    type witness
+
+    val eq : ((O.t1, O.t2, O.t3) p, witness) Type_equal.t
+
+    type ('a1, 'a2, 'a3) poly = ('a1, 'a2, 'a3, witness) t
+
+    val mk_eq : unit -> (('a1, 'a2, 'a3) poly, ('a1, 'a2, 'a3) p) Type_equal.t
+
+    val to_poly : ('a1, 'a2, 'a3) p -> ('a1, 'a2, 'a3) poly
+
+    val of_poly : ('a1, 'a2, 'a3) poly -> ('a1, 'a2, 'a3) p
+  end
+
+  module T (M : T3) :
+    S
+    with type ('a1, 'a2, 'a3) p = ('a1, 'a2, 'a3) M.t
+     and type witness = W(M).t = struct
+    type ('a1, 'a2, 'a3) p = ('a1, 'a2, 'a3) M.t
+
+    type witness = W(M).t
+
+    let eq = Type_equal.T
+
+    type ('a1, 'a2, 'a3) poly = ('a1, 'a2, 'a3, witness) t
+
+    (* Here be dragons *)
+
+    let mk_eq () = Obj.magic Type_equal.T
+
+    let to_poly = Obj.magic
+
+    let of_poly = Obj.magic
+  end
+end
+
+module P4 = struct
+  type (_, _, _, _, _) t
+
+  module W (M : T4) = struct
+    type t = (O.t1, O.t2, O.t3, O.t4) M.t
+  end
+
+  module type S = sig
+    type (_, _, _, _) p
+
+    type witness
+
+    val eq : ((O.t1, O.t2, O.t3, O.t4) p, witness) Type_equal.t
+
+    type ('a1, 'a2, 'a3, 'a4) poly = ('a1, 'a2, 'a3, 'a4, witness) t
+
+    val mk_eq :
+      unit -> (('a1, 'a2, 'a3, 'a4) poly, ('a1, 'a2, 'a3, 'a4) p) Type_equal.t
+
+    val to_poly : ('a1, 'a2, 'a3, 'a4) p -> ('a1, 'a2, 'a3, 'a4) poly
+
+    val of_poly : ('a1, 'a2, 'a3, 'a4) poly -> ('a1, 'a2, 'a3, 'a4) p
+  end
+
+  module T (M : T4) :
+    S
+    with type ('a1, 'a2, 'a3, 'a4) p = ('a1, 'a2, 'a3, 'a4) M.t
+     and type witness = W(M).t = struct
+    type ('a1, 'a2, 'a3, 'a4) p = ('a1, 'a2, 'a3, 'a4) M.t
+
+    type witness = W(M).t
+
+    let eq = Type_equal.T
+
+    type ('a1, 'a2, 'a3, 'a4) poly = ('a1, 'a2, 'a3, 'a4, witness) t
+
+    (* Here be dragons *)
+
+    let mk_eq () = Obj.magic Type_equal.T
+
+    let to_poly = Obj.magic
+
+    let of_poly = Obj.magic
+  end
+end
+
+module P5 = struct
+  type (_, _, _, _, _, _) t
+
+  module W (M : T5) = struct
+    type t = (O.t1, O.t2, O.t3, O.t4, O.t5) M.t
+  end
+
+  module type S = sig
+    type (_, _, _, _, _) p
+
+    type witness
+
+    val eq : ((O.t1, O.t2, O.t3, O.t4, O.t5) p, witness) Type_equal.t
+
+    type ('a1, 'a2, 'a3, 'a4, 'a5) poly = ('a1, 'a2, 'a3, 'a4, 'a5, witness) t
+
+    val mk_eq :
+         unit
+      -> ( ('a1, 'a2, 'a3, 'a4, 'a5) poly
+         , ('a1, 'a2, 'a3, 'a4, 'a5) p )
+         Type_equal.t
+
+    val to_poly : ('a1, 'a2, 'a3, 'a4, 'a5) p -> ('a1, 'a2, 'a3, 'a4, 'a5) poly
+
+    val of_poly : ('a1, 'a2, 'a3, 'a4, 'a5) poly -> ('a1, 'a2, 'a3, 'a4, 'a5) p
+  end
+
+  module T (M : T5) :
+    S
+    with type ('a1, 'a2, 'a3, 'a4, 'a5) p = ('a1, 'a2, 'a3, 'a4, 'a5) M.t
+     and type witness = W(M).t = struct
+    type ('a1, 'a2, 'a3, 'a4, 'a5) p = ('a1, 'a2, 'a3, 'a4, 'a5) M.t
+
+    type witness = W(M).t
+
+    let eq = Type_equal.T
+
+    type ('a1, 'a2, 'a3, 'a4, 'a5) poly = ('a1, 'a2, 'a3, 'a4, 'a5, witness) t
+
+    (* Here be dragons *)
+
+    let mk_eq () = Obj.magic Type_equal.T
+
+    let to_poly = Obj.magic
+
+    let of_poly = Obj.magic
+  end
+end
+
+let%test_module "Higher_kinded_poly" =
+  ( module struct
+    module Int_1 = struct
+      type _ t = int
+    end
+
+    module Poly_int_1 = P1.T (Int_1)
+
+    module Int_2 = struct
+      type (_, _) t = int
+    end
+
+    module Poly_int_2 = P2.T (Int_2)
+
+    module Int_3 = struct
+      type (_, _, _) t = int
+    end
+
+    module Poly_int_3 = P3.T (Int_3)
+
+    module Int_4 = struct
+      type (_, _, _, _) t = int
+    end
+
+    module Poly_int_4 = P4.T (Int_4)
+
+    module Int_5 = struct
+      type (_, _, _, _, _) t = int
+    end
+
+    module Poly_int_5 = P5.T (Int_5)
+
+    let ints = [1; 2; 3; 4; 5]
+
+    let poly_ints_1 = List.map ~f:Poly_int_1.to_poly ints
+
+    let poly_ints_2 = List.map ~f:Poly_int_2.to_poly ints
+
+    let poly_ints_3 = List.map ~f:Poly_int_3.to_poly ints
+
+    let poly_ints_4 = List.map ~f:Poly_int_4.to_poly ints
+
+    let poly_ints_5 = List.map ~f:Poly_int_5.to_poly ints
+
+    let%test "P1 round-trips" =
+      ints = List.map ~f:Poly_int_1.of_poly poly_ints_1
+
+    let%test "P2 round-trips" =
+      ints = List.map ~f:Poly_int_2.of_poly poly_ints_2
+
+    let%test "P3 round-trips" =
+      ints = List.map ~f:Poly_int_3.of_poly poly_ints_3
+
+    let%test "P4 round-trips" =
+      ints = List.map ~f:Poly_int_4.of_poly poly_ints_4
+
+    let%test "P5 round-trips" =
+      ints = List.map ~f:Poly_int_5.of_poly poly_ints_5
+
+    module Poly_option = P1.T (Option)
+
+    let options = [Some 1; None; None; Some 4; Some 5]
+
+    let poly_options = List.map ~f:Poly_option.to_poly options
+
+    let%test "P1.T(Option) round-trips" =
+      options = List.map ~f:Poly_option.of_poly poly_options
+
+    module Ignore_1 = struct
+      type ('a, _) t = 'a * unit
+    end
+
+    module Poly_ignore_1 = P2.T (Ignore_1)
+
+    module Ignore_2 = struct
+      type ('a, _) t = 'a * unit
+    end
+
+    module Poly_ignore_2 = P2.T (Ignore_2)
+
+    let num_unit_tuples = [(1, ()); (2, ()); (3, ()); (4, ())]
+
+    let ignore_1s : (int, _, _) P2.t list =
+      List.map ~f:Poly_ignore_1.to_poly num_unit_tuples
+
+    let ignore_2s : (int, _, _) P2.t list =
+      List.map ~f:Poly_ignore_2.to_poly num_unit_tuples
+
+    let ignore_1s_and_2s = ignore_1s @ ignore_2s
+
+    let%test "Mixing of distinct unifiable types" =
+      num_unit_tuples @ num_unit_tuples
+      = List.map ~f:Poly_ignore_1.of_poly ignore_1s_and_2s
+  end )

--- a/src/lib/pickles_types/higher_kinded_poly.ml
+++ b/src/lib/pickles_types/higher_kinded_poly.ml
@@ -30,6 +30,9 @@ module O = struct
 end
 
 module P1 = struct
+  (** This type is the application of a type [_ x] to the variable ['a],
+      represented as [('a, O.t1 x) t].
+  *)
   type (_, _) t
 
   module W (M : T1) = struct
@@ -73,6 +76,9 @@ module P1 = struct
 end
 
 module P2 = struct
+  (** This type is the application of a type [(_, _) x] to the variables ['a1],
+      ['a2], represented as [('a1, 'a2, (O.t1, O.t2) x) t].
+  *)
   type (_, _, _) t
 
   module W (M : T2) = struct
@@ -117,6 +123,10 @@ module P2 = struct
 end
 
 module P3 = struct
+  (** This type is the application of a type [(_, _, _) x] to the variables
+      ['a1], ['a2], ['a3], represented as
+      [('a1, 'a2, 'a3, (O.t1, O.t2, O.t3) x) t].
+  *)
   type (_, _, _, _) t
 
   module W (M : T3) = struct
@@ -162,6 +172,10 @@ module P3 = struct
 end
 
 module P4 = struct
+  (** This type is the application of a type [(_, _, _, _) x] to the variables
+      ['a1], ['a2], ['a3], ['a4] represented as
+      [('a1, 'a2, 'a3, 'a4, (O.t1, O.t2, O.t3, O.t4) x) t].
+  *)
   type (_, _, _, _, _) t
 
   module W (M : T4) = struct
@@ -208,6 +222,10 @@ module P4 = struct
 end
 
 module P5 = struct
+  (** This type is the application of a type [(_, _, _, _, _) x] to the
+      variables ['a1], ['a2], ['a3], ['a4], ['a5] represented as
+      [('a1, 'a2, 'a3, 'a4, 'a5, (O.t1, O.t2, O.t3, O.t4, O.t5) x) t].
+  *)
   type (_, _, _, _, _, _) t
 
   module W (M : T5) = struct

--- a/src/lib/pickles_types/hlist.ml
+++ b/src/lib/pickles_types/hlist.ml
@@ -1,24 +1,5 @@
 open Core_kernel
-
-module type T0 = sig
-  type t
-end
-
-module type T1 = sig
-  type _ t
-end
-
-module type T2 = sig
-  type (_, _) t
-end
-
-module type T3 = sig
-  type (_, _, _) t
-end
-
-module type T4 = sig
-  type (_, _, _, _) t
-end
+open Poly_types
 
 module E13 (T : T1) = struct
   type ('a, _, _) t = 'a T.t

--- a/src/lib/pickles_types/poly_types.ml
+++ b/src/lib/pickles_types/poly_types.ml
@@ -1,0 +1,23 @@
+module type T0 = sig
+  type t
+end
+
+module type T1 = sig
+  type _ t
+end
+
+module type T2 = sig
+  type (_, _) t
+end
+
+module type T3 = sig
+  type (_, _, _) t
+end
+
+module type T4 = sig
+  type (_, _, _, _) t
+end
+
+module type T5 = sig
+  type (_, _, _, _, _) t
+end


### PR DESCRIPTION
This PR adds the `Pickles_types.Higher_kinded_poly` utility library.

This is a type-level hack that allows manipulating higher-kinded polymorphic types using type variables.

For example, we can constrain packed modules to have a particular higher-kinded type even though we cannot do so in the surface-level type system:
```ocaml
module My_type = struct
  type 'a t
end
module type S = sig
  type 'a t
  module Poly_witness : P1.S with type 'a p = 'a t
end
let f (module M : S with type Poly_witness.witness = P1.W(My_type).t) = ...
let g (type t_poly) (module M : S with type Poly_witness.witness = t_poly) (module N : S with type Poly_witness.witness = t_poly) = ...
```

This also plays nicely with `Hlist`. For our purposes, we can use this to carry proofs from multiple proof systems in the same `Hlist`:
```ocaml
let my_list_of_lists_of_proofs : ('varss, 'valuess, 'num_parentsss, 'num_rulesss, 'proof_systems) H4_1.T(P4) =
  [ [PS1.to_poly proof1; PS1.to_poly proof2; PS1.to_poly proof3]
  ; [PS2.to_poly proof4; PS2.to_poly proof5] ]
(* Actual type is *)
val my_list_of_lists_of_proofs :
   ( ('var1 * ('var2 * ('var3 * unit))) * (('var4 * ('var5 * unit)) * unit)
   , ('value1 * ('value2 * ('value3 * unit))) * (('value4 * ('value5 * unit)) * unit)
   , ('num_parents1 * ('num_parents2 * ('num_parents3 * unit))) * (('num_parents4 * ('num_parents5 * unit) * unit)
   , ('num_rules1 * ('num_rules2 * ('num_rules3 * unit))) * (('num_rules4 * ('num_rules5 * unit) * unit)
   , P4.W(PS1.T).t * (P4.W(PS2.t * unit) )
   H4_1.T(P4)
```
and then the prover can operate over a defined set of proof systems `(P4.W(PS1.T).t * ((P4.W(PS2.T).t * unit)) H1(Proof_system).t` that it accepts as a parameter.

-------

As a (hopefully) compelling argument for the safety of this, my first version of this used a (nearly) equivalent formulation:
```ocaml
module P1 : sig (* snip *) end = struct
  type (_, _) t = ..
  module T (M : T1) : sig (* snip *) end = struct
    type (_, _) t += T : 'a M.t -> ('a, O.t1 M.t) t
    let to_poly x = T x
    (* Equivalent to [match x with T x -> x], except we don't check the tag of the constructor,
       so multiple functor calls that result in different functors will still alias if the type
       is the same.
    *)
    let of_poly x = Obj.(obj (field (repr x) 1))
  end
end
```
This is necessarily safe, as the only low-level manipulation is to bypass the tag equality check from the match, and the field access otherwise matches what match would do. This current version is nearly functionally equivalent, except avoiding the wrapping constructor lets us write more-concise, more efficient code by coercing directly and avoiding the wrapping allocations.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
