### PR TITLE
use range check for currency and numbers

### DIFF
--- a/src/lib/block_time/block_time.mli
+++ b/src/lib/block_time/block_time.mli
@@ -70,7 +70,11 @@ module Time : sig
   module Checked : sig
     open Snark_params.Tick
 
-    type t = Unpacked.var
+    type t
+
+    val typ : (t, Stable.Latest.t) Typ.t
+
+    val to_input : t -> Field.Var.t Random_oracle_input.Chunked.t
 
     val ( = ) : t -> t -> (Boolean.var, _) Checked.t
 
@@ -82,7 +86,11 @@ module Time : sig
 
     val ( >= ) : t -> t -> (Boolean.var, _) Checked.t
 
-    val to_input : t -> Field.Var.t Random_oracle_input.Chunked.t
+    val to_field : t -> Field.Var.t
+
+    module Unsafe : sig
+      val of_field : Field.Var.t -> t
+    end
   end
 
   module Span : sig
@@ -106,7 +114,7 @@ module Time : sig
         with type Unpacked.value = t
          and type Packed.value = t
 
-    val to_time_ns_span : t -> Core.Time_ns.Span.t
+    val to_time_ns_span : t -> Core_kernel.Time_ns.Span.t
 
     val to_string_hum : t -> string
 
@@ -137,9 +145,19 @@ module Time : sig
     val to_input : t -> Tick.Field.t Random_oracle_input.Chunked.t
 
     module Checked : sig
-      type t = Unpacked.var
+      type t
 
-      val to_input : t -> Tick.Field.Var.t Random_oracle.Input.Chunked.t
+      val typ : (t, Stable.V1.t) Snark_params.Tick.Typ.t
+
+      open Snark_params.Tick
+
+      val to_input : t -> Tick.Field.Var.t Random_oracle_input.Chunked.t
+
+      val to_field : t -> Field.Var.t
+
+      module Unsafe : sig
+        val of_field : Field.Var.t -> t
+      end
     end
   end
 
@@ -172,6 +190,8 @@ module Time : sig
   val to_int64 : t -> Int64.t
 
   val of_int64 : Int64.t -> t
+
+  val of_uint64 : Unsigned.UInt64.t -> t
 
   val to_string : t -> string
 

--- a/src/lib/block_time/dune
+++ b/src/lib/block_time/dune
@@ -4,7 +4,7 @@
  (library_flags -linkall)
  (inline_tests)
  (preprocessor_deps ../../config.mlh)
- (libraries core mina_numbers logger snark_params snark_bits unsigned_extended timeout_lib)
+ (libraries core_kernel mina_numbers snark_params snark_bits unsigned_extended timeout_lib)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_hash ppx_let
                   ppx_coda ppx_version ppx_deriving_yojson ppx_bin_prot ppx_compare ppx_sexp_conv ppx_compare ppx_optcomp

--- a/src/lib/consensus/constants.ml
+++ b/src/lib/consensus/constants.ml
@@ -45,10 +45,7 @@ module Stable = struct
 end]
 
 type var =
-  ( Length.Checked.t
-  , Block_time.Unpacked.var
-  , Block_time.Span.Unpacked.var )
-  Poly.t
+  (Length.Checked.t, Block_time.Checked.t, Block_time.Span.Checked.t) Poly.t
 
 module type M_intf = sig
   type t
@@ -130,53 +127,55 @@ module Constants_UInt32 :
   let min = UInt32.min
 end
 
+module N =
+  Mina_numbers.Nat.Make_checked
+    (Unsigned_extended.UInt64)
+    (Snark_bits.Bits.UInt64)
+
 module Constants_checked :
   M_intf
     with type length = Length.Checked.t
-     and type time = Block_time.Unpacked.var
-     and type timespan = Block_time.Span.Unpacked.var = struct
-  open Snarky_integer
-
-  type t = field Integer.t
+     and type time = Block_time.Checked.t
+     and type timespan = Block_time.Span.Checked.t = struct
+  type t = N.var
 
   type length = Length.Checked.t
 
-  type time = Block_time.Unpacked.var
+  type time = Block_time.Checked.t
 
-  type timespan = Block_time.Span.Unpacked.var
+  type timespan = Block_time.Span.Checked.t
 
   type bool_type = Boolean.var
 
-  let constant c = Integer.constant ~m (Bignum_bigint.of_int c)
+  let constant c = N.Unsafe.of_field (Field.Var.constant (Field.of_int c))
 
   let zero = constant 0
 
   let one = constant 1
 
-  let of_length = Length.Checked.to_integer
+  let of_length = Fn.compose N.Unsafe.of_field Length.Checked.to_field
 
-  let to_length = Length.Checked.Unsafe.of_integer
+  let to_length = Fn.compose Length.Checked.Unsafe.of_field N.to_field
 
-  let of_time = Fn.compose (Integer.of_bits ~m) Block_time.Unpacked.var_to_bits
+  let of_time : Block_time.Checked.t -> t =
+    Fn.compose N.Unsafe.of_field Block_time.Checked.to_field
 
-  let to_time =
-    Fn.compose Block_time.Unpacked.var_of_bits
-      (Integer.to_bits ~m ~length:Block_time.Unpacked.size_in_bits)
+  let to_time : t -> Block_time.Checked.t =
+    Fn.compose Block_time.Checked.Unsafe.of_field N.to_field
 
-  let of_timespan =
-    Fn.compose (Integer.of_bits ~m) Block_time.Span.Unpacked.var_to_bits
+  let of_timespan : timespan -> t =
+    Fn.compose N.Unsafe.of_field Block_time.Span.Checked.to_field
 
-  let to_timespan =
-    Fn.compose Block_time.Span.Unpacked.var_of_bits
-      (Integer.to_bits ~length:Block_time.Span.Unpacked.size_in_bits ~m)
+  let to_timespan : t -> timespan =
+    Fn.compose Block_time.Span.Checked.Unsafe.of_field N.to_field
 
-  let ( / ) (t : t) (t' : t) = Integer.div_mod ~m t t' |> fst
+  let ( / ) (t : t) (t' : t) = Run.run_checked (N.div_mod t t') |> fst
 
-  let ( * ) = Integer.mul ~m
+  let ( * ) x y = Run.run_checked (N.mul x y)
 
-  let ( + ) = Integer.add ~m
+  let ( + ) x y = Run.run_checked (N.add x y)
 
-  let min = Integer.min ~m
+  let min x y = Run.run_checked (N.min x y)
 end
 
 let create' (type a b c)
@@ -324,11 +323,11 @@ let data_spec =
     ; Length.Checked.typ
     ; Length.Checked.typ
     ; Length.Checked.typ
-    ; Block_time.Span.Unpacked.typ
-    ; Block_time.Span.Unpacked.typ
-    ; Block_time.Span.Unpacked.typ
-    ; Block_time.Span.Unpacked.typ
-    ; Block_time.Unpacked.typ
+    ; Block_time.Span.Checked.typ
+    ; Block_time.Span.Checked.typ
+    ; Block_time.Span.Checked.typ
+    ; Block_time.Span.Checked.typ
+    ; Block_time.Checked.typ
     ]
 
 let typ =
@@ -403,7 +402,6 @@ module Checked = struct
   let create ~(constraint_constants : Genesis_constants.Constraint_constants.t)
       ~(protocol_constants : Mina_base.Protocol_constants_checked.var) :
       (var, _) Checked.t =
-    let open Snarky_integer in
     let%bind constants =
       make_checked (fun () ->
           create'
@@ -411,26 +409,26 @@ module Checked = struct
             ~constraint_constants ~protocol_constants)
     in
     let%map checkpoint_window_slots_per_year, checkpoint_window_size_in_slots =
-      let constant c = Integer.constant ~m (Bignum_bigint.of_int c) in
+      let constant c =
+        N.Unsafe.of_field (Field.Var.constant (Field.of_int c))
+      in
       let per_year = constant 12 in
       let slot_duration_ms =
-        Integer.of_bits ~m
-          (Block_time.Span.Unpacked.var_to_bits constants.slot_duration_ms)
+        N.Unsafe.of_field
+          (Block_time.Span.Checked.to_field constants.slot_duration_ms)
       in
-      let slots_per_year =
+      let%bind slots_per_year, _ =
         let one_year_ms =
           constant (Core.Time.Span.(to_ms (of_day 365.)) |> Float.to_int)
         in
-        fst (Integer.div_mod ~m one_year_ms slot_duration_ms)
+        N.div_mod one_year_ms slot_duration_ms
       in
       let%map size_in_slots =
-        let size_in_slots, rem = Integer.div_mod ~m slots_per_year per_year in
-        let%map () =
-          Boolean.Assert.is_true (Integer.equal ~m rem (constant 0))
-        in
+        let%bind size_in_slots, rem = N.div_mod slots_per_year per_year in
+        let%map () = N.Assert.equal rem (constant 0) in
         size_in_slots
       in
-      let to_length = Length.Checked.Unsafe.of_integer in
+      let to_length = Fn.compose Length.Checked.Unsafe.of_field N.to_field in
       (to_length slots_per_year, to_length size_in_slots)
     in
     { constants with

--- a/src/lib/consensus/global_slot.ml
+++ b/src/lib/consensus/global_slot.ml
@@ -37,8 +37,8 @@ let typ =
     ~value_of_hlist:Poly.of_hlist
 
 let to_input (t : value) =
-  Random_oracle.Input.Chunked.append (T.to_input t.slot_number)
-    (Length.to_input t.slots_per_epoch)
+  Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
+    [| T.to_input t.slot_number; Length.to_input t.slots_per_epoch |]
 
 let gen ~(constants : Constants.t) =
   let open Quickcheck.Let_syntax in
@@ -60,9 +60,6 @@ let zero ~(constants : Constants.t) : t =
 let slot_number { Poly.slot_number; _ } = slot_number
 
 let slots_per_epoch { Poly.slots_per_epoch; _ } = slots_per_epoch
-
-let to_bits (t : t) =
-  List.concat_map ~f:T.to_bits [ t.slot_number; t.slots_per_epoch ]
 
 let epoch (t : t) = UInt32.Infix.(t.slot_number / t.slots_per_epoch)
 
@@ -121,28 +118,20 @@ module Checked = struct
   let of_slot_number ~(constants : Constants.var) slot_number : t =
     { slot_number; slots_per_epoch = constants.slots_per_epoch }
 
-  let to_bits (t : t) =
-    let open Bitstring_lib.Bitstring.Lsb_first in
-    let%map slot_number = T.Checked.to_bits t.slot_number
-    and slots_per_epoch = Length.Checked.to_bits t.slots_per_epoch in
-    List.concat_map ~f:to_list [ slot_number; slots_per_epoch ] |> of_list
-
-  let to_input (t : var) =
-    Random_oracle.Input.Chunked.append
-      (T.Checked.to_input t.slot_number)
-      (Length.Checked.to_input t.slots_per_epoch)
+  let to_input (var : t) =
+    Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
+      [| T.Checked.to_input var.slot_number
+       ; Length.Checked.to_input var.slots_per_epoch
+      |]
 
   let to_epoch_and_slot (t : t) :
       (Epoch.Checked.t * Slot.Checked.t, _) Checked.t =
-    make_checked (fun () ->
-        let open Snarky_integer in
-        let epoch, slot =
-          Integer.div_mod ~m
-            (T.Checked.to_integer t.slot_number)
-            (Length.Checked.to_integer t.slots_per_epoch)
-        in
-        ( Epoch.Checked.Unsafe.of_integer epoch
-        , Slot.Checked.Unsafe.of_integer slot ))
+    let%map epoch, slot =
+      T.Checked.div_mod t.slot_number
+        (T.Checked.Unsafe.of_field (Length.Checked.to_field t.slots_per_epoch))
+    in
+    ( Epoch.Checked.Unsafe.of_field (T.Checked.to_field epoch)
+    , Slot.Checked.Unsafe.of_field (T.Checked.to_field slot) )
 
   let sub (t : t) (t' : t) = T.Checked.sub t.slot_number t'.slot_number
 end

--- a/src/lib/consensus/global_slot.mli
+++ b/src/lib/consensus/global_slot.mli
@@ -45,8 +45,6 @@ val of_epoch_and_slot : constants:Constants.t -> Epoch.t * Slot.t -> t
 
 val zero : constants:Constants.t -> t
 
-val to_bits : t -> bool list
-
 val epoch : t -> Epoch.t
 
 val slot : t -> Slot.t
@@ -66,7 +64,6 @@ val diff : constants:Constants.t -> t -> Epoch.t * Slot.t -> t
 [%%ifdef consensus_mechanism]
 
 open Snark_params.Tick
-open Bitstring_lib
 
 module Checked : sig
   open Snark_params.Tick
@@ -78,8 +75,6 @@ module Checked : sig
 
   val of_slot_number :
     constants:Constants.var -> Mina_numbers.Global_slot.Checked.t -> t
-
-  val to_bits : t -> (Boolean.var Bitstring.Lsb_first.t, _) Checked.t
 
   val to_input : t -> Field.Var.t Random_oracle.Input.Chunked.t
 

--- a/src/lib/consensus/global_sub_window.ml
+++ b/src/lib/consensus/global_sub_window.ml
@@ -22,40 +22,38 @@ let sub a b = UInt32.sub a b
 let constant a = a
 
 module Checked = struct
-  open Snarky_integer
+  module T = Mina_numbers.Global_slot
 
-  type t = field Integer.t
+  type t = T.Checked.t
+
+  let of_length (x : Mina_numbers.Length.Checked.t) : t =
+    T.Checked.Unsafe.of_field (Mina_numbers.Length.Checked.to_field x)
 
   let of_global_slot ~(constants : Constants.var) (s : Global_slot.Checked.t) :
       (t, _) Checked.t =
-    make_checked (fun () ->
-        let q, _ =
-          Integer.div_mod ~m
-            (Mina_numbers.Global_slot.Checked.to_integer
-               (Global_slot.slot_number s))
-            (Mina_numbers.Length.Checked.to_integer
-               constants.slots_per_sub_window)
-        in
-        q)
+    let%map q, _ =
+      T.Checked.div_mod
+        (Global_slot.slot_number s)
+        (of_length constants.slots_per_sub_window)
+    in
+    q
 
   let sub_window ~(constants : Constants.var) (t : t) :
       (Sub_window.Checked.t, _) Checked.t =
-    make_checked (fun () ->
-        let _, shift =
-          Integer.div_mod ~m t
-            (Mina_numbers.Length.Checked.to_integer
-               constants.sub_windows_per_window)
-        in
-        Sub_window.Checked.Unsafe.of_integer shift)
+    let%map _, shift =
+      T.Checked.div_mod t (of_length constants.sub_windows_per_window)
+    in
+    Sub_window.Checked.Unsafe.of_field (T.Checked.to_field shift)
 
-  let succ (t : t) : t = Integer.succ ~m t
+  let succ (t : t) : (t, _) Checked.t = T.Checked.succ t
 
-  let equal a b = make_checked (fun () -> Integer.equal ~m a b)
+  let equal = T.Checked.equal
 
   let constant a =
-    Integer.constant ~m @@ Bignum_bigint.of_int @@ UInt32.to_int a
+    T.Checked.Unsafe.of_field @@ Field.Var.constant @@ Field.of_int
+    @@ UInt32.to_int a
 
-  let add a b = Integer.add ~m a (Mina_numbers.Length.Checked.to_integer b)
+  let add a (b : Mina_numbers.Length.Checked.t) = T.Checked.add a (of_length b)
 
-  let ( >= ) a b = make_checked (fun () -> Integer.gte ~m a b)
+  let ( >= ) a b = T.Checked.( >= ) a b
 end

--- a/src/lib/consensus/global_sub_window.mli
+++ b/src/lib/consensus/global_sub_window.mli
@@ -19,13 +19,13 @@ module Checked : sig
 
   type t
 
-  val succ : t -> t
+  val succ : t -> (t, _) Checked.t
 
   val equal : t -> t -> (Boolean.var, _) Checked.t
 
   val constant : Unsigned.UInt32.t -> t
 
-  val add : t -> Mina_numbers.Length.Checked.t -> t
+  val add : t -> Mina_numbers.Length.Checked.t -> (t, _) Checked.t
 
   val ( >= ) : t -> t -> (Boolean.var, _) Checked.t
 

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -54,7 +54,7 @@ module type Blockchain_state = sig
     ( Staged_ledger_hash.var
     , Frozen_ledger_hash.var
     , Token_id.var
-    , Block_time.Unpacked.var )
+    , Block_time.Checked.t )
     Poly.t
 
   val create_value :

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1319,8 +1319,10 @@ module Data = struct
         in
         let%bind overlapping_window =
           Global_sub_window.Checked.(
-            add prev_global_sub_window constants.sub_windows_per_window
-            >= next_global_sub_window)
+            let%bind x =
+              add prev_global_sub_window constants.sub_windows_per_window
+            in
+            x >= next_global_sub_window)
         in
         let if_ cond ~then_ ~else_ =
           let%bind cond = cond and then_ = then_ and else_ = else_ in
@@ -1364,8 +1366,8 @@ module Data = struct
           let%bind in_grace_period =
             Global_slot.Checked.( < ) next_global_slot
               (Global_slot.Checked.of_slot_number ~constants
-                 (Mina_numbers.Global_slot.Checked.Unsafe.of_integer
-                    (Length.Checked.to_integer constants.grace_period_end)))
+                 (Mina_numbers.Global_slot.Checked.Unsafe.of_field
+                    (Length.Checked.to_field constants.grace_period_end)))
           in
           if_
             Boolean.(same_sub_window || in_grace_period)

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1959,27 +1959,28 @@ module Data = struct
     let same_checkpoint_window ~(constants : Constants.var)
         ~prev:(slot1 : Global_slot.Checked.t)
         ~next:(slot2 : Global_slot.Checked.t) =
-      let open Snarky_integer in
-      let open Run in
       let module Slot = Mina_numbers.Global_slot in
-      let slot1 = Slot.Checked.to_integer (Global_slot.slot_number slot1) in
+      let slot1 : Slot.Checked.t = Global_slot.slot_number slot1 in
       let checkpoint_window_size_in_slots =
-        Length.Checked.to_integer constants.checkpoint_window_size_in_slots
+        constants.checkpoint_window_size_in_slots
       in
-      let _q1, r1 = Integer.div_mod ~m slot1 checkpoint_window_size_in_slots in
+      let%bind _q1, r1 =
+        Slot.Checked.div_mod slot1
+          (Slot.Checked.Unsafe.of_field
+             (Length.Checked.to_field checkpoint_window_size_in_slots))
+      in
       let next_window_start =
-        Field.(
-          Integer.to_field slot1 - Integer.to_field r1
-          + Integer.to_field checkpoint_window_size_in_slots)
+        Run.Field.(
+          Slot.Checked.to_field slot1
+          - Slot.Checked.to_field r1
+          + Length.Checked.to_field checkpoint_window_size_in_slots)
       in
-      (Field.compare ~bit_length:Slot.length_in_bits
-         ( Global_slot.slot_number slot2
-         |> Slot.Checked.to_integer |> Integer.to_field )
-         next_window_start)
-        .less
+      Slot.Checked.( < )
+        (Global_slot.slot_number slot2)
+        (Slot.Checked.Unsafe.of_field next_window_start)
 
     let same_checkpoint_window ~constants ~prev ~next =
-      make_checked (fun () -> same_checkpoint_window ~constants ~prev ~next)
+      same_checkpoint_window ~constants ~prev ~next
 
     let negative_one ~genesis_ledger
         ~(genesis_epoch_data : Genesis_epoch_data.t) ~(constants : Constants.t)

--- a/src/lib/consensus/slot.ml
+++ b/src/lib/consensus/slot.ml
@@ -17,25 +17,22 @@ module Checked = struct
 
   let in_seed_update_range ~(constants : Constants.var) (slot : var) =
     let open Tick in
-    let open Snarky_integer in
     let module Length = Mina_numbers.Length in
-    let integer_mul i i' = make_checked (fun () -> Integer.mul ~m i i') in
-    let to_integer = Length.Checked.to_integer in
-    let%bind third_epoch =
-      make_checked (fun () ->
-          let q, r =
-            Integer.div_mod ~m
-              (to_integer constants.slots_per_epoch)
-              (Integer.constant ~m (Bignum_bigint.of_int 3))
-          in
-          Tick.Run.Boolean.Assert.is_true
-            (Integer.equal ~m r (Integer.constant ~m Bignum_bigint.zero)) ;
-          q)
+    let constant c =
+      Length.Checked.Unsafe.of_field (Field.Var.constant (Field.of_int c))
     in
-    let two = Integer.constant ~m (Bignum_bigint.of_int 2) in
-    let%bind ck_times_2 = integer_mul third_epoch two in
-    make_checked (fun () ->
-        Integer.lt ~m (T.Checked.to_integer slot) ck_times_2)
+    let%bind third_epoch =
+      let%bind q, r =
+        Length.Checked.div_mod constants.slots_per_epoch (constant 3)
+      in
+      let%map () = Length.Checked.Assert.equal r (constant 0) in
+      q
+    in
+    let two = constant 2 in
+    let%bind ck_times_2 = Length.Checked.mul third_epoch two in
+    Length.Checked.( < )
+      (Length.Checked.Unsafe.of_field (T.Checked.to_field slot))
+      ck_times_2
 end
 
 let gen (constants : Constants.t) =

--- a/src/lib/consensus/vrf/consensus_vrf.ml
+++ b/src/lib/consensus/vrf/consensus_vrf.ml
@@ -335,7 +335,14 @@ module Threshold = struct
     Bignum.(lhs <= rhs)
 
   module Checked = struct
-    let is_satisfied ~my_stake ~total_stake (vrf_output : Output.Truncated.var)
+    let balance_upper_bound =
+      Bignum_bigint.(one lsl Currency.Balance.length_in_bits)
+
+    let amount_upper_bound =
+      Bignum_bigint.(one lsl Currency.Amount.length_in_bits)
+
+    let is_satisfied ~(my_stake : Currency.Balance.var)
+        ~(total_stake : Currency.Amount.var) (vrf_output : Output.Truncated.var)
         =
       let open Currency in
       let open Snark_params.Tick in
@@ -347,8 +354,14 @@ module Threshold = struct
             Exp.one_minus_exp ~m params
               (Floating_point.of_quotient ~m
                  ~precision:params.per_term_precision
-                 ~top:(Integer.of_bits ~m (Balance.var_to_bits my_stake))
-                 ~bottom:(Integer.of_bits ~m (Amount.var_to_bits total_stake))
+                 ~top:
+                   (Integer.create
+                      ~value:(Balance.pack_var my_stake)
+                      ~upper_bound:balance_upper_bound)
+                 ~bottom:
+                   (Integer.create
+                      ~value:(Amount.pack_var total_stake)
+                      ~upper_bound:amount_upper_bound)
                  ~top_is_less_than_bottom:())
           in
           let vrf_output = Array.to_list (vrf_output :> Boolean.var array) in

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -23,6 +23,14 @@ module Signed_poly = Signed_poly
 
 type uint64 = Unsigned.uint64
 
+module Signed_var = struct
+  type 'mag repr = ('mag, Sgn.var) Signed_poly.t
+
+  (* Invariant: At least one of these is Some *)
+  type nonrec 'mag t =
+    { mutable repr : 'mag repr option; mutable value : Field.Var.t option }
+end
+
 module Make (Unsigned : sig
   include Unsigned_extended.S
 
@@ -34,11 +42,13 @@ end) (M : sig
 end) : sig
   [%%ifdef consensus_mechanism]
 
-  include S with type t = Unsigned.t and type var = Boolean.var list
-
-  val var_of_bits : Boolean.var Bitstring.Lsb_first.t -> var
-
-  val unpack_var : Field.Var.t -> (var, _) Tick.Checked.t
+  include
+    S
+      with type t = Unsigned.t
+       and type var = Field.Var.t
+       and type Signed.var = Field.Var.t Signed_var.t
+       and type Signed.signed_fee = (Unsigned.t, Sgn.t) Signed_poly.t
+       and type Signed.Checked.signed_fee_var = Field.Var.t Signed_var.t
 
   val pack_var : var -> Field.Var.t
 
@@ -141,30 +151,60 @@ end = struct
 
   [%%ifdef consensus_mechanism]
 
-  include Bits.Snarkable.Small_bit_vector (Tick) (Vector)
-  include Unpacked
+  type var = Field.Var.t
 
-  let var_to_number t = Number.of_bits (var_to_bits t :> Boolean.var list)
+  let pack_var = Fn.id
 
-  let var_to_input t =
-    Random_oracle.Input.Chunked.packed (Field.Var.project t, length_in_bits)
+  let equal_var = Field.Checked.equal
 
-  let var_to_input_legacy t =
-    Random_oracle.Input.Legacy.bitstring (var_to_bits t :> Boolean.var list)
+  let m = Snark_params.Tick.m
 
-  let var_of_bits (bits : Boolean.var Bitstring.Lsb_first.t) : var =
-    let bits = (bits :> Boolean.var list) in
-    let n = List.length bits in
-    assert (Int.( <= ) n M.length) ;
-    let padding = M.length - n in
-    bits @ List.init padding ~f:(fun _ -> Boolean.false_)
+  let make_checked = Snark_params.Tick.make_checked
 
-  let var_of_t t =
-    List.init M.length ~f:(fun i -> Boolean.var_of_value (Vector.get t i))
+  let var_to_bits_ (t : var) = Field.Checked.unpack ~length:length_in_bits t
 
-  let if_ cond ~then_ ~else_ =
-    Field.Checked.if_ cond ~then_:(pack_var then_) ~else_:(pack_var else_)
-    >>= unpack_var
+  let var_to_bits t = var_to_bits_ t >>| Bitstring.Lsb_first.of_list
+
+  let var_to_input (t : var) =
+    Random_oracle.Input.Chunked.packed (t, length_in_bits)
+
+  let var_to_input_legacy (t : var) =
+    var_to_bits_ t >>| Random_oracle.Input.Legacy.bitstring
+
+  let var_of_t (t : t) : var = Field.Var.constant (Field.project (to_bits t))
+
+  let if_ cond ~then_ ~else_ : (var, _) Checked.t =
+    Field.Checked.if_ cond ~then_ ~else_
+
+  let () = assert (Int.(length_in_bits mod 16 = 0))
+
+  let range_check' (t : var) =
+    make_checked (fun () ->
+        let _, _, actual_packed =
+          Pickles.Scalar_challenge.to_field_checked' ~num_bits:length_in_bits m
+            (Kimchi_backend_common.Scalar_challenge.create t)
+        in
+        actual_packed)
+
+  let range_check t =
+    let%bind actual = range_check' t in
+    Field.Checked.Assert.equal actual t
+
+  let range_check_flag t =
+    let%bind actual = range_check' t in
+    Field.Checked.equal actual t
+
+  let of_field (x : Field.t) : t =
+    of_bits (List.take (Field.unpack x) length_in_bits)
+
+  let to_field (x : t) : Field.t = Field.project (to_bits x)
+
+  let typ : (var, t) Typ.t =
+    Typ.transport
+      { Field.typ with check = range_check }
+      ~there:to_field ~back:of_field
+
+  let seal x = make_checked (fun () -> Pickles.Util.seal Tick.m x)
 
   [%%endif]
 
@@ -178,6 +218,10 @@ end = struct
     let z = Unsigned.add x y in
     if z < x then None else Some z
 
+  let add_flagged x y =
+    let z = Unsigned.add x y in
+    (z, `Overflow (z < x))
+
   let scale u64 i =
     let i = Unsigned.of_int i in
     let max_val = Unsigned.(div max_int i) in
@@ -189,7 +233,7 @@ end = struct
 
   type magnitude = t [@@deriving sexp, hash, compare, yojson]
 
-  let to_input t =
+  let to_input (t : t) =
     Random_oracle.Input.Chunked.packed
       (Field.project (to_bits t), length_in_bits)
 
@@ -201,6 +245,8 @@ end = struct
     [@@deriving sexp, hash, compare, yojson, hlist]
 
     type t = (Unsigned.t, Sgn.t) Signed_poly.t [@@deriving sexp, hash, yojson]
+
+    type signed_fee = t
 
     let compare : t -> t -> int =
       let cmp = [%compare: (Unsigned.t, Sgn.t) Signed_poly.t] in
@@ -282,104 +328,213 @@ end = struct
 
     let ( + ) = add
 
+    let to_fee = Fn.id
+
+    let of_fee = Fn.id
+
     [%%ifdef consensus_mechanism]
 
-    type nonrec var = (var, Sgn.var) Signed_poly.t
+    let magnitude_to_field = to_field
 
-    let typ =
+    let to_field (t : t) : Field.t =
+      Field.mul (Sgn.to_field t.sgn) (magnitude_to_field t.magnitude)
+
+    let magnitude_upper_bound =
+      Bigint.of_bignum_bigint Bignum_bigint.(one lsl M.length)
+
+    let of_field (x : Field.t) : t =
+      let n = Bigint.of_field x in
+      let sgn, magnitude =
+        if Int.( <= ) (Bigint.compare n magnitude_upper_bound) 0 then
+          (Sgn.Pos, x)
+        else (Sgn.Neg, Field.negate x)
+      in
+      { sgn; magnitude = of_field magnitude }
+
+    type repr = var Signed_var.repr
+
+    type nonrec var = var Signed_var.t
+
+    let repr_typ : (repr, t) Typ.t =
       Typ.of_hlistable [ typ; Sgn.typ ] ~var_to_hlist:typ_to_hlist
         ~var_of_hlist:typ_of_hlist ~value_to_hlist:typ_to_hlist
         ~value_of_hlist:typ_of_hlist
 
+    let typ : (var, t) Typ.t =
+      { alloc =
+          Snarky_backendless.Typ_monads.Alloc.map repr_typ.alloc ~f:(fun r ->
+              { Signed_var.value = None; repr = Some r })
+      ; check =
+          (fun x ->
+            match x.repr with None -> return () | Some r -> repr_typ.check r)
+      ; read =
+          (fun (x : var) ->
+            match (x.repr, x.value) with
+            | None, None ->
+                assert false
+            | Some r, None | Some r, Some _ ->
+                repr_typ.read r
+            | None, Some v ->
+                Snarky_backendless.Typ_monads.Read.map (Field.typ.read v)
+                  ~f:of_field)
+      ; store =
+          (fun (x : t) ->
+            Snarky_backendless.Typ_monads.Store.map (repr_typ.store x)
+              ~f:(fun r -> { Signed_var.value = None; repr = Some r }))
+      }
+
+    let create_var ~magnitude ~sgn : var =
+      { repr = Some { magnitude; sgn }; value = None }
+
     module Checked = struct
       type t = var
 
-      let to_bits { magnitude; sgn } =
-        Sgn.Checked.is_pos sgn :: (var_to_bits magnitude :> Boolean.var list)
+      type signed_fee_var = t
 
-      let to_input { magnitude; sgn } =
+      let repr_value ({ magnitude; sgn } : repr) =
+        Field.Checked.mul magnitude (sgn :> Field.Var.t)
+
+      let repr (x : Field.Var.t) =
+        let%bind repr =
+          exists repr_typ
+            ~compute:As_prover.(map (read Field.typ x) ~f:of_field)
+        in
+        let%bind x' = repr_value repr in
+        let%map () = Field.Checked.Assert.equal x x' in
+        repr
+
+      let repr (t : var) =
+        match t.repr with
+        | Some r ->
+            Checked.return r
+        | None ->
+            let%map r = repr (Option.value_exn t.value) in
+            t.repr <- Some r ;
+            r
+
+      let value (t : var) =
+        match t.value with
+        | Some x ->
+            Checked.return x
+        | None ->
+            let r = Option.value_exn t.repr in
+            let%map x = Field.Checked.mul (r.sgn :> Field.Var.t) r.magnitude in
+            t.value <- Some x ;
+            x
+
+      let to_field_var = value
+
+      let to_input t =
+        let%map { magnitude; sgn } = repr t in
         let mag = var_to_input magnitude in
         Random_oracle.Input.Chunked.(
           append mag (packed ((Sgn.Checked.is_pos sgn :> Field.Var.t), 1)))
 
-      let to_input_legacy t = Random_oracle.Input.Legacy.bitstring (to_bits t)
+      let to_input_legacy t =
+        let to_bits { magnitude; sgn } =
+          let%map magnitude = var_to_bits_ magnitude in
+          Sgn.Checked.is_pos sgn :: magnitude
+        in
+        repr t >>= to_bits >>| Random_oracle.Input.Legacy.bitstring
 
-      let constant { magnitude; sgn } =
-        { magnitude = var_of_t magnitude; sgn = Sgn.Checked.constant sgn }
+      let constant ({ magnitude; sgn } as t) =
+        { Signed_var.repr =
+            Some
+              { magnitude = var_of_t magnitude; sgn = Sgn.Checked.constant sgn }
+        ; value = Some (Field.Var.constant (to_field t))
+        }
 
-      let of_unsigned magnitude = { magnitude; sgn = Sgn.Checked.pos }
+      let of_unsigned magnitude : var =
+        { repr = Some { magnitude; sgn = Sgn.Checked.pos }
+        ; value = Some magnitude
+        }
 
-      let negate { magnitude; sgn } =
-        { magnitude; sgn = Sgn.Checked.negate sgn }
+      let negate (t : var) : var =
+        { value = Option.map t.value ~f:Field.Var.negate
+        ; repr =
+            Option.map t.repr ~f:(fun { magnitude; sgn } ->
+                { magnitude; sgn = Sgn.Checked.negate sgn })
+        }
 
-      let if_ cond ~then_ ~else_ =
+      let if_repr cond ~then_ ~else_ =
         let%map sgn = Sgn.Checked.if_ cond ~then_:then_.sgn ~else_:else_.sgn
         and magnitude =
           if_ cond ~then_:then_.magnitude ~else_:else_.magnitude
         in
         { sgn; magnitude }
 
-      let to_field_var ({ magnitude; sgn } : var) =
-        Field.Checked.mul (pack_var magnitude) (sgn :> Field.Var.t)
+      let if_ cond ~(then_ : var) ~(else_ : var) : (var, _) Checked.t =
+        let%bind repr =
+          match (then_.repr, else_.repr) with
+          | Some r1, Some r2 ->
+              if_repr cond ~then_:r1 ~else_:r2 >>| Option.return
+          | _ ->
+              return None
+        in
+        let%map value =
+          match (then_.value, else_.value) with
+          | Some v1, Some v2 ->
+              Field.Checked.if_ cond ~then_:v1 ~else_:v2 >>| Option.return
+          | _ ->
+              return None
+        in
+        assert (Option.is_some repr || Option.is_some value) ;
+        { Signed_var.value; repr }
 
-      let add (x : var) (y : var) =
-        let%bind xv = to_field_var x and yv = to_field_var y in
+      let sgn (t : var) =
+        let%map r = repr t in
+        r.sgn
+
+      let magnitude (t : var) =
+        let%map r = repr t in
+        r.magnitude
+
+      let add_flagged (x : var) (y : var) =
+        let%bind xv = value x and yv = value y in
         let%bind sgn =
           exists Sgn.typ
             ~compute:
               (let open As_prover in
               let%map x = read typ x and y = read typ y in
-              (Option.value_exn (add x y)).sgn)
+              Option.value_map (add x y) ~f:(fun r -> r.sgn) ~default:Sgn.Pos)
         in
-        let%bind res =
-          Tick.Field.Checked.mul (sgn :> Field.Var.t) (Field.Var.add xv yv)
+        let%bind res_value = seal (Field.Var.add xv yv) in
+        let%bind magnitude =
+          Tick.Field.Checked.mul (sgn :> Field.Var.t) res_value
         in
-        let%map magnitude = unpack_var res in
-        { magnitude; sgn }
+        let%map no_overflow = range_check_flag magnitude in
+        ( { Signed_var.repr = Some { magnitude; sgn }; value = Some res_value }
+        , `Overflow (Boolean.not no_overflow) )
+
+      let add (x : var) (y : var) =
+        let%bind xv = value x and yv = value y in
+        let%bind sgn =
+          exists Sgn.typ
+            ~compute:
+              (let open As_prover in
+              let%map x = read typ x and y = read typ y in
+              Option.value_map (add x y) ~default:Sgn.Pos ~f:(fun r -> r.sgn))
+        in
+        let%bind res_value = seal (Field.Var.add xv yv) in
+        let%bind magnitude =
+          Tick.Field.Checked.mul (sgn :> Field.Var.t) res_value
+        in
+        let%map () = range_check magnitude in
+        { Signed_var.repr = Some { magnitude; sgn }; value = Some res_value }
 
       let ( + ) = add
 
       let equal (t1 : var) (t2 : var) =
-        let%bind t1 = to_field_var t1 and t2 = to_field_var t2 in
+        let%bind t1 = value t1 and t2 = value t2 in
         Field.Checked.equal t1 t2
 
       let assert_equal (t1 : var) (t2 : var) =
-        let%bind t1 = to_field_var t1 and t2 = to_field_var t2 in
+        let%bind t1 = value t1 and t2 = value t2 in
         Field.Checked.Assert.equal t1 t2
 
-      let cswap_field (b : Boolean.var) (x, y) =
-        (* (x + b(y - x), y + b(x - y)) *)
-        let open Field.Checked in
-        let%map b_y_minus_x =
-          Tick.Field.Checked.mul (b :> Field.Var.t) (y - x)
-        in
-        (x + b_y_minus_x, y - b_y_minus_x)
+      let to_fee = Fn.id
 
-      let cswap b (x, y) =
-        let l_sgn, r_sgn =
-          match (x.sgn, y.sgn) with
-          | Sgn.Pos, Sgn.Pos ->
-              Sgn.Checked.(pos, pos)
-          | Neg, Neg ->
-              Sgn.Checked.(neg, neg)
-          | Pos, Neg ->
-              (Sgn.Checked.neg_if_true b, Sgn.Checked.pos_if_true b)
-          | Neg, Pos ->
-              (Sgn.Checked.pos_if_true b, Sgn.Checked.neg_if_true b)
-        in
-        let%map l_mag, r_mag =
-          let%bind l, r =
-            cswap_field b (pack_var x.magnitude, pack_var y.magnitude)
-          in
-          let%map l = unpack_var l and r = unpack_var r in
-          (l, r)
-        in
-        ({ sgn = l_sgn; magnitude = l_mag }, { sgn = r_sgn; magnitude = r_mag })
-
-      let scale (f : Field.Var.t) (t : var) =
-        let%bind x = Field.Checked.mul (pack_var t.magnitude) f in
-        let%map x = unpack_var x in
-        { sgn = t.sgn; magnitude = x }
+      let of_fee = Fn.id
     end
 
     [%%endif]
@@ -394,57 +549,67 @@ end = struct
 
     let if_ = if_
 
-    let if_value cond ~then_ ~else_ : var =
-      List.init M.length ~f:(fun i ->
-          match (Vector.get then_ i, Vector.get else_ i) with
-          | true, true ->
-              Boolean.true_
-          | false, false ->
-              Boolean.false_
-          | true, false ->
-              cond
-          | false, true ->
-              Boolean.not cond)
-
     (* Unpacking protects against underflow *)
-    let sub (x : Unpacked.var) (y : Unpacked.var) =
-      unpack_var (Field.Var.sub (pack_var x) (pack_var y))
+    let sub (x : var) (y : var) =
+      let%bind res = seal (Field.Var.sub x y) in
+      let%map () = range_check res in
+      res
 
     let sub_flagged x y =
-      let z = Field.Var.sub (pack_var x) (pack_var y) in
-      let%map bits, `Success no_underflow =
-        Field.Checked.unpack_flagged z ~length:length_in_bits
-      in
-      (bits, `Underflow (Boolean.not no_underflow))
+      let%bind z = seal (Field.Var.sub x y) in
+      let%map no_underflow = range_check_flag z in
+      (z, `Underflow (Boolean.not no_underflow))
 
-    let assert_equal x y = Field.Checked.Assert.equal (pack_var x) (pack_var y)
+    let sub_or_zero x y =
+      make_checked (fun () ->
+          let open Tick.Run in
+          let res = Pickles.Util.seal Tick.m Field.(x - y) in
+          let neg_res = Pickles.Util.seal Tick.m (Field.negate res) in
+          let x_gte_y = run_checked (range_check_flag res) in
+          let y_gte_x = run_checked (range_check_flag neg_res) in
+          Boolean.Assert.any [ x_gte_y; y_gte_x ] ;
+          (* If y_gte_x is false, then x_gte_y is true, so x >= y and
+             thus there was no underflow.
 
-    let equal x y = Field.Checked.equal (pack_var x) (pack_var y)
+             If y_gte_x is true, then y >= x, which means there was underflow
+             iff y != x.
+
+             Thus, underflow = (neg_res_good && y != x)
+          *)
+          let underflow =
+            Boolean.( &&& ) y_gte_x (Boolean.not (Field.equal x y))
+          in
+          Field.if_ underflow ~then_:Field.zero ~else_:res)
+
+    let assert_equal x y = Field.Checked.Assert.equal x y
+
+    let equal x y = Field.Checked.equal x y
 
     let ( = ) = equal
 
-    let op f (x : var) (y : var) : (Boolean.var, 'a) Checked.t =
-      let g = Fn.compose N.of_bits var_to_bits in
-      f (g x) (g y)
+    (* x <= y iff range_check_flag (y - x) *)
+    let ( <= ) x y = range_check_flag (Field.Var.sub y x)
 
-    let ( <= ) x = op N.( <= ) x
+    (* x >= y iff y <= x *)
+    let ( >= ) x y = y <= x
 
-    let ( >= ) x = op N.( >= ) x
+    let ( < ) x y =
+      let%bind x_lt_y = x <= y in
+      let%bind eq = x = y in
+      Boolean.( &&& ) x_lt_y (Boolean.not eq)
 
-    let ( < ) x = op N.( < ) x
-
-    let ( > ) x = op N.( > ) x
+    let ( > ) x y = y < x
 
     (* Unpacking protects against overflow *)
-    let add (x : Unpacked.var) (y : Unpacked.var) =
-      unpack_var (Field.Var.add (pack_var x) (pack_var y))
+    let add (x : var) (y : var) =
+      let%bind res = seal (Field.Var.add x y) in
+      let%map () = range_check res in
+      res
 
     let add_flagged x y =
-      let z = Field.Var.add (pack_var x) (pack_var y) in
-      let%map bits, `Success no_overflow =
-        Field.Checked.unpack_flagged z ~length:length_in_bits
-      in
-      (bits, `Overflow (Boolean.not no_overflow))
+      let%bind z = seal (Field.Var.add x y) in
+      let%map no_overflow = range_check_flag z in
+      (z, `Overflow (Boolean.not no_overflow))
 
     let ( - ) = sub
 
@@ -452,19 +617,20 @@ end = struct
 
     let add_signed (t : var) (d : Signed.var) =
       let%bind d = Signed.Checked.to_field_var d in
-      Field.Var.add (pack_var t) d |> unpack_var
+      let%bind res = seal (Field.Var.add t d) in
+      let%map () = range_check res in
+      res
 
     let add_signed_flagged (t : var) (d : Signed.var) =
       let%bind d = Signed.Checked.to_field_var d in
-      let%map bits, `Success no_overflow =
-        Field.Var.add (pack_var t) d
-        |> Field.Checked.unpack_flagged ~length:length_in_bits
-      in
-      (bits, `Overflow (Boolean.not no_overflow))
+      let%bind res = seal (Field.Var.add t d) in
+      let%map no_overflow = range_check_flag res in
+      (res, `Overflow (Boolean.not no_overflow))
 
     let scale (f : Field.Var.t) (t : var) =
-      let%bind x = Field.Checked.mul (pack_var t) f in
-      unpack_var x
+      let%bind res = Field.Checked.mul t f in
+      let%map () = range_check res in
+      res
 
     let%test_module "currency_test" =
       ( module struct
@@ -668,9 +834,6 @@ module Amount = struct
     let of_fee (fee : Fee.var) : var = fee
 
     let to_fee (t : var) : Fee.var = t
-
-    let add_fee (t : var) (fee : Fee.var) =
-      Tick.Field.Var.add (pack_var t) (Fee.pack_var fee) |> unpack_var
   end
 
   [%%endif]
@@ -715,6 +878,12 @@ module Balance = struct
   module Checked = struct
     include Amount.Checked
 
+    module Unsafe = struct
+      let of_field (x : Field.Var.t) : var = x
+    end
+
+    let to_amount = Fn.id
+
     let add_signed_amount = add_signed
 
     let add_amount = add
@@ -746,8 +915,10 @@ let%test_module "sub_flagged module" =
 
       type magnitude = t [@@deriving sexp, compare]
 
-      type var =
-        field Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t list
+      type var
+
+      (* TODO =
+         field Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t list *)
 
       val zero : t
 

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -23,6 +23,8 @@ module Signed_poly = Signed_poly
 
 type uint64 = Unsigned.uint64
 
+[%%ifdef consensus_mechanism]
+
 module Signed_var = struct
   type 'mag repr = ('mag, Sgn.var) Signed_poly.t
 
@@ -30,6 +32,8 @@ module Signed_var = struct
   type nonrec 'mag t =
     { mutable repr : 'mag repr option; mutable value : Field.Var.t option }
 end
+
+[%%endif]
 
 module Make (Unsigned : sig
   include Unsigned_extended.S

--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -86,7 +86,11 @@ module Amount : sig
   [%%ifdef consensus_mechanism]
 
   module Signed :
-    Signed_intf with type magnitude := t and type magnitude_var := var
+    Signed_intf
+      with type magnitude := t
+       and type magnitude_var := var
+       and type signed_fee := Fee.Signed.t
+       and type Checked.signed_fee_var := Fee.Signed.Checked.t
 
   [%%else]
 

--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -7,6 +7,14 @@ open Intf
 
 open Snark_params.Tick
 
+module Signed_var : sig
+  type 'mag repr = ('mag, Sgn.var) Signed_poly.t
+
+  (* Invariant: At least one of these is Some *)
+  type nonrec 'mag t =
+    { mutable repr : 'mag repr option; mutable value : Field.Var.t option }
+end
+
 [%%endif]
 
 type uint64 = Unsigned.uint64
@@ -108,8 +116,6 @@ module Amount : sig
     val of_fee : Fee.var -> var
 
     val to_fee : var -> Fee.var
-
-    val add_fee : var -> Fee.var -> (var, _) Checked.t
   end
 
   [%%endif]
@@ -144,6 +150,8 @@ module Balance : sig
   module Checked : sig
     type t = var
 
+    val to_amount : t -> Amount.var
+
     val add_signed_amount : var -> Amount.Signed.var -> (var, _) Checked.t
 
     val add_amount : var -> Amount.var -> (var, _) Checked.t
@@ -160,6 +168,8 @@ module Balance : sig
          var
       -> Amount.Signed.var
       -> (var * [ `Overflow of Boolean.var ], _) Checked.t
+
+    val sub_or_zero : var -> var -> (var, _) Checked.t
 
     val ( + ) : var -> Amount.var -> (var, _) Checked.t
 
@@ -178,6 +188,10 @@ module Balance : sig
     val ( >= ) : var -> var -> (Boolean.var, _) Checked.t
 
     val if_ : Boolean.var -> then_:var -> else_:var -> (var, _) Checked.t
+
+    module Unsafe : sig
+      val of_field : Field.Var.t -> var
+    end
   end
 
   [%%endif]

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -70,15 +70,18 @@ module type Basic = sig
 
   val var_of_t : t -> var
 
-  val var_to_number : var -> Number.t
-
-  val var_to_bits : var -> Boolean.var Bitstring_lib.Bitstring.Lsb_first.t
+  val var_to_bits :
+    var -> (Boolean.var Bitstring_lib.Bitstring.Lsb_first.t, _) Checked.t
 
   val var_to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
 
-  val var_to_input_legacy : var -> (_, Boolean.var) Random_oracle.Legacy.Input.t
+  val var_to_input_legacy :
+       var
+    -> ((Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t, _) Checked.t
 
   val equal_var : var -> var -> (Boolean.var, _) Checked.t
+
+  val pack_var : var -> Field.Var.t
 
   [%%endif]
 end
@@ -87,6 +90,8 @@ module type Arithmetic_intf = sig
   type t
 
   val add : t -> t -> t option
+
+  val add_flagged : t -> t -> t * [ `Overflow of bool ]
 
   val sub : t -> t -> t option
 
@@ -99,6 +104,8 @@ end
 
 module type Signed_intf = sig
   type magnitude
+
+  type signed_fee
 
   [%%ifdef consensus_mechanism]
 
@@ -138,26 +145,43 @@ module type Signed_intf = sig
 
   val of_unsigned : magnitude -> t
 
+  val to_fee : t -> signed_fee
+
+  val of_fee : signed_fee -> t
+
   [%%ifdef consensus_mechanism]
 
-  type var = (magnitude_var, Sgn.var) Signed_poly.t
+  type var (* = (magnitude_var, Sgn.var) Signed_poly.t *)
+
+  val create_var : magnitude:magnitude_var -> sgn:Sgn.var -> var
 
   val typ : (var, t) Typ.t
 
   module Checked : sig
+    type signed_fee_var
+
     val constant : t -> var
 
     val of_unsigned : magnitude_var -> var
+
+    val sgn : var -> (Sgn.var, _) Checked.t
+
+    val magnitude : var -> (magnitude_var, _) Checked.t
 
     val negate : var -> var
 
     val if_ : Boolean.var -> then_:var -> else_:var -> (var, _) Checked.t
 
-    val to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
+    val to_input :
+      var -> (Field.Var.t Random_oracle.Input.Chunked.t, _) Checked.t
 
-    val to_input_legacy : var -> (_, Boolean.var) Random_oracle.Legacy.Input.t
+    val to_input_legacy :
+      var -> ((_, Boolean.var) Random_oracle.Legacy.Input.t, _) Checked.t
 
     val add : var -> var -> (var, _) Checked.t
+
+    val add_flagged :
+      var -> var -> (var * [ `Overflow of Boolean.var ], _) Checked.t
 
     val assert_equal : var -> var -> (unit, _) Checked.t
 
@@ -167,13 +191,9 @@ module type Signed_intf = sig
 
     val to_field_var : var -> (Field.Var.t, _) Checked.t
 
-    val scale : Field.Var.t -> var -> (var, _) Checked.t
+    val to_fee : var -> signed_fee_var
 
-    val cswap :
-         Boolean.var
-      -> (magnitude_var, Sgn.t) Signed_poly.t
-         * (magnitude_var, Sgn.t) Signed_poly.t
-      -> (var * var, _) Checked.t
+    val of_fee : signed_fee_var -> var
 
     type t = var
   end
@@ -194,14 +214,14 @@ module type Checked_arithmetic_intf = sig
 
   val if_ : Boolean.var -> then_:var -> else_:var -> (var, _) Checked.t
 
-  val if_value : Boolean.var -> then_:value -> else_:value -> var
-
   val add : var -> var -> (var, _) Checked.t
 
   val sub : var -> var -> (var, _) Checked.t
 
   val sub_flagged :
     var -> var -> (var * [ `Underflow of Boolean.var ], _) Checked.t
+
+  val sub_or_zero : var -> var -> (var, _) Checked.t
 
   val add_flagged :
     var -> var -> (var * [ `Overflow of Boolean.var ], _) Checked.t

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -443,39 +443,36 @@ module Checked = struct
   let min_balance_at_slot ~global_slot ~cliff_time ~cliff_amount ~vesting_period
       ~vesting_increment ~initial_minimum_balance =
     let%bind before_cliff = Global_slot.Checked.(global_slot < cliff_time) in
-    let balance_to_int balance =
-      Snarky_integer.Integer.of_bits ~m @@ Balance.var_to_bits balance
+    let%bind else_branch =
+      make_checked (fun () ->
+          let _, slot_diff =
+            Tick.Run.run_checked
+              (Global_slot.Checked.sub_or_zero global_slot cliff_time)
+          in
+          let cliff_decrement = cliff_amount in
+          let min_balance_less_cliff_decrement, _ =
+            Tick.Run.run_checked
+              (Balance.Checked.sub_amount_flagged initial_minimum_balance
+                 cliff_decrement)
+          in
+          let num_periods, _ =
+            Tick.Run.run_checked
+              (Global_slot.Checked.div_mod slot_diff vesting_period)
+          in
+          let vesting_decrement =
+            Tick.Run.Field.mul
+              (Global_slot.Checked.to_field num_periods)
+              (Amount.pack_var vesting_increment)
+          in
+          let min_balance_less_cliff_and_vesting_decrements =
+            Tick.Run.run_checked
+              (Balance.Checked.sub_or_zero min_balance_less_cliff_decrement
+                 (Balance.Checked.Unsafe.of_field vesting_decrement))
+          in
+          min_balance_less_cliff_and_vesting_decrements)
     in
-    let open Snarky_integer.Integer in
-    let initial_minimum_balance_int = balance_to_int initial_minimum_balance in
-    make_checked (fun () ->
-        if_ ~m before_cliff ~then_:initial_minimum_balance_int
-          ~else_:
-            (let global_slot_int = Global_slot.Checked.to_integer global_slot in
-             let cliff_time_int = Global_slot.Checked.to_integer cliff_time in
-             let _, slot_diff =
-               subtract_unpacking_or_zero ~m global_slot_int cliff_time_int
-             in
-             let cliff_decrement_int =
-               Amount.var_to_bits cliff_amount |> of_bits ~m
-             in
-             let _, min_balance_less_cliff_decrement =
-               subtract_unpacking_or_zero ~m initial_minimum_balance_int
-                 cliff_decrement_int
-             in
-             let vesting_period_int =
-               Global_slot.Checked.to_integer vesting_period
-             in
-             let num_periods, _ = div_mod ~m slot_diff vesting_period_int in
-             let vesting_increment_int =
-               Amount.var_to_bits vesting_increment |> of_bits ~m
-             in
-             let vesting_decrement = mul ~m num_periods vesting_increment_int in
-             let _, min_balance_less_cliff_and_vesting_decrements =
-               subtract_unpacking_or_zero ~m min_balance_less_cliff_decrement
-                 vesting_decrement
-             in
-             min_balance_less_cliff_and_vesting_decrements))
+    Balance.Checked.if_ before_cliff ~then_:initial_minimum_balance
+      ~else_:else_branch
 
   let has_locked_tokens ~global_slot (t : var) =
     let open Timing.As_record in
@@ -493,12 +490,7 @@ module Checked = struct
         ~cliff_amount ~vesting_period ~vesting_increment
     in
     let%map zero_min_balance =
-      let zero_int =
-        Snarky_integer.Integer.constant ~m
-          (Bigint.of_field Field.zero |> Bigint.to_bignum_bigint)
-      in
-      make_checked (fun () ->
-          Snarky_integer.Integer.equal ~m cur_min_balance zero_int)
+      Balance.equal_var Balance.(var_of_t zero) cur_min_balance
     in
     (*Note: Untimed accounts will always have zero min balance*)
     Boolean.not zero_min_balance

--- a/src/lib/mina_base/fee_excess.ml
+++ b/src/lib/mina_base/fee_excess.ml
@@ -158,12 +158,10 @@ let to_input { fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } =
 let to_input_checked { fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } =
   let fee_token_l = Token_id.Checked.to_input fee_token_l
   and fee_token_r = Token_id.Checked.to_input fee_token_r in
+  let%map fee_excess_l = Fee.Signed.Checked.to_input fee_excess_l
+  and fee_excess_r = Fee.Signed.Checked.to_input fee_excess_r in
   List.reduce_exn ~f:Random_oracle.Input.Chunked.append
-    [ fee_token_l
-    ; Fee.Signed.Checked.to_input fee_excess_l
-    ; fee_token_r
-    ; Fee.Signed.Checked.to_input fee_excess_r
-    ]
+    [ fee_token_l; fee_excess_l; fee_token_r; fee_excess_r ]
 
 let assert_equal_checked (t1 : var) (t2 : var) =
   Checked.all_unit

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -173,7 +173,7 @@ module Body = struct
         [ Public_key.Compressed.Checked.to_input pk
         ; Update.Checked.to_input update
         ; Token_id.Checked.to_input token_id
-        ; Amount.Signed.Checked.to_input delta
+        ; Impl.run_checked (Amount.Signed.Checked.to_input delta)
         ]
 
     let digest (t : t) =

--- a/src/lib/mina_base/payment_payload.ml
+++ b/src/lib/mina_base/payment_payload.ml
@@ -83,12 +83,13 @@ let to_input_legacy { Poly.source_pk; receiver_pk; token_id; amount } =
     |]
 
 let var_to_input_legacy { Poly.source_pk; receiver_pk; token_id; amount } =
-  let%map token_id = Token_id.Checked.to_input_legacy token_id in
+  let%map token_id = Token_id.Checked.to_input_legacy token_id
+  and amount = Amount.var_to_input_legacy amount in
   Array.reduce_exn ~f:Random_oracle.Input.Legacy.append
     [| Public_key.Compressed.Checked.to_input_legacy source_pk
      ; Public_key.Compressed.Checked.to_input_legacy receiver_pk
      ; token_id
-     ; Amount.var_to_input_legacy amount
+     ; amount
     |]
 
 let var_of_t ({ source_pk; receiver_pk; token_id; amount } : t) : var =

--- a/src/lib/mina_base/protocol_constants_checked.ml
+++ b/src/lib/mina_base/protocol_constants_checked.ml
@@ -88,7 +88,7 @@ let to_input (t : value) =
 
 [%%if defined consensus_mechanism]
 
-type var = (T.Checked.t, T.Checked.t, Block_time.Unpacked.var) Poly.t
+type var = (T.Checked.t, T.Checked.t, Block_time.Checked.t) Poly.t
 
 let data_spec =
   Data_spec.

--- a/src/lib/mina_base/protocol_constants_checked.ml
+++ b/src/lib/mina_base/protocol_constants_checked.ml
@@ -96,7 +96,7 @@ let data_spec =
     ; T.Checked.typ
     ; T.Checked.typ
     ; T.Checked.typ
-    ; Block_time.Unpacked.typ
+    ; Block_time.Checked.typ
     ]
 
 let typ =

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -181,9 +181,10 @@ module Common = struct
         ({ fee; fee_token; fee_payer_pk; nonce; valid_until; memo } : var) =
       let%map nonce = Account_nonce.Checked.to_input_legacy nonce
       and valid_until = Global_slot.Checked.to_input_legacy valid_until
-      and fee_token = Token_id.Checked.to_input_legacy fee_token in
+      and fee_token = Token_id.Checked.to_input_legacy fee_token
+      and fee = Currency.Fee.var_to_input_legacy fee in
       Array.reduce_exn ~f:Random_oracle.Input.Legacy.append
-        [| Currency.Fee.var_to_input_legacy fee
+        [| fee
          ; fee_token
          ; Public_key.Compressed.Checked.to_input_legacy fee_payer_pk
          ; nonce

--- a/src/lib/mina_base/snapp_command.ml
+++ b/src/lib/mina_base/snapp_command.ml
@@ -170,7 +170,7 @@ module Party = struct
         List.reduce_exn ~f:Random_oracle_input.Chunked.append
           [ Public_key.Compressed.Checked.to_input pk
           ; Update.Checked.to_input update
-          ; Amount.Signed.Checked.to_input delta
+          ; Impl.run_checked (Amount.Signed.Checked.to_input delta)
           ]
 
       let digest (t : t) =

--- a/src/lib/mina_base/snapp_predicate.ml
+++ b/src/lib/mina_base/snapp_predicate.ml
@@ -140,7 +140,7 @@ module Numeric = struct
         ; lte_checked = run Checked.( <= )
         ; zero
         ; max_value
-        ; typ = Unpacked.typ
+        ; typ = Checked.typ
         ; to_input
         ; to_input_checked = Checked.to_input
         }
@@ -729,7 +729,7 @@ module Protocol_state = struct
       type t =
         ( Frozen_ledger_hash.var
         , Token_id.var
-        , Block_time.Unpacked.var
+        , Block_time.Checked.t
         , Length.Checked.t
         , unit (* TODO *)
         , Global_slot.Checked.t
@@ -748,7 +748,7 @@ module Protocol_state = struct
     type t =
       ( Frozen_ledger_hash.var Hash.Checked.t
       , Token_id.var Numeric.Checked.t
-      , Block_time.Unpacked.var Numeric.Checked.t
+      , Block_time.Checked.t Numeric.Checked.t
       , Length.Checked.t Numeric.Checked.t
       , unit (* TODO *)
       , Global_slot.Checked.t Numeric.Checked.t

--- a/src/lib/mina_base/token_id.ml
+++ b/src/lib/mina_base/token_id.ml
@@ -94,8 +94,6 @@ let typ = T.typ
 let var_of_t = T.Checked.constant
 
 module Checked = struct
-  open Snark_params.Tick
-
   type t = var
 
   let next = T.Checked.succ
@@ -111,10 +109,7 @@ module Checked = struct
   let if_ = T.Checked.if_
 
   module Assert = struct
-    let equal x y =
-      let x = T.Checked.to_integer x |> Snarky_integer.Integer.to_field in
-      let y = T.Checked.to_integer y |> Snarky_integer.Integer.to_field in
-      Field.Checked.Assert.equal x y
+    let equal = T.Checked.Assert.equal
   end
 
   let ( = ) = T.Checked.( = )

--- a/src/lib/mina_base/transaction_union_payload.ml
+++ b/src/lib/mina_base/transaction_union_payload.ml
@@ -178,13 +178,14 @@ module Body = struct
 
     let to_input_legacy
         { tag; source_pk; receiver_pk; token_id; amount; token_locked } =
-      let%map token_id = Token_id.Checked.to_input_legacy token_id in
+      let%map token_id = Token_id.Checked.to_input_legacy token_id
+      and amount = Currency.Amount.var_to_input_legacy amount in
       Array.reduce_exn ~f:Random_oracle.Input.Legacy.append
         [| Tag.Unpacked.to_input_legacy tag
          ; Public_key.Compressed.Checked.to_input_legacy source_pk
          ; Public_key.Compressed.Checked.to_input_legacy receiver_pk
          ; token_id
-         ; Currency.Amount.var_to_input_legacy amount
+         ; amount
          ; Random_oracle.Input.Legacy.bitstring [ token_locked ]
         |]
   end

--- a/src/lib/mina_numbers/intf.ml
+++ b/src/lib/mina_numbers/intf.ml
@@ -77,7 +77,6 @@ module type S_checked = sig
   type unchecked
 
   open Snark_params.Tick
-  open Bitstring_lib
 
   type var
 
@@ -90,6 +89,8 @@ module type S_checked = sig
   val succ : t -> (t, _) Checked.t
 
   val add : t -> t -> (t, _) Checked.t
+
+  val mul : t -> t -> (t, _) Checked.t
 
   (** [sub_or_zero x y] computes [x - y].
 
@@ -107,16 +108,10 @@ module type S_checked = sig
 
   val min : t -> t -> (t, _) Checked.t
 
-  val of_bits : Boolean.var Bitstring.Lsb_first.t -> t
-
-  val to_bits : t -> (Boolean.var Bitstring.Lsb_first.t, _) Checked.t
-
   val to_input : t -> Field.Var.t Random_oracle.Input.Chunked.t
 
   val to_input_legacy :
     t -> ((_, Boolean.var) Random_oracle.Legacy.Input.t, _) Checked.t
-
-  val to_integer : t -> field Snarky_integer.Integer.t
 
   val succ_if : t -> Boolean.var -> (t, _) Checked.t
 
@@ -126,6 +121,8 @@ module type S_checked = sig
   val typ : (t, unchecked) Snark_params.Tick.Typ.t
 
   val equal : t -> t -> (Boolean.var, _) Checked.t
+
+  val div_mod : t -> t -> (t * t, _) Checked.t
 
   val ( = ) : t -> t -> (Boolean.var, _) Checked.t
 
@@ -137,8 +134,14 @@ module type S_checked = sig
 
   val ( >= ) : t -> t -> (Boolean.var, _) Checked.t
 
+  module Assert : sig
+    val equal : t -> t -> (unit, _) Checked.t
+  end
+
+  val to_field : t -> Field.Var.t
+
   module Unsafe : sig
-    val of_integer : field Snarky_integer.Integer.t -> t
+    val of_field : Field.Var.t -> t
   end
 end
 
@@ -149,15 +152,10 @@ module type S = sig
 
   [%%ifdef consensus_mechanism]
 
-  open Snark_params.Tick
-  open Bitstring_lib
-
   module Checked : S_checked with type unchecked := t
 
   (** warning: this typ does not work correctly with the generic if_ *)
   val typ : (Checked.t, t) Snark_params.Tick.Typ.t
-
-  val var_to_bits : Checked.t -> Boolean.var Bitstring.Lsb_first.t
 
   [%%endif]
 end

--- a/src/lib/mina_numbers/nat.ml
+++ b/src/lib/mina_numbers/nat.ml
@@ -9,111 +9,177 @@ module Intf = Intf
 
 open Snark_bits
 
-let zero_checked =
-  Snarky_integer.Integer.constant ~m:Snark_params.Tick.m Bigint.zero
-
 module Make_checked
     (N : Unsigned_extended.S)
     (Bits : Bits_intf.Convertible_bits with type t := N.t) =
 struct
-  open Bitstring_lib
   open Snark_params.Tick
-  open Snarky_integer
 
-  type var = field Integer.t
+  type var = Field.Var.t
 
   let () = assert (Int.(N.length_in_bits < Field.size_in_bits))
 
-  let to_field = Integer.to_field
+  let to_input (t : var) =
+    Random_oracle.Input.Chunked.packed (t, N.length_in_bits)
 
-  let of_bits bs = Integer.of_bits ~m bs
-
-  let to_bits t =
-    with_label
-      (sprintf "to_bits: %s" __LOC__)
-      (make_checked (fun () -> Integer.to_bits ~length:N.length_in_bits ~m t))
-
-  let to_input t =
-    Random_oracle_input.Chunked.packed (to_field t, N.length_in_bits)
-
-  let to_input_legacy t =
+  let to_input_legacy (t : var) =
+    let to_bits (t : var) =
+      with_label
+        (sprintf "to_bits: %s" __LOC__)
+        (Field.Checked.choose_preimage_var t ~length:N.length_in_bits)
+    in
     Checked.map (to_bits t) ~f:(fun bits ->
-        Random_oracle.Input.Legacy.bitstring
-          (Bitstring_lib.Bitstring.Lsb_first.to_list bits))
+        Random_oracle.Input.Legacy.bitstring bits)
 
-  let constant n = Integer.constant ~length:N.length_in_bits ~m (N.to_bigint n)
+  let constant n =
+    Field.Var.constant
+      (Bigint.to_field (Bigint.of_bignum_bigint (N.to_bigint n)))
 
-  (* warning: this typ does not work correctly with the generic if_ *)
-  let typ : (field Integer.t, N.t) Typ.t =
-    let typ = Typ.list ~length:N.length_in_bits Boolean.typ in
-    let of_bits bs = of_bits (Bitstring.Lsb_first.of_list bs) in
-    let alloc = Typ.Alloc.map typ.alloc ~f:of_bits in
-    let store t =
-      Typ.Store.map (typ.store (Fold.to_list (Bits.fold t))) ~f:of_bits
+  let () = assert (Int.(N.length_in_bits mod 16 = 0))
+
+  let range_check' (t : var) =
+    let _, _, actual_packed =
+      Pickles.Scalar_challenge.to_field_checked' ~num_bits:N.length_in_bits m
+        (Kimchi_backend_common.Scalar_challenge.create t)
     in
-    let check v =
-      typ.check (Bitstring.Lsb_first.to_list (Integer.to_bits_exn v))
+    actual_packed
+
+  let range_check t =
+    let%bind actual = make_checked (fun () -> range_check' t) in
+    Field.Checked.Assert.equal actual t
+
+  let range_check_flag t =
+    let open Pickles.Impls.Step in
+    let actual = range_check' t in
+    Field.equal actual t
+
+  let of_field (x : Field.t) : N.t =
+    let of_bits bs =
+      (* TODO: Make this efficient *)
+      List.foldi bs ~init:N.zero ~f:(fun i acc b ->
+          if b then N.(logor (shift_left one i) acc) else acc)
     in
-    let read v =
-      let of_field_elt x =
-        let bs = List.take (Field.unpack x) N.length_in_bits in
-        (* TODO: Make this efficient *)
-        List.foldi bs ~init:N.zero ~f:(fun i acc b ->
-            if b then N.(logor (shift_left one i) acc) else acc)
-      in
-      Typ.Read.map (Field.typ.read (Integer.to_field v)) ~f:of_field_elt
+    of_bits (List.take (Field.unpack x) N.length_in_bits)
+
+  let to_field (x : N.t) : Field.t = Field.project (Fold.to_list (Bits.fold x))
+
+  let typ : (var, N.t) Typ.t =
+    Typ.transport
+      { Field.typ with check = range_check }
+      ~there:to_field ~back:of_field
+
+  let () = assert (N.length_in_bits * 2 < Field.size_in_bits + 1)
+
+  let div_mod (x : var) (y : var) =
+    let%bind q, r =
+      exists (Typ.tuple2 typ typ)
+        ~compute:
+          As_prover.(
+            let%map x = read typ x and y = read typ y in
+            (N.div x y, N.rem x y))
     in
-    { alloc; store; check; read }
+
+    (* q * y + r = x
+
+       q * y = x - r
+    *)
+    let%map () = assert_r1cs q y (Field.Var.sub x r) in
+    (q, r)
 
   type t = var
 
   let is_succ ~pred ~succ =
     let open Snark_params.Tick in
     let open Field in
-    Checked.(equal (to_field pred + Var.constant one) (to_field succ))
+    Checked.(equal (pred + Var.constant one) succ)
 
-  let min a b = make_checked (fun () -> Integer.min ~m a b)
+  let gte x y =
+    let open Pickles.Impls.Step in
+    let xy = Pickles.Util.seal m Field.(x - y) in
+    let yx = Pickles.Util.seal m (Field.negate xy) in
+    let x_gte_y = range_check_flag xy in
+    let y_gte_x = range_check_flag yx in
+    Boolean.Assert.any [ x_gte_y; y_gte_x ] ;
+    x_gte_y
 
-  let if_ c ~then_ ~else_ =
-    make_checked (fun () -> Integer.if_ ~m c ~then_ ~else_)
+  let op op a b = make_checked (fun () -> op a b)
 
-  let succ_if t c =
+  let ( >= ) a b = op gte a b
+
+  let ( <= ) a b = b >= a
+
+  let ( < ) a b =
     make_checked (fun () ->
-        let t = Integer.succ_if ~m t c in
-        t)
+        let open Pickles.Impls.Step in
+        Boolean.( &&& ) (gte b a) (Boolean.not (Field.equal b a)))
 
-  let succ t =
-    make_checked (fun () ->
-        let t = Integer.succ ~m t in
-        t)
+  let ( > ) a b = b < a
 
-  let op op a b = make_checked (fun () -> op ~m a b)
+  module Assert = struct
+    let equal = Field.Checked.Assert.equal
+  end
 
-  let add a b = op Integer.add a b
+  let to_field = Fn.id
 
-  let sub_or_zero a b = op Integer.subtract_unpacking_or_zero a b
+  module Unsafe = struct
+    let of_field = Fn.id
+  end
 
-  let sub a b = op Integer.subtract_unpacking a b
+  let min a b =
+    let%bind a_lte_b = a <= b in
+    Field.Checked.if_ a_lte_b ~then_:a ~else_:b
 
-  let equal a b = op Integer.equal a b
+  let if_ = Field.Checked.if_
 
-  let ( < ) a b = op Integer.lt a b
+  let succ_if (t : var) (c : Boolean.var) =
+    Checked.return (Field.Var.add t (c :> Field.Var.t))
 
-  let ( <= ) a b = op Integer.lte a b
+  let succ (t : var) =
+    Checked.return (Field.Var.add t (Field.Var.constant Field.one))
 
-  let ( > ) a b = op Integer.gt a b
+  let seal x = make_checked (fun () -> Pickles.Util.seal m x)
 
-  let ( >= ) a b = op Integer.gte a b
+  let add (x : var) (y : var) =
+    let%bind res = seal (Field.Var.add x y) in
+    let%map () = range_check res in
+    res
+
+  let mul (x : var) (y : var) =
+    let%bind res = Field.Checked.mul x y in
+    let%map () = range_check res in
+    res
+
+  let subtract_unpacking_or_zero x y =
+    let open Pickles.Impls.Step in
+    let res = Pickles.Util.seal m Field.(x - y) in
+    let neg_res = Pickles.Util.seal m (Field.negate res) in
+    let x_gte_y = range_check_flag res in
+    let y_gte_x = range_check_flag neg_res in
+    Boolean.Assert.any [ x_gte_y; y_gte_x ] ;
+    (* If y_gte_x is false, then x_gte_y is true, so x >= y and
+       thus there was no underflow.
+
+       If y_gte_x is true, then y >= x, which means there was underflow
+       iff y != x.
+
+       Thus, underflow = (neg_res_good && y != x)
+    *)
+    let underflow = Boolean.( &&& ) y_gte_x (Boolean.not (Field.equal x y)) in
+    (`Underflow underflow, Field.if_ underflow ~then_:Field.zero ~else_:res)
+
+  let sub_or_zero a b = make_checked (fun () -> subtract_unpacking_or_zero a b)
+
+  (* Unpacking protects against underflow *)
+  let sub (x : var) (y : var) =
+    let%bind res = seal (Field.Var.sub x y) in
+    let%map () = range_check res in
+    res
+
+  let equal a b = Field.Checked.equal a b
 
   let ( = ) = equal
 
-  let to_integer = Fn.id
-
-  module Unsafe = struct
-    let of_integer = Fn.id
-  end
-
-  let zero = zero_checked
+  let zero = Field.Var.constant Field.zero
 end
 
 open Snark_params.Tick
@@ -153,10 +219,6 @@ struct
 
   (* warning: this typ does not work correctly with the generic if_ *)
   let typ = Checked.typ
-
-  let var_to_bits var =
-    Snarky_integer.Integer.to_bits ~length:N.length_in_bits
-      ~m:Snark_params.Tick.m var
 
   [%%endif]
 

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -49,7 +49,7 @@ type var =
   ( Staged_ledger_hash.var
   , Frozen_ledger_hash.var
   , Token_id.var
-  , Block_time.Unpacked.var )
+  , Block_time.Checked.t )
   Poly.t
 
 let create_value ~staged_ledger_hash ~snarked_ledger_hash ~genesis_ledger_hash
@@ -67,7 +67,7 @@ let data_spec =
   ; Frozen_ledger_hash.typ
   ; Frozen_ledger_hash.typ
   ; Token_id.typ
-  ; Block_time.Unpacked.typ
+  ; Block_time.Checked.typ
   ]
 
 let typ : (var, Value.t) Typ.t =

--- a/src/lib/mina_state/blockchain_state.mli
+++ b/src/lib/mina_state/blockchain_state.mli
@@ -39,7 +39,7 @@ include
           ( Staged_ledger_hash.var
           , Frozen_ledger_hash.var
           , Token_id.var
-          , Block_time.Unpacked.var )
+          , Block_time.Checked.t )
           Poly.t
      and type value := Value.t
 


### PR DESCRIPTION
This PR uses the efficient range-check that comes from `Scalar_challenge.to_field` to implement arithmetic operations in currencly.ml