### PR TITLE
Remove ~succeed from Snapp generator in archive unit test

### DIFF
--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -78,8 +78,8 @@ let%test_module "Archive node unit tests" =
       |> fun _ ->
       let protocol_state = Snapp_predicate.Protocol_state.accept in
       let%map (parties : Parties.t) =
-        Snapp_generators.gen_parties_from ~succeed:false ~fee_payer_keypair
-          ~keymap ~ledger ~protocol_state
+        Snapp_generators.gen_parties_from ~fee_payer_keypair ~keymap ~ledger
+          ~protocol_state ()
       in
       User_command.Parties parties
 

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1790,7 +1790,7 @@ let%test_module _ =
             let%bind protocol_state = Snapp_predicate.Protocol_state.gen in
             let%map (parties : Parties.t) =
               Mina_base.Snapp_generators.gen_parties_from ~succeed:true ~keymap
-                ~fee_payer_keypair ~ledger ~protocol_state
+                ~fee_payer_keypair ~ledger ~protocol_state ()
             in
             User_command.Parties parties
           in


### PR DESCRIPTION
For some reason, it had been necessary to add `~succeed:false` when invoking this generator to make the test succeed, but that's no longer reproducible. That flag is only meant to affect whether the generated Snapp can be applied successfully, so it should have no affect on this test. 

Remove the use of that flag. Also, update all the Snapp generators so the flag is actually optional. If all the arguments to a function are labelled, then arguments with `?` are not optional. Adding a unit argument makes those optional.

Remove a comment that hid some no longer used code.