### PR TITLE
Rosetta handle internal cmd account creation, dup txn hashes

### DIFF
--- a/src/app/rosetta/rosetta.conf
+++ b/src/app/rosetta/rosetta.conf
@@ -1,7 +1,7 @@
 {
  "network": {
   "blockchain": "coda",
-  "network": "debug"
+  "network": "dev"
  },
  "online_url": "http://localhost:3087",
  "data_directory": "",
@@ -59,7 +59,7 @@
       "name": "create_account",
       "actions": [
        {
-        "input": "{\"network\":\"coda\", \"blockchain\":\"debug\"}",
+        "input": "{\"network\":\"coda\", \"blockchain\":\"dev\"}",
         "type": "set_variable",
         "output_path": "network"
        },
@@ -89,7 +89,7 @@
       "name": "transfer",
       "actions": [
        {
-        "input": "{\"network\":\"coda\", \"blockchain\":\"debug\"}",
+        "input": "{\"network\":\"coda\", \"blockchain\":\"dev\"}",
         "type": "set_variable",
         "output_path": "transfer.network"
        },

--- a/src/lib/rosetta_lib/operation_types.ml
+++ b/src/lib/rosetta_lib/operation_types.ml
@@ -6,6 +6,7 @@ type t =
   | `Coinbase_inc
   | `Account_creation_fee_via_payment
   | `Account_creation_fee_via_fee_payer
+  | `Account_creation_fee_via_fee_receiver
   | `Payment_source_dec
   | `Payment_receiver_inc
   | `Delegate_change
@@ -24,6 +25,8 @@ let name = function
       "account_creation_fee_via_payment"
   | `Account_creation_fee_via_fee_payer ->
       "account_creation_fee_via_fee_payer"
+  | `Account_creation_fee_via_fee_receiver ->
+      "account_creation_fee_via_fee_receiver"
   | `Payment_source_dec ->
       "payment_source_dec"
   | `Payment_receiver_inc ->


### PR DESCRIPTION
In Rosetta, handle account creation fees for internal commands, as were added in #9356. Add a new operation `Account_creation_fee_via_fee_receiver` for this purpose.

Also, when creating a Rosetta `Transaction_identifier.hash`, prepend the Mina internal command type and `:` to the actual hash, because the archive db schema makes the type, hash unique, so duplicate hashes are possible (and occurred during Rosetta testing).

Other fixes:
- in `rosetta.conf`, change the network name to `dev` from `debug`
- for the query in `Balance_from_last_relevant_command`, take the union of balances from fee payer, source, and receiver in user commands; there had been a `JOIN` over those, which resulted in 0 rows rturned when any of those was `NULL` in `blocks_user_commands`, causing the genesis ledger balance to be used. Not certain this is semantically correct, but it eliminates the balance reconciliation errors reported by Rosetta when the genesis balance was used.

Tested by running the `rosetta-cli` tool with `devnet2`. It does fail after 600+ blocks; before these changes, it failed much sooner.