### PR TITLE
Postgresql apps, don't mention password in suggested URI

### DIFF
--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -89,7 +89,7 @@ let () =
            Param.flag "--archive-uri" ~aliases:["archive-uri"]
              ~doc:
                "URI URI for connecting to the archive database (e.g., \
-                postgres://$USER:$USER@localhost:5432/archiver)"
+                postgres://$USER@localhost:5432/archiver)"
              Param.(required string)
          and precomputed =
            Param.(flag "--precomputed" ~aliases:["precomputed"] no_arg)

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -450,7 +450,7 @@ let () =
            Param.flag "--archive-uri"
              ~doc:
                "URI URI for connecting to the archive database (e.g., \
-                postgres://$USER:$USER@localhost:5432/archiver)"
+                postgres://$USER@localhost:5432/archiver)"
              Param.(required string)
          and start_state_hash_opt =
            Param.flag "--start-state-hash"

--- a/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
+++ b/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
@@ -44,7 +44,7 @@ let () =
            Param.flag "--archive-uri"
              ~doc:
                "URI URI for connecting to the archive database (e.g., \
-                postgres://$USER:$USER@localhost:5432/archiver)"
+                postgres://$USER@localhost:5432/archiver)"
              Param.(required string)
          in
          main ~archive_uri)))

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -914,7 +914,7 @@ let () =
            Param.flag "--archive-uri"
              ~doc:
                "URI URI for connecting to the archive database (e.g., \
-                postgres://$USER:$USER@localhost:5432/archiver)"
+                postgres://$USER@localhost:5432/archiver)"
              Param.(required string)
          in
          main ~input_file ~output_file ~archive_uri)))


### PR DESCRIPTION
For apps that take an `--archive-uri` argument, don't mention `$USER` as the password in the example URI. That's a very bad password!

We do use `$USER:$USER` in Rosetta test scripts, but I don't think the password matters in those cases.

For other apps, just omit the password in the example URI. The apps run locally for me without a password, in any case.