### PR TITLE
Use catchsegv to dump backtrace on segfaults

### DIFF
--- a/automation/bake/Dockerfile
+++ b/automation/bake/Dockerfile
@@ -27,7 +27,7 @@ command=$1 \n\
 shift \n\
 while true; do\n\
   rm -f /root/.mina-config/.mina-lock\n\
-  mina "$command" -config-file "'${CONFIG_FILE}'" "$@" 2>&1 >mina.log &\n\
+  catchsegv mina "$command" -config-file "'${CONFIG_FILE}'" "$@" 2>&1 >mina.log &\n\
   mina_pid=$!\n\
   tail -q -f mina.log &\n\
   tail_pid=$!\n\


### PR DESCRIPTION


Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: