### PR TITLE
Fix flaky tests: ensure all async jobs have completed before asserting

### DIFF
--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1806,6 +1806,7 @@ let%test_module _ =
             List.map ~f:User_command.forget_check
               (expires_later2 :: List.drop few_now 1)
           in
+          let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
           assert_pool_txs cmds_wo_check ;
           (*Add new commands, remove old commands some of which are now expired*)
           let expired_command =
@@ -1842,6 +1843,7 @@ let%test_module _ =
               ( expires_later1 :: expires_later2 :: unexpired_command
               :: List.drop few_now 1 )
           in
+          let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
           assert_pool_txs cmds_wo_check ;
           (*after 5 block times there should be no expired transactions*)
           let%bind () =
@@ -1854,6 +1856,7 @@ let%test_module _ =
           let cmds_wo_check =
             List.map ~f:User_command.forget_check (List.drop few_now 1)
           in
+          let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
           assert_pool_txs cmds_wo_check ;
           Deferred.unit )
 


### PR DESCRIPTION
These tests have become far more flaky as of late. This variability seems to be coming from the async scheduler, which may choose to run the test's assertion before committing the updates sent to a broadcast pipe.

This PR fixes this, by yielding to the scheduler and waiting for all jobs to finish before running the checks.

cc @psteckler, this should fix the failures you were seeing in #8898.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: