### PR TITLE
Chain status pending, update queries

### DIFF
--- a/scripts/archive/add_chain_status.sh
+++ b/scripts/archive/add_chain_status.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# add chain_status column to `blocks` table
+
+# this script can be run multiple times, if new blocks
+#  are added to the archive database
+
+# from src/config/{mainnet,devnet}.mlh
+K=290
+
+PSQL="psql -t --no-align"
+ARCHIVE=archive
+
+echo "Creating the chain_status column, if it doesn't exist"
+psql $ARCHIVE <<EOF
+CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned', 'pending');
+ALTER TABLE blocks ADD COLUMN chain_status chain_status_type DEFAULT 'pending';
+CREATE INDEX idx_chain_status ON blocks(chain_status)
+EOF
+
+echo "Marking genesis block as canonical"
+$PSQL $ARCHIVE <<EOF
+UPDATE blocks SET chain_status = 'canonical'
+WHERE global_slot = 0
+EOF
+
+# get greatest canonical block height
+GREATEST_CANONICAL_HEIGHT_QUERY="SELECT height FROM blocks WHERE chain_status='canonical' ORDER BY height DESC LIMIT 1"
+GREATEST_CANONICAL_HEIGHT=$(/bin/echo $GREATEST_CANONICAL_HEIGHT_QUERY | $PSQL $ARCHIVE)
+
+echo "Greatest canonical block height is" $GREATEST_CANONICAL_HEIGHT
+
+# greatest greatest block height, use $1 or query db
+GREATEST_HEIGHT_QUERY="SELECT max(height) FROM blocks"
+GREATEST_HEIGHT=${1:-$(/bin/echo $GREATEST_HEIGHT_QUERY | $PSQL $ARCHIVE)}
+
+echo "Greatest block height is" $GREATEST_HEIGHT
+
+# find all blocks with the greatest height
+TMPFILE_GREATEST=$(mktemp -t add-chain-status-greatest.XXXXX)
+$PSQL $ARCHIVE <<EOF > $TMPFILE_GREATEST
+SELECT state_hash FROM blocks
+WHERE HEIGHT = $GREATEST_HEIGHT
+EOF
+
+TMPFILE_SUBCHAIN=$(mktemp -t add-chain-status-subchain.XXXXX)
+EXPECTED_LENGTH=$(expr $GREATEST_HEIGHT - $GREATEST_CANONICAL_HEIGHT + 1)
+FOUND_CHAIN=0
+
+# the subchain is enumerated by ascending height, so blocks are marked
+#  as canonical in order, starting from those already marked as canonical;
+# there won't be gaps among the canonical blocks, and
+#  if the script is interrupted, we can re-run the script to resume where
+#  we left off
+while read -r state_hash ; do
+    echo "Looking for subchain from block with state hash" $state_hash "with length" $EXPECTED_LENGTH
+    $PSQL --field-separator=" " $ARCHIVE <<EOF > $TMPFILE_SUBCHAIN
+WITH RECURSIVE chain AS (
+
+              SELECT id,state_hash,parent_id,height
+              FROM blocks WHERE state_hash = '$state_hash'
+
+              UNION ALL
+
+              SELECT b.id,b.state_hash,b.parent_id,b.height
+              FROM blocks b
+
+              INNER JOIN chain
+
+              ON b.id = chain.parent_id AND chain.height <> $GREATEST_CANONICAL_HEIGHT
+           )
+
+SELECT state_hash,height FROM chain ORDER BY height ASC
+EOF
+
+CHAIN_LENGTH=$(wc -l $TMPFILE_SUBCHAIN | awk '{print $1}')
+
+if [ $CHAIN_LENGTH -eq $EXPECTED_LENGTH ]; then
+    echo "Found a chain of length" $CHAIN_LENGTH
+    FOUND_CHAIN=1
+    break
+fi
+done < $TMPFILE_GREATEST
+
+if [ $FOUND_CHAIN = 0 ]; then
+    echo "*** Did not find a subchain back to a canonical block starting from height" $GREATEST_HEIGHT
+    echo "*** Try passing a lower height as the first argument to this script"
+    exit 1
+fi
+
+# mark chain statuses
+while read -r state_hash height; do
+    if [ $height -le $(expr $GREATEST_HEIGHT - $K) ]; then
+	echo "Marking block with height" $height "and state hash" $state_hash "as canonical"
+	$PSQL $ARCHIVE <<EOF
+        UPDATE blocks SET chain_status = 'canonical'
+        WHERE state_hash='$state_hash'
+EOF
+	echo "Marking other blocks with height" $height "as orphaned"
+	$PSQL $ARCHIVE <<EOF
+        UPDATE blocks SET chain_status = 'orphaned'
+        WHERE height=$height AND state_hash<>'$state_hash'
+EOF
+    fi
+done < $TMPFILE_SUBCHAIN
+
+echo "Removing temporary files"
+rm -f $TMPFILE_GREATEST
+rm -f $TMPFILE_SUBCHAIN

--- a/src/app/archive/archive_lib/chain_status.ml
+++ b/src/app/archive/archive_lib/chain_status.ml
@@ -2,15 +2,17 @@
 
 open Core_kernel
 
-type t = Canonical | Orphaned
+type t = Canonical | Orphaned | Pending
 [@@deriving yojson, equal, bin_io_unversioned]
 
 let to_string = function
   | Canonical -> "canonical"
   | Orphaned -> "orphaned"
+  | Pending -> "pending"
 
 let of_string = function
   | "canonical" -> Canonical
   | "orphaned" -> Orphaned
+  | "pending" -> Pending
   | s ->
     failwithf "Chain_status.of_string: invalid string = %s" s ()

--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -85,7 +85,7 @@ module Block = struct
     ; timestamp: Block_time.Stable.Latest.t
     ; user_cmds: User_command.t list
     ; internal_cmds: Internal_command.t list
-    ; chain_status: Chain_status.t option
+    ; chain_status: Chain_status.t
     }
   [@@deriving yojson, equal, bin_io_unversioned]
 end

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1023,7 +1023,7 @@ module Block = struct
     ; global_slot_since_hard_fork: int64
     ; global_slot_since_genesis: int64
     ; timestamp: int64
-    ; chain_status: string option
+    ; chain_status: string
     }
   [@@deriving hlist]
 
@@ -1044,7 +1044,7 @@ module Block = struct
         ; int64
         ; int64
         ; int64
-        ; option string
+        ; string
         ]
     in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
@@ -1153,7 +1153,7 @@ module Block = struct
                 Protocol_state.blockchain_state protocol_state
                 |> Blockchain_state.timestamp |> Block_time.to_int64
             (* we don't yet know the chain status for a block we're adding *)
-            ; chain_status=None
+            ; chain_status=Chain_status.(to_string Pending)
             }
         in
         let transactions =
@@ -1453,7 +1453,7 @@ module Block = struct
             ; global_slot_since_genesis=
                 block.global_slot_since_genesis |> Unsigned.UInt32.to_int64
             ; timestamp= block.timestamp |> Block_time.to_int64
-            ; chain_status= Option.map block.chain_status ~f:Chain_status.to_string
+            ; chain_status= Chain_status.to_string block.chain_status
             }
     in
     (* add user commands *)

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -64,9 +64,8 @@ CREATE TABLE epoch_data
 , ledger_hash_id int    NOT NULL REFERENCES snarked_ledger_hashes(id)
 );
 
-CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned')
+CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned', 'pending');
 
-/* we cannot be certain whether recent blocks are canonical, hence the column is nullable */
 CREATE TABLE blocks
 ( id                         serial PRIMARY KEY
 , state_hash                 text   NOT NULL UNIQUE
@@ -82,7 +81,7 @@ CREATE TABLE blocks
 , global_slot                bigint NOT NULL
 , global_slot_since_genesis  bigint NOT NULL
 , timestamp                  bigint NOT NULL
-, chain_status               chain_status_type
+, chain_status               chain_status_type NOT NULL
 );
 
 CREATE INDEX idx_blocks_id ON blocks(id);

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -83,7 +83,7 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
     Unsigned.UInt32.of_int64 block.global_slot_since_genesis
   in
   let timestamp = Block_time.of_int64 block.timestamp in
-  let chain_status = Option.map block.chain_status ~f:Chain_status.of_string in
+  let chain_status = Chain_status.of_string block.chain_status in
   (* commands to be filled in later *)
   return
     { Extensional.Block.state_hash

--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -118,7 +118,7 @@ WITH RECURSIVE chain AS (
 
   SELECT b.id, b.state_hash, b.parent_id, b.height, b.global_slot_since_genesis, b.timestamp, b.chain_status FROM blocks b
   INNER JOIN chain
-  ON b.id = chain.parent_id AND chain.id <> chain.parent_id AND (chain.chain_status = 'orphaned' OR chain.chain_status IS NULL)
+  ON b.id = chain.parent_id AND chain.id <> chain.parent_id AND chain.chain_status <> 'canonical'
 ),
 
 %s

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -287,7 +287,7 @@ WITH RECURSIVE chain AS (
 
   SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.global_slot_since_genesis, b.timestamp, b.chain_status FROM blocks b
   INNER JOIN chain
-  ON b.id = chain.parent_id AND chain.id <> chain.parent_id AND (chain.chain_status = 'orphaned' OR chain.chain_status IS NULL)
+  ON b.id = chain.parent_id AND chain.id <> chain.parent_id AND chain.chain_status <> 'canonical'
 ) SELECT c.id, c.state_hash, c.parent_id, c.parent_hash, c.creator_id, c.block_winner_id, c.snarked_ledger_hash_id, c.staking_epoch_data_id, c.next_epoch_data_id, c.ledger_hash, c.height, c.global_slot, c.global_slot_since_genesis, c.timestamp, c.chain_status, pk.value as creator, bw.value as winner FROM chain c
   INNER JOIN public_keys pk
   ON pk.id = c.creator_id


### PR DESCRIPTION
This PR against `rosetta-1.2.1-safe` contains the changes to use `pending` instead of NULL for chain status, as in #9810.
It also simplifies the Rosetta `account` and `block` queries, because the `chain_status` column is now never NULL.

