### PR TITLE
Add minimum tx fee to rosetta construction/metadata

### DIFF
--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -158,11 +158,18 @@ module Metadata_data = struct
   type t =
     { sender: string
     ; nonce: Unsigned_extended.UInt32.t
-    ; token_id: Unsigned_extended.UInt64.t }
+    ; token_id: Unsigned_extended.UInt64.t
+    ; minimum_fee: Amount.t list [@default []] }
   [@@deriving yojson]
 
   let create ~nonce ~sender ~token_id =
-    {sender= Public_key.Compressed.to_base58_check sender; nonce; token_id}
+    { sender= Public_key.Compressed.to_base58_check sender
+    ; nonce
+    ; token_id
+    ; minimum_fee=
+        [ Amount_of.coda
+            (MinaCurrency.Fee.to_uint64
+               Mina_compile_config.minimum_user_command_fee) ] }
 
   let of_json r =
     of_yojson r


### PR DESCRIPTION
This PR adds the minimum tx fee to the rosetta `construction/metadata` response so that clients can prevent users from creating transactions that would fail to be accepted.  The minimum fee is obtained from the compile-time config `Mina_compile_config.minimum_user_command_fee`

For compatibility with the [Rosetta specification](https://www.rosetta-api.org/docs/models/ConstructionMetadataResponse.html) we've added the additional `"minimum_fee"` information to the metadata property like so
```json
{
    "metadata": {
        "sender": "B62qnzbXmRNo9q32n4SNu2mpB8e7FYYLH8NmaX6oFCBYjjQ8SbD7uzV",
        "nonce": "0",
        "token_id": "1",
        "minimum_fee": [
            {
                "value": "1000000",
                "currency": {
                    "symbol": "CODA",
                    "decimals": 9
                }
            }
        ]
    },
    "suggested_fee": [
        {
            "value": "250000000",
            "currency": {
                "symbol": "CODA",
                "decimals": 9
            }
        }
    ]
}
```
**Testing**
This can be tested with `mina_ledger_wallet send-payment` and `src/app/rosetta/test-curl/con_metadata.sh`.  Prior to this change the `"minimum_fee"` component will not be present in the JSON response.  After this change it should be present and contain the value found in `src/config/amount_defaults/realistic.mlh`.

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #8086