### PR TITLE
Log monitor chain on long async cycles

### DIFF
--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -7,4 +7,4 @@
  (libraries init tests consensus child_processes memory_stats node_addrs_and_ports jemalloc genesis_ledger_helper mina_plugins error_json)
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_coda ppx_version ppx_let ppx_sexp_conv ppx_optcomp ppx_deriving_yojson)))
+ (preprocess (pps ppx_coda ppx_version ppx_here ppx_let ppx_sexp_conv ppx_optcomp ppx_deriving_yojson)))

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -927,12 +927,8 @@ let setup_daemon logger =
           let monitors = get_monitors [ctx.monitor] ctx.monitor in
           let monitor_infos =
             List.map monitors ~f:(fun monitor ->
-                `Assoc
-                  [ ( "name"
-                    , `String
-                        ( Async_kernel.Monitor.name monitor
-                        |> Info.to_string_hum ) )
-                  ; ("depth", `Int (Async_kernel.Monitor.depth monitor)) ] )
+                `String
+                  (Async_kernel.Monitor.sexp_of_t monitor |> Sexp.to_string) )
           in
           [%log debug]
             ~metadata:

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -997,8 +997,7 @@ let setup_daemon logger =
             return []
         | Some file -> (
             match%bind
-              Monitor.try_with_or_error ~here:[%here]
-                ~name:"peer list from file" (fun () ->
+              Monitor.try_with_or_error ~here:[%here] (fun () ->
                   Reader.file_contents file )
             with
             | Ok contents ->
@@ -1254,7 +1253,7 @@ let rec ensure_testnet_id_still_good logger =
   in
   let soon_minutes = Int.of_float (60.0 *. recheck_soon) in
   match%bind
-    Monitor.try_with_or_error ~name:"ensure testnet" ~here:[%here] (fun () ->
+    Monitor.try_with_or_error ~here:[%here] (fun () ->
         Client.get (Uri.of_string "http://updates.o1test.net/testnet_id") )
   with
   | Error e ->

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -913,9 +913,9 @@ let setup_daemon logger =
             client_trustlist
       in
       Stream.iter
-        (Async_kernel.Async_kernel_scheduler.(long_cycles_with_context (t ()))
+        (Async_kernel.Async_kernel_scheduler.(long_cycles_with_context @@ t ())
            ~at_least:(sec 0.5 |> Time_ns.Span.of_span_float_round_nearest))
-        ~f:(fun (span, ctx) ->
+        ~f:(fun (span, context) ->
           let secs = Time_ns.Span.to_sec span in
           let rec get_monitors accum monitor =
             match Async_kernel.Monitor.parent monitor with
@@ -924,11 +924,11 @@ let setup_daemon logger =
             | Some parent ->
                 get_monitors (parent :: accum) parent
           in
-          let monitors = get_monitors [ctx.monitor] ctx.monitor in
+          let monitors = get_monitors [context.monitor] context.monitor in
           let monitor_infos =
             List.map monitors ~f:(fun monitor ->
-                `String
-                  (Async_kernel.Monitor.sexp_of_t monitor |> Sexp.to_string) )
+                Async_kernel.Monitor.sexp_of_t monitor
+                |> Error_json.sexp_to_yojson )
           in
           [%log debug]
             ~metadata:

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -280,7 +280,7 @@ let get_public_keys =
 
 let read_json filepath ~flag =
   let%map res =
-    Deferred.Or_error.try_with ~name:"read json" ~here:[%here] (fun () ->
+    Deferred.Or_error.try_with ~here:[%here] (fun () ->
         let%map json_contents = Reader.file_contents filepath in
         Ok (Yojson.Safe.from_string json_contents) )
   in
@@ -774,8 +774,7 @@ let send_rosetta_transactions_graphql =
          let lexbuf = Lexing.from_channel In_channel.stdin in
          let lexer = Yojson.init_lexer () in
          match%bind
-           Deferred.Or_error.try_with ~name:"send Rosetta txns GraphQL"
-             ~here:[%here] (fun () ->
+           Deferred.Or_error.try_with ~here:[%here] (fun () ->
                Deferred.repeat_until_finished () (fun () ->
                    try
                      let transaction_json =

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -280,7 +280,7 @@ let get_public_keys =
 
 let read_json filepath ~flag =
   let%map res =
-    Deferred.Or_error.try_with (fun () ->
+    Deferred.Or_error.try_with ~name:"read json" ~here:[%here] (fun () ->
         let%map json_contents = Reader.file_contents filepath in
         Ok (Yojson.Safe.from_string json_contents) )
   in
@@ -774,7 +774,8 @@ let send_rosetta_transactions_graphql =
          let lexbuf = Lexing.from_channel In_channel.stdin in
          let lexer = Yojson.init_lexer () in
          match%bind
-           Deferred.Or_error.try_with (fun () ->
+           Deferred.Or_error.try_with ~name:"send Rosetta txns GraphQL"
+             ~here:[%here] (fun () ->
                Deferred.repeat_until_finished () (fun () ->
                    try
                      let transaction_json =

--- a/src/app/cli/src/init/find_ip.ml
+++ b/src/app/cli/src/init/find_ip.ml
@@ -13,7 +13,7 @@ let services =
 
 let ip_service_result {uri; body_handler} ~logger =
   match%map
-    Monitor.try_with (fun () ->
+    Monitor.try_with ~name:"ip service result" ~here:[%here] (fun () ->
         let%bind resp, body = Client.get (Uri.of_string uri) in
         let%map body = Body.to_string body in
         if resp.status = `OK then Some (body_handler body) else None )

--- a/src/app/cli/src/init/find_ip.ml
+++ b/src/app/cli/src/init/find_ip.ml
@@ -13,7 +13,7 @@ let services =
 
 let ip_service_result {uri; body_handler} ~logger =
   match%map
-    Monitor.try_with ~name:"ip service result" ~here:[%here] (fun () ->
+    Monitor.try_with ~here:[%here] (fun () ->
         let%bind resp, body = Client.get (Uri.of_string uri) in
         let%map body = Body.to_string body in
         if resp.status = `OK then Some (body_handler body) else None )

--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -172,8 +172,7 @@ let disconnect ((conn, proc, _) as t) ~logger =
   (* This kills any straggling snark worker process *)
   let%bind () =
     match%map
-      Monitor.try_with ~name:"disconnnect 1" ~here:[%here] (fun () ->
-          stop_snark_worker t )
+      Monitor.try_with ~here:[%here] (fun () -> stop_snark_worker t)
     with
     | Ok () ->
         ()
@@ -182,10 +181,7 @@ let disconnect ((conn, proc, _) as t) ~logger =
           ~metadata:[("exn", `String (Exn.to_string exn))]
   in
   let%bind () = Coda_worker.Connection.close conn in
-  match%map
-    Monitor.try_with ~name:"disconnect 2" ~here:[%here] (fun () ->
-        Process.wait proc )
-  with
+  match%map Monitor.try_with ~here:[%here] (fun () -> Process.wait proc) with
   | Ok _ ->
       ()
   | Error e ->

--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -171,7 +171,10 @@ let disconnect ((conn, proc, _) as t) ~logger =
     ~module_:__MODULE__ ~location:__LOC__ ;
   (* This kills any straggling snark worker process *)
   let%bind () =
-    match%map Monitor.try_with (fun () -> stop_snark_worker t) with
+    match%map
+      Monitor.try_with ~name:"disconnnect 1" ~here:[%here] (fun () ->
+          stop_snark_worker t )
+    with
     | Ok () ->
         ()
     | Error exn ->
@@ -179,7 +182,10 @@ let disconnect ((conn, proc, _) as t) ~logger =
           ~metadata:[("exn", `String (Exn.to_string exn))]
   in
   let%bind () = Coda_worker.Connection.close conn in
-  match%map Monitor.try_with (fun () -> Process.wait proc) with
+  match%map
+    Monitor.try_with ~name:"disconnect 2" ~here:[%here] (fun () ->
+        Process.wait proc )
+  with
   | Ok _ ->
       ()
   | Error e ->

--- a/src/app/cli/src/tests/dune
+++ b/src/app/cli/src/tests/dune
@@ -17,5 +17,6 @@
                ppx_assert
                ppx_coda
                ppx_version
+               ppx_here
                ppx_optcomp ppx_bin_prot ppx_let
                ppx_custom_printf)))

--- a/src/app/rosetta/lib/graphql.ml
+++ b/src/app/rosetta/lib/graphql.ml
@@ -35,7 +35,8 @@ let query query_obj uri =
       [("Content-Type", "application/json"); ("Accept", "application/json")]
   in
   let%bind response, body =
-    Deferred.Or_error.try_with ~extract_exn:true (fun () ->
+    Deferred.Or_error.try_with ~name:"Rosetta query GraphQL" ~here:[%here]
+      ~extract_exn:true (fun () ->
         Cohttp_async.Client.post ~headers
           ~body:(Cohttp_async.Body.of_string body_string)
           uri )

--- a/src/app/rosetta/lib/graphql.ml
+++ b/src/app/rosetta/lib/graphql.ml
@@ -35,8 +35,7 @@ let query query_obj uri =
       [("Content-Type", "application/json"); ("Accept", "application/json")]
   in
   let%bind response, body =
-    Deferred.Or_error.try_with ~name:"Rosetta query GraphQL" ~here:[%here]
-      ~extract_exn:true (fun () ->
+    Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true (fun () ->
         Cohttp_async.Client.post ~headers
           ~body:(Cohttp_async.Body.of_string body_string)
           uri )

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -297,7 +297,8 @@ let main inputs =
                 (Yojson.Safe.to_string (Logger.Message.to_yojson message)))
            ~test_result:(Malleable_error.return ()))
     in
-    Monitor.try_with ~extract_exn:false (fun () ->
+    Monitor.try_with ~name:"test executive" ~here:[%here] ~extract_exn:false
+      (fun () ->
         let init_result =
           let open Deferred.Or_error.Let_syntax in
           let lift = Deferred.map ~f:Or_error.return in

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -297,8 +297,7 @@ let main inputs =
                 (Yojson.Safe.to_string (Logger.Message.to_yojson message)))
            ~test_result:(Malleable_error.return ()))
     in
-    Monitor.try_with ~name:"test executive" ~here:[%here] ~extract_exn:false
-      (fun () ->
+    Monitor.try_with ~here:[%here] ~extract_exn:false (fun () ->
         let init_result =
           let open Deferred.Or_error.Let_syntax in
           let lift = Deferred.map ~f:Or_error.return in

--- a/src/lib/cache_dir/cache_dir.ml
+++ b/src/lib/cache_dir/cache_dir.ml
@@ -47,7 +47,7 @@ let possible_paths base =
 
 let load_from_s3 s3_bucket_prefix s3_install_path ~logger =
   Deferred.map ~f:Result.join
-  @@ Monitor.try_with ~name:"load from s3" ~here:[%here] (fun () ->
+  @@ Monitor.try_with ~here:[%here] (fun () ->
          let each_uri (uri_string, file_path) =
            let open Deferred.Let_syntax in
            [%log trace] "Downloading file from S3"

--- a/src/lib/cache_dir/cache_dir.ml
+++ b/src/lib/cache_dir/cache_dir.ml
@@ -47,7 +47,7 @@ let possible_paths base =
 
 let load_from_s3 s3_bucket_prefix s3_install_path ~logger =
   Deferred.map ~f:Result.join
-  @@ Monitor.try_with (fun () ->
+  @@ Monitor.try_with ~name:"load from s3" ~here:[%here] (fun () ->
          let each_uri (uri_string, file_path) =
            let open Deferred.Let_syntax in
            [%log trace] "Downloading file from S3"

--- a/src/lib/cache_dir/dune
+++ b/src/lib/cache_dir/dune
@@ -10,4 +10,4 @@
    blake2
    logger)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_coda ppx_version ppx_let ppx_custom_printf)))
+ (preprocess (pps ppx_coda ppx_version ppx_here ppx_let ppx_custom_printf)))

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -320,8 +320,7 @@ let start_custom :
   don't_wait_for
     (let open Deferred.Let_syntax in
     let%bind termination_status =
-      Deferred.Or_error.try_with ~name:"start custom" ~here:[%here] (fun () ->
-          Process.wait process )
+      Deferred.Or_error.try_with ~here:[%here] (fun () -> Process.wait process)
     in
     [%log trace] "child process %s died" name ;
     don't_wait_for

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -320,7 +320,8 @@ let start_custom :
   don't_wait_for
     (let open Deferred.Let_syntax in
     let%bind termination_status =
-      Deferred.Or_error.try_with (fun () -> Process.wait process)
+      Deferred.Or_error.try_with ~name:"start custom" ~here:[%here] (fun () ->
+          Process.wait process )
     in
     [%log trace] "child process %s died" name ;
     don't_wait_for

--- a/src/lib/child_processes/dune
+++ b/src/lib/child_processes/dune
@@ -5,6 +5,6 @@
  (inline_tests)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps
-               ppx_assert ppx_coda ppx_version ppx_custom_printf ppx_deriving.show ppx_inline_test ppx_let
-               ppx_pipebang))
+               ppx_assert ppx_coda ppx_version ppx_here ppx_custom_printf ppx_deriving.show
+               ppx_inline_test ppx_let ppx_pipebang))
  (libraries async core ctypes ctypes.foreign file_system error_json logger pipe_lib))

--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -72,8 +72,7 @@ let wait_for_process_log_errors ~logger process ~module_ ~location =
         let waiting = Process.wait process in
         don't_wait_for
           ( match%map
-              Monitor.try_with_or_error ~name:"wait for process log errors"
-                ~here:[%here] (fun () -> waiting)
+              Monitor.try_with_or_error ~here:[%here] (fun () -> waiting)
             with
           | Ok _ ->
               ()

--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -71,7 +71,10 @@ let wait_for_process_log_errors ~logger process ~module_ ~location =
         *)
         let waiting = Process.wait process in
         don't_wait_for
-          ( match%map Monitor.try_with_or_error (fun () -> waiting) with
+          ( match%map
+              Monitor.try_with_or_error ~name:"wait for process log errors"
+                ~here:[%here] (fun () -> waiting)
+            with
           | Ok _ ->
               ()
           | Error err ->

--- a/src/lib/cli_lib/exceptions.ml
+++ b/src/lib/cli_lib/exceptions.ml
@@ -2,10 +2,7 @@ open Core_kernel
 open Async
 
 let handle_nicely (type a) (f : unit -> a Deferred.t) () : a Deferred.t =
-  match%bind
-    Deferred.Or_error.try_with ~name:"exns, handle nicely" ~here:[%here]
-      ~extract_exn:true f
-  with
+  match%bind Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true f with
   | Ok e ->
       return e
   | Error e ->

--- a/src/lib/cli_lib/exceptions.ml
+++ b/src/lib/cli_lib/exceptions.ml
@@ -2,7 +2,10 @@ open Core_kernel
 open Async
 
 let handle_nicely (type a) (f : unit -> a Deferred.t) () : a Deferred.t =
-  match%bind Deferred.Or_error.try_with ~extract_exn:true f with
+  match%bind
+    Deferred.Or_error.try_with ~name:"exns, handle nicely" ~here:[%here]
+      ~extract_exn:true f
+  with
   | Ok e ->
       return e
   | Error e ->

--- a/src/lib/daemon_rpcs/client.ml
+++ b/src/lib/daemon_rpcs/client.ml
@@ -7,7 +7,7 @@ let print_rpc_error error =
   eprintf "RPC connection error: %s\n" (Error.to_string_hum error)
 
 let dispatch rpc query (host_and_port : Host_and_port.t) =
-  Deferred.Or_error.try_with_join ~name:"dispatch RPC" ~here:[%here] (fun () ->
+  Deferred.Or_error.try_with_join ~here:[%here] (fun () ->
       Tcp.with_connection (Tcp.Where_to_connect.of_host_and_port host_and_port)
         ~timeout:(Time.Span.of_sec 1.) (fun _ r w ->
           let open Deferred.Let_syntax in

--- a/src/lib/daemon_rpcs/client.ml
+++ b/src/lib/daemon_rpcs/client.ml
@@ -7,7 +7,7 @@ let print_rpc_error error =
   eprintf "RPC connection error: %s\n" (Error.to_string_hum error)
 
 let dispatch rpc query (host_and_port : Host_and_port.t) =
-  Deferred.Or_error.try_with_join (fun () ->
+  Deferred.Or_error.try_with_join ~name:"dispatch RPC" ~here:[%here] (fun () ->
       Tcp.with_connection (Tcp.Where_to_connect.of_host_and_port host_and_port)
         ~timeout:(Time.Span.of_sec 1.) (fun _ r w ->
           let open Deferred.Let_syntax in

--- a/src/lib/exit_handlers/dune
+++ b/src/lib/exit_handlers/dune
@@ -4,5 +4,5 @@
  (library_flags -linkall)
  (libraries core_kernel async_kernel async_unix logger)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_coda ppx_version ppx_let))
+ (preprocess (pps ppx_coda ppx_version ppx_here ppx_let))
  (synopsis "Exit handlers"))

--- a/src/lib/exit_handlers/exit_handlers.ml
+++ b/src/lib/exit_handlers/exit_handlers.ml
@@ -31,7 +31,10 @@ let register_async_shutdown_handler ~logger ~description
       ~metadata:[("description", `String description)] ;
     let open Deferred.Let_syntax in
     let%map () =
-      match%map Monitor.try_with ~extract_exn:true f with
+      match%map
+        Monitor.try_with ~name:"register async shutdown" ~here:[%here]
+          ~extract_exn:true f
+      with
       | Ok () ->
           ()
       | Error exn ->

--- a/src/lib/exit_handlers/exit_handlers.ml
+++ b/src/lib/exit_handlers/exit_handlers.ml
@@ -31,10 +31,7 @@ let register_async_shutdown_handler ~logger ~description
       ~metadata:[("description", `String description)] ;
     let open Deferred.Let_syntax in
     let%map () =
-      match%map
-        Monitor.try_with ~name:"register async shutdown" ~here:[%here]
-          ~extract_exn:true f
-      with
+      match%map Monitor.try_with ~here:[%here] ~extract_exn:true f with
       | Ok () ->
           ()
       | Error exn ->

--- a/src/lib/gossip_net/dune
+++ b/src/lib/gossip_net/dune
@@ -8,6 +8,6 @@
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_coda ppx_version ppx_inline_test ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson ppx_optcomp
-       ppx_bin_prot ppx_sexp_conv ppx_fields_conv ppx_let ppx_custom_printf ppx_pipebang))
+       ppx_here ppx_bin_prot ppx_sexp_conv ppx_fields_conv ppx_let ppx_custom_printf ppx_pipebang))
  (instrumentation (backend bisect_ppx))
  (synopsis "Gossip Network"))

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -151,7 +151,8 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
       let conf_dir = config.conf_dir ^/ "mina_net2" in
       let%bind () = Unix.mkdir ~p:() conf_dir in
       match%bind
-        Monitor.try_with ~rest:`Raise (fun () ->
+        Monitor.try_with ~name:"create Mina_net2" ~here:[%here] ~rest:`Raise
+          (fun () ->
             trace "mina_net2" (fun () ->
                 Mina_net2.create ~logger:config.logger ~conf_dir ~pids
                   ~on_unexpected_termination ) )
@@ -596,7 +597,8 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
         -> q Deferred.Or_error.t =
      fun ?heartbeat_timeout ?timeout ~rpc_name t peer transport dispatch query ->
       let call () =
-        Monitor.try_with (fun () ->
+        Monitor.try_with ~name:"try call rpc with dispatch" ~here:[%here]
+          (fun () ->
             (* Async_rpc_kernel takes a transport instead of a Reader.t *)
             Async_rpc_kernel.Rpc.Connection.with_close
               ~heartbeat_config:

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -151,8 +151,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
       let conf_dir = config.conf_dir ^/ "mina_net2" in
       let%bind () = Unix.mkdir ~p:() conf_dir in
       match%bind
-        Monitor.try_with ~name:"create Mina_net2" ~here:[%here] ~rest:`Raise
-          (fun () ->
+        Monitor.try_with ~here:[%here] ~rest:`Raise (fun () ->
             trace "mina_net2" (fun () ->
                 Mina_net2.create ~logger:config.logger ~conf_dir ~pids
                   ~on_unexpected_termination ) )
@@ -597,8 +596,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
         -> q Deferred.Or_error.t =
      fun ?heartbeat_timeout ?timeout ~rpc_name t peer transport dispatch query ->
       let call () =
-        Monitor.try_with ~name:"try call rpc with dispatch" ~here:[%here]
-          (fun () ->
+        Monitor.try_with ~here:[%here] (fun () ->
             (* Async_rpc_kernel takes a transport instead of a Reader.t *)
             Async_rpc_kernel.Rpc.Connection.with_close
               ~heartbeat_config:

--- a/src/lib/graphql_lib/client.ml
+++ b/src/lib/graphql_lib/client.ml
@@ -85,7 +85,8 @@ module Make (Config : Config_intf) = struct
           Cohttp.Header.add header key value )
     in
     let%bind response, body =
-      Deferred.Or_error.try_with ~extract_exn:true (fun () ->
+      Deferred.Or_error.try_with ~name:"GraphQL client query" ~here:[%here]
+        ~extract_exn:true (fun () ->
           Cohttp_async.Client.post ~headers
             ~body:(Cohttp_async.Body.of_string body_string)
             uri )

--- a/src/lib/graphql_lib/client.ml
+++ b/src/lib/graphql_lib/client.ml
@@ -85,8 +85,7 @@ module Make (Config : Config_intf) = struct
           Cohttp.Header.add header key value )
     in
     let%bind response, body =
-      Deferred.Or_error.try_with ~name:"GraphQL client query" ~here:[%here]
-        ~extract_exn:true (fun () ->
+      Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true (fun () ->
           Cohttp_async.Client.post ~headers
             ~body:(Cohttp_async.Body.of_string body_string)
             uri )

--- a/src/lib/ledger_catchup/normal_catchup.ml
+++ b/src/lib/ledger_catchup/normal_catchup.ml
@@ -389,7 +389,8 @@ let download_transitions ~target_hash ~logger ~trust_system ~network
         | `Available peer -> (
             Hash_set.add busy peer ;
             let%bind res =
-              Deferred.Or_error.try_with_join (fun () ->
+              Deferred.Or_error.try_with_join ~name:"download transitions"
+                ~here:[%here] (fun () ->
                   let open Deferred.Or_error.Let_syntax in
                   [%log debug]
                     ~metadata:

--- a/src/lib/ledger_catchup/normal_catchup.ml
+++ b/src/lib/ledger_catchup/normal_catchup.ml
@@ -389,8 +389,7 @@ let download_transitions ~target_hash ~logger ~trust_system ~network
         | `Available peer -> (
             Hash_set.add busy peer ;
             let%bind res =
-              Deferred.Or_error.try_with_join ~name:"download transitions"
-                ~here:[%here] (fun () ->
+              Deferred.Or_error.try_with_join ~here:[%here] (fun () ->
                   let open Deferred.Or_error.Let_syntax in
                   [%log debug]
                     ~metadata:

--- a/src/lib/mina_lib/coda_subscriptions.ml
+++ b/src/lib/mina_lib/coda_subscriptions.ml
@@ -188,7 +188,8 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                           we have information about which of these different
                           kinds of exception were seen, if any.
                        *)
-                       Deferred.Or_error.try_with_join (fun () ->
+                       Deferred.Or_error.try_with_join ~name:"run gsutil"
+                         ~here:[%here] (fun () ->
                            Or_error.try_with (fun () ->
                                Async.Process.run () ~prog:"bash"
                                  ~args:["-c"; command]

--- a/src/lib/mina_lib/coda_subscriptions.ml
+++ b/src/lib/mina_lib/coda_subscriptions.ml
@@ -188,8 +188,7 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                           we have information about which of these different
                           kinds of exception were seen, if any.
                        *)
-                       Deferred.Or_error.try_with_join ~name:"run gsutil"
-                         ~here:[%here] (fun () ->
+                       Deferred.Or_error.try_with_join ~here:[%here] (fun () ->
                            Or_error.try_with (fun () ->
                                Async.Process.run () ~prog:"bash"
                                  ~args:["-c"; command]

--- a/src/lib/mina_lib/conf_dir.ml
+++ b/src/lib/mina_lib/conf_dir.ml
@@ -12,7 +12,8 @@ let check_and_set_lockfile ~logger conf_dir =
   | `No -> (
       let open Async in
       match%map
-        Monitor.try_with ~extract_exn:true (fun () ->
+        Monitor.try_with ~name:"lockfile doesn't exist" ~here:[%here]
+          ~extract_exn:true (fun () ->
             Writer.with_file ~exclusive:true lockfile ~f:(fun writer ->
                 let pid = Unix.getpid () in
                 return (Writer.writef writer "%d\n" (Pid.to_int pid)) ) )
@@ -35,7 +36,8 @@ let check_and_set_lockfile ~logger conf_dir =
   | `Yes -> (
       let open Async in
       match%map
-        Monitor.try_with ~extract_exn:true (fun () ->
+        Monitor.try_with ~name:"lockfile exists" ~here:[%here]
+          ~extract_exn:true (fun () ->
             Reader.with_file ~exclusive:true lockfile ~f:(fun reader ->
                 let%bind pid =
                   let rm_and_raise () =
@@ -153,7 +155,8 @@ let export_logs_to_tar ?basename ~conf_dir =
       let hw_info = "hardware.info" in
       let hw_info_file = conf_dir ^/ hw_info in
       match%map
-        Monitor.try_with ~extract_exn:true (fun () ->
+        Monitor.try_with ~name:"hardware info" ~here:[%here] ~extract_exn:true
+          (fun () ->
             Writer.with_file ~exclusive:true hw_info_file ~f:(fun writer ->
                 Deferred.List.map (Option.value_exn hw_info_opt)
                   ~f:(fun line -> return (Writer.write_line writer line)) ) )

--- a/src/lib/mina_lib/conf_dir.ml
+++ b/src/lib/mina_lib/conf_dir.ml
@@ -12,8 +12,7 @@ let check_and_set_lockfile ~logger conf_dir =
   | `No -> (
       let open Async in
       match%map
-        Monitor.try_with ~name:"lockfile doesn't exist" ~here:[%here]
-          ~extract_exn:true (fun () ->
+        Monitor.try_with ~here:[%here] ~extract_exn:true (fun () ->
             Writer.with_file ~exclusive:true lockfile ~f:(fun writer ->
                 let pid = Unix.getpid () in
                 return (Writer.writef writer "%d\n" (Pid.to_int pid)) ) )
@@ -36,8 +35,7 @@ let check_and_set_lockfile ~logger conf_dir =
   | `Yes -> (
       let open Async in
       match%map
-        Monitor.try_with ~name:"lockfile exists" ~here:[%here]
-          ~extract_exn:true (fun () ->
+        Monitor.try_with ~here:[%here] ~extract_exn:true (fun () ->
             Reader.with_file ~exclusive:true lockfile ~f:(fun reader ->
                 let%bind pid =
                   let rm_and_raise () =
@@ -155,8 +153,7 @@ let export_logs_to_tar ?basename ~conf_dir =
       let hw_info = "hardware.info" in
       let hw_info_file = conf_dir ^/ hw_info in
       match%map
-        Monitor.try_with ~name:"hardware info" ~here:[%here] ~extract_exn:true
-          (fun () ->
+        Monitor.try_with ~here:[%here] ~extract_exn:true (fun () ->
             Writer.with_file ~exclusive:true hw_info_file ~f:(fun writer ->
                 Deferred.List.map (Option.value_exn hw_info_opt)
                   ~f:(fun line -> return (Writer.write_line writer line)) ) )

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -200,7 +200,8 @@ module Snark_worker = struct
       snark_worker_process ~module_:__MODULE__ ~location:__LOC__ ;
     don't_wait_for
       ( match%bind
-          Monitor.try_with (fun () -> Process.wait snark_worker_process)
+          Monitor.try_with ~name:"SNARK worker process wait" ~here:[%here]
+            (fun () -> Process.wait snark_worker_process)
         with
       | Ok signal_or_error -> (
         match signal_or_error with
@@ -1004,7 +1005,7 @@ let create ?wallets (config : Config.t) =
   Async.Scheduler.within' ~monitor (fun () ->
       trace "coda" (fun () ->
           let%bind prover =
-            Monitor.try_with
+            Monitor.try_with ~name:"Mina_lib create" ~here:[%here]
               ~rest:
                 (`Call
                   (fun exn ->
@@ -1021,7 +1022,7 @@ let create ?wallets (config : Config.t) =
             >>| Result.ok_exn
           in
           let%bind verifier =
-            Monitor.try_with
+            Monitor.try_with ~name:"verifier create" ~here:[%here]
               ~rest:
                 (`Call
                   (fun exn ->

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -200,8 +200,8 @@ module Snark_worker = struct
       snark_worker_process ~module_:__MODULE__ ~location:__LOC__ ;
     don't_wait_for
       ( match%bind
-          Monitor.try_with ~name:"SNARK worker process wait" ~here:[%here]
-            (fun () -> Process.wait snark_worker_process)
+          Monitor.try_with ~here:[%here] (fun () ->
+              Process.wait snark_worker_process )
         with
       | Ok signal_or_error -> (
         match signal_or_error with
@@ -1005,7 +1005,7 @@ let create ?wallets (config : Config.t) =
   Async.Scheduler.within' ~monitor (fun () ->
       trace "coda" (fun () ->
           let%bind prover =
-            Monitor.try_with ~name:"Mina_lib create" ~here:[%here]
+            Monitor.try_with ~here:[%here]
               ~rest:
                 (`Call
                   (fun exn ->
@@ -1022,7 +1022,7 @@ let create ?wallets (config : Config.t) =
             >>| Result.ok_exn
           in
           let%bind verifier =
-            Monitor.try_with ~name:"verifier create" ~here:[%here]
+            Monitor.try_with ~here:[%here]
               ~rest:
                 (`Call
                   (fun exn ->

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -1039,7 +1039,8 @@ module Helper = struct
                   [Tcp.Server.create]. See [handle_protocol] doc comment.
                *)
                 match%map
-                  Monitor.try_with ~extract_exn:true (fun () -> ph.f stream)
+                  Monitor.try_with ~name:"new incoming stream" ~here:[%here]
+                    ~extract_exn:true (fun () -> ph.f stream)
                 with
                 | Ok () ->
                     ()

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -1039,8 +1039,8 @@ module Helper = struct
                   [Tcp.Server.create]. See [handle_protocol] doc comment.
                *)
                 match%map
-                  Monitor.try_with ~name:"new incoming stream" ~here:[%here]
-                    ~extract_exn:true (fun () -> ph.f stream)
+                  Monitor.try_with ~here:[%here] ~extract_exn:true (fun () ->
+                      ph.f stream )
                 with
                 | Ok () ->
                     ()

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -111,8 +111,7 @@ module Worker_state = struct
                    (block : Snark_transition.value) (t : Ledger_proof.t option)
                    state_for_handler pending_coinbase =
                  let%map.Async res =
-                   Deferred.Or_error.try_with ~name:"prover create"
-                     ~here:[%here] (fun () ->
+                   Deferred.Or_error.try_with ~here:[%here] (fun () ->
                        let t = ledger_proof_opt chain next_state t in
                        let%map.Async proof =
                          B.step

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -111,7 +111,8 @@ module Worker_state = struct
                    (block : Snark_transition.value) (t : Ledger_proof.t option)
                    state_for_handler pending_coinbase =
                  let%map.Async res =
-                   Deferred.Or_error.try_with (fun () ->
+                   Deferred.Or_error.try_with ~name:"prover create"
+                     ~here:[%here] (fun () ->
                        let t = ledger_proof_opt chain next_state t in
                        let%map.Async proof =
                          B.step

--- a/src/lib/secrets/secret_file.ml
+++ b/src/lib/secrets/secret_file.ml
@@ -11,8 +11,7 @@ let handle_open ~mkdir ~(f : string -> 'a Deferred.t) path =
   let%bind parent_exists =
     let open Deferred.Let_syntax in
     match%bind
-      Monitor.try_with ~name:"secret file open" ~here:[%here] ~extract_exn:true
-        (fun () ->
+      Monitor.try_with ~here:[%here] ~extract_exn:true (fun () ->
           let%bind stat = Unix.stat dn in
           Deferred.return
           @@
@@ -38,8 +37,7 @@ let handle_open ~mkdir ~(f : string -> 'a Deferred.t) path =
   let%bind () =
     let open Deferred.Let_syntax in
     match%bind
-      Monitor.try_with ~name:"secret file mkdir" ~here:[%here]
-        ~extract_exn:true (fun () ->
+      Monitor.try_with ~here:[%here] ~extract_exn:true (fun () ->
           if (not parent_exists) && mkdir then
             let%bind () = Unix.mkdir ~p:() dn in
             let%bind () = Unix.chmod dn ~perm:0o700 in
@@ -58,8 +56,8 @@ let handle_open ~mkdir ~(f : string -> 'a Deferred.t) path =
   in
   let open Deferred.Let_syntax in
   match%bind
-    Deferred.Or_error.try_with ~name:"secret file, f path" ~here:[%here]
-      ~extract_exn:true (fun () -> f path)
+    Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true (fun () ->
+        f path )
   with
   | Ok x ->
       Deferred.Result.return x

--- a/src/lib/secrets/secret_file.ml
+++ b/src/lib/secrets/secret_file.ml
@@ -11,7 +11,8 @@ let handle_open ~mkdir ~(f : string -> 'a Deferred.t) path =
   let%bind parent_exists =
     let open Deferred.Let_syntax in
     match%bind
-      Monitor.try_with ~extract_exn:true (fun () ->
+      Monitor.try_with ~name:"secret file open" ~here:[%here] ~extract_exn:true
+        (fun () ->
           let%bind stat = Unix.stat dn in
           Deferred.return
           @@
@@ -37,7 +38,8 @@ let handle_open ~mkdir ~(f : string -> 'a Deferred.t) path =
   let%bind () =
     let open Deferred.Let_syntax in
     match%bind
-      Monitor.try_with ~extract_exn:true (fun () ->
+      Monitor.try_with ~name:"secret file mkdir" ~here:[%here]
+        ~extract_exn:true (fun () ->
           if (not parent_exists) && mkdir then
             let%bind () = Unix.mkdir ~p:() dn in
             let%bind () = Unix.chmod dn ~perm:0o700 in
@@ -56,7 +58,8 @@ let handle_open ~mkdir ~(f : string -> 'a Deferred.t) path =
   in
   let open Deferred.Let_syntax in
   match%bind
-    Deferred.Or_error.try_with ~extract_exn:true (fun () -> f path)
+    Deferred.Or_error.try_with ~name:"secret file, f path" ~here:[%here]
+      ~extract_exn:true (fun () -> f path)
   with
   | Ok x ->
       Deferred.Result.return x

--- a/src/lib/secrets/wallets.ml
+++ b/src/lib/secrets/wallets.ml
@@ -139,7 +139,8 @@ let create_hd_account t ~hd_index :
 let delete ({cache; _} as t : t) (pk : Public_key.Compressed.t) :
     (unit, [`Not_found]) Deferred.Result.t =
   Hashtbl.remove cache pk ;
-  Deferred.Or_error.try_with (fun () -> Unix.remove (get_path t pk))
+  Deferred.Or_error.try_with ~name:"wallets delete" ~here:[%here] (fun () ->
+      Unix.remove (get_path t pk) )
   |> Deferred.Result.map_error ~f:(fun _ -> `Not_found)
 
 let pks ({cache; _} : t) = Public_key.Compressed.Table.keys cache

--- a/src/lib/secrets/wallets.ml
+++ b/src/lib/secrets/wallets.ml
@@ -139,7 +139,7 @@ let create_hd_account t ~hd_index :
 let delete ({cache; _} as t : t) (pk : Public_key.Compressed.t) :
     (unit, [`Not_found]) Deferred.Result.t =
   Hashtbl.remove cache pk ;
-  Deferred.Or_error.try_with ~name:"wallets delete" ~here:[%here] (fun () ->
+  Deferred.Or_error.try_with ~here:[%here] (fun () ->
       Unix.remove (get_path t pk) )
   |> Deferred.Result.map_error ~f:(fun _ -> `Not_found)
 

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -10,6 +10,7 @@
   (pps
     ppx_bin_prot
     ppx_coda
+    ppx_here
     ppx_custom_printf
     ppx_deriving_yojson
     ppx_inline_test

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -116,8 +116,7 @@ module Inputs = struct
                       Sparse_ledger.snapp_accounts w.ledger
                         (Transaction.forget t)
                     in
-                    Deferred.Or_error.try_with ~name:"SNARK worker process"
-                      ~here:[%here] (fun () ->
+                    Deferred.Or_error.try_with ~here:[%here] (fun () ->
                         M.of_transaction ~sok_digest ~snapp_account1
                           ~snapp_account2
                           ~source:input.Transaction_snark.Statement.source

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -116,7 +116,8 @@ module Inputs = struct
                       Sparse_ledger.snapp_accounts w.ledger
                         (Transaction.forget t)
                     in
-                    Deferred.Or_error.try_with (fun () ->
+                    Deferred.Or_error.try_with ~name:"SNARK worker process"
+                      ~here:[%here] (fun () ->
                         M.of_transaction ~sok_digest ~snapp_account1
                           ~snapp_account2
                           ~source:input.Transaction_snark.Statement.source

--- a/src/lib/transition_handler/breadcrumb_builder.ml
+++ b/src/lib/transition_handler/breadcrumb_builder.ml
@@ -95,7 +95,8 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                 let open Deferred.Let_syntax in
                 match%bind
                   O1trace.trace_recurring "Breadcrumb.build" (fun () ->
-                      Deferred.Or_error.try_with (fun () ->
+                      Deferred.Or_error.try_with ~name:"breadcrumb build"
+                        ~here:[%here] (fun () ->
                           Transition_frontier.Breadcrumb.build ~logger
                             ~precomputed_values ~verifier ~trust_system ~parent
                             ~transition:mostly_validated_transition

--- a/src/lib/transition_handler/breadcrumb_builder.ml
+++ b/src/lib/transition_handler/breadcrumb_builder.ml
@@ -95,8 +95,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                 let open Deferred.Let_syntax in
                 match%bind
                   O1trace.trace_recurring "Breadcrumb.build" (fun () ->
-                      Deferred.Or_error.try_with ~name:"breadcrumb build"
-                        ~here:[%here] (fun () ->
+                      Deferred.Or_error.try_with ~here:[%here] (fun () ->
                           Transition_frontier.Breadcrumb.build ~logger
                             ~precomputed_values ~verifier ~trust_system ~parent
                             ~transition:mostly_validated_transition

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -1,6 +1,8 @@
 (library
  (name verifier)
  (public_name verifier)
- (libraries precomputed_values core_kernel async_kernel rpc_parallel mina_base mina_state blockchain_snark memory_stats snark_params ledger_proof logger child_processes)
+ (libraries precomputed_values core_kernel async_kernel rpc_parallel mina_base mina_state
+            blockchain_snark memory_stats snark_params ledger_proof logger child_processes)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_compare ppx_hash ppx_coda ppx_version ppx_bin_prot ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv)))
+ (preprocess (pps ppx_compare ppx_hash ppx_coda ppx_version ppx_here ppx_bin_prot ppx_let
+                  ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv)))

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -262,8 +262,7 @@ let wait_safe process =
   match
     Or_error.try_with (fun () ->
         let deferred_wait = Process.wait process in
-        Deferred.Or_error.try_with ~name:"wait safe" ~here:[%here] (fun () ->
-            deferred_wait ) )
+        Deferred.Or_error.try_with ~here:[%here] (fun () -> deferred_wait) )
   with
   | Ok x ->
       x

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -262,7 +262,8 @@ let wait_safe process =
   match
     Or_error.try_with (fun () ->
         let deferred_wait = Process.wait process in
-        Deferred.Or_error.try_with (fun () -> deferred_wait) )
+        Deferred.Or_error.try_with ~name:"wait safe" ~here:[%here] (fun () ->
+            deferred_wait ) )
   with
   | Ok x ->
       x
@@ -291,7 +292,7 @@ let create ~logger ~proof_level ~constraint_constants ~pids ~conf_dir :
          [rest] handler for the 'rest' of the errors after the value is
          determined, which logs the errors and then swallows them.
       *)
-      Monitor.try_with ~name:"Verifier RPC worker" ~run:`Now
+      Monitor.try_with ~name:"Verifier RPC worker" ~here:[%here] ~run:`Now
         ~rest:
           (`Call
             (fun exn ->


### PR DESCRIPTION
Use the `long_cycles_with_context` exported by the O(1) fork of `async_kernel` to log the active monitor chain on long async cycles.

For uses of `Async.try_with...` and `Deferred.Or_error.try_with...`, add the `here` flag to get the source code location, using the `%here` ppx.

The logs use the `sexp` representation of monitors, converted to a string, which contains the source code location. That location doesn't seem to be available as an individual data item. Here's an example of that output, using a dummy monitor I created:
```
(((name"my monitor")(here(src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml:23:58))
  (id 2)(has_seen_error false)(is_detached false))
```
If this sexp is too ugly, I can modify the `async_kernel` fork to expose the source location.

Closes #8808.