### PR TITLE
Fix/8956 bigint256 serialization

### DIFF
--- a/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
@@ -114,7 +114,7 @@ pub fn caml_bigint_256_to_bytes(x: ocaml::Pointer<BigInteger256>) -> ocaml::Valu
     let x_ptr: *const BigInteger256 = x.as_ref();
     unsafe {
         let mut input_bytes = vec![];
-        (*x_ptr).serialize(&mut input_bytes).expect("caml_bigint_256_to_bytes, serialize failed");
+        (*x_ptr).serialize(&mut input_bytes).expect("serialize failed");
         core::ptr::copy_nonoverlapping(input_bytes.as_ptr(), ocaml::sys::string_val(str), input_bytes.len());
     }
     ocaml::Value(str)
@@ -126,10 +126,7 @@ pub fn caml_bigint_256_of_bytes(x: &[u8]) -> Result<BigInteger256, ocaml::Error>
     if x.len() != len {
         ocaml::Error::failwith("caml_bigint_256_of_bytes")?;
     };
-    match BigInteger256::deserialize(&mut &x[..]) {
-        Ok(b) => Ok(b),
-        Err(_) => Err(ocaml::Error::invalid_argument("caml_bigint_256_of_bytes, deserialize failed").err().unwrap())
-    }
+    BigInteger256::deserialize(&mut &x[..]).map_err(|_| ocaml::Error::Message("deserialization error"))
 }
 
 #[ocaml::func]

--- a/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
@@ -114,7 +114,7 @@ pub fn caml_bigint_256_to_bytes(x: ocaml::Pointer<BigInteger256>) -> ocaml::Valu
     let x_ptr: *const BigInteger256 = x.as_ref();
     unsafe {
         let mut input_bytes = vec![];
-        (*x_ptr).serialize(&mut input_bytes).expect("serialize failed");
+        (*x_ptr).serialize(&mut input_bytes).expect("caml_bigint_256_to_bytes, serialize failed");
         core::ptr::copy_nonoverlapping(input_bytes.as_ptr(), ocaml::sys::string_val(str), input_bytes.len());
     }
     ocaml::Value(str)
@@ -126,8 +126,10 @@ pub fn caml_bigint_256_of_bytes(x: &[u8]) -> Result<BigInteger256, ocaml::Error>
     if x.len() != len {
         ocaml::Error::failwith("caml_bigint_256_of_bytes")?;
     };
-    let x = BigInteger256::deserialize(&mut &x[..]).expect("deserialize failed");
-    Ok(x)
+    match BigInteger256::deserialize(&mut &x[..]) {
+        Ok(b) => Ok(b),
+        Err(_) => Err(ocaml::Error::invalid_argument("caml_bigint_256_of_bytes, deserialize failed").err().unwrap())
+    }
 }
 
 #[ocaml::func]

--- a/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
@@ -1,4 +1,6 @@
 use algebra::biginteger::{BigInteger, BigInteger256};
+use algebra::CanonicalSerialize as _;
+use algebra::CanonicalDeserialize as _;
 use num_bigint::BigUint;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::convert::TryInto;
@@ -111,7 +113,9 @@ pub fn caml_bigint_256_to_bytes(x: ocaml::Pointer<BigInteger256>) -> ocaml::Valu
     let str = unsafe { ocaml::sys::caml_alloc_string(len) };
     let x_ptr: *const BigInteger256 = x.as_ref();
     unsafe {
-        core::ptr::copy_nonoverlapping(x_ptr as *const u8, ocaml::sys::string_val(str), len);
+        let mut input_bytes = vec![];
+        (*x_ptr).serialize(&mut input_bytes).unwrap();
+        core::ptr::copy_nonoverlapping(input_bytes.as_ptr(), ocaml::sys::string_val(str), input_bytes.len());
     }
     ocaml::Value(str)
 }
@@ -122,7 +126,7 @@ pub fn caml_bigint_256_of_bytes(x: &[u8]) -> Result<BigInteger256, ocaml::Error>
     if x.len() != len {
         ocaml::Error::failwith("caml_bigint_256_of_bytes")?;
     };
-    let x = unsafe { *(x.as_ptr() as *const BigInteger256) };
+    let x = BigInteger256::deserialize(&mut &x[..]).unwrap();
     Ok(x)
 }
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/bigint_256.rs
@@ -114,7 +114,7 @@ pub fn caml_bigint_256_to_bytes(x: ocaml::Pointer<BigInteger256>) -> ocaml::Valu
     let x_ptr: *const BigInteger256 = x.as_ref();
     unsafe {
         let mut input_bytes = vec![];
-        (*x_ptr).serialize(&mut input_bytes).unwrap();
+        (*x_ptr).serialize(&mut input_bytes).expect("serialize failed");
         core::ptr::copy_nonoverlapping(input_bytes.as_ptr(), ocaml::sys::string_val(str), input_bytes.len());
     }
     ocaml::Value(str)
@@ -126,7 +126,7 @@ pub fn caml_bigint_256_of_bytes(x: &[u8]) -> Result<BigInteger256, ocaml::Error>
     if x.len() != len {
         ocaml::Error::failwith("caml_bigint_256_of_bytes")?;
     };
-    let x = BigInteger256::deserialize(&mut &x[..]).unwrap();
+    let x = BigInteger256::deserialize(&mut &x[..]).expect("deserialize failed");
     Ok(x)
 }
 


### PR DESCRIPTION
Going with the option (3) from #8956 we make sure to explicitly serialize to/from little-endian.
Closes #8956
