### PR TITLE
Add message type to IPC communication [WIP]

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -27,6 +27,14 @@ The short version:
       you need to [set up SSH keys on your machine](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
 4.  Run `git config --local --add submodule.recurse true`
 
+### Developer Setup (NixOS/nix)
+
+When using nix package manager, run `scripts/nixos-setup.sh` script to install all of the dependencies.
+
+This script was tested on channel `20.03` but should work well on newer channels too.
+
+Troubleshooting tip: to remove everything and build from scratch, use `rm -Rf ~/.opam _build`.
+
 ### Developer Setup (MacOS)
 
 - Invoke `make macos-setup`

--- a/scripts/nixos-setup.sh
+++ b/scripts/nixos-setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+
+nix-shell --run "git submodule update --init --recursive"
+nix-shell --run "opam init -y"
+nix-shell --run "opam switch create -y ocaml-base-compiler.4.11.2"
+nix-shell --run "opam switch import -y src/opam.export"
+
+set -e
+
+nix-shell --run 'NIX_SODIUM_LDFLAGS=$(pkg-config --libs-only-L libsodium) ./scripts/pin-external-packages.sh'
+nix-shell --run "make build"

--- a/scripts/pin-external-packages.sh
+++ b/scripts/pin-external-packages.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 
+set -e
+
 # update and pin packages, used by CI
 
-PACKAGES="ocaml-sodium rpc_parallel ocaml-extlib ocaml-extlib async_kernel coda_base58 graphql_ppx ppx_deriving_yojson"
+PACKAGES="$1"
+
+if [[ "$PACKAGES" == "" ]]; then
+  PACKAGES="ocaml-sodium rpc_parallel ocaml-extlib ocaml-extlib async_kernel coda_base58 graphql_ppx ppx_deriving_yojson"
+fi
 
 git submodule sync && git submodule update --init --recursive
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+with import <nixpkgs> {};
+mkShell {
+  nativeBuildInputs = 
+    [ opam pkgconfig
+      m4 openssl gmp jemalloc libffi
+      libsodium postgresql
+      cargo zlib bzip2
+    ];
+  shellHook = ''
+    eval $(opam env 2>/dev/null)
+    '';
+}

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -253,6 +253,7 @@ type MessageStats struct {
 	sync.RWMutex
 }
 
+// UpdateMetrics accepts a `val` which is the size of a network message
 func (ms *MessageStats) UpdateMetrics(val uint64) {
 	ms.Lock()
 	defer ms.Unlock()

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -805,6 +805,9 @@ func handleStreamReads(app *app, stream net.Stream, idx int) {
 			app.P2p.MsgStats.UpdateMetrics(length)
 
 			msgType, err := r.ReadByte()
+			// Ocaml process is able to determine the message type
+			// by the message itself
+			_ = msgType
 			if err != nil {
 				app.writeMsg(streamLostUpcall{
 					Upcall:    "streamLost",

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -451,8 +451,8 @@ func (m *listeningAddrsMsg) run(app *app) (interface{}, error) {
 
 type publishMsg struct {
 	Topic       string `json:"topic"`
-	MessageType byte   `json:"type`
 	Data        string `json:"data"`
+	MessageType byte   `json:"type"`
 }
 
 func (t *publishMsg) run(app *app) (interface{}, error) {
@@ -562,13 +562,13 @@ func (s *subscribeMsg) run(app *app) (interface{}, error) {
 		msgType := msg.Data[0]
 
 		app.writeMsg(validateUpcall{
-			Sender:     sender,
-			Expiration: deadline.UnixNano(),
-			Data:       codaEncode(msg.Data[1:]),
-			Seqno:      seqno,
-			Upcall:     "validate",
-			Idx:        s.Subscription,
-			MessageType:       msgType,
+			Sender:       sender,
+			Expiration:   deadline.UnixNano(),
+			Data:         codaEncode(msg.Data[1:]),
+			Seqno:        seqno,
+			Upcall:       "validate",
+			Idx:          s.Subscription,
+			MessageType:  msgType,
 		})
 
 		// Wait for the validation response, but be sure to honor any timeout/deadline in ctx
@@ -660,13 +660,13 @@ func (u *unsubscribeMsg) run(app *app) (interface{}, error) {
 }
 
 type validateUpcall struct {
-	Sender     *codaPeerInfo `json:"sender"`
-	Expiration int64         `json:"expiration"`
-	Data       string        `json:"data"`
-	Seqno      int           `json:"seqno"`
-	Upcall     string        `json:"upcall"`
-	Idx        int           `json:"subscription_idx"`
-	MessageType       byte          `json:"type"`
+	Sender      *codaPeerInfo `json:"sender"`
+	Expiration  int64         `json:"expiration"`
+	Data        string        `json:"data"`
+	Seqno       int           `json:"seqno"`
+	Upcall      string        `json:"upcall"`
+	Idx         int           `json:"subscription_idx"`
+	MessageType byte          `json:"type"`
 }
 
 type validationCompleteMsg struct {
@@ -738,7 +738,10 @@ type incomingMsgUpcall struct {
 	Upcall    string `json:"upcall"`
 	StreamIdx int    `json:"stream_idx"`
 	Data      string `json:"data"`
-	MessageType      byte   `json:"type"`
+  // Seems like it is not necessary to send as
+  // OCaml can demarschal the message and determine
+  // it's type automatically
+	// MessageType      byte   `json:"type"`
 }
 
 func handleStreamReads(app *app, stream net.Stream, idx int) {
@@ -829,7 +832,7 @@ func handleStreamReads(app *app, stream net.Stream, idx int) {
 					Upcall:    "incomingStreamMsg",
 					Data:      codaEncode(buffer[:bufferReadSize]),
 					StreamIdx: idx,
-					MessageType: msgType,
+					// MessageType: msgType,
 				})
 			}
 		}

--- a/src/app/libp2p_helper/src/libp2p_helper/main_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"codanet"
+
 	logging "github.com/ipfs/go-log"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -966,7 +967,7 @@ func waitForMessage(t *testing.T, app *app, expectedMessageSize int) []byte {
 
 		upcall, ok := result["upcall"]
 		require.True(t, ok)
-		require.Equal(t, upcall, "incomingStreamMsg")
+		require.Equal(t, "incomingStreamMsg", upcall)
 
 		data, ok := result["data"]
 		require.True(t, ok)

--- a/src/external/ocaml-sodium/myocamlbuild.ml
+++ b/src/external/ocaml-sodium/myocamlbuild.ml
@@ -3,19 +3,18 @@ open Ocamlbuild_pack;;
 
 let ctypes_libdir = Sys.getenv "CTYPES_LIB_DIR" in
 let ocaml_libdir = Sys.getenv "OCAML_LIB_DIR" in
+let nix_sodium_ldflags = Sys.getenv "NIX_SODIUM_LDFLAGS" in
 let lsodium =
   let cwd = Unix.getcwd () in
   let uname_chan = Unix.open_process_in "uname" in
   let l = input_line uname_chan in
+  let nix =
+        if String.length nix_sodium_ldflags = 0 then []
+        else [ A "-cclib"; A nix_sodium_ldflags ] in
+  let res = List.append nix [ A "-cclib"; A "-lsodium" ] in
   match l with
-  | "Darwin" -> [A "-cclib"; A "-lsodium"]
-  | "Linux" ->
-      [ A "-cclib"
-      ; A "-Wl,--push-state,-Bstatic"
-      ; A "-cclib"
-      ; A "-lsodium"
-      ; A "-cclib"
-      ; A "-Wl,--pop-state" ]
+  | "Darwin" -> res
+  | "Linux" -> res
   | s -> failwith (Printf.sprintf "don't know how to link on %s yet" s)
 in
 dispatch begin

--- a/src/lib/mina_version/gen.sh
+++ b/src/lib/mina_version/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 commit_id_short=$(git rev-parse --short=8 --verify HEAD)

--- a/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
+++ b/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -o pipefail
 marlin_submodule_dir=$(git submodule status | grep marlin | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
 marlin_repo_sha=$(cd $marlin_submodule_dir && git rev-parse --short=8 --verify HEAD)


### PR DESCRIPTION
Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

Replaces #8725 

Explain your changes here.

* add `MessageType` byte to `sendStreamMsgMsg` and `publishMsg`
* add prefix before sending msg, remove prefix when reading from stream

Explain how you tested your changes here.

```
go test ./...
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
