### PR TITLE
Implement bitswap block split/join

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_block.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_block.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+)
+
+const LINK_SIZE = 32
+
+type link = [LINK_SIZE]byte
+
+// Split data blob to a series of bitswap
+// blocks. Each resulting block follows
+// the byte format:
+//
+//  * [2 bytes] number of links n
+//  * [n * LINK_SIZE bytes] links (each link is a 256-bit hash)
+//  * [up to (maxBlockSize - 2 - LINK_SIZE * n) bytes] data
+//
+// Resulting bitswap block tree is balanced. Tree is
+// optimized for breadth-first search (BFS), in particular:
+//
+//  * Data blobs should be concatenated in BFS order
+//  * There exist such `M >= 0` such that for any result of the function
+//    first `M` blocks contain exactly `min(maxBlockSize / LINK_SIZE, 65535)` links
+//    per block, and all blocks from `M + 2` (in the BFS order)
+//    contain only data (no links)
+// All blocks except for last one (in BFS order) are exactly of `maxBlockSize` size.
+//
+// Returns a map of bitswap blocks, indexed by
+// hashes of respective blocks and the root block hash.
+func SplitData(maxBlockSize int, hashF func([]byte) link, data []byte) (map[link][]byte, link) {
+	if maxBlockSize <= 2+LINK_SIZE {
+		panic("Max block size too small")
+	}
+	// Maximum number of links that can fit in a single Bitswap block
+	linksPerBlock := (maxBlockSize - 2) / LINK_SIZE
+	if linksPerBlock > 65535 {
+		linksPerBlock = 65535
+	}
+	// `n` is the total number of bitswap blocks
+	//   formula for `n` is derived as follows
+	//   (for s_i the data part of bitswap block i,
+	//   l_i the number of links in the block i):
+	//      1. 2 + LINK_SIZE * l_i + s_i <= maxBlockSize
+	//      2. sum_i{1..n} ( 2 + LINK_SIZE * l_i + s_i ) <= n * maxBlockSize
+	//      3. sum_i{1..n} l_i = n - 1 (as each block is referenced by
+	//         a single link and root block is referenced by none)
+	//      4. sum_i{1..n} s_i = len(data) (sum of all data parts is
+	//         equal to the size of the data blob)
+	//      5. 2 * n + LINK_SIZE * (n - 1) + len(data) <= n * maxBlockSize
+	//         (following from 2., 3. and 4.)
+	//      6. n >= (len(data) - LINK_SIZE) / (maxBlockSize - LINK_SIZE - 2)
+	n := 1
+	if len(data) > maxBlockSize-2 {
+		n1 := len(data) - LINK_SIZE
+		n2 := maxBlockSize - LINK_SIZE - 2
+		n = n1 / n2
+		if n1%n2 > 0 {
+			n++
+		}
+	}
+	// calculate size of the data chunk in the last block
+	//   note that by definition last block contains no links
+	//   to calculate last block data chunk size, we subtract
+	//   amount of data fit in first (n - 1) blocks from total
+	//   length of data
+
+	lastBlockDataSz := len(data) - (maxBlockSize-LINK_SIZE-2)*(n-1)
+
+	res := make(map[link][]byte)
+	queue := make([]link, 0, n)
+	addBlock := func(links []link, chunk []byte) {
+		l := len(links)
+		sz := l*LINK_SIZE + 2 + len(chunk)
+		if l > 65535 || sz > maxBlockSize {
+			panic("DataToBlocks: invalid block produced")
+		}
+		block := make([]byte, sz)
+		block[0] = byte(l >> 8)
+		block[1] = byte(l & 0xFF)
+		for i_ := range links {
+			// We iterate links in reverse order as they were
+			// taken out of queue which has the order reversed
+			i := len(links) - i_ - 1
+			copy(block[2+LINK_SIZE*i:], links[i][:])
+		}
+		copy(block[2+l*LINK_SIZE:], chunk)
+		blockLink := hashF(block)
+		res[blockLink] = block
+		queue = append(queue, blockLink)
+	}
+
+	// end of data not yet allocated to some block
+	dataEnd := len(data) - lastBlockDataSz
+	addBlock([]link{}, data[dataEnd:])
+
+	if n > 1 {
+		// number of bitswap blocks containing exactly
+		// `linksPerBlock` links
+		fullLinkBlocks := (n - 1) / linksPerBlock
+		// number of bitswap blocks containing exactly
+		// `maxBlockSize - 2` bytes of data
+		dataBlocks := n - fullLinkBlocks - 1
+		lRem := (n - 1) % linksPerBlock
+		if lRem > 0 {
+			dataBlocks--
+		}
+		// Amount of data fitting into data-only block
+		dataBlockSz := maxBlockSize - 2
+		// Adding data-only blocks
+		for i := 0; i < dataBlocks; i++ {
+			addBlock([]link{}, data[dataEnd-dataBlockSz:dataEnd])
+			dataEnd = dataEnd - dataBlockSz
+		}
+		if lRem > 0 {
+			// Adding a single block with some links that
+			// contains less than `linksPerBlock` links
+			dsz := maxBlockSize - 2 - lRem*LINK_SIZE
+			addBlock(queue[:lRem], data[dataEnd-dsz:dataEnd])
+			queue = queue[lRem:]
+			dataEnd = dataEnd - dsz
+		}
+		dsz := maxBlockSize - 2 - linksPerBlock*LINK_SIZE
+		for i := 0; i < fullLinkBlocks; i++ {
+			addBlock(queue[:linksPerBlock], data[dataEnd-dsz:dataEnd])
+			queue = queue[linksPerBlock:]
+			dataEnd = dataEnd - dsz
+		}
+	}
+	return res, queue[0]
+}
+
+// Parses block
+func ReadBlock(block []byte) ([]link, []byte, error) {
+	if len(block) >= 2 {
+		l := (int(block[0]) << 8) | int(block[1])
+		prefix := LINK_SIZE*l + 2
+		if len(block) >= prefix {
+			links := make([]link, l)
+			for i := 0; i < l; i++ {
+				// Copy relies on fixed size of link
+				copy(links[i][:], block[2+i*LINK_SIZE:])
+			}
+			return links, block[prefix:], nil
+		}
+	}
+	return nil, nil, errors.New("Block is too short")
+}
+
+func JoinData(blocks map[link][]byte, root link) ([]byte, error) {
+	queue := make([]link, 0, len(blocks))
+	queue = append(queue, root)
+	res := make([][]byte, 0, len(blocks))
+	for {
+		block, has := blocks[queue[0]]
+		if !has {
+			return nil, errors.New("Didn't find a block")
+		}
+		links, data, err := ReadBlock(block)
+		if err != nil {
+			return nil, err
+		}
+		queue = append(queue[1:], links...)
+		res = append(res, data)
+
+		if len(queue) == 0 {
+			break
+		}
+	}
+	return bytes.Join(res, []byte{}), nil
+}

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_block_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_block_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"github.com/stretchr/testify/require"
+	"hash/fnv"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+)
+
+const BAD_HASH_SEED_1 uint64 = 6854716328964733685
+const BAD_HASH_SEED_2 uint64 = 7260501629894841770
+const BAD_HASH_SEED_3 uint64 = 5145406058976553587
+const BAD_HASH_SEED_4 uint64 = 14640219404054247361
+
+// non-cryptographic collission-irresistant hash
+// with 32-byte output
+func badHash(data []byte) [32]byte {
+	h := fnv.New64a()
+	h.Write(data)
+	s := h.Sum64()
+	s1 := s ^ BAD_HASH_SEED_1
+	s2 := s ^ BAD_HASH_SEED_2
+	s3 := s ^ BAD_HASH_SEED_3
+	s4 := s ^ BAD_HASH_SEED_4
+	return [32]byte{
+		byte(0xff & s1),
+		byte(0xff & (s1 >> 8)),
+		byte(0xff & (s1 >> 16)),
+		byte(0xff & (s1 >> 24)),
+		byte(0xff & (s1 >> 32)),
+		byte(0xff & (s1 >> 40)),
+		byte(0xff & (s1 >> 48)),
+		byte(0xff & (s1 >> 56)),
+		byte(0xff & s2),
+		byte(0xff & (s2 >> 8)),
+		byte(0xff & (s2 >> 16)),
+		byte(0xff & (s2 >> 24)),
+		byte(0xff & (s2 >> 32)),
+		byte(0xff & (s2 >> 40)),
+		byte(0xff & (s2 >> 48)),
+		byte(0xff & (s2 >> 56)),
+		byte(0xff & s3),
+		byte(0xff & (s3 >> 8)),
+		byte(0xff & (s3 >> 16)),
+		byte(0xff & (s3 >> 24)),
+		byte(0xff & (s3 >> 32)),
+		byte(0xff & (s3 >> 40)),
+		byte(0xff & (s3 >> 48)),
+		byte(0xff & (s3 >> 56)),
+		byte(0xff & s4),
+		byte(0xff & (s4 >> 8)),
+		byte(0xff & (s4 >> 16)),
+		byte(0xff & (s4 >> 24)),
+		byte(0xff & (s4 >> 32)),
+		byte(0xff & (s4 >> 40)),
+		byte(0xff & (s4 >> 48)),
+		byte(0xff & (s4 >> 56)),
+	}
+}
+
+func testSplitJoin(maxBlockSize int, data []byte) error {
+	blocks, root := SplitData(maxBlockSize, badHash, data)
+	res, err := JoinData(blocks, root)
+	if err != nil {
+		return err
+	}
+	if bytes.Compare(res, data) != 0 {
+		return errors.New("Unexpected result of join")
+	}
+	n := 0
+	for _, block := range blocks {
+		if len(block) == maxBlockSize {
+			n++
+		}
+	}
+	if n < len(blocks)-1 {
+		return errors.New("More than one block of non-max size")
+	}
+	return nil
+}
+
+const louis = "I see trees of green, red roses too\nI see them bloom for me and you\nAnd I think to myself\nWhat a wonderful world\n\nI see skies of blue and clouds of white\nThe bright blessed days, the dark sacred nights\nAnd I think to myself\nWhat a wonderful world"
+
+func TestBitswapBlockSplitJoin(t *testing.T) {
+	require.NoError(t, testSplitJoin(40, []byte("Hello world!")))
+	require.NoError(t, testSplitJoin(40, []byte(louis)))
+	var data [65536 * 2 * 32]byte
+	chunk := badHash([]byte(louis))
+	copy(data[:], chunk[:])
+	for i := 1; i < len(data)<<5; i++ {
+		chunk = badHash(data[(i-1)>>5 : i>>5])
+		copy(data[i>>5:], chunk[:])
+	}
+	require.NoError(t, testSplitJoin(64, data[:93]))
+	for i := 35; i <= 128; i++ {
+		for j := 1; j <= 1000; j++ {
+			t.Logf("i=%d j=%d", i, j)
+			err := testSplitJoin(i, data[:j])
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	}
+	require.NoError(t, testSplitJoin(65534*32, data[:]))
+	require.NoError(t, testSplitJoin(65535*32, data[:]))
+	require.NoError(t, testSplitJoin(65536*32, data[:]))
+	for i := 65533; i <= 65540; i++ {
+		for j := 65533; j <= 65540; j++ {
+			require.NoError(t, testSplitJoin(i*32, data[:j*32]))
+		}
+	}
+	require.NoError(t, testSplitJoin(65536*64, data[:]))
+	require.NoError(t, testSplitJoin(100000*32, data[:]))
+}
+
+type blockSplitJoinConfig struct {
+	maxBlockSize int
+	data         []byte
+}
+
+func (blockSplitJoinConfig) Generate(r *rand.Rand, size int) reflect.Value {
+	data := make([]byte, size)
+	_, _ = r.Read(data)
+	return reflect.ValueOf(blockSplitJoinConfig{r.Intn(1 << 24), data})
+}
+
+func TestBitswapBlockSplitJoinQC(t *testing.T) {
+	f := func(c blockSplitJoinConfig) bool {
+		err := testSplitJoin(c.maxBlockSize, c.data)
+		return err == nil
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
Bitswap blocks are chunks of arbitrary binary data which are content addressed by [IPFS CIDs](https://docs.ipfs.io/concepts/content-addressing/#cid-conversion). There is no pre-defined maximum size of each Bitswap block, but IPFS uses 256kb, and the maximum recommended size of a Bitswap block is 1mb. Realistically, we want Bitswap blocks to be as small as possible, so we should start at 256kb for our maximum size, but keep the size of Bitswap blocks as a parameter we can tune so that we can optimize for block size vs block count.

While the Bitswap specification does not care about what data is stored in each block, we do require each block have a commonly-defined format:

 1. `[2 bytes]` count of links n
 2. `[n * 32 bytes]` links (each link is a 256-bit hash)
 3. `[up to (maxBlockSize - 2 - 32 * n) bytes]` data

Hence, data blob is converted to a tree of blocks. We advertise the "root" block of the tree as the initial block to download for each resource we store in Bitswap, and the libp2p helper process will automatically explore all the child blocks referenced throughout the tree. To construct the full binary blob out of this tree, breadth-first search (BFS) algorithm should be utilized to traverse the tree. BFS is a more favourable approach to DFS (another traversal order) as it allows to lazily load the blob by each time following nodes links to which we already have from the root block (counter to the order induced by DFS where one has to go to the deepest level before emitting a chunk of data).

For links a 256-bit version of Blake2b hash is to be used. Packing algorithm can be implemented in the way that no padding is used in blocks and there are maximum `n = (blobSize - 32) / (maxBlockSize - 34)` blocks generated with `n - 1` blocks of exactly `maxBlockSize` bytes.

Implementation of split and join algorithms is tested by a roundtrip unit test.

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? Partly addresses #9452
