### PR TITLE
Add stable pipeline support to buildkite (round 2)

### DIFF
--- a/buildkite/src/Pipeline/Mode.dhall
+++ b/buildkite/src/Pipeline/Mode.dhall
@@ -1,0 +1,1 @@
+<PullRequest | Stable>

--- a/buildkite/src/Prepare.dhall
+++ b/buildkite/src/Prepare.dhall
@@ -18,9 +18,9 @@ let config : Pipeline.Config.Type = Pipeline.Config::{
     dirtyWhen = [ SelectFiles.everything ]
   },
   steps = [
-  Command.build
-    Command.Config::{
+    Command.build Command.Config::{
       commands = [
+        Cmd.run "export BUILDKITE_PIPELINE_MODE=${env:BUILDKITE_PIPELINE_MODE as Text ? "(./buildkite/src/Pipeline/Mode.dhall).PullRequest"}",
         Cmd.run "./buildkite/scripts/generate-jobs.sh > buildkite/src/gen/Jobs.dhall",
         triggerCommand "src/Monorepo.dhall"
       ],
@@ -29,7 +29,7 @@ let config : Pipeline.Config.Type = Pipeline.Config::{
       target = Size.Small,
       docker = Some Docker::{
         image = (./Constants/ContainerImages.dhall).toolchainBase,
-        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN", "BUILDKITE_PIPELINE_TYPE"]
+        environment = ["BUILDKITE_AGENT_ACCESS_TOKEN"]
       }
     }
   ]

--- a/buildkite/src/gen/Jobs.dhall
+++ b/buildkite/src/gen/Jobs.dhall
@@ -2,4 +2,3 @@
 -- dhall configuration can still execute locally without running codegen.
 let Pipeline = ../Pipeline/Dsl.dhall in
 [ ] : List Pipeline.CompoundType
-


### PR DESCRIPTION
My first PR (#8715) seems to have not fully worked as intended. Attempting to fix that in this version of the PR.

It's rather difficult to pass env vars down through Prepare.dhall and into Monorepo.dhall. I think Prepare.dhall is pretty unnecessary and that we should probably just replace it with an entry shell script, if reasonable. Might do that in a future PR. 