### PR TITLE
[Trivial] Remove core as a dependency of pickles

### DIFF
--- a/src/lib/pickles/cache.ml
+++ b/src/lib/pickles/cache.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 
 module Step = struct
   module Key = struct

--- a/src/lib/pickles/commitment_lengths.ml
+++ b/src/lib/pickles/commitment_lengths.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Pickles_types
 open Import
 

--- a/src/lib/pickles/dlog_main.ml
+++ b/src/lib/pickles/dlog_main.ml
@@ -90,17 +90,17 @@ struct
       as_prover
         As_prover.(
           fun () ->
-            Core.printf "in-snark: %s %!" lab ;
+            printf "in-snark: %s %!" lab ;
             Field.Constant.print (read_var x) ;
-            Core.printf ", %!" ;
+            printf ", %!" ;
             Field.Constant.print (read_var y) ;
-            Core.printf "\n%!")
+            printf "\n%!")
 
   let print_w lab gs =
     if debug then
       Array.iteri gs ~f:(fun i (fin, g) ->
           as_prover
-            As_prover.(fun () -> Core.printf "fin=%b %!" (read Boolean.typ fin)) ;
+            As_prover.(fun () -> printf "fin=%b %!" (read Boolean.typ fin)) ;
           ksprintf print_g "%s[%d]" lab i g)
 
   let print_chal lab x =
@@ -108,10 +108,10 @@ struct
       as_prover
         As_prover.(
           fun () ->
-            Core.printf "in-snark %s:%!" lab ;
+            printf "in-snark %s:%!" lab ;
             Field.Constant.print
               (Field.Constant.project (List.map ~f:(read Boolean.typ) x)) ;
-            Core.printf "\n%!")
+            printf "\n%!")
 
   let print_bool lab x =
     if debug then

--- a/src/lib/pickles/dummy.ml
+++ b/src/lib/pickles/dummy.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Pickles_types
 open Backend
 open Composition_types

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -67,7 +67,8 @@ let typ (type n avar aval m) (statement : (avar, aval) Impls.Step.Typ.t)
     (let lengths =
        Commitment_lengths.of_domains_vector step_domains
          ~max_degree:Common.Max_degree.step
-       |> Dlog_plonk_types.Evals.map ~f:(Vector.reduce_exn ~f:Core.Int.max)
+       |> Dlog_plonk_types.Evals.map
+            ~f:(Vector.reduce_exn ~f:Core_kernel.Int.max)
      in
      let t =
        Typ.tuple2

--- a/src/lib/pickles/plonk_curve_ops.ml
+++ b/src/lib/pickles/plonk_curve_ops.ml
@@ -119,6 +119,6 @@ struct
               G.Constant.scale g x)
             (random_point, xs)
         with e ->
-          Core.eprintf !"Input %{sexp: bool list}\n%!" xs ;
+          eprintf !"Input %{sexp: bool list}\n%!" xs ;
           raise e)
 end

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Pickles_types
 open Import
 open Types

--- a/src/lib/pickles/reduced_me_only.ml
+++ b/src/lib/pickles/reduced_me_only.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Import
 open Pickles_types
 open Types

--- a/src/lib/pickles/requests.ml
+++ b/src/lib/pickles/requests.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Import
 open Types
 open Pickles_types

--- a/src/lib/pickles/ro.ml
+++ b/src/lib/pickles/ro.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Backend
 open Pickles_types
 open Import

--- a/src/lib/pickles/scalar_challenge.ml
+++ b/src/lib/pickles/scalar_challenge.ml
@@ -173,7 +173,7 @@ let test (type f)
               (Scalar_challenge (Challenge.Constant.of_bits s)))
           xs
       with e ->
-        Core.eprintf !"Input %{sexp: bool list}\n%!" xs ;
+        eprintf !"Input %{sexp: bool list}\n%!" xs ;
         raise e)
 
 module Make
@@ -307,7 +307,7 @@ struct
               G.Constant.scale g x)
             (random_point, xs)
         with e ->
-          Core.eprintf !"Input %{sexp: bool list}\n%!" xs ;
+          eprintf !"Input %{sexp: bool list}\n%!" xs ;
           raise e)
 
   let endo_inv ((gx, gy) as g) chal =

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -1,5 +1,5 @@
 module SC = Scalar_challenge
-open Core
+open Core_kernel
 module P = Proof
 open Pickles_types
 open Poly_types

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Pickles_types
 open Hlist
 open Common

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -1,5 +1,5 @@
 module S = Sponge
-open Core
+open Core_kernel
 open Pickles_types
 open Common
 open Poly_types

--- a/src/lib/pickles/timer.ml
+++ b/src/lib/pickles/timer.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 
 let l = ref ""
 
@@ -15,7 +15,7 @@ let clock =
   Common.when_profiling
     (fun loc ->
       let t = Time.now () in
-      Core.printf "%s -> %s: %s\n%!" !l loc
+      printf "%s -> %s: %s\n%!" !l loc
         (Time.Span.to_string_hum (Time.diff t !r)) ;
       r := t ;
       l := loc)

--- a/src/lib/pickles/verification_key.ml
+++ b/src/lib/pickles/verification_key.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Pickles_types
 open Import
 open Zexe_backend.Pasta

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -1,5 +1,5 @@
 module SC = Scalar_challenge
-open Core
+open Core_kernel
 open Pickles_types
 open Common
 open Import

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -4,7 +4,7 @@ open Pickles_types
 open Hlist
 open Tuple_lib
 open Common
-open Core
+open Core_kernel
 open Import
 open Types
 open Backend

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -1,4 +1,4 @@
-open Core
+open Core_kernel
 open Pickles_types
 open Hlist
 open Common

--- a/src/lib/zexe_backend/dune
+++ b/src/lib/zexe_backend/dune
@@ -16,5 +16,5 @@
     snarky.backendless
     sponge
     snarkette
-    core
+    core_kernel
     integers ))


### PR DESCRIPTION
This PR replaces all uses of `Core` with `Core_kernel`.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them