### PR TITLE
Update chain status in archive db when blocks added

### DIFF
--- a/src/app/archive/archive_lib/chain_status.ml
+++ b/src/app/archive/archive_lib/chain_status.ml
@@ -1,0 +1,16 @@
+(* chain_status.ml *)
+
+open Core_kernel
+
+type t = Canonical | Orphaned
+[@@deriving yojson, equal, bin_io_unversioned]
+
+let to_string = function
+  | Canonical -> "canonical"
+  | Orphaned -> "orphaned"
+
+let of_string = function
+  | "canonical" -> Canonical
+  | "orphaned" -> Orphaned
+  | s ->
+    failwithf "Chain_status.of_string: invalid string = %s" s ()

--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -84,6 +84,8 @@ module Block = struct
     ; global_slot_since_genesis: Mina_numbers.Global_slot.Stable.Latest.t
     ; timestamp: Block_time.Stable.Latest.t
     ; user_cmds: User_command.t list
-    ; internal_cmds: Internal_command.t list }
+    ; internal_cmds: Internal_command.t list
+    ; chain_status: Chain_status.t option
+    }
   [@@deriving yojson, equal, bin_io_unversioned]
 end

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1022,7 +1022,9 @@ module Block = struct
     ; height: int64
     ; global_slot_since_hard_fork: int64
     ; global_slot_since_genesis: int64
-    ; timestamp: int64 }
+    ; timestamp: int64
+    ; chain_status: string option
+    }
   [@@deriving hlist]
 
   let typ =
@@ -1041,7 +1043,9 @@ module Block = struct
         ; int64
         ; int64
         ; int64
-        ; int64 ]
+        ; int64
+        ; option string
+        ]
     in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
@@ -1065,7 +1069,7 @@ module Block = struct
          {sql| SELECT state_hash, parent_id, parent_hash, creator_id,
                       block_winner_id, snarked_ledger_hash_id, staking_epoch_data_id,
                       next_epoch_data_id, ledger_hash, height, global_slot,
-                      global_slot_since_genesis, timestamp FROM blocks
+                      global_slot_since_genesis, timestamp, chain_status FROM blocks
                WHERE id = ?
          |sql})
       id
@@ -1116,8 +1120,8 @@ module Block = struct
                       creator_id, block_winner_id,
                       snarked_ledger_hash_id, staking_epoch_data_id,
                       next_epoch_data_id, ledger_hash, height, global_slot,
-                      global_slot_since_genesis, timestamp)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
+                      global_slot_since_genesis, timestamp, chain_status)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
                |sql})
             { state_hash= hash |> State_hash.to_base58_check
             ; parent_id
@@ -1146,7 +1150,10 @@ module Block = struct
                 |> Unsigned.UInt32.to_int64
             ; timestamp=
                 Protocol_state.blockchain_state protocol_state
-                |> Blockchain_state.timestamp |> Block_time.to_int64 }
+                |> Blockchain_state.timestamp |> Block_time.to_int64
+            (* we don't yet know the chain status for a block we're adding *)
+            ; chain_status=None
+            }
         in
         let transactions =
           let coinbase_receiver =
@@ -1427,8 +1434,8 @@ module Block = struct
                       creator_id, block_winner_id,
                       snarked_ledger_hash_id, staking_epoch_data_id,
                       next_epoch_data_id, ledger_hash, height, global_slot,
-                      global_slot_since_genesis, timestamp)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
+                      global_slot_since_genesis, timestamp, chain_status)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
                |sql})
             { state_hash= block.state_hash |> State_hash.to_base58_check
             ; parent_id
@@ -1443,7 +1450,9 @@ module Block = struct
             ; global_slot_since_hard_fork= block.global_slot_since_hard_fork |> Unsigned.UInt32.to_int64
             ; global_slot_since_genesis=
                 block.global_slot_since_genesis |> Unsigned.UInt32.to_int64
-            ; timestamp= block.timestamp |> Block_time.to_int64 }
+            ; timestamp= block.timestamp |> Block_time.to_int64
+            ; chain_status= Option.map block.chain_status ~f:Chain_status.to_string
+            }
     in
     (* add user commands *)
     let%bind user_cmds_with_ids =
@@ -1546,6 +1555,74 @@ module Block = struct
                AND parent_id IS NULL
          |sql})
       (parent_id, State_hash.to_base58_check parent_hash)
+
+  let get_subchain (module Conn : CONNECTION) ~start_block_id ~end_block_id =
+    Conn.collect_list
+      (Caqti_request.collect Caqti_type.(tup2 int int) typ
+      {sql| WITH RECURSIVE chain AS (
+              SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
+                     next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp, chain_status
+              FROM blocks b WHERE b.id = $1
+
+              UNION ALL
+
+              SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,b.snarked_ledger_hash_id,b.staking_epoch_data_id,
+                     b.next_epoch_data_id,b.ledger_hash,b.height,b.global_slot,b.global_slot_since_genesis,b.timestamp,b.chain_status
+              FROM blocks b
+
+              INNER JOIN chain
+
+              ON b.id = chain.parent_id AND (chain.id <> $2 OR b.id = $2)
+
+           )
+
+           SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
+                  next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp,chain_status
+           FROM chain ORDER BY height ASC
+      |sql})
+      (end_block_id,start_block_id)
+
+  let get_highest_canonical_block (module Conn : CONNECTION) =
+    Conn.find
+      (Caqti_request.find Caqti_type.unit Caqti_type.(tup2 int int64)
+         "SELECT id,height FROM blocks WHERE chain_status='canonical' ORDER BY height DESC LIMIT 1")
+
+  let mark_as_canonical (module Conn : CONNECTION) ~state_hash =
+    Conn.exec
+      (Caqti_request.exec Caqti_type.string
+         "UPDATE blocks SET chain_status='canonical' WHERE state_hash = ?")
+      state_hash
+
+  let mark_as_orphaned (module Conn : CONNECTION) ~state_hash ~height =
+    Conn.exec
+      (Caqti_request.exec Caqti_type.(tup2 string int64)
+         {sql| UPDATE blocks SET chain_status='orphaned'
+               WHERE height = $2
+               AND state_hash <> $1
+         |sql})
+      (state_hash,height)
+
+  (* update chain_status for blocks now known to be canonical or orphaned *)
+   let update_chain_status (module Conn : CONNECTION) ~block_id =
+     let open Deferred.Result.Let_syntax in
+     let k_int64 = Genesis_constants.k |> Int64.of_int in
+     let%bind block = load (module Conn) ~id:block_id in
+     let%bind highest_canonical_block_id,greatest_canonical_height =
+       get_highest_canonical_block (module Conn) () in
+     if Int64.(>) block.height (Int64.(+) greatest_canonical_height k_int64) then
+         (* subchain between new block and highest canonical block *)
+         let%bind subchain_blocks = get_subchain (module Conn) ~start_block_id:highest_canonical_block_id ~end_block_id:block_id in
+         let block_height_less_k_int64 = Int64.(-) block.height k_int64 in
+         (* mark canonical, orphaned blocks in subchain at least k behind the new block *)
+         let canonical_blocks = List.filter subchain_blocks ~f:(fun subchain_block ->
+             Int64.(<=) subchain_block.height block_height_less_k_int64) in
+         let%map () = deferred_result_list_fold canonical_blocks ~init:() ~f:(fun () block ->
+             let%bind () = mark_as_canonical (module Conn) ~state_hash:block.state_hash in
+             mark_as_orphaned (module Conn) ~state_hash:block.state_hash ~height:block.height)
+         in
+         ()
+       else
+         Deferred.Result.return ()
 
   let delete_if_older_than ?height ?num_blocks ?timestamp
       (module Conn : CONNECTION) =
@@ -1653,12 +1730,17 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
           let%bind () = Conn.start () in
           let%bind block_id = add_block (module Conn : CONNECTION) block in
           (* if an existing block has a parent hash that's for the block just added,
-       set its parent id
-      *)
+             set its parent id
+          *)
           let%bind () =
             Block.set_parent_id_if_null
               (module Conn)
               ~parent_hash:(hash block) ~parent_id:block_id
+          in
+          (* update chain status for existing blocks *)
+          let%bind () =
+            Block.update_chain_status (module Conn)
+              ~block_id
           in
           match delete_older_than with
           | Some num_blocks ->

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -64,21 +64,25 @@ CREATE TABLE epoch_data
 , ledger_hash_id int    NOT NULL REFERENCES snarked_ledger_hashes(id)
 );
 
+CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned')
+
+/* we cannot be certain whether recent blocks are canonical, hence the column is nullable */
 CREATE TABLE blocks
-( id                      serial PRIMARY KEY
-, state_hash              text   NOT NULL UNIQUE
-, parent_id               int                    REFERENCES blocks(id)
-, parent_hash             text   NOT NULL
-, creator_id              int    NOT NULL        REFERENCES public_keys(id)
-, block_winner_id         int    NOT NULL        REFERENCES public_keys(id)
-, snarked_ledger_hash_id  int    NOT NULL        REFERENCES snarked_ledger_hashes(id)
-, staking_epoch_data_id   int    NOT NULL        REFERENCES epoch_data(id)
-, next_epoch_data_id      int    NOT NULL        REFERENCES epoch_data(id)
-, ledger_hash             text   NOT NULL
-, height                  bigint NOT NULL
-, global_slot             bigint NOT NULL
-, global_slot_since_genesis bigint NOT NULL
-, timestamp               bigint NOT NULL
+( id                         serial PRIMARY KEY
+, state_hash                 text   NOT NULL UNIQUE
+, parent_id                  int                    REFERENCES blocks(id)
+, parent_hash                text   NOT NULL
+, creator_id                 int    NOT NULL        REFERENCES public_keys(id)
+, block_winner_id            int    NOT NULL        REFERENCES public_keys(id)
+, snarked_ledger_hash_id     int    NOT NULL        REFERENCES snarked_ledger_hashes(id)
+, staking_epoch_data_id      int    NOT NULL        REFERENCES epoch_data(id)
+, next_epoch_data_id         int    NOT NULL        REFERENCES epoch_data(id)
+, ledger_hash                text   NOT NULL
+, height                     bigint NOT NULL
+, global_slot                bigint NOT NULL
+, global_slot_since_genesis  bigint NOT NULL
+, timestamp                  bigint NOT NULL
+, chain_status               chain_status_type
 );
 
 CREATE INDEX idx_blocks_id ON blocks(id);
@@ -86,6 +90,7 @@ CREATE INDEX idx_blocks_parent_id ON blocks(parent_id);
 CREATE INDEX idx_blocks_state_hash ON blocks(state_hash);
 CREATE INDEX idx_blocks_creator_id ON blocks(creator_id);
 CREATE INDEX idx_blocks_height     ON blocks(height);
+CREATE INDEX idx_chain_status      ON blocks(chain_status);
 
 CREATE TABLE balances
 ( id            serial PRIMARY KEY

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -83,6 +83,7 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
     Unsigned.UInt32.of_int64 block.global_slot_since_genesis
   in
   let timestamp = Block_time.of_int64 block.timestamp in
+  let chain_status = Option.map block.chain_status ~f:Chain_status.of_string in
   (* commands to be filled in later *)
   return
     { Extensional.Block.state_hash
@@ -101,6 +102,7 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
     ; timestamp
     ; user_cmds = []
     ; internal_cmds = []
+    ; chain_status
     }
 
 let fill_in_user_commands pool block_state_hash =

--- a/src/app/extract_blocks/sql.ml
+++ b/src/app/extract_blocks/sql.ml
@@ -1,4 +1,4 @@
-(* sql.ml -- (Postgresql) SQL queries for missing subchain app *)
+(* sql.ml -- (Postgresql) SQL queries for extract blocks app *)
 
 module Subchain = struct
   let make_sql ~join_condition =
@@ -6,13 +6,13 @@ module Subchain = struct
       {sql| WITH RECURSIVE chain AS (
 
               SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
-                     next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp
+                     next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp, chain_status
               FROM blocks b WHERE b.state_hash = $1
 
               UNION ALL
 
               SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,b.snarked_ledger_hash_id,b.staking_epoch_data_id,
-                     b.next_epoch_data_id,b.ledger_hash,b.height,b.global_slot,b.global_slot_since_genesis,b.timestamp
+                     b.next_epoch_data_id,b.ledger_hash,b.height,b.global_slot,b.global_slot_since_genesis,b.timestamp,b.chain_status
               FROM blocks b
 
               INNER JOIN chain
@@ -21,7 +21,7 @@ module Subchain = struct
            )
 
            SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
-                  next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp
+                  next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp,chain_status
            FROM chain
       |sql}
       join_condition
@@ -50,7 +50,7 @@ module Subchain = struct
   let query_all =
     Caqti_request.collect Caqti_type.unit Archive_lib.Processor.Block.typ
       {sql| SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
-                   next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp
+                   next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp, chain_status
             FROM blocks
       |sql}
 


### PR DESCRIPTION
Add a new column to the `blocks` table, `chain_status`, that can be either `canonical` or `orphaned`, and is nullable.

When a new block is added to the table, find a subchain back to the highest block that is canonical. For all blocks along that subchain that are least `k` blocks lower than the new block, mark them as canonical. For blocks that meet the same height criterion, but are not in the subchain, mark them as orphaned. This is the same algorithm used in the script in #9795.

Tested by adding extensional blocks using the `archive_blocks` app, verifying that the new code is called.
