### PR TITLE
Account creation fee for coinbases in archive db

### DIFF
--- a/scripts/archive/coinbase-account-fees.sh
+++ b/scripts/archive/coinbase-account-fees.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# add account creation fee to blocks_internal_commands for coinbases, where the balance is the coinbase amount minus 1 Mina
+
+ARCHIVE=archive
+TMPFILE=$(mktemp -t coinbase-acct-fee.XXXXX)
+
+psql $ARCHIVE <<EOF
+ALTER TABLE blocks_internal_commands
+ADD COLUMN receiver_account_creation_fee_paid bigint
+EOF
+
+# use `head` to strip header lines, trailing output
+psql $ARCHIVE <<EOF | awk -F \| '(NR > 2){print $1 $2 $3 $4}' | head -n -2 > $TMPFILE
+SELECT block_id, internal_command_id, sequence_no, secondary_sequence_no
+FROM blocks_internal_commands AS bic
+INNER JOIN internal_commands as ic
+ON bic.internal_command_id = ic.id
+INNER JOIN balances
+ON bic.receiver_balance = balances.id
+WHERE ic.type='coinbase' AND ((ic.fee = 1440000000000 AND balances.balance = 1439000000000) OR (ic.fee = 720000000000 AND balances.balance = 719000000000))
+EOF
+
+while read -r block_id internal_command_id sequence_no secondary_sequence_no; do
+    psql $ARCHIVE <<EOF
+    UPDATE blocks_internal_commands SET receiver_account_creation_fee_paid = 1000000000
+    WHERE block_id=$block_id AND internal_command_id=$internal_command_id AND sequence_no=$sequence_no AND secondary_sequence_no=$secondary_sequence_no
+EOF
+done < $TMPFILE

--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -56,6 +56,8 @@ module Internal_command = struct
     ; secondary_sequence_no: int
     ; typ: string
     ; receiver: Public_key.Compressed.Stable.Latest.t
+    ; receiver_account_creation_fee_paid:
+        Currency.Amount.Stable.Latest.t option
     ; receiver_balance: Currency.Balance.Stable.Latest.t
     ; fee: Currency.Fee.Stable.Latest.t
     ; token: Token_id.Stable.Latest.t

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -756,28 +756,32 @@ module Block_and_internal_command = struct
     ; internal_command_id: int
     ; sequence_no: int
     ; secondary_sequence_no: int
+    ; receiver_account_creation_fee_paid: int64 option
     ; receiver_balance_id: int }
   [@@deriving hlist]
 
   let typ =
     let open Caqti_type_spec in
-    let spec = Caqti_type.[int; int; int; int; int] in
+    let spec = Caqti_type.[int; int; int; int; option int64; int] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
     Caqti_type.custom ~encode ~decode (to_rep spec)
 
   let add (module Conn : CONNECTION) ~block_id ~internal_command_id
-      ~sequence_no ~secondary_sequence_no ~receiver_balance_id =
+      ~sequence_no ~secondary_sequence_no ~receiver_account_creation_fee_paid
+      ~receiver_balance_id =
     Conn.exec
       (Caqti_request.exec typ
          {sql| INSERT INTO blocks_internal_commands
-                (block_id, internal_command_id, sequence_no, secondary_sequence_no, receiver_balance)
-                VALUES (?, ?, ?, ?, ?)
+                (block_id, internal_command_id, sequence_no, secondary_sequence_no,
+                 receiver_account_creation_fee_paid,receiver_balance)
+                VALUES (?, ?, ?, ?, ?, ?)
          |sql})
       { block_id
       ; internal_command_id
       ; sequence_no
       ; secondary_sequence_no
+      ; receiver_account_creation_fee_paid
       ; receiver_balance_id }
 
   let find (module Conn : CONNECTION) ~block_id ~internal_command_id
@@ -796,7 +800,7 @@ module Block_and_internal_command = struct
 
   let add_if_doesn't_exist (module Conn : CONNECTION) ~block_id
       ~internal_command_id ~sequence_no ~secondary_sequence_no
-      ~receiver_balance_id =
+      ~receiver_account_creation_fee_paid ~receiver_balance_id =
     let open Deferred.Result.Let_syntax in
     match%bind
       find
@@ -809,7 +813,7 @@ module Block_and_internal_command = struct
         add
           (module Conn)
           ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
-          ~receiver_balance_id
+          ~receiver_account_creation_fee_paid ~receiver_balance_id
 end
 
 module Block_and_signed_command = struct
@@ -1242,10 +1246,12 @@ module Block = struct
                           (module Conn)
                           ~public_key_id:receiver_id ~balance
                       in
+                      (* TODO: use transaction status for account creation fee *)
                       Block_and_internal_command.add
                         (module Conn)
                         ~block_id ~internal_command_id:fee_transfer_id
                         ~sequence_no ~secondary_sequence_no
+                        ~receiver_account_creation_fee_paid:None
                         ~receiver_balance_id
                       >>| ignore )
                 in
@@ -1274,18 +1280,38 @@ module Block = struct
                           (module Conn)
                           receiver_pk
                       in
+                      let balance = Option.value_exn
+                          balances.fee_transfer_receiver_balance
+                      in
                       let%bind receiver_balance_id =
                         Balance.add_if_doesn't_exist
                           (module Conn)
                           ~public_key_id:fee_transfer_receiver_id
-                          ~balance:
-                            (Option.value_exn
-                               balances.fee_transfer_receiver_balance)
+                          ~balance
+                      in
+                      (* TODO: add transaction statuses to internal commands
+                         the archive lib should not know the details of
+                         account creation fees; the calculation below is
+                         a temporizing hack
+                      *)
+                      let receiver_account_creation_fee_paid =
+                        let fee_uint64 = Currency.Fee.to_uint64 fee in
+                        let balance_uint64 = Currency.Balance.to_uint64 balance in
+                        let account_creation_fee_uint64 = Currency.Fee.to_uint64
+                            constraint_constants.account_creation_fee
+                        in
+                        if Unsigned.UInt64.equal balance_uint64
+                            (Unsigned.UInt64.sub fee_uint64 account_creation_fee_uint64) then
+                          Some (Unsigned.UInt64.to_int64 account_creation_fee_uint64)
+                        else
+                          None
                       in
                       Block_and_internal_command.add
                         (module Conn)
                         ~block_id ~internal_command_id:id ~sequence_no
-                        ~secondary_sequence_no:0 ~receiver_balance_id
+                        ~secondary_sequence_no:0
+                        ~receiver_account_creation_fee_paid
+                        ~receiver_balance_id
                       >>| ignore
                 in
                 let%bind id =
@@ -1306,7 +1332,8 @@ module Block = struct
                   Block_and_internal_command.add
                     (module Conn)
                     ~block_id ~internal_command_id:id ~sequence_no
-                    ~secondary_sequence_no:0 ~receiver_balance_id
+                    ~secondary_sequence_no:0 ~receiver_account_creation_fee_paid:None (* TEMP *)
+                    ~receiver_balance_id
                   >>| ignore
                 in
                 sequence_no + 1 )
@@ -1480,6 +1507,7 @@ module Block = struct
           Block_and_internal_command.add_if_doesn't_exist
             (module Conn)
             ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
+            ~receiver_account_creation_fee_paid:None (* TEMP *)
             ~receiver_balance_id )
     in
     return block_id

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -116,6 +116,7 @@ CREATE TABLE blocks_internal_commands
 , internal_command_id   int NOT NULL REFERENCES internal_commands(id) ON DELETE CASCADE
 , sequence_no           int NOT NULL
 , secondary_sequence_no int NOT NULL
+, receiver_account_creation_fee_paid bigint
 , receiver_balance      int NOT NULL REFERENCES balances(id) ON DELETE CASCADE
 , PRIMARY KEY (block_id, internal_command_id, sequence_no, secondary_sequence_no)
 );

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -246,6 +246,7 @@ let fill_in_internal_commands pool block_state_hash =
          { internal_command_id
          ; sequence_no
          ; secondary_sequence_no
+         ; receiver_account_creation_fee_paid
          ; receiver_balance_id
          }
        ->
@@ -271,11 +272,16 @@ let fill_in_internal_commands pool block_state_hash =
         internal_cmd.token |> Unsigned.UInt64.of_int64 |> Token_id.of_uint64
       in
       let hash = internal_cmd.hash |> Transaction_hash.of_base58_check_exn in
+      let receiver_account_creation_fee_paid =
+        Option.map receiver_account_creation_fee_paid ~f:(fun fee ->
+            fee |> Unsigned.UInt64.of_int64 |> Currency.Amount.of_uint64)
+      in
       let cmd =
         { Extensional.Internal_command.sequence_no
         ; secondary_sequence_no
         ; typ
         ; receiver
+        ; receiver_account_creation_fee_paid
         ; receiver_balance
         ; fee
         ; token

--- a/src/app/extract_blocks/sql.ml
+++ b/src/app/extract_blocks/sql.ml
@@ -103,20 +103,21 @@ module Blocks_and_internal_commands = struct
     { internal_command_id : int
     ; sequence_no : int
     ; secondary_sequence_no : int
+    ; receiver_account_creation_fee_paid : int64 option
     ; receiver_balance_id : int
     }
   [@@deriving hlist]
 
   let typ =
     let open Archive_lib.Processor.Caqti_type_spec in
-    let spec = Caqti_type.[ int; int; int; int ] in
+    let spec = Caqti_type.[ int; int; int; option int64; int ] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
     Caqti_type.custom ~encode ~decode (to_rep spec)
 
   let query =
     Caqti_request.collect Caqti_type.int typ
-      {sql| SELECT internal_command_id, sequence_no, secondary_sequence_no, receiver_balance
+      {sql| SELECT internal_command_id, sequence_no, secondary_sequence_no, receiver_account_creation_fee_paid, receiver_balance
             FROM (blocks_internal_commands
               INNER JOIN blocks
               ON blocks.id = blocks_internal_commands.block_id)


### PR DESCRIPTION
Add a new column, `account_creation_fee_paid`, to `blocks_internal_commands`. An internal command can create a new account, and we'd like to be expose the account creation fee. We need that for Rosetta, so the balances will reconcile. The Rosetta changes will be in a subsequent PR.

In the archive db, when there's a coinbase internal command added, if the balance after the command is 1 Mina less the coinbase amount, it must be a new account, and we enter 1000000000 nanoMina in that column.

*THIS IS A TEMPORIZING BUT SAFE HACK*

Eventually, we'll want to have internal commands return a list of `Transaction_status.t`s. Coinbases and fee transfers can consist of multiple commands, so we need a status for each. That's a biggish/riskier change which we can do in a later PR.

Other changes:
- add a script to migrate existing archive dbs
- update the replayer test archive db to include the column
- update the extensional block type and `extract_blocks` to include this new data

Tested the replayer locally. Extracted all blocks from the migrated replayer test archive db, verified that some of these columns were non-null; archived an extracted block back.
