### PR TITLE
Make the GraphQL error retriable

### DIFF
--- a/src/lib/rosetta_lib/errors.ml
+++ b/src/lib/rosetta_lib/errors.ml
@@ -178,7 +178,7 @@ end = struct
     | `Json_parse _ ->
         false
     | `Graphql_mina_query _ ->
-        false
+        true
     | `Network_doesn't_exist _ ->
         false
     | `Chain_info_missing ->


### PR DESCRIPTION
This makes Rosetta not fail if the daemon (temporarily) times out