### PR TITLE
Reformat

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -341,8 +341,8 @@ let setup_daemon logger =
       (optional (Arg_type.create Genesis_constants.Proof_level.of_string))
       ~doc:
         "full|check|none Internal, for testing. Start or connect to a network \
-         with full proving (full), snark-testing with dummy proofs (check), \
-         or dummy proofs (none)"
+         with full proving (full), snark-testing with dummy proofs (check), or \
+         dummy proofs (none)"
   and plugins = plugin_flag
   and precomputed_blocks_path =
     flag "--precomputed-blocks-file"


### PR DESCRIPTION
The format checker doesn't run correctly for PRs submitted by external contributors. This allowed a formatting error to slip in.

Merging this when that job passes CI; this is a no-op.