### PR TITLE
Fix alert rule regex query filter omitting ci/integration testnets

### DIFF
--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -12,7 +12,7 @@ terraform {
 module "o1testnet_alerts" {
   source = "../modules/testnet-alerts"
 
-  rule_filter            = "{testnet=~\"^(?!(it-|ci-net)).+\"}" # omit testnets deployed by integration/CI tests
+  rule_filter            = "{testnet!~\"^(it-|ci-net).+\"}" # omit testnets deployed by integration/CI tests
   rule_timeframe         = "1h"
   pagerduty_alert_filter = "devnet|finalfinal2|mainnet|devnet2"
 }


### PR DESCRIPTION
Use regex NOT operator `!~` instead of `?!` syntax ([see](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) for details) - Fixes the following metric deployment failure:

```
ERRO[0000] unable parse rules file                       error="163:11: group \"Critical Alerts\", rule 0, \"WatchdogClusterCrashes\": could not parse expression: 1:64: parse error: error parsing regexp: invalid or unsupported Perl syntax: `(?!`" file=alert_rules.yml
```

**Test:** Buildkite CI + Prometheus Explorer + online regex checker

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: