### PR TITLE
Move Caqti code to mina_caqti library

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11613,7 +11613,8 @@
             },
             {
               "name": "snappState",
-              "description": "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
+              "description":
+                "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
               "args": [],
               "type": {
                 "kind": "LIST",

--- a/src/app/archive/archive_lib/dune
+++ b/src/app/archive/archive_lib/dune
@@ -1,7 +1,7 @@
 (library
  (name archive_lib)
  (public_name archive_lib)
- (libraries core async mina_base mina_transition one_or_two transition_frontier caqti-async caqti caqti-driver-postgresql genesis_ledger_helper)
+ (libraries core async mina_base mina_caqti mina_transition one_or_two transition_frontier genesis_ledger_helper)
  (inline_tests)
  (modes native)
  (instrumentation (backend bisect_ppx))

--- a/src/app/archive/archive_lib/dune
+++ b/src/app/archive/archive_lib/dune
@@ -1,7 +1,8 @@
 (library
  (name archive_lib)
  (public_name archive_lib)
- (libraries core async mina_base mina_caqti mina_transition one_or_two transition_frontier genesis_ledger_helper)
+ (libraries core async caqti-driver-postgresql
+            mina_base mina_caqti mina_transition one_or_two transition_frontier genesis_ledger_helper)
  (inline_tests)
  (modes native)
  (instrumentation (backend bisect_ppx))

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -240,7 +240,7 @@ let%test_module "Archive node unit tests" =
           Strict_pipe.Writer.close writer ;
           let%bind () = processor_deferred_computation in
           match%map
-            Processor.deferred_result_list_fold breadcrumbs ~init:()
+            Mina_caqti.deferred_result_list_fold breadcrumbs ~init:()
               ~f:(fun () breadcrumb ->
                 Caqti_async.Pool.use
                   (fun conn ->

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -11,6 +11,15 @@
 
 */
 
+/* the tables below named `blocks_xxx_commands`, where xxx is `user`, `internal`, or `snapps`,
+   contain columns `block_id` and `xxx_command_id`
+
+   this naming convention must be followed for `find_command_ids_query` in `Replayer.Sql`
+   to work properly
+
+   the comment "Blocks command convention" indicates the use of this convention
+*/
+
 CREATE TABLE public_keys
 ( id    serial PRIMARY KEY
 , value text   NOT NULL UNIQUE
@@ -150,6 +159,8 @@ CREATE TABLE balances
 
 /* a join table between blocks and user_commands, with some additional information
    sequence_no gives the order within all transactions in the block
+
+   Blocks command convention
 */
 CREATE TABLE blocks_user_commands
 ( block_id        int NOT NULL REFERENCES blocks(id) ON DELETE CASCADE
@@ -171,6 +182,8 @@ CREATE INDEX idx_blocks_user_commands_user_command_id ON blocks_user_commands(us
 
 /* a join table between blocks and internal_commands, with some additional information
    the pair sequence_no, secondary_sequence_no gives the order within all transactions in the block
+
+   Blocks command convention
 */
 CREATE TABLE blocks_internal_commands
 ( block_id              int NOT NULL REFERENCES blocks(id) ON DELETE CASCADE
@@ -197,7 +210,10 @@ CREATE TABLE snapp_party_balances
 
    other_parties_list_id refers to a list of balances in the same order as the other parties in the
    snapps_command; that is, the list_index for the balances is the same as the list_index for other_parties
+
+   Blocks command convention
 */
+
 CREATE TABLE blocks_snapp_commands
 ( block_id                        int  NOT NULL REFERENCES blocks(id) ON DELETE CASCADE
 , snapp_command_id                int  NOT NULL REFERENCES snapp_commands(id) ON DELETE CASCADE
@@ -209,3 +225,4 @@ CREATE TABLE blocks_snapp_commands
 
 CREATE INDEX idx_blocks_snapp_commands_block_id ON blocks_snapp_commands(block_id);
 CREATE INDEX idx_blocks_snapp_commands_snapp_command_id ON blocks_snapp_commands(snapp_command_id);
+CREATE INDEX idx_blocks_snapp_commands_sequence_no ON blocks_snapp_commands(sequence_no);

--- a/src/app/delegation_compliance/delegation_compliance.ml
+++ b/src/app/delegation_compliance/delegation_compliance.ml
@@ -618,9 +618,8 @@ let main ~input_file ~csv_file ~preliminary_csv_file_opt ~archive_uri
             in
             let%bind payments_by_coinbase_receivers =
               match%map
-                Archive_lib.Processor.deferred_result_list_fold
-                  coinbase_receiver_ids ~init:[]
-                  ~f:(fun accum coinbase_receiver_id ->
+                Mina_caqti.deferred_result_list_fold coinbase_receiver_ids
+                  ~init:[] ~f:(fun accum coinbase_receiver_id ->
                     let%bind cb_receiver_pk =
                       pk_of_pk_id pool coinbase_receiver_id
                     in

--- a/src/app/delegation_compliance/dune
+++ b/src/app/delegation_compliance/dune
@@ -10,6 +10,7 @@
    caqti-driver-postgresql
    archive_lib
    mina_base
+   mina_caqti
    mina_state
    genesis_constants
    genesis_ledger_helper

--- a/src/app/delegation_compliance/sql.ml
+++ b/src/app/delegation_compliance/sql.ml
@@ -8,7 +8,7 @@ module Block_info = struct
   [@@deriving hlist]
 
   let typ =
-    let open Archive_lib.Processor.Caqti_type_spec in
+    let open Mina_caqti.Type_spec in
     let spec = Caqti_type.[ int; int64; string; string ] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
@@ -92,7 +92,7 @@ module User_command = struct
   [@@deriving yojson, hlist, equal]
 
   let typ =
-    let open Archive_lib.Processor.Caqti_type_spec in
+    let open Mina_caqti.Type_spec in
     let spec =
       Caqti_type.
         [ string

--- a/src/app/extract_blocks/dune
+++ b/src/app/extract_blocks/dune
@@ -5,11 +5,9 @@
  (libraries
    async
    core_kernel
-   caqti
-   caqti-async
-   caqti-driver-postgresql
    archive_lib
    block_time
+   mina_caqti
    mina_numbers
    logger
    mina_base)

--- a/src/app/extract_blocks/dune
+++ b/src/app/extract_blocks/dune
@@ -4,6 +4,7 @@
  (public_name extract_blocks)
  (libraries
    async
+   caqti-driver-postgresql
    core_kernel
    archive_lib
    block_time

--- a/src/app/extract_blocks/sql.ml
+++ b/src/app/extract_blocks/sql.ml
@@ -109,7 +109,7 @@ module Blocks_and_internal_commands = struct
   [@@deriving hlist]
 
   let typ =
-    let open Archive_lib.Processor.Caqti_type_spec in
+    let open Mina_caqti.Type_spec in
     let spec = Caqti_type.[ int; int; int; option int64; int ] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in

--- a/src/app/replayer/dune
+++ b/src/app/replayer/dune
@@ -5,11 +5,8 @@
  (libraries
    async_kernel
    core
-   caqti
-   caqti-async
-   caqti-driver-postgresql
-   archive_lib
    mina_base
+   mina_caqti
    mina_state
    genesis_constants
    genesis_ledger_helper

--- a/src/app/replayer/dune
+++ b/src/app/replayer/dune
@@ -4,6 +4,7 @@
  (public_name replayer)
  (libraries
    async_kernel
+   caqti-driver-postgresql
    core
    mina_base
    mina_caqti

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -12,7 +12,7 @@ module Block_info = struct
   [@@deriving hlist]
 
   let typ =
-    let open Archive_lib.Processor.Caqti_type_spec in
+    let open Mina_caqti.Type_spec in
     let spec = Caqti_type.[ int; int64; string; string ] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
@@ -162,7 +162,7 @@ module User_command = struct
   [@@deriving hlist]
 
   let typ =
-    let open Archive_lib.Processor.Caqti_type_spec in
+    let open Mina_caqti.Type_spec in
     let spec =
       Caqti_type.
         [ string
@@ -244,7 +244,7 @@ module Internal_command = struct
   [@@deriving hlist]
 
   let typ =
-    let open Archive_lib.Processor.Caqti_type_spec in
+    let open Mina_caqti.Type_spec in
     let spec =
       Caqti_type.
         [ string

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -357,7 +357,7 @@ WITH RECURSIVE chain AS (
       let created_token t = t.created_token
 
       let typ =
-        let open Archive_lib.Processor.Caqti_type_spec in
+        let open Mina_caqti.Type_spec in
         let spec =
           Caqti_type.
             [ string

--- a/src/app/rosetta/lib/dune
+++ b/src/app/rosetta/lib/dune
@@ -13,6 +13,7 @@
    cohttp-async
    core_kernel
    logger
+   mina_caqti
    mina_compile_config
    ppx_deriving_yojson.runtime
    rosetta_lib

--- a/src/lib/mina_caqti/dune
+++ b/src/lib/mina_caqti/dune
@@ -1,0 +1,9 @@
+(library
+ (name mina_caqti)
+ (public_name mina_caqti)
+ (inline_tests)
+ (libraries core_kernel async caqti-async mina_base)
+ (preprocess
+  (pps ppx_coda ppx_version ppx_jane ppx_custom_printf h_list.ppx))
+ (instrumentation (backend bisect_ppx))
+ (synopsis "Helpers for the Caqti database bindings"))

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -1,0 +1,202 @@
+(* mina_caqti.ml -- Mina helpers for the Caqti database bindings *)
+
+open Async
+open Core_kernel
+open Caqti_async
+open Mina_base
+
+type _ Caqti_type.field +=
+  | Array_nullable_int : int option array Caqti_type.field
+
+module Type_spec = struct
+  type (_, _) t =
+    | [] : (unit, unit) t
+    | ( :: ) : 'c Caqti_type.t * ('a, 'b) t -> ('c -> 'a, 'c * 'b) t
+
+  let rec to_rep : 'hlist 'tuple. ('hlist, 'tuple) t -> 'tuple Caqti_type.t =
+    fun (type hlist tuple) (spec : (hlist, tuple) t) ->
+     match spec with
+     | [] ->
+         (Caqti_type.unit : tuple Caqti_type.t)
+     | rep :: spec ->
+         Caqti_type.tup2 rep (to_rep spec)
+
+  let rec hlist_to_tuple :
+            'hlist 'tuple.    ('hlist, 'tuple) t -> (unit, 'hlist) H_list.t
+            -> 'tuple =
+    fun (type hlist tuple) (spec : (hlist, tuple) t)
+        (l : (unit, hlist) H_list.t) ->
+     match (spec, l) with
+     | [], [] ->
+         (() : tuple)
+     | _ :: spec, x :: l ->
+         ((x, hlist_to_tuple spec l) : tuple)
+
+  let rec tuple_to_hlist :
+            'hlist 'tuple.    ('hlist, 'tuple) t -> 'tuple
+            -> (unit, 'hlist) H_list.t =
+    fun (type hlist tuple) (spec : (hlist, tuple) t) (t : tuple) ->
+     match (spec, t) with
+     | [], () ->
+         ([] : (unit, hlist) H_list.t)
+     | _ :: spec, (x, t) ->
+         x :: tuple_to_hlist spec t
+end
+
+(* register coding for nullable int arrays.
+   for example, the ocaml int array `[| 0; 1; 2 |]` would be encoded to
+   `'{0, 1, 2}'` for postgresql. There is no need to add the single quotes,
+   as caqti does this when using a string representation.
+   type annotations are necessary for int array values in postgresql, eg.
+   `SELECT id FROM snapp_states WHERE element_ids = '{0,1,2,...}'::int[]` *)
+let () =
+  let open Caqti_type.Field in
+  let rep = Caqti_type.String in
+  let encode xs =
+    Array.map xs ~f:(Option.value_map ~f:Int.to_string ~default:"NULL")
+    |> String.concat_array ~sep:", "
+    |> sprintf "{ %s }" |> Result.return
+  in
+  let decode s =
+    let open Result.Let_syntax in
+    let error = "Failed to decode nullable int array" in
+    let decode_elem = function
+      | "NULL" | "null" ->
+          return None
+      | elem -> (
+          try return @@ Option.some @@ Int.of_string elem
+          with _ -> Result.fail error )
+    in
+    String.chop_prefix ~prefix:"{" s
+    |> Result.of_option ~error
+    >>= fun s ->
+    String.chop_suffix ~suffix:"}" s
+    |> Result.of_option ~error
+    >>= fun s ->
+    String.filter ~f:(Char.( <> ) ' ') s
+    |> String.split ~on:',' |> List.map ~f:decode_elem |> Result.all
+    >>| List.to_array
+  in
+  let get_coding : type a. _ -> a t -> a coding =
+   fun _ -> function
+    | Array_nullable_int ->
+        Coding { rep; encode; decode }
+    | _ ->
+        assert false
+  in
+  define_coding Array_nullable_int { get_coding }
+
+(* this type may require type annotations in queries, eg.
+  `SELECT id FROM snapp_states WHERE element_ids = ?::int[]`
+*)
+let array_nullable_int_typ : int option array Caqti_type.t =
+  Caqti_type.field Array_nullable_int
+
+let array_int_typ : int array Caqti_type.t =
+  let open Result.Let_syntax in
+  let encode xs = return @@ Array.map ~f:Option.some xs in
+  let decode xs =
+    Option.all (Array.to_list xs)
+    |> Result.of_option
+         ~error:"Failed to decode int array, encountered NULL value"
+    >>| Array.of_list
+  in
+  Caqti_type.custom array_nullable_int_typ ~encode ~decode
+
+(* process a Caqti query on list of items
+   if we were instead to simply map the query over the list,
+    we'd get "in use" assertion failures for the connection
+   the bind makes sure the connection is available for
+    each query
+*)
+let rec deferred_result_list_fold ls ~init ~f =
+  let open Deferred.Result.Let_syntax in
+  match ls with
+  | [] ->
+      return init
+  | h :: t ->
+      let%bind init = f init h in
+      deferred_result_list_fold t ~init ~f
+
+let deferred_result_list_mapi ~f xs =
+  let open Deferred.Result.Let_syntax in
+  deferred_result_list_fold xs ~init:(0, []) ~f:(fun (index, acc) x ->
+      let%map res = f index x in
+      (Int.succ index, res :: acc))
+  >>| snd >>| List.rev
+
+let deferred_result_list_map ~f = deferred_result_list_mapi ~f:(Fn.const f)
+
+let deferred_result_lift_opt :
+    ('a, 'err) Deferred.Result.t option -> ('a option, 'err) Deferred.Result.t =
+  let open Deferred.Result.Let_syntax in
+  function Some x -> x >>| Option.some | None -> return None
+
+let add_if_some (f : 'arg -> ('res, 'err) Deferred.Result.t) :
+    'arg option -> ('res option, 'err) Deferred.Result.t =
+  Fn.compose deferred_result_lift_opt @@ Option.map ~f
+
+let add_if_snapp_set (f : 'arg -> ('res, 'err) Deferred.Result.t) :
+    'arg Snapp_basic.Set_or_keep.t -> ('res option, 'err) Deferred.Result.t =
+  Fn.compose (add_if_some f) Snapp_basic.Set_or_keep.to_option
+
+let add_if_snapp_check (f : 'arg -> ('res, 'err) Deferred.Result.t) :
+    'arg Snapp_basic.Or_ignore.t -> ('res option, 'err) Deferred.Result.t =
+  Fn.compose (add_if_some f) Snapp_basic.Or_ignore.to_option
+
+(* `select_cols ~select:"s0" ~table_name:"t0" ["col0", "col1", ...]`
+   creates the string
+   `"SELECT s0 FROM t0 WHERE col0 = ? AND col1 = ? AND..."`.
+   The optional `tannot` function maps column names to type annotations. *)
+let select_cols ~(select : string) ~(table_name : string)
+    ?(tannot : string -> string option = Fn.const None) (cols : string list) :
+    string =
+  List.map cols ~f:(fun col ->
+      let annot =
+        match tannot col with None -> "" | Some tannot -> "::" ^ tannot
+      in
+      sprintf "%s = ?%s" col annot)
+  |> String.concat ~sep:" AND "
+  |> sprintf "SELECT %s FROM %s WHERE %s" select table_name
+
+(* `insert_into_cols ~returning:ret0 ~table_name:t0 ["col0", "col1", ...]`
+   creates the string
+   `"INSERT INTO t0 (col0, col1, ...) VALUES (?, ?, ...) RETURNING ret0"`.
+   The optional `tannot` function maps column names to type annotations.
+   No type annotation is included if `tannot` returns an empty string. *)
+let insert_into_cols ~(returning : string) ~(table_name : string)
+    ?(tannot : string -> string option = Fn.const None) (cols : string list) :
+    string =
+  let values =
+    List.map cols ~f:(fun col ->
+        match tannot col with None -> "?" | Some tannot -> "?::" ^ tannot)
+    |> String.concat ~sep:", "
+  in
+  sprintf "INSERT INTO %s (%s) VALUES (%s) RETURNING %s" table_name
+    (String.concat ~sep:", " cols)
+    values returning
+
+let select_insert_into_cols ~(select : string * 'select Caqti_type.t)
+    ~(table_name : string) ?tannot ~(cols : string list * 'cols Caqti_type.t)
+    (module Conn : CONNECTION) (value : 'cols) =
+  let open Deferred.Result.Let_syntax in
+  Conn.find_opt
+    ( Caqti_request.find_opt (snd cols) (snd select)
+    @@ select_cols ~select:(fst select) ~table_name ?tannot (fst cols) )
+    value
+  >>= function
+  | Some id ->
+      return id
+  | None ->
+      Conn.find
+        ( Caqti_request.find (snd cols) (snd select)
+        @@ insert_into_cols ~returning:(fst select) ~table_name ?tannot
+             (fst cols) )
+        value
+
+let query ~f pool =
+  match%bind Caqti_async.Pool.use f pool with
+  | Ok v ->
+      return v
+  | Error msg ->
+      failwithf "Error querying db, error: %s" (Caqti_error.show msg) ()

--- a/src/mina_caqti.opam
+++ b/src/mina_caqti.opam
@@ -1,0 +1,5 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]


### PR DESCRIPTION
There was a lot of Caqti-related code in `Archive_lib.Processor` of general applicability, that was also used in the `replayer`, `extract_blocks`, and `archive_blocks`.  It seemed awkward to have those apps depends on the processor, so move that code to its own library, `mina_caqti`.

The `vector` Caqti type encoding is removed, because unused.

Also: add mention of a db schema invariant that has been implicit.

This change is preparation for the Snapps-related changes to the replayer and other archive db-related apps (#9260, #9261, #9262).