### PR TITLE
Feature: Add stagedLedgerProofEmitted to GraphQL

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6548,6 +6548,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "stagedLedgerProofEmitted",
+              "description": "Block finished a staged ledger, and a proof was emitted from it and included into this block's proof. If there is no transition frontier available, this will return null.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6326,6 +6326,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "stagedLedgerProofEmitted",
+              "description": "Block finished a staged ledger, and a proof was emitted from it and included into this block's proof. If there is no transition frontier available or no block found, this will return null.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -6545,18 +6557,6 @@
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "stagedLedgerProofEmitted",
-              "description": "Block finished a staged ledger, and a proof was emitted from it and included into this block's proof. If there is no transition frontier available, this will return null.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -543,11 +543,18 @@ module Types = struct
             ~typ:(non_null @@ list @@ non_null work_statement)
             ~resolve:(fun _ w -> One_or_two.to_list w) ] )
 
-  let blockchain_state =
+  let blockchain_state :
+      ( 'context
+      , (Mina_state.Blockchain_state.Value.t * State_hash.t) option )
+      typ =
     obj "BlockchainState" ~fields:(fun _ ->
         [ field "date" ~typ:(non_null string) ~doc:(Doc.date "date")
             ~args:Arg.[]
-            ~resolve:(fun _ {Mina_state.Blockchain_state.Poly.timestamp; _} ->
+            ~resolve:(fun _ t ->
+              let blockchain_state, _ = t in
+              let timestamp =
+                Mina_state.Blockchain_state.timestamp blockchain_state
+              in
               Block_time.to_string timestamp )
         ; field "utcDate" ~typ:(non_null string)
             ~doc:
@@ -557,46 +564,84 @@ module Types = struct
                     time instead of genesis time."
                  "utcDate")
             ~args:Arg.[]
-            ~resolve:
-              (fun {ctx= coda; _}
-                   {Mina_state.Blockchain_state.Poly.timestamp; _} ->
+            ~resolve:(fun {ctx= coda; _} t ->
+              let blockchain_state, _ = t in
+              let timestamp =
+                Mina_state.Blockchain_state.timestamp blockchain_state
+              in
               Block_time.to_string_system_time
                 (Mina_lib.time_controller coda)
                 timestamp )
         ; field "snarkedLedgerHash" ~typ:(non_null string)
             ~doc:"Base58Check-encoded hash of the snarked ledger"
             ~args:Arg.[]
-            ~resolve:
-              (fun _ {Mina_state.Blockchain_state.Poly.snarked_ledger_hash; _} ->
+            ~resolve:(fun _ t ->
+              let blockchain_state, _ = t in
+              let snarked_ledger_hash =
+                Mina_state.Blockchain_state.snarked_ledger_hash
+                  blockchain_state
+              in
               Frozen_ledger_hash.to_string snarked_ledger_hash )
         ; field "stagedLedgerHash" ~typ:(non_null string)
             ~doc:"Base58Check-encoded hash of the staged ledger"
             ~args:Arg.[]
-            ~resolve:
-              (fun _ {Mina_state.Blockchain_state.Poly.staged_ledger_hash; _} ->
+            ~resolve:(fun _ t ->
+              let blockchain_state, _ = t in
+              let staged_ledger_hash =
+                Mina_state.Blockchain_state.staged_ledger_hash blockchain_state
+              in
               Mina_base.Ledger_hash.to_string
-              @@ Staged_ledger_hash.ledger_hash staged_ledger_hash ) ] )
+              @@ Staged_ledger_hash.ledger_hash staged_ledger_hash )
+        ; field "stagedLedgerProofEmitted" ~typ:bool
+            ~doc:
+              "Block finished a staged ledger, and a proof was emitted from \
+               it and included into this block's proof. If there is no \
+               transition frontier available or no block found, this will \
+               return null."
+            ~args:Arg.[]
+            ~resolve:(fun {ctx= coda; _} t ->
+              let open Option.Let_syntax in
+              let _, hash = t in
+              let%bind frontier =
+                Mina_lib.transition_frontier coda
+                |> Pipe_lib.Broadcast_pipe.Reader.peek
+              in
+              match Transition_frontier.find frontier hash with
+              | None ->
+                  None
+              | Some b ->
+                  Some (Transition_frontier.Breadcrumb.just_emitted_a_proof b)
+              ) ] )
 
-  let protocol_state =
+  let protocol_state :
+      ( 'context
+      , (Filtered_external_transition.Protocol_state.t * State_hash.t) option
+      )
+      typ =
     let open Filtered_external_transition.Protocol_state in
     obj "ProtocolState" ~fields:(fun _ ->
         [ field "previousStateHash" ~typ:(non_null string)
             ~doc:"Base58Check-encoded hash of the previous state"
             ~args:Arg.[]
             ~resolve:(fun _ t ->
-              State_hash.to_base58_check t.previous_state_hash )
+              let protocol_state, _ = t in
+              State_hash.to_base58_check protocol_state.previous_state_hash )
         ; field "blockchainState"
             ~doc:"State which is agnostic of a particular consensus algorithm"
             ~typ:(non_null blockchain_state)
             ~args:Arg.[]
-            ~resolve:(fun _ t -> t.blockchain_state)
+            ~resolve:(fun _ t ->
+              let protocol_state, state_hash = t in
+              (protocol_state.blockchain_state, state_hash) )
         ; field "consensusState"
             ~doc:
               "State specific to the Codaboros Proof of Stake consensus \
                algorithm"
             ~typ:(non_null @@ Consensus.Data.Consensus_state.graphql_type ())
             ~args:Arg.[]
-            ~resolve:(fun _ t -> t.consensus_state) ] )
+            ~resolve:(fun _ t ->
+              let protocol_state, _ = t in
+              protocol_state.consensus_state ) ] )
 
   let chain_reorganization_status : ('contxt, [`Changed] option) typ =
     enum "ChainReorganizationStatus"
@@ -1484,7 +1529,8 @@ module Types = struct
               State_hash.to_decimal_string hash )
         ; field "protocolState" ~typ:(non_null protocol_state)
             ~args:Arg.[]
-            ~resolve:(fun _ {With_hash.data; _} -> data.protocol_state)
+            ~resolve:(fun _ {With_hash.data; With_hash.hash; _} ->
+              (data.protocol_state, hash) )
         ; field "protocolStateProof"
             ~typ:(non_null protocol_state_proof)
             ~doc:"Snark proof of blockchain state"
@@ -1496,33 +1542,7 @@ module Types = struct
         ; field "snarkJobs"
             ~typ:(non_null @@ list @@ non_null completed_work)
             ~args:Arg.[]
-            ~resolve:(fun _ {With_hash.data; _} -> data.snark_jobs)
-        ; field "stagedLedgerProofEmitted" ~typ:bool
-            ~doc:
-              "Block finished a staged ledger, and a proof was emitted from \
-               it and included into this block's proof. If there is no \
-               transition frontier available or no block found, this will \
-               return null."
-            ~args:Arg.[]
-            ~resolve:(fun {ctx= coda; _} {With_hash.hash; With_hash.data; _} ->
-              let open Option.Let_syntax in
-              let%bind frontier =
-                Mina_lib.transition_frontier coda
-                |> Pipe_lib.Broadcast_pipe.Reader.peek
-              in
-              match Transition_frontier.find frontier hash with
-              | None ->
-                  None
-              | Some b ->
-                  let breadcrumb_staged_ledger_hash =
-                    Staged_ledger.hash
-                      (Transition_frontier.Breadcrumb.staged_ledger b)
-                  in
-                  let staged_ledger_hash =
-                    data.protocol_state.blockchain_state.staged_ledger_hash
-                  in
-                  Some (breadcrumb_staged_ledger_hash = staged_ledger_hash) )
-        ] )
+            ~resolve:(fun _ {With_hash.data; _} -> data.snark_jobs) ] )
 
   let snark_worker =
     obj "SnarkWorker" ~fields:(fun _ ->


### PR DESCRIPTION
This PR implements the `stagedLedgerProofEmitted` endpoint in our GraphQL. This endpoint looks for a given state hash and attempts to find a corresponding breadcrumb in the transition frontier. If we find a breadcrumb, we call the `just_emitted_a_proof` method to see if the staged ledger proof has been emitted. If no breadcrumb or block is found, we return null.

GraphQL:
![image](https://user-images.githubusercontent.com/9512405/115090597-1b16e600-9eca-11eb-8425-e90efccdd9d8.png)
