### PR TITLE
minimum block reward

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -344,6 +344,14 @@ let setup_daemon logger =
     flag "--log-precomputed-blocks" ~aliases:["log-precomputed-blocks"]
       (optional_with_default false bool)
       ~doc:"true|false Include precomputed blocks in the log (default: false)"
+  and block_reward_threshold =
+    flag "--minimum-block-reward" ~aliases:["minimum-block-reward"]
+      ~doc:
+        "AMOUNT Minimum reward a block produced by the node should have. \
+         Empty blocks are created if the rewards are lower than the specified \
+         threshold (default: No threshold, transactions and coinbase will be \
+         included as long as the required snark work is included)"
+      (optional txn_amount)
   and upload_blocks_to_gcloud =
     flag "--upload-blocks-to-gcloud"
       ~aliases:["upload-blocks-to-gcloud"]
@@ -1089,7 +1097,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
              ~consensus_local_state ~is_archive_rocksdb ~work_reassignment_wait
              ~archive_process_location ~log_block_creation ~precomputed_values
              ~start_time ?precomputed_blocks_path ~log_precomputed_blocks
-             ~upload_blocks_to_gcloud ())
+             ~upload_blocks_to_gcloud ~block_reward_threshold ())
       in
       { Coda_initialization.coda
       ; client_trustlist

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -350,7 +350,8 @@ let setup_daemon logger =
         "AMOUNT Minimum reward a block produced by the node should have. \
          Empty blocks are created if the rewards are lower than the specified \
          threshold (default: No threshold, transactions and coinbase will be \
-         included as long as the required snark work is included)"
+         included as long as the required snark work is available and can be \
+         paid for)"
       (optional txn_amount)
   and upload_blocks_to_gcloud =
     flag "--upload-blocks-to-gcloud"

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -150,15 +150,14 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
           |> Result.map_error ~f:(fun err ->
                  Staged_ledger.Staged_ledger_error.Pre_diff err )
         in
-        match diff with
-        | Ok d when Option.is_some block_reward_threshold ->
+        match (diff, block_reward_threshold) with
+        | Ok d, Some threshold ->
             let net_return =
               Option.value ~default:Currency.Amount.zero
                 (Staged_ledger_diff.net_return ~constraint_constants
                    ~supercharge_coinbase
                    (Staged_ledger_diff.forget d))
             in
-            let threshold = Option.value_exn block_reward_threshold in
             if Currency.Amount.(net_return >= threshold) then diff
             else (
               [%log info]

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -112,7 +112,7 @@ end
 let generate_next_state ~constraint_constants ~previous_protocol_state
     ~time_controller ~staged_ledger ~transactions ~get_completed_work ~logger
     ~(block_data : Consensus.Data.Block_data.t) ~winner_pk ~scheduled_time
-    ~log_block_creation =
+    ~log_block_creation ~block_reward_threshold =
   let open Interruptible.Let_syntax in
   let previous_protocol_state_body_hash =
     Protocol_state.body previous_protocol_state |> Protocol_state.Body.hash
@@ -140,14 +140,34 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
         Consensus.Data.Block_data.coinbase_receiver block_data
       in
       let diff =
-        measure "create_diff" (fun () ->
-            Staged_ledger.create_diff ~constraint_constants staged_ledger
-              ~coinbase_receiver ~logger
-              ~current_state_view:previous_state_view
-              ~transactions_by_fee:transactions ~get_completed_work
-              ~log_block_creation ~supercharge_coinbase )
-        |> Result.map_error ~f:(fun err ->
-               Staged_ledger.Staged_ledger_error.Pre_diff err )
+        let diff =
+          measure "create_diff" (fun () ->
+              Staged_ledger.create_diff ~constraint_constants staged_ledger
+                ~coinbase_receiver ~logger
+                ~current_state_view:previous_state_view
+                ~transactions_by_fee:transactions ~get_completed_work
+                ~log_block_creation ~supercharge_coinbase )
+          |> Result.map_error ~f:(fun err ->
+                 Staged_ledger.Staged_ledger_error.Pre_diff err )
+        in
+        match diff with
+        | Ok d when Option.is_some block_reward_threshold ->
+            let net_return =
+              Option.value ~default:Currency.Amount.zero
+                (Staged_ledger_diff.net_return ~constraint_constants
+                   ~supercharge_coinbase
+                   (Staged_ledger_diff.forget d))
+            in
+            let threshold = Option.value_exn block_reward_threshold in
+            if Currency.Amount.(net_return >= threshold) then diff
+            else (
+              [%log info]
+                "Block reward is less than the min-block-reward $threshold, \
+                 creating empty block"
+                ~metadata:[("threshold", Currency.Amount.to_yojson threshold)] ;
+              Ok Staged_ledger_diff.With_valid_signatures_and_proofs.empty_diff )
+        | _ ->
+            diff
       in
       match%map
         let%bind.Deferred.Result.Let_syntax diff = return diff in
@@ -424,7 +444,7 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
     ~transaction_resource_pool ~time_controller ~keypairs
     ~consensus_local_state ~coinbase_receiver ~frontier_reader
     ~transition_writer ~set_next_producer_timing ~log_block_creation
-    ~(precomputed_values : Precomputed_values.t) =
+    ~(precomputed_values : Precomputed_values.t) ~block_reward_threshold =
   trace "block_producer" (fun () ->
       let constraint_constants = precomputed_values.constraint_constants in
       let consensus_constants = precomputed_values.consensus_constants in
@@ -479,7 +499,7 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                 ~block_data ~previous_protocol_state ~time_controller
                 ~staged_ledger:(Breadcrumb.staged_ledger crumb)
                 ~transactions ~get_completed_work ~logger ~log_block_creation
-                ~winner_pk
+                ~winner_pk ~block_reward_threshold
             in
             trace_event "next state generated" ;
             match next_state_opt with

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -162,9 +162,11 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
             if Currency.Amount.(net_return >= threshold) then diff
             else (
               [%log info]
-                "Block reward is less than the min-block-reward $threshold, \
-                 creating empty block"
-                ~metadata:[("threshold", Currency.Amount.to_yojson threshold)] ;
+                "Block reward $reward is less than the min-block-reward \
+                 $threshold, creating empty block"
+                ~metadata:
+                  [ ("threshold", Currency.Amount.to_yojson threshold)
+                  ; ("reward", Currency.Amount.to_yojson net_return) ] ;
               Ok Staged_ledger_diff.With_valid_signatures_and_proofs.empty_diff )
         | _ ->
             diff

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -52,5 +52,6 @@ type t =
   ; start_time: Time.t
   ; precomputed_blocks_path: string option
   ; log_precomputed_blocks: bool
-  ; upload_blocks_to_gcloud: bool }
+  ; upload_blocks_to_gcloud: bool
+  ; block_reward_threshold: Currency.Amount.t option [@default None] }
 [@@deriving make]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -979,7 +979,8 @@ let start t =
     ~frontier_reader:t.components.transition_frontier
     ~transition_writer:t.pipes.producer_transition_writer
     ~log_block_creation:t.config.log_block_creation
-    ~precomputed_values:t.config.precomputed_values ;
+    ~precomputed_values:t.config.precomputed_values
+    ~block_reward_threshold:t.config.block_reward_threshold ;
   perform_compaction t ;
   Snark_worker.start t
 

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -1084,14 +1084,7 @@ let genesis ~precomputed_values =
   let protocol_state_proof =
     Precomputed_values.genesis_proof precomputed_values
   in
-  let empty_diff =
-    { Staged_ledger_diff.diff=
-        ( { completed_works= []
-          ; commands= []
-          ; coinbase= Staged_ledger_diff.At_most_two.Zero
-          ; internal_command_balances= [] }
-        , None ) }
-  in
+  let empty_diff = Staged_ledger_diff.empty_diff in
   (* the genesis transition is assumed to be valid *)
   let (`I_swear_this_is_safe_see_my_comment transition) =
     Validated.create_unsafe_pre_hashed

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.ml
@@ -213,6 +213,14 @@ module With_valid_signatures_and_proofs = struct
 
   type t = {diff: diff} [@@deriving sexp, to_yojson]
 
+  let empty_diff : t =
+    { diff=
+        ( { completed_works= []
+          ; commands= []
+          ; coinbase= At_most_two.Zero
+          ; internal_command_balances= [] }
+        , None ) }
+
   let commands t =
     (fst t.diff).commands
     @ Option.value_map (snd t.diff) ~default:[] ~f:(fun d -> d.commands)
@@ -368,21 +376,31 @@ let completed_works (t : t) =
   (fst t.diff).completed_works
   @ Option.value_map (snd t.diff) ~default:[] ~f:(fun d -> d.completed_works)
 
-let net_return (t : t) =
+let net_return
+    ~(constraint_constants : Genesis_constants.Constraint_constants.t)
+    ~supercharge_coinbase (t : t) =
   let open Currency in
-  let commands_return =
-    List.fold ~init:Fee.zero (commands t) ~f:(fun sum cmd ->
-        try
-          Option.value_exn
-            (Fee.( + ) sum (User_command.fee_exn (With_status.data cmd)))
-        with _ -> sum )
+  let open Option.Let_syntax in
+  let%bind coinbase = coinbase ~constraint_constants ~supercharge_coinbase t in
+  let%bind total_reward =
+    List.fold
+      ~init:(Some (Amount.to_fee coinbase))
+      (commands t)
+      ~f:(fun sum cmd ->
+        let%bind sum = sum in
+        Fee.( + ) sum (User_command.fee_exn (With_status.data cmd)) )
   in
-  let completed_works_fees =
-    List.fold ~init:Fee.zero (completed_works t) ~f:(fun sum work ->
-        try Option.value_exn (Fee.( + ) sum work.Transaction_snark_work.fee)
-        with _ -> sum )
+  let%bind completed_works_fees =
+    List.fold ~init:(Some Fee.zero) (completed_works t) ~f:(fun sum work ->
+        let%bind sum = sum in
+        Fee.( + ) sum work.Transaction_snark_work.fee )
   in
-  Amount.(
-    Signed.(
-      of_unsigned (of_fee commands_return)
-      + negate (of_unsigned (of_fee completed_works_fees))))
+  Amount.(of_fee total_reward - of_fee completed_works_fees)
+
+let empty_diff : t =
+  { diff=
+      ( { completed_works= []
+        ; commands= []
+        ; coinbase= At_most_two.Zero
+        ; internal_command_balances= [] }
+      , None ) }

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.mli
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.mli
@@ -141,6 +141,8 @@ module With_valid_signatures_and_proofs : sig
 
   type t = {diff: diff} [@@deriving sexp, to_yojson]
 
+  val empty_diff : t
+
   val commands : t -> User_command.Valid.t With_status.t list
 end
 
@@ -192,3 +194,11 @@ val coinbase :
   -> supercharge_coinbase:bool
   -> t
   -> Currency.Amount.t option
+
+val net_return :
+     constraint_constants:Genesis_constants.Constraint_constants.t
+  -> supercharge_coinbase:bool
+  -> t
+  -> Currency.Amount.t option
+
+val empty_diff : t


### PR DESCRIPTION
Added a new flag `--minimum-block-reward` to the daemon command.
If the total reward of a block generated by a node is less than the  `minimum-block-reward` configured by the node then it discards the diff (consisting of transactions and snark work) and creates an empty block (no coinbase or transactions) instead.

This is temporary solution to a problem described in #8576. The long term solution is described here #8585

Closes #8576
