### PR TITLE
Move code to wait and log errors to library code

### DIFF
--- a/src/app/cli/src/tests/dune
+++ b/src/app/cli/src/tests/dune
@@ -6,7 +6,8 @@
    async core
    ; libs
    mina_base mina_graphql mina_lib mina_state mina_net2
-   mina_transition mina_version parallel protocol_version
+   mina_transition mina_version child_processes
+   parallel protocol_version
    node_addrs_and_ports transition_frontier
    ; internal deps
    init)

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -279,30 +279,8 @@ let start_custom :
          ; Some ("coda-" ^ name) ])
       ~f:(fun prog -> Process.create ~stdin:"" ~prog ~args ())
   in
-  (* Handle implicit raciness in the wait syscall by calling [Process.wait]
-     early, so that its value will be correctly cached when we actually need
-     it.
-  *)
-  ( match
-      Or_error.try_with (fun () ->
-          (* Eagerly force [Process.wait], so that it won't be captured
-             elsewhere on exit.
-          *)
-          let waiting = Process.wait process in
-          don't_wait_for
-            ( match%map.Async Monitor.try_with_or_error (fun () -> waiting) with
-            | Ok _ ->
-                ()
-            | Error err ->
-                [%log error]
-                  "Saw a deferred exception $exn while waiting for process"
-                  ~metadata:[("exn", Error_json.error_to_yojson err)] ) )
-    with
-  | Ok _ ->
-      ()
-  | Error err ->
-      [%log error] "Saw an exception $exn while waiting for process"
-        ~metadata:[("exn", Error_json.error_to_yojson err)] ) ;
+  Termination.wait_for_process_log_errors ~logger process ~module_:__MODULE__
+    ~location:__LOC__ ;
   let%bind () =
     Deferred.map ~f:Or_error.return
     @@ Async.Writer.save lock_path

--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -49,3 +49,30 @@ let check_terminated_child (t : t) child_pid logger =
           [ ("child_pid", `Int (Pid.to_int child_pid))
           ; ("process_kind", `String (show_process_kind data.kind)) ] ;
       Core_kernel.exit 99 )
+
+let wait_for_process_log_errors ~logger process ~module_ ~location =
+  (* Handle implicit raciness in the wait syscall by calling [Process.wait]
+     early, so that its value will be correctly cached when we actually need
+     it.
+  *)
+  match
+    Or_error.try_with (fun () ->
+        (* Eagerly force [Process.wait], so that it won't be captured
+           elsewhere on exit.
+        *)
+        let waiting = Process.wait process in
+        don't_wait_for
+          ( match%map Monitor.try_with_or_error (fun () -> waiting) with
+          | Ok _ ->
+              ()
+          | Error err ->
+              Logger.error logger ~module_ ~location
+                "Saw a deferred exception $exn while waiting for process"
+                ~metadata:[("exn", Error_json.error_to_yojson err)] ) )
+  with
+  | Ok _ ->
+      ()
+  | Error err ->
+      Logger.error logger ~module_ ~location
+        "Saw an immediate exception $exn while waiting for process"
+        ~metadata:[("exn", Error_json.error_to_yojson err)]

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -5,7 +5,7 @@
  (inline_tests)
  (libraries core mina_intf mina_version pipe_lib user_command_input logger async async_extra
             filtered_external_transition unix_timestamp debug_assert o1trace consensus
-            incremental secrets work_selector
+            child_processes incremental secrets work_selector
             mina_networking block_producer genesis_constants sync_handler transition_router node_addrs_and_ports
             otp_lib protocol_version snark_worker participating_state transaction_inclusion_status
             sync_status daemon_rpcs archive_lib exit_handlers)

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -183,30 +183,8 @@ module Snark_worker = struct
                  (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
                ~shutdown_on_disconnect:false )
     in
-    (* Handle implicit raciness in the wait syscall by calling [Process.wait]
-       early, so that its value will be correctly cached when we actually need
-       it.
-    *)
-    ( match
-        Or_error.try_with (fun () ->
-            (* Eagerly force [Process.wait], so that it won't be captured
-               elsewhere on exit.
-            *)
-            let waiting = Process.wait snark_worker_process in
-            don't_wait_for
-              ( match%map Monitor.try_with_or_error (fun () -> waiting) with
-              | Ok _ ->
-                  ()
-              | Error err ->
-                  [%log error]
-                    "Saw a deferred exception $exn while waiting for process"
-                    ~metadata:[("exn", Error_json.error_to_yojson err)] ) )
-      with
-    | Ok _ ->
-        ()
-    | Error err ->
-        [%log error] "Saw an exception $exn while waiting for process"
-          ~metadata:[("exn", Error_json.error_to_yojson err)] ) ;
+    Child_processes.Termination.wait_for_process_log_errors ~logger
+      snark_worker_process ~module_:__MODULE__ ~location:__LOC__ ;
     don't_wait_for
       ( match%bind
           Monitor.try_with (fun () -> Process.wait snark_worker_process)


### PR DESCRIPTION
Move the code to eagerly/deferredly trap `Process.wait` errors to `Child_processes.Termination`, instead of having duplicated code.

Pass the module and location to the library code, don't use the `log` ppx, so that error logs show where this new function is called from.

Untested, but the wait code is the same as in #8352.