### PR TITLE
Receiver balances in internal cmds, not balance ids

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -137,9 +137,12 @@ module Timing_info = struct
     let%bind pk_id = Public_key.find (module Conn) acc.public_key in
     Conn.find
       (Caqti_request.find Caqti_type.int typ
-         "SELECT public_key_id, token, initial_balance, \
-          initial_minimum_balance, cliff_time, cliff_amount, vesting_period, \
-          vesting_increment FROM timing_info WHERE public_key_id = ?")
+         {sql| SELECT public_key_id, token, initial_balance,
+                      initial_minimum_balance, cliff_time, cliff_amount,
+                      vesting_period, vesting_increment
+               FROM timing_info
+               WHERE public_key_id = ?
+         |sql})
       pk_id
 
   let find_by_pk_opt (module Conn : CONNECTION) public_key =
@@ -147,9 +150,12 @@ module Timing_info = struct
     let%bind pk_id = Public_key.find (module Conn) public_key in
     Conn.find_opt
       (Caqti_request.find_opt Caqti_type.int typ
-         "SELECT public_key_id, token, initial_balance, \
-          initial_minimum_balance, cliff_time, cliff_amount, vesting_period, \
-          vesting_increment FROM timing_info WHERE public_key_id = ?")
+         {sql| SELECT public_key_id, token, initial_balance,
+                     initial_minimum_balance, cliff_time, cliff_amount,
+                     vesting_period, vesting_increment
+               FROM timing_info
+               WHERE public_key_id = ?
+         |sql})
       pk_id
 
   let add_if_doesn't_exist (module Conn : CONNECTION) (acc : Account.t) =
@@ -745,17 +751,34 @@ module Balance = struct
 end
 
 module Block_and_internal_command = struct
+  type t =
+    { block_id: int
+    ; internal_command_id: int
+    ; sequence_no: int
+    ; secondary_sequence_no: int
+    ; receiver_balance_id: int }
+  [@@deriving hlist]
+
+  let typ =
+    let open Caqti_type_spec in
+    let spec = Caqti_type.[int; int; int; int; int] in
+    let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
+    let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
+    Caqti_type.custom ~encode ~decode (to_rep spec)
+
   let add (module Conn : CONNECTION) ~block_id ~internal_command_id
       ~sequence_no ~secondary_sequence_no ~receiver_balance_id =
     Conn.exec
-      (Caqti_request.exec
-         Caqti_type.(tup2 (tup4 int int int int) int)
+      (Caqti_request.exec typ
          {sql| INSERT INTO blocks_internal_commands
                 (block_id, internal_command_id, sequence_no, secondary_sequence_no, receiver_balance)
                 VALUES (?, ?, ?, ?, ?)
          |sql})
-      ( (block_id, internal_command_id, sequence_no, secondary_sequence_no)
-      , receiver_balance_id )
+      { block_id
+      ; internal_command_id
+      ; sequence_no
+      ; secondary_sequence_no
+      ; receiver_balance_id }
 
   let find (module Conn : CONNECTION) ~block_id ~internal_command_id
       ~sequence_no ~secondary_sequence_no =

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -238,7 +238,7 @@ let fill_in_internal_commands pool block_state_hash =
     query_db
       ~item:
         "internal command id, global_slot, sequence no, secondary sequence \
-         no, receiver_balance" ~f:(fun db ->
+         no, receiver_balance_id" ~f:(fun db ->
         Sql.Blocks_and_internal_commands.run db ~block_id )
   in
   Deferred.List.map internal_cmd_info
@@ -246,10 +246,14 @@ let fill_in_internal_commands pool block_state_hash =
             ; global_slot
             ; sequence_no
             ; secondary_sequence_no
-            ; receiver_balance }
+            ; receiver_balance_id }
        ->
+      let%bind _pubkey, receiver_balance_int64 =
+        query_db ~item:"receiver balance" ~f:(fun db ->
+            Processor.Balance.load db ~id:receiver_balance_id )
+      in
       let receiver_balance =
-        receiver_balance |> Unsigned.UInt64.of_int64
+        Unsigned.UInt64.of_int64 receiver_balance_int64
         |> Currency.Balance.of_uint64
       in
       (* pieces from the internal_commands table *)

--- a/src/app/extract_blocks/sql.ml
+++ b/src/app/extract_blocks/sql.ml
@@ -104,12 +104,12 @@ module Blocks_and_internal_commands = struct
     ; global_slot: int64
     ; sequence_no: int
     ; secondary_sequence_no: int
-    ; receiver_balance: int64 }
+    ; receiver_balance_id: int }
   [@@deriving hlist]
 
   let typ =
     let open Archive_lib.Processor.Caqti_type_spec in
-    let spec = Caqti_type.[int; int64; int; int; int64] in
+    let spec = Caqti_type.[int; int64; int; int; int] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
     Caqti_type.custom ~encode ~decode (to_rep spec)


### PR DESCRIPTION
The program to compare a poked-and-patched archive db with an original archive db indicated that the balances in internal commands differed. The bug was that the balance ids instead of the actual balances were placed in the internal commands in extracted blocks.

After making this fix, the program to compare archive dbs succeeded. That will be a separate PR.

There's also a little cleanup in `Archive_lib.Processor` here.