### PR TITLE
Stop using hard-coded compile-time verification keys

### DIFF
--- a/buildkite/scripts/check-graphql-schema.sh
+++ b/buildkite/scripts/check-graphql-schema.sh
@@ -20,9 +20,9 @@ apt-get install --allow-downgrades -y curl ${PROJECT}=${VERSION}
 mina daemon --seed --proof-level none --rest-port 8080 &
 
 # Update the graphql schema
-num_retries=5
+num_retries=15
 for ((i=1;i<=$num_retries;i++)); do
-  sleep 10s
+  sleep 15s
   set +e
   make update-graphql
   status_exit_code=$?

--- a/buildkite/scripts/export-git-env-vars.sh
+++ b/buildkite/scripts/export-git-env-vars.sh
@@ -12,7 +12,6 @@ export GITTAG=$(git describe --abbrev=0 | sed 's!/!-!g; s!_!-!g')
 # Identify All Artifacts by Branch and Git Hash
 set +u
 
-# export PVKEYHASH=$(/workdir/_build/default/src/app/cli/src/mina.exe internal snark-hashes | sort | md5sum | cut -c1-8)
 
 export PROJECT="mina-$(echo "$DUNE_PROFILE" | tr _ -)"
 

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -14,7 +14,6 @@ GITHASH_CONFIG=$(git rev-parse --short=8 --verify HEAD)
 
 # Identify All Artifacts by Branch and Git Hash
 set +u
-PVKEYHASH=$(./default/src/app/cli/src/mina.exe internal snark-hashes | sort | md5sum | cut -c1-8)
 
 
 # TODO: be smarter about this when we introduce a devnet package

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -13,6 +13,14 @@ let%test_module "Archive node unit tests" =
     let precomputed_values =
       {(Lazy.force Precomputed_values.for_unit_tests) with proof_level}
 
+    let constraint_constants = precomputed_values.constraint_constants
+
+    let verifier =
+      Async.Thread_safe.block_on_async_exn (fun () ->
+          Verifier.create ~logger ~proof_level ~constraint_constants
+            ~conf_dir:None
+            ~pids:(Child_processes.Termination.create_pid_table ()) )
+
     module Genesis_ledger = (val Genesis_ledger.for_unit_tests)
 
     let archive_uri =
@@ -139,10 +147,9 @@ let%test_module "Archive node unit tests" =
         ( Quickcheck.Generator.with_size ~size:10
         @@ Quickcheck_lib.gen_imperative_list
              (Transition_frontier.For_tests.gen_genesis_breadcrumb
-                ~precomputed_values ())
+                ~precomputed_values ~verifier ())
              (Transition_frontier.Breadcrumb.For_tests.gen_non_deferred
-                ?logger:None ~precomputed_values ?verifier:None
-                ?trust_system:None
+                ?logger:None ~precomputed_values ~verifier ?trust_system:None
                 ~accounts_with_secret_keys:(Lazy.force Genesis_ledger.accounts))
         )
         ~f:(fun breadcrumbs ->
@@ -211,7 +218,7 @@ let%test_module "Archive node unit tests" =
              (Transition_frontier.For_tests.gen_genesis_breadcrumb
                 ~precomputed_values ())
              (Transition_frontier.Breadcrumb.For_tests.gen_non_deferred
-                ?logger:None ~precomputed_values ?verifier:None
+                ?logger:None ~precomputed_values ~verifier
                 ?trust_system:None
                 ~accounts_with_secret_keys:(Lazy.force Genesis_ledger.accounts))
         )

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -19,11 +19,15 @@ let () = Async.Scheduler.set_record_backtraces true
 
 [%%endif]
 
-let chain_id ~genesis_state_hash ~genesis_constants =
+let chain_id ~constraint_system_digests ~genesis_state_hash ~genesis_constants
+    =
   (* if this changes, also change Mina_commands.chain_id_inputs *)
   let genesis_state_hash = State_hash.to_base58_check genesis_state_hash in
   let genesis_constants_hash = Genesis_constants.hash genesis_constants in
-  let all_snark_keys = String.concat ~sep:"" Precomputed_values.key_hashes in
+  let all_snark_keys =
+    List.map constraint_system_digests ~f:(fun (_, digest) -> Md5.to_hex digest)
+    |> String.concat ~sep:""
+  in
   let b2 =
     Blake2.digest_string
       (genesis_state_hash ^ all_snark_keys ^ genesis_constants_hash)
@@ -1020,6 +1024,8 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
       let chain_id =
         chain_id ~genesis_state_hash
           ~genesis_constants:precomputed_values.genesis_constants
+          ~constraint_system_digests:
+            (Lazy.force precomputed_values.constraint_system_digests)
       in
       let gossip_net_params =
         Gossip_net.Libp2p.Config.
@@ -1285,11 +1291,20 @@ let snark_hashes =
       let json = Cli_lib.Flag.json in
       let print = Core.printf "%s\n%!" in
       fun () ->
-        if json then
-          print
-            (Yojson.Safe.to_string
-               (Hashes.to_yojson Precomputed_values.key_hashes))
-        else List.iter Precomputed_values.key_hashes ~f:print]
+        let hashes =
+          match Precomputed_values.compiled with
+          | Some compiled ->
+              (Lazy.force compiled).constraint_system_digests |> Lazy.force
+              |> List.map ~f:(fun (_constraint_system_id, digest) ->
+                     (* Throw away the constraint system ID to avoid changing the
+                    format of the output here.
+                 *)
+                     Md5.to_hex digest )
+          | None ->
+              []
+        in
+        if json then print (Yojson.Safe.to_string (Hashes.to_yojson hashes))
+        else List.iter hashes ~f:print]
 
 let internal_commands logger =
   [ (Snark_worker.Intf.command_name, Snark_worker.command)

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1420,6 +1420,8 @@ let internal_commands logger =
           let%bind verifier =
             Verifier.create ~logger
               ~proof_level:Genesis_constants.Proof_level.compiled
+              ~constraint_constants:
+                Genesis_constants.Constraint_constants.compiled
               ~pids:(Pid.Table.create ()) ~conf_dir:(Some conf_dir)
           in
           let%bind result =

--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -322,6 +322,8 @@ let main num_transactions repeats preeval () =
       let module T = Transaction_snark.Make (struct
         let constraint_constants =
           Genesis_constants.Constraint_constants.compiled
+
+        let proof_level = Genesis_constants.Proof_level.Full
       end) in
       run (profile (module T)) num_transactions repeats preeval )
 

--- a/src/lib/blockchain_snark/blockchain_snark_state.mli
+++ b/src/lib/blockchain_snark/blockchain_snark_state.mli
@@ -47,6 +47,8 @@ module type S = sig
        , Protocol_state.Value.t
        , Proof.t Async.Deferred.t )
        Pickles.Prover.t
+
+  val constraint_system_digests : (string * Md5_lib.t) list Lazy.t
 end
 
 module Make (T : sig

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -586,9 +586,13 @@ let%test_module "Bootstrap_controller tests" =
 
     let constraint_constants = precomputed_values.constraint_constants
 
-    module Genesis_ledger = (val precomputed_values.genesis_ledger)
+    let verifier =
+      Async.Thread_safe.block_on_async_exn (fun () ->
+          Verifier.create ~logger ~proof_level ~constraint_constants
+            ~conf_dir:None
+            ~pids:(Child_processes.Termination.create_pid_table ()) )
 
-    let pids = Child_processes.Termination.create_pid_table ()
+    module Genesis_ledger = (val precomputed_values.genesis_ledger)
 
     let downcast_transition ~sender transition =
       let transition =
@@ -605,10 +609,6 @@ let%test_module "Bootstrap_controller tests" =
         (Transition_frontier.Breadcrumb.validated_transition breadcrumb)
 
     let make_non_running_bootstrap ~genesis_root ~network =
-      let verifier =
-        Async.Thread_safe.block_on_async_exn (fun () ->
-            Verifier.create ~logger ~proof_level ~conf_dir:None ~pids )
-      in
       let transition =
         genesis_root
         |> External_transition.Validation
@@ -633,11 +633,12 @@ let%test_module "Bootstrap_controller tests" =
         (* we only need one node for this test, but we need more than one peer so that mina_networking does not throw an error *)
         let%bind fake_network =
           Fake_network.Generator.(
-            gen ~precomputed_values ~max_frontier_length
+            gen ~precomputed_values ~verifier ~max_frontier_length
               [fresh_peer; fresh_peer])
         in
         let%map make_branch =
           Transition_frontier.Breadcrumb.For_tests.gen_seq ~precomputed_values
+            ~verifier
             ~accounts_with_secret_keys:(Lazy.force Genesis_ledger.accounts)
             branch_size
         in
@@ -711,10 +712,6 @@ let%test_module "Bootstrap_controller tests" =
 
     let run_bootstrap ~timeout_duration ~my_net ~transition_reader =
       let open Fake_network in
-      let verifier =
-        Async.Thread_safe.block_on_async_exn (fun () ->
-            Verifier.create ~conf_dir:None ~proof_level ~logger ~pids )
-      in
       let time_controller = Block_time.Controller.basic ~logger in
       let persistent_root =
         Transition_frontier.persistent_root my_net.state.frontier
@@ -768,7 +765,7 @@ let%test_module "Bootstrap_controller tests" =
     let%test_unit "sync with one node after receiving a transition" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
-          gen ~precomputed_values ~max_frontier_length
+          gen ~precomputed_values ~verifier ~max_frontier_length
             [ fresh_peer
             ; peer_with_branch
                 ~frontier_branch_size:((max_frontier_length * 2) + 2) ])
@@ -805,7 +802,7 @@ let%test_module "Bootstrap_controller tests" =
     let%test_unit "reconstruct staged_ledgers using \
                    of_scan_state_and_snarked_ledger" =
       Quickcheck.test ~trials:1
-        (Transition_frontier.For_tests.gen ~precomputed_values
+        (Transition_frontier.For_tests.gen ~precomputed_values ~verifier
            ~max_length:max_frontier_length ~size:max_frontier_length ())
         ~f:(fun frontier ->
           Thread_safe.block_on_async_exn
@@ -837,9 +834,6 @@ let%test_module "Bootstrap_controller tests" =
               in
               let pending_coinbases =
                 Staged_ledger.pending_coinbase_collection staged_ledger
-              in
-              let%bind verifier =
-                Verifier.create ~conf_dir:None ~proof_level ~logger ~pids
               in
               let%map actual_staged_ledger =
                 Staged_ledger

--- a/src/lib/command_line_tests/command_line_tests.ml
+++ b/src/lib/command_line_tests/command_line_tests.ml
@@ -75,6 +75,8 @@ let%test_module "Command line tests" =
       let test_failed = ref false in
       let port = 1337 in
       let client_delay = 40. in
+      let retry_delay = 15. in
+      let retry_attempts = 15 in
       let config_dir, genesis_ledger_dir = create_config_directories () in
       Monitor.protect
         ~finally:(fun () ->
@@ -91,13 +93,27 @@ let%test_module "Command line tests" =
           match%map
             let open Deferred.Or_error.Let_syntax in
             let%bind _ = start_daemon config_dir genesis_ledger_dir port in
-            (* it takes awhile for the daemon to become available *)
+            (* It takes a while for the daemon to become available. *)
             let%bind () =
               Deferred.map
                 (after @@ Time.Span.of_sec client_delay)
                 ~f:Or_error.return
             in
-            let%bind _ = start_client port in
+            let%bind _ =
+              let rec go retries_remaining =
+                let open Deferred.Let_syntax in
+                match%bind start_client port with
+                | Error _ when retries_remaining > 0 ->
+                    Core.Printf.printf
+                      "Daemon not responding.. retrying (%i/%i)\n"
+                      (retry_attempts - retries_remaining) retry_attempts ;
+                    let%bind () = after @@ Time.Span.of_sec retry_delay in
+                    go (retries_remaining - 1)
+                | ret ->
+                    return ret
+              in
+              go retry_attempts
+            in
             let%map _ = stop_daemon port in
             ()
           with

--- a/src/lib/command_line_tests/command_line_tests.ml
+++ b/src/lib/command_line_tests/command_line_tests.ml
@@ -106,7 +106,8 @@ let%test_module "Command line tests" =
                 | Error _ when retries_remaining > 0 ->
                     Core.Printf.printf
                       "Daemon not responding.. retrying (%i/%i)\n"
-                      (retry_attempts - retries_remaining) retry_attempts ;
+                      (retry_attempts - retries_remaining)
+                      retry_attempts ;
                     let%bind () = after @@ Time.Span.of_sec retry_delay in
                     go (retries_remaining - 1)
                 | ret ->

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -153,10 +153,11 @@ module Generator = struct
 
   type peer_config =
        precomputed_values:Precomputed_values.t
+    -> verifier:Verifier.t
     -> max_frontier_length:int
     -> peer_state Generator.t
 
-  let fresh_peer ~precomputed_values ~max_frontier_length =
+  let fresh_peer ~precomputed_values ~verifier ~max_frontier_length =
     let epoch_ledger_location =
       Filename.temp_dir_name ^/ "epoch_ledger"
       ^ (Uuid_unix.create () |> Uuid.to_string)
@@ -174,12 +175,12 @@ module Generator = struct
           (With_hash.hash precomputed_values.protocol_state_with_hash)
     in
     let%map frontier =
-      Transition_frontier.For_tests.gen ~precomputed_values
+      Transition_frontier.For_tests.gen ~precomputed_values ~verifier
         ~consensus_local_state ~max_length:max_frontier_length ~size:0 ()
     in
     {frontier; consensus_local_state}
 
-  let peer_with_branch ~frontier_branch_size ~precomputed_values
+  let peer_with_branch ~frontier_branch_size ~precomputed_values ~verifier
       ~max_frontier_length =
     let epoch_ledger_location =
       Filename.temp_dir_name ^/ "epoch_ledger"
@@ -199,7 +200,7 @@ module Generator = struct
     in
     let%map frontier, branch =
       Transition_frontier.For_tests.gen_with_branch ~precomputed_values
-        ~max_length:max_frontier_length ~frontier_size:0
+        ~verifier ~max_length:max_frontier_length ~frontier_size:0
         ~branch_size:frontier_branch_size ~consensus_local_state ()
     in
     Async.Thread_safe.block_on_async_exn (fun () ->
@@ -207,11 +208,11 @@ module Generator = struct
           ~f:(Transition_frontier.add_breadcrumb_exn frontier) ) ;
     {frontier; consensus_local_state}
 
-  let gen ~precomputed_values ~max_frontier_length configs =
+  let gen ~precomputed_values ~verifier ~max_frontier_length configs =
     let open Quickcheck.Generator.Let_syntax in
     let%map states =
       Vect.Quickcheck_generator.map configs ~f:(fun config ->
-          config ~precomputed_values ~max_frontier_length )
+          config ~precomputed_values ~verifier ~max_frontier_length )
     in
     setup ~precomputed_values states
 end

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -29,6 +29,7 @@ module Generator : sig
 
   type peer_config =
        precomputed_values:Precomputed_values.t
+    -> verifier:Verifier.t
     -> max_frontier_length:int
     -> peer_state Generator.t
 
@@ -38,6 +39,7 @@ module Generator : sig
 
   val gen :
        precomputed_values:Precomputed_values.t
+    -> verifier:Verifier.t
     -> max_frontier_length:int
     -> (peer_config, 'n num_peers) Vect.t
     -> 'n num_peers t Generator.t

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -148,7 +148,10 @@ let chain_id_inputs (t : Mina_lib.t) =
     Precomputed_values.genesis_state_hash precomputed_values
   in
   let genesis_constants = precomputed_values.genesis_constants in
-  let snark_keys = Precomputed_values.key_hashes in
+  let snark_keys =
+    Lazy.force precomputed_values.constraint_system_digests
+    |> List.map ~f:(fun (_, digest) -> Md5.to_hex digest)
+  in
   (genesis_state_hash, genesis_constants, snark_keys)
 
 let verify_payment t (addr : Account_id.t) (verifying_txn : User_command.t)

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1031,6 +1031,8 @@ let create ?wallets (config : Config.t) =
                 trace "verifier" (fun () ->
                     Verifier.create ~logger:config.logger
                       ~proof_level:config.precomputed_values.proof_level
+                      ~constraint_constants:
+                        config.precomputed_values.constraint_constants
                       ~pids:config.pids ~conf_dir:(Some config.conf_dir) ) )
             >>| Result.ok_exn
           in

--- a/src/lib/precomputed_values/gen_values/dune
+++ b/src/lib/precomputed_values/gen_values/dune
@@ -16,6 +16,6 @@
    snarky.backendless)
  (preprocessor_deps ../../../config.mlh)
  (preprocess
-  (pps ppx_version ppx_optcomp ppx_let ppxlib.metaquot))
+  (pps ppx_version ppx_optcomp ppx_let ppxlib.metaquot ppx_here))
  (instrumentation (backend bisect_ppx))
  (modes native))

--- a/src/lib/precomputed_values/precomputed_values.mli
+++ b/src/lib/precomputed_values/precomputed_values.mli
@@ -2,8 +2,6 @@ include module type of Genesis_proof.T with type t = Genesis_proof.T.t
 
 val blockchain_proof_system_id : unit -> Pickles.Verification_key.Id.t
 
-val key_hashes : string list
-
 val blockchain_verification : unit -> Pickles.Verification_key.t
 
 val transaction_verification : unit -> Pickles.Verification_key.t

--- a/src/lib/precomputed_values/precomputed_values.mli
+++ b/src/lib/precomputed_values/precomputed_values.mli
@@ -2,10 +2,6 @@ include module type of Genesis_proof.T with type t = Genesis_proof.T.t
 
 val blockchain_proof_system_id : unit -> Pickles.Verification_key.Id.t
 
-val blockchain_verification : unit -> Pickles.Verification_key.t
-
-val transaction_verification : unit -> Pickles.Verification_key.t
-
 val for_unit_tests : t Lazy.t
 
 val compiled_inputs : Genesis_proof.Inputs.t Lazy.t

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -92,6 +92,8 @@ module Worker_state = struct
              ( module struct
                module T = Transaction_snark.Make (struct
                  let constraint_constants = constraint_constants
+
+                 let proof_level = proof_level
                end)
 
                module B = Blockchain_snark.Blockchain_snark_state.Make (struct

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -134,6 +134,8 @@ let handle_dirty dirty =
 let str ~loc =
   let module T = Transaction_snark.Make (struct
     let constraint_constants = Genesis_constants.Constraint_constants.compiled
+
+    let proof_level = Genesis_constants.Proof_level.compiled
   end) in
   let module B = Blockchain_snark.Blockchain_snark_state.Make (struct
     let tag = T.tag

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -36,6 +36,8 @@ module Inputs = struct
             Some
               ( module Transaction_snark.Make (struct
                 let constraint_constants = constraint_constants
+
+                let proof_level = proof_level
               end)
               : S )
         | Check | None ->

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1927,6 +1927,14 @@ let%test_module "test" =
     let constraint_constants =
       Genesis_constants.Constraint_constants.for_unit_tests
 
+    let logger = Logger.null ()
+
+    let verifier =
+      Async.Thread_safe.block_on_async_exn (fun () ->
+          Verifier.create ~logger ~proof_level ~constraint_constants
+            ~conf_dir:None
+            ~pids:(Child_processes.Termination.create_pid_table ()) )
+
     let supercharge_coinbase ~ledger ~winner ~global_slot =
       (*using staged ledger to confirm coinbase amount is correctly generated*)
       let epoch_ledger =
@@ -1939,7 +1947,7 @@ let%test_module "test" =
     let create_and_apply_with_state_body_hash
         ?(coinbase_receiver = coinbase_receiver) ?(winner = self_pk)
         ~(current_state_view : Snapp_predicate.Protocol_state.View.t)
-        ~state_and_body_hash sl logger pids txns stmt_to_work =
+        ~state_and_body_hash sl txns stmt_to_work =
       let open Deferred.Let_syntax in
       let supercharge_coinbase =
         supercharge_coinbase ~ledger:(Sl.ledger !sl) ~winner
@@ -1958,9 +1966,6 @@ let%test_module "test" =
             Error.raise (Pre_diff_info.Error.to_error e)
       in
       let diff' = Staged_ledger_diff.forget diff in
-      let%bind verifier =
-        Verifier.create ~logger ~proof_level ~pids ~conf_dir:None
-      in
       let%map ( `Hash_after_applying hash
               , `Ledger_proof ledger_proof
               , `Staged_ledger sl'
@@ -2000,13 +2005,13 @@ let%test_module "test" =
         global_slot_since_genesis }
 
     let create_and_apply ?(coinbase_receiver = coinbase_receiver)
-        ?(winner = self_pk) sl logger pids txns stmt_to_work =
+        ?(winner = self_pk) sl txns stmt_to_work =
       let open Deferred.Let_syntax in
       let%map ledger_proof, diff, _, _, _ =
         create_and_apply_with_state_body_hash ~coinbase_receiver ~winner
           ~current_state_view:(dummy_state_view ())
           ~state_and_body_hash:(State_hash.dummy, State_body_hash.dummy)
-          sl logger pids txns stmt_to_work
+          sl txns stmt_to_work
       in
       (ledger_proof, diff)
 
@@ -2270,13 +2275,11 @@ let%test_module "test" =
         -> unit Deferred.t =
      fun init_state cmds cmd_iters sl ?(expected_proof_count = None) test_mask
          provers stmt_to_work ->
-      let logger = Logger.null () in
-      let pids = Child_processes.Termination.create_pid_table () in
       let%map total_ledger_proofs =
         iter_cmds_acc cmds cmd_iters 0
           (fun cmds_left count_opt cmds_this_iter proof_count ->
             let%bind ledger_proof, diff =
-              create_and_apply sl logger pids cmds_this_iter stmt_to_work
+              create_and_apply sl cmds_this_iter stmt_to_work
             in
             let proof_count' =
               proof_count + if Option.is_some ledger_proof then 1 else 0
@@ -2505,8 +2508,6 @@ let%test_module "test" =
             Ledger.init_state * User_command.Valid.t list * int option list]
         ~trials:10 ~f:(fun (ledger_init_state, cmds, iters) ->
           async_with_ledgers ledger_init_state (fun sl _test_mask ->
-              let logger = Logger.null () in
-              let pids = Child_processes.Termination.create_pid_table () in
               let%map checked =
                 iter_cmds_acc cmds iters true
                   (fun _cmds_left _count_opt cmds_this_iter checked ->
@@ -2540,9 +2541,6 @@ let%test_module "test" =
                         ~ledger:(Sl.ledger !sl)
                         ~coinbase_amount:constraint_constants.coinbase_amount
                         cmds_this_iter work_done partitions
-                    in
-                    let%bind verifier =
-                      Verifier.create ~logger ~proof_level ~pids ~conf_dir:None
                     in
                     let%bind apply_res =
                       Sl.apply ~constraint_constants !sl diff ~logger ~verifier
@@ -2601,7 +2599,6 @@ let%test_module "test" =
         ~trials:1
         ~f:(fun (ledger_init_state, cmds, iters) ->
           async_with_ledgers ledger_init_state (fun sl _test_mask ->
-              let logger = Logger.null () in
               iter_cmds_acc cmds iters ()
                 (fun _cmds_left _count_opt cmds_this_iter () ->
                   let diff =
@@ -2656,8 +2653,6 @@ let%test_module "test" =
         -> [`One_prover | `Many_provers]
         -> unit Deferred.t =
      fun init_state cmds cmd_iters proofs_available sl test_mask provers ->
-      let logger = Logger.null () in
-      let pids = Child_processes.Termination.create_pid_table () in
       let%map proofs_available_left =
         iter_cmds_acc cmds cmd_iters proofs_available
           (fun cmds_left _count_opt cmds_this_iter proofs_available_left ->
@@ -2669,7 +2664,7 @@ let%test_module "test" =
               List.hd_exn proofs_available_left
             in
             let%map proof, diff =
-              create_and_apply sl logger pids cmds_this_iter
+              create_and_apply sl cmds_this_iter
                 (stmt_to_work_restricted
                    (List.take work_list proofs_available_this_iter)
                    provers)
@@ -2813,8 +2808,6 @@ let%test_module "test" =
         -> [`One_prover | `Many_provers]
         -> unit Deferred.t =
      fun _init_state cmds cmd_iters proofs_available sl _test_mask provers ->
-      let logger = Logger.null () in
-      let pids = Child_processes.Termination.create_pid_table () in
       let%map proofs_available_left =
         iter_cmds_acc cmds cmd_iters proofs_available
           (fun _cmds_left _count_opt cmds_this_iter proofs_available_left ->
@@ -2829,7 +2822,7 @@ let%test_module "test" =
               List.(zip_exn work_list (take fees_for_each (length work_list)))
             in
             let%map _proof, diff =
-              create_and_apply sl logger pids cmds_this_iter
+              create_and_apply sl cmds_this_iter
                 (stmt_to_work_random_fee work_to_be_done provers)
             in
             let sorted_work_from_diff1
@@ -3014,8 +3007,6 @@ let%test_module "test" =
         -> unit Deferred.t =
      fun init_state cmds cmd_iters proofs_available state_body_hashes
          current_state_view sl test_mask provers ->
-      let logger = Logger.null () in
-      let pids = Child_processes.Termination.create_pid_table () in
       let%map proofs_available_left, _state_body_hashes_left =
         iter_cmds_acc cmds cmd_iters (proofs_available, state_body_hashes)
           (fun cmds_left
@@ -3034,8 +3025,7 @@ let%test_module "test" =
             let%map proof, diff, is_new_stack, pc_update, supercharge_coinbase
                 =
               create_and_apply_with_state_body_hash ~current_state_view
-                ~state_and_body_hash:state_body_hash sl logger pids
-                cmds_this_iter
+                ~state_and_body_hash:state_body_hash sl cmds_this_iter
                 (stmt_to_work_restricted
                    (List.take work_list proofs_available_this_iter)
                    provers)
@@ -3154,14 +3144,12 @@ let%test_module "test" =
           (f_expected_balance count init_balance)
           account.balance
       in
-      let logger = Logger.null () in
-      let pids = Child_processes.Termination.create_pid_table () in
       Deferred.List.iter
         (List.init block_count ~f:(( + ) 1))
         ~f:(fun block_count ->
           let%bind _ =
             create_and_apply_with_state_body_hash ~winner:delegator.public_key
-              ~coinbase_receiver:coinbase_receiver.public_key sl logger pids
+              ~coinbase_receiver:coinbase_receiver.public_key sl
               ~current_state_view:
                 (dummy_state_view
                    ~global_slot_since_genesis:

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -76,11 +76,21 @@ let%test_module "transaction_status" =
 
     let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
+    let proof_level = precomputed_values.proof_level
+
+    let constraint_constants = precomputed_values.constraint_constants
+
     module Genesis_ledger = (val precomputed_values.genesis_ledger)
 
     let trust_system = Trust_system.null ()
 
     let pool_max_size = precomputed_values.genesis_constants.txpool_max_size
+
+    let verifier =
+      Async.Thread_safe.block_on_async_exn (fun () ->
+          Verifier.create ~logger ~proof_level ~constraint_constants
+            ~conf_dir:None
+            ~pids:(Child_processes.Termination.create_pid_table ()) )
 
     let key_gen =
       let open Quickcheck.Generator in
@@ -92,14 +102,12 @@ let%test_module "transaction_status" =
           (Option.value_exn random_key_opt) )
 
     let gen_frontier =
-      Transition_frontier.For_tests.gen ~logger ~precomputed_values
+      Transition_frontier.For_tests.gen ~logger ~precomputed_values ~verifier
         ~trust_system ~max_length ~size:frontier_size ()
 
     let gen_user_command =
       Signed_command.Gen.payment ~sign_type:`Real ~max_amount:100 ~fee_range:10
         ~key_gen ~nonce:(Account_nonce.of_int 1) ()
-
-    let proof_level = Genesis_constants.Proof_level.for_unit_tests
 
     let create_pool ~frontier_broadcast_pipe =
       let pool_reader, _ =
@@ -109,12 +117,7 @@ let%test_module "transaction_status" =
       let local_reader, local_writer =
         Strict_pipe.(create ~name:"transaction_status local diff" Synchronous)
       in
-      let%bind config =
-        let%map verifier =
-          Verifier.create ~logger ~proof_level
-            ~pids:(Child_processes.Termination.create_pid_table ())
-            ~conf_dir:None
-        in
+      let config =
         Transaction_pool.Resource_pool.make_config ~trust_system ~pool_max_size
           ~verifier
       in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2931,10 +2931,10 @@ module Merge = struct
       ; Token_id.Checked.Assert.equal s2.next_available_token_after
           s.next_available_token_after ]
 
-  let rule self : _ Pickles.Inductive_rule.t =
+  let rule ~proof_level self : _ Pickles.Inductive_rule.t =
     let prev_should_verify =
-      match Genesis_constants.Proof_level.compiled with
-      | Full ->
+      match proof_level with
+      | Genesis_constants.Proof_level.Full ->
           true
       | _ ->
           false
@@ -2965,7 +2965,7 @@ let time lab f =
   printf "%s: %s\n%!" lab (Time.Span.to_string_hum (Time.diff stop start)) ;
   x
 
-let system ~constraint_constants =
+let system ~proof_level ~constraint_constants =
   time "Transaction_snark.system" (fun () ->
       Pickles.compile ~cache:Cache_dir.cache
         (module Statement.With_sok.Checked)
@@ -2978,7 +2978,7 @@ let system ~constraint_constants =
           (Genesis_constants.Constraint_constants.to_snark_keys_header
              constraint_constants)
         ~choices:(fun ~self ->
-          [Base.rule ~constraint_constants; Merge.rule self] ) )
+          [Base.rule ~constraint_constants; Merge.rule ~proof_level self] ) )
 
 module Verification = struct
   module type S = sig
@@ -2991,6 +2991,8 @@ module Verification = struct
     val verification_key : Pickles.Verification_key.t Lazy.t
 
     val verify_against_digest : t -> bool
+
+    val constraint_system_digests : (string * Md5_lib.t) list Lazy.t
   end
 end
 
@@ -3322,14 +3324,32 @@ let verify (ts : (t * _) list) ~key =
        key
        (List.map ts ~f:(fun ({statement; proof}, _) -> (statement, proof)))
 
+let constraint_system_digests ~constraint_constants () =
+  let digest = Tick.R1CS_constraint_system.digest in
+  [ ( "transaction-merge"
+    , digest
+        Merge.(
+          Tick.constraint_system ~exposing:[Statement.With_sok.typ] (fun x ->
+              let open Tick in
+              let%bind x1 = exists Statement.With_sok.typ in
+              let%bind x2 = exists Statement.With_sok.typ in
+              main [x1; x2] x )) )
+  ; ( "transaction-base"
+    , digest
+        Base.(
+          Tick.constraint_system ~exposing:[Statement.With_sok.typ]
+            (main ~constraint_constants)) ) ]
+
 module Make (Inputs : sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
+
+  val proof_level : Genesis_constants.Proof_level.t
 end) =
 struct
   open Inputs
 
   let tag, cache_handle, p, Pickles.Provers.[base; merge] =
-    system ~constraint_constants
+    system ~proof_level ~constraint_constants
 
   module Proof = (val p)
 
@@ -3489,6 +3509,9 @@ struct
       merge [(x12.statement, x12.proof); (x23.statement, x23.proof)] s
     in
     Ok {statement= s; proof}
+
+  let constraint_system_digests =
+    lazy (constraint_system_digests ~constraint_constants ())
 end
 
 let%test_module "transaction_snark" =
@@ -3497,6 +3520,8 @@ let%test_module "transaction_snark" =
       Genesis_constants.Constraint_constants.for_unit_tests
 
     let genesis_constants = Genesis_constants.for_unit_tests
+
+    let proof_level = Genesis_constants.Proof_level.for_unit_tests
 
     let consensus_constants =
       Consensus.Constants.create ~constraint_constants
@@ -3583,6 +3608,8 @@ let%test_module "transaction_snark" =
 
     include Make (struct
       let constraint_constants = constraint_constants
+
+      let proof_level = proof_level
     end)
 
     let state_body =
@@ -6068,19 +6095,3 @@ let%test_module "account timing check" =
       | _ ->
           false
   end )
-
-let constraint_system_digests ~constraint_constants () =
-  let digest = Tick.R1CS_constraint_system.digest in
-  [ ( "transaction-merge"
-    , digest
-        Merge.(
-          Tick.constraint_system ~exposing:[Statement.With_sok.typ] (fun x ->
-              let open Tick in
-              let%bind x1 = exists Statement.With_sok.typ in
-              let%bind x2 = exists Statement.With_sok.typ in
-              main [x1; x2] x )) )
-  ; ( "transaction-base"
-    , digest
-        Base.(
-          Tick.constraint_system ~exposing:[Statement.With_sok.typ]
-            (main ~constraint_constants)) ) ]

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -245,6 +245,8 @@ module Verification : sig
     val verification_key : Pickles.Verification_key.t Lazy.t
 
     val verify_against_digest : t -> bool
+
+    val constraint_system_digests : (string * Md5_lib.t) list Lazy.t
   end
 end
 
@@ -342,6 +344,8 @@ end
 
 module Make (Inputs : sig
   val constraint_constants : Genesis_constants.Constraint_constants.t
+
+  val proof_level : Genesis_constants.Proof_level.t
 end) : S
 
 val constraint_system_digests :

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -285,20 +285,10 @@ module For_tests = struct
         Signed_command.sign sender_keypair payload )
 
   let gen ?(logger = Logger.null ())
-      ~(precomputed_values : Precomputed_values.t) ?verifier
+      ~(precomputed_values : Precomputed_values.t) ~verifier
       ?(trust_system = Trust_system.null ()) ~accounts_with_secret_keys :
       (t -> t Deferred.t) Quickcheck.Generator.t =
     let open Quickcheck.Let_syntax in
-    let verifier =
-      match verifier with
-      | Some verifier ->
-          verifier
-      | None ->
-          Async.Thread_safe.block_on_async_exn (fun () ->
-              Verifier.create ~logger
-                ~proof_level:precomputed_values.proof_level ~conf_dir:None
-                ~pids:(Child_processes.Termination.create_pid_table ()) )
-    in
     let gen_slot_advancement = Int.gen_incl 1 10 in
     let%bind make_next_consensus_state =
       Consensus_state_hooks.For_tests.gen_consensus_state ~gen_slot_advancement
@@ -458,21 +448,21 @@ module For_tests = struct
       | Error (`Invalid_staged_ledger_hash e) ->
           failwithf !"Invalid staged ledger hash: %{sexp:Error.t}" e ()
 
-  let gen_non_deferred ?logger ~precomputed_values ?verifier ?trust_system
+  let gen_non_deferred ?logger ~precomputed_values ~verifier ?trust_system
       ~accounts_with_secret_keys =
     let open Quickcheck.Generator.Let_syntax in
     let%map make_deferred =
-      gen ?logger ?verifier ~precomputed_values ?trust_system
+      gen ?logger ~verifier ~precomputed_values ?trust_system
         ~accounts_with_secret_keys
     in
     fun x -> Async.Thread_safe.block_on_async_exn (fun () -> make_deferred x)
 
-  let gen_seq ?logger ~precomputed_values ?verifier ?trust_system
+  let gen_seq ?logger ~precomputed_values ~verifier ?trust_system
       ~accounts_with_secret_keys n =
     let open Quickcheck.Generator.Let_syntax in
     let gen_list =
       List.gen_with_length n
-        (gen ?logger ~precomputed_values ?verifier ?trust_system
+        (gen ?logger ~precomputed_values ~verifier ?trust_system
            ~accounts_with_secret_keys)
     in
     let%map breadcrumbs_constructors = gen_list in

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -88,7 +88,7 @@ module For_tests : sig
   val gen :
        ?logger:Logger.t
     -> precomputed_values:Precomputed_values.t
-    -> ?verifier:Verifier.t
+    -> verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> accounts_with_secret_keys:(Private_key.t option * Account.t) list
     -> (t -> t Deferred.t) Quickcheck.Generator.t
@@ -96,7 +96,7 @@ module For_tests : sig
   val gen_non_deferred :
        ?logger:Logger.t
     -> precomputed_values:Precomputed_values.t
-    -> ?verifier:Verifier.t
+    -> verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> accounts_with_secret_keys:(Private_key.t option * Account.t) list
     -> (t -> t) Quickcheck.Generator.t
@@ -104,7 +104,7 @@ module For_tests : sig
   val gen_seq :
        ?logger:Logger.t
     -> precomputed_values:Precomputed_values.t
-    -> ?verifier:Verifier.t
+    -> verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> accounts_with_secret_keys:(Private_key.t option * Account.t) list
     -> int

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -22,7 +22,13 @@ let%test_module "Full_frontier tests" =
 
     let ledger_depth = constraint_constants.ledger_depth
 
-    let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
+    let proof_level = precomputed_values.proof_level
+
+    let verifier =
+      Async.Thread_safe.block_on_async_exn (fun () ->
+          Verifier.create ~logger ~proof_level ~constraint_constants
+            ~conf_dir:None
+            ~pids:(Child_processes.Termination.create_pid_table ()) )
 
     module Genesis_ledger = (val precomputed_values.genesis_ledger)
 
@@ -31,11 +37,11 @@ let%test_module "Full_frontier tests" =
     let max_length = 5
 
     let gen_breadcrumb =
-      Breadcrumb.For_tests.gen ~logger ~precomputed_values ?verifier:None
+      Breadcrumb.For_tests.gen ~logger ~precomputed_values ~verifier
         ?trust_system:None ~accounts_with_secret_keys
 
     let gen_breadcrumb_seq =
-      Breadcrumb.For_tests.gen_seq ~logger ~precomputed_values ?verifier:None
+      Breadcrumb.For_tests.gen_seq ~logger ~precomputed_values ~verifier
         ?trust_system:None ~accounts_with_secret_keys
 
     module Transfer = Ledger_transfer.Make (Ledger) (Ledger)

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -91,21 +91,21 @@ module For_tests : sig
 
   val gen_genesis_breadcrumb :
        ?logger:Logger.t
-    -> ?verifier:Verifier.t
+    -> verifier:Verifier.t
     -> precomputed_values:Precomputed_values.t
     -> unit
     -> Breadcrumb.t Quickcheck.Generator.t
 
   val gen_persistence :
        ?logger:Logger.t
-    -> ?verifier:Verifier.t
+    -> verifier:Verifier.t
     -> precomputed_values:Precomputed_values.t
     -> unit
     -> (Persistent_root.t * Persistent_frontier.t) Quickcheck.Generator.t
 
   val gen :
        ?logger:Logger.t
-    -> ?verifier:Verifier.t
+    -> verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t
@@ -123,7 +123,7 @@ module For_tests : sig
 
   val gen_with_branch :
        ?logger:Logger.t
-    -> ?verifier:Verifier.t
+    -> verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -6,7 +6,7 @@ type t = unit
 
 type ledger_proof = Ledger_proof.t
 
-let create ~logger:_ ~proof_level ~pids:_ ~conf_dir:_ =
+let create ~logger:_ ~proof_level ~constraint_constants:_ ~pids:_ ~conf_dir:_ =
   match proof_level with
   | Genesis_constants.Proof_level.Full ->
       failwith "Unable to handle proof-level=Full"

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -32,19 +32,33 @@ module Worker_state = struct
   type init_arg =
     { conf_dir: string option
     ; logger: Logger.Stable.Latest.t
-    ; proof_level: Genesis_constants.Proof_level.Stable.Latest.t }
+    ; proof_level: Genesis_constants.Proof_level.Stable.Latest.t
+    ; constraint_constants:
+        Genesis_constants.Constraint_constants.Stable.Latest.t }
   [@@deriving bin_io_unversioned]
 
   type t = (module S)
 
-  let create {logger; proof_level; _} : t Deferred.t =
+  let create {logger; proof_level; constraint_constants; _} : t Deferred.t =
     Memory_stats.log_memory_stats logger ~process:"verifier" ;
     match proof_level with
     | Full ->
         Deferred.return
-          (let bc_vk = Precomputed_values.blockchain_verification ()
-           and tx_vk = Precomputed_values.transaction_verification () in
-           let module M = struct
+          (let module M = struct
+             module T = Transaction_snark.Make (struct
+               let constraint_constants = constraint_constants
+
+               let proof_level = proof_level
+             end)
+
+             module B = Blockchain_snark_state.Make (struct
+               let tag = T.tag
+
+               let constraint_constants = constraint_constants
+
+               let proof_level = proof_level
+             end)
+
              let verify_commands (cs : User_command.Verifiable.t list) : _ list
                  =
                let cs = List.map cs ~f:Common.check in
@@ -70,14 +84,10 @@ module Worker_state = struct
                  | `Valid_assuming (c, xs) ->
                      if all_verified then `Valid c else `Valid_assuming xs )
 
-             let verify_blockchain_snarks ts =
-               Blockchain_snark.Blockchain_snark_state.verify ts ~key:bc_vk
+             let verify_blockchain_snarks = B.Proof.verify
 
              let verify_transaction_snarks ts =
-               match
-                 Or_error.try_with (fun () ->
-                     Transaction_snark.verify ~key:tx_vk ts )
-               with
+               match Or_error.try_with (fun () -> T.verify ts) with
                | Ok result ->
                    result
                | Error e ->
@@ -87,7 +97,7 @@ module Worker_state = struct
                       snark" ;
                    failwith "Verifier crashed"
            end in
-           (module M : S))
+          (module M : S))
     | Check | None ->
         Deferred.return
         @@ ( module struct
@@ -195,7 +205,8 @@ module Worker = struct
                   list]
               , verify_commands ) }
 
-      let init_worker_state Worker_state.{conf_dir; logger; proof_level} =
+      let init_worker_state
+          Worker_state.{conf_dir; logger; proof_level; constraint_constants} =
         ( if Option.is_some conf_dir then
           let max_size = 256 * 1024 * 512 in
           let num_rotate = 1 in
@@ -206,7 +217,8 @@ module Worker = struct
                  ~directory:(Option.value_exn conf_dir)
                  ~log_filename:"mina-verifier.log" ~max_size ~num_rotate) ) ;
         [%log info] "Verifier started" ;
-        Worker_state.create {conf_dir; logger; proof_level}
+        Worker_state.create
+          {conf_dir; logger; proof_level; constraint_constants}
 
       let init_connection_state ~connection:_ ~worker_state:_ () =
         Deferred.unit
@@ -260,7 +272,8 @@ let wait_safe process =
       Deferred.Or_error.fail err
 
 (* TODO: investigate why conf_dir wasn't being used *)
-let create ~logger ~proof_level ~pids ~conf_dir : t Deferred.t =
+let create ~logger ~proof_level ~constraint_constants ~pids ~conf_dir :
+    t Deferred.t =
   let on_failure err =
     [%log error] "Verifier process failed with error $err"
       ~metadata:[("err", Error_json.error_to_yojson err)] ;
@@ -276,7 +289,7 @@ let create ~logger ~proof_level ~pids ~conf_dir : t Deferred.t =
     let%map connection, process =
       Worker.spawn_in_foreground_exn ~connection_timeout:(Time.Span.of_min 1.)
         ~on_failure ~shutdown_on:Disconnect ~connection_state_init_arg:()
-        {conf_dir; logger; proof_level}
+        {conf_dir; logger; proof_level; constraint_constants}
     in
     Child_processes.Termination.wait_for_process_log_errors ~logger process
       ~module_:__MODULE__ ~location:__LOC__ ;

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -38,6 +38,7 @@ module type S = sig
   val create :
        logger:Logger.t
     -> proof_level:Genesis_constants.Proof_level.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> pids:Child_processes.Termination.t
     -> conf_dir:string option
     -> t Deferred.t


### PR DESCRIPTION
This PR builds upon #8497. This ensures that we don't depend on verification keys from the `Precomputed_values` library, which will not necessarily be the correct ones if we switch between signature schemes.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: