### PR TITLE
ClientSDK - Upgrade tsc in package.json

### DIFF
--- a/frontend/client_sdk/package.json
+++ b/frontend/client_sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@o1labs/client-sdk",
   "description": "Node API for signing transactions for Mina Protocol",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "build": "bsb -make-world && tsc src/SDKWrapper.ts -d",
     "start": "bsb -make-world -w",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "bs-platform": "^7.0.2-dev.2",
     "gentype": "^3.11.0",
-    "typescript": "^3.7.5"
+    "typescript": "^3.8.2"
   },
   "dependencies": {
     "@types/node": "^13.7.0"

--- a/frontend/client_sdk/yarn.lock
+++ b/frontend/client_sdk/yarn.lock
@@ -12,12 +12,12 @@ bs-platform@^7.0.2-dev.2:
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.0.2-dev.2.tgz#ae055440ce075348179f84bac591ff874201e082"
   integrity sha512-IMHf+9JNrBZy4jpbDZROPjF/13xro5rGGuGmRqlbJe0rImXtHZMmT3jNFXveou/F5hKU8c40jpQEGdUUNv1iFA==
 
-gentype@^3.8.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/gentype/-/gentype-3.10.0.tgz#df42ac24b65bcac2c5363609252fdd870e039d2c"
-  integrity sha512-NQUnbrCKLd9r1IX/BuNLPUYM/5Mg3/dNI1VvBUzM205ac314wXKt/t0WySA7euoNaPqkDmC9g96YEo79QOZ3iA==
+gentype@^3.11.0:
+  version "3.50.0"
+  resolved "https://registry.npmjs.org/gentype/-/gentype-3.50.0.tgz#68b4de22e885c26e44b110b41c2675e704f1f896"
+  integrity sha512-EKZzbS4HBuw80zDm5ZJxDdfoGw4nYClTgkv4vp8/db1MXmvCdJSA2NuvxNBYF8i5VqYccdQWzNGClmhWpTFWFQ==
 
-typescript@^3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@^3.8.2:
+  version "3.9.10"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==


### PR DESCRIPTION
This PR upgrades the typescript version to be a minimum of `3.8.2`. Our build client sdk job has been failing due to a `error TS1005: '=' expected.` which indicates that we are using an old version of typescript (checked on a `1.1.6alpha5` build) https://buildkite.com/o-1-labs-2/mina/builds/17865#a511dc97-d28f-42e0-a792-b8bc3532b124/140-164. 

This fix has been tested by creating a PR to trigger the CI and force a build of the client sdk. See here: https://github.com/MinaProtocol/mina/pull/9078/files

The resulting job in our CI passed as seen here:
https://buildkite.com/o-1-labs-2/mina/builds/17908#563cd2a4-e3b7-486d-9df0-d73579cf7400/127-149

