### PR TITLE
Fix commitment lengths for side-loaded verification keys

### DIFF
--- a/src/lib/pickles/commitment_lengths.ml
+++ b/src/lib/pickles/commitment_lengths.ml
@@ -12,7 +12,7 @@ let generic' ~h ~sub ~add:( + ) ~mul:( * ) ~of_int ~ceil_div_max_degree :
     ceil_div_max_degree (Common.max_quot_size ~of_int ~mul:( * ) ~sub n)
   in
   let h = ceil_div_max_degree n in
-  { l = n; r = n; o = n; z = n; t = t_bound; f = n; sigma1 = h; sigma2 = h }
+  { l = h; r = h; o = h; z = h; t = t_bound; f = h; sigma1 = h; sigma2 = h }
 
 let generic map ~h ~max_degree : _ Dlog_plonk_types.Evals.t =
   let t_bound = map h ~f:(fun h -> Common.max_quot_size_int h) in


### PR DESCRIPTION
This error was introduced in df12992198627f0f115a617dd4197ee5322d6d93, where the `generic` version was updated correctly to use `h` everywhere, but the `generic'` version incorrectly used `n` instead of `h`. Since we weren't using side-loaded keys anywhere at the time, this was also missed during testing.

**NOTE: This is deliberately against `develop` rather than `compatible`, because this change will cause snark keys to change!**

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
