### PR TITLE
MINA_TRACING environment variable

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -5,7 +5,7 @@ When starting a daemon with `-tracing` or using `mina client start-tracing`,
 it will write `*.trace` files into its config directory. They can grow
 quite fast, but for the most part they grow no faster than 5MB/minute.
 
-Most of the integration tests (including full-test) support a `CODA_TRACING`
+Most of the integration tests (including full-test) support a `MINA_TRACING`
 environment variable that specifies the directory the integration tests
 will put their trace files in. If you leave it empty, no tracing will
 occur.

--- a/src/app/cli/src/tests/coda_peers_test.ml
+++ b/src/app/cli/src/tests/coda_peers_test.ml
@@ -33,7 +33,7 @@ let main () =
     Coda_processes.local_configs n ~program_dir ~block_production_interval
       ~acceptable_delay ~chain_id:name ~snark_worker_public_keys:None
       ~block_production_keys:(Fn.const None) ~work_selection_method
-      ~trace_dir:(Unix.getenv "CODA_TRACING")
+      ~trace_dir:(Unix.getenv "MINA_TRACING")
       ~max_concurrent_connections:None
       ~runtime_config:precomputed_values.runtime_config
   in

--- a/src/app/cli/src/tests/coda_transitive_peers_test.ml
+++ b/src/app/cli/src/tests/coda_transitive_peers_test.ml
@@ -29,7 +29,7 @@ let main () =
     Cli_lib.Arg_type.Work_selection_method.Sequence
   in
   Coda_processes.init () ;
-  let trace_dir = Unix.getenv "CODA_TRACING" in
+  let trace_dir = Unix.getenv "MINA_TRACING" in
   let max_concurrent_connections = None in
   let%bind configs =
     Coda_processes.local_configs n ~program_dir ~block_production_interval

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -482,7 +482,7 @@ let test ?archive_process_location ?is_archive_rocksdb ~name logger n
       ~block_production_keys ~acceptable_delay ~chain_id:name
       ~snark_worker_public_keys:(Some (List.init n ~f:snark_work_public_keys))
       ~work_selection_method
-      ~trace_dir:(Unix.getenv "CODA_TRACING")
+      ~trace_dir:(Unix.getenv "MINA_TRACING")
       ~max_concurrent_connections ?is_archive_rocksdb ?archive_process_location
       ~runtime_config
   in

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -95,7 +95,7 @@ let run_test () : unit Deferred.t =
     ~f:(fun temp_conf_dir ->
       let keypair = Genesis_ledger.largest_account_keypair_exn () in
       let%bind () =
-        match Unix.getenv "CODA_TRACING" with
+        match Unix.getenv "MINA_TRACING" with
         | Some trace_dir ->
             let%bind () = Async.Unix.mkdir ~p:() trace_dir in
             Coda_tracing.start trace_dir


### PR DESCRIPTION
Replace `CODA_TRACING` environment variable with `MINA_TRACING`.

As far as I see, we're only using this variable internally, in the CLI tests (which we're not running).