### PR TITLE
Integration tests: retry creating subscriptions after a cleanup

### DIFF
--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -132,6 +132,11 @@ module Subscription = struct
     | None ->
         Deferred.Or_error.ok_unit
 
+  let resource_names name : t =
+    let topic = name ^ "_topic" in
+    let sink = name ^ "_sink" in
+    {name; topic; sink}
+
   let create ~name ~filter ~logger =
     let open Deferred.Or_error.Let_syntax in
     let gcloud_key_file_env = "GCLOUD_API_KEY" in
@@ -159,15 +164,14 @@ module Subscription = struct
         ; "--topic-project"
         ; project_id ]
     in
-    let topic = name ^ "_topic" in
-    let sink = name ^ "_sink" in
-    let%bind _ = create_topic topic in
-    let%bind _ = create_sink ~topic ~filter ~key ~logger sink in
-    let%map _ = create_subscription name topic in
+    let t = resource_names name in
+    let%bind _ = create_topic t.topic in
+    let%bind _ = create_sink ~topic:t.topic ~filter ~key ~logger t.sink in
+    let%map _ = create_subscription name t.topic in
     [%log debug]
       "Succesfully created subscription \"$name\" to topic \"$topic\""
-      ~metadata:[("name", `String name); ("topic", `String topic)] ;
-    {name; topic; sink}
+      ~metadata:[("name", `String name); ("topic", `String t.topic)] ;
+    t
 
   let delete t =
     let open Deferred.Or_error.Let_syntax in
@@ -188,6 +192,25 @@ module Subscription = struct
         [delete_subscription; delete_sink; delete_topic]
     in
     ()
+
+  let cleanup name =
+    let t = resource_names name in
+    delete t
+
+  let create_with_retry ~name ~filter ~logger =
+    let open Deferred.Let_syntax in
+    let create () = create ~logger ~name ~filter in
+    match%bind create () with
+    | Error e ->
+        [%log error]
+          "Failed to created stackdriver subscription: $error. Cleaning up \
+           existing pubsub resources (topic, subscription, sink) and \
+           retrying.."
+          ~metadata:[("error", `String (Error.to_string_hum e))] ;
+        let%bind _ = cleanup name in
+        create ()
+    | Ok res ->
+        Deferred.Or_error.return res
 
   let pull ~logger t =
     let open Deferred.Or_error.Let_syntax in
@@ -280,7 +303,8 @@ let create ~logger ~(network : Kubernetes_network.t) =
     String.concat filters ~sep:"\n"
   in
   let%map subscription =
-    Subscription.create ~logger ~name:network.namespace ~filter:log_filter
+    Subscription.create_with_retry ~logger ~name:network.namespace
+      ~filter:log_filter
   in
   [%log info] "Event subscription created" ;
   let event_reader, event_writer = Pipe.create () in


### PR DESCRIPTION
If the test fails to create pubsub resources (sink, topic, subscription) then clean up and retry once more. This will ensure the resources that were not cleaned up in the previous run does not fail the new run.

Closes #8276

