### PR TITLE
Chain status 'pending' instead of NULL

### DIFF
--- a/scripts/archive/add_chain_status.sh
+++ b/scripts/archive/add_chain_status.sh
@@ -13,8 +13,9 @@ ARCHIVE=archive
 
 echo "Creating the chain_status column, if it doesn't exist"
 psql $ARCHIVE <<EOF
-CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned');
-ALTER TABLE blocks ADD COLUMN chain_status chain_status_type
+CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned', 'pending');
+ALTER TABLE blocks ADD COLUMN chain_status chain_status_type DEFAULT 'pending';
+CREATE INDEX idx_chain_status ON blocks(chain_status)
 EOF
 
 echo "Marking genesis block as canonical"

--- a/src/app/archive/archive_lib/chain_status.ml
+++ b/src/app/archive/archive_lib/chain_status.ml
@@ -2,15 +2,17 @@
 
 open Core_kernel
 
-type t = Canonical | Orphaned
+type t = Canonical | Orphaned | Pending
 [@@deriving yojson, equal, bin_io_unversioned]
 
 let to_string = function
   | Canonical -> "canonical"
   | Orphaned -> "orphaned"
+  | Pending -> "pending"
 
 let of_string = function
   | "canonical" -> Canonical
   | "orphaned" -> Orphaned
+  | "pending" -> Pending
   | s ->
     failwithf "Chain_status.of_string: invalid string = %s" s ()

--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -85,7 +85,7 @@ module Block = struct
     ; timestamp: Block_time.Stable.Latest.t
     ; user_cmds: User_command.t list
     ; internal_cmds: Internal_command.t list
-    ; chain_status: Chain_status.t option
+    ; chain_status: Chain_status.t
     }
   [@@deriving yojson, equal, bin_io_unversioned]
 end

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1023,7 +1023,7 @@ module Block = struct
     ; global_slot_since_hard_fork: int64
     ; global_slot_since_genesis: int64
     ; timestamp: int64
-    ; chain_status: string option
+    ; chain_status: string
     }
   [@@deriving hlist]
 
@@ -1044,7 +1044,7 @@ module Block = struct
         ; int64
         ; int64
         ; int64
-        ; option string
+        ; string
         ]
     in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
@@ -1153,7 +1153,7 @@ module Block = struct
                 Protocol_state.blockchain_state protocol_state
                 |> Blockchain_state.timestamp |> Block_time.to_int64
             (* we don't yet know the chain status for a block we're adding *)
-            ; chain_status=None
+            ; chain_status=Chain_status.(to_string Pending)
             }
         in
         let transactions =
@@ -1453,7 +1453,7 @@ module Block = struct
             ; global_slot_since_genesis=
                 block.global_slot_since_genesis |> Unsigned.UInt32.to_int64
             ; timestamp= block.timestamp |> Block_time.to_int64
-            ; chain_status= Option.map block.chain_status ~f:Chain_status.to_string
+            ; chain_status= Chain_status.to_string block.chain_status
             }
     in
     (* add user commands *)

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -64,9 +64,8 @@ CREATE TABLE epoch_data
 , ledger_hash_id int    NOT NULL REFERENCES snarked_ledger_hashes(id)
 );
 
-CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned')
+CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned', 'pending');
 
-/* we cannot be certain whether recent blocks are canonical, hence the column is nullable */
 CREATE TABLE blocks
 ( id                         serial PRIMARY KEY
 , state_hash                 text   NOT NULL UNIQUE
@@ -82,7 +81,7 @@ CREATE TABLE blocks
 , global_slot                bigint NOT NULL
 , global_slot_since_genesis  bigint NOT NULL
 , timestamp                  bigint NOT NULL
-, chain_status               chain_status_type
+, chain_status               chain_status_type NOT NULL
 );
 
 CREATE INDEX idx_blocks_id ON blocks(id);

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -83,7 +83,7 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
     Unsigned.UInt32.of_int64 block.global_slot_since_genesis
   in
   let timestamp = Block_time.of_int64 block.timestamp in
-  let chain_status = Option.map block.chain_status ~f:Chain_status.of_string in
+  let chain_status = Chain_status.of_string block.chain_status in
   (* commands to be filled in later *)
   return
     { Extensional.Block.state_hash


### PR DESCRIPTION
In the archive database, use `pending` for chain status instead of a NULL. Avoiding NULLs lessens the chance for error and simplifies queries.

The migration script is updated accordingly. We'll have to migrate the live databases after merging this.

Tested the migration script on a local database. For an already-migrated database, the column and chain status type need to be DROPped before running the script.