### PR TITLE
Add https/wss support to graphql api webpage

### DIFF
--- a/src/app/cli/src/init/assets/index_extensions.html
+++ b/src/app/cli/src/init/assets/index_extensions.html
@@ -1,4 +1,3 @@
-
 <!--
 The request to this GraphQL server provided the header "Accept: text/html"
 and as a result has been presented GraphiQL - an in-browser IDE for
@@ -9,10 +8,12 @@ add "&raw" to the end of the URL within a browser.
 -->
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <style>
-    html, body {
+    html,
+    body {
       height: 100%;
       margin: 0;
       overflow: hidden;
@@ -22,16 +23,18 @@ add "&raw" to the end of the URL within a browser.
   <link href="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.css" rel="stylesheet" />
   <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
-  <script src="//cdn.jsdelivr.net/gh/codaprotocol/graphiql-with-extensions@8c90eed/graphiqlWithExtensions.min.js"></script>
+  <script
+    src="//cdn.jsdelivr.net/gh/codaprotocol/graphiql-with-extensions@8c90eed/graphiqlWithExtensions.min.js"></script>
   <script src="//unpkg.com/subscriptions-transport-ws@0.8.1/browser/client.js"></script>
   <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
 </head>
+
 <body>
   <script>
     var defaultQuery = "query MyQuery { \nversion\n}";
     var serverUrl = window.location.host + window.location.pathname;
-    var httpServerUrl = "http://" + serverUrl;
-    var wsServerUrl = "ws://" + serverUrl;
+    var httpServerUrl = (window.location.href.startsWith("http://") ? "http://" : "https://") + serverUrl;
+    var wsServerUrl = (window.location.href.startsWith("http://") ? "ws://" : "wss://") + serverUrl;
 
     // Collect the URL parameters
     var parameters = {};
@@ -128,4 +131,5 @@ add "&raw" to the end of the URL within a browser.
     );
   </script>
 </body>
+
 </html>


### PR DESCRIPTION
<!-- ### Welcome 👋

Thank you for contributing to Mina! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

If you cannot complete any of the steps below, please ask for help from a core
contributor.

### Incomplete Work

We feel it's important that everyone is comfortable landing incomplete projects
so we don't keep PRs open for too long (especially on develop). To do this we
don't want to forget that something is incomplete, don't want to be blocked on
landing things, and we don't want to land anything that breaks the daemon. We
don't want to forget to test the incomplete things whenever they are completed,
and finally we want to clean up after ourselves: any temporary cruft gets
completely removed before a project is considered done.

To achieve the above, we wish to keep track of incomplete work using a draft of
the release notes. We can share this part of the current draft at anytime with
external contributors. Moreover, we will review this draft during hardforks.

To ship incomplete work, put it behind feature flags -- prefer a runtime
CLI/daemon-config-style flag if possible, and only if necessary fallthrough to
compile time flags. Note that if you put code behind a compile time flag, you
_must_ ensure that CI is building all possible code paths. Don't land something
that doesn't build in CI.

## PLEASE DELETE EVERYTHING ABOVE THIS LINE
--->

Explain your changes:
* Add https/wss support to the graphql api webpage

Explain how you tested your changes:
* Run mina daemon
* [ngrok](https://ngrok.com/) http 3085
* Use the tmp https:// reverse proxy url to visit graphql client page 


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
