### PR TITLE
Propagate Parties.t failures to apply_transaction

### DIFF
--- a/src/lib/mina_base/ledger.mli
+++ b/src/lib/mina_base/ledger.mli
@@ -227,7 +227,8 @@ val apply_parties_unchecked :
          , Currency.Amount.t
          , t
          , bool
-         , unit )
+         , unit
+         , Transaction_status.Failure.t option )
          Parties_logic.Local_state.t
        * Currency.Amount.Signed.t ) )
      Or_error.t

--- a/src/lib/mina_base/parties_logic.ml
+++ b/src/lib/mina_base/parties_logic.ml
@@ -1,3 +1,5 @@
+(* parties_logic.ml *)
+
 module type Iffable = sig
   type bool
 
@@ -66,7 +68,14 @@ module Local_state = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type ('parties, 'token_id, 'excess, 'ledger, 'bool, 'comm) t =
+      type ( 'parties
+           , 'token_id
+           , 'excess
+           , 'ledger
+           , 'bool
+           , 'comm
+           , 'failure_status )
+           t =
         { parties : 'parties
         ; call_stack : 'parties
         ; transaction_commitment : 'comm
@@ -74,14 +83,15 @@ module Local_state = struct
         ; excess : 'excess
         ; ledger : 'ledger
         ; success : 'bool
+        ; failure_status : 'failure_status
         }
       [@@deriving compare, equal, hash, sexp, yojson, fields, hlist]
     end
   end]
 
-  let typ parties token_id excess ledger bool comm =
+  let typ parties token_id excess ledger bool comm failure_status =
     Pickles.Impls.Step.Typ.of_hlistable
-      [ parties; parties; comm; token_id; excess; ledger; bool ]
+      [ parties; parties; comm; token_id; excess; ledger; bool; failure_status ]
       ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
       ~value_of_hlist:of_hlist
 
@@ -95,7 +105,8 @@ module Local_state = struct
           , Currency.Amount.Stable.V1.t
           , Ledger_hash.Stable.V1.t
           , bool
-          , Parties.Transaction_commitment.Stable.V1.t )
+          , Parties.Transaction_commitment.Stable.V1.t
+          , Transaction_status.Failure.Stable.V1.t option )
           Stable.V1.t
         [@@deriving compare, equal, hash, sexp, yojson]
 
@@ -113,7 +124,8 @@ module Local_state = struct
       , Currency.Amount.Checked.t
       , Ledger_hash.var
       , Boolean.var
-      , Parties.Transaction_commitment.Checked.t )
+      , Parties.Transaction_commitment.Checked.t
+      , unit )
       Stable.Latest.t
   end
 end
@@ -244,7 +256,7 @@ module Eff = struct
         ; global_state : 'global_state
         ; inclusion_proof : 'ip
         }
-        -> ( 'account * 'bool
+        -> ( 'account * 'bool * 'failure
            , < inclusion_proof : 'ip
              ; bool : 'bool
              ; party : 'party
@@ -252,6 +264,7 @@ module Eff = struct
              ; transaction_commitment : 'transaction_commitment
              ; account : 'account
              ; global_state : 'global_state
+             ; failure : 'failure
              ; .. > )
            t
     | Balance :
@@ -374,6 +387,7 @@ module Make (Inputs : Inputs_intf) = struct
          ; transaction_commitment : Transaction_commitment.t
          ; amount : Amount.t
          ; bool : Bool.t
+         ; failure : Transaction_status.Failure.t option
          ; .. >
          as
          'env)
@@ -462,7 +476,7 @@ module Make (Inputs : Inputs_intf) = struct
     let predicate_satisfied : Bool.t =
       h.perform (Check_predicate (is_start', party, a, global_state))
     in
-    let a', update_permitted =
+    let a', update_permitted, failure_status =
       h.perform
         (Check_auth_and_update_account
            { is_start = is_start'
@@ -517,6 +531,7 @@ module Make (Inputs : Inputs_intf) = struct
       { local_state with
         excess = new_local_fee_excess
       ; success = Bool.(local_state.success &&& not overflowed)
+      ; failure_status
       }
     in
 

--- a/src/lib/mina_base/parties_logic.ml
+++ b/src/lib/mina_base/parties_logic.ml
@@ -378,7 +378,7 @@ module Make (Inputs : Inputs_intf) = struct
     in
     (party, current_stack, call_stack)
 
-  let apply (type global_state)
+  let apply (type global_state failure_status)
       ~(constraint_constants : Genesis_constants.Constraint_constants.t)
       ~(is_start :
          [ `Yes of _ Start_data.t | `No | `Compute of _ Start_data.t ])
@@ -387,7 +387,7 @@ module Make (Inputs : Inputs_intf) = struct
          ; transaction_commitment : Transaction_commitment.t
          ; amount : Amount.t
          ; bool : Bool.t
-         ; failure : Transaction_status.Failure.t option
+         ; failure : failure_status
          ; .. >
          as
          'env)

--- a/src/lib/mina_base/sparse_ledger.mli
+++ b/src/lib/mina_base/sparse_ledger.mli
@@ -93,7 +93,8 @@ val apply_parties_unchecked_with_states :
          , Currency.Amount.t
          , t
          , bool
-         , unit )
+         , unit
+         , Transaction_status.Failure.t option )
          Parties_logic.Local_state.t )
        list )
      Or_error.t

--- a/src/lib/mina_base/transaction_status.ml
+++ b/src/lib/mina_base/transaction_status.ml
@@ -114,31 +114,6 @@ module Failure = struct
     | _ ->
         Error "Signed_command_status.Failure.of_string: Unknown value"
 
-  let to_input, option_to_input =
-    let bits t =
-      (* the least value is encoded as 0 *)
-      let n = to_enum t - failure_min in
-      let rec go acc pos =
-        let bit = n land (1 lsl pos) <> 0 in
-        let acc' = bit :: acc in
-        if pos >= failure_num_bits - 1 then acc' else go acc' (pos + 1)
-      in
-      go [] 0
-    in
-    let to_input t = Random_oracle.Input.bitstring (bits t) in
-    let option_to_input t_opt =
-      match t_opt with
-      | None ->
-          (* least_t is encoded as 0s, of_enum always returns Some *)
-          let least_t = Option.value_exn (of_enum failure_min) in
-          (* prepend false to indicate None *)
-          Random_oracle.Input.bitstring (false :: bits least_t)
-      | Some t ->
-          (* prepend true to indicate Some *)
-          Random_oracle.Input.bitstring (true :: bits t)
-    in
-    (to_input, option_to_input)
-
   let%test_unit "of_string(to_string) roundtrip" =
     for i = failure_min to failure_max do
       let failure = Option.value_exn (of_enum i) in

--- a/src/lib/mina_state/local_state.ml
+++ b/src/lib/mina_state/local_state.ml
@@ -5,7 +5,14 @@ module Impl = Pickles.Impls.Step
 include Parties_logic.Local_state.Value
 
 type display =
-  (string, string, string, string, bool, string) Parties_logic.Local_state.t
+  ( string
+  , string
+  , string
+  , string
+  , bool
+  , string
+  , string )
+  Parties_logic.Local_state.t
 [@@deriving yojson]
 
 let display
@@ -16,6 +23,7 @@ let display
      ; excess
      ; ledger
      ; success
+     ; failure_status
      } :
       t) : display =
   let f x =
@@ -31,6 +39,9 @@ let display
       Visualization.display_prefix_of_string
       @@ Frozen_ledger_hash.to_base58_check ledger
   ; success
+  ; failure_status =
+      Option.value_map failure_status ~default:"<no failure>"
+        ~f:Transaction_status.Failure.to_string
   }
 
 let dummy : t =
@@ -41,6 +52,7 @@ let dummy : t =
   ; excess = Amount.zero
   ; ledger = Frozen_ledger_hash.empty_hash
   ; success = true
+  ; failure_status = None
   }
 
 let empty = dummy
@@ -53,7 +65,11 @@ let gen : t Quickcheck.Generator.t =
   and parties = Impl.Field.Constant.gen
   and call_stack = Impl.Field.Constant.gen
   and token_id = Token_id.gen
-  and success = Bool.quickcheck_generator in
+  and success = Bool.quickcheck_generator
+  and failure_status =
+    let%bind failure = Transaction_status.Failure.gen in
+    Quickcheck.Generator.of_list [ None; Some failure ]
+  in
   { Parties_logic.Local_state.parties
   ; call_stack
   ; transaction_commitment
@@ -61,6 +77,7 @@ let gen : t Quickcheck.Generator.t =
   ; ledger
   ; excess
   ; success
+  ; failure_status
   }
 
 let to_input
@@ -71,6 +88,7 @@ let to_input
      ; excess
      ; ledger
      ; success
+     ; failure_status
      } :
       t) =
   let open Random_oracle.Input in
@@ -82,6 +100,7 @@ let to_input
      ; Amount.to_input excess
      ; Ledger_hash.to_input ledger
      ; bitstring [ success ]
+     ; Transaction_status.Failure.option_to_input failure_status
     |]
 
 module Checked = struct
@@ -101,6 +120,7 @@ module Checked = struct
       ~excess:(f !Currency.Amount.Checked.assert_equal)
       ~ledger:(f !Ledger_hash.assert_equal)
       ~success:(f Impl.Boolean.Assert.( = ))
+      ~failure_status:(f (fun () () -> ()))
 
   let equal' (t1 : t) (t2 : t) =
     let ( ! ) f x y = Impl.run_checked (f x y) in
@@ -110,6 +130,7 @@ module Checked = struct
       ~token_id:(f !Token_id.Checked.equal)
       ~excess:(f !Currency.Amount.Checked.equal)
       ~ledger:(f !Ledger_hash.equal_var) ~success:(f Impl.Boolean.equal)
+      ~failure_status:(f (fun () () -> Impl.Boolean.true_))
 
   let to_input
       ({ parties
@@ -119,8 +140,10 @@ module Checked = struct
        ; excess
        ; ledger
        ; success
+       ; failure_status = _
        } :
         t) =
+    (* failure_status is the unit value, no need to represent it *)
     let open Random_oracle.Input in
     Array.reduce_exn ~f:append
       [| field parties
@@ -133,6 +156,16 @@ module Checked = struct
       |]
 end
 
+(* there: map any failure status to the unit value in Checked
+   back: map the unit value in Checked to None in the value world
+   (an alternative would be to fail, since we intend never to do that)
+*)
+let failure_status_typ : (unit, Transaction_status.Failure.t option) Impl.Typ.t
+    =
+  Impl.Typ.transport Impl.Typ.unit
+    ~there:(fun _failure_status -> ())
+    ~back:(fun () -> None)
+
 let typ : (Checked.t, t) Impl.Typ.t =
   let open Parties_logic.Local_state in
   let open Impl in
@@ -144,6 +177,7 @@ let typ : (Checked.t, t) Impl.Typ.t =
     ; Amount.typ
     ; Ledger_hash.typ
     ; Boolean.typ
+    ; failure_status_typ
     ]
     ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
     ~value_of_hlist:of_hlist

--- a/src/lib/mina_state/local_state.ml
+++ b/src/lib/mina_state/local_state.ml
@@ -157,7 +157,8 @@ end
 
 (* there: map any failure status to the unit value in Checked
    back: map the unit value in Checked to None in the value world
-   (an alternative would be to fail, since we intend never to do that)
+   (an alternative would be to fail, since we intend never to do that,
+   and it would make debugging difficult if we ever did that)
 *)
 let failure_status_typ : (unit, Transaction_status.Failure.t option) Impl.Typ.t
     =

--- a/src/lib/mina_state/local_state.ml
+++ b/src/lib/mina_state/local_state.ml
@@ -88,7 +88,7 @@ let to_input
      ; excess
      ; ledger
      ; success
-     ; failure_status
+     ; failure_status = _
      } :
       t) =
   let open Random_oracle.Input in
@@ -100,7 +100,6 @@ let to_input
      ; Amount.to_input excess
      ; Ledger_hash.to_input ledger
      ; bitstring [ success ]
-     ; Transaction_status.Failure.option_to_input failure_status
     |]
 
 module Checked = struct

--- a/src/lib/mina_transition/external_transition_sample_precomputed_block.ml
+++ b/src/lib/mina_transition/external_transition_sample_precomputed_block.ml
@@ -35,7 +35,7 @@ let sample_block_sexp =
               0x0000000000000000000000000000000000000000000000000000000000000000)
              (transaction_commitment
               0x0000000000000000000000000000000000000000000000000000000000000000)
-             (token_id 1) (excess 0) (ledger 0) (success true)))))
+             (token_id 1) (excess 0) (ledger 0) (success true) (failure_status (Update_not_permitted))))))
        (timestamp 1600251660000)))
      (consensus_state
       ((blockchain_length 2) (epoch_count 0) (min_window_density 77)
@@ -3644,7 +3644,8 @@ let sample_block_json =
         },
         "genesis_ledger_hash":
           "jxRZMzMSPVEMJ9wE4yqKEwQqVS3KZfDewHLYCC9aeqdig68Trco",
-        "registers":{"ledger":"jxRZMzMSPVEMJ9wE4yqKEwQqVS3KZfDewHLYCC9aeqdig68Trco","pending_coinbase_stack":null,"next_available_token":"2","local_state":{"parties":"0x0000000000000000000000000000000000000000000000000000000000000000","call_stack":"0x0000000000000000000000000000000000000000000000000000000000000000","transaction_commitment":"0x0000000000000000000000000000000000000000000000000000000000000000","token_id":"1","excess":"0","ledger":"jw6bz2wud1N6itRUHZ5ypo3267stk4UgzkiuWtAMPRZo9g4Udyd","success":true}},
+        "registers":{"ledger":"jxRZMzMSPVEMJ9wE4yqKEwQqVS3KZfDewHLYCC9aeqdig68Trco","pending_coinbase_stack":null,"next_available_token":"2","local_state":{"parties":"0x0000000000000000000000000000000000000000000000000000000000000000","call_stack":"0x0000000000000000000000000000000000000000000000000000000000000000","transaction_commitment":"0x0000000000000000000000000000000000000000000000000000000000000000","token_id":"1","excess":"0","ledger":"jw6bz2wud1N6itRUHZ5ypo3267stk4UgzkiuWtAMPRZo9g4Udyd","success":true,
+        "failure_status":["Update_not_permitted"]}},
         "timestamp": "1600251660000"
       },
       "consensus_state": {

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1819,7 +1819,7 @@ module Base = struct
           ; protocol_state_predicate : Snapp_predicate.Protocol_state.Checked.t
           ; transaction_commitment : Transaction_commitment.t
           ; field : Field.t
-          ; failure : Transaction_status.Failure.t option >
+          ; failure : unit >
       end
 
       include Parties_logic.Make (Inputs)
@@ -2054,7 +2054,7 @@ module Base = struct
                   checks_succeeded
             in
             (* omit failure status here, unlike `Transaction_logic` *)
-            (account_with_hash account', success, None)
+            (account_with_hash account', success, ())
         | Balance account ->
             Balance.Checked.to_amount account.data.balance
     end

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4844,16 +4844,26 @@ let%test_module "transaction_snark" =
                   let vk =
                     With_hash.of_data ~hash_data:Snapp_account.digest_vk vk
                   in
-                  let _is_new, _loc =
+                  let set_or_create ledger id account =
+                    match Ledger.location_of_account ledger id with
+                    | Some loc ->
+                        Ledger.set ledger loc account
+                    | None ->
+                        let _loc, _new =
+                          Ledger.get_or_create_account ledger id account
+                          |> Or_error.ok_exn
+                        in
+                        ()
+                  in
+                  let () =
                     let id =
                       Public_key.compress sender.public_key
                       |> fun pk -> Account_id.create pk Token_id.default
                     in
-                    Ledger.get_or_create_account ledger id
+                    set_or_create ledger id
                       (Account.create id Balance.(of_int 888_888))
-                    |> Or_error.ok_exn
                   in
-                  let _is_new, _loc =
+                  let () =
                     let id =
                       Account_id.create trivial_account_pk Token_id.default
                     in
@@ -4870,8 +4880,7 @@ let%test_module "transaction_snark" =
                             }
                       }
                     in
-                    Ledger.get_or_create_account ledger id account
-                    |> Or_error.ok_exn
+                    set_or_create ledger id account
                   in
                   (*TODO: Add another signed party for the transfer*)
                   (*let total = Option.value_exn (Amount.add fee amount) in*)

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -15,7 +15,8 @@ module Parties_segment_witness = struct
             , Amount.Stable.V1.t
             , Sparse_ledger.Stable.V2.t
             , bool
-            , Zexe_backend.Pasta.Fp.Stable.V1.t )
+            , Zexe_backend.Pasta.Fp.Stable.V1.t
+            , Transaction_status.Failure.Stable.V1.t option )
             Parties_logic.Local_state.Stable.V1.t
         ; start_parties :
             ( Parties.Stable.V1.t

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -15,7 +15,8 @@ module Parties_segment_witness : sig
             , Amount.Stable.V1.t
             , Sparse_ledger.Stable.V2.t
             , bool
-            , Zexe_backend.Pasta.Fp.Stable.V1.t )
+            , Zexe_backend.Pasta.Fp.Stable.V1.t
+            , Transaction_status.Failure.t option )
             Parties_logic.Local_state.Stable.V1.t
         ; start_parties :
             ( Parties.Stable.V1.t


### PR DESCRIPTION
Propagate failures in `Parties_logic` to errors in `Transaction_logic.apply_transaction`.

The strategy for that is to add a new field `failure_status` in `Parties_logic.Local_state.t`. Outside the transaction SNARK, that's a `Transaction_status.Failure.t option`; inside the SNARK, it's `unit`.

In `apply_parties_unchecked_aux`, if a step returns a local status with a failure, we convert that failure to an error.

Some bits to review carefully: 
- `Mina_state.Local_state.to_input` changes, which relies on `Transaction_status.Failure.option_to_input`
- in the same module, `failure_status_typ`, which relates `failure_status` types in/out the SNARK
- also `gen` in that module, which relies on `Transaction_status.Failure.gen`

Closes #9592