### PR TITLE
Removed duplicate constants from consensus code

### DIFF
--- a/src/lib/consensus/constants.ml
+++ b/src/lib/consensus/constants.ml
@@ -16,7 +16,6 @@ module Poly = struct
         ; sub_windows_per_window : 'length
         ; slots_per_epoch : 'length (* The first slot after the grace period. *)
         ; grace_period_end : 'length
-        ; epoch_size : 'length
         ; checkpoint_window_slots_per_year : 'length
         ; checkpoint_window_size_in_slots : 'length
         ; block_window_duration_ms : 'timespan
@@ -253,7 +252,6 @@ let create' (type a b c)
     ; slots_per_epoch = to_length slots_per_epoch
     ; grace_period_end = to_length grace_period_end
     ; slot_duration_ms = to_timespan Slot.duration_ms
-    ; epoch_size = to_length Epoch.size
     ; epoch_duration = to_timespan Epoch.duration
     ; checkpoint_window_slots_per_year = to_length zero
     ; checkpoint_window_size_in_slots = to_length zero
@@ -349,7 +347,6 @@ let to_input (t : t) =
             ; t.sub_windows_per_window
             ; t.slots_per_epoch
             ; t.grace_period_end
-            ; t.epoch_size
             ; t.checkpoint_window_slots_per_year
             ; t.checkpoint_window_size_in_slots
            |]
@@ -368,8 +365,8 @@ let gc_parameters (constants : t) =
   let delay = Block_time.Span.to_ms constants.delta_duration |> of_int64 in
   let gc_width = delay * of_int 2 in
   (* epoch, slot components of gc_width *)
-  let gc_width_epoch = gc_width / constants.epoch_size in
-  let gc_width_slot = gc_width mod constants.epoch_size in
+  let gc_width_epoch = gc_width / constants.slots_per_epoch in
+  let gc_width_slot = gc_width mod constants.slots_per_epoch in
   let gc_interval = gc_width in
   ( `Acceptable_network_delay delay
   , `Gc_width gc_width
@@ -389,7 +386,6 @@ module Checked = struct
     and sub_windows_per_window = u var.sub_windows_per_window
     and slots_per_epoch = u var.slots_per_epoch
     and grace_period_end = u var.grace_period_end
-    and epoch_size = u var.epoch_size
     and checkpoint_window_slots_per_year =
       u var.checkpoint_window_slots_per_year
     and checkpoint_window_size_in_slots =
@@ -411,7 +407,6 @@ module Checked = struct
           ; sub_windows_per_window
           ; slots_per_epoch
           ; grace_period_end
-          ; epoch_size
           ; checkpoint_window_slots_per_year
           ; checkpoint_window_size_in_slots
           ; block_window_duration_ms

--- a/src/lib/consensus/epoch.ml
+++ b/src/lib/consensus/epoch.ml
@@ -65,7 +65,7 @@ let diff_in_slots ~(constants : Constants.t) ((epoch, slot) : t * Slot.t)
   let of_uint32 = UInt32.to_int64 in
   let epoch, slot = (of_uint32 epoch, of_uint32 slot) in
   let epoch', slot' = (of_uint32 epoch', of_uint32 slot') in
-  let epoch_size = UInt32.to_int64 constants.epoch_size in
+  let epoch_size = UInt32.to_int64 constants.slots_per_epoch in
   let epoch_diff = epoch - epoch' in
   if epoch_diff > 0L then
     ((epoch_diff - 1L) * epoch_size) + slot + (epoch_size - slot')
@@ -78,7 +78,7 @@ let%test_unit "test diff_in_slots" =
   let open Int64.Infix in
   let ( !^ ) = UInt32.of_int in
   let ( !@ ) = Fn.compose ( !^ ) Int64.to_int in
-  let epoch_size_int64 = UInt32.to_int64 constants.epoch_size in
+  let epoch_size_int64 = UInt32.to_int64 constants.slots_per_epoch in
   [%test_eq: int64] (diff_in_slots (!^0, !^5) (!^0, !^0) ~constants) 5L ;
   [%test_eq: int64] (diff_in_slots (!^3, !^23) (!^3, !^20) ~constants) 3L ;
   [%test_eq: int64]
@@ -101,6 +101,6 @@ let incr ~(constants : Constants.t) ((epoch, slot) : t * Slot.t) =
   let open UInt32 in
   if
     Slot.equal slot
-      (sub (Mina_numbers.Length.to_uint32 constants.epoch_size) one)
+      (sub (Mina_numbers.Length.to_uint32 constants.slots_per_epoch) one)
   then (add epoch one, zero)
   else (epoch, add slot one)

--- a/src/lib/consensus/global_slot.ml
+++ b/src/lib/consensus/global_slot.ml
@@ -109,7 +109,7 @@ let diff ~(constants : Constants.t) (t : t) (other_epoch, other_slot) =
     - UInt32.(of_int @@ if compare other_slot slot > 0 then 1 else 0)
   in
   let old_slot =
-    (slot - other_slot) mod Length.to_uint32 constants.epoch_size
+    (slot - other_slot) mod Length.to_uint32 constants.slots_per_epoch
   in
   of_epoch_and_slot (old_epoch, old_slot) ~constants
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -108,7 +108,7 @@ module Configuration = struct
     let of_span = Fn.compose Int64.to_int Block_time.Span.to_ms in
     { delta = of_int32 constants.delta
     ; k = of_int32 constants.k
-    ; slots_per_epoch = of_int32 constants.epoch_size
+    ; slots_per_epoch = of_int32 constants.slots_per_epoch
     ; slot_duration = of_span constants.slot_duration_ms
     ; epoch_duration = of_span constants.epoch_duration
     ; genesis_state_timestamp = constants.genesis_state_timestamp
@@ -3168,7 +3168,7 @@ module Hooks = struct
             ~finish:(fun () -> None)
         in
         let rec find_winning_slot (slot : Slot.t) =
-          if UInt32.compare slot constants.epoch_size >= 0 then
+          if UInt32.compare slot constants.slots_per_epoch >= 0 then
             Deferred.return None
           else
             match%bind


### PR DESCRIPTION
This PR removes duplicate constants from the consensus code.

Originally `slots_per_epoch` was an alias to `epoch_size` for printing in the node status way back in early 2019. Refactoring and combining data structures over the years caused them both to be promoted into the consensus constants.

`slots_per_epoch` is the better name so this PR removes `epoch_size`

* Closes #9906
