### PR TITLE
hotfix/pre-release-debian-channel Add codename branch for master-qa

### DIFF
--- a/buildkite/scripts/publish-deb.sh
+++ b/buildkite/scripts/publish-deb.sh
@@ -28,6 +28,8 @@ fi
 case $BUILDKITE_BRANCH in
     master)
         CODENAME=release ;;
+    master-qa)
+        CODANAME=pre-release ;;
     *)
         CODENAME=unstable ;;
 esac

--- a/buildkite/src/Jobs/Release/TestnetAlerts.dhall
+++ b/buildkite/src/Jobs/Release/TestnetAlerts.dhall
@@ -37,6 +37,7 @@ Pipeline.build
           , depends_on = [ { name = "TestnetAlerts", key = "lint-testnet-alerts" } ]
           , soft_fail = Some (B/SoftFail.Boolean True)
           , docker = None Docker.Type
+          , if = Some "build.branch == 'compatible' || build.env('DEPLOY_ALERTS') == 'true'"
         }
     ]
   }


### PR DESCRIPTION
Also pulls in the alerting change from compatible that causes alerts to drift out of date