### PR TITLE
[TRIVIAL] Disable log message at the start of each `mina client status`

### DIFF
--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -269,7 +269,7 @@ module Status = struct
               (* TODO: We will temporarily have to create a time controller
                   until the inversion relationship between GraphQL and the RPC code inverts *)
               Block_time.now
-              @@ Block_time.Controller.basic ~logger:(Logger.create ())
+              @@ Block_time.Controller.basic ~logger:(Logger.null ())
             in
             let diff = diff time current_time in
             if Block_time.(time > current_time) then


### PR DESCRIPTION
This disables the unhelpful log message at the top of each `mina client status` output:
```json
{"timestamp":"2000-01-01 00:00:00.000000Z","level":"Debug","source":{"module":"Block_time","location":"File \"src/lib/block_time/block_time.ml\", line 83, characters 18-30"},"message":"Environment variable CODA_TIME_OFFSET not found, using default of 0","metadata":{"pid":1}}
```

A call to format the results of a status request is never the right time to emit this log message, so passing the `Logger.null ()` logger here is strictly an improvement.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #9054