### PR TITLE
Allow accounts to be created with timing info in parties transactions

### DIFF
--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1275,10 +1275,13 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
     (* Check timing. *)
     let%bind timing =
       match delta.sgn with
-      | Pos ->
+      | Pos when not is_new ->
           Ok timing
-      | Neg ->
-          validate_timing ~txn_amount:delta.magnitude
+      | _ ->
+          let txn_amount =
+            match delta.sgn with Pos -> Amount.zero | Neg -> delta.magnitude
+          in
+          validate_timing ~txn_amount
             ~txn_global_slot:state_view.global_slot_since_genesis
             ~account:{ a with timing }
           |> Result.map_error ~f:timing_error_to_user_command_status

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1268,7 +1268,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
             (* This should be a reject, not a failure, otherwise the snark
                circuit becomes unsatisfiable.
             *)
-            Error (failure Update_not_permitted)
+            failwith "Transaction contains invalid timing information"
       | Set _ ->
           Error (failure Update_not_permitted)
     in


### PR DESCRIPTION
This PR builds upon #9354.

This adds a `timing` field to the `changes` record within a party. When a party in a transaction results in the creation of an account, this data is used to set the timing info for that account. If the timing data is invalid (e.g. the initial balance is below the actual balance) or the account already exists then the update fails, and the only effect of the transaction is to charge the fee to the fee payer.

This also fixes a bug where a party receiving funds had their timing calculated as if they were sending them, which would make the snark unsatisfiable for any such transaction.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: