### PR TITLE
[TRIVIAL] Don't print a large error in the pretty logs for missing config files

### DIFF
--- a/src/app/cli/src/mina.ml
+++ b/src/app/cli/src/mina.ml
@@ -612,8 +612,7 @@ let setup_daemon logger =
                     "The configuration file %s could not be read:\n%s"
                     config_file (Error.to_string_hum err)
               | `May_be_missing ->
-                  [%log warn]
-                    "Could not read configuration from $config_file: $error"
+                  [%log warn] "Could not read configuration from $config_file"
                     ~metadata:
                       [ ("config_file", `String config_file)
                       ; ("error", Error_json.error_to_yojson err) ] ;


### PR DESCRIPTION
This removes the `$error` interpolation from a log message where the error is not usually useful for the user. This changes the startup logs from
```
$ _build/default/src/app/cli/src/mina.exe daemon -seed
2021-03-15 23:17:59 UTC [Info] Coda daemon is booting up; built with commit "48401e92d94948c066c03ca76326c065e5cbfc92" on branch "feature/catch-seed-list-url-errors"
2021-03-15 23:17:59 UTC [Info] Created daemon lockfile "/home/matthew/.mina-config/.mina-lock"
2021-03-15 23:17:59 UTC [Info] Registering async shutdown handler: "Remove daemon lockfile"
2021-03-15 23:17:59 UTC [Info] Booting may take several seconds, please wait
2021-03-15 23:17:59 UTC [Info] Reading configuration files [ "/home/matthew/.mina-config/daemon.json" ]
2021-03-15 23:17:59 UTC [Warn] Could not read configuration from "/home/matthew/.mina-config/daemon.json": $error
        error: {
  "commit_id": "48401e92d94948c066c03ca76326c065e5cbfc92",
  "exn_name": "Async_kernel__Monitor.Error_",
  "exn": [
    "monitor.ml.Error",
    [
      "Unix.Unix_error", "No such file or directory", "open",
      "((filename /home/matthew/.mina-config/daemon.json) (mode (O_RDONLY O_CLOEXEC)) (perm 0o0))"
    ],
    [
      "Raised at file \"src/result.ml\", line 158, characters 17-26",
      "Called from file \"src/deferred1.ml\", line 17, characters 40-45",
      "Called from file \"src/job_queue.ml\" (inlined), line 131, characters 2-5",
      "Called from file \"src/job_queue.ml\", line 171, characters 6-47",
      "Caught by monitor try_with_or_error"
    ]
  ]
}
2021-03-15 23:17:59 UTC [Info] Initializing with runtime configuration. Ledger name: null
2021-03-15 23:17:59 UTC [Info] Using the compiled constraint constants
2021-03-15 23:17:59 UTC [Info] Found genesis proof file at $path
        path: "/home/matthew/.mina-config/genesis/genesis_proof_6a58187abb23eeff53488b4c53c13ca7290f8c28006c93dc59f4216f94463d2d"
2021-03-15 23:17:59 UTC [Info] Loaded ledger from $ledger_file and genesis proof from $proof_file
        ledger_file: "/home/matthew/.mina-config/genesis/genesis_ledger_test_aa18bcdc63c20e16897300c1d05b71170080d3f8eaad4b2b6a492ac5694c98c8.tar.gz"
        proof_file: "/home/matthew/.mina-config/genesis/genesis_proof_6a58187abb23eeff53488b4c53c13ca7290f8c28006c93dc59f4216f94463d2d"
2021-03-15 23:17:59 UTC [Info] Cleaning up old epoch ledgers with genesis state $state_hash at locations $staking and $next
        state_hash: "3NKjfe8qKZfpzGdP53ycKwLxZ4kbA856zBr5Hrq3HAyREVXkEB8b"
        staking: "/home/matthew/.mina-config/epoch_ledgerdd86ee3e-4bcb-3808-9930-f5e1d28f7165"
        next: "/home/matthew/.mina-config/epoch_ledger4498c61b-c1cb-3031-db44-d1628eb0d8e6"
2021-03-15 23:17:59 UTC [Info] Starting node as a seed node
2021-03-15 23:17:59 UTC [Info] Setting current protocol version to "2.0.0" from config
2021-03-15 23:18:00 UTC [Info] Daemon started process of kind "Prover" with pid 20419
2021-03-15 23:18:00 UTC [Info] Registering async shutdown handler: "Close transition frontier, if exists"
2021-03-15 23:18:00 UTC [Info] libp2p peer ID this session is $peer_id
        peer_id: "12D3KooWED5aukSFiuCt2jYNg4jeEjVbZ9ML5cpXvZCNuXMGCGuM"
2021-03-15 23:18:00 UTC [Info] Network not instantiated when node status requested
2021-03-15 23:18:00 UTC [Warn] GCLOUD_KEYFILE environment variable not set. Must be set to use upload_blocks_to_gcloud
2021-03-15 23:18:00 UTC [Info] Mina daemon is connecting
```
to
```
$ _build/default/src/app/cli/src/mina.exe daemon -seed
2021-03-15 23:23:54 UTC [Info] Coda daemon is booting up; built with commit "48401e92d94948c066c03ca76326c065e5cbfc92" on branch "feature/unnoisy-config-logs"
2021-03-15 23:23:54 UTC [Info] Created daemon lockfile "/home/matthew/.mina-config/.mina-lock"
2021-03-15 23:23:54 UTC [Info] Registering async shutdown handler: "Remove daemon lockfile"
2021-03-15 23:23:54 UTC [Info] Booting may take several seconds, please wait
2021-03-15 23:23:54 UTC [Info] Reading configuration files [ "/home/matthew/.mina-config/daemon.json" ]
2021-03-15 23:23:54 UTC [Warn] Could not read configuration from "/home/matthew/.mina-config/daemon.json"
2021-03-15 23:23:54 UTC [Info] Initializing with runtime configuration. Ledger name: null
2021-03-15 23:23:54 UTC [Info] Using the compiled constraint constants
2021-03-15 23:23:54 UTC [Info] Found genesis proof file at $path
        path: "/home/matthew/.mina-config/genesis/genesis_proof_6a58187abb23eeff53488b4c53c13ca7290f8c28006c93dc59f4216f94463d2d"
2021-03-15 23:23:54 UTC [Info] Loaded ledger from $ledger_file and genesis proof from $proof_file
        ledger_file: "/home/matthew/.mina-config/genesis/genesis_ledger_test_aa18bcdc63c20e16897300c1d05b71170080d3f8eaad4b2b6a492ac5694c98c8.tar.gz"
        proof_file: "/home/matthew/.mina-config/genesis/genesis_proof_6a58187abb23eeff53488b4c53c13ca7290f8c28006c93dc59f4216f94463d2d"
2021-03-15 23:23:54 UTC [Info] Cleaning up old epoch ledgers with genesis state $state_hash at locations $staking and $next
        state_hash: "3NLnNpAw6TPQDwLeyMXrzPe5FjNRiNRUwhT8xo77ZyNkdk2Ed6jF"
        staking: "/home/matthew/.mina-config/epoch_ledger105d4ee0-2df2-3efd-6180-d2f8cdee0022"
        next: "/home/matthew/.mina-config/epoch_ledger6e038c71-922e-36cf-af69-4fc0991c8429"
2021-03-15 23:23:54 UTC [Info] Starting node as a seed node
2021-03-15 23:23:54 UTC [Info] Setting current protocol version to "2.0.0" from config
2021-03-15 23:23:54 UTC [Info] Daemon started process of kind "Prover" with pid 22382
2021-03-15 23:23:54 UTC [Info] Registering async shutdown handler: "Close transition frontier, if exists"
2021-03-15 23:23:55 UTC [Info] libp2p peer ID this session is $peer_id
        peer_id: "12D3KooWLaHeYCFjj444VZ1X7L9pWiiDYLUyGcP9SyoM9yKPSb4D"
2021-03-15 23:23:55 UTC [Info] Network not instantiated when node status requested
2021-03-15 23:23:55 UTC [Warn] GCLOUD_KEYFILE environment variable not set. Must be set to use upload_blocks_to_gcloud
2021-03-15 23:23:55 UTC [Info] Mina daemon is connecting
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: