### PR TITLE
Add warning for txns that can't cover account creation fee

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3309,6 +3309,10 @@ module Queries = struct
         let%map user_command, _ =
           User_command_input.to_user_command
             ~get_current_nonce:(Mina_lib.get_current_nonce mina)
+            ~get_account:(Mina_lib.get_account mina)
+            ~constraint_constants:
+              (Mina_lib.config mina).precomputed_values.constraint_constants
+            ~logger:(Mina_lib.top_level_logger mina)
             user_command_input
           |> Deferred.Result.map_error ~f:Error.to_string_hum
         in

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -98,6 +98,8 @@ val add_full_transactions :
      * Network_pool.Transaction_pool.Resource_pool.Diff.Rejected.t )
      Deferred.Or_error.t
 
+val get_account : t -> Account_id.t -> Account.t option Participating_state.T.t
+
 val get_inferred_nonce_from_transaction_pool_and_ledger :
   t -> Account_id.t -> Account.Nonce.t option Participating_state.t
 

--- a/src/lib/user_command_input/user_command_input.ml
+++ b/src/lib/user_command_input/user_command_input.ml
@@ -167,8 +167,37 @@ let inferred_nonce ~get_current_nonce ~(fee_payer : Account_id.t) ~nonce_map =
       in
       (min_nonce, txn_pool_or_account_nonce, updated_map)
 
+(* If the receiver account doesn't exist yet (as far as we can tell) *and* the
+ * user command isn't sufficient to cover the account creation fee, log a
+ * warning. *)
+let warn_if_unable_to_pay_account_creation_fee ~get_account
+    ~(constraint_constants : Genesis_constants.Constraint_constants.t) ~logger
+    user_command_payload =
+  let receiver_pk = Signed_command_payload.receiver_pk user_command_payload in
+  let token = Signed_command_payload.token user_command_payload in
+  let receiver = Account_id.create receiver_pk token in
+  let receiver_account = get_account receiver in
+  let amount = Signed_command_payload.amount user_command_payload in
+  match (receiver_account, amount) with
+  | `Bootstrapping, _ | `Active (Some _), _ | _, None ->
+      ()
+  | `Active None, Some amount ->
+      let open Currency.Amount in
+      let account_creation_fee =
+        of_fee constraint_constants.account_creation_fee
+      in
+      if amount < account_creation_fee then
+        [%log warn]
+          "A transaction was submitted that is likely to fail because the \
+           receiver account doesn't appear to have been created already and \
+           the transaction amount of %s is smaller than the account creation \
+           fee of %s."
+          (to_formatted_string amount)
+          (to_formatted_string account_creation_fee) ;
+      ()
+
 let to_user_command ?(nonce_map = Account_id.Map.empty) ~get_current_nonce
-    (client_input : t) =
+    ~get_account ~constraint_constants ~logger (client_input : t) =
   Deferred.map
     ~f:
       (Result.map_error ~f:(fun str ->
@@ -186,6 +215,10 @@ let to_user_command ?(nonce_map = Account_id.Map.empty) ~get_current_nonce
       ~inferred_nonce
     |> Deferred.return
   in
+  let () =
+    warn_if_unable_to_pay_account_creation_fee ~get_account
+      ~constraint_constants ~logger user_command_payload
+  in
   let%map signed_user_command =
     sign ~signer:client_input.signer ~user_command_payload
       client_input.signature
@@ -193,7 +226,8 @@ let to_user_command ?(nonce_map = Account_id.Map.empty) ~get_current_nonce
   (Signed_command.forget_check signed_user_command, updated_nonce_map)
 
 let to_user_commands ?(nonce_map = Account_id.Map.empty) ~get_current_nonce
-    uc_inputs : Signed_command.t list Deferred.Or_error.t =
+    ~get_account ~constraint_constants ~logger uc_inputs :
+    Signed_command.t list Deferred.Or_error.t =
   (* When batching multiple user commands, keep track of the nonces and send
       all the user commands if they are valid or none if there is an error in
       one of them.
@@ -203,7 +237,8 @@ let to_user_commands ?(nonce_map = Account_id.Map.empty) ~get_current_nonce
     Deferred.Or_error.List.fold ~init:([], nonce_map) uc_inputs
       ~f:(fun (valid_user_commands, nonce_map) uc_input ->
         let%map res, updated_nonce_map =
-          to_user_command ~nonce_map ~get_current_nonce uc_input
+          to_user_command ~nonce_map ~get_current_nonce ~get_account
+            ~constraint_constants ~logger uc_input
         in
         (res :: valid_user_commands, updated_nonce_map) )
   in

--- a/src/lib/user_command_input/user_command_input.mli
+++ b/src/lib/user_command_input/user_command_input.mli
@@ -73,6 +73,9 @@ val to_user_command :
                         -> ( [`Min of Account_nonce.t] * Account_nonce.t
                            , string )
                            Result.t)
+  -> get_account:(Account_id.t -> Account.t option Participating_state.T.t)
+  -> constraint_constants:Genesis_constants.Constraint_constants.t
+  -> logger:Logger.t
   -> t
   -> (Signed_command.t * (Account.Nonce.t * Account.Nonce.t) Account_id.Map.t)
      Deferred.Or_error.t
@@ -83,5 +86,8 @@ val to_user_commands :
                         -> ( [`Min of Account_nonce.t] * Account_nonce.t
                            , string )
                            Result.t)
+  -> get_account:(Account_id.t -> Account.t option Participating_state.T.t)
+  -> constraint_constants:Genesis_constants.Constraint_constants.t
+  -> logger:Logger.t
   -> t list
   -> Signed_command.t list Deferred.Or_error.t


### PR DESCRIPTION
- Thread `get_account`, `logger`, and `constraint_constants` to `User_command_input.to_user_command`
- Have `User_command.to_user_command` log a warning if it encounters a user command where the receiver doesn't have an account yet and the command has an amount smaller than the account creation fee

TODO:
- A few inline code questions
- Testing

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Addresses hotfix part of #8213