### PR TITLE
Snapp generators, nonce from ledger

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11613,7 +11613,8 @@
             },
             {
               "name": "snappState",
-              "description": "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
+              "description":
+                "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
               "args": [],
               "type": {
                 "kind": "LIST",

--- a/src/lib/mina_base/snapp_generators.ml
+++ b/src/lib/mina_base/snapp_generators.ml
@@ -522,7 +522,7 @@ let gen_party_predicated_signed ?account_id ~ledger :
             account )
   in
   let predicate = account.nonce in
-  Party.Predicated.Poly.{ body; predicate }
+  return Party.Predicated.Poly.{ body; predicate }
 
 (* takes an account id, if we want to sign this data *)
 let gen_party_predicated_fee_payer ~account_id ~ledger :

--- a/src/lib/mina_base/snapp_generators.ml
+++ b/src/lib/mina_base/snapp_generators.ml
@@ -498,32 +498,6 @@ let gen_party_from ?(succeed = true) ?(new_account = false)
   in
   { Party.data; authorization }
 
-(* takes an optional account id, if we want to sign this data *)
-let gen_party_predicated_signed ?account_id ~ledger :
-    Party.Predicated.Signed.t Quickcheck.Generator.t =
-  let open Quickcheck.Let_syntax in
-  let%bind body =
-    gen_party_body ~gen_delta ~f_delta:Fn.id
-      ~increment_nonce:(Option.is_some account_id)
-      ?account_id ~ledger ()
-  in
-  (* use nonce from account in ledger *)
-  let pk = body.pk in
-  let account_id = Account_id.create pk body.token_id in
-  let account =
-    match Ledger.location_of_account ledger account_id with
-    | None ->
-        failwith "gen_party_predicated_signed: expected account to be in ledger"
-    | Some loc -> (
-        match Ledger.get ledger loc with
-        | None ->
-            failwith "gen_party_predicated_signed: no account at location"
-        | Some account ->
-            account )
-  in
-  let predicate = account.nonce in
-  return Party.Predicated.Poly.{ body; predicate }
-
 (* takes an account id, if we want to sign this data *)
 let gen_party_predicated_fee_payer ~account_id ~ledger :
     Party.Predicated.Fee_payer.t Quickcheck.Generator.t =
@@ -554,14 +528,6 @@ let gen_party_predicated_fee_payer ~account_id ~ledger :
   in
   let predicate = account.nonce in
   Party.Predicated.Poly.{ body; predicate }
-
-let gen_party_signed ?account_id ~ledger : Party.Signed.t Quickcheck.Generator.t
-    =
-  let open Quickcheck.Let_syntax in
-  let%map data = gen_party_predicated_signed ?account_id ~ledger in
-  (* real signature to be added when this data inserted into a Parties.t *)
-  let authorization = Signature.dummy in
-  Party.Signed.{ data; authorization }
 
 let gen_fee_payer ~account_id ~ledger : Party.Fee_payer.t Quickcheck.Generator.t
     =


### PR DESCRIPTION
In the Snapps generators, we were using incorrect nonces as predicates in two places.

In `gen_party_predicated_signed`, we were generating a nonce.

In `gen_party_predicated_fee_payer`, we were invariantly using the zero nonce.

In both cases, look up the account in the ledger, and use the nonce there.

Closes #9727.

Note that this change does not address the possibility that an account is used more than once in a single Parties.t.