### PR TITLE
User_command_generators

### DIFF
--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -47,8 +47,8 @@ let%test_module "Archive node unit tests" =
     let keys = Array.init 5 ~f:(fun _ -> Keypair.create ())
 
     let user_command_signed_gen =
-      User_command.Gen.payment_with_random_participants ~keys ~max_amount:1000
-        ~fee_range:10 ()
+      User_command_generators.payment_with_random_participants ~keys
+        ~max_amount:1000 ~fee_range:10 ()
 
     let user_command_snapp_gen :
         ('a, Parties.t) User_command.t_ Base_quickcheck.Generator.t =
@@ -78,8 +78,8 @@ let%test_module "Archive node unit tests" =
       |> fun _ ->
       let protocol_state = Snapp_predicate.Protocol_state.accept in
       let%map (parties : Parties.t) =
-        Snapp_generators.gen_parties_from ~succeed:false ~fee_payer_keypair
-          ~keymap ~ledger ~protocol_state
+        Snapp_generators.gen_parties_from ~fee_payer_keypair ~keymap ~ledger
+          ~protocol_state ()
       in
       User_command.Parties parties
 

--- a/src/lib/mina_base/snapp_generators.ml
+++ b/src/lib/mina_base/snapp_generators.ml
@@ -531,13 +531,14 @@ let gen_fee_payer ~account_id ~ledger : Party.Fee_payer.t Quickcheck.Generator.t
   let authorization = Signature.dummy in
   Party.Fee_payer.{ data; authorization }
 
+let max_other_parties = 5
+
 let gen_parties_from ?(succeed = true)
     ~(fee_payer_keypair : Signature_lib.Keypair.t)
     ~(keymap :
        Signature_lib.Private_key.t Signature_lib.Public_key.Compressed.Map.t)
-    ~ledger ~protocol_state =
+    ~ledger ~protocol_state () =
   let open Quickcheck.Let_syntax in
-  let max_parties = 5 in
   let fee_payer_pk =
     Signature_lib.Public_key.compress fee_payer_keypair.public_key
   in
@@ -580,7 +581,7 @@ let gen_parties_from ?(succeed = true)
     go [] num_parties
   in
   (* at least 1 party, so that `succeed` affects at least one predicate *)
-  let%bind num_parties = Int.gen_uniform_incl 1 max_parties in
+  let%bind num_parties = Int.gen_uniform_incl 1 max_other_parties in
   let%bind num_new_accounts = Int.gen_uniform_incl 0 num_parties in
   let num_old_parties = num_parties - num_new_accounts in
   let%bind old_parties =
@@ -619,7 +620,6 @@ let gen_parties_from ?(succeed = true)
     Snapp_predicate.Protocol_state.digest
       parties_dummy_signatures.protocol_state
   in
-
   let sign_for_other_party sk =
     Signature_lib.Schnorr.sign sk
       (Random_oracle.Input.field

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -27,30 +27,31 @@ type ('u, 's) t_ = ('u, 's) Poly.Stable.Latest.t =
   | Signed_command of 'u
   | Parties of 's
 
-(* TODO: For now, we don't generate snapp transactions. *)
 module Gen_make (C : Signed_command_intf.Gen_intf) = struct
-  let f g = Quickcheck.Generator.map g ~f:(fun c -> Signed_command c)
+  let to_signed_command f =
+    Quickcheck.Generator.map f ~f:(fun c -> Signed_command c)
 
   open C.Gen
 
   let payment ?sign_type ~key_gen ?nonce ~max_amount ?fee_token ?payment_token
       ~fee_range () =
-    f
+    to_signed_command
       (payment ?sign_type ~key_gen ?nonce ~max_amount ?fee_token ?payment_token
          ~fee_range ())
 
   let payment_with_random_participants ?sign_type ~keys ?nonce ~max_amount
       ?fee_token ?payment_token ~fee_range () =
-    f
+    to_signed_command
       (payment_with_random_participants ?sign_type ~keys ?nonce ~max_amount
          ?fee_token ?payment_token ~fee_range ())
 
   let stake_delegation ~key_gen ?nonce ?fee_token ~fee_range () =
-    f (stake_delegation ~key_gen ?nonce ?fee_token ~fee_range ())
+    to_signed_command
+      (stake_delegation ~key_gen ?nonce ?fee_token ~fee_range ())
 
   let stake_delegation_with_random_participants ~keys ?nonce ?fee_token
       ~fee_range () =
-    f
+    to_signed_command
       (stake_delegation_with_random_participants ~keys ?nonce ?fee_token
          ~fee_range ())
 

--- a/src/lib/mina_base/user_command_generators.ml
+++ b/src/lib/mina_base/user_command_generators.ml
@@ -1,0 +1,62 @@
+(* user_command_generators.ml *)
+
+(* generate User_command.t's, that is, either Signed_commands or
+   Parties
+*)
+
+open Core_kernel
+include User_command.Gen
+
+let parties () =
+  let open Quickcheck.Let_syntax in
+  let open Signature_lib in
+  (* Need a fee payer keypair, and max_other_parties * 2 keypairs, because
+     all the other parties might be new and their accounts not in the ledger;
+     or they might all be old and in the ledger
+
+     We'll put the fee payer account and max_other_parties accounts in the
+     ledger, and have max_other_parties keypairs available for new accounts
+  *)
+  let num_keypairs = (Snapp_generators.max_other_parties * 2) + 1 in
+  let keypairs = List.init num_keypairs ~f:(fun _ -> Keypair.create ()) in
+  let keymap =
+    List.fold keypairs ~init:Public_key.Compressed.Map.empty
+      ~f:(fun map { public_key; private_key } ->
+        let key = Public_key.compress public_key in
+        Public_key.Compressed.Map.add_exn map ~key ~data:private_key)
+  in
+  let num_keypairs_in_ledger = Snapp_generators.max_other_parties + 1 in
+  let keypairs_in_ledger = List.take keypairs num_keypairs_in_ledger in
+  let account_ids =
+    List.map keypairs_in_ledger ~f:(fun { public_key; _ } ->
+        Account_id.create (Public_key.compress public_key) Token_id.default)
+  in
+  let%bind balances =
+    Quickcheck.Generator.list_with_length num_keypairs_in_ledger
+      Currency.Balance.gen
+  in
+  let accounts =
+    List.map2_exn account_ids balances ~f:(fun account_id balance ->
+        Account.create account_id balance)
+  in
+  let fee_payer_keypair = List.hd_exn keypairs in
+  (* using Precomputed_values depth introduces a cyclic dependency *)
+  let depth = 20 in
+  let ledger = Ledger.create ~depth () in
+  List.iter2_exn account_ids accounts ~f:(fun acct_id acct ->
+      match Ledger.get_or_create_account ledger acct_id acct with
+      | Error err ->
+          failwithf
+            "parties: error adding account for account id: %s, error: %s@."
+            (Account_id.to_yojson acct_id |> Yojson.Safe.to_string)
+            (Error.to_string_hum err) ()
+      | Ok (`Existed, _) ->
+          failwithf "parties: account for account id already exists: %s@."
+            (Account_id.to_yojson acct_id |> Yojson.Safe.to_string)
+            ()
+      | Ok (`Added, _) ->
+          ()) ;
+  let%bind protocol_state = Snapp_predicate.Protocol_state.gen in
+  Quickcheck.Generator.map
+    (Snapp_generators.gen_parties_from ~fee_payer_keypair ~keymap ~ledger
+       ~protocol_state ()) ~f:(fun parties -> User_command.Parties parties)

--- a/src/lib/mina_base/user_command_generators.ml
+++ b/src/lib/mina_base/user_command_generators.ml
@@ -40,8 +40,9 @@ let parties () =
         Account.create account_id balance)
   in
   let fee_payer_keypair = List.hd_exn keypairs in
-  (* using Precomputed_values depth introduces a cyclic dependency *)
-  let depth = 20 in
+  let depth =
+    Genesis_constants.Constraint_constants.for_unit_tests.ledger_depth
+  in
   let ledger = Ledger.create ~depth () in
   List.iter2_exn account_ids accounts ~f:(fun acct_id acct ->
       match Ledger.get_or_create_account ledger acct_id acct with

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1439,7 +1439,7 @@ let%test_module _ =
                 Quickcheck.Generator.tuple2 (return sender)
                   (Quickcheck_lib.of_array test_keys)
               in
-              User_command.Gen.payment ~sign_type:`Fake ~key_gen
+              User_command_generators.payment ~sign_type:`Fake ~key_gen
                 ~nonce:current_nonce ~max_amount:1 ~fee_range:0 ()
             in
             let cmd_currency = amounts.(n - 1) in
@@ -1477,7 +1477,7 @@ let%test_module _ =
             Quickcheck.Generator.tuple2 (return sender)
               (Quickcheck_lib.of_array test_keys)
           in
-          User_command.Gen.payment ~sign_type:`Fake ~key_gen
+          User_command_generators.payment ~sign_type:`Fake ~key_gen
             ~nonce:(Account_nonce.of_int replaced_nonce)
             ~max_amount:(Currency.Amount.to_int init_balance)
             ~fee_range:0 ()

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1790,7 +1790,7 @@ let%test_module _ =
             let%bind protocol_state = Snapp_predicate.Protocol_state.gen in
             let%map (parties : Parties.t) =
               Mina_base.Snapp_generators.gen_parties_from ~succeed:true ~keymap
-                ~fee_payer_keypair ~ledger ~protocol_state
+                ~fee_payer_keypair ~ledger ~protocol_state ()
             in
             User_command.Parties parties
           in


### PR DESCRIPTION
New module `Mina_base.User_command_generators`, which includes `Mina_base.User_command.Gen`, and also `parties`, a generator for a `Parties.t`.

This new generator takes only a unit argument, and creates a ledger and keymap passed to `Snapp_generators.gen_parties_from`.

It would have been nice to put the new generator in `Mina_base.User_command.Gen`, but uses of `Snapp_generators` or `Ledger` there result in cyclic dependencies, hence the new file.

Change existing code to use `User_command_generators` instead of `User_command.Gen`.

Tested by calling the new `parties` generator, confirming it produces a result.