### PR TITLE
`--replace` flag for archive_blocks

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1658,8 +1658,8 @@ let retry ~f ~logger ~error_str retries =
   in
   go retries
 
-let add_block_aux ?(retries = 3) ?(_replace_block = false) ~logger ~add_block
-    ~hash ~delete_older_than pool block =
+let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
+    pool block =
   let add () =
     Caqti_async.Pool.use
       (fun (module Conn : CONNECTION) ->


### PR DESCRIPTION
Add optional `--replace` flag to `archive_blocks` app. If given, the block and related data are deleted before adding the block.

Tested by:
- extracting a block, modifying some data, replacing the block, extracting again, confirming the data in the 2nd extraction matches the modified block
- removing the block manually from Postgresql, archiving with replacement, confirming the block is still  added and can be extracted

This change is in service of patching the bad balance data in the archive db. See #8504.