### PR TITLE
Uptime service, retry POST

### DIFF
--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -75,60 +75,97 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
       ; ("submitter", Public_key.to_yojson submitter_keypair.public_key) ]
   in
   let headers = Cohttp.Header.of_list [("Content-Type", "application/json")] in
+  let metadata_of_body = function
+    | `String s ->
+        [("error", `String s)]
+    | `Strings ss ->
+        [("error", `List (List.map ss ~f:(fun s -> `String s)))]
+    | `Empty | `Pipe _ ->
+        []
+  in
   match%map
     make_interruptible
       (Monitor.try_with ~here:[%here] ~extract_exn:true (fun () ->
-           let interruptible =
-             match%map
-               make_interruptible
-                 (Cohttp_async.Client.post ~headers
-                    ~body:
-                      ( Yojson.Safe.to_string json
-                      |> Cohttp_async.Body.of_string )
-                    url)
-             with
-             | {status; _}, body ->
-                 if Cohttp.Code.code_of_status status = 200 then
-                   [%log info]
-                     "Sent block with state hash $state_hash to uptime \
-                      service at URL $url"
-                     ~metadata:
+           let max_attempts = 8 in
+           let attempt_pause_sec = 10.0 in
+           let run_attempt attempt =
+             let interruptible =
+               match%map
+                 make_interruptible
+                   (Cohttp_async.Client.post ~headers
+                      ~body:
+                        ( Yojson.Safe.to_string json
+                        |> Cohttp_async.Body.of_string )
+                      url)
+               with
+               | {status; _}, body ->
+                   let succeeded = Cohttp.Code.code_of_status status = 200 in
+                   ( if succeeded then
+                     [%log info]
+                       "Sent block with state hash $state_hash to uptime \
+                        service at URL $url"
+                       ~metadata:
+                         [ ("state_hash", State_hash.to_yojson state_hash)
+                         ; ( "includes_snark_work"
+                           , `Bool (Option.is_some block_data.snark_work) )
+                         ; ("is_produced_block", `Bool produced)
+                         ; ("url", `String (Uri.to_string url)) ]
+                   else if attempt >= max_attempts then
+                     let base_metadata =
                        [ ("state_hash", State_hash.to_yojson state_hash)
-                       ; ( "includes_snark_work"
-                         , `Bool (Option.is_some block_data.snark_work) )
-                       ; ("is_produced_block", `Bool produced)
-                       ; ("url", `String (Uri.to_string url)) ]
-                 else
-                   let base_metadata =
-                     [ ("state_hash", State_hash.to_yojson state_hash)
-                     ; ("url", `String (Uri.to_string url))
-                     ; ("http_code", `Int (Cohttp.Code.code_of_status status))
-                     ; ( "http_error"
-                       , `String (Cohttp.Code.string_of_status status) )
-                     ; ("payload", json) ]
-                   in
-                   let extra_metadata =
-                     match body with
-                     | `String s ->
-                         [("error", `String s)]
-                     | `Strings ss ->
-                         [ ( "error"
-                           , `List (List.map ss ~f:(fun s -> `String s)) ) ]
-                     | `Empty | `Pipe _ ->
-                         []
-                   in
-                   let metadata = base_metadata @ extra_metadata in
-                   [%log error]
-                     "Failure when sending block with state hash $state_hash \
-                      to uptime service at URL $url"
-                     ~metadata
+                       ; ("url", `String (Uri.to_string url))
+                       ; ("http_code", `Int (Cohttp.Code.code_of_status status))
+                       ; ( "http_error"
+                         , `String (Cohttp.Code.string_of_status status) )
+                       ; ("payload", json) ]
+                     in
+                     let extra_metadata = metadata_of_body body in
+                     let metadata = base_metadata @ extra_metadata in
+                     [%log error]
+                       "After %d attempts, failed to send block with state \
+                        hash $state_hash to uptime service at URL $url, no \
+                        more retries"
+                       max_attempts ~metadata
+                   else
+                     let base_metadata =
+                       [ ("state_hash", State_hash.to_yojson state_hash)
+                       ; ("url", `String (Uri.to_string url))
+                       ; ("http_code", `Int (Cohttp.Code.code_of_status status))
+                       ; ( "http_error"
+                         , `String (Cohttp.Code.string_of_status status) ) ]
+                     in
+                     let extra_metadata = metadata_of_body body in
+                     let metadata = base_metadata @ extra_metadata in
+                     [%log info]
+                       "Failure when sending block with state hash \
+                        $state_hash to uptime service at URL $url, attempt %d \
+                        of %d, retrying"
+                       attempt max_attempts ~metadata ) ;
+                   succeeded
+             in
+             match%map.Deferred.Let_syntax
+               Interruptible.force interruptible
+             with
+             | Ok succeeded ->
+                 succeeded
+             | Error _ ->
+                 [%log error]
+                   "In uptime service, POST of uptime data was interrupted" ;
+                 (* interrupted, don't want to retry, claim success *)
+                 true
            in
-           match%map.Deferred.Let_syntax Interruptible.force interruptible with
-           | Ok () ->
-               ()
-           | Error _ ->
-               [%log error]
-                 "In uptime service, POST of uptime data was interrupted" ))
+           let rec go attempt =
+             let open Deferred.Let_syntax in
+             let%bind succeeded = run_attempt attempt in
+             if succeeded then Deferred.return ()
+             else if attempt < max_attempts then
+               let%bind () =
+                 Async.after (Time.Span.of_sec attempt_pause_sec)
+               in
+               go (attempt + 1)
+             else Deferred.unit
+           in
+           go 1 ))
   with
   | Ok () ->
       ()

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -150,7 +150,11 @@ let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
                  succeeded
              | Error _ ->
                  [%log error]
-                   "In uptime service, POST of uptime data was interrupted" ;
+                   "In uptime service, POST of block with state hash \
+                    $state_hash was interrupted"
+                   ~metadata:
+                     [ ("state_hash", State_hash.to_yojson state_hash)
+                     ; ("payload", json) ] ;
                  (* interrupted, don't want to retry, claim success *)
                  true
            in


### PR DESCRIPTION
If POST to the uptime service returns a code other than 200, retry it. The retries occur in a bounded loop, and there's a uniform pause between them. The number of retries and pause are constants that could be tweaked, if desired.

Tested the code with an unregistered uptime submitter key, and the each retry produced a 401 Unauthorized response, and the loop terminated.

I was unable to test with a registered key, but the submission code is as before, so I have good confidence that it works correctly.