### PR TITLE
Omit alerts from private testnets

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -371,7 +371,7 @@ There's several gotchas here that the script will check for:
 Next, you must create a new testnet in `terraform/testnets/`. For ease of use, you can copy-paste an existing one, however it's important to go through the terraform and change the following things:
 
 - location of Terraform state file
-- Name of testnet
+- Name of testnet (Note: Prefix it with `test-` for testnets that don't require alerting. For example, private testnets for testing specific features)
 - number of nodes to deploy
 - Location of the Genesis Ledger
 

--- a/automation/terraform/monitoring/o1-testnet-alerts.tf
+++ b/automation/terraform/monitoring/o1-testnet-alerts.tf
@@ -12,7 +12,7 @@ terraform {
 module "o1testnet_alerts" {
   source = "../modules/testnet-alerts"
 
-  rule_filter            = "{testnet!~\"^(it-|ci-net).+\"}" # omit testnets deployed by integration/CI tests
+  rule_filter            = "{testnet!~\"^(it-|ci-net|test-).+\"}" # omit testnets deployed by integration/CI tests
   alert_timeframe        = "1h"
   alert_duration         = "10m"
   pagerduty_alert_filter = "devnet2|mainnet"


### PR DESCRIPTION
Omitting alerts from testnets that start with `test-`. Any private testnet can have the prefix `test-` in its name to omit alerts from it. This is to reduce noise in testnet-warnings channel
Integration tests and ci nets are already being ignored. Retaining alerts from `nightly` since we want to ensure it runs fine in order to make alpha releases