### PR TITLE
Add missing .ocamlformat files

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,1 @@
+src/.ocamlformat

--- a/src/app/archive/.ocamlformat
+++ b/src/app/archive/.ocamlformat
@@ -1,0 +1,1 @@
+../../.ocamlformat

--- a/src/app/archive/archive_lib/.ocamlformat
+++ b/src/app/archive/archive_lib/.ocamlformat
@@ -1,0 +1,1 @@
+../../../.ocamlformat

--- a/src/app/archive/archive_lib/ast.ml
+++ b/src/app/archive/archive_lib/ast.ml
@@ -1,6 +1,6 @@
 module Rel_insert_input = struct
   type ('data, 'on_conflict) t =
-    < data: 'data ; on_conflict: 'on_conflict option >
+    < data : 'data ; on_conflict : 'on_conflict option >
 
   type nonrec ('data, 'on_conflict) array = ('data array, 'on_conflict) t
 end
@@ -9,7 +9,7 @@ type void
 
 module On_conflict = struct
   type ('constraint_, 'update_columns) t =
-    < constraint_: 'constraint_ ; update_columns: 'update_columns array >
+    < constraint_ : 'constraint_ ; update_columns : 'update_columns array >
 
   let create constraint_ update_columns =
     object
@@ -18,45 +18,46 @@ module On_conflict = struct
       method update_columns = Array.of_list update_columns
     end
 
-  type public_keys = ([`public_keys_value_key], [`value]) t
+  type public_keys = ([ `public_keys_value_key ], [ `value ]) t
 
-  type fee_transfers = ([`fee_transfers_hash_key], [`first_seen]) t
+  type fee_transfers = ([ `fee_transfers_hash_key ], [ `first_seen ]) t
 
-  type user_commands = ([`user_commands_hash_key], [`first_seen]) t
+  type user_commands = ([ `user_commands_hash_key ], [ `first_seen ]) t
 
-  type receipt_chain_hash = ([`receipt_chain_hashes_hash_key], [`hash]) t
+  type receipt_chain_hash = ([ `receipt_chain_hashes_hash_key ], [ `hash ]) t
 
-  type snark_jobs = ([`snark_jobs_job1_job2_key], [`job1 | `job2]) t
+  type snark_jobs = ([ `snark_jobs_job1_job2_key ], [ `job1 | `job2 ]) t
 
   type blocks_user_commands =
-    ( [`blocks_user_commands_block_id_user_command_id_receipt_chain_has]
+    ( [ `blocks_user_commands_block_id_user_command_id_receipt_chain_has ]
     , void )
     t
 
   type blocks_fee_transfers =
-    ([`blocks_fee_transfers_block_id_fee_transfer_id_key], void) t
+    ([ `blocks_fee_transfers_block_id_fee_transfer_id_key ], void) t
 
   type block_snark_jobs =
-    ([`blocks_snark_jobs_block_id_snark_job_id_key], void) t
+    ([ `blocks_snark_jobs_block_id_snark_job_id_key ], void) t
 
-  type state_hashes = ([`state_hashes_value_key], [`value]) t
+  type state_hashes = ([ `state_hashes_value_key ], [ `value ]) t
 
-  type blocks = ([`blocks_state_hash_key], [`block_length]) t
+  type blocks = ([ `blocks_state_hash_key ], [ `block_length ]) t
 
-  let public_keys : public_keys = create `public_keys_value_key [`value]
+  let public_keys : public_keys = create `public_keys_value_key [ `value ]
 
-  let state_hashes : state_hashes = create `state_hashes_value_key [`value]
+  let state_hashes : state_hashes = create `state_hashes_value_key [ `value ]
 
   let user_commands : user_commands =
-    create `user_commands_hash_key [`first_seen]
+    create `user_commands_hash_key [ `first_seen ]
 
   let fee_transfers : fee_transfers =
-    create `fee_transfers_hash_key [`first_seen]
+    create `fee_transfers_hash_key [ `first_seen ]
 
-  let snark_jobs : snark_jobs = create `snark_jobs_job1_job2_key [`job1; `job2]
+  let snark_jobs : snark_jobs =
+    create `snark_jobs_job1_job2_key [ `job1; `job2 ]
 
   let receipt_chain_hash : receipt_chain_hash =
-    create `receipt_chain_hashes_hash_key [`hash]
+    create `receipt_chain_hashes_hash_key [ `hash ]
 
   let blocks_user_commands : blocks_user_commands =
     create `blocks_user_commands_block_id_user_command_id_receipt_chain_has []
@@ -73,37 +74,35 @@ type bit = Yojson.Basic.t
 type user_command_type = Yojson.Basic.t
 
 type public_keys_insert_input =
-  < blocks: blocks_arr_rel_insert_input option
-  ; fee_transfers: fee_transfers_arr_rel_insert_input option
-  ; snark_jobs: snark_jobs_arr_rel_insert_input option
-  ; userCommandsByReceiver: user_commands_arr_rel_insert_input option
-  ; user_commands: user_commands_arr_rel_insert_input option
-  ; value: string option >
+  < blocks : blocks_arr_rel_insert_input option
+  ; fee_transfers : fee_transfers_arr_rel_insert_input option
+  ; snark_jobs : snark_jobs_arr_rel_insert_input option
+  ; userCommandsByReceiver : user_commands_arr_rel_insert_input option
+  ; user_commands : user_commands_arr_rel_insert_input option
+  ; value : string option >
 
 and public_keys_obj_rel_insert_input =
   (public_keys_insert_input, On_conflict.public_keys) Rel_insert_input.t
 
 and fee_transfers_insert_input =
-  < blocks_fee_transfers: blocks_fee_transfers_arr_rel_insert_input option
-  ; fee: bit option
-  ; first_seen: bit option
-  ; hash: string option
-  ; public_key: public_keys_obj_rel_insert_input option
-  ; receiver: int option >
+  < blocks_fee_transfers : blocks_fee_transfers_arr_rel_insert_input option
+  ; fee : bit option
+  ; first_seen : bit option
+  ; hash : string option
+  ; public_key : public_keys_obj_rel_insert_input option
+  ; receiver : int option >
 
 and fee_transfers_obj_rel_insert_input =
   (fee_transfers_insert_input, On_conflict.fee_transfers) Rel_insert_input.t
 
 and fee_transfers_arr_rel_insert_input =
-  ( fee_transfers_insert_input
-  , On_conflict.fee_transfers )
-  Rel_insert_input.array
+  (fee_transfers_insert_input, On_conflict.fee_transfers) Rel_insert_input.array
 
 and receipt_chain_hashes_insert_input =
-  < blocks_user_commands: blocks_user_commands_arr_rel_insert_input option
-  ; hash: string option
-  ; receipt_chain_hash: receipt_chain_hashes_obj_rel_insert_input option
-  ; receipt_chain_hashes: receipt_chain_hashes_arr_rel_insert_input option >
+  < blocks_user_commands : blocks_user_commands_arr_rel_insert_input option
+  ; hash : string option
+  ; receipt_chain_hash : receipt_chain_hashes_obj_rel_insert_input option
+  ; receipt_chain_hashes : receipt_chain_hashes_arr_rel_insert_input option >
 
 and receipt_chain_hashes_obj_rel_insert_input =
   ( receipt_chain_hashes_insert_input
@@ -116,21 +115,21 @@ and receipt_chain_hashes_arr_rel_insert_input =
   Rel_insert_input.array
 
 and user_commands_insert_input =
-  < amount: bit option
-  ; blocks_user_commands: blocks_user_commands_arr_rel_insert_input option
-  ; fee: bit option
-  ; first_seen: bit option
-  ; hash: string option
-  ; memo: string option
-  ; nonce: bit option
-  ; publicKeyByReceiver: public_keys_obj_rel_insert_input option
-  ; public_key: public_keys_obj_rel_insert_input option
-  ; typ: user_command_type option >
+  < amount : bit option
+  ; blocks_user_commands : blocks_user_commands_arr_rel_insert_input option
+  ; fee : bit option
+  ; first_seen : bit option
+  ; hash : string option
+  ; memo : string option
+  ; nonce : bit option
+  ; publicKeyByReceiver : public_keys_obj_rel_insert_input option
+  ; public_key : public_keys_obj_rel_insert_input option
+  ; typ : user_command_type option >
 
 and state_hashes_insert_input =
-  < block: blocks_obj_rel_insert_input option
-  ; blocks: blocks_arr_rel_insert_input option
-  ; value: string option >
+  < block : blocks_obj_rel_insert_input option
+  ; blocks : blocks_arr_rel_insert_input option
+  ; value : string option >
 
 and state_hashes_obj_rel_insert_input =
   (state_hashes_insert_input, On_conflict.state_hashes) Rel_insert_input.t
@@ -139,17 +138,15 @@ and user_commands_obj_rel_insert_input =
   (user_commands_insert_input, On_conflict.user_commands) Rel_insert_input.t
 
 and user_commands_arr_rel_insert_input =
-  ( user_commands_insert_input
-  , On_conflict.user_commands )
-  Rel_insert_input.array
+  (user_commands_insert_input, On_conflict.user_commands) Rel_insert_input.array
 
 and snark_jobs_insert_input =
-  < blocks_snark_jobs: blocks_snark_jobs_arr_rel_insert_input option
-  ; fee: bit option
-  ; job1: int option
-  ; job2: int option
-  ; prover: int option
-  ; public_key: public_keys_obj_rel_insert_input option >
+  < blocks_snark_jobs : blocks_snark_jobs_arr_rel_insert_input option
+  ; fee : bit option
+  ; job1 : int option
+  ; job2 : int option
+  ; prover : int option
+  ; public_key : public_keys_obj_rel_insert_input option >
 
 and snark_jobs_obj_rel_insert_input =
   (snark_jobs_insert_input, On_conflict.snark_jobs) Rel_insert_input.t
@@ -158,10 +155,10 @@ and snark_jobs_arr_rel_insert_input =
   (snark_jobs_insert_input, On_conflict.snark_jobs) Rel_insert_input.array
 
 and blocks_fee_transfers_insert_input =
-  < block: blocks_obj_rel_insert_input option
-  ; block_id: int option
-  ; fee_transfer: fee_transfers_obj_rel_insert_input option
-  ; fee_transfer_id: int option >
+  < block : blocks_obj_rel_insert_input option
+  ; block_id : int option
+  ; fee_transfer : fee_transfers_obj_rel_insert_input option
+  ; fee_transfer_id : int option >
 
 and blocks_fee_transfers_obj_rel_insert_input =
   ( blocks_fee_transfers_insert_input
@@ -174,9 +171,9 @@ and blocks_fee_transfers_arr_rel_insert_input =
   Rel_insert_input.array
 
 and blocks_user_commands_insert =
-  < block: blocks_obj_rel_insert_input option
-  ; receipt_chain_hash: receipt_chain_hashes_obj_rel_insert_input option
-  ; user_command: user_commands_obj_rel_insert_input option >
+  < block : blocks_obj_rel_insert_input option
+  ; receipt_chain_hash : receipt_chain_hashes_obj_rel_insert_input option
+  ; user_command : user_commands_obj_rel_insert_input option >
 
 and blocks_user_commands_arr_rel_insert_input =
   ( blocks_user_commands_insert
@@ -184,10 +181,10 @@ and blocks_user_commands_arr_rel_insert_input =
   Rel_insert_input.array
 
 and blocks_snark_jobs_insert_input =
-  < block: blocks_obj_rel_insert_input option
-  ; block_id: int option
-  ; snark_job: snark_jobs_obj_rel_insert_input option
-  ; snark_job_id: int option >
+  < block : blocks_obj_rel_insert_input option
+  ; block_id : int option
+  ; snark_job : snark_jobs_obj_rel_insert_input option
+  ; snark_job_id : int option >
 
 and blocks_snark_jobs_arr_rel_insert_input =
   ( blocks_snark_jobs_insert_input
@@ -195,18 +192,18 @@ and blocks_snark_jobs_arr_rel_insert_input =
   Rel_insert_input.array
 
 and blocks_insert_input =
-  < block_length: bit option
-  ; block_time: bit option
-  ; blocks_fee_transfers: blocks_fee_transfers_arr_rel_insert_input option
-  ; blocks_snark_jobs: blocks_snark_jobs_arr_rel_insert_input option
-  ; blocks_user_commands: blocks_user_commands_arr_rel_insert_input option
-  ; global_slot: int option
-  ; ledger_hash: string option
-  ; ledger_proof_nonce: int option
-  ; public_key: public_keys_obj_rel_insert_input option
-  ; stateHashByParentHash: state_hashes_obj_rel_insert_input option
-  ; stateHashByStateHash: state_hashes_obj_rel_insert_input option
-  ; status: int option >
+  < block_length : bit option
+  ; block_time : bit option
+  ; blocks_fee_transfers : blocks_fee_transfers_arr_rel_insert_input option
+  ; blocks_snark_jobs : blocks_snark_jobs_arr_rel_insert_input option
+  ; blocks_user_commands : blocks_user_commands_arr_rel_insert_input option
+  ; global_slot : int option
+  ; ledger_hash : string option
+  ; ledger_proof_nonce : int option
+  ; public_key : public_keys_obj_rel_insert_input option
+  ; stateHashByParentHash : state_hashes_obj_rel_insert_input option
+  ; stateHashByStateHash : state_hashes_obj_rel_insert_input option
+  ; status : int option >
 
 and blocks_obj_rel_insert_input =
   (blocks_insert_input, On_conflict.blocks) Rel_insert_input.t

--- a/src/app/archive/archive_lib/diff.ml
+++ b/src/app/archive/archive_lib/diff.ml
@@ -11,16 +11,16 @@ module Transition_frontier = struct
     module V1 = struct
       type t =
         | Breadcrumb_added of
-            { block:
+            { block :
                 ( External_transition.Stable.V1.t
                 , State_hash.Stable.V1.t )
                 With_hash.Stable.V1.t
-            ; sender_receipt_chains_from_parent_ledger:
+            ; sender_receipt_chains_from_parent_ledger :
                 (Account_id.Stable.V1.t * Receipt.Chain_hash.Stable.V1.t) list
             }
         | Root_transitioned of
             Transition_frontier.Diff.Root_transition.Lite.Stable.V1.t
-        | Bootstrap of {lost_blocks: State_hash.Stable.V1.t list}
+        | Bootstrap of { lost_blocks : State_hash.Stable.V1.t list }
 
       let to_latest = Fn.id
     end
@@ -32,8 +32,9 @@ module Transaction_pool = struct
   module Stable = struct
     module V1 = struct
       type t =
-        { added: User_command.Stable.V1.t list
-        ; removed: User_command.Stable.V1.t list }
+        { added : User_command.Stable.V1.t list
+        ; removed : User_command.Stable.V1.t list
+        }
 
       let to_latest = Fn.id
     end
@@ -60,8 +61,8 @@ module Builder = struct
     let sender_receipt_chains_from_parent_ledger =
       let senders =
         commands
-        |> List.map ~f:(fun {data; _} ->
-               User_command.(fee_payer (forget_check data)) )
+        |> List.map ~f:(fun { data; _ } ->
+               User_command.(fee_payer (forget_check data)))
         |> Account_id.Set.of_list
       in
       let ledger =
@@ -74,14 +75,14 @@ module Builder = struct
                let%bind ledger_location =
                  Ledger.location_of_account ledger sender
                in
-               let%map {receipt_chain_hash; _} =
+               let%map { receipt_chain_hash; _ } =
                  Ledger.get ledger ledger_location
                in
-               (sender, receipt_chain_hash)) )
+               (sender, receipt_chain_hash)))
     in
     Transition_frontier.Breadcrumb_added
-      {block; sender_receipt_chains_from_parent_ledger}
+      { block; sender_receipt_chains_from_parent_ledger }
 
   let user_commands user_commands =
-    Transaction_pool {Transaction_pool.added= user_commands; removed= []}
+    Transaction_pool { Transaction_pool.added = user_commands; removed = [] }
 end

--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -19,31 +19,32 @@ module User_command = struct
       top-level Transaction.t
   *)
   type t =
-    { sequence_no: int
-    ; typ: string
-    ; fee_payer: Public_key.Compressed.Stable.Latest.t
-    ; source: Public_key.Compressed.Stable.Latest.t
-    ; receiver: Public_key.Compressed.Stable.Latest.t
-    ; fee_token: Token_id.Stable.Latest.t
-    ; token: Token_id.Stable.Latest.t
-    ; nonce: Account.Nonce.Stable.Latest.t
-    ; amount: Currency.Amount.Stable.Latest.t option
-    ; fee: Currency.Fee.Stable.Latest.t
-    ; valid_until: Mina_numbers.Global_slot.Stable.Latest.t option
-    ; memo: Signed_command_memo.Stable.Latest.t
-    ; hash: Transaction_hash.Stable.Latest.t
+    { sequence_no : int
+    ; typ : string
+    ; fee_payer : Public_key.Compressed.Stable.Latest.t
+    ; source : Public_key.Compressed.Stable.Latest.t
+    ; receiver : Public_key.Compressed.Stable.Latest.t
+    ; fee_token : Token_id.Stable.Latest.t
+    ; token : Token_id.Stable.Latest.t
+    ; nonce : Account.Nonce.Stable.Latest.t
+    ; amount : Currency.Amount.Stable.Latest.t option
+    ; fee : Currency.Fee.Stable.Latest.t
+    ; valid_until : Mina_numbers.Global_slot.Stable.Latest.t option
+    ; memo : Signed_command_memo.Stable.Latest.t
+    ; hash : Transaction_hash.Stable.Latest.t
           [@to_yojson Transaction_hash.to_yojson]
           [@of_yojson Transaction_hash.of_yojson]
-    ; status: string
-    ; failure_reason: Transaction_status.Failure.Stable.Latest.t option
-    ; source_balance: Currency.Balance.Stable.Latest.t option
-    ; fee_payer_account_creation_fee_paid:
+    ; status : string
+    ; failure_reason : Transaction_status.Failure.Stable.Latest.t option
+    ; source_balance : Currency.Balance.Stable.Latest.t option
+    ; fee_payer_account_creation_fee_paid :
         Currency.Amount.Stable.Latest.t option
-    ; fee_payer_balance: Currency.Balance.Stable.Latest.t
-    ; receiver_account_creation_fee_paid:
+    ; fee_payer_balance : Currency.Balance.Stable.Latest.t
+    ; receiver_account_creation_fee_paid :
         Currency.Amount.Stable.Latest.t option
-    ; receiver_balance: Currency.Balance.Stable.Latest.t option
-    ; created_token: Token_id.Stable.Latest.t option }
+    ; receiver_balance : Currency.Balance.Stable.Latest.t option
+    ; created_token : Token_id.Stable.Latest.t option
+    }
   [@@deriving yojson, equal, bin_io_unversioned]
 end
 
@@ -52,36 +53,38 @@ module Internal_command = struct
      no existing string conversion for the original OCaml type
   *)
   type t =
-    { sequence_no: int
-    ; secondary_sequence_no: int
-    ; typ: string
-    ; receiver: Public_key.Compressed.Stable.Latest.t
-    ; receiver_balance: Currency.Balance.Stable.Latest.t
-    ; fee: Currency.Fee.Stable.Latest.t
-    ; token: Token_id.Stable.Latest.t
-    ; hash: Transaction_hash.Stable.Latest.t
+    { sequence_no : int
+    ; secondary_sequence_no : int
+    ; typ : string
+    ; receiver : Public_key.Compressed.Stable.Latest.t
+    ; receiver_balance : Currency.Balance.Stable.Latest.t
+    ; fee : Currency.Fee.Stable.Latest.t
+    ; token : Token_id.Stable.Latest.t
+    ; hash : Transaction_hash.Stable.Latest.t
           [@to_yojson Transaction_hash.to_yojson]
-          [@of_yojson Transaction_hash.of_yojson] }
+          [@of_yojson Transaction_hash.of_yojson]
+    }
   [@@deriving yojson, equal, bin_io_unversioned]
 end
 
 module Block = struct
   type t =
-    { state_hash: State_hash.Stable.Latest.t
-    ; parent_hash: State_hash.Stable.Latest.t
-    ; creator: Public_key.Compressed.Stable.Latest.t
-    ; block_winner: Public_key.Compressed.Stable.Latest.t
-    ; snarked_ledger_hash: Frozen_ledger_hash.Stable.Latest.t
-    ; staking_epoch_seed: Epoch_seed.Stable.Latest.t
-    ; staking_epoch_ledger_hash: Frozen_ledger_hash.Stable.Latest.t
-    ; next_epoch_seed: Epoch_seed.Stable.Latest.t
-    ; next_epoch_ledger_hash: Frozen_ledger_hash.Stable.Latest.t
-    ; ledger_hash: Ledger_hash.Stable.Latest.t
-    ; height: Unsigned_extended.UInt32.Stable.Latest.t
-    ; global_slot: Mina_numbers.Global_slot.Stable.Latest.t
-    ; global_slot_since_genesis: Mina_numbers.Global_slot.Stable.Latest.t
-    ; timestamp: Block_time.Stable.Latest.t
-    ; user_cmds: User_command.t list
-    ; internal_cmds: Internal_command.t list }
+    { state_hash : State_hash.Stable.Latest.t
+    ; parent_hash : State_hash.Stable.Latest.t
+    ; creator : Public_key.Compressed.Stable.Latest.t
+    ; block_winner : Public_key.Compressed.Stable.Latest.t
+    ; snarked_ledger_hash : Frozen_ledger_hash.Stable.Latest.t
+    ; staking_epoch_seed : Epoch_seed.Stable.Latest.t
+    ; staking_epoch_ledger_hash : Frozen_ledger_hash.Stable.Latest.t
+    ; next_epoch_seed : Epoch_seed.Stable.Latest.t
+    ; next_epoch_ledger_hash : Frozen_ledger_hash.Stable.Latest.t
+    ; ledger_hash : Ledger_hash.Stable.Latest.t
+    ; height : Unsigned_extended.UInt32.Stable.Latest.t
+    ; global_slot : Mina_numbers.Global_slot.Stable.Latest.t
+    ; global_slot_since_genesis : Mina_numbers.Global_slot.Stable.Latest.t
+    ; timestamp : Block_time.Stable.Latest.t
+    ; user_cmds : User_command.t list
+    ; internal_cmds : Internal_command.t list
+    }
   [@@deriving yojson, equal, bin_io_unversioned]
 end

--- a/src/app/archive/archive_lib/graphql_query/base_types.ml
+++ b/src/app/archive/archive_lib/graphql_query/base_types.ml
@@ -34,7 +34,7 @@ end = struct
 end
 
 module User_command_type = struct
-  type t = [`Payment | `Delegation]
+  type t = [ `Payment | `Delegation ]
 
   let encode = function
     | `Payment ->

--- a/src/app/archive/archive_lib/metrics.ml
+++ b/src/app/archive/archive_lib/metrics.ml
@@ -24,7 +24,7 @@ module Max_block_height = struct
         Mina_metrics.(
           Gauge.set
             (Archive.max_block_height metric_server)
-            (Float.of_int max_height)) )
+            (Float.of_int max_height)))
 end
 
 module Missing_blocks = struct
@@ -48,7 +48,7 @@ module Missing_blocks = struct
         Mina_metrics.(
           Gauge.set
             (Archive.missing_blocks metric_server)
-            (Float.of_int missing_blocks)) )
+            (Float.of_int missing_blocks)))
 end
 
 module Unparented_blocks = struct
@@ -68,26 +68,26 @@ module Unparented_blocks = struct
         Mina_metrics.(
           Gauge.set
             (Archive.unparented_blocks metric_server)
-            (Float.of_int unparented_block_count)) )
+            (Float.of_int unparented_block_count)))
 end
 
 let log_error ~logger pool metric_server
     (f :
          (module Caqti_async.CONNECTION)
       -> Mina_metrics.Archive.t
-      -> (unit, [> Caqti_error.call_or_retrieve]) Deferred.Result.t) =
+      -> (unit, [> Caqti_error.call_or_retrieve ]) Deferred.Result.t) =
   let open Deferred.Let_syntax in
   match%map
     Caqti_async.Pool.use
       (fun (module Conn : Caqti_async.CONNECTION) ->
-        f (module Conn) metric_server )
+        f (module Conn) metric_server)
       pool
   with
   | Ok () ->
       ()
   | Error e ->
       [%log warn] "Error updating archive metrics: $error"
-        ~metadata:[("error", `String (Caqti_error.show e))]
+        ~metadata:[ ("error", `String (Caqti_error.show e)) ]
 
 let update ~logger ~missing_blocks_width pool metric_server =
   Deferred.all_unit
@@ -95,4 +95,5 @@ let update ~logger ~missing_blocks_width pool metric_server =
        ~f:(log_error ~logger pool metric_server)
        [ Max_block_height.update
        ; Unparented_blocks.update
-       ; Missing_blocks.update ~missing_blocks_width ])
+       ; Missing_blocks.update ~missing_blocks_width
+       ])

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -46,8 +46,8 @@ module Caqti_type_spec = struct
          x :: tuple_to_hlist spec t
 end
 
-let rec vector : type t n.
-    n Nat.t -> t Caqti_type.t -> (t, n) Vector.t Caqti_type.t =
+let rec vector :
+    type t n. n Nat.t -> t Caqti_type.t -> (t, n) Vector.t Caqti_type.t =
  fun n t ->
   match n with
   | Z ->
@@ -113,20 +113,21 @@ end
 
 module Timing_info = struct
   type t =
-    { public_key_id: int
-    ; token: int64
-    ; initial_balance: int64
-    ; initial_minimum_balance: int64
-    ; cliff_time: int64
-    ; cliff_amount: int64
-    ; vesting_period: int64
-    ; vesting_increment: int64 }
+    { public_key_id : int
+    ; token : int64
+    ; initial_balance : int64
+    ; initial_minimum_balance : int64
+    ; cliff_time : int64
+    ; cliff_amount : int64
+    ; vesting_period : int64
+    ; vesting_increment : int64
+    }
   [@@deriving hlist]
 
   let typ =
     let open Caqti_type_spec in
     let spec =
-      Caqti_type.[int; int64; int64; int64; int64; int64; int64; int64]
+      Caqti_type.[ int; int64; int64; int64; int64; int64; int64; int64 ]
     in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
@@ -187,23 +188,25 @@ module Timing_info = struct
           | Timed timing ->
               { public_key_id
               ; token
-              ; initial_balance= balance_to_int64 acc.balance
-              ; initial_minimum_balance=
+              ; initial_balance = balance_to_int64 acc.balance
+              ; initial_minimum_balance =
                   balance_to_int64 timing.initial_minimum_balance
-              ; cliff_time= slot_to_int64 timing.cliff_time
-              ; cliff_amount= amount_to_int64 timing.cliff_amount
-              ; vesting_period= slot_to_int64 timing.vesting_period
-              ; vesting_increment= amount_to_int64 timing.vesting_increment }
+              ; cliff_time = slot_to_int64 timing.cliff_time
+              ; cliff_amount = amount_to_int64 timing.cliff_amount
+              ; vesting_period = slot_to_int64 timing.vesting_period
+              ; vesting_increment = amount_to_int64 timing.vesting_increment
+              }
           | Untimed ->
               let zero = Int64.zero in
               { public_key_id
               ; token
-              ; initial_balance= balance_to_int64 acc.balance
-              ; initial_minimum_balance= zero
-              ; cliff_time= zero
-              ; cliff_amount= zero
-              ; vesting_period= zero
-              ; vesting_increment= zero }
+              ; initial_balance = balance_to_int64 acc.balance
+              ; initial_minimum_balance = zero
+              ; cliff_time = zero
+              ; cliff_amount = zero
+              ; vesting_period = zero
+              ; vesting_increment = zero
+              }
         in
         Conn.find
           (Caqti_request.find typ Caqti_type.int
@@ -224,8 +227,8 @@ module Snarked_ledger_hash = struct
          "SELECT id FROM snarked_ledger_hashes WHERE value = ?")
       hash
 
-  let add_if_doesn't_exist (module Conn : CONNECTION)
-      (t : Frozen_ledger_hash.t) =
+  let add_if_doesn't_exist (module Conn : CONNECTION) (t : Frozen_ledger_hash.t)
+      =
     let open Deferred.Result.Let_syntax in
     let hash = Frozen_ledger_hash.to_string t in
     match%bind
@@ -244,11 +247,11 @@ module Snarked_ledger_hash = struct
 end
 
 module Epoch_data = struct
-  type t = {seed: string; ledger_hash_id: int}
+  type t = { seed : string; ledger_hash_id : int }
 
   let typ =
     let encode t = Ok (t.seed, t.ledger_hash_id) in
-    let decode (seed, ledger_hash_id) = Ok {seed; ledger_hash_id} in
+    let decode (seed, ledger_hash_id) = Ok { seed; ledger_hash_id } in
     let rep = Caqti_type.(tup2 string int) in
     Caqti_type.custom ~encode ~decode rep
 
@@ -261,7 +264,7 @@ module Epoch_data = struct
       Conn.find_opt
         (Caqti_request.find_opt typ Caqti_type.int
            "SELECT id FROM epoch_data WHERE seed = ? AND ledger_hash_id = ?")
-        {seed; ledger_hash_id}
+        { seed; ledger_hash_id }
     with
     | Some id ->
         return id
@@ -271,12 +274,12 @@ module Epoch_data = struct
              {sql| INSERT INTO epoch_data (seed, ledger_hash_id) VALUES (?, ?)
                    RETURNING id
              |sql})
-          {seed; ledger_hash_id}
+          { seed; ledger_hash_id }
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (t : Mina_base.Epoch_data.Value.t) =
     let open Deferred.Result.Let_syntax in
-    let Mina_base.Epoch_ledger.Poly.{hash; _} =
+    let Mina_base.Epoch_ledger.Poly.{ hash; _ } =
       Mina_base.Epoch_data.Poly.ledger t
     in
     let%bind ledger_hash_id =
@@ -291,18 +294,19 @@ end
 module User_command = struct
   module Signed_command = struct
     type t =
-      { typ: string
-      ; fee_payer_id: int
-      ; source_id: int
-      ; receiver_id: int
-      ; fee_token: int64
-      ; token: int64
-      ; nonce: int
-      ; amount: int64 option
-      ; fee: int64
-      ; valid_until: int64 option
-      ; memo: string
-      ; hash: string }
+      { typ : string
+      ; fee_payer_id : int
+      ; source_id : int
+      ; receiver_id : int
+      ; fee_token : int64
+      ; token : int64
+      ; nonce : int
+      ; amount : int64 option
+      ; fee : int64
+      ; valid_until : int64 option
+      ; memo : string
+      ; hash : string
+      }
     [@@deriving hlist]
 
     let typ =
@@ -320,14 +324,15 @@ module User_command = struct
           ; int64
           ; option int64
           ; string
-          ; string ]
+          ; string
+          ]
       in
       let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
       let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
       Caqti_type.custom ~encode ~decode (to_rep spec)
 
-    let find (module Conn : CONNECTION)
-        ~(transaction_hash : Transaction_hash.t) =
+    let find (module Conn : CONNECTION) ~(transaction_hash : Transaction_hash.t)
+        =
       Conn.find_opt
         (Caqti_request.find_opt Caqti_type.string Caqti_type.int
            "SELECT id FROM user_commands WHERE hash = ?")
@@ -345,7 +350,7 @@ module User_command = struct
         id
 
     type balance_public_key_ids =
-      {fee_payer_id: int; source_id: int; receiver_id: int}
+      { fee_payer_id : int; source_id : int; receiver_id : int }
 
     let add_balance_public_keys_if_don't_exist (module Conn : CONNECTION)
         (t : Signed_command.t) =
@@ -365,19 +370,17 @@ module User_command = struct
           (module Conn)
           (Signed_command.receiver_pk t)
       in
-      {fee_payer_id; source_id; receiver_id}
+      { fee_payer_id; source_id; receiver_id }
 
     let add_if_doesn't_exist ?(via = `Ident) (module Conn : CONNECTION)
         (t : Signed_command.t) =
       let open Deferred.Result.Let_syntax in
-      let transaction_hash =
-        Transaction_hash.hash_command (Signed_command t)
-      in
+      let transaction_hash = Transaction_hash.hash_command (Signed_command t) in
       match%bind find (module Conn) ~transaction_hash with
       | Some user_command_id ->
           return user_command_id
       | None ->
-          let%bind {fee_payer_id; source_id; receiver_id} =
+          let%bind { fee_payer_id; source_id; receiver_id } =
             add_balance_public_keys_if_don't_exist (module Conn) t
           in
           let valid_until =
@@ -397,7 +400,7 @@ module User_command = struct
                       valid_until, memo, hash)
                     VALUES (?::user_command_type, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     RETURNING id |sql})
-            { typ=
+            { typ =
                 ( match via with
                 | `Ident ->
                     Signed_command.tag_string t
@@ -406,25 +409,25 @@ module User_command = struct
             ; fee_payer_id
             ; source_id
             ; receiver_id
-            ; fee_token=
+            ; fee_token =
                 Signed_command.fee_token t |> Token_id.to_uint64
                 |> Unsigned.UInt64.to_int64
-            ; token=
+            ; token =
                 Signed_command.token t |> Token_id.to_uint64
                 |> Unsigned.UInt64.to_int64
-            ; nonce= Signed_command.nonce t |> Unsigned.UInt32.to_int
-            ; amount=
+            ; nonce = Signed_command.nonce t |> Unsigned.UInt32.to_int
+            ; amount =
                 Signed_command.amount t
                 |> Core.Option.map ~f:(fun amt ->
-                       Currency.Amount.to_uint64 amt
-                       |> Unsigned.UInt64.to_int64 )
-            ; fee=
+                       Currency.Amount.to_uint64 amt |> Unsigned.UInt64.to_int64)
+            ; fee =
                 ( Signed_command.fee t
                 |> fun amt ->
                 Currency.Fee.to_uint64 amt |> Unsigned.UInt64.to_int64 )
             ; valid_until
-            ; memo= Signed_command.memo t |> Signed_command_memo.to_string
-            ; hash= transaction_hash |> Transaction_hash.to_base58_check }
+            ; memo = Signed_command.memo t |> Signed_command_memo.to_string
+            ; hash = transaction_hash |> Transaction_hash.to_base58_check
+            }
   end
 
   let as_signed_command (t : User_command.t) : Mina_base.Signed_command.t =
@@ -433,28 +436,32 @@ module User_command = struct
         c
     | Snapp_command c ->
         let module S = Mina_base.Snapp_command in
-        let ({source; receiver; amount} : S.transfer) = S.as_transfer c in
+        let ({ source; receiver; amount } : S.transfer) = S.as_transfer c in
         let fee_payer = S.fee_payer c in
-        { signature= Signature.dummy
-        ; signer= Snark_params.Tick.Field.(zero, zero)
-        ; payload=
-            { common=
-                { fee= S.fee_exn c
-                ; fee_token= Account_id.token_id fee_payer
-                ; fee_payer_pk= Account_id.public_key fee_payer
-                ; nonce=
+        { signature = Signature.dummy
+        ; signer = Snark_params.Tick.Field.(zero, zero)
+        ; payload =
+            { common =
+                { fee = S.fee_exn c
+                ; fee_token = Account_id.token_id fee_payer
+                ; fee_payer_pk = Account_id.public_key fee_payer
+                ; nonce =
                     Option.value (S.nonce c)
                       ~default:Mina_numbers.Account_nonce.zero
-                ; valid_until= Mina_numbers.Global_slot.max_value
-                ; memo= Signed_command_memo.create_from_string_exn "snapp" }
-            ; body=
+                ; valid_until = Mina_numbers.Global_slot.max_value
+                ; memo = Signed_command_memo.create_from_string_exn "snapp"
+                }
+            ; body =
                 Payment
-                  { source_pk= source
-                  ; receiver_pk= receiver
-                  ; token_id= S.token_id c
-                  ; amount } } }
+                  { source_pk = source
+                  ; receiver_pk = receiver
+                  ; token_id = S.token_id c
+                  ; amount
+                  }
+            }
+        }
 
-  let via (t : User_command.t) : [`Snapp_command | `Ident] =
+  let via (t : User_command.t) : [ `Snapp_command | `Ident ] =
     match t with
     | Signed_command _ ->
         `Ident
@@ -492,25 +499,26 @@ module User_command = struct
                     VALUES (?::user_command_type, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     RETURNING id
          |sql})
-      { typ= user_cmd.typ
+      { typ = user_cmd.typ
       ; fee_payer_id
       ; source_id
       ; receiver_id
-      ; fee_token=
+      ; fee_token =
           user_cmd.fee_token |> Token_id.to_uint64 |> Unsigned.UInt64.to_int64
-      ; token= user_cmd.token |> Token_id.to_uint64 |> Unsigned.UInt64.to_int64
-      ; nonce= user_cmd.nonce |> Unsigned.UInt32.to_int
-      ; amount= user_cmd.amount |> amount_opt_to_int64_opt
-      ; fee=
+      ; token = user_cmd.token |> Token_id.to_uint64 |> Unsigned.UInt64.to_int64
+      ; nonce = user_cmd.nonce |> Unsigned.UInt32.to_int
+      ; amount = user_cmd.amount |> amount_opt_to_int64_opt
+      ; fee =
           user_cmd.fee
           |> Fn.compose Unsigned.UInt64.to_int64 Currency.Fee.to_uint64
-      ; valid_until=
+      ; valid_until =
           Option.map user_cmd.valid_until
             ~f:
               (Fn.compose Unsigned.UInt32.to_int64
                  Mina_numbers.Global_slot.to_uint32)
-      ; memo= user_cmd.memo |> Signed_command_memo.to_string
-      ; hash= user_cmd.hash |> Transaction_hash.to_base58_check }
+      ; memo = user_cmd.memo |> Signed_command_memo.to_string
+      ; hash = user_cmd.hash |> Transaction_hash.to_base58_check
+      }
 
   let add_extensional_if_doesn't_exist (module Conn : CONNECTION)
       (user_cmd : Extensional.User_command.t) =
@@ -524,12 +532,17 @@ end
 
 module Internal_command = struct
   type t =
-    {typ: string; receiver_id: int; fee: int64; token: int64; hash: string}
+    { typ : string
+    ; receiver_id : int
+    ; fee : int64
+    ; token : int64
+    ; hash : string
+    }
 
   let typ =
     let encode t = Ok ((t.typ, t.receiver_id, t.fee, t.token), t.hash) in
     let decode ((typ, receiver_id, fee, token), hash) =
-      Ok {typ; receiver_id; fee; token; hash}
+      Ok { typ; receiver_id; fee; token; hash }
     in
     let rep = Caqti_type.(tup2 (tup4 string int int64 int64) string) in
     Caqti_type.custom ~encode ~decode rep
@@ -540,7 +553,8 @@ module Internal_command = struct
       (Caqti_request.find_opt
          Caqti_type.(tup2 string string)
          Caqti_type.int
-         "SELECT id FROM internal_commands WHERE hash = $1 AND type = $2::internal_command_type")
+         "SELECT id FROM internal_commands WHERE hash = $1 AND type = \
+          $2::internal_command_type")
       (Transaction_hash.to_base58_check transaction_hash, typ)
 
   let load (module Conn : CONNECTION) ~(id : int) =
@@ -573,20 +587,21 @@ module Internal_command = struct
                    VALUES (?::internal_command_type, ?, ?, ?, ?)
                    RETURNING id
              |sql})
-          { typ= internal_cmd.typ
+          { typ = internal_cmd.typ
           ; receiver_id
-          ; fee=
+          ; fee =
               internal_cmd.fee |> Currency.Fee.to_uint64
               |> Unsigned.UInt64.to_int64
-          ; token=
+          ; token =
               internal_cmd.token |> Token_id.to_uint64
               |> Unsigned.UInt64.to_int64
-          ; hash= internal_cmd.hash |> Transaction_hash.to_base58_check }
+          ; hash = internal_cmd.hash |> Transaction_hash.to_base58_check
+          }
 end
 
 module Fee_transfer = struct
   module Kind = struct
-    type t = [`Normal | `Via_coinbase]
+    type t = [ `Normal | `Via_coinbase ]
 
     let to_string : t -> string = function
       | `Normal ->
@@ -596,7 +611,12 @@ module Fee_transfer = struct
   end
 
   type t =
-    {kind: Kind.t; receiver_id: int; fee: int; token: int64; hash: string}
+    { kind : Kind.t
+    ; receiver_id : int
+    ; fee : int
+    ; token : int64
+    ; hash : string
+    }
 
   let typ =
     let encode t =
@@ -614,13 +634,13 @@ module Fee_transfer = struct
         | s ->
             Result.fail (sprintf "Bad kind %s in decode attempt" s)
       in
-      Ok {kind; receiver_id; fee; token; hash}
+      Ok { kind; receiver_id; fee; token; hash }
     in
     let rep = Caqti_type.(tup2 (tup4 string int int int64) string) in
     Caqti_type.custom ~encode ~decode rep
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
-      (t : Fee_transfer.Single.t) (kind : [`Normal | `Via_coinbase]) =
+      (t : Fee_transfer.Single.t) (kind : [ `Normal | `Via_coinbase ]) =
     let open Deferred.Result.Let_syntax in
     let transaction_hash = Transaction_hash.hash_fee_transfer t in
     match%bind
@@ -645,13 +665,14 @@ module Fee_transfer = struct
              |sql})
           { kind
           ; receiver_id
-          ; fee= Fee_transfer.Single.fee t |> Currency.Fee.to_int
-          ; token= Token_id.to_string t.fee_token |> Int64.of_string
-          ; hash= transaction_hash |> Transaction_hash.to_base58_check }
+          ; fee = Fee_transfer.Single.fee t |> Currency.Fee.to_int
+          ; token = Token_id.to_string t.fee_token |> Int64.of_string
+          ; hash = transaction_hash |> Transaction_hash.to_base58_check
+          }
 end
 
 module Coinbase = struct
-  type t = {receiver_id: int; amount: int; hash: string}
+  type t = { receiver_id : int; amount : int; hash : string }
 
   let coinbase_typ = "coinbase"
 
@@ -665,7 +686,7 @@ module Coinbase = struct
         , t.hash )
     in
     let decode ((_, receiver_id, amount, _), hash) =
-      Ok {receiver_id; amount; hash}
+      Ok { receiver_id; amount; hash }
     in
     let rep = Caqti_type.(tup2 (tup4 string int int int64) string) in
     Caqti_type.custom ~encode ~decode rep
@@ -680,9 +701,7 @@ module Coinbase = struct
         return internal_command_id
     | None ->
         let%bind receiver_id =
-          Public_key.add_if_doesn't_exist
-            (module Conn)
-            (Coinbase.receiver_pk t)
+          Public_key.add_if_doesn't_exist (module Conn) (Coinbase.receiver_pk t)
         in
         Conn.find
           (Caqti_request.find typ Caqti_type.int
@@ -692,16 +711,17 @@ module Coinbase = struct
                    RETURNING id
              |sql})
           { receiver_id
-          ; amount= Coinbase.amount t |> Currency.Amount.to_int
-          ; hash= transaction_hash |> Transaction_hash.to_base58_check }
+          ; amount = Coinbase.amount t |> Currency.Amount.to_int
+          ; hash = transaction_hash |> Transaction_hash.to_base58_check
+          }
 end
 
 module Balance = struct
-  type t = {id: int; public_key_id: int; balance: int64} [@@deriving hlist]
+  type t = { id : int; public_key_id : int; balance : int64 } [@@deriving hlist]
 
   let typ =
     let open Caqti_type_spec in
-    let spec = Caqti_type.[int; int; int64] in
+    let spec = Caqti_type.[ int; int; int64 ] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
     Caqti_type.custom ~encode ~decode (to_rep spec)
@@ -752,22 +772,23 @@ end
 
 module Block_and_internal_command = struct
   type t =
-    { block_id: int
-    ; internal_command_id: int
-    ; sequence_no: int
-    ; secondary_sequence_no: int
-    ; receiver_balance_id: int }
+    { block_id : int
+    ; internal_command_id : int
+    ; sequence_no : int
+    ; secondary_sequence_no : int
+    ; receiver_balance_id : int
+    }
   [@@deriving hlist]
 
   let typ =
     let open Caqti_type_spec in
-    let spec = Caqti_type.[int; int; int; int; int] in
+    let spec = Caqti_type.[ int; int; int; int; int ] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
     Caqti_type.custom ~encode ~decode (to_rep spec)
 
-  let add (module Conn : CONNECTION) ~block_id ~internal_command_id
-      ~sequence_no ~secondary_sequence_no ~receiver_balance_id =
+  let add (module Conn : CONNECTION) ~block_id ~internal_command_id ~sequence_no
+      ~secondary_sequence_no ~receiver_balance_id =
     Conn.exec
       (Caqti_request.exec typ
          {sql| INSERT INTO blocks_internal_commands
@@ -778,7 +799,8 @@ module Block_and_internal_command = struct
       ; internal_command_id
       ; sequence_no
       ; secondary_sequence_no
-      ; receiver_balance_id }
+      ; receiver_balance_id
+      }
 
   let find (module Conn : CONNECTION) ~block_id ~internal_command_id
       ~sequence_no ~secondary_sequence_no =
@@ -814,17 +836,18 @@ end
 
 module Block_and_signed_command = struct
   type t =
-    { block_id: int
-    ; user_command_id: int
-    ; sequence_no: int
-    ; status: string
-    ; failure_reason: string option
-    ; fee_payer_account_creation_fee_paid: int64 option
-    ; receiver_account_creation_fee_paid: int64 option
-    ; created_token: int64 option
-    ; fee_payer_balance_id: int
-    ; source_balance_id: int option
-    ; receiver_balance_id: int option }
+    { block_id : int
+    ; user_command_id : int
+    ; sequence_no : int
+    ; status : string
+    ; failure_reason : string option
+    ; fee_payer_account_creation_fee_paid : int64 option
+    ; receiver_account_creation_fee_paid : int64 option
+    ; created_token : int64 option
+    ; fee_payer_balance_id : int
+    ; source_balance_id : int option
+    ; receiver_balance_id : int option
+    }
   [@@deriving hlist]
 
   let typ =
@@ -841,7 +864,8 @@ module Block_and_signed_command = struct
         ; option int64
         ; int
         ; option int
-        ; option int ]
+        ; option int
+        ]
     in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
@@ -865,7 +889,7 @@ module Block_and_signed_command = struct
     in
     let created_token =
       Option.map created_token ~f:(fun tid ->
-          Unsigned.UInt64.to_int64 (Token_id.to_uint64 tid) )
+          Unsigned.UInt64.to_int64 (Token_id.to_uint64 tid))
     in
     Conn.exec
       (Caqti_request.exec typ
@@ -893,7 +917,8 @@ module Block_and_signed_command = struct
       ; created_token
       ; fee_payer_balance_id
       ; source_balance_id
-      ; receiver_balance_id }
+      ; receiver_balance_id
+      }
 
   let add_with_status (module Conn : CONNECTION) ~block_id ~user_command_id
       ~sequence_no ~(status : Transaction_status.t) ~fee_payer_id ~source_id
@@ -906,12 +931,14 @@ module Block_and_signed_command = struct
         , created_token
         , { Transaction_status.Balance_data.fee_payer_balance
           ; source_balance
-          ; receiver_balance } ) =
+          ; receiver_balance
+          } ) =
       match status with
       | Applied
           ( { fee_payer_account_creation_fee_paid
             ; receiver_account_creation_fee_paid
-            ; created_token }
+            ; created_token
+            }
           , balances ) ->
           ( "applied"
           , None
@@ -950,13 +977,13 @@ module Block_and_signed_command = struct
     in
     add
       (module Conn)
-      ~block_id ~user_command_id ~sequence_no ~status:status_str
-      ~failure_reason ~fee_payer_account_creation_fee_paid
-      ~receiver_account_creation_fee_paid ~created_token ~fee_payer_balance_id
-      ~source_balance_id ~receiver_balance_id
+      ~block_id ~user_command_id ~sequence_no ~status:status_str ~failure_reason
+      ~fee_payer_account_creation_fee_paid ~receiver_account_creation_fee_paid
+      ~created_token ~fee_payer_balance_id ~source_balance_id
+      ~receiver_balance_id
 
-  let add_if_doesn't_exist (module Conn : CONNECTION) ~block_id
-      ~user_command_id ~sequence_no ~(status : string) ~failure_reason
+  let add_if_doesn't_exist (module Conn : CONNECTION) ~block_id ~user_command_id
+      ~sequence_no ~(status : string) ~failure_reason
       ~fee_payer_account_creation_fee_paid ~receiver_account_creation_fee_paid
       ~created_token ~fee_payer_balance_id ~source_balance_id
       ~receiver_balance_id =
@@ -1006,19 +1033,20 @@ end
 
 module Block = struct
   type t =
-    { state_hash: string
-    ; parent_id: int option
-    ; parent_hash: string
-    ; creator_id: int
-    ; block_winner_id: int
-    ; snarked_ledger_hash_id: int
-    ; staking_epoch_data_id: int
-    ; next_epoch_data_id: int
-    ; ledger_hash: string
-    ; height: int64
-    ; global_slot: int64
-    ; global_slot_since_genesis: int64
-    ; timestamp: int64 }
+    { state_hash : string
+    ; parent_id : int option
+    ; parent_hash : string
+    ; creator_id : int
+    ; block_winner_id : int
+    ; snarked_ledger_hash_id : int
+    ; staking_epoch_data_id : int
+    ; next_epoch_data_id : int
+    ; ledger_hash : string
+    ; height : int64
+    ; global_slot : int64
+    ; global_slot_since_genesis : int64
+    ; timestamp : int64
+    }
   [@@deriving hlist]
 
   let typ =
@@ -1037,7 +1065,8 @@ module Block = struct
         ; int64
         ; int64
         ; int64
-        ; int64 ]
+        ; int64
+        ]
     in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
@@ -1115,9 +1144,9 @@ module Block = struct
                       global_slot_since_genesis, timestamp)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
                |sql})
-            { state_hash= hash |> State_hash.to_string
+            { state_hash = hash |> State_hash.to_string
             ; parent_id
-            ; parent_hash=
+            ; parent_hash =
                 Protocol_state.previous_state_hash protocol_state
                 |> State_hash.to_string
             ; creator_id
@@ -1125,24 +1154,25 @@ module Block = struct
             ; snarked_ledger_hash_id
             ; staking_epoch_data_id
             ; next_epoch_data_id
-            ; ledger_hash=
+            ; ledger_hash =
                 Protocol_state.blockchain_state protocol_state
                 |> Blockchain_state.staged_ledger_hash
                 |> Staged_ledger_hash.ledger_hash |> Ledger_hash.to_string
-            ; height=
+            ; height =
                 consensus_state
                 |> Consensus.Data.Consensus_state.blockchain_length
                 |> Unsigned.UInt32.to_int64
-            ; global_slot=
+            ; global_slot =
                 Consensus.Data.Consensus_state.curr_global_slot consensus_state
                 |> Unsigned.UInt32.to_int64
-            ; global_slot_since_genesis=
+            ; global_slot_since_genesis =
                 consensus_state
                 |> Consensus.Data.Consensus_state.global_slot_since_genesis
                 |> Unsigned.UInt32.to_int64
-            ; timestamp=
+            ; timestamp =
                 Protocol_state.blockchain_state protocol_state
-                |> Blockchain_state.timestamp |> Block_time.to_int64 }
+                |> Blockchain_state.timestamp |> Block_time.to_int64
+            }
         in
         let transactions =
           let coinbase_receiver =
@@ -1164,16 +1194,17 @@ module Block = struct
           deferred_result_list_fold transactions ~init:0 ~f:(fun sequence_no ->
             function
             | { Mina_base.With_status.status
-              ; data= Mina_base.Transaction.Command command } ->
+              ; data = Mina_base.Transaction.Command command
+              } ->
                 let user_command =
-                  {Mina_base.With_status.status; data= command}
+                  { Mina_base.With_status.status; data = command }
                 in
                 let%bind id =
                   User_command.add_if_doesn't_exist
                     (module Conn)
                     user_command.data
                 in
-                let%bind {fee_payer_id; source_id; receiver_id} =
+                let%bind { fee_payer_id; source_id; receiver_id } =
                   User_command.Signed_command
                   .add_balance_public_keys_if_don't_exist
                     (module Conn)
@@ -1188,7 +1219,7 @@ module Block = struct
                   >>| ignore
                 in
                 sequence_no + 1
-            | {data= Fee_transfer fee_transfer_bundled; status} ->
+            | { data = Fee_transfer fee_transfer_bundled; status } ->
                 let balances =
                   Transaction_status.Fee_transfer_balance_data
                   .of_balance_data_exn
@@ -1210,16 +1241,17 @@ module Block = struct
                           fee_transfer `Normal
                       in
                       (id, secondary_sequence_no, fee_transfer.receiver_pk)
-                      :: acc )
+                      :: acc)
                 in
                 let fee_transfer_infos_with_balances =
                   match fee_transfer_infos with
-                  | [id] ->
-                      [(id, balances.receiver1_balance)]
-                  | [id2; id1] ->
+                  | [ id ] ->
+                      [ (id, balances.receiver1_balance) ]
+                  | [ id2; id1 ] ->
                       (* the fold reverses the order of the infos from the fee transfers *)
                       [ (id1, balances.receiver1_balance)
-                      ; (id2, Option.value_exn balances.receiver2_balance) ]
+                      ; (id2, Option.value_exn balances.receiver2_balance)
+                      ]
                   | _ ->
                       failwith
                         "Unexpected number of single fee transfers in a fee \
@@ -1228,9 +1260,10 @@ module Block = struct
                 let%map () =
                   deferred_result_list_fold fee_transfer_infos_with_balances
                     ~init:()
-                    ~f:(fun ()
-                       ( (fee_transfer_id, secondary_sequence_no, receiver_pk)
-                       , balance )
+                    ~f:(fun
+                         ()
+                         ( (fee_transfer_id, secondary_sequence_no, receiver_pk)
+                         , balance )
                        ->
                       let%bind receiver_id =
                         Public_key.add_if_doesn't_exist
@@ -1245,12 +1278,11 @@ module Block = struct
                       Block_and_internal_command.add
                         (module Conn)
                         ~block_id ~internal_command_id:fee_transfer_id
-                        ~sequence_no ~secondary_sequence_no
-                        ~receiver_balance_id
-                      >>| ignore )
+                        ~sequence_no ~secondary_sequence_no ~receiver_balance_id
+                      >>| ignore)
                 in
                 sequence_no + 1
-            | {data= Coinbase coinbase; status} ->
+            | { data = Coinbase coinbase; status } ->
                 let balances =
                   Transaction_status.Coinbase_balance_data.of_balance_data_exn
                     (Transaction_status.balance_data status)
@@ -1259,7 +1291,7 @@ module Block = struct
                   match Mina_base.Coinbase.fee_transfer coinbase with
                   | None ->
                       return ()
-                  | Some {receiver_pk; fee} ->
+                  | Some { receiver_pk; fee } ->
                       let fee_transfer =
                         Mina_base.Fee_transfer.Single.create ~receiver_pk ~fee
                           ~fee_token:Token_id.default
@@ -1309,12 +1341,12 @@ module Block = struct
                     ~secondary_sequence_no:0 ~receiver_balance_id
                   >>| ignore
                 in
-                sequence_no + 1 )
+                sequence_no + 1)
         in
         return block_id
 
   let add_if_doesn't_exist conn ~constraint_constants
-      ({data= t; hash} : (External_transition.t, State_hash.t) With_hash.t) =
+      ({ data = t; hash } : (External_transition.t, State_hash.t) With_hash.t) =
     add_parts_if_doesn't_exist conn ~constraint_constants
       ~protocol_state:(External_transition.protocol_state t)
       ~staged_ledger_diff:(External_transition.staged_ledger_diff t)
@@ -1379,20 +1411,21 @@ module Block = struct
                       global_slot_since_genesis, timestamp)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
                |sql})
-            { state_hash= block.state_hash |> State_hash.to_string
+            { state_hash = block.state_hash |> State_hash.to_string
             ; parent_id
-            ; parent_hash= block.parent_hash |> State_hash.to_string
+            ; parent_hash = block.parent_hash |> State_hash.to_string
             ; creator_id
             ; block_winner_id
             ; snarked_ledger_hash_id
             ; staking_epoch_data_id
             ; next_epoch_data_id
-            ; ledger_hash= block.ledger_hash |> Ledger_hash.to_string
-            ; height= block.height |> Unsigned.UInt32.to_int64
-            ; global_slot= block.global_slot |> Unsigned.UInt32.to_int64
-            ; global_slot_since_genesis=
+            ; ledger_hash = block.ledger_hash |> Ledger_hash.to_string
+            ; height = block.height |> Unsigned.UInt32.to_int64
+            ; global_slot = block.global_slot |> Unsigned.UInt32.to_int64
+            ; global_slot_since_genesis =
                 block.global_slot_since_genesis |> Unsigned.UInt32.to_int64
-            ; timestamp= block.timestamp |> Block_time.to_int64 }
+            ; timestamp = block.timestamp |> Block_time.to_int64
+            }
     in
     (* add user commands *)
     let%bind user_cmds_with_ids =
@@ -1404,7 +1437,7 @@ module Block = struct
                 (module Conn)
                 user_cmd
             in
-            cmd_id :: acc )
+            cmd_id :: acc)
       in
       List.zip_exn block.user_cmds (List.rev user_cmd_ids_rev)
     in
@@ -1418,7 +1451,7 @@ module Block = struct
       Option.value_map balance_opt ~default:(Deferred.Result.return None)
         ~f:(fun balance ->
           let%map id = balance_id_of_pk_and_balance pk balance in
-          Some id )
+          Some id)
     in
     (* add user commands to join table *)
     let%bind () =
@@ -1446,7 +1479,7 @@ module Block = struct
             ~receiver_account_creation_fee_paid:
               user_command.receiver_account_creation_fee_paid
             ~created_token:user_command.created_token ~fee_payer_balance_id
-            ~source_balance_id ~receiver_balance_id )
+            ~source_balance_id ~receiver_balance_id)
     in
     (* add internal commands *)
     let%bind internal_cmds_ids_and_seq_nos =
@@ -1458,20 +1491,21 @@ module Block = struct
                 (module Conn)
                 internal_cmd
             in
-            (internal_cmd, cmd_id) :: acc )
+            (internal_cmd, cmd_id) :: acc)
       in
       let sequence_nos =
         List.map block.internal_cmds ~f:(fun internal_cmd ->
-            (internal_cmd.sequence_no, internal_cmd.secondary_sequence_no) )
+            (internal_cmd.sequence_no, internal_cmd.secondary_sequence_no))
       in
       List.zip_exn (List.rev internal_cmds_and_ids_rev) sequence_nos
     in
     (* add internal commands to join table *)
     let%bind () =
       deferred_result_list_fold internal_cmds_ids_and_seq_nos ~init:()
-        ~f:(fun ()
-           ( (internal_command, internal_command_id)
-           , (sequence_no, secondary_sequence_no) )
+        ~f:(fun
+             ()
+             ( (internal_command, internal_command_id)
+             , (sequence_no, secondary_sequence_no) )
            ->
           let%bind receiver_balance_id =
             balance_id_of_pk_and_balance internal_command.receiver
@@ -1480,7 +1514,7 @@ module Block = struct
           Block_and_internal_command.add_if_doesn't_exist
             (module Conn)
             ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
-            ~receiver_balance_id )
+            ~receiver_balance_id)
     in
     return block_id
 
@@ -1535,8 +1569,8 @@ module Block = struct
         Conn.exec
           (Caqti_request.exec
              Caqti_type.(tup2 int int64)
-             "DELETE FROM blocks WHERE blocks.height < ? OR blocks.timestamp \
-              < ?")
+             "DELETE FROM blocks WHERE blocks.height < ? OR blocks.timestamp < \
+              ?")
           (height, timestamp)
       in
       let%bind () =
@@ -1582,7 +1616,7 @@ let retry ~f ~logger ~error_str retries =
         if retry_count <= 0 then return (Error e)
         else (
           [%log warn] "Error in %s : $error. Retrying..." error_str
-            ~metadata:[("error", `String (Caqti_error.show e))] ;
+            ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
           let wait_for = Random.float_range 20. 2000. in
           let%bind () = after (Time.Span.of_ms wait_for) in
           go (retry_count - 1) )
@@ -1601,8 +1635,8 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
           let%bind () = Conn.start () in
           let%bind block_id = add_block (module Conn : CONNECTION) block in
           (* if an existing block has a parent hash that's for the block just added,
-       set its parent id
-      *)
+             set its parent id
+          *)
           let%bind () =
             Block.set_parent_id_if_null
               (module Conn)
@@ -1620,14 +1654,14 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
             [%log warn]
               "Error when adding block data to the database, rolling it back: \
                $error"
-              ~metadata:[("error", `String (Caqti_error.show e))] ;
+              ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
             let%map _ = Conn.rollback () in
             err
         | Ok _ ->
             [%log info] "Committing block data for $state_hash"
               ~metadata:
-                [("state_hash", Mina_base.State_hash.to_yojson (hash block))] ;
-            Conn.commit () )
+                [ ("state_hash", Mina_base.State_hash.to_yojson (hash block)) ] ;
+            Conn.commit ())
       pool
   in
   retry ~f:add ~logger ~error_str:"add_block_aux" retries
@@ -1636,7 +1670,7 @@ let add_block_aux_precomputed ~constraint_constants =
   add_block_aux ~add_block:(Block.add_from_precomputed ~constraint_constants)
     ~hash:(fun block ->
       block.External_transition.Precomputed_block.protocol_state
-      |> Protocol_state.hash )
+      |> Protocol_state.hash)
 
 let add_block_aux_extensional =
   add_block_aux ~add_block:Block.add_from_extensional
@@ -1644,7 +1678,7 @@ let add_block_aux_extensional =
 
 let run pool reader ~constraint_constants ~logger ~delete_older_than =
   Strict_pipe.Reader.iter reader ~f:(function
-    | Diff.Transition_frontier (Breadcrumb_added {block; _}) -> (
+    | Diff.Transition_frontier (Breadcrumb_added { block; _ }) -> (
         let add_block = Block.add_if_doesn't_exist ~constraint_constants in
         let hash block = With_hash.hash block in
         match%map
@@ -1654,13 +1688,14 @@ let run pool reader ~constraint_constants ~logger ~delete_older_than =
             [%log warn]
               ~metadata:
                 [ ("block", With_hash.hash block |> State_hash.to_yojson)
-                ; ("error", `String (Caqti_error.show e)) ]
+                ; ("error", `String (Caqti_error.show e))
+                ]
               "Failed to archive block: $block, see $error"
         | Ok () ->
             () )
     | Transition_frontier _ ->
         Deferred.return ()
-    | Transaction_pool {added; removed= _} ->
+    | Transaction_pool { added; removed = _ } ->
         let%map _ =
           Caqti_async.Pool.use
             (fun (module Conn : CONNECTION) ->
@@ -1676,17 +1711,18 @@ let run pool reader ~constraint_constants ~logger ~delete_older_than =
                           ~metadata:
                             [ ("error", `String (Caqti_error.show e))
                             ; ( "command"
-                              , Mina_base.User_command.to_yojson command ) ]
+                              , Mina_base.User_command.to_yojson command )
+                            ]
                           "Failed to archive user command $command from \
-                           transaction pool: $block, see $error" )
+                           transaction pool: $block, see $error")
               in
-              Ok () )
+              Ok ())
             pool
         in
-        () )
+        ())
 
-let add_genesis_accounts ~logger
-    ~(runtime_config_opt : Runtime_config.t option) pool =
+let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
+    pool =
   match runtime_config_opt with
   | None ->
       Deferred.unit
@@ -1696,17 +1732,17 @@ let add_genesis_accounts ~logger
         | Some (Accounts accounts) ->
             Genesis_ledger_helper.Accounts.to_full accounts
         | Some (Named name) -> (
-          match Genesis_ledger.fetch_ledger name with
-          | Some (module M) ->
-              [%log info] "Found ledger with name $ledger_name"
-                ~metadata:[("ledger_name", `String name)] ;
-              Lazy.force M.accounts
-          | None ->
-              [%log error]
-                "Could not find a built-in ledger named $ledger_name"
-                ~metadata:[("ledger_name", `String name)] ;
-              failwith "Could not add genesis accounts: Named ledger not found"
-          )
+            match Genesis_ledger.fetch_ledger name with
+            | Some (module M) ->
+                [%log info] "Found ledger with name $ledger_name"
+                  ~metadata:[ ("ledger_name", `String name) ] ;
+                Lazy.force M.accounts
+            | None ->
+                [%log error]
+                  "Could not find a built-in ledger named $ledger_name"
+                  ~metadata:[ ("ledger_name", `String name) ] ;
+                failwith
+                  "Could not add genesis accounts: Named ledger not found" )
         | _ ->
             failwith "No accounts found in runtime config file"
       in
@@ -1728,7 +1764,8 @@ let add_genesis_accounts ~logger
                       [%log error]
                         ~metadata:
                           [ ("account", Account.to_yojson account)
-                          ; ("error", `String (Caqti_error.show e)) ]
+                          ; ("error", `String (Caqti_error.show e))
+                          ]
                         "Failed to add genesis account: $account, see $error" ;
                       let%map _ = Conn.rollback () in
                       err
@@ -1736,7 +1773,7 @@ let add_genesis_accounts ~logger
                       go accounts' )
             in
             let%bind () = go accounts in
-            Conn.commit () )
+            Conn.commit ())
           pool
       in
       match%map
@@ -1744,7 +1781,7 @@ let add_genesis_accounts ~logger
       with
       | Error e ->
           [%log warn] "genesis accounts could not be added"
-            ~metadata:[("error", `String (Caqti_error.show e))] ;
+            ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
           failwith "Failed to add genesis accounts"
       | Ok () ->
           () )
@@ -1789,21 +1826,20 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
   in
   let implementations =
     [ Async.Rpc.Rpc.implement Archive_rpc.t (fun () archive_diff ->
-          Strict_pipe.Writer.write writer archive_diff )
+          Strict_pipe.Writer.write writer archive_diff)
     ; Async.Rpc.Rpc.implement Archive_rpc.precomputed_block
         (fun () precomputed_block ->
-          Strict_pipe.Writer.write precomputed_block_writer precomputed_block
-      )
+          Strict_pipe.Writer.write precomputed_block_writer precomputed_block)
     ; Async.Rpc.Rpc.implement Archive_rpc.extensional_block
         (fun () extensional_block ->
-          Strict_pipe.Writer.write extensional_block_writer extensional_block
-      ) ]
+          Strict_pipe.Writer.write extensional_block_writer extensional_block)
+    ]
   in
   match Caqti_async.connect_pool ~max_size:30 postgres_address with
   | Error e ->
       [%log error]
         "Failed to create a Caqti pool for Postgresql, see error: $error"
-        ~metadata:[("error", `String (Caqti_error.show e))] ;
+        ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
       Deferred.unit
   | Ok pool ->
       let%bind () = add_genesis_accounts pool ~logger ~runtime_config_opt in
@@ -1822,9 +1858,10 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                   [ ( "block"
                     , Protocol_state.hash precomputed_block.protocol_state
                       |> State_hash.to_yojson )
-                  ; ("error", `String (Caqti_error.show e)) ]
+                  ; ("error", `String (Caqti_error.show e))
+                  ]
           | Ok () ->
-              () )
+              ())
       |> don't_wait_for ;
       Strict_pipe.Reader.iter extensional_block_reader
         ~f:(fun extensional_block ->
@@ -1838,9 +1875,10 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                 ~metadata:
                   [ ( "block"
                     , extensional_block.state_hash |> State_hash.to_yojson )
-                  ; ("error", `String (Caqti_error.show e)) ]
+                  ; ("error", `String (Caqti_error.show e))
+                  ]
           | Ok () ->
-              () )
+              ())
       |> don't_wait_for ;
       Deferred.ignore_m
       @@ Tcp.Server.create
@@ -1851,7 +1889,8 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                    "Exception while handling TCP server request: $error"
                    ~metadata:
                      [ ("error", `String (Core.Exn.to_string_mach exn))
-                     ; ("context", `String "rpc_tcp_server") ] ))
+                     ; ("context", `String "rpc_tcp_server")
+                     ]))
            where_to_listen
            (fun address reader writer ->
              let address = Socket.Address.Inet.addr address in
@@ -1870,8 +1909,9 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                          [ ("error", `String (Core.Exn.to_string_mach exn))
                          ; ("context", `String "rpc_server")
                          ; ( "address"
-                           , `String (Unix.Inet_addr.to_string address) ) ] ;
-                     Deferred.unit )) )
+                           , `String (Unix.Inet_addr.to_string address) )
+                         ] ;
+                     Deferred.unit)))
       |> don't_wait_for ;
       (*Update archive metrics*)
       create_metrics_server ~logger ~metrics_server_port ~missing_blocks_width
@@ -1885,7 +1925,7 @@ module For_test = struct
     let open Deferred.Result.Let_syntax in
     match parent_id with
     | Some id ->
-        let%map Block.{state_hash= actual; _} = Block.load conn ~id in
+        let%map Block.{ state_hash = actual; _ } = Block.load conn ~id in
         [%test_result: string]
           ~expect:(parent_hash |> State_hash.to_base58_check)
           actual

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -11,7 +11,7 @@ let%test_module "Archive node unit tests" =
     let proof_level = Genesis_constants.Proof_level.None
 
     let precomputed_values =
-      {(Lazy.force Precomputed_values.for_unit_tests) with proof_level}
+      { (Lazy.force Precomputed_values.for_unit_tests) with proof_level }
 
     let constraint_constants = precomputed_values.constraint_constants
 
@@ -19,7 +19,7 @@ let%test_module "Archive node unit tests" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ()))
 
     module Genesis_ledger = (val Genesis_ledger.for_unit_tests)
 
@@ -51,8 +51,7 @@ let%test_module "Archive node unit tests" =
         ~fee_range:10 ()
 
     let fee_transfer_gen =
-      Fee_transfer.Single.Gen.with_random_receivers ~keys ~min_fee:0
-        ~max_fee:10
+      Fee_transfer.Single.Gen.with_random_receivers ~keys ~min_fee:0 ~max_fee:10
         ~token:(Quickcheck.Generator.return Token_id.default)
 
     let coinbase_gen =
@@ -82,7 +81,7 @@ let%test_module "Archive node unit tests" =
           | Ok () ->
               ()
           | Error e ->
-              failwith @@ Caqti_error.show e )
+              failwith @@ Caqti_error.show e)
 
     let%test_unit "Fee_transfer: read and write" =
       let kind_gen =
@@ -95,7 +94,7 @@ let%test_module "Archive node unit tests" =
       Thread_safe.block_on_async_exn
       @@ fun () ->
       Async.Quickcheck.async_test
-        ~sexp_of:[%sexp_of: [`Normal | `Via_coinbase] * Fee_transfer.Single.t]
+        ~sexp_of:[%sexp_of: [ `Normal | `Via_coinbase ] * Fee_transfer.Single.t]
         (Quickcheck.Generator.tuple2 kind_gen fee_transfer_gen)
         ~f:(fun (kind, fee_transfer) ->
           let transaction_hash =
@@ -104,8 +103,7 @@ let%test_module "Archive node unit tests" =
           match%map
             let open Deferred.Result.Let_syntax in
             let%bind fee_transfer_id =
-              Processor.Fee_transfer.add_if_doesn't_exist conn fee_transfer
-                kind
+              Processor.Fee_transfer.add_if_doesn't_exist conn fee_transfer kind
             in
             let%map result =
               Processor.Internal_command.find conn ~transaction_hash
@@ -117,7 +115,7 @@ let%test_module "Archive node unit tests" =
           | Ok () ->
               ()
           | Error e ->
-              failwith @@ Caqti_error.show e )
+              failwith @@ Caqti_error.show e)
 
     let%test_unit "Coinbase: read and write" =
       let conn = Lazy.force conn_lazy in
@@ -140,7 +138,7 @@ let%test_module "Archive node unit tests" =
           | Ok () ->
               ()
           | Error e ->
-              failwith @@ Caqti_error.show e )
+              failwith @@ Caqti_error.show e)
 
     let%test_unit "Block: read and write" =
       let pool = Lazy.force conn_pool_lazy in
@@ -162,14 +160,14 @@ let%test_module "Archive node unit tests" =
           in
           let processor_deferred_computation =
             Processor.run
-              ~constraint_constants:precomputed_values.constraint_constants
-              pool reader ~logger ~delete_older_than:None
+              ~constraint_constants:precomputed_values.constraint_constants pool
+              reader ~logger ~delete_older_than:None
           in
           let diffs =
             List.map
               ~f:(fun breadcrumb ->
                 Diff.Transition_frontier
-                  (Diff.Builder.breadcrumb_added breadcrumb) )
+                  (Diff.Builder.breadcrumb_added breadcrumb))
               breadcrumbs
           in
           List.iter diffs ~f:(Strict_pipe.Writer.write writer) ;
@@ -187,7 +185,7 @@ let%test_module "Archive node unit tests" =
                           (Transition_frontier.Breadcrumb.state_hash breadcrumb)
                     with
                     | Some id ->
-                        let%bind Processor.Block.{parent_id; _} =
+                        let%bind Processor.Block.{ parent_id; _ } =
                           Processor.Block.load conn ~id
                         in
                         if
@@ -204,13 +202,13 @@ let%test_module "Archive node unit tests" =
                             conn
                         else Deferred.Result.return ()
                     | None ->
-                        failwith "Failed to find saved block in database" )
-                  pool )
+                        failwith "Failed to find saved block in database")
+                  pool)
           with
           | Ok () ->
               ()
           | Error e ->
-              failwith @@ Caqti_error.show e )
+              failwith @@ Caqti_error.show e)
 
     (*
     let%test_unit "Block: read and write with pruning" =

--- a/src/app/archive/cli/archive_cli.ml
+++ b/src/app/archive/cli/archive_cli.ml
@@ -10,13 +10,14 @@ let command_run =
      and log_level = Flag.Log.level
      and server_port = Flag.Port.Archive.server
      and metrics_server_port =
-       flag "--metrics-port" ~aliases:["-metrics-port"]
+       flag "--metrics-port" ~aliases:[ "-metrics-port" ]
          ~doc:
            "PORT metrics server for scraping via Prometheus (default no \
             metrics-server)"
          (optional Cli_lib.Arg_type.int16)
      and missing_blocks_width =
-       flag "--missing-blocks-width" ~aliases:["-missing-blocks-width"]
+       flag "--missing-blocks-width"
+         ~aliases:[ "-missing-blocks-width" ]
          ~doc:
            (sprintf
               "int The width of block heights within which missing blocks are \
@@ -28,10 +29,10 @@ let command_run =
          (optional int)
      and postgres = Flag.Uri.Archive.postgres
      and runtime_config_file =
-       flag "--config-file" ~aliases:["-config-file"] (optional string)
+       flag "--config-file" ~aliases:[ "-config-file" ] (optional string)
          ~doc:"PATH to the configuration file containing the genesis ledger"
      and delete_older_than =
-       flag "--delete-older-than" ~aliases:["-delete-older-than"]
+       flag "--delete-older-than" ~aliases:[ "-delete-older-than" ]
          (optional int)
          ~doc:
            "int Delete blocks that are more than n blocks lower than the \
@@ -40,7 +41,7 @@ let command_run =
      let runtime_config_opt =
        Option.map runtime_config_file ~f:(fun file ->
            Yojson.Safe.from_file file |> Runtime_config.of_yojson
-           |> Result.ok_or_failwith )
+           |> Result.ok_or_failwith)
      in
      fun () ->
        let logger = Logger.create () in
@@ -62,16 +63,16 @@ let command_prune =
   let open Command.Let_syntax in
   Command.async ~summary:"Prune old blocks and their transactions"
     (let%map_open height =
-       flag "--height" ~aliases:["-height"] (optional int)
+       flag "--height" ~aliases:[ "-height" ] (optional int)
          ~doc:"int Delete blocks with height lower than the given height"
      and num_blocks =
-       flag "--num-blocks" ~aliases:["-num-blocks"] (optional int)
+       flag "--num-blocks" ~aliases:[ "-num-blocks" ] (optional int)
          ~doc:
            "int Delete blocks that are more than n blocks lower than the \
             maximum seen block. This argument is ignored if the --height \
             argument is also given"
      and timestamp =
-       flag "--timestamp" ~aliases:["-timestamp"] (optional time_arg)
+       flag "--timestamp" ~aliases:[ "-timestamp" ] (optional time_arg)
          ~doc:
            "timestamp Delete blocks that are older than the given timestamp. \
             Format: 2000-00-00 12:00:00+0100"
@@ -107,7 +108,8 @@ let command_prune =
            [ Option.map height ~f:(fun v -> ("height", `Int v))
            ; Option.map num_blocks ~f:(fun v -> ("num_blocks", `Int v))
            ; Option.map timestamp ~f:(fun v ->
-                 ("timestamp", `String (Int64.to_string v)) ) ]
+                 ("timestamp", `String (Int64.to_string v)))
+           ]
        in
        match%map.Async.Deferred go () with
        | Ok () ->
@@ -117,4 +119,4 @@ let command_prune =
              ~metadata:
                (("error", `String (Caqti_error.show err)) :: cmd_metadata))
 
-let commands = [("run", command_run); ("prune", command_prune)]
+let commands = [ ("run", command_run); ("prune", command_prune) ]

--- a/src/app/benchmarks/.ocamlformat
+++ b/src/app/benchmarks/.ocamlformat
@@ -1,0 +1,1 @@
+../../.ocamlformat

--- a/src/app/benchmarks/main.ml
+++ b/src/app/benchmarks/main.ml
@@ -7,7 +7,7 @@
 
 open Core_kernel
 
-let available_libraries = ["vrf_lib_tests"; "mina_base"]
+let available_libraries = [ "vrf_lib_tests"; "mina_base" ]
 
 let run_benchmarks_in_lib libname =
   Core.printf "Running inline tests in library \"%s\"\n%!" libname ;
@@ -22,7 +22,7 @@ let () =
       let bad_libnames = ref [] in
       List.iter chosen_libraries ~f:(fun lib ->
           if not (List.mem available_libraries lib ~equal:String.equal) then
-            bad_libnames := lib :: !bad_libnames ) ;
+            bad_libnames := lib :: !bad_libnames) ;
       if not (List.is_empty !bad_libnames) then (
         eprintf "These libraries not available for benchmarking: %s\n%!"
           (String.concat (List.rev !bad_libnames) ~sep:",") ;

--- a/src/app/logproc/.ocamlformat
+++ b/src/app/logproc/.ocamlformat
@@ -1,0 +1,1 @@
+../../.ocamlformat

--- a/src/app/reformat/.ocamlformat
+++ b/src/app/reformat/.ocamlformat
@@ -1,0 +1,1 @@
+../../.ocamlformat

--- a/src/app/reformat/reformat.ml
+++ b/src/app/reformat/reformat.ml
@@ -17,7 +17,8 @@ let dirs_trustlist =
   ; "zexe"
   ; "marlin"
   ; "snarky"
-  ; "_opam" ]
+  ; "_opam"
+  ]
 
 let rec fold_over_files ~path ~process_path ~init ~f =
   let%bind all = Sys.ls_dir path in
@@ -30,7 +31,7 @@ let rec fold_over_files ~path ~process_path ~init ~f =
       | _ when process_path `File (path ^/ x) ->
           f acc (path ^/ x)
       | _ ->
-          return acc )
+          return acc)
 
 let main dry_run check path =
   let%bind _all =
@@ -40,20 +41,20 @@ let main dry_run check path =
         | `Dir ->
             not
               (List.exists dirs_trustlist ~f:(fun s ->
-                   String.is_suffix ~suffix:s path ))
+                   String.is_suffix ~suffix:s path))
         | `File ->
             (not
                (List.exists trustlist ~f:(fun s ->
-                    String.is_suffix ~suffix:s path )))
+                    String.is_suffix ~suffix:s path)))
             && ( String.is_suffix ~suffix:".ml" path
-               || String.is_suffix ~suffix:".mli" path ) )
+               || String.is_suffix ~suffix:".mli" path ))
       ~f:(fun () file ->
         let dump prog args =
           printf !"%s %{sexp: string List.t}\n" prog args ;
           return ()
         in
         if check then
-          let prog, args = ("ocamlformat", ["--doc-comments=before"; file]) in
+          let prog, args = ("ocamlformat", [ "--doc-comments=before"; file ]) in
           let%bind formatted = Process.run_exn ~prog ~args () in
           let%bind raw = Reader.file_contents file in
           if not (String.equal formatted raw) then (
@@ -62,12 +63,12 @@ let main dry_run check path =
           else return ()
         else
           let prog, args =
-            ("ocamlformat", ["--doc-comments=before"; "-i"; file])
+            ("ocamlformat", [ "--doc-comments=before"; "-i"; file ])
           in
           if dry_run then dump prog args
           else
             let%map _stdout = Process.run_exn ~prog ~args () in
-            () )
+            ())
   in
   exit 0
 
@@ -75,11 +76,11 @@ let cli =
   let open Command.Let_syntax in
   Command.async ~summary:"Format all ml and mli files"
     (let%map_open path =
-       flag "--path" ~aliases:["path"] ~doc:"Path to traverse"
+       flag "--path" ~aliases:[ "path" ] ~doc:"Path to traverse"
          (required string)
-     and dry_run = flag "--dry-run" ~aliases:["dry-run"] no_arg ~doc:"Dry run"
+     and dry_run = flag "--dry-run" ~aliases:[ "dry-run" ] no_arg ~doc:"Dry run"
      and check =
-       flag "--check" ~aliases:["check"] no_arg
+       flag "--check" ~aliases:[ "check" ] no_arg
          ~doc:
            "Return with an error code if there exists an ml file that was \
             formatted improperly"

--- a/src/app/rosetta/.ocamlformat
+++ b/src/app/rosetta/.ocamlformat
@@ -1,0 +1,1 @@
+../../.ocamlformat

--- a/src/app/rosetta/lib/cli.ml
+++ b/src/app/rosetta/lib/cli.ml
@@ -21,7 +21,7 @@ let log_level =
              (*   |> String.concat ~sep:", " ) ; *)
              failwith "test"
          | Ok ll ->
-             ll ))
+             ll))
 
 let logger_setup log_json log_level =
   let stdout_log_processor =
@@ -29,9 +29,10 @@ let logger_setup log_json log_level =
     else
       Logger.Processor.pretty ~log_level
         ~config:
-          { Logproc_lib.Interpolator.mode= Inline
-          ; max_interpolation_length= 50
-          ; pretty_print= true }
+          { Logproc_lib.Interpolator.mode = Inline
+          ; max_interpolation_length = 50
+          ; pretty_print = true
+          }
   in
   Logger.Consumer_registry.register ~id:"default"
     ~processor:stdout_log_processor

--- a/src/app/rosetta/lib/graphql.ml
+++ b/src/app/rosetta/lib/graphql.ml
@@ -32,16 +32,16 @@ let query query_obj uri =
   let open Deferred.Result.Let_syntax in
   let headers =
     Cohttp.Header.of_list
-      [("Content-Type", "application/json"); ("Accept", "application/json")]
+      [ ("Content-Type", "application/json"); ("Accept", "application/json") ]
   in
   let%bind response, body =
     Deferred.Or_error.try_with ~here:[%here] ~extract_exn:true (fun () ->
         Cohttp_async.Client.post ~headers
           ~body:(Cohttp_async.Body.of_string body_string)
-          uri )
+          uri)
     |> Deferred.Result.map_error ~f:(fun e ->
            Errors.create ~context:"Internal POST to Coda Daemon failed"
-             (`Graphql_coda_query (Error.to_string_hum e)) )
+             (`Graphql_coda_query (Error.to_string_hum e)))
   in
   let%bind body_str =
     Cohttp_async.Body.to_string body |> Deferred.map ~f:Result.return
@@ -76,7 +76,7 @@ let query query_obj uri =
                ~context:"JSON parse error in response from Coda Daemon"
                (`Graphql_coda_query
                  (Printf.sprintf "Error parsing graphql response: %s"
-                    (Exn.to_string e))) ) )
+                    (Exn.to_string e)))) )
   |> Deferred.return
 
 module Decoders = struct

--- a/src/app/rosetta/lib/signer.ml
+++ b/src/app/rosetta/lib/signer.ml
@@ -9,10 +9,10 @@ module User_command = Mina_base.User_command
 module Signed_command = Mina_base.Signed_command
 
 module Keys = struct
-  type t = {keypair: Keypair.t; public_key_hex_bytes: string}
+  type t = { keypair : Keypair.t; public_key_hex_bytes : string }
 
   let of_keypair keypair =
-    {keypair; public_key_hex_bytes= Coding.of_public_key keypair.public_key}
+    { keypair; public_key_hex_bytes = Coding.of_public_key keypair.public_key }
 
   let to_private_key_bytes t = Coding.of_scalar t.keypair.private_key
 

--- a/src/app/rosetta/lib/test.ml
+++ b/src/app/rosetta/lib/test.ml
@@ -19,6 +19,6 @@ let assert_ ~f ~expected ~actual =
     let output =
       Yojson.Safe.pretty_to_string
         (`Assoc
-          [("expected", to_yojson expected); ("actual", to_yojson actual)])
+          [ ("expected", to_yojson expected); ("actual", to_yojson actual) ])
     in
     eprintf "%s" output ; failwith output

--- a/src/app/rosetta/lib/these.ml
+++ b/src/app/rosetta/lib/these.ml
@@ -1,3 +1,3 @@
 (** These allows you to represent one or another or both while keeping
  * neither unrepresentable *)
-type ('a, 'b) t = [`This of 'a | `That of 'b | `Those of 'a * 'b]
+type ('a, 'b) t = [ `This of 'a | `That of 'b | `Those of 'a * 'b ]

--- a/src/app/rosetta/ocaml-signer/signer.ml
+++ b/src/app/rosetta/ocaml-signer/signer.ml
@@ -2,6 +2,5 @@ open Async
 
 let () =
   Command.run
-    (Command.group
-       ~summary:"OCaml reference signer implementation for Rosetta."
+    (Command.group ~summary:"OCaml reference signer implementation for Rosetta."
        Signer_cli.commands)

--- a/src/app/rosetta/ocaml-signer/signer_cli.ml
+++ b/src/app/rosetta/ocaml-signer/signer_cli.ml
@@ -9,11 +9,10 @@ open Lib
 let sign_command =
   let open Command.Let_syntax in
   let%map_open unsigned_transaction =
-    flag "--unsigned-transaction" ~aliases:["unsigned-transaction"]
-      ~doc:"Unsigned transaction string returned from Rosetta"
-      (required string)
+    flag "--unsigned-transaction" ~aliases:[ "unsigned-transaction" ]
+      ~doc:"Unsigned transaction string returned from Rosetta" (required string)
   and private_key =
-    flag "--private-key" ~aliases:["private-key"] ~doc:"Private key hex bytes"
+    flag "--private-key" ~aliases:[ "private-key" ] ~doc:"Private key hex bytes"
       (required string)
   in
   let open Deferred.Let_syntax in
@@ -31,10 +30,10 @@ let sign_command =
 let verify_command =
   let open Command.Let_syntax in
   let%map_open signed_transaction =
-    flag "--signed-transaction" ~aliases:["signed-transaction"]
+    flag "--signed-transaction" ~aliases:[ "signed-transaction" ]
       ~doc:"Signed transaction string returned from Rosetta" (required string)
   and public_key =
-    flag "--public-key" ~aliases:["public-key"] ~doc:"Public key hex bytes"
+    flag "--public-key" ~aliases:[ "public-key" ] ~doc:"Public key hex bytes"
       (required string)
   in
   let open Deferred.Let_syntax in
@@ -55,7 +54,7 @@ let verify_command =
 let derive_command =
   let open Command.Let_syntax in
   let%map_open private_key =
-    flag "--private-key" ~aliases:["private-key"] ~doc:"Private key hex bytes"
+    flag "--private-key" ~aliases:[ "private-key" ] ~doc:"Private key hex bytes"
       (required string)
   in
   let open Deferred.Let_syntax in
@@ -84,4 +83,5 @@ let commands =
     , Command.async ~summary:"Import a private key, returns a public-key"
         derive_command )
   ; ( "generate-private-key"
-    , Command.async ~summary:"Generate a new private key" generate_command ) ]
+    , Command.async ~summary:"Generate a new private key" generate_command )
+  ]

--- a/src/app/rosetta/ocaml-signer/signer_mainnet_signatures.ml
+++ b/src/app/rosetta/ocaml-signer/signer_mainnet_signatures.ml
@@ -2,6 +2,5 @@ open Async
 
 let () =
   Command.run
-    (Command.group
-       ~summary:"OCaml reference signer implementation for Rosetta."
+    (Command.group ~summary:"OCaml reference signer implementation for Rosetta."
        Signer_cli.commands)

--- a/src/app/rosetta/ocaml-signer/signer_testnet_signatures.ml
+++ b/src/app/rosetta/ocaml-signer/signer_testnet_signatures.ml
@@ -2,6 +2,5 @@ open Async
 
 let () =
   Command.run
-    (Command.group
-       ~summary:"OCaml reference signer implementation for Rosetta."
+    (Command.group ~summary:"OCaml reference signer implementation for Rosetta."
        Signer_cli.commands)

--- a/src/app/rosetta/test-agent/offline.ml
+++ b/src/app/rosetta/test-agent/offline.ml
@@ -15,11 +15,13 @@ module Derive = struct
       post ~rosetta_uri ~logger
         ~body:
           Construction_derive_request.(
-            { network_identifier= net_id network_response
-            ; public_key=
-                { Public_key.hex_bytes= public_key_hex_bytes
-                ; curve_type= "pallas" }
-            ; metadata= Some Amount_of.Token_id.(encode default) }
+            { network_identifier = net_id network_response
+            ; public_key =
+                { Public_key.hex_bytes = public_key_hex_bytes
+                ; curve_type = "pallas"
+                }
+            ; metadata = Some Amount_of.Token_id.(encode default)
+            }
             |> to_yojson)
         ~path:"construction/derive"
     in
@@ -33,11 +35,12 @@ module Preprocess = struct
       post ~rosetta_uri ~logger
         ~body:
           Construction_preprocess_request.(
-            { network_identifier= net_id network_response
-            ; max_fee= [Amount_of.coda max_fee]
+            { network_identifier = net_id network_response
+            ; max_fee = [ Amount_of.coda max_fee ]
             ; operations
-            ; suggested_fee_multiplier= None
-            ; metadata= None }
+            ; suggested_fee_multiplier = None
+            ; metadata = None
+            }
             |> to_yojson)
         ~path:"construction/preprocess"
     in
@@ -51,10 +54,11 @@ module Payloads = struct
       post ~rosetta_uri ~logger
         ~body:
           Construction_payloads_request.(
-            { network_identifier= net_id network_response
+            { network_identifier = net_id network_response
             ; operations
-            ; metadata= Some metadata
-            ; public_keys= [] }
+            ; metadata = Some metadata
+            ; public_keys = []
+            }
             |> to_yojson)
         ~path:"construction/payloads"
     in
@@ -75,7 +79,10 @@ module Parse = struct
       post ~rosetta_uri ~logger
         ~body:
           Construction_parse_request.(
-            {network_identifier= net_id network_response; transaction; signed}
+            { network_identifier = net_id network_response
+            ; transaction
+            ; signed
+            }
             |> to_yojson)
         ~path:"construction/parse"
     in
@@ -90,20 +97,25 @@ module Combine = struct
       post ~rosetta_uri ~logger
         ~body:
           Construction_combine_request.(
-            { network_identifier= net_id network_response
+            { network_identifier = net_id network_response
             ; unsigned_transaction
-            ; signatures=
+            ; signatures =
                 [ (* TODO: How important is it to fill in all these details properly? *)
-                  { Signature.signing_payload=
-                      { Signing_payload.account_identifier= Some account_id
-                      ; address= None
-                      ; hex_bytes= "TODO"
-                      ; signature_type= None }
-                  ; public_key=
-                      { Public_key.hex_bytes= public_key_hex_bytes
-                      ; curve_type= "pallas" }
-                  ; signature_type= "schnorr_poseidon"
-                  ; hex_bytes= signature } ] }
+                  { Signature.signing_payload =
+                      { Signing_payload.account_identifier = Some account_id
+                      ; address = None
+                      ; hex_bytes = "TODO"
+                      ; signature_type = None
+                      }
+                  ; public_key =
+                      { Public_key.hex_bytes = public_key_hex_bytes
+                      ; curve_type = "pallas"
+                      }
+                  ; signature_type = "schnorr_poseidon"
+                  ; hex_bytes = signature
+                  }
+                ]
+            }
             |> to_yojson)
         ~path:"construction/combine"
     in
@@ -117,7 +129,7 @@ module Hash = struct
       post ~rosetta_uri ~logger
         ~body:
           Construction_hash_request.(
-            {network_identifier= net_id network_response; signed_transaction}
+            { network_identifier = net_id network_response; signed_transaction }
             |> to_yojson)
         ~path:"construction/hash"
     in

--- a/src/app/rosetta/test-agent/poke.ml
+++ b/src/app/rosetta/test-agent/poke.ml
@@ -23,7 +23,7 @@ module Staking = struct
   let disable ~graphql_uri =
     let open Deferred.Result.Let_syntax in
     let%map res = Graphql.query (Disable.make ()) graphql_uri in
-    (res#setStaking)#lastStaking
+    res#setStaking#lastStaking
 
   module Enable =
   [%graphql
@@ -40,7 +40,7 @@ module Staking = struct
     let%map res =
       Graphql.query (Enable.make ~publicKey:(`String pk) ()) graphql_uri
     in
-    (res#setStaking)#lastStaking
+    res#setStaking#lastStaking
 end
 
 module Account = struct
@@ -61,7 +61,7 @@ module Account = struct
         (Unlock.make ~password:"" ~public_key:(`String pk) ())
         graphql_uri
     in
-    (res#unlockAccount)#publicKey
+    res#unlockAccount#publicKey
 end
 
 module SendTransaction = struct
@@ -84,7 +84,7 @@ module SendTransaction = struct
         (Payment.make ~fee ~amount ?token ~to_ ~from:(`String pk) ())
         graphql_uri
     in
-    let (`UserCommand x) = (res#sendPayment)#payment in
+    let (`UserCommand x) = res#sendPayment#payment in
     x#hash
 
   (* Note: These operations below are intentionally constructed from a templated
@@ -126,7 +126,7 @@ module SendTransaction = struct
         (Delegation.make ~fee ~to_ ~from:(`String pk) ())
         graphql_uri
     in
-    let (`UserCommand cmd) = (res#sendDelegation)#delegation in
+    let (`UserCommand cmd) = res#sendDelegation#delegation in
     cmd#hash
 
   let delegation_operations ~from ~fee ~to_ =
@@ -163,7 +163,7 @@ module SendTransaction = struct
         (Create_token.make ~fee ~sender:(`String pk) ~receiver:(`String pk) ())
         graphql_uri
     in
-    let cmd = (res#createToken)#createNewToken in
+    let cmd = res#createToken#createNewToken in
     cmd#hash
 
   let create_token_operations ~fee ~sender =
@@ -203,7 +203,7 @@ module SendTransaction = struct
            ~receiver:(`String receiver) ~tokenOwner:(`String pk) ~token ~fee ())
         graphql_uri
     in
-    let cmd = (res#createTokenAccount)#createNewTokenAccount in
+    let cmd = res#createTokenAccount#createNewTokenAccount in
     cmd#hash
 
   let create_token_account_operations ~fee ~sender =

--- a/src/app/runtime_genesis_ledger/.ocamlformat
+++ b/src/app/runtime_genesis_ledger/.ocamlformat
@@ -1,0 +1,1 @@
+../../.ocamlformat

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -29,8 +29,8 @@ let () =
     (Command.async
        ~summary:
          "Generate the genesis ledger and genesis proof for a given \
-          configuration file, or for the compile-time configuration if none \
-          is provided"
+          configuration file, or for the compile-time configuration if none is \
+          provided"
        Command.(
          let open Let_syntax in
          let open Command.Param in

--- a/src/lib/transition_frontier/.ocamlformat
+++ b/src/lib/transition_frontier/.ocamlformat
@@ -1,0 +1,1 @@
+../../.ocamlformat

--- a/src/lib/transition_frontier/catchup_hash_tree.ml
+++ b/src/lib/transition_frontier/catchup_hash_tree.ml
@@ -14,7 +14,7 @@ module Node = struct
       let to_yojson (t : t) =
         `List
           (List.map (Hash_set.to_list t) ~f:(fun x ->
-               `String (Catchup_job_id.to_string x) ))
+               `String (Catchup_job_id.to_string x)))
     end
 
     type t = Have_breadcrumb | Part_of_catchups of Ids.t
@@ -22,10 +22,10 @@ module Node = struct
   end
 
   type t =
-    { parent: State_hash.t
-    ; state: State.t
+    { parent : State_hash.t
+    ; state : State.t
           (* If a node has a breadcrumb, then all of its ancestors have
-   breadcrumbs as well. *)
+             breadcrumbs as well. *)
     }
   [@@deriving to_yojson]
 end
@@ -42,7 +42,7 @@ module State_hash_table = struct
   let to_yojson f t : Yojson.Safe.t =
     `Assoc
       (List.map (State_hash.Table.to_alist t) ~f:(fun (h, x) ->
-           (State_hash.to_base58_check h, f x) ))
+           (State_hash.to_base58_check h, f x)))
 end
 
 module State_hash_hash_set = struct
@@ -60,11 +60,12 @@ module State_hash_set = struct
 end
 
 type t =
-  { nodes: Node.t State_hash_table.t
-  ; tips: State_hash_hash_set.t
-  ; children: State_hash_set.t State_hash_table.t
-  ; mutable root: State_hash.t
-  ; logger: L.t }
+  { nodes : Node.t State_hash_table.t
+  ; tips : State_hash_hash_set.t
+  ; children : State_hash_set.t State_hash_table.t
+  ; mutable root : State_hash.t
+  ; logger : L.t
+  }
 [@@deriving to_yojson]
 
 let max_catchup_chain_length t =
@@ -73,30 +74,31 @@ let max_catchup_chain_length t =
     | Have_breadcrumb ->
         acc
     | Part_of_catchups _ -> (
-      match Hashtbl.find t.nodes node.parent with
-      | None ->
-          (* This node is a root. *)
-          acc
-      | Some parent ->
-          missing_length (acc + 1) parent )
+        match Hashtbl.find t.nodes node.parent with
+        | None ->
+            (* This node is a root. *)
+            acc
+        | Some parent ->
+            missing_length (acc + 1) parent )
   in
   Hash_set.fold t.tips ~init:0 ~f:(fun acc tip ->
-      Int.max acc (missing_length 0 (Hashtbl.find_exn t.nodes tip)) )
+      Int.max acc (missing_length 0 (Hashtbl.find_exn t.nodes tip)))
 
 let create ~root =
   let root_hash = Breadcrumb.state_hash root in
   let parent = Breadcrumb.parent_hash root in
   let nodes =
     State_hash.Table.of_alist_exn
-      [(root_hash, {Node.parent; state= Have_breadcrumb})]
+      [ (root_hash, { Node.parent; state = Have_breadcrumb }) ]
   in
-  { root= root_hash
-  ; tips= State_hash.Hash_set.create ()
-  ; children=
+  { root = root_hash
+  ; tips = State_hash.Hash_set.create ()
+  ; children =
       State_hash.Table.of_alist_exn
-        [(parent, State_hash.Set.singleton root_hash)]
+        [ (parent, State_hash.Set.singleton root_hash) ]
   ; nodes
-  ; logger= Logger.create () }
+  ; logger = Logger.create ()
+  }
 
 let check_for_parent t h ~parent:p ~check_has_breadcrumb =
   match Hashtbl.find t.nodes p with
@@ -105,7 +107,8 @@ let check_for_parent t h ~parent:p ~check_has_breadcrumb =
         ~metadata:
           [ ("parent", State_hash.to_yojson p)
           ; ("hash", State_hash.to_yojson h)
-          ; ("tree", to_yojson t) ]
+          ; ("tree", to_yojson t)
+          ]
         "hash tree invariant broken: $parent not found in $tree for $hash"
   | Some x ->
       if check_has_breadcrumb && not (Node.State.equal x.state Have_breadcrumb)
@@ -114,7 +117,8 @@ let check_for_parent t h ~parent:p ~check_has_breadcrumb =
           ~metadata:
             [ ("parent", State_hash.to_yojson p)
             ; ("hash", State_hash.to_yojson h)
-            ; ("tree", to_yojson t) ]
+            ; ("tree", to_yojson t)
+            ]
           "hash tree invariant broken: expected $parent to have breadcrumb \
            (child is $hash) in $tree"
       else ()
@@ -124,7 +128,7 @@ let add_child t h ~parent =
     | None ->
         State_hash.Set.singleton h
     | Some s ->
-        Set.add s h )
+        Set.add s h)
 
 let add t h ~parent ~job =
   if Hashtbl.mem t.nodes h then
@@ -140,7 +144,8 @@ let add t h ~parent ~job =
     Hash_set.remove t.tips parent ;
     Hashtbl.set t.nodes ~key:h
       ~data:
-        {parent; state= Part_of_catchups (Catchup_job_id.Hash_set.create ())} )
+        { parent; state = Part_of_catchups (Catchup_job_id.Hash_set.create ()) }
+    )
 
 let breadcrumb_added (t : t) b =
   let h = Breadcrumb.state_hash b in
@@ -150,9 +155,9 @@ let breadcrumb_added (t : t) b =
     | None ->
         (* New child *)
         add_child t h ~parent ;
-        {parent; state= Have_breadcrumb}
+        { parent; state = Have_breadcrumb }
     | Some x ->
-        {x with state= Have_breadcrumb} ) ;
+        { x with state = Have_breadcrumb }) ;
   Hash_set.remove t.tips h
 
 let remove_node t h =
@@ -160,13 +165,13 @@ let remove_node t h =
   match Hashtbl.find_and_remove t.nodes h with
   | None ->
       ()
-  | Some {parent; _} ->
+  | Some { parent; _ } ->
       Hashtbl.change t.children parent ~f:(function
         | None ->
             None
         | Some s ->
             let s' = Set.remove s h in
-            if Set.is_empty s' then None else Some s' )
+            if Set.is_empty s' then None else Some s')
 
 (* Remove everything not reachable from the root *)
 let prune t =
@@ -186,9 +191,9 @@ let prune t =
         in
         go stack
   in
-  go [t.root] ;
+  go [ t.root ] ;
   List.iter (Hashtbl.keys t.nodes) ~f:(fun h ->
-      if not (Hash_set.mem keep h) then remove_node t h )
+      if not (Hash_set.mem keep h) then remove_node t h)
 
 let catchup_failed t job =
   let to_remove =
@@ -198,7 +203,7 @@ let catchup_failed t job =
             acc
         | Part_of_catchups s ->
             Hash_set.remove s job ;
-            if Hash_set.is_empty s then key :: acc else acc )
+            if Hash_set.is_empty s then key :: acc else acc)
   in
   List.iter to_remove ~f:(remove_node t)
 
@@ -206,20 +211,20 @@ let apply_diffs t (ds : Diff.Full.E.t list) =
   List.iter ds ~f:(function
     | E (New_node (Full b)) ->
         breadcrumb_added t b
-    | E (Root_transitioned {new_root; garbage= Full hs}) ->
+    | E (Root_transitioned { new_root; garbage = Full hs }) ->
         List.iter (Diff.Node_list.to_lite hs) ~f:(remove_node t) ;
         let h = Root_data.Limited.hash new_root in
         Hashtbl.change t.nodes h ~f:(function
           | None ->
               [%log' debug t.logger]
                 ~metadata:
-                  [("hash", State_hash.to_yojson h); ("tree", to_yojson t)]
+                  [ ("hash", State_hash.to_yojson h); ("tree", to_yojson t) ]
                 "hash $tree invariant broken: new root $hash not present. \
                  Diffs may have been applied out of order" ;
               None
           | Some x ->
               t.root <- h ;
-              Some {x with state= Have_breadcrumb} ) ;
+              Some { x with state = Have_breadcrumb }) ;
         prune t
     | E (Best_tip_changed _) ->
-        () )
+        ())

--- a/src/lib/transition_frontier/extensions/best_tip_diff.ml
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.ml
@@ -3,38 +3,42 @@ open Mina_base
 open Frontier_base
 
 module T = struct
-  type t = {logger: Logger.t; best_tip_diff_logger: Logger.t}
+  type t = { logger : Logger.t; best_tip_diff_logger : Logger.t }
 
   type view =
-    { new_commands: User_command.Valid.t With_status.t list
-    ; removed_commands: User_command.Valid.t With_status.t list
-    ; reorg_best_tip: bool }
+    { new_commands : User_command.Valid.t With_status.t list
+    ; removed_commands : User_command.Valid.t With_status.t list
+    ; reorg_best_tip : bool
+    }
 
   module Log_event = struct
     type t =
-      { protocol_state: Mina_state.Protocol_state.Value.t
-      ; state_hash: State_hash.t
-      ; just_emitted_a_proof: bool }
+      { protocol_state : Mina_state.Protocol_state.Value.t
+      ; state_hash : State_hash.t
+      ; just_emitted_a_proof : bool
+      }
     [@@deriving yojson, sexp]
 
     let compare t t' = State_hash.compare t.state_hash t'.state_hash
 
     type Structured_log_events.t +=
       | New_best_tip_event of
-          { added_transitions: t list
-          ; removed_transitions: t list
-          ; reorg_best_tip: bool }
-      [@@deriving register_event {msg= "Formed a new best tip"}]
+          { added_transitions : t list
+          ; removed_transitions : t list
+          ; reorg_best_tip : bool
+          }
+      [@@deriving register_event { msg = "Formed a new best tip" }]
   end
 
   let create ~logger frontier =
     let best_tip_diff_logger =
       Logger.create ~id:Logger.Logger_id.best_tip_diff ()
     in
-    ( {logger; best_tip_diff_logger}
-    , { new_commands= Breadcrumb.commands (Full_frontier.root frontier)
-      ; removed_commands= []
-      ; reorg_best_tip= false } )
+    ( { logger; best_tip_diff_logger }
+    , { new_commands = Breadcrumb.commands (Full_frontier.root frontier)
+      ; removed_commands = []
+      ; reorg_best_tip = false
+      } )
 
   (* Get the breadcrumbs that are on bc1's path but not bc2's, and vice versa.
      Ordered oldest to newest. *)
@@ -62,10 +66,10 @@ module T = struct
     let view, should_broadcast =
       List.fold diffs_with_mutants
         ~init:
-          ( {new_commands= []; removed_commands= []; reorg_best_tip= false}
+          ( { new_commands = []; removed_commands = []; reorg_best_tip = false }
           , false )
         ~f:
-          (fun ( ({new_commands; removed_commands; reorg_best_tip= _} as acc)
+          (fun ( ({ new_commands; removed_commands; reorg_best_tip = _ } as acc)
                , should_broadcast ) -> function
           | E (Best_tip_changed new_best_tip, old_best_tip_hash) ->
               let new_best_tip_breadcrumb =
@@ -92,36 +96,37 @@ module T = struct
               let added_transitions =
                 List.map
                   ~f:(fun b ->
-                    { Log_event.protocol_state= Breadcrumb.protocol_state b
-                    ; state_hash= Breadcrumb.state_hash b
-                    ; just_emitted_a_proof= Breadcrumb.just_emitted_a_proof b
-                    } )
+                    { Log_event.protocol_state = Breadcrumb.protocol_state b
+                    ; state_hash = Breadcrumb.state_hash b
+                    ; just_emitted_a_proof = Breadcrumb.just_emitted_a_proof b
+                    })
                   added_to_best_tip_path
               in
               let removed_transitions =
                 List.map
                   ~f:(fun b ->
-                    { Log_event.protocol_state= Breadcrumb.protocol_state b
-                    ; state_hash= Breadcrumb.state_hash b
-                    ; just_emitted_a_proof= Breadcrumb.just_emitted_a_proof b
-                    } )
+                    { Log_event.protocol_state = Breadcrumb.protocol_state b
+                    ; state_hash = Breadcrumb.state_hash b
+                    ; just_emitted_a_proof = Breadcrumb.just_emitted_a_proof b
+                    })
                   removed_from_best_tip_path
               in
               let event =
                 Log_event.New_best_tip_event
-                  {added_transitions; removed_transitions; reorg_best_tip}
+                  { added_transitions; removed_transitions; reorg_best_tip }
               in
               [%str_log' debug t.logger]
                 ~metadata:
                   [ ( "no_of_added_breadcrumbs"
                     , `Int (List.length added_to_best_tip_path) )
                   ; ( "no_of_removed_breadcrumbs"
-                    , `Int (List.length removed_from_best_tip_path) ) ]
+                    , `Int (List.length removed_from_best_tip_path) )
+                  ]
                 event ;
               [%str_log' best_tip_diff t.best_tip_diff_logger] event ;
-              ({new_commands; removed_commands; reorg_best_tip}, true)
+              ({ new_commands; removed_commands; reorg_best_tip }, true)
           | E (New_node (Full _), _) -> (acc, should_broadcast)
-          | E (Root_transitioned _, _) -> (acc, should_broadcast) )
+          | E (Root_transitioned _, _) -> (acc, should_broadcast))
     in
     Option.some_if should_broadcast view
 end

--- a/src/lib/transition_frontier/extensions/best_tip_diff.mli
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.mli
@@ -1,22 +1,25 @@
 open Mina_base
 
 type view =
-  { new_commands: User_command.Valid.t With_status.t list
-  ; removed_commands: User_command.Valid.t With_status.t list
-  ; reorg_best_tip: bool }
+  { new_commands : User_command.Valid.t With_status.t list
+  ; removed_commands : User_command.Valid.t With_status.t list
+  ; reorg_best_tip : bool
+  }
 
 module Log_event : sig
   type t =
-    { protocol_state: Mina_state.Protocol_state.Value.t
-    ; state_hash: State_hash.t
-    ; just_emitted_a_proof: bool }
+    { protocol_state : Mina_state.Protocol_state.Value.t
+    ; state_hash : State_hash.t
+    ; just_emitted_a_proof : bool
+    }
   [@@deriving yojson, sexp, compare]
 
   type Structured_log_events.t +=
     | New_best_tip_event of
-        { added_transitions: t list
-        ; removed_transitions: t list
-        ; reorg_best_tip: bool }
+        { added_transitions : t list
+        ; removed_transitions : t list
+        ; reorg_best_tip : bool
+        }
     [@@deriving register_event]
 end
 

--- a/src/lib/transition_frontier/extensions/extensions.ml
+++ b/src/lib/transition_frontier/extensions/extensions.ml
@@ -10,13 +10,14 @@ module New_breadcrumbs = New_breadcrumbs
 module Ledger_table = Ledger_table
 
 type t =
-  { root_history: Root_history.Broadcasted.t
-  ; snark_pool_refcount: Snark_pool_refcount.Broadcasted.t
-  ; best_tip_diff: Best_tip_diff.Broadcasted.t
-  ; transition_registry: Transition_registry.Broadcasted.t
-  ; ledger_table: Ledger_table.Broadcasted.t
-  ; identity: Identity.Broadcasted.t
-  ; new_breadcrumbs: New_breadcrumbs.Broadcasted.t }
+  { root_history : Root_history.Broadcasted.t
+  ; snark_pool_refcount : Snark_pool_refcount.Broadcasted.t
+  ; best_tip_diff : Best_tip_diff.Broadcasted.t
+  ; transition_registry : Transition_registry.Broadcasted.t
+  ; ledger_table : Ledger_table.Broadcasted.t
+  ; identity : Identity.Broadcasted.t
+  ; new_breadcrumbs : New_breadcrumbs.Broadcasted.t
+  }
 [@@deriving fields]
 
 let create ~logger frontier : t Deferred.t =
@@ -33,9 +34,7 @@ let create ~logger frontier : t Deferred.t =
   let%bind transition_registry =
     Transition_registry.(Broadcasted.create (create ~logger frontier))
   in
-  let%bind identity =
-    Identity.(Broadcasted.create (create ~logger frontier))
-  in
+  let%bind identity = Identity.(Broadcasted.create (create ~logger frontier)) in
   let%bind new_breadcrumbs =
     New_breadcrumbs.(Broadcasted.create (create ~logger frontier))
   in
@@ -49,7 +48,8 @@ let create ~logger frontier : t Deferred.t =
     ; transition_registry
     ; identity
     ; ledger_table
-    ; new_breadcrumbs }
+    ; new_breadcrumbs
+    }
 
 (* HACK: A way to ensure that all the pipes are closed in a type-safe manner *)
 let close t : unit =
@@ -103,15 +103,17 @@ type ('ext, 'view) broadcasted_extension =
       * 't
       -> ('ext, 'view) broadcasted_extension
 
-let get : type ext view.
-    t -> (ext, view) access -> (ext, view) broadcasted_extension =
+let get :
+    type ext view. t -> (ext, view) access -> (ext, view) broadcasted_extension
+    =
  fun { root_history
      ; snark_pool_refcount
      ; best_tip_diff
      ; transition_registry
      ; ledger_table
      ; new_breadcrumbs
-     ; identity } -> function
+     ; identity
+     } -> function
   | Root_history ->
       Broadcasted_extension ((module Root_history.Broadcasted), root_history)
   | Snark_pool_refcount ->
@@ -135,8 +137,8 @@ let get_extension : type ext view. t -> (ext, view) access -> ext =
   let (Broadcasted_extension ((module B), ext)) = get t access in
   B.extension ext
 
-let get_view_pipe : type ext view.
-    t -> (ext, view) access -> view Broadcast_pipe.Reader.t =
+let get_view_pipe :
+    type ext view. t -> (ext, view) access -> view Broadcast_pipe.Reader.t =
  fun t access ->
   let (Broadcasted_extension ((module B), ext)) = get t access in
   B.reader ext

--- a/src/lib/transition_frontier/extensions/functor.ml
+++ b/src/lib/transition_frontier/extensions/functor.ml
@@ -3,32 +3,33 @@ open Pipe_lib
 
 module Make_broadcasted (Extension : Intf.Extension_base_intf) :
   Intf.Broadcasted_extension_intf
-  with type extension = Extension.t
-   and type view = Extension.view = struct
+    with type extension = Extension.t
+     and type view = Extension.view = struct
   type extension = Extension.t
 
   type view = Extension.view
 
   type t =
-    { extension: Extension.t
-    ; writer: Extension.view Broadcast_pipe.Writer.t
-    ; reader: Extension.view Broadcast_pipe.Reader.t }
+    { extension : Extension.t
+    ; writer : Extension.view Broadcast_pipe.Writer.t
+    ; reader : Extension.view Broadcast_pipe.Reader.t
+    }
 
-  let extension {extension; _} = extension
+  let extension { extension; _ } = extension
 
   let create (extension, initial_view) =
     let open Deferred.Let_syntax in
     let reader, writer = Broadcast_pipe.create initial_view in
     let%map () = Broadcast_pipe.Writer.write writer initial_view in
-    {extension; reader; writer}
+    { extension; reader; writer }
 
-  let close {writer; _} = Broadcast_pipe.Writer.close writer
+  let close { writer; _ } = Broadcast_pipe.Writer.close writer
 
-  let peek {reader; _} = Broadcast_pipe.Reader.peek reader
+  let peek { reader; _ } = Broadcast_pipe.Reader.peek reader
 
-  let reader {reader; _} = reader
+  let reader { reader; _ } = reader
 
-  let update {extension; writer; _} frontier diffs =
+  let update { extension; writer; _ } frontier diffs =
     match Extension.handle_diffs extension frontier diffs with
     | Some view ->
         Broadcast_pipe.Writer.write writer view

--- a/src/lib/transition_frontier/extensions/ledger_table.ml
+++ b/src/lib/transition_frontier/extensions/ledger_table.ml
@@ -10,16 +10,17 @@ module T = struct
   (* a pair of hash tables
      the first maps ledger hashes to ledgers
      the second maps ledger hashes to reference counts
-   *)
+  *)
   type t =
-    {ledgers: Ledger.t Ledger_hash.Table.t; counts: int Ledger_hash.Table.t}
+    { ledgers : Ledger.t Ledger_hash.Table.t; counts : int Ledger_hash.Table.t }
 
   type view = unit
 
   let add_entry t ~ledger_hash ~ledger =
     (* add ledger, increment ref count *)
     ignore
-      (Hashtbl.add t.ledgers ~key:ledger_hash ~data:ledger : [`Duplicate | `Ok]) ;
+      ( Hashtbl.add t.ledgers ~key:ledger_hash ~data:ledger
+        : [ `Duplicate | `Ok ] ) ;
     ignore (Hashtbl.incr t.counts ledger_hash : view)
 
   let remove_entry t ~ledger_hash =
@@ -31,14 +32,15 @@ module T = struct
   let create ~logger:_ frontier =
     (* populate ledger table from breadcrumbs *)
     let t =
-      { ledgers= Ledger_hash.Table.create ()
-      ; counts= Ledger_hash.Table.create () }
+      { ledgers = Ledger_hash.Table.create ()
+      ; counts = Ledger_hash.Table.create ()
+      }
     in
     let breadcrumbs = Full_frontier.all_breadcrumbs frontier in
     List.iter breadcrumbs ~f:(fun bc ->
         let ledger = Staged_ledger.ledger @@ Breadcrumb.staged_ledger bc in
         let ledger_hash = Ledger.merkle_root ledger in
-        add_entry t ~ledger_hash ~ledger ) ;
+        add_entry t ~ledger_hash ~ledger) ;
     (t, ())
 
   let lookup t ledger_hash = Ledger_hash.Table.find t.ledgers ledger_hash
@@ -53,27 +55,27 @@ module T = struct
           let ledger_hash = Ledger.merkle_root ledger in
           add_entry t ~ledger_hash ~ledger
       | E (Root_transitioned transition, _) -> (
-        match transition.garbage with
-        | Full nodes ->
-            let open Mina_state in
-            List.iter nodes ~f:(fun node ->
-                let With_hash.{data= external_transition; _}, _ =
-                  node.transition
-                in
-                let blockchain_state =
-                  Protocol_state.blockchain_state
-                  @@ Mina_transition.External_transition.protocol_state
-                       external_transition
-                in
-                let staged_ledger =
-                  Blockchain_state.staged_ledger_hash blockchain_state
-                in
-                let ledger_hash =
-                  Staged_ledger_hash.ledger_hash staged_ledger
-                in
-                remove_entry t ~ledger_hash ) )
+          match transition.garbage with
+          | Full nodes ->
+              let open Mina_state in
+              List.iter nodes ~f:(fun node ->
+                  let With_hash.{ data = external_transition; _ }, _ =
+                    node.transition
+                  in
+                  let blockchain_state =
+                    Protocol_state.blockchain_state
+                    @@ Mina_transition.External_transition.protocol_state
+                         external_transition
+                  in
+                  let staged_ledger =
+                    Blockchain_state.staged_ledger_hash blockchain_state
+                  in
+                  let ledger_hash =
+                    Staged_ledger_hash.ledger_hash staged_ledger
+                  in
+                  remove_entry t ~ledger_hash) )
       | E (Best_tip_changed _, _) ->
-          () ) ;
+          ()) ;
     None
 end
 

--- a/src/lib/transition_frontier/extensions/new_breadcrumbs.ml
+++ b/src/lib/transition_frontier/extensions/new_breadcrumbs.ml
@@ -6,7 +6,7 @@ module T = struct
 
   type view = Breadcrumb.t list
 
-  let create ~logger:_ frontier = ((), [Full_frontier.root frontier])
+  let create ~logger:_ frontier = ((), [ Full_frontier.root frontier ])
 
   let handle_diffs () _frontier diffs_with_mutants =
     let open Diff.Full.With_mutant in
@@ -15,7 +15,7 @@ module T = struct
         | E (New_node (Full breadcrumb), _) ->
             Some breadcrumb
         | _ ->
-            None )
+            None)
     in
     Option.some_if (not @@ List.is_empty new_nodes) new_nodes
 end

--- a/src/lib/transition_frontier/extensions/root_history.ml
+++ b/src/lib/transition_frontier/extensions/root_history.ml
@@ -6,11 +6,12 @@ module Queue = Hash_queue.Make (State_hash)
 
 module T = struct
   type t =
-    { history: Root_data.Historical.t Queue.t
-    ; capacity: int
-    ; mutable current_root: Root_data.Historical.t
-    ; mutable protocol_states_for_root_scan_state:
-        Full_frontier.Protocol_states_for_root_scan_state.t }
+    { history : Root_data.Historical.t Queue.t
+    ; capacity : int
+    ; mutable current_root : Root_data.Historical.t
+    ; mutable protocol_states_for_root_scan_state :
+        Full_frontier.Protocol_states_for_root_scan_state.t
+    }
 
   type view = t
 
@@ -24,8 +25,9 @@ module T = struct
       { history
       ; capacity
       ; current_root
-      ; protocol_states_for_root_scan_state=
-          Full_frontier.protocol_states_for_root_scan_state frontier }
+      ; protocol_states_for_root_scan_state =
+          Full_frontier.protocol_states_for_root_scan_state frontier
+      }
     in
     (t, t)
 
@@ -43,17 +45,18 @@ module T = struct
           t.protocol_states_for_root_scan_state
           ~new_scan_state:(scan_state new_oldest_root)
           ~old_root_state:
-            { With_hash.data=
+            { With_hash.data =
                 External_transition.Validated.protocol_state
                   (transition oldest_root)
-            ; hash=
+            ; hash =
                 External_transition.Validated.state_hash
-                  (transition oldest_root) }
+                  (transition oldest_root)
+            }
         |> State_hash.Map.of_alist_exn
       in
       t.protocol_states_for_root_scan_state <- new_protocol_states_map ) ;
     assert (
-      [%equal: [`Ok | `Key_already_present]] `Ok
+      [%equal: [ `Ok | `Key_already_present ]] `Ok
         (Queue.enqueue_back t.history
            (External_transition.Validated.state_hash
               (transition t.current_root))
@@ -65,12 +68,12 @@ module T = struct
     let should_produce_view =
       List.exists diffs_with_mutants ~f:(function
         (* TODO: send full diffs to extensions to avoid extra lookups in frontier *)
-        | E (Root_transitioned {new_root; _}, _) ->
+        | E (Root_transitioned { new_root; _ }, _) ->
             Full_frontier.find_exn frontier (Root_data.Limited.hash new_root)
             |> Root_data.Historical.of_breadcrumb |> enqueue root_history ;
             true
         | E _ ->
-            false )
+            false)
     in
     Option.some_if should_produce_view root_history
 end
@@ -78,12 +81,12 @@ end
 include T
 module Broadcasted = Functor.Make_broadcasted (T)
 
-let lookup {history; _} = Queue.lookup history
+let lookup { history; _ } = Queue.lookup history
 
-let mem {history; _} = Queue.mem history
+let mem { history; _ } = Queue.mem history
 
 let protocol_states_for_scan_state
-    {history; protocol_states_for_root_scan_state; _} state_hash =
+    { history; protocol_states_for_root_scan_state; _ } state_hash =
   let open Option.Let_syntax in
   let open Root_data.Historical in
   let%bind data = Queue.lookup history state_hash in
@@ -104,22 +107,21 @@ let protocol_states_for_scan_state
             (*Not present in the history queue, check in the protocol states map that has all the protocol states required for transactions in the root*)
             State_hash.Map.find protocol_states_for_root_scan_state hash
       in
-      match res with None -> Stop None | Some state -> Continue (state :: acc)
-      )
+      match res with None -> Stop None | Some state -> Continue (state :: acc))
 
-let most_recent {history; _} =
+let most_recent { history; _ } =
   (* unfortunately, there is not function to inspect the last element in the queue,
    * so we need to remove it and reinsert it instead *)
   let open Option.Let_syntax in
   let%map state_hash, breadcrumb = Queue.dequeue_back_with_key history in
   (* should never return `Key_already_present since we just removed it *)
   assert (
-    [%equal: [`Ok | `Key_already_present]] `Ok
+    [%equal: [ `Ok | `Key_already_present ]] `Ok
       (Queue.enqueue_back history state_hash breadcrumb) ) ;
   breadcrumb
 
-let oldest {history; _} = Queue.first history
+let oldest { history; _ } = Queue.first history
 
-let is_empty {history; _} = Queue.is_empty history
+let is_empty { history; _ } = Queue.is_empty history
 
-let to_list {history; _} = Queue.to_list history
+let to_list { history; _ } = Queue.to_list history

--- a/src/lib/transition_frontier/extensions/snark_pool_refcount.ml
+++ b/src/lib/transition_frontier/extensions/snark_pool_refcount.ml
@@ -4,13 +4,13 @@ module Work = Transaction_snark_work.Statement
 
 module T = struct
   type view =
-    { removed: int
-    ; refcount_table: int Work.Table.t
+    { removed : int
+    ; refcount_table : int Work.Table.t
           (** Tracks the number of blocks that have each work statement in
               their scan state.
               Work is included iff it is a member of some block scan state.
           *)
-    ; best_tip_table: Work.Hash_set.t
+    ; best_tip_table : Work.Hash_set.t
           (** The set of all snark work statements present in the scan state
               for the last 10 blocks in the best chain.
           *)
@@ -18,12 +18,12 @@ module T = struct
   [@@deriving sexp]
 
   type t =
-    { refcount_table: int Work.Table.t
+    { refcount_table : int Work.Table.t
           (** Tracks the number of blocks that have each work statement in
               their scan state.
               Work is included iff it is a member of some block scan state.
           *)
-    ; best_tip_table: Work.Hash_set.t
+    ; best_tip_table : Work.Hash_set.t
           (** The set of all snark work statements present in the scan state
               for the last 10 blocks in the best chain.
           *)
@@ -41,7 +41,7 @@ module T = struct
               count + 1
           | None ->
               res := true ;
-              1 ) ) ;
+              1)) ;
     !res
 
   (** Returns true if this update changed which elements are in the table
@@ -56,7 +56,7 @@ module T = struct
           | Some count ->
               Some (count - 1)
           | None ->
-              failwith "Removed a breadcrumb we didn't know about" ) ) ;
+              failwith "Removed a breadcrumb we didn't know about")) ;
     !res
 
   let add_scan_state_to_ref_table table scan_state : bool =
@@ -67,8 +67,9 @@ module T = struct
 
   let create ~logger:_ frontier =
     let t =
-      { refcount_table= Work.Table.create ()
-      ; best_tip_table= Work.Hash_set.create () }
+      { refcount_table = Work.Table.create ()
+      ; best_tip_table = Work.Hash_set.create ()
+      }
     in
     let () =
       let breadcrumb = Full_frontier.root frontier in
@@ -78,17 +79,18 @@ module T = struct
       ignore (add_scan_state_to_ref_table t.refcount_table scan_state : bool)
     in
     ( t
-    , { removed= 0
-      ; refcount_table= t.refcount_table
-      ; best_tip_table= t.best_tip_table } )
+    , { removed = 0
+      ; refcount_table = t.refcount_table
+      ; best_tip_table = t.best_tip_table
+      } )
 
-  type diff_update = {num_removed: int; is_added: bool}
+  type diff_update = { num_removed : int; is_added : bool }
 
   let handle_diffs t frontier diffs_with_mutants =
     let open Diff.Full.With_mutant in
-    let {num_removed; is_added} =
-      List.fold diffs_with_mutants ~init:{num_removed= 0; is_added= false}
-        ~f:(fun {num_removed; is_added} -> function
+    let { num_removed; is_added } =
+      List.fold diffs_with_mutants ~init:{ num_removed = 0; is_added = false }
+        ~f:(fun { num_removed; is_added } -> function
         | E (New_node (Full breadcrumb), _) ->
             let scan_state =
               Breadcrumb.staged_ledger breadcrumb |> Staged_ledger.scan_state
@@ -96,8 +98,8 @@ module T = struct
             let added_scan_state =
               add_scan_state_to_ref_table t.refcount_table scan_state
             in
-            {num_removed; is_added= is_added || added_scan_state}
-        | E (Root_transitioned {new_root= _; garbage= Full garbage_nodes}, _)
+            { num_removed; is_added = is_added || added_scan_state }
+        | E (Root_transitioned { new_root = _; garbage = Full garbage_nodes }, _)
           ->
             let open Diff.Node_list in
             let extra_num_removed =
@@ -109,9 +111,9 @@ module T = struct
                     then 1
                     else 0
                   in
-                  acc + delta )
+                  acc + delta)
             in
-            {num_removed= num_removed + extra_num_removed; is_added}
+            { num_removed = num_removed + extra_num_removed; is_added }
         | E (Best_tip_changed new_best_tip_hash, _) ->
             let rec update_best_tip_table blocks_remaining state_hash =
               match Full_frontier.find frontier state_hash with
@@ -132,13 +134,14 @@ module T = struct
             let num_blocks_to_include = 3 in
             Hash_set.clear t.best_tip_table ;
             update_best_tip_table num_blocks_to_include new_best_tip_hash ;
-            {num_removed; is_added= true} )
+            { num_removed; is_added = true })
     in
     if num_removed > 0 || is_added then
       Some
-        { removed= num_removed
-        ; refcount_table= t.refcount_table
-        ; best_tip_table= t.best_tip_table }
+        { removed = num_removed
+        ; refcount_table = t.refcount_table
+        ; best_tip_table = t.best_tip_table
+        }
     else None
 end
 

--- a/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
+++ b/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
@@ -1,11 +1,11 @@
 type view =
-  { removed: int
-  ; refcount_table: int Transaction_snark_work.Statement.Table.t
+  { removed : int
+  ; refcount_table : int Transaction_snark_work.Statement.Table.t
         (** Tracks the number of blocks that have each work statement in their
             scan state.
             Work is included iff it is a member of some block scan state.
         *)
-  ; best_tip_table: Transaction_snark_work.Statement.Hash_set.t
+  ; best_tip_table : Transaction_snark_work.Statement.Hash_set.t
         (** The set of all snark work statements present in the scan state for
             the last 10 blocks in the best chain.
         *)

--- a/src/lib/transition_frontier/extensions/transition_registry.ml
+++ b/src/lib/transition_frontier/extensions/transition_registry.ml
@@ -16,10 +16,10 @@ module T = struct
           List.iter ls ~f:(fun ivar ->
               if Ivar.is_full ivar then
                 [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-              Ivar.fill ivar () ) ;
+              Ivar.fill ivar ()) ;
           None
       | None ->
-          None )
+          None)
 
   let register t state_hash =
     Deferred.create (fun ivar ->
@@ -27,14 +27,14 @@ module T = struct
           | Some ls ->
               ivar :: ls
           | None ->
-              [ivar] ) )
+              [ ivar ]))
 
   let handle_diffs transition_registry _ diffs_with_mutants =
     List.iter diffs_with_mutants ~f:(function
       | Diff.Full.With_mutant.E (New_node (Full breadcrumb), _) ->
           notify transition_registry (Breadcrumb.state_hash breadcrumb)
       | _ ->
-          () ) ;
+          ()) ;
     None
 end
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -9,10 +9,11 @@ module T = struct
   let id = "breadcrumb"
 
   type t =
-    { validated_transition: External_transition.Validated.t
-    ; staged_ledger: Staged_ledger.t [@sexp.opaque]
-    ; just_emitted_a_proof: bool
-    ; transition_receipt_time: Time.t option }
+    { validated_transition : External_transition.Validated.t
+    ; staged_ledger : Staged_ledger.t [@sexp.opaque]
+    ; just_emitted_a_proof : bool
+    ; transition_receipt_time : Time.t option
+    }
   [@@deriving sexp, fields]
 
   type 'a creator =
@@ -33,13 +34,15 @@ module T = struct
     { validated_transition
     ; staged_ledger
     ; just_emitted_a_proof
-    ; transition_receipt_time }
+    ; transition_receipt_time
+    }
 
   let to_yojson
       { validated_transition
-      ; staged_ledger= _
+      ; staged_ledger = _
       ; just_emitted_a_proof
-      ; transition_receipt_time } =
+      ; transition_receipt_time
+      } =
     `Assoc
       [ ( "validated_transition"
         , External_transition.Validated.to_yojson validated_transition )
@@ -47,9 +50,9 @@ module T = struct
       ; ("just_emitted_a_proof", `Bool just_emitted_a_proof)
       ; ( "transition_receipt_time"
         , `String
-            (Option.value_map transition_receipt_time
-               ~default:"<not available>"
-               ~f:(Time.to_string_iso8601_basic ~zone:Time.Zone.utc)) ) ]
+            (Option.value_map transition_receipt_time ~default:"<not available>"
+               ~f:(Time.to_string_iso8601_basic ~zone:Time.Zone.utc)) )
+      ]
 end
 
 [%%define_locally
@@ -62,17 +65,16 @@ T.
 
 include Allocation_functor.Make.Sexp (T)
 
-let build ?skip_staged_ledger_verification ~logger ~precomputed_values
-    ~verifier ~trust_system ~parent
-    ~transition:(transition_with_validation :
-                  External_transition.Almost_validated.t) ~sender
-    ~transition_receipt_time () =
+let build ?skip_staged_ledger_verification ~logger ~precomputed_values ~verifier
+    ~trust_system ~parent
+    ~transition:
+      (transition_with_validation : External_transition.Almost_validated.t)
+    ~sender ~transition_receipt_time () =
   O1trace.trace_recurring "Breadcrumb.build" (fun () ->
       let open Deferred.Let_syntax in
       match%bind
-        External_transition.Staged_ledger_validation
-        .validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
-          ~precomputed_values ~verifier
+        External_transition.Staged_ledger_validation.validate_staged_ledger_diff
+          ?skip_staged_ledger_verification ~logger ~precomputed_values ~verifier
           ~parent_staged_ledger:(staged_ledger parent)
           ~parent_protocol_state:
             (External_transition.Validated.protocol_state
@@ -81,8 +83,7 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
       with
       | Ok
           ( `Just_emitted_a_proof just_emitted_a_proof
-          , `External_transition_with_validation
-              fully_valid_external_transition
+          , `External_transition_with_validation fully_valid_external_transition
           , `Staged_ledger transitioned_staged_ledger ) ->
           return
           @@ Ok
@@ -96,7 +97,7 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
                 | `Incorrect_target_staged_ledger_hash ->
                     "staged ledger hash"
                 | `Incorrect_target_snarked_ledger_hash ->
-                    "snarked ledger hash" ))
+                    "snarked ledger hash"))
           in
           let message = "invalid staged ledger diff: incorrect " ^ reasons in
           let%map () =
@@ -127,12 +128,12 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
                   ( action
                   , Some
                       ( "Staged_ledger error: $error"
-                      , [("error", `String error_string)] ) )
+                      , [ ("error", `String error_string) ] ) )
                 in
                 let open Trust_system.Actions in
                 (* TODO : refine these actions (#2375) *)
                 let open Staged_ledger.Pre_diff_info.Error in
-                with_return (fun {return} ->
+                with_return (fun { return } ->
                     let action =
                       match staged_ledger_error with
                       | Couldn't_reach_verifier _ ->
@@ -149,15 +150,14 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
                           make_actions Gossiped_invalid_transition
                       | Unexpected _ ->
                           failwith
-                            "build: Unexpected staged ledger error should \
-                             have been caught in another pattern"
+                            "build: Unexpected staged ledger error should have \
+                             been caught in another pattern"
                     in
-                    Trust_system.record trust_system logger peer action )
+                    Trust_system.record trust_system logger peer action)
           in
           Error
             (`Invalid_staged_ledger_diff
-              (Staged_ledger.Staged_ledger_error.to_error staged_ledger_error))
-  )
+              (Staged_ledger.Staged_ledger_error.to_error staged_ledger_error)))
 
 let lift f breadcrumb = f (validated_transition breadcrumb)
 
@@ -201,10 +201,11 @@ let name t =
   @@ state_hash t
 
 type display =
-  { state_hash: string
-  ; blockchain_state: Blockchain_state.display
-  ; consensus_state: Consensus.Data.Consensus_state.display
-  ; parent: string }
+  { state_hash : string
+  ; blockchain_state : Blockchain_state.display
+  ; consensus_state : Consensus.Data.Consensus_state.display
+  ; parent : string
+  }
 [@@deriving yojson]
 
 let display t =
@@ -214,22 +215,23 @@ let display t =
     Visualization.display_prefix_of_string @@ State_hash.to_base58_check
     @@ parent_hash t
   in
-  { state_hash= name t
+  { state_hash = name t
   ; blockchain_state
-  ; consensus_state= Consensus.Data.Consensus_state.display consensus_state
-  ; parent }
+  ; consensus_state = Consensus.Data.Consensus_state.display consensus_state
+  ; parent
+  }
 
 let all_user_commands breadcrumbs =
   Sequence.fold (Sequence.of_list breadcrumbs) ~init:Signed_command.Set.empty
     ~f:(fun acc_set breadcrumb ->
       breadcrumb |> commands
-      |> List.filter_map ~f:(fun {data; _} ->
+      |> List.filter_map ~f:(fun { data; _ } ->
              match data with
              | Snapp_command _ ->
                  None
              | Signed_command c ->
-                 Some (Signed_command.forget_check c) )
-      |> Signed_command.Set.of_list |> Set.union acc_set )
+                 Some (Signed_command.forget_check c))
+      |> Signed_command.Set.of_list |> Set.union acc_set)
 
 module For_tests = struct
   open Currency
@@ -242,7 +244,7 @@ module For_tests = struct
       Signed_command.With_valid_signature.t Sequence.t =
     let account_ids =
       List.map accounts_with_secret_keys ~f:(fun (_, account) ->
-          Account.identifier account )
+          Account.identifier account)
     in
     Sequence.filter_map (accounts_with_secret_keys |> Sequence.of_list)
       ~f:(fun (sender_sk, sender_account) ->
@@ -265,7 +267,7 @@ module For_tests = struct
               sender_account
             |> Or_error.ok_exn
           in
-          assert ([%equal: [`Existed | `Added]] status `Existed) ;
+          assert ([%equal: [ `Existed | `Added ]] status `Existed) ;
           (Option.value_exn (Ledger.get ledger account_location)).nonce
         in
         let send_amount = Currency.Amount.of_int 1 in
@@ -280,12 +282,13 @@ module For_tests = struct
             ~valid_until:None ~memo:Signed_command_memo.dummy
             ~body:
               (Payment
-                 { source_pk= sender_pk
+                 { source_pk = sender_pk
                  ; receiver_pk
-                 ; token_id= token
-                 ; amount= send_amount })
+                 ; token_id = token
+                 ; amount = send_amount
+                 })
         in
-        Signed_command.sign sender_keypair payload )
+        Signed_command.sign sender_keypair payload)
 
   let gen ?(logger = Logger.null ())
       ~(precomputed_values : Precomputed_values.t) ~verifier
@@ -314,17 +317,18 @@ module For_tests = struct
       in
       let largest_account_public_key = Account.public_key largest_account in
       let get_completed_work stmts =
-        let {Keypair.public_key; _} = Keypair.create () in
+        let { Keypair.public_key; _ } = Keypair.create () in
         let prover = Public_key.compress public_key in
         Some
           Transaction_snark_work.Checked.
-            { fee= Fee.of_int 1
-            ; proofs=
+            { fee = Fee.of_int 1
+            ; proofs =
                 One_or_two.map stmts ~f:(fun statement ->
                     Ledger_proof.create ~statement
                       ~sok_digest:Sok_message.Digest.default
-                      ~proof:Proof.transaction_dummy )
-            ; prover }
+                      ~proof:Proof.transaction_dummy)
+            ; prover
+            }
       in
       let current_state_view, state_and_body_hash =
         let prev_state =
@@ -375,7 +379,7 @@ module For_tests = struct
       let next_ledger_hash =
         Option.value_map ledger_proof_opt
           ~f:(fun (proof, _) ->
-            Ledger_proof.statement proof |> Ledger_proof.statement_target )
+            Ledger_proof.statement proof |> Ledger_proof.statement_target)
           ~default:previous_ledger_hash
       in
       let snarked_next_available_token =
@@ -401,12 +405,12 @@ module For_tests = struct
         make_next_consensus_state ~snarked_ledger_hash:previous_ledger_hash
           ~previous_protocol_state:
             With_hash.
-              {data= previous_protocol_state; hash= previous_state_hash}
+              { data = previous_protocol_state; hash = previous_state_hash }
           ~coinbase_receiver ~supercharge_coinbase
       in
       let genesis_state_hash =
-        Protocol_state.genesis_state_hash
-          ~state_hash:(Some previous_state_hash) previous_protocol_state
+        Protocol_state.genesis_state_hash ~state_hash:(Some previous_state_hash)
+          previous_protocol_state
       in
       let protocol_state =
         Protocol_state.create_value ~genesis_state_hash ~previous_state_hash
@@ -440,8 +444,8 @@ module For_tests = struct
       | Ok new_breadcrumb ->
           [%log info]
             ~metadata:
-              [ ( "state_hash"
-                , state_hash new_breadcrumb |> State_hash.to_yojson ) ]
+              [ ("state_hash", state_hash new_breadcrumb |> State_hash.to_yojson)
+              ]
             "Producing a breadcrumb with hash: $state_hash" ;
           new_breadcrumb
       | Error (`Fatal_error exn) ->
@@ -475,7 +479,7 @@ module For_tests = struct
         Deferred.List.fold breadcrumbs_constructors ~init:(root, [])
           ~f:(fun (previous, acc) make_breadcrumb ->
             let%map breadcrumb = make_breadcrumb previous in
-            (breadcrumb, breadcrumb :: acc) )
+            (breadcrumb, breadcrumb :: acc))
       in
       List.rev ls
 end

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -14,10 +14,11 @@ open Network_peer
 type t [@@deriving sexp, equal, compare, to_yojson]
 
 type display =
-  { state_hash: string
-  ; blockchain_state: Blockchain_state.display
-  ; consensus_state: Consensus.Data.Consensus_state.display
-  ; parent: string }
+  { state_hash : string
+  ; blockchain_state : Blockchain_state.display
+  ; consensus_state : Consensus.Data.Consensus_state.display
+  ; parent : string
+  }
 [@@deriving yojson]
 
 val create :
@@ -28,7 +29,7 @@ val create :
   -> t
 
 val build :
-     ?skip_staged_ledger_verification:[`All | `Proofs]
+     ?skip_staged_ledger_verification:[ `All | `Proofs ]
   -> logger:Logger.t
   -> precomputed_values:Precomputed_values.t
   -> verifier:Verifier.t

--- a/src/lib/transition_frontier/frontier_base/diff.mli
+++ b/src/lib/transition_frontier/frontier_base/diff.mli
@@ -29,14 +29,13 @@ end
 
 module Node_list : sig
   type full_node =
-    { transition: External_transition.Validated.t
-    ; scan_state: Staged_ledger.Scan_state.t }
+    { transition : External_transition.Validated.t
+    ; scan_state : Staged_ledger.Scan_state.t
+    }
 
   type lite_node = State_hash.Stable.V1.t
 
-  type _ t =
-    | Full : full_node list -> full t
-    | Lite : lite_node list -> lite t
+  type _ t = Full : full_node list -> full t | Lite : lite_node list -> lite t
 
   type 'repr node_list = 'repr t
 
@@ -59,7 +58,7 @@ end
  *  by transitioning the root.
  *)
 module Root_transition : sig
-  type 'repr t = {new_root: Root_data.Limited.t; garbage: 'repr Node_list.t}
+  type 'repr t = { new_root : Root_data.Limited.t; garbage : 'repr Node_list.t }
 
   type 'repr root_transition = 'repr t
 

--- a/src/lib/transition_frontier/frontier_base/root_data.ml
+++ b/src/lib/transition_frontier/frontier_base/root_data.ml
@@ -7,20 +7,22 @@ module Common = struct
   module Stable = struct
     module V1 = struct
       type t =
-        { scan_state: Staged_ledger.Scan_state.Stable.V1.t
-        ; pending_coinbase: Pending_coinbase.Stable.V1.t }
+        { scan_state : Staged_ledger.Scan_state.Stable.V1.t
+        ; pending_coinbase : Pending_coinbase.Stable.V1.t
+        }
 
       let to_latest = Fn.id
 
-      let to_yojson {scan_state= _; pending_coinbase} =
+      let to_yojson { scan_state = _; pending_coinbase } =
         `Assoc
           [ ("scan_state", `String "<opaque>")
           ; ( "pending_coinbase"
-            , Pending_coinbase.Stable.V1.to_yojson pending_coinbase ) ]
+            , Pending_coinbase.Stable.V1.to_yojson pending_coinbase )
+          ]
     end
   end]
 
-  let create ~scan_state ~pending_coinbase = {scan_state; pending_coinbase}
+  let create ~scan_state ~pending_coinbase = { scan_state; pending_coinbase }
 
   let scan_state t = t.scan_state
 
@@ -32,9 +34,10 @@ module Historical = struct
   module Stable = struct
     module V1 = struct
       type t =
-        { transition: External_transition.Validated.Stable.V1.t
-        ; common: Common.Stable.V1.t
-        ; staged_ledger_target_ledger_hash: Ledger_hash.Stable.V1.t }
+        { transition : External_transition.Validated.Stable.V1.t
+        ; common : Common.Stable.V1.t
+        ; staged_ledger_target_ledger_hash : Ledger_hash.Stable.V1.t
+        }
 
       let to_latest = Fn.id
     end
@@ -59,7 +62,7 @@ module Historical = struct
       Staged_ledger.hash staged_ledger |> Staged_ledger_hash.ledger_hash
     in
     let common = Common.create ~scan_state ~pending_coinbase in
-    {transition; common; staged_ledger_target_ledger_hash}
+    { transition; common; staged_ledger_target_ledger_hash }
 end
 
 module Limited = struct
@@ -67,29 +70,30 @@ module Limited = struct
   module Stable = struct
     module V1 = struct
       type t =
-        { transition: External_transition.Validated.Stable.V1.t
-        ; protocol_states:
+        { transition : External_transition.Validated.Stable.V1.t
+        ; protocol_states :
             ( Mina_base.State_hash.Stable.V1.t
             * Mina_state.Protocol_state.Value.Stable.V1.t )
             list
-        ; common: Common.Stable.V1.t }
+        ; common : Common.Stable.V1.t
+        }
 
-      let to_yojson {transition; protocol_states= _; common} =
+      let to_yojson { transition; protocol_states = _; common } =
         `Assoc
           [ ("transition", External_transition.Validated.to_yojson transition)
           ; ("protocol_states", `String "<opaque>")
-          ; ("common", Common.Stable.V1.to_yojson common) ]
+          ; ("common", Common.Stable.V1.to_yojson common)
+          ]
 
       let to_latest = Fn.id
     end
   end]
 
-  [%%define_locally
-  Stable.Latest.(to_yojson)]
+  [%%define_locally Stable.Latest.(to_yojson)]
 
   let create ~transition ~scan_state ~pending_coinbase ~protocol_states =
-    let common = {Common.scan_state; pending_coinbase} in
-    {transition; common; protocol_states}
+    let common = { Common.scan_state; pending_coinbase } in
+    { transition; common; protocol_states }
 
   let transition t = t.transition
 
@@ -108,21 +112,21 @@ module Minimal = struct
     [@@@no_toplevel_latest_type]
 
     module V1 = struct
-      type t = {hash: State_hash.Stable.V1.t; common: Common.Stable.V1.t}
+      type t = { hash : State_hash.Stable.V1.t; common : Common.Stable.V1.t }
       [@@driving to_yojson]
 
       let to_latest = Fn.id
     end
   end]
 
-  type t = Stable.Latest.t = {hash: State_hash.t; common: Common.t}
+  type t = Stable.Latest.t = { hash : State_hash.t; common : Common.t }
   [@@driving to_yojson]
 
   let hash t = t.hash
 
   let of_limited (l : Limited.t) =
     let hash = External_transition.Validated.state_hash l.transition in
-    {hash; common= l.common}
+    { hash; common = l.common }
 
   let upgrade t ~transition ~protocol_states =
     let hash = hash t in
@@ -136,11 +140,11 @@ module Minimal = struct
           ~protocol_states:(List.map ~f:snd protocol_states)
         |> Or_error.ok_exn
         : (State_hash.t * Mina_state.Protocol_state.value) list ) ;
-    {Limited.transition; protocol_states; common= t.common}
+    { Limited.transition; protocol_states; common = t.common }
 
   let create ~hash ~scan_state ~pending_coinbase =
-    let common = {Common.scan_state; pending_coinbase} in
-    {hash; common}
+    let common = { Common.scan_state; pending_coinbase } in
+    { hash; common }
 
   let scan_state t = Common.scan_state t.common
 
@@ -148,23 +152,24 @@ module Minimal = struct
 end
 
 type t =
-  { transition: External_transition.Validated.t
-  ; staged_ledger: Staged_ledger.t
-  ; protocol_states:
-      (Mina_base.State_hash.t * Mina_state.Protocol_state.Value.t) list }
+  { transition : External_transition.Validated.t
+  ; staged_ledger : Staged_ledger.t
+  ; protocol_states :
+      (Mina_base.State_hash.t * Mina_state.Protocol_state.Value.t) list
+  }
 
-let minimize {transition; staged_ledger; protocol_states= _} =
+let minimize { transition; staged_ledger; protocol_states = _ } =
   let scan_state = Staged_ledger.scan_state staged_ledger in
   let pending_coinbase =
     Staged_ledger.pending_coinbase_collection staged_ledger
   in
   let common = Common.create ~scan_state ~pending_coinbase in
-  {Minimal.hash= External_transition.Validated.state_hash transition; common}
+  { Minimal.hash = External_transition.Validated.state_hash transition; common }
 
-let limit {transition; staged_ledger; protocol_states} =
+let limit { transition; staged_ledger; protocol_states } =
   let scan_state = Staged_ledger.scan_state staged_ledger in
   let pending_coinbase =
     Staged_ledger.pending_coinbase_collection staged_ledger
   in
   let common = Common.create ~scan_state ~pending_coinbase in
-  {Limited.transition; common; protocol_states}
+  { Limited.transition; common; protocol_states }

--- a/src/lib/transition_frontier/frontier_base/root_data.mli
+++ b/src/lib/transition_frontier/frontier_base/root_data.mli
@@ -77,9 +77,8 @@ module Minimal : sig
   val upgrade :
        t
     -> transition:External_transition.Validated.t
-    -> protocol_states:( Mina_base.State_hash.t
-                       * Mina_state.Protocol_state.Value.t )
-                       list
+    -> protocol_states:
+         (Mina_base.State_hash.t * Mina_state.Protocol_state.Value.t) list
     -> Limited.t
 
   val create :
@@ -90,10 +89,11 @@ module Minimal : sig
 end
 
 type t =
-  { transition: External_transition.Validated.t
-  ; staged_ledger: Staged_ledger.t
-  ; protocol_states:
-      (Mina_base.State_hash.t * Mina_state.Protocol_state.Value.t) list }
+  { transition : External_transition.Validated.t
+  ; staged_ledger : Staged_ledger.t
+  ; protocol_states :
+      (Mina_base.State_hash.t * Mina_state.Protocol_state.Value.t) list
+  }
 
 val minimize : t -> Minimal.t
 

--- a/src/lib/transition_frontier/frontier_base/root_identifier.ml
+++ b/src/lib/transition_frontier/frontier_base/root_identifier.ml
@@ -6,10 +6,10 @@ module Stable = struct
   [@@@no_toplevel_latest_type]
 
   module V1 = struct
-    type t = {state_hash: State_hash.Stable.V1.t}
+    type t = { state_hash : State_hash.Stable.V1.t }
 
     let to_latest = Fn.id
   end
 end]
 
-type t = Stable.Latest.t = {state_hash: State_hash.t} [@@deriving yojson]
+type t = Stable.Latest.t = { state_hash : State_hash.t } [@@deriving yojson]

--- a/src/lib/transition_frontier/frontier_base/root_identifier.mli
+++ b/src/lib/transition_frontier/frontier_base/root_identifier.mli
@@ -5,7 +5,7 @@ module Stable : sig
   [@@@no_toplevel_latest_type]
 
   module V1 : sig
-    type t = {state_hash: State_hash.t}
+    type t = { state_hash : State_hash.t }
   end
 end]
 

--- a/src/lib/transition_frontier/full_catchup_tree.ml
+++ b/src/lib/transition_frontier/full_catchup_tree.ml
@@ -8,10 +8,10 @@ open Mina_numbers
 
 module Attempt_history = struct
   module Attempt = struct
-    type reason = [`Download | `Initial_validate | `Verify | `Build_breadcrumb]
+    type reason = [ `Download | `Initial_validate | `Verify | `Build_breadcrumb ]
     [@@deriving yojson]
 
-    type t = {failure_reason: reason} [@@deriving yojson]
+    type t = { failure_reason : reason } [@@deriving yojson]
   end
 
   type t = Attempt.t Peer.Map.t
@@ -19,7 +19,7 @@ module Attempt_history = struct
   let to_yojson (t : t) =
     `Assoc
       (List.map (Map.to_alist t) ~f:(fun (peer, a) ->
-           (Peer.to_multiaddr_string peer, Attempt.to_yojson a) ))
+           (Peer.to_multiaddr_string peer, Attempt.to_yojson a)))
 
   let empty : t = Peer.Map.empty
 end
@@ -38,7 +38,8 @@ module Downloader_job = struct
     `Assoc
       [ ("hash", State_hash.to_yojson h)
       ; ("length", Length.to_yojson l)
-      ; ("attempts", Attempt_history.to_yojson t.attempts) ]
+      ; ("attempts", Attempt_history.to_yojson t.attempts)
+      ]
 
   let result (t : t) = Ivar.read t.res
 end
@@ -59,7 +60,7 @@ module Node = struct
           , State_hash.t )
           Cached.t
       | To_build_breadcrumb of
-          ( [`Parent of State_hash.t]
+          ( [ `Parent of State_hash.t ]
           * ( External_transition.Almost_validated.t Envelope.Incoming.t
             , State_hash.t )
             Cached.t )
@@ -104,12 +105,13 @@ module Node = struct
   end
 
   type t =
-    { mutable state: State.t
-    ; mutable attempts: Attempt_history.t
-    ; state_hash: State_hash.t
-    ; blockchain_length: Length.t
-    ; parent: State_hash.t
-    ; result: ([`Added_to_frontier], Attempt_history.t) Result.t Ivar.t }
+    { mutable state : State.t
+    ; mutable attempts : Attempt_history.t
+    ; state_hash : State_hash.t
+    ; blockchain_length : Length.t
+    ; parent : State_hash.t
+    ; result : ([ `Added_to_frontier ], Attempt_history.t) Result.t Ivar.t
+    }
 end
 
 let add_state states (node : Node.t) =
@@ -117,26 +119,27 @@ let add_state states (node : Node.t) =
     | None ->
         State_hash.Set.singleton node.state_hash
     | Some hashes ->
-        State_hash.Set.add hashes node.state_hash )
+        State_hash.Set.add hashes node.state_hash)
 
 let remove_state states (node : Node.t) =
   Hashtbl.update states (Node.State.enum node.state) ~f:(function
     | None ->
         State_hash.Set.empty
     | Some hashes ->
-        State_hash.Set.remove hashes node.state_hash )
+        State_hash.Set.remove hashes node.state_hash)
 
 (* Invariant: The length of the path from each best tip to its oldest
    ancestor is at most k *)
 type t =
-  { nodes: Node.t State_hash.Table.t
-  ; states: State_hash.Set.t Node.State.Enum.Table.t
-  ; logger: Logger.t }
+  { nodes : Node.t State_hash.Table.t
+  ; states : State_hash.Set.t Node.State.Enum.Table.t
+  ; logger : Logger.t
+  }
 
 (* mutable root: Node.t ; *)
 (*     ; mutable target: State_hash.t Envelope.Incoming.t (* So that we know who to punish if the process fails *) *)
 
-let tear_down {nodes; states; _} =
+let tear_down { nodes; states; _ } =
   Hashtbl.iter nodes ~f:(fun x ->
       match x.state with
       | Root _ | Failed | Finished ->
@@ -146,7 +149,7 @@ let tear_down {nodes; states; _} =
       | To_initial_validate _
       | To_verify _
       | To_build_breadcrumb _ ->
-          Ivar.fill_if_empty x.result (Error x.attempts) ) ;
+          Ivar.fill_if_empty x.result (Error x.attempts)) ;
   Hashtbl.clear nodes ;
   Hashtbl.clear states
 
@@ -171,8 +174,7 @@ let to_yojson =
   fun (t : t) ->
     T.to_yojson
     @@ List.map (Hashtbl.to_alist t.states) ~f:(fun (state, hashes) ->
-           ( state
-           , (State_hash.Set.length hashes, State_hash.Set.to_list hashes) ) )
+           (state, (State_hash.Set.length hashes, State_hash.Set.to_list hashes)))
 
 let max_catchup_chain_length (t : t) =
   (* Find the longest directed path *)
@@ -192,27 +194,28 @@ let max_catchup_chain_length (t : t) =
           | To_initial_validate _
           | To_verify _
           | To_build_breadcrumb _ -> (
-            match Hashtbl.find t.nodes node.parent with
-            | None ->
-                1
-            | Some parent ->
-                1 + longest_starting_at parent )
+              match Hashtbl.find t.nodes node.parent with
+              | None ->
+                  1
+              | Some parent ->
+                  1 + longest_starting_at parent )
         in
         Hashtbl.set lengths ~key:node.state_hash ~data:n ;
         n
   in
   Hashtbl.fold t.nodes ~init:0 ~f:(fun ~key:_ ~data acc ->
-      Int.max acc (longest_starting_at data) )
+      Int.max acc (longest_starting_at data))
 
 let create_node_full t b : unit =
   let h = Breadcrumb.state_hash b in
   let node : Node.t =
-    { state= Finished
-    ; state_hash= h
-    ; blockchain_length= Breadcrumb.blockchain_length b
-    ; attempts= Attempt_history.empty
-    ; parent= Breadcrumb.parent_hash b
-    ; result= Ivar.create_full (Ok `Added_to_frontier) }
+    { state = Finished
+    ; state_hash = h
+    ; blockchain_length = Breadcrumb.blockchain_length b
+    ; attempts = Attempt_history.empty
+    ; parent = Breadcrumb.parent_hash b
+    ; result = Ivar.create_full (Ok `Added_to_frontier)
+    }
   in
   add_state t.states node ;
   Hashtbl.add_exn t.nodes ~key:h ~data:node
@@ -277,11 +280,11 @@ let prune t ~root_hash =
           | None ->
               false
           | Some parent ->
-              reachable_from_root parent )
+              reachable_from_root parent)
   in
   let to_remove =
     Hashtbl.fold t.nodes ~init:[] ~f:(fun ~key:_ ~data acc ->
-        if reachable_from_root data then acc else data :: acc )
+        if reachable_from_root data then acc else data :: acc)
   in
   List.iter to_remove ~f:(remove_node' t)
 
@@ -289,24 +292,26 @@ let apply_diffs (t : t) (ds : Diff.Full.E.t list) =
   List.iter ds ~f:(function
     | E (New_node (Full b)) ->
         breadcrumb_added t b
-    | E (Root_transitioned {new_root; garbage= Full hs}) ->
+    | E (Root_transitioned { new_root; garbage = Full hs }) ->
         List.iter (Diff.Node_list.to_lite hs) ~f:(remove_node t) ;
         let h = Root_data.Limited.hash new_root in
         if Hashtbl.mem t.nodes h then prune t ~root_hash:h
         else (
           [%log' debug t.logger]
-            ~metadata:[("hash", State_hash.to_yojson h); ("tree", to_yojson t)]
-            "catchup $tree invariant broken: new root $hash not present. \
-             Diffs may have been applied out of order. This may lead to a \
-             memory leak" ;
+            ~metadata:
+              [ ("hash", State_hash.to_yojson h); ("tree", to_yojson t) ]
+            "catchup $tree invariant broken: new root $hash not present. Diffs \
+             may have been applied out of order. This may lead to a memory \
+             leak" ;
           () )
     | E (Best_tip_changed _) ->
-        () )
+        ())
 
 let create ~root =
   let t =
-    { states= Node.State.Enum.Table.create ()
-    ; nodes= State_hash.Table.create ()
-    ; logger= Logger.create () }
+    { states = Node.State.Enum.Table.create ()
+    ; nodes = State_hash.Table.create ()
+    ; logger = Logger.create ()
+    }
   in
   create_node_full t root ; t

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -6,30 +6,33 @@ open Frontier_base
 
 module Node = struct
   type t =
-    {breadcrumb: Breadcrumb.t; successor_hashes: State_hash.t list; length: int}
+    { breadcrumb : Breadcrumb.t
+    ; successor_hashes : State_hash.t list
+    ; length : int
+    }
   [@@deriving sexp, fields]
 
   type display =
-    { length: int
-    ; state_hash: string
-    ; blockchain_state: Blockchain_state.display
-    ; consensus_state: Consensus.Data.Consensus_state.display }
+    { length : int
+    ; state_hash : string
+    ; blockchain_state : Blockchain_state.display
+    ; consensus_state : Consensus.Data.Consensus_state.display
+    }
   [@@deriving yojson]
 
   let equal node1 node2 = Breadcrumb.equal node1.breadcrumb node2.breadcrumb
 
   let hash node = Breadcrumb.hash node.breadcrumb
 
-  let compare node1 node2 =
-    Breadcrumb.compare node1.breadcrumb node2.breadcrumb
+  let compare node1 node2 = Breadcrumb.compare node1.breadcrumb node2.breadcrumb
 
   let name t = Breadcrumb.name t.breadcrumb
 
   let display t =
-    let {Breadcrumb.state_hash; consensus_state; blockchain_state; _} =
+    let { Breadcrumb.state_hash; consensus_state; blockchain_state; _ } =
       Breadcrumb.display t.breadcrumb
     in
-    {state_hash; blockchain_state; length= t.length; consensus_state}
+    { state_hash; blockchain_state; length = t.length; consensus_state }
 end
 
 module Protocol_states_for_root_scan_state = struct
@@ -44,33 +47,34 @@ module Protocol_states_for_root_scan_state = struct
     in
     let protocol_state_map =
       (*Note: Protocol states for the next root should all be in this map
-      assuming roots transition to their successors and do not skip any node in
-      between*)
+        assuming roots transition to their successors and do not skip any node in
+        between*)
       State_hash.Map.set protocol_states_for_old_root ~key:old_root_state.hash
         ~data:old_root_state.data
     in
     List.map required_state_hashes ~f:(fun hash ->
-        (hash, State_hash.Map.find_exn protocol_state_map hash) )
+        (hash, State_hash.Map.find_exn protocol_state_map hash))
 end
 
 (* Invariant: The path from the root to the tip inclusively, will be max_length *)
 type t =
-  { root_ledger: Ledger.Any_ledger.witness
-  ; mutable root: State_hash.t
-  ; mutable best_tip: State_hash.t
-  ; logger: Logger.t
-  ; table: Node.t State_hash.Table.t
-  ; mutable protocol_states_for_root_scan_state:
+  { root_ledger : Ledger.Any_ledger.witness
+  ; mutable root : State_hash.t
+  ; mutable best_tip : State_hash.t
+  ; logger : Logger.t
+  ; table : Node.t State_hash.Table.t
+  ; mutable protocol_states_for_root_scan_state :
       Protocol_states_for_root_scan_state.t
-  ; consensus_local_state: Consensus.Data.Local_state.t
-  ; max_length: int
-  ; precomputed_values: Precomputed_values.t
-  ; time_controller: Block_time.Controller.t }
+  ; consensus_local_state : Consensus.Data.Local_state.t
+  ; max_length : int
+  ; precomputed_values : Precomputed_values.t
+  ; time_controller : Block_time.Controller.t
+  }
 
-let consensus_local_state {consensus_local_state; _} = consensus_local_state
+let consensus_local_state { consensus_local_state; _ } = consensus_local_state
 
 let all_breadcrumbs t =
-  List.map (Hashtbl.data t.table) ~f:(fun {breadcrumb; _} -> breadcrumb)
+  List.map (Hashtbl.data t.table) ~f:(fun { breadcrumb; _ } -> breadcrumb)
 
 let find t hash =
   let open Option.Let_syntax in
@@ -134,33 +138,35 @@ let create ~logger ~root_data ~root_ledger ~consensus_local_state ~max_length
       ~transition_receipt_time
   in
   let root_node =
-    {Node.breadcrumb= root_breadcrumb; successor_hashes= []; length= 0}
+    { Node.breadcrumb = root_breadcrumb; successor_hashes = []; length = 0 }
   in
-  let table = State_hash.Table.of_alist_exn [(root_hash, root_node)] in
+  let table = State_hash.Table.of_alist_exn [ (root_hash, root_node) ] in
   Mina_metrics.(Gauge.set Transition_frontier.active_breadcrumbs 1.0) ;
   let t =
     { logger
     ; root_ledger
-    ; root= root_hash
-    ; best_tip= root_hash
+    ; root = root_hash
+    ; best_tip = root_hash
     ; table
     ; consensus_local_state
     ; max_length
     ; precomputed_values
     ; protocol_states_for_root_scan_state
-    ; time_controller }
+    ; time_controller
+    }
   in
   t
 
 let root_data t =
   let open Root_data in
   let root = root t in
-  { transition= Breadcrumb.validated_transition root
-  ; staged_ledger= Breadcrumb.staged_ledger root
-  ; protocol_states=
-      State_hash.Map.to_alist t.protocol_states_for_root_scan_state }
+  { transition = Breadcrumb.validated_transition root
+  ; staged_ledger = Breadcrumb.staged_ledger root
+  ; protocol_states =
+      State_hash.Map.to_alist t.protocol_states_for_root_scan_state
+  }
 
-let max_length {max_length; _} = max_length
+let max_length { max_length; _ } = max_length
 
 let root_length t = (Hashtbl.find_exn t.table t.root).length
 
@@ -170,7 +176,7 @@ let successor_hashes t hash =
 
 let rec successor_hashes_rec t hash =
   List.bind (successor_hashes t hash) ~f:(fun succ_hash ->
-      succ_hash :: successor_hashes_rec t succ_hash )
+      succ_hash :: successor_hashes_rec t succ_hash)
 
 let successors t breadcrumb =
   List.map
@@ -179,7 +185,7 @@ let successors t breadcrumb =
 
 let rec successors_rec t breadcrumb =
   List.bind (successors t breadcrumb) ~f:(fun succ ->
-      succ :: successors_rec t succ )
+      succ :: successors_rec t succ)
 
 let path_map ?max_length t breadcrumb ~f =
   let rec find_path b count_opt acc =
@@ -206,7 +212,7 @@ let genesis_constants t = t.precomputed_values.genesis_constants
 
 let iter t ~f = Hashtbl.iter t.table ~f:(fun n -> f n.breadcrumb)
 
-let best_tip_path_length_exn {table; root; best_tip; _} =
+let best_tip_path_length_exn { table; root; best_tip; _ } =
   let open Option.Let_syntax in
   let result =
     let%bind best_tip_node = Hashtbl.find table best_tip in
@@ -215,8 +221,7 @@ let best_tip_path_length_exn {table; root; best_tip; _} =
   in
   result |> Option.value_exn
 
-let common_ancestor t (bc1 : Breadcrumb.t) (bc2 : Breadcrumb.t) : State_hash.t
-    =
+let common_ancestor t (bc1 : Breadcrumb.t) (bc2 : Breadcrumb.t) : State_hash.t =
   let rec go ancestors1 ancestors2 b1 b2 =
     let sh1 = Breadcrumb.state_hash b1 in
     let sh2 = Breadcrumb.state_hash b2 in
@@ -257,15 +262,16 @@ module Visualizor = struct
                 [%log' debug t.logger]
                   ~metadata:
                     [ ("state_hash", State_hash.to_yojson successor_state_hash)
-                    ; ("error", `String "missing from frontier") ]
+                    ; ("error", `String "missing from frontier")
+                    ]
                   "Could not visualize state $state_hash: $error" ;
-                acc_graph ) )
+                acc_graph))
 end
 
 let visualize ~filename (t : t) =
   Out_channel.with_file filename ~f:(fun output_channel ->
       let graph = Visualizor.to_graph t in
-      Visualizor.output_graph output_channel graph )
+      Visualizor.output_graph output_channel graph)
 
 let visualize_to_string t =
   let graph = Visualizor.to_graph t in
@@ -284,11 +290,11 @@ let calculate_root_transition_diff t heir =
   let heir_staged_ledger = Breadcrumb.staged_ledger heir in
   let heir_siblings =
     List.filter (successors t root) ~f:(fun breadcrumb ->
-        not (State_hash.equal heir_hash (Breadcrumb.state_hash breadcrumb)) )
+        not (State_hash.equal heir_hash (Breadcrumb.state_hash breadcrumb)))
   in
   let garbage_breadcrumbs =
     List.bind heir_siblings ~f:(fun sibling ->
-        sibling :: successors_rec t sibling )
+        sibling :: successors_rec t sibling)
     |> List.rev
   in
   let garbage_nodes =
@@ -298,15 +304,14 @@ let calculate_root_transition_diff t heir =
         let scan_state =
           Staged_ledger.scan_state (Breadcrumb.staged_ledger breadcrumb)
         in
-        {transition; scan_state} )
+        { transition; scan_state })
   in
   let protocol_states =
-    Protocol_states_for_root_scan_state
-    .protocol_states_for_next_root_scan_state
+    Protocol_states_for_root_scan_state.protocol_states_for_next_root_scan_state
       t.protocol_states_for_root_scan_state
       ~new_scan_state:(Staged_ledger.scan_state heir_staged_ledger)
       ~old_root_state:
-        {With_hash.hash= root_hash; data= Breadcrumb.protocol_state root}
+        { With_hash.hash = root_hash; data = Breadcrumb.protocol_state root }
   in
   let new_root_data =
     Root_data.Limited.create ~transition:heir_transition
@@ -316,7 +321,8 @@ let calculate_root_transition_diff t heir =
       ~protocol_states
   in
   Diff.Full.E.E
-    (Root_transitioned {new_root= new_root_data; garbage= Full garbage_nodes})
+    (Root_transitioned
+       { new_root = new_root_data; garbage = Full garbage_nodes })
 
 let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
     ~enable_epoch_ledger_sync =
@@ -375,7 +381,7 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
               (Breadcrumb.consensus_state old_root_node.breadcrumb)
               (Breadcrumb.consensus_state new_root_node.breadcrumb)
               ~local_state:t.consensus_local_state ~snarked_ledger
-              ~genesis_ledger_hash )
+              ~genesis_ledger_hash)
     | `Disabled ->
         ()
   in
@@ -393,7 +399,7 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
         ignore
           ( Ledger.Maskable.unregister_mask_exn ~loc:__LOC__ mask
             : Ledger.unattached_mask ) ;
-        Hashtbl.remove t.table hash ) ;
+        Hashtbl.remove t.table hash) ;
     (* STEP 2 *)
     (* go ahead and remove the old root from the frontier *)
     Hashtbl.remove t.table t.root ;
@@ -444,7 +450,7 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
                    ~constraint_constants:
                      t.precomputed_values.constraint_constants ~txn_state_view
                    mt txn.data)
-              : Ledger.Transaction_applied.t ) ) ;
+              : Ledger.Transaction_applied.t )) ;
       (* STEP 6 *)
       Ledger.commit mt ;
       (* STEP 7 *)
@@ -465,15 +471,15 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
         (Breadcrumb.transition_receipt_time new_root_node.breadcrumb)
   in
   (*Update the protocol states required for scan state at the new root.
-  Note: this should be after applying the transactions to the snarked ledger (Step 5)
-  because the protocol states corresponding to those transactions won't be part
-  of the new_root_protocol_states since those transactions would have been
-  deleted from the scan state after emitting the proof*)
+    Note: this should be after applying the transactions to the snarked ledger (Step 5)
+    because the protocol states corresponding to those transactions won't be part
+    of the new_root_protocol_states since those transactions would have been
+    deleted from the scan state after emitting the proof*)
   let new_protocol_states_map =
     State_hash.Map.of_alist_exn new_root_protocol_states
   in
   t.protocol_states_for_root_scan_state <- new_protocol_states_map ;
-  let new_root_node = {new_root_node with breadcrumb= new_root_breadcrumb} in
+  let new_root_node = { new_root_node with breadcrumb = new_root_breadcrumb } in
   (* update the new root breadcrumb in the frontier *)
   Hashtbl.set t.table ~key:new_root_hash ~data:new_root_node ;
   (* rewrite the root pointer to the new root hash *)
@@ -489,7 +495,7 @@ let calculate_diffs t breadcrumb =
       in
       let root_node = Hashtbl.find_exn t.table t.root in
       let current_best_tip = best_tip t in
-      let diffs = [Full.E.E (New_node (Full breadcrumb))] in
+      let diffs = [ Full.E.E (New_node (Full breadcrumb)) ] in
       (* check if new breadcrumb extends frontier to longer than k *)
       let diffs =
         if parent_node.length + 1 - root_node.length > t.max_length then
@@ -503,19 +509,19 @@ let calculate_diffs t breadcrumb =
           Consensus.Hooks.equal_select_status
             (Consensus.Hooks.select
                ~constants:t.precomputed_values.consensus_constants
-               ~existing:
-                 (Breadcrumb.consensus_state_with_hash current_best_tip)
+               ~existing:(Breadcrumb.consensus_state_with_hash current_best_tip)
                ~candidate:(Breadcrumb.consensus_state_with_hash breadcrumb)
                ~logger:
                  (Logger.extend t.logger
                     [ ( "selection_context"
-                      , `String "comparing new breadcrumb to best tip" ) ]))
+                      , `String "comparing new breadcrumb to best tip" )
+                    ]))
             `Take
         then Full.E.E (Best_tip_changed breadcrumb_hash) :: diffs
         else diffs
       in
       (* reverse diffs so that they are applied in the correct order *)
-      List.rev diffs )
+      List.rev diffs)
 
 (* TODO: refactor metrics tracking outside of apply_diff (could maybe even be an extension?) *)
 let apply_diff (type mutant) t (diff : (Diff.full, mutant) Diff.t)
@@ -526,18 +532,19 @@ let apply_diff (type mutant) t (diff : (Diff.full, mutant) Diff.t)
       let parent_hash = Breadcrumb.parent_hash breadcrumb in
       let parent_node = Hashtbl.find_exn t.table parent_hash in
       Hashtbl.add_exn t.table ~key:breadcrumb_hash
-        ~data:{breadcrumb; successor_hashes= []; length= parent_node.length + 1} ;
+        ~data:
+          { breadcrumb; successor_hashes = []; length = parent_node.length + 1 } ;
       Hashtbl.set t.table ~key:parent_hash
         ~data:
           { parent_node with
-            successor_hashes= breadcrumb_hash :: parent_node.successor_hashes
+            successor_hashes = breadcrumb_hash :: parent_node.successor_hashes
           } ;
       ((), None)
   | Best_tip_changed new_best_tip ->
       let old_best_tip = t.best_tip in
       t.best_tip <- new_best_tip ;
       (old_best_tip, None)
-  | Root_transitioned {new_root; garbage= Full garbage} ->
+  | Root_transitioned { new_root; garbage = Full garbage } ->
       let new_root_hash = Root_data.Limited.hash new_root in
       let old_root_hash = t.root in
       let new_root_protocol_states =
@@ -554,20 +561,20 @@ module Metrics = struct
       let tbl = State_hash.Table.create () in
       Hashtbl.iter t.table ~f:(fun node ->
           let b = node.breadcrumb in
-          Hashtbl.add_multi tbl ~key:(Breadcrumb.parent_hash b) ~data:b ) ;
+          Hashtbl.add_multi tbl ~key:(Breadcrumb.parent_hash b) ~data:b) ;
       fun b -> Hashtbl.find_multi tbl (Breadcrumb.state_hash b)
     in
     let on_best_tip_path : Breadcrumb.t -> bool =
       let s = State_hash.Hash_set.create () in
       List.iter (best_tip_path t) ~f:(fun b ->
-          Hash_set.add s (Breadcrumb.state_hash b) ) ;
+          Hash_set.add s (Breadcrumb.state_hash b)) ;
       fun b -> Hash_set.mem s (Breadcrumb.state_hash b)
     in
     let rec longest_fork subtree_root =
       (* TODO: Make tail recursive *)
       List.map (children subtree_root) ~f:(fun child ->
           if on_best_tip_path child then longest_fork child
-          else 1 + longest_fork child )
+          else 1 + longest_fork child)
       |> List.max_elt ~compare:Int.compare
       |> Option.value ~default:0
     in
@@ -604,9 +611,9 @@ module Metrics = struct
         .diff
     in
     match (d1.coinbase, d2) with
-    | Zero, None | Zero, Some {coinbase= Zero; _} ->
+    | Zero, None | Zero, Some { coinbase = Zero; _ } ->
         false
-    | Zero, Some {coinbase= One _; _} | One _, _ | Two _, _ ->
+    | Zero, Some { coinbase = One _; _ } | One _, _ | Two _, _ ->
         true
 
   let intprop f b = Unsigned.UInt32.to_int (f (Breadcrumb.consensus_state b))
@@ -644,8 +651,8 @@ module Metrics = struct
     else Float.of_int length_change /. Float.of_int slot_change
 end
 
-let update_metrics_with_diff (type mutant) t
-    (diff : (Diff.full, mutant) Diff.t) : unit =
+let update_metrics_with_diff (type mutant) t (diff : (Diff.full, mutant) Diff.t)
+    : unit =
   let open Metrics in
   match diff with
   | New_node (Full b) ->
@@ -654,7 +661,7 @@ let update_metrics_with_diff (type mutant) t
         Counter.inc_one Transition_frontier.total_breadcrumbs ;
         Gauge.set Transition_frontier.accepted_block_slot_time_sec
           (slot_time t b |> slot_time_to_offset_time_span))
-  | Root_transitioned {garbage= Full garbage_breadcrumbs; _} ->
+  | Root_transitioned { garbage = Full garbage_breadcrumbs; _ } ->
       let new_root_breadcrumb = root t in
       Mina_metrics.(
         let num_breadcrumbs_removed =
@@ -663,8 +670,7 @@ let update_metrics_with_diff (type mutant) t
         let num_finalized_staged_txns =
           Int.to_float (List.length (Breadcrumb.commands new_root_breadcrumb))
         in
-        Gauge.dec Transition_frontier.active_breadcrumbs
-          num_breadcrumbs_removed ;
+        Gauge.dec Transition_frontier.active_breadcrumbs num_breadcrumbs_removed ;
         Gauge.set Transition_frontier.recently_finalized_staged_txns
           num_finalized_staged_txns ;
         Counter.inc Transition_frontier.finalized_staged_txns
@@ -741,15 +747,14 @@ let apply_diffs t diffs ~enable_epoch_ledger_sync ~has_long_catchup_job =
           | None ->
               prev_root
           | Some state_hash ->
-              Some {state_hash}
+              Some { state_hash }
         in
-        (new_root, Diff.Full.With_mutant.E (diff, mutant) :: diffs_with_mutants)
-    )
+        (new_root, Diff.Full.With_mutant.E (diff, mutant) :: diffs_with_mutants))
   in
   [%log' trace t.logger] "after applying diffs to full frontier" ;
   if
     (not
-       ([%equal: [`Enabled of _ | `Disabled]] enable_epoch_ledger_sync
+       ([%equal: [ `Enabled of _ | `Disabled ]] enable_epoch_ledger_sync
           `Disabled))
     && not has_long_catchup_job
   then
@@ -766,8 +771,8 @@ let apply_diffs t diffs ~enable_epoch_ledger_sync ~has_long_catchup_job =
             (* But if there wasn't sync work to do when we started, then there shouldn't be now. *)
             if local_state_was_synced_at_start then (
               [%log' fatal t.logger]
-                "after lock transition, the best tip consensus state is out \
-                 of sync with the local state -- bug in either \
+                "after lock transition, the best tip consensus state is out of \
+                 sync with the local state -- bug in either \
                  required_local_state_sync or frontier_root_transition."
                 ~metadata:
                   [ ( "sync_jobs"
@@ -775,11 +780,12 @@ let apply_diffs t diffs ~enable_epoch_ledger_sync ~has_long_catchup_job =
                   ; ( "local_state"
                     , Consensus.Data.Local_state.to_yojson
                         t.consensus_local_state )
-                  ; ("tf_viz", `String (visualize_to_string t)) ] ;
+                  ; ("tf_viz", `String (visualize_to_string t))
+                  ] ;
               failwith
                 "local state desynced after applying diffs to full frontier" )
         | None ->
-            () ) ;
+            ()) ;
   `New_root_and_diffs_with_mutants (new_root, diffs_with_mutants)
 
 module For_tests = struct

--- a/src/lib/transition_frontier/full_frontier/full_frontier.mli
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.mli
@@ -47,7 +47,7 @@ val protocol_states_for_root_scan_state :
 val apply_diffs :
      t
   -> Diff.Full.E.t list
-  -> enable_epoch_ledger_sync:[`Enabled of Ledger.Db.t | `Disabled]
+  -> enable_epoch_ledger_sync:[ `Enabled of Ledger.Db.t | `Disabled ]
   -> has_long_catchup_job:bool
   -> [ `New_root_and_diffs_with_mutants of
        Root_identifier.t option * Diff.Full.With_mutant.t list ]

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -32,6 +32,7 @@ module Schema = struct
       [%%versioned
       module Stable = struct
         [@@@no_toplevel_latest_type]
+
         module V1 = struct
           type t = string * State_hash.Stable.V1.t
 
@@ -85,23 +86,26 @@ module Schema = struct
       -> of_gadt:(a t -> data)
       -> a t Bin_prot.Type_class.t =
    fun (module M) ~to_gadt ~of_gadt ->
-    let ({shape; writer= {size; write}; reader= {read; vtag_read}}
+    let ({ shape; writer = { size; write }; reader = { read; vtag_read } }
           : data Bin_prot.Type_class.t) =
       [%bin_type_class: M.t]
     in
     { shape
-    ; writer=
-        { size= Fn.compose size of_gadt
-        ; write= (fun buffer ~pos gadt -> write buffer ~pos (of_gadt gadt)) }
-    ; reader=
-        { read= (fun buffer ~pos_ref -> to_gadt (read buffer ~pos_ref))
-        ; vtag_read=
+    ; writer =
+        { size = Fn.compose size of_gadt
+        ; write = (fun buffer ~pos gadt -> write buffer ~pos (of_gadt gadt))
+        }
+    ; reader =
+        { read = (fun buffer ~pos_ref -> to_gadt (read buffer ~pos_ref))
+        ; vtag_read =
             (fun buffer ~pos_ref number ->
-              to_gadt (vtag_read buffer ~pos_ref number) ) } }
+              to_gadt (vtag_read buffer ~pos_ref number))
+        }
+    }
 
   (* HACK: The OCaml compiler thought the pattern matching in of_gadts was
-   non-exhaustive. However, it should not be since I constrained the
-   polymorphic type *)
+     non-exhaustive. However, it should not be since I constrained the
+     polymorphic type *)
   let[@warning "-8"] binable_key_type (type a) :
       a t -> a t Bin_prot.Type_class.t = function
     | Db_version ->
@@ -134,7 +138,7 @@ module Schema = struct
           (module Keys.String)
           ~to_gadt:(fun _ -> Protocol_states_for_root_scan_state)
           ~of_gadt:(fun Protocol_states_for_root_scan_state ->
-            "protocol_states_in_root_scan_state" )
+            "protocol_states_in_root_scan_state")
 end
 
 module Error = struct
@@ -151,11 +155,11 @@ module Error = struct
     | `Arcs of State_hash.t
     | `Protocol_states_for_root_scan_state ]
 
-  type not_found = [`Not_found of not_found_member]
+  type not_found = [ `Not_found of not_found_member ]
 
-  type raised = [`Raised of Error.t]
+  type raised = [ `Raised of Error.t ]
 
-  type t = [not_found | raised | `Invalid_version]
+  type t = [ not_found | raised | `Invalid_version ]
 
   let not_found_message (`Not_found member) =
     let member_name, member_id =
@@ -185,7 +189,7 @@ module Error = struct
     in
     let additional_context =
       Option.map member_id ~f:(fun id ->
-          Printf.sprintf " (hash = %s)" (State_hash.raw_hash_bytes id) )
+          Printf.sprintf " (hash = %s)" (State_hash.raw_hash_bytes id))
       |> Option.value ~default:""
     in
     Printf.sprintf "%s not found%s" member_name additional_context
@@ -201,12 +205,12 @@ end
 
 module Rocks = Rocksdb.Serializable.GADT.Make (Schema)
 
-type t = {directory: string; logger: Logger.t; db: Rocks.t}
+type t = { directory : string; logger : Logger.t; db : Rocks.t }
 
 let create ~logger ~directory =
-  if not (Result.is_ok (Unix.access directory [`Exists])) then
+  if not (Result.is_ok (Unix.access directory [ `Exists ])) then
     Unix.mkdir ~perm:0o766 directory ;
-  {directory; logger; db= Rocks.create directory}
+  { directory; logger; db = Rocks.create directory }
 
 let close t = Rocks.close t.db
 
@@ -268,7 +272,7 @@ let check t ~genesis_state_hash =
               get t.db ~key:(Transition succ_hash)
                 ~error:(`Corrupt (`Not_found (`Transition succ_hash)))
             in
-            check_arcs succ_hash )
+            check_arcs succ_hash)
       in
       let%bind () = check_version () in
       let%bind root_hash, root_transition = check_base () in
@@ -277,21 +281,21 @@ let check t ~genesis_state_hash =
           External_transition.protocol_state root_transition
           |> Mina_state.Protocol_state.genesis_state_hash
         in
-        if State_hash.equal persisted_genesis_state_hash genesis_state_hash
-        then Ok ()
+        if State_hash.equal persisted_genesis_state_hash genesis_state_hash then
+          Ok ()
         else Error (`Genesis_state_mismatch persisted_genesis_state_hash)
       in
-      check_arcs root_hash )
+      check_arcs root_hash)
   |> Result.map_error ~f:(fun err -> `Corrupt (`Raised err))
   |> Result.join
 
 let initialize t ~root_data =
   let open Root_data.Limited in
-  let {With_hash.hash= root_state_hash; data= root_transition}, _ =
+  let { With_hash.hash = root_state_hash; data = root_transition }, _ =
     External_transition.Validated.erase (transition root_data)
   in
   [%log' trace t.logger]
-    ~metadata:[("root_data", Root_data.Limited.to_yojson root_data)]
+    ~metadata:[ ("root_data", Root_data.Limited.to_yojson root_data) ]
     "Initializing persistent frontier database with $root_data" ;
   Batch.with_batch t.db ~f:(fun batch ->
       Batch.set batch ~key:Db_version ~data:version ;
@@ -300,11 +304,11 @@ let initialize t ~root_data =
       Batch.set batch ~key:Root ~data:(Root_data.Minimal.of_limited root_data) ;
       Batch.set batch ~key:Best_tip ~data:root_state_hash ;
       Batch.set batch ~key:Protocol_states_for_root_scan_state
-        ~data:(List.unzip (protocol_states root_data) |> snd) )
+        ~data:(List.unzip (protocol_states root_data) |> snd))
 
 let add t ~transition =
   let parent_hash = External_transition.Validated.parent_hash transition in
-  let {With_hash.hash; data= raw_transition}, _ =
+  let { With_hash.hash; data = raw_transition }, _ =
     External_transition.Validated.erase transition
   in
   let%bind () =
@@ -318,7 +322,7 @@ let add t ~transition =
   Batch.with_batch t.db ~f:(fun batch ->
       Batch.set batch ~key:(Transition hash) ~data:raw_transition ;
       Batch.set batch ~key:(Arcs hash) ~data:[] ;
-      Batch.set batch ~key:(Arcs parent_hash) ~data:(hash :: parent_arcs) )
+      Batch.set batch ~key:(Arcs parent_hash) ~data:(hash :: parent_arcs))
 
 let move_root t ~new_root ~garbage =
   let open Root_data.Limited in
@@ -343,7 +347,7 @@ let move_root t ~new_root ~garbage =
            * parents as well
            *)
           Batch.remove batch ~key:(Transition node_hash) ;
-          Batch.remove batch ~key:(Arcs node_hash) ) ) ;
+          Batch.remove batch ~key:(Arcs node_hash))) ;
   old_root_hash
 
 let get_transition t hash =
@@ -356,8 +360,7 @@ let get_transition t hash =
   in
   validated_transition
 
-let get_arcs t hash =
-  get t.db ~key:(Arcs hash) ~error:(`Not_found (`Arcs hash))
+let get_arcs t hash = get t.db ~key:(Arcs hash) ~error:(`Not_found (`Arcs hash))
 
 let get_root t = get t.db ~key:Root ~error:(`Not_found `Root)
 
@@ -386,4 +389,4 @@ let rec crawl_successors t hash ~init ~f =
         Deferred.map (f init transition)
           ~f:(Result.map_error ~f:(fun err -> `Crawl_error err))
       in
-      crawl_successors t succ_hash ~init:init' ~f )
+      crawl_successors t succ_hash ~init:init' ~f)

--- a/src/lib/transition_frontier/persistent_frontier/database.mli
+++ b/src/lib/transition_frontier/persistent_frontier/database.mli
@@ -29,11 +29,11 @@ module Error : sig
     | `Arcs of State_hash.t
     | `Protocol_states_for_root_scan_state ]
 
-  type not_found = [`Not_found of not_found_member]
+  type not_found = [ `Not_found of not_found_member ]
 
-  type raised = [`Raised of Error.t]
+  type raised = [ `Raised of Error.t ]
 
-  type t = [not_found | raised | `Invalid_version]
+  type t = [ not_found | raised | `Invalid_version ]
 
   val not_found_message : not_found -> string
 
@@ -71,7 +71,7 @@ val add :
   -> transition:External_transition.Validated.t
   -> ( unit
      , [> `Not_found of
-          [> `Parent_transition of State_hash.t | `Arcs of State_hash.t] ] )
+          [> `Parent_transition of State_hash.t | `Arcs of State_hash.t ] ] )
      Result.t
 
 val move_root :
@@ -79,36 +79,39 @@ val move_root :
   -> new_root:Root_data.Limited.t
   -> garbage:State_hash.t list
   -> ( State_hash.t
-     , [> `Not_found of [> `New_root_transition | `Old_root_transition]] )
+     , [> `Not_found of [> `New_root_transition | `Old_root_transition ] ] )
      Result.t
 
 val get_transition :
      t
   -> State_hash.t
   -> ( External_transition.Validated.t
-     , [> `Not_found of [> `Transition of State_hash.t]] )
+     , [> `Not_found of [> `Transition of State_hash.t ] ] )
      Result.t
 
 val get_arcs :
      t
   -> State_hash.t
-  -> (State_hash.t list, [> `Not_found of [> `Arcs of State_hash.t]]) Result.t
+  -> (State_hash.t list, [> `Not_found of [> `Arcs of State_hash.t ] ]) Result.t
 
-val get_root : t -> (Root_data.Minimal.t, [> `Not_found of [> `Root]]) Result.t
+val get_root :
+  t -> (Root_data.Minimal.t, [> `Not_found of [> `Root ] ]) Result.t
 
 val get_protocol_states_for_root_scan_state :
      t
   -> ( Mina_state.Protocol_state.value list
-     , [> `Not_found of [> `Protocol_states_for_root_scan_state]] )
+     , [> `Not_found of [> `Protocol_states_for_root_scan_state ] ] )
      Result.t
 
-val get_root_hash : t -> (State_hash.t, [> `Not_found of [> `Root]]) Result.t
+val get_root_hash : t -> (State_hash.t, [> `Not_found of [> `Root ] ]) Result.t
 
 val get_best_tip :
-  t -> (State_hash.t, [> `Not_found of [> `Best_tip]]) Result.t
+  t -> (State_hash.t, [> `Not_found of [> `Best_tip ] ]) Result.t
 
 val set_best_tip :
-  t -> State_hash.t -> (State_hash.t, [> `Not_found of [> `Best_tip]]) Result.t
+     t
+  -> State_hash.t
+  -> (State_hash.t, [> `Not_found of [> `Best_tip ] ]) Result.t
 
 val crawl_successors :
      t
@@ -117,6 +120,6 @@ val crawl_successors :
   -> f:('a -> External_transition.Validated.t -> ('a, 'b) Deferred.Result.t)
   -> ( unit
      , [> `Crawl_error of 'b
-       | `Not_found of [> `Arcs of State_hash.t | `Transition of State_hash.t]
+       | `Not_found of [> `Arcs of State_hash.t | `Transition of State_hash.t ]
        ] )
      Deferred.Result.t

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -8,9 +8,8 @@ module Database = Database
 
 exception Invalid_genesis_state_hash of External_transition.Validated.t
 
-let construct_staged_ledger_at_root
-    ~(precomputed_values : Precomputed_values.t) ~root_ledger ~root_transition
-    ~root ~protocol_states ~logger =
+let construct_staged_ledger_at_root ~(precomputed_values : Precomputed_values.t)
+    ~root_ledger ~root_transition ~root ~protocol_states ~logger =
   let open Deferred.Or_error.Let_syntax in
   let open Root_data.Minimal in
   let snarked_ledger_hash =
@@ -28,13 +27,13 @@ let construct_staged_ledger_at_root
       ~f:(fun acc protocol_state ->
         Map.add_exn acc
           ~key:(Protocol_state.hash protocol_state)
-          ~data:protocol_state )
+          ~data:protocol_state)
   in
   let get_state hash =
     match Map.find protocol_states_map hash with
     | None ->
         [%log error]
-          ~metadata:[("state_hash", State_hash.to_yojson hash)]
+          ~metadata:[ ("state_hash", State_hash.to_yojson hash) ]
           "Protocol state (for scan state transactions) for $state_hash not \
            found when loading persisted transition frontier" ;
         Or_error.errorf
@@ -71,7 +70,7 @@ let construct_staged_ledger_at_root
              Or_error.errorf
                !"Mismatched user command status. Expected: %{sexp: \
                  Transaction_status.t} Got: %{sexp: Transaction_status.t}"
-               txn.status computed_status )
+               txn.status computed_status)
   in
   Staged_ledger.of_scan_state_and_ledger_unchecked ~snarked_ledger_hash
     ~snarked_next_available_token ~ledger:mask ~scan_state
@@ -80,17 +79,18 @@ let construct_staged_ledger_at_root
 
 module rec Instance_type : sig
   type t =
-    {db: Database.t; mutable sync: Sync.t option; factory: Factory_type.t}
+    { db : Database.t; mutable sync : Sync.t option; factory : Factory_type.t }
 end =
   Instance_type
 
 and Factory_type : sig
   type t =
-    { logger: Logger.t
-    ; directory: string
-    ; verifier: Verifier.t
-    ; time_controller: Block_time.Controller.t
-    ; mutable instance: Instance_type.t option }
+    { logger : Logger.t
+    ; directory : string
+    ; verifier : Verifier.t
+    ; time_controller : Block_time.Controller.t
+    ; mutable instance : Instance_type.t option
+    }
 end =
   Factory_type
 
@@ -104,7 +104,7 @@ module Instance = struct
     let db =
       Database.create ~logger:factory.logger ~directory:factory.directory
     in
-    {db; sync= None; factory}
+    { db; sync = None; factory }
 
   let assert_no_sync t =
     if Option.is_some t.sync then Error `Sync_cannot_be_running else Ok ()
@@ -119,21 +119,21 @@ module Instance = struct
   let start_sync ~constraint_constants t =
     let open Result.Let_syntax in
     let%map () = assert_no_sync t in
-    t.sync
-    <- Some
-         (Sync.create ~constraint_constants ~logger:t.factory.logger
-            ~time_controller:t.factory.time_controller ~db:t.db)
+    t.sync <-
+      Some
+        (Sync.create ~constraint_constants ~logger:t.factory.logger
+           ~time_controller:t.factory.time_controller ~db:t.db)
 
   let stop_sync t =
     let open Deferred.Let_syntax in
     assert_sync t ~f:(fun sync ->
         let%map () = Sync.close sync in
         t.sync <- None ;
-        Ok () )
+        Ok ())
 
   let notify_sync t ~diffs =
     assert_sync t ~f:(fun sync ->
-        Sync.notify sync ~diffs ; Deferred.Result.return () )
+        Sync.notify sync ~diffs ; Deferred.Result.return ())
 
   let destroy t =
     let open Deferred.Let_syntax in
@@ -149,7 +149,7 @@ module Instance = struct
     Database.close t.db ;
     t.factory.instance <- None
 
-  let factory {factory; _} = factory
+  let factory { factory; _ } = factory
 
   let check_database t = Database.check t.db
 
@@ -160,7 +160,7 @@ module Instance = struct
     |> Result.map_error ~f:Database.Error.message
 
   let fast_forward t target_root :
-      (unit, [> `Failure of string | `Bootstrap_required]) Result.t =
+      (unit, [> `Failure of string | `Bootstrap_required ]) Result.t =
     let open Root_identifier.Stable.Latest in
     let open Result.Let_syntax in
     let%bind () = assert_no_sync t in
@@ -176,9 +176,10 @@ module Instance = struct
       [%log' warn t.factory.logger]
         ~metadata:
           [ ("current_root", State_hash.to_yojson root_hash)
-          ; ("target_root", State_hash.to_yojson target_root.state_hash) ]
-        "Cannot fast forward persistent frontier's root: bootstrap is \
-         required ($current_root --> $target_root)" ;
+          ; ("target_root", State_hash.to_yojson target_root.state_hash)
+          ]
+        "Cannot fast forward persistent frontier's root: bootstrap is required \
+         ($current_root --> $target_root)" ;
       Error `Bootstrap_required )
 
   let load_full_frontier t ~root_ledger ~consensus_local_state ~max_length
@@ -186,7 +187,7 @@ module Instance = struct
     let open Deferred.Result.Let_syntax in
     let downgrade_transition transition genesis_state_hash :
         ( External_transition.Almost_validated.t
-        , [`Invalid_genesis_protocol_state] )
+        , [ `Invalid_genesis_protocol_state ] )
         Result.t =
       let open Result.Let_syntax in
       let transition =
@@ -221,7 +222,7 @@ module Instance = struct
       in
       (root, root_transition, best_tip, protocol_states, root_hash))
       |> Result.map_error ~f:(fun err ->
-             `Failure (Database.Error.not_found_message err) )
+             `Failure (Database.Error.not_found_message err))
       |> Deferred.return
     in
     let root_genesis_state_hash =
@@ -245,9 +246,9 @@ module Instance = struct
       Full_frontier.create ~logger:t.factory.logger
         ~time_controller:t.factory.time_controller
         ~root_data:
-          { transition= root_transition
-          ; staged_ledger= root_staged_ledger
-          ; protocol_states=
+          { transition = root_transition
+          ; staged_ledger = root_staged_ledger
+          ; protocol_states =
               (*TODO: store the hashes as well?*)
               List.map protocol_states ~f:(fun s -> (Protocol_state.hash s, s))
           }
@@ -261,7 +262,7 @@ module Instance = struct
     in
     let apply_diff diff =
       let (`New_root_and_diffs_with_mutants (_, diffs_with_mutants)) =
-        Full_frontier.apply_diffs frontier [diff] ~has_long_catchup_job:false
+        Full_frontier.apply_diffs frontier [ diff ] ~has_long_catchup_job:false
           ~enable_epoch_ledger_sync:
             ( if ignore_consensus_local_state then `Disabled
             else `Enabled root_ledger )
@@ -296,7 +297,7 @@ module Instance = struct
                  ~sender:None ~transition_receipt_time ()
              in
              let%map () = apply_diff Diff.(E (New_node (Full breadcrumb))) in
-             breadcrumb ))
+             breadcrumb))
         ~f:
           (Result.map_error ~f:(function
             | `Crawl_error err ->
@@ -313,7 +314,7 @@ module Instance = struct
                   ( "error rebuilding transition frontier from persistence: "
                   ^ msg )
             | `Not_found _ as err ->
-                `Failure (Database.Error.not_found_message err) ))
+                `Failure (Database.Error.not_found_message err)))
     in
     let%map () = apply_diff Diff.(E (Best_tip_changed best_tip)) in
     (frontier, extensions)
@@ -322,7 +323,7 @@ end
 type t = Factory_type.t
 
 let create ~logger ~verifier ~time_controller ~directory =
-  {logger; verifier; time_controller; directory; instance= None}
+  { logger; verifier; time_controller; directory; instance = None }
 
 let destroy_database_exn t =
   assert (Option.is_none t.instance) ;
@@ -347,8 +348,8 @@ let reset_database_exn t ~root_data ~genesis_state_hash =
     ~metadata:
       [ ( "state_hash"
         , State_hash.to_yojson
-            (External_transition.Validated.state_hash (transition root_data))
-        ) ]
+            (External_transition.Validated.state_hash (transition root_data)) )
+      ]
     "Resetting transition frontier database to new root" ;
   let%bind () = destroy_database_exn t in
   with_instance_exn t ~f:(fun instance ->
@@ -364,5 +365,5 @@ let reset_database_exn t ~root_data ~genesis_state_hash =
                | `Genesis_state_mismatch _ ->
                    "genesis state mismatch"
                | `Corrupt err ->
-                   Database.Error.message err )
-          |> Result.ok_or_failwith ) )
+                   Database.Error.message err)
+          |> Result.ok_or_failwith))

--- a/src/lib/transition_frontier/persistent_frontier/sync.ml
+++ b/src/lib/transition_frontier/persistent_frontier/sync.ml
@@ -1,18 +1,18 @@
 open Async_kernel
 
 (* TODO: *new* convert into an extension *)
-type t = {worker: Worker.t; buffer: Diff_buffer.t}
+type t = { worker : Worker.t; buffer : Diff_buffer.t }
 
 let buffer t = DynArray.to_list t.buffer.diff_array
 
 (* NB: the persistent frontier must remain open as
  * long as the synchronization is using it *)
 let create ~constraint_constants ~logger ~time_controller ~db =
-  let worker = Worker.create {db; logger} in
+  let worker = Worker.create { db; logger } in
   let buffer =
     Diff_buffer.create ~constraint_constants ~time_controller ~worker
   in
-  {worker; buffer}
+  { worker; buffer }
 
 let close t =
   let%bind () = Diff_buffer.close_and_finish_copy t.buffer in

--- a/src/lib/transition_frontier/persistent_frontier/worker.mli
+++ b/src/lib/transition_frontier/persistent_frontier/worker.mli
@@ -1,11 +1,11 @@
 open Frontier_base
 
-type create_args = {db: Database.t; logger: Logger.t}
+type create_args = { db : Database.t; logger : Logger.t }
 
 type input = Diff.Lite.E.t list
 
 include
   Otp_lib.Worker_supervisor.S
-  with type create_args := create_args
-   and type input := input
-   and type output := unit
+    with type create_args := create_args
+     and type input := input
+     and type output := unit

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -28,7 +28,7 @@ let%test_module "Full_frontier tests" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ()))
 
     module Genesis_ledger = (val precomputed_values.genesis_ledger)
 
@@ -66,8 +66,7 @@ let%test_module "Full_frontier tests" =
         Consensus.Data.Local_state.create Public_key.Compressed.Set.empty
           ~genesis_ledger:Genesis_ledger.t
           ~genesis_epoch_data:precomputed_values.genesis_epoch_data
-          ~epoch_ledger_location
-          ~ledger_depth:constraint_constants.ledger_depth
+          ~epoch_ledger_location ~ledger_depth:constraint_constants.ledger_depth
           ~genesis_state_hash:
             (With_hash.hash precomputed_values.protocol_state_with_hash)
       in
@@ -79,10 +78,11 @@ let%test_module "Full_frontier tests" =
       in
       let root_data =
         let open Root_data in
-        { transition= External_transition.For_tests.genesis ~precomputed_values
-        ; staged_ledger=
+        { transition = External_transition.For_tests.genesis ~precomputed_values
+        ; staged_ledger =
             Staged_ledger.create_exn ~constraint_constants ~ledger:root_ledger
-        ; protocol_states= [] }
+        ; protocol_states = []
+        }
       in
       Full_frontier.create ~logger ~root_data
         ~root_ledger:(Ledger.Any_ledger.cast (module Ledger) root_ledger)
@@ -100,7 +100,7 @@ let%test_module "Full_frontier tests" =
                 Full_frontier.find_exn frontier
                   (Breadcrumb.state_hash breadcrumb)
               in
-              [%test_eq: Breadcrumb.t] breadcrumb queried_breadcrumb ) )
+              [%test_eq: Breadcrumb.t] breadcrumb queried_breadcrumb))
 
     let%test_unit "Constructing a better branch should change the best tip" =
       let gen_branches =
@@ -130,13 +130,12 @@ let%test_module "Full_frontier tests" =
               test_best_tip
                 (List.last_exn short_branch)
                 ~message:
-                  "best tip should not change when only part of long branch \
-                   is added" ;
+                  "best tip should not change when only part of long branch is \
+                   added" ;
               add_breadcrumbs frontier (List.tl_exn long_branch) ;
               test_best_tip
                 (List.last_exn long_branch)
-                ~message:"best tip should change when all of best tip is added"
-          ) )
+                ~message:"best tip should change when all of best tip is added"))
 
     let%test_unit "The root should be updated after (> max_length) nodes are \
                    added in sequence" =
@@ -144,7 +143,7 @@ let%test_module "Full_frontier tests" =
       let test_not_eq ?message =
         let message = Option.map message ~f:(fun m -> "not " ^ m) in
         [%test_eq: Breadcrumb.t] ?message ~equal:(fun a b ->
-            not (Breadcrumb.equal a b) )
+            not (Breadcrumb.equal a b))
       in
       Quickcheck.test
         (gen_breadcrumb_seq (max_length * 2))
@@ -169,7 +168,7 @@ let%test_module "Full_frontier tests" =
                          ~message:
                            "roots should be the same before max_length \
                             breadcrumbs" ;
-                     i + 1 ) ) )
+                     i + 1)))
 
     let%test_unit "Protocol states are available for every transaction in the \
                    frontier" =
@@ -193,7 +192,7 @@ let%test_module "Full_frontier tests" =
                       ignore
                         ( Full_frontier.For_tests.find_protocol_state_exn
                             frontier hash
-                          : Mina_state.Protocol_state.value ) ) ) ) )
+                          : Mina_state.Protocol_state.value )))))
 
     let%test_unit "The length of the longest branch should never be greater \
                    than max_length" =
@@ -211,8 +210,7 @@ let%test_module "Full_frontier tests" =
                   [%test_pred: int] (( >= ) max_length)
                     (List.length
                        Full_frontier.(
-                         path_map frontier (best_tip frontier) ~f:Fn.id)) ) )
-      )
+                         path_map frontier (best_tip frontier) ~f:Fn.id)))))
 
     let%test_unit "Common ancestor can be reliably found" =
       let ancestor_length = (max_length / 2) - 1 in
@@ -243,5 +241,5 @@ let%test_module "Full_frontier tests" =
               add_breadcrumbs frontier (branch_a @ branch_b) ;
               [%test_eq: State_hash.t]
                 (Full_frontier.common_ancestor frontier tip_a tip_b)
-                (Breadcrumb.state_hash youngest_ancestor) ) )
+                (Breadcrumb.state_hash youngest_ancestor)))
   end )

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -22,18 +22,19 @@ let global_max_length (genesis_constants : Genesis_constants.t) =
   genesis_constants.protocol.k
 
 type t =
-  { logger: Logger.t
-  ; verifier: Verifier.t
-  ; consensus_local_state: Consensus.Data.Local_state.t
-  ; catchup_tree: Catchup_tree.t
-  ; full_frontier: Full_frontier.t
-  ; persistent_root: Persistent_root.t
-  ; persistent_root_instance: Persistent_root.Instance.t
-  ; persistent_frontier: Persistent_frontier.t
-  ; persistent_frontier_instance: Persistent_frontier.Instance.t
-  ; extensions: Extensions.t
-  ; genesis_state_hash: State_hash.t
-  ; closed: unit Ivar.t }
+  { logger : Logger.t
+  ; verifier : Verifier.t
+  ; consensus_local_state : Consensus.Data.Local_state.t
+  ; catchup_tree : Catchup_tree.t
+  ; full_frontier : Full_frontier.t
+  ; persistent_root : Persistent_root.t
+  ; persistent_root_instance : Persistent_root.Instance.t
+  ; persistent_frontier : Persistent_frontier.t
+  ; persistent_frontier_instance : Persistent_frontier.Instance.t
+  ; extensions : Extensions.t
+  ; genesis_state_hash : State_hash.t
+  ; closed : unit Ivar.t
+  }
 
 let catchup_tree t = t.catchup_tree
 
@@ -42,8 +43,8 @@ type Structured_log_events.t += Added_breadcrumb_user_commands
 
 (* There is no Diff.Full.E.of_yojson, so we store raw Yojson.Safe.t here so that
  * we can still deserialize something to inspect *)
-type Structured_log_events.t += Applying_diffs of {diffs: Yojson.Safe.t list}
-  [@@deriving register_event {msg= "Applying diffs: $diffs"}]
+type Structured_log_events.t += Applying_diffs of { diffs : Yojson.Safe.t list }
+  [@@deriving register_event { msg = "Applying diffs: $diffs" }]
 
 let genesis_root_data ~precomputed_values =
   let open Root_data.Limited in
@@ -78,8 +79,8 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
   let%bind () =
     Deferred.return
       ( match
-          Persistent_frontier.Instance.fast_forward
-            persistent_frontier_instance root_identifier
+          Persistent_frontier.Instance.fast_forward persistent_frontier_instance
+            root_identifier
         with
       | Ok () ->
           [%log info] "Fast forward successful" ;
@@ -91,7 +92,7 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
       | Error (`Failure msg) ->
           [%log fatal]
             ~metadata:
-              [("target_root", Root_identifier.to_yojson root_identifier)]
+              [ ("target_root", Root_identifier.to_yojson root_identifier) ]
             "Unable to fast forward persistent frontier: %s" msg ;
           Error (`Failure msg) )
   in
@@ -108,7 +109,7 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
           | `Sync_cannot_be_running ->
               `Failure "sync job is already running on persistent frontier"
           | `Failure _ as err ->
-              err ))
+              err))
   in
   [%log info] "Loaded full frontier and extensions" ;
   let%map () =
@@ -121,11 +122,10 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
                `Failure "sync job is already running on persistent frontier"
            | `Not_found _ as err ->
                `Failure
-                 (Persistent_frontier.Database.Error.not_found_message err) )
-      )
+                 (Persistent_frontier.Database.Error.not_found_message err)) )
   in
   { logger
-  ; catchup_tree=
+  ; catchup_tree =
       Catchup_tree.create catchup_mode ~root:(Full_frontier.root full_frontier)
   ; verifier
   ; consensus_local_state
@@ -135,9 +135,10 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
   ; persistent_frontier
   ; persistent_frontier_instance
   ; extensions
-  ; closed= Ivar.create ()
-  ; genesis_state_hash=
-      Precomputed_values.genesis_state_hash precomputed_values }
+  ; closed = Ivar.create ()
+  ; genesis_state_hash =
+      Precomputed_values.genesis_state_hash precomputed_values
+  }
 
 let rec load_with_max_length :
        max_length:int
@@ -148,7 +149,7 @@ let rec load_with_max_length :
     -> persistent_root:Persistent_root.t
     -> persistent_frontier:Persistent_frontier.t
     -> precomputed_values:Precomputed_values.t
-    -> catchup_mode:[`Normal | `Super]
+    -> catchup_mode:[ `Normal | `Super ]
     -> unit
     -> ( t
        , [> `Bootstrap_required
@@ -223,7 +224,8 @@ let rec load_with_max_length :
             , State_hash.to_yojson persisted_genesis_state_hash )
           ; ( "precomputed_state_hash"
             , State_hash.to_yojson
-                precomputed_values.protocol_state_with_hash.hash ) ] ;
+                precomputed_values.protocol_state_with_hash.hash )
+          ] ;
       reset_and_continue ()
   | Error (`Corrupt err) ->
       [%log error] "Persistent frontier database is corrupt: %s"
@@ -246,18 +248,17 @@ let rec load_with_max_length :
                     "failed to destroy and create new persistent frontier \
                      database"
               | err ->
-                  err ) )
+                  err) )
       else return (Error `Persistent_frontier_malformed)
   | Ok () -> (
       match%bind
-        continue persistent_frontier_instance
-          ~ignore_consensus_local_state:true
+        continue persistent_frontier_instance ~ignore_consensus_local_state:true
       with
       | Error (`Failure err) when retry_with_fresh_db ->
           [%log error]
             "Failed to initialize transition frontier: $err. Destroying old \
              persistent frontier database and retrying."
-            ~metadata:[("err", `String err)] ;
+            ~metadata:[ ("err", `String err) ] ;
           (* The frontier instance is already destroyed by [continue] before it
              returns an [Error], don't attempt to do it again.
           *)
@@ -266,8 +267,7 @@ let rec load_with_max_length :
           return res )
 
 let load ?(retry_with_fresh_db = true) ~logger ~verifier ~consensus_local_state
-    ~persistent_root ~persistent_frontier ~precomputed_values ~catchup_mode ()
-    =
+    ~persistent_root ~persistent_frontier ~precomputed_values ~catchup_mode () =
   let max_length =
     global_max_length (Precomputed_values.genesis_constants precomputed_values)
   in
@@ -279,17 +279,18 @@ let load ?(retry_with_fresh_db = true) ~logger ~verifier ~consensus_local_state
  * because their lifecycle is longer than the transition frontier's *)
 let close ~loc
     { logger
-    ; verifier= _
-    ; consensus_local_state= _
-    ; catchup_tree= _
+    ; verifier = _
+    ; consensus_local_state = _
+    ; catchup_tree = _
     ; full_frontier
-    ; persistent_root= _safe_to_ignore_1
+    ; persistent_root = _safe_to_ignore_1
     ; persistent_root_instance
-    ; persistent_frontier= _safe_to_ignore_2
+    ; persistent_frontier = _safe_to_ignore_2
     ; persistent_frontier_instance
     ; extensions
     ; closed
-    ; genesis_state_hash= _ } =
+    ; genesis_state_hash = _
+    } =
   [%log debug] "Closing transition frontier" ;
   Full_frontier.close ~loc full_frontier ;
   Extensions.close extensions ;
@@ -301,15 +302,15 @@ let close ~loc
 
 let closed t = Ivar.read t.closed
 
-let persistent_root {persistent_root; _} = persistent_root
+let persistent_root { persistent_root; _ } = persistent_root
 
-let persistent_frontier {persistent_frontier; _} = persistent_frontier
+let persistent_frontier { persistent_frontier; _ } = persistent_frontier
 
-let extensions {extensions; _} = extensions
+let extensions { extensions; _ } = extensions
 
-let genesis_state_hash {genesis_state_hash; _} = genesis_state_hash
+let genesis_state_hash { genesis_state_hash; _ } = genesis_state_hash
 
-let root_snarked_ledger {persistent_root_instance; _} =
+let root_snarked_ledger { persistent_root_instance; _ } =
   Persistent_root.Instance.snarked_ledger persistent_root_instance
 
 let add_breadcrumb_exn t breadcrumb =
@@ -321,11 +322,11 @@ let add_breadcrumb_exn t breadcrumb =
         , State_hash.to_yojson
             (Breadcrumb.state_hash (Full_frontier.best_tip t.full_frontier)) )
       ; ( "n"
-        , `Int (List.length @@ Full_frontier.all_breadcrumbs t.full_frontier)
-        ) ]
+        , `Int (List.length @@ Full_frontier.all_breadcrumbs t.full_frontier) )
+      ]
     "PRE: ($state_hash, $n)" ;
   [%str_log' trace t.logger]
-    (Applying_diffs {diffs= List.map ~f:Diff.Full.E.to_yojson diffs}) ;
+    (Applying_diffs { diffs = List.map ~f:Diff.Full.E.to_yojson diffs }) ;
   Catchup_tree.apply_diffs t.catchup_tree diffs ;
   let (`New_root_and_diffs_with_mutants
         (new_root_identifier, diffs_with_mutants)) =
@@ -336,17 +337,15 @@ let add_breadcrumb_exn t breadcrumb =
       ~enable_epoch_ledger_sync:(`Enabled (root_snarked_ledger t))
   in
   Option.iter new_root_identifier
-    ~f:
-      (Persistent_root.Instance.set_root_identifier t.persistent_root_instance) ;
+    ~f:(Persistent_root.Instance.set_root_identifier t.persistent_root_instance) ;
   [%log' trace t.logger]
     ~metadata:
       [ ( "state_hash"
         , State_hash.to_yojson
-            (Breadcrumb.state_hash @@ Full_frontier.best_tip t.full_frontier)
-        )
+            (Breadcrumb.state_hash @@ Full_frontier.best_tip t.full_frontier) )
       ; ( "n"
-        , `Int (List.length @@ Full_frontier.all_breadcrumbs t.full_frontier)
-        ) ]
+        , `Int (List.length @@ Full_frontier.all_breadcrumbs t.full_frontier) )
+      ]
     "POST: ($state_hash, $n)" ;
   let user_cmds = Breadcrumb.commands breadcrumb in
   if not (List.is_empty user_cmds) then
@@ -358,7 +357,8 @@ let add_breadcrumb_exn t breadcrumb =
         [ ( "user_commands"
           , `List
               (List.map user_cmds
-                 ~f:(With_status.to_yojson User_command.Valid.to_yojson)) ) ] ;
+                 ~f:(With_status.to_yojson User_command.Valid.to_yojson)) )
+        ] ;
   let lite_diffs =
     List.map diffs ~f:Diff.(fun (Full.E.E diff) -> Lite.E.E (to_lite diff))
   in
@@ -372,7 +372,7 @@ let add_breadcrumb_exn t breadcrumb =
          Failure
            "Cannot add breadcrumb because persistent frontier sync job is not \
             running, which indicates that transition frontier initialization \
-            has not been performed correctly" )
+            has not been performed correctly")
   |> Result.ok_exn ;
   Extensions.notify t.extensions ~frontier:t.full_frontier ~diffs_with_mutants
 
@@ -380,7 +380,7 @@ let add_breadcrumb_exn t breadcrumb =
 include struct
   open Full_frontier
 
-  let proxy1 f {full_frontier; _} = f full_frontier
+  let proxy1 f { full_frontier; _ } = f full_frontier
 
   let max_length = proxy1 max_length
 
@@ -431,7 +431,7 @@ include struct
   let find_protocol_state = proxy1 find_protocol_state
 
   (* why can't this one be proxied? *)
-  let path_map ?max_length {full_frontier; _} breadcrumb ~f =
+  let path_map ?max_length { full_frontier; _ } breadcrumb ~f =
     path_map ?max_length full_frontier breadcrumb ~f
 end
 
@@ -440,7 +440,7 @@ module For_tests = struct
   module Ledger_transfer = Ledger_transfer.Make (Ledger) (Ledger.Db)
   open Full_frontier.For_tests
 
-  let proxy2 f {full_frontier= x; _} {full_frontier= y; _} = f x y
+  let proxy2 f { full_frontier = x; _ } { full_frontier = y; _ } = f x y
 
   let equal = proxy2 equal
 
@@ -508,11 +508,11 @@ module For_tests = struct
                           ~depth:constraint_constants.pending_coinbase_depth ()
                      )
                    ~snarked_ledger:genesis_ledger
-                   ~expected_merkle_root:(Ledger.merkle_root genesis_ledger) ))
+                   ~expected_merkle_root:(Ledger.merkle_root genesis_ledger)))
         in
         Breadcrumb.create ~validated_transition:genesis_transition
           ~staged_ledger:genesis_staged_ledger ~just_emitted_a_proof:false
-          ~transition_receipt_time )
+          ~transition_receipt_time)
 
   let gen_persistence ?(logger = Logger.null ()) ~verifier
       ~(precomputed_values : Precomputed_values.t) () =
@@ -527,14 +527,14 @@ module For_tests = struct
         let clean_temp_dirs _ =
           if not !cleaned then (
             let process_info =
-              Unix.create_process ~prog:"rm" ~args:["-rf"; temp_dir]
+              Unix.create_process ~prog:"rm" ~args:[ "-rf"; temp_dir ]
             in
             Unix.waitpid process_info.pid
             |> Result.map_error ~f:(function
                  | `Exit_non_zero n ->
                      Printf.sprintf "error (exit code %d)" n
                  | `Signal _ ->
-                     "error (received unexpected signal)" )
+                     "error (received unexpected signal)")
             |> Result.ok_or_failwith ;
             cleaned := true )
         in
@@ -555,11 +555,11 @@ module For_tests = struct
             Option.iter
               persistent_frontier.Persistent_frontier.Factory_type.instance
               ~f:(fun instance ->
-                Persistent_frontier.Database.close instance.db ) ;
+                Persistent_frontier.Database.close instance.db) ;
             Option.iter persistent_root.Persistent_root.Factory_type.instance
               ~f:(fun instance -> Ledger.Db.close instance.snarked_ledger) ;
-            clean_temp_dirs x ) ;
-        (persistent_root, persistent_frontier) )
+            clean_temp_dirs x) ;
+        (persistent_root, persistent_frontier))
 
   let gen_genesis_breadcrumb_with_protocol_states ~logger ~verifier
       ~precomputed_values () =
@@ -627,21 +627,19 @@ module For_tests = struct
     in
     Async.Thread_safe.block_on_async_exn (fun () ->
         Persistent_frontier.reset_database_exn persistent_frontier ~root_data
-          ~genesis_state_hash:precomputed_values.protocol_state_with_hash.hash
-    ) ;
+          ~genesis_state_hash:precomputed_values.protocol_state_with_hash.hash) ;
     Persistent_root.with_instance_exn persistent_root ~f:(fun instance ->
         Persistent_root.Instance.set_root_state_hash instance
           (External_transition.Validated.state_hash
              (Root_data.Limited.transition root_data)) ;
         ignore
         @@ Ledger_transfer.transfer_accounts ~src:root_snarked_ledger
-             ~dest:(Persistent_root.Instance.snarked_ledger instance) ) ;
+             ~dest:(Persistent_root.Instance.snarked_ledger instance)) ;
     let frontier_result =
       Async.Thread_safe.block_on_async_exn (fun () ->
           load_with_max_length ~max_length ~retry_with_fresh_db:false ~logger
             ~verifier ~consensus_local_state ~persistent_root
-            ~catchup_mode:`Normal ~persistent_frontier ~precomputed_values ()
-      )
+            ~catchup_mode:`Normal ~persistent_frontier ~precomputed_values ())
     in
     let frontier =
       let fail msg = failwith ("failed to load transition frontier: " ^ msg) in
@@ -657,7 +655,7 @@ module For_tests = struct
     in
     Async.Thread_safe.block_on_async_exn (fun () ->
         Deferred.List.iter ~how:`Sequential branches
-          ~f:(deferred_rose_tree_iter ~f:(add_breadcrumb_exn frontier)) ) ;
+          ~f:(deferred_rose_tree_iter ~f:(add_breadcrumb_exn frontier))) ;
     Core.Gc.Expert.add_finalizer_exn consensus_local_state
       (fun consensus_local_state ->
         Consensus.Data.Local_state.(
@@ -665,7 +663,7 @@ module For_tests = struct
           @@ staking_epoch_ledger consensus_local_state) ;
         Consensus.Data.Local_state.(
           Snapshot.Ledger_snapshot.close
-          @@ next_epoch_ledger consensus_local_state) ) ;
+          @@ next_epoch_ledger consensus_local_state)) ;
     frontier
 
   let gen_with_branch ?logger ~verifier ?trust_system ?consensus_local_state
@@ -689,7 +687,7 @@ module For_tests = struct
     in
     let branch =
       Async.Thread_safe.block_on_async_exn (fun () ->
-          make_branch (get_branch_root frontier) )
+          make_branch (get_branch_root frontier))
     in
     (frontier, branch)
 end

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -23,7 +23,7 @@ include Frontier_intf.S
 type Structured_log_events.t += Added_breadcrumb_user_commands
   [@@deriving register_event]
 
-type Structured_log_events.t += Applying_diffs of {diffs: Yojson.Safe.t list}
+type Structured_log_events.t += Applying_diffs of { diffs : Yojson.Safe.t list }
   [@@deriving register_event]
 
 val max_catchup_chunk_length : int
@@ -43,7 +43,7 @@ val load :
   -> persistent_root:Persistent_root.t
   -> persistent_frontier:Persistent_frontier.t
   -> precomputed_values:Precomputed_values.t
-  -> catchup_mode:[`Normal | `Super]
+  -> catchup_mode:[ `Normal | `Super ]
   -> unit
   -> ( t
      , [> `Failure of string
@@ -82,7 +82,7 @@ module For_tests : sig
     -> persistent_root:Persistent_root.t
     -> persistent_frontier:Persistent_frontier.t
     -> precomputed_values:Precomputed_values.t
-    -> catchup_mode:[`Normal | `Super]
+    -> catchup_mode:[ `Normal | `Super ]
     -> unit
     -> ( t
        , [> `Failure of string
@@ -110,13 +110,12 @@ module For_tests : sig
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t
-    -> ?root_ledger_and_accounts:Ledger.t
-                                 * (Private_key.t option * Account.t) list
-    -> ?gen_root_breadcrumb:( Breadcrumb.t
-                            * ( Mina_base.State_hash.t
-                              * Mina_state.Protocol_state.value )
-                              list )
-                            Quickcheck.Generator.t
+    -> ?root_ledger_and_accounts:
+         Ledger.t * (Private_key.t option * Account.t) list
+    -> ?gen_root_breadcrumb:
+         ( Breadcrumb.t
+         * (Mina_base.State_hash.t * Mina_state.Protocol_state.value) list )
+         Quickcheck.Generator.t
     -> max_length:int
     -> size:int
     -> unit
@@ -128,13 +127,12 @@ module For_tests : sig
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> precomputed_values:Precomputed_values.t
-    -> ?root_ledger_and_accounts:Ledger.t
-                                 * (Private_key.t option * Account.t) list
-    -> ?gen_root_breadcrumb:( Breadcrumb.t
-                            * ( Mina_base.State_hash.t
-                              * Mina_state.Protocol_state.value )
-                              list )
-                            Quickcheck.Generator.t
+    -> ?root_ledger_and_accounts:
+         Ledger.t * (Private_key.t option * Account.t) list
+    -> ?gen_root_breadcrumb:
+         ( Breadcrumb.t
+         * (Mina_base.State_hash.t * Mina_state.Protocol_state.value) list )
+         Quickcheck.Generator.t
     -> ?get_branch_root:(t -> Breadcrumb.t)
     -> max_length:int
     -> frontier_size:int


### PR DESCRIPTION
This PR
* adds symlinks to the root `.ocamlformat` file in `src/`
* uses `make reformat` to apply the formatting to the affected libraries.

This is a no-op, inspired in part by the formatting changes embedded in #9219.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: