### PR TITLE
Added NPM token env variable to running buildkite container

### DIFF
--- a/buildkite/src/Jobs/Release/ClientSdk.dhall
+++ b/buildkite/src/Jobs/Release/ClientSdk.dhall
@@ -28,7 +28,7 @@ Pipeline.build
     steps = [
       Command.build
         Command.Config::{
-          commands = OpamInit.andThenRunInDocker ([] : List Text) "./buildkite/scripts/client-sdk-tool.sh 'publish --non-interactive'"
+          commands = OpamInit.andThenRunInDocker (["NPM_TOKEN"]) "./buildkite/scripts/client-sdk-tool.sh 'publish --non-interactive'"
           , label = "Publish client SDK to npm"
           , key = "publish-client-sdk"
           , target = Size.Medium


### PR DESCRIPTION
The NPM token was not being passed into the running containers and thus the client-sdk-tool.sh script was not firing correctly. The following fix was tested by initiating a buildkite job and then logging into the container to check if the env var was being properly set.
