### PR TITLE
hotfix/rename-critical-metrics 

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1423,7 +1423,7 @@ type successResult struct {
 }
 
 var connectionCountMetric = prometheus.NewGauge(prometheus.GaugeOpts{
-	Name: "connection_count",
+	Name: "Coda_active_connections_total",
 	Help: "Number of active connections, according to the CodaConnectionManager.",
 })
 


### PR DESCRIPTION
Update connection count metric to use Coda_ prefix, leave others as-is.

Currently this is the only metric we explicitly expose, the rest are default `proccess_` and `go_` metrics (and some meta-metrics for the metrics server). Based on the documentation for the libraries we are using and prometheus it is not recommended to adjust the prefix of these metrics, instead there will be a follow-up PR to forward those prefixes to grafana cloud alongside the ones we already send.
