### PR TITLE
Rosetta: constrain pk curve type

### DIFF
--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -182,6 +182,12 @@ module Derive = struct
 
     let handle ~(env : Env.T(M).t) (req : Construction_derive_request.t) =
       let open M.Let_syntax in
+      let%bind () =
+        if String.equal req.public_key.curve_type "pallas" then
+          M.return ()
+        else
+          M.fail (Errors.create `Invalid_curve_type)
+      in
       let%bind pk =
         let pk_or_error =
           try Ok (Rosetta_coding.Coding.to_public_key req.public_key.hex_bytes)

--- a/src/lib/rosetta_lib/errors.ml
+++ b/src/lib/rosetta_lib/errors.ml
@@ -32,6 +32,7 @@ module Variant = struct
     | `Operations_not_valid of Partial_reason.t list
     | `Unsupported_operation_for_construction
     | `Signature_missing
+    | `Invalid_curve_type
     | `Public_key_format_not_valid
     | `No_options_provided
     | `Exception of string
@@ -91,6 +92,8 @@ end = struct
         "Malformed public key"
     | `Operations_not_valid _ ->
         "Cannot convert operations to valid transaction"
+    | `Invalid_curve_type ->
+        "Invalid curve type"
     | `Public_key_format_not_valid ->
         "Invalid public key format"
     | `Unsupported_operation_for_construction ->
@@ -155,6 +158,8 @@ end = struct
              !"Cannot recover transaction for the following reasons: %{sexp: \
                Partial_reason.t list}"
              reasons)
+    | `Invalid_curve_type ->
+        None
     | `Public_key_format_not_valid ->
         None
     | `Unsupported_operation_for_construction ->
@@ -194,6 +199,8 @@ end = struct
     | `Malformed_public_key ->
         false
     | `Operations_not_valid _ ->
+        false
+    | `Invalid_curve_type ->
         false
     | `Public_key_format_not_valid ->
         false
@@ -238,6 +245,8 @@ end = struct
         "The public key you provided was malformed."
     | `Operations_not_valid _ ->
         "We could not convert those operations to a valid transaction."
+    | `Invalid_curve_type ->
+        "The curve type you provided is not valid."
     | `Public_key_format_not_valid ->
         "The public key you provided had an invalid format."
     | `Unsupported_operation_for_construction ->


### PR DESCRIPTION
Made the Rosetta `/construction/derive` API to return an error if the curve type is not set to `"pallas"`