### PR TITLE
lk86/rosetta-bootstrap-forever 

### DIFF
--- a/src/app/rosetta/docker-start.sh
+++ b/src/app/rosetta/docker-start.sh
@@ -91,8 +91,7 @@ MINA_DAEMON_PID=$!
 sleep 30
 
 echo "========================= POPULATING MISSING BLOCKS ==========================="
-# Note: this script takes some time to fail even in the best case (~30 minutes) and we don't start waiting on the other daemons until it completes
-./download-missing-blocks.sh ${MINA_NETWORK} ${POSTGRES_DBNAME} ${POSTGRES_USERNAME}
+./download-missing-blocks.sh ${MINA_NETWORK} ${POSTGRES_DBNAME} ${POSTGRES_USERNAME} &
 
 
 if ! kill -0 "${MINA_DAEMON_PID}"; then

--- a/src/app/rosetta/download-missing-blocks.sh
+++ b/src/app/rosetta/download-missing-blocks.sh
@@ -14,30 +14,36 @@ PG_CONN=postgres://${POSTGRES_USERNAME}:${POSTGRES_USERNAME}@127.0.0.1:5432/${PO
 export MINA_CONFIG_FILE=/genesis_ledgers/${MINA_NETWORK}.json
 export MINA_CONFIG_DIR="${MINA_CONFIG_DIR:=/data/.mina-config}"
 
+# Bootstrap finds every missing state hash in the database and imports them from the o1labs bucket of .json blocks
+function bootstrap() {
+  echo "[BOOTSTRAP] Top 10 blocks before bootstrapping the archiveDB:"
+  psql "${PG_CONN}" -c "SELECT state_hash,height FROM blocks ORDER BY height DESC LIMIT 10"
+  echo "[BOOTSTRAP] Restoring blocks individually from ${BLOCKS_BUCKET}..."
+
+  until [[ "$PARENT" == "null" ]] ; do
+    PARENT_FILE="$(mina-missing-blocks-auditor --archive-uri $PG_CONN | jq -rs '.[-1].metadata | "'${MINA_NETWORK}'-\(.parent_height)-\(.parent_hash).json"')"
+    echo "Downloading $PARENT_FILE block"
+    curl -sO "${BLOCKS_BUCKET}/${PARENT_FILE}"
+    mina-archive-blocks --precomputed --archive-uri "$PG_CONN" "$PARENT_FILE" | jq -rs '"[BOOTSTRAP] Populated database with block: \(.[-1].message)"'
+    rm "$PARENT_FILE"
+    PARENT="$(mina-missing-blocks-auditor --archive-uri $PG_CONN | jq -rs .[-1].metadata.parent_hash)"
+  done
+
+  echo "[BOOTSTRAP] Top 10 blocks in bootstrapped archiveDB:"
+  psql "${PG_CONN}" -c "SELECT state_hash,height FROM blocks ORDER BY height DESC LIMIT 10"
+  echo "[BOOTSTRAP] This rosetta node is synced with no missing blocks back to genesis!"
+
+  echo "[BOOTSTRAP] Checking again in 60 minutes..."
+  sleep 3000
+}
+
 # Wait until there is a block missing
 PARENT=null
-for i in {1..6}; do # Test every 5 minutes for the first 30 minutes
+while true; do # Test once every 10 minutes forever, take an hour off when bootstrap completes
   PARENT="$(mina-missing-blocks-auditor --archive-uri $PG_CONN | jq -rs .[-1].metadata.parent_hash)"
   echo "[BOOTSTRAP] $(mina-missing-blocks-auditor --archive-uri $PG_CONN | jq -rs .[-1].message)"
-  [[ "$PARENT" != "null" ]] && echo "[BOOSTRAP] Some blocks are missing, moving to reovery logic..." && break
-  sleep 300 # Wait for the daemon to catchup and start downloading new blocks
+  [[ "$PARENT" != "null" ]] && echo "[BOOSTRAP] Some blocks are missing, moving to recovery logic..." && bootstrap
+  sleep 600 # Wait for the daemon to catchup and start downloading new blocks
 done
 
-echo "[BOOTSTRAP] Top 10 blocks before bootstrapping the archiveDB:"
-psql "${PG_CONN}" -c "SELECT state_hash,height FROM blocks ORDER BY height DESC LIMIT 10"
-echo "[BOOTSTRAP] Restoring blocks individually from ${BLOCKS_BUCKET}..."
 
-# Continue until no more blocks are missing
-until [[ "$PARENT" == "null" ]] ; do
-  PARENT_FILE="$(mina-missing-blocks-auditor --archive-uri $PG_CONN | jq -rs '.[-1].metadata | "'${MINA_NETWORK}'-\(.parent_height)-\(.parent_hash).json"')"
-  echo "Downloading $PARENT_FILE block"
-  curl -sO "${BLOCKS_BUCKET}/${PARENT_FILE}"
-  mina-archive-blocks --precomputed --archive-uri "$PG_CONN" "$PARENT_FILE" | jq -rs '"[BOOTSTRAP] Populated database with block: \(.[-1].message)"'
-  rm "$PARENT_FILE"
-  PARENT="$(mina-missing-blocks-auditor --archive-uri $PG_CONN | jq -rs .[-1].metadata.parent_hash)"
-done
-
-echo "[BOOTSTRAP] Top 10 blocks in bootstrapped archiveDB:"
-psql "${PG_CONN}" -c "SELECT state_hash,height FROM blocks ORDER BY height DESC LIMIT 10"
-
-echo "[BOOTSTRAP] This rosetta node is synced with no missing blocks back to genesis!"


### PR DESCRIPTION
Make download-missing-blocks run forever and in the background
---

Explain your changes:
*

Explain how you tested your changes:
*


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
