### PR TITLE
Use chain status for block recency

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -122,7 +122,7 @@ module Sql = struct
         |> Errors.Lift.sql ~context:"Finding specified block"
       with
       | None ->
-          Deferred.Result.fail (Errors.create `Block_missing)
+          Deferred.Result.fail (Errors.create @@ `Block_missing (Block_query.to_string block_query))
       | Some (_block_id, block_info, _) ->
           Deferred.Result.return
             ( block_info.height

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -254,11 +254,11 @@ module Sql = struct
 
     let typ = Caqti_type.(tup3 int Archive_lib.Processor.Block.typ Extras.typ)
 
-    let query_count_pending_at_height =
+    let query_count_canonical_at_height =
       Caqti_request.find Caqti_type.int64 Caqti_type.int64
         {sql| SELECT COUNT(*) FROM blocks
               WHERE height = ?
-              AND chain_status = 'pending'
+              AND chain_status = 'canonical'
         |sql}
 
     let query_height_old =
@@ -355,10 +355,10 @@ WITH RECURSIVE chain AS (
     let run_is_old_height (module Conn : Caqti_async.CONNECTION) ~height =
       let open Deferred.Result.Let_syntax in
       let open Int64 in
-      let%map num_pending_at_height =
-        Conn.find query_count_pending_at_height height
+      let%map num_canonical_at_height =
+        Conn.find query_count_canonical_at_height height
       in
-      Int64.equal num_pending_at_height Int64.zero
+      Int64.(>) num_canonical_at_height Int64.zero
 
     let run (module Conn : Caqti_async.CONNECTION) = function
       | Some (`This (`Height h)) ->

--- a/src/lib/rosetta_lib/errors.ml
+++ b/src/lib/rosetta_lib/errors.ml
@@ -37,7 +37,7 @@ module Variant = struct
     | `Account_not_found of string
     | `Invariant_violation
     | `Transaction_not_found of string
-    | `Block_missing
+    | `Block_missing of string
     | `Malformed_public_key
     | `Operations_not_valid of Partial_reason.t list
     | `Unsupported_operation_for_construction
@@ -107,7 +107,7 @@ end = struct
         "Internal invariant violation (you found a bug)"
     | `Transaction_not_found _ ->
         "Transaction not found"
-    | `Block_missing ->
+    | `Block_missing _ ->
         "Block not found"
     | `Malformed_public_key ->
         "Malformed public key"
@@ -179,10 +179,12 @@ end = struct
               this transaction in a recent block. It also could be due to the \
               transaction being evicted from the mempool."
              hash)
-    | `Block_missing ->
+    | `Block_missing s ->
         Some
-          "We couldn't find the block you specified in the archive node. Ask a \
-           friend for the missing data."
+          (sprintf
+             "We couldn't find the block in the archive node, specified by %s. \
+              Ask a friend for the missing data."
+             s)
     | `Malformed_public_key ->
         None
     | `Operations_not_valid reasons ->
@@ -239,7 +241,7 @@ end = struct
         false
     | `Transaction_not_found _ ->
         true
-    | `Block_missing ->
+    | `Block_missing _ ->
         true
     | `Malformed_public_key ->
         false
@@ -295,9 +297,11 @@ end = struct
          bug!)"
     | `Transaction_not_found _ ->
         "That transaction could not be found."
-    | `Block_missing ->
-        "We couldn't find the block you specified in the archive node. Ask a \
-         friend for the missing data."
+    | `Block_missing s ->
+        sprintf
+          "We couldn't find the block in the archive node, specified by %s. \
+           Ask a friend for the missing data."
+          s
     | `Malformed_public_key ->
         "The public key you provided was malformed."
     | `Operations_not_valid _ ->

--- a/src/lib/vrf_lib/tests/integrated_test.ml
+++ b/src/lib/vrf_lib/tests/integrated_test.ml
@@ -60,7 +60,7 @@ end
 module Output_hash = struct
   type value = Snark_params.Tick.Field.t [@@deriving equal, sexp]
 
-  type t = value [@@deriving eq, sexp]
+  type t = value [@@deriving equal, sexp]
 
   type var = Random_oracle.Checked.Digest.t
 


### PR DESCRIPTION
There are two queries for blocks in Rosetta, one for for "old" blocks, another for "recent" blocks. There was a call to dispatch to those two queries, based on the difference between the maximum block height and the height of the query. 

But if we chose the recent query, and the block was already marked as canonical, the query returned no block.

Instead, determine the recency of the block by the chain status of blocks at the requested height. 

If there is a canonical block at that height, the chain status of blocks at that height has been resolved, choose that canonical block.

If there is no canonical block at that height, then find a subchain from the block at maximum height back to a canonical block, and choose the block in the subchain with the requested height.

Also: put the query info into the `Block_missing` error, to know what went wrong.

Tested using `check:data`. (The actual testing was slightly different: choose the old query if are any canonical blocks at the requested height *or higher*. I believe the result is the same.)