### PR TITLE
Distinguish verification failures

### DIFF
--- a/dockerfiles/stages/1-build-deps
+++ b/dockerfiles/stages/1-build-deps
@@ -116,7 +116,7 @@ RUN mkdir --mode=700 ~/.gnupg \
 # Ocaml install of a given OCAML_VERSION via opam switch
 # additionally initializes opam with sandboxing disabled, as we did not install bubblewrap above.
 RUN git clone \
-  git://github.com/ocaml/opam-repository \
+  https://github.com/ocaml/opam-repository.git \
   --depth 1 \
   /home/opam/opam-repository \
   && opam init --disable-sandboxing -k git -a ~/opam-repository --bare \

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -563,9 +563,12 @@ let initial_validate ~(precomputed_values : Precomputed_values.t) ~logger
     match%bind Initial_validate_batcher.verify batcher transition with
     | Ok (Ok tv) ->
         return (Ok { transition with data = tv })
-    | Ok (Error `Invalid_proof) ->
+    | Ok (Error invalid) ->
         let s = "initial_validate: block failed to verify, invalid proof" in
-        [%log warn] ~metadata:[ ("state_hash", state_hash) ] "%s" s ;
+        [%log warn]
+          ~metadata:[ ("state_hash", state_hash) ]
+          "%s, %s" s
+          (Verifier.invalid_to_string invalid) ;
         let%map () =
           match transition.sender with
           | Local ->
@@ -576,9 +579,6 @@ let initial_validate ~(precomputed_values : Precomputed_values.t) ~logger
                   Actions.(Sent_invalid_proof, None))
         in
         Error (`Error (Error.of_string s))
-    | Ok (Error _err) ->
-        (* _err could be `Invalid_keys or `Invalid_proof *)
-        failwith "initial_validate: Unexpected verification error"
     | Error e ->
         [%log warn]
           ~metadata:
@@ -919,8 +919,9 @@ let run ~logger ~trust_system ~verifier ~network ~frontier
               Gauge.set Catchup.verification_time
                 Time.(Span.to_ms @@ diff (now ()) start_time)) ;
             match result with
-            | Error _ ->
-                [%log' warn t.logger] "verification failed! redownloading"
+            | Error err ->
+                [%log' warn t.logger] "verification failed: %s! redownloading"
+                  (Verifier.invalid_to_string err)
                   ~metadata:
                     [ ("state_hash", State_hash.to_yojson node.state_hash) ] ;
                 ( match iv.sender with

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -387,11 +387,14 @@ let check_signature ?signature_kind ({ payload; signer; signature } : t) =
 
 [%%endif]
 
-let check_valid_keys t =
+let public_keys t =
   let fee_payer = fee_payer_pk t in
   let source = source_pk t in
   let receiver = receiver_pk t in
-  List.for_all [ fee_payer; source; receiver ] ~f:(fun pk ->
+  [ fee_payer; source; receiver ]
+
+let check_valid_keys t =
+  List.for_all (public_keys t) ~f:(fun pk ->
       Option.is_some (Public_key.decompress pk))
 
 let create_with_signature_checked ?signature_kind signature signer payload =

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -415,7 +415,11 @@ let%test_unit "json" =
   Quickcheck.test ~trials:20 ~sexp_of:sexp_of_t gen_test ~f:(fun t ->
       assert (Codable.For_tests.check_encoding (module Stable.Latest) ~equal t))
 
+(* return type is `t option` here, interface coerces that to `With_valid_signature.t option` *)
 let check t = Option.some_if (check_signature t && check_valid_keys t) t
+
+(* return type is `t option` here, interface coerces that to `With_valid_signature.t option` *)
+let check_only_for_signature t = Option.some_if (check_signature t) t
 
 let forget_check t = t
 

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -183,12 +183,17 @@ module type S = sig
     -> Signed_command_payload.t
     -> With_valid_signature.t option
 
+  val check_valid_keys : t -> bool
+
   module For_tests : sig
     val fake_sign :
       Signature_keypair.t -> Signed_command_payload.t -> With_valid_signature.t
   end
 
+  (** checks signature and keys *)
   val check : t -> With_valid_signature.t option
+
+  val check_only_for_signature : t -> With_valid_signature.t option
 
   val to_valid_unsafe :
        t

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -122,6 +122,8 @@ module type S = sig
 
   val receiver : next_available_token:Token_id.t -> t -> Account_id.t
 
+  val public_keys : t -> Public_key.Compressed.t list
+
   val amount : t -> Currency.Amount.t option
 
   val memo : t -> Signed_command_memo.t

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -86,15 +86,15 @@ let rec determine_outcome :
               [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
             Ivar.fill elt.res (Ok (Error (`Invalid_signature keys))) ;
             None
-        | `Missing_verification_key keys ->
-            if Ivar.is_full elt.res then
-              [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-            Ivar.fill elt.res (Ok (Error (`Missing_verification_key keys))) ;
-            None
         | `Invalid_proof ->
             if Ivar.is_full elt.res then
               [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
             Ivar.fill elt.res (Ok (Error `Invalid_proof)) ;
+            None
+        | `Missing_verification_key keys ->
+            if Ivar.is_full elt.res then
+              [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
+            Ivar.fill elt.res (Ok (Error (`Missing_verification_key keys))) ;
             None
         | `Potentially_invalid new_hint ->
             Some (elt, new_hint))

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -4,11 +4,13 @@ open Network_peer
 
 module Id = Unique_id.Int ()
 
+type invalid = [ `Invalid_keys | `Invalid_signature | `Invalid_proof ]
+
 type ('init, 'result) elt =
   { id : Id.t
   ; data : 'init
   ; weight : int
-  ; res : (('result, unit) Result.t Or_error.t Ivar.t[@sexp.opaque])
+  ; res : (('result, invalid) Result.t Or_error.t Ivar.t[@sexp.opaque])
   }
 [@@deriving sexp]
 
@@ -33,7 +35,9 @@ type ('init, 'partially_validated, 'result) t =
             fails to verify. *)
          [ `Init of 'init | `Partially_validated of 'partially_validated ] list
       -> [ `Valid of 'result
-         | `Invalid
+         | `Invalid_keys
+         | `Invalid_signature
+         | `Invalid_proof
          | `Potentially_invalid of 'partially_validated ]
          list
          Deferred.Or_error.t
@@ -62,7 +66,7 @@ let call_verifier t (ps : 'proof list) = t.verifier ps
 let rec determine_outcome :
     type p r partial.
        (p, r) elt list
-    -> [ `Valid of r | `Invalid | `Potentially_invalid of partial ] list
+    -> [ `Valid of r | `Potentially_invalid of partial | invalid ] list
     -> (p, partial, r) t
     -> unit Deferred.Or_error.t =
  fun ps res v ->
@@ -76,10 +80,20 @@ let rec determine_outcome :
               [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
             Ivar.fill elt.res (Ok (Ok r)) ;
             None
-        | `Invalid ->
+        | `Invalid_keys ->
             if Ivar.is_full elt.res then
               [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-            Ivar.fill elt.res (Ok (Error ())) ;
+            Ivar.fill elt.res (Ok (Error `Invalid_keys)) ;
+            None
+        | `Invalid_signature ->
+            if Ivar.is_full elt.res then
+              [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
+            Ivar.fill elt.res (Ok (Error `Invalid_signature)) ;
+            None
+        | `Invalid_proof ->
+            if Ivar.is_full elt.res then
+              [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
+            Ivar.fill elt.res (Ok (Error `Invalid_proof)) ;
             None
         | `Potentially_invalid new_hint ->
             Some (elt, new_hint))
@@ -92,7 +106,7 @@ let rec determine_outcome :
   | [ ({ res; _ }, _) ] ->
       if Ivar.is_full res then
         [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-      Ivar.fill res (Ok (Error ())) ;
+      Ivar.fill res (Ok (Error `Invalid_proof)) ;
       (* If there is a potentially invalid proof in this batch of size 1, then
          that proof is itself invalid. *)
       return ()
@@ -184,7 +198,7 @@ let rec start_verifier : type proof partial r. (proof, partial, r) t -> unit =
         start_verifier t) )
 
 let verify (type p r partial) (t : (p, partial, r) t) (proof : p) :
-    (r, unit) Result.t Deferred.Or_error.t =
+    (r, invalid) Result.t Deferred.Or_error.t =
   let elt =
     { id = Id.create ()
     ; data = proof
@@ -293,13 +307,19 @@ module Transaction_pool = struct
            the verification result of the diff that it belongs to. *)
         List.iter2_exn unknowns res ~f:(fun ((i, j), v) r ->
             match r with
-            | `Invalid ->
+            | `Invalid_keys ->
                 (* A diff is invalid is any of the transactions it contains are invalid.
                    Invalidate the whole diff that this transaction comes from. *)
-                result.(i) <- `Invalid
+                result.(i) <- `Invalid_keys
+            | `Invalid_signature ->
+                (* Invalidate the whole diff *)
+                result.(i) <- `Invalid_signature
+            | `Invalid_proof ->
+                (* Invalidate the whole diff *)
+                result.(i) <- `Invalid_proof
             | `Valid_assuming xs -> (
                 match result.(i) with
-                | `Invalid ->
+                | `Invalid_keys | `Invalid_signature | `Invalid_proof ->
                     (* If this diff has already been declared invalid, knowing that one of its
                        transactions is partially valid is not useful. *)
                     ()
@@ -309,13 +329,17 @@ module Transaction_pool = struct
             | `Valid c -> (
                 (* Similar to the above. *)
                 match result.(i) with
-                | `Invalid ->
+                | `Invalid_keys | `Invalid_signature | `Invalid_proof ->
                     ()
                 | `In_progress a ->
                     a.(j) <- `Valid c )) ;
         list_of_array_map result ~f:(function
-          | `Invalid ->
-              `Invalid
+          | `Invalid_keys ->
+              `Invalid_keys
+          | `Invalid_signature ->
+              `Invalid_signature
+          | `Invalid_proof ->
+              `Invalid_proof
           | `In_progress a -> (
               (* If the diff is all valid, we're done. If not, we return a partial
                    result. *)
@@ -347,7 +371,7 @@ module Snark_pool = struct
 
   let verify (t : t) (p : proof_envelope) : bool Deferred.Or_error.t =
     let open Deferred.Or_error.Let_syntax in
-    match%map verify t p with Ok () -> true | Error () -> false
+    match%map verify t p with Ok () -> true | Error _ -> false
 
   let create verifier : t =
     create

--- a/src/lib/network_pool/batcher.mli
+++ b/src/lib/network_pool/batcher.mli
@@ -16,6 +16,8 @@ end
 
 type ('initial, 'partially_validated, 'result) t
 
+type invalid = [ `Invalid_keys | `Invalid_signature | `Invalid_proof ]
+
 val create :
      ?how_to_add:[ `Insert | `Enqueue_back ]
   -> ?logger:Logger.t
@@ -24,8 +26,8 @@ val create :
   -> ?max_weight_per_call:int
   -> (   [ `Init of 'init | `Partially_validated of 'partially_validated ] list
       -> [ `Valid of 'result
-         | `Invalid
-         | `Potentially_invalid of 'partially_validated ]
+         | `Potentially_invalid of 'partially_validated
+         | invalid ]
          list
          Deferred.Or_error.t)
   -> ('init, 'partially_validated, 'result) t
@@ -33,7 +35,7 @@ val create :
 val verify :
      ('input, 'partial, 'result) t
   -> 'input
-  -> ('result, unit) Result.t Deferred.Or_error.t
+  -> ('result, invalid) Result.t Deferred.Or_error.t
 
 val compare_envelope : _ Envelope.Incoming.t -> _ Envelope.Incoming.t -> int
 
@@ -47,5 +49,5 @@ module Transaction_pool : sig
   val verify :
        t
     -> User_command.Verifiable.t list Envelope.Incoming.t
-    -> (User_command.Valid.t list, unit) Result.t Deferred.Or_error.t
+    -> (User_command.Valid.t list, invalid) Result.t Deferred.Or_error.t
 end

--- a/src/lib/network_pool/batcher.mli
+++ b/src/lib/network_pool/batcher.mli
@@ -16,8 +16,6 @@ end
 
 type ('initial, 'partially_validated, 'result) t
 
-type invalid = [ `Invalid_keys | `Invalid_signature | `Invalid_proof ]
-
 val create :
      ?how_to_add:[ `Insert | `Enqueue_back ]
   -> ?logger:Logger.t
@@ -27,7 +25,7 @@ val create :
   -> (   [ `Init of 'init | `Partially_validated of 'partially_validated ] list
       -> [ `Valid of 'result
          | `Potentially_invalid of 'partially_validated
-         | invalid ]
+         | Verifier.invalid ]
          list
          Deferred.Or_error.t)
   -> ('init, 'partially_validated, 'result) t
@@ -35,7 +33,7 @@ val create :
 val verify :
      ('input, 'partial, 'result) t
   -> 'input
-  -> ('result, invalid) Result.t Deferred.Or_error.t
+  -> ('result, Verifier.invalid) Result.t Deferred.Or_error.t
 
 val compare_envelope : _ Envelope.Incoming.t -> _ Envelope.Incoming.t -> int
 
@@ -49,5 +47,6 @@ module Transaction_pool : sig
   val verify :
        t
     -> User_command.Verifiable.t list Envelope.Incoming.t
-    -> (User_command.Valid.t list, invalid) Result.t Deferred.Or_error.t
+    -> (User_command.Valid.t list, Verifier.invalid) Result.t
+       Deferred.Or_error.t
 end

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1215,7 +1215,7 @@ struct
                                       with
                                       | Error _ ->
                                           None
-                                      | Ok (Error ()) ->
+                                      | Ok (Error _) ->
                                           None
                                       | Ok (Ok [ c ]) ->
                                           Some c

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1037,6 +1037,12 @@ module T = struct
   [%%if feature_snapps]
 
   let check_commands ledger ~verifier (cs : User_command.t list) =
+    let mk_invalid_error s =
+      Error
+        (Verifier.Failure.Verification_failed
+           (Error.of_string
+              (sprintf "verification failed on command, invalid %s" s)))
+    in
     let cs =
       List.map cs
         ~f:
@@ -1049,10 +1055,12 @@ module T = struct
       (List.map xs ~f:(function
         | `Valid x ->
             Ok x
-        | `Invalid ->
-            Error
-              (Verifier.Failure.Verification_failed
-                 (Error.of_string "verification failed on command"))
+        | `Invalid_keys ->
+            mk_invalid_error "keys"
+        | `Invalid_signature ->
+            mk_invalid_error "signature"
+        | `Invalid_proof ->
+            mk_invalid_error "proof"
         | `Valid_assuming _ ->
             Error
               (Verifier.Failure.Verification_failed

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1050,9 +1050,9 @@ module T = struct
         | `Valid x ->
             Ok x
         | ( `Invalid_keys _
-          | `Invalid_signature
+          | `Invalid_signature _
           | `Invalid_proof
-          | `Missing_verification_key ) as invalid ->
+          | `Missing_verification_key _ ) as invalid ->
             Error
               (Verifier.Failure.Verification_failed
                  (Error.of_string

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -5,9 +5,9 @@ type invalid =
   [ `Invalid_keys of Signature_lib.Public_key.Compressed.Stable.Latest.t list
   | `Invalid_signature of
     Signature_lib.Public_key.Compressed.Stable.Latest.t list
+  | `Invalid_proof
   | `Missing_verification_key of
-    Signature_lib.Public_key.Compressed.Stable.Latest.t list
-  | `Invalid_proof ]
+    Signature_lib.Public_key.Compressed.Stable.Latest.t list ]
 [@@deriving bin_io_unversioned]
 
 let invalid_to_string (invalid : invalid) =

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -15,24 +15,33 @@ let create ~logger:_ ~proof_level ~constraint_constants:_ ~pids:_ ~conf_dir:_ =
 
 let verify_blockchain_snarks _ _ = Deferred.Or_error.return true
 
+(* N.B.: Valid_assuming is never returned, in fact; we assert a return type
+   containing Valid_assuming to match the expected type
+*)
 let verify_commands _ (cs : User_command.Verifiable.t list) :
     [ `Valid of Mina_base.User_command.Valid.t
-    | `Invalid
     | `Valid_assuming of
       ( Pickles.Side_loaded.Verification_key.t
       * Mina_base.Snapp_statement.t
       * Pickles.Side_loaded.Proof.t )
-      list ]
+      list
+    | `Invalid_keys
+    | `Invalid_signature
+    | `Invalid_proof ]
     list
     Deferred.Or_error.t =
   List.map cs ~f:(fun c ->
       match Common.check c with
       | `Valid c ->
           `Valid c
-      | `Invalid ->
-          `Invalid
       | `Valid_assuming (c, _) ->
-          `Valid c)
+          `Valid c
+      | `Invalid_keys ->
+          `Invalid_keys
+      | `Invalid_signature ->
+          `Invalid_signature
+      | `Invalid_proof ->
+          `Invalid_proof)
   |> Deferred.Or_error.return
 
 let verify_transaction_snarks _ ts =

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -40,12 +40,12 @@ let verify_commands _ (cs : User_command.Verifiable.t list) :
           `Valid c
       | `Invalid_keys keys ->
           `Invalid_keys keys
-      | `Invalid_signature ->
-          `Invalid_signature
+      | `Invalid_signature keys ->
+          `Invalid_signature keys
       | `Invalid_proof ->
           `Invalid_proof
-      | `Missing_verification_key ->
-          `Missing_verification_key)
+      | `Missing_verification_key keys ->
+          `Missing_verification_key keys)
   |> Deferred.Or_error.return
 
 let verify_transaction_snarks _ ts =

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -4,5 +4,5 @@
  (libraries precomputed_values core_kernel async_kernel rpc_parallel mina_base mina_state
             blockchain_snark memory_stats snark_params ledger_proof logger child_processes)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_compare ppx_hash ppx_coda ppx_version ppx_here ppx_bin_prot ppx_let
+ (preprocess (pps ppx_version ppx_compare ppx_hash ppx_coda ppx_version ppx_here ppx_bin_prot ppx_let
                   ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv)))

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -75,9 +75,9 @@ module Worker_state = struct
                    | `Valid_assuming (_, xs) ->
                        xs
                    | `Invalid_keys _
-                   | `Invalid_signature
+                   | `Invalid_signature _
                    | `Invalid_proof
-                   | `Missing_verification_key ->
+                   | `Missing_verification_key _ ->
                        [])
                in
                let%map all_verified =
@@ -92,12 +92,12 @@ module Worker_state = struct
                      if all_verified then `Valid c else `Valid_assuming xs
                  | `Invalid_keys keys ->
                      `Invalid_keys keys
-                 | `Invalid_signature ->
-                     `Invalid_signature
+                 | `Invalid_signature keys ->
+                     `Invalid_signature keys
                  | `Invalid_proof ->
                      `Invalid_proof
-                 | `Missing_verification_key ->
-                     `Missing_verification_key)
+                 | `Missing_verification_key keys ->
+                     `Missing_verification_key keys)
 
              let verify_blockchain_snarks = B.Proof.verify
 
@@ -125,12 +125,12 @@ module Worker_state = struct
                        `Valid c
                    | `Invalid_keys keys ->
                        `Invalid_keys keys
-                   | `Invalid_signature ->
-                       `Invalid_signature
+                   | `Invalid_signature keys ->
+                       `Invalid_signature keys
                    | `Invalid_proof ->
                        `Invalid_proof
-                   | `Missing_verification_key ->
-                       `Missing_verification_key)
+                   | `Missing_verification_key keys ->
+                       `Missing_verification_key keys)
                |> Deferred.return
 
              let verify_blockchain_snarks _ = Deferred.return true

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -7,6 +7,15 @@ module Base = struct
 
     type ledger_proof
 
+    type invalid =
+      [ `Invalid_keys of Signature_lib.Public_key.Compressed.t list
+      | `Invalid_signature
+      | `Invalid_proof
+      | `Missing_verification_key ]
+    [@@deriving bin_io]
+
+    val invalid_to_string : invalid -> string
+
     val verify_commands :
          t
       -> Mina_base.User_command.Verifiable.t list
@@ -18,9 +27,7 @@ module Base = struct
            * Mina_base.Snapp_statement.t
            * Pickles.Side_loaded.Proof.t )
            list
-         | `Invalid_keys
-         | `Invalid_signature
-         | `Invalid_proof ]
+         | invalid ]
          list
          Deferred.Or_error.t
 

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -9,9 +9,9 @@ module Base = struct
 
     type invalid =
       [ `Invalid_keys of Signature_lib.Public_key.Compressed.t list
-      | `Invalid_signature
-      | `Invalid_proof
-      | `Missing_verification_key ]
+      | `Invalid_signature of Signature_lib.Public_key.Compressed.t list
+      | `Missing_verification_key of Signature_lib.Public_key.Compressed.t list
+      | `Invalid_proof ]
     [@@deriving bin_io]
 
     val invalid_to_string : invalid -> string

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -13,12 +13,14 @@ module Base = struct
          (* The first level of error represents failure to verify, the second a failure in
             communicating with the verifier. *)
       -> [ `Valid of Mina_base.User_command.Valid.t
-         | `Invalid
          | `Valid_assuming of
            ( Pickles.Side_loaded.Verification_key.t
            * Mina_base.Snapp_statement.t
            * Pickles.Side_loaded.Proof.t )
-           list ]
+           list
+         | `Invalid_keys
+         | `Invalid_signature
+         | `Invalid_proof ]
          list
          Deferred.Or_error.t
 

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -10,8 +10,9 @@ module Base = struct
     type invalid =
       [ `Invalid_keys of Signature_lib.Public_key.Compressed.t list
       | `Invalid_signature of Signature_lib.Public_key.Compressed.t list
+      | `Invalid_proof
       | `Missing_verification_key of Signature_lib.Public_key.Compressed.t list
-      | `Invalid_proof ]
+      ]
     [@@deriving bin_io]
 
     val invalid_to_string : invalid -> string


### PR DESCRIPTION
Verification failures had been captured by a single token `Invalid`. We have more information than that, which we can return.

There are three sources of failure: invalid keys, invalid signatures, and invalid proofs.

The ultimate consumer of the verification result seems to be `Staged_ledger.check_commands`, which is called directly by `Staged_ledger.apply`.

Introduce a new function, `Signed_command.check_only_for_signature`, which omits the key validation in `check`. The new function also returns a `With_valid_signature.t`. With that new function, we can make a separate call to validate the keys, and return an appropriate error.

Part of #9592.