### PR TITLE
Archive node metrics

### DIFF
--- a/src/app/archive/archive.ml
+++ b/src/app/archive/archive.ml
@@ -10,7 +10,7 @@ let command_run =
      and log_level = Flag.Log.level
      and server_port = Flag.Port.Archive.server
      and metrics_server_port =
-       flag "--metrics-port" ~aliases:["metrics-port"]
+       flag "--metrics-port" ~aliases:["-metrics-port"]
          ~doc:
            "PORT metrics server for scraping via Prometheus (default no \
             metrics-server)"

--- a/src/app/archive/archive.ml
+++ b/src/app/archive/archive.ml
@@ -9,6 +9,12 @@ let command_run =
     (let%map_open log_json = Flag.Log.json
      and log_level = Flag.Log.level
      and server_port = Flag.Port.Archive.server
+     and metrics_server_port =
+       flag "--metrics-port" ~aliases:["metrics-port"]
+         ~doc:
+           "PORT metrics server for scraping via Prometheus (default no \
+            metrics-server)"
+         (optional Cli_lib.Arg_type.int16)
      and postgres = Flag.Uri.Archive.postgres
      and runtime_config_file =
        flag "--config-file" ~aliases:["-config-file"] (optional string)
@@ -28,7 +34,7 @@ let command_run =
      fun () ->
        let logger = Logger.create () in
        Stdout_log.setup log_json log_level ;
-       Archive_lib.Processor.setup_server ~logger
+       Archive_lib.Processor.setup_server ~metrics_server_port ~logger
          ~constraint_constants:Genesis_constants.Constraint_constants.compiled
          ~postgres_address:postgres.value
          ~server_port:

--- a/src/app/archive/archive_lib/metrics.ml
+++ b/src/app/archive/archive_lib/metrics.ml
@@ -1,0 +1,83 @@
+open Core_kernel
+open Async
+
+module Max_block_height = struct
+  let query =
+    Caqti_request.find Caqti_type.unit Caqti_type.int
+      "SELECT max(height) FROM blocks"
+
+  let update (module Conn : Caqti_async.CONNECTION) metric_server =
+    let open Deferred.Result.Let_syntax in
+    let%map max_height = Conn.find query () in
+    Mina_metrics.(
+      Gauge.set
+        (Archive.max_block_height metric_server)
+        (Float.of_int max_height))
+end
+
+module Missing_blocks = struct
+  (*A block is missing if there is no entry for a specific height. However, if there is an entry then it doesn't necessarily mean that it is part of the main chain. Unparented_blocks will show value > 1 in that case*)
+  let query =
+    Caqti_request.find Caqti_type.unit Caqti_type.int
+      (Core_kernel.sprintf
+         {sql| 
+        SELECT count(*) 
+        FROM (SELECT h::int from generate_series(1, (select max(height) from blocks)) h
+        LEFT JOIN blocks b 
+        ON h = b.height where b.height is null) as v
+      |sql})
+
+  let update (module Conn : Caqti_async.CONNECTION) metric_server =
+    let open Deferred.Result.Let_syntax in
+    let%map missing_blocks = Conn.find query () in
+    Mina_metrics.(
+      Gauge.set
+        (Archive.missing_blocks metric_server)
+        (Float.of_int missing_blocks))
+end
+
+module Unparented_blocks = struct
+  (* parent_hashes represent ends of chains leading to an orphan block *)
+
+  let query =
+    Caqti_request.find Caqti_type.unit Caqti_type.int
+      {sql|
+           SELECT count(*) FROM blocks
+           WHERE parent_id IS NULL
+      |sql}
+
+  let update (module Conn : Caqti_async.CONNECTION) metric_server =
+    let open Deferred.Result.Let_syntax in
+    let%map unparented_block_count = Conn.find query () in
+    Core.printf "updating unparented blocks %!\n" ;
+    Mina_metrics.(
+      Gauge.set
+        (Archive.unparented_blocks metric_server)
+        (Float.of_int unparented_block_count))
+end
+
+let log_error ~logger pool metric_server
+    (f :
+         (module Caqti_async.CONNECTION)
+      -> Mina_metrics.Archive.t
+      -> (unit, [> Caqti_error.call_or_retrieve]) Deferred.Result.t) =
+  let open Deferred.Let_syntax in
+  match%map
+    Caqti_async.Pool.use
+      (fun (module Conn : Caqti_async.CONNECTION) ->
+        f (module Conn) metric_server )
+      pool
+  with
+  | Ok () ->
+      ()
+  | Error e ->
+      [%log warn] "Error updating archive metrics: $error"
+        ~metadata:[("error", `String (Caqti_error.show e))]
+
+let update ~logger pool metric_server =
+  Deferred.all_unit
+    (List.map
+       ~f:(log_error ~logger pool metric_server)
+       [ Max_block_height.update
+       ; Unparented_blocks.update
+       ; Missing_blocks.update ])

--- a/src/app/archive/archive_lib/metrics.ml
+++ b/src/app/archive/archive_lib/metrics.ml
@@ -16,13 +16,13 @@ module Max_block_height = struct
 end
 
 module Missing_blocks = struct
-  (*A block is missing if there is no entry for a specific height. However, if there is an entry then it doesn't necessarily mean that it is part of the main chain. Unparented_blocks will show value > 1 in that case*)
+  (*A block is missing if there is no entry for a specific height. However, if there is an entry then it doesn't necessarily mean that it is part of the main chain. Unparented_blocks will show value > 1 in that case. Look for the last 2000 blocks*)
   let query =
     Caqti_request.find Caqti_type.unit Caqti_type.int
       (Core_kernel.sprintf
          {sql| 
         SELECT count(*) 
-        FROM (SELECT h::int from generate_series(1, (select max(height) from blocks)) h
+        FROM (SELECT h::int FROM generate_series(GREATEST(1, (select max(height) from blocks)-2000) , (select max(height) from blocks)) h
         LEFT JOIN blocks b 
         ON h = b.height where b.height is null) as v
       |sql})

--- a/src/app/archive/archive_lib/metrics.ml
+++ b/src/app/archive/archive_lib/metrics.ml
@@ -49,7 +49,6 @@ module Unparented_blocks = struct
   let update (module Conn : Caqti_async.CONNECTION) metric_server =
     let open Deferred.Result.Let_syntax in
     let%map unparented_block_count = Conn.find query () in
-    Core.printf "updating unparented blocks %!\n" ;
     Mina_metrics.(
       Gauge.set
         (Archive.unparented_blocks metric_server)

--- a/src/app/archive/archive_lib/metrics.ml
+++ b/src/app/archive/archive_lib/metrics.ml
@@ -21,7 +21,7 @@ module Missing_blocks = struct
     Caqti_request.find Caqti_type.unit Caqti_type.int
       (Core_kernel.sprintf
          {sql| 
-        SELECT count(*) 
+        SELECT count( * )
         FROM (SELECT h::int FROM generate_series(GREATEST(1, (select max(height) from blocks)-2000) , (select max(height) from blocks)) h
         LEFT JOIN blocks b 
         ON h = b.height where b.height is null) as v
@@ -42,7 +42,7 @@ module Unparented_blocks = struct
   let query =
     Caqti_request.find Caqti_type.unit Caqti_type.int
       {sql|
-           SELECT count(*) FROM blocks
+           SELECT count( * ) FROM blocks
            WHERE parent_id IS NULL
       |sql}
 

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -75,6 +75,13 @@ let rec deferred_result_list_fold ls ~init ~f =
       let%bind init = f init h in
       deferred_result_list_fold t ~init ~f
 
+let query ~f pool =
+  match%bind Caqti_async.Pool.use f pool with
+  | Ok v ->
+      return v
+  | Error msg ->
+      failwithf "Error querying db, error: %s" (Caqti_error.show msg) ()
+
 module Public_key = struct
   let find (module Conn : CONNECTION) (t : Public_key.Compressed.t) =
     let public_key = Public_key.Compressed.to_base58_check t in
@@ -1556,40 +1563,43 @@ let retry ~f ~logger ~error_str retries =
   go retries
 
 let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
-    (module Conn : CONNECTION) block =
+    pool block =
   let add () =
-    let%bind res =
-      let open Deferred.Result.Let_syntax in
-      let%bind () = Conn.start () in
-      let%bind block_id = add_block (module Conn : CONNECTION) block in
-      (* if an existing block has a parent hash that's for the block just added,
+    Caqti_async.Pool.use
+      (fun (module Conn : CONNECTION) ->
+        let%bind res =
+          let open Deferred.Result.Let_syntax in
+          let%bind () = Conn.start () in
+          let%bind block_id = add_block (module Conn : CONNECTION) block in
+          (* if an existing block has a parent hash that's for the block just added,
        set its parent id
       *)
-      let%bind () =
-        Block.set_parent_id_if_null
-          (module Conn)
-          ~parent_hash:(hash block) ~parent_id:block_id
-      in
-      match delete_older_than with
-      | Some num_blocks ->
-          Block.delete_if_older_than ~num_blocks (module Conn)
-      | None ->
-          return ()
-    in
-    match res with
-    | Error e as err ->
-        (*Error in the current transaction*)
-        [%log warn]
-          "Error when adding block data to the database, rolling it back: \
-           $error"
-          ~metadata:[("error", `String (Caqti_error.show e))] ;
-        let%map _ = Conn.rollback () in
-        err
-    | Ok _ ->
-        [%log info] "Committing block data for $state_hash"
-          ~metadata:
-            [("state_hash", Mina_base.State_hash.to_yojson (hash block))] ;
-        Conn.commit ()
+          let%bind () =
+            Block.set_parent_id_if_null
+              (module Conn)
+              ~parent_hash:(hash block) ~parent_id:block_id
+          in
+          match delete_older_than with
+          | Some num_blocks ->
+              Block.delete_if_older_than ~num_blocks (module Conn)
+          | None ->
+              return ()
+        in
+        match res with
+        | Error e as err ->
+            (*Error in the current transaction*)
+            [%log warn]
+              "Error when adding block data to the database, rolling it back: \
+               $error"
+              ~metadata:[("error", `String (Caqti_error.show e))] ;
+            let%map _ = Conn.rollback () in
+            err
+        | Ok _ ->
+            [%log info] "Committing block data for $state_hash"
+              ~metadata:
+                [("state_hash", Mina_base.State_hash.to_yojson (hash block))] ;
+            Conn.commit () )
+      pool
   in
   retry ~f:add ~logger ~error_str:"add_block_aux" retries
 
@@ -1603,16 +1613,13 @@ let add_block_aux_extensional =
   add_block_aux ~add_block:Block.add_from_extensional
     ~hash:(fun (block : Extensional.Block.t) -> block.state_hash)
 
-let run (module Conn : CONNECTION) reader ~constraint_constants ~logger
-    ~delete_older_than =
+let run pool reader ~constraint_constants ~logger ~delete_older_than =
   Strict_pipe.Reader.iter reader ~f:(function
     | Diff.Transition_frontier (Breadcrumb_added {block; _}) -> (
         let add_block = Block.add_if_doesn't_exist ~constraint_constants in
         let hash block = With_hash.hash block in
         match%map
-          add_block_aux ~logger ~delete_older_than ~hash ~add_block
-            (module Conn)
-            block
+          add_block_aux ~logger ~delete_older_than ~hash ~add_block pool block
         with
         | Error e ->
             [%log warn]
@@ -1625,12 +1632,32 @@ let run (module Conn : CONNECTION) reader ~constraint_constants ~logger
     | Transition_frontier _ ->
         Deferred.return ()
     | Transaction_pool {added; removed= _} ->
-        Deferred.List.iter added ~f:(fun command ->
-            User_command.add_if_doesn't_exist (module Conn) command >>| ignore
-        ) )
+        let%map _ =
+          Caqti_async.Pool.use
+            (fun (module Conn : CONNECTION) ->
+              let%map () =
+                Deferred.List.iter added ~f:(fun command ->
+                    match%map
+                      User_command.add_if_doesn't_exist (module Conn) command
+                    with
+                    | Ok _ ->
+                        ()
+                    | Error e ->
+                        [%log warn]
+                          ~metadata:
+                            [ ("error", `String (Caqti_error.show e))
+                            ; ( "command"
+                              , Mina_base.User_command.to_yojson command ) ]
+                          "Failed to archive user command $command from \
+                           transaction pool: $block, see $error" )
+              in
+              Ok () )
+            pool
+        in
+        () )
 
-let add_genesis_accounts (module Conn : CONNECTION) ~logger
-    ~(runtime_config_opt : Runtime_config.t option) =
+let add_genesis_accounts ~logger
+    ~(runtime_config_opt : Runtime_config.t option) pool =
   match runtime_config_opt with
   | None ->
       Deferred.unit
@@ -1655,30 +1682,33 @@ let add_genesis_accounts (module Conn : CONNECTION) ~logger
             failwith "No accounts found in runtime config file"
       in
       let add_accounts () =
-        let open Deferred.Result.Let_syntax in
-        let%bind () = Conn.start () in
-        let rec go accounts =
-          let open Deferred.Let_syntax in
-          match accounts with
-          | [] ->
-              Deferred.Result.return ()
-          | (_, account) :: accounts' -> (
-              match%bind
-                Timing_info.add_if_doesn't_exist (module Conn) account
-              with
-              | Error e as err ->
-                  [%log error]
-                    ~metadata:
-                      [ ("account", Account.to_yojson account)
-                      ; ("error", `String (Caqti_error.show e)) ]
-                    "Failed to add genesis account: $account, see $error" ;
-                  let%map _ = Conn.rollback () in
-                  err
-              | Ok _ ->
-                  go accounts' )
-        in
-        let%bind () = go accounts in
-        Conn.commit ()
+        Caqti_async.Pool.use
+          (fun (module Conn : CONNECTION) ->
+            let open Deferred.Result.Let_syntax in
+            let%bind () = Conn.start () in
+            let rec go accounts =
+              let open Deferred.Let_syntax in
+              match accounts with
+              | [] ->
+                  Deferred.Result.return ()
+              | (_, account) :: accounts' -> (
+                  match%bind
+                    Timing_info.add_if_doesn't_exist (module Conn) account
+                  with
+                  | Error e as err ->
+                      [%log error]
+                        ~metadata:
+                          [ ("account", Account.to_yojson account)
+                          ; ("error", `String (Caqti_error.show e)) ]
+                        "Failed to add genesis account: $account, see $error" ;
+                      let%map _ = Conn.rollback () in
+                      err
+                  | Ok _ ->
+                      go accounts' )
+            in
+            let%bind () = go accounts in
+            Conn.commit () )
+          pool
       in
       match%map
         retry ~f:add_accounts ~logger ~error_str:"add_genesis_accounts" 3
@@ -1690,8 +1720,26 @@ let add_genesis_accounts (module Conn : CONNECTION) ~logger
       | Ok () ->
           () )
 
-let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
-    ~delete_older_than ~runtime_config_opt =
+let create_metrics_server ~logger ~metrics_server_port pool =
+  match metrics_server_port with
+  | None ->
+      return ()
+  | Some port ->
+      let%bind metric_server =
+        Mina_metrics.Archive.create_archive_server ~port ~logger
+      in
+      let interval =
+        Float.of_int (Mina_compile_config.block_window_duration_ms * 2)
+      in
+      let rec go () =
+        let%bind () = Metrics.update pool metric_server ~logger in
+        let%bind () = after (Time.Span.of_ms interval) in
+        go ()
+      in
+      go ()
+
+let setup_server ~metrics_server_port ~constraint_constants ~logger
+    ~postgres_address ~server_port ~delete_older_than ~runtime_config_opt =
   let where_to_listen =
     Async.Tcp.Where_to_listen.bind_to All_addresses (On_port server_port)
   in
@@ -1714,21 +1762,21 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
           Strict_pipe.Writer.write extensional_block_writer extensional_block
       ) ]
   in
-  match%bind Caqti_async.connect postgres_address with
+  match Caqti_async.connect_pool ~max_size:30 postgres_address with
   | Error e ->
       [%log error]
-        "Failed to connect to postgresql database, see error: $error"
+        "Failed to create a Caqti pool for Postgresql, see error: $error"
         ~metadata:[("error", `String (Caqti_error.show e))] ;
       Deferred.unit
-  | Ok conn ->
-      let%bind () = add_genesis_accounts conn ~logger ~runtime_config_opt in
-      run ~constraint_constants conn reader ~logger ~delete_older_than
+  | Ok pool ->
+      let%bind () = add_genesis_accounts pool ~logger ~runtime_config_opt in
+      run ~constraint_constants pool reader ~logger ~delete_older_than
       |> don't_wait_for ;
       Strict_pipe.Reader.iter precomputed_block_reader
         ~f:(fun precomputed_block ->
           match%map
             add_block_aux_precomputed ~logger ~constraint_constants
-              ~delete_older_than conn precomputed_block
+              ~delete_older_than pool precomputed_block
           with
           | Error e ->
               [%log warn]
@@ -1744,7 +1792,7 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
       Strict_pipe.Reader.iter extensional_block_reader
         ~f:(fun extensional_block ->
           match%map
-            add_block_aux_extensional ~logger ~delete_older_than conn
+            add_block_aux_extensional ~logger ~delete_older_than pool
               extensional_block
           with
           | Error e ->
@@ -1788,6 +1836,8 @@ let setup_server ~constraint_constants ~logger ~postgres_address ~server_port
                            , `String (Unix.Inet_addr.to_string address) ) ] ;
                      Deferred.unit )) )
       |> don't_wait_for ;
+      (*Update archive metrics*)
+      create_metrics_server ~logger ~metrics_server_port pool |> don't_wait_for ;
       [%log info] "Archive process ready. Clients can now connect" ;
       Async.never ()
 

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -15,16 +15,24 @@ let%test_module "Archive node unit tests" =
 
     module Genesis_ledger = (val Genesis_ledger.for_unit_tests)
 
+    let archive_uri =
+      Uri.of_string "postgres://admin:codarules@localhost:5432/archiver"
+
     let conn_lazy =
       lazy
         ( Thread_safe.block_on_async_exn
         @@ fun () ->
-        match%map
-          Caqti_async.connect
-            (Uri.of_string "postgres://admin:codarules@localhost:5432/archiver")
-        with
+        match%map Caqti_async.connect archive_uri with
         | Ok conn ->
             conn
+        | Error e ->
+            failwith @@ Caqti_error.show e )
+
+    let conn_pool_lazy =
+      lazy
+        ( match Caqti_async.connect_pool archive_uri with
+        | Ok pool ->
+            pool
         | Error e ->
             failwith @@ Caqti_error.show e )
 
@@ -126,7 +134,7 @@ let%test_module "Archive node unit tests" =
               failwith @@ Caqti_error.show e )
 
     let%test_unit "Block: read and write" =
-      let conn = Lazy.force conn_lazy in
+      let pool = Lazy.force conn_pool_lazy in
       Quickcheck.test ~trials:20
         ( Quickcheck.Generator.with_size ~size:10
         @@ Quickcheck_lib.gen_imperative_list
@@ -147,7 +155,7 @@ let%test_module "Archive node unit tests" =
           let processor_deferred_computation =
             Processor.run
               ~constraint_constants:precomputed_values.constraint_constants
-              conn reader ~logger ~delete_older_than:None
+              pool reader ~logger ~delete_older_than:None
           in
           let diffs =
             List.map
@@ -162,29 +170,32 @@ let%test_module "Archive node unit tests" =
           match%map
             Processor.deferred_result_list_fold breadcrumbs ~init:()
               ~f:(fun () breadcrumb ->
-                let open Deferred.Result.Let_syntax in
-                match%bind
-                  Processor.Block.find_opt conn
-                    ~state_hash:
-                      (Transition_frontier.Breadcrumb.state_hash breadcrumb)
-                with
-                | Some id ->
-                    let%bind Processor.Block.{parent_id; _} =
-                      Processor.Block.load conn ~id
-                    in
-                    if
-                      Transition_frontier.Breadcrumb.blockchain_length
-                        breadcrumb
-                      > Unsigned.UInt32.of_int 1
-                    then
-                      Processor.For_test.assert_parent_exist ~parent_id
-                        ~parent_hash:
-                          (Transition_frontier.Breadcrumb.parent_hash
-                             breadcrumb)
-                        conn
-                    else Deferred.Result.return ()
-                | None ->
-                    failwith "Failed to find saved block in database" )
+                Caqti_async.Pool.use
+                  (fun conn ->
+                    let open Deferred.Result.Let_syntax in
+                    match%bind
+                      Processor.Block.find_opt conn
+                        ~state_hash:
+                          (Transition_frontier.Breadcrumb.state_hash breadcrumb)
+                    with
+                    | Some id ->
+                        let%bind Processor.Block.{parent_id; _} =
+                          Processor.Block.load conn ~id
+                        in
+                        if
+                          Transition_frontier.Breadcrumb.blockchain_length
+                            breadcrumb
+                          > Unsigned.UInt32.of_int 1
+                        then
+                          Processor.For_test.assert_parent_exist ~parent_id
+                            ~parent_hash:
+                              (Transition_frontier.Breadcrumb.parent_hash
+                                 breadcrumb)
+                            conn
+                        else Deferred.Result.return ()
+                    | None ->
+                        failwith "Failed to find saved block in database" )
+                  pool )
           with
           | Ok () ->
               ()

--- a/src/app/cli/src/tests/coda_archive_processor_test.ml
+++ b/src/app/cli/src/tests/coda_archive_processor_test.ml
@@ -18,8 +18,8 @@ let main () =
         failwith @@ Caqti_error.show e
   in
   let logger = Logger.create () in
-  Archive_lib.Processor.setup_server ~logger ~constraint_constants
-    ~postgres_address
+  Archive_lib.Processor.setup_server ~metrics_server_port:None ~logger
+    ~constraint_constants ~postgres_address
     ~server_port:(Host_and_port.port archive_address)
     ~delete_older_than:None
     ~runtime_config_opt:

--- a/src/lib/mina_metrics/dune
+++ b/src/lib/mina_metrics/dune
@@ -4,4 +4,4 @@
  (libraries async cohttp cohttp-async logger jemalloc prometheus)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_coda ppx_version ppx_pipebang ppx_custom_printf ppx_optcomp)))
+ (preprocess (pps ppx_coda ppx_let ppx_version ppx_pipebang ppx_custom_printf ppx_optcomp)))

--- a/src/lib/mina_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/mina_metrics.ml
@@ -5,6 +5,7 @@ open Core_kernel
 open Prometheus
 open Namespace
 open Metric_generators
+open Async_kernel
 
 let time_offset_sec = 1609459200.
 
@@ -878,7 +879,7 @@ module Object_lifetime_statistics = struct
     Gauge_map.add lifetime_quartile_ms_table ~name ~help
 end
 
-let server ~port ~logger =
+let generic_server ~port ~logger ~registry =
   let open Cohttp in
   let open Cohttp_async in
   let handle_error _ exn =
@@ -890,7 +891,7 @@ let server ~port ~logger =
     let uri = Request.uri req in
     match (Request.meth req, Uri.path uri) with
     | `GET, "/metrics" ->
-        let data = CollectorRegistry.(collect default) in
+        let data = CollectorRegistry.(collect registry) in
         let body = Fmt.to_to_string TextFormat_0_0_4.output data in
         let headers =
           Header.init_with "Content-Type" "text/plain; version=0.0.4"
@@ -902,6 +903,51 @@ let server ~port ~logger =
   Server.create ~mode:`TCP ~on_handler_error:(`Call handle_error)
     (Async_extra.Tcp.Where_to_listen.of_port port)
     callback
+
+let server ~port ~logger =
+  generic_server ~port ~logger ~registry:CollectorRegistry.default
+
+module Archive = struct
+  type t =
+    {registry: CollectorRegistry.t; gauge_metrics: (string, Gauge.t) Hashtbl.t}
+
+  let subsystem = "Archive"
+
+  let find_or_add t ~name ~help ~subsystem =
+    match Hashtbl.find t.gauge_metrics name with
+    | None ->
+        let g =
+          Gauge.v name ~help ~namespace ~subsystem ~registry:t.registry
+        in
+        Hashtbl.add_exn t.gauge_metrics ~key:name ~data:g ;
+        g
+    | Some m ->
+        m
+
+  let unparented_blocks t : Gauge.t =
+    let help = "Number of blocks without a parent" in
+    let name = "unparented_blocks" in
+    find_or_add t ~name ~help ~subsystem
+
+  let max_block_height t : Gauge.t =
+    let help = "Max block height" in
+    let name = "max_block_height" in
+    find_or_add t ~name ~help ~subsystem
+
+  let missing_blocks t : Gauge.t =
+    let help =
+      "Number of missing blocks (A block is missing if there is no entry for \
+       a specific height less than the max height"
+    in
+    let name = "missing_blocks" in
+    find_or_add t ~name ~help ~subsystem
+
+  let create_archive_server ~port ~logger =
+    let open Async_kernel.Deferred.Let_syntax in
+    let archive_registry = CollectorRegistry.create () in
+    let%map _ = generic_server ~port ~logger ~registry:archive_registry in
+    {registry= archive_registry; gauge_metrics= Hashtbl.create (module String)}
+end
 
 (* re-export a constrained subset of prometheus to keep consumers of this module abstract over implementation *)
 include (

--- a/src/lib/mina_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/mina_metrics.ml
@@ -930,14 +930,15 @@ module Archive = struct
     find_or_add t ~name ~help ~subsystem
 
   let max_block_height t : Gauge.t =
-    let help = "Max block height" in
+    let help = "Max block height recorded in the archive database" in
     let name = "max_block_height" in
     find_or_add t ~name ~help ~subsystem
 
   let missing_blocks t : Gauge.t =
     let help =
-      "Number of missing blocks in the last 2000 blocks (A block is missing \
-       if there is no entry for a specific height less than the max height"
+      "Number of missing blocks in the last 2000 blocks (A block for a \
+       specific height is missing if there is no entry in the blocks table \
+       for that height)"
     in
     let name = "missing_blocks" in
     find_or_add t ~name ~help ~subsystem

--- a/src/lib/mina_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/mina_metrics.ml
@@ -936,8 +936,8 @@ module Archive = struct
 
   let missing_blocks t : Gauge.t =
     let help =
-      "Number of missing blocks (A block is missing if there is no entry for \
-       a specific height less than the max height"
+      "Number of missing blocks in the last 2000 blocks (A block is missing \
+       if there is no entry for a specific height less than the max height"
     in
     let name = "missing_blocks" in
     find_or_add t ~name ~help ~subsystem


### PR DESCRIPTION
Added a prometheus server for the archive process related metrics
Metrics included are:
1. `Coda_Archive_unparented_blocks` - number of blocks that don't reference parent block id. Either means the parent is missing or the foreign key reference needs to be added
2. `Coda_Archive_max_block_height`- Max block height that's in the database
3. `Coda_Archive_missing_blocks`- Any missing blocks between heights `max_height - 2000` and  `max_height`

The metrics get updated every `slot_duration_ms * 2`

Tested the changes locally
Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #7863
