### PR TITLE
Explicit fields for GraphQL Snapp txns

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -810,8 +810,1508 @@
         },
         {
           "kind": "SCALAR",
+          "name": "StateHash",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappStateHashOrIgnore",
+          "description": null,
+          "fields": [
+            {
+              "name": "state_hash",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "StateHash",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "state_hash",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "StateHash",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "EpochSeedOrIgnore",
+          "description": null,
+          "fields": [
+            {
+              "name": "epoch_seed",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "EpochSeed",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "epoch_seed",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "EpochSeed",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "EpochLedger",
+          "description": null,
+          "fields": [
+            {
+              "name": "totalCurrency",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CurrencyAmountNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hash",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnarkedLedgerHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "totalCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CurrencyAmountNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "hash",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnarkedLedgerHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "EpochData",
+          "description": null,
+          "fields": [
+            {
+              "name": "epochLength",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "LengthNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lockCheckpoint",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappStateHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startCheckpoint",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappStateHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "seed",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EpochSeedOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ledger",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EpochLedger",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "epochLength",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "LengthNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lockCheckpoint",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappStateHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "startCheckpoint",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappStateHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "seed",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EpochSeedOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "ledger",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EpochLedger",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "GlobalSlot",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "global_slot",
+          "description": null,
+          "fields": [
+            {
+              "name": "upper",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "GlobalSlot",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "GlobalSlot",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "upper",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "GlobalSlot",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "GlobalSlot",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "GlobalSlotNumeric",
+          "description": null,
+          "fields": [
+            {
+              "name": "global_slot",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "global_slot",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "global_slot",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "global_slot",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "currency_amount",
+          "description": null,
+          "fields": [
+            {
+              "name": "upper",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "CurrencyAmount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "CurrencyAmount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "upper",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "CurrencyAmount",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "CurrencyAmount",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CurrencyAmountNumeric",
+          "description": null,
+          "fields": [
+            {
+              "name": "currency_amount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "currency_amount",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "currency_amount",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "currency_amount",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "VrfOutput",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Length",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "length",
+          "description": null,
+          "fields": [
+            {
+              "name": "upper",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Length",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Length",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "upper",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Length",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Length",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "LengthNumeric",
+          "description": null,
+          "fields": [
+            {
+              "name": "length",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "length",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "length",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "length",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "BlockTime",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "block_time",
+          "description": null,
+          "fields": [
+            {
+              "name": "upper",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BlockTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BlockTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "upper",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BlockTime",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BlockTime",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "BlockTimeNumeric",
+          "description": null,
+          "fields": [
+            {
+              "name": "block_time",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "block_time",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "block_time",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "block_time",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "token_id",
+          "description": null,
+          "fields": [
+            {
+              "name": "upper",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "upper",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappNumericTokenId",
+          "description": null,
+          "fields": [
+            {
+              "name": "token_id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "token_id",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "token_id",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "token_id",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "SnarkedLedgerHash",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnarkedLedgerHashOrIgnore",
+          "description": null,
+          "fields": [
+            {
+              "name": "snarkedLedgerHash",
+              "description": "Snarked ledger hash in Base58Check format, or null if Ignore",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "SnarkedLedgerHash",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "snarkedLedgerHash",
+              "description": "Snarked ledger hash in Base58Check format, or null if Ignore",
+              "type": {
+                "kind": "SCALAR",
+                "name": "SnarkedLedgerHash",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "SnappProtocolState",
           "description": "Protocol state for a Snapp transaction",
+          "fields": [
+            {
+              "name": "nextEpochData",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EpochData",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stakingEpochData",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EpochData",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "globalSlotSinceGenesis",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "GlobalSlotNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currGlobalSlot",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "GlobalSlotNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCurrency",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CurrencyAmountNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastVrfOutput",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "VrfOutput",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minWindowDensity",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "LengthNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "blockchainLength",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "LengthNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timestamp",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BlockTimeNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snarkedNextAvailableToken",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappNumericTokenId",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snarkedLedgerHash",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnarkedLedgerHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "nextEpochData",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EpochData",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "stakingEpochData",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "EpochData",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "globalSlotSinceGenesis",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "GlobalSlotNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "currGlobalSlot",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "GlobalSlotNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "totalCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CurrencyAmountNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lastVrfOutput",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "VrfOutput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "minWindowDensity",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "LengthNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "blockchainLength",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "LengthNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "timestamp",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BlockTimeNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "snarkedNextAvailableToken",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappNumericTokenId",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "snarkedLedgerHash",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnarkedLedgerHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "SnappProof",
+          "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -819,9 +2319,1264 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "ProofOrSignature",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Proof",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Signature",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "None_given",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "Control",
+          "description": null,
+          "fields": [
+            {
+              "name": "signature",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Signature",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "proof",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "SnappProof",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "proofOrSignature",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProofOrSignature",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "signature",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Signature",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "proof",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "SnappProof",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "proofOrSignature",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProofOrSignature",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "BoolOrIgnore",
+          "description": null,
+          "fields": [
+            {
+              "name": "bool",
+              "description": "A boolean, or null if Ignore",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "bool",
+              "description": "A boolean, or null if Ignore",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappFieldOrIgnore",
+          "description": null,
+          "fields": [
+            {
+              "name": "field",
+              "description": "Field in string format, or null if Ignore",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Field",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "field",
+              "description": "Field in string format, or null if Ignore",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Field",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappState",
+          "description": "Snapp state, a list of 8 field elements",
+          "fields": [
+            {
+              "name": "elements",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SnappFieldOrIgnore",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "elements",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "SnappFieldOrIgnore",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "Public_keyOrIgnore",
+          "description": null,
+          "fields": [
+            {
+              "name": "public_key",
+              "description": "Public key in Base58Check format, or null if Ignore",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "PublicKey",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "public_key",
+              "description": "Public key in Base58Check format, or null if Ignore",
+              "type": {
+                "kind": "SCALAR",
+                "name": "PublicKey",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
+          "name": "ReceiptChainHash",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappReceiptChainHashOrIgnore",
+          "description": null,
+          "fields": [
+            {
+              "name": "receipt_chain_hash",
+              "description": "receipt chain hash, or null if Ignore",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ReceiptChainHash",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "receipt_chain_hash",
+              "description": "receipt chain hash, or null if Ignore",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ReceiptChainHash",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "nonce",
+          "description": null,
+          "fields": [
+            {
+              "name": "upper",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Nonce",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Nonce",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "upper",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Nonce",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Nonce",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "NonceNumeric",
+          "description": null,
+          "fields": [
+            {
+              "name": "nonce",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "nonce",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "nonce",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "nonce",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "check_or_ignore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Balance",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "BalanceClosedInterval",
+          "description": null,
+          "fields": [
+            {
+              "name": "upper",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Balance",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Balance",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "upper",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Balance",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lower",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Balance",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrIgnore",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Ignore",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Check",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "BalanceNumeric",
+          "description": null,
+          "fields": [
+            {
+              "name": "balanceInterval",
+              "description": "Balance interval, or null if Ignore",
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BalanceClosedInterval",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "checkOrIgnore",
+              "description": "Check or ignore",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "balanceInterval",
+              "description": "Balance interval, or null if Ignore",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "BalanceClosedInterval",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "checkOrIgnore",
+              "description": "Check or ignore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappPredicateAccount",
+          "description": null,
+          "fields": [
+            {
+              "name": "provedState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BoolOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rollupState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappFieldOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "delegate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Public_keyOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publicKey",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Public_keyOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "receiptChainHash",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappReceiptChainHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nonce",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NonceNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "balance",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BalanceNumeric",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "provedState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BoolOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rollupState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappFieldOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappState",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "delegate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Public_keyOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "publicKey",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Public_keyOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "receiptChainHash",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappReceiptChainHashOrIgnore",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "nonce",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NonceNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "balance",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BalanceNumeric",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "SnappPredicateConstructors",
+          "description": "Constructors for Snapp predicates",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Full",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Nonce",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Accept",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappPredicate",
+          "description": null,
+          "fields": [
+            {
+              "name": "nonce",
+              "description": "A nonce for Nonce, null otherwise",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Nonce",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "account",
+              "description": "An account for Full, null otherwise",
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SnappPredicateAccount",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fullOrNonceOrAccept",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SnappPredicateConstructors",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "nonce",
+              "description": "A nonce for Nonce, null otherwise",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Nonce",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "account",
+              "description": "An account for Full, null otherwise",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SnappPredicateAccount",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fullOrNonceOrAccept",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SnappPredicateConstructors",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappPartyPredicated",
+          "description": null,
+          "fields": [
+            {
+              "name": "predicate",
+              "description": "Predicate of the party predicated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappPredicate",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "body",
+              "description": "Body of the party predicated",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartyBody",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "predicate",
+              "description": "Predicate of the party predicated",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappPredicate",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "body",
+              "description": "Body of the party predicated",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartyBody",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "SnappParty",
           "description": "A party to a Snapp transaction",
+          "fields": [
+            {
+              "name": "authorization",
+              "description": "Authorization for this party",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Control",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "data",
+              "description": "Predicated party",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappPartyPredicated",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "authorization",
+              "description": "Authorization for this party",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Control",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "data",
+              "description": "Predicated party",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappPartyPredicated",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Signature",
+          "description": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -830,10 +3585,1897 @@
         },
         {
           "kind": "SCALAR",
-          "name": "SnappPartySigned",
-          "description": "A party to a Snapp transaction with a signature authorization",
+          "name": "Nonce",
+          "description": null,
           "fields": null,
           "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "Sign",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "PLUS",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MINUS",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "CurrencyAmount",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "Delta",
+          "description": "A signed amount",
+          "fields": [
+            {
+              "name": "sgn",
+              "description": "The sign of the amount",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Sign",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "magnitude",
+              "description": "An amount of Mina",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "CurrencyAmount",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "sgn",
+              "description": "The sign of the amount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Sign",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "magnitude",
+              "description": "An amount of Mina",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "CurrencyAmount",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "Timing",
+          "description": null,
+          "fields": [
+            {
+              "name": "vestingIncrement",
+              "description": "Vesting amount, as a string",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vestingPeriod",
+              "description": "Vesting period, a number of slots, as a string",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cliffAmount",
+              "description": "Cliff amoount, as a string",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cliffTime",
+              "description": "Cliff time, a global slot, as a string",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "initialMinimumBalance",
+              "description": "Initial minimum balance as a string",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "vestingIncrement",
+              "description": "Vesting amount, as a string",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "vestingPeriod",
+              "description": "Vesting period, a number of slots, as a string",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "cliffAmount",
+              "description": "Cliff amoount, as a string",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "cliffTime",
+              "description": "Cliff time, a global slot, as a string",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "initialMinimumBalance",
+              "description": "Initial minimum balance as a string",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TimingSetOrKeep",
+          "description": null,
+          "fields": [
+            {
+              "name": "timing",
+              "description": "Timing info, or null if Keep",
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "Timing",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "timing",
+              "description": "Timing info, or null if Keep",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "Timing",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "AccountToken",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AccountTokenSetOrKeep",
+          "description": null,
+          "fields": [
+            {
+              "name": "tokenSymbol",
+              "description": "Token symbol",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "AccountToken",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "tokenSymbol",
+              "description": "Token symbol",
+              "type": {
+                "kind": "SCALAR",
+                "name": "AccountToken",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappUriSetOrKeep",
+          "description": null,
+          "fields": [
+            {
+              "name": "uri",
+              "description": "A URI string, or null if Keep",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "uri",
+              "description": "A URI string, or null if Keep",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "AuthRequired",
+          "description": "Kind of authorization required",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "None",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Either",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Proof",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Signature",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Both",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Impossible",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "Permissions",
+          "description": null,
+          "fields": [
+            {
+              "name": "setTokenSymbol",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editRollupState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setSnappUri",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setVerification_key",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setPermissions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setDelegate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "receive",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "send",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stake",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "setTokenSymbol",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "editRollupState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setSnappUri",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setVerification_key",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setPermissions",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setDelegate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "receive",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "send",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "editState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "stake",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PermissionsSetOrKeep",
+          "description": null,
+          "fields": [
+            {
+              "name": "permissions",
+              "description": "Permissions, or null if Keep",
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "Permissions",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "permissions",
+              "description": "Permissions, or null if Keep",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "Permissions",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "VerificationKeyWithHash",
+          "description": "Verification key with hash",
+          "fields": [
+            {
+              "name": "hash",
+              "description": "Hash of verification key",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "verificationKey",
+              "description": "Verification key in Base58Check format",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "hash",
+              "description": "Hash of verification key",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "verificationKey",
+              "description": "Verification key in Base58Check format",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "VerificationKeyWithHashSetOrKeep",
+          "description": null,
+          "fields": [
+            {
+              "name": "verification_key_with_hash",
+              "description": "A verification key and hash, or null if Keep",
+              "args": [],
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "VerificationKeyWithHash",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "verification_key_with_hash",
+              "description": "A verification key and hash, or null if Keep",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "VerificationKeyWithHash",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PublicKeySetOrKeep",
+          "description": null,
+          "fields": [
+            {
+              "name": "public_key",
+              "description": "A public key in Base58Check format, or null if Keep",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "PublicKey",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "public_key",
+              "description": "A public key in Base58Check format, or null if Keep",
+              "type": {
+                "kind": "SCALAR",
+                "name": "PublicKey",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Field",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "SetOrKeep",
+          "description": "Keep or set a value",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Keep",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Set",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "FieldSetOrKeep",
+          "description": null,
+          "fields": [
+            {
+              "name": "field",
+              "description": "A field in string format, or null if Keep",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Field",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "field",
+              "description": "A field in string format, or null if Keep",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Field",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setOrKeep",
+              "description": "Flag to keep or set",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "SetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PartyUpdate",
+          "description": "Update component of a Snapp Party",
+          "fields": [
+            {
+              "name": "timing",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TimingSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tokenSymbol",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AccountTokenSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snappUri",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappUriSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "permissions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PermissionsSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "verificationKey",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "VerificationKeyWithHashSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "delegate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PublicKeySetOrKeep",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "appState",
+              "description": "List of 8 field elements",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "FieldSetOrKeep",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "timing",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TimingSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "tokenSymbol",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AccountTokenSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "snappUri",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappUriSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "permissions",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PermissionsSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "verificationKey",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "VerificationKeyWithHashSetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "delegate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PublicKeySetOrKeep",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "appState",
+              "description": "List of 8 field elements",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "FieldSetOrKeep",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PartyBody",
+          "description": "Body component of a Snapp Party",
+          "fields": [
+            {
+              "name": "depth",
+              "description": "An integer in string format",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "callData",
+              "description": "A field in Base58Check",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rollupEvents",
+              "description": "A list of list of fields in Base58Check",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "events",
+              "description": "A list of list of fields in Base58Check",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "delta",
+              "description": "Signed amount",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Delta",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tokenId",
+              "description": "Token id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "update",
+              "description": "Update part of the body",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartyUpdate",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pk",
+              "description": "Public key as a Base58Check string",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "depth",
+              "description": "An integer in string format",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "callData",
+              "description": "A field in Base58Check",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "rollupEvents",
+              "description": "A list of list of fields in Base58Check",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "events",
+              "description": "A list of list of fields in Base58Check",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "String",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "delta",
+              "description": "Signed amount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "Delta",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "tokenId",
+              "description": "Token id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "update",
+              "description": "Update part of the body",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartyUpdate",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "pk",
+              "description": "Public key as a Base58Check string",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappPartyPredicatedSigned",
+          "description": "A party to a Snapp transaction with a nonce predicate",
+          "fields": [
+            {
+              "name": "predicate",
+              "description": "nonce",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Nonce",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "body",
+              "description": "signed predicated party",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartyBody",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "predicate",
+              "description": "nonce",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Nonce",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "body",
+              "description": "signed predicated party",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PartyBody",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SnappPartySigned",
+          "description": "A party to a Snapp transaction with a signature authorization",
+          "fields": [
+            {
+              "name": "authorization",
+              "description": "signature",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Signature",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "data",
+              "description": "party with a signature and nonce predicate",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappPartyPredicatedSigned",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "authorization",
+              "description": "signature",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Signature",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "data",
+              "description": "party with a signature and nonce predicate",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "SnappPartyPredicatedSigned",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
           "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
@@ -851,7 +5493,7 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
+                  "kind": "INPUT_OBJECT",
                   "name": "SnappProtocolState",
                   "ofType": null
                 }
@@ -873,7 +5515,7 @@
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "SCALAR",
+                      "kind": "INPUT_OBJECT",
                       "name": "SnappParty",
                       "ofType": null
                     }
@@ -891,7 +5533,7 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
+                  "kind": "INPUT_OBJECT",
                   "name": "SnappPartySigned",
                   "ofType": null
                 }
@@ -908,7 +5550,7 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
+                  "kind": "INPUT_OBJECT",
                   "name": "SnappProtocolState",
                   "ofType": null
                 }
@@ -928,7 +5570,7 @@
                     "kind": "NON_NULL",
                     "name": null,
                     "ofType": {
-                      "kind": "SCALAR",
+                      "kind": "INPUT_OBJECT",
                       "name": "SnappParty",
                       "ofType": null
                     }
@@ -944,7 +5586,7 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
+                  "kind": "INPUT_OBJECT",
                   "name": "SnappPartySigned",
                   "ofType": null
                 }
@@ -8344,7 +12986,7 @@
             },
             {
               "name": "snappUri",
-              "description": "The URI associated with this account, usually pointing to the snapp source code",
+              "description": "The URI associated with this account, usually pointing to the Snapp source code",
               "args": [],
               "type": {
                 "kind": "SCALAR",

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -188,7 +188,7 @@
           "description": "Network identifiers for another protocol participant",
           "fields": [
             {
-              "name": "libp2p_port",
+              "name": "libp2pPort",
               "description": null,
               "args": [],
               "type": {
@@ -220,7 +220,7 @@
               "deprecationReason": null
             },
             {
-              "name": "peer_id",
+              "name": "peerId",
               "description": "base58-encoded peer ID",
               "args": [],
               "type": {
@@ -238,7 +238,7 @@
           ],
           "inputFields": [
             {
-              "name": "libp2p_port",
+              "name": "libp2pPort",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -266,7 +266,7 @@
               "defaultValue": null
             },
             {
-              "name": "peer_id",
+              "name": "peerId",
               "description": "base58-encoded peer ID",
               "type": {
                 "kind": "NON_NULL",
@@ -824,7 +824,7 @@
           "description": null,
           "fields": [
             {
-              "name": "state_hash",
+              "name": "stateHash",
               "description": null,
               "args": [],
               "type": {
@@ -836,7 +836,7 @@
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -854,7 +854,7 @@
           ],
           "inputFields": [
             {
-              "name": "state_hash",
+              "name": "stateHash",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -864,7 +864,7 @@
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -888,7 +888,7 @@
           "description": null,
           "fields": [
             {
-              "name": "epoch_seed",
+              "name": "epochSeed",
               "description": null,
               "args": [],
               "type": {
@@ -900,7 +900,7 @@
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -918,7 +918,7 @@
           ],
           "inputFields": [
             {
-              "name": "epoch_seed",
+              "name": "epochSeed",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -928,7 +928,7 @@
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -1192,7 +1192,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "global_slot",
+          "name": "globalSlot",
           "description": null,
           "fields": [
             {
@@ -1268,19 +1268,19 @@
           "description": null,
           "fields": [
             {
-              "name": "global_slot",
+              "name": "globalSlot",
               "description": null,
               "args": [],
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "global_slot",
+                "name": "globalSlot",
                 "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -1298,17 +1298,17 @@
           ],
           "inputFields": [
             {
-              "name": "global_slot",
+              "name": "globalSlot",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "global_slot",
+                "name": "globalSlot",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -1328,7 +1328,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "currency_amount",
+          "name": "currencyAmount",
           "description": null,
           "fields": [
             {
@@ -1404,19 +1404,19 @@
           "description": null,
           "fields": [
             {
-              "name": "currency_amount",
+              "name": "currencyAmount",
               "description": null,
               "args": [],
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "currency_amount",
+                "name": "currencyAmount",
                 "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -1434,17 +1434,17 @@
           ],
           "inputFields": [
             {
-              "name": "currency_amount",
+              "name": "currencyAmount",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "currency_amount",
+                "name": "currencyAmount",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -1572,7 +1572,7 @@
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -1600,7 +1600,7 @@
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -1630,7 +1630,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "block_time",
+          "name": "blockTime",
           "description": null,
           "fields": [
             {
@@ -1706,19 +1706,19 @@
           "description": null,
           "fields": [
             {
-              "name": "block_time",
+              "name": "blockTime",
               "description": null,
               "args": [],
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "block_time",
+                "name": "blockTime",
                 "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -1736,17 +1736,17 @@
           ],
           "inputFields": [
             {
-              "name": "block_time",
+              "name": "blockTime",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "block_time",
+                "name": "blockTime",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -1766,7 +1766,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "token_id",
+          "name": "tokenId",
           "description": null,
           "fields": [
             {
@@ -1842,19 +1842,19 @@
           "description": null,
           "fields": [
             {
-              "name": "token_id",
+              "name": "tokenId",
               "description": null,
               "args": [],
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "token_id",
+                "name": "tokenId",
                 "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -1872,17 +1872,17 @@
           ],
           "inputFields": [
             {
-              "name": "token_id",
+              "name": "tokenId",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "token_id",
+                "name": "tokenId",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -1928,7 +1928,7 @@
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -1956,7 +1956,7 @@
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -2339,7 +2339,7 @@
               "deprecationReason": null
             },
             {
-              "name": "None_given",
+              "name": "NoneGiven",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -2451,7 +2451,7 @@
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -2479,7 +2479,7 @@
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -2515,7 +2515,7 @@
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -2543,7 +2543,7 @@
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -2621,11 +2621,11 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "Public_keyOrIgnore",
+          "name": "PublicKeyOrIgnore",
           "description": null,
           "fields": [
             {
-              "name": "public_key",
+              "name": "publicKey",
               "description": "Public key in Base58Check format, or null if Ignore",
               "args": [],
               "type": {
@@ -2637,7 +2637,7 @@
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -2655,7 +2655,7 @@
           ],
           "inputFields": [
             {
-              "name": "public_key",
+              "name": "publicKey",
               "description": "Public key in Base58Check format, or null if Ignore",
               "type": {
                 "kind": "SCALAR",
@@ -2665,7 +2665,7 @@
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -2699,7 +2699,7 @@
           "description": null,
           "fields": [
             {
-              "name": "receipt_chain_hash",
+              "name": "receiptChainHash",
               "description": "receipt chain hash, or null if Ignore",
               "args": [],
               "type": {
@@ -2711,7 +2711,7 @@
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -2729,7 +2729,7 @@
           ],
           "inputFields": [
             {
-              "name": "receipt_chain_hash",
+              "name": "receiptChainHash",
               "description": "receipt chain hash, or null if Ignore",
               "type": {
                 "kind": "SCALAR",
@@ -2739,7 +2739,7 @@
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -2847,7 +2847,7 @@
               "deprecationReason": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "args": [],
               "type": {
@@ -2875,7 +2875,7 @@
               "defaultValue": null
             },
             {
-              "name": "check_or_ignore",
+              "name": "checkOrIgnore",
               "description": "Check or ignore",
               "type": {
                 "kind": "NON_NULL",
@@ -3124,7 +3124,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "Public_keyOrIgnore",
+                  "name": "PublicKeyOrIgnore",
                   "ofType": null
                 }
               },
@@ -3140,7 +3140,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "Public_keyOrIgnore",
+                  "name": "PublicKeyOrIgnore",
                   "ofType": null
                 }
               },
@@ -3247,7 +3247,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "Public_keyOrIgnore",
+                  "name": "PublicKeyOrIgnore",
                   "ofType": null
                 }
               },
@@ -3261,7 +3261,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "Public_keyOrIgnore",
+                  "name": "PublicKeyOrIgnore",
                   "ofType": null
                 }
               },
@@ -4163,7 +4163,7 @@
               "deprecationReason": null
             },
             {
-              "name": "setVerification_key",
+              "name": "setVerificationKey",
               "description": null,
               "args": [],
               "type": {
@@ -4319,7 +4319,7 @@
               "defaultValue": null
             },
             {
-              "name": "setVerification_key",
+              "name": "setVerificationKey",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -4563,7 +4563,7 @@
           "description": null,
           "fields": [
             {
-              "name": "verification_key_with_hash",
+              "name": "verificationKeyWithHash",
               "description": "A verification key and hash, or null if Keep",
               "args": [],
               "type": {
@@ -4593,7 +4593,7 @@
           ],
           "inputFields": [
             {
-              "name": "verification_key_with_hash",
+              "name": "verificationKeyWithHash",
               "description": "A verification key and hash, or null if Keep",
               "type": {
                 "kind": "INPUT_OBJECT",
@@ -4627,7 +4627,7 @@
           "description": null,
           "fields": [
             {
-              "name": "public_key",
+              "name": "publicKey",
               "description": "A public key in Base58Check format, or null if Keep",
               "args": [],
               "type": {
@@ -4657,7 +4657,7 @@
           ],
           "inputFields": [
             {
-              "name": "public_key",
+              "name": "publicKey",
               "description": "A public key in Base58Check format, or null if Keep",
               "type": {
                 "kind": "SCALAR",
@@ -9287,7 +9287,7 @@
           "description": null,
           "fields": [
             {
-              "name": "ip_addr",
+              "name": "ipAddr",
               "description": "IP address",
               "args": [],
               "type": {
@@ -9303,7 +9303,7 @@
               "deprecationReason": null
             },
             {
-              "name": "peer_id",
+              "name": "peerId",
               "description": "libp2p Peer ID",
               "args": [],
               "type": {
@@ -9335,7 +9335,7 @@
               "deprecationReason": null
             },
             {
-              "name": "banned_status",
+              "name": "bannedStatus",
               "description": "Banned status",
               "args": [],
               "type": {
@@ -12377,7 +12377,7 @@
           "description": null,
           "fields": [
             {
-              "name": "peer_id",
+              "name": "peerId",
               "description": "base58-encoded peer ID",
               "args": [],
               "type": {
@@ -12409,7 +12409,7 @@
               "deprecationReason": null
             },
             {
-              "name": "libp2p_port",
+              "name": "libp2pPort",
               "description": null,
               "args": [],
               "type": {
@@ -12626,7 +12626,7 @@
           "description": null,
           "fields": [
             {
-              "name": "initial_mininum_balance",
+              "name": "initialMininumBalance",
               "description": "The initial minimum balance for a time-locked account",
               "args": [],
               "type": {
@@ -12638,7 +12638,7 @@
               "deprecationReason": null
             },
             {
-              "name": "cliff_time",
+              "name": "cliffTime",
               "description": "The cliff time for a time-locked account",
               "args": [],
               "type": {
@@ -12650,7 +12650,7 @@
               "deprecationReason": null
             },
             {
-              "name": "cliff_amount",
+              "name": "cliffAmount",
               "description": "The cliff amount for a time-locked account",
               "args": [],
               "type": {
@@ -12662,7 +12662,7 @@
               "deprecationReason": null
             },
             {
-              "name": "vesting_period",
+              "name": "vestingPeriod",
               "description": "The vesting period for a time-locked account",
               "args": [],
               "type": {
@@ -12674,7 +12674,7 @@
               "deprecationReason": null
             },
             {
-              "name": "vesting_increment",
+              "name": "vestingIncrement",
               "description": "The vesting increment for a time-locked account",
               "args": [],
               "type": {

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -425,7 +425,7 @@ module Types = struct
 
   let account_timing : (Mina_lib.t, Account_timing.t option) typ =
     obj "AccountTiming" ~fields:(fun _ ->
-        [ field "initial_mininum_balance" ~typ:uint64
+        [ field "initialMininumBalance" ~typ:uint64
             ~doc:"The initial minimum balance for a time-locked account"
             ~args:Arg.[]
             ~resolve:(fun _ timing ->
@@ -434,7 +434,7 @@ module Types = struct
                   None
               | Timed timing_info ->
                   Some (Balance.to_uint64 timing_info.initial_minimum_balance))
-        ; field "cliff_time" ~typ:uint32
+        ; field "cliffTime" ~typ:uint32
             ~doc:"The cliff time for a time-locked account"
             ~args:Arg.[]
             ~resolve:(fun _ timing ->
@@ -443,7 +443,7 @@ module Types = struct
                   None
               | Timed timing_info ->
                   Some timing_info.cliff_time)
-        ; field "cliff_amount" ~typ:uint64
+        ; field "cliffAmount" ~typ:uint64
             ~doc:"The cliff amount for a time-locked account"
             ~args:Arg.[]
             ~resolve:(fun _ timing ->
@@ -452,7 +452,7 @@ module Types = struct
                   None
               | Timed timing_info ->
                   Some (Currency.Amount.to_uint64 timing_info.cliff_amount))
-        ; field "vesting_period" ~typ:uint32
+        ; field "vestingPeriod" ~typ:uint32
             ~doc:"The vesting period for a time-locked account"
             ~args:Arg.[]
             ~resolve:(fun _ timing ->
@@ -461,7 +461,7 @@ module Types = struct
                   None
               | Timed timing_info ->
                   Some timing_info.vesting_period)
-        ; field "vesting_increment" ~typ:uint64
+        ; field "vestingIncrement" ~typ:uint64
             ~doc:"The vesting increment for a time-locked account"
             ~args:Arg.[]
             ~resolve:(fun _ timing ->
@@ -1734,7 +1734,7 @@ module Types = struct
   module Payload = struct
     let peer : ('context, Network_peer.Peer.t option) typ =
       obj "NetworkPeerPayload" ~fields:(fun _ ->
-          [ field "peer_id" ~doc:"base58-encoded peer ID" ~typ:(non_null string)
+          [ field "peerId" ~doc:"base58-encoded peer ID" ~typ:(non_null string)
               ~args:Arg.[]
               ~resolve:(fun _ peer -> peer.Network_peer.Peer.peer_id)
           ; field "host" ~doc:"IP address of the remote host"
@@ -1742,7 +1742,7 @@ module Types = struct
               ~args:Arg.[]
               ~resolve:(fun _ peer ->
                 Unix.Inet_addr.to_string peer.Network_peer.Peer.host)
-          ; field "libp2p_port" ~typ:(non_null int)
+          ; field "libp2pPort" ~typ:(non_null int)
               ~args:Arg.[]
               ~resolve:(fun _ peer -> peer.Network_peer.Peer.libp2p_port)
           ])
@@ -1832,17 +1832,17 @@ module Types = struct
     let trust_status =
       obj "TrustStatusPayload" ~fields:(fun _ ->
           let open Trust_system.Peer_status in
-          [ field "ip_addr" ~typ:(non_null string) ~doc:"IP address"
+          [ field "ipAddr" ~typ:(non_null string) ~doc:"IP address"
               ~args:Arg.[]
               ~resolve:(fun _ (peer, _) ->
                 Unix.Inet_addr.to_string peer.Network_peer.Peer.host)
-          ; field "peer_id" ~typ:(non_null string) ~doc:"libp2p Peer ID"
+          ; field "peerId" ~typ:(non_null string) ~doc:"libp2p Peer ID"
               ~args:Arg.[]
               ~resolve:(fun _ (peer, __) -> peer.Network_peer.Peer.peer_id)
           ; field "trust" ~typ:(non_null float) ~doc:"Trust score"
               ~args:Arg.[]
               ~resolve:(fun _ (_, { trust; _ }) -> trust)
-          ; field "banned_status" ~typ:string ~doc:"Banned status"
+          ; field "bannedStatus" ~typ:string ~doc:"Banned status"
               ~args:Arg.[]
               ~resolve:(fun _ (_, { banned; _ }) ->
                 string_of_banned_status banned)
@@ -2029,10 +2029,10 @@ module Types = struct
                 { peer_id; host = Unix.Inet_addr.of_string host; libp2p_port }
           with _ -> Error "Invalid format for NetworkPeer.host")
         ~fields:
-          [ arg "peer_id" ~doc:"base58-encoded peer ID" ~typ:(non_null string)
+          [ arg "peerId" ~doc:"base58-encoded peer ID" ~typ:(non_null string)
           ; arg "host" ~doc:"IP address of the remote host"
               ~typ:(non_null string)
-          ; arg "libp2p_port" ~typ:(non_null int)
+          ; arg "libp2pPort" ~typ:(non_null int)
           ]
 
     let public_key_arg =
@@ -2192,7 +2192,7 @@ module Types = struct
 
       let snapp_pk_set_or_keep =
         snapp_make_set_or_keep "PublicKeySetOrKeep"
-          (arg "public_key"
+          (arg "publicKey"
              ~doc:"A public key in Base58Check format, or null if Keep"
              ~typ:public_key_arg)
 
@@ -2216,7 +2216,7 @@ module Types = struct
 
       let snapp_vk_with_hash_set_or_keep =
         snapp_make_set_or_keep_for_result "VerificationKeyWithHashSetOrKeep"
-          (arg "verification_key_with_hash"
+          (arg "verificationKeyWithHash"
              ~doc:"A verification key and hash, or null if Keep"
              ~typ:snapp_vk_with_hash)
 
@@ -2265,7 +2265,7 @@ module Types = struct
             ; arg "receive" ~typ:(non_null snapp_auth_required)
             ; arg "setDelegate" ~typ:(non_null snapp_auth_required)
             ; arg "setPermissions" ~typ:(non_null snapp_auth_required)
-            ; arg "setVerification_key" ~typ:(non_null snapp_auth_required)
+            ; arg "setVerificationKey" ~typ:(non_null snapp_auth_required)
             ; arg "setSnappUri" ~typ:(non_null snapp_auth_required)
             ; arg "editRollupState" ~typ:(non_null snapp_auth_required)
             ; arg "setTokenSymbol" ~typ:(non_null snapp_auth_required)
@@ -2504,14 +2504,14 @@ module Types = struct
             | Check, None ->
                 Error "Got Check with a null value")
           ~fields:
-            [ arg "check_or_ignore" ~doc:"Check or ignore"
+            [ arg "checkOrIgnore" ~doc:"Check or ignore"
                 ~typ:(non_null snapp_check_or_ignore)
             ; value_arg
             ]
 
       let snapp_pk_or_ignore =
-        snapp_make_check_or_ignore "Public_keyOrIgnore"
-          (arg "public_key"
+        snapp_make_check_or_ignore "PublicKeyOrIgnore"
+          (arg "publicKey"
              ~doc:"Public key in Base58Check format, or null if Ignore"
              ~typ:public_key_arg)
 
@@ -2580,7 +2580,7 @@ module Types = struct
 
       let snapp_receipt_chain_hash_or_ignore =
         snapp_make_check_or_ignore "SnappReceiptChainHashOrIgnore"
-          (arg "receipt_chain_hash" ~doc:"receipt chain hash, or null if Ignore"
+          (arg "receiptChainHash" ~doc:"receipt chain hash, or null if Ignore"
              ~typ:snapp_receipt_chain_hash)
 
       let snapp_field_or_ignore =
@@ -2705,7 +2705,7 @@ module Types = struct
           ~values:
             [ enum_value "Proof" ~value:Proof
             ; enum_value "Signature" ~value:Signature
-            ; enum_value "None_given" ~value:None_given
+            ; enum_value "NoneGiven" ~value:None_given
             ]
 
       let snapp_control =
@@ -2755,11 +2755,11 @@ module Types = struct
           ~typ:token_id_arg
 
       let snapp_token_id_numeric =
-        snapp_make_numeric ~name:"SnappNumericTokenId" ~arg_name:"token_id"
+        snapp_make_numeric ~name:"SnappNumericTokenId" ~arg_name:"tokenId"
           ~typ:token_id_arg
 
       let snapp_block_time_numeric =
-        snapp_make_numeric ~name:"BlockTimeNumeric" ~arg_name:"block_time"
+        snapp_make_numeric ~name:"BlockTimeNumeric" ~arg_name:"blockTime"
           ~typ:block_time
 
       let snapp_length_numeric =
@@ -2775,7 +2775,7 @@ module Types = struct
 
       let snapp_currency_amount_numeric =
         snapp_make_numeric ~name:"CurrencyAmountNumeric"
-          ~arg_name:"currency_amount" ~typ:currency_amount
+          ~arg_name:"currencyAmount" ~typ:currency_amount
 
       let snapp_global_slot =
         scalar "GlobalSlot" ~coerce:(fun amt ->
@@ -2787,7 +2787,7 @@ module Types = struct
                 Error "Expected string for global slot")
 
       let snapp_global_slot_numeric =
-        snapp_make_numeric ~name:"GlobalSlotNumeric" ~arg_name:"global_slot"
+        snapp_make_numeric ~name:"GlobalSlotNumeric" ~arg_name:"globalSlot"
           ~typ:snapp_global_slot
 
       let snapp_state_hash =
@@ -2802,7 +2802,7 @@ module Types = struct
 
       let snapp_state_hash_or_ignore =
         snapp_make_check_or_ignore "SnappStateHashOrIgnore"
-          (arg "state_hash" ~typ:snapp_state_hash)
+          (arg "stateHash" ~typ:snapp_state_hash)
 
       let snapp_epoch_seed =
         scalar "EpochSeed" ~coerce:(fun field ->
@@ -2814,7 +2814,7 @@ module Types = struct
 
       let snapp_epoch_seed_or_ignore =
         snapp_make_check_or_ignore "EpochSeedOrIgnore"
-          (arg "epoch_seed" ~typ:snapp_epoch_seed)
+          (arg "epochSeed" ~typ:snapp_epoch_seed)
 
       let snapp_epoch_ledger =
         obj "EpochLedger"

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2147,7 +2147,7 @@ module Types = struct
       type set_or_keep = Set | Keep
 
       let snapp_set_or_keep =
-        enum "KeepOrSet" ~doc:"Keep or set a value"
+        enum "SetOrKeep" ~doc:"Keep or set a value"
           ~values:[ enum_value "Keep" ~value:Keep; enum_value "Set" ~value:Set ]
 
       let snapp_make_set_or_keep name value_arg =
@@ -2163,7 +2163,7 @@ module Types = struct
             | Set, None ->
                 Error "No value given for Set")
           ~fields:
-            [ arg "set_or_keep" ~doc:"Flag to keep or set"
+            [ arg "setOrKeep" ~doc:"Flag to keep or set"
                 ~typ:(non_null snapp_set_or_keep)
             ; value_arg
             ]
@@ -2185,7 +2185,7 @@ module Types = struct
             | Set, None ->
                 Error "No value given for Set")
           ~fields:
-            [ arg "set_or_keep" ~doc:"Flag to keep or set"
+            [ arg "setOrKeep" ~doc:"Flag to keep or set"
                 ~typ:(non_null snapp_set_or_keep)
             ; value_arg
             ]
@@ -2208,7 +2208,7 @@ module Types = struct
             in
             { With_hash.data; hash })
           ~fields:
-            [ arg "verification_key"
+            [ arg "verificationKey"
                 ~doc:"Verification key in Base58Check format"
                 ~typ:(non_null string)
             ; arg "hash" ~doc:"Hash of verification key" ~typ:(non_null string)
@@ -2226,7 +2226,7 @@ module Types = struct
 
       let snapp_token_symbol_set_or_keep =
         snapp_make_set_or_keep "AccountTokenSetOrKeep"
-          (arg "token_symbol" ~doc:"Token symbol" ~typ:snapp_token)
+          (arg "tokenSymbol" ~doc:"Token symbol" ~typ:snapp_token)
 
       let snapp_auth_required =
         let open Permissions.Auth_required in
@@ -2260,15 +2260,15 @@ module Types = struct
               })
           ~fields:
             [ arg "stake" ~typ:(non_null bool)
-            ; arg "edit_state" ~typ:(non_null snapp_auth_required)
+            ; arg "editState" ~typ:(non_null snapp_auth_required)
             ; arg "send" ~typ:(non_null snapp_auth_required)
             ; arg "receive" ~typ:(non_null snapp_auth_required)
-            ; arg "set_delegate" ~typ:(non_null snapp_auth_required)
-            ; arg "set_permissions" ~typ:(non_null snapp_auth_required)
-            ; arg "set_verification_key" ~typ:(non_null snapp_auth_required)
-            ; arg "set_snapp_uri" ~typ:(non_null snapp_auth_required)
-            ; arg "edit_rollup_state" ~typ:(non_null snapp_auth_required)
-            ; arg "set_token_symbol" ~typ:(non_null snapp_auth_required)
+            ; arg "setDelegate" ~typ:(non_null snapp_auth_required)
+            ; arg "setPermissions" ~typ:(non_null snapp_auth_required)
+            ; arg "setVerification_key" ~typ:(non_null snapp_auth_required)
+            ; arg "setSnappUri" ~typ:(non_null snapp_auth_required)
+            ; arg "editRollupState" ~typ:(non_null snapp_auth_required)
+            ; arg "setTokenSymbol" ~typ:(non_null snapp_auth_required)
             ]
 
       let snapp_permissions_set_or_keep =
@@ -2312,17 +2312,17 @@ module Types = struct
                 }
             with exn -> Error (Exn.to_string exn))
           ~fields:
-            [ arg "initial_minimum_balance"
+            [ arg "initialMinimumBalance"
                 ~doc:"Initial minimum balance as a string"
                 ~typ:(non_null string)
-            ; arg "cliff_time" ~doc:"Cliff time, a global slot, as a string"
+            ; arg "cliffTime" ~doc:"Cliff time, a global slot, as a string"
                 ~typ:(non_null string)
-            ; arg "cliff_amount" ~doc:"Cliff amoount, as a string"
+            ; arg "cliffAmount" ~doc:"Cliff amoount, as a string"
                 ~typ:(non_null string)
-            ; arg "vesting_period"
+            ; arg "vestingPeriod"
                 ~doc:"Vesting period, a number of slots, as a string"
                 ~typ:(non_null string)
-            ; arg "vesting_increment" ~doc:"Vesting amount, as a string"
+            ; arg "vestingIncrement" ~doc:"Vesting amount, as a string"
                 ~typ:(non_null string)
             ]
 
@@ -2364,14 +2364,14 @@ module Types = struct
               ; timing
               })
           ~fields:
-            [ arg "app_state" ~doc:"List of 8 field elements"
+            [ arg "appState" ~doc:"List of 8 field elements"
                 ~typ:(non_null (list (non_null snapp_field_set_or_keep)))
             ; arg "delegate" ~typ:(non_null snapp_pk_set_or_keep)
-            ; arg "verification_key"
+            ; arg "verificationKey"
                 ~typ:(non_null snapp_vk_with_hash_set_or_keep)
             ; arg "permissions" ~typ:(non_null snapp_permissions_set_or_keep)
-            ; arg "snapp_uri" ~typ:(non_null snapp_uri_set_or_keep)
-            ; arg "token_symbol" ~typ:(non_null snapp_token_symbol_set_or_keep)
+            ; arg "snappUri" ~typ:(non_null snapp_uri_set_or_keep)
+            ; arg "tokenSymbol" ~typ:(non_null snapp_token_symbol_set_or_keep)
             ; arg "timing" ~typ:(non_null snapp_timing_set_or_keep)
             ]
 
@@ -2415,13 +2415,13 @@ module Types = struct
                 ~typ:(non_null string)
             ; arg "update" ~doc:"Update part of the body"
                 ~typ:(non_null snapp_update)
-            ; arg "token_id" ~doc:"Token id" ~typ:(non_null string)
+            ; arg "tokenId" ~doc:"Token id" ~typ:(non_null string)
             ; arg "delta" ~doc:"Signed amount" ~typ:(non_null snapp_delta)
             ; arg "events" ~doc:"A list of list of fields in Base58Check"
                 ~typ:(non_null (list (non_null (list (non_null string)))))
-            ; arg "rollup_events" ~doc:"A list of list of fields in Base58Check"
+            ; arg "rollupEvents" ~doc:"A list of list of fields in Base58Check"
                 ~typ:(non_null (list (non_null (list (non_null string)))))
-            ; arg "call_data" ~doc:"A field in Base58Check"
+            ; arg "callData" ~doc:"A field in Base58Check"
                 ~typ:(non_null string)
             ; arg "depth" ~doc:"An integer in string format"
                 ~typ:(non_null string)
@@ -2439,7 +2439,7 @@ module Types = struct
           ~fields:
             [ arg "body" ~doc:"signed predicated party"
                 ~typ:(non_null snapp_party_body)
-            ; arg "predicate" ~doc:"signature" ~typ:(non_null nonce)
+            ; arg "predicate" ~doc:"nonce" ~typ:(non_null nonce)
             ]
 
       let snapp_signature =
@@ -2547,9 +2547,9 @@ module Types = struct
             | Check, None ->
                 Error "Got Check with a null value")
           ~fields:
-            [ arg "check_or_ignore" ~doc:"Check or ignore"
+            [ arg "checkOrIgnore" ~doc:"Check or ignore"
                 ~typ:(non_null snapp_check_or_ignore)
-            ; arg "balance_interval" ~doc:"Balance interval, or null if Ignore"
+            ; arg "balanceInterval" ~doc:"Balance interval, or null if Ignore"
                 ~typ:snapp_balance_closed_interval
             ]
 
@@ -2636,13 +2636,13 @@ module Types = struct
           ~fields:
             [ arg "balance" ~typ:(non_null snapp_balance_numeric)
             ; arg "nonce" ~typ:(non_null snapp_nonce_numeric)
-            ; arg "receipt_chain_hash"
+            ; arg "receiptChainHash"
                 ~typ:(non_null snapp_receipt_chain_hash_or_ignore)
-            ; arg "public_key" ~typ:(non_null snapp_pk_or_ignore)
+            ; arg "publicKey" ~typ:(non_null snapp_pk_or_ignore)
             ; arg "delegate" ~typ:(non_null snapp_pk_or_ignore)
             ; arg "state" ~typ:(non_null snapp_state)
-            ; arg "rollup_state" ~typ:(non_null snapp_field_or_ignore)
-            ; arg "proved_state" ~typ:(non_null snapp_bool_or_ignore)
+            ; arg "rollupState" ~typ:(non_null snapp_field_or_ignore)
+            ; arg "provedState" ~typ:(non_null snapp_bool_or_ignore)
             ]
 
       let snapp_predicate =
@@ -2666,7 +2666,7 @@ module Types = struct
             | Nonce, _, _ ->
                 Error "Nonce requires a non-null nonce value")
           ~fields:
-            [ arg "full_or_nonce_or_accept" ~typ:(non_null snapp_predicate_enum)
+            [ arg "fullOrNonceOrAccept" ~typ:(non_null snapp_predicate_enum)
             ; arg "account" ~doc:"An account for Full, null otherwise"
                 ~typ:snapp_predicate_account
             ; arg "nonce" ~doc:"A nonce for Nonce, null otherwise" ~typ:nonce
@@ -2725,7 +2725,7 @@ module Types = struct
             | None_given, _, _ ->
                 Error "None_given, other data should be null")
           ~fields:
-            [ arg "proof_or_signature" ~typ:(non_null snapp_control_enum)
+            [ arg "proofOrSignature" ~typ:(non_null snapp_control_enum)
             ; arg "proof" ~typ:snapp_proof
             ; arg "signature" ~typ:snapp_signature
             ]
@@ -2746,7 +2746,7 @@ module Types = struct
 
       let snapp_snarked_ledger_hash_or_ignore =
         snapp_make_check_or_ignore "SnarkedLedgerHashOrIgnore"
-          (arg "snarked_ledger_hash"
+          (arg "snarkedLedgerHash"
              ~doc:"Snarked ledger hash in Base58Check format, or null if Ignore"
              ~typ:snarked_ledger_hash)
 
@@ -2825,7 +2825,7 @@ module Types = struct
             Ok { Epoch_ledger.Poly.hash; total_currency })
           ~fields:
             [ arg "hash" ~typ:(non_null snapp_snarked_ledger_hash_or_ignore)
-            ; arg "total_currency" ~typ:(non_null snapp_currency_amount_numeric)
+            ; arg "totalCurrency" ~typ:(non_null snapp_currency_amount_numeric)
             ]
 
       let snapp_epoch_data =
@@ -2849,9 +2849,9 @@ module Types = struct
           ~fields:
             [ arg "ledger" ~typ:(non_null snapp_epoch_ledger)
             ; arg "seed" ~typ:(non_null snapp_epoch_seed_or_ignore)
-            ; arg "start_checkpoint" ~typ:(non_null snapp_state_hash_or_ignore)
-            ; arg "lock_checkpoint" ~typ:(non_null snapp_state_hash_or_ignore)
-            ; arg "epoch_length" ~typ:(non_null snapp_length_numeric)
+            ; arg "startCheckpoint" ~typ:(non_null snapp_state_hash_or_ignore)
+            ; arg "lockCheckpoint" ~typ:(non_null snapp_state_hash_or_ignore)
+            ; arg "epochLength" ~typ:(non_null snapp_length_numeric)
             ]
 
       let snapp_protocol_state_arg :
@@ -2899,20 +2899,20 @@ module Types = struct
               ; next_epoch_data
               })
           ~fields:
-            [ arg "snarked_ledger_hash"
+            [ arg "snarkedLedgerHash"
                 ~typ:(non_null snapp_snarked_ledger_hash_or_ignore)
-            ; arg "snarked_next_available_token"
+            ; arg "snarkedNextAvailableToken"
                 ~typ:(non_null snapp_token_id_numeric)
             ; arg "timestamp" ~typ:(non_null snapp_block_time_numeric)
-            ; arg "blockchain_length" ~typ:(non_null snapp_length_numeric)
-            ; arg "min_window_density" ~typ:(non_null snapp_length_numeric)
-            ; arg "last_vrf_output" ~typ:snapp_vrf_output (* nullable! *)
-            ; arg "total_currency" ~typ:(non_null snapp_currency_amount_numeric)
-            ; arg "curr_global_slot" ~typ:(non_null snapp_global_slot_numeric)
-            ; arg "global_slot_since_genesis"
+            ; arg "blockchainLength" ~typ:(non_null snapp_length_numeric)
+            ; arg "minWindowDensity" ~typ:(non_null snapp_length_numeric)
+            ; arg "lastVrfOutput" ~typ:snapp_vrf_output (* nullable! *)
+            ; arg "totalCurrency" ~typ:(non_null snapp_currency_amount_numeric)
+            ; arg "currGlobalSlot" ~typ:(non_null snapp_global_slot_numeric)
+            ; arg "globalSlotSinceGenesis"
                 ~typ:(non_null snapp_global_slot_numeric)
-            ; arg "staking_epoch_data" ~typ:(non_null snapp_epoch_data)
-            ; arg "next_epoch_data" ~typ:(non_null snapp_epoch_data)
+            ; arg "stakingEpochData" ~typ:(non_null snapp_epoch_data)
+            ; arg "nextEpochData" ~typ:(non_null snapp_epoch_data)
             ]
     end
 

--- a/src/lib/pickles/composition_types/index.ml
+++ b/src/lib/pickles/composition_types/index.ml
@@ -4,26 +4,11 @@ open Pickles_types
 [%%versioned
 module Stable = struct
   module V1 = struct
-    type t = char [@@deriving sexp, sexp, compare, hash, equal]
-
-    (* encode/decode as integer, which is readable by GraphQL *)
-    let to_yojson c : Yojson.Safe.t = `Int (Char.to_int c)
-
-    let of_yojson =
-      let min_char_int = Char.to_int Char.min_value in
-      let max_char_int = Char.to_int Char.max_value in
-      fun json ->
-        match json with
-        | `Int n when n >= min_char_int && n <= max_char_int ->
-            Result.Ok (Char.of_int_exn n)
-        | _ ->
-            Result.Error "Index.Stable.V1.t"
+    type t = char [@@deriving sexp, sexp, compare, yojson, hash, equal]
 
     let to_latest = Fn.id
   end
 end]
-
-[%%define_locally Stable.Latest.(to_yojson, of_yojson)]
 
 let of_int = Char.of_int
 

--- a/src/lib/pickles/dune
+++ b/src/lib/pickles/dune
@@ -8,6 +8,7 @@
  (libraries
    digestif
    mina_version
+   base64
    zexe_backend
    random_oracle_input
    pickles_base

--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -157,8 +157,16 @@ module Side_loaded : sig
         type t =
           (Verification_key.Max_width.n, Verification_key.Max_width.n) Proof.t
         [@@deriving sexp, equal, yojson, hash, compare]
+
+        val to_base64 : t -> string
+
+        val of_base64 : string -> (t, string) Result.t
       end
     end]
+
+    val to_base64 : t -> string
+
+    val of_base64 : string -> (t, string) Result.t
   end
 
   val create :

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -265,6 +265,20 @@ module Make (W : Nat.Intf) (MLMB : Nat.Intf) = struct
               let of_sexpable = of_repr
             end)
 
+  let to_base64 t =
+    (* assume call to Nat.lte_exn does not raise with a valid instance of t *)
+    let sexp = sexp_of_t t in
+    (* raises only on invalid optional arguments *)
+    Base64.encode_exn (Sexp.to_string sexp)
+
+  let of_base64 b64 =
+    match Base64.decode b64 with
+    | Ok t -> (
+        try Ok (t_of_sexp (Sexp.of_string t))
+        with exn -> Error (Exn.to_string exn) )
+    | Error (`Msg s) ->
+        Error s
+
   let to_yojson x = Repr.to_yojson (to_repr x)
 
   let of_yojson x = Result.map ~f:of_repr (Repr.of_yojson x)


### PR DESCRIPTION
Name the fields in the input to a GraphQL Snapps transaction.

Tested by taking an existing transaction used to test the code in #9466, and modifying it to conform to this format, and running against a daemon in demo mode.

Here's that input: https://gist.github.com/psteckler/b3ab4632b55e565dac5f723ef40b07a8

The new input is a bit more verbose than the JSON-derived input. Constructors like `Set`, `Keep`, `Check`, `Ignore` are in fields with names, rather than as unadorned list elements.