### PR TITLE
Remove daemon wait loop

### DIFF
--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -18,7 +18,10 @@ type t =
       [ `Always_raise
       | `Raise_on_failure
       | `Handler of
-        killed:bool -> Unix.Exit_or_signal.t Or_error.t -> unit Deferred.t
+           killed:bool
+        -> Process.t
+        -> Unix.Exit_or_signal.t Or_error.t
+        -> unit Deferred.t
       | `Ignore ]
   }
 
@@ -241,7 +244,10 @@ let start_custom :
          [ `Always_raise
          | `Raise_on_failure
          | `Handler of
-           killed:bool -> Unix.Exit_or_signal.t Or_error.t -> unit Deferred.t
+              killed:bool
+           -> Process.t
+           -> Unix.Exit_or_signal.t Or_error.t
+           -> unit Deferred.t
          | `Ignore ]
     -> t Deferred.Or_error.t =
  fun ~logger ~name ~git_root_relative_path ~conf_dir ~args ~stdout ~stderr
@@ -355,7 +361,7 @@ let start_custom :
     | `Raise_on_failure, Ok (Ok ()) ->
         Deferred.unit
     | `Handler f, _ ->
-        f ~killed:t.killing termination_status) ;
+        f ~killed:t.killing process termination_status) ;
   Deferred.Or_error.return t
 
 let kill : t -> Unix.Exit_or_signal.t Deferred.Or_error.t =
@@ -384,10 +390,8 @@ let kill : t -> Unix.Exit_or_signal.t Deferred.Or_error.t =
   | Some _ ->
       Deferred.Or_error.error_string "already terminated"
 
-let register_process ?termination_expected (termination : Termination.t)
-    (process : t) kind =
-  Termination.register_process ?termination_expected termination process.process
-    kind
+let register_process (termination : Termination.t) (process : t) kind =
+  Termination.register_process termination process.process kind
 
 let%test_module _ =
   ( module struct

--- a/src/lib/child_processes/child_processes.mli
+++ b/src/lib/child_processes/child_processes.mli
@@ -54,7 +54,10 @@ val start_custom :
        [ `Always_raise
        | `Raise_on_failure
        | `Handler of
-         killed:bool -> Unix.Exit_or_signal.t Or_error.t -> unit Deferred.t
+            killed:bool
+         -> Process.t
+         -> Unix.Exit_or_signal.t Or_error.t
+         -> unit Deferred.t
        | `Ignore ]
        (** What to do when the process exits. Note that an exception will not be
          raised after you run [kill] on it, regardless of this value.
@@ -72,9 +75,4 @@ val kill : t -> Unix.Exit_or_signal.t Deferred.Or_error.t
 
 module Termination : module type of Termination
 
-val register_process :
-     ?termination_expected:bool
-  -> Termination.t
-  -> t
-  -> Termination.process_kind
-  -> unit
+val register_process : Termination.t -> t -> Termination.process_kind -> unit

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -336,8 +336,6 @@ let create ~logger ~proof_level ~constraint_constants ~pids ~conf_dir :
     (* Always report termination as expected, and use the restart logic here
        instead.
     *)
-    let pid = Process.pid process in
-    Child_processes.Termination.mark_termination_as_expected pids pid ;
     don't_wait_for
     @@ Pipe.iter
          (Process.stdout process |> Reader.pipe)
@@ -372,6 +370,7 @@ let create ~logger ~proof_level ~constraint_constants ~pids ~conf_dir :
     upon finished (fun e ->
         don't_wait_for (Process.stdin process |> Writer.close) ;
         let pid = Process.pid process in
+        Child_processes.Termination.remove pids pid ;
         let create_worker_trigger = Ivar.create () in
         don't_wait_for
           (* If we don't hear back that the process has died after 10 seconds,


### PR DESCRIPTION
My understanding of the world: After a process is created, there should be exactly one `wait` on that process:
- if there's no `wait`, after the parent terminates, the child will be a "zombie" process
- the child's exit-or-signal status is reported to the parent upon the first `wait`; any `wait` after the first one will raise `WNOHANG`

The `wait` loop in the daemon violates this principle, because it waits on all child processes. So if it finds a terminated child, any other `wait` on that child will raise a `WNHOHANG`. I added this loop in early days to detect crashed children, but the `wait`s that exist specifically for those children should serve that purpose.

After the removal of this loop, I'm supposing that the monitors around `Process.run` may be unnecessary.

The pid table used by this loop is used outside the removed loop. It's used to kill children upon crashes. So the table remains here. For libp2p and the verifier, there is code to detect when those processes terminate; we remove the pid from the table in those cases.

For the prover, we call `wait_safe`, and bind on the result of that. If the prover terminates, we crash the daemon, as before.


