### PR TITLE
helper app that generates keys and txns

### DIFF
--- a/src/app/batch_generate_keys/batch_generate_keys.ml
+++ b/src/app/batch_generate_keys/batch_generate_keys.ml
@@ -68,17 +68,16 @@ let output_cmds =
                of_int txns_per_block /. of_int slot_time *. fill_rate
                *. of_int rate_limit_interval)
            in
-           let limit =
-             Float.(min slot_limit (of_int rate_limit_level) *. 1000.)
-           in
+           let limit = min (Float.to_int slot_limit) rate_limit_level in
            Some limit
          else None
        in
        let batch_count = ref 0 in
        List.iter (gen_keys count) ~f:(fun pk ->
            Option.iter rate_limit ~f:(fun rate_limit ->
-               if !batch_count >= rate_limit_level then (
-                 Format.printf "sleep %f@." rate_limit ;
+               if !batch_count >= rate_limit then (
+                 Format.printf "sleep %f@."
+                   Float.(of_int rate_limit_interval /. 1000.) ;
                  batch_count := 0 )
                else incr batch_count ) ;
            Format.printf

--- a/src/app/batch_generate_keys/batch_generate_keys.ml
+++ b/src/app/batch_generate_keys/batch_generate_keys.ml
@@ -32,7 +32,7 @@ let output_cmds =
        flag "--slot-time" ~aliases:["slot-time"]
          ~doc:
            "NUM_MILLISECONDS Slot duration in milliseconds. (default: 180000)"
-         (optional_with_default 3000 int)
+         (optional_with_default 180000 int)
      and fill_rate =
        flag "--fill-rate" ~aliases:["fill-rate"]
          ~doc:"FILL_RATE Fill rate (default: 0.75)"

--- a/src/app/batch_generate_keys/batch_generate_keys.ml
+++ b/src/app/batch_generate_keys/batch_generate_keys.ml
@@ -1,0 +1,93 @@
+open Core
+open Signature_lib
+
+let gen_keys count =
+  Quickcheck.random_value ~seed:`Nondeterministic
+    (Quickcheck.Generator.list_with_length count Public_key.Compressed.gen)
+
+let output_keys =
+  let open Command.Let_syntax in
+  Command.basic ~summary:"Generate the given number of public keys on stdout"
+    (let%map_open count =
+       flag "--count" ~aliases:["count"] ~doc:"NUM Number of keys to generate"
+         (required int)
+     in
+     fun () ->
+       List.iter (gen_keys count) ~f:(fun pk ->
+           Format.printf "%s@." (Public_key.Compressed.to_base58_check pk) ))
+
+let output_cmds =
+  let open Command.Let_syntax in
+  Command.basic ~summary:"Generate the given number of public keys on stdout"
+    (let%map_open count =
+       flag "--count" ~aliases:["count"] ~doc:"NUM Number of keys to generate"
+         (required int)
+     and txns_per_block =
+       flag "--txn-capacity-per-block" ~aliases:["txn-capacity-per-block"]
+         ~doc:
+           "NUM Transaction capacity per block. Used for rate limiting. \
+            (default: 128)"
+         (optional_with_default 128 int)
+     and slot_time =
+       flag "--slot-time" ~aliases:["slot-time"]
+         ~doc:
+           "NUM_MILLISECONDS Slot duration in milliseconds. (default: 180000)"
+         (optional_with_default 3000 int)
+     and fill_rate =
+       flag "--fill-rate" ~aliases:["fill-rate"]
+         ~doc:"FILL_RATE Fill rate (default: 0.75)"
+         (optional_with_default 0.75 float)
+     and rate_limit =
+       flag "--apply-rate-limit" ~aliases:["apply-rate-limit"]
+         ~doc:
+           "TRUE/FALSE Whether to emit sleep commands between commands to \
+            enforce sleeps (default: true)"
+         (optional_with_default true bool)
+     and rate_limit_level =
+       flag "--rate-limit-level" ~aliases:["rate-limit-level"]
+         ~doc:
+           "NUM Number of transactions that can be sent in a time interval \
+            before hitting the rate limit (default: 200)"
+         (optional_with_default 200 int)
+     and rate_limit_interval =
+       flag "--rate-limit-interval" ~aliases:["rate-limit-interval"]
+         ~doc:
+           "NUM_MILLISECONDS Interval that the rate-limiter is applied over \
+            (default: 300000)"
+         (optional_with_default 300000 int)
+     and sender_key =
+       flag "--sender-pk" ~aliases:["sender-pk"]
+         ~doc:"PUBLIC_KEY Public key to send the transactions from"
+         (required string)
+     in
+     fun () ->
+       let rate_limit =
+         if rate_limit then
+           let slot_limit =
+             Float.(
+               of_int txns_per_block /. of_int slot_time *. fill_rate
+               *. of_int rate_limit_interval)
+           in
+           let limit =
+             Float.(min slot_limit (of_int rate_limit_level) *. 1000.)
+           in
+           Some limit
+         else None
+       in
+       let batch_count = ref 0 in
+       List.iter (gen_keys count) ~f:(fun pk ->
+           Option.iter rate_limit ~f:(fun rate_limit ->
+               if !batch_count >= rate_limit_level then (
+                 Format.printf "sleep %f@." rate_limit ;
+                 batch_count := 0 )
+               else incr batch_count ) ;
+           Format.printf
+             "mina client send-payment --amount 1 --receiver %s --sender %s@."
+             (Public_key.Compressed.to_base58_check pk)
+             sender_key ))
+
+let () =
+  Command.run
+    (Command.group
+       ~summary:"Generate public keys for sending batches of transactions"
+       [("gen-keys", output_keys); ("gen-txns", output_cmds)])

--- a/src/app/batch_generate_keys/dune
+++ b/src/app/batch_generate_keys/dune
@@ -1,0 +1,4 @@
+(executable
+ (name batch_generate_keys)
+ (libraries signature_lib core)
+ (preprocess (pps ppx_version ppx_let)))


### PR DESCRIPTION
This PR adds a `batch_generate_keys.exe` helper application. This has 2 modes:
* `batch_generate_keys.exe gen-keys --count n`, to generate `n` new random public keys:
```
$ _build/default/src/app/batch_generate_keys/batch_generate_keys.exe gen-keys -count 10
B62qjRUfvxvCcmUxY2ES4MCrZRvnbBf2Umo2wgpy1bQAJfozetGbzgv
B62qoDwM4P4nvi9gdSpkiQdpXridLwEueRVhyHfqjFTUNiTAmfhrAiD
B62qne9bBQsDic1VQ9K82TrTjQnSxDmf5FMpZdJr1H9WuBfd3L5de2K
B62qmEC8jf5QKTeFSyhKD1VkKhcEiGoEKf4tzjv6xKeFaQLuB2h1XXH
B62qjciJJb8cJpsUUBF8jk2qVYnUWmM7gDjdmH2HcM6btWDD5GxYvVr
B62qj67VKYe3DRr4qbYPorQW79y63KhX89azzEz9wbR55wao6bRaotp
B62qoiUM8WadVrucac3Gh1548vWFpc732UvjeVayvx7kZSMgYD7dXgF
B62qjJKLFRh1CPHCqu6Fs3V16j52ePB5yYKyvPAYNBsrHdvw1c6Pruc
B62qrFygLypnmbiCQJn8DKeWK22QnjbZCDpUoaY1G35PhGvSM7R7PmK
B62qn5L79pGDYX55DL8PmcmjbC9mp8Rua3JBzEbK4u88iWr92HPxugp
```
* `batch_generate_keys.exe gen-txns -count n --sender-pk pk` to generate `n` commands to send to new random public keys:
```
$ _build/default/src/app/batch_generate_keys/batch_generate_keys.exe gen-txns -count 10 --sender-pk B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qoqkX6kCf1BcFrRpyitwUNz5sttfN3RyFBMzSo73rXZHwV7XkWb7 --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qro1oW3pLNqrk5PPLiDQe9BUMLKYWhXbeGhGs9sUoBAiV19SCPe9 --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qksaZQujpTrjY99M4t82hYxdajAXWaFSoTeEGEJom5QV2nyu1cY6 --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qnUmCqJBaq9zrp795zveBV9xw6DBMQXhfmER4GTwhhpmzPuYd5gF --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qqngrbyrgA2RKsgeCGKDN75woUcgKQUiECN92SsrtmcBGoavxSiH --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qkEwVL6VPgPLUcR77XdCAjmjbdJjicBB31iiNyVLnqRbN1YnbZwG --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qqyzMnjxGC43aGB8smqi3qAd22ppuF4cmiLiTEqYaUya8gGnHdEH --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qnNpzBrhRRZ9YuQ9TUoxnbGpTPDM7N2DAmWAuSkqzbYH32PiyyVx --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qjSMTD9yaDm3o8Aa3ekkUtC3fgS4u1yKXwifr9dQoPCjF6BfCkos --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qncvCx7DuCraaFVt8wMoMPTQqFFoFDFaJNEwGe6tjwZjZmKMGc1W --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
```

-----------------------------------

The `gen-txns` mode also includes some additional logic to add periodic `sleep` commands, to ensure that the transactions are at a rate that the network can handle, are slow enough to avoid filling the txn pool, and are below the rate-limit. This can be configured by the additional flags to the `gen-txns` command. Sample including a `sleep`:

```
mina client send-payment --amount 1 --receiver B62qrsGz3YZ6C6VtTM59XTpox7oh5mSbRFNyudh5aWVrUQYnaQnyFo8 --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qrFkY1paPyf5ov8F17BFBDbretCeHteiKpAvPF5jVreqL8s766S4 --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qk4m2GpWfMhN5jdLeHmZtnrKyMStwWeR3SWsqBaB5XnkYU561Mp3 --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
sleep 200000.000000
mina client send-payment --amount 1 --receiver B62qnQHhU7Tqvo6QRJedeMS5XTpW7NX9HCyrGfAj8puNNydyxQvWmRP --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qrBZXe54uo1UWPnZ9bZe6ExxijvUo4Y3PhQmxe6dSwiKCks2pHvs --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qkR6QVbzR2ebveYat5aAkktm8tZ4f4wh4aKbsgWAz4iE2NRW2gyW --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
mina client send-payment --amount 1 --receiver B62qmCW6buxze1EibPPmjnaTXWCJdLKzD7QeADxV2VyD3fGbs1ZLX1W --sender B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV
```

The output is 1 bash-executable command per line. In an environment with a daemon running and the key chosen as `sender-pk` unlocked, these commands can be run with
```
echo '#!/bin/bash' > txn_commands
_build/default/src/app/batch_generate_keys/batch_generate_keys.exe gen-txns -count 150000 --sender-pk B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV >> txn_commands
chmod +x txn_commands
./txn_commands
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: