### PR TITLE
Use proof_level=none for integration tests

### DIFF
--- a/src/app/archive/archive.opam
+++ b/src/app/archive/archive.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "0.1"
 build: [
   ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]

--- a/src/config/integration_tests.mlh
+++ b/src/config/integration_tests.mlh
@@ -1,3 +1,7 @@
 (* same as testnet_postake_medium_curves, but always starts at genesis = 0 *)
 [%%import "/src/config/testnet_postake_medium_curves.mlh"]
 [%%import "/src/config/fork.mlh"]
+
+(* This profile is only used for the test executive binary, so we don't need
+   snark keys, a valid genesis proof, etc. *)
+[%%import "/src/config/proof_level/none.mlh"]


### PR DESCRIPTION
This PR changes the `proof_level` for the test executive, so that it doesn't attempt to generate snark keys or a genesis proof during compilation.

This builds upon #8454, which ensures that the types etc. used by binaries from different proof levels are compatible.
