### PR TITLE
[kimchi][backend] add backend code for new endoscale scalar gate

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/endoscale_round.ml
+++ b/src/lib/crypto/kimchi_backend/common/endoscale_round.ml
@@ -1,6 +1,4 @@
 open Core_kernel
-
-(** some module *)
 module H_list = Snarky_backendless.H_list
 
 [%%versioned

--- a/src/lib/crypto/kimchi_backend/common/endoscale_scalar_round.ml
+++ b/src/lib/crypto/kimchi_backend/common/endoscale_scalar_round.ml
@@ -1,0 +1,58 @@
+open Core_kernel
+
+[%%versioned
+module Stable = struct
+  module V2 = struct
+    type 'a t =
+      { n0 : 'a
+      ; n8 : 'a
+      ; a0 : 'a
+      ; b0 : 'a
+      ; a8 : 'a
+      ; b8 : 'a
+      ; x0 : 'a
+      ; x1 : 'a
+      ; x2 : 'a
+      ; x3 : 'a
+      ; x4 : 'a
+      ; x5 : 'a
+      ; x6 : 'a
+      ; x7 : 'a
+      }
+    [@@deriving sexp, fields, hlist]
+  end
+end]
+
+let map { n0; n8; a0; b0; a8; b8; x0; x1; x2; x3; x4; x5; x6; x7 } ~f =
+  { n0 = f n0
+  ; n8 = f n8
+  ; a0 = f a0
+  ; b0 = f b0
+  ; a8 = f a8
+  ; b8 = f b8
+  ; x0 = f x0
+  ; x1 = f x1
+  ; x2 = f x2
+  ; x3 = f x3
+  ; x4 = f x4
+  ; x5 = f x5
+  ; x6 = f x6
+  ; x7 = f x7
+  }
+
+let map2 t1 t2 ~f =
+  { n0 = f t1.n0 t2.n0
+  ; n8 = f t1.n8 t2.n8
+  ; a0 = f t1.a0 t2.a0
+  ; b0 = f t1.b0 t2.b0
+  ; a8 = f t1.a8 t2.a8
+  ; b8 = f t1.b8 t2.b8
+  ; x0 = f t1.x0 t2.x0
+  ; x1 = f t1.x1 t2.x1
+  ; x2 = f t1.x2 t2.x2
+  ; x3 = f t1.x3 t2.x3
+  ; x4 = f t1.x4 t2.x4
+  ; x5 = f t1.x5 t2.x5
+  ; x6 = f t1.x6 t2.x6
+  ; x7 = f t1.x7 t2.x7
+  }

--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -150,6 +150,12 @@ module Plonk_constraint = struct
       | EC_scale of { state : 'v Scale_round.t array }
       | EC_endoscale of
           { state : 'v Endoscale_round.t array; xs : 'v; ys : 'v; n_acc : 'v }
+      | EC_endoscalar of
+          { state : 'v Endoscale_scalar_round.t array
+          ; n8 : 'v
+          ; a8 : 'v
+          ; b8 : 'v
+          }
     [@@deriving sexp]
 
     (** map t *)
@@ -181,6 +187,14 @@ module Plonk_constraint = struct
             ; xs = f xs
             ; ys = f ys
             ; n_acc = f n_acc
+            }
+      | EC_endoscalar { state; n8; a8; b8 } ->
+          EC_endoscalar
+            { state =
+                Array.map ~f:(fun x -> Endoscale_scalar_round.map ~f x) state
+            ; n8 = f n8
+            ; a8 = f a8
+            ; b8 = f b8
             }
 
     (* TODO: this seems to be a "double check" type of function? It just checks that the basic gate is equal to 0? what is eval_one? what is v and f? *)
@@ -363,14 +377,30 @@ struct
                 Scale_round.fold a ~init:acc ~f:cvars)
         | EC_endoscale { state; xs; ys; n_acc } ->
             let t = H.feed_string t "ec_endoscale" in
-            Array.fold state ~init:t
-              ~f:(fun
-                   acc
-                   { xt; yt; xp; yp; n_acc; xr; yr; s1; s3; b1; b2; b3; b4 }
-                 ->
-                cvars
-                  [ xt; yt; xp; yp; n_acc; xr; yr; s1; s3; b1; b2; b3; b4 ]
-                  acc) )
+            let t =
+              Array.fold state ~init:t
+                ~f:(fun
+                     acc
+                     { xt; yt; xp; yp; n_acc; xr; yr; s1; s3; b1; b2; b3; b4 }
+                   ->
+                  cvars
+                    [ xt; yt; xp; yp; n_acc; xr; yr; s1; s3; b1; b2; b3; b4 ]
+                    acc)
+            in
+            cvars [ xs; ys; n_acc ] t
+        | EC_endoscalar { state; n8; a8; b8 } ->
+            let t = H.feed_string t "ec_endoscale_scalar" in
+            let t =
+              Array.fold state ~init:t
+                ~f:(fun
+                     acc
+                     { n0; n8; a0; b0; a8; b8; x0; x1; x2; x3; x4; x5; x6; x7 }
+                   ->
+                  cvars
+                    [ n0; n8; a0; b0; a8; b8; x0; x1; x2; x3; x4; x5; x6; x7 ]
+                    acc)
+            in
+            cvars [ n8; a8; b8 ] t )
     | _ ->
         failwith "Unsupported constraint"
 
@@ -1100,6 +1130,59 @@ struct
            ; Some (reduce_to_v xs)
            ; Some (reduce_to_v ys)
            ; Some (reduce_to_v n_acc)
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+           ; None
+          |]
+        in
+        add_row sys vars Zero [||]
+    | Plonk_constraint.T
+        (EC_endoscalar
+          { state : 'v Endoscale_scalar_round.t array
+          ; n8 : 'v
+          ; a8 : 'v
+          ; b8 : 'v
+          }) ->
+        (* reduce state *)
+        let state =
+          Array.map state ~f:(Endoscale_scalar_round.map ~f:reduce_to_v)
+        in
+        (* add round function *)
+        let add_endoscale_scalar_round (round : V.t Endoscale_scalar_round.t) =
+          let row =
+            [| Some round.n0
+             ; Some round.n8
+             ; Some round.a0
+             ; Some round.b0
+             ; Some round.a8
+             ; Some round.b8
+             ; Some round.x0
+             ; Some round.x1
+             ; Some round.x2
+             ; Some round.x3
+             ; Some round.x4
+             ; Some round.x5
+             ; Some round.x6
+             ; Some round.x7
+             ; None
+            |]
+          in
+          add_row sys row Kimchi.Protocol.EndomulScalar [||]
+        in
+        Array.iter state ~f:add_endoscale_scalar_round ;
+        (* last row *)
+        let vars =
+          [| None
+           ; Some (reduce_to_v n8)
+           ; None
+           ; None
+           ; Some (reduce_to_v a8)
+           ; Some (reduce_to_v b8)
+           ; None
            ; None
            ; None
            ; None


### PR DESCRIPTION
Adding backend code for the new endomul scalar custom gate of kimchi, see https://github.com/o1-labs/proof-systems/pull/199