### PR TITLE
snapps: merkle root mismatch fix

### DIFF
--- a/src/lib/mina_base/parties.ml
+++ b/src/lib/mina_base/parties.ml
@@ -300,7 +300,7 @@ let fee_excess (t : t) =
 let accounts_accessed (t : t) =
   List.map (parties t) ~f:(fun p ->
       Account_id.create p.data.body.pk p.data.body.token_id)
-  |> List.dedup_and_sort ~compare:Account_id.compare
+  |> List.stable_dedup
 
 let fee_payer_pk (t : t) = t.fee_payer.data.body.pk
 

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4718,13 +4718,13 @@ let%test_module "transaction_snark" =
                     { pk = acct1.account.public_key
                     ; update = Party.Update.noop
                     ; token_id = Token_id.default
-                    ; delta =
+                    ; balance_change =
                         Amount.Signed.(of_unsigned receiver_amount |> negate)
                     ; increment_nonce = true
                     ; events = []
                     ; sequence_events = []
                     ; call_data = Field.zero
-                    ; depth = 0
+                    ; call_depth = 0
                     }
                 ; predicate = Accept
                 }


### PR DESCRIPTION
The order of accounts when creating sparse ledger was different from the parties application order causing a merkle root mismatch. Fixed by maintaining the order when de-duping

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
