### PR TITLE
Only accept valid UInt32/64 values in GraphQL

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1812,6 +1812,8 @@ module Types = struct
     module type Numeric_type = sig
       type t
 
+      val to_string : t -> string
+
       val of_string : string -> t
 
       val of_int : int -> t
@@ -1828,9 +1830,38 @@ module Types = struct
               is a string, it must represent the number in base 10"
              lower_name) ~coerce:(fun key ->
           match key with
-          | `String s ->
-              result_of_exn Numeric.of_string s
-                ~error:(sprintf "Could not decode %s." lower_name)
+          | `String s -> (
+            try
+              let n = Numeric.of_string s in
+              let s' = Numeric.to_string n in
+              (* Here, we check that the string that was passed converts to
+                   the numeric type, and that it is in range, by converting
+                   back to a string and checking that it is equal to the one
+                   passed. This prevents the following weirdnesses in the
+                   [Unsigned.UInt*] parsers:
+                   * if the absolute value is greater than [max_int], the value
+                     returned is [max_int]
+                     - ["99999999999999999999999999999999999"] is [max_int]
+                     - ["-99999999999999999999999999999999999"] is [max_int]
+                   * if otherwise the value is negative, the value returned is
+                     [max_int - (x - 1)]
+                     - ["-1"] is [max_int]
+                   * if there is a non-numeric character part-way through the
+                     string, the numeric prefix is treated as a number
+                     - ["1_000_000"] is [1]
+                     - ["-1_000_000"] is [max_int]
+                     - ["1.1"] is [1]
+                     - ["0x15"] is [0]
+                   * leading spaces are ignored
+                     - [" 1"] is [1]
+                   This is annoying to document, none of these behaviors are
+                   useful to users, and unexpectedly triggering one of them
+                   could have nasty consequences. Thus, we raise an error
+                   rather than silently misinterpreting their input.
+                *)
+              assert (String.equal s s') ;
+              Ok n
+            with _ -> Error (sprintf "Could not decode %s." lower_name) )
           | `Int n ->
               if n < 0 then
                 Error


### PR DESCRIPTION
This PR prevents us from accepting any string that does not roundtrip with (`to_string (of_string s) = s`). This may seem overstrict, but the unsigned parsers do unexpected things (see the code comment) and it's safer to fail explicitly than misinterpret the user.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #8527