### PR TITLE
Add account creation fee for internal command when adding extensional blocks

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1539,10 +1539,15 @@ module Block = struct
             balance_id_of_pk_and_balance internal_command.receiver
               internal_command.receiver_balance
           in
+          let receiver_account_creation_fee_paid = internal_command.receiver_account_creation_fee_paid
+                                                   |> Option.map ~f:(fun amount ->
+                                                       Currency.Amount.to_uint64 amount |>
+                                                       Unsigned.UInt64.to_int64)
+          in
           Block_and_internal_command.add_if_doesn't_exist
             (module Conn)
             ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
-            ~receiver_account_creation_fee_paid:None (* TEMP *)
+            ~receiver_account_creation_fee_paid
             ~receiver_balance_id )
     in
     return block_id


### PR DESCRIPTION
The code to add extensional blocks in the archive processor had a `TEMP` comment for the account creation fees associated with internal commands, and always passed `None` as the creation fee.

The data is there in the extensional block, so use that value.