### PR TITLE
Update Rosetta test-agent

### DIFF
--- a/src/app/rosetta/make-runtime-genesis.sh
+++ b/src/app/rosetta/make-runtime-genesis.sh
@@ -17,5 +17,5 @@ mkdir -p /tmp/keys \
   && echo "$PK" >  ~/.mina-config/wallets/store/$PK.pub \
   && cp /tmp/keys/demo-block-producer ~/.mina-config/wallets/store/$PK \
   && rm -rf ~/.mina-config/genesis* \
-  && echo '{"ledger":{"accounts":[{"pk":"'$PK'","balance":"66000","sk":null,"delegate":null}, {"pk":"'$SNARK_PK'","balance":"0.000000001","sk":null,"delegate":null}, {"pk":"'$TIMELOCKED_PK'","balance":"10000","sk":null,"delegate":null,"timing":{"initial_minimum_balance":"5000","cliff_time":"20","cliff_amount":"2000","vesting_period":"5","vesting_increment":"10"}}]}}' > /tmp/config.json \
+  && echo '{"ledger":{"accounts":[{"pk":"'$PK'","balance":"66000","sk":null,"delegate":null}, {"pk":"'$SNARK_PK'","balance":"0.000000001","sk":null,"delegate":null}, {"pk":"'$TIMELOCKED_PK'","balance":"10000","sk":null,"delegate":null,"timing":{"initial_minimum_balance":"5000","cliff_time":"20","cliff_amount":"2000","vesting_period":"5","vesting_increment":"10"}}], "add_genesis_winner":true}}' > /tmp/config.json \
   && ../../../_build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe --config-file /tmp/config.json

--- a/src/app/rosetta/start.sh
+++ b/src/app/rosetta/start.sh
@@ -51,7 +51,7 @@ sleep 3
     -log-level debug &
 
 # wait for it to settle
-sleep 3
+sleep 60
 
 # rosetta
 ../../../_build/default/src/app/rosetta/rosetta.exe \
@@ -97,4 +97,3 @@ else
   # then cleanup and forward the status
   cleanup $AGENT_STATUS
 fi
-

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -151,8 +151,8 @@ let verify_in_mempool_and_block ~logger ~rosetta_uri ~graphql_uri
             `Failed
         | Ok (Some block) ->
             `Succeeded block )
-      ~retry_count:20 ~initial_delay:(Span.of_ms 250.0)
-      ~each_delay:(Span.of_ms 500.0)
+      ~retry_count:20 ~initial_delay:(Span.of_sec 1.0)
+      ~each_delay:(Span.of_sec 1.0)
       ~failure_reason:"Took too long for a block to be created"
   in
   [%log debug]
@@ -276,6 +276,8 @@ let direct_graphql_delegation_through_block ~logger ~rosetta_uri ~graphql_uri
           ; _type= "fee_payer_dec"
           ; target= `Check None } ]
 
+(* token creation disabled in daemon for now *)
+(*
 let direct_graphql_create_token_through_block ~logger ~rosetta_uri ~graphql_uri
     ~network_response =
   let open Deferred.Result.Let_syntax in
@@ -322,6 +324,7 @@ let direct_graphql_create_token_account_through_block ~logger ~rosetta_uri
           ; status= "Pending"
           ; _type= "fee_payer_dec"
           ; target= `Check None } ]
+*)
 
 let construction_api_transaction_through_mempool ~logger ~rosetta_uri
     ~graphql_uri ~network_response ~operation_expectations ~operations =
@@ -470,6 +473,8 @@ let construction_api_delegation_through_mempool =
           ; _type= "fee_payer_dec"
           ; target= `Check None } ]
 
+(* token creation disabled in daemon for now *)
+(*
 let construction_api_create_token_through_mempool =
   construction_api_transaction_through_mempool
     ~operations:(fun account_id ->
@@ -502,6 +507,7 @@ let construction_api_create_token_account_through_mempool =
           ; status= "Pending"
           ; _type= "fee_payer_dec"
           ; target= `Check None } ]
+*)
 
 let get_consensus_constants ~logger :
     Consensus.Constants.t Or_error.t Deferred.t =
@@ -716,8 +722,10 @@ let check_new_account_user_commands ~logger ~rosetta_uri ~graphql_uri =
       ~graphql_uri ~network_response
   in
   [%log info] "Created construction delegation and waited" ;
+  (* token creation is disabled in daemon for now *)
+  (*
+   [%log info] "Starting create token check" ;
   (* Stop staking *)
-  [%log info] "Starting create token check" ;
   let%bind _res = Poke.Staking.disable ~graphql_uri in
   let%bind () =
     direct_graphql_create_token_through_block ~logger ~rosetta_uri ~graphql_uri
@@ -748,8 +756,8 @@ let check_new_account_user_commands ~logger ~rosetta_uri ~graphql_uri =
   let%bind _ =
     historical_balance_check ~logger ~rosetta_uri ~network_response
   in
+  *)
   [%log info] "Finished historical balance check" ;
-  (* Stop staking *)
   (* Success *)
   return ()
 

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -315,8 +315,10 @@ let get_status ~flag t =
       | `Offline ->
           `Active `Offline
       | `Synced | `Catchup ->
-          if abs (!max_block_height - blockchain_length) < 5 then
-            `Active `Synced
+          if
+            (Mina_lib.config t).demo_mode
+            || abs (!max_block_height - blockchain_length) < 5
+          then `Active `Synced
           else `Active `Catchup
     in
     let consensus_time_best_tip =


### PR DESCRIPTION
Get the Rosetta test-agent to run again.

Changes:
- comment out tests involving token creation
- increase wait times for block production
- `add_genesis_winner` in generated config file
- increase sleep time before starting Rosetta
- in demo code, always have `Synced` status

The wait times for block production are tuned to the short slots (2 sec) for the `dev` profile. So running the test agent with a daemon on a "real" network, not in demo mode, will fail. Nonetheless, retaining the otherwise-harmless check for sync status, in case the test is updated to allow running with a real network.

Testing: ran `start.sh` twice in a row with a 0 exit status.

This PR is part of updating Rosetta to use current models.