### PR TITLE
Add block height option to node status

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1153,17 +1153,20 @@ let create ?wallets (config : Config.t) =
                                instantiated when node status requested"
                              node_ip_addr node_peer_id))
               | Some net ->
-                  let protocol_state_hash, k_block_hashes_and_timestamps =
+                  let ( protocol_state_hash
+                      , best_tip_opt
+                      , k_block_hashes_and_timestamps ) =
                     match
                       Broadcast_pipe.Reader.peek frontier_broadcast_pipe_r
                     with
                     | None ->
                         ( config.precomputed_values.protocol_state_with_hash
                             .hash
+                        , None
                         , [] )
                     | Some frontier ->
+                        let tip = Transition_frontier.best_tip frontier in
                         let protocol_state_hash =
-                          let tip = Transition_frontier.best_tip frontier in
                           let state =
                             Transition_frontier.Breadcrumb.protocol_state tip
                           in
@@ -1184,7 +1187,9 @@ let create ?wallets (config : Config.t) =
                                     (Time.to_string_iso8601_basic
                                        ~zone:Time.Zone.utc) ) )
                         in
-                        (protocol_state_hash, k_block_hashes_and_timestamps)
+                        ( protocol_state_hash
+                        , Some tip
+                        , k_block_hashes_and_timestamps )
                   in
                   let%bind peers = Mina_networking.peers net in
                   let open Deferred.Or_error.Let_syntax in
@@ -1217,6 +1222,22 @@ let create ?wallets (config : Config.t) =
                       ~f:Fn.id
                       ~default:(Float.to_int minutes_float)
                   in
+                  let block_height_opt =
+                    match best_tip_opt with
+                    | None ->
+                        None
+                    | Some tip ->
+                        let state =
+                          Transition_frontier.Breadcrumb.protocol_state tip
+                        in
+                        let consensus_state =
+                          state |> Mina_state.Protocol_state.consensus_state
+                        in
+                        Some
+                          ( Mina_numbers.Length.to_int
+                          @@ Consensus.Data.Consensus_state.blockchain_length
+                               consensus_state )
+                  in
                   Mina_networking.Rpcs.Get_node_status.Node_status.
                     { node_ip_addr
                     ; node_peer_id
@@ -1227,7 +1248,8 @@ let create ?wallets (config : Config.t) =
                     ; ban_statuses
                     ; k_block_hashes_and_timestamps
                     ; git_commit
-                    ; uptime_minutes }
+                    ; uptime_minutes
+                    ; block_height_opt }
           in
           let get_some_initial_peers _ =
             match !net_ref with

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -595,7 +595,7 @@ module Rpcs = struct
                 (State_hash.Stable.V1.t * string) list
             ; git_commit: string
             ; uptime_minutes: int
-            ; block_height_opt: int option }
+            ; block_height_opt: int option [@default None] }
           [@@deriving to_yojson, of_yojson]
 
           let to_latest = Fn.id
@@ -631,7 +631,7 @@ module Rpcs = struct
             ; uptime_minutes: int }
           [@@deriving to_yojson, of_yojson]
 
-          let to_latest status : V2.t =
+          let to_latest status : Latest.t =
             { node_ip_addr= status.node_ip_addr
             ; node_peer_id= status.node_peer_id
             ; sync_status= status.sync_status

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -567,6 +567,40 @@ module Rpcs = struct
     module Node_status = struct
       [%%versioned
       module Stable = struct
+        module V2 = struct
+          type t =
+            { node_ip_addr: Core.Unix.Inet_addr.Stable.V1.t
+                  [@to_yojson
+                    fun ip_addr -> `String (Unix.Inet_addr.to_string ip_addr)]
+                  [@of_yojson
+                    function
+                    | `String s ->
+                        Ok (Unix.Inet_addr.of_string s)
+                    | _ ->
+                        Error "expected string"]
+            ; node_peer_id: Network_peer.Peer.Id.Stable.V1.t
+                  [@to_yojson fun peer_id -> `String peer_id]
+                  [@of_yojson
+                    function `String s -> Ok s | _ -> Error "expected string"]
+            ; sync_status: Sync_status.Stable.V1.t
+            ; peers: Network_peer.Peer.Stable.V1.t list
+            ; block_producers:
+                Signature_lib.Public_key.Compressed.Stable.V1.t list
+            ; protocol_state_hash: State_hash.Stable.V1.t
+            ; ban_statuses:
+                ( Network_peer.Peer.Stable.V1.t
+                * Trust_system.Peer_status.Stable.V1.t )
+                list
+            ; k_block_hashes_and_timestamps:
+                (State_hash.Stable.V1.t * string) list
+            ; git_commit: string
+            ; uptime_minutes: int
+            ; block_height_opt: int option }
+          [@@deriving to_yojson, of_yojson]
+
+          let to_latest = Fn.id
+        end
+
         module V1 = struct
           type t =
             { node_ip_addr: Core.Unix.Inet_addr.Stable.V1.t
@@ -597,7 +631,19 @@ module Rpcs = struct
             ; uptime_minutes: int }
           [@@deriving to_yojson, of_yojson]
 
-          let to_latest = Fn.id
+          let to_latest status : V2.t =
+            { node_ip_addr= status.node_ip_addr
+            ; node_peer_id= status.node_peer_id
+            ; sync_status= status.sync_status
+            ; peers= status.peers
+            ; block_producers= status.block_producers
+            ; protocol_state_hash= status.protocol_state_hash
+            ; ban_statuses= status.ban_statuses
+            ; k_block_hashes_and_timestamps=
+                status.k_block_hashes_and_timestamps
+            ; git_commit= status.git_commit
+            ; uptime_minutes= status.uptime_minutes
+            ; block_height_opt= None }
         end
       end]
     end
@@ -622,7 +668,7 @@ module Rpcs = struct
     let response_to_yojson response =
       match response with
       | Ok status ->
-          Node_status.Stable.V1.to_yojson status
+          Node_status.Stable.Latest.to_yojson status
       | Error err ->
           `Assoc [("error", Error_json.error_to_yojson err)]
 
@@ -630,6 +676,34 @@ module Rpcs = struct
       include M
       include Master
     end)
+
+    module V2 = struct
+      module T = struct
+        type query = unit [@@deriving bin_io, sexp, version {rpc}]
+
+        type response =
+          Node_status.Stable.V2.t Core_kernel.Or_error.Stable.V1.t
+        [@@deriving bin_io, version {rpc}]
+
+        let query_of_caller_model = Fn.id
+
+        let callee_model_of_query = Fn.id
+
+        let response_of_callee_model = Fn.id
+
+        let caller_model_of_response = Fn.id
+      end
+
+      module T' =
+        Perf_histograms.Rpc.Plain.Decorate_bin_io (struct
+            include M
+            include Master
+          end)
+          (T)
+
+      include T'
+      include Register (T')
+    end
 
     module V1 = struct
       module T = struct
@@ -643,9 +717,28 @@ module Rpcs = struct
 
         let callee_model_of_query = Fn.id
 
-        let response_of_callee_model = Fn.id
+        let response_of_callee_model = function
+          | Error err ->
+              Error err
+          | Ok (status : Node_status.Stable.Latest.t) ->
+              Ok
+                { Node_status.Stable.V1.node_ip_addr= status.node_ip_addr
+                ; node_peer_id= status.node_peer_id
+                ; sync_status= status.sync_status
+                ; peers= status.peers
+                ; block_producers= status.block_producers
+                ; protocol_state_hash= status.protocol_state_hash
+                ; ban_statuses= status.ban_statuses
+                ; k_block_hashes_and_timestamps=
+                    status.k_block_hashes_and_timestamps
+                ; git_commit= status.git_commit
+                ; uptime_minutes= status.uptime_minutes }
 
-        let caller_model_of_response = Fn.id
+        let caller_model_of_response = function
+          | Error err ->
+              Error err
+          | Ok (status : Node_status.Stable.V1.t) ->
+              Ok (Node_status.Stable.V1.to_latest status)
       end
 
       module T' =

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -91,7 +91,7 @@ module Rpcs : sig
     module Node_status : sig
       [%%versioned:
       module Stable : sig
-        module V1 : sig
+        module V2 : sig
           type t =
             { node_ip_addr: Core.Unix.Inet_addr.Stable.V1.t
             ; node_peer_id: Peer.Id.Stable.V1.t
@@ -107,7 +107,8 @@ module Rpcs : sig
             ; k_block_hashes_and_timestamps:
                 (State_hash.Stable.V1.t * string) list
             ; git_commit: string
-            ; uptime_minutes: int }
+            ; uptime_minutes: int
+            ; block_height_opt: int option }
         end
       end]
     end


### PR DESCRIPTION
Add an optional block height to the node status.

That change required creating `Node_status.V2` (our first version new versioned type!). The node status is an option, so the coercion from `V1` gives `None` for the block height.

The new type version feeds into a new version `V2` for the `Get_node_status` RPC, which requires `response_of_callee_model` and `caller_model_of_response` coercions that are not the identity function.

A perhaps-important observation:

The latter coercion relies on `Node_status.V1.to_latest` function, hence trivial. The other coercion works in the other direction. That means when creating new versions that feed into RPCs, you have to contemplate not only going from an old version to the latest version, but also the reverse. So if your new version elided record fields, for example, it may not be possible to go from the new version to the old version.

Closes #8354.