### PR TITLE
Replayer, update for Snapps

### DIFF
--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -76,10 +76,11 @@ module Block = struct
     ; creator : Public_key.Compressed.Stable.Latest.t
     ; block_winner : Public_key.Compressed.Stable.Latest.t
     ; snarked_ledger_hash : Frozen_ledger_hash.Stable.Latest.t
-    ; staking_epoch_seed : Epoch_seed.Stable.Latest.t
-    ; staking_epoch_ledger_hash : Frozen_ledger_hash.Stable.Latest.t
-    ; next_epoch_seed : Epoch_seed.Stable.Latest.t
-    ; next_epoch_ledger_hash : Frozen_ledger_hash.Stable.Latest.t
+    ; staking_epoch_data : Mina_base.Epoch_data.Value.Stable.Latest.t
+    ; next_epoch_data : Mina_base.Epoch_data.Value.Stable.Latest.t
+    ; min_window_density : Mina_numbers.Length.Stable.Latest.t
+    ; total_currency : Currency.Amount.Stable.Latest.t
+    ; next_available_token : Token_id.Stable.Latest.t
     ; ledger_hash : Ledger_hash.Stable.Latest.t
     ; height : Unsigned_extended.UInt32.Stable.Latest.t
     ; global_slot_since_hard_fork : Mina_numbers.Global_slot.Stable.Latest.t

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2114,7 +2114,7 @@ module Block = struct
     ; next_available_token : int64
     ; ledger_hash : string
     ; height : int64
-    ; global_slot_since_hard_fork : int64
+    ; global_slot : int64
     ; global_slot_since_genesis : int64
     ; timestamp : int64
     }
@@ -2240,7 +2240,7 @@ module Block = struct
                 consensus_state
                 |> Consensus.Data.Consensus_state.blockchain_length
                 |> Unsigned.UInt32.to_int64
-            ; global_slot_since_hard_fork =
+            ; global_slot =
                 Consensus.Data.Consensus_state.curr_global_slot consensus_state
                 |> Unsigned.UInt32.to_int64
             ; global_slot_since_genesis =
@@ -2557,7 +2557,7 @@ module Block = struct
                 |> Unsigned.UInt64.to_int64
             ; ledger_hash = block.ledger_hash |> Ledger_hash.to_base58_check
             ; height = block.height |> Unsigned.UInt32.to_int64
-            ; global_slot_since_hard_fork =
+            ; global_slot =
                 block.global_slot_since_hard_fork |> Unsigned.UInt32.to_int64
             ; global_slot_since_genesis =
                 block.global_slot_since_genesis |> Unsigned.UInt32.to_int64

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2118,7 +2118,7 @@ module Block = struct
     ; global_slot_since_genesis : int64
     ; timestamp : int64
     }
-  [@@deriving hlist]
+  [@@deriving hlist, fields]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
@@ -2153,17 +2153,11 @@ module Block = struct
          "SELECT id FROM blocks WHERE state_hash = ?")
       (State_hash.to_base58_check state_hash)
 
-  let load (module Conn : CONNECTION) ~(id : int) =
+  let load (module Conn : CONNECTION) ~id =
     Conn.find
       (Caqti_request.find Caqti_type.int typ
-         {sql| SELECT state_hash, parent_id, parent_hash, creator_id,
-                      block_winner_id, snarked_ledger_hash_id,
-                      staking_epoch_data_id,next_epoch_data_id,
-                      min_window_density, total_next, currency_token_id,
-                      ledger_hash, height, global_slot,
-                      global_slot_since_genesis, timestamp FROM blocks
-               WHERE id = ?
-         |sql})
+         (Mina_caqti.select_cols_from_id ~table_name:"blocks"
+            ~cols:Fields.names))
       id
 
   let add_parts_if_doesn't_exist (module Conn : CONNECTION)

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2114,7 +2114,7 @@ module Block = struct
     ; next_available_token : int64
     ; ledger_hash : string
     ; height : int64
-    ; global_slot : int64
+    ; global_slot_since_hard_fork : int64
     ; global_slot_since_genesis : int64
     ; timestamp : int64
     }
@@ -2206,7 +2206,7 @@ module Block = struct
                       creator_id, block_winner_id,
                       snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id,
                       min_window_density, total_currency, next_available_token,
-                      ledger_hash, height, global_slot,
+                      ledger_hash, height, global_slot_since_hard_fork,
                       global_slot_since_genesis, timestamp)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
                |sql})
@@ -2240,7 +2240,7 @@ module Block = struct
                 consensus_state
                 |> Consensus.Data.Consensus_state.blockchain_length
                 |> Unsigned.UInt32.to_int64
-            ; global_slot =
+            ; global_slot_since_hard_fork =
                 Consensus.Data.Consensus_state.curr_global_slot consensus_state
                 |> Unsigned.UInt32.to_int64
             ; global_slot_since_genesis =
@@ -2534,7 +2534,7 @@ module Block = struct
                       snarked_ledger_hash_id, staking_epoch_data_id,
                       next_epoch_data_id,
                       min_window_density, total_currency, next_available_token,
-                      ledger_hash, height, global_slot,
+                      ledger_hash, height, global_slot_since_hard_fork,
                       global_slot_since_genesis, timestamp)
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
                |sql})
@@ -2557,7 +2557,7 @@ module Block = struct
                 |> Unsigned.UInt64.to_int64
             ; ledger_hash = block.ledger_hash |> Ledger_hash.to_base58_check
             ; height = block.height |> Unsigned.UInt32.to_int64
-            ; global_slot =
+            ; global_slot_since_hard_fork =
                 block.global_slot_since_hard_fork |> Unsigned.UInt32.to_int64
             ; global_slot_since_genesis =
                 block.global_slot_since_genesis |> Unsigned.UInt32.to_int64

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1306,11 +1306,22 @@ module Epoch_data = struct
     in
     match%bind
       Conn.find_opt
-        (Caqti_request.find_opt
-           Caqti_type.(tup2 string int)
-           Caqti_type.int
-           "SELECT id FROM epoch_data WHERE seed = ? AND ledger_hash_id = ?")
-        (seed, ledger_hash_id)
+        (Caqti_request.find_opt typ Caqti_type.int
+           {sql| SELECT id FROM epoch_data
+                 WHERE seed = $1
+                 AND ledger_hash_id = $2
+                 AND total_currency = $3
+                 AND start_checkpoint = $4
+                 AND lock_checkpoint = $5
+                 AND epoch_length = $6
+           |sql})
+        { seed
+        ; ledger_hash_id
+        ; total_currency
+        ; start_checkpoint
+        ; lock_checkpoint
+        ; epoch_length
+        }
     with
     | Some id ->
         return id
@@ -2536,7 +2547,8 @@ module Block = struct
                       min_window_density, total_currency, next_available_token,
                       ledger_hash, height, global_slot_since_hard_fork,
                       global_slot_since_genesis, timestamp)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     RETURNING id
                |sql})
             { state_hash = block.state_hash |> State_hash.to_base58_check
             ; parent_id

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -103,9 +103,13 @@ CREATE TABLE snapp_commands
 );
 
 CREATE TABLE epoch_data
-( id             serial PRIMARY KEY
-, seed           text   NOT NULL
-, ledger_hash_id int    NOT NULL REFERENCES snarked_ledger_hashes(id)
+( id               serial PRIMARY KEY
+, seed             text   NOT NULL
+, ledger_hash_id   int    NOT NULL REFERENCES snarked_ledger_hashes(id)
+, total_currency   bigint NOT NULL
+, start_checkpoint text   NOT NULL
+, lock_checkpoint  text   NOT NULL
+, epoch_length     int    NOT NULL
 );
 
 CREATE TABLE blocks
@@ -118,6 +122,9 @@ CREATE TABLE blocks
 , snarked_ledger_hash_id  int    NOT NULL        REFERENCES snarked_ledger_hashes(id)
 , staking_epoch_data_id   int    NOT NULL        REFERENCES epoch_data(id)
 , next_epoch_data_id      int    NOT NULL        REFERENCES epoch_data(id)
+, min_window_density      bigint NOT NULL
+, total_currency          bigint NOT NULL
+, next_available_token    bigint NOT NULL
 , ledger_hash             text   NOT NULL
 , height                  bigint NOT NULL
 , global_slot             bigint NOT NULL

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -113,23 +113,23 @@ CREATE TABLE epoch_data
 );
 
 CREATE TABLE blocks
-( id                      serial PRIMARY KEY
-, state_hash              text   NOT NULL UNIQUE
-, parent_id               int                    REFERENCES blocks(id)
-, parent_hash             text   NOT NULL
-, creator_id              int    NOT NULL        REFERENCES public_keys(id)
-, block_winner_id         int    NOT NULL        REFERENCES public_keys(id)
-, snarked_ledger_hash_id  int    NOT NULL        REFERENCES snarked_ledger_hashes(id)
-, staking_epoch_data_id   int    NOT NULL        REFERENCES epoch_data(id)
-, next_epoch_data_id      int    NOT NULL        REFERENCES epoch_data(id)
-, min_window_density      bigint NOT NULL
-, total_currency          bigint NOT NULL
-, next_available_token    bigint NOT NULL
-, ledger_hash             text   NOT NULL
-, height                  bigint NOT NULL
-, global_slot             bigint NOT NULL
-, global_slot_since_genesis bigint NOT NULL
-, timestamp               bigint NOT NULL
+( id                           serial PRIMARY KEY
+, state_hash                   text   NOT NULL UNIQUE
+, parent_id                    int                    REFERENCES blocks(id)
+, parent_hash                  text   NOT NULL
+, creator_id                   int    NOT NULL        REFERENCES public_keys(id)
+, block_winner_id              int    NOT NULL        REFERENCES public_keys(id)
+, snarked_ledger_hash_id       int    NOT NULL        REFERENCES snarked_ledger_hashes(id)
+, staking_epoch_data_id        int    NOT NULL        REFERENCES epoch_data(id)
+, next_epoch_data_id           int    NOT NULL        REFERENCES epoch_data(id)
+, min_window_density           bigint NOT NULL
+, total_currency               bigint NOT NULL
+, next_available_token         bigint NOT NULL
+, ledger_hash                  text   NOT NULL
+, height                       bigint NOT NULL
+, global_slot_since_hard_fork  bigint NOT NULL
+, global_slot_since_genesis    bigint NOT NULL
+, timestamp                    bigint NOT NULL
 );
 
 CREATE INDEX idx_blocks_id ON blocks(id);

--- a/src/app/archive/snapp_tables.sql
+++ b/src/app/archive/snapp_tables.sql
@@ -193,7 +193,7 @@ CREATE TABLE snapp_predicate_protocol_states
 , curr_global_slot_since_hard_fork int                            REFERENCES snapp_global_slot_bounds(id)
 , global_slot_since_genesis        int                            REFERENCES snapp_global_slot_bounds(id)
 , staking_epoch_data_id            int                            REFERENCES snapp_epoch_data(id)
-, next_epoch_data                  int                            REFERENCES snapp_epoch_data(id)
+, next_epoch_data_id               int                            REFERENCES snapp_epoch_data(id)
 );
 
 /* events_ids and sequence_events_ids indicate a list of ids in

--- a/src/app/archive/snapp_tables.sql
+++ b/src/app/archive/snapp_tables.sql
@@ -70,12 +70,14 @@ CREATE TABLE snapp_permissions
 , set_snapp_uri            snapp_auth_required_type    NOT NULL
 , edit_sequence_state      snapp_auth_required_type    NOT NULL
 , set_token_symbol         snapp_auth_required_type    NOT NULL
+, increment_nonce          snapp_auth_required_type    NOT NULL
 );
 
 CREATE TABLE snapp_timing_info
 ( id                       serial  PRIMARY KEY
 , initial_minimum_balance  bigint  NOT NULL
 , cliff_time               bigint  NOT NULL
+, cliff_amount             bigint  NOT NULL
 , vesting_period           bigint  NOT NULL
 , vesting_increment        bigint  NOT NULL
 );

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -14,6 +14,39 @@ let query_db pool ~f ~item =
       failwithf "Error getting %s from db, error: %s" item
         (Caqti_error.show msg) ()
 
+let epoch_data_of_raw_epoch_data ~pool (raw_epoch_data : Processor.Epoch_data.t)
+    =
+  let%bind hash_str =
+    query_db pool
+      ~f:(fun db ->
+        Sql.Snarked_ledger_hashes.run db raw_epoch_data.ledger_hash_id)
+      ~item:"epoch ledger hash"
+  in
+  let hash = Frozen_ledger_hash.of_base58_check_exn hash_str in
+  let total_currency =
+    raw_epoch_data.total_currency |> Unsigned.UInt64.of_int64
+    |> Currency.Amount.of_uint64
+  in
+  let ledger = { Mina_base.Epoch_ledger.Poly.hash; total_currency } in
+  let seed = raw_epoch_data.seed |> Epoch_seed.of_base58_check_exn in
+  let start_checkpoint =
+    raw_epoch_data.start_checkpoint |> State_hash.of_base58_check_exn
+  in
+  let lock_checkpoint =
+    raw_epoch_data.lock_checkpoint |> State_hash.of_base58_check_exn
+  in
+  let epoch_length =
+    raw_epoch_data.epoch_length |> Unsigned.UInt32.of_int64
+    |> Mina_numbers.Length.of_uint32
+  in
+  return
+    { Mina_base.Epoch_data.Poly.ledger
+    ; seed
+    ; start_checkpoint
+    ; lock_checkpoint
+    ; epoch_length
+    }
+
 let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
     Extensional.Block.t Deferred.t =
   let query_db ~item ~f = query_db pool ~item ~f in
@@ -43,36 +76,31 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
   let snarked_ledger_hash =
     Frozen_ledger_hash.of_base58_check_exn snarked_ledger_hash_str
   in
-  let%bind staking_epoch_seed_str, staking_epoch_ledger_hash_id =
+  let%bind staking_epoch_data_raw =
     query_db
-      ~f:(fun db -> Sql.Epoch_data.run db block.staking_epoch_data_id)
+      ~f:(fun db -> Processor.Epoch_data.load db block.staking_epoch_data_id)
       ~item:"staking epoch data"
   in
-  let staking_epoch_seed =
-    Epoch_seed.of_base58_check_exn staking_epoch_seed_str
+  let%bind staking_epoch_data =
+    epoch_data_of_raw_epoch_data ~pool staking_epoch_data_raw
   in
-  let%bind staking_epoch_ledger_hash_str =
+  let%bind next_epoch_data_raw =
     query_db
-      ~f:(fun db ->
-        Sql.Snarked_ledger_hashes.run db staking_epoch_ledger_hash_id)
-      ~item:"staking epoch ledger hash"
-  in
-  let staking_epoch_ledger_hash =
-    Frozen_ledger_hash.of_base58_check_exn staking_epoch_ledger_hash_str
-  in
-  let%bind next_epoch_seed_str, next_epoch_ledger_hash_id =
-    query_db
-      ~f:(fun db -> Sql.Epoch_data.run db block.next_epoch_data_id)
+      ~f:(fun db -> Processor.Epoch_data.load db block.next_epoch_data_id)
       ~item:"staking epoch data"
   in
-  let next_epoch_seed = Epoch_seed.of_base58_check_exn next_epoch_seed_str in
-  let%bind next_epoch_ledger_hash_str =
-    query_db
-      ~f:(fun db -> Sql.Snarked_ledger_hashes.run db next_epoch_ledger_hash_id)
-      ~item:"next epoch ledger hash"
+  let%bind next_epoch_data =
+    epoch_data_of_raw_epoch_data ~pool next_epoch_data_raw
   in
-  let next_epoch_ledger_hash =
-    Frozen_ledger_hash.of_base58_check_exn next_epoch_ledger_hash_str
+  let min_window_density =
+    block.min_window_density |> Unsigned.UInt32.of_int64
+    |> Mina_numbers.Length.of_uint32
+  in
+  let total_currency =
+    Unsigned.UInt64.of_int64 block.total_currency |> Currency.Amount.of_uint64
+  in
+  let next_available_token =
+    Unsigned.UInt64.of_int64 block.next_available_token |> Token_id.of_uint64
   in
   let ledger_hash = Ledger_hash.of_base58_check_exn block.ledger_hash in
   let height = Unsigned.UInt32.of_int64 block.height in
@@ -90,10 +118,11 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
     ; creator
     ; block_winner
     ; snarked_ledger_hash
-    ; staking_epoch_seed
-    ; staking_epoch_ledger_hash
-    ; next_epoch_seed
-    ; next_epoch_ledger_hash
+    ; staking_epoch_data
+    ; next_epoch_data
+    ; min_window_density
+    ; total_currency
+    ; next_available_token
     ; ledger_hash
     ; height
     ; global_slot_since_hard_fork

--- a/src/app/extract_blocks/sql.ml
+++ b/src/app/extract_blocks/sql.ml
@@ -1,4 +1,4 @@
-(* sql.ml -- (Postgresql) SQL queries for missing subchain app *)
+(* sql.ml -- (Postgresql) SQL queries for extract_blocks app *)
 
 module Subchain = struct
   let make_sql ~join_condition =
@@ -6,13 +6,13 @@ module Subchain = struct
       {sql| WITH RECURSIVE chain AS (
 
               SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
-                     next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp
+                     next_epoch_data_id,ledger_hash,height,global_slot_since_hard_fork,global_slot_since_genesis,timestamp
               FROM blocks b WHERE b.state_hash = $1
 
               UNION ALL
 
               SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,b.snarked_ledger_hash_id,b.staking_epoch_data_id,
-                     b.next_epoch_data_id,b.ledger_hash,b.height,b.global_slot,b.global_slot_since_genesis,b.timestamp
+                     b.next_epoch_data_id,b.ledger_hash,b.height,b.global_slot_since_hard_fork,b.global_slot_since_genesis,b.timestamp
               FROM blocks b
 
               INNER JOIN chain
@@ -21,7 +21,7 @@ module Subchain = struct
            )
 
            SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
-                  next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp
+                  next_epoch_data_id,ledger_hash,height,global_slot_since_hard_fork,global_slot_since_genesis,timestamp
            FROM chain
       |sql}
       join_condition
@@ -50,7 +50,7 @@ module Subchain = struct
   let query_all =
     Caqti_request.collect Caqti_type.unit Archive_lib.Processor.Block.typ
       {sql| SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
-                   next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp
+                   next_epoch_data_id,ledger_hash,height,global_slot_since_hard_fork,global_slot_since_genesis,timestamp
             FROM blocks
       |sql}
 

--- a/src/app/extract_blocks/sql.ml
+++ b/src/app/extract_blocks/sql.ml
@@ -109,11 +109,8 @@ module Blocks_and_internal_commands = struct
   [@@deriving hlist]
 
   let typ =
-    let open Mina_caqti.Type_spec in
-    let spec = Caqti_type.[ int; int; int; option int64; int ] in
-    let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
-    let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
-    Caqti_type.custom ~encode ~decode (to_rep spec)
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.[ int; int; int; option int64; int ]
 
   let query =
     Caqti_request.collect Caqti_type.int typ

--- a/src/app/replayer/dune
+++ b/src/app/replayer/dune
@@ -6,6 +6,7 @@
    async_kernel
    caqti-driver-postgresql
    core
+   archive_lib
    mina_base
    mina_caqti
    mina_state

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -702,10 +702,10 @@ let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t)
 
 module Snapp_helpers = struct
   let get_parent_state_view ~pool block_id :
-      (* when a Snapp is applied, use the protocol state associated with the parent block
-         of the block containing the transaction
-      *)
       Snapp_predicate.Protocol_state.View.t Deferred.t =
+    (* when a Snapp is applied, use the protocol state associated with the parent block
+       of the block containing the transaction
+    *)
     let%bind parent_id =
       query_db pool
         ~f:(fun db -> Sql.Block.get_parent_id db block_id)
@@ -1592,8 +1592,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
       in
       [%log info] "Loading Snapp command ids" ;
       let%bind snapp_cmd_ids =
-        return []
-        (*        get_command_ids (module Sql.Snapp_command_ids) "Snapp" *)
+        get_command_ids (module Sql.Snapp_command_ids) "Snapp"
       in
       [%log info]
         "Obtained %d user command ids, %d internal command ids, and %d Snapp \

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -3,6 +3,7 @@
 open Core
 open Async
 open Mina_base
+module Processor = Archive_lib.Processor
 
 (* identify a target block B containing staking and next epoch ledgers
    to be used in a hard fork, by giving its state hash
@@ -37,6 +38,15 @@ type output =
   ; target_epoch_data : Runtime_config.Epoch_data.t
   }
 [@@deriving yojson]
+
+type command_type = [ `Internal_command | `User_command | `Snapp_command ]
+
+module type Get_command_ids = sig
+  val run :
+       Caqti_async.connection
+    -> string
+    -> (int list, [> Caqti_error.call_or_retrieve ]) Deferred.Result.t
+end
 
 let error_count = ref 0
 
@@ -164,47 +174,6 @@ let balance_of_id_and_pk_id pool ~id ~pk_id : Currency.Balance.t Deferred.t =
       failwithf
         "Error retrieving balance with id %d and public key %d, error: %s" id
         pk_id (Caqti_error.show msg) ()
-
-let epoch_staking_id_of_state_hash ~logger pool state_hash =
-  match%map
-    Caqti_async.Pool.use
-      (fun db -> Sql.Epoch_data.get_staking_epoch_data_id db state_hash)
-      pool
-  with
-  | Ok staking_epoch_data_id ->
-      [%log info] "Found staking epoch data id for state hash %s" state_hash ;
-      staking_epoch_data_id
-  | Error msg ->
-      failwithf
-        "Error retrieving staking epoch data id for state hash %s, error: %s"
-        state_hash (Caqti_error.show msg) ()
-
-let epoch_next_id_of_state_hash ~logger pool state_hash =
-  match%map
-    Caqti_async.Pool.use
-      (fun db -> Sql.Epoch_data.get_next_epoch_data_id db state_hash)
-      pool
-  with
-  | Ok next_epoch_data_id ->
-      [%log info] "Found next epoch data id for state hash %s" state_hash ;
-      next_epoch_data_id
-  | Error msg ->
-      failwithf
-        "Error retrieving next epoch data id for state hash %s, error: %s"
-        state_hash (Caqti_error.show msg) ()
-
-let epoch_data_of_id ~logger pool epoch_data_id =
-  match%map
-    Caqti_async.Pool.use
-      (fun db -> Sql.Epoch_data.get_epoch_data db epoch_data_id)
-      pool
-  with
-  | Ok { epoch_ledger_hash; epoch_data_seed } ->
-      [%log info] "Found epoch data for id %d" epoch_data_id ;
-      ({ epoch_ledger_hash; epoch_data_seed } : Sql.Epoch_data.epoch_data)
-  | Error msg ->
-      failwithf "Error retrieving epoch data for epoch data id %d, error: %s"
-        epoch_data_id (Caqti_error.show msg) ()
 
 let process_block_infos_of_state_hash ~logger pool state_hash ~f =
   match%bind
@@ -485,7 +454,7 @@ let run_internal_command ~logger ~pool ~ledger (cmd : Sql.Internal_command.t)
     |> Error.raise
   in
   let pk_id = cmd.receiver_id in
-  let balance_id = cmd.receiver_balance in
+  let balance_id = cmd.receiver_balance_id in
   let token_int64 = cmd.token in
   let receiver_account_creation_fee = cmd.receiver_account_creation_fee_paid in
   let%bind () =
@@ -574,11 +543,11 @@ let apply_combined_fee_transfer ~logger ~pool ~ledger ~continue_on_error
   | Ok _ ->
       let%bind () =
         verify_balance ~logger ~pool ~ledger ~who:"combined fee transfer (1)"
-          ~balance_id:cmd1.receiver_balance ~pk_id:cmd1.receiver_id
+          ~balance_id:cmd1.receiver_balance_id ~pk_id:cmd1.receiver_id
           ~token_int64:cmd1.token ~continue_on_error
       in
       verify_balance ~logger ~pool ~ledger ~who:"combined fee transfer (2)"
-        ~balance_id:cmd2.receiver_balance ~pk_id:cmd2.receiver_id
+        ~balance_id:cmd2.receiver_balance_id ~pk_id:cmd2.receiver_id
         ~token_int64:cmd2.token ~continue_on_error
   | Error err ->
       Error.tag_arg err "Error applying combined fee transfer"
@@ -586,63 +555,66 @@ let apply_combined_fee_transfer ~logger ~pool ~ledger ~continue_on_error
         [%sexp_of: string * int]
       |> Error.raise
 
-let body_of_sql_user_cmd pool
-    ({ type_
-     ; source_id
-     ; receiver_id
-     ; token = tok
-     ; amount
-     ; global_slot_since_genesis
-     ; _
-     } :
-      Sql.User_command.t) : Signed_command_payload.Body.t Deferred.t =
-  let open Signed_command_payload.Body in
-  let open Deferred.Let_syntax in
-  let%bind source_pk = pk_of_pk_id pool source_id in
-  let%map receiver_pk = pk_of_pk_id pool receiver_id in
-  let token_id = Token_id.of_uint64 (Unsigned.UInt64.of_int64 tok) in
-  let amount =
-    Option.map amount
-      ~f:(Fn.compose Currency.Amount.of_uint64 Unsigned.UInt64.of_int64)
-  in
-  (* possibilities from user_command_type enum in SQL schema *)
-  (* TODO: handle "snapp" user commands *)
-  match type_ with
-  | "payment" ->
-      if Option.is_none amount then
-        failwithf "Payment at global slot since genesis %Ld has NULL amount"
-          global_slot_since_genesis () ;
-      let amount = Option.value_exn amount in
-      Payment Payment_payload.Poly.{ source_pk; receiver_pk; token_id; amount }
-  | "delegation" ->
-      Stake_delegation
-        (Stake_delegation.Set_delegate
-           { delegator = source_pk; new_delegate = receiver_pk })
-  | "create_token" ->
-      Create_new_token
-        { New_token_payload.token_owner_pk = source_pk
-        ; disable_new_accounts = false
-        }
-  | "create_account" ->
-      Create_token_account
-        { New_account_payload.token_id
-        ; token_owner_pk = source_pk
-        ; receiver_pk
-        ; account_disabled = false
-        }
-  | "mint_tokens" ->
-      if Option.is_none amount then
-        failwithf "Mint token at global slot since genesis %Ld has NULL amount"
-          global_slot_since_genesis () ;
-      let amount = Option.value_exn amount in
-      Mint_tokens
-        { Minting_payload.token_id
-        ; token_owner_pk = source_pk
-        ; receiver_pk
-        ; amount
-        }
-  | _ ->
-      failwithf "Invalid user command type: %s" type_ ()
+module User_command_helpers = struct
+  let body_of_sql_user_cmd pool
+      ({ type_
+       ; source_id
+       ; receiver_id
+       ; token = tok
+       ; amount
+       ; global_slot_since_genesis
+       ; _
+       } :
+        Sql.User_command.t) : Signed_command_payload.Body.t Deferred.t =
+    let open Signed_command_payload.Body in
+    let open Deferred.Let_syntax in
+    let%bind source_pk = pk_of_pk_id pool source_id in
+    let%map receiver_pk = pk_of_pk_id pool receiver_id in
+    let token_id = Token_id.of_uint64 (Unsigned.UInt64.of_int64 tok) in
+    let amount =
+      Option.map amount
+        ~f:(Fn.compose Currency.Amount.of_uint64 Unsigned.UInt64.of_int64)
+    in
+    (* possibilities from user_command_type enum in SQL schema *)
+    match type_ with
+    | "payment" ->
+        if Option.is_none amount then
+          failwithf "Payment at global slot since genesis %Ld has NULL amount"
+            global_slot_since_genesis () ;
+        let amount = Option.value_exn amount in
+        Payment
+          Payment_payload.Poly.{ source_pk; receiver_pk; token_id; amount }
+    | "delegation" ->
+        Stake_delegation
+          (Stake_delegation.Set_delegate
+             { delegator = source_pk; new_delegate = receiver_pk })
+    | "create_token" ->
+        Create_new_token
+          { New_token_payload.token_owner_pk = source_pk
+          ; disable_new_accounts = false
+          }
+    | "create_account" ->
+        Create_token_account
+          { New_account_payload.token_id
+          ; token_owner_pk = source_pk
+          ; receiver_pk
+          ; account_disabled = false
+          }
+    | "mint_tokens" ->
+        if Option.is_none amount then
+          failwithf
+            "Mint token at global slot since genesis %Ld has NULL amount"
+            global_slot_since_genesis () ;
+        let amount = Option.value_exn amount in
+        Mint_tokens
+          { Minting_payload.token_id
+          ; token_owner_pk = source_pk
+          ; receiver_pk
+          ; amount
+          }
+    | _ ->
+        failwithf "Invalid user command type: %s" type_ ()
+end
 
 let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t)
     ~continue_on_error =
@@ -650,7 +622,7 @@ let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t)
     "Applying user command (%s) with nonce %Ld, global slot since genesis %Ld, \
      and sequence number %d"
     cmd.type_ cmd.nonce cmd.global_slot_since_genesis cmd.sequence_no ;
-  let%bind body = body_of_sql_user_cmd pool cmd in
+  let%bind body = User_command_helpers.body_of_sql_user_cmd pool cmd in
   let%bind fee_payer_pk = pk_of_pk_id pool cmd.fee_payer_id in
   let memo = Signed_command_memo.of_string cmd.memo in
   let valid_until =
@@ -703,7 +675,7 @@ let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t)
             cmd.token
       in
       let%bind () =
-        match cmd.source_balance with
+        match cmd.source_balance_id with
         | Some balance_id ->
             verify_balance ~logger ~pool ~ledger ~who:"source" ~balance_id
               ~pk_id:cmd.source_id ~token_int64 ~continue_on_error
@@ -711,7 +683,7 @@ let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t)
             return ()
       in
       let%bind () =
-        match cmd.receiver_balance with
+        match cmd.receiver_balance_id with
         | Some balance_id ->
             verify_balance ~logger ~pool ~ledger ~who:"receiver" ~balance_id
               ~pk_id:cmd.receiver_id ~token_int64 ~continue_on_error
@@ -719,10 +691,733 @@ let run_user_command ~logger ~pool ~ledger (cmd : Sql.User_command.t)
             return ()
       in
       verify_balance ~logger ~pool ~ledger ~who:"fee payer"
-        ~balance_id:cmd.fee_payer_balance ~pk_id:cmd.fee_payer_id
+        ~balance_id:cmd.fee_payer_balance_id ~pk_id:cmd.fee_payer_id
         ~token_int64:cmd.fee_token ~continue_on_error
   | Error err ->
       Error.tag_arg err "User command failed on replay"
+        ( ("global slot_since_genesis", cmd.global_slot_since_genesis)
+        , ("sequence number", cmd.sequence_no) )
+        [%sexp_of: (string * int64) * (string * int)]
+      |> Error.raise
+
+module Snapp_helpers = struct
+  let get_parent_state_view ~pool block_id :
+      (* when a Snapp is applied, use the protocol state associated with the parent block
+         of the block containing the transaction
+      *)
+      Snapp_predicate.Protocol_state.View.t Deferred.t =
+    let%bind parent_id =
+      query_db pool
+        ~f:(fun db -> Sql.Block.get_parent_id db block_id)
+        ~item:"block parent id"
+    in
+    let%bind parent_block =
+      query_db pool
+        ~f:(fun db -> Processor.Block.load db ~id:parent_id)
+        ~item:"parent block"
+    in
+    let%bind snarked_ledger_hash_str =
+      query_db pool
+        ~f:(fun db ->
+          Sql.Snarked_ledger_hashes.run db parent_block.snarked_ledger_hash_id)
+        ~item:"parent block snarked ledger hash"
+    in
+    let snarked_ledger_hash =
+      Frozen_ledger_hash.of_base58_check_exn snarked_ledger_hash_str
+    in
+    let snarked_next_available_token =
+      parent_block.next_available_token |> Unsigned.UInt64.of_int64
+      |> Token_id.of_uint64
+    in
+    let timestamp = parent_block.timestamp |> Block_time.of_int64 in
+    let blockchain_length =
+      parent_block.height |> Unsigned.UInt32.of_int64
+      |> Mina_numbers.Length.of_uint32
+    in
+    let min_window_density =
+      parent_block.min_window_density |> Unsigned.UInt32.of_int64
+      |> Mina_numbers.Length.of_uint32
+    in
+    (* TODO : this will change *)
+    let last_vrf_output = () in
+    let total_currency =
+      parent_block.total_currency |> Unsigned.UInt64.of_int64
+      |> Currency.Amount.of_uint64
+    in
+    let global_slot_since_hard_fork =
+      parent_block.global_slot_since_hard_fork |> Unsigned.UInt32.of_int64
+      |> Mina_numbers.Global_slot.of_uint32
+    in
+    let global_slot_since_genesis =
+      parent_block.global_slot_since_genesis |> Unsigned.UInt32.of_int64
+      |> Mina_numbers.Global_slot.of_uint32
+    in
+    let epoch_data_of_raw_epoch_data (raw_epoch_data : Processor.Epoch_data.t) :
+        Mina_base.Epoch_data.Value.t Deferred.t =
+      let%bind hash_str =
+        query_db pool
+          ~f:(fun db ->
+            Sql.Snarked_ledger_hashes.run db raw_epoch_data.ledger_hash_id)
+          ~item:"epoch ledger hash"
+      in
+      let hash = Frozen_ledger_hash.of_base58_check_exn hash_str in
+      let total_currency =
+        raw_epoch_data.total_currency |> Unsigned.UInt64.of_int64
+        |> Currency.Amount.of_uint64
+      in
+      let ledger = { Mina_base.Epoch_ledger.Poly.hash; total_currency } in
+      let seed = raw_epoch_data.seed |> Epoch_seed.of_base58_check_exn in
+      let start_checkpoint =
+        raw_epoch_data.start_checkpoint |> State_hash.of_base58_check_exn
+      in
+      let lock_checkpoint =
+        raw_epoch_data.lock_checkpoint |> State_hash.of_base58_check_exn
+      in
+      let epoch_length =
+        raw_epoch_data.epoch_length |> Unsigned.UInt32.of_int64
+        |> Mina_numbers.Length.of_uint32
+      in
+      return
+        { Mina_base.Epoch_data.Poly.ledger
+        ; seed
+        ; start_checkpoint
+        ; lock_checkpoint
+        ; epoch_length
+        }
+    in
+    let%bind staking_epoch_raw =
+      query_db pool
+        ~f:(fun db ->
+          Processor.Epoch_data.load db parent_block.staking_epoch_data_id)
+        ~item:"staking epoch data"
+    in
+    let%bind (staking_epoch_data : Mina_base.Epoch_data.Value.t) =
+      epoch_data_of_raw_epoch_data staking_epoch_raw
+    in
+    let%bind next_epoch_raw =
+      query_db pool
+        ~f:(fun db ->
+          Processor.Epoch_data.load db parent_block.staking_epoch_data_id)
+        ~item:"staking epoch data"
+    in
+    let%bind next_epoch_data = epoch_data_of_raw_epoch_data next_epoch_raw in
+    return
+      { Snapp_predicate.Protocol_state.Poly.snarked_ledger_hash
+      ; snarked_next_available_token
+      ; timestamp
+      ; blockchain_length
+      ; min_window_density
+      ; last_vrf_output
+      ; total_currency
+      ; global_slot_since_hard_fork
+      ; global_slot_since_genesis
+      ; staking_epoch_data
+      ; next_epoch_data
+      }
+
+  let get_field_arrays ~pool array_id_arrays =
+    let array_ids = Array.to_list array_id_arrays in
+    Deferred.List.map array_ids ~f:(fun array_id ->
+        let%bind element_id_array =
+          query_db pool
+            ~f:(fun db -> Processor.Snapp_state_data_array.load db array_id)
+            ~item:"Snapp state data array"
+        in
+        let element_ids = Array.to_list element_id_array in
+        let%bind field_strs =
+          Deferred.List.map element_ids ~f:(fun elt_id ->
+              query_db pool ~item:"Snapp field element" ~f:(fun db ->
+                  Processor.Snapp_state_data.load db elt_id))
+        in
+        let fields =
+          List.map field_strs ~f:(fun field_str ->
+              Snark_params.Tick.Field.of_string field_str)
+        in
+        return (Array.of_list fields))
+
+  let state_data_of_ids ~pool ids =
+    Deferred.Array.map ids ~f:(fun state_data_id ->
+        match state_data_id with
+        | None ->
+            return None
+        | Some id ->
+            let%map field_str =
+              query_db pool
+                ~f:(fun db -> Processor.Snapp_state_data.load db id)
+                ~item:"Snapp state data"
+            in
+            Some (Snark_params.Tick.Field.of_string field_str))
+
+  let party_body_of_id ~pool body_id =
+    let%bind (body_data : Processor.Snapp_party_body.t) =
+      query_db pool
+        ~f:(fun db -> Processor.Snapp_party_body.load db body_id)
+        ~item:"Snapp party body"
+    in
+    let%bind pk = pk_of_pk_id pool body_data.public_key_id in
+    let%bind update_data =
+      query_db pool
+        ~f:(fun db -> Processor.Snapp_updates.load db body_data.update_id)
+        ~item:"snapp updates"
+    in
+    let%bind app_state_data_ids =
+      query_db pool
+        ~f:(fun db -> Processor.Snapp_states.load db update_data.app_state_id)
+        ~item:"snapp app state ids"
+    in
+    let%bind app_state_data = state_data_of_ids ~pool app_state_data_ids in
+    let app_state =
+      Array.map app_state_data ~f:Snapp_basic.Set_or_keep.of_option
+      |> Array.to_list |> Pickles_types.Vector.Vector_8.of_list_exn
+    in
+    let%bind delegate =
+      match update_data.delegate_id with
+      | Some id ->
+          let%map pk = pk_of_pk_id pool id in
+          Snapp_basic.Set_or_keep.Set pk
+      | None ->
+          return Snapp_basic.Set_or_keep.Keep
+    in
+    let%bind verification_key =
+      match update_data.verification_key_id with
+      | Some id ->
+          let%map ({ verification_key; hash }
+                    : Processor.Snapp_verification_keys.t) =
+            query_db pool
+              ~f:(fun db -> Processor.Snapp_verification_keys.load db id)
+              ~item:"snapp verification key"
+          in
+          let data =
+            Pickles.Side_loaded.Verification_key.of_base58_check_exn
+              verification_key
+          in
+          let hash = Snark_params.Tick.Field.of_string hash in
+          Snapp_basic.Set_or_keep.Set { With_hash.data; hash }
+      | None ->
+          return Snapp_basic.Set_or_keep.Keep
+    in
+    let%bind permissions =
+      match update_data.permissions_id with
+      | Some id ->
+          let%map perms_data =
+            query_db pool
+              ~f:(fun db -> Processor.Snapp_permissions.load db id)
+              ~item:"snapp verification key"
+          in
+          let perms : Mina_base.Permissions.t =
+            { stake = perms_data.stake
+            ; edit_state = perms_data.edit_state
+            ; send = perms_data.send
+            ; receive = perms_data.receive
+            ; set_delegate = perms_data.set_delegate
+            ; set_permissions = perms_data.set_permissions
+            ; set_verification_key = perms_data.set_verification_key
+            ; set_snapp_uri = perms_data.set_snapp_uri
+            ; edit_sequence_state = perms_data.edit_sequence_state
+            ; set_token_symbol = perms_data.set_token_symbol
+            ; increment_nonce = perms_data.increment_nonce
+            }
+          in
+          Snapp_basic.Set_or_keep.Set perms
+      | None ->
+          return Snapp_basic.Set_or_keep.Keep
+    in
+    let snapp_uri =
+      update_data.snapp_uri |> Snapp_basic.Set_or_keep.of_option
+    in
+    let token_symbol =
+      update_data.token_symbol |> Snapp_basic.Set_or_keep.of_option
+    in
+    let%bind timing =
+      match update_data.timing_id with
+      | None ->
+          return Snapp_basic.Set_or_keep.Keep
+      | Some id ->
+          let%map tm_info =
+            query_db pool
+              ~f:(fun db -> Processor.Snapp_timing_info.load db id)
+              ~item:"snapp timing info"
+          in
+          Snapp_basic.Set_or_keep.Set
+            { Party.Update.Timing_info.initial_minimum_balance =
+                tm_info.initial_minimum_balance |> Unsigned.UInt64.of_int64
+                |> Currency.Balance.of_uint64
+            ; cliff_time =
+                tm_info.cliff_time |> Unsigned.UInt32.of_int64
+                |> Mina_numbers.Global_slot.of_uint32
+            ; cliff_amount =
+                tm_info.cliff_amount |> Unsigned.UInt64.of_int64
+                |> Currency.Amount.of_uint64
+            ; vesting_period =
+                tm_info.vesting_period |> Unsigned.UInt32.of_int64
+                |> Mina_numbers.Global_slot.of_uint32
+            ; vesting_increment =
+                tm_info.vesting_increment |> Unsigned.UInt64.of_int64
+                |> Currency.Amount.of_uint64
+            }
+    in
+    let update : Party.Update.t =
+      { app_state
+      ; delegate
+      ; verification_key
+      ; permissions
+      ; snapp_uri
+      ; token_symbol
+      ; timing
+      }
+    in
+    let token_id =
+      body_data.token_id |> Unsigned.UInt64.of_int64 |> Token_id.of_uint64
+    in
+    let balance_change =
+      let magnitude =
+        body_data.balance_change |> Int64.abs |> Unsigned.UInt64.of_int64
+        |> Currency.Amount.of_uint64
+      in
+      let sgn =
+        if Int64.is_negative body_data.balance_change then Sgn.Neg else Sgn.Pos
+      in
+      Currency.Signed_poly.{ magnitude; sgn }
+    in
+    let increment_nonce = body_data.increment_nonce in
+    let%bind events = get_field_arrays ~pool body_data.events_ids in
+    let%bind sequence_events =
+      get_field_arrays ~pool body_data.sequence_events_ids
+    in
+    let%bind call_data_str =
+      query_db pool
+        ~f:(fun db -> Processor.Snapp_state_data.load db body_data.call_data_id)
+        ~item:"Snapp call data"
+    in
+    let call_data = Snark_params.Tick.Field.of_string call_data_str in
+    let call_depth = body_data.call_depth in
+    let%bind protocol_state_data =
+      query_db pool
+        ~f:(fun db ->
+          Processor.Snapp_predicate_protocol_states.load db
+            body_data.snapp_predicate_protocol_state_id)
+        ~item:"Snapp predicate protocol state"
+    in
+    let%bind snarked_ledger_hash =
+      match protocol_state_data.snarked_ledger_hash_id with
+      | None ->
+          return Snapp_predicate.Hash.Ignore
+      | Some id ->
+          let%map hash_str =
+            query_db pool ~item:"snarked ledger hash" ~f:(fun db ->
+                Processor.Snarked_ledger_hash.load db id)
+          in
+          Snapp_predicate.Hash.Check
+            (Frozen_ledger_hash.of_base58_check_exn hash_str)
+    in
+    let%bind snarked_next_available_token =
+      match protocol_state_data.snarked_next_available_token_id with
+      | None ->
+          return Snapp_basic.Or_ignore.Ignore
+      | Some id ->
+          let%map bounds =
+            query_db pool ~item:"Snapp token id bounds" ~f:(fun db ->
+                Processor.Snapp_token_id_bounds.load db id)
+          in
+          let to_token_id i64 =
+            i64 |> Unsigned.UInt64.of_int64 |> Token_id.of_uint64
+          in
+          let lower = to_token_id bounds.token_id_lower_bound in
+          let upper = to_token_id bounds.token_id_upper_bound in
+          Snapp_basic.Or_ignore.Check
+            Snapp_predicate.Closed_interval.{ lower; upper }
+    in
+    let%bind timestamp =
+      match protocol_state_data.timestamp_id with
+      | None ->
+          return Snapp_basic.Or_ignore.Ignore
+      | Some id ->
+          let%map bounds =
+            query_db pool ~item:"Snapp timestamp bounds" ~f:(fun db ->
+                Processor.Snapp_timestamp_bounds.load db id)
+          in
+          let to_timestamp i64 = i64 |> Block_time.of_int64 in
+          let lower = to_timestamp bounds.timestamp_lower_bound in
+          let upper = to_timestamp bounds.timestamp_upper_bound in
+          Snapp_basic.Or_ignore.Check
+            Snapp_predicate.Closed_interval.{ lower; upper }
+    in
+    let length_bounds_of_id = function
+      | None ->
+          return Snapp_basic.Or_ignore.Ignore
+      | Some id ->
+          let%map bounds =
+            query_db pool ~item:"Snapp length bounds" ~f:(fun db ->
+                Processor.Snapp_length_bounds.load db id)
+          in
+          let to_length i64 =
+            i64 |> Unsigned.UInt32.of_int64 |> Mina_numbers.Length.of_uint32
+          in
+          let lower = to_length bounds.length_lower_bound in
+          let upper = to_length bounds.length_upper_bound in
+          Snapp_basic.Or_ignore.Check
+            Snapp_predicate.Closed_interval.{ lower; upper }
+    in
+    let%bind blockchain_length =
+      length_bounds_of_id protocol_state_data.blockchain_length_id
+    in
+    let%bind min_window_density =
+      length_bounds_of_id protocol_state_data.min_window_density_id
+    in
+    let total_currency_of_id = function
+      | None ->
+          return Snapp_basic.Or_ignore.Ignore
+      | Some id ->
+          let%map bounds =
+            query_db pool ~item:"Snapp currency bounds" ~f:(fun db ->
+                Processor.Snapp_amount_bounds.load db id)
+          in
+          let to_amount i64 =
+            i64 |> Unsigned.UInt64.of_int64 |> Currency.Amount.of_uint64
+          in
+          let lower = to_amount bounds.amount_lower_bound in
+          let upper = to_amount bounds.amount_upper_bound in
+          Snapp_basic.Or_ignore.Check
+            Snapp_predicate.Closed_interval.{ lower; upper }
+    in
+    (* TODO: this will change *)
+    let last_vrf_output = () in
+    let%bind total_currency =
+      total_currency_of_id protocol_state_data.total_currency_id
+    in
+    let global_slot_of_id = function
+      | None ->
+          return Snapp_basic.Or_ignore.Ignore
+      | Some id ->
+          let%map bounds =
+            query_db pool ~item:"Snapp global slot bounds" ~f:(fun db ->
+                Processor.Snapp_global_slot_bounds.load db id)
+          in
+          let to_slot i64 =
+            i64 |> Unsigned.UInt32.of_int64
+            |> Mina_numbers.Global_slot.of_uint32
+          in
+          let lower = to_slot bounds.global_slot_lower_bound in
+          let upper = to_slot bounds.global_slot_upper_bound in
+          Snapp_basic.Or_ignore.Check
+            Snapp_predicate.Closed_interval.{ lower; upper }
+    in
+    let%bind global_slot_since_hard_fork =
+      global_slot_of_id protocol_state_data.curr_global_slot_since_hard_fork
+    in
+    let%bind global_slot_since_genesis =
+      global_slot_of_id protocol_state_data.global_slot_since_genesis
+    in
+    let epoch_data_of_id id =
+      let%bind epoch_data_raw =
+        query_db pool ~item:"Snapp epoch data" ~f:(fun db ->
+            Processor.Snapp_epoch_data.load db id)
+      in
+      let%bind ledger =
+        let%bind epoch_ledger_data =
+          query_db pool ~item:"Snapp epoch ledger" ~f:(fun db ->
+              Processor.Snapp_epoch_ledger.load db id)
+        in
+        let%bind hash =
+          Option.value_map epoch_ledger_data.hash_id
+            ~default:(return Snapp_basic.Or_ignore.Ignore) ~f:(fun id ->
+              let%map hash_str =
+                query_db pool ~item:"Snapp epoch ledger hash" ~f:(fun db ->
+                    Processor.Snarked_ledger_hash.load db id)
+              in
+              Snapp_basic.Or_ignore.Check
+                (Frozen_ledger_hash.of_base58_check_exn hash_str))
+        in
+        let%map total_currency =
+          total_currency_of_id epoch_ledger_data.total_currency_id
+        in
+        { Epoch_ledger.Poly.hash; total_currency }
+      in
+      let seed =
+        Option.value_map epoch_data_raw.epoch_seed
+          ~default:Snapp_basic.Or_ignore.Ignore ~f:(fun s ->
+            Snapp_basic.Or_ignore.Check (Epoch_seed.of_base58_check_exn s))
+      in
+      let checkpoint_of_str str =
+        Option.value_map str ~default:Snapp_basic.Or_ignore.Ignore ~f:(fun s ->
+            Snapp_basic.Or_ignore.Check (State_hash.of_base58_check_exn s))
+      in
+      let start_checkpoint =
+        checkpoint_of_str epoch_data_raw.start_checkpoint
+      in
+      let lock_checkpoint = checkpoint_of_str epoch_data_raw.lock_checkpoint in
+      let%map epoch_length =
+        length_bounds_of_id epoch_data_raw.epoch_length_id
+      in
+      { Snapp_predicate.Protocol_state.Epoch_data.Poly.ledger
+      ; seed
+      ; start_checkpoint
+      ; lock_checkpoint
+      ; epoch_length
+      }
+    in
+    let%bind staking_epoch_data =
+      epoch_data_of_id protocol_state_data.staking_epoch_data_id
+    in
+    let%bind next_epoch_data =
+      epoch_data_of_id protocol_state_data.next_epoch_data_id
+    in
+    let protocol_state : Snapp_predicate.Protocol_state.t =
+      { snarked_ledger_hash
+      ; snarked_next_available_token
+      ; timestamp
+      ; blockchain_length
+      ; min_window_density
+      ; last_vrf_output
+      ; total_currency
+      ; global_slot_since_hard_fork
+      ; global_slot_since_genesis
+      ; staking_epoch_data
+      ; next_epoch_data
+      }
+    in
+    let use_full_commitment = body_data.use_full_commitment in
+    return
+      ( { pk
+        ; update
+        ; token_id
+        ; balance_change
+        ; increment_nonce
+        ; events
+        ; sequence_events
+        ; call_data
+        ; call_depth
+        ; protocol_state
+        ; use_full_commitment
+        }
+        : Party.Body.t )
+
+  (* fee payer body is like a party body, except the balance change is a fee, not signed,
+     and some fields are placeholders with the unit value
+  *)
+  let fee_payer_body_of_id ~pool body_id =
+    let%map body = party_body_of_id ~pool body_id in
+    let balance_change =
+      match body.balance_change with
+      | { magnitude; sgn = Sgn.Pos } ->
+          Currency.Amount.to_uint64 magnitude |> Currency.Fee.of_uint64
+      | _ ->
+          failwith
+            "fee_payer_body_of_id: expected positive balance change for fee \
+             payer"
+    in
+    ( { pk = body.pk
+      ; update = body.update
+      ; token_id = ()
+      ; balance_change
+      ; increment_nonce = ()
+      ; events = body.events
+      ; sequence_events = body.sequence_events
+      ; call_data = body.call_data
+      ; call_depth = body.call_depth
+      ; protocol_state = body.protocol_state
+      ; use_full_commitment = ()
+      }
+      : Party.Body.Fee_payer.t )
+end
+
+let parties_of_snapp_command ~pool (cmd : Sql.Snapp_command.t) :
+    Parties.t Deferred.t =
+  let%bind fee_payer_data =
+    query_db pool
+      ~f:(fun db -> Processor.Snapp_fee_payers.load db cmd.fee_payer_id)
+      ~item:"Snapp fee payer"
+  in
+  let%bind (fee_payer : Party.Fee_payer.t) =
+    let%bind (data : Party.Predicated.Fee_payer.t) =
+      let%bind (body : Party.Body.Fee_payer.t) =
+        Snapp_helpers.fee_payer_body_of_id ~pool fee_payer_data.body_id
+      in
+      let predicate =
+        fee_payer_data.nonce |> Unsigned.UInt32.of_int64
+        |> Mina_numbers.Account_nonce.of_uint32
+      in
+      return { Party.Predicated.Poly.body; predicate }
+    in
+    return { Party.Fee_payer.data; authorization = Signature.dummy }
+  in
+  let%bind (other_parties : Party.t list) =
+    Deferred.List.map (Array.to_list cmd.other_party_ids) ~f:(fun id ->
+        let%bind snapp_party_data =
+          query_db pool
+            ~f:(fun db -> Processor.Snapp_party.load db id)
+            ~item:"Snapp party"
+        in
+        let%bind (data : Party.Predicated.t) =
+          let%bind (body : Party.Body.t) =
+            Snapp_helpers.party_body_of_id ~pool snapp_party_data.body_id
+          in
+          let%bind (predicate : Party.Predicate.t) =
+            let%bind predicate_data =
+              query_db pool ~item:"Snapp predicate" ~f:(fun db ->
+                  Processor.Snapp_predicate.load db
+                    snapp_party_data.predicate_id)
+            in
+            match predicate_data.kind with
+            | Full ->
+                let%bind snapp_account_data =
+                  match predicate_data.account_id with
+                  | None ->
+                      failwith "Expected account id for predicate of kind Full"
+                  | Some account_id ->
+                      query_db pool ~item:"Snapp account" ~f:(fun db ->
+                          Processor.Snapp_account.load db account_id)
+                in
+                let%map snapp_account =
+                  let%bind balance =
+                    match snapp_account_data.balance_id with
+                    | None ->
+                        return Snapp_basic.Or_ignore.Ignore
+                    | Some balance_id ->
+                        let%map bounds =
+                          query_db pool ~item:"Snapp balance" ~f:(fun db ->
+                              Processor.Snapp_balance_bounds.load db balance_id)
+                        in
+                        let to_balance i64 =
+                          i64 |> Unsigned.UInt64.of_int64
+                          |> Currency.Balance.of_uint64
+                        in
+                        let lower = to_balance bounds.balance_lower_bound in
+                        let upper = to_balance bounds.balance_upper_bound in
+                        Snapp_basic.Or_ignore.Check
+                          Snapp_predicate.Closed_interval.{ lower; upper }
+                  in
+                  let%bind nonce =
+                    match snapp_account_data.nonce_id with
+                    | None ->
+                        return Snapp_basic.Or_ignore.Ignore
+                    | Some balance_id ->
+                        let%map bounds =
+                          query_db pool ~item:"Snapp nonce" ~f:(fun db ->
+                              Processor.Snapp_nonce_bounds.load db balance_id)
+                        in
+                        let to_nonce i64 =
+                          i64 |> Unsigned.UInt32.of_int64
+                          |> Mina_numbers.Account_nonce.of_uint32
+                        in
+                        let lower = to_nonce bounds.nonce_lower_bound in
+                        let upper = to_nonce bounds.nonce_upper_bound in
+                        Snapp_basic.Or_ignore.Check
+                          Snapp_predicate.Closed_interval.{ lower; upper }
+                  in
+                  let receipt_chain_hash =
+                    Option.value_map snapp_account_data.receipt_chain_hash
+                      ~default:Snapp_basic.Or_ignore.Ignore ~f:(fun s ->
+                        Snapp_basic.Or_ignore.Check
+                          (Receipt.Chain_hash.of_base58_check_exn s))
+                  in
+                  let pk_check_or_ignore_of_id id =
+                    Option.value_map id
+                      ~default:(return Snapp_basic.Or_ignore.Ignore)
+                      ~f:(fun pk_id ->
+                        let%map pk = pk_of_pk_id pool pk_id in
+                        Snapp_basic.Or_ignore.Check pk)
+                  in
+                  let%bind public_key =
+                    pk_check_or_ignore_of_id snapp_account_data.public_key_id
+                  in
+                  let%bind delegate =
+                    pk_check_or_ignore_of_id snapp_account_data.delegate_id
+                  in
+                  let%bind state =
+                    let%bind snapp_state_ids =
+                      query_db pool ~item:"Snapp state id" ~f:(fun db ->
+                          Processor.Snapp_states.load db
+                            snapp_account_data.state_id)
+                    in
+                    let%map state_data =
+                      Snapp_helpers.state_data_of_ids ~pool snapp_state_ids
+                    in
+                    Array.map state_data ~f:Snapp_basic.Or_ignore.of_option
+                    |> Array.to_list
+                    |> Pickles_types.Vector.Vector_8.of_list_exn
+                  in
+                  let%bind sequence_state =
+                    Option.value_map snapp_account_data.sequence_state_id
+                      ~default:(return Snapp_basic.Or_ignore.Ignore)
+                      ~f:(fun state_id ->
+                        let%map state_data_str =
+                          query_db pool ~item:"Snapp state data" ~f:(fun db ->
+                              Processor.Snapp_state_data.load db state_id)
+                        in
+                        let state_data =
+                          Pickles.Backend.Tick.Field.of_string state_data_str
+                        in
+                        Snapp_basic.Or_ignore.Check state_data)
+                  in
+                  let proved_state =
+                    Option.value_map snapp_account_data.proved_state
+                      ~default:Snapp_basic.Or_ignore.Ignore ~f:(fun b ->
+                        Snapp_basic.Or_ignore.Check b)
+                  in
+                  return
+                    ( { balance
+                      ; nonce
+                      ; receipt_chain_hash
+                      ; public_key
+                      ; delegate
+                      ; state
+                      ; sequence_state
+                      ; proved_state
+                      }
+                      : Snapp_predicate.Account.t )
+                in
+                Party.Predicate.Full snapp_account
+            | Nonce -> (
+                match predicate_data.nonce with
+                | None ->
+                    failwith "Expected nonce for predicate of kind Nonce"
+                | Some nonce ->
+                    return
+                      (Party.Predicate.Nonce
+                         (Mina_numbers.Account_nonce.of_uint32
+                            (Unsigned.UInt32.of_int64 nonce))) )
+            | Accept ->
+                return Party.Predicate.Accept
+          in
+          return ({ body; predicate } : Party.Predicated.t)
+        in
+        let authorization =
+          (* dummy proof, signature, don't affect replay *)
+          match snapp_party_data.authorization_kind with
+          | Control.Tag.Proof ->
+              let n2 = Pickles_types.Nat.N2.n in
+              let proof = Pickles.Proof.dummy n2 n2 n2 in
+              Control.Proof proof
+          | Control.Tag.Signature ->
+              Control.Signature Signature.dummy
+          | Control.Tag.None_given ->
+              Control.None_given
+        in
+        return ({ data; authorization } : Party.t))
+  in
+  (* memo contents don't affect ability to replay snapp *)
+  let memo = Mina_base.Signed_command_memo.dummy in
+  return ({ fee_payer; other_parties; memo } : Parties.t)
+
+let run_snapp_command ~logger ~pool ~ledger ~continue_on_error:_
+    (cmd : Sql.Snapp_command.t) =
+  [%log info]
+    "Applying Snapp command at global slot since genesis %Ld, and sequence \
+     number %d"
+    cmd.global_slot_since_genesis cmd.sequence_no ;
+  let%bind state_view =
+    Snapp_helpers.get_parent_state_view ~pool cmd.block_id
+  in
+  let%bind parties = parties_of_snapp_command ~pool cmd in
+  match
+    Ledger.apply_parties_unchecked ~constraint_constants ~state_view ledger
+      parties
+  with
+  | Ok _ ->
+      Deferred.unit
+  | Error err ->
+      Error.tag_arg err "Snapp command failed on replay"
         ( ("global slot_since_genesis", cmd.global_slot_since_genesis)
         , ("sequence number", cmd.sequence_no) )
         [%sexp_of: (string * int64) * (string * int)]
@@ -874,37 +1569,38 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
           "Block chain leading to target state hash does not include genesis \
            block" ;
         Core_kernel.exit 1 ) ;
-      [%log info] "Loading user command ids" ;
-      let%bind user_cmd_ids =
+      let get_command_ids (module Command_ids : Get_command_ids) name =
         match%bind
           Caqti_async.Pool.use
-            (fun db -> Sql.User_command_ids.run db target_state_hash)
+            (fun db -> Command_ids.run db target_state_hash)
             pool
         with
         | Ok ids ->
             return ids
         | Error msg ->
-            [%log error] "Error getting user command ids"
+            [%log error] "Error getting %s command ids" name
               ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
             exit 1
       in
       [%log info] "Loading internal command ids" ;
       let%bind internal_cmd_ids =
-        match%bind
-          Caqti_async.Pool.use
-            (fun db -> Sql.Internal_command_ids.run db target_state_hash)
-            pool
-        with
-        | Ok ids ->
-            return ids
-        | Error msg ->
-            [%log error] "Error getting user command ids"
-              ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
-            exit 1
+        get_command_ids (module Sql.Internal_command_ids) "internal"
       in
-      [%log info] "Obtained %d user command ids and %d internal command ids"
+      [%log info] "Loading user command ids" ;
+      let%bind user_cmd_ids =
+        get_command_ids (module Sql.User_command_ids) "user"
+      in
+      [%log info] "Loading Snapp command ids" ;
+      let%bind snapp_cmd_ids =
+        return []
+        (*        get_command_ids (module Sql.Snapp_command_ids) "Snapp" *)
+      in
+      [%log info]
+        "Obtained %d user command ids, %d internal command ids, and %d Snapp \
+         command ids"
         (List.length user_cmd_ids)
-        (List.length internal_cmd_ids) ;
+        (List.length internal_cmd_ids)
+        (List.length snapp_cmd_ids) ;
       [%log info] "Loading internal commands" ;
       let%bind unsorted_internal_cmds_list =
         Deferred.List.map internal_cmd_ids ~f:(fun id ->
@@ -986,10 +1682,42 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
             in
             [%compare: int64 * int] (tuple uc1) (tuple uc2))
       in
+      [%log info] "Loading Snapp commands" ;
+      let%bind unsorted_snapp_cmds_list =
+        Deferred.List.map snapp_cmd_ids ~f:(fun id ->
+            let open Deferred.Let_syntax in
+            match%map
+              Caqti_async.Pool.use (fun db -> Sql.Snapp_command.run db id) pool
+            with
+            | Ok [] ->
+                failwithf "Expected at least one Snapp command with id %d" id ()
+            | Ok snapp_cmds ->
+                snapp_cmds
+            | Error msg ->
+                failwithf
+                  "Error querying for Snapp commands with id %d, error %s" id
+                  (Caqti_error.show msg) ())
+      in
+      let unsorted_snapp_cmds = List.concat unsorted_snapp_cmds_list in
+      let filtered_snapp_cmds =
+        List.filter unsorted_snapp_cmds ~f:(fun (cmd : Sql.Snapp_command.t) ->
+            Int64.( >= ) cmd.global_slot_since_genesis
+              input.start_slot_since_genesis
+            && Int.Set.mem block_ids cmd.block_id)
+      in
+      let sorted_snapp_cmds =
+        List.sort filtered_snapp_cmds ~compare:(fun sc1 sc2 ->
+            let tuple (sc : Sql.Snapp_command.t) =
+              (sc.global_slot_since_genesis, sc.sequence_no)
+            in
+            [%compare: int64 * int] (tuple sc1) (tuple sc2))
+      in
       (* apply commands in global slot, sequence order *)
       let rec apply_commands (internal_cmds : Sql.Internal_command.t list)
-          (user_cmds : Sql.User_command.t list) ~last_global_slot_since_genesis
-          ~last_block_id ~staking_epoch_ledger ~next_epoch_ledger =
+          (user_cmds : Sql.User_command.t list)
+          (snapp_cmds : Sql.Snapp_command.t list)
+          ~last_global_slot_since_genesis ~last_block_id ~staking_epoch_ledger
+          ~next_epoch_ledger =
         let%bind staking_epoch_ledger, staking_seed =
           update_staking_epoch_data ~logger pool ~last_block_id ~ledger
             ~staking_epoch_ledger
@@ -1058,7 +1786,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                 apply_combined_fee_transfer ~logger ~pool ~ledger
                   ~continue_on_error ic ic2
               in
-              apply_commands ics2 user_cmds
+              apply_commands ics2 user_cmds snapp_cmds
                 ~last_global_slot_since_genesis:ic.global_slot_since_genesis
                 ~last_block_id:ic.block_id ~staking_epoch_ledger
                 ~next_epoch_ledger
@@ -1067,49 +1795,114 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
               let%bind () =
                 run_internal_command ~logger ~pool ~ledger ~continue_on_error ic
               in
-              apply_commands ics user_cmds
+              apply_commands ics user_cmds snapp_cmds
                 ~last_global_slot_since_genesis:ic.global_slot_since_genesis
                 ~last_block_id:ic.block_id ~staking_epoch_ledger
                 ~next_epoch_ledger
         in
-        (* choose command with least global slot since genesis, sequence number *)
-        let cmp_ic_uc (ic : Sql.Internal_command.t) (uc : Sql.User_command.t) =
-          [%compare: int64 * int]
-            (ic.global_slot_since_genesis, ic.sequence_no)
-            (uc.global_slot_since_genesis, uc.sequence_no)
+        (* a sequence is a command type, slot, sequence number triple *)
+        let get_internal_cmd_sequence (ic : Sql.Internal_command.t) =
+          (`Internal_command, ic.global_slot_since_genesis, ic.sequence_no)
         in
-        match (internal_cmds, user_cmds) with
-        | [], [] ->
+        let get_user_cmd_sequence (uc : Sql.User_command.t) =
+          (`User_command, uc.global_slot_since_genesis, uc.sequence_no)
+        in
+        let get_snapp_cmd_sequence (sc : Sql.Snapp_command.t) =
+          (`Snapp_command, sc.global_slot_since_genesis, sc.sequence_no)
+        in
+        let command_type_of_sequences seqs =
+          let compare (_cmd_ty1, slot1, seq_no1) (_cmd_ty2, slot2, seq_no2) =
+            [%compare: int64 * int] (slot1, seq_no1) (slot2, seq_no2)
+          in
+          let sorted_seqs = List.sort seqs ~compare in
+          let cmd_ty, _slot, _seq_no = List.hd_exn sorted_seqs in
+          cmd_ty
+        in
+        let run_user_commands (uc : Sql.User_command.t) ucs =
+          log_on_slot_change uc.global_slot_since_genesis ;
+          let%bind () =
+            run_user_command ~logger ~pool ~ledger ~continue_on_error uc
+          in
+          apply_commands internal_cmds ucs snapp_cmds
+            ~last_global_slot_since_genesis:uc.global_slot_since_genesis
+            ~last_block_id:uc.block_id ~staking_epoch_ledger ~next_epoch_ledger
+        in
+        let run_snapp_commands (sc : Sql.Snapp_command.t) scs =
+          log_on_slot_change sc.global_slot_since_genesis ;
+          let%bind () =
+            run_snapp_command ~logger ~pool ~ledger ~continue_on_error sc
+          in
+          apply_commands internal_cmds user_cmds scs
+            ~last_global_slot_since_genesis:sc.global_slot_since_genesis
+            ~last_block_id:sc.block_id ~staking_epoch_ledger ~next_epoch_ledger
+        in
+        match (internal_cmds, user_cmds, snapp_cmds) with
+        | [], [], [] ->
+            (* all done *)
             log_ledger_hash_after_last_slot () ;
             Deferred.return
               (staking_epoch_ledger, staking_seed, next_epoch_ledger, next_seed)
-        | [], uc :: ucs ->
-            log_on_slot_change uc.global_slot_since_genesis ;
-            let%bind () =
-              run_user_command ~logger ~pool ~ledger ~continue_on_error uc
-            in
-            apply_commands [] ucs
-              ~last_global_slot_since_genesis:uc.global_slot_since_genesis
-              ~last_block_id:uc.block_id ~staking_epoch_ledger
-              ~next_epoch_ledger
-        | ic :: _, uc :: ucs when cmp_ic_uc ic uc > 0 ->
-            log_on_slot_change uc.global_slot_since_genesis ;
-            let%bind () =
-              run_user_command ~logger ~pool ~ledger ~continue_on_error uc
-            in
-            apply_commands internal_cmds ucs
-              ~last_global_slot_since_genesis:uc.global_slot_since_genesis
-              ~last_block_id:uc.block_id ~staking_epoch_ledger
-              ~next_epoch_ledger
-        | ic :: ics, [] ->
+        | ic :: ics, [], [] ->
+            (* only internal commands *)
             combine_or_run_internal_cmds ic ics
-        | ic :: ics, uc :: _ when cmp_ic_uc ic uc < 0 ->
-            combine_or_run_internal_cmds ic ics
-        | ic :: _, _ :: __ ->
-            failwithf
-              "An internal command and a user command have the same global \
-               slot since_genesis %Ld and sequence number %d"
-              ic.global_slot_since_genesis ic.sequence_no ()
+        | [], uc :: ucs, [] ->
+            (* only user commands *)
+            run_user_commands uc ucs
+        | [], [], sc :: scs ->
+            (* only Snapp commands *)
+            run_snapp_commands sc scs
+        | [], uc :: ucs, sc :: scs -> (
+            (* no internal commands *)
+            let seqs =
+              [ get_user_cmd_sequence uc; get_snapp_cmd_sequence sc ]
+            in
+            match command_type_of_sequences seqs with
+            | `User_command ->
+                run_user_commands uc ucs
+            | `Snapp_command ->
+                run_snapp_commands sc scs )
+        | ic :: ics, [], sc :: scs -> (
+            (* no user commands *)
+            let seqs =
+              [ get_internal_cmd_sequence ic; get_snapp_cmd_sequence sc ]
+            in
+            match command_type_of_sequences seqs with
+            | `Internal_command ->
+                combine_or_run_internal_cmds ic ics
+            | `Snapp_command ->
+                run_snapp_commands sc scs )
+        | ic :: ics, uc :: ucs, [] -> (
+            (* no Snapp commands *)
+            let seqs =
+              [ get_internal_cmd_sequence ic; get_user_cmd_sequence uc ]
+            in
+            match command_type_of_sequences seqs with
+            | `Internal_command ->
+                combine_or_run_internal_cmds ic ics
+            | `User_command ->
+                run_user_commands uc ucs )
+        | ic :: ics, uc :: ucs, sc :: scs -> (
+            (* internal, user, and Snapp commands *)
+            let seqs =
+              [ get_internal_cmd_sequence ic
+              ; get_user_cmd_sequence uc
+              ; get_snapp_cmd_sequence sc
+              ]
+            in
+            match command_type_of_sequences seqs with
+            | `Internal_command ->
+                combine_or_run_internal_cmds ic ics
+            | `User_command ->
+                log_on_slot_change uc.global_slot_since_genesis ;
+                let%bind () =
+                  run_user_command ~logger ~pool ~ledger ~continue_on_error uc
+                in
+                apply_commands internal_cmds ucs scs
+                  ~last_global_slot_since_genesis:uc.global_slot_since_genesis
+                  ~last_block_id:uc.block_id ~staking_epoch_ledger
+                  ~next_epoch_ledger
+            | `Snapp_command ->
+                run_snapp_commands sc scs )
       in
       let%bind unparented_ids =
         query_db pool
@@ -1128,7 +1921,7 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
         ~metadata:[ ("ledger_hash", json_ledger_hash_of_ledger ledger) ] ;
       let%bind staking_epoch_ledger, staking_seed, next_epoch_ledger, next_seed
           =
-        apply_commands sorted_internal_cmds sorted_user_cmds
+        apply_commands sorted_internal_cmds sorted_user_cmds sorted_snapp_cmds
           ~last_global_slot_since_genesis:input.start_slot_since_genesis
           ~last_block_id:genesis_block_id ~staking_epoch_ledger:ledger
           ~next_epoch_ledger:ledger

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -12,11 +12,8 @@ module Block_info = struct
   [@@deriving hlist]
 
   let typ =
-    let open Mina_caqti.Type_spec in
-    let spec = Caqti_type.[ int; int64; string; string ] in
-    let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
-    let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
-    Caqti_type.custom ~encode ~decode (to_rep spec)
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.[ int; int64; string; string ]
 
   (* find all blocks, working back from block with given state hash *)
   let query =
@@ -79,6 +76,15 @@ module Block = struct
 
   let get_state_hash (module Conn : Caqti_async.CONNECTION) id =
     Conn.find state_hash_query id
+
+  let parent_id_query =
+    Caqti_request.find Caqti_type.int Caqti_type.int
+      {sql| SELECT parent_id FROM blocks
+            WHERE id = ?
+      |sql}
+
+  let get_parent_id (module Conn : Caqti_async.CONNECTION) id =
+    Conn.find parent_id_query id
 
   let unparented_query =
     Caqti_request.collect Caqti_type.unit Caqti_type.int
@@ -155,15 +161,14 @@ module User_command = struct
     ; sequence_no : int
     ; status : string
     ; created_token : int64 option
-    ; fee_payer_balance : int
-    ; source_balance : int option
-    ; receiver_balance : int option
+    ; fee_payer_balance_id : int
+    ; source_balance_id : int option
+    ; receiver_balance_id : int option
     }
   [@@deriving hlist]
 
   let typ =
-    let open Mina_caqti.Type_spec in
-    let spec =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
       Caqti_type.
         [ string
         ; int
@@ -186,10 +191,6 @@ module User_command = struct
         ; option int
         ; option int
         ]
-    in
-    let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
-    let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
-    Caqti_type.custom ~encode ~decode (to_rep spec)
 
   let query =
     Caqti_request.collect Caqti_type.int typ
@@ -218,6 +219,103 @@ module User_command = struct
     Conn.collect_list query user_cmd_id
 end
 
+module Snapp_command_ids = struct
+  let query =
+    Caqti_request.collect Caqti_type.string Caqti_type.int
+      (find_command_ids_query "snapp")
+
+  let run (module Conn : Caqti_async.CONNECTION) state_hash =
+    Conn.collect_list query state_hash
+end
+
+module Snapp_command = struct
+  type t =
+    { fee_payer_id : int
+    ; other_party_ids : int array
+    ; predicate_protocol_state_id : int
+    ; block_id : int
+    ; global_slot_since_genesis : int64
+    ; txn_global_slot_since_genesis : int64
+    ; sequence_no : int
+    ; fee_payer_balance_id : int
+    ; hash : string
+    }
+  [@@deriving hlist]
+
+  let typ =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.
+        [ int
+        ; Mina_caqti.array_int_typ
+        ; int
+        ; int
+        ; int64
+        ; int64
+        ; int
+        ; int
+        ; string
+        ]
+
+  let query =
+    Caqti_request.collect Caqti_type.int typ
+      {sql| SELECT fee_payer_id,other_party_ids,predicate_protocol_state_id,
+                   blocks.id,blocks.global_slot_since_genesis,parent.global_slot_since_genesis,
+                   sequence_no,fee_payer_balance,hash
+
+            FROM (SELECT * FROM snapp_commands WHERE id = ?) AS sc
+
+            INNER JOIN blocks_snapp_commands AS bsc
+
+            ON sc.id = bsc.user_command_id
+
+            INNER JOIN blocks
+
+            ON blocks.id = bsc.block_id
+
+            INNER JOIN blocks as parent
+
+            ON parent.id = blocks.parent_id
+
+       |sql}
+
+  let run (module Conn : Caqti_async.CONNECTION) snapp_cmd_id =
+    Conn.collect_list query snapp_cmd_id
+end
+
+module Snapp_protocol_state = struct
+  type t =
+    { snarked_ledger_hash_id : int
+    ; snarked_next_available_token_id : int
+    ; timestamp_id : int
+    ; blockchain_length_id : int
+    ; min_window_density_id : int
+          (* omitting 'last_vrf_output', it's unit value in OCaml *)
+    ; total_currency_id : int
+    ; curr_global_slot_since_hard_fork : int
+    ; global_slot_since_genesis : int
+    ; staking_epoch_data_id : int
+    ; next_epoch_data : int
+    }
+  [@@deriving hlist]
+
+  let typ =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.[ int; int; int; int; int; int; int; int; int; int ]
+
+  let query =
+    Caqti_request.find Caqti_type.int typ
+      {sql| SELECT snarked_ledger_hash_id,snarked_next_available_token_id,
+                   timestamp_id,blockchain_length_id,
+                   min_window_density_id,total_currency_id,              ,
+                   curr_global_slot_since_hard_fork,global_slot_since_genesis,
+                   staking_epoch_data_id,next_epoch_data
+            FROM snapp_predicate_protocol_states
+            WHERE id = ?
+      |sql}
+
+  let run (module Conn : Caqti_async.CONNECTION) id = Conn.find query id
+end
+
 module Internal_command_ids = struct
   let query =
     Caqti_request.collect Caqti_type.string Caqti_type.int
@@ -231,7 +329,7 @@ module Internal_command = struct
   type t =
     { type_ : string
     ; receiver_id : int
-    ; receiver_balance : int
+    ; receiver_balance_id : int
     ; fee : int64
     ; token : int64
     ; block_id : int
@@ -244,8 +342,7 @@ module Internal_command = struct
   [@@deriving hlist]
 
   let typ =
-    let open Mina_caqti.Type_spec in
-    let spec =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
       Caqti_type.
         [ string
         ; int
@@ -259,10 +356,6 @@ module Internal_command = struct
         ; int
         ; int
         ]
-    in
-    let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
-    let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
-    Caqti_type.custom ~encode ~decode (to_rep spec)
 
   (* the transaction global slot since genesis is taken from the internal command's parent block, mirroring
      the call to Staged_ledger.apply in Block_producer
@@ -303,6 +396,16 @@ module Public_key = struct
 
   let run (module Conn : Caqti_async.CONNECTION) pk_id =
     Conn.find_opt query pk_id
+end
+
+module Snarked_ledger_hashes = struct
+  let query =
+    Caqti_request.find Caqti_type.int Caqti_type.string
+      {sql| SELECT value FROM snarked_ledger_hashes
+            WHERE id = ?
+      |sql}
+
+  let run (module Conn : Caqti_async.CONNECTION) id = Conn.find query id
 end
 
 module Epoch_data = struct

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -232,7 +232,6 @@ module Snapp_command = struct
   type t =
     { fee_payer_id : int
     ; other_party_ids : int array
-    ; predicate_protocol_state_id : int
     ; block_id : int
     ; global_slot_since_genesis : int64
     ; txn_global_slot_since_genesis : int64
@@ -245,20 +244,11 @@ module Snapp_command = struct
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
       Caqti_type.
-        [ int
-        ; Mina_caqti.array_int_typ
-        ; int
-        ; int
-        ; int64
-        ; int64
-        ; int
-        ; int
-        ; string
-        ]
+        [ int; Mina_caqti.array_int_typ; int; int64; int64; int; int; string ]
 
   let query =
     Caqti_request.collect Caqti_type.int typ
-      {sql| SELECT fee_payer_id,other_party_ids,predicate_protocol_state_id,
+      {sql| SELECT fee_payer_id,other_party_ids,
                    blocks.id,blocks.global_slot_since_genesis,parent.global_slot_since_genesis,
                    sequence_no,fee_payer_balance,hash
 
@@ -280,40 +270,6 @@ module Snapp_command = struct
 
   let run (module Conn : Caqti_async.CONNECTION) snapp_cmd_id =
     Conn.collect_list query snapp_cmd_id
-end
-
-module Snapp_protocol_state = struct
-  type t =
-    { snarked_ledger_hash_id : int
-    ; snarked_next_available_token_id : int
-    ; timestamp_id : int
-    ; blockchain_length_id : int
-    ; min_window_density_id : int
-          (* omitting 'last_vrf_output', it's unit value in OCaml *)
-    ; total_currency_id : int
-    ; curr_global_slot_since_hard_fork : int
-    ; global_slot_since_genesis : int
-    ; staking_epoch_data_id : int
-    ; next_epoch_data : int
-    }
-  [@@deriving hlist]
-
-  let typ =
-    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int; int; int; int; int; int; int; int; int; int ]
-
-  let query =
-    Caqti_request.find Caqti_type.int typ
-      {sql| SELECT snarked_ledger_hash_id,snarked_next_available_token_id,
-                   timestamp_id,blockchain_length_id,
-                   min_window_density_id,total_currency_id,              ,
-                   curr_global_slot_since_hard_fork,global_slot_since_genesis,
-                   staking_epoch_data_id,next_epoch_data
-            FROM snapp_predicate_protocol_states
-            WHERE id = ?
-      |sql}
-
-  let run (module Conn : Caqti_async.CONNECTION) id = Conn.find query id
 end
 
 module Internal_command_ids = struct

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -356,9 +356,7 @@ WITH RECURSIVE chain AS (
 
       let created_token t = t.created_token
 
-      let typ =
-        let open Mina_caqti.Type_spec in
-        let spec =
+      let typ = Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
           Caqti_type.
             [ string
             ; string
@@ -368,10 +366,6 @@ WITH RECURSIVE chain AS (
             ; option int64
             ; option int64
             ; option int64 ]
-        in
-        let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
-        let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
-        Caqti_type.custom ~encode ~decode (to_rep spec)
     end
 
     let typ =

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -514,6 +514,8 @@ module type S = sig
 
       val curr_global_slot : Value.t -> Mina_numbers.Global_slot.t
 
+      val total_currency : Value.t -> Amount.t
+
       val global_slot_since_genesis : Value.t -> Mina_numbers.Global_slot.t
 
       val global_slot_since_genesis_var :

--- a/src/lib/mina_base/epoch_data.ml
+++ b/src/lib/mina_base/epoch_data.ml
@@ -14,9 +14,8 @@ module Poly = struct
         { ledger : 'epoch_ledger
         ; seed : 'epoch_seed
         ; start_checkpoint : 'start_checkpoint
-              (* The lock checkpoint is the hash of the latest state in the seed update range,
-                 not including the current state.
-              *)
+              (* The lock checkpoint is the hash of the latest state in the seed update range, not including
+                 the current state. *)
         ; lock_checkpoint : 'lock_checkpoint
         ; epoch_length : 'length
         }

--- a/src/lib/mina_base/epoch_data.ml
+++ b/src/lib/mina_base/epoch_data.ml
@@ -14,8 +14,9 @@ module Poly = struct
         { ledger : 'epoch_ledger
         ; seed : 'epoch_seed
         ; start_checkpoint : 'start_checkpoint
-              (* The lock checkpoint is the hash of the latest state in the seed update range, not including
-                 the current state. *)
+              (* The lock checkpoint is the hash of the latest state in the seed update range,
+                 not including the current state.
+              *)
         ; lock_checkpoint : 'lock_checkpoint
         ; epoch_length : 'length
         }

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -414,7 +414,7 @@ module Body = struct
     end
   end]
 
-  (* * Delta for the fee payer is always going to be Neg, so represent it using
+  (* * Balance change for the fee payer is always going to be Neg, so represent it using
        an unsigned fee,
      * token id is always going to be the default, so use unit value as a
        placeholder,

--- a/src/lib/mina_base/snapp_predicate.ml
+++ b/src/lib/mina_base/snapp_predicate.ml
@@ -707,7 +707,7 @@ end
 
 module Protocol_state = struct
   (* On each numeric field, you may assert a range
-      On each hash field, you may assert an equality
+     On each hash field, you may assert an equality
   *)
 
   module Epoch_data = struct

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -149,7 +149,7 @@ let add_if_snapp_check (f : 'arg -> ('res, 'err) Deferred.Result.t) :
     'arg Snapp_basic.Or_ignore.t -> ('res option, 'err) Deferred.Result.t =
   Fn.compose (add_if_some f) Snapp_basic.Or_ignore.to_option
 
-(* `select_cols ~select:"s0" ~table_name:"t0" ["col0", "col1", ...]`
+(* `select_cols ~select:"s0" ~table_name:"t0" ~cols:["col0";"col1";...]`
    creates the string
    `"SELECT s0 FROM t0 WHERE col0 = ? AND col1 = ? AND..."`.
    The optional `tannot` function maps column names to type annotations. *)
@@ -164,15 +164,15 @@ let select_cols ~(select : string) ~(table_name : string)
   |> String.concat ~sep:" AND "
   |> sprintf "SELECT %s FROM %s WHERE %s" select table_name
 
-(* `select_cols_from_id ~table_name:"t0" ["col0", "col1", ...]`
+(* `select_cols_from_id ~table_name:"t0" ~cols:["col0";"col1";...]`
    creates the string
-   `"SELECT col0,col1,... FROM t0 WHERE id = ?"
+   `"SELECT col0,col1,... FROM t0 WHERE id = ?"`
 *)
 let select_cols_from_id ~(table_name : string) ~(cols : string list) : string =
   let comma_cols = String.concat cols ~sep:"," in
   sprintf "SELECT %s FROM %s WHERE id = ?" comma_cols table_name
 
-(* `insert_into_cols ~returning:ret0 ~table_name:t0 ["col0", "col1", ...]`
+(* `insert_into_cols ~returning:ret0 ~table_name:t0 ~cols:["col0";"col1";...]`
    creates the string
    `"INSERT INTO t0 (col0, col1, ...) VALUES (?, ?, ...) RETURNING ret0"`.
    The optional `tannot` function maps column names to type annotations.

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -41,6 +41,11 @@ module Type_spec = struct
          ([] : (unit, hlist) H_list.t)
      | _ :: spec, (x, t) ->
          x :: tuple_to_hlist spec t
+
+  let custom_type ~to_hlist ~of_hlist tys =
+    let encode t = Ok (hlist_to_tuple tys (to_hlist t)) in
+    let decode t = Ok (of_hlist (tuple_to_hlist tys t)) in
+    Caqti_type.custom ~encode ~decode (to_rep tys)
 end
 
 (* register coding for nullable int arrays.
@@ -158,6 +163,14 @@ let select_cols ~(select : string) ~(table_name : string)
       sprintf "%s = ?%s" col annot)
   |> String.concat ~sep:" AND "
   |> sprintf "SELECT %s FROM %s WHERE %s" select table_name
+
+(* `select_cols_from_id ~table_name:"t0" ["col0", "col1", ...]`
+   creates the string
+   `"SELECT col0,col1,... FROM t0 WHERE id = ?"
+*)
+let select_cols_from_id ~(table_name : string) ~(cols : string list) : string =
+  let comma_cols = String.concat cols ~sep:"," in
+  sprintf "SELECT %s FROM %s WHERE id = ?" comma_cols table_name
 
 (* `insert_into_cols ~returning:ret0 ~table_name:t0 ["col0", "col1", ...]`
    creates the string


### PR DESCRIPTION
Update the replayer to handle Snapp commands.

As before, the app replays commands ordered by global slot and sequence number. There are now three lists of commands, user commands, internal commands, and Snapp commands, so choosing the next command to run is a little more involved.

The function `run_snapp_command` runs the Snapp commands, by constructing a `state_view` from a parent block, and a `Parties.t`, then running `Ledger.apply_parties_unchecked`. 

To create the fee payer body in a `Parties.t`, we create an ordinary `Party.Body.t`, and substitute the fee and the unit value placeholders. That approach does more work than necessary, but allows reuse of code. Reviewers: too much of a hack?

There are some new db columns in `epoch_data` and `blocks`, needed to construct a state view when applying a Snapp.  Those additional columns show up as new fields in extensional blocks. Also added a column `increment_nonce` to `snapp_permissions` and `cliff_amount` to `snapp_timing_info` to match the corresponding OCaml types. Renamed column `global_slot` in `blocks` to `global_slot_since_hard_fork` to match OCaml code. Rename `next_epoch_data` to `next_epoch_data_id` in `snapp_predicate_protocol_states`, to match `staking_epoch_data_id`.

Added `Mina_caqti.select_cols_from_id` to make it easy to load a table row into an OCaml data structure. Added `Mina_caqti.Type_spec.custom_type` to capture a repeated pattern for creating custom types.

This code is untested, of course, because we don't yet have Snapp commands in a database.

Note: for Rosetta, we added chain statuses for blocks, and additional columns to `balances`. Those changes are not in this code. Presumably, everything will get added to `develop` or `compatible` at some point.





