### PR TITLE
MINA_IMAGE, MINA_AUTOMATION_LOCATION

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -112,7 +112,7 @@ If you don't know if you _should_ do this, you probably shouldn't!
 1) make a new `terraform/testnets/<testnet>`
 2) `./scripts/generate-keys-and-ledger.sh --testnet=<testnet> --wc=10 --fc=10`
 3) run `./scripts/bake.sh --testnet=<testnet> --docker-tag=<tag, ex. 0.0.17-beta6-develop> --automation-commit=$(git log -1 --pretty=format:%H) --cloud=true`
-4) copy the image tag from the output of bake.sh to `coda_image` in `terraform/testnets/<testnet>/main.tf`
+4) copy the image tag from the output of bake.sh to `mina_image` in `terraform/testnets/<testnet>/main.tf`
 5) set the archive image tag to the corresponding tag name - for example, if the image is `0.0.17-beta10-880882e`, use  `gcr.io/o1labs-192920/coda-archive:0.0.17-beta10-880882e`
 6) run `terraform apply`
 7) after its done applying, run `./scripts/upload-keys-k8s.sh <testnet>`
@@ -387,7 +387,7 @@ module "network" {
 
 module "seed_one" {
   source             = "../../modules/google-cloud/coda-seed-node"
-  coda_image         = local.coda_image
+  mina_image         = local.mina_image
   project_id         = data.google_project.project.project_id
   subnetwork_project = data.google_project.project.project_id
   subnetwork         = module.network.subnet_link
@@ -402,7 +402,7 @@ module "seed_one" {
 
 module "seed_two" {
   source             = "../../modules/google-cloud/coda-seed-node"
-  coda_image         = local.coda_image
+  mina_image         = local.mina_image
   project_id         = data.google_project.project.project_id
   subnetwork_project = data.google_project.project.project_id
   subnetwork         = module.network.subnet_link

--- a/automation/scripts/generate-keys-and-ledger.sh
+++ b/automation/scripts/generate-keys-and-ledger.sh
@@ -10,7 +10,7 @@ FISH_COUNT=1
 SEED_COUNT=1
 EXTRA_COUNT=1 # Extra community keys to be handed out manually
 
-CODA_DAEMON_IMAGE="codaprotocol/coda-daemon:0.4.2-renaming-mina-binary-and-mina-config-a46b9ef"
+MINA_DAEMON_IMAGE="codaprotocol/mina-daemon:1.1.6alpha4-feature-mina-passwd-envvars-devnet-4a86bc8"
 
 WHALE_AMOUNT=2250000
 FISH_AMOUNT=20000
@@ -88,18 +88,18 @@ function generate_key_files {
   for k in $(seq 1 $COUNT); do
     docker run \
       -v "${output_dir}:/keys:z" \
-      --entrypoint /bin/bash $CODA_DAEMON_IMAGE \
+      --entrypoint /bin/bash $MINA_DAEMON_IMAGE \
       -c "MINA_PRIVKEY_PASS='${privkey_pass}' mina advanced generate-keypair -privkey-path /keys/${name_prefix}_account_${k}"
     docker run \
       --mount type=bind,source=${output_dir},target=/keys \
-      --entrypoint /bin/bash $CODA_DAEMON_IMAGE \
+      --entrypoint /bin/bash $MINA_DAEMON_IMAGE \
       -c "MINA_LIBP2P_PASS='${privkey_pass}' mina advanced generate-libp2p-keypair -privkey-path /keys/${name_prefix}_libp2p_${k}"
   done
 
   # ensure proper r+w permissions for access to keys external to container
   docker run \
     -v "${output_dir}:/keys:z" \
-    --entrypoint /bin/bash $CODA_DAEMON_IMAGE \
+    --entrypoint /bin/bash $MINA_DAEMON_IMAGE \
     -c "chmod -R +rw /keys"
 }
 
@@ -293,7 +293,7 @@ if [[ -s "terraform/testnets/${TESTNET}/genesis_ledger.json" ]] ; then
   exit
 fi
 
-#if $COMMUNITY_ENABLED ; then 
+#if $COMMUNITY_ENABLED ; then
 #    echo "-- Creating genesis ledger with 'coda-network genesis' --"
 #else
 #  echo "-- Creating genesis ledger with 'coda-network genesis' without community keys --"

--- a/automation/terraform/modules/google-cloud/coda-seed-node/main.tf
+++ b/automation/terraform/modules/google-cloud/coda-seed-node/main.tf
@@ -37,7 +37,7 @@ resource "google_compute_instance" "vm" {
     spec:
       containers:
         - name: ${var.instance_name}
-          image: ${var.coda_image}
+          image: ${var.mina_image}
           command:
             - /bin/bash
           args:

--- a/automation/terraform/modules/google-cloud/coda-seed-node/variables.tf
+++ b/automation/terraform/modules/google-cloud/coda-seed-node/variables.tf
@@ -48,7 +48,7 @@ variable "discovery_keypair" {
   description = "The LibP2P Keypair to use when launching the seed node."
 }
 
-variable "coda_image" {
+variable "mina_image" {
   description = "The docker image to deploy."
 }
 

--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -81,7 +81,7 @@ locals {
     healthcheck = local.healthcheck_vars
 
     userAgent = {
-      image         = var.coda_agent_image
+      image         = var.mina_agent_image
       minFee        = var.agent_min_fee
       maxFee        = var.agent_max_fee
       minTx         = var.agent_min_tx
@@ -92,7 +92,7 @@ locals {
     }
 
     bots = {
-      image = var.coda_bots_image
+      image = var.mina_bots_image
       faucet = {
         amount = var.coda_faucet_amount
         fee    = var.coda_faucet_fee

--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -12,7 +12,7 @@ locals {
 
   coda_vars = {
     runtimeConfig        = var.runtime_config
-    image                = var.coda_image
+    image                = var.mina_image
     useCustomEntrypoint  = var.use_custom_entrypoint
     customEntrypoint     = var.custom_entrypoint
     privkeyPass          = var.block_producer_key_pass
@@ -37,7 +37,7 @@ locals {
     testnetName = var.testnet_name
     coda = {
       runtimeConfig = local.coda_vars.runtimeConfig
-      image         = var.coda_image
+      image         = var.mina_image
       useCustomEntrypoint  = var.use_custom_entrypoint
       customEntrypoint     = var.custom_entrypoint
       privkeyPass   = var.block_producer_key_pass
@@ -120,7 +120,7 @@ locals {
   archive_vars = [for item in var.archive_configs : {
       testnetName = var.testnet_name
       coda        = {
-        image         = var.coda_image
+        image         = var.mina_image
         seedPeers     = local.peers
         runtimeConfig = local.coda_vars.runtimeConfig
         seedPeersURL  = var.seed_peers_url
@@ -177,7 +177,7 @@ locals {
     testnetName = var.testnet_name
     image       = var.watchdog_image
     coda = {
-      image                = var.coda_image
+      image                = var.mina_image
       ports                = { metrics : 8000 }
       uploadBlocksToGCloud = var.upload_blocks_to_gcloud
     }

--- a/automation/terraform/modules/kubernetes/testnet/variables.tf
+++ b/automation/terraform/modules/kubernetes/testnet/variables.tf
@@ -41,7 +41,7 @@ variable "deploy_watchdog" {
   default = true
 }
 
-variable "coda_image" {
+variable "mina_image" {
   type    = string
   default = "codaprotocol/coda-daemon:0.0.13-beta-master-99d1e1f"
 }

--- a/automation/terraform/modules/kubernetes/testnet/variables.tf
+++ b/automation/terraform/modules/kubernetes/testnet/variables.tf
@@ -56,7 +56,7 @@ variable "custom_entrypoint" {
   default = ""
 }
 
-variable "coda_archive_image" {
+variable "mina_archive_image" {
   type    = string
   default = ""
 }
@@ -71,7 +71,7 @@ variable "archive_node_count" {
   default = 0
 }
 
-variable "coda_agent_image" {
+variable "mina_agent_image" {
   type    = string
   default = "codaprotocol/coda-user-agent:0.1.4"
 }
@@ -81,12 +81,12 @@ variable "coda_agent_active" {
   default = "true"
 }
 
-variable "coda_bots_image" {
+variable "mina_bots_image" {
   type    = string
   default = ""
 }
 
-variable "coda_points_image" {
+variable "mina_points_image" {
   type    = string
   default = ""
 }

--- a/automation/terraform/modules/o1-integration/inputs.tf
+++ b/automation/terraform/modules/o1-integration/inputs.tf
@@ -30,19 +30,19 @@ variable "mina_image" {
   type = string
 }
 
-variable "coda_archive_image" {
+variable "mina_archive_image" {
   type = string
 }
 
-variable "coda_agent_image" {
+variable "mina_agent_image" {
   type = string
 }
 
-variable "coda_bots_image" {
+variable "mina_bots_image" {
   type = string
 }
 
-variable "coda_points_image" {
+variable "mina_points_image" {
   type = string
 }
 

--- a/automation/terraform/modules/o1-integration/inputs.tf
+++ b/automation/terraform/modules/o1-integration/inputs.tf
@@ -26,7 +26,7 @@ variable "testnet_name" {
   type = string
 }
 
-variable "coda_image" {
+variable "mina_image" {
   type = string
 }
 

--- a/automation/terraform/modules/o1-integration/locals.tf
+++ b/automation/terraform/modules/o1-integration/locals.tf
@@ -26,7 +26,7 @@ locals {
   snark_coordinator_name = "snark-coordinator-${lower(substr(var.snark_worker_public_key, length(var.snark_worker_public_key) - 6, 6))}"
 
   default_archive_node = {
-    image                   = var.coda_archive_image
+    image                   = var.mina_archive_image
     serverPort              = "3086"
     externalPort            = "11010"
     enableLocalDaemon       = true

--- a/automation/terraform/modules/o1-integration/testnet.tf
+++ b/automation/terraform/modules/o1-integration/testnet.tf
@@ -12,7 +12,7 @@ module "kubernetes_testnet" {
   k8s_context    = var.k8s_context
   testnet_name   = var.testnet_name
 
-  coda_image         = var.coda_image
+  mina_image         = var.mina_image
   use_custom_entrypoint = true
   custom_entrypoint = "/mina_daemon_puppeteer.py"
   coda_archive_image = var.coda_archive_image

--- a/automation/terraform/modules/o1-integration/testnet.tf
+++ b/automation/terraform/modules/o1-integration/testnet.tf
@@ -15,10 +15,10 @@ module "kubernetes_testnet" {
   mina_image         = var.mina_image
   use_custom_entrypoint = true
   custom_entrypoint = "/mina_daemon_puppeteer.py"
-  coda_archive_image = var.coda_archive_image
-  coda_agent_image   = var.coda_agent_image
-  coda_bots_image    = var.coda_bots_image
-  coda_points_image  = var.coda_points_image
+  mina_archive_image = var.mina_archive_image
+  mina_agent_image   = var.mina_agent_image
+  mina_bots_image    = var.mina_bots_image
+  mina_points_image  = var.mina_points_image
 
   log_level             = "Trace"
   log_snark_work_gossip = true

--- a/automation/terraform/modules/o1-testnet/inputs.tf
+++ b/automation/terraform/modules/o1-testnet/inputs.tf
@@ -30,7 +30,7 @@ variable "artifact_path" {
   default = "/tmp"
 }
 
-variable "coda_image" {
+variable "mina_image" {
   type    = string
   default = "codaprotocol/coda-daemon:0.0.13-beta-master-99d1e1f"
 }

--- a/automation/terraform/modules/o1-testnet/inputs.tf
+++ b/automation/terraform/modules/o1-testnet/inputs.tf
@@ -35,7 +35,7 @@ variable "mina_image" {
   default = "codaprotocol/coda-daemon:0.0.13-beta-master-99d1e1f"
 }
 
-variable "coda_archive_image" {
+variable "mina_archive_image" {
   type    = string
   default = ""
 }
@@ -45,7 +45,7 @@ variable "mina_archive_schema" {
   default = ""
 }
 
-variable "coda_agent_image" {
+variable "mina_agent_image" {
   type    = string
   default = "codaprotocol/coda-user-agent:0.1.4"
 }
@@ -55,12 +55,12 @@ variable "coda_agent_active" {
   default = "true"
 }
 
-variable "coda_bots_image" {
+variable "mina_bots_image" {
   type    = string
   default = ""
 }
 
-variable "coda_points_image" {
+variable "mina_points_image" {
   type    = string
   default = ""
 }

--- a/automation/terraform/modules/o1-testnet/locals.tf
+++ b/automation/terraform/modules/o1-testnet/locals.tf
@@ -16,7 +16,7 @@ locals {
   }
 
   default_archive_node = {
-    image                   = var.coda_archive_image
+    image                   = var.mina_archive_image
     serverPort              = "3086"
     externalPort            = "11010"
     enableLocalDaemon       = true

--- a/automation/terraform/modules/o1-testnet/testnet.tf
+++ b/automation/terraform/modules/o1-testnet/testnet.tf
@@ -30,10 +30,10 @@ module "kubernetes_testnet" {
 
   use_local_charts   = false
   mina_image         = var.mina_image
-  coda_archive_image = var.coda_archive_image
-  coda_agent_image   = var.coda_agent_image
-  coda_bots_image    = var.coda_bots_image
-  coda_points_image  = var.coda_points_image
+  mina_archive_image = var.mina_archive_image
+  mina_agent_image   = var.mina_agent_image
+  mina_bots_image    = var.mina_bots_image
+  mina_points_image  = var.mina_points_image
   watchdog_image     = var.watchdog_image
 
   coda_faucet_amount = var.coda_faucet_amount

--- a/automation/terraform/modules/o1-testnet/testnet.tf
+++ b/automation/terraform/modules/o1-testnet/testnet.tf
@@ -29,7 +29,7 @@ module "kubernetes_testnet" {
   testnet_name   = var.testnet_name
 
   use_local_charts   = false
-  coda_image         = var.coda_image
+  mina_image         = var.mina_image
   coda_archive_image = var.coda_archive_image
   coda_agent_image   = var.coda_agent_image
   coda_bots_image    = var.coda_bots_image

--- a/automation/terraform/testnets/bug-net/main.tf
+++ b/automation/terraform/testnets/bug-net/main.tf
@@ -36,7 +36,7 @@ provider "google" {
 
 locals {
   testnet_name = "bug-net"
-  coda_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.1.1-add-testworld-ledger-bbda99d-bug-net-607e718"
+  mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.1.1-add-testworld-ledger-bbda99d-bug-net-607e718"
   coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.1.1-temporary-qa-staging-ci-wait-cf2b767"
   seed_region = "us-central1"
   seed_zone = "us-central1-b"
@@ -60,7 +60,7 @@ module "testnet_central" {
   cluster_region        = "us-central1"
   testnet_name          = local.testnet_name
 
-  coda_image            = local.coda_image
+  mina_image            = local.mina_image
   coda_archive_image    = local.coda_archive_image
   coda_agent_image      = "codaprotocol/coda-user-agent:0.1.8"
   coda_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"

--- a/automation/terraform/testnets/bug-net/main.tf
+++ b/automation/terraform/testnets/bug-net/main.tf
@@ -37,7 +37,7 @@ provider "google" {
 locals {
   testnet_name = "bug-net"
   mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.1.1-add-testworld-ledger-bbda99d-bug-net-607e718"
-  coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.1.1-temporary-qa-staging-ci-wait-cf2b767"
+  mina_archive_image = "gcr.io/o1labs-192920/coda-archive:0.1.1-temporary-qa-staging-ci-wait-cf2b767"
   seed_region = "us-central1"
   seed_zone = "us-central1-b"
   seed_discovery_keypairs = [
@@ -61,10 +61,10 @@ module "testnet_central" {
   testnet_name          = local.testnet_name
 
   mina_image            = local.mina_image
-  coda_archive_image    = local.coda_archive_image
-  coda_agent_image      = "codaprotocol/coda-user-agent:0.1.8"
-  coda_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"
-  coda_points_image     = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image    = local.mina_archive_image
+  mina_agent_image      = "codaprotocol/coda-user-agent:0.1.8"
+  mina_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"
+  mina_points_image     = "codaprotocol/coda-points-hack:32b.4"
 
   coda_faucet_amount    = "10000000000"
   coda_faucet_fee       = "100000000"

--- a/automation/terraform/testnets/bug-net/public-seeds.tf
+++ b/automation/terraform/testnets/bug-net/public-seeds.tf
@@ -13,7 +13,7 @@
  
  module "seed_one" {
    source             = "../../modules/google-cloud/coda-seed-node"
-   coda_image         = local.coda_image
+   mina_image         = local.mina_image
    project_id         = "o1labs-192920"
    runtime_config     = local.runtime_config
    subnetwork_project = "o1labs-192920"
@@ -28,7 +28,7 @@
  
  module "seed_two" {
    source             = "../../modules/google-cloud/coda-seed-node"
-   coda_image         = local.coda_image
+   mina_image         = local.mina_image
    runtime_config     = local.runtime_config
    project_id         = "o1labs-192920"
    subnetwork_project = "o1labs-192920"

--- a/automation/terraform/testnets/bugspray/main.tf
+++ b/automation/terraform/testnets/bugspray/main.tf
@@ -15,14 +15,14 @@ provider "aws" {
 
 locals {
   testnet_name = "bugspray"
-  coda_image   = var.coda_image
+  mina_image   = var.mina_image
   coda_agent_image = var.coda_agent_image
   coda_bots_image = var.coda_bots_image
   coda_faucet_amount = var.coda_faucet_amount
   coda_faucet_fee = var.coda_faucet_fee
 }
 
-variable "coda_image" {
+variable "mina_image" {
   type = string
   default = "codaprotocol/coda-daemon:0.0.12-beta-feature-bump-genesis-timestamp-16200a0"
 }

--- a/automation/terraform/testnets/bugspray/main.tf
+++ b/automation/terraform/testnets/bugspray/main.tf
@@ -16,8 +16,8 @@ provider "aws" {
 locals {
   testnet_name = "bugspray"
   mina_image   = var.mina_image
-  coda_agent_image = var.coda_agent_image
-  coda_bots_image = var.coda_bots_image
+  mina_agent_image = var.mina_agent_image
+  mina_bots_image = var.mina_bots_image
   coda_faucet_amount = var.coda_faucet_amount
   coda_faucet_fee = var.coda_faucet_fee
 }
@@ -27,12 +27,12 @@ variable "mina_image" {
   default = "codaprotocol/coda-daemon:0.0.12-beta-feature-bump-genesis-timestamp-16200a0"
 }
 
-variable "coda_agent_image" {
+variable "mina_agent_image" {
   type = string
   default = "codaprotocol/coda-user-agent:0.1.5"
 }
 
-variable "coda_bots_image" {
+variable "mina_bots_image" {
   type = string
   default = "codaprotocol/coda-bots:0.0.13-beta-1"
 }

--- a/automation/terraform/testnets/bugspray/us-east1.tf
+++ b/automation/terraform/testnets/bugspray/us-east1.tf
@@ -14,7 +14,7 @@ module "testnet_east" {
   cluster_name          = "coda-infra-east"
   cluster_region        = "us-east1"
   testnet_name          = local.testnet_name
-  coda_image            = local.coda_image
+  mina_image            = local.mina_image
   coda_agent_image      = local.coda_agent_image
   coda_bots_image       = local.coda_bots_image
   coda_faucet_amount    = local.coda_faucet_amount

--- a/automation/terraform/testnets/bugspray/us-east1.tf
+++ b/automation/terraform/testnets/bugspray/us-east1.tf
@@ -15,8 +15,8 @@ module "testnet_east" {
   cluster_region        = "us-east1"
   testnet_name          = local.testnet_name
   mina_image            = local.mina_image
-  coda_agent_image      = local.coda_agent_image
-  coda_bots_image       = local.coda_bots_image
+  mina_agent_image      = local.mina_agent_image
+  mina_bots_image       = local.mina_bots_image
   coda_faucet_amount    = local.coda_faucet_amount
   coda_faucet_fee       = local.coda_faucet_fee
 

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -20,7 +20,7 @@ variable "mina_image" {
   default     = "gcr.io/o1labs-192920/coda-daemon:0.2.11-develop"
 }
 
-variable "coda_archive_image" {
+variable "mina_archive_image" {
   type = string
 
   description = "Mina archive node image to use in provisioning a ci-net"
@@ -80,10 +80,10 @@ module "ci_testnet" {
   testnet_name   = "ci-net-${substr(sha256(terraform.workspace), 0, 7)}"
 
   mina_image         = var.mina_image
-  coda_archive_image = var.coda_archive_image
-  coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
-  coda_bots_image    = "codaprotocol/bots:1.0.0"
-  coda_points_image  = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image = var.mina_archive_image
+  mina_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
+  mina_bots_image    = "codaprotocol/bots:1.0.0"
+  mina_points_image  = "codaprotocol/coda-points-hack:32b.4"
 
   coda_faucet_amount = "10000000000"
   coda_faucet_fee    = "100000000"

--- a/automation/terraform/testnets/ci-net/main.tf
+++ b/automation/terraform/testnets/ci-net/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
   region = "us-west-2"
 }
 
-variable "coda_image" {
+variable "mina_image" {
   type = string
 
   description = "Mina daemon image to use in provisioning a ci-net"
@@ -79,7 +79,7 @@ module "ci_testnet" {
   k8s_context    = var.ci_k8s_ctx
   testnet_name   = "ci-net-${substr(sha256(terraform.workspace), 0, 7)}"
 
-  coda_image         = var.coda_image
+  mina_image         = var.mina_image
   coda_archive_image = var.coda_archive_image
   coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
   coda_bots_image    = "codaprotocol/bots:1.0.0"

--- a/automation/terraform/testnets/devnet2/main.tf
+++ b/automation/terraform/testnets/devnet2/main.tf
@@ -56,7 +56,7 @@ variable "seed_count" {
 locals {
   testnet_name = "devnet2"
   mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.0.4-8202b60-devnet-0f2032c"
-  coda_archive_image = "gcr.io/o1labs-192920/coda-archive:1.0.4-8202b60"
+  mina_archive_image = "gcr.io/o1labs-192920/coda-archive:1.0.4-8202b60"
   seed_region = "us-east4"
   seed_zone = "us-east4-b"
 
@@ -84,10 +84,10 @@ module "testnet_east" {
   testnet_name   = local.testnet_name
 
   mina_image         = local.mina_image
-  coda_archive_image = local.coda_archive_image
-  coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
-  coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
-  coda_points_image  = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image = local.mina_archive_image
+  mina_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
+  mina_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
+  mina_points_image  = "codaprotocol/coda-points-hack:32b.4"
   watchdog_image     = "gcr.io/o1labs-192920/watchdog:0.4.3"
 
   archive_node_count  = 3

--- a/automation/terraform/testnets/devnet2/main.tf
+++ b/automation/terraform/testnets/devnet2/main.tf
@@ -55,7 +55,7 @@ variable "seed_count" {
 
 locals {
   testnet_name = "devnet2"
-  coda_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.0.4-8202b60-devnet-0f2032c"
+  mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.0.4-8202b60-devnet-0f2032c"
   coda_archive_image = "gcr.io/o1labs-192920/coda-archive:1.0.4-8202b60"
   seed_region = "us-east4"
   seed_zone = "us-east4-b"
@@ -83,7 +83,7 @@ module "testnet_east" {
   k8s_context    = "gke_o1labs-192920_us-east4_coda-infra-east4"
   testnet_name   = local.testnet_name
 
-  coda_image         = local.coda_image
+  mina_image         = local.mina_image
   coda_archive_image = local.coda_archive_image
   coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
   coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"

--- a/automation/terraform/testnets/finalfinal2/main.tf
+++ b/automation/terraform/testnets/finalfinal2/main.tf
@@ -55,7 +55,7 @@ variable "seed_count" {
 
 locals {
   testnet_name = "finalfinal2"
-  coda_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.0.0-fd39808-finalfinal2-fd39808"
+  mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.0.0-fd39808-finalfinal2-fd39808"
   coda_archive_image = "gcr.io/o1labs-192920/coda-archive:1.0.0-fix-archive-build-profile-e344c96"
 
   # replace with `make_report_discord_webhook_url = ""` if not in use (will fail if file not present)
@@ -81,7 +81,7 @@ module "finalfinal2" {
   k8s_context    = "gke_o1labs-192920_us-east1_coda-infra-east"
   testnet_name   = local.testnet_name
 
-  coda_image         = local.coda_image
+  mina_image         = local.mina_image
   coda_archive_image = local.coda_archive_image
   watchdog_image     = "gcr.io/o1labs-192920/watchdog:0.4.1"
 

--- a/automation/terraform/testnets/finalfinal2/main.tf
+++ b/automation/terraform/testnets/finalfinal2/main.tf
@@ -56,7 +56,7 @@ variable "seed_count" {
 locals {
   testnet_name = "finalfinal2"
   mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.0.0-fd39808-finalfinal2-fd39808"
-  coda_archive_image = "gcr.io/o1labs-192920/coda-archive:1.0.0-fix-archive-build-profile-e344c96"
+  mina_archive_image = "gcr.io/o1labs-192920/coda-archive:1.0.0-fix-archive-build-profile-e344c96"
 
   # replace with `make_report_discord_webhook_url = ""` if not in use (will fail if file not present)
   make_report_discord_webhook_url = <<EOT
@@ -82,7 +82,7 @@ module "finalfinal2" {
   testnet_name   = local.testnet_name
 
   mina_image         = local.mina_image
-  coda_archive_image = local.coda_archive_image
+  mina_archive_image = local.mina_archive_image
   watchdog_image     = "gcr.io/o1labs-192920/watchdog:0.4.1"
 
   block_producer_key_pass = "naughty blue worm"

--- a/automation/terraform/testnets/mainnet/main.tf
+++ b/automation/terraform/testnets/mainnet/main.tf
@@ -56,7 +56,7 @@ variable "seed_count" {
 locals {
   testnet_name = "mainnet"
   mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.1.2-0975867-mainnet-6a9354a"
-  coda_archive_image = "gcr.io/o1labs-192920/coda-archive:1.1.2-0975867"
+  mina_archive_image = "gcr.io/o1labs-192920/coda-archive:1.1.2-0975867"
   seed_region = "us-east1"
   seed_zone = "us-east1-b"
 
@@ -84,7 +84,7 @@ module "mainnet" {
   testnet_name   = local.testnet_name
 
   mina_image         = local.mina_image
-  coda_archive_image = local.coda_archive_image
+  mina_archive_image = local.mina_archive_image
   watchdog_image     = "gcr.io/o1labs-192920/watchdog:0.4.5"
 
   block_producer_key_pass = "naughty blue worm"

--- a/automation/terraform/testnets/mainnet/main.tf
+++ b/automation/terraform/testnets/mainnet/main.tf
@@ -55,7 +55,7 @@ variable "seed_count" {
 
 locals {
   testnet_name = "mainnet"
-  coda_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.1.2-0975867-mainnet-6a9354a"
+  mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.1.2-0975867-mainnet-6a9354a"
   coda_archive_image = "gcr.io/o1labs-192920/coda-archive:1.1.2-0975867"
   seed_region = "us-east1"
   seed_zone = "us-east1-b"
@@ -83,7 +83,7 @@ module "mainnet" {
   k8s_context    = "gke_o1labs-192920_us-east1_coda-infra-east"
   testnet_name   = local.testnet_name
 
-  coda_image         = local.coda_image
+  mina_image         = local.mina_image
   coda_archive_image = local.coda_archive_image
   watchdog_image     = "gcr.io/o1labs-192920/watchdog:0.4.5"
 

--- a/automation/terraform/testnets/multiple-seeds-test/main.tf
+++ b/automation/terraform/testnets/multiple-seeds-test/main.tf
@@ -56,7 +56,7 @@ variable "seed_count" {
 locals {
   testnet_name = "multiple-seeds-test"
   mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.3.3-compatible-9e2b5bc-testworld-496409d"
-  coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.3.3-compatible-9e2b5bc"
+  mina_archive_image = "gcr.io/o1labs-192920/coda-archive:0.3.3-compatible-9e2b5bc"
   seed_region = "us-east4"
   seed_zone = "us-east4-b"
 
@@ -84,10 +84,10 @@ module "testnet_east" {
   testnet_name   = local.testnet_name
 
   mina_image         = local.mina_image
-  coda_archive_image = local.coda_archive_image
-  coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
-  coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
-  coda_points_image  = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image = local.mina_archive_image
+  mina_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
+  mina_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
+  mina_points_image  = "codaprotocol/coda-points-hack:32b.4"
   watchdog_image     = "gcr.io/o1labs-192920/watchdog:0.3.7"
 
   coda_faucet_amount = "10000000000"

--- a/automation/terraform/testnets/multiple-seeds-test/main.tf
+++ b/automation/terraform/testnets/multiple-seeds-test/main.tf
@@ -55,7 +55,7 @@ variable "seed_count" {
 
 locals {
   testnet_name = "multiple-seeds-test"
-  coda_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.3.3-compatible-9e2b5bc-testworld-496409d"
+  mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.3.3-compatible-9e2b5bc-testworld-496409d"
   coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.3.3-compatible-9e2b5bc"
   seed_region = "us-east4"
   seed_zone = "us-east4-b"
@@ -83,7 +83,7 @@ module "testnet_east" {
   k8s_context    = "gke_o1labs-192920_us-east4_coda-infra-east4"
   testnet_name   = local.testnet_name
 
-  coda_image         = local.coda_image
+  mina_image         = local.mina_image
   coda_archive_image = local.coda_archive_image
   coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
   coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"

--- a/automation/terraform/testnets/nightly/main.tf
+++ b/automation/terraform/testnets/nightly/main.tf
@@ -48,7 +48,7 @@ variable "fish_count" {
   default     = 1
 }
 
-variable "coda_archive_image" {
+variable "mina_archive_image" {
   type = string
 
   description = "Mina archive node image to use in provisioning a ci-net"
@@ -74,10 +74,10 @@ module "ci_testnet" {
   testnet_name          = var.testnet_name
 
   mina_image            = var.mina_image
-  coda_archive_image    = var.coda_archive_image
-  coda_agent_image      = "codaprotocol/coda-user-agent:0.1.5"
-  coda_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"
-  coda_points_image     = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image    = var.mina_archive_image
+  mina_agent_image      = "codaprotocol/coda-user-agent:0.1.5"
+  mina_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"
+  mina_points_image     = "codaprotocol/coda-points-hack:32b.4"
 
   coda_faucet_amount    = "10000000000"
   coda_faucet_fee       = "100000000"

--- a/automation/terraform/testnets/nightly/main.tf
+++ b/automation/terraform/testnets/nightly/main.tf
@@ -27,7 +27,7 @@ variable "testnet_name" {
   default     = "ci-net"
 }
 
-variable "coda_image" {
+variable "mina_image" {
   type = string
 
   description = "Mina daemon image to use in provisioning a ci-net"
@@ -73,7 +73,7 @@ module "ci_testnet" {
   k8s_context           = "gke_o1labs-192920_us-east4_coda-infra-east4"
   testnet_name          = var.testnet_name
 
-  coda_image            = var.coda_image
+  mina_image            = var.mina_image
   coda_archive_image    = var.coda_archive_image
   coda_agent_image      = "codaprotocol/coda-user-agent:0.1.5"
   coda_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"

--- a/automation/terraform/testnets/nightly/terraform.tfvars
+++ b/automation/terraform/testnets/nightly/terraform.tfvars
@@ -3,5 +3,5 @@ testnet_name = "nightly"
 whale_count = 3
 fish_count = 2
 
-coda_image = "gcr.io/o1labs-192920/coda-daemon:0.0.17-beta11-develop"
+mina_image = "gcr.io/o1labs-192920/coda-daemon:0.0.17-beta11-develop"
 coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.0.17-beta11-develop"

--- a/automation/terraform/testnets/nightly/terraform.tfvars
+++ b/automation/terraform/testnets/nightly/terraform.tfvars
@@ -4,4 +4,4 @@ whale_count = 3
 fish_count = 2
 
 mina_image = "gcr.io/o1labs-192920/coda-daemon:0.0.17-beta11-develop"
-coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.0.17-beta11-develop"
+mina_archive_image = "gcr.io/o1labs-192920/coda-archive:0.0.17-beta11-develop"

--- a/automation/terraform/testnets/renaming/main.tf
+++ b/automation/terraform/testnets/renaming/main.tf
@@ -20,7 +20,7 @@ provider "google" {
   zone    = "us-west1-a"
 }
 
-variable "coda_image" {
+variable "mina_image" {
   type = string
 
   description = "Mina daemon image to use in provisioning a ci-net"
@@ -87,7 +87,7 @@ module "ci_testnet" {
   k8s_context           = var.ci_k8s_ctx
   testnet_name          = "renaming"
 
-  coda_image            = var.coda_image
+  mina_image            = var.mina_image
   coda_archive_image    = var.coda_archive_image
   coda_agent_image      = "codaprotocol/coda-user-agent:0.1.8"
   coda_bots_image       = "codaprotocol/bots:1.0.0"

--- a/automation/terraform/testnets/renaming/main.tf
+++ b/automation/terraform/testnets/renaming/main.tf
@@ -27,7 +27,7 @@ variable "mina_image" {
   default     = "gcr.io/o1labs-192920/coda-daemon:0.4.2-renaming-mina-binary-and-mina-config-87e6365"
 }
 
-variable "coda_archive_image" {
+variable "mina_archive_image" {
   type = string
 
   description = "Mina archive node image to use in provisioning a ci-net"
@@ -88,10 +88,10 @@ module "ci_testnet" {
   testnet_name          = "renaming"
 
   mina_image            = var.mina_image
-  coda_archive_image    = var.coda_archive_image
-  coda_agent_image      = "codaprotocol/coda-user-agent:0.1.8"
-  coda_bots_image       = "codaprotocol/bots:1.0.0"
-  coda_points_image     = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image    = var.mina_archive_image
+  mina_agent_image      = "codaprotocol/coda-user-agent:0.1.8"
+  mina_bots_image       = "codaprotocol/bots:1.0.0"
+  mina_points_image     = "codaprotocol/coda-points-hack:32b.4"
 
   coda_faucet_amount    = "10000000000"
   coda_faucet_fee       = "100000000"

--- a/automation/terraform/testnets/static-peers-net/main.tf
+++ b/automation/terraform/testnets/static-peers-net/main.tf
@@ -48,7 +48,7 @@ variable "fish_count" {
   default     = 1
 }
 
-variable "coda_archive_image" {
+variable "mina_archive_image" {
   type = string
 
   description = "Mina archive node image to use in provisioning a ci-net"
@@ -74,10 +74,10 @@ module "ci_testnet" {
   testnet_name   = var.testnet_name
 
   mina_image         = var.mina_image
-  coda_archive_image = var.coda_archive_image
-  coda_agent_image   = "codaprotocol/coda-user-agent:0.1.5"
-  coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
-  coda_points_image  = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image = var.mina_archive_image
+  mina_agent_image   = "codaprotocol/coda-user-agent:0.1.5"
+  mina_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
+  mina_points_image  = "codaprotocol/coda-points-hack:32b.4"
 
   coda_faucet_amount = "10000000000"
   coda_faucet_fee    = "100000000"

--- a/automation/terraform/testnets/static-peers-net/main.tf
+++ b/automation/terraform/testnets/static-peers-net/main.tf
@@ -27,7 +27,7 @@ variable "testnet_name" {
   default     = "ci-net"
 }
 
-variable "coda_image" {
+variable "mina_image" {
   type = string
 
   description = "Mina daemon image to use in provisioning a ci-net"
@@ -73,7 +73,7 @@ module "ci_testnet" {
   k8s_context    = "gke_o1labs-192920_us-east4_coda-infra-east4"
   testnet_name   = var.testnet_name
 
-  coda_image         = var.coda_image
+  mina_image         = var.mina_image
   coda_archive_image = var.coda_archive_image
   coda_agent_image   = "codaprotocol/coda-user-agent:0.1.5"
   coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"

--- a/automation/terraform/testnets/static-peers-net/terraform.tfvars
+++ b/automation/terraform/testnets/static-peers-net/terraform.tfvars
@@ -3,5 +3,5 @@ testnet_name = "beans"
 whale_count = 3
 fish_count = 2
 
-coda_image = "gcr.io/o1labs-192920/coda-daemon:0.0.17-beta11-develop"
+mina_image = "gcr.io/o1labs-192920/coda-daemon:0.0.17-beta11-develop"
 coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.0.17-beta11-develop"

--- a/automation/terraform/testnets/static-peers-net/terraform.tfvars
+++ b/automation/terraform/testnets/static-peers-net/terraform.tfvars
@@ -4,4 +4,4 @@ whale_count = 3
 fish_count = 2
 
 mina_image = "gcr.io/o1labs-192920/coda-daemon:0.0.17-beta11-develop"
-coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.0.17-beta11-develop"
+mina_archive_image = "gcr.io/o1labs-192920/coda-archive:0.0.17-beta11-develop"

--- a/automation/terraform/testnets/test-labels/main.tf
+++ b/automation/terraform/testnets/test-labels/main.tf
@@ -55,7 +55,7 @@ variable "seed_count" {
 
 locals {
   testnet_name = "test-labels"
-  coda_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.1.5-compatible-be67bed-test-labels-425db71"
+  mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.1.5-compatible-be67bed-test-labels-425db71"
   coda_archive_image = "gcr.io/o1labs-192920/coda-archive:1.0.4-8202b60"
   seed_region = "us-central1"
   seed_zone = "us-central1-b"
@@ -81,7 +81,7 @@ module "testlabels" {
   k8s_context    = "gke_o1labs-192920_us-central1_coda-infra-central1"
   testnet_name   = local.testnet_name
 
-  coda_image         = local.coda_image
+  mina_image         = local.mina_image
   coda_archive_image = local.coda_archive_image
   coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
   coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"

--- a/automation/terraform/testnets/test-labels/main.tf
+++ b/automation/terraform/testnets/test-labels/main.tf
@@ -56,7 +56,7 @@ variable "seed_count" {
 locals {
   testnet_name = "test-labels"
   mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:1.1.5-compatible-be67bed-test-labels-425db71"
-  coda_archive_image = "gcr.io/o1labs-192920/coda-archive:1.0.4-8202b60"
+  mina_archive_image = "gcr.io/o1labs-192920/coda-archive:1.0.4-8202b60"
   seed_region = "us-central1"
   seed_zone = "us-central1-b"
 
@@ -82,10 +82,10 @@ module "testlabels" {
   testnet_name   = local.testnet_name
 
   mina_image         = local.mina_image
-  coda_archive_image = local.coda_archive_image
-  coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
-  coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
-  coda_points_image  = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image = local.mina_archive_image
+  mina_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
+  mina_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
+  mina_points_image  = "codaprotocol/coda-points-hack:32b.4"
   watchdog_image     = "gcr.io/o1labs-192920/watchdog:0.4.3"
 
   archive_node_count  = 3

--- a/automation/terraform/testnets/testworld/main.tf
+++ b/automation/terraform/testnets/testworld/main.tf
@@ -36,7 +36,7 @@ provider "google" {
 
 locals {
   testnet_name = "testworld"
-  coda_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.1.1-add-testworld-ledger-bbda99d-testworld-4af8f09"
+  mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.1.1-add-testworld-ledger-bbda99d-testworld-4af8f09"
   coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.1.1-temporary-qa-staging-ci-wait-cf2b767"
   seed_region = "us-central1"
   seed_zone = "us-central1-b"
@@ -60,7 +60,7 @@ module "testnet_central" {
   cluster_region        = "us-central1"
   testnet_name          = local.testnet_name
 
-  coda_image            = local.coda_image
+  mina_image            = local.mina_image
   coda_archive_image    = local.coda_archive_image
   coda_agent_image      = "codaprotocol/coda-user-agent:0.1.8"
   coda_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"

--- a/automation/terraform/testnets/testworld/main.tf
+++ b/automation/terraform/testnets/testworld/main.tf
@@ -37,7 +37,7 @@ provider "google" {
 locals {
   testnet_name = "testworld"
   mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.1.1-add-testworld-ledger-bbda99d-testworld-4af8f09"
-  coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.1.1-temporary-qa-staging-ci-wait-cf2b767"
+  mina_archive_image = "gcr.io/o1labs-192920/coda-archive:0.1.1-temporary-qa-staging-ci-wait-cf2b767"
   seed_region = "us-central1"
   seed_zone = "us-central1-b"
   seed_discovery_keypairs = [
@@ -61,10 +61,10 @@ module "testnet_central" {
   testnet_name          = local.testnet_name
 
   mina_image            = local.mina_image
-  coda_archive_image    = local.coda_archive_image
-  coda_agent_image      = "codaprotocol/coda-user-agent:0.1.8"
-  coda_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"
-  coda_points_image     = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image    = local.mina_archive_image
+  mina_agent_image      = "codaprotocol/coda-user-agent:0.1.8"
+  mina_bots_image       = "codaprotocol/coda-bots:0.0.13-beta-1"
+  mina_points_image     = "codaprotocol/coda-points-hack:32b.4"
 
   coda_faucet_amount    = "10000000000"
   coda_faucet_fee       = "100000000"

--- a/automation/terraform/testnets/testworld/public-seeds.tf
+++ b/automation/terraform/testnets/testworld/public-seeds.tf
@@ -13,7 +13,7 @@
  
  module "seed_one" {
    source             = "../../modules/google-cloud/coda-seed-node"
-   coda_image         = local.coda_image
+   mina_image         = local.mina_image
    project_id         = "o1labs-192920"
    runtime_config     = local.runtime_config
    subnetwork_project = "o1labs-192920"
@@ -28,7 +28,7 @@
  
  module "seed_two" {
    source             = "../../modules/google-cloud/coda-seed-node"
-   coda_image         = local.coda_image
+   mina_image         = local.mina_image
    runtime_config     = local.runtime_config
    project_id         = "o1labs-192920"
    subnetwork_project = "o1labs-192920"

--- a/automation/terraform/testnets/watchdog-test/main.tf
+++ b/automation/terraform/testnets/watchdog-test/main.tf
@@ -56,7 +56,7 @@ variable "seed_count" {
 locals {
   testnet_name = "watchdog-test"
   mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.4.2-245a3f7-watchdog-test-88a86bc"
-  coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.4.2-245a3f7"
+  mina_archive_image = "gcr.io/o1labs-192920/coda-archive:0.4.2-245a3f7"
   seed_region = "us-east4"
   seed_zone = "us-east4-b"
 
@@ -84,10 +84,10 @@ module "testnet_east" {
   testnet_name   = local.testnet_name
 
   mina_image         = local.mina_image
-  coda_archive_image = local.coda_archive_image
-  coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
-  coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
-  coda_points_image  = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image = local.mina_archive_image
+  mina_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
+  mina_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
+  mina_points_image  = "codaprotocol/coda-points-hack:32b.4"
   watchdog_image     = "gcr.io/o1labs-192920/watchdog:0.3.9"
 
   coda_faucet_amount = "10000000000"

--- a/automation/terraform/testnets/watchdog-test/main.tf
+++ b/automation/terraform/testnets/watchdog-test/main.tf
@@ -55,7 +55,7 @@ variable "seed_count" {
 
 locals {
   testnet_name = "watchdog-test"
-  coda_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.4.2-245a3f7-watchdog-test-88a86bc"
+  mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.4.2-245a3f7-watchdog-test-88a86bc"
   coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.4.2-245a3f7"
   seed_region = "us-east4"
   seed_zone = "us-east4-b"
@@ -83,7 +83,7 @@ module "testnet_east" {
   k8s_context    = "gke_o1labs-192920_us-east4_coda-infra-east4"
   testnet_name   = local.testnet_name
 
-  coda_image         = local.coda_image
+  mina_image         = local.mina_image
   coda_archive_image = local.coda_archive_image
   coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
   coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"

--- a/automation/terraform/testnets/zenith/main.tf
+++ b/automation/terraform/testnets/zenith/main.tf
@@ -56,7 +56,7 @@ variable "seed_count" {
 locals {
   testnet_name = "zenith"
   mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.4.2-245a3f7-zenith-7a89538"
-  coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.4.2-245a3f7"
+  mina_archive_image = "gcr.io/o1labs-192920/coda-archive:0.4.2-245a3f7"
   seed_region = "us-east4"
   seed_zone = "us-east4-b"
 
@@ -84,10 +84,10 @@ module "testnet_east" {
   testnet_name   = local.testnet_name
 
   mina_image         = local.mina_image
-  coda_archive_image = local.coda_archive_image
-  coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
-  coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
-  coda_points_image  = "codaprotocol/coda-points-hack:32b.4"
+  mina_archive_image = local.mina_archive_image
+  mina_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
+  mina_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"
+  mina_points_image  = "codaprotocol/coda-points-hack:32b.4"
   watchdog_image     = "gcr.io/o1labs-192920/watchdog:0.3.9"
 
   coda_faucet_amount = "10000000000"

--- a/automation/terraform/testnets/zenith/main.tf
+++ b/automation/terraform/testnets/zenith/main.tf
@@ -55,7 +55,7 @@ variable "seed_count" {
 
 locals {
   testnet_name = "zenith"
-  coda_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.4.2-245a3f7-zenith-7a89538"
+  mina_image = "gcr.io/o1labs-192920/coda-daemon-baked:0.4.2-245a3f7-zenith-7a89538"
   coda_archive_image = "gcr.io/o1labs-192920/coda-archive:0.4.2-245a3f7"
   seed_region = "us-east4"
   seed_zone = "us-east4-b"
@@ -83,7 +83,7 @@ module "testnet_east" {
   k8s_context    = "gke_o1labs-192920_us-east4_coda-infra-east4"
   testnet_name   = local.testnet_name
 
-  coda_image         = local.coda_image
+  mina_image         = local.mina_image
   coda_archive_image = local.coda_archive_image
   coda_agent_image   = "codaprotocol/coda-user-agent:0.1.8"
   coda_bots_image    = "codaprotocol/coda-bots:0.0.13-beta-1"

--- a/buildkite/scripts/run-test-executive.sh
+++ b/buildkite/scripts/run-test-executive.sh
@@ -6,8 +6,8 @@ MINA_IMAGE="gcr.io/o1labs-192920/mina-daemon:$MINA_VERSION-devnet-$MINA_GIT_HASH
 ARCHIVE_IMAGE="gcr.io/o1labs-192920/mina-archive:$MINA_VERSION-$MINA_GIT_HASH"
 
 ./test_executive.exe cloud "$TEST_NAME" \
-  --coda-image "$MINA_IMAGE" \
+  --mina-image "$MINA_IMAGE" \
   --archive-image "$ARCHIVE_IMAGE" \
-  --coda-automation-location ./automation \
+  --mina-automation-location ./automation \
   | tee "$TEST_NAME.test.log" \
   | coda-logproc -i inline -f '!(.level in ["Debug", "Spam"])'

--- a/buildkite/src/Command/DeployTestnet.dhall
+++ b/buildkite/src/Command/DeployTestnet.dhall
@@ -45,7 +45,7 @@ in
           Cmd.run "source ${spec.deployEnvFile}",
           Cmd.run (
             "terraform apply -auto-approve" ++
-              " -var coda_image=gcr.io/o1labs-192920/mina-daemon:\\\$MINA_VERSION-\\\$MINA_GIT_HASH" ++
+              " -var mina_image=gcr.io/o1labs-192920/mina-daemon:\\\$MINA_VERSION-\\\$MINA_GIT_HASH" ++
               " -var ci_artifact_path=${spec.artifactPath}" ++
               " || (terraform destroy -auto-approve && exit 1)"
           ),

--- a/src/app/test_executive/README.md
+++ b/src/app/test_executive/README.md
@@ -11,10 +11,10 @@ Note: this environment setup assumes that one is a member of o(1) labs and has a
 
 ![automated-validation service account "Keys" tab](https://user-images.githubusercontent.com/3465290/112069746-9aaed080-8b29-11eb-83f1-f36876f3ac3d.png)
 
-3) Other than `GCLOUD_API_KEY`, ensure the following other environment variables are also properly set (preferably in in .bashrc or .profile.): 
+3) Other than `GCLOUD_API_KEY`, ensure the following other environment variables are also properly set (preferably in in .bashrc or .profile.):
 - `KUBE_CONFIG_PATH`.  this should usually be `~/.kube/config`
-- any other vars relating to Google cloud access, 
-- any AWS related vars, namely: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION=us-west-2`, 
+- any other vars relating to Google cloud access,
+- any AWS related vars, namely: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION=us-west-2`,
 - vars relating to ocaml compilation
 
 4) Run the following commands in order to log in to Google Cloud, and activate the service account for one's work machine.
@@ -44,20 +44,20 @@ alias logproc=./_build/default/src/app/logproc/logproc.exe
 2) Build `test_executive.exe` with the `integration_tests` profile
 
 3) Run `test_executive.exe`, passing in the coda image selected in step 1, and the name of the test one intends to run
-  
+
 3.1) It's recommended to run with the `--debug` flag when iterating on the development of tests.  this flag will pause the destruction and cleanup of the generated testnet and associated terraform configuration files, so that those things can be inspected post-hoc
-  
+
 3.2) It's also recommended to pipe log output through logproc with a filter to remove Debug and Spam logs be default (those log levels are very verbose and are intended for debugging test framework internals).  Use `tee test.log` to store the raw output into the file `test.log` so that it can be saved and later inspected.
 
 ```sh
 alias test_executive=./_build/default/src/app/test_executive/test_executive.exe
 alias logproc=./_build/default/src/app/logproc/logproc.exe
 
-CODA_IMAGE=... # pick a suitable (recent) "coda-daemon-puppeteered:XXX-develop-XXX" dockerhub
+MINA_IMAGE=... # pick a suitable (recent) "coda-daemon-puppeteered:XXX-develop-XXX" dockerhub
 TEST=... # name of the test one wants to run
 
 dune build --profile=integration_tests src/app/test_executive/test_executive.exe src/app/logproc/logproc.exe
-test_executive cloud $TEST --coda-image=$CODA_IMAGE --debug | tee test.log | logproc -i inline -f '!(.level in ["Debug", "Spam"])'
+test_executive cloud $TEST --mina-image=$MINA_IMAGE --debug | tee test.log | logproc -i inline -f '!(.level in ["Debug", "Spam"])'
 ```
 
 4) OPTIONAL: In the event that the automatic cleanup doesn't work properly, one needs to do it manually.  Firstly, destroy what's on GCP with `kubectl delete namespace <namespace of test>`.  Then, delete the local testnet directory, which is in `./automation/terraform/testnets/`

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -27,14 +27,14 @@ type test_inputs_with_cli_inputs =
 type inputs =
   { test_inputs : test_inputs_with_cli_inputs
   ; test : test
-  ; coda_image : string
+  ; mina_image : string
   ; archive_image : string
   ; debug : bool
   }
 
-let validate_inputs { coda_image; _ } =
-  if String.is_empty coda_image then
-    failwith "Coda image cannot be an empt string"
+let validate_inputs { mina_image; _ } =
+  if String.is_empty mina_image then
+    failwith "Mina image cannot be an empty string"
 
 let engines : engine list =
   [ ("cloud", (module Integration_test_cloud_engine : Intf.Engine.S)) ]
@@ -239,7 +239,7 @@ let main inputs =
    *)
   let logger = Logger.create () in
   let images =
-    { Test_config.Container_images.coda = inputs.coda_image
+    { Test_config.Container_images.mina = inputs.mina_image
     ; archive_node = inputs.archive_image
     ; user_agent = "codaprotocol/coda-user-agent:0.1.5"
     ; bots = "codaprotocol/coda-bots:0.0.13-beta-1"
@@ -355,13 +355,13 @@ let test_arg =
   let doc = "The name of the test to execute." in
   Arg.(required & pos 0 (some (enum indexed_tests)) None & info [] ~doc)
 
-let coda_image_arg =
+let mina_image_arg =
   let doc = "Identifier of the coda docker image to test." in
-  let env = Arg.env_var "CODA_IMAGE" ~doc in
+  let env = Arg.env_var "MINA_IMAGE" ~doc in
   Arg.(
     required
     & opt (some string) None
-    & info [ "coda-image" ] ~env ~docv:"CODA_IMAGE" ~doc)
+    & info [ "mina-image" ] ~env ~docv:"MINA_IMAGE" ~doc)
 
 let archive_image_arg =
   let doc = "Identifier of the archive node docker image to test." in
@@ -393,12 +393,12 @@ let engine_cmd ((engine_name, (module Engine)) : engine) =
     Term.(const wrap_cli_inputs $ Engine.Network_config.Cli_inputs.term)
   in
   let inputs_term =
-    let cons_inputs test_inputs test coda_image archive_image debug =
-      { test_inputs; test; coda_image; archive_image; debug }
+    let cons_inputs test_inputs test mina_image archive_image debug =
+      { test_inputs; test; mina_image; archive_image; debug }
     in
     Term.(
       const cons_inputs $ test_inputs_with_cli_inputs_arg $ test_arg
-      $ coda_image_arg $ archive_image_arg $ debug_arg)
+      $ mina_image_arg $ archive_image_arg $ debug_arg)
   in
   let term = Term.(const start $ inputs_term) in
   (term, info)

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -356,7 +356,7 @@ let test_arg =
   Arg.(required & pos 0 (some (enum indexed_tests)) None & info [] ~doc)
 
 let mina_image_arg =
-  let doc = "Identifier of the coda docker image to test." in
+  let doc = "Identifier of the Mina docker image to test." in
   let env = Arg.env_var "MINA_IMAGE" ~doc in
   Arg.(
     required

--- a/src/lib/integration_test_cloud_engine/cli_inputs.ml
+++ b/src/lib/integration_test_cloud_engine/cli_inputs.ml
@@ -1,19 +1,19 @@
 open Cmdliner
 
-type t = { coda_automation_location : string }
+type t = { mina_automation_location : string }
 
 let term =
-  let coda_automation_location =
+  let mina_automation_location =
     let doc =
-      "Location of the coda automation repository to use when deploying the \
+      "Location of the Mina automation repository to use when deploying the \
        network."
     in
-    let env = Arg.env_var "CODA_AUTOMATION_LOCATION" ~doc in
+    let env = Arg.env_var "MINA_AUTOMATION_LOCATION" ~doc in
     Arg.(
       value & opt string "./automation"
       & info
-          [ "coda-automation-location" ]
-          ~env ~docv:"CODA_AUTOMATION_LOCATION" ~doc)
+          [ "mina-automation-location" ]
+          ~env ~docv:"MINA_AUTOMATION_LOCATION" ~doc)
   in
-  let cons_inputs coda_automation_location = { coda_automation_location } in
-  Term.(const cons_inputs $ coda_automation_location)
+  let cons_inputs mina_automation_location = { mina_automation_location } in
+  Term.(const cons_inputs $ mina_automation_location)

--- a/src/lib/integration_test_cloud_engine/integration_test_cloud_engine.ml
+++ b/src/lib/integration_test_cloud_engine/integration_test_cloud_engine.ml
@@ -1,6 +1,6 @@
 let name = "cloud"
 
 module Network = Kubernetes_network
-module Network_config = Coda_automation.Network_config
-module Network_manager = Coda_automation.Network_manager
+module Network_config = Mina_automation.Network_config
+module Network_manager = Mina_automation.Network_manager
 module Log_engine = Stack_driver_log_engine

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -40,11 +40,11 @@ module Network_config = struct
     ; aws_route53_zone_id : string
     ; testnet_name : string
     ; deploy_graphql_ingress : bool
-    ; coda_image : string
-    ; coda_agent_image : string
-    ; coda_bots_image : string
-    ; coda_points_image : string
-    ; coda_archive_image : string
+    ; mina_image : string
+    ; mina_agent_image : string
+    ; mina_bots_image : string
+    ; mina_points_image : string
+    ; mina_archive_image : string
           (* this field needs to be sent as a string to terraform, even though it's a json encoded value *)
     ; runtime_config : Yojson.Safe.t
           [@to_yojson fun j -> `String (Yojson.Safe.to_string j)]
@@ -59,7 +59,7 @@ module Network_config = struct
   [@@deriving to_yojson]
 
   type t =
-    { coda_automation_location : string
+    { mina_automation_location : string
     ; debug_arg : bool
     ; keypairs : Network_keypair.t list
     ; constants : Test_config.constants
@@ -221,7 +221,7 @@ module Network_config = struct
       "https://raw.githubusercontent.com/MinaProtocol/mina/develop/src/app/archive/create_schema.sql"
     in
     (* NETWORK CONFIG *)
-    { coda_automation_location = cli_inputs.coda_automation_location
+    { mina_automation_location = cli_inputs.mina_automation_location
     ; debug_arg = debug
     ; keypairs = block_producer_keypairs
     ; constants
@@ -231,11 +231,11 @@ module Network_config = struct
         ; k8s_context = cluster_id
         ; testnet_name
         ; deploy_graphql_ingress = requires_graphql
-        ; coda_image = images.coda
-        ; coda_agent_image = images.user_agent
-        ; coda_bots_image = images.bots
-        ; coda_points_image = images.points
-        ; coda_archive_image = images.archive_node
+        ; mina_image = images.mina
+        ; mina_agent_image = images.user_agent
+        ; mina_bots_image = images.bots
+        ; mina_points_image = images.points
+        ; mina_archive_image = images.archive_node
         ; runtime_config = Runtime_config.to_yojson runtime_config
         ; block_producer_configs =
             List.mapi block_producer_keypairs ~f:block_producer_config
@@ -326,7 +326,7 @@ module Network_manager = struct
     in
     let all_namespaces = String.split ~on:' ' all_namespaces_str in
     let testnet_dir =
-      network_config.coda_automation_location ^/ "terraform/testnets"
+      network_config.mina_automation_location ^/ "terraform/testnets"
       ^/ network_config.terraform.testnet_name
     in
     let%bind () =
@@ -366,7 +366,7 @@ module Network_manager = struct
         ~constraint_constants ~genesis_constants
     in
     let%bind (_, genesis_proof_filename) =
-      Genesis_ledger_helper.Genesis_proof.load_or_generate ~logger ~genesis_dir 
+      Genesis_ledger_helper.Genesis_proof.load_or_generate ~logger ~genesis_dir
         inputs
     in
     *)

--- a/src/lib/integration_test_lib/test_config.ml
+++ b/src/lib/integration_test_lib/test_config.ml
@@ -1,6 +1,6 @@
 module Container_images = struct
   type t =
-    { coda : string
+    { mina : string
     ; archive_node : string
     ; user_agent : string
     ; bots : string


### PR DESCRIPTION
Use environment variables `MINA_IMAGE` and `MINA_AUTOMATION_LOCATION` for the test executive. Change OCaml and Terraform field names, variables to match these changes.

Also change some other `coda...image` names to `mina...image`.

Renamed module `Coda_automation` to `Mina_automation`.

Last PR for #9041.