### PR TITLE
[WIP] Benchmarking and testing delegation scaling

### DIFF
--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -11,7 +11,9 @@ locals {
   peers = var.additional_peers
 
   coda_vars = {
+    runtimeConfigSrc     = var.runtime_config_src
     runtimeConfig        = var.runtime_config
+    runtimeConfigUri     = var.runtime_config_uri
     image                = var.coda_image
     privkeyPass          = var.block_producer_key_pass
     seedPeers            = local.peers
@@ -34,9 +36,11 @@ locals {
   seed_vars = {
     testnetName = var.testnet_name
     coda = {
-      runtimeConfig = local.coda_vars.runtimeConfig
-      image         = var.coda_image
-      privkeyPass   = var.block_producer_key_pass
+      runtimeConfigSrc = var.runtime_config_src
+      runtimeConfig    = var.runtime_config
+      runtimeConfigUri = var.runtime_config_uri
+      image            = var.coda_image
+      privkeyPass      = var.block_producer_key_pass
       // TODO: Change this to a better name
       seedPeers          = local.peers
       logLevel           = var.log_level

--- a/automation/terraform/modules/kubernetes/testnet/variables.tf
+++ b/automation/terraform/modules/kubernetes/testnet/variables.tf
@@ -108,7 +108,17 @@ variable "additional_peers" {
   default = []
 }
 
+variable "runtime_config_src" {
+  type    = string
+  default = "direct"
+}
+
 variable "runtime_config" {
+  type    = string
+  default = ""
+}
+
+variable "runtime_config_uri" {
   type    = string
   default = ""
 }

--- a/automation/terraform/modules/o1-integration/inputs.tf
+++ b/automation/terraform/modules/o1-integration/inputs.tf
@@ -46,10 +46,6 @@ variable "coda_points_image" {
   type = string
 }
 
-variable "runtime_config" {
-  type = string
-}
-
 variable "snark_worker_replicas" {
   type = number
 }

--- a/automation/terraform/modules/o1-integration/locals.tf
+++ b/automation/terraform/modules/o1-integration/locals.tf
@@ -3,6 +3,10 @@ locals {
   snark_worker_host_port            = 10001
   block_producer_starting_host_port = 10010
 
+  integration_test_bucket    = "o1labs-integration-tests"
+  runtime_config_object_name = "${var.testnet_name}-runtime-config.json"
+  # runtime_config_object_uri   = "https://storage.cloud.google.com/${local.integration_test_bucket}/${local.runtime_config_object_name}"
+
   seed_peer = {
     multiaddr = "/dns4/seed.${var.testnet_name}/tcp/10401/p2p/12D3KooWCoGWacXE4FRwAX8VqhnWVKhz5TTEecWEuGmiNrDt2XLf",
     peerid = "2D3KooWCoGWacXE4FRwAX8VqhnWVKhz5TTEecWEuGmiNrDt2XLf",

--- a/automation/terraform/modules/o1-integration/locals.tf
+++ b/automation/terraform/modules/o1-integration/locals.tf
@@ -4,7 +4,7 @@ locals {
   block_producer_starting_host_port = 10010
 
   integration_test_bucket    = "o1labs-integration-tests"
-  runtime_config_object_name = "${var.testnet_name}-runtime-config.json"
+  runtime_config_object_name = "${filesha256("daemon.json")}.json"
   # runtime_config_object_uri   = "https://storage.cloud.google.com/${local.integration_test_bucket}/${local.runtime_config_object_name}"
 
   seed_peer = {

--- a/automation/terraform/modules/o1-integration/runtime_config.tf
+++ b/automation/terraform/modules/o1-integration/runtime_config.tf
@@ -1,0 +1,6 @@
+resource "google_storage_bucket_object" "runtime_config" {
+  bucket  = local.integration_test_bucket
+  name    = local.runtime_config_object_name
+  # content = var.runtime_config
+  source  = "daemon.json"
+}

--- a/automation/terraform/modules/o1-integration/runtime_config.tf
+++ b/automation/terraform/modules/o1-integration/runtime_config.tf
@@ -4,3 +4,9 @@ resource "google_storage_bucket_object" "runtime_config" {
   # content = var.runtime_config
   source  = "daemon.json"
 }
+
+data "google_storage_object_signed_url" "runtime_config" {
+  provider = "google.gke"
+  bucket   = local.integration_test_bucket
+  path     = local.runtime_config_object_name
+}

--- a/automation/terraform/modules/o1-integration/testnet.tf
+++ b/automation/terraform/modules/o1-integration/testnet.tf
@@ -1,7 +1,6 @@
 module "kubernetes_testnet" {
   providers  = { google = google.gke }
   source     = "../kubernetes/testnet"
-  # depends_on = [google_storage_bucket_object.runtime_config]
 
   use_local_charts    = true
   expose_graphql      = var.deploy_graphql_ingress
@@ -23,11 +22,12 @@ module "kubernetes_testnet" {
   log_snark_work_gossip = true
 
   additional_peers = [local.seed_peer.multiaddr]
-  runtime_config_src = "download"
-  runtime_config_uri = google_storage_bucket_object.runtime_config.media_link
 
-  seed_zone   = "us-west1-a"
-  seed_region = "us-west1"
+  runtime_config_src = "download"
+  runtime_config_uri = data.google_storage_object_signed_url.runtime_config.signed_url
+
+  seed_zone    = "us-west1-a"
+  seed_region  = "us-west1"
   seed_configs = [local.seed_config]
 
   archive_configs = local.archive_node_configs

--- a/automation/terraform/modules/o1-integration/testnet.tf
+++ b/automation/terraform/modules/o1-integration/testnet.tf
@@ -1,6 +1,7 @@
 module "kubernetes_testnet" {
-  providers = { google = google.gke }
-  source    = "../kubernetes/testnet"
+  providers  = { google = google.gke }
+  source     = "../kubernetes/testnet"
+  # depends_on = [google_storage_bucket_object.runtime_config]
 
   use_local_charts    = true
   expose_graphql      = var.deploy_graphql_ingress
@@ -22,7 +23,8 @@ module "kubernetes_testnet" {
   log_snark_work_gossip = true
 
   additional_peers = [local.seed_peer.multiaddr]
-  runtime_config   = var.runtime_config
+  runtime_config_src = "download"
+  runtime_config_uri = google_storage_bucket_object.runtime_config.media_link
 
   seed_zone   = "us-west1-a"
   seed_region = "us-west1"

--- a/dockerfiles/puppeteer-context/mina_daemon_puppeteer.py
+++ b/dockerfiles/puppeteer-context/mina_daemon_puppeteer.py
@@ -104,7 +104,7 @@ def inactive_loop():
         active_daemon_request = False
         break
   finally:
-    server.shutdown()
+    server.server_close()
 
   active_loop()
 

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -74,6 +74,17 @@ spec:
         - name: actual-libp2p
           mountPath: /root/libp2p-keys
       {{- end }}
+      {{- if eq $.Values.coda.runtimeConfigSrc "download" -}}
+      - name: download-runtime-config
+        image: {{ $.Values.coda.image | quote }}
+        command:
+        - bash
+        - -c
+        - curl {{ $.Values.coda.runtimeConfigUri | quote}} -o /config/daemon.json
+        volumeMounts:
+        - name: daemon-config
+          mountPath: /config
+      {{- end }}
       containers:
       {{ if $config.runWithUserAgent -}}
       - name: user-agent
@@ -212,7 +223,7 @@ spec:
           {{- if $.Values.coda.uploadBlocksToGCloud }}
           "-upload-blocks-to-gcloud", "true",
           {{- end }}
-          {{- if $.Values.coda.runtimeConfig }}
+          {{- if ne $.Values.coda.runtimeConfigSrc "" }}
           "-config-file", "/config/daemon.json",
           {{- end -}}
           "-generate-genesis-proof", {{ $.Values.coda.generateGenesisProof | quote }},
@@ -277,7 +288,7 @@ spec:
         - name: gcloud-keyfile
           mountPath: "/gcloud/"
         {{- end }}
-        {{- if $.Values.coda.runtimeConfig }}
+        {{- if ne $.Values.coda.runtimeConfigSrc "" }}
         - name: daemon-config
           mountPath: "/config/"
         {{- end }}
@@ -329,10 +340,15 @@ spec:
         emptyDir: {}
       - name: actual-libp2p
         emptyDir: {}
-      {{- if $.Values.coda.runtimeConfig }}
+      {{- if ne $.Values.coda.runtimeConfigSrc "" }}
       - name: daemon-config
+        {{- if eq $.Values.coda.runtimeConfigSrc "direct" }}
         configMap:
           name: block-producer-daemon-config
+        {{- end }}
+        {{- if eq $.Values.coda.runtimeConfigSrc "download" }}
+        emptyDir: {}
+        {{- end }}
       {{- end }}
       {{- if $.Values.coda.uploadBlocksToGCloud }}
       - name: gcloud-keyfile

--- a/helm/block-producer/templates/genesis-configmap.yaml
+++ b/helm/block-producer/templates/genesis-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.coda.runtimeConfig }}
+{{- if eq $.Values.coda.runtimeConfigSrc "direct" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/seed-node/templates/genesis-configmap.yaml
+++ b/helm/seed-node/templates/genesis-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.coda.runtimeConfig }}
+{{- if eq .Values.coda.runtimeConfigSrc "direct" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -38,6 +38,17 @@ spec:
         - name: actual-libp2p
           mountPath: /root/libp2p-keys
       {{- end }}
+      {{- if eq $.Values.coda.runtimeConfigSrc "download" }}
+      - name: download-runtime-config
+        image: {{ $.Values.coda.image | quote }}
+        command:
+        - bash
+        - -c
+        - curl {{ $.Values.coda.runtimeConfigUri | quote}} -o /config/daemon.json
+        volumeMounts:
+        - name: daemon-config
+          mountPath: /config
+      {{- end }}
       containers:
       - name: coda
         resources:
@@ -68,7 +79,7 @@ spec:
           {{- if $.Values.coda.seedPeersURL }}
           "-peer-list-url", {{ $.Values.coda.seedPeersURL | quote }},
           {{- end -}}
-          {{- if $.Values.coda.runtimeConfig }}
+          {{- if ne $.Values.coda.runtimeConfigSrc "" }}
           "-config-file", "/config/daemon.json",
           {{- end }}
           {{- if $config.libp2pSecret }}
@@ -137,15 +148,20 @@ spec:
         - name: gcloud-keyfile
           mountPath: "/gcloud/"
         {{- end }}
-        {{- if $.Values.coda.runtimeConfig }}
+        {{- if ne $.Values.coda.runtimeConfigSrc "" }}
         - name: daemon-config
           mountPath: "/config/"
         {{- end }}
       volumes:
-      {{- if $.Values.coda.runtimeConfig }}
+      {{- if ne $.Values.coda.runtimeConfigSrc "" }}
       - name: daemon-config
+        {{- if eq $.Values.coda.runtimeConfigSrc "direct" }}
         configMap:
           name: seed-daemon-config
+        {{- end }}
+        {{- if eq $.Values.coda.runtimeConfigSrc "download" }}
+        emptyDir: {}
+        {{- end }}
       {{- end }}
       {{- if $config.privateKeySecret }}
       - name: private-keys

--- a/src/app/benchmarks/dune
+++ b/src/app/benchmarks/dune
@@ -1,7 +1,7 @@
 (executable
  (name main)
  (public_name main)
- (libraries core_bench.inline_benchmarks vrf_lib_tests mina_base)
+ (libraries core_bench.inline_benchmarks vrf_lib_tests mina_base consensus)
  ; the -w list here should be the same as in src/dune
  (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60)
  (instrumentation (backend bisect_ppx))

--- a/src/app/benchmarks/main.ml
+++ b/src/app/benchmarks/main.ml
@@ -7,7 +7,7 @@
 
 open Core_kernel
 
-let available_libraries = ["vrf_lib_tests"; "mina_base"]
+let available_libraries = ["consensus"; "vrf_lib_tests"; "mina_base"]
 
 let run_benchmarks_in_lib libname =
   Core.printf "Running inline tests in library \"%s\"\n%!" libname ;

--- a/src/app/test_executive/archive_node_test.ml
+++ b/src/app/test_executive/archive_node_test.ml
@@ -19,10 +19,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     { default with
       requires_graphql= true (* a few block producers, where few = 4 *)
     ; block_producers=
-        [ {balance= "4000"; timing= Untimed}
-        ; {balance= "9000"; timing= Untimed}
-        ; {balance= "8000"; timing= Untimed}
-        ; {balance= "17000"; timing= Untimed} ]
+        [ {balance= "4000"; timing= Untimed; delegate= None}
+        ; {balance= "9000"; timing= Untimed; delegate= None}
+        ; {balance= "8000"; timing= Untimed; delegate= None}
+        ; {balance= "17000"; timing= Untimed; delegate= None} ]
     ; num_archive_nodes= 1
     ; num_snark_workers= 0
     ; log_precomputed_blocks= true }

--- a/src/app/test_executive/delegation_stress_test.ml
+++ b/src/app/test_executive/delegation_stress_test.ml
@@ -1,0 +1,45 @@
+open Core_kernel
+open Integration_test_lib
+
+module Make (Inputs : Intf.Test.Inputs_intf) = struct
+  open Inputs
+  open Engine
+  open Dsl
+
+  type network = Network.t
+
+  type node = Network.Node.t
+
+  type dsl = Dsl.t
+
+  let delegation_count = 10_000
+
+  let config =
+    let open Test_config in
+    let open Test_config.Account_config in
+    let block_producers = [{balance= "0"; timing= Untimed; delegate= None}] in
+    let delegating_account =
+      {balance= "1000"; timing= Untimed; delegate= Some (Block_producer 0)}
+    in
+    let additional_accounts =
+      List.init delegation_count ~f:(Fn.const delegating_account)
+    in
+    { default with
+      block_producers
+    ; additional_accounts
+        (* this test does not run long enough to require snark work *)
+    ; num_snark_workers= 0 }
+
+  let run network t =
+    let open Malleable_error.Let_syntax in
+    let block_producer = List.nth_exn (Network.block_producers network) 0 in
+    let%bind () =
+      wait_for t (Wait_condition.node_to_initialize block_producer)
+    in
+    (* This tests is the block producer can keep up with the VRF evaluations.
+     * If the block producer were to fall behind the VRF evaluations, we would expect
+     * it to be unable to produce blocks since it wouldn't find the winning slots
+     * in time. *)
+    section "blocks are produced"
+      (wait_for t (Wait_condition.blocks_to_be_produced 6))
+end

--- a/src/app/test_executive/delegation_stress_test.ml
+++ b/src/app/test_executive/delegation_stress_test.ml
@@ -12,14 +12,24 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   type dsl = Dsl.t
 
-  let delegation_count = 10_000
+  let alternate_producer_balance = "20000000"
+
+  let delegater_balance = "1000"
+
+  let delegation_count = 40_000
 
   let config =
     let open Test_config in
     let open Test_config.Account_config in
-    let block_producers = [{balance= "0"; timing= Untimed; delegate= None}] in
+    let block_producers =
+      [ {balance= "0"; timing= Untimed; delegate= None}
+      ; {balance= alternate_producer_balance; timing= Untimed; delegate= None}
+      ]
+    in
     let delegating_account =
-      {balance= "1000"; timing= Untimed; delegate= Some (Block_producer 0)}
+      { balance= delegater_balance
+      ; timing= Untimed
+      ; delegate= Some (Block_producer 0) }
     in
     let additional_accounts =
       List.init delegation_count ~f:(Fn.const delegating_account)
@@ -32,14 +42,24 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let run network t =
     let open Malleable_error.Let_syntax in
-    let block_producer = List.nth_exn (Network.block_producers network) 0 in
-    let%bind () =
-      wait_for t (Wait_condition.node_to_initialize block_producer)
-    in
+    let[@warning "-8"] [bp1; bp2] = Network.block_producers network in
+    let%bind () = wait_for t (Wait_condition.node_to_initialize bp1) in
+    let%bind () = wait_for t (Wait_condition.node_to_initialize bp2) in
     (* This tests is the block producer can keep up with the VRF evaluations.
      * If the block producer were to fall behind the VRF evaluations, we would expect
      * it to be unable to produce blocks since it wouldn't find the winning slots
-     * in time. *)
-    section "blocks are produced"
-      (wait_for t (Wait_condition.blocks_to_be_produced 6))
+     * in time. If the VRF evaluations are starving the async scheduler, we would
+     * expect it to be unable to stay in sync with the other block producer. *)
+    let%bind () =
+      section "blocks are produced by producer with lots of delegations"
+        (wait_for t (Wait_condition.blocks_to_be_produced_by ~node:bp1 6))
+    in
+    section
+      "block producer with lots of delegations is still in sync after \
+       producing some blocks"
+      (wait_for t
+         ( Wait_condition.nodes_to_synchronize [bp1; bp2]
+         |> Wait_condition.with_timeouts
+              ~hard_timeout:(Network_time_span.Literal (Time.Span.of_sec 15.0))
+         ))
 end

--- a/src/app/test_executive/delegation_stress_test.mli
+++ b/src/app/test_executive/delegation_stress_test.mli
@@ -1,0 +1,1 @@
+module Make : Integration_test_lib.Intf.Test.Functor_intf

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -22,8 +22,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       requires_graphql= true
     ; block_producers=
         List.init n ~f:(fun _ ->
-            {Block_producer.balance= block_producer_balance; timing= Untimed}
-        ) }
+            { Account_config.balance= block_producer_balance
+            ; timing= Untimed
+            ; delegate= None } ) }
 
   let wait_for_all_to_initialize ~logger network t =
     let open Malleable_error.Let_syntax in

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -21,7 +21,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   (* TODO: test snark work *)
   let config =
     let open Test_config in
-    let open Test_config.Block_producer in
+    let open Test_config.Account_config in
     let make_timing ~min_balance ~cliff_time ~cliff_amount ~vesting_period
         ~vesting_increment : Mina_base.Account_timing.t =
       let open Currency in
@@ -35,13 +35,14 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     { default with
       requires_graphql= true
     ; block_producers=
-        [ {balance= "4000"; timing= Untimed}
-        ; {balance= "3000"; timing= Untimed}
+        [ {balance= "4000"; timing= Untimed; delegate= None}
+        ; {balance= "3000"; timing= Untimed; delegate= None}
         ; { balance= "1000"
           ; timing=
               make_timing ~min_balance:100_000_000_000 ~cliff_time:4
                 ~cliff_amount:0 ~vesting_period:2
-                ~vesting_increment:50_000_000_000 } ]
+                ~vesting_increment:50_000_000_000
+          ; delegate= None } ]
     ; num_snark_workers= 0 }
 
   let run network t =

--- a/src/app/test_executive/reliability_test.ml
+++ b/src/app/test_executive/reliability_test.ml
@@ -16,13 +16,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
   let config =
     let open Test_config in
-    let open Test_config.Block_producer in
+    let open Test_config.Account_config in
     { default with
       requires_graphql= true
     ; block_producers=
-        [ {balance= "1000"; timing= Untimed}
-        ; {balance= "1000"; timing= Untimed}
-        ; {balance= "1000"; timing= Untimed} ]
+        [ {balance= "1000"; timing= Untimed; delegate= None}
+        ; {balance= "1000"; timing= Untimed; delegate= None}
+        ; {balance= "1000"; timing= Untimed; delegate= None} ]
     ; num_snark_workers= 0 }
 
   let check_common_prefixes ~number_of_blocks:n ~logger chains =

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -47,7 +47,8 @@ let tests : test list =
   *)
   ; ("archive-node", (module Archive_node_test.Make : Intf.Test.Functor_intf))
   ; ("gossip-consis", (module Gossip_consistency.Make : Intf.Test.Functor_intf))
-  ]
+  ; ( "delegation"
+    , (module Delegation_stress_test.Make : Intf.Test.Functor_intf) ) ]
 
 let report_test_errors ~log_error_set ~internal_error_set =
   (* TODO: we should be able to show which sections passed as well *)

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -152,25 +152,21 @@ let report_test_errors ~log_error_set ~internal_error_set =
   (* determine if test is passed/failed and exit accordingly *)
   let test_failed =
     match (log_errors_severity, internal_errors_severity) with
-    | _, `Hard | _, `Soft ->
+    | `Hard, _ | _, `Hard | _, `Soft ->
         true
     (* TODO: re-enable log error checks after libp2p logs are cleaned up *)
-    | `Hard, _ | `Soft, _ | `None, `None ->
+    | `Soft, _ | `None, `None ->
         false
   in
   Print.eprintf "\n" ;
-  let result =
-    if test_failed then (
-      color_eprintf Bash_colors.red
-        "The test has failed. See the above errors for details.\n\n" ;
-      false )
-    else (
-      color_eprintf Bash_colors.green
-        "The test has completed successfully.\n\n" ;
-      true )
-  in
+  if test_failed then
+    color_eprintf Bash_colors.red
+      "The test has failed. See the above errors for details.\n\n"
+  else
+    color_eprintf Bash_colors.green
+      "The test has completed successfully.\n\n" ;
   let%bind () = Writer.(flushed (Lazy.force stderr)) in
-  return result
+  return (not test_failed)
 
 (* TODO: refactor cleanup system (smells like a monad for composing linear resources would help a lot) *)
 

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -163,8 +163,7 @@ let report_test_errors ~log_error_set ~internal_error_set =
     color_eprintf Bash_colors.red
       "The test has failed. See the above errors for details.\n\n"
   else
-    color_eprintf Bash_colors.green
-      "The test has completed successfully.\n\n" ;
+    color_eprintf Bash_colors.green "The test has completed successfully.\n\n" ;
   let%bind () = Writer.(flushed (Lazy.force stderr)) in
   return (not test_failed)
 
@@ -248,7 +247,8 @@ let main inputs =
   in
   [%log spam] "Loading keypairs from keypool" ;
   let network_keypairs =
-    Network_keypair.Pool.load ~logger ~pool_filepath:"keypool" ~size:(Test_config.keypair_count T.config)
+    Network_keypair.Pool.load ~logger ~pool_filepath:"keypool"
+      ~size:(Test_config.keypair_count T.config)
   in
   [%log spam] "Expanding network config" ;
   let network_config =

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -40,7 +40,8 @@
     ppx_optcomp
     ppx_sexp_conv
     ppx_snarky
-    ppx_version))
+    ppx_version
+    ppx_bench))
  (instrumentation (backend bisect_ppx))
  (synopsis "Consensus mechanisms"))
 

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -209,6 +209,7 @@ module Dsl = struct
       ; snarked_ledgers_generated: int
       ; blocks_generated: int
       ; node_initialization: bool String.Map.t
+      ; blocks_generated_by_node: int String.Map.t
       ; gossip_received: Gossip_state.t String.Map.t
       ; best_tips_by_node: State_hash.t String.Map.t }
 
@@ -239,6 +240,8 @@ module Dsl = struct
     val node_to_initialize : Engine.Network.Node.t -> t
 
     val blocks_to_be_produced : int -> t
+
+    val blocks_to_be_produced_by : node:Engine.Network.Node.t -> int -> t
 
     val nodes_to_synchronize : Engine.Network.Node.t list -> t
 

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -24,6 +24,7 @@ module Engine = struct
       -> debug:bool
       -> test_config:Test_config.t
       -> images:Test_config.Container_images.t
+      -> network_keypairs:Network_keypair.t list
       -> t
   end
 

--- a/src/lib/integration_test_lib/network_keypair.ml
+++ b/src/lib/integration_test_lib/network_keypair.ml
@@ -1,14 +1,26 @@
 open Signature_lib
-open Core_kernel
+open Core
 
-type t =
-  { keypair: Keypair.t
-  ; secret_name: string
-  ; public_key_file: string
-  ; private_key_file: string }
-[@@deriving to_yojson]
+[%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t =
+        { keypair: Keypair.Stable.V1.t
+        ; public_key_file: string
+        ; private_key_file: string }
+      [@@deriving to_yojson, bin_io, version]
 
-let create_network_keypair ~keypair ~secret_name =
+      let to_latest = Fn.id
+    end
+  end
+]
+
+(* We use the same password for all the network keypairs (we don't care about
+ * the security of these given this is just for tests).
+ *)
+let password = "naughty blue worm"
+
+let of_keypair keypair =
   let open Keypair in
   let public_key_file =
     Public_key.Compressed.to_base58_check
@@ -19,8 +31,131 @@ let create_network_keypair ~keypair ~secret_name =
     let plaintext =
       Bigstring.to_bytes (Private_key.to_bigstring keypair.private_key)
     in
-    let password = Bytes.of_string "naughty blue worm" in
-    Secrets.Secret_box.encrypt ~plaintext ~password
+    Secrets.Secret_box.encrypt ~plaintext ~password:(Bytes.of_string password)
     |> Secrets.Secret_box.to_yojson |> Yojson.Safe.to_string
   in
-  {keypair; secret_name; public_key_file; private_key_file}
+  {keypair; public_key_file; private_key_file}
+
+let create () = of_keypair (Keypair.create ())
+
+module Pool = struct
+  module Chunk = struct
+    let max_size = 500
+
+    [%%versioned
+      module Stable = struct
+        module V1 = struct
+          type t = Stable.V1.t list
+          [@@deriving bin_io, version]
+
+          let to_latest = Fn.id
+        end
+      end
+    ]
+
+    let size = List.length
+
+    let filename ~pool_filepath ~index = pool_filepath ^/ ("keypool.chunk." ^ Int.to_string index)
+
+    let write chunk ~pool_filepath ~index =
+      let data =
+        let len = Stable.Latest.bin_size_t chunk in
+        let buf = Bin_prot.Common.create_buf len in
+        ignore (Stable.Latest.bin_write_t buf ~pos:0 chunk) ;
+        Bigstring.to_string ~pos:0 ~len buf
+      in
+      Out_channel.write_all (filename ~pool_filepath ~index) ~data
+
+    let extend chunk ~pool_filepath ~index ~count =
+      if List.length chunk + count > max_size then failwith "invalid keypool chunk extension size" ;
+      let chunk' = chunk @ List.init count ~f:(fun _ -> create ()) in
+      write chunk' ~pool_filepath ~index ;
+      chunk'
+
+    let create ~pool_filepath ~index ~size =
+      if size > max_size then failwith "invalid keypool chunk size" ;
+      let chunk = List.init size ~f:(fun _ -> create ()) in
+      write chunk ~pool_filepath ~index ;
+      chunk
+
+    let load ~pool_filepath ~index =
+      Unix.with_file ~mode:[Unix.O_RDONLY] (filename ~pool_filepath ~index) ~f:(fun fd ->
+        let len = Int64.to_int_exn (Unix.fstat fd).st_size in
+        let buf = Bigstring.map_file ~shared:false fd len in
+        Option.value_exn (Stable.bin_read_to_latest_opt buf ~pos_ref:(ref 0)))
+  end
+
+  (** Extends the on-disk network keypair pool by to a specified size. *)
+  let extend ~pool_filepath ~chunks ~count =
+    (* first, we extend any non-filled chunks *)
+    let (remaining_count, filled_chunks) =
+      List.fold_mapi chunks ~init:count ~f:(fun index count chunk ->
+        if Chunk.size chunk < Chunk.max_size then (
+          let space = Chunk.max_size - Chunk.size chunk in
+          let amount_to_add = min space count in
+          let chunk' = Chunk.extend chunk ~count:amount_to_add ~pool_filepath ~index in
+          (count - amount_to_add, chunk'))
+        else
+          (count, chunk))
+    in
+    (* second, we generate additional chunks for any remaining keys *)
+    let rec add_new_chunks remaining index =
+      let chunk_size = min remaining Chunk.max_size in
+      let chunk = Chunk.create ~pool_filepath ~index ~size:chunk_size in
+      let remaining' = remaining - chunk_size in
+      if remaining' > 0 then
+        chunk :: add_new_chunks remaining' (index + 1)
+      else
+        [chunk]
+    in
+    filled_chunks @ add_new_chunks remaining_count (List.length filled_chunks)
+
+  (** Loads the network keypair pool from disk, returning the specified number
+   *  of keypairs. If there are not enough keypairs in the pool, more will be
+   *  generated and saved back to the filesystem for later re-use.
+   *)
+  let load ~logger ~pool_filepath ~size =
+    let minimum_chunks_required = size / Chunk.max_size + if size mod Chunk.max_size > 0 then 1 else 0 in
+    Unix.mkdir_p ~perm:0o776 pool_filepath ;
+    (* This does not attempt to align chunks or deal with missing chunks in the
+     * sequence; I believe this is ok and won't cause any issues.
+     *
+     * I suppose the issue with this could be that, if we don't do this and
+     * corrupt the keypool, we could end up loading duplicat keypairs, which
+     * would be bad.
+     *)
+    let chunk_indices =
+      let chunk_regexp = Re.(compile @@ whole_string @@ seq [str "keypool.chunk."; group (rep1 digit)]) in
+      let rec read_contents dir =
+        match Unix.readdir_opt dir with
+        | None -> []
+        | Some item -> item :: read_contents dir
+      in
+      Unix.opendir pool_filepath
+      |> read_contents
+      |> List.filter_map ~f:(fun item ->
+          Re.exec_opt chunk_regexp item
+          |> Option.map ~f:(fun g ->
+              let index = Int.of_string (Re.Group.get g 1) in
+              index))
+      |> List.sort ~compare:Int.compare
+    in
+    let chunks =
+      List.take chunk_indices minimum_chunks_required
+      |> List.map ~f:(fun index -> Chunk.load ~pool_filepath ~index)
+    in
+    let available_keypair_count = List.fold chunks ~init:0 ~f:(fun acc chunk -> acc + Chunk.size chunk) in
+    let chunks' =
+      if available_keypair_count < size then (
+        let missing_count = size - available_keypair_count in
+        [%log info] "Not enough keypairs in keypool (available keys = $available_count); generating $missing_count keypairs"
+          ~metadata:
+            [ ("available_count", `Int available_keypair_count)
+            ; ("missing_count", `Int missing_count) ] ;
+        extend ~pool_filepath ~chunks ~count:missing_count)
+      else
+        chunks
+    in
+    let keypairs = List.concat (List.take chunks' minimum_chunks_required) in
+    List.take keypairs size
+end

--- a/src/lib/integration_test_lib/network_keypair.ml
+++ b/src/lib/integration_test_lib/network_keypair.ml
@@ -2,18 +2,17 @@ open Signature_lib
 open Core
 
 [%%versioned
-  module Stable = struct
-    module V1 = struct
-      type t =
-        { keypair: Keypair.Stable.V1.t
-        ; public_key_file: string
-        ; private_key_file: string }
-      [@@deriving to_yojson, bin_io, version]
+module Stable = struct
+  module V1 = struct
+    type t =
+      { keypair: Keypair.Stable.V1.t
+      ; public_key_file: string
+      ; private_key_file: string }
+    [@@deriving to_yojson, bin_io, version]
 
-      let to_latest = Fn.id
-    end
+    let to_latest = Fn.id
   end
-]
+end]
 
 (* We use the same password for all the network keypairs (we don't care about
  * the security of these given this is just for tests).
@@ -43,19 +42,18 @@ module Pool = struct
     let max_size = 500
 
     [%%versioned
-      module Stable = struct
-        module V1 = struct
-          type t = Stable.V1.t list
-          [@@deriving bin_io, version]
+    module Stable = struct
+      module V1 = struct
+        type t = Stable.V1.t list [@@deriving bin_io, version]
 
-          let to_latest = Fn.id
-        end
+        let to_latest = Fn.id
       end
-    ]
+    end]
 
     let size = List.length
 
-    let filename ~pool_filepath ~index = pool_filepath ^/ ("keypool.chunk." ^ Int.to_string index)
+    let filename ~pool_filepath ~index =
+      pool_filepath ^/ "keypool.chunk." ^ Int.to_string index
 
     let write chunk ~pool_filepath ~index =
       let data =
@@ -67,7 +65,8 @@ module Pool = struct
       Out_channel.write_all (filename ~pool_filepath ~index) ~data
 
     let extend chunk ~pool_filepath ~index ~count =
-      if List.length chunk + count > max_size then failwith "invalid keypool chunk extension size" ;
+      if List.length chunk + count > max_size then
+        failwith "invalid keypool chunk extension size" ;
       let chunk' = chunk @ List.init count ~f:(fun _ -> create ()) in
       write chunk' ~pool_filepath ~index ;
       chunk'
@@ -79,34 +78,41 @@ module Pool = struct
       chunk
 
     let load ~pool_filepath ~index =
-      Unix.with_file ~mode:[Unix.O_RDONLY] (filename ~pool_filepath ~index) ~f:(fun fd ->
-        let len = Int64.to_int_exn (Unix.fstat fd).st_size in
-        let buf = Bigstring.map_file ~shared:false fd len in
-        Option.value_exn (Stable.bin_read_to_latest_opt buf ~pos_ref:(ref 0)))
+      Unix.with_file ~mode:[Unix.O_RDONLY] (filename ~pool_filepath ~index)
+        ~f:(fun fd ->
+          let len = Int64.to_int_exn (Unix.fstat fd).st_size in
+          let buf = Bigstring.map_file ~shared:false fd len in
+          Option.value_exn (Stable.bin_read_to_latest_opt buf ~pos_ref:(ref 0))
+      )
   end
 
   (** Extends the on-disk network keypair pool by to a specified size. *)
-  let extend ~pool_filepath ~chunks ~count =
+  let extend ~logger ~pool_filepath ~chunks ~count =
     (* first, we extend any non-filled chunks *)
-    let (remaining_count, filled_chunks) =
+    let remaining_count, filled_chunks =
       List.fold_mapi chunks ~init:count ~f:(fun index count chunk ->
-        if Chunk.size chunk < Chunk.max_size then (
-          let space = Chunk.max_size - Chunk.size chunk in
-          let amount_to_add = min space count in
-          let chunk' = Chunk.extend chunk ~count:amount_to_add ~pool_filepath ~index in
-          (count - amount_to_add, chunk'))
-        else
-          (count, chunk))
+          if Chunk.size chunk < Chunk.max_size then (
+            let space = Chunk.max_size - Chunk.size chunk in
+            let amount_to_add = min space count in
+            [%log spam] "Extending chunk from size $size to $new_size"
+              ~metadata:
+                [ ("size", `Int (Chunk.size chunk))
+                ; ("new_size", `Int (Chunk.size chunk + amount_to_add)) ] ;
+            let chunk' =
+              Chunk.extend chunk ~count:amount_to_add ~pool_filepath ~index
+            in
+            (count - amount_to_add, chunk') )
+          else (count, chunk) )
     in
     (* second, we generate additional chunks for any remaining keys *)
     let rec add_new_chunks remaining index =
       let chunk_size = min remaining Chunk.max_size in
+      [%log spam] "Creating new chunk of size $size"
+        ~metadata:[("size", `Int chunk_size)] ;
       let chunk = Chunk.create ~pool_filepath ~index ~size:chunk_size in
       let remaining' = remaining - chunk_size in
-      if remaining' > 0 then
-        chunk :: add_new_chunks remaining' (index + 1)
-      else
-        [chunk]
+      if remaining' > 0 then chunk :: add_new_chunks remaining' (index + 1)
+      else [chunk]
     in
     filled_chunks @ add_new_chunks remaining_count (List.length filled_chunks)
 
@@ -115,7 +121,9 @@ module Pool = struct
    *  generated and saved back to the filesystem for later re-use.
    *)
   let load ~logger ~pool_filepath ~size =
-    let minimum_chunks_required = size / Chunk.max_size + if size mod Chunk.max_size > 0 then 1 else 0 in
+    let minimum_chunks_required =
+      (size / Chunk.max_size) + if size mod Chunk.max_size > 0 then 1 else 0
+    in
     Unix.mkdir_p ~perm:0o776 pool_filepath ;
     (* This does not attempt to align chunks or deal with missing chunks in the
      * sequence; I believe this is ok and won't cause any issues.
@@ -125,36 +133,44 @@ module Pool = struct
      * would be bad.
      *)
     let chunk_indices =
-      let chunk_regexp = Re.(compile @@ whole_string @@ seq [str "keypool.chunk."; group (rep1 digit)]) in
+      let chunk_regexp =
+        Re.(
+          compile @@ whole_string
+          @@ seq [str "keypool.chunk."; group (rep1 digit)])
+      in
       let rec read_contents dir =
         match Unix.readdir_opt dir with
-        | None -> []
-        | Some item -> item :: read_contents dir
+        | None ->
+            []
+        | Some item ->
+            item :: read_contents dir
       in
-      Unix.opendir pool_filepath
-      |> read_contents
+      Unix.opendir pool_filepath |> read_contents
       |> List.filter_map ~f:(fun item ->
-          Re.exec_opt chunk_regexp item
-          |> Option.map ~f:(fun g ->
-              let index = Int.of_string (Re.Group.get g 1) in
-              index))
+             Re.exec_opt chunk_regexp item
+             |> Option.map ~f:(fun g ->
+                    let index = Int.of_string (Re.Group.get g 1) in
+                    index ) )
       |> List.sort ~compare:Int.compare
     in
     let chunks =
       List.take chunk_indices minimum_chunks_required
       |> List.map ~f:(fun index -> Chunk.load ~pool_filepath ~index)
     in
-    let available_keypair_count = List.fold chunks ~init:0 ~f:(fun acc chunk -> acc + Chunk.size chunk) in
+    let available_keypair_count =
+      List.fold chunks ~init:0 ~f:(fun acc chunk -> acc + Chunk.size chunk)
+    in
     let chunks' =
       if available_keypair_count < size then (
         let missing_count = size - available_keypair_count in
-        [%log info] "Not enough keypairs in keypool (available keys = $available_count); generating $missing_count keypairs"
+        [%log info]
+          "Not enough keypairs in keypool (available keys = \
+           $available_count); generating $missing_count keypairs"
           ~metadata:
             [ ("available_count", `Int available_keypair_count)
             ; ("missing_count", `Int missing_count) ] ;
-        extend ~pool_filepath ~chunks ~count:missing_count)
-      else
-        chunks
+        extend ~logger ~pool_filepath ~chunks ~count:missing_count )
+      else chunks
     in
     let keypairs = List.concat (List.take chunks' minimum_chunks_required) in
     List.take keypairs size

--- a/src/lib/integration_test_lib/test_config.ml
+++ b/src/lib/integration_test_lib/test_config.ml
@@ -1,3 +1,5 @@
+type delegation_config = Block_producer of int | Additional_account of int
+
 module Container_images = struct
   type t =
     { coda: string
@@ -7,8 +9,11 @@ module Container_images = struct
     ; points: string }
 end
 
-module Block_producer = struct
-  type t = {balance: string; timing: Mina_base.Account_timing.t}
+module Account_config = struct
+  type t =
+    { balance: string
+    ; timing: Mina_base.Account_timing.t
+    ; delegate: delegation_config option }
 end
 
 type constants =
@@ -25,7 +30,8 @@ type t =
   ; slots_per_sub_window: int
   ; proof_level: Runtime_config.Proof_keys.Level.t
   ; txpool_max_size: int
-  ; block_producers: Block_producer.t list
+  ; block_producers: Account_config.t list
+  ; additional_accounts: Account_config.t list
   ; num_snark_workers: int
   ; num_archive_nodes: int
   ; log_precomputed_blocks: bool
@@ -41,6 +47,7 @@ let default =
   ; proof_level= Full
   ; txpool_max_size= 3000
   ; block_producers= []
+  ; additional_accounts= []
   ; num_snark_workers= 0
   ; num_archive_nodes= 0
   ; log_precomputed_blocks= false

--- a/src/lib/integration_test_lib/test_config.ml
+++ b/src/lib/integration_test_lib/test_config.ml
@@ -38,6 +38,9 @@ type t =
   ; snark_worker_fee: string
   ; snark_worker_public_key: string }
 
+let keypair_count {block_producers; additional_accounts; _} =
+  List.length block_producers + List.length additional_accounts
+
 let default =
   { requires_graphql= false
   ; k= 20

--- a/src/lib/mina_metrics/metric_generators.ml
+++ b/src/lib/mina_metrics/metric_generators.ml
@@ -54,7 +54,7 @@ module Rolling_average (Spec : Metric_spec_intf) () :
     moving_average := None
 
   let update_avg ~avg ~count ~value =
-    ((avg /. count) +. value) *. (count +. 1.0)
+    ((avg *. count) +. value) /. (count +. 1.0)
 
   let update value =
     (moving_average :=

--- a/src/lib/mina_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/mina_metrics.ml
@@ -533,8 +533,55 @@ module Consensus = struct
   *)
 
   let vrf_evaluations : Counter.t =
-    let help = "vrf evaluations performed" in
+    let help = "# of vrf evaluations performed" in
     Counter.v "vrf_evaluations" ~help ~namespace ~subsystem
+
+  let max_vrfs_evaluated_per_slot : Gauge.t =
+    let help = "max vrfs evaluated per slot" in
+    Gauge.v "max_vrfs_evaluated_per_slot" ~help ~namespace ~subsystem
+
+  let full_slot_checks : Counter.t =
+    let help =
+      "# of slot checks performed where the max # of vrfs were evaluated"
+    in
+    Counter.v "full_slot_vrf_checks" ~help ~namespace ~subsystem
+
+  let slot_checks : Counter.t =
+    let help = "# of slot checks performed" in
+    Counter.v "slot_checks" ~help ~namespace ~subsystem
+
+  module Avg_full_slot_check_time_ms =
+    Rolling_average (struct
+        let subsystem = subsystem
+
+        let name = "avg_full_slot_check_time_ms"
+
+        let help =
+          "avg time elapsed performing slot checks where the max # of vrfs \
+           were evaluated"
+      end)
+      ()
+
+  module Avg_slot_check_time_ms =
+    Rolling_average (struct
+        let subsystem = subsystem
+
+        let name = "avg_slot_check_time_ms"
+
+        let help = "avg time elapsed performing slot checks"
+      end)
+      ()
+
+  let record_slot_check ~time_elapsed_ms ~vrfs_evaluated_in_slot
+      ~max_vrfs_to_evaluate_in_slot =
+    Counter.inc vrf_evaluations (Float.of_int vrfs_evaluated_in_slot) ;
+    Gauge.set max_vrfs_evaluated_per_slot
+      (Float.of_int max_vrfs_to_evaluate_in_slot) ;
+    Counter.inc_one slot_checks ;
+    Avg_slot_check_time_ms.update time_elapsed_ms ;
+    if vrfs_evaluated_in_slot = max_vrfs_to_evaluate_in_slot then (
+      Counter.inc_one full_slot_checks ;
+      Avg_full_slot_check_time_ms.update time_elapsed_ms )
 
   let staking_keypairs : Gauge.t =
     let help = "# of actively staking keypairs" in


### PR DESCRIPTION
In this PR:

- new consensus slot check metrics
  - this involved some restructuring of the slot check code; please review carefully to ensure no new bugs are introduced
- support for additional accounts and delegations in test configs
- keypair pool for caching and reuse of encrypted keypairs (required to reasonably implement tests with large ledgers)
  - TODO: wire this into CI cache logic
- support runtime configs of unbounded sizes in deployment automation
  - this works by uploading runtime configs to gcloud storage and generating signed urls the init containers use to download these configs
- new test for stress testing delegations
  - TODO: collect metrics and assert threshold?
- WIP: fixes for integration test issues from upstream