### PR TITLE
Rosetta, limit max height of block queries

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -359,11 +359,6 @@ WITH RECURSIVE chain AS (
       in
       Int64.(>) num_canonical_at_height Int64.zero
 
-    let max_height_delta =
-      match Sys.getenv "MINA_ROSETTA_MAX_HEIGHT_DELTA" with
-      | Some n -> Int64.of_string n
-      | None -> 0L
-
     let run (module Conn : Caqti_async.CONNECTION) = function
       | Some (`This (`Height h)) ->
         let open Deferred.Result.Let_syntax in
@@ -375,7 +370,7 @@ WITH RECURSIVE chain AS (
               (Caqti_request.find Caqti_type.unit Caqti_type.int64
                  {sql| SELECT MAX(height) FROM blocks |sql}) ()
           in
-          let max_queryable_height = Int64.(-) max_height max_height_delta in
+          let max_queryable_height = Int64.(-) max_height Network.Sql.max_height_delta in
           if Int64.(<=) h max_queryable_height then
             Conn.find_opt query_height_pending h
           else

--- a/src/app/rosetta/lib/network.ml
+++ b/src/app/rosetta/lib/network.ml
@@ -39,15 +39,20 @@ module Sql = struct
       Caqti_type.(tup2 int64 string)
       "SELECT height, state_hash FROM blocks ORDER BY timestamp ASC, state_hash ASC LIMIT 1"
 
+  let max_height_delta =
+    match Sys.getenv "MINA_ROSETTA_MAX_HEIGHT_DELTA" with
+    | Some n -> Int64.of_string n
+    | None -> 0L
+
   let latest_block_query =
     Caqti_request.find
       Caqti_type.unit
       Caqti_type.(tup3 int64 string int64)
-      {sql| SELECT height, state_hash, timestamp FROM blocks b
-            WHERE height = (select MAX(height) from blocks)
-            ORDER BY timestamp ASC, state_hash ASC
-            LIMIT 1
-      |sql}
+      (sprintf {sql| SELECT height, state_hash, timestamp FROM blocks b
+                     WHERE height = (select MAX(height) - %Ld FROM blocks)
+                     ORDER BY timestamp ASC, state_hash ASC
+                     LIMIT 1
+               |sql} max_height_delta)
 end
 
 let sync_status_to_string = function


### PR DESCRIPTION
In Rosetta, allow use of environment variable `MINA_ROSETTA_MAX_HEIGHT_DELTA` to limit the maximum height of block queries. 

Let `d` be the value of that variable. If the maximum height of blocks is `h` in the archive db, then a query for a block of height greater than `h - d` will return `None`.

This change affects not only direct `block` queries, but also `account/balance` queries, both of which call `Block.run`. In both cases, the `None` becomes the `Block_missing` error.

The environment variable is also used to determine the height of the latest block in the `/network/status/` endpoint.

If the environment variable is absent, a zero value is used for the delta.

The purpose of this change is to disallow queries for blocks near the tip, whose ultimate chain status is uncertain.
