### PR TITLE
show file read errors when unlocking keys

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1545,6 +1545,13 @@ let export_key =
                     !"wrong password provided for account \
                       %{Public_key.Compressed.to_base58_check}"
                     pk)
+           | Error (`Key_read_error e) ->
+               Error
+                 (sprintf
+                    !"Error reading the secret key file for account \
+                      %{Public_key.Compressed.to_base58_check}: %s"
+                    pk
+                    (Secrets.Privkey_error.to_string e))
            | Error `Not_found ->
                Error
                  (sprintf

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2634,6 +2634,10 @@ module Mutations = struct
         Error "Could not find owned account associated with provided key"
     | Error `Bad_password ->
         Error "Wrong password provided"
+    | Error (`Key_read_error e) ->
+        Error
+          (sprintf "Error reading the secret key file: %s"
+             (Secrets.Privkey_error.to_string e))
     | Ok () ->
         Ok pk
 

--- a/src/lib/secrets/privkey_error.ml
+++ b/src/lib/secrets/privkey_error.ml
@@ -3,28 +3,28 @@ open Core
 type t =
   [ `Corrupted_privkey of Error.t
   | `Incorrect_password_or_corrupted_privkey
-  | `Cannot_open_file of string
+  | `Cannot_open_file of string * Unix.Error.t
   | `Parent_directory_does_not_exist of string
   | `Password_not_in_environment of string list ]
 
 let to_string : t -> string = function
   | `Corrupted_privkey e ->
-      sprintf !"The key was corrupted: %s" (Error.to_string_hum e)
+      sprintf "The key was corrupted: %s" (Error.to_string_hum e)
   | `Incorrect_password_or_corrupted_privkey ->
       "The password was incorrect, or the key is corrupted"
-  | `Cannot_open_file path ->
-      sprintf !"Cannot open file: %s" path
+  | `Cannot_open_file (path, e) ->
+      sprintf "Cannot open file: %s. Error: %s" path (Unix.Error.message e)
   | `Parent_directory_does_not_exist directory_name ->
       sprintf
-        !"Parent directory %s does not exist\n\n\
-          Hint: mkdir -p %s; chmod 700 %s\n"
+        "Parent directory %s does not exist\n\n\
+         Hint: mkdir -p %s; chmod 700 %s\n"
         directory_name directory_name directory_name
   | `Password_not_in_environment [ env_var ] ->
-      sprintf !"No password was specified in environment variable %s" env_var
+      sprintf "No password was specified in environment variable %s" env_var
   | `Password_not_in_environment env_vars ->
       sprintf
-        !"No password was specified in any of the following environment \
-          variables: %s"
+        "No password was specified in any of the following environment \
+         variables: %s"
         (String.concat env_vars ~sep:", ")
 
 let raise ~which t =

--- a/src/lib/secrets/secret_file.ml
+++ b/src/lib/secrets/secret_file.ml
@@ -63,8 +63,8 @@ let handle_open ~mkdir ~(f : string -> 'a Deferred.t) path =
       Deferred.Result.return x
   | Error e -> (
       match Error.to_exn e with
-      | Unix.Unix_error (_, _, _) ->
-          Deferred.return (Error (`Cannot_open_file path))
+      | Unix.Unix_error (error_code, _, _) ->
+          Deferred.return (Error (`Cannot_open_file (path, error_code)))
       | e ->
           Deferred.return @@ corrupted_privkey (Error.of_exn e) )
 

--- a/src/lib/secrets/wallets.ml
+++ b/src/lib/secrets/wallets.ml
@@ -182,7 +182,7 @@ let unlock { cache; path } ~needle ~password =
   let unlock_keypair = function
     | Locked file ->
         Secret_keypair.read ~privkey_path:(path ^/ file) ~password
-        |> Deferred.Result.map_error ~f:(fun _ -> `Bad_password)
+        |> Deferred.Result.map_error ~f:(fun e -> `Key_read_error e)
         |> Deferred.Result.map ~f:(fun kp ->
                Public_key.Compressed.Table.set cache ~key:needle
                  ~data:(Unlocked (file, kp)))

--- a/src/lib/secrets/wallets.mli
+++ b/src/lib/secrets/wallets.mli
@@ -39,7 +39,9 @@ val unlock :
      t
   -> needle:Public_key.Compressed.t
   -> password:Secret_file.password
-  -> (unit, [ `Not_found | `Bad_password ]) Deferred.Result.t
+  -> ( unit
+     , [ `Not_found | `Bad_password | `Key_read_error of Privkey_error.t ] )
+     Deferred.Result.t
 
 val lock : t -> needle:Public_key.Compressed.t -> unit
 


### PR DESCRIPTION
Explain your changes:
*Propagate Privkey_error.t to the account unlock command output
*Added unix error in the error message

Explain how you tested your changes:
* Ran a node locally, deleted imported keys and tried to unlock them. 

Before the change:
```
❌ Error: Wrong password provided (in ["unlockAccount"])
```
After the change
```
❌ Error: Error reading the secret key file: Cannot open file: /.mina-config/wallets/store/B62qjJwgq7kNXYHXQsMeyiMWL7fHsnPeuAiPfYd3yTor3eKpK8VV1gG. Error: No such file or directory (in ["unlockAccount"])
```


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
