### PR TITLE
Omit testnets deployed by CI/integration tests from monitoring and alerting flow

### DIFF
--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -12,7 +12,7 @@ terraform {
 module "o1testnet_alerts" {
   source = "../modules/testnet-alerts"
 
-  rule_filter            = "{testnet=~\".+\"}" # any non-empty testnet name
+  rule_filter            = "{testnet=~\"^(?!(it-|ci-net)).+\"}" # omit testnets deployed by integration/CI tests
   rule_timeframe         = "1h"
   pagerduty_alert_filter = "devnet|finalfinal2|mainnet|devnet2"
 }


### PR DESCRIPTION
**Test:** Buildkite CI + manual

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: