### PR TITLE
Delegation backend: new storage structure

### DIFF
--- a/src/app/delegation_backend/README.md
+++ b/src/app/delegation_backend/README.md
@@ -56,15 +56,18 @@ Backend Service is a web server that exposes the following entrypoints:
 Cloud storage has the following structure:
 
 - `submissions`
-    - `<submitter>/<block_hash>/<created_at>.json`
-        - File contents:
-           - `submitted_at` with server's timestamp (of the time of submission)
-           - `remote_addr` with the `ip:port` address from which request has come
-           - `peer_id` (as in user's JSON submission)
-           - `snark_work` (optional, as in user's JSON submission)
-        - `<submitter>` is base58check-encoded submitter's public key
-        - `<created_at>` is UTC-based `RFC-3339` -encoded
-        - `<block_hash>` is base64check-encoded hash of a block
+    - `<submitted_at_date>/<submitted_at>-<submitter>.json`
+      - Path contents:
+        - `submitted_at_date` with server's date (of the time of submission) in format `YYYY-MM-DD`
+        - `submitted_at` with server's timestamp (of the time of submission) in RFC-3339
+        - `submitter` is base58check-encoded submitter's public key
+      - File contents:
+        - `remote_addr` with the `ip:port` address from which request has come
+        - `peer_id` (as in user's JSON submission)
+        - `snark_work` (optional, as in user's JSON submission)
+        - `submitter` is base58check-encoded submitter's public key
+        - `created_at` is UTC-based `RFC-3339` -encoded
+        - `block_hash` is base64check-encoded hash of a block
 - `blocks`
     - `<block-hash>.dat`
         - Contains raw block

--- a/src/app/delegation_backend/README.md
+++ b/src/app/delegation_backend/README.md
@@ -22,7 +22,7 @@ Backend Service is a web server that exposes the following entrypoints:
 
     ```json
     { "data":
-       { "peer_id": "<base64-encoded peer id of the node from libp2p library>"
+       { "peer_id": "<base58-encoded peer id of the node from libp2p library>"
        , "block": "<base64-encoded bytes of the latest known block>"
        , "created_at": "<current time>"
 
@@ -67,7 +67,7 @@ Cloud storage has the following structure:
         - `snark_work` (optional, as in user's JSON submission)
         - `submitter` is base58check-encoded submitter's public key
         - `created_at` is UTC-based `RFC-3339` -encoded
-        - `block_hash` is base64check-encoded hash of a block
+        - `block_hash` is base58check-encoded hash of a block
 - `blocks`
     - `<block-hash>.dat`
         - Contains raw block

--- a/src/app/delegation_backend/src/constants.go
+++ b/src/app/delegation_backend/src/constants.go
@@ -11,8 +11,10 @@ const DELEGATION_WHITELIST_LIST = "Form Responses 1"
 const DELEGATION_WHITELIST_COLUMN = "E"
 
 // Production
-const DELEGATION_WHITELIST_SPREADSHEET_ID = "1xiKppb0BFUo8IKM2itIx2EWIQbBzUlFxgtZlKdnrLCU"
-const CLOUD_BUCKET_NAME = "foundation-delegation-snark-work"
+// const DELEGATION_WHITELIST_SPREADSHEET_ID = "1xiKppb0BFUo8IKM2itIx2EWIQbBzUlFxgtZlKdnrLCU"
+// const CLOUD_BUCKET_NAME = "foundation-delegation-snark-work"
+const DELEGATION_WHITELIST_SPREADSHEET_ID = "1NODwwcVxLNnCI4XnIrGdGBSjointN4MZ8QZ7wqgtSTQ"
+const CLOUD_BUCKET_NAME = "georgeee-delegation-test-1"
 
 var PK_PREFIX = [...]byte{1, 1}
 var SIG_PREFIX = [...]byte{1}

--- a/src/app/delegation_backend/src/constants.go
+++ b/src/app/delegation_backend/src/constants.go
@@ -1,6 +1,9 @@
 package delegation_backend
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
 const MAX_SUBMIT_PAYLOAD_SIZE = 50000000 // max payload size in bytes
 const REQUESTS_PER_PK_HOURLY = 120
@@ -11,10 +14,27 @@ const DELEGATION_WHITELIST_LIST = "Form Responses 1"
 const DELEGATION_WHITELIST_COLUMN = "E"
 
 // Production
-// const DELEGATION_WHITELIST_SPREADSHEET_ID = "1xiKppb0BFUo8IKM2itIx2EWIQbBzUlFxgtZlKdnrLCU"
-// const CLOUD_BUCKET_NAME = "foundation-delegation-snark-work"
-const DELEGATION_WHITELIST_SPREADSHEET_ID = "1NODwwcVxLNnCI4XnIrGdGBSjointN4MZ8QZ7wqgtSTQ"
-const CLOUD_BUCKET_NAME = "georgeee-delegation-test-1"
+const PROD_WHITELIST_SPREADSHEET_ID = "1xiKppb0BFUo8IKM2itIx2EWIQbBzUlFxgtZlKdnrLCU"
+const PROD_CLOUD_BUCKET_NAME = "foundation-delegation-snark-work"
+
+const TEST_WHITELIST_SPREADSHEET_ID = "1NODwwcVxLNnCI4XnIrGdGBSjointN4MZ8QZ7wqgtSTQ"
+const TEST_CLOUD_BUCKET_NAME = "georgeee-delegation-test-1"
+
+func CloudBucketName() string {
+	if os.Getenv("TEST") == "" {
+		return PROD_CLOUD_BUCKET_NAME
+	} else {
+		return TEST_CLOUD_BUCKET_NAME
+	}
+}
+
+func WhitelistSpreadsheetId() string {
+	if os.Getenv("TEST") == "" {
+		return PROD_WHITELIST_SPREADSHEET_ID
+	} else {
+		return TEST_WHITELIST_SPREADSHEET_ID
+	}
+}
 
 var PK_PREFIX = [...]byte{1, 1}
 var SIG_PREFIX = [...]byte{1}

--- a/src/app/delegation_backend/src/constants.go
+++ b/src/app/delegation_backend/src/constants.go
@@ -38,11 +38,13 @@ func WhitelistSpreadsheetId() string {
 
 var PK_PREFIX = [...]byte{1, 1}
 var SIG_PREFIX = [...]byte{1}
+var BLOCK_HASH_PREFIX = [...]byte{1}
 
 const NETWORK_ID = 1  // mainnet
 const PK_LENGTH = 33  // one field element (32B) + 1 bit (encoded as full byte)
 const SIG_LENGTH = 64 // one field element (32B) and one scalar (32B)
 
+// we use state hash code here, although it's not state hash
 const BASE58CHECK_VERSION_BLOCK_HASH byte = 0x10
 const BASE58CHECK_VERSION_PK byte = 0xCB
 const BASE58CHECK_VERSION_SIG byte = 0x9A

--- a/src/app/delegation_backend/src/constants.go
+++ b/src/app/delegation_backend/src/constants.go
@@ -15,7 +15,7 @@ const DELEGATION_WHITELIST_COLUMN = "E"
 
 // Production
 const PROD_WHITELIST_SPREADSHEET_ID = "1xiKppb0BFUo8IKM2itIx2EWIQbBzUlFxgtZlKdnrLCU"
-const PROD_CLOUD_BUCKET_NAME = "foundation-delegation-snark-work"
+const PROD_CLOUD_BUCKET_NAME = "foundation-delegation-uptime-data"
 
 const TEST_WHITELIST_SPREADSHEET_ID = "1NODwwcVxLNnCI4XnIrGdGBSjointN4MZ8QZ7wqgtSTQ"
 const TEST_CLOUD_BUCKET_NAME = "georgeee-delegation-test-1"

--- a/src/app/delegation_backend/src/constants.go
+++ b/src/app/delegation_backend/src/constants.go
@@ -15,7 +15,7 @@ const DELEGATION_WHITELIST_COLUMN = "E"
 
 // Production
 const PROD_WHITELIST_SPREADSHEET_ID = "1xiKppb0BFUo8IKM2itIx2EWIQbBzUlFxgtZlKdnrLCU"
-const PROD_CLOUD_BUCKET_NAME = "foundation-delegation-uptime-data"
+const PROD_CLOUD_BUCKET_NAME = "foundation-delegation-uptime"
 
 const TEST_WHITELIST_SPREADSHEET_ID = "1NODwwcVxLNnCI4XnIrGdGBSjointN4MZ8QZ7wqgtSTQ"
 const TEST_CLOUD_BUCKET_NAME = "georgeee-delegation-test-1"

--- a/src/app/delegation_backend/src/data.go
+++ b/src/app/delegation_backend/src/data.go
@@ -77,14 +77,14 @@ func (pk *Pk) UnmarshalJSON(b []byte) error {
 	}
 	return err
 }
-func (d Pk) MarshalJSON() ([]byte, error) {
-	return json.Marshal(base58.CheckEncode(append(PK_PREFIX[:], d[:]...), BASE58CHECK_VERSION_PK))
+func (pk Pk) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pk.String())
 }
 func (pk Pk) Format() string {
 	return pk.String()
 }
 func (pk Pk) String() string {
-	return base58.CheckEncode(pk[:], BASE58CHECK_VERSION_PK)
+	return base58.CheckEncode(append(PK_PREFIX[:], pk[:]...), BASE58CHECK_VERSION_PK)
 }
 
 type Base64 struct {
@@ -143,6 +143,6 @@ type MetaToBeSaved struct {
 	PeerId     string  `json:"peer_id"`
 	SnarkWork  *Base64 `json:"snark_work,omitempty"`
 	RemoteAddr string  `json:"remote_addr"`
-	Submitter  string  `json:"submitter"`  // is base58check-encoded submitter's public key
-	BlockHash  string  `json:"block_hash"` // is base64check-encoded hash of a block
+	Submitter  Pk      `json:"submitter"`  // is base58check-encoded submitter's public key
+	BlockHash  string  `json:"block_hash"` // is base58check-encoded hash of a block
 }

--- a/src/app/delegation_backend/src/data.go
+++ b/src/app/delegation_backend/src/data.go
@@ -6,8 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/btcsuite/btcutil/base58"
 	"time"
+
+	"github.com/btcsuite/btcutil/base58"
 )
 
 // Just a different interface for Unmarshal
@@ -18,7 +19,7 @@ func JSONToString(b []byte) (s string, err error) {
 func StringToPk(pk *Pk, s string) error {
 	bs, ver, err := base58.CheckDecode(s)
 	if err == nil && ver != BASE58CHECK_VERSION_PK {
-		return errors.New("Unexpected base58check version for Pk")
+		return errors.New("unexpected base58check version for Pk")
 	}
 	if err == nil {
 		prefixLen := len(PK_PREFIX)
@@ -26,10 +27,10 @@ func StringToPk(pk *Pk, s string) error {
 			if bytes.Equal(bs[:prefixLen], PK_PREFIX[:]) {
 				copy(pk[:], bs[prefixLen:])
 			} else {
-				err = errors.New("Unexpected prefix of Pk")
+				err = errors.New("unexpected prefix of Pk")
 			}
 		} else {
-			err = errors.New(fmt.Sprintf("Public key of an unexpected size %d", len(bs)))
+			err = fmt.Errorf("public key of an unexpected size %d", len(bs))
 		}
 	}
 	return err
@@ -37,7 +38,7 @@ func StringToPk(pk *Pk, s string) error {
 func StringToSig(sig *Sig, s string) error {
 	bs, ver, err := base58.CheckDecode(s)
 	if err == nil && ver != BASE58CHECK_VERSION_SIG {
-		return errors.New("Unexpected base58check version for Sig")
+		return errors.New("unexpected base58check version for Sig")
 	}
 	if err == nil {
 		prefixLen := len(SIG_PREFIX)
@@ -45,10 +46,10 @@ func StringToSig(sig *Sig, s string) error {
 			if bytes.Equal(bs[:prefixLen], SIG_PREFIX[:]) {
 				copy(sig[:], bs[prefixLen:])
 			} else {
-				err = errors.New("Unexpected prefix of signature")
+				err = errors.New("unexpected prefix of signature")
 			}
 		} else {
-			err = errors.New(fmt.Sprintf("Signature of an unexpected size %d", len(bs)))
+			err = fmt.Errorf("signature of an unexpected size %d", len(bs))
 		}
 	}
 	return err
@@ -127,7 +128,7 @@ func (boe *BufferOrError) Write(b []byte) {
 }
 
 type submitRequestData struct {
-	PeerId    *Base64   `json:"peer_id"`
+	PeerId    string    `json:"peer_id"`
 	Block     *Base64   `json:"block"`
 	SnarkWork *Base64   `json:"snark_work,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
@@ -137,9 +138,11 @@ type submitRequest struct {
 	Submitter Pk                `json:"submitter"`
 	Sig       Sig               `json:"signature"`
 }
-type metaToBeSaved struct {
-	SubmittedAt time.Time `json:"submitted_at"`
-	PeerId      *Base64   `json:"peer_id"`
-	SnarkWork   *Base64   `json:"snark_work,omitempty"`
-	RemoteAddr  string    `json:"remote_addr"`
+type MetaToBeSaved struct {
+	CreatedAt  string  `json:"created_at"`
+	PeerId     string  `json:"peer_id"`
+	SnarkWork  *Base64 `json:"snark_work,omitempty"`
+	RemoteAddr string  `json:"remote_addr"`
+	Submitter  string  `json:"submitter"`  // is base58check-encoded submitter's public key
+	BlockHash  string  `json:"block_hash"` // is base64check-encoded hash of a block
 }

--- a/src/app/delegation_backend/src/delegation_backend/main.go
+++ b/src/app/delegation_backend/src/delegation_backend/main.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"cloud.google.com/go/storage"
 	"context"
 	. "delegation_backend"
+	"net/http"
+	"time"
+
+	"cloud.google.com/go/storage"
 	logging "github.com/ipfs/go-log/v2"
 	"google.golang.org/api/option"
 	sheets "google.golang.org/api/sheets/v4"
-	"net/http"
-	"time"
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 		log.Fatalf("Error creating Cloud client: %v", err1)
 		return
 	}
-	gctx := GoogleContext{client.Bucket(CLOUD_BUCKET_NAME), ctx, log}
+	gctx := GoogleContext{Bucket: client.Bucket(CLOUD_BUCKET_NAME), Context: ctx, Log: log}
 	app.Save = func(objs ObjectsToSave) {
 		gctx.GoogleStorageSave(objs)
 	}

--- a/src/app/delegation_backend/src/delegation_backend/main.go
+++ b/src/app/delegation_backend/src/delegation_backend/main.go
@@ -33,7 +33,7 @@ func main() {
 		log.Fatalf("Error creating Cloud client: %v", err1)
 		return
 	}
-	gctx := GoogleContext{Bucket: client.Bucket(CLOUD_BUCKET_NAME), Context: ctx, Log: log}
+	gctx := GoogleContext{Bucket: client.Bucket(CloudBucketName()), Context: ctx, Log: log}
 	app.Save = func(objs ObjectsToSave) {
 		gctx.GoogleStorageSave(objs)
 	}

--- a/src/app/delegation_backend/src/delegation_backend/main.go
+++ b/src/app/delegation_backend/src/delegation_backend/main.go
@@ -27,6 +27,9 @@ func main() {
 
 	app := new(App)
 	app.Log = log
+	http.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+		_, _ = rw.Write([]byte("delegation backend service"))
+	})
 	http.Handle("/v1/submit", app.NewSubmitH())
 	client, err1 := storage.NewClient(ctx)
 	if err1 != nil {

--- a/src/app/delegation_backend/src/delegation_backend_migrate/main.go
+++ b/src/app/delegation_backend/src/delegation_backend_migrate/main.go
@@ -1,0 +1,95 @@
+package main
+
+// This utility migrates from old bucket format to the new one
+
+import (
+	"context"
+	. "delegation_backend"
+	"encoding/json"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	logging "github.com/ipfs/go-log/v2"
+	"google.golang.org/api/iterator"
+)
+
+type oldMeta struct {
+	SubmittedAt string  `json:"submitted_at"`
+	PeerId      string  `json:"peer_id"`
+	SnarkWork   *Base64 `json:"snark_work,omitempty"`
+	RemoteAddr  string  `json:"remote_addr"`
+}
+
+func main() {
+	logging.SetupLogging(logging.Config{
+		Format: logging.JSONOutput,
+		Stderr: true,
+		Stdout: false,
+		Level:  logging.LevelDebug,
+		File:   "",
+	})
+	log := logging.Logger("delegation backend")
+	log.Infof("delegation backend has the following logging subsystems active: %v", logging.GetSubsystems())
+
+	ctx := context.Background()
+
+	client, err1 := storage.NewClient(ctx)
+	if err1 != nil {
+		log.Fatalf("Error creating Cloud client: %v", err1)
+		return
+	}
+	gctx := GoogleContext{Bucket: client.Bucket(CloudBucketName()), Context: ctx, Log: log}
+	prefix := "submissions/"
+	suffix := ".json"
+	q := storage.Query{Prefix: prefix}
+	lst := gctx.Bucket.Objects(ctx, &q)
+	objAttrs, err := lst.Next()
+	for ; err == nil; objAttrs, err = lst.Next() {
+		fullName := objAttrs.Name
+		var parts []string
+		if strings.HasSuffix(fullName, suffix) {
+			name := fullName[:len(fullName)-len(suffix)][len(prefix):]
+			parts = strings.Split(name, "/")
+		}
+		if len(parts) != 3 {
+			log.Warn("Malformed submission name: %s", fullName)
+			continue
+		}
+		log.Debug("Processing %s", fullName)
+		pkStr := parts[0]
+		blockHashStr := parts[1]
+		createdAtStr := parts[2]
+		var oldMeta oldMeta
+		{
+			reader, err := gctx.Bucket.Object(fullName).NewReader(ctx)
+			if err == nil {
+				decoder := json.NewDecoder(reader)
+				err = decoder.Decode(&oldMeta)
+			}
+			if err != nil {
+				log.Warn("Malformed submission file %s: %v", fullName, err)
+				continue
+			}
+		}
+		pathsNew := MakePathsImpl(oldMeta.SubmittedAt, blockHashStr, pkStr)
+		newMetaPath := pathsNew.Meta
+		newMeta := MetaToBeSaved{
+			CreatedAt:  createdAtStr,
+			PeerId:     oldMeta.PeerId,
+			RemoteAddr: oldMeta.RemoteAddr,
+			SnarkWork:  oldMeta.SnarkWork,
+			Submitter:  pkStr,
+			BlockHash:  blockHashStr,
+		}
+		newMetaBytes, err1 := json.Marshal(newMeta)
+		if err1 != nil {
+			log.Errorf("Error while marshaling JSON for %s: %v", fullName, err)
+			continue
+		}
+		gctx.GoogleStorageSave(ObjectsToSave{newMetaPath: newMetaBytes})
+	}
+	if err != iterator.Done {
+		log.Fatalf("Error while iteration through objects: %v", err)
+		return
+	}
+}

--- a/src/app/delegation_backend/src/delegation_backend_migrate/main.go
+++ b/src/app/delegation_backend/src/delegation_backend_migrate/main.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/btcsuite/btcutil/base58"
@@ -35,7 +36,7 @@ func readOldPk(pkOld string) (pk dg.Pk, err error) {
 }
 
 type oldMeta struct {
-	SubmittedAt string     `json:"submitted_at"`
+	SubmittedAt time.Time  `json:"submitted_at"`
 	PeerId      string     `json:"peer_id"`
 	SnarkWork   *dg.Base64 `json:"snark_work,omitempty"`
 	RemoteAddr  string     `json:"remote_addr"`
@@ -76,7 +77,7 @@ func main() {
 			log.Warnf("Malformed submission name: %s", fullName)
 			continue
 		}
-		log.Debug("Processing", fullName)
+		log.Debug("Processing ", fullName)
 		pkStr := parts[0]
 		blockHashStr := parts[1]
 		createdAtStr := parts[2]
@@ -97,7 +98,8 @@ func main() {
 			log.Warnf("Malformed pk in %s: %v", fullName, err)
 			continue
 		}
-		pathsNew := dg.MakePathsImpl(oldMeta.SubmittedAt, blockHashStr, pk)
+		submittedAt := oldMeta.SubmittedAt.UTC().Format(time.RFC3339)
+		pathsNew := dg.MakePathsImpl(submittedAt, blockHashStr, pk)
 		newMetaPath := pathsNew.Meta
 		newMeta := dg.MetaToBeSaved{
 			CreatedAt:  createdAtStr,

--- a/src/app/delegation_backend/src/delegation_backend_migrate/main_test.go
+++ b/src/app/delegation_backend/src/delegation_backend_migrate/main_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertOldPkToNew(t *testing.T) {
+	pkOld := "X4pjnQmPXyvay6ohytRAMWQDAhLw15LYb8L3qNnvaZyhhWndcxwv"
+	pk, err := readOldPk(pkOld)
+	require.NoError(t, err)
+	require.Equal(t, "B62qka4Xt1WGENxiv17rQpb4ryU6HhWdwdjukBowV7g5qKMzXrYoWB3", pk.String())
+}

--- a/src/app/delegation_backend/src/go.mod
+++ b/src/app/delegation_backend/src/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/storage v1.16.0
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/ipfs/go-log/v2 v2.1.3
+	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	google.golang.org/api v0.49.0
 )

--- a/src/app/delegation_backend/src/go.sum
+++ b/src/app/delegation_backend/src/go.sum
@@ -162,8 +162,10 @@ github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfE
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -538,6 +540,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/src/app/delegation_backend/src/sheets.go
+++ b/src/app/delegation_backend/src/sheets.go
@@ -30,7 +30,7 @@ func processRows(rows [][](interface{})) Whitelist {
 func RetrieveWhitelist(service *sheets.Service, log *logging.ZapEventLogger) Whitelist {
 	col := DELEGATION_WHITELIST_COLUMN
 	readRange := DELEGATION_WHITELIST_LIST + "!" + col + ":" + col
-	spId := DELEGATION_WHITELIST_SPREADSHEET_ID
+	spId := WhitelistSpreadsheetId()
 	resp, err := service.Spreadsheets.Values.Get(spId, readRange).Do()
 	if err != nil {
 		log.Fatalf("Unable to retrieve data from sheet: %v", err)

--- a/src/app/delegation_backend/src/submit.go
+++ b/src/app/delegation_backend/src/submit.go
@@ -2,16 +2,17 @@ package delegation_backend
 
 import (
 	"bytes"
-	"cloud.google.com/go/storage"
 	"context"
 	"encoding/json"
-	"github.com/btcsuite/btcutil/base58"
-	logging "github.com/ipfs/go-log/v2"
-	"golang.org/x/crypto/blake2b"
 	"io"
 	"net/http"
 	"strings"
 	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/btcsuite/btcutil/base58"
+	logging "github.com/ipfs/go-log/v2"
+	"golang.org/x/crypto/blake2b"
 )
 
 type errorResponse struct {
@@ -63,18 +64,21 @@ type SubmitH struct {
 }
 
 type Paths struct {
-	metaPath  string
-	blockPath string
+	Meta  string
+	Block string
 }
 
-func makePaths(req *submitRequest) (res Paths) {
-	blockHashBytes := blake2b.Sum256(req.Data.Block.data)
-	blockHash := base58.CheckEncode(blockHashBytes[:], BASE58CHECK_VERSION_BLOCK_HASH)
-	createdAtStr := req.Data.CreatedAt.UTC().Format(time.RFC3339)
-	pkStr := base58.CheckEncode(req.Submitter[:], BASE58CHECK_VERSION_PK)
-	res.metaPath = strings.Join([]string{"submissions", pkStr, blockHash, createdAtStr + ".json"}, "/")
-	res.blockPath = "blocks/" + blockHash + ".dat"
+func MakePathsImpl(submittedAt string, blockHash string, submitter string) (res Paths) {
+	res.Meta = strings.Join([]string{"submissions", submittedAt[:10], submittedAt + "-" + submitter + ".json"}, "/")
+	res.Block = "blocks/" + blockHash + ".dat"
 	return
+}
+func makePaths(submittedAt time.Time, req *submitRequest) (res Paths, blockHash string, pkStr string) {
+	blockHashBytes := blake2b.Sum256(req.Data.Block.data)
+	blockHash = base58.CheckEncode(blockHashBytes[:], BASE58CHECK_VERSION_BLOCK_HASH)
+	submittedAtStr := submittedAt.UTC().Format(time.RFC3339)
+	pkStr = base58.CheckEncode(req.Submitter[:], BASE58CHECK_VERSION_PK)
+	return MakePathsImpl(submittedAtStr, blockHash, pkStr), blockHash, pkStr
 }
 
 func makeSignPayload(req *submitRequestData) ([]byte, error) {
@@ -88,8 +92,9 @@ func makeSignPayload(req *submitRequestData) ([]byte, error) {
 	signPayload.Write(req.Block.json)
 	signPayload.WriteString(",\"created_at\":")
 	signPayload.Write(createdAtJson)
-	signPayload.WriteString(",\"peer_id\":")
-	signPayload.Write(req.PeerId.json)
+	signPayload.WriteString(",\"peer_id\":\"")
+	signPayload.WriteString(req.PeerId)
+	signPayload.WriteString("\"")
 	if req.SnarkWork != nil {
 		signPayload.WriteString(",\"snark_work\":")
 		signPayload.Write(req.SnarkWork.json)
@@ -125,7 +130,7 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeErrorResponse(h.app, &w, "Wrong payload")
 		return
 	}
-	if req.Data.Block == nil || req.Data.PeerId == nil || req.Data.CreatedAt == nilTime || req.Submitter == nilPk || req.Sig == nilSig {
+	if req.Data.Block == nil || req.Data.PeerId == "" || req.Data.CreatedAt == nilTime || req.Submitter == nilPk || req.Sig == nilSig {
 		h.app.Log.Debug("One of required fields wasn't provided")
 		w.WriteHeader(400)
 		writeErrorResponse(h.app, &w, "One of required fields wasn't provided")
@@ -168,11 +173,16 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var meta metaToBeSaved
-	meta.SubmittedAt = submittedAt
-	meta.PeerId = req.Data.PeerId
-	meta.SnarkWork = req.Data.SnarkWork
-	meta.RemoteAddr = r.RemoteAddr
+	ps, blockHashStr, pkStr := makePaths(submittedAt, &req)
+
+	meta := MetaToBeSaved{
+		CreatedAt:  req.Data.CreatedAt.Format(time.RFC3339),
+		PeerId:     req.Data.PeerId,
+		SnarkWork:  req.Data.SnarkWork,
+		RemoteAddr: r.RemoteAddr,
+		BlockHash:  blockHashStr,
+		Submitter:  pkStr,
+	}
 
 	metaBytes, err1 := json.Marshal(meta)
 	if err1 != nil {
@@ -182,11 +192,9 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ps := makePaths(&req)
-
 	toSave := make(ObjectsToSave)
-	toSave[ps.metaPath] = metaBytes
-	toSave[ps.blockPath] = req.Data.Block.data
+	toSave[ps.Meta] = metaBytes
+	toSave[ps.Block] = req.Data.Block.data
 	h.app.Save(toSave)
 
 	_, err2 := io.Copy(w, bytes.NewReader([]byte("{\"status\":\"ok\"}")))

--- a/src/app/delegation_backend/src/submit.go
+++ b/src/app/delegation_backend/src/submit.go
@@ -33,12 +33,12 @@ func writeErrorResponse(app *App, w *http.ResponseWriter, msg string) {
 
 func (ctx *GoogleContext) GoogleStorageSave(objs ObjectsToSave) {
 	for path, bs := range objs {
-		writer := ctx.Bucket.Object(path).NewWriter(ctx.Context)
+		obj := ctx.Bucket.Object(path).If(storage.Conditions{DoesNotExist: true})
+		writer := obj.NewWriter(ctx.Context)
 		defer writer.Close()
 		_, err := io.Copy(writer, bytes.NewReader(bs))
 		if err != nil {
-			ctx.Log.Debugf("Error while saving metadata: %v", err)
-			return
+			ctx.Log.Warnf("Error while saving metadata: %v", err)
 		}
 	}
 }

--- a/src/app/delegation_backend/src/submit_test.go
+++ b/src/app/delegation_backend/src/submit_test.go
@@ -188,14 +188,14 @@ func TestSuccess(t *testing.T) {
 			t.Logf("Failed testing %s: %v", f, rep)
 			t.FailNow()
 		}
-		paths, bhStr, pkStr := makePaths(tm.Now(), &req)
+		paths, bhStr := makePaths(tm.Now(), &req)
 		var meta MetaToBeSaved
 		meta.CreatedAt = req.Data.CreatedAt.Format(time.RFC3339)
 		meta.PeerId = req.Data.PeerId
 		meta.SnarkWork = req.Data.SnarkWork
 		meta.RemoteAddr = "192.0.2.1:1234"
 		meta.BlockHash = bhStr
-		meta.Submitter = pkStr
+		meta.Submitter = req.Submitter
 		metaBytes, err2 := json.Marshal(meta)
 		if err2 != nil || !bytes.Equal((*objs)[paths.Meta], metaBytes) ||
 			!bytes.Equal((*objs)[paths.Block], req.Data.Block.data) {

--- a/src/app/delegation_backend/src/submit_test.go
+++ b/src/app/delegation_backend/src/submit_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	logging "github.com/ipfs/go-log/v2"
 	"io/ioutil"
 	"math/rand"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	logging "github.com/ipfs/go-log/v2"
 )
 
 const TSPG_EXPECTED_1 = `{"block":"zLgvHQzxSh8MWlTjXK+cMA==","created_at":"2021-07-01T16:21:33Z","peer_id":"MLF0jAGTpL84LLerLddNs5M10NCHM+BwNeMxK78+"}`
@@ -31,7 +32,7 @@ func mkB64B(b []byte) *Base64 {
 
 func TestSignPayloadGeneration(t *testing.T) {
 	req := new(submitRequestData)
-	req.PeerId = mkB64("MLF0jAGTpL84LLerLddNs5M10NCHM+BwNeMxK78+")
+	req.PeerId = "MLF0jAGTpL84LLerLddNs5M10NCHM+BwNeMxK78+"
 	req.Block = mkB64("zLgvHQzxSh8MWlTjXK+cMA==")
 	req.CreatedAt, _ = time.Parse(time.RFC3339, "2021-07-01T19:21:33+03:00")
 	json, err := makeSignPayload(req)
@@ -187,15 +188,17 @@ func TestSuccess(t *testing.T) {
 			t.Logf("Failed testing %s: %v", f, rep)
 			t.FailNow()
 		}
-		paths := makePaths(&req)
-		var meta metaToBeSaved
-		meta.SubmittedAt = tm.Now()
+		paths, bhStr, pkStr := makePaths(tm.Now(), &req)
+		var meta MetaToBeSaved
+		meta.CreatedAt = req.Data.CreatedAt.Format(time.RFC3339)
 		meta.PeerId = req.Data.PeerId
 		meta.SnarkWork = req.Data.SnarkWork
 		meta.RemoteAddr = "192.0.2.1:1234"
+		meta.BlockHash = bhStr
+		meta.Submitter = pkStr
 		metaBytes, err2 := json.Marshal(meta)
-		if err2 != nil || !bytes.Equal((*objs)[paths.metaPath], metaBytes) ||
-			!bytes.Equal((*objs)[paths.blockPath], req.Data.Block.data) {
+		if err2 != nil || !bytes.Equal((*objs)[paths.Meta], metaBytes) ||
+			!bytes.Equal((*objs)[paths.Block], req.Data.Block.data) {
 			t.Logf("Content check failed for %s", f)
 			t.FailNow()
 		}
@@ -228,7 +231,7 @@ func Test40x(t *testing.T) {
 		t.FailNow()
 	}
 	req2 = req
-	req2.Data.PeerId = nil
+	req2.Data.PeerId = ""
 	body2, err2 = json.Marshal(req2)
 	if rep := sh.testRequest(body2); err2 != nil || rep.Code != 400 {
 		t.Log("No peerId test failed")


### PR DESCRIPTION
Upon request from OnTab, a few changes were introduced to Delegation backend. A different directory structure was agreed upon to ease implementation of Ontab's software.

Explain your changes:
* User submissions are saved by path `<submited_date>/<submitted_time>-<submitter>.json`
* Fields `created_at`, `submitter` and `block_hash` are added to the JSON file
* (Minor) encoding of `submitter` field is fixed to match Mina's standard Pk encoding (prefix was added)
* Migration tool to migrate existing submissions to the new format was implemented

Explain how you tested your changes:
* Existing tests were tested accordingly

Checklist:

- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues?