### PR TITLE
[master] Metric for all peers ever seen

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1591,6 +1591,7 @@ let generate_libp2p_keypair =
       File_system.with_temp_dir "coda-generate-libp2p-keypair" ~f:(fun tmpd ->
           match%bind
             Mina_net2.create ~logger ~conf_dir:tmpd
+              ~all_peers_seen_metric:false
               ~pids:(Child_processes.Termination.create_pid_table ())
               ~on_unexpected_termination:(fun () ->
                 raise Child_processes.Child_died )

--- a/src/app/cli/src/mina.ml
+++ b/src/app/cli/src/mina.ml
@@ -351,6 +351,12 @@ let setup_daemon logger =
         "true|false upload blocks to gcloud storage. Requires the environment \
          variables GCLOUD_KEYFILE, NETWORK_NAME, and \
          GCLOUD_BLOCK_UPLOAD_BUCKET"
+  and all_peers_seen_metric =
+    flag "--all-peers-seen-metric" ~aliases:["all-peers-seen-metric"]
+      (optional_with_default false bool)
+      ~doc:
+        "true|false whether to track the set of all peers ever seen for the \
+         all_peers metric (default: false)"
   in
   fun () ->
     let open Deferred.Let_syntax in
@@ -1024,7 +1030,8 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
           ; max_connections
           ; validation_queue_size
           ; isolate= Option.value ~default:false isolate
-          ; keypair= libp2p_keypair }
+          ; keypair= libp2p_keypair
+          ; all_peers_seen_metric }
       in
       let net_config =
         { Mina_networking.Config.logger

--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -14,7 +14,7 @@ let net_configs n =
         Mina_net2.create
           ~pids:(Child_processes.Termination.create_pid_table ())
           ~logger:(Logger.create ()) ~conf_dir:tmpd
-          ~on_unexpected_termination:(fun () ->
+          ~all_peers_seen_metric:false ~on_unexpected_termination:(fun () ->
             raise Child_processes.Child_died )
       in
       let net = Or_error.ok_exn net in

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -426,7 +426,8 @@ module T = struct
               ; validation_queue_size= 150
               ; peer_exchange= true
               ; mina_peer_exchange= true
-              ; keypair= Some libp2p_keypair }
+              ; keypair= Some libp2p_keypair
+              ; all_peers_seen_metric= false }
           in
           let net_config =
             { Mina_networking.Config.logger

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -149,7 +149,8 @@ let run_test () : unit Deferred.t =
           ; trust_system
           ; max_connections= 50
           ; validation_queue_size= 150
-          ; keypair= None }
+          ; keypair= None
+          ; all_peers_seen_metric= false }
       in
       let net_config =
         Mina_networking.Config.

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -37,7 +37,8 @@ module Config = struct
     ; seed_peer_list_url: Uri.t option
     ; max_connections: int
     ; validation_queue_size: int
-    ; mutable keypair: Mina_net2.Keypair.t option }
+    ; mutable keypair: Mina_net2.Keypair.t option
+    ; all_peers_seen_metric: bool }
   [@@deriving make]
 end
 
@@ -153,7 +154,9 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
       match%bind
         Monitor.try_with ~rest:`Raise (fun () ->
             trace "mina_net2" (fun () ->
-                Mina_net2.create ~logger:config.logger ~conf_dir ~pids
+                Mina_net2.create
+                  ~all_peers_seen_metric:config.all_peers_seen_metric
+                  ~logger:config.logger ~conf_dir ~pids
                   ~on_unexpected_termination ) )
       with
       | Ok (Ok net2) -> (

--- a/src/lib/mina_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/mina_metrics.ml
@@ -344,6 +344,10 @@ module Network = struct
     let help = "# of peers seen through gossip net" in
     Gauge.v "peers" ~help ~namespace ~subsystem
 
+  let all_peers : Gauge.t =
+    let help = "# of peers ever seen through gossip net" in
+    Gauge.v "all_peers" ~help ~namespace ~subsystem
+
   let gossip_messages_received : Counter.t =
     let help = "# of messages received" in
     Counter.v "messages_received" ~help ~namespace ~subsystem

--- a/src/lib/mina_net2/dune
+++ b/src/lib/mina_net2/dune
@@ -1,7 +1,7 @@
 (library
  (name mina_net2)
  (public_name mina_net2)
- (libraries async base58 base64 error_json child_processes digestif core file_system logger network_peer pipe_lib yojson timeout_lib)
+ (libraries async base58 base64 error_json child_processes digestif core file_system logger network_peer pipe_lib yojson timeout_lib mina_metrics)
  (inline_tests)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane ppx_deriving.std ppx_let ppx_deriving_yojson)))

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -212,7 +212,8 @@ end
   * This can fail for a variety of reasons related to spawning the subprocess.
 *)
 val create :
-     on_unexpected_termination:(unit -> unit Deferred.t)
+     all_peers_seen_metric:bool
+  -> on_unexpected_termination:(unit -> unit Deferred.t)
   -> logger:Logger.t
   -> pids:Child_processes.Termination.t
   -> conf_dir:string


### PR DESCRIPTION
This PR adds one of the metrics for the investigation in #8638: when the `--all-peers-seen-metric true` flag is passed, the node will accumulate the set of all peers it ever receives a message from, exposing the size of this set as the `all_peers` metric.

Note that this doesn't use the connection events that we receive from libp2p, because the metrics from the connection manager indicate that it isn't correctly tracking connections (issue #8525). Instead, this is hooked into the `incomingStream` message, so this metric is more accurately tracking every peer that we've ever received an incoming connection from in OCaml.

Tracking of peers is done using the IP address and port only, to ensure that we don't double(or triple, etc.) count peers that restart and generate a new libp2p ID.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: