### PR TITLE
Client SDK, choose network when signing payments, delegations

### DIFF
--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -133,13 +133,18 @@ let _ =
          else Js._false
 
        (** sign payment transaction payload with private key *)
-       method signPayment (sk_base58_check_js : string_js)
-           (payment_js : payment_js) : signed_payment =
+       method signPayment (network_js : string_js)
+           (sk_base58_check_js : string_js) (payment_js : payment_js)
+           : signed_payment =
+         let signature_kind =
+           signature_kind_of_string_js network_js "signPayment"
+         in
          let sk_base58_check = Js.to_string sk_base58_check_js in
          let sk = Private_key.of_base58_check_exn sk_base58_check in
          let payload = payload_of_payment_js payment_js in
          let signature =
-           Signed_command.sign_payload sk payload |> signature_to_js_object
+           Signed_command.sign_payload ~signature_kind sk payload
+           |> signature_to_js_object
          in
          let publicKey = _self##publicKeyOfPrivateKey sk_base58_check_js in
          object%js
@@ -151,8 +156,11 @@ let _ =
          end
 
        (** verify signed payments *)
-       method verifyPaymentSignature (signed_payment : signed_payment)
-           : bool Js.t =
+       method verifyPaymentSignature (network_js : string_js)
+           (signed_payment : signed_payment) : bool Js.t =
+         let signature_kind =
+           signature_kind_of_string_js network_js "verifyPaymentSignature"
+         in
          let payload : Signed_command_payload.t =
            payload_of_payment_js signed_payment##.payment
          in
@@ -163,7 +171,8 @@ let _ =
          in
          let signature = signature_of_js_object signed_payment##.signature in
          let signed = Signed_command.Poly.{ payload; signer; signature } in
-         if Signed_command.check_signature signed then Js._true else Js._false
+         if Signed_command.check_signature ~signature_kind signed then Js._true
+         else Js._false
 
        method hashPayment (signed_payment : signed_payment) : Js.js_string Js.t
            =
@@ -180,14 +189,19 @@ let _ =
          |> Transaction_hash.to_base58_check |> Js.string
 
        (** sign payment transaction payload with private key *)
-       method signStakeDelegation (sk_base58_check_js : string_js)
+       method signStakeDelegation (network_js : string_js)
+           (sk_base58_check_js : string_js)
            (stake_delegation_js : stake_delegation_js) : signed_stake_delegation
            =
+         let signature_kind =
+           signature_kind_of_string_js network_js "signStakeDelegation"
+         in
          let sk_base58_check = Js.to_string sk_base58_check_js in
          let sk = Private_key.of_base58_check_exn sk_base58_check in
          let payload = payload_of_stake_delegation_js stake_delegation_js in
          let signature =
-           Signed_command.sign_payload sk payload |> signature_to_js_object
+           Signed_command.sign_payload ~signature_kind sk payload
+           |> signature_to_js_object
          in
          let publicKey = _self##publicKeyOfPrivateKey sk_base58_check_js in
          object%js
@@ -199,8 +213,12 @@ let _ =
          end
 
        (** verify signed delegations *)
-       method verifyStakeDelegationSignature
+       method verifyStakeDelegationSignature (network_js : string_js)
            (signed_stake_delegation : signed_stake_delegation) : bool Js.t =
+         let signature_kind =
+           signature_kind_of_string_js network_js
+             "verifyStakeDelegationSignature"
+         in
          let payload : Signed_command_payload.t =
            payload_of_stake_delegation_js
              signed_stake_delegation##.stakeDelegation
@@ -214,7 +232,8 @@ let _ =
            signature_of_js_object signed_stake_delegation##.signature
          in
          let signed = Signed_command.Poly.{ payload; signer; signature } in
-         if Signed_command.check_signature signed then Js._true else Js._false
+         if Signed_command.check_signature ~signature_kind signed then Js._true
+         else Js._false
 
        method hashStakeDelegation
            (signed_stake_delegation : signed_stake_delegation)

--- a/src/app/client_sdk/tests/test_signatures.js
+++ b/src/app/client_sdk/tests/test_signatures.js
@@ -51,19 +51,24 @@ var strings = [
 
 var printSignature = s => console.log(`  { field: '${s.field}'\n  , scalar: '${s.scalar}'\n  },`);
 
-var payment_signatures = payments.map (t => mina.signPayment(keypair.privateKey, t))
+var networks = ["testnet","mainnet"]
 
-var delegation_signatures = delegations.map (t => mina.signStakeDelegation(keypair.privateKey, t))
+for (let i = 0; i < networks.length; i++) {
 
-var string_signatures = strings.map (t => mina.signString('testnet',keypair.privateKey, t))
+    var payment_signatures = payments.map (t => mina.signPayment(networks[i],keypair.privateKey, t))
 
-// verify signatures before printing them
-payment_signatures.forEach (t => { if (!mina.verifyPaymentSignature (t)) { console.error ("Payment signature did not verify"); process.exit (1) } })
-delegation_signatures.forEach (t => { if (!mina.verifyStakeDelegationSignature (t)) { console.error ("Delegation signature did not verify"); process.exit (1) } })
-string_signatures.forEach (t => {if (!mina.verifyStringSignature ('testnet',t)) { console.error ("String signature did not verify"); process.exit (1) } })
+    var delegation_signatures = delegations.map (t => mina.signStakeDelegation(networks[i],keypair.privateKey, t))
 
-console.log("[");
-payment_signatures.forEach(t => printSignature (t.signature))
-delegation_signatures.forEach(t => printSignature (t.signature))
-string_signatures.forEach(t => printSignature (t.signature))
-console.log("]");
+    var string_signatures = strings.map (t => mina.signString(networks[i],keypair.privateKey, t))
+
+    // verify signatures before printing them
+    payment_signatures.forEach (t => { if (!mina.verifyPaymentSignature (networks[i],t)) { console.error ("Payment signature did not verify"); process.exit (1) } })
+    delegation_signatures.forEach (t => { if (!mina.verifyStakeDelegationSignature (networks[i],t)) { console.error ("Delegation signature did not verify"); process.exit (1) } })
+    string_signatures.forEach (t => {if (!mina.verifyStringSignature (networks[i],t)) { console.error ("String signature did not verify"); process.exit (1) } })
+
+    console.log("[");
+    payment_signatures.forEach(t => printSignature (t.signature))
+    delegation_signatures.forEach(t => printSignature (t.signature))
+    string_signatures.forEach(t => printSignature (t.signature))
+    console.log("]")
+}

--- a/src/app/client_sdk/tests/test_signatures.ml
+++ b/src/app/client_sdk/tests/test_signatures.ml
@@ -108,8 +108,9 @@ let transactions = payments @ delegations
 
 type jsSignature = { privateKey : Field.t; publicKey : Inner_curve.Scalar.t }
 
-let get_signature payload =
-  (Signed_command.sign keypair payload :> Signed_command.With_valid_signature.t)
+let get_signature ~signature_kind payload =
+  ( Signed_command.sign ~signature_kind keypair payload
+    :> Signed_command.With_valid_signature.t )
 
 (* output format matches signatures in client SDK *)
 let print_signature field scalar =
@@ -117,43 +118,48 @@ let print_signature field scalar =
   printf "  , scalar: '%s'\n" (Inner_curve.Scalar.to_string scalar) ;
   printf "  },\n%!"
 
+let signature_kinds =
+  let open Mina_signature_kind in
+  [ Testnet; Mainnet ]
+
 let main () =
-  let txn_signatures = List.map transactions ~f:get_signature in
-  let string_signatures =
-    List.map strings
-      ~f:
-        (String_sign.sign ~signature_kind:Mina_signature_kind.Testnet
-           keypair.private_key)
-  in
-  (* make sure signatures verify *)
-  List.iteri txn_signatures ~f:(fun i signature ->
-      let signature = (signature :> Signed_command.t) in
-      if not (Signed_command.check_signature signature) then (
-        eprintf
-          !"Transaction signature (%d) failed to verify: %{sexp: \
-            Signed_command.t}\n\
-            %!"
-          i signature ;
-        exit 1 )) ;
-  List.iteri string_signatures ~f:(fun i signature ->
-      if
-        not
-          (String_sign.verify ~signature_kind:Mina_signature_kind.Testnet
-             signature keypair.public_key (List.nth_exn strings i))
-      then (
-        eprintf
-          !"Signature (%d) failed to verify for string: %s\n%!"
-          i (List.nth_exn strings i) ;
-        exit 1 )) ;
-  printf "[\n" ;
-  List.iter txn_signatures ~f:(fun signature ->
-      let Signed_command.Poly.{ signature = field, scalar; _ } =
-        (signature :> Signed_command.t)
+  List.iter signature_kinds ~f:(fun signature_kind ->
+      let txn_signatures =
+        List.map transactions ~f:(get_signature ~signature_kind)
       in
-      print_signature field scalar) ;
-  List.iter string_signatures ~f:(fun signature ->
-      let field, scalar = signature in
-      print_signature field scalar) ;
-  printf "]\n"
+      let string_signatures =
+        List.map strings
+          ~f:(String_sign.sign ~signature_kind keypair.private_key)
+      in
+      (* make sure signatures verify *)
+      List.iteri txn_signatures ~f:(fun i signature ->
+          let signature = (signature :> Signed_command.t) in
+          if not (Signed_command.check_signature ~signature_kind signature) then (
+            eprintf
+              !"Transaction signature (%d) failed to verify: %{sexp: \
+                Signed_command.t}\n\
+                %!"
+              i signature ;
+            exit 1 )) ;
+      List.iteri string_signatures ~f:(fun i signature ->
+          if
+            not
+              (String_sign.verify ~signature_kind signature keypair.public_key
+                 (List.nth_exn strings i))
+          then (
+            eprintf
+              !"Signature (%d) failed to verify for string: %s\n%!"
+              i (List.nth_exn strings i) ;
+            exit 1 )) ;
+      printf "[\n" ;
+      List.iter txn_signatures ~f:(fun signature ->
+          let Signed_command.Poly.{ signature = field, scalar; _ } =
+            (signature :> Signed_command.t)
+          in
+          print_signature field scalar) ;
+      List.iter string_signatures ~f:(fun signature ->
+          let field, scalar = signature in
+          print_signature field scalar) ;
+      printf "]\n")
 
 let _ = main ()

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -138,19 +138,20 @@ let check_tokens ({ payload = { common = { fee_token; _ }; body }; _ } : t) =
       (not (Token_id.(equal invalid) token_id))
       && not (Token_id.(equal default) token_id)
 
-let sign_payload (private_key : Signature_lib.Private_key.t)
+let sign_payload ?signature_kind (private_key : Signature_lib.Private_key.t)
     (payload : Payload.t) : Signature.t =
-  Signature_lib.Schnorr.sign private_key (to_input payload)
+  Signature_lib.Schnorr.sign ?signature_kind private_key (to_input payload)
 
-let sign (kp : Signature_keypair.t) (payload : Payload.t) : t =
+let sign ?signature_kind (kp : Signature_keypair.t) (payload : Payload.t) : t =
   { payload
   ; signer = kp.public_key
-  ; signature = sign_payload kp.private_key payload
+  ; signature = sign_payload ?signature_kind kp.private_key payload
   }
 
 module For_tests = struct
   (* Pretend to sign a command. Much faster than actually signing. *)
-  let fake_sign (kp : Signature_keypair.t) (payload : Payload.t) : t =
+  let fake_sign ?signature_kind:_ (kp : Signature_keypair.t)
+      (payload : Payload.t) : t =
     { payload; signer = kp.public_key; signature = Signature.dummy }
 end
 

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -169,10 +169,16 @@ module type S = sig
   end
 
   val sign_payload :
-    Signature_lib.Private_key.t -> Signed_command_payload.t -> Signature.t
+       ?signature_kind:Mina_signature_kind.t
+    -> Signature_lib.Private_key.t
+    -> Signed_command_payload.t
+    -> Signature.t
 
   val sign :
-    Signature_keypair.t -> Signed_command_payload.t -> With_valid_signature.t
+       ?signature_kind:Mina_signature_kind.t
+    -> Signature_keypair.t
+    -> Signed_command_payload.t
+    -> With_valid_signature.t
 
   val check_signature : ?signature_kind:Mina_signature_kind.t -> t -> bool
 
@@ -184,8 +190,12 @@ module type S = sig
     -> With_valid_signature.t option
 
   module For_tests : sig
+    (** the signature kind is an argument, to match `sign`, but ignored *)
     val fake_sign :
-      Signature_keypair.t -> Signed_command_payload.t -> With_valid_signature.t
+         ?signature_kind:Mina_signature_kind.t
+      -> Signature_keypair.t
+      -> Signed_command_payload.t
+      -> With_valid_signature.t
   end
 
   val check : t -> With_valid_signature.t option


### PR DESCRIPTION
In client SDK, require a network argument when signing and verifying such signatures for payments and stake delegations. The Typescript wrapper can choose a default, if desired. 

#9808 made a similar change for signing strings, and verifying those signatures.

To enable that change, added an optional signature kind argument to `Signed_commands.{sign, sign_payload}`.

In the `compare_test_signatures` script for CI, run the signers and verifiers, including the ones for strings, for both networks. That script passes locally.



