### PR TITLE
[Trivial] Improve error message from missing --generate-genesis-proof

### DIFF
--- a/src/lib/genesis_ledger_helper/dune
+++ b/src/lib/genesis_ledger_helper/dune
@@ -2,7 +2,7 @@
  (public_name genesis_ledger_helper)
  (name genesis_ledger_helper)
  (inline_tests)
- (libraries snark_keys core_kernel mina_base signature_lib genesis_constants runtime_config cache_dir genesis_ledger genesis_proof precomputed_values)
+ (libraries snark_keys core_kernel mina_base signature_lib genesis_constants runtime_config cache_dir genesis_ledger genesis_proof precomputed_values mina_user_error)
  (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_jane ppx_version ppx_inline_test ppx_let ppx_deriving.std ppx_deriving_yojson ppx_custom_printf)))

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -1084,9 +1084,13 @@ module Genesis_proof = struct
           "No genesis proof file was found for $base_hash and not allowed to \
            generate a new genesis proof"
           ~metadata:[("base_hash", Base_hash.to_yojson base_hash)] ;
-        Deferred.Or_error.errorf
-          "No genesis proof file was found and not allowed to generate a new \
-           genesis proof"
+        Deferred.Or_error.of_exn
+          (Mina_user_error.Mina_user_error
+             { where= Some "generating a genesis proof"
+             ; message=
+                 "Hint: pass the flag --generate-genesis-proof true. For \
+                  example,\n\
+                  mina.exe daemon --generate-genesis-proof true" })
 end
 
 let make_constraint_constants

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -1088,9 +1088,11 @@ module Genesis_proof = struct
           (Mina_user_error.Mina_user_error
              { where= Some "generating a genesis proof"
              ; message=
-                 "Hint: pass the flag --generate-genesis-proof true. For \
-                  example,\n\
-                  mina.exe daemon --generate-genesis-proof true" })
+                 sprintf
+                   "Hint: pass the flag --generate-genesis-proof true. For \
+                    example,\n\
+                    %s daemon --generate-genesis-proof true"
+                   Sys.argv.(0) })
 end
 
 let make_constraint_constants


### PR DESCRIPTION
This now prints
```

FATAL ERROR

  ☠  Coda Daemon encountered a configuration error generating a genesis proof.

Hint: pass the flag --generate-genesis-proof true. For example,
mina.exe daemon --generate-genesis-proof true
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #8093