### PR TITLE
fix next producing time in daemon status (1.2.1)

### DIFF
--- a/src/lib/cli_lib/default.ml
+++ b/src/lib/cli_lib/default.ml
@@ -7,4 +7,6 @@ let validation_queue_size = 150
 
 let conf_dir_name = ".mina-config"
 
-let stop_time = 24
+let stop_time = 168
+
+(* 24*7 hours*)

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -173,6 +173,7 @@ module Status = struct
       | Check_again of Block_time.Stable.Latest.t
       | Produce of producing_time
       | Produce_now of producing_time
+      | Evaluating_vrf of Mina_numbers.Global_slot.Stable.Latest.t
     [@@deriving to_yojson, bin_io_unversioned]
 
     type t = {generated_from_consensus_at: slot; timing: timing}
@@ -288,6 +289,10 @@ module Status = struct
           match producer_timing.timing with
           | Check_again time ->
               sprintf "None this epoch… checking at %s (%s)" (str time)
+                generated_from
+          | Evaluating_vrf last_checked_slot ->
+              sprintf "Evaluating VRF… Last checked global slot %s (%s)"
+                (Mina_numbers.Global_slot.to_string last_checked_slot)
                 generated_from
           | Produce {time; for_slot} ->
               sprintf "%s for %s (%s)" (str time) (slot_str for_slot)

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -244,6 +244,8 @@ module Types = struct
               match timing with
               | Daemon_rpcs.Types.Status.Next_producer_timing.Check_again _ ->
                   []
+              | Evaluating_vrf _last_checked_slot ->
+                  []
               | Produce info ->
                   [of_time info.time ~consensus_constants]
               | Produce_now info ->
@@ -256,6 +258,8 @@ module Types = struct
               (fun _ {Daemon_rpcs.Types.Status.Next_producer_timing.timing; _} ->
               match timing with
               | Daemon_rpcs.Types.Status.Next_producer_timing.Check_again _ ->
+                  []
+              | Evaluating_vrf _last_checked_slot ->
                   []
               | Produce info ->
                   [info.for_slot.global_slot_since_genesis]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1050,23 +1050,27 @@ let check_and_stop_daemon t ~wait =
     match t.next_producer_timing with
     | None ->
         `Now
-    | Some timing ->
-        let tm =
-          match timing.timing with
-          | Daemon_rpcs.Types.Status.Next_producer_timing.Check_again tm ->
-              Block_time.to_time tm
-          | Produce tm | Produce_now tm ->
-              Block_time.to_time tm.time
-        in
-        (*Assuming it takes at most 1hr to bootstrap and catchup*)
-        let next_block =
-          Time.add tm
-            (Block_time.Span.to_time_span
-               t.config.precomputed_values.consensus_constants.slot_duration_ms)
-        in
-        let wait_for = Time.(diff next_block (now ())) in
-        if Time.Span.(wait_for > max_catchup_time) then `Now
-        else `Check_in wait_for
+    | Some timing -> (
+      match timing.timing with
+      | Daemon_rpcs.Types.Status.Next_producer_timing.Check_again tm
+      | Produce {time= tm; _}
+      | Produce_now {time= tm; _} ->
+          let tm = Block_time.to_time tm in
+          (*Assuming it takes at most 1hr to bootstrap and catchup*)
+          let next_block =
+            Time.add tm
+              (Block_time.Span.to_time_span
+                 t.config.precomputed_values.consensus_constants
+                   .slot_duration_ms)
+          in
+          let wait_for = Time.(diff next_block (now ())) in
+          if Time.Span.(wait_for > max_catchup_time) then `Now
+          else `Check_in wait_for
+      | Evaluating_vrf _last_checked_slot ->
+          `Check_in
+            (Core.Time.Span.of_ms
+               (Mina_compile_config.vrf_poll_interval_ms * 2 |> Int.to_float))
+      )
 
 let stop_long_running_daemon t =
   let wait_mins = (t.config.stop_time * 60) + (Random.int 10 * 60) in
@@ -1120,6 +1124,9 @@ let start t =
             ( `Free
             , Daemon_rpcs.Types.Status.Next_producer_timing.Check_again
                 block_time )
+        | `Evaluating_vrf last_checked_slot ->
+            (* Vrf evaluation is still going on, so treating it as if a block is being produced*)
+            (`Producing, Evaluating_vrf last_checked_slot)
         | `Produce_now (block_data, _) ->
             let info :
                 Daemon_rpcs.Types.Status.Next_producer_timing.producing_time =

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -395,6 +395,11 @@ let start ~logger ~uptime_url ~snark_worker_opt ~transition_frontier
                   [%log trace]
                     "Next producer timing not available for uptime service" ;
                   None
+              | Evaluating_vrf _ ->
+                  [%log trace]
+                    "Evaluating VRF, wait for block production status for \
+                     uptime service" ;
+                  None
               | Produce prod_tm | Produce_now prod_tm ->
                   Some (Block_time.to_time prod_tm.time) )
         in

--- a/src/lib/vrf_evaluator/vrf_evaluator.ml
+++ b/src/lib/vrf_evaluator/vrf_evaluator.ml
@@ -209,7 +209,9 @@ module Worker_state = struct
           let global_slot = Consensus_time.to_global_slot consensus_time in
           t.current_slot <- Some global_slot ;
           let epoch' = Consensus_time.epoch consensus_time in
-          if Epoch.(epoch' > epoch) then Interruptible.return ()
+          if Epoch.(epoch' > epoch) then (
+            t.current_slot <- None ;
+            Interruptible.return () )
           else
             let start = Time.now () in
             match%bind evaluate_vrf ~consensus_time with


### PR DESCRIPTION

Explain your changes:
* update next producing time in the daemon status when there are no more slots won. 
* Added a new status `Evaluating VRF` when there are no slots won and vrf evaluations are still in progress 
For example-
`Evaluating VRF… Last checked global slot 576 (Generated from consensus at slot: 544 slot-since-genesis: 544)`
* Updated daemon stop time to 7 days

Explain how you tested your changes:
* ran a BP node locally and checked `mina client status`

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
