### PR TITLE
Client SDK, signature kind arg to string signer, verifier

### DIFF
--- a/scripts/compare_test_signatures.sh
+++ b/scripts/compare_test_signatures.sh
@@ -4,7 +4,6 @@ set -e
 
 # compare test signatures generated:
 # - in native executable, using consensus code
-# - in native executable, using nonconsensus code
 # - in JS code, using nonconsensus code
 
 # build executables
@@ -24,7 +23,7 @@ node src/app/client_sdk/tests/test_signatures.js > js.nonconsensus.json
 # we've been careful so that the output formatting of all the signatures is the same
 # so we can use diff (rather parsing the JSON with Python or such)
 
-diff nat.consensus.json js.nonconsensus.json
+diff -q nat.consensus.json js.nonconsensus.json
 
 if [ $? -ne 0 ]; then
     echo "Consensus and JS code generate different signatures";

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1584,9 +1584,9 @@ module Block = struct
       |sql})
       (end_block_id,start_block_id)
 
-  let get_highest_canonical_block (module Conn : CONNECTION) =
-    Conn.find
-      (Caqti_request.find Caqti_type.unit Caqti_type.(tup2 int int64)
+  let get_highest_canonical_blocks (module Conn : CONNECTION) =
+    Conn.collect_list
+      (Caqti_request.collect Caqti_type.unit Caqti_type.(tup2 int int64)
          "SELECT id,height FROM blocks WHERE chain_status='canonical' ORDER BY height DESC LIMIT 1")
 
   let mark_as_canonical (module Conn : CONNECTION) ~state_hash =
@@ -1607,24 +1607,29 @@ module Block = struct
   (* update chain_status for blocks now known to be canonical or orphaned *)
    let update_chain_status (module Conn : CONNECTION) ~block_id =
      let open Deferred.Result.Let_syntax in
-     let k_int64 = Genesis_constants.k |> Int64.of_int in
-     let%bind block = load (module Conn) ~id:block_id in
-     let%bind highest_canonical_block_id,greatest_canonical_height =
-       get_highest_canonical_block (module Conn) () in
-     if Int64.(>) block.height (Int64.(+) greatest_canonical_height k_int64) then
+     match%bind get_highest_canonical_blocks (module Conn) () with
+     | [] ->
+       (* no canonical blocks in this database, don't update statuses
+          this can happen on a new database, such as a test database
+       *)
+       Deferred.Result.return ()
+     | [highest_canonical_block_id,greatest_canonical_height] ->
+       let%bind block = load (module Conn) ~id:block_id in
+       let k_int64 = Genesis_constants.k |> Int64.of_int in
+       let block_height_less_k_int64 = Int64.(-) block.height k_int64 in
+       if Int64.(>) block.height (Int64.(+) greatest_canonical_height k_int64) then
          (* subchain between new block and highest canonical block *)
          let%bind subchain_blocks = get_subchain (module Conn) ~start_block_id:highest_canonical_block_id ~end_block_id:block_id in
-         let block_height_less_k_int64 = Int64.(-) block.height k_int64 in
          (* mark canonical, orphaned blocks in subchain at least k behind the new block *)
          let canonical_blocks = List.filter subchain_blocks ~f:(fun subchain_block ->
              Int64.(<=) subchain_block.height block_height_less_k_int64) in
-         let%map () = deferred_result_list_fold canonical_blocks ~init:() ~f:(fun () block ->
+         deferred_result_list_fold canonical_blocks ~init:() ~f:(fun () block ->
              let%bind () = mark_as_canonical (module Conn) ~state_hash:block.state_hash in
              mark_as_orphaned (module Conn) ~state_hash:block.state_hash ~height:block.height)
-         in
-         ()
        else
          Deferred.Result.return ()
+     | _ ->
+       failwith "update_chain_status: expected 0 or 1 results from get_highest_canonical_blocks"
 
   let delete_if_older_than ?height ?num_blocks ?timestamp
       (module Conn : CONNECTION) =

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1121,7 +1121,8 @@ module Block = struct
                       snarked_ledger_hash_id, staking_epoch_data_id,
                       next_epoch_data_id, ledger_hash, height, global_slot,
                       global_slot_since_genesis, timestamp, chain_status)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::chain_status_type)
+                     RETURNING id
                |sql})
             { state_hash= hash |> State_hash.to_base58_check
             ; parent_id
@@ -1435,7 +1436,8 @@ module Block = struct
                       snarked_ledger_hash_id, staking_epoch_data_id,
                       next_epoch_data_id, ledger_hash, height, global_slot,
                       global_slot_since_genesis, timestamp, chain_status)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::chain_status_type)
+                     RETURNING id
                |sql})
             { state_hash= block.state_hash |> State_hash.to_base58_check
             ; parent_id

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -64,7 +64,7 @@ CREATE TABLE epoch_data
 , ledger_hash_id int    NOT NULL REFERENCES snarked_ledger_hashes(id)
 );
 
-CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned')
+CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned');
 
 /* we cannot be certain whether recent blocks are canonical, hence the column is nullable */
 CREATE TABLE blocks

--- a/src/app/client_sdk/dune
+++ b/src/app/client_sdk/dune
@@ -2,8 +2,9 @@
  (name client_sdk)
  (modes js)
  (js_of_ocaml (flags +toplevel.js +dynlink.js))
- (libraries snark_params_nonconsensus rosetta_lib_nonconsensus mina_base_nonconsensus data_hash_lib_nonconsensus
-            random_oracle_nonconsensus signature_lib_nonconsensus string_sign_nonconsensus
+ (libraries core_kernel snark_params_nonconsensus rosetta_lib_nonconsensus mina_base_nonconsensus
+            data_hash_lib_nonconsensus random_oracle_nonconsensus signature_lib_nonconsensus
+            string_sign_nonconsensus mina_signature_kind
             zarith_stubs_js integers integers_stubs_js js_of_ocaml digestif.ocaml)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/client_sdk/js_util.ml
+++ b/src/app/client_sdk/js_util.ml
@@ -118,6 +118,12 @@ let signature_of_js_object (signature_js : signature_js) : Signature.t =
   in
   (field, scalar)
 
+type signed_string =
+  < string : string_js Js.readonly_prop
+  ; signer : string_js Js.readonly_prop
+  ; signature : signature_js Js.readonly_prop >
+  Js.t
+
 type signed_payment =
   < payment : payment_js Js.readonly_prop
   ; sender : string_js Js.readonly_prop
@@ -129,3 +135,14 @@ type signed_stake_delegation =
   ; sender : string_js Js.readonly_prop
   ; signature : signature_js Js.readonly_prop >
   Js.t
+
+let signature_kind_of_string_js network_js fname : Mina_signature_kind.t =
+  match Js.to_string network_js |> Base.String.lowercase with
+  | "mainnet" ->
+      Mainnet
+  | "testnet" ->
+      Testnet
+  | s ->
+      raise_js_error
+        (Core_kernel.sprintf
+           "%s: expected network to be mainnet or testnet, got: %s" fname s)

--- a/src/app/client_sdk/tests/dune
+++ b/src/app/client_sdk/tests/dune
@@ -4,7 +4,7 @@
  (public_name test_signatures)
  (modes native)
  (modules test_signatures)
- (libraries core_kernel mina_base mina_numbers currency signature_lib snark_params)
+ (libraries core_kernel mina_base mina_numbers currency signature_lib snark_params string_sign)
  (preprocessor_deps ../../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_optcomp ppx_custom_printf))
@@ -16,7 +16,8 @@
  (public_name test_signatures_nonconsensus)
  (modes native)
  (modules test_signatures_nonconsensus)
- (libraries core_kernel mina_base_nonconsensus mina_numbers_nonconsensus currency_nonconsensus signature_lib_nonconsensus snark_params_nonconsensus)
+ (libraries core_kernel mina_base_nonconsensus mina_numbers_nonconsensus currency_nonconsensus
+            signature_lib_nonconsensus snark_params_nonconsensus string_sign_nonconsensus)
  (preprocessor_deps ../../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_optcomp ppx_custom_printf))

--- a/src/app/client_sdk/tests/test_signatures.js
+++ b/src/app/client_sdk/tests/test_signatures.js
@@ -43,17 +43,27 @@ var delegations = [
     },
   ];
 
+var strings = [
+    'this is a test',
+    'this is only a test',
+    'if this had been an actual emergency...'
+    ]
+
 var printSignature = s => console.log(`  { field: '${s.field}'\n  , scalar: '${s.scalar}'\n  },`);
 
 var payment_signatures = payments.map (t => mina.signPayment(keypair.privateKey, t))
 
 var delegation_signatures = delegations.map (t => mina.signStakeDelegation(keypair.privateKey, t))
 
+var string_signatures = strings.map (t => mina.signString('testnet',keypair.privateKey, t))
+
 // verify signatures before printing them
 payment_signatures.forEach (t => { if (!mina.verifyPaymentSignature (t)) { console.error ("Payment signature did not verify"); process.exit (1) } })
 delegation_signatures.forEach (t => { if (!mina.verifyStakeDelegationSignature (t)) { console.error ("Delegation signature did not verify"); process.exit (1) } })
+string_signatures.forEach (t => {if (!mina.verifyStringSignature ('testnet',t)) { console.error ("String signature did not verify"); process.exit (1) } })
 
 console.log("[");
 payment_signatures.forEach(t => printSignature (t.signature))
 delegation_signatures.forEach(t => printSignature (t.signature))
+string_signatures.forEach(t => printSignature (t.signature))
 console.log("]");

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -14,6 +14,12 @@ module type Message_intf = sig
 
   val derive : t -> private_key:curve_scalar -> public_key:curve -> curve_scalar
 
+  val derive_for_mainnet :
+    t -> private_key:curve_scalar -> public_key:curve -> curve_scalar
+
+  val derive_for_testnet :
+    t -> private_key:curve_scalar -> public_key:curve -> curve_scalar
+
   val hash : t -> public_key:curve -> r:field -> curve_scalar
 
   val hash_for_mainnet : t -> public_key:curve -> r:field -> curve_scalar
@@ -112,7 +118,11 @@ module type S = sig
 
   val compress : curve -> bool list
 
-  val sign : Private_key.t -> Message.t -> Signature.t
+  val sign :
+       ?signature_kind:Mina_signature_kind.t
+    -> Private_key.t
+    -> Message.t
+    -> Signature.t
 
   val verify :
        ?signature_kind:Mina_signature_kind.t
@@ -210,17 +220,37 @@ module Make
 
   let is_even (t : Field.t) = not (Bigint.test_bit (Bigint.of_field t) 0)
 
-  let sign (d_prime : Private_key.t) m =
+  let sign ?signature_kind (d_prime : Private_key.t) (m : Message.t) =
     let public_key =
       (* TODO: Don't recompute this. *) Curve.scale Curve.one d_prime
     in
     (* TODO: Once we switch to implicit sign-bit we'll have to conditionally negate d_prime. *)
     let d = d_prime in
-    let k_prime = Message.derive m ~public_key ~private_key:d in
+    let derive =
+      let open Mina_signature_kind in
+      match signature_kind with
+      | None ->
+          Message.derive
+      | Some Mainnet ->
+          Message.derive_for_mainnet
+      | Some Testnet ->
+          Message.derive_for_testnet
+    in
+    let k_prime = derive m ~public_key ~private_key:d in
     assert (not Curve.Scalar.(equal k_prime zero)) ;
     let r, ry = Curve.(to_affine_exn (scale Curve.one k_prime)) in
     let k = if is_even ry then k_prime else Curve.Scalar.negate k_prime in
-    let e = Message.hash m ~public_key ~r in
+    let hash =
+      let open Mina_signature_kind in
+      match signature_kind with
+      | None ->
+          Message.hash
+      | Some Mainnet ->
+          Message.hash_for_mainnet
+      | Some Testnet ->
+          Message.hash_for_testnet
+    in
+    let e = hash m ~public_key ~r in
     let s = Curve.Scalar.(k + (e * d)) in
     (r, s)
 
@@ -334,7 +364,11 @@ module type S = sig
     type t = curve [@@deriving sexp]
   end
 
-  val sign : Private_key.t -> Message.t -> Signature.t
+  val sign :
+       ?signature_kind:Mina_signature_kind.t
+    -> Private_key.t
+    -> Message.t
+    -> Signature.t
 
   val verify :
        ?signature_kind:Mina_signature_kind.t
@@ -395,20 +429,40 @@ module Make
 
   let is_even (t : Impl.Field.t) = not @@ Impl.Field.parity t
 
-  let sign (d_prime : Private_key.t) m =
+  let sign ?signature_kind (d_prime : Private_key.t) m =
     let public_key =
       (* TODO: Don't recompute this. *)
       Curve.scale Curve.one d_prime
     in
     (* TODO: Once we switch to implicit sign-bit we'll have to conditionally negate d_prime. *)
     let d = d_prime in
-    let k_prime = Message.derive m ~public_key ~private_key:d in
+    let derive =
+      let open Mina_signature_kind in
+      match signature_kind with
+      | None ->
+          Message.derive
+      | Some Mainnet ->
+          Message.derive_for_mainnet
+      | Some Testnet ->
+          Message.derive_for_testnet
+    in
+    let k_prime = derive m ~public_key ~private_key:d in
     assert (not Curve.Scalar.(equal k_prime zero)) ;
     let r, (ry : Impl.Field.t) =
       Curve.(to_affine_exn (scale Curve.one k_prime))
     in
     let k = if is_even ry then k_prime else Curve.Scalar.negate k_prime in
-    let e = Message.hash m ~public_key ~r in
+    let hash =
+      let open Mina_signature_kind in
+      match signature_kind with
+      | None ->
+          Message.hash
+      | Some Mainnet ->
+          Message.hash_for_mainnet
+      | Some Testnet ->
+          Message.hash_for_testnet
+    in
+    let e = hash m ~public_key ~r in
     let s = Curve.Scalar.(k + (e * d)) in
     (r, s)
 
@@ -444,14 +498,18 @@ module Message = struct
 
   type t = (Field.t, bool) Random_oracle.Input.t [@@deriving sexp]
 
+  let network_id_mainnet = Char.of_int_exn 1
+
+  let network_id_testnet = Char.of_int_exn 0
+
   let network_id =
     match Mina_signature_kind.t with
     | Mainnet ->
-        Char.of_int_exn 1
+        network_id_mainnet
     | Testnet ->
-        Char.of_int_exn 0
+        network_id_testnet
 
-  let derive t ~private_key ~public_key =
+  let make_derive ~network_id t ~private_key ~public_key =
     let input =
       let x, y = Tick.Inner_curve.to_affine_exn public_key in
       Random_oracle.Input.append t
@@ -467,6 +525,12 @@ module Message = struct
     |> Blake2.to_raw_string |> Blake2.string_to_bits |> Array.to_list
     |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
     |> Tock.Field.project
+
+  let derive = make_derive ~network_id
+
+  let derive_for_mainnet = make_derive ~network_id:network_id_mainnet
+
+  let derive_for_testnet = make_derive ~network_id:network_id_testnet
 
   let make_hash ~init t ~public_key ~r =
     let input =

--- a/src/lib/string_sign/dune
+++ b/src/lib/string_sign/dune
@@ -1,8 +1,9 @@
 (library
  (name string_sign)
  (public_name string_sign)
- (libraries snark_params mina_base random_oracle signature_lib digestif.ocaml)
+ (inline_tests)
+ (libraries signature_lib)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_snarky ppx_optcomp))
+ (preprocess (pps ppx_version ppx_optcomp ppx_inline_test))
  (synopsis "Schnorr signatures for strings"))

--- a/src/lib/string_sign/string_sign.ml
+++ b/src/lib/string_sign/string_sign.ml
@@ -4,131 +4,118 @@
 
 [%%ifdef consensus_mechanism]
 
-open Snark_params
-open Signature_lib
-open Mina_base
-module Field = Snark_params.Tick.Field
-module Boolean = Snark_params.Tick.Boolean
 module Inner_curve = Snark_params.Tick.Inner_curve
+open Signature_lib
 
 [%%else]
 
-open Snark_params_nonconsensus
-open Signature_lib_nonconsensus
-open Mina_base_nonconsensus
-module Snark_params = Snark_params_nonconsensus
-module Tick = Snark_params
+module Inner_curve = Snark_params_nonconsensus.Inner_curve
 module Signature_lib = Signature_lib_nonconsensus
 module Random_oracle = Random_oracle_nonconsensus.Random_oracle
-module Inner_curve = Snark_params.Inner_curve
+open Signature_lib
 
 [%%endif]
 
-module Message = struct
-  type t = string
+let nybble_bits = function
+  | 0x0 ->
+      [ false; false; false; false ]
+  | 0x1 ->
+      [ false; false; false; true ]
+  | 0x2 ->
+      [ false; false; true; false ]
+  | 0x3 ->
+      [ false; false; true; true ]
+  | 0x4 ->
+      [ false; true; false; false ]
+  | 0x5 ->
+      [ false; true; false; true ]
+  | 0x6 ->
+      [ false; true; true; false ]
+  | 0x7 ->
+      [ false; true; true; true ]
+  | 0x8 ->
+      [ true; false; false; false ]
+  | 0x9 ->
+      [ true; false; false; true ]
+  | 0xA ->
+      [ true; false; true; false ]
+  | 0xB ->
+      [ true; false; true; true ]
+  | 0xC ->
+      [ true; true; false; false ]
+  | 0xD ->
+      [ true; true; false; true ]
+  | 0xE ->
+      [ true; true; true; false ]
+  | 0xF ->
+      [ true; true; true; true ]
+  | _ ->
+      failwith "nybble_bits: expected value from 0 to 0xF"
 
-  let nybble_bits = function
-    | 0x0 ->
-        [ false; false; false; false ]
-    | 0x1 ->
-        [ false; false; false; true ]
-    | 0x2 ->
-        [ false; false; true; false ]
-    | 0x3 ->
-        [ false; false; true; true ]
-    | 0x4 ->
-        [ false; true; false; false ]
-    | 0x5 ->
-        [ false; true; false; true ]
-    | 0x6 ->
-        [ false; true; true; false ]
-    | 0x7 ->
-        [ false; true; true; true ]
-    | 0x8 ->
-        [ true; false; false; false ]
-    | 0x9 ->
-        [ true; false; false; true ]
-    | 0xA ->
-        [ true; false; true; false ]
-    | 0xB ->
-        [ true; false; true; true ]
-    | 0xC ->
-        [ true; true; false; false ]
-    | 0xD ->
-        [ true; true; false; true ]
-    | 0xE ->
-        [ true; true; true; false ]
-    | 0xF ->
-        [ true; true; true; true ]
-    | _ ->
-        failwith "nybble_bits: expected value from 0 to 0xF"
+let char_bits c =
+  let open Core_kernel in
+  let n = Char.to_int c in
+  let hi = Int.(shift_right (bit_and n 0xF0) 4) in
+  let lo = Int.bit_and n 0x0F in
+  List.concat_map [ hi; lo ] ~f:nybble_bits
 
-  let char_bits c =
-    let open Core_kernel in
-    let n = Char.to_int c in
-    let hi = Int.(shift_right (bit_and n 0xF0) 4) in
-    let lo = Int.bit_and n 0x0F in
-    List.concat_map [ hi; lo ] ~f:nybble_bits
+let string_to_input s =
+  Random_oracle.Input.
+    { field_elements = [||]
+    ; bitstrings = Stdlib.(Array.of_seq (Seq.map char_bits (String.to_seq s)))
+    }
 
-  let string_bits s =
-    let open Core_kernel in
-    List.(concat_map (String.to_list s) ~f:char_bits)
+let verify ?signature_kind signature pk s =
+  let m = string_to_input s in
+  let inner_curve = Inner_curve.of_affine pk in
+  Schnorr.verify ?signature_kind signature inner_curve m
 
-  let derive t ~private_key ~public_key:pk =
-    let pk_bits { Public_key.Compressed.Poly.x; is_odd } =
-      is_odd :: Field.unpack x
-    in
-    List.concat
-      [ Tock.Field.unpack private_key
-      ; pk_bits (Public_key.compress (Inner_curve.to_affine_exn pk))
-      ; string_bits t
-      ]
-    |> Array.of_list |> Blake2.bits_to_string |> Blake2.digest_string
-    |> Blake2.to_raw_string |> Blake2.string_to_bits |> Array.to_list
-    |> Base.(Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1)))
-    |> Tock.Field.project
+let sign ?signature_kind sk s =
+  let m = string_to_input s in
+  Schnorr.sign ?signature_kind sk m
 
-  let make_hash ~init t ~public_key ~r =
-    let string_to_input s =
-      Random_oracle.Input.
-        { field_elements = [||]
-        ; bitstrings =
-            Stdlib.(Array.of_seq (Seq.map char_bits (String.to_seq s)))
-        }
-    in
-    let input =
-      let px, py = Inner_curve.to_affine_exn public_key in
-      Random_oracle.Input.append (string_to_input t)
-        { field_elements = [| px; py; r |]; bitstrings = [||] }
-    in
-    let open Random_oracle in
-    hash ~init (pack_input input)
-    |> Digest.to_bits |> Inner_curve.Scalar.of_bits
+let%test_module "Sign_string tests" =
+  ( module struct
+    let keypair : Signature_lib.Keypair.t =
+      let public_key =
+        Signature_lib.Public_key.Compressed.of_base58_check_exn
+          "B62qnNkiQn1t1Nhof2fyTtBTbHLbXcUDVX2BWpjGKKK3HsfP8LPhYgE"
+        |> Signature_lib.Public_key.decompress_exn
+      in
+      let private_key =
+        Signature_lib.Private_key.of_base58_check_exn
+          "EKEyDHNLpR42jU8j9p13t6GA3wKBXdHszrV17G6jpfJbK8FZDfYo"
+      in
+      { public_key; private_key }
 
-  let hash = make_hash ~init:Hash_prefix.signature
+    let%test "Sign, verify with default network" =
+      let s =
+        "Now is the time for all good men to come to the aid of their party"
+      in
+      let signature = sign keypair.private_key s in
+      verify signature keypair.public_key s
 
-  let hash_for_mainnet = make_hash ~init:Hash_prefix.signature_for_mainnet
+    let%test "Sign, verify with mainnet" =
+      let s = "Rain and Spain don't rhyme with cheese" in
+      let signature_kind = Mina_signature_kind.Mainnet in
+      let signature = sign ~signature_kind:Mainnet keypair.private_key s in
+      verify ~signature_kind signature keypair.public_key s
 
-  let hash_for_testnet = make_hash ~init:Hash_prefix.signature_for_testnet
+    let%test "Sign, verify with testnet" =
+      let s = "In a galaxy far, far away" in
+      let signature_kind = Mina_signature_kind.Testnet in
+      let signature = sign ~signature_kind keypair.private_key s in
+      verify ~signature_kind signature keypair.public_key s
 
-  [%%ifdef consensus_mechanism]
+    let%test "Sign with testnet, fail to verify with mainnet" =
+      let open Mina_signature_kind in
+      let s = "Some pills make you larger" in
+      let signature = sign ~signature_kind:Testnet keypair.private_key s in
+      not (verify ~signature_kind:Mainnet signature keypair.public_key s)
 
-  (* TODO: factor out this common code from Signature_lib.Schnorr.Message *)
-  type var = (Field.Var.t, Boolean.var) Random_oracle.Input.t
-
-  let%snarkydef hash_checked t ~public_key ~r =
-    let input =
-      let px, py = public_key in
-      Random_oracle.Input.append t
-        { field_elements = [| px; py; r |]; bitstrings = [||] }
-    in
-    Tick.make_checked (fun () ->
-        let open Random_oracle.Checked in
-        hash ~init:Hash_prefix_states.signature (pack_input input)
-        |> Digest.to_bits ~length:Field.size_in_bits
-        |> Bitstring_lib.Bitstring.Lsb_first.of_list)
-
-  [%%endif]
-end
-
-module Schnorr = Signature_lib.Schnorr.Make (Tick) (Inner_curve) (Message)
+    let%test "Sign with mainnet, fail to verify with testnet" =
+      let open Mina_signature_kind in
+      let s = "Watson, come here, I need you" in
+      let signature = sign ~signature_kind:Mainnet keypair.private_key s in
+      not (verify ~signature_kind:Testnet signature keypair.public_key s)
+  end )

--- a/src/nonconsensus/string_sign/dune
+++ b/src/nonconsensus/string_sign/dune
@@ -1,10 +1,11 @@
 (library
  (name string_sign_nonconsensus)
  (public_name string_sign_nonconsensus)
+ (inline_tests)
  (library_flags -linkall)
  (libraries snark_params_nonconsensus mina_base_nonconsensus random_oracle_nonconsensus
             signature_lib_nonconsensus digestif.ocaml)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_version ppx_snarky ppx_optcomp))
- (synopsis "Schnorr signatures for strings"))
+ (preprocess (pps ppx_version ppx_snarky ppx_optcomp ppx_inline_test))
+ (synopsis "Schnorr signatures for strings, nonconsensus version"))


### PR DESCRIPTION
In the client SDK, add a required network argument to the methods `signString` and `verifyStringSignature`. The argument must be either "mainnet" or "testnet" (case irrelevant), or an exception will be raised.  If we wish to omit that argument, the typescript wrapper can add a default.

Formerly, `signString` returned just a signature object. In this PR, it returns an object with the signature, the string that was signed, and the signer's public key.  That matches the signing methods for payments and delegations, which return information about what was signed, and who signed it.

Added tests that compare the consensus/nonconsensus code for string signing and verification, which are run by the `compare_test_signatures` script in CI.

Simplified `String_sign` to rely on the signer and verifier in `Signature_lib.Schnorr`, rather than apply the functor there. Add unit tests there to show that the network must match in the signer and verifier.

This is the first step in making the signers and verifiers in the client SDK "network polymorphic". We already had such polymorphism for the string verifier, so it was straightforward to add that for the signer. Next up, we'll add network polymorphism for payment and delegation signatures.

Also: fixed some bugs for CI (missing semicolon in archive db schema, handle case where no blocks marked as canonical, type annotation for inserting blocks).
