### PR TITLE
Use hash-based message id function

### DIFF
--- a/src/app/libp2p_helper/Makefile
+++ b/src/app/libp2p_helper/Makefile
@@ -12,7 +12,7 @@ libp2p_helper: ../../libp2p_ipc/libp2p_ipc.capnp.go
 	$(WRAPAPP) ../../../scripts/build-go-helper.sh libp2p_helper
 
 test: ../../libp2p_ipc/libp2p_ipc.capnp.go
-	cd src/libp2p_helper && $(GO) test -short -timeout 15m
+	cd src/libp2p_helper && $(GO) test -short -timeout 40m
 
 test-bs-qc: ../../libp2p_ipc/libp2p_ipc.capnp.go
 	cd src/libp2p_helper \

--- a/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
@@ -15,7 +15,9 @@ import (
 	peerstore "github.com/libp2p/go-libp2p-core/peerstore"
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/multiformats/go-multiaddr"
+	"golang.org/x/crypto/blake2b"
 )
 
 type BeginAdvertisingReqT = ipc.Libp2pHelperInterface_BeginAdvertising_Request
@@ -137,6 +139,13 @@ func configurePubsub(app *app, validationQueueSize int, directPeers []peer.AddrI
 			pubsub.WithMaxMessageSize(1024 * 1024 * 32),
 			pubsub.WithDirectPeers(directPeers),
 			pubsub.WithValidateQueueSize(validationQueueSize),
+			pubsub.WithMessageIdFn(func(pmsg *pb.Message) string {
+				hash, err := blake2b.New256([]byte(pmsg.GetTopic()))
+				panicOnErr(err)
+				_, err = hash.Write(pmsg.GetData())
+				panicOnErr(err)
+				return string(hash.Sum(nil))
+			}),
 		}, opts...)...,
 	)
 	app.P2p.Pubsub = ps

--- a/src/app/libp2p_helper/src/libp2p_helper/message_id_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/message_id_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/stretchr/testify/require"
+)
+
+// This file contains test for the use of message id function
+
+func TestPubsubMsgIdFun(t *testing.T) {
+	newProtocol := "/mina/97"
+	var mask uint32 = upcallDropAllMask ^ (1 << IncomingStreamChan) ^ (1 << GossipReceivedChan)
+	errChan := make(chan error, 3)
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	handleErrChan(t, errChan, ctxCancel)
+
+	alice, appAPort := newTestApp(t, nil, false)
+	alice.SetConnectionHandlers()
+	appAInfos, err := addrInfos(alice.P2p.Host)
+	require.NoError(t, err)
+	trapA := newUpcallTrap("a", 64, mask)
+	launchFeedUpcallTrap(alice.P2p.Logger, alice.OutChan, trapA, errChan, ctx)
+	testAddStreamHandlerDo(t, newProtocol, alice, 10990)
+
+	bob, _ := newTestApp(t, appAInfos, false)
+	trapB := newUpcallTrap("b", 64, mask)
+	launchFeedUpcallTrap(bob.P2p.Logger, bob.OutChan, trapB, errChan, ctx)
+	err = bob.P2p.Host.Connect(bob.Ctx, appAInfos[0])
+	require.NoError(t, err)
+
+	carol, _ := newTestApp(t, appAInfos, false)
+	trapC := newUpcallTrap("c", 64, mask)
+	launchFeedUpcallTrap(carol.P2p.Logger, carol.OutChan, trapC, errChan, ctx)
+	err = carol.P2p.Host.Connect(carol.Ctx, appAInfos[0])
+	require.NoError(t, err)
+
+	gossipSubp := pubsub.DefaultGossipSubParams()
+	gossipSubp.D = 4
+	gossipSubp.Dlo = 2
+	gossipSubp.Dhi = 6
+	require.NoError(t, configurePubsub(alice, 100, nil, pubsub.WithGossipSubParams(gossipSubp)))
+	require.NoError(t, configurePubsub(bob, 100, nil, pubsub.WithGossipSubParams(gossipSubp)))
+	require.NoError(t, configurePubsub(carol, 100, nil, pubsub.WithGossipSubParams(gossipSubp)))
+
+	// Subscribe to the topic
+	topic := "test"
+	testSubscribeDo(t, alice, topic, 21, 58)
+	testSubscribeDo(t, bob, topic, 21, 58)
+	testSubscribeDo(t, carol, topic, 21, 58)
+
+	_ = testOpenStreamDo(t, bob, alice.P2p.Host, appAPort, 9900, string(newProtocol))
+	_ = testOpenStreamDo(t, carol, alice.P2p.Host, appAPort, 9900, string(newProtocol))
+	<-trapA.IncomingStream
+	<-trapA.IncomingStream
+
+	msg := []byte("hello world")
+	testPublishDo(t, alice, topic, msg, 21)
+	testPublishDo(t, bob, topic, msg, 21)
+
+	time.Sleep(time.Millisecond * 100)
+
+	n := 0
+loop:
+	for {
+		select {
+		case <-trapC.GossipReceived:
+		default:
+			break loop
+		}
+		n++
+	}
+	require.Equal(t, 1, n)
+}

--- a/src/app/libp2p_helper/src/libp2p_helper/multinode_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/multinode_test.go
@@ -80,20 +80,7 @@ func initNodes(t *testing.T, numNodes int, upcallMask uint32) ([]testNode, []con
 		nodes[ni].node = node
 		nodes[ni].trap = trap
 	}
-	go func() {
-		err, has := <-errChan
-		if has {
-			topCtxCancel()
-			errChan <- err
-		}
-	}()
-	t.Cleanup(func() {
-		topCtxCancel()
-		close(errChan)
-		for err := range errChan {
-			t.Errorf("feed upcall trap failed with %s", err)
-		}
-	})
+	handleErrChan(t, errChan, topCtxCancel)
 	return nodes, cancels
 }
 

--- a/src/app/libp2p_helper/src/libp2p_helper/multinode_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/multinode_test.go
@@ -107,9 +107,9 @@ func connectRingTopology(t *testing.T, nodes []testNode, protect bool) {
 	})
 }
 
-func testBroadcast(t *testing.T, nodes []testNode, senderIx int, timeout time.Duration) {
+func testBroadcast(t *testing.T, iterationIx int, nodes []testNode, senderIx int, timeout time.Duration) {
 	nodes[senderIx].node.P2p.Logger.Infof("Sending broadcast message")
-	msg := []byte("bla")
+	msg := []byte(fmt.Sprintf("broadcast message %d", iterationIx))
 	testPublishDo(t, nodes[senderIx].node, "test", msg, 102)
 	ctx, cancelF := context.WithTimeout(context.Background(), timeout)
 	defer cancelF()
@@ -378,6 +378,6 @@ func TestBroadcastInNotFullConnectedNetwork(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		time.Sleep(11 * time.Second)
 		trimConnections(nodes)
-		testBroadcast(t, nodes, r.Intn(len(nodes)), 2*time.Minute)
+		testBroadcast(t, i, nodes, r.Intn(len(nodes)), 2*time.Minute)
 	}
 }

--- a/src/app/libp2p_helper/src/libp2p_helper/upcall_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/upcall_test.go
@@ -211,13 +211,7 @@ func TestUpcalls(t *testing.T) {
 	errChan := make(chan error, 3)
 	ctx, cancelF := context.WithCancel(context.Background())
 
-	t.Cleanup(func() {
-		cancelF()
-		close(errChan)
-		for err := range errChan {
-			t.Errorf("feedUpcallTrap failed with %s", err)
-		}
-	})
+	handleErrChan(t, errChan, cancelF)
 
 	launchFeedUpcallTrap(alice.P2p.Logger, alice.OutChan, aTrap, errChan, ctx)
 	launchFeedUpcallTrap(bob.P2p.Logger, bob.OutChan, bTrap, errChan, ctx)

--- a/src/app/libp2p_helper/src/libp2p_helper/util_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/util_test.go
@@ -66,7 +66,7 @@ func newTestAppWithMaxConnsAndCtx(t *testing.T, privkey crypto.PrivKey, seeds []
 		minConns,
 		maxConns,
 		minaPeerExchange,
-		10 * time.Second,
+		10*time.Second,
 	)
 	require.NoError(t, err)
 
@@ -248,4 +248,21 @@ func withCustomTimeoutAsync(registerDone func(done chan interface{}), timeout ti
 	case <-done:
 		return true
 	}
+}
+
+func handleErrChan(t *testing.T, errChan chan error, ctxCancel context.CancelFunc) {
+	go func() {
+		err, has := <-errChan
+		if has {
+			ctxCancel()
+			errChan <- err
+		}
+	}()
+	t.Cleanup(func() {
+		ctxCancel()
+		close(errChan)
+		for err := range errChan {
+			t.Errorf("failed with %s", err)
+		}
+	})
 }


### PR DESCRIPTION
Problem: default message id function used for pubsub is
based on public key of the message creator and some nonce.
Hence, it is possible for the same message to appear twice on the same
topic provided it was sent by different creators.
This might be problematic for some types of gossip, especially in the
light of forecoming softfork introducing a versioning mechanism for
pubsub topics.

Solution: use hash-based message id function.

Explain how you tested your changes:
* a new unit test is added, which would be failing without the other changes in the PR

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues?  Closes #9876
