### PR TITLE
[hotfix] Revert staged ledger diff changes

### DIFF
--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -35,7 +35,7 @@ RUN apt-get -y update && \
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
   && apt-get update \
-  && apt-get install -y google-cloud-sdk
+  && apt-get install -y google-cloud-sdk kubectl
 
 # Mina daemon package
 # jemalloc is also installed automatically here to match the package dependencies for this $deb_codename

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1568,7 +1568,8 @@ module T = struct
         (*There's enough work. Check if they satisfy other constraints*)
         Resources.budget_sufficient resources
       then
-        if Resources.worked_more ~constraint_constants resources then
+        if Resources.space_constraint_satisfied resources then (resources, log)
+        else if Resources.worked_more ~constraint_constants resources then
           (*There are too many fee_transfers(from the proofs) occupying the slots. discard one and check*)
           let resources', work_opt =
             Resources.discard_last_work ~constraint_constants resources
@@ -1577,8 +1578,6 @@ module T = struct
             (Option.value_map work_opt ~default:log ~f:(fun work ->
                  Diff_creation_log.discard_completed_work `Extra_work work log
              ))
-        else if Resources.space_constraint_satisfied resources then
-          (resources, log)
         else
           (*Well, there's no space; discard a user command *)
           let resources', uc_opt = Resources.discard_user_command resources in


### PR DESCRIPTION
Block production failed with a [diff application error](https://console.cloud.google.com/logs/viewer?interval=CUSTOM&project=o1labs-192920&minLogLevel=0&expandAll=false&timestamp=2021-06-17T06:03:23.367000000Z&customFacets=jsonPayload.metadata.proof_count,jsonPayload.metadata.txn_count,jsonPayload.metadata.error_extra.expected_nonce,jsonPayload.metadata.error_extra.nonce,jsonPayload.metadata.cmd%5B1%5D.signer,jsonPayload.metadata.cmd%5B1%5D.payload.common.nonce,jsonPayload.metadata.rate_limiter.by_peer_id%5B0%5D%5B0%5D,jsonPayload.metadata.rate_limiter.by_peer_id%5B0%5D%5B1%5D.capacity_used,jsonPayload.metadata.work_ids,jsonPayload.metadata.reorg_best_tip,jsonPayload.metadata.added_transitions%5B0%5D.protocol_state.body.consensus_state.curr_global_slot.slot_number,jsonPayload.metadata.added_transitions%5B0%5D.protocol_state.body.consensus_state.blockchain_length&limitCustomFacetWidth=true&scrollTimestamp=2021-06-17T03:36:09.482384191Z&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22o1labs-192920%22%0Aresource.labels.location%3D%22us-east4%22%0Aresource.labels.cluster_name%3D%22coda-infra-east4%22%0Aresource.labels.namespace_name%3D%22devnet2%22%0Aresource.labels.pod_name:%22whale-block-producer-2%22%0Aresource.labels.container_name%3D%22coda%22%0A&dateRangeStart=2021-06-17T03:36:06.579Z&dateRangeEnd=2021-06-17T03:36:10.592Z). 
This is due to removing extra work which broke an invariant that any work added (to the first partition of the scan state) later on for coinbase transaction won't break space/work constraints. The fix will be to remove that invariant but I think it is a high impact change and the current diff creation is working fine. So reverting the change from this release.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
