### PR TITLE
WASM bindings for vectors

### DIFF
--- a/src/lib/marlin_plonk_bindings/js/bindings.js
+++ b/src/lib/marlin_plonk_bindings/js/bindings.js
@@ -415,3 +415,51 @@ var caml_pasta_fq_of_bytes = function(ocaml_bytes) {
 // Provides: caml_pasta_fq_deep_copy
 // Requires: plonk_wasm
 var caml_pasta_fq_deep_copy = plonk_wasm.caml_pasta_fq_deep_copy
+
+
+
+
+
+// Provides: caml_pasta_fp_vector_create
+var caml_pasta_fp_vector_create = function() {
+    return [];
+};
+
+// Provides: caml_pasta_fp_vector_length
+var caml_pasta_fp_vector_length = function (v) {
+    return v.length;
+};
+
+// Provides: caml_pasta_fp_vector_emplace_back
+var caml_pasta_fp_vector_emplace_back = function (v, x) {
+    v.push(x);
+}
+
+// Provides: caml_pasta_fp_vector_get
+var caml_pasta_fp_vector_get = function (v, i) {
+    return v[i];
+}
+
+
+
+
+
+// Provides: caml_pasta_fq_vector_create
+var caml_pasta_fq_vector_create = function() {
+    return [];
+};
+
+// Provides: caml_pasta_fq_vector_length
+var caml_pasta_fq_vector_length = function (v) {
+    return v.length;
+};
+
+// Provides: caml_pasta_fq_vector_emplace_back
+var caml_pasta_fq_vector_emplace_back = function (v, x) {
+    v.push(x);
+}
+
+// Provides: caml_pasta_fq_vector_get
+var caml_pasta_fq_vector_get = function (v, i) {
+    return v[i];
+}

--- a/src/lib/marlin_plonk_bindings/js/test/bindings_js_test.ml
+++ b/src/lib/marlin_plonk_bindings/js/test/bindings_js_test.ml
@@ -364,3 +364,59 @@ let _ =
          assert (equal (of_bytes (to_bytes gen)) gen) ;
          assert (equal (deep_copy rand2) rand2)
     end)
+
+let _ =
+  let open Pasta_fp_vector in
+  Js.export "pasta_fp_vector_test"
+    (object%js (_self)
+       method run =
+         let first = create () in
+         let second = create () in
+         assert (length first = 0) ;
+         assert (length second = 0) ;
+         assert (not (first == second)) ;
+         emplace_back first (Pasta_fp.of_int 0) ;
+         assert (length first = 1) ;
+         assert (length second = 0) ;
+         emplace_back second (Pasta_fp.of_int 1) ;
+         assert (length first = 1) ;
+         assert (length second = 1) ;
+         emplace_back first (Pasta_fp.of_int 10) ;
+         assert (length first = 2) ;
+         assert (length second = 1) ;
+         emplace_back first (Pasta_fp.of_int 30) ;
+         assert (length first = 3) ;
+         assert (length second = 1) ;
+         assert (Pasta_fp.equal (Pasta_fp.of_int 0) (get first 0)) ;
+         assert (Pasta_fp.equal (Pasta_fp.of_int 10) (get first 1)) ;
+         assert (Pasta_fp.equal (Pasta_fp.of_int 30) (get first 2)) ;
+         assert (Pasta_fp.equal (Pasta_fp.of_int 1) (get second 0))
+    end)
+
+let _ =
+  let open Pasta_fq_vector in
+  Js.export "pasta_fq_vector_test"
+    (object%js (_self)
+       method run =
+         let first = create () in
+         let second = create () in
+         assert (length first = 0) ;
+         assert (length second = 0) ;
+         assert (not (first == second)) ;
+         emplace_back first (Pasta_fq.of_int 0) ;
+         assert (length first = 1) ;
+         assert (length second = 0) ;
+         emplace_back second (Pasta_fq.of_int 1) ;
+         assert (length first = 1) ;
+         assert (length second = 1) ;
+         emplace_back first (Pasta_fq.of_int 10) ;
+         assert (length first = 2) ;
+         assert (length second = 1) ;
+         emplace_back first (Pasta_fq.of_int 30) ;
+         assert (length first = 3) ;
+         assert (length second = 1) ;
+         assert (Pasta_fq.equal (Pasta_fq.of_int 0) (get first 0)) ;
+         assert (Pasta_fq.equal (Pasta_fq.of_int 10) (get first 1)) ;
+         assert (Pasta_fq.equal (Pasta_fq.of_int 30) (get first 2)) ;
+         assert (Pasta_fq.equal (Pasta_fq.of_int 1) (get second 0))
+    end)


### PR DESCRIPTION
This PR implements vectors for the JS OCaml bindings.

These bindings aren't really rust vectors -- instead, we encode them entirely in javascript. This allows us to avoid calling across the FFI and to leverage the existing `Array` vector implementation in JS.

Checklist:

- [X] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [X] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [X] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: