### PR TITLE
Add increment_nonce to archive db

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -529,6 +529,7 @@ module Snapp_party_body = struct
     ; update_id : int
     ; token_id : int64
     ; delta : int64
+    ; increment_nonce : bool
     ; events_ids : int array
     ; sequence_events_ids : int array
     ; call_data_id : int
@@ -540,7 +541,7 @@ module Snapp_party_body = struct
     let open Caqti_type_spec in
     let spec =
       Caqti_type.
-        [ int; int; int64; int64; array_int_typ; array_int_typ; int; int ]
+        [ int; int; int64; int64; bool; array_int_typ; array_int_typ; int; int ]
     in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
@@ -554,6 +555,7 @@ module Snapp_party_body = struct
     let%bind update_id =
       Snapp_updates.add_if_doesn't_exist (module Conn) body.update
     in
+    let increment_nonce = body.increment_nonce in
     let%bind events_ids =
       deferred_result_list_map body.events
         ~f:(Snapp_state_data_array.add_if_doesn't_exist (module Conn))
@@ -587,6 +589,7 @@ module Snapp_party_body = struct
       ; update_id
       ; token_id
       ; delta
+      ; increment_nonce
       ; events_ids
       ; sequence_events_ids
       ; call_data_id

--- a/src/app/archive/snapp_tables.sql
+++ b/src/app/archive/snapp_tables.sql
@@ -100,6 +100,7 @@ CREATE TABLE snapp_party_body
 , update_id                int              NOT NULL REFERENCES snapp_updates(id)
 , token_id                 bigint           NOT NULL
 , delta                    bigint           NOT NULL
+, increment_nonce          boolean          NOT NULL
 , events_ids               int[]            NOT NULL
 , sequence_events_ids      int[]            NOT NULL
 , call_data_id             int              NOT NULL REFERENCES snapp_state_data(id)


### PR DESCRIPTION
Add `increment_nonce` to the archive db schema as a column with type `boolean` in the table `snapps_party_body`.

Add that field to the type in `Processor.Snapp_party_body`.

N.B.: the type `Party.Fee_payer.t` uses the `unit` type for that field, but `Party.Body.of_fee_payer` converts that unit value to `true`, which will get written to the archive db.

Closes #9886.