### PR TITLE
Log block heights in missing blocks auditor

### DIFF
--- a/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
+++ b/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
@@ -26,13 +26,17 @@ let main ~archive_uri () =
               ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
             exit 1
       in
-      List.iter missing_blocks ~f:(fun (block_id, state_hash, parent_hash) ->
-          [%log info] "Block has no parent in archive db"
-            ~metadata:
-              [ ("block_id", `Int block_id)
-              ; ("state_hash", `String state_hash)
-              ; ("parent_hash", `String parent_hash)
-              ]) ;
+      List.iter missing_blocks
+        ~f:(fun (block_id, state_hash, height, parent_hash) ->
+          if height > 1 then
+            [%log info] "Block has no parent in archive db"
+              ~metadata:
+                [ ("block_id", `Int block_id)
+                ; ("state_hash", `String state_hash)
+                ; ("height", `Int height)
+                ; ("parent_hash", `String parent_hash)
+                ; ("parent_height", `Int (height - 1))
+                ]) ;
       ()
 
 let () =

--- a/src/app/missing_blocks_auditor/sql.ml
+++ b/src/app/missing_blocks_auditor/sql.ml
@@ -5,11 +5,11 @@ module Unparented_blocks = struct
 
   let query =
     Caqti_request.collect Caqti_type.unit
-      Caqti_type.(tup3 int string string)
-      {|
-           SELECT id,state_hash,parent_hash FROM blocks
+      Caqti_type.(tup4 int string int string)
+      {sql|
+           SELECT id, state_hash, height, parent_hash FROM blocks
            WHERE parent_id IS NULL
-      |}
+      |sql}
 
   let run (module Conn : Caqti_async.CONNECTION) () = Conn.collect_list query ()
 end


### PR DESCRIPTION
Log the height of the block with a missing parent, and the height of that missing parent (by subtracting 1).

If the block has height 1, it's the genesis block, so don't report a missing parent in that case.

Tested against a local copy of the devnet2 archive db.