### PR TITLE
Rosetta, remove nonce from balance response

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -493,14 +493,14 @@ let router ~graphql_uri ~logger ~with_db (route : string list) body =
             body
         in
         let%bind req =
-            Errors.Lift.parse ~context:"Request"
-            @@ Account_balance_request.of_yojson body
-            |> Errors.Lift.wrap
-          in
-          let%map res =
-            Balance.Real.handle ~graphql_uri ~env:(Balance.Env.real ~db ~graphql_uri) req
-            |> Errors.Lift.wrap
-          in
-          Account_balance_response.to_yojson res)
+          Errors.Lift.parse ~context:"Request"
+          @@ Account_balance_request.of_yojson body
+          |> Errors.Lift.wrap
+        in
+        let%map res =
+          Balance.Real.handle ~graphql_uri ~env:(Balance.Env.real ~db ~graphql_uri) req
+          |> Errors.Lift.wrap
+        in
+        Account_balance_response.to_yojson res)
   | _ ->
       Deferred.Result.fail `Page_not_found


### PR DESCRIPTION
In Rosetta, the `account/balance` query was returning a nonce in the response metadata, which makes no sense for historical balance lookups, and probably not even for the current balance. That was the only metadata item, so make the metadata `null` (None in OCaml).

Other than the nonce, the results of GraphQL query made on every balance query were only used for current balances, so move the GraphQL call there, and don't call it for historical balances.

Tested by running `view:balance` from rosetta-cli, with and without a block height.
