### PR TITLE
Add stable pipeline support to buildkite

### DIFF
--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -23,17 +23,23 @@ let makeCommand : JobSpec.Type -> Cmd.Type = \(job : JobSpec.Type) ->
   let dirtyWhen = SelectFiles.compile job.dirtyWhen
   let trigger = triggerCommand "src/Jobs/${job.path}/${job.name}.dhall"
   in Cmd.quietly ''
-    if cat _computed_diff.txt | egrep -q '${dirtyWhen}'; then
-        echo "Triggering ${job.name} for reason:"
-        cat _computed_diff.txt | egrep '${dirtyWhen}'
-        ${Cmd.format trigger}
-    fi
+    case "$BUILDKITE_PIPELINE_TYPE" in
+      ""|pull_request)
+        if cat _computed_diff.txt | egrep -q '${dirtyWhen}'; then
+          echo "Triggering ${job.name} for reason:"
+          cat _computed_diff.txt | egrep '${dirtyWhen}'
+          ${Cmd.format trigger}
+        fi;;
+      stable)
+        echo "Triggering ${job.name} because buildkite this is a stable buildkite run"
+        ${Cmd.format trigger};;
+    esac
   ''
 
 let prefixCommands = [
   Cmd.run "git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt", -- Tell git where to find certs for https connections
   Cmd.run "git fetch origin", -- Freshen the cache
-  Cmd.run "./buildkite/scripts/generate-diff.sh > _computed_diff.txt"
+  Cmd.run "([ -z \"$BUILDKITE_PIPELINE_TYPE\" ] || [ \"$BUILDKITE_PIPELINE_TYPE\" == pull_request ]) && (./buildkite/scripts/generate-diff.sh > _computed_diff.txt)"
 ]
 
 let commands = Prelude.List.map JobSpec.Type Cmd.Type makeCommand jobs
@@ -53,7 +59,7 @@ in Pipeline.build Pipeline.Config::{
       target = Size.Small,
       docker = Some Docker::{
         image = (./Constants/ContainerImages.dhall).toolchainBase,
-        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_INCREMENTAL"]
+        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_INCREMENTAL", "BUILDKITE_PIPELINE_TYPE"]
       }
     }
   ]

--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -33,6 +33,9 @@ let makeCommand : JobSpec.Type -> Cmd.Type = \(job : JobSpec.Type) ->
       stable)
         echo "Triggering ${job.name} because this is a stable buildkite run"
         ${Cmd.format trigger};;
+      *)
+        echo "Invalid BUILDKITE_PIPELINE_TYPE: $BUILDKITE_PIPELINE_TYPE"
+        exit 1;;
     esac
   ''
 

--- a/buildkite/src/Monorepo.dhall
+++ b/buildkite/src/Monorepo.dhall
@@ -31,7 +31,7 @@ let makeCommand : JobSpec.Type -> Cmd.Type = \(job : JobSpec.Type) ->
           ${Cmd.format trigger}
         fi;;
       stable)
-        echo "Triggering ${job.name} because buildkite this is a stable buildkite run"
+        echo "Triggering ${job.name} because this is a stable buildkite run"
         ${Cmd.format trigger};;
     esac
   ''

--- a/buildkite/src/Prepare.dhall
+++ b/buildkite/src/Prepare.dhall
@@ -27,7 +27,10 @@ let config : Pipeline.Config.Type = Pipeline.Config::{
       label = "Prepare monorepo triage",
       key = "monorepo",
       target = Size.Small,
-      docker = Some Docker::{ image = (./Constants/ContainerImages.dhall).toolchainBase }
+      docker = Some Docker::{
+        image = (./Constants/ContainerImages.dhall).toolchainBase,
+        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_PIPELINE_TYPE"]
+      }
     }
   ]
 }


### PR DESCRIPTION
The purpose of this PR is to support a new type of buildkite pipeline for stable branch builds which will run all available buildkite jobs whenever stable branches are updated. The new pipeline can be found here https://buildkite.com/o-1-labs-2/mina-stable.

Once this lands, we would be disabling our hourly scheduled builds on stable branches and only use this new pipeline for testing stable branches when they are updated. We will likely keep nightlies around for the time being, but will be thinking of the best way to maintain them soon.