### PR TITLE
[hotfix] fee transfer type in graphql blocks query

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -3571,6 +3571,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": "Fee_transfer|Fee_transfer_via_coinbase Snark worker fees deducted from the coinbase amount are of type 'Fee_transfer_via_coinbase', rest are deducted from transaction fees",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -390,12 +390,26 @@ module Types = struct
             ~args:Arg.[]
             ~doc:"Public key of fee transfer recipient"
             ~typ:(non_null public_key)
-            ~resolve:(fun _ {Fee_transfer.receiver_pk= pk; _} -> pk)
+            ~resolve:(fun _ ({Fee_transfer.receiver_pk= pk; _}, _) -> pk)
         ; field "fee" ~typ:(non_null uint64)
             ~args:Arg.[]
             ~doc:"Amount that the recipient is paid in this fee transfer"
-            ~resolve:(fun _ {Fee_transfer.fee; _} -> Currency.Fee.to_uint64 fee)
-        ] )
+            ~resolve:(fun _ ({Fee_transfer.fee; _}, _) ->
+              Currency.Fee.to_uint64 fee )
+        ; field "type" ~typ:(non_null string)
+            ~args:Arg.[]
+            ~doc:
+              "Fee_transfer|Fee_transfer_via_coinbase Snark worker fees \
+               deducted from the coinbase amount are of type \
+               'Fee_transfer_via_coinbase', rest are deducted from \
+               transaction fees"
+            ~resolve:(fun _ (_, transfer_type) ->
+              match transfer_type with
+              | Filtered_external_transition.Fee_transfer_type
+                .Fee_transfer_via_coinbase ->
+                  "Fee_transfer_via_coinbase"
+              | Fee_transfer ->
+                  "Fee_transfer" ) ] )
 
   let account_timing : (Mina_lib.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->


### PR DESCRIPTION
Added a new string field `type` to the fee transfer in graphql for queries that return blocks. The value of this field is `Fee_transfer` or `Fee_transfer_via_coinbase`.
`Fee_transfer_via_coinbase` is the fee transfer in a coinbase transaction. This corresponds to the snark worker fee deducted from the coinbase amount. 
All other snark worker fees are deducted from transaction fees. These (and the fee transfer paying the remainder transaction fee to the block producer) have the type `Fee_Transfer`

Ran a node and tested the graphql output of the `best_chain` query

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #8072 
