### PR TITLE
`get_ledger` in sys thread for release

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -917,18 +917,18 @@ let export_ledger =
         (optional string))
   in
   let ledger_kind =
+    let available_ledgers =
+      [ "staged-ledger"
+      ; "snarked-ledger"
+      ; "staking-epoch-ledger"
+      ; "next-epoch-ledger" ]
+    in
     let t =
       Command.Param.Arg_type.of_alist_exn
-        (List.map
-           [ "staged-ledger"
-           ; "snarked-ledger"
-           ; "staking-epoch-ledger"
-           ; "next-epoch-ledger" ] ~f:(fun s -> (s, s)))
+        (List.map available_ledgers ~f:(fun s -> (s, s)))
     in
-    Command.Param.(
-      anon
-        ( "staged-ledger|snarked-ledger|staking-epoch-ledger|next-epoch-ledger"
-        %: t ))
+    let ledger_args = String.concat ~sep:"|" available_ledgers in
+    Command.Param.(anon (ledger_args %: t))
   in
   let plaintext_flag = Cli_lib.Flag.plaintext in
   let flags = Args.zip3 state_hash_flag plaintext_flag ledger_kind in

--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -328,7 +328,10 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
     ; implement Daemon_rpcs.Clear_hist_status.rpc (fun () flag ->
           Mina_commands.clear_hist_status ~flag coda )
     ; implement Daemon_rpcs.Get_ledger.rpc (fun () lh ->
-          Mina_lib.get_ledger coda lh |> return )
+          (* getting the ledger may take more time than a heartbeat timeout
+             run in thread to allow RPC heartbeats to proceed
+          *)
+          Async.In_thread.run (fun () -> Mina_lib.get_ledger coda lh) )
     ; implement Daemon_rpcs.Get_snarked_ledger.rpc (fun () lh ->
           Mina_lib.get_snarked_ledger coda lh |> return )
     ; implement Daemon_rpcs.Get_staking_ledger.rpc (fun () which ->


### PR DESCRIPTION
Apply the diff for #8996 to the `release/1.2.0` branch.

When running CLI command `ledger export staged-ledger`, run `Mina_lib.get_ledger` in a system thread, so RPC heartbeats can be processed. No other code is affected.

(There's also some cleanup of the flag processing for ledger export.)
