### PR TITLE
Remove version byte for uncompressed Non_zero_curve_point

### DIFF
--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -58,8 +58,6 @@ let snapp_command : t = '\x1A'
 
 let private_key : t = '\x5A'
 
-let non_zero_curve_point : t = '\xCE'
-
 let non_zero_curve_point_compressed : t = '\xCB'
 
 let signature : t = '\x9A'


### PR DESCRIPTION
The base58check representation of `Non_zero_curve_point` always represents the compressed representation of the point. The version byte for the uncompressed point was used in the past, but not used in the current code, so its presence is confusing.


