### PR TITLE
Guard against underflow when checking acct creation fee

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1175,7 +1175,9 @@ module Block = struct
           let account_creation_fee_uint64 = Currency.Fee.to_uint64
               constraint_constants.account_creation_fee
           in
-          if Unsigned.UInt64.compare balance_uint64
+          (* first comparison guards against underflow in subtraction *)
+          if Unsigned.UInt64.compare fee_uint64 account_creation_fee_uint64 >= 0 &&
+             Unsigned.UInt64.compare balance_uint64
               (Unsigned.UInt64.sub fee_uint64 account_creation_fee_uint64) <= 0
           then
             Some (Unsigned.UInt64.to_int64 account_creation_fee_uint64)


### PR DESCRIPTION
The archive processor was putting in account creation fees for internal commands in some cases when it should not have done. The issue was that an underflow in `Unsigned.UInt64` created a large number than gave a "false positive" in a comparison.

Add a guard to see if there might be an underflow.

Tested by putting in numbers appearing in devnet that caused such an underflow (a fee of `392905756`, which is less than the acct creation fee of 1 Mina, and a balance of `462183034057832`). Those numbers gave the false positive, putting in the guard gives the right result.