### PR TITLE
receiver configuration for warnings

### DIFF
--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-receivers.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-receivers.yml.tpl
@@ -12,15 +12,13 @@ receivers:
       - api_url: ${slack_alert_webhook}
         channel: '#testnet-warnings'
         send_resolved: true
-        title: |-
-          [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .Labels.testnet }} for {{ .CommonLabels.job }}
         text: >-
+          {{ if eq .Status "firing" }}All active alerts:{{ end }}
+
           {{ range .Alerts -}}
-          *Alert:* {{ .Labels.alertname }}{{ if .Labels.severity }} - `{{ .Labels.severity }}`{{ end }}
-
-          *Description:* {{ .Annotations.description }}
-
-          *Runbook:* {{ if .Annotations.runbook }} `{{ .Annotations.runbook }}` {{ end }}
+            *Alert:* {{ .Labels.alertname }}{{ if .Labels.severity }} - `{{ .Labels.severity }}`{{ end }}
+            *Description:* {{ .Annotations.description }}
+            *Runbook:* {{ if .Annotations.runbook }} `{{ .Annotations.runbook }}` {{ end }}
 
           {{ end }}
 

--- a/automation/terraform/modules/testnet-alerts/templates/testnet-alert-receivers.yml.tpl
+++ b/automation/terraform/modules/testnet-alerts/templates/testnet-alert-receivers.yml.tpl
@@ -8,8 +8,22 @@ receivers:
     pagerduty_configs:
       - service_key: ${pagerduty_service_key}
   - name: slack-alert-default
-    webhook_configs:
-      - url: ${slack_alert_webhook}
+    slack_configs:
+      - api_url: ${slack_alert_webhook}
+        channel: '#testnet-warnings'
+        send_resolved: true
+        title: |-
+          [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .Labels.testnet }} for {{ .CommonLabels.job }}
+        text: >-
+          {{ range .Alerts -}}
+          *Alert:* {{ .Labels.alertname }}{{ if .Labels.severity }} - `{{ .Labels.severity }}`{{ end }}
+
+          *Description:* {{ .Annotations.description }}
+
+          *Runbook:* {{ if .Annotations.runbook }} `{{ .Annotations.runbook }}` {{ end }}
+
+          {{ end }}
+
 route:
   receiver: slack-alert-default
   group_by:


### PR DESCRIPTION
The generic webhook receiver config wasn't working for slack integration. Added the slack specific one and specified some details about the alert to be displayed in the notification.

Deployed the receiver config manually