### PR TITLE
Bump ppx_version

### DIFF
--- a/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
@@ -28,8 +28,7 @@ Pipeline.build
       JobSpec::{
         dirtyWhen = [
           S.strictly (S.contains "Makefile"),
-          S.strictlyStart (S.contains "src/app/archive"),
-          S.strictlyStart (S.contains "src/app/test-executive"),
+          S.strictlyStart (S.contains "src"),
           S.strictlyStart (S.contains "scripts/archive"),
           S.strictlyStart (S.contains "automation"),
           S.strictlyStart (S.contains "buildkite/src/Jobs/Release/ArchiveNodeArtifact")

--- a/buildkite/src/Jobs/Release/ArchiveRedundancyTools.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveRedundancyTools.dhall
@@ -30,10 +30,7 @@ Pipeline.build
     spec =
       JobSpec::{
         dirtyWhen = [
-            S.strictlyStart (S.contains "src/app/archive"),
-            S.strictlyStart (S.contains "src/app/extract_blocks"),
-            S.strictlyStart (S.contains "src/app/missing_blocks_auditor"),
-            S.strictlyStart (S.contains "src/app/archive_blocks"),
+            S.strictlyStart (S.contains "src"),
             S.strictlyStart (S.contains "scripts/archive"),
             S.strictlyStart (S.contains "automation"),
             S.strictlyStart (S.contains "buildkite/src/Jobs/Release/ArchiveNodeArtifact"),

--- a/src/lib/allocation_functor/make.ml
+++ b/src/lib/allocation_functor/make.ml
@@ -120,7 +120,7 @@ module Versioned_v1 = struct
 
       let versions = M.Stable.versions
 
-      let deserialize_binary_opt = M.Stable.deserialize_binary_opt
+      let bin_read_to_latest_opt = M.Stable.bin_read_to_latest_opt
     end
 
     type t = Stable.V1.t
@@ -149,7 +149,7 @@ module Versioned_v1 = struct
 
       let versions = M.Stable.versions
 
-      let deserialize_binary_opt = M.Stable.deserialize_binary_opt
+      let bin_read_to_latest_opt = M.Stable.bin_read_to_latest_opt
     end
 
     type t = Stable.V1.t
@@ -178,7 +178,7 @@ module Versioned_v1 = struct
 
       let versions = M.Stable.versions
 
-      let deserialize_binary_opt = M.Stable.deserialize_binary_opt
+      let bin_read_to_latest_opt = M.Stable.bin_read_to_latest_opt
     end
 
     type t = Stable.V1.t
@@ -216,7 +216,7 @@ module Versioned_v1 = struct
 
       let versions = M.Stable.versions
 
-      let deserialize_binary_opt = M.Stable.deserialize_binary_opt
+      let bin_read_to_latest_opt = M.Stable.bin_read_to_latest_opt
     end
 
     type t = Stable.V1.t
@@ -253,7 +253,7 @@ module Versioned_v1 = struct
 
       let versions = M.Stable.versions
 
-      let deserialize_binary_opt = M.Stable.deserialize_binary_opt
+      let bin_read_to_latest_opt = M.Stable.bin_read_to_latest_opt
     end
 
     type t = Stable.V1.t


### PR DESCRIPTION
Bump commit of `ppx_version` submodule.

In that library, `deserialize_binary_opt` was renamed to `bin_read_to_latest_opt`. The signature for that function is changed to use a `pos_ref` argument; there was a bug involving buffer offsets, fixed.

Thanks to Gregg Reynolds who contributed patches to the expected test results, and patches to the Bazel code.