### PR TITLE
Rosetta, log Postgresql connection, locks data

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -395,6 +395,7 @@ let router ~graphql_uri ~logger ~with_db (route : string list) body =
   let open Async.Deferred.Result.Let_syntax in
   [%log debug] "Handling /account/ $route"
     ~metadata:[("route", `List (List.map route ~f:(fun s -> `String s)))] ;
+  [%log info] "Account query" ~metadata:[("query",body)];
   match route with
   | ["balance"] ->
       with_db (fun ~db ->

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -812,6 +812,7 @@ let router ~graphql_uri ~logger ~with_db (route : string list) body =
   let open Async.Deferred.Result.Let_syntax in
   [%log debug] "Handling /block/ $route"
     ~metadata:[("route", `List (List.map route ~f:(fun s -> `String s)))] ;
+  [%log info] "Block query" ~metadata:[("query",body)];
   match route with
   | [] | [""] ->
       with_db (fun ~db ->

--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -1206,6 +1206,7 @@ let router
   [%log debug] "Handling /construction/ $route"
     ~metadata:[ ("route", `List (List.map route ~f:(fun s -> `String s))) ] ;
   let open Deferred.Result.Let_syntax in
+  [%log info] "Construction query" ~metadata:[("query",body)];
   match route with
   | [ "derive" ] ->
       let%bind req =

--- a/src/app/rosetta/lib/mempool.ml
+++ b/src/app/rosetta/lib/mempool.ml
@@ -320,6 +320,7 @@ let router ~graphql_uri ~logger (route : string list) body =
   let open Async.Deferred.Result.Let_syntax in
   [%log debug] "Handling /mempool/ $route"
     ~metadata:[("route", `List (List.map route ~f:(fun s -> `String s)))] ;
+  [%log info] "Mempool query" ~metadata:[("query",body)];
   match route with
   | [] | [""] ->
       let%bind req =

--- a/src/app/rosetta/lib/network.ml
+++ b/src/app/rosetta/lib/network.ml
@@ -492,6 +492,7 @@ let router ~graphql_uri ~logger ~with_db (route : string list) body =
   let open Async.Deferred.Result.Let_syntax in
   [%log debug] "Handling /network/ $route"
     ~metadata:[("route", `List (List.map route ~f:(fun s -> `String s)))] ;
+  [%log info] "Network query" ~metadata:[("query",body)];
   match route with
   | ["list"] ->
       let%bind _meta =

--- a/src/app/rosetta/lib/pg_data.ml
+++ b/src/app/rosetta/lib/pg_data.ml
@@ -1,0 +1,24 @@
+(* pg_data.ml -- Postgres data *)
+
+
+let query_connection_count =
+      Caqti_request.find
+        Caqti_type.unit
+        Caqti_type.int64
+        {sql| SELECT count(*) FROM pg_stat_activity
+              WHERE state = 'active'
+        |sql}
+
+let run_connection_count (module Conn : Caqti_async.CONNECTION) =
+  Conn.find query_connection_count
+
+let query_lock_count =
+      Caqti_request.find
+        Caqti_type.unit
+        Caqti_type.int64
+        {sql| SELECT count(*) FROM pg_locks
+              WHERE mode = 'SIReadLock'
+        |sql}
+
+let run_lock_count (module Conn : Caqti_async.CONNECTION) =
+  Conn.find query_lock_count


### PR DESCRIPTION
Add some logs to Rosetta:

- for account, blocks, and construction endpoints, log the query data
- at some interval, log the Postgresql number of connections and number of locks

The default interval is 30 seconds. That default can be overridden using the environment variable `MINA_ROSETTA_PG_DATA_INTERVAL`, given in seconds.

Tested locally to make sure the Postgresql logs appeared at the given interval.