### PR TITLE
Fix `Pickles.Impls.*.Other_field.forbidden_shifted_values`

### DIFF
--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -38,7 +38,8 @@ module Step = struct
     let forbidden_shifted_values =
       forbidden_shifted_values ~size_in_bits:Constant.size_in_bits
         ~max_size:B.(Field.size * of_int 2)
-        ~modulus:(Wrap_impl.Bigint.to_bignum_bigint Constant.size) ~f:(fun x ->
+        ~modulus:(Wrap_impl.Bigint.to_bignum_bigint Constant.size)
+        ~f:(fun x ->
           let hi = test_bit x (Field.size_in_bits - 1) in
           let lo = B.shift_right x 1 in
           (Impl.Bigint.(to_field (of_bignum_bigint lo)), hi))


### PR DESCRIPTION
@mimoo identified an error where we were converting too-large bigints into field elements. Due to the behaviour of zexe, this was being interpreted as `Field.zero` :grimacing: 

```ocaml
utop # Step.Other_field.forbidden_shifted_values;;
- : (Marlin_plonk_bindings_pasta_fp.t * bool) list =
[(45560315531506369815346746415080538112, false);
 (45560315531506369815346746415080538113, false);
 (14474011154664524427946373126085988481727088556502330059655218120611762012161,
  true);
 (14474011154664524427946373126085988481727088556502330059655218120611762012161,
  true)]
utop # Wrap.Other_field.forbidden_shifted_values;;
- : Marlin_plonk_bindings_pasta_fq.t list =
[91120631062839412180561524743370440705;
 91120631062839412180561524743370440706; 0; 0]
```

The circuit depends on these `forbidden_shifted_variables`, so this PR is against `develop` in order to not break compatibility.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: