### PR TITLE
lk86/fix-docker-permissions Use a smaller UserID for the mina user in docker

### DIFF
--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -45,13 +45,14 @@ RUN echo "Building image with version $deb_version from repo $deb_release $deb_c
   && apt-get install -y --allow-downgrades "mina-$network=$deb_version"
 
 
-# Move to a non-root UID in the future, for now stick to root for compatibility
+# Move to a non-root UID in the future (specifically 65534, the maximum UID for most systems)
+# for now stick to root for compatibility
 ARG UID=0
 
 # TODO: flesh out this feature + test
 # Create a mina user to execute the daemon with
 RUN mkdir /home/mina \
-  && adduser --uid 192920 --disabled-password --gecos '' mina \
+  && adduser --uid 65534 --disabled-password --gecos '' mina \
   && passwd -l mina \
   && chown -R mina:mina /home/mina
 


### PR DESCRIPTION
Use 65534 as the safe user ID for the mina home directory. As requested on discord in #qa-task-force by user `KP`.
