### PR TITLE
Add unable to cover account creation checks to GraphQL

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -2477,6 +2477,16 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "ignoreWarnings",
+                  "description": "When true the payment will be attempted even if we anticipate an error (defaults to false)",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -9181,6 +9191,16 @@
                       "name": "SendPaymentInput",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "ignoreWarnings",
+                  "description": "When true warnings will be ignored when validating the payment (defaults to true)",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -90,10 +90,10 @@ module Snark_pool =
 {|
 query snarkPool {
   snarkPool {
-  fee @bsDecoder(fn: "Decoders.uint64")
-  prover @bsDecoder(fn: "Decoders.public_key")
-  work_ids: workIds
-}
+    fee @bsDecoder(fn: "Decoders.uint64")
+    prover @bsDecoder(fn: "Decoders.public_key")
+    work_ids: workIds
+  }
 }
 |}]
 
@@ -111,9 +111,9 @@ query pendingSnarkWork {
       }
       supply_increase: supplyIncrease @bsDecoder(fn: "Decoders.uint64")
       work_id: workId
-      }
     }
   }
+}
 |}]
 
 module Set_staking =
@@ -124,8 +124,8 @@ mutation ($public_key: PublicKey) {
     lastStaking @bsDecoder(fn: "Decoders.public_key_array")
     lockedPublicKeys @bsDecoder(fn: "Decoders.public_key_array")
     currentStakingKeys @bsDecoder(fn: "Decoders.public_key_array")
-    }
   }
+}
 |}]
 
 module Set_coinbase_receiver =
@@ -144,9 +144,9 @@ module Set_snark_worker =
 {|
 mutation ($public_key: PublicKey) {
   setSnarkWorker (input : {publicKey: $public_key}) {
-      lastSnarkWorker @bsDecoder(fn: "Decoders.optional_public_key")
-    }
+    lastSnarkWorker @bsDecoder(fn: "Decoders.optional_public_key")
   }
+}
 |}]
 
 module Set_snark_work_fee =
@@ -155,7 +155,7 @@ module Set_snark_work_fee =
 mutation ($fee: UInt64!) {
   setSnarkWorkFee(input: {fee: $fee}) {
     lastFee @bsDecoder(fn: "Decoders.uint64")
-    }
+  }
 }
 |}]
 
@@ -165,7 +165,8 @@ module Send_payment =
 mutation ($sender: PublicKey!,
           $receiver: PublicKey!,
           $amount: UInt64!,
-          $token: UInt64,                                                                                                                                                                                                                              $fee: UInt64!,
+          $token: UInt64,
+          $fee: UInt64!,
           $nonce: UInt32,
           $memo: String) {
   sendPayment(input:
@@ -339,7 +340,7 @@ module Archive_precomputed_block =
 {|
 mutation ($block: PrecomputedBlock!) {
   archivePrecomputedBlock(block: $block) {
-      applied
+    applied
   }
 }
 |}]
@@ -349,7 +350,7 @@ module Archive_extensional_block =
 {|
 mutation ($block: ExtensionalBlock!) {
   archiveExtensionalBlock(block: $block) {
-      applied
+    applied
   }
 }
 |}]

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -170,7 +170,8 @@ mutation ($sender: PublicKey!,
           $nonce: UInt32,
           $memo: String) {
   sendPayment(input:
-    {from: $sender, to: $receiver, amount: $amount, token: $token, fee: $fee, nonce: $nonce, memo: $memo}) {
+    {from: $sender, to: $receiver, amount: $amount, token: $token, fee: $fee, nonce: $nonce, memo: $memo},
+    ignoreWarnings: true) {
     payment {
       id
     }

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -168,10 +168,11 @@ mutation ($sender: PublicKey!,
           $token: UInt64,
           $fee: UInt64!,
           $nonce: UInt32,
-          $memo: String) {
+          $memo: String,
+          $ignore_warnings: Boolean!) {
   sendPayment(input:
     {from: $sender, to: $receiver, amount: $amount, token: $token, fee: $fee, nonce: $nonce, memo: $memo},
-    ignoreWarnings: true) {
+    ignoreWarnings: $ignore_warnings) {
     payment {
       id
     }

--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -35,14 +35,18 @@ module Validate_payment =
 [%graphql
 {|
   query validate($from: PublicKey!, $to_: PublicKey!, $token: UInt64, $amount: UInt64, $fee: UInt64, $validUntil: UInt64, $memo: String, $nonce: UInt32!, $signature: String!) {
-    validatePayment(signature: {rawSignature: $signature}, input: {from: $from, to:$to_, token:$token, amount:$amount, fee:$fee, validUntil: $validUntil, memo: $memo, nonce:$nonce}) }
+    validatePayment(signature: {rawSignature: $signature},
+                    input: {from: $from, to:$to_, token:$token, amount:$amount, fee:$fee, validUntil: $validUntil, memo: $memo, nonce:$nonce},
+                    ignoreWarnings: true) }
   |}]
 
 module Send_payment =
 [%graphql
 {|
   mutation send($from: PublicKey!, $to_: PublicKey!, $token: UInt64, $amount: UInt64, $fee: UInt64, $validUntil: UInt64, $memo: String, $nonce: UInt32!, $signature: String!) {
-    sendPayment(signature: {rawSignature: $signature}, input: {from: $from, to:$to_, token:$token, amount:$amount, fee:$fee, validUntil: $validUntil, memo: $memo, nonce:$nonce}) {
+    sendPayment(signature: {rawSignature: $signature},
+                input: {from: $from, to:$to_, token:$token, amount:$amount, fee:$fee, validUntil: $validUntil, memo: $memo, nonce:$nonce},
+                ignoreWarnings: true) {
       payment {
         hash
       }

--- a/src/app/rosetta/test-agent/poke.ml
+++ b/src/app/rosetta/test-agent/poke.ml
@@ -68,7 +68,9 @@ module SendTransaction = struct
   [%graphql
   {|
     mutation sendPayment($fee: UInt64!, $amount: UInt64!, $token: TokenId, $to_: PublicKey!, $from: PublicKey!) {
-      sendPayment(input: {fee: $fee, amount: $amount, token: $token, to: $to_, from: $from}, signature: null) {
+      sendPayment(input: {fee: $fee, amount: $amount, token: $token, to: $to_, from: $from},
+                  signature: null,
+                  ignoreWarnings: true) {
         payment {
           hash
         }

--- a/src/app/rosetta/test-agent/poke.ml
+++ b/src/app/rosetta/test-agent/poke.ml
@@ -27,12 +27,12 @@ module Staking = struct
   module Enable =
   [%graphql
   {|
-  mutation enableStaking($publicKey: PublicKey!) {
+    mutation enableStaking($publicKey: PublicKey!) {
       setStaking(input: {publicKeys: [$publicKey]}) {
         lastStaking
       }
     }
-|}]
+  |}]
 
   let enable ~graphql_uri =
     let open Deferred.Result.Let_syntax in
@@ -46,12 +46,12 @@ module Account = struct
   module Unlock =
   [%graphql
   {|
-      mutation ($password: String!, $public_key: PublicKey!) {
-        unlockAccount(input: {password: $password, publicKey: $public_key }) {
-          publicKey
-        }
+    mutation ($password: String!, $public_key: PublicKey!) {
+      unlockAccount(input: {password: $password, publicKey: $public_key }) {
+        publicKey
       }
-    |}]
+    }
+  |}]
 
   let unlock ~graphql_uri =
     let open Deferred.Result.Let_syntax in
@@ -67,14 +67,14 @@ module SendTransaction = struct
   module Payment =
   [%graphql
   {|
-      mutation sendPayment($fee: UInt64!, $amount: UInt64!, $token: TokenId, $to_: PublicKey!, $from: PublicKey!) {
-        sendPayment(input: {fee: $fee, amount: $amount, token: $token, to: $to_, from: $from}, signature: null) {
-          payment {
-            hash
-          }
+    mutation sendPayment($fee: UInt64!, $amount: UInt64!, $token: TokenId, $to_: PublicKey!, $from: PublicKey!) {
+      sendPayment(input: {fee: $fee, amount: $amount, token: $token, to: $to_, from: $from}, signature: null) {
+        payment {
+          hash
         }
-        }
-    |}]
+      }
+    }
+  |}]
 
   let payment ~fee ~amount ?token ~to_ ~graphql_uri () =
     let open Deferred.Result.Let_syntax in
@@ -108,15 +108,14 @@ module SendTransaction = struct
   module Delegation =
   [%graphql
   {|
-
-       mutation sendDelegation($fee : UInt64!, $to_: PublicKey!, $from: PublicKey!) {
-         sendDelegation(input: {fee: $fee, to: $to_, from: $from}, signature: null) {
-           delegation {
-             hash
-           }
-         }
-       }
-    |}]
+    mutation sendDelegation($fee : UInt64!, $to_: PublicKey!, $from: PublicKey!) {
+      sendDelegation(input: {fee: $fee, to: $to_, from: $from}, signature: null) {
+        delegation {
+          hash
+        }
+      }
+    }
+  |}]
 
   let delegation ~fee ~to_ ~graphql_uri () =
     let open Deferred.Result.Let_syntax in
@@ -144,16 +143,16 @@ module SendTransaction = struct
   module Create_token =
   [%graphql
   {|
-       mutation ($sender: PublicKey!,
-                 $receiver: PublicKey!,
-                 $fee: UInt64!) {
-          createToken(input: {feePayer: $sender, tokenOwner: $receiver, fee: $fee}, signature: null) {
-           createNewToken {
-             hash
-           }
-       }
-     }
-   |}]
+    mutation ($sender: PublicKey!,
+              $receiver: PublicKey!,
+              $fee: UInt64!) {
+      createToken(input: {feePayer: $sender, tokenOwner: $receiver, fee: $fee}, signature: null) {
+        createNewToken {
+          hash
+        }
+      }
+    }
+  |}]
 
   let create_token ~fee ~receiver:_ ~graphql_uri () =
     let open Deferred.Result.Let_syntax in
@@ -180,19 +179,19 @@ module SendTransaction = struct
   module Create_token_account =
   [%graphql
   {|
-  mutation ($sender: PublicKey,
-            $tokenOwner: PublicKey!,
-            $receiver: PublicKey!,
-            $token: TokenId!,
-            $fee: UInt64!) {
-    createTokenAccount(input:
-       {feePayer: $sender, tokenOwner: $tokenOwner, receiver: $receiver, token: $token, fee: $fee}, signature: null) {
-         createNewTokenAccount {
-           hash
-         }
-       }
-     }
-   |}]
+    mutation ($sender: PublicKey,
+              $tokenOwner: PublicKey!,
+              $receiver: PublicKey!,
+              $token: TokenId!,
+              $fee: UInt64!) {
+      createTokenAccount(input:
+        {feePayer: $sender, tokenOwner: $tokenOwner, receiver: $receiver, token: $token, fee: $fee}, signature: null) {
+        createNewTokenAccount {
+          hash
+        }
+      }
+    }
+  |}]
 
   let create_token_account ~fee ~receiver ~token ~graphql_uri () =
     let open Deferred.Result.Let_syntax in

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -143,7 +143,8 @@ module Node = struct
       $nonce: UInt32,
       $memo: String) {
         sendPayment(input:
-          {from: $sender, to: $receiver, amount: $amount, token: $token, fee: $fee, nonce: $nonce, memo: $memo}) {
+          {from: $sender, to: $receiver, amount: $amount, token: $token, fee: $fee, nonce: $nonce, memo: $memo},
+          ignoreWarnings: true) {
             payment {
               id
             }

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -398,6 +398,18 @@ module Body = struct
         Transaction_union_tag.Create_account
     | Mint_tokens _ ->
         Transaction_union_tag.Mint_tokens
+
+  let amount = function
+    | Payment payload ->
+        Some payload.Payment_payload.Poly.amount
+    | Stake_delegation _ ->
+        None
+    | Create_new_token _ ->
+        None
+    | Create_token_account _ ->
+        None
+    | Mint_tokens payload ->
+        Some payload.Minting_payload.amount
 end
 
 module Poly = struct
@@ -466,18 +478,7 @@ let token (t : t) = Body.token t.body
 
 let tag (t : t) = Body.tag t.body
 
-let amount (t : t) =
-  match t.body with
-  | Payment payload ->
-      Some payload.Payment_payload.Poly.amount
-  | Stake_delegation _ ->
-      None
-  | Create_new_token _ ->
-      None
-  | Create_token_account _ ->
-      None
-  | Mint_tokens payload ->
-      Some payload.Minting_payload.amount
+let amount (t : t) = Body.amount t.body
 
 let fee_excess (t : t) =
   Fee_excess.of_single (fee_token t, Currency.Fee.Signed.of_unsigned (fee t))

--- a/src/lib/mina_base/signed_command_payload.mli
+++ b/src/lib/mina_base/signed_command_payload.mli
@@ -45,6 +45,8 @@ module Body : sig
   val source : next_available_token:Token_id.t -> t -> Account_id.t
 
   val token : t -> Token_id.t
+
+  val amount : t -> Currency.Amount.t option
 end
 
 module Common : sig

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2463,11 +2463,18 @@ module Mutations = struct
       ~args:
         Arg.
           [ arg "input" ~typ:(non_null Types.Input.send_payment)
-          ; Types.Input.Fields.signature ]
+          ; Types.Input.Fields.signature
+          ; arg "ignoreWarnings"
+              ~doc:
+                "When true the payment will be attempted even if we \
+                 anticipate an error (defaults to false)"
+              ~typ:bool ]
       ~resolve:
         (fun {ctx= coda; _} ()
              (from, to_, token_id, amount, fee, valid_until, memo, nonce_opt)
-             signature ->
+             signature ignore_warnings ->
+        let ignore_warnings = Option.value ~default:false ignore_warnings in
+        let _ = ignore ignore_warnings in
         let body =
           Signed_command_payload.Body.Payment
             { source_pk= from
@@ -3365,12 +3372,19 @@ module Queries = struct
       ~args:
         Arg.
           [ arg "input" ~typ:(non_null Types.Input.send_payment)
-          ; Types.Input.Fields.signature ]
+          ; Types.Input.Fields.signature
+          ; arg "ignoreWarnings"
+              ~doc:
+                "When true warnings will be ignored when validating the \
+                 payment (defaults to true)"
+              ~typ:bool ]
       ~resolve:
         (fun {ctx= mina; _} ()
              (from, to_, token_id, amount, fee, valid_until, memo, nonce_opt)
-             signature ->
+             signature ignore_warnings ->
         let open Deferred.Result.Let_syntax in
+        let ignore_warnings = Option.value ~default:true ignore_warnings in
+        let _ = ignore ignore_warnings in
         let body =
           Signed_command_payload.Body.Payment
             { source_pk= from

--- a/src/lib/user_command_input/user_command_input.mli
+++ b/src/lib/user_command_input/user_command_input.mli
@@ -67,6 +67,12 @@ val create :
   -> unit
   -> t
 
+val unable_to_pay_account_creation_fee :
+     get_account:(Account_id.t -> Account.t option Participating_state.T.t)
+  -> constraint_constants:Genesis_constants.Constraint_constants.t
+  -> Signed_command_payload.Body.t
+  -> bool
+
 val to_user_command :
      ?nonce_map:(Account.Nonce.t * Account.Nonce.t) Account_id.Map.t
   -> get_current_nonce:(   Account_id.t


### PR DESCRIPTION
- Adds `ignoreWarnings` params to `sendPayment` and `validatePayment` in the GraphQL schema
- Updates existing GraphQL queries in CLI, Rosetta, and some tests to pass `ignoreWarnings` as `true` initially
- Makes it so on requests where 1. a payment is being sent or validated, 2.`ignoreWarning` is not set to true, 3. the recipient of the payment does not have an account, and 4. the payment is for an amount smaller than the account creation fee, GraphQL returns an error

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #8213