### PR TITLE
s/multi-user/default/ on systemd user service

### DIFF
--- a/scripts/mina.service
+++ b/scripts/mina.service
@@ -18,4 +18,4 @@ ExecStart=/usr/local/bin/mina daemon \
 ExecStop=/usr/local/bin/mina client stop-daemon
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
### Explain your changes here.

`multi-user.target` apparently only exists for system services.
For user services, the desired target is `default.target`.

This should fix mina not starting automatically at boot.

Further information here: <https://unix.stackexchange.com/q/251211>

### Explain how you tested your changes here.

Prior to the change, the daemon did not start at boot and I had to run `systemctl --user start mina`.

After the change, I rebooted my node and confirmed that mina was running at boot.