### PR TITLE
Generate graphql_schema.json during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,8 +195,7 @@ macos-portable:
 	@echo Find coda-daemon-macos.zip inside _build/
 
 update-graphql:
-	@echo Make sure that the daemon is running with -rest-port 8080
-	python3 scripts/introspection_query.py > graphql_schema.json
+	ulimit -s 65532 && (ulimit -n 10240 || true) && dune build --profile=$(DUNE_PROFILE) graphql_schema.json
 
 ########################################
 ## Lint

--- a/buildkite/scripts/check-graphql-schema.sh
+++ b/buildkite/scripts/check-graphql-schema.sh
@@ -1,39 +1,9 @@
 #!/bin/bash
-
 set -eo pipefail
 
-export DUNE_PROFILE=devnet
+export PATH=/home/opam/.cargo/bin:/usr/lib/go/bin:$PATH
+export GO=/usr/lib/go/bin/go
 
-# Don't prompt for answers during apt-get install
-export DEBIAN_FRONTEND=noninteractive
-apt-get update
-apt-get install -y git python3 apt-transport-https ca-certificates make curl
-
-# Source the environment script to get the proper ${MINA_DEB_VERSION}. Must be executed after installing git but before installing mina.
-source buildkite/scripts/export-git-env-vars.sh
-
-echo "Installing mina daemon package: mina-devnet=${MINA_DEB_VERSION}"
-echo "deb [trusted=yes] http://packages.o1test.net ${MINA_DEB_CODENAME} ${MINA_DEB_RELEASE}" | tee /etc/apt/sources.list.d/mina.list
-apt-get update
-apt-get install --allow-downgrades -y curl "mina-devnet=${MINA_DEB_VERSION}"
-
-mina daemon --seed --proof-level none --rest-port 8080 &
-
-# Update the graphql schema
-num_retries=15
-for ((i=1;i<=$num_retries;i++)); do
-  sleep 15s
-  set +e
-  make update-graphql
-  status_exit_code=$?
-  set -e
-  if [ $status_exit_code -eq 0 ]; then
-    break
-  elif [ $i -eq $num_retries ]; then
-    exit $status_exit_code
-  fi
-done
-
-kill %1
-
+eval $(opam env)
+make update-graphql
 git diff --exit-code -- graphql_schema.json

--- a/buildkite/src/Command/CheckGraphQLSchema.dhall
+++ b/buildkite/src/Command/CheckGraphQLSchema.dhall
@@ -1,21 +1,15 @@
 let Prelude = ../External/Prelude.dhall
 
 let Command = ./Base.dhall
-let Docker = ./Docker/Type.dhall
 let Size = ./Size.dhall
-
-let Cmd = ../Lib/Cmds.dhall in
+let RunInToolchain = ./RunInToolchain.dhall in
 
 { step = \(dependsOn : List Command.TaggedKey.Type) ->
     Command.build
       Command.Config::{
-        commands = [
-          Cmd.runInDocker
-            Cmd.Docker::{
-              image = (../Constants/ContainerImages.dhall).ubuntu1804
-            }
-            "./buildkite/scripts/check-graphql-schema.sh"
-        ],
+        commands =
+          RunInToolchain.runInToolchainStretch ([] : List Text)
+            "./buildkite/scripts/check-graphql-schema.sh",
         label = "Check GraphQL Schema",
         key = "check-graphql-schema",
         target = Size.Large,

--- a/dune
+++ b/dune
@@ -1,0 +1,4 @@
+(rule
+ (targets graphql_schema.json)
+ (mode promote)
+ (action (with-stdout-to graphql_schema.json (run %{exe:src/app/graphql_schema_dump/graphql_schema_dump.exe}))))

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -1,15 +1,9 @@
 {
   "data": {
     "__schema": {
-      "queryType": {
-        "name": "query"
-      },
-      "mutationType": {
-        "name": "mutation"
-      },
-      "subscriptionType": {
-        "name": "subscription"
-      },
+      "queryType": { "name": "query" },
+      "mutationType": { "name": "mutation" },
+      "subscriptionType": { "name": "subscription" },
       "types": [
         {
           "kind": "ENUM",
@@ -35,7 +29,8 @@
           "fields": [
             {
               "name": "newSyncUpdate",
-              "description": "Event that triggers when the network sync status changes",
+              "description":
+                "Event that triggers when the network sync status changes",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -51,7 +46,8 @@
             },
             {
               "name": "newBlock",
-              "description": "Event that triggers when a new block is created that either contains a transaction with the specified public key, or was produced by it. If no public key is provided, then the event will trigger for every new block received",
+              "description":
+                "Event that triggers when a new block is created that either contains a transaction with the specified public key, or was produced by it. If no public key is provided, then the event will trigger for every new block received",
               "args": [
                 {
                   "name": "publicKey",
@@ -78,7 +74,8 @@
             },
             {
               "name": "chainReorganization",
-              "description": "Event that triggers when the best tip changes in a way that is not a trivial extension of the existing one",
+              "description":
+                "Event that triggers when the best tip changes in a way that is not a trivial extension of the existing one",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -185,7 +182,8 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "NetworkPeer",
-          "description": "Network identifiers for another protocol participant",
+          "description":
+            "Network identifiers for another protocol participant",
           "fields": [
             {
               "name": "libp2p_port",
@@ -194,11 +192,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -243,11 +237,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "defaultValue": null
             },
@@ -291,7 +281,8 @@
           "fields": [
             {
               "name": "isolate",
-              "description": "If true, no connections will be allowed unless they are from a trusted peer",
+              "description":
+                "If true, no connections will be allowed unless they are from a trusted peer",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -307,7 +298,8 @@
             },
             {
               "name": "bannedPeers",
-              "description": "Peers we will never allow connections from (unless they are also trusted!)",
+              "description":
+                "Peers we will never allow connections from (unless they are also trusted!)",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -357,7 +349,8 @@
           "inputFields": [
             {
               "name": "isolate",
-              "description": "If true, no connections will be allowed unless they are from a trusted peer",
+              "description":
+                "If true, no connections will be allowed unless they are from a trusted peer",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -371,7 +364,8 @@
             },
             {
               "name": "bannedPeers",
-              "description": "Peers we will never allow connections from (unless they are also trusted!)",
+              "description":
+                "Peers we will never allow connections from (unless they are also trusted!)",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -494,7 +488,8 @@
           "fields": [
             {
               "name": "publicKey",
-              "description": "Public key you wish to start snark-working on; null to stop doing any snark work",
+              "description":
+                "Public key you wish to start snark-working on; null to stop doing any snark work",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -508,7 +503,8 @@
           "inputFields": [
             {
               "name": "publicKey",
-              "description": "Public key you wish to start snark-working on; null to stop doing any snark work",
+              "description":
+                "Public key you wish to start snark-working on; null to stop doing any snark work",
               "type": {
                 "kind": "SCALAR",
                 "name": "PublicKey",
@@ -528,7 +524,8 @@
           "fields": [
             {
               "name": "lastSnarkWorker",
-              "description": "Returns the last public key that was designated for snark work",
+              "description":
+                "Returns the last public key that was designated for snark work",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -551,7 +548,8 @@
           "fields": [
             {
               "name": "publicKey",
-              "description": "Public key of the account to receive coinbases. Block production keys will receive the coinbases if none is given",
+              "description":
+                "Public key of the account to receive coinbases. Block production keys will receive the coinbases if none is given",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -565,7 +563,8 @@
           "inputFields": [
             {
               "name": "publicKey",
-              "description": "Public key of the account to receive coinbases. Block production keys will receive the coinbases if none is given",
+              "description":
+                "Public key of the account to receive coinbases. Block production keys will receive the coinbases if none is given",
               "type": {
                 "kind": "SCALAR",
                 "name": "PublicKey",
@@ -585,7 +584,8 @@
           "fields": [
             {
               "name": "lastCoinbaseReceiver",
-              "description": "Returns the public key that was receiving coinbases previously, or none if it was the block producer",
+              "description":
+                "Returns the public key that was receiving coinbases previously, or none if it was the block producer",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -597,7 +597,8 @@
             },
             {
               "name": "currentCoinbaseReceiver",
-              "description": "Returns the public key that will receive coinbase, or none if it will be the block producer",
+              "description":
+                "Returns the public key that will receive coinbase, or none if it will be the block producer",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -620,7 +621,8 @@
           "fields": [
             {
               "name": "publicKeys",
-              "description": "Public keys of accounts you wish to stake with - these must be accounts that are in trackedAccounts",
+              "description":
+                "Public keys of accounts you wish to stake with - these must be accounts that are in trackedAccounts",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -646,7 +648,8 @@
           "inputFields": [
             {
               "name": "publicKeys",
-              "description": "Public keys of accounts you wish to stake with - these must be accounts that are in trackedAccounts",
+              "description":
+                "Public keys of accounts you wish to stake with - these must be accounts that are in trackedAccounts",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -678,7 +681,8 @@
           "fields": [
             {
               "name": "lastStaking",
-              "description": "Returns the public keys that were staking funds previously",
+              "description":
+                "Returns the public keys that were staking funds previously",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -702,7 +706,8 @@
             },
             {
               "name": "lockedPublicKeys",
-              "description": "List of public keys that could not be used to stake because they were locked",
+              "description":
+                "List of public keys that could not be used to stake because they were locked",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -726,7 +731,8 @@
             },
             {
               "name": "currentStakingKeys",
-              "description": "Returns the public keys that are now staking their funds",
+              "description":
+                "Returns the public keys that are now staking their funds",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -815,13 +821,10 @@
           "fields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -829,23 +832,16 @@
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -867,7 +863,8 @@
             },
             {
               "name": "amount",
-              "description": "Amount of token to create in the receiver's account",
+              "description":
+                "Amount of token to create in the receiver's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -883,7 +880,8 @@
             },
             {
               "name": "receiver",
-              "description": "Public key to mint the new tokens for (defaults to token owner's account)",
+              "description":
+                "Public key to mint the new tokens for (defaults to token owner's account)",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -929,32 +927,22 @@
           "inputFields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "The global slot number after which this transaction cannot be applied",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
@@ -973,7 +961,8 @@
             },
             {
               "name": "amount",
-              "description": "Amount of token to create in the receiver's account",
+              "description":
+                "Amount of token to create in the receiver's account",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -987,7 +976,8 @@
             },
             {
               "name": "receiver",
-              "description": "Public key to mint the new tokens for (defaults to token owner's account)",
+              "description":
+                "Public key to mint the new tokens for (defaults to token owner's account)",
               "type": {
                 "kind": "SCALAR",
                 "name": "PublicKey",
@@ -1062,13 +1052,10 @@
           "fields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -1076,29 +1063,23 @@
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "feePayer",
-              "description": "Public key to pay the fees from and sign the transaction with (defaults to the receiver)",
+              "description":
+                "Public key to pay the fees from and sign the transaction with (defaults to the receiver)",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -1176,37 +1157,28 @@
           "inputFields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "The global slot number after which this transaction cannot be applied",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "feePayer",
-              "description": "Public key to pay the fees from and sign the transaction with (defaults to the receiver)",
+              "description":
+                "Public key to pay the fees from and sign the transaction with (defaults to the receiver)",
               "type": {
                 "kind": "SCALAR",
                 "name": "PublicKey",
@@ -1309,13 +1281,10 @@
           "fields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -1323,23 +1292,16 @@
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -1377,7 +1339,8 @@
             },
             {
               "name": "feePayer",
-              "description": "Public key to pay the fee from (defaults to the tokenOwner)",
+              "description":
+                "Public key to pay the fee from (defaults to the tokenOwner)",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -1391,32 +1354,22 @@
           "inputFields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "The global slot number after which this transaction cannot be applied",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
@@ -1449,7 +1402,8 @@
             },
             {
               "name": "feePayer",
-              "description": "Public key to pay the fee from (defaults to the tokenOwner)",
+              "description":
+                "Public key to pay the fee from (defaults to the tokenOwner)",
               "type": {
                 "kind": "SCALAR",
                 "name": "PublicKey",
@@ -1496,13 +1450,10 @@
           "fields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -1510,23 +1461,16 @@
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -1582,32 +1526,22 @@
           "inputFields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "The global slot number after which this transaction cannot be applied",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
@@ -2200,7 +2134,8 @@
           "fields": [
             {
               "name": "addWallet",
-              "description": "Add a wallet - this will create a new keypair and store it in the daemon",
+              "description":
+                "Add a wallet - this will create a new keypair and store it in the daemon",
               "args": [
                 {
                   "name": "input",
@@ -2231,7 +2166,8 @@
             },
             {
               "name": "createAccount",
-              "description": "Create a new account - this will create a new keypair and store it in the daemon",
+              "description":
+                "Create a new account - this will create a new keypair and store it in the daemon",
               "args": [
                 {
                   "name": "input",
@@ -2262,7 +2198,8 @@
             },
             {
               "name": "createHDAccount",
-              "description": "Create an account with hardware wallet - this will let the hardware wallet generate a keypair corresponds to the HD-index you give and store this HD-index and the generated public key in the daemon. Calling this command with the same HD-index and the same hardware wallet will always generate the same keypair.",
+              "description":
+                "Create an account with hardware wallet - this will let the hardware wallet generate a keypair corresponds to the HD-index you give and store this HD-index and the generated public key in the daemon. Calling this command with the same HD-index and the same hardware wallet will always generate the same keypair.",
               "args": [
                 {
                   "name": "input",
@@ -2293,7 +2230,8 @@
             },
             {
               "name": "unlockAccount",
-              "description": "Allow transactions to be sent from the unlocked account",
+              "description":
+                "Allow transactions to be sent from the unlocked account",
               "args": [
                 {
                   "name": "input",
@@ -2324,7 +2262,8 @@
             },
             {
               "name": "unlockWallet",
-              "description": "Allow transactions to be sent from the unlocked account",
+              "description":
+                "Allow transactions to be sent from the unlocked account",
               "args": [
                 {
                   "name": "input",
@@ -2355,7 +2294,8 @@
             },
             {
               "name": "lockAccount",
-              "description": "Lock an unlocked account to prevent transaction being sent from it",
+              "description":
+                "Lock an unlocked account to prevent transaction being sent from it",
               "args": [
                 {
                   "name": "input",
@@ -2386,7 +2326,8 @@
             },
             {
               "name": "lockWallet",
-              "description": "Lock an unlocked account to prevent transaction being sent from it",
+              "description":
+                "Lock an unlocked account to prevent transaction being sent from it",
               "args": [
                 {
                   "name": "input",
@@ -2417,7 +2358,8 @@
             },
             {
               "name": "deleteAccount",
-              "description": "Delete the private key for an account that you track",
+              "description":
+                "Delete the private key for an account that you track",
               "args": [
                 {
                   "name": "input",
@@ -2448,7 +2390,8 @@
             },
             {
               "name": "deleteWallet",
-              "description": "Delete the private key for an account that you track",
+              "description":
+                "Delete the private key for an account that you track",
               "args": [
                 {
                   "name": "input",
@@ -2513,7 +2456,8 @@
                 },
                 {
                   "name": "path",
-                  "description": "Path to the wallet file, relative to the daemon's current working directory.",
+                  "description":
+                    "Path to the wallet file, relative to the daemon's current working directory.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -2560,7 +2504,8 @@
               "args": [
                 {
                   "name": "signature",
-                  "description": "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
+                  "description":
+                    "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "SignatureInput",
@@ -2601,7 +2546,8 @@
               "args": [
                 {
                   "name": "signature",
-                  "description": "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
+                  "description":
+                    "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "SignatureInput",
@@ -2642,7 +2588,8 @@
               "args": [
                 {
                   "name": "signature",
-                  "description": "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
+                  "description":
+                    "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "SignatureInput",
@@ -2683,7 +2630,8 @@
               "args": [
                 {
                   "name": "signature",
-                  "description": "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
+                  "description":
+                    "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "SignatureInput",
@@ -2724,7 +2672,8 @@
               "args": [
                 {
                   "name": "signature",
-                  "description": "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
+                  "description":
+                    "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "SignatureInput",
@@ -2850,7 +2799,8 @@
             },
             {
               "name": "setSnarkWorker",
-              "description": "Set key you wish to snark work with or disable snark working",
+              "description":
+                "Set key you wish to snark work with or disable snark working",
               "args": [
                 {
                   "name": "input",
@@ -2881,7 +2831,8 @@
             },
             {
               "name": "setSnarkWorkFee",
-              "description": "Set fee that you will like to receive for doing snark work",
+              "description":
+                "Set fee that you will like to receive for doing snark work",
               "args": [
                 {
                   "name": "input",
@@ -2912,7 +2863,8 @@
             },
             {
               "name": "setConnectionGatingConfig",
-              "description": "Set the connection gating config, returning the current config after the application (which may have failed)",
+              "description":
+                "Set the connection gating config, returning the current config after the application (which may have failed)",
               "args": [
                 {
                   "name": "input",
@@ -3314,16 +3266,13 @@
           "fields": [
             {
               "name": "delegatorIndex",
-              "description": "Position in the ledger of the delegator's account",
+              "description":
+                "Position in the ledger of the delegator's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3364,15 +3313,12 @@
           "inputFields": [
             {
               "name": "delegatorIndex",
-              "description": "Position in the ledger of the delegator's account",
+              "description":
+                "Position in the ledger of the delegator's account",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "defaultValue": null
             },
@@ -3412,11 +3358,13 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "VrfThresholdInput",
-          "description": "The amount of stake delegated, used to determine the threshold for a vrf evaluation producing a block",
+          "description":
+            "The amount of stake delegated, used to determine the threshold for a vrf evaluation producing a block",
           "fields": [
             {
               "name": "totalStake",
-              "description": "The total amount of stake across all accounts in the epoch's staking ledger.",
+              "description":
+                "The total amount of stake across all accounts in the epoch's staking ledger.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3432,7 +3380,8 @@
             },
             {
               "name": "delegatedStake",
-              "description": "The amount of stake delegated to the vrf evaluator by the delegating account. This should match the amount in the epoch's staking ledger, which may be different to the amount in the current ledger.",
+              "description":
+                "The amount of stake delegated to the vrf evaluator by the delegating account. This should match the amount in the epoch's staking ledger, which may be different to the amount in the current ledger.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3450,7 +3399,8 @@
           "inputFields": [
             {
               "name": "totalStake",
-              "description": "The total amount of stake across all accounts in the epoch's staking ledger.",
+              "description":
+                "The total amount of stake across all accounts in the epoch's staking ledger.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3464,7 +3414,8 @@
             },
             {
               "name": "delegatedStake",
-              "description": "The amount of stake delegated to the vrf evaluator by the delegating account. This should match the amount in the epoch's staking ledger, which may be different to the amount in the current ledger.",
+              "description":
+                "The amount of stake delegated to the vrf evaluator by the delegating account. This should match the amount in the epoch's staking ledger, which may be different to the amount in the current ledger.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3484,11 +3435,13 @@
         {
           "kind": "OBJECT",
           "name": "VrfThreshold",
-          "description": "The amount of stake delegated, used to determine the threshold for a vrf evaluation winning a slot",
+          "description":
+            "The amount of stake delegated, used to determine the threshold for a vrf evaluation winning a slot",
           "fields": [
             {
               "name": "delegatedStake",
-              "description": "The amount of stake delegated to the vrf evaluator by the delegating account. This should match the amount in the epoch's staking ledger, which may be different to the amount in the current ledger.",
+              "description":
+                "The amount of stake delegated to the vrf evaluator by the delegating account. This should match the amount in the epoch's staking ledger, which may be different to the amount in the current ledger.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3504,7 +3457,8 @@
             },
             {
               "name": "totalStake",
-              "description": "The total amount of stake across all accounts in the epoch's staking ledger.",
+              "description":
+                "The total amount of stake across all accounts in the epoch's staking ledger.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3573,16 +3527,13 @@
             },
             {
               "name": "delegatorIndex",
-              "description": "Position in the ledger of the delegator's account",
+              "description":
+                "Position in the ledger of the delegator's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3596,7 +3547,8 @@
         {
           "kind": "OBJECT",
           "name": "VrfEvaluation",
-          "description": "A witness to a vrf evaluation, which may be externally verified",
+          "description":
+            "A witness to a vrf evaluation, which may be externally verified",
           "fields": [
             {
               "name": "message",
@@ -3664,7 +3616,8 @@
             },
             {
               "name": "scaledMessageHash",
-              "description": "A group element represented as 2 field elements",
+              "description":
+                "A group element represented as 2 field elements",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3700,31 +3653,26 @@
             },
             {
               "name": "vrfOutput",
-              "description": "The vrf output derived from the evaluation witness. If null, the vrf witness was invalid.",
+              "description":
+                "The vrf output derived from the evaluation witness. If null, the vrf witness was invalid.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "vrfOutputFractional",
-              "description": "The vrf output derived from the evaluation witness, as a fraction. This represents a won slot if vrfOutputFractional <= (1 - (1 / 4)^(delegated_balance / total_stake)). If null, the vrf witness was invalid.",
+              "description":
+                "The vrf output derived from the evaluation witness, as a fraction. This represents a won slot if vrfOutputFractional <= (1 - (1 / 4)^(delegated_balance / total_stake)). If null, the vrf witness was invalid.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Float", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "thresholdMet",
-              "description": "Whether the threshold to produce a block was met, if specified",
+              "description":
+                "Whether the threshold to produce a block was met, if specified",
               "args": [
                 {
                   "name": "input",
@@ -3737,11 +3685,7 @@
                   "defaultValue": null
                 }
               ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -3754,17 +3698,14 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "SignatureInput",
-          "description": "A cryptographic signature -- you must provide either field+scalar or rawSignature",
+          "description":
+            "A cryptographic signature -- you must provide either field+scalar or rawSignature",
           "fields": [
             {
               "name": "rawSignature",
               "description": "Raw encoded signature",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -3772,11 +3713,7 @@
               "name": "scalar",
               "description": "Scalar component of signature",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -3784,11 +3721,7 @@
               "name": "field",
               "description": "Field component of signature",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -3797,31 +3730,19 @@
             {
               "name": "rawSignature",
               "description": "Raw encoded signature",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "scalar",
               "description": "Scalar component of signature",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "field",
               "description": "Field component of signature",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "defaultValue": null
             }
           ],
@@ -3836,13 +3757,10 @@
           "fields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -3850,23 +3768,16 @@
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -3906,11 +3817,7 @@
               "name": "token",
               "description": "Token to send",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "TokenId",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "TokenId", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -3950,32 +3857,22 @@
           "inputFields": [
             {
               "name": "nonce",
-              "description": "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "Should only be set when cancelling transactions, otherwise a nonce is determined automatically",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "memo",
               "description": "Short arbitrary message provided by the sender",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "defaultValue": null
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "description":
+                "The global slot number after which this transaction cannot be applied",
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "defaultValue": null
             },
             {
@@ -4009,11 +3906,7 @@
             {
               "name": "token",
               "description": "Token to send",
-              "type": {
-                "kind": "SCALAR",
-                "name": "TokenId",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "TokenId", "ofType": null },
               "defaultValue": null
             },
             {
@@ -4072,7 +3965,8 @@
             },
             {
               "name": "coinbase",
-              "description": "The amount received as a coinbase reward for producing a block",
+              "description":
+                "The amount received as a coinbase reward for producing a block",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4127,11 +4021,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "sign",
-                  "ofType": null
-                }
+                "ofType": { "kind": "ENUM", "name": "sign", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4161,7 +4051,8 @@
         {
           "kind": "OBJECT",
           "name": "WorkDescription",
-          "description": "Transition from a source ledger to a target ledger with some fee excess and increase in supply ",
+          "description":
+            "Transition from a source ledger to a target ledger with some fee excess and increase in supply ",
           "fields": [
             {
               "name": "sourceLedgerHash",
@@ -4197,7 +4088,8 @@
             },
             {
               "name": "feeExcess",
-              "description": "Total transaction fee that is not accounted for in the transition from source ledger to target ledger",
+              "description":
+                "Total transaction fee that is not accounted for in the transition from source ledger to target ledger",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4234,11 +4126,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4252,7 +4140,8 @@
         {
           "kind": "OBJECT",
           "name": "PendingSnarkWork",
-          "description": "Snark work bundles that are not available in the pool yet",
+          "description":
+            "Snark work bundles that are not available in the pool yet",
           "fields": [
             {
               "name": "workBundle",
@@ -4351,11 +4240,7 @@
               "name": "banned_status",
               "description": "Banned status",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -4381,13 +4266,15 @@
             },
             {
               "name": "PENDING",
-              "description": "A transaction either in the transition frontier or in transaction pool but is not on the longest chain",
+              "description":
+                "A transaction either in the transition frontier or in transaction pool but is not on the longest chain",
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "UNKNOWN",
-              "description": "The transaction has either been snarked, reached finality through consensus or has been dropped",
+              "description":
+                "The transaction has either been snarked, reached finality through consensus or has been dropped",
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -4484,7 +4371,8 @@
             },
             {
               "name": "fee",
-              "description": "Amount that the recipient is paid in this fee transfer",
+              "description":
+                "Amount that the recipient is paid in this fee transfer",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4500,7 +4388,8 @@
             },
             {
               "name": "type",
-              "description": "Fee_transfer|Fee_transfer_via_coinbase Snark worker fees deducted from the coinbase amount are of type 'Fee_transfer_via_coinbase', rest are deducted from transaction fees",
+              "description":
+                "Fee_transfer|Fee_transfer_via_coinbase Snark worker fees deducted from the coinbase amount are of type 'Fee_transfer_via_coinbase', rest are deducted from transaction fees",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4532,11 +4421,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4575,16 +4460,13 @@
             },
             {
               "name": "nonce",
-              "description": "Sequence number of command for the fee-payer's account",
+              "description":
+                "Sequence number of command for the fee-payer's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4639,7 +4521,8 @@
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4671,7 +4554,8 @@
             },
             {
               "name": "amount",
-              "description": "Amount that the source is sending to receiver; 0 for commands without an associated amount",
+              "description":
+                "Amount that the source is sending to receiver; 0 for commands without an associated amount",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4703,7 +4587,8 @@
             },
             {
               "name": "fee",
-              "description": "Fee that the fee-payer is willing to pay for making the transaction",
+              "description":
+                "Fee that the fee-payer is willing to pay for making the transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4719,7 +4604,8 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description":
+                "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4735,7 +4621,8 @@
             },
             {
               "name": "isDelegation",
-              "description": "If true, this command represents a delegation of stake",
+              "description":
+                "If true, this command represents a delegation of stake",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4815,24 +4702,17 @@
             },
             {
               "name": "failureReason",
-              "description": "null is no failure or status unknown, reason for failure otherwise.",
+              "description":
+                "null is no failure or status unknown, reason for failure otherwise.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "UserCommand",
-              "ofType": null
-            }
+            { "kind": "INTERFACE", "name": "UserCommand", "ofType": null }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -4881,11 +4761,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4924,16 +4800,13 @@
             },
             {
               "name": "nonce",
-              "description": "Sequence number of command for the fee-payer's account",
+              "description":
+                "Sequence number of command for the fee-payer's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4988,7 +4861,8 @@
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5020,7 +4894,8 @@
             },
             {
               "name": "amount",
-              "description": "Amount that the source is sending to receiver; 0 for commands without an associated amount",
+              "description":
+                "Amount that the source is sending to receiver; 0 for commands without an associated amount",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5052,7 +4927,8 @@
             },
             {
               "name": "fee",
-              "description": "Fee that the fee-payer is willing to pay for making the transaction",
+              "description":
+                "Fee that the fee-payer is willing to pay for making the transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5068,7 +4944,8 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description":
+                "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5084,7 +4961,8 @@
             },
             {
               "name": "isDelegation",
-              "description": "If true, this command represents a delegation of stake",
+              "description":
+                "If true, this command represents a delegation of stake",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5164,24 +5042,17 @@
             },
             {
               "name": "failureReason",
-              "description": "null is no failure or status unknown, reason for failure otherwise.",
+              "description":
+                "null is no failure or status unknown, reason for failure otherwise.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "UserCommand",
-              "ofType": null
-            }
+            { "kind": "INTERFACE", "name": "UserCommand", "ofType": null }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -5193,7 +5064,8 @@
           "fields": [
             {
               "name": "tokenOwner",
-              "description": "Public key to set as the owner of the new token",
+              "description":
+                "Public key to set as the owner of the new token",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5209,7 +5081,8 @@
             },
             {
               "name": "newAccountsDisabled",
-              "description": "Whether new accounts created in this token are disabled",
+              "description":
+                "Whether new accounts created in this token are disabled",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5230,11 +5103,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5273,16 +5142,13 @@
             },
             {
               "name": "nonce",
-              "description": "Sequence number of command for the fee-payer's account",
+              "description":
+                "Sequence number of command for the fee-payer's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5337,7 +5203,8 @@
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5369,7 +5236,8 @@
             },
             {
               "name": "amount",
-              "description": "Amount that the source is sending to receiver; 0 for commands without an associated amount",
+              "description":
+                "Amount that the source is sending to receiver; 0 for commands without an associated amount",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5401,7 +5269,8 @@
             },
             {
               "name": "fee",
-              "description": "Fee that the fee-payer is willing to pay for making the transaction",
+              "description":
+                "Fee that the fee-payer is willing to pay for making the transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5417,7 +5286,8 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description":
+                "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5433,7 +5303,8 @@
             },
             {
               "name": "isDelegation",
-              "description": "If true, this command represents a delegation of stake",
+              "description":
+                "If true, this command represents a delegation of stake",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5513,24 +5384,17 @@
             },
             {
               "name": "failureReason",
-              "description": "null is no failure or status unknown, reason for failure otherwise.",
+              "description":
+                "null is no failure or status unknown, reason for failure otherwise.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "UserCommand",
-              "ofType": null
-            }
+            { "kind": "INTERFACE", "name": "UserCommand", "ofType": null }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -5542,7 +5406,8 @@
           "fields": [
             {
               "name": "tokenOwner",
-              "description": "The account that owns the token for the new account",
+              "description":
+                "The account that owns the token for the new account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5558,7 +5423,8 @@
             },
             {
               "name": "disabled",
-              "description": "Whether this account should be disabled upon creation. If this command was not issued by the token owner, it should match the 'newAccountsDisabled' property set in the token owner's account.",
+              "description":
+                "Whether this account should be disabled upon creation. If this command was not issued by the token owner, it should match the 'newAccountsDisabled' property set in the token owner's account.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5579,11 +5445,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5622,16 +5484,13 @@
             },
             {
               "name": "nonce",
-              "description": "Sequence number of command for the fee-payer's account",
+              "description":
+                "Sequence number of command for the fee-payer's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5686,7 +5545,8 @@
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5718,7 +5578,8 @@
             },
             {
               "name": "amount",
-              "description": "Amount that the source is sending to receiver; 0 for commands without an associated amount",
+              "description":
+                "Amount that the source is sending to receiver; 0 for commands without an associated amount",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5750,7 +5611,8 @@
             },
             {
               "name": "fee",
-              "description": "Fee that the fee-payer is willing to pay for making the transaction",
+              "description":
+                "Fee that the fee-payer is willing to pay for making the transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5766,7 +5628,8 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description":
+                "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5782,7 +5645,8 @@
             },
             {
               "name": "isDelegation",
-              "description": "If true, this command represents a delegation of stake",
+              "description":
+                "If true, this command represents a delegation of stake",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -5862,24 +5726,17 @@
             },
             {
               "name": "failureReason",
-              "description": "null is no failure or status unknown, reason for failure otherwise.",
+              "description":
+                "null is no failure or status unknown, reason for failure otherwise.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "UserCommand",
-              "ofType": null
-            }
+            { "kind": "INTERFACE", "name": "UserCommand", "ofType": null }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -5932,11 +5789,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -5975,16 +5828,13 @@
             },
             {
               "name": "nonce",
-              "description": "Sequence number of command for the fee-payer's account",
+              "description":
+                "Sequence number of command for the fee-payer's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -6039,7 +5889,8 @@
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6071,7 +5922,8 @@
             },
             {
               "name": "amount",
-              "description": "Amount that the source is sending to receiver; 0 for commands without an associated amount",
+              "description":
+                "Amount that the source is sending to receiver; 0 for commands without an associated amount",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6103,7 +5955,8 @@
             },
             {
               "name": "fee",
-              "description": "Fee that the fee-payer is willing to pay for making the transaction",
+              "description":
+                "Fee that the fee-payer is willing to pay for making the transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6119,7 +5972,8 @@
             },
             {
               "name": "memo",
-              "description": "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
+              "description":
+                "A short message from the sender, encoded with Base58Check, version byte=0x14; byte 2 of the decoding is the message length",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6135,7 +5989,8 @@
             },
             {
               "name": "isDelegation",
-              "description": "If true, this command represents a delegation of stake",
+              "description":
+                "If true, this command represents a delegation of stake",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6215,24 +6070,17 @@
             },
             {
               "name": "failureReason",
-              "description": "null is no failure or status unknown, reason for failure otherwise.",
+              "description":
+                "null is no failure or status unknown, reason for failure otherwise.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [
-            {
-              "kind": "INTERFACE",
-              "name": "UserCommand",
-              "ofType": null
-            }
+            { "kind": "INTERFACE", "name": "UserCommand", "ofType": null }
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -6249,11 +6097,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -6292,16 +6136,13 @@
             },
             {
               "name": "nonce",
-              "description": "Sequence number of command for the fee-payer's account",
+              "description":
+                "Sequence number of command for the fee-payer's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -6356,7 +6197,8 @@
             },
             {
               "name": "validUntil",
-              "description": "The global slot number after which this transaction cannot be applied",
+              "description":
+                "The global slot number after which this transaction cannot be applied",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6388,7 +6230,8 @@
             },
             {
               "name": "amount",
-              "description": "Amount that the source is sending to receiver - 0 for commands that are not associated with an amount",
+              "description":
+                "Amount that the source is sending to receiver - 0 for commands that are not associated with an amount",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6420,7 +6263,8 @@
             },
             {
               "name": "fee",
-              "description": "Fee that the fee-payer is willing to pay for making the transaction",
+              "description":
+                "Fee that the fee-payer is willing to pay for making the transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6452,7 +6296,8 @@
             },
             {
               "name": "isDelegation",
-              "description": "If true, this represents a delegation of stake, otherwise it is a payment",
+              "description":
+                "If true, this represents a delegation of stake, otherwise it is a payment",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6532,13 +6377,10 @@
             },
             {
               "name": "failureReason",
-              "description": "null is no failure, reason for failure otherwise.",
+              "description":
+                "null is no failure, reason for failure otherwise.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -6581,7 +6423,8 @@
           "fields": [
             {
               "name": "userCommands",
-              "description": "List of user commands (payments and stake delegations) included in this block",
+              "description":
+                "List of user commands (payments and stake delegations) included in this block",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6629,7 +6472,8 @@
             },
             {
               "name": "coinbase",
-              "description": "Amount of mina granted to the producer of this block",
+              "description":
+                "Amount of mina granted to the producer of this block",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6645,13 +6489,10 @@
             },
             {
               "name": "coinbaseReceiverAccount",
-              "description": "Account to which the coinbase for this block was granted",
+              "description":
+                "Account to which the coinbase for this block was granted",
               "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              },
+              "type": { "kind": "OBJECT", "name": "Account", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -6670,11 +6511,7 @@
               "name": "base64",
               "description": "Base-64 encoded proof",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -7119,7 +6956,8 @@
           "fields": [
             {
               "name": "date",
-              "description": "date (stringified Unix time - number of milliseconds since January 1, 1970)",
+              "description":
+                "date (stringified Unix time - number of milliseconds since January 1, 1970)",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7135,7 +6973,8 @@
             },
             {
               "name": "utcDate",
-              "description": "utcDate (stringified Unix time - number of milliseconds since January 1, 1970). Time offsets are adjusted to reflect true wall-clock time instead of genesis time.",
+              "description":
+                "utcDate (stringified Unix time - number of milliseconds since January 1, 1970). Time offsets are adjusted to reflect true wall-clock time instead of genesis time.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7183,13 +7022,10 @@
             },
             {
               "name": "stagedLedgerProofEmitted",
-              "description": "Block finished a staged ledger, and a proof was emitted from it and included into this block's proof. If there is no transition frontier available or no block found, this will return null.",
+              "description":
+                "Block finished a staged ledger, and a proof was emitted from it and included into this block's proof. If there is no transition frontier available or no block found, this will return null.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -7222,7 +7058,8 @@
             },
             {
               "name": "blockchainState",
-              "description": "State which is agnostic of a particular consensus algorithm",
+              "description":
+                "State which is agnostic of a particular consensus algorithm",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7238,7 +7075,8 @@
             },
             {
               "name": "consensusState",
-              "description": "State specific to the Codaboros Proof of Stake consensus algorithm",
+              "description":
+                "State specific to the Codaboros Proof of Stake consensus algorithm",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7313,7 +7151,8 @@
             },
             {
               "name": "stateHash",
-              "description": "Base58Check-encoded hash of the state after this block",
+              "description":
+                "Base58Check-encoded hash of the state after this block",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7329,7 +7168,8 @@
             },
             {
               "name": "stateHashField",
-              "description": "Experimental: Bigint field-element representation of stateHash",
+              "description":
+                "Experimental: Bigint field-element representation of stateHash",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7460,7 +7300,8 @@
             },
             {
               "name": "fee",
-              "description": "Fee that snark worker is charging to generate a snark proof",
+              "description":
+                "Fee that snark worker is charging to generate a snark proof",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7524,11 +7365,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -7570,7 +7407,8 @@
             },
             {
               "name": "bannedPeers",
-              "description": "Peers we will never allow connections from (unless they are also trusted!)",
+              "description":
+                "Peers we will never allow connections from (unless they are also trusted!)",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7594,7 +7432,8 @@
             },
             {
               "name": "isolate",
-              "description": "If true, no connections will be allowed unless they are from a trusted peer",
+              "description":
+                "If true, no connections will be allowed unless they are from a trusted peer",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7627,7 +7466,8 @@
         {
           "kind": "OBJECT",
           "name": "AnnotatedBalance",
-          "description": "A total balance annotated with the amount that is currently unknown with the invariant unknown <= total, as well as the currently liquid and locked balances.",
+          "description":
+            "A total balance annotated with the amount that is currently unknown with the invariant unknown <= total, as well as the currently liquid and locked balances.",
           "fields": [
             {
               "name": "total",
@@ -7647,7 +7487,8 @@
             },
             {
               "name": "unknown",
-              "description": "The amount of mina owned by the account whose origin is currently unknown",
+              "description":
+                "The amount of mina owned by the account whose origin is currently unknown",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -7663,25 +7504,19 @@
             },
             {
               "name": "liquid",
-              "description": "The amount of mina owned by the account which is currently available. Can be null if bootstrapping.",
+              "description":
+                "The amount of mina owned by the account which is currently available. Can be null if bootstrapping.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt64",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt64", "ofType": null },
               "isDeprecated": true,
               "deprecationReason": null
             },
             {
               "name": "locked",
-              "description": "The amount of mina owned by the account which is currently locked. Can be null if bootstrapping.",
+              "description":
+                "The amount of mina owned by the account which is currently locked. Can be null if bootstrapping.",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt64",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt64", "ofType": null },
               "isDeprecated": true,
               "deprecationReason": null
             },
@@ -7703,13 +7538,10 @@
             },
             {
               "name": "stateHash",
-              "description": "Hash of block at which balance was measured. Can be null if bootstrapping. Guaranteed to be non-null for direct account lookup queries when not bootstrapping. Can also be null when accessed as nested properties (eg. via delegators). ",
+              "description":
+                "Hash of block at which balance was measured. Can be null if bootstrapping. Guaranteed to be non-null for direct account lookup queries when not bootstrapping. Can also be null when accessed as nested properties (eg. via delegators). ",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -7736,13 +7568,10 @@
           "fields": [
             {
               "name": "initial_mininum_balance",
-              "description": "The initial minimum balance for a time-locked account",
+              "description":
+                "The initial minimum balance for a time-locked account",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt64",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt64", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7750,11 +7579,7 @@
               "name": "cliff_time",
               "description": "The cliff time for a time-locked account",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7762,11 +7587,7 @@
               "name": "cliff_amount",
               "description": "The cliff amount for a time-locked account",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt64",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt64", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7774,23 +7595,16 @@
               "name": "vesting_period",
               "description": "The vesting period for a time-locked account",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt32",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt32", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "vesting_increment",
-              "description": "The vesting increment for a time-locked account",
+              "description":
+                "The vesting increment for a time-locked account",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "UInt64",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "UInt64", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -7803,7 +7617,8 @@
         {
           "kind": "SCALAR",
           "name": "TokenId",
-          "description": "String representation of a token's UInt64 identifier",
+          "description":
+            "String representation of a token's UInt64 identifier",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -7891,37 +7706,28 @@
             },
             {
               "name": "nonce",
-              "description": "A natural number that increases with each transaction (stringified uint32)",
+              "description":
+                "A natural number that increases with each transaction (stringified uint32)",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "inferredNonce",
-              "description": "Like the `nonce` field, except it includes the scheduled transactions (transactions not yet included in a block) (stringified uint32)",
+              "description":
+                "Like the `nonce` field, except it includes the scheduled transactions (transactions not yet included in a block) (stringified uint32)",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "epochDelegateAccount",
-              "description": "The account that you delegated on the staking ledger of the current block's epoch",
+              "description":
+                "The account that you delegated on the staking ledger of the current block's epoch",
               "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              },
+              "type": { "kind": "OBJECT", "name": "Account", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -7929,17 +7735,14 @@
               "name": "receiptChainHash",
               "description": "Top hash of the receipt chain merkle-list",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "delegate",
-              "description": "The public key to which you are delegating - if you are not delegating to anybody, this would return your public key",
+              "description":
+                "The public key to which you are delegating - if you are not delegating to anybody, this would return your public key",
               "args": [],
               "type": {
                 "kind": "SCALAR",
@@ -7951,19 +7754,17 @@
             },
             {
               "name": "delegateAccount",
-              "description": "The account to which you are delegating - if you are not delegating to anybody, this would return your public key",
+              "description":
+                "The account to which you are delegating - if you are not delegating to anybody, this would return your public key",
               "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              },
+              "type": { "kind": "OBJECT", "name": "Account", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "delegators",
-              "description": "The list of accounts which are delegating to you (note that the info is recorded in the last epoch so it might not be up to date with the current account status)",
+              "description":
+                "The list of accounts which are delegating to you (note that the info is recorded in the last epoch so it might not be up to date with the current account status)",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -7983,7 +7784,8 @@
             },
             {
               "name": "lastEpochDelegators",
-              "description": "The list of accounts which are delegating to you in the last epoch (note that the info is recorded in the one before last epoch epoch so it might not be up to date with the current account status)",
+              "description":
+                "The list of accounts which are delegating to you in the last epoch (note that the info is recorded in the one before last epoch epoch so it might not be up to date with the current account status)",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -8003,19 +7805,17 @@
             },
             {
               "name": "votingFor",
-              "description": "The previous epoch lock hash of the chain which you are voting for",
+              "description":
+                "The previous epoch lock hash of the chain which you are voting for",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "stakingActive",
-              "description": "True if you are actively staking with this account on the current daemon - this may not yet have been updated if the staking key was changed recently",
+              "description":
+                "True if you are actively staking with this account on the current daemon - this may not yet have been updated if the staking key was changed recently",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8047,13 +7847,10 @@
             },
             {
               "name": "locked",
-              "description": "True if locked, false if unlocked, null if the account isn't tracked by the queried daemon",
+              "description":
+                "True if locked, false if unlocked, null if the account isn't tracked by the queried daemon",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8061,35 +7858,25 @@
               "name": "isTokenOwner",
               "description": "True if this account owns its associated token",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "isDisabled",
-              "description": "True if this account has been disabled by the owner of the associated token",
+              "description":
+                "True if this account has been disabled by the owner of the associated token",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "index",
-              "description": "The index of this account in the ledger, or null if this account does not yet have a known position in the best tip ledger",
+              "description":
+                "The index of this account in the ledger, or null if this account does not yet have a known position in the best tip ledger",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -8140,11 +7927,7 @@
               "name": "peer",
               "description": null,
               "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Peer",
-                "ofType": null
-              },
+              "type": { "kind": "OBJECT", "name": "Peer", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8155,11 +7938,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8171,11 +7950,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8198,11 +7973,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8214,11 +7985,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8230,11 +7997,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8246,11 +8009,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8262,11 +8021,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8294,11 +8049,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8312,11 +8063,13 @@
         {
           "kind": "OBJECT",
           "name": "ConsensusTimeGlobalSlot",
-          "description": "Consensus time and the corresponding global slot since genesis",
+          "description":
+            "Consensus time and the corresponding global slot since genesis",
           "fields": [
             {
               "name": "consensusTime",
-              "description": "Time in terms of slot number in an epoch, start and end time of the slot since UTC epoch",
+              "description":
+                "Time in terms of slot number in an epoch, start and end time of the slot since UTC epoch",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8383,7 +8136,8 @@
             },
             {
               "name": "globalSlotSinceGenesis",
-              "description": "Next block production global-slot-since-genesis ",
+              "description":
+                "Next block production global-slot-since-genesis ",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8407,7 +8161,8 @@
             },
             {
               "name": "generatedFromConsensusAt",
-              "description": "Consensus time of the block that was used to determine the next block production time",
+              "description":
+                "Consensus time of the block that was used to determine the next block production time",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8631,11 +8386,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8647,11 +8398,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8903,11 +8650,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8963,11 +8706,7 @@
               "name": "numAccounts",
               "description": null,
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8975,11 +8714,7 @@
               "name": "blockchainLength",
               "description": null,
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -8990,11 +8725,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -9006,11 +8737,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -9022,11 +8749,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -9035,11 +8758,7 @@
               "name": "ledgerMerkleRoot",
               "description": null,
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -9047,11 +8766,7 @@
               "name": "stateHash",
               "description": null,
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -9134,11 +8849,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -9147,11 +8858,7 @@
               "name": "snarkWorker",
               "description": null,
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -9162,11 +8869,7 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -9235,11 +8938,7 @@
               "name": "coinbaseReceiver",
               "description": null,
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -9271,11 +8970,7 @@
               "name": "globalSlotSinceGenesisBestTip",
               "description": null,
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -9449,17 +9144,14 @@
               "name": "version",
               "description": "The version of the node (git commit hash)",
               "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "ownedWallets",
-              "description": "Wallets for which the daemon knows the private key",
+              "description":
+                "Wallets for which the daemon knows the private key",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -9483,7 +9175,8 @@
             },
             {
               "name": "trackedAccounts",
-              "description": "Accounts for which the daemon tracks the private key",
+              "description":
+                "Accounts for which the daemon tracks the private key",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -9524,17 +9217,14 @@
                   "defaultValue": null
                 }
               ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              },
+              "type": { "kind": "OBJECT", "name": "Account", "ofType": null },
               "isDeprecated": true,
               "deprecationReason": "use account instead"
             },
             {
               "name": "connectionGatingConfig",
-              "description": "The rules that the libp2p helper will use to determine which connections to permit",
+              "description":
+                "The rules that the libp2p helper will use to determine which connections to permit",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -9554,7 +9244,8 @@
               "args": [
                 {
                   "name": "token",
-                  "description": "Token of account being retrieved (defaults to CODA)",
+                  "description":
+                    "Token of account being retrieved (defaults to CODA)",
                   "type": {
                     "kind": "SCALAR",
                     "name": "TokenId",
@@ -9577,11 +9268,7 @@
                   "defaultValue": null
                 }
               ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Account",
-                "ofType": null
-              },
+              "type": { "kind": "OBJECT", "name": "Account", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },
@@ -9665,16 +9352,14 @@
             },
             {
               "name": "bestChain",
-              "description": "Retrieve a list of blocks from transition frontier's root to the current best tip. Returns an error if the system is bootstrapping.",
+              "description":
+                "Retrieve a list of blocks from transition frontier's root to the current best tip. Returns an error if the system is bootstrapping.",
               "args": [
                 {
                   "name": "maxLength",
-                  "description": "The maximum number of blocks to return. If there are more blocks in the transition frontier from root to tip, the n blocks closest to the best tip will be returned",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
+                  "description":
+                    "The maximum number of blocks to return. If there are more blocks in the transition frontier from root to tip, the n blocks closest to the best tip will be returned",
+                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
                   "defaultValue": null
                 }
               ],
@@ -9696,16 +9381,14 @@
             },
             {
               "name": "block",
-              "description": "Retrieve a block with the given state hash or height, if contained in the transition frontier.",
+              "description":
+                "Retrieve a block with the given state hash or height, if contained in the transition frontier.",
               "args": [
                 {
                   "name": "height",
-                  "description": "The height of the desired block in the best chain",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
+                  "description":
+                    "The height of the desired block in the best chain",
+                  "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
                   "defaultValue": null
                 },
                 {
@@ -9749,7 +9432,8 @@
             },
             {
               "name": "initialPeers",
-              "description": "List of peers that the daemon first used to connect to the network",
+              "description":
+                "List of peers that the daemon first used to connect to the network",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -9773,7 +9457,8 @@
             },
             {
               "name": "getPeers",
-              "description": "List of peers that the daemon is currently connected to",
+              "description":
+                "List of peers that the daemon is currently connected to",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -9797,7 +9482,8 @@
             },
             {
               "name": "pooledUserCommands",
-              "description": "Retrieve all the scheduled user commands for a specified sender that the current daemon sees in their transaction pool. All scheduled commands are queried if no sender is specified",
+              "description":
+                "Retrieve all the scheduled user commands for a specified sender that the current daemon sees in their transaction pool. All scheduled commands are queried if no sender is specified",
               "args": [
                 {
                   "name": "ids",
@@ -9837,7 +9523,8 @@
                 },
                 {
                   "name": "publicKey",
-                  "description": "Public key of sender of pooled user commands",
+                  "description":
+                    "Public key of sender of pooled user commands",
                   "type": {
                     "kind": "SCALAR",
                     "name": "PublicKey",
@@ -9958,7 +9645,8 @@
             },
             {
               "name": "snarkPool",
-              "description": "List of completed snark works that have the lowest fee so far",
+              "description":
+                "List of completed snark works that have the lowest fee so far",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -10006,7 +9694,8 @@
             },
             {
               "name": "genesisConstants",
-              "description": "The constants used to determine the configuration of the genesis block and all of its transitive dependencies",
+              "description":
+                "The constants used to determine the configuration of the genesis block and all of its transitive dependencies",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -10022,23 +9711,21 @@
             },
             {
               "name": "timeOffset",
-              "description": "The time offset in seconds used to convert real times into blockchain times",
+              "description":
+                "The time offset in seconds used to convert real times into blockchain times",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
               "name": "nextAvailableToken",
-              "description": "The next token ID that has not been allocated. Token IDs are allocated sequentially, so all lower token IDs have been allocated",
+              "description":
+                "The next token ID that has not been allocated. Token IDs are allocated sequentially, so all lower token IDs have been allocated",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -10058,7 +9745,8 @@
               "args": [
                 {
                   "name": "signature",
-                  "description": "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
+                  "description":
+                    "If a signature is provided, this transaction is considered signed and will be broadcasted to the network without requiring a private key",
                   "type": {
                     "kind": "INPUT_OBJECT",
                     "name": "SignatureInput",
@@ -10095,7 +9783,8 @@
             },
             {
               "name": "evaluateVrf",
-              "description": "Evaluate a vrf for the given public key. This includes a witness which may be verified without access to the private key for this vrf evaluation.",
+              "description":
+                "Evaluate a vrf for the given public key. This includes a witness which may be verified without access to the private key for this vrf evaluation.",
               "args": [
                 {
                   "name": "vrfThreshold",
@@ -10150,7 +9839,8 @@
             },
             {
               "name": "checkVrf",
-              "description": "Check a vrf evaluation commitment. This can be used to check vrf evaluations without needing to reveal the private key, in the format returned by evaluateVrf",
+              "description":
+                "Check a vrf evaluation commitment. This can be used to check vrf evaluations without needing to reveal the private key, in the format returned by evaluateVrf",
               "args": [
                 {
                   "name": "input",
@@ -10181,7 +9871,8 @@
             },
             {
               "name": "runtimeConfig",
-              "description": "The runtime configuration passed to the daemon at start-up",
+              "description":
+                "The runtime configuration passed to the daemon at start-up",
               "args": [],
               "type": {
                 "kind": "NON_NULL",

--- a/src/app/cli/src/init/dune
+++ b/src/app/cli/src/init/dune
@@ -19,5 +19,5 @@
    transition_frontier web_client_pipe
    web_request graphql_lib genesis_ledger_helper bash_colors)
  (instrumentation (backend bisect_ppx))
- (preprocessor_deps ../../../../config.mlh)
+ (preprocessor_deps ../../../../config.mlh ../../../../../graphql_schema.json)
  (preprocess (pps ppx_coda graphql_ppx ppx_version ppx_jane ppx_deriving_yojson)))

--- a/src/app/graphql_schema_dump/dune
+++ b/src/app/graphql_schema_dump/dune
@@ -1,0 +1,4 @@
+(executable
+ (name graphql_schema_dump)
+ (libraries graphql_parser mina_graphql)
+ (preprocess (pps ppx_version)))

--- a/src/app/graphql_schema_dump/dune
+++ b/src/app/graphql_schema_dump/dune
@@ -1,4 +1,5 @@
 (executable
  (name graphql_schema_dump)
  (libraries graphql_parser mina_graphql)
+ (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version)))

--- a/src/app/graphql_schema_dump/graphql_schema_dump.ml
+++ b/src/app/graphql_schema_dump/graphql_schema_dump.ml
@@ -1,0 +1,115 @@
+let introspection_query_raw =
+  {graphql|
+query IntrospectionQuery {
+    __schema {
+      queryType { name }
+      mutationType { name }
+      subscriptionType { name }
+      types {
+        ...FullType
+      }
+      directives {
+        name
+        description
+        locations
+        args {
+          ...InputValue
+        }
+      }
+    }
+  }
+  fragment FullType on __Type {
+    kind
+    name
+    description
+    fields(includeDeprecated: true) {
+      name
+      description
+      args {
+        ...InputValue
+      }
+      type {
+        ...TypeRef
+      }
+      isDeprecated
+      deprecationReason
+    }
+    inputFields {
+      ...InputValue
+    }
+    interfaces {
+      ...TypeRef
+    }
+    enumValues(includeDeprecated: true) {
+      name
+      description
+      isDeprecated
+      deprecationReason
+    }
+    possibleTypes {
+      ...TypeRef
+    }
+  }
+  fragment InputValue on __InputValue {
+    name
+    description
+    type { ...TypeRef }
+    defaultValue
+  }
+  fragment TypeRef on __Type {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+|graphql}
+
+let () =
+  let introspection_query =
+    match Graphql_parser.parse introspection_query_raw with
+    | Ok res ->
+        res
+    | Error err ->
+        failwith err
+  in
+  let fake_mina_lib = Obj.magic () in
+  let res =
+    Async.Thread_safe.block_on_async_exn (fun () ->
+        Graphql_async.Schema.execute Mina_graphql.schema fake_mina_lib
+          introspection_query)
+  in
+  let response =
+    match res with
+    | Ok (`Response data) ->
+        data
+    | _ ->
+        failwith "Unexpected response"
+  in
+  let pretty_string = Yojson.Basic.pretty_to_string response in
+  Format.printf "%s@." pretty_string


### PR DESCRIPTION
This PR
* adds an ocaml executable `graphql_schema_dump` for generating the schema
* adds a dune rule to generate the schema during build using this executable
  - this rule includes a `(mode promote)` stanza, so the file is updated automatically when there are changes
* adds the preprocessor dependency on the `graphql_schema.json` file to ensure that it gets regenerated during build

This removes the need to start a daemon in order to dump the GraphQL schema, and also removes the need to use a python script to generate it. This should also ensure that the schema is never out-of-date, since `make build` and friends will always automatically update it.

Since this uses `Yojson.Safe.pretty_to_string` to output the schema, the formatting is different from the formatting generated by python. Thus, this PR also includes an updated `graphql_schema.json` with the new formatting.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them