### PR TITLE
setStaking, log locked block production keys

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3081,15 +3081,23 @@ module Mutations = struct
               | None ->
                   `Snd pk)
         in
+        let unlocked_pks = List.map unlocked ~f:(fun (_kp, pk) -> pk) in
         [%log' info (Mina_lib.top_level_logger coda)]
           ~metadata:
             [ ( "old"
               , [%to_yojson: Public_key.Compressed.t list]
                   (Public_key.Compressed.Set.to_list old_block_production_keys)
               )
-            ; ("new", [%to_yojson: Public_key.Compressed.t list] pks)
+            ; ("new", [%to_yojson: Public_key.Compressed.t list] unlocked_pks)
             ]
-          !"Block production key replacement; old: $old, new: $new" ;
+          "Block production key replacement; old: $old, new: $new" ;
+        if not (List.is_empty locked) then
+          [%log' warn (Mina_lib.top_level_logger coda)]
+            "Some public keys are locked and unavailable as block production \
+             keys"
+            ~metadata:
+              [ ("locked_pks", [%to_yojson: Public_key.Compressed.t list] locked)
+              ] ;
         ignore
         @@ Mina_lib.replace_block_production_keypairs coda
              (Keypair.And_compressed_pk.Set.of_list unlocked) ;


### PR DESCRIPTION
For the GraphQL mutation `setStaking`, if a given key is locked, it's unavailable as a block production key. Despite that, the existing log always indicated that the passed-in keys were the new block production keys.

Instead, indicate which of the passed-in keys are the new block production keys, and issue a warning log if any of the passed-in keys is locked.
