### PR TITLE
initialize best tip coinbase metric to 1

### DIFF
--- a/src/lib/mina_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/mina_metrics.ml
@@ -656,7 +656,8 @@ module Transition_frontier = struct
     let help =
       "0 if there is no coinbase in the current best tip, 1 otherwise"
     in
-    Gauge.v "best_tip_coinbase" ~help ~namespace ~subsystem
+    let t = Gauge.v "best_tip_coinbase" ~help ~namespace ~subsystem in
+    Gauge.set t 1. ; t
 
   let longest_fork : Gauge.t =
     let help = "Length of the longest path in the frontier" in


### PR DESCRIPTION
This PR initializes the best tip coinbase metric to "1" so that the alert does not fire inaccurately when a node first starts up.