### PR TITLE
[TRIVIAL] Silence output for passing tests in ledger_catchup, mina_net2, network_pool

### DIFF
--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1,3 +1,5 @@
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
 open Core
 open Async
 open Cache_lib

--- a/src/lib/mina_net2/tests/all_ipc.ml
+++ b/src/lib/mina_net2/tests/all_ipc.ml
@@ -22,6 +22,9 @@ open Core
 open Async
 open Mina_net2
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
+
 type status = NotMet | Connected | Disconnected [@@deriving sexp]
 
 type typed_msg = { a : int; b : string option }

--- a/src/lib/mina_net2/tests/dune
+++ b/src/lib/mina_net2/tests/dune
@@ -1,6 +1,6 @@
 (library
  (name mina_net2_tests)
- (libraries mina_net2)
+ (libraries mina_net2 inline_test_quiet_logs)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_coda ppx_version))
  (inline_tests))

--- a/src/lib/mina_net2/tests/tests.ml
+++ b/src/lib/mina_net2/tests/tests.ml
@@ -2,6 +2,9 @@ open Core
 open Async
 open Mina_net2
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
+
 let%test_module "coda network tests" =
   ( module struct
     let logger = Logger.create ()

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -2,6 +2,9 @@ open Core_kernel
 open Async_kernel
 open Network_peer
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
+
 module Id = Unique_id.Int ()
 
 type ('init, 'result) elt =

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1052,6 +1052,9 @@ let add_from_backtrack :
       ; time_controller
       }
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
+
 let%test_module _ =
   ( module struct
     open For_tests

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -746,6 +746,9 @@ module Diff_versioned = struct
   [@@deriving compare, sexp, to_yojson, hash]
 end
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
+
 let%test_module "random set test" =
   ( module struct
     open Mina_base

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -3,6 +3,9 @@ open Core_kernel
 open Pipe_lib
 open Network_peer
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
+
 let%test_module "network pool test" =
   ( module struct
     let trust_system = Mocks.trust_system

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1437,6 +1437,9 @@ include Make
               Extensions.(get_view_pipe (extensions t) Best_tip_diff)
           end)
 
+(* Only show stdout for failed inline tests. *)
+open Inline_test_quiet_logs
+
 let%test_module _ =
   ( module struct
     module Mock_base_ledger = Mocks.Base_ledger


### PR DESCRIPTION
This PR uses the existing `Inline_test_quiet_logs` library to silence the output of inline tests from `ledger_catchup`, `mina_net2` and `network_pool`. Note that this library only suppresses output for passing tests; failing tests will display their full output.

This significantly reduces the amount of output in the dev unit-tests job in CI (by >3000 lines compared to a recent run), which will make it easier to see and debug actual errors.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them