### PR TITLE
Fix misspelling of cache_exceptions

### DIFF
--- a/src/config/debug_level/all.mlh
+++ b/src/config/debug_level/all.mlh
@@ -1,5 +1,5 @@
 [%%define debug_logs true]
 [%%define call_logger true]
 [%%define tracing true]
-[%%define cache_exception true]
+[%%define cache_exceptions true]
 [%%define record_async_backtraces true]


### PR DESCRIPTION
Fix misspelling of `cache_exceptions` in `debug_level/all.mlh`.

That compile-time flag is used only in `Cache_lib`, the misspelling is not found anywhere else.

Closes #8145.