### PR TITLE
Rosetta, making block queries deterministic

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -42,7 +42,7 @@ module Sql = struct
 
                 FROM blocks b
                 WHERE height = (select MAX(height) from blocks)
-                ORDER BY timestamp ASC
+                ORDER BY timestamp ASC, state_hash
                 LIMIT 1)
 
                 UNION ALL

--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -42,7 +42,7 @@ module Sql = struct
 
                 FROM blocks b
                 WHERE height = (select MAX(height) from blocks)
-                ORDER BY timestamp ASC, state_hash
+                ORDER BY timestamp ASC, state_hash ASC
                 LIMIT 1)
 
                 UNION ALL

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -293,7 +293,7 @@ SELECT c.id, c.state_hash, c.parent_id, c.parent_hash, c.creator_id, c.block_win
         {|
 WITH RECURSIVE chain AS (
   (SELECT id, state_hash, parent_id, parent_hash, creator_id, block_winner_id, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id, ledger_hash, height, global_slot, global_slot_since_genesis, timestamp, chain_status FROM blocks b WHERE height = (select MAX(height) from blocks)
-  ORDER BY timestamp ASC, state_hash
+  ORDER BY timestamp ASC, state_hash ASC
   LIMIT 1)
 
   UNION ALL
@@ -346,7 +346,7 @@ WITH RECURSIVE chain AS (
            INNER JOIN public_keys bw
            ON bw.id = b.block_winner_id
            WHERE b.height = (select MAX(b.height) from blocks b)
-           ORDER BY timestamp ASC, state_hash
+           ORDER BY timestamp ASC, state_hash ASC
            LIMIT 1 |}
 
     let run_by_id (module Conn : Caqti_async.CONNECTION) id =

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -293,7 +293,7 @@ SELECT c.id, c.state_hash, c.parent_id, c.parent_hash, c.creator_id, c.block_win
         {|
 WITH RECURSIVE chain AS (
   (SELECT id, state_hash, parent_id, parent_hash, creator_id, block_winner_id, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id, ledger_hash, height, global_slot, global_slot_since_genesis, timestamp, chain_status FROM blocks b WHERE height = (select MAX(height) from blocks)
-  ORDER BY timestamp ASC
+  ORDER BY timestamp ASC, state_hash
   LIMIT 1)
 
   UNION ALL
@@ -346,7 +346,7 @@ WITH RECURSIVE chain AS (
            INNER JOIN public_keys bw
            ON bw.id = b.block_winner_id
            WHERE b.height = (select MAX(b.height) from blocks b)
-           ORDER BY timestamp ASC
+           ORDER BY timestamp ASC, state_hash
            LIMIT 1 |}
 
     let run_by_id (module Conn : Caqti_async.CONNECTION) id =

--- a/src/app/rosetta/lib/network.ml
+++ b/src/app/rosetta/lib/network.ml
@@ -37,7 +37,7 @@ module Sql = struct
   let oldest_block_query =
     Caqti_request.find Caqti_type.unit
       Caqti_type.(tup2 int64 string)
-      "SELECT height, state_hash FROM blocks ORDER BY timestamp ASC LIMIT 1"
+      "SELECT height, state_hash FROM blocks ORDER BY timestamp ASC, state_hash LIMIT 1"
 
   let latest_block_query =
     Caqti_request.find

--- a/src/app/rosetta/lib/network.ml
+++ b/src/app/rosetta/lib/network.ml
@@ -37,7 +37,7 @@ module Sql = struct
   let oldest_block_query =
     Caqti_request.find Caqti_type.unit
       Caqti_type.(tup2 int64 string)
-      "SELECT height, state_hash FROM blocks ORDER BY timestamp ASC, state_hash LIMIT 1"
+      "SELECT height, state_hash FROM blocks ORDER BY timestamp ASC, state_hash ASC LIMIT 1"
 
   let latest_block_query =
     Caqti_request.find
@@ -45,7 +45,7 @@ module Sql = struct
       Caqti_type.(tup3 int64 string int64)
       {sql| SELECT height, state_hash, timestamp FROM blocks b
             WHERE height = (select MAX(height) from blocks)
-            ORDER BY timestamp ASC
+            ORDER BY timestamp ASC, state_hash ASC
             LIMIT 1
       |sql}
 end


### PR DESCRIPTION
In Rosetta, several of the queries for blocks order results by timestamp, but timestamps are not unique.

For those queries, add `state_hash` as an additional field to qualify the ordering. The ordering of state hashes is arbitrary, of course, but makes these queries deterministic.
