### PR TITLE
Use the correct branch name for 'versions compatibility changes' in CI

### DIFF
--- a/scripts/compare_ci_diff_types.sh
+++ b/scripts/compare_ci_diff_types.sh
@@ -5,4 +5,4 @@ set -eo pipefail
 # build print_versioned_types, then run Python script to compare versioned types in a pull request
 source ~/.profile && \
     (dune build --profile=dev src/external/ppx_version/tools/print_versioned_types.exe) && \
-    ./scripts/compare_pr_diff_types.py ${BUILDKITE_BRANCH:-develop}
+    ./scripts/compare_pr_diff_types.py ${BASE_BRANCH_NAME:-develop}


### PR DESCRIPTION
This brings the behaviour into line with the 'binable compatibility changes' PR, and should stop the spurious failures we see for this job in CI.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them