### PR TITLE
Snapp commands in archive db schema

### DIFF
--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -1,3 +1,16 @@
+/* the Postgresql schema used by the Mina archive database */
+
+/* there are a number of values represented by a Postgresql bigint here, which is a 64-bit signed value,
+   while in OCaml, the value is represented by a 64-bit unsigned value, so that overflow is
+   possible
+
+   while overflow is unlikely, because a bigint can be very large, it's possible in theory
+
+   that describes almost all the bigint values below, except for those representing
+   nonces and slots, which are unsigned 32-bit values in OCaml
+
+*/
+
 CREATE TABLE public_keys
 ( id    serial PRIMARY KEY
 , value text   NOT NULL UNIQUE
@@ -5,6 +18,9 @@ CREATE TABLE public_keys
 
 CREATE INDEX idx_public_keys_value ON public_keys(value);
 
+/* the initial balance is the balance at genesis, whether the account is timed or not
+   for untimed accounts, the fields other than id, public_key_id, and token are 0
+*/
 CREATE TABLE timing_info
 ( id                      serial    PRIMARY KEY
 , public_key_id           int       NOT NULL REFERENCES public_keys(id)
@@ -58,6 +74,48 @@ CREATE TABLE internal_commands
 , UNIQUE (hash,type)
 );
 
+/* import supporting Snapp-related tables */
+\i snapp_tables.sql
+
+CREATE TABLE snapp_fee_payers
+( id                       serial           PRIMARY KEY
+, body_id                  int              NOT NULL REFERENCES snapp_party_body(id)
+, nonce                    bigint           NOT NULL
+);
+
+/* encode a list of party's: the list_id identifies the list, the list_index indicates the order */
+CREATE TABLE snapp_other_parties
+( list_id                  int              NOT NULL
+, list_index               int              NOT NULL
+, party_id                 int              NOT NULL REFERENCES snapp_party(id)
+, PRIMARY KEY (list_id,list_index)
+);
+
+/* NULL convention -- see comment at start of snapp_tables.sql */
+CREATE TABLE snapp_protocol_states
+( id                               serial                         NOT NULL PRIMARY KEY
+, snarked_ledger_hash_id           int                            REFERENCES snarked_ledger_hashes(id)
+, snarked_next_available_token_id  int                            REFERENCES snapp_bounded_token_id(id)
+, timestamp_id                     int                            REFERENCES snapp_bounded_timestamp(id)
+, blockchain_length_id             int                            REFERENCES snapp_bounded_blockchain_length(id)
+, min_window_density_id            int                            REFERENCES snapp_bounded_blockchain_length(id)
+/* omitting 'last_vrf_output' for now, it's the unit value in OCaml */
+, total_currency_id                int                            REFERENCES snapp_bounded_amount(id)
+, curr_global_slot_since_hard_fork int                            REFERENCES snapp_bounded_global_slot(id)
+, global_slot_since_genesis        int                            REFERENCES snapp_bounded_global_slot(id)
+, staking_epoch_data_id            int                            REFERENCES snapp_epoch_data(id)
+, next_epoch_data                  int                            REFERENCES snapp_epoch_data(id)
+);
+
+/* snapp_other_parties_list_id refers to list_id in snapp_other_parties, not a foreign key */
+CREATE TABLE snapp_commands
+( id                            serial           PRIMARY KEY
+, snapp_fee_payer_id            int              NOT NULL REFERENCES snapp_fee_payers(id)
+, snapp_other_parties_list_id   int              NOT NULL
+, snapp_protocol_state_id       int              NOT NULL REFERENCES snapp_protocol_states(id)
+, hash                          text             NOT NULL UNIQUE
+);
+
 CREATE TABLE epoch_data
 ( id             serial PRIMARY KEY
 , seed           text   NOT NULL
@@ -87,12 +145,18 @@ CREATE INDEX idx_blocks_state_hash ON blocks(state_hash);
 CREATE INDEX idx_blocks_creator_id ON blocks(creator_id);
 CREATE INDEX idx_blocks_height     ON blocks(height);
 
+/* a balance is associated with a public key after a particular transaction
+   the token id is given by the transaction, but implicit in this table
+*/
 CREATE TABLE balances
 ( id            serial PRIMARY KEY
 , public_key_id int    NOT NULL REFERENCES public_keys(id)
 , balance       bigint NOT NULL
 );
 
+/* a join table between blocks and user_commands, with some additional information
+   sequence_no gives the order within all transactions in the block
+*/
 CREATE TABLE blocks_user_commands
 ( block_id        int NOT NULL REFERENCES blocks(id) ON DELETE CASCADE
 , user_command_id int NOT NULL REFERENCES user_commands(id) ON DELETE CASCADE
@@ -111,6 +175,9 @@ CREATE TABLE blocks_user_commands
 CREATE INDEX idx_blocks_user_commands_block_id ON blocks_user_commands(block_id);
 CREATE INDEX idx_blocks_user_commands_user_command_id ON blocks_user_commands(user_command_id);
 
+/* a join table between blocks and internal_commands, with some additional information
+   the pair sequence_no, secondary_sequence_no gives the order within all transactions in the block
+*/
 CREATE TABLE blocks_internal_commands
 ( block_id              int NOT NULL REFERENCES blocks(id) ON DELETE CASCADE
 , internal_command_id   int NOT NULL REFERENCES internal_commands(id) ON DELETE CASCADE
@@ -122,3 +189,28 @@ CREATE TABLE blocks_internal_commands
 
 CREATE INDEX idx_blocks_internal_commands_block_id ON blocks_internal_commands(block_id);
 CREATE INDEX idx_blocks_internal_commands_internal_command_id ON blocks_internal_commands(internal_command_id);
+
+/* in this file because reference to balances doesn't work if in snapp_tables.sql */
+CREATE TABLE snapp_party_balances
+( list_id                  int  NOT NULL
+, list_index               int  NOT NULL
+, balance_id               int  NOT NULL REFERENCES balances(id)
+);
+
+/* a join table between blocks and snapp_commands, with some additional information
+   sequence_no gives the order within all transactions in the block
+
+   other_parties_list_id refers to a list of balances in the same order as the other parties in the
+   snapps_command; that is, the list_index for the balances is the same as the list_index for other_parties
+*/
+CREATE TABLE blocks_snapp_commands
+( block_id                        int  NOT NULL REFERENCES blocks(id) ON DELETE CASCADE
+, snapp_command_id                int  NOT NULL REFERENCES snapp_commands(id) ON DELETE CASCADE
+, sequence_no                     int  NOT NULL
+, fee_payer_balance_id            int  NOT NULL REFERENCES balances(id)
+, other_parties_balances_list_id  int  NOT NULL
+, PRIMARY KEY (block_id, snapp_command_id, sequence_no)
+);
+
+CREATE INDEX idx_blocks_snapp_commands_block_id ON blocks_snapp_commands(block_id);
+CREATE INDEX idx_blocks_snapp_commands_snapp_command_id ON blocks_snapp_commands(snapp_command_id);

--- a/src/app/archive/drop_tables.sql
+++ b/src/app/archive/drop_tables.sql
@@ -1,14 +1,18 @@
+/* delete all relations and types from the archive database
+
+   it is not necessary to explicitly drop indexes, they're removed when dropping the relation
+    containing the indexed column
+*/
+
 drop table blocks_internal_commands;
 
 drop table blocks_user_commands;
 
+drop table blocks_snapp_commands;
+
+drop table snapp_party_balances;
+
 drop table balances;
-
-drop index idx_blocks_height;
-
-drop index idx_blocks_creator_id;
-
-drop index idx_blocks_state_hash;
 
 drop table blocks;
 
@@ -24,13 +28,65 @@ drop type user_command_type;
 
 drop type user_command_status;
 
-drop index idx_snarked_ledger_hashes_value;
+drop table snapp_commands;
+
+drop table snapp_other_parties;
+
+drop table snapp_party;
+
+drop table snapp_fee_payers;
+
+drop table snapp_party_predicated;
+
+drop table snapp_party_body;
+
+drop table snapp_updates;
+
+drop table snapp_protocol_states;
+
+drop table snapp_predicate;
+
+drop table snapp_predicate_account;
+
+drop table snapp_epoch_data;
+
+drop table snapp_epoch_ledger;
+
+drop table snapp_events;
+
+drop table snapp_permissions;
+
+drop table snapp_state_array;
+
+drop table snapp_states;
+
+drop table snapp_state_data;
+
+drop table snapp_timing_info;
+
+drop table snapp_verification_keys;
+
+drop table snapp_bounded_amount;
+
+drop table snapp_bounded_balance;
+
+drop table snapp_bounded_blockchain_length;
+
+drop table snapp_bounded_global_slot;
+
+drop table snapp_bounded_nonce;
+
+drop table snapp_bounded_timestamp;
+
+drop table snapp_bounded_token_id;
+
+drop type snapp_auth_required_type;
+
+drop type snapp_authorization_kind_type;
+
+drop type snapp_predicate_type;
 
 drop table snarked_ledger_hashes;
-
-drop index idx_public_keys_value;
-
-drop index idx_public_key_id;
 
 drop table timing_info;
 

--- a/src/app/archive/snapp_tables.sql
+++ b/src/app/archive/snapp_tables.sql
@@ -1,0 +1,210 @@
+/* snapp_tables.sql -- support tables for Snapp commands */
+
+/* Several of the tables below support the following convention, related
+   to NULL values.
+
+   In OCaml, some Snapp-related types use the constructors Check, which takes a value,
+   and Ignore, which is nullary. In columns following the convention, a NULL means Ignore, while
+   non-NULL means Check.
+
+   Similarly, in OCaml, there are the constructors Set, which takes a value, and
+   Keep, which is nullary. NULL means Set, and non-NULL means Keep.
+
+   The tables that follow this convention have a comment "NULL convention".
+*/
+
+/* the string representation of an algebraic field */
+CREATE TABLE snapp_state_data
+( id                       serial           PRIMARY KEY
+, field                    text             NOT NULL UNIQUE
+);
+
+/* Variable-width arrays of algebraic fields, given as
+   id's from snapp_state_data
+
+   Postgresql does not allow enforcing that these are
+   foreign keys.
+*/
+CREATE TABLE snapp_state_array
+( id                       serial  PRIMARY KEY
+, items                    int[]   NOT NULL
+);
+
+/* NULL convention */
+CREATE TABLE snapp_states
+( id                       serial           PRIMARY KEY
+, element_0_id             int              REFERENCES snapp_state_data(id)
+, element_1_id             int              REFERENCES snapp_state_data(id)
+, element_2_id             int              REFERENCES snapp_state_data(id)
+, element_3_id             int              REFERENCES snapp_state_data(id)
+, element_4_id             int              REFERENCES snapp_state_data(id)
+, element_5_id             int              REFERENCES snapp_state_data(id)
+, element_6_id             int              REFERENCES snapp_state_data(id)
+, element_7_id             int              REFERENCES snapp_state_data(id)
+);
+
+CREATE TABLE snapp_verification_keys
+( id                       serial           PRIMARY KEY
+, verification_key         text             NOT NULL UNIQUE
+, hash                     text             NOT NULL UNIQUE
+);
+
+CREATE TYPE snapp_auth_required_type AS ENUM ('none', 'either', 'proof', 'signature', 'both', 'impossible');
+
+CREATE TABLE snapp_permissions
+( id                       serial                PRIMARY KEY
+, stake                    boolean               NOT NULL
+, edit_state               snapp_auth_required_type    NOT NULL
+, send                     snapp_auth_required_type    NOT NULL
+, receive                  snapp_auth_required_type    NOT NULL
+, set_delegate             snapp_auth_required_type    NOT NULL
+, set_permissions          snapp_auth_required_type    NOT NULL
+, set_verification_key     snapp_auth_required_type    NOT NULL
+, set_snapp_uri            snapp_auth_required_type    NOT NULL
+, edit_rollup_state        snapp_auth_required_type    NOT NULL
+, set_token_symbol         snapp_auth_required_type    NOT NULL
+);
+
+CREATE TABLE snapp_timing_info
+( id                       serial  PRIMARY KEY
+, initial_minimum_balance  bigint  NOT NULL
+, cliff_time               bigint  NOT NULL
+, vesting_period           bigint  NOT NULL
+, vesting_increment        bigint  NOT NULL
+);
+
+/* NULL convention */
+CREATE TABLE snapp_updates
+( id                       serial           PRIMARY KEY
+, app_state_id             int              NOT NULL REFERENCES snapp_states(id)
+, delegate_id              int              REFERENCES public_keys(id)
+, verification_key_id      int              REFERENCES snapp_verification_keys(id)
+, permissions_id           int              REFERENCES snapp_permissions(id)
+, snapp_uri                text
+, token_symbol             varchar(6)
+, timing_id                int              REFERENCES snapp_timing_info(id)
+);
+
+/* in OCaml, events are a list of array of field elements
+   here, a list is given by an id, each contained array is given its
+    order within the list
+*/
+CREATE TABLE snapp_events
+( list_id                  int              NOT NULL
+, list_index               int              NOT NULL
+, state_array_id           int              NOT NULL REFERENCES snapp_state_array(id)
+, PRIMARY KEY (list_id,list_index)
+);
+
+/* events_list_id and rollup_events_list_id indicate a list_id in snapp_events, which
+   is not a key, since it appears as many times as there are list elements
+*/
+CREATE TABLE snapp_party_body
+( id                       serial           PRIMARY KEY
+, public_key_id            int              NOT NULL REFERENCES public_keys(id)
+, update_id                int              NOT NULL REFERENCES snapp_updates(id)
+, token_id                 bigint           NOT NULL
+, delta                    bigint           NOT NULL
+, events_list_id           int              NOT NULL
+, rollup_events_list_id    int              NOT NULL
+, call_data_id             int              NOT NULL REFERENCES snapp_state_data(id)
+, depth                    int              NOT NULL
+);
+
+CREATE TABLE snapp_bounded_balance
+( id                       serial           PRIMARY KEY
+, balance_lower_bound      bigint           NOT NULL
+, balance_upper_bound      bigint           NOT NULL
+);
+
+CREATE TABLE snapp_bounded_nonce
+( id                       serial           PRIMARY KEY
+, nonce_lower_bound        bigint           NOT NULL
+, nonce_upper_bound        bigint           NOT NULL
+);
+
+CREATE TYPE snapp_predicate_type AS ENUM ('full', 'nonce', 'accept');
+
+/* NULL convention */
+CREATE TABLE snapp_predicate_account
+( id                       serial                 PRIMARY KEY
+, balance_id               int                    REFERENCES snapp_bounded_balance(id)
+, nonce_id                 int                    REFERENCES snapp_bounded_nonce(id)
+, receipt_chain_hash       text
+, public_key_id            int                    REFERENCES public_keys(id)
+, delegate_id              int                    REFERENCES public_keys(id)
+, state_id                 int                    NOT NULL REFERENCES snapp_states(id)
+, rollup_state_id          int                    REFERENCES snapp_state_data(id)
+, proved_state             boolean
+);
+
+/* invariants: account id is not NULL iff kind is 'full'
+               nonce is not NULL iff kind is 'nonce'
+*/
+CREATE TABLE snapp_predicate
+( id               serial                 PRIMARY KEY
+, kind             snapp_predicate_type   NOT NULL
+, account_id       int                    REFERENCES snapp_predicate_account(id)
+, nonce            bigint
+);
+
+CREATE TABLE snapp_party_predicated
+( id               serial    PRIMARY KEY
+, body_id          int       NOT NULL REFERENCES snapp_party_body(id)
+, predicate_id     int       NOT NULL REFERENCES snapp_predicate(id)
+);
+
+CREATE TYPE snapp_authorization_kind_type AS ENUM ('proof','signature','none_given');
+
+CREATE TABLE snapp_bounded_token_id
+( id                       serial           PRIMARY KEY
+, token_id_lower_bound     bigint           NOT NULL
+, token_id_upper_bound     bigint           NOT NULL
+);
+
+CREATE TABLE snapp_bounded_timestamp
+( id                        serial           PRIMARY KEY
+, timestamp_lower_bound     bigint          NOT NULL
+, timestamp_upper_bound     bigint          NOT NULL
+);
+
+CREATE TABLE snapp_bounded_blockchain_length
+( id                                  serial          PRIMARY KEY
+, blockchain_length_lower_bound       bigint          NOT NULL
+, blockchain_length_upper_bound       bigint          NOT NULL
+);
+
+CREATE TABLE snapp_bounded_amount
+( id                       serial          PRIMARY KEY
+, amount_lower_bound       bigint          NOT NULL
+, amount_upper_bound       bigint          NOT NULL
+);
+
+CREATE TABLE snapp_bounded_global_slot
+( id                       serial          PRIMARY KEY
+, global_slot_lower_bound  bigint          NOT NULL
+, global_slot_upper_bound  bigint          NOT NULL
+);
+
+/* NULL convention */
+CREATE TABLE snapp_epoch_ledger
+( id                       serial          PRIMARY KEY
+, hash_id                  int             REFERENCES snarked_ledger_hashes(id)
+, total_currency_id        int             REFERENCES snapp_bounded_amount(id)
+);
+
+/* NULL convention */
+CREATE TABLE snapp_epoch_data
+( id                       serial          PRIMARY KEY
+, epoch_ledger_id          int             REFERENCES snapp_epoch_ledger(id)
+, epoch_seed               text
+, start_checkpoint         text
+, lock_checkpoint          text
+, epoch_length_id          int             REFERENCES snapp_bounded_blockchain_length(id)
+);
+
+CREATE TABLE snapp_party
+( id                       serial                          NOT NULL PRIMARY KEY
+, data_id                  int                             NOT NULL REFERENCES snapp_party_predicated(id)
+, authorization_kind       snapp_authorization_kind_type   NOT NULL
+);


### PR DESCRIPTION
Add Snapp commands to the archive data schema for Postgresql.

Because there are many tables, create a new file `snapps_tables.sql`, to avoid cluttering the main SQL file, `create_schema.sql`.

Updated `drop_tables.sql` to remove all types and relations. Indexes are removed implicitly.

Added some comments to the existing schema.

Tested by:
- importing the schema using `psql`, no errors
- running `drop_tables.sql`, confirming there were no remaining relations, types, indexes in the db

Items to carefully review:
- the encoding of Check/Ignore and Set/Keep using NULLs
- the encoding of lists (tables with a `list_id` column)
- using unenforced foreign keys in `snapp_state_array` (we could inline the fields instead)

Closes #9258.
