### PR TITLE
Re-enable libp2p metrics; remove per-peer metrics

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	gonet "net"
 	"net/http"
 	"os"
@@ -1093,14 +1094,6 @@ func (ap *beginAdvertisingMsg) run(app *app) (interface{}, error) {
 			ID:     peer.Encode(id),
 			Upcall: "peerConnected",
 		})
-
-		// Note: These are disabled because we see weirdness on our networks
-		//       caused by this prometheus issues.
-		// go app.checkBandwidth(id)
-		// go app.checkLatency(id)
-		// go app.checkPeerCount(id)
-		// go app.checkMessageExchanged(id)
-		// go app.checkMessageStats(id)
 	}
 
 	app.P2p.ConnectionManager.OnDisconnect = func(net net.Network, c net.Conn) {
@@ -1126,50 +1119,53 @@ func (app *app) updateConnectionMetrics() {
 	connectionCountMetric.Set(float64(info.ConnCount))
 }
 
-func (app *app) checkBandwidth(id peer.ID) {
+// TODO: {peer,protocol}-{min,max,avg}
+func (app *app) checkBandwidth() {
 	totalIn := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("total_bandwidth_in_%s", id),
-		Help: "The bandwidth used by the given peer.",
+		Name: "total_bandwidth_in",
+		Help: "The total incoming bandwidth used",
 	})
 	totalOut := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("total_bandwidth_out_%s", id),
-		Help: "The bandwidth used by the given peer.",
+		Name: "total_bandwidth_out",
+		Help: "The total outgoing bandwidth used",
 	})
 	rateIn := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("bandwidth_rate_in_%s", id),
-		Help: "The bandwidth used by the given peer.",
+		Name: "bandwidth_rate_in",
+		Help: "The incoming bandwidth rate",
 	})
 	rateOut := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("bandwidth_rate_out_%s", id),
-		Help: "The bandwidth used by the given peer.",
+		Name: "bandwidth_rate_out",
+		Help: "The outging bandwidth rate",
 	})
 
-	err := prometheus.Register(totalIn)
+	var err error
+
+	err = prometheus.Register(totalIn)
 	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register total-in bandwidth gauge for id", id, "perhaps we've already done so", err.Error())
+		app.P2p.Logger.Debugf("couldn't register total_bandwidth_in; perhaps we've already done so", err.Error())
 		return
 	}
 
 	err = prometheus.Register(totalOut)
 	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register total-out bandwidth gauge for id", id, "perhaps we've already done so", err.Error())
+		app.P2p.Logger.Debugf("couldn't register total_bandwidth_out; perhaps we've already done so", err.Error())
 		return
 	}
 
 	err = prometheus.Register(rateIn)
 	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register rate-in bandwidth gauge for id", id, "perhaps we've already done so", err.Error())
+		app.P2p.Logger.Debugf("couldn't register bandwidth_rate_in; perhaps we've already done so", err.Error())
 		return
 	}
 
 	err = prometheus.Register(rateOut)
 	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register rate-out bandwidth gauge for id", id, "perhaps we've already done so", err.Error())
+		app.P2p.Logger.Debugf("couldn't register bandwidth_rate_out; perhaps we've already done so", err.Error())
 		return
 	}
 
 	for {
-		stats := app.P2p.BandwidthCounter.GetBandwidthForPeer(id)
+		stats := app.P2p.BandwidthCounter.GetBandwidthTotals()
 		totalIn.Set(float64(stats.TotalIn))
 		totalOut.Set(float64(stats.TotalOut))
 		rateIn.Set(stats.RateIn)
@@ -1179,104 +1175,138 @@ func (app *app) checkBandwidth(id peer.ID) {
 	}
 }
 
-func (app *app) checkPeerCount(id peer.ID) {
-	peerCountGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("peer_count_%s", id),
-		Help: "The total number of peers connected by the peer",
+func (app *app) checkPeerCount() {
+	peerCount := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "peer_count",
+		Help: "The total number of peers in our network",
+	})
+	connectedPeerCount := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "connected_peer_count",
+		Help: "The total number of peers we are actively connected to",
 	})
 
-	err := prometheus.Register(peerCountGauge)
+	var err error
+
+	err = prometheus.Register(peerCount)
 	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register peer count for id", id, "perhaps we've already done so", err.Error())
+		app.P2p.Logger.Debugf("couldn't register peer_count; perhaps we've already done so", err.Error())
+		return
+	}
+
+	err = prometheus.Register(connectedPeerCount)
+	if err != nil {
+		app.P2p.Logger.Debugf("couldn't register connected_peer_count; perhaps we've already done so", err.Error())
 		return
 	}
 
 	for {
-		peerIDs := app.P2p.Host.Network().Peers()
-		peerCountGauge.Set(float64(len(peerIDs)))
+		peerCount.Set(float64(len(app.P2p.Host.Network().Peers())))
+		connectedPeerCount.Set(float64(app.P2p.ConnectionManager.GetInfo().ConnCount))
+
 		time.Sleep(app.MetricsRefreshTime)
 	}
 }
 
-func (app *app) checkMessageExchanged(id peer.ID) {
-	msgGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("message_exchanged_%s", id),
-		Help: "The number of different peers that the peer connects with",
+func (app *app) checkMessageStats() {
+	msgMax := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: fmt.Sprintf("message_max_stats"),
+		Help: "The max size of network message received",
+	})
+	msgAvg := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: fmt.Sprintf("message_avg_stats"),
+		Help: "The average size of network message received",
+	})
+	msgMin := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: fmt.Sprintf("message_min_stats"),
+		Help: "The min size of network message received",
 	})
 
-	err := prometheus.Register(msgGauge)
+	err := prometheus.Register(msgMax)
 	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register message exchanged of peers for id", id, "perhaps we've already done so", err.Error())
+		app.P2p.Logger.Debugf("couldn't register message_max_stats; perhaps we've already done so", err.Error())
 		return
 	}
 
-	for {
-		currentCount := app.P2p.ConnectionManager.GetInfo().ConnCount
-		msgGauge.Set(float64(currentCount))
-		time.Sleep(app.MetricsRefreshTime)
-	}
-}
-
-func (app *app) checkMessageStats(id peer.ID) {
-	msgMaxGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("message_max_stats_%s", id),
-		Help: "The max size of network message received by the peer",
-	})
-
-	msgAvgGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("message_avg_stats_%s", id),
-		Help: "The average size of network message received by the peer",
-	})
-
-	msgMinGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("message_min_stats_%s", id),
-		Help: "The min size of network message received by the peer",
-	})
-
-	err := prometheus.Register(msgMaxGauge)
+	err = prometheus.Register(msgAvg)
 	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register message max stats for id", id, "perhaps we've already done so", err.Error())
+		app.P2p.Logger.Debugf("couldn't register message_avg_stats; perhaps we've already done so", err.Error())
 		return
 	}
 
-	err = prometheus.Register(msgAvgGauge)
+	err = prometheus.Register(msgMin)
 	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register message average stats for id", id, "perhaps we've already done so", err.Error())
-		return
-	}
-
-	err = prometheus.Register(msgMinGauge)
-	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register message min stats for id", id, "perhaps we've already done so", err.Error())
+		app.P2p.Logger.Debugf("couldn't register message_min_stats; perhaps we've already done so", err.Error())
 		return
 	}
 
 	for {
 		msgStats := app.P2p.MsgStats.GetStats()
-		msgMinGauge.Set(msgStats.Min)
-		msgAvgGauge.Set(msgStats.Avg)
-		msgMaxGauge.Set(msgStats.Max)
+		msgMin.Set(msgStats.Min)
+		msgAvg.Set(msgStats.Avg)
+		msgMax.Set(msgStats.Max)
 
 		time.Sleep(app.MetricsRefreshTime)
 	}
 }
 
-func (app *app) checkLatency(id peer.ID) {
-	latencyGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("latency_%s", id),
-		Help: "The latency for the given peer.",
+func (app *app) checkLatency() {
+	latencyMin := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: fmt.Sprintf("latency_min"),
+		Help: fmt.Sprintf("The minimum latency (recorded over %s)", latencyMeasurementTime),
+	})
+	latencyMax := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: fmt.Sprintf("latency_max"),
+		Help: fmt.Sprintf("The maximum latency (recorded over %s)", latencyMeasurementTime),
+	})
+	latencyAvg := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: fmt.Sprintf("latency_avg"),
+		Help: fmt.Sprintf("The average latency (recorded over %s)", latencyMeasurementTime),
 	})
 
-	err := prometheus.Register(latencyGauge)
+	var err error
+
+	err = prometheus.Register(latencyMin)
 	if err != nil {
-		app.P2p.Logger.Debugf("couldn't register latency gauge for id", id, "perhaps we've already done so", err.Error())
+		app.P2p.Logger.Debugf("couldn't register latency_min; perhaps we've already done so", err.Error())
+		return
+	}
+
+	err = prometheus.Register(latencyMax)
+	if err != nil {
+		app.P2p.Logger.Debugf("couldn't register latency_max; perhaps we've already done so", err.Error())
+		return
+	}
+
+	err = prometheus.Register(latencyAvg)
+	if err != nil {
+		app.P2p.Logger.Debugf("couldn't register latency_avg; perhaps we've already done so", err.Error())
 		return
 	}
 
 	for {
-		app.P2p.Host.Peerstore().RecordLatency(id, latencyMeasurementTime)
-		latency := app.P2p.Host.Peerstore().LatencyEWMA(id)
-		latencyGauge.Set(float64(latency))
+		peers := app.P2p.Host.Peerstore().Peers()
+		if len(peers) > 0 {
+			sum := 0.0
+			minimum := math.MaxFloat64
+			maximum := 0.0
+
+			for _, peer := range peers {
+				app.P2p.Host.Peerstore().RecordLatency(peer, latencyMeasurementTime)
+				latency := float64(app.P2p.Host.Peerstore().LatencyEWMA(peer))
+
+				sum += latency
+				minimum = math.Min(minimum, latency)
+				maximum = math.Max(maximum, latency)
+			}
+
+			latencyMin.Set(minimum)
+			latencyMax.Set(maximum)
+			latencyAvg.Set(sum / float64(len(peers)))
+		} else {
+			latencyMin.Set(0.0)
+			latencyMax.Set(0.0)
+			latencyAvg.Set(0.0)
+		}
 
 		time.Sleep(app.MetricsRefreshTime)
 	}
@@ -1609,6 +1639,11 @@ func main() {
 	lines.Buffer(make([]byte, bufsize), bufsize)
 
 	app := newApp()
+
+	go app.checkBandwidth()
+	go app.checkPeerCount()
+	go app.checkMessageStats()
+	go app.checkLatency()
 
 	go func() {
 		for {

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1130,19 +1130,19 @@ func (app *app) updateConnectionMetrics() {
 // TODO: {peer,protocol}-{min,max,avg}
 func (app *app) checkBandwidth() {
 	totalIn := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "total_bandwidth_in",
+		Name: "Mina_libp2p_total_bandwidth_in",
 		Help: "The total incoming bandwidth used",
 	})
 	totalOut := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "total_bandwidth_out",
+		Name: "Mina_libp2p_total_bandwidth_out",
 		Help: "The total outgoing bandwidth used",
 	})
 	rateIn := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "bandwidth_rate_in",
+		Name: "Mina_libp2p_bandwidth_rate_in",
 		Help: "The incoming bandwidth rate",
 	})
 	rateOut := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "bandwidth_rate_out",
+		Name: "Mina_libp2p_bandwidth_rate_out",
 		Help: "The outging bandwidth rate",
 	})
 
@@ -1185,11 +1185,11 @@ func (app *app) checkBandwidth() {
 
 func (app *app) checkPeerCount() {
 	peerCount := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "peer_count",
+		Name: "Mina_libp2p_peer_count",
 		Help: "The total number of peers in our network",
 	})
 	connectedPeerCount := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "connected_peer_count",
+		Name: "Mina_libp2p_connected_peer_count",
 		Help: "The total number of peers we are actively connected to",
 	})
 
@@ -1217,15 +1217,15 @@ func (app *app) checkPeerCount() {
 
 func (app *app) checkMessageStats() {
 	msgMax := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("message_max_stats"),
+		Name: "Mina_libp2p_message_max_stats",
 		Help: "The max size of network message received",
 	})
 	msgAvg := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("message_avg_stats"),
+		Name: "Mina_libp2p_message_avg_stats",
 		Help: "The average size of network message received",
 	})
 	msgMin := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("message_min_stats"),
+		Name: "Mina_libp2p_message_min_stats",
 		Help: "The min size of network message received",
 	})
 
@@ -1259,15 +1259,15 @@ func (app *app) checkMessageStats() {
 
 func (app *app) checkLatency() {
 	latencyMin := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("latency_min"),
+		Name: "Mina_libp2p_latency_min",
 		Help: fmt.Sprintf("The minimum latency (recorded over %s)", latencyMeasurementTime),
 	})
 	latencyMax := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("latency_max"),
+		Name: "Mina_libp2p_latency_max",
 		Help: fmt.Sprintf("The maximum latency (recorded over %s)", latencyMeasurementTime),
 	})
 	latencyAvg := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: fmt.Sprintf("latency_avg"),
+		Name: "Mina_libp2p_latency_avg",
 		Help: fmt.Sprintf("The average latency (recorded over %s)", latencyMeasurementTime),
 	})
 
@@ -1551,7 +1551,7 @@ type successResult struct {
 }
 
 var connectionCountMetric = prometheus.NewGauge(prometheus.GaugeOpts{
-	Name: "Coda_active_connections_total",
+	Name: "Mina_libp2p_connections_total",
 	Help: "Number of active connections, according to the CodaConnectionManager.",
 })
 


### PR DESCRIPTION
Part of #8749. There will be a followup PR that fixes the OCaml integration with the libp2p_helper wrt surfacing these metrics.