### PR TITLE
Only execute integration tests on developer/non-mainline branch CI runs

### DIFF
--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -33,7 +33,8 @@ in
             ],
         label = "Build test-executive",
         key = "build-test-executive",
-        target = Size.XLarge
+        target = Size.XLarge,
+        if = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'"
       },
 
   execute = \(testName : Text) -> \(dependsOn : List Command.TaggedKey.Type) ->
@@ -53,6 +54,7 @@ in
         label = "${testName} integration test",
         key = "integration-test-${testName}",
         target = Size.Medium,
-        depends_on = dependsOn
+        depends_on = dependsOn,
+        if = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'"
       }
 }

--- a/buildkite/src/Jobs/Lint/TestnetAlerts.dhall
+++ b/buildkite/src/Jobs/Lint/TestnetAlerts.dhall
@@ -41,7 +41,6 @@ Pipeline.build
           , label = "Lint Testnet alert rules"
           , key = "lint-testnet-alerts"
           , target = Size.Small
-          , soft_fail = Some (B/SoftFail.Boolean True)
           , docker = None Docker.Type
         }
     ]

--- a/buildkite/src/Jobs/Release/TestnetAlerts.dhall
+++ b/buildkite/src/Jobs/Release/TestnetAlerts.dhall
@@ -38,7 +38,6 @@ Pipeline.build
           , key = "deploy-testnet-alerts"
           , target = Size.Medium
           , depends_on = [ { name = "TestnetAlerts", key = "lint-testnet-alerts" } ]
-          , soft_fail = Some (B/SoftFail.Boolean True)
           , docker = None Docker.Type
         }
     ]


### PR DESCRIPTION
Also remove `soft-fails` from testnet alert CI jobs since failures should now be blockers.

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: