### PR TITLE
Replayer, start with arbitrary staged ledger

### DIFF
--- a/scripts/replayer-test.sh
+++ b/scripts/replayer-test.sh
@@ -53,7 +53,7 @@ echo "Building replayer"
 make replayer
 
 echo "Running replayer"
-./_build/default/src/app/replayer/replayer.exe --archive-uri $PG_CONN --input-file $REPLAYER_DIR/test/input.json --output-file /dev/null
+./_build/default/src/app/replayer/replayer.exe --archive-uri $PG_CONN --input-file $REPLAYER_DIR/test/input.json
 
 RESULT=$?
 

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -24,7 +24,8 @@ open Mina_base
 *)
 
 type input =
-  { target_epoch_ledgers_state_hash : State_hash.t
+  { target_epoch_ledgers_state_hash : State_hash.t option [@default None]
+  ; start_slot : int64 [@default 0L]
   ; genesis_ledger : Runtime_config.Ledger.t
   }
 [@@deriving yojson]
@@ -85,6 +86,32 @@ let create_output ~target_fork_state_hash ~target_epoch_ledgers_state_hash
 (* map from global slots to state hash, ledger hash pairs *)
 let global_slot_hashes_tbl : (Int64.t, State_hash.t * Ledger_hash.t) Hashtbl.t =
   Int64.Table.create ()
+
+(* the starting slot may not have a block, so there may not be an entry in the table
+    of hashes
+   look at the predecessor slots until we find an entry
+   this search should only happen on the start slot, all other slots
+    come from commands in blocks, for which we have an entry in the table
+*)
+let get_slot_hashes ~logger slot =
+  let rec go curr_slot =
+    if Int64.is_negative curr_slot then (
+      [%log fatal]
+        "Could not find state and ledger hashes for slot %Ld, despite trying \
+         all predecessor slots"
+        slot ;
+      Core.exit 1 ) ;
+    match Hashtbl.find global_slot_hashes_tbl curr_slot with
+    | None ->
+        [%log info]
+          "State and ledger hashes not available at slot %Ld, will try \
+           predecessor slot"
+          curr_slot ;
+        go (Int64.pred curr_slot)
+    | Some hashes ->
+        hashes
+  in
+  go slot
 
 (* cache of account keys *)
 let pk_tbl : (int, Account.key) Hashtbl.t = Int.Table.create ()
@@ -586,6 +613,49 @@ let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t)
         [%sexp_of: (string * int64) * (string * int)]
       |> Error.raise
 
+let find_canonical_chain ~logger pool slot =
+  (* find longest canonical chain
+     a slot may represent several blocks, only one of which can be on canonical chain
+     starting with max slot, look for chain, decrementing slot until chain found
+  *)
+  let find_state_hash_chain state_hash =
+    match%map
+      query_db pool
+        ~f:(fun db -> Sql.Block.get_chain db state_hash)
+        ~item:"chain from state hash"
+    with
+    | [] ->
+        [%log info] "Block with state hash %s is not along canonical chain"
+          state_hash ;
+        None
+    | _ ->
+        Some state_hash
+  in
+  let%bind state_hashes =
+    query_db pool
+      ~f:(fun db -> Sql.Block.get_state_hashes_by_slot db slot)
+      ~item:"ids by slot"
+  in
+  Deferred.List.find_map state_hashes ~f:find_state_hash_chain
+
+let try_slot ~logger pool slot =
+  let num_tries = 5 in
+  let rec go ~slot ~tries_left =
+    if tries_left <= 0 then (
+      [%log fatal] "Could not find canonical chain after trying %d slots"
+        num_tries ;
+      Core_kernel.exit 1 ) ;
+    match%bind find_canonical_chain ~logger pool slot with
+    | None ->
+        go ~slot:(slot - 1) ~tries_left:(tries_left - 1)
+    | Some state_hash ->
+        [%log info]
+          "Found possible canonical chain to target state hash %s at slot %d"
+          state_hash slot ;
+        return state_hash
+  in
+  go ~slot ~tries_left:num_tries
+
 let unquoted_string_of_yojson json =
   (* Yojson.Safe.to_string produces double-quoted strings
      remove those quotes for SQL queries
@@ -593,7 +663,7 @@ let unquoted_string_of_yojson json =
   let s = Yojson.Safe.to_string json in
   String.sub s ~pos:1 ~len:(String.length s - 2)
 
-let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
+let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
   let logger = Logger.create () in
   let json = Yojson.Safe.from_file input_file in
   let input =
@@ -612,7 +682,7 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
         ~metadata:[ ("error", `String (Caqti_error.show e)) ]
         "Failed to create a Caqti pool for Postgresql" ;
       exit 1
-  | Ok pool ->
+  | Ok pool -> (
       [%log info] "Successfully created Caqti pool for Postgresql" ;
       (* load from runtime config in same way as daemon
          except that we don't consider loading from a tar file
@@ -635,19 +705,32 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
           ~depth:constraint_constants.ledger_depth padded_accounts
       in
       let ledger = Lazy.force @@ Genesis_ledger.Packed.t packed_ledger in
-      let epoch_ledgers_state_hash =
-        State_hash.to_string input.target_epoch_ledgers_state_hash
+      let epoch_ledgers_state_hash_opt =
+        Option.map input.target_epoch_ledgers_state_hash ~f:State_hash.to_string
       in
-      [%log info] "Retrieving fork block state_hash" ;
-      let%bind fork_state_hash =
-        query_db pool
-          ~f:(fun db ->
-            Sql.Parent_block.get_parent_state_hash db epoch_ledgers_state_hash)
-          ~item:"parent state hash of state hash"
+      let%bind target_state_hash =
+        match epoch_ledgers_state_hash_opt with
+        | Some epoch_ledgers_state_hash ->
+            [%log info] "Retrieving fork block state_hash" ;
+            query_db pool
+              ~f:(fun db ->
+                Sql.Parent_block.get_parent_state_hash db
+                  epoch_ledgers_state_hash)
+              ~item:"parent state hash of state hash"
+        | None ->
+            [%log info]
+              "Searching for block with greatest height on canonical chain" ;
+            let%bind max_slot =
+              query_db pool
+                ~f:(fun db -> Sql.Block.get_max_slot db ())
+                ~item:"max slot"
+            in
+            [%log info] "Maximum global slot in blocks is %d" max_slot ;
+            try_slot ~logger pool max_slot
       in
       [%log info] "Loading block information using target state hash" ;
       let%bind block_ids =
-        process_block_infos_of_state_hash ~logger pool fork_state_hash
+        process_block_infos_of_state_hash ~logger pool target_state_hash
           ~f:(fun block_infos ->
             let ids = List.map block_infos ~f:(fun { id; _ } -> id) in
             (* build mapping from global slots to state and ledger hashes *)
@@ -676,7 +759,7 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
       let%bind user_cmd_ids =
         match%bind
           Caqti_async.Pool.use
-            (fun db -> Sql.User_command_ids.run db fork_state_hash)
+            (fun db -> Sql.User_command_ids.run db target_state_hash)
             pool
         with
         | Ok ids ->
@@ -690,13 +773,13 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
       let%bind internal_cmd_ids =
         match%bind
           Caqti_async.Pool.use
-            (fun db -> Sql.Internal_command_ids.run db fork_state_hash)
+            (fun db -> Sql.Internal_command_ids.run db target_state_hash)
             pool
         with
         | Ok ids ->
             return ids
         | Error msg ->
-            [%log error] "Error getting user command ids"
+            [%log error] "Error getting user command ids and slots"
               ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
             exit 1
       in
@@ -723,11 +806,16 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
                   (Caqti_error.show msg) ())
       in
       let unsorted_internal_cmds = List.concat unsorted_internal_cmds_list in
-      (* filter out internal commands in blocks not along chain from target state hash *)
+      (* filter out internal commands in blocks not along chain from target state hash
+         or before start slot
+      *)
       let filtered_internal_cmds =
         List.filter unsorted_internal_cmds ~f:(fun cmd ->
-            Int.Set.mem block_ids cmd.block_id)
+            Int64.( >= ) cmd.global_slot input.start_slot
+            && Int.Set.mem block_ids cmd.block_id)
       in
+      [%log info] "Will replay %d internal commands"
+        (List.length filtered_internal_cmds) ;
       let sorted_internal_cmds =
         List.sort filtered_internal_cmds ~compare:(fun ic1 ic2 ->
             let tuple (ic : Sql.Internal_command.t) =
@@ -758,11 +846,16 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
                   (Caqti_error.show msg) ())
       in
       let unsorted_user_cmds = List.concat unsorted_user_cmds_list in
-      (* filter out user commands in blocks not along chain from target state hash *)
+      (* filter out user commands in blocks not along chain from target state hash
+         or before start slot
+      *)
       let filtered_user_cmds =
         List.filter unsorted_user_cmds ~f:(fun cmd ->
-            Int.Set.mem block_ids cmd.block_id)
+            Int64.( >= ) cmd.global_slot input.start_slot
+            && Int.Set.mem block_ids cmd.block_id)
       in
+      [%log info] "Will replay %d user commands"
+        (List.length filtered_user_cmds) ;
       let sorted_user_cmds =
         List.sort filtered_user_cmds ~compare:(fun uc1 uc2 ->
             let tuple (uc : Sql.User_command.t) =
@@ -770,9 +863,6 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
             in
             [%compare: int64 * int] (tuple uc1) (tuple uc2))
       in
-      [%log info] "Applying %d user commands and %d internal commands"
-        (List.length sorted_user_cmds)
-        (List.length sorted_internal_cmds) ;
       (* apply commands in global slot, sequence order *)
       let rec apply_commands (internal_cmds : Sql.Internal_command.t list)
           (user_cmds : Sql.User_command.t list) ~last_global_slot ~last_block_id
@@ -787,7 +877,7 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
         in
         let log_ledger_hash_after_last_slot () =
           let _state_hash, expected_ledger_hash =
-            Hashtbl.find_exn global_slot_hashes_tbl last_global_slot
+            get_slot_hashes ~logger last_global_slot
           in
           if Ledger_hash.equal (Ledger.merkle_root ledger) expected_ledger_hash
           then
@@ -810,7 +900,7 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
         in
         let log_state_hash_on_next_slot curr_global_slot =
           let state_hash, _ledger_hash =
-            Hashtbl.find_exn global_slot_hashes_tbl curr_global_slot
+            get_slot_hashes ~logger curr_global_slot
           in
           [%log info]
             ~metadata:
@@ -822,6 +912,15 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
         in
         let log_on_slot_change curr_global_slot =
           if Int64.( > ) curr_global_slot last_global_slot then (
+            if Int64.equal curr_global_slot 12004L then (
+              Format.eprintf "GLOBAL SLOT: %Ld@." last_global_slot ;
+              let accounts = Ledger.to_list ledger in
+              Format.eprintf "LEDGER: %s@."
+                (Yojson.Safe.pretty_to_string
+                   (Runtime_config.Accounts.to_yojson
+                      (List.map accounts ~f:(fun a ->
+                           Genesis_ledger_helper.Accounts.Single.of_account a
+                             None)))) ) ;
             log_ledger_hash_after_last_slot () ;
             log_state_hash_on_next_slot curr_global_slot )
         in
@@ -902,32 +1001,45 @@ let main ~input_file ~output_file ~archive_uri ~continue_on_error () =
         | _ ->
             failwith "Expected only the genesis block to have an unparented id"
       in
-      [%log info] "At genesis, ledger hash"
+      [%log info] "At start slot %Ld, ledger hash" input.start_slot
         ~metadata:[ ("ledger_hash", json_ledger_hash_of_ledger ledger) ] ;
       let%bind staking_epoch_ledger, staking_seed, next_epoch_ledger, next_seed
           =
         apply_commands sorted_internal_cmds sorted_user_cmds
-          ~last_global_slot:0L ~last_block_id:genesis_block_id
+          ~last_global_slot:input.start_slot ~last_block_id:genesis_block_id
           ~staking_epoch_ledger:ledger ~next_epoch_ledger:ledger
       in
-      if Int.equal !error_count 0 then (
-        [%log info] "Writing output to $output_file"
-          ~metadata:[ ("output_file", `String output_file) ] ;
-        let output =
-          create_output
-            ~target_epoch_ledgers_state_hash:
-              input.target_epoch_ledgers_state_hash
-            ~target_fork_state_hash:(State_hash.of_string fork_state_hash)
-            ~ledger ~staking_epoch_ledger ~staking_seed ~next_epoch_ledger
-            ~next_seed input.genesis_ledger
-          |> output_to_yojson |> Yojson.Safe.to_string
-        in
-        let%map writer = Async_unix.Writer.open_file output_file in
-        Async.fprintf writer "%s\n" output ;
-        () )
-      else (
-        [%log error] "There were %d errors, not writing output" !error_count ;
-        exit 1 )
+      match input.target_epoch_ledgers_state_hash with
+      | None ->
+          [%log info]
+            "Not writing output, because target state hash was obtained from \
+             the longest chain, not from a fork point that produced an epoch \
+             ledger hash" ;
+          return ()
+      | Some target_epoch_ledgers_state_hash -> (
+          match output_file_opt with
+          | None ->
+              [%log info] "Output file not supplied, not writing output" ;
+              return ()
+          | Some output_file ->
+              if Int.equal !error_count 0 then (
+                [%log info] "Writing output to $output_file"
+                  ~metadata:[ ("output_file", `String output_file) ] ;
+                let output =
+                  create_output ~target_epoch_ledgers_state_hash
+                    ~target_fork_state_hash:
+                      (State_hash.of_string target_state_hash)
+                    ~ledger ~staking_epoch_ledger ~staking_seed
+                    ~next_epoch_ledger ~next_seed input.genesis_ledger
+                  |> output_to_yojson |> Yojson.Safe.to_string
+                in
+                let%map writer = Async_unix.Writer.open_file output_file in
+                Async.fprintf writer "%s\n" output ;
+                () )
+              else (
+                [%log error] "There were %d errors, not writing output"
+                  !error_count ;
+                exit 1 ) ) )
 
 let () =
   Command.(
@@ -938,10 +1050,10 @@ let () =
            Param.flag "--input-file"
              ~doc:"file File containing the genesis ledger"
              Param.(required string)
-         and output_file =
+         and output_file_opt =
            Param.flag "--output-file"
              ~doc:"file File containing the resulting ledger"
-             Param.(required string)
+             Param.(optional string)
          and archive_uri =
            Param.flag "--archive-uri"
              ~doc:
@@ -952,4 +1064,4 @@ let () =
            Param.flag "--continue-on-error"
              ~doc:"Continue processing after errors" Param.no_arg
          in
-         main ~input_file ~output_file ~archive_uri ~continue_on_error)))
+         main ~input_file ~output_file_opt ~archive_uri ~continue_on_error)))

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -779,7 +779,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
         | Ok ids ->
             return ids
         | Error msg ->
-            [%log error] "Error getting user command ids and slots"
+            [%log error] "Error getting user command ids"
               ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
             exit 1
       in
@@ -912,15 +912,6 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
         in
         let log_on_slot_change curr_global_slot =
           if Int64.( > ) curr_global_slot last_global_slot then (
-            if Int64.equal curr_global_slot 12004L then (
-              Format.eprintf "GLOBAL SLOT: %Ld@." last_global_slot ;
-              let accounts = Ledger.to_list ledger in
-              Format.eprintf "LEDGER: %s@."
-                (Yojson.Safe.pretty_to_string
-                   (Runtime_config.Accounts.to_yojson
-                      (List.map accounts ~f:(fun a ->
-                           Genesis_ledger_helper.Accounts.Single.of_account a
-                             None)))) ) ;
             log_ledger_hash_after_last_slot () ;
             log_state_hash_on_next_slot curr_global_slot )
         in

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -84,6 +84,43 @@ module Block = struct
 
   let get_unparented (module Conn : Caqti_async.CONNECTION) () =
     Conn.collect_list unparented_query ()
+
+  let max_slot_query =
+    Caqti_request.find Caqti_type.unit Caqti_type.int
+      {sql| SELECT MAX(global_slot) FROM blocks |sql}
+
+  let get_max_slot (module Conn : Caqti_async.CONNECTION) () =
+    Conn.find max_slot_query ()
+
+  let state_hashes_by_slot_query =
+    Caqti_request.collect Caqti_type.int Caqti_type.string
+      {sql| SELECT state_hash FROM blocks WHERE global_slot = $1 |sql}
+
+  let get_state_hashes_by_slot (module Conn : Caqti_async.CONNECTION) slot =
+    Conn.collect_list state_hashes_by_slot_query slot
+
+  (* find all blocks, working back from block with given state hash *)
+  let chain_query =
+    Caqti_request.collect Caqti_type.string Caqti_type.string
+      {sql| WITH RECURSIVE chain AS (
+
+              SELECT id,parent_id FROM blocks b WHERE b.state_hash = ?
+
+              UNION ALL
+
+              SELECT b.id,b.parent_id FROM blocks b
+
+              INNER JOIN chain
+
+              ON b.id = chain.parent_id AND NOT chain.parent_id IS NULL
+           )
+
+           SELECT 'ok' AS found_chain FROM chain c
+
+      |sql}
+
+  let get_chain (module Conn : Caqti_async.CONNECTION) state_hash =
+    Conn.collect_list chain_query state_hash
 end
 
 module User_command_ids = struct


### PR DESCRIPTION
Allow the replayer to start with an arbitrary staged ledger, instead of the genesis ledger. The input file now allows an optional field, `start_slot`, default `0`, corresponding to the staged ledger.

The field `target_epoch_ledgers_state_hash` becomes optional. If not given, the replayer will try to play through the block of greatest height along the canonical chain. Additionally, if that field is omitted, don't produce output, because the output contains staking ledgers, meant for use at a hard fork. The thinking is, if you omitted the field, you meant to validate the data in the archive db.

The cli flag `--ouput-file` becomes optional, so we don't have to specify `/dev/null` in CI tests.

Tested by printing the ledger at an arbitrary slot when running the `replayer-test.sh` script; using that ledger as input and slot in the input file; running the replayer for 1000ish blocks with no errors. I find that convincing: If this approach were to fail, it'd fail fast.

Closes #9405.