### PR TITLE
Optimize staged ledger diff application

### DIFF
--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -153,9 +153,10 @@ let profile (module T : Transaction_snark.S) sparse_ledger0
         let next_available_token_before =
           Sparse_ledger.next_available_token sparse_ledger
         in
-        let sparse_ledger' =
-          Sparse_ledger.apply_transaction_exn ~constraint_constants
-            ~txn_state_view sparse_ledger (Transaction.forget t)
+        let sparse_ledger', _ =
+          Sparse_ledger.apply_transaction ~constraint_constants ~txn_state_view
+            sparse_ledger (Transaction.forget t)
+          |> Or_error.ok_exn
         in
         let next_available_token_after =
           Sparse_ledger.next_available_token sparse_ledger'
@@ -220,9 +221,10 @@ let check_base_snarks sparse_ledger0 (transitions : Transaction.Valid.t list)
           let next_available_token_before =
             Sparse_ledger.next_available_token sparse_ledger
           in
-          let sparse_ledger' =
-            Sparse_ledger.apply_transaction_exn ~constraint_constants
+          let sparse_ledger', _ =
+            Sparse_ledger.apply_transaction ~constraint_constants
               ~txn_state_view sparse_ledger (Transaction.forget t)
+            |> Or_error.ok_exn
           in
           let next_available_token_after =
             Sparse_ledger.next_available_token sparse_ledger'
@@ -267,9 +269,10 @@ let generate_base_snarks_witness sparse_ledger0
           let next_available_token_before =
             Sparse_ledger.next_available_token sparse_ledger
           in
-          let sparse_ledger' =
-            Sparse_ledger.apply_transaction_exn ~constraint_constants
+          let sparse_ledger', _ =
+            Sparse_ledger.apply_transaction ~constraint_constants
               ~txn_state_view sparse_ledger (Transaction.forget t)
+            |> Or_error.ok_exn
           in
           let next_available_token_after =
             Sparse_ledger.next_available_token sparse_ledger'

--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -120,6 +120,8 @@ module Make_base (Inputs : Inputs_intf) :
 
     let merkle_path (T ((module Base), t)) = Base.merkle_path t
 
+    let merkle_path_batch (T ((module Base), t)) = Base.merkle_path_batch t
+
     let merkle_root (T ((module Base), t)) = Base.merkle_root t
 
     let index_of_account_exn (T ((module Base), t)) =

--- a/src/lib/merkle_ledger/base_ledger_intf.ml
+++ b/src/lib/merkle_ledger/base_ledger_intf.ml
@@ -139,6 +139,8 @@ module type S = sig
 
   val merkle_path : t -> Location.t -> Path.t
 
+  val merkle_path_batch : t -> Location.t list -> (Location.t * Path.t) list
+
   val merkle_path_at_index_exn : t -> int -> Path.t
 
   val remove_accounts_exn : t -> account_id list -> unit

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -151,6 +151,17 @@ module Make (Inputs : Inputs_intf) :
     | None ->
         empty_hash (Location.height ~ledger_depth:mdb.depth location)
 
+  let get_hash_batch mdb locs =
+    assert (List.for_all locs ~f:Location.is_hash) ;
+    get_bin_batch mdb locs Hash.bin_read_t
+    |> List.zip_exn locs
+    |> List.map ~f:(fun (loc, result) ->
+           match result with
+           | Some hashes ->
+               hashes
+           | None ->
+               empty_hash (Location.height ~ledger_depth:mdb.depth loc))
+
   let account_list_bin { kvdb; _ } account_bin_read : Account.t list =
     let all_keys_values = Kvdb.to_alist kvdb in
     (* see comment at top of location.ml about encoding of locations *)
@@ -740,6 +751,38 @@ module Make (Inputs : Inputs_intf) :
         :: loop (Location.parent k)
     in
     loop location
+
+  let merkle_path_batch mdb =
+    let rec loop height locs =
+      if height >= mdb.depth then List.init (List.length locs) ~f:(Fn.const [])
+      else
+        let siblings = List.map locs ~f:Location.sibling in
+        let hashes = get_hash_batch mdb siblings in
+        let this_layer =
+          List.zip_exn locs hashes
+          |> List.map ~f:(fun (loc, hash) ->
+                 loc |> Location.to_path_exn |> Location.last_direction
+                 |> Direction.map ~left:(`Left hash) ~right:(`Right hash))
+        in
+        let next_layer = loop (height + 1) (List.map locs ~f:Location.parent) in
+        List.zip_exn this_layer next_layer |> List.map ~f:(fun (h, t) -> h :: t)
+    in
+    fun locs ->
+      let locs =
+        List.map locs ~f:(fun loc ->
+            if Location.is_account loc then
+              Location.Hash (Location.to_path_exn loc)
+            else loc)
+      in
+      match locs with
+      | [] ->
+          []
+      | first_loc :: _ ->
+          let height = Location.height ~ledger_depth:mdb.depth first_loc in
+          assert (
+            List.for_all locs ~f:(fun loc ->
+                Location.height ~ledger_depth:mdb.depth loc = height) ) ;
+          List.zip_exn locs (loop height locs)
 
   let merkle_path_at_addr_exn t addr = merkle_path t (Location.Hash addr)
 

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -64,6 +64,9 @@ end = struct
     in
     loop location
 
+  let merkle_path_batch t locs =
+    List.zip_exn locs (List.map locs ~f:(merkle_path t))
+
   let merkle_root t = empty_hash_at_height t.depth
 
   let merkle_path_at_addr_exn t addr = merkle_path t (Location.Hash addr)

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -240,6 +240,14 @@ module Make (Inputs : Inputs_intf.S) = struct
       let parent_merkle_path = Base.merkle_path (get_parent t) location in
       fixup_merkle_path t parent_merkle_path address
 
+    (* TODO: we should be able to optimize this some with a little thought *)
+    let merkle_path_batch t locations =
+      assert_is_attached t ;
+      locations
+      |> Base.merkle_path_batch (get_parent t)
+      |> List.map ~f:(fun (loc, path) ->
+             (loc, fixup_merkle_path t path (Location.to_path_exn loc)))
+
     (* given a Merkle path corresponding to a starting address, calculate
        addresses and hashes for each node affected by the starting hash; that is,
        along the path from the account address to root *)
@@ -762,13 +770,37 @@ module Make (Inputs : Inputs_intf.S) = struct
         ( Addr.of_directions
         @@ List.init ledger_depth ~f:(fun _ -> Direction.Left) )
 
+    let next_location t =
+      let maybe_location =
+        match last_filled t with
+        | None ->
+            Some (first_location ~ledger_depth:t.depth)
+        | Some loc ->
+            Location.next loc
+      in
+      match maybe_location with
+      | None ->
+          Or_error.error_string "Db_error.Out_of_leaves"
+      | Some location ->
+          Ok location
+
     let loc_max a b =
       let a' = Location.to_path_exn a in
       let b' = Location.to_path_exn b in
       if Location.Addr.compare a' b' > 0 then a else b
 
+    (* NB: unsafe to call if account_id is already in ledger *)
+    let unsafe_create_account t account_id account =
+      let open Or_error.Let_syntax in
+      let%map location = next_location t in
+      set t location account ;
+      self_set_location t account_id location ;
+      t.current_location <- Some location ;
+      location
+
     (* NB: updates the mutable current_location field in t *)
     let get_or_create_account t account_id account =
+      let open Or_error.Let_syntax in
       assert_is_attached t ;
       match self_find_location t account_id with
       | None -> (
@@ -776,23 +808,9 @@ module Make (Inputs : Inputs_intf.S) = struct
           match Base.location_of_account (get_parent t) account_id with
           | Some location ->
               Ok (`Existed, location)
-          | None -> (
-              (* not in parent, create new location *)
-              let maybe_location =
-                match last_filled t with
-                | None ->
-                    Some (first_location ~ledger_depth:t.depth)
-                | Some loc ->
-                    Location.next loc
-              in
-              match maybe_location with
-              | None ->
-                  Or_error.error_string "Db_error.Out_of_leaves"
-              | Some location ->
-                  set t location account ;
-                  self_set_location t account_id location ;
-                  t.current_location <- Some location ;
-                  Ok (`Added, location) ) )
+          | None ->
+              let%map location = unsafe_create_account t account_id account in
+              (`Added, location) )
       | Some location ->
           Ok (`Existed, location)
 

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -1,4 +1,6 @@
 (* masking_merkle_tree_intf.ml *)
+open Core_kernel
+
 (* the type of a Merkle tree mask associated with a parent Merkle tree *)
 module type S = sig
   type t
@@ -52,6 +54,9 @@ module type S = sig
 
     (** get hash from mask, if present, else from its parent *)
     val get_hash : t -> Addr.t -> hash option
+
+    val unsafe_create_account :
+      t -> account_id -> account -> Location.t Or_error.t
 
     (** commit all state to the parent, flush state locally *)
     val commit : t -> unit

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -55,6 +55,7 @@ module type S = sig
     (** get hash from mask, if present, else from its parent *)
     val get_hash : t -> Addr.t -> hash option
 
+    (** registers a new account in the ledger; unsafe to call if account id already exists *)
     val unsafe_create_account :
       t -> account_id -> account -> Location.t Or_error.t
 

--- a/src/lib/mina_base/dune
+++ b/src/lib/mina_base/dune
@@ -51,7 +51,7 @@
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_snarky ppx_here ppx_coda ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord
-       ppx_base ppx_bench ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test h_list.ppx
+       ppx_base ppx_bench ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_pipebang ppx_assert ppx_deriving_yojson ppx_inline_test h_list.ppx
  ))
  (instrumentation (backend bisect_ppx))
  (synopsis "Snarks and friends necessary for keypair generation"))

--- a/src/lib/mina_base/ledger.mli
+++ b/src/lib/mina_base/ledger.mli
@@ -1,5 +1,6 @@
 open Core
 open Signature_lib
+open Transaction_logic
 
 module Location : Merkle_ledger.Location_intf.S
 
@@ -100,88 +101,8 @@ val register_mask : t -> Mask.t -> Mask.Attached.t
 
 val commit : Mask.Attached.t -> unit
 
-module Transaction_applied : sig
-  open Transaction_logic
-
-  module Signed_command_applied : sig
-    module Common : sig
-      type t = Transaction_applied.Signed_command_applied.Common.t =
-        { user_command : Signed_command.t With_status.t
-        ; previous_receipt_chain_hash : Receipt.Chain_hash.t
-        ; fee_payer_timing : Account.Timing.t
-        ; source_timing : Account.Timing.t option
-        }
-      [@@deriving sexp]
-    end
-
-    module Body : sig
-      type t = Transaction_applied.Signed_command_applied.Body.t =
-        | Payment of { previous_empty_accounts : Account_id.t list }
-        | Stake_delegation of
-            { previous_delegate : Public_key.Compressed.t option }
-        | Create_new_token of { created_token : Token_id.t }
-        | Create_token_account
-        | Mint_tokens
-        | Failed
-      [@@deriving sexp]
-    end
-
-    type t = Transaction_applied.Signed_command_applied.t =
-      { common : Common.t; body : Body.t }
-    [@@deriving sexp]
-  end
-
-  module Snapp_command_applied : sig
-    type t = Transaction_applied.Snapp_command_applied.t =
-      { accounts : (Account_id.t * Account.t option) list
-      ; command : Snapp_command.t With_status.t
-      }
-    [@@deriving sexp]
-  end
-
-  module Command_applied : sig
-    type t = Transaction_applied.Command_applied.t =
-      | Signed_command of Signed_command_applied.t
-      | Snapp_command of Snapp_command_applied.t
-    [@@deriving sexp]
-  end
-
-  module Fee_transfer_applied : sig
-    type t = Transaction_applied.Fee_transfer_applied.t =
-      { fee_transfer : Fee_transfer.t
-      ; previous_empty_accounts : Account_id.t list
-      ; receiver_timing : Account.Timing.t
-      ; balances : Transaction_status.Fee_transfer_balance_data.t
-      }
-    [@@deriving sexp]
-  end
-
-  module Coinbase_applied : sig
-    type t = Transaction_applied.Coinbase_applied.t =
-      { coinbase : Coinbase.t
-      ; previous_empty_accounts : Account_id.t list
-      ; receiver_timing : Account.Timing.t
-      ; balances : Transaction_status.Coinbase_balance_data.t
-      }
-    [@@deriving sexp]
-  end
-
-  module Varying : sig
-    type t = Transaction_applied.Varying.t =
-      | Command of Command_applied.t
-      | Fee_transfer of Fee_transfer_applied.t
-      | Coinbase of Coinbase_applied.t
-    [@@deriving sexp]
-  end
-
-  type t = Transaction_applied.t =
-    { previous_hash : Ledger_hash.t; varying : Varying.t }
-  [@@deriving sexp]
-
-  val transaction : t -> Transaction.t With_status.t
-
-  val user_command_status : t -> Transaction_status.t
-end
+val unsafe_create_account :
+  t -> Account_id.t -> Account.t -> Location.t Or_error.t
 
 (** Raises if the ledger is full, or if an account already exists for the given
     [Account_id.t].

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -1018,7 +1018,8 @@ module T = struct
     let root_hash = hash_at_level depth in
     { Poly.tree =
         make_tree
-          (Merkle_tree.of_hash ~depth ~next_available_token:() root_hash)
+          (Merkle_tree.of_hash ~depth ~next_available_token:()
+             ~next_available_index:None root_hash)
           Stack_id.zero
     ; pos_list = []
     ; new_pos = Stack_id.zero

--- a/src/lib/mina_base/sparse_ledger.ml
+++ b/src/lib/mina_base/sparse_ledger.ml
@@ -1,3 +1,6 @@
+(* TODO NOW: pull over ledger batching code (new impl of `of_ledger_subset_exn`, updated usage of ledgers in staged_ledger.ml) *)
+(* TODO: refactor the misleading implementation of Ledger.foldi that confused me so much in the first place. *)
+
 open Core
 open Import
 open Snark_params.Tick
@@ -102,29 +105,49 @@ M.
   , to_yojson
   , get_exn
   , path_exn
+  , arm_exn
   , set_exn
+  , find_index
   , find_index_exn
   , add_path
-  , merkle_root
+  , merkle_root (* , data *)
   , iteri
-  , next_available_token )]
+  , depth
+  , next_available_token
+  , next_available_index )]
 
-let of_root ~depth ~next_available_token (h : Ledger_hash.t) =
-  of_hash ~depth ~next_available_token
+(* TODO: share this cache globally across modules *)
+let empty_hash =
+  Empty_hashes.extensible_cache
+    (module Ledger_hash)
+    ~init_hash:(Ledger_hash.of_digest Account.empty_digest)
+
+let of_root ~depth ~next_available_token ~next_available_index
+    (h : Ledger_hash.t) =
+  of_hash ~depth ~next_available_token ~next_available_index
+    (* TODO: Is this of_digest casting really necessary? What's it doing? *)
     (Ledger_hash.of_digest (h :> Random_oracle.Digest.t))
 
-let of_ledger_root ledger =
-  of_root ~depth:(Ledger.depth ledger)
-    ~next_available_token:(Ledger.next_available_token ledger)
-    (Ledger.merkle_root ledger)
+let of_any_ledger_root ledger =
+  let next_available_index =
+    match Ledger.Any_ledger.M.last_filled ledger with
+    | Some (Ledger.Location.Account addr) ->
+        Option.map (Ledger.Addr.next addr) ~f:Ledger.Addr.to_int
+    | Some _ ->
+        failwith
+          "unable to get next available index from ledger: last filled \
+           location is invalid"
+    | None ->
+        Some 0
+  in
+  of_root
+    ~depth:(Ledger.Any_ledger.M.depth ledger)
+    ~next_available_token:(Ledger.Any_ledger.M.next_available_token ledger)
+    ~next_available_index
+    (Ledger.Any_ledger.M.merkle_root ledger)
 
 let of_any_ledger (ledger : Ledger.Any_ledger.witness) =
-  Ledger.Any_ledger.M.foldi ledger
-    ~init:
-      (of_root
-         ~depth:(Ledger.Any_ledger.M.depth ledger)
-         ~next_available_token:(Ledger.Any_ledger.M.next_available_token ledger)
-         (Ledger.Any_ledger.M.merkle_root ledger))
+  Ledger.Any_ledger.M.foldi ledger ~init:(of_any_ledger_root ledger)
     ~f:(fun _addr sparse_ledger account ->
       let loc =
         Option.value_exn
@@ -147,12 +170,12 @@ let of_ledger_subset_exn (oledger : Ledger.t) keys =
             , add_path sl
                 (Ledger.merkle_path ledger loc)
                 key
-                ( Ledger.get ledger loc
-                |> Option.value_exn ?here:None ?error:None ?message:None ) )
+                (Ledger.get ledger loc |> Option.value_exn) )
         | None ->
             let path, acct = Ledger.create_empty_exn ledger key in
             (key :: new_keys, add_path sl path key acct))
-      ~init:([], of_ledger_root ledger)
+      ~init:
+        ([], of_any_ledger_root (Ledger.Any_ledger.cast (module Ledger) ledger))
   in
   Debug_assert.debug_assert (fun () ->
       [%test_eq: Ledger_hash.t]
@@ -160,14 +183,9 @@ let of_ledger_subset_exn (oledger : Ledger.t) keys =
         ((merkle_root sparse :> Random_oracle.Digest.t) |> Ledger_hash.of_hash)) ;
   sparse
 
+(* TODO: optimize this to batch as well (used during block production) *)
 let of_ledger_index_subset_exn (ledger : Ledger.Any_ledger.witness) indexes =
-  List.fold indexes
-    ~init:
-      (of_root
-         ~depth:(Ledger.Any_ledger.M.depth ledger)
-         ~next_available_token:(Ledger.Any_ledger.M.next_available_token ledger)
-         (Ledger.Any_ledger.M.merkle_root ledger))
-    ~f:(fun acc i ->
+  List.fold indexes ~init:(of_any_ledger_root ledger) ~f:(fun acc i ->
       let account = Ledger.Any_ledger.M.get_at_index_exn ledger i in
       add_path acc
         (Ledger.Any_ledger.M.merkle_path_at_index_exn ledger i)
@@ -191,6 +209,254 @@ let%test_unit "of_ledger_subset_exn with keys that don't exist works" =
         (Ledger.merkle_root ledger)
         ((merkle_root sl :> Random_oracle.Digest.t) |> Ledger_hash.of_hash))
 
+let next_index ~depth idx =
+  if idx >= Sparse_ledger_lib.Sparse_ledger.max_index depth then None
+  else Some (idx + 1)
+
+let path_of_arm =
+  List.map ~f:(function `Left, _, r -> `Left r | `Right, l, _ -> `Right l)
+
+(** Derives the next arm of a merkle tree from the previous arm. Assumes that
+    all hashes to the right of the previous arm are derived from empty leaves
+    (thus, the next arm is a new arm in the tree). *)
+let derive_next_arm_exn prev_arm =
+  let is_right = function `Left, _, _ -> false | `Right, _, _ -> true in
+  let flip_left ~on_right ~empty_error = function
+    | [] ->
+        failwith empty_error
+    | (`Left, l, r) :: rest ->
+        (`Right, l, r) :: rest
+    | (`Right, _, _) :: _ ->
+        on_right ()
+  in
+  let rec flip_rights rights height =
+    match rights with
+    | [] ->
+        []
+    | (`Right, _, _) :: rest ->
+        let h = empty_hash height in
+        (`Left, h, h) :: flip_rights rest (height + 1)
+    | _ ->
+        failwith "this shouldn't happen"
+  in
+  flip_left prev_arm ~empty_error:"invalid arm" ~on_right:(fun () ->
+      let rights_to_flip, rest = List.split_while prev_arm ~f:is_right in
+      let rest' =
+        flip_left rest ~empty_error:"no space left in ledger"
+          ~on_right:(fun () -> failwith "this shouldn't happen")
+      in
+      flip_rights rights_to_flip 0 @ rest')
+
+let%test_unit "adding paths generated via derive_next_arm_exn does not \
+               conflict with the initial merkle root of the ledger" =
+  (* initial account to store in the left-most position (just needs to have some hash different than the empty account hash) *)
+  let account = { Account.empty with balance = Currency.Balance.of_int 100 } in
+  (* right leaning hashes for merkle proof *)
+  let path_hashes = List.map [ 0; 1; 2 ] ~f:empty_hash in
+  let path = List.map path_hashes ~f:(fun h -> `Left h) in
+  let root, _, arm_reversed =
+    List.fold_left path_hashes
+      ~init:(Ledger_hash.of_digest (Account.digest account), 0, [])
+      ~f:(fun (hash, height, acc) path_hash ->
+        ( Ledger_hash.merge ~height hash path_hash
+        , height + 1
+        , (`Left, hash, path_hash) :: acc ))
+  in
+  let arm = List.rev arm_reversed in
+  let ledger =
+    of_root ~depth:3
+      ~next_available_token:(Token_id.of_uint64 Unsigned_extended.UInt64.one)
+      ~next_available_index:(Some 1) root
+  in
+  let ledger = add_path ledger path (Account.identifier account) account in
+  let ledger, _ =
+    List.fold_left [ 1; 2; 3; 4; 5; 6; 7 ] ~init:(ledger, arm)
+      ~f:(fun (ledger, prev_arm) _ ->
+        let next_arm = derive_next_arm_exn prev_arm in
+        let ledger =
+          add_path ledger (path_of_arm next_arm)
+            (Account.identifier Account.empty)
+            Account.empty
+        in
+        (ledger, next_arm))
+  in
+  [%test_eq: Ledger_hash.t] (merkle_root ledger) root
+
+let of_sparse_ledger_subset_exn base_ledger account_ids =
+  let add_existing_accounts l =
+    List.fold_right account_ids ~init:(l, [])
+      ~f:(fun id (l, missing_accounts) ->
+        match find_index base_ledger id with
+        | Some idx ->
+            let account = get_exn base_ledger idx in
+            let path = path_exn base_ledger idx in
+            (add_path l path id account, missing_accounts)
+        | None ->
+            (l, id :: missing_accounts))
+  in
+  let add_missing_accounts l missing_account_ids =
+    let next_idx =
+      Option.value_exn (next_available_index l)
+        ~message:"not enough space in ledger"
+    in
+    (* TODO: handle empty ledgers here *)
+    assert (next_idx > 0) ;
+    let last_idx = next_idx - 1 in
+    let last_arm = arm_exn base_ledger last_idx in
+    let result, _, _ =
+      (* TODO: we could just check the remaining available slots in the ledger upfront instead of folding over the index (which is otherwise unused here) *)
+      List.fold_left missing_account_ids ~init:(l, last_arm, Some next_idx)
+        ~f:(fun (l, prev_arm, idx_opt) id ->
+          let idx =
+            Option.value_exn idx_opt ~message:"not enough space in ledger"
+          in
+          let next_arm = derive_next_arm_exn prev_arm in
+          ( add_path l (path_of_arm next_arm) id Account.empty
+          , next_arm
+          , next_index ~depth:(depth l) idx ))
+    in
+    result
+  in
+  let result_ledger =
+    let ledger =
+      of_root ~depth:(depth base_ledger)
+        ~next_available_token:(next_available_token base_ledger)
+        ~next_available_index:(next_available_index base_ledger)
+        (merkle_root base_ledger)
+    in
+    let ledger, missing_account_ids = add_existing_accounts ledger in
+    if List.is_empty missing_account_ids then ledger
+    else add_missing_accounts ledger missing_account_ids
+  in
+  Debug_assert.debug_assert (fun () ->
+      [%test_eq: Ledger_hash.t]
+        (merkle_root result_ledger)
+        (merkle_root base_ledger)) ;
+  result_ledger
+
+(* IMPORTANT TODO: rightmost path in parent sparse ledger must exist in order for derivation on new accounts to work *)
+(* ^^^ should probably setup a test to ensure the error message is decent *)
+
+(* challenge: computing paths to empty accounts from another sparse ledger
+    universal issue: need to have path to last account loaded on any sparse ledger this is called on (read: every sparse ledger)
+    options:
+    - add accounts to copy of sparse ledger, get paths from that
+      issue: add_account_exn doens't work
+        - definition as is throws exn when account isn't already indexed as Account.empty
+        - logic in sparse ledger is not using the new next_available_index yet (pull code from other branch)
+    - compute the path dynamically
+      issue: complicated messy code
+    - don't load missing accounts at all
+      issue: defers computation to later
+*)
+
+let%test_module "of_sparse_ledger_subset_exn" =
+  ( module struct
+    (* TODO: let check_predicates ~expected_accounts ledger = ... *)
+
+    (* Not really a great solution for refining generators, but works ok so long as predicate fails on only a small subset of it's domain. *)
+    let gen_until ?(max_retries = 1_000) p g =
+      let open Quickcheck.Let_syntax in
+      let rec loop n =
+        if n < max_retries then
+          let%bind x = g in
+          if p x then return x else loop (n + 1)
+        else
+          failwith
+            "gen_until: failed to generate a value that matched specified \
+             predicate"
+      in
+      loop 0
+
+    (* Generates a unattached ledger mask with a random amount of accounts, along with a random selection of account
+       locations pointing to a subset of accounts in the ledger. *)
+    let gen_ledger_with_subset_selection ?(min_size = 1) ?(min_subset_size = 0)
+        ?(min_free_space = 0) depth =
+      let open Quickcheck.Let_syntax in
+      let max_size = Int.pow 2 depth in
+      assert (0 <= min_free_space && min_free_space <= max_size) ;
+      assert (0 <= min_size && min_size <= max_size - min_free_space) ;
+      let%bind size = Int.gen_incl min_size (max_size - min_free_space) in
+      let%bind accounts = List.gen_with_length size Account.gen in
+      let%map indices =
+        gen_until
+          (fun l -> List.length l > min_subset_size)
+          (List.gen_filtered (List.init size ~f:Fn.id))
+      in
+      let ledger = Ledger.create_ephemeral ~depth () in
+      List.iter accounts ~f:(fun acct ->
+          Ledger.create_new_account_exn ledger (Account.identifier acct) acct) ;
+      let account_ids =
+        List.map indices ~f:(fun i ->
+            Ledger.Location.Account
+              (Ledger.Addr.of_int_exn ~ledger_depth:depth i)
+            |> Ledger.get ledger |> Option.value_exn |> Account.identifier)
+      in
+      (ledger, account_ids)
+
+    let%test_unit "when all accounts already exist" =
+      let depth = 4 in
+      Quickcheck.test (gen_ledger_with_subset_selection depth) ~trials:100
+        ~f:(fun (ledger, account_ids) ->
+          let sl = of_ledger_subset_exn ledger account_ids in
+          [%test_result: Ledger_hash.t]
+            ~expect:(Ledger.merkle_root ledger)
+            (merkle_root @@ of_sparse_ledger_subset_exn sl account_ids))
+
+    let%test_unit "with new accounts" =
+      let depth = 4 in
+      let gen =
+        let open Quickcheck.Let_syntax in
+        let%bind num_new_accounts = Int.gen_incl 1 (Int.pow 2 depth - 1) in
+        let%bind new_account_ids =
+          List.gen_with_length num_new_accounts Account_id.gen
+        in
+        let%map ledger, existing_account_ids =
+          gen_ledger_with_subset_selection ~min_free_space:num_new_accounts
+            depth
+        in
+        (ledger, existing_account_ids @ new_account_ids)
+      in
+      Quickcheck.test gen ~trials:100 ~f:(fun (ledger, account_ids) ->
+          let sl =
+            of_ledger_subset_exn ledger
+              (ledger |> Ledger.accounts |> Set.elements)
+          in
+          [%test_result: Ledger_hash.t]
+            ~expect:(Ledger.merkle_root ledger)
+            (merkle_root @@ of_sparse_ledger_subset_exn sl account_ids))
+
+    let%test_unit "on an empty ledger" =
+      let depth = 4 in
+      let gen =
+        let open Quickcheck.Let_syntax in
+        let%bind n = Int.gen_incl 1 (Int.pow 2 depth) in
+        List.gen_with_length n Account_id.gen
+      in
+      Quickcheck.test gen ~trials:100 ~f:(fun account_ids ->
+          let ledger = Ledger.create_ephemeral ~depth () in
+          let sl = of_ledger_subset_exn ledger [] in
+          [%test_result: Ledger_hash.t]
+            ~expect:(Ledger.merkle_root ledger)
+            (merkle_root @@ of_sparse_ledger_subset_exn sl account_ids))
+
+    let%test_unit "throws when missing accounts are not new" =
+      let depth = 4 in
+      Quickcheck.test
+        (gen_ledger_with_subset_selection ~min_subset_size:1 depth) ~trials:100
+        ~f:(fun (ledger, account_ids) ->
+          match List.permute account_ids with
+          | [] ->
+              failwith "shouldn't happen as ledger shouldn't be empty"
+          | _ :: subset_ids ->
+              let sl = of_ledger_subset_exn ledger subset_ids in
+              let result =
+                Or_error.try_with (fun () ->
+                    of_sparse_ledger_subset_exn sl account_ids)
+              in
+              [%test_pred: t Or_error.t] Or_error.is_error result)
+  end )
+
 let get_or_initialize_exn account_id t idx =
   let account = get_exn t idx in
   if Public_key.Compressed.(equal empty account.public_key) then
@@ -208,420 +474,26 @@ let get_or_initialize_exn account_id t idx =
       } )
   else (`Existed, account)
 
-let sub_account_creation_fee
-    ~(constraint_constants : Genesis_constants.Constraint_constants.t) action
-    (amount : Currency.Amount.t) =
-  if equal_account_state action `Added then
-    Option.value_exn
-      Currency.Amount.(
-        sub amount (of_fee constraint_constants.account_creation_fee))
-  else amount
-
-let apply_user_command_exn
-    ~(constraint_constants : Genesis_constants.Constraint_constants.t)
-    ~txn_global_slot t
-    ({ signer; payload; signature = _ } as user_command : Signed_command.t) =
-  let open Currency in
-  let signer_pk = Public_key.compress signer in
-  let current_global_slot = txn_global_slot in
-  (* Fee-payer information *)
-  let fee_token = Signed_command.fee_token user_command in
-  let fee_payer = Signed_command.fee_payer user_command in
-  let nonce = Signed_command.nonce user_command in
-  assert (
-    Public_key.Compressed.equal (Account_id.public_key fee_payer) signer_pk ) ;
-  assert (Token_id.equal fee_token Token_id.default) ;
-  let fee_payer_idx, fee_payer_account =
-    let idx = find_index_exn t fee_payer in
-    let account = get_exn t idx in
-    assert (Account.Nonce.equal account.nonce nonce) ;
-    let fee = Signed_command.fee user_command in
-    let timing =
-      Or_error.ok_exn
-      @@ Transaction_logic.validate_timing ~txn_amount:(Amount.of_fee fee)
-           ~txn_global_slot:current_global_slot ~account
-    in
-    ( idx
-    , { account with
-        nonce = Account.Nonce.succ account.nonce
-      ; balance =
-          Balance.sub_amount account.balance (Amount.of_fee fee)
-          |> Option.value_exn ?here:None ?error:None ?message:None
-      ; receipt_chain_hash =
-          Receipt.Chain_hash.cons (Signed_command payload)
-            account.receipt_chain_hash
-      ; timing
-      } )
-  in
-  (* Charge the fee. *)
-  let t = set_exn t fee_payer_idx fee_payer_account in
-  let next_available_token = next_available_token t in
-  let source = Signed_command.source ~next_available_token user_command in
-  let receiver = Signed_command.receiver ~next_available_token user_command in
-  let exception Reject of exn in
-  let charge_account_creation_fee_exn (account : Account.t) =
-    let balance =
-      Option.value_exn
-        (Balance.sub_amount account.balance
-           (Amount.of_fee constraint_constants.account_creation_fee))
-    in
-    let account = { account with balance } in
-    let timing =
-      Or_error.ok_exn
-        (Transaction_logic.validate_timing ~txn_amount:Amount.zero
-           ~txn_global_slot:current_global_slot ~account)
-    in
-    { account with timing }
-  in
-  let compute_updates () =
-    (* Raise an exception if any of the invariants for the user command are not
-       satisfied, so that the command will not go through.
-
-       This must re-check the conditions in Transaction_logic, to ensure that
-       the failure cases are consistent.
-    *)
-    let predicate_passed =
-      if
-        Public_key.Compressed.equal
-          (Signed_command.fee_payer_pk user_command)
-          (Signed_command.source_pk user_command)
-      then true
-      else
-        match payload.body with
-        | Create_new_token _ ->
-            (* Any account is allowed to create a new token associated with a
-               public key.
-            *)
-            true
-        | Create_token_account _ ->
-            (* Predicate failure is deferred here. It will be checked later. *)
-            let predicate_result =
-              (* TODO(#4554): Hook predicate evaluation in here once
-                 implemented.
-              *)
-              false
-            in
-            predicate_result
-        | Payment _ | Stake_delegation _ | Mint_tokens _ ->
-            (* TODO(#4554): Hook predicate evaluation in here once implemented. *)
-            failwith
-              "The fee-payer is not authorised to issue commands for the \
-               source account"
-    in
-    match Signed_command.Payload.body payload with
-    | Stake_delegation _ ->
-        let receiver_account = get_exn t @@ find_index_exn t receiver in
-        (* Check that receiver account exists. *)
-        assert (
-          not Public_key.Compressed.(equal empty receiver_account.public_key) ) ;
-        let source_idx = find_index_exn t source in
-        let source_account = get_exn t source_idx in
-        (* Check that source account exists. *)
-        assert (
-          not Public_key.Compressed.(equal empty source_account.public_key) ) ;
-        let source_account =
-          (* Timing is always valid, but we need to record any switch from
-             timed to untimed here to stay in sync with the snark.
-          *)
-          let timing =
-            Or_error.ok_exn
-            @@ Transaction_logic.validate_timing ~txn_amount:Amount.zero
-                 ~txn_global_slot:current_global_slot ~account:source_account
-          in
-          { source_account with
-            delegate = Some (Account_id.public_key receiver)
-          ; timing
-          }
-        in
-        [ (source_idx, source_account) ]
-    | Payment { amount; token_id = token; _ } ->
-        let receiver_idx = find_index_exn t receiver in
-        let action, receiver_account =
-          get_or_initialize_exn receiver t receiver_idx
-        in
-        let receiver_amount =
-          if Token_id.(equal default) token then
-            sub_account_creation_fee ~constraint_constants action amount
-          else if equal_account_state action `Added then
-            failwith "Receiver account does not exist, and we cannot create it"
-          else amount
-        in
-        let receiver_account =
-          { receiver_account with
-            balance =
-              Balance.add_amount receiver_account.balance receiver_amount
-              |> Option.value_exn ?here:None ?error:None ?message:None
-          }
-        in
-        let source_idx = find_index_exn t source in
-        let source_account =
-          let account =
-            if Account_id.equal source receiver then (
-              assert (equal_account_state action `Existed) ;
-              receiver_account )
-            else get_exn t source_idx
-          in
-          (* Check that source account exists. *)
-          assert (not Public_key.Compressed.(equal empty account.public_key)) ;
-          try
-            { account with
-              balance =
-                Balance.sub_amount account.balance amount
-                |> Option.value_exn ?here:None ?error:None ?message:None
-            ; timing =
-                Or_error.ok_exn
-                @@ Transaction_logic.validate_timing ~txn_amount:amount
-                     ~txn_global_slot:current_global_slot ~account
-            }
-          with exn when Account_id.equal fee_payer source ->
-            (* Don't process transactions with insufficient balance from the
-               fee-payer.
-            *)
-            raise (Reject exn)
-        in
-        [ (receiver_idx, receiver_account); (source_idx, source_account) ]
-    | Create_new_token { disable_new_accounts; _ } ->
-        (* NOTE: source and receiver are definitionally equal here. *)
-        let fee_payer_account =
-          try charge_account_creation_fee_exn fee_payer_account
-          with exn -> raise (Reject exn)
-        in
-        let receiver_idx = find_index_exn t receiver in
-        let action, receiver_account =
-          get_or_initialize_exn receiver t receiver_idx
-        in
-        if not (equal_account_state action `Added) then
-          raise
-            (Reject
-               (Failure
-                  "Token owner account for newly created token already exists")) ;
-        let receiver_account =
-          { receiver_account with
-            token_permissions =
-              Token_permissions.Token_owned { disable_new_accounts }
-          }
-        in
-        [ (fee_payer_idx, fee_payer_account); (receiver_idx, receiver_account) ]
-    | Create_token_account { account_disabled; _ } ->
-        if
-          account_disabled
-          && Token_id.(equal default) (Account_id.token_id receiver)
-        then
-          raise
-            (Reject
-               (Failure "Cannot open a disabled account in the default token")) ;
-        let fee_payer_account =
-          try charge_account_creation_fee_exn fee_payer_account
-          with exn -> raise (Reject exn)
-        in
-        let receiver_idx = find_index_exn t receiver in
-        let action, receiver_account =
-          get_or_initialize_exn receiver t receiver_idx
-        in
-        if equal_account_state action `Existed then
-          failwith "Attempted to create an account that already exists" ;
-        let receiver_account =
-          { receiver_account with
-            token_permissions = Token_permissions.Not_owned { account_disabled }
-          }
-        in
-        let source_idx = find_index_exn t source in
-        let source_account =
-          if Account_id.equal source receiver then receiver_account
-          else if Account_id.equal source fee_payer then fee_payer_account
-          else
-            match get_or_initialize_exn receiver t source_idx with
-            | `Added, _ ->
-                failwith "Source account does not exist"
-            | `Existed, source_account ->
-                source_account
-        in
-        let () =
-          match source_account.token_permissions with
-          | Token_owned { disable_new_accounts } ->
-              if
-                not
-                  ( Bool.equal account_disabled disable_new_accounts
-                  || predicate_passed )
-              then
-                failwith
-                  "The fee-payer is not authorised to create token accounts \
-                   for this token"
-          | Not_owned _ ->
-              if Token_id.(equal default) (Account_id.token_id receiver) then ()
-              else failwith "Token owner account does not own the token"
-        in
-        let source_account =
-          let timing =
-            Or_error.ok_exn
-            @@ Transaction_logic.validate_timing ~txn_amount:Amount.zero
-                 ~txn_global_slot:current_global_slot ~account:source_account
-          in
-          { source_account with timing }
-        in
-        if Account_id.equal source receiver then
-          (* For token_id= default, we allow this *)
-          [ (fee_payer_idx, fee_payer_account); (source_idx, source_account) ]
-        else
-          [ (receiver_idx, receiver_account)
-          ; (fee_payer_idx, fee_payer_account)
-          ; (source_idx, source_account)
-          ]
-    | Mint_tokens { token_id = token; amount; _ } ->
-        assert (not (Token_id.(equal default) token)) ;
-        let receiver_idx = find_index_exn t receiver in
-        let action, receiver_account =
-          get_or_initialize_exn receiver t receiver_idx
-        in
-        assert (equal_account_state action `Existed) ;
-        let receiver_account =
-          { receiver_account with
-            balance =
-              Balance.add_amount receiver_account.balance amount
-              |> Option.value_exn ?here:None ?error:None ?message:None
-          }
-        in
-        let source_idx = find_index_exn t source in
-        let source_account =
-          let account =
-            if Account_id.equal source receiver then receiver_account
-            else get_exn t source_idx
-          in
-          (* Check that source account exists. *)
-          assert (not Public_key.Compressed.(equal empty account.public_key)) ;
-          (* Check that source account owns the token. *)
-          let () =
-            match account.token_permissions with
-            | Token_owned _ ->
-                ()
-            | Not_owned _ ->
-                failwithf
-                  !"The claimed token owner %{sexp: Account_id.t} does not own \
-                    the token %{sexp: Token_id.t}"
-                  source token ()
-          in
-          { account with
-            timing =
-              Or_error.ok_exn
-              @@ Transaction_logic.validate_timing ~txn_amount:Amount.zero
-                   ~txn_global_slot:current_global_slot ~account
-          }
-        in
-        [ (receiver_idx, receiver_account); (source_idx, source_account) ]
-  in
-  try
-    let indexed_accounts = compute_updates () in
-    (* User command succeeded, update accounts in the ledger. *)
-    List.fold ~init:t indexed_accounts ~f:(fun t (idx, account) ->
-        set_exn t idx account)
-  with
-  | Reject exn ->
-      (* TODO: These transactions should never reach this stage, this error
-         should be fatal.
-      *)
-      raise exn
-  | _ ->
-      (* Not able to apply the user command successfully, charge fee only. *)
-      t
-
-let apply_snapp_command_exn
-    ~(constraint_constants : Genesis_constants.Constraint_constants.t)
-    ~txn_state_view t (c : Snapp_command.t) =
-  let t = ref t in
-  T.apply_transaction ~constraint_constants ~txn_state_view t
-    (Command (Snapp_command c))
-  |> Or_error.ok_exn |> ignore ;
-  !t
-
-let update_timing_when_no_deduction ~txn_global_slot account =
-  Transaction_logic.validate_timing ~txn_amount:Currency.Amount.zero
-    ~txn_global_slot ~account
-  |> Or_error.ok_exn
-
-let apply_fee_transfer_exn ~constraint_constants ~txn_global_slot =
-  let apply_single ~update_timing t (ft : Fee_transfer.Single.t) =
-    let account_id = Fee_transfer.Single.receiver ft in
-    let index = find_index_exn t account_id in
-    let action, account = get_or_initialize_exn account_id t index in
-    let open Currency in
-    let amount = Amount.of_fee ft.fee in
-    let timing =
-      if update_timing then
-        update_timing_when_no_deduction ~txn_global_slot account
-      else account.timing
-    in
-    let balance =
-      let amount' =
-        sub_account_creation_fee ~constraint_constants action amount
-      in
-      Option.value_exn (Balance.add_amount account.balance amount')
-    in
-    set_exn t index { account with balance; timing }
-  in
-  fun t transfer ->
-    match Fee_transfer.to_singles transfer with
-    | `One s ->
-        apply_single ~update_timing:true t s
-    | `Two (s1, s2) ->
-        (*Note: Not updating the timing for s1 to avoid additional check in transactions snark (check_timing for "receiver"). This is OK because timing rules will not be violated when balance increases and will be checked whenever an amount is deducted from the account.(#5973)*)
-        let t' = apply_single ~update_timing:false t s1 in
-        apply_single ~update_timing:true t' s2
-
-let apply_coinbase_exn ~constraint_constants ~txn_global_slot t
-    ({ receiver; fee_transfer; amount = coinbase_amount } : Coinbase.t) =
-  let open Currency in
-  let add_to_balance ~update_timing t pk amount =
-    let idx = find_index_exn t pk in
-    let action, a = get_or_initialize_exn pk t idx in
-    let timing =
-      if update_timing then update_timing_when_no_deduction ~txn_global_slot a
-      else a.timing
-    in
-    let balance =
-      let amount' =
-        sub_account_creation_fee ~constraint_constants action amount
-      in
-      Option.value_exn (Balance.add_amount a.balance amount')
-    in
-    set_exn t idx { a with balance; timing }
-  in
-  (* Note: Updating coinbase receiver timing only if there is no fee transfer. This is so as to not add any extra constraints in transaction snark for checking "receiver" timings. This is OK because timing rules will not be violated when balance increases and will be checked whenever an amount is deducted from the account(#5973)*)
-  let receiver_reward, t, update_coinbase_receiver_timing =
-    match fee_transfer with
-    | None ->
-        (coinbase_amount, t, true)
-    | Some ({ receiver_pk = _; fee } as ft) ->
-        let fee = Amount.of_fee fee in
-        let reward =
-          Amount.sub coinbase_amount fee
-          |> Option.value_exn ?here:None ?message:None ?error:None
-        in
-        let transferee_id = Coinbase.Fee_transfer.receiver ft in
-        (reward, add_to_balance ~update_timing:true t transferee_id fee, false)
-  in
-  let receiver_id = Account_id.create receiver Token_id.default in
-  add_to_balance ~update_timing:update_coinbase_receiver_timing t receiver_id
-    receiver_reward
-
-let apply_transaction_exn ~constraint_constants
-    ~(txn_state_view : Snapp_predicate.Protocol_state.View.t) t
-    (transition : Transaction.t) =
-  let txn_global_slot = txn_state_view.global_slot_since_genesis in
-  match transition with
-  | Fee_transfer tr ->
-      apply_fee_transfer_exn ~constraint_constants ~txn_global_slot t tr
-  | Command (Signed_command cmd) ->
-      apply_user_command_exn ~constraint_constants ~txn_global_slot t
-        (cmd :> Signed_command.t)
-  | Command (Snapp_command cmd) ->
-      apply_snapp_command_exn ~constraint_constants ~txn_state_view t cmd
-  | Coinbase c ->
-      apply_coinbase_exn ~constraint_constants ~txn_global_slot t c
-
 let has_locked_tokens_exn ~global_slot ~account_id t =
   let idx = find_index_exn t account_id in
   let _, account = get_or_initialize_exn account_id t idx in
   Account.has_locked_tokens ~global_slot account
+
+let apply_transaction_logic f t x =
+  let open Or_error.Let_syntax in
+  let t' = ref t in
+  let%map app = f t' x in
+  (!t', app)
+
+let apply_user_command ~constraint_constants ~txn_global_slot =
+  apply_transaction_logic
+    (T.apply_user_command ~constraint_constants ~txn_global_slot)
+
+let apply_transaction' = T.apply_transaction
+
+let apply_transaction ~constraint_constants ~txn_state_view =
+  apply_transaction_logic
+    (T.apply_transaction ~constraint_constants ~txn_state_view)
 
 let merkle_root t = Ledger_hash.of_hash (merkle_root t :> Random_oracle.Digest.t)
 

--- a/src/lib/mina_base/sparse_ledger.mli
+++ b/src/lib/mina_base/sparse_ledger.mli
@@ -65,7 +65,10 @@ val of_ledger_subset_exn : Ledger.t -> Account_id.t list -> t
 
 val of_ledger_index_subset_exn : Ledger.Any_ledger.witness -> int list -> t
 
-(* val of_sparse_ledger_subset_exn : t -> Account_id.t list -> t *)
+val of_sparse_ledger_subset_exn : t -> Account_id.t list -> t
+
+(* TODO: erase Account_id.t from here (doesn't make sense to have it) *)
+val data : t -> (int * Account.t) list
 
 val iteri : t -> f:(Account.Index.t -> Account.t -> unit) -> unit
 

--- a/src/lib/mina_base/sparse_ledger.mli
+++ b/src/lib/mina_base/sparse_ledger.mli
@@ -27,21 +27,37 @@ val path_exn :
 
 val find_index_exn : t -> Account_id.t -> int
 
-val of_root : depth:int -> next_available_token:Token_id.t -> Ledger_hash.t -> t
+val of_root :
+     depth:int
+  -> next_available_token:Token_id.t
+  -> next_available_index:int option
+  -> Ledger_hash.t
+  -> t
 
-val apply_user_command_exn :
+val has_locked_tokens_exn :
+  global_slot:Mina_numbers.Global_slot.t -> account_id:Account_id.t -> t -> bool
+
+val apply_user_command :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> txn_global_slot:Mina_numbers.Global_slot.t
   -> t
-  -> Signed_command.t
-  -> t
+  -> Signed_command.With_valid_signature.t
+  -> (t * Transaction_logic.Transaction_applied.Signed_command_applied.t)
+     Or_error.t
 
-val apply_transaction_exn :
+val apply_transaction' :
+     constraint_constants:Genesis_constants.Constraint_constants.t
+  -> txn_state_view:Snapp_predicate.Protocol_state.View.t
+  -> t ref
+  -> Transaction.t
+  -> Transaction_logic.Transaction_applied.t Or_error.t
+
+val apply_transaction :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> txn_state_view:Snapp_predicate.Protocol_state.View.t
   -> t
   -> Transaction.t
-  -> t
+  -> (t * Transaction_logic.Transaction_applied.t) Or_error.t
 
 val of_any_ledger : Ledger.Any_ledger.M.t -> t
 
@@ -49,12 +65,11 @@ val of_ledger_subset_exn : Ledger.t -> Account_id.t list -> t
 
 val of_ledger_index_subset_exn : Ledger.Any_ledger.witness -> int list -> t
 
+(* val of_sparse_ledger_subset_exn : t -> Account_id.t list -> t *)
+
 val iteri : t -> f:(Account.Index.t -> Account.t -> unit) -> unit
 
 val handler : t -> Handler.t Staged.t
 
 val snapp_accounts :
   t -> Transaction.t -> Snapp_account.t option * Snapp_account.t option
-
-val has_locked_tokens_exn :
-  global_slot:Mina_numbers.Global_slot.t -> account_id:Account_id.t -> t -> bool

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -176,6 +176,51 @@ module Transaction_applied = struct
       let to_latest = Fn.id
     end
   end]
+
+  let transaction_with_status : t -> Transaction.t With_status.t =
+   fun { varying; _ } ->
+    match varying with
+    | Command (Signed_command uc) ->
+        With_status.map uc.common.user_command ~f:(fun cmd ->
+            Transaction.Command (User_command.Signed_command cmd))
+    | Command (Snapp_command s) ->
+        With_status.map s.command ~f:(fun c ->
+            Transaction.Command (User_command.Snapp_command c))
+    | Fee_transfer f ->
+        { data = Fee_transfer f.fee_transfer
+        ; status =
+            Applied
+              ( Transaction_status.Auxiliary_data.empty
+              , Transaction_status.Fee_transfer_balance_data.to_balance_data
+                  f.balances )
+        }
+    | Coinbase c ->
+        { data = Coinbase c.coinbase
+        ; status =
+            Applied
+              ( Transaction_status.Auxiliary_data.empty
+              , Transaction_status.Coinbase_balance_data.to_balance_data
+                  c.balances )
+        }
+
+  let user_command_status : t -> Transaction_status.t =
+   fun { varying; _ } ->
+    match varying with
+    | Command
+        (Signed_command { common = { user_command = { status; _ }; _ }; _ }) ->
+        status
+    | Command (Snapp_command c) ->
+        c.command.status
+    | Fee_transfer f ->
+        Applied
+          ( Transaction_status.Auxiliary_data.empty
+          , Transaction_status.Fee_transfer_balance_data.to_balance_data
+              f.balances )
+    | Coinbase c ->
+        Applied
+          ( Transaction_status.Auxiliary_data.empty
+          , Transaction_status.Coinbase_balance_data.to_balance_data c.balances
+          )
 end
 
 module type S = sig

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -31,6 +31,7 @@ module T = struct
         { indexes : ('key * int) list
         ; depth : int
         ; tree : ('hash, 'account) Tree.Stable.V1.t
+        ; next_available_index : int option
         ; next_available_token : 'token_id
         }
       [@@deriving sexp, to_yojson]
@@ -42,6 +43,7 @@ module T = struct
     { indexes : ('key * int) list
     ; depth : int
     ; tree : ('hash, 'account) Tree.t
+    ; next_available_index : int option
     ; next_available_token : 'token_id
     }
   [@@deriving sexp, to_yojson]
@@ -59,18 +61,29 @@ module type S = sig
   type t = (hash, account_id, account, token_id) T.t
   [@@deriving sexp, to_yojson]
 
-  val of_hash : depth:int -> next_available_token:token_id -> hash -> t
+  val of_hash :
+       depth:int
+    -> next_available_token:token_id
+    -> next_available_index:int option
+    -> hash
+    -> t
 
   val get_exn : t -> int -> account
 
   val path_exn : t -> int -> [ `Left of hash | `Right of hash ] list
 
+  val arm_exn : t -> int -> ([ `Left | `Right ] * hash * hash) list
+
   val set_exn : t -> int -> account -> t
+
+  val find_index : t -> account_id -> int option
 
   val find_index_exn : t -> account_id -> int
 
   val add_path :
     t -> [ `Left of hash | `Right of hash ] list -> account_id -> account -> t
+
+  val data : t -> (int * account_id * account) list
 
   val iteri : t -> f:(int -> account -> unit) -> unit
 
@@ -78,13 +91,30 @@ module type S = sig
 
   val depth : t -> int
 
+  val next_available_index : t -> int option
+
   val next_available_token : t -> token_id
 end
 
 let tree { T.tree; _ } = tree
 
-let of_hash ~depth ~next_available_token h =
-  { T.indexes = []; depth; tree = Hash h; next_available_token }
+(* integer indices mean that we cannot support tree depths > bit size of native machine int (- 1 for ocaml repr) *)
+let max_index depth =
+  let rec set_bits n i =
+    let n' = n lor (1 lsl i) in
+    if i = 0 then n' else set_bits n' (i - 1)
+  in
+  set_bits 0 depth
+
+let of_hash ~depth ~next_available_index ~next_available_token h =
+  Option.iter next_available_index ~f:(fun idx ->
+      assert (idx <= max_index depth)) ;
+  { T.indexes = []
+  ; depth
+  ; tree = Hash h
+  ; next_available_index
+  ; next_available_token
+  }
 
 module Make (Hash : sig
   type t [@@deriving equal, sexp, to_yojson, compare]
@@ -117,8 +147,9 @@ end = struct
   type t = (Hash.t, Account_id.t, Account.t, Token_id.t) T.t
   [@@deriving sexp, to_yojson]
 
-  let of_hash ~depth ~next_available_token (hash : Hash.t) =
-    of_hash ~depth ~next_available_token hash
+  let of_hash ~depth ~next_available_token ~next_available_index (hash : Hash.t)
+      =
+    of_hash ~depth ~next_available_token ~next_available_index hash
 
   let hash : (Hash.t, Account.t) Tree.t -> Hash.t = function
     | Account a ->
@@ -133,6 +164,8 @@ end = struct
   let depth { T.depth; _ } = depth
 
   let merkle_root { T.tree; _ } = hash tree
+
+  let next_available_index { T.next_available_index; _ } = next_available_index
 
   let next_available_token { T.next_available_token; _ } = next_available_token
 
@@ -201,6 +234,9 @@ end = struct
     go 0 (t.depth - 1) t.tree ~f
 
   let ith_bit idx i = (idx lsr i) land 1 = 1
+
+  let find_index (t : t) aid =
+    List.Assoc.find t.indexes ~equal:Account_id.equal aid
 
   let find_index_exn (t : t) aid =
     List.Assoc.find_exn t.indexes ~equal:Account_id.equal aid
@@ -271,15 +307,34 @@ end = struct
       else
         match tree with
         | Tree.Account _ ->
-            failwithf "Sparse_ledger.path: Bad depth at index %i." idx ()
+            failwithf "Sparse_ledger.path_exn: Bad depth at index %i." idx ()
         | Hash _ ->
-            failwithf "Sparse_ledger.path: Dead end at index %i." idx ()
+            failwithf "Sparse_ledger.path_exn: Dead end at index %i." idx ()
         | Node (_, l, r) ->
-            let go_right = ith_bit idx i in
-            if go_right then go (`Right (hash l) :: acc) (i - 1) r
-            else go (`Left (hash r) :: acc) (i - 1) l
+            let next, sibling_hash =
+              if ith_bit idx i then (r, `Right (hash l)) else (l, `Left (hash r))
+            in
+            go (sibling_hash :: acc) (i - 1) next
     in
     go [] (depth - 1) tree
+
+  let arm_exn { T.tree; depth; _ } idx =
+    let rec go acc i tree =
+      if i < 0 then acc
+      else
+        match tree with
+        | Tree.Account _ ->
+            failwithf "Sparse_ledger.arm_exn: Bad depth at index %i." idx ()
+        | Hash _ ->
+            failwithf "Sparse_ledger.arm_exn: Dead end at index %i." idx ()
+        | Node (_, l, r) ->
+            let next, dir = if ith_bit idx i then (r, `Right) else (l, `Left) in
+            go ((dir, hash l, hash r) :: acc) (i - 1) next
+    in
+    go [] (depth - 1) tree
+
+  let data (t : t) =
+    List.map t.indexes ~f:(fun (id, idx) -> (idx, id, get_exn t idx))
 end
 
 type ('hash, 'key, 'account, 'token_id) t =
@@ -379,7 +434,12 @@ let%test_module "sparse-ledger-test" =
       in
       let%bind depth = Int.gen_incl 0 16 in
       let%map tree = gen depth >>| prune_hash_branches in
-      { T.tree; depth; indexes = indexes depth tree; next_available_token = () }
+      { T.tree
+      ; depth
+      ; indexes = indexes depth tree
+      ; next_available_token = ()
+      ; next_available_index = None
+      }
 
     let%test_unit "iteri consistent indices with t.indexes" =
       Quickcheck.test gen ~f:(fun t ->

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -83,7 +83,7 @@ module type S = sig
   val add_path :
     t -> [ `Left of hash | `Right of hash ] list -> account_id -> account -> t
 
-  val data : t -> (int * account_id * account) list
+  val data : t -> (int * account) list
 
   val iteri : t -> f:(int -> account -> unit) -> unit
 
@@ -334,7 +334,7 @@ end = struct
     go [] (depth - 1) tree
 
   let data (t : t) =
-    List.map t.indexes ~f:(fun (id, idx) -> (idx, id, get_exn t idx))
+    List.map t.indexes ~f:(fun (_, idx) -> (idx, get_exn t idx))
 end
 
 type ('hash, 'key, 'account, 'token_id) t =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -235,8 +235,8 @@ module T = struct
     in
     target
 
-  let verify_scan_state_after_apply ~next_available_token ledger
-      (scan_state : Scan_state.t) =
+  let verify_scan_state_after_apply ~constraint_constants ~next_available_token
+      ledger (scan_state : Scan_state.t) =
     let error_prefix =
       "Error verifying the parallel scan state after applying the diff."
     in
@@ -251,13 +251,17 @@ module T = struct
       |> Option.value_map ~default:(None, None) ~f:(fun proof ->
              (Some (get_target proof), Some (next_available_token_begin proof)))
     in
-    Statement_scanner.check_invariants scan_state ~verifier:() ~error_prefix
+    Statement_scanner.check_invariants scan_state ~constraint_constants
+      ~statement_check:`Partial ~verifier:() ~error_prefix
       ~ledger_hash_end:ledger ~ledger_hash_begin ~next_available_token_begin
       ~next_available_token_end:next_available_token
 
-  let statement_exn t =
+  let statement_exn ~constraint_constants ~statement_check t =
     let open Deferred.Let_syntax in
-    match%map Statement_scanner.scan_statement t.scan_state ~verifier:() with
+    match%map
+      Statement_scanner.scan_statement t.scan_state ~constraint_constants
+        ~statement_check ~verifier:()
+    with
     | Ok s ->
         `Non_empty s
     | Error `Empty ->
@@ -269,9 +273,9 @@ module T = struct
       ~constraint_constants ~pending_coinbase_collection =
     { ledger; scan_state; constraint_constants; pending_coinbase_collection }
 
-  let of_scan_state_and_ledger ~logger ~constraint_constants ~verifier
-      ~snarked_ledger_hash ~snarked_next_available_token ~ledger ~scan_state
-      ~pending_coinbase_collection =
+  let of_scan_state_and_ledger ~logger ~constraint_constants ~statement_check
+      ~verifier ~snarked_ledger_hash ~snarked_next_available_token ~ledger
+      ~scan_state ~pending_coinbase_collection =
     let open Deferred.Or_error.Let_syntax in
     let t =
       of_scan_state_and_ledger_unchecked ~ledger ~scan_state
@@ -279,6 +283,7 @@ module T = struct
     in
     let%bind () =
       Statement_scanner_with_proofs.check_invariants scan_state
+        ~constraint_constants ~statement_check
         ~verifier:{ Statement_scanner_proof_verifier.logger; verifier }
         ~error_prefix:"Staged_ledger.of_scan_state_and_ledger"
         ~ledger_hash_end:
@@ -297,7 +302,8 @@ module T = struct
       { ledger; scan_state; constraint_constants; pending_coinbase_collection }
     in
     let%bind () =
-      Statement_scanner.check_invariants scan_state ~verifier:()
+      Statement_scanner.check_invariants scan_state ~constraint_constants
+        ~statement_check:`Partial ~verifier:()
         ~error_prefix:"Staged_ledger.of_scan_state_and_ledger"
         ~ledger_hash_end:
           (Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger))
@@ -354,7 +360,8 @@ module T = struct
                   Got:%{sexp:Ledger_hash.t}"
                 expected_merkle_root staged_ledger_hash)
     in
-    of_scan_state_and_ledger ~logger ~constraint_constants ~verifier
+    of_scan_state_and_ledger ~logger ~constraint_constants
+      ~statement_check:`Full ~verifier
       ~snarked_ledger_hash:snarked_frozen_ledger_hash
       ~snarked_next_available_token ~ledger:snarked_ledger ~scan_state
       ~pending_coinbase_collection:pending_coinbases
@@ -954,7 +961,7 @@ module T = struct
           if skip_verification then Deferred.return (Ok ())
           else
             Deferred.(
-              verify_scan_state_after_apply
+              verify_scan_state_after_apply ~constraint_constants
                 ~next_available_token:
                   (Sparse_ledger.next_available_token !local_ledger)
                 (Frozen_ledger_hash.of_ledger_hash

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -180,9 +180,7 @@ val can_apply_supercharged_coinbase_exn :
   -> bool
 
 val statement_exn :
-     constraint_constants:Genesis_constants.Constraint_constants.t
-  -> t
-  -> [ `Non_empty of Transaction_snark.Statement.t | `Empty ] Deferred.t
+  t -> [ `Non_empty of Transaction_snark.Statement.t | `Empty ] Deferred.t
 
 val of_scan_state_pending_coinbases_and_snarked_ledger :
      logger:Logger.t

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -89,6 +89,7 @@ val create_exn :
 val of_scan_state_and_ledger :
      logger:Logger.t
   -> constraint_constants:Genesis_constants.Constraint_constants.t
+  -> statement_check:[ `Full | `Partial ]
   -> verifier:Verifier.t
   -> snarked_ledger_hash:Frozen_ledger_hash.t
   -> snarked_next_available_token:Token_id.t
@@ -180,7 +181,10 @@ val can_apply_supercharged_coinbase_exn :
   -> bool
 
 val statement_exn :
-  t -> [ `Non_empty of Transaction_snark.Statement.t | `Empty ] Deferred.t
+     constraint_constants:Genesis_constants.Constraint_constants.t
+  -> statement_check:[ `Full | `Partial ]
+  -> t
+  -> [ `Non_empty of Transaction_snark.Statement.t | `Empty ] Deferred.t
 
 val of_scan_state_pending_coinbases_and_snarked_ledger :
      logger:Logger.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4362,7 +4362,8 @@ let%test_module "transaction_snark" =
                 ( Ledger.apply_user_command ~constraint_constants ledger
                     ~txn_global_slot:current_global_slot t1
                   |> Or_error.ok_exn
-                  : Ledger.Transaction_applied.Signed_command_applied.t ) ;
+                  : Transaction_logic.Transaction_applied.Signed_command_applied
+                    .t ) ;
               [%test_eq: Frozen_ledger_hash.t]
                 (Ledger.merkle_root ledger)
                 (Sparse_ledger.merkle_root sparse_ledger) ;
@@ -4385,7 +4386,8 @@ let%test_module "transaction_snark" =
                 ( Ledger.apply_user_command ledger ~constraint_constants
                     ~txn_global_slot:current_global_slot t2
                   |> Or_error.ok_exn
-                  : Ledger.Transaction_applied.Signed_command_applied.t ) ;
+                  : Transaction_logic.Transaction_applied.Signed_command_applied
+                    .t ) ;
               [%test_eq: Frozen_ledger_hash.t]
                 (Ledger.merkle_root ledger)
                 (Sparse_ledger.merkle_root sparse_ledger) ;

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3797,12 +3797,12 @@ let%test_module "transaction_snark" =
             Sparse_ledger.of_ledger_subset_exn ledger
               [ producer_id; receiver_id; other_id ]
           in
-          let sparse_ledger_after =
-            Sparse_ledger.apply_transaction_exn ~constraint_constants
-              sparse_ledger
+          let sparse_ledger_after, _ =
+            Sparse_ledger.apply_transaction ~constraint_constants sparse_ledger
               ~txn_state_view:
                 (txn_in_block.block_data |> Mina_state.Protocol_state.Body.view)
               txn_in_block.transaction
+            |> Or_error.ok_exn
           in
           check_transaction txn_in_block
             (unstage (Sparse_ledger.handler sparse_ledger))
@@ -4322,10 +4322,10 @@ let%test_module "transaction_snark" =
                 Mina_state.Protocol_state.Body.consensus_state state_body1
                 |> Consensus.Data.Consensus_state.global_slot_since_genesis
               in
-              let sparse_ledger =
-                Sparse_ledger.apply_user_command_exn ~constraint_constants
-                  ~txn_global_slot:current_global_slot sparse_ledger
-                  (t1 :> Signed_command.t)
+              let sparse_ledger, _ =
+                Sparse_ledger.apply_user_command ~constraint_constants
+                  ~txn_global_slot:current_global_slot sparse_ledger t1
+                |> Or_error.ok_exn
               in
               let pending_coinbase_stack_state2, state_body2 =
                 let previous_stack = pending_coinbase_stack_state1.pc.target in
@@ -4376,10 +4376,10 @@ let%test_module "transaction_snark" =
                 Mina_state.Protocol_state.Body.consensus_state state_body2
                 |> Consensus.Data.Consensus_state.global_slot_since_genesis
               in
-              let sparse_ledger =
-                Sparse_ledger.apply_user_command_exn ~constraint_constants
-                  ~txn_global_slot:current_global_slot sparse_ledger
-                  (t2 :> Signed_command.t)
+              let sparse_ledger, _ =
+                Sparse_ledger.apply_user_command ~constraint_constants
+                  ~txn_global_slot:current_global_slot sparse_ledger t2
+                |> Or_error.ok_exn
               in
               ignore
                 ( Ledger.apply_user_command ledger ~constraint_constants

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -195,10 +195,9 @@ let create_expected_statement ~constraint_constants
   let { With_status.data = transaction; status = _ } =
     Ledger.Transaction_applied.transaction transaction_with_info
   in
-  let%bind after =
-    Or_error.try_with (fun () ->
-        Sparse_ledger.apply_transaction_exn ~constraint_constants
-          ~txn_state_view:state_view ledger_witness transaction)
+  let%bind after, _ =
+    Sparse_ledger.apply_transaction ~constraint_constants
+      ~txn_state_view:state_view ledger_witness transaction
   in
   let target =
     Frozen_ledger_hash.of_ledger_hash @@ Sparse_ledger.merkle_root after

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -176,69 +176,6 @@ end]
 
 (**********Helpers*************)
 
-let create_expected_statement ~constraint_constants
-    { Transaction_with_witness.transaction_with_info
-    ; state_hash
-    ; state_view
-    ; ledger_witness
-    ; init_stack
-    ; statement
-    } =
-  let open Or_error.Let_syntax in
-  let source =
-    Frozen_ledger_hash.of_ledger_hash
-    @@ Sparse_ledger.merkle_root ledger_witness
-  in
-  let next_available_token_before =
-    Sparse_ledger.next_available_token ledger_witness
-  in
-  let { With_status.data = transaction; status = _ } =
-    Transaction_logic.Transaction_applied.transaction_with_status
-      transaction_with_info
-  in
-  let%bind after, _ =
-    Sparse_ledger.apply_transaction ~constraint_constants
-      ~txn_state_view:state_view ledger_witness transaction
-  in
-  let target =
-    Frozen_ledger_hash.of_ledger_hash @@ Sparse_ledger.merkle_root after
-  in
-  let next_available_token_after = Sparse_ledger.next_available_token after in
-  let%bind pending_coinbase_before =
-    match init_stack with
-    | Base source ->
-        Ok source
-    | Merge ->
-        Or_error.errorf
-          !"Invalid init stack in Pending coinbase stack state . Expected Base \
-            found Merge"
-  in
-  let pending_coinbase_after =
-    let state_body_hash = snd state_hash in
-    let pending_coinbase_with_state =
-      Pending_coinbase.Stack.push_state state_body_hash pending_coinbase_before
-    in
-    match transaction with
-    | Coinbase c ->
-        Pending_coinbase.Stack.push_coinbase c pending_coinbase_with_state
-    | _ ->
-        pending_coinbase_with_state
-  in
-  let%bind fee_excess = Transaction.fee_excess transaction in
-  let%map supply_increase = Transaction.supply_increase transaction in
-  { Transaction_snark.Statement.source
-  ; target
-  ; fee_excess
-  ; next_available_token_before
-  ; next_available_token_after
-  ; supply_increase
-  ; pending_coinbase_stack_state =
-      { statement.pending_coinbase_stack_state with
-        target = pending_coinbase_after
-      }
-  ; sok_digest = ()
-  }
-
 let completed_work_to_scanable_work (job : job) (fee, current_proof, prover) :
     'a Or_error.t =
   let sok_digest = Ledger_proof.sok_digest current_proof
@@ -367,7 +304,7 @@ struct
   end
 
   (*TODO: fold over the pending_coinbase tree and validate the statements?*)
-  let scan_statement ~constraint_constants tree ~verifier :
+  let scan_statement tree ~verifier :
       ( Transaction_snark.Statement.t
       , [ `Error of Error.t | `Empty ] )
       Deferred.Result.t =
@@ -376,9 +313,6 @@ struct
     let yield_occasionally =
       let f = Staged.unstage (Async.Scheduler.yield_every ~n:50) in
       fun () -> f () |> Deferred.map ~f:Or_error.return
-    in
-    let yield_always () =
-      Async.Scheduler.yield () |> Deferred.map ~f:Or_error.return
     in
     let module Acc = struct
       type t = (Transaction_snark.Statement.t * P.t list) option
@@ -428,26 +362,8 @@ struct
       | Full { status = Parallel_scan.Job_status.Done; _ } ->
           return acc_statement
       | Full { job = transaction; _ } ->
-          with_error "Bad base statement" ~f:(fun () ->
-              let%bind expected_statement =
-                Timer.time timer
-                  (sprintf "create_expected_statement:%s" __LOC__) (fun () ->
-                    Deferred.return
-                      (create_expected_statement ~constraint_constants
-                         transaction))
-              in
-              let%bind () = yield_always () in
-              if
-                Transaction_snark.Statement.equal transaction.statement
-                  expected_statement
-              then merge_acc ~proofs:[] acc_statement transaction.statement
-              else
-                Deferred.Or_error.error_string
-                  (sprintf
-                     !"Bad base statement expected: \
-                       %{sexp:Transaction_snark.Statement.t} got: \
-                       %{sexp:Transaction_snark.Statement.t}"
-                     transaction.statement expected_statement))
+          let open Transaction_with_witness in
+          merge_acc ~proofs:[] acc_statement transaction.statement
     in
     let%bind.Deferred res =
       Fold.fold_chronological_until tree ~init:None
@@ -485,7 +401,7 @@ struct
     | Error e ->
         Deferred.return (Error (`Error e))
 
-  let check_invariants t ~constraint_constants ~verifier ~error_prefix
+  let check_invariants t ~verifier ~error_prefix
       ~ledger_hash_end:current_ledger_hash
       ~ledger_hash_begin:snarked_ledger_hash
       ~next_available_token_begin:snarked_ledger_next_available_token
@@ -493,10 +409,7 @@ struct
     let clarify_error cond err =
       if not cond then Or_error.errorf "%s : %s" error_prefix err else Ok ()
     in
-    match%map
-      time "scan_statement" (fun () ->
-          scan_statement ~constraint_constants ~verifier t)
-    with
+    match%map time "scan_statement" (fun () -> scan_statement ~verifier t) with
     | Error (`Error e) ->
         Error e
     | Error `Empty ->

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -50,6 +50,8 @@ module Make_statement_scanner (Verifier : sig
 end) : sig
   val scan_statement :
        t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
+    -> statement_check:[ `Full | `Partial ]
     -> verifier:Verifier.t
     -> ( Transaction_snark.Statement.t
        , [ `Empty | `Error of Error.t ] )
@@ -57,6 +59,8 @@ end) : sig
 
   val check_invariants :
        t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
+    -> statement_check:[ `Full | `Partial ]
     -> verifier:Verifier.t
     -> error_prefix:string
     -> ledger_hash_end:Frozen_ledger_hash.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -49,8 +49,7 @@ module Make_statement_scanner (Verifier : sig
     -> bool Deferred.Or_error.t
 end) : sig
   val scan_statement :
-       constraint_constants:Genesis_constants.Constraint_constants.t
-    -> t
+       t
     -> verifier:Verifier.t
     -> ( Transaction_snark.Statement.t
        , [ `Empty | `Error of Error.t ] )
@@ -58,7 +57,6 @@ end) : sig
 
   val check_invariants :
        t
-    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> verifier:Verifier.t
     -> error_prefix:string
     -> ledger_hash_end:Frozen_ledger_hash.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -14,7 +14,7 @@ end]
 module Transaction_with_witness : sig
   (* TODO: The statement is redundant here - it can be computed from the witness and the transaction *)
   type t =
-    { transaction_with_info : Ledger.Transaction_applied.t
+    { transaction_with_info : Transaction_logic.Transaction_applied.t
     ; state_hash : State_hash.t * State_body_hash.t
     ; state_view : Mina_base.Snapp_predicate.Protocol_state.View.Stable.V1.t
     ; statement : Transaction_snark.Statement.t

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -444,7 +444,7 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
                    ~constraint_constants:
                      t.precomputed_values.constraint_constants ~txn_state_view
                    mt txn.data)
-              : Ledger.Transaction_applied.t ) ) ;
+              : Transaction_logic.Transaction_applied.t ) ) ;
       (* STEP 6 *)
       Ledger.commit mt ;
       (* STEP 7 *)

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -63,7 +63,7 @@ let construct_staged_ledger_at_root
                txn.data
            in
            let computed_status =
-             Ledger.Transaction_applied.user_command_status txn_with_info
+             Transaction_logic.Transaction_applied.user_command_status txn_with_info
            in
            if Transaction_status.equal txn.status computed_status then
              Or_error.return ()


### PR DESCRIPTION
Changes:
* Removed custom sparse ledger implementation of transaction application algorithms in favor of unifying under `Transaction_logic` functor.
* Added support for deriving sparse ledger subsets from existing sparse ledgers.
	* This involved giving sparse ledger some notion of the "next index" to allocate new accounts at, though this "next index" does not automatically increment as you interact with the sparse ledger.
* Added new batching operations to standard ledger interface; implemented operations in various ledger modules.
* Batched ledger mask interactions when extracting subsets of ledgers into sparse ledgers.
* Update sparse ledger application logic to pre-load all accounts modified by txns in the staged ledger diff into a sparse ledger upfront (this allows us to batch the ledger mask operations, and then operate on a fully in-memory, non-chained ledger datastructure when applying txns).
* Remove logic that re-applies the txns after building the new staged ledger (@deepthiskumar and I decided this is no longer a necessary step).

Testing:
* Added unit test for the new sparse ledger subset extraction from existing sparse ledgers.
* Trusted existing staged ledger unit tests and integration tests for ensuring the rest of tje changes are correct.

Closes #9648.
Closes #9649.