### PR TITLE
MINA_INTEGRATION_TEST_DIR, MINA_prog_PATH

### DIFF
--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -25,7 +25,7 @@ let local_config ?block_production_interval:_ ~is_seed ~peers ~addrs_and_ports
     ~offset ~trace_dir ~max_concurrent_connections ~is_archive_rocksdb
     ~archive_process_location ~runtime_config () =
   let conf_dir =
-    match Sys.getenv "CODA_INTEGRATION_TEST_DIR" with
+    match Sys.getenv "MINA_INTEGRATION_TEST_DIR" with
     | Some dir ->
         dir
         ^/ Network_peer.Peer.Id.to_string
@@ -38,7 +38,7 @@ let local_config ?block_production_interval:_ ~is_seed ~peers ~addrs_and_ports
     not ([%equal: [`Yes | `No | `Unknown]] (Core.Sys.file_exists conf_dir) `No)
   then
     failwithf
-      "cannot configure coda process because directory already exists: %s"
+      "cannot configure Mina process because directory already exists: %s"
       conf_dir () ;
   let config =
     { Coda_worker.Input.addrs_and_ports

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -273,6 +273,7 @@ let start_custom :
   in
   let%bind process =
     keep_trying
+      (* TODO: remove CODA...PATH and coda-, eventually *)
       (List.filter_opt
          [ Unix.getenv @@ "MINA_" ^ String.uppercase name ^ "_PATH"
          ; Unix.getenv @@ "CODA_" ^ String.uppercase name ^ "_PATH"

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -274,7 +274,8 @@ let start_custom :
   let%bind process =
     keep_trying
       (List.filter_opt
-         [ Unix.getenv @@ "CODA_" ^ String.uppercase name ^ "_PATH"
+         [ Unix.getenv @@ "MINA_" ^ String.uppercase name ^ "_PATH"
+         ; Unix.getenv @@ "CODA_" ^ String.uppercase name ^ "_PATH"
          ; relative_to_root
          ; Some (Filename.dirname mina_binary_path ^/ name)
          ; Some ("mina-" ^ name)


### PR DESCRIPTION
Use `MINA_INTEGRATION_TEST_DIR` for the CLI tests. Those tests are not currently run, and this variable doesn't appear elsewhere, so I think it's not important to use the old name.

For child processes, allow `MINA_prog_PATH`, in addition to `CODA_prog_PATH`.

Part of #9041.