### PR TITLE
Use the same code and types for all proof_levels

### DIFF
--- a/src/lib/ledger_proof/dune
+++ b/src/lib/ledger_proof/dune
@@ -2,6 +2,5 @@
  (name ledger_proof)
  (public_name ledger_proof)
  (libraries core_kernel mina_base transaction_snark)
- (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_hash ppx_compare ppx_version ppx_deriving_yojson)))
+ (preprocess (pps ppx_bin_prot ppx_sexp_conv ppx_hash ppx_compare ppx_version ppx_deriving_yojson)))

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -37,42 +37,7 @@ module Prod : Ledger_proof_intf.S with type t = Transaction_snark.t = struct
       ~next_available_token_after ~sok_digest ~proof
 end
 
-module Debug :
-  Ledger_proof_intf.S
-  with type t = Transaction_snark.Statement.t * Sok_message.Digest.Stable.V1.t =
-struct
-  [%%versioned
-  module Stable = struct
-    module V1 = struct
-      type t =
-        Transaction_snark.Statement.Stable.V1.t
-        * Sok_message.Digest.Stable.V1.t
-      [@@deriving compare, hash, sexp, yojson]
-
-      let to_latest = Fn.id
-
-      let of_latest t = Ok t
-    end
-  end]
-
-  let statement ((t, _) : t) : Transaction_snark.Statement.t = t
-
-  let underlying_proof (_ : t) = Proof.transaction_dummy
-
-  let statement_target (t : Transaction_snark.Statement.t) = t.target
-
-  let sok_digest (_, d) = d
-
-  let create ~statement ~sok_digest ~proof:_ = (statement, sok_digest)
-end
-
 include Prod
-
-type _ type_witness =
-  | Debug : Debug.t type_witness
-  | Prod : Prod.t type_witness
-
-type with_witness = With_witness : 't * 't type_witness -> with_witness
 
 module For_tests = struct
   let mk_dummy_proof statement =

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -1,6 +1,3 @@
-[%%import
-"../../config.mlh"]
-
 open Core_kernel
 open Mina_base
 
@@ -69,18 +66,7 @@ struct
   let create ~statement ~sok_digest ~proof:_ = (statement, sok_digest)
 end
 
-[%%if
-proof_level = "full"]
-
 include Prod
-
-[%%else]
-
-(* TODO #1698: proof_level=check *)
-
-include Debug
-
-[%%endif]
 
 type _ type_witness =
   | Debug : Debug.t type_witness

--- a/src/lib/ledger_proof/ledger_proof.mli
+++ b/src/lib/ledger_proof/ledger_proof.mli
@@ -1,5 +1,3 @@
-[%%import "../../config.mlh"]
-
 module type S = Ledger_proof_intf.S
 
 module Prod : S with type t = Transaction_snark.t
@@ -8,15 +6,7 @@ module Debug :
   S
   with type t = Transaction_snark.Statement.t * Mina_base.Sok_message.Digest.t
 
-[%%if proof_level = "full"]
-
 include S with type t = Prod.t
-
-[%%else]
-
-include S with type t = Debug.t
-
-[%%endif]
 
 type _ type_witness =
   | Debug : Debug.t type_witness

--- a/src/lib/ledger_proof/ledger_proof.mli
+++ b/src/lib/ledger_proof/ledger_proof.mli
@@ -2,17 +2,7 @@ module type S = Ledger_proof_intf.S
 
 module Prod : S with type t = Transaction_snark.t
 
-module Debug :
-  S
-  with type t = Transaction_snark.Statement.t * Mina_base.Sok_message.Digest.t
-
 include S with type t = Prod.t
-
-type _ type_witness =
-  | Debug : Debug.t type_witness
-  | Prod : Prod.t type_witness
-
-type with_witness = With_witness : 't * 't type_witness -> with_witness
 
 module For_tests : sig
   val mk_dummy_proof : Transaction_snark.Statement.t -> t

--- a/src/lib/network_pool/mocks.ml
+++ b/src/lib/network_pool/mocks.ml
@@ -6,7 +6,6 @@ open Mina_base
 let trust_system = Trust_system.null ()
 
 module Transaction_snark_work = Transaction_snark_work
-module Ledger_proof = Ledger_proof.Debug
 
 module Base_ledger = struct
   type t = Account.t Account_id.Map.t [@@deriving sexp]

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -14,10 +14,8 @@
     ppx_deriving_yojson
     ppx_inline_test
     ppx_let
-    ppx_optcomp
     ppx_register_event
     ppx_sexp_conv
     ppx_version))
  (instrumentation (backend bisect_ppx))
- (preprocessor_deps "../../config.mlh")
  (synopsis "Lib powering the snark_worker interactions with the daemon"))

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -1,18 +1,5 @@
-[%%import
-"/src/config.mlh"]
-
 module Intf = Intf
-
-[%%if
-proof_level = "full"]
-
 module Inputs = Prod.Inputs
-
-[%%else]
-
-module Inputs = Debug.Inputs
-
-[%%endif]
 
 module Worker = struct
   include Functor.Make (Inputs)

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -4,7 +4,7 @@ open Mina_base
 
 type t = unit
 
-type ledger_proof = Ledger_proof.Debug.t
+type ledger_proof = Ledger_proof.t
 
 let create ~logger:_ ~proof_level ~pids:_ ~conf_dir:_ =
   match proof_level with
@@ -35,13 +35,4 @@ let verify_commands _ (cs : User_command.Verifiable.t list) :
           `Valid c )
   |> Deferred.Or_error.return
 
-let verify_transaction_snarks _ ts =
-  (*Don't check if the proof has default sok becasue they were probably not
-  intended to be checked. If it has some value then check that against the
-  message passed. This is particularly used to test that invalid proofs are not
-  added to the snark pool*)
-  List.for_all ts ~f:(fun (proof, message) ->
-      let msg_digest = Sok_message.digest message in
-      Sok_message.Digest.(equal (snd proof) default)
-      || Mina_base.Sok_message.Digest.equal (snd proof) msg_digest )
-  |> Deferred.Or_error.return
+let verify_transaction_snarks _ _ = Deferred.Or_error.return true

--- a/src/lib/verifier/dummy.mli
+++ b/src/lib/verifier/dummy.mli
@@ -1,1 +1,1 @@
-include Verifier_intf.S with type ledger_proof = Ledger_proof.Debug.t
+include Verifier_intf.S with type ledger_proof = Ledger_proof.t

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -2,6 +2,5 @@
  (name verifier)
  (public_name verifier)
  (libraries precomputed_values core_kernel async_kernel rpc_parallel mina_base mina_state blockchain_snark memory_stats snark_params ledger_proof logger child_processes)
- (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_compare ppx_hash ppx_coda ppx_version ppx_optcomp ppx_bin_prot ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv)))
+ (preprocess (pps ppx_compare ppx_hash ppx_coda ppx_version ppx_bin_prot ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv)))

--- a/src/lib/verifier/verifier.ml
+++ b/src/lib/verifier/verifier.ml
@@ -4,14 +4,4 @@
 module Failure = Verification_failure
 module Prod = Prod
 module Dummy = Dummy
-
-[%%if
-proof_level = "full"]
-
 include Prod
-
-[%%else]
-
-include Dummy
-
-[%%endif]

--- a/src/lib/verifier/verifier.ml
+++ b/src/lib/verifier/verifier.ml
@@ -3,12 +3,12 @@ module Prod = Prod
 module Dummy = Dummy
 
 let m =
-  if Core_kernel.am_running_inline_test then
+  if Base__Import.am_testing then
     (* Spawning a process using [Rpc_parallel] calls the current binary with a
        particular set of arguments. Unfortunately, unit tests use the inline
-       test binary, which doesn't support these arguments, and so we're not
-       able to use these [Rpc_parallel] calls. Instead, we detect this and call
-       out to the dummy verifier instead.
+       test binary -- which doesn't support these arguments -- and so we're not
+       able to use these [Rpc_parallel] calls. Here we detect this and call out
+       to the dummy verifier instead.
        The implementation of dummy is equivalent to the one with
        [proof_level <> Full], so this should make no difference. Inline tests
        shouldn't be run with [proof_level = Full].

--- a/src/lib/verifier/verifier.ml
+++ b/src/lib/verifier/verifier.ml
@@ -1,6 +1,3 @@
-[%%import
-"/src/config.mlh"]
-
 module Failure = Verification_failure
 module Prod = Prod
 module Dummy = Dummy

--- a/src/lib/verifier/verifier.ml
+++ b/src/lib/verifier/verifier.ml
@@ -1,4 +1,19 @@
 module Failure = Verification_failure
 module Prod = Prod
 module Dummy = Dummy
-include Prod
+
+let m =
+  if Core_kernel.am_running_inline_test then
+    (* Spawning a process using [Rpc_parallel] calls the current binary with a
+       particular set of arguments. Unfortunately, unit tests use the inline
+       test binary, which doesn't support these arguments, and so we're not
+       able to use these [Rpc_parallel] calls. Instead, we detect this and call
+       out to the dummy verifier instead.
+       The implementation of dummy is equivalent to the one with
+       [proof_level <> Full], so this should make no difference. Inline tests
+       shouldn't be run with [proof_level = Full].
+    *)
+    (module Dummy : Verifier_intf.S with type ledger_proof = Ledger_proof.t )
+  else (module Prod)
+
+include (val m)

--- a/src/lib/verifier/verifier.mli
+++ b/src/lib/verifier/verifier.mli
@@ -6,12 +6,4 @@ module Dummy : module type of Dummy
 
 module Prod : module type of Prod
 
-[%%if proof_level = "full"]
-
 include module type of Prod
-
-[%%else]
-
-include module type of Dummy
-
-[%%endif]

--- a/src/lib/verifier/verifier.mli
+++ b/src/lib/verifier/verifier.mli
@@ -1,5 +1,3 @@
-[%%import "../../config.mlh"]
-
 module Failure = Verification_failure
 
 module Dummy : module type of Dummy

--- a/src/lib/verifier/verifier.mli
+++ b/src/lib/verifier/verifier.mli
@@ -4,4 +4,4 @@ module Dummy : module type of Dummy
 
 module Prod : module type of Prod
 
-include module type of Prod
+include Verifier_intf.S with type ledger_proof = Ledger_proof.t


### PR DESCRIPTION
This PR tweaks compilation so no types or important behaviour is determined by the compile-time `proof_level` (except for compile time keys and genesis proof generation). There is still a warning in `Staged_ledger_hash.Non_snark.typ` that is disabled by setting `proof_level < Full`, but this should have no other impact.

This should (hopefully!) make it possible to switch the integration test executive to a lower proof level and avoid downloading keys.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: