### PR TITLE
Remove CODA_DUNE_PROFILE

### DIFF
--- a/src/config/dune
+++ b/src/config/dune
@@ -4,7 +4,7 @@ let rec find_all_files ~banlist_exts dirname basename =
   let ext =
     try String.split_on_char '.' basename |> List.rev |> List.hd with _ -> ""
   in
-  if List.exists (( =) ext) banlist_exts then []
+  if List.exists (String.equal ext) banlist_exts then []
   else
     let fullname = Filename.concat dirname basename in
     if Sys.is_directory fullname then
@@ -22,5 +22,5 @@ let () =
      \  (targets config.mlh)\n\
      \  (mode fallback)\n\
      \  (deps %{profile}.mlh " ^ config_deps
-     ^ " (env_var CODA_DUNE_PROFILE))\n
+     ^ " (env_var MINA_DUNE_PROFILE))\n
      \  (action (copy %{profile}.mlh config.mlh)))"

--- a/src/config/dune
+++ b/src/config/dune
@@ -21,6 +21,5 @@ let () =
   @@ "(rule\n\
      \  (targets config.mlh)\n\
      \  (mode fallback)\n\
-     \  (deps %{profile}.mlh " ^ config_deps
-     ^ " (env_var MINA_DUNE_PROFILE))\n
+     \  (deps %{profile}.mlh " ^ config_deps ^ ")\n
      \  (action (copy %{profile}.mlh config.mlh)))"


### PR DESCRIPTION
In the dependencies list to rebuild `config.mlh`, remove the use of `CODA_DUNE_PROFILE`, which is otherwise unused.

Also, change a polymorphic equality to a string equality. Not required, since this code doesn't use the Jane St libraries, but good practice.

Part of #9041.