### PR TITLE
[HOTFIX] Make mainnet parameter configurable from the config file

### DIFF
--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -38,7 +38,7 @@ let create_ledger_and_transactions num_transitions =
              ; token_id= Token_id.default
              ; amount })
     in
-    Signed_command.sign from_kp payload
+    Signed_command.sign ~mainnet:true from_kp payload
   in
   let nonces =
     Public_key.Compressed.Table.of_alist_exn

--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -84,14 +84,14 @@ let _ =
              Mina_base_nonconsensus.Signed_command_payload.dummy
            in
            let signature =
-             Mina_base_nonconsensus.Signed_command.sign_payload sk
-               dummy_payload
+             Mina_base_nonconsensus.Signed_command.sign_payload ~mainnet:true
+               sk dummy_payload
            in
            let message =
              Mina_base_nonconsensus.Signed_command.to_input dummy_payload
            in
            let verified =
-             Schnorr.verify signature
+             Schnorr.verify ~mainnet:true signature
                (Snark_params_nonconsensus.Inner_curve.of_affine pk)
                message
            in
@@ -104,7 +104,8 @@ let _ =
          let sk_base58_check = Js.to_string sk_base58_check_js in
          let sk = Private_key.of_base58_check_exn sk_base58_check in
          let str = Js.to_string str_js in
-         String_sign.Schnorr.sign sk str |> signature_to_js_object
+         String_sign.Schnorr.sign ~mainnet:true sk str
+         |> signature_to_js_object
 
        (** verify signature of arbitrary string signed with signString *)
        method verifyStringSignature (signature_js : signature_js)
@@ -123,7 +124,8 @@ let _ =
            Snark_params_nonconsensus.Inner_curve.of_affine pk
          in
          let str = Js.to_string str_js in
-         if String_sign.Schnorr.verify signature inner_curve str then Js._true
+         if String_sign.Schnorr.verify ~mainnet:true signature inner_curve str
+         then Js._true
          else Js._false
 
        (** sign payment transaction payload with private key *)
@@ -133,7 +135,8 @@ let _ =
          let sk = Private_key.of_base58_check_exn sk_base58_check in
          let payload = payload_of_payment_js payment_js in
          let signature =
-           Signed_command.sign_payload sk payload |> signature_to_js_object
+           Signed_command.sign_payload ~mainnet:true sk payload
+           |> signature_to_js_object
          in
          let publicKey = _self##publicKeyOfPrivateKey sk_base58_check_js in
          object%js
@@ -157,7 +160,8 @@ let _ =
          in
          let signature = signature_of_js_object signed_payment##.signature in
          let signed = Signed_command.Poly.{payload; signer; signature} in
-         if Signed_command.check_signature signed then Js._true else Js._false
+         if Signed_command.check_signature ~mainnet:true signed then Js._true
+         else Js._false
 
        (** sign payment transaction payload with private key *)
        method signStakeDelegation (sk_base58_check_js : string_js)
@@ -167,7 +171,8 @@ let _ =
          let sk = Private_key.of_base58_check_exn sk_base58_check in
          let payload = payload_of_stake_delegation_js stake_delegation_js in
          let signature =
-           Signed_command.sign_payload sk payload |> signature_to_js_object
+           Signed_command.sign_payload ~mainnet:true sk payload
+           |> signature_to_js_object
          in
          let publicKey = _self##publicKeyOfPrivateKey sk_base58_check_js in
          object%js
@@ -194,7 +199,8 @@ let _ =
            signature_of_js_object signed_stake_delegation##.signature
          in
          let signed = Signed_command.Poly.{payload; signer; signature} in
-         if Signed_command.check_signature signed then Js._true else Js._false
+         if Signed_command.check_signature ~mainnet:true signed then Js._true
+         else Js._false
 
        (** sign a transaction in Rosetta rendered format *)
        method signRosettaTransaction (sk_base58_check_js : string_js)
@@ -217,7 +223,8 @@ let _ =
            match payload_or_err with
            | Ok payload -> (
                let signature =
-                 Signed_command.sign_payload sk payload |> Signature.Raw.encode
+                 Signed_command.sign_payload ~mainnet:true sk payload
+                 |> Signature.Raw.encode
                in
                let signed_txn =
                  Transaction.Signed.{command; nonce; signature}

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -21,6 +21,9 @@ let snark_pk = "B62qjnkjj3zDxhEfxbn1qZhUawVeLsUr2GCzEz8m1MDztiBouNsiMUL"
 
 let timelocked_pk = "B62qpJDprqj1zjNLf4wSpFC6dqmLzyokMy6KtMLSvkU8wfdL1midEb4"
 
+(* Use mainnet hashing for this network. *)
+let mainnet = true
+
 let wait span = Async.after span |> Deferred.map ~f:Result.return
 
 (* Keep trying to run `step` `retry_count` many times initially waiting for `initial_delay` and each time waiting `each_delay` *)
@@ -369,7 +372,7 @@ let construction_api_transaction_through_mempool ~logger ~rosetta_uri
       "Construction_parse : Expected $expected, after payloads+parse $actual" ;
     failwith "Operations are not equal before and after payloads+parse" ) ;
   let%bind signature =
-    Signer.sign ~keys
+    Signer.sign ~mainnet ~keys
       ~unsigned_transaction_string:payloads_res.unsigned_transaction
     |> Deferred.return
   in
@@ -398,7 +401,7 @@ let construction_api_transaction_through_mempool ~logger ~rosetta_uri
       ~signed_transaction:combine_res.signed_transaction
   in
   let%bind verified_bool =
-    Signer.verify ~public_key_hex_bytes:keys.public_key_hex_bytes
+    Signer.verify ~mainnet ~public_key_hex_bytes:keys.public_key_hex_bytes
       ~signed_transaction_string:combine_res.signed_transaction
     |> Deferred.return
   in

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -27,6 +27,8 @@ let validate_keypair =
     let%map_open privkey_path = Flag.privkey_write_path in
     Exceptions.handle_nicely
     @@ fun () ->
+    (* Validate keypair for mainnet. *)
+    let mainnet = true in
     let read_pk () =
       let pubkey_path = privkey_path ^ ".pub" in
       try
@@ -61,12 +63,12 @@ let validate_keypair =
     let validate_transaction keypair =
       let dummy_payload = Mina_base.Signed_command_payload.dummy in
       let signature =
-        Mina_base.Signed_command.sign_payload keypair.Keypair.private_key
-          dummy_payload
+        Mina_base.Signed_command.sign_payload ~mainnet
+          keypair.Keypair.private_key dummy_payload
       in
       let message = Mina_base.Signed_command.to_input dummy_payload in
       let verified =
-        Schnorr.verify signature
+        Schnorr.verify ~mainnet signature
           (Snark_params.Tick.Inner_curve.of_affine keypair.public_key)
           message
       in
@@ -100,124 +102,144 @@ let validate_transaction =
     ~summary:
       "Validate the signature on one or more transactions, provided to stdin \
        in rosetta format"
-    ( Command.Param.return
-    @@ fun () ->
-    let num_fails = ref 0 in
-    let jsons = Yojson.Safe.stream_from_channel In_channel.stdin in
-    ( match
-        Or_error.try_with (fun () ->
-            Caml.Stream.iter
-              (fun transaction_json ->
-                match
-                  Or_error.try_with_join (fun () ->
-                      let open Or_error.Let_syntax in
-                      let%bind rosetta_transaction_rendered =
-                        Rosetta_lib.Transaction.Signed.Rendered.of_yojson
-                          transaction_json
-                        |> Result.map_error ~f:Error.of_string
-                      in
-                      let%bind rosetta_transaction =
-                        Rosetta_lib.Transaction.Signed.of_rendered
-                          rosetta_transaction_rendered
-                        |> Result.map_error ~f:(fun err ->
-                               Error.of_string (Rosetta_lib.Errors.show err) )
-                      in
-                      let valid_until, memo =
-                        (* This is a hack..
+    (let default =
+       if Mina_compile_config.mainnet then "mainnet" else "testnet"
+     in
+     let%map_open.Command.Let_syntax mainnet =
+       flag "--mainnet" ~aliases:["mainnet"] (optional bool)
+         ~doc:
+           (sprintf
+              "Whether to validate the transactions for mainnet or for a \
+               testnet (default: %s)"
+              default)
+     in
+     fun () ->
+       let num_fails = ref 0 in
+       let jsons = Yojson.Safe.stream_from_channel In_channel.stdin in
+       let mainnet =
+         Option.value ~default:Mina_compile_config.mainnet mainnet
+       in
+       ( match
+           Or_error.try_with (fun () ->
+               Caml.Stream.iter
+                 (fun transaction_json ->
+                   match
+                     Or_error.try_with_join (fun () ->
+                         let open Or_error.Let_syntax in
+                         let%bind rosetta_transaction_rendered =
+                           Rosetta_lib.Transaction.Signed.Rendered.of_yojson
+                             transaction_json
+                           |> Result.map_error ~f:Error.of_string
+                         in
+                         let%bind rosetta_transaction =
+                           Rosetta_lib.Transaction.Signed.of_rendered
+                             rosetta_transaction_rendered
+                           |> Result.map_error ~f:(fun err ->
+                                  Error.of_string (Rosetta_lib.Errors.show err)
+                              )
+                         in
+                         let valid_until, memo =
+                           (* This is a hack..
                    TODO: Handle these properly in rosetta.
                 *)
-                        match rosetta_transaction.command.kind with
-                        | `Payment ->
-                            ( Option.bind rosetta_transaction_rendered.payment
-                                ~f:(fun {valid_until; _} -> valid_until)
-                            , Option.bind rosetta_transaction_rendered.payment
-                                ~f:(fun {memo; _} -> memo) )
-                        | `Delegation ->
-                            ( Option.bind
-                                rosetta_transaction_rendered.stake_delegation
-                                ~f:(fun {valid_until; _} -> valid_until)
-                            , Option.bind
-                                rosetta_transaction_rendered.stake_delegation
-                                ~f:(fun {memo; _} -> memo) )
-                        | `Create_token ->
-                            ( Option.bind
-                                rosetta_transaction_rendered.create_token
-                                ~f:(fun {valid_until; _} -> valid_until)
-                            , Option.bind
-                                rosetta_transaction_rendered.create_token
-                                ~f:(fun {memo; _} -> memo) )
-                        | `Create_token_account ->
-                            ( Option.bind
-                                rosetta_transaction_rendered
-                                  .create_token_account
-                                ~f:(fun {valid_until; _} -> valid_until)
-                            , Option.bind
-                                rosetta_transaction_rendered
-                                  .create_token_account ~f:(fun {memo; _} ->
-                                  memo ) )
-                        | `Mint_tokens ->
-                            ( Option.bind
-                                rosetta_transaction_rendered.mint_tokens
-                                ~f:(fun {valid_until; _} -> valid_until)
-                            , Option.bind
-                                rosetta_transaction_rendered.mint_tokens
-                                ~f:(fun {memo; _} -> memo) )
-                      in
-                      let pk (`Pk x) =
-                        Public_key.Compressed.of_base58_check_exn x
-                      in
-                      let%bind payload =
-                        Rosetta_lib.User_command_info.Partial
-                        .to_user_command_payload rosetta_transaction.command
-                          ~nonce:rosetta_transaction.nonce ?memo ?valid_until
-                        |> Result.map_error ~f:(fun err ->
-                               Error.of_string (Rosetta_lib.Errors.show err) )
-                      in
-                      let%map signature =
-                        match
-                          Mina_base.Signature.Raw.decode
-                            rosetta_transaction.signature
-                        with
-                        | Some signature ->
-                            Ok signature
-                        | None ->
-                            Or_error.errorf "Could not decode signature"
-                      in
-                      let command : Mina_base.Signed_command.t =
-                        { Mina_base.Signed_command.Poly.signature
-                        ; signer=
-                            pk rosetta_transaction.command.fee_payer
-                            |> Public_key.decompress_exn
-                        ; payload }
-                      in
-                      command )
-                with
-                | Ok cmd ->
-                    if Mina_base.Signed_command.check_signature cmd then
-                      Format.eprintf "Transaction was valid@."
-                    else (
-                      incr num_fails ;
-                      Format.eprintf "Transaction was invalid@." )
-                | Error err ->
-                    incr num_fails ;
-                    Format.eprintf
-                      "Failed to validate transaction:@.%s@.Failed with \
-                       error:%s@."
-                      (Yojson.Safe.pretty_to_string transaction_json)
-                      (Yojson.Safe.pretty_to_string
-                         (Error_json.error_to_yojson err)) )
-              jsons )
-      with
-    | Ok () ->
-        ()
-    | Error err ->
-        Format.eprintf "Error:@.%s@.@."
-          (Yojson.Safe.pretty_to_string (Error_json.error_to_yojson err)) ;
-        Format.printf "Invalid transaction.@." ;
-        Core_kernel.exit 1 ) ;
-    if !num_fails > 0 then (
-      Format.printf "Some transactions failed to verify@." ;
-      exit 1 )
-    else (
-      Format.printf "All transactions were valid@." ;
-      exit 0 ) )
+                           match rosetta_transaction.command.kind with
+                           | `Payment ->
+                               ( Option.bind
+                                   rosetta_transaction_rendered.payment
+                                   ~f:(fun {valid_until; _} -> valid_until)
+                               , Option.bind
+                                   rosetta_transaction_rendered.payment
+                                   ~f:(fun {memo; _} -> memo) )
+                           | `Delegation ->
+                               ( Option.bind
+                                   rosetta_transaction_rendered
+                                     .stake_delegation
+                                   ~f:(fun {valid_until; _} -> valid_until)
+                               , Option.bind
+                                   rosetta_transaction_rendered
+                                     .stake_delegation ~f:(fun {memo; _} ->
+                                     memo ) )
+                           | `Create_token ->
+                               ( Option.bind
+                                   rosetta_transaction_rendered.create_token
+                                   ~f:(fun {valid_until; _} -> valid_until)
+                               , Option.bind
+                                   rosetta_transaction_rendered.create_token
+                                   ~f:(fun {memo; _} -> memo) )
+                           | `Create_token_account ->
+                               ( Option.bind
+                                   rosetta_transaction_rendered
+                                     .create_token_account
+                                   ~f:(fun {valid_until; _} -> valid_until)
+                               , Option.bind
+                                   rosetta_transaction_rendered
+                                     .create_token_account ~f:(fun {memo; _} ->
+                                     memo ) )
+                           | `Mint_tokens ->
+                               ( Option.bind
+                                   rosetta_transaction_rendered.mint_tokens
+                                   ~f:(fun {valid_until; _} -> valid_until)
+                               , Option.bind
+                                   rosetta_transaction_rendered.mint_tokens
+                                   ~f:(fun {memo; _} -> memo) )
+                         in
+                         let pk (`Pk x) =
+                           Public_key.Compressed.of_base58_check_exn x
+                         in
+                         let%bind payload =
+                           Rosetta_lib.User_command_info.Partial
+                           .to_user_command_payload rosetta_transaction.command
+                             ~nonce:rosetta_transaction.nonce ?memo
+                             ?valid_until
+                           |> Result.map_error ~f:(fun err ->
+                                  Error.of_string (Rosetta_lib.Errors.show err)
+                              )
+                         in
+                         let%map signature =
+                           match
+                             Mina_base.Signature.Raw.decode
+                               rosetta_transaction.signature
+                           with
+                           | Some signature ->
+                               Ok signature
+                           | None ->
+                               Or_error.errorf "Could not decode signature"
+                         in
+                         let command : Mina_base.Signed_command.t =
+                           { Mina_base.Signed_command.Poly.signature
+                           ; signer=
+                               pk rosetta_transaction.command.fee_payer
+                               |> Public_key.decompress_exn
+                           ; payload }
+                         in
+                         command )
+                   with
+                   | Ok cmd ->
+                       if Mina_base.Signed_command.check_signature ~mainnet cmd
+                       then Format.eprintf "Transaction was valid@."
+                       else (
+                         incr num_fails ;
+                         Format.eprintf "Transaction was invalid@." )
+                   | Error err ->
+                       incr num_fails ;
+                       Format.eprintf
+                         "Failed to validate transaction:@.%s@.Failed with \
+                          error:%s@."
+                         (Yojson.Safe.pretty_to_string transaction_json)
+                         (Yojson.Safe.pretty_to_string
+                            (Error_json.error_to_yojson err)) )
+                 jsons )
+         with
+       | Ok () ->
+           ()
+       | Error err ->
+           Format.eprintf "Error:@.%s@.@."
+             (Yojson.Safe.pretty_to_string (Error_json.error_to_yojson err)) ;
+           Format.printf "Invalid transaction.@." ;
+           Core_kernel.exit 1 ) ;
+       if !num_fails > 0 then (
+         Format.printf "Some transactions failed to verify@." ;
+         exit 1 )
+       else (
+         Format.printf "All transactions were valid@." ;
+         exit 0 ))

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -69,7 +69,8 @@ module Constraint_constants = struct
         ; coinbase_amount: Currency.Amount.Stable.V1.t
         ; supercharged_coinbase_factor: int
         ; account_creation_fee: Currency.Fee.Stable.V1.t
-        ; fork: Fork_constants.Stable.V1.t option }
+        ; fork: Fork_constants.Stable.V1.t option
+        ; mainnet: bool }
       [@@deriving sexp, eq, yojson]
 
       let to_latest = Fn.id
@@ -210,6 +211,9 @@ module Constraint_constants = struct
 
         [%%endif]
 
+        [%%inject
+        "mainnet", mainnet]
+
         let compiled =
           { sub_windows_per_window
           ; ledger_depth
@@ -222,7 +226,8 @@ module Constraint_constants = struct
           ; supercharged_coinbase_factor
           ; account_creation_fee=
               Currency.Fee.of_formatted_string account_creation_fee_string
-          ; fork }
+          ; fork
+          ; mainnet }
       end :
       sig
         val compiled : t

--- a/src/lib/hash_prefix_states/hash_prefix_states.ml
+++ b/src/lib/hash_prefix_states/hash_prefix_states.ml
@@ -66,16 +66,12 @@ let coinbase_merkle_tree =
 
 let vrf_message = salt vrf_message
 
-[%%if
-mainnet]
+let signature_mainnet = salt signature_mainnet
 
-let signature = salt signature_mainnet
+let signature_testnet = salt signature_testnet
 
-[%%else]
-
-let signature = salt signature_testnet
-
-[%%endif]
+let signature ~mainnet =
+  if mainnet then signature_mainnet else signature_testnet
 
 let vrf_output = salt vrf_output
 

--- a/src/lib/hash_prefix_states/hash_prefix_states.mli
+++ b/src/lib/hash_prefix_states/hash_prefix_states.mli
@@ -14,7 +14,7 @@ module Random_oracle = Random_oracle_nonconsensus.Random_oracle
 
 open Random_oracle
 
-val signature : Field.t State.t
+val signature : mainnet:bool -> Field.t State.t
 
 (** [merkle_tree depth] gives the hash prefix for the given node depth.
 

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -171,15 +171,22 @@ module type S = sig
   end
 
   val sign_payload :
-    Signature_lib.Private_key.t -> Signed_command_payload.t -> Signature.t
+       mainnet:bool
+    -> Signature_lib.Private_key.t
+    -> Signed_command_payload.t
+    -> Signature.t
 
   val sign :
-    Signature_keypair.t -> Signed_command_payload.t -> With_valid_signature.t
+       mainnet:bool
+    -> Signature_keypair.t
+    -> Signed_command_payload.t
+    -> With_valid_signature.t
 
-  val check_signature : t -> bool
+  val check_signature : mainnet:bool -> t -> bool
 
   val create_with_signature_checked :
-       Signature.t
+       mainnet:bool
+    -> Signature.t
     -> Public_key.Compressed.t
     -> Signed_command_payload.t
     -> With_valid_signature.t option

--- a/src/lib/mina_base/snapp_command.ml
+++ b/src/lib/mina_base/snapp_command.ml
@@ -1236,8 +1236,8 @@ let to_payload (t : t) : Payload.t =
             Option.map fee_payment ~f:(fun {payload; signature= _} -> payload)
         }
 
-let signed_signed ?fee_payment ~token_id (signer1, data1) (signer2, data2) : t
-    =
+let signed_signed ~mainnet ?fee_payment ~token_id (signer1, data1)
+    (signer2, data2) : t =
   let r : _ Inner.t =
     { one= {Party.Authorized.Poly.data= data1; authorization= Signature.dummy}
     ; two= {Party.Authorized.Poly.data= data2; authorization= Signature.dummy}
@@ -1252,7 +1252,7 @@ let signed_signed ?fee_payment ~token_id (signer1, data1) (signer2, data2) : t
       |> Payload.digested |> Payload.Digested.digest
       |> Random_oracle_input.field
     in
-    fun sk -> Schnorr.sign sk msg
+    fun sk -> Schnorr.sign ~mainnet sk msg
   in
   Signed_signed
     { r with
@@ -1262,7 +1262,7 @@ let signed_signed ?fee_payment ~token_id (signer1, data1) (signer2, data2) : t
         Option.map2 fee_payment r.fee_payment ~f:(fun (sk, _) x ->
             {x with signature= sign sk} ) }
 
-let signed_empty ?fee_payment ?data2 ~token_id (signer1, data1) : t =
+let signed_empty ~mainnet ?fee_payment ?data2 ~token_id (signer1, data1) : t =
   let r : _ Inner.t =
     { one= {Party.Authorized.Poly.data= data1; authorization= Signature.dummy}
     ; two=
@@ -1279,7 +1279,7 @@ let signed_empty ?fee_payment ?data2 ~token_id (signer1, data1) : t =
       |> Payload.digested |> Payload.Digested.digest
       |> Random_oracle_input.field
     in
-    fun sk -> Schnorr.sign sk msg
+    fun sk -> Schnorr.sign ~mainnet sk msg
   in
   Signed_empty
     { r with

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -60,3 +60,6 @@ let rpc_handshake_timeout_sec = 60.0
 let rpc_heartbeat_timeout_sec = 60.0
 
 let rpc_heartbeat_send_every_sec = 10.0 (*same as the default*)
+
+[%%inject
+"mainnet", mainnet]

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3213,17 +3213,21 @@ module Queries = struct
           | None ->
               Deferred.Result.fail "Signature field is missing"
         in
+        let mainnet =
+          (Mina_lib.config mina).precomputed_values.constraint_constants
+            .mainnet
+        in
         let%bind user_command_input =
           Mutations.make_signed_user_command ~nonce_opt ~signer:from ~memo ~fee
             ~fee_token ~fee_payer_pk:from ~valid_until ~body ~signature
         in
         let%map user_command, _ =
-          User_command_input.to_user_command
+          User_command_input.to_user_command ~mainnet
             ~get_current_nonce:(Mina_lib.get_current_nonce mina)
             user_command_input
           |> Deferred.Result.map_error ~f:Error.to_string_hum
         in
-        Signed_command.check_signature user_command )
+        Signed_command.check_signature ~mainnet user_command )
 
   let commands =
     [ sync_state

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1320,7 +1320,8 @@ let create ?wallets (config : Config.t) =
           Strict_pipe.Reader.iter user_command_input_reader
             ~f:(fun (input_list, result_cb, get_current_nonce) ->
               match%bind
-                User_command_input.to_user_commands ~get_current_nonce
+                User_command_input.to_user_commands
+                  ~mainnet:constraint_constants.mainnet ~get_current_nonce
                   input_list
               with
               | Ok user_commands ->

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -256,7 +256,7 @@ module Transaction_pool = struct
       (Array.to_list
          (Array.map a ~f:(function `Valid c -> Some c | _ -> None)))
 
-  let create verifier : t =
+  let create ~mainnet verifier : t =
     create ~compare_init:compare_envelope (fun (ds : input list) ->
         let open Deferred.Or_error.Let_syntax in
         let result = init_result ds in
@@ -278,7 +278,7 @@ module Transaction_pool = struct
         in
         let%map res =
           (* Verify the unknowns *)
-          Verifier.verify_commands verifier (List.map unknowns ~f:snd)
+          Verifier.verify_commands ~mainnet verifier (List.map unknowns ~f:snd)
         in
         (* We now iterate over the results of the unknown transactions and appropriately modify
            the verification result of the diff that it belongs to. *)

--- a/src/lib/network_pool/batcher.mli
+++ b/src/lib/network_pool/batcher.mli
@@ -42,7 +42,7 @@ module Transaction_pool : sig
 
   type t [@@deriving sexp]
 
-  val create : Verifier.t -> t
+  val create : mainnet:bool -> Verifier.t -> t
 
   val verify :
        t

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -640,7 +640,12 @@ struct
                        .Latest )
         ; config
         ; logger
-        ; batcher= Batcher.create config.verifier
+        ; batcher=
+            Batcher.create
+              ~mainnet:
+                constraint_constants
+                  .Genesis_constants.Constraint_constants.mainnet
+              config.verifier
         ; best_tip_diff_relay= None
         ; recently_seen= Lru_cache.Q.create ()
         ; best_tip_ledger= None }
@@ -1585,7 +1590,7 @@ let%test_module _ =
 
     let mk_payment' ?valid_until sender_idx fee nonce receiver_idx amount =
       let get_pk idx = Public_key.compress test_keys.(idx).public_key in
-      Signed_command.sign test_keys.(sender_idx)
+      Signed_command.sign ~mainnet:true test_keys.(sender_idx)
         (Signed_command_payload.create ~fee:(Currency.Fee.of_int fee)
            ~fee_token:Token_id.default ~fee_payer_pk:(get_pk sender_idx)
            ~valid_until
@@ -1911,7 +1916,8 @@ let%test_module _ =
                 as body } ->
               {common= {common with fee_payer_pk= sender_pk}; body}
         in
-        User_command.Signed_command (Signed_command.sign sender_kp payload)
+        User_command.Signed_command
+          (Signed_command.sign ~mainnet:true sender_kp payload)
       in
       let txs0 =
         [ mk_payment' 0 1_000_000_000 0 9 20_000_000_000

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -277,7 +277,8 @@ module Json_layout = struct
       ; coinbase_amount: (Currency.Amount.t option[@default None])
       ; supercharged_coinbase_factor: (int option[@default None])
       ; account_creation_fee: (Currency.Fee.t option[@default None])
-      ; fork: (Fork_config.t option[@default None]) }
+      ; fork: (Fork_config.t option[@default None])
+      ; mainnet: (bool option[@default None]) }
     [@@deriving yojson, dhall_type]
 
     let fields =
@@ -289,7 +290,8 @@ module Json_layout = struct
        ; "transaction_capacity"
        ; "coinbase_amount"
        ; "supercharged_coinbase_factor"
-       ; "account_creation_fee" |]
+       ; "account_creation_fee"
+       ; "mainnet" |]
 
     let of_yojson json = of_yojson_generic ~fields of_yojson json
   end
@@ -628,7 +630,8 @@ module Proof_keys = struct
     ; coinbase_amount: Currency.Amount.Stable.Latest.t option
     ; supercharged_coinbase_factor: int option
     ; account_creation_fee: Currency.Fee.Stable.Latest.t option
-    ; fork: Fork_config.t option }
+    ; fork: Fork_config.t option
+    ; mainnet: bool option }
   [@@deriving bin_io_unversioned]
 
   let to_json_layout
@@ -641,7 +644,8 @@ module Proof_keys = struct
       ; coinbase_amount
       ; supercharged_coinbase_factor
       ; account_creation_fee
-      ; fork } =
+      ; fork
+      ; mainnet } =
     { Json_layout.Proof_keys.level= Option.map ~f:Level.to_json_layout level
     ; sub_windows_per_window
     ; ledger_depth
@@ -652,7 +656,8 @@ module Proof_keys = struct
     ; coinbase_amount
     ; supercharged_coinbase_factor
     ; account_creation_fee
-    ; fork }
+    ; fork
+    ; mainnet }
 
   let of_json_layout
       { Json_layout.Proof_keys.level
@@ -664,7 +669,8 @@ module Proof_keys = struct
       ; coinbase_amount
       ; supercharged_coinbase_factor
       ; account_creation_fee
-      ; fork } =
+      ; fork
+      ; mainnet } =
     let open Result.Let_syntax in
     let%map level = result_opt ~f:Level.of_json_layout level
     and transaction_capacity =
@@ -679,7 +685,8 @@ module Proof_keys = struct
     ; coinbase_amount
     ; supercharged_coinbase_factor
     ; account_creation_fee
-    ; fork }
+    ; fork
+    ; mainnet }
 
   let to_yojson x = Json_layout.Proof_keys.to_yojson (to_json_layout x)
 
@@ -707,7 +714,8 @@ module Proof_keys = struct
     ; account_creation_fee=
         opt_fallthrough ~default:t1.account_creation_fee
           t2.account_creation_fee
-    ; fork= opt_fallthrough ~default:t1.fork t2.fork }
+    ; fork= opt_fallthrough ~default:t1.fork t2.fork
+    ; mainnet= opt_fallthrough ~default:t1.mainnet t2.mainnet }
 end
 
 module Genesis = struct

--- a/src/lib/secrets/hardware_wallets.ml
+++ b/src/lib/secrets/hardware_wallets.ml
@@ -92,7 +92,7 @@ let compute_public_key ~hd_index =
   |> Deferred.Result.map_error ~f:report_process_error
   |> Deferred.map ~f:(Result.bind ~f:decode_public_key)
 
-let sign ~hd_index ~public_key ~user_command_payload :
+let sign ~mainnet ~hd_index ~public_key ~user_command_payload :
     (Signed_command.With_valid_signature.t, string) Deferred.Result.t =
   let open Deferred.Result.Let_syntax in
   let input =
@@ -120,7 +120,7 @@ let sign ~hd_index ~public_key ~user_command_payload :
     in
     let%bind signature = decode_signature signature_str |> Deferred.return in
     match
-      Signed_command.create_with_signature_checked signature
+      Signed_command.create_with_signature_checked ~mainnet signature
         (Public_key.compress public_key)
         user_command_payload
     with

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -13,10 +13,16 @@ module type Message_intf = sig
 
   type curve_scalar
 
+  (* TODO(mrmr1993): [mainnet] here is a heinous abstraction leak. *)
   val derive :
-    t -> private_key:curve_scalar -> public_key:curve -> curve_scalar
+       mainnet:bool
+    -> t
+    -> private_key:curve_scalar
+    -> public_key:curve
+    -> curve_scalar
 
-  val hash : t -> public_key:curve -> r:field -> curve_scalar
+  (* TODO(mrmr1993): [mainnet] here is a heinous abstraction leak. *)
+  val hash : mainnet:bool -> t -> public_key:curve -> r:field -> curve_scalar
 
   [%%ifdef consensus_mechanism]
 
@@ -32,8 +38,13 @@ module type Message_intf = sig
 
   type (_, _) checked
 
+  (* TODO(mrmr1993): [mainnet] here is a heinous abstraction leak. *)
   val hash_checked :
-    var -> public_key:curve_var -> r:field_var -> (curve_scalar_var, _) checked
+       mainnet:bool
+    -> var
+    -> public_key:curve_var
+    -> r:field_var
+    -> (curve_scalar_var, _) checked
 
   [%%endif]
 end
@@ -94,15 +105,19 @@ module type S = sig
   module Checked : sig
     val compress : curve_var -> (Boolean.var list, _) Checked.t
 
+    (* TODO(mrmr1993): [mainnet] here is a heinous abstraction leak. *)
     val verifies :
-         (module Shifted.S with type t = 't)
+         mainnet:bool
+      -> (module Shifted.S with type t = 't)
       -> Signature.var
       -> Public_key.var
       -> Message.var
       -> (Boolean.var, _) Checked.t
 
+    (* TODO(mrmr1993): [mainnet] here is a heinous abstraction leak. *)
     val assert_verifies :
-         (module Shifted.S with type t = 't)
+         mainnet:bool
+      -> (module Shifted.S with type t = 't)
       -> Signature.var
       -> Public_key.var
       -> Message.var
@@ -111,9 +126,9 @@ module type S = sig
 
   val compress : curve -> bool list
 
-  val sign : Private_key.t -> Message.t -> Signature.t
+  val sign : mainnet:bool -> Private_key.t -> Message.t -> Signature.t
 
-  val verify : Signature.t -> Public_key.t -> Message.t -> bool
+  val verify : mainnet:bool -> Signature.t -> Public_key.t -> Message.t -> bool
 end
 
 module Make
@@ -205,22 +220,23 @@ module Make
 
   let is_even (t : Field.t) = not (Bigint.test_bit (Bigint.of_field t) 0)
 
-  let sign (d_prime : Private_key.t) m =
+  let sign ~mainnet (d_prime : Private_key.t) m =
     let public_key =
       (* TODO: Don't recompute this. *) Curve.scale Curve.one d_prime
     in
     (* TODO: Once we switch to implicit sign-bit we'll have to conditionally negate d_prime. *)
     let d = d_prime in
-    let k_prime = Message.derive m ~public_key ~private_key:d in
+    let k_prime = Message.derive ~mainnet m ~public_key ~private_key:d in
     assert (not Curve.Scalar.(equal k_prime zero)) ;
     let r, ry = Curve.(to_affine_exn (scale Curve.one k_prime)) in
     let k = if is_even ry then k_prime else Curve.Scalar.negate k_prime in
-    let e = Message.hash m ~public_key ~r in
+    let e = Message.hash ~mainnet m ~public_key ~r in
     let s = Curve.Scalar.(k + (e * d)) in
     (r, s)
 
-  let verify ((r, s) : Signature.t) (pk : Public_key.t) (m : Message.t) =
-    let e = Message.hash ~public_key:pk ~r m in
+  let verify ~mainnet ((r, s) : Signature.t) (pk : Public_key.t)
+      (m : Message.t) =
+    let e = Message.hash ~mainnet ~public_key:pk ~r m in
     let r_pt = Curve.(scale one s + negate (scale pk e)) in
     match Curve.to_affine_exn r_pt with
     | rx, ry ->
@@ -254,12 +270,12 @@ module Make
     (* returning r_point as a representable point ensures it is nonzero so the nonzero
      * check does not have to explicitly be performed *)
 
-    let%snarkydef verifier (type s) ~equal ~final_check
+    let%snarkydef verifier (type s) ~mainnet ~equal ~final_check
         ((module Shifted) as shifted :
           (module Curve.Checked.Shifted.S with type t = s))
         ((r, s) : Signature.var) (public_key : Public_key.var)
         (m : Message.var) =
-      let%bind e = Message.hash_checked m ~public_key ~r in
+      let%bind e = Message.hash_checked ~mainnet m ~public_key ~r in
       (* s * g - e * public_key *)
       let%bind e_pk =
         Curve.Checked.scale shifted
@@ -277,11 +293,12 @@ module Make
       let%bind r_correct = equal r rx in
       final_check r_correct y_even
 
-    let verifies s =
-      verifier ~equal:Field.Checked.equal ~final_check:Boolean.( && ) s
+    let verifies ~mainnet s =
+      verifier ~mainnet ~equal:Field.Checked.equal ~final_check:Boolean.( && )
+        s
 
-    let assert_verifies s =
-      verifier ~equal:Field.Checked.Assert.equal
+    let assert_verifies ~mainnet s =
+      verifier ~mainnet ~equal:Field.Checked.Assert.equal
         ~final_check:(fun () ry_even -> Boolean.Assert.is_true ry_even)
         s
   end
@@ -320,9 +337,9 @@ module type S = sig
     type t = curve [@@deriving sexp]
   end
 
-  val sign : Private_key.t -> Message.t -> Signature.t
+  val sign : mainnet:bool -> Private_key.t -> Message.t -> Signature.t
 
-  val verify : Signature.t -> Public_key.t -> Message.t -> bool
+  val verify : mainnet:bool -> Signature.t -> Public_key.t -> Message.t -> bool
 end
 
 module Make
@@ -376,25 +393,26 @@ module Make
 
   let is_even (t : Impl.Field.t) = not @@ Impl.Field.parity t
 
-  let sign (d_prime : Private_key.t) m =
+  let sign ~mainnet (d_prime : Private_key.t) m =
     let public_key =
       (* TODO: Don't recompute this. *)
       Curve.scale Curve.one d_prime
     in
     (* TODO: Once we switch to implicit sign-bit we'll have to conditionally negate d_prime. *)
     let d = d_prime in
-    let k_prime = Message.derive m ~public_key ~private_key:d in
+    let k_prime = Message.derive ~mainnet m ~public_key ~private_key:d in
     assert (not Curve.Scalar.(equal k_prime zero)) ;
     let r, (ry : Impl.Field.t) =
       Curve.(to_affine_exn (scale Curve.one k_prime))
     in
     let k = if is_even ry then k_prime else Curve.Scalar.negate k_prime in
-    let e = Message.hash m ~public_key ~r in
+    let e = Message.hash ~mainnet m ~public_key ~r in
     let s = Curve.Scalar.(k + (e * d)) in
     (r, s)
 
-  let verify ((r, s) : Signature.t) (pk : Public_key.t) (m : Message.t) =
-    let e = Message.hash ~public_key:pk ~r m in
+  let verify ~mainnet ((r, s) : Signature.t) (pk : Public_key.t)
+      (m : Message.t) =
+    let e = Message.hash ~mainnet ~public_key:pk ~r m in
     let r_pt = Curve.(scale one s + negate (scale pk e)) in
     match Curve.to_affine_exn r_pt with
     | rx, ry ->
@@ -414,18 +432,10 @@ module Message = struct
 
   type t = (Field.t, bool) Random_oracle.Input.t [@@deriving sexp]
 
-  [%%if
-  mainnet]
+  let network_id ~mainnet =
+    if mainnet then Char.of_int_exn 1 else Char.of_int_exn 0
 
-  let network_id = Char.of_int_exn 1
-
-  [%%else]
-
-  let network_id = Char.of_int_exn 0
-
-  [%%endif]
-
-  let derive t ~private_key ~public_key =
+  let derive ~mainnet t ~private_key ~public_key =
     let input =
       let x, y = Tick.Inner_curve.to_affine_exn public_key in
       Random_oracle.Input.append t
@@ -433,7 +443,8 @@ module Message = struct
         ; bitstrings=
             [| Tock.Field.unpack private_key
              ; Fold_lib.Fold.(
-                 to_list (string_bits (String.of_char network_id))) |] }
+                 to_list (string_bits (String.of_char (network_id ~mainnet))))
+            |] }
     in
     Random_oracle.Input.to_bits ~unpack:Field.unpack input
     |> Array.of_list |> Blake2.bits_to_string |> Blake2.digest_string
@@ -441,14 +452,14 @@ module Message = struct
     |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
     |> Tock.Field.project
 
-  let hash t ~public_key ~r =
+  let hash ~mainnet t ~public_key ~r =
     let input =
       let px, py = Inner_curve.to_affine_exn public_key in
       Random_oracle.Input.append t
         {field_elements= [|px; py; r|]; bitstrings= [||]}
     in
     let open Random_oracle in
-    hash ~init:Hash_prefix_states.signature (pack_input input)
+    hash ~init:(Hash_prefix_states.signature ~mainnet) (pack_input input)
     |> Digest.to_bits ~length:Field.size_in_bits
     |> Inner_curve.Scalar.of_bits
 
@@ -457,7 +468,7 @@ module Message = struct
 
   type var = (Field.Var.t, Boolean.var) Random_oracle.Input.t
 
-  let%snarkydef hash_checked t ~public_key ~r =
+  let%snarkydef hash_checked ~mainnet t ~public_key ~r =
     let input =
       let px, py = public_key in
       Random_oracle.Input.append t
@@ -465,7 +476,7 @@ module Message = struct
     in
     make_checked (fun () ->
         let open Random_oracle.Checked in
-        hash ~init:Hash_prefix_states.signature (pack_input input)
+        hash ~init:(Hash_prefix_states.signature ~mainnet) (pack_input input)
         |> Digest.to_bits ~length:Field.size_in_bits
         |> Bitstring_lib.Bitstring.Lsb_first.of_list )
 
@@ -518,9 +529,9 @@ let message_typ () : (Message.var, Message.t) Tick.Typ.t =
 
 let%test_unit "schnorr checked + unchecked" =
   Quickcheck.test ~trials:5 gen ~f:(fun (pk, msg) ->
-      let s = S.sign pk msg in
+      let s = S.sign ~mainnet:true pk msg in
       let pubkey = Tick.Inner_curve.(scale one pk) in
-      assert (S.verify s pubkey msg) ;
+      assert (S.verify ~mainnet:true s pubkey msg) ;
       (Tick.Test.test_equal ~sexp_of_t:[%sexp_of: bool] ~equal:Bool.equal
          Tick.Typ.(
            tuple3 Tick.Inner_curve.typ (message_typ ()) S.Signature.typ)
@@ -530,7 +541,8 @@ let%test_unit "schnorr checked + unchecked" =
            let%bind (module Shifted) =
              Tick.Inner_curve.Checked.Shifted.create ()
            in
-           S.Checked.verifies (module Shifted) s public_key msg )
+           S.Checked.verifies ~mainnet:true (module Shifted) s public_key msg
+           )
          (fun _ -> true))
         (pubkey, msg, s) )
 

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -207,7 +207,8 @@ val all_work_pairs :
 val all_work_statements_exn : t -> Transaction_snark_work.Statement.t list
 
 val check_commands :
-     Ledger.t
+     mainnet:bool
+  -> Ledger.t
   -> verifier:Verifier.t
   -> User_command.t list
   -> (User_command.Valid.t list, Verifier.Failure.t) Result.t

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -282,7 +282,7 @@ module For_tests = struct
                  ; token_id= token
                  ; amount= send_amount })
         in
-        Signed_command.sign sender_keypair payload )
+        Signed_command.sign ~mainnet:true sender_keypair payload )
 
   let gen ?(logger = Logger.null ())
       ~(precomputed_values : Precomputed_values.t) ?verifier

--- a/src/lib/user_command_input/user_command_input.mli
+++ b/src/lib/user_command_input/user_command_input.mli
@@ -68,7 +68,8 @@ val create :
   -> t
 
 val to_user_command :
-     ?nonce_map:(Account.Nonce.t * Account.Nonce.t) Account_id.Map.t
+     mainnet:bool
+  -> ?nonce_map:(Account.Nonce.t * Account.Nonce.t) Account_id.Map.t
   -> get_current_nonce:(   Account_id.t
                         -> ( [`Min of Account_nonce.t] * Account_nonce.t
                            , string )
@@ -78,7 +79,8 @@ val to_user_command :
      Deferred.Or_error.t
 
 val to_user_commands :
-     ?nonce_map:(Account.Nonce.t * Account.Nonce.t) Account_id.Map.t
+     mainnet:bool
+  -> ?nonce_map:(Account.Nonce.t * Account.Nonce.t) Account_id.Map.t
   -> get_current_nonce:(   Account_id.t
                         -> ( [`Min of Account_nonce.t] * Account_nonce.t
                            , string )

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -2,10 +2,12 @@ open Core_kernel
 open Mina_base
 
 let check :
-       User_command.Verifiable.t
+       mainnet:bool
+    -> User_command.Verifiable.t
     -> [ `Valid of User_command.Valid.t
        | `Invalid
-       | `Valid_assuming of User_command.Valid.t * _ list ] = function
+       | `Valid_assuming of User_command.Valid.t * _ list ] =
+ fun ~mainnet -> function
   | User_command.Signed_command c -> (
     match Signed_command.check c with
     | None ->
@@ -22,7 +24,7 @@ let check :
           let check_signature s pk =
             if
               not
-                (Signature_lib.Schnorr.verify s
+                (Signature_lib.Schnorr.verify ~mainnet s
                    (Backend.Tick.Inner_curve.of_affine
                       (Signature_lib.Public_key.decompress_exn pk))
                    (Random_oracle_input.field (Lazy.force payload)))

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -15,7 +15,7 @@ let create ~logger:_ ~proof_level ~pids:_ ~conf_dir:_ =
 
 let verify_blockchain_snarks _ _ = Deferred.Or_error.return true
 
-let verify_commands _ (cs : User_command.Verifiable.t list) :
+let verify_commands ~mainnet _ (cs : User_command.Verifiable.t list) :
     [ `Valid of Mina_base.User_command.Valid.t
     | `Invalid
     | `Valid_assuming of
@@ -26,7 +26,7 @@ let verify_commands _ (cs : User_command.Verifiable.t list) :
     list
     Deferred.Or_error.t =
   List.map cs ~f:(fun c ->
-      match Common.check c with
+      match Common.check ~mainnet c with
       | `Valid c ->
           `Valid c
       | `Invalid ->

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -8,7 +8,8 @@ module Base = struct
     type ledger_proof
 
     val verify_commands :
-         t
+         mainnet:bool
+      -> t
       -> Mina_base.User_command.Verifiable.t list
          (* The first level of error represents failure to verify, the second a failure in
    communicating with the verifier. *)


### PR DESCRIPTION
This PR adds support for setting `mainnet= true` in the config file. It is a sub-entry of the `proof` object (`proof.mainnet`), since it affects the proof system (ie. proving keys will change).

Most of this PR is straightforward piping through of the value. Of note are the deviations from that:
* instead of using the compiled configuration to run unit tests, I have hardcoded `mainnet= true` for them
  - I felt it was more important to ensure that the tests work correctly with the mainnet configuration than that they match their given configuration, especially since they will never run with this parameter otherwise
* there's a nasty hack (and unpleasant comment) in `genesis_ledger_helper.ml` that we need to permit the binary to run with the modified configuration
  - this allows only the value of `mainnet` to change in the constraint system configuration; any other value changing will result in an error, as usual
* the client SDK is now hardcoded to use mainnet signatures
  - we never hooked it up to use any sort of runtime configuration, so this is our only option to have it be compatible with mainnet without substantial extra changes

I have not tested these changes.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: