### PR TITLE
Panic-less WASM bindings

### DIFF
--- a/src/lib/marlin_plonk_bindings/js/test/basic.ml
+++ b/src/lib/marlin_plonk_bindings/js/test/basic.ml
@@ -1,0 +1,27 @@
+open Marlin_plonk_bindings
+
+module Bigint256 = struct
+  include Bigint_256
+
+  let num_limbs = num_limbs ()
+
+  let bytes_per_limb = bytes_per_limb ()
+
+  let length_in_bytes = num_limbs * bytes_per_limb
+
+  let to_hex_string t =
+    let data = to_bytes t in
+    "0x" ^ Hex.encode (Bytes.to_string data)
+
+  let of_hex_string s =
+    assert (Char.equal s.[0] '0' && Char.equal s.[1] 'x') ;
+    String.sub s 2 (String.length s - 2)
+    |> Hex.Safe.of_hex
+    |> (function Some x -> x | None -> assert false)
+    |> Bytes.of_string |> of_bytes
+
+  let of_numeral s ~base = of_numeral s (String.length s) base
+end
+
+module Fp = Pasta_fp
+module Fq = Pasta_fq

--- a/src/lib/marlin_plonk_bindings/js/test/chrome/index.html
+++ b/src/lib/marlin_plonk_bindings/js/test/chrome/index.html
@@ -33,8 +33,9 @@
       }
       function discover_tests() {
         var discovered_tests = document.getElementById("discovered_tests");
+        var child;
         while (child = discovered_tests.firstChild) {
-          discovered_tests.removeChild(firstChild);
+          discovered_tests.removeChild(child);
         };
         for (var i in window) {
           if(i.indexOf("_test") != -1 && typeof window[i] === "object" && typeof window[i].run === "function") {

--- a/src/lib/marlin_plonk_bindings/js/test/dune
+++ b/src/lib/marlin_plonk_bindings/js/test/dune
@@ -1,6 +1,6 @@
 (library
  (name bindings_js_test)
  (js_of_ocaml (flags +toplevel.js +dynlink.js))
- (libraries marlin_plonk_bindings js_of_ocaml bindings_js)
+ (libraries marlin_plonk_bindings js_of_ocaml bindings_js hex)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version js_of_ocaml-ppx)))

--- a/src/lib/marlin_plonk_bindings/js/test/pasta_precomputed.ml
+++ b/src/lib/marlin_plonk_bindings/js/test/pasta_precomputed.ml
@@ -1,0 +1,1 @@
+../../../zexe_backend/pasta/precomputed.ml

--- a/src/lib/marlin_plonk_bindings/stubs/src/index_serialization.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/index_serialization.rs
@@ -234,8 +234,8 @@ where
     let srs = PlonkSRSValue::Ref(unsafe { &(*srs) });
     let vk = PlonkVerifierIndex {
         domain,
-        w: zk_w(domain),
-        zkpm: zk_polynomial(domain),
+        w: zk_w(domain).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Cannot evaluate zk_w"))?,
+        zkpm: zk_polynomial(domain).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Cannot evaluate zk_polynomial"))?,
         max_poly_size,
         max_quot_size,
         srs,
@@ -419,7 +419,7 @@ where
     let o = G::ScalarField::read(&mut r)?;
     let endo = G::ScalarField::read(&mut r)?;
 
-    let zkpm = zk_polynomial(domain.d1);
+    let zkpm = zk_polynomial(domain.d1).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Cannot evaluate zk_polynomial"))?;
     let zkpl = zkpm.evaluate_over_domain_by_ref(domain.d8);
     Ok(PlonkConstraintSystem {
         zkpm,

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_oracles.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_oracles.rs
@@ -43,9 +43,9 @@ pub fn caml_pasta_fp_plonk_oracles_create(
             .map(|x| x)
             .collect(),
         &proof.public.iter().map(|s| -*s).collect(),
-    );
+    ).unwrap();
     let (mut sponge, digest_before_evaluations, o, _, p_eval, _, _, _, combined_inner_product) =
-        proof.oracles::<DefaultFqSponge<VestaParameters, PlonkSpongeConstants>, DefaultFrSponge<Fp, PlonkSpongeConstants>>(&index, &p_comm);
+        proof.oracles::<DefaultFqSponge<VestaParameters, PlonkSpongeConstants>, DefaultFrSponge<Fp, PlonkSpongeConstants>>(&index, &p_comm).unwrap();
 
     sponge.absorb_fr(&[shift_scalar(combined_inner_product)]);
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -123,8 +123,8 @@ pub fn of_ocaml<'a>(
     let domain = Domain::<Fp>::new(1 << log_size_of_group).unwrap();
     let index = DlogVerifierIndex::<GAffine> {
         domain,
-        w: zk_w(domain),
-        zkpm: zk_polynomial(domain),
+        w: zk_w(domain).unwrap(),
+        zkpm: zk_polynomial(domain).unwrap(),
         max_poly_size: max_poly_size as usize,
         max_quot_size: max_quot_size as usize,
         srs,

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_oracles.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_oracles.rs
@@ -43,9 +43,9 @@ pub fn caml_pasta_fq_plonk_oracles_create(
             .map(|x| x)
             .collect(),
         &proof.public.iter().map(|s| -*s).collect(),
-    );
+    ).unwrap();
     let (mut sponge, digest_before_evaluations, o, _, p_eval, _, _, _, combined_inner_product) =
-        proof.oracles::<DefaultFqSponge<PallasParameters, PlonkSpongeConstants>, DefaultFrSponge<Fq, PlonkSpongeConstants>>(&index, &p_comm);
+        proof.oracles::<DefaultFqSponge<PallasParameters, PlonkSpongeConstants>, DefaultFrSponge<Fq, PlonkSpongeConstants>>(&index, &p_comm).unwrap();
 
     sponge.absorb_fr(&[shift_scalar(combined_inner_product)]);
 

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
@@ -123,8 +123,8 @@ pub fn of_ocaml<'a>(
     let domain = Domain::<Fq>::new(1 << log_size_of_group).unwrap();
     let index = DlogVerifierIndex::<GAffine> {
         domain,
-        w: zk_w(domain),
-        zkpm: zk_polynomial(domain),
+        w: zk_w(domain).unwrap(),
+        zkpm: zk_polynomial(domain).unwrap(),
         max_poly_size: max_poly_size as usize,
         max_quot_size: max_quot_size as usize,
         srs,

--- a/src/lib/marlin_plonk_bindings/wasm/src/index_serialization.rs
+++ b/src/lib/marlin_plonk_bindings/wasm/src/index_serialization.rs
@@ -234,8 +234,8 @@ where
     let srs = PlonkSRSValue::Ref(unsafe { &(*srs) });
     let vk = PlonkVerifierIndex {
         domain,
-        w: zk_w(domain),
-        zkpm: zk_polynomial(domain),
+        w: zk_w(domain).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Cannot evaluate zk_w"))?,
+        zkpm: zk_polynomial(domain).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Cannot evaluate zk_polynomial"))?,
         max_poly_size,
         max_quot_size,
         srs,
@@ -419,7 +419,7 @@ where
     let o = G::ScalarField::read(&mut r)?;
     let endo = G::ScalarField::read(&mut r)?;
 
-    let zkpm = zk_polynomial(domain.d1);
+    let zkpm = zk_polynomial(domain.d1).ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Cannot evaluate zk_polynomial"))?;
     let zkpl = zkpm.evaluate_over_domain_by_ref(domain.d8);
     Ok(PlonkConstraintSystem {
         zkpm,

--- a/src/lib/marlin_plonk_bindings/wasm/src/lib.rs
+++ b/src/lib/marlin_plonk_bindings/wasm/src/lib.rs
@@ -17,7 +17,7 @@ extern "C" {
 }
 
 macro_rules! console_log {
-    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
+    ($($t:tt)*) => (crate::log(&format_args!($($t)*).to_string()))
 }
 
 #[wasm_bindgen]

--- a/src/lib/marlin_plonk_bindings/wasm/src/pasta_fp_plonk_oracles.rs
+++ b/src/lib/marlin_plonk_bindings/wasm/src/pasta_fp_plonk_oracles.rs
@@ -25,6 +25,8 @@ use crate::pasta_vesta_poly_comm::WasmPastaVestaPolyComm;
 use crate::pasta_fp_plonk_verifier_index::WasmPastaFpPlonkVerifierIndex;
 use crate::pasta_fp_plonk_proof::WasmPastaFpProverProof;
 
+use std::convert::TryInto;
+
 #[derive(Copy, Clone, Debug)]
 pub struct WasmPastaFpRandomOracles
 {
@@ -121,8 +123,10 @@ pub fn caml_pasta_fp_plonk_oracles_create(
     lgr_comm: WasmVector<WasmPastaVestaPolyComm>,
     index: WasmPastaFpPlonkVerifierIndex,
     proof: WasmPastaFpProverProof,
-) -> WasmPastaFpPlonkOracles {
-    let index: DlogVerifierIndex<'_, GAffine> = index.into();
+) -> Result<WasmPastaFpPlonkOracles, JsValue> {
+    let index: DlogVerifierIndex<'_, GAffine> = TryInto::try_into(index).map_err(|()| {
+      JsValue::from_str("caml_pasta_fp_plonk_oracles_create: Could not convert index")
+    })?;
     let proof: DlogProof<GAffine> = proof.into();
     let lgr_comm: Vec<PolyComm<GAffine>> = lgr_comm.into_iter().map(From::from).collect();
 
@@ -133,13 +137,13 @@ pub fn caml_pasta_fp_plonk_oracles_create(
             .map(|x| x)
             .collect(),
         &proof.public.iter().map(|s| -*s).collect(),
-    );
+    ).ok_or_else(|| JsValue::from_str("caml_pasta_fp_plonk_oracles_create: Could not compute p_comm"))?;
     let (mut sponge, digest_before_evaluations, o, _, p_eval, _, _, _, combined_inner_product) =
-        proof.oracles::<DefaultFqSponge<VestaParameters, PlonkSpongeConstants>, DefaultFrSponge<Fp, PlonkSpongeConstants>>(&index, &p_comm);
+        proof.oracles::<DefaultFqSponge<VestaParameters, PlonkSpongeConstants>, DefaultFrSponge<Fp, PlonkSpongeConstants>>(&index, &p_comm).ok_or_else(|| JsValue::from_str("caml_pasta_fp_plonk_oracles_create: Could not compute oracle values"))?;
 
     sponge.absorb_fr(&[shift_scalar(combined_inner_product)]);
 
-    WasmPastaFpPlonkOracles {
+    Ok(WasmPastaFpPlonkOracles {
         o: WasmPastaFpRandomOracles {
             beta: o.beta.into(),
             gamma: o.gamma.into(),
@@ -161,7 +165,7 @@ pub fn caml_pasta_fp_plonk_oracles_create(
             .map(|x| x.0.into())
             .collect(),
         digest_before_evaluations: digest_before_evaluations.into(),
-    }
+    })
 }
 
 #[wasm_bindgen]

--- a/src/lib/marlin_plonk_bindings/wasm/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/marlin_plonk_bindings/wasm/src/pasta_fp_plonk_proof.rs
@@ -30,6 +30,7 @@ use crate::wasm_flat_vector::WasmFlatVector;
 use crate::wasm_vector::WasmVector;
 use crate::pasta_vesta::WasmVestaGAffine;
 use crate::pasta_vesta_poly_comm::WasmPastaVestaPolyComm;
+use std::convert::TryInto;
 
 #[wasm_bindgen]
 #[derive(Clone)]
@@ -671,6 +672,8 @@ pub fn caml_pasta_fp_plonk_proof_create(
                 oracle::rndoracle::ProofError::EvaluationGroup => "caml_pasta_fp_plonk_proof_create: EvaluationGroup",
                 oracle::rndoracle::ProofError::OracleCommit => "caml_pasta_fp_plonk_proof_create: OracleCommit",
                 oracle::rndoracle::ProofError::RuntimeEnv => "caml_pasta_fp_plonk_proof_create: RuntimeEnv",
+                oracle::rndoracle::ProofError::BadMultiScalarMul => "caml_pasta_fq_plonk_proof_create: BadMultiScalarMul",
+                oracle::rndoracle::ProofError::BadSrsLength => "caml_pasta_fq_plonk_proof_create: BadSrsLength",
             };
         JsValue::from_str(str)
     })
@@ -683,6 +686,10 @@ pub fn proof_verify(
     proof: WasmPastaFpProverProof,
 ) -> bool {
     let group_map = <GAffine as CommitmentCurve>::Map::setup();
+    let index = match index.try_into() {
+        Ok(index) => index,
+        Err(_) => return false
+    };
 
     DlogProof::verify::<
         DefaultFqSponge<VestaParameters, PlonkSpongeConstants>,
@@ -690,7 +697,7 @@ pub fn proof_verify(
     >(
         &group_map,
         &[(
-            &index.into(),
+            &index,
             &lgr_comm.into_iter().map(From::from).collect(),
             &proof.into(),
         )]
@@ -729,21 +736,22 @@ pub fn caml_pasta_fp_plonk_proof_batch_verify(
     lgr_comms: WasmVecVecVestaPolyComm,
     indexes: WasmVector<WasmPastaFpPlonkVerifierIndex>,
     proofs: WasmVector<WasmPastaFpProverProof>,
-) -> bool {
-    let ts: Vec<_> = indexes
+) -> Result<bool, JsValue> {
+    let ts: Option<Vec<_>> = indexes
         .into_iter()
         .zip(lgr_comms.0.into_iter())
         .zip(proofs.into_iter())
-        .map(|((i, l), p)| (i.into(), l.into_iter().map(From::from).collect(), p.into()))
+        .map(|((i, l), p)| Some((i.try_into().ok()?, l.into_iter().map(From::from).collect(), p.into())))
         .collect();
+    let ts = ts.ok_or_else(|| JsValue::from_str("caml_pasta_fp_plonk_proof_batch_verify"))?;
     let ts: Vec<_> = ts.iter().map(|(i, l, p)| (i, l, p)).collect();
     let group_map = GroupMap::<Fq>::setup();
 
-    DlogProof::<GAffine>::verify::<
+    Ok(DlogProof::<GAffine>::verify::<
         DefaultFqSponge<VestaParameters, PlonkSpongeConstants>,
         DefaultFrSponge<Fp, PlonkSpongeConstants>,
     >(&group_map, &ts)
-    .is_ok()
+    .is_ok())
 }
 
 #[wasm_bindgen]

--- a/src/lib/marlin_plonk_bindings/wasm/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/marlin_plonk_bindings/wasm/src/pasta_fq_plonk_verifier_index.rs
@@ -20,6 +20,7 @@ use plonk_protocol_dlog::index::{VerifierIndex as DlogVerifierIndex};
 use std::{
     fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
+    convert::{TryFrom, TryInto},
 };
 
 use std::rc::Rc;
@@ -424,7 +425,7 @@ pub fn of_wasm<'a>(
     urs: &WasmPastaFqUrs,
     evals: &WasmPastaFqPlonkVerificationEvals,
     shifts: &WasmPastaFqPlonkVerificationShifts,
-) -> (DlogVerifierIndex<'a, GAffine>, Rc<SRS<GAffine>>) {
+) -> Option<(DlogVerifierIndex<'a, GAffine>, Rc<SRS<GAffine>>)> {
     let urs_copy = Rc::clone(&*urs);
     let urs_copy_outer = Rc::clone(&*urs);
     let srs = {
@@ -436,8 +437,8 @@ pub fn of_wasm<'a>(
     let domain = Domain::<Fq>::new(1 << log_size_of_group).unwrap();
     let index = DlogVerifierIndex::<GAffine> {
         domain,
-        w: zk_w(domain),
-        zkpm: zk_polynomial(domain),
+        w: zk_w(domain)?,
+        zkpm: zk_polynomial(domain)?,
         max_poly_size: max_poly_size as usize,
         max_quot_size: max_quot_size as usize,
         srs,
@@ -461,20 +462,20 @@ pub fn of_wasm<'a>(
         fq_sponge_params: oracle::pasta::fp::params(),
         endo: endo_q,
     };
-    (index, urs_copy_outer)
+    Some((index, urs_copy_outer))
 }
 
-impl From<WasmPastaFqPlonkVerifierIndex> for DlogVerifierIndex<'_, GAffine> {
-    fn from(index: WasmPastaFqPlonkVerifierIndex) -> Self {
-        of_wasm(
+impl TryFrom<WasmPastaFqPlonkVerifierIndex> for DlogVerifierIndex<'_, GAffine> {
+    type Error = ();
+    fn try_from(index: WasmPastaFqPlonkVerifierIndex) -> Result<Self, Self::Error> {
+        Ok(of_wasm(
             index.max_poly_size,
             index.max_quot_size,
             index.domain.log_size_of_group,
             &index.urs,
             &index.evals,
             &index.shifts,
-        )
-        .0
+        ).ok_or_else(|| ())?.0)
     }
 }
 
@@ -542,7 +543,9 @@ pub fn caml_pasta_fq_plonk_verifier_index_write(
     index: &WasmPastaFqPlonkVerifierIndex,
     path: String,
 ) -> Result<(), JsValue> {
-    write_raw(append, &index.clone().into(), path).map_err(|err| {
+    let index = TryInto::try_into(index.clone()).map_err(|()| {
+    JsValue::from_str("caml_pasta_fq_plonk_verifier_index_write: could not generate index") })?;
+    write_raw(append, &index, path).map_err(|err| {
     JsValue::from_str(format!("caml_pasta_fq_plonk_verifier_index_write: {}", err).as_str()) })
 }
 


### PR DESCRIPTION
This PR builds upon o1-labs/proof-systems#132 to create bindings for WASM that raise an error to javascript rather than aborting. This allows invalid proofs etc. to be passed to various functions without crashing the WASM process.

This also includes the changes from #9335, which update the native bindings to support this same PR. The other changes here are slightly more involved, in order to bubble the error up to the bindings' level, but the user-observable behaviour is the same in both bindings (modulo the text content of the exceptions).

This also adds some of the tests that were excluded from #9278, now that they don't crash the WASM process.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: