### PR TITLE
Use Base58Check funs, not string funs

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -218,7 +218,7 @@ end
 
 module Snarked_ledger_hash = struct
   let find (module Conn : CONNECTION) (t : Frozen_ledger_hash.t) =
-    let hash = Frozen_ledger_hash.to_string t in
+    let hash = Frozen_ledger_hash.to_base58_check t in
     Conn.find
       (Caqti_request.find Caqti_type.string Caqti_type.int
          "SELECT id FROM snarked_ledger_hashes WHERE value = ?")
@@ -227,7 +227,7 @@ module Snarked_ledger_hash = struct
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (t : Frozen_ledger_hash.t) =
     let open Deferred.Result.Let_syntax in
-    let hash = Frozen_ledger_hash.to_string t in
+    let hash = Frozen_ledger_hash.to_base58_check t in
     match%bind
       Conn.find_opt
         (Caqti_request.find_opt Caqti_type.string Caqti_type.int
@@ -256,7 +256,7 @@ module Epoch_data = struct
   let add_from_seed_and_ledger_hash_id (module Conn : CONNECTION) ~seed
       ~ledger_hash_id =
     let open Deferred.Result.Let_syntax in
-    let seed = Epoch_seed.to_string seed in
+    let seed = Epoch_seed.to_base58_check seed in
     match%bind
       Conn.find_opt
         (Caqti_request.find_opt typ Caqti_type.int
@@ -1051,13 +1051,13 @@ module Block = struct
     Conn.find
       (Caqti_request.find Caqti_type.string Caqti_type.int
          "SELECT id FROM blocks WHERE state_hash = ?")
-      (State_hash.to_string state_hash)
+      (State_hash.to_base58_check state_hash)
 
   let find_opt (module Conn : CONNECTION) ~(state_hash : State_hash.t) =
     Conn.find_opt
       (Caqti_request.find_opt Caqti_type.string Caqti_type.int
          "SELECT id FROM blocks WHERE state_hash = ?")
-      (State_hash.to_string state_hash)
+      (State_hash.to_base58_check state_hash)
 
   let load (module Conn : CONNECTION) ~(id : int) =
     Conn.find
@@ -1119,11 +1119,11 @@ module Block = struct
                       global_slot_since_genesis, timestamp)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
                |sql})
-            { state_hash= hash |> State_hash.to_string
+            { state_hash= hash |> State_hash.to_base58_check
             ; parent_id
             ; parent_hash=
                 Protocol_state.previous_state_hash protocol_state
-                |> State_hash.to_string
+                |> State_hash.to_base58_check
             ; creator_id
             ; block_winner_id
             ; snarked_ledger_hash_id
@@ -1132,7 +1132,7 @@ module Block = struct
             ; ledger_hash=
                 Protocol_state.blockchain_state protocol_state
                 |> Blockchain_state.staged_ledger_hash
-                |> Staged_ledger_hash.ledger_hash |> Ledger_hash.to_string
+                |> Staged_ledger_hash.ledger_hash |> Ledger_hash.to_base58_check
             ; height=
                 consensus_state
                 |> Consensus.Data.Consensus_state.blockchain_length
@@ -1430,15 +1430,15 @@ module Block = struct
                       global_slot_since_genesis, timestamp)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
                |sql})
-            { state_hash= block.state_hash |> State_hash.to_string
+            { state_hash= block.state_hash |> State_hash.to_base58_check
             ; parent_id
-            ; parent_hash= block.parent_hash |> State_hash.to_string
+            ; parent_hash= block.parent_hash |> State_hash.to_base58_check
             ; creator_id
             ; block_winner_id
             ; snarked_ledger_hash_id
             ; staking_epoch_data_id
             ; next_epoch_data_id
-            ; ledger_hash= block.ledger_hash |> Ledger_hash.to_string
+            ; ledger_hash= block.ledger_hash |> Ledger_hash.to_base58_check
             ; height= block.height |> Unsigned.UInt32.to_int64
             ; global_slot_since_hard_fork= block.global_slot_since_hard_fork |> Unsigned.UInt32.to_int64
             ; global_slot_since_genesis=

--- a/src/app/best_tip_merger/best_tip_merger.ml
+++ b/src/app/best_tip_merger/best_tip_merger.ml
@@ -271,9 +271,9 @@ module Graph_node = struct
   let name (t : t) =
     match t.state with
     | Root s ->
-        State_hash.to_string s |> Fn.flip String.suffix 7
+        State_hash.to_base58_check s |> Fn.flip String.suffix 7
     | Node s ->
-        State_hash.to_string s.current |> Fn.flip String.suffix 7
+        State_hash.to_base58_check s.current |> Fn.flip String.suffix 7
 
   let display (t : t) =
     let state = name t in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1197,7 +1197,7 @@ let pending_snark_work =
                       Array.map bundle#workBundle ~f:(fun w ->
                           let f = w#fee_excess in
                           let hash_of_string =
-                            Mina_base.Frozen_ledger_hash.of_string
+                            Mina_base.Frozen_ledger_hash.of_base58_check_exn
                           in
                           { Cli_lib.Graphql_types.Pending_snark_work.Work
                             .work_id = w#work_id

--- a/src/app/delegation_compliance/delegation_compliance.ml
+++ b/src/app/delegation_compliance/delegation_compliance.ml
@@ -480,8 +480,8 @@ let main ~input_file ~csv_file ~preliminary_csv_file_opt ~archive_uri
           ~f:(fun { global_slot; state_hash; ledger_hash; _ } ->
             Hashtbl.add_exn global_slot_hashes_tbl ~key:global_slot
               ~data:
-                ( State_hash.of_string state_hash
-                , Ledger_hash.of_string ledger_hash )) ;
+                ( State_hash.of_base58_check_exn state_hash
+                , Ledger_hash.of_base58_check_exn ledger_hash )) ;
         Int.Set.of_list ids
       in
       (* check that genesis block is in chain to target hash

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -430,7 +430,9 @@ let main ~archive_uri ~start_state_hash_opt ~end_state_hash_opt ~all_blocks () =
             [%log info] "Writing block with $state_hash"
               ~metadata:
                 [ ("state_hash", State_hash.to_yojson block.state_hash) ] ;
-            let output_file = State_hash.to_string block.state_hash ^ ".json" in
+            let output_file =
+              State_hash.to_base58_check block.state_hash ^ ".json"
+            in
             Async_unix.Writer.with_file output_file ~f:(fun writer ->
                 return
                   (Async.fprintf writer "%s\n%!"

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -221,14 +221,14 @@ let process_block_infos_of_state_hash ~logger pool state_hash ~f =
       exit 1
 
 let update_epoch_ledger ~logger ~name ~ledger ~epoch_ledger epoch_ledger_hash =
-  let epoch_ledger_hash = Ledger_hash.of_string epoch_ledger_hash in
+  let epoch_ledger_hash = Ledger_hash.of_base58_check_exn epoch_ledger_hash in
   let curr_ledger_hash = Ledger.merkle_root ledger in
   if Frozen_ledger_hash.equal epoch_ledger_hash curr_ledger_hash then (
     [%log info]
       "Creating %s epoch ledger from ledger with Merkle root matching epoch \
        ledger hash %s"
       name
-      (Ledger_hash.to_string epoch_ledger_hash) ;
+      (Ledger_hash.to_base58_check epoch_ledger_hash) ;
     (* Ledger.copy doesn't actually copy, roll our own here *)
     let accounts = Ledger.to_list ledger in
     let epoch_ledger = Ledger.create ~depth:(Ledger.depth ledger) () in
@@ -821,7 +821,8 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
       in
       let ledger = Lazy.force @@ Genesis_ledger.Packed.t packed_ledger in
       let epoch_ledgers_state_hash_opt =
-        Option.map input.target_epoch_ledgers_state_hash ~f:State_hash.to_string
+        Option.map input.target_epoch_ledgers_state_hash
+          ~f:State_hash.to_base58_check
       in
       let%bind target_state_hash =
         match epoch_ledgers_state_hash_opt with
@@ -856,8 +857,8 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                 Hashtbl.add_exn global_slot_hashes_tbl
                   ~key:global_slot_since_genesis
                   ~data:
-                    ( State_hash.of_string state_hash
-                    , Ledger_hash.of_string ledger_hash )) ;
+                    ( State_hash.of_base58_check_exn state_hash
+                    , Ledger_hash.of_base58_check_exn ledger_hash )) ;
             return (Int.Set.of_list ids))
       in
       (* check that genesis block is in chain to target hash
@@ -1151,7 +1152,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                 let output =
                   create_output ~target_epoch_ledgers_state_hash
                     ~target_fork_state_hash:
-                      (State_hash.of_string target_state_hash)
+                      (State_hash.of_base58_check_exn target_state_hash)
                     ~ledger ~staking_epoch_ledger ~staking_seed
                     ~next_epoch_ledger ~next_seed input.genesis_ledger
                   |> output_to_yojson |> Yojson.Safe.to_string

--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -52,6 +52,10 @@ let pending_coinbase_hash_builder : t = '\x19'
 
 let snapp_command : t = '\x1A'
 
+(** used for testing only *)
+
+let ledger_test_hash : t = '\x30'
+
 (** The following version bytes are non-sequential; existing
     user key infrastructure depends on them. don't change them!
 *)

--- a/src/lib/cli_lib/arg_type.ml
+++ b/src/lib/cli_lib/arg_type.ml
@@ -49,7 +49,7 @@ let token_id =
 
 let receipt_chain_hash =
   Command.Arg_type.map Command.Param.string
-    ~f:Mina_base.Receipt.Chain_hash.of_string
+    ~f:Mina_base.Receipt.Chain_hash.of_base58_check_exn
 
 let peer : Host_and_port.t Command.Arg_type.t =
   Command.Arg_type.create (fun s -> Host_and_port.of_string s)

--- a/src/lib/codable/codable.ml
+++ b/src/lib/codable/codable.ml
@@ -96,15 +96,15 @@ struct
 
   let of_base58_check_exn s = of_base58_check s |> Or_error.ok_exn
 
-  module String_ops = struct
-    type t = T.t
+  let to_yojson t = `String (to_base58_check t)
 
-    let to_string = to_base58_check
-
-    let of_string = of_base58_check_exn
-  end
-
-  include Make_of_string (String_ops)
+  let of_yojson = function
+    | `String s ->
+        Result.map_error (of_base58_check s) ~f:Error.to_string_hum
+    | json ->
+        failwithf "of_yojson: expect JSON string, got %s"
+          (Yojson.Safe.to_string json)
+          ()
 end
 
 module type Base58_check_base_intf = sig
@@ -119,12 +119,6 @@ end
 
 module type Base58_check_intf = sig
   type t
-
-  (** string encoding (Base58Check) *)
-  val to_string : t -> string
-
-  (** string (Base58Check) decoding *)
-  val of_string : string -> t
 
   (** explicit Base58Check encoding *)
   val to_base58_check : t -> string

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -591,7 +591,7 @@ module Data = struct
           [ field "hash" ~typ:(non_null string)
               ~args:Arg.[]
               ~resolve:(fun _ { Poly.hash; _ } ->
-                Mina_base.Frozen_ledger_hash.to_string hash)
+                Mina_base.Frozen_ledger_hash.to_base58_check hash)
           ; field "totalCurrency"
               ~typ:(non_null @@ Graphql_base_types.uint64 ())
               ~args:Arg.[]

--- a/src/lib/data_hash_lib/data_hash.ml
+++ b/src/lib/data_hash_lib/data_hash.ml
@@ -166,11 +166,8 @@ module Make_full_size (B58_data : Data_hash_intf.Data_hash_descriptor) = struct
   end)
 
   [%%define_locally
-  Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
-
-  [%%define_locally Base58_check.String_ops.(to_string, of_string)]
-
-  [%%define_locally Base58_check.(to_yojson, of_yojson)]
+  Base58_check.
+    (to_base58_check, of_base58_check, of_base58_check_exn, to_yojson, of_yojson)]
 
   module T = struct
     type t = Field.t [@@deriving sexp, compare, hash]

--- a/src/lib/data_hash_lib/data_hash_intf.ml
+++ b/src/lib/data_hash_lib/data_hash_intf.ml
@@ -54,10 +54,6 @@ module type Basic = sig
 
   [%%endif]
 
-  val to_string : t -> string
-
-  val of_string : string -> t
-
   val to_base58_check : t -> string
 
   val of_base58_check : string -> t Base.Or_error.t

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1001,7 +1001,7 @@ let run ~logger ~trust_system ~verifier ~network ~frontier
                   Error.tag
                     (Error.of_string
                        (sprintf "Parent breadcrumb with state_hash %s not found"
-                          (State_hash.to_string parent_hash)))
+                          (State_hash.to_base58_check parent_hash)))
                     ~tag:"parent breadcrumb not found"
             in
             failed ~error:e ~sender:av.sender `Build_breadcrumb

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -94,7 +94,7 @@ end
 module type Hash = sig
   type t [@@deriving bin_io, compare, equal, sexp, yojson]
 
-  val to_string : t -> string
+  val to_base58_check : t -> string
 
   include Hashable.S_binable with type t := t
 

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -41,19 +41,18 @@ module Receipt = Mina_base.Receipt
 module Hash = struct
   module T = struct
     type t = Md5.t [@@deriving sexp, hash, compare, bin_io_unversioned, equal]
-
-    let to_string = Md5.to_hex
-
-    let to_yojson t = `String (Md5.to_hex t)
-
-    let of_yojson = function
-      | `String s ->
-          Ok (Md5.of_hex_exn s)
-      | _ ->
-          Error "expected string"
   end
 
   include T
+
+  include Codable.Make_base58_check (struct
+    type t = T.t [@@deriving bin_io_unversioned]
+
+    let description = "Ledger test hash"
+
+    let version_byte = Base58_check.Version_bytes.ledger_test_hash
+  end)
+
   include Hashable.Make_binable (T)
 
   (* to prevent pre-image attack,

--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -59,7 +59,8 @@ module Make (Inputs : Inputs_intf) = struct
       in
       let uuid = format_uuid mask in
       { hash =
-          Visualization.display_prefix_of_string @@ Hash.to_string root_hash
+          Visualization.display_prefix_of_string
+          @@ Hash.to_base58_check root_hash
       ; num_accounts
       ; total_currency
       ; uuid

--- a/src/lib/mina_base/coinbase.ml
+++ b/src/lib/mina_base/coinbase.ml
@@ -25,8 +25,6 @@ module Base58_check = Codable.Make_base58_check (Stable.Latest)
 [%%define_locally
 Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
 
-[%%define_locally Base58_check.String_ops.(to_string, of_string)]
-
 let receiver_pk t = t.receiver
 
 let receiver t = Account_id.create t.receiver Token_id.default

--- a/src/lib/mina_base/coinbase_fee_transfer.ml
+++ b/src/lib/mina_base/coinbase_fee_transfer.ml
@@ -26,8 +26,6 @@ module Base58_check = Codable.Make_base58_check (Stable.Latest)
 [%%define_locally
 Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
 
-[%%define_locally Base58_check.String_ops.(to_string, of_string)]
-
 let receiver_pk { receiver_pk; _ } = receiver_pk
 
 let receiver { receiver_pk; _ } = Account_id.create receiver_pk Token_id.default

--- a/src/lib/mina_base/fee_transfer.ml
+++ b/src/lib/mina_base/fee_transfer.ml
@@ -26,8 +26,6 @@ module Single = struct
   [%%define_locally
   Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
 
-  [%%define_locally Base58_check.String_ops.(to_string, of_string)]
-
   let create ~receiver_pk ~fee ~fee_token = { receiver_pk; fee; fee_token }
 
   let receiver_pk { receiver_pk; _ } = receiver_pk

--- a/src/lib/mina_base/ledger.ml
+++ b/src/lib/mina_base/ledger.ml
@@ -49,7 +49,7 @@ module Ledger_inner = struct
 
         include Hashable.Make_binable (Arg)
 
-        let to_string = Ledger_hash.to_string
+        let to_base58_check = Ledger_hash.to_base58_check
 
         let merge = Ledger_hash.merge
 

--- a/src/lib/mina_base/ledger_hash_intf.ml
+++ b/src/lib/mina_base/ledger_hash_intf.ml
@@ -19,9 +19,9 @@ module type S = sig
   val merge : height:int -> t -> t -> t
 
   (** string representation of hash is Base58Check of bin_io representation *)
-  val to_string : t -> string
+  val to_base58_check : t -> string
 
-  val of_string : string -> t
+  val of_base58_check : string -> t Base.Or_error.t
 
   val empty_hash : t
 

--- a/src/lib/mina_base/ledger_transfer.ml
+++ b/src/lib/mina_base/ledger_transfer.ml
@@ -27,8 +27,8 @@ end = struct
     if not (Ledger_hash.equal src_hash dest_hash) then
       Or_error.errorf
         "Merkle roots differ after transfer: expected %s, actual %s"
-        (Ledger_hash.to_string src_hash)
-        (Ledger_hash.to_string dest_hash)
+        (Ledger_hash.to_base58_check src_hash)
+        (Ledger_hash.to_base58_check dest_hash)
     else Ok dest
 end
 
@@ -52,8 +52,8 @@ end = struct
       if not (Ledger_hash.equal src_hash dest_hash) then
         Or_error.errorf
           "Merkle roots differ after transfer: expected %s, actual %s"
-          (Ledger_hash.to_string src_hash)
-          (Ledger_hash.to_string dest_hash)
+          (Ledger_hash.to_base58_check src_hash)
+          (Ledger_hash.to_base58_check dest_hash)
       else Ok dest
     else
       Or_error.errorf

--- a/src/lib/mina_base/receipt.mli
+++ b/src/lib/mina_base/receipt.mli
@@ -26,9 +26,9 @@ module Chain_hash : sig
 
   include Codable.S with type t := t
 
-  val to_string : t -> string
+  val to_base58_check : t -> string
 
-  val of_string : string -> t
+  val of_base58_check : string -> t Or_error.t
 
   val empty : t
 

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -369,8 +369,6 @@ module Base58_check = Codable.Make_base58_check (Stable.Latest)
 [%%define_locally
 Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
 
-[%%define_locally Base58_check.String_ops.(to_string, of_string)]
-
 [%%ifdef consensus_mechanism]
 
 let check_signature ?signature_kind ({ payload; signer; signature } : t) =

--- a/src/lib/mina_base/sync_ledger.ml
+++ b/src/lib/mina_base/sync_ledger.ml
@@ -3,7 +3,7 @@ open Core_kernel
 module Hash = struct
   include Ledger_hash.Stable.V1
 
-  let to_string = Ledger_hash.to_string
+  let to_base58_check = Ledger_hash.to_base58_check
 
   let merge = Ledger_hash.merge
 

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -289,7 +289,7 @@ let get_status ~flag t =
     let open Participating_state.Let_syntax in
     let%bind ledger = Mina_lib.best_ledger t in
     let ledger_merkle_root =
-      Ledger.merkle_root ledger |> Ledger_hash.to_string
+      Ledger.merkle_root ledger |> Ledger_hash.to_base58_check
     in
     let num_accounts = Ledger.num_accounts ledger in
     let%bind state = Mina_lib.best_protocol_state t in

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -515,12 +515,12 @@ module Types = struct
             ~doc:"Base58Check-encoded hash of the source ledger"
             ~args:Arg.[]
             ~resolve:(fun _ { Transaction_snark.Statement.source; _ } ->
-              Frozen_ledger_hash.to_string source)
+              Frozen_ledger_hash.to_base58_check source)
         ; field "targetLedgerHash" ~typ:(non_null string)
             ~doc:"Base58Check-encoded hash of the target ledger"
             ~args:Arg.[]
             ~resolve:(fun _ { Transaction_snark.Statement.target; _ } ->
-              Frozen_ledger_hash.to_string target)
+              Frozen_ledger_hash.to_base58_check target)
         ; field "feeExcess" ~typ:(non_null signed_fee)
             ~doc:
               "Total transaction fee that is not accounted for in the \
@@ -594,7 +594,7 @@ module Types = struct
               let snarked_ledger_hash =
                 Mina_state.Blockchain_state.snarked_ledger_hash blockchain_state
               in
-              Frozen_ledger_hash.to_string snarked_ledger_hash)
+              Frozen_ledger_hash.to_base58_check snarked_ledger_hash)
         ; field "stagedLedgerHash" ~typ:(non_null string)
             ~doc:"Base58Check-encoded hash of the staged ledger"
             ~args:Arg.[]
@@ -603,7 +603,7 @@ module Types = struct
               let staged_ledger_hash =
                 Mina_state.Blockchain_state.staged_ledger_hash blockchain_state
               in
-              Mina_base.Ledger_hash.to_string
+              Mina_base.Ledger_hash.to_base58_check
               @@ Staged_ledger_hash.ledger_hash staged_ledger_hash)
         ; field "stagedLedgerProofEmitted" ~typ:bool
             ~doc:
@@ -1029,7 +1029,7 @@ module Types = struct
                  ~doc:"Top hash of the receipt chain merkle-list"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
-                   Option.map ~f:Receipt.Chain_hash.to_string
+                   Option.map ~f:Receipt.Chain_hash.to_base58_check
                      account.Account.Poly.receipt_chain_hash)
              ; field "delegate" ~typ:public_key
                  ~doc:

--- a/src/lib/mina_lib/coda_subscriptions.ml
+++ b/src/lib/mina_lib/coda_subscriptions.ml
@@ -159,7 +159,7 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
              in
              match (gcloud_keyfile, network, bucket) with
              | Some _, Some network, Some bucket ->
-                 let hash_string = State_hash.to_string hash in
+                 let hash_string = State_hash.to_base58_check hash in
                  let height =
                    Mina_transition.External_transition.Validated
                    .blockchain_length new_block

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -604,7 +604,7 @@ let get_snarked_ledger t state_hash_opt =
                        (sprintf
                           "No transactions corresponding to the emitted proof \
                            for state_hash:%s"
-                          (State_hash.to_string
+                          (State_hash.to_base58_check
                              (Transition_frontier.Breadcrumb.state_hash b))))
               | Some txns -> (
                   match
@@ -636,7 +636,7 @@ let get_snarked_ledger t state_hash_opt =
                             Stop
                               (Or_error.errorf
                                  !"Coudln't find protocol state with hash %s"
-                                 (State_hash.to_string state_hash)))
+                                 (State_hash.to_base58_check state_hash)))
                       ~finish:Fn.id
                   with
                   | Ok _ ->
@@ -658,9 +658,9 @@ let get_snarked_ledger t state_hash_opt =
       else
         Or_error.errorf
           "Expected snarked ledger hash %s but got %s for state hash %s"
-          (Frozen_ledger_hash.to_string snarked_ledger_hash)
-          (Frozen_ledger_hash.to_string merkle_root)
-          (State_hash.to_string state_hash)
+          (Frozen_ledger_hash.to_base58_check snarked_ledger_hash)
+          (Frozen_ledger_hash.to_base58_check merkle_root)
+          (State_hash.to_base58_check state_hash)
   | None ->
       Or_error.error_string
         "get_snarked_ledger: state hash not found in transition frontier"

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -144,14 +144,14 @@ let display
       ; timestamp
       } =
   { Poly.staged_ledger_hash =
-      Visualization.display_prefix_of_string @@ Ledger_hash.to_string
+      Visualization.display_prefix_of_string @@ Ledger_hash.to_base58_check
       @@ Staged_ledger_hash.ledger_hash staged_ledger_hash
   ; snarked_ledger_hash =
       Visualization.display_prefix_of_string
-      @@ Frozen_ledger_hash.to_string snarked_ledger_hash
+      @@ Frozen_ledger_hash.to_base58_check snarked_ledger_hash
   ; genesis_ledger_hash =
       Visualization.display_prefix_of_string
-      @@ Frozen_ledger_hash.to_string genesis_ledger_hash
+      @@ Frozen_ledger_hash.to_base58_check genesis_ledger_hash
   ; snarked_next_available_token =
       Token_id.to_string snarked_next_available_token
   ; timestamp =

--- a/src/lib/transition_frontier/persistent_frontier/worker.ml
+++ b/src/lib/transition_frontier/persistent_frontier/worker.ml
@@ -91,11 +91,11 @@ module Worker = struct
         "old root transition not found"
     | `Not_found (`Parent_transition hash) ->
         Printf.sprintf "parent transition %s not found"
-          (State_hash.to_string hash)
+          (State_hash.to_base58_check hash)
     | `Not_found `Best_tip ->
         "best tip not found"
     | `Not_found (`Arcs hash) ->
-        Printf.sprintf "arcs not found for %s" (State_hash.to_string hash)
+        Printf.sprintf "arcs not found for %s" (State_hash.to_base58_check hash)
 
   let apply_diff (type mutant) (t : t) (diff : mutant Diff.Lite.t) :
       (mutant, apply_diff_error) Result.t =


### PR DESCRIPTION
Don't export `String_ops` from `Codable.Make_base58_check`, which contained `to_string, of_string` functions that were aliases for `to_base58_check` and `of_base58_check_exn`. Those aliases disguise what the string representation is, which makes for confusion. I'd frequently find myself asking, are these strings Base58Check, or something else?

The `encode` and `decode` functions created by `Make_of_string (String_ops)` were not used at all.
The Yojson functions returned by that functor application were used, so we create those functions explicitly.

Replace the uses of the string functions by the explict Base58Check functions throughout the code.

The remaining `to_string` and `of_string` instances in the code should be cases the representation is not Base58Check.

