### PR TITLE
Accept transactions by ID in pooledUserCommands

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2802,43 +2802,72 @@ module Queries = struct
           [ arg "publicKey" ~doc:"Public key of sender of pooled user commands"
               ~typ:Types.Input.public_key_arg
           ; arg "hashes" ~doc:"Hashes of the commands to find in the pool"
-              ~typ:(list (non_null string)) ]
-      ~resolve:(fun {ctx= coda; _} () opt_pk opt_hashes ->
+              ~typ:(list (non_null string))
+          ; arg "ids" ~typ:(list (non_null guid)) ~doc:"Ids of UserCommands" ]
+      ~resolve:(fun {ctx= coda; _} () opt_pk opt_hashes opt_txns ->
         let transaction_pool = Mina_lib.transaction_pool coda in
         let resource_pool =
           Network_pool.Transaction_pool.resource_pool transaction_pool
         in
-        ( match (opt_pk, opt_hashes) with
-        | None, None ->
+        ( match (opt_pk, opt_hashes, opt_txns) with
+        | None, None, None ->
             Network_pool.Transaction_pool.Resource_pool.get_all resource_pool
-        | Some pk, None ->
+        | Some pk, None, None ->
             let account_id = Account_id.create pk Token_id.default in
             Network_pool.Transaction_pool.Resource_pool.all_from_account
               resource_pool account_id
-        | _, Some hashes ->
-            List.filter_map hashes ~f:(fun hash ->
-                let txn =
-                  hash |> Transaction_hash.of_base58_check
-                  |> Result.map
-                       ~f:
-                         (Network_pool.Transaction_pool.Resource_pool
-                          .find_by_hash resource_pool)
-                in
-                match (txn, opt_pk) with
-                | Ok (Some txn), Some pk ->
-                    (* Filter by fee-payer pk. *)
-                    if
-                      txn
-                      |> Transaction_hash.User_command_with_valid_signature
-                         .command |> User_command.fee_payer
-                      |> Account_id.public_key
-                      |> Public_key.Compressed.equal pk
-                    then Some txn
-                    else None
-                | Ok (Some txn), None ->
-                    Some txn
-                | _ ->
-                    None ) )
+        | _ -> (
+            let hashes_txns =
+              (* Transactions identified by hashes. *)
+              match opt_hashes with
+              | Some hashes ->
+                  List.filter_map hashes ~f:(fun hash ->
+                      hash |> Transaction_hash.of_base58_check |> Result.ok
+                      |> Option.bind
+                           ~f:
+                             (Network_pool.Transaction_pool.Resource_pool
+                              .find_by_hash resource_pool) )
+              | None ->
+                  []
+            in
+            let txns =
+              (* Transactions as identified by IDs.
+                 This is a little redundant, but it makes our API more
+                 consistent.
+              *)
+              match opt_txns with
+              | Some txns ->
+                  List.filter_map txns ~f:(fun serialized_txn ->
+                      Signed_command.of_base58_check serialized_txn
+                      |> Result.map ~f:(fun signed_command ->
+                             (* These commands get piped through [forget_check]
+                                below; this is just to make the types work
+                                without extra unnecessary mapping in the other
+                                branches above.
+                             *)
+                             let (`If_this_is_used_it_should_have_a_comment_justifying_it
+                                   cmd) =
+                               User_command.to_valid_unsafe
+                                 (Signed_command signed_command)
+                             in
+                             Transaction_hash.User_command_with_valid_signature
+                             .create cmd )
+                      |> Result.ok )
+              | None ->
+                  []
+            in
+            let all_txns = hashes_txns @ txns in
+            match opt_pk with
+            | None ->
+                all_txns
+            | Some pk ->
+                (* Only return commands paid for by the given public key. *)
+                List.filter all_txns ~f:(fun txn ->
+                    txn
+                    |> Transaction_hash.User_command_with_valid_signature
+                       .command |> User_command.fee_payer
+                    |> Account_id.public_key
+                    |> Public_key.Compressed.equal pk ) ) )
         |> List.filter_map ~f:(fun x ->
                let x =
                  Transaction_hash.User_command_with_valid_signature


### PR DESCRIPTION
This allows `pooledUserCommands` to accept transactions encoded with either hashes or ids, to make them more consistent with `transactionStatus`.

This also can be used to get the hash of a transaction from its ID via GraphQL: you can send the transaction as an ID and query its hash in the output.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #8244
