### PR TITLE
Register snark worker process

### DIFF
--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -6,7 +6,7 @@ open Async
 open Core_kernel
 include Hashable.Make_binable (Pid)
 
-type process_kind = Prover | Verifier | Libp2p_helper
+type process_kind = Prover | Verifier | Libp2p_helper | Snark_worker
 [@@deriving show { with_path = false }, yojson]
 
 type t = process_kind Pid.Table.t

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -202,6 +202,8 @@ module Snark_worker = struct
                  (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
                ~shutdown_on_disconnect:false )
     in
+    Child_processes.Termination.register_process pids snark_worker_process
+      Snark_worker ;
     Child_processes.Termination.wait_for_process_log_errors ~logger
       snark_worker_process ~module_:__MODULE__ ~location:__LOC__ ~here:[%here] ;
     let close_stdin () =


### PR DESCRIPTION
The SNARK worker process was not being registered as a child process, as is done for the verifier, prover, and libp2p helper.

There was code to remove its pid from the child process table, which was never added, in fact. :-)
