### PR TITLE
Docs, minor changes to Base58_check

### DIFF
--- a/src/lib/base58_check/README.md
+++ b/src/lib/base58_check/README.md
@@ -1,0 +1,58 @@
+# Base58Check
+
+For many values in the protocol that users see, we wish to present
+them in a way that is human-readable. The values may be represented in
+computer code as arbitrary bit sequences. We can encode values as
+strings in base 58 over some alphabet, and decode those strings back
+to values in the internal representation.
+
+## Base 58 alphabet
+
+The base 58 alphabet we use is the same as Bitcoin uses for base 58
+encodings of addresses, consisting of
+
+  - the numerals 1 to 9
+  - the ASCII uppercase letters A to Z, omitting I and O, and
+  - the ASCII lowercase letters, omitting l
+
+## Prefix and suffix
+
+To assure that base 58 strings represent bonafide values, we use the
+Base58Check algorithm, which adds a prefix and suffix to the value
+before converting the result to base 58.
+
+The prefix is a single byte, which is distinct for each type that we
+encode. When decoding a Base58 string to a value of a type, the prefix
+is checked against the expected byte. It's an error if the prefix
+differs from what's expected.  The OCaml code raise an exception in
+that case. The check yields a measure of run-time type safety.
+
+The added suffix is a derived from double-hashing a payload using the
+SHA256 algorithm. The suffix is the first four bytes of the
+double-hash. The checksum is checked when decoding a Base58Check value
+to assure the integrity of the encoded string. The OCaml code raises
+an exception if the checksum at the end the decoded string does not
+match the checksum of the decoded payload.
+
+## Creating encoders and decoders for a type
+
+In this library, the `Version_bytes` module contains bindings for the
+types that are Base58Check-encoded. The functor `Base58_check.Make`
+takes a structure containing a version byte for a type (and a textual
+description of the type), and returns a structure with an encoder and
+decoders. One decoder raise exceptions in the case of an errors, the
+other returns an `Or_error.t`
+
+Encoding a value to Base58Check requires that the value of a type
+first be encoded as an OCaml string. The decoders returned by
+`Base58_check.Make` return a string, so that string needs to be
+converted to the value of the type.
+
+While a value can be converted to and from a string in whatever way,
+if the type is `Bin_prot`-serializable, there's a convenient means to
+obtain Base58Check encoders and decoders. The `Codable` library
+contains the functor `Make_base58_check`, which accepts a structure
+with such a type, a version byte, and a textual description, and
+returns an encoder and decoders. The encoder takes a value of the type
+(not a string), and the decoders return a value of the type (not a
+string).

--- a/src/lib/base58_check/base58_check.ml
+++ b/src/lib/base58_check/base58_check.ml
@@ -13,7 +13,7 @@ exception Invalid_base58_check_length of string
 exception Invalid_base58_character of string
 
 (* same as Bitcoin alphabet *)
-let coda_alphabet =
+let mina_alphabet =
   B58.make_alphabet
     "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
@@ -32,10 +32,9 @@ struct
   let version_string = String.make 1 version_byte
 
   (* the Base58 library's "convert" routine, used for both
-     encoding and decoding, runs in time O(n^2); limit
-     length of input when encoding to avoid bottlenecks
-   *)
-
+      encoding and decoding, runs in time O(n^2); limit
+      length of input when encoding to avoid bottlenecks
+  *)
   let max_encodable_length = 8192
 
   let compute_checksum payload =
@@ -55,12 +54,12 @@ struct
       failwith (sprintf "Base58_check.encode: input too long (%d bytes)" len) ;
     let checksum = compute_checksum payload in
     let bytes = version_string ^ payload ^ checksum |> Bytes.of_string in
-    B58.encode coda_alphabet bytes |> Bytes.to_string
+    B58.encode mina_alphabet bytes |> Bytes.to_string
 
   let decode_exn s =
     let bytes = Bytes.of_string s in
     let decoded =
-      try B58.decode coda_alphabet bytes |> Bytes.to_string
+      try B58.decode mina_alphabet bytes |> Bytes.to_string
       with B58.Invalid_base58_character ->
         raise (Invalid_base58_character M.description)
     in

--- a/src/lib/base58_check/base58_check.mli
+++ b/src/lib/base58_check/base58_check.mli
@@ -1,6 +1,6 @@
-open Core_kernel
-
 (* base58_check.mli -- implementation of Base58Check algorithm *)
+
+open Core_kernel
 
 exception Invalid_base58_checksum of string
 
@@ -10,18 +10,20 @@ exception Invalid_base58_check_length of string
 
 exception Invalid_base58_character of string
 
-val coda_alphabet : B58.alphabet
+(** the Mina base 58 alphabet *)
+val mina_alphabet : B58.alphabet
 
 module Make (M : sig
   val description : string
 
   val version_byte : char
 end) : sig
-  (** apply Base58Check algorithm to version byte and payload *)
+  (** apply Base58Check algorithm to a payload *)
   val encode : string -> string
 
   (** decode Base58Check result into payload; can raise the above
-   * exceptions and a B58.Invalid_base58_character *)
+      exceptions
+  *)
   val decode_exn : string -> string
 
   (** decode Base58Check result into payload *)

--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -2,7 +2,9 @@
 
 type t = char
 
-(* each of the following values should be distinct *)
+(** Base58Check version bytes for individual types
+    Each of the following values should be distinct
+*)
 
 let coinbase : t = '\x01'
 
@@ -50,9 +52,9 @@ let pending_coinbase_hash_builder : t = '\x19'
 
 let snapp_command : t = '\x1A'
 
-(* the following version bytes are non-sequential because existing testnet
-   user key infrastructure depend on them. don't change them while we 
-   care about user keys! *)
+(** The following version bytes are non-sequential; existing
+    user key infrastructure depends on them. don't change them!
+*)
 
 let private_key : t = '\x5A'
 

--- a/src/lib/secrets/hardware_wallets.ml
+++ b/src/lib/secrets/hardware_wallets.ml
@@ -29,7 +29,7 @@ let decode_field (type field) (module Tick : Tick_intf with type field = field)
     : string -> field =
  fun field ->
   Bytes.of_string field
-  |> B58.decode Base58_check.coda_alphabet
+  |> B58.decode Base58_check.mina_alphabet
   |> Bytes.to_list |> List.rev |> Bytes.of_char_list |> Bytes.to_string
   |> String.foldi ~init:Bigint.zero ~f:(fun i acc byte ->
          Bigint.(acc lor (of_int (Char.to_int byte) lsl Int.( * ) 8 i)) )


### PR DESCRIPTION
Add a `README` for `Base58_check` library, update comments in .mli file, add/update comments in `Version_bytes`.

Rename `coda_alphabet` to `mina_alphabet`.