### PR TITLE
Audit canonical chain statuses

### DIFF
--- a/src/app/missing_blocks_auditor/sql.ml
+++ b/src/app/missing_blocks_auditor/sql.ml
@@ -33,4 +33,32 @@ module Chain_status = struct
 
   let run_count_pending_below (module Conn : Caqti_async.CONNECTION) height =
     Conn.find query_count_pending_below height
+
+  let query_canonical_chain =
+    Caqti_request.collect Caqti_type.int64
+      Caqti_type.(tup3 int string string)
+      {sql| WITH RECURSIVE chain AS (
+
+               (SELECT id, state_hash, parent_id, chain_status
+
+                FROM blocks b
+                WHERE height = $1
+                AND chain_status = 'canonical')
+
+                UNION ALL
+
+                SELECT b.id, b.state_hash, b.parent_id, b.chain_status
+
+                FROM blocks b
+                INNER JOIN chain
+                ON b.id = chain.parent_id AND chain.id <> chain.parent_id
+               )
+
+              SELECT id,state_hash,chain_status
+              FROM chain
+              ORDER BY id ASC
+      |sql}
+
+  let run_canonical_chain (module Conn : Caqti_async.CONNECTION) height =
+    Conn.collect_list query_canonical_chain height
 end


### PR DESCRIPTION
In `missing_blocks_auditor`, check that all the chain statuses along the canonical chain are, in fact, `canonical`.

Ran on mainnet `archive_balances_migrated`, it had no errors.

Closes #9815.