### PR TITLE
Accounts graphql null if no account exist

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1848,7 +1848,7 @@ let get_peers_graphql =
              printf "%s\n"
                (Network_peer.Peer.to_multiaddr_string
                   { host = Unix.Inet_addr.of_string peer#host
-                  ; libp2p_port = peer#libp2p_port
+                  ; libp2p_port = peer#libp2pPort
                   ; peer_id = peer#peerId
                   }))))
 
@@ -1905,7 +1905,7 @@ let add_peers_graphql =
              printf "%s\n"
                (Network_peer.Peer.to_multiaddr_string
                   { host = Unix.Inet_addr.of_string peer#host
-                  ; libp2p_port = peer#libp2p_port
+                  ; libp2p_port = peer#libp2pPort
                   ; peer_id = peer#peerId
                   }))))
 

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -316,7 +316,7 @@ module Get_peers =
 query get_peers {
   getPeers {
     host
-    libp2p_port
+    libp2pPort
     peerId
   }
 }
@@ -328,7 +328,7 @@ module Add_peers =
 mutation ($peers: [NetworkPeer!]!, $seed: Boolean) {
   addPeers(peers: $peers, seed: $seed) {
     host
-    libp2p_port
+    libp2pPort
     peerId
   }
 }


### PR DESCRIPTION
This needs a schema regeneration and the libp2pPort fix -- I'm having trouble running the schema regen still, hoping someone can help

---

Explain your changes:
* When we refactored the accounts graphql endpoint to take a tokenId too we broke the contract that it be null if we can't find the account. I don't consider this a backwards incompatible change because we're just fixing the code to match the documented functionality.
* Now, accounts is None if we can't get access to the breadcrumb (either because of bootstrapping or the account missing)
* This will cause the rosetta account/balance endpoint to behave properly


Explain how you tested your changes:
* Can't test without schema regeneration and libp2pPort fix
