### PR TITLE
[HOTFIX] Change some Coda to Mina for logs, UX

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1915,7 +1915,7 @@ let archive_blocks =
                  Graphql_client.query (graphql_make ~block ()) graphql_endpoint
                  |> Deferred.Result.map_error ~f:(function
                       | `Failed_request e ->
-                          Error.create "Unable to connect to Coda daemon" ()
+                          Error.create "Unable to connect to Mina daemon" ()
                             (fun () ->
                               Sexp.List
                                 [ List

--- a/src/app/cli/src/init/graphql_client.ml
+++ b/src/app/cli/src/init/graphql_client.ml
@@ -20,7 +20,7 @@ let run_exn ~f query_obj (uri : Uri.t Cli_lib.Flag.Types.with_name) =
       Deferred.return r
   | Error (`Failed_request e) ->
       eprintf
-        "Error: Unable to connect to Coda daemon.\n\
+        "Error: Unable to connect to Mina daemon.\n\
          - The daemon might not be running. See logs%s for details.\n\
         \  Run `mina daemon -help` to see how to start daemon.\n\
          - If you just started the daemon, wait a minute for the GraphQL \

--- a/src/app/cli/src/mina.ml
+++ b/src/app/cli/src/mina.ml
@@ -1104,7 +1104,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
     return coda
 
 let daemon logger =
-  Command.async ~summary:"Coda daemon"
+  Command.async ~summary:"Mina daemon"
     (Command.Param.map (setup_daemon logger) ~f:(fun setup_daemon () ->
          (* Immediately disable updating the time offset. *)
          Block_time.Controller.disable_setting_offset () ;
@@ -1215,7 +1215,7 @@ let rec ensure_testnet_id_still_good logger =
           eprintf
             "The version for the testnet has changed, and this client \
              (version %s) is no longer compatible. Please download the latest \
-             Coda software!\n\
+             Mina software!\n\
              Valid versions:\n\
              %s\n"
             ( local_id |> Option.map ~f:str
@@ -1511,6 +1511,6 @@ let () =
        print_version_help coda_exe version
    | _ ->
        Command.run
-         (Command.group ~summary:"Coda" ~preserve_subcommand_order:()
+         (Command.group ~summary:"Mina" ~preserve_subcommand_order:()
             (mina_commands logger))) ;
   Core.exit 0

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -146,7 +146,7 @@ let maybe_kill_and_unlock : string -> Filename.t -> Logger.t -> unit Deferred.t
           | Error exn ->
               [%log warn]
                 !"Couldn't delete lock file for %s (pid $childPid) after \
-                  killing it. If another Coda daemon was already running it \
+                  killing it. If another Mina daemon was already running it \
                   may have cleaned it up for us. ($exn)"
                 name
                 ~metadata:

--- a/src/lib/cli_lib/background_daemon.ml
+++ b/src/lib/cli_lib/background_daemon.ml
@@ -17,7 +17,7 @@ let run ~f (t : Host_and_port.t Flag.Types.with_name) arg =
         if has_daemon then go Run_client else go No_daemon
     | No_daemon ->
         Print.printf
-          !"Error: Unable to connect to Coda daemon.\n\
+          !"Error: Unable to connect to Mina daemon.\n\
             - The daemon might not be running. See logs (in \
             `~/.mina-config/mina.log`) for details under the host:%s.\n\
            \  Run `mina daemon -help` to see how to start daemon.\n\

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -423,6 +423,6 @@ module Status = struct
     |> List.filter_map ~f:Fn.id
 
   let to_text (t : t) =
-    let title = "Coda daemon status\n-----------------------------------\n" in
+    let title = "Mina daemon status\n-----------------------------------\n" in
     digest_entries ~title (entries t)
 end

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -17,19 +17,19 @@ module Snark_worker_lib = Snark_worker
 module Timeout = Timeout_lib.Core_time
 
 type Structured_log_events.t += Connecting
-  [@@deriving register_event {msg= "Coda daemon is connecting"}]
+  [@@deriving register_event {msg= "Mina daemon is connecting"}]
 
 type Structured_log_events.t += Listening
-  [@@deriving register_event {msg= "Coda daemon is listening"}]
+  [@@deriving register_event {msg= "Mina daemon is listening"}]
 
 type Structured_log_events.t += Bootstrapping
-  [@@deriving register_event {msg= "Coda daemon is bootstrapping"}]
+  [@@deriving register_event {msg= "Mina daemon is bootstrapping"}]
 
 type Structured_log_events.t += Ledger_catchup
-  [@@deriving register_event {msg= "Coda daemon is doing ledger catchup"}]
+  [@@deriving register_event {msg= "Mina daemon is doing ledger catchup"}]
 
 type Structured_log_events.t += Synced
-  [@@deriving register_event {msg= "Coda daemon is synced"}]
+  [@@deriving register_event {msg= "Mina daemon is synced"}]
 
 type Structured_log_events.t +=
   | Rebroadcast_transition of {state_hash: State_hash.t}


### PR DESCRIPTION
Change some uses of `Coda` to `Mina` in UX and logs. In particular, change header line in `client status`, logs like `daemon is listening`, and `daemon -help`.

Partially addresses #8087 (which was the name of an Intel math co-processor, way back when).


