### PR TITLE
Pass archive image for integration tests

### DIFF
--- a/buildkite/scripts/run-test-executive.sh
+++ b/buildkite/scripts/run-test-executive.sh
@@ -3,9 +3,11 @@ set -o pipefail -x
 
 TEST_NAME="$1"
 CODA_IMAGE="gcr.io/o1labs-192920/coda-daemon-puppeteered:$CODA_VERSION-$CODA_GIT_HASH"
+ARCHIVE_IMAGE="gcr.io/o1labs-192920/coda-archive:$CODA_VERSION-$CODA_GIT_HASH"
 
 ./test_executive.exe cloud "$TEST_NAME" \
   --coda-image "$CODA_IMAGE" \
+  --archive-image "$ARCHIVE_IMAGE" \
   --coda-automation-location ./automation \
   | tee "$TEST_NAME.test.log" \
   | coda-logproc -i inline -f '!(.level in ["Debug", "Spam"])'

--- a/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
@@ -29,6 +29,7 @@ Pipeline.build
         dirtyWhen = [
           S.strictly (S.contains "Makefile"),
           S.strictlyStart (S.contains "src/app/archive"),
+          S.strictlyStart (S.contains "src/app/test-executive"),
           S.strictlyStart (S.contains "scripts/archive"),
           S.strictlyStart (S.contains "automation"),
           S.strictlyStart (S.contains "buildkite/src/Jobs/Release/ArchiveNodeArtifact")

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -7,7 +7,8 @@ let TestExecutive = ../../Command/TestExecutive.dhall
 
 let dependsOn = [
     { name = "TestnetIntegrationTests", key = "build-test-executive" },
-    { name = "MinaArtifact", key = "puppeteered-docker-image" }
+    { name = "MinaArtifact", key = "puppeteered-docker-image" },
+    { name = "ArchiveNodeArtifact", key = "archive-docker-image" }
 ]
 
 in Pipeline.build Pipeline.Config::{

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -30,7 +30,7 @@ type inputs =
   { test_inputs: test_inputs_with_cli_inputs
   ; test: test
   ; coda_image: string
-  ; archiver_image: string
+  ; archive_image: string
   ; debug: bool }
 
 let validate_inputs {coda_image; _} =
@@ -219,7 +219,7 @@ let main inputs =
   let logger = Logger.create () in
   let images =
     { Test_config.Container_images.coda= inputs.coda_image
-    ; archive_node= inputs.archiver_image
+    ; archive_node= inputs.archive_image
     ; user_agent= "codaprotocol/coda-user-agent:0.1.5"
     ; bots= "codaprotocol/coda-bots:0.0.13-beta-1"
     ; points= "codaprotocol/coda-points-hack:32b.4" }
@@ -342,13 +342,13 @@ let coda_image_arg =
     & opt (some string) None
     & info ["coda-image"] ~env ~docv:"CODA_IMAGE" ~doc)
 
-let archiver_image_arg =
+let archive_image_arg =
   let doc = "Identifier of the archive node docker image to test." in
-  let env = Arg.env_var "ARCHIVER_IMAGE" ~doc in
+  let env = Arg.env_var "ARCHIVE_IMAGE" ~doc in
   Arg.(
     value
       ( opt string "unused"
-      & info ["archiver-image"] ~env ~docv:"ARCHIVER_IMAGE" ~doc ))
+      & info ["archive-image"] ~env ~docv:"ARCHIVE_IMAGE" ~doc ))
 
 let debug_arg =
   let doc =
@@ -372,12 +372,12 @@ let engine_cmd ((engine_name, (module Engine)) : engine) =
     Term.(const wrap_cli_inputs $ Engine.Network_config.Cli_inputs.term)
   in
   let inputs_term =
-    let cons_inputs test_inputs test coda_image archiver_image debug =
-      {test_inputs; test; coda_image; archiver_image; debug}
+    let cons_inputs test_inputs test coda_image archive_image debug =
+      {test_inputs; test; coda_image; archive_image; debug}
     in
     Term.(
       const cons_inputs $ test_inputs_with_cli_inputs_arg $ test_arg
-      $ coda_image_arg $ archiver_image_arg $ debug_arg)
+      $ coda_image_arg $ archive_image_arg $ debug_arg)
   in
   let term = Term.(const start $ inputs_term) in
   (term, info)


### PR DESCRIPTION
Pass an archive image to the test executive for integration tests. This change is in preparation for adding the archive node test. While the image is currently required only for that test, it's no harm to pass it for other tests.

In the test executive, change `archiver` to `archive`, a little less awkward.
