### PR TITLE
Rosetta: Fast canonical lookups chain_status

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -31,6 +31,9 @@ end
 
 module Sql = struct
   module Balance_from_last_relevant_command = struct
+    (* This is SQL is the common chunk shared between the query_recent and
+     * query_old that retreives the relevant balance changes from transactions
+     * at a block. *)
     let common_sql =
       {sql|
 relevant_internal_block_balances AS (


### PR DESCRIPTION
The rosetta side of the equation


Explain your changes:
* Only use the archive-node path for /account/balance
* Use chain-status for "old" queries of blocks rather than the slower recursive queries

Explain how you tested your changes:
* TODO: Blocked on #9796 and running #9795 on one of the databases
* After it's unblocked, we should sync a node and poke at the endpoint a bit and then try cli check:data
