### PR TITLE
Dump archive daily cron job

### DIFF
--- a/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
@@ -15,7 +15,18 @@ spec:
           - command:
             - /bin/bash
             - -c
-            - 'pg_dump --no-owner --create postgres://postgres:foobar@archive-3:5432/archive > mainnet_archive.sql
+            - '
+            DATE="$(date +%F_%H%M)"
+            FILENAME=archive-dump-"$DATE".sql
+
+            pg_dump --no-owner --create postgres://postgres:foobar@archive-3-postgresql:5432/archive > $FILENAME
+
+            echo "archive database dumped"
+
+            gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $FILENAME gs://mina-archive-dumps
+
+            echo "archive database uploaded to bucket"
+
             '
             env:
             - name: GCLOUD_KEYFILE

--- a/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
@@ -16,16 +16,24 @@ spec:
             - /bin/bash
             - -c
             - '
-            DATE="$(date +%F_%H%M)"
-            FILENAME=archive-dump-"$DATE".sql
+            apk add curl;
+            apk add python3;
+            curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-347.0.0-linux-x86_64.tar.gz;
+            tar -xzf google-cloud-sdk-347.0.0-linux-x86_64.tar.gz;
+            echo "installed gsutil";
 
-            pg_dump --no-owner --create postgres://postgres:foobar@archive-3-postgresql:5432/archive > $FILENAME
+            DATE="$(date +%F_%H%M)";
+            FILENAME=archive-dump-"$DATE".sql;
 
-            echo "archive database dumped"
+            pg_dump --no-owner --create postgres://postgres:foobar@archive-3-postgresql:5432/archive > $FILENAME;
 
-            gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $FILENAME gs://mina-archive-dumps
+            tar -czvf $FILENAME.tar.gz $FILENAME;
 
-            echo "archive database uploaded to bucket"
+            echo "archive database dumped";
+
+            ./google-cloud-sdk/bin/gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $FILENAME.tar.gz gs://mina-archive-dumps;
+
+            echo "archive database uploaded to bucket";
 
             '
             env:

--- a/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
@@ -1,0 +1,47 @@
+# kubectl apply -f helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
+# the above command, with this accompanying file, needs only be run once.  it does not get run in CI.  this file is provided here for future reference
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: mainnet-dump-archive-cronjob
+spec:
+  concurrencyPolicy: Replace
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - command:
+            - /bin/bash
+            - -c
+            - 'pg_dump --no-owner --create postgres://postgres:foobar@archive-3:5432/archive > mainnet_archive.sql
+            '
+            env:
+            - name: GCLOUD_KEYFILE
+              value: /gcloud/keyfile.json
+            image: postgres:11-alpine
+            imagePullPolicy: IfNotPresent
+            name: mainnet-dump-archive-cronjob
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /gcloud/
+              name: gcloud-keyfile
+          dnsPolicy: ClusterFirst
+          restartPolicy: Never
+          schedulerName: default-scheduler
+          securityContext: {}
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: gcloud-keyfile
+            secret:
+              defaultMode: 256
+              items:
+              - key: keyfile
+                path: keyfile.json
+              secretName: gcloud-keyfile
+  schedule: 0 0 * * *
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/helm/cron_jobs/mainnet-dump-staking-ledger-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-dump-staking-ledger-cronjob.yaml
@@ -1,4 +1,4 @@
-# kubectl apply -f helm/staking-ledger-cron/mainnet-dump-staking-ledger-cronjob.yaml
+# kubectl apply -f helm/cron_jobs/mainnet-dump-staking-ledger-cronjob.yaml
 # the above command, with this accompanying file, needs only be run once.  it does not get run in CI.  this file is provided here for future reference
 apiVersion: batch/v1beta1
 kind: CronJob


### PR DESCRIPTION
https://github.com/MinaProtocol/mina/issues/9138

the actual cron job task is here: https://console.cloud.google.com/kubernetes/cronjob/us-east1/coda-infra-east/mainnet/mainnet-dump-archive-cronjob/details?authuser=2&project=o1labs-192920

committing the job specs to github is mostly for future reference

Note by @psteckler: output is to `https://console.cloud.google.com/storage/browser/mina-archive-dumps`