### PR TITLE
Escape verification loop on failure

### DIFF
--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -6,6 +6,7 @@
  (libraries async core one_or_two pipe_lib quickcheck_lib verifier mina_base ledger_proof transaction_snark transition_frontier consensus mina_numbers)
  (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_base ppx_coda ppx_version ppx_register_event ppx_let ppx_assert ppx_pipebang ppx_deriving.std ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv))
+ (preprocess (pps ppx_base ppx_coda ppx_version ppx_register_event ppx_here ppx_let ppx_assert ppx_pipebang
+                  ppx_deriving.std ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv))
  (synopsis
    "Network pool is an interface that processes incoming diffs and then broadcasts them"))

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1207,13 +1207,7 @@ struct
                             let rec go sender_local_state u_acc acc
                                 (rejected : Rejected.t) = function
                               | [] ->
-                                  (* If there are accepted commands, we keep the signer lock until this verified diff is applied.
-                                     Otherwise, we release the lock now.
-                                  *)
-                                  if List.is_empty acc then
-                                    Option.iter
-                                      (Hashtbl.find t.sender_mutex signer)
-                                      ~f:Mutex.release ;
+                                  (* We keep the signer lock until this verified diff is applied. *)
                                   return
                                     (Ok
                                        ( List.rev acc

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1207,7 +1207,13 @@ struct
                             let rec go sender_local_state u_acc acc
                                 (rejected : Rejected.t) = function
                               | [] ->
-                                  (* We keep the signer lock until this verified diff is applied. *)
+                                  (* If there are accepted commands, we keep the signer lock until this verified diff is applied.
+                                     Otherwise, we release the lock now.
+                                  *)
+                                  if List.is_empty acc then
+                                    Option.iter
+                                      (Hashtbl.find t.sender_mutex signer)
+                                      ~f:Mutex.release ;
                                   return
                                     (Ok
                                        ( List.rev acc


### PR DESCRIPTION
The function `Transaction_pool.verify'` consists of two loops:
- an outer loop, run in parallel, that uses Deferred.List.map, over senders
- an inner, sequential loop, over user commands (in the internal `go` function)

Unless we're allowing failure for tests, we don't use any verification results once there's been a failure. 
So wrap the outer loop in an `Async` monitor, and when there's a failure, release the signer lock and raise an exception.
The exception wraps the failure, and `verify'` returns an Error containing a string derived from the failure.

If we are allow failure for tests, as before, any errors are filtered out from the verification results.

The `Other_command_failed` token, which was used when terminating `go`, is no longer needed, since any failure  immediately terminates `go`.

Reviewer: Please check whether the mutex strategy makes sense. When escaping from the inner loop, the mutexes for all senders are released.

Closes .#9757.