### PR TITLE
Fixed min window density reference implementation off-by-one

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1310,7 +1310,7 @@ module Data = struct
           let sub_window_diff =
             UInt32.(
               to_int
-              @@ min (succ constants.sub_windows_per_window)
+              @@ min constants.sub_windows_per_window
               @@ Global_sub_window.sub next_global_sub_window
                    prev_global_sub_window)
           in


### PR DESCRIPTION
When the update_min_window_density_reference_implementation function, which is unit tested against the update_min_window_density, computes the sub_window_diff it accidentally takes the minimum of sub_windows_per_window + 1 and next_global_sub_window - prev_global_sub_window. However, it should just be sub_windows_per_window.

As defined here https://github.com/MinaProtocol/mina/blob/f9eee0d1a295cc20af4f2a9befab40b1beff2d4b/src/lib/consensus/proof_of_stake.ml#L1937  the length of sub_window_densities is sub_windows_per_windows so the diff should not be greater than this.

This off-by-one doesn't seem to cause any issues in the unit tests, but we should fix this for clarity and to avoid confusion.

Closes #9437
