### PR TITLE
Client SDK, add Rosetta signed txn to signed cmd method

### DIFF
--- a/frontend/client_sdk/src/CodaSDK.re
+++ b/frontend/client_sdk/src/CodaSDK.re
@@ -51,7 +51,7 @@ type payment = {
 };
 
 type codaSDK;
-[@bs.module "./client_sdk.bc.js"] external codaSDK: codaSDK = "codaSDK";
+[@bs.module "./client_sdk.bc.js"] external codaSDK: codaSDK = "minaSDK";
 
 [@bs.send] external genKeys: (codaSDK, unit) => keypair = "genKeys";
 /**

--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -20,7 +20,7 @@ open Rosetta_coding_nonconsensus
 open Js_util
 
 let _ =
-  Js.export "codaSDK"
+  Js.export "minaSDK"
     (object%js (_self)
        (** public key corresponding to a private key *)
        method publicKeyOfPrivateKey (sk_base58_check_js : string_js) =
@@ -259,6 +259,27 @@ let _ =
                 exclusively"
          | Error msg ->
              make_error msg
+
+       method signedRosettaTransactionToSignedCommand
+             (signedRosettaTxn : string_js) =
+         let signed_txn_json =
+           Js.to_string signedRosettaTxn |> Yojson.Safe.from_string
+         in
+         let result_json =
+           match Transaction.to_mina_signed signed_txn_json with
+           | Ok signed_cmd ->
+               let cmd_json = Signed_command.to_yojson signed_cmd in
+               `Assoc [("data", cmd_json)]
+           | Error err ->
+               let open Core_kernel in
+               let err_msg =
+                 sprintf
+                   "Could not parse JSON for signed Rosetta transaction: %s"
+                   (Error.to_string_hum err)
+               in
+               `Assoc [("error", `String err_msg)]
+         in
+         Js.string (Yojson.Safe.to_string result_json)
 
        method runUnitTests () : bool Js.t = Coding.run_unit_tests () ; Js._true
     end)

--- a/src/app/client_sdk/tests/run_unit_tests.js
+++ b/src/app/client_sdk/tests/run_unit_tests.js
@@ -1,5 +1,5 @@
-var coda = require("../../../../_build/default/src/app/client_sdk/client_sdk.bc.js").codaSDK;
+var mina = require("../../../../_build/default/src/app/client_sdk/client_sdk.bc.js").minaSDK;
 
 console.log("Running client SDK unit tests");
-coda.runUnitTests () ();
+mina.runUnitTests () ();
 console.log("Done.");

--- a/src/app/client_sdk/tests/test_encodings.js
+++ b/src/app/client_sdk/tests/test_encodings.js
@@ -1,12 +1,12 @@
 // test_encodings.js -- print Rosetta encodings of a couple of public keys
 
-var coda = require("../../../../_build/default/src/app/client_sdk/client_sdk.bc.js").codaSDK;
+var mina = require("../../../../_build/default/src/app/client_sdk/client_sdk.bc.js").minaSDK;
 
 var pk1 = "B62qrcFstkpqXww1EkSGrqMCwCNho86kuqBd4FrAAUsPxNKdiPzAUsy";
 var pk2 = "B62qkfHpLpELqpMK6ZvUTJ5wRqKDRF3UHyJ4Kv3FU79Sgs4qpBnx5RR";
 
-var enc1 = coda.rawPublicKeyOfPublicKey(pk1)
-var enc2 = coda.rawPublicKeyOfPublicKey(pk2)
+var enc1 = mina.rawPublicKeyOfPublicKey(pk1)
+var enc2 = mina.rawPublicKeyOfPublicKey(pk2)
 
 console.log(enc1)
 console.log(enc2)

--- a/src/app/client_sdk/tests/test_signatures.js
+++ b/src/app/client_sdk/tests/test_signatures.js
@@ -1,4 +1,4 @@
-var coda = require("../../../../_build/default/src/app/client_sdk/client_sdk.bc.js").codaSDK;
+var mina = require("../../../../_build/default/src/app/client_sdk/client_sdk.bc.js").minaSDK;
 
 var keypair = {
   privateKey:
@@ -45,13 +45,13 @@ var delegations = [
 
 var printSignature = s => console.log(`  { field: '${s.field}'\n  , scalar: '${s.scalar}'\n  },`);
 
-var payment_signatures = payments.map (t => coda.signPayment(keypair.privateKey, t))
+var payment_signatures = payments.map (t => mina.signPayment(keypair.privateKey, t))
 
-var delegation_signatures = delegations.map (t => coda.signStakeDelegation(keypair.privateKey, t))
+var delegation_signatures = delegations.map (t => mina.signStakeDelegation(keypair.privateKey, t))
 
 // verify signatures before printing them
-payment_signatures.forEach (t => { if (!coda.verifyPaymentSignature (t)) { console.error ("Payment signature did not verify"); process.exit (1) } })
-delegation_signatures.forEach (t => { if (!coda.verifyStakeDelegationSignature (t)) { console.error ("Delegation signature did not verify"); process.exit (1) } })
+payment_signatures.forEach (t => { if (!mina.verifyPaymentSignature (t)) { console.error ("Payment signature did not verify"); process.exit (1) } })
+delegation_signatures.forEach (t => { if (!mina.verifyStakeDelegationSignature (t)) { console.error ("Delegation signature did not verify"); process.exit (1) } })
 
 console.log("[");
 payment_signatures.forEach(t => printSignature (t.signature))


### PR DESCRIPTION
Add method to convert a Rosetta signed transaction to a signed command. The input is a JS string, because that's what the existing method `signRosettaTransaction` returns. The output is a JS string representing the JSON conversion of a `Signed_command.t`.

The output of this method is intended to be an input to GraphQL, so a string, rather than a structured object, should be acceptable.

Tested with a Rosetta signed delegation, and a Rosetta signed payment.

Changed the name of the method-containing object from `CodaSDK` to `MinaSDK`. Changed the Reason wrapper to use that new name when importing, but didn't change the wrapper name.

Closes #8282.
