### PR TITLE
Rosetta, report total balance for vesting accounts

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -394,7 +394,7 @@ module Balance = struct
               Amount_of.coda
           | Some token_id ->
               Amount_of.token token_id )
-            liquid_balance
+            total_balance
         in
         let locked_balance =
           Unsigned.UInt64.sub total_balance liquid_balance
@@ -403,6 +403,8 @@ module Balance = struct
           `Assoc
             [ ( "locked_balance"
               , `Intlit (Unsigned.UInt64.to_string locked_balance) )
+            ; ( "liquid_balance"
+              , `Intlit (Unsigned.UInt64.to_string liquid_balance) )
             ; ( "total_balance"
               , `Intlit (Unsigned.UInt64.to_string total_balance) ) ]
         in
@@ -500,7 +502,22 @@ let router ~graphql_uri ~logger ~with_db (route : string list) body =
   match route with
   | ["balance"] ->
       with_db (fun ~db ->
-          let%bind req =
+        let body =
+          (* workaround: rosetta-cli with view:balance does not seem to have a way to submit the
+             currencies list, so supply it here
+          *)
+          match body with
+          | `Assoc items -> (
+            match List.Assoc.find items "currencies" ~equal:String.equal with
+                Some _ -> body
+              | None ->
+                `Assoc (items @ [("currencies",`List [`Assoc [("symbol",`String "MINA");("decimals", `Int 9)]])])
+          )
+          | _ ->
+            (* will fail on JSON parse below *)
+            body
+        in
+        let%bind req =
             Errors.Lift.parse ~context:"Request"
             @@ Account_balance_request.of_yojson body
             |> Errors.Lift.wrap

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -702,13 +702,11 @@ module Specific = struct
                    "type" fields, which correspond to the "kind" here
                 *)
                 {Transaction_identifier.hash=
-                   (Internal_command_info.Kind.to_string info.kind)
-                   ^ ":" ^
-                   (Int.to_string info.sequence_no)
-                   ^ ":" ^
-                   (Int.to_string info.secondary_sequence_no)
-                   ^ ":" ^
-                   info.hash}
+                   sprintf "%s:%s:%s:%s"
+                     (Internal_command_info.Kind.to_string info.kind)
+                     (Int.to_string info.sequence_no)
+                     (Int.to_string info.secondary_sequence_no)
+                     info.hash}
             ; operations
             ; metadata= None }
             :: acc )


### PR DESCRIPTION
In Rosetta, a balance query reported only the liquid balance, causing balance reconciliation errors between the "computed" balance, which uses that value, and the "live" balance, which is what's in the archive db.

Instead, report the total balance, and consign the liquid balance to the balance metadata.

Other changes:
- add the `currencies` field to balance queries that are missing it, as when using the rosetta-cli `view:balance` query
- simpler formatting of transaction hashes that add the transaction type and sequence nos

With these changes, tested `view:balance` and `check:data` against mainnet.