### PR TITLE
Upgrade snarky to support 'public outputs' for circuits

### DIFF
--- a/src/lib/marlin_plonk_bindings/pasta_fp/vector/marlin_plonk_bindings_pasta_fp_vector.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fp/vector/marlin_plonk_bindings_pasta_fp_vector.ml
@@ -9,3 +9,5 @@ external length : t -> int = "caml_pasta_fp_vector_length"
 external emplace_back : t -> elt -> unit = "caml_pasta_fp_vector_emplace_back"
 
 external get : t -> int -> elt = "caml_pasta_fp_vector_get"
+
+external set : t -> int -> elt -> unit = "caml_pasta_fp_vector_set"

--- a/src/lib/marlin_plonk_bindings/pasta_fq/vector/marlin_plonk_bindings_pasta_fq_vector.ml
+++ b/src/lib/marlin_plonk_bindings/pasta_fq/vector/marlin_plonk_bindings_pasta_fq_vector.ml
@@ -9,3 +9,5 @@ external length : t -> int = "caml_pasta_fq_vector_length"
 external emplace_back : t -> elt -> unit = "caml_pasta_fq_vector_emplace_back"
 
 external get : t -> int -> elt = "caml_pasta_fq_vector_get"
+
+external set : t -> int -> elt -> unit = "caml_pasta_fq_vector_set"

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_vector.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fp_vector.rs
@@ -30,3 +30,12 @@ pub fn caml_pasta_fp_vector_get(
             .unwrap()),
     }
 }
+
+#[ocaml::func]
+pub fn caml_pasta_fp_vector_set(
+    mut v: CamlPastaFpVector,
+    i: ocaml::Int,
+    x: Fp,
+) {
+    v[i as usize] = x
+}

--- a/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_vector.rs
+++ b/src/lib/marlin_plonk_bindings/stubs/src/pasta_fq_vector.rs
@@ -30,3 +30,12 @@ pub fn caml_pasta_fq_vector_get(
             .unwrap()),
     }
 }
+
+#[ocaml::func]
+pub fn caml_pasta_fq_vector_set(
+    mut v: CamlPastaFqVector,
+    i: ocaml::Int,
+    x: Fq,
+) {
+    v[i as usize] = x
+}

--- a/src/lib/mina_base/signed_command_memo.ml
+++ b/src/lib/mina_base/signed_command_memo.ml
@@ -229,8 +229,9 @@ let%test_module "user_command_memo" =
             assert false
       in
       let memo_var =
-        Snarky_backendless.Typ_monads.Store.run (typ.store memo) (fun x ->
-            Snarky_backendless.Cvar.Constant x)
+        Snarky_backendless.Typ_monads.Store.run (typ.store memo)
+          (fun x -> Snarky_backendless.Cvar.Constant x)
+          (fun () -> failwith "No delayed variables supported")
       in
       let memo_read =
         Snarky_backendless.Typ_monads.Read.run (typ.read memo_var) read_constant


### PR DESCRIPTION
This PR upgrades snarky to add a new `Typ.Internal.delayed` (o1-labs/snarky#599). This allows us to 'delay' providing a public input to a circuit -- providing `()` in its place -- and then generating the desired value within the circuit and back-filling it later.

This is an important dependency of SnarkyJS, allowing a snapp to 'return' the desired parties stack hash, rather than needing to know its full form before the snapp code has been run.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
