### PR TITLE
Base58Check for verification keys

### DIFF
--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -52,6 +52,8 @@ let pending_coinbase_hash_builder : t = '\x19'
 
 let snapp_command : t = '\x1A'
 
+let verification_key : t = '\x1B'
+
 (** The following version bytes are non-sequential; existing
     user key infrastructure depends on them. don't change them!
 *)

--- a/src/lib/pickles/dune
+++ b/src/lib/pickles/dune
@@ -16,7 +16,9 @@
  (libraries
    digestif
    mina_version
+   base58_check
    base64
+   codable
    zexe_backend
    random_oracle_input
    pickles_base

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -168,6 +168,10 @@ module Stable = struct
 
     let to_latest = Fn.id
 
+    let description = "Verification key"
+
+    let version_byte = Base58_check.Version_bytes.verification_key
+
     include Binable.Of_binable
               (R.Stable.V1)
               (struct
@@ -219,6 +223,8 @@ module Stable = struct
               end)
   end
 end]
+
+include Codable.Make_base58_check (Stable.Latest)
 
 let dummy : t =
   { step_data = At_most.[]


### PR DESCRIPTION
Add Base58Check for `Pickles.Side_loaded_verification_key.t`.

This PR only adds Base58Check for the type `t`, equal to `Stable.Latest.t`. Do we want Base58Check for every version? The strategy in this PR is followed elsewhere in the code.

Closes #9256.
