### PR TITLE
Integration tests nginx ingress

### DIFF
--- a/automation/terraform/modules/o1-integration/graphql_ingress.tf
+++ b/automation/terraform/modules/o1-integration/graphql_ingress.tf
@@ -10,42 +10,37 @@ resource "kubernetes_ingress" "testnet_graphql_ingress" {
   metadata {
     name = "${var.testnet_name}-graphql-ingress"
     namespace = var.testnet_name
+    annotations = {
+      "kubernetes.io/ingress.class" = "nginx"
+      "nginx.org/mergeable-ingress-type" = "minion"
+      "nginx.ingress.kubernetes.io/rewrite-target" = "/$2"
+    }
   }
 
   spec {
-    dynamic "rule" {
-      for_each = concat(
-        [local.seed_config.name],
-        [for config in var.block_producer_configs : config.name],
-        var.snark_worker_replicas > 0 ? [local.snark_coordinator_name] : []
-      )
+    rule {
+      host = "${local.graphql_ingress_dns}"
+      http {
+        dynamic "path" {
+          for_each = concat(
+            [local.seed_config.name],
+            [for config in var.block_producer_configs : config.name],
+            var.snark_worker_replicas > 0 ? [local.snark_coordinator_name] : []
+          )
 
-      content {
-        host = "${rule.value}.${local.base_graphql_dns}"
-        http {
-          path {
+          content {
             backend {
-              service_name = "${rule.value}-graphql"
-              service_port = 3085
+              service_name = "${path.value}-graphql"
+              service_port = 80
             }
 
-            path = "/graphql"
+            path = "/${path.value}(/|$)(.*)"
           }
         }
       }
     }
   }
 
-  wait_for_load_balancer = true
-}
-
-resource "aws_route53_record" "testnet_graphql_dns" {
-  count = var.deploy_graphql_ingress ? 1 : 0
-  depends_on = [kubernetes_ingress.testnet_graphql_ingress]
-
-  zone_id = var.aws_route53_zone_id
-  name    = "*.${local.base_graphql_dns}"
-  type    = "A"
-  ttl     = "300"
-  records = [kubernetes_ingress.testnet_graphql_ingress[0].status[0].load_balancer[0].ingress[0].ip]
+  # wait_for_load_balancer = true
+  wait_for_load_balancer = false
 }

--- a/automation/terraform/modules/o1-integration/locals.tf
+++ b/automation/terraform/modules/o1-integration/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  base_graphql_dns = "${var.testnet_name}.graphql.o1test.net"
+  graphql_ingress_dns = "${var.testnet_name}.graphql.test.o1test.net"
   snark_worker_host_port            = 10001
   block_producer_starting_host_port = 10010
 

--- a/dockerfiles/coda_daemon_puppeteer.py
+++ b/dockerfiles/coda_daemon_puppeteer.py
@@ -94,7 +94,7 @@ def stop_daemon():
 def inactive_loop():
   global active_daemon_request
 
-  with HTTPServer(('127.0.0.1', 3085), MockRequestHandler) as server:
+  with HTTPServer(('0.0.0.0', 3085), MockRequestHandler) as server:
     while True:
       server.handle_request()
       signal.sigtimedwait(ALL_SIGNALS, 0)

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -362,14 +362,15 @@ kind: Service
 metadata:
   name: {{ $config.name }}-graphql
 spec:
-  type: NodePort
+  type: ClusterIP
   publishNotReadyAddresses: true
   selector:
     app: {{ $config.name }}
   ports:
   - name: http-graphql
     protocol: TCP
-    port: {{ $.Values.coda.ports.graphql }}
+    port: 80
+    targetPort: {{ $.Values.coda.ports.graphql }}
 {{- end }}
 ---
 {{ end }}

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -205,14 +205,15 @@ kind: Service
 metadata:
   name: {{ $config.name }}-graphql
 spec:
-  type: NodePort
+  type: ClusterIP
   publishNotReadyAddresses: true
   selector:
     app: {{ $config.name }}
   ports:
   - name: http-graphql
     protocol: TCP
-    port: {{ $.Values.coda.ports.graphql }}
+    port: 80
+    targetPort: {{ $.Values.coda.ports.graphql }}
 {{- end }}
 ---
 {{ end }}

--- a/helm/snark-worker/templates/coordinator-service.yaml
+++ b/helm/snark-worker/templates/coordinator-service.yaml
@@ -27,14 +27,15 @@ kind: Service
 metadata:
   name: {{ tpl .Values.coordinator.fullname . }}-graphql
 spec:
-  type: NodePort
+  type: ClusterIP
   publishNotReadyAddresses: true
   selector:
     app: {{ tpl .Values.coordinator.fullname . }}
   ports:
   - name: http-graphql
     protocol: TCP
-    port: {{ .Values.coda.ports.graphql }}
+    port: 80
+    targetPort: {{ .Values.coda.ports.graphql }}
 {{- end }}
 ---
 {{ end }}

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -110,11 +110,11 @@ module Node = struct
 
   module Graphql = struct
     let ingress_uri node =
-      Uri.make ~scheme:"http"
-        ~host:
-          (Printf.sprintf "%s.%s.graphql.o1test.net" node.pod_id
-             node.testnet_name)
-        ~path:"/graphql" ~port:80 ()
+      let host =
+        Printf.sprintf "%s.graphql.test.o1test.net" node.testnet_name
+      in
+      let path = Printf.sprintf "/%s/graphql" node.pod_id in
+      Uri.make ~scheme:"http" ~host ~path ~port:80 ()
 
     module Client = Graphql_lib.Client.Make (struct
       let preprocess_variables_string = Fn.id


### PR DESCRIPTION
This PR switches the integration test over to use an nginx ingress controller w/ mergeable ingress types. This will provide a serious speed improvement to the integration tests, and replaces the unreliable/flaky gke ingress controller system we had in place previously.

For now, I've manually deployed the nginx ingress controller and master ingress for the integration test cluster. I will create a separate PR that updates the infrastructure terraform module to deploy the nginx ingress (for the future, in case we need to recreate the cluster).