### PR TITLE
Introduce and use Sink abstraction

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1144,12 +1144,14 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
               ; all_peers_seen_metric
               ; known_private_ip_nets =
                   Option.value ~default:[] client_trustlist
+              ; time_controller
               }
           in
           let net_config =
             { Mina_networking.Config.logger
             ; trust_system
             ; time_controller
+            ; consensus_constants = precomputed_values.consensus_constants
             ; consensus_local_state
             ; genesis_ledger_hash
             ; constraint_constants = precomputed_values.constraint_constants

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -433,6 +433,7 @@ module T = struct
               ; keypair = Some libp2p_keypair
               ; all_peers_seen_metric = false
               ; known_private_ip_nets = []
+              ; time_controller
               }
           in
           let net_config =
@@ -444,6 +445,7 @@ module T = struct
             ; genesis_ledger_hash =
                 Ledger.merkle_root (Lazy.force Genesis_ledger.t)
             ; constraint_constants
+            ; consensus_constants = precomputed_values.consensus_constants
             ; log_gossip_heard =
                 { snark_pool_diff = true
                 ; transaction_pool_diff = true

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -147,6 +147,7 @@ let run_test () : unit Deferred.t =
           ; keypair = None
           ; all_peers_seen_metric = false
           ; known_private_ip_nets = []
+          ; time_controller
           }
       in
       let net_config =
@@ -155,6 +156,7 @@ let run_test () : unit Deferred.t =
           ; trust_system
           ; time_controller
           ; consensus_local_state
+          ; consensus_constants = precomputed_values.consensus_constants
           ; is_seed = true
           ; genesis_ledger_hash =
               Ledger.merkle_root (Lazy.force Genesis_ledger.t)

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -16,7 +16,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
   let block_producer_balance = "1000" (* 1_000_000_000_000 *)
 
   let config =
-    let n = 3 in
+    let n = 2 in
     let open Test_config in
     { default with
       requires_graphql = true

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -113,6 +113,7 @@ let setup (type n) ~logger ?(trust_system = Trust_system.null ())
         Ledger.merkle_root
           (Lazy.force (Precomputed_values.genesis_ledger precomputed_values))
     ; constraint_constants = precomputed_values.constraint_constants
+    ; consensus_constants = precomputed_values.consensus_constants
     ; creatable_gossip_net =
         Gossip_net.Any.Creatable
           ( (module Gossip_net.Fake)
@@ -131,6 +132,10 @@ let setup (type n) ~logger ?(trust_system = Trust_system.null ())
               (* TODO: merge implementations with mina_lib *)
               Mina_networking.create
                 (config peer state.consensus_local_state)
+                ~sinks:
+                  ( Transition_handler.Block_sink.void
+                  , Network_pool.Transaction_pool.Remote_sink.void
+                  , Network_pool.Snark_pool.Remote_sink.void )
                 ~get_staged_ledger_aux_and_pending_coinbases_at_hash:
                   state.get_staged_ledger_aux_and_pending_coinbases_at_hash
                 ~get_some_initial_peers:state.get_some_initial_peers

--- a/src/lib/gossip_net/any.ml
+++ b/src/lib/gossip_net/any.ml
@@ -12,7 +12,7 @@ module type S = sig
 
   include Intf.Gossip_net_intf with module Rpc_intf := Rpc_intf and type t := t
 
-  type 't creator = Rpc_intf.rpc_handler list -> 't Deferred.t
+  type 't creator = Rpc_intf.rpc_handler list -> Message.sinks -> 't Deferred.t
 
   type creatable = Creatable : 't implementation * 't creator -> creatable
 
@@ -30,12 +30,12 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
 
   type t = Any : 't implementation * 't -> t
 
-  type 't creator = rpc_handler list -> 't Deferred.t
+  type 't creator = rpc_handler list -> Message.sinks -> 't Deferred.t
 
   type creatable = Creatable : 't implementation * 't creator -> creatable
 
-  let create (Creatable ((module M), creator)) impls =
-    let%map gossip_net = creator impls in
+  let create (Creatable ((module M), creator)) impls sinks =
+    let%map gossip_net = creator impls sinks in
     Any ((module M), gossip_net)
 
   let peers (Any ((module M), t)) = M.peers t
@@ -62,15 +62,18 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
 
   let query_random_peers (Any ((module M), t)) = M.query_random_peers t
 
-  let broadcast (Any ((module M), t)) = M.broadcast t
+  let broadcast_state (Any ((module M), t)) = M.broadcast_state t
+
+  let broadcast_transaction_pool_diff (Any ((module M), t)) =
+    M.broadcast_transaction_pool_diff t
+
+  let broadcast_snark_pool_diff (Any ((module M), t)) =
+    M.broadcast_snark_pool_diff t
 
   let on_first_connect (Any ((module M), t)) = M.on_first_connect t
 
   let on_first_high_connectivity (Any ((module M), t)) =
     M.on_first_high_connectivity t
-
-  let received_message_reader (Any ((module M), t)) =
-    M.received_message_reader t
 
   let ban_notification_reader (Any ((module M), t)) =
     M.ban_notification_reader t

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -14,7 +14,11 @@ module type S = sig
   val create_network : Peer.t list -> network
 
   val create_instance :
-    network -> Peer.t -> Rpc_intf.rpc_handler list -> t Deferred.t
+       network
+    -> Peer.t
+    -> Rpc_intf.rpc_handler list
+    -> Message.sinks
+    -> t Deferred.t
 end
 
 module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
@@ -29,14 +33,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
           -> 'r Mina_base.Rpc_intf.rpc_response Deferred.t
       }
 
-    type network_interface =
-      { broadcast_message_writer :
-          ( Message.msg Envelope.Incoming.t * Mina_net2.Validation_callback.t
-          , Strict_pipe.crash Strict_pipe.buffered
-          , unit )
-          Strict_pipe.Writer.t
-      ; rpc_hook : rpc_hook
-      }
+    type network_interface = { sinks : Message.sinks; rpc_hook : rpc_hook }
 
     type node = { peer : Peer.t; mutable interface : network_interface option }
 
@@ -75,19 +72,27 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
           Or_error.error_string
             "cannot call rpc on peer which was never registered"
 
-    let broadcast t ~sender msg =
-      Hashtbl.iter t.nodes ~f:(fun nodes ->
-          List.iter nodes ~f:(fun node ->
-              if not (Peer.equal node.peer sender) then
-                Or_error.iter (get_interface node) ~f:(fun intf ->
+    let broadcast t ~sender msg send_f =
+      Hashtbl.fold t.nodes ~init:Deferred.unit
+        ~f:(fun ~key:_ ~data:nodes prev ->
+          prev
+          >>= fun () ->
+          Deferred.List.iter ~how:`Sequential nodes ~f:(fun node ->
+              if Peer.equal node.peer sender then Deferred.unit
+              else
+                Option.fold node.interface
+                  ~f:(fun a intf ->
+                    a
+                    >>= fun () ->
                     let msg =
                       Envelope.(
                         Incoming.wrap ~data:msg ~sender:(Sender.Remote sender))
                     in
-                    Strict_pipe.Writer.write intf.broadcast_message_writer
+                    send_f intf.sinks
                       ( msg
                       , Mina_net2.Validation_callback.create_without_expiration
-                          () ))))
+                          () ))
+                  ~init:Deferred.unit))
 
     let call_rpc :
         type q r.
@@ -120,16 +125,9 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
       ; peer_table : (Peer.Id.t, Peer.t) Hashtbl.t
       ; initial_peers : Peer.t list
       ; connection_gating : Mina_net2.connection_gating ref
-      ; received_message_reader :
-          (Message.msg Envelope.Incoming.t * Mina_net2.Validation_callback.t)
-          Strict_pipe.Reader.t
-      ; received_message_writer :
-          ( Message.msg Envelope.Incoming.t * Mina_net2.Validation_callback.t
-          , Strict_pipe.crash Strict_pipe.buffered
-          , unit )
-          Strict_pipe.Writer.t
       ; ban_notification_reader : ban_notification Linear_pipe.Reader.t
       ; ban_notification_writer : ban_notification Linear_pipe.Writer.t
+      ; time_controller : Block_time.Controller.t
       }
 
     let rpc_hook t rpc_handlers =
@@ -164,16 +162,17 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
       in
       Network.{ hook }
 
-    let create network me rpc_handlers =
+    let create network me rpc_handlers sinks =
       let initial_peers = Network.get_initial_peers network me.Peer.host in
       let peer_table = Hashtbl.create (module Peer.Id) in
       List.iter initial_peers ~f:(fun peer ->
           Hashtbl.add_exn peer_table ~key:peer.peer_id ~data:peer) ;
-      let received_message_reader, received_message_writer =
-        Strict_pipe.(create (Buffered (`Capacity 5, `Overflow Crash)))
-      in
       let ban_notification_reader, ban_notification_writer =
         Linear_pipe.create ()
+      in
+      let time_controller =
+        Block_time.Controller.create
+        @@ Block_time.Controller.basic ~logger:(Logger.create ())
       in
       let t =
         { network
@@ -185,17 +184,14 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
             ref
               Mina_net2.
                 { banned_peers = []; trusted_peers = []; isolate = false }
-        ; received_message_reader
-        ; received_message_writer
         ; ban_notification_reader
         ; ban_notification_writer
+        ; time_controller
         }
       in
       Network.(
         attach_interface network me
-          { broadcast_message_writer = received_message_writer
-          ; rpc_hook = rpc_hook t rpc_handlers
-          }) ;
+          { sinks; rpc_hook = rpc_hook t rpc_handlers }) ;
       t
 
     let peers { peer_table; _ } = Hashtbl.data peer_table |> Deferred.return
@@ -232,9 +228,6 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
 
     let on_first_high_connectivity _ ~f:_ = Deferred.never ()
 
-    let received_message_reader { received_message_reader; _ } =
-      received_message_reader
-
     let ban_notification_reader { ban_notification_reader; _ } =
       ban_notification_reader
 
@@ -265,7 +258,25 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
 
     let query_random_peers _ = failwith "TODO stub"
 
-    let broadcast t msg = Network.broadcast t.network ~sender:t.me msg
+    let broadcast_state t state =
+      Network.broadcast t.network ~sender:t.me state
+        (fun (Any_sinks (sinksM, (sink_block, _, _))) (env, vc) ->
+          let time = Block_time.now t.time_controller in
+          let module M = (val sinksM) in
+          M.Block_sink.push sink_block
+            (`Transition env, `Time_received time, `Valid_cb vc))
+
+    let broadcast_snark_pool_diff t diff =
+      Network.broadcast t.network ~sender:t.me diff
+        (fun (Any_sinks (sinksM, (_, _, sink_snark_work))) ->
+          let module M = (val sinksM) in
+          M.Snark_sink.push sink_snark_work)
+
+    let broadcast_transaction_pool_diff t diff =
+      Network.broadcast t.network ~sender:t.me diff
+        (fun (Any_sinks (sinksM, (_, sink_tx, _))) ->
+          let module M = (val sinksM) in
+          M.Tx_sink.push sink_tx)
 
     let connection_gating t = Deferred.return !(t.connection_gating)
 
@@ -282,6 +293,6 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
 
   let create_network = Network.create
 
-  let create_instance network local_ip impls =
-    Deferred.return (Instance.create network local_ip impls)
+  let create_instance network local_ip impls sinks =
+    Deferred.return (Instance.create network local_ip impls sinks)
 end

--- a/src/lib/gossip_net/intf.ml
+++ b/src/lib/gossip_net/intf.ml
@@ -67,16 +67,17 @@ module type Gossip_net_intf = sig
     -> 'q
     -> 'r rpc_response Deferred.t List.t Deferred.t
 
-  val broadcast : t -> Message.msg -> unit
+  val broadcast_state : t -> Message.state_msg -> unit Deferred.t
+
+  val broadcast_transaction_pool_diff :
+    t -> Message.transaction_pool_diff_msg -> unit Deferred.t
+
+  val broadcast_snark_pool_diff :
+    t -> Message.snark_pool_diff_msg -> unit Deferred.t
 
   val on_first_connect : t -> f:(unit -> 'a) -> 'a Deferred.t
 
   val on_first_high_connectivity : t -> f:(unit -> 'a) -> 'a Deferred.t
-
-  val received_message_reader :
-       t
-    -> (Message.msg Envelope.Incoming.t * Mina_net2.Validation_callback.t)
-       Strict_pipe.Reader.t
 
   val ban_notification_reader : t -> ban_notification Linear_pipe.Reader.t
 end

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -32,6 +32,7 @@ module Config = struct
     ; mina_peer_exchange : bool
     ; seed_peer_list_url : Uri.t option
     ; min_connections : int
+    ; time_controller : Block_time.Controller.t
     ; max_connections : int
     ; validation_queue_size : int
     ; mutable keypair : Mina_net2.Keypair.t option
@@ -48,6 +49,7 @@ module type S = sig
        Config.t
     -> pids:Child_processes.Termination.t
     -> Rpc_intf.rpc_handler list
+    -> Message.sinks
     -> t Deferred.t
 end
 
@@ -57,6 +59,44 @@ let download_seed_peer_list uri =
   let%bind _resp, body = Cohttp_async.Client.get uri in
   let%map contents = Cohttp_async.Body.to_string body in
   Mina_net2.Multiaddr.of_file_contents contents
+
+type publish_functions = { publish_v0 : Message.msg -> unit Deferred.t }
+
+let empty_publish_functions logger =
+  { publish_v0 =
+      Fn.const
+      @@ Deferred.return ([%log warn] "Call of uninitialized publish_v0")
+  }
+
+let validate_gossip_base ~fn my_peer_id envelope validation_callback =
+  (* Messages from ourselves are valid. Don't try and reingest them. *)
+  match Envelope.Incoming.sender envelope with
+  | Local ->
+      Mina_net2.Validation_callback.fire_if_not_already_fired
+        validation_callback `Accept ;
+      Deferred.unit
+  | Remote sender ->
+      if not (Peer.Id.equal sender.peer_id my_peer_id) then
+        (* Match on different cases *)
+        fn (envelope, validation_callback)
+      else (
+        Mina_net2.Validation_callback.fire_if_not_already_fired
+          validation_callback `Accept ;
+        Deferred.unit )
+
+let on_gossip_decode_failure (config : Config.t) envelope (err : Error.t) =
+  let peer = Envelope.Incoming.sender envelope |> Envelope.Sender.remote_exn in
+  let metadata =
+    [ ("sender_peer_id", `String peer.peer_id)
+    ; ("error", Error_json.error_to_yojson err)
+    ]
+  in
+  Trust_system.(
+    record config.trust_system config.logger peer
+      Actions.
+        (Decoding_failed, Some ("failed to decode gossip message", metadata)))
+  |> don't_wait_for ;
+  ()
 
 module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
   S with module Rpc_intf := Rpc_intf = struct
@@ -70,10 +110,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
       ; first_peer_ivar : unit Ivar.t
       ; high_connectivity_ivar : unit Ivar.t
       ; ban_reader : Intf.ban_notification Linear_pipe.Reader.t
-      ; message_reader :
-          (Message.msg Envelope.Incoming.t * Mina_net2.Validation_callback.t)
-          Strict_pipe.Reader.t
-      ; subscription : Message.msg Mina_net2.Pubsub.subscription Deferred.t ref
+      ; publish_functions : publish_functions ref
       ; restart_helper : unit -> unit
       }
 
@@ -140,7 +177,10 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
     (* Creates just the helper, making sure to register everything
        BEFORE we start listening/advertise ourselves for discovery. *)
     let create_libp2p (config : Config.t) rpc_handlers first_peer_ivar
-        high_connectivity_ivar ~added_seeds ~pids ~on_unexpected_termination =
+        high_connectivity_ivar ~added_seeds ~pids ~on_unexpected_termination
+        ~sinks:
+          (Message.Any_sinks (sinksM, (sink_block, sink_tx, sink_snark_work))) =
+      let module Sinks = (val sinksM) in
       let ctr = ref 0 in
       let record_peer_connection () =
         [%log' trace config.logger] "Fired peer_connected callback" ;
@@ -337,57 +377,37 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
                           | Ok () ->
                               () )))
             in
-            let message_reader, message_writer =
-              Strict_pipe.(
-                create
-                  ~name:"Gossip_net.Libp2p messages with validation callbacks"
-                  Synchronous)
-            in
-            let%bind subscription =
+            let subscribe ~fn topic bin_prot =
               Mina_net2.Pubsub.subscribe_encode net2
-                "coda/consensus-messages/0.0.1"
+                topic
                 (* Fix for #4097: validation is tied into a lot of complex control flow.
                    Instead of refactoring it to have validation up-front and decoupled,
                    we pass along a validation callback with the message. This ends up
                    ignoring the actual subscription message pipe, so drain it separately. *)
                 ~handle_and_validate_incoming_message:
-                  (fun envelope validation_callback ->
-                  (* Messages from ourselves are valid. Don't try and reingest them. *)
-                  match Envelope.Incoming.sender envelope with
-                  | Local ->
-                      Mina_net2.Validation_callback.fire_if_not_already_fired
-                        validation_callback `Accept ;
-                      Deferred.unit
-                  | Remote sender ->
-                      if not (Peer.Id.equal sender.peer_id my_peer_id) then
-                        Strict_pipe.Writer.write message_writer
-                          (envelope, validation_callback)
-                      else (
-                        Mina_net2.Validation_callback.fire_if_not_already_fired
-                          validation_callback `Accept ;
-                        Deferred.unit ))
-                ~bin_prot:Message.Latest.T.bin_msg
-                ~on_decode_failure:
-                  (`Call
-                    (fun envelope (err : Error.t) ->
-                      let peer =
-                        Envelope.Incoming.sender envelope
-                        |> Envelope.Sender.remote_exn
-                      in
-                      let metadata =
-                        [ ("sender_peer_id", `String peer.peer_id)
-                        ; ("error", Error_json.error_to_yojson err)
-                        ]
-                      in
-                      Trust_system.(
-                        record config.trust_system config.logger peer
-                          Actions.
-                            ( Decoding_failed
-                            , Some ("failed to decode gossip message", metadata)
-                            ))
-                      |> don't_wait_for ;
-                      ()))
+                  (validate_gossip_base ~fn my_peer_id)
+                ~bin_prot
+                ~on_decode_failure:(`Call (on_gossip_decode_failure config))
             in
+            let subscribe_v0_impl =
+              subscribe
+                ~fn:(fun (env, vc) ->
+                  match Envelope.Incoming.data env with
+                  | Message.New_state state ->
+                      Sinks.Block_sink.push sink_block
+                        ( `Transition
+                            (Envelope.Incoming.map ~f:(fun _ -> state) env)
+                        , `Time_received (Block_time.now config.time_controller)
+                        , `Valid_cb vc )
+                  | Message.Transaction_pool_diff diff ->
+                      Sinks.Tx_sink.push sink_tx
+                        (Envelope.Incoming.map ~f:(fun _ -> diff) env, vc)
+                  | Message.Snark_pool_diff diff ->
+                      Sinks.Snark_sink.push sink_snark_work
+                        (Envelope.Incoming.map ~f:(fun _ -> diff) env, vc))
+                "coda/consensus-messages/0.0.1" Message.Latest.T.bin_msg
+            in
+            let%bind publish_v0 = subscribe_v0_impl >>| Pubsub.publish net2 in
             let%map _ =
               (* XXX: this ALWAYS needs to be AFTER handle_protocol/subscribe
                  or it is possible to miss connections! *)
@@ -426,11 +446,11 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
                        [%log' warn config.logger]
                          "starting libp2p up failed: $error"
                          ~metadata:[ ("error", Error_json.error_to_yojson e) ])) ;
-            (subscription, message_reader)
+            { publish_v0 }
           in
           match%map initializing_libp2p_result with
-          | Ok (subscription, message_reader) ->
-              (net2, subscription, message_reader, me)
+          | Ok pfs ->
+              (net2, pfs, me)
           | Error e ->
               fail e )
       | Ok (Error e) ->
@@ -442,14 +462,11 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
 
     let bandwidth_info t = !(t.net2) >>= Mina_net2.bandwidth_info
 
-    let create (config : Config.t) ~pids rpc_handlers =
+    let create (config : Config.t) ~pids rpc_handlers (sinks : Message.sinks) =
       let first_peer_ivar = Ivar.create () in
       let high_connectivity_ivar = Ivar.create () in
-      let message_reader, message_writer =
-        Strict_pipe.create ~name:"libp2p_messages" Synchronous
-      in
       let net2_ref = ref (Deferred.never ()) in
-      let subscription_ref = ref (Deferred.never ()) in
+      let pfs_ref = ref @@ empty_publish_functions config.logger in
       let restarts_r, restarts_w =
         Strict_pipe.create ~name:"libp2p-restarts"
           (Strict_pipe.Buffered
@@ -459,7 +476,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
       let%bind () =
         let rec on_libp2p_create res =
           net2_ref :=
-            Deferred.map res ~f:(fun (n, _, _, _) ->
+            Deferred.map res ~f:(fun (n, _, _) ->
                 ( match
                     Sys.getenv "MINA_LIBP2P_HELPER_RESTART_INTERVAL_BASE"
                   with
@@ -484,18 +501,21 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
                 | None ->
                     () ) ;
                 n) ;
-          subscription_ref := Deferred.map res ~f:(fun (_, s, _, _) -> s) ;
-          upon res (fun (_, _, m, me) ->
+          let pf_impl f msg =
+            let%bind _, pf, _ = res in
+            f pf msg
+          in
+          pfs_ref := { publish_v0 = pf_impl (fun pf -> pf.publish_v0) } ;
+          upon res (fun (_, _, me) ->
               (* This is a hack so that we keep the same keypair across restarts. *)
               config.keypair <- Some me ;
               let logger = config.logger in
-              [%log trace] ~metadata:[] "Successfully restarted libp2p" ;
-              don't_wait_for (Strict_pipe.transfer m message_writer ~f:Fn.id))
+              [%log trace] ~metadata:[] "Successfully restarted libp2p")
         and start_libp2p () =
           let libp2p =
             create_libp2p config rpc_handlers first_peer_ivar
               high_connectivity_ivar ~added_seeds ~pids
-              ~on_unexpected_termination:restart_libp2p
+              ~on_unexpected_termination:restart_libp2p ~sinks
           in
           on_libp2p_create libp2p ; Deferred.ignore_m libp2p
         and restart_libp2p () = don't_wait_for (start_libp2p ()) in
@@ -555,8 +575,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
         ; net2 = net2_ref
         ; first_peer_ivar
         ; high_connectivity_ivar
-        ; subscription = subscription_ref
-        ; message_reader
+        ; publish_functions = pfs_ref
         ; ban_reader
         ; restart_helper = (fun () -> Strict_pipe.Writer.write restarts_w ())
         }
@@ -794,18 +813,22 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
         (Peer.pretty_list peers) ;
       List.map peers ~f:(fun peer -> query_peer t peer.peer_id rpc query)
 
-    let broadcast t msg =
-      don't_wait_for
-        (let%bind net2 = !(t.net2) in
-         let%bind subscription = !(t.subscription) in
-         Mina_net2.Pubsub.publish net2 subscription msg)
+    let broadcast_state t state =
+      let pfs = !(t.publish_functions) in
+      pfs.publish_v0 (Message.New_state state)
+
+    let broadcast_transaction_pool_diff t diff =
+      let pfs = !(t.publish_functions) in
+      pfs.publish_v0 (Message.Transaction_pool_diff diff)
+
+    let broadcast_snark_pool_diff t diff =
+      let pfs = !(t.publish_functions) in
+      pfs.publish_v0 (Message.Snark_pool_diff diff)
 
     let on_first_connect t ~f = Deferred.map (Ivar.read t.first_peer_ivar) ~f
 
     let on_first_high_connectivity t ~f =
       Deferred.map (Ivar.read t.high_connectivity_ivar) ~f
-
-    let received_message_reader t = t.message_reader
 
     let ban_notification_reader t = t.ban_reader
 

--- a/src/lib/gossip_net/message.ml
+++ b/src/lib/gossip_net/message.ml
@@ -2,6 +2,7 @@ open Async
 open Core_kernel
 open Mina_transition
 open Network_pool
+open Network_peer
 
 module Master = struct
   module T = struct
@@ -10,6 +11,12 @@ module Master = struct
       | Snark_pool_diff of Snark_pool.Resource_pool.Diff.t
       | Transaction_pool_diff of Transaction_pool.Resource_pool.Diff.t
     [@@deriving sexp, to_yojson]
+
+    type state_msg = External_transition.t
+
+    type snark_pool_diff_msg = Snark_pool.Resource_pool.Diff.t
+
+    type transaction_pool_diff_msg = Transaction_pool.Resource_pool.Diff.t
   end
 
   let name = "message"
@@ -28,6 +35,12 @@ module V1 = struct
       | Snark_pool_diff of Snark_pool.Diff_versioned.Stable.V1.t
       | Transaction_pool_diff of Transaction_pool.Diff_versioned.Stable.V1.t
     [@@deriving bin_io, sexp, version { rpc }]
+
+    type state_msg = External_transition.Stable.V1.t
+
+    type snark_pool_diff_msg = Snark_pool.Diff_versioned.Stable.V1.t
+
+    type transaction_pool_diff_msg = Transaction_pool.Diff_versioned.Stable.V1.t
 
     let callee_model_of_msg = Fn.id
 
@@ -48,3 +61,35 @@ end
 module Latest = V1
 
 [%%define_locally Latest.(summary)]
+
+type block_sink_msg =
+  [ `Transition of state_msg Envelope.Incoming.t ]
+  * [ `Time_received of Block_time.t ]
+  * [ `Valid_cb of Mina_net2.Validation_callback.t ]
+
+type tx_sink_msg =
+  transaction_pool_diff_msg Envelope.Incoming.t
+  * Mina_net2.Validation_callback.t
+
+type snark_sink_msg =
+  snark_pool_diff_msg Envelope.Incoming.t * Mina_net2.Validation_callback.t
+
+type 'msg push_modifier = ('msg -> unit Deferred.t) -> 'msg -> unit Deferred.t
+
+module type Sinks_intf = sig
+  module Block_sink : Mina_net2.Sink.S with type msg := block_sink_msg
+
+  module Tx_sink : Mina_net2.Sink.S with type msg := tx_sink_msg
+
+  module Snark_sink : Mina_net2.Sink.S with type msg := snark_sink_msg
+
+  type t = Block_sink.t * Tx_sink.t * Snark_sink.t
+end
+
+type ('sink_block, 'sink_tx, 'sink_snark) sinks_impl =
+  (module Sinks_intf
+     with type Block_sink.t = 'sink_block
+      and type Snark_sink.t = 'sink_snark
+      and type Tx_sink.t = 'sink_tx)
+
+type sinks = Any_sinks : ('a, 'b, 'c) sinks_impl * ('a * 'b * 'c) -> sinks

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -246,7 +246,8 @@ module Gossip = struct
 
     let parse_func message =
       match%bind parse id message with
-      | Transition_handler.Block_sink.Block_received { state_hash; sender = _ } ->
+      | Transition_handler.Block_sink.Block_received { state_hash; sender = _ }
+        ->
           Ok ({ state_hash }, Direction.Received)
       | Mina_networking.Gossip_new_state { state_hash } ->
           Ok ({ state_hash }, Sent)

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -242,11 +242,11 @@ module Gossip = struct
 
     let name = "Block_gossip"
 
-    let id = Mina_networking.block_received_structured_events_id
+    let id = Transition_handler.Block_sink.block_received_structured_events_id
 
     let parse_func message =
       match%bind parse id message with
-      | Mina_networking.Block_received { state_hash; sender = _ } ->
+      | Transition_handler.Block_sink.Block_received { state_hash; sender = _ } ->
           Ok ({ state_hash }, Direction.Received)
       | Mina_networking.Gossip_new_state { state_hash } ->
           Ok ({ state_hash }, Sent)
@@ -264,11 +264,14 @@ module Gossip = struct
 
     let name = "Snark_work_gossip"
 
-    let id = Mina_networking.snark_work_received_structured_events_id
+    let id =
+      Network_pool.Snark_pool.Resource_pool.Diff
+      .snark_work_received_structured_events_id
 
     let parse_func message =
       match%bind parse id message with
-      | Mina_networking.Snark_work_received { work; sender = _ } ->
+      | Network_pool.Snark_pool.Resource_pool.Diff.Snark_work_received
+          { work; sender = _ } ->
           Ok ({ work }, Direction.Received)
       | Mina_networking.Gossip_snark_pool_diff { work } ->
           Ok ({ work }, Direction.Received)
@@ -287,11 +290,14 @@ module Gossip = struct
 
     let name = "Transactions_gossip"
 
-    let id = Mina_networking.transactions_received_structured_events_id
+    let id =
+      Network_pool.Transaction_pool.Resource_pool.Diff
+      .transactions_received_structured_events_id
 
     let parse_func message =
       match%bind parse id message with
-      | Mina_networking.Transactions_received { txns; sender = _ } ->
+      | Network_pool.Transaction_pool.Resource_pool.Diff.Transactions_received
+          { txns; sender = _ } ->
           Ok ({ txns }, Direction.Received)
       | Mina_networking.Gossip_transaction_pool_diff { txns } ->
           Ok ({ txns }, Sent)

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -364,6 +364,7 @@ module type Transition_router_intf = sig
          * External_transition.Initial_validated.t Broadcast_pipe.Writer.t
     -> precomputed_values:Precomputed_values.t
     -> catchup_mode:[ `Normal | `Super ]
+    -> notify_online:(unit -> unit Deferred.t)
     -> ( [ `Transition of External_transition.Validated.t ]
        * [ `Source of [ `Gossip | `Catchup | `Internal ] ] )
        Strict_pipe.Reader.t

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Async
-open Unsigned
 open Mina_base
 open Mina_transition
 open Pipe_lib
@@ -74,11 +73,6 @@ type pipes =
       , Strict_pipe.synchronous
       , unit Deferred.t )
       Strict_pipe.Writer.t
-  ; external_transitions_writer :
-      ( External_transition.t Envelope.Incoming.t
-      * Block_time.t
-      * Mina_net2.Validation_callback.t )
-      Pipe.Writer.t
   ; user_command_input_writer :
       ( User_command_input.t list
         * (   ( Network_pool.Transaction_pool.Resource_pool.Diff.t
@@ -93,24 +87,8 @@ type pipes =
       , Strict_pipe.synchronous
       , unit Deferred.t )
       Strict_pipe.Writer.t
-  ; user_command_writer :
-      ( User_command.t list
-        * (   ( Network_pool.Transaction_pool.Resource_pool.Diff.t
-              * Network_pool.Transaction_pool.Resource_pool.Diff.Rejected.t )
-              Or_error.t
-           -> unit)
-      , Strict_pipe.synchronous
-      , unit Deferred.t )
-      Strict_pipe.Writer.t
-  ; local_snark_work_writer :
-      ( Network_pool.Snark_pool.Resource_pool.Diff.t
-        * (   ( Network_pool.Snark_pool.Resource_pool.Diff.t
-              * Network_pool.Snark_pool.Resource_pool.Diff.rejected )
-              Or_error.t
-           -> unit)
-      , Strict_pipe.synchronous
-      , unit Deferred.t )
-      Strict_pipe.Writer.t
+  ; tx_local_sink : Network_pool.Transaction_pool.Local_sink.t
+  ; snark_local_sink : Network_pool.Snark_pool.Local_sink.t
   }
 
 type t =
@@ -873,7 +851,7 @@ let add_work t (work : Snark_worker_lib.Work.Result.t) =
     Work_selection_method.remove t.snark_job_state spec
   in
   ignore (Or_error.try_with (fun () -> update_metrics ()) : unit Or_error.t) ;
-  Strict_pipe.Writer.write t.pipes.local_snark_work_writer
+  Network_pool.Snark_pool.Local_sink.push t.pipes.snark_local_sink
     (Network_pool.Snark_pool.Resource_pool.Diff.of_result work, cb)
   |> Deferred.don't_wait_for
 
@@ -908,7 +886,7 @@ let add_transactions t (uc_inputs : User_command_input.t list) =
 
 let add_full_transactions t user_command =
   let result_ivar = Ivar.create () in
-  Strict_pipe.Writer.write t.pipes.user_command_writer
+  Network_pool.Transaction_pool.Local_sink.push t.pipes.tx_local_sink
     (user_command, Ivar.fill result_ivar)
   |> Deferred.don't_wait_for ;
   Ivar.read result_ivar
@@ -1110,6 +1088,34 @@ let stop_long_running_daemon t =
             go tm)
   in
   go (Time.Span.of_ms (wait_mins * 60 * 1000 |> Float.of_int))
+
+let offline_time
+    { Genesis_constants.Constraint_constants.block_window_duration_ms; _ } =
+  (* This is a bit of a hack, see #3232. *)
+  let inactivity_ms = block_window_duration_ms * 8 in
+  Block_time.Span.of_ms @@ Int64.of_int inactivity_ms
+
+let setup_timer ~constraint_constants time_controller sync_state_broadcaster =
+  Block_time.Timeout.create time_controller (offline_time constraint_constants)
+    ~f:(fun _ ->
+      Broadcast_pipe.Writer.write sync_state_broadcaster `Offline
+      |> don't_wait_for)
+
+let online_broadcaster ~constraint_constants time_controller =
+  let online_reader, online_writer = Broadcast_pipe.create `Offline in
+  let init =
+    Block_time.Timeout.create time_controller
+      (Block_time.Span.of_ms Int64.zero)
+      ~f:ignore
+  in
+  let current_timer = ref init in
+  let notify_online () =
+    let%map () = Broadcast_pipe.Writer.write online_writer `Online in
+    Block_time.Timeout.cancel time_controller !current_timer () ;
+    current_timer :=
+      setup_timer ~constraint_constants time_controller online_writer
+  in
+  (online_reader, notify_online)
 
 let start t =
   let set_next_producer_timing timing consensus_state =
@@ -1373,36 +1379,6 @@ let create ?wallets (config : Config.t) =
                     [ ("rate_limiter", Network_pool.Rate_limiter.summary rl) ]
                   !"%s $rate_limiter" label)
           in
-          let external_transitions_reader, external_transitions_writer =
-            let rl =
-              Network_pool.Rate_limiter.create
-                ~capacity:
-                  ( (* Max of 20 transitions per slot per peer. *)
-                    20
-                  , `Per
-                      (Block_time.Span.to_time_span
-                         consensus_constants.slot_duration_ms) )
-            in
-            log_rate_limiter_occasionally rl ~label:"new_block" ;
-            let r, w = Strict_pipe.create Synchronous in
-            ( Strict_pipe.Reader.filter_map r ~f:(fun ((e, _, cb) as x) ->
-                  let sender = Envelope.Incoming.sender e in
-                  match
-                    Network_pool.Rate_limiter.add rl sender ~now:(Time.now ())
-                      ~score:1
-                  with
-                  | `Capacity_exceeded ->
-                      [%log' warn config.logger]
-                        "$sender has sent many blocks. This is very unusual."
-                        ~metadata:
-                          [ ("sender", Envelope.Sender.to_yojson sender) ] ;
-                      Mina_net2.Validation_callback.fire_if_not_already_fired cb
-                        `Reject ;
-                      None
-                  | `Within_capacity ->
-                      Some x)
-            , w )
-          in
           let producer_transition_reader, producer_transition_writer =
             Strict_pipe.create Synchronous
           in
@@ -1572,9 +1548,63 @@ let create ?wallets (config : Config.t) =
                 | Some net ->
                     Mina_networking.peers net)
           in
+          let txn_pool_config =
+            Network_pool.Transaction_pool.Resource_pool.make_config ~verifier
+              ~trust_system:config.trust_system
+              ~pool_max_size:
+                config.precomputed_values.genesis_constants.txpool_max_size
+          in
+          let first_received_message_signal = Ivar.create () in
+          let online_status, notify_online_impl =
+            online_broadcaster
+              ~constraint_constants:config.net_config.constraint_constants
+              config.time_controller
+          in
+          let on_first_received_message ~f =
+            Ivar.read first_received_message_signal >>| f
+          in
+
+          (* TODO remove the line below after making sure notification will not lead
+             to a stale lock *)
+          let notify_online () =
+            Ivar.fill_if_empty first_received_message_signal () ;
+            notify_online_impl () |> don't_wait_for ;
+            Deferred.unit
+          in
+          let transaction_pool, tx_remote_sink, tx_local_sink =
+            (* make transaction pool return writer for local and incoming diffs *)
+            Network_pool.Transaction_pool.create ~config:txn_pool_config
+              ~constraint_constants ~consensus_constants
+              ~time_controller:config.time_controller ~logger:config.logger
+              ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
+          in
+          let snark_pool_config =
+            Network_pool.Snark_pool.Resource_pool.make_config ~verifier
+              ~trust_system:config.trust_system
+              ~disk_location:config.snark_pool_disk_location
+          in
+          let%bind snark_pool, snark_remote_sink, snark_local_sink =
+            Network_pool.Snark_pool.load ~config:snark_pool_config
+              ~constraint_constants ~consensus_constants
+              ~time_controller:config.time_controller ~logger:config.logger
+              ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
+          in
+          let block_reader, block_sink =
+            Transition_handler.Block_sink.create
+              { logger = config.logger
+              ; slot_duration_ms =
+                  config.precomputed_values.consensus_constants.slot_duration_ms
+              ; on_push = notify_online
+              ; log_gossip_heard = config.net_config.log_gossip_heard.new_state
+              ; time_controller = config.net_config.time_controller
+              ; consensus_constants = config.net_config.consensus_constants
+              }
+          in
+          let sinks = (block_sink, tx_remote_sink, snark_remote_sink) in
           let%bind net =
             O1trace.thread "mina_networking" (fun () ->
                 Mina_networking.create config.net_config ~get_some_initial_peers
+                  ~sinks
                   ~get_staged_ledger_aux_and_pending_coinbases_at_hash:
                     (fun query_env ->
                     O1trace.thread
@@ -1679,27 +1709,7 @@ let create ?wallets (config : Config.t) =
           let user_command_input_reader, user_command_input_writer =
             Strict_pipe.(create ~name:"local transactions" Synchronous)
           in
-          let local_txns_reader, local_txns_writer =
-            Strict_pipe.(create ~name:"local transactions" Synchronous)
-          in
-          let local_snark_work_reader, local_snark_work_writer =
-            Strict_pipe.(create ~name:"local snark work" Synchronous)
-          in
           let block_produced_bvar = Bvar.create () in
-          let txn_pool_config =
-            Network_pool.Transaction_pool.Resource_pool.make_config ~verifier
-              ~trust_system:config.trust_system
-              ~pool_max_size:
-                config.precomputed_values.genesis_constants.txpool_max_size
-          in
-          let transaction_pool =
-            Network_pool.Transaction_pool.create ~config:txn_pool_config
-              ~constraint_constants ~consensus_constants
-              ~time_controller:config.time_controller ~logger:config.logger
-              ~incoming_diffs:(Mina_networking.transaction_pool_diffs net)
-              ~local_diffs:local_txns_reader
-              ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
-          in
           (*Read from user_command_input_reader that has the user command inputs from client, infer nonce, create user command, and write it to the pipe consumed by the network pool*)
           Strict_pipe.Reader.iter user_command_input_reader
             ~f:(fun (input_list, result_cb, get_current_nonce, get_account) ->
@@ -1714,8 +1724,8 @@ let create ?wallets (config : Config.t) =
                       (Error (Error.of_string "No user commands to send")) ;
                     Deferred.unit )
                   else
-                    (*callback for the result from transaction_pool.apply_diff*)
-                    Strict_pipe.Writer.write local_txns_writer
+                    Network_pool.Transaction_pool.Local_sink.push tx_local_sink
+                      (*callback for the result from transaction_pool.apply_diff*)
                       ( List.map user_commands ~f:(fun c ->
                             User_command.Signed_command c)
                       , result_cb )
@@ -1742,37 +1752,7 @@ let create ?wallets (config : Config.t) =
               ~persistent_frontier_location:config.persistent_frontier_location
               ~frontier_broadcast_pipe:
                 (frontier_broadcast_pipe_r, frontier_broadcast_pipe_w)
-              ~catchup_mode
-              ~network_transition_reader:
-                (Strict_pipe.Reader.map external_transitions_reader
-                   ~f:(fun (tn, tm, cb) ->
-                     let lift_consensus_time =
-                       Fn.compose UInt32.to_int
-                         Consensus.Data.Consensus_time.to_uint32
-                     in
-                     let tn_production_consensus_time =
-                       External_transition.consensus_time_produced_at
-                         (Envelope.Incoming.data tn)
-                     in
-                     let tn_production_slot =
-                       lift_consensus_time tn_production_consensus_time
-                     in
-                     let tn_production_time =
-                       Consensus.Data.Consensus_time.to_time
-                         ~constants:consensus_constants
-                         tn_production_consensus_time
-                     in
-                     let tm_slot =
-                       lift_consensus_time
-                         (Consensus.Data.Consensus_time.of_time_exn
-                            ~constants:consensus_constants tm)
-                     in
-                     Mina_metrics.Block_latency.Gossip_slots.update
-                       (Float.of_int (tm_slot - tn_production_slot)) ;
-                     Mina_metrics.Block_latency.Gossip_time.update
-                       Block_time.(
-                         Span.to_time_span @@ diff tm tn_production_time) ;
-                     (`Transition tn, `Time_received tm, `Valid_cb cb)))
+              ~catchup_mode ~network_transition_reader:block_reader
               ~producer_transition_reader:
                 (Strict_pipe.Reader.map producer_transition_reader
                    ~f:(fun breadcrumb ->
@@ -1788,7 +1768,7 @@ let create ?wallets (config : Config.t) =
                        validation_callback ;
                      don't_wait_for
                        (* this will never throw since the callback was created without expiration *)
-                       (let%map v =
+                       (let%bind v =
                           Mina_net2.Validation_callback.await_exn
                             validation_callback
                         in
@@ -1798,10 +1778,11 @@ let create ?wallets (config : Config.t) =
                         then
                           Mina_networking.broadcast_state net
                             (External_transition.Validation
-                             .forget_validation_with_hash et)) ;
+                             .forget_validation_with_hash et)
+                        else Deferred.unit) ;
                      breadcrumb))
               ~most_recent_valid_block
-              ~precomputed_values:config.precomputed_values
+              ~precomputed_values:config.precomputed_values ~notify_online
           in
           let ( valid_transitions_for_network
               , valid_transitions_for_api
@@ -1830,8 +1811,7 @@ let create ?wallets (config : Config.t) =
                         Network_pool.Transaction_pool.Resource_pool.Diff
                         .max_per_15_seconds x
                   in
-                  Mina_networking.broadcast_transaction_pool_diff net x ;
-                  Deferred.unit)) ;
+                  Mina_networking.broadcast_transaction_pool_diff net x)) ;
           O1trace.background_thread "broadcast_blocks" (fun () ->
               Strict_pipe.Reader.iter_without_pushback
                 valid_transitions_for_network
@@ -1900,10 +1880,6 @@ let create ?wallets (config : Config.t) =
                           [%log' warn config.logger] ~metadata
                             "Not rebroadcasting block $state_hash because it \
                              was received $timing" ))) ;
-          don't_wait_for
-            (Strict_pipe.transfer
-               (Mina_networking.states net)
-               external_transitions_writer ~f:ident) ;
           (* FIXME #4093: augment ban_notifications with a Peer.ID so we can implement ban_notify
              trace_task "ban notification loop" (fun () ->
               Linear_pipe.iter (Mina_networking.ban_notification_reader net)
@@ -1920,19 +1896,6 @@ let create ?wallets (config : Config.t) =
             (Linear_pipe.iter
                (Mina_networking.ban_notification_reader net)
                ~f:(Fn.const Deferred.unit)) ;
-          let snark_pool_config =
-            Network_pool.Snark_pool.Resource_pool.make_config ~verifier
-              ~trust_system:config.trust_system
-              ~disk_location:config.snark_pool_disk_location
-          in
-          let%bind snark_pool =
-            Network_pool.Snark_pool.load ~config:snark_pool_config
-              ~constraint_constants ~consensus_constants
-              ~time_controller:config.time_controller ~logger:config.logger
-              ~incoming_diffs:(Mina_networking.snark_pool_diffs net)
-              ~local_diffs:local_snark_work_reader
-              ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
-          in
           let snark_jobs_state =
             Work_selector.State.init
               ~reassignment_wait:config.work_reassignment_wait
@@ -1960,8 +1923,7 @@ let create ?wallets (config : Config.t) =
                         Network_pool.Snark_pool.Resource_pool.Diff
                         .max_per_15_seconds x
                   in
-                  Mina_networking.broadcast_snark_pool_diff net x ;
-                  Deferred.unit)) ;
+                  Mina_networking.broadcast_snark_pool_diff net x)) ;
           Option.iter config.archive_process_location
             ~f:(fun archive_process_port ->
               [%log' info config.logger]
@@ -2008,15 +1970,12 @@ let create ?wallets (config : Config.t) =
             create_sync_status_observer ~logger:config.logger ~net
               ~is_seed:config.is_seed ~demo_mode:config.demo_mode
               ~transition_frontier_and_catchup_signal_incr
-              ~online_status_incr:
-                ( Var.watch @@ of_broadcast_pipe
-                @@ Mina_networking.online_status net )
+              ~online_status_incr:(Var.watch @@ of_broadcast_pipe online_status)
               ~first_connection_incr:
                 ( Var.watch @@ of_deferred
                 @@ Mina_networking.on_first_connect net ~f:Fn.id )
               ~first_message_incr:
-                ( Var.watch @@ of_deferred
-                @@ Mina_networking.on_first_received_message net ~f:Fn.id )
+                (Var.watch @@ of_deferred @@ on_first_received_message ~f:Fn.id)
           in
           (* tie other knot *)
           sync_status_ref := Some sync_status ;
@@ -2042,12 +2001,9 @@ let create ?wallets (config : Config.t) =
             ; pipes =
                 { validated_transitions_reader = valid_transitions_for_api
                 ; producer_transition_writer
-                ; external_transitions_writer =
-                    Strict_pipe.Writer.to_linear_pipe
-                      external_transitions_writer
                 ; user_command_input_writer
-                ; user_command_writer = local_txns_writer
-                ; local_snark_work_writer
+                ; tx_local_sink
+                ; snark_local_sink
                 }
             ; wallets
             ; coinbase_receiver = ref config.coinbase_receiver

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1577,6 +1577,9 @@ let create ?wallets (config : Config.t) =
               ~constraint_constants ~consensus_constants
               ~time_controller:config.time_controller ~logger:config.logger
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
+              ~on_remote_push:notify_online
+              ~log_gossip_heard:
+                config.net_config.log_gossip_heard.transaction_pool_diff
           in
           let snark_pool_config =
             Network_pool.Snark_pool.Resource_pool.make_config ~verifier
@@ -1588,6 +1591,9 @@ let create ?wallets (config : Config.t) =
               ~constraint_constants ~consensus_constants
               ~time_controller:config.time_controller ~logger:config.logger
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
+              ~on_remote_push:notify_online
+              ~log_gossip_heard:
+                config.net_config.log_gossip_heard.snark_pool_diff
           in
           let block_reader, block_sink =
             Transition_handler.Block_sink.create

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -6,6 +6,7 @@ module Keypair = Keypair
 module Libp2p_stream = Libp2p_stream
 module Multiaddr = Multiaddr
 module Validation_callback = Validation_callback
+module Sink = Sink
 
 exception
   Libp2p_helper_died_unexpectedly = Libp2p_helper

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -108,6 +108,7 @@ module Keypair : sig
 end
 
 module Validation_callback = Validation_callback
+module Sink = Sink
 
 (** [create ~logger ~conf_dir] starts a new [net] storing its state in [conf_dir]
   *

--- a/src/lib/mina_net2/sink.ml
+++ b/src/lib/mina_net2/sink.ml
@@ -1,0 +1,15 @@
+open Async_kernel
+
+module type S = sig
+  type t
+
+  type msg
+
+  val push : t -> msg -> unit Deferred.t
+end
+
+module type S_with_void = sig
+  include S
+
+  val void : t
+end

--- a/src/lib/mina_networking/dune
+++ b/src/lib/mina_networking/dune
@@ -5,7 +5,7 @@
  (libraries core o1trace async mina_intf
             gossip_net mina_base unix_timestamp perf_histograms proof_carrying_data
             consensus network_pool mina_transition transition_frontier staged_ledger
-            sync_status)
+            transition_handler sync_status mina_net2)
  (inline_tests)
  (preprocess
   (pps ppx_coda ppx_compare ppx_hash ppx_version ppx_inline_test ppx_compare ppx_deriving.make ppx_deriving_yojson ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_fields_conv ppx_let ppx_register_event ppx_custom_printf))

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -1,7 +1,6 @@
 open Core
 open Async
 open Mina_base
-open Mina_state
 open Mina_transition
 open Network_peer
 open Network_pool
@@ -10,26 +9,6 @@ open Pipe_lib
 let refused_answer_query_string = "Refused to answer_query"
 
 exception No_initial_peers
-
-type Structured_log_events.t +=
-  | Block_received of { state_hash : State_hash.t; sender : Envelope.Sender.t }
-  [@@deriving register_event { msg = "Received a block from $sender" }]
-
-type Structured_log_events.t +=
-  | Snark_work_received of
-      { work : Snark_pool.Resource_pool.Diff.compact
-      ; sender : Envelope.Sender.t
-      }
-  [@@deriving
-    register_event { msg = "Received Snark-pool diff $work from $sender" }]
-
-type Structured_log_events.t +=
-  | Transactions_received of
-      { txns : Transaction_pool.Resource_pool.Diff.t
-      ; sender : Envelope.Sender.t
-      }
-  [@@deriving
-    register_event { msg = "Received transaction-pool diff $txns from $sender" }]
 
 type Structured_log_events.t +=
   | Gossip_new_state of { state_hash : State_hash.t }
@@ -1019,6 +998,7 @@ module Config = struct
     { logger : Logger.t
     ; trust_system : Trust_system.t
     ; time_controller : Block_time.Controller.t
+    ; consensus_constants : Consensus.Constants.t
     ; consensus_local_state : Consensus.Data.Local_state.t
     ; genesis_ledger_hash : Ledger_hash.t
     ; constraint_constants : Genesis_constants.Constraint_constants.t
@@ -1033,54 +1013,13 @@ type t =
   { logger : Logger.t
   ; trust_system : Trust_system.t
   ; gossip_net : Gossip_net.Any.t
-  ; states :
-      ( External_transition.t Envelope.Incoming.t
-      * Block_time.t
-      * Mina_net2.Validation_callback.t )
-      Strict_pipe.Reader.t
-  ; transaction_pool_diffs :
-      ( Transaction_pool.Resource_pool.Diff.t Envelope.Incoming.t
-      * Mina_net2.Validation_callback.t )
-      Strict_pipe.Reader.t
-  ; snark_pool_diffs :
-      ( Snark_pool.Resource_pool.Diff.t Envelope.Incoming.t
-      * Mina_net2.Validation_callback.t )
-      Strict_pipe.Reader.t
-  ; online_status : [ `Offline | `Online ] Broadcast_pipe.Reader.t
-  ; first_received_message_signal : unit Ivar.t
   }
 [@@deriving fields]
-
-let offline_time
-    { Genesis_constants.Constraint_constants.block_window_duration_ms; _ } =
-  (* This is a bit of a hack, see #3232. *)
-  let inactivity_ms = block_window_duration_ms * 8 in
-  Block_time.Span.of_ms @@ Int64.of_int inactivity_ms
-
-let setup_timer ~constraint_constants time_controller sync_state_broadcaster =
-  Block_time.Timeout.create time_controller (offline_time constraint_constants)
-    ~f:(fun _ ->
-      Broadcast_pipe.Writer.write sync_state_broadcaster `Offline
-      |> don't_wait_for)
-
-let online_broadcaster ~constraint_constants time_controller received_messages =
-  let online_reader, online_writer = Broadcast_pipe.create `Offline in
-  let init =
-    Block_time.Timeout.create time_controller
-      (Block_time.Span.of_ms Int64.zero)
-      ~f:ignore
-  in
-  Strict_pipe.Reader.fold received_messages ~init ~f:(fun old_timeout _ ->
-      let%map () = Broadcast_pipe.Writer.write online_writer `Online in
-      Block_time.Timeout.cancel time_controller old_timeout () ;
-      setup_timer ~constraint_constants time_controller online_writer)
-  |> Deferred.ignore_m |> don't_wait_for ;
-  online_reader
 
 let wrap_rpc_data_in_envelope conn data =
   Envelope.Incoming.wrap_peer ~data ~sender:conn
 
-let create (config : Config.t)
+let create (config : Config.t) ~sinks
     ~(get_some_initial_peers :
           Rpcs.Get_some_initial_peers.query Envelope.Incoming.t
        -> Rpcs.Get_some_initial_peers.response Deferred.t)
@@ -1437,7 +1376,8 @@ let create (config : Config.t)
   in
   let%map gossip_net =
     O1trace.thread "gossip_net" (fun () ->
-        Gossip_net.Any.create config.creatable_gossip_net rpc_handlers)
+        Gossip_net.Any.create config.creatable_gossip_net rpc_handlers
+          (Gossip_net.Message.Any_sinks ((module Sinks), sinks)))
   in
   (* The node status RPC is implemented directly in go, serving a string which
      is periodically updated. This is so that one can make this RPC on a node even
@@ -1471,99 +1411,7 @@ let create (config : Config.t)
         For example, some things you really want to not drop (like your outgoing
         block announcment).
   *)
-  let received_gossips, online_notifier =
-    Strict_pipe.Reader.Fork.two
-      (Gossip_net.Any.received_message_reader gossip_net)
-  in
-  let online_status =
-    online_broadcaster ~constraint_constants:config.constraint_constants
-      config.time_controller online_notifier
-  in
-  let first_received_message_signal = Ivar.create () in
-  let states, snark_pool_diffs, transaction_pool_diffs =
-    Strict_pipe.Reader.partition_map3 received_gossips
-      ~f:(fun (envelope, valid_cb) ->
-        O1trace.sync_thread "handle_pubsub_gossips" (fun () ->
-            Ivar.fill_if_empty first_received_message_signal () ;
-            Mina_metrics.(Counter.inc_one Network.gossip_messages_received) ;
-            match Envelope.Incoming.data envelope with
-            | New_state state ->
-                let processing_start_time =
-                  Block_time.(now config.time_controller |> to_time)
-                in
-                don't_wait_for
-                  ( match%map Mina_net2.Validation_callback.await valid_cb with
-                  | Some `Accept ->
-                      let processing_time_span =
-                        Time.diff
-                          Block_time.(now config.time_controller |> to_time)
-                          processing_start_time
-                      in
-                      Mina_metrics.Block_latency.(
-                        Validation_acceptance_time.update processing_time_span)
-                  | _ ->
-                      () ) ;
-                Perf_histograms.add_span ~name:"external_transition_latency"
-                  (Core.Time.abs_diff
-                     Block_time.(now config.time_controller |> to_time)
-                     ( External_transition.protocol_state state
-                     |> Protocol_state.blockchain_state
-                     |> Blockchain_state.timestamp |> Block_time.to_time )) ;
-                Mina_metrics.(Gauge.inc_one Network.new_state_received) ;
-                if config.log_gossip_heard.new_state then
-                  [%str_log info]
-                    ~metadata:
-                      [ ( "external_transition"
-                        , External_transition.to_yojson state )
-                      ]
-                    (Block_received
-                       { state_hash =
-                           (External_transition.state_hashes state).state_hash
-                       ; sender = Envelope.Incoming.sender envelope
-                       }) ;
-                Mina_net2.Validation_callback.set_message_type valid_cb `Block ;
-                Mina_metrics.(Counter.inc_one Network.Block.received) ;
-                `Fst
-                  ( Envelope.Incoming.map envelope ~f:(fun _ -> state)
-                  , Block_time.now config.time_controller
-                  , valid_cb )
-            | Snark_pool_diff diff ->
-                Mina_metrics.(Gauge.inc_one Network.snark_pool_diff_received) ;
-                if config.log_gossip_heard.snark_pool_diff then
-                  Option.iter (Snark_pool.Resource_pool.Diff.to_compact diff)
-                    ~f:(fun work ->
-                      [%str_log debug]
-                        (Snark_work_received
-                           { work; sender = Envelope.Incoming.sender envelope })) ;
-                Mina_metrics.(Counter.inc_one Network.Snark_work.received) ;
-                Mina_net2.Validation_callback.set_message_type valid_cb
-                  `Snark_work ;
-                `Snd
-                  (Envelope.Incoming.map envelope ~f:(fun _ -> diff), valid_cb)
-            | Transaction_pool_diff diff ->
-                Mina_metrics.(
-                  Gauge.inc_one Network.transaction_pool_diff_received) ;
-                if config.log_gossip_heard.transaction_pool_diff then
-                  [%str_log debug]
-                    (Transactions_received
-                       { txns = diff
-                       ; sender = Envelope.Incoming.sender envelope
-                       }) ;
-                Mina_net2.Validation_callback.set_message_type valid_cb
-                  `Transaction ;
-                Mina_metrics.(Counter.inc_one Network.Transaction.received) ;
-                `Trd
-                  (Envelope.Incoming.map envelope ~f:(fun _ -> diff), valid_cb)))
-  in
-  { gossip_net
-  ; logger = config.logger
-  ; trust_system = config.trust_system
-  ; states
-  ; snark_pool_diffs
-  ; transaction_pool_diffs
-  ; online_status
-  ; first_received_message_signal
-  }
+  { gossip_net; logger = config.logger; trust_system = config.trust_system }
 
 (* lift and expose select gossip net functions *)
 include struct
@@ -1615,41 +1463,36 @@ include struct
     lift set_connection_gating t config
 end
 
-let on_first_received_message { first_received_message_signal; _ } ~f =
-  Ivar.read first_received_message_signal >>| f
-
-let fill_first_received_message_signal { first_received_message_signal; _ } =
-  Ivar.fill_if_empty first_received_message_signal ()
-
 (* TODO: Have better pushback behavior *)
-let broadcast t ~log_msg msg =
-  [%str_log' trace t.logger]
+let log_gossip logger ~log_msg msg =
+  [%str_log' trace logger]
     ~metadata:[ ("message", Gossip_net.Message.msg_to_yojson msg) ]
-    log_msg ;
-  Gossip_net.Any.broadcast t.gossip_net msg
+    log_msg
 
 let broadcast_state t state =
-  let msg = Gossip_net.Message.New_state (With_hash.data state) in
-  [%str_log' info t.logger]
-    ~metadata:[ ("message", Gossip_net.Message.msg_to_yojson msg) ]
-    (Gossip_new_state
-       { state_hash = State_hash.With_state_hashes.state_hash state }) ;
+  let msg = With_hash.data state in
+  log_gossip t.logger (Gossip_net.Message.New_state msg)
+    ~log_msg:
+      (Gossip_new_state
+         { state_hash = State_hash.With_state_hashes.state_hash state }) ;
   Mina_metrics.(Gauge.inc_one Network.new_state_broadcasted) ;
-  Gossip_net.Any.broadcast t.gossip_net msg
+  Gossip_net.Any.broadcast_state t.gossip_net msg
 
 let broadcast_transaction_pool_diff t diff =
+  log_gossip t.logger (Gossip_net.Message.Transaction_pool_diff diff)
+    ~log_msg:(Gossip_transaction_pool_diff { txns = diff }) ;
   Mina_metrics.(Gauge.inc_one Network.transaction_pool_diff_broadcasted) ;
-  broadcast t (Gossip_net.Message.Transaction_pool_diff diff)
-    ~log_msg:(Gossip_transaction_pool_diff { txns = diff })
+  Gossip_net.Any.broadcast_transaction_pool_diff t.gossip_net diff
 
 let broadcast_snark_pool_diff t diff =
   Mina_metrics.(Gauge.inc_one Network.snark_pool_diff_broadcasted) ;
-  broadcast t (Gossip_net.Message.Snark_pool_diff diff)
+  log_gossip t.logger (Gossip_net.Message.Snark_pool_diff diff)
     ~log_msg:
       (Gossip_snark_pool_diff
          { work =
              Option.value_exn (Snark_pool.Resource_pool.Diff.to_compact diff)
-         })
+         }) ;
+  Gossip_net.Any.broadcast_snark_pool_diff t.gossip_net diff
 
 (* TODO: Don't copy and paste *)
 let find_map' xs ~f =
@@ -1666,8 +1509,6 @@ let find_map' xs ~f =
         else Deferred.never ())
   in
   Deferred.any (none_worked :: List.map ~f:(filter ~f:Or_error.is_ok) ds)
-
-let online_status t = t.online_status
 
 let make_rpc_request ?heartbeat_timeout ?timeout ~rpc ~label t peer input =
   let open Deferred.Let_syntax in

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -9,15 +9,6 @@ open Network_peer
 exception No_initial_peers
 
 type Structured_log_events.t +=
-  | Block_received of { state_hash : State_hash.t; sender : Envelope.Sender.t }
-  | Snark_work_received of
-      { work : Snark_pool.Resource_pool.Diff.compact
-      ; sender : Envelope.Sender.t
-      }
-  | Transactions_received of
-      { txns : Transaction_pool.Resource_pool.Diff.t
-      ; sender : Envelope.Sender.t
-      }
   | Gossip_new_state of { state_hash : State_hash.t }
   | Gossip_transaction_pool_diff of
       { txns : Transaction_pool.Resource_pool.Diff.t }
@@ -168,6 +159,7 @@ module Config : sig
     { logger : Logger.t
     ; trust_system : Trust_system.t
     ; time_controller : Block_time.Controller.t
+    ; consensus_constants : Consensus.Constants.t
     ; consensus_local_state : Consensus.Data.Local_state.t
     ; genesis_ledger_hash : Ledger_hash.t
     ; constraint_constants : Genesis_constants.Constraint_constants.t
@@ -179,13 +171,6 @@ module Config : sig
 end
 
 type t
-
-val states :
-     t
-  -> ( External_transition.t Envelope.Incoming.t
-     * Block_time.t
-     * Mina_net2.Validation_callback.t )
-     Strict_pipe.Reader.t
 
 val peers : t -> Network_peer.Peer.t list Deferred.t
 
@@ -202,15 +187,9 @@ val get_peer_node_status :
 val add_peer :
   t -> Network_peer.Peer.t -> is_seed:bool -> unit Deferred.Or_error.t
 
-val on_first_received_message : t -> f:(unit -> 'a) -> 'a Deferred.t
-
-val fill_first_received_message_signal : t -> unit
-
 val on_first_connect : t -> f:(unit -> 'a) -> 'a Deferred.t
 
 val on_first_high_connectivity : t -> f:(unit -> 'a) -> 'a Deferred.t
-
-val online_status : t -> [ `Online | `Offline ] Broadcast_pipe.Reader.t
 
 val random_peers : t -> int -> Network_peer.Peer.t list Deferred.t
 
@@ -262,25 +241,14 @@ val get_staged_ledger_aux_and_pending_coinbases_at_hash :
 
 val ban_notify : t -> Network_peer.Peer.t -> Time.t -> unit Deferred.Or_error.t
 
-val snark_pool_diffs :
-     t
-  -> ( Snark_pool.Resource_pool.Diff.t Envelope.Incoming.t
-     * Mina_net2.Validation_callback.t )
-     Strict_pipe.Reader.t
-
-val transaction_pool_diffs :
-     t
-  -> ( Transaction_pool.Resource_pool.Diff.t Envelope.Incoming.t
-     * Mina_net2.Validation_callback.t )
-     Strict_pipe.Reader.t
-
 val broadcast_state :
-  t -> External_transition.t State_hash.With_state_hashes.t -> unit
+  t -> External_transition.t State_hash.With_state_hashes.t -> unit Deferred.t
 
-val broadcast_snark_pool_diff : t -> Snark_pool.Resource_pool.Diff.t -> unit
+val broadcast_snark_pool_diff :
+  t -> Snark_pool.Resource_pool.Diff.t -> unit Deferred.t
 
 val broadcast_transaction_pool_diff :
-  t -> Transaction_pool.Resource_pool.Diff.t -> unit
+  t -> Transaction_pool.Resource_pool.Diff.t -> unit Deferred.t
 
 val glue_sync_ledger :
      t
@@ -315,6 +283,7 @@ val ban_notification_reader :
 
 val create :
      Config.t
+  -> sinks:Sinks.t
   -> get_some_initial_peers:
        (   Rpcs.Get_some_initial_peers.query Envelope.Incoming.t
         -> Rpcs.Get_some_initial_peers.response Deferred.t)

--- a/src/lib/mina_networking/sinks.ml
+++ b/src/lib/mina_networking/sinks.ml
@@ -1,0 +1,5 @@
+module Tx_sink = Network_pool.Transaction_pool.Remote_sink
+module Snark_sink = Network_pool.Snark_pool.Remote_sink
+module Block_sink = Transition_handler.Block_sink
+
+type t = Block_sink.t * Tx_sink.t * Snark_sink.t

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -181,6 +181,8 @@ module type Network_pool_base_intf = sig
     -> frontier_broadcast_pipe:
          transition_frontier Option.t Broadcast_pipe.Reader.t
     -> logger:Logger.t
+    -> log_gossip_heard:bool
+    -> on_remote_push:(unit -> unit Deferred.t)
     -> t * Remote_sink.t * Local_sink.t
 
   val of_resource_pool_and_diffs :
@@ -188,6 +190,8 @@ module type Network_pool_base_intf = sig
     -> logger:Logger.t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> tf_diffs:transition_frontier_diff Strict_pipe.Reader.t
+    -> log_gossip_heard:bool
+    -> on_remote_push:(unit -> unit Deferred.t)
     -> t * Remote_sink.t * Local_sink.t
 
   val resource_pool : t -> resource_pool

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -92,6 +92,12 @@ module type Resource_pool_diff_intf = sig
        Deferred.t
 
   val is_empty : t -> bool
+
+  val update_metrics :
+       t Envelope.Incoming.t
+    -> Mina_net2.Validation_callback.t
+    -> Logger.t option
+    -> unit
 end
 
 (** A [Resource_pool_intf] ties together an associated pair of
@@ -111,6 +117,18 @@ module type Resource_pool_intf = sig
   *)
   val get_rebroadcastable :
     t -> has_timed_out:(Time.t -> [ `Timed_out | `Ok ]) -> Diff.t list
+end
+
+module type Broadcast_callback = sig
+  type resource_pool_diff
+
+  type rejected_diff
+
+  type t =
+    | Local of ((resource_pool_diff * rejected_diff) Or_error.t -> unit)
+    | External of Mina_net2.Validation_callback.t
+
+  val drop : resource_pool_diff -> rejected_diff -> t -> unit Deferred.t
 end
 
 (** A [Network_pool_base_intf] is the core implementation of a
@@ -138,44 +156,39 @@ module type Network_pool_base_intf = sig
 
   type transition_frontier
 
-  module Broadcast_callback : sig
-    type t =
-      | Local of ((resource_pool_diff * rejected_diff) Or_error.t -> unit)
-      | External of Mina_net2.Validation_callback.t
-  end
+  module Local_sink :
+    Mina_net2.Sink.S_with_void
+      with type msg :=
+            resource_pool_diff
+            * ((resource_pool_diff * rejected_diff) Or_error.t -> unit)
+
+  module Remote_sink :
+    Mina_net2.Sink.S_with_void
+      with type msg :=
+            resource_pool_diff Envelope.Incoming.t
+            * Mina_net2.Validation_callback.t
+
+  module Broadcast_callback :
+    Broadcast_callback
+      with type resource_pool_diff := resource_pool_diff
+       and type rejected_diff := rejected_diff
 
   val create :
        config:config
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
-    -> incoming_diffs:
-         ( resource_pool_diff Envelope.Incoming.t
-         * Mina_net2.Validation_callback.t )
-         Strict_pipe.Reader.t
-    -> local_diffs:
-         ( resource_pool_diff
-         * ((resource_pool_diff * rejected_diff) Or_error.t -> unit) )
-         Strict_pipe.Reader.t
     -> frontier_broadcast_pipe:
          transition_frontier Option.t Broadcast_pipe.Reader.t
     -> logger:Logger.t
-    -> t
+    -> t * Remote_sink.t * Local_sink.t
 
   val of_resource_pool_and_diffs :
        resource_pool
     -> logger:Logger.t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
-    -> incoming_diffs:
-         ( resource_pool_diff Envelope.Incoming.t
-         * Mina_net2.Validation_callback.t )
-         Strict_pipe.Reader.t
-    -> local_diffs:
-         ( resource_pool_diff
-         * ((resource_pool_diff * rejected_diff) Or_error.t -> unit) )
-         Strict_pipe.Reader.t
     -> tf_diffs:transition_frontier_diff Strict_pipe.Reader.t
-    -> t
+    -> t * Remote_sink.t * Local_sink.t
 
   val resource_pool : t -> resource_pool
 
@@ -250,6 +263,10 @@ module type Snark_pool_diff_intf = sig
     }
   [@@deriving yojson, hash]
 
+  type Structured_log_events.t +=
+    | Snark_work_received of { work : compact; sender : Envelope.Sender.t }
+    [@@deriving register_event]
+
   include
     Resource_pool_diff_intf
       with type t := t
@@ -295,6 +312,10 @@ module type Transaction_pool_diff_intf = sig
   module Rejected : sig
     type t = (User_command.t * Diff_error.t) list [@@deriving sexp, yojson]
   end
+
+  type Structured_log_events.t +=
+    | Transactions_received of { txns : t; sender : Envelope.Sender.t }
+    [@@deriving register_event]
 
   include
     Resource_pool_diff_intf

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -19,10 +19,6 @@ end)
   let apply_and_broadcast_thread_label =
     "apply_and_broadcast_" ^ Resource_pool.label ^ "_diffs"
 
-  let handle_diffs_thread_label = "handle_" ^ Resource_pool.label ^ "_diffs"
-
-  let verify_diffs_thread_label = "verify_" ^ Resource_pool.label ^ "_diffs"
-
   let processing_diffs_thread_label =
     "processing_" ^ Resource_pool.label ^ "_diffs"
 
@@ -32,6 +28,10 @@ end)
   let rebroadcast_loop_thread_label = Resource_pool.label ^ "_rebroadcast_loop"
 
   module Broadcast_callback = struct
+    type resource_pool_diff = Resource_pool.Diff.t
+
+    type rejected_diff = Resource_pool.Diff.rejected
+
     type t =
       | Local of
           (   (Resource_pool.Diff.t * Resource_pool.Diff.rejected) Or_error.t
@@ -76,6 +76,24 @@ end)
           fire_if_not_already_fired cb `Ignore ;
           Linear_pipe.write broadcast_pipe accepted
   end
+
+  module Remote_sink =
+    Pool_sink.Remote_sink
+      (struct
+        include Resource_pool.Diff
+
+        type pool = Resource_pool.t
+      end)
+      (Broadcast_callback)
+
+  module Local_sink =
+    Pool_sink.Local_sink
+      (struct
+        include Resource_pool.Diff
+
+        type pool = Resource_pool.t
+      end)
+      (Broadcast_callback)
 
   type t =
     { resource_pool : Resource_pool.t
@@ -131,100 +149,13 @@ end)
           ~metadata:[ ("rate_limiter", Rate_limiter.summary rl) ]
           !"%s $rate_limiter" Resource_pool.label)
 
-  let filter_verified (type a) ~log_rate_limiter (pipe : a Strict_pipe.Reader.t)
-      (t : t)
-      ~(f :
-         a -> Resource_pool.Diff.t Envelope.Incoming.t * Broadcast_callback.t) :
-      (Resource_pool.Diff.verified Envelope.Incoming.t * Broadcast_callback.t)
-      Strict_pipe.Reader.t =
-    let r, w =
-      Strict_pipe.create ~name:"verified network pool diffs"
-        (Buffered
-           ( `Capacity 1024
-           , `Overflow
-               (Call
-                  (fun (env, cb) ->
-                    Mina_metrics.(
-                      Counter.inc_one
-                        Pipe.Drop_on_overflow.verified_network_pool_diffs) ;
-                    let diff = Envelope.Incoming.data env in
-                    [%log' warn t.logger]
-                      "Dropping verified diff $diff due to pipe overflow"
-                      ~metadata:
-                        [ ("diff", Resource_pool.Diff.verified_to_yojson diff) ] ;
-                    Broadcast_callback.drop Resource_pool.Diff.empty
-                      (Resource_pool.Diff.reject_overloaded_diff diff)
-                      cb)) ))
-    in
-    let rl = create_rate_limiter () in
-    if log_rate_limiter then log_rate_limiter_occasionally t rl ;
-    (*Note: This is done asynchronously to use batch verification*)
-    Strict_pipe.Reader.iter_without_pushback pipe ~f:(fun d ->
-        O1trace.sync_thread handle_diffs_thread_label (fun () ->
-            let diff, cb = f d in
-            if not (Broadcast_callback.is_expired cb) then (
-              let summary =
-                `String
-                  (Resource_pool.Diff.summary @@ Envelope.Incoming.data diff)
-              in
-              [%log' debug t.logger] "Verifying $diff from $sender"
-                ~metadata:
-                  [ ("diff", summary)
-                  ; ("sender", Envelope.Sender.to_yojson diff.sender)
-                  ] ;
-              don't_wait_for
-                ( match
-                    Rate_limiter.add rl diff.sender ~now:(Time.now ())
-                      ~score:(Resource_pool.Diff.score diff.data)
-                  with
-                | `Capacity_exceeded ->
-                    [%log' debug t.logger]
-                      ~metadata:
-                        [ ("sender", Envelope.Sender.to_yojson diff.sender)
-                        ; ("diff", summary)
-                        ]
-                      "exceeded capacity from $sender" ;
-                    Broadcast_callback.error
-                      (Error.of_string "exceeded capacity")
-                      cb
-                | `Within_capacity ->
-                    O1trace.thread verify_diffs_thread_label (fun () ->
-                        match%bind
-                          Resource_pool.Diff.verify t.resource_pool diff
-                        with
-                        | Error err ->
-                            [%log' debug t.logger]
-                              "Refusing to rebroadcast $diff. Verification \
-                               error: $error"
-                              ~metadata:
-                                [ ("diff", summary)
-                                ; ("error", Error_json.error_to_yojson err)
-                                ] ;
-                            (*reject incoming messages*)
-                            Broadcast_callback.error err cb
-                        | Ok verified_diff -> (
-                            [%log' debug t.logger]
-                              "Verified diff: $verified_diff"
-                              ~metadata:
-                                [ ( "verified_diff"
-                                  , Resource_pool.Diff.verified_to_yojson
-                                    @@ Envelope.Incoming.data verified_diff )
-                                ; ( "sender"
-                                  , Envelope.Sender.to_yojson
-                                    @@ Envelope.Incoming.sender verified_diff )
-                                ] ;
-                            match
-                              Strict_pipe.Writer.write w (verified_diff, cb)
-                            with
-                            | Some r ->
-                                r
-                            | None ->
-                                Deferred.unit )) ) )))
-    |> don't_wait_for ;
-    r
+  type wrapped_t =
+    | Diff of
+        (Resource_pool.Diff.verified Envelope.Incoming.t * Broadcast_callback.t)
+    | Transition_frontier_extension of Resource_pool.transition_frontier_diff
 
   let of_resource_pool_and_diffs resource_pool ~logger ~constraint_constants
-      ~incoming_diffs ~local_diffs ~tf_diffs =
+      ~tf_diffs =
     let read_broadcasts, write_broadcasts = Linear_pipe.create () in
     let network_pool =
       { resource_pool
@@ -234,35 +165,42 @@ end)
       ; constraint_constants
       }
     in
+    let remote_r, remote_w, remote_rl =
+      Remote_sink.create
+        ~wrap:(fun m -> Diff m)
+        ~unwrap:(function
+          | Diff m -> m | _ -> failwith "unexpected message type")
+        ~trace_label:Resource_pool.label ~logger resource_pool
+    in
+    let local_r, local_w, _ =
+      Local_sink.create
+        ~wrap:(fun m -> Diff m)
+        ~unwrap:(function
+          | Diff m -> m | _ -> failwith "unexpected message type")
+        ~trace_label:Resource_pool.label ~logger resource_pool
+    in
+    log_rate_limiter_occasionally network_pool remote_rl ;
     (*proiority: Transition frontier diffs > local diffs > incomming diffs*)
     Deferred.don't_wait_for
       (O1trace.thread Resource_pool.label (fun () ->
            Strict_pipe.Reader.Merge.iter
              [ Strict_pipe.Reader.map tf_diffs ~f:(fun diff ->
-                   `Transition_frontier_extension diff)
-             ; Strict_pipe.Reader.map
-                 (filter_verified ~log_rate_limiter:false local_diffs
-                    network_pool ~f:(fun (diff, cb) ->
-                      (Envelope.Incoming.local diff, Broadcast_callback.Local cb)))
-                 ~f:(fun d -> `Diff d)
-             ; Strict_pipe.Reader.map
-                 (filter_verified ~log_rate_limiter:true incoming_diffs
-                    network_pool ~f:(fun (diff, cb) ->
-                      (diff, Broadcast_callback.External cb)))
-                 ~f:(fun d -> `Diff d)
+                   Transition_frontier_extension diff)
+             ; remote_r
+             ; local_r
              ]
              ~f:(fun diff_source ->
                match diff_source with
-               | `Diff (verified_diff, cb) ->
+               | Diff ((verified_diff, cb) : Remote_sink.unwrapped_t) ->
                    O1trace.thread processing_diffs_thread_label (fun () ->
                        apply_and_broadcast network_pool verified_diff cb)
-               | `Transition_frontier_extension diff ->
+               | Transition_frontier_extension diff ->
                    O1trace.thread
                      processing_transition_frontier_diffs_thread_label
                      (fun () ->
                        Resource_pool.handle_transition_frontier_diff diff
                          resource_pool)))) ;
-    network_pool
+    (network_pool, remote_w, local_w)
 
   (* Rebroadcast locally generated pool items every 10 minutes. Do so for 50
      minutes - at most 5 rebroadcasts - before giving up.
@@ -311,21 +249,20 @@ end)
     go ()
 
   let create ~config ~constraint_constants ~consensus_constants ~time_controller
-      ~incoming_diffs ~local_diffs ~frontier_broadcast_pipe ~logger =
+      ~frontier_broadcast_pipe ~logger =
     (*Diffs from tansition frontier extensions*)
     let tf_diff_reader, tf_diff_writer =
       Strict_pipe.(
         create ~name:"Network pool transition frontier diffs" Synchronous)
     in
-    let t =
+    let t, locals, remotes =
       of_resource_pool_and_diffs
         (Resource_pool.create ~constraint_constants ~consensus_constants
            ~time_controller ~config ~logger ~frontier_broadcast_pipe
            ~tf_diff_writer)
-        ~constraint_constants ~incoming_diffs ~local_diffs ~logger
-        ~tf_diffs:tf_diff_reader
+        ~constraint_constants ~logger ~tf_diffs:tf_diff_reader
     in
     O1trace.background_thread rebroadcast_loop_thread_label (fun () ->
         rebroadcast_loop t logger) ;
-    t
+    (t, locals, remotes)
 end

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -155,7 +155,7 @@ end)
     | Transition_frontier_extension of Resource_pool.transition_frontier_diff
 
   let of_resource_pool_and_diffs resource_pool ~logger ~constraint_constants
-      ~tf_diffs =
+      ~tf_diffs ~log_gossip_heard ~on_remote_push =
     let read_broadcasts, write_broadcasts = Linear_pipe.create () in
     let network_pool =
       { resource_pool
@@ -166,7 +166,7 @@ end)
       }
     in
     let remote_r, remote_w, remote_rl =
-      Remote_sink.create
+      Remote_sink.create ~log_gossip_heard ~on_push:on_remote_push
         ~wrap:(fun m -> Diff m)
         ~unwrap:(function
           | Diff m -> m | _ -> failwith "unexpected message type")
@@ -249,7 +249,7 @@ end)
     go ()
 
   let create ~config ~constraint_constants ~consensus_constants ~time_controller
-      ~frontier_broadcast_pipe ~logger =
+      ~frontier_broadcast_pipe ~logger ~log_gossip_heard ~on_remote_push =
     (*Diffs from tansition frontier extensions*)
     let tf_diff_reader, tf_diff_writer =
       Strict_pipe.(
@@ -260,7 +260,8 @@ end)
         (Resource_pool.create ~constraint_constants ~consensus_constants
            ~time_controller ~config ~logger ~frontier_broadcast_pipe
            ~tf_diff_writer)
-        ~constraint_constants ~logger ~tf_diffs:tf_diff_reader
+        ~constraint_constants ~logger ~tf_diffs:tf_diff_reader ~log_gossip_heard
+        ~on_remote_push
     in
     O1trace.background_thread rebroadcast_loop_thread_label (fun () ->
         rebroadcast_loop t logger) ;

--- a/src/lib/network_pool/pool_sink.ml
+++ b/src/lib/network_pool/pool_sink.ml
@@ -1,0 +1,240 @@
+open Pipe_lib
+open Async_kernel
+open Network_peer
+open Core_kernel
+
+module type BC_ext = sig
+  include Intf.Broadcast_callback
+
+  val is_expired : t -> bool
+
+  val error : Error.t -> t -> unit Deferred.t
+end
+
+module type Pool_sink = sig
+  include Mina_net2.Sink.S_with_void
+
+  type unwrapped_t
+
+  type pool
+
+  val create :
+       wrap:(unwrapped_t -> 'wrapped_t)
+    -> unwrap:('wrapped_t -> unwrapped_t)
+    -> trace_label:string
+    -> logger:Logger.t
+    -> pool
+    -> 'wrapped_t Strict_pipe.Reader.t * t * Rate_limiter.t
+end
+
+module Base
+    (Diff : Intf.Resource_pool_diff_intf)
+    (BC : BC_ext
+            with type resource_pool_diff = Diff.t
+             and type rejected_diff = Diff.rejected)
+    (Msg : sig
+      type raw_msg
+
+      type raw_callback
+
+      val convert_callback : raw_callback -> BC.t
+
+      val convert : raw_msg -> Diff.t Envelope.Incoming.t
+    end) :
+  Pool_sink
+    with type pool := Diff.pool
+     and type unwrapped_t = Diff.verified Envelope.Incoming.t * BC.t
+     and type msg := Msg.raw_msg * Msg.raw_callback = struct
+  type unwrapped_t = Diff.verified Envelope.Incoming.t * BC.t
+
+  (* TODO consider moving these constants elsewhere *)
+  let max_waiting_jobs = 2048
+
+  let max_concurrent_jobs = 1024
+
+  let verified_pipe_capacity = 1024
+
+  type t =
+    | Sink :
+        { writer :
+            ( 'w
+            , Strict_pipe.call Strict_pipe.buffered
+            , unit Deferred.t option )
+            Strict_pipe.Writer.t
+        ; logger : Logger.t
+        ; rate_limiter : Rate_limiter.t
+        ; pool : Diff.pool
+        ; wrap : unwrapped_t -> 'w
+        ; trace_label : string
+        ; throttle : unit Throttle.t
+        }
+        -> t
+    | Void
+
+  let on_overflow ~unwrap logger m =
+    match unwrap m with
+    | env, cb ->
+        Mina_metrics.(
+          Counter.inc_one Pipe.Drop_on_overflow.verified_network_pool_diffs) ;
+        let diff = Envelope.Incoming.data env in
+        [%log' warn logger] "Dropping verified diff $diff due to pipe overflow"
+          ~metadata:[ ("diff", Diff.verified_to_yojson diff) ] ;
+        BC.drop Diff.empty (Diff.reject_overloaded_diff diff) cb
+
+  let verify_impl ~logger ~trace_label resource_pool rl env cb :
+      Diff.verified Envelope.Incoming.t option Deferred.t =
+    let handle_diffs_thread_label = "handle_" ^ trace_label ^ "_diffs" in
+
+    let verify_diffs_thread_label = "verify_" ^ trace_label ^ "_diffs" in
+    O1trace.sync_thread handle_diffs_thread_label (fun () ->
+        if BC.is_expired cb then Deferred.return None
+        else
+          let summary = `String (Diff.summary @@ Envelope.Incoming.data env) in
+          [%log' debug logger] "Verifying $diff from $sender"
+            ~metadata:
+              [ ("diff", summary)
+              ; ("sender", Envelope.Sender.to_yojson env.sender)
+              ] ;
+          match
+            Rate_limiter.add rl env.sender ~now:(Time.now ())
+              ~score:(Diff.score env.data)
+          with
+          | `Capacity_exceeded ->
+              [%log' debug logger]
+                ~metadata:
+                  [ ("sender", Envelope.Sender.to_yojson env.sender)
+                  ; ("diff", summary)
+                  ]
+                "exceeded capacity from $sender" ;
+              BC.error (Error.of_string "exceeded capacity") cb
+              >>| fun _ -> None
+          | `Within_capacity ->
+              O1trace.thread verify_diffs_thread_label (fun () ->
+                  match%bind Diff.verify resource_pool env with
+                  | Error err ->
+                      [%log' debug logger]
+                        "Refusing to rebroadcast $diff. Verification error: \
+                         $error"
+                        ~metadata:
+                          [ ("diff", summary)
+                          ; ("error", Error_json.error_to_yojson err)
+                          ] ;
+                      (*reject incoming messages*)
+                      BC.error err cb >>| fun _ -> None
+                  | Ok verified_diff ->
+                      [%log' debug logger] "Verified diff: $verified_diff"
+                        ~metadata:
+                          [ ( "verified_diff"
+                            , Diff.verified_to_yojson
+                              @@ Envelope.Incoming.data verified_diff )
+                          ; ( "sender"
+                            , Envelope.Sender.to_yojson
+                              @@ Envelope.Incoming.sender verified_diff )
+                          ] ;
+                      Deferred.return (Some verified_diff)))
+
+  let push t (msg, cb) =
+    match t with
+    | Sink
+        { writer = w
+        ; logger
+        ; rate_limiter = rl
+        ; pool
+        ; wrap
+        ; trace_label
+        ; throttle
+        } ->
+        O1trace.sync_thread (sprintf "handle %s gossip" trace_label)
+        @@ fun () ->
+        let env' = Msg.convert msg in
+        let cb' = Msg.convert_callback cb in
+        if Throttle.num_jobs_waiting_to_start throttle > max_waiting_jobs then
+          [%log warn] "Ignoring push to %s: throttle is full" trace_label
+        else
+          don't_wait_for
+            (Throttle.enqueue throttle (fun () ->
+                 match%bind
+                   verify_impl ~logger ~trace_label pool rl env' cb'
+                 with
+                 | None ->
+                     [%log debug] "Received unverified gossip on %s" trace_label
+                       ~metadata:
+                         [ ("sender", Envelope.Sender.to_yojson env'.sender)
+                         ; ( "received_at"
+                           , `String (Time.to_string env'.received_at) )
+                         ] ;
+                     Deferred.unit
+                 | Some verified_env ->
+                     let m' = wrap (verified_env, cb') in
+                     Option.value ~default:Deferred.unit
+                       (Strict_pipe.Writer.write w m'))) ;
+        Deferred.unit
+    | Void ->
+        Deferred.unit
+
+  let create ~wrap ~unwrap ~trace_label ~logger pool =
+    let r, writer =
+      Strict_pipe.create ~name:"verified network pool diffs"
+        (Buffered
+           ( `Capacity verified_pipe_capacity
+           , `Overflow (Call (on_overflow ~unwrap logger)) ))
+    in
+
+    let rate_limiter =
+      Rate_limiter.create
+        ~capacity:(Diff.max_per_15_seconds, `Per (Time.Span.of_sec 15.0))
+    in
+    let throttle =
+      Throttle.create ~continue_on_error:true ~max_concurrent_jobs
+    in
+    ( r
+    , Sink { writer; logger; rate_limiter; pool; wrap; trace_label; throttle }
+    , rate_limiter )
+
+  let void = Void
+end
+
+module Local_sink
+    (Diff : Intf.Resource_pool_diff_intf)
+    (BC : BC_ext
+            with type resource_pool_diff = Diff.t
+             and type rejected_diff = Diff.rejected) :
+  Pool_sink
+    with type pool := Diff.pool
+     and type unwrapped_t = Diff.verified Envelope.Incoming.t * BC.t
+     and type msg :=
+          BC.resource_pool_diff
+          * ((BC.resource_pool_diff * BC.rejected_diff) Or_error.t -> unit) =
+  Base (Diff) (BC)
+    (struct
+      type raw_msg = BC.resource_pool_diff
+
+      type raw_callback =
+        (BC.resource_pool_diff * BC.rejected_diff) Or_error.t -> unit
+
+      let convert_callback cb = BC.Local cb
+
+      let convert m = Envelope.Incoming.local m
+    end)
+
+module Remote_sink
+    (Diff : Intf.Resource_pool_diff_intf)
+    (BC : BC_ext
+            with type resource_pool_diff = Diff.t
+             and type rejected_diff = Diff.rejected) :
+  Pool_sink
+    with type pool := Diff.pool
+     and type unwrapped_t = Diff.verified Envelope.Incoming.t * BC.t
+     and type msg :=
+          BC.resource_pool_diff Envelope.Incoming.t
+          * Mina_net2.Validation_callback.t =
+  Base (Diff) (BC)
+    (struct
+      type raw_msg = BC.resource_pool_diff Envelope.Incoming.t
+
+      type raw_callback = Mina_net2.Validation_callback.t
+
+      let convert_callback cb = BC.External cb
+
+      let convert m = m
+    end)

--- a/src/lib/network_pool/pool_sink.ml
+++ b/src/lib/network_pool/pool_sink.ml
@@ -19,7 +19,9 @@ module type Pool_sink = sig
   type pool
 
   val create :
-       wrap:(unwrapped_t -> 'wrapped_t)
+       ?on_push:(unit -> unit Deferred.t)
+    -> ?log_gossip_heard:bool
+    -> wrap:(unwrapped_t -> 'wrapped_t)
     -> unwrap:('wrapped_t -> unwrapped_t)
     -> trace_label:string
     -> logger:Logger.t
@@ -67,6 +69,8 @@ module Base
         ; wrap : unwrapped_t -> 'w
         ; trace_label : string
         ; throttle : unit Throttle.t
+        ; on_push : unit -> unit Deferred.t
+        ; log_gossip_heard : bool
         }
         -> t
     | Void
@@ -143,11 +147,20 @@ module Base
         ; wrap
         ; trace_label
         ; throttle
+        ; on_push
+        ; log_gossip_heard
         } ->
         O1trace.sync_thread (sprintf "handle_%s_gossip" trace_label)
         @@ fun () ->
+        let%bind () = on_push () in
         let env' = Msg.convert msg in
         let cb' = Msg.convert_callback cb in
+        ( match cb' with
+        | BC.External cb'' ->
+            Diff.update_metrics env' cb''
+              (Option.some_if log_gossip_heard logger)
+        | _ ->
+            () ) ;
         if Throttle.num_jobs_waiting_to_start throttle > max_waiting_jobs then
           [%log warn] "Ignoring push to %s: throttle is full" trace_label
         else
@@ -172,7 +185,8 @@ module Base
     | Void ->
         Deferred.unit
 
-  let create ~wrap ~unwrap ~trace_label ~logger pool =
+  let create ?(on_push = Fn.const Deferred.unit) ?(log_gossip_heard = false)
+      ~wrap ~unwrap ~trace_label ~logger pool =
     let r, writer =
       Strict_pipe.create ~name:"verified network pool diffs"
         (Buffered
@@ -188,7 +202,17 @@ module Base
       Throttle.create ~continue_on_error:true ~max_concurrent_jobs
     in
     ( r
-    , Sink { writer; logger; rate_limiter; pool; wrap; trace_label; throttle }
+    , Sink
+        { writer
+        ; logger
+        ; rate_limiter
+        ; pool
+        ; wrap
+        ; trace_label
+        ; throttle
+        ; on_push
+        ; log_gossip_heard
+        }
     , rate_limiter )
 
   let void = Void

--- a/src/lib/network_pool/pool_sink.ml
+++ b/src/lib/network_pool/pool_sink.ml
@@ -144,7 +144,7 @@ module Base
         ; trace_label
         ; throttle
         } ->
-        O1trace.sync_thread (sprintf "handle %s gossip" trace_label)
+        O1trace.sync_thread (sprintf "handle_%s_gossip" trace_label)
         @@ fun () ->
         let env' = Msg.convert msg in
         let cb' = Msg.convert_callback cb in

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -103,18 +103,9 @@ module type S = sig
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
-    -> incoming_diffs:
-         ( Resource_pool.Diff.t Envelope.Incoming.t
-         * Mina_net2.Validation_callback.t )
-         Strict_pipe.Reader.t
-    -> local_diffs:
-         ( Resource_pool.Diff.t
-         * (   (Resource_pool.Diff.t * Resource_pool.Diff.rejected) Or_error.t
-            -> unit) )
-         Strict_pipe.Reader.t
     -> frontier_broadcast_pipe:
          transition_frontier option Broadcast_pipe.Reader.t
-    -> t Deferred.t
+    -> (t * Remote_sink.t * Local_sink.t) Deferred.t
 end
 
 module type Transition_frontier_intf = sig
@@ -652,7 +643,7 @@ struct
   let loaded = ref false
 
   let load ~config ~logger ~constraint_constants ~consensus_constants
-      ~time_controller ~incoming_diffs ~local_diffs ~frontier_broadcast_pipe =
+      ~time_controller ~frontier_broadcast_pipe =
     if !loaded then
       failwith
         "Snark_pool.load should only be called once. It has been called twice." ;
@@ -661,7 +652,7 @@ struct
       Strict_pipe.(
         create ~name:"Snark pool Transition frontier diffs" Synchronous)
     in
-    let%map res =
+    let%map pool, r_sink, l_sink =
       match%map
         Async.Reader.load_bin_prot config.Resource_pool.Config.disk_location
           Snark_tables.Serializable.Stable.Latest.bin_reader_t
@@ -671,20 +662,19 @@ struct
             Resource_pool.of_serializable snark_table ~constraint_constants
               ~config ~logger ~frontier_broadcast_pipe
           in
-          let network_pool =
+          let res =
             of_resource_pool_and_diffs pool ~logger ~constraint_constants
-              ~incoming_diffs ~local_diffs ~tf_diffs:tf_diff_reader
+              ~tf_diffs:tf_diff_reader
           in
           Resource_pool.listen_to_frontier_broadcast_pipe
             frontier_broadcast_pipe pool ~tf_diff_writer ;
-          network_pool
+          res
       | Error _e ->
           create ~config ~logger ~constraint_constants ~consensus_constants
-            ~time_controller ~incoming_diffs ~local_diffs
-            ~frontier_broadcast_pipe
+            ~time_controller ~frontier_broadcast_pipe
     in
-    store_periodically (resource_pool res) ;
-    res
+    store_periodically (resource_pool pool) ;
+    (pool, r_sink, l_sink)
 end
 
 (* TODO: defunctor or remove monkey patching (#3731) *)
@@ -800,34 +790,25 @@ let%test_module "random set test" =
       in
       let tf = Mocks.Transition_frontier.create [] in
       let frontier_broadcast_pipe_r, _ = Broadcast_pipe.create (Some tf) in
-      let incoming_diff_r, _incoming_diff_w =
-        Strict_pipe.(create ~name:"Snark pool test" Synchronous)
+      let open Deferred.Let_syntax in
+      let mock_pool, _r_sink, _l_sink =
+        Mock_snark_pool.create ~config ~logger ~constraint_constants
+          ~consensus_constants ~time_controller
+          ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
+        (* |>  *)
       in
-      let local_diff_r, _local_diff_w =
-        Strict_pipe.(create ~name:"Snark pool test" Synchronous)
+      let pool = Mock_snark_pool.resource_pool mock_pool in
+      (*Statements should be referenced before work for those can be included*)
+      let%bind () =
+        Mocks.Transition_frontier.refer_statements tf
+          (List.unzip sample_solved_work |> fst)
       in
-      let res =
-        let open Deferred.Let_syntax in
-        let resource_pool =
-          Mock_snark_pool.create ~config ~logger ~constraint_constants
-            ~consensus_constants ~time_controller
-            ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
-            ~incoming_diffs:incoming_diff_r ~local_diffs:local_diff_r
-          |> Mock_snark_pool.resource_pool
-        in
-        (*Statements should be referenced before work for those can be included*)
-        let%bind () =
-          Mocks.Transition_frontier.refer_statements tf
-            (List.unzip sample_solved_work |> fst)
-        in
-        let%map () =
-          Deferred.List.iter sample_solved_work ~f:(fun (work, fee) ->
-              let%map res = apply_diff resource_pool work fee in
-              assert (Result.is_ok res))
-        in
-        (resource_pool, tf)
+      let%map () =
+        Deferred.List.iter sample_solved_work ~f:(fun (work, fee) ->
+            let%map res = apply_diff pool work fee in
+            assert (Result.is_ok res))
       in
-      res
+      (pool, tf)
 
     let%test_unit "serialization" =
       let t, _tf =
@@ -983,19 +964,12 @@ let%test_module "random set test" =
     let%test_unit "Work that gets fed into apply_and_broadcast will be \
                    received in the pool's reader" =
       Async.Thread_safe.block_on_async_exn (fun () ->
-          let pool_reader, _pool_writer =
-            Strict_pipe.(create ~name:"Snark pool test" Synchronous)
-          in
-          let local_reader, _local_writer =
-            Strict_pipe.(create ~name:"Snark pool test" Synchronous)
-          in
           let frontier_broadcast_pipe_r, _ =
             Broadcast_pipe.create (Some (Mocks.Transition_frontier.create []))
           in
-          let network_pool =
+          let network_pool, _, _ =
             Mock_snark_pool.create ~config ~constraint_constants
-              ~consensus_constants ~time_controller ~incoming_diffs:pool_reader
-              ~local_diffs:local_reader ~logger
+              ~consensus_constants ~time_controller ~logger
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
           in
           let priced_proof =
@@ -1058,36 +1032,29 @@ let%test_module "random set test" =
                   } )
           in
           let verify_unsolved_work () =
-            let pool_reader, pool_writer =
-              Strict_pipe.(create ~name:"Snark pool test" Synchronous)
-            in
-            let local_reader, local_writer =
-              Strict_pipe.(create ~name:"Snark pool test" Synchronous)
-            in
             (*incomming diffs*)
+            let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
+            let frontier_broadcast_pipe_r, _ =
+              Broadcast_pipe.create (Some (Mocks.Transition_frontier.create []))
+            in
+            let network_pool, remote_sink, local_sink =
+              Mock_snark_pool.create ~logger ~config ~constraint_constants
+                ~consensus_constants ~time_controller
+                ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
+            in
             List.map (List.take works per_reader) ~f:create_work
             |> List.map ~f:(fun work ->
                    ( Envelope.Incoming.local work
                    , Mina_net2.Validation_callback.create_without_expiration ()
                    ))
             |> List.iter ~f:(fun diff ->
-                   Strict_pipe.Writer.write pool_writer diff
+                   Mock_snark_pool.Remote_sink.push remote_sink diff
                    |> Deferred.don't_wait_for) ;
             (* locally generated diffs *)
             List.map (List.drop works per_reader) ~f:create_work
             |> List.iter ~f:(fun diff ->
-                   Strict_pipe.Writer.write local_writer (diff, Fn.const ())
+                   Mock_snark_pool.Local_sink.push local_sink (diff, Fn.const ())
                    |> Deferred.don't_wait_for) ;
-            let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-            let frontier_broadcast_pipe_r, _ =
-              Broadcast_pipe.create (Some (Mocks.Transition_frontier.create []))
-            in
-            let network_pool =
-              Mock_snark_pool.create ~logger ~config ~constraint_constants
-                ~consensus_constants ~time_controller
-                ~incoming_diffs:pool_reader ~local_diffs:local_reader
-                ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
-            in
             don't_wait_for
             @@ Linear_pipe.iter (Mock_snark_pool.broadcasts network_pool)
                  ~f:(fun work_command ->
@@ -1109,12 +1076,6 @@ let%test_module "random set test" =
           verify_unsolved_work ())
 
     let%test_unit "rebroadcast behavior" =
-      let pool_reader, _pool_writer =
-        Strict_pipe.(create ~name:"Snark pool test" Synchronous)
-      in
-      let local_reader, _local_writer =
-        Strict_pipe.(create ~name:"Snark pool test" Synchronous)
-      in
       let tf = Mocks.Transition_frontier.create [] in
       let frontier_broadcast_pipe_r, _w = Broadcast_pipe.create (Some tf) in
       let stmt1, stmt2, stmt3, stmt4 =
@@ -1159,10 +1120,9 @@ let%test_module "random set test" =
       in
       Async.Thread_safe.block_on_async_exn (fun () ->
           let open Deferred.Let_syntax in
-          let network_pool =
+          let network_pool, _, _ =
             Mock_snark_pool.create ~logger:(Logger.null ()) ~config
               ~constraint_constants ~consensus_constants ~time_controller
-              ~incoming_diffs:pool_reader ~local_diffs:local_reader
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
           in
           let resource_pool = Mock_snark_pool.resource_pool network_pool in

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -1,6 +1,5 @@
 open Async_kernel
 open Pipe_lib
-open Network_peer
 open Core_kernel
 
 module type S = sig
@@ -45,18 +44,9 @@ module type S = sig
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
-    -> incoming_diffs:
-         ( Resource_pool.Diff.t Envelope.Incoming.t
-         * Mina_net2.Validation_callback.t )
-         Strict_pipe.Reader.t
-    -> local_diffs:
-         ( Resource_pool.Diff.t
-         * (   (Resource_pool.Diff.t * Resource_pool.Diff.rejected) Or_error.t
-            -> unit) )
-         Strict_pipe.Reader.t
     -> frontier_broadcast_pipe:
          transition_frontier option Broadcast_pipe.Reader.t
-    -> t Deferred.t
+    -> (t * Remote_sink.t * Local_sink.t) Deferred.t
 end
 
 module type Transition_frontier_intf = sig

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -46,6 +46,8 @@ module type S = sig
     -> time_controller:Block_time.Controller.t
     -> frontier_broadcast_pipe:
          transition_frontier option Broadcast_pipe.Reader.t
+    -> log_gossip_heard:bool
+    -> on_remote_push:(unit -> unit Deferred.t)
     -> (t * Remote_sink.t * Local_sink.t) Deferred.t
 end
 

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -157,4 +157,21 @@ module Make
             Deferred.return
               ( if is_local then Error (`Locally_generated (diff, ()))
               else Error (`Other e) ) )
+
+  type Structured_log_events.t +=
+    | Snark_work_received of { work : compact; sender : Envelope.Sender.t }
+    [@@deriving
+      register_event { msg = "Received Snark-pool diff $work from $sender" }]
+
+  let update_metrics envelope valid_cb gossip_heard_logger_option =
+    Mina_metrics.(Counter.inc_one Network.gossip_messages_received) ;
+    Mina_metrics.(Gauge.inc_one Network.snark_pool_diff_received) ;
+    let diff = Envelope.Incoming.data envelope in
+    Option.iter gossip_heard_logger_option ~f:(fun logger ->
+        Option.iter (to_compact diff) ~f:(fun work ->
+            [%str_log debug]
+              (Snark_work_received
+                 { work; sender = Envelope.Incoming.sender envelope }))) ;
+    Mina_metrics.(Counter.inc_one Network.Snark_work.received) ;
+    Mina_net2.Validation_callback.set_message_type valid_cb `Snark_work
 end

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -59,6 +59,7 @@ let%test_module "network pool test" =
             Mock_snark_pool.create ~config ~logger ~constraint_constants
               ~consensus_constants ~time_controller
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
+              ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
           in
           let%bind () =
             Mocks.Transition_frontier.refer_statements tf [ work ]
@@ -114,6 +115,7 @@ let%test_module "network pool test" =
           Mock_snark_pool.create ~config ~logger ~constraint_constants
             ~consensus_constants ~time_controller
             ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
+            ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
         in
         List.map (List.take works per_reader) ~f:create_work
         |> List.map ~f:(fun work ->

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1344,6 +1344,23 @@ struct
             Ok e
         | Error e ->
             Error (`Other e)
+
+      type Structured_log_events.t +=
+        | Transactions_received of { txns : t; sender : Envelope.Sender.t }
+        [@@deriving
+          register_event
+            { msg = "Received transaction-pool diff $txns from $sender" }]
+
+      let update_metrics envelope valid_cb gossip_heard_logger_option =
+        Mina_metrics.(Counter.inc_one Network.gossip_messages_received) ;
+        Mina_metrics.(Gauge.inc_one Network.transaction_pool_diff_received) ;
+        let diff = Envelope.Incoming.data envelope in
+        Option.iter gossip_heard_logger_option ~f:(fun logger ->
+            [%str_log debug]
+              (Transactions_received
+                 { txns = diff; sender = Envelope.Incoming.sender envelope })) ;
+        Mina_net2.Validation_callback.set_message_type valid_cb `Transaction ;
+        Mina_metrics.(Counter.inc_one Network.Transaction.received)
     end
 
     let get_rebroadcastable (t : t) ~has_timed_out =
@@ -1547,22 +1564,15 @@ let%test_module _ =
     let setup_test () =
       let tf, best_tip_diff_w = Mock_transition_frontier.create () in
       let tf_pipe_r, _tf_pipe_w = Broadcast_pipe.create @@ Some tf in
-      let incoming_diff_r, _incoming_diff_w =
-        Strict_pipe.(create ~name:"Transaction pool test" Synchronous)
-      in
-      let local_diff_r, _local_diff_w =
-        Strict_pipe.(create ~name:"Transaction pool test" Synchronous)
-      in
       let trust_system = Trust_system.null () in
       let config =
         Test.Resource_pool.make_config ~trust_system ~pool_max_size ~verifier
       in
-      let pool =
+      let pool_, _, _ =
         Test.create ~config ~logger ~constraint_constants ~consensus_constants
-          ~time_controller ~incoming_diffs:incoming_diff_r
-          ~local_diffs:local_diff_r ~frontier_broadcast_pipe:tf_pipe_r
-        |> Test.resource_pool
+          ~time_controller ~frontier_broadcast_pipe:tf_pipe_r
       in
+      let pool = Test.resource_pool pool_ in
       let%map () = Async.Scheduler.yield () in
       ( (fun txs ->
           Indexed_pool.For_tests.assert_invariants pool.pool ;
@@ -2006,24 +2016,17 @@ let%test_module _ =
       Thread_safe.block_on_async_exn (fun () ->
           (* Set up initial frontier *)
           let frontier_pipe_r, frontier_pipe_w = Broadcast_pipe.create None in
-          let incoming_diff_r, _incoming_diff_w =
-            Strict_pipe.(create ~name:"Transaction pool test" Synchronous)
-          in
-          let local_diff_r, _local_diff_w =
-            Strict_pipe.(create ~name:"Transaction pool test" Synchronous)
-          in
           let trust_system = Trust_system.null () in
           let config =
             Test.Resource_pool.make_config ~trust_system ~pool_max_size
               ~verifier
           in
-          let pool =
+          let pool_, _, _ =
             Test.create ~config ~logger ~constraint_constants
               ~consensus_constants ~time_controller
-              ~incoming_diffs:incoming_diff_r ~local_diffs:local_diff_r
               ~frontier_broadcast_pipe:frontier_pipe_r
-            |> Test.resource_pool
           in
+          let pool = Test.resource_pool pool_ in
           let assert_pool_txs txs =
             [%test_eq: User_command.t List.t]
               ( Test.Resource_pool.transactions ~logger pool

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1571,6 +1571,7 @@ let%test_module _ =
       let pool_, _, _ =
         Test.create ~config ~logger ~constraint_constants ~consensus_constants
           ~time_controller ~frontier_broadcast_pipe:tf_pipe_r
+          ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
       in
       let pool = Test.resource_pool pool_ in
       let%map () = Async.Scheduler.yield () in
@@ -2024,7 +2025,8 @@ let%test_module _ =
           let pool_, _, _ =
             Test.create ~config ~logger ~constraint_constants
               ~consensus_constants ~time_controller
-              ~frontier_broadcast_pipe:frontier_pipe_r
+              ~frontier_broadcast_pipe:frontier_pipe_r ~log_gossip_heard:false
+              ~on_remote_push:(Fn.const Deferred.unit)
           in
           let pool = Test.resource_pool pool_ in
           let assert_pool_txs txs =

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -110,23 +110,15 @@ let%test_module "transaction_status" =
         ~key_gen ~nonce:(Account_nonce.of_int 1) ()
 
     let create_pool ~frontier_broadcast_pipe =
-      let pool_reader, _ =
-        Strict_pipe.(
-          create ~name:"transaction_status incomming diff" Synchronous)
-      in
-      let local_reader, local_writer =
-        Strict_pipe.(create ~name:"transaction_status local diff" Synchronous)
-      in
       let config =
         Transaction_pool.Resource_pool.make_config ~trust_system ~pool_max_size
           ~verifier
       in
-      let transaction_pool =
+      let transaction_pool, _, local_sink =
         Transaction_pool.create ~config
           ~constraint_constants:precomputed_values.constraint_constants
           ~consensus_constants:precomputed_values.consensus_constants
-          ~time_controller ~incoming_diffs:pool_reader ~logger
-          ~local_diffs:local_reader ~frontier_broadcast_pipe
+          ~time_controller ~logger ~frontier_broadcast_pipe
       in
       don't_wait_for
       @@ Linear_pipe.iter (Transaction_pool.broadcasts transaction_pool)
@@ -142,7 +134,7 @@ let%test_module "transaction_status" =
              Deferred.unit) ;
       (* Need to wait for transaction_pool to see the transition_frontier *)
       let%map () = Async.Scheduler.yield_until_no_jobs_remain () in
-      (transaction_pool, local_writer)
+      (transaction_pool, local_sink)
 
     let%test_unit "If the transition frontier currently doesn't exist, the \
                    status of a sent transaction will be unknown" =
@@ -154,7 +146,7 @@ let%test_module "transaction_status" =
                 create_pool ~frontier_broadcast_pipe
               in
               let%bind () =
-                Strict_pipe.Writer.write local_diffs_writer
+                Transaction_pool.Local_sink.push local_diffs_writer
                   ([ Signed_command user_command ], Fn.const ())
               in
               let%map () = Async.Scheduler.yield_until_no_jobs_remain () in
@@ -178,7 +170,7 @@ let%test_module "transaction_status" =
                 create_pool ~frontier_broadcast_pipe
               in
               let%bind () =
-                Strict_pipe.Writer.write local_diffs_writer
+                Transaction_pool.Local_sink.push local_diffs_writer
                   ([ Signed_command user_command ], Fn.const ())
               in
               let%map () = Async.Scheduler.yield_until_no_jobs_remain () in
@@ -215,7 +207,7 @@ let%test_module "transaction_status" =
                 Non_empty_list.uncons user_commands
               in
               let%bind () =
-                Strict_pipe.Writer.write local_diffs_writer
+                Transaction_pool.Local_sink.push local_diffs_writer
                   ( List.map pool_user_commands ~f:(fun x ->
                         User_command.Signed_command x)
                   , Fn.const () )

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -119,6 +119,7 @@ let%test_module "transaction_status" =
           ~constraint_constants:precomputed_values.constraint_constants
           ~consensus_constants:precomputed_values.consensus_constants
           ~time_controller ~logger ~frontier_broadcast_pipe
+          ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
       in
       don't_wait_for
       @@ Linear_pipe.iter (Transaction_pool.broadcasts transaction_pool)

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -49,7 +49,7 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
       ; log_gossip_heard
       ; consensus_constants
       } ->
-      O1trace.sync_thread "handle block gossip"
+      O1trace.sync_thread "handle_block_gossip"
       @@ fun () ->
       let%bind () = on_push () in
       Mina_metrics.(Counter.inc_one Network.gossip_messages_received) ;

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -1,0 +1,163 @@
+open Network_peer
+open Core_kernel
+open Async
+open Pipe_lib.Strict_pipe
+open Mina_base
+open Mina_state
+open Mina_transition
+
+type stream_msg =
+  [ `Transition of External_transition.t Envelope.Incoming.t ]
+  * [ `Time_received of Block_time.t ]
+  * [ `Valid_cb of Mina_net2.Validation_callback.t ]
+
+type block_sink_config =
+  { logger : Logger.t
+  ; slot_duration_ms : Block_time.Span.t
+  ; on_push : unit -> unit Deferred.t
+  ; time_controller : Block_time.Controller.t
+  ; log_gossip_heard : bool
+  ; consensus_constants : Consensus.Constants.t
+  }
+
+type t =
+  | Sink of
+      { writer : (stream_msg, synchronous, unit Deferred.t) Writer.t
+      ; rate_limiter : Network_pool.Rate_limiter.t
+      ; logger : Logger.t
+      ; on_push : unit -> unit Deferred.t
+      ; time_controller : Block_time.Controller.t
+      ; log_gossip_heard : bool
+      ; consensus_constants : Consensus.Constants.t
+      }
+  | Void
+
+type Structured_log_events.t +=
+  | Block_received of { state_hash : State_hash.t; sender : Envelope.Sender.t }
+  [@@deriving register_event { msg = "Received a block from $sender" }]
+
+let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
+  match sink with
+  | Void ->
+      Deferred.unit
+  | Sink
+      { writer
+      ; rate_limiter
+      ; logger
+      ; on_push
+      ; time_controller
+      ; log_gossip_heard
+      ; consensus_constants
+      } ->
+      O1trace.sync_thread "handle block gossip"
+      @@ fun () ->
+      let%bind () = on_push () in
+      Mina_metrics.(Counter.inc_one Network.gossip_messages_received) ;
+      let state = Envelope.Incoming.data e in
+      let processing_start_time = Block_time.(now time_controller |> to_time) in
+      don't_wait_for
+        ( match%map Mina_net2.Validation_callback.await cb with
+        | Some `Accept ->
+            let processing_time_span =
+              Time.diff
+                Block_time.(now time_controller |> to_time)
+                processing_start_time
+            in
+            Mina_metrics.Block_latency.(
+              Validation_acceptance_time.update processing_time_span)
+        | _ ->
+            () ) ;
+      Perf_histograms.add_span ~name:"external_transition_latency"
+        (Core.Time.abs_diff
+           Block_time.(now time_controller |> to_time)
+           ( External_transition.protocol_state state
+           |> Protocol_state.blockchain_state |> Blockchain_state.timestamp
+           |> Block_time.to_time )) ;
+      Mina_metrics.(Gauge.inc_one Network.new_state_received) ;
+      if log_gossip_heard then
+        [%str_log info]
+          ~metadata:
+            [ ("external_transition", External_transition.to_yojson state) ]
+          (Block_received
+             { state_hash = (External_transition.state_hashes state).state_hash
+             ; sender = Envelope.Incoming.sender e
+             }) ;
+      Mina_net2.Validation_callback.set_message_type cb `Block ;
+      Mina_metrics.(Counter.inc_one Network.Block.received) ;
+      let sender = Envelope.Incoming.sender e in
+      let%bind () =
+        match
+          Network_pool.Rate_limiter.add rate_limiter sender ~now:(Time.now ())
+            ~score:1
+        with
+        | `Capacity_exceeded ->
+            [%log' warn logger]
+              "$sender has sent many blocks. This is very unusual."
+              ~metadata:[ ("sender", Envelope.Sender.to_yojson sender) ] ;
+            Mina_net2.Validation_callback.fire_if_not_already_fired cb `Reject ;
+            Deferred.unit
+        | `Within_capacity ->
+            Writer.write writer (`Transition e, `Time_received tm, `Valid_cb cb)
+      in
+      let lift_consensus_time =
+        Fn.compose Unsigned.UInt32.to_int
+          Consensus.Data.Consensus_time.to_uint32
+      in
+      let tn_production_consensus_time =
+        External_transition.consensus_time_produced_at
+          (Envelope.Incoming.data e)
+      in
+      let tn_production_slot =
+        lift_consensus_time tn_production_consensus_time
+      in
+      let tn_production_time =
+        Consensus.Data.Consensus_time.to_time ~constants:consensus_constants
+          tn_production_consensus_time
+      in
+      let tm_slot =
+        lift_consensus_time
+          (Consensus.Data.Consensus_time.of_time_exn
+             ~constants:consensus_constants tm)
+      in
+      Mina_metrics.Block_latency.Gossip_slots.update
+        (Float.of_int (tm_slot - tn_production_slot)) ;
+      Mina_metrics.Block_latency.Gossip_time.update
+        Block_time.(Span.to_time_span @@ diff tm tn_production_time) ;
+      Deferred.unit
+
+let log_rate_limiter_occasionally rl ~logger ~label =
+  let t = Time.Span.of_min 1. in
+  every t (fun () ->
+      [%log' debug logger]
+        ~metadata:[ ("rate_limiter", Network_pool.Rate_limiter.summary rl) ]
+        !"%s $rate_limiter" label)
+
+let create
+    { logger
+    ; slot_duration_ms
+    ; on_push
+    ; time_controller
+    ; log_gossip_heard
+    ; consensus_constants
+    } =
+  let rate_limiter =
+    Network_pool.Rate_limiter.create
+      ~capacity:
+        ( (* Max of 20 transitions per slot per peer. *)
+          20
+        , `Per (Block_time.Span.to_time_span slot_duration_ms) )
+  in
+  log_rate_limiter_occasionally rate_limiter ~logger ~label:"new_block" ;
+  let reader, writer = create Synchronous in
+  ( reader
+  , Sink
+      { writer
+      ; rate_limiter
+      ; logger
+      ; on_push
+      ; time_controller
+      ; log_gossip_heard
+      ; consensus_constants
+      } )
+
+let void = Void

--- a/src/lib/transition_handler/block_sink.mli
+++ b/src/lib/transition_handler/block_sink.mli
@@ -1,0 +1,31 @@
+open Network_peer
+open Mina_base
+open Mina_transition
+
+type Structured_log_events.t +=
+  | Block_received of { state_hash : State_hash.t; sender : Envelope.Sender.t }
+  [@@deriving register_event]
+
+include
+  Mina_net2.Sink.S_with_void
+    with type msg :=
+          [ `Transition of External_transition.t Envelope.Incoming.t ]
+          * [ `Time_received of Block_time.t ]
+          * [ `Valid_cb of Mina_net2.Validation_callback.t ]
+
+type block_sink_config =
+  { logger : Logger.t
+  ; slot_duration_ms : Block_time.Span.t
+  ; on_push : unit -> unit Async_kernel.Deferred.t
+  ; time_controller : Block_time.Controller.t
+  ; log_gossip_heard : bool
+  ; consensus_constants : Consensus.Constants.t
+  }
+
+val create :
+     block_sink_config
+  -> ( [ `Transition of External_transition.t Envelope.Incoming.t ]
+     * [ `Time_received of Block_time.t ]
+     * [ `Valid_cb of Mina_net2.Validation_callback.t ] )
+     Pipe_lib.Strict_pipe.Reader.t
+     * t

--- a/src/lib/transition_handler/dune
+++ b/src/lib/transition_handler/dune
@@ -2,6 +2,6 @@
  (name transition_handler)
  (public_name transition_handler)
  (inline_tests)
- (libraries mina_metrics perf_histograms core_kernel transition_frontier consensus mina_intf rose_tree pipe_lib otp_lib mina_base cache_lib)
+ (libraries mina_metrics perf_histograms core_kernel transition_frontier consensus mina_intf rose_tree pipe_lib otp_lib mina_base cache_lib network_pool)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane)))

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -247,13 +247,13 @@ let run ~logger ~trust_system ~verifier ~transition_reader
   let open Deferred.Let_syntax in
   let duplicate_checker = Duplicate_block_detector.create () in
   O1trace.background_thread "initially_validate_blocks" (fun () ->
-      Reader.iter transition_reader ~f:(fun network_transition ->
+      Reader.iter transition_reader
+        ~f:(fun
+             ( `Transition transition_env
+             , `Time_received time_received
+             , `Valid_cb valid_cb )
+           ->
           if Ivar.is_full initialization_finish_signal then (
-            let ( `Transition transition_env
-                , `Time_received time_received
-                , `Valid_cb valid_cb ) =
-              network_transition
-            in
             let blockchain_length =
               Envelope.Incoming.data transition_env
               |> External_transition.consensus_state


### PR DESCRIPTION
Problem: there are a few layers of pipes that are used between sites of
pubsub message receival and pubsub message processing. These layers
complicate reasoning about code and impose an unnecessary additional load
onto Async scheduler.

Solution: introduce a Sink abstraction and use it to handle all gossips.

Explain your changes:
* Introduce sink abstraction
* Remove all intermediate pipes for gossip message processing

Explain how you tested your changes:
* No change to behavior was made
* Existing tests pass

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
