### PR TITLE
DO NOT MERGE - re-release-sidecar 

### DIFF
--- a/automation/services/mina-bp-stats/sidecar/build.sh
+++ b/automation/services/mina-bp-stats/sidecar/build.sh
@@ -2,6 +2,8 @@
 
 BUILDDIR="${BUILDDIR:-deb_build}"
 
+VERSION=1.1.6-${GITHASH}
+
 # Get CWD if run locally or run through "source"
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 

--- a/buildkite/scripts/publish-deb.sh
+++ b/buildkite/scripts/publish-deb.sh
@@ -34,7 +34,11 @@ case $BUILDKITE_BRANCH in
         CODENAME=unstable ;;
 esac
 
-echo "Publishing debs: ${DEBS}"
+CODENAME=pre-release
+
+echo "WARNING: publishing to release repo!"
+
+echo "Publishing debs to repo [${CODENAME}]: ${DEBS}"
 set -x
 # Upload the deb files to s3.
 # If this fails, attempt to remove the lockfile and retry.

--- a/buildkite/scripts/publish-deb.sh
+++ b/buildkite/scripts/publish-deb.sh
@@ -34,7 +34,7 @@ case $BUILDKITE_BRANCH in
         CODENAME=unstable ;;
 esac
 
-CODENAME=pre-release
+CODENAME=release
 
 echo "WARNING: publishing to release repo!"
 

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -336,6 +336,9 @@ ls -lh mina*.deb
 #remove build dir to prevent running out of space on the host machine
 rm -rf "${BUILDDIR}"
 
+echo "removing all extra packages to avoid pushing new versions on this branch"
+rm -rf *.deb
+
 # Build mina block producer sidecar 
 source ../automation/services/mina-bp-stats/sidecar/build.sh
 ls -lh mina*.deb


### PR DESCRIPTION
Modify scripts to create new sidecar release vaguely safely. Only intended to last the lifetime of one CI run, DO NOT MERGE!