### PR TITLE
Close stdin for some processes

### DIFF
--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -366,6 +366,7 @@ let create ~logger ~proof_level ~constraint_constants ~pids ~conf_dir :
               `Wait_threw_an_exception err ) ]
     in
     upon finished (fun e ->
+        don't_wait_for (Process.stdin process |> Writer.close) ;
         let pid = Process.pid process in
         let create_worker_trigger = Ivar.create () in
         don't_wait_for


### PR DESCRIPTION
Issue #9163 suggests that there's a FIFO leak in the code. When child processes terminate, the Mina executable should close `stdin`, its end of the pipe shared with those processes.

For `libp2p`, the `start_custom` code already does a close on termination. For the SNARK worker and verifier, this PR introduces explicit closes.

Tested that the code for the verifier is exercised by running a local network, killing the verifier, and printing out the closed status of all 3 file descriptors. Only the `stdin` was open. (Also verified that the closes for libp2p helper are being called. Probably the one for stdout isn't needed.)

(In fact, in one case, all 3 descriptors remained open, but I'm supposing that's a race where the stdout and stderr had not yet been automatically closed.)
