### PR TITLE
fix: Rename CodaSDK -> MinaSDK

### DIFF
--- a/frontend/client_sdk/README.md
+++ b/frontend/client_sdk/README.md
@@ -1,9 +1,10 @@
-# Coda Client Javascript SDK
+# Mina Client Javascript SDK
 
-This is a NodeJS client SDK that allows you to sign transactions and strings using Coda's keypairs.
-The project contains Typescript and ReasonML typings but can be used from plain NodeJS as well. 
+This is a NodeJS client SDK that allows you to sign transactions and strings using Mina's keypairs.
+The project contains Typescript and ReasonML typings but can be used from plain NodeJS as well.
 
 # Install
+
 ```bash
 yarn add @o1labs/client-sdk
 # or with npm:
@@ -11,59 +12,69 @@ npm install --save @o1labs/client-sdk
 ```
 
 # Usage
+
 Typescript:
+
 ```typescript
-import * as CodaSDK from "@o1labs/client-sdk";
+import * as MinaSDK from "@o1labs/client-sdk";
 
-let keys = CodaSDK.genKeys();
-let signed = CodaSDK.signMessage("hello", keys);
-if (CodaSDK.verifyMessage(signed)) {
-    console.log("Message was verified successfully")
-};
+let keys = MinaSDK.genKeys();
+let signed = MinaSDK.signMessage("hello", keys);
+if (MinaSDK.verifyMessage(signed)) {
+  console.log("Message was verified successfully");
+}
 
-let signedPayment = CodaSDK.signPayment({
+let signedPayment = MinaSDK.signPayment(
+  {
     to: keys.publicKey,
     from: keys.publicKey,
     amount: 1,
     fee: 1,
-    nonce: 0
-  }, keys);
+    nonce: 0,
+  },
+  keys
+);
 ```
 
 NodeJS:
+
 ```javascript
-const CodaSDK = require("@o1labs/client-sdk");
+const MinaSDK = require("@o1labs/client-sdk");
 
-let keys = CodaSDK.genKeys();
-let signed = CodaSDK.signMessage("hello", keys);
-if (CodaSDK.verifyMessage(signed)) {
-    console.log("Message was verified successfully")
-};
+let keys = MinaSDK.genKeys();
+let signed = MinaSDK.signMessage("hello", keys);
+if (MinaSDK.verifyMessage(signed)) {
+  console.log("Message was verified successfully");
+}
 
-let signedPayment = CodaSDK.signPayment({
+let signedPayment = MinaSDK.signPayment(
+  {
     to: keys.publicKey,
     from: keys.publicKey,
     amount: 1,
     fee: 1,
-    nonce: 0
-  }, keys);
+    nonce: 0,
+  },
+  keys
+);
 ```
 
 ReasonML:
+
 - Install gentype: `yarn add -D gentype`
 - Install bs-platform: `yarn add -D bs-platform`
 - Build dependencies: `yarn bsb -make-world`
 
 ```reason
-module CodaSDK = O1labsClientSdk.CodaSDK;
+module MinaSDK = O1labsClientSdk.MinaSDK;
 
-let keys = CodaSDK.genKeys();
-let signed = CodaSDK.signMessage(. "hello", keys);
-if (CodaSDK.verifyMessage(. signed)) {
+let keys = MinaSDK.genKeys();
+let signed = MinaSDK.signMessage(. "hello", keys);
+if (MinaSDK.verifyMessage(. signed)) {
   Js.log("Message was verified successfully");
 };
 
-let signedPayment = CodaSDK.signPayment({
+let signedPayment = MinaSDK.signPayment({
     to_: keys.publicKey,
     from: keys.publicKey,
     amount: "1",
@@ -74,5 +85,6 @@ let signedPayment = CodaSDK.signPayment({
 ```
 
 # API Reference
-- [Main API](src/CodaSDK.d.ts)
+
+- [Main API](src/MinaSDK.d.ts)
 - [Other](src/SDKWrapper.d.ts)

--- a/frontend/client_sdk/package.json
+++ b/frontend/client_sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@o1labs/client-sdk",
   "description": "Node API for signing transactions for Mina Protocol",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "scripts": {
     "build": "bsb -make-world && tsc src/SDKWrapper.ts -d",
     "start": "bsb -make-world -w",

--- a/frontend/client_sdk/src/MinaSDK.d.ts
+++ b/frontend/client_sdk/src/MinaSDK.d.ts
@@ -1,5 +1,5 @@
-import { uint32 as $$uint32 } from './TSTypes';
-import { uint64 as $$uint64 } from './TSTypes';
+import type { uint32 as $$uint32 } from './TSTypes';
+import type { uint64 as $$uint64 } from './TSTypes';
 export declare type publicKey = string;
 export declare type privateKey = string;
 export declare type uint64 = $$uint64;

--- a/frontend/client_sdk/src/MinaSDK.re
+++ b/frontend/client_sdk/src/MinaSDK.re
@@ -50,18 +50,18 @@ type payment = {
   validUntil: option(uint32),
 };
 
-type codaSDK;
-[@bs.module "./client_sdk.bc.js"] external codaSDK: codaSDK = "minaSDK";
+type minaSDK;
+[@bs.module "./client_sdk.bc.js"] external minaSDK: minaSDK = "minaSDK";
 
-[@bs.send] external genKeys: (codaSDK, unit) => keypair = "genKeys";
+[@bs.send] external genKeys: (minaSDK, unit) => keypair = "genKeys";
 /**
   * Generates a public/private keypair
  */
 [@genType]
-let genKeys = () => genKeys(codaSDK, ());
+let genKeys = () => genKeys(minaSDK, ());
 
 [@bs.send]
-external publicKeyOfPrivateKey: (codaSDK, privateKey) => publicKey =
+external publicKeyOfPrivateKey: (minaSDK, privateKey) => publicKey =
   "publicKeyOfPrivateKey";
 /**
   * Derives the public key of the corresponding private key
@@ -71,9 +71,9 @@ external publicKeyOfPrivateKey: (codaSDK, privateKey) => publicKey =
  */
 [@genType]
 let derivePublicKey = (privateKey: privateKey) =>
-  publicKeyOfPrivateKey(codaSDK, privateKey);
+  publicKeyOfPrivateKey(minaSDK, privateKey);
 
-[@bs.send] external validKeypair: (codaSDK, keypair) => bool = "validKeypair";
+[@bs.send] external validKeypair: (minaSDK, keypair) => bool = "validKeypair";
 /**
   * Verifies if a keypair is valid by checking if the public key can be derived from
   * the private key and additionally checking if we can use the private key to
@@ -84,11 +84,11 @@ let derivePublicKey = (privateKey: privateKey) =>
   */
 [@genType]
 let verifyKeypair = (keypair: keypair) => {
-  validKeypair(codaSDK, keypair);
+  validKeypair(minaSDK, keypair);
 };
 
 [@bs.send]
-external signString: (codaSDK, privateKey, string) => signature = "signString";
+external signString: (minaSDK, privateKey, string) => signature = "signString";
 /**
   * Signs an arbitrary message
   *
@@ -100,12 +100,12 @@ external signString: (codaSDK, privateKey, string) => signature = "signString";
 let signMessage =
   (. message: string, key: keypair) => {
     publicKey: key.publicKey,
-    signature: signString(codaSDK, key.privateKey, message),
+    signature: signString(minaSDK, key.privateKey, message),
     payload: message,
   };
 
 [@bs.send]
-external verifyStringSignature: (codaSDK, signature, publicKey, string) => bool =
+external verifyStringSignature: (minaSDK, signature, publicKey, string) => bool =
   "verifyStringSignature";
 /**
   * Verifies that a signature matches a message.
@@ -118,7 +118,7 @@ external verifyStringSignature: (codaSDK, signature, publicKey, string) => bool 
 let verifyMessage =
   (. signedMessage: signed(string)) => {
     verifyStringSignature(
-      codaSDK,
+      minaSDK,
       signedMessage.signature,
       signedMessage.publicKey,
       signedMessage.payload,
@@ -200,7 +200,7 @@ type signed_stake_delegation_js = {
 };
 
 [@bs.send]
-external signPayment: (codaSDK, privateKey, payment_js) => signed_js =
+external signPayment: (minaSDK, privateKey, payment_js) => signed_js =
   "signPayment";
 /**
   * Signs a payment transaction using a private key.
@@ -236,7 +236,7 @@ let signPayment =
       },
       signature:
         signPayment(
-          codaSDK,
+          minaSDK,
           key.privateKey,
           {
             "common": {
@@ -258,7 +258,7 @@ let signPayment =
 
 [@bs.send]
 external signStakeDelegation:
-  (codaSDK, privateKey, stake_delegation_js) => signed_js =
+  (minaSDK, privateKey, stake_delegation_js) => signed_js =
   "signStakeDelegation";
 
 /**
@@ -297,7 +297,7 @@ let signStakeDelegation =
       },
       signature:
         signStakeDelegation(
-          codaSDK,
+          minaSDK,
           key.privateKey,
           {
             "common": {
@@ -317,7 +317,7 @@ let signStakeDelegation =
   };
 
 [@bs.send]
-external verifyPaymentSignature: (codaSDK, signed_payment_js) => bool =
+external verifyPaymentSignature: (minaSDK, signed_payment_js) => bool =
   "verifyPaymentSignature";
 
 /**
@@ -339,7 +339,7 @@ let verifyPaymentSignature = (signedPayment: signed(payment)) => {
     Js.String.make(value(~default=defaultValidUntil, payload.validUntil));
 
   verifyPaymentSignature(
-    codaSDK,
+    minaSDK,
     {
       "sender": signedPayment.publicKey,
       "signature": signedPayment.signature,
@@ -363,7 +363,7 @@ let verifyPaymentSignature = (signedPayment: signed(payment)) => {
 
 [@bs.send]
 external verifyStakeDelegationSignature:
-  (codaSDK, signed_stake_delegation_js) => bool =
+  (minaSDK, signed_stake_delegation_js) => bool =
   "verifyStakeDelegationSignature";
 
 /**
@@ -385,7 +385,7 @@ let verifyStakeDelegationSignature =
     Js.String.make(value(~default=defaultValidUntil, payload.validUntil));
 
   verifyStakeDelegationSignature(
-    codaSDK,
+    minaSDK,
     {
       "sender": signedStakeDelegation.publicKey,
       "signature": signedStakeDelegation.signature,
@@ -407,7 +407,7 @@ let verifyStakeDelegationSignature =
 };
 
 [@bs.send]
-external signedRosettaTransactionToSignedCommand: (codaSDK, string) => string =
+external signedRosettaTransactionToSignedCommand: (minaSDK, string) => string =
   "signedRosettaTransactionToSignedCommand";
 
 /**
@@ -420,11 +420,11 @@ external signedRosettaTransactionToSignedCommand: (codaSDK, string) => string =
   */
 [@genType]
 let signedRosettaTransactionToSignedCommand = (signedRosettaTxn: string) => {
-  signedRosettaTransactionToSignedCommand(codaSDK, signedRosettaTxn);
+  signedRosettaTransactionToSignedCommand(minaSDK, signedRosettaTxn);
 };
 
 [@bs.send]
-external rawPublicKeyOfPublicKey: (codaSDK, publicKey) => string =
+external rawPublicKeyOfPublicKey: (minaSDK, publicKey) => string =
   "rawPublicKeyOfPublicKey";
 
 /**
@@ -436,5 +436,5 @@ external rawPublicKeyOfPublicKey: (codaSDK, publicKey) => string =
   */
 [@genType]
 let publicKeyToRaw = (publicKey: string) => {
-  rawPublicKeyOfPublicKey(codaSDK, publicKey);
+  rawPublicKeyOfPublicKey(minaSDK, publicKey);
 };

--- a/frontend/client_sdk/src/SDKWrapper.d.ts
+++ b/frontend/client_sdk/src/SDKWrapper.d.ts
@@ -1,15 +1,15 @@
-import * as SDK from "./CodaSDK";
-export * from './CodaSDK';
+import * as SDK from "./MinaSDK";
+export * from "./MinaSDK";
 export declare type signable = SDK.payment | SDK.stakeDelegation | string;
 /**
-  * Signs an arbitrary signable payload using a private key.
-  *
-  * This is marked unsafe because it performs ad hoc checks on the
-  * passed-in payload to determine which signing strategy to use.
-  *
-  * @param payload - An signable object or string
-  * @param key - The keypair used to sign the transaction
-  * @returns A signed payload
+ * Signs an arbitrary signable payload using a private key.
+ *
+ * This is marked unsafe because it performs ad hoc checks on the
+ * passed-in payload to determine which signing strategy to use.
+ *
+ * @param payload - An signable object or string
+ * @param key - The keypair used to sign the transaction
+ * @returns A signed payload
  */
 export declare function unsafeSignAny(payload: string, key: SDK.keypair): SDK.signed<string>;
 export declare function unsafeSignAny(payload: SDK.payment, key: SDK.keypair): SDK.signed<SDK.payment>;

--- a/frontend/client_sdk/src/SDKWrapper.ts
+++ b/frontend/client_sdk/src/SDKWrapper.ts
@@ -1,36 +1,59 @@
-import * as SDK from "./CodaSDK";
-export * from './CodaSDK';
+import * as SDK from "./MinaSDK";
+export * from "./MinaSDK";
 
 export type signable = SDK.payment | SDK.stakeDelegation | string;
 
 function hasCommonProperties(p: signable) {
-  return p.hasOwnProperty("to") && p.hasOwnProperty("from") && p.hasOwnProperty("fee") && p.hasOwnProperty("nonce");
+  return (
+    p.hasOwnProperty("to") &&
+    p.hasOwnProperty("from") &&
+    p.hasOwnProperty("fee") &&
+    p.hasOwnProperty("nonce")
+  );
 }
 
-function isPayment(p: signable) : p is SDK.payment {
-  return hasCommonProperties(p) && p.hasOwnProperty('amount');
+function isPayment(p: signable): p is SDK.payment {
+  return hasCommonProperties(p) && p.hasOwnProperty("amount");
 }
 
 function isStakeDelegation(p: signable): p is SDK.stakeDelegation {
-    return hasCommonProperties(p) && !p.hasOwnProperty('amount');
+  return hasCommonProperties(p) && !p.hasOwnProperty("amount");
 }
 
 /**
-  * Signs an arbitrary signable payload using a private key.
-  *
-  * This is marked unsafe because it performs ad hoc checks on the
-  * passed-in payload to determine which signing strategy to use.
-  *
-  * @param payload - An signable object or string
-  * @param key - The keypair used to sign the transaction
-  * @returns A signed payload
+ * Signs an arbitrary signable payload using a private key.
+ *
+ * This is marked unsafe because it performs ad hoc checks on the
+ * passed-in payload to determine which signing strategy to use.
+ *
+ * @param payload - An signable object or string
+ * @param key - The keypair used to sign the transaction
+ * @returns A signed payload
  */
-export function unsafeSignAny(payload: string, key: SDK.keypair): SDK.signed<string>;
-export function unsafeSignAny(payload: SDK.payment, key: SDK.keypair): SDK.signed<SDK.payment>;
-export function unsafeSignAny(payload: SDK.stakeDelegation, key: SDK.keypair): SDK.signed<SDK.stakeDelegation>;
-export function unsafeSignAny<T>(payload: signable, key: SDK.keypair): SDK.signed<signable> {
-  if (typeof payload === 'string') { return SDK.signMessage(payload, key); }
-  if (isPayment(payload)) { return SDK.signPayment(payload, key); }
-  if (isStakeDelegation(payload)) { return SDK.signStakeDelegation(payload, key); }
+export function unsafeSignAny(
+  payload: string,
+  key: SDK.keypair
+): SDK.signed<string>;
+export function unsafeSignAny(
+  payload: SDK.payment,
+  key: SDK.keypair
+): SDK.signed<SDK.payment>;
+export function unsafeSignAny(
+  payload: SDK.stakeDelegation,
+  key: SDK.keypair
+): SDK.signed<SDK.stakeDelegation>;
+export function unsafeSignAny<T>(
+  payload: signable,
+  key: SDK.keypair
+): SDK.signed<signable> {
+  if (typeof payload === "string") {
+    return SDK.signMessage(payload, key);
+  }
+  if (isPayment(payload)) {
+    return SDK.signPayment(payload, key);
+  }
+  if (isStakeDelegation(payload)) {
+    return SDK.signStakeDelegation(payload, key);
+  }
   throw new Error(`Expected signable payload, got '${payload}'.`);
-};
+}

--- a/frontend/client_sdk/test/Test.ts
+++ b/frontend/client_sdk/test/Test.ts
@@ -1,31 +1,31 @@
-import * as CodaSDK from "../src/SDKWrapper";
+import * as MinaSDK from "../src/SDKWrapper";
 import { deepStrictEqual } from "assert";
 
-let key = CodaSDK.genKeys();
-let publicKey = CodaSDK.derivePublicKey(key.privateKey);
-let signed = CodaSDK.signMessage("hello", key);
-CodaSDK.verifyMessage(signed);
+let key = MinaSDK.genKeys();
+let publicKey = MinaSDK.derivePublicKey(key.privateKey);
+let signed = MinaSDK.signMessage("hello", key);
+MinaSDK.verifyMessage(signed);
 
 deepStrictEqual(publicKey, key.publicKey, "Public keys do not match");
 
 deepStrictEqual(
-  CodaSDK.verifyKeypair(key),
+  MinaSDK.verifyKeypair(key),
   true,
   "Generated keypair could not be verified"
 );
 
 deepStrictEqual(
-  typeof CodaSDK.publicKeyToRaw(key.publicKey),
+  typeof MinaSDK.publicKeyToRaw(key.publicKey),
   "string",
   "Conversion to valid raw public key failed"
 );
 
-let payment1 = CodaSDK.unsafeSignAny(
+let payment1 = MinaSDK.unsafeSignAny(
   { to: key.publicKey, from: key.publicKey, amount: "1", fee: "1", nonce: "0" },
   key
 );
 
-let payment2 = CodaSDK.signPayment(
+let payment2 = MinaSDK.signPayment(
   { to: key.publicKey, from: key.publicKey, amount: 1, fee: 1, nonce: 0 },
   key
 );
@@ -37,29 +37,29 @@ deepStrictEqual(
 );
 
 deepStrictEqual(
-  CodaSDK.verifyPaymentSignature(payment1),
+  MinaSDK.verifyPaymentSignature(payment1),
   true,
   "Unsafe signed payment could not be verified"
 );
 deepStrictEqual(
-  CodaSDK.verifyPaymentSignature(payment2),
+  MinaSDK.verifyPaymentSignature(payment2),
   true,
   "Signed payment could not be verified"
 );
 
-let invalidPayment = { ...payment2, publicKey: CodaSDK.genKeys().publicKey };
+let invalidPayment = { ...payment2, publicKey: MinaSDK.genKeys().publicKey };
 deepStrictEqual(
-  CodaSDK.verifyPaymentSignature(invalidPayment),
+  MinaSDK.verifyPaymentSignature(invalidPayment),
   false,
   "Invalid signed payment was verified"
 );
 
-let sd1 = CodaSDK.signStakeDelegation(
+let sd1 = MinaSDK.signStakeDelegation(
   { to: key.publicKey, from: key.publicKey, fee: "1", nonce: "0" },
   key
 );
 
-let sd2 = CodaSDK.signStakeDelegation(
+let sd2 = MinaSDK.signStakeDelegation(
   { to: key.publicKey, from: key.publicKey, fee: 1, nonce: 0 },
   key
 );
@@ -70,16 +70,16 @@ deepStrictEqual(
   "Stake delegation signatures don't match (string vs numeric inputs)"
 );
 
-CodaSDK.verifyStakeDelegationSignature(sd1);
+MinaSDK.verifyStakeDelegationSignature(sd1);
 deepStrictEqual(
-  CodaSDK.verifyStakeDelegationSignature(sd1),
+  MinaSDK.verifyStakeDelegationSignature(sd1),
   true,
   "Signed delegation could not be verified"
 );
 
-let invalidSd = { ...sd1, publicKey: CodaSDK.genKeys().publicKey };
+let invalidSd = { ...sd1, publicKey: MinaSDK.genKeys().publicKey };
 deepStrictEqual(
-  CodaSDK.verifyStakeDelegationSignature(invalidSd),
+  MinaSDK.verifyStakeDelegationSignature(invalidSd),
   false,
   "Invalid signed delegation was verified"
 );
@@ -105,7 +105,7 @@ const signedRosettaTnxMock = `
 `;
 
 const signedGraphQLCommand =
-  CodaSDK.signedRosettaTransactionToSignedCommand(signedRosettaTnxMock);
+  MinaSDK.signedRosettaTransactionToSignedCommand(signedRosettaTnxMock);
 const signedRosettaTnxMockJson = JSON.parse(signedRosettaTnxMock);
 const signedGraphQLCommandJson = JSON.parse(signedGraphQLCommand);
 


### PR DESCRIPTION
- Renamed all references of `CodaSDK` to `MinaSDK`. The new usage is reflected in `Test.ts`. 
- Bumped major version number
- Code formatting was additionally applied.

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)

Closes  #9468
