### PR TITLE
Update bindings to work with panic-less marlin

### DIFF
--- a/src/lib/marlin_plonk_bindings/stubs/src/index_serialization.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/index_serialization.rs
@@ -234,8 +234,8 @@ where
     let srs = PlonkSRSValue::Ref(unsafe { &(*srs) });
     let vk = PlonkVerifierIndex {
         domain,
-        w: zk_w(domain),
-        zkpm: zk_polynomial(domain),
+        w: zk_w(domain).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Cannot evaluate zk_w"))?,
+        zkpm: zk_polynomial(domain).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Cannot evaluate zk_polynomial"))?,
         max_poly_size,
         max_quot_size,
         srs,
@@ -419,7 +419,7 @@ where
     let o = G::ScalarField::read(&mut r)?;
     let endo = G::ScalarField::read(&mut r)?;
 
-    let zkpm = zk_polynomial(domain.d1);
+    let zkpm = zk_polynomial(domain.d1).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Cannot evaluate zk_polynomial"))?;
     let zkpl = zkpm.evaluate_over_domain_by_ref(domain.d8);
     Ok(PlonkConstraintSystem {
         zkpm,

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_oracles.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_oracles.rs
@@ -43,9 +43,9 @@ pub fn caml_pasta_fp_plonk_oracles_create(
             .map(|x| x)
             .collect(),
         &proof.public.iter().map(|s| -*s).collect(),
-    );
+    ).unwrap();
     let (mut sponge, digest_before_evaluations, o, _, p_eval, _, _, _, combined_inner_product) =
-        proof.oracles::<DefaultFqSponge<VestaParameters, PlonkSpongeConstants>, DefaultFrSponge<Fp, PlonkSpongeConstants>>(&index, &p_comm);
+        proof.oracles::<DefaultFqSponge<VestaParameters, PlonkSpongeConstants>, DefaultFrSponge<Fp, PlonkSpongeConstants>>(&index, &p_comm).unwrap();
 
     sponge.absorb_fr(&[shift_scalar(combined_inner_product)]);
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -123,8 +123,8 @@ pub fn of_ocaml<'a>(
     let domain = Domain::<Fp>::new(1 << log_size_of_group).unwrap();
     let index = DlogVerifierIndex::<GAffine> {
         domain,
-        w: zk_w(domain),
-        zkpm: zk_polynomial(domain),
+        w: zk_w(domain).unwrap(),
+        zkpm: zk_polynomial(domain).unwrap(),
         max_poly_size: max_poly_size as usize,
         max_quot_size: max_quot_size as usize,
         srs,

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_oracles.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_oracles.rs
@@ -43,9 +43,9 @@ pub fn caml_pasta_fq_plonk_oracles_create(
             .map(|x| x)
             .collect(),
         &proof.public.iter().map(|s| -*s).collect(),
-    );
+    ).unwrap();
     let (mut sponge, digest_before_evaluations, o, _, p_eval, _, _, _, combined_inner_product) =
-        proof.oracles::<DefaultFqSponge<PallasParameters, PlonkSpongeConstants>, DefaultFrSponge<Fq, PlonkSpongeConstants>>(&index, &p_comm);
+        proof.oracles::<DefaultFqSponge<PallasParameters, PlonkSpongeConstants>, DefaultFrSponge<Fq, PlonkSpongeConstants>>(&index, &p_comm).unwrap();
 
     sponge.absorb_fr(&[shift_scalar(combined_inner_product)]);
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
@@ -123,8 +123,8 @@ pub fn of_ocaml<'a>(
     let domain = Domain::<Fq>::new(1 << log_size_of_group).unwrap();
     let index = DlogVerifierIndex::<GAffine> {
         domain,
-        w: zk_w(domain),
-        zkpm: zk_polynomial(domain),
+        w: zk_w(domain).unwrap(),
+        zkpm: zk_polynomial(domain).unwrap(),
         max_poly_size: max_poly_size as usize,
         max_quot_size: max_quot_size as usize,
         srs,


### PR DESCRIPTION
This PR updates the bindings to support the marlin PR o1-labs/proof-systems#132. That PR modifies some functions to avoid panics lower down the stack, which allows WASM to surface these errors to javascript (panics are 'aborts' in WASM, so the process just crashes otherwise).

This PR uses `unwrap()` within the bindings themselves, which will be caught by ocaml-rs and surfaced as an OCaml exception. This matches the old behaviour; this PR should be a no-op.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: