### PR TITLE
Protect against detached ledger crashes in snark pool

### DIFF
--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -269,14 +269,15 @@ struct
         Currency.Fee.(fee >= t.account_creation_fee)
         ||
         match best_tip_ledger with
-        | None ->
-            false
-        | Some l ->
+        | Some l
+          when Option.is_none (Deferred.peek (Base_ledger.detached_signal l)) ->
             Option.(
               is_some
                 ( Base_ledger.location_of_account l
                     (Account_id.create prover Token_id.default)
                 >>= Base_ledger.get l ))
+        | None | Some _ ->
+            false
 
       let handle_transition_frontier_diff u t =
         match u with


### PR DESCRIPTION
This PR tweaks the behaviour of the snark pool so that looking up the worker in a detached ledger causes the snark work to be rejected instead of crashing the daemon.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #9152
