### PR TITLE
[HOTFIX] Coda to Mina in visualization docstring

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2114,7 +2114,7 @@ module Visualization = struct
   end
 
   let command_group =
-    Command.group ~summary:"Visualize data structures special to Coda"
+    Command.group ~summary:"Visualize data structures special to Mina"
       [ (Frontier.name, Frontier.command)
       ; (Registered_masks.name, Registered_masks.command) ]
 end


### PR DESCRIPTION
Remaining Coda mention in a `-help` docstring changed to Mina.

Might be last fix for #8087.