### PR TITLE
Bump marlin submodule

### DIFF
--- a/src/lib/marlin_plonk_bindings/stubs/src/index_serialization.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/index_serialization.rs
@@ -6,7 +6,7 @@ use algebra::{
 
 use commitment_dlog::{
     commitment::{CommitmentCurve, CommitmentField, PolyComm},
-    srs::SRS,
+    srs::{SRS, SRSValue as PlonkSRSValue},
 };
 use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations, Radix2EvaluationDomain as Domain};
 use oracle::poseidon::ArithmeticSpongeParams;
@@ -14,9 +14,7 @@ use plonk_circuits::{
     constraints::{zk_polynomial, zk_w, ConstraintSystem as PlonkConstraintSystem},
     domains::EvaluationDomains as PlonkEvaluationDomains,
 };
-use plonk_protocol_dlog::index::{
-    Index as PlonkIndex, SRSValue as PlonkSRSValue, VerifierIndex as PlonkVerifierIndex,
-};
+use plonk_protocol_dlog::index::{Index as PlonkIndex, VerifierIndex as PlonkVerifierIndex};
 use std::io::{Error, ErrorKind, Read, Result as IoResult, Write};
 
 pub fn write_vec<A: ToBytes, W: Write>(v: &Vec<A>, mut writer: W) -> IoResult<()> {

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_index.rs
@@ -11,8 +11,8 @@ use plonk_circuits::wires::{Col::*, GateWires, Wire};
 
 use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 
-use commitment_dlog::srs::SRS;
-use plonk_protocol_dlog::index::{Index as DlogIndex, SRSSpec};
+use commitment_dlog::srs::{SRS, SRSSpec};
+use plonk_protocol_dlog::index::Index as DlogIndex;
 
 use std::{
     fs::{File, OpenOptions},

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -14,9 +14,9 @@ use algebra::{
 
 use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 
-use commitment_dlog::{commitment::PolyComm, srs::SRS};
+use commitment_dlog::{commitment::PolyComm, srs::{SRS, SRSValue}};
 use plonk_circuits::constraints::{zk_polynomial, zk_w, ConstraintSystem};
-use plonk_protocol_dlog::index::{SRSValue, VerifierIndex as DlogVerifierIndex};
+use plonk_protocol_dlog::index::{VerifierIndex as DlogVerifierIndex};
 
 use std::{
     fs::{File, OpenOptions},

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_index.rs
@@ -11,8 +11,8 @@ use plonk_circuits::wires::{Col::*, GateWires, Wire};
 
 use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 
-use commitment_dlog::srs::SRS;
-use plonk_protocol_dlog::index::{Index as DlogIndex, SRSSpec};
+use commitment_dlog::srs::{SRS, SRSSpec};
+use plonk_protocol_dlog::index::Index as DlogIndex;
 
 use std::{
     fs::{File, OpenOptions},

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
@@ -14,9 +14,9 @@ use algebra::{
 
 use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 
-use commitment_dlog::{commitment::PolyComm, srs::SRS};
+use commitment_dlog::{commitment::PolyComm, srs::{SRS, SRSValue}};
 use plonk_circuits::constraints::{zk_polynomial, zk_w, ConstraintSystem};
-use plonk_protocol_dlog::index::{SRSValue, VerifierIndex as DlogVerifierIndex};
+use plonk_protocol_dlog::index::{VerifierIndex as DlogVerifierIndex};
 
 use std::{
     fs::{File, OpenOptions},


### PR DESCRIPTION
This PR pulls in the latest changes from the marlin repo.

This PR is a no-op; the changes here are only to respect the some rust code that was moved in the marlin repo.

Tested by syncing a daemon to devnet.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
