### PR TITLE
Support changing block producer keys

### DIFF
--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/devnet.mlh
+++ b/src/config/devnet.mlh
@@ -43,3 +43,4 @@
 [%%import "/src/config/features/public_testnet.mlh"]
 (* 2*block_window_duration *)
 [%%define compaction_interval 360000]
+[%%define vrf_poll_interval 5000]

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/fuzz_medium.mlh
+++ b/src/config/fuzz_medium.mlh
@@ -31,3 +31,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/fuzz_small.mlh
+++ b/src/config/fuzz_small.mlh
@@ -31,3 +31,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/mainnet.mlh
+++ b/src/config/mainnet.mlh
@@ -43,3 +43,4 @@
 [%%import "/src/config/features/mainnet.mlh"]
 (* 2*block_window_duration *)
 [%%define compaction_interval 360000]
+[%%define vrf_poll_interval 5000]

--- a/src/config/nonconsensus_medium_curves.mlh
+++ b/src/config/nonconsensus_medium_curves.mlh
@@ -31,3 +31,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 5000]

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 5000]

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%define compaction_interval 360000]
+[%%define vrf_poll_interval 0]

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -32,3 +32,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/test_postake_three_producers.mlh
+++ b/src/config/test_postake_three_producers.mlh
@@ -33,3 +33,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -33,3 +33,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 5000]

--- a/src/config/testnet_postake_many_producers.mlh
+++ b/src/config/testnet_postake_many_producers.mlh
@@ -31,3 +31,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 5000]

--- a/src/config/testnet_postake_many_producers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_producers_medium_curves.mlh
@@ -33,3 +33,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 5000]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -43,3 +43,4 @@
 [%%import "/src/config/features/public_testnet.mlh"]
 (* 2*block_window_duration *)
 [%%define compaction_interval 360000]
+[%%define vrf_poll_interval 5000]

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -33,3 +33,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -34,3 +34,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 0]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -33,3 +33,4 @@
 [%%import "/src/config/fork.mlh"]
 [%%import "/src/config/features/dev.mlh"]
 [%%undef compaction_interval]
+[%%define vrf_poll_interval 5000]

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -499,7 +499,7 @@ module Vrf_evaluation_state = struct
     Queue.enqueue_all t.queue vrf_result.slots_won ;
     update_status t vrf_result.evaluator_status ;
     [%log info]
-      !"Global slots won: $slots"
+      !"New global slots won: $slots"
       ~metadata:
         [ ( "slots"
           , `List
@@ -1004,9 +1004,10 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                              curr_global_slot
                          with
                          | None ->
-                             [%log debug]
-                               "Skipping global slot $slot_won because it has \
-                                passed. Current global slot is $curr_slot"
+                             [%log warn]
+                               "Skipping block production for global slot \
+                                $slot_won because it has passed. Current \
+                                global slot is $curr_slot"
                                ~metadata:
                                  [ ( "slot_won"
                                    , Mina_numbers.Global_slot.to_yojson

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -509,8 +509,12 @@ module Vrf_evaluation_state = struct
     let%map vrf_result =
       match (vrf_result.evaluator_status, vrf_result.slots_won) with
       | At _, [] ->
-          (*try again after 5 seconds*)
-          let%bind () = Async.after (Core.Time.Span.of_ms 5000.) in
+          (*try again*)
+          let%bind () =
+            Async.after
+              (Core.Time.Span.of_ms
+                 (Mina_compile_config.vrf_poll_interval_ms |> Int.to_float))
+          in
           poll_vrf_evaluator vrf_evaluator ~logger ~time_controller
       | _ ->
           return vrf_result
@@ -1013,7 +1017,10 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                            (Vrf_evaluation_state.finished vrf_evaluation_state)
                        then
                          let%bind () =
-                           Async.after (Core.Time.Span.of_ms 5000.)
+                           Async.after
+                             (Core.Time.Span.of_ms
+                                ( Mina_compile_config.vrf_poll_interval_ms
+                                |> Int.to_float ))
                          in
                          let%map () =
                            Vrf_evaluation_state.poll ~vrf_evaluator ~logger

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -462,17 +462,34 @@ module Vrf_evaluation_state = struct
 
   type t =
     { queue: Consensus.Data.Slot_won.t Queue.t
-    ; mutable vrf_evaluator_status: status }
+    ; mutable vrf_evaluator_status: status
+    ; mutable last_scheduled: Mina_numbers.Global_slot.t option
+    ; mutable current_slot: Mina_numbers.Global_slot.t
+    ; mutable current_epoch: Mina_numbers.Length.t }
 
-  let poll_vrf_evaluator ~logger vrf_evaluator =
+  let poll_vrf_evaluator ~logger ~time_controller vrf_evaluator =
     let f () =
       measure "asking vrf evaluator for any slots won" (fun () ->
-          Vrf_evaluator.slots_won_so_far vrf_evaluator )
+          Vrf_evaluator.slots_won_so_far vrf_evaluator
+            ~now:(Block_time.now time_controller) )
     in
     retry ~logger ~error_message:"Error fetching slots from the VRF evaluator"
       f
 
-  let create () = {queue= Core.Queue.create (); vrf_evaluator_status= Start}
+  let create () =
+    { queue= Core.Queue.create ()
+    ; vrf_evaluator_status= Start
+    ; last_scheduled= None
+    ; current_slot= Mina_numbers.Global_slot.zero
+    ; current_epoch= Mina_numbers.Length.zero }
+
+  let next_slot t =
+    match Queue.dequeue t.queue with
+    | None ->
+        None
+    | Some s ->
+        t.last_scheduled <- Some s.global_slot ;
+        Some s
 
   let finished t =
     match t.vrf_evaluator_status with Completed -> true | _ -> false
@@ -484,29 +501,77 @@ module Vrf_evaluation_state = struct
     | Completed ->
         t.vrf_evaluator_status <- Completed
 
-  let poll ~vrf_evaluator ~logger t =
+  let poll ~vrf_evaluator ~logger ~time_controller t =
     [%log info] "Polling VRF evaluator process" ;
-    let%bind vrf_result = poll_vrf_evaluator vrf_evaluator ~logger in
+    let%bind vrf_result =
+      poll_vrf_evaluator vrf_evaluator ~logger ~time_controller
+    in
     let%map vrf_result =
       match (vrf_result.evaluator_status, vrf_result.slots_won) with
       | At _, [] ->
           (*try again after 5 seconds*)
           let%bind () = Async.after (Core.Time.Span.of_ms 5000.) in
-          poll_vrf_evaluator vrf_evaluator ~logger
+          poll_vrf_evaluator vrf_evaluator ~logger ~time_controller
       | _ ->
           return vrf_result
     in
-    Queue.enqueue_all t.queue vrf_result.slots_won ;
+    [%log info]
+      !"All lobal slots won: $slots"
+      ~metadata:
+        [ ( "slots"
+          , `List
+              (List.map vrf_result.slots_won ~f:(fun s ->
+                   Mina_numbers.Global_slot.to_yojson s.global_slot )) ) ] ;
+    [%log info]
+      !"Current global slots won: $slots"
+      ~metadata:
+        [ ( "slots"
+          , `List
+              (List.map (Queue.to_list t.queue) ~f:(fun s ->
+                   Mina_numbers.Global_slot.to_yojson s.global_slot )) ) ] ;
+    let new_slots_won =
+      match (t.last_scheduled, Queue.last t.queue) with
+      | _, Some {global_slot; _} | Some global_slot, None ->
+          List.filter vrf_result.slots_won ~f:(fun s ->
+              Mina_numbers.Global_slot.(s.global_slot > global_slot) )
+      | None, None ->
+          vrf_result.slots_won
+    in
+    Queue.enqueue_all t.queue new_slots_won ;
     update_status t vrf_result.evaluator_status ;
     [%log info]
       !"New global slots won: $slots"
       ~metadata:
         [ ( "slots"
           , `List
-              (List.map vrf_result.slots_won ~f:(fun s ->
+              (List.map new_slots_won ~f:(fun s ->
                    Mina_numbers.Global_slot.to_yojson s.global_slot )) ) ]
 
-  let update_epoch_data ~vrf_evaluator ~logger ~epoch_data_for_vrf t =
+  let clear t =
+    t.vrf_evaluator_status <- Start ;
+    t.last_scheduled <- None ;
+    Queue.clear t.queue
+
+  let update_block_producer_keys
+      ~(epoch_data_for_vrf : Consensus.Data.Epoch_data_for_vrf.t) ~logger
+      ~vrf_evaluator ~time_controller ~keypairs t =
+    [%log info] "Updating block producer keys in VRF evaluator" ;
+    let now = Block_time.now time_controller in
+    let update_keys () =
+      let f () =
+        measure "Updating block producer keys in VRF evaluator" (fun () ->
+            Vrf_evaluator.update_block_producer_keys vrf_evaluator ~keypairs
+              ~delegatee_table:epoch_data_for_vrf.delegatee_table ~now )
+      in
+      retry ~logger
+        ~error_message:"Error updating block producer keys in VRF evaluator" f
+    in
+    clear t ;
+    let%bind () = update_keys () in
+    poll ~vrf_evaluator ~logger ~time_controller t
+
+  let update_epoch_data ~vrf_evaluator ~logger ~epoch_data_for_vrf
+      ~time_controller t =
     let set_epoch_data () =
       let f () =
         measure "Setting epoch data of the VRF evaluator" (fun () ->
@@ -519,9 +584,9 @@ module Vrf_evaluation_state = struct
     [%log info] "Sending data for VRF evaluations for epoch $epoch"
       ~metadata:
         [("epoch", Mina_numbers.Length.to_yojson epoch_data_for_vrf.epoch)] ;
-    t.vrf_evaluator_status <- Start ;
+    clear t ;
     let%bind () = set_epoch_data () in
-    poll ~logger ~vrf_evaluator t
+    poll ~logger ~vrf_evaluator ~time_controller t
 end
 
 let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
@@ -837,10 +902,11 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
       let production_supervisor = Singleton_supervisor.create ~task:produce in
       let scheduler = Singleton_scheduler.create time_controller in
       let vrf_evaluation_state = Vrf_evaluation_state.create () in
-      let rec check_next_block_timing slot epoch () =
+      let update_keys = ref false in
+      let rec check_next_block_timing () =
         trace_recurring "check next block timing" (fun () ->
             (* See if we want to change keypairs *)
-            let _keypairs =
+            let keypairs =
               match Agent.get keypairs with
               | keypairs, `Different ->
                   (* Perform block production key swap since we have new
@@ -850,6 +916,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                     ( Keypair.And_compressed_pk.Set.to_list keypairs
                     |> List.map ~f:snd |> Public_key.Compressed.Set.of_list )
                     (Time.now time_controller) ;
+                  update_keys := true ;
                   (*TODO: propagate updated delegatee table to the VRF evaluator*)
                   keypairs
               | keypairs, `Same ->
@@ -864,7 +931,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                      Broadcast_pipe.Reader.iter_until frontier_reader
                        ~f:(Fn.compose Deferred.return Option.is_some)
                    in
-                   check_next_block_timing slot epoch ())
+                   check_next_block_timing ())
             | Some transition_frontier ->
                 let consensus_state =
                   Transition_frontier.best_tip transition_frontier
@@ -906,23 +973,40 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                    = None ) ; *)
                 don't_wait_for
                   (let%bind () =
-                     if Mina_numbers.Length.(new_epoch > epoch) then
+                     if !update_keys then (
+                       update_keys := false ;
+                       Vrf_evaluation_state.update_block_producer_keys
+                         ~vrf_evaluator ~keypairs ~epoch_data_for_vrf ~logger
+                         ~time_controller vrf_evaluation_state )
+                     else Deferred.unit
+                   in
+                   let%bind () =
+                     if
+                       Mina_numbers.Length.(
+                         new_epoch > vrf_evaluation_state.current_epoch)
+                     then
                        Vrf_evaluation_state.update_epoch_data ~vrf_evaluator
-                         ~epoch_data_for_vrf ~logger vrf_evaluation_state
+                         ~epoch_data_for_vrf ~logger ~time_controller
+                         vrf_evaluation_state
                      else Deferred.unit
                    in
                    let%bind () =
                      (*Poll once every slot if the evaluation for the epoch is not completed or the evaluation is completed*)
                      if
-                       Mina_numbers.Global_slot.(new_global_slot > slot)
+                       Mina_numbers.Global_slot.(
+                         new_global_slot > vrf_evaluation_state.current_slot)
                        && not
                             (Vrf_evaluation_state.finished vrf_evaluation_state)
                      then
                        Vrf_evaluation_state.poll ~vrf_evaluator ~logger
-                         vrf_evaluation_state
+                         ~time_controller vrf_evaluation_state
                      else Deferred.unit
                    in
-                   match Core.Queue.dequeue vrf_evaluation_state.queue with
+                   vrf_evaluation_state.current_slot <- new_global_slot ;
+                   vrf_evaluation_state.current_epoch <- new_epoch ;
+                   match
+                     Vrf_evaluation_state.next_slot vrf_evaluation_state
+                   with
                    | None ->
                        (*Keep trying until we get some slots*)
                        if
@@ -934,26 +1018,23 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                          in
                          let%map () =
                            Vrf_evaluation_state.poll ~vrf_evaluator ~logger
-                             vrf_evaluation_state
+                             ~time_controller vrf_evaluation_state
                          in
                          Singleton_scheduler.schedule scheduler
                            (Time.now time_controller)
-                           ~f:
-                             (check_next_block_timing new_global_slot new_epoch)
+                           ~f:check_next_block_timing
                        else
                          let epoch_end_time =
                            Consensus.Hooks.epoch_end_time
-                             ~constants:consensus_constants epoch
+                             ~constants:consensus_constants
+                             epoch_data_for_vrf.epoch
                          in
                          set_next_producer_timing (`Check_again epoch_end_time)
                            consensus_state ;
                          [%log info] "No more slots won in this epoch" ;
                          return
                            (Singleton_scheduler.schedule scheduler
-                              epoch_end_time
-                              ~f:
-                                (check_next_block_timing new_global_slot
-                                   new_epoch))
+                              epoch_end_time ~f:check_next_block_timing)
                    | Some slot_won -> (
                        let winning_global_slot = slot_won.global_slot in
                        let slot, epoch =
@@ -995,8 +1076,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                          Interruptible.finally
                            (Singleton_supervisor.dispatch production_supervisor
                               (now, data, winner_pk))
-                           ~f:
-                             (check_next_block_timing new_global_slot new_epoch)
+                           ~f:check_next_block_timing
                          |> ignore )
                        else
                          match
@@ -1015,9 +1095,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                                  ; ( "curr_slot"
                                    , Mina_numbers.Global_slot.to_yojson
                                        curr_global_slot ) ] ;
-                             return
-                               (check_next_block_timing new_global_slot
-                                  new_epoch ())
+                             return (check_next_block_timing ())
                          | Some slot_diff ->
                              [%log info] "Producing a block in $slots slots"
                                ~metadata:
@@ -1069,9 +1147,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                                       (Singleton_supervisor.dispatch
                                          production_supervisor
                                          (scheduled_time, data, winner_pk))
-                                      ~f:
-                                        (check_next_block_timing
-                                           new_global_slot new_epoch)) ) ;
+                                      ~f:check_next_block_timing) ) ;
                              Deferred.return () )) )
       in
       let start () =
@@ -1085,11 +1161,8 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
          * *)
         Agent.on_update keypairs ~f:(fun _new_keypairs ->
             Singleton_scheduler.schedule scheduler (Time.now time_controller)
-              ~f:
-                (check_next_block_timing Mina_numbers.Global_slot.zero
-                   Mina_numbers.Length.zero) ) ;
-        check_next_block_timing Mina_numbers.Global_slot.zero
-          Mina_numbers.Length.zero ()
+              ~f:check_next_block_timing ) ;
+        check_next_block_timing ()
       in
       let genesis_state_timestamp =
         consensus_constants.genesis_state_timestamp

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -917,7 +917,6 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                     |> List.map ~f:snd |> Public_key.Compressed.Set.of_list )
                     (Time.now time_controller) ;
                   update_keys := true ;
-                  (*TODO: propagate updated delegatee table to the VRF evaluator*)
                   keypairs
               | keypairs, `Same ->
                   keypairs

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -377,12 +377,13 @@ module type S = sig
                            -> Mina_base.Account.t
                               Mina_base.Account.Index.Table.t
                               option)
-        -> ( [> `Vrf_output of Consensus_vrf.Output_hash.t]
-           * [> `Delegator of
-                Signature_lib.Public_key.Compressed.t
-                * Mina_base.Account.Index.t ] )
-           option
-           Deferred.t
+        -> ( ( [> `Vrf_output of Consensus_vrf.Output_hash.t]
+             * [> `Delegator of
+                  Signature_lib.Public_key.Compressed.t
+                  * Mina_base.Account.Index.t ] )
+             option
+           , unit )
+           Interruptible.t
     end
 
     module Prover_state : sig

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -55,6 +55,9 @@ let default_snark_worker_fee =
 [%%inject
 "block_window_duration_ms", block_window_duration]
 
+[%%inject
+"vrf_poll_interval_ms", vrf_poll_interval]
+
 let rpc_handshake_timeout_sec = 60.0
 
 let rpc_heartbeat_timeout_sec = 60.0

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2987,17 +2987,8 @@ module Mutations = struct
     field "setStaking" ~doc:"Set keys you wish to stake with"
       ~args:Arg.[arg "input" ~typ:(non_null Types.Input.set_staking)]
       ~typ:(non_null Types.Payload.set_staking)
-      ~resolve:(fun {ctx= coda; _} () _pks ->
-        [%log' error (Mina_lib.top_level_logger coda)]
-          "setStaking is temorarily disabled in this build. Please restart \
-           the daemon with the new block producer key" ;
+      ~resolve:(fun {ctx= coda; _} () pks ->
         let old_block_production_keys =
-          Mina_lib.block_production_pubkeys coda
-          |> Public_key.Compressed.Set.to_list
-        in
-        (old_block_production_keys, [], old_block_production_keys)
-        (*TODO: uncomment this after key swaps are fixed for the new VRF evaluator implementation *)
-        (*let old_block_production_keys =
           Mina_lib.block_production_pubkeys coda
         in
         let wallet = Mina_lib.wallets coda in
@@ -3022,8 +3013,7 @@ module Mutations = struct
              (Keypair.And_compressed_pk.Set.of_list unlocked) ;
         ( Public_key.Compressed.Set.to_list old_block_production_keys
         , locked
-        , List.map ~f:Tuple.T2.get2 unlocked )*)
-        )
+        , List.map ~f:Tuple.T2.get2 unlocked ) )
 
   let set_coinbase_receiver =
     field "setCoinbaseReceiver" ~doc:"Set the key to receive coinbases"

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1187,8 +1187,8 @@ let create ?wallets (config : Config.t) =
                     Vrf_evaluator.create ~constraint_constants
                       ~pids:config.pids ~logger:config.logger
                       ~conf_dir:config.conf_dir ~consensus_constants
-                      ~keypairs:(Agent.get block_production_keypairs |> fst) )
-                )
+                      ~keypairs:(Agent.get block_production_keypairs |> fst)
+                      ~now:(Block_time.now config.time_controller) ) )
             >>| Result.ok_exn
           in
           let snark_worker =

--- a/src/lib/vrf_evaluator/vrf_evaluator.ml
+++ b/src/lib/vrf_evaluator/vrf_evaluator.ml
@@ -10,20 +10,55 @@ module Slot = Mina_numbers.Global_slot
 (* Can extract both slot numbers and epoch number*)
 module Consensus_time = Consensus.Data.Consensus_time
 
-module Block_producer_keys = struct
+module Set_keys_input = struct
   [%%versioned
   module Stable = struct
     [@@@no_toplevel_latest_type]
 
     module V1 = struct
-      type t = (Keypair.Stable.V1.t * Public_key.Compressed.Stable.V1.t) list
+      type t =
+        { block_producer_keys:
+            (Keypair.Stable.V1.t * Public_key.Compressed.Stable.V1.t) list
+        ; time: Block_time.Stable.V1.t }
       [@@deriving sexp]
 
       let to_latest = Fn.id
     end
   end]
 
-  type t = Stable.Latest.t [@@deriving sexp]
+  type t = Stable.Latest.t =
+    { block_producer_keys: (Keypair.t * Public_key.Compressed.t) list
+    ; time: Block_time.t }
+  [@@deriving sexp]
+end
+
+module Update_keys_input = struct
+  [%%versioned
+  module Stable = struct
+    [@@@no_toplevel_latest_type]
+
+    module V1 = struct
+      type t =
+        { block_producer_keys:
+            (Keypair.Stable.V1.t * Public_key.Compressed.Stable.V1.t) list
+        ; delegatee_table:
+            Mina_base.Account.Stable.V1.t
+            Mina_base.Account.Index.Stable.V1.Table.t
+            Public_key.Compressed.Stable.V1.Table.t
+        ; time: Block_time.Stable.V1.t }
+      [@@deriving sexp]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  type t = Stable.Latest.t =
+    { block_producer_keys: (Keypair.t * Public_key.Compressed.t) list
+    ; delegatee_table:
+        Mina_base.Account.t Mina_base.Account.Index.Stable.Latest.Table.t
+        Public_key.Compressed.Stable.Latest.Table.t
+    ; time: Block_time.t }
+  [@@deriving sexp]
 end
 
 module Evaluator_status = struct
@@ -42,23 +77,107 @@ module Evaluator_status = struct
   [@@deriving sexp]
 end
 
-module Vrf_evaluation_result = struct
-  [%%versioned
-  module Stable = struct
-    [@@@no_toplevel_latest_type]
+module Vrf_evaluation = struct
+  module Input = struct
+    [%%versioned
+    module Stable = struct
+      [@@@no_toplevel_latest_type]
 
-    module V1 = struct
-      type t =
-        { slots_won: Consensus.Data.Slot_won.Stable.V1.t list
-        ; evaluator_status: Evaluator_status.Stable.V1.t }
+      module V1 = struct
+        type t = Block_time.Stable.V1.t
 
-      let to_latest = Fn.id
-    end
-  end]
+        let to_latest = Fn.id
+      end
+    end]
 
-  type t = Stable.Latest.t =
-    { slots_won: Consensus.Data.Slot_won.t list
-    ; evaluator_status: Evaluator_status.t }
+    type t = Stable.Latest.t
+  end
+
+  module Result = struct
+    [%%versioned
+    module Stable = struct
+      [@@@no_toplevel_latest_type]
+
+      module V1 = struct
+        type t =
+          { slots_won: Consensus.Data.Slot_won.Stable.V1.t list
+          ; evaluator_status: Evaluator_status.Stable.V1.t }
+
+        let to_latest = Fn.id
+      end
+    end]
+
+    type t = Stable.Latest.t =
+      { slots_won: Consensus.Data.Slot_won.t list
+      ; evaluator_status: Evaluator_status.t }
+  end
+end
+
+module Slots_won = struct
+  open Doubly_linked
+
+  type t = Consensus.Data.Slot_won.t Doubly_linked.t [@@deriving sexp]
+
+  module Slot_won = struct
+    type t = Consensus.Data.Slot_won.t Elt.t
+
+    let is_for_slot (t : t) ~slot =
+      Global_slot.(slot = (Elt.value t).global_slot)
+
+    let global_slot (t : t) = (Elt.value t).global_slot
+
+    let block_producer (t : t) = (Elt.value t).producer
+
+    let value = Elt.value
+  end
+
+  let check t =
+    match first t with
+    | None ->
+        ()
+    | Some first ->
+        fold t ~init:first
+          ~f:(fun (prev : Consensus.Data.Slot_won.t)
+             (curr : Consensus.Data.Slot_won.t)
+             ->
+            if Global_slot.(curr.global_slot = first.global_slot) then curr
+            else if Global_slot.(prev.global_slot < curr.global_slot) then curr
+            else failwith "Slots won in an incorrect order" )
+        |> ignore
+
+  (*First list contains wins for slots < [at] and seconds list for slots >= [at]*)
+  let split ~at t =
+    let rec go before = function
+      | [] ->
+          (List.rev before, [])
+      | (x : Consensus.Data.Slot_won.t) :: xs
+        when Global_slot.(x.global_slot >= at) ->
+          (List.rev before, x :: xs)
+      | x :: xs ->
+          go (x :: before) xs
+    in
+    go [] (to_list t)
+
+  let all ~from t = snd (split ~at:from t)
+
+  let delete_all_before ~slot t =
+    filter_inplace t ~f:(fun (s : Consensus.Data.Slot_won.t) ->
+        Global_slot.(s.global_slot >= slot) )
+
+  [%%define_locally
+  Doubly_linked.
+    ( first_elt
+    , insert_after
+    , insert_before
+    , insert_first
+    , insert_last
+    , remove
+    , remove_first
+    , remove_last
+    , next
+    , prev
+    , clear
+    , create )]
 end
 
 module Worker_state = struct
@@ -70,28 +189,46 @@ module Worker_state = struct
     ; logger: Logger.Stable.Latest.t }
   [@@deriving bin_io_unversioned]
 
+  (*type delegate_progress = {last_checked = Epoch.t * Slot.t
+    ; slots_won: }*)
+
   type t =
     { config: init_arg
-    ; mutable last_checked_slot_and_epoch:
-        (Epoch.t * Slot.t) Public_key.Compressed.Table.t
     ; slots_won: Consensus.Data.Slot_won.t Queue.t
-          (*possibly multiple producers per slot*)
+    ; slots_won_staged: Slots_won.t
+          (*To keep track of slots won from previous keys that may still be applicable, acts a working area so that stale slots are not sent to the parent process*)
     ; mutable current_slot: Global_slot.t option
     ; mutable epoch_data:
         unit Ivar.t * Consensus.Data.Epoch_data_for_vrf.t option
-    ; mutable block_producer_keys: Block_producer_keys.t }
+    ; mutable block_producer_keys: (Keypair.t * Public_key.Compressed.t) list
+    ; last_checked_slot_and_epoch:
+        (Epoch.t * Slot.t) Public_key.Compressed.Table.t }
 
-  let make_last_checked_slot_and_epoch_table old_table new_keys ~default =
-    let module Set = Public_key.Compressed.Set in
+  let update_last_checked_slot_and_epoch_table t new_keys ~now =
+    (* TODO: Be smarter so that we don't have to look at the slot before again *)
+    let global_slot =
+      Consensus.Data.Consensus_time.(
+        of_time_exn now ~constants:t.config.consensus_constants)
+    in
+    let epoch, slot =
+      Consensus.Data.Consensus_time.(epoch global_slot, slot global_slot)
+    in
     let module Table = Public_key.Compressed.Table in
-    let last_checked_slot_and_epoch = Table.create () in
     List.iter new_keys ~f:(fun (_, pk) ->
-        let data = Option.value (Table.find old_table pk) ~default in
-        Table.add_exn last_checked_slot_and_epoch ~key:pk ~data ) ;
-    last_checked_slot_and_epoch
+        Table.change t.last_checked_slot_and_epoch pk ~f:(fun _ ->
+            Some (epoch, slot) ) ) ;
+    [%log' info t.config.logger]
+      !"last checked epoch slots %{sexp: (Epoch.t * Slot.t) \
+        Public_key.Compressed.Table.t}%!"
+      t.last_checked_slot_and_epoch
 
-  let seen_slot last_checked_slot_and_epoch epoch slot =
+  let seen_slot last_checked_slot_and_epoch epoch slot ~logger =
     let module Table = Public_key.Compressed.Table in
+    [%log info] "checking seen keys" ;
+    [%log info]
+      !"last checked epoch slots %{sexp: (Epoch.t * Slot.t) \
+        Public_key.Compressed.Table.t}%!"
+      last_checked_slot_and_epoch ;
     let unseens =
       Table.to_alist last_checked_slot_and_epoch
       |> List.filter_map ~f:(fun (pk, last_checked_epoch_and_slot) ->
@@ -99,10 +236,11 @@ module Worker_state = struct
                Tuple2.compare ~cmp1:Epoch.compare ~cmp2:Slot.compare
                  last_checked_epoch_and_slot (epoch, slot)
              in
+             [%log info]
+               !"last checked epoch slot %{sexp: Epoch.t * Slot.t}, current \
+                 epoch slot %{sexp: Epoch.t*Slot.t},i: %d"
+               last_checked_epoch_and_slot (epoch, slot) i ;
              if i > 0 then None
-             else if i = 0 then
-               (*vrf evaluation was stopped at this point because it was either the end of the epoch or the key won this slot; re-check this slot when staking keys are reset so that we don't skip producing block. This will not occur in the normal flow because [slot] will be greater than the last-checked-slot*)
-               Some pk
              else (
                Table.set last_checked_slot_and_epoch ~key:pk ~data:(epoch, slot) ;
                Some pk ) )
@@ -113,12 +251,27 @@ module Worker_state = struct
     | nel ->
         `Unseen (Public_key.Compressed.Set.of_list nel)
 
+  let validate_start_slot (t : t) start_time =
+    match snd t.epoch_data with
+    | None ->
+        true
+    | Some e ->
+        let c1 =
+          Global_slot.(
+            Consensus_time.to_global_slot start_time >= e.global_slot)
+        in
+        let start_epoch = Consensus_time.epoch start_time in
+        let c2 = Epoch.(start_epoch = e.epoch) in
+        c1 && c2
+
   let evaluate
       ( { config
         ; slots_won
+        ; slots_won_staged
         ; block_producer_keys
+        ; last_checked_slot_and_epoch
         ; epoch_data= interrupt_ivar, epoch_data
-        ; _ } as t ) : (unit, unit) Interruptible.t =
+        ; _ } as t ) ~consensus_time_now : (unit, unit) Interruptible.t =
     match epoch_data with
     | None ->
         Interruptible.return ()
@@ -132,21 +285,30 @@ module Worker_state = struct
         let epoch = epoch_data.epoch in
         [%log info] "Starting VRF evaluation for epoch: $epoch"
           ~metadata:[("epoch", Epoch.to_yojson epoch)] ;
+        [%log info]
+          !"last checked epoch slots %{sexp: (Epoch.t * Slot.t) \
+            Public_key.Compressed.Table.t}%!"
+          last_checked_slot_and_epoch ;
         let keypairs = block_producer_keys in
         let logger = config.logger in
-        let start_global_slot = epoch_data.global_slot in
-        let start_global_slot_since_genesis =
-          epoch_data.global_slot_since_genesis
+        let start_global_slot =
+          Consensus_time.to_global_slot consensus_time_now
         in
-        let constants = config.consensus_constants in
+        (*delete *)
+        Slots_won.delete_all_before ~slot:start_global_slot slots_won_staged ;
+        let slot_offset_since_genesis =
+          match
+            Global_slot.sub epoch_data.global_slot_since_genesis
+              epoch_data.global_slot
+          with
+          | None ->
+              failwith "Global slot > Global slot since genesis "
+          | Some diff ->
+              diff
+        in
         let delegatee_table = epoch_data.delegatee_table in
-        (*slot in the epoch*)
-        let start_consensus_time =
-          Consensus.Data.Consensus_time.(
-            of_global_slot ~constants start_global_slot)
-        in
         let total_stake = epoch_data.epoch_ledger.total_currency in
-        let evaluate_vrf ~consensus_time =
+        let evaluate_vrf ~consensus_time unseen_pks =
           (* Try vrfs for all keypairs that are unseen within this slot until one wins or all lose *)
           (* TODO: Don't do this, and instead pick the one that has the highest chance of winning. See #2573 *)
           let slot = Consensus_time.slot consensus_time in
@@ -155,75 +317,146 @@ module Worker_state = struct
             | [] ->
                 Interruptible.return None
             | ((keypair : Keypair.t), public_key_compressed) :: keypairs -> (
-                let global_slot_since_genesis =
-                  let slot_diff =
-                    match Global_slot.sub global_slot start_global_slot with
-                    | None ->
-                        failwith
-                          "Checking slot-winner for a slot which is older \
-                           than the slot in the latest consensus state. \
-                           System time might be out-of-sync"
-                    | Some diff ->
-                        diff
+                if
+                  not
+                  @@ Public_key.Compressed.Set.mem unseen_pks
+                       public_key_compressed
+                then go keypairs
+                else
+                  let global_slot_since_genesis =
+                    Global_slot.add global_slot slot_offset_since_genesis
                   in
-                  Global_slot.add start_global_slot_since_genesis slot_diff
-                in
-                [%log info]
-                  "Checking VRF evaluations at epoch: $epoch, slot: $slot"
-                  ~metadata:
-                    [ ("epoch", `Int (Epoch.to_int epoch))
-                    ; ("slot", `Int (Slot.to_int slot)) ] ;
-                match%bind
-                  Consensus.Data.Vrf.check
-                    ~constraint_constants:config.constraint_constants
-                    ~global_slot ~seed:epoch_data.epoch_seed
-                    ~get_delegators:
-                      (Public_key.Compressed.Table.find delegatee_table)
-                    ~producer_private_key:keypair.private_key
-                    ~producer_public_key:public_key_compressed ~total_stake
-                    ~logger
-                with
-                | None ->
-                    go keypairs
-                | Some (`Vrf_output vrf_result, `Delegator delegator) ->
-                    [%log info] "Won slot %d in epoch %d" (Slot.to_int slot)
-                      (Epoch.to_int epoch) ;
-                    let slot_won =
-                      Consensus.Data.Slot_won.
-                        { delegator
-                        ; producer= keypair
-                        ; global_slot
-                        ; global_slot_since_genesis
-                        ; vrf_result }
-                    in
-                    Interruptible.return (Some slot_won) )
+                  [%log info]
+                    "Checking VRF evaluations at epoch: $epoch, slot: $slot"
+                    ~metadata:
+                      [ ("epoch", `Int (Epoch.to_int epoch))
+                      ; ("slot", `Int (Slot.to_int slot)) ] ;
+                  match%bind
+                    Consensus.Data.Vrf.check
+                      ~constraint_constants:config.constraint_constants
+                      ~global_slot ~seed:epoch_data.epoch_seed
+                      ~get_delegators:
+                        (Public_key.Compressed.Table.find delegatee_table)
+                      ~producer_private_key:keypair.private_key
+                      ~producer_public_key:public_key_compressed ~total_stake
+                      ~logger
+                  with
+                  | None ->
+                      go keypairs
+                  | Some (`Vrf_output vrf_result, `Delegator delegator) ->
+                      [%log info] "Won slot %d in epoch %d" (Slot.to_int slot)
+                        (Epoch.to_int epoch) ;
+                      let slot_won =
+                        Consensus.Data.Slot_won.
+                          { delegator
+                          ; producer= keypair
+                          ; global_slot
+                          ; global_slot_since_genesis
+                          ; vrf_result }
+                      in
+                      Interruptible.return (Some slot_won) )
           in
           go keypairs
         in
+        let curr_slot_won = ref (Slots_won.first_elt slots_won_staged) in
         let rec find_winning_slot (consensus_time : Consensus_time.t) =
+          Core.printf !"slots list: %{sexp: Slots_won.t}\n%!" slots_won_staged ;
           let slot = Consensus_time.slot consensus_time in
           let global_slot = Consensus_time.to_global_slot consensus_time in
           t.current_slot <- Some global_slot ;
           let epoch' = Consensus_time.epoch consensus_time in
           [%log info] "Slot in an epoch: $slot"
             ~metadata:[("slot", Slot.to_yojson slot)] ;
-          if Epoch.(epoch' > epoch) then Interruptible.return ()
-          else
+          let find f =
             let start = Time.now () in
-            match%bind evaluate_vrf ~consensus_time with
+            let%bind () =
+              match%bind
+                seen_slot last_checked_slot_and_epoch epoch' slot ~logger
+                |> Interruptible.return
+              with
+              | `All_seen ->
+                  [%log info] "Did not win a slot, took $time ms"
+                    ~metadata:
+                      [("time", `Float Time.(Span.to_ms (diff (now ()) start)))] ;
+                  Interruptible.return ()
+              | `Unseen pks -> (
+                  match%map evaluate_vrf pks ~consensus_time with
+                  | None ->
+                      [%log info] "Did not win a slot, took $time ms"
+                        ~metadata:
+                          [ ( "time"
+                            , `Float Time.(Span.to_ms (diff (now ()) start)) )
+                          ]
+                  | Some slot_won ->
+                      [%log info] "Won a slot, took $time ms"
+                        ~metadata:
+                          [ ( "time"
+                            , `Float Time.(Span.to_ms (diff (now ()) start)) )
+                          ] ;
+                      Queue.enqueue slots_won slot_won ;
+                      f slot_won |> ignore )
+            in
+            find_winning_slot (Consensus_time.succ consensus_time)
+          in
+          if Epoch.(epoch' > epoch) then (
+            (*TODO: Delete later*)
+            Slots_won.check slots_won_staged ;
+            t.current_slot <- None ;
+            Interruptible.return () )
+          else
+            match !curr_slot_won with
             | None ->
-                [%log info] "Did not win a slot, took $time ms"
-                  ~metadata:
-                    [("time", `Float Time.(Span.to_ms (diff (now ()) start)))] ;
-                find_winning_slot (Consensus_time.succ consensus_time)
-            | Some slot_won ->
-                [%log info] "Won a slot, took $time ms"
-                  ~metadata:
-                    [("time", `Float Time.(Span.to_ms (diff (now ()) start)))] ;
-                Queue.enqueue slots_won slot_won ;
-                find_winning_slot (Consensus_time.succ consensus_time)
+                [%log info] "No slots won yet%!" ;
+                find (fun a -> Slots_won.insert_last slots_won_staged a)
+            | Some computed_win ->
+                [%log info] "Some slot won" ;
+                if
+                  Global_slot.(
+                    global_slot = Slots_won.Slot_won.global_slot computed_win)
+                then (
+                  [%log info] "current slot won" ;
+                  if
+                    (*Slot already won; check if the block producer is still applicable*)
+                    List.mem (List.map keypairs ~f:fst)
+                      (Slots_won.Slot_won.block_producer computed_win)
+                      ~equal:Signature_lib.Keypair.equal
+                  then (
+                    [%log info] "slot won (VRF already computed)" ;
+                    curr_slot_won :=
+                      Slots_won.next slots_won_staged computed_win ;
+                    Queue.enqueue slots_won
+                      (Slots_won.Slot_won.value computed_win) ;
+                    find_winning_slot (Consensus_time.succ consensus_time) )
+                  else
+                    (*Not applicable. remove the winning slot and recompute*)
+                    match Slots_won.next slots_won_staged computed_win with
+                    | None ->
+                        Slots_won.remove slots_won_staged computed_win ;
+                        curr_slot_won := None ;
+                        find (fun a ->
+                            Slots_won.insert_last slots_won_staged a |> ignore
+                        )
+                    | Some next ->
+                        Slots_won.remove slots_won_staged computed_win ;
+                        curr_slot_won := Some next ;
+                        find (fun a ->
+                            Slots_won.insert_before slots_won_staged next a
+                            |> ignore ) )
+                else if
+                  Global_slot.(
+                    global_slot < Slots_won.Slot_won.global_slot computed_win)
+                then
+                  find (fun a ->
+                      Slots_won.insert_before slots_won_staged computed_win a
+                  )
+                else
+                  find (fun a ->
+                      let new_elt =
+                        Slots_won.insert_after slots_won_staged computed_win a
+                      in
+                      curr_slot_won := Some new_elt )
         in
-        find_winning_slot start_consensus_time
+        find_winning_slot consensus_time_now
 
   let create config =
     { config
@@ -233,6 +466,7 @@ module Worker_state = struct
           ~capacity:
             (Global_slot.to_int config.consensus_constants.slots_per_epoch)
           ()
+    ; slots_won_staged= Slots_won.create ()
     ; current_slot= None
     ; epoch_data= (Ivar.create (), None)
     ; block_producer_keys= [] }
@@ -256,10 +490,15 @@ module Functions = struct
             ~metadata:[("epoch", Epoch.to_yojson e.epoch)] ;
           let interrupt_ivar, _ = w.epoch_data in
           Ivar.fill_if_empty interrupt_ivar () ;
+          Slots_won.clear w.slots_won_staged ;
           Queue.clear w.slots_won ;
           w.current_slot <- None ;
           w.epoch_data <- (Ivar.create (), Some e) ;
-          Interruptible.don't_wait_for (Worker_state.evaluate w) ;
+          Interruptible.don't_wait_for
+            (Worker_state.evaluate w
+               ~consensus_time_now:
+                 (Consensus_time.of_global_slot e.global_slot
+                    ~constants:w.config.consensus_constants)) ;
           Deferred.unit
         in
         match w.epoch_data with
@@ -274,12 +513,19 @@ module Functions = struct
               Deferred.unit ) )
 
   let slots_won_so_far =
-    create Unit.bin_t Vrf_evaluation_result.Stable.Latest.bin_t (fun w () ->
+    create Vrf_evaluation.Input.Stable.Latest.bin_t
+      Vrf_evaluation.Result.Stable.Latest.bin_t (fun w _now ->
+        (*let global_slot =
+          Consensus.Data.Consensus_time.(
+            of_time_exn now ~constants:w.config.consensus_constants
+            |> to_global_slot)
+        in*)
+        (*Slots_won.delete_all_before ~slot:global_slot w.slots_won ;
+        let slots_won = Slots_won.all ~from:global_slot w.slots_won in*)
         let slots_won = Queue.to_list w.slots_won in
         [%log' info w.config.logger]
-          !"Slots won evaluator: %{sexp: Consensus.Data.Slot_won.t list}"
+          !"Slots won: %{sexp: Consensus.Data.Slot_won.t list}"
           slots_won ;
-        Queue.clear w.slots_won ;
         let evaluator_status =
           match w.current_slot with
           | Some slot ->
@@ -287,14 +533,57 @@ module Functions = struct
           | None ->
               Completed
         in
-        return Vrf_evaluation_result.{slots_won; evaluator_status} )
+        return Vrf_evaluation.Result.{slots_won; evaluator_status} )
 
   let update_block_producer_keys =
-    create Block_producer_keys.Stable.Latest.bin_t Unit.bin_t (fun w e ->
+    create Update_keys_input.Stable.Latest.bin_t Unit.bin_t
+      (fun w {block_producer_keys; delegatee_table; time} ->
         let logger = w.config.logger in
-        [%log info] "Updating block producer keys" ;
-        w.block_producer_keys <- e ;
-        (*TODO: Interrupt the evaluation here when we handle key updated*)
+        [%log info]
+          !"Updating block producer keys %{sexp: (Keypair.t * \
+            Signature_lib.Public_key.Compressed.t) list}"
+          block_producer_keys ;
+        let update_keys () =
+          w.block_producer_keys <- block_producer_keys ;
+          Worker_state.update_last_checked_slot_and_epoch_table w
+            block_producer_keys ~now:time
+        in
+        match snd w.epoch_data with
+        | None ->
+            return (update_keys ())
+        | Some e ->
+            let consensus_time_now =
+              Consensus_time.of_time_exn time
+                ~constants:w.config.consensus_constants
+            in
+            let epoch_now = Consensus_time.epoch consensus_time_now in
+            let global_slot_now =
+              Consensus_time.to_global_slot consensus_time_now
+            in
+            (*If current time is *)
+            let interrupt_vrf_evaluation = Epoch.(epoch_now = e.epoch) in
+            if interrupt_vrf_evaluation then (
+              (*Update keys after stopping the evaluation*)
+              Ivar.fill_if_empty (fst w.epoch_data) () ;
+              w.current_slot <- Some global_slot_now ;
+              Queue.clear w.slots_won ;
+              w.epoch_data <- (Ivar.create (), Some {e with delegatee_table}) ;
+              update_keys () ;
+              Interruptible.don't_wait_for
+                (Worker_state.evaluate w ~consensus_time_now) )
+            else
+              (*evaluation should have stopped by now, waiting for new epoch data*)
+              update_keys () ;
+            Deferred.unit )
+
+  let set_block_producer_keys =
+    create Set_keys_input.Stable.Latest.bin_t Unit.bin_t
+      (fun w {block_producer_keys; time} ->
+        let logger = w.config.logger in
+        [%log info] "Setting block producer keys" ;
+        w.block_producer_keys <- block_producer_keys ;
+        Worker_state.update_last_checked_slot_and_epoch_table w
+          block_producer_keys ~now:time ;
         Deferred.unit )
 end
 
@@ -307,9 +596,14 @@ module Worker = struct
           , unit )
           Rpc_parallel.Function.t
       ; slots_won_so_far:
-          ('worker, unit, Vrf_evaluation_result.t) Rpc_parallel.Function.t
+          ( 'worker
+          , Vrf_evaluation.Input.t
+          , Vrf_evaluation.Result.t )
+          Rpc_parallel.Function.t
       ; update_block_producer_keys:
-          ('worker, Block_producer_keys.t, unit) Rpc_parallel.Function.t }
+          ('worker, Update_keys_input.t, unit) Rpc_parallel.Function.t
+      ; set_block_producer_keys:
+          ('worker, Set_keys_input.t, unit) Rpc_parallel.Function.t }
 
     module Worker_state = Worker_state
 
@@ -333,7 +627,8 @@ module Worker = struct
         let open Functions in
         { set_new_epoch_state= f set_new_epoch_state
         ; slots_won_so_far= f slots_won_so_far
-        ; update_block_producer_keys= f update_block_producer_keys }
+        ; update_block_producer_keys= f update_block_producer_keys
+        ; set_block_producer_keys= f set_block_producer_keys }
 
       let init_worker_state (init_arg : Worker_state.init_arg) =
         let logger = init_arg.logger in
@@ -357,13 +652,23 @@ end
 
 type t = {connection: Worker.Connection.t; process: Process.t}
 
-let update_block_producer_keys {connection; process= _} ~keypairs =
+let set_block_producer_keys {connection; process= _} ~keypairs ~now =
+  Worker.Connection.run connection ~f:Worker.functions.set_block_producer_keys
+    ~arg:
+      { block_producer_keys= Keypair.And_compressed_pk.Set.to_list keypairs
+      ; time= now }
+
+let update_block_producer_keys {connection; process= _} ~keypairs
+    ~delegatee_table ~now =
   Worker.Connection.run connection
     ~f:Worker.functions.update_block_producer_keys
-    ~arg:(Keypair.And_compressed_pk.Set.to_list keypairs)
+    ~arg:
+      { block_producer_keys= Keypair.And_compressed_pk.Set.to_list keypairs
+      ; delegatee_table
+      ; time= now }
 
 let create ~constraint_constants ~pids ~consensus_constants ~conf_dir ~logger
-    ~keypairs =
+    ~keypairs ~now =
   let on_failure err =
     [%log error] "VRF evaluator process failed with error $err"
       ~metadata:[("err", Error_json.error_to_yojson err)] ;
@@ -398,12 +703,13 @@ let create ~constraint_constants ~pids ~consensus_constants ~conf_dir ~logger
          @@ [%log error] "Vrf_evaluator stderr: $stderr"
               ~metadata:[("stderr", `String stderr)] ) ;
   let t = {connection; process} in
-  let%map _ = update_block_producer_keys ~keypairs t in
+  let%map _ = set_block_producer_keys ~keypairs ~now t in
   t
 
 let set_new_epoch_state {connection; process= _} ~epoch_data_for_vrf =
   Worker.Connection.run connection ~f:Worker.functions.set_new_epoch_state
     ~arg:epoch_data_for_vrf
 
-let slots_won_so_far {connection; process= _} =
-  Worker.Connection.run connection ~f:Worker.functions.slots_won_so_far ~arg:()
+let slots_won_so_far {connection; process= _} ~now =
+  Worker.Connection.run connection ~f:Worker.functions.slots_won_so_far
+    ~arg:now


### PR DESCRIPTION
This is extending the change introduced in #9136 which did not allow changing block producer keys using the `set_staking` command. 
Added that functionality in this PR