### PR TITLE
Remove verifier auto-restart

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,7 @@
+Current changes
+===============
+
+### Performance enhancements
+
+* #9530: Remove verifier process automatic restart, which was
+  intended to work around memory leaks, now fixed (Paul Steckler)


### PR DESCRIPTION
Remove the code introduced in #5911 that automatically restarts the verifier every 15 minutes.

The restarts were to avoid problems due to memory leaks, which reportedly no longer exist.

Tested by running a node against mainnet for 21 minutes, the verifier did not restart.