### PR TITLE
Report chain status gaps in missing blocks auditor

### DIFF
--- a/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
+++ b/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
@@ -15,7 +15,7 @@ let main ~archive_uri () =
   | Ok pool ->
       [%log info] "Successfully created Caqti pool for Postgresql" ;
       [%log info] "Querying missing blocks" ;
-      let%map missing_blocks =
+      let%bind missing_blocks_raw =
         match%bind
           Caqti_async.Pool.use (fun db -> Sql.Unparented_blocks.run db ()) pool
         with
@@ -26,18 +26,65 @@ let main ~archive_uri () =
               ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
             exit 1
       in
-      List.iter missing_blocks
-        ~f:(fun (block_id, state_hash, height, parent_hash) ->
-          if height > 1 then
-            [%log info] "Block has no parent in archive db"
-              ~metadata:
-                [ ("block_id", `Int block_id)
-                ; ("state_hash", `String state_hash)
-                ; ("height", `Int height)
-                ; ("parent_hash", `String parent_hash)
-                ; ("parent_height", `Int (height - 1))
-                ]) ;
-      ()
+      (* filter out genesis block *)
+      let missing_blocks =
+        List.filter missing_blocks_raw ~f:(fun (_, _, height, _) -> height <> 1)
+      in
+      if List.is_empty missing_blocks then
+        [%log info] "There are no missing blocks in the archive db"
+      else
+        List.iter missing_blocks
+          ~f:(fun (block_id, state_hash, height, parent_hash) ->
+            if height > 1 then
+              [%log info] "Block has no parent in archive db"
+                ~metadata:
+                  [ ("block_id", `Int block_id)
+                  ; ("state_hash", `String state_hash)
+                  ; ("height", `Int height)
+                  ; ("parent_hash", `String parent_hash)
+                  ; ("parent_height", `Int (height - 1))
+                  ]) ;
+      [%log info] "Querying for gaps in chain statuses" ;
+      let%bind highest_canonical =
+        match%bind
+          Caqti_async.Pool.use
+            (fun db -> Sql.Chain_status.run_highest_canonical db ())
+            pool
+        with
+        | Ok height ->
+            return height
+        | Error msg ->
+            [%log error] "Error getting greatest height of canonical blocks"
+              ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
+            exit 1
+      in
+      let%bind pending_below =
+        match%bind
+          Caqti_async.Pool.use
+            (fun db ->
+              Sql.Chain_status.run_count_pending_below db highest_canonical)
+            pool
+        with
+        | Ok count ->
+            return count
+        | Error msg ->
+            [%log error] "Error getting greatest height of canonical blocks"
+              ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
+            exit 1
+      in
+      if Int64.equal pending_below Int64.zero then
+        [%log info] "There are no gaps in the chain statuses"
+      else
+        [%log info]
+          "There are $num_pending_blocks_below pending blocks lower than the \
+           highest canonical block"
+          ~metadata:
+            [ ( "max_height_canonical_block"
+              , `String (Int64.to_string highest_canonical) )
+            ; ( "num_pending_blocks_below"
+              , `String (Int64.to_string pending_below) )
+            ] ;
+      return ()
 
 let () =
   Command.(

--- a/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
+++ b/src/app/missing_blocks_auditor/missing_blocks_auditor.ml
@@ -68,7 +68,9 @@ let main ~archive_uri () =
         | Ok count ->
             return count
         | Error msg ->
-            [%log error] "Error getting greatest height of canonical blocks"
+            [%log error]
+              "Error getting number of pending blocks below highest canonical \
+               block"
               ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
             exit 1
       in

--- a/src/app/missing_blocks_auditor/sql.ml
+++ b/src/app/missing_blocks_auditor/sql.ml
@@ -13,3 +13,24 @@ module Unparented_blocks = struct
 
   let run (module Conn : Caqti_async.CONNECTION) () = Conn.collect_list query ()
 end
+
+module Chain_status = struct
+  let query_highest_canonical =
+    Caqti_request.find Caqti_type.unit Caqti_type.int64
+      {sql| SELECT max(height) FROM blocks
+            WHERE chain_status = 'canonical'
+      |sql}
+
+  let run_highest_canonical (module Conn : Caqti_async.CONNECTION) () =
+    Conn.find query_highest_canonical ()
+
+  let query_count_pending_below =
+    Caqti_request.find Caqti_type.int64 Caqti_type.int64
+      {sql| SELECT count(*) FROM blocks
+            WHERE chain_status = 'pending'
+            AND height <= ?
+      |sql}
+
+  let run_count_pending_below (module Conn : Caqti_async.CONNECTION) height =
+    Conn.find query_count_pending_below height
+end


### PR DESCRIPTION
Report gaps in the block chain statuses in the archive db.

There's a gap if there's a `pending` block with a height the same or lower than the highest `canonical` block.

The mainnet `3` `archive_balances_migrated` db had a few of these, since corrected.

The devnet `1` `archive_balances_migrated` db still has many of these, will fix.