### PR TITLE
MINA_CONFIG... environment variables

### DIFF
--- a/dockerfiles/Dockerfile-rosetta-hardcoded
+++ b/dockerfiles/Dockerfile-rosetta-hardcoded
@@ -277,7 +277,7 @@ FROM debian@sha256:b527bec3708ee1fe2ffb4625d742a60bb45b06064e7c64a81b16550fe4271
 
 ARG POSTGRES_DATA_DIR=/data/postgresql
 ARG CODA_DAEMON_PORT=10101
-ARG CODA_CONFIG_DIR=/root/.mina-config
+ARG MINA_CONFIG_DIR=/root/.mina-config
 # Sample public key for use in dev profile / demo mode genesis block
 ARG PK=B62qrPN5Y5yq8kGE3FbVKbGTdTAJNdtNtB5sNVpxyRwWGcDEhpMzc8g
 
@@ -319,14 +319,14 @@ COPY --from=builder /home/opam/coda/src/app/rosetta/config.json /data/config.jso
 
 
 # Set up coda config dir with demo mode keys and genesis
-COPY --from=builder /home/opam/demo-genesis ${CODA_CONFIG_DIR}/demo-genesis
-COPY --from=builder /home/opam/coda/src/app/rosetta/demo-config.json ${CODA_CONFIG_DIR}/daemon.json
+COPY --from=builder /home/opam/demo-genesis ${MINA_CONFIG_DIR}/demo-genesis
+COPY --from=builder /home/opam/coda/src/app/rosetta/demo-config.json ${MINA_CONFIG_DIR}/daemon.json
 
-RUN mkdir -p --mode=700 ${CODA_CONFIG_DIR}/wallets/store/ \
-  && echo "$PK" >  ${CODA_CONFIG_DIR}/wallets/store/$PK.pub \
+RUN mkdir -p --mode=700 ${MINA_CONFIG_DIR}/wallets/store/ \
+  && echo "$PK" >  ${MINA_CONFIG_DIR}/wallets/store/$PK.pub \
   && echo '{"box_primitive":"xsalsa20poly1305","pw_primitive":"argon2i","nonce":"8jGuTAxw3zxtWasVqcD1H6rEojHLS1yJmG3aHHd","pwsalt":"AiUCrMJ6243h3TBmZ2rqt3Voim1Y","pwdiff":[134217728,6],"ciphertext":"DbAy736GqEKWe9NQWT4yaejiZUo9dJ6rsK7cpS43APuEf5AH1Qw6xb1s35z8D2akyLJBrUr6m"}' \
-  > ${CODA_CONFIG_DIR}/wallets/store/${PK} \
-  && chmod go-rwx ${CODA_CONFIG_DIR}/wallets/store/${PK}
+  > ${MINA_CONFIG_DIR}/wallets/store/${PK} \
+  && chmod go-rwx ${MINA_CONFIG_DIR}/wallets/store/${PK}
 
 USER postgres
 

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -318,7 +318,7 @@ let setup_daemon logger =
   and config_files =
     flag "--config-file" ~aliases:["config-file"]
       ~doc:
-        "PATH path to a configuration file (overrides CODA_CONFIG_FILE, \
+        "PATH path to a configuration file (overrides MINA_CONFIG_FILE, \
          default: <config_dir>/daemon.json). Pass multiple times to override \
          fields from earlier config files"
       (listed string)
@@ -606,10 +606,17 @@ let setup_daemon logger =
         (conf_dir ^/ "daemon.json", `May_be_missing)
       in
       let config_file_envvar =
-        match Sys.getenv "CODA_CONFIG_FILE" with
-        | Some config_file ->
+        (* TODO: remove deprecated variable, eventually *)
+        let mina_config_file = "MINA_CONFIG_FILE" in
+        let coda_config_file = "CODA_CONFIG_FILE" in
+        match Sys.getenv mina_config_file,Sys.getenv coda_config_file with
+        | Some config_file, _ ->
             Some (config_file, `Must_exist)
-        | None ->
+        | None, Some config_file ->
+          [%log warn] "Using deprecated environment variable %s, please use %s instead"
+            coda_config_file mina_config_file;
+          Some (config_file, `Must_exist)
+        | None, None ->
             None
       in
       let config_files =

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1933,10 +1933,16 @@ let compile_time_constants =
            home ^/ Cli_lib.Default.conf_dir_name
          in
          let config_file =
-           match Sys.getenv "CODA_CONFIG_FILE" with
-           | Some config_file ->
+           (* TODO: eventually, remove CODA_ variable *)
+           let mina_config_file = "MINA_CONFIG_FILE" in
+           let coda_config_file = "CODA_CONFIG_FILE" in
+           match Sys.getenv mina_config_file, Sys.getenv coda_config_file with
+           | Some config_file,_ ->
                config_file
-           | None ->
+           | None, Some config_file ->
+             (* we print a deprecation warning on daemon startup, don't print here *)
+             config_file
+           | None, None ->
                conf_dir ^/ "daemon.json"
          in
          let open Async in
@@ -1987,7 +1993,7 @@ let compile_time_constants =
                    (Unsigned.UInt32.to_int consensus_constants.slots_per_epoch)
                ) ]
          in
-         Core.printf "%s\n%!" (Yojson.Safe.to_string all_constants) ))
+         Core_kernel.printf "%s\n%!" (Yojson.Safe.to_string all_constants) ))
 
 let node_status =
   let open Command.Param in

--- a/src/app/rosetta/run-demo.sh
+++ b/src/app/rosetta/run-demo.sh
@@ -11,6 +11,6 @@ now_time=$(date +%s)
 
 export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
 export CODA_PRIVKEY_PASS=""
-export CODA_CONFIG_FILE=/tmp/config.json
+export MINA_CONFIG_FILE=/tmp/config.json
 
 exec $BIN daemon -seed -demo-mode -block-producer-key /tmp/keys/demo-block-producer -run-snark-worker $SNARK_PK -config-file /tmp/config.json -insecure-rest-server $@

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -512,10 +512,16 @@ let get_consensus_constants ~logger :
     Filename.concat home ".coda-config"
   in
   let config_file =
-    match Sys.getenv "CODA_CONFIG_FILE" with
-    | Some config_file ->
+    let mina_config_file = "MINA_CONFIG_FILE" in
+    let coda_config_file = "CODA_CONFIG_FILE" in
+    match Sys.getenv mina_config_file,Sys.getenv coda_config_file with
+    | Some config_file,_ ->
         config_file
-    | None ->
+    | None,Some config_file ->
+      [%log warn] "Using deprecated environment variable %s, please use %s instead"
+        coda_config_file mina_config_file;
+      config_file
+    | None,None ->
         Filename.concat conf_dir "config.json"
   in
   let%bind config =


### PR DESCRIPTION
Use environment variables `MINA_CONFIG_DIR` and `MINA_CONFIG_FILE`.

The first of these is used internally in the Rosetta Dockerfile and demo scripts.

The second is used in the daemon startup, an `advanced` command, and the Rosetta test agent, so we still allow use of `CODA_CONFIG_FILE`. In the cases of the daemon startup and the Rosetta test agent, we print a deprecation message.

Part of #9041.