### PR TITLE
lk86/fix-rosetta-builds-on-stable-pipeline

### DIFF
--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -97,7 +97,7 @@ let pipeline : DebianVersions.DebVersion -> Pipeline.Config.Type = \(debVersion 
         let rosettaSpec = DockerImage.ReleaseSpec::{
           deps=DebianVersions.dependsOnGitEnv,
           service="mina-rosetta",
-          extra_args="--build-arg MINA_BRANCH=\\\${BUILDKITE_BRANCH} --build-arg MINA_REPO=\\\${BUILDKITE_PULL_REQUEST_REPO}",
+          extra_args="--build-arg MINA_BRANCH=\\\${BUILDKITE_BRANCH}",
           deb_codename="${DebianVersions.lowerName debVersion}",
           step_key="rosetta-mainnet-${DebianVersions.lowerName debVersion}-docker-image"
         }

--- a/buildkite/src/Jobs/Release/MinaRosettaUbuntu.dhall
+++ b/buildkite/src/Jobs/Release/MinaRosettaUbuntu.dhall
@@ -39,7 +39,7 @@ Pipeline.build
         deps=dependsOn,
         service="mina-rosetta-ubuntu",
         deb_codename="stretch",
-        extra_args="--build-arg MINA_BRANCH=\\\${BUILDKITE_BRANCH} --build-arg MINA_REPO=\\\${BUILDKITE_PULL_REQUEST_REPO} --no-cache",
+        extra_args="--build-arg MINA_BRANCH=\\\${BUILDKITE_BRANCH}  --no-cache",
         step_key="mina-rosetta-ubuntu-docker-image"
       }
 

--- a/helm/cron_jobs/devnet2-dump-archive-cronjob.yaml
+++ b/helm/cron_jobs/devnet2-dump-archive-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             DATE="$(date +%F_%H%M)";
             FILENAME=devnet2-archive-dump-"$DATE".sql;
 
-            pg_dump --no-owner --create postgres://postgres:foobar@archive-3-postgresql:5432/archive > $FILENAME;
+            pg_dump --no-owner --create postgres://postgres:foobar@archive-1-postgresql:5432/archive > $FILENAME;
 
             tar -czvf $FILENAME.tar.gz $FILENAME;
 

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -82,12 +82,18 @@ leaderboard)
 esac
 
 
+if [ -z "${BUILDKITE_PULL_REQUEST_REPO}" ]; then
+  REPO="--build-arg MINA_REPO=https://github.com/MinaProtocol/mina"
+else
+  REPO="--build-arg MINA_REPO=${BUILDKITE_PULL_REQUEST_REPO}"
+fi
+
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build
 extra_build_args=$(echo $EXTRA | tr -d '"')
-if [ -z "$DOCKER_CONTEXT" ]; then
-  cat $DOCKERFILE_PATH | docker build $CACHE $NETWORK $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $extra_build_args -t gcr.io/o1labs-192920/$SERVICE:$VERSION -
+if [ -z "${DOCKER_CONTEXT}" ]; then
+  cat $DOCKERFILE_PATH | docker build $CACHE $NETWORK $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $REPO $extra_build_args -t gcr.io/o1labs-192920/$SERVICE:$VERSION -
 else
-  docker build $CACHE $NETWORK $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $extra_build_args $DOCKER_CONTEXT -t gcr.io/o1labs-192920/$SERVICE:$VERSION -f $DOCKERFILE_PATH
+  docker build $CACHE $NETWORK $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $extra_build_args $REPO $DOCKER_CONTEXT -t gcr.io/o1labs-192920/$SERVICE:$VERSION -f $DOCKERFILE_PATH
 fi
 
 tag-and-push() {

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -13,7 +13,7 @@ RED='\033[0;31m'
 VALID_SERVICES=('mina-archive', 'mina-daemon' 'mina-rosetta' 'mina-rosetta-ubuntu' 'mina-toolchain' 'bot' 'leaderboard')
 
 function usage() {
-  if [ -n "$1" ]; then
+  if [[ -n "$1" ]]; then
     echo -e "${RED}☞  $1${CLEAR}\n";
   fi
   echo "Usage: $0 [-s service-to-release] [-v service-version] [-n network]"
@@ -43,16 +43,16 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 esac; shift; done
 
 # Debug prints for visability
-echo 'service="'$SERVICE'" version="'$VERSION'" deb_version="'${DEB_VERSION}'" deb_release="'${DEB_RELEASE}' "deb_codename="'${DEB_CODENAME}'" '
-echo $EXTRA
+echo 'service="'${SERVICE}'" version="'${VERSION}'" deb_version="'${DEB_VERSION}'" deb_release="'${DEB_RELEASE}' "deb_codename="'${DEB_CODENAME}'" '
+echo ${EXTRA}
 
 # Verify Required Parameters are Present
-if [ -z "$SERVICE" ]; then usage "Service is not set!"; fi;
-if [ -z "$VERSION" ]; then usage "Version is not set!"; fi;
-if [ -z "$EXTRA" ]; then EXTRA=""; fi;
-if [ $(echo ${VALID_SERVICES[@]} | grep -o "$SERVICE" - | wc -w) -eq 0 ]; then usage "Invalid service!"; fi
+if [[ -z "$SERVICE" ]]; then usage "Service is not set!"; fi;
+if [[ -z "$VERSION" ]]; then usage "Version is not set!"; fi;
+if [[ -z "$EXTRA" ]]; then EXTRA=""; fi;
+if [[ $(echo ${VALID_SERVICES[@]} | grep -o "$SERVICE" - | wc -w) -eq 0 ]]; then usage "Invalid service!"; fi
 
-case $SERVICE in
+case "${SERVICE}" in
 mina-archive)
   DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-archive"
   DOCKER_CONTEXT="dockerfiles/"
@@ -82,15 +82,15 @@ leaderboard)
 esac
 
 
-if [ -z "${BUILDKITE_PULL_REQUEST_REPO}" ]; then
+if [[ -z "${BUILDKITE_PULL_REQUEST_REPO}" ]]; then
   REPO="--build-arg MINA_REPO=https://github.com/MinaProtocol/mina"
 else
   REPO="--build-arg MINA_REPO=${BUILDKITE_PULL_REQUEST_REPO}"
 fi
 
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build
-extra_build_args=$(echo $EXTRA | tr -d '"')
-if [ -z "${DOCKER_CONTEXT}" ]; then
+extra_build_args=$(echo ${EXTRA} | tr -d '"')
+if [[ -z "${DOCKER_CONTEXT}" ]]; then
   cat $DOCKERFILE_PATH | docker build $CACHE $NETWORK $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $REPO $extra_build_args -t gcr.io/o1labs-192920/$SERVICE:$VERSION -
 else
   docker build $CACHE $NETWORK $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $extra_build_args $REPO $DOCKER_CONTEXT -t gcr.io/o1labs-192920/$SERVICE:$VERSION -f $DOCKERFILE_PATH
@@ -101,7 +101,7 @@ tag-and-push() {
   docker push "$1"
 }
 
-if [ -z "$NOUPLOAD" ] || [ "$NOUPLOAD" -eq 0 ]; then
+if [[ -z "$NOUPLOAD" ]] || [[ "$NOUPLOAD" -eq 0 ]]; then
   tag-and-push "minaprotocol/$SERVICE:$VERSION"
   docker push "gcr.io/o1labs-192920/$SERVICE:$VERSION"
 fi


### PR DESCRIPTION
Handle repo specification automagically in release-docker.sh instead of manually passing it with every rosetta build
