### PR TITLE
Fix signed equality

### DIFF
--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -192,8 +192,36 @@ end = struct
       { magnitude : 'magnitude; sgn : 'sgn }
     [@@deriving sexp, hash, compare, yojson, hlist]
 
-    type t = (Unsigned.t, Sgn.t) Signed_poly.t
-    [@@deriving sexp, hash, compare, equal, yojson]
+    type t = (Unsigned.t, Sgn.t) Signed_poly.t [@@deriving sexp, hash, yojson]
+
+    let compare : t -> t -> int =
+      let cmp = [%compare: (Unsigned.t, Sgn.t) Signed_poly.t] in
+      fun t1 t2 ->
+        if Unsigned.(equal t1.magnitude zero && equal t2.magnitude zero) then 0
+        else cmp t1 t2
+
+    let equal : t -> t -> bool =
+      let eq = [%equal: (Unsigned.t, Sgn.t) Signed_poly.t] in
+      fun t1 t2 ->
+        if Unsigned.(equal t1.magnitude zero && equal t2.magnitude zero) then
+          true
+        else eq t1 t2
+
+    let is_zero (t : t) : bool = Unsigned.(equal t.magnitude zero)
+
+    let is_positive (t : t) : bool =
+      match t.sgn with
+      | Pos ->
+          not Unsigned.(equal zero t.magnitude)
+      | Neg ->
+          false
+
+    let is_negative (t : t) : bool =
+      match t.sgn with
+      | Neg ->
+          not Unsigned.(equal zero t.magnitude)
+      | Pos ->
+          false
 
     type magnitude = Unsigned.t [@@deriving sexp, compare]
 

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -115,6 +115,12 @@ module type Signed_intf = sig
 
   val zero : t
 
+  val is_zero : t -> bool
+
+  val is_positive : t -> bool
+
+  val is_negative : t -> bool
+
   val to_input : t -> (_, bool) Random_oracle.Input.t
 
   val add : t -> t -> t option


### PR DESCRIPTION
Currently, for signed values we have

```ocaml
{ sgn= Pos; magnitude= 0 } <> { sgn= Neg; magnitude= 0 }
```

This PR corrects this so that those two values are now equal, and adds some helper functions.