### PR TITLE
Check that other txn is fee transfer via coinbase

### DIFF
--- a/scripts/archive/internal-command-account-fees.sh
+++ b/scripts/archive/internal-command-account-fees.sh
@@ -38,6 +38,7 @@ ON ic_fee_transfer.id = bic_fee_transfer.internal_command_id
 INNER JOIN balances
 ON bic_coinbase.receiver_balance = balances.id
 WHERE ic_coinbase.type = 'coinbase'
+AND ic_fee_transfer.type = 'fee_transfer_via_coinbase'
 AND balances.balance = ic_coinbase.fee - 1000000000 - ic_fee_transfer.fee
 EOF
 

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1164,7 +1164,7 @@ module Block = struct
           | Error e ->
               Error.raise (Staged_ledger.Pre_diff_info.Error.to_error e)
         in
-        let account_creation_fee_of_fees_and_balance ?(additional_fee=None) fee balance =
+        let account_creation_fee_of_fees_and_balance ?additional_fee fee balance =
           (* TODO: add transaction statuses to internal commands
              the archive lib should not know the details of
              account creation fees; the calculation below is
@@ -1348,7 +1348,7 @@ module Block = struct
                     ~balance:balances.coinbase_receiver_balance
                 in
                 let receiver_account_creation_fee_paid =
-                  account_creation_fee_of_fees_and_balance ~additional_fee
+                  account_creation_fee_of_fees_and_balance ?additional_fee
                     (Currency.Amount.to_fee coinbase.amount)
                     balances.coinbase_receiver_balance
                 in


### PR DESCRIPTION
The patch script changes in #9636 did not mention that the transactions joined with a `coinbase` transaction must be a `fee_transfer_via_coinbase`, so the coinbase could be joined with itself. Add that restriction. 

(The self-join won't produce a bogus creation fee, because the balance would be compared with coinbase_fee - 1 Mina - coinbase_fee, which is negative, and balances are always nonnegative. But it's saner to not do the comparison.)

Also, no need to give an OCaml default with the `?` syntax, the default is already `None`.