### PR TITLE
Update stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -11,10 +15,12 @@ jobs:
       - uses: actions/stale@main
         id: stale
         with:
-          debug-only: true
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove the stale label or comment or this will be considered for closing.'
+          debug-only: false
+          ascending: true
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove the stale label or comment or this will be closed in 14 days from this message.'
           days-before-stale: 30
-          days-before-close: -1
+          days-before-close: 14
+          operations-per-run: 500
           exempt-issue-labels: 'blocked,must,should,keep'
           exempt-assignees: 'bkase,imeckler,deepthiskumar,nholland94,psteckler,mrmr1993,ghost-not-in-the-shell,crispthoughts,aneesharaines,bijanshahrokhi,QuiteStochastic,lk86,MartinMinkov,jspada,mimoo,A-Manning,georgeee,joseandro,iregina,samuelarogbonlo,es92'
       - name: Print outputs


### PR DESCRIPTION
Explain your changes:
Updated the stale action to run out of debug mode, increased the total number of allowed operations per run, and added the ability to auto-close a stale issue after 14 days of inactivity.

Explain how you tested your changes:
Test will happen live on Github


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [X] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
