### PR TITLE
ensure reset/full sync of testnet alert state during CI and rename integration test jobs

### DIFF
--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -50,7 +50,7 @@ in
               Cmd.run "source ${deployEnv} && ./buildkite/scripts/run-test-executive.sh ${testName}"
             ],
         artifact_paths = [SelectFiles.exactly "." "${testName}.test.log"],
-        label = "Execute integration test: ${testName}",
+        label = "${testName} integration test",
         key = "integration-test-${testName}",
         target = Size.Medium,
         depends_on = dependsOn

--- a/buildkite/src/Jobs/Lint/TestnetAlerts.dhall
+++ b/buildkite/src/Jobs/Lint/TestnetAlerts.dhall
@@ -20,6 +20,7 @@ Pipeline.build
     spec = JobSpec::{
       dirtyWhen = [
         S.exactly "automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml" "tpl",
+        S.exactly "automation/terraform/monitoring/o1-testnet-alerts" "tf",
         S.strictlyStart (S.contains "buildkite/src/Jobs/Lint/TestnetAlerts"),
         S.strictlyStart (S.contains "buildkite/src/Jobs/Release/TestnetAlerts")
       ],
@@ -30,7 +31,8 @@ Pipeline.build
       Command.build
         Command.Config::{
           commands = [
-          Cmd.run "cd automation/terraform/monitoring && terraform init",
+            --- destroy state prior to start to ensure reset
+            Cmd.run "cd automation/terraform/monitoring && terraform init && terraform destroy -auto-approve",
             Cmd.run (
               "terraform apply -auto-approve -target module.o1testnet_alerts.null_resource.alert_rules_lint" ++
               " -target module.o1testnet_alerts.null_resource.alert_rules_check"

--- a/buildkite/src/Jobs/Release/TestnetAlerts.dhall
+++ b/buildkite/src/Jobs/Release/TestnetAlerts.dhall
@@ -20,6 +20,7 @@ Pipeline.build
     spec = JobSpec::{
       dirtyWhen = [
         S.exactly "automation/terraform/modules/testnet-alerts/templates/testnet-alert-rules.yml" "tpl",
+        S.exactly "automation/terraform/monitoring/o1-testnet-alerts" "tf",
         S.strictlyStart (S.contains "buildkite/src/Jobs/Release/TestnetAlerts")
       ],
       path = "Release",
@@ -29,8 +30,10 @@ Pipeline.build
       Command.build
         Command.Config::{
           commands = [
-              Cmd.run "cd automation/terraform/monitoring && terraform init",
-              Cmd.run "terraform apply -auto-approve -target module.o1testnet_alerts.docker_container.sync_alert_rules" ]
+            --- destroy state prior to start to ensure reset
+            Cmd.run "cd automation/terraform/monitoring && terraform init && terraform destroy -auto-approve",
+            Cmd.run "terraform apply -auto-approve -target module.o1testnet_alerts.docker_container.sync_alert_rules"
+          ]
           , label = "Deploy Testnet alert rules"
           , key = "deploy-testnet-alerts"
           , target = Size.Medium


### PR DESCRIPTION
**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: