### PR TITLE
int64 for internal cmd amounts, secondary seq no in Rosetta last relevant command

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -596,7 +596,7 @@ module Fee_transfer = struct
   end
 
   type t =
-    {kind: Kind.t; receiver_id: int; fee: int; token: int64; hash: string}
+    {kind: Kind.t; receiver_id: int; fee: int64; token: int64; hash: string}
 
   let typ =
     let encode t =
@@ -616,7 +616,7 @@ module Fee_transfer = struct
       in
       Ok {kind; receiver_id; fee; token; hash}
     in
-    let rep = Caqti_type.(tup2 (tup4 string int int int64) string) in
+    let rep = Caqti_type.(tup2 (tup4 string int int64 int64) string) in
     Caqti_type.custom ~encode ~decode rep
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
@@ -645,13 +645,13 @@ module Fee_transfer = struct
              |sql})
           { kind
           ; receiver_id
-          ; fee= Fee_transfer.Single.fee t |> Currency.Fee.to_int
+          ; fee= Fee_transfer.Single.fee t |> Currency.Fee.to_uint64 |> Unsigned.UInt64.to_int64
           ; token= Token_id.to_string t.fee_token |> Int64.of_string
           ; hash= transaction_hash |> Transaction_hash.to_base58_check }
 end
 
 module Coinbase = struct
-  type t = {receiver_id: int; amount: int; hash: string}
+  type t = {receiver_id: int; amount: int64; hash: string}
 
   let coinbase_typ = "coinbase"
 
@@ -667,7 +667,7 @@ module Coinbase = struct
     let decode ((_, receiver_id, amount, _), hash) =
       Ok {receiver_id; amount; hash}
     in
-    let rep = Caqti_type.(tup2 (tup4 string int int int64) string) in
+    let rep = Caqti_type.(tup2 (tup4 string int int64 int64) string) in
     Caqti_type.custom ~encode ~decode rep
 
   let add_if_doesn't_exist (module Conn : CONNECTION) (t : Coinbase.t) =
@@ -692,7 +692,7 @@ module Coinbase = struct
                    RETURNING id
              |sql})
           { receiver_id
-          ; amount= Coinbase.amount t |> Currency.Amount.to_int
+          ; amount= Coinbase.amount t |> Currency.Amount.to_uint64 |> Unsigned.UInt64.to_int64
           ; hash= transaction_hash |> Transaction_hash.to_base58_check }
 end
 

--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -64,6 +64,7 @@ relevant_internal_block_balances AS (
   SELECT
     block_internal_command.block_id,
     block_internal_command.sequence_no,
+    block_internal_command.secondary_sequence_no,
     receiver_balance.balance
   FROM blocks_internal_commands block_internal_command
   INNER JOIN balances receiver_balance ON block_internal_command.receiver_balance = receiver_balance.id
@@ -119,9 +120,9 @@ relevant_user_block_balances AS (
 ),
 
 relevant_block_balances AS (
-  (SELECT block_id, sequence_no, balance FROM relevant_internal_block_balances)
+  (SELECT block_id, sequence_no, secondary_sequence_no, balance FROM relevant_internal_block_balances)
   UNION
-  (SELECT block_id, sequence_no, balance FROM relevant_user_block_balances)
+  (SELECT block_id, sequence_no, 0 AS secondary_sequence_no, balance FROM relevant_user_block_balances)
 )
 
 SELECT
@@ -131,7 +132,7 @@ FROM
 chain
 JOIN relevant_block_balances rbb ON chain.id = rbb.block_id
 WHERE chain.height <= $2
-ORDER BY (chain.height, sequence_no) DESC
+ORDER BY (chain.height, sequence_no, secondary_sequence_no) DESC
 LIMIT 1
       |sql}
 

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -408,15 +408,6 @@ let gen_test =
   Gen.payment_with_random_participants ~sign_type:`Real
     ~keys:(Array.of_list keys) ~max_amount:10000 ~fee_range:1000 ()
 
-let (_ : unit) =
-  let payment = Quickcheck.random_value gen_test in
-  Format.eprintf "%s@." (to_yojson payment |> Yojson.Safe.pretty_to_string) ;
-  let buf = Bin_prot.Common.create_buf 8192 in
-  let len = Stable.Latest.bin_write_t buf ~pos:0 payment in
-  Format.eprintf "BUF LEN: %d@." len ;
-  let s = String.init len ~f:(fun ndx -> buf.{ndx}) in
-  Format.eprintf "%s@." (Hex.Safe.to_hex s)
-
 let%test_unit "completeness" =
   Quickcheck.test ~trials:20 gen_test ~f:(fun t -> assert (check_signature t))
 

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -408,6 +408,15 @@ let gen_test =
   Gen.payment_with_random_participants ~sign_type:`Real
     ~keys:(Array.of_list keys) ~max_amount:10000 ~fee_range:1000 ()
 
+let (_ : unit) =
+  let payment = Quickcheck.random_value gen_test in
+  Format.eprintf "%s@." (to_yojson payment |> Yojson.Safe.pretty_to_string) ;
+  let buf = Bin_prot.Common.create_buf 8192 in
+  let len = Stable.Latest.bin_write_t buf ~pos:0 payment in
+  Format.eprintf "BUF LEN: %d@." len ;
+  let s = String.init len ~f:(fun ndx -> buf.{ndx}) in
+  Format.eprintf "%s@." (Hex.Safe.to_hex s)
+
 let%test_unit "completeness" =
   Quickcheck.test ~trials:20 gen_test ~f:(fun t -> assert (check_signature t))
 


### PR DESCRIPTION
Two changes:

- The Caqti type for coinbase amounts and fee transfer fees is changed from `int` to `int64`, because the db schema uses `bigint` for internal command amounts 
- for Rosetta, to retrieve the "last relevant command", consider the secondary sequence number in the descending sort, using a dummy 0 for user commands

The Rosetta change did not seem to fix any of the observed errors reported by `rosetta-cli`, but it could avoid errors.

Probably there are no errors fixed by the archive db change, the amounts for fees and coinbases are usually small. It's better to have the types match up, though.