### PR TITLE
only update coinbase metric when the new best tip is recent

### DIFF
--- a/src/lib/transition_frontier/full_frontier/full_frontier.mli
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.mli
@@ -32,6 +32,7 @@ val create :
   -> consensus_local_state:Consensus.Data.Local_state.t
   -> max_length:int
   -> precomputed_values:Precomputed_values.t
+  -> time_controller:Block_time.Controller.t
   -> t
 
 val close : loc:string -> t -> unit

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -243,6 +243,7 @@ module Instance = struct
     (* initialize the new in memory frontier and extensions *)
     let frontier =
       Full_frontier.create ~logger:t.factory.logger
+        ~time_controller:t.factory.time_controller
         ~root_data:
           { transition= root_transition
           ; staged_ledger= root_staged_ledger

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -79,6 +79,7 @@ let%test_module "Full_frontier tests" =
       Full_frontier.create ~logger ~root_data
         ~root_ledger:(Ledger.Any_ledger.cast (module Ledger) root_ledger)
         ~consensus_local_state ~max_length ~precomputed_values
+        ~time_controller:(Block_time.Controller.basic ~logger)
 
     let%test_unit "Should be able to find a breadcrumbs after adding them" =
       Quickcheck.test gen_breadcrumb ~trials:4 ~f:(fun make_breadcrumb ->


### PR DESCRIPTION
Change to only update the best tip coinbase metric when the new best tip block is recent.