### PR TITLE
Add Coda_watchdog_nodes_queried metric

### DIFF
--- a/automation/services/watchdog/node_status_metrics.py
+++ b/automation/services/watchdog/node_status_metrics.py
@@ -21,7 +21,7 @@ def peer_to_multiaddr(peer):
     peer['libp2p_port'],
     peer['peer_id'] )
 
-def collect_node_status_metrics(v1, namespace, nodes_synced_near_best_tip, nodes_synced, prover_errors):
+def collect_node_status_metrics(v1, namespace, nodes_synced_near_best_tip, nodes_synced, nodes_queried, prover_errors):
   print('collecting node status metrics')
 
   pods = v1.list_namespaced_pod(namespace, watch=False)
@@ -38,8 +38,11 @@ def collect_node_status_metrics(v1, namespace, nodes_synced_near_best_tip, nodes
 
   peers = crawl_for_peers(v1, namespace, seed, seed_daemon_port)
 
-  synced_fraction = sum([ p['sync_status'] == 'Synced' for p in peers.values() ]) / len(peers.values())
+  num_peers = len(peers.values())
 
+  synced_fraction = sum([ p['sync_status'] == 'Synced' for p in peers.values() ]) / num_peers
+
+  nodes_queried.set(num_peers)
   nodes_synced.set(synced_fraction)
 
   # -------------------------------------------------

--- a/automation/services/watchdog/watchdog.py
+++ b/automation/services/watchdog/watchdog.py
@@ -27,6 +27,7 @@ def main():
 
   nodes_synced_near_best_tip = Gauge('Coda_watchdog_nodes_synced_near_best_tip', 'Description of gauge')
   nodes_synced = Gauge('Coda_watchdog_nodes_synced', 'Description of gauge')
+  nodes_queried = Gauge('Coda_watchdog_nodes_queried', 'Number of nodes that responded to the last status query')
   prover_errors = Counter('Coda_watchdog_prover_errors', 'Description of gauge')
   pods_with_no_new_logs = Gauge('Coda_watchdog_pods_with_no_new_logs', 'Number of nodes whose latest log is older than 10 minutes')
 
@@ -37,7 +38,7 @@ def main():
 
   fns = [
     ( lambda: metrics.collect_cluster_crashes(v1, namespace, cluster_crashes), 30*60 ),
-    ( lambda: metrics.collect_node_status_metrics(v1, namespace, nodes_synced_near_best_tip, nodes_synced, prover_errors), 60*60 ),
+    ( lambda: metrics.collect_node_status_metrics(v1, namespace, nodes_synced_near_best_tip, nodes_synced, nodes_queried, prover_errors), 60*60 ),
     ( lambda: metrics.check_seed_list_up(v1, namespace, seeds_reachable), 60*60 ),
     ( lambda: metrics.pods_with_no_new_logs(v1, namespace, pods_with_no_new_logs), 60*10 ),
   ]


### PR DESCRIPTION
As discussed in a meeting earlier today, without knowing how many nodes respond to a status query, it's hard to tell how significant a change in the `synced` or `synced_near_best_tip` metrics actually is. This information can be extracted from the watchdog logs manually, but it's useful to have it exposed directly as a metric.

This PR adds a metric tracking this information.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: