### PR TITLE
Close stdin for verifier, snark worker (in compatible)

### DIFF
--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -370,6 +370,7 @@ let create ~logger ~proof_level ~constraint_constants ~pids ~conf_dir :
         ]
     in
     upon finished (fun e ->
+        don't_wait_for (Process.stdin process |> Writer.close) ;
         let pid = Process.pid process in
         let create_worker_trigger = Ivar.create () in
         don't_wait_for


### PR DESCRIPTION
Close stdin when verifier or SNARK worker terminate.

Same as #9178, except against `compatible`, and the calls for the `Ok` cases for the SNARK worker are factored out into one call.