### PR TITLE
Wrap a couple of `Process.run`

### DIFF
--- a/src/lib/file_system/file_system.ml
+++ b/src/lib/file_system/file_system.ml
@@ -9,7 +9,10 @@ let dir_exists dir =
   else return false
 
 let remove_dir dir =
-  let%bind _ = Process.run_exn ~prog:"rm" ~args:["-rf"; dir] () in
+  let%bind _ =
+    Monitor.try_with ~here:[%here] (fun () ->
+        Process.run_exn ~prog:"rm" ~args:["-rf"; dir] () )
+  in
   Deferred.unit
 
 let rec rmrf path =

--- a/src/lib/key_cache/dune
+++ b/src/lib/key_cache/dune
@@ -4,4 +4,4 @@
  (libraries core async error_json logger)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_coda ppx_version ppx_base ppx_let ppx_custom_printf ppx_optcomp)))
+ (preprocess (pps ppx_coda ppx_version ppx_base ppx_here ppx_let ppx_custom_printf ppx_optcomp)))


### PR DESCRIPTION
The `1.2.0` beta still reveals `WNOHANG` crashes. 

In issue #9169, the exception is generated in `Process.collect_output_and_wait`, which is called (indirectly) by `Process.run`.

While the two calls here are unlikely candidates to have generated the exception, it's good practice to wrap them in monitors.
