### PR TITLE
CI: Enable soft_fail on optional lint steps

### DIFF
--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -18,6 +18,9 @@ let RunInToolchain = ../../Command/RunInToolchain.dhall
 
 let Size = ../../Command/Size.dhall
 
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+let B/ExitStatus = B.definitions/commandStep/properties/soft_fail/union/properties/exit_status/Type
+
 let commands =
       [ Cmd.run "./scripts/lint_codeowners.sh"
       , Cmd.run "./scripts/lint_rfcs.sh"
@@ -56,6 +59,9 @@ in  Pipeline.build
             , key = "lint-optional-types"
             , target = Size.Medium
             , docker = None Docker.Type
+            , soft_fail = Some (B/SoftFail.ListSoft_fail/Type [{
+              , exit_status = Some (B/ExitStatus.Number 1)
+              }])
             }
         , Command.build
             Command.Config::{


### PR DESCRIPTION


Explain your changes:
* This results in the optional lint step not causing the entire CI pipeline to fail

Explain how you tested your changes:
* This PR ;)


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
