### PR TITLE
snapps fix predicate typ

### DIFF
--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -551,7 +551,40 @@ module Predicate = struct
   end]
 
   module Tag = struct
-    type t = Full | Nonce | Accept [@@deriving equal, compare, sexp]
+    type t = Full | Nonce | Accept [@@deriving equal, compare, sexp, yojson]
+
+    type var = Boolean.var * Boolean.var
+
+    let to_bits = function
+      | Accept ->
+          (true, true)
+      | Nonce ->
+          (true, false)
+      | Full ->
+          (false, true)
+
+    let of_bits = function
+      | true, true ->
+          Accept
+      | true, false ->
+          Nonce
+      | false, true ->
+          Full
+      | false, false ->
+          failwith "invalid"
+
+    let typ =
+      Typ.transport Typ.(Boolean.typ * Boolean.typ) ~there:to_bits ~back:of_bits
+
+    let accept ((a, b) : var) = Impl.run_checked Boolean.(a &&& b)
+
+    let nonce_check ((a, b) : var) = Impl.run_checked Boolean.(a &&& not b)
+
+    let account_check ((a, b) : var) = Impl.run_checked Boolean.((not a) &&& b)
+
+    let var_of_t t =
+      let a, b = to_bits t in
+      (Boolean.var_of_value a, Boolean.var_of_value b)
   end
 
   let tag : t -> Tag.t = function
@@ -577,42 +610,56 @@ module Predicate = struct
     | Accept ->
         Lazy.force accept
 
+  type value =
+    { tag : Tag.t
+    ; nonce : Account.Nonce.t
+    ; account : Snapp_predicate.Account.t
+    }
+  [@@deriving hlist, sexp, equal, yojson, compare]
+
+  let value_of_t = function
+    | Accept ->
+        { tag = Accept
+        ; nonce = Account.Nonce.zero
+        ; account = Snapp_predicate.Account.accept
+        }
+    | Nonce nonce ->
+        { tag = Nonce; nonce; account = Snapp_predicate.Account.accept }
+    | Full account ->
+        { tag = Full; nonce = Account.Nonce.zero; account }
+
   module Checked = struct
     type t =
-      | Nonce_or_accept of
-          { nonce : Account.Nonce.Checked.t; accept : Boolean.var }
-      | Full of Snapp_predicate.Account.Checked.t
+      { tag : Tag.var
+      ; nonce : Account.Nonce.Checked.t
+      ; account : Snapp_predicate.Account.Checked.t
+      }
+    [@@deriving hlist]
 
     let digest (t : t) =
       let digest x =
         Random_oracle.Checked.(
           hash ~init:Hash_prefix_states.party_predicate (pack_input x))
       in
-      match t with
-      | Full a ->
-          Snapp_predicate.Account.Checked.to_input a |> digest
-      | Nonce_or_accept { nonce; accept = b } ->
-          let open Impl in
-          Field.(
-            if_ b
-              ~then_:(constant (Lazy.force accept))
-              ~else_:
-                (digest (run_checked (Account.Nonce.Checked.to_input nonce))))
+      let open Impl in
+      Field.(
+        if_ (Tag.accept t.tag)
+          ~then_:(constant (Lazy.force accept))
+          ~else_:
+            (if_ (Tag.nonce_check t.tag)
+               ~then_:
+                 (digest (run_checked (Account.Nonce.Checked.to_input t.nonce)))
+               ~else_:
+                 (Snapp_predicate.Account.Checked.to_input t.account |> digest)))
   end
 
-  let typ () : (Snapp_predicate.Account.Checked.t, t) Typ.t =
-    Typ.transport
-      (Snapp_predicate.Account.typ ())
-      ~there:(function
-        | Full s ->
-            s
-        | Nonce n ->
-            { Snapp_predicate.Account.accept with
-              nonce = Check { lower = n; upper = n }
-            }
-        | Accept ->
-            Snapp_predicate.Account.accept)
-      ~back:(fun s -> Full s)
+  let typ () : (Checked.t, _) Typ.t =
+    (*Typ.transport (Typ.tuple3 Tag.typ Account.Nonce.typ (Snapp_predicate.Account.typ ())) ~there:(function
+      | Full s -> {})*)
+    Typ.of_hlistable
+      [ Tag.typ; Account.Nonce.typ; Snapp_predicate.Account.typ () ]
+      ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
+      ~value_to_hlist ~value_of_hlist
 end
 
 module Predicated = struct
@@ -645,7 +692,10 @@ module Predicated = struct
   let digest (t : t) =
     Random_oracle.(hash ~init:Hash_prefix.party (pack_input (to_input t)))
 
-  let typ () : (_, t) Typ.t =
+  type value = (Body.t, Predicate.value) Poly.t
+  [@@deriving sexp, equal, yojson, compare]
+
+  let typ () : (_, value) Typ.t =
     let open Poly in
     Typ.of_hlistable
       [ Body.typ (); Predicate.typ () ]


### PR DESCRIPTION
Explain your changes:
Proofs parties are expected to have Full predicates but they can't be the first party https://github.com/MinaProtocol/mina/blob/642746d802f378f811a6647c178498aea6fdb2eb/src/lib/transaction_snark/transaction_snark.ml#L1674 
This means one cannot create a txn that just updates the state.

Changed it to accept both `nonce` and `accept` predicate by doing the appropriate transformation between t and var

Explain how you tested your changes:
Ran a local node, generated the transaction that performs an update with Proof which got included in the block and snark worker generated a txn snark for it


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
