### PR TITLE
Canonicalize extensional blocks

### DIFF
--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -44,7 +44,7 @@ module User_command = struct
         Currency.Amount.Stable.Latest.t option
     ; receiver_balance: Currency.Balance.Stable.Latest.t option
     ; created_token: Token_id.Stable.Latest.t option }
-  [@@deriving yojson, bin_io_unversioned]
+  [@@deriving yojson, equal, bin_io_unversioned]
 end
 
 module Internal_command = struct
@@ -62,7 +62,7 @@ module Internal_command = struct
     ; hash: Transaction_hash.Stable.Latest.t
           [@to_yojson Transaction_hash.to_yojson]
           [@of_yojson Transaction_hash.of_yojson] }
-  [@@deriving yojson, bin_io_unversioned]
+  [@@deriving yojson, equal, bin_io_unversioned]
 end
 
 module Block = struct
@@ -83,5 +83,5 @@ module Block = struct
     ; timestamp: Block_time.Stable.Latest.t
     ; user_cmds: User_command.t list
     ; internal_cmds: Internal_command.t list }
-  [@@deriving yojson, bin_io_unversioned]
+  [@@deriving yojson, equal, bin_io_unversioned]
 end

--- a/src/app/missing_subchain/missing_subchain.ml
+++ b/src/app/missing_subchain/missing_subchain.ml
@@ -100,7 +100,7 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
     ; user_cmds= []
     ; internal_cmds= [] }
 
-let fill_in_user_command pool block_state_hash =
+let fill_in_user_commands pool block_state_hash =
   let query_db ~item ~f = query_db pool ~item ~f in
   let pk_of_id id ~item =
     let%map pk_str = query_db ~f:(fun db -> Sql.Public_key.run db id) ~item in
@@ -223,7 +223,7 @@ let fill_in_user_command pool block_state_hash =
         ; receiver_balance
         ; created_token } )
 
-let fill_in_internal_command pool block_state_hash =
+let fill_in_internal_commands pool block_state_hash =
   let query_db ~item ~f = query_db pool ~item ~f in
   let pk_of_id id ~item =
     let%map pk_str = query_db ~f:(fun db -> Sql.Public_key.run db id) ~item in
@@ -360,14 +360,30 @@ let main ~archive_uri ~start_state_hash_opt ~end_state_hash () =
       [%log info] "Querying for user commands in blocks" ;
       let%bind blocks_with_user_cmds =
         Deferred.List.map extensional_blocks ~f:(fun block ->
-            let%map user_cmds = fill_in_user_command pool block.state_hash in
+            let%map unsorted_user_cmds =
+              fill_in_user_commands pool block.state_hash
+            in
+            (* sort, to give block a canonical representation *)
+            let user_cmds =
+              List.sort unsorted_user_cmds
+                ~compare:(fun (cmd1 : Extensional.User_command.t) cmd2 ->
+                  Int.compare cmd1.sequence_no cmd2.sequence_no )
+            in
             {block with user_cmds} )
       in
       [%log info] "Querying for internal commands in blocks" ;
       let%bind blocks_with_all_cmds =
         Deferred.List.map blocks_with_user_cmds ~f:(fun block ->
-            let%map internal_cmds =
-              fill_in_internal_command pool block.state_hash
+            let%map unsorted_internal_cmds =
+              fill_in_internal_commands pool block.state_hash
+            in
+            (* sort, to give block a canonical representation *)
+            let internal_cmds =
+              List.sort unsorted_internal_cmds
+                ~compare:(fun (cmd1 : Extensional.Internal_command.t) cmd2 ->
+                  [%compare: int * int]
+                    (cmd1.sequence_no, cmd1.secondary_sequence_no)
+                    (cmd2.sequence_no, cmd2.secondary_sequence_no) )
             in
             {block with internal_cmds} )
       in

--- a/src/lib/blake2/blake2.ml
+++ b/src/lib/blake2/blake2.ml
@@ -29,7 +29,7 @@ module Make () = struct
   [%%versioned_binable
   module Stable = struct
     module V1 = struct
-      type t = T1.t [@@deriving hash, sexp, compare]
+      type t = T1.t [@@deriving hash, sexp, compare, equal]
 
       let to_latest = Fn.id
 

--- a/src/lib/blake2/intf.ml
+++ b/src/lib/blake2/intf.ml
@@ -8,7 +8,7 @@ module type S = sig
   [%%versioned:
   module Stable : sig
     module V1 : sig
-      type t [@@deriving sexp, compare, hash]
+      type t [@@deriving sexp, compare, hash, equal]
     end
   end]
 

--- a/src/lib/mina_base/transaction_hash.mli
+++ b/src/lib/mina_base/transaction_hash.mli
@@ -5,11 +5,11 @@ module Stable : sig
   [@@@no_toplevel_latest_type]
 
   module V1 : sig
-    type t [@@deriving sexp, compare, hash]
+    type t [@@deriving sexp, compare, hash, equal]
   end
 end]
 
-type t = Stable.Latest.t [@@deriving sexp, compare, hash, yojson]
+type t = Stable.Latest.t [@@deriving sexp, compare, hash, yojson, equal]
 
 val of_base58_check : string -> t Or_error.t
 


### PR DESCRIPTION
For #8277, we want to be able to compare the contents of two archive dbs, to check whether they are equivalent. Databases can be equivalent, without being equal. They can differ in the ids of blocks, for example.

We can test whether two dbs are equivalent by using the `missing_subchain` tool to dump extensional blocks for them, then check whether the set of block files is the same, and that the contents of each pair of block files are identical.

Each extensional block contains lists of commands, and there was no guarantee that the lists were in any particular order. This PR sorts those lists, to yield a canonical representation of extensional blocks, so we can compare a pair of blocks with `equal`. Add the deriver for `equal` to `Extensional.Block`.