### PR TITLE
Bump marlin submodule

### DIFF
--- a/scripts/zexe-standardize.sh
+++ b/scripts/zexe-standardize.sh
@@ -5,6 +5,6 @@ set -eo pipefail
 echo "--- zexe standardize"
 # Mac uses an ancient sed that needs an extra argument to -i..
 case "$(uname -s)" in
-    Darwin*) sed -i "" 's/+bmi2,+adx/-bmi2,-adx/g' src/lib/marlin/zexe/snarky-bn382/dune src/lib/marlin_plonk_bindings/stubs/dune;;
-    *) sed -i 's/+bmi2,+adx/-bmi2,-adx/g' src/lib/marlin/zexe/snarky-bn382/dune src/lib/marlin_plonk_bindings/stubs/dune;;
+    Darwin*) sed -i "" 's/+bmi2,+adx/-bmi2,-adx/g' src/lib/marlin_plonk_bindings/stubs/dune;;
+    *) sed -i 's/+bmi2,+adx/-bmi2,-adx/g' src/lib/marlin_plonk_bindings/stubs/dune;;
 esac

--- a/src/lib/marlin_plonk_bindings/stubs/Cargo.toml
+++ b/src/lib/marlin_plonk_bindings/stubs/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib"]
 ################################# Dependencies ################################
 
 [dependencies]
-groupmap = { path = "../../marlin/zexe/groupmap" }
+groupmap = { path = "../../marlin/groupmap" }
 libc = { version = "0.2.0" }
 algebra = { path = "../../marlin/zexe/algebra", features = [ "asm", "parallel", "pasta", "ocaml_types" ] }
 ff-fft = { path = "../../marlin/zexe/ff-fft", features = [ "parallel" ] }

--- a/src/lib/marlin_plonk_bindings/stubs/Cargo.toml
+++ b/src/lib/marlin_plonk_bindings/stubs/Cargo.toml
@@ -26,16 +26,11 @@ rayon = { version = "1" }
 ocaml = { version = "0.18.1" }
 
 oracle = { path = "../../marlin/oracle" }
-dlog_solver = { path = "../../marlin/dlog_solver" }
-marlin_circuits = { path = "../../marlin/circuits/marlin" }
 plonk_circuits = { path = "../../marlin/circuits/plonk", features = [ "ocaml_types" ] }
 
-commitment_pairing = { path = "../../marlin/pairing/commitment" }
-marlin_protocol_pairing = { path = "../../marlin/pairing/marlin" }
-
 commitment_dlog = { path = "../../marlin/dlog/commitment", features = [ "ocaml_types" ] }
-marlin_protocol_dlog = { path = "../../marlin/dlog/marlin/" }
 plonk_protocol_dlog = { path = "../../marlin/dlog/plonk", features = [ "ocaml_types" ] }
+mina-curves = { path = "../../marlin/curves" }
 
 [profile.release]
 debug = true

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp.rs
@@ -1,8 +1,8 @@
 use crate::bigint_256;
 use algebra::biginteger::BigInteger256;
+use mina_curves::pasta::fp::{Fp, FpParameters as Fp_params};
 use algebra::{
     fields::{Field, FpParameters, PrimeField, SquareRootField},
-    pasta::fp::{Fp, FpParameters as Fp_params},
     FftField, One, UniformRand, Zero,
 };
 use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_index.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use algebra::pasta::{
+use mina_curves::pasta::{
     vesta::{Affine as GAffine, VestaParameters},
     pallas::Affine as GAffineOther,
     fp::Fp,

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_oracles.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_oracles.rs
@@ -1,4 +1,4 @@
-use algebra::pasta::{
+use mina_curves::pasta::{
     vesta::{Affine as GAffine, VestaParameters},
     fp::Fp,
 };

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -1,10 +1,10 @@
-use algebra::{
-    curves::AffineCurve,
-    pasta::{
+use mina_curves::pasta::{
         vesta::{Affine as GAffine, VestaParameters},
         fp::Fp,
         fq::Fq,
-    },
+};
+use algebra::{
+    curves::AffineCurve,
     One,
 };
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -6,9 +6,9 @@ use crate::plonk_verifier_index::{
 };
 use crate::pasta_fp_plonk_index::CamlPastaFpPlonkIndexPtr;
 use crate::pasta_fp_urs::CamlPastaFpUrs;
+use mina_curves::pasta::{vesta::Affine as GAffine, pallas::Affine as GAffineOther, fp::Fp};
 use algebra::{
     curves::AffineCurve,
-    pasta::{vesta::Affine as GAffine, pallas::Affine as GAffineOther, fp::Fp},
     One,
 };
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_urs.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_urs.rs
@@ -1,7 +1,5 @@
-use algebra::{
-    pasta::{vesta::Affine as GAffine, fp::Fp},
-    One, Zero,
-};
+use mina_curves::pasta::{vesta::Affine as GAffine, fp::Fp};
+use algebra::{One, Zero};
 use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations};
 
 use commitment_dlog::{

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_vector.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_vector.rs
@@ -1,5 +1,5 @@
 use crate::caml_pointer::{self, CamlPointer};
-use algebra::pasta::fp::Fp;
+use mina_curves::pasta::fp::Fp;
 
 pub type CamlPastaFpVector = CamlPointer<Vec<Fp>>;
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq.rs
@@ -1,8 +1,8 @@
 use crate::bigint_256;
 use algebra::biginteger::BigInteger256;
+use mina_curves::pasta::fq::{Fq, FqParameters as Fq_params};
 use algebra::{
     fields::{Field, FpParameters, PrimeField, SquareRootField},
-    pasta::fq::{Fq, FqParameters as Fq_params},
     FftField, One, UniformRand, Zero,
 };
 use ff_fft::{EvaluationDomain, Radix2EvaluationDomain as Domain};

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_index.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use algebra::pasta::{
+use mina_curves::pasta::{
     vesta::Affine as GAffineOther,
     pallas::{Affine as GAffine, PallasParameters},
     fq::Fq,

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_oracles.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_oracles.rs
@@ -1,4 +1,4 @@
-use algebra::pasta::{
+use mina_curves::pasta::{
     pallas::{Affine as GAffine, PallasParameters},
     fq::Fq,
 };

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -1,10 +1,10 @@
+use mina_curves::pasta::{
+    pallas::{Affine as GAffine, PallasParameters},
+    fp::Fp,
+    fq::Fq,
+};
 use algebra::{
     curves::AffineCurve,
-    pasta::{
-        pallas::{Affine as GAffine, PallasParameters},
-        fp::Fp,
-        fq::Fq,
-    },
     One,
 };
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
@@ -6,9 +6,9 @@ use crate::plonk_verifier_index::{
 };
 use crate::pasta_fq_plonk_index::CamlPastaFqPlonkIndexPtr;
 use crate::pasta_fq_urs::CamlPastaFqUrs;
+use mina_curves::pasta::{vesta::Affine as GAffineOther, pallas::Affine as GAffine, fq::Fq};
 use algebra::{
     curves::AffineCurve,
-    pasta::{vesta::Affine as GAffineOther, pallas::Affine as GAffine, fq::Fq},
     One,
 };
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_urs.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_urs.rs
@@ -1,7 +1,5 @@
-use algebra::{
-    pasta::{pallas::Affine as GAffine, fq::Fq},
-    One, Zero,
-};
+use mina_curves::pasta::{pallas::Affine as GAffine, fq::Fq};
+use algebra::{One, Zero};
 use ff_fft::{DensePolynomial, EvaluationDomain, Evaluations};
 
 use commitment_dlog::{

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_vector.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_vector.rs
@@ -1,5 +1,5 @@
 use crate::caml_pointer::{self, CamlPointer};
-use algebra::pasta::fq::Fq;
+use mina_curves::pasta::fq::Fq;
 
 pub type CamlPastaFqVector = CamlPointer<Vec<Fq>>;
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_pallas.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_pallas.rs
@@ -1,10 +1,10 @@
+use mina_curves::pasta::{
+    pallas::{Affine as GAffine, Projective as GProjective},
+    fp::Fp,
+    fq::Fq,
+};
 use algebra::{
     curves::{AffineCurve, ProjectiveCurve},
-    pasta::{
-        pallas::{Affine as GAffine, Projective as GProjective},
-        fp::Fp,
-        fq::Fq,
-    },
     One, UniformRand,
 };
 use rand::rngs::StdRng;

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_vesta.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_vesta.rs
@@ -1,10 +1,10 @@
+use mina_curves::pasta::{
+    vesta::{Affine as GAffine, Projective as GProjective},
+    fp::Fp,
+    fq::Fq,
+};
 use algebra::{
     curves::{AffineCurve, ProjectiveCurve},
-    pasta::{
-        vesta::{Affine as GAffine, Projective as GProjective},
-        fp::Fp,
-        fq::Fq,
-    },
     One, UniformRand,
 };
 use rand::rngs::StdRng;

--- a/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
+++ b/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e -o pipefail
-marlin_submodule_dir=$(git submodule status | grep marlin | cut -d ' ' -f 2)
+marlin_submodule_dir=$(git submodule status | grep marlin | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
 marlin_repo_sha=$(cd $marlin_submodule_dir && git rev-parse --short=8 --verify HEAD)
 
 echo "let marlin_repo_sha = \"$marlin_repo_sha\"" >> "$1"

--- a/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
+++ b/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e -o pipefail
-
-marlin_submodule_dir=$(git submodule | grep marlin | cut -d' ' -f3)
+marlin_submodule_dir=$(git submodule status | grep marlin | cut -d ' ' -f 2)
 marlin_repo_sha=$(cd $marlin_submodule_dir && git rev-parse --short=8 --verify HEAD)
 
 echo "let marlin_repo_sha = \"$marlin_repo_sha\"" >> "$1"


### PR DESCRIPTION
This PR updates the marlin submodule to the current `master`, in order to reduce the size of the diffs for the rust version upgrade and the upgrade from zexe to arkworks.

This PR is a no-op. Successfully synced a node to mainnet with this build as a sanity-check.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: