### PR TITLE
Remove logic that pulls metrics from libp2p helper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,3 +29,6 @@
 	path = src/external/ppx_deriving_yojson
 	url = https://github.com/MinaProtocol/ppx_deriving_yojson.git
 	branch = master
+[submodule "src/external/pushprox"]
+	path = src/external/pushprox
+	url = https://github.com/prometheus-community/pushprox.git

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1122,12 +1122,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
       coda ;
     let%bind () =
       Option.map metrics_server_port ~f:(fun port ->
-          let forward_uri =
-            Option.map libp2p_metrics_port ~f:(fun port ->
-                Uri.with_uri ~scheme:(Some "http") ~host:(Some "127.0.0.1")
-                  ~port:(Some port) ~path:(Some "/metrics") Uri.empty)
-          in
-          Mina_metrics.server ?forward_uri ~port ~logger () >>| ignore)
+          Mina_metrics.server ~port ~logger () >>| ignore)
       |> Option.value ~default:Deferred.unit
     in
     let () = Mina_plugins.init_plugins ~logger coda plugins in

--- a/src/lib/mina_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/mina_metrics.ml
@@ -947,7 +947,7 @@ module Object_lifetime_statistics = struct
     Gauge_map.add lifetime_quartile_ms_table ~name ~help
 end
 
-let generic_server ?forward_uri ~port ~logger ~registry () =
+let generic_server ~port ~logger ~registry () =
   let open Cohttp in
   let open Cohttp_async in
   let handle_error _ exn =
@@ -959,34 +959,8 @@ let generic_server ?forward_uri ~port ~logger ~registry () =
     let uri = Request.uri req in
     match (Request.meth req, Uri.path uri) with
     | `GET, "/metrics" ->
-        let%bind other_data =
-          match forward_uri with
-          | Some uri ->
-              let%bind resp, body = Client.get uri in
-              let status = Response.status resp in
-              if Code.is_success (Code.code_of_status status) then
-                let%map body = Body.to_string body in
-                Some body
-              else (
-                [%log error] "Could not forward request to $url, got: $status"
-                  ~metadata:
-                    [ ("url", `String (Uri.to_string uri))
-                    ; ("status_code", `Int (Code.code_of_status status))
-                    ; ("status", `String (Code.string_of_status status))
-                    ] ;
-                return None )
-          | None ->
-              return None
-        in
         let data = CollectorRegistry.(collect registry) in
         let body = Fmt.to_to_string TextFormat_0_0_4.output data in
-        let body =
-          match other_data with
-          | Some other_data ->
-              body ^ "\n" ^ other_data
-          | None ->
-              body
-        in
         let headers =
           Header.init_with "Content-Type" "text/plain; version=0.0.4"
         in
@@ -998,9 +972,8 @@ let generic_server ?forward_uri ~port ~logger ~registry () =
     (Async.Tcp.Where_to_listen.of_port port)
     callback
 
-let server ?forward_uri ~port ~logger () =
-  generic_server ?forward_uri ~port ~logger ~registry:CollectorRegistry.default
-    ()
+let server ~port ~logger () =
+  generic_server ~port ~logger ~registry:CollectorRegistry.default ()
 
 module Archive = struct
   type t =
@@ -1038,12 +1011,10 @@ module Archive = struct
     let name = "missing_blocks" in
     find_or_add t ~name ~help ~subsystem
 
-  let create_archive_server ?forward_uri ~port ~logger () =
+  let create_archive_server ~port ~logger () =
     let open Async_kernel.Deferred.Let_syntax in
     let archive_registry = CollectorRegistry.create () in
-    let%map _ =
-      generic_server ?forward_uri ~port ~logger ~registry:archive_registry ()
-    in
+    let%map _ = generic_server ~port ~logger ~registry:archive_registry () in
     { registry = archive_registry
     ; gauge_metrics = Hashtbl.create (module String)
     }


### PR DESCRIPTION
Problem: Libp2p helper exposes HTTP endpoint that can be directly pulled
by the Prometheus server, which is called both by Prometheus and the
Daemon process, hence introducing unnecessary redundancy.

Solution: Do not pull metrics from libp2p helper from the Daemon.

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #8601
