### PR TITLE
rename External_transition.broadcast

### DIFF
--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -324,10 +324,10 @@ let payments t =
     | _ ->
         None)
 
-let broadcast t =
+let accept t =
   Mina_net2.Validation_callback.fire_exn (validation_callback t) `Accept
 
-let don't_broadcast t =
+let reject t =
   Mina_net2.Validation_callback.fire_exn (validation_callback t) `Reject
 
 let poke_validation_callback t cb = set_validation_callback t cb
@@ -909,9 +909,9 @@ module With_validation = struct
 
   let protocol_version_status t = lift protocol_version_status t
 
-  let broadcast t = lift broadcast t
+  let accept t = lift accept t
 
-  let don't_broadcast t = lift don't_broadcast t
+  let reject t = lift reject t
 
   let poke_validation_callback t = lift poke_validation_callback t
 end
@@ -1046,8 +1046,8 @@ module Validated = struct
     , current_protocol_version
     , proposed_protocol_version_opt
     , protocol_version_status
-    , broadcast
-    , don't_broadcast
+    , accept
+    , reject
     , poke_validation_callback
     , protocol_state_proof
     , blockchain_state

--- a/src/lib/mina_transition/external_transition_intf.ml
+++ b/src/lib/mina_transition/external_transition_intf.ml
@@ -57,9 +57,9 @@ module type External_transition_common_intf = sig
 
   val proposed_protocol_version_opt : t -> Protocol_version.t option
 
-  val broadcast : t -> unit
+  val accept : t -> unit
 
-  val don't_broadcast : t -> unit
+  val reject : t -> unit
 
   val poke_validation_callback : t -> Mina_net2.Validation_callback.t -> unit
 end


### PR DESCRIPTION
Renamed `broadcast` and `don't_broadcast` in external_transition.ml to to `accept` and `reject`. Added some comments explaining what setting the validation callbacks for different transitions (gossiped vs produced vs downloaded for catchup) does.


Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
