### PR TITLE
docs: update submodules recursively

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -22,7 +22,7 @@ The short version:
 1.  Start with Ubuntu 18 or run it in a [virtual machine](https://www.osboxes.org/ubuntu/)
 2.  Set github repos to pull and push over ssh: `git config --global url.ssh://git@github.com/.insteadOf https://github.com/`
     - To push branches to repos in the MinaProtocol or o1-labs organisations, you must complete this step. These repositories do not accept the password authentication used by the https URLs.
-3.  Pull in our submodules: `git submodule update --init`
+3.  Pull in our submodules: `git submodule update --init --recursive`
     - This might fail with `git@github.com: Permission denied (publickey).`. If that happens it means
       you need to [set up SSH keys on your machine](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
 4.  Run `git config --local --add submodule.recurse true`


### PR DESCRIPTION
Since the [zexe repository](https://github.com/o1-labs/zexe/tree/21a9eb6948083dcad7aa21c61da6feac05e28319) is a submodule of the [marlin repository](https://github.com/o1-labs/marlin). We need to resolve the git submodules recursively otherwise we cannot build the project because `zexe` will be missing.
