### PR TITLE
lk86/fix-demo-script Fix demo script

### DIFF
--- a/dockerfiles/auxiliary_entrypoints/01-run-demo.sh
+++ b/dockerfiles/auxiliary_entrypoints/01-run-demo.sh
@@ -6,7 +6,7 @@ if [[ -n ${RUN_DEMO} ]]; then
     # Demo keys and config file
     echo "Running Mina demo..."
     MINA_CONFIG_DIR=${MINA_CONFIG_DIR:-/root/.mina-config}
-    MINA_CONFIG_FILE="${MINA_CONFIG_DIR}/daemon.json}"
+    MINA_CONFIG_FILE="${MINA_CONFIG_DIR}/daemon.json"
 
     export PK=${PK:-"B62qiZfzW27eavtPrnF6DeDSAKEjXuGFdkouC3T5STRa6rrYLiDUP2p"}
     SNARK_PK=${SNARK_PK:-"B62qjnkjj3zDxhEfxbn1qZhUawVeLsUr2GCzEz8m1MDztiBouNsiMUL"}


### PR DESCRIPTION
Fixes a typo preventing the RUN_DEMO=true logic from working properly. There are more issues with this script remaining in master and release/1.2.0 (to be fixed in a future PR) but this solves the more minor problems in compatible