### PR TITLE
Enable `dune utop src/lib/mina_base`

### DIFF
--- a/src/external/ocaml-rocksdb/dune
+++ b/src/external/ocaml-rocksdb/dune
@@ -2,7 +2,6 @@
     (name rocks)
     (public_name rocks)
     (no_dynlink)
-    (modes native)
     (libraries ctypes ctypes.foreign)
     (modules (:standard \ rocks_linker_flags_gen rocks_test))
     (c_library_flags (:standard (:include flags.sexp)))


### PR DESCRIPTION
This PR is a no-op for normal compilation.

This tweaks the `dune` file for the rocksdb library so that it can be built in bytecode mode as well as native mode, allowing `mina_base` and other libraries that depend on it to be loaded by utop.

Found as part of testing #9022.

Verified by running `dune utop src/lib/mina_base`.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
