### PR TITLE
fix: Change WantedBy to default.target

### DIFF
--- a/scripts/mina.service
+++ b/scripts/mina.service
@@ -18,4 +18,4 @@ ExecStart=/usr/local/bin/mina daemon \
 ExecStop=/usr/local/bin/mina client stop-daemon
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target


### PR DESCRIPTION
Change value of "WantedBy" from "multi-user.target" to
"default.target" in the "[Install]" section of "mina.service".

User services in systemd do not use "multi-user.target" and therefore
will not start at boot if "WantedBy=multi-user.target". Use
"default.target" instead.

Resolves #7845

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #7845
