### PR TITLE
Reduce alert timeframe from 1h to 10m for faster resolution detection

### DIFF
--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -13,7 +13,7 @@ module "o1testnet_alerts" {
   source = "../modules/testnet-alerts"
 
   rule_filter            = "{testnet!~\"^(it-|ci-net).+\"}" # omit testnets deployed by integration/CI tests
-  alert_timeframe        = "1h"
+  alert_timeframe        = "10m"
   alert_duration         = "10m"
   pagerduty_alert_filter = "devnet2|mainnet"
 }


### PR DESCRIPTION
Reduce alert timeframe and synchronize with alert violation duration threshold in order to allow for faster network incident resolution detection.  Basically this change allows an alert which triggered 30 minutes ago, for example, though has since been resolved a little over ten minutes ago to actually report as resolved rather than having to wait for the currently configured timeframe period of 1 hour. 

**Test:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: