### PR TITLE
Allow MINA_TIME_OFFSET

### DIFF
--- a/automation/bake/Dockerfile
+++ b/automation/bake/Dockerfile
@@ -44,6 +44,6 @@ done'\
 
 RUN chmod +x init_mina_baked.sh
 
-ENV CODA_TIME_OFFSET 0
+ENV MINA_TIME_OFFSET 0
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/root/init_mina_baked.sh"]

--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -71,8 +71,6 @@ COPY --chown=${UID} ./auxiliary_entrypoints /entrypoint.d
 COPY --chown=${UID} puppeteer-context/* /
 RUN chmod +x /mina_daemon_puppeteer.py /find_puppeteer.sh /start.sh /stop.sh
 
-ENV CODA_TIME_OFFSET 0
-# for future use
 ENV MINA_TIME_OFFSET 0
 
 ENTRYPOINT ["/usr/bin/dumb-init", "/entrypoint.sh"]

--- a/dockerfiles/auxiliary_entrypoints/01-run-demo.sh
+++ b/dockerfiles/auxiliary_entrypoints/01-run-demo.sh
@@ -31,7 +31,7 @@ if [[ -n ${RUN_DEMO} ]]; then
     echo "Contents of config file ${MINA_CONFIG_FILE}:"
     cat "${MINA_CONFIG_FILE}"
 
-    CODA_TIME_OFFSET=${CODA_TIME_OFFSET:-0}
+    MINA_TIME_OFFSET=${MINA_TIME_OFFSET:-0}
     MINA_TIME_OFFSET=${MINA_TIME_OFFSET:-0}
     
     CODA_PRIVKEY_PASS=${CODA_PRIVKEY_PASS:-""}

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -122,9 +122,9 @@ let get_time_offset_graphql =
            "Current time offset:\n\
             %i\n\n\
             Start other daemons with this offset by setting the \
-            CODA_TIME_OFFSET environment variable in the shell before \
+            MINA_TIME_OFFSET environment variable in the shell before \
             executing them:\n\
-            export CODA_TIME_OFFSET=%i\n"
+            export MINA_TIME_OFFSET=%i\n"
            time_offset time_offset ))
 
 let print_trust_statuses statuses json =

--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -51,7 +51,7 @@ let local_config ?block_production_interval:_ ~is_seed ~peers ~addrs_and_ports
             ~f:(List.map ~f:Node_addrs_and_ports.to_display)
             all_peers_list )
     ; env=
-        ( "CODA_TIME_OFFSET"
+        ( "MINA_TIME_OFFSET"
         , Time.Span.to_int63_seconds_round_down_exn offset
           |> Int63.to_int
           |> Option.value_exn ?here:None ?message:None ?error:None

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -52,7 +52,7 @@ let medium_curves = false
 time_offsets = true]
 
 let setup_time_offsets consensus_constants =
-  Unix.putenv ~key:"CODA_TIME_OFFSET"
+  Unix.putenv ~key:"MINA_TIME_OFFSET"
     ~data:
       ( Time.Span.to_int63_seconds_round_down_exn
           (Coda_processes.offset consensus_constants)

--- a/src/app/rosetta/docker-demo-start.sh
+++ b/src/app/rosetta/docker-demo-start.sh
@@ -43,7 +43,7 @@ SNARK_PK=${SNARK_PK:-B62qiZfzW27eavtPrnF6DeDSAKEjXuGFdkouC3T5STRa6rrYLiDUP2p}
 genesis_time=$(date -d '2019-01-30 20:00:00.000000Z' '+%s')
 now_time=$(date +%s)
 
-export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
+export MINA_TIME_OFFSET=$(( $now_time - $genesis_time ))
 export CODA_PRIVKEY_PASS=""
 export CODA_LIBP2P_HELPER_PATH=/mina-bin/libp2p_helper
 

--- a/src/app/rosetta/docker-test-start.sh
+++ b/src/app/rosetta/docker-test-start.sh
@@ -31,7 +31,7 @@ sleep 3
 PK=${PK:-B62qmnkbvNpNvxJ9FkSkBy5W6VkquHbgN2MDHh1P8mRVX3FQ1eWtcxV}
 genesis_time=$(date -d '2019-01-30 20:00:00.000000Z' '+%s')
 now_time=$(date +%s)
-export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
+export MINA_TIME_OFFSET=$(( $now_time - $genesis_time ))
 export CODA_PRIVKEY_PASS=""
 export CODA_LIBP2P_HELPER_PATH=/mina-bin/libp2p_helper
 MINA_CONFIG_DIR=/root/.mina-config

--- a/src/app/rosetta/run-demo.sh
+++ b/src/app/rosetta/run-demo.sh
@@ -9,7 +9,7 @@ SNARK_PK=B62qjnkjj3zDxhEfxbn1qZhUawVeLsUr2GCzEz8m1MDztiBouNsiMUL
 genesis_time=$(date -d '2019-01-30 20:00:00.000000Z' '+%s')
 now_time=$(date +%s)
 
-export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
+export MINA_TIME_OFFSET=$(( $now_time - $genesis_time ))
 export CODA_PRIVKEY_PASS=""
 export CODA_CONFIG_FILE=/tmp/config.json
 

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -73,14 +73,21 @@ module Time = struct
           offset
       | None ->
           let offset =
+            let env = "MINA_TIME_OFFSET" in
+            let env_deprecated = "CODA_TIME_OFFSET" in
             let env_offset =
-              match Core.Sys.getenv "CODA_TIME_OFFSET" with
-              | Some tm ->
+              match (Core.Sys.getenv env, Core.Sys.getenv env_deprecated) with
+              | Some tm, _ ->
                   Int.of_string tm
-              | None ->
+              | _, Some tm ->
+                  [%log warn]
+                    "Using deprecated environment variable %s, please use %s \
+                     instead"
+                    env_deprecated env ;
+                  Int.of_string tm
+              | None, None ->
                   [%log debug]
-                    "Environment variable CODA_TIME_OFFSET not found, using \
-                     default of 0" ;
+                    "Environment variable %s not found, using default of 0" env ;
                   0
             in
             Core_kernel.Time.Span.of_int_sec env_offset

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -74,6 +74,7 @@ module Time = struct
       | None ->
           let offset =
             let env = "MINA_TIME_OFFSET" in
+            (* TODO: remove eventually *)
             let env_deprecated = "CODA_TIME_OFFSET" in
             let env_offset =
               match (Core.Sys.getenv env, Core.Sys.getenv env_deprecated) with

--- a/src/lib/block_time/block_time.mli
+++ b/src/lib/block_time/block_time.mli
@@ -21,7 +21,7 @@ module Time : sig
 
     val basic : logger:Logger.t -> t
 
-    (** Override the time offset set by the [CODA_TIME_OFFSET] environment
+    (** Override the time offset set by the [MINA_TIME_OFFSET] environment
         variable for all block time controllers.
         [enable_setting_offset] must have been called first, and
         [disable_setting_offset] must not have been called, otherwise this
@@ -29,7 +29,7 @@ module Time : sig
     *)
     val set_time_offset : Time.Span.t -> unit
 
-    (** Get the current time offset, either from the [CODA_TIME_OFFSET]
+    (** Get the current time offset, either from the [MINA_TIME_OFFSET]
         environment variable, or as last set by [set_time_offset].
     *)
     val get_time_offset : logger:Logger.t -> Time.Span.t


### PR DESCRIPTION
Allow use of `MINA_TIME_OFFSET` as an environment variable, while continuing to allow `CODA_TIME_OFFSET`.

If the old variable is used, a warning log is issued.

All uses of the variable in the codebase are updated.

Part of #9041.