### PR TITLE
Add timestamp to epoch ledger files in GCloud

### DIFF
--- a/dockerfiles/scripts/cron_job_dump_ledger.sh
+++ b/dockerfiles/scripts/cron_job_dump_ledger.sh
@@ -38,23 +38,23 @@ done
 mina ledger export next-epoch-ledger > next_epoch_ledger.json
 echo "next epoch ledger dumped!"
 
-# DATE="$(date +%F_%H%M)"
+DATE="$(date +%F_%H%M)"
 #extract the epoch number out of mina client status.  if the output format of mina client status changes, then this is gonna break
 EPOCHNUM="$(mina client status | grep "Best tip consensus time" | grep -o "epoch=[0-9]*" | sed "s/[^0-9]*//g" )"
 
 # rename the file in the required file name format
 STAKING_HASH="$(mina ledger hash --ledger-file staking_epoch_ledger.json)"
 STAKING_MD5="$(md5sum staking_epoch_ledger.json | cut -d " " -f 1 )"
-LEDGER_FILENAME=staking-"$EPOCHNUM"-"$STAKING_HASH"-"$STAKING_MD5".json
+LEDGER_FILENAME=staking-"$EPOCHNUM"-"$STAKING_HASH"-"$STAKING_MD5"-"$DATE".json
 mv ./staking_epoch_ledger.json ./$LEDGER_FILENAME
 
 NEXT_STAKING_HASH="$(mina ledger hash --ledger-file next_epoch_ledger.json)"
 NEXT_STAKING_MD5="$(md5sum next_epoch_ledger.json | cut -d " " -f 1 )"
-NEXT_FILENAME=next-staking-"$EPOCHNUM"-"$NEXT_STAKING_HASH"-"$NEXT_STAKING_MD5".json
+NEXT_FILENAME=next-staking-"$EPOCHNUM"-"$NEXT_STAKING_HASH"-"$NEXT_STAKING_MD5"-"$DATE".json
 mv ./next_epoch_ledger.json ./$NEXT_FILENAME
 
 EXPORTED_LOGS="local-logs"
-LOGS_FILENAME="daemon-logs-epoch-$EPOCHNUM.tgz"
+LOGS_FILENAME="daemon-logs-epoch-$EPOCHNUM-"$DATE".tgz"
 mina client export-local-logs --tarfile $EXPORTED_LOGS
 mv /root/.mina-config/exported_logs/$EXPORTED_LOGS.tar.gz $LOGS_FILENAME
 

--- a/helm/staking-ledger-cron/mainnet-dump-staking-ledger-cronjob.yaml
+++ b/helm/staking-ledger-cron/mainnet-dump-staking-ledger-cronjob.yaml
@@ -38,16 +38,17 @@ spec:
                done;
                mina ledger export next-epoch-ledger>next_epoch_ledger.json;
                echo "next epoch ledger dumped!";
+               DATE="$(date +%F_%H%M)"
                EPOCHNUM="$(mina client status|grep "Best tip consensus time"|grep -o "epoch=[0-9]*"|sed "s/[^0-9]*//g")";
                STAKING_HASH="$(mina ledger hash --ledger-file staking_epoch_ledger.json)";
                STAKING_MD5="$(md5sum staking_epoch_ledger.json|cut -d " " -f 1)";
-               LEDGER_FILENAME=staking-"$EPOCHNUM"-"$STAKING_HASH"-"$STAKING_MD5".json;
+               LEDGER_FILENAME=staking-"$EPOCHNUM"-"$STAKING_HASH"-"$STAKING_MD5"-"$DATE".json;
                mv ./staking_epoch_ledger.json ./$LEDGER_FILENAME;NEXT_STAKING_HASH="$(mina ledger hash --ledger-file next_epoch_ledger.json)";
                NEXT_STAKING_MD5="$(md5sum next_epoch_ledger.json|cut -d " " -f 1)";
-               NEXT_FILENAME=next-staking-"$EPOCHNUM"-"$NEXT_STAKING_HASH"-"$NEXT_STAKING_MD5".json;
+               NEXT_FILENAME=next-staking-"$EPOCHNUM"-"$NEXT_STAKING_HASH"-"$NEXT_STAKING_MD5"-"$DATE".json;
                mv ./next_epoch_ledger.json ./$NEXT_FILENAME;
                EXPORTED_LOGS="local-logs";
-               LOGS_FILENAME="daemon-logs-epoch-$EPOCHNUM.tgz";
+               LOGS_FILENAME="daemon-logs-epoch-$EPOCHNUM-"$DATE".tgz";
                mina client export-local-logs --tarfile $EXPORTED_LOGS;
                mv /root/.mina-config/exported_logs/$EXPORTED_LOGS.tar.gz $LOGS_FILENAME;
                echo "upload to a GCP cloud storage bucket";


### PR DESCRIPTION
Add timestamp to epoch ledgers (and daemon logs) saved to GCloud by cron job.

The existing cron job saved these files at the beginning of epochs, then subsequent runs would fail, because the saved files could not be deleted. That meant, if the first run produced bogus results, we'd never have valid results.

Tested by running the cron job manually, inspecting the results in GCloud.

Clients of these files should be able to select a valid one.