### PR TITLE
Replayer and delegation compliance, undo bad optimization

### DIFF
--- a/src/app/delegation_compliance/delegation_compliance.ml
+++ b/src/app/delegation_compliance/delegation_compliance.ml
@@ -189,13 +189,9 @@ let process_block_infos_of_state_hash ~logger pool state_hash ~f =
       exit 1
 
 let update_epoch_ledger ~logger ~name ~ledger ~epoch_ledger epoch_ledger_hash =
-  let old_epoch_ledger_hash = Ledger.merkle_root epoch_ledger in
   let epoch_ledger_hash = Ledger_hash.of_string epoch_ledger_hash in
   let curr_ledger_hash = Ledger.merkle_root ledger in
-  if
-    (not (Frozen_ledger_hash.equal old_epoch_ledger_hash epoch_ledger_hash))
-    && Frozen_ledger_hash.equal epoch_ledger_hash curr_ledger_hash
-  then (
+  if Frozen_ledger_hash.equal epoch_ledger_hash curr_ledger_hash then (
     [%log info]
       "Creating %s epoch ledger from ledger with Merkle root matching epoch \
        ledger hash %s"

--- a/src/app/delegation_compliance/sql.ml
+++ b/src/app/delegation_compliance/sql.ml
@@ -370,18 +370,18 @@ module Block = struct
   let get_unparented (module Conn : Caqti_async.CONNECTION) () =
     Conn.collect_list unparented_query ()
 
-  let creator_slot_bounds_count_query =
-    Caqti_request.find
+  let creator_slot_bounds_query =
+    Caqti_request.collect
       Caqti_type.(tup3 int int64 int64)
       Caqti_type.int
-      {sql| SELECT COUNT (id) FROM blocks
+      {sql| SELECT id FROM blocks
             WHERE creator_id = $1
             AND global_slot >= $2 AND global_slot <= $3
       |sql}
 
-  let get_creator_count_in_slot_bounds (module Conn : Caqti_async.CONNECTION)
-      ~creator ~low_slot ~high_slot =
-    Conn.find creator_slot_bounds_count_query (creator, low_slot, high_slot)
+  let get_block_ids_for_creator_in_slot_bounds
+      (module Conn : Caqti_async.CONNECTION) ~creator ~low_slot ~high_slot =
+    Conn.collect_list creator_slot_bounds_query (creator, low_slot, high_slot)
 end
 
 module Parent_block = struct

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -191,13 +191,9 @@ let process_block_infos_of_state_hash ~logger pool state_hash ~f =
       exit 1
 
 let update_epoch_ledger ~logger ~name ~ledger ~epoch_ledger epoch_ledger_hash =
-  let old_epoch_ledger_hash = Ledger.merkle_root epoch_ledger in
   let epoch_ledger_hash = Ledger_hash.of_string epoch_ledger_hash in
   let curr_ledger_hash = Ledger.merkle_root ledger in
-  if
-    (not (Frozen_ledger_hash.equal old_epoch_ledger_hash epoch_ledger_hash))
-    && Frozen_ledger_hash.equal epoch_ledger_hash curr_ledger_hash
-  then (
+  if Frozen_ledger_hash.equal epoch_ledger_hash curr_ledger_hash then (
     [%log info]
       "Creating %s epoch ledger from ledger with Merkle root matching epoch \
        ledger hash %s"


### PR DESCRIPTION
I had made an "optimization" in the replayer and delegation compliance apps, in #8735 and #8739, by not creating epoch ledgers if the existing ledger had the right hash.

But those tools start with epoch ledgers that are the genesis ledger, not copies of it, and that ledger gets updated. Comparing some results for delegation compliance with Gareth's data, there were incorrect values. Removing the "optimization" resolved the discrepancies; the epoch ledgers get copied (again).

Tested by comparing a delegation total for a particular delegatee, comparing with Gareth's value for the same delegatee.

Also fixes a couple of bugs in the compliance app: 1) use delegator's balance on the staking ledger, rather than the active ledger, to compute stake fraction; 2) only count blocks produced on the canonical chain when computing payout reward.

Apologies for the inconvenience.