### PR TITLE
fix transactions being dropped from mempool

### DIFF
--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -588,13 +588,15 @@ let handle_committed_txn :
        t
     -> Transaction_hash.User_command_with_valid_signature.t
     -> fee_payer_balance:Currency.Amount.t
+    -> fee_payer_nonce:Mina_base.Account.Nonce.t
     -> ( t * Transaction_hash.User_command_with_valid_signature.t Sequence.t
        , [ `Queued_txns_by_sender of
            string
            * Transaction_hash.User_command_with_valid_signature.t Sequence.t ]
        )
        Result.t =
- fun ({constraint_constants; _} as t) committed ~fee_payer_balance ->
+ fun ({constraint_constants; _} as t) committed ~fee_payer_balance
+     ~fee_payer_nonce ->
   let committed' =
     Transaction_hash.User_command_with_valid_signature.command committed
   in
@@ -632,9 +634,14 @@ let handle_committed_txn :
           |> Fn.flip remove_all_by_fee_and_hash_and_expiration_exn first_cmd
         in
         let new_queued_cmds, currency_reserved'', dropped_cmds =
-          drop_until_sufficient_balance ~constraint_constants
-            (rest_cmds, currency_reserved')
-            fee_payer_balance
+          if Mina_base.Account.Nonce.equal first_nonce fee_payer_nonce then
+            (* remove user_commands that consume more currency than what the latest fee_payer_balance is*)
+            drop_until_sufficient_balance ~constraint_constants
+              (rest_cmds, currency_reserved')
+              fee_payer_balance
+          else
+            (* Don't check if the balance is sufficient, there are other committed user_commands in the pool from the current fee payer that has been accounted for in the fee_payer_balance*)
+            (rest_cmds, currency_reserved', Sequence.empty)
         in
         let t2 =
           Sequence.fold dropped_cmds ~init:t1

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -74,6 +74,7 @@ val handle_committed_txn :
      t
   -> Transaction_hash.User_command_with_valid_signature.t
   -> fee_payer_balance:Currency.Amount.t
+  -> fee_payer_nonce:Mina_base.Account.Nonce.t
   -> ( t * Transaction_hash.User_command_with_valid_signature.t Sequence.t
      , [ `Queued_txns_by_sender of
          string


### PR DESCRIPTION
When handling committed transactions, we want to drop pending user commands that consume more currency than what the fee-payer has. This logic was counting the consumed currency from committed transactions twice which caused pending transactions to be dropped if the fee payer balance was not sufficiently big.

Reproduced and tested locally

Fixes #8331