### PR TITLE
catchup failure cases unit tests

### DIFF
--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -234,7 +234,7 @@ module Generator = struct
     let get_transition_chain_impl :
            Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
         -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
-     fun _ -> Deferred.return (Some [])
+     fun _ -> Deferred.return None
      (* (Sync_handler.get_transition_chain ~frontier
         (Envelope.Incoming.data query_env)) *)
     in

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -6,6 +6,120 @@ open Signature_lib
 open Network_peer
 module Gossip_net = Mina_networking.Gossip_net
 
+(* 
+type rpc_implementations =
+  { get_staged_ledger_aux_and_pending_coinbases_at_hash :
+         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+      -> ( Staged_ledger.Scan_state.t
+         * Marlin_plonk_bindings_pasta_fp.t
+         * Pending_coinbase.t
+         * Mina_state.Protocol_state.value list )
+         option
+         Deferred.t
+  ; get_some_initial_peers : unit Envelope.Incoming.t -> Peer.t list Deferred.t
+  ; answer_sync_ledger_query :
+         (Marlin_plonk_bindings_pasta_fp.t * Sync_ledger.Query.t)
+         Envelope.Incoming.t
+      -> (Sync_ledger.Answer.t, Error.t) result Deferred.t
+  ; get_ancestry :
+         ( Consensus.Data.Consensus_state.Value.t
+         , Marlin_plonk_bindings_pasta_fp.t )
+         With_hash.t
+         Envelope.Incoming.t
+      -> ( Mina_transition.External_transition.t
+         , State_body_hash.t list * Mina_transition.External_transition.t )
+         Proof_carrying_data.t
+         option
+         Deferred.t
+  ; get_best_tip :
+         unit Envelope.Incoming.t
+      -> ( Mina_transition.External_transition.t
+         , Marlin_plonk_bindings_pasta_fp.t list
+           * Mina_transition.External_transition.t )
+         Proof_carrying_data.t
+         option
+         Deferred.t
+  ; get_node_status :
+         unit Envelope.Incoming.t
+      -> (Mina_networking.Rpcs.Get_node_status.Node_status.t, Error.t) result
+         Deferred.t
+  ; get_transition_knowledge :
+         unit Envelope.Incoming.t
+      -> Marlin_plonk_bindings_pasta_fp.t list Deferred.t
+  ; get_transition_chain_proof :
+         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+      -> ( Marlin_plonk_bindings_pasta_fp.t
+         * Marlin_plonk_bindings_pasta_fp.t list )
+         option
+         Deferred.t
+  ; get_transition_chain :
+         Marlin_plonk_bindings_pasta_fp.t list Envelope.Incoming.t
+      -> Mina_transition.External_transition.t list option Deferred.t
+  } *)
+
+(* let rpc_implementations_default ~frontier
+    ~(precomputed_values : Precomputed_values.t) ~logger =
+  { get_staged_ledger_aux_and_pending_coinbases_at_hash =
+      (fun query_env ->
+        let input = Envelope.Incoming.data query_env in
+        Deferred.return
+          (let open Option.Let_syntax in
+          let%map ( scan_state
+                  , expected_merkle_root
+                  , pending_coinbases
+                  , protocol_states ) =
+            Sync_handler.get_staged_ledger_aux_and_pending_coinbases_at_hash
+              ~frontier input
+          in
+          let staged_ledger_hash =
+            Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
+              (Staged_ledger.Scan_state.hash scan_state)
+              expected_merkle_root pending_coinbases
+          in
+          [%log debug]
+            ~metadata:
+              [ ( "staged_ledger_hash"
+                , Staged_ledger_hash.to_yojson staged_ledger_hash )
+              ]
+            "sending scan state and pending coinbase" ;
+          (scan_state, expected_merkle_root, pending_coinbases, protocol_states)))
+  ; get_some_initial_peers = (fun _ -> Deferred.return [])
+  ; answer_sync_ledger_query =
+      (fun query_env ->
+        let ledger_hash, _ = Envelope.Incoming.data query_env in
+        Sync_handler.answer_query ~frontier ledger_hash
+          (Envelope.Incoming.map ~f:Tuple2.get2 query_env)
+          ~logger:(Logger.create ()) ~trust_system:(Trust_system.null ())
+        |> Deferred.map (* begin error string prefix so we can pattern-match *)
+             ~f:
+               (Result.of_option
+                  ~error:
+                    (Error.createf
+                       !"%s for ledger_hash: %{sexp:Ledger_hash.t}"
+                       Mina_networking.refused_answer_query_string ledger_hash)))
+  ; get_ancestry =
+      (fun query_env ->
+        Deferred.return
+          (Sync_handler.Root.prove
+             ~consensus_constants:precomputed_values.consensus_constants ~logger
+             ~frontier
+             (Envelope.Incoming.data query_env)))
+  ; get_best_tip = (fun _ -> failwith "Get_best_tip unimplemented")
+  ; get_node_status = (fun _ -> failwith "Get_node_status unimplemented")
+  ; get_transition_knowledge =
+      (fun _query -> Deferred.return (Sync_handler.best_tip_path ~frontier))
+  ; get_transition_chain_proof =
+      (fun query_env ->
+        Deferred.return
+          (Transition_chain_prover.prove ~frontier
+             (Envelope.Incoming.data query_env)))
+  ; get_transition_chain =
+      (fun query_env ->
+        Deferred.return
+          (Sync_handler.get_transition_chain ~frontier
+             (Envelope.Incoming.data query_env)))
+  } *)
+
 (* There must be at least 2 peers to create a network *)
 type 'n num_peers = 'n Peano.gt_1
 
@@ -13,10 +127,53 @@ type 'n num_peers = 'n Peano.gt_1
 type peer_state =
   { frontier : Transition_frontier.t
   ; consensus_local_state : Consensus.Data.Local_state.t
-  ; get_transition_chain_impl :
-      (   Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
-       -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t)
-      option
+  ; get_staged_ledger_aux_and_pending_coinbases_at_hash :
+         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+      -> ( Staged_ledger.Scan_state.t
+         * Marlin_plonk_bindings_pasta_fp.t
+         * Pending_coinbase.t
+         * Mina_state.Protocol_state.value list )
+         option
+         Deferred.t
+  ; get_some_initial_peers : unit Envelope.Incoming.t -> Peer.t list Deferred.t
+  ; answer_sync_ledger_query :
+         (Marlin_plonk_bindings_pasta_fp.t * Sync_ledger.Query.t)
+         Envelope.Incoming.t
+      -> (Sync_ledger.Answer.t, Error.t) result Deferred.t
+  ; get_ancestry :
+         ( Consensus.Data.Consensus_state.Value.t
+         , Marlin_plonk_bindings_pasta_fp.t )
+         With_hash.t
+         Envelope.Incoming.t
+      -> ( Mina_transition.External_transition.t
+         , State_body_hash.t list * Mina_transition.External_transition.t )
+         Proof_carrying_data.t
+         option
+         Deferred.t
+  ; get_best_tip :
+         unit Envelope.Incoming.t
+      -> ( Mina_transition.External_transition.t
+         , Marlin_plonk_bindings_pasta_fp.t list
+           * Mina_transition.External_transition.t )
+         Proof_carrying_data.t
+         option
+         Deferred.t
+  ; get_node_status :
+         unit Envelope.Incoming.t
+      -> (Mina_networking.Rpcs.Get_node_status.Node_status.t, Error.t) result
+         Deferred.t
+  ; get_transition_knowledge :
+         unit Envelope.Incoming.t
+      -> Marlin_plonk_bindings_pasta_fp.t list Deferred.t
+  ; get_transition_chain_proof :
+         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+      -> ( Marlin_plonk_bindings_pasta_fp.t
+         * Marlin_plonk_bindings_pasta_fp.t list )
+         option
+         Deferred.t
+  ; get_transition_chain :
+         Marlin_plonk_bindings_pasta_fp.t list Envelope.Incoming.t
+      -> Mina_transition.External_transition.t list option Deferred.t
   }
 
 type peer_network =
@@ -37,8 +194,7 @@ module Constants = struct
   let init_discovery_port = 1337
 end
 
-let setup (type n) ?(logger = Logger.null ())
-    ?(trust_system = Trust_system.null ())
+let setup (type n) ~logger ?(trust_system = Trust_system.null ())
     ?(time_controller = Block_time.Controller.basic ~logger)
     ~(precomputed_values : Precomputed_values.t)
     (states : (peer_state, n num_peers) Vect.t) : n num_peers t =
@@ -84,81 +240,30 @@ let setup (type n) ?(logger = Logger.null ())
   in
   let peer_networks =
     Vect.map2 peers states ~f:(fun peer state ->
-        let frontier = state.frontier in
+        (* let frontier = state.frontier in *)
         let network =
           Thread_safe.block_on_async_exn (fun () ->
               (* TODO: merge implementations with mina_lib *)
+              (* let rpc =
+                   match state.rpc_impl with
+                   | Some impl ->
+                       impl
+                   | None ->
+                       rpc_implementations_default ~logger ~precomputed_values
+                         ~frontier
+                 in *)
               Mina_networking.create
                 (config peer state.consensus_local_state)
                 ~get_staged_ledger_aux_and_pending_coinbases_at_hash:
-                  (fun query_env ->
-                  let input = Envelope.Incoming.data query_env in
-                  Deferred.return
-                    (let open Option.Let_syntax in
-                    let%map ( scan_state
-                            , expected_merkle_root
-                            , pending_coinbases
-                            , protocol_states ) =
-                      Sync_handler
-                      .get_staged_ledger_aux_and_pending_coinbases_at_hash
-                        ~frontier input
-                    in
-                    let staged_ledger_hash =
-                      Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
-                        (Staged_ledger.Scan_state.hash scan_state)
-                        expected_merkle_root pending_coinbases
-                    in
-                    [%log debug]
-                      ~metadata:
-                        [ ( "staged_ledger_hash"
-                          , Staged_ledger_hash.to_yojson staged_ledger_hash )
-                        ]
-                      "sending scan state and pending coinbase" ;
-                    ( scan_state
-                    , expected_merkle_root
-                    , pending_coinbases
-                    , protocol_states )))
-                ~get_some_initial_peers:(fun _ -> Deferred.return [])
-                ~answer_sync_ledger_query:(fun query_env ->
-                  let ledger_hash, _ = Envelope.Incoming.data query_env in
-                  Sync_handler.answer_query ~frontier ledger_hash
-                    (Envelope.Incoming.map ~f:Tuple2.get2 query_env)
-                    ~logger:(Logger.create ())
-                    ~trust_system:(Trust_system.null ())
-                  |> Deferred.map
-                     (* begin error string prefix so we can pattern-match *)
-                       ~f:
-                         (Result.of_option
-                            ~error:
-                              (Error.createf
-                                 !"%s for ledger_hash: %{sexp:Ledger_hash.t}"
-                                 Mina_networking.refused_answer_query_string
-                                 ledger_hash)))
-                ~get_ancestry:(fun query_env ->
-                  Deferred.return
-                    (Sync_handler.Root.prove
-                       ~consensus_constants:
-                         precomputed_values.consensus_constants ~logger
-                       ~frontier
-                       (Envelope.Incoming.data query_env)))
-                ~get_best_tip:(fun _ -> failwith "Get_best_tip unimplemented")
-                ~get_node_status:(fun _ ->
-                  failwith "Get_node_status unimplemented")
-                ~get_transition_knowledge:(fun _query ->
-                  Deferred.return (Sync_handler.best_tip_path ~frontier))
-                ~get_transition_chain_proof:(fun query_env ->
-                  Deferred.return
-                    (Transition_chain_prover.prove ~frontier
-                       (Envelope.Incoming.data query_env)))
-                ~get_transition_chain:
-                  ( match state.get_transition_chain_impl with
-                  | None ->
-                      fun query_env ->
-                        Deferred.return
-                          (Sync_handler.get_transition_chain ~frontier
-                             (Envelope.Incoming.data query_env))
-                  | Some impl ->
-                      impl ))
+                  state.get_staged_ledger_aux_and_pending_coinbases_at_hash
+                ~get_some_initial_peers:state.get_some_initial_peers
+                ~answer_sync_ledger_query:state.answer_sync_ledger_query
+                ~get_ancestry:state.get_ancestry
+                ~get_best_tip:state.get_best_tip
+                ~get_node_status:state.get_node_status
+                ~get_transition_knowledge:state.get_transition_knowledge
+                ~get_transition_chain_proof:state.get_transition_chain_proof
+                ~get_transition_chain:state.get_transition_chain)
         in
         { peer; state; network })
   in
@@ -168,15 +273,205 @@ module Generator = struct
   open Quickcheck
   open Generator.Let_syntax
 
+  (* let match_rpc_option ~rpc_impl ~frontier ~consensus_local_state ~logger ~precomputed_values =
+     match rpc_impl with
+     | Some impl ->
+         { frontier
+         ; consensus_local_state
+         ; rpc_impl=impl
+         }
+     | None ->
+         { frontier
+         ; consensus_local_state
+         ; rpc_impl=(rpc_implementations_default ~frontier ~precomputed_values ~logger)
+         } *)
+
+  (* type peer_config =
+        ?get_staged_ledger_aux_and_pending_coinbases_at_hash:
+          (   Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+           -> ( Staged_ledger.Scan_state.t
+              * Marlin_plonk_bindings_pasta_fp.t
+              * Pending_coinbase.t
+              * Mina_state.Protocol_state.value list )
+              option
+              Deferred.t)
+     -> ?get_some_initial_peers:
+          (unit Envelope.Incoming.t -> Peer.t list Deferred.t)
+     -> ?answer_sync_ledger_query:
+          (   (Marlin_plonk_bindings_pasta_fp.t * Sync_ledger.Query.t)
+              Envelope.Incoming.t
+           -> (Sync_ledger.Answer.t, Error.t) result Deferred.t)
+     -> ?get_ancestry:
+          (   ( Consensus.Data.Consensus_state.Value.t
+              , Marlin_plonk_bindings_pasta_fp.t )
+              With_hash.t
+              Envelope.Incoming.t
+           -> ( Mina_transition.External_transition.t
+              , State_body_hash.t list * Mina_transition.External_transition.t
+              )
+              Proof_carrying_data.t
+              option
+              Deferred.t)
+     -> ?get_best_tip:
+          (   unit Envelope.Incoming.t
+           -> ( Mina_transition.External_transition.t
+              , Marlin_plonk_bindings_pasta_fp.t list
+                * Mina_transition.External_transition.t )
+              Proof_carrying_data.t
+              option
+              Deferred.t)
+     -> ?get_node_status:
+          (   unit Envelope.Incoming.t
+           -> ( Mina_networking.Rpcs.Get_node_status.Node_status.t
+              , Error.t )
+              result
+              Deferred.t)
+     -> ?get_transition_knowledge:
+          (   unit Envelope.Incoming.t
+           -> Marlin_plonk_bindings_pasta_fp.t list Deferred.t)
+     -> ?get_transition_chain_proof:
+          (   Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+           -> ( Marlin_plonk_bindings_pasta_fp.t
+              * Marlin_plonk_bindings_pasta_fp.t list )
+              option
+              Deferred.t)
+     -> ?get_transition_chain:
+          (   Marlin_plonk_bindings_pasta_fp.t list Envelope.Incoming.t
+           -> Mina_transition.External_transition.t list option Deferred.t)
+     -> logger:Logger.t
+     -> precomputed_values:Precomputed_values.t
+     -> verifier:Verifier.t
+     -> max_frontier_length:int
+     -> use_super_catchup:bool
+     -> peer_state Generator.t *)
+
   type peer_config =
-       precomputed_values:Precomputed_values.t
+       logger:Logger.t
+    -> precomputed_values:Precomputed_values.t
     -> verifier:Verifier.t
     -> max_frontier_length:int
     -> use_super_catchup:bool
     -> peer_state Generator.t
 
-  let fresh_peer ~precomputed_values ~verifier ~max_frontier_length
-      ~use_super_catchup =
+  let make_peer_state ?get_staged_ledger_aux_and_pending_coinbases_at_hash
+      ?get_some_initial_peers ?answer_sync_ledger_query ?get_ancestry
+      ?get_best_tip ?get_node_status ?get_transition_knowledge
+      ?get_transition_chain_proof ?get_transition_chain ~frontier
+      ~consensus_local_state ~logger ~(precomputed_values : Genesis_proof.t) =
+    { frontier
+    ; consensus_local_state
+    ; get_staged_ledger_aux_and_pending_coinbases_at_hash =
+        ( match get_staged_ledger_aux_and_pending_coinbases_at_hash with
+        | Some f ->
+            f
+        | None ->
+            fun query_env ->
+              let input = Envelope.Incoming.data query_env in
+              Deferred.return
+                (let open Option.Let_syntax in
+                let%map ( scan_state
+                        , expected_merkle_root
+                        , pending_coinbases
+                        , protocol_states ) =
+                  Sync_handler
+                  .get_staged_ledger_aux_and_pending_coinbases_at_hash ~frontier
+                    input
+                in
+                let staged_ledger_hash =
+                  Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
+                    (Staged_ledger.Scan_state.hash scan_state)
+                    expected_merkle_root pending_coinbases
+                in
+                [%log debug]
+                  ~metadata:
+                    [ ( "staged_ledger_hash"
+                      , Staged_ledger_hash.to_yojson staged_ledger_hash )
+                    ]
+                  "sending scan state and pending coinbase" ;
+                ( scan_state
+                , expected_merkle_root
+                , pending_coinbases
+                , protocol_states )) )
+    ; get_some_initial_peers =
+        ( match get_some_initial_peers with
+        | Some f ->
+            f
+        | None ->
+            fun _ -> Deferred.return [] )
+    ; answer_sync_ledger_query =
+        ( match answer_sync_ledger_query with
+        | Some f ->
+            f
+        | None ->
+            fun query_env ->
+              let ledger_hash, _ = Envelope.Incoming.data query_env in
+              Sync_handler.answer_query ~frontier ledger_hash
+                (Envelope.Incoming.map ~f:Tuple2.get2 query_env)
+                ~logger:(Logger.create ()) ~trust_system:(Trust_system.null ())
+              |> Deferred.map
+                 (* begin error string prefix so we can pattern-match *)
+                   ~f:
+                     (Result.of_option
+                        ~error:
+                          (Error.createf
+                             !"%s for ledger_hash: %{sexp:Ledger_hash.t}"
+                             Mina_networking.refused_answer_query_string
+                             ledger_hash)) )
+    ; get_ancestry =
+        ( match get_ancestry with
+        | Some f ->
+            f
+        | None ->
+            fun query_env ->
+              Deferred.return
+                (Sync_handler.Root.prove
+                   ~consensus_constants:precomputed_values.consensus_constants
+                   ~logger ~frontier
+                   (Envelope.Incoming.data query_env)) )
+    ; get_best_tip =
+        ( match get_best_tip with
+        | Some f ->
+            f
+        | None ->
+            fun _ -> failwith "Get_best_tip unimplemented" )
+    ; get_node_status =
+        ( match get_node_status with
+        | Some f ->
+            f
+        | None ->
+            fun _ -> failwith "Get_node_status unimplemented" )
+    ; get_transition_knowledge =
+        ( match get_transition_knowledge with
+        | Some f ->
+            f
+        | None ->
+            fun _query -> Deferred.return (Sync_handler.best_tip_path ~frontier)
+        )
+    ; get_transition_chain_proof =
+        ( match get_transition_chain_proof with
+        | Some f ->
+            f
+        | None ->
+            fun query_env ->
+              Deferred.return
+                (Transition_chain_prover.prove ~frontier
+                   (Envelope.Incoming.data query_env)) )
+    ; get_transition_chain =
+        ( match get_transition_chain with
+        | Some f ->
+            f
+        | None ->
+            fun query_env ->
+              Deferred.return
+                (Sync_handler.get_transition_chain ~frontier
+                   (Envelope.Incoming.data query_env)) )
+    }
+
+  let fresh_peer_custom_rpc ?get_staged_ledger_aux_and_pending_coinbases_at_hash
+      ?get_some_initial_peers ?answer_sync_ledger_query ?get_ancestry
+      ?get_best_tip ?get_node_status ?get_transition_knowledge
+      ?get_transition_chain_proof ?get_transition_chain ~logger
+      ~precomputed_values ~verifier ~max_frontier_length ~use_super_catchup =
     let epoch_ledger_location =
       Filename.temp_dir_name ^/ "epoch_ledger"
       ^ (Uuid_unix.create () |> Uuid.to_string)
@@ -196,10 +491,30 @@ module Generator = struct
         ~consensus_local_state ~max_length:max_frontier_length ~size:0
         ~use_super_catchup ()
     in
-    { frontier; consensus_local_state; get_transition_chain_impl = None }
+    make_peer_state ~frontier ~consensus_local_state ~precomputed_values ~logger
+      ?get_staged_ledger_aux_and_pending_coinbases_at_hash
+      ?get_some_initial_peers ?answer_sync_ledger_query ?get_ancestry
+      ?get_best_tip ?get_node_status ?get_transition_knowledge
+      ?get_transition_chain_proof ?get_transition_chain
 
-  let peer_with_branch ~frontier_branch_size ~precomputed_values ~verifier
-      ~max_frontier_length ~use_super_catchup =
+  (* { frontier; consensus_local_state; rpc_impl } *)
+
+  let fresh_peer ~logger ~precomputed_values ~verifier ~max_frontier_length
+      ~use_super_catchup =
+    fresh_peer_custom_rpc
+      ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
+      ?get_some_initial_peers:None ?answer_sync_ledger_query:None
+      ?get_ancestry:None ?get_best_tip:None ?get_node_status:None
+      ?get_transition_knowledge:None ?get_transition_chain_proof:None
+      ?get_transition_chain:None ~logger ~precomputed_values ~verifier
+      ~max_frontier_length ~use_super_catchup
+
+  let peer_with_branch_custom_rpc ~frontier_branch_size
+      ?get_staged_ledger_aux_and_pending_coinbases_at_hash
+      ?get_some_initial_peers ?answer_sync_ledger_query ?get_ancestry
+      ?get_best_tip ?get_node_status ?get_transition_knowledge
+      ?get_transition_chain_proof ?get_transition_chain ~logger
+      ~precomputed_values ~verifier ~max_frontier_length ~use_super_catchup =
     let epoch_ledger_location =
       Filename.temp_dir_name ^/ "epoch_ledger"
       ^ (Uuid_unix.create () |> Uuid.to_string)
@@ -223,43 +538,33 @@ module Generator = struct
     Async.Thread_safe.block_on_async_exn (fun () ->
         Deferred.List.iter branch
           ~f:(Transition_frontier.add_breadcrumb_exn frontier)) ;
-    { frontier; consensus_local_state; get_transition_chain_impl = None }
 
-  let broken_rpc_peer_branch ~frontier_branch_size
-      ~get_transition_chain_impl_option ~precomputed_values ~verifier
-      ~max_frontier_length ~use_super_catchup =
-    let%map { frontier; consensus_local_state; _ } =
-      peer_with_branch ~frontier_branch_size ~precomputed_values ~verifier
-        ~max_frontier_length ~use_super_catchup
-    in
-    match get_transition_chain_impl_option with
-    | Some impl ->
-        { frontier
-        ; consensus_local_state
-        ; get_transition_chain_impl = Some impl
-        }
-    | None ->
-        let get_transition_chain_impl :
-               Mina_networking.Rpcs.Get_transition_chain.query
-               Envelope.Incoming.t
-            -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
-         fun _ ->
-          (* let valid_result= (Sync_handler.get_transition_chain ~frontier
-             (Envelope.Incoming.data query_env)) in *)
-          Deferred.return (Some [])
-        in
-        { frontier
-        ; consensus_local_state
-        ; get_transition_chain_impl = Some get_transition_chain_impl
-        }
+    make_peer_state ~frontier ~consensus_local_state ~precomputed_values ~logger
+      ?get_staged_ledger_aux_and_pending_coinbases_at_hash
+      ?get_some_initial_peers ?answer_sync_ledger_query ?get_ancestry
+      ?get_best_tip ?get_node_status ?get_transition_knowledge
+      ?get_transition_chain_proof ?get_transition_chain
 
-  let gen ~precomputed_values ~verifier ~max_frontier_length ~use_super_catchup
-      configs =
+  (* { frontier; consensus_local_state; rpc_impl } *)
+
+  let peer_with_branch ~frontier_branch_size ~logger ~precomputed_values
+      ~verifier ~max_frontier_length ~use_super_catchup =
+    peer_with_branch_custom_rpc ~frontier_branch_size
+      ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
+      ?get_some_initial_peers:None ?answer_sync_ledger_query:None
+      ?get_ancestry:None ?get_best_tip:None ?get_node_status:None
+      ?get_transition_knowledge:None ?get_transition_chain_proof:None
+      ?get_transition_chain:None ~logger ~precomputed_values ~verifier
+      ~max_frontier_length ~use_super_catchup
+
+  let gen ?(logger = Logger.null ()) ~precomputed_values ~verifier
+      ~max_frontier_length ~use_super_catchup
+      (configs : (peer_config, 'n num_peers) Gadt_lib.Vect.t) =
     let open Quickcheck.Generator.Let_syntax in
     let%map states =
-      Vect.Quickcheck_generator.map configs ~f:(fun config ->
-          config ~precomputed_values ~verifier ~max_frontier_length
+      Vect.Quickcheck_generator.map configs ~f:(fun (config : peer_config) ->
+          config ~logger ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup)
     in
-    setup ~precomputed_values states
+    setup ~precomputed_values ~logger states
 end

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -126,18 +126,9 @@ let setup (type n) ~logger ?(trust_system = Trust_system.null ())
   in
   let peer_networks =
     Vect.map2 peers states ~f:(fun peer state ->
-        (* let frontier = state.frontier in *)
         let network =
           Thread_safe.block_on_async_exn (fun () ->
               (* TODO: merge implementations with mina_lib *)
-              (* let rpc =
-                   match state.rpc_impl with
-                   | Some impl ->
-                       impl
-                   | None ->
-                       rpc_implementations_default ~logger ~precomputed_values
-                         ~frontier
-                 in *)
               Mina_networking.create
                 (config peer state.consensus_local_state)
                 ~get_staged_ledger_aux_and_pending_coinbases_at_hash:

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -243,7 +243,10 @@ module Generator = struct
                Mina_networking.Rpcs.Get_transition_chain.query
                Envelope.Incoming.t
             -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
-         fun _ -> Deferred.return None
+         fun _ ->
+          (* let valid_result= (Sync_handler.get_transition_chain ~frontier
+             (Envelope.Incoming.data query_env)) in *)
+          Deferred.return (Some [])
         in
         { frontier
         ; consensus_local_state

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -164,19 +164,65 @@ let setup (type n) ?(logger = Logger.null ())
   in
   { fake_gossip_network; peer_networks }
 
-module Generator = struct
+module Verifier_dummy_success = Verifier.Dummy
+
+module Verifier_dummy_fail = struct
+  type t = unit
+
+  let create = ""
+
+  let verify_blockchain_snark = ""
+end
+
+module MakeGenerator (Test_verifier : sig
+  type t
+
+  type ledger_proof
+
+  val create :
+       logger:Logger.t
+    -> proof_level:Genesis_constants.Proof_level.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
+    -> pids:Child_processes.Termination.t
+    -> conf_dir:string option
+    -> t Deferred.t
+
+  val verify_blockchain_snark :
+    t -> Blockchain_snark.Blockchain.t list -> bool Or_error.t Deferred.t
+
+  val verify_transaction_snarks :
+       t
+    -> (ledger_proof * Mina_base.Sok_message.t) list
+    -> bool Or_error.t Deferred.t
+
+  val verify_commands :
+       t
+    -> Mina_base.User_command.Verifiable.t list
+       (* The first level of error represents failure to verify, the second a failure in
+          communicating with the verifier. *)
+    -> [ `Valid of Mina_base.User_command.Valid.t
+       | `Invalid
+       | `Valid_assuming of
+         ( Pickles.Side_loaded.Verification_key.t
+         * Mina_base.Snapp_statement.t
+         * Pickles.Side_loaded.Proof.t )
+         list ]
+       list
+       Deferred.Or_error.t
+end) =
+struct
   open Quickcheck
   open Generator.Let_syntax
 
   type peer_config =
        precomputed_values:Precomputed_values.t
-    -> verifier:Verifier.t
+    -> verifier:Test_verifier.t
     -> max_frontier_length:int
     -> use_super_catchup:bool
     -> peer_state Generator.t
 
-  let fresh_peer ~precomputed_values ~verifier ~max_frontier_length
-      ~use_super_catchup =
+  let fresh_peer ~precomputed_values ~(verifier : Test_verifier.t)
+      ~max_frontier_length ~use_super_catchup =
     let epoch_ledger_location =
       Filename.temp_dir_name ^/ "epoch_ledger"
       ^ (Uuid_unix.create () |> Uuid.to_string)

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -2,17 +2,117 @@ open Async
 open Core
 open Gadt_lib
 open Network_peer
+open Mina_base
 
 (* There must be at least 2 peers to create a network *)
 type 'n num_peers = 'n Peano.gt_1
 
+(* type rpc_implementations =
+  { get_staged_ledger_aux_and_pending_coinbases_at_hash :
+         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+      -> ( Staged_ledger.Scan_state.t
+         * Marlin_plonk_bindings_pasta_fp.t
+         * Pending_coinbase.t
+         * Mina_state.Protocol_state.value list )
+         option
+         Deferred.t
+  ; get_some_initial_peers : unit Envelope.Incoming.t -> Peer.t list Deferred.t
+  ; answer_sync_ledger_query :
+         (Marlin_plonk_bindings_pasta_fp.t * Sync_ledger.Query.t)
+         Envelope.Incoming.t
+      -> (Sync_ledger.Answer.t, Error.t) result Deferred.t
+  ; get_ancestry :
+         ( Consensus.Data.Consensus_state.Value.t
+         , Marlin_plonk_bindings_pasta_fp.t )
+         With_hash.t
+         Envelope.Incoming.t
+      -> ( Mina_transition.External_transition.t
+         , State_body_hash.t list * Mina_transition.External_transition.t )
+         Proof_carrying_data.t
+         option
+         Deferred.t
+  ; get_best_tip :
+         unit Envelope.Incoming.t
+      -> ( Mina_transition.External_transition.t
+         , Marlin_plonk_bindings_pasta_fp.t list
+           * Mina_transition.External_transition.t )
+         Proof_carrying_data.t
+         option
+         Deferred.t
+  ; get_node_status :
+         unit Envelope.Incoming.t
+      -> (Mina_networking.Rpcs.Get_node_status.Node_status.t, Error.t) result
+         Deferred.t
+  ; get_transition_knowledge :
+         unit Envelope.Incoming.t
+      -> Marlin_plonk_bindings_pasta_fp.t list Deferred.t
+  ; get_transition_chain_proof :
+         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+      -> ( Marlin_plonk_bindings_pasta_fp.t
+         * Marlin_plonk_bindings_pasta_fp.t list )
+         option
+         Deferred.t
+  ; get_transition_chain :
+         Marlin_plonk_bindings_pasta_fp.t list Envelope.Incoming.t
+      -> Mina_transition.External_transition.t list option Deferred.t
+  }
+
+val rpc_implementations_default :
+     frontier:Transition_frontier.t
+  -> precomputed_values:Precomputed_values.t
+  -> logger:Logger.t
+  -> rpc_implementations *)
+
 type peer_state =
   { frontier : Transition_frontier.t
   ; consensus_local_state : Consensus.Data.Local_state.t
-  ; get_transition_chain_impl :
-      (   Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
-       -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t)
-      option
+  ; get_staged_ledger_aux_and_pending_coinbases_at_hash :
+         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+      -> ( Staged_ledger.Scan_state.t
+         * Marlin_plonk_bindings_pasta_fp.t
+         * Pending_coinbase.t
+         * Mina_state.Protocol_state.value list )
+         option
+         Deferred.t
+  ; get_some_initial_peers : unit Envelope.Incoming.t -> Peer.t list Deferred.t
+  ; answer_sync_ledger_query :
+         (Marlin_plonk_bindings_pasta_fp.t * Sync_ledger.Query.t)
+         Envelope.Incoming.t
+      -> (Sync_ledger.Answer.t, Error.t) result Deferred.t
+  ; get_ancestry :
+         ( Consensus.Data.Consensus_state.Value.t
+         , Marlin_plonk_bindings_pasta_fp.t )
+         With_hash.t
+         Envelope.Incoming.t
+      -> ( Mina_transition.External_transition.t
+         , State_body_hash.t list * Mina_transition.External_transition.t )
+         Proof_carrying_data.t
+         option
+         Deferred.t
+  ; get_best_tip :
+         unit Envelope.Incoming.t
+      -> ( Mina_transition.External_transition.t
+         , Marlin_plonk_bindings_pasta_fp.t list
+           * Mina_transition.External_transition.t )
+         Proof_carrying_data.t
+         option
+         Deferred.t
+  ; get_node_status :
+         unit Envelope.Incoming.t
+      -> (Mina_networking.Rpcs.Get_node_status.Node_status.t, Error.t) result
+         Deferred.t
+  ; get_transition_knowledge :
+         unit Envelope.Incoming.t
+      -> Marlin_plonk_bindings_pasta_fp.t list Deferred.t
+  ; get_transition_chain_proof :
+         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+      -> ( Marlin_plonk_bindings_pasta_fp.t
+         * Marlin_plonk_bindings_pasta_fp.t list )
+         option
+         Deferred.t
+  ; get_transition_chain :
+         Marlin_plonk_bindings_pasta_fp.t list Envelope.Incoming.t
+      -> Mina_transition.External_transition.t list option Deferred.t
   }
 
 type peer_network =
@@ -28,7 +128,7 @@ type nonrec 'n t =
   constraint 'n = _ num_peers
 
 val setup :
-     ?logger:Logger.t
+     logger:Logger.t
   -> ?trust_system:Trust_system.t
   -> ?time_controller:Block_time.Controller.t
   -> precomputed_values:Precomputed_values.t
@@ -39,26 +139,137 @@ module Generator : sig
   open Quickcheck
 
   type peer_config =
-       precomputed_values:Precomputed_values.t
+       logger:Logger.t
+    -> precomputed_values:Precomputed_values.t
     -> verifier:Verifier.t
     -> max_frontier_length:int
     -> use_super_catchup:bool
     -> peer_state Generator.t
 
+  val fresh_peer_custom_rpc :
+       ?get_staged_ledger_aux_and_pending_coinbases_at_hash:
+         (   Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+          -> ( Staged_ledger.Scan_state.t
+             * Marlin_plonk_bindings_pasta_fp.t
+             * Pending_coinbase.t
+             * Mina_state.Protocol_state.value list )
+             option
+             Deferred.t)
+    -> ?get_some_initial_peers:
+         (unit Envelope.Incoming.t -> Peer.t list Deferred.t)
+    -> ?answer_sync_ledger_query:
+         (   (Marlin_plonk_bindings_pasta_fp.t * Sync_ledger.Query.t)
+             Envelope.Incoming.t
+          -> (Sync_ledger.Answer.t, Error.t) result Deferred.t)
+    -> ?get_ancestry:
+         (   ( Consensus.Data.Consensus_state.Value.t
+             , Marlin_plonk_bindings_pasta_fp.t )
+             With_hash.t
+             Envelope.Incoming.t
+          -> ( Mina_transition.External_transition.t
+             , State_body_hash.t list * Mina_transition.External_transition.t
+             )
+             Proof_carrying_data.t
+             option
+             Deferred.t)
+    -> ?get_best_tip:
+         (   unit Envelope.Incoming.t
+          -> ( Mina_transition.External_transition.t
+             , Marlin_plonk_bindings_pasta_fp.t list
+               * Mina_transition.External_transition.t )
+             Proof_carrying_data.t
+             option
+             Deferred.t)
+    -> ?get_node_status:
+         (   unit Envelope.Incoming.t
+          -> ( Mina_networking.Rpcs.Get_node_status.Node_status.t
+             , Error.t )
+             result
+             Deferred.t)
+    -> ?get_transition_knowledge:
+         (   unit Envelope.Incoming.t
+          -> Marlin_plonk_bindings_pasta_fp.t list Deferred.t)
+    -> ?get_transition_chain_proof:
+         (   Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+          -> ( Marlin_plonk_bindings_pasta_fp.t
+             * Marlin_plonk_bindings_pasta_fp.t list )
+             option
+             Deferred.t)
+    -> ?get_transition_chain:
+         (   Marlin_plonk_bindings_pasta_fp.t list Envelope.Incoming.t
+          -> Mina_transition.External_transition.t list option Deferred.t)
+    -> peer_config
+
   val fresh_peer : peer_config
+
+  val peer_with_branch_custom_rpc :
+       frontier_branch_size:int
+    -> ?get_staged_ledger_aux_and_pending_coinbases_at_hash:
+         (   Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+          -> ( Staged_ledger.Scan_state.t
+             * Marlin_plonk_bindings_pasta_fp.t
+             * Pending_coinbase.t
+             * Mina_state.Protocol_state.value list )
+             option
+             Deferred.t)
+    -> ?get_some_initial_peers:
+         (unit Envelope.Incoming.t -> Peer.t list Deferred.t)
+    -> ?answer_sync_ledger_query:
+         (   (Marlin_plonk_bindings_pasta_fp.t * Sync_ledger.Query.t)
+             Envelope.Incoming.t
+          -> (Sync_ledger.Answer.t, Error.t) result Deferred.t)
+    -> ?get_ancestry:
+         (   ( Consensus.Data.Consensus_state.Value.t
+             , Marlin_plonk_bindings_pasta_fp.t )
+             With_hash.t
+             Envelope.Incoming.t
+          -> ( Mina_transition.External_transition.t
+             , State_body_hash.t list * Mina_transition.External_transition.t
+             )
+             Proof_carrying_data.t
+             option
+             Deferred.t)
+    -> ?get_best_tip:
+         (   unit Envelope.Incoming.t
+          -> ( Mina_transition.External_transition.t
+             , Marlin_plonk_bindings_pasta_fp.t list
+               * Mina_transition.External_transition.t )
+             Proof_carrying_data.t
+             option
+             Deferred.t)
+    -> ?get_node_status:
+         (   unit Envelope.Incoming.t
+          -> ( Mina_networking.Rpcs.Get_node_status.Node_status.t
+             , Error.t )
+             result
+             Deferred.t)
+    -> ?get_transition_knowledge:
+         (   unit Envelope.Incoming.t
+          -> Marlin_plonk_bindings_pasta_fp.t list Deferred.t)
+    -> ?get_transition_chain_proof:
+         (   Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
+          -> ( Marlin_plonk_bindings_pasta_fp.t
+             * Marlin_plonk_bindings_pasta_fp.t list )
+             option
+             Deferred.t)
+    -> ?get_transition_chain:
+         (   Marlin_plonk_bindings_pasta_fp.t list Envelope.Incoming.t
+          -> Mina_transition.External_transition.t list option Deferred.t)
+    -> peer_config
 
   val peer_with_branch : frontier_branch_size:int -> peer_config
 
-  val broken_rpc_peer_branch :
-       frontier_branch_size:int
-    -> get_transition_chain_impl_option:
-         (   Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
-          -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t)
-         option
-    -> peer_config
+  (* val broken_rpc_peer_branch :
+        frontier_branch_size:int
+     -> get_transition_chain_impl_option:
+          (   Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
+           -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t)
+          option
+     -> peer_config *)
 
   val gen :
-       precomputed_values:Precomputed_values.t
+       ?logger:Logger.t
+    -> precomputed_values:Precomputed_values.t
     -> verifier:Verifier.t
     -> max_frontier_length:int
     -> use_super_catchup:bool

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -7,62 +7,6 @@ open Mina_base
 (* There must be at least 2 peers to create a network *)
 type 'n num_peers = 'n Peano.gt_1
 
-(* type rpc_implementations =
-  { get_staged_ledger_aux_and_pending_coinbases_at_hash :
-         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
-      -> ( Staged_ledger.Scan_state.t
-         * Marlin_plonk_bindings_pasta_fp.t
-         * Pending_coinbase.t
-         * Mina_state.Protocol_state.value list )
-         option
-         Deferred.t
-  ; get_some_initial_peers : unit Envelope.Incoming.t -> Peer.t list Deferred.t
-  ; answer_sync_ledger_query :
-         (Marlin_plonk_bindings_pasta_fp.t * Sync_ledger.Query.t)
-         Envelope.Incoming.t
-      -> (Sync_ledger.Answer.t, Error.t) result Deferred.t
-  ; get_ancestry :
-         ( Consensus.Data.Consensus_state.Value.t
-         , Marlin_plonk_bindings_pasta_fp.t )
-         With_hash.t
-         Envelope.Incoming.t
-      -> ( Mina_transition.External_transition.t
-         , State_body_hash.t list * Mina_transition.External_transition.t )
-         Proof_carrying_data.t
-         option
-         Deferred.t
-  ; get_best_tip :
-         unit Envelope.Incoming.t
-      -> ( Mina_transition.External_transition.t
-         , Marlin_plonk_bindings_pasta_fp.t list
-           * Mina_transition.External_transition.t )
-         Proof_carrying_data.t
-         option
-         Deferred.t
-  ; get_node_status :
-         unit Envelope.Incoming.t
-      -> (Mina_networking.Rpcs.Get_node_status.Node_status.t, Error.t) result
-         Deferred.t
-  ; get_transition_knowledge :
-         unit Envelope.Incoming.t
-      -> Marlin_plonk_bindings_pasta_fp.t list Deferred.t
-  ; get_transition_chain_proof :
-         Marlin_plonk_bindings_pasta_fp.t Envelope.Incoming.t
-      -> ( Marlin_plonk_bindings_pasta_fp.t
-         * Marlin_plonk_bindings_pasta_fp.t list )
-         option
-         Deferred.t
-  ; get_transition_chain :
-         Marlin_plonk_bindings_pasta_fp.t list Envelope.Incoming.t
-      -> Mina_transition.External_transition.t list option Deferred.t
-  }
-
-val rpc_implementations_default :
-     frontier:Transition_frontier.t
-  -> precomputed_values:Precomputed_values.t
-  -> logger:Logger.t
-  -> rpc_implementations *)
-
 type peer_state =
   { frontier : Transition_frontier.t
   ; consensus_local_state : Consensus.Data.Local_state.t
@@ -258,14 +202,6 @@ module Generator : sig
     -> peer_config
 
   val peer_with_branch : frontier_branch_size:int -> peer_config
-
-  (* val broken_rpc_peer_branch :
-        frontier_branch_size:int
-     -> get_transition_chain_impl_option:
-          (   Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
-           -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t)
-          option
-     -> peer_config *)
 
   val gen :
        ?logger:Logger.t

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -1,5 +1,7 @@
+open Async
 open Core
 open Gadt_lib
+open Network_peer
 
 (* There must be at least 2 peers to create a network *)
 type 'n num_peers = 'n Peano.gt_1
@@ -7,6 +9,10 @@ type 'n num_peers = 'n Peano.gt_1
 type peer_state =
   { frontier : Transition_frontier.t
   ; consensus_local_state : Consensus.Data.Local_state.t
+  ; get_transition_chain_impl :
+      (   Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
+       -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t)
+      option
   }
 
 type peer_network =
@@ -42,6 +48,8 @@ module Generator : sig
   val fresh_peer : peer_config
 
   val peer_with_branch : frontier_branch_size:int -> peer_config
+
+  val broken_rpc_peer_branch : frontier_branch_size:int -> peer_config
 
   val gen :
        precomputed_values:Precomputed_values.t

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -49,7 +49,13 @@ module Generator : sig
 
   val peer_with_branch : frontier_branch_size:int -> peer_config
 
-  val broken_rpc_peer_branch : frontier_branch_size:int -> peer_config
+  val broken_rpc_peer_branch :
+       frontier_branch_size:int
+    -> get_transition_chain_impl_option:
+         (   Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
+          -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t)
+         option
+    -> peer_config
 
   val gen :
        precomputed_values:Precomputed_values.t

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -35,49 +35,12 @@ val setup :
   -> (peer_state, 'n num_peers) Vect.t
   -> 'n num_peers t
 
-module Verifier_dummy_success = Verifier.Dummy
-
-module MakeGenerator (Test_verifier : sig
-  type t
-
-  type ledger_proof
-
-  val create :
-       logger:Logger.t
-    -> proof_level:Genesis_constants.Proof_level.t
-    -> constraint_constants:Genesis_constants.Constraint_constants.t
-    -> pids:Child_processes.Termination.t
-    -> conf_dir:string option
-    -> t Deferred.t
-
-  val verify_blockchain_snark :
-    t -> Blockchain_snark.Blockchain.t list -> bool Or_error.t Deferred.t
-
-  val verify_transaction_snarks :
-       t
-    -> (ledger_proof * Mina_base.Sok_message.t) list
-    -> bool Or_error.t Deferred.t
-
-  val verify_commands :
-       t
-    -> Mina_base.User_command.Verifiable.t list
-       (* The first level of error represents failure to verify, the second a failure in
-          communicating with the verifier. *)
-    -> [ `Valid of Mina_base.User_command.Valid.t
-       | `Invalid
-       | `Valid_assuming of
-         ( Pickles.Side_loaded.Verification_key.t
-         * Mina_base.Snapp_statement.t
-         * Pickles.Side_loaded.Proof.t )
-         list ]
-       list
-       Deferred.Or_error.t
-end) : sig
+module Generator : sig
   open Quickcheck
 
   type peer_config =
        precomputed_values:Precomputed_values.t
-    -> verifier:Test_verifier.t
+    -> verifier:Verifier.t
     -> max_frontier_length:int
     -> use_super_catchup:bool
     -> peer_state Generator.t
@@ -96,7 +59,7 @@ end) : sig
 
   val gen :
        precomputed_values:Precomputed_values.t
-    -> verifier:Test_verifier.t
+    -> verifier:Verifier.t
     -> max_frontier_length:int
     -> use_super_catchup:bool
     -> (peer_config, 'n num_peers) Vect.t

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1420,10 +1420,8 @@ let%test_module "Ledger_catchup tests" =
 
     let%test_unit "catchup succeeds even if the parent transition is already \
                    in the frontier" =
-      let module Gener =
-        Fake_network.MakeGenerator (Fake_network.Verifier_dummy_success) in
       Quickcheck.test ~trials:1
-        Gener.(
+        Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup
             [ fresh_peer; peer_with_branch ~frontier_branch_size:1 ])
@@ -1510,109 +1508,106 @@ let%test_module "Ledger_catchup tests" =
                     "target transition should've been invalidated with a \
                      failure"))
 
-    (*
-       let%test_unit "when catchup fails to download a block, catchup will retry \
-                      and attempt again" =
-         let attempts_ivar = Ivar.create () in
-         let attempt_counter = ref 0 in
-         let impl_rpc :
-                Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
-             -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
-          fun _ ->
-           [%log info] "" ;
+    let%test_unit "when catchup fails to download a block, catchup will retry \
+                   and attempt again" =
+      let attempts_ivar = Ivar.create () in
+      let attempt_counter = ref 0 in
+      let impl_rpc :
+             Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
+          -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
+       fun _ ->
+        Deferred.return
+          ( if !attempt_counter > 0 then Ivar.fill attempts_ivar true
+            else attempt_counter := !attempt_counter + 1 ;
+            None )
+      in
 
-           Deferred.return
-             ( if !attempt_counter > 0 then Ivar.fill attempts_ivar true
-               else attempt_counter := !attempt_counter + 1 ;
-               None )
-         in
+      Quickcheck.test ~trials:1
+        Fake_network.Generator.(
+          gen ~precomputed_values ~verifier ~max_frontier_length
+            ~use_super_catchup
+            [ fresh_peer
+            ; broken_rpc_peer_branch
+                ~frontier_branch_size:(max_frontier_length / 2)
+                ~get_transition_chain_impl_option:(Some impl_rpc)
+            ])
+        ~f:(fun network ->
+          let open Fake_network in
+          let [ my_net; peer_net ] = network.peer_networks in
+          let target_best_tip_path =
+            [ Transition_frontier.best_tip peer_net.state.frontier ]
+          in
+          let open Fake_network in
+          let target_breadcrumb = List.last_exn target_best_tip_path in
+          let test =
+            setup_catchup_pipes ~network:my_net.network
+              ~frontier:my_net.state.frontier
+          in
+          let parent_hash =
+            Transition_frontier.Breadcrumb.parent_hash target_breadcrumb
+          in
+          let target_transition =
+            Transition_handler.Unprocessed_transition_cache.register_exn
+              test.cache
+              (downcast_breadcrumb target_breadcrumb)
+          in
+          Strict_pipe.Writer.write test.job_writer
+            (parent_hash, [ Rose_tree.T (target_transition, []) ]) ;
+          Thread_safe.block_on_async_exn (fun () ->
+              let final = Cache_lib.Cached.final_state target_transition in
 
-         Quickcheck.test ~trials:1
-           Fake_network.Generator.(
-             gen ~precomputed_values ~verifier ~max_frontier_length
-               ~use_super_catchup
-               [ fresh_peer
-               ; broken_rpc_peer_branch
-                   ~frontier_branch_size:(max_frontier_length / 2)
-                   ~get_transition_chain_impl_option:(Some impl_rpc)
-               ])
-           ~f:(fun network ->
-             let open Fake_network in
-             let [ my_net; peer_net ] = network.peer_networks in
-             let target_best_tip_path =
-               [ Transition_frontier.best_tip peer_net.state.frontier ]
-             in
-             let open Fake_network in
-             let target_breadcrumb = List.last_exn target_best_tip_path in
-             let test =
-               setup_catchup_pipes ~network:my_net.network
-                 ~frontier:my_net.state.frontier
-             in
-             let parent_hash =
-               Transition_frontier.Breadcrumb.parent_hash target_breadcrumb
-             in
-             let target_transition =
-               Transition_handler.Unprocessed_transition_cache.register_exn
-                 test.cache
-                 (downcast_breadcrumb target_breadcrumb)
-             in
-             Strict_pipe.Writer.write test.job_writer
-               (parent_hash, [ Rose_tree.T (target_transition, []) ]) ;
-             Thread_safe.block_on_async_exn (fun () ->
-                 let final = Cache_lib.Cached.final_state target_transition in
-
-                 match%map
-                   Deferred.any
-                     [ (Ivar.read final >>| fun x -> `Catchup_failed x)
-                     ; (Ivar.read attempts_ivar >>| fun _ -> `Attempts_exceeded)
-                     ; Strict_pipe.Reader.read test.breadcrumbs_reader
-                       >>| const `Catchup_success
-                     ]
-                 with
-                 | `Attempts_exceeded ->
-                     ()
-                 | `Catchup_success ->
-                     failwith
-                       "target transition should've been invalidated with a \
-                        failure"
-                 | `Catchup_failed fnl -> (
-                     match fnl with
-                     | `Success _ ->
-                         failwith "final state should be at `Failed"
-                     | `Failed ->
-                         let catchup_tree =
-                           match
-                             Transition_frontier.catchup_tree my_net.state.frontier
-                           with
-                           | Full tr ->
-                               tr
-                           | Hash _ ->
-                               failwith
-                                 "in super catchup unit tests, the catchup tree \
-                                  should always be Full_catchup_tree, but it is \
-                                  Catchup_hash_tree for some reason"
-                         in
-                         let catchup_tree_node_list =
-                           State_hash.Table.data catchup_tree.nodes
-                         in
-                         let catchup_tree_node =
-                           List.hd_exn catchup_tree_node_list
-                         in
-                         let num_attempts =
-                           Peer.Map.length catchup_tree_node.attempts
-                         in
-                         if num_attempts < 2 then
-                           let failstring =
-                             Format.sprintf
-                               "UNIT TEST FAILED.  catchup should have made more \
-                                attempts after failing to download a block.  \
-                                attempts= %d.  length of catchup_tree_node_list= \
-                                %d"
-                               num_attempts
-                               (List.length catchup_tree_node_list)
-                           in
-                           failwith failstring
-                         else () ))) *)
+              match%map
+                Deferred.any
+                  [ (Ivar.read final >>| fun x -> `Catchup_failed x)
+                  ; (Ivar.read attempts_ivar >>| fun _ -> `Attempts_exceeded)
+                  ; Strict_pipe.Reader.read test.breadcrumbs_reader
+                    >>| const `Catchup_success
+                  ]
+              with
+              | `Attempts_exceeded ->
+                  ()
+              | `Catchup_success ->
+                  failwith
+                    "target transition should've been invalidated with a \
+                     failure"
+              | `Catchup_failed fnl -> (
+                  match fnl with
+                  | `Success _ ->
+                      failwith "final state should be at `Failed"
+                  | `Failed ->
+                      let catchup_tree =
+                        match
+                          Transition_frontier.catchup_tree my_net.state.frontier
+                        with
+                        | Full tr ->
+                            tr
+                        | Hash _ ->
+                            failwith
+                              "in super catchup unit tests, the catchup tree \
+                               should always be Full_catchup_tree, but it is \
+                               Catchup_hash_tree for some reason"
+                      in
+                      let catchup_tree_node_list =
+                        State_hash.Table.data catchup_tree.nodes
+                      in
+                      let catchup_tree_node =
+                        List.hd_exn catchup_tree_node_list
+                      in
+                      let num_attempts =
+                        Peer.Map.length catchup_tree_node.attempts
+                      in
+                      if num_attempts < 2 then
+                        let failstring =
+                          Format.sprintf
+                            "UNIT TEST FAILED.  catchup should have made more \
+                             attempts after failing to download a block.  \
+                             attempts= %d.  length of catchup_tree_node_list= \
+                             %d"
+                            num_attempts
+                            (List.length catchup_tree_node_list)
+                        in
+                        failwith failstring
+                      else () )))
 
     let%test_unit "when initial validation of a blocks fails (except for the \
                    verifier_unreachable case), then catchup will cancel the \

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1518,7 +1518,6 @@ let%test_module "Ledger_catchup tests" =
             setup_catchup_pipes ~network:my_net.network
               ~frontier:my_net.state.frontier
           in
-          (* let { breadcrumbs_reader; job_writer; cache } = test in *)
           let parent_hash =
             Transition_frontier.Breadcrumb.parent_hash target_breadcrumb
           in
@@ -1531,8 +1530,6 @@ let%test_module "Ledger_catchup tests" =
           Strict_pipe.Writer.write test.job_writer
             (parent_hash, [ Rose_tree.T (target_transition, []) ]) ;
           Thread_safe.block_on_async_exn (fun () ->
-              (* let%bind _ = call_read ~test.breadcrumbs_reader ~target_best_tip_path ~my_peer:my_net [] 0 in *)
-              (* let breadcrumbs_tree = Rose_tree.of_list_exn breadcrumb_list in *)
               let final = Cache_lib.Cached.final_state target_transition in
               match%map
                 Deferred.any
@@ -1579,29 +1576,8 @@ let%test_module "Ledger_catchup tests" =
         in
         Deferred.return (Some [])
       in
-
-      (* let broken_nodes_state =
-           Fake_network.Generator.peer_with_branch ~precomputed_values ~verifier ~max_frontier_length
-           ~use_super_catchup  ~frontier_branch_size:(max_frontier_length / 2) ~rpc_impl:None
-         in *)
-
-      (* let broken_nodes_states =
-             Fake_network.Generator.gen ~precomputed_values ~verifier ~max_frontier_length
-                 ~use_super_catchup
-                 [Fake_network.Generator.peer_with_branch ~frontier_branch_size:(max_frontier_length / 2) ~rpc_impl:None
-                 ; Fake_network.Generator.peer_with_branch ~frontier_branch_size:(max_frontier_length / 2) ~rpc_impl:None
-                 ]
-           in
-           let broken_nodes_state = List.hd_exn (Vect.to_list broken_nodes_states)
-         in *)
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
-          (* let open Quickcheck.Generator.Let_syntax in
-             let%bind broken_nodes_state =
-               peer_with_branch ~precomputed_values
-                 ~verifier ~max_frontier_length ~use_super_catchup
-                 ~frontier_branch_size:(max_frontier_length / 2) ~rpc_impl:None
-             in *)
           gen ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup
             [ fresh_peer

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1573,17 +1573,18 @@ let%test_module "Ledger_catchup tests" =
              Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
           -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
        fun _ ->
-        Deferred.return
-          ( if !attempt_counter > 0 then Ivar.fill attempts_ivar true
-            else attempt_counter := !attempt_counter + 1 ;
-            None )
+        let () =
+          if !attempt_counter > 0 then Ivar.fill attempts_ivar true
+          else attempt_counter := !attempt_counter + 1
+        in
+        Deferred.return None
       in
-
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup
             [ fresh_peer
+              (* ; peer_with_branch ~frontier_branch_size:(max_frontier_length / 2) *)
             ; broken_rpc_peer_branch
                 ~frontier_branch_size:(max_frontier_length / 2)
                 ~get_transition_chain_impl_option:(Some impl_rpc)
@@ -1666,115 +1667,115 @@ let%test_module "Ledger_catchup tests" =
                         failwith failstring
                       else () )))
 
-    let%test_unit "when initial validation of a blocks fails (except for the \
-                   verifier_unreachable case), then catchup will cancel the \
-                   block's children's catchup job" =
-      Quickcheck.test ~trials:1
-        Fake_network.Generator.(
-          gen ~precomputed_values ~verifier ~max_frontier_length
-            ~use_super_catchup
-            [ fresh_peer
-            ; broken_rpc_peer_branch
-                ~frontier_branch_size:(max_frontier_length / 2)
-                ~get_transition_chain_impl_option:None
-              (* TODO: write some kind of mock that makes validation fail, and thus make the test pass *)
-            ])
-        ~f:(fun network ->
-          let open Fake_network in
-          let [ my_net; peer_net ] = network.peer_networks in
-          let target_best_tip_path =
-            Transition_frontier.best_tip_path peer_net.state.frontier
-          in
-          let open Fake_network in
-          let target_breadcrumb_child = List.last_exn target_best_tip_path in
-          let target_breadcrumb_child_hash =
-            Transition_frontier.Breadcrumb.state_hash target_breadcrumb_child
-          in
-          let target_breadcrumb_parent =
-            List.nth_exn target_best_tip_path
-              (List.length target_best_tip_path - 2)
-          in
-          let test =
-            setup_catchup_pipes ~network:my_net.network
-              ~frontier:my_net.state.frontier
-          in
-          let parent_hash =
-            Transition_frontier.Breadcrumb.parent_hash target_breadcrumb_parent
-          in
-          let target_transition_parent =
-            Transition_handler.Unprocessed_transition_cache.register_exn
-              test.cache
-              (downcast_breadcrumb target_breadcrumb_parent)
-          in
-          let target_transition_child =
-            Transition_handler.Unprocessed_transition_cache.register_exn
-              test.cache
-              (downcast_breadcrumb target_breadcrumb_child)
-          in
-          [%log info] "validation fails unit test" ;
-          Strict_pipe.Writer.write test.job_writer
-            ( parent_hash
-            , [ Rose_tree.T
-                  ( target_transition_parent
-                  , [ Rose_tree.T (target_transition_child, []) ] )
-              ] ) ;
-          Thread_safe.block_on_async_exn (fun () ->
-              let final =
-                Cache_lib.Cached.final_state target_transition_parent
-              in
-              match%map
-                Deferred.any
-                  [ (Ivar.read final >>| fun x -> `Catchup_failed x)
-                  ; Strict_pipe.Reader.read test.breadcrumbs_reader
-                    >>| const `Catchup_success
-                  ]
-              with
-              | `Catchup_success ->
-                  [%log info]
-                    "validation fails unit test: somehow incorrectly succeeded" ;
+    (* let%test_unit "when initial validation of a blocks fails (except for the \
+                    verifier_unreachable case), then catchup will cancel the \
+                    block's children's catchup job" =
+       Quickcheck.test ~trials:1
+         Fake_network.Generator.(
+           gen ~precomputed_values ~verifier ~max_frontier_length
+             ~use_super_catchup
+             [ fresh_peer
+             ; broken_rpc_peer_branch
+                 ~frontier_branch_size:(max_frontier_length / 2)
+                 ~get_transition_chain_impl_option:None
+               (* TODO: write some kind of mock that makes validation fail, and thus make the test pass *)
+             ])
+         ~f:(fun network ->
+           let open Fake_network in
+           let [ my_net; peer_net ] = network.peer_networks in
+           let target_best_tip_path =
+             Transition_frontier.best_tip_path peer_net.state.frontier
+           in
+           let open Fake_network in
+           let target_breadcrumb_child = List.last_exn target_best_tip_path in
+           let target_breadcrumb_child_hash =
+             Transition_frontier.Breadcrumb.state_hash target_breadcrumb_child
+           in
+           let target_breadcrumb_parent =
+             List.nth_exn target_best_tip_path
+               (List.length target_best_tip_path - 2)
+           in
+           let test =
+             setup_catchup_pipes ~network:my_net.network
+               ~frontier:my_net.state.frontier
+           in
+           let parent_hash =
+             Transition_frontier.Breadcrumb.parent_hash target_breadcrumb_parent
+           in
+           let target_transition_parent =
+             Transition_handler.Unprocessed_transition_cache.register_exn
+               test.cache
+               (downcast_breadcrumb target_breadcrumb_parent)
+           in
+           let target_transition_child =
+             Transition_handler.Unprocessed_transition_cache.register_exn
+               test.cache
+               (downcast_breadcrumb target_breadcrumb_child)
+           in
+           [%log info] "validation fails unit test" ;
+           Strict_pipe.Writer.write test.job_writer
+             ( parent_hash
+             , [ Rose_tree.T
+                   ( target_transition_parent
+                   , [ Rose_tree.T (target_transition_child, []) ] )
+               ] ) ;
+           Thread_safe.block_on_async_exn (fun () ->
+               let final =
+                 Cache_lib.Cached.final_state target_transition_parent
+               in
+               match%map
+                 Deferred.any
+                   [ (Ivar.read final >>| fun x -> `Catchup_failed x)
+                   ; Strict_pipe.Reader.read test.breadcrumbs_reader
+                     >>| const `Catchup_success
+                   ]
+               with
+               | `Catchup_success ->
+                   [%log info]
+                     "validation fails unit test: somehow incorrectly succeeded" ;
 
-                  failwith
-                    "target transition should've been invalidated with a \
-                     failure"
-              | `Catchup_failed fnl -> (
-                  match fnl with
-                  | `Success _ ->
-                      [%log info]
-                        "validation fails unit test: somehow incorrectly \
-                         succeeded" ;
-                      failwith "final state should be at `Failed"
-                  | `Failed ->
-                      [%log info]
-                        "validation fails unit test: correctly failed, running \
-                         checks" ;
+                   failwith
+                     "target transition should've been invalidated with a \
+                      failure"
+               | `Catchup_failed fnl -> (
+                   match fnl with
+                   | `Success _ ->
+                       [%log info]
+                         "validation fails unit test: somehow incorrectly \
+                          succeeded" ;
+                       failwith "final state should be at `Failed"
+                   | `Failed ->
+                       [%log info]
+                         "validation fails unit test: correctly failed, running \
+                          checks" ;
 
-                      let catchup_tree =
-                        match
-                          Transition_frontier.catchup_tree my_net.state.frontier
-                        with
-                        | Full tr ->
-                            tr
-                        | Hash _ ->
-                            failwith
-                              "in super catchup unit tests, the catchup tree \
-                               should always be Full_catchup_tree, but it is \
-                               Catchup_hash_tree for some reason"
-                      in
-                      let catchup_tree_node_list =
-                        State_hash.Table.data catchup_tree.nodes
-                      in
-                      List.iter catchup_tree_node_list ~f:(fun catchup_node ->
-                          let hash = catchup_node.state_hash in
-                          if
-                            Marlin_plonk_bindings_pasta_fp.equal hash
-                              target_breadcrumb_child_hash
-                          then
-                            failwith
-                              "the catchup job associated with \
-                               target_breadcrumb_child_hash should have been \
-                               cancelled and thus removed from the catchup \
-                               tree, but it is still here"
-                          else ()) )))
+                       let catchup_tree =
+                         match
+                           Transition_frontier.catchup_tree my_net.state.frontier
+                         with
+                         | Full tr ->
+                             tr
+                         | Hash _ ->
+                             failwith
+                               "in super catchup unit tests, the catchup tree \
+                                should always be Full_catchup_tree, but it is \
+                                Catchup_hash_tree for some reason"
+                       in
+                       let catchup_tree_node_list =
+                         State_hash.Table.data catchup_tree.nodes
+                       in
+                       List.iter catchup_tree_node_list ~f:(fun catchup_node ->
+                           let hash = catchup_node.state_hash in
+                           if
+                             Marlin_plonk_bindings_pasta_fp.equal hash
+                               target_breadcrumb_child_hash
+                           then
+                             failwith
+                               "the catchup job associated with \
+                                target_breadcrumb_child_hash should have been \
+                                cancelled and thus removed from the catchup \
+                                tree, but it is still here"
+                           else ()) ))) *)
 
     (* let%test_unit "when verification of a blocks fails, catchup will cancel \
                     its children's catchup job and remove the failed-to-verify \

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1579,21 +1579,54 @@ let%test_module "Ledger_catchup tests" =
         in
         Deferred.return (Some [])
       in
+
+      (* let broken_nodes_state =
+           Fake_network.Generator.peer_with_branch ~precomputed_values ~verifier ~max_frontier_length
+           ~use_super_catchup  ~frontier_branch_size:(max_frontier_length / 2) ~rpc_impl:None
+         in *)
+
+      (* let broken_nodes_states =
+             Fake_network.Generator.gen ~precomputed_values ~verifier ~max_frontier_length
+                 ~use_super_catchup
+                 [Fake_network.Generator.peer_with_branch ~frontier_branch_size:(max_frontier_length / 2) ~rpc_impl:None
+                 ; Fake_network.Generator.peer_with_branch ~frontier_branch_size:(max_frontier_length / 2) ~rpc_impl:None
+                 ]
+           in
+           let broken_nodes_state = List.hd_exn (Vect.to_list broken_nodes_states)
+         in *)
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
+          (* let open Quickcheck.Generator.Let_syntax in
+             let%bind broken_nodes_state =
+               peer_with_branch ~precomputed_values
+                 ~verifier ~max_frontier_length ~use_super_catchup
+                 ~frontier_branch_size:(max_frontier_length / 2) ~rpc_impl:None
+             in *)
           gen ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup
             [ fresh_peer
               (* ; peer_with_branch ~frontier_branch_size:(max_frontier_length / 2) *)
-            ; broken_rpc_peer_branch
+            ; peer_with_branch_custom_rpc
                 ~frontier_branch_size:(max_frontier_length / 2)
-                ~get_transition_chain_impl_option:(Some impl_rpc)
-            ; broken_rpc_peer_branch
+                ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
+                ?get_some_initial_peers:None ?answer_sync_ledger_query:None
+                ?get_ancestry:None ?get_best_tip:None ?get_node_status:None
+                ?get_transition_knowledge:None ?get_transition_chain_proof:None
+                ?get_transition_chain:(Some impl_rpc)
+            ; peer_with_branch_custom_rpc
                 ~frontier_branch_size:(max_frontier_length / 2)
-                ~get_transition_chain_impl_option:(Some impl_rpc)
-            ; broken_rpc_peer_branch
+                ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
+                ?get_some_initial_peers:None ?answer_sync_ledger_query:None
+                ?get_ancestry:None ?get_best_tip:None ?get_node_status:None
+                ?get_transition_knowledge:None ?get_transition_chain_proof:None
+                ?get_transition_chain:(Some impl_rpc)
+            ; peer_with_branch_custom_rpc
                 ~frontier_branch_size:(max_frontier_length / 2)
-                ~get_transition_chain_impl_option:(Some impl_rpc)
+                ?get_staged_ledger_aux_and_pending_coinbases_at_hash:None
+                ?get_some_initial_peers:None ?answer_sync_ledger_query:None
+                ?get_ancestry:None ?get_best_tip:None ?get_node_status:None
+                ?get_transition_knowledge:None ?get_transition_chain_proof:None
+                ?get_transition_chain:(Some impl_rpc)
             ])
         ~f:(fun network ->
           let open Fake_network in

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1509,7 +1509,7 @@ let%test_module "Ledger_catchup tests" =
           gen ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup
             [ fresh_peer
-            ; peer_with_branch
+            ; broken_rpc_peer_branch
                 ~frontier_branch_size:((max_frontier_length * 3) + 1)
             ])
         ~f:(fun network ->

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1254,6 +1254,12 @@ let%test_module "Ledger_catchup tests" =
             ~conf_dir:None
             ~pids:(Child_processes.Termination.create_pid_table ()))
 
+    (* let mock_verifier =
+       Async.Thread_safe.block_on_async_exn (fun () ->
+           Verifier.Dummy.create ~logger ~proof_level ~constraint_constants
+             ~conf_dir:None
+             ~pids:(Child_processes.Termination.create_pid_table ())) *)
+
     let downcast_transition transition =
       let transition =
         transition
@@ -1502,89 +1508,106 @@ let%test_module "Ledger_catchup tests" =
                     "target transition should've been invalidated with a \
                      failure"))
 
-    (* let%test_unit "when catchup fails to download a block, catchup will retry \
-                    and attempt again" =
-       Quickcheck.test ~trials:1
-         Fake_network.Generator.(
-           gen ~precomputed_values ~verifier ~max_frontier_length
-             ~use_super_catchup
-             [ fresh_peer
-             ; broken_rpc_peer_branch
-                 ~frontier_branch_size:(max_frontier_length / 2)
-             ])
-         ~f:(fun network ->
-           let open Fake_network in
-           let [ my_net; peer_net ] = network.peer_networks in
-           let target_best_tip_path =
-             [ Transition_frontier.best_tip peer_net.state.frontier ]
-           in
-           let open Fake_network in
-           let target_breadcrumb = List.last_exn target_best_tip_path in
-           let test =
-             setup_catchup_pipes ~network:my_net.network
-               ~frontier:my_net.state.frontier
-           in
-           let parent_hash =
-             Transition_frontier.Breadcrumb.parent_hash target_breadcrumb
-           in
-           let target_transition =
-             Transition_handler.Unprocessed_transition_cache.register_exn
-               test.cache
-               (downcast_breadcrumb target_breadcrumb)
-           in
-           Strict_pipe.Writer.write test.job_writer
-             (parent_hash, [ Rose_tree.T (target_transition, []) ]) ;
-           Thread_safe.block_on_async_exn (fun () ->
-               let final = Cache_lib.Cached.final_state target_transition in
-               match%map
-                 Deferred.any
-                   [ (Ivar.read final >>| fun x -> `Catchup_failed x)
-                   ; Strict_pipe.Reader.read test.breadcrumbs_reader
-                     >>| const `Catchup_success
-                   ]
-               with
-               | `Catchup_success ->
-                   failwith
-                     "target transition should've been invalidated with a \
-                      failure"
-               | `Catchup_failed fnl -> (
-                   match fnl with
-                   | `Success _ ->
-                       failwith "final state should be at `Failed"
-                   | `Failed ->
-                       let catchup_tree =
-                         match
-                           Transition_frontier.catchup_tree my_net.state.frontier
-                         with
-                         | Full tr ->
-                             tr
-                         | Hash _ ->
-                             failwith
-                               "in super catchup unit tests, the catchup tree \
-                                should always be Full_catchup_tree, but it is \
-                                Catchup_hash_tree for some reason"
-                       in
-                       let catchup_tree_node_list =
-                         State_hash.Table.data catchup_tree.nodes
-                       in
-                       let catchup_tree_node =
-                         List.hd_exn catchup_tree_node_list
-                       in
-                       let num_attempts =
-                         Peer.Map.length catchup_tree_node.attempts
-                       in
-                       if num_attempts < 2 then
-                         let failstring =
-                           Format.sprintf
-                             "UNIT TEST FAILED.  catchup should have made more \
-                              attempts after failing to download a block.  \
-                              attempts= %d.  length of catchup_tree_node_list= \
-                              %d"
-                             num_attempts
-                             (List.length catchup_tree_node_list)
-                         in
-                         failwith failstring
-                       else () ))) *)
+    let%test_unit "when catchup fails to download a block, catchup will retry \
+                   and attempt again" =
+      let attempts_ivar = Ivar.create () in
+      let attempt_counter = ref 0 in
+      let impl_rpc :
+             Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
+          -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
+       fun _ ->
+        Deferred.return
+          ( if !attempt_counter > 0 then Ivar.fill attempts_ivar true
+            else attempt_counter := !attempt_counter + 1 ;
+            None )
+      in
+
+      Quickcheck.test ~trials:1
+        Fake_network.Generator.(
+          gen ~precomputed_values ~verifier ~max_frontier_length
+            ~use_super_catchup
+            [ fresh_peer
+            ; broken_rpc_peer_branch
+                ~frontier_branch_size:(max_frontier_length / 2)
+                ~get_transition_chain_impl_option:(Some impl_rpc)
+            ])
+        ~f:(fun network ->
+          let open Fake_network in
+          let [ my_net; peer_net ] = network.peer_networks in
+          let target_best_tip_path =
+            [ Transition_frontier.best_tip peer_net.state.frontier ]
+          in
+          let open Fake_network in
+          let target_breadcrumb = List.last_exn target_best_tip_path in
+          let test =
+            setup_catchup_pipes ~network:my_net.network
+              ~frontier:my_net.state.frontier
+          in
+          let parent_hash =
+            Transition_frontier.Breadcrumb.parent_hash target_breadcrumb
+          in
+          let target_transition =
+            Transition_handler.Unprocessed_transition_cache.register_exn
+              test.cache
+              (downcast_breadcrumb target_breadcrumb)
+          in
+          Strict_pipe.Writer.write test.job_writer
+            (parent_hash, [ Rose_tree.T (target_transition, []) ]) ;
+          Thread_safe.block_on_async_exn (fun () ->
+              let final = Cache_lib.Cached.final_state target_transition in
+
+              match%map
+                Deferred.any
+                  [ (Ivar.read final >>| fun x -> `Catchup_failed x)
+                  ; (Ivar.read attempts_ivar >>| fun _ -> `Attempts_exceeded)
+                  ; Strict_pipe.Reader.read test.breadcrumbs_reader
+                    >>| const `Catchup_success
+                  ]
+              with
+              | `Attempts_exceeded ->
+                  ()
+              | `Catchup_success ->
+                  failwith
+                    "target transition should've been invalidated with a \
+                     failure"
+              | `Catchup_failed fnl -> (
+                  match fnl with
+                  | `Success _ ->
+                      failwith "final state should be at `Failed"
+                  | `Failed ->
+                      let catchup_tree =
+                        match
+                          Transition_frontier.catchup_tree my_net.state.frontier
+                        with
+                        | Full tr ->
+                            tr
+                        | Hash _ ->
+                            failwith
+                              "in super catchup unit tests, the catchup tree \
+                               should always be Full_catchup_tree, but it is \
+                               Catchup_hash_tree for some reason"
+                      in
+                      let catchup_tree_node_list =
+                        State_hash.Table.data catchup_tree.nodes
+                      in
+                      let catchup_tree_node =
+                        List.hd_exn catchup_tree_node_list
+                      in
+                      let num_attempts =
+                        Peer.Map.length catchup_tree_node.attempts
+                      in
+                      if num_attempts < 2 then
+                        let failstring =
+                          Format.sprintf
+                            "UNIT TEST FAILED.  catchup should have made more \
+                             attempts after failing to download a block.  \
+                             attempts= %d.  length of catchup_tree_node_list= \
+                             %d"
+                            num_attempts
+                            (List.length catchup_tree_node_list)
+                        in
+                        failwith failstring
+                      else () )))
 
     let%test_unit "when initial validation of a blocks fails (except for the \
                    verifier_unreachable case), then catchup will cancel the \
@@ -1596,6 +1619,7 @@ let%test_module "Ledger_catchup tests" =
             [ fresh_peer
             ; broken_rpc_peer_branch
                 ~frontier_branch_size:(max_frontier_length / 2)
+                ~get_transition_chain_impl_option:None
               (* TODO, write some kind of mock that makes validation fail *)
             ])
         ~f:(fun network ->

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1567,18 +1567,18 @@ let%test_module "Ledger_catchup tests" =
 
     let%test_unit "when catchup fails to download a block, catchup will retry \
                    and attempt again" =
-      (* let attempts_ivar = Ivar.create () in
-         let attempt_counter = ref 0 in
-         let impl_rpc :
-                Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
-             -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
-          fun _ ->
-           let () =
-             attempt_counter := !attempt_counter + 1;
-             if !attempt_counter > 1 then Ivar.fill attempts_ivar true;
-           in
-           Deferred.return None
-         in *)
+      let attempts_ivar = Ivar.create () in
+      let attempt_counter = ref 0 in
+      let impl_rpc :
+             Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
+          -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
+       fun _ ->
+        let () =
+          attempt_counter := !attempt_counter + 1 ;
+          if !attempt_counter > 1 then Ivar.fill attempts_ivar true
+        in
+        Deferred.return None
+      in
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
           gen ~precomputed_values ~verifier ~max_frontier_length
@@ -1587,7 +1587,7 @@ let%test_module "Ledger_catchup tests" =
               (* ; peer_with_branch ~frontier_branch_size:(max_frontier_length / 2) *)
             ; broken_rpc_peer_branch
                 ~frontier_branch_size:(max_frontier_length / 2)
-                ~get_transition_chain_impl_option:None
+                ~get_transition_chain_impl_option:(Some impl_rpc)
             ])
         ~f:(fun network ->
           let open Fake_network in
@@ -1612,90 +1612,90 @@ let%test_module "Ledger_catchup tests" =
           Strict_pipe.Writer.write test.job_writer
             (parent_hash, [ Rose_tree.T (target_transition, []) ]) ;
           Thread_safe.block_on_async_exn (fun () ->
-              let catchup_tree =
-                match
-                  Transition_frontier.catchup_tree my_net.state.frontier
-                with
-                | Full tr ->
-                    tr
-                | Hash _ ->
-                    failwith
-                      "in super catchup unit tests, the catchup tree should \
-                       always be Full_catchup_tree, but it is \
-                       Catchup_hash_tree for some reason"
-              in
-              let catchup_tree_node_list =
-                State_hash.Table.data catchup_tree.nodes
-              in
-              let catchup_tree_node = List.hd_exn catchup_tree_node_list in
+              (* let catchup_tree =
+                   match
+                     Transition_frontier.catchup_tree my_net.state.frontier
+                   with
+                   | Full tr ->
+                       tr
+                   | Hash _ ->
+                       failwith
+                         "in super catchup unit tests, the catchup tree should \
+                          always be Full_catchup_tree, but it is \
+                          Catchup_hash_tree for some reason"
+                 in
+                 let catchup_tree_node_list =
+                   State_hash.Table.data catchup_tree.nodes
+                 in
+                 let catchup_tree_node = List.hd_exn catchup_tree_node_list in
 
-              let rec check ~start_time () =
-                let num_attempts = Peer.Map.length catchup_tree_node.attempts in
-                if num_attempts < 2 then
-                  let%bind () = Async.Scheduler.yield () in
-                  let elapsed_seconds =
-                    Time.Span.to_sec (Time.diff (Time.now ()) start_time)
-                  in
-                  if Float.compare elapsed_seconds 300.0 < 0 then
-                    check ~start_time ()
-                  else failwith "time limit exceeded"
-                else Deferred.return ()
-              in
-              let start_time = Time.now () in
-              check ~start_time ()
-              (* let final = Cache_lib.Cached.final_state target_transition in *)
-              (* match%map
-                   Deferred.any
-                     [ (Ivar.read final >>| fun x -> `Catchup_failed x)
-                     ; (Ivar.read attempts_ivar >>| fun _ -> `Attempts_exceeded)
-                     ; Strict_pipe.Reader.read test.breadcrumbs_reader
-                       >>| const `Catchup_success
-                     ]
-                 with
-                 | `Attempts_exceeded ->
-                     ()
-                 | `Catchup_success ->
-                     failwith
-                       "target transition should've been invalidated with a \
-                        failure"
-                 | `Catchup_failed fnl -> (
-                     match fnl with
-                     | `Success _ ->
-                         failwith "final state should be at `Failed"
-                     | `Failed ->
-                         let catchup_tree =
-                           match
-                             Transition_frontier.catchup_tree my_net.state.frontier
-                           with
-                           | Full tr ->
-                               tr
-                           | Hash _ ->
-                               failwith
-                                 "in super catchup unit tests, the catchup tree \
-                                  should always be Full_catchup_tree, but it is \
-                                  Catchup_hash_tree for some reason"
-                         in
-                         let catchup_tree_node_list =
-                           State_hash.Table.data catchup_tree.nodes
-                         in
-                         let catchup_tree_node =
-                           List.hd_exn catchup_tree_node_list
-                         in
-                         let num_attempts =
-                           Peer.Map.length catchup_tree_node.attempts
-                         in
-                         if num_attempts < 2 then
-                           let failstring =
-                             Format.sprintf
-                               "UNIT TEST FAILED.  catchup should have made more \
-                                attempts after failing to download a block.  \
-                                attempts= %d.  length of catchup_tree_node_list= \
-                                %d"
-                               num_attempts
-                               (List.length catchup_tree_node_list)
-                           in
-                           failwith failstring
-                         else () ) *)))
+                 let rec check ~start_time () =
+                   let num_attempts = Peer.Map.length catchup_tree_node.attempts in
+                   if num_attempts < 1 then
+                     let%bind () = Async.Scheduler.yield () in
+                     let elapsed_seconds =
+                       Time.Span.to_sec (Time.diff (Time.now ()) start_time)
+                     in
+                     if Float.compare elapsed_seconds 300.0 < 0 then
+                       check ~start_time ()
+                     else failwith "time limit exceeded"
+                   else Deferred.return ()
+                 in
+                 let start_time = Time.now () in
+                 check ~start_time () *)
+              let final = Cache_lib.Cached.final_state target_transition in
+              match%map
+                Deferred.any
+                  [ (Ivar.read final >>| fun x -> `Catchup_failed x)
+                  ; (Ivar.read attempts_ivar >>| fun _ -> `Attempts_exceeded)
+                  ; Strict_pipe.Reader.read test.breadcrumbs_reader
+                    >>| const `Catchup_success
+                  ]
+              with
+              | `Attempts_exceeded ->
+                  ()
+              | `Catchup_success ->
+                  failwith
+                    "target transition should've been invalidated with a \
+                     failure"
+              | `Catchup_failed fnl -> (
+                  match fnl with
+                  | `Success _ ->
+                      failwith "final state should be at `Failed"
+                  | `Failed ->
+                      let catchup_tree =
+                        match
+                          Transition_frontier.catchup_tree my_net.state.frontier
+                        with
+                        | Full tr ->
+                            tr
+                        | Hash _ ->
+                            failwith
+                              "in super catchup unit tests, the catchup tree \
+                               should always be Full_catchup_tree, but it is \
+                               Catchup_hash_tree for some reason"
+                      in
+                      let catchup_tree_node_list =
+                        State_hash.Table.data catchup_tree.nodes
+                      in
+                      let catchup_tree_node =
+                        List.hd_exn catchup_tree_node_list
+                      in
+                      let num_attempts =
+                        Peer.Map.length catchup_tree_node.attempts
+                      in
+                      if num_attempts < 2 then
+                        let failstring =
+                          Format.sprintf
+                            "UNIT TEST FAILED.  catchup should have made more \
+                             attempts after failing to download a block.  \
+                             attempts= %d.  length of catchup_tree_node_list= \
+                             %d"
+                            num_attempts
+                            (List.length catchup_tree_node_list)
+                        in
+                        failwith failstring
+                      else () )))
 
     (* let%test_unit "when initial validation of a blocks fails (except for the \
                     verifier_unreachable case), then catchup will cancel the \

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1420,8 +1420,10 @@ let%test_module "Ledger_catchup tests" =
 
     let%test_unit "catchup succeeds even if the parent transition is already \
                    in the frontier" =
+      let module Gener =
+        Fake_network.MakeGenerator (Fake_network.Verifier_dummy_success) in
       Quickcheck.test ~trials:1
-        Fake_network.Generator.(
+        Gener.(
           gen ~precomputed_values ~verifier ~max_frontier_length
             ~use_super_catchup
             [ fresh_peer; peer_with_branch ~frontier_branch_size:1 ])
@@ -1508,106 +1510,109 @@ let%test_module "Ledger_catchup tests" =
                     "target transition should've been invalidated with a \
                      failure"))
 
-    let%test_unit "when catchup fails to download a block, catchup will retry \
-                   and attempt again" =
-      let attempts_ivar = Ivar.create () in
-      let attempt_counter = ref 0 in
-      let impl_rpc :
-             Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
-          -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
-       fun _ ->
-        Deferred.return
-          ( if !attempt_counter > 0 then Ivar.fill attempts_ivar true
-            else attempt_counter := !attempt_counter + 1 ;
-            None )
-      in
+    (*
+       let%test_unit "when catchup fails to download a block, catchup will retry \
+                      and attempt again" =
+         let attempts_ivar = Ivar.create () in
+         let attempt_counter = ref 0 in
+         let impl_rpc :
+                Mina_networking.Rpcs.Get_transition_chain.query Envelope.Incoming.t
+             -> Mina_networking.Rpcs.Get_transition_chain.response Deferred.t =
+          fun _ ->
+           [%log info] "" ;
 
-      Quickcheck.test ~trials:1
-        Fake_network.Generator.(
-          gen ~precomputed_values ~verifier ~max_frontier_length
-            ~use_super_catchup
-            [ fresh_peer
-            ; broken_rpc_peer_branch
-                ~frontier_branch_size:(max_frontier_length / 2)
-                ~get_transition_chain_impl_option:(Some impl_rpc)
-            ])
-        ~f:(fun network ->
-          let open Fake_network in
-          let [ my_net; peer_net ] = network.peer_networks in
-          let target_best_tip_path =
-            [ Transition_frontier.best_tip peer_net.state.frontier ]
-          in
-          let open Fake_network in
-          let target_breadcrumb = List.last_exn target_best_tip_path in
-          let test =
-            setup_catchup_pipes ~network:my_net.network
-              ~frontier:my_net.state.frontier
-          in
-          let parent_hash =
-            Transition_frontier.Breadcrumb.parent_hash target_breadcrumb
-          in
-          let target_transition =
-            Transition_handler.Unprocessed_transition_cache.register_exn
-              test.cache
-              (downcast_breadcrumb target_breadcrumb)
-          in
-          Strict_pipe.Writer.write test.job_writer
-            (parent_hash, [ Rose_tree.T (target_transition, []) ]) ;
-          Thread_safe.block_on_async_exn (fun () ->
-              let final = Cache_lib.Cached.final_state target_transition in
+           Deferred.return
+             ( if !attempt_counter > 0 then Ivar.fill attempts_ivar true
+               else attempt_counter := !attempt_counter + 1 ;
+               None )
+         in
 
-              match%map
-                Deferred.any
-                  [ (Ivar.read final >>| fun x -> `Catchup_failed x)
-                  ; (Ivar.read attempts_ivar >>| fun _ -> `Attempts_exceeded)
-                  ; Strict_pipe.Reader.read test.breadcrumbs_reader
-                    >>| const `Catchup_success
-                  ]
-              with
-              | `Attempts_exceeded ->
-                  ()
-              | `Catchup_success ->
-                  failwith
-                    "target transition should've been invalidated with a \
-                     failure"
-              | `Catchup_failed fnl -> (
-                  match fnl with
-                  | `Success _ ->
-                      failwith "final state should be at `Failed"
-                  | `Failed ->
-                      let catchup_tree =
-                        match
-                          Transition_frontier.catchup_tree my_net.state.frontier
-                        with
-                        | Full tr ->
-                            tr
-                        | Hash _ ->
-                            failwith
-                              "in super catchup unit tests, the catchup tree \
-                               should always be Full_catchup_tree, but it is \
-                               Catchup_hash_tree for some reason"
-                      in
-                      let catchup_tree_node_list =
-                        State_hash.Table.data catchup_tree.nodes
-                      in
-                      let catchup_tree_node =
-                        List.hd_exn catchup_tree_node_list
-                      in
-                      let num_attempts =
-                        Peer.Map.length catchup_tree_node.attempts
-                      in
-                      if num_attempts < 2 then
-                        let failstring =
-                          Format.sprintf
-                            "UNIT TEST FAILED.  catchup should have made more \
-                             attempts after failing to download a block.  \
-                             attempts= %d.  length of catchup_tree_node_list= \
-                             %d"
-                            num_attempts
-                            (List.length catchup_tree_node_list)
-                        in
-                        failwith failstring
-                      else () )))
+         Quickcheck.test ~trials:1
+           Fake_network.Generator.(
+             gen ~precomputed_values ~verifier ~max_frontier_length
+               ~use_super_catchup
+               [ fresh_peer
+               ; broken_rpc_peer_branch
+                   ~frontier_branch_size:(max_frontier_length / 2)
+                   ~get_transition_chain_impl_option:(Some impl_rpc)
+               ])
+           ~f:(fun network ->
+             let open Fake_network in
+             let [ my_net; peer_net ] = network.peer_networks in
+             let target_best_tip_path =
+               [ Transition_frontier.best_tip peer_net.state.frontier ]
+             in
+             let open Fake_network in
+             let target_breadcrumb = List.last_exn target_best_tip_path in
+             let test =
+               setup_catchup_pipes ~network:my_net.network
+                 ~frontier:my_net.state.frontier
+             in
+             let parent_hash =
+               Transition_frontier.Breadcrumb.parent_hash target_breadcrumb
+             in
+             let target_transition =
+               Transition_handler.Unprocessed_transition_cache.register_exn
+                 test.cache
+                 (downcast_breadcrumb target_breadcrumb)
+             in
+             Strict_pipe.Writer.write test.job_writer
+               (parent_hash, [ Rose_tree.T (target_transition, []) ]) ;
+             Thread_safe.block_on_async_exn (fun () ->
+                 let final = Cache_lib.Cached.final_state target_transition in
+
+                 match%map
+                   Deferred.any
+                     [ (Ivar.read final >>| fun x -> `Catchup_failed x)
+                     ; (Ivar.read attempts_ivar >>| fun _ -> `Attempts_exceeded)
+                     ; Strict_pipe.Reader.read test.breadcrumbs_reader
+                       >>| const `Catchup_success
+                     ]
+                 with
+                 | `Attempts_exceeded ->
+                     ()
+                 | `Catchup_success ->
+                     failwith
+                       "target transition should've been invalidated with a \
+                        failure"
+                 | `Catchup_failed fnl -> (
+                     match fnl with
+                     | `Success _ ->
+                         failwith "final state should be at `Failed"
+                     | `Failed ->
+                         let catchup_tree =
+                           match
+                             Transition_frontier.catchup_tree my_net.state.frontier
+                           with
+                           | Full tr ->
+                               tr
+                           | Hash _ ->
+                               failwith
+                                 "in super catchup unit tests, the catchup tree \
+                                  should always be Full_catchup_tree, but it is \
+                                  Catchup_hash_tree for some reason"
+                         in
+                         let catchup_tree_node_list =
+                           State_hash.Table.data catchup_tree.nodes
+                         in
+                         let catchup_tree_node =
+                           List.hd_exn catchup_tree_node_list
+                         in
+                         let num_attempts =
+                           Peer.Map.length catchup_tree_node.attempts
+                         in
+                         if num_attempts < 2 then
+                           let failstring =
+                             Format.sprintf
+                               "UNIT TEST FAILED.  catchup should have made more \
+                                attempts after failing to download a block.  \
+                                attempts= %d.  length of catchup_tree_node_list= \
+                                %d"
+                               num_attempts
+                               (List.length catchup_tree_node_list)
+                           in
+                           failwith failstring
+                         else () ))) *)
 
     let%test_unit "when initial validation of a blocks fails (except for the \
                    verifier_unreachable case), then catchup will cancel the \

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1586,6 +1586,104 @@ let%test_module "Ledger_catchup tests" =
                          failwith failstring
                        else () ))) *)
 
+    let%test_unit "when initial validation of a blocks fails (except for the \
+                   verifier_unreachable case), then catchup will cancel the \
+                   block's children's catchup job" =
+      Quickcheck.test ~trials:1
+        Fake_network.Generator.(
+          gen ~precomputed_values ~verifier ~max_frontier_length
+            ~use_super_catchup
+            [ fresh_peer
+            ; broken_rpc_peer_branch
+                ~frontier_branch_size:(max_frontier_length / 2)
+              (* TODO, write some kind of mock that makes validation fail *)
+            ])
+        ~f:(fun network ->
+          let open Fake_network in
+          let [ my_net; peer_net ] = network.peer_networks in
+          let target_best_tip_path =
+            [ Transition_frontier.best_tip peer_net.state.frontier ]
+          in
+          let open Fake_network in
+          let target_breadcrumb_child = List.last_exn target_best_tip_path in
+          let target_breadcrumb_child_hash =
+            Transition_frontier.Breadcrumb.state_hash target_breadcrumb_child
+          in
+          let target_breadcrumb_parent =
+            List.nth_exn target_best_tip_path
+              (List.length target_best_tip_path - 2)
+          in
+          let test =
+            setup_catchup_pipes ~network:my_net.network
+              ~frontier:my_net.state.frontier
+          in
+          let parent_hash =
+            Transition_frontier.Breadcrumb.parent_hash target_breadcrumb_parent
+          in
+          let target_transition_parent =
+            Transition_handler.Unprocessed_transition_cache.register_exn
+              test.cache
+              (downcast_breadcrumb target_breadcrumb_parent)
+          in
+          let target_transition_child =
+            Transition_handler.Unprocessed_transition_cache.register_exn
+              test.cache
+              (downcast_breadcrumb target_breadcrumb_child)
+          in
+          Strict_pipe.Writer.write test.job_writer
+            ( parent_hash
+            , [ Rose_tree.T
+                  ( target_transition_parent
+                  , [ Rose_tree.T (target_transition_child, []) ] )
+              ] ) ;
+          Thread_safe.block_on_async_exn (fun () ->
+              let final =
+                Cache_lib.Cached.final_state target_transition_parent
+              in
+              match%map
+                Deferred.any
+                  [ (Ivar.read final >>| fun x -> `Catchup_failed x)
+                  ; Strict_pipe.Reader.read test.breadcrumbs_reader
+                    >>| const `Catchup_success
+                  ]
+              with
+              | `Catchup_success ->
+                  failwith
+                    "target transition should've been invalidated with a \
+                     failure"
+              | `Catchup_failed fnl -> (
+                  match fnl with
+                  | `Success _ ->
+                      failwith "final state should be at `Failed"
+                  | `Failed ->
+                      let catchup_tree =
+                        match
+                          Transition_frontier.catchup_tree my_net.state.frontier
+                        with
+                        | Full tr ->
+                            tr
+                        | Hash _ ->
+                            failwith
+                              "in super catchup unit tests, the catchup tree \
+                               should always be Full_catchup_tree, but it is \
+                               Catchup_hash_tree for some reason"
+                      in
+                      let catchup_tree_node_list =
+                        State_hash.Table.data catchup_tree.nodes
+                      in
+                      List.iter catchup_tree_node_list ~f:(fun catchup_node ->
+                          let hash = catchup_node.state_hash in
+                          if
+                            Marlin_plonk_bindings_pasta_fp.equal hash
+                              target_breadcrumb_child_hash
+                          then
+                            failwith
+                              "the catchup job associated with \
+                               target_breadcrumb_child_hash should have been \
+                               cancelled and thus removed from the catchup \
+                               tree, but it is still here"
+                          else ()) )))
+
     (* let%test_unit "catchup fails if one of the parent transitions fail" =
        Quickcheck.test ~trials:1
          Fake_network.Generator.(

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -471,4 +471,46 @@ module For_tests = struct
             (breadcrumb, breadcrumb :: acc) )
       in
       List.rev ls
-end
+
+  let build_fail ?skip_staged_ledger_verification ~logger ~precomputed_values
+      ~verifier ~trust_system ~parent
+      ~transition:(transition_with_validation :
+                    External_transition.Almost_validated.t) ~sender
+      ~transition_receipt_time () : (t,
+      [> `Fatal_error of exn
+       | `Invalid_staged_ledger_diff of Core_kernel.Error.t
+       | `Invalid_staged_ledger_hash of Core_kernel.Error.t ])
+     result Async_kernel.Deferred.t =
+     O1trace.trace_recurring "Breadcrumb.build" ( 
+       fun () ->
+
+        let _ = logger in
+        let _ = precomputed_values in
+        let _ = skip_staged_ledger_verification in
+        let _ = verifier in
+        let _ = sender in
+        let _ = transition_receipt_time in
+        let _ = trust_system in
+        let _ = parent in
+        let _ = transition_with_validation in
+
+       Deferred.return (Error (`Fatal_error (failwith "deliberately failing for unit tests")))
+
+      
+
+     )
+
+    end
+
+
+(*         match%bind
+          External_transition.Staged_ledger_validation
+          .validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
+            ~precomputed_values ~verifier
+            ~parent_staged_ledger:(staged_ledger parent)
+            ~parent_protocol_state:
+              (External_transition.Validated.protocol_state
+                 parent.validated_transition)
+            transition_with_validation
+        with
+        | Ok  *)

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -111,4 +111,22 @@ module For_tests : sig
     -> accounts_with_secret_keys:(Private_key.t option * Account.t) list
     -> int
     -> (t -> t list Deferred.t) Quickcheck.Generator.t
+
+  val build_fail :
+    ?skip_staged_ledger_verification:[`All | `Proofs]
+ -> logger:Logger.t
+ -> precomputed_values:Precomputed_values.t
+ -> verifier:Verifier.t
+ -> trust_system:Trust_system.t
+ -> parent:t
+ -> transition:External_transition.Almost_validated.t
+ -> sender:Envelope.Sender.t option
+ -> transition_receipt_time:Time.t option
+ -> unit
+ -> ( t
+    , [> `Invalid_staged_ledger_diff of Error.t
+      | `Invalid_staged_ledger_hash of Error.t
+      | `Fatal_error of exn ] )
+    Result.t
+    Deferred.t
 end


### PR DESCRIPTION
https://github.com/MinaProtocol/mina/issues/9403

Super catchup failure and recovery unit tests.

If catchup fails, some cleanup needs to be done. Catch-uping with a block consists of the following steps: 1. downloading state hashes; 2. download block; 3. initial validation; 4. verification of transaction snark; 5. build breadcrumb; 6. add those blocks to transition frontier. If any step fails, then we have some clean up jobs to do.  

- [x] If downloading state hashes fails, the cache of catchup blocks (the blocks that triggered catchup) would be cleared
- [x] If downloading the block fails, make sure it would retry

These following test were originally spec'd, but jiawei and i have decided that they don't actually make sense to test
- [ ] If initial validation blocks fails (except for the verifier_unreachable case), then we should cancel its children's catchup job
- [ ] If verification fails, then we should cancel its children's catchup job and we should remove this block from the cache
- [ ] If building breadcrumb fails, then we should cancel its children's catchup job and we should remove this block from the cache