### PR TITLE
[WIP] lk86/disable-transaction-isolation 

### DIFF
--- a/src/app/rosetta/init-db.sh
+++ b/src/app/rosetta/init-db.sh
@@ -24,7 +24,9 @@ pg_createcluster --start ${POSTGRES_VERSION} -d ${POSTGRES_DATA_DIR} main
 
 sudo -u postgres psql --command "CREATE USER ${POSTGRES_USERNAME} WITH SUPERUSER PASSWORD '${POSTGRES_USERNAME}';"
 sudo -u postgres createdb -O ${POSTGRES_USERNAME} ${POSTGRES_DBNAME}
-sudo -u postgres psql --command "ALTER DATABASE ${POSTGRES_DBNAME} SET DEFAULT_TRANSACTION_ISOLATION TO SERIALIZABLE;"
+# Disable this for now as it seems rosetta-cli check:data runs better without it.
+# Its useful for safety when multiple archive nodes write to the same DB but rosetta doesnt do that anyway
+# sudo -u postgres psql --command "ALTER DATABASE ${POSTGRES_DBNAME} SET DEFAULT_TRANSACTION_ISOLATION TO SERIALIZABLE;"
 
 DATE="$(date -Idate)_0000"
 curl "https://storage.googleapis.com/mina-archive-dumps/${MINA_NETWORK}-archive-dump-${DATE}.sql.tar.gz" -o o1labs-archive-dump.tar.gz


### PR DESCRIPTION
Update init-db.sh to remove transaction isolation policy in rosetta use-cases.

WIP until fully tested, but if it runs more reliably than before, also merge into rosetta-v1 branch

Initial testing does not indicate an improvement here, we may have to roll-back some of the rosetta graphql removal changes