### PR TITLE
[WIP][rust] pinning version of rust to 1.45.2

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.45.2"


### PR DESCRIPTION
On Mac I couldn't build mina with the latest stable version of Rust, it works if I pin the version to 1.45.2 (which is what is done in the Dockerfile).

Instead of manually setting this, we can just rely on a rust-toolchain file at the root of our directory.

`DUNE_PROFILE=mainnet make build` built without error.


