### PR TITLE
Improved error messages for rejection in sendRosettaTransaction

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2530,9 +2530,17 @@ module Mutations = struct
                  ; hash= Transaction_hash.hash_command transaction })
         | Error err ->
             Error (Error.to_string_hum err)
-        | _ ->
-            (* TODO: Be better here, we actually have more info. *)
-            Error "Transaction could not be entered into the pool" )
+        | Ok ([], [(_, diff_error)]) ->
+            let diff_error =
+              Network_pool.Transaction_pool.Resource_pool.Diff.Diff_error
+              .to_string_hum diff_error
+            in
+            Error
+              (sprintf "Transaction could not be entered into the pool: %s"
+                 diff_error)
+        | Ok _ ->
+            Error
+              "Internal error: response from transaction pool was malformed" )
 
   let export_logs =
     io_field "exportLogs" ~doc:"Export daemon logs to tar archive"

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -281,6 +281,8 @@ module type Transaction_pool_diff_intf = sig
       | Expired
       | Overloaded
     [@@deriving sexp, yojson]
+
+    val to_string_hum : t -> string
   end
 
   module Rejected : sig

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -96,6 +96,37 @@ module Diff_versioned = struct
       | Expired
       | Overloaded
     [@@deriving sexp, yojson]
+
+    let to_string_hum = function
+      | Insufficient_replace_fee ->
+          "This transaction would have replaced an existing transaction in \
+           the pool, but the fee was too low"
+      | Invalid_signature ->
+          "This transaction had an invalid signature"
+      | Duplicate ->
+          "This transaction is a duplicate of one already in the pool"
+      | Sender_account_does_not_exist ->
+          "The fee-payer's account for this transaction could not be found in \
+           the ledger"
+      | Invalid_nonce ->
+          "This transaction had an invalid nonce"
+      | Insufficient_funds ->
+          "There are not enough funds in the fee-payer's account to execute \
+           this transaction"
+      | Insufficient_fee ->
+          "The fee for this transaction is too low"
+      | Overflow ->
+          "Executing this transaction would result in an integer overflow"
+      | Bad_token ->
+          "This transaction uses non-default tokens where they are not \
+           permitted"
+      | Unwanted_fee_token ->
+          "This transaction pays fees in a non-default token that this pool \
+           does not accept"
+      | Expired ->
+          "This transaction has expired"
+      | Overloaded ->
+          "The diff containing this transaction was too large"
   end
 
   module Rejected = struct
@@ -771,6 +802,8 @@ struct
           | Expired
           | Overloaded
         [@@deriving sexp, yojson]
+
+        let to_string_hum = Diff_versioned.Diff_error.to_string_hum
       end
 
       module Rejected = struct


### PR DESCRIPTION
This PR improves the error messages from the `sendRosettaTransaction` GraphQL query. Previously, any error from the pool was a catch-all `Transaction could not be entered into the pool`.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: