### PR TITLE
add puppeteered archive node image

### DIFF
--- a/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
@@ -60,7 +60,7 @@ Pipeline.build
             #
 
             [
-              Cmd.run "artifact-cache-helper.sh ./${spec.deploy_env_file} --upload"
+              Cmd.run "artifact-cache-helper.sh ./${spec_docker.deploy_env_file} --upload"
             ],
           label = "Build Archive node debian package",
           key = "build-archive-deb-pkg",
@@ -76,6 +76,6 @@ Pipeline.build
           ]
         },
       DockerImage.generateStep spec_docker,
-      DockerImage.generateStep spec_puppeteered
+      DockerImage.generateStep spec_docker_puppeteered
     ]
   }

--- a/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
@@ -17,11 +17,13 @@ let dependsOn = [ { name = "ArchiveNodeArtifact", key = "build-archive-deb-pkg" 
 let spec_docker = DockerImage.ReleaseSpec::{
     deps=dependsOn,
     deploy_env_file="ARCHIVE_DOCKER_DEPLOY",
+    service="coda-archive",
     step_key="archive-docker-image"
 }
 let spec_docker_puppeteered = DockerImage.ReleaseSpec::{
     deps=dependsOn # [{ name = "ArchiveNodeArtifact", key = "archive-docker-image" }],
     deploy_env_file="ARCHIVE_DOCKER_DEPLOY",
+    service="coda-archive-puppeteered",
     step_key="archive-docker-puppeteered-image"
 }
 

--- a/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
@@ -20,7 +20,7 @@ let spec_docker = DockerImage.ReleaseSpec::{
     step_key="archive-docker-image"
 }
 let spec_docker_puppeteered = DockerImage.ReleaseSpec::{
-    deps=dependsOn :: { name = "Artifact", key = "archive-docker-image" },
+    deps=dependsOn # [{ name = "Artifact", key = "archive-docker-image" }],
     deploy_env_file="ARCHIVE_DOCKER_DEPLOY",
     step_key="archive-docker-puppeteered-image"
 }

--- a/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
@@ -20,7 +20,7 @@ let spec_docker = DockerImage.ReleaseSpec::{
     step_key="archive-docker-image"
 }
 let spec_docker_puppeteered = DockerImage.ReleaseSpec::{
-    deps=dependsOn # [{ name = "Artifact", key = "archive-docker-image" }],
+    deps=dependsOn # [{ name = "ArchiveNodeArtifact", key = "archive-docker-image" }],
     deploy_env_file="ARCHIVE_DOCKER_DEPLOY",
     step_key="archive-docker-puppeteered-image"
 }

--- a/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
@@ -14,10 +14,15 @@ let DockerImage = ../../Command/DockerImage.dhall
 
 let dependsOn = [ { name = "ArchiveNodeArtifact", key = "build-archive-deb-pkg" } ]
 
-let spec = DockerImage.ReleaseSpec::{
+let spec_docker = DockerImage.ReleaseSpec::{
     deps=dependsOn,
     deploy_env_file="ARCHIVE_DOCKER_DEPLOY",
     step_key="archive-docker-image"
+}
+let spec_docker_puppeteered = DockerImage.ReleaseSpec::{
+    deps=dependsOn :: { name = "Artifact", key = "archive-docker-image" },
+    deploy_env_file="ARCHIVE_DOCKER_DEPLOY",
+    step_key="archive-docker-puppeteered-image"
 }
 
 in
@@ -70,6 +75,7 @@ Pipeline.build
             { name = "ArchiveRedundancyTools", key = "archive-redundancy-swap_bad_balances" }
           ]
         },
-      DockerImage.generateStep spec
+      DockerImage.generateStep spec_docker,
+      DockerImage.generateStep spec_puppeteered
     ]
   }

--- a/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
@@ -22,7 +22,7 @@ let spec_docker = DockerImage.ReleaseSpec::{
 }
 let spec_docker_puppeteered = DockerImage.ReleaseSpec::{
     deps=dependsOn # [{ name = "ArchiveNodeArtifact", key = "archive-docker-image" }],
-    deploy_env_file="ARCHIVE_DOCKER_DEPLOY",
+    deploy_env_file="DOCKER_DEPLOY_ENV",
     service="coda-archive-puppeteered",
     step_key="archive-docker-puppeteered-image"
 }

--- a/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
+++ b/buildkite/src/Jobs/Release/ArchiveNodeArtifact.dhall
@@ -22,7 +22,7 @@ let spec_docker = DockerImage.ReleaseSpec::{
 }
 let spec_docker_puppeteered = DockerImage.ReleaseSpec::{
     deps=dependsOn # [{ name = "ArchiveNodeArtifact", key = "archive-docker-image" }],
-    deploy_env_file="DOCKER_DEPLOY_ENV",
+    -- deploy_env_file="DOCKER_DEPLOY_ENV",
     service="coda-archive-puppeteered",
     step_key="archive-docker-puppeteered-image"
 }

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -7,9 +7,11 @@ let TestExecutive = ../../Command/TestExecutive.dhall
 
 let dependsOn = [
     { name = "TestnetIntegrationTests", key = "build-test-executive" },
-    { name = "MinaArtifact", key = "puppeteered-docker-image" },
-    { name = "ArchiveNodeArtifact", key = "archive-docker-image" }
+    { name = "MinaArtifact", key = "puppeteered-docker-image" }
+    -- { name = "ArchiveNodeArtifact", key = "archive-docker-image" }
 ]
+
+let dependsOnArchive = dependsOn :: { name = "ArchiveNodeArtifact", key = "archive-docker-image" }
 
 in Pipeline.build Pipeline.Config::{
   spec =
@@ -27,6 +29,8 @@ in Pipeline.build Pipeline.Config::{
     TestExecutive.execute "bootstrap" dependsOn,
     TestExecutive.execute "peers" dependsOn,
     TestExecutive.execute "send-payment" dependsOn,
-    TestExecutive.execute "common-prefix" dependsOn
+    TestExecutive.execute "common-prefix" dependsOn,
+    TestExecutive.execute "archive-node" dependsOnArchive
+
   ]
 }

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -11,7 +11,7 @@ let dependsOn = [
     -- { name = "ArchiveNodeArtifact", key = "archive-docker-image" }
 ]
 
-let dependsOnArchive = dependsOn :: { name = "ArchiveNodeArtifact", key = "archive-docker-image" }
+let dependsOnArchive = dependsOn :: { name = "ArchiveNodeArtifact", key = "archive-docker-puppeteered-image" }
 
 in Pipeline.build Pipeline.Config::{
   spec =

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -11,7 +11,7 @@ let dependsOn = [
     -- { name = "ArchiveNodeArtifact", key = "archive-docker-image" }
 ]
 
-let dependsOnArchive = dependsOn :: { name = "ArchiveNodeArtifact", key = "archive-docker-puppeteered-image" }
+let dependsOnArchive = dependsOn # [{ name = "ArchiveNodeArtifact", key = "archive-docker-puppeteered-image" }]
 
 in Pipeline.build Pipeline.Config::{
   spec =

--- a/dockerfiles/Dockerfile-coda-archive-puppeteered
+++ b/dockerfiles/Dockerfile-coda-archive-puppeteered
@@ -1,0 +1,29 @@
+# This dockerfile is part of a "temporary" hack for integration tests. Do not use
+# this dockerfile in a production environment. See `coda_daemon_puppeteer.py`
+# for more details.
+
+ARG CODA_VERSION
+FROM codaprotocol/coda-archive:${CODA_VERSION}
+
+ARG CODA_BRANCH
+
+RUN echo '#!/bin/bash\n\
+pgrep -f --newest "python3 /root/coda_daemon_puppeteer.py"'\
+> find_puppeteer.sh
+
+RUN echo '#!/bin/bash\n\
+kill -s SIGUSR2 $(./find_puppeteer.sh)\n\
+while [ ! -f daemon-active ]; do sleep 1; done'\
+> start.sh
+
+RUN echo '#!/bin/bash\n\
+kill -s SIGUSR1 $(./find_puppeteer.sh)\n\
+while [ -f daemon-active ]; do sleep 1; done'\
+> stop.sh
+
+RUN chmod +x find_puppeteer.sh start.sh stop.sh
+
+RUN curl -sL "https://raw.githubusercontent.com/MinaProtocol/mina/${CODA_BRANCH}/dockerfiles/coda_daemon_puppeteer.py" \
+  -o /root/coda_daemon_puppeteer.py
+
+ENTRYPOINT ["/usr/bin/dumb-init", "python3", "/root/coda_daemon_puppeteer.py"]

--- a/scripts/archive/build-release-archives.sh
+++ b/scripts/archive/build-release-archives.sh
@@ -203,7 +203,7 @@ if [ -n "${BUILDKITE+x}" ]; then
     set -x
 
     # Export variables for use with downstream steps
-    echo "export CODA_SERVICE=coda-archive" >> ./ARCHIVE_DOCKER_DEPLOY
+    # echo "export CODA_SERVICE=coda-archive" >> ./ARCHIVE_DOCKER_DEPLOY
     echo "export CODA_VERSION=${DOCKER_TAG}" >> ./ARCHIVE_DOCKER_DEPLOY
     echo "export CODA_DEB_VERSION=${VERSION}" >> ./ARCHIVE_DOCKER_DEPLOY
     echo "export CODA_DEB_REPO=${CODENAME}" >> ./ARCHIVE_DOCKER_DEPLOY

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -10,7 +10,7 @@ set +x
 CLEAR='\033[0m'
 RED='\033[0;31m'
 # Array of valid service names
-VALID_SERVICES=('coda-archive', 'coda-daemon' 'coda-daemon-puppeteered' 'bot' 'coda-demo' 'coda-rosetta', 'leaderboard')
+VALID_SERVICES=('coda-archive','coda-archive-puppeteered', 'coda-daemon' 'coda-daemon-puppeteered' 'bot' 'coda-demo' 'coda-rosetta', 'leaderboard')
 
 function usage() {
   if [ -n "$1" ]; then
@@ -50,6 +50,9 @@ if [ $(echo ${VALID_SERVICES[@]} | grep -o "$SERVICE" - | wc -w) -eq 0 ]; then u
 case $SERVICE in
 coda-archive)
   DOCKERFILE_PATH="scripts/archive/Dockerfile"
+  ;;
+coda-archive-puppeteered)
+  DOCKERFILE_PATH="dockerfiles/Dockerfile-coda-archive-puppeteered"
   ;;
 bot)
   DOCKERFILE_PATH="frontend/bot/Dockerfile"

--- a/src/app/cli/src/cli.opam
+++ b/src/app/cli/src/cli.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "0.1"
 build: [
   ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]


### PR DESCRIPTION
the integration test requires all the nodes to be puppeteered nodes.  this PR makes a puppeteered version of the archive node docker image so that it can be treated the same way as other nodes.

Also adds the archive node test back into CI.  