### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Stale issue handler'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@main
+        id: stale
+        with:
+          debug-only: true
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove the stale label or comment or this will be considered for closing.'
+          days-before-stale: 30
+          days-before-close: -1
+          exempt-issue-labels: 'blocked,must,should,keep'
+          exempt-assignees: 'bkase,imeckler,deepthiskumar,nholland94,psteckler,mrmr1993,ghost-not-in-the-shell,crispthoughts,aneesharaines,bijanshahrokhi,QuiteStochastic,lk86,MartinMinkov,jspada,mimoo,A-Manning,georgeee,joseandro,iregina,samuelarogbonlo,es92'
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
Explain your changes:
* Created stale GitHub action. This action will label issues that are older than 30 days and reported by the community as stale! This will help us to automate this work and will run every day at midnight.

Explain how you tested your changes:
* Live. Only on GitHub itself.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
