### PR TITLE
Range check for numbers

### DIFF
--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -67,7 +67,7 @@ module Time = struct
 
     let create offset = offset
 
-    let basic ~logger () =
+    let basic ~logger:_ () =
       match !time_offset with
       | Some offset ->
           offset
@@ -75,11 +75,11 @@ module Time = struct
           let offset =
             let env = "MINA_TIME_OFFSET" in
             let env_offset =
-              match Core.Sys.getenv env with
+              match Core_kernel.Sys.getenv_opt env with
               | Some tm ->
                   Int.of_string tm
               | None ->
-                  [%log debug]
+                  eprintf
                     "Environment variable %s not found, using default of 0" env ;
                   0
             in
@@ -112,25 +112,33 @@ module Time = struct
   module B = Bits
   module Bits = Bits.UInt64
   include B.Snarkable.UInt64 (Tick)
+  module N = Mina_numbers.Nat.Make_checked (UInt64) (Bits)
+
+  let to_input (t : t) =
+    Random_oracle_input.packed (Tick.Field.project (Bits.to_bits t), 64)
 
   module Checked = struct
-    type t = Unpacked.var
+    type t = N.var
 
-    module N = Mina_numbers.Nat.Make_checked (UInt64) (Bits)
+    module Unsafe = N.Unsafe
 
-    let op f (x : t) (y : t) : (Boolean.var, 'a) Checked.t =
-      let g = Fn.compose N.of_bits Unpacked.var_to_bits in
-      f (g x) (g y)
+    let typ = N.typ
 
-    let ( = ) x = op N.( = ) x
+    let to_input (t : t) = N.to_input t
 
-    let ( <= ) x = op N.( <= ) x
+    let to_field = N.to_field
 
-    let ( >= ) x = op N.( >= ) x
+    open N
 
-    let ( < ) x = op N.( < ) x
+    let ( = ) = ( = )
 
-    let ( > ) x = op N.( > ) x
+    let ( <= ) = ( <= )
+
+    let ( >= ) = ( >= )
+
+    let ( < ) = ( < )
+
+    let ( > ) = ( > )
   end
 
   module Span = struct
@@ -179,6 +187,10 @@ module Time = struct
     let min = UInt64.min
 
     let zero = UInt64.zero
+
+    let to_input = to_input
+
+    module Checked = Checked
   end
 
   include Comparable.Make (Stable.Latest)
@@ -230,6 +242,8 @@ module Time = struct
   let to_int64 = Fn.compose Span.to_ms to_span_since_epoch
 
   let of_int64 = Fn.compose of_span_since_epoch Span.of_ms
+
+  let of_uint64 : UInt64.t -> t = of_span_since_epoch
 
   let to_string = Fn.compose Int64.to_string to_int64
 

--- a/src/lib/block_time/block_time.mli
+++ b/src/lib/block_time/block_time.mli
@@ -19,7 +19,7 @@ module Time : sig
 
     val create : t -> t
 
-    val basic : logger:Logger.t -> t
+    val basic : logger:Logger_type.t -> t
 
     (** Override the time offset set by the [MINA_TIME_OFFSET] environment
         variable for all block time controllers.
@@ -32,7 +32,7 @@ module Time : sig
     (** Get the current time offset, either from the [MINA_TIME_OFFSET]
         environment variable, or as last set by [set_time_offset].
     *)
-    val get_time_offset : logger:Logger.t -> Time.Span.t
+    val get_time_offset : logger:Logger_type.t -> Time.Span.t
 
     (** Disallow setting the time offset. This should be run at every
         entrypoint which does not explicitly need to update the time offset.
@@ -65,10 +65,16 @@ module Time : sig
        and type Packed.value = t
        and type Packed.var = private Tick.Field.Var.t
 
+  val to_input : t -> Tick.Field.t Random_oracle_input.t
+
   module Checked : sig
     open Snark_params.Tick
 
-    type t = Unpacked.var
+    type t
+
+    val typ : (t, Stable.Latest.t) Typ.t
+
+    val to_input : t -> Field.Var.t Random_oracle_input.t
 
     val ( = ) : t -> t -> (Boolean.var, _) Checked.t
 
@@ -79,6 +85,12 @@ module Time : sig
     val ( <= ) : t -> t -> (Boolean.var, _) Checked.t
 
     val ( >= ) : t -> t -> (Boolean.var, _) Checked.t
+
+    val to_field : t -> Field.Var.t
+
+    module Unsafe : sig
+      val of_field : Field.Var.t -> t
+    end
   end
 
   module Span : sig
@@ -102,7 +114,7 @@ module Time : sig
         with type Unpacked.value = t
          and type Packed.value = t
 
-    val to_time_ns_span : t -> Core.Time_ns.Span.t
+    val to_time_ns_span : t -> Core_kernel.Time_ns.Span.t
 
     val to_string_hum : t -> string
 
@@ -129,6 +141,24 @@ module Time : sig
     val min : t -> t -> t
 
     val zero : t
+
+    val to_input : t -> Tick.Field.t Random_oracle_input.t
+
+    module rec Checked : sig
+      type t
+
+      val typ : (Checked.t, Stable.V1.t) Snark_params.Tick.Typ.t
+
+      open Snark_params.Tick
+
+      val to_input : t -> Tick.Field.Var.t Random_oracle_input.t
+
+      val to_field : t -> Field.Var.t
+
+      module Unsafe : sig
+        val of_field : Field.Var.t -> t
+      end
+    end
   end
 
   val field_var_to_unpacked :
@@ -160,6 +190,8 @@ module Time : sig
   val to_int64 : t -> Int64.t
 
   val of_int64 : Int64.t -> t
+
+  val of_uint64 : Unsigned.UInt64.t -> t
 
   val to_string : t -> string
 

--- a/src/lib/block_time/dune
+++ b/src/lib/block_time/dune
@@ -4,7 +4,7 @@
  (library_flags -linkall)
  (inline_tests)
  (preprocessor_deps ../../config.mlh)
- (libraries core mina_numbers logger snark_params snark_bits unsigned_extended timeout_lib)
+ (libraries logger_type core_kernel mina_numbers snark_params snark_bits unsigned_extended timeout_lib)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_hash ppx_let
                   ppx_coda ppx_version ppx_deriving_yojson ppx_bin_prot ppx_compare ppx_sexp_conv ppx_compare ppx_optcomp

--- a/src/lib/consensus/constants.ml
+++ b/src/lib/consensus/constants.ml
@@ -45,10 +45,7 @@ module Stable = struct
 end]
 
 type var =
-  ( Length.Checked.t
-  , Block_time.Unpacked.var
-  , Block_time.Span.Unpacked.var )
-  Poly.t
+  (Length.Checked.t, Block_time.Checked.t, Block_time.Span.Checked.t) Poly.t
 
 module type M_intf = sig
   type t
@@ -130,53 +127,55 @@ module Constants_UInt32 :
   let min = UInt32.min
 end
 
+module N =
+  Mina_numbers.Nat.Make_checked
+    (Unsigned_extended.UInt64)
+    (Snark_bits.Bits.UInt64)
+
 module Constants_checked :
   M_intf
     with type length = Length.Checked.t
-     and type time = Block_time.Unpacked.var
-     and type timespan = Block_time.Span.Unpacked.var = struct
-  open Snarky_integer
-
-  type t = field Integer.t
+     and type time = Block_time.Checked.t
+     and type timespan = Block_time.Span.Checked.t = struct
+  type t = N.var
 
   type length = Length.Checked.t
 
-  type time = Block_time.Unpacked.var
+  type time = Block_time.Checked.t
 
-  type timespan = Block_time.Span.Unpacked.var
+  type timespan = Block_time.Span.Checked.t
 
   type bool_type = Boolean.var
 
-  let constant c = Integer.constant ~m (Bignum_bigint.of_int c)
+  let constant c = N.Unsafe.of_field (Field.Var.constant (Field.of_int c))
 
   let zero = constant 0
 
   let one = constant 1
 
-  let of_length = Length.Checked.to_integer
+  let of_length = Fn.compose N.Unsafe.of_field Length.Checked.to_field
 
-  let to_length = Length.Checked.Unsafe.of_integer
+  let to_length = Fn.compose Length.Checked.Unsafe.of_field N.to_field
 
-  let of_time = Fn.compose (Integer.of_bits ~m) Block_time.Unpacked.var_to_bits
+  let of_time : Block_time.Checked.t -> t =
+    Fn.compose N.Unsafe.of_field Block_time.Checked.to_field
 
-  let to_time =
-    Fn.compose Block_time.Unpacked.var_of_bits
-      (Integer.to_bits ~m ~length:Block_time.Unpacked.size_in_bits)
+  let to_time : t -> Block_time.Checked.t =
+    Fn.compose Block_time.Checked.Unsafe.of_field N.to_field
 
-  let of_timespan =
-    Fn.compose (Integer.of_bits ~m) Block_time.Span.Unpacked.var_to_bits
+  let of_timespan : timespan -> t =
+    Fn.compose N.Unsafe.of_field Block_time.Span.Checked.to_field
 
-  let to_timespan =
-    Fn.compose Block_time.Span.Unpacked.var_of_bits
-      (Integer.to_bits ~length:Block_time.Span.Unpacked.size_in_bits ~m)
+  let to_timespan : t -> timespan =
+    Fn.compose Block_time.Span.Checked.Unsafe.of_field N.to_field
 
-  let ( / ) (t : t) (t' : t) = Integer.div_mod ~m t t' |> fst
+  let ( / ) (t : t) (t' : t) = Run.run_checked (N.div_mod t t') |> fst
 
-  let ( * ) = Integer.mul ~m
+  let ( * ) x y = Run.run_checked (N.mul x y)
 
-  let ( + ) = Integer.add ~m
+  let ( + ) x y = Run.run_checked (N.add x y)
 
-  let min = Integer.min ~m
+  let min x y = Run.run_checked (N.min x y)
 end
 
 let create' (type a b c)
@@ -324,11 +323,11 @@ let data_spec =
     ; Length.Checked.typ
     ; Length.Checked.typ
     ; Length.Checked.typ
-    ; Block_time.Span.Unpacked.typ
-    ; Block_time.Span.Unpacked.typ
-    ; Block_time.Span.Unpacked.typ
-    ; Block_time.Span.Unpacked.typ
-    ; Block_time.Unpacked.typ
+    ; Block_time.Span.Checked.typ
+    ; Block_time.Span.Checked.typ
+    ; Block_time.Span.Checked.typ
+    ; Block_time.Span.Checked.typ
+    ; Block_time.Checked.typ
     ]
 
 let typ =
@@ -432,26 +431,26 @@ module Checked = struct
             ~constraint_constants ~protocol_constants)
     in
     let%map checkpoint_window_slots_per_year, checkpoint_window_size_in_slots =
-      let constant c = Integer.constant ~m (Bignum_bigint.of_int c) in
+      let constant c =
+        N.Unsafe.of_field (Field.Var.constant (Field.of_int c))
+      in
       let per_year = constant 12 in
       let slot_duration_ms =
-        Integer.of_bits ~m
-          (Block_time.Span.Unpacked.var_to_bits constants.slot_duration_ms)
+        N.Unsafe.of_field
+          (Block_time.Span.Checked.to_field constants.slot_duration_ms)
       in
-      let slots_per_year =
+      let%bind slots_per_year, _ =
         let one_year_ms =
           constant (Core.Time.Span.(to_ms (of_day 365.)) |> Float.to_int)
         in
-        fst (Integer.div_mod ~m one_year_ms slot_duration_ms)
+        N.div_mod one_year_ms slot_duration_ms
       in
       let%map size_in_slots =
-        let size_in_slots, rem = Integer.div_mod ~m slots_per_year per_year in
-        let%map () =
-          Boolean.Assert.is_true (Integer.equal ~m rem (constant 0))
-        in
+        let%bind size_in_slots, rem = N.div_mod slots_per_year per_year in
+        let%map () = N.Assert.equal rem (constant 0) in
         size_in_slots
       in
-      let to_length = Length.Checked.Unsafe.of_integer in
+      let to_length = Fn.compose Length.Checked.Unsafe.of_field N.to_field in
       (to_length slots_per_year, to_length size_in_slots)
     in
     { constants with

--- a/src/lib/consensus/global_slot.mli
+++ b/src/lib/consensus/global_slot.mli
@@ -23,7 +23,7 @@ module Stable : sig
   end
 end]
 
-val to_input : t -> (_, bool) Random_oracle.Input.t
+val to_input : t -> Snark_params.Tick.Field.t Random_oracle.Input.t
 
 val of_slot_number : constants:Constants.t -> Mina_numbers.Global_slot.t -> t
 
@@ -45,8 +45,6 @@ val of_epoch_and_slot : constants:Constants.t -> Epoch.t * Slot.t -> t
 
 val zero : constants:Constants.t -> t
 
-val to_bits : t -> bool list
-
 val epoch : t -> Epoch.t
 
 val slot : t -> Slot.t
@@ -66,7 +64,6 @@ val diff : constants:Constants.t -> t -> Epoch.t * Slot.t -> t
 [%%ifdef consensus_mechanism]
 
 open Snark_params.Tick
-open Bitstring_lib
 
 module Checked : sig
   open Snark_params.Tick
@@ -79,13 +76,7 @@ module Checked : sig
   val of_slot_number :
     constants:Constants.var -> Mina_numbers.Global_slot.Checked.t -> t
 
-  val to_bits : t -> (Boolean.var Bitstring.Lsb_first.t, _) Checked.t
-
-  val to_input :
-       t
-    -> ( (Field.Var.t, Snark_params.Tick.Boolean.var) Random_oracle.Input.t
-       , _ )
-       Checked.t
+  val to_input : t -> Field.Var.t Random_oracle.Input.t
 
   val to_epoch_and_slot : t -> (Epoch.Checked.t * Slot.Checked.t, _) Checked.t
 

--- a/src/lib/consensus/global_sub_window.ml
+++ b/src/lib/consensus/global_sub_window.ml
@@ -22,40 +22,38 @@ let sub a b = UInt32.sub a b
 let constant a = a
 
 module Checked = struct
-  open Snarky_integer
+  module T = Mina_numbers.Global_slot
 
-  type t = field Integer.t
+  type t = T.Checked.t
+
+  let of_length (x : Mina_numbers.Length.Checked.t) : t =
+    T.Checked.Unsafe.of_field (Mina_numbers.Length.Checked.to_field x)
 
   let of_global_slot ~(constants : Constants.var) (s : Global_slot.Checked.t) :
       (t, _) Checked.t =
-    make_checked (fun () ->
-        let q, _ =
-          Integer.div_mod ~m
-            (Mina_numbers.Global_slot.Checked.to_integer
-               (Global_slot.slot_number s))
-            (Mina_numbers.Length.Checked.to_integer
-               constants.slots_per_sub_window)
-        in
-        q)
+    let%map q, _ =
+      T.Checked.div_mod
+        (Global_slot.slot_number s)
+        (of_length constants.slots_per_sub_window)
+    in
+    q
 
   let sub_window ~(constants : Constants.var) (t : t) :
       (Sub_window.Checked.t, _) Checked.t =
-    make_checked (fun () ->
-        let _, shift =
-          Integer.div_mod ~m t
-            (Mina_numbers.Length.Checked.to_integer
-               constants.sub_windows_per_window)
-        in
-        Sub_window.Checked.Unsafe.of_integer shift)
+    let%map _, shift =
+      T.Checked.div_mod t (of_length constants.sub_windows_per_window)
+    in
+    Sub_window.Checked.Unsafe.of_field (T.Checked.to_field shift)
 
-  let succ (t : t) : t = Integer.succ ~m t
+  let succ (t : t) : (t, _) Checked.t = T.Checked.succ t
 
-  let equal a b = make_checked (fun () -> Integer.equal ~m a b)
+  let equal = T.Checked.equal
 
   let constant a =
-    Integer.constant ~m @@ Bignum_bigint.of_int @@ UInt32.to_int a
+    T.Checked.Unsafe.of_field @@ Field.Var.constant @@ Field.of_int
+    @@ UInt32.to_int a
 
-  let add a b = Integer.add ~m a (Mina_numbers.Length.Checked.to_integer b)
+  let add a (b : Mina_numbers.Length.Checked.t) = T.Checked.add a (of_length b)
 
-  let ( >= ) a b = make_checked (fun () -> Integer.gte ~m a b)
+  let ( >= ) a b = T.Checked.( >= ) a b
 end

--- a/src/lib/consensus/global_sub_window.mli
+++ b/src/lib/consensus/global_sub_window.mli
@@ -19,13 +19,13 @@ module Checked : sig
 
   type t
 
-  val succ : t -> t
+  val succ : t -> (t, _) Checked.t
 
   val equal : t -> t -> (Boolean.var, _) Checked.t
 
   val constant : Unsigned.UInt32.t -> t
 
-  val add : t -> Mina_numbers.Length.Checked.t -> t
+  val add : t -> Mina_numbers.Length.Checked.t -> (t, _) Checked.t
 
   val ( >= ) : t -> t -> (Boolean.var, _) Checked.t
 

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -51,7 +51,7 @@ module type Blockchain_state = sig
     , Frozen_ledger_hash.var
     , Token_id.var
     , Parties_logic.Local_state.Checked.t
-    , Block_time.Unpacked.var )
+    , Block_time.Checked.t )
     Poly.t
 
   val staged_ledger_hash :

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1936,27 +1936,28 @@ module Data = struct
     let same_checkpoint_window ~(constants : Constants.var)
         ~prev:(slot1 : Global_slot.Checked.t)
         ~next:(slot2 : Global_slot.Checked.t) =
-      let open Snarky_integer in
-      let open Run in
       let module Slot = Mina_numbers.Global_slot in
-      let slot1 = Slot.Checked.to_integer (Global_slot.slot_number slot1) in
+      let slot1 : Slot.Checked.t = Global_slot.slot_number slot1 in
       let checkpoint_window_size_in_slots =
-        Length.Checked.to_integer constants.checkpoint_window_size_in_slots
+        constants.checkpoint_window_size_in_slots
       in
-      let _q1, r1 = Integer.div_mod ~m slot1 checkpoint_window_size_in_slots in
+      let%bind _q1, r1 =
+        Slot.Checked.div_mod slot1
+          (Slot.Checked.Unsafe.of_field
+             (Length.Checked.to_field checkpoint_window_size_in_slots))
+      in
       let next_window_start =
-        Field.(
-          Integer.to_field slot1 - Integer.to_field r1
-          + Integer.to_field checkpoint_window_size_in_slots)
+        Run.Field.(
+          Slot.Checked.to_field slot1
+          - Slot.Checked.to_field r1
+          + Length.Checked.to_field checkpoint_window_size_in_slots)
       in
-      (Field.compare ~bit_length:Slot.length_in_bits
-         ( Global_slot.slot_number slot2
-         |> Slot.Checked.to_integer |> Integer.to_field )
-         next_window_start)
-        .less
+      Slot.Checked.( < )
+        (Global_slot.slot_number slot2)
+        (Slot.Checked.Unsafe.of_field next_window_start)
 
     let same_checkpoint_window ~constants ~prev ~next =
-      make_checked (fun () -> same_checkpoint_window ~constants ~prev ~next)
+      same_checkpoint_window ~constants ~prev ~next
 
     let negative_one ~genesis_ledger
         ~(genesis_epoch_data : Genesis_epoch_data.t) ~(constants : Constants.t)

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1267,8 +1267,10 @@ module Data = struct
         in
         let%bind overlapping_window =
           Global_sub_window.Checked.(
-            add prev_global_sub_window constants.sub_windows_per_window
-            >= next_global_sub_window)
+            let%bind x =
+              add prev_global_sub_window constants.sub_windows_per_window
+            in
+            x >= next_global_sub_window)
         in
         let if_ cond ~then_ ~else_ =
           let%bind cond = cond and then_ = then_ and else_ = else_ in
@@ -1312,8 +1314,8 @@ module Data = struct
           let%bind in_grace_period =
             Global_slot.Checked.( < ) next_global_slot
               (Global_slot.Checked.of_slot_number ~constants
-                 (Mina_numbers.Global_slot.Checked.Unsafe.of_integer
-                    (Length.Checked.to_integer constants.grace_period_end)))
+                 (Mina_numbers.Global_slot.Checked.Unsafe.of_field
+                    (Length.Checked.to_field constants.grace_period_end)))
           in
           if_
             Boolean.(same_sub_window || in_grace_period)

--- a/src/lib/consensus/slot.ml
+++ b/src/lib/consensus/slot.ml
@@ -17,25 +17,22 @@ module Checked = struct
 
   let in_seed_update_range ~(constants : Constants.var) (slot : var) =
     let open Tick in
-    let open Snarky_integer in
     let module Length = Mina_numbers.Length in
-    let integer_mul i i' = make_checked (fun () -> Integer.mul ~m i i') in
-    let to_integer = Length.Checked.to_integer in
-    let%bind third_epoch =
-      make_checked (fun () ->
-          let q, r =
-            Integer.div_mod ~m
-              (to_integer constants.slots_per_epoch)
-              (Integer.constant ~m (Bignum_bigint.of_int 3))
-          in
-          Tick.Run.Boolean.Assert.is_true
-            (Integer.equal ~m r (Integer.constant ~m Bignum_bigint.zero)) ;
-          q)
+    let constant c =
+      Length.Checked.Unsafe.of_field (Field.Var.constant (Field.of_int c))
     in
-    let two = Integer.constant ~m (Bignum_bigint.of_int 2) in
-    let%bind ck_times_2 = integer_mul third_epoch two in
-    make_checked (fun () ->
-        Integer.lt ~m (T.Checked.to_integer slot) ck_times_2)
+    let%bind third_epoch =
+      let%bind q, r =
+        Length.Checked.div_mod constants.slots_per_epoch (constant 3)
+      in
+      let%map () = Length.Checked.Assert.equal r (constant 0) in
+      q
+    in
+    let two = constant 2 in
+    let%bind ck_times_2 = Length.Checked.mul third_epoch two in
+    Length.Checked.( < )
+      (Length.Checked.Unsafe.of_field (T.Checked.to_field slot))
+      ck_times_2
 end
 
 let gen (constants : Constants.t) =

--- a/src/lib/mina_numbers/intf.ml
+++ b/src/lib/mina_numbers/intf.ml
@@ -62,7 +62,9 @@ module type S_unchecked = sig
 
   val of_bits : bool list -> t
 
-  val to_input : t -> (_, bool) Random_oracle.Input.t
+  val to_input : t -> Snark_params.Tick.Field.t Random_oracle.Input.t
+
+  val to_input_legacy : t -> (_, bool) Random_oracle.Input.Legacy.t
 
   val fold : t -> bool Triple.t Fold.t
 end
@@ -73,7 +75,6 @@ module type S_checked = sig
   type unchecked
 
   open Snark_params.Tick
-  open Bitstring_lib
 
   type var
 
@@ -86,6 +87,8 @@ module type S_checked = sig
   val succ : t -> (t, _) Checked.t
 
   val add : t -> t -> (t, _) Checked.t
+
+  val mul : t -> t -> (t, _) Checked.t
 
   (** [sub_or_zero x y] computes [x - y].
 
@@ -103,13 +106,10 @@ module type S_checked = sig
 
   val min : t -> t -> (t, _) Checked.t
 
-  val of_bits : Boolean.var Bitstring.Lsb_first.t -> t
+  val to_input : t -> Field.Var.t Random_oracle.Input.t
 
-  val to_bits : t -> (Boolean.var Bitstring.Lsb_first.t, _) Checked.t
-
-  val to_input : t -> ((_, Boolean.var) Random_oracle.Input.t, _) Checked.t
-
-  val to_integer : t -> field Snarky_integer.Integer.t
+  val to_input_legacy :
+    t -> ((_, Boolean.var) Random_oracle.Legacy.Input.t, _) Checked.t
 
   val succ_if : t -> Boolean.var -> (t, _) Checked.t
 
@@ -119,6 +119,8 @@ module type S_checked = sig
   val typ : (t, unchecked) Snark_params.Tick.Typ.t
 
   val equal : t -> t -> (Boolean.var, _) Checked.t
+
+  val div_mod : t -> t -> (t * t, _) Checked.t
 
   val ( = ) : t -> t -> (Boolean.var, _) Checked.t
 
@@ -130,8 +132,14 @@ module type S_checked = sig
 
   val ( >= ) : t -> t -> (Boolean.var, _) Checked.t
 
+  module Assert : sig
+    val equal : t -> t -> (unit, _) Checked.t
+  end
+
+  val to_field : t -> Field.Var.t
+
   module Unsafe : sig
-    val of_integer : field Snarky_integer.Integer.t -> t
+    val of_field : Field.Var.t -> t
   end
 end
 
@@ -142,15 +150,10 @@ module type S = sig
 
   [%%ifdef consensus_mechanism]
 
-  open Snark_params.Tick
-  open Bitstring_lib
-
   module Checked : S_checked with type unchecked := t
 
   (** warning: this typ does not work correctly with the generic if_ *)
   val typ : (Checked.t, t) Snark_params.Tick.Typ.t
-
-  val var_to_bits : Checked.t -> Boolean.var Bitstring.Lsb_first.t
 
   [%%endif]
 end

--- a/src/lib/mina_numbers/nat.ml
+++ b/src/lib/mina_numbers/nat.ml
@@ -9,108 +9,176 @@ module Intf = Intf
 
 open Snark_bits
 
-let zero_checked =
-  Snarky_integer.Integer.constant ~m:Snark_params.Tick.m Bigint.zero
-
 module Make_checked
     (N : Unsigned_extended.S)
     (Bits : Bits_intf.Convertible_bits with type t := N.t) =
 struct
-  open Bitstring_lib
   open Snark_params.Tick
-  open Snarky_integer
 
-  type var = field Integer.t
+  type var = Field.Var.t
 
   let () = assert (Int.(N.length_in_bits < Field.size_in_bits))
 
-  let to_field = Integer.to_field
+  let to_input (t : var) = Random_oracle.Input.packed (t, N.length_in_bits)
 
-  let of_bits bs = Integer.of_bits ~m bs
-
-  let to_bits t =
-    with_label
-      (sprintf "to_bits: %s" __LOC__)
-      (make_checked (fun () -> Integer.to_bits ~length:N.length_in_bits ~m t))
-
-  let to_input t =
+  let to_input_legacy (t : var) =
+    let to_bits (t : var) =
+      with_label
+        (sprintf "to_bits: %s" __LOC__)
+        (Field.Checked.choose_preimage_var t ~length:N.length_in_bits)
+    in
     Checked.map (to_bits t) ~f:(fun bits ->
-        Random_oracle.Input.bitstring
-          (Bitstring_lib.Bitstring.Lsb_first.to_list bits))
+        Random_oracle.Input.Legacy.bitstring bits)
 
-  let constant n = Integer.constant ~length:N.length_in_bits ~m (N.to_bigint n)
+  let constant n =
+    Field.Var.constant
+      (Bigint.to_field (Bigint.of_bignum_bigint (N.to_bigint n)))
 
-  (* warning: this typ does not work correctly with the generic if_ *)
-  let typ : (field Integer.t, N.t) Typ.t =
-    let typ = Typ.list ~length:N.length_in_bits Boolean.typ in
-    let of_bits bs = of_bits (Bitstring.Lsb_first.of_list bs) in
-    let alloc = Typ.Alloc.map typ.alloc ~f:of_bits in
-    let store t =
-      Typ.Store.map (typ.store (Fold.to_list (Bits.fold t))) ~f:of_bits
+  let () = assert (Int.(N.length_in_bits mod 16 = 0))
+
+  let range_check' (t : var) =
+    let _, _, actual_packed =
+      Pickles.Scalar_challenge.to_field_checked' ~num_bits:N.length_in_bits m
+        (Pickles_types.Scalar_challenge.create t)
     in
-    let check v =
-      typ.check (Bitstring.Lsb_first.to_list (Integer.to_bits_exn v))
+    actual_packed
+
+  let range_check t =
+    let%bind actual = make_checked (fun () -> range_check' t) in
+    Field.Checked.Assert.equal actual t
+
+  let range_check_flag t =
+    let open Pickles.Impls.Step in
+    let actual = range_check' t in
+    Field.equal actual t
+
+  let of_field (x : Field.t) : N.t =
+    let of_bits bs =
+      (* TODO: Make this efficient *)
+      List.foldi bs ~init:N.zero ~f:(fun i acc b ->
+          if b then N.(logor (shift_left one i) acc) else acc)
     in
-    let read v =
-      let of_field_elt x =
-        let bs = List.take (Field.unpack x) N.length_in_bits in
-        (* TODO: Make this efficient *)
-        List.foldi bs ~init:N.zero ~f:(fun i acc b ->
-            if b then N.(logor (shift_left one i) acc) else acc)
-      in
-      Typ.Read.map (Field.typ.read (Integer.to_field v)) ~f:of_field_elt
+    of_bits (List.take (Field.unpack x) N.length_in_bits)
+
+  let to_field (x : N.t) : Field.t = Field.project (Fold.to_list (Bits.fold x))
+
+  let typ : (var, N.t) Typ.t =
+    Typ.transport
+      { Field.typ with check = range_check }
+      ~there:to_field ~back:of_field
+
+  let () = assert (N.length_in_bits * 2 < Field.size_in_bits + 1)
+
+  let div_mod (x : var) (y : var) =
+    let%bind q, r =
+      exists (Typ.tuple2 typ typ)
+        ~compute:
+          As_prover.(
+            let%map x = read typ x and y = read typ y in
+            (N.div x y, N.rem x y))
     in
-    { alloc; store; check; read }
+
+    (* q * y + r = x
+
+       q * y = x - r
+    *)
+    let%map () = assert_r1cs q y (Field.Var.sub x r) in
+    (q, r)
 
   type t = var
 
   let is_succ ~pred ~succ =
     let open Snark_params.Tick in
     let open Field in
-    Checked.(equal (to_field pred + Var.constant one) (to_field succ))
+    Checked.(equal (pred + Var.constant one) succ)
 
-  let min a b = make_checked (fun () -> Integer.min ~m a b)
+  let gte x y =
+    let open Pickles.Impls.Step in
+    let xy = Pickles.Util.seal m Field.(x - y) in
+    let yx = Pickles.Util.seal m (Field.negate xy) in
+    let x_gte_y = range_check_flag xy in
+    let y_gte_x = range_check_flag yx in
+    Boolean.Assert.any [ x_gte_y; y_gte_x ] ;
+    x_gte_y
 
-  let if_ c ~then_ ~else_ =
-    make_checked (fun () -> Integer.if_ ~m c ~then_ ~else_)
+  let op op a b = make_checked (fun () -> op a b)
 
-  let succ_if t c =
+  let ( >= ) a b = op gte a b
+
+  let ( <= ) a b = b >= a
+
+  let ( < ) a b =
     make_checked (fun () ->
-        let t = Integer.succ_if ~m t c in
-        t)
+        let open Pickles.Impls.Step in
+        Boolean.( &&& ) (gte b a) (Boolean.not (Field.equal b a)))
 
-  let succ t =
-    make_checked (fun () ->
-        let t = Integer.succ ~m t in
-        t)
+  let ( > ) a b = b < a
 
-  let op op a b = make_checked (fun () -> op ~m a b)
+  module Assert = struct
+    let equal = Field.Checked.Assert.equal
+  end
 
-  let add a b = op Integer.add a b
+  let to_field = Fn.id
 
-  let sub_or_zero a b = op Integer.subtract_unpacking_or_zero a b
+  module Unsafe = struct
+    let of_field = Fn.id
+  end
 
-  let sub a b = op Integer.subtract_unpacking a b
+  let min a b =
+    let%bind a_lte_b = a <= b in
+    Field.Checked.if_ a_lte_b ~then_:a ~else_:b
 
-  let equal a b = op Integer.equal a b
+  let if_ = Field.Checked.if_
 
-  let ( < ) a b = op Integer.lt a b
+  let succ_if (t : var) (c : Boolean.var) =
+    Checked.return (Field.Var.add t (c :> Field.Var.t))
 
-  let ( <= ) a b = op Integer.lte a b
+  let succ (t : var) =
+    Checked.return (Field.Var.add t (Field.Var.constant Field.one))
 
-  let ( > ) a b = op Integer.gt a b
+  let seal x = make_checked (fun () -> Pickles.Util.seal m x)
 
-  let ( >= ) a b = op Integer.gte a b
+  let add (x : var) (y : var) =
+    let%bind res = seal (Field.Var.add x y) in
+    let%map () = range_check res in
+    res
+
+  let mul (x : var) (y : var) =
+    let%bind res = Field.Checked.mul x y in
+    let%map () = range_check res in
+    res
+
+  let subtract_unpacking_or_zero x y =
+    let open Pickles.Impls.Step in
+    let res = Pickles.Util.seal m Field.(x - y) in
+    let neg_res = Pickles.Util.seal m (Field.negate res) in
+    let x_gte_y = range_check_flag res in
+    let y_gte_x = range_check_flag neg_res in
+    Boolean.Assert.any [ x_gte_y; y_gte_x ] ;
+    (* If y_gte_x is false, then x_gte_y is true, so x >= y and
+       thus there was no underflow.
+
+       If y_gte_x is true, then y >= x, which means there was underflow
+       iff y != x.
+
+       Thus, underflow = (neg_res_good && y != x)
+    *)
+    let underflow = Boolean.( &&& ) y_gte_x (Boolean.not (Field.equal x y)) in
+    (`Underflow underflow, Field.if_ underflow ~then_:Field.zero ~else_:res)
+
+  let sub_or_zero a b = make_checked (fun () -> subtract_unpacking_or_zero a b)
+
+  (* Unpacking protects against underflow *)
+  let sub (x : var) (y : var) =
+    let%bind res = seal (Field.Var.sub x y) in
+    let%map () = range_check res in
+    res
+
+  let equal a b = Field.Checked.equal a b
 
   let ( = ) = equal
 
-  let to_integer = Fn.id
-
-  module Unsafe = struct
-    let of_integer = Fn.id
-  end
-
-  let zero = zero_checked
+  let zero = Field.Var.constant Field.zero
 end
 
 [%%else]
@@ -148,10 +216,6 @@ struct
   (* warning: this typ does not work correctly with the generic if_ *)
   let typ = Checked.typ
 
-  let var_to_bits var =
-    Snarky_integer.Integer.to_bits ~length:N.length_in_bits
-      ~m:Snark_params.Tick.m var
-
   [%%endif]
 
   module Bits = Bits
@@ -160,7 +224,11 @@ struct
 
   let of_bits = Bits.of_bits
 
-  let to_input t = Random_oracle.Input.bitstring (to_bits t)
+  let to_input (t : t) =
+    Random_oracle.Input.packed
+      (Snark_params.Tick.Field.project (to_bits t), N.length_in_bits)
+
+  let to_input_legacy t = Random_oracle.Input.Legacy.bitstring (to_bits t)
 
   let fold t = Fold.group3 ~default:false (Bits.fold t)
 


### PR DESCRIPTION
This PR eliminates the bit unpacking implementation of mina_numbers, replacing it with an implementation based on the efficient range-check, which allows for checking a values fits in 16k bits with only k constraints.