### PR TITLE
Rename rollup_events to sequence_events

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -3572,7 +3572,7 @@
               "deprecationReason": null
             },
             {
-              "name": "rollupEvents",
+              "name": "sequenceEvents",
               "description": "A list of list of fields in Base58Check",
               "args": [],
               "type": {
@@ -3730,7 +3730,7 @@
               "defaultValue": null
             },
             {
-              "name": "rollupEvents",
+              "name": "sequenceEvents",
               "description": "A list of list of fields in Base58Check",
               "type": {
                 "kind": "NON_NULL",
@@ -5384,7 +5384,7 @@
               "deprecationReason": null
             },
             {
-              "name": "rollupEvents",
+              "name": "sequenceEvents",
               "description": "A list of list of fields in Base58Check",
               "args": [],
               "type": {
@@ -5526,7 +5526,7 @@
               "defaultValue": null
             },
             {
-              "name": "rollupEvents",
+              "name": "sequenceEvents",
               "description": "A list of list of fields in Base58Check",
               "type": {
                 "kind": "NON_NULL",
@@ -9740,8 +9740,8 @@
               "deprecationReason": null
             },
             {
-              "name": "rollupEvents",
-              "description": "Rollup events associated with the party (fields in Base58Check)",
+              "name": "sequenceEvents",
+              "description": "Sequence events associated with the party (fields in Base58Check)",
               "args": [],
               "type": {
                 "kind": "NON_NULL",

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -3084,7 +3084,7 @@
               "deprecationReason": null
             },
             {
-              "name": "rollupState",
+              "name": "sequenceState",
               "description": null,
               "args": [],
               "type": {
@@ -3212,7 +3212,7 @@
               "defaultValue": null
             },
             {
-              "name": "rollupState",
+              "name": "sequenceState",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -4457,7 +4457,7 @@
               "deprecationReason": null
             },
             {
-              "name": "editRollupState",
+              "name": "editSequenceState",
               "description": null,
               "args": [],
               "type": {
@@ -4617,7 +4617,7 @@
               "defaultValue": null
             },
             {
-              "name": "editRollupState",
+              "name": "editSequenceState",
               "description": null,
               "type": {
                 "kind": "NON_NULL",

--- a/src/app/archive/snapp_tables.sql
+++ b/src/app/archive/snapp_tables.sql
@@ -103,7 +103,7 @@ CREATE TABLE snapp_events
 , PRIMARY KEY (list_id,list_index)
 );
 
-/* events_list_id and rollup_events_list_id indicate a list_id in snapp_events, which
+/* events_list_id and sequence_events_list_id indicate a list_id in snapp_events, which
    is not a key, since it appears as many times as there are list elements
 */
 CREATE TABLE snapp_party_body
@@ -113,7 +113,7 @@ CREATE TABLE snapp_party_body
 , token_id                 bigint           NOT NULL
 , delta                    bigint           NOT NULL
 , events_list_id           int              NOT NULL
-, rollup_events_list_id    int              NOT NULL
+, sequence_events_list_id    int              NOT NULL
 , call_data_id             int              NOT NULL REFERENCES snapp_state_data(id)
 , depth                    int              NOT NULL
 );

--- a/src/app/archive/snapp_tables.sql
+++ b/src/app/archive/snapp_tables.sql
@@ -113,7 +113,7 @@ CREATE TABLE snapp_party_body
 , token_id                 bigint           NOT NULL
 , delta                    bigint           NOT NULL
 , events_list_id           int              NOT NULL
-, sequence_events_list_id    int              NOT NULL
+, sequence_events_list_id  int              NOT NULL
 , call_data_id             int              NOT NULL REFERENCES snapp_state_data(id)
 , depth                    int              NOT NULL
 );

--- a/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
+++ b/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
@@ -56,7 +56,7 @@ module Accounts = struct
             ; set_permissions
             ; set_verification_key
             ; set_snapp_uri
-            ; edit_rollup_state
+            ; edit_sequence_state
             ; set_token_symbol
             } ->
             let auth_required a =
@@ -82,7 +82,7 @@ module Accounts = struct
             ; set_permissions = auth_required set_permissions
             ; set_verification_key = auth_required set_verification_key
             ; set_snapp_uri = auth_required set_snapp_uri
-            ; edit_rollup_state = auth_required edit_rollup_state
+            ; edit_sequence_state = auth_required edit_sequence_state
             ; set_token_symbol = auth_required set_token_symbol
             }
       in
@@ -114,8 +114,8 @@ module Accounts = struct
             { state
             ; verification_key
             ; snapp_version
-            ; rollup_state
-            ; last_rollup_slot
+            ; sequence_state
+            ; last_sequence_slot
             ; proved_state
             } ->
             let%bind app_state =
@@ -133,26 +133,27 @@ module Accounts = struct
               Option.map verification_key
                 ~f:(With_hash.of_data ~hash_data:Snapp_account.digest_vk)
             in
-            let%map rollup_state =
+            let%map sequence_state =
               if
                 Pickles_types.Vector.Nat.to_int Pickles_types.Nat.N5.n
-                <> List.length rollup_state
+                <> List.length sequence_state
               then
                 Or_error.errorf
-                  !"Snap account rollup_state has invalid length %{sexp: \
+                  !"Snap account sequence_state has invalid length %{sexp: \
                     Runtime_config.Accounts.Single.t} length: %d"
-                  t (List.length rollup_state)
-              else Ok (Pickles_types.Vector.Vector_5.of_list_exn rollup_state)
+                  t
+                  (List.length sequence_state)
+              else Ok (Pickles_types.Vector.Vector_5.of_list_exn sequence_state)
             in
-            let last_rollup_slot =
-              Mina_numbers.Global_slot.of_int last_rollup_slot
+            let last_sequence_slot =
+              Mina_numbers.Global_slot.of_int last_sequence_slot
             in
             Some
               { Snapp_account.verification_key
               ; app_state
               ; snapp_version
-              ; rollup_state
-              ; last_rollup_slot
+              ; sequence_state
+              ; last_sequence_slot
               ; proved_state
               }
       in
@@ -237,7 +238,7 @@ module Accounts = struct
             ; set_permissions
             ; set_verification_key
             ; set_snapp_uri
-            ; edit_rollup_state
+            ; edit_sequence_state
             ; set_token_symbol
             } =
           account.permissions
@@ -251,7 +252,7 @@ module Accounts = struct
           ; set_permissions = auth_required set_permissions
           ; set_verification_key = auth_required set_verification_key
           ; set_snapp_uri = auth_required set_snapp_uri
-          ; edit_rollup_state = auth_required edit_rollup_state
+          ; edit_sequence_state = auth_required edit_sequence_state
           ; set_token_symbol = auth_required set_token_symbol
           }
       in
@@ -261,8 +262,8 @@ module Accounts = struct
                { app_state
                ; verification_key
                ; snapp_version
-               ; rollup_state
-               ; last_rollup_slot
+               ; sequence_state
+               ; last_sequence_slot
                ; proved_state
                }
              ->
@@ -270,15 +271,15 @@ module Accounts = struct
             let verification_key =
               Option.map verification_key ~f:With_hash.data
             in
-            let rollup_state = Pickles_types.Vector.to_list rollup_state in
-            let last_rollup_slot =
-              Mina_numbers.Global_slot.to_int last_rollup_slot
+            let sequence_state = Pickles_types.Vector.to_list sequence_state in
+            let last_sequence_slot =
+              Mina_numbers.Global_slot.to_int last_sequence_slot
             in
             { Runtime_config.Accounts.Single.Snapp_account.state
             ; verification_key
             ; snapp_version
-            ; rollup_state
-            ; last_rollup_slot
+            ; sequence_state
+            ; last_sequence_slot
             ; proved_state
             })
       in

--- a/src/lib/hash_prefix_states/hash_prefix_states.ml
+++ b/src/lib/hash_prefix_states/hash_prefix_states.ml
@@ -114,6 +114,6 @@ let snapp_event = salt snapp_event
 
 let snapp_events = salt snapp_events
 
-let snapp_rollup_events = salt snapp_rollup_events
+let snapp_sequence_events = salt snapp_sequence_events
 
 let snapp_memo = salt snapp_memo

--- a/src/lib/hash_prefix_states/hash_prefix_states.mli
+++ b/src/lib/hash_prefix_states/hash_prefix_states.mli
@@ -93,6 +93,6 @@ val snapp_event : Field.t State.t
 
 val snapp_events : Field.t State.t
 
-val snapp_rollup_events : Field.t State.t
+val snapp_sequence_events : Field.t State.t
 
 val snapp_memo : Field.t State.t

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -95,6 +95,6 @@ let snapp_event = create "MinaSnappEvent"
 
 let snapp_events = create "MinaSnappEvents"
 
-let snapp_rollup_events = create "MinaSnappRollup"
+let snapp_sequence_events = create "MinaSnappRollup"
 
 let snapp_memo = create "MinaSnappMemo"

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -95,6 +95,6 @@ let snapp_event = create "MinaSnappEvent"
 
 let snapp_events = create "MinaSnappEvents"
 
-let snapp_sequence_events = create "MinaSnappRollup"
+let snapp_sequence_events = create "MinaSnappSeqEvents"
 
 let snapp_memo = create "MinaSnappMemo"

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -357,7 +357,7 @@ module Update = struct
 end
 
 module Events = Snapp_account.Events
-module Rollup_events = Snapp_account.Rollup_events
+module Sequence_events = Snapp_account.Sequence_events
 
 module Body = struct
   module Poly = struct

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -370,7 +370,7 @@ module Body = struct
           ; token_id : 'token_id
           ; delta : 'amount
           ; events : 'events
-          ; rollup_events : 'events
+          ; sequence_events : 'events
           ; call_data : 'call_data
           ; depth : 'int
           }
@@ -428,7 +428,7 @@ module Body = struct
       ; token_id = ()
       ; delta = Fee.zero
       ; events = []
-      ; rollup_events = []
+      ; sequence_events = []
       ; call_data = Field.zero
       ; depth = 0
       }
@@ -457,7 +457,7 @@ module Body = struct
          ; token_id
          ; delta
          ; events
-         ; rollup_events
+         ; sequence_events
          ; call_data
          ; depth = _depth (* ignored *)
          } :
@@ -468,7 +468,7 @@ module Body = struct
         ; Impl.run_checked (Token_id.Checked.to_input token_id)
         ; Amount.Signed.Checked.to_input delta
         ; Events.var_to_input events
-        ; Events.var_to_input rollup_events
+        ; Events.var_to_input sequence_events
         ; Random_oracle_input.field call_data
         ]
 
@@ -498,7 +498,7 @@ module Body = struct
     ; token_id = Token_id.default
     ; delta = Amount.Signed.zero
     ; events = []
-    ; rollup_events = []
+    ; sequence_events = []
     ; call_data = Field.zero
     ; depth = 0
     }
@@ -509,7 +509,7 @@ module Body = struct
        ; token_id
        ; delta
        ; events
-       ; rollup_events
+       ; sequence_events
        ; call_data
        ; depth = _ (* ignored *)
        } :
@@ -520,7 +520,7 @@ module Body = struct
       ; Token_id.to_input token_id
       ; Amount.Signed.to_input delta
       ; Events.to_input events
-      ; Events.to_input rollup_events
+      ; Events.to_input sequence_events
       ; Random_oracle_input.field call_data
       ]
 

--- a/src/lib/mina_base/permissions.ml
+++ b/src/lib/mina_base/permissions.ml
@@ -302,7 +302,7 @@ module Poly = struct
         ; set_permissions : 'controller
         ; set_verification_key : 'controller
         ; set_snapp_uri : 'controller
-        ; edit_rollup_state : 'controller
+        ; edit_sequence_state : 'controller
         ; set_token_symbol : 'controller
         }
       [@@deriving sexp, equal, compare, hash, yojson, hlist, fields]
@@ -316,7 +316,7 @@ module Poly = struct
       ~edit_state:(f controller) ~send:(f controller)
       ~set_delegate:(f controller) ~set_permissions:(f controller)
       ~set_verification_key:(f controller) ~receive:(f controller)
-      ~set_snapp_uri:(f controller) ~edit_rollup_state:(f controller)
+      ~set_snapp_uri:(f controller) ~edit_sequence_state:(f controller)
       ~set_token_symbol:(f controller)
     |> List.reduce_exn ~f:Random_oracle.Input.append
 end
@@ -341,7 +341,7 @@ let gen : t Quickcheck.Generator.t =
   let%bind set_permissions = Auth_required.gen in
   let%bind set_verification_key = Auth_required.gen in
   let%bind set_snapp_uri = Auth_required.gen in
-  let%bind edit_rollup_state = Auth_required.gen in
+  let%bind edit_sequence_state = Auth_required.gen in
   let%bind set_token_symbol = Auth_required.gen in
   return
     { Poly.stake
@@ -352,7 +352,7 @@ let gen : t Quickcheck.Generator.t =
     ; set_permissions
     ; set_verification_key
     ; set_snapp_uri
-    ; edit_rollup_state
+    ; edit_sequence_state
     ; set_token_symbol
     }
 
@@ -374,7 +374,7 @@ module Checked = struct
     let c = g Auth_required.Checked.if_ in
     Poly.Fields.map ~stake:(g Boolean.if_) ~edit_state:c ~send:c ~receive:c
       ~set_delegate:c ~set_permissions:c ~set_verification_key:c
-      ~set_snapp_uri:c ~edit_rollup_state:c ~set_token_symbol:c
+      ~set_snapp_uri:c ~edit_sequence_state:c ~set_token_symbol:c
 
   let constant (t : Stable.Latest.t) : t =
     let open Core_kernel.Field in
@@ -382,7 +382,7 @@ module Checked = struct
     Poly.Fields.map
       ~stake:(fun f -> Boolean.var_of_value (get f t))
       ~edit_state:a ~send:a ~receive:a ~set_delegate:a ~set_permissions:a
-      ~set_verification_key:a ~set_snapp_uri:a ~edit_rollup_state:a
+      ~set_verification_key:a ~set_snapp_uri:a ~edit_sequence_state:a
       ~set_token_symbol:a
 end
 
@@ -416,7 +416,7 @@ let user_default : t =
   ; set_permissions = Signature
   ; set_verification_key = Signature
   ; set_snapp_uri = Signature
-  ; edit_rollup_state = Signature
+  ; edit_sequence_state = Signature
   ; set_token_symbol = Signature
   }
 
@@ -429,6 +429,6 @@ let empty : t =
   ; set_permissions = None
   ; set_verification_key = None
   ; set_snapp_uri = None
-  ; edit_rollup_state = None
+  ; edit_sequence_state = None
   ; set_token_symbol = None
   }

--- a/src/lib/mina_base/permissions.mli
+++ b/src/lib/mina_base/permissions.mli
@@ -54,7 +54,7 @@ module Poly : sig
         ; set_permissions : 'controller
         ; set_verification_key : 'controller
         ; set_snapp_uri : 'controller
-        ; edit_rollup_state : 'controller
+        ; edit_sequence_state : 'controller
         ; set_token_symbol : 'controller
         }
       [@@deriving sexp, equal, compare, hash, yojson, hlist, fields]

--- a/src/lib/mina_base/snapp_account.ml
+++ b/src/lib/mina_base/snapp_account.ml
@@ -100,7 +100,7 @@ module Events = struct
 end
 
 module Sequence_events = struct
-  let empty_hash = lazy Random_oracle.(salt "MinaSnappRollupEmpty" |> digest)
+  let empty_hash = lazy Random_oracle.(salt "MinaSnappSequenceEmpty" |> digest)
 
   let push_hash acc hash =
     Random_oracle.hash ~init:Hash_prefix_states.snapp_sequence_events
@@ -125,8 +125,8 @@ module Poly = struct
         { app_state : 'app_state
         ; verification_key : 'vk
         ; snapp_version : 'snapp_version
-        ; rollup_state : 'field Pickles_types.Vector.Vector_5.Stable.V1.t
-        ; last_rollup_slot : 'slot
+        ; sequence_state : 'field Pickles_types.Vector.Vector_5.Stable.V1.t
+        ; last_sequence_slot : 'slot
         ; proved_state : 'bool
         }
       [@@deriving sexp, equal, compare, hash, yojson, hlist, fields]
@@ -145,8 +145,8 @@ type ('app_state, 'vk, 'snapp_version, 'field, 'slot, 'bool) t_ =
   { app_state : 'app_state
   ; verification_key : 'vk
   ; snapp_version : 'snapp_version
-  ; rollup_state : 'field Pickles_types.Vector.Vector_5.t
-  ; last_rollup_slot : 'slot
+  ; sequence_state : 'field Pickles_types.Vector.Vector_5.t
+  ; last_sequence_slot : 'slot
   ; proved_state : 'bool
   }
 
@@ -183,10 +183,10 @@ module Stable = struct
       { app_state
       ; verification_key
       ; snapp_version = Mina_numbers.Snapp_version.zero
-      ; rollup_state =
+      ; sequence_state =
           (let empty = Lazy.force Sequence_events.empty_hash in
            [ empty; empty; empty; empty; empty ])
-      ; last_rollup_slot = Mina_numbers.Global_slot.zero
+      ; last_sequence_slot = Mina_numbers.Global_slot.zero
       ; proved_state = false
       }
   end
@@ -222,8 +222,8 @@ module Checked = struct
       ~snapp_version:
         (f (fun x ->
              Run.run_checked (Mina_numbers.Snapp_version.Checked.to_input x)))
-      ~rollup_state:(f app_state)
-      ~last_rollup_slot:
+      ~sequence_state:(f app_state)
+      ~last_sequence_slot:
         (f (fun x ->
              Run.run_checked (Mina_numbers.Global_slot.Checked.to_input x)))
       ~proved_state:(f (fun b -> bitstring [ b ]))
@@ -286,8 +286,8 @@ let to_input (t : t) =
          (Fn.compose field
             (Option.value_map ~default:(dummy_vk_hash ()) ~f:With_hash.hash)))
     ~snapp_version:(f Mina_numbers.Snapp_version.to_input)
-    ~rollup_state:(f app_state)
-    ~last_rollup_slot:(f Mina_numbers.Global_slot.to_input)
+    ~sequence_state:(f app_state)
+    ~last_sequence_slot:(f Mina_numbers.Global_slot.to_input)
     ~proved_state:(f (fun b -> bitstring [ b ]))
   |> List.reduce_exn ~f:append
 
@@ -296,10 +296,10 @@ let default : _ Poly.t =
   { app_state = Vector.init Snapp_state.Max_state_size.n ~f:(fun _ -> F.zero)
   ; verification_key = None
   ; snapp_version = Mina_numbers.Snapp_version.zero
-  ; rollup_state =
+  ; sequence_state =
       (let empty = Lazy.force Sequence_events.empty_hash in
        [ empty; empty; empty; empty; empty ])
-  ; last_rollup_slot = Mina_numbers.Global_slot.zero
+  ; last_sequence_slot = Mina_numbers.Global_slot.zero
   ; proved_state = false
   }
 

--- a/src/lib/mina_base/snapp_account.ml
+++ b/src/lib/mina_base/snapp_account.ml
@@ -99,7 +99,7 @@ module Events = struct
   [%%endif]
 end
 
-module Rollup_events = struct
+module Sequence_events = struct
   let empty_hash = lazy Random_oracle.(salt "MinaSnappRollupEmpty" |> digest)
 
   let push_hash acc hash =
@@ -184,7 +184,7 @@ module Stable = struct
       ; verification_key
       ; snapp_version = Mina_numbers.Snapp_version.zero
       ; rollup_state =
-          (let empty = Lazy.force Rollup_events.empty_hash in
+          (let empty = Lazy.force Sequence_events.empty_hash in
            [ empty; empty; empty; empty; empty ])
       ; last_rollup_slot = Mina_numbers.Global_slot.zero
       ; proved_state = false
@@ -297,7 +297,7 @@ let default : _ Poly.t =
   ; verification_key = None
   ; snapp_version = Mina_numbers.Snapp_version.zero
   ; rollup_state =
-      (let empty = Lazy.force Rollup_events.empty_hash in
+      (let empty = Lazy.force Sequence_events.empty_hash in
        [ empty; empty; empty; empty; empty ])
   ; last_rollup_slot = Mina_numbers.Global_slot.zero
   ; proved_state = false

--- a/src/lib/mina_base/snapp_account.ml
+++ b/src/lib/mina_base/snapp_account.ml
@@ -103,7 +103,7 @@ module Rollup_events = struct
   let empty_hash = lazy Random_oracle.(salt "MinaSnappRollupEmpty" |> digest)
 
   let push_hash acc hash =
-    Random_oracle.hash ~init:Hash_prefix_states.snapp_rollup_events
+    Random_oracle.hash ~init:Hash_prefix_states.snapp_sequence_events
       [| acc; hash |]
 
   let push_events acc events = push_hash acc (Events.hash events)
@@ -111,7 +111,7 @@ module Rollup_events = struct
   [%%ifdef consensus_mechanism]
 
   let push_events_checked x (e : Events.var) =
-    Random_oracle.Checked.hash ~init:Hash_prefix_states.snapp_rollup_events
+    Random_oracle.Checked.hash ~init:Hash_prefix_states.snapp_sequence_events
       [| x; Data_as_hash.hash e |]
 
   [%%endif]

--- a/src/lib/mina_base/snapp_generators.ml
+++ b/src/lib/mina_base/snapp_generators.ml
@@ -439,7 +439,7 @@ let gen_party_body (type a) ?account_id ?balances_tbl ?(new_account = false)
   in
   (* TODO: are these lengths reasonable? *)
   let%bind events = field_array_list_gen ~max_array_len:8 ~max_list_len:12 in
-  let%bind rollup_events =
+  let%bind sequence_events =
     field_array_list_gen ~max_array_len:4 ~max_list_len:6
   in
   let%map call_data = Snark_params.Tick.Field.gen in
@@ -450,7 +450,7 @@ let gen_party_body (type a) ?account_id ?balances_tbl ?(new_account = false)
   ; token_id
   ; delta
   ; events
-  ; rollup_events
+  ; sequence_events
   ; call_data
   ; depth
   }

--- a/src/lib/mina_base/snapp_generators.ml
+++ b/src/lib/mina_base/snapp_generators.ml
@@ -103,7 +103,7 @@ let gen_predicate_from ?(succeed = true) ~account_id ~ledger =
                 | Some pk ->
                     Or_ignore.gen (return pk)
               in
-              let%bind state, rollup_state, proved_state =
+              let%bind state, sequence_state, proved_state =
                 match snapp with
                 | None ->
                     (* won't raise, correct length given *)
@@ -111,18 +111,18 @@ let gen_predicate_from ?(succeed = true) ~account_id ~ledger =
                       Snapp_state.V.of_list_exn
                         (List.init 8 ~f:(fun _ -> Or_ignore.Ignore))
                     in
-                    let rollup_state = Or_ignore.Ignore in
+                    let sequence_state = Or_ignore.Ignore in
                     let proved_state = Or_ignore.Ignore in
-                    return (state, rollup_state, proved_state)
-                | Some { app_state; rollup_state; proved_state; _ } ->
+                    return (state, sequence_state, proved_state)
+                | Some { app_state; sequence_state; proved_state; _ } ->
                     let state =
                       Snapp_state.V.map app_state ~f:(fun field ->
                           Quickcheck.random_value (Or_ignore.gen (return field)))
                     in
-                    let%bind rollup_state =
-                      (* choose a value from account rollup state *)
+                    let%bind sequence_state =
+                      (* choose a value from account sequence state *)
                       let fields =
-                        Pickles_types.Vector.Vector_5.to_list rollup_state
+                        Pickles_types.Vector.Vector_5.to_list sequence_state
                       in
                       let%bind ndx =
                         Int.gen_uniform_incl 0 (List.length fields - 1)
@@ -130,7 +130,7 @@ let gen_predicate_from ?(succeed = true) ~account_id ~ledger =
                       return (Or_ignore.Check (List.nth_exn fields ndx))
                     in
                     let proved_state = Or_ignore.Check proved_state in
-                    return (state, rollup_state, proved_state)
+                    return (state, sequence_state, proved_state)
               in
               return
                 { Snapp_predicate.Account.Poly.balance
@@ -139,7 +139,7 @@ let gen_predicate_from ?(succeed = true) ~account_id ~ledger =
                 ; public_key
                 ; delegate
                 ; state
-                ; rollup_state
+                ; sequence_state
                 ; proved_state
                 }
             in
@@ -152,7 +152,7 @@ let gen_predicate_from ?(succeed = true) ~account_id ~ledger =
                   | Receipt_chain_hash
                   | Delegate
                   | State
-                  | Rollup_state
+                  | Sequence_state
                   | Proved_state
               end in
               let%bind faulty_predicate_account =
@@ -163,7 +163,7 @@ let gen_predicate_from ?(succeed = true) ~account_id ~ledger =
                   ; Receipt_chain_hash
                   ; Delegate
                   ; State
-                  ; Rollup_state
+                  ; Sequence_state
                   ; Proved_state
                   ]
                 in
@@ -215,10 +215,10 @@ let gen_predicate_from ?(succeed = true) ~account_id ~ledger =
                       Snapp_state.V.of_list_exn (Array.to_list fields)
                     in
                     return { predicate_account with state }
-                | Rollup_state ->
+                | Sequence_state ->
                     let%bind field = Snark_params.Tick.Field.gen in
-                    let rollup_state = Or_ignore.Check field in
-                    return { predicate_account with rollup_state }
+                    let sequence_state = Or_ignore.Check field in
+                    return { predicate_account with sequence_state }
                 | Proved_state ->
                     let%bind proved_state =
                       match predicate_account.proved_state with

--- a/src/lib/mina_base/snapp_predicate.ml
+++ b/src/lib/mina_base/snapp_predicate.ml
@@ -232,7 +232,7 @@ module Eq_data = struct
         ; to_input_checked = field
         }
 
-    let rollup_state =
+    let sequence_state =
       let open Random_oracle_input in
       lazy
         Field.
@@ -397,7 +397,7 @@ module Account = struct
           ; public_key : 'pk
           ; delegate : 'pk
           ; state : 'field Snapp_state.V.Stable.V1.t
-          ; rollup_state : 'field
+          ; sequence_state : 'field
           ; proved_state : 'bool
           }
         [@@deriving hlist, sexp, equal, yojson, hash, compare]
@@ -452,7 +452,7 @@ module Account = struct
         ; public_key
         ; delegate
         ; state
-        ; rollup_state = Ignore
+        ; sequence_state = Ignore
         ; proved_state = Ignore
         }
     end
@@ -473,7 +473,7 @@ module Account = struct
       (* won't raise because length is correct *)
       Quickcheck.Generator.return (Snapp_state.V.of_list_exn fields)
     in
-    let%bind rollup_state =
+    let%bind sequence_state =
       let%bind n = Int.gen_uniform_incl Int.min_value Int.max_value in
       let field_gen = Quickcheck.Generator.return (F.of_int n) in
       Or_ignore.gen field_gen
@@ -486,7 +486,7 @@ module Account = struct
       ; public_key
       ; delegate
       ; state
-      ; rollup_state
+      ; sequence_state
       ; proved_state
       }
 
@@ -498,7 +498,7 @@ module Account = struct
     ; delegate = Ignore
     ; state =
         Vector.init Snapp_state.Max_state_size.n ~f:(fun _ -> Or_ignore.Ignore)
-    ; rollup_state = Ignore
+    ; sequence_state = Ignore
     ; proved_state = Ignore
     }
 
@@ -509,7 +509,7 @@ module Account = struct
        ; public_key
        ; delegate
        ; state
-       ; rollup_state
+       ; sequence_state
        ; proved_state
        } :
         t) =
@@ -522,8 +522,8 @@ module Account = struct
       ; Eq_data.(to_input_explicit (Tc.public_key ()) delegate)
       ; Vector.reduce_exn ~f:append
           (Vector.map state ~f:Eq_data.(to_input_explicit Tc.field))
-      ; Eq_data.(to_input ~explicit:false (Lazy.force Tc.rollup_state))
-          rollup_state
+      ; Eq_data.(to_input ~explicit:false (Lazy.force Tc.sequence_state))
+          sequence_state
       ; Eq_data.(to_input_explicit Tc.boolean) proved_state
       ]
 
@@ -548,7 +548,7 @@ module Account = struct
          ; public_key
          ; delegate
          ; state
-         ; rollup_state
+         ; sequence_state
          ; proved_state
          } :
           t) =
@@ -561,7 +561,8 @@ module Account = struct
         ; Eq_data.(to_input_checked (Tc.public_key ()) delegate)
         ; Vector.reduce_exn ~f:append
             (Vector.map state ~f:Eq_data.(to_input_checked Tc.field))
-        ; Eq_data.(to_input_checked (Lazy.force Tc.rollup_state)) rollup_state
+        ; Eq_data.(to_input_checked (Lazy.force Tc.sequence_state))
+            sequence_state
         ; Eq_data.(to_input_checked Tc.boolean) proved_state
         ]
 
@@ -574,7 +575,7 @@ module Account = struct
          ; public_key
          ; delegate
          ; state = _
-         ; rollup_state = _
+         ; sequence_state = _
          ; proved_state = _
          } :
           t) (a : Account.Checked.Unhashed.t) =
@@ -596,17 +597,17 @@ module Account = struct
          ; public_key = _
          ; delegate = _
          ; state
-         ; rollup_state
+         ; sequence_state
          ; proved_state
          } :
           t) (snapp : Snapp_account.Checked.t) =
       Boolean.any
         Vector.(
           to_list
-            (map snapp.rollup_state
+            (map snapp.sequence_state
                ~f:
                  Eq_data.(
-                   check_checked (Lazy.force Tc.rollup_state) rollup_state)))
+                   check_checked (Lazy.force Tc.sequence_state) sequence_state)))
       :: Eq_data.(check_checked Tc.boolean proved_state snapp.proved_state)
       :: Vector.(
            to_list
@@ -645,7 +646,7 @@ module Account = struct
        ; public_key
        ; delegate
        ; state
-       ; rollup_state
+       ; sequence_state
        ; proved_state
        } :
         t) (a : Account.t) =
@@ -690,14 +691,14 @@ module Account = struct
           in
           if
             Option.is_some
-            @@ List.find (Vector.to_list snapp.rollup_state) ~f:(fun state ->
+            @@ List.find (Vector.to_list snapp.sequence_state) ~f:(fun state ->
                    Eq_data.(
                      check
-                       (Lazy.force Tc.rollup_state)
-                       ~label:"" rollup_state state)
+                       (Lazy.force Tc.sequence_state)
+                       ~label:"" sequence_state state)
                    |> Or_error.is_ok)
           then Ok ()
-          else Or_error.errorf "Equality check failed: rollup_state"
+          else Or_error.errorf "Equality check failed: sequence_state"
     in
     return ()
 end

--- a/src/lib/mina_base/snapp_predicate.ml
+++ b/src/lib/mina_base/snapp_predicate.ml
@@ -239,7 +239,7 @@ module Eq_data = struct
           { typ
           ; equal
           ; equal_checked = run Checked.equal
-          ; default = Lazy.force Snapp_account.Rollup_events.empty_hash
+          ; default = Lazy.force Snapp_account.Sequence_events.empty_hash
           ; to_input = field
           ; to_input_checked = field
           }
@@ -632,7 +632,7 @@ module Account = struct
       ; public_key ()
       ; Snapp_state.typ (Or_ignore.typ_explicit Field.typ ~ignore:Field.zero)
       ; Or_ignore.typ_implicit Field.typ ~equal:Field.equal
-          ~ignore:(Lazy.force Snapp_account.Rollup_events.empty_hash)
+          ~ignore:(Lazy.force Snapp_account.Sequence_events.empty_hash)
       ; Or_ignore.typ_explicit Boolean.typ ~ignore:false
       ]
       ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1364,12 +1364,12 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         update a.permissions.set_verification_key verification_key
           init.verification_key ~is_keep:Set_or_keep.is_keep ~update:(fun u x ->
             match (u, x) with Keep, _ -> x | Set x, _ -> Some x)
-      and rollup_state, last_rollup_slot =
-        let [ s1; s2; s3; s4; s5 ] = init.rollup_state in
-        let last_rollup_slot = init.last_rollup_slot in
+      and sequence_state, last_sequence_slot =
+        let [ s1; s2; s3; s4; s5 ] = init.sequence_state in
+        let last_sequence_slot = init.last_sequence_slot in
         let is_this_slot =
           Mina_numbers.Global_slot.equal global_slot_since_genesis
-            last_rollup_slot
+            last_sequence_slot
         in
         (* Shift along if last update wasn't this slot *)
         let s5 = if is_this_slot then s5 else s4 in
@@ -1382,15 +1382,15 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           if is_empty then s1
           else Party.Sequence_events.push_events s1 sequence_events
         in
-        let new_rollup_state =
+        let new_sequence_state =
           if is_empty then Set_or_keep.Keep
           else
             Set_or_keep.Set
               ( ([ s1; s2; s3; s4; s5 ] : _ Pickles_types.Vector.t)
               , global_slot_since_genesis )
         in
-        update a.permissions.edit_rollup_state new_rollup_state
-          (init.rollup_state, init.last_rollup_slot)
+        update a.permissions.edit_sequence_state new_sequence_state
+          (init.sequence_state, init.last_sequence_slot)
           ~is_keep:Set_or_keep.is_keep ~update:(fun u x ->
             match u with Keep -> x | Set x -> x)
       in
@@ -1402,8 +1402,8 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         { app_state
         ; verification_key
         ; snapp_version
-        ; rollup_state
-        ; last_rollup_slot
+        ; sequence_state
+        ; last_sequence_slot
         ; proved_state
         }
       in

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1260,7 +1260,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
            ; delta
            ; events = _ (* This is for the snapp to use, we don't need it. *)
            ; call_data = _ (* This is for the snapp to use, we don't need it. *)
-           ; rollup_events
+           ; sequence_events
            ; depth = _ (* This is used to build the 'stack of stacks'. *)
            }
        ; predicate
@@ -1377,10 +1377,10 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         let s3 = if is_this_slot then s3 else s2 in
         let s2 = if is_this_slot then s2 else s1 in
         (* Push events to s1 *)
-        let is_empty = List.is_empty rollup_events in
+        let is_empty = List.is_empty sequence_events in
         let s1 =
           if is_empty then s1
-          else Party.Rollup_events.push_events s1 rollup_events
+          else Party.Rollup_events.push_events s1 sequence_events
         in
         let new_rollup_state =
           if is_empty then Set_or_keep.Keep
@@ -2528,7 +2528,7 @@ module For_tests = struct
                   ; token_id = ()
                   ; delta = fee
                   ; events = []
-                  ; rollup_events = []
+                  ; sequence_events = []
                   ; call_data = Snark_params.Tick.Field.zero
                   ; depth = 0
                   }
@@ -2545,7 +2545,7 @@ module For_tests = struct
                     ; token_id = Token_id.default
                     ; delta = Amount.Signed.(negate (of_unsigned amount))
                     ; events = []
-                    ; rollup_events = []
+                    ; sequence_events = []
                     ; call_data = Snark_params.Tick.Field.zero
                     ; depth = 0
                     }
@@ -2560,7 +2560,7 @@ module For_tests = struct
                     ; token_id = Token_id.default
                     ; delta = Amount.Signed.(of_unsigned amount)
                     ; events = []
-                    ; rollup_events = []
+                    ; sequence_events = []
                     ; call_data = Snark_params.Tick.Field.zero
                     ; depth = 0
                     }

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1380,7 +1380,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         let is_empty = List.is_empty sequence_events in
         let s1 =
           if is_empty then s1
-          else Party.Rollup_events.push_events s1 sequence_events
+          else Party.Sequence_events.push_events s1 sequence_events
         in
         let new_rollup_state =
           if is_empty then Set_or_keep.Keep

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1556,9 +1556,9 @@ module Types = struct
               ~args:Arg.[]
               ~resolve:(fun _ (party : Party.t) ->
                 mk_field_lists party.data.body.events)
-          ; field "rollupEvents"
+          ; field "sequenceEvents"
               ~doc:
-                "Rollup events associated with the party (fields in \
+                "Sequence events associated with the party (fields in \
                  Base58Check)"
               ~typ:(non_null (list (non_null (list (non_null string)))))
               ~args:Arg.[]
@@ -2477,7 +2477,8 @@ module Types = struct
             ; arg "delta" ~doc:"Signed amount" ~typ:(non_null snapp_delta)
             ; arg "events" ~doc:"A list of list of fields in Base58Check"
                 ~typ:(non_null (list (non_null (list (non_null string)))))
-            ; arg "rollupEvents" ~doc:"A list of list of fields in Base58Check"
+            ; arg "sequenceEvents"
+                ~doc:"A list of list of fields in Base58Check"
                 ~typ:(non_null (list (non_null (list (non_null string)))))
             ; arg "callData" ~doc:"A field in Base58Check"
                 ~typ:(non_null string)
@@ -2526,7 +2527,8 @@ module Types = struct
             ; arg "fee" ~doc:"Transaction fee" ~typ:(non_null fee)
             ; arg "events" ~doc:"A list of list of fields in Base58Check"
                 ~typ:(non_null (list (non_null (list (non_null string)))))
-            ; arg "rollupEvents" ~doc:"A list of list of fields in Base58Check"
+            ; arg "sequenceEvents"
+                ~doc:"A list of list of fields in Base58Check"
                 ~typ:(non_null (list (non_null (list (non_null string)))))
             ; arg "callData" ~doc:"A field in Base58Check"
                 ~typ:(non_null string)

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1563,7 +1563,7 @@ module Types = struct
               ~typ:(non_null (list (non_null (list (non_null string)))))
               ~args:Arg.[]
               ~resolve:(fun _ (party : Party.t) ->
-                mk_field_lists party.data.body.rollup_events)
+                mk_field_lists party.data.body.sequence_events)
           ])
 
     let snapp_command =
@@ -2436,8 +2436,8 @@ module Types = struct
       let snapp_party_body : (Party.Body.t, string) Result.t option arg_typ =
         obj "PartyBody" ~doc:"Body component of a Snapp Party"
           ~coerce:
-            (fun pk update_result token_id delta events rollup_events call_data
-                 depth ->
+            (fun pk update_result token_id delta events sequence_events
+                 call_data depth ->
             try
               let open Result.Let_syntax in
               let%bind pk =
@@ -2454,7 +2454,7 @@ module Types = struct
               let%bind update = update_result in
               let%map delta = delta in
               let events = mk_field_arrays events in
-              let rollup_events = mk_field_arrays rollup_events in
+              let sequence_events = mk_field_arrays sequence_events in
               let call_data = Snark_params.Tick.Field.of_string call_data in
               let depth = Int.of_string depth in
               Party.Body.Poly.
@@ -2463,7 +2463,7 @@ module Types = struct
                 ; token_id
                 ; delta
                 ; events
-                ; rollup_events
+                ; sequence_events
                 ; call_data
                 ; depth
                 }
@@ -2488,7 +2488,7 @@ module Types = struct
       let snapp_fee_payer_party_body =
         obj "FeePayerPartyBody" ~doc:"Body component of a Snapp Fee Payer Party"
           ~coerce:
-            (fun pk update_result fee events rollup_events call_data depth ->
+            (fun pk update_result fee events sequence_events call_data depth ->
             try
               let open Result.Let_syntax in
               let%bind pk =
@@ -2505,7 +2505,7 @@ module Types = struct
               let%map update = update_result in
               let delta = fee in
               let events = mk_field_arrays events in
-              let rollup_events = mk_field_arrays rollup_events in
+              let sequence_events = mk_field_arrays sequence_events in
               let call_data = Snark_params.Tick.Field.of_string call_data in
               let depth = Int.of_string depth in
               { Party.Body.Poly.pk
@@ -2513,7 +2513,7 @@ module Types = struct
               ; token_id
               ; delta
               ; events
-              ; rollup_events
+              ; sequence_events
               ; call_data
               ; depth
               }

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2302,7 +2302,7 @@ module Types = struct
         obj "Permissions"
           ~coerce:
             (fun stake edit_state send receive set_delegate set_permissions
-                 set_verification_key set_snapp_uri edit_rollup_state
+                 set_verification_key set_snapp_uri edit_sequence_state
                  set_token_symbol ->
             Ok
               { Permissions.Poly.stake
@@ -2313,7 +2313,7 @@ module Types = struct
               ; set_permissions
               ; set_verification_key
               ; set_snapp_uri
-              ; edit_rollup_state
+              ; edit_sequence_state
               ; set_token_symbol
               })
           ~fields:
@@ -2325,7 +2325,7 @@ module Types = struct
             ; arg "setPermissions" ~typ:(non_null snapp_auth_required)
             ; arg "setVerificationKey" ~typ:(non_null snapp_auth_required)
             ; arg "setSnappUri" ~typ:(non_null snapp_auth_required)
-            ; arg "editRollupState" ~typ:(non_null snapp_auth_required)
+            ; arg "editSequenceState" ~typ:(non_null snapp_auth_required)
             ; arg "setTokenSymbol" ~typ:(non_null snapp_auth_required)
             ]
 
@@ -2720,7 +2720,7 @@ module Types = struct
           ~coerce:
             (fun balance_result nonce_result receipt_chain_hash_result
                  public_key_result delegate_result state_result
-                 rollup_state_result proved_state_result ->
+                 sequence_state_result proved_state_result ->
             let open Result.Let_syntax in
             let%bind balance = balance_result in
             let%bind nonce = nonce_result in
@@ -2728,7 +2728,7 @@ module Types = struct
             let%bind public_key = public_key_result in
             let%bind delegate = delegate_result in
             let%bind state = state_result in
-            let%bind rollup_state = rollup_state_result in
+            let%bind sequence_state = sequence_state_result in
             let%bind proved_state = proved_state_result in
             return
               ( Snapp_predicate.Account.Poly.
@@ -2738,7 +2738,7 @@ module Types = struct
                   ; public_key
                   ; delegate
                   ; state
-                  ; rollup_state
+                  ; sequence_state
                   ; proved_state
                   }
                 : Snapp_predicate.Account.t ))
@@ -2750,7 +2750,7 @@ module Types = struct
             ; arg "publicKey" ~typ:(non_null snapp_pk_or_ignore)
             ; arg "delegate" ~typ:(non_null snapp_pk_or_ignore)
             ; arg "state" ~typ:(non_null snapp_state)
-            ; arg "rollupState" ~typ:(non_null snapp_field_or_ignore)
+            ; arg "sequenceState" ~typ:(non_null snapp_field_or_ignore)
             ; arg "provedState" ~typ:(non_null snapp_bool_or_ignore)
             ]
 

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -122,7 +122,7 @@ module Json_layout = struct
           ; set_permissions : Auth_required.t [@default None]
           ; set_verification_key : Auth_required.t [@default None]
           ; set_snapp_uri : Auth_required.t [@default None]
-          ; edit_rollup_state : Auth_required.t [@default None]
+          ; edit_sequence_state : Auth_required.t [@default None]
           ; set_token_symbol : Auth_required.t [@default None]
           }
         [@@deriving yojson, dhall_type, sexp, bin_io_unversioned]
@@ -136,7 +136,7 @@ module Json_layout = struct
            ; "set_permissions"
            ; "set_verification_key"
            ; "set_snapp_uri"
-           ; "edit_rollup_state"
+           ; "edit_sequence_state"
            ; "set_token_symbol"
           |]
 
@@ -211,8 +211,8 @@ module Json_layout = struct
           { state : Field.t list
           ; verification_key : Verification_key.t option
           ; snapp_version : Snapp_version.t
-          ; rollup_state : Field.t list
-          ; last_rollup_slot : int
+          ; sequence_state : Field.t list
+          ; last_sequence_slot : int
           ; proved_state : bool
           }
         [@@deriving sexp, dhall_type, yojson, bin_io_unversioned]
@@ -221,8 +221,8 @@ module Json_layout = struct
           [| "state"
            ; "verification_key"
            ; "snapp_version"
-           ; "rollup_state"
-           ; "last_rollup_slot"
+           ; "sequence_state"
+           ; "last_sequence_slot"
            ; "proved_state"
           |]
 

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1396,12 +1396,12 @@ module Base = struct
                 (Set_or_keep.Checked.set_or_keep ~if_:Field.if_ verification_key
                    (Lazy.force a.snapp.verification_key.hash)))
         in
-        let rollup_state, last_rollup_slot =
-          let [ s1'; s2'; s3'; s4'; s5' ] = a.snapp.rollup_state in
-          let last_rollup_slot = a.snapp.last_rollup_slot in
+        let sequence_state, last_sequence_slot =
+          let [ s1'; s2'; s3'; s4'; s5' ] = a.snapp.sequence_state in
+          let last_sequence_slot = a.snapp.last_sequence_slot in
           let is_this_slot =
             !(Mina_numbers.Global_slot.Checked.equal txn_global_slot
-                last_rollup_slot)
+                last_sequence_slot)
           in
           (* Push events to s1 *)
           let is_empty = !(Party.Events.is_empty_var sequence_events) in
@@ -1420,14 +1420,14 @@ module Base = struct
           let s2 = Field.if_ is_full_and_different_slot ~then_:s2' ~else_:s1' in
           let new_global_slot =
             !(Mina_numbers.Global_slot.Checked.if_ is_empty
-                ~then_:last_rollup_slot ~else_:txn_global_slot)
+                ~then_:last_sequence_slot ~else_:txn_global_slot)
           in
-          let new_rollup_state =
+          let new_sequence_state =
             ( ([ s1; s2; s3; s4; s5 ] : _ Pickles_types.Vector.t)
             , new_global_slot )
           in
-          update_authorized a.permissions.edit_rollup_state ~is_keep:is_empty
-            ~updated:(`Ok new_rollup_state)
+          update_authorized a.permissions.edit_sequence_state ~is_keep:is_empty
+            ~updated:(`Ok new_sequence_state)
         in
         let snapp_version =
           (* Current snapp version. Upgrade mechanism should live here. *)
@@ -1442,8 +1442,8 @@ module Base = struct
             }
         ; app_state
         ; snapp_version
-        ; rollup_state
-        ; last_rollup_slot
+        ; sequence_state
+        ; last_sequence_slot
         ; proved_state
         }
       in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1256,7 +1256,7 @@ module Base = struct
              ; events = _ (* This is for the snapp to use, we don't need it. *)
              ; call_data =
                  _ (* This is for the snapp to use, we don't need it. *)
-             ; rollup_events
+             ; sequence_events
              ; depth = _ (* This is used to build the 'stack of stacks'. *)
              }
          ; predicate
@@ -1404,10 +1404,11 @@ module Base = struct
                 last_rollup_slot)
           in
           (* Push events to s1 *)
-          let is_empty = !(Party.Events.is_empty_var rollup_events) in
+          let is_empty = !(Party.Events.is_empty_var sequence_events) in
           let s1 =
             Field.if_ is_empty ~then_:s1'
-              ~else_:(Party.Rollup_events.push_events_checked s1' rollup_events)
+              ~else_:
+                (Party.Rollup_events.push_events_checked s1' sequence_events)
           in
           (* Shift along if last update wasn't this slot *)
           let is_full_and_different_slot =
@@ -4453,7 +4454,7 @@ let%test_module "transaction_snark" =
                   ; token_id = ()
                   ; delta = Fee.of_int full_amount
                   ; events = []
-                  ; rollup_events = []
+                  ; sequence_events = []
                   ; call_data = Field.zero
                   ; depth = 0
                   }
@@ -4469,7 +4470,7 @@ let%test_module "transaction_snark" =
                     ; token_id = Token_id.default
                     ; delta = Amount.Signed.(of_unsigned receiver_amount)
                     ; events = []
-                    ; rollup_events = []
+                    ; sequence_events = []
                     ; call_data = Field.zero
                     ; depth = 0
                     }
@@ -4878,7 +4879,7 @@ let%test_module "transaction_snark" =
                             ; token_id = ()
                             ; delta = fee
                             ; events = []
-                            ; rollup_events = []
+                            ; sequence_events = []
                             ; call_data = Field.zero
                             ; depth = 0
                             }
@@ -4895,7 +4896,7 @@ let%test_module "transaction_snark" =
                         ; token_id = Token_id.default
                         ; delta = Amount.(Signed.(negate (of_unsigned amount)))
                         ; events = []
-                        ; rollup_events = []
+                        ; sequence_events = []
                         ; call_data = Field.zero
                         ; depth = 0
                         }
@@ -4909,7 +4910,7 @@ let%test_module "transaction_snark" =
                         ; token_id = Token_id.default
                         ; delta = Amount.Signed.(of_unsigned amount)
                         ; events = []
-                        ; rollup_events = []
+                        ; sequence_events = []
                         ; call_data = Field.zero
                         ; depth = 0
                         }
@@ -5190,7 +5191,7 @@ let%test_module "transaction_snark" =
                             ; token_id = ()
                             ; delta = fee
                             ; events = []
-                            ; rollup_events = []
+                            ; sequence_events = []
                             ; call_data = Field.zero
                             ; depth = 0
                             }
@@ -5207,7 +5208,7 @@ let%test_module "transaction_snark" =
                         ; token_id = Token_id.default
                         ; delta = Amount.(Signed.(negate (of_unsigned amount)))
                         ; events = []
-                        ; rollup_events = []
+                        ; sequence_events = []
                         ; call_data = Field.zero
                         ; depth = 0
                         }
@@ -5221,7 +5222,7 @@ let%test_module "transaction_snark" =
                         ; token_id = Token_id.default
                         ; delta = Amount.Signed.(of_unsigned amount)
                         ; events = []
-                        ; rollup_events = []
+                        ; sequence_events = []
                         ; call_data = Field.zero
                         ; depth = 0
                         }

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1408,7 +1408,7 @@ module Base = struct
           let s1 =
             Field.if_ is_empty ~then_:s1'
               ~else_:
-                (Party.Rollup_events.push_events_checked s1' sequence_events)
+                (Party.Sequence_events.push_events_checked s1' sequence_events)
           in
           (* Shift along if last update wasn't this slot *)
           let is_full_and_different_slot =


### PR DESCRIPTION
Rename `rollup_events` to `sequence_events`.

Closes #9688.

Note: this name change will trigger the versioned type linter error. The serialization of the type hasn't changed, so the error can be ignored.