### PR TITLE
[master-qa] Add much more aggressive handling of waits, with logging upon errors

### DIFF
--- a/src/app/cli/src/mina.ml
+++ b/src/app/cli/src/mina.ml
@@ -524,8 +524,14 @@ let setup_daemon logger =
           let%bind () = Async.after (Time.Span.of_min 1.) in
           terminated_child_loop ()
       | Some (child_pid, exit_or_signal) ->
+          let child_data =
+            Child_processes.Termination.get_child_data pids child_pid
+          in
           let child_pid_metadata =
-            [("child_pid", `Int (Pid.to_int child_pid))]
+            [ ("child_pid", `Int (Pid.to_int child_pid))
+            ; ( "child_data"
+              , [%to_yojson: Child_processes.Termination.data option]
+                  child_data ) ]
           in
           ( match exit_or_signal with
           | Ok () ->

--- a/src/app/cli/src/mina.ml
+++ b/src/app/cli/src/mina.ml
@@ -503,13 +503,21 @@ let setup_daemon logger =
     let pids = Child_processes.Termination.create_pid_table () in
     let rec terminated_child_loop () =
       match
-        try Unix.wait_nohang `Any
-        with
+        try Unix.wait_nohang `Any with
         | Unix.Unix_error (errno, _, _)
-        when Int.equal (Unix.Error.compare errno Unix.ECHILD) 0
-             (* no child processes exist *)
-        ->
-          None
+          when Int.equal (Unix.Error.compare errno Unix.ECHILD) 0
+               (* no child processes exist *) ->
+            None
+        | exn ->
+            [%log fatal] "Saw an unexpected error $exn from wait_nohang."
+              ~metadata:
+                [ ( "exn"
+                  , Error_json.error_to_yojson
+                      (Error.of_exn ~backtrace:`Get exn) ) ] ;
+            (* This will now appear in the backtrace for this exception when it
+               reaches the top level, making this very easy to identify.
+            *)
+            raise exn
       with
       | None ->
           (* no children have terminated, wait to check again *)

--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -167,6 +167,30 @@ let stop_snark_worker (conn, _, _) =
     ~f:Coda_worker.functions.stop_snark_worker ~arg:()
 
 let disconnect ((conn, proc, _) as t) ~logger =
+  (* Handle implicit raciness in the wait syscall by calling [Process.wait]
+     early, so that its value will be correctly cached when we actually need
+     it.
+  *)
+  ( match
+      Or_error.try_with (fun () ->
+          (* Eagerly force [Process.wait], so that it won't be captured
+             elsewhere on exit.
+          *)
+          let waiting = Process.wait proc in
+          don't_wait_for
+            ( match%map Monitor.try_with_or_error (fun () -> waiting) with
+            | Ok _ ->
+                ()
+            | Error err ->
+                [%log error]
+                  "Saw a deferred exception $exn while waiting for process"
+                  ~metadata:[("exn", Error_json.error_to_yojson err)] ) )
+    with
+  | Ok _ ->
+      ()
+  | Error err ->
+      [%log error] "Saw an exception $exn while waiting for process"
+        ~metadata:[("exn", Error_json.error_to_yojson err)] ) ;
   (* This kills any straggling snark worker process *)
   let%bind () =
     match%map Monitor.try_with (fun () -> stop_snark_worker t) with

--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -6,9 +6,11 @@ open Async
 open Core_kernel
 include Hashable.Make_binable (Pid)
 
-type process_kind = Prover | Verifier [@@deriving show {with_path= false}]
+type process_kind = Prover | Verifier
+[@@deriving show {with_path= false}, yojson]
 
 type data = {kind: process_kind; termination_expected: bool}
+[@@deriving yojson]
 
 type t = data Pid.Table.t
 
@@ -34,6 +36,8 @@ let get_signal_cause_opt =
     ~f:(fun (signal, msg) ->
       Base.ignore (Table.add signal_causes_tbl ~key:signal ~data:msg) ) ;
   fun signal -> Signal.Table.find signal_causes_tbl signal
+
+let get_child_data (t : t) child_pid = Pid.Table.find t child_pid
 
 let check_terminated_child (t : t) child_pid logger =
   if Pid.Table.mem t child_pid then

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -183,6 +183,30 @@ module Snark_worker = struct
                  (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
                ~shutdown_on_disconnect:false )
     in
+    (* Handle implicit raciness in the wait syscall by calling [Process.wait]
+       early, so that its value will be correctly cached when we actually need
+       it.
+    *)
+    ( match
+        Or_error.try_with (fun () ->
+            (* Eagerly force [Process.wait], so that it won't be captured
+               elsewhere on exit.
+            *)
+            let waiting = Process.wait snark_worker_process in
+            don't_wait_for
+              ( match%map Monitor.try_with_or_error (fun () -> waiting) with
+              | Ok _ ->
+                  ()
+              | Error err ->
+                  [%log error]
+                    "Saw a deferred exception $exn while waiting for process"
+                    ~metadata:[("exn", Error_json.error_to_yojson err)] ) )
+      with
+    | Ok _ ->
+        ()
+    | Error err ->
+        [%log error] "Saw an exception $exn while waiting for process"
+          ~metadata:[("exn", Error_json.error_to_yojson err)] ) ;
     don't_wait_for
       ( match%bind
           Monitor.try_with (fun () -> Process.wait snark_worker_process)

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -278,6 +278,30 @@ let create ~logger ~proof_level ~pids ~conf_dir : t Deferred.t =
         ~on_failure ~shutdown_on:Disconnect ~connection_state_init_arg:()
         {conf_dir; logger; proof_level}
     in
+    (* Handle implicit raciness in the wait syscall by calling [Process.wait]
+       early, so that its value will be correctly cached when we actually need
+       it.
+    *)
+    ( match
+        Or_error.try_with (fun () ->
+            (* Eagerly force [Process.wait], so that it won't be captured
+               elsewhere on exit.
+            *)
+            let waiting = Process.wait process in
+            don't_wait_for
+              ( match%map Monitor.try_with_or_error (fun () -> waiting) with
+              | Ok _ ->
+                  ()
+              | Error err ->
+                  [%log error]
+                    "Saw a deferred exception $exn while waiting for process"
+                    ~metadata:[("exn", Error_json.error_to_yojson err)] ) )
+      with
+    | Ok _ ->
+        ()
+    | Error err ->
+        [%log error] "Saw an exception $exn while waiting for process"
+          ~metadata:[("exn", Error_json.error_to_yojson err)] ) ;
     let exit_or_signal = wait_safe process in
     [%log info]
       "Daemon started process of kind $process_kind with pid $verifier_pid"


### PR DESCRIPTION
This PR tweaks the handling of `wait` syscalls throughout the codebase. Specifically,
* it seems unlikely, but we may be mishandling the error in ``wait_nohang `Any`` in `mina.ml`
  - This adds some additional logging, and a `try ... with exn -> ...; raise exn` to inject that location into the backtrace.
* there is additional handling to force the early evaluation of `Process.wait` for all processes that (I can tell that) we use it on
  - This code also catches and logs any errors that it sees, distinguishing errors at 'call time' and 'deferred time' to give us the maximum amount of information
  - This code is deliberately duplicated in each location, so that we will have the location information for *that particular error* if it fires. Not having this information has been the primary pain point in diagnosing this issue, so it is important that we can tell that the error came from a particular subsystem going forward.
* the child termination log, which we see in every crash in #8350, has been updated to include information about which process kind has crashed
  - given the attention that has been paid to the verifier process, and the relative lack of attention paid to the prover process, my hypothesis is that it is that; this will allow us to confirm this, if this still does not fix the issue.

This comes out of the analysis in #8350, where we have still seen a WNOHANG in the current version of `master-qa`. I propose that we merge this and re-deploy `master-qa` including these changes, to collect more data.

In my opinion, this is not a signal that the original fix included in `master-qa` is not working. Indeed, we have not seen those nodes become stuck at a particular block height, which was the symptom that the original fixes were trying to resolve. The likely culprit is the prover process managed through `src/lib/child_processes/child_processes.ml`, where the handling of waits was lacking and no dedicated fix had been applied.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #8350
