### PR TITLE
Increase node status timeout

### DIFF
--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -43,7 +43,7 @@ import (
 	mplex "github.com/libp2p/go-mplex"
 )
 
-const NodeStatusTimeout = 1000 * time.Millisecond
+const NodeStatusTimeout = 10 * time.Second
 
 func parseCIDR(cidr string) gonet.IPNet {
 	_, ipnet, err := gonet.ParseCIDR(cidr)


### PR DESCRIPTION
Bump the node status timeout in an attempt to reduce the number of "context deadline exceeded" errors we get back from our watchdog.