### PR TITLE
Add Archive Postgres block metric alerts

### DIFF
--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml.tpl
@@ -150,6 +150,24 @@ groups:
       summary: "{{ $labels.testnet }}: no new transactions seen for 2 slots."
       description: "No node has received transactions in their transaction pool in the last 2 slots (6 minutes) on network {{ $labels.testnet }}."
 
+  - alert: HighUnparentedBlockCount
+    expr: max by (testnet) (max_over_time(Coda_Archive_unparented_blocks ${rule_filter} [${alerting_timeframe}])) > 30
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} has a critically high unparented block count"
+      description: "{{ $value }} Unparented block count is critically high on network {{ $labels.testnet }}."
+
+  - alert: HighMissingBlockCount
+    expr: max by (testnet) (max_over_time(Coda_Archive_missing_blocks ${rule_filter} [${alerting_timeframe}])) > 30
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: critical
+    annotations:
+      summary: "{{ $labels.testnet }} has a critically high missing block count"
+      description: "{{ $value }} Missing block count is critically high on network {{ $labels.testnet }}."
+
 - name: Warnings
   rules:
   - alert: HighBlockGossipLatency
@@ -205,3 +223,30 @@ groups:
     annotations:
       summary: "{{ $labels.testnet }} block production is critically low (there has been less than 1 block in the last hour)"
       description: "Zero blocks have been produced on network {{ $labels.testnet }} in the last hour (according to some node)."
+
+  - alert: LowPostgresBlockHeightGrowth
+    expr: min by (testnet) (increase(Coda_Archive_max_block_height ${rule_filter} [${alerting_timeframe}])) < 1
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: warning
+    annotations:
+      summary: "{{ $labels.testnet }} rate of archival of network blocks in Postgres DB is lower than expected"
+      description: "The rate of {{ $value }} new blocks observed by archive postgres instances is low on network {{ $labels.testnet }}."
+
+  - alert: UnparentedBlocksObserved
+    expr: max by (testnet) (max_over_time(Coda_Archive_unparented_blocks ${rule_filter} [${alerting_timeframe}])) > 1
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: warning
+    annotations:
+      summary: "Unparented blocks observed on {{ $labels.testnet }}"
+      description: "{{ $value }} Unparented block(s) observed on network {{ $labels.testnet }}."
+
+  - alert: MissingBlocksObserved
+    expr: max by (testnet) (max_over_time(Coda_Archive_missing_blocks ${rule_filter} [${alerting_timeframe}])) > 0
+    labels:
+      testnet: "{{ $labels.testnet }}"
+      severity: warning
+    annotations:
+      summary: "Missing blocks observed on {{ $labels.testnet }}"
+      description: "{{ $value }} Missing block(s) observed on network {{ $labels.testnet }}."


### PR DESCRIPTION
Add testnet alerts for tracking the following archive/postgres block stats:

* Coda_Archive_unparented_blocks
* Coda_Archive_max_block_height
* Coda_Archive_missing_blocks

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #8063