### PR TITLE
Remove generics from libp2p_ipc description; improve OCaml codegen

### DIFF
--- a/src/libp2p_ipc/libp2p_ipc.capnp
+++ b/src/libp2p_ipc/libp2p_ipc.capnp
@@ -7,10 +7,19 @@ struct Multiaddr {
   representation @0 :Text;
 }
 
+struct PeerId {
+  id @0 :Text;
+}
+
+struct AddrInfo {
+  peerId @0 :PeerId;
+  addrs @1 :List(Multiaddr);
+}
+
 struct PeerInfo {
   libp2pPort @0 :UInt16;
   host @1 :Text;
-  peerId @2 :Text;
+  peerId @2 :PeerId;
 }
 
 struct StreamId {
@@ -24,14 +33,14 @@ struct SubscriptionId {
 struct Libp2pKeypair {
   privateKey @0 :Text;
   publicKey @1 :Text;
-  peerId @2 :Text;
+  peerId @2 :PeerId;
 }
 
 struct GatingConfig {
-  bannedIPs @0 :List(Text);
-  bannedPeerIDs @1 :List(Text);
-  trustedIPs @2 :List(Text);
-  trustedPeerIDs @3 :List(Text);
+  bannedIps @0 :List(Text);
+  bannedPeerIds @1 :List(Text);
+  trustedIps @2 :List(Text);
+  trustedPeerIds @3 :List(Text);
   isolate @4 :Bool;
 }
 
@@ -42,7 +51,7 @@ struct Libp2pConfig {
   listenOn @3 :List(Text);
   metricsPort @4 :Int16;
   externalMultiaddr @5 :Text;
-  unsafeNoTrustIP @6 :Bool;
+  unsafeNoTrustIp @6 :Bool;
   flood @7 :Bool;
   peerExchange @8 :Bool;
   directPeers @9 :List(Text);
@@ -51,40 +60,6 @@ struct Libp2pConfig {
   maxConnections @12 :UInt32;
   validationQueueSize @13 :UInt32;
   minaPeerExchange @14 :Bool;
-}
-
-struct Publish {
-  topic @0 :Text;
-  data @1 :Data;
-}
-
-struct Subscribe {
-  topic @0 :Text;
-  subscriptionId @1 :UInt64;
-}
-
-struct OutgoingStream {
-  peer @0 :Text;
-  protocolId @1 :Text;
-}
-
-struct Stream {
-  id @0 :UInt64;
-  peer @1 :PeerInfo;
-}
-
-struct NewPeer {
-  multiaddr @0 :Multiaddr;
-  isSeed @1 :Bool;
-}
-
-struct GossipMessage {
-  sender @0 :PeerInfo;
-  seenAt @1 :UInt64;
-  expiration @2 :UInt64;
-  subscriptionId @3 :UInt64;
-  validationSeqNumber @4 :UInt64;
-  data @5 :Data;
 }
 
 enum ValidationResult {
@@ -98,248 +73,184 @@ struct ValidationMessage {
   result @1 :ValidationResult;
 }
 
-struct IncomingStream {
-  id @0 :UInt64;
-  peer @1 :PeerInfo;
-  protocol @2 :Text;
-}
-
-struct StreamLost {
-  id @0 :UInt64;
-  reason @1 :Text;
-}
-
 struct StreamMessage {
-  id @0 :UInt64;
+  id @0 :StreamId;
   data @1 :Data;
 }
 
-struct PushMessage(T) {
+struct PushMessageHeader {
   timeSent @0 :UInt64;
-  content @1 :T;
 }
 
-struct RPCMessage {
-  struct Header {
-    timeSent @0 :UInt64;
-    seqNumber @1 :UInt64;
-  }
-
-  struct VoidRequest {
-    header @0 :RPCMessage.Header;
-  }
-
-  struct Request(T) {
-    header @0 :RPCMessage.Header;
-    content @1 :T;
-  }
-
-  struct VoidResult {
-    header @0 :RPCMessage.Header;
-    union {
-      error @1 :Text;
-      success @2 :Void;
-    }
-  }
-
-  struct Result(T) {
-    header @0 :RPCMessage.Header;
-    union {
-      error @1 :Text;
-      success @2 :T;
-    }
-  }
+struct RpcMessageHeader {
+  timeSent @0 :UInt64;
+  seqNumber @1 :UInt64;
 }
 
-# all messages in the libp2p_helper interface are RPC calls, except for validations
+# all messages in the libp2p_helper interface are Rpc calls, except for validations
 struct Libp2pHelperInterface {
   struct Configure {
     struct Request {
-      config @0 :RPCMessage.Request(Libp2pConfig);
+      config @0 :Libp2pConfig;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct SetGatingConfig  {
     struct Request {
-      gatingConfig @0 :RPCMessage.Request(GatingConfig);
+      gatingConfig @0 :GatingConfig;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct Listen {
     struct Request {
-      iface @0 :RPCMessage.Request(Text);
+      iface @0 :Text;
     }
 
     struct Response {
-      result @0 :RPCMessage.Result(List(Multiaddr));
+      result @0 :List(Multiaddr);
     }
   }
 
   struct GetListeningAddrs {
-    struct Request {
-      void @0 :RPCMessage.VoidResult;
-    }
+    struct Request {}
 
     struct Response {
-      result @0 :RPCMessage.Result(List(Multiaddr));
+      result @0 :List(Multiaddr);
     }
   }
 
   struct BeginAdvertising {
     struct Request {}
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct AddPeer {
     struct Request {
-      peer @0 :RPCMessage.Request(NewPeer);
+      multiaddr @0 :Multiaddr;
+      isSeed @1 :Bool;
     }
 
     struct Response {
-      result @0 :RPCMessage.Result(NewPeer);
+      result @0 :AddrInfo;
     }
   }
 
   struct ListPeers {
-    struct Request {
-      void @0 :RPCMessage.VoidResult;
-    }
+    struct Request {}
 
     struct Response {
-      result @0 :RPCMessage.Result(List(PeerInfo));
+      result @0 :List(PeerInfo);
     }
   }
 
   struct GenerateKeypair {
-    struct Request {
-      void @0 :RPCMessage.VoidResult;
-    }
+    struct Request {}
 
     struct Response {
-      result @0 :RPCMessage.Result(Libp2pKeypair);
+      result @0 :Libp2pKeypair;
     }
   }
 
   struct Publish {
     struct Request {
-      publish @0 :RPCMessage.Request(Publish);
+      topic @0 :Text;
+      data @1 :Data;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct Subscribe {
     struct Request {
-      subscribe @0 :RPCMessage.Request(Subscribe);
+      topic @0 :Text;
+      subscriptionId @1 :UInt64;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   # do we use this anymore?
   struct Unsubscribe {
    struct Request {
-      subscriptionId @0 :RPCMessage.Request(SubscriptionId);
+      subscriptionId @0 :SubscriptionId;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct AddStreamHandler {
    struct Request {
-      protocol @0 :RPCMessage.Request(Text);
+      protocol @0 :Text;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   # do we use this anymore?
   struct RemoveStreamHandler {
    struct Request {
-      protocol @0 :RPCMessage.Request(Text);
+      protocol @0 :Text;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct OpenStream {
    struct Request {
-      stream @0 :RPCMessage.Request(OutgoingStream);
+      peer @0 :Text;
+      protocolId @1 :Text;
     }
 
     struct Response {
-      result @0 :RPCMessage.Result(Stream);
+      id @0 :StreamId;
+      peer @1 :PeerInfo;
     }
   }
 
   struct CloseStream {
    struct Request {
-      streamId @0 :RPCMessage.Request(StreamId);
+      streamId @0 :StreamId;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct ResetStream {
    struct Request {
-      streamId @0 :RPCMessage.Request(StreamId);
+      streamId @0 :StreamId;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct SendStream {
    struct Request {
-      msg @0 :RPCMessage.Request(StreamMessage);
+      msg @0 :StreamMessage;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct SetNodeStatus {
    struct Request {
-      status @0 :RPCMessage.Request(Data);
+      status @0 :Data;
     }
 
-    struct Response {
-      result @0 :RPCMessage.VoidResult;
-    }
+    struct Response {}
   }
 
   struct GetPeerNodeStatus {
    struct Request {
-      peer @0 :RPCMessage.Request(Multiaddr);
+      peer @0 :Multiaddr;
     }
 
     struct Response {
-      result @0 :RPCMessage.Result(Data);
+      result @0 :Data;
     }
   }
 
@@ -347,33 +258,134 @@ struct Libp2pHelperInterface {
   # corresponds to the the push message sent to the daemon in the
   # GossipReceived message
   struct Validation {
-    validation @0 :PushMessage(ValidationMessage);
+    validation @0 :ValidationMessage;
+  }
+
+  struct RpcRequest {
+    header @0 :RpcMessageHeader;
+
+    union {
+      configure @1 :Libp2pHelperInterface.Configure.Request;
+      setGatingConfig @2 :Libp2pHelperInterface.SetGatingConfig.Request;
+      listen @3 :Libp2pHelperInterface.Listen.Request;
+      getListeningAddrs @4 :Libp2pHelperInterface.GetListeningAddrs.Request;
+      beginAdvertising @5 :Libp2pHelperInterface.BeginAdvertising.Request;
+      addPeer @6 :Libp2pHelperInterface.AddPeer.Request;
+      listPeers @7 :Libp2pHelperInterface.ListPeers.Request;
+      generateKeypair @8 :Libp2pHelperInterface.GenerateKeypair.Request;
+      publish @9 :Libp2pHelperInterface.Publish.Request;
+      subscribe @10 :Libp2pHelperInterface.Subscribe.Request;
+      unsubscribe @11 :Libp2pHelperInterface.Unsubscribe.Request;
+      addStreamHandler @12 :Libp2pHelperInterface.AddStreamHandler.Request;
+      removeStreamHandler @13 :Libp2pHelperInterface.RemoveStreamHandler.Request;
+      openStream @14 :Libp2pHelperInterface.OpenStream.Request;
+      closeStream @15 :Libp2pHelperInterface.CloseStream.Request;
+      resetStream @16 :Libp2pHelperInterface.ResetStream.Request;
+      sendStream @17 :Libp2pHelperInterface.SendStream.Request;
+      setNodeStatus @18 :Libp2pHelperInterface.SetNodeStatus.Request;
+      getPeerNodeStatus @19 :Libp2pHelperInterface.GetPeerNodeStatus.Request;
+    }
+  }
+
+  struct RpcResponseSuccess {
+    union {
+      configure @0 :Libp2pHelperInterface.Configure.Response;
+      setGatingConfig @1 :Libp2pHelperInterface.SetGatingConfig.Response;
+      listen @2 :Libp2pHelperInterface.Listen.Response;
+      getListeningAddrs @3 :Libp2pHelperInterface.GetListeningAddrs.Response;
+      beginAdvertising @4 :Libp2pHelperInterface.BeginAdvertising.Response;
+      addPeer @5 :Libp2pHelperInterface.AddPeer.Response;
+      listPeers @6 :Libp2pHelperInterface.ListPeers.Response;
+      generateKeypair @7 :Libp2pHelperInterface.GenerateKeypair.Response;
+      publish @8 :Libp2pHelperInterface.Publish.Response;
+      subscribe @9 :Libp2pHelperInterface.Subscribe.Response;
+      unsubscribe @10 :Libp2pHelperInterface.Unsubscribe.Response;
+      addStreamHandler @11 :Libp2pHelperInterface.AddStreamHandler.Response;
+      removeStreamHandler @12 :Libp2pHelperInterface.RemoveStreamHandler.Response;
+      openStream @13 :Libp2pHelperInterface.OpenStream.Response;
+      closeStream @14 :Libp2pHelperInterface.CloseStream.Response;
+      resetStream @15 :Libp2pHelperInterface.ResetStream.Response;
+      sendStream @16 :Libp2pHelperInterface.SendStream.Response;
+      setNodeStatus @17 :Libp2pHelperInterface.SetNodeStatus.Response;
+      getPeerNodeStatus @18 :Libp2pHelperInterface.GetPeerNodeStatus.Response;
+    }
+  }
+
+  struct RpcResponse {
+    header @0 :RpcMessageHeader;
+    union {
+      error @1 :Text;
+      success @2 :RpcResponseSuccess;
+    }
+  }
+
+  struct PushMessage {
+    header @0 :PushMessageHeader;
+
+    # union {
+    validation @1 :Libp2pHelperInterface.Validation;
+    # }
+  }
+
+  struct IncomingMessage {
+    union {
+      rpcRequest @0 :Libp2pHelperInterface.RpcRequest;
+      pushMessage @1 :Libp2pHelperInterface.PushMessage;
+    }
   }
 }
 
 # all messages in the daemon interface are push messages 
 struct DaemonInterface {
   struct PeerConnected {
-    peerId @0 :PushMessage(Text);
+    peerId @0 :PeerId;
   }
 
   struct GossipReceived {
-    msg @0 :PushMessage(GossipMessage);
+    sender @0 :PeerInfo;
+    seenAt @1 :UInt64;
+    expiration @2 :UInt64;
+    subscriptionId @3 :UInt64;
+    validationSeqNumber @4 :UInt64;
+    data @5 :Data;
   }
 
   struct IncomingStream {
-    stream @0 :PushMessage(IncomingStream);
+    id @0 :UInt64;
+    peer @1 :PeerInfo;
+    protocol @2 :Text;
   }
 
   struct StreamLost {
-    streamLost @0 :PushMessage(StreamLost);
+    id @0 :UInt64;
+    reason @1 :Text;
   }
 
   struct StreamComplete {
-    streamId @0 :PushMessage(StreamId);
+    streamId @0 :StreamId;
   }
 
   struct StreamMessageReceived {
-    msg @0 :PushMessage(StreamMessage);
+    msg @0 :StreamMessage;
+  }
+
+  struct PushMessage {
+    header @0 :PushMessageHeader;
+
+    union {
+      peerConnected @1 :DaemonInterface.PeerConnected;
+      gossipReceived @2 :DaemonInterface.GossipReceived;
+      incomingStream @3 :DaemonInterface.IncomingStream;
+      streamLost @4 :DaemonInterface.StreamLost;
+      streamComplete @5 :DaemonInterface.StreamComplete;
+      streamMessageReceived @6 :DaemonInterface.StreamMessageReceived;
+    }
+  }
+
+  struct IncomingMessage {
+    union {
+      libp2pHelperResponse @0 :Libp2pHelperInterface.RpcResponse;
+      pushMessage @1 :DaemonInterface.PushMessage;
+    }
   }
 }

--- a/src/libp2p_ipc/libp2p_ipc.capnp
+++ b/src/libp2p_ipc/libp2p_ipc.capnp
@@ -68,11 +68,6 @@ enum ValidationResult {
   ignore @2;
 }
 
-struct ValidationMessage {
-  validationSeqNumber @0 :UInt64;
-  result @1 :ValidationResult;
-}
-
 struct StreamMessage {
   id @0 :StreamId;
   data @1 :Data;
@@ -258,7 +253,8 @@ struct Libp2pHelperInterface {
   # corresponds to the the push message sent to the daemon in the
   # GossipReceived message
   struct Validation {
-    validation @0 :ValidationMessage;
+    validationSeqNumber @0 :UInt64;
+    result @1 :ValidationResult;
   }
 
   struct RpcRequest {
@@ -327,7 +323,7 @@ struct Libp2pHelperInterface {
     # }
   }
 
-  struct IncomingMessage {
+  struct Message {
     union {
       rpcRequest @0 :Libp2pHelperInterface.RpcRequest;
       pushMessage @1 :Libp2pHelperInterface.PushMessage;
@@ -382,7 +378,7 @@ struct DaemonInterface {
     }
   }
 
-  struct IncomingMessage {
+  struct Message {
     union {
       libp2pHelperResponse @0 :Libp2pHelperInterface.RpcResponse;
       pushMessage @1 :DaemonInterface.PushMessage;


### PR DESCRIPTION
Cap'N Proto generics were causing some issue on the OCaml codegen, and Go lacks generics anyway, so we decided to move towards a non-generic approach. Additionally, I did some renaming of some of the struct names and fields so that the names in the generated OCaml code get translated properly from `CamelCase` to `snake_case`.