### PR TITLE
Use rust implementation of poseidon

### DIFF
--- a/src/app/rosetta/README.md
+++ b/src/app/rosetta/README.md
@@ -50,7 +50,7 @@ Implementation of the [Rosetta API](https://www.rosetta-api.org/) for Mina.
 
 ## How to build your own docker image
 
-Checkout the "rosetta-v1" branch of the mina repository, ensure your Docker configuration has a large amount of RAM (2GB is too small, 8GB seems is enough) and then run the following:
+Checkout the "rosetta-v1" branch of the mina repository, ensure your Docker configuration has a large amount of RAM (at least 12GB, recommended 16GB) and then run the following:
 
 `cat dockerfiles/stages/1-build-deps dockerfiles/stages/2-toolchain dockerfiles/stages/3-opam-deps dockerfiles/stages/4-builder dockerfiles/stages/5-prod-ubuntu | docker build -t mina-rosetta:v1 --build-arg "deb_codename=stretch" --build-arg "MINA_BRANCH=rosetta-v1" -`
 

--- a/src/app/rosetta/README.md
+++ b/src/app/rosetta/README.md
@@ -4,9 +4,13 @@ Implementation of the [Rosetta API](https://www.rosetta-api.org/) for Mina.
 
 ## Changelog
 
+2021/09/12:
+
+- Construction API ready to ship on rosetta-v2
+
 2021/09/02:
 
-- Build off of the rosetta-v1 branch so that compatible does not break in parrallel to this document
+- Build off of the rosetta-v2 branch so that compatible does not break in parrallel to this document
 - All docker build instructions and docker image references have been updated accordingly
 
 2021/08/31:
@@ -50,12 +54,12 @@ Implementation of the [Rosetta API](https://www.rosetta-api.org/) for Mina.
 
 ## How to build your own docker image
 
-Checkout the "rosetta-v1" branch of the mina repository, ensure your Docker configuration has a large amount of RAM (at least 12GB, recommended 16GB) and then run the following:
+Checkout the "rosetta-v2" branch of the mina repository, ensure your Docker configuration has a large amount of RAM (at least 12GB, recommended 16GB) and then run the following:
 
-`cat dockerfiles/stages/1-build-deps dockerfiles/stages/2-toolchain dockerfiles/stages/3-opam-deps dockerfiles/stages/4-builder dockerfiles/stages/5-prod-ubuntu | docker build -t mina-rosetta:v1 --build-arg "deb_codename=stretch" --build-arg "MINA_BRANCH=rosetta-v1" -`
+`cat dockerfiles/stages/1-build-deps dockerfiles/stages/2-toolchain dockerfiles/stages/3-opam-deps dockerfiles/stages/4-builder dockerfiles/stages/5-prod-ubuntu | docker build -t mina-rosetta:v2 --build-arg "deb_codename=stretch" --build-arg "MINA_BRANCH=rosetta-v2" -`
 
-This creates an image (mina-rosetta:v1) based on the most up-to-date changes that support rosetta. This image
-can be used as a drop-in replacement for `gcr.io/o1labs-192920/mina-rosetta:v1` in any of the below commands for testing.
+This creates an image (mina-rosetta:v2) based on the most up-to-date changes that support rosetta. This image
+can be used as a drop-in replacement for `gcr.io/o1labs-192920/mina-rosetta:v2` in any of the below commands for testing.
 
 ## How to Run
 
@@ -63,13 +67,13 @@ The container includes 4 scripts in /rosetta which run a different set of servic
 - `docker-standalone-start.sh` is the most straightforward, it starts only the mina-rosetta API endpoint and any flags passed into the script go to mina-rosetta. Use this for the "offline" part of the Construction API.
 - `docker-demo-start.sh` launches a mina node with a very simple 1-address genesis ledger as a sandbox for developing and playing around in. This script starts the full suite of tools (a mina node, mina-archive, a postgresql DB, and mina-rosetta), but for a demo network with all operations occuring inside this container and no external network activity.
 - `docker-test-start.sh` launches the same demo network as in demo-start.sh but also launches the mina-rosetta-test-agent to run a suite of tests against the rosetta API.
-- The default, `docker-start.sh`, which connects the mina node to our [Mainnet](https://docs.minaprotocol.com/en/using-mina/connecting) network and initializes the archive database from publicly-availible nightly O(1) Labs backups. As with `docker-demo-start.sh`, this script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. The script also periodically checks for blocks that may be missing between the nightly backup and the tip of the chain and will fill in those gaps by walking back the linked list of blocks in the canonical chain and importing them one at a time. Take a look at the [source](https://github.com/MinaProtocol/mina/blob/rosetta-v1/src/app/rosetta/docker-start.sh) for more information about what you can configure and how.
+- The default, `docker-start.sh`, which connects the mina node to our [Mainnet](https://docs.minaprotocol.com/en/using-mina/connecting) network and initializes the archive database from publicly-availible nightly O(1) Labs backups. As with `docker-demo-start.sh`, this script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. The script also periodically checks for blocks that may be missing between the nightly backup and the tip of the chain and will fill in those gaps by walking back the linked list of blocks in the canonical chain and importing them one at a time. Take a look at the [source](https://github.com/MinaProtocol/mina/blob/rosetta-v2/src/app/rosetta/docker-start.sh) for more information about what you can configure and how.
 - Finally, the previous default, `docker-devnet-start.sh`, which connects the mina node to our [Devnet](https://docs.minaprotocol.com/en/advanced/connecting-devnet) network with the archive database initalized in a similar way to docker-start.sh. As with `docker-demo-start.sh`, this script runs a mina node, mina-archive, a postgresql DB, and mina-rosetta. `docker-devnet-start.sh` is now just a special case of `docker-start.sh` so inspect the source there for more detailed configuration.
 
 For example, to run the `docker-devnet-start.sh` and connect to the live devnet:
 
 ```
-docker run -it --rm --name rosetta --entrypoint=./docker-devnet-start.sh -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 gcr.io/o1labs-192920/mina-rosetta:v1
+docker run -it --rm --name rosetta --entrypoint=./docker-devnet-start.sh -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 gcr.io/o1labs-192920/mina-rosetta:v2
 ```
 
 Note: It will take 20min-1hr for your node to sync
@@ -167,13 +171,13 @@ The Construction API is _not_ validated using `rosetta-cli` as this would requir
 
 ### Reproduce agent and rosetta-cli validation
 
-`gcr.io/o1labs-192920/mina-rosetta:v1` and `rosetta-cli @ v0.5.12`
+`gcr.io/o1labs-192920/mina-rosetta:v2` and `rosetta-cli @ v0.5.12`
 using this [`rosetta.conf`](https://github.com/MinaProtocol/mina/blob/2b43c8cccfb9eb480122d207c5a3e6e58c4bbba3/src/app/rosetta/rosetta.conf) and the [`bootstrap_balances.json`](https://github.com/MinaProtocol/mina/blob/2b43c8cccfb9eb480122d207c5a3e6e58c4bbba3/src/app/rosetta/bootstrap_balances.json) next to it.
 
 **Create one of each transaction type using the test-agent and exit**
 
 ```
-$ docker run --rm --publish 3087:3087 --publish 3086:3086 --publish 3085:3085 --name mina-rosetta-test --entrypoint ./docker-test-start.sh -d gcr.io/o1labs-192920/mina-rosetta:v1
+$ docker run --rm --publish 3087:3087 --publish 3086:3086 --publish 3085:3085 --name mina-rosetta-test --entrypoint ./docker-test-start.sh -d gcr.io/o1labs-192920/mina-rosetta:v2
 
 $ docker logs --follow mina-rosetta-test
 ```
@@ -181,7 +185,7 @@ $ docker logs --follow mina-rosetta-test
 **Run a fast sandbox network forever and test with rosetta-cli**
 
 ```
-$ docker run --rm --publish 3087:3087 --publish 3086:3086 --publish 3085:3085 --name mina-rosetta-demo --entrypoint ./docker-demo-start.sh -d gcr.io/o1labs-192920/mina-rosetta:v1
+$ docker run --rm --publish 3087:3087 --publish 3086:3086 --publish 3085:3085 --name mina-rosetta-demo --entrypoint ./docker-demo-start.sh -d gcr.io/o1labs-192920/mina-rosetta:v2
 
 $ docker logs --follow mina-rosetta-demo
 

--- a/src/lib/marlin_plonk_bindings/dune
+++ b/src/lib/marlin_plonk_bindings/dune
@@ -31,6 +31,9 @@
    marlin_plonk_bindings_pasta_fq_proof
    ;; Oracles
    marlin_plonk_bindings_pasta_fp_oracles
-   marlin_plonk_bindings_pasta_fq_oracles)
+   marlin_plonk_bindings_pasta_fq_oracles
+   ;; Poseidon
+   marlin_plonk_bindings_pasta_fp_poseidon
+   marlin_plonk_bindings_pasta_fq_poseidon )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version)))

--- a/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
+++ b/src/lib/marlin_plonk_bindings/marlin_plonk_bindings.ml
@@ -41,3 +41,7 @@ module Pasta_fq_proof = Marlin_plonk_bindings_pasta_fq_proof
 (* Oracles *)
 module Pasta_fp_oracles = Marlin_plonk_bindings_pasta_fp_oracles
 module Pasta_fq_oracles = Marlin_plonk_bindings_pasta_fq_oracles
+
+(* Poseidon *)
+module Pasta_fp_poseidon = Marlin_plonk_bindings_pasta_fp_poseidon
+module Pasta_fq_poseidon = Marlin_plonk_bindings_pasta_fq_poseidon

--- a/src/lib/marlin_plonk_bindings/pasta_fp_poseidon/dune
+++ b/src/lib/marlin_plonk_bindings/pasta_fp_poseidon/dune
@@ -1,0 +1,10 @@
+(library
+ (public_name marlin_plonk_bindings.pasta_fp_poseidon)
+ (name marlin_plonk_bindings_pasta_fp_poseidon)
+ (libraries
+   marlin_plonk_bindings_stubs
+   marlin_plonk_bindings_types
+   marlin_plonk_bindings_pasta_fp_vector)
+ (instrumentation (backend bisect_ppx))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/pasta_fp_poseidon/marlin_plonk_bindings_pasta_fp_poseidon.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fp_poseidon/marlin_plonk_bindings_pasta_fp_poseidon.ml
@@ -1,0 +1,6 @@
+type t
+
+external create : unit -> t = "caml_pasta_fp_poseidon_params_create"
+
+external block_cipher : t -> Marlin_plonk_bindings_pasta_fp_vector.t -> unit
+  = "caml_pasta_fp_poseidon_block_cipher"

--- a/src/lib/marlin_plonk_bindings/pasta_fq_poseidon/dune
+++ b/src/lib/marlin_plonk_bindings/pasta_fq_poseidon/dune
@@ -1,0 +1,10 @@
+(library
+ (public_name marlin_plonk_bindings.pasta_fq_poseidon)
+ (name marlin_plonk_bindings_pasta_fq_poseidon)
+ (libraries
+   marlin_plonk_bindings_stubs
+   marlin_plonk_bindings_types
+   marlin_plonk_bindings_pasta_fq_vector)
+ (instrumentation (backend bisect_ppx))
+ (inline_tests)
+ (preprocess (pps ppx_version ppx_inline_test)))

--- a/src/lib/marlin_plonk_bindings/pasta_fq_poseidon/marlin_plonk_bindings_pasta_fq_poseidon.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fq_poseidon/marlin_plonk_bindings_pasta_fq_poseidon.ml
@@ -1,0 +1,6 @@
+type t
+
+external create : unit -> t = "caml_pasta_fq_poseidon_params_create"
+
+external block_cipher : t -> Marlin_plonk_bindings_pasta_fq_vector.t -> unit
+  = "caml_pasta_fq_poseidon_block_cipher"

--- a/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/lib.rs
@@ -32,3 +32,6 @@ pub mod pasta_fq_plonk_proof;
 /* Oracles */
 pub mod pasta_fp_plonk_oracles;
 pub mod pasta_fq_plonk_oracles;
+/* Poseidon */
+pub mod pasta_fp_poseidon;
+pub mod pasta_fq_poseidon;

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_poseidon.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_poseidon.rs
@@ -1,0 +1,36 @@
+use mina_curves::pasta::{
+    fp::Fp,
+};
+use oracle::poseidon::{
+    poseidon_block_cipher,
+    PlonkSpongeConstants,
+    ArithmeticSpongeParams};
+use crate::pasta_fp_vector::CamlPastaFpVector;
+
+pub struct CamlPastaFpPoseidonParams(ArithmeticSpongeParams<Fp>);
+pub type CamlPastaFpPoseidonParamsPtr<'a> = ocaml::Pointer<'a, CamlPastaFpPoseidonParams>;
+
+extern "C" fn caml_pasta_fp_poseidon_params_finalize(v: ocaml::Raw) {
+    unsafe {
+        let v: CamlPastaFpPoseidonParamsPtr = v.as_pointer();
+        v.drop_in_place()
+    };
+}
+
+ocaml::custom!(CamlPastaFpPoseidonParams {
+    finalize: caml_pasta_fp_poseidon_params_finalize,
+});
+
+#[ocaml::func]
+pub fn caml_pasta_fp_poseidon_params_create() -> CamlPastaFpPoseidonParams {
+    CamlPastaFpPoseidonParams(oracle::pasta::fp::params())
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fp_poseidon_block_cipher(
+    params: CamlPastaFpPoseidonParamsPtr,
+    mut state: CamlPastaFpVector) {
+    poseidon_block_cipher::<Fp, PlonkSpongeConstants>(
+        & params.as_ref().0,
+        state.as_mut())
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_poseidon.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_poseidon.rs
@@ -1,0 +1,36 @@
+use mina_curves::pasta::{
+    fq::Fq,
+};
+use oracle::poseidon::{
+    poseidon_block_cipher,
+    PlonkSpongeConstants,
+    ArithmeticSpongeParams};
+use crate::pasta_fq_vector::CamlPastaFqVector;
+
+pub struct CamlPastaFqPoseidonParams(ArithmeticSpongeParams<Fq>);
+pub type CamlPastaFqPoseidonParamsPtr<'a> = ocaml::Pointer<'a, CamlPastaFqPoseidonParams>;
+
+extern "C" fn caml_pasta_fq_poseidon_params_finalize(v: ocaml::Raw) {
+    unsafe {
+        let v: CamlPastaFqPoseidonParamsPtr = v.as_pointer();
+        v.drop_in_place()
+    };
+}
+
+ocaml::custom!(CamlPastaFqPoseidonParams {
+    finalize: caml_pasta_fq_poseidon_params_finalize,
+});
+
+#[ocaml::func]
+pub fn caml_pasta_fq_poseidon_params_create() -> CamlPastaFqPoseidonParams {
+    CamlPastaFqPoseidonParams(oracle::pasta::fq::params())
+}
+
+#[ocaml::func]
+pub fn caml_pasta_fq_poseidon_block_cipher(
+    params: CamlPastaFqPoseidonParamsPtr,
+    mut state: CamlPastaFqVector) {
+    poseidon_block_cipher::<Fq, PlonkSpongeConstants>(
+        & params.as_ref().0,
+        state.as_mut())
+}


### PR DESCRIPTION
This PR switches us to using a rust implementation of poseidon. It's about 60% faster than the OCaml implementation:

```
rust: 49.591us
ocaml: 120.401us
rust: 49.829us
ocaml: 118.494us
rust: 50.783us
ocaml: 117.779us
```

We already had the implementation, just had to expose it and call it from OCaml. Copying the array input back and forth from a vector actually takes quite a bit of time, so there's some room for optimizing that away by operating on the OCaml array directly.