### PR TITLE
Add account creation fee on inequality

### DIFF
--- a/scripts/archive/internal-command-account-fees.sh
+++ b/scripts/archive/internal-command-account-fees.sh
@@ -18,7 +18,7 @@ INNER JOIN internal_commands as ic
 ON bic.internal_command_id = ic.id
 INNER JOIN balances
 ON bic.receiver_balance = balances.id
-WHERE balances.balance = ic.fee - 1000000000
+WHERE balances.balance <= ic.fee - 1000000000
 EOF
 
 while read -r block_id internal_command_id sequence_no secondary_sequence_no; do

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1175,8 +1175,9 @@ module Block = struct
           let account_creation_fee_uint64 = Currency.Fee.to_uint64
               constraint_constants.account_creation_fee
           in
-          if Unsigned.UInt64.equal balance_uint64
-              (Unsigned.UInt64.sub fee_uint64 account_creation_fee_uint64) then
+          if Unsigned.UInt64.compare balance_uint64
+              (Unsigned.UInt64.sub fee_uint64 account_creation_fee_uint64) <= 0
+          then
             Some (Unsigned.UInt64.to_int64 account_creation_fee_uint64)
           else
             None


### PR DESCRIPTION
We were adding an account creation fee for internal commands to the archive db when the resulting balance was the command fee minus the account creation fee.

For coinbases with an associated fee transfer, the resulting balance also subtracts the fee transfer amount.

So, instead of adding the fee if the balance is equal to the transaction amount minus the creation fee, add it when the balance is less than or equal to that difference.

Make this change for:
- the patch script `internal-command-account-fees.sh`
- the archive db processor

Tested the script on a dump of the devnet db.