### PR TITLE
Improve randomness generation for nonconsensus signature lib

### DIFF
--- a/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
@@ -46,6 +46,5 @@ Pipeline.build
       },
     steps = [
       buildTestCmd "dev" "src/lib" Size.XLarge,
-      buildTestCmd "nonconsensus_medium_curves" "src/nonconsensus" Size.Large
     ]
   }

--- a/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/DaemonUnitTest.dhall
@@ -45,6 +45,6 @@ Pipeline.build
         name = "DaemonUnitTest"
       },
     steps = [
-      buildTestCmd "dev" "src/lib" Size.XLarge,
+      buildTestCmd "dev" "src/lib" Size.XLarge
     ]
   }

--- a/frontend/client_sdk/package.json
+++ b/frontend/client_sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@o1labs/client-sdk",
   "description": "Node API for signing transactions for Mina Protocol",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "scripts": {
     "build": "bsb -make-world && tsc src/SDKWrapper.ts -d",
     "start": "bsb -make-world -w",

--- a/scripts/client-sdk-unit-tests.sh
+++ b/scripts/client-sdk-unit-tests.sh
@@ -20,29 +20,16 @@ make rosetta_lib_encodings
 echo "Running"
 ./_build/default/src/lib/rosetta_lib/test/test_encodings.exe > encodings.consensus
 
-# native/nonconsensus
-echo "Building nonconsensus native code for encodings..."
-make rosetta_lib_encodings_nonconsensus
-echo "Running"
-./_build/default/src/nonconsensus/rosetta_lib/test/test_encodings.exe > encodings.nonconsensus
-
 # js/nonconsensus
 echo "Building nonconsensus Javascript code for encodings..."
 make client_sdk
 echo "Running"
 nodejs src/app/client_sdk/tests/test_encodings.js > encodings.js.nonconsensus
 
-diff encodings.consensus encodings.nonconsensus
+diff encodings.consensus encodings.js.nonconsensus
 
 if [ $? -ne 0 ]; then
-    echo "Consensus and nonconsensus code generate different encodings";
-    exit 1
-fi
-
-diff encodings.nonconsensus encodings.js.nonconsensus
-
-if [ $? -ne 0 ]; then
-    echo "Nonconsensus native and Javascript code generate different encodings";
+    echo "Consensus and Javascript code generate different encodings";
     exit 1
 fi
 

--- a/scripts/compare_test_signatures.sh
+++ b/scripts/compare_test_signatures.sh
@@ -15,12 +15,6 @@ make client_sdk_test_sigs
 echo "Running"
 ./_build/default/src/app/client_sdk/tests/test_signatures.exe > nat.consensus.json
 
-# native/nonconsensus
-echo "Building nonconsensus native code..."
-make client_sdk_test_sigs_nonconsensus
-echo "Running"
-./_build/default/src/app/client_sdk/tests/test_signatures_nonconsensus.exe > nat.nonconsensus.json
-
 # js/nonconsensus
 echo "Building nonconsensus JS code..."
 make client_sdk
@@ -30,17 +24,10 @@ nodejs src/app/client_sdk/tests/test_signatures.js > js.nonconsensus.json
 # we've been careful so that the output formatting of all the signatures is the same
 # so we can use diff (rather parsing the JSON with Python or such)
 
-diff nat.consensus.json nat.nonconsensus.json
+diff nat.consensus.json js.nonconsensus.json
 
 if [ $? -ne 0 ]; then
-    echo "Consensus and nonconsensus code generate different signatures";
-    exit 1
-fi
-
-diff nat.nonconsensus.json js.nonconsensus.json
-
-if [ $? -ne 0 ]; then
-    echo "Nonconsensus native and JS code generate different signatures";
+    echo "Consensus and JS code generate different signatures";
     exit 1
 fi
 

--- a/src/nonconsensus/signature_lib/dune
+++ b/src/nonconsensus/signature_lib/dune
@@ -12,6 +12,7 @@
    random_oracle_nonconsensus
    mina_signature_kind
    snark_params_nonconsensus
+   js_of_ocaml
    yojson)
  (preprocessor_deps ../../config.mlh)
  (preprocess


### PR DESCRIPTION
This PR uses JavaScript's crypto API (working around the different APIs of node and the browser) to provide random bytes for keypair generation for the JS build. It has been tested in Firefox and node.js