### PR TITLE
Removed completed non-determinable genesis epoch seed todo comment

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -943,9 +943,7 @@ module Data = struct
           ]
 
       let genesis ~(genesis_epoch_data : Genesis_epoch_data.Data.t) =
-        { Poly.ledger =
-            Epoch_ledger.genesis ~ledger:genesis_epoch_data.ledger
-            (* TODO: epoch_seed needs to be non-determinable by o1-labs before mainnet launch *)
+        { Poly.ledger = Epoch_ledger.genesis ~ledger:genesis_epoch_data.ledger
         ; seed = genesis_epoch_data.seed
         ; start_checkpoint = Mina_base.State_hash.(of_hash zero)
         ; lock_checkpoint = Lock_checkpoint.null


### PR DESCRIPTION
    * Security checked code that indeed genesis epoch seed is derived
      with nothing-up-my-sleeve numbers
    * Cross-checked with team members

* Closes #9768
