### PR TITLE
Redescribe libp2p IPC format without capnp RPC

### DIFF
--- a/src/libp2p_ipc/libp2p_ipc.capnp
+++ b/src/libp2p_ipc/libp2p_ipc.capnp
@@ -3,29 +3,6 @@ using Go = import "/go.capnp";
 $Go.package("libp2p_ipc");
 $Go.import("libp2p_ipc");
 
-struct VoidMsg {
-  timeSent @0 :UInt64;
-}
-
-struct Msg(T) {
-  timeSent @0 :UInt64;
-  content @1 :T;
-}
-
-struct VoidResult {
-  union {
-    error @0 :Msg(Text);
-    success @1 :VoidMsg;
-  }
-}
-
-struct Result(T) {
-  union {
-    error @0 :Msg(Text);
-    success @1 :Msg(T);
-  }
-}
-
 struct Multiaddr {
   representation @0 :Text;
 }
@@ -101,48 +78,24 @@ struct NewPeer {
   isSeed @1 :Bool;
 }
 
-interface Libp2pHelper {
-  configure @0 (config :Msg(Libp2pConfig)) -> (result :VoidResult);
-  setGatingConfig @1 (gatingConfig :Msg(GatingConfig)) -> (result :VoidResult);
-
-  listen @2 (iface :Msg(Text)) -> (result :Result(List(Multiaddr)));
-  getListeningAddrs @3 (void :VoidMsg) -> (result :Result(List(Multiaddr)));
-  beginAdvertising @4 () -> (result :VoidResult);
-
-  addPeer @5 (peer :Msg(NewPeer)) -> (result :Result(NewPeer));
-  listPeers @6 (void :VoidMsg) -> (result :Result(List(PeerInfo)));
-
-  generateKeypair @7 (void :VoidMsg) -> (result :Result(Libp2pKeypair));
-
-  publish @8 (publish :Msg(Publish)) -> (result :VoidResult);
-  subscribe @9 (subscribe :Msg(Subscribe)) -> (result :VoidResult);
-  # do we use this anymore?
-  unsubscribe @10 (subscriptionId :Msg(SubscriptionId)) -> (result :VoidResult);
-  addStreamHandler @11 (protocol :Msg(Text)) -> (result :VoidResult);
-
-  # do we use this anymore?
-  removeStreamHandler @12 (protocol :Msg(Text)) -> (result :VoidResult);
-  openStream @13 (stream :Msg(OutgoingStream)) -> (result :Result(Stream));
-  closeStream @14 (streamId :Msg(StreamId)) -> (result :VoidResult);
-  resetStream @15 (streamId :Msg(StreamId)) -> (result :VoidResult);
-  sendStream @16 (msg :Msg(StreamMessage)) -> (result :VoidResult);
-
-  setNodeStatus @17 (status :Msg(Data)) -> (result :VoidResult);
-  getPeerNodeStatus @18 (peer :Msg(Multiaddr)) -> (result :Result(Data));
-}
-
-
-interface Validation {
-  validate @0 (validation :Msg(Validation)) -> (result :VoidResult);
-}
-
 struct GossipMessage {
   sender @0 :PeerInfo;
   seenAt @1 :UInt64;
   expiration @2 :UInt64;
   subscriptionId @3 :UInt64;
-  data @4 :Data;
-  validation @5 :Validation;
+  validationSeqNumber @4 :UInt64;
+  data @5 :Data;
+}
+
+enum ValidationResult {
+  accept @0;
+  reject @1;
+  ignore @2;
+}
+
+struct ValidationMessage {
+  validationSeqNumber @0 :UInt64;
+  result @1 :ValidationResult;
 }
 
 struct IncomingStream {
@@ -161,11 +114,266 @@ struct StreamMessage {
   data @1 :Data;
 }
 
-interface Daemon {
-  peerConnected @0 (peerId :Msg(Text));
-  gossipReceived @1 (validation :Msg(GossipMessage));
-  incomingStream @2 (stream :Msg(IncomingStream));
-  streamLost @3 (streamLost :Msg(StreamLost));
-  streamComplete @4 (streamId :Msg(StreamId));
-  streamMessageReceived @5 (msg :Msg(StreamMessage));
+struct PushMessage(T) {
+  timeSent @0 :UInt64;
+  content @1 :T;
+}
+
+struct RPCMessage {
+  struct Header {
+    timeSent @0 :UInt64;
+    seqNumber @1 :UInt64;
+  }
+
+  struct VoidRequest {
+    header @0 :RPCMessage.Header;
+  }
+
+  struct Request(T) {
+    header @0 :RPCMessage.Header;
+    content @1 :T;
+  }
+
+  struct VoidResult {
+    header @0 :RPCMessage.Header;
+    union {
+      error @1 :Text;
+      success @2 :Void;
+    }
+  }
+
+  struct Result(T) {
+    header @0 :RPCMessage.Header;
+    union {
+      error @1 :Text;
+      success @2 :T;
+    }
+  }
+}
+
+# all messages in the libp2p_helper interface are RPC calls, except for validations
+struct Libp2pHelperInterface {
+  struct Configure {
+    struct Request {
+      config @0 :RPCMessage.Request(Libp2pConfig);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct SetGatingConfig  {
+    struct Request {
+      gatingConfig @0 :RPCMessage.Request(GatingConfig);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct Listen {
+    struct Request {
+      iface @0 :RPCMessage.Request(Text);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.Result(List(Multiaddr));
+    }
+  }
+
+  struct GetListeningAddrs {
+    struct Request {
+      void @0 :RPCMessage.VoidResult;
+    }
+
+    struct Response {
+      result @0 :RPCMessage.Result(List(Multiaddr));
+    }
+  }
+
+  struct BeginAdvertising {
+    struct Request {}
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct AddPeer {
+    struct Request {
+      peer @0 :RPCMessage.Request(NewPeer);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.Result(NewPeer);
+    }
+  }
+
+  struct ListPeers {
+    struct Request {
+      void @0 :RPCMessage.VoidResult;
+    }
+
+    struct Response {
+      result @0 :RPCMessage.Result(List(PeerInfo));
+    }
+  }
+
+  struct GenerateKeypair {
+    struct Request {
+      void @0 :RPCMessage.VoidResult;
+    }
+
+    struct Response {
+      result @0 :RPCMessage.Result(Libp2pKeypair);
+    }
+  }
+
+  struct Publish {
+    struct Request {
+      publish @0 :RPCMessage.Request(Publish);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct Subscribe {
+    struct Request {
+      subscribe @0 :RPCMessage.Request(Subscribe);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  # do we use this anymore?
+  struct Unsubscribe {
+   struct Request {
+      subscriptionId @0 :RPCMessage.Request(SubscriptionId);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct AddStreamHandler {
+   struct Request {
+      protocol @0 :RPCMessage.Request(Text);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  # do we use this anymore?
+  struct RemoveStreamHandler {
+   struct Request {
+      protocol @0 :RPCMessage.Request(Text);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct OpenStream {
+   struct Request {
+      stream @0 :RPCMessage.Request(OutgoingStream);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.Result(Stream);
+    }
+  }
+
+  struct CloseStream {
+   struct Request {
+      streamId @0 :RPCMessage.Request(StreamId);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct ResetStream {
+   struct Request {
+      streamId @0 :RPCMessage.Request(StreamId);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct SendStream {
+   struct Request {
+      msg @0 :RPCMessage.Request(StreamMessage);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct SetNodeStatus {
+   struct Request {
+      status @0 :RPCMessage.Request(Data);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.VoidResult;
+    }
+  }
+
+  struct GetPeerNodeStatus {
+   struct Request {
+      peer @0 :RPCMessage.Request(Multiaddr);
+    }
+
+    struct Response {
+      result @0 :RPCMessage.Result(Data);
+    }
+  }
+
+  # validation is a special push message where the sequence number
+  # corresponds to the the push message sent to the daemon in the
+  # GossipReceived message
+  struct Validation {
+    validation @0 :PushMessage(ValidationMessage);
+  }
+}
+
+# all messages in the daemon interface are push messages 
+struct DaemonInterface {
+  struct PeerConnected {
+    peerId @0 :PushMessage(Text);
+  }
+
+  struct GossipReceived {
+    msg @0 :PushMessage(GossipMessage);
+  }
+
+  struct IncomingStream {
+    stream @0 :PushMessage(IncomingStream);
+  }
+
+  struct StreamLost {
+    streamLost @0 :PushMessage(StreamLost);
+  }
+
+  struct StreamComplete {
+    streamId @0 :PushMessage(StreamId);
+  }
+
+  struct StreamMessageReceived {
+    msg @0 :PushMessage(StreamMessage);
+  }
 }


### PR DESCRIPTION
We made a decision today (due to lack of async support on the ocaml capnp-rpc library) to move forward with only utilizing the Cap'N Proto serialization format rather than the entire Cap'N Proto RPC protocol. We will continue to look into a full upgrade to the Cap'N Proto RPC protocol, but this scope cut will allow us to still deliver a large benefit in the meantime without risk of extending our deadline on the networking project.