### PR TITLE
[master-qa] Track libp2p_helper process termination in Child_processes.Termination

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1591,6 +1591,7 @@ let generate_libp2p_keypair =
       File_system.with_temp_dir "coda-generate-libp2p-keypair" ~f:(fun tmpd ->
           match%bind
             Mina_net2.create ~logger ~conf_dir:tmpd
+              ~pids:(Child_processes.Termination.create_pid_table ())
               ~on_unexpected_termination:(fun () ->
                 raise Child_processes.Child_died )
           with

--- a/src/app/cli/src/mina.ml
+++ b/src/app/cli/src/mina.ml
@@ -1037,8 +1037,8 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
         ; is_seed
         ; creatable_gossip_net=
             Mina_networking.Gossip_net.(
-              Any.Creatable ((module Libp2p), Libp2p.create gossip_net_params))
-        }
+              Any.Creatable
+                ((module Libp2p), Libp2p.create ~pids gossip_net_params)) }
       in
       (* log terminated child processes *)
       O1trace.trace_task "terminated child loop" terminated_child_loop ;

--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -11,7 +11,9 @@ type ports = {communication_port: int; discovery_port: int; libp2p_port: int}
 let net_configs n =
   File_system.with_temp_dir "coda-processes-generate-keys" ~f:(fun tmpd ->
       let%bind net =
-        Mina_net2.create ~logger:(Logger.create ()) ~conf_dir:tmpd
+        Mina_net2.create
+          ~pids:(Child_processes.Termination.create_pid_table ())
+          ~logger:(Logger.create ()) ~conf_dir:tmpd
           ~on_unexpected_termination:(fun () ->
             raise Child_processes.Child_died )
       in

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -444,7 +444,8 @@ module T = struct
             ; creatable_gossip_net=
                 Mina_networking.Gossip_net.(
                   Any.Creatable
-                    ((module Libp2p), Libp2p.create gossip_net_params)) }
+                    ((module Libp2p), Libp2p.create gossip_net_params ~pids))
+            }
           in
           let monitor = Async.Monitor.create ~name:"coda" () in
           let with_monitor f input =

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -167,8 +167,8 @@ let run_test () : unit Deferred.t =
               ; new_state= false }
           ; creatable_gossip_net=
               Mina_networking.Gossip_net.(
-                Any.Creatable ((module Libp2p), Libp2p.create gossip_net_params))
-          }
+                Any.Creatable
+                  ((module Libp2p), Libp2p.create ~pids gossip_net_params)) }
       in
       Core.Backtrace.elide := false ;
       Async.Scheduler.set_record_backtraces true ;

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -263,8 +263,10 @@ let start_custom :
     Deferred.map ~f:Or_error.return
     @@ maybe_kill_and_unlock name lock_path logger
   in
-  [%log debug] "Starting custom child process %s with args $args" name
-    ~metadata:[("args", `List (List.map args ~f:(fun a -> `String a)))] ;
+  [%log debug] "Starting custom child process $name with args $args"
+    ~metadata:
+      [ ("name", `String name)
+      ; ("args", `List (List.map args ~f:(fun a -> `String a))) ] ;
   let%bind coda_binary_path = get_coda_binary () in
   let relative_to_root =
     get_project_root ()
@@ -279,6 +281,11 @@ let start_custom :
          ; Some ("coda-" ^ name) ])
       ~f:(fun prog -> Process.create ~stdin:"" ~prog ~args ())
   in
+  [%log info] "Custom child process $name started with pid $pid"
+    ~metadata:
+      [ ("name", `String name)
+      ; ("args", `List (List.map args ~f:(fun a -> `String a)))
+      ; ("pid", `Int (Process.pid process |> Pid.to_int)) ] ;
   (* Handle implicit raciness in the wait syscall by calling [Process.wait]
      early, so that its value will be correctly cached when we actually need
      it.

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -379,9 +379,10 @@ let kill : t -> Unix.Exit_or_signal.t Deferred.Or_error.t =
   | Some _ ->
       Deferred.Or_error.error_string "already terminated"
 
-let register_process ?termination_expected (t : Termination.t) (process : t)
-    kind =
-  Termination.register_process ?termination_expected t process.process kind
+let register_process ?termination_expected (termination : Termination.t)
+    (process : t) kind =
+  Termination.register_process ?termination_expected termination
+    process.process kind
 
 let%test_module _ =
   ( module struct

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -394,6 +394,10 @@ let kill : t -> Unix.Exit_or_signal.t Deferred.Or_error.t =
   | Some _ ->
       Deferred.Or_error.error_string "already terminated"
 
+let register_process ?termination_expected (t : Termination.t) (process : t)
+    kind =
+  Termination.register_process ?termination_expected t process.process kind
+
 let%test_module _ =
   ( module struct
     let logger = Logger.create ()

--- a/src/lib/child_processes/child_processes.mli
+++ b/src/lib/child_processes/child_processes.mli
@@ -72,3 +72,10 @@ val kill : t -> Unix.Exit_or_signal.t Deferred.Or_error.t
 (* val start_rpc_worker : ... *)
 
 module Termination : module type of Termination
+
+val register_process :
+     ?termination_expected:bool
+  -> Termination.t
+  -> t
+  -> Termination.process_kind
+  -> unit

--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -6,7 +6,7 @@ open Async
 open Core_kernel
 include Hashable.Make_binable (Pid)
 
-type process_kind = Prover | Verifier
+type process_kind = Prover | Verifier | Libp2p_helper
 [@@deriving show {with_path= false}, yojson]
 
 type data = {kind: process_kind; termination_expected: bool}

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -44,7 +44,11 @@ end
 module type S = sig
   include Intf.Gossip_net_intf
 
-  val create : Config.t -> Rpc_intf.rpc_handler list -> t Deferred.t
+  val create :
+       Config.t
+    -> pids:Child_processes.Termination.t
+    -> Rpc_intf.rpc_handler list
+    -> t Deferred.t
 end
 
 let rpc_transport_proto = "coda/rpcs/0.0.1"
@@ -132,7 +136,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
     (* Creates just the helper, making sure to register everything
        BEFORE we start listening/advertise ourselves for discovery. *)
     let create_libp2p (config : Config.t) rpc_handlers first_peer_ivar
-        high_connectivity_ivar ~added_seeds ~on_unexpected_termination =
+        high_connectivity_ivar ~added_seeds ~pids ~on_unexpected_termination =
       let%bind seeds_from_url =
         match config.seed_peer_list_url with
         | None ->
@@ -149,7 +153,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
       match%bind
         Monitor.try_with ~rest:`Raise (fun () ->
             trace "mina_net2" (fun () ->
-                Mina_net2.create ~logger:config.logger ~conf_dir
+                Mina_net2.create ~logger:config.logger ~conf_dir ~pids
                   ~on_unexpected_termination ) )
       with
       | Ok (Ok net2) -> (
@@ -418,7 +422,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
 
     let peers t = !(t.net2) >>= Mina_net2.peers
 
-    let create (config : Config.t) rpc_handlers =
+    let create (config : Config.t) ~pids rpc_handlers =
       let first_peer_ivar = Ivar.create () in
       let high_connectivity_ivar = Ivar.create () in
       let message_reader, message_writer =
@@ -471,12 +475,14 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
         and on_unexpected_termination () =
           on_libp2p_create
             (create_libp2p config rpc_handlers first_peer_ivar
-               high_connectivity_ivar ~added_seeds ~on_unexpected_termination) ;
+               high_connectivity_ivar ~added_seeds ~pids
+               ~on_unexpected_termination) ;
           Deferred.unit
         in
         let res =
           create_libp2p config rpc_handlers first_peer_ivar
-            high_connectivity_ivar ~added_seeds ~on_unexpected_termination
+            high_connectivity_ivar ~added_seeds ~pids
+            ~on_unexpected_termination
         in
         on_libp2p_create res ;
         don't_wait_for

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -214,6 +214,7 @@ end
 val create :
      on_unexpected_termination:(unit -> unit Deferred.t)
   -> logger:Logger.t
+  -> pids:Child_processes.Termination.t
   -> conf_dir:string
   -> net Deferred.Or_error.t
 


### PR DESCRIPTION
It seems likely that the remaining WNOHANG crashes are coming from the libp2p_helper process. This PR adds the `child_data` metadata that we need to confirm this for to libp2p_helper processes, and also a log message for the process ID to help us track the process lifetime.

This change is a no-op except for the more detailed logging.

Sample log [here](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22o1labs-192920%22%0Aresource.labels.location%3D%22us-east1%22%0Aresource.labels.cluster_name%3D%22coda-infra-east%22%0Aresource.labels.namespace_name%3D%22mainnet%22%0Aresource.labels.pod_name%3D%22seed-3-77994d66b8-q4px9%22%0Aresource.labels.container_name%3D%22coda%22%0Atimestamp%3D%222021-03-23T06:36:07.433039953Z%22%0AinsertId%3D%22pscwhwgyl57djyydr%22;timeRange=2021-03-23T06:36:00.000Z%2F2021-03-23T06:36:45.000Z?project=o1labs-192920) (the `Unhandled toplevel exception` is the next log message):
```json
{
  "level": "Info",
  "metadata": {
    "pid": 12,
    "child_data": null,
    "peer_id": "12D3KooWNofeYVAJXA3WGg2qCDhs3GEe71kTmKpFQXRbZmCz1Vr7",
    "child_pid": 31550
  },
  "message": "Daemon child process $child_pid terminated with exit code 0",
  "timestamp": "2021-03-23 06:36:06.828828Z",
  "source": {
    "module": "Dune__exe__Mina",
    "location": "File \"src/app/cli/src/mina.ml\", line 538, characters 14-25"
  }
}
{
  "timestamp": "2021-03-23 06:36:06.829099Z",
  "level": "Fatal",
  "message": "Unhandled top-level exception: $exn\nGenerating crash report",
  "metadata": {
    "pid": 12,
    "peer_id": "12D3KooWNofeYVAJXA3WGg2qCDhs3GEe71kTmKpFQXRbZmCz1Vr7",
    "exn": {
      "commit_id": "1bc4a10ad7a51ddbb505b1f2fb7bfd8cf01d46e0",
      "sexp": [
        "monitor.ml.Error",
        [
          "Unix.Unix_error",
          "No child processes",
          "waitpid",
          "((mode (WNOHANG)) (pid 31550))"
        ],
        [
          "Raised at file \"src/core_unix.ml\", line 50, characters 4-43",
          "Called from file \"src/core_unix.ml\", line 930, characters 4-246",
          "Called from file \"src/unix_syscalls.ml\", line 596, characters 10-39",
          "Called from file \"src/unix_syscalls.ml\" (inlined), line 602, characters 21-55",
          "Called from file \"src/unix_syscalls.ml\", line 610, characters 33-48",
          "Called from file \"camlinternalLazy.ml\", line 27, characters 17-27",
          "Re-raised at file \"camlinternalLazy.ml\", line 34, characters 4-11",
          "Called from file \"src/process.ml\" (inlined), line 142, characters 13-25",
          "Called from file \"src/process.ml\", line 148, characters 25-31",
          "Called from file \"src/deferred0.ml\", line 56, characters 64-69",
          "Called from file \"src/job_queue.ml\" (inlined), line 131, characters 2-5",
          "Called from file \"src/job_queue.ml\", line 171, characters 6-47",
          "Caught by monitor coda"
        ]
      ],
      "backtrace": [
        "Raised at file \"lib/read.mll\", line 712, characters 13-36",
        "Called from file \"lib/read.mll\", line 241, characters 23-47"
      ]
    }
  },
  "source": {
    "module": "Init__Coda_run",
    "location": "File \"src/app/cli/src/init/coda_run.ml\", line 603, characters 2-26"
  }
}
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: