### PR TITLE
Show snark coordinator pk in client status

### DIFF
--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -202,7 +202,9 @@ let get_status ~flag t =
   let user_commands_sent = !txn_count in
   let snark_worker =
     Option.map
-      (Mina_lib.snark_worker_key t)
+      (Option.merge ~f:Fn.const
+         (Mina_lib.snark_worker_key t)
+         (Mina_lib.snark_coordinator_key t))
       ~f:Public_key.Compressed.to_base58_check
   in
   let snark_work_fee = Currency.Fee.to_int @@ Mina_lib.snark_work_fee t in


### PR DESCRIPTION
This PR exposes the snark coordinator public key in the `snark worker` field of `client status`.

The logic here mirrors the logic in [`coda_run.ml`](https://github.com/MinaProtocol/mina/blob/a1b38c244500a5efa45f87c25d6fb8303876ecfc/src/app/cli/src/init/coda_run.ml#L413) used to select the public key for snark workers communicating with the coordinator.

I've found myself wanting this when trying to find the snark-coordinator's public key on our nodes.

Sample output:
```
$ _build/default/src/app/cli/src/mina.exe daemon --seed --proof-level none --run-snark-coordinator B62qiZfzW27eavtPrnF6DeDSAKEjXuGFdkouC3T5STRa6rrYLiDUP2p &
$ _build/default/src/app/cli/src/mina.exe client status
Mina daemon status
-----------------------------------

Max observed block height:              1
Max observed unvalidated block height:  0
Local uptime:                           5s
Chain id:                               971ab7c2a9370f90a3e4f5d1e711d6428e4d7ff210cbb7b5563d70843ce95274
Git SHA-1:                              5e51473fd2aba320fd4cc7deca7e65c17629d9e1
Configuration directory:                ~/.mina-config
Peers:                                  0
User_commands sent:                     0
SNARK worker:                           B62qiZfzW27eavtPrnF6DeDSAKEjXuGFdkouC3T5STRa6rrYLiDUP2p
SNARK work fee:                         1000000000
Sync status:                            Bootstrap
Block producers running:                0
Coinbase receiver:                      Block producer
Consensus time now:                     epoch=59414, slot=253
Consensus mechanism:                    proof_of_stake
Consensus configuration:
        Delta:                     0
        k:                         24
        Slots per epoch:           576
        Slot duration:             2s
        Epoch duration:            19m12s
        Chain start timestamp:     2019-01-30 20:00:00.000000Z
        Acceptable network delay:  2s

Addresses and ports:
        External IP:    127.0.0.1
        Bind IP:        0.0.0.0
        Libp2p PeerID:  12D3KooWNeyCh5w5fyXTUxbMdeBrtoLrZVReDjY9ZDEb1JnS1GHZ
        Libp2p port:    8302
        Client port:    8301
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: