### PR TITLE
Replayer, don't create epoch ledger if exists

### DIFF
--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -191,9 +191,13 @@ let process_block_infos_of_state_hash ~logger pool state_hash ~f =
       exit 1
 
 let update_epoch_ledger ~logger ~name ~ledger ~epoch_ledger epoch_ledger_hash =
+  let old_epoch_ledger_hash = Ledger.merkle_root epoch_ledger in
   let epoch_ledger_hash = Ledger_hash.of_string epoch_ledger_hash in
   let curr_ledger_hash = Ledger.merkle_root ledger in
-  if Frozen_ledger_hash.equal epoch_ledger_hash curr_ledger_hash then (
+  if
+    (not (Frozen_ledger_hash.equal old_epoch_ledger_hash epoch_ledger_hash))
+    && Frozen_ledger_hash.equal epoch_ledger_hash curr_ledger_hash
+  then (
     [%log info]
       "Creating %s epoch ledger from ledger with Merkle root matching epoch \
        ledger hash %s"


### PR DESCRIPTION
Check to see if the existing epoch ledger has the hash we want before creating a new epoch ledger. This saves creating new epoch ledgers when they're the same as the genesis ledger.

Tested by making the same change in the code for #8735, verifying that the new epoch ledgers were not created.
