### PR TITLE
MINA_KEYS_PATH

### DIFF
--- a/src/lib/cache_dir/cache_dir.ml
+++ b/src/lib/cache_dir/cache_dir.ml
@@ -32,10 +32,15 @@ let cache =
   ]
 
 let env_path =
-  match Sys.getenv "CODA_KEYS_PATH" with
-  | Some path ->
+  (* TODO: remove deprecated variable, eventually *)
+  let mina_keys_path = "MINA_KEYS_PATH" in
+  let coda_keys_path = "CODA_KEYS_PATH" in
+  match (Sys.getenv mina_keys_path, Sys.getenv coda_keys_path) with
+  | Some path, _ ->
       path
-  | None ->
+  | None, Some path ->
+      path
+  | None, None ->
       manual_install_path
 
 let possible_paths base =


### PR DESCRIPTION
Add `MINA_KEYS_PATH`, while still allowing use of `CODA_KEYS_PATH`.

Part of #9041.