### PR TITLE
include updated block production keys in node status

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1112,6 +1112,15 @@ let create ?wallets (config : Config.t) =
           (* knot-tying hacks so we can pass a get_node_status function before net, Mina_lib.t created *)
           let net_ref = ref None in
           let sync_status_ref = ref None in
+          let block_production_keypairs =
+            Agent.create
+              ~f:(fun kps ->
+                Keypair.Set.to_list kps
+                |> List.map ~f:(fun kp ->
+                       (kp, Public_key.compress kp.Keypair.public_key) )
+                |> Keypair.And_compressed_pk.Set.of_list )
+              config.initial_block_production_keypairs
+          in
           let get_node_status _env =
             let node_ip_addr =
               config.gossip_net_params.addrs_and_ports.external_ip
@@ -1193,10 +1202,9 @@ let create ?wallets (config : Config.t) =
                           (Mina_incremental.Status.Observer.value status)
                   in
                   let block_producers =
-                    config.initial_block_production_keypairs
-                    |> Keypair.Set.to_list
-                    |> List.map ~f:(fun {Keypair.public_key; _} ->
-                           Public_key.compress public_key )
+                    let public_keys, _ = Agent.get block_production_keypairs in
+                    Public_key.Compressed.Set.map public_keys ~f:snd
+                    |> Set.to_list
                   in
                   let ban_statuses =
                     Trust_system.Peer_trust.peer_statuses config.trust_system
@@ -1597,15 +1605,6 @@ let create ?wallets (config : Config.t) =
                 ~f:(fun x ->
                   Mina_networking.broadcast_snark_pool_diff net x ;
                   Deferred.unit ) ) ;
-          let block_production_keypairs =
-            Agent.create
-              ~f:(fun kps ->
-                Keypair.Set.to_list kps
-                |> List.map ~f:(fun kp ->
-                       (kp, Public_key.compress kp.Keypair.public_key) )
-                |> Keypair.And_compressed_pk.Set.of_list )
-              config.initial_block_production_keypairs
-          in
           Option.iter config.archive_process_location
             ~f:(fun archive_process_port ->
               [%log' info config.logger]


### PR DESCRIPTION
Previously only the ones passed in daemon command were sent. BP keys can be updated using the `set-staking` command