### PR TITLE
Make compile-time genesis proof creation optional

### DIFF
--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -116,7 +116,7 @@ let rec pair_up = function
   | _ ->
       failwith "Expected even length list"
 
-let precomputed_values = Precomputed_values.compiled
+let precomputed_values = Precomputed_values.compiled_inputs
 
 let state_body =
   Mina_state.(

--- a/src/app/cli/src/tests/coda_archive_processor_test.ml
+++ b/src/app/cli/src/tests/coda_archive_processor_test.ml
@@ -8,7 +8,7 @@ let main () =
   let postgres_address =
     Uri.of_string "postgres://admin:codarules@localhost:5432/archiver"
   in
-  let precomputed_values = Lazy.force Precomputed_values.compiled in
+  let precomputed_values = Lazy.force Precomputed_values.compiled_inputs in
   let constraint_constants = precomputed_values.constraint_constants in
   let%bind conn =
     match%map Caqti_async.connect postgres_address with
@@ -26,7 +26,7 @@ let main () =
       (Some (Lazy.force Runtime_config.Test_configs.transactions))
   |> don't_wait_for ;
   let public_key =
-    Precomputed_values.largest_account_pk_exn precomputed_values
+    Genesis_proof.Inputs.largest_account_pk_exn precomputed_values
   in
   let n = 2 in
   let block_production_keys i = if i = 0 then Some i else None in

--- a/src/app/cli/src/tests/coda_block_production_test.ml
+++ b/src/app/cli/src/tests/coda_block_production_test.ml
@@ -8,8 +8,7 @@ let runtime_config = Runtime_config.Test_configs.split_snarkless
 let main () =
   let logger = Logger.create () in
   let%bind precomputed_values, _runtime_config =
-    Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
-      ~proof_level:None
+    Genesis_ledger_helper.inputs_from_config_file ~logger ~proof_level:None
       (Lazy.force runtime_config)
     >>| Or_error.ok_exn
   in

--- a/src/app/cli/src/tests/coda_bootstrap_test.ml
+++ b/src/app/cli/src/tests/coda_bootstrap_test.ml
@@ -8,8 +8,7 @@ let runtime_config = Runtime_config.Test_configs.bootstrap
 let main () =
   let logger = Logger.create () in
   let%bind precomputed_values, _runtime_config =
-    Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
-      ~proof_level:None
+    Genesis_ledger_helper.inputs_from_config_file ~logger ~proof_level:None
       (Lazy.force runtime_config)
     >>| Or_error.ok_exn
   in
@@ -17,7 +16,7 @@ let main () =
   let block_production_keys i = Some i in
   let snark_work_public_keys i =
     if i = 0 then
-      Some (Precomputed_values.largest_account_pk_exn precomputed_values)
+      Some (Genesis_proof.Inputs.largest_account_pk_exn precomputed_values)
     else None
   in
   let%bind testnet =

--- a/src/app/cli/src/tests/coda_change_snark_worker_test.ml
+++ b/src/app/cli/src/tests/coda_change_snark_worker_test.ml
@@ -15,13 +15,12 @@ let main () =
     if i = snark_worker_and_block_producer_id then Some i else None
   in
   let%bind precomputed_values, _runtime_config =
-    Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
-      ~proof_level:None
+    Genesis_ledger_helper.inputs_from_config_file ~logger ~proof_level:None
       (Lazy.force runtime_config)
     >>| Or_error.ok_exn
   in
   let largest_public_key =
-    Precomputed_values.largest_account_pk_exn precomputed_values
+    Genesis_proof.Inputs.largest_account_pk_exn precomputed_values
   in
   let snark_work_public_keys i =
     if i = snark_worker_and_block_producer_id then Some largest_public_key
@@ -70,7 +69,7 @@ let main () =
     wait_for_snark_worker_proof new_block_pipe1 largest_public_key
   in
   let new_snark_worker =
-    Precomputed_values.find_new_account_record_exn_ precomputed_values
+    Genesis_proof.Inputs.find_new_account_record_exn_ precomputed_values
       [largest_public_key]
     |> Precomputed_values.pk_of_account_record
   in

--- a/src/app/cli/src/tests/coda_delegation_test.ml
+++ b/src/app/cli/src/tests/coda_delegation_test.ml
@@ -12,13 +12,14 @@ let runtime_config = Runtime_config.Test_configs.delegation
 let main () =
   let logger = Logger.create () in
   let%bind precomputed_values, _runtime_config =
-    Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
-      ~proof_level:None
+    Genesis_ledger_helper.inputs_from_config_file ~logger ~proof_level:None
       (Lazy.force runtime_config)
     >>| Or_error.ok_exn
   in
   let num_block_producers = 3 in
-  let accounts = Lazy.force (Precomputed_values.accounts precomputed_values) in
+  let accounts =
+    Lazy.force (Genesis_proof.Inputs.accounts precomputed_values)
+  in
   let snark_work_public_keys ndx =
     List.nth_exn accounts ndx
     |> fun (_, acct) -> Some (Account.public_key acct)
@@ -53,7 +54,7 @@ let main () =
   let ((_, delegator_account) as delegator) = List.nth_exn accounts 2 in
   let delegator_pubkey = Account.public_key delegator_account in
   let delegator_keypair =
-    Precomputed_values.keypair_of_account_record_exn delegator
+    Genesis_proof.Inputs.keypair_of_account_record_exn delegator
   in
   (* zeroth account is delegatee *)
   let _, delegatee_account = List.nth_exn accounts 0 in

--- a/src/app/cli/src/tests/coda_five_nodes_test.ml
+++ b/src/app/cli/src/tests/coda_five_nodes_test.ml
@@ -6,13 +6,13 @@ let name = "coda-five-nodes-test"
 
 let main () =
   let logger = Logger.create () in
-  let precomputed_values = Lazy.force Precomputed_values.compiled in
+  let precomputed_values = Lazy.force Precomputed_values.compiled_inputs in
   let n = 5 in
   let snark_work_public_keys = function
     | 0 ->
         Some
           ( List.nth_exn
-              (Lazy.force (Precomputed_values.accounts precomputed_values))
+              (Lazy.force (Genesis_proof.Inputs.accounts precomputed_values))
               5
           |> snd |> Account.public_key )
     | _ ->

--- a/src/app/cli/src/tests/coda_long_fork.ml
+++ b/src/app/cli/src/tests/coda_long_fork.ml
@@ -6,14 +6,14 @@ let name = "coda-long-fork"
 let main n waiting_time () =
   let precomputed_values =
     (* TODO: Load for this specific test. *)
-    Lazy.force Precomputed_values.compiled
+    Lazy.force Precomputed_values.compiled_inputs
   in
   let consensus_constants = precomputed_values.consensus_constants in
   let logger = Logger.create () in
   let public_keys =
     List.map
-      (Lazy.force (Precomputed_values.accounts precomputed_values))
-      ~f:Precomputed_values.pk_of_account_record
+      (Lazy.force (Genesis_proof.Inputs.accounts precomputed_values))
+      ~f:Genesis_proof.Inputs.pk_of_account_record
   in
   let snark_work_public_keys i = Some (List.nth_exn public_keys i) in
   let%bind testnet =

--- a/src/app/cli/src/tests/coda_peers_test.ml
+++ b/src/app/cli/src/tests/coda_peers_test.ml
@@ -8,8 +8,7 @@ let runtime_config = Runtime_config.Test_configs.split_snarkless
 let main () =
   let logger = Logger.create () in
   let%bind precomputed_values, _runtime_config =
-    Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
-      ~proof_level:None
+    Genesis_ledger_helper.inputs_from_config_file ~logger ~proof_level:None
       (Lazy.force runtime_config)
     >>| Or_error.ok_exn
   in

--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -70,7 +70,7 @@ let local_configs ?block_production_interval
       | Some timestamp ->
           Genesis_constants.genesis_timestamp_of_string timestamp
       | None ->
-          (Lazy.force Precomputed_values.compiled).consensus_constants
+          (Lazy.force Precomputed_values.compiled_inputs).consensus_constants
             .genesis_state_timestamp |> Block_time.to_time
     in
     Core.Time.(diff (now ())) genesis_state_timestamp

--- a/src/app/cli/src/tests/coda_restart_node_test.ml
+++ b/src/app/cli/src/tests/coda_restart_node_test.ml
@@ -7,9 +7,9 @@ include Heartbeat.Make ()
 
 let main () =
   let logger = Logger.create () in
-  let precomputed_values = Lazy.force Precomputed_values.compiled in
+  let precomputed_values = Lazy.force Precomputed_values.compiled_inputs in
   let largest_account_pk =
-    Precomputed_values.largest_account_pk_exn precomputed_values
+    Genesis_proof.Inputs.largest_account_pk_exn precomputed_values
   in
   Deferred.don't_wait_for (print_heartbeat logger) ;
   let n = 2 in

--- a/src/app/cli/src/tests/coda_restarts_and_txns_holy_grail.ml
+++ b/src/app/cli/src/tests/coda_restarts_and_txns_holy_grail.ml
@@ -8,8 +8,10 @@ let main n () =
   let wait_time = Time.Span.of_min 2. in
   assert (n > 1) ;
   let logger = Logger.create () in
-  let precomputed_values = Lazy.force Precomputed_values.compiled in
-  let accounts = Lazy.force (Precomputed_values.accounts precomputed_values) in
+  let precomputed_values = Lazy.force Precomputed_values.compiled_inputs in
+  let accounts =
+    Lazy.force (Genesis_proof.Inputs.accounts precomputed_values)
+  in
   let snark_work_public_keys =
     Fn.const @@ Some (List.nth_exn accounts 5 |> snd |> Account.public_key)
   in
@@ -21,7 +23,7 @@ let main n () =
   in
   (* SEND TXNS *)
   let keypairs =
-    List.map accounts ~f:Precomputed_values.keypair_of_account_record_exn
+    List.map accounts ~f:Genesis_proof.Inputs.keypair_of_account_record_exn
   in
   let random_block_producer () = Random.int 2 + 1 in
   let random_non_block_producer () = Random.int 2 + 3 in

--- a/src/app/cli/src/tests/coda_shared_prefix_multiproducer_test.ml
+++ b/src/app/cli/src/tests/coda_shared_prefix_multiproducer_test.ml
@@ -5,15 +5,15 @@ let name = "coda-shared-prefix-multiproducer-test"
 
 let main n enable_payments () =
   let logger = Logger.create () in
-  let precomputed_values = Lazy.force Precomputed_values.compiled in
+  let precomputed_values = Lazy.force Precomputed_values.compiled_inputs in
   let keypairs =
     List.map
-      (Lazy.force (Precomputed_values.accounts precomputed_values))
-      ~f:Precomputed_values.keypair_of_account_record_exn
+      (Lazy.force (Genesis_proof.Inputs.accounts precomputed_values))
+      ~f:Genesis_proof.Inputs.keypair_of_account_record_exn
   in
   let public_keys =
-    List.map ~f:Precomputed_values.pk_of_account_record
-      (Lazy.force (Precomputed_values.accounts precomputed_values))
+    List.map ~f:Genesis_proof.Inputs.pk_of_account_record
+      (Lazy.force (Genesis_proof.Inputs.accounts precomputed_values))
   in
   let snark_work_public_keys i = Some (List.nth_exn public_keys i) in
   let%bind testnet =

--- a/src/app/cli/src/tests/coda_shared_prefix_test.ml
+++ b/src/app/cli/src/tests/coda_shared_prefix_test.ml
@@ -8,8 +8,7 @@ let runtime_config = Runtime_config.Test_configs.split_snarkless
 let main who_produces () =
   let logger = Logger.create () in
   let%bind precomputed_values, _runtime_config =
-    Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
-      ~proof_level:None
+    Genesis_ledger_helper.inputs_from_config_file ~logger ~proof_level:None
       (Lazy.force runtime_config)
     >>| Or_error.ok_exn
   in

--- a/src/app/cli/src/tests/coda_shared_state_test.ml
+++ b/src/app/cli/src/tests/coda_shared_state_test.ml
@@ -10,8 +10,7 @@ let runtime_config = Runtime_config.Test_configs.transactions
 let main () =
   let logger = Logger.create () in
   let%bind precomputed_values, _runtime_config =
-    Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
-      ~proof_level:None
+    Genesis_ledger_helper.inputs_from_config_file ~logger ~proof_level:None
       (Lazy.force runtime_config)
     >>| Or_error.ok_exn
   in
@@ -19,12 +18,12 @@ let main () =
   let n = 2 in
   let keypairs =
     List.map
-      (Lazy.force (Precomputed_values.accounts precomputed_values))
-      ~f:Precomputed_values.keypair_of_account_record_exn
+      (Lazy.force (Genesis_proof.Inputs.accounts precomputed_values))
+      ~f:Genesis_proof.Inputs.keypair_of_account_record_exn
   in
   let public_keys =
-    List.map ~f:Precomputed_values.pk_of_account_record
-      (Lazy.force (Precomputed_values.accounts precomputed_values))
+    List.map ~f:Genesis_proof.Inputs.pk_of_account_record
+      (Lazy.force (Genesis_proof.Inputs.accounts precomputed_values))
   in
   let snark_work_public_keys i = Some (List.nth_exn public_keys i) in
   let%bind testnet =

--- a/src/app/cli/src/tests/coda_transitive_peers_test.ml
+++ b/src/app/cli/src/tests/coda_transitive_peers_test.ml
@@ -8,8 +8,7 @@ let runtime_config = Runtime_config.Test_configs.split_snarkless
 let main () =
   let logger = Logger.create () in
   let%bind precomputed_values, _runtime_config =
-    Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
-      ~proof_level:None
+    Genesis_ledger_helper.inputs_from_config_file ~logger ~proof_level:None
       (Lazy.force runtime_config)
     >>| Or_error.ok_exn
   in

--- a/src/app/cli/src/tests/coda_txns_and_restart_non_producers.ml
+++ b/src/app/cli/src/tests/coda_txns_and_restart_non_producers.ml
@@ -7,8 +7,10 @@ let name = "coda-txns-and-restart-non-producers"
 let main () =
   let wait_time = Time.Span.of_min 2. in
   let logger = Logger.create () in
-  let precomputed_values = Lazy.force Precomputed_values.compiled in
-  let accounts = Lazy.force (Precomputed_values.accounts precomputed_values) in
+  let precomputed_values = Lazy.force Precomputed_values.compiled_inputs in
+  let accounts =
+    Lazy.force (Genesis_proof.Inputs.accounts precomputed_values)
+  in
   let snark_work_public_keys =
     Fn.const @@ Some (List.nth_exn accounts 5 |> snd |> Account.public_key)
   in
@@ -20,7 +22,7 @@ let main () =
   in
   (* send txns *)
   let keypairs =
-    List.map accounts ~f:Precomputed_values.keypair_of_account_record_exn
+    List.map accounts ~f:Genesis_proof.Inputs.keypair_of_account_record_exn
   in
   let%bind () = after wait_time in
   Coda_worker_testnet.Payments.send_several_payments testnet ~node:0 ~keypairs

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -354,7 +354,7 @@ module T = struct
           ()
       in
       let%bind precomputed_values, _runtime_config =
-        Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:false
+        Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:true
           ~proof_level:None runtime_config
         >>| Or_error.ok_exn
       in

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -27,7 +27,7 @@ module Api = struct
         so eventually the counter _must_ become 0, ensuring progress. *)
     ; root_lengths: int Array.t
     ; restart_signals: (restart_type * unit Ivar.t) Option.t Array.t
-    ; precomputed_values: Precomputed_values.t }
+    ; precomputed_values: Genesis_proof.Inputs.t }
 
   let create ~precomputed_values configs workers start_writer =
     let status =
@@ -392,7 +392,8 @@ let start_payment_check logger root_pipe (testnet : Api.t) =
          | _ ->
              Deferred.unit ) ))
 
-let events ~(precomputed_values : Precomputed_values.t) workers start_reader =
+let events ~(precomputed_values : Genesis_proof.Inputs.t) workers start_reader
+    =
   let event_r, event_w = Linear_pipe.create () in
   let root_r, root_w = Linear_pipe.create () in
   let connect_worker i worker =
@@ -458,7 +459,8 @@ let start_checks logger (workers : Coda_process.t array) start_reader
    *   change network connectivity *)
 let test ?archive_process_location ?is_archive_rocksdb ~name logger n
     block_production_keys snark_work_public_keys work_selection_method
-    ~max_concurrent_connections ~(precomputed_values : Precomputed_values.t) =
+    ~max_concurrent_connections ~(precomputed_values : Genesis_proof.Inputs.t)
+    =
   let logger = Logger.extend logger [("worker_testnet", `Bool true)] in
   let block_production_interval =
     precomputed_values.constraint_constants.block_window_duration_ms

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -83,7 +83,7 @@ let print_heartbeat logger =
 
 let run_test () : unit Deferred.t =
   let logger = Logger.create () in
-  let precomputed_values = Lazy.force Precomputed_values.compiled in
+  let precomputed_values = Lazy.force Precomputed_values.compiled_inputs in
   let constraint_constants = precomputed_values.constraint_constants in
   let (module Genesis_ledger) = precomputed_values.genesis_ledger in
   let pids = Child_processes.Termination.create_pid_table () in
@@ -183,6 +183,11 @@ let run_test () : unit Deferred.t =
         if with_snark then (fee 0, fee 0) else (fee 100, fee 200)
       in
       let start_time = Time.now () in
+      let%bind precomputed_values =
+        Deferred.Or_error.ok_exn
+        @@ Genesis_ledger_helper.init_from_inputs ~logger ~may_generate:true
+             precomputed_values
+      in
       let%bind coda =
         Mina_lib.create
           (Mina_lib.Config.make ~logger ~pids ~trust_system ~net_config

--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/devnet.mlh
+++ b/src/config/devnet.mlh
@@ -33,6 +33,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys true]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/fuzz_medium.mlh
+++ b/src/config/fuzz_medium.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 [%%define daemon_expiry "never"]

--- a/src/config/fuzz_small.mlh
+++ b/src/config/fuzz_small.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 [%%define daemon_expiry "never"]

--- a/src/config/mainnet.mlh
+++ b/src/config/mainnet.mlh
@@ -33,6 +33,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys true]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/nonconsensus_medium_curves.mlh
+++ b/src/config/nonconsensus_medium_curves.mlh
@@ -22,6 +22,7 @@
 [%%define print_versioned_types false]
 
 [%%define download_snark_keys true]
+[%%define generate_genesis_proof false]
 
 [%%define daemon_expiry "never"]
 [%%define test_full_epoch false]

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types true]
 

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_medium_curves.mlh
+++ b/src/config/test_postake_medium_curves.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -23,6 +23,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/test_postake_three_producers.mlh
+++ b/src/config/test_postake_three_producers.mlh
@@ -24,6 +24,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -24,6 +24,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/testnet_postake_many_producers.mlh
+++ b/src/config/testnet_postake_many_producers.mlh
@@ -22,6 +22,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/testnet_postake_many_producers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_producers_medium_curves.mlh
@@ -24,6 +24,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -33,6 +33,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys true]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -24,6 +24,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -25,6 +25,7 @@
 [%%define force_updates false]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -24,6 +24,7 @@
 [%%define force_updates true]
 
 [%%define download_snark_keys false]
+[%%define generate_genesis_proof false]
 
 [%%define print_versioned_types false]
 

--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -19,6 +19,53 @@ module Inputs = struct
            [None] here.
         *)
         Pickles.Verification_key.Id.t option }
+
+  let runtime_config {runtime_config; _} = runtime_config
+
+  let constraint_constants {constraint_constants; _} = constraint_constants
+
+  let genesis_constants {genesis_constants; _} = genesis_constants
+
+  let proof_level {proof_level; _} = proof_level
+
+  let protocol_constants t = (genesis_constants t).protocol
+
+  let ledger_depth {genesis_ledger; _} =
+    Genesis_ledger.Packed.depth genesis_ledger
+
+  include Genesis_ledger.Utils
+
+  let genesis_ledger {genesis_ledger; _} =
+    Genesis_ledger.Packed.t genesis_ledger
+
+  let genesis_epoch_data {genesis_epoch_data; _} = genesis_epoch_data
+
+  let accounts {genesis_ledger; _} =
+    Genesis_ledger.Packed.accounts genesis_ledger
+
+  let find_new_account_record_exn {genesis_ledger; _} =
+    Genesis_ledger.Packed.find_new_account_record_exn genesis_ledger
+
+  let find_new_account_record_exn_ {genesis_ledger; _} =
+    Genesis_ledger.Packed.find_new_account_record_exn_ genesis_ledger
+
+  let largest_account_exn {genesis_ledger; _} =
+    Genesis_ledger.Packed.largest_account_exn genesis_ledger
+
+  let largest_account_keypair_exn {genesis_ledger; _} =
+    Genesis_ledger.Packed.largest_account_keypair_exn genesis_ledger
+
+  let largest_account_pk_exn {genesis_ledger; _} =
+    Genesis_ledger.Packed.largest_account_pk_exn genesis_ledger
+
+  let consensus_constants {consensus_constants; _} = consensus_constants
+
+  let genesis_state_with_hash {protocol_state_with_hash; _} =
+    protocol_state_with_hash
+
+  let genesis_state t = (genesis_state_with_hash t).data
+
+  let genesis_state_hash t = (genesis_state_with_hash t).hash
 end
 
 module T = struct

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -60,3 +60,6 @@ let rpc_handshake_timeout_sec = 60.0
 let rpc_heartbeat_timeout_sec = 60.0
 
 let rpc_heartbeat_send_every_sec = 10.0 (*same as the default*)
+
+[%%inject
+"generate_genesis_proof", generate_genesis_proof]

--- a/src/lib/precomputed_values/gen_values/gen_values.ml
+++ b/src/lib/precomputed_values/gen_values/gen_values.ml
@@ -20,7 +20,8 @@ let use_dummy_values = true
 
 [%%endif]
 
-let generate_genesis_proof = false
+[%%inject
+"generate_genesis_proof", generate_genesis_proof]
 
 module type S = sig
   val blockchain_proof_system_id : Parsetree.expression

--- a/src/lib/precomputed_values/gen_values/gen_values.ml
+++ b/src/lib/precomputed_values/gen_values/gen_values.ml
@@ -20,7 +20,7 @@ let use_dummy_values = true
 
 [%%endif]
 
-let generate_genesis_proof = true
+let generate_genesis_proof = false
 
 module type S = sig
   val blockchain_proof_system_id : Parsetree.expression

--- a/src/lib/precomputed_values/gen_values/gen_values.ml
+++ b/src/lib/precomputed_values/gen_values/gen_values.ml
@@ -20,10 +20,12 @@ let use_dummy_values = true
 
 [%%endif]
 
+let generate_genesis_proof = true
+
 module type S = sig
   val blockchain_proof_system_id : Parsetree.expression
 
-  val base_proof_expr : Parsetree.expression Async.Deferred.t
+  val base_proof_expr : Parsetree.expression Async.Deferred.t option
 
   val transaction_verification : Parsetree.expression
 
@@ -52,7 +54,10 @@ let hashes =
 module Dummy = struct
   let loc = Ppxlib.Location.none
 
-  let base_proof_expr = Async.return [%expr Mina_base.Proof.blockchain_dummy]
+  let base_proof_expr =
+    if generate_genesis_proof then
+      Some (Async.return [%expr Mina_base.Proof.blockchain_dummy])
+    else None
 
   let blockchain_proof_system_id =
     [%expr fun () -> Pickles.Verification_key.Id.dummy ()]
@@ -159,15 +164,18 @@ module Make_real () = struct
       fun () -> Lazy.force t]
 
   let base_proof_expr =
-    let%map.Async compiled_values = compiled_values in
-    [%expr
-      Core.Binable.of_string
-        (module Mina_base.Proof.Stable.Latest)
-        [%e
-          estring
-            (Binable.to_string
-               (module Mina_base.Proof.Stable.Latest)
-               compiled_values.genesis_proof)]]
+    if generate_genesis_proof then
+      Some
+        (let%map.Async compiled_values = compiled_values in
+         [%expr
+           Core.Binable.of_string
+             (module Mina_base.Proof.Stable.Latest)
+             [%e
+               estring
+                 (Binable.to_string
+                    (module Mina_base.Proof.Stable.Latest)
+                    compiled_values.genesis_proof)]])
+    else None
 end
 
 open Async
@@ -179,7 +187,14 @@ let main () =
   let (module M) =
     if use_dummy_values then (module Dummy : S) else (module Make_real () : S)
   in
-  let%bind base_proof_expr = M.base_proof_expr in
+  let%bind base_proof_expr =
+    match M.base_proof_expr with
+    | Some expr ->
+        let%map expr = expr in
+        [%expr Some [%e expr]]
+    | None ->
+        Deferred.return [%expr None]
+  in
   let structure =
     [%str
       module T = Genesis_proof.T
@@ -217,7 +232,7 @@ let main () =
 
       let transaction_verification = [%e M.transaction_verification]
 
-      let compiled =
+      let compiled_inputs =
         lazy
           (let constraint_constants =
              Genesis_constants.Constraint_constants.compiled
@@ -233,7 +248,7 @@ let main () =
                ~genesis_ledger:Test_genesis_ledger.t ~genesis_epoch_data
                ~constraint_constants ~consensus_constants
            in
-           { runtime_config= Runtime_config.default
+           { Genesis_proof.Inputs.runtime_config= Runtime_config.default
            ; constraint_constants
            ; proof_level= Genesis_constants.Proof_level.compiled
            ; genesis_constants
@@ -241,7 +256,26 @@ let main () =
            ; genesis_epoch_data
            ; consensus_constants
            ; protocol_state_with_hash
-           ; genesis_proof= compiled_base_proof })]
+           ; blockchain_proof_system_id= Some (blockchain_proof_system_id ())
+           })
+
+      let compiled =
+        match compiled_base_proof with
+        | Some compiled_base_proof ->
+            Some
+              ( lazy
+                (let inputs = Lazy.force compiled_inputs in
+                 { runtime_config= inputs.runtime_config
+                 ; constraint_constants= inputs.constraint_constants
+                 ; proof_level= inputs.proof_level
+                 ; genesis_constants= inputs.genesis_constants
+                 ; genesis_ledger= inputs.genesis_ledger
+                 ; genesis_epoch_data= inputs.genesis_epoch_data
+                 ; consensus_constants= inputs.consensus_constants
+                 ; protocol_state_with_hash= inputs.protocol_state_with_hash
+                 ; genesis_proof= compiled_base_proof }) )
+        | None ->
+            None]
   in
   Pprintast.top_phrase fmt (Ptop_def structure) ;
   exit 0

--- a/src/lib/precomputed_values/precomputed_values.mli
+++ b/src/lib/precomputed_values/precomputed_values.mli
@@ -1,0 +1,15 @@
+include module type of Genesis_proof.T with type t = Genesis_proof.T.t
+
+val blockchain_proof_system_id : unit -> Pickles.Verification_key.Id.t
+
+val key_hashes : string list
+
+val blockchain_verification : unit -> Pickles.Verification_key.t
+
+val transaction_verification : unit -> Pickles.Verification_key.t
+
+val for_unit_tests : t Lazy.t
+
+val compiled_inputs : Genesis_proof.Inputs.t Lazy.t
+
+val compiled : t Lazy.t option

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -158,7 +158,7 @@ module Worker_state = struct
                      (Protocol_state.hash next_state)
                    |> Or_error.map ~f:(fun () ->
                           Blockchain_snark.Blockchain.create ~state:next_state
-                            ~proof:Precomputed_values.compiled_base_proof )
+                            ~proof:Mina_base.Proof.blockchain_dummy )
                  in
                  Or_error.iter_error res ~f:(fun e ->
                      [%log error]


### PR DESCRIPTION
This PR makes compile-time proof generation optional, with tweaks to remove the dependency everywhere except `Genesis_ledger_helper`.

This is configurable by a flag in `config.mlh`. At the moment, it's disabled everywhere, but this gives us the option of generating a proof for mainnet binaries at compile-time so that we don't have to bundle a proof file with the executable.

Tested by running CI, where everything succeeds.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: