### PR TITLE
Integration Test Fixes

### DIFF
--- a/automation/terraform/modules/kubernetes/testnet/kubernetes.tf
+++ b/automation/terraform/modules/kubernetes/testnet/kubernetes.tf
@@ -9,4 +9,8 @@ resource "kubernetes_namespace" "testnet_namespace" {
   metadata {
     name = var.testnet_name
   }
+
+  timeouts {
+    delete = "15m"
+  }
 }

--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -22,6 +22,13 @@ locals {
     seedPeersURL         = var.seed_peers_url
   }
 
+  healthcheck_vars = {
+    enabled             = var.healthcheck_enabled
+    failureThreshold    = 60
+    periodSeconds       = 5
+    initialDelaySeconds = 30
+  }
+
   seed_vars = {
     testnetName = var.testnet_name
     coda = {
@@ -42,6 +49,8 @@ locals {
       uploadBlocksToGCloud = var.upload_blocks_to_gcloud
     }
 
+    healthcheck = local.healthcheck_vars
+
     seedConfigs = [
       for index, config in var.seed_configs : {
         name             = config.name
@@ -60,6 +69,8 @@ locals {
     testnetName = var.testnet_name
 
     coda = local.coda_vars
+
+    healthcheck = local.healthcheck_vars
 
     userAgent = {
       image         = var.coda_agent_image
@@ -106,6 +117,7 @@ locals {
         runtimeConfig = local.coda_vars.runtimeConfig
         seedPeersURL  = var.seed_peers_url
       }
+      healthcheck = local.healthcheck_vars
       archive     = item
       postgresql = {
         persistence = {
@@ -139,6 +151,7 @@ locals {
   snark_worker_vars = {
     testnetName = var.testnet_name
     coda        = local.coda_vars
+    healthcheck = local.healthcheck_vars
     worker = {
       active      = var.snark_worker_replicas > 0
       numReplicas = var.snark_worker_replicas

--- a/automation/terraform/modules/kubernetes/testnet/variables.tf
+++ b/automation/terraform/modules/kubernetes/testnet/variables.tf
@@ -26,6 +26,11 @@ variable "use_local_charts" {
   default = false
 }
 
+variable "healthcheck_enabled" {
+  type    = bool
+  default = true
+}
+
 variable "deploy_watchdog" {
   type    = bool
   default = true

--- a/automation/terraform/modules/o1-integration/graphql_ingress.tf
+++ b/automation/terraform/modules/o1-integration/graphql_ingress.tf
@@ -1,4 +1,5 @@
 resource "kubernetes_ingress" "testnet_graphql_ingress" {
+  count = var.deploy_graphql_ingress ? 1 : 0
   depends_on = [
     module.kubernetes_testnet.testnet_namespace,
     module.kubernetes_testnet.seeds_release,
@@ -39,11 +40,12 @@ resource "kubernetes_ingress" "testnet_graphql_ingress" {
 }
 
 resource "aws_route53_record" "testnet_graphql_dns" {
+  count = var.deploy_graphql_ingress ? 1 : 0
   depends_on = [kubernetes_ingress.testnet_graphql_ingress]
 
   zone_id = var.aws_route53_zone_id
   name    = "*.${local.base_graphql_dns}"
   type    = "A"
   ttl     = "300"
-  records = [kubernetes_ingress.testnet_graphql_ingress.status[0].load_balancer[0].ingress[0].ip]
+  records = [kubernetes_ingress.testnet_graphql_ingress[0].status[0].load_balancer[0].ingress[0].ip]
 }

--- a/automation/terraform/modules/o1-integration/inputs.tf
+++ b/automation/terraform/modules/o1-integration/inputs.tf
@@ -2,6 +2,10 @@ provider "google" {
   alias = "gke"
 }
 
+variable "deploy_graphql_ingress" {
+  type = bool
+}
+
 variable "aws_route53_zone_id" {
   type = string
 }

--- a/automation/terraform/modules/o1-integration/testnet.tf
+++ b/automation/terraform/modules/o1-integration/testnet.tf
@@ -2,8 +2,9 @@ module "kubernetes_testnet" {
   providers = { google = google.gke }
   source    = "../kubernetes/testnet"
 
-  use_local_charts = true
-  deploy_watchdog  = false
+  use_local_charts    = true
+  healthcheck_enabled = false
+  deploy_watchdog     = false
 
   cluster_name   = var.cluster_name
   cluster_region = var.cluster_region

--- a/buildkite/src/Jobs/Release/MinaArtifact.dhall
+++ b/buildkite/src/Jobs/Release/MinaArtifact.dhall
@@ -32,6 +32,9 @@ Pipeline.build
           S.strictlyStart (S.contains "buildkite/src/Jobs/Release/MinaArtifact"),
           S.exactly "buildkite/scripts/build-artifact" "sh",
           S.exactly "buildkite/scripts/connect-to-testnet-on-develop" "sh",
+          S.exactly "dockerfiles/Dockerfile-coda-daemon" "",
+          S.exactly "dockerfiles/Dockerfile-coda-daemon-puppeteered" "",
+          S.exactly "dockerfiles/coda_daemon_puppeteer" "py",
           S.exactly "dockerfiles/scripts/healthcheck-utilities" "sh",
           S.strictlyStart (S.contains "scripts")
         ],

--- a/dockerfiles/coda_daemon_puppeteer.py
+++ b/dockerfiles/coda_daemon_puppeteer.py
@@ -13,12 +13,27 @@ import signal
 import subprocess
 import sys
 import time
+from socketserver import TCPServer
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+# all signals handled by this program
+ALL_SIGNALS = [signal.SIGCHLD, signal.SIGUSR1, signal.SIGUSR2]
 
 active_daemon_request = False
 inactive_daemon_request = False
 tail_process = None
 mina_process = None
 daemon_args = sys.argv[1:] if len(sys.argv) > 1 else []
+
+TCPServer.allow_reuse_address = True
+HTTPServer.timeout = 1
+
+class MockRequestHandler(BaseHTTPRequestHandler):
+  def do_GET(s):
+    s.send_response(200)
+    s.send_header('Content-Type', 'text/html')
+    s.end_headers()
+    s.wfile.write(b'<html><body>The daemon is currently offline.<br/><i>This broadcast was brought to you by the puppeteer mock server</i></body></html>')
 
 # just nooping on this signal suffices, since merely trapping it will cause
 # `signal.pause()` to resume
@@ -63,32 +78,36 @@ def start_daemon():
   Path('daemon-active').touch()
 
 def stop_daemon():
-  global coda_process
-  coda_process.send_signal(signal.SIGTERM)
+  global mina_process
+  mina_process.send_signal(signal.SIGTERM)
 
-  child_pids = get_child_processes(coda_process.pid)
-  coda_process.wait()
+  child_pids = get_child_processes(mina_process.pid)
+  mina_process.wait()
   for child_pid in child_pids:
       wait_for_pid(child_pid)
   Path('daemon-active').unlink()
-  coda_process = None
+  mina_process = None
 
 # technically, doing the loops like this will eventually result in a stack overflow
 # however, you would need to do a lot of starts and stops to hit this condition
 
 def inactive_loop():
   global active_daemon_request
-  while True:
-    signal.pause()
-    if active_daemon_request:
-      start_daemon()
-      active_daemon_request = False
-      break
+
+  with HTTPServer(('127.0.0.1', 3085), MockRequestHandler) as server:
+    while True:
+      server.handle_request()
+      signal.sigtimedwait(ALL_SIGNALS, 0)
+      if active_daemon_request:
+        start_daemon()
+        active_daemon_request = False
+        break
 
   active_loop()
 
 def active_loop():
   global mina_process, inactive_daemon_request
+
   while True:
     signal.pause()
     status = mina_process.poll()
@@ -123,5 +142,4 @@ if __name__ == '__main__':
       ['tail', '-q', '-f', 'mina.log', '-f', '.mina-config/mina-prover.log', '-f', '.mina-config/mina-verifier.log', '-f' , '.mina-config/mina-best-tip.log']
   )
 
-  start_daemon()
-  active_loop()
+  inactive_loop()

--- a/src/app/test_executive/archive_node_test.ml
+++ b/src/app/test_executive/archive_node_test.ml
@@ -17,8 +17,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   let config =
     let open Test_config in
     { default with
-      (* a few block producers, where few = 4 *)
-      block_producers=
+      requires_graphql= true (* a few block producers, where few = 4 *)
+    ; block_producers=
         [ {balance= "4000"; timing= Untimed}
         ; {balance= "9000"; timing= Untimed}
         ; {balance= "8000"; timing= Untimed}

--- a/src/app/test_executive/archive_node_test.mli
+++ b/src/app/test_executive/archive_node_test.mli
@@ -1,0 +1,1 @@
+module Make : Integration_test_lib.Intf.Test.Functor_intf

--- a/src/app/test_executive/payments_timed_accounts_test.ml
+++ b/src/app/test_executive/payments_timed_accounts_test.ml
@@ -37,7 +37,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ~vesting_period:1 ~vesting_increment:500_000_000_000
     in
     { default with
-      block_producers=
+      requires_graphql= true
+    ; block_producers=
         [ {balance= block_producer_balance; timing= timing1}
         ; {balance= block_producer_balance; timing= timing2} ] }
 

--- a/src/app/test_executive/peers_test.ml
+++ b/src/app/test_executive/peers_test.ml
@@ -26,7 +26,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; vesting_increment= Amount.of_int 50_000_000_000 }
     in
     { default with
-      block_producers=
+      requires_graphql= true
+    ; block_producers=
         [ {balance= "1000"; timing}
         ; {balance= "1000"; timing}
         ; {balance= "1000"; timing} ]

--- a/src/app/test_executive/send_payment_test.ml
+++ b/src/app/test_executive/send_payment_test.ml
@@ -15,7 +15,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   let config =
     let open Test_config in
     { default with
-      block_producers=
+      requires_graphql= true
+    ; block_producers=
         [{balance= "4000"; timing= Untimed}; {balance= "3000"; timing= Untimed}]
     ; num_snark_workers= 0 }
 

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -303,12 +303,7 @@ let main inputs =
         let%bind network, dsl =
           Deferred.bind init_result ~f:Malleable_error.of_or_error_hard
         in
-        let%bind () =
-          Engine.Network.all_nodes network
-          (* TODO: parallelize (requires accumlative hard errors) *)
-          |> Malleable_error.List.iter
-               ~f:(Engine.Network.Node.start ~fresh_state:false)
-        in
+        let%bind () = Engine.Network.initialize ~logger network in
         T.run network dsl )
   in
   let exit_reason, test_result =

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -303,6 +303,12 @@ let main inputs =
         let%bind network, dsl =
           Deferred.bind init_result ~f:Malleable_error.of_or_error_hard
         in
+        let%bind () =
+          Engine.Network.all_nodes network
+          (* TODO: parallelize (requires accumlative hard errors) *)
+          |> Malleable_error.List.iter
+               ~f:(Engine.Network.Node.start ~fresh_state:false)
+        in
         T.run network dsl )
   in
   let exit_reason, test_result =

--- a/src/lib/integration_test_cloud_engine/coda_automation.ml
+++ b/src/lib/integration_test_cloud_engine/coda_automation.ml
@@ -370,7 +370,11 @@ module Network_manager = struct
             (String.length network_config.terraform.snark_worker_public_key - 6)
           ~len:6
     in
-    let snark_coordinator_nodes = [cons_node snark_coordinator_name None] in
+    let snark_coordinator_nodes =
+      if network_config.terraform.snark_worker_replicas > 0 then
+        [cons_node snark_coordinator_name None]
+      else []
+    in
     let block_producer_nodes =
       List.map network_config.terraform.block_producer_configs
         ~f:(fun bp_config -> cons_node bp_config.name (Some bp_config.keypair)
@@ -418,6 +422,7 @@ module Network_manager = struct
     let result =
       { Kubernetes_network.namespace= t.namespace
       ; constants= t.constants
+      ; seeds= t.seed_nodes
       ; block_producers= t.block_producer_nodes
       ; snark_coordinators= t.snark_coordinator_nodes
       ; archive_nodes= t.archive_nodes

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -440,6 +440,7 @@ end
 type t =
   { namespace: string
   ; constants: Test_config.constants
+  ; seeds: Node.t list
   ; block_producers: Node.t list
   ; snark_coordinators: Node.t list
   ; archive_nodes: Node.t list
@@ -453,15 +454,18 @@ let constraint_constants {constants; _} = constants.constraints
 
 let genesis_constants {constants; _} = constants.genesis
 
+let seeds {seeds; _} = seeds
+
 let block_producers {block_producers; _} = block_producers
 
 let snark_coordinators {snark_coordinators; _} = snark_coordinators
 
 let archive_nodes {archive_nodes; _} = archive_nodes
 
-let keypairs {keypairs; _} = keypairs
+(* TODO: snark workers (until then, pretty sure snark work won't be done) *)
+let all_nodes {seeds; block_producers; snark_coordinators; archive_nodes; _} =
+  List.concat [seeds; block_producers; snark_coordinators; archive_nodes]
 
-let all_nodes {block_producers; snark_coordinators; archive_nodes; _} =
-  block_producers @ snark_coordinators @ archive_nodes
+let keypairs {keypairs; _} = keypairs
 
 let lookup_node_by_app_id t = Map.find t.nodes_by_app_id

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -161,6 +161,7 @@ module Subscription = struct
     in
     let topic = name ^ "_topic" in
     let sink = name ^ "_sink" in
+    (* TODO: check if exists, delete old one, create new one always *)
     let%bind _ = create_topic topic in
     let%bind _ = create_sink ~topic ~filter ~key ~logger sink in
     let%map _ = create_subscription name topic in

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -161,7 +161,6 @@ module Subscription = struct
     in
     let topic = name ^ "_topic" in
     let sink = name ^ "_sink" in
-    (* TODO: check if exists, delete old one, create new one always *)
     let%bind _ = create_topic topic in
     let%bind _ = create_sink ~topic ~filter ~key ~logger sink in
     let%map _ = create_subscription name topic in
@@ -171,24 +170,22 @@ module Subscription = struct
     {name; topic; sink}
 
   let delete t =
-    let open Deferred.Or_error.Let_syntax in
-    let delete_subscription =
+    let open Deferred.Let_syntax in
+    let%bind delete_subscription_res =
       run_cmd_or_error "." prog
         ["pubsub"; "subscriptions"; "delete"; t.name; "--project"; project_id]
     in
-    let delete_sink =
+    let%bind delete_sink_res =
       run_cmd_or_error "." prog
         ["logging"; "sinks"; "delete"; t.sink; "--project"; project_id]
     in
-    let delete_topic =
+    let%map delete_topic_res =
       run_cmd_or_error "." prog
         ["pubsub"; "topics"; "delete"; t.topic; "--project"; project_id]
     in
-    let%map _ =
-      Deferred.Or_error.combine_errors
-        [delete_subscription; delete_sink; delete_topic]
-    in
-    ()
+    Or_error.combine_errors
+      [delete_subscription_res; delete_sink_res; delete_topic_res]
+    |> Or_error.map ~f:(Fn.const ())
 
   let pull ~logger t =
     let open Deferred.Or_error.Let_syntax in

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -87,6 +87,8 @@ module Engine = struct
     val all_nodes : t -> Node.t list
 
     val keypairs : t -> Signature_lib.Keypair.t list
+
+    val initialize : logger:Logger.t -> t -> unit Malleable_error.t
   end
 
   module type Network_manager_intf = sig

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -76,11 +76,15 @@ module Engine = struct
 
     val genesis_constants : t -> Genesis_constants.t
 
+    val seeds : t -> Node.t list
+
     val block_producers : t -> Node.t list
 
     val snark_coordinators : t -> Node.t list
 
     val archive_nodes : t -> Node.t list
+
+    val all_nodes : t -> Node.t list
 
     val keypairs : t -> Signature_lib.Keypair.t list
   end

--- a/src/lib/integration_test_lib/test_config.ml
+++ b/src/lib/integration_test_lib/test_config.ml
@@ -17,7 +17,9 @@ type constants =
 [@@deriving to_yojson]
 
 type t =
-  { k: int
+  { (* temporary flag to enable/disable graphql ingress deployments *)
+    requires_graphql: bool
+  ; k: int
   ; delta: int
   ; slots_per_epoch: int
   ; slots_per_sub_window: int
@@ -31,7 +33,8 @@ type t =
   ; snark_worker_public_key: string }
 
 let default =
-  { k= 20
+  { requires_graphql= false
+  ; k= 20
   ; slots_per_epoch= 3 * 8 * 20
   ; slots_per_sub_window= 2
   ; delta= 0


### PR DESCRIPTION
This PR contains a variety of fixes to the integration test framework to address recent issues. Fixes included:

- graphql ingress race condition (nodes failing to initialize, but initialization log is present)
- context deadline timeout on network destructions
- skip deploying graphql ingresses for tests that do not require it
- pod assignment race condition (very rare, but became more frequent with changes introduced in this PR)
- seed node artifact generation race condition (nodes failing to initialize, unable to find initial peers and restart in time)