### PR TITLE
Better doc for peer-list-file flag

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -299,8 +299,8 @@ let setup_daemon logger =
   and libp2p_peer_list_file =
     flag "--peer-list-file" ~aliases:["peer-list-file"]
       ~doc:
-        "/ip4/IPADDR/tcp/PORT/p2p/PEERID initial \"bootstrap\" peers for \
-         discovery inside a file delimited by new-lines (\\n)"
+        "PATH path to a file containing \"bootstrap\" peers for discovery, \
+         one multiaddress per line"
       (optional string)
   and seed_peer_list_url =
     flag "--peer-list-url" ~aliases:["peer-list-url"]


### PR DESCRIPTION
The docstring for `--peer-list-file` appeared to suggest that it takes a multiaddress as an argument, rather than a file.

Change the docstring to indicate that it's a path to a file that's needed.

Tested by building mina.exe, examining `daemon -help`.