### PR TITLE
Use MINA_GRAPHQL... environment variables

### DIFF
--- a/automation/services/graphql-public-proxy/Dockerfile
+++ b/automation/services/graphql-public-proxy/Dockerfile
@@ -9,8 +9,8 @@ RUN yarn && \
 
 COPY ./src ./src/
 
-ENV CODA_GRAPHQL_HOST=localhost
-ENV CODA_GRAPHQL_PORT=8304
+ENV MINA_GRAPHQL_HOST=localhost
+ENV MINA_GRAPHQL_PORT=8304
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
@@ -18,4 +18,4 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 ENTRYPOINT ["bash", "-c"]
-CMD ["dockerize -wait tcp://$CODA_GRAPHQL_HOST:$CODA_GRAPHQL_PORT -timeout 90s && yarn start" ]
+CMD ["dockerize -wait tcp://$MINA_GRAPHQL_HOST:$MINA_GRAPHQL_PORT -timeout 90s && yarn start" ]

--- a/automation/services/graphql-public-proxy/src/index.js
+++ b/automation/services/graphql-public-proxy/src/index.js
@@ -13,12 +13,12 @@ const {HttpLink} = require('apollo-link-http');
 const fetch = require('node-fetch');
 const fs = require('fs');
 
-const CODA_GRAPHQL_HOST = process.env["CODA_GRAPHQL_HOST"] || "localhost";
-const CODA_GRAPHQL_PORT = process.env["CODA_GRAPHQL_PORT"] || 3085;
-const CODA_GRAPHQL_PATH = process.env["CODA_GRAPHQL_PATH"] || "/graphql";
+const MINA_GRAPHQL_HOST = process.env["MINA_GRAPHQL_HOST"] || "localhost";
+const MINA_GRAPHQL_PORT = process.env["MINA_GRAPHQL_PORT"] || 3085;
+const MINA_GRAPHQL_PATH = process.env["MINA_GRAPHQL_PATH"] || "/graphql";
 const EXTERNAL_PORT = process.env["EXTERNAL_PORT"] || 3000;
 
-let graphqlUri = "http://" + CODA_GRAPHQL_HOST + ":" + CODA_GRAPHQL_PORT + CODA_GRAPHQL_PATH;
+let graphqlUri = "http://" + MINA_GRAPHQL_HOST + ":" + MINA_GRAPHQL_PORT + MINA_GRAPHQL_PATH;
 
 const hiddenFields = [
   "trackedAccounts",
@@ -39,9 +39,9 @@ const graphiqlString = fs.readFileSync("./index.html");
 const link = new HttpLink({ uri: graphqlUri, fetch });
 
 // Set up proxy server for websocket
-let proxy = httpProxy.createProxyServer({ target: {host: CODA_GRAPHQL_HOST, port: CODA_GRAPHQL_PORT},  ws: true});
+let proxy = httpProxy.createProxyServer({ target: {host: MINA_GRAPHQL_HOST, port: MINA_GRAPHQL_PORT},  ws: true});
 proxy.on('error', err => console.log('Error in proxy server:', err));
-//proxy.listen(CODA_GRAPHQL_PORT);
+//proxy.listen(MINA_GRAPHQL_PORT);
 
 introspectSchema(link)
 .then(remoteSchema => {

--- a/automation/terraform/modules/services/faucet/templates/container-definition.json.tpl
+++ b/automation/terraform/modules/services/faucet/templates/container-definition.json.tpl
@@ -14,8 +14,8 @@
     },
     "environment" : [
         { "name" : "DISCORD_API_KEY", "value" : "${discord_api_key}" },
-        { "name" : "CODA_GRAPHQL_HOST", "value" : "${coda_graphql_host}" },
-        { "name" : "CODA_GRAPHQL_PORT", "value" : "${coda_graphql_port}" },
+        { "name" : "MINA_GRAPHQL_HOST", "value" : "${coda_graphql_host}" },
+        { "name" : "MINA_GRAPHQL_PORT", "value" : "${coda_graphql_port}" },
         { "name" : "FAUCET_PUBLICKEY", "value" : "${faucet_public_key}" },
         { "name" : "FAUCET_PASSWORD", "value" : "${faucet_password}" },
         { "name" : "ECHO_PUBLICKEY", "value" : "${echo_public_key}" },

--- a/automation/terraform/modules/services/graphql-proxy/templates/container-definition.json.tpl
+++ b/automation/terraform/modules/services/graphql-proxy/templates/container-definition.json.tpl
@@ -19,8 +19,8 @@
       }
     },
     "environment" : [
-        { "name" : "CODA_GRAPHQL_HOST", "value" : "${coda_graphql_host}" },
-        { "name" : "CODA_GRAPHQL_PORT", "value" : "${coda_graphql_port}" },
+        { "name" : "MINA_GRAPHQL_HOST", "value" : "${coda_graphql_host}" },
+        { "name" : "MINA_GRAPHQL_PORT", "value" : "${coda_graphql_port}" },
         { "name" : "EXTERNAL_PORT", "value" : "${proxy_external_port}" }
     ]
   },

--- a/buildkite/src/Jobs/Release/BotArtifact.dhall
+++ b/buildkite/src/Jobs/Release/BotArtifact.dhall
@@ -39,7 +39,7 @@ Pipeline.build
       Command.build
         Command.Config::{
           commands = [
-              Cmd.run "echo export CODA_VERSION=$(cat frontend/bot/package.json | jq '.version') > BOT_DEPLOY_ENV && buildkite/scripts/buildkite-artifact-helper.sh BOT_DEPLOY_ENV"
+              Cmd.run "echo export MINA_VERSION=$(cat frontend/bot/package.json | jq '.version') > BOT_DEPLOY_ENV && buildkite/scripts/buildkite-artifact-helper.sh BOT_DEPLOY_ENV"
           ],
           label = "Setup o1bot docker image deploy environment",
           key = "setup-deploy-env",

--- a/buildkite/src/Jobs/Release/LeaderboardArtifact.dhall
+++ b/buildkite/src/Jobs/Release/LeaderboardArtifact.dhall
@@ -39,7 +39,7 @@ Pipeline.build
       Command.build
         Command.Config::{
           commands = [
-              Cmd.run "echo export CODA_VERSION=$(cat frontend/leaderboard/package.json | jq '.version') > LEADERBOARD_DEPLOY_ENV && buildkite/scripts/buildkite-artifact-helper.sh LEADERBOARD_DEPLOY_ENV"
+              Cmd.run "echo export MINA_VERSION=$(cat frontend/leaderboard/package.json | jq '.version') > LEADERBOARD_DEPLOY_ENV && buildkite/scripts/buildkite-artifact-helper.sh LEADERBOARD_DEPLOY_ENV"
           ],
           label = "Setup Leaderboard docker image deploy environment",
           key = "setup-deploy-env",

--- a/frontend/bot/Dockerfile
+++ b/frontend/bot/Dockerfile
@@ -15,8 +15,8 @@ COPY ./src ./src
 RUN yarn build-without-copy
 
 
-ENV CODA_GRAPHQL_HOST=localhost
-ENV CODA_GRAPHQL_PORT=8304
+ENV MINA_GRAPHQL_HOST=localhost
+ENV MINA_GRAPHQL_PORT=8304
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
@@ -24,4 +24,4 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 ENTRYPOINT ["bash", "-c"]
-CMD ["dockerize -wait tcp://$CODA_GRAPHQL_HOST:$CODA_GRAPHQL_PORT -timeout 90s && yarn start" ]
+CMD ["dockerize -wait tcp://$MINA_GRAPHQL_HOST:$MINA_GRAPHQL_PORT -timeout 90s && yarn start" ]

--- a/frontend/bot/README.md
+++ b/frontend/bot/README.md
@@ -7,5 +7,5 @@ It is a *Coda Service*, meaning it is necessary to run this alongside a synced a
 `ECHO_PUBLICKEY`: Coda Public Key that corresponds to a installed wallet
 `FAUCET_PUBLICKEY`: Coda Public Key that corresponds to a installed wallet
 `DISCORD_API_KEY`: A Discord Bot API Key
-`CODA_GRAPHQL_HOST`: Defaults to `localhost`, the hostname of the *Coda Daemon* 
-`CODA_GRAPHQL_PORT`: Defaults to `0xc0d` (3085), the port the *Coda Daemon* is listening on 
+`MINA_GRAPHQL_HOST`: Defaults to `localhost`, the hostname of the *Coda Daemon* 
+`MINA_GRAPHQL_PORT`: Defaults to `0xc0d` (3085), the port the *Coda Daemon* is listening on 

--- a/frontend/bot/src/Constants.re
+++ b/frontend/bot/src/Constants.re
@@ -24,8 +24,8 @@ let faucetPassword = getEnvOrFail("FAUCET_PASSWORD");
 
 let discordApiKey = getEnvOrFail("DISCORD_API_KEY");
 
-let graphqlPort = getEnv(~default=string_of_int(0xc0d), "CODA_GRAPHQL_PORT");
-let graphqlHost = getEnv(~default="localhost", "CODA_GRAPHQL_HOST");
+let graphqlPort = getEnv(~default=string_of_int(0xc0d), "MINA_GRAPHQL_PORT");
+let graphqlHost = getEnv(~default="localhost", "MINA_GRAPHQL_HOST");
 
 let listeningChannels = ["faucet"];
 let faucetApproveRole = "faucet-approvers";

--- a/frontend/points-hack-april20/Dockerfile
+++ b/frontend/points-hack-april20/Dockerfile
@@ -9,8 +9,8 @@ RUN yarn install && yarn cache clean
 
 COPY lib.js .
 
-ENV CODA_GRAPHQL_HOST=localhost
-ENV CODA_GRAPHQL_PORT=3085
+ENV MINA_GRAPHQL_HOST=localhost
+ENV MINA_GRAPHQL_PORT=3085
 
 ENV GOOGLE_CLOUD_STORAGE_API_KEY=
 
@@ -20,5 +20,5 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 ENTRYPOINT ["bash", "-c"]
-CMD ["dockerize -wait tcp://$CODA_GRAPHQL_HOST:$CODA_GRAPHQL_PORT -timeout 90s && node lib.js" ]
+CMD ["dockerize -wait tcp://$MINA_GRAPHQL_HOST:$MINA_GRAPHQL_PORT -timeout 90s && node lib.js" ]
 

--- a/frontend/points-hack-april20/lib.js
+++ b/frontend/points-hack-april20/lib.js
@@ -12,9 +12,9 @@ const fs = require("fs");
 const { tmpdir } = require("os");
 const Path = require("path");
 
-const CODA_GRAPHQL_HOST = process.env["CODA_GRAPHQL_HOST"] || "localhost";
-const CODA_GRAPHQL_PORT = process.env["CODA_GRAPHQL_PORT"] || 3085;
-const CODA_GRAPHQL_PATH = process.env["CODA_GRAPHQL_PATH"] || "/graphql";
+const MINA_GRAPHQL_HOST = process.env["MINA_GRAPHQL_HOST"] || "localhost";
+const MINA_GRAPHQL_PORT = process.env["MINA_GRAPHQL_PORT"] || 3085;
+const MINA_GRAPHQL_PATH = process.env["MINA_GRAPHQL_PATH"] || "/graphql";
 const CODA_TESTNET_NAME = process.env["CODA_TESTNET_NAME"] || "unknown";
 
 const API_KEY_SECRET = process.env["GOOGLE_CLOUD_STORAGE_API_KEY"];
@@ -29,7 +29,7 @@ const json_file_path = Path.join(tmpdir(), "google_cloud_api_key.json");
 fs.writeFileSync(json_file_path, API_KEY_SECRET);
 
 const graphqlUriNoScheme =
-  CODA_GRAPHQL_HOST + ":" + CODA_GRAPHQL_PORT + CODA_GRAPHQL_PATH;
+  MINA_GRAPHQL_HOST + ":" + MINA_GRAPHQL_PORT + MINA_GRAPHQL_PATH;
 const httpLink = new HttpLink({
   uri: "http://" + graphqlUriNoScheme,
   fetch: fetch,

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -132,9 +132,9 @@ spec:
             cpu: 0.1
         image: {{ $.Values.bots.image }}
         env:
-          - name: CODA_GRAPHQL_HOST
+          - name: MINA_GRAPHQL_HOST
             value: "0.0.0.0"
-          - name: CODA_GRAPHQL_PORT
+          - name: MINA_GRAPHQL_PORT
             value: {{ $.Values.bots.ports.graphql | quote }}
           - name: ECHO_PUBLICKEY
             valueFrom:


### PR DESCRIPTION
Use environment variables `MINA_GRAPHQL_HOST` and `MINA_GRAPHQL_PORT` instead of `CODA_...` equivalents.

All uses of the old variables in the codebase are changed here.