### PR TITLE
[crypto] poseidon.js

### DIFF
--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -281,5 +281,11 @@ let _ =
          in
          Js.string (Yojson.Safe.to_string result_json)
 
+       method hashBytearray = Poseidon_hash.hash_bytearray
+
+       method hashFieldElems = Poseidon_hash.hash_field_elems
+
+       val hashOrder = Poseidon_hash.Field.(Hex.encode @@ Nat.to_bytes order)
+
        method runUnitTests () : bool Js.t = Coding.run_unit_tests () ; Js._true
     end)

--- a/src/app/client_sdk/dune
+++ b/src/app/client_sdk/dune
@@ -1,10 +1,25 @@
 (executable
  (name client_sdk)
  (modes js)
- (js_of_ocaml (flags +toplevel.js +dynlink.js))
- (libraries snark_params_nonconsensus rosetta_lib_nonconsensus mina_base_nonconsensus data_hash_lib_nonconsensus
-            random_oracle_nonconsensus signature_lib_nonconsensus zarith_stubs_js integers integers_stubs_js js_of_ocaml
-            digestif.ocaml)
+ (js_of_ocaml
+  (flags +toplevel.js +dynlink.js))
+ (libraries
+  core_kernel
+  snark_params_nonconsensus
+  rosetta_lib_nonconsensus
+  mina_base_nonconsensus
+  data_hash_lib_nonconsensus
+  random_oracle_nonconsensus
+  signature_lib_nonconsensus
+  zarith_stubs_js
+  integers
+  integers_stubs_js
+  js_of_ocaml
+  digestif.ocaml
+  sponge
+  hex)
  (preprocessor_deps ../../config.mlh)
- (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_custom_printf ppx_optcomp js_of_ocaml-ppx)))
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_version ppx_custom_printf ppx_optcomp js_of_ocaml-ppx)))

--- a/src/app/client_sdk/poseidon_hash.ml
+++ b/src/app/client_sdk/poseidon_hash.ml
@@ -1,0 +1,138 @@
+open Core_kernel
+open Js_of_ocaml
+
+(* *************** *
+ *    our field    *
+ * *************** *)
+
+module Field = struct
+  include Snark_params_nonconsensus.Field
+
+  (* Converts a byterray into a [Field.t], raises an exception if the number obtained is larger than the order *)
+  let of_bytes bytearray =
+    let aux i acc c =
+      let big = Nat.of_int @@ int_of_char c in
+      let offset = Nat.shift_left big (Int.( * ) i 8) in
+      Nat.(acc + offset)
+    in
+    let zero = Nat.of_int 0 in
+    let big = Array.foldi bytearray ~init:zero ~f:aux in
+    let one = Nat.of_int 1 in
+    if Nat.(order - one < big) then
+      failwith "the given field is larger than the order" ;
+    of_bigint big
+
+  (* Converts a field element into an hexadecimal string (encoding the field element in little-endian) *)
+  let to_hex field =
+    (* taken from src/lib/pickles *)
+    let bits_to_bytes bits =
+      let byte_of_bits bs =
+        List.foldi bs ~init:0 ~f:(fun i acc b ->
+            if b then acc lor (1 lsl i) else acc )
+        |> Char.of_int_exn
+      in
+      List.map
+        (List.groupi bits ~break:(fun i _ _ -> i mod 8 = 0))
+        ~f:byte_of_bits
+      |> String.of_char_list
+    in
+    let bytearray = to_bits field |> bits_to_bytes in
+    Hex.encode bytearray
+end
+
+(* ********************** *
+ * our permutation Config *
+ * ********************** *)
+
+module Config = struct
+  module Field = Field
+
+  let rounds_full = 54
+
+  let initial_ark = false
+
+  let rounds_partial = 0
+
+  let to_the_alpha x =
+    let open Field in
+    let x_2 = x * x in
+    let x_4 = x_2 * x_2 in
+    let x_7 = x_4 * x_2 * x in
+    x_7
+
+  module Operations = struct
+    let add_assign ~state i x = Field.(state.(i) <- state.(i) + x)
+
+    let apply_affine_map (matrix, constants) v =
+      let dotv row =
+        Array.reduce_exn (Array.map2_exn row v ~f:Field.( * )) ~f:Field.( + )
+      in
+      let res = Array.map matrix ~f:dotv in
+      Array.map2_exn res constants ~f:Field.( + )
+
+    let copy a = Array.map a ~f:Fn.id
+  end
+end
+
+(* ***************** *
+ *   hash function   *
+ * ***************** *)
+
+module Hash = struct
+  include Sponge.Make_hash (Sponge.Poseidon (Config))
+
+  let params : Field.t Sponge.Params.t =
+    Sponge.Params.(map pasta_p_3 ~f:Field.of_string)
+
+  let update ~state = update ~state params
+
+  let hash ?init = hash ?init params
+
+  let pack_input =
+    Random_oracle_input.pack_to_fields ~size_in_bits:Field.size_in_bits
+      ~pack:Field.project
+end
+
+(* ************************ *
+ *   javascript interface   *
+ * ************************ *)
+
+type 'a array_js = 'a Js.js_array Js.t
+
+type u8_array_js = Js_of_ocaml.Typed_array.uint8Array Js.t
+
+type string_js = Js.js_string Js.t
+
+(* input is a raw string of bytes *)
+let hash_bytearray (bytearray : u8_array_js) : string_js =
+  let string_to_bitstring s =
+    let char_bits = String_sign.Message.char_bits in
+    let x = Stdlib.(Array.of_seq (Seq.map char_bits (String.to_seq s))) in
+    Random_oracle_input.bitstrings x
+  in
+  let input = Js_of_ocaml.Typed_array.String.of_uint8Array bytearray in
+  let input =
+    if String.length input = 0 then [||]
+    else input |> string_to_bitstring |> Hash.pack_input
+  in
+  let init = Hash.initial_state in
+  let digest = Hash.hash ~init input in
+  let digest_hex = Field.to_hex digest in
+  Js.string digest_hex
+
+(* input is an array of field elements encoded as bytearrays *)
+let hash_field_elems (field_elems : u8_array_js array_js) : string_js =
+  let field_of_js_field x =
+    let field_bytes = Js_of_ocaml.Typed_array.String.of_uint8Array x in
+    if String.length field_bytes = 0 then failwith "invalid field element" ;
+    String.to_array field_bytes |> Field.of_bytes
+  in
+  let input : u8_array_js array = Js.to_array field_elems in
+  let input : Field.t array =
+    if Array.length input = 0 then [||]
+    else Array.map input ~f:field_of_js_field
+  in
+  let init = Hash.initial_state in
+  let digest = Hash.hash ~init input in
+  let digest_hex = Field.to_hex digest in
+  Js.string digest_hex

--- a/src/app/client_sdk/tests/poseidon_test_vectors.json
+++ b/src/app/client_sdk/tests/poseidon_test_vectors.json
@@ -1,0 +1,46 @@
+[
+    {
+        "input": [],
+        "output": "87b24ed3fe1f35af6497c504acd6de35f06bd9c2e2490a1b5012715719de8d05"
+    },
+    {
+        "input": [
+            "df698e389c6f1987ffe186d806f8163738f5bf22e8be02572cce99dc6a4ab030"
+        ],
+        "output": "d2f75185842484ba5a1a4e0ba5f3870ed48782cc4f89a8228f5eaf75e1833906"
+    },
+    {
+        "input": [
+            "56b648a5a85619814900a6b40375676803fe16fb1ad2d1fb79115eb1b52ac026",
+            "f26a8a03d9c9bbd9c6b2a1324d2a3f4d894bafe25a7e4ad1a498705f4026ff2f"
+        ],
+        "output": "922d4e7f5802aee157ae13afb8c7a4aadca06913b9d36a9d1f20f5edb70e2c30"
+    },
+    {
+        "input": [
+            "075c41fa23e4690694df5ded43624fd60ab7ee6ec6dd48f44dc71bc206cecb26",
+            "a4e2beebb09bd02ad42bbccc11051e8262b6ef50445d8382b253e91ab1557a0d",
+            "7dfc23a1242d9c0d6eb16e924cfba342bb2fccf36b8cbaf296851f2e6c469639"
+        ],
+        "output": "1879e13397b27ddec5fcdfb50183d106744368525494afcb256c8207129a103d"
+    },
+    {
+        "input": [
+            "a1a659b14e80d47318c6fcdbbd388de4272d5c2815eb458cf4f196d52403b639",
+            "5e33065d1801131b64d13038ff9693a7ef6283f24ec8c19438d112ff59d50f04",
+            "38a8f4d0a9b6d0facdc4e825f6a2ba2b85401d5de119bf9f2bcb908235683e06",
+            "3456d0313a30d7ccb23bd71ed6aa70ab234dad683d8187b677aef73f42f4f52e"
+        ],
+        "output": "415aab36a9011fa8218bd67be746c7a8fd9ba83d01d1ca669574c60caef12d30"
+    },
+    {
+        "input": [
+            "bccfee48dc76bb991c97bd531cf489f4ee37a66a15f5cfac31bdd4f159d4a905",
+            "2d106fb21a262f85fd400a995c6d74bad48d8adab2554046871c215e585b072b",
+            "8300e93ee8587956534d0756bb2aa575e5878c670cff5c8e3e55c62632333c06",
+            "879c32da31566f6d16afdefff94cba5260fec1057e97f19fc9a61dc2c54a6417",
+            "9c0aa6e5501cfb2d08aeaea5b3cddac2c9bee85d13324118b44bafb63a59611e"
+        ],
+        "output": "9d69ee732cfe073cc9417aef734293002c8db0c69b1e814cfa7a858e7c995d33"
+    }
+]

--- a/src/app/client_sdk/tests/test_hash.js
+++ b/src/app/client_sdk/tests/test_hash.js
@@ -1,0 +1,94 @@
+const assert = require('assert');
+const mina = require("../../../../_build/default/src/app/client_sdk/client_sdk.bc.js").minaSDK;
+const fs = require('fs');
+
+// helpers
+// =======
+
+function hexstring_to_typedarray(hexString) {
+    // checks
+    if (hexString.length % 2 != 0) {
+        throw "invalid length";
+    }
+
+    const re = /[0-9A-Fa-f]*/g;
+    if (!re.test(hexString)) {
+        throw "invalid character";
+    }
+
+    // conversion
+    return Uint8Array.from(Buffer.from(hexString, 'hex'));
+}
+
+// handy function to convert little-endian encoded hexstrings into their decimal counterparts 
+function hex_to_decimal(hex) {
+    let hex_be = hex.match(/../g).reverse().join('');
+    let bn = BigInt('0x' + hex_be);
+    return bn.toString(10);
+}
+
+// hash_bytearray
+// ==============
+// Note: the hash_bytearray API does not have test vectors at the moment.
+
+// hash(0xdeadbeef)
+let input = hexstring_to_typedarray("deadbeef");
+assert(mina.hashBytearray(input) == "59b88198cfe25b4f730bafb48593e5b60a94f022cdc168e1ebbfe371f9935f27");
+
+// compare the two APIs on the empty input
+input = hexstring_to_typedarray("");
+assert(mina.hashBytearray(input) == mina.hashFieldElems([]));
+
+// hash_field_elems
+// ================
+
+// read test vectors file
+let rawdata = fs.readFileSync('src/app/client_sdk/tests/poseidon_test_vectors.json');
+let test_vectors = JSON.parse(rawdata);
+
+// iterate over every test vector
+test_vectors.map((test_vector, idx) => {
+    // hash
+    const input = test_vector.input.map(hexString =>
+        hexstring_to_typedarray(hexString)
+    );
+    let digest = mina.hashFieldElems(input);
+
+    // expected result
+    assert(test_vector.output == digest);
+})
+
+// negative tests
+
+// bad hexstring length
+assert.throws(() => {
+    let hexString = "01110101101010101010101010101010101010101";
+    let input = hexstring_to_typedarray(hexString)
+    mina.hashFieldElems([input]);
+});
+
+// bad input: not an array of uint8array
+assert.throws(() => {
+    let hexString = "0111010110101010101010101010101010101010";
+    let input = hexstring_to_typedarray(hexString)
+    mina.hashFieldElems(input);
+});
+
+// passed null value
+assert.throws(() => {
+    mina.hashFieldElems(null); // <-- null!
+});
+
+// passed field element larger or equal to the order
+let order = mina.hashOrder.c;
+
+assert.throws(() => {
+    let input = hexstring_to_typedarray(order);
+    mina.hashFieldElems([input]);
+});
+
+assert.throws(() => {
+    let input = hexstring_to_typedarray(order);
+    input[0] += 1;
+    mina.hashFieldElems([input]);
+});

--- a/src/lib/pickles/make_sponge.ml
+++ b/src/lib/pickles/make_sponge.ml
@@ -4,6 +4,8 @@ open Core_kernel
 module Rounds = struct
   let rounds_full = 63
 
+  let initial_ark = true
+
   let rounds_partial = 0
 end
 

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -37,6 +37,8 @@ module Inputs = struct
 
   let rounds_full = 63
 
+  let initial_ark = true
+
   let rounds_partial = 0
 
   (* Computes x^5 *)


### PR DESCRIPTION
This commit exports an OCaml poseidon hash implemention to javascript.
It uses the fp_3 parameters (see https://github.com/o1-labs/marlin/blob/master/oracle/src/poseidon.rs#L73).
In particular, the javascript implementation has two methods:

- `hashBytearray` to hash an opaque array of bytes. The type expected is a Uint8Array.
- `hashFieldElems` to hash an array of field elements. The field elements must be represented in little-endian hex encoded form.

Both methods return a digest in hexadecimal form of a little-endian encoded field element.

For more details see https://hackmd.io/ecBTibDpTzGdH9WM30gwQw
