### PR TITLE
Add NOT NULL constraint when adding chain_status column

### DIFF
--- a/scripts/archive/add_chain_status.sh
+++ b/scripts/archive/add_chain_status.sh
@@ -14,7 +14,7 @@ ARCHIVE=archive
 echo "Creating the chain_status column, if it doesn't exist"
 psql $ARCHIVE <<EOF
 CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned', 'pending');
-ALTER TABLE blocks ADD COLUMN chain_status chain_status_type DEFAULT 'pending';
+ALTER TABLE blocks ADD COLUMN chain_status chain_status_type NOT NULL DEFAULT 'pending';
 CREATE INDEX idx_chain_status ON blocks(chain_status)
 EOF
 


### PR DESCRIPTION
The migration script was missing the NOT NULL constraint. 

No NULL values were created because we had the `DEFAULT` value, but without the constraint, the integrity of the database could be compromised by later actions.