### PR TITLE
Uptime service for delegation program

### DIFF
--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -4,7 +4,7 @@
  (name mina_cli_entrypoint)
  (public_name cli.mina_cli_entrypoint)
  (modes native)
- (libraries init tests consensus child_processes memory_stats node_addrs_and_ports jemalloc genesis_ledger_helper mina_plugins error_json)
+ (libraries init tests consensus child_processes memory_stats node_addrs_and_ports uptime_service jemalloc genesis_ledger_helper mina_plugins error_json)
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_here ppx_let ppx_sexp_conv ppx_optcomp ppx_deriving_yojson)))

--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -4,7 +4,7 @@
  (name mina_cli_entrypoint)
  (public_name cli.mina_cli_entrypoint)
  (modes native)
- (libraries init tests consensus child_processes memory_stats node_addrs_and_ports uptime_service jemalloc genesis_ledger_helper mina_plugins error_json)
+ (libraries init tests consensus child_processes memory_stats node_addrs_and_ports jemalloc genesis_ledger_helper mina_plugins error_json)
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_here ppx_let ppx_sexp_conv ppx_optcomp ppx_deriving_yojson)))

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -55,6 +55,14 @@ let plugin_flag = Command.Param.return []
 
 [%%endif]
 
+let get_tracked_keypair ~logger ~read_from_env_exn ~which conf_dir pk =
+  let%bind wallets =
+    Secrets.Wallets.load ~logger ~disk_location:(conf_dir ^/ "wallets")
+  in
+  let sk_file = Secrets.Wallets.get_path wallets pk in
+  let%map kp = read_from_env_exn ~logger ~which sk_file in
+  Some kp
+
 let setup_daemon logger =
   let open Command.Let_syntax in
   let open Cli_lib.Arg_type in
@@ -369,6 +377,14 @@ let setup_daemon logger =
       ~doc:
         "true|false whether to track the set of all peers ever seen for the \
          all_peers metric (default: false)"
+  and uptime_url_string =
+    flag "--uptime-url" ~aliases:["uptime-url"] (optional string)
+      ~doc:"URL URL of the uptime service of the Mina delegation program"
+  and uptime_submitter_string =
+    flag "--uptime-submitter" ~aliases:["uptime-submitter"] (optional string)
+      ~doc:
+        "PUBLICKEY Public key of the submitter to the uptime service of the \
+         Mina delegation program"
   in
   fun () ->
     let open Deferred.Let_syntax in
@@ -870,16 +886,10 @@ let setup_daemon logger =
             in
             Some kp
         | _, Some tracked_pubkey ->
-            let%bind wallets =
-              Secrets.Wallets.load ~logger
-                ~disk_location:(conf_dir ^/ "wallets")
-            in
-            let sk_file = Secrets.Wallets.get_path wallets tracked_pubkey in
-            let%map kp =
-              Secrets.Keypair.Terminal_stdin.read_from_env_exn ~logger
-                ~which:"block producer keypair" sk_file
-            in
-            Some kp
+            get_tracked_keypair ~logger
+              ~read_from_env_exn:
+                Secrets.Keypair.Terminal_stdin.read_from_env_exn
+              ~which:"block producer keypair" conf_dir tracked_pubkey
       in
       let%bind client_trustlist =
         Reader.load_sexp
@@ -1103,6 +1113,40 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
         Coda_run.get_proposed_protocol_version_opt ~conf_dir ~logger
           proposed_protocol_version
       in
+      ( match (uptime_url_string, uptime_submitter_string) with
+      | Some _, Some _ | None, None ->
+          ()
+      | _ ->
+          failwith "Must provide both --uptime-url and --uptime-submitter" ) ;
+      let uptime_url =
+        Option.map uptime_url_string ~f:(fun s -> Uri.of_string s)
+      in
+      let uptime_submitter =
+        Option.map uptime_submitter_string ~f:(fun s ->
+            match Public_key.Compressed.of_base58_check s with
+            | Ok pk -> (
+              match Public_key.decompress pk with
+              | Some _ ->
+                  pk
+              | None ->
+                  failwithf
+                    "Invalid public key %s for uptime submitter (could not \
+                     decompress)"
+                    s () )
+            | Error err ->
+                failwithf "Invalid public key %s for uptime submitter, %s" s
+                  (Error.to_string_hum err) () )
+      in
+      let%bind uptime_submitter_keypair =
+        match uptime_submitter with
+        | None ->
+            return None
+        | Some pk ->
+            get_tracked_keypair ~logger
+              ~read_from_env_exn:
+                Secrets.Uptime_keypair.Terminal_stdin.read_from_env_exn
+              ~which:"uptime submitter keypair" conf_dir pk
+      in
       let start_time = Time.now () in
       let%map coda =
         Mina_lib.create ~wallets
@@ -1130,7 +1174,8 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
              ~consensus_local_state ~is_archive_rocksdb ~work_reassignment_wait
              ~archive_process_location ~log_block_creation ~precomputed_values
              ~start_time ?precomputed_blocks_path ~log_precomputed_blocks
-             ~upload_blocks_to_gcloud ~block_reward_threshold ())
+             ~upload_blocks_to_gcloud ~block_reward_threshold ~uptime_url
+             ~uptime_submitter_keypair ())
       in
       { Coda_initialization.coda
       ; client_trustlist
@@ -1178,6 +1223,7 @@ let daemon logger =
          Block_time.Controller.disable_setting_offset () ;
          let%bind coda = setup_daemon () in
          let%bind () = Mina_lib.start coda in
+         let () = Uptime_service.start coda in
          [%log info] "Daemon ready. Clients can now connect" ;
          Async.never () ))
 

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1225,7 +1225,6 @@ let daemon logger =
          Block_time.Controller.disable_setting_offset () ;
          let%bind coda = setup_daemon () in
          let%bind () = Mina_lib.start coda in
-         let () = Uptime_service.start coda in
          [%log info] "Daemon ready. Clients can now connect" ;
          Async.never () ))
 

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1113,7 +1113,8 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
       | Some _, Some _ | None, None ->
           ()
       | _ ->
-          failwith "Must provide both --uptime-url and --uptime-submitter" ) ;
+          Mina_user_error.raise
+            "Must provide both --uptime-url and --uptime-submitter" ) ;
       let uptime_url =
         Option.map uptime_url_string ~f:(fun s -> Uri.of_string s)
       in
@@ -1130,7 +1131,8 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                      decompress)"
                     s () )
             | Error err ->
-                failwithf "Invalid public key %s for uptime submitter, %s" s
+                Mina_user_error.raisef
+                  "Invalid public key %s for uptime submitter, %s" s
                   (Error.to_string_hum err) () )
       in
       let%bind uptime_submitter_keypair =

--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -18,6 +18,7 @@ open Mina_base_nonconsensus
 open Rosetta_lib_nonconsensus
 open Rosetta_coding_nonconsensus
 open Js_util
+module String_sign = String_sign_nonconsensus.String_sign
 
 let _ =
   Js.export "minaSDK"

--- a/src/app/client_sdk/dune
+++ b/src/app/client_sdk/dune
@@ -3,8 +3,8 @@
  (modes js)
  (js_of_ocaml (flags +toplevel.js +dynlink.js))
  (libraries snark_params_nonconsensus rosetta_lib_nonconsensus mina_base_nonconsensus data_hash_lib_nonconsensus
-            random_oracle_nonconsensus signature_lib_nonconsensus zarith_stubs_js integers integers_stubs_js js_of_ocaml
-            digestif.ocaml)
+            random_oracle_nonconsensus signature_lib_nonconsensus string_sign_nonconsensus
+            zarith_stubs_js integers integers_stubs_js js_of_ocaml digestif.ocaml)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_custom_printf ppx_optcomp js_of_ocaml-ppx)))

--- a/src/lib/cache_lib/impl.ml
+++ b/src/lib/cache_lib/impl.ml
@@ -196,7 +196,9 @@ module Make (Inputs : Inputs_intf) : Intf.Main.S = struct
            ; final_state= final_state t })
 
     let invalidate_with_failure (type a b) (t : (a, b) t) : a =
-      assert_not_finalized t "Cached item has already been finalized" ;
+      ( if was_finalized t && not (is_pure t) then
+        let logger = Cache.logger (cache t) in
+        [%log error] "Cached item has already been finalized" ) ;
       mark_failed t ;
       Cache.remove (cache t) `Failure (original t) ;
       value t

--- a/src/lib/cache_lib/impl.ml
+++ b/src/lib/cache_lib/impl.ml
@@ -196,9 +196,7 @@ module Make (Inputs : Inputs_intf) : Intf.Main.S = struct
            ; final_state= final_state t })
 
     let invalidate_with_failure (type a b) (t : (a, b) t) : a =
-      ( if was_finalized t && not (is_pure t) then
-        let logger = Cache.logger (cache t) in
-        [%log error] "Cached item has already been finalized" ) ;
+      assert_not_finalized t "Cached item has already been finalized" ;
       mark_failed t ;
       Cache.remove (cache t) `Failure (original t) ;
       value t

--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -6,7 +6,7 @@ open Async
 open Core_kernel
 include Hashable.Make_binable (Pid)
 
-type process_kind = Prover | Verifier | Libp2p_helper
+type process_kind = Prover | Verifier | Libp2p_helper | Uptime_snark_worker
 [@@deriving show {with_path= false}, yojson]
 
 type data = {kind: process_kind; termination_expected: bool}

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -53,5 +53,7 @@ type t =
   ; precomputed_blocks_path: string option
   ; log_precomputed_blocks: bool
   ; upload_blocks_to_gcloud: bool
-  ; block_reward_threshold: Currency.Amount.t option [@default None] }
+  ; block_reward_threshold: Currency.Amount.t option [@default None]
+  ; uptime_url: Uri.t option [@default None]
+  ; uptime_submitter_keypair: Keypair.t option [@default None] }
 [@@deriving make]

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -8,7 +8,7 @@
             child_processes incremental secrets work_selector
             mina_networking block_producer genesis_constants sync_handler transition_router node_addrs_and_ports
             otp_lib protocol_version snark_worker participating_state transaction_inclusion_status
-            sync_status daemon_rpcs archive_lib exit_handlers)
+            sync_status daemon_rpcs archive_lib exit_handlers uptime_service)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_coda ppx_version ppx_inline_test ppx_deriving.std))
  (synopsis "Coda gut layer"))

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1207,11 +1207,12 @@ let create ?wallets (config : Config.t) =
                     (`Call
                       (fun exn ->
                         let err = Error.of_exn ~backtrace:`Get exn in
-                        [%log' warn config.logger]
+                        [%log' fatal config.logger]
                           "unhandled exception from uptime service SNARK \
-                           worker: $exn"
-                          ~metadata:[("exn", Error_json.error_to_yojson err)]
-                        ))
+                           worker: $exn, terminating daemon"
+                          ~metadata:[("exn", Error_json.error_to_yojson err)] ;
+                        (* make sure Async shutdown handlers are called *)
+                        don't_wait_for (Async.exit 1) ))
                   (fun () ->
                     trace "uptime SNARK worker" (fun () ->
                         Uptime_service.Uptime_snark_worker.create

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1085,6 +1085,14 @@ let start t =
     ~block_reward_threshold:t.config.block_reward_threshold
     ~block_produced_bvar:t.components.block_produced_bvar ;
   perform_compaction t ;
+  Uptime_service.start ~logger:t.config.logger ~uptime_url:t.config.uptime_url
+    ~transition_frontier:t.components.transition_frontier
+    ~time_controller:t.config.time_controller
+    ~block_produced_bvar:t.components.block_produced_bvar
+    ~uptime_submitter_keypair:t.config.uptime_submitter_keypair
+    ~get_next_producer_timing:(fun () -> t.next_producer_timing)
+    ~get_snark_work_fee:(fun () -> snark_work_fee t)
+    ~get_peer:(fun () -> t.config.gossip_net_params.addrs_and_ports.peer) ;
   Snark_worker.start t
 
 let start_with_precomputed_blocks t blocks =

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -144,8 +144,9 @@ let client_port t =
 
 (* Get the most recently set public keys  *)
 let block_production_pubkeys t : Public_key.Compressed.Set.t =
-  let public_keys, _ = Agent.get t.block_production_keypairs in
-  Public_key.Compressed.Set.map public_keys ~f:snd
+  let keypair_and_compressed_pks, _ = Agent.get t.block_production_keypairs in
+  Public_key.Compressed.Set.map keypair_and_compressed_pks
+    ~f:(fun (_keypair, pk_compressed) -> pk_compressed)
 
 let coinbase_receiver t = !(t.coinbase_receiver)
 

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -183,6 +183,9 @@ val subscriptions : t -> Coda_subscriptions.t
 val most_recent_valid_transition :
   t -> External_transition.Initial_validated.t Broadcast_pipe.Reader.t
 
+val block_produced_bvar :
+  t -> (Transition_frontier.Breadcrumb.t, read_write) Bvar.t
+
 val top_level_logger : t -> Logger.t
 
 val config : t -> Config.t

--- a/src/lib/secrets/keypair.ml
+++ b/src/lib/secrets/keypair.ml
@@ -1,78 +1,8 @@
-open Signature_lib
-open Core
-open Async
-open Async.Deferred.Let_syntax
-open Keypair_common
-
-module T = struct
-  type t = Keypair.t
-
+module T = Keypair_read_write.Make (struct
   let env = "CODA_PRIVKEY_PASS"
 
-  let which = "coda keypair"
-
-  (** Writes a keypair to [privkey_path] and [privkey_path ^ ".pub"] using [Secret_file] *)
-  let write_exn {Keypair.private_key; public_key} ~(privkey_path : string)
-      ~(password : Secret_file.password) : unit Deferred.t =
-    let privkey_bytes =
-      Private_key.to_bigstring private_key |> Bigstring.to_bytes
-    in
-    let pubkey_string =
-      Public_key.Compressed.to_base58_check (Public_key.compress public_key)
-    in
-    match%bind
-      Secret_file.write ~path:privkey_path ~mkdir:true ~plaintext:privkey_bytes
-        ~password
-    with
-    | Ok () ->
-        (* The hope is that if [Secret_file.write] succeeded then this ought to
-       as well, letting [handle_open] stay inside [Secret_file]. It might not
-       if the environment changes underneath us, and we won't have nice errors
-       in that case. *)
-        let%bind pubkey_f = Writer.open_file (privkey_path ^ ".pub") in
-        Writer.write_line pubkey_f pubkey_string ;
-        Writer.close pubkey_f
-    | Error e ->
-        Privkey_error.raise ~which e
-
-  (** Reads a private key from [privkey_path] using [Secret_file] *)
-  let read ~(privkey_path : string) ~(password : Secret_file.password) :
-      (Keypair.t, Privkey_error.t) Deferred.Result.t =
-    let open Deferred.Result.Let_syntax in
-    let%bind pk_bytes = Secret_file.read ~path:privkey_path ~password in
-    let open Result.Let_syntax in
-    Deferred.return
-    @@ let%bind sk =
-         try
-           return
-             (pk_bytes |> Bigstring.of_bytes |> Private_key.of_bigstring_exn)
-         with exn ->
-           Privkey_error.corrupted_privkey
-             (Error.createf "Error parsing decrypted private key file: %s"
-                (Exn.to_string exn))
-       in
-       try return (Keypair.of_private_key_exn sk)
-       with exn ->
-         Privkey_error.corrupted_privkey
-           (Error.createf
-              "Error computing public key from private, is your keyfile \
-               corrupt? %s"
-              (Exn.to_string exn))
-
-  (** Reads a private key from [privkey_path] using [Secret_file], throws on failure *)
-  let read_exn ~(privkey_path : string) ~(password : Secret_file.password) :
-      Keypair.t Deferred.t =
-    match%map read ~privkey_path ~password with
-    | Ok keypair ->
-        keypair
-    | Error priv_key_error ->
-        Privkey_error.raise ~which priv_key_error
-
-  let read_exn' path =
-    read_exn ~privkey_path:path
-      ~password:
-        (lazy (Password.hidden_line_or_env "Secret key password: " ~env))
-end
+  let which = "Coda keypair"
+end)
 
 include T
-module Terminal_stdin = Make_terminal_stdin (T)
+module Terminal_stdin = Keypair_common.Make_terminal_stdin (T)

--- a/src/lib/secrets/keypair_read_write.ml
+++ b/src/lib/secrets/keypair_read_write.ml
@@ -1,0 +1,83 @@
+(* keypair_read_write.ml -- readers, writers for keypairs *)
+
+open Core_kernel
+open Async
+open Signature_lib
+
+module Make (Env : sig
+  val env : string
+
+  val which : string
+end) =
+struct
+  open Env
+
+  (* avoid spurious cyclic dependency *)
+  module Keypair = Signature_lib.Keypair
+
+  type t = Keypair.t
+
+  let env = env
+
+  (** Writes a keypair to [privkey_path] and [privkey_path ^ ".pub"] using [Secret_file] *)
+  let write_exn {Keypair.private_key; public_key} ~(privkey_path : string)
+      ~(password : Secret_file.password) : unit Deferred.t =
+    let privkey_bytes =
+      Private_key.to_bigstring private_key |> Bigstring.to_bytes
+    in
+    let pubkey_string =
+      Public_key.Compressed.to_base58_check (Public_key.compress public_key)
+    in
+    match%bind
+      Secret_file.write ~path:privkey_path ~mkdir:true ~plaintext:privkey_bytes
+        ~password
+    with
+    | Ok () ->
+        (* The hope is that if [Secret_file.write] succeeded then this ought to
+       as well, letting [handle_open] stay inside [Secret_file]. It might not
+       if the environment changes underneath us, and we won't have nice errors
+       in that case. *)
+        let%bind pubkey_f = Writer.open_file (privkey_path ^ ".pub") in
+        Writer.write_line pubkey_f pubkey_string ;
+        Writer.close pubkey_f
+    | Error e ->
+        Privkey_error.raise ~which e
+
+  (** Reads a private key from [privkey_path] using [Secret_file] *)
+  let read ~(privkey_path : string) ~(password : Secret_file.password) :
+      (Keypair.t, Privkey_error.t) Deferred.Result.t =
+    let open Deferred.Result.Let_syntax in
+    let%bind pk_bytes = Secret_file.read ~path:privkey_path ~password in
+    let open Result.Let_syntax in
+    Deferred.return
+    @@ let%bind sk =
+         try
+           return
+             (pk_bytes |> Bigstring.of_bytes |> Private_key.of_bigstring_exn)
+         with exn ->
+           Privkey_error.corrupted_privkey
+             (Error.createf "Error parsing decrypted private key file: %s"
+                (Exn.to_string exn))
+       in
+       try return (Keypair.of_private_key_exn sk)
+       with exn ->
+         Privkey_error.corrupted_privkey
+           (Error.createf
+              "Error computing public key from private, is your keyfile \
+               corrupt? %s"
+              (Exn.to_string exn))
+
+  (** Reads a private key from [privkey_path] using [Secret_file], throws on failure *)
+  let read_exn ~(privkey_path : string) ~(password : Secret_file.password) :
+      Keypair.t Deferred.t =
+    match%map read ~privkey_path ~password with
+    | Ok keypair ->
+        keypair
+    | Error priv_key_error ->
+        Privkey_error.raise ~which priv_key_error
+
+  let read_exn' path =
+    read_exn ~privkey_path:path
+      ~password:
+        (lazy (Password.hidden_line_or_env "Secret key password: " ~env))
+end

--- a/src/lib/secrets/uptime_keypair.ml
+++ b/src/lib/secrets/uptime_keypair.ml
@@ -1,0 +1,10 @@
+(* uptime_keypair.ml -- keypair for uptime service *)
+
+module T = Keypair_read_write.Make (struct
+  let env = "UPTIME_PRIVKEY_PASS"
+
+  let which = "Uptime service keypair"
+end)
+
+include T
+module Terminal_stdin = Keypair_common.Make_terminal_stdin (T)

--- a/src/lib/secrets/wallets.ml
+++ b/src/lib/secrets/wallets.ml
@@ -201,6 +201,11 @@ let lock {cache; _} ~needle =
     | k ->
         k )
 
+let get_tracked_keypair ~logger ~which ~read_from_env_exn ~conf_dir pk =
+  let%bind wallets = load ~logger ~disk_location:(conf_dir ^/ "wallets") in
+  let sk_file = get_path wallets pk in
+  read_from_env_exn ~logger ~which sk_file
+
 let%test_module "wallets" =
   ( module struct
     let logger = Logger.create ()

--- a/src/lib/secrets/wallets.mli
+++ b/src/lib/secrets/wallets.mli
@@ -47,3 +47,14 @@ val get_path : t -> Public_key.Compressed.t -> string
 
 val delete :
   t -> Public_key.Compressed.t -> (unit, [`Not_found]) Deferred.Result.t
+
+val get_tracked_keypair :
+     logger:Logger.t
+  -> which:string
+  -> read_from_env_exn:(   logger:Logger.t
+                        -> which:string
+                        -> string
+                        -> Keypair.t Deferred.t)
+  -> conf_dir:string
+  -> Public_key.Compressed.t
+  -> Keypair.t Deferred.t

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -17,7 +17,7 @@ open Snark_params_nonconsensus
 [%%versioned_asserted
 module Stable = struct
   module V1 = struct
-    type t = Inner_curve.Scalar.t
+    type t = Inner_curve.Scalar.t [@@deriving compare, sexp]
 
     let to_latest = Fn.id
 
@@ -79,6 +79,8 @@ let create () =
 let create () = Quickcheck.random_value ~seed:`Nondeterministic gen
 
 [%%endif]
+
+include Comparable.Make_binable (Stable.Latest)
 
 let of_bigstring_exn = Binable.of_bigstring (module Stable.Latest)
 

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -48,12 +48,13 @@ module Inputs = struct
     let worker_wait_time = 5.
   end
 
+  (* bin_io is for uptime service SNARK worker *)
   type single_spec =
-    ( Transaction.t
-    , Transaction_witness.t
-    , Transaction_snark.t )
-    Snark_work_lib.Work.Single.Spec.t
-  [@@deriving sexp]
+    ( Transaction.Stable.Latest.t
+    , Transaction_witness.Stable.Latest.t
+    , Transaction_snark.Stable.Latest.t )
+    Snark_work_lib.Work.Single.Spec.Stable.Latest.t
+  [@@deriving bin_io_unversioned, sexp]
 
   let perform_single ({m; cache; proof_level} : Worker_state.t) ~message =
     let open Deferred.Or_error.Let_syntax in

--- a/src/lib/string_sign/dune
+++ b/src/lib/string_sign/dune
@@ -1,0 +1,8 @@
+(library
+ (name string_sign)
+ (public_name string_sign)
+ (libraries snark_params mina_base random_oracle signature_lib digestif.ocaml)
+ (preprocessor_deps ../../config.mlh)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version ppx_snarky ppx_optcomp))
+ (synopsis "Schnorr signatures for strings"))

--- a/src/lib/uptime_service/dune
+++ b/src/lib/uptime_service/dune
@@ -3,7 +3,7 @@
  (public_name uptime_service)
  (inline_tests)
  (libraries core_kernel async block_producer daemon_rpcs mina_transition otp_lib ptime
-            snark_work_lib snark_worker string_sign)
+            snark_work_lib snark_worker)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_coda ppx_version ppx_inline_test ppx_deriving.std))
  (synopsis "Uptime service library for delegation program"))

--- a/src/lib/uptime_service/dune
+++ b/src/lib/uptime_service/dune
@@ -2,7 +2,8 @@
  (name uptime_service)
  (public_name uptime_service)
  (inline_tests)
- (libraries core_kernel async block_producer mina_lib mina_transition otp_lib ptime snark_worker string_sign)
+ (libraries core_kernel async block_producer mina_lib mina_transition otp_lib ptime
+            snark_work_lib snark_worker string_sign)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_coda ppx_version ppx_inline_test ppx_deriving.std))
  (synopsis "Uptime service library for delegation program"))

--- a/src/lib/uptime_service/dune
+++ b/src/lib/uptime_service/dune
@@ -1,0 +1,8 @@
+(library
+ (name uptime_service)
+ (public_name uptime_service)
+ (inline_tests)
+ (libraries core_kernel async block_producer mina_lib mina_transition otp_lib ptime snark_worker string_sign)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_jane ppx_coda ppx_version ppx_inline_test ppx_deriving.std))
+ (synopsis "Uptime service library for delegation program"))

--- a/src/lib/uptime_service/dune
+++ b/src/lib/uptime_service/dune
@@ -2,7 +2,7 @@
  (name uptime_service)
  (public_name uptime_service)
  (inline_tests)
- (libraries core_kernel async block_producer mina_lib mina_transition otp_lib ptime
+ (libraries core_kernel async block_producer daemon_rpcs mina_transition otp_lib ptime
             snark_work_lib snark_worker string_sign)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_coda ppx_version ppx_inline_test ppx_deriving.std))

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -1,0 +1,326 @@
+(* uptime_service.ml -- proof of uptime for Mina delegation program *)
+
+open Core_kernel
+open Async
+open Mina_base
+open Mina_transition
+open Pipe_lib
+open Signature_lib
+
+module Blake2 = Blake2.Make ()
+
+type block_data =
+  { block: string
+  ; created_at: string
+  ; peer_id: string
+  ; snark_work: string option [@default None] }
+[@@deriving to_yojson]
+
+type proof_data =
+  (Ledger_proof.Stable.Latest.t * Core_kernel.Time.Span.t)
+  One_or_two.Stable.Latest.t
+[@@deriving bin_io_unversioned]
+
+(* TODO: what's the max size of a serialized block? *)
+let block_buf = Bin_prot.Common.create_buf 12_000_000
+
+(* TODO: what the size of a serialized proof? *)
+let proof_buf = Bin_prot.Common.create_buf 500_000
+
+let external_transition_of_breadcrumb breadcrumb =
+  let {With_hash.data= external_transition; _}, _ =
+    Transition_frontier.Breadcrumb.validated_transition breadcrumb
+    |> External_transition.Validated.erase
+  in
+  external_transition
+
+let get_rfc3339_time () =
+  let tm = Unix.gettimeofday () in
+  match Ptime.of_float_s tm with
+  | None ->
+      (* should never occur *)
+      failwith "In uptime service, could not convert current time to Ptime.t"
+  | Some ptime ->
+      Ptime.to_rfc3339 ~tz_offset_s:0 ptime
+
+let send_uptime_data ~logger ~(submitter_keypair : Keypair.t) ~url ~state_hash
+    block_data =
+  let block_data_json = block_data_to_yojson block_data in
+  let block_data_string = Yojson.Safe.to_string block_data_json in
+  let signature =
+    String_sign.Schnorr.sign submitter_keypair.private_key block_data_string
+  in
+  let json =
+    (* JSON structure in issue 9110 *)
+    `Assoc
+      [ ("data", block_data_json)
+      ; ("signature", Signature.to_yojson signature)
+      ; ("submitter", Public_key.to_yojson submitter_keypair.public_key) ]
+  in
+  let headers = Cohttp.Header.of_list [("Content-Type", "application/json")] in
+  match%map
+    Monitor.try_with ~here:[%here] ~extract_exn:true (fun () ->
+        match%map
+          Cohttp_async.Client.post ~headers
+            ~body:(Yojson.Safe.to_string json |> Cohttp_async.Body.of_string)
+            url
+        with
+        | {status; _}, _body ->
+            if Cohttp.Code.code_of_status status = 200 then
+              [%log info]
+                "Sent block with state hash $state_hash to uptime server at \
+                 URL $url"
+                ~metadata:
+                  [ ("state_hash", State_hash.to_yojson state_hash)
+                  ; ( "includes_snark_work"
+                    , `Bool (Option.is_some block_data.snark_work) )
+                  ; ("url", `String (Uri.to_string url)) ]
+            else
+              [%log error]
+                "Failure when sending block with state hash $state_hash to \
+                 uptime server at URL $url"
+                ~metadata:
+                  [ ("state_hash", State_hash.to_yojson state_hash)
+                  ; ("url", `String (Uri.to_string url))
+                  ; ("http_code", `Int (Cohttp.Code.code_of_status status))
+                  ; ( "http_error"
+                    , `String (Cohttp.Code.string_of_status status) ) ] )
+  with
+  | Ok () ->
+      ()
+  | Error exn ->
+      [%log error]
+        "Error when sending block with state hash $state_hash to uptime \
+         server at URL $url"
+        ~metadata:
+          [ ("state_hash", State_hash.to_yojson state_hash)
+          ; ("url", `String (Uri.to_string url))
+          ; ("error", `String (Exn.to_string exn)) ]
+
+let block_base64_of_breadcrumb ~logger breadcrumb =
+  let external_transition = external_transition_of_breadcrumb breadcrumb in
+  let block_len =
+    External_transition.Stable.Latest.bin_write_t block_buf ~pos:0
+      external_transition
+  in
+  let block_string = String.init block_len ~f:(fun ndx -> block_buf.{ndx}) in
+  let block_base64_result = Base64.encode block_string in
+  match block_base64_result with
+  | Ok block_base64 ->
+      Some block_base64
+  | Error (`Msg err) ->
+      [%log error] "Could not Base64-encode block with state hash $state_hash"
+        ~metadata:
+          [ ( "state_hash"
+            , State_hash.to_yojson
+              @@ External_transition.state_hash external_transition )
+          ; ("error", `String err) ] ;
+      None
+
+let send_produced_block_at ~logger ~url ~transition_frontier ~peer_id
+    ~(submitter_keypair : Keypair.t) tm =
+  (* give block production some time *)
+  let%bind () = at (Time.add tm Time.Span.minute) in
+  match Block_producer.last_block_produced_opt () with
+  | None ->
+      [%log error] "State hash of last block produced unavailable"
+        ~metadata:
+          [ ( "expected_block_production_time"
+            , `String (Time.to_string_abs ~zone:Time.Zone.utc tm) ) ] ;
+      return ()
+  | Some state_hash -> (
+    match Broadcast_pipe.Reader.peek transition_frontier with
+    | None ->
+        [%log error]
+          "Transition frontier not available to obtain produced block with \
+           state hash $state_hash"
+          ~metadata:[("state_hash", State_hash.to_yojson state_hash)] ;
+        return ()
+    | Some tf -> (
+      match Transition_frontier.find tf state_hash with
+      | None ->
+          [%log error]
+            "Produced block with state hash $state_hash not found in \
+             transition frontier"
+            ~metadata:[("state_hash", State_hash.to_yojson state_hash)] ;
+          return ()
+      | Some breadcrumb -> (
+        match block_base64_of_breadcrumb ~logger breadcrumb with
+        | Some block_base64 ->
+            let block_data =
+              { block= block_base64
+              ; created_at= get_rfc3339_time ()
+              ; peer_id
+              ; snark_work= None }
+            in
+            send_uptime_data ~logger ~submitter_keypair ~url ~state_hash
+              block_data
+        | None ->
+            return () ) ) )
+
+let send_block_and_transaction_snark ~logger ~url ~transition_frontier ~peer_id
+    ~(submitter_keypair : Keypair.t) =
+  match Broadcast_pipe.Reader.peek transition_frontier with
+  | None ->
+      [%log error]
+        "Transition frontier not available to send a block to uptime service" ;
+      return ()
+  | Some tf -> (
+      let breadcrumb = Transition_frontier.best_tip tf in
+      match block_base64_of_breadcrumb ~logger breadcrumb with
+      | None ->
+          [%log info]
+            "Could not Base64-encode block, not performing SNARK work" ;
+          return ()
+      | Some block_base64 -> (
+          let message =
+            Sok_message.create ~fee:Currency.Fee.zero
+              ~prover:(Public_key.compress submitter_keypair.public_key)
+          in
+          (* mimicking code from standalone snark worker *)
+          let module Prod = Snark_worker__Prod.Inputs in
+          let%bind ({m; _} as worker_state : Prod.Worker_state.t) =
+            Prod.Worker_state.create
+              ~constraint_constants:
+                Genesis_constants.Constraint_constants.compiled
+              ~proof_level:Full ()
+          in
+          let (module M : Transaction_snark.S) = Option.value_exn m in
+          let best_tip = Transition_frontier.best_tip tf in
+          let best_tip_staged_ledger =
+            Transition_frontier.Breadcrumb.staged_ledger best_tip
+          in
+          match
+            Staged_ledger.all_work_pairs best_tip_staged_ledger
+              ~get_state:(fun state_hash ->
+                match Transition_frontier.find tf state_hash with
+                | None ->
+                    Error
+                      (Error.createf
+                         "Could not find state_hash %s in transition frontier \
+                          for uptime service"
+                         (State_hash.to_base58_check state_hash))
+                | Some breadcrumb ->
+                    Ok
+                      (Transition_frontier.Breadcrumb.protocol_state breadcrumb)
+            )
+          with
+          | Error e ->
+              [%log error]
+                "Could not get SNARK work from best tip staged ledger for \
+                 uptime service"
+                ~metadata:[("error", Error_json.error_to_yojson e)] ;
+              return ()
+          | Ok [] ->
+              [%log info] "No SNARK jobs available for uptime service" ;
+              return ()
+          | Ok jobs -> (
+              let last_job = List.last_exn jobs in
+              match%bind
+                One_or_two.Deferred_result.map last_job ~f:(fun single_spec ->
+                    Prod.perform_single worker_state ~message single_spec )
+              with
+              | Error e ->
+                  [%log error]
+                    "Error when computing SNARK work for uptime service"
+                    ~metadata:[("error", Error_json.error_to_yojson e)] ;
+                  return ()
+              | Ok proofs -> (
+                  let proof_len =
+                    bin_write_proof_data proof_buf ~pos:0 proofs
+                  in
+                  let proof_string =
+                    String.init proof_len ~f:(fun ndx -> proof_buf.{ndx})
+                  in
+                  match Base64.encode proof_string with
+                  | Error (`Msg err) ->
+                      [%log error]
+                        "Could not Base64-encode SNARK work for uptime service"
+                        ~metadata:[("error", `String err)] ;
+                      return ()
+                  | Ok snark_work_base64 ->
+                      let state_hash =
+                        Transition_frontier.Breadcrumb.state_hash best_tip
+                      in
+                      let block_data =
+                        { block= block_base64
+                        ; created_at= get_rfc3339_time ()
+                        ; peer_id
+                        ; snark_work= Some snark_work_base64 }
+                      in
+                      send_uptime_data ~logger ~submitter_keypair ~url
+                        ~state_hash block_data ) ) ) )
+
+let start (mina : Mina_lib.t) =
+  let config = Mina_lib.config mina in
+  let transition_frontier = Mina_lib.transition_frontier mina in
+  match config.uptime_url with
+  | None ->
+      [%log' info config.logger] "Not running uptime service, no URL given" ;
+      ()
+  | Some url ->
+      [%log' info config.logger] "Starting uptime service using URL $url"
+        ~metadata:[("url", `String (Uri.to_string url))] ;
+      let slot_duration_ms =
+        Consensus.Configuration.t
+          ~constraint_constants:Genesis_constants.Constraint_constants.compiled
+          ~protocol_constants:Genesis_constants.compiled.protocol
+        |> Consensus.Configuration.slot_duration |> Float.of_int
+      in
+      let five_slots_span = Time.Span.of_ms (slot_duration_ms *. 5.0) in
+      (* every 5 slots, check whether block will be produced *)
+      Async.Clock.every' ~continue_on_error:true five_slots_span (fun () ->
+          [%log' trace config.logger]
+            "Uptime service determining which action to take" ;
+          let now = Time.now () in
+          let five_slots_from_now = Time.add now five_slots_span in
+          let get_next_producer_time_opt () =
+            match Mina_lib.next_producer_timing mina with
+            | None ->
+                [%log' trace config.logger]
+                  "Next producer timing not set for uptime service" ;
+                return None
+            | Some timing -> (
+                let open Daemon_rpcs.Types.Status.Next_producer_timing in
+                match timing.timing with
+                | Check_again _tm ->
+                    [%log' trace config.logger]
+                      "Next producer timing not available for uptime service" ;
+                    return None
+                | Produce prod_tm | Produce_now prod_tm ->
+                    return (Some (Block_time.to_time prod_tm.time)) )
+          in
+          match
+            ( config.gossip_net_params.addrs_and_ports.peer
+            , config.uptime_submitter_keypair )
+          with
+          | None, _ ->
+              [%log' warn config.logger]
+                "Daemon is not yet a peer in the gossip network, uptime \
+                 service not sending a produced block" ;
+              return ()
+          | Some _, None ->
+              (* should be unreachable *)
+              failwith
+                "No uptime submitter keypair, though a submitter URL was given"
+          | Some {peer_id; _}, Some submitter_keypair -> (
+              let send_just_block next_producer_time =
+                [%log' info config.logger]
+                  "Uptime service will attempt to send the next produced block" ;
+                send_produced_block_at ~logger:config.logger ~url
+                  ~transition_frontier ~peer_id ~submitter_keypair
+                  next_producer_time
+              in
+              let send_block_and_snark_work () =
+                [%log' info config.logger]
+                  "Uptime service will attempt to send a block and SNARK work" ;
+                send_block_and_transaction_snark ~logger:config.logger ~url
+                  ~transition_frontier ~peer_id ~submitter_keypair
+              in
+              match%bind get_next_producer_time_opt () with
+              | None ->
+                  send_block_and_snark_work ()
+              | Some next_producer_time ->
+                  if Time.( <= ) next_producer_time five_slots_from_now then
+                    send_just_block next_producer_time
+                  else send_block_and_snark_work () ) )

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -1,0 +1,137 @@
+(* uptime_snark_worker.ml *)
+
+open Core_kernel
+open Async
+open Mina_base
+module Prod = Snark_worker__Prod.Inputs
+
+module Worker_state = struct
+  module type S = sig
+    val perform_single :
+         Sok_message.t * Prod.single_spec
+      -> (Ledger_proof.t * Time.Span.t) Deferred.Or_error.t
+  end
+
+  (* bin_io required by rpc_parallel *)
+  type init_arg = Logger.Stable.Latest.t [@@deriving bin_io_unversioned]
+
+  type t = (module S)
+
+  let create ~logger : t Deferred.t =
+    Memory_stats.log_memory_stats logger ~process:"uptime service SNARK worker" ;
+    Deferred.return
+      (let module M = struct
+         let perform_single (message, single_spec) =
+           let%bind (worker_state : Prod.Worker_state.t) =
+             Prod.Worker_state.create
+               ~constraint_constants:
+                 Genesis_constants.Constraint_constants.compiled
+               ~proof_level:Full ()
+           in
+           Prod.perform_single worker_state ~message single_spec
+       end in
+      (module M : S))
+
+  let get = Fn.id
+end
+
+module Worker = struct
+  module T = struct
+    module F = Rpc_parallel.Function
+
+    type 'w functions =
+      { perform_single:
+          ( 'w
+          , Sok_message.t * Prod.single_spec
+          , (Ledger_proof.t * Time.Span.t) Or_error.t )
+          F.t }
+
+    module Worker_state = Worker_state
+
+    module Connection_state = struct
+      (* bin_io required by rpc_parallel *)
+      type init_arg = unit [@@deriving bin_io_unversioned]
+
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+             with type worker_state := Worker_state.t
+              and type connection_state := Connection_state.t) =
+    struct
+      let perform_single (w : Worker_state.t) msg_and_single_spec =
+        let (module M) = Worker_state.get w in
+        M.perform_single msg_and_single_spec
+
+      let functions =
+        let f (i, o, f) =
+          C.create_rpc
+            ~f:(fun ~worker_state ~conn_state:_ i -> f worker_state i)
+            ~bin_input:i ~bin_output:o ()
+        in
+        { perform_single=
+            f
+              ( [%bin_type_class:
+                  Sok_message.Stable.Latest.t * Prod.single_spec]
+              , [%bin_type_class:
+                  (Ledger_proof.Stable.Latest.t * Time.Span.t) Or_error.t]
+              , perform_single ) }
+
+      let init_worker_state logger =
+        [%log info] "Uptime SNARK worker started" ;
+        Worker_state.create ~logger
+
+      let init_connection_state ~connection:_ ~worker_state:_ () =
+        Deferred.unit
+    end
+  end
+
+  include Rpc_parallel.Make (T)
+end
+
+type t =
+  { connection: Worker.Connection.t
+  ; process: Process.t
+  ; logger: Logger.Stable.Latest.t }
+
+let create ~logger ~pids : t Deferred.t =
+  let on_failure err =
+    [%log error] "Uptime service SNARK worker process failed with error $err"
+      ~metadata:[("err", Error_json.error_to_yojson err)] ;
+    Error.raise err
+  in
+  [%log info] "Starting a new uptime service SNARK worker process" ;
+  let%map connection, process =
+    Worker.spawn_in_foreground_exn ~connection_timeout:(Time.Span.of_min 1.)
+      ~on_failure ~shutdown_on:Disconnect ~connection_state_init_arg:() logger
+  in
+  [%log info]
+    "Daemon started process of kind $process_kind with pid \
+     $uptime_snark_worker_pid"
+    ~metadata:
+      [ ("uptime_snark_worker_pid", `Int (Process.pid process |> Pid.to_int))
+      ; ( "process_kind"
+        , `String
+            Child_processes.Termination.(show_process_kind Uptime_snark_worker)
+        ) ] ;
+  Child_processes.Termination.register_process pids process
+    Child_processes.Termination.Uptime_snark_worker ;
+  don't_wait_for
+  @@ Pipe.iter
+       (Process.stdout process |> Reader.pipe)
+       ~f:(fun stdout ->
+         return
+         @@ [%log debug] "Uptime SNARK worker stdout: $stdout"
+              ~metadata:[("stdout", `String stdout)] ) ;
+  don't_wait_for
+  @@ Pipe.iter
+       (Process.stderr process |> Reader.pipe)
+       ~f:(fun stderr ->
+         return
+         @@ [%log error] "Uptime SNARK worker stderr: $stderr"
+              ~metadata:[("stderr", `String stderr)] ) ;
+  {connection; process; logger}
+
+let perform_single {connection; _} ((_message, _single_spec) as arg) =
+  Worker.Connection.run connection ~f:Worker.functions.perform_single ~arg

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -117,6 +117,12 @@ let create ~logger ~pids : t Deferred.t =
         ) ] ;
   Child_processes.Termination.register_process pids process
     Child_processes.Termination.Uptime_snark_worker ;
+  (* the wait loop in the daemon will terminate the daemon if this SNARK worker
+     process dies
+
+     when this code is migrated to `compatible`, please follow the strategy
+     used in prover.ml to call Async.exit when the prover terminates
+  *)
   don't_wait_for
   @@ Pipe.iter
        (Process.stdout process |> Reader.pipe)

--- a/src/nonconsensus/string_sign/dune
+++ b/src/nonconsensus/string_sign/dune
@@ -1,0 +1,10 @@
+(library
+ (name string_sign_nonconsensus)
+ (public_name string_sign_nonconsensus)
+ (library_flags -linkall)
+ (libraries snark_params_nonconsensus mina_base_nonconsensus random_oracle_nonconsensus
+            signature_lib_nonconsensus digestif.ocaml)
+ (preprocessor_deps ../../config.mlh)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version ppx_snarky ppx_optcomp))
+ (synopsis "Schnorr signatures for strings"))

--- a/src/nonconsensus/string_sign/string_sign.ml
+++ b/src/nonconsensus/string_sign/string_sign.ml
@@ -1,0 +1,1 @@
+../../lib/string_sign/string_sign.ml

--- a/src/string_sign.opam
+++ b/src/string_sign.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+

--- a/src/string_sign_nonconsensus.opam
+++ b/src/string_sign_nonconsensus.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+

--- a/src/uptime_service.opam
+++ b/src/uptime_service.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
Uptime service for Mina Foundation delegation program.

Every 5 slots (15 minutes), if the node will produce a block within the next 5 slots, send that block to the uptime backend. Else, send a block from the best tip and some transaction SNARK work. The code for this is in a new library `Uptime_service`.

Specifically, the SNARK work is the Base64 encoding of a `Bin_prot`-serialized instance of the type:
```ocaml
type proof_data =
        { proof: Ledger_proof.Stable.Latest.t
        ; proof_time: Core_kernel.Time.Span.t
        ; snark_work_fee: Currency.Fee.Stable.Latest.t
```
This type is not versioned, so the verifier will need to be using the exact same type.

The daemon CLI adds two new flags:
```
[--uptime-submitter PUBLICKEY]                      Public key of the
                                                      submitter to the uptime
                                                      service of the Mina
                                                      delegation program
                                                      (alias: -uptime-submitter)
[--uptime-url URL]                                  URL of the uptime service
                                                      of the Mina delegation
                                                      program
                                                      (alias: -uptime-url)
```
The uptime submitter private key uses the environment variable `UPTIME_PRIVKEY_PASSWORD`. The code in `Secrets` is refactored to allow multiple keypair kinds.

The signature included in the uptime payload is derived from the Yojson string representing the `data` field. The backend will need to be able to reproduce that string representation exactly in order to verify the signature.

Update: The first signature implementation used string signature code is in a new library `String_sign`, factored out from the client SDK; the conditionally-compiled `consensus` code is new, to satisfy a functor signature, but unused here. The signature code now signs a `Blake2` hash, so that separate library isn't needed for the uptime service. I've kept the library in case it's needed in the future.

Tested by 
- running a local node on mainnet, verifying that the payloads with SNARKs are delivered by the backend to Google Cloud.
- running a node on devnet2, a whale that produces lots of blocks, so that the block producer case is tested