### PR TITLE
Snapps, some renamings

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -2247,7 +2247,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "Delta",
+          "name": "BalanceChange",
           "description": "A signed amount",
           "fields": [
             {
@@ -2315,7 +2315,7 @@
           "description": "Body component of a Snapp Party",
           "fields": [
             {
-              "name": "depth",
+              "name": "callDepth",
               "description":
                 "The number of nested snapp calls in the transaction before reaching this party.",
               "args": [],
@@ -2427,7 +2427,7 @@
               "deprecationReason": null
             },
             {
-              "name": "delta",
+              "name": "balance_change",
               "description":
                 "Signed amount representing the amount to change for this particular relevant party.",
               "args": [],
@@ -2436,7 +2436,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "Delta",
+                  "name": "BalanceChange",
                   "ofType": null
                 }
               },
@@ -2494,7 +2494,7 @@
           ],
           "inputFields": [
             {
-              "name": "depth",
+              "name": "callDepth",
               "description":
                 "The number of nested snapp calls in the transaction before reaching this party.",
               "type": {
@@ -2596,7 +2596,7 @@
               "defaultValue": null
             },
             {
-              "name": "delta",
+              "name": "balance_change",
               "description":
                 "Signed amount representing the amount to change for this particular relevant party.",
               "type": {
@@ -2604,7 +2604,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "Delta",
+                  "name": "BalanceChange",
                   "ofType": null
                 }
               },
@@ -3656,7 +3656,7 @@
           "description": "Body component of a Snapp Fee Payer Party",
           "fields": [
             {
-              "name": "depth",
+              "name": "callDepth",
               "description": "An integer in string format",
               "args": [],
               "type": {
@@ -3798,7 +3798,7 @@
           ],
           "inputFields": [
             {
-              "name": "depth",
+              "name": "callDepth",
               "description": "An integer in string format",
               "type": {
                 "kind": "NON_NULL",
@@ -11613,7 +11613,8 @@
             },
             {
               "name": "snappState",
-              "description": "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
+              "description":
+                "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
               "args": [],
               "type": {
                 "kind": "LIST",

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -528,12 +528,12 @@ module Snapp_party_body = struct
     { public_key_id : int
     ; update_id : int
     ; token_id : int64
-    ; delta : int64
+    ; balance_change : int64
     ; increment_nonce : bool
     ; events_ids : int array
     ; sequence_events_ids : int array
     ; call_data_id : int
-    ; depth : int
+    ; call_depth : int
     }
   [@@deriving fields, hlist]
 
@@ -572,28 +572,28 @@ module Snapp_party_body = struct
     let token_id =
       Unsigned.UInt64.to_int64 @@ Token_id.to_uint64 body.token_id
     in
-    let delta =
+    let balance_change =
       let magnitude =
-        Currency.Amount.to_uint64 body.delta.magnitude
+        Currency.Amount.to_uint64 body.balance_change.magnitude
         |> Unsigned.UInt64.to_int64
       in
-      match body.delta.sgn with
+      match body.balance_change.sgn with
       | Sgn.Pos ->
           magnitude
       | Sgn.Neg ->
           Int64.neg magnitude
     in
-    let depth = body.depth in
+    let call_depth = body.call_depth in
     let value =
       { public_key_id
       ; update_id
       ; token_id
-      ; delta
+      ; balance_change
       ; increment_nonce
       ; events_ids
       ; sequence_events_ids
       ; call_data_id
-      ; depth
+      ; call_depth
       }
     in
     select_insert_into_cols ~select:("id", Caqti_type.int)

--- a/src/app/archive/snapp_tables.sql
+++ b/src/app/archive/snapp_tables.sql
@@ -99,12 +99,12 @@ CREATE TABLE snapp_party_body
 , public_key_id            int              NOT NULL REFERENCES public_keys(id)
 , update_id                int              NOT NULL REFERENCES snapp_updates(id)
 , token_id                 bigint           NOT NULL
-, delta                    bigint           NOT NULL
+, balance_change           bigint           NOT NULL
 , increment_nonce          boolean          NOT NULL
 , events_ids               int[]            NOT NULL
 , sequence_events_ids      int[]            NOT NULL
 , call_data_id             int              NOT NULL REFERENCES snapp_state_data(id)
-, depth                    int              NOT NULL
+, call_depth               int              NOT NULL
 );
 
 CREATE TABLE snapp_balance_bounds

--- a/src/lib/mina_base/parties.ml
+++ b/src/lib/mina_base/parties.ml
@@ -213,7 +213,7 @@ module Party_or_stack = struct
 
     let of_parties_list xs : _ t =
       of_parties_list
-        ~party_depth:(fun ((p : Party.t), _) -> p.data.body.depth)
+        ~party_depth:(fun ((p : Party.t), _) -> p.data.body.call_depth)
         xs
       |> accumulate_hashes
 
@@ -264,10 +264,10 @@ end
 
 let check_depths (t : t) =
   try
-    assert (t.fee_payer.data.body.depth = 0) ;
+    assert (t.fee_payer.data.body.call_depth = 0) ;
     let (_ : int) =
       List.fold ~init:0 t.other_parties ~f:(fun depth party ->
-          let new_depth = party.data.body.depth in
+          let new_depth = party.data.body.call_depth in
           if new_depth >= 0 && new_depth <= depth + 1 then new_depth
           else assert false)
     in
@@ -284,7 +284,7 @@ let parties (t : t) : Party.t list =
   }
   :: t.other_parties
 
-let fee (t : t) : Currency.Fee.t = t.fee_payer.data.body.delta
+let fee (t : t) : Currency.Fee.t = t.fee_payer.data.body.balance_change
 
 let fee_payer_party ({ fee_payer; _ } : t) = fee_payer
 

--- a/src/lib/mina_base/parties_logic.ml
+++ b/src/lib/mina_base/parties_logic.ml
@@ -137,7 +137,7 @@ module type Party_intf = sig
 
   type signed_amount
 
-  val delta : t -> signed_amount
+  val balance_change : t -> signed_amount
 end
 
 module type Parties_intf = sig
@@ -511,7 +511,7 @@ module Make (Inputs : Inputs_intf) = struct
          will never be promoted to the global excess, so this amount is
          irrelevant.
       *)
-      Amount.Signed.negate (Party.delta party)
+      Amount.Signed.negate (Party.balance_change party)
     in
     let party_token = h.perform (Party_token_id party) in
     Bool.(assert_ (not (Token_id.(equal invalid) party_token))) ;

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1246,13 +1246,13 @@ module Base = struct
                  ; token_symbol
                  ; timing
                  }
-             ; delta
+             ; balance_change
              ; increment_nonce
              ; events = _ (* This is for the snapp to use, we don't need it. *)
              ; call_data =
                  _ (* This is for the snapp to use, we don't need it. *)
              ; sequence_events
-             ; depth = _ (* This is used to build the 'stack of stacks'. *)
+             ; call_depth = _ (* This is used to build the 'stack of stacks'. *)
              }
          ; predicate = _
          } :
@@ -1281,7 +1281,7 @@ module Base = struct
       in
       Boolean.Assert.any
         [ is_new; !(Public_key.Compressed.Checked.equal pk a.public_key) ] ;
-      let is_receiver = Sgn.Checked.is_pos delta.sgn in
+      let is_receiver = Sgn.Checked.is_pos balance_change.sgn in
       let timing =
         let open Snapp_basic in
         let new_timing =
@@ -1307,10 +1307,12 @@ module Base = struct
             update_authorized
               (Permissions.Auth_required.Checked.if_ is_receiver
                  ~then_:a.permissions.receive ~else_:a.permissions.send)
-              ~is_keep:!Amount.Signed.(Checked.(equal (constant zero) delta))
+              ~is_keep:
+                !Amount.Signed.(Checked.(equal (constant zero) balance_change))
               ~updated:
                 (let balance, `Overflow failed1 =
-                   !(Balance.Checked.add_signed_amount_flagged a.balance delta)
+                   !(Balance.Checked.add_signed_amount_flagged a.balance
+                       balance_change)
                  in
                  let fee =
                    Amount.Checked.of_fee
@@ -1720,7 +1722,7 @@ module Base = struct
         module Party = struct
           type t = party
 
-          let delta (t : t) = t.party.data.body.delta
+          let balance_change (t : t) = t.party.data.body.balance_change
         end
 
         module Account = struct
@@ -3896,8 +3898,8 @@ let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
                    !"unexpected fee excess. source %{sexp: Amount.Signed.t} \
                      target %{sexp: Amount.Signed.t}"
                    target_global.fee_excess source_global.fee_excess)
-          | Some delta ->
-              delta
+          | Some balance_change ->
+              balance_change
         in
         { fee_token_l = Token_id.default
         ; fee_excess_l = Amount.Signed.to_fee fee_excess
@@ -4244,12 +4246,12 @@ module For_tests = struct
               { pk = sender_pk
               ; update = Party.Update.noop
               ; token_id = ()
-              ; delta = fee
+              ; balance_change = fee
               ; increment_nonce = ()
               ; events = []
               ; sequence_events = []
               ; call_data = Field.zero
-              ; depth = 0
+              ; call_depth = 0
               }
           ; predicate = sender_nonce
           }
@@ -4262,12 +4264,12 @@ module For_tests = struct
           { pk = sender_pk
           ; update = Party.Update.noop
           ; token_id = Token_id.default
-          ; delta = Amount.(Signed.(negate (of_unsigned amount)))
+          ; balance_change = Amount.(Signed.(negate (of_unsigned amount)))
           ; increment_nonce = true
           ; events = []
           ; sequence_events = []
           ; call_data = Field.zero
-          ; depth = 0
+          ; call_depth = 0
           }
       ; predicate = Nonce (Account.Nonce.succ sender_nonce)
       }
@@ -4277,12 +4279,12 @@ module For_tests = struct
           { pk = trivial_account_pk
           ; update = update_empty_permissions
           ; token_id = Token_id.default
-          ; delta = Amount.Signed.(of_unsigned amount)
+          ; balance_change = Amount.Signed.(of_unsigned amount)
           ; increment_nonce = false
           ; events = []
           ; sequence_events = []
           ; call_data = Field.zero
-          ; depth = 0
+          ; call_depth = 0
           }
       ; predicate = Full Snapp_predicate.Account.accept
       }
@@ -4291,7 +4293,7 @@ module For_tests = struct
     let memo = Signed_command_memo.empty in
     let ps =
       Parties.Party_or_stack.of_parties_list
-        ~party_depth:(fun (p : Party.Predicated.t) -> p.body.depth)
+        ~party_depth:(fun (p : Party.Predicated.t) -> p.body.call_depth)
         [ sender_party_data; snapp_party_data ]
       |> Parties.Party_or_stack.accumulate_hashes_predicated
     in
@@ -4309,7 +4311,7 @@ module For_tests = struct
     let proof_party =
       let ps =
         Parties.Party_or_stack.of_parties_list
-          ~party_depth:(fun (p : Party.Predicated.t) -> p.body.depth)
+          ~party_depth:(fun (p : Party.Predicated.t) -> p.body.call_depth)
           [ snapp_party_data ]
         |> Parties.Party_or_stack.accumulate_hashes_predicated
       in
@@ -4695,12 +4697,12 @@ let%test_module "transaction_snark" =
                       ; timing = Keep
                       }
                   ; token_id = ()
-                  ; delta = Fee.of_int full_amount
+                  ; balance_change = Fee.of_int full_amount
                   ; increment_nonce = ()
                   ; events = []
                   ; sequence_events = []
                   ; call_data = Field.zero
-                  ; depth = 0
+                  ; call_depth = 0
                   }
               ; predicate = acct1.account.nonce
               }
@@ -4712,12 +4714,13 @@ let%test_module "transaction_snark" =
                     { pk = acct2.account.public_key
                     ; update = Party.Update.noop
                     ; token_id = Token_id.default
-                    ; delta = Amount.Signed.(of_unsigned receiver_amount)
+                    ; balance_change =
+                        Amount.Signed.(of_unsigned receiver_amount)
                     ; increment_nonce = false
                     ; events = []
                     ; sequence_events = []
                     ; call_data = Field.zero
-                    ; depth = 0
+                    ; call_depth = 0
                     }
                 ; predicate = Accept
                 }
@@ -5238,12 +5241,12 @@ let%test_module "transaction_snark" =
                             { pk = sender_pk
                             ; update = Party.Update.noop
                             ; token_id = ()
-                            ; delta = fee
+                            ; balance_change = fee
                             ; increment_nonce = ()
                             ; events = []
                             ; sequence_events = []
                             ; call_data = Field.zero
-                            ; depth = 0
+                            ; call_depth = 0
                             }
                         ; predicate = sender_nonce
                         }
@@ -5256,12 +5259,13 @@ let%test_module "transaction_snark" =
                         { pk = sender_pk
                         ; update = Party.Update.noop
                         ; token_id = Token_id.default
-                        ; delta = Amount.(Signed.(negate (of_unsigned amount)))
+                        ; balance_change =
+                            Amount.(Signed.(negate (of_unsigned amount)))
                         ; increment_nonce = true
                         ; events = []
                         ; sequence_events = []
                         ; call_data = Field.zero
-                        ; depth = 0
+                        ; call_depth = 0
                         }
                     ; predicate = Nonce (Account.Nonce.succ sender_nonce)
                     }
@@ -5271,12 +5275,12 @@ let%test_module "transaction_snark" =
                         { pk = multisig_account_pk
                         ; update = update_empty_permissions
                         ; token_id = Token_id.default
-                        ; delta = Amount.Signed.(of_unsigned amount)
+                        ; balance_change = Amount.Signed.(of_unsigned amount)
                         ; increment_nonce = false
                         ; events = []
                         ; sequence_events = []
                         ; call_data = Field.zero
-                        ; depth = 0
+                        ; call_depth = 0
                         }
                     ; predicate = Full Snapp_predicate.Account.accept
                     }
@@ -5286,7 +5290,7 @@ let%test_module "transaction_snark" =
                   let ps =
                     Parties.Party_or_stack.of_parties_list
                       ~party_depth:(fun (p : Party.Predicated.t) ->
-                        p.body.depth)
+                        p.body.call_depth)
                       [ sender_party_data; snapp_party_data ]
                     |> Parties.Party_or_stack.accumulate_hashes_predicated
                   in


### PR DESCRIPTION
Change `depth` to `call_depth` and `delta` to `balance_change`.

Made that change to OCaml code, in the archive db schema, and in the GraphQL schema.

Note: these changes will trigger the versioned type change linter.  Field name changes, as here, are innocuous, because serializations don't change. So this PR will require manual merge.

Closes #9844.