### PR TITLE
[HOTFIX] Assign node-status response in watchdog

### DIFF
--- a/automation/services/watchdog/node_status_metrics.py
+++ b/automation/services/watchdog/node_status_metrics.py
@@ -139,7 +139,7 @@ def crawl_for_peers(v1, namespace, seed, seed_daemon_port, max_crawl_requests=10
 
     print ('Queried ' + str(len(queried_peers)) + ' peers. Gathering node status on %s unqueried peers'%(str(len(unqueried_peers))))
 
-    util.exec_on_pod(v1, namespace, seed, 'seed', "mina advanced node-status -daemon-port " + seed_daemon_port + " -peers " + peers + " -show-errors")
+    resp = util.exec_on_pod(v1, namespace, seed, 'seed', "mina advanced node-status -daemon-port " + seed_daemon_port + " -peers " + peers + " -show-errors")
     add_resp(resp, peers_to_query)
 
     requests += 1


### PR DESCRIPTION
When merging `master` to `compatible`, there was a conflict. In `master`, I noticed the result of a `node-status` called was being discarded (o, Python!) in the watchdog. 

Restore the assignment of the response. This change is already in `compatible`.