### PR TITLE
add transaction rejected event type integration test framework side

### DIFF
--- a/src/app/test_executive/payments_timed_accounts_test.ml
+++ b/src/app/test_executive/payments_timed_accounts_test.ml
@@ -104,6 +104,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       | Error {hard_error= {error; _}; soft_errors= _} ->
           (* expect GraphQL error due to insufficient funds *)
           let err_str = Error.to_string_mach error in
+          [%log info] "err_str: %s" err_str ;
           let err_str_lowercase = String.lowercase err_str in
           if
             String.is_substring ~substring:"insufficient_funds"
@@ -118,5 +119,5 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             Malleable_error.of_string_hard_error_format
               "Payment failed for unexpected reason: %s" err_str )
     in
-    [%log info] "Payment test with timed accounts completed"
+    [%log info] "Payment test with timed accounts completed succesfully!"
 end

--- a/src/app/test_executive/payments_timed_accounts_test.ml
+++ b/src/app/test_executive/payments_timed_accounts_test.ml
@@ -40,7 +40,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       requires_graphql= true
     ; block_producers=
         [ {balance= block_producer_balance; timing= timing1}
-        ; {balance= block_producer_balance; timing= timing2} ] }
+        ; {balance= block_producer_balance; timing= timing2} ]
+    ; num_snark_workers= 0 }
 
   let expected_error_event_reprs =
     let open Network_pool.Transaction_pool in

--- a/src/lib/integration_test_cloud_engine/coda_automation.ml
+++ b/src/lib/integration_test_cloud_engine/coda_automation.ml
@@ -391,11 +391,7 @@ module Network_manager = struct
     in
     let archive_nodes =
       List.init network_config.terraform.archive_node_count ~f:(fun i ->
-<<<<<<< HEAD
           cons_node (sprintf "archive-%d" (i + 1)) "archive" None )
-=======
-          cons_node (sprintf "archive-%d-postgresql" (i + 1)) None )
->>>>>>> debugging
     in
     let nodes_by_app_id =
       let all_nodes =

--- a/src/lib/integration_test_cloud_engine/coda_automation.ml
+++ b/src/lib/integration_test_cloud_engine/coda_automation.ml
@@ -391,7 +391,11 @@ module Network_manager = struct
     in
     let archive_nodes =
       List.init network_config.terraform.archive_node_count ~f:(fun i ->
+<<<<<<< HEAD
           cons_node (sprintf "archive-%d" (i + 1)) "archive" None )
+=======
+          cons_node (sprintf "archive-%d-postgresql" (i + 1)) None )
+>>>>>>> debugging
     in
     let nodes_by_app_id =
       let all_nodes =

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -510,7 +510,7 @@ let lookup_node_by_app_id t = Map.find t.nodes_by_app_id
 let initialize ~logger network =
   let open Malleable_error.Let_syntax in
   let poll_interval = Time.Span.of_sec 15.0 in
-  let max_polls = 60 (* 15 mins *) in
+  let max_polls = 120 (* 30 mins *) in
   let all_pods =
     all_nodes network
     |> List.map ~f:(fun {pod_id; _} -> pod_id)

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -202,16 +202,20 @@ module Transaction_rejected = struct
       Network_pool.Transaction_pool
       .rejecting_command_for_reason_structured_events_id
 
-  type t = {command: User_command.Valid.t With_status.t list}
+  type t = unit [@@deriving to_yojson]
+
+  let parse = Fn.const (Or_error.return ())
+
+  (* type t = {command: User_command.Valid.t With_status.t list}
   [@@deriving to_yojson]
 
   let parse message =
     let open Json_parsing in
     let open Or_error.Let_syntax in
     let%map command =
-      get_metadata message "command" >>= parse valid_commands_with_statuses
+      get_metadata message "message" >>= parse valid_commands_with_statuses
     in
-    {command}
+    {command} *)
 end
 
 type 'a t =

--- a/src/lib/integration_test_lib/event_type.mli
+++ b/src/lib/integration_test_lib/event_type.mli
@@ -63,7 +63,7 @@ module Breadcrumb_added : sig
 end
 
 module Transaction_rejected : sig
-  type t = {command: User_command.Valid.t With_status.t list}
+  type t = unit
 
   include Event_type_intf with type t := t
 end

--- a/src/lib/integration_test_lib/event_type.mli
+++ b/src/lib/integration_test_lib/event_type.mli
@@ -62,6 +62,12 @@ module Breadcrumb_added : sig
   include Event_type_intf with type t := t
 end
 
+module Transaction_rejected : sig
+  type t = {command: User_command.Valid.t With_status.t list}
+
+  include Event_type_intf with type t := t
+end
+
 type 'a t =
   | Log_error : Log_error.t t
   | Node_initialization : Node_initialization.t t
@@ -69,6 +75,7 @@ type 'a t =
       : Transition_frontier_diff_application.t t
   | Block_produced : Block_produced.t t
   | Breadcrumb_added : Breadcrumb_added.t t
+  | Transaction_rejected : Transaction_rejected.t t
 
 val to_string : 'a t -> string
 


### PR DESCRIPTION
the `Rejecting_command_for_reason` structured event type isn't actually registered integration test side, and should be.  pmt timed acct test depends on this feature