### PR TITLE
Fork from node status

### DIFF
--- a/automation/services/watchdog/node_status_metrics.py
+++ b/automation/services/watchdog/node_status_metrics.py
@@ -61,7 +61,6 @@ def collect_node_status_metrics(v1, namespace, nodes_synced_near_best_tip, nodes
       tree.setdefault(parent, set())
       tree[parent].add(child)
       parents[child] = parent
- 
 
   blocks = set(itertools.chain(tree.keys(), *tree.values()))
   roots = [ b for b in blocks if b not in parents.keys() ]

--- a/automation/services/watchdog/watchdog.py
+++ b/automation/services/watchdog/watchdog.py
@@ -22,16 +22,18 @@ def main():
 
   v1, namespace = util.get_kubernetes()
 
-  cluster_crashes = Gauge('Coda_watchdog_cluster_crashes', 'Description of gauge')
+  cluster_crashes = Gauge('Coda_watchdog_cluster_crashes', 'Fraction of containers recently (30mins ago) restarted')
   error_counter = Counter('Coda_watchdog_errors', 'Description of gauge')
 
-  nodes_synced_near_best_tip = Gauge('Coda_watchdog_nodes_synced_near_best_tip', 'Description of gauge')
-  nodes_synced = Gauge('Coda_watchdog_nodes_synced', 'Description of gauge')
-  prover_errors = Counter('Coda_watchdog_prover_errors', 'Description of gauge')
+  nodes_synced_near_best_tip = Gauge('Coda_watchdog_nodes_synced_near_best_tip', 'Fraction of nodes that are synced to the latest 4 blocks in the canonical chain ')
+  nodes_synced = Gauge('Coda_watchdog_nodes_synced', 'Fraction of nodes with Synced status')
+  prover_errors = Counter('Coda_watchdog_prover_errors', 'Not implemented yet')
   pods_with_no_new_logs = Gauge('Coda_watchdog_pods_with_no_new_logs', 'Number of nodes whose latest log is older than 10 minutes')
 
-  recent_google_bucket_blocks = Gauge('Coda_watchdog_recent_google_bucket_blocks', 'Description of gauge')
-  seeds_reachable = Gauge('Coda_watchdog_seeds_reachable', 'Description of gauge')
+  max_fork_length = Gauge('Coda_node_status_max_fork_length', 'Maximum length of forks from node status')
+
+  recent_google_bucket_blocks = Gauge('Coda_watchdog_recent_google_bucket_blocks', 'Time since last added block data to the google storage bucket ')
+  seeds_reachable = Gauge('Coda_watchdog_seeds_reachable', 'Fraction of reachable seed peers')
 
   # ========================================================================
 


### PR DESCRIPTION
Metric for forks as determined from node status (as part of #8514). I don't think we should add an alert based on this as there are many block producers (with 0 stake) stuck at a very old height. During testing, the metric almost always showed a fork with max length of 291

Added descriptions to some existing metrics 