### PR TITLE
Fix SetGatingConfig RPC endpoint

### DIFF
--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -382,7 +382,11 @@ func (h *Helper) GatingState() *CodaGatingState {
 }
 
 func (h *Helper) SetGatingState(gs *CodaGatingState) {
-	h.gatingState = gs
+	h.gatingState.TrustedPeers = gs.TrustedPeers
+	h.gatingState.BannedPeers = gs.BannedPeers
+	h.gatingState.TrustedAddrFilters = gs.TrustedAddrFilters
+	h.gatingState.BannedAddrFilters = gs.BannedAddrFilters
+	h.gatingState.KnownPrivateAddrFilters = gs.KnownPrivateAddrFilters
 	for _, c := range h.Host.Network().Conns() {
 		pid := c.RemotePeer()
 		maddr := c.RemoteMultiaddr()

--- a/src/lib/best_tip_prover/best_tip_prover.ml
+++ b/src/lib/best_tip_prover/best_tip_prover.ml
@@ -87,7 +87,7 @@ module Make (Inputs : Inputs_intf) :
           (merkle_list, root |> External_transition.Validation.forget_validation)
       }
 
-  let validate_proof ~verifier transition_with_hash =
+  let validate_proof ~genesis_state_hash ~verifier transition_with_hash =
     let open Deferred.Result.Monad_infix in
     External_transition.(
       Validation.wrap transition_with_hash
@@ -97,7 +97,8 @@ module Make (Inputs : Inputs_intf) :
            `This_transition_was_generated_internally
       |> skip_protocol_versions_validation
            `This_transition_has_valid_protocol_versions
-      |> (fun x -> validate_proofs ~verifier [ x ] >>| List.hd_exn)
+      |> (fun x ->
+           validate_proofs ~genesis_state_hash ~verifier [ x ] >>| List.hd_exn)
       >>= Fn.compose Deferred.Result.return
             (skip_delta_transition_chain_validation
                `This_transition_was_not_received_via_gossip)
@@ -143,8 +144,8 @@ module Make (Inputs : Inputs_intf) :
     in
     let%map root, best_tip =
       Deferred.Or_error.both
-        (validate_proof ~verifier root_transition_with_hash)
-        (validate_proof ~verifier best_tip_with_hash)
+        (validate_proof ~genesis_state_hash ~verifier root_transition_with_hash)
+        (validate_proof ~genesis_state_hash ~verifier best_tip_with_hash)
     in
     (`Root root, `Best_tip best_tip)
 end

--- a/src/lib/ledger_catchup/normal_catchup.ml
+++ b/src/lib/ledger_catchup/normal_catchup.ml
@@ -467,8 +467,12 @@ let verify_transitions_and_build_breadcrumbs ~logger
   let%bind transitions_with_initial_validation, initial_hash =
     let%bind tvs =
       let open Deferred.Let_syntax in
+      let genesis_state_hash =
+        Precomputed_values.genesis_state_with_hash precomputed_values
+        |> With_hash.hash
+      in
       match%bind
-        External_transition.validate_proofs ~verifier
+        External_transition.validate_proofs ~verifier ~genesis_state_hash
           (List.map transitions ~f:(fun t ->
                External_transition.Validation.wrap (Envelope.Incoming.data t)))
       with

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -799,15 +799,29 @@ let validate_genesis_protocol_state ~genesis_state_hash (t, validation) =
   then Ok (t, Validation.Unsafe.set_valid_genesis_state validation)
   else Error `Invalid_genesis_protocol_state
 
-let validate_proofs tvs ~verifier =
+let validate_proofs tvs ~verifier ~genesis_state_hash =
   let open Deferred.Let_syntax in
+  let to_verify =
+    List.filter_map tvs ~f:(fun (t, _validation) ->
+        if State_hash.equal (With_hash.hash t) genesis_state_hash then
+          (* Don't require a valid proof for the genesis block, since the
+             peer may not have one.
+          *)
+          None
+        else
+          let transition = With_hash.data t in
+          Some
+            (Blockchain_snark.Blockchain.create
+               ~state:(protocol_state transition)
+               ~proof:(protocol_state_proof transition)))
+  in
   match%map
-    Verifier.verify_blockchain_snarks verifier
-      (List.map tvs ~f:(fun (t, _validation) ->
-           let transition = With_hash.data t in
-           Blockchain_snark.Blockchain.create
-             ~state:(protocol_state transition)
-             ~proof:(protocol_state_proof transition)))
+    match to_verify with
+    | [] ->
+        (* Skip calling the verifier, nothing here to verify. *)
+        return (Ok true)
+    | _ ->
+        Verifier.verify_blockchain_snarks verifier to_verify
   with
   | Ok verified ->
       if verified then

--- a/src/lib/mina_transition/external_transition_intf.ml
+++ b/src/lib/mina_transition/external_transition_intf.ml
@@ -495,6 +495,7 @@ module type S = sig
        Validation.with_transition
        list
     -> verifier:Verifier.t
+    -> genesis_state_hash:State_hash.t
     -> ( ( 'time_received
          , 'genesis_state
          , [ `Proof ] * unit Truth.true_t

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -290,7 +290,7 @@ let run ~logger ~trust_system ~verifier ~transition_reader
                          (validate_genesis_protocol_state ~genesis_state_hash)
                    >>= (fun x ->
                          Interruptible.uninterruptible
-                           (validate_proofs ~verifier [ x ])
+                           (validate_proofs ~verifier ~genesis_state_hash [ x ])
                          >>| List.hd_exn)
                    >>= defer validate_delta_transition_chain
                    >>= defer validate_protocol_versions)


### PR DESCRIPTION
Problem: banning behavior is not enacted for
future connections.

Solution: implement a test that makes previous code fail,
set gaiting config properly.

Explain how you tested your changes:
* Added a unit test that tests that no stream can be opened after ban is enacted.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? Nope