### PR TITLE
fee transfer type in graphql blocks query

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -3571,6 +3571,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": "Fee_transfer|Fee_transfer_via_coinbase Snark worker fees deducted from the coinbase amount are of type 'Fee_transfer_via_coinbase', rest are deducted from transaction fees",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -100,8 +100,8 @@
         },
         {
           "kind": "SCALAR",
-          "name": "PrecomputedBlock",
-          "description": "Block encoded in precomputed block format",
+          "name": "ExtensionalBlock",
+          "description": "Block encoded in extensional block format",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -110,8 +110,8 @@
         },
         {
           "kind": "SCALAR",
-          "name": "ExtensionalBlock",
-          "description": "Block encoded in extensional block format",
+          "name": "PrecomputedBlock",
+          "description": "Block encoded in precomputed block format",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -721,7 +721,7 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description": "Short arbitrary message provided by the sender",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -833,7 +833,7 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description": "Short arbitrary message provided by the sender",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -968,7 +968,7 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description": "Short arbitrary message provided by the sender",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -1080,7 +1080,7 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description": "Short arbitrary message provided by the sender",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1215,7 +1215,7 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description": "Short arbitrary message provided by the sender",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -1295,7 +1295,7 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description": "Short arbitrary message provided by the sender",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1402,7 +1402,7 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description": "Short arbitrary message provided by the sender",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -1486,7 +1486,7 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description": "Short arbitrary message provided by the sender",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
@@ -1575,304 +1575,6 @@
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "SignatureInput",
-          "description": "A cryptographic signature -- you must provide either field+scalar or rawSignature",
-          "fields": [
-            {
-              "name": "rawSignature",
-              "description": "Raw encoded signature",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "scalar",
-              "description": "Scalar component of signature",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "field",
-              "description": "Field component of signature",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": [
-            {
-              "name": "rawSignature",
-              "description": "Raw encoded signature",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "scalar",
-              "description": "Scalar component of signature",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "field",
-              "description": "Field component of signature",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "SendPaymentInput",
-          "description": null,
-          "fields": [
-            {
-              "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "fee",
-              "description": "Fee amount in order to send payment",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "UInt64",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "amount",
-              "description": "Amount of coda to send to to receiver",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "UInt64",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "token",
-              "description": "Token to send",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "TokenId",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "to",
-              "description": "Public key of recipient of payment",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "PublicKey",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "from",
-              "description": "Public key of sender of payment",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "PublicKey",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": [
-            {
-              "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "fee",
-              "description": "Fee amount in order to send payment",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "UInt64",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "amount",
-              "description": "Amount of coda to send to to receiver",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "UInt64",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "token",
-              "description": "Token to send",
-              "type": {
-                "kind": "SCALAR",
-                "name": "TokenId",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "to",
-              "description": "Public key of recipient of payment",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "PublicKey",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "from",
-              "description": "Public key of sender of payment",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "PublicKey",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -3124,6 +2826,304 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "SignatureInput",
+          "description": "A cryptographic signature -- you must provide either field+scalar or rawSignature",
+          "fields": [
+            {
+              "name": "rawSignature",
+              "description": "Raw encoded signature",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "scalar",
+              "description": "Scalar component of signature",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "field",
+              "description": "Field component of signature",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "rawSignature",
+              "description": "Raw encoded signature",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "scalar",
+              "description": "Scalar component of signature",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "field",
+              "description": "Field component of signature",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SendPaymentInput",
+          "description": null,
+          "fields": [
+            {
+              "name": "nonce",
+              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt32",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "memo",
+              "description": "Short arbitrary message provided by the sender",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "validUntil",
+              "description": "The global slot number after which this transaction cannot be applied",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt32",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fee",
+              "description": "Fee amount in order to send payment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UInt64",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "amount",
+              "description": "Amount of coda to send to to receiver",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UInt64",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "token",
+              "description": "Token to send",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "TokenId",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "to",
+              "description": "Public key of recipient of payment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "PublicKey",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "from",
+              "description": "Public key of sender of payment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "PublicKey",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "nonce",
+              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt32",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "memo",
+              "description": "Short arbitrary message provided by the sender",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "validUntil",
+              "description": "The global slot number after which this transaction cannot be applied",
+              "type": {
+                "kind": "SCALAR",
+                "name": "UInt32",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fee",
+              "description": "Fee amount in order to send payment",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UInt64",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "amount",
+              "description": "Amount of coda to send to to receiver",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UInt64",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "token",
+              "description": "Token to send",
+              "type": {
+                "kind": "SCALAR",
+                "name": "TokenId",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "to",
+              "description": "Public key of recipient of payment",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "PublicKey",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "from",
+              "description": "Public key of sender of payment",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "PublicKey",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "GenesisConstants",
           "description": null,
@@ -3777,7 +3777,7 @@
             },
             {
               "name": "isDelegation",
-              "description": "If true, this represents a delegation of stake, otherwise it is a payment",
+              "description": "If true, this command represents a delegation of stake",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5338,7 +5338,7 @@
             },
             {
               "name": "memo",
-		"description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description": "Short arbitrary message provided by the sender",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6503,16 +6503,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "UInt64",
-          "description": "String representing a uint64 number in base 10",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "AnnotatedBalance",
           "description": "A total balance annotated with the amount that is currently unknown with the invariant unknown <= total, as well as the currently liquid and locked balances.",
@@ -6551,25 +6541,27 @@
             },
             {
               "name": "liquid",
-              "isDeprecated": true,
+              "description": "The amount of coda owned by the account which is currently available. Can be null if bootstrapping.",
               "args": [],
-              "deprecationReason": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "UInt64"
+                "name": "UInt64",
+                "ofType": null
               },
-              "description": "The amount of coda owned by the account which is currently available. Can be null if bootstrapping."
+              "isDeprecated": true,
+              "deprecationReason": null
             },
             {
               "name": "locked",
-              "isDeprecated": true,
+              "description": "The amount of coda owned by the account which is currently locked. Can be null if bootstrapping.",
               "args": [],
-              "deprecationReason": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "UInt64"
+                "name": "UInt64",
+                "ofType": null
               },
-              "description": "The amount of coda owned by the account which is currently locked. Can be null if bootstrapping."
+              "isDeprecated": true,
+              "deprecationReason": null
             },
             {
               "name": "blockHeight",
@@ -6602,6 +6594,16 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "UInt64",
+          "description": "String representing a uint64 number in base 10",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -7180,7 +7182,7 @@
           "fields": [
             {
               "name": "consensusTime",
-              "description": null,
+              "description": "Time in terms of slot number in an epoch, start and end time of the slot since UTC epoch",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7864,6 +7866,22 @@
               "deprecationReason": null
             },
             {
+              "name": "highestUnvalidatedBlockLengthReceived",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "uptimeSecs",
               "description": null,
               "args": [],
@@ -8501,7 +8519,7 @@
             },
             {
               "name": "bestChain",
-              "description": "Retrieve a list of blocks from transition frontier's root to the current best tip. Returns null if the system is bootstrapping.",
+              "description": "Retrieve a list of blocks from transition frontier's root to the current best tip. Returns an error if the system is bootstrapping.",
               "args": [
                 {
                   "name": "maxLength",
@@ -8532,27 +8550,37 @@
             },
             {
               "name": "block",
-              "description": "Retrieve a block with the given state hash, if contained in the transition frontier.",
+              "description": "Retrieve a block with the given state hash or height, if contained in the transition frontier.",
               "args": [
+                {
+                  "name": "height",
+                  "description": "The height of the desired block",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "stateHash",
                   "description": "The state hash of the desired block",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "Block",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Block",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -390,12 +390,26 @@ module Types = struct
             ~args:Arg.[]
             ~doc:"Public key of fee transfer recipient"
             ~typ:(non_null public_key)
-            ~resolve:(fun _ {Fee_transfer.receiver_pk= pk; _} -> pk)
+            ~resolve:(fun _ ({Fee_transfer.receiver_pk= pk; _}, _) -> pk)
         ; field "fee" ~typ:(non_null uint64)
             ~args:Arg.[]
             ~doc:"Amount that the recipient is paid in this fee transfer"
-            ~resolve:(fun _ {Fee_transfer.fee; _} -> Currency.Fee.to_uint64 fee)
-        ] )
+            ~resolve:(fun _ ({Fee_transfer.fee; _}, _) ->
+              Currency.Fee.to_uint64 fee )
+        ; field "type" ~typ:(non_null string)
+            ~args:Arg.[]
+            ~doc:
+              "Fee_transfer|Fee_transfer_via_coinbase Snark worker fees \
+               deducted from the coinbase amount are of type \
+               'Fee_transfer_via_coinbase', rest are deducted from \
+               transaction fees"
+            ~resolve:(fun _ (_, transfer_type) ->
+              match transfer_type with
+              | Filtered_external_transition.Fee_transfer_type
+                .Fee_transfer_via_coinbase ->
+                  "Fee_transfer_via_coinbase"
+              | Fee_transfer ->
+                  "Fee_transfer" ) ] )
 
   let account_timing : (Mina_lib.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->


### PR DESCRIPTION
Added a new string field `type` to the fee transfer in graphql for queries that return blocks. The value of this field is `Fee_transfer` or `Fee_transfer_via_coinbase`.
`Fee_transfer_via_coinbase` is the fee transfer in a coinbase transaction. This corresponds to the snark worker fee deducted from the coinbase amount. 
All other snark worker fees are deducted from transaction fees. These (and the fee transfer paying the remainder transaction fee to the block producer) have the type `Fee_Transfer`

Updated graphql schema using `make update-graphql` (a bunch of other chnages got added so i'm assuming it was out-of-date)

Ran a node and tested the graphql output of the `best_chain` query

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #8072 
