### PR TITLE
Add nix development setup script

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -32,6 +32,14 @@ The short version:
 You can build Mina using Docker. This should work in any dev environment.
 Refer to [/dev](/dev).
 
+### Developer Setup (NixOS/nix)
+
+When using nix package manager, run `scripts/nixos-setup.sh` script to install all of the dependencies.
+
+This script was tested on channel `20.03` but should work well on newer channels too.
+
+Troubleshooting tip: to remove everything and build from scratch, use `rm -Rf ~/.opam _build`.
+
 ### Developer Setup (MacOS)
 
 - Invoke `make macos-setup`

--- a/README-dev.md
+++ b/README-dev.md
@@ -27,6 +27,22 @@ The short version:
       you need to [set up SSH keys on your machine](https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).
 4.  Run `git config --local --add submodule.recurse true`
 
+### Connecting to mainnet
+
+1. Build mina with `DUNE_PROFILE=mainnet make build`
+2. Launch with `_build/default/src/app/cli/src/mina.exe daemon --config-file genesis_ledgers/mainnet.json --generate-genesis-proof true --peer-list-url https://storage.googleapis.com/mina-seed-lists/mainnet_seeds.txt`
+
+Please be aware that direct access to port 8302 is required for other nodes to be able to connect to your node (for your node to properly participate in the network). If your IPS doesn't allow you such setup, the following trick might be utilized:
+
+1. Configure your machine's firewall to allow incoming traffic on port 8302 (or other port configured with `--external-port` CLI argument)
+2. Setup a remote ssh host by setting `GatewayPorts yes` in your sshd config (on ubuntu: edit `/etc/ssh/sshd_config`)
+3. Restart ssh service on remote host (on ubuntu: `sudo systemctl restart sshd`)
+4. Install `sshuttle` onto your local machine
+5. Run following commands in parallel: `sudo sshuttle -r username@sshserver 0/0` and `ssh -NCR 8302:127.0.0.1:8302 username@sshserver`
+
+That's it! With `sshuttle` you will use remote SSH server as VPN server and all outgoing connections will look like as if they were initiated by the remote host. And `ssh -NCR` allows incoming connections to reach your local Mina node.
+
+
 ### Developer Setup (Docker)
 
 You can build Mina using Docker. This should work in any dev environment.
@@ -39,6 +55,19 @@ When using nix package manager, run `scripts/nixos-setup.sh` script to install a
 This script was tested on channel `20.03` but should work well on newer channels too.
 
 Troubleshooting tip: to remove everything and build from scratch, use `rm -Rf ~/.opam _build`.
+
+
+#### Testing on a remote host
+
+For binaries built with nix there is an easy way to test mina on a remote host.
+
+1. Make sure your host has at least 16GB of RAM and direct external IP address
+2. Setup nix with `scripts/nixos-setup.sh`
+3. Build mina for mainnet with `nix-shell --run 'DUNE_PROFILE=mainnet make build'`
+4. Configure SSH host with `scripts/upload-nix-remote.sh root@{sshserver}`
+5. Launch Mina daemon with `ssh root@{sshserver} 'su -c "cd /home/mina && ./launch.sh daemon --config-file genesis_ledgers/mainnet.json --generate-genesis-proof true --peer-list-url https://storage.googleapis.com/mina-seed-lists/mainnet_seeds.txt" mina'`
+
+Note that scripts will setup user `mina` on the remote machine.
 
 ### Developer Setup (MacOS)
 

--- a/scripts/nix-setup.sh
+++ b/scripts/nix-setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+nix-shell --run "rustup update stable"
+
+nix-shell --run "git submodule update --init --recursive"
+nix-shell --run "opam init -y"
+nix-shell --run "opam switch create -y ocaml-base-compiler.4.11.2"
+nix-shell --run "opam switch import -y src/opam.export"
+
+set -e
+
+nix-shell --run "opam install -y ocaml-lsp-server"
+nix-shell --run 'NIX_SODIUM_LDFLAGS=$(pkg-config --libs-only-L libsodium) ./scripts/pin-external-packages.sh'
+nix-shell --run "make build"

--- a/scripts/setup-nix-remote.sh
+++ b/scripts/setup-nix-remote.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+USER=mina
+
+cat <<EOT >> launch.sh
+#!/usr/bin/env bash
+
+. ~/.nix-profile/etc/profile.d/nix.sh
+nix-channel --add https://nixos.org/channels/nixos-20.09 nixpkgs && nix-channel --update
+
+export MINA_LIBP2P_HELPER_PATH=./helper
+nix-shell --run "./mina \$*"
+EOT
+
+chmod +x launch.sh
+
+ufw allow 8302/tcp
+useradd -s /bin/bash -d /home/$USER -m $USER
+mkdir -p -m 0755 /nix && sudo chown -R $USER:$USER /nix
+mv {mina,helper,launch.sh,shell.nix,genesis_ledgers} /home/$USER
+curl -L https://nixos.org/nix/install > /home/$USER/setup-nix.sh
+chmod +x /home/$USER/setup-nix.sh
+chown -R $USER:$USER /home/$USER/{mina,helper,launch.sh,shell.nix,.ssh,setup-nix.sh,genesis_ledgers}
+su -c "sh -c 'cd ~; ./setup-nix.sh'" $USER

--- a/scripts/upload-nix-remote.sh
+++ b/scripts/upload-nix-remote.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [[ "$1" == "" ]]; then
+  echo "specify username@sshserver as the argument for the script"
+  exit 1
+fi
+
+ssh "$1" 'mkdir -p genesis_ledgers'
+scp -C genesis_ledgers/*.json "$1":genesis_ledgers
+scp -C _build/default/src/app/cli/src/mina.exe "$1":mina
+scp -C src/app/libp2p_helper/result/bin/libp2p_helper "$1":helper
+scp scripts/setup-nix-remote.sh "$1":setup.sh
+scp shell.nix "$1":shell.nix
+
+ssh "$1" ./setup.sh

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+with import <nixpkgs> {};
+mkShell {
+  nativeBuildInputs = 
+    [ opam pkgconfig
+      m4 openssl gmp jemalloc libffi
+      libsodium postgresql
+      rocksdb
+      rustup # ships both cargo and rustc
+      zlib bzip2
+      capnproto go_1_16
+      pythonPackages.jinja2
+      pythonPackages.readchar
+    ];
+  shellHook = ''
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.postgresql.lib}/lib"
+    eval $(opam env 2>/dev/null)
+    '';
+}

--- a/src/external/ocaml-sodium/myocamlbuild.ml
+++ b/src/external/ocaml-sodium/myocamlbuild.ml
@@ -1,98 +1,109 @@
-open Ocamlbuild_plugin;;
-open Ocamlbuild_pack;;
+open Ocamlbuild_plugin
+open Ocamlbuild_pack
 
+;;
 let ctypes_libdir = Sys.getenv "CTYPES_LIB_DIR" in
 let ocaml_libdir = Sys.getenv "OCAML_LIB_DIR" in
 let lsodium =
   let cwd = Unix.getcwd () in
   let uname_chan = Unix.open_process_in "uname" in
   let l = input_line uname_chan in
-  match l with
-  | "Darwin" -> [A "-cclib"; A "-lsodium"]
-  | "Linux" ->
-      [ A "-cclib"
-      ; A "-Wl,--push-state,-Bstatic"
-      ; A "-cclib"
-      ; A "-lsodium"
-      ; A "-cclib"
-      ; A "-Wl,--pop-state" ]
-  | s -> failwith (Printf.sprintf "don't know how to link on %s yet" s)
+  let def_flags = [ A "-cclib"; A "-lsodium" ] in
+  match l, Sys.getenv_opt "NIX_SODIUM_LDFLAGS" with
+  | "Darwin", None ->
+      def_flags
+  | _, Some ldfs ->
+      List.append [ A "-cclib"; A ldfs ] def_flags
+  | "Linux", None ->
+    [ A "-cclib"
+    ; A "-Wl,--push-state,-Bstatic"
+    ; A "-cclib"
+    ; A "-lsodium"
+    ; A "-cclib"
+    ; A "-Wl,--pop-state"
+    ]
+  | s, _ ->
+      failwith (Printf.sprintf "don't know how to link on %s yet" s)
 in
-dispatch begin
-  function
+dispatch (function
   | After_rules ->
+      rule "cstubs: lib_gen/x_types_detect.c -> x_types_detect"
+        ~prods:[ "lib_gen/%_types_detect" ] ~deps:[ "lib_gen/%_types_detect.c" ]
+        (fun env build ->
+          Cmd
+            (S
+               [ A "cc"
+               ; A "-I"
+               ; A ctypes_libdir
+               ; A "-I"
+               ; A ocaml_libdir
+               ; A "-o"
+               ; A (env "lib_gen/%_types_detect")
+               ; A (env "lib_gen/%_types_detect.c")
+               ])) ;
 
-    rule "cstubs: lib_gen/x_types_detect.c -> x_types_detect"
-      ~prods:["lib_gen/%_types_detect"]
-      ~deps:["lib_gen/%_types_detect.c"]
-      (fun env build ->
-         Cmd (S[A"cc";
-                A("-I"); A ctypes_libdir;
-                A("-I"); A ocaml_libdir;
-                A"-o";
-                A(env "lib_gen/%_types_detect");
-                A(env "lib_gen/%_types_detect.c");
-               ]));
+      rule "cstubs: lib_gen/x_types_detect -> lib/x_types_detected.ml"
+        ~prods:[ "lib/%_types_detected.ml" ] ~deps:[ "lib_gen/%_types_detect" ]
+        (fun env build ->
+          Cmd
+            (S
+               [ A (env "lib_gen/%_types_detect")
+               ; Sh ">"
+               ; A (env "lib/%_types_detected.ml")
+               ])) ;
 
-    rule "cstubs: lib_gen/x_types_detect -> lib/x_types_detected.ml"
-      ~prods:["lib/%_types_detected.ml"]
-      ~deps:["lib_gen/%_types_detect"]
-      (fun env build ->
-         Cmd (S[A(env "lib_gen/%_types_detect");
-                Sh">";
-                A(env "lib/%_types_detected.ml");
-               ]));
+      rule "cstubs: lib_gen/x_types.ml -> x_types_detect.c"
+        ~prods:[ "lib_gen/%_types_detect.c" ] ~deps:[ "lib_gen/%_typegen.byte" ]
+        (fun env build -> Cmd (A (env "lib_gen/%_typegen.byte"))) ;
 
-    rule "cstubs: lib_gen/x_types.ml -> x_types_detect.c"
-      ~prods:["lib_gen/%_types_detect.c"]
-      ~deps: ["lib_gen/%_typegen.byte"]
-      (fun env build ->
-         Cmd (A(env "lib_gen/%_typegen.byte")));
+      copy_rule "cstubs: lib_gen/x_types.ml -> lib/x_types.ml"
+        "lib_gen/%_types.ml" "lib/%_types.ml" ;
 
-    copy_rule "cstubs: lib_gen/x_types.ml -> lib/x_types.ml"
-      "lib_gen/%_types.ml" "lib/%_types.ml";
+      rule "cstubs: lib/x_bindings.ml -> x_stubs.c, x_stubs.ml"
+        ~prods:[ "lib/%_stubs.c"; "lib/%_generated.ml" ]
+        ~deps:[ "lib_gen/%_bindgen.byte" ] (fun env build ->
+          Cmd (A (env "lib_gen/%_bindgen.byte"))) ;
 
-    rule "cstubs: lib/x_bindings.ml -> x_stubs.c, x_stubs.ml"
-      ~prods:["lib/%_stubs.c"; "lib/%_generated.ml"]
-      ~deps: ["lib_gen/%_bindgen.byte"]
-      (fun env build ->
-        Cmd (A(env "lib_gen/%_bindgen.byte")));
+      copy_rule "cstubs: lib_gen/x_bindings.ml -> lib/x_bindings.ml"
+        "lib_gen/%_bindings.ml" "lib/%_bindings.ml" ;
 
-    copy_rule "cstubs: lib_gen/x_bindings.ml -> lib/x_bindings.ml"
-      "lib_gen/%_bindings.ml" "lib/%_bindings.ml";
+      flag [ "c"; "compile" ] & S [ A "-ccopt"; A "-I/usr/local/include" ] ;
+      flag [ "c"; "ocamlmklib" ] & A "-L/usr/local/lib" ;
+      flag [ "ocaml"; "link"; "native"; "program" ]
+      & S [ A "-cclib"; A "-L/usr/local/lib" ] ;
 
-    flag ["c"; "compile"] & S[A"-ccopt"; A"-I/usr/local/include"];
-    flag ["c"; "ocamlmklib"] & A"-L/usr/local/lib";
-    flag ["ocaml"; "link"; "native"; "program"] &
-      S[A"-cclib"; A"-L/usr/local/lib"];
+      (* Linking cstubs *)
+      flag [ "c"; "compile"; "use_ctypes" ] & S [ A "-I"; A ctypes_libdir ] ;
+      flag [ "c"; "compile"; "debug" ] & A "-g" ;
 
-    (* Linking cstubs *)
-    flag ["c"; "compile"; "use_ctypes"] & S[A"-I"; A ctypes_libdir];
-    flag ["c"; "compile"; "debug"] & A"-g";
+      (* Linking sodium *)
+      flag [ "c"; "compile"; "use_sodium" ]
+      & S
+          [ A "-ccopt"
+          ; A "--std=c99 -Wall -pedantic -Werror -Wno-pointer-sign"
+          ] ;
+      flag [ "c"; "ocamlmklib"; "use_sodium" ] & S lsodium ;
 
-    (* Linking sodium *)
-    flag ["c"; "compile"; "use_sodium"] &
-      S[A"-ccopt"; A"--std=c99 -Wall -pedantic -Werror -Wno-pointer-sign"];
-    flag ["c"; "ocamlmklib"; "use_sodium"] & S lsodium;
+      (* Linking generated stubs *)
+      dep
+        [ "ocaml"; "link"; "byte"; "library"; "use_sodium_stubs" ]
+        [ "lib/dllsodium_stubs" -.- !Options.ext_dll ] ;
+      flag [ "ocaml"; "link"; "byte"; "library"; "use_sodium_stubs" ]
+      & S [ A "-dllib"; A "-lsodium_stubs" ] ;
 
-    (* Linking generated stubs *)
-    dep ["ocaml"; "link"; "byte"; "library"; "use_sodium_stubs"]
-      ["lib/dllsodium_stubs"-.-(!Options.ext_dll)];
-    flag ["ocaml"; "link"; "byte"; "library"; "use_sodium_stubs"] &
-      S[A"-dllib"; A"-lsodium_stubs"];
+      dep
+        [ "ocaml"; "link"; "native"; "library"; "use_sodium_stubs" ]
+        [ "lib/libsodium_stubs" -.- !Options.ext_lib ] ;
+      flag [ "ocaml"; "link"; "native"; "library"; "use_sodium_stubs" ]
+      & S (List.append [ A "-cclib"; A "-lsodium_stubs" ] lsodium) ;
 
-    dep ["ocaml"; "link"; "native"; "library"; "use_sodium_stubs"]
-      ["lib/libsodium_stubs"-.-(!Options.ext_lib)];
-    flag ["ocaml"; "link"; "native"; "library"; "use_sodium_stubs"] &
-      S (List.append [A"-cclib"; A"-lsodium_stubs"] lsodium);
-
-    (* Linking tests *)
-    flag ["ocaml"; "link"; "byte"; "program"; "use_sodium_stubs"] &
-      S[A"-dllib"; A"-lsodium_stubs"];
-    dep ["ocaml"; "link"; "native"; "program"; "use_sodium_stubs"]
-      ["lib/libsodium_stubs"-.-(!Options.ext_lib)];
-    flag ["ocaml"; "link"; "native"; "program"; "use_sodium_stubs"] &
-      S lsodium;
-
-  | _ -> ()
-end;;
+      (* Linking tests *)
+      flag [ "ocaml"; "link"; "byte"; "program"; "use_sodium_stubs" ]
+      & S [ A "-dllib"; A "-lsodium_stubs" ] ;
+      dep
+        [ "ocaml"; "link"; "native"; "program"; "use_sodium_stubs" ]
+        [ "lib/libsodium_stubs" -.- !Options.ext_lib ] ;
+      flag [ "ocaml"; "link"; "native"; "program"; "use_sodium_stubs" ]
+      & S lsodium
+  | _ ->
+      ())

--- a/src/lib/mina_version/gen.sh
+++ b/src/lib/mina_version/gen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 commit_id_short=$(git rev-parse --short=8 --verify HEAD)

--- a/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
+++ b/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -o pipefail
 marlin_submodule_dir=$(git submodule status | grep marlin | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
 marlin_repo_sha=$(cd $marlin_submodule_dir && git rev-parse --short=8 --verify HEAD)


### PR DESCRIPTION
Add `scripts/nixos-setup.sh` script to configure and setup OCaml development environment. 

On any system that has `nix` package manager installed, launch `scripts/nixos-setup.sh` to install all needed dependencies and execute `make build`. This has benefit over the default installation in easier reproducibility. Also this is a preferred way to setup dev environment on NixOS. 

To rebuild the project, just run `nix-shell --run 'make build'` (which is equivalent to `make build` launched within the shell opened with `nix-shell`).

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? Nope