### PR TITLE
5-wires plonk gate checks

### DIFF
--- a/src/lib/pickles/plonk_checks/gates/dune
+++ b/src/lib/pickles/plonk_checks/gates/dune
@@ -1,0 +1,13 @@
+(library
+ (name plonk_check_gates)
+ (public_name pickles.plonk_check_gates)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_coda ppx_version ppx_jane ppx_deriving.std ppx_deriving_yojson))
+ (libraries
+   composition_types
+   pickles_base
+
+   zexe_backend
+   pickles_types
+   snarky.backendless
+   core_kernel))

--- a/src/lib/pickles/plonk_checks/gates/ecadd_5_wires.ml
+++ b/src/lib/pickles/plonk_checks/gates/ecadd_5_wires.ml
@@ -1,0 +1,38 @@
+let range = (7, 10)
+
+module Aux_data = struct
+  type _ t = unit
+end
+
+type 'a checks = 'a * 'a * 'a
+
+type 'a check_evals = 'a
+
+let checks (type t) (module F : Intf.Field_intf with type t = t) ~e0 ~e1
+    (() : t Aux_data.t) =
+  let open F in
+  let get = Five_wires_evals.get in
+  let x1 = get L e0 in
+  let y1 = get R e0 in
+  let x2 = get O e0 in
+  let y2 = get Q e0 in
+  let x3 = get L e1 in
+  let y3 = get R e1 in
+  let r = get P e1 in
+  (* Cache some additions *)
+  let y31 = y3 + y1 in
+  let x13 = x1 - x3 in
+  let x21 = x2 - x1 in
+  ( (x21 * y31) - ((y2 - y1) * x13)
+  , ((x1 + x2 + x3) * (x13 * x13)) - (y31 * y31)
+  , (x21 * r) - one )
+
+let check_evals (type t) (module F : Intf.Field_intf with type t = t) alphas
+    ~e0 ~e1 aux =
+  let open F in
+  let check0, check1, check2 = checks (module F) ~e0 ~e1 aux in
+  (check0 * alphas range 0)
+  + (check1 * alphas range 1)
+  + (check2 * alphas range 2)
+
+let fold_check_evals ~init x ~f = f init x

--- a/src/lib/pickles/plonk_checks/gates/ecdouble_5_wires.ml
+++ b/src/lib/pickles/plonk_checks/gates/ecdouble_5_wires.ml
@@ -1,0 +1,40 @@
+let range = (10, 13)
+
+module Aux_data = struct
+  type _ t = unit
+end
+
+type 'a checks = 'a * 'a * 'a
+
+type 'a check_evals = 'a
+
+let checks (type t) (module F : Intf.Field_intf with type t = t) ~e0 ~e1:_
+    (() : t Aux_data.t) =
+  let open F in
+  let get = Five_wires_evals.get in
+  let x1 = get L e0 in
+  let y1 = get R e0 in
+  let x2 = get O e0 in
+  let y2 = get Q e0 in
+  let y1_inv = get P e0 in
+  let pow x i =
+    (* Keep the code tidy, but do powers efficiently. *)
+    if i = 2 then x * x
+    else if i = 4 then
+      let x2 = x * x in
+      x2 * x2
+    else invalid_arg "pow"
+  in
+  ( (of_int 4 * pow y1 2 * (x2 + (of_int 2 * x1))) - (of_int 9 * pow x1 4)
+  , (of_int 2 * y1 * (y2 + y1)) - ((x1 - x2) * of_int 3 * pow x1 2)
+  , (y1 * y1_inv) - one )
+
+let check_evals (type t) (module F : Intf.Field_intf with type t = t) alphas
+    ~e0 ~e1 aux =
+  let open F in
+  let check0, check1, check2 = checks (module F) ~e0 ~e1 aux in
+  (check0 * alphas range 0)
+  + (check1 * alphas range 1)
+  + (check2 * alphas range 2)
+
+let fold_check_evals ~init x ~f = f init x

--- a/src/lib/pickles/plonk_checks/gates/endosclmul_5_wires.ml
+++ b/src/lib/pickles/plonk_checks/gates/endosclmul_5_wires.ml
@@ -1,0 +1,56 @@
+let range = (13, 19)
+
+module Aux_data = struct
+  type 'a t = 'a
+end
+
+type 'a checks = 'a * 'a * 'a * 'a * 'a * 'a
+
+type 'a check_evals = 'a
+
+let checks (type t) (module F : Intf.Field_intf with type t = t) ~e0 ~e1
+    (endo : t Aux_data.t) =
+  let open F in
+  let get = Five_wires_evals.get in
+  let xt = get L e0 in
+  let yt = get R e0 in
+  let s1 = get O e0 in
+  let s2 = get Q e0 in
+  let b1 = get P e0 in
+  let xs = get L e1 in
+  let ys = get R e1 in
+  let xp = get O e1 in
+  let yp = get Q e1 in
+  let b2 = get P e1 in
+  (* Shared values *)
+  let xq = (one + (b2 * (endo - one))) * xt in
+  let pow x i =
+    (* Keep the code tidy, but do powers efficiently. *)
+    if i = 2 then x * x else invalid_arg "pow"
+  in
+  ( (* binary constrain b1 *)
+    b1 - (b1 * b1) (* binary constrain b2 *)
+  , b2 - (b2 * b2)
+  , (* (xp - (1 + (endo - 1) * b2) * xt) * s1 = yp – (2*b1-1)*yt *)
+    ((xp - xq) * s1) - yp + (yt * ((of_int 2 * b1) - one))
+  , (* s1^2 - s2^2 = (1 + (endo - 1) * b2) * xt - xs *)
+    pow s1 2 - pow s2 2 - xq + xs
+  , (* (2*xp + (1 + (endo - 1) * b2) * xt – s1^2) * (s1 + s2) = 2*yp *)
+    (((of_int 2 * xp) + xq - pow s1 2) * (s1 + s2)) - (of_int 2 * yp)
+  , (* (xp – xs) * s2 = ys + yp *)
+    ((xp - xs) * s2) - ys - yp )
+
+let check_evals (type t) (module F : Intf.Field_intf with type t = t) alphas
+    ~e0 ~e1 aux =
+  let open F in
+  let check0, check1, check2, check3, check4, check5 =
+    checks (module F) ~e0 ~e1 aux
+  in
+  (check0 * alphas range 0)
+  + (check1 * alphas range 1)
+  + (check2 * alphas range 2)
+  + (check3 * alphas range 3)
+  + (check4 * alphas range 4)
+  + (check5 * alphas range 5)
+
+let fold_check_evals ~init x ~f = f init x

--- a/src/lib/pickles/plonk_checks/gates/five_wires_cols.ml
+++ b/src/lib/pickles/plonk_checks/gates/five_wires_cols.ml
@@ -1,0 +1,2 @@
+(* TODO: Uplift this. *)
+type t = L | R | O | Q | P

--- a/src/lib/pickles/plonk_checks/gates/five_wires_evals.ml
+++ b/src/lib/pickles/plonk_checks/gates/five_wires_evals.ml
@@ -1,0 +1,40 @@
+(* TODO: Uplift this. *)
+type 'eval t = {l: 'eval; r: 'eval; o: 'eval; q: 'eval; p: 'eval}
+
+let get (x : Five_wires_cols.t) {l; r; o; q; p} =
+  match x with L -> l | R -> r | O -> o | Q -> q | P -> p
+
+let mapi {l; r; o; q; p} ~f =
+  { l= f Five_wires_cols.L l
+  ; r= f Five_wires_cols.R r
+  ; o= f Five_wires_cols.O o
+  ; q= f Five_wires_cols.Q q
+  ; p= f Five_wires_cols.P p }
+
+let map x ~f = mapi x ~f:(fun _ -> f)
+
+let map2i x y ~f = mapi x ~f:(fun idx x -> f idx x (get idx y))
+
+let map2 x ~f = map2i x ~f:(fun _ -> f)
+
+let foldi {l; r; o; q; p} ~init ~f =
+  let acc = init in
+  let acc = f Five_wires_cols.L acc l in
+  let acc = f Five_wires_cols.R acc r in
+  let acc = f Five_wires_cols.O acc o in
+  let acc = f Five_wires_cols.Q acc q in
+  let acc = f Five_wires_cols.P acc p in
+  acc
+
+let fold x ~init ~f = foldi x ~init ~f:(fun _ -> f)
+
+let fold2i x y ~init ~f =
+  foldi x ~init ~f:(fun idx acc x -> f idx acc x (get idx y))
+
+let fold2 x y ~init ~f = fold2i x y ~init ~f:(fun _ -> f)
+
+let reduce {l; r; o; q; p} ~f =
+  let acc = f l r in
+  let acc = f acc o in
+  let acc = f acc q in
+  f acc p

--- a/src/lib/pickles/plonk_checks/gates/five_wires_gates.ml
+++ b/src/lib/pickles/plonk_checks/gates/five_wires_gates.ml
@@ -1,0 +1,222 @@
+(* Dedicated functor for the type, since instantiating it will be optimised out
+   if there are no values.
+*)
+
+module Utils = struct
+  module Id = struct
+    type 'a t = 'a
+  end
+
+  module Gate_id (Gate : Intf.Five_wires_gate_intf) = Id
+
+  module Constant (A : sig
+    type t
+  end) =
+  struct
+    type 'a t = A.t
+  end
+
+  module Gate_constant (A : sig
+    type t
+  end)
+  (Gate : Intf.Five_wires_gate_intf) =
+    Constant (A)
+
+  module Gate_aux_data (Gate : Intf.Five_wires_gate_intf) = struct
+    type 'a t = 'a Gate.Aux_data.t
+  end
+
+  module Gate_check_evals (Gate : Intf.Five_wires_gate_intf) = struct
+    type 'a t = 'a Gate.check_evals
+  end
+end
+
+module T (F : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  type 'a t
+end) =
+struct
+  type 'a t =
+    { poseidon: 'a F(Poseidon_5_wires).t
+    ; ecadd: 'a F(Ecadd_5_wires).t
+    ; ecdouble: 'a F(Ecdouble_5_wires).t
+    ; endosclmul: 'a F(Endosclmul_5_wires).t
+    ; packing: 'a F(Packing_5_wires).t
+    ; varbasemul: 'a F(Varbasemul_5_wires).t
+    ; varbasemulpack: 'a F(Varbasemulpack_5_wires).t }
+end
+
+module Make_functions
+    (Combinator : functor
+      (Gate : Intf.Five_wires_gate_intf)
+      -> sig
+  type 'a t
+end) (A : sig
+  type t
+end) (Fn : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  val f : A.t Combinator(Gate).t
+end) =
+struct
+  let fns : A.t T(Combinator).t =
+    { poseidon=
+        (let module M = Fn (Poseidon_5_wires) in
+        M.f)
+    ; ecadd=
+        (let module M = Fn (Ecadd_5_wires) in
+        M.f)
+    ; ecdouble=
+        (let module M = Fn (Ecdouble_5_wires) in
+        M.f)
+    ; endosclmul=
+        (let module M = Fn (Endosclmul_5_wires) in
+        M.f)
+    ; packing=
+        (let module M = Fn (Packing_5_wires) in
+        M.f)
+    ; varbasemul=
+        (let module M = Fn (Varbasemul_5_wires) in
+        M.f)
+    ; varbasemulpack=
+        (let module M = Fn (Varbasemulpack_5_wires) in
+        M.f) }
+end
+
+module Map (F1 : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  type 'a t
+end) (F2 : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  type 'a t
+end) (A : sig
+  type _ t
+end) (B : sig
+  type _ t
+end) (Map : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  val f : 'f A.t F1(Gate).t -> 'f B.t F2(Gate).t
+end) =
+struct
+  let f (type f) (t : f A.t T(F1).t) : f B.t T(F2).t =
+    let module Fn (Gate : Intf.Five_wires_gate_intf) = struct
+      type 'f t = 'f A.t F1(Gate).t -> 'f B.t F2(Gate).t
+    end in
+    let module Fns =
+      Make_functions
+        (Fn)
+        (struct
+          type t = f
+        end)
+        (Map)
+    in
+    { poseidon= Fns.fns.poseidon t.poseidon
+    ; ecadd= Fns.fns.ecadd t.ecadd
+    ; ecdouble= Fns.fns.ecdouble t.ecdouble
+    ; endosclmul= Fns.fns.endosclmul t.endosclmul
+    ; packing= Fns.fns.packing t.packing
+    ; varbasemul= Fns.fns.varbasemul t.varbasemul
+    ; varbasemulpack= Fns.fns.varbasemulpack t.varbasemulpack }
+end
+
+module Map2 (F1 : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  type 'a t
+end) (F2 : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  type 'a t
+end) (F3 : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  type 'a t
+end) (A : sig
+  type _ t
+end) (B : sig
+  type _ t
+end) (C : sig
+  type _ t
+end) (Map2 : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  val f : 'f A.t F1(Gate).t -> 'f B.t F2(Gate).t -> 'f C.t F3(Gate).t
+end) =
+struct
+  let f (type f) (t1 : f A.t T(F1).t) (t2 : f B.t T(F2).t) : f C.t T(F3).t =
+    let module Fn (Gate : Intf.Five_wires_gate_intf) = struct
+      type 'f t = 'f A.t F1(Gate).t -> 'f B.t F2(Gate).t -> 'f C.t F3(Gate).t
+    end in
+    let module Fns =
+      Make_functions
+        (Fn)
+        (struct
+          type t = f
+        end)
+        (Map2)
+    in
+    { poseidon= Fns.fns.poseidon t1.poseidon t2.poseidon
+    ; ecadd= Fns.fns.ecadd t1.ecadd t2.ecadd
+    ; ecdouble= Fns.fns.ecdouble t1.ecdouble t2.ecdouble
+    ; endosclmul= Fns.fns.endosclmul t1.endosclmul t2.endosclmul
+    ; packing= Fns.fns.packing t1.packing t2.packing
+    ; varbasemul= Fns.fns.varbasemul t1.varbasemul t2.varbasemul
+    ; varbasemulpack=
+        Fns.fns.varbasemulpack t1.varbasemulpack t2.varbasemulpack }
+end
+
+module Fold (F : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  type 'a t
+end) (A : sig
+  type _ t
+end) (Acc : sig
+  type _ t
+end) (Fold : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  val f : 'f Acc.t -> 'f A.t F(Gate).t -> 'f Acc.t
+end) =
+struct
+  let f (type f) ~init:(acc : f Acc.t) (t : f A.t T(F).t) : f Acc.t =
+    let module Fn (Gate : Intf.Five_wires_gate_intf) = struct
+      type 'f t = 'f Acc.t -> 'f A.t F(Gate).t -> 'f Acc.t
+    end in
+    let module Fns =
+      Make_functions
+        (Fn)
+        (struct
+          type t = f
+        end)
+        (Fold)
+    in
+    let acc = Fns.fns.poseidon acc t.poseidon in
+    let acc = Fns.fns.ecadd acc t.ecadd in
+    let acc = Fns.fns.ecdouble acc t.ecdouble in
+    let acc = Fns.fns.endosclmul acc t.endosclmul in
+    let acc = Fns.fns.packing acc t.packing in
+    let acc = Fns.fns.varbasemul acc t.varbasemul in
+    let acc = Fns.fns.varbasemulpack acc t.varbasemulpack in
+    acc
+end
+
+module Fold2 (F1 : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  type 'a t
+end) (F2 : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  type 'a t
+end) (A : sig
+  type _ t
+end) (B : sig
+  type _ t
+end) (Acc : sig
+  type _ t
+end) (Fold2 : functor (Gate : Intf.Five_wires_gate_intf) -> sig
+  val f : 'f Acc.t -> 'f A.t F1(Gate).t -> 'f B.t F2(Gate).t -> 'f Acc.t
+end) =
+struct
+  let f (type f) ~init:(acc : f Acc.t) (t1 : f A.t T(F1).t)
+      (t2 : f B.t T(F2).t) : f Acc.t =
+    let module Fn (Gate : Intf.Five_wires_gate_intf) = struct
+      type 'f t =
+        'f Acc.t -> 'f A.t F1(Gate).t -> 'f B.t F2(Gate).t -> 'f Acc.t
+    end in
+    let module Fns =
+      Make_functions
+        (Fn)
+        (struct
+          type t = f
+        end)
+        (Fold2)
+    in
+    let acc = Fns.fns.poseidon acc t1.poseidon t2.poseidon in
+    let acc = Fns.fns.ecadd acc t1.ecadd t2.ecadd in
+    let acc = Fns.fns.ecdouble acc t1.ecdouble t2.ecdouble in
+    let acc = Fns.fns.endosclmul acc t1.endosclmul t2.endosclmul in
+    let acc = Fns.fns.packing acc t1.packing t2.packing in
+    let acc = Fns.fns.varbasemul acc t1.varbasemul t2.varbasemul in
+    let acc = Fns.fns.varbasemulpack acc t1.varbasemulpack t2.varbasemulpack in
+    acc
+end

--- a/src/lib/pickles/plonk_checks/gates/intf.ml
+++ b/src/lib/pickles/plonk_checks/gates/intf.ml
@@ -1,0 +1,46 @@
+module type Field_intf = sig
+  type t
+
+  val size_in_bits : int
+
+  val one : t
+
+  val of_int : int -> t
+
+  val ( * ) : t -> t -> t
+
+  val ( / ) : t -> t -> t
+
+  val ( + ) : t -> t -> t
+
+  val ( - ) : t -> t -> t
+
+  val negate : t -> t
+end
+
+module type Five_wires_gate_intf = sig
+  val range : int * int
+
+  module Aux_data : sig
+    type 'f t
+  end
+
+  type 'f checks
+
+  type 'f check_evals
+
+  val checks :
+       (module Field_intf with type t = 'f)
+    -> e0:'f Five_wires_evals.t
+    -> e1:'f Five_wires_evals.t
+    -> 'f Aux_data.t
+    -> 'f checks
+
+  val check_evals :
+       (module Field_intf with type t = 'f)
+    -> (int * int -> int -> 'f)
+    -> e0:'f Five_wires_evals.t
+    -> e1:'f Five_wires_evals.t
+    -> 'f Aux_data.t
+    -> 'f check_evals
+end

--- a/src/lib/pickles/plonk_checks/gates/packing_5_wires.ml
+++ b/src/lib/pickles/plonk_checks/gates/packing_5_wires.ml
@@ -1,0 +1,47 @@
+let range = (19, 24)
+
+module Aux_data = struct
+  type _ t = unit
+end
+
+type 'a checks = 'a * 'a * 'a * 'a * 'a
+
+type 'a check_evals = 'a
+
+let checks (type t) (module F : Intf.Field_intf with type t = t) ~e0 ~e1
+    (() : t Aux_data.t) =
+  let open F in
+  let get = Five_wires_evals.get in
+  let b0 = get Q e1 in
+  let b1 = get O e1 in
+  let b2 = get R e1 in
+  let b3 = get L e1 in
+  let b4 = get P e0 in
+  let res = get P e1 in
+  ( (* Unpack *)
+    b0
+    + (of_int 2 * b1)
+    + (of_int 4 * b2)
+    + (of_int 8 * b3)
+    + (of_int 16 * b4)
+    - res
+  , (* binary constrain b3 *)
+    b3 - (b3 * b3)
+  , (* binary constrain b2 *)
+    b2 - (b2 * b2)
+  , (* binary constrain b1 *)
+    b1 - (b1 * b1)
+  , (* binary constrain b0 *)
+    b0 - (b0 * b0) )
+
+let check_evals (type t) (module F : Intf.Field_intf with type t = t) alphas
+    ~e0 ~e1 aux =
+  let open F in
+  let check0, check1, check2, check3, check4 = checks (module F) ~e0 ~e1 aux in
+  (check0 * alphas range 0)
+  + (check1 * alphas range 1)
+  + (check2 * alphas range 2)
+  + (check3 * alphas range 3)
+  + (check4 * alphas range 4)
+
+let fold_check_evals ~init x ~f = f init x

--- a/src/lib/pickles/plonk_checks/gates/poseidon_5_wires.ml
+++ b/src/lib/pickles/plonk_checks/gates/poseidon_5_wires.ml
@@ -1,0 +1,43 @@
+let range = (0, 5)
+
+module Aux_data = struct
+  type 'a t = 'a Five_wires_evals.t Five_wires_evals.t
+end
+
+type 'a checks = 'a * 'a * 'a * 'a * 'a
+
+type 'a check_evals = 'a
+
+let checks (type t) (module F : Intf.Field_intf with type t = t) ~e0 ~e1
+    (mds : t Aux_data.t) =
+  let open F in
+  let get = Five_wires_evals.get in
+  let sbox x =
+    (* x^7 *)
+    let x2 = x * x in
+    let x4 = x2 * x2 in
+    x * x2 * x4
+  in
+  let sboxes = Five_wires_evals.map ~f:sbox e0 in
+  let lro =
+    Five_wires_evals.map mds ~f:(fun mds ->
+        Five_wires_evals.map2 sboxes mds ~f:( * )
+        |> Five_wires_evals.reduce ~f:( + ) )
+  in
+  ( get L lro - get L e1
+  , get R lro - get R e1
+  , get O lro - get O e1
+  , get Q lro - get Q e1
+  , get P lro - get P e1 )
+
+let check_evals (type t) (module F : Intf.Field_intf with type t = t) alphas
+    ~e0 ~e1 aux =
+  let open F in
+  let check0, check1, check2, check3, check4 = checks (module F) ~e0 ~e1 aux in
+  (check0 * alphas range 0)
+  + (check1 * alphas range 1)
+  + (check2 * alphas range 2)
+  + (check3 * alphas range 3)
+  + (check4 * alphas range 4)
+
+let fold_check_evals ~init x ~f = f init x

--- a/src/lib/pickles/plonk_checks/gates/varbasemul_5_wires.ml
+++ b/src/lib/pickles/plonk_checks/gates/varbasemul_5_wires.ml
@@ -1,0 +1,49 @@
+let range = (24, 29)
+
+module Aux_data = struct
+  type _ t = unit
+end
+
+type 'a checks = 'a * 'a * 'a * 'a * 'a
+
+type 'a check_evals = 'a
+
+let checks (type t) (module F : Intf.Field_intf with type t = t) ~e0 ~e1
+    (() : t Aux_data.t) =
+  let open F in
+  let get = Five_wires_evals.get in
+  let xt = get L e0 in
+  let yt = get R e0 in
+  let s1 = get O e0 in
+  let s2 = get Q e0 in
+  let b = get P e0 in
+  let xs = get L e1 in
+  let ys = get R e1 in
+  let xp = get O e1 in
+  let yp = get Q e1 in
+  let pow x i =
+    (* Keep the code tidy, but do powers efficiently. *)
+    if i = 2 then x * x else invalid_arg "pow"
+  in
+  ( (* binary constrain b *)
+    b - (b * b)
+  , (* (xp - xt) * s1 = yp – (2b-1)*yt *)
+    ((xp - xt) * s1) - yp + (yt * ((of_int 2 * b) - one))
+  , (* s1^2 - s2^2 = xt - xs *)
+    pow s1 2 - pow s2 2 - xt + xs
+  , (* (2*xp + xt – s1^2) * (s1 + s2) = 2*yp *)
+    (((of_int 2 * xp) + xt - pow s1 2) * (s1 + s2)) - (of_int 2 * yp)
+  , (* (xp – xs) * s2 = ys + yp *)
+    ((xp - xs) * s2) - ys - yp )
+
+let check_evals (type t) (module F : Intf.Field_intf with type t = t) alphas
+    ~e0 ~e1 aux =
+  let open F in
+  let check0, check1, check2, check3, check4 = checks (module F) ~e0 ~e1 aux in
+  (check0 * alphas range 0)
+  + (check1 * alphas range 1)
+  + (check2 * alphas range 2)
+  + (check3 * alphas range 3)
+  + (check4 * alphas range 4)
+
+let fold_check_evals ~init x ~f = f init x

--- a/src/lib/pickles/plonk_checks/gates/varbasemulpack_5_wires.ml
+++ b/src/lib/pickles/plonk_checks/gates/varbasemulpack_5_wires.ml
@@ -1,0 +1,53 @@
+let range = (29, 34)
+
+module Aux_data = struct
+  type _ t = unit
+end
+
+type 'a checks = 'a * 'a * 'a * 'a * 'a
+
+type 'a check_evals = 'a
+
+let checks (type t) (module F : Intf.Field_intf with type t = t) ~e0 ~e1
+    (() : t Aux_data.t) =
+  let open F in
+  let get = Five_wires_evals.get in
+  let xt = get L e0 in
+  let yt = get R e0 in
+  let s1 = get O e0 in
+  let b = get Q e0 in
+  let n1 = get P e0 in
+  let xs = get L e1 in
+  let ys = get R e1 in
+  let xp = get O e1 in
+  let yp = get Q e1 in
+  let n2 = get P e1 in
+  (* Shared values *)
+  let ps = xp - xs in
+  let pow x i =
+    (* Keep the code tidy, but do powers efficiently. *)
+    if i = 2 then x * x else invalid_arg "pow"
+  in
+  ( (* binary constrain b *)
+    b - (b * b)
+  , (* (xp - xt) * s1 = yp – (2b-1)*yt *)
+    ((xp - xt) * s1) - yp + (yt * ((of_int 2 * b) - one))
+  , (* (2*xp – s1^2 + xt) * ((xp – xs) * s1 + ys + yp) = (xp – xs) * 2*yp *)
+    ((of_int 2 * xp) - pow s1 2 + xt)
+    * ((ps * s1) + ys + yp - (of_int 2 * yp * ps))
+  , (* (ys + yp)^2 - (xp – xs)^2 * (s1^2 – xt + xs) *)
+    pow (ys + yp) 2 - (pow ps 2 * (pow s1 2 - xt + xs))
+  , (* n1 - 2*n2 - b *)
+    n1 - (of_int 2 * n2) - b )
+
+let check_evals (type t) (module F : Intf.Field_intf with type t = t) alphas
+    ~e0 ~e1 aux =
+  let open F in
+  let check0, check1, check2, check3, check4 = checks (module F) ~e0 ~e1 aux in
+  (check0 * alphas range 0)
+  + (check1 * alphas range 1)
+  + (check2 * alphas range 2)
+  + (check3 * alphas range 3)
+  + (check4 * alphas range 4)
+
+let fold_check_evals ~init x ~f = f init x


### PR DESCRIPTION
This PR proposes a way to compose plonk gate checks such that we can add or remove gates as needed without either
* using `Hlist`s, with all of the encoding issues that come with them
  - `Five_wires_gates.T(_).t` is a record with a dedicated field for each gate, but is specialised by the argument to contain some data specific to the gate. (Concretely, this means that we can do `x.varbasemul` for any instance, instead of needing to keep hlists in sync.)
  - This gives a much nicer conversion to rust types too: we can use rust generics to keep the structs in sync, or manually specify each instance we need.
  - We have far fewer issues with `bin_prot`: the type is concrete when we know which proof system we're using (which we'd better if we're serialising it!), and so we can just derive on the type `type t = Five_wires_gates.T(Foo).t = { ... }`
* rewriting the logic for interpreting the gates for the different proof systems
  - we achieve this by having a general shape in `Five_wires_gates`: considering only `T`, `Map`, `Map2`, `Fold`, and `Fold2`, we can take the auxiliary data for each gate (e.g. round constants for poseidon), compute the gate evaluations, and check that they were equal to what was expected, all without concern to the number of gates, the shape of wires, etc.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: