### PR TITLE
fail snapp txn when fee excess > txn fee

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11613,7 +11613,8 @@
             },
             {
               "name": "snappState",
-              "description": "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
+              "description":
+                "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
               "args": [],
               "type": {
                 "kind": "LIST",

--- a/src/lib/mina_base/ledger.mli
+++ b/src/lib/mina_base/ledger.mli
@@ -183,14 +183,6 @@ module Transaction_applied : sig
   val user_command_status : t -> Transaction_status.t
 end
 
-module Global_state : sig
-  type nonrec t =
-    { ledger : t
-    ; fee_excess : Currency.Amount.Signed.t
-    ; protocol_state : Snapp_predicate.Protocol_state.View.t
-    }
-end
-
 (** Raises if the ledger is full, or if an account already exists for the given
     [Account_id.t].
 *)
@@ -240,27 +232,6 @@ val apply_parties_unchecked :
          Parties_logic.Local_state.t
        * Currency.Amount.Signed.t ) )
      Or_error.t
-
-val apply_parties_unchecked_aux :
-     constraint_constants:Genesis_constants.Constraint_constants.t
-  -> state_view:Snapp_predicate.Protocol_state.View.t
-  -> init:'acc
-  -> f:
-       (   'acc
-        -> Global_state.t
-           * ( (Party.t, unit) Parties.Party_or_stack.t list
-             , Token_id.t
-             , Currency.Amount.t
-             , t
-             , bool
-             , unit
-             , Transaction_status.Failure.t option )
-             Parties_logic.Local_state.t
-        -> 'acc)
-  -> ?fee_excess:Currency.Amount.Signed.t
-  -> t
-  -> Parties.t
-  -> (Transaction_applied.Parties_applied.t * 'acc) Or_error.t
 
 val undo :
      constraint_constants:Genesis_constants.Constraint_constants.t

--- a/src/lib/mina_base/parties.ml
+++ b/src/lib/mina_base/parties.ml
@@ -294,6 +294,9 @@ let nonce (t : t) : Account.Nonce.t = (fee_payer_party t).data.predicate
 
 let fee_token (_t : t) = Token_id.default
 
+let fee_excess (t : t) =
+  Fee_excess.of_single (fee_token t, Currency.Fee.Signed.of_unsigned (fee t))
+
 let accounts_accessed (t : t) =
   List.map (parties t) ~f:(fun p ->
       Account_id.create p.data.body.pk p.data.body.token_id)

--- a/src/lib/mina_base/sparse_ledger.ml
+++ b/src/lib/mina_base/sparse_ledger.ml
@@ -191,20 +191,6 @@ let apply_parties_unchecked_with_states ~constraint_constants ~state_view
          *)
          (party_applied, List.rev states))
 
-let apply_parties_with_fee_excess_exn ~constraint_constants ~state_view
-    ~fee_excess ledger c =
-  let open T in
-  let t = ref ledger in
-  let _, fee_excess =
-    apply_parties_unchecked_aux ~constraint_constants ~state_view ~fee_excess t
-      c ~init:fee_excess ~f:(fun _ (global_state, _local_state) ->
-        global_state.fee_excess)
-    |> Or_error.ok_exn
-  in
-  ( !t
-  , Fee_excess.of_single
-      (Token_id.default, Currency.Amount.Signed.to_fee fee_excess) )
-
 let of_root ~depth ~next_available_token (h : Ledger_hash.t) =
   of_hash ~depth ~next_available_token
     (Ledger_hash.of_digest (h :> Random_oracle.Digest.t))

--- a/src/lib/mina_base/sparse_ledger.mli
+++ b/src/lib/mina_base/sparse_ledger.mli
@@ -99,14 +99,6 @@ val apply_parties_unchecked_with_states :
        list )
      Or_error.t
 
-val apply_parties_with_fee_excess_exn :
-     constraint_constants:Genesis_constants.Constraint_constants.t
-  -> state_view:Snapp_predicate.Protocol_state.View.t
-  -> fee_excess:Currency.Amount.Signed.t
-  -> t
-  -> Parties.t
-  -> t * Fee_excess.t
-
 val of_any_ledger : Ledger.Any_ledger.M.t -> t
 
 val of_ledger_subset_exn : Ledger.t -> Account_id.t list -> t

--- a/src/lib/mina_base/transaction.ml
+++ b/src/lib/mina_base/transaction.ml
@@ -78,10 +78,8 @@ let forget : Valid.t -> t = fun x -> (x :> t)
 let fee_excess : t -> Fee_excess.t Or_error.t = function
   | Command (Signed_command t) ->
       Ok (Signed_command.fee_excess t)
-  | Command (Parties _ps) ->
-      failwith
-        "Invalid for parties transaction. Apply parties transaction to obtain \
-         the fee excess"
+  | Command (Parties ps) ->
+      Ok (Parties.fee_excess ps)
   | Fee_transfer t ->
       Fee_transfer.fee_excess t
   | Coinbase t ->

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1515,6 +1515,8 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
 
       let zero = zero
 
+      let equal = equal
+
       let add_flagged = add_flagged
 
       let add_signed_flagged (x1 : t) (x2 : Signed.t) : t * [ `Overflow of bool ]
@@ -1657,6 +1659,10 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       | Set_account (l, a, loc) ->
           Or_error.ok_exn (set_with_location l loc a) ;
           l
+      | Check_fee_excess (valid_fee_excess, prev_failure_status) ->
+          if not valid_fee_excess then
+            Some Transaction_status.Failure.Invalid_fee_excess
+          else prev_failure_status
       | Modify_global_excess (s, f) ->
           { s with fee_excess = f s.fee_excess }
       | Modify_global_ledger { global_state; ledger; should_update } ->

--- a/src/lib/mina_base/transaction_status.ml
+++ b/src/lib/mina_base/transaction_status.ml
@@ -26,6 +26,7 @@ module Failure = struct
         | Snapp_account_not_present
         | Update_not_permitted
         | Incorrect_nonce
+        | Invalid_fee_excess
       [@@deriving sexp, yojson, equal, compare, enum, hash]
 
       let to_latest = Fn.id
@@ -79,6 +80,8 @@ module Failure = struct
         "Update_not_permitted"
     | Incorrect_nonce ->
         "Incorrect_nonce"
+    | Invalid_fee_excess ->
+        "Invalid_fee_excess"
 
   let of_string = function
     | "Predicate" ->
@@ -111,6 +114,8 @@ module Failure = struct
         Ok Update_not_permitted
     | "Incorrect_nonce" ->
         Ok Incorrect_nonce
+    | "Invalid_fee_excess" ->
+        Ok Invalid_fee_excess
     | _ ->
         Error "Signed_command_status.Failure.of_string: Unknown value"
 
@@ -155,6 +160,8 @@ module Failure = struct
         "An account is not permitted to make the given update"
     | Incorrect_nonce ->
         "Incorrect nonce"
+    | Invalid_fee_excess ->
+        "Fee excess from parties transaction more than the transaction fees"
 
   [%%ifdef consensus_mechanism]
 
@@ -182,6 +189,7 @@ module Failure = struct
         ; snapp_account_not_present : 'bool
         ; update_not_permitted : 'bool
         ; incorrect_nonce : 'bool
+        ; invalid_fee_excess : 'bool
         }
       [@@deriving hlist, equal, sexp, compare]
 
@@ -201,6 +209,7 @@ module Failure = struct
           ; snapp_account_not_present
           ; update_not_permitted
           ; incorrect_nonce
+          ; invalid_fee_excess
           } =
         { predicate = f predicate
         ; source_not_present = f source_not_present
@@ -218,6 +227,7 @@ module Failure = struct
         ; snapp_account_not_present = f snapp_account_not_present
         ; update_not_permitted = f update_not_permitted
         ; incorrect_nonce = f incorrect_nonce
+        ; invalid_fee_excess = f invalid_fee_excess
         }
     end
 
@@ -237,6 +247,7 @@ module Failure = struct
       ; snapp_account_not_present : 'bool
       ; update_not_permitted : 'bool
       ; incorrect_nonce : 'bool
+      ; invalid_fee_excess : 'bool
       }
     [@@deriving equal, sexp, compare]
 
@@ -273,6 +284,8 @@ module Failure = struct
           t.update_not_permitted
       | Incorrect_nonce ->
           t.incorrect_nonce
+      | Invalid_fee_excess ->
+          t.invalid_fee_excess
 
     type var = Boolean.var poly
 
@@ -294,6 +307,7 @@ module Failure = struct
         ; snapp_account_not_present
         ; update_not_permitted
         ; incorrect_nonce
+        ; invalid_fee_excess
         } =
       let bool_to_int b = if b then 1 else 0 in
       let failures =
@@ -312,13 +326,14 @@ module Failure = struct
         + bool_to_int snapp_account_not_present
         + bool_to_int update_not_permitted
         + bool_to_int incorrect_nonce
+        + bool_to_int invalid_fee_excess
       in
       failures = 0 || failures = 1
 
     let typ : (var, t) Typ.t =
       let bt = Boolean.typ in
       Typ.of_hlistable
-        [ bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt ]
+        [ bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt; bt ]
         ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
         ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
 
@@ -338,6 +353,7 @@ module Failure = struct
       ; snapp_account_not_present = false
       ; update_not_permitted = false
       ; incorrect_nonce = false
+      ; invalid_fee_excess = false
       }
 
     let predicate = { none with predicate = true }
@@ -377,6 +393,8 @@ module Failure = struct
 
     let incorrect_nonce = { none with incorrect_nonce = true }
 
+    let invalid_fee_excess = { none with invalid_fee_excess = true }
+
     let to_enum = function
       | { predicate = true; _ } ->
           to_enum Predicate
@@ -408,6 +426,8 @@ module Failure = struct
           to_enum Update_not_permitted
       | { incorrect_nonce = true; _ } ->
           to_enum Incorrect_nonce
+      | { invalid_fee_excess = true; _ } ->
+          to_enum Invalid_fee_excess
       | _ ->
           0
 
@@ -449,7 +469,9 @@ module Failure = struct
                 | Update_not_permitted ->
                     update_not_permitted
                 | Incorrect_nonce ->
-                    incorrect_nonce )
+                    incorrect_nonce
+                | Invalid_fee_excess ->
+                    invalid_fee_excess )
           | None ->
               None )
 
@@ -516,6 +538,8 @@ module Failure = struct
 
     val incorrect_nonce : t
 
+    val invalid_fee_excess : t
+
     val get : t -> failure -> Boolean.var
   end = struct
     module Accumulators = struct
@@ -538,6 +562,7 @@ module Failure = struct
            ; snapp_account_not_present
            ; update_not_permitted
            ; incorrect_nonce
+           ; invalid_fee_excess
            } :
             As_record.var) : t =
         let user_command_failure =
@@ -558,6 +583,7 @@ module Failure = struct
                ; (snapp_account_not_present :> Field.Var.t)
                ; (update_not_permitted :> Field.Var.t)
                ; (incorrect_nonce :> Field.Var.t)
+               ; (invalid_fee_excess :> Field.Var.t)
                ])
         in
         { user_command_failure }
@@ -623,6 +649,8 @@ module Failure = struct
     let update_not_permitted = mk_var As_record.update_not_permitted
 
     let incorrect_nonce = mk_var As_record.incorrect_nonce
+
+    let invalid_fee_excess = mk_var As_record.invalid_fee_excess
 
     let get { data; _ } failure = As_record.get data failure
 

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -516,37 +516,13 @@ module T = struct
         ~f:(fun x -> Ok x)
     else Ok constraint_constants.coinbase_amount
 
-  let apply_transaction ~constraint_constants ~ledger ~txn_state_view
-      ~source_merkle_root (s : Transaction.t) =
-    let open Or_error.Let_syntax in
-    match s with
-    | Command (Parties c) ->
-        let fee_excess = Amount.Signed.zero in
-        let to_fee_excess fee =
-          Fee_excess.of_single (Token_id.default, Amount.Signed.to_fee fee)
-        in
-        let%map applied_parties, fee_excess =
-          Ledger.apply_parties_unchecked_aux ~constraint_constants
-            ~state_view:txn_state_view ~fee_excess ledger c ~init:fee_excess
-            ~f:(fun _ (global_state, _local_state) -> global_state.fee_excess)
-        in
-        ( { Ledger.Transaction_applied.previous_hash = source_merkle_root
-          ; varying = Command (Parties applied_parties)
-          }
-        , to_fee_excess fee_excess )
-    | _ ->
-        let%bind applied_txn =
-          Ledger.apply_transaction ~constraint_constants ~txn_state_view ledger
-            s
-        in
-        let%map fee_excess = Transaction.fee_excess s in
-        (applied_txn, fee_excess)
-
   let apply_transaction_and_get_statement ~constraint_constants ledger
       (pending_coinbase_stack_state : Stack_state_with_init_stack.t) s
       txn_state_view =
     let open Result.Let_syntax in
-    let%bind supply_increase =
+    (*TODO: check fee_excess as a result of applying the txns matches with this*)
+    let%bind fee_excess = Transaction.fee_excess s |> to_staged_ledger_or_error
+    and supply_increase =
       Transaction.supply_increase s |> to_staged_ledger_or_error
     in
     let source_merkle_root =
@@ -560,9 +536,8 @@ module T = struct
       push_coinbase pending_coinbase_stack_state.init_stack s
     in
     let empty_local_state = Mina_state.Local_state.empty in
-    let%map applied_txn, fee_excess =
-      apply_transaction ~constraint_constants ~txn_state_view ~ledger
-        ~source_merkle_root s
+    let%map applied_txn =
+      Ledger.apply_transaction ~constraint_constants ~txn_state_view ledger s
       |> to_staged_ledger_or_error
     in
     let next_available_token_after = Ledger.next_available_token ledger in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1753,6 +1753,8 @@ module Base = struct
           let if_ b ~then_ ~else_ =
             run_checked (Amount.Checked.if_ b ~then_ ~else_)
 
+          let equal t t' = run_checked (Amount.Checked.equal t t')
+
           let zero = Amount.(var_of_t zero)
 
           let add_flagged x y = run_checked (Amount.Checked.add_flagged x y)
@@ -1937,6 +1939,8 @@ module Base = struct
                       let a : Account.t = read account_typ a.data in
                       let idx = idx ledger (Account.identifier a) in
                       Sparse_ledger.set_exn ledger idx a) )
+        | Check_fee_excess (valid_fee_excess, ()) ->
+            Boolean.Assert.is_true valid_fee_excess
         | Modify_global_excess (global, f) ->
             { global with fee_excess = f global.fee_excess }
         | Modify_global_ledger { global_state; ledger; should_update } ->
@@ -4708,6 +4712,23 @@ let%test_module "transaction_snark" =
           }
       ; other_parties =
           [ { data =
+                { body =
+                    { pk = acct1.account.public_key
+                    ; update = Party.Update.noop
+                    ; token_id = Token_id.default
+                    ; delta =
+                        Amount.Signed.(of_unsigned receiver_amount |> negate)
+                    ; increment_nonce = true
+                    ; events = []
+                    ; sequence_events = []
+                    ; call_data = Field.zero
+                    ; depth = 0
+                    }
+                ; predicate = Accept
+                }
+            ; authorization = Signature Signature.dummy
+            }
+          ; { data =
                 { body =
                     { pk = acct2.account.public_key
                     ; update = Party.Update.noop


### PR DESCRIPTION

All balance transfers within a parties transaction should be settled and the fee excess from applying should be equal to the transaction fee 

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
