### PR TITLE
Swap balances for combined fee transfers

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1189,12 +1189,12 @@ module Block = struct
                       (id, secondary_sequence_no, fee_transfer.receiver_pk)
                       :: acc )
                 in
-                (* the fold reverses the order of the infos from the fee transfers *)
                 let fee_transfer_infos_with_balances =
                   match fee_transfer_infos with
                   | [id] ->
                       [(id, balances.receiver1_balance)]
                   | [id2; id1] ->
+                      (* the fold reverses the order of the infos from the fee transfers *)
                       [ (id1, balances.receiver1_balance)
                       ; (id2, Option.value_exn balances.receiver2_balance) ]
                   | _ ->

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1174,6 +1174,10 @@ module Block = struct
                 let fee_transfers =
                   Mina_base.Fee_transfer.to_numbered_list fee_transfer_bundled
                 in
+                (* balances.receiver1_balance is for receiver of head of fee_transfers
+                   balances.receiver2_balance, if it exists, is for receiver of
+                     next element of fee_transfers
+                *)
                 let%bind fee_transfer_infos =
                   deferred_result_list_fold fee_transfers ~init:[]
                     ~f:(fun acc (secondary_sequence_no, fee_transfer) ->
@@ -1185,11 +1189,12 @@ module Block = struct
                       (id, secondary_sequence_no, fee_transfer.receiver_pk)
                       :: acc )
                 in
-                let fee_transfer_infos =
+                (* the fold reverses the order of the infos from the fee transfers *)
+                let fee_transfer_infos_with_balances =
                   match fee_transfer_infos with
                   | [id] ->
                       [(id, balances.receiver1_balance)]
-                  | [id1; id2] ->
+                  | [id2; id1] ->
                       [ (id1, balances.receiver1_balance)
                       ; (id2, Option.value_exn balances.receiver2_balance) ]
                   | _ ->
@@ -1198,7 +1203,8 @@ module Block = struct
                          transfer transaction"
                 in
                 let%map () =
-                  deferred_result_list_fold fee_transfer_infos ~init:()
+                  deferred_result_list_fold fee_transfer_infos_with_balances
+                    ~init:()
                     ~f:(fun ()
                        ( (fee_transfer_id, secondary_sequence_no, receiver_pk)
                        , balance )


### PR DESCRIPTION
For combined fee transfers, where two fee transfers are combined into one, the archive db was receiving balances swapped between the two receivers of the fee transfers.

The code has a list of fee transfers, and a separate record of corresponding balances. The code was adding the fee transfer to the db, and retrieving the db id for them. It did so via a fold that reversed the order of the fee transfers, and so associated balances with the wrong fee transfers.

I'm unable to test this fix with Rosetta, since it doesn't create such combined fee transfers, as far as I see. The real way to test this would be to create a testnet with an archive db, and run the replayer on it.

That said, I believe this fix is correct.

Fixes #8504, as far as I see.