### PR TITLE
`get_ledger` in system thread for export

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -917,18 +917,18 @@ let export_ledger =
         (optional string))
   in
   let ledger_kind =
+    let available_ledgers =
+      [ "staged-ledger"
+      ; "snarked-ledger"
+      ; "staking-epoch-ledger"
+      ; "next-epoch-ledger" ]
+    in
     let t =
       Command.Param.Arg_type.of_alist_exn
-        (List.map
-           [ "staged-ledger"
-           ; "snarked-ledger"
-           ; "staking-epoch-ledger"
-           ; "next-epoch-ledger" ] ~f:(fun s -> (s, s)))
+        (List.map available_ledgers ~f:(fun s -> (s, s)))
     in
-    Command.Param.(
-      anon
-        ( "staged-ledger|snarked-ledger|staking-epoch-ledger|next-epoch-ledger"
-        %: t ))
+    let ledger_args = String.concat ~sep:"|" available_ledgers in
+    Command.Param.(anon (ledger_args %: t))
   in
   let plaintext_flag = Cli_lib.Flag.plaintext in
   let flags = Args.zip3 state_hash_flag plaintext_flag ledger_kind in

--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -331,7 +331,10 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
     ; implement Daemon_rpcs.Clear_hist_status.rpc (fun () flag ->
           Mina_commands.clear_hist_status ~flag coda )
     ; implement Daemon_rpcs.Get_ledger.rpc (fun () lh ->
-          Mina_lib.get_ledger coda lh |> return )
+          (* getting the ledger may take more time than a heartbeat timeout
+             run in thread to allow RPC heartbeats to proceed
+          *)
+          Async.In_thread.run (fun () -> Mina_lib.get_ledger coda lh) )
     ; implement Daemon_rpcs.Get_snarked_ledger.rpc (fun () lh ->
           Mina_lib.get_snarked_ledger coda lh |> return )
     ; implement Daemon_rpcs.Get_staking_ledger.rpc (fun () which ->


### PR DESCRIPTION
The RPC call to export the staged ledger was timing out, because RPC heartbeats could not be processed.

Wrapping the daemon-side call to `get_ledger` in a system thread seems to allow the heartbeats to continue, and the ledger export succeeds, though it takes time well beyond the RPC heartbeat timeout.

This call is only reading data, so I don't think there's a concern with data shared between threads.

Also cleaned up the flag processing for `ledger export` to make it more maintainable.

Tested by compiling with the `mainnet` profile, running the node locally, exporting the ledger. That failed without the changes in this PR.

Closes #8988.