### PR TITLE
[master-qa] Expose libp2p_helper metrics via daemon

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1731,7 +1731,7 @@ let create_metrics_server ~logger ~metrics_server_port ~missing_blocks_width
           missing_blocks_width
       in
       let%bind metric_server =
-        Mina_metrics.Archive.create_archive_server ~port ~logger
+        Mina_metrics.Archive.create_archive_server ~port ~logger ()
       in
       let interval =
         Float.of_int (Mina_compile_config.block_window_duration_ms * 2)

--- a/src/app/cli/src/mina.ml
+++ b/src/app/cli/src/mina.ml
@@ -1098,7 +1098,12 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
       coda ;
     let%bind () =
       Option.map metrics_server_port ~f:(fun port ->
-          Mina_metrics.server ~port ~logger >>| ignore )
+          let forward_uri =
+            Option.map libp2p_metrics_port ~f:(fun port ->
+                Uri.with_uri ~scheme:(Some "http") ~host:(Some "127.0.0.1")
+                  ~port:(Some port) ~path:(Some "/metrics") Uri.empty )
+          in
+          Mina_metrics.server ?forward_uri ~port ~logger () >>| ignore )
       |> Option.value ~default:Deferred.unit
     in
     let () = Mina_plugins.init_plugins ~logger coda plugins in

--- a/src/lib/mina_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/mina_metrics.ml
@@ -880,7 +880,7 @@ module Object_lifetime_statistics = struct
     Gauge_map.add lifetime_quartile_ms_table ~name ~help
 end
 
-let generic_server ~port ~logger ~registry =
+let generic_server ?forward_uri ~port ~logger ~registry () =
   let open Cohttp in
   let open Cohttp_async in
   let handle_error _ exn =
@@ -892,8 +892,33 @@ let generic_server ~port ~logger ~registry =
     let uri = Request.uri req in
     match (Request.meth req, Uri.path uri) with
     | `GET, "/metrics" ->
+        let%bind other_data =
+          match forward_uri with
+          | Some uri ->
+              let%bind resp, body = Client.get uri in
+              let status = Response.status resp in
+              if Code.is_success (Code.code_of_status status) then
+                let%map body = Body.to_string body in
+                Some body
+              else (
+                [%log error] "Could not forward request to $url, got: $status"
+                  ~metadata:
+                    [ ("url", `String (Uri.to_string uri))
+                    ; ("status_code", `Int (Code.code_of_status status))
+                    ; ("status", `String (Code.string_of_status status)) ] ;
+                return None )
+          | None ->
+              return None
+        in
         let data = CollectorRegistry.(collect registry) in
         let body = Fmt.to_to_string TextFormat_0_0_4.output data in
+        let body =
+          match other_data with
+          | Some other_data ->
+              body ^ "\n" ^ other_data
+          | None ->
+              body
+        in
         let headers =
           Header.init_with "Content-Type" "text/plain; version=0.0.4"
         in
@@ -905,8 +930,9 @@ let generic_server ~port ~logger ~registry =
     (Async_extra.Tcp.Where_to_listen.of_port port)
     callback
 
-let server ~port ~logger =
-  generic_server ~port ~logger ~registry:CollectorRegistry.default
+let server ?forward_uri ~port ~logger () =
+  generic_server ?forward_uri ~port ~logger ~registry:CollectorRegistry.default
+    ()
 
 module Archive = struct
   type t =
@@ -944,10 +970,12 @@ module Archive = struct
     let name = "missing_blocks" in
     find_or_add t ~name ~help ~subsystem
 
-  let create_archive_server ~port ~logger =
+  let create_archive_server ?forward_uri ~port ~logger () =
     let open Async_kernel.Deferred.Let_syntax in
     let archive_registry = CollectorRegistry.create () in
-    let%map _ = generic_server ~port ~logger ~registry:archive_registry in
+    let%map _ =
+      generic_server ?forward_uri ~port ~logger ~registry:archive_registry ()
+    in
     {registry= archive_registry; gauge_metrics= Hashtbl.create (module String)}
 end
 


### PR DESCRIPTION
Tested with `_build/default/src/app/cli/src/mina.exe daemon -seed -proof-level none -libp2p-metrics-port 6666 -metrics-port 7777` and observing that the libp2p_helper metrics are included in `http://localhost:7777/metrics`.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: