### PR TITLE
Extend balances table for better Rosetta

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -697,11 +697,18 @@ module Coinbase = struct
 end
 
 module Balance = struct
-  type t = {id: int; public_key_id: int; balance: int64} [@@deriving hlist]
+  type t = { id: int
+           ; public_key_id: int
+           ; balance: int64
+           ; block_id: int
+           ; block_height: int64
+           ; block_sequence_no: int
+           ; block_secondary_sequence_no: int
+           } [@@deriving hlist]
 
   let typ =
     let open Caqti_type_spec in
-    let spec = Caqti_type.[int; int; int64] in
+    let spec = Caqti_type.[int; int; int64; int; int64;int;int] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
     Caqti_type.custom ~encode ~decode (to_rep spec)
@@ -711,43 +718,52 @@ module Balance = struct
     |> Unsigned.UInt64.to_int64
 
   let find (module Conn : CONNECTION) ~(public_key_id : int)
-      ~(balance : Currency.Balance.t) =
+      ~(balance : Currency.Balance.t) ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no =
     Conn.find_opt
       (Caqti_request.find_opt
-         Caqti_type.(tup2 int int64)
+         Caqti_type.(tup2 (tup2 int int64) (tup4 int int64 int int))
          Caqti_type.int
          {sql| SELECT id FROM balances
                WHERE public_key_id = $1
                AND balance = $2
+               AND block_id = $3
+               AND block_height = $4
+               AND block_sequence_no = $5
+               AND block_secondary_sequence_no = $6
          |sql})
-      (public_key_id, balance_to_int64 balance)
+         ((public_key_id, balance_to_int64 balance),
+          (block_id, block_height, block_sequence_no, block_secondary_sequence_no))
 
   let load (module Conn : CONNECTION) ~(id : int) =
     Conn.find
       (Caqti_request.find Caqti_type.int
-         Caqti_type.(tup2 int int64)
-         {sql| SELECT public_key_id, balance FROM balances
+         typ
+         {sql| SELECT id, public_key_id, balance,
+                      block_id, block_height,
+                      block_sequence_no, block_secondary_sequence_no
+               FROM balances
                WHERE id = $1
          |sql})
       id
 
   let add (module Conn : CONNECTION) ~(public_key_id : int)
-      ~(balance : Currency.Balance.t) =
+      ~(balance : Currency.Balance.t) ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no =
     Conn.find
       (Caqti_request.find
-         Caqti_type.(tup2 int int64)
+         Caqti_type.(tup2 (tup2 int int64) (tup4 int int64 int int))
          Caqti_type.int
          {sql| INSERT INTO balances (public_key_id, balance) VALUES (?, ?) RETURNING id |sql})
-      (public_key_id, balance_to_int64 balance)
+      ((public_key_id, balance_to_int64 balance),
+       (block_id, block_height, block_sequence_no, block_secondary_sequence_no))
 
   let add_if_doesn't_exist (module Conn : CONNECTION) ~(public_key_id : int)
-      ~(balance : Currency.Balance.t) =
+      ~(balance : Currency.Balance.t) ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no =
     let open Deferred.Result.Let_syntax in
-    match%bind find (module Conn) ~public_key_id ~balance with
+    match%bind find (module Conn) ~public_key_id ~balance  ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no with
     | Some balance_id ->
         return balance_id
     | None ->
-        add (module Conn) ~public_key_id ~balance
+        add (module Conn) ~public_key_id ~balance ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no
 end
 
 module Block_and_internal_command = struct
@@ -899,7 +915,7 @@ module Block_and_signed_command = struct
       ; source_balance_id
       ; receiver_balance_id }
 
-  let add_with_status (module Conn : CONNECTION) ~block_id ~user_command_id
+  let add_with_status (module Conn : CONNECTION) ~block_id ~block_height ~user_command_id
       ~sequence_no ~(status : Transaction_status.t) ~fee_payer_id ~source_id
       ~receiver_id =
     let open Deferred.Result.Let_syntax in
@@ -926,7 +942,7 @@ module Block_and_signed_command = struct
       | Failed (failure, balances) ->
           ("failed", Some failure, None, None, None, balances)
     in
-    let add_optional_balance id balance =
+    let add_optional_balance id balance ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no =
       match balance with
       | None ->
           Deferred.Result.return None
@@ -935,6 +951,7 @@ module Block_and_signed_command = struct
             Balance.add_if_doesn't_exist
               (module Conn)
               ~public_key_id:id ~balance
+              ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no
           in
           Some balance_id
     in
@@ -945,12 +962,15 @@ module Block_and_signed_command = struct
       Balance.add_if_doesn't_exist
         (module Conn)
         ~public_key_id:fee_payer_id ~balance:fee_payer_balance
+        ~block_id ~block_height ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0
     in
     let%bind source_balance_id =
       add_optional_balance source_id source_balance
+                ~block_id ~block_height ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0
     in
     let%bind receiver_balance_id =
       add_optional_balance receiver_id receiver_balance
+        ~block_id ~block_height ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0
     in
     add
       (module Conn)
@@ -1113,6 +1133,11 @@ module Block = struct
             (module Conn)
             (Consensus.Data.Consensus_state.next_epoch_data consensus_state)
         in
+        let height =
+          consensus_state
+          |> Consensus.Data.Consensus_state.blockchain_length
+          |> Unsigned.UInt32.to_int64
+        in
         let%bind block_id =
           Conn.find
             (Caqti_request.find typ Caqti_type.int
@@ -1138,10 +1163,7 @@ module Block = struct
                 Protocol_state.blockchain_state protocol_state
                 |> Blockchain_state.staged_ledger_hash
                 |> Staged_ledger_hash.ledger_hash |> Ledger_hash.to_string
-            ; height=
-                consensus_state
-                |> Consensus.Data.Consensus_state.blockchain_length
-                |> Unsigned.UInt32.to_int64
+            ; height
             ; global_slot_since_hard_fork=
                 Consensus.Data.Consensus_state.curr_global_slot consensus_state
                 |> Unsigned.UInt32.to_int64
@@ -1224,7 +1246,7 @@ module Block = struct
                 let%map () =
                   Block_and_signed_command.add_with_status
                     (module Conn)
-                    ~block_id ~user_command_id:id ~sequence_no
+                    ~block_id ~block_height:height ~user_command_id:id ~sequence_no
                     ~status:user_command.status ~fee_payer_id ~source_id
                     ~receiver_id
                   >>| ignore
@@ -1283,6 +1305,8 @@ module Block = struct
                         Balance.add_if_doesn't_exist
                           (module Conn)
                           ~public_key_id:receiver_id ~balance
+                          ~block_id ~block_height:height
+                          ~block_sequence_no:sequence_no ~block_secondary_sequence_no:secondary_sequence_no
                       in
                       let receiver_account_creation_fee_paid =
                         account_creation_fee_of_fees_and_balance fee balance
@@ -1328,6 +1352,7 @@ module Block = struct
                           (module Conn)
                           ~public_key_id:fee_transfer_receiver_id
                           ~balance
+                          ~block_id ~block_height:height ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0
                       in
                       let receiver_account_creation_fee_paid =
                         account_creation_fee_of_fees_and_balance fee balance
@@ -1354,6 +1379,10 @@ module Block = struct
                     (module Conn)
                     ~public_key_id:coinbase_receiver_id
                     ~balance:balances.coinbase_receiver_balance
+                    ~block_id ~block_height:height
+                    ~block_sequence_no:sequence_no
+                    ~block_secondary_sequence_no:0
+
                 in
                 let receiver_account_creation_fee_paid =
                   account_creation_fee_of_fees_and_balance ?additional_fee
@@ -1470,33 +1499,40 @@ module Block = struct
       in
       List.zip_exn block.user_cmds (List.rev user_cmd_ids_rev)
     in
-    let balance_id_of_pk_and_balance pk balance =
+    let balance_id_of_info pk balance ~block_sequence_no ~block_secondary_sequence_no =
       let%bind public_key_id =
         Public_key.add_if_doesn't_exist (module Conn) pk
       in
       Balance.add_if_doesn't_exist (module Conn) ~public_key_id ~balance
+        ~block_id ~block_height:(block.height |> Unsigned.UInt32.to_int64) ~block_sequence_no
+        ~block_secondary_sequence_no
     in
-    let balance_id_of_pk_and_balance_opt pk balance_opt =
+    let balance_id_of_info_balance_opt pk balance_opt ~block_sequence_no ~block_secondary_sequence_no =
       Option.value_map balance_opt ~default:(Deferred.Result.return None)
         ~f:(fun balance ->
-          let%map id = balance_id_of_pk_and_balance pk balance in
-          Some id )
+            let%map id = balance_id_of_info pk balance
+                ~block_sequence_no ~block_secondary_sequence_no
+            in
+            Some id )
     in
     (* add user commands to join table *)
     let%bind () =
       deferred_result_list_fold user_cmds_with_ids ~init:()
         ~f:(fun () (user_command, user_command_id) ->
-          let%bind source_balance_id =
-            balance_id_of_pk_and_balance_opt user_command.source
-              user_command.source_balance
-          in
           let%bind fee_payer_balance_id =
-            balance_id_of_pk_and_balance user_command.fee_payer
+            balance_id_of_info user_command.fee_payer
               user_command.fee_payer_balance
+              ~block_sequence_no:user_command.sequence_no ~block_secondary_sequence_no:0
+          in
+          let%bind source_balance_id =
+            balance_id_of_info_balance_opt user_command.source
+              user_command.source_balance
+              ~block_sequence_no:user_command.sequence_no ~block_secondary_sequence_no:0
           in
           let%bind receiver_balance_id =
-            balance_id_of_pk_and_balance_opt user_command.receiver
+            balance_id_of_info_balance_opt user_command.receiver
               user_command.receiver_balance
+              ~block_sequence_no:user_command.sequence_no ~block_secondary_sequence_no:0
           in
           Block_and_signed_command.add_if_doesn't_exist
             (module Conn)
@@ -1536,8 +1572,9 @@ module Block = struct
            , (sequence_no, secondary_sequence_no) )
            ->
           let%bind receiver_balance_id =
-            balance_id_of_pk_and_balance internal_command.receiver
+            balance_id_of_info internal_command.receiver
               internal_command.receiver_balance
+              ~block_sequence_no:internal_command.sequence_no ~block_secondary_sequence_no:internal_command.secondary_sequence_no
           in
           Block_and_internal_command.add_if_doesn't_exist
             (module Conn)

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -752,7 +752,10 @@ module Balance = struct
       (Caqti_request.find
          Caqti_type.(tup2 (tup2 int int64) (tup4 int int64 int int))
          Caqti_type.int
-         {sql| INSERT INTO balances (public_key_id, balance) VALUES (?, ?) RETURNING id |sql})
+         {sql| INSERT INTO balances (public_key_id, balance,
+                                     block_id, block_height, block_sequence_no, block_secondary_sequence_no)
+               VALUES (?, ?, ?, ?, ?, ?)
+               RETURNING id |sql})
       ((public_key_id, balance_to_int64 balance),
        (block_id, block_height, block_sequence_no, block_secondary_sequence_no))
 
@@ -1382,7 +1385,6 @@ module Block = struct
                     ~block_id ~block_height:height
                     ~block_sequence_no:sequence_no
                     ~block_secondary_sequence_no:0
-
                 in
                 let receiver_account_creation_fee_paid =
                   account_creation_fee_of_fees_and_balance ?additional_fee

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -94,7 +94,11 @@ CREATE INDEX idx_chain_status      ON blocks(chain_status);
 
 /* the block_* columns refer to the block containing a user command or internal command that
     results in a balance
-   for a user command, the secondary sequence no is always 0
+   for a balance resulting from a user command, the secondary sequence no is always 0
+   these columns duplicate information available in the
+    blocks_user_commands and blocks_internal_commands tables
+   they are included here to allow Rosetta account queries to consume
+    fewer Postgresql resources
 */
 CREATE TABLE balances
 ( id                           serial PRIMARY KEY

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -104,7 +104,7 @@ CREATE TABLE balances
 ( id                           serial PRIMARY KEY
 , public_key_id                int    NOT NULL REFERENCES public_keys(id)
 , balance                      bigint NOT NULL
-, block_id                     int    NOT NULL REFERENCES blocks(id)
+, block_id                     int    NOT NULL REFERENCES blocks(id) ON DELETE CASCADE
 , block_height                 int    NOT NULL
 , block_sequence_no            int    NOT NULL
 , block_secondary_sequence_no  int    NOT NULL

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -92,14 +92,24 @@ CREATE INDEX idx_blocks_creator_id ON blocks(creator_id);
 CREATE INDEX idx_blocks_height     ON blocks(height);
 CREATE INDEX idx_chain_status      ON blocks(chain_status);
 
+/* the block_* columns refer to the block containing a user command or internal command that
+    results in a balance
+   for a user command, the secondary sequence no is always 0
+*/
 CREATE TABLE balances
-( id            serial PRIMARY KEY
-, public_key_id int    NOT NULL REFERENCES public_keys(id)
-, balance       bigint NOT NULL
+( id                           serial PRIMARY KEY
+, public_key_id                int    NOT NULL REFERENCES public_keys(id)
+, balance                      bigint NOT NULL
+, block_id                     int    NOT NULL REFERENCES blocks(id)
+, block_height                 int    NOT NULL
+, block_sequence_no            int    NOT NULL
+, block_secondary_sequence_no  int    NOT NULL
+, UNIQUE (public_key_id,balance,block_id,block_height,block_sequence_no,block_secondary_sequence_no)
 );
 
 CREATE INDEX idx_balances_id ON balances(id);
 CREATE INDEX idx_balances_public_key_id ON balances(public_key_id);
+CREATE INDEX idx_balances_height_seq_nos ON balances(block_height,block_sequence_no,block_secondary_sequence_no);
 
 CREATE TABLE blocks_user_commands
 ( block_id        int NOT NULL REFERENCES blocks(id) ON DELETE CASCADE

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -112,7 +112,7 @@ let fill_in_user_commands pool block_state_hash =
     Public_key.Compressed.of_base58_check_exn pk_str
   in
   let balance_of_id id ~item =
-    let%map _pk_id, balance =
+    let%map { balance; _ } =
       query_db ~f:(fun db -> Processor.Balance.load db ~id) ~item
     in
     balance |> Unsigned.UInt64.of_int64 |> Currency.Balance.of_uint64
@@ -254,7 +254,7 @@ let fill_in_internal_commands pool block_state_hash =
          ; receiver_balance_id
          }
        ->
-      let%bind _pubkey, receiver_balance_int64 =
+      let%bind { balance = receiver_balance_int64; _ } =
         query_db ~item:"receiver balance" ~f:(fun db ->
             Processor.Balance.load db ~id:receiver_balance_id)
       in

--- a/src/app/migrate-balances-table/dune
+++ b/src/app/migrate-balances-table/dune
@@ -1,0 +1,15 @@
+(executable
+ (package migrate_balances_table)
+ (name migrate_balances_table)
+ (public_name migrate_balances_table)
+ (libraries
+   async
+   core_kernel
+   caqti
+   caqti-async
+   caqti-driver-postgresql
+   logger
+ )
+ (preprocessor_deps ../../config.mlh)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_coda ppx_version ppx_let)))

--- a/src/app/migrate-balances-table/migrate_balances_table.ml
+++ b/src/app/migrate-balances-table/migrate_balances_table.ml
@@ -353,8 +353,8 @@ let main ~archive_uri () =
       let%bind () =
         query_db pool
           ~f:(fun db ->
-            Sql.add_foreign_key_constraint db "blocks_internal_commands"
-              "receiver_balance"
+            Sql.add_balances_foreign_key_constraint db
+              "blocks_internal_commands" "receiver_balance"
               "blocks_internal_commands_receiver_balance_fkey" ())
           ~item:
             "Blocks_internal_commands receiver balance foreign key constraint"
@@ -362,7 +362,7 @@ let main ~archive_uri () =
       let%bind () =
         query_db pool
           ~f:(fun db ->
-            Sql.add_foreign_key_constraint db "blocks_user_commands"
+            Sql.add_balances_foreign_key_constraint db "blocks_user_commands"
               "fee_payer_balance" "blocks_user_commands_fee_payer_balance_fkey"
               ())
           ~item:"Blocks_user_commands fee payer balance foreign key constraint"
@@ -370,17 +370,39 @@ let main ~archive_uri () =
       let%bind () =
         query_db pool
           ~f:(fun db ->
-            Sql.add_foreign_key_constraint db "blocks_user_commands"
+            Sql.add_balances_foreign_key_constraint db "blocks_user_commands"
               "source_balance" "blocks_user_commands_source_balance_fkey" ())
           ~item:"Blocks_user_commands source balance foreign key constraint"
       in
       let%bind () =
         query_db pool
           ~f:(fun db ->
-            Sql.add_foreign_key_constraint db "blocks_user_commands"
+            Sql.add_balances_foreign_key_constraint db "blocks_user_commands"
               "receiver_balance" "blocks_user_commands_receiver_balance_fkey" ())
           ~item:"Blocks_user_commands receiver balance foreign key constraint"
       in
+      let%bind () =
+        query_db pool
+          ~f:(fun db ->
+            Sql.add_blocks_foreign_key_constraint db "blocks_internal_commands"
+              "block_id" "blocks_internal_commands_block_id_fkey" ())
+          ~item:"Blocks_internal_commands block id foreign key constraint"
+      in
+      let%bind () =
+        query_db pool
+          ~f:(fun db ->
+            Sql.add_blocks_foreign_key_constraint db "blocks_user_commands"
+              "block_id" "blocks_user_commands_block_id_fkey" ())
+          ~item:"Blocks_user_commands block id foreign key constraint"
+      in
+      let%bind () =
+        query_db pool
+          ~f:(fun db ->
+            Sql.add_blocks_foreign_key_constraint db "balances" "block_id"
+              "balances_block_id_fkey" ())
+          ~item:"Balances block id foreign key constraint"
+      in
+      [%log info] "Migration successful" ;
       return ()
 
 let () =

--- a/src/app/migrate-balances-table/migrate_balances_table.ml
+++ b/src/app/migrate-balances-table/migrate_balances_table.ml
@@ -1,0 +1,398 @@
+(* migrate_balances_table.ml *)
+
+open Core_kernel
+open Async
+
+let query_db pool ~f ~item =
+  match%bind Caqti_async.Pool.use f pool with
+  | Ok v ->
+      return v
+  | Error msg ->
+      failwithf "Error getting %s from db, error: %s" item
+        (Caqti_error.show msg) ()
+
+let main ~archive_uri () =
+  let logger = Logger.create () in
+  let archive_uri = Uri.of_string archive_uri in
+  match Caqti_async.connect_pool ~max_size:128 archive_uri with
+  | Error e ->
+      [%log fatal]
+        ~metadata:[ ("error", `String (Caqti_error.show e)) ]
+        "Failed to create a Caqti pool for Postgresql" ;
+      exit 1
+  | Ok pool ->
+      [%log info] "Successfully created Caqti pool for Postgresql" ;
+      let drop_and_rename_table table =
+        [%log info] "DROP original %s table, overwrite with temp table" table ;
+        let%bind () =
+          query_db pool
+            ~f:(fun db -> Sql.drop_table db table ())
+            ~item:(sprintf "DROP %s table" table)
+        in
+        query_db pool
+          ~f:(fun db -> Sql.rename_temp_table db table ())
+          ~item:(sprintf "RENAME %s_temp table" table)
+      in
+      let mk_temp_table table =
+        query_db pool
+          ~f:(fun db -> Sql.copy_table_to_temp_table db table ())
+          ~item:(sprintf "temp table: %s" table)
+      in
+      let get_balances_id ~public_key_id ~balance ~block_id ~block_height
+          ~block_sequence_no ~block_secondary_sequence_no =
+        match%bind
+          query_db pool
+            ~f:(fun db ->
+              Sql.find_balance_entry db ~public_key_id ~balance ~block_id
+                ~block_height ~block_sequence_no ~block_secondary_sequence_no)
+            ~item:"find balance entry"
+        with
+        | None ->
+            query_db pool
+              ~f:(fun db ->
+                Sql.insert_balance_entry db ~public_key_id ~balance ~block_id
+                  ~block_height ~block_sequence_no ~block_secondary_sequence_no)
+              ~item:"insert balance entry"
+        | Some id ->
+            return id
+      in
+      let read_cursor name =
+        match%map
+          query_db pool
+            ~f:(fun db -> Sql.current_cursor db name ())
+            ~item:(sprintf "read %s cursor" name)
+        with
+        | Some ndx ->
+            ndx
+        | None ->
+            0
+      in
+      let update_cursor name ndx =
+        query_db pool
+          ~f:(fun db -> Sql.update_cursor db name ndx)
+          ~item:(sprintf "update %s cursor" name)
+      in
+      [%log info] "Checking whether balances table is already migrated" ;
+      let%bind num_balance_columns =
+        query_db pool
+          ~f:(fun db -> Sql.get_column_count db "balances")
+          ~item:"balances column count"
+      in
+      if num_balance_columns = 7 then (
+        [%log info] "Balances table has %d columns, already migrated"
+          num_balance_columns ;
+        Core_kernel.exit 0 ) ;
+      [%log info] "Creating temporary balances table" ;
+      let%bind () =
+        query_db pool
+          ~f:(fun db -> Sql.create_temp_balances_table db ())
+          ~item:"balances temp table"
+      in
+      [%log info] "Creating indexes for temp balances table" ;
+      let%bind () =
+        Deferred.List.iter
+          [ "id"
+          ; "public_key_id"
+          ; "block_id"
+          ; "block_height"
+          ; "block_sequence_no"
+          ; "block_secondary_sequence_no"
+          ] ~f:(fun col ->
+            let table = "balances" in
+            let%bind () =
+              query_db pool
+                ~f:(fun db -> Sql.drop_temp_table_index db table col ())
+                ~item:"drop blocks internal commands index"
+            in
+            query_db pool
+              ~f:(fun db -> Sql.create_temp_table_index db table col ())
+              ~item:"balances index")
+      in
+      let%bind () =
+        query_db pool
+          ~f:(fun db ->
+            Sql.create_temp_table_named_index db "balances"
+              "block_height,block_sequence_no,block_secondary_sequence_no"
+              "height_seq_nos" ())
+          ~item:"balances index"
+      in
+      [%log info] "Creating temporary blocks internal commands table" ;
+      let%bind () = mk_temp_table "blocks_internal_commands" in
+      [%log info]
+        "Creating indexes for temporary blocks internal commands table" ;
+      let%bind () =
+        Deferred.List.iter
+          [ "block_id"
+          ; "internal_command_id"
+          ; "sequence_no"
+          ; "secondary_sequence_no"
+          ; "receiver_balance"
+          ] ~f:(fun col ->
+            let table = "blocks_internal_commands" in
+            let%bind () =
+              query_db pool
+                ~f:(fun db -> Sql.drop_temp_table_index db table col ())
+                ~item:"drop blocks internal commands index"
+            in
+            query_db pool
+              ~f:(fun db -> Sql.create_temp_table_index db table col ())
+              ~item:"create blocks internal commands index")
+      in
+      [%log info] "Creating temporary blocks user commands table" ;
+      let%bind () = mk_temp_table "blocks_user_commands" in
+      [%log info] "Creating indexes for temporary blocks user commands table" ;
+      let%bind () =
+        Deferred.List.iter [ "block_id"; "user_command_id"; "sequence_no" ]
+          ~f:(fun col ->
+            let table = "blocks_user_commands" in
+            let%bind () =
+              query_db pool
+                ~f:(fun db -> Sql.drop_temp_table_index db table col ())
+                ~item:"drop blocks internal commands index"
+            in
+            query_db pool
+              ~f:(fun db -> Sql.create_temp_table_index db table col ())
+              ~item:"blocks user commands index")
+      in
+      let internal_cmds_cursor_name = "internal_cmds" in
+      let fee_payer_cursor_name = "fee_payer" in
+      let source_cursor_name = "source" in
+      let receiver_cursor_name = "receiver" in
+      [%log info] "Creating cursors" ;
+      let%bind () =
+        Deferred.List.iter
+          [ internal_cmds_cursor_name
+          ; fee_payer_cursor_name
+          ; source_cursor_name
+          ; receiver_cursor_name
+          ] ~f:(fun cursor ->
+            let%bind () =
+              query_db pool
+                ~f:(fun db -> Sql.create_cursor db cursor ())
+                ~item:(sprintf "Create cursor %s" cursor)
+            in
+            match%bind
+              query_db pool
+                ~f:(fun db -> Sql.current_cursor db cursor ())
+                ~item:(sprintf "Current cursor %s" cursor)
+            with
+            | None ->
+                query_db pool
+                  ~f:(fun db -> Sql.initialize_cursor db cursor ())
+                  ~item:(sprintf "Initialize cursor %s" cursor)
+            | Some _ ->
+                return ())
+      in
+      [%log info] "Getting internal commands" ;
+      let%bind internal_commands =
+        query_db pool
+          ~f:(fun db -> Sql.get_internal_commands db ())
+          ~item:"Get internal commands"
+      in
+      [%log info] "Updating receiver balances in %d internal commands"
+        (List.length internal_commands) ;
+      let%bind internal_cmd_cursor = read_cursor internal_cmds_cursor_name in
+      if internal_cmd_cursor > 0 then
+        [%log info] "Skipping %d internal commands, already processed"
+          internal_cmd_cursor ;
+      let%bind () =
+        Deferred.List.iteri internal_commands
+          ~f:(fun
+               ndx
+               ( public_key_id
+               , balance
+               , ( block_id
+                 , block_height
+                 , block_sequence_no
+                 , block_secondary_sequence_no )
+               , internal_command_id )
+             ->
+            if ndx < internal_cmd_cursor then return ()
+            else
+              let%bind new_balance_id =
+                get_balances_id ~public_key_id ~balance ~block_id ~block_height
+                  ~block_sequence_no ~block_secondary_sequence_no
+              in
+              let%bind () =
+                query_db pool
+                  ~f:(fun db ->
+                    Sql.update_internal_command_receiver_balance db
+                      ~new_balance_id ~block_id ~internal_command_id
+                      ~block_sequence_no ~block_secondary_sequence_no)
+                  ~item:"update internal command receiver balance"
+              in
+              (* update cursor only periodically, otherwise too slow *)
+              if ndx % 1000 = 0 then (
+                [%log info] "Updated internal command receiver balance: %d" ndx ;
+                update_cursor internal_cmds_cursor_name ndx )
+              else return ())
+      in
+      [%log info] "Getting user command fee payer balance information" ;
+      let%bind user_command_fee_payers =
+        query_db pool
+          ~f:(fun db -> Sql.get_user_command_fee_payers db ())
+          ~item:"Get user commands with fee payer balances"
+      in
+      [%log info] "Updating fee payer balances in %d user commands"
+        (List.length user_command_fee_payers) ;
+      let%bind fee_payer_cursor = read_cursor fee_payer_cursor_name in
+      if fee_payer_cursor > 0 then
+        [%log info]
+          "Skipping %d user commands for fee payers, already processed"
+          fee_payer_cursor ;
+      let%bind () =
+        Deferred.List.iteri user_command_fee_payers
+          ~f:(fun
+               ndx
+               ( (block_id, block_height, block_sequence_no, user_command_id)
+               , (public_key_id, balance) )
+             ->
+            if ndx < fee_payer_cursor then return ()
+            else
+              let%bind new_balance_id =
+                get_balances_id ~public_key_id ~balance ~block_id ~block_height
+                  ~block_sequence_no ~block_secondary_sequence_no:0
+              in
+              let%bind () =
+                query_db pool
+                  ~f:(fun db ->
+                    Sql.update_user_command_fee_payer_balance db ~new_balance_id
+                      ~block_id ~user_command_id ~block_sequence_no)
+                  ~item:"update user command fee payer balance"
+              in
+              if ndx % 1000 = 0 then (
+                [%log info] "Updated user command fee payer balance: %d" ndx ;
+                update_cursor fee_payer_cursor_name ndx )
+              else return ())
+      in
+      [%log info] "Getting user command source balance information" ;
+      let%bind user_command_sources =
+        query_db pool
+          ~f:(fun db -> Sql.get_user_command_sources db ())
+          ~item:"Get user commands with source balances"
+      in
+      [%log info] "Updating source balances in %d user commands"
+        (List.length user_command_sources) ;
+      let%bind source_cursor = read_cursor source_cursor_name in
+      if source_cursor > 0 then
+        [%log info]
+          "Skipping %d user commands for source payers, already processed"
+          source_cursor ;
+      let%bind () =
+        Deferred.List.iteri user_command_sources
+          ~f:(fun
+               ndx
+               ( (block_id, block_height, block_sequence_no, user_command_id)
+               , (public_key_id, balance) )
+             ->
+            if ndx < source_cursor then return ()
+            else
+              let%bind new_balance_id =
+                get_balances_id ~public_key_id ~balance ~block_id ~block_height
+                  ~block_sequence_no ~block_secondary_sequence_no:0
+              in
+              let%bind () =
+                query_db pool
+                  ~f:(fun db ->
+                    Sql.update_user_command_source_balance db ~new_balance_id
+                      ~block_id ~user_command_id ~block_sequence_no)
+                  ~item:"update user command source balance"
+              in
+              if ndx % 1000 = 0 then (
+                [%log info] "Updated user command source balance: %d" ndx ;
+                update_cursor source_cursor_name ndx )
+              else return ())
+      in
+      [%log info] "Getting user command receiver balance information" ;
+      let%bind user_command_receivers =
+        query_db pool
+          ~f:(fun db -> Sql.get_user_command_receivers db ())
+          ~item:"Get user commands with receiver balances"
+      in
+      [%log info] "Updating receiver balances in %d user commands"
+        (List.length user_command_receivers) ;
+      let%bind receiver_cursor = read_cursor receiver_cursor_name in
+      if receiver_cursor > 0 then
+        [%log info]
+          "Skipping %d user commands for source payers, already processed"
+          receiver_cursor ;
+      let%bind () =
+        Deferred.List.iteri user_command_receivers
+          ~f:(fun
+               ndx
+               ( (block_id, block_height, block_sequence_no, user_command_id)
+               , (public_key_id, balance) )
+             ->
+            if ndx < receiver_cursor then return ()
+            else
+              let%bind new_balance_id =
+                get_balances_id ~public_key_id ~balance ~block_id ~block_height
+                  ~block_sequence_no ~block_secondary_sequence_no:0
+              in
+              let%bind () =
+                query_db pool
+                  ~f:(fun db ->
+                    Sql.update_user_command_receiver_balance db ~new_balance_id
+                      ~block_id ~user_command_id ~block_sequence_no)
+                  ~item:"update user command receiver balance"
+              in
+              if ndx % 1000 = 0 then (
+                [%log info] "Updated user command receiver balance: %d" ndx ;
+                update_cursor receiver_cursor_name ndx )
+              else return ())
+      in
+      [%log info]
+        "DROP original blocks_internal_command table, overwrite with temp table" ;
+      let%bind () = drop_and_rename_table "blocks_internal_commands" in
+      [%log info]
+        "DROP original blocks_user_command table, overwrite with temp table" ;
+      let%bind () = drop_and_rename_table "blocks_user_commands" in
+      [%log info] "DROP original balances table, overwrite with temp table" ;
+      let%bind () = drop_and_rename_table "balances" in
+      [%log info] "Adding back foreign key constraints" ;
+      let%bind () =
+        query_db pool
+          ~f:(fun db ->
+            Sql.add_foreign_key_constraint db "blocks_internal_commands"
+              "receiver_balance"
+              "blocks_internal_commands_receiver_balance_fkey" ())
+          ~item:
+            "Blocks_internal_commands receiver balance foreign key constraint"
+      in
+      let%bind () =
+        query_db pool
+          ~f:(fun db ->
+            Sql.add_foreign_key_constraint db "blocks_user_commands"
+              "fee_payer_balance" "blocks_user_commands_fee_payer_balance_fkey"
+              ())
+          ~item:"Blocks_user_commands fee payer balance foreign key constraint"
+      in
+      let%bind () =
+        query_db pool
+          ~f:(fun db ->
+            Sql.add_foreign_key_constraint db "blocks_user_commands"
+              "source_balance" "blocks_user_commands_source_balance_fkey" ())
+          ~item:"Blocks_user_commands source balance foreign key constraint"
+      in
+      let%bind () =
+        query_db pool
+          ~f:(fun db ->
+            Sql.add_foreign_key_constraint db "blocks_user_commands"
+              "receiver_balance" "blocks_user_commands_receiver_balance_fkey" ())
+          ~item:"Blocks_user_commands receiver balance foreign key constraint"
+      in
+      return ()
+
+let () =
+  Command.(
+    run
+      (let open Let_syntax in
+      Command.async ~summary:"Migrate balances table to extended balances table"
+        (let%map archive_uri =
+           Param.flag "--archive-uri"
+             ~doc:
+               "URI URI for connecting to the archive database (e.g., \
+                postgres://$USER@localhost:5432/archiver)"
+             Param.(required string)
+         in
+         main ~archive_uri)))

--- a/src/app/migrate-balances-table/sql.ml
+++ b/src/app/migrate-balances-table/sql.ml
@@ -1,0 +1,297 @@
+(* sql.ml -- (Postgresql) SQL queries for migrate_balances_table *)
+
+open Core_kernel
+
+let create_temp_balances_table (module Conn : Caqti_async.CONNECTION) =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.unit
+       {sql| CREATE TABLE IF NOT EXISTS balances_temp
+           ( id                           serial PRIMARY KEY
+           , public_key_id                int    NOT NULL REFERENCES public_keys(id)
+           , balance                      bigint NOT NULL
+           , block_id                     int    NOT NULL REFERENCES blocks(id)
+           , block_height                 int    NOT NULL
+           , block_sequence_no            int    NOT NULL
+           , block_secondary_sequence_no  int    NOT NULL
+           , UNIQUE (public_key_id,balance,block_id,block_height,block_sequence_no,block_secondary_sequence_no)
+           )
+      |sql})
+
+let copy_table_to_temp_table (module Conn : Caqti_async.CONNECTION) table =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.unit
+       (sprintf
+          {sql| CREATE TABLE IF NOT EXISTS %s_temp AS (SELECT * FROM %s)
+                |sql}
+          table table))
+
+let create_table_index (module Conn : Caqti_async.CONNECTION) table col =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.unit
+       (sprintf
+          {sql| CREATE INDEX IF NOT EXISTS idx_%s_%s ON %s(%s)
+                |sql}
+          table col table col))
+
+let create_temp_table_index (module Conn : Caqti_async.CONNECTION) table col =
+  create_table_index (module Conn) (sprintf "%s_temp" table) col
+
+let create_table_named_index (module Conn : Caqti_async.CONNECTION) table col
+    name =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.unit
+       (sprintf
+          {sql| CREATE INDEX IF NOT EXISTS idx_%s_%s ON %s(%s)
+                |sql}
+          table name table col))
+
+let create_temp_table_named_index (module Conn : Caqti_async.CONNECTION) table
+    col name =
+  create_table_named_index (module Conn) (sprintf "%s_temp" table) col name
+
+let drop_table_index (module Conn : Caqti_async.CONNECTION) table col =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.unit
+       (sprintf {sql| DROP INDEX IF EXISTS idx_%s_%s
+          |sql} table col))
+
+let drop_temp_table_index (module Conn : Caqti_async.CONNECTION) table col =
+  drop_table_index (module Conn) (sprintf "%s_temp" table) col
+
+let create_cursor (module Conn : Caqti_async.CONNECTION) name =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.unit
+       (sprintf
+          {sql| CREATE TABLE IF NOT EXISTS %s_cursor
+                      ( value int NOT NULL)
+                 |sql}
+          name))
+
+let initialize_cursor (module Conn : Caqti_async.CONNECTION) name =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.unit
+       (sprintf
+          {sql| INSERT INTO %s_cursor (value) VALUES (0)
+                |sql}
+          name))
+
+let current_cursor (module Conn : Caqti_async.CONNECTION) name =
+  Conn.find_opt
+    (Caqti_request.find_opt Caqti_type.unit Caqti_type.int
+       (sprintf {sql| SELECT value FROM %s_cursor
+                |sql} name))
+
+let update_cursor (module Conn : Caqti_async.CONNECTION) name ndx =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.int
+       (sprintf
+          {sql| UPDATE %s_cursor SET value = $1
+                |sql}
+          name))
+    ndx
+
+let drop_foreign_key_constraint (module Conn : Caqti_async.CONNECTION) table
+    foreign_key =
+  let sql =
+    sprintf
+      {sql| ALTER TABLE %s
+            DROP CONSTRAINT %s
+      |sql}
+      table foreign_key
+  in
+  Conn.exec (Caqti_request.exec Caqti_type.unit sql)
+
+let add_foreign_key_constraint (module Conn : Caqti_async.CONNECTION) table col
+    foreign_key =
+  let sql =
+    sprintf
+      {sql| ALTER TABLE %s
+            ADD CONSTRAINT %s
+            FOREIGN KEY (%s)
+            REFERENCES balances(id)
+      |sql}
+      table foreign_key col
+  in
+  Conn.exec (Caqti_request.exec Caqti_type.unit sql)
+
+let find_balance_entry (module Conn : Caqti_async.CONNECTION) ~public_key_id
+    ~balance ~block_id ~block_height ~block_sequence_no
+    ~block_secondary_sequence_no =
+  Conn.find_opt
+    (Caqti_request.find_opt
+       Caqti_type.(tup3 int int64 (tup4 int int int int))
+       Caqti_type.int
+       {sql| SELECT id
+            FROM balances_temp
+            WHERE public_key_id = $1
+            AND balance = $2
+            AND block_id = $3
+            AND block_height = $4
+            AND block_sequence_no = $5
+            AND block_secondary_sequence_no = $6
+      |sql})
+    ( public_key_id
+    , balance
+    , (block_id, block_height, block_sequence_no, block_secondary_sequence_no)
+    )
+
+let insert_balance_entry (module Conn : Caqti_async.CONNECTION) ~public_key_id
+    ~balance ~block_id ~block_height ~block_sequence_no
+    ~block_secondary_sequence_no =
+  Conn.find
+    (Caqti_request.find
+       Caqti_type.(tup3 int int64 (tup4 int int int int))
+       Caqti_type.int
+       {sql| INSERT INTO balances_temp
+            ( public_key_id
+            , balance
+            , block_id
+            , block_height
+            , block_sequence_no
+            , block_secondary_sequence_no)
+            VALUES
+            ( $1
+            , $2
+            , $3
+            , $4
+            , $5
+            , $6)
+            RETURNING id
+      |sql})
+    ( public_key_id
+    , balance
+    , (block_id, block_height, block_sequence_no, block_secondary_sequence_no)
+    )
+
+let get_internal_commands (module Conn : Caqti_async.CONNECTION) =
+  Conn.collect_list
+    (Caqti_request.collect Caqti_type.unit
+       Caqti_type.(tup4 int int64 (tup4 int int int int) int)
+       {sql| SELECT bal.public_key_id,bal.balance,bic.block_id,blocks.height,bic.sequence_no,bic.secondary_sequence_no,
+            internal_command_id
+            FROM blocks_internal_commands bic
+            INNER JOIN blocks ON blocks.id = bic.block_id
+            INNER JOIN balances bal ON bal.id = receiver_balance
+            ORDER BY (bal.public_key_id,bal.balance,bic.block_id,blocks.height,bic.sequence_no,bic.secondary_sequence_no,
+                      internal_command_id)
+      |sql})
+
+let update_internal_command_receiver_balance
+    (module Conn : Caqti_async.CONNECTION) ~new_balance_id ~block_id
+    ~internal_command_id ~block_sequence_no ~block_secondary_sequence_no =
+  Conn.exec
+    (Caqti_request.exec
+       Caqti_type.(tup2 int (tup4 int int int int))
+       {sql| UPDATE blocks_internal_commands_temp SET receiver_balance = $1
+          WHERE block_id = $2
+          AND internal_command_id = $3
+          AND sequence_no = $4
+          AND secondary_sequence_no = $5
+      |sql})
+    ( new_balance_id
+    , ( block_id
+      , internal_command_id
+      , block_sequence_no
+      , block_secondary_sequence_no ) )
+
+let get_user_command_fee_payers (module Conn : Caqti_async.CONNECTION) =
+  Conn.collect_list
+    (Caqti_request.collect Caqti_type.unit
+       Caqti_type.(tup2 (tup4 int int int int) (tup2 int int64))
+       {sql| SELECT buc.block_id,blocks.height,buc.sequence_no,user_command_id,
+                    bal_fee_payer.public_key_id,bal_fee_payer.balance
+             FROM blocks_user_commands buc
+             INNER JOIN blocks ON blocks.id = buc.block_id
+             INNER JOIN balances bal_fee_payer ON bal_fee_payer.id = fee_payer_balance
+             ORDER BY (buc.block_id,blocks.height,buc.sequence_no,user_command_id,
+                       bal_fee_payer.public_key_id,bal_fee_payer.balance)
+      |sql})
+
+let get_user_command_sources (module Conn : Caqti_async.CONNECTION) =
+  Conn.collect_list
+    (Caqti_request.collect Caqti_type.unit
+       Caqti_type.(tup2 (tup4 int int int int) (tup2 int int64))
+       {sql| SELECT buc.block_id,blocks.height,buc.sequence_no,user_command_id,
+                    bal_source.public_key_id,bal_source.balance
+             FROM blocks_user_commands buc
+             INNER JOIN blocks ON blocks.id = buc.block_id
+             INNER JOIN balances bal_source ON bal_source.id = source_balance
+             WHERE source_balance IS NOT NULL
+             ORDER BY (buc.block_id,blocks.height,buc.sequence_no,user_command_id,
+                       bal_source.public_key_id,bal_source.balance)
+      |sql})
+
+let get_user_command_receivers (module Conn : Caqti_async.CONNECTION) =
+  Conn.collect_list
+    (Caqti_request.collect Caqti_type.unit
+       Caqti_type.(tup2 (tup4 int int int int) (tup2 int int64))
+       {sql| SELECT buc.block_id,blocks.height,buc.sequence_no,user_command_id,
+                    bal_receiver.public_key_id,bal_receiver.balance
+             FROM blocks_user_commands buc
+             INNER JOIN blocks ON blocks.id = buc.block_id
+             INNER JOIN balances bal_receiver ON bal_receiver.id = receiver_balance
+             WHERE receiver_balance IS NOT NULL
+             ORDER BY (buc.block_id,blocks.height,buc.sequence_no,user_command_id,
+                       bal_receiver.public_key_id,bal_receiver.balance)
+      |sql})
+
+let update_user_command_fee_payer_balance (module Conn : Caqti_async.CONNECTION)
+    ~new_balance_id ~block_id ~user_command_id ~block_sequence_no =
+  Conn.exec
+    (Caqti_request.exec
+       Caqti_type.(tup2 int (tup3 int int int))
+       {sql| UPDATE blocks_user_commands_temp SET fee_payer_balance = $1
+          WHERE block_id = $2
+          AND user_command_id = $3
+          AND sequence_no = $4
+      |sql})
+    (new_balance_id, (block_id, user_command_id, block_sequence_no))
+
+let update_user_command_source_balance (module Conn : Caqti_async.CONNECTION)
+    ~new_balance_id ~block_id ~user_command_id ~block_sequence_no =
+  Conn.exec
+    (Caqti_request.exec
+       Caqti_type.(tup2 int (tup3 int int int))
+       {sql| UPDATE blocks_user_commands_temp SET source_balance = $1
+          WHERE block_id = $2
+          AND user_command_id = $3
+          AND sequence_no = $4
+          AND source_balance IS NOT NULL
+      |sql})
+    (new_balance_id, (block_id, user_command_id, block_sequence_no))
+
+let update_user_command_receiver_balance (module Conn : Caqti_async.CONNECTION)
+    ~new_balance_id ~block_id ~user_command_id ~block_sequence_no =
+  Conn.exec
+    (Caqti_request.exec
+       Caqti_type.(tup2 int (tup3 int int int))
+       {sql| UPDATE blocks_user_commands_temp SET receiver_balance = $1
+          WHERE block_id = $2
+          AND user_command_id = $3
+          AND sequence_no = $4
+          AND receiver_balance IS NOT NULL
+      |sql})
+    (new_balance_id, (block_id, user_command_id, block_sequence_no))
+
+let drop_table (module Conn : Caqti_async.CONNECTION) table =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.unit
+       (sprintf {sql| DROP TABLE %s
+                |sql} table))
+
+let rename_temp_table (module Conn : Caqti_async.CONNECTION) table =
+  Conn.exec
+    (Caqti_request.exec Caqti_type.unit
+       (sprintf
+          {sql| ALTER TABLE %s_temp
+                RENAME TO %s
+          |sql}
+          table table))
+
+let get_column_count (module Conn : Caqti_async.CONNECTION) table =
+  Conn.find
+    (Caqti_request.find Caqti_type.string Caqti_type.int
+       {sql| SELECT COUNT(*) FROM information_schema.columns
+             WHERE table_name=$1
+       |sql})
+    table

--- a/src/app/migrate-balances-table/sql.ml
+++ b/src/app/migrate-balances-table/sql.ml
@@ -101,14 +101,27 @@ let drop_foreign_key_constraint (module Conn : Caqti_async.CONNECTION) table
   in
   Conn.exec (Caqti_request.exec Caqti_type.unit sql)
 
-let add_foreign_key_constraint (module Conn : Caqti_async.CONNECTION) table col
-    foreign_key =
+let add_balances_foreign_key_constraint (module Conn : Caqti_async.CONNECTION)
+    table col foreign_key =
   let sql =
     sprintf
       {sql| ALTER TABLE %s
             ADD CONSTRAINT %s
             FOREIGN KEY (%s)
             REFERENCES balances(id)
+      |sql}
+      table foreign_key col
+  in
+  Conn.exec (Caqti_request.exec Caqti_type.unit sql)
+
+let add_blocks_foreign_key_constraint (module Conn : Caqti_async.CONNECTION)
+    table col foreign_key =
+  let sql =
+    sprintf
+      {sql| ALTER TABLE %s
+            ADD CONSTRAINT %s
+            FOREIGN KEY (%s)
+            REFERENCES blocks(id)
       |sql}
       table foreign_key col
   in

--- a/src/app/migrate-balances-table/sql.ml
+++ b/src/app/migrate-balances-table/sql.ml
@@ -108,7 +108,7 @@ let add_balances_foreign_key_constraint (module Conn : Caqti_async.CONNECTION)
       {sql| ALTER TABLE %s
             ADD CONSTRAINT %s
             FOREIGN KEY (%s)
-            REFERENCES balances(id)
+            REFERENCES balances(id) ON DELETE CASCADE
       |sql}
       table foreign_key col
   in
@@ -121,7 +121,7 @@ let add_blocks_foreign_key_constraint (module Conn : Caqti_async.CONNECTION)
       {sql| ALTER TABLE %s
             ADD CONSTRAINT %s
             FOREIGN KEY (%s)
-            REFERENCES blocks(id)
+            REFERENCES blocks(id) ON DELETE CASCADE
       |sql}
       table foreign_key col
   in

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -38,6 +38,13 @@ type output =
   }
 [@@deriving yojson]
 
+type balance_block_data =
+  { block_id : int
+  ; block_height : int64
+  ; sequence_no : int
+  ; secondary_sequence_no : int
+  }
+
 let error_count = ref 0
 
 let constraint_constants = Genesis_constants.Constraint_constants.compiled
@@ -150,20 +157,25 @@ let pk_of_pk_id pool pk_id : Account.key Deferred.t =
           failwithf "Error retrieving public key with id %d, error: %s" pk_id
             (Caqti_error.show msg) () )
 
-let balance_of_id_and_pk_id pool ~id ~pk_id : Currency.Balance.t Deferred.t =
-  let open Deferred.Let_syntax in
-  match%map
-    Caqti_async.Pool.use (fun db -> Sql.Balance.run db ~id ~pk_id) pool
-  with
-  | Ok (Some balance) ->
-      balance |> Unsigned.UInt64.of_int64 |> Currency.Balance.of_uint64
-  | Ok None ->
-      failwithf "Could not find balance with id %d and public key %d" id pk_id
-        ()
-  | Error msg ->
-      failwithf
-        "Error retrieving balance with id %d and public key %d, error: %s" id
-        pk_id (Caqti_error.show msg) ()
+let balance_info_of_id pool ~id =
+  query_db pool
+    ~f:(fun db -> Archive_lib.Processor.Balance.load db ~id)
+    ~item:"balance info of id"
+
+let internal_command_to_balance_block_data
+    (internal_cmd : Sql.Internal_command.t) =
+  { block_id = internal_cmd.block_id
+  ; block_height = internal_cmd.block_height
+  ; sequence_no = internal_cmd.sequence_no
+  ; secondary_sequence_no = internal_cmd.secondary_sequence_no
+  }
+
+let user_command_to_balance_block_data (user_cmd : Sql.User_command.t) =
+  { block_id = user_cmd.block_id
+  ; block_height = user_cmd.block_height
+  ; sequence_no = user_cmd.sequence_no
+  ; secondary_sequence_no = 0
+  }
 
 let epoch_staking_id_of_state_hash ~logger pool state_hash =
   match%map
@@ -334,12 +346,16 @@ let cache_fee_transfer_via_coinbase pool (internal_cmd : Sql.Internal_command.t)
   | _ ->
       Deferred.unit
 
+(* balance_block_data come from a loaded internal or user command, which
+    includes data from the blocks table and
+    - for internal commands, the tables internal_commands and blocks_internals_commands
+    - for user commands, the tables user_commands and blocks_user_commands
+   we compare those against the same-named values in the balances row
+*)
 let verify_balance ~logger ~pool ~ledger ~who ~balance_id ~pk_id ~token_int64
-    ~continue_on_error =
+    ~balance_block_data ~continue_on_error =
   let%bind pk = pk_of_pk_id pool pk_id in
-  let%map claimed_balance =
-    balance_of_id_and_pk_id pool ~id:balance_id ~pk_id
-  in
+  let%map balance_info = balance_info_of_id pool ~id:balance_id in
   let token = token_int64 |> Unsigned.UInt64.of_int64 |> Token_id.of_uint64 in
   let account_id = Account_id.create pk token in
   let actual_balance =
@@ -360,12 +376,58 @@ let verify_balance ~logger ~pool ~ledger ~who ~balance_id ~pk_id ~token_int64
           (Signature_lib.Public_key.Compressed.to_base58_check pk)
           (Token_id.to_string token) ()
   in
+  let claimed_balance =
+    balance_info.balance |> Unsigned.UInt64.of_int64
+    |> Currency.Balance.of_uint64
+  in
   if not (Currency.Balance.equal actual_balance claimed_balance) then (
     [%log error] "Claimed balance does not match actual balance in ledger"
       ~metadata:
         [ ("who", `String who)
         ; ("claimed_balance", Currency.Balance.to_yojson claimed_balance)
         ; ("actual_balance", Currency.Balance.to_yojson actual_balance)
+        ] ;
+    if continue_on_error then incr error_count else Core_kernel.exit 1 ) ;
+  let { block_id; block_height; sequence_no; secondary_sequence_no } =
+    balance_block_data
+  in
+  if not (block_id = balance_info.block_id) then (
+    [%log error]
+      "Block id from command does not match block id in balances table"
+      ~metadata:
+        [ ("who", `String who)
+        ; ("block_id_command", `Int block_id)
+        ; ("block_id_balances", `Int balance_info.block_id)
+        ] ;
+    if continue_on_error then incr error_count else Core_kernel.exit 1 ) ;
+  if not (Int64.equal block_height balance_info.block_height) then (
+    [%log error]
+      "Block height from command does not match block height in balances table"
+      ~metadata:
+        [ ("who", `String who)
+        ; ("block_height_command", `String (Int64.to_string block_height))
+        ; ( "block_height_balances"
+          , `String (Int64.to_string balance_info.block_height) )
+        ] ;
+    if continue_on_error then incr error_count else Core_kernel.exit 1 ) ;
+  if not (sequence_no = balance_info.block_sequence_no) then (
+    [%log error]
+      "Sequence no from command does not match sequence no in balances table"
+      ~metadata:
+        [ ("who", `String who)
+        ; ("block_sequence_no_command", `Int sequence_no)
+        ; ("block_sequence_no_balances", `Int balance_info.block_sequence_no)
+        ] ;
+    if continue_on_error then incr error_count else Core_kernel.exit 1 ) ;
+  if not (secondary_sequence_no = balance_info.block_secondary_sequence_no) then (
+    [%log error]
+      "Secondary sequence no from command does not match secondary sequence no \
+       in balances table"
+      ~metadata:
+        [ ("who", `String who)
+        ; ("block_secondary_sequence_no_command", `Int secondary_sequence_no)
+        ; ( "block_secondary_sequence_no_balances"
+          , `Int balance_info.block_secondary_sequence_no )
         ] ;
     if continue_on_error then incr error_count else Core_kernel.exit 1 )
 
@@ -376,9 +438,11 @@ let account_creation_fee_int64 =
   Currency.Fee.to_int constraint_constants.account_creation_fee |> Int64.of_int
 
 let verify_account_creation_fee ~logger ~pool ~receiver_account_creation_fee
-    ~balance_id ~pk_id ~fee ~continue_on_error =
-  let%map claimed_balance =
-    balance_of_id_and_pk_id pool ~id:balance_id ~pk_id
+    ~balance_id ~fee ~continue_on_error =
+  let%map balance_info = balance_info_of_id pool ~id:balance_id in
+  let claimed_balance =
+    balance_info.balance |> Unsigned.UInt64.of_int64
+    |> Currency.Balance.of_uint64
   in
   let balance_uint64 = Currency.Balance.to_uint64 claimed_balance in
   let fee_uint64 = Currency.Fee.to_uint64 fee in
@@ -488,9 +552,10 @@ let run_internal_command ~logger ~pool ~ledger (cmd : Sql.Internal_command.t)
   let balance_id = cmd.receiver_balance in
   let token_int64 = cmd.token in
   let receiver_account_creation_fee = cmd.receiver_account_creation_fee_paid in
+  let balance_block_data = internal_command_to_balance_block_data cmd in
   let%bind () =
     verify_account_creation_fee ~logger ~pool ~receiver_account_creation_fee
-      ~balance_id ~pk_id ~fee ~continue_on_error
+      ~balance_id ~fee ~continue_on_error
   in
   let open Mina_base.Ledger in
   match cmd.type_ with
@@ -505,7 +570,8 @@ let run_internal_command ~logger ~pool ~ledger (cmd : Sql.Internal_command.t)
       match undo_or_error with
       | Ok _undo ->
           verify_balance ~logger ~pool ~ledger ~who:"fee transfer receiver"
-            ~balance_id ~pk_id ~token_int64 ~continue_on_error
+            ~balance_id ~pk_id ~token_int64 ~balance_block_data
+            ~continue_on_error
       | Error err ->
           fail_on_error err )
   | "coinbase" -> (
@@ -531,7 +597,8 @@ let run_internal_command ~logger ~pool ~ledger (cmd : Sql.Internal_command.t)
       match undo_or_error with
       | Ok _undo ->
           verify_balance ~logger ~pool ~ledger ~who:"coinbase receiver"
-            ~balance_id ~pk_id ~token_int64 ~continue_on_error
+            ~balance_id ~pk_id ~token_int64 ~balance_block_data
+            ~continue_on_error
       | Error err ->
           fail_on_error err )
   | "fee_transfer_via_coinbase" ->
@@ -572,14 +639,16 @@ let apply_combined_fee_transfer ~logger ~pool ~ledger ~continue_on_error
   in
   match applied_or_error with
   | Ok _ ->
+      let balance_block_data = internal_command_to_balance_block_data cmd1 in
       let%bind () =
         verify_balance ~logger ~pool ~ledger ~who:"combined fee transfer (1)"
           ~balance_id:cmd1.receiver_balance ~pk_id:cmd1.receiver_id
-          ~token_int64:cmd1.token ~continue_on_error
+          ~token_int64:cmd1.token ~balance_block_data ~continue_on_error
       in
+      let balance_block_data = internal_command_to_balance_block_data cmd2 in
       verify_balance ~logger ~pool ~ledger ~who:"combined fee transfer (2)"
         ~balance_id:cmd2.receiver_balance ~pk_id:cmd2.receiver_id
-        ~token_int64:cmd2.token ~continue_on_error
+        ~token_int64:cmd2.token ~balance_block_data ~continue_on_error
   | Error err ->
       Error.tag_arg err "Error applying combined fee transfer"
         ("sequence number", cmd1.sequence_no)
@@ -702,11 +771,13 @@ let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t)
         | _, None ->
             cmd.token
       in
+      let balance_block_data = user_command_to_balance_block_data cmd in
       let%bind () =
         match cmd.source_balance with
         | Some balance_id ->
             verify_balance ~logger ~pool ~ledger ~who:"source" ~balance_id
-              ~pk_id:cmd.source_id ~token_int64 ~continue_on_error
+              ~pk_id:cmd.source_id ~token_int64 ~balance_block_data
+              ~continue_on_error
         | None ->
             return ()
       in
@@ -714,13 +785,14 @@ let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t)
         match cmd.receiver_balance with
         | Some balance_id ->
             verify_balance ~logger ~pool ~ledger ~who:"receiver" ~balance_id
-              ~pk_id:cmd.receiver_id ~token_int64 ~continue_on_error
+              ~pk_id:cmd.receiver_id ~token_int64 ~balance_block_data
+              ~continue_on_error
         | None ->
             return ()
       in
       verify_balance ~logger ~pool ~ledger ~who:"fee payer"
         ~balance_id:cmd.fee_payer_balance ~pk_id:cmd.fee_payer_id
-        ~token_int64:cmd.fee_token ~continue_on_error
+        ~token_int64:cmd.fee_token ~balance_block_data ~continue_on_error
   | Error err ->
       Error.tag_arg err "User command failed on replay"
         ( ("global slot_since_genesis", cmd.global_slot_since_genesis)

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -89,6 +89,13 @@ module Block = struct
   let get_unparented (module Conn : Caqti_async.CONNECTION) () =
     Conn.collect_list unparented_query ()
 
+  let get_height_query =
+    Caqti_request.find Caqti_type.int Caqti_type.int64
+      {sql| SELECT height FROM blocks WHERE id = $1 |sql}
+
+  let get_height (module Conn : Caqti_async.CONNECTION) ~block_id =
+    Conn.find get_height_query block_id
+
   let max_slot_query =
     Caqti_request.find Caqti_type.unit Caqti_type.int
       {sql| SELECT MAX(global_slot_since_genesis) FROM blocks |sql}
@@ -150,6 +157,7 @@ module User_command = struct
     ; memo : string
     ; nonce : int64
     ; block_id : int
+    ; block_height : int64
     ; global_slot_since_genesis : int64
     ; txn_global_slot_since_genesis : int64
     ; sequence_no : int
@@ -179,6 +187,7 @@ module User_command = struct
         ; int
         ; int64
         ; int64
+        ; int64
         ; int
         ; string
         ; option int64
@@ -194,7 +203,7 @@ module User_command = struct
   let query =
     Caqti_request.collect Caqti_type.int typ
       {sql| SELECT type,fee_payer_id, source_id,receiver_id,fee,fee_token,token,amount,valid_until,memo,nonce,
-                   blocks.id,blocks.global_slot_since_genesis,parent.global_slot_since_genesis,
+                   blocks.id,blocks.height,blocks.global_slot_since_genesis,parent.global_slot_since_genesis,
                    sequence_no,status,created_token,
                    fee_payer_balance, source_balance, receiver_balance
 
@@ -235,6 +244,7 @@ module Internal_command = struct
     ; fee : int64
     ; token : int64
     ; block_id : int
+    ; block_height : int64
     ; global_slot_since_genesis : int64
     ; txn_global_slot_since_genesis : int64
     ; receiver_account_creation_fee_paid : int64 option
@@ -255,6 +265,7 @@ module Internal_command = struct
         ; int
         ; int64
         ; int64
+        ; int64
         ; option int64
         ; int
         ; int
@@ -270,7 +281,7 @@ module Internal_command = struct
   let query =
     Caqti_request.collect Caqti_type.int typ
       {sql| SELECT type,receiver_id,receiver_balance,fee,token,
-                   blocks.id,blocks.global_slot_since_genesis,parent.global_slot_since_genesis,
+                   blocks.id,blocks.height,blocks.global_slot_since_genesis,parent.global_slot_since_genesis,
                    receiver_account_creation_fee_paid,
                    sequence_no,secondary_sequence_no
 
@@ -372,18 +383,4 @@ module Parent_block = struct
   let get_parent_state_hash (module Conn : Caqti_async.CONNECTION)
       epoch_ledgers_state_hash =
     Conn.find query_parent_state_hash epoch_ledgers_state_hash
-end
-
-module Balance = struct
-  let query =
-    Caqti_request.find_opt
-      Caqti_type.(tup2 int int)
-      Caqti_type.int64
-      {sql| SELECT balance FROM balances
-            WHERE id = $1
-            AND public_key_id = $2
-      |sql}
-
-  let run (module Conn : Caqti_async.CONNECTION) ~id ~pk_id =
-    Conn.find_opt query (id, pk_id)
 end

--- a/src/migrate_balances_table.opam
+++ b/src/migrate_balances_table.opam
@@ -1,0 +1,5 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]


### PR DESCRIPTION
Add extra columns to the `balances` table in the archive db schema, to speed up Rosetta queries and make them less resource-intensive.

Update the archive processor to populate those extra columns.

There's a new app, `migrate_balances_table` to convert existing databases to the new format. Tested that app by migrating the replayer test database, then running the replayer, which verifies balances after running each transaction. The replayer found bugs in the migration app. After fixing those bugs, the replayer succeeded.

The migration app add cursor tables to the db, so that if it crashes, the app can be restarted and resuming (approximately) where it left off.  The app does not remove those tables, they can be DROPped manually (or I can add an automatic DROP if desired). Such restart capability is needed because Postgresql consumes a lot of memory during the migration -- the 32 Gb on my desktop was exhausted about 1/3 the way through the migration.

(The code for the migration app is a bit quick-n-dirty, sorry, but we'll only need to run it once for each archive db.)

Also: updated `extract_blocks` to accommodate these changes. After migrating the replayer archive test db, had to run the script to add the chain status column. Ran `extract_blocks` on a small subchain to test.
