### PR TITLE
Don't generate genesis proof at startup

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -325,14 +325,9 @@ let setup_daemon logger =
          default: <config_dir>/daemon.json). Pass multiple times to override \
          fields from earlier config files"
       (listed string)
-  and may_generate =
+  and _may_generate =
     flag "--generate-genesis-proof" ~aliases:["generate-genesis-proof"]
-      ~doc:
-        (sprintf
-           "true|false Generate a new genesis proof for the current \
-            configuration if none is found (default: %s)"
-           ( if Mina_compile_config.generate_genesis_proof then "false"
-           else "true" ))
+      ~doc:"true|false Deprecated. Passing this flag has no effect"
       (optional bool)
   and disable_node_status =
     flag "--disable-node-status" ~aliases:["disable-node-status"] no_arg
@@ -515,13 +510,6 @@ let setup_daemon logger =
     let time_controller =
       Block_time.Controller.create @@ Block_time.Controller.basic ~logger
     in
-    let may_generate =
-      (* Default is [true] if there is no compile-time genesis proof to fall
-         back on, or [false] otherwise.
-      *)
-      Option.value may_generate
-        ~default:(not Mina_compile_config.generate_genesis_proof)
-    in
     (* FIXME adapt to new system, move into child_processes lib *)
     let pids = Child_processes.Termination.create_pid_table () in
     let rec terminated_child_loop () =
@@ -676,7 +664,7 @@ let setup_daemon logger =
       let%bind precomputed_values =
         match%map
           Genesis_ledger_helper.init_from_config_file ~genesis_dir ~logger
-            ~may_generate ~proof_level config
+            ~proof_level config
         with
         | Ok (precomputed_values, _) ->
             precomputed_values

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1932,7 +1932,7 @@ let compile_time_constants =
            >>| Runtime_config.of_yojson >>| Result.ok
            >>| Option.value ~default:Runtime_config.default
            >>= Genesis_ledger_helper.init_from_config_file ~genesis_dir
-                 ~logger:(Logger.null ()) ~may_generate:false ~proof_level:None
+                 ~logger:(Logger.null ()) ~proof_level:None
            >>| Or_error.ok_exn
          in
          let all_constants =

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -354,8 +354,8 @@ module T = struct
           ()
       in
       let%bind precomputed_values, _runtime_config =
-        Genesis_ledger_helper.init_from_config_file ~logger ~may_generate:true
-          ~proof_level:None runtime_config
+        Genesis_ledger_helper.init_from_config_file ~logger ~proof_level:None
+          runtime_config
         >>| Or_error.ok_exn
       in
       let constraint_constants = precomputed_values.constraint_constants in

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -185,8 +185,7 @@ let run_test () : unit Deferred.t =
       let start_time = Time.now () in
       let%bind precomputed_values =
         Deferred.Or_error.ok_exn
-        @@ Genesis_ledger_helper.init_from_inputs ~logger ~may_generate:true
-             precomputed_values
+        @@ Genesis_ledger_helper.init_from_inputs ~logger precomputed_values
       in
       let%bind coda =
         Mina_lib.create

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -528,7 +528,7 @@ let get_consensus_constants ~logger :
   in
   let%map proof, _ =
     Genesis_ledger_helper.init_from_config_file ~genesis_dir ~logger
-      ~may_generate:true ~proof_level:None config
+      ~proof_level:None config
   in
   Precomputed_values.consensus_constants proof
 

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -22,7 +22,7 @@ let main ~config_file ~genesis_dir ~proof_level () =
   in
   Deferred.Or_error.ok_exn @@ Deferred.Or_error.ignore
   @@ Genesis_ledger_helper.init_from_config_file ?genesis_dir
-       ~logger:(Logger.create ()) ~may_generate:true ~proof_level config
+       ~logger:(Logger.create ()) ~proof_level config
 
 let () =
   Command.run

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -451,6 +451,37 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
   trace "block_producer" (fun () ->
       let constraint_constants = precomputed_values.constraint_constants in
       let consensus_constants = precomputed_values.consensus_constants in
+      let genesis_breadcrumb =
+        let started = ref false in
+        let genesis_breadcrumb_ivar = Ivar.create () in
+        fun () ->
+          if !started then Ivar.read genesis_breadcrumb_ivar
+          else (
+            started := true ;
+            let max_num_retries = 3 in
+            let rec go retries =
+              [%log info]
+                "Generating genesis proof ($attempts_remaining / $max_attempts)"
+                ~metadata:
+                  [ ("attempts_remaining", `Int retries)
+                  ; ("max_attempts", `Int max_num_retries) ] ;
+              match%bind
+                Prover.create_genesis_block prover
+                  (Genesis_proof.to_inputs precomputed_values)
+              with
+              | Ok res ->
+                  Ivar.fill genesis_breadcrumb_ivar (Ok res) ;
+                  return (Ok res)
+              | Error err ->
+                  [%log error] "Failed to generate genesis breadcrumb: $error"
+                    ~metadata:[("error", Error_json.error_to_yojson err)] ;
+                  if retries > 0 then go (retries - 1)
+                  else (
+                    Ivar.fill genesis_breadcrumb_ivar (Error err) ;
+                    return (Error err) )
+            in
+            go max_num_retries )
+      in
       let rejected_blocks_logger =
         Logger.create ~id:Logger.Logger_id.rejected_blocks ()
       in
@@ -483,9 +514,29 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
               External_transition.protocol_state
                 (With_hash.data previous_transition)
             in
-            let previous_protocol_state_proof =
-              External_transition.protocol_state_proof
-                (With_hash.data previous_transition)
+            let%bind previous_protocol_state_proof =
+              if
+                Consensus.Data.Consensus_state.is_genesis_state
+                  (External_transition.consensus_state
+                     (With_hash.data previous_transition))
+                && Option.is_none precomputed_values.proof_data
+              then (
+                match%bind
+                  Interruptible.uninterruptible (genesis_breadcrumb ())
+                with
+                | Ok block ->
+                    let proof = Blockchain_snark.Blockchain.proof block in
+                    Interruptible.lift (Deferred.return proof)
+                      (Deferred.never ())
+                | Error _ ->
+                    [%log error]
+                      "Aborting block production: cannot generate a genesis \
+                       proof" ;
+                    Interruptible.lift (Deferred.never ()) (Deferred.return ()) )
+              else
+                return
+                  (External_transition.protocol_state_proof
+                     (With_hash.data previous_transition))
             in
             let transactions =
               Network_pool.Transaction_pool.Resource_pool.transactions ~logger
@@ -736,6 +787,21 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                   Transition_frontier.best_tip transition_frontier
                   |> Breadcrumb.consensus_state
                 in
+                let generate_genesis_proof_if_needed () =
+                  match Broadcast_pipe.Reader.peek frontier_reader with
+                  | Some transition_frontier ->
+                      let consensus_state =
+                        Transition_frontier.best_tip transition_frontier
+                        |> Breadcrumb.consensus_state
+                      in
+                      if
+                        Consensus.Data.Consensus_state.is_genesis_state
+                          consensus_state
+                      then genesis_breadcrumb () |> Deferred.ignore_m
+                      else Deferred.return ()
+                  | None ->
+                      Deferred.return ()
+                in
                 (* TODO: Re-enable this assertion when it doesn't fail dev demos
                  *       (see #5354)
                  * assert (
@@ -745,7 +811,7 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                    = None ) ; *)
                 don't_wait_for
                   (let now = Time.now time_controller in
-                   let%map next_producer_timing =
+                   let%bind next_producer_timing =
                      measure "asking consensus what to do" (fun () ->
                          Consensus.Hooks.next_producer_timing
                            ~constraint_constants ~constants:consensus_constants
@@ -758,9 +824,11 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                    match next_producer_timing with
                    | `Check_again time ->
                        Singleton_scheduler.schedule scheduler (time_of_ms time)
-                         ~f:check_next_block_timing
+                         ~f:check_next_block_timing ;
+                       Deferred.return ()
                    | `Produce_now (data, winner_pk) ->
                        Mina_metrics.(Counter.inc_one Block_producer.slots_won) ;
+                       let%map () = generate_genesis_proof_if_needed () in
                        Interruptible.finally
                          (Singleton_supervisor.dispatch production_supervisor
                             (now, data, winner_pk))
@@ -769,6 +837,30 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                    | `Produce (time, data, winner_pk) ->
                        Mina_metrics.(Counter.inc_one Block_producer.slots_won) ;
                        let scheduled_time = time_of_ms time in
+                       don't_wait_for
+                         ((* Attempt to generate a genesis proof in the slot
+                            immediately before we'll actually need it, so that
+                            it isn't limiting our block production time in the
+                            won slot.
+                            This also allows non-genesis blocks to be received
+                            in the meantime and alleviate the need to produce
+                            one at all, if this won't have block height 1.
+                         *)
+                          let scheduled_genesis_time =
+                            time_of_ms
+                              Int64.(
+                                time
+                                - of_int
+                                    constraint_constants
+                                      .block_window_duration_ms)
+                          in
+                          let span_till_time =
+                            Time.diff scheduled_genesis_time
+                              (Time.now time_controller)
+                            |> Time.Span.to_time_span
+                          in
+                          let%bind () = after span_till_time in
+                          generate_genesis_proof_if_needed ()) ;
                        Singleton_scheduler.schedule scheduler scheduled_time
                          ~f:(fun () ->
                            ignore
@@ -776,7 +868,8 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                                 (Singleton_supervisor.dispatch
                                    production_supervisor
                                    (scheduled_time, data, winner_pk))
-                                ~f:check_next_block_timing) )) )
+                                ~f:check_next_block_timing) ) ;
+                       Deferred.return ()) )
       in
       let start () =
         (* Schedule to wake up immediately on the next tick of the producer loop

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -376,6 +376,8 @@ module type S = sig
 
       type t = Stable.Latest.t [@@deriving to_yojson, sexp]
 
+      val genesis_data : genesis_epoch_ledger:Mina_base.Ledger.t Lazy.t -> t
+
       val precomputed_handler :
            constraint_constants:Genesis_constants.Constraint_constants.t
         -> genesis_epoch_ledger:Mina_base.Ledger.t Lazy.t

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -987,6 +987,22 @@ module Data = struct
 
       let genesis_winner = keypairs.(0)
 
+      let genesis_stake_proof :
+          genesis_epoch_ledger:Mina_base.Ledger.t Lazy.t -> Stake_proof.t =
+       fun ~genesis_epoch_ledger ->
+        let pk, sk = genesis_winner in
+        let dummy_sparse_ledger =
+          Mina_base.Sparse_ledger.of_ledger_subset_exn
+            (Lazy.force genesis_epoch_ledger)
+            [Mina_base.(Account_id.create pk Token_id.default)]
+        in
+        { delegator= 0
+        ; delegator_pk= pk
+        ; coinbase_receiver_pk= pk
+        ; ledger= dummy_sparse_ledger
+        ; producer_private_key= sk
+        ; producer_public_key= Public_key.decompress_exn pk }
+
       let handler :
              constraint_constants:Genesis_constants.Constraint_constants.t
           -> genesis_epoch_ledger:Mina_base.Ledger.t Lazy.t
@@ -2596,6 +2612,8 @@ module Data = struct
 
   module Prover_state = struct
     include Stake_proof
+
+    let genesis_data = Vrf.Precomputed.genesis_stake_proof
 
     let precomputed_handler = Vrf.Precomputed.handler
 

--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -247,3 +247,23 @@ let create_values_no_proof (t : Inputs.t) =
         (let txn, b = blockchain_snark_state t in
          Lazy.force (digests txn b))
   ; proof_data= None }
+
+let to_inputs (t : t) : Inputs.t =
+  { runtime_config= t.runtime_config
+  ; constraint_constants= t.constraint_constants
+  ; proof_level= t.proof_level
+  ; genesis_constants= t.genesis_constants
+  ; genesis_ledger= t.genesis_ledger
+  ; genesis_epoch_data= t.genesis_epoch_data
+  ; consensus_constants= t.consensus_constants
+  ; protocol_state_with_hash= t.protocol_state_with_hash
+  ; constraint_system_digests=
+      ( if Lazy.is_val t.constraint_system_digests then
+        Some (Lazy.force t.constraint_system_digests)
+      else None )
+  ; blockchain_proof_system_id=
+      ( match t.proof_data with
+      | Some {blockchain_proof_system_id; _} ->
+          Some blockchain_proof_system_id
+      | None ->
+          None ) }

--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -70,6 +70,12 @@ module Inputs = struct
   let genesis_state_hash t = (genesis_state_with_hash t).hash
 end
 
+module Proof_data = struct
+  type t =
+    { blockchain_proof_system_id: Pickles.Verification_key.Id.t
+    ; genesis_proof: Proof.t }
+end
+
 module T = struct
   type t =
     { runtime_config: Runtime_config.t
@@ -82,8 +88,7 @@ module T = struct
     ; protocol_state_with_hash:
         (Protocol_state.value, State_hash.t) With_hash.t
     ; constraint_system_digests: (string * Md5_lib.t) list Lazy.t
-    ; blockchain_proof_system_id: Pickles.Verification_key.Id.t
-    ; genesis_proof: Proof.t }
+    ; proof_data: Proof_data.t option }
 
   let runtime_config {runtime_config; _} = runtime_config
 
@@ -132,7 +137,8 @@ module T = struct
 
   let genesis_state_hash t = (genesis_state_with_hash t).hash
 
-  let genesis_proof {genesis_proof; _} = genesis_proof
+  let genesis_proof {proof_data; _} =
+    Option.map proof_data ~f:(fun {Proof_data.genesis_proof= p; _} -> p)
 end
 
 include T
@@ -192,6 +198,23 @@ let digests (module T : Transaction_snark.S)
   let%map blockchain_digests = B.constraint_system_digests in
   txn_digests @ blockchain_digests
 
+let blockchain_snark_state (inputs : Inputs.t) :
+    (module Transaction_snark.S)
+    * (module Blockchain_snark.Blockchain_snark_state.S) =
+  let module T = Transaction_snark.Make (struct
+    let constraint_constants = inputs.constraint_constants
+
+    let proof_level = inputs.proof_level
+  end) in
+  let module B = Blockchain_snark.Blockchain_snark_state.Make (struct
+    let tag = T.tag
+
+    let constraint_constants = inputs.constraint_constants
+
+    let proof_level = inputs.proof_level
+  end) in
+  ((module T), (module B))
+
 let create_values txn b (t : Inputs.t) =
   let%map.Async genesis_proof = base_proof b t in
   { runtime_config= t.runtime_config
@@ -203,7 +226,24 @@ let create_values txn b (t : Inputs.t) =
   ; consensus_constants= t.consensus_constants
   ; protocol_state_with_hash= t.protocol_state_with_hash
   ; constraint_system_digests= digests txn b
-  ; blockchain_proof_system_id=
-      (let (module B) = b in
-       Lazy.force B.Proof.id)
-  ; genesis_proof }
+  ; proof_data=
+      Some
+        { blockchain_proof_system_id=
+            (let (module B) = b in
+             Lazy.force B.Proof.id)
+        ; genesis_proof } }
+
+let create_values_no_proof (t : Inputs.t) =
+  { runtime_config= t.runtime_config
+  ; constraint_constants= t.constraint_constants
+  ; proof_level= t.proof_level
+  ; genesis_constants= t.genesis_constants
+  ; genesis_ledger= t.genesis_ledger
+  ; genesis_epoch_data= t.genesis_epoch_data
+  ; consensus_constants= t.consensus_constants
+  ; protocol_state_with_hash= t.protocol_state_with_hash
+  ; constraint_system_digests=
+      lazy
+        (let txn, b = blockchain_snark_state t in
+         Lazy.force (digests txn b))
+  ; proof_data= None }

--- a/src/lib/integration_test_cloud_engine/coda_automation.ml
+++ b/src/lib/integration_test_cloud_engine/coda_automation.ml
@@ -346,7 +346,7 @@ module Network_manager = struct
         ~constraint_constants ~genesis_constants
     in
     let%bind (_, genesis_proof_filename) =
-      Genesis_ledger_helper.Genesis_proof.load_or_generate ~logger ~genesis_dir ~may_generate:true
+      Genesis_ledger_helper.Genesis_proof.load_or_generate ~logger ~genesis_dir 
         inputs
     in
     *)

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -303,10 +303,7 @@ let parse_event (message : Logger.Message.t) =
   | Some event_id ->
       let (Event_type event_type) =
         of_structured_event_id event_id
-        |> Option.value_exn
-             ~message:
-               "could not convert incoming event log into event type; no \
-                matching structured event id"
+        |> Option.value ~default:(Event_type Log_error)
       in
       let (module Type) = event_type_module event_type in
       let%map data = Type.parse message in

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3251,8 +3251,8 @@ module Queries = struct
         let { Precomputed_values.genesis_ledger
             ; constraint_constants
             ; consensus_constants
-            ; genesis_proof
             ; genesis_epoch_data
+            ; proof_data
             ; _ } =
           (Mina_lib.config coda).precomputed_values
         in
@@ -3279,7 +3279,18 @@ module Queries = struct
                 ; coinbase_receiver=
                     Some (fst Consensus_state_hooks.genesis_winner) }
             ; snark_jobs= []
-            ; proof= genesis_proof }
+            ; proof=
+                ( match proof_data with
+                | Some {genesis_proof; _} ->
+                    genesis_proof
+                | None ->
+                    (* It's nearly never useful to have a specific genesis
+                       proof to pass here -- anyone can create one as needed --
+                       and we don't want this GraphQL query to trigger an
+                       expensive proof generation step if we don't have one
+                       available.
+                    *)
+                    Proof.blockchain_dummy ) }
         ; hash } )
 
   (* used by best_chain, block below *)

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -1081,15 +1081,19 @@ let genesis ~precomputed_values =
   let genesis_protocol_state =
     Precomputed_values.genesis_state_with_hash precomputed_values
   in
-  let protocol_state_proof =
-    Precomputed_values.genesis_proof precomputed_values
-  in
   let empty_diff = Staged_ledger_diff.empty_diff in
   (* the genesis transition is assumed to be valid *)
   let (`I_swear_this_is_safe_see_my_comment transition) =
     Validated.create_unsafe_pre_hashed
       (With_hash.map genesis_protocol_state ~f:(fun protocol_state ->
-           create ~protocol_state ~protocol_state_proof
+           create
+             ~protocol_state
+               (* We pass a dummy proof here, with the understanding that it will
+                never be validated except as part of the snark for the first
+                block produced (where we will explicitly generate the genesis
+                proof).
+             *)
+             ~protocol_state_proof:Proof.blockchain_dummy
              ~staged_ledger_diff:empty_diff
              ~validation_callback:
                (Mina_net2.Validation_callback.create_without_expiration ())

--- a/src/lib/prover/intf.ml
+++ b/src/lib/prover/intf.ml
@@ -43,4 +43,7 @@ module type S = sig
     -> Internal_transition.t
     -> Pending_coinbase_witness.t
     -> Proof.t Deferred.Or_error.t
+
+  val create_genesis_block :
+    t -> Genesis_proof.Inputs.t -> Blockchain.t Deferred.Or_error.t
 end


### PR DESCRIPTION
This PR
* removes genesis proof generation from the startup code
* adds support for generating genesis proofs in the prover process
* adds logic to generate a genesis proof when a block producer will need one to be able to produce their block
  - if the next block for the producer is `n` slots in the future, the genesis proof will be produced at slot `n-1`, if it is still needed
  - if it's needed immediately, the genesis proof will be produced as soon as possible and then used to generate the block

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
