### PR TITLE
Make rosetta construction/metadata return the correct default fee

### DIFF
--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -1,6 +1,9 @@
 open Core_kernel
 open Async
 open Rosetta_lib
+
+(* Rosetta_models.Currency shadows our Currency so we "save" it as MinaCurrency first *)
+module MinaCurrency = Currency
 open Rosetta_models
 module Signature = Mina_base.Signature
 module Transaction = Rosetta_lib.Transaction
@@ -290,8 +293,10 @@ module Metadata = struct
           Metadata_data.create ~sender:options.Options.sender
             ~token_id:options.Options.token_id ~nonce
           |> Metadata_data.to_yojson
-      ; suggested_fee= [Amount_of.coda (Unsigned.UInt64.of_int 1_000_000_000)]
-      }
+      ; suggested_fee=
+          [ Amount_of.coda
+              (MinaCurrency.Fee.to_uint64
+                 Mina_compile_config.default_transaction_fee) ] }
   end
 
   module Real = Impl (Deferred.Result)

--- a/src/app/rosetta/lib/dune
+++ b/src/app/rosetta/lib/dune
@@ -13,6 +13,7 @@
    cohttp-async
    core_kernel
    logger
+   mina_compile_config
    ppx_deriving_yojson.runtime
    rosetta_lib
    rosetta_models


### PR DESCRIPTION
    * Use compile-time constant rather than hardcoded

This PR fixes an issue with rosetta `construction/metadata` where it returns a hardcoded default transaction fee.

Instead of returning the hardcoded fee we now return the default fee from the compile-time config `Mina_compile_config.minimum_user_command_fee`

The test agent (`test-agent/agent.ml`) does not have any test cases using the default fee so required no updates.

**Testing:**

Prior to these changes `construction/metadata` returns a hardcoded fee of 1 Mina.  After the change it returns the value from the compile-time constant in one of the `.mlh` files.

Rosetta will now return the default fee depending on the build profile used.  For example, for the production build profile, the `default_transaction_fee` from `src/config/amount_defaults/realistic.mlh` will be returned.

This can be tested either with the test script `src/app/rosetta/test-curl/con_metadata.sh` or by using `mina_ledger_wallet send-payment` and seeing that the correct default fee is obtained.

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #8100
