### PR TITLE
Fix async scheduler starvation

### DIFF
--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -493,7 +493,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
              server_description port )
   in
   Option.iter rest_server_port ~f:(fun rest_server_port ->
-      trace_task "REST server" (fun () ->
+      trace_task "full GraphQL server" (fun () ->
           create_graphql_server
             ~bind_to_address:
               Tcp.Bind_to_address.(
@@ -502,7 +502,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
             rest_server_port ) ) ;
   (*Second graphql server with limited queries exopsed*)
   Option.iter limited_graphql_port ~f:(fun rest_server_port ->
-      trace_task "Second REST server (with limited queries)" (fun () ->
+      trace_task "limited GraphQL server" (fun () ->
           create_graphql_server
             ~bind_to_address:
               Tcp.Bind_to_address.(
@@ -514,64 +514,62 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
     Tcp.Where_to_listen.bind_to All_addresses
       (On_port (Mina_lib.client_port coda))
   in
-  don't_wait_for
-    (Deferred.ignore
-       (trace "client RPC handling" (fun () ->
-            Tcp.Server.create
-              ~on_handler_error:
-                (`Call
-                  (fun _net exn ->
-                    [%log error]
-                      "Exception while handling TCP server request: $error"
-                      ~metadata:
-                        [ ("error", `String (Exn.to_string_mach exn))
-                        ; ("context", `String "rpc_tcp_server") ] ))
-              where_to_listen
-              (fun address reader writer ->
-                let address = Socket.Address.Inet.addr address in
-                if
-                  not
-                    (Set.exists !client_trustlist ~f:(fun cidr ->
-                         Unix.Cidr.does_match cidr address ))
-                then (
-                  [%log error]
-                    !"Rejecting client connection from $address, it is not \
-                      present in the trustlist."
-                    ~metadata:
-                      [("$address", `String (Unix.Inet_addr.to_string address))] ;
-                  Deferred.unit )
-                else
-                  Rpc.Connection.server_with_close
-                    ~handshake_timeout:
-                      (Time.Span.of_sec
-                         Mina_compile_config.rpc_handshake_timeout_sec)
-                    ~heartbeat_config:
-                      (Rpc.Connection.Heartbeat_config.create
-                         ~timeout:
-                           (Time_ns.Span.of_sec
-                              Mina_compile_config.rpc_heartbeat_timeout_sec)
-                         ~send_every:
-                           (Time_ns.Span.of_sec
-                              Mina_compile_config.rpc_heartbeat_send_every_sec))
-                    reader writer
-                    ~implementations:
-                      (Rpc.Implementations.create_exn
-                         ~implementations:(client_impls @ snark_worker_impls)
-                         ~on_unknown_rpc:`Raise)
-                    ~connection_state:(fun _ -> ())
-                    ~on_handshake_error:
-                      (`Call
-                        (fun exn ->
-                          [%log warn]
-                            "Handshake error while handling RPC server \
-                             request from $address"
-                            ~metadata:
-                              [ ("error", `String (Exn.to_string_mach exn))
-                              ; ("context", `String "rpc_server")
-                              ; ( "address"
-                                , `String (Unix.Inet_addr.to_string address) )
-                              ] ;
-                          Deferred.unit )) ) )))
+  trace_task "client RPC server" (fun () ->
+      Deferred.ignore
+        (Tcp.Server.create
+           ~on_handler_error:
+             (`Call
+               (fun _net exn ->
+                 [%log error]
+                   "Exception while handling TCP server request: $error"
+                   ~metadata:
+                     [ ("error", `String (Exn.to_string_mach exn))
+                     ; ("context", `String "rpc_tcp_server") ] ))
+           where_to_listen
+           (fun address reader writer ->
+             let address = Socket.Address.Inet.addr address in
+             if
+               not
+                 (Set.exists !client_trustlist ~f:(fun cidr ->
+                      Unix.Cidr.does_match cidr address ))
+             then (
+               [%log error]
+                 !"Rejecting client connection from $address, it is not \
+                   present in the trustlist."
+                 ~metadata:
+                   [("$address", `String (Unix.Inet_addr.to_string address))] ;
+               Deferred.unit )
+             else
+               Rpc.Connection.server_with_close
+                 ~handshake_timeout:
+                   (Time.Span.of_sec
+                      Mina_compile_config.rpc_handshake_timeout_sec)
+                 ~heartbeat_config:
+                   (Rpc.Connection.Heartbeat_config.create
+                      ~timeout:
+                        (Time_ns.Span.of_sec
+                           Mina_compile_config.rpc_heartbeat_timeout_sec)
+                      ~send_every:
+                        (Time_ns.Span.of_sec
+                           Mina_compile_config.rpc_heartbeat_send_every_sec))
+                 reader writer
+                 ~implementations:
+                   (Rpc.Implementations.create_exn
+                      ~implementations:(client_impls @ snark_worker_impls)
+                      ~on_unknown_rpc:`Raise)
+                 ~connection_state:(fun _ -> ())
+                 ~on_handshake_error:
+                   (`Call
+                     (fun exn ->
+                       [%log warn]
+                         "Handshake error while handling RPC server request \
+                          from $address"
+                         ~metadata:
+                           [ ("error", `String (Exn.to_string_mach exn))
+                           ; ("context", `String "rpc_server")
+                           ; ( "address"
+                             , `String (Unix.Inet_addr.to_string address) ) ] ;
+                       Deferred.unit )) )) )
 
 let coda_crash_message ~log_issue ~action ~error =
   let followup =

--- a/src/external/ocaml-rocksdb/rocks.ml
+++ b/src/external/ocaml-rocksdb/rocks.ml
@@ -690,6 +690,61 @@ and RocksDb : (Rocks_intf.ROCKS with type batch := WriteBatch.t) = struct
     | None ->
         ReadOptions.with_t inner
 
+  let multi_get_raw =
+    foreign "rocksdb_multi_get"
+      ( t
+      @-> ReadOptions.t
+      @-> Views.int_to_size_t
+      @-> ptr (ptr char)
+      @-> ptr size_t
+      @-> ptr (ptr char)
+      @-> ptr size_t
+      @-> ptr (ptr char)
+      @-> returning void )
+
+  let multi_get ?opts t keys =
+    let inner opts =
+      let cast_array_ptr typ arr = arr |> bigarray_start array1 |> to_voidp |> from_voidp typ in
+      let count = List.length keys in
+      (* could optimize this into a single allocation *)
+      let inputs = Bigarray.(Array1.create Nativeint C_layout) count in
+      let input_lengths = Bigarray.(Array1.create Nativeint C_layout) count in
+      let outputs = Bigarray.(Array1.create Nativeint C_layout) count in
+      let output_lengths = Bigarray.(Array1.create Nativeint C_layout) count in
+      let errors = Bigarray.(Array1.create Nativeint C_layout) count in
+      keys |> List.iteri (fun i key ->
+        Bigarray.Array1.unsafe_set inputs i (bigarray_start array1 key |> to_voidp |> raw_address_of_ptr) ;
+        Bigarray.Array1.unsafe_set input_lengths i (Bigarray.Array1.dim key |> Nativeint.of_int) ) ;
+      multi_get_raw t opts count
+        (cast_array_ptr (ptr char) inputs)
+        (cast_array_ptr size_t input_lengths)
+        (cast_array_ptr (ptr char) outputs)
+        (cast_array_ptr size_t output_lengths)
+        (cast_array_ptr (ptr char) errors) ;
+      let results = ref [] in
+      for i = count - 1 downto 0 do
+        let res =
+          let error_ptr = Bigarray.Array1.unsafe_get errors i |> ptr_of_raw_address in
+          if is_null error_ptr then (
+            let output_length = Nativeint.to_int (Bigarray.Array1.unsafe_get output_lengths i) in
+            let output_ptr = Bigarray.Array1.unsafe_get outputs i |> ptr_of_raw_address |> from_voidp char in
+            let output = bigarray_of_ptr array1 output_length Bigarray.char output_ptr in
+            Gc.finalise_last (fun () -> free (to_voidp output_ptr)) output ;
+            Some output )
+          else (
+            free error_ptr ;
+            None )
+        in
+        results := res :: !results
+      done ;
+      !results
+    in
+    match opts with
+    | Some opts ->
+        inner opts
+    | None ->
+        ReadOptions.with_t inner
+
   let flush_raw =
     foreign "rocksdb_flush" (t @-> FlushOptions.t @-> returning_error void)
 

--- a/src/external/ocaml-rocksdb/rocks_intf.ml
+++ b/src/external/ocaml-rocksdb/rocks_intf.ml
@@ -97,6 +97,9 @@ module type ROCKS = sig
   val get : ?pos:int -> ?len:int -> ?opts:ReadOptions.t -> t -> bigarray -> bigarray option
   val get_string : ?pos:int -> ?len:int -> ?opts:ReadOptions.t -> t -> string -> string option
 
+  (* there are more efficient encodings of this... *)
+  val multi_get : ?opts:ReadOptions.t -> t -> bigarray list -> bigarray option list
+
   val put : ?key_pos:int -> ?key_len:int -> ?value_pos:int -> ?value_len:int -> ?opts:WriteOptions.t -> t -> bigarray -> bigarray -> unit
   val put_string : ?key_pos:int -> ?key_len:int -> ?value_pos:int -> ?value_len:int -> ?opts:WriteOptions.t -> t -> string -> string -> unit
 

--- a/src/external/ocaml-rocksdb/rocks_options.ml
+++ b/src/external/ocaml-rocksdb/rocks_options.ml
@@ -128,6 +128,22 @@ module BlockBasedTableOptions =
   end
 
 module Options = struct
+  module SliceTransform = struct
+    type t = Rocks_common.t
+
+    let t = Rocks_common.t
+
+    module Noop = struct
+      include CreateConstructors(struct
+        let super_name = "slicetransform"
+        let name = "noop"
+        let constructor = "rocksdb_" ^ super_name ^ "_create_" ^ name
+        let destructor  = "rocksdb_" ^ super_name ^ "_destroy"
+        let setter_prefix = "rocksdb_" ^ super_name ^ "_" ^ name ^ "_"
+      end)
+    end
+  end
+
   (* extern rocksdb_options_t* rocksdb_options_create(); *)
   (* extern void rocksdb_options_destroy(rocksdb_options_t*\); *)
   module C = CreateConstructors_(struct let name = "options" end)
@@ -210,8 +226,11 @@ module Options = struct
 
   (* extern void rocksdb_options_set_compression_options( *)
   (*     rocksdb_options_t*, int, int, int); *)
-  (* extern void rocksdb_options_set_prefix_extractor( *)
-  (*     rocksdb_options_t*, rocksdb_slicetransform_t*\); *)
+
+  (* extern void rocksdb_options_set_prefix_extractor(rocksdb_options_t* opt, rocksdb_slicetransform_t* trans); *)
+  let set_prefix_extractor =
+    create_setter "set_prefix_extractor" SliceTransform.t
+
   (* extern void rocksdb_options_set_num_levels(rocksdb_options_t*, int); *)
   (* extern void rocksdb_options_set_level0_file_num_compaction_trigger( *)
   (*     rocksdb_options_t*, int); *)

--- a/src/lib/key_value_database/key_value_database.ml
+++ b/src/lib/key_value_database/key_value_database.ml
@@ -52,6 +52,8 @@ module Intf = struct
 
     val get : t -> key:key -> value option M.t
 
+    val get_batch : t -> keys:key list -> value option list M.t
+
     val set : t -> key:key -> data:value -> unit M.t
 
     val remove : t -> key:key -> unit M.t
@@ -94,6 +96,8 @@ module Make_mock
   let create _ = Key.Table.create ()
 
   let get t ~key = Key.Table.find t key
+
+  let get_batch t ~keys = List.map keys ~f:(Key.Table.find t)
 
   let set = Key.Table.set
 

--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -135,6 +135,8 @@ module Make_base (Inputs : Inputs_intf) :
 
     let get (T ((module Base), t)) = Base.get t
 
+    let get_batch (T ((module Base), t)) = Base.get_batch t
+
     let get_uuid (T ((module Base), t)) = Base.get_uuid t
 
     let get_directory (T ((module Base), t)) = Base.get_directory t
@@ -147,6 +149,9 @@ module Make_base (Inputs : Inputs_intf) :
       Base.get_or_create_account t
 
     let location_of_account (T ((module Base), t)) = Base.location_of_account t
+
+    let location_of_account_batch (T ((module Base), t)) =
+      Base.location_of_account_batch t
 
     let fold_until (T ((module Base), t)) = Base.fold_until t
 

--- a/src/lib/merkle_ledger/base_ledger_intf.ml
+++ b/src/lib/merkle_ledger/base_ledger_intf.ml
@@ -29,7 +29,9 @@ module type S = sig
   module Path : Merkle_path.S with type hash := hash
 
   module Location : sig
-    type t [@@deriving sexp, compare, hash, eq]
+    type t [@@deriving sexp, compare, hash]
+
+    include Comparable.S with type t := t
   end
 
   include
@@ -95,6 +97,9 @@ module type S = sig
 
   val location_of_account : t -> account_id -> Location.t option
 
+  val location_of_account_batch :
+    t -> account_id list -> (account_id * Location.t option) list
+
   (** This may return an error if the ledger is full. *)
   val get_or_create_account :
     t -> account_id -> account -> ([`Added | `Existed] * Location.t) Or_error.t
@@ -111,6 +116,8 @@ module type S = sig
   val get_directory : t -> string option
 
   val get : t -> Location.t -> account option
+
+  val get_batch : t -> Location.t list -> (Location.t * account option) list
 
   val set : t -> Location.t -> account -> unit
 

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -113,9 +113,19 @@ module Make (Inputs : Inputs_intf) :
   let get_raw {kvdb; depth; _} location =
     Kvdb.get kvdb ~key:(Location.serialize ~ledger_depth:depth location)
 
+  let get_raw_batch {kvdb; depth; _} locations =
+    let keys =
+      List.map locations ~f:(Location.serialize ~ledger_depth:depth)
+    in
+    Kvdb.get_batch kvdb ~keys
+
   let get_bin mdb location bin_read =
     get_raw mdb location
     |> Option.map ~f:(fun v -> bin_read v ~pos_ref:(ref 0))
+
+  let get_bin_batch mdb locations bin_read =
+    get_raw_batch mdb locations
+    |> List.map ~f:(Option.map ~f:(fun v -> bin_read v ~pos_ref:(ref 0)))
 
   let delete_raw {kvdb; depth; _} location =
     Kvdb.remove kvdb ~key:(Location.serialize ~ledger_depth:depth location)
@@ -123,6 +133,10 @@ module Make (Inputs : Inputs_intf) :
   let get mdb location =
     assert (Location.is_account location) ;
     get_bin mdb location Account.bin_read_t
+
+  let get_batch mdb locations =
+    assert (List.for_all locations ~f:Location.is_account) ;
+    List.zip_exn locations (get_bin_batch mdb locations Account.bin_read_t)
 
   let get_hash mdb location =
     assert (Location.is_hash location) ;
@@ -192,6 +206,10 @@ module Make (Inputs : Inputs_intf) :
     assert (Location.is_generic location) ;
     get_raw mdb location
 
+  let get_generic_batch mdb locations =
+    assert (List.for_all locations ~f:Location.is_generic) ;
+    get_raw_batch mdb locations
+
   module Account_location = struct
     (** encodes a key, token_id pair as a location used as a database key, so
         we can find the account location associated with that key.
@@ -216,6 +234,18 @@ module Make (Inputs : Inputs_intf) :
       | Some location_bin ->
           Location.parse ~ledger_depth:mdb.depth location_bin
           |> Result.map_error ~f:(fun () -> Db_error.Malformed_database)
+
+    let get_batch mdb keys =
+      let parse_location bin =
+        match Location.parse ~ledger_depth:mdb.depth bin with
+        | Ok loc ->
+            Some loc
+        | Error () ->
+            None
+      in
+      List.map keys ~f:build_location
+      |> get_generic_batch mdb
+      |> List.map ~f:(Option.bind ~f:parse_location)
 
     let delete mdb key = delete_raw mdb (build_location key)
 
@@ -451,6 +481,9 @@ module Make (Inputs : Inputs_intf) :
         None
     | Ok location ->
         Some location
+
+  let location_of_account_batch t keys =
+    List.zip_exn keys (Account_location.get_batch t keys)
 
   let last_filled t = Account_location.last_location t
 

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -85,6 +85,8 @@ end = struct
 
   let get _t _loc = None
 
+  let get_batch _t locs = List.map locs ~f:(fun loc -> (loc, None))
+
   let get_uuid t = t.uuid
 
   let get_directory _ = None
@@ -97,6 +99,9 @@ end = struct
     failwith "get_or_create_account: null ledgers cannot be mutated"
 
   let location_of_account _t _ = None
+
+  let location_of_account_batch _t accts =
+    List.map accts ~f:(fun acct -> (acct, None))
 
   let accounts _t = Account_id.Set.empty
 

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -177,6 +177,18 @@ module Make (Inputs : Inputs_intf.S) = struct
       | None ->
           Base.get (get_parent t) location
 
+    let get_batch t locations =
+      assert_is_attached t ;
+      let found_accounts, leftover_locations =
+        List.partition_map locations ~f:(fun location ->
+            match self_find_account t location with
+            | Some account ->
+                `Fst (location, Some account)
+            | None ->
+                `Snd location )
+      in
+      found_accounts @ Base.get_batch (get_parent t) leftover_locations
+
     (* fixup_merkle_path patches a Merkle path reported by the parent,
        overriding with hashes which are stored in the mask *)
 
@@ -546,6 +558,19 @@ module Make (Inputs : Inputs_intf.S) = struct
           mask_result
       | None ->
           Base.location_of_account (get_parent t) account_id
+
+    let location_of_account_batch t account_ids =
+      assert_is_attached t ;
+      let found_locations, leftover_account_ids =
+        List.partition_map account_ids ~f:(fun account_id ->
+            match self_find_location t account_id with
+            | Some location ->
+                `Fst (account_id, Some location)
+            | None ->
+                `Snd account_id )
+      in
+      found_locations
+      @ Base.location_of_account_batch (get_parent t) leftover_account_ids
 
     (* not needed for in-memory mask; in the database, it's currently a NOP *)
     let make_space_for t =

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -339,7 +339,12 @@ module type Base_ledger_intf = sig
 
   val location_of_account : t -> Account_id.t -> Location.t option
 
+  val location_of_account_batch :
+    t -> Account_id.t list -> (Account_id.t * Location.t option) list
+
   val get : t -> Location.t -> Account.t option
+
+  val get_batch : t -> Location.t list -> (Location.t * Account.t option) list
 
   val detached_signal : t -> unit Deferred.t
 end

--- a/src/lib/network_pool/mocks.ml
+++ b/src/lib/network_pool/mocks.ml
@@ -16,7 +16,11 @@ module Base_ledger = struct
 
   let location_of_account _t k = Some k
 
+  let location_of_account_batch _t ks = List.map ks ~f:(fun k -> (k, Some k))
+
   let get t l = Map.find t l
+
+  let get_batch t ls = List.map ls ~f:(fun l -> (l, get t l))
 
   let detached_signal _ = Deferred.never ()
 end

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open Async
 open Pipe_lib
 open Network_peer
+open O1trace
 module Statement_table = Transaction_snark_work.Statement.Table
 
 module Snark_tables = struct
@@ -252,41 +253,60 @@ struct
           | Some _ ->
               true )
 
-      let fee_is_sufficient t ~fee ~prover ~best_tip_ledger =
-        let open Mina_base in
-        Currency.Fee.(fee >= t.account_creation_fee)
-        ||
-        match best_tip_ledger with
-        | None ->
-            false
-        | Some l ->
-            Option.(
-              is_some
-                ( Base_ledger.location_of_account l
-                    (Account_id.create prover Token_id.default)
-                >>= Base_ledger.get l ))
+      let fee_is_sufficient t ~fee ~account_exists =
+        Currency.Fee.(fee >= t.account_creation_fee) || account_exists
 
-      let handle_transition_frontier_diff u t =
-        match u with
-        | `New_best_tip l ->
+      let handle_new_best_tip_ledger t ledger =
+        let open Mina_base in
+        trace_recurring "handle_new_best_tip_ledger" (fun () ->
+            let%bind prover_account_ids_by_statement =
+              trace_recurring "generate account ids of provers in snark table"
+                (fun () ->
+                  let prover_account_id
+                      ({fee= {prover; _}; _} : 'a Priced_proof.t) =
+                    Account_id.create prover Token_id.default
+                  in
+                  let account_ids =
+                    Statement_table.map t.snark_tables.all ~f:prover_account_id
+                  in
+                  Scheduler.yield () >>| Fn.const account_ids )
+            in
+            (* if this is still starving the scheduler, we can make `location_of_account_batch` yield while it traverses the masks *)
+            let%map prover_account_locations =
+              trace_recurring
+                "lookup prover account locations in best tip ledger" (fun () ->
+                  let account_locations =
+                    Statement_table.data prover_account_ids_by_statement
+                    |> Base_ledger.location_of_account_batch ledger
+                    |> Account_id.Map.of_alist_exn
+                  in
+                  Scheduler.yield () >>| Fn.const account_locations )
+            in
             Statement_table.filteri_inplace t.snark_tables.all
-              ~f:(fun ~key ~data:{fee= {fee; prover}; _} ->
+              ~f:(fun ~key ~data:{fee= {fee; _}; _} ->
+                let prover_account_exists =
+                  Statement_table.find_exn prover_account_ids_by_statement key
+                  |> Map.find_exn prover_account_locations
+                  |> Option.is_some
+                in
                 let keep =
-                  fee_is_sufficient t ~fee ~prover ~best_tip_ledger:(Some l)
+                  fee_is_sufficient t ~fee
+                    ~account_exists:prover_account_exists
                 in
                 if not keep then
                   Hashtbl.remove t.snark_tables.rebroadcastable key ;
-                keep ) ;
-            return ()
-        | `New_refcount_table
-            { Extensions.Snark_pool_refcount.removed
-            ; refcount_table
-            ; best_tip_table } ->
+                keep ) )
+
+      let handle_new_refcount_table t
+          ({removed; refcount_table; best_tip_table} :
+            Extensions.Snark_pool_refcount.view) =
+        trace_recurring "handle_new_refcount_table" (fun () ->
+            (* I think this is needed here to make the tracing work properly here? TODO: test to see if this is true *)
+            let%map () = Deferred.return () in
             t.ref_table <- Some refcount_table ;
             t.best_tip_table <- Some best_tip_table ;
             t.removed_counter <- t.removed_counter + removed ;
-            if t.removed_counter < removed_breadcrumb_wait then return ()
-            else (
+            if t.removed_counter >= removed_breadcrumb_wait then (
               t.removed_counter <- 0 ;
               Statement_table.filter_keys_inplace t.snark_tables.all
                 ~f:(fun k ->
@@ -294,11 +314,16 @@ struct
                   if not keep then
                     Hashtbl.remove t.snark_tables.rebroadcastable k ;
                   keep ) ;
-              return
-                (*when snark works removed from the pool*)
-                Mina_metrics.(
-                  Gauge.set Snark_work.snark_pool_size
-                    (Float.of_int @@ Hashtbl.length t.snark_tables.all)) )
+              Mina_metrics.(
+                Gauge.set Snark_work.snark_pool_size
+                  (Float.of_int @@ Hashtbl.length t.snark_tables.all)) ) )
+
+      let handle_transition_frontier_diff u t =
+        match u with
+        | `New_best_tip ledger ->
+            handle_new_best_tip_ledger t ledger
+        | `New_refcount_table refcount_table ->
+            handle_new_refcount_table t refcount_table
 
       (*TODO? add referenced statements from the transition frontier to ref_table here otherwise the work referenced in the root and not in any of the successor blocks will never be included. This may not be required because the chances of a new block from the root is very low (root's existing successor is 1 block away from finality)*)
       let listen_to_frontier_broadcast_pipe frontier_broadcast_pipe (t : t)
@@ -397,7 +422,6 @@ struct
           `Statement_not_referenced
 
       let verify_and_act t ~work ~sender =
-        let best_tip_ledger = t.best_tip_ledger () in
         let statements, priced_proof = work in
         let {Priced_proof.proof= proofs; fee= {prover; fee}} = priced_proof in
         let trust_record =
@@ -425,9 +449,6 @@ struct
           else Deferred.return ()
         in
         let message = Mina_base.Sok_message.create ~fee ~prover in
-        let prover_account_ok =
-          fee_is_sufficient t ~fee ~prover ~best_tip_ledger
-        in
         let verify proofs =
           let open Deferred.Let_syntax in
           let%bind statement_check =
@@ -447,7 +468,18 @@ struct
                   Error e )
           in
           let work = One_or_two.map proofs ~f:snd in
-          if not prover_account_ok then (
+          let prover_account_exists =
+            let open Option.Let_syntax in
+            Option.is_some
+              (let open Mina_base in
+              let%bind ledger = t.best_tip_ledger () in
+              Account_id.create prover Token_id.default
+              |> Base_ledger.location_of_account ledger)
+          in
+          if
+            not
+              (fee_is_sufficient t ~fee ~account_exists:prover_account_exists)
+          then (
             [%log' debug t.logger]
               "Prover $prover did not have sufficient balance" ~metadata ;
             return false )

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -13,6 +13,8 @@ include T
 let create directory =
   let opts = Rocks.Options.create () in
   Rocks.Options.set_create_if_missing opts true ;
+  Rocks.Options.set_prefix_extractor opts
+    (Rocks.Options.SliceTransform.Noop.create_no_gc ()) ;
   {uuid= Uuid_unix.create (); db= Rocks.open_db ~opts directory}
 
 let create_checkpoint t dir =
@@ -25,6 +27,9 @@ let close t = Rocks.close t.db
 
 let get t ~(key : Bigstring.t) : Bigstring.t option =
   Rocks.get ?pos:None ?len:None ?opts:None t.db key
+
+let get_batch t ~(keys : Bigstring.t list) : Bigstring.t option list =
+  Rocks.multi_get t.db keys
 
 let set t ~(key : Bigstring.t) ~(data : Bigstring.t) : unit =
   Rocks.put ?key_pos:None ?key_len:None ?value_pos:None ?value_len:None

--- a/src/lib/rocksdb/serializable.ml
+++ b/src/lib/rocksdb/serializable.ml
@@ -19,6 +19,11 @@ module Make (Key : Binable.S) (Value : Binable.S) :
     in
     Binable.of_bigstring (module Value) serialized_value
 
+  let get_batch t ~keys =
+    Database.get_batch t
+      ~keys:(List.map keys ~f:(Binable.to_bigstring (module Key)))
+    |> List.map ~f:(Option.map ~f:(Binable.of_bigstring (module Value)))
+
   let set t ~key ~data =
     Database.set t
       ~key:(Binable.to_bigstring (module Key) key)

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -4,7 +4,7 @@
 (* Only show stdout for failed inline tests. *)
 open Inline_test_quiet_logs
 open Core_kernel
-open Async_kernel
+open Async
 open Mina_base
 open Currency
 open O1trace
@@ -12,6 +12,8 @@ open Signature_lib
 
 let option lab =
   Option.value_map ~default:(Or_error.error_string lab) ~f:(fun x -> Ok x)
+
+let yield_result () = Deferred.map (Scheduler.yield ()) ~f:Result.return
 
 module T = struct
   module Scan_state = Transaction_snark_scan_state
@@ -177,13 +179,11 @@ module T = struct
             Error (Couldn't_reach_verifier e) )
 
   module Statement_scanner = struct
-    include Scan_state.Make_statement_scanner
-              (Deferred)
-              (struct
-                type t = unit
+    include Scan_state.Make_statement_scanner (struct
+      type t = unit
 
-                let verify ~verifier:() _proofs = Deferred.return (Ok true)
-              end)
+      let verify ~verifier:() _proofs = Deferred.Or_error.return true
+    end)
   end
 
   module Statement_scanner_proof_verifier = struct
@@ -195,9 +195,7 @@ module T = struct
   end
 
   module Statement_scanner_with_proofs =
-    Scan_state.Make_statement_scanner
-      (Deferred)
-      (Statement_scanner_proof_verifier)
+    Scan_state.Make_statement_scanner (Statement_scanner_proof_verifier)
 
   type t =
     { scan_state: Scan_state.t
@@ -243,18 +241,16 @@ module T = struct
       in
       next_available_token_after
     in
-    match Scan_state.latest_ledger_proof scan_state with
-    | None ->
-        Statement_scanner.check_invariants ~constraint_constants scan_state
-          ~verifier:() ~error_prefix ~ledger_hash_end:ledger
-          ~ledger_hash_begin:None ~next_available_token_begin:None
-          ~next_available_token_end:next_available_token
-    | Some proof ->
-        Statement_scanner.check_invariants ~constraint_constants scan_state
-          ~verifier:() ~error_prefix ~ledger_hash_end:ledger
-          ~ledger_hash_begin:(Some (get_target proof))
-          ~next_available_token_begin:(Some (next_available_token_begin proof))
-          ~next_available_token_end:next_available_token
+    let ledger_hash_begin, next_available_token_begin =
+      Scan_state.latest_ledger_proof scan_state
+      |> Option.value_map ~default:(None, None) ~f:(fun proof ->
+             (Some (get_target proof), Some (next_available_token_begin proof))
+         )
+    in
+    Statement_scanner.check_invariants ~constraint_constants scan_state
+      ~verifier:() ~error_prefix ~ledger_hash_end:ledger ~ledger_hash_begin
+      ~next_available_token_begin
+      ~next_available_token_end:next_available_token
 
   let statement_exn ~constraint_constants t =
     let open Deferred.Let_syntax in
@@ -332,7 +328,7 @@ module T = struct
     let%bind _ =
       Deferred.Or_error.List.iter txs_with_protocol_state
         ~f:(fun (tx, protocol_state) ->
-          let%map.Async () = Async.Scheduler.yield () in
+          let%map.Deferred.Let_syntax () = Scheduler.yield () in
           let%bind.Or_error.Let_syntax txn_with_info =
             Ledger.apply_transaction ~constraint_constants
               ~txn_state_view:
@@ -507,6 +503,7 @@ module T = struct
   let apply_transaction_and_get_witness ~constraint_constants ledger
       pending_coinbase_stack_state s status txn_state_view state_and_body_hash
       =
+    let open Deferred.Result.Let_syntax in
     let account_ids : Transaction.t -> _ = function
       | Fee_transfer t ->
           Fee_transfer.receivers t
@@ -525,15 +522,14 @@ module T = struct
       measure "sparse ledger" (fun () ->
           Sparse_ledger.of_ledger_subset_exn ledger (account_ids s) )
     in
-    let r =
+    let%bind () = yield_result () in
+    let%bind applied_txn, statement, updated_pending_coinbase_stack_state =
       measure "apply+stmt" (fun () ->
           apply_transaction_and_get_statement ~constraint_constants ledger
             pending_coinbase_stack_state s txn_state_view )
+      |> Deferred.return
     in
-    let open Result.Let_syntax in
-    let%bind applied_txn, statement, updated_pending_coinbase_stack_state =
-      r
-    in
+    let%bind () = yield_result () in
     let%map () =
       match status with
       | None ->
@@ -545,7 +541,7 @@ module T = struct
           in
           if Transaction_status.equal status got_status then return ()
           else
-            Result.fail
+            Deferred.Result.fail
               (Staged_ledger_error.Mismatched_statuses
                  ({With_status.data= s; status}, got_status))
     in
@@ -556,13 +552,6 @@ module T = struct
       ; init_stack= Base pending_coinbase_stack_state.init_stack
       ; statement }
     , updated_pending_coinbase_stack_state )
-
-  let rec partition size = function
-    | [] ->
-        []
-    | ls ->
-        let sub, rest = List.split_n ls size in
-        sub :: partition size rest
 
   let update_ledger_and_get_statements ~constraint_constants ledger
       current_stack ts current_state_view state_and_body_hash =
@@ -577,32 +566,28 @@ module T = struct
       in
       let exception Exit of Staged_ledger_error.t in
       Async.try_with ~extract_exn:true (fun () ->
-          let tss = partition 10 ts in
-          Deferred.List.fold tss ~init:([], pending_coinbase_stack_state)
-            ~f:(fun (acc, pending_coinbase_stack_state) ts ->
+          Deferred.List.fold ts ~init:([], pending_coinbase_stack_state)
+            ~f:(fun (acc, pending_coinbase_stack_state) t ->
               let open Deferred.Let_syntax in
-              let%map () = Async.Scheduler.yield () in
-              List.fold ts ~init:(acc, pending_coinbase_stack_state)
-                ~f:(fun (acc, pending_coinbase_stack_state) t ->
-                  ( match
-                      List.find (Transaction.public_keys t.With_status.data)
-                        ~f:(fun pk ->
-                          Option.is_none
-                            (Signature_lib.Public_key.decompress pk) )
-                    with
-                  | None ->
-                      ()
-                  | Some pk ->
-                      raise (Exit (Invalid_public_key pk)) ) ;
-                  match
-                    apply_transaction_and_get_witness ~constraint_constants
-                      ledger pending_coinbase_stack_state t.With_status.data
-                      (Some t.status) current_state_view state_and_body_hash
-                  with
-                  | Ok (res, updated_pending_coinbase_stack_state) ->
-                      (res :: acc, updated_pending_coinbase_stack_state)
-                  | Error err ->
-                      raise (Exit err) ) ) )
+              ( match
+                  List.find (Transaction.public_keys t.With_status.data)
+                    ~f:(fun pk ->
+                      Option.is_none (Signature_lib.Public_key.decompress pk)
+                  )
+                with
+              | None ->
+                  ()
+              | Some pk ->
+                  raise (Exit (Invalid_public_key pk)) ) ;
+              match%map
+                apply_transaction_and_get_witness ~constraint_constants ledger
+                  pending_coinbase_stack_state t.With_status.data
+                  (Some t.status) current_state_view state_and_body_hash
+              with
+              | Ok (res, updated_pending_coinbase_stack_state) ->
+                  (res :: acc, updated_pending_coinbase_stack_state)
+              | Error err ->
+                  raise (Exit err) ) )
       |> Deferred.Result.map_error ~f:(function
            | Exit err ->
                err
@@ -671,7 +656,7 @@ module T = struct
 
   let time ~logger label f =
     let start = Core.Time.now () in
-    let%map x = f () in
+    let%map x = trace_recurring label f in
     [%log debug]
       ~metadata:
         [("time_elapsed", `Float Core.Time.(Span.to_ms @@ diff (now ()) start))]
@@ -865,14 +850,13 @@ module T = struct
             && List.length data
                > Scan_state.free_space t.scan_state - required + work_count
           then
-            Deferred.return
-              (Error
-                 (Staged_ledger_error.Insufficient_work
-                    (sprintf
-                       !"Insufficient number of transaction snark work (slots \
-                         occupying: %d)  required %d, got %d"
-                       slots required work_count)))
-          else Deferred.return (Ok ()) )
+            Deferred.Result.fail
+              (Staged_ledger_error.Insufficient_work
+                 (sprintf
+                    !"Insufficient number of transaction snark work (slots \
+                      occupying: %d)  required %d, got %d"
+                    slots required work_count))
+          else Deferred.Result.return () )
     in
     let%bind () = Deferred.return (check_zero_fee_excess t.scan_state data) in
     let%bind res_opt, scan_state' =
@@ -899,6 +883,7 @@ module T = struct
                   the scan_state $scan_state: $error" ) ;
           Deferred.return (to_staged_ledger_or_error r) )
     in
+    let%bind () = yield_result () in
     let%bind updated_pending_coinbase_collection' =
       time ~logger "update_pending_coinbase_collection" (fun () ->
           update_pending_coinbase_collection
@@ -907,9 +892,11 @@ module T = struct
             ~ledger_proof:res_opt
           |> Deferred.return )
     in
+    let%bind () = yield_result () in
     let%bind coinbase_amount =
-      coinbase_for_blockchain_snark coinbases |> Deferred.return
+      Deferred.return (coinbase_for_blockchain_snark coinbases)
     in
+    let%bind () = yield_result () in
     let%map () =
       time ~logger
         (sprintf "verify_scan_state_after_apply (skip=%b)" skip_verification)

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -1,4 +1,5 @@
 open Core_kernel
+open Async_kernel
 open Mina_base
 
 [%%versioned:
@@ -38,32 +39,21 @@ module Job_view : sig
   type t [@@deriving sexp, to_yojson]
 end
 
-module type Monad_with_Or_error_intf = sig
-  type 'a t
+module Make_statement_scanner (Verifier : sig
+  type t
 
-  include Monad.S with type 'a t := 'a t
-
-  module Or_error : sig
-    type nonrec 'a t = 'a Or_error.t t
-
-    include Monad.S with type 'a t := 'a t
-  end
-end
-
-module Make_statement_scanner
-    (M : Monad_with_Or_error_intf) (Verifier : sig
-        type t
-
-        val verify :
-             verifier:t
-          -> Ledger_proof_with_sok_message.t list
-          -> sexp_bool M.Or_error.t
-    end) : sig
+  val verify :
+       verifier:t
+    -> Ledger_proof_with_sok_message.t list
+    -> sexp_bool Deferred.Or_error.t
+end) : sig
   val scan_statement :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> t
     -> verifier:Verifier.t
-    -> (Transaction_snark.Statement.t, [`Empty | `Error of Error.t]) result M.t
+    -> ( Transaction_snark.Statement.t
+       , [`Empty | `Error of Error.t] )
+       Deferred.Result.t
 
   val check_invariants :
        t
@@ -74,7 +64,7 @@ module Make_statement_scanner
     -> ledger_hash_begin:Frozen_ledger_hash.t option
     -> next_available_token_begin:Token_id.t option
     -> next_available_token_end:Token_id.t
-    -> (unit, Error.t) result M.t
+    -> (unit, Error.t) Deferred.Result.t
 end
 
 (*All the transactions with undos*)

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -5,6 +5,7 @@ open Async
 open Mina_base
 open Mina_state
 open Blockchain_snark
+open O1trace
 
 type ledger_proof = Ledger_proof.Prod.t
 
@@ -458,55 +459,59 @@ let with_retry ~logger f =
   go 4
 
 let verify_blockchain_snarks {worker; logger} chains =
-  with_retry ~logger (fun () ->
-      let%bind {connection; _} =
-        let ivar = !worker in
-        match Ivar.peek ivar with
-        | Some worker ->
-            Deferred.return worker
-        | None ->
-            [%log debug] "Waiting for the verifier process to restart" ;
-            let%map worker = Ivar.read ivar in
-            [%log debug] "Verifier process has restarted; finished waiting" ;
-            worker
-      in
-      Deferred.any
-        [ ( after (Time.Span.of_min 3.)
-          >>| fun _ ->
-          Or_error.return
-          @@ `Stop (Error.of_string "verify_blockchain_snarks timeout") )
-        ; Worker.Connection.run connection
-            ~f:Worker.functions.verify_blockchains ~arg:chains
-          |> Deferred.Or_error.map ~f:(fun x -> `Continue x) ] )
+  trace_recurring "Verifier.verify_blockchain_snarks" (fun () ->
+      with_retry ~logger (fun () ->
+          let%bind {connection; _} =
+            let ivar = !worker in
+            match Ivar.peek ivar with
+            | Some worker ->
+                Deferred.return worker
+            | None ->
+                [%log debug] "Waiting for the verifier process to restart" ;
+                let%map worker = Ivar.read ivar in
+                [%log debug] "Verifier process has restarted; finished waiting" ;
+                worker
+          in
+          Deferred.any
+            [ ( after (Time.Span.of_min 3.)
+              >>| fun _ ->
+              Or_error.return
+              @@ `Stop (Error.of_string "verify_blockchain_snarks timeout") )
+            ; Worker.Connection.run connection
+                ~f:Worker.functions.verify_blockchains ~arg:chains
+              |> Deferred.Or_error.map ~f:(fun x -> `Continue x) ] ) )
 
 module Id = Unique_id.Int ()
 
 let verify_transaction_snarks {worker; logger} ts =
-  let id = Id.create () in
-  let n = List.length ts in
-  let metadata () =
-    ("id", `String (Id.to_string id))
-    :: ("n", `Int n)
-    :: Memory_stats.(jemalloc_memory_stats () @ ocaml_memory_stats ())
-  in
-  [%log trace] "verify $n transaction_snarks (before)" ~metadata:(metadata ()) ;
-  let res =
-    with_retry ~logger (fun () ->
-        let%bind {connection; _} = Ivar.read !worker in
-        Worker.Connection.run connection
-          ~f:Worker.functions.verify_transaction_snarks ~arg:ts
-        |> Deferred.Or_error.map ~f:(fun x -> `Continue x) )
-  in
-  upon res (fun x ->
+  trace_recurring "Verifier.verify_transaction_snarks" (fun () ->
+      let id = Id.create () in
+      let n = List.length ts in
+      let metadata () =
+        ("id", `String (Id.to_string id))
+        :: ("n", `Int n)
+        :: Memory_stats.(jemalloc_memory_stats () @ ocaml_memory_stats ())
+      in
+      [%log trace] "verify $n transaction_snarks (before)"
+        ~metadata:(metadata ()) ;
+      let%map res =
+        with_retry ~logger (fun () ->
+            let%bind {connection; _} = Ivar.read !worker in
+            Worker.Connection.run connection
+              ~f:Worker.functions.verify_transaction_snarks ~arg:ts
+            |> Deferred.Or_error.map ~f:(fun x -> `Continue x) )
+      in
       [%log trace] "verify $n transaction_snarks (after)!"
         ~metadata:
-          ( ("result", `String (Sexp.to_string ([%sexp_of: bool Or_error.t] x)))
-          :: metadata () ) ) ;
-  res
+          ( ( "result"
+            , `String (Sexp.to_string ([%sexp_of: bool Or_error.t] res)) )
+          :: metadata () ) ;
+      res )
 
 let verify_commands {worker; logger} ts =
-  with_retry ~logger (fun () ->
-      let%bind {connection; _} = Ivar.read !worker in
-      Worker.Connection.run connection ~f:Worker.functions.verify_commands
-        ~arg:ts
-      |> Deferred.Or_error.map ~f:(fun x -> `Continue x) )
+  trace_recurring "Verifier.verify_commands" (fun () ->
+      with_retry ~logger (fun () ->
+          let%bind {connection; _} = Ivar.read !worker in
+          Worker.Connection.run connection ~f:Worker.functions.verify_commands
+            ~arg:ts
+          |> Deferred.Or_error.map ~f:(fun x -> `Continue x) ) )


### PR DESCRIPTION
Some changes intended to address some of the async scheduler starvation issues that we believe are the root cause of the unresponsive daemon servers.

I recommend reviewing commit-by-commit, as the commits are broken up to represent the pieces of work that were done in this PR.