### PR TITLE
Only download cortextool if not in PATH of local operator ENV

### DIFF
--- a/automation/terraform/modules/testnet-alerts/alerts.tf
+++ b/automation/terraform/modules/testnet-alerts/alerts.tf
@@ -29,7 +29,7 @@ resource "local_file" "alert_rules_config" {
 resource "null_resource" "download_cortextool" {
   provisioner "local-exec" {
     working_dir = path.cwd
-    command = "curl --fail --show-error --location --output /tmp/cortextool ${local.cortextool_download_url} && chmod a+x /tmp/cortextool"
+    command = "which cortextool || (curl --fail --show-error --location --output ${local.cortextool_install_dir} ${local.cortextool_download_url} && chmod a+x ${local.cortextool_install_dir})"
   }
 }
 
@@ -38,7 +38,7 @@ resource "null_resource" "download_cortextool" {
 resource "null_resource" "alert_rules_lint" {
   provisioner "local-exec" {
     working_dir = path.cwd
-    command     = "/tmp/cortextool rules lint --rule-files alert_rules.yml"
+    command     = "cortextool rules lint --rule-files alert_rules.yml"
   }
 
   depends_on = [local_file.alert_rules_config, null_resource.download_cortextool]
@@ -46,7 +46,7 @@ resource "null_resource" "alert_rules_lint" {
 
 resource "null_resource" "alert_rules_check" {
   provisioner "local-exec" {
-    command     = "/tmp/cortextool rules check --rule-files alert_rules.yml"
+    command     = "cortextool rules check --rule-files alert_rules.yml"
   }
 
   depends_on = [local_file.alert_rules_config, null_resource.download_cortextool]

--- a/automation/terraform/modules/testnet-alerts/locals.tf
+++ b/automation/terraform/modules/testnet-alerts/locals.tf
@@ -1,4 +1,5 @@
 locals {
   cortex_image            = "grafana/cortextool:latest"
   cortextool_download_url = "https://github.com/grafana/cortex-tools/releases/download/v0.7.2/cortextool_0.7.2_linux_x86_64"
+  cortextool_install_dir  = "~/.local/bin/cortextool"
 }


### PR DESCRIPTION
**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
Depend on local install install of `cortextool` (if present and in $PATH); otherwise download and install Linux version of tool to local bin DIR (should be in $PATH for most OSes) for testing purposes to support Mac and Window users.   

- Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #8298 
