### PR TITLE
Mask `last_filled`, use Addr.compare

### DIFF
--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -418,8 +418,19 @@ module Make (Inputs : Inputs_intf.S) = struct
           match t.current_location with
           | None ->
               Some parent_loc
-          | Some our_loc ->
-              Some (max parent_loc our_loc) )
+          | Some our_loc -> (
+            match (parent_loc, our_loc) with
+            | Account parent_addr, Account our_addr ->
+                (* Addr.compare is Bitstring.compare, essentially String.compare *)
+                let loc =
+                  if Addr.compare parent_addr our_addr >= 0 then parent_loc
+                  else our_loc
+                in
+                Some loc
+            | _ ->
+                failwith
+                  "last_filled: expected account locations for the parent and \
+                   mask" ) )
 
     include Merkle_ledger.Util.Make (struct
       module Location = Location


### PR DESCRIPTION
For Merkle masks, `last_filled` was using the polymorphic `max` to compare locations. That might have worked, but hard to know.

Instead, check that the locations are indeed account locations, and use `Addr.compare` to compare the underlying addresses. `Addr.compare` is `Bitstring.compare`, which is essentially `String.compare`. For accounts, the addresses are bitstrings with length equal to the ledger depth. A set bit is greater than an unset bit (verified by testing).

Closes #8474.

