### PR TITLE
Allow MINA_PRIVKEY_PASS, MINA_LIBP2P_PASS

### DIFF
--- a/automation/scripts/generate-keys-and-ledger.sh
+++ b/automation/scripts/generate-keys-and-ledger.sh
@@ -89,11 +89,11 @@ function generate_key_files {
     docker run \
       -v "${output_dir}:/keys:z" \
       --entrypoint /bin/bash $CODA_DAEMON_IMAGE \
-      -c "CODA_PRIVKEY_PASS='${privkey_pass}' mina advanced generate-keypair -privkey-path /keys/${name_prefix}_account_${k}"
+      -c "MINA_PRIVKEY_PASS='${privkey_pass}' mina advanced generate-keypair -privkey-path /keys/${name_prefix}_account_${k}"
     docker run \
       --mount type=bind,source=${output_dir},target=/keys \
       --entrypoint /bin/bash $CODA_DAEMON_IMAGE \
-      -c "CODA_LIBP2P_PASS='${privkey_pass}' mina advanced generate-libp2p-keypair -privkey-path /keys/${name_prefix}_libp2p_${k}"
+      -c "MINA_LIBP2P_PASS='${privkey_pass}' mina advanced generate-libp2p-keypair -privkey-path /keys/${name_prefix}_libp2p_${k}"
   done
 
   # ensure proper r+w permissions for access to keys external to container

--- a/automation/scripts/testnet-keys.py
+++ b/automation/scripts/testnet-keys.py
@@ -88,7 +88,7 @@ def generate_service_keys(output_dir, privkey_pass):
             MINA_DAEMON_IMAGE,
             entrypoint="bash -c",
             command=[
-                "CODA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/{}_service"
+                "MINA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/{}_service"
                 .format(privkey_pass, service)
             ],
             volumes={output_dir: {
@@ -121,7 +121,7 @@ def generate_online_whale_keys(count, output_dir, privkey_pass):
             MINA_DAEMON_IMAGE,
             entrypoint="bash -c",
             command=[
-                "CODA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/online_whale_account_{}"
+                "MINA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/online_whale_account_{}"
                 .format(privkey_pass, whale_key)
             ],
             volumes={output_dir: {
@@ -154,7 +154,7 @@ def generate_offline_whale_keys(count, output_dir, privkey_pass):
             MINA_DAEMON_IMAGE,
             entrypoint="bash -c",
             command=[
-                "CODA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/offline_whale_account_{}"
+                "MINA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/offline_whale_account_{}"
                 .format(privkey_pass, i + 1)
             ],
             volumes={output_dir: {
@@ -187,7 +187,7 @@ def generate_offline_fish_keys(count, output_dir, privkey_pass):
             MINA_DAEMON_IMAGE,
             entrypoint="bash -c",
             command=[
-                "CODA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/offline_fish_account_{}"
+                "MINA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/offline_fish_account_{}"
                 .format(privkey_pass, fish_number)
             ],
             volumes={output_dir: {
@@ -221,7 +221,7 @@ def generate_online_fish_keys(count, output_dir, privkey_pass):
             MINA_DAEMON_IMAGE,
             entrypoint="bash -c",
             command=[
-                "CODA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/online_fish_account_{}"
+                "MINA_PRIVKEY_PASS='{}' mina advanced generate-keypair -privkey-path /keys/online_fish_account_{}"
                 .format(privkey_pass, fish_number)
             ],
             volumes={output_dir: {

--- a/automation/services/coda-user-agent/agent.py
+++ b/automation/services/coda-user-agent/agent.py
@@ -24,7 +24,7 @@ def getenv_currency(env_var: str, lower_bound: Currency, upper_bound: Currency) 
     return getenv_default_map(env_var, Currency, Currency.random(lower_bound, upper_bound))
 
 CODA_PUBLIC_KEY = getenv_str("CODA_PUBLIC_KEY", "4vsRCVyVkSRs89neWnKPrnz4FRPmXXrWtbsAQ31hUTSi41EkbptYaLkzmxezQEGCgZnjqY2pQ6mdeCytu7LrYMGx9NiUNNJh8XfJYbzprhhJmm1ZjVbW9ZLRvhWBXRqes6znuF7fWbECrCpQ")
-CODA_PRIVKEY_PASS = getenv_str("CODA_PRIVKEY_PASS", "naughty blue worm")
+MINA_PRIVKEY_PASS = getenv_str("MINA_PRIVKEY_PASS", "naughty blue worm")
 AGENT_MIN_FEE = getenv_currency("AGENT_MIN_FEE", Currency("0.06"), Currency("0.1"))
 AGENT_MAX_FEE = getenv_currency("AGENT_MAX_FEE", AGENT_MIN_FEE, AGENT_MIN_FEE + Currency("0.2"))
 AGENT_MIN_TX = getenv_currency("AGENT_MIN_TX", Currency("0.0015"), Currency("0.005"))
@@ -110,7 +110,7 @@ class Agent(object):
 
 
 def main():
-    agent = Agent(CODA_CLIENT_ARGS, CODA_PUBLIC_KEY, CODA_PRIVKEY_PASS)
+    agent = Agent(CODA_CLIENT_ARGS, CODA_PUBLIC_KEY, MINA_PRIVKEY_PASS)
     schedule.every(AGENT_SEND_EVERY_MINS).minutes.do(agent.send_transaction_batch)
     print("Sending a transaction every {} minutes.".format(AGENT_SEND_EVERY_MINS))
     while True:

--- a/automation/services/watchdog/metrics.py
+++ b/automation/services/watchdog/metrics.py
@@ -118,7 +118,7 @@ def get_chain_id(v1, namespace):
       resp = util.exec_on_pod(v1, namespace, pod_name, container_name, 'mina client status --json')      
       resp = resp.strip()
       if resp[0] != '{':
-        #first line could be 'Using password from environment variable CODA_PRIVKEY_PASS'
+        #first line could be 'Using password from environment variable MINA_PRIVKEY_PASS'
         resp = resp.split("\n", 1)[1]
       resp_dict = ast.literal_eval(resp.strip())
       print("Chain ID: {}".format(resp_dict['chain_id']))

--- a/automation/terraform/modules/services/daemon/templates/container-definition.json.tpl
+++ b/automation/terraform/modules/services/daemon/templates/container-definition.json.tpl
@@ -22,7 +22,7 @@
         { "name" : "DAEMON_EXTERNAL_PORT", "value" : "${daemon_external_port}" },
         { "name" : "DAEMON_DISCOVERY_PORT", "value" : "${daemon_discovery_port}" },
         { "name" : "DAEMON_METRICS_PORT", "value" : "${daemon_metrics_port}" },
-        { "name" : "CODA_PRIVKEY_PASS", "value" : "${coda_privkey_pass}" },
+        { "name" : "MINA_PRIVKEY_PASS", "value" : "${coda_privkey_pass}" },
         { "name" : "CODA_SNARK_KEY", "value" : "${coda_snark_key}" },
         { "name" : "CODA_PROPOSE_KEY", "value" : "${coda_propose_key}" }
     ]

--- a/automation/terraform/modules/services/faucet/templates/container-definition.json.tpl
+++ b/automation/terraform/modules/services/faucet/templates/container-definition.json.tpl
@@ -47,7 +47,7 @@
         { "name" : "DAEMON_DISCOVERY_PORT", "value" : "${coda_discovery_port}" },
         { "name" : "DAEMON_METRICS_PORT", "value" : "${coda_metrics_port}" },
         { "name" : "DAEMON_CLIENT_PORT", "value" : "${coda_client_port}" },
-        { "name" : "CODA_PRIVKEY_PASS", "value" : "${coda_privkey_pass}" },
+        { "name" : "MINA_PRIVKEY_PASS", "value" : "${coda_privkey_pass}" },
         { "name" : "CODA_TESTNET", "value" : "${coda_testnet}" }
     ]
   }

--- a/automation/terraform/modules/services/graphql-proxy/templates/container-definition.json.tpl
+++ b/automation/terraform/modules/services/graphql-proxy/templates/container-definition.json.tpl
@@ -54,7 +54,7 @@
         { "name" : "DAEMON_DISCOVERY_PORT", "value" : "${coda_discovery_port}" },
         { "name" : "DAEMON_METRICS_PORT", "value" : "${coda_metrics_port}" },
         { "name" : "DAEMON_CLIENT_PORT", "value" : "${coda_client_port}" },
-        { "name" : "CODA_PRIVKEY_PASS", "value" : "${coda_privkey_pass}" },
+        { "name" : "MINA_PRIVKEY_PASS", "value" : "${coda_privkey_pass}" },
         { "name" : "CODA_TESTNET", "value" : "${coda_testnet}" },
         { "name" : "CODA_ARCHIVE_NODE", "value" : "${coda_archive_node}" }
     ]

--- a/dockerfiles/auxiliary_entrypoints/01-run-demo.sh
+++ b/dockerfiles/auxiliary_entrypoints/01-run-demo.sh
@@ -34,7 +34,7 @@ if [[ -n ${RUN_DEMO} ]]; then
     CODA_TIME_OFFSET=${CODA_TIME_OFFSET:-0}
     MINA_TIME_OFFSET=${MINA_TIME_OFFSET:-0}
     
-    CODA_PRIVKEY_PASS=${CODA_PRIVKEY_PASS:-""}
+    MINA_PRIVKEY_PASS=${MINA_PRIVKEY_PASS:-""}
     MINA_PRIVKEY_PASS=${MINA_PRIVKEY_PASS:-""}
 
     exec mina daemon --generate-genesis-proof true --seed --demo-mode --proof-level none --config-dir ${MINA_CONFIG_DIR} --block-producer-pubkey ${PK} --run-snark-worker ${SNARK_PK} -insecure-rest-server $@

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -43,7 +43,7 @@ services:
     command: 
       daemon -peer <testnet>.o1test.net:8303 -rest-port 8304 -external-port 10101 -metrics-port 10000 -block-producer-key /root/wallet-keys/my_wallet -unsafe-track-block-producer-key
     environment: 
-      CODA_PRIVKEY_PASS: <key-password>
+      MINA_PRIVKEY_PASS: <key-password>
     volumes:
       - ~/wallet-keys:/root/wallet-keys
 ```

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -59,7 +59,7 @@ spec:
         - name: config-dir
           mountPath: /root/.mina-config
         env:
-          - name: CODA_PRIVKEY_PASS
+          - name: MINA_PRIVKEY_PASS
             value: {{ $.Values.coda.privkeyPass | quote }}
       {{ if $config.libp2pSecret -}}
       - name: libp2p-perms
@@ -114,7 +114,7 @@ spec:
               secretKeyRef:
                 name: {{ $config.privateKeySecret }}
                 key: pub
-          - name: CODA_PRIVKEY_PASS
+          - name: MINA_PRIVKEY_PASS
             value: {{ $.Values.coda.privkeyPass | quote }}
           - name: PYTHONUNBUFFERED
             value: "1"
@@ -240,10 +240,10 @@ spec:
           value: {{ $.Values.testnetName }}
         - name: GCLOUD_BLOCK_UPLOAD_BUCKET
           value: "mina_network_block_data"
-        - name: CODA_PRIVKEY_PASS
+        - name: MINA_PRIVKEY_PASS
           value: {{ $.Values.coda.privkeyPass | quote }}
         {{- if $config.libp2pSecret }}
-        - name: CODA_LIBP2P_PASS
+        - name: MINA_LIBP2P_PASS
           value: {{ $.Values.coda.privkeyPass | quote }}
         {{- end }}
         - name: CODA_CLIENT_TRUSTLIST

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -111,7 +111,7 @@ spec:
         - name: DAEMON_EXTERNAL_PORT
           value: {{ default $.Values.coda.ports.p2p $config.externalPort | quote }}
         {{- if $config.libp2pSecret }}
-        - name: CODA_LIBP2P_PASS
+        - name: MINA_LIBP2P_PASS
           value: {{ $.Values.coda.privkeyPass | quote }}
         {{- end }}
         ports:

--- a/scripts/get-wallet-keys.sh
+++ b/scripts/get-wallet-keys.sh
@@ -16,7 +16,7 @@ jsonpath="$tmpdir/sample_keypairs.json"
 cd "$SCRIPTPATH/.."
 
 mkdir -p wallet-keys
-export CODA_PRIVKEY_PASS=""
+export MINA_PRIVKEY_PASS=""
 
 # Iterate over the keys in the JSON and wrap them in the proper format
 i=1

--- a/scripts/run_local_network.sh
+++ b/scripts/run_local_network.sh
@@ -170,7 +170,7 @@ for i in $(seq 1 $whales); do
   metrics_port=$(echo $whale_start_port + 3 + $i*5 | bc)
   libp2p_metrics_port=$(echo $whale_start_port + 4 + $i*5 | bc)
 
-  CODA_PRIVKEY_PASS="naughty blue worm" $MINA daemon -peer "/ip4/127.0.0.1/tcp/3002/p2p/12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr" -client-port $client_port -rest-port $rest_port -external-port $ext_port -metrics-port $metrics_port -libp2p-metrics-port $libp2p_metrics_port -config-directory $folder -config-file $daemon -generate-genesis-proof true -block-producer-key $keyfile -log-json -snark-worker-fee "0.01" -run-snark-worker B62qp4UturELw4MmhAZhor8rwzaH1BBAivRnvdp1Yhkq6odhhFiT8uC -work-selection seq -log-level Trace &> $logfile &
+  MINA_PRIVKEY_PASS="naughty blue worm" $MINA daemon -peer "/ip4/127.0.0.1/tcp/3002/p2p/12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr" -client-port $client_port -rest-port $rest_port -external-port $ext_port -metrics-port $metrics_port -libp2p-metrics-port $libp2p_metrics_port -config-directory $folder -config-file $daemon -generate-genesis-proof true -block-producer-key $keyfile -log-json -snark-worker-fee "0.01" -run-snark-worker B62qp4UturELw4MmhAZhor8rwzaH1BBAivRnvdp1Yhkq6odhhFiT8uC -work-selection seq -log-level Trace &> $logfile &
   whale_pids[${i}]=$!
   whale_logfiles[${i}]=$logfile
   whale_clientport[${i}]=$client_port
@@ -190,7 +190,7 @@ for i in $(seq 1 $fish); do
   metrics_port=$(echo $fish_start_port + 3 + $i*5 | bc)
   libp2p_metrics_port=$(echo $fish_start_port + 4 + $i*5 | bc)
 
-  CODA_PRIVKEY_PASS="naughty blue worm" $MINA daemon -peer "/ip4/127.0.0.1/tcp/3002/p2p/12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr" -client-port $client_port -rest-port $rest_port -external-port $ext_port -metrics-port $metrics_port -libp2p-metrics-port $libp2p_metrics_port -config-directory $folder -config-file $daemon -generate-genesis-proof true -block-producer-key $keyfile -log-json -snark-worker-fee "0.01" -run-snark-worker B62qp4UturELw4MmhAZhor8rwzaH1BBAivRnvdp1Yhkq6odhhFiT8uC -work-selection seq -log-level Trace &> $logfile &
+  MINA_PRIVKEY_PASS="naughty blue worm" $MINA daemon -peer "/ip4/127.0.0.1/tcp/3002/p2p/12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr" -client-port $client_port -rest-port $rest_port -external-port $ext_port -metrics-port $metrics_port -libp2p-metrics-port $libp2p_metrics_port -config-directory $folder -config-file $daemon -generate-genesis-proof true -block-producer-key $keyfile -log-json -snark-worker-fee "0.01" -run-snark-worker B62qp4UturELw4MmhAZhor8rwzaH1BBAivRnvdp1Yhkq6odhhFiT8uC -work-selection seq -log-level Trace &> $logfile &
   fish_pids[${i}]=$!
   fish_logfiles[${i}]=$logfile
   fish_clientport[${i}]=$client_port
@@ -210,7 +210,7 @@ for i in $(seq 1 $nodes); do
   metrics_port=$(echo $node_start_port + 3 + $i*5 | bc)
   libp2p_metrics_port=$(echo $node_start_port + 4 + $i*5 | bc)
 
-  CODA_PRIVKEY_PASS="naughty blue worm" $MINA daemon -peer "/ip4/127.0.0.1/tcp/3002/p2p/12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr" -client-port $client_port -rest-port $rest_port -external-port $ext_port -metrics-port $metrics_port -libp2p-metrics-port $libp2p_metrics_port -config-directory $folder -config-file $daemon -generate-genesis-proof true -log-json -log-level Trace &> $logfile &
+  MINA_PRIVKEY_PASS="naughty blue worm" $MINA daemon -peer "/ip4/127.0.0.1/tcp/3002/p2p/12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr" -client-port $client_port -rest-port $rest_port -external-port $ext_port -metrics-port $metrics_port -libp2p-metrics-port $libp2p_metrics_port -config-directory $folder -config-file $daemon -generate-genesis-proof true -log-json -log-level Trace &> $logfile &
   node_pids[${i}]=$!
   node_logfiles[${i}]=$logfile
   node_clientport[${i}]=$client_port
@@ -269,13 +269,13 @@ if $transactions; then
 
   echo "starting to send transactions every $transaction_frequency seconds"
 
-  CODA_PRIVKEY_PASS="naughty blue worm" $MINA account import -config-directory $folder -rest-server "http://127.0.0.1:$port/graphql" -privkey-path $keyfile &> /dev/null
+  MINA_PRIVKEY_PASS="naughty blue worm" $MINA account import -config-directory $folder -rest-server "http://127.0.0.1:$port/graphql" -privkey-path $keyfile &> /dev/null
 
-  CODA_PRIVKEY_PASS="naughty blue worm" $MINA account unlock -rest-server "http://127.0.0.1:$port/graphql" -public-key $pubkey  &> /dev/null
+  MINA_PRIVKEY_PASS="naughty blue worm" $MINA account unlock -rest-server "http://127.0.0.1:$port/graphql" -public-key $pubkey  &> /dev/null
 
   while true; do
     sleep $transaction_frequency
-    CODA_PRIVKEY_PASS="naughty blue worm" $MINA client send-payment -rest-server "http://127.0.0.1:$port/graphql" -amount 1 -receiver $pubkey -sender $pubkey &> /dev/null
+    MINA_PRIVKEY_PASS="naughty blue worm" $MINA client send-payment -rest-server "http://127.0.0.1:$port/graphql" -amount 1 -receiver $pubkey -sender $pubkey &> /dev/null
   done
 
 fi

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -75,7 +75,7 @@ let setup_daemon logger =
       ~aliases:["block-producer-password"]
       ~doc:
         "PASSWORD Password associated with the block-producer key. Setting \
-         this is equivalent to setting the CODA_PRIVKEY_PASS environment \
+         this is equivalent to setting the MINA_PRIVKEY_PASS environment \
          variable. Be careful when setting it in the commandline as it will \
          likely get tracked in your history. Mainly to be used from the \
          daemon.json config file"

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -476,7 +476,7 @@ let batch_send_payments =
   let main port (privkey_path, payments_path) =
     let open Deferred.Let_syntax in
     let%bind keypair =
-      Secrets.Keypair.Terminal_stdin.read_exn ~which:"coda keypair"
+      Secrets.Keypair.Terminal_stdin.read_exn ~which:"Mina keypair"
         privkey_path
     and infos = get_infos payments_path in
     let ts : User_command_input.t list =
@@ -882,7 +882,7 @@ let dump_keypair =
     @@ fun () ->
     let open Deferred.Let_syntax in
     let%map kp =
-      Secrets.Keypair.Terminal_stdin.read_exn ~which:"coda keypair"
+      Secrets.Keypair.Terminal_stdin.read_exn ~which:"Mina keypair"
         privkey_path
     in
     printf "Public key: %s\nPrivate key: %s\n"
@@ -1375,7 +1375,7 @@ let import_key =
   Command.async
     ~summary:
       "Import a password protected private key to be tracked by the daemon.\n\
-       Set CODA_PRIVKEY_PASS environment variable to use non-interactively \
+       Set MINA_PRIVKEY_PASS environment variable to use non-interactively \
        (key will be imported using the same password)."
     (let%map_open.Command access_method =
        choose_one
@@ -1511,7 +1511,7 @@ let export_key =
     ~summary:
       "Export a tracked account so that it can be saved or transferred \
        between machines.\n\
-      \ Set CODA_PRIVKEY_PASS environment variable to use non-interactively \
+      \ Set MINA_PRIVKEY_PASS environment variable to use non-interactively \
        (key will be exported using the same password)."
     (Cli_lib.Background_daemon.graphql_init flags
        ~f:(fun _ (export_path, pk, conf_dir) ->

--- a/src/app/rosetta/docker-demo-start.sh
+++ b/src/app/rosetta/docker-demo-start.sh
@@ -44,7 +44,7 @@ genesis_time=$(date -d '2019-01-30 20:00:00.000000Z' '+%s')
 now_time=$(date +%s)
 
 export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
-export CODA_PRIVKEY_PASS=""
+export MINA_PRIVKEY_PASS=""
 export CODA_LIBP2P_HELPER_PATH=/mina-bin/libp2p_helper
 
 MINA_CONFIG_DIR=/root/.mina-config

--- a/src/app/rosetta/docker-start.sh
+++ b/src/app/rosetta/docker-start.sh
@@ -26,7 +26,7 @@ pg_ctlcluster 11 main start
 # wait for it to settle
 sleep 3
 
-export CODA_PRIVKEY_PASS=""
+export MINA_PRIVKEY_PASS=""
 export CODA_LIBP2P_HELPER_PATH=/mina-bin/libp2p_helper
 
 export MINA_CONFIG_FILE=${MINA_CONFIG_FILE:=/data/config.json}

--- a/src/app/rosetta/docker-test-start.sh
+++ b/src/app/rosetta/docker-test-start.sh
@@ -32,7 +32,7 @@ PK=${PK:-B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV}
 genesis_time=$(date -d '2019-01-30 20:00:00.000000Z' '+%s')
 now_time=$(date +%s)
 export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
-export CODA_PRIVKEY_PASS=""
+export MINA_PRIVKEY_PASS=""
 export CODA_LIBP2P_HELPER_PATH=/mina-bin/libp2p_helper
 MINA_CONFIG_DIR=/root/.mina-config
 

--- a/src/app/rosetta/run-demo.sh
+++ b/src/app/rosetta/run-demo.sh
@@ -10,7 +10,7 @@ genesis_time=$(date -d '2019-01-30 20:00:00.000000Z' '+%s')
 now_time=$(date +%s)
 
 export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
-export CODA_PRIVKEY_PASS=""
+export MINA_PRIVKEY_PASS=""
 export CODA_CONFIG_FILE=/tmp/config.json
 
 exec $BIN daemon -seed -demo-mode -block-producer-key /tmp/keys/demo-block-producer -run-snark-worker $SNARK_PK -config-file /tmp/config.json -insecure-rest-server $@

--- a/src/lib/secrets/keypair_common.ml
+++ b/src/lib/secrets/keypair_common.ml
@@ -9,6 +9,8 @@ module Make_terminal_stdin (KP : sig
 
   val env : string
 
+  val env_deprecated : string
+
   val read :
        privkey_path:string
     -> password:Secret_file.password
@@ -32,15 +34,25 @@ struct
   let read_exn ?(should_reask = true) ~which path =
     let read_privkey password = read ~privkey_path:path ~password in
     let%bind result =
-      match Sys.getenv env with
-      | Some password ->
+      match (Sys.getenv env, Sys.getenv env_deprecated) with
+      | Some password, _ ->
           (* this function is only called from client commands that can prompt for
              a password, so printing a message, rather than a formatted log, is OK
           *)
           printf "Using %s private-key password from environment variable %s\n"
             which env ;
           read_privkey (lazy (Deferred.return @@ Bytes.of_string password))
-      | None ->
+      | None, Some password ->
+          (* this function is only called from client commands that can prompt for
+             a password, so printing a message, rather than a formatted log, is OK
+          *)
+          printf
+            "Using %s private-key password from deprecated environment \
+             variable %s\n"
+            which env_deprecated ;
+          printf "Please use environment variable %s instead\n" env ;
+          read_privkey (lazy (Deferred.return @@ Bytes.of_string password))
+      | None, None ->
           let read_file () =
             read_privkey
               ( lazy

--- a/src/lib/secrets/libp2p_keypair.ml
+++ b/src/lib/secrets/libp2p_keypair.ml
@@ -6,7 +6,9 @@ open Keypair_common
 module T = struct
   type t = Mina_net2.Keypair.t
 
-  let env = "CODA_LIBP2P_PASS"
+  let env = "MINA_LIBP2P_PASS"
+
+  let env_deprecated = "CODA_LIBP2P_PASS"
 
   let which = "libp2p keypair"
 


### PR DESCRIPTION
Allow use of environment variables `MINA_PRIVKEY_PASS` and `MINA_LIBP2P_PASS`, while still allowing use of the `CODA_` equivalents.

When the `CODA_` variables are used, mention that they are deprecated, and suggest use of the corresponding `MINA_` variable.

All uses of the old variables are replaced with the new variables.

Tested by running `advanced dump-keypair`, with both environment variables, and with no variable set.

Part of #9041.