### PR TITLE
Fix client SDK build

### DIFF
--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -11,6 +11,7 @@ open Tick
 
 [%%else]
 
+open Snark_params_nonconsensus
 module Currency = Currency_nonconsensus.Currency
 module Mina_numbers = Mina_numbers_nonconsensus.Mina_numbers
 module Random_oracle = Random_oracle_nonconsensus.Random_oracle
@@ -175,6 +176,8 @@ module Token_symbol = struct
     Random_oracle_input.bitstrings
       [| Pickles_types.Vector.to_list (to_bits x) |]
 
+  [%%ifdef consensus_mechanism]
+
   type var = (Boolean.var, Num_bits.n) Pickles_types.Vector.t
 
   let var_of_value x =
@@ -190,6 +193,8 @@ module Token_symbol = struct
   let if_ (b : Boolean.var) ~(then_ : var) ~(else_ : var) : var =
     Pickles_types.Vector.map2 then_ else_ ~f:(fun then_ else_ ->
         Snark_params.Tick.Run.Boolean.if_ b ~then_ ~else_)
+
+  [%%endif]
 end
 
 module Poly = struct

--- a/src/lib/mina_base/snapp_account.ml
+++ b/src/lib/mina_base/snapp_account.ml
@@ -10,6 +10,7 @@ module Hash_prefix_states = Hash_prefix_states
 
 [%%else]
 
+open Snark_params_nonconsensus
 module Mina_numbers = Mina_numbers_nonconsensus.Mina_numbers
 module Currency = Currency_nonconsensus.Currency
 module Random_oracle = Random_oracle_nonconsensus.Random_oracle
@@ -24,17 +25,19 @@ module Events = struct
     (* Arbitrary hash input, encoding determined by the snapp's developer. *)
     type t = Field.t array
 
-    type var = Field.Var.t array
-
     let hash (x : t) = Random_oracle.hash ~init:Hash_prefix_states.snapp_event x
+
+    [%%ifdef consensus_mechanism]
+
+    type var = Field.Var.t array
 
     let hash_var (x : Field.Var.t array) =
       Random_oracle.Checked.hash ~init:Hash_prefix_states.snapp_event x
+
+    [%%endif]
   end
 
   type t = Event.t list
-
-  type var = t Data_as_hash.t
 
   let empty_hash = lazy Random_oracle.(salt "MinaSnappEventsEmpty" |> digest)
 
@@ -46,6 +49,10 @@ module Events = struct
   let hash (x : t) = List.fold ~init:(Lazy.force empty_hash) ~f:push_event x
 
   let to_input (x : t) = Random_oracle_input.field (hash x)
+
+  [%%ifdef consensus_mechanism]
+
+  type var = t Data_as_hash.t
 
   let var_to_input (x : var) = Data_as_hash.to_input x
 
@@ -88,6 +95,8 @@ module Events = struct
          [| Data_as_hash.hash events; Event.hash_var e |])
       (Data_as_hash.hash res) ;
     res
+
+  [%%endif]
 end
 
 module Rollup_events = struct
@@ -99,9 +108,13 @@ module Rollup_events = struct
 
   let push_events acc events = push_hash acc (Events.hash events)
 
+  [%%ifdef consensus_mechanism]
+
   let push_events_checked x (e : Events.var) =
     Random_oracle.Checked.hash ~init:Hash_prefix_states.snapp_rollup_events
       [| x; Data_as_hash.hash e |]
+
+  [%%endif]
 end
 
 module Poly = struct

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1061,7 +1061,7 @@ module T = struct
       (User_command.Valid.t list, _) result Deferred.Or_error.t =
     Result.all
       (List.map cs ~f:(function
-        | Snapp_command _ ->
+        | Parties _ ->
             Error
               (Verifier.Failure.Verification_failed
                  (Error.of_string "check_commands: snapp commands disabled"))

--- a/src/nonconsensus/mina_numbers/snapp_version.ml
+++ b/src/nonconsensus/mina_numbers/snapp_version.ml
@@ -1,0 +1,1 @@
+../../lib/mina_numbers/snapp_version.ml


### PR DESCRIPTION
After some of the code changes for Snapps, the client SDK was not building.

Fixed by moving some code inside `consensus_mechanism` blocks, opening `Snark_params_nonconsensus` where needed.