### PR TITLE
deprecate setStaking command

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -2814,8 +2814,8 @@
                   "ofType": null
                 }
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "Restart the daemon with the flag --block-producer-key instead"
             },
             {
               "name": "setCoinbaseReceiver",

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1258,7 +1258,11 @@ let set_staking_graphql =
       ~doc:"PUBLICKEY Public key of account with which to produce blocks"
       (required public_key_compressed)
   in
-  Command.async ~summary:"Start producing blocks"
+  Command.async
+    ~summary:
+      "The set-staking command is deprecated and no longer has any effect.To \
+       enable block production, instead restart the daemon with the flag \
+       --block-producer-key"
     (Cli_lib.Background_daemon.graphql_init pk_flag
        ~f:(fun graphql_endpoint public_key ->
          let print_message msg arr =

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2984,46 +2984,18 @@ module Mutations = struct
           ~f:(Fn.compose Yojson.Safe.to_string Error_json.error_to_yojson) )
 
   let set_staking =
-    field "setStaking" ~doc:"Set keys you wish to stake with"
+    result_field "setStaking" ~doc:"Set keys you wish to stake with"
       ~args:Arg.[arg "input" ~typ:(non_null Types.Input.set_staking)]
       ~typ:(non_null Types.Payload.set_staking)
-      ~resolve:(fun {ctx= coda; _} () _pks ->
-        [%log' error (Mina_lib.top_level_logger coda)]
-          "setStaking is temorarily disabled in this build. Please restart \
-           the daemon with the new block producer key" ;
-        let old_block_production_keys =
-          Mina_lib.block_production_pubkeys coda
-          |> Public_key.Compressed.Set.to_list
-        in
-        (old_block_production_keys, [], old_block_production_keys)
-        (*TODO: uncomment this after key swaps are fixed for the new VRF evaluator implementation *)
-        (*let old_block_production_keys =
-          Mina_lib.block_production_pubkeys coda
-        in
-        let wallet = Mina_lib.wallets coda in
-        let unlocked, locked =
-          List.partition_map pks ~f:(fun pk ->
-              match Secrets.Wallets.find_unlocked ~needle:pk wallet with
-              | Some kp ->
-                  `Fst (kp, pk)
-              | None ->
-                  `Snd pk )
-        in
-        [%log' info (Mina_lib.top_level_logger coda)]
-          ~metadata:
-            [ ( "old"
-              , [%to_yojson: Public_key.Compressed.t list]
-                  (Public_key.Compressed.Set.to_list old_block_production_keys)
-              )
-            ; ("new", [%to_yojson: Public_key.Compressed.t list] pks) ]
-          !"Block production key replacement; old: $old, new: $new" ;
-        ignore
-        @@ Mina_lib.replace_block_production_keypairs coda
-             (Keypair.And_compressed_pk.Set.of_list unlocked) ;
-        ( Public_key.Compressed.Set.to_list old_block_production_keys
-        , locked
-        , List.map ~f:Tuple.T2.get2 unlocked )*)
-        )
+      ~deprecated:
+        (Deprecated
+           (Some
+              "Restart the daemon with the flag --block-producer-key instead"))
+      ~resolve:(fun {ctx= _coda; _} () _pks ->
+        Error
+          "The setStaking command is deprecated and no longer has any effect. \
+           To enable block production, instead restart the daemon with the \
+           flag --block-producer-key." )
 
   let set_coinbase_receiver =
     field "setCoinbaseReceiver" ~doc:"Set the key to receive coinbases"


### PR DESCRIPTION

Explain your changes:
* deprecate setStaking graphql and cli command. 

Explain how you tested your changes:
*tested the cli command and the graphql mutation  by running a node locally


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
