### PR TITLE
Consider fee transfer via coinbase for creation fee

### DIFF
--- a/scripts/archive/internal-command-account-fees.sh
+++ b/scripts/archive/internal-command-account-fees.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-# add account creation fee to blocks_internal_commands for internal commands, where the balance is the command amount minus 1 Mina
+# add account creation fee of 1 Mina to blocks_internal_commands for internal commands, where
+# the balance is the command amount minus 1 Mina
 
 ARCHIVE=archive
-TMPFILE=$(mktemp -t coinbase-acct-fee.XXXXX)
+TMPFILE=$(mktemp -t internal-cmd-acct-fee.XXXXX)
 
 psql $ARCHIVE <<EOF
 ALTER TABLE blocks_internal_commands
@@ -18,12 +19,34 @@ INNER JOIN internal_commands as ic
 ON bic.internal_command_id = ic.id
 INNER JOIN balances
 ON bic.receiver_balance = balances.id
-WHERE balances.balance <= ic.fee - 1000000000
+WHERE balances.balance = ic.fee - 1000000000
+EOF
+
+# if a coinbase has an associated fee transfer, add account creation fee if
+# the balance is coinbase amount minus 1 Mina, minus the amount of the fee transfer
+# an associated fee transfer is in the same block with the same sequence number as the coinbase
+psql $ARCHIVE <<EOF | awk -F \| '(NR > 2){print $1 $2 $3 $4}' | head -n -2 >> $TMPFILE
+SELECT bic_coinbase.block_id, bic_coinbase.internal_command_id, bic_coinbase.sequence_no, bic_coinbase.secondary_sequence_no
+FROM blocks_internal_commands AS bic_coinbase
+INNER JOIN internal_commands AS ic_coinbase
+ON bic_coinbase.internal_command_id = ic_coinbase.id
+INNER JOIN blocks_internal_commands AS bic_fee_transfer
+ON bic_coinbase.block_id = bic_fee_transfer.block_id
+AND bic_coinbase.sequence_no = bic_fee_transfer.sequence_no
+INNER JOIN internal_commands AS ic_fee_transfer
+ON ic_fee_transfer.id = bic_fee_transfer.internal_command_id
+INNER JOIN balances
+ON bic_coinbase.receiver_balance = balances.id
+WHERE ic_coinbase.type = 'coinbase'
+AND balances.balance = ic_coinbase.fee - 1000000000 - ic_fee_transfer.fee
 EOF
 
 while read -r block_id internal_command_id sequence_no secondary_sequence_no; do
     psql $ARCHIVE <<EOF
     UPDATE blocks_internal_commands SET receiver_account_creation_fee_paid = 1000000000
-    WHERE block_id=$block_id AND internal_command_id=$internal_command_id AND sequence_no=$sequence_no AND secondary_sequence_no=$secondary_sequence_no
+    WHERE block_id=$block_id
+    AND internal_command_id=$internal_command_id
+    AND sequence_no=$sequence_no
+    AND secondary_sequence_no=$secondary_sequence_no
 EOF
 done < $TMPFILE

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1164,7 +1164,7 @@ module Block = struct
           | Error e ->
               Error.raise (Staged_ledger.Pre_diff_info.Error.to_error e)
         in
-        let account_creation_fee_of_fee_and_balance fee balance =
+        let account_creation_fee_of_fees_and_balance ?(additional_fee=None) fee balance =
           (* TODO: add transaction statuses to internal commands
              the archive lib should not know the details of
              account creation fees; the calculation below is
@@ -1175,9 +1175,21 @@ module Block = struct
           let account_creation_fee_uint64 = Currency.Fee.to_uint64
               constraint_constants.account_creation_fee
           in
-          if Unsigned.UInt64.compare balance_uint64
-              (Unsigned.UInt64.sub fee_uint64 account_creation_fee_uint64) <= 0
-          then
+          (* for coinbases, an associated fee transfer may reduce
+             the amount given to the coinbase receiver beyond
+             the account creation fee
+          *)
+          let creation_deduction_uint64 =
+            match additional_fee with
+            | None -> account_creation_fee_uint64
+            | Some fee' ->
+              Unsigned.UInt64.add (Currency.Fee.to_uint64 fee')
+                account_creation_fee_uint64
+          in
+          (* first compare guards against underflow in subtraction *)
+          if Unsigned.UInt64.compare fee_uint64 creation_deduction_uint64 >= 0 &&
+             Unsigned.UInt64.equal balance_uint64
+               (Unsigned.UInt64.sub fee_uint64 creation_deduction_uint64) then
             Some (Unsigned.UInt64.to_int64 account_creation_fee_uint64)
           else
             None
@@ -1265,7 +1277,7 @@ module Block = struct
                           ~public_key_id:receiver_id ~balance
                       in
                       let receiver_account_creation_fee_paid =
-                        account_creation_fee_of_fee_and_balance fee balance
+                        account_creation_fee_of_fees_and_balance fee balance
                       in
                       Block_and_internal_command.add
                         (module Conn)
@@ -1281,10 +1293,10 @@ module Block = struct
                   Transaction_status.Coinbase_balance_data.of_balance_data_exn
                     (Transaction_status.balance_data status)
                 in
-                let%bind () =
+                let%bind additional_fee =
                   match Mina_base.Coinbase.fee_transfer coinbase with
                   | None ->
-                      return ()
+                      return None
                   | Some {receiver_pk; fee} ->
                       let fee_transfer =
                         Mina_base.Fee_transfer.Single.create ~receiver_pk ~fee
@@ -1310,15 +1322,16 @@ module Block = struct
                           ~balance
                       in
                       let receiver_account_creation_fee_paid =
-                        account_creation_fee_of_fee_and_balance fee balance
+                        account_creation_fee_of_fees_and_balance fee balance
                       in
-                      Block_and_internal_command.add
+                      let%bind () = Block_and_internal_command.add
                         (module Conn)
                         ~block_id ~internal_command_id:id ~sequence_no
                         ~secondary_sequence_no:0
                         ~receiver_account_creation_fee_paid
                         ~receiver_balance_id
-                      >>| ignore
+                      in
+                      return (Some fee)
                 in
                 let%bind id =
                   Coinbase.add_if_doesn't_exist (module Conn) coinbase
@@ -1335,8 +1348,9 @@ module Block = struct
                     ~balance:balances.coinbase_receiver_balance
                 in
                 let receiver_account_creation_fee_paid =
-                  account_creation_fee_of_fee_and_balance
-                    (Currency.Amount.to_fee coinbase.amount) balances.coinbase_receiver_balance
+                  account_creation_fee_of_fees_and_balance ~additional_fee
+                    (Currency.Amount.to_fee coinbase.amount)
+                    balances.coinbase_receiver_balance
                 in
                 let%map () =
                   Block_and_internal_command.add


### PR DESCRIPTION
Consider the fee transfer associated with a coinbase when adding a creation fee for an internal command.

That had also been the goal of the closed #9616. That PR added the fee transfer amount to the creation fee, to aid Rosetta, but it turns out Rosetta was already accounting for that amount.

Compared to that PR, we add a guard in the calculation to prevent an underflow in unsigned subtraction.

The code that this replaces (from #9620) used an inequality, rather than equality, to compare a balance. That gets all the desired cases, but it also put in a creation fee incorrectly in some cases.

Add a case in the patch script for coinbases with associated fee transfers. 

Tested the script against a dump of the mainnet archive. (I took a count of the non-NULL creation fees, set all the creation fees to NULL, then ran the script. Then there was one more non-NULL creation fee than before, corresponding to the one case I had found where a coinbase with a fee transfer created an account.)
