### PR TITLE
Distinguish internal cmds by sequence

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -135,7 +135,6 @@ module Internal_command_info = struct
                 ; coin_change= None
                 ; metadata= None }
           | `Fee_receiver_inc ->
-            let `Pk pk = t.receiver in
             M.return
                 { Operation.operation_identifier
                 ; related_operations


### PR DESCRIPTION
For Rosetta, use sequence no and secondary sequence no to distinguish internal commands, even if they have the same type and hash. Those numbers are included in the hash reported to Rosetta.

Also, for account creation fee operations, make the operation that created the operation a "related operation", in the same way that's done for the two sides of a payment.

Tested with rosetta-cli on devnet2, which gets past some balance reconciliation errors reported earlier.
