### PR TITLE
New "packed" random oracle input type

### DIFF
--- a/buildkite/scripts/replayer-test.sh
+++ b/buildkite/scripts/replayer-test.sh
@@ -36,4 +36,6 @@ cd /workdir
 
 echo "Running replayer"
 mina-replayer --archive-uri postgres://postgres:$PGPASSWORD@localhost:5432/archive \
-	      --input-file $TEST_DIR/input.json --output-file /dev/null
+	      --input-file $TEST_DIR/input.json --output-file /dev/null \
+          --continue-on-error # DO NOT MERGE
+exit 1

--- a/buildkite/scripts/replayer-test.sh
+++ b/buildkite/scripts/replayer-test.sh
@@ -36,6 +36,4 @@ cd /workdir
 
 echo "Running replayer"
 mina-replayer --archive-uri postgres://postgres:$PGPASSWORD@localhost:5432/archive \
-	      --input-file $TEST_DIR/input.json --output-file /dev/null \
-          --continue-on-error # DO NOT MERGE
-exit 1
+	      --input-file $TEST_DIR/input.json --output-file /dev/null

--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -84,10 +84,10 @@ let _ =
              Mina_base_nonconsensus.Signed_command.sign_payload sk dummy_payload
            in
            let message =
-             Mina_base_nonconsensus.Signed_command.to_input dummy_payload
+             Mina_base_nonconsensus.Signed_command.to_input_legacy dummy_payload
            in
            let verified =
-             Schnorr.verify signature
+             Schnorr.Legacy.verify signature
                (Snark_params_nonconsensus.Inner_curve.of_affine pk)
                message
            in

--- a/src/app/client_sdk/poseidon_hash.ml
+++ b/src/app/client_sdk/poseidon_hash.ml
@@ -89,7 +89,7 @@ module Hash = struct
   let hash ?init = hash ?init params
 
   let pack_input =
-    Random_oracle_input.pack_to_fields ~size_in_bits:Field.size_in_bits
+    Random_oracle_input.Legacy.pack_to_fields ~size_in_bits:Field.size_in_bits
       ~pack:Field.project
 end
 
@@ -110,7 +110,7 @@ let hash_bytearray (bytearray : u8_array_js) : string_js =
   let string_to_bitstring s =
     let char_bits = String_sign.char_bits in
     let x = Stdlib.(Array.of_seq (Seq.map char_bits (String.to_seq s))) in
-    Random_oracle_input.bitstrings x
+    Random_oracle_input.Legacy.bitstrings x
   in
   let input = Js_of_ocaml.Typed_array.String.of_uint8Array bytearray in
   let input =

--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -572,7 +572,7 @@ module Payloads = struct
           partial_user_command
         |> env.lift
       in
-      let random_oracle_input = Signed_command.to_input user_command_payload in
+      let random_oracle_input = Signed_command.to_input_legacy user_command_payload in
       let%map unsigned_transaction_string =
         { Transaction.Unsigned.random_oracle_input
         ; command = partial_user_command

--- a/src/app/rosetta/lib/signer.ml
+++ b/src/app/rosetta/lib/signer.ml
@@ -58,7 +58,7 @@ let sign ~(keys : Keys.t) ~unsigned_transaction_string =
   (* TODO: Should we use the signer_input explicitly here to dogfood it? *)
   (* Should we just inline that here? *)
   let signature =
-    Schnorr.sign keys.keypair.private_key
+    Schnorr.Legacy.sign keys.keypair.private_key
       unsigned_transaction.random_oracle_input
   in
   let signature' =
@@ -92,7 +92,7 @@ let verify ~public_key_hex_bytes ~signed_transaction_string =
     |> Result.ok
     |> Option.value_exn ~here:[%here] ?error:None ?message:None
   in
-  let message = Signed_command.to_input user_command_payload in
-  Schnorr.verify signature
+  let message = Signed_command.to_input_legacy user_command_payload in
+  Schnorr.Legacy.verify signature
     (Snark_params.Tick.Inner_curve.of_affine public_key)
     message

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -36,13 +36,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     { default with
       requires_graphql = true
     ; block_producers =
-        [ { balance = "4000"; timing = Untimed }
-        ; { balance = "3000"; timing = Untimed }
-        ; { balance = "1000"
+        [ { balance = "40000"; timing = Untimed }
+        ; { balance = "30000"; timing = Untimed }
+        ; { balance = "10000"
           ; timing =
-              make_timing ~min_balance:100_000_000_000 ~cliff_time:8
+              make_timing ~min_balance:1_000_000_000_000 ~cliff_time:8
                 ~cliff_amount:0 ~vesting_period:4
-                ~vesting_increment:50_000_000_000
+                ~vesting_increment:500_000_000_000
           }
         ]
     ; num_snark_workers = 0
@@ -64,7 +64,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section "send a single payment between 2 untimed accounts"
-        (let amount = Currency.Amount.of_int 200_000_000 in
+        (let amount = Currency.Amount.of_int 2_000_000_000 in
          let fee = Currency.Fee.of_int 10_000_000 in
          let receiver = untimed_node_a in
          let%bind receiver_pub_key = Util.pub_key_of_node receiver in
@@ -80,7 +80,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section "send a single payment from timed account using available liquid"
-        (let amount = Currency.Amount.of_int 300_000_000_000 in
+        (let amount = Currency.Amount.of_int 3_000_000_000_000 in
          let receiver = untimed_node_a in
          let%bind receiver_pub_key = Util.pub_key_of_node receiver in
          let sender = timed_node_a in
@@ -94,7 +94,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
               ~receiver_pub_key ~amount))
     in
     section "unable to send payment from timed account using illiquid tokens"
-      (let amount = Currency.Amount.of_int 600_000_000_000 in
+      (let amount = Currency.Amount.of_int 6_000_000_000_000 in
        let receiver = untimed_node_b in
        let%bind receiver_pub_key = Util.pub_key_of_node receiver in
        let sender = timed_node_a in

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -94,7 +94,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
               ~receiver_pub_key ~amount))
     in
     section "unable to send payment from timed account using illiquid tokens"
-      (let amount = Currency.Amount.of_int 6_000_000_000_000 in
+      (let amount = Currency.Amount.of_int 6_900_000_000_000 in
        let receiver = untimed_node_b in
        let%bind receiver_pub_key = Util.pub_key_of_node receiver in
        let sender = timed_node_a in

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -113,10 +113,20 @@ module Time = struct
   module Bits = Bits.UInt64
   include B.Snarkable.UInt64 (Tick)
 
+  let to_input (t : t) =
+    Random_oracle.Input.Chunked.packeds
+      (Array.of_list
+         (List.map (Bits.to_bits t) ~f:(fun b ->
+              ((if b then Tick.Field.one else Tick.Field.zero), 1))))
+
   module Checked = struct
     type t = Unpacked.var
 
     module N = Mina_numbers.Nat.Make_checked (UInt64) (Bits)
+
+    let to_input (t : t) =
+      Random_oracle.Input.Chunked.packeds
+        (Array.of_list (List.map t ~f:(fun b -> ((b :> Tick.Field.Var.t), 1))))
 
     let op f (x : t) (y : t) : (Boolean.var, 'a) Checked.t =
       let g = Fn.compose N.of_bits Unpacked.var_to_bits in
@@ -179,6 +189,21 @@ module Time = struct
     let min = UInt64.min
 
     let zero = UInt64.zero
+
+    let to_input (t : t) =
+      Random_oracle.Input.Chunked.packeds
+        (Array.of_list
+           (List.map (Bits.to_bits t) ~f:(fun b ->
+                ((if b then Tick.Field.one else Tick.Field.zero), 1))))
+
+    module Checked = struct
+      type t = Unpacked.var
+
+      let to_input (t : t) =
+        Random_oracle.Input.Chunked.packeds
+          (Array.of_list
+             (List.map t ~f:(fun b -> ((b :> Tick.Field.Var.t), 1))))
+    end
   end
 
   include Comparable.Make (Stable.Latest)

--- a/src/lib/block_time/block_time.mli
+++ b/src/lib/block_time/block_time.mli
@@ -65,6 +65,8 @@ module Time : sig
        and type Packed.value = t
        and type Packed.var = private Tick.Field.Var.t
 
+  val to_input : t -> Tick.Field.t Random_oracle_input.Chunked.t
+
   module Checked : sig
     open Snark_params.Tick
 
@@ -79,6 +81,8 @@ module Time : sig
     val ( <= ) : t -> t -> (Boolean.var, _) Checked.t
 
     val ( >= ) : t -> t -> (Boolean.var, _) Checked.t
+
+    val to_input : t -> Field.Var.t Random_oracle_input.Chunked.t
   end
 
   module Span : sig
@@ -129,6 +133,14 @@ module Time : sig
     val min : t -> t -> t
 
     val zero : t
+
+    val to_input : t -> Tick.Field.t Random_oracle_input.Chunked.t
+
+    module Checked : sig
+      type t = Unpacked.var
+
+      val to_input : t -> Tick.Field.Var.t Random_oracle.Input.Chunked.t
+    end
   end
 
   val field_var_to_unpacked :

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -64,9 +64,9 @@ let validate_keypair =
         Mina_base.Signed_command.sign_payload keypair.Keypair.private_key
           dummy_payload
       in
-      let message = Mina_base.Signed_command.to_input dummy_payload in
+      let message = Mina_base.Signed_command.to_input_legacy dummy_payload in
       let verified =
-        Schnorr.verify signature
+        Schnorr.Legacy.verify signature
           (Snark_params.Tick.Inner_curve.of_affine keypair.public_key)
           message
       in

--- a/src/lib/consensus/global_slot.mli
+++ b/src/lib/consensus/global_slot.mli
@@ -23,7 +23,7 @@ module Stable : sig
   end
 end]
 
-val to_input : t -> (_, bool) Random_oracle.Input.t
+val to_input : t -> Snark_params.Tick.Field.t Random_oracle.Input.Chunked.t
 
 val of_slot_number : constants:Constants.t -> Mina_numbers.Global_slot.t -> t
 
@@ -81,11 +81,7 @@ module Checked : sig
 
   val to_bits : t -> (Boolean.var Bitstring.Lsb_first.t, _) Checked.t
 
-  val to_input :
-       t
-    -> ( (Field.Var.t, Snark_params.Tick.Boolean.var) Random_oracle.Input.t
-       , _ )
-       Checked.t
+  val to_input : t -> Field.Var.t Random_oracle.Input.Chunked.t
 
   val to_epoch_and_slot : t -> (Epoch.Checked.t * Slot.Checked.t, _) Checked.t
 

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -515,10 +515,9 @@ module type S = sig
 
       open Snark_params.Tick
 
-      val var_to_input :
-        var -> ((Field.Var.t, Boolean.var) Random_oracle.Input.t, _) Checked.t
+      val var_to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
 
-      val to_input : Value.t -> (Field.t, bool) Random_oracle.Input.t
+      val to_input : Value.t -> Field.t Random_oracle.Input.Chunked.t
 
       val display : Value.t -> display
 

--- a/src/lib/consensus/vrf/consensus_vrf.ml
+++ b/src/lib/consensus/vrf/consensus_vrf.ml
@@ -94,13 +94,13 @@ module Message = struct
   let to_input
       ~(constraint_constants : Genesis_constants.Constraint_constants.t)
       ({ global_slot; seed; delegator } : value) =
-    { Random_oracle.Input.field_elements = [| (seed :> Tick.field) |]
-    ; bitstrings =
-        [| Global_slot.Bits.to_bits global_slot
-         ; Mina_base.Account.Index.to_bits
-             ~ledger_depth:constraint_constants.ledger_depth delegator
-        |]
-    }
+    let open Random_oracle.Input.Chunked in
+    Array.reduce_exn ~f:append
+      [| field (seed :> Tick.field)
+       ; Global_slot.to_input global_slot
+       ; Mina_base.Account.Index.to_input
+           ~ledger_depth:constraint_constants.ledger_depth delegator
+      |]
 
   let data_spec
       ~(constraint_constants : Genesis_constants.Constraint_constants.t) =
@@ -123,19 +123,16 @@ module Message = struct
     |> Group_map.to_group |> Tick.Inner_curve.of_affine
 
   module Checked = struct
-    open Tick
-
     let to_input ({ global_slot; seed; delegator } : var) =
-      let open Tick.Checked.Let_syntax in
-      let%map global_slot = Global_slot.Checked.to_bits global_slot in
-      let s = Bitstring_lib.Bitstring.Lsb_first.to_list in
-      { Random_oracle.Input.field_elements =
-          [| Mina_base.Epoch_seed.var_to_hash_packed seed |]
-      ; bitstrings = [| s global_slot; delegator |]
-      }
+      let open Random_oracle.Input.Chunked in
+      Array.reduce_exn ~f:append
+        [| field (Mina_base.Epoch_seed.var_to_hash_packed seed)
+         ; Global_slot.Checked.to_input global_slot
+         ; Mina_base.Account.Index.Unpacked.to_input delegator
+        |]
 
     let hash_to_group msg =
-      let%bind input = to_input msg in
+      let input = to_input msg in
       Tick.make_checked (fun () ->
           Random_oracle.Checked.hash ~init:Mina_base.Hash_prefix.vrf_message
             (Random_oracle.Checked.pack_input input)
@@ -226,6 +223,14 @@ module Output = struct
       in
       Bignum.(
         of_bigint n / of_bigint Bignum_bigint.(shift_left one length_in_bits))
+
+    let to_input (t : t) =
+      List.map (to_bits t) ~f:(fun b -> (Mina_base.Util.field_of_bool b, 1))
+      |> List.to_array |> Random_oracle.Input.Chunked.packeds
+
+    let var_to_input (t : var) =
+      Array.map t ~f:(fun b -> ((b :> Tick.Field.Var.t), 1))
+      |> Random_oracle.Input.Chunked.packeds
   end
 
   open Tick
@@ -241,7 +246,7 @@ module Output = struct
   let hash ~constraint_constants msg g =
     let x, y = Non_zero_curve_point.of_inner_curve_exn g in
     let input =
-      Random_oracle.Input.(
+      Random_oracle.Input.Chunked.(
         append
           (Message.to_input ~constraint_constants msg)
           (field_elements [| x; y |]))
@@ -257,9 +262,9 @@ module Output = struct
           |> Array.of_list)
 
     let hash msg (x, y) =
-      let%bind msg = Message.Checked.to_input msg in
+      let msg = Message.Checked.to_input msg in
       let input =
-        Random_oracle.Input.(append msg (field_elements [| x; y |]))
+        Random_oracle.Input.Chunked.(append msg (field_elements [| x; y |]))
       in
       make_checked (fun () ->
           let open Random_oracle.Checked in
@@ -358,15 +363,11 @@ end
 module Evaluation_hash = struct
   let hash_for_proof ~constraint_constants message public_key g1 g2 =
     let input =
-      let open Random_oracle_input in
       let g_to_input g =
-        { field_elements =
-            (let f1, f2 = Group.to_affine_exn g in
-             [| f1; f2 |])
-        ; bitstrings = [||]
-        }
+        let f1, f2 = Group.to_affine_exn g in
+        Random_oracle_input.Chunked.field_elements [| f1; f2 |]
       in
-      Array.reduce_exn ~f:Random_oracle_input.append
+      Array.reduce_exn ~f:Random_oracle_input.Chunked.append
         [| Message.to_input ~constraint_constants message
          ; g_to_input public_key
          ; g_to_input g1
@@ -383,14 +384,12 @@ module Evaluation_hash = struct
   module Checked = struct
     let hash_for_proof message public_key g1 g2 =
       let open Tick.Checked.Let_syntax in
-      let%bind input =
-        let open Random_oracle_input in
+      let input =
         let g_to_input (f1, f2) =
-          { field_elements = [| f1; f2 |]; bitstrings = [||] }
+          Random_oracle_input.Chunked.field_elements [| f1; f2 |]
         in
-        let%map message_input = Message.Checked.to_input message in
-        Array.reduce_exn ~f:Random_oracle_input.append
-          [| message_input
+        Array.reduce_exn ~f:Random_oracle_input.Chunked.append
+          [| Message.Checked.to_input message
            ; g_to_input public_key
            ; g_to_input g1
            ; g_to_input g2

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -12,6 +12,7 @@ open Let_syntax
 
 [%%else]
 
+open Snark_params_nonconsensus
 open Snark_bits_nonconsensus
 module Unsigned_extended = Unsigned_extended_nonconsensus.Unsigned_extended
 

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -146,7 +146,10 @@ end = struct
   let var_to_number t = Number.of_bits (var_to_bits t :> Boolean.var list)
 
   let var_to_input t =
-    Random_oracle.Input.bitstring (var_to_bits t :> Boolean.var list)
+    Random_oracle.Input.Chunked.packed (Field.Var.project t, length_in_bits)
+
+  let var_to_input_legacy t =
+    Random_oracle.Input.Legacy.bitstring (var_to_bits t :> Boolean.var list)
 
   let var_of_bits (bits : Boolean.var Bitstring.Lsb_first.t) : var =
     let bits = (bits :> Boolean.var list) in
@@ -185,7 +188,11 @@ end = struct
 
   type magnitude = t [@@deriving sexp, hash, compare, yojson]
 
-  let to_input t = Random_oracle.Input.bitstring @@ to_bits t
+  let to_input t =
+    Random_oracle.Input.Chunked.packed
+      (Field.project (to_bits t), length_in_bits)
+
+  let to_input_legacy t = Random_oracle.Input.Legacy.bitstring @@ to_bits t
 
   module Signed = struct
     type ('magnitude, 'sgn) typ = ('magnitude, 'sgn) Signed_poly.t =
@@ -242,7 +249,12 @@ end = struct
 
     let to_bits ({ sgn; magnitude } : t) = sgn_to_bool sgn :: to_bits magnitude
 
-    let to_input t = Random_oracle.Input.bitstring (to_bits t)
+    let to_input { sgn; magnitude } =
+      Random_oracle.Input.Chunked.(
+        append (to_input magnitude)
+          (packed (Field.project [ sgn_to_bool sgn ], 1)))
+
+    let to_input_legacy t = Random_oracle.Input.Legacy.bitstring (to_bits t)
 
     let add (x : t) (y : t) : t option =
       match (x.sgn, y.sgn) with
@@ -284,7 +296,12 @@ end = struct
       let to_bits { magnitude; sgn } =
         Sgn.Checked.is_pos sgn :: (var_to_bits magnitude :> Boolean.var list)
 
-      let to_input t = Random_oracle.Input.bitstring (to_bits t)
+      let to_input { magnitude; sgn } =
+        let mag = var_to_input magnitude in
+        Random_oracle.Input.Chunked.(
+          append mag (packed ((Sgn.Checked.is_pos sgn :> Field.Var.t), 1)))
+
+      let to_input_legacy t = Random_oracle.Input.Legacy.bitstring (to_bits t)
 
       let constant { magnitude; sgn } =
         { magnitude = var_of_t magnitude; sgn = Sgn.Checked.constant sgn }

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -37,7 +37,9 @@ module type Basic = sig
 
   include Bits_intf.Convertible_bits with type t := t
 
-  val to_input : t -> (_, bool) Random_oracle.Input.t
+  val to_input : t -> Snark_params.Tick.Field.t Random_oracle.Input.Chunked.t
+
+  val to_input_legacy : t -> (_, bool) Random_oracle.Legacy.Input.t
 
   val zero : t
 
@@ -71,7 +73,9 @@ module type Basic = sig
 
   val var_to_bits : var -> Boolean.var Bitstring_lib.Bitstring.Lsb_first.t
 
-  val var_to_input : var -> (_, Boolean.var) Random_oracle.Input.t
+  val var_to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
+
+  val var_to_input_legacy : var -> (_, Boolean.var) Random_oracle.Legacy.Input.t
 
   val equal_var : var -> var -> (Boolean.var, _) Checked.t
 
@@ -121,7 +125,9 @@ module type Signed_intf = sig
 
   val is_negative : t -> bool
 
-  val to_input : t -> (_, bool) Random_oracle.Input.t
+  val to_input : t -> Snark_params.Tick.Field.t Random_oracle.Input.Chunked.t
+
+  val to_input_legacy : t -> (_, bool) Random_oracle.Legacy.Input.t
 
   val add : t -> t -> t option
 
@@ -146,7 +152,9 @@ module type Signed_intf = sig
 
     val if_ : Boolean.var -> then_:var -> else_:var -> (var, _) Checked.t
 
-    val to_input : var -> (_, Boolean.var) Random_oracle.Input.t
+    val to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
+
+    val to_input_legacy : var -> (_, Boolean.var) Random_oracle.Legacy.Input.t
 
     val add : var -> var -> (var, _) Checked.t
 

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -9,6 +9,7 @@ open Snark_params.Tick
 
 [%%else]
 
+open Snark_params_nonconsensus
 open Snark_bits_nonconsensus
 module Random_oracle = Random_oracle_nonconsensus.Random_oracle
 module Sgn = Sgn_nonconsensus.Sgn
@@ -37,7 +38,7 @@ module type Basic = sig
 
   include Bits_intf.Convertible_bits with type t := t
 
-  val to_input : t -> Snark_params.Tick.Field.t Random_oracle.Input.Chunked.t
+  val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 
   val to_input_legacy : t -> (_, bool) Random_oracle.Legacy.Input.t
 
@@ -125,7 +126,7 @@ module type Signed_intf = sig
 
   val is_negative : t -> bool
 
-  val to_input : t -> Snark_params.Tick.Field.t Random_oracle.Input.Chunked.t
+  val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 
   val to_input_legacy : t -> (_, bool) Random_oracle.Legacy.Input.t
 

--- a/src/lib/data_hash_lib/data_hash.ml
+++ b/src/lib/data_hash_lib/data_hash.ml
@@ -33,7 +33,7 @@ struct
 
   let () = assert (Int.(length_in_bits <= Field.size_in_bits))
 
-  let to_input t = Random_oracle.Input.field t
+  let to_input t = Random_oracle.Input.Chunked.field t
 
   [%%ifdef consensus_mechanism]
 
@@ -85,7 +85,7 @@ struct
         t.bits <- Some (Bitstring.Lsb_first.of_list bits) ;
         bits
 
-  let var_to_input (t : var) = Random_oracle.Input.field t.digest
+  let var_to_input (t : var) = Random_oracle.Input.Chunked.field t.digest
 
   (* TODO : use Random oracle.Digest to satisfy Bits_intf.S, move out of
      consensus_mechanism guard

--- a/src/lib/data_hash_lib/data_hash_intf.ml
+++ b/src/lib/data_hash_lib/data_hash_intf.ml
@@ -35,7 +35,7 @@ module type Basic = sig
 
   val var_to_hash_packed : var -> Random_oracle.Checked.Digest.t
 
-  val var_to_input : var -> Field.Var.t Random_oracle.Input.t
+  val var_to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
 
   val var_to_bits : var -> (Boolean.var list, _) Checked.t
 
@@ -60,7 +60,7 @@ module type Basic = sig
 
   val of_base58_check_exn : string -> t
 
-  val to_input : t -> Field.t Random_oracle.Input.t
+  val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 end
 
 module type Full_size = sig

--- a/src/lib/data_hash_lib/data_hash_intf.ml
+++ b/src/lib/data_hash_lib/data_hash_intf.ml
@@ -35,7 +35,7 @@ module type Basic = sig
 
   val var_to_hash_packed : var -> Random_oracle.Checked.Digest.t
 
-  val var_to_input : var -> (Field.Var.t, Boolean.var) Random_oracle.Input.t
+  val var_to_input : var -> Field.Var.t Random_oracle.Input.t
 
   val var_to_bits : var -> (Boolean.var list, _) Checked.t
 
@@ -60,7 +60,7 @@ module type Basic = sig
 
   val of_base58_check_exn : string -> t
 
-  val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+  val to_input : t -> Field.t Random_oracle.Input.t
 end
 
 module type Full_size = sig

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -3,6 +3,7 @@
 [%%import "/src/config.mlh"]
 
 open Core_kernel
+open Util
 
 [%%ifdef consensus_mechanism]
 
@@ -62,7 +63,8 @@ module Index = struct
   let of_bits = List.foldi ~init:Vector.empty ~f:(fun i t b -> Vector.set t i b)
 
   let to_input ~ledger_depth x =
-    Random_oracle.Input.Chunked.packed (Field.of_int x, ledger_depth)
+    List.map (to_bits ~ledger_depth x) ~f:(fun b -> (field_of_bool b, 1))
+    |> List.to_array |> Random_oracle.Input.Chunked.packeds
 
   let fold_bits ~ledger_depth t =
     { Fold.fold =

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -60,6 +60,9 @@ module Index = struct
 
   let of_bits = List.foldi ~init:Vector.empty ~f:(fun i t b -> Vector.set t i b)
 
+  let to_input ~ledger_depth x =
+    Random_oracle.Input.Chunked.packed (Tick.Field.of_int x, ledger_depth)
+
   let fold_bits ~ledger_depth t =
     { Fold.fold =
         (fun ~init ~f ->
@@ -78,6 +81,10 @@ module Index = struct
     type var = Tick.Boolean.var list
 
     type value = Vector.t
+
+    let to_input x =
+      List.map x ~f:(fun (b : Boolean.var) -> ((b :> Field.Var.t), 1))
+      |> List.to_array |> Random_oracle.Input.Chunked.packeds
 
     let typ ~ledger_depth : (var, value) Tick.Typ.t =
       Typ.transport
@@ -265,17 +272,16 @@ let hash_snapp_account_opt = function
 let delegate_opt = Option.value ~default:Public_key.Compressed.empty
 
 let to_input (t : t) =
-  let open Random_oracle.Input in
+  let open Random_oracle.Input.Chunked in
   let f mk acc field = mk (Core_kernel.Field.get field t) :: acc in
-  let bits conv = f (Fn.compose bitstring conv) in
   Poly.Fields.fold ~init:[]
     ~public_key:(f Public_key.Compressed.to_input)
-    ~token_id:(f Token_id.to_input) ~balance:(bits Balance.to_bits)
+    ~token_id:(f Token_id.to_input) ~balance:(f Balance.to_input)
     ~token_permissions:(f Token_permissions.to_input)
-    ~nonce:(bits Nonce.Bits.to_bits)
+    ~nonce:(f Nonce.to_input)
     ~receipt_chain_hash:(f Receipt.Chain_hash.to_input)
     ~delegate:(f (Fn.compose Public_key.Compressed.to_input delegate_opt))
-    ~voting_for:(f State_hash.to_input) ~timing:(bits Timing.to_bits)
+    ~voting_for:(f State_hash.to_input) ~timing:(f Timing.to_input)
     ~snapp:(f (Fn.compose field hash_snapp_account_opt))
     ~permissions:(f Permissions.to_input)
   |> List.reduce_exn ~f:append
@@ -406,13 +412,8 @@ module Checked = struct
   end
 
   let to_input (t : var) =
-    let ( ! ) f x = Run.run_checked (f x) in
     let f mk acc field = mk (Core_kernel.Field.get field t) :: acc in
-    let open Random_oracle.Input in
-    let bits conv =
-      f (fun x ->
-          bitstring (Bitstring_lib.Bitstring.Lsb_first.to_list (conv x)))
-    in
+    let open Random_oracle.Input.Chunked in
     make_checked (fun () ->
         List.reduce_exn ~f:append
           (Poly.Fields.fold ~init:[]
@@ -423,14 +424,13 @@ module Checked = struct
                (* We use [run_checked] here to avoid routing the [Checked.t]
                   monad throughout this calculation.
                *)
-               (f (fun x -> Run.run_checked (Token_id.Checked.to_input x)))
+               (f Token_id.Checked.to_input)
              ~token_permissions:(f Token_permissions.var_to_input)
-             ~balance:(bits Balance.var_to_bits)
-             ~nonce:(bits !Nonce.Checked.to_bits)
+             ~balance:(f Balance.var_to_input) ~nonce:(f Nonce.Checked.to_input)
              ~receipt_chain_hash:(f Receipt.Chain_hash.var_to_input)
              ~delegate:(f Public_key.Compressed.Checked.to_input)
              ~voting_for:(f State_hash.var_to_input)
-             ~timing:(bits Timing.var_to_bits)))
+             ~timing:(f Timing.var_to_input)))
 
   let digest t =
     make_checked (fun () ->

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -11,6 +11,7 @@ open Tick
 
 [%%else]
 
+open Snark_params_nonconsensus
 module Currency = Currency_nonconsensus.Currency
 module Mina_numbers = Mina_numbers_nonconsensus.Mina_numbers
 module Random_oracle = Random_oracle_nonconsensus.Random_oracle
@@ -61,7 +62,7 @@ module Index = struct
   let of_bits = List.foldi ~init:Vector.empty ~f:(fun i t b -> Vector.set t i b)
 
   let to_input ~ledger_depth x =
-    Random_oracle.Input.Chunked.packed (Tick.Field.of_int x, ledger_depth)
+    Random_oracle.Input.Chunked.packed (Field.of_int x, ledger_depth)
 
   let fold_bits ~ledger_depth t =
     { Fold.fold =

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -12,7 +12,6 @@ open Tick
 
 [%%else]
 
-open Snark_params_nonconsensus
 module Currency = Currency_nonconsensus.Currency
 module Mina_numbers = Mina_numbers_nonconsensus.Mina_numbers
 module Random_oracle = Random_oracle_nonconsensus.Random_oracle

--- a/src/lib/mina_base/account_id.ml
+++ b/src/lib/mina_base/account_id.ml
@@ -21,11 +21,6 @@ let public_key (key, _tid) = key
 
 let token_id (_key, tid) = tid
 
-let to_input (key, tid) =
-  Random_oracle.Input.append
-    (Public_key.Compressed.to_input key)
-    (Token_id.to_input tid)
-
 let gen =
   let open Quickcheck.Let_syntax in
   let%map key = Public_key.Compressed.gen and tid = Token_id.gen in
@@ -52,10 +47,6 @@ module Checked = struct
   let public_key (key, _tid) = key
 
   let token_id (_key, tid) = tid
-
-  let to_input (key, tid) =
-    let%map tid = Token_id.Checked.to_input tid in
-    Random_oracle.Input.append (Public_key.Compressed.Checked.to_input key) tid
 
   let equal (pk1, tid1) (pk2, tid2) =
     let%bind pk_equal = Public_key.Compressed.Checked.equal pk1 pk2 in

--- a/src/lib/mina_base/account_id.mli
+++ b/src/lib/mina_base/account_id.mli
@@ -3,16 +3,6 @@
 open Core_kernel
 open Import
 
-[%%ifdef consensus_mechanism]
-
-open Snark_params.Tick
-
-[%%else]
-
-open Snark_params_nonconsensus
-
-[%%endif]
-
 [%%versioned:
 module Stable : sig
   module V1 : sig
@@ -27,8 +17,6 @@ val empty : t
 val public_key : t -> Public_key.Compressed.t
 
 val token_id : t -> Token_id.t
-
-val to_input : t -> (Field.t, bool) Random_oracle.Input.t
 
 val gen : t Quickcheck.Generator.t
 
@@ -53,14 +41,6 @@ module Checked : sig
   val public_key : var -> Public_key.Compressed.var
 
   val token_id : var -> Token_id.var
-
-  val to_input :
-       var
-    -> ( ( Snark_params.Tick.Field.Var.t
-         , Snark_params.Tick.Boolean.var )
-         Random_oracle.Input.t
-       , _ )
-       Checked.t
 
   val equal : var -> var -> (Boolean.var, _) Checked.t
 

--- a/src/lib/mina_base/account_timing.ml
+++ b/src/lib/mina_base/account_timing.ml
@@ -107,7 +107,7 @@ let to_record t =
         ; vesting_increment
         }
 
-let to_bits t =
+let to_input t =
   let As_record.
         { is_timed
         ; initial_minimum_balance
@@ -118,39 +118,39 @@ let to_bits t =
         } =
     to_record t
   in
-  is_timed
-  :: ( Balance.to_bits initial_minimum_balance
-     @ Global_slot.to_bits cliff_time
-     @ Amount.to_bits cliff_amount
-     @ Global_slot.to_bits vesting_period
-     @ Amount.to_bits vesting_increment )
+  let open Random_oracle_input.Chunked in
+  Array.reduce_exn ~f:append
+    [| packed ((if is_timed then Field.one else Field.zero), 1)
+     ; Balance.to_input initial_minimum_balance
+     ; Global_slot.to_input cliff_time
+     ; Amount.to_input cliff_amount
+     ; Global_slot.to_input vesting_period
+     ; Amount.to_input vesting_increment
+    |]
 
 [%%ifdef consensus_mechanism]
 
 type var =
   (Boolean.var, Global_slot.Checked.var, Balance.var, Amount.var) As_record.t
 
-let var_to_bits
+let var_to_input
     As_record.
-      { is_timed
+      { is_timed : Boolean.var
       ; initial_minimum_balance
       ; cliff_time
       ; cliff_amount
       ; vesting_period
       ; vesting_increment
       } =
-  let open Bitstring_lib.Bitstring.Lsb_first in
-  let initial_minimum_balance =
-    to_list @@ Balance.var_to_bits initial_minimum_balance
-  in
-  let cliff_time = to_list @@ Global_slot.var_to_bits cliff_time in
-  let cliff_amount = to_list @@ Amount.var_to_bits cliff_amount in
-  let vesting_period = to_list @@ Global_slot.var_to_bits vesting_period in
-  let vesting_increment = to_list @@ Amount.var_to_bits vesting_increment in
-  of_list
-    ( is_timed
-    :: ( initial_minimum_balance @ cliff_time @ cliff_amount @ vesting_period
-       @ vesting_increment ) )
+  let open Random_oracle_input.Chunked in
+  Array.reduce_exn ~f:append
+    [| packed ((is_timed :> Field.Var.t), 1)
+     ; Balance.var_to_input initial_minimum_balance
+     ; Global_slot.Checked.to_input cliff_time
+     ; Amount.var_to_input cliff_amount
+     ; Global_slot.Checked.to_input vesting_period
+     ; Amount.var_to_input vesting_increment
+    |]
 
 let var_of_t (t : t) : var =
   let As_record.

--- a/src/lib/mina_base/account_timing.ml
+++ b/src/lib/mina_base/account_timing.ml
@@ -9,6 +9,7 @@ open Tick
 
 [%%else]
 
+open Snark_params_nonconsensus
 module Currency = Currency_nonconsensus.Currency
 module Mina_numbers = Mina_numbers_nonconsensus.Mina_numbers
 module Random_oracle = Random_oracle_nonconsensus.Random_oracle

--- a/src/lib/mina_base/epoch_ledger.ml
+++ b/src/lib/mina_base/epoch_ledger.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 open Currency
 open Snark_params.Tick
-open Bitstring_lib
 
 module Poly = struct
   [%%versioned
@@ -28,10 +27,8 @@ module Value = struct
 end
 
 let to_input ({ hash; total_currency } : Value.t) =
-  let open Snark_params.Tick in
-  { Random_oracle.Input.field_elements = [| (hash :> Field.t) |]
-  ; bitstrings = [| Amount.to_bits total_currency |]
-  }
+  Random_oracle_input.Chunked.(
+    append (field (hash :> Field.t)) (Amount.to_input total_currency))
 
 type var = (Frozen_ledger_hash0.var, Amount.var) Poly.t
 
@@ -43,11 +40,9 @@ let typ : (var, Value.t) Typ.t =
     ~value_of_hlist:Poly.of_hlist
 
 let var_to_input ({ Poly.hash; total_currency } : var) =
-  { Random_oracle.Input.field_elements =
-      [| Frozen_ledger_hash0.var_to_hash_packed hash |]
-  ; bitstrings =
-      [| Bitstring.Lsb_first.to_list (Amount.var_to_bits total_currency) |]
-  }
+  let total_currency = Amount.var_to_input total_currency in
+  Random_oracle_input.Chunked.(
+    append (field (Frozen_ledger_hash0.var_to_hash_packed hash)) total_currency)
 
 let if_ cond ~(then_ : (Frozen_ledger_hash0.var, Amount.var) Poly.t)
     ~(else_ : (Frozen_ledger_hash0.var, Amount.var) Poly.t) =

--- a/src/lib/mina_base/fee_excess.ml
+++ b/src/lib/mina_base/fee_excess.ml
@@ -145,7 +145,7 @@ let var_of_t ({ fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } : t) :
 [%%endif]
 
 let to_input { fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } =
-  let open Random_oracle.Input in
+  let open Random_oracle.Input.Chunked in
   List.reduce_exn ~f:append
     [ Token_id.to_input fee_token_l
     ; Fee.Signed.to_input fee_excess_l
@@ -156,9 +156,9 @@ let to_input { fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } =
 [%%ifdef consensus_mechanism]
 
 let to_input_checked { fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } =
-  let%map fee_token_l = Token_id.Checked.to_input fee_token_l
+  let fee_token_l = Token_id.Checked.to_input fee_token_l
   and fee_token_r = Token_id.Checked.to_input fee_token_r in
-  List.reduce_exn ~f:Random_oracle.Input.append
+  List.reduce_exn ~f:Random_oracle.Input.Chunked.append
     [ fee_token_l
     ; Fee.Signed.Checked.to_input fee_excess_l
     ; fee_token_r

--- a/src/lib/mina_base/other_fee_payer.ml
+++ b/src/lib/mina_base/other_fee_payer.ml
@@ -50,12 +50,11 @@ module Payload = struct
       Poly.t
 
     let to_input ({ pk; token_id; nonce; fee } : t) =
-      let ( ! ) = Impl.run_checked in
-      let open Random_oracle_input in
+      let open Random_oracle_input.Chunked in
       List.reduce_exn ~f:append
         [ Public_key.Compressed.Checked.to_input pk
-        ; !(Token_id.Checked.to_input token_id)
-        ; !(Mina_numbers.Account_nonce.Checked.to_input nonce)
+        ; Token_id.Checked.to_input token_id
+        ; Mina_numbers.Account_nonce.Checked.to_input nonce
         ; Currency.Fee.var_to_input fee
         ]
   end
@@ -81,7 +80,7 @@ module Payload = struct
     }
 
   let to_input ({ pk; token_id; nonce; fee } : t) =
-    let open Random_oracle_input in
+    let open Random_oracle_input.Chunked in
     List.reduce_exn ~f:append
       [ Public_key.Compressed.to_input pk
       ; Token_id.to_input token_id

--- a/src/lib/mina_base/payment_payload.ml
+++ b/src/lib/mina_base/payment_payload.ml
@@ -74,21 +74,21 @@ let typ : (var, t) Typ.t =
   Typ.of_hlistable spec ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
     ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
-let to_input { Poly.source_pk; receiver_pk; token_id; amount } =
-  Array.reduce_exn ~f:Random_oracle.Input.append
-    [| Public_key.Compressed.to_input source_pk
-     ; Public_key.Compressed.to_input receiver_pk
-     ; Token_id.to_input token_id
-     ; Amount.to_input amount
+let to_input_legacy { Poly.source_pk; receiver_pk; token_id; amount } =
+  Array.reduce_exn ~f:Random_oracle.Input.Legacy.append
+    [| Public_key.Compressed.to_input_legacy source_pk
+     ; Public_key.Compressed.to_input_legacy receiver_pk
+     ; Token_id.to_input_legacy token_id
+     ; Amount.to_input_legacy amount
     |]
 
-let var_to_input { Poly.source_pk; receiver_pk; token_id; amount } =
-  let%map token_id = Token_id.Checked.to_input token_id in
-  Array.reduce_exn ~f:Random_oracle.Input.append
-    [| Public_key.Compressed.Checked.to_input source_pk
-     ; Public_key.Compressed.Checked.to_input receiver_pk
+let var_to_input_legacy { Poly.source_pk; receiver_pk; token_id; amount } =
+  let%map token_id = Token_id.Checked.to_input_legacy token_id in
+  Array.reduce_exn ~f:Random_oracle.Input.Legacy.append
+    [| Public_key.Compressed.Checked.to_input_legacy source_pk
+     ; Public_key.Compressed.Checked.to_input_legacy receiver_pk
      ; token_id
-     ; Amount.var_to_input amount
+     ; Amount.var_to_input_legacy amount
     |]
 
 let var_of_t ({ source_pk; receiver_pk; token_id; amount } : t) : var =

--- a/src/lib/mina_base/payment_payload.mli
+++ b/src/lib/mina_base/payment_payload.mli
@@ -57,9 +57,9 @@ type var = (Public_key.Compressed.var, Token_id.var, Currency.Amount.var) Poly.t
 
 val typ : (var, t) Typ.t
 
-val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+val to_input_legacy : t -> (Field.t, bool) Random_oracle.Input.Legacy.t
 
-val var_to_input :
-  var -> ((Field.Var.t, Boolean.var) Random_oracle.Input.t, _) Checked.t
+val var_to_input_legacy :
+  var -> ((Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t, _) Checked.t
 
 val var_of_t : t -> var

--- a/src/lib/mina_base/pending_coinbase_intf.ml
+++ b/src/lib/mina_base/pending_coinbase_intf.ml
@@ -114,7 +114,7 @@ module type S = sig
 
     val gen : t Quickcheck.Generator.t
 
-    val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+    val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 
     val to_bits : t -> bool list
 
@@ -122,7 +122,7 @@ module type S = sig
 
     val equal_var : var -> var -> (Boolean.var, _) Tick.Checked.t
 
-    val var_to_input : var -> (Field.Var.t, Boolean.var) Random_oracle.Input.t
+    val var_to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
 
     val empty : t
 

--- a/src/lib/mina_base/permissions.ml
+++ b/src/lib/mina_base/permissions.ml
@@ -1,6 +1,7 @@
 [%%import "/src/config.mlh"]
 
 open Core_kernel
+open Util
 
 [%%ifdef consensus_mechanism]
 
@@ -115,9 +116,11 @@ module Auth_required = struct
       }
     [@@deriving hlist, fields]
 
-    let to_input t =
+    let to_input ~field_of_bool t =
       let [ x; y; z ] = to_hlist t in
-      Random_oracle.Input.bitstring [ x; y; z ]
+      let bs = [| x; y; z |] in
+      Random_oracle.Input.Chunked.packeds
+        (Array.map bs ~f:(fun b -> (field_of_bool b, 1)))
 
     let map t ~f =
       { constant = f t.constant
@@ -214,7 +217,9 @@ module Auth_required = struct
 
     let if_ = Encoding.if_
 
-    let to_input : t -> _ = Encoding.to_input
+    let to_input : t -> _ =
+      Encoding.to_input ~field_of_bool:(fun (b : Boolean.var) ->
+          (b :> Field.Var.t))
 
     let constant t = Encoding.map (encode t) ~f:Boolean.var_of_value
 
@@ -260,7 +265,7 @@ module Auth_required = struct
 
   [%%endif]
 
-  let to_input x = Encoding.to_input (encode x)
+  let to_input x = Encoding.to_input (encode x) ~field_of_bool
 
   let check (t : t) (c : Control.Tag.t) =
     match (t, c) with
@@ -302,14 +307,15 @@ module Poly = struct
     end
   end]
 
-  let to_input controller t =
+  let to_input ~field_of_bool controller t =
     let f mk acc field = mk (Core_kernel.Field.get field t) :: acc in
     Stable.Latest.Fields.fold ~init:[]
-      ~stake:(f (fun x -> Random_oracle.Input.bitstring [ x ]))
+      ~stake:
+        (f (fun x -> Random_oracle.Input.Chunked.packed (field_of_bool x, 1)))
       ~edit_state:(f controller) ~send:(f controller)
       ~set_delegate:(f controller) ~set_permissions:(f controller)
       ~set_verification_key:(f controller) ~receive:(f controller)
-    |> List.reduce_exn ~f:Random_oracle.Input.append
+    |> List.reduce_exn ~f:Random_oracle.Input.Chunked.append
 end
 
 [%%versioned
@@ -327,7 +333,9 @@ end]
 module Checked = struct
   type t = (Boolean.var, Auth_required.Checked.t) Poly.Stable.Latest.t
 
-  let to_input x = Poly.to_input Auth_required.Checked.to_input x
+  let to_input (x : t) =
+    Poly.to_input Auth_required.Checked.to_input x
+      ~field_of_bool:(fun (b : Boolean.var) -> (b :> Field.Var.t))
 
   open Pickles.Impls.Step
 
@@ -366,7 +374,7 @@ let typ =
 
 [%%endif]
 
-let to_input x = Poly.to_input Auth_required.to_input x
+let to_input (x : t) = Poly.to_input ~field_of_bool Auth_required.to_input x
 
 let user_default : t =
   { stake = true

--- a/src/lib/mina_base/permissions.mli
+++ b/src/lib/mina_base/permissions.mli
@@ -15,7 +15,7 @@ module Auth_required : sig
     end
   end]
 
-  val to_input : t -> (_, bool) Random_oracle_input.t
+  val to_input : t -> Field.Constant.t Random_oracle_input.Chunked.t
 
   val check : t -> Control.Tag.t -> bool
 
@@ -26,7 +26,7 @@ module Auth_required : sig
 
     val if_ : Boolean.var -> then_:t -> else_:t -> t
 
-    val to_input : t -> (_, Boolean.var) Random_oracle_input.t
+    val to_input : t -> Field.t Random_oracle_input.Chunked.t
 
     val eval_no_proof : t -> signature_verifies:Boolean.var -> Boolean.var
 
@@ -67,14 +67,14 @@ module Stable : sig
   end
 end]
 
-val to_input : t -> (_, bool) Random_oracle_input.t
+val to_input : t -> Field.Constant.t Random_oracle_input.Chunked.t
 
 [%%ifdef consensus_mechanism]
 
 module Checked : sig
   type t = (Boolean.var, Auth_required.Checked.t) Poly.Stable.Latest.t
 
-  val to_input : t -> (_, Boolean.var) Random_oracle_input.t
+  val to_input : t -> Field.t Random_oracle_input.Chunked.t
 
   val constant : Stable.Latest.t -> t
 

--- a/src/lib/mina_base/permissions.mli
+++ b/src/lib/mina_base/permissions.mli
@@ -2,7 +2,11 @@
 
 [%%ifdef consensus_mechanism]
 
-open Pickles.Impls.Step
+open Snark_params.Tick
+
+[%%else]
+
+open Snark_params_nonconsensus
 
 [%%endif]
 
@@ -15,7 +19,7 @@ module Auth_required : sig
     end
   end]
 
-  val to_input : t -> Field.Constant.t Random_oracle_input.Chunked.t
+  val to_input : t -> Field.t Random_oracle_input.Chunked.t
 
   val check : t -> Control.Tag.t -> bool
 
@@ -26,7 +30,7 @@ module Auth_required : sig
 
     val if_ : Boolean.var -> then_:t -> else_:t -> t
 
-    val to_input : t -> Field.t Random_oracle_input.Chunked.t
+    val to_input : t -> Field.Var.t Random_oracle_input.Chunked.t
 
     val eval_no_proof : t -> signature_verifies:Boolean.var -> Boolean.var
 
@@ -67,14 +71,14 @@ module Stable : sig
   end
 end]
 
-val to_input : t -> Field.Constant.t Random_oracle_input.Chunked.t
+val to_input : t -> Field.t Random_oracle_input.Chunked.t
 
 [%%ifdef consensus_mechanism]
 
 module Checked : sig
   type t = (Boolean.var, Auth_required.Checked.t) Poly.Stable.Latest.t
 
-  val to_input : t -> Field.t Random_oracle_input.Chunked.t
+  val to_input : t -> Field.Var.t Random_oracle_input.Chunked.t
 
   val constant : Stable.Latest.t -> t
 

--- a/src/lib/mina_base/protocol_constants_checked.ml
+++ b/src/lib/mina_base/protocol_constants_checked.ml
@@ -78,12 +78,12 @@ let t_of_value (v : value) : Genesis_constants.Protocol.t =
   }
 
 let to_input (t : value) =
-  Random_oracle.Input.bitstrings
-    [| T.to_bits t.k
-     ; T.to_bits t.delta
-     ; T.to_bits t.slots_per_epoch
-     ; T.to_bits t.slots_per_sub_window
-     ; Block_time.Bits.to_bits t.genesis_state_timestamp
+  Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
+    [| T.to_input t.k
+     ; T.to_input t.delta
+     ; T.to_input t.slots_per_epoch
+     ; T.to_input t.slots_per_sub_window
+     ; Block_time.to_input t.genesis_state_timestamp
     |]
 
 [%%if defined consensus_mechanism]
@@ -105,22 +105,20 @@ let typ =
     ~value_of_hlist:Poly.of_hlist
 
 let var_to_input (var : var) =
-  let s = Bitstring_lib.Bitstring.Lsb_first.to_list in
-  let%map k = T.Checked.to_bits var.k
-  and delta = T.Checked.to_bits var.delta
-  and slots_per_epoch = T.Checked.to_bits var.slots_per_epoch
-  and slots_per_sub_window = T.Checked.to_bits var.slots_per_sub_window in
+  let k = T.Checked.to_input var.k
+  and delta = T.Checked.to_input var.delta
+  and slots_per_epoch = T.Checked.to_input var.slots_per_epoch
+  and slots_per_sub_window = T.Checked.to_input var.slots_per_sub_window in
   let genesis_state_timestamp =
-    Block_time.Unpacked.var_to_bits var.genesis_state_timestamp
+    Block_time.Checked.to_input var.genesis_state_timestamp
   in
-  Random_oracle.Input.bitstrings
-    (Array.map ~f:s
-       [| k
-        ; delta
-        ; slots_per_epoch
-        ; slots_per_sub_window
-        ; genesis_state_timestamp
-       |])
+  Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
+    [| k
+     ; delta
+     ; slots_per_epoch
+     ; slots_per_sub_window
+     ; genesis_state_timestamp
+    |]
 
 let%test_unit "value = var" =
   let compiled = Genesis_constants.for_unit_tests.protocol in

--- a/src/lib/mina_base/receipt.ml
+++ b/src/lib/mina_base/receipt.ml
@@ -56,14 +56,14 @@ module Chain_hash = struct
   let empty = of_hash Random_oracle.(salt "CodaReceiptEmpty" |> digest)
 
   let cons (e : Elt.t) (t : t) =
-    let open Random_oracle in
+    let open Random_oracle.Legacy in
     let init, x =
       let open Hash_prefix in
       match e with
       | Signed_command payload ->
           ( receipt_chain_user_command
           , Transaction_union_payload.(
-              to_input (of_user_command_payload payload)) )
+              to_input_legacy (of_user_command_payload payload)) )
       | Snapp_command s ->
           (receipt_chain_snapp, Input.field s)
     in
@@ -87,21 +87,22 @@ module Chain_hash = struct
     let if_ = if_
 
     let cons (e : Elt.t) t =
-      let open Random_oracle in
+      let open Random_oracle.Legacy in
       let open Checked in
       let open Hash_prefix in
       let%bind init, x =
         match e with
         | Signed_command payload ->
             let%map payload =
-              Transaction_union_payload.Checked.to_input payload
+              Transaction_union_payload.Checked.to_input_legacy payload
             in
             (receipt_chain_user_command, payload)
         | Snapp_command s ->
             Let_syntax.return (receipt_chain_snapp, Input.field s)
       in
       make_checked (fun () ->
-          hash ~init (pack_input Input.(append x (var_to_input t)))
+          hash ~init
+            (pack_input Input.(append x (field (var_to_hash_packed t))))
           |> var_of_hash_packed)
   end
 

--- a/src/lib/mina_base/side_loaded_verification_key.ml
+++ b/src/lib/mina_base/side_loaded_verification_key.ml
@@ -67,7 +67,9 @@ module Stable = struct
   end
 end]
 
-let to_input = Pickles_base.Side_loaded_verification_key.to_input
+let to_input x =
+  Pickles_base.Side_loaded_verification_key.to_input
+    ~field_of_int:Snark_params_nonconsensus.Field.of_int x
 
 let dummy : t =
   let open Pickles_types in

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -118,8 +118,8 @@ let tag_string (t : t) =
 let next_available_token ({ payload; _ } : t) tid =
   Payload.next_available_token payload tid
 
-let to_input (payload : Payload.t) =
-  Transaction_union_payload.(to_input (of_user_command_payload payload))
+let to_input_legacy (payload : Payload.t) =
+  Transaction_union_payload.(to_input_legacy (of_user_command_payload payload))
 
 let check_tokens ({ payload = { common = { fee_token; _ }; body }; _ } : t) =
   (not (Token_id.(equal invalid) fee_token))
@@ -140,7 +140,8 @@ let check_tokens ({ payload = { common = { fee_token; _ }; body }; _ } : t) =
 
 let sign_payload ?signature_kind (private_key : Signature_lib.Private_key.t)
     (payload : Payload.t) : Signature.t =
-  Signature_lib.Schnorr.sign ?signature_kind private_key (to_input payload)
+  Signature_lib.Schnorr.Legacy.sign ?signature_kind private_key
+    (to_input_legacy payload)
 
 let sign ?signature_kind (kp : Signature_keypair.t) (payload : Payload.t) : t =
   { payload
@@ -373,16 +374,16 @@ Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
 [%%ifdef consensus_mechanism]
 
 let check_signature ?signature_kind ({ payload; signer; signature } : t) =
-  Signature_lib.Schnorr.verify ?signature_kind signature
+  Signature_lib.Schnorr.Legacy.verify ?signature_kind signature
     (Snark_params.Tick.Inner_curve.of_affine signer)
-    (to_input payload)
+    (to_input_legacy payload)
 
 [%%else]
 
 let check_signature ?signature_kind ({ payload; signer; signature } : t) =
-  Signature_lib_nonconsensus.Schnorr.verify ?signature_kind signature
+  Signature_lib_nonconsensus.Schnorr.Legacy.verify ?signature_kind signature
     (Snark_params_nonconsensus.Inner_curve.of_affine signer)
-    (to_input payload)
+    (to_input_legacy payload)
 
 [%%endif]
 

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -139,8 +139,8 @@ module type S = sig
 
   val next_available_token : t -> Token_id.t -> Token_id.t
 
-  val to_input :
-    Signed_command_payload.t -> (Field.t, bool) Random_oracle_input.t
+  val to_input_legacy :
+    Signed_command_payload.t -> (Field.t, bool) Random_oracle_input.Legacy.t
 
   (** Check that the command is used with compatible tokens. This check is fast
       and cheap, to be used for filtering.

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -107,15 +107,15 @@ module Common = struct
 
   [%%endif]
 
-  let to_input ({ fee; fee_token; fee_payer_pk; nonce; valid_until; memo } : t)
-      =
-    let bitstring = Random_oracle.Input.bitstring in
-    Array.reduce_exn ~f:Random_oracle.Input.append
-      [| Currency.Fee.to_input fee
-       ; Token_id.to_input fee_token
-       ; Public_key.Compressed.to_input fee_payer_pk
-       ; Account_nonce.to_input nonce
-       ; Global_slot.to_input valid_until
+  let to_input_legacy
+      ({ fee; fee_token; fee_payer_pk; nonce; valid_until; memo } : t) =
+    let bitstring = Random_oracle.Input.Legacy.bitstring in
+    Array.reduce_exn ~f:Random_oracle.Input.Legacy.append
+      [| Currency.Fee.to_input_legacy fee
+       ; Token_id.to_input_legacy fee_token
+       ; Public_key.Compressed.to_input_legacy fee_payer_pk
+       ; Account_nonce.to_input_legacy nonce
+       ; Global_slot.to_input_legacy valid_until
        ; bitstring (Memo.to_bits memo)
       |]
 
@@ -177,18 +177,18 @@ module Common = struct
       ; valid_until = Global_slot.Checked.constant valid_until
       }
 
-    let to_input
+    let to_input_legacy
         ({ fee; fee_token; fee_payer_pk; nonce; valid_until; memo } : var) =
-      let%map nonce = Account_nonce.Checked.to_input nonce
-      and valid_until = Global_slot.Checked.to_input valid_until
-      and fee_token = Token_id.Checked.to_input fee_token in
-      Array.reduce_exn ~f:Random_oracle.Input.append
-        [| Currency.Fee.var_to_input fee
+      let%map nonce = Account_nonce.Checked.to_input_legacy nonce
+      and valid_until = Global_slot.Checked.to_input_legacy valid_until
+      and fee_token = Token_id.Checked.to_input_legacy fee_token in
+      Array.reduce_exn ~f:Random_oracle.Input.Legacy.append
+        [| Currency.Fee.var_to_input_legacy fee
          ; fee_token
-         ; Public_key.Compressed.Checked.to_input fee_payer_pk
+         ; Public_key.Compressed.Checked.to_input_legacy fee_payer_pk
          ; nonce
          ; valid_until
-         ; Random_oracle.Input.bitstring
+         ; Random_oracle.Input.Legacy.bitstring
              (Array.to_list (memo :> Boolean.var array))
         |]
   end

--- a/src/lib/mina_base/signed_command_payload.mli
+++ b/src/lib/mina_base/signed_command_payload.mli
@@ -80,7 +80,7 @@ module Common : sig
     end
   end]
 
-  val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+  val to_input_legacy : t -> (Field.t, bool) Random_oracle.Input.Legacy.t
 
   val gen : ?fee_token_id:Token_id.t -> unit -> t Quickcheck.Generator.t
 
@@ -98,9 +98,9 @@ module Common : sig
   val typ : (var, t) Typ.t
 
   module Checked : sig
-    val to_input :
+    val to_input_legacy :
          var
-      -> ( (Field.Var.t, Boolean.var) Random_oracle.Input.t
+      -> ( (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
          , _ )
          Snark_params.Tick.Checked.t
 

--- a/src/lib/mina_base/snapp_account.ml
+++ b/src/lib/mina_base/snapp_account.ml
@@ -67,9 +67,11 @@ module Checked = struct
     Poly.t
 
   let to_input' (t : _ Poly.t) =
-    let open Random_oracle.Input in
+    let open Random_oracle.Input.Chunked in
     let f mk acc field = mk (Core_kernel.Field.get field t) :: acc in
-    let app_state v = Random_oracle.Input.field_elements (Vector.to_array v) in
+    let app_state v =
+      Random_oracle.Input.Chunked.field_elements (Vector.to_array v)
+    in
     Poly.Fields.fold ~init:[] ~app_state:(f app_state)
       ~verification_key:(f (fun x -> field x))
     |> List.reduce_exn ~f:append
@@ -118,9 +120,11 @@ let dummy_vk_hash =
   Memo.unit (fun () -> digest_vk Side_loaded_verification_key.dummy)
 
 let to_input (t : t) =
-  let open Random_oracle.Input in
+  let open Random_oracle.Input.Chunked in
   let f mk acc field = mk (Core_kernel.Field.get field t) :: acc in
-  let app_state v = Random_oracle.Input.field_elements (Vector.to_array v) in
+  let app_state v =
+    Random_oracle.Input.Chunked.field_elements (Vector.to_array v)
+  in
   Poly.Fields.fold ~init:[] ~app_state:(f app_state)
     ~verification_key:
       (f

--- a/src/lib/mina_base/snapp_basic.ml
+++ b/src/lib/mina_base/snapp_basic.ml
@@ -2,6 +2,8 @@
 
 open Core_kernel
 
+let field_of_bool = Util.field_of_bool
+
 [%%ifdef consensus_mechanism]
 
 open Snark_params.Tick
@@ -23,7 +25,8 @@ module Transition = struct
     end
   end]
 
-  let to_input { prev; next } ~f = Random_oracle_input.append (f prev) (f next)
+  let to_input { prev; next } ~f =
+    Random_oracle_input.Chunked.append (f prev) (f next)
 
   [%%ifdef consensus_mechanism]
 
@@ -46,14 +49,15 @@ module Flagged_data = struct
   [%%endif]
 
   let to_input' { flag; data } ~flag:f ~data:d =
-    Random_oracle_input.(append (f flag) (d data))
+    Random_oracle_input.Chunked.(append (f flag) (d data))
 end
 
 module Flagged_option = struct
   type ('bool, 'a) t = { is_some : 'bool; data : 'a } [@@deriving hlist, fields]
 
-  let to_input' { is_some; data } ~f =
-    Random_oracle_input.(append (bitstring [ is_some ]) (f data))
+  let to_input' ~field_of_bool { is_some; data } ~f =
+    Random_oracle_input.Chunked.(
+      append (packed (field_of_bool is_some, 1)) (f data))
 
   let to_input { is_some; data } ~default ~f =
     let data = if is_some then data else default in
@@ -120,8 +124,8 @@ module Set_or_keep = struct
 
     val to_input :
          'a t
-      -> f:('a -> ('f, Boolean.var) Random_oracle_input.t)
-      -> ('f, Boolean.var) Random_oracle_input.t
+      -> f:('a -> Field.Var.t Random_oracle_input.Chunked.t)
+      -> Field.Var.t Random_oracle_input.Chunked.t
   end = struct
     type 'a t = (Boolean.var, 'a) Flagged_option.t
 
@@ -139,7 +143,9 @@ module Set_or_keep = struct
         (Flagged_option.option_typ ~default:dummy t)
         ~there:to_option ~back:of_option
 
-    let to_input (t : _ t) ~f = Flagged_option.to_input' t ~f
+    let to_input (t : _ t) ~f =
+      Flagged_option.to_input' t ~f ~field_of_bool:(fun (b : Boolean.var) ->
+          (b :> Field.Var.t))
   end
 
   let typ = Checked.typ
@@ -147,7 +153,7 @@ module Set_or_keep = struct
   [%%endif]
 
   let to_input t ~dummy:default ~f =
-    Flagged_option.to_input ~default ~f
+    Flagged_option.to_input ~default ~f ~field_of_bool
       (Flagged_option.of_option ~default (to_option t))
 end
 
@@ -180,8 +186,8 @@ module Or_ignore = struct
 
     val to_input :
          'a t
-      -> f:('a -> ('f, Boolean.var) Random_oracle_input.t)
-      -> ('f, Boolean.var) Random_oracle_input.t
+      -> f:('a -> Field.Var.t Random_oracle_input.Chunked.t)
+      -> Field.Var.t Random_oracle_input.Chunked.t
 
     val check : 'a t -> f:('a -> Boolean.var) -> Boolean.var
   end = struct
@@ -194,7 +200,8 @@ module Or_ignore = struct
       | Implicit x ->
           f x
       | Explicit t ->
-          Flagged_option.to_input' t ~f
+          Flagged_option.to_input' t ~f ~field_of_bool:(fun (b : Boolean.var) ->
+              (b :> Field.Var.t))
 
     let check t ~f =
       match t with
@@ -241,7 +248,9 @@ module Account_state = struct
   module Encoding = struct
     type 'b t = { any : 'b; empty : 'b } [@@deriving hlist]
 
-    let to_input { any; empty } = Random_oracle_input.bitstring [ any; empty ]
+    let to_input ~field_of_bool { any; empty } =
+      Random_oracle_input.Chunked.packeds
+        [| (field_of_bool any, 1); (field_of_bool empty, 1) |]
   end
 
   let encode : t -> bool Encoding.t = function
@@ -260,7 +269,7 @@ module Account_state = struct
     | { any = true; empty = false } | { any = true; empty = true } ->
         Any
 
-  let to_input (x : t) = Encoding.to_input (encode x)
+  let to_input (x : t) = Encoding.to_input ~field_of_bool (encode x)
 
   let check (t : t) (x : [ `Empty | `Non_empty ]) =
     match (t, x) with
@@ -276,7 +285,9 @@ module Account_state = struct
 
     type t = Boolean.var Encoding.t
 
-    let to_input (t : t) = Encoding.to_input t
+    let to_input (t : t) =
+      Encoding.to_input t ~field_of_bool:(fun (b : Boolean.var) ->
+          (b :> Field.t))
 
     let check (t : t) ~is_empty =
       Boolean.(

--- a/src/lib/mina_base/snapp_predicate.ml
+++ b/src/lib/mina_base/snapp_predicate.ml
@@ -34,7 +34,7 @@ module Closed_interval = struct
   end]
 
   let to_input { lower; upper } ~f =
-    Random_oracle_input.append (f lower) (f upper)
+    Random_oracle_input.Chunked.append (f lower) (f upper)
 
   let typ x =
     Typ.of_hlistable [ x; x ] ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
@@ -54,9 +54,8 @@ module Numeric = struct
       ; compare : 'a -> 'a -> int
       ; equal : 'a -> 'a -> bool
       ; typ : ('var, 'a) Typ.t
-      ; to_input : 'a -> (F.t, bool) Random_oracle_input.t
-      ; to_input_checked :
-          'var -> (Field.Var.t, Boolean.var) Random_oracle_input.t
+      ; to_input : 'a -> F.t Random_oracle_input.Chunked.t
+      ; to_input_checked : 'var -> Field.Var.t Random_oracle_input.Chunked.t
       ; lte_checked : 'var -> 'var -> Boolean.var
       }
 
@@ -71,7 +70,7 @@ module Numeric = struct
         ; equal
         ; typ
         ; to_input
-        ; to_input_checked = Fn.compose Impl.run_checked Checked.to_input
+        ; to_input_checked = Checked.to_input
         }
 
     let amount =
@@ -107,7 +106,7 @@ module Numeric = struct
         ; equal
         ; typ
         ; to_input
-        ; to_input_checked = Fn.compose Impl.run_checked Checked.to_input
+        ; to_input_checked = Checked.to_input
         }
 
     let global_slot =
@@ -119,7 +118,7 @@ module Numeric = struct
         ; equal
         ; typ
         ; to_input
-        ; to_input_checked = Fn.compose Impl.run_checked Checked.to_input
+        ; to_input_checked = Checked.to_input
         }
 
     let token_id =
@@ -131,7 +130,7 @@ module Numeric = struct
         ; lte_checked = run Checked.( <= )
         ; typ
         ; to_input
-        ; to_input_checked = Fn.compose Impl.run_checked Checked.to_input
+        ; to_input_checked = Checked.to_input
         }
 
     let time =
@@ -142,11 +141,8 @@ module Numeric = struct
         ; zero
         ; max_value
         ; typ = Unpacked.typ
-        ; to_input = Fn.compose Random_oracle_input.bitstring Bits.to_bits
-        ; to_input_checked =
-            (fun x ->
-              Random_oracle_input.bitstring
-                (Unpacked.var_to_bits x :> Boolean.var list))
+        ; to_input
+        ; to_input_checked = Checked.to_input
         }
   end
 
@@ -205,15 +201,14 @@ module Eq_data = struct
       ; equal_checked : 'var -> 'var -> Boolean.var
       ; default : 'a
       ; typ : ('var, 'a) Typ.t
-      ; to_input : 'a -> (F.t, bool) Random_oracle_input.t
-      ; to_input_checked :
-          'var -> (Field.Var.t, Boolean.var) Random_oracle_input.t
+      ; to_input : 'a -> F.t Random_oracle_input.Chunked.t
+      ; to_input_checked : 'var -> Field.Var.t Random_oracle_input.Chunked.t
       }
 
     let run f x y = Impl.run_checked (f x y)
 
     let field =
-      let open Random_oracle_input in
+      let open Random_oracle_input.Chunked in
       Field.
         { typ
         ; equal
@@ -281,7 +276,7 @@ module Eq_data = struct
 
   let to_input ~explicit { Tc.default; to_input; _ } (t : _ t) =
     if explicit then
-      Flagged_option.to_input' ~f:to_input
+      Flagged_option.to_input' ~f:to_input ~field_of_bool
         ( match t with
         | Ignore ->
             { is_some = false; data = default }
@@ -400,7 +395,7 @@ module Account = struct
   let to_input
       ({ balance; nonce; receipt_chain_hash; public_key; delegate; state } : t)
       =
-    let open Random_oracle_input in
+    let open Random_oracle_input.Chunked in
     List.reduce_exn ~f:append
       [ Numeric.(to_input Tc.balance balance)
       ; Numeric.(to_input Tc.nonce nonce)
@@ -427,7 +422,7 @@ module Account = struct
     let to_input
         ({ balance; nonce; receipt_chain_hash; public_key; delegate; state } :
           t) =
-      let open Random_oracle_input in
+      let open Random_oracle_input.Chunked in
       List.reduce_exn ~f:append
         [ Numeric.(Checked.to_input Tc.balance balance)
         ; Numeric.(Checked.to_input Tc.nonce nonce)
@@ -566,7 +561,7 @@ module Protocol_state = struct
          ; epoch_length
          } :
           t) =
-      let open Random_oracle.Input in
+      let open Random_oracle.Input.Chunked in
       List.reduce_exn ~f:append
         [ Hash.(to_input Tc.frozen_ledger_hash hash)
         ; Numeric.(to_input Tc.amount total_currency)
@@ -595,7 +590,7 @@ module Protocol_state = struct
            ; epoch_length
            } :
             t) =
-        let open Random_oracle.Input in
+        let open Random_oracle.Input.Chunked in
         List.reduce_exn ~f:append
           [ Hash.(to_input_checked Tc.frozen_ledger_hash hash)
           ; Numeric.(Checked.to_input Tc.amount total_currency)
@@ -682,7 +677,7 @@ module Protocol_state = struct
        ; next_epoch_data
        } :
         t) =
-    let open Random_oracle.Input in
+    let open Random_oracle.Input.Chunked in
     let () = last_vrf_output in
     let length = Numeric.(to_input Tc.length) in
     List.reduce_exn ~f:append
@@ -775,7 +770,7 @@ module Protocol_state = struct
          ; next_epoch_data
          } :
           t) =
-      let open Random_oracle.Input in
+      let open Random_oracle.Input.Chunked in
       let () = last_vrf_output in
       let length = Numeric.(Checked.to_input Tc.length) in
       List.reduce_exn ~f:append
@@ -1052,12 +1047,19 @@ module Account_type = struct
     | _ ->
         assert false
 
-  let to_input x = Random_oracle_input.bitstring (to_bits x)
+  let to_input x =
+    let open Random_oracle_input.Chunked in
+    Array.reduce_exn ~f:append
+      (Array.of_list_map (to_bits x) ~f:(fun b -> packed (field_of_bool b, 1)))
 
   module Checked = struct
     type t = { user : Boolean.var; snapp : Boolean.var } [@@deriving hlist]
 
-    let to_input { user; snapp } = Random_oracle_input.bitstring [ user; snapp ]
+    let to_input { user; snapp } =
+      let open Random_oracle_input.Chunked in
+      Array.reduce_exn ~f:append
+        (Array.map [| user; snapp |] ~f:(fun b ->
+             packed ((b :> Field.Var.t), 1)))
 
     let constant =
       let open Boolean in
@@ -1140,7 +1142,7 @@ module Other = struct
       Poly.Stable.Latest.t
 
     let to_input ({ predicate; account_transition; account_vk } : t) =
-      let open Random_oracle_input in
+      let open Random_oracle_input.Chunked in
       List.reduce_exn ~f:append
         [ Account.Checked.to_input predicate
         ; Transition.to_input ~f:Account_state.Checked.to_input
@@ -1150,7 +1152,7 @@ module Other = struct
   end
 
   let to_input ({ predicate; account_transition; account_vk } : t) =
-    let open Random_oracle_input in
+    let open Random_oracle_input.Chunked in
     List.reduce_exn ~f:append
       [ Account.to_input predicate
       ; Transition.to_input ~f:Account_state.to_input account_transition
@@ -1212,7 +1214,7 @@ module Digested = F
 
 let to_input
     ({ self_predicate; other; fee_payer; protocol_state_predicate } : t) =
-  let open Random_oracle_input in
+  let open Random_oracle_input.Chunked in
   List.reduce_exn ~f:append
     [ Account.to_input self_predicate
     ; Other.to_input other
@@ -1278,7 +1280,7 @@ module Checked = struct
 
   let to_input
       ({ self_predicate; other; fee_payer; protocol_state_predicate } : t) =
-    let open Random_oracle_input in
+    let open Random_oracle_input.Chunked in
     List.reduce_exn ~f:append
       [ Account.Checked.to_input self_predicate
       ; Other.Checked.to_input other

--- a/src/lib/mina_base/snapp_state.ml
+++ b/src/lib/mina_base/snapp_state.ml
@@ -64,4 +64,4 @@ module Value = struct
 end
 
 let to_input (t : _ V.t) ~f =
-  Vector.(reduce_exn (map t ~f) ~f:Random_oracle_input.append)
+  Vector.(reduce_exn (map t ~f) ~f:Random_oracle_input.Chunked.append)

--- a/src/lib/mina_base/sok_message.ml
+++ b/src/lib/mina_base/sok_message.ml
@@ -1,4 +1,5 @@
 open Core
+open Util
 open Import
 
 [%%versioned
@@ -38,11 +39,15 @@ module Digest = struct
                     s
                 end)
 
+      open Snark_params.Tick
+
       let to_input t =
-        Random_oracle.Input.bitstring Fold_lib.Fold.(to_list (string_bits t))
+        Random_oracle.Input.Chunked.packeds
+          (Array.of_list_map
+             Fold_lib.Fold.(to_list (string_bits t))
+             ~f:(fun b -> (field_of_bool b, 1)))
 
       let typ =
-        let open Snark_params.Tick in
         Typ.array ~length:Blake2.digest_size_in_bits Boolean.typ
         |> Typ.transport ~there:Blake2.string_to_bits
              ~back:Blake2.bits_to_string
@@ -54,7 +59,9 @@ module Digest = struct
 
     type t = Boolean.var array
 
-    let to_input t = Random_oracle.Input.bitstring (Array.to_list t)
+    let to_input (t : t) =
+      Random_oracle.Input.Chunked.packeds
+        (Array.map t ~f:(fun b -> ((b :> Field.Var.t), 1)))
   end
 
   [%%define_locally Stable.Latest.(to_input, typ)]

--- a/src/lib/mina_base/sok_message.mli
+++ b/src/lib/mina_base/sok_message.mli
@@ -39,10 +39,10 @@ module Digest : sig
   module Checked : sig
     type t
 
-    val to_input : t -> (_, Boolean.var) Random_oracle.Input.t
+    val to_input : t -> Field.Var.t Random_oracle.Input.Chunked.t
   end
 
-  val to_input : t -> (_, bool) Random_oracle.Input.t
+  val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 
   val typ : (Checked.t, t) Typ.t
 

--- a/src/lib/mina_base/staged_ledger_hash.ml
+++ b/src/lib/mina_base/staged_ledger_hash.ml
@@ -1,6 +1,7 @@
 [%%import "../../config.mlh"]
 
 open Core
+open Util
 open Fold_lib
 open Snark_params.Tick
 
@@ -131,7 +132,12 @@ module Non_snark = struct
 
   let fold t = Fold.string_bits (digest t)
 
-  let to_input t = Random_oracle.Input.bitstring (Fold.to_list (fold t))
+  let to_input t =
+    let open Random_oracle.Input.Chunked in
+    Array.reduce_exn ~f:append
+      (Array.of_list_map
+         (Fold.to_list (fold t))
+         ~f:(fun b -> packed (field_of_bool b, 1)))
 
   let ledger_hash ({ ledger_hash; _ } : t) = ledger_hash
 
@@ -141,7 +147,10 @@ module Non_snark = struct
       =
     { aux_hash; ledger_hash; pending_coinbase_aux }
 
-  let var_to_input = Random_oracle.Input.bitstring
+  let var_to_input (t : var) =
+    let open Random_oracle.Input.Chunked in
+    Array.reduce_exn ~f:append
+      (Array.of_list_map t ~f:(fun b -> packed ((b :> Field.Var.t), 1)))
 
   let var_of_t t : var =
     List.map (Fold.to_list @@ fold t) ~f:Boolean.var_of_value
@@ -242,13 +251,13 @@ let var_of_t ({ pending_coinbase_hash; non_snark } : t) : var =
   { non_snark; pending_coinbase_hash }
 
 let to_input ({ non_snark; pending_coinbase_hash } : t) =
-  Random_oracle.Input.(
+  Random_oracle.Input.Chunked.(
     append
       (Non_snark.to_input non_snark)
       (field (pending_coinbase_hash :> Field.t)))
 
 let var_to_input ({ non_snark; pending_coinbase_hash } : var) =
-  Random_oracle.Input.(
+  Random_oracle.Input.Chunked.(
     append
       (Non_snark.var_to_input non_snark)
       (field (Pending_coinbase.Hash.var_to_hash_packed pending_coinbase_hash)))

--- a/src/lib/mina_base/staged_ledger_hash.mli
+++ b/src/lib/mina_base/staged_ledger_hash.mli
@@ -13,9 +13,9 @@ val var_of_t : t -> var
 
 val typ : (var, t) Typ.t
 
-val var_to_input : var -> (Field.Var.t, Boolean.var) Random_oracle.Input.t
+val var_to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
 
-val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 
 val genesis :
      constraint_constants:Genesis_constants.Constraint_constants.t

--- a/src/lib/mina_base/stake_delegation.ml
+++ b/src/lib/mina_base/stake_delegation.ml
@@ -48,8 +48,8 @@ let gen_with_delegator delegator =
 let gen =
   Quickcheck.Generator.bind ~f:gen_with_delegator Public_key.Compressed.gen
 
-let to_input = function
+let to_input_legacy = function
   | Set_delegate { delegator; new_delegate } ->
-      Random_oracle.Input.append
-        (Public_key.Compressed.to_input delegator)
-        (Public_key.Compressed.to_input new_delegate)
+      Random_oracle.Input.Legacy.append
+        (Public_key.Compressed.to_input_legacy delegator)
+        (Public_key.Compressed.to_input_legacy new_delegate)

--- a/src/lib/mina_base/token_id.ml
+++ b/src/lib/mina_base/token_id.ml
@@ -14,6 +14,8 @@ let default = T.of_uint64 Unsigned.UInt64.one
 
 let to_input = T.to_input
 
+let to_input_legacy = T.to_input_legacy
+
 let to_string = T.to_string
 
 let of_string = T.of_string
@@ -101,6 +103,8 @@ module Checked = struct
   let next_if = T.Checked.succ_if
 
   let to_input = T.Checked.to_input
+
+  let to_input_legacy = T.Checked.to_input_legacy
 
   let equal = T.Checked.equal
 

--- a/src/lib/mina_base/token_id.mli
+++ b/src/lib/mina_base/token_id.mli
@@ -21,7 +21,9 @@ module Stable : sig
   end
 end]
 
-val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+val to_input : t -> Field.t Random_oracle.Input.Chunked.t
+
+val to_input_legacy : t -> (Field.t, bool) Random_oracle.Input.Legacy.t
 
 val to_string : t -> string
 
@@ -73,8 +75,13 @@ val typ : (var, t) Typ.t
 val var_of_t : t -> var
 
 module Checked : sig
-  val to_input :
-    var -> ((Field.Var.t, Boolean.var) Random_oracle.Input.t, _) Tick.Checked.t
+  val to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
+
+  val to_input_legacy :
+       var
+    -> ( (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
+       , _ )
+       Tick.Checked.t
 
   val next : var -> (var, _) Checked.t
 

--- a/src/lib/mina_base/token_permissions.ml
+++ b/src/lib/mina_base/token_permissions.ml
@@ -22,11 +22,16 @@ end]
 
 let default = Not_owned { account_disabled = false }
 
-let to_input = function
-  | Token_owned { disable_new_accounts } ->
-      Random_oracle.Input.bitstring [ true; disable_new_accounts ]
-  | Not_owned { account_disabled } ->
-      Random_oracle.Input.bitstring [ false; account_disabled ]
+let to_input t =
+  let bs =
+    match t with
+    | Token_owned { disable_new_accounts } ->
+        [ true; disable_new_accounts ]
+    | Not_owned { account_disabled } ->
+        [ false; account_disabled ]
+  in
+  Random_oracle.Input.Chunked.packed
+    (Snark_params.Tick.Field.project bs, List.length bs)
 
 [%%ifdef consensus_mechanism]
 
@@ -78,7 +83,8 @@ let typ : (var, t) Typ.t =
   }
 
 let var_to_input { token_owner; token_locked } =
-  Random_oracle.Input.bitstring [ token_owner; token_locked ]
+  let bs = [ token_owner; token_locked ] in
+  Random_oracle.Input.Chunked.packed (Field.Var.project bs, List.length bs)
 
 [%%endif]
 

--- a/src/lib/mina_base/token_permissions.ml
+++ b/src/lib/mina_base/token_permissions.ml
@@ -2,9 +2,14 @@
 
 open Core_kernel
 
-[%%ifndef consensus_mechanism]
+[%%ifdef consensus_mechanism]
+
+open Snark_params.Tick
+
+[%%else]
 
 open Import
+open Snark_params_nonconsensus
 
 [%%endif]
 
@@ -30,8 +35,7 @@ let to_input t =
     | Not_owned { account_disabled } ->
         [ false; account_disabled ]
   in
-  Random_oracle.Input.Chunked.packed
-    (Snark_params.Tick.Field.project bs, List.length bs)
+  Random_oracle.Input.Chunked.packed (Field.project bs, List.length bs)
 
 [%%ifdef consensus_mechanism]
 

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -2292,8 +2292,8 @@ module For_tests = struct
       }
     in
     let signature =
-      Schnorr.sign sender.private_key
-        (Random_oracle.Input.field
+      Schnorr.Chunked.sign sender.private_key
+        (Random_oracle.Input.Chunked.field
            ( Parties.Transaction_commitment.create
                ~other_parties_hash:
                  (Parties.With_hashes.other_parties_hash parties)

--- a/src/lib/mina_base/transaction_union.ml
+++ b/src/lib/mina_base/transaction_union.ml
@@ -14,7 +14,9 @@ type t = (Payload.t, Public_key.t, Signature.t) t_
 type var = (Payload.var, Public_key.var, Signature.var) t_
 
 let typ : (var, t) Typ.t =
-  let spec = Data_spec.[ Payload.typ; Public_key.typ; Schnorr.Signature.typ ] in
+  let spec =
+    Data_spec.[ Payload.typ; Public_key.typ; Schnorr.Chunked.Signature.typ ]
+  in
   Typ.of_hlistable spec ~var_to_hlist:t__to_hlist ~var_of_hlist:t__of_hlist
     ~value_to_hlist:t__to_hlist ~value_of_hlist:t__of_hlist
 

--- a/src/lib/mina_base/transaction_union_payload.ml
+++ b/src/lib/mina_base/transaction_union_payload.ml
@@ -176,29 +176,30 @@ module Body = struct
       ; token_locked = Boolean.var_of_value token_locked
       }
 
-    let to_input { tag; source_pk; receiver_pk; token_id; amount; token_locked }
-        =
-      let%map token_id = Token_id.Checked.to_input token_id in
-      Array.reduce_exn ~f:Random_oracle.Input.append
-        [| Tag.Unpacked.to_input tag
-         ; Public_key.Compressed.Checked.to_input source_pk
-         ; Public_key.Compressed.Checked.to_input receiver_pk
+    let to_input_legacy
+        { tag; source_pk; receiver_pk; token_id; amount; token_locked } =
+      let%map token_id = Token_id.Checked.to_input_legacy token_id in
+      Array.reduce_exn ~f:Random_oracle.Input.Legacy.append
+        [| Tag.Unpacked.to_input_legacy tag
+         ; Public_key.Compressed.Checked.to_input_legacy source_pk
+         ; Public_key.Compressed.Checked.to_input_legacy receiver_pk
          ; token_id
-         ; Currency.Amount.var_to_input amount
-         ; Random_oracle.Input.bitstring [ token_locked ]
+         ; Currency.Amount.var_to_input_legacy amount
+         ; Random_oracle.Input.Legacy.bitstring [ token_locked ]
         |]
   end
 
   [%%endif]
 
-  let to_input { tag; source_pk; receiver_pk; token_id; amount; token_locked } =
-    Array.reduce_exn ~f:Random_oracle.Input.append
-      [| Tag.to_input tag
-       ; Public_key.Compressed.to_input source_pk
-       ; Public_key.Compressed.to_input receiver_pk
-       ; Token_id.to_input token_id
-       ; Currency.Amount.to_input amount
-       ; Random_oracle.Input.bitstring [ token_locked ]
+  let to_input_legacy
+      { tag; source_pk; receiver_pk; token_id; amount; token_locked } =
+    Array.reduce_exn ~f:Random_oracle.Input.Legacy.append
+      [| Tag.to_input_legacy tag
+       ; Public_key.Compressed.to_input_legacy source_pk
+       ; Public_key.Compressed.to_input_legacy receiver_pk
+       ; Token_id.to_input_legacy token_id
+       ; Currency.Amount.to_input_legacy amount
+       ; Random_oracle.Input.Legacy.bitstring [ token_locked ]
       |]
 end
 
@@ -236,10 +237,11 @@ let typ : (var, t) Typ.t =
 let payload_typ = typ
 
 module Checked = struct
-  let to_input ({ common; body } : var) =
-    let%map common = Signed_command_payload.Common.Checked.to_input common
-    and body = Body.Checked.to_input body in
-    Random_oracle.Input.append common body
+  let to_input_legacy ({ common; body } : var) =
+    let%map common =
+      Signed_command_payload.Common.Checked.to_input_legacy common
+    and body = Body.Checked.to_input_legacy body in
+    Random_oracle.Input.Legacy.append common body
 
   let constant ({ common; body } : t) : var =
     { common = Signed_command_payload.Common.Checked.constant common
@@ -249,10 +251,10 @@ end
 
 [%%endif]
 
-let to_input ({ common; body } : t) =
-  Random_oracle.Input.append
-    (Signed_command_payload.Common.to_input common)
-    (Body.to_input body)
+let to_input_legacy ({ common; body } : t) =
+  Random_oracle.Input.Legacy.append
+    (Signed_command_payload.Common.to_input_legacy common)
+    (Body.to_input_legacy body)
 
 let excess (payload : t) : Amount.Signed.t =
   let tag = payload.body.tag in

--- a/src/lib/mina_base/transaction_union_tag.ml
+++ b/src/lib/mina_base/transaction_union_tag.ml
@@ -64,7 +64,7 @@ module Bits = struct
 
   let to_bits (b1, b2, b3) = [ b1; b2; b3 ]
 
-  let to_input t = Random_oracle.Input.bitstring (to_bits t)
+  let to_input_legacy t = Random_oracle.Input.Legacy.bitstring (to_bits t)
 
   [%%ifdef consensus_mechanism]
 
@@ -270,7 +270,7 @@ module Unpacked = struct
 
   let to_bits t = Bits.to_bits (to_bits_var t)
 
-  let to_input t = Random_oracle.Input.bitstring (to_bits t)
+  let to_input_legacy t = Random_oracle.Input.Legacy.bitstring (to_bits t)
 
   [%%endif]
 end
@@ -291,7 +291,7 @@ let unpacked_t_of_t = function
 
 let to_bits tag = Bits.to_bits (Unpacked.to_bits_t (unpacked_t_of_t tag))
 
-let to_input tag = Random_oracle.Input.bitstring (to_bits tag)
+let to_input_legacy tag = Random_oracle.Input.Legacy.bitstring (to_bits tag)
 
 [%%ifdef consensus_mechanism]
 

--- a/src/lib/mina_base/transaction_union_tag.mli
+++ b/src/lib/mina_base/transaction_union_tag.mli
@@ -25,7 +25,7 @@ val gen : t Quickcheck.Generator.t
 
 val to_bits : t -> bool list
 
-val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+val to_input_legacy : t -> (Field.t, bool) Random_oracle.Input.Legacy.t
 
 [%%ifdef consensus_mechanism]
 
@@ -37,7 +37,8 @@ module Bits : sig
 
   val to_bits : var -> Boolean.var list
 
-  val to_input : var -> (Field.Var.t, Boolean.var) Random_oracle.Input.t
+  val to_input_legacy :
+    var -> (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
 end
 
 val bits_of_t : t -> Bits.var
@@ -66,7 +67,8 @@ module Unpacked : sig
 
   val to_bits : var -> Boolean.var list
 
-  val to_input : var -> (Field.Var.t, Boolean.var) Random_oracle.Input.t
+  val to_input_legacy :
+    var -> (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
 end
 
 val unpacked_of_t : t -> Unpacked.var

--- a/src/lib/mina_base/util.ml
+++ b/src/lib/mina_base/util.ml
@@ -1,5 +1,8 @@
 open Core_kernel
 
+let field_of_bool =
+  Snark_params.Tick.(fun b -> if b then Field.one else Field.zero)
+
 let bit_length_to_triple_length n =
   let r = n mod 3 in
   let k = n / 3 in

--- a/src/lib/mina_base/util.ml
+++ b/src/lib/mina_base/util.ml
@@ -1,7 +1,18 @@
+[%%import "/src/config.mlh"]
+
 open Core_kernel
 
-let field_of_bool =
-  Snark_params.Tick.(fun b -> if b then Field.one else Field.zero)
+[%%ifdef consensus_mechanism]
+
+open Snark_params.Tick
+
+[%%else]
+
+open Snark_params_nonconsensus
+
+[%%endif]
+
+let field_of_bool b = if b then Field.one else Field.zero
 
 let bit_length_to_triple_length n =
   let r = n mod 3 in

--- a/src/lib/mina_numbers/intf.ml
+++ b/src/lib/mina_numbers/intf.ml
@@ -8,10 +8,12 @@ open Unsigned
 [%%ifdef consensus_mechanism]
 
 open Snark_bits
+open Snark_params.Tick
 
 [%%else]
 
 open Snark_bits_nonconsensus
+open Snark_params_nonconsensus
 module Unsigned_extended = Unsigned_extended_nonconsensus.Unsigned_extended
 module Random_oracle = Random_oracle_nonconsensus.Random_oracle
 
@@ -62,7 +64,7 @@ module type S_unchecked = sig
 
   val of_bits : bool list -> t
 
-  val to_input : t -> Snark_params.Tick.Field.t Random_oracle.Input.Chunked.t
+  val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 
   val to_input_legacy : t -> (_, bool) Random_oracle.Legacy.Input.t
 

--- a/src/lib/mina_numbers/intf.ml
+++ b/src/lib/mina_numbers/intf.ml
@@ -62,7 +62,9 @@ module type S_unchecked = sig
 
   val of_bits : bool list -> t
 
-  val to_input : t -> (_, bool) Random_oracle.Input.t
+  val to_input : t -> Snark_params.Tick.Field.t Random_oracle.Input.Chunked.t
+
+  val to_input_legacy : t -> (_, bool) Random_oracle.Legacy.Input.t
 
   val fold : t -> bool Triple.t Fold.t
 end
@@ -107,7 +109,10 @@ module type S_checked = sig
 
   val to_bits : t -> (Boolean.var Bitstring.Lsb_first.t, _) Checked.t
 
-  val to_input : t -> ((_, Boolean.var) Random_oracle.Input.t, _) Checked.t
+  val to_input : t -> Field.Var.t Random_oracle.Input.Chunked.t
+
+  val to_input_legacy :
+    t -> ((_, Boolean.var) Random_oracle.Legacy.Input.t, _) Checked.t
 
   val to_integer : t -> field Snarky_integer.Integer.t
 

--- a/src/lib/mina_numbers/nat.ml
+++ b/src/lib/mina_numbers/nat.ml
@@ -116,8 +116,11 @@ struct
   let zero = zero_checked
 end
 
+open Snark_params.Tick
+
 [%%else]
 
+open Snark_params_nonconsensus
 open Snark_bits_nonconsensus
 
 [%%endif]
@@ -165,7 +168,7 @@ struct
 
   let to_input (t : t) =
     Random_oracle.Input.Chunked.packed
-      (Snark_params.Tick.Field.project (to_bits t), N.length_in_bits)
+      (Field.project (to_bits t), N.length_in_bits)
 
   let to_input_legacy t = Random_oracle.Input.Legacy.bitstring (to_bits t)
 

--- a/src/lib/mina_numbers/nat.ml
+++ b/src/lib/mina_numbers/nat.ml
@@ -34,8 +34,11 @@ struct
       (make_checked (fun () -> Integer.to_bits ~length:N.length_in_bits ~m t))
 
   let to_input t =
+    Random_oracle_input.Chunked.packed (to_field t, N.length_in_bits)
+
+  let to_input_legacy t =
     Checked.map (to_bits t) ~f:(fun bits ->
-        Random_oracle.Input.bitstring
+        Random_oracle.Input.Legacy.bitstring
           (Bitstring_lib.Bitstring.Lsb_first.to_list bits))
 
   let constant n = Integer.constant ~length:N.length_in_bits ~m (N.to_bigint n)
@@ -160,7 +163,11 @@ struct
 
   let of_bits = Bits.of_bits
 
-  let to_input t = Random_oracle.Input.bitstring (to_bits t)
+  let to_input (t : t) =
+    Random_oracle.Input.Chunked.packed
+      (Snark_params.Tick.Field.project (to_bits t), N.length_in_bits)
+
+  let to_input_legacy t = Random_oracle.Input.Legacy.bitstring (to_bits t)
 
   let fold t = Fold.group3 ~default:false (Bits.fold t)
 

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -82,18 +82,13 @@ let var_to_input
      ; timestamp
      } :
       var) =
-  let open Random_oracle.Input in
-  let%map.Checked snarked_next_available_token =
-    Token_id.Checked.to_input snarked_next_available_token
-  in
+  let open Random_oracle.Input.Chunked in
   List.reduce_exn ~f:append
     [ Staged_ledger_hash.var_to_input staged_ledger_hash
     ; field (Frozen_ledger_hash.var_to_hash_packed snarked_ledger_hash)
     ; field (Frozen_ledger_hash.var_to_hash_packed genesis_ledger_hash)
-    ; snarked_next_available_token
-    ; bitstring
-        (Bitstring_lib.Bitstring.Lsb_first.to_list
-           (Block_time.Unpacked.var_to_bits timestamp))
+    ; Token_id.Checked.to_input snarked_next_available_token
+    ; Block_time.Checked.to_input timestamp
     ]
 
 let to_input
@@ -104,13 +99,13 @@ let to_input
      ; timestamp
      } :
       Value.t) =
-  let open Random_oracle.Input in
+  let open Random_oracle.Input.Chunked in
   List.reduce_exn ~f:append
     [ Staged_ledger_hash.to_input staged_ledger_hash
     ; field (snarked_ledger_hash :> Field.t)
     ; field (genesis_ledger_hash :> Field.t)
     ; Token_id.to_input snarked_next_available_token
-    ; bitstring (Block_time.Bits.to_bits timestamp)
+    ; Block_time.to_input timestamp
     ]
 
 let set_timestamp t timestamp = { t with Poly.timestamp }

--- a/src/lib/mina_state/blockchain_state.mli
+++ b/src/lib/mina_state/blockchain_state.mli
@@ -83,10 +83,9 @@ val set_timestamp :
   -> 'time
   -> ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) Poly.t
 
-val to_input : Value.t -> (Field.t, bool) Random_oracle.Input.t
+val to_input : Value.t -> Field.t Random_oracle.Input.Chunked.t
 
-val var_to_input :
-  var -> ((Field.Var.t, Boolean.var) Random_oracle.Input.t, _) Checked.t
+val var_to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
 
 type display = (string, string, string, string) Poly.t [@@deriving yojson]
 

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -94,7 +94,7 @@ module Body = struct
       ; consensus_state
       ; constants
       } =
-    Random_oracle.Input.(
+    Random_oracle.Input.Chunked.(
       append
         (Blockchain_state.to_input blockchain_state)
         (Consensus.Data.Consensus_state.to_input consensus_state)
@@ -104,20 +104,18 @@ module Body = struct
   let var_to_input
       { Poly.genesis_state_hash; blockchain_state; consensus_state; constants }
       =
-    let%bind blockchain_state =
-      Blockchain_state.var_to_input blockchain_state
-    in
-    let%bind constants = Protocol_constants_checked.var_to_input constants in
-    let%map consensus_state =
+    let blockchain_state = Blockchain_state.var_to_input blockchain_state in
+    let constants = Protocol_constants_checked.var_to_input constants in
+    let consensus_state =
       Consensus.Data.Consensus_state.var_to_input consensus_state
     in
-    Random_oracle.Input.(
+    Random_oracle.Input.Chunked.(
       append blockchain_state consensus_state
       |> append (field (State_hash.var_to_hash_packed genesis_state_hash))
       |> append constants)
 
   let hash_checked (t : var) =
-    let%bind input = var_to_input t in
+    let input = var_to_input t in
     make_checked (fun () ->
         Random_oracle.Checked.(
           hash ~init:Hash_prefix.protocol_state_body (pack_input input)

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -122,7 +122,7 @@ module Compressed = struct
   let empty = Poly.{ x = Field.zero; is_odd = false }
 
   let to_input { Poly.x; is_odd } =
-    { Random_oracle.Input.field_elements = [| x |]
+    { Random_oracle.Input.Chunked.field_elements = [| x |]
     ; packeds = [| (Field.project [ is_odd ], 1) |]
     }
 
@@ -157,7 +157,7 @@ module Compressed = struct
       Boolean.(x_eq && odd_eq)
 
     let to_input ({ x; is_odd } : var) =
-      { Random_oracle.Input.field_elements = [| x |]
+      { Random_oracle.Input.Chunked.field_elements = [| x |]
       ; packeds = [| ((is_odd :> Field.Var.t), 1) |]
       }
 

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -123,6 +123,11 @@ module Compressed = struct
 
   let to_input { Poly.x; is_odd } =
     { Random_oracle.Input.field_elements = [| x |]
+    ; packeds = [| (Field.project [ is_odd ], 1) |]
+    }
+
+  let to_input_legacy { Poly.x; is_odd } =
+    { Random_oracle.Input.Legacy.field_elements = [| x |]
     ; bitstrings = [| [ is_odd ] |]
     }
 
@@ -151,7 +156,12 @@ module Compressed = struct
       let%bind odd_eq = Boolean.equal t1.is_odd t2.is_odd in
       Boolean.(x_eq && odd_eq)
 
-    let to_input = to_input
+    let to_input ({ x; is_odd } : var) =
+      { Random_oracle.Input.field_elements = [| x |]
+      ; packeds = [| ((is_odd :> Field.Var.t), 1) |]
+      }
+
+    let to_input_legacy = to_input_legacy
 
     let if_ cond ~then_:t1 ~else_:t2 =
       let%map x = Field.Checked.if_ cond ~then_:t1.Poly.x ~else_:t2.Poly.x

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1,3 +1,4 @@
+module Endo = Endo
 module P = Proof
 
 module type Statement_intf = Intf.Statement
@@ -814,6 +815,9 @@ module Side_loaded = struct
   module Verification_key = struct
     include Side_loaded_verification_key
 
+    let to_input (t : t) =
+      to_input ~field_of_int:Impls.Step.Field.Constant.of_int t
+
     let of_compiled tag : t =
       let d = Types_map.lookup_compiled tag.Tag.id in
       { wrap_vk = Some (Lazy.force d.wrap_vk)
@@ -1055,7 +1059,7 @@ let%test_module "test no side-loaded" =
                   Field.Constant.zero))
       in
       assert (
-        Async.Thread_safe.block_on_async_exn (fun () ->
+        Run_in_thread.block_on_async_exn (fun () ->
             Blockchain_snark.Proof.verify [ (Field.Constant.zero, b0) ]) ) ;
       let b1 =
         Common.time "b1" (fun () ->

--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -142,12 +142,12 @@ module Side_loaded : sig
 
     open Impls.Step
 
-    val to_input : t -> Field.Constant.t Random_oracle_input.t
+    val to_input : t -> Field.Constant.t Random_oracle_input.Chunked.t
 
     module Checked : sig
       type t
 
-      val to_input : t -> Field.t Random_oracle_input.t
+      val to_input : t -> Field.t Random_oracle_input.Chunked.t
     end
 
     val typ : (Checked.t, t) Impls.Step.Typ.t

--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -1,4 +1,5 @@
 module Scalar_challenge = Scalar_challenge
+module Endo = Endo
 open Core_kernel
 open Async_kernel
 open Pickles_types
@@ -141,12 +142,12 @@ module Side_loaded : sig
 
     open Impls.Step
 
-    val to_input : t -> (Field.Constant.t, bool) Random_oracle_input.t
+    val to_input : t -> Field.Constant.t Random_oracle_input.t
 
     module Checked : sig
       type t
 
-      val to_input : t -> (Field.t, Boolean.var) Random_oracle_input.t
+      val to_input : t -> Field.t Random_oracle_input.t
     end
 
     val typ : (Checked.t, t) Impls.Step.Typ.t

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -273,10 +273,10 @@ module Checked = struct
   let width_size = Nat.to_int Width.Length.n
 
   let to_input =
-    let open Random_oracle_input in
+    let open Random_oracle_input.Chunked in
     let map_reduce t ~f = Array.map t ~f |> Array.reduce_exn ~f:append in
     fun { step_domains; step_widths; max_width; wrap_index; num_branches } :
-        _ Random_oracle_input.t ->
+        _ Random_oracle_input.Chunked.t ->
       let width w = (Width.Checked.to_field w, width_size) in
       List.reduce_exn ~f:append
         [ map_reduce (Vector.to_array step_domains) ~f:(fun { Domains.h } ->

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -288,17 +288,17 @@ module Checked = struct
 
   type t =
     { step_domains : (Field.t Domain.t Domains.t, Max_branches.n) Vector.t
-      (** The domain size for proofs of each branch. *)
+          (** The domain size for proofs of each branch. *)
     ; step_widths : (Width.Checked.t, Max_branches.n) Vector.t
-      (** The width for for proofs of each branch. *)
+          (** The width for for proofs of each branch. *)
     ; max_width : Width.Checked.t
-      (** The maximum of all of the [step_widths]. *)
+          (** The maximum of all of the [step_widths]. *)
     ; wrap_index : Inner_curve.t Plonk_verification_key_evals.t
-      (** The plonk verification key for the 'wrapping' proof that this key is
-          used to verify.
-      *)
+          (** The plonk verification key for the 'wrapping' proof that this key
+              is used to verify.
+          *)
     ; num_branches : (Boolean.var, Max_branches.Log2.n) Vector.t
-      (** The number of branches, encoded as a bitstring. *)
+          (** The number of branches, encoded as a bitstring. *)
     }
   [@@deriving hlist, fields]
 

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -1,3 +1,28 @@
+(** A verification key for a pickles proof, whose contents are not fixed within
+    the verifier circuit.
+    This is used to verify a proof where the verification key is determined by
+    some other constraint, for example to use a verification key provided as
+    input to the circuit, or loaded from an account that was chosen based upon
+    the circuit inputs.
+
+    Here and elsewhere, we use the terms
+    * **width**:
+      - the number of proofs that a proof has verified itself;
+      - (equivalently) the maximum number of proofs that a proof depends upon
+        directly.
+      - NB: This does not include recursively-verified proofs, this only refers
+        to proofs that were provided directly to pickles when the proof was
+        being generated.
+    * **branch**:
+      - a single 'rule' or 'circuit' for which a proof can be generated, where
+        a verification key verifies a proof for any of these branches.
+      - It is common to have a 'base' branch and a 'recursion' branch. For
+        example, the transaction snark has a 'transaction' proof that evaluates
+        a single transaction and a 'merge' proof that combines two transaction
+        snark proofs that prove sequential updates, each of which may be either
+        a 'transaction' or a 'merge'.
+*)
+
 open Core_kernel
 open Pickles_types
 open Common
@@ -263,13 +288,21 @@ module Checked = struct
 
   type t =
     { step_domains : (Field.t Domain.t Domains.t, Max_branches.n) Vector.t
+      (** The domain size for proofs of each branch. *)
     ; step_widths : (Width.Checked.t, Max_branches.n) Vector.t
+      (** The width for for proofs of each branch. *)
     ; max_width : Width.Checked.t
+      (** The maximum of all of the [step_widths]. *)
     ; wrap_index : Inner_curve.t Plonk_verification_key_evals.t
+      (** The plonk verification key for the 'wrapping' proof that this key is
+          used to verify.
+      *)
     ; num_branches : (Boolean.var, Max_branches.Log2.n) Vector.t
+      (** The number of branches, encoded as a bitstring. *)
     }
   [@@deriving hlist, fields]
 
+  (** [log_2] of the width. *)
   let width_size = Nat.to_int Width.Length.n
 
   let to_input =

--- a/src/lib/pickles_base/side_loaded_verification_key.ml
+++ b/src/lib/pickles_base/side_loaded_verification_key.ml
@@ -191,15 +191,15 @@ let index_to_field_elements (k : 'a Plonk_verification_key_evals.t) ~g =
   |> Array.concat
 
 let wrap_index_to_input (type gs f) (g : gs -> f array) t =
-  Random_oracle_input.field_elements (index_to_field_elements t ~g)
+  Random_oracle_input.Chunked.field_elements (index_to_field_elements t ~g)
 
 let width_size = Nat.to_int Width.Length.n
 
 let to_input (type a) ~(field_of_int : int -> a) :
-    (a * a, _) Poly.t -> a Random_oracle_input.t =
-  let open Random_oracle_input in
+    (a * a, _) Poly.t -> a Random_oracle_input.Chunked.t =
+  let open Random_oracle_input.Chunked in
   let map_reduce t ~f = Array.map t ~f |> Array.reduce_exn ~f:append in
-  fun { step_data; max_width; wrap_index } : _ Random_oracle_input.t ->
+  fun { step_data; max_width; wrap_index } : _ Random_oracle_input.Chunked.t ->
     let num_branches =
       packed
         (field_of_int (At_most.length step_data), Nat.to_int Max_branches.Log2.n)

--- a/src/lib/random_oracle/intf.ml
+++ b/src/lib/random_oracle/intf.ml
@@ -1,6 +1,8 @@
 module Input = Random_oracle_input
 
 module type S = sig
+  type input
+
   module State : sig
     type _ t
   end
@@ -25,5 +27,5 @@ module type S = sig
 
   val hash : ?init:field_constant State.t -> field array -> Digest.t
 
-  val pack_input : (field, bool) Input.t -> field array
+  val pack_input : input -> field array
 end

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -107,9 +107,7 @@ let update ~state = update ~state params
 let hash ?init = hash ?init params
 
 let pow2 =
-  let rec pow2 acc n =
-    if n = 0 then acc else pow2 (Field.add acc acc) (n - 1)
-  in
+  let rec pow2 acc n = if n = 0 then acc else pow2 Field.(acc + acc) (n - 1) in
   Memo.general ~hashable:Int.hashable (fun n -> pow2 Field.one n)
 
 [%%ifdef consensus_mechanism]

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -146,6 +146,16 @@ module Checked = struct
   let digest xs = xs.(0)
 end
 
+let read_typ ({ field_elements; packeds } : _ Input.Chunked.t) =
+  let open Pickles.Impls.Step in
+  let open As_prover in
+  { Input.Chunked.field_elements = Array.map ~f:(read Field.typ) field_elements
+  ; packeds = Array.map packeds ~f:(fun (x, i) -> (read Field.typ x, i))
+  }
+
+let read_typ' input : _ Pickles.Impls.Step.Internal_Basic.As_prover.t =
+ fun _ x -> (x, read_typ input)
+
 [%%endif]
 
 let pack_input = Input.Chunked.pack_to_fields ~pow2 (module Field)

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -106,6 +106,12 @@ let update ~state = update ~state params
 
 let hash ?init = hash ?init params
 
+let pow2 =
+  let rec pow2 acc n =
+    if n = 0 then acc else pow2 (Field.add acc acc) (n - 1)
+  in
+  Memo.general ~hashable:Int.hashable (fun n -> pow2 Field.one n)
+
 [%%ifdef consensus_mechanism]
 
 module Checked = struct
@@ -133,15 +139,16 @@ module Checked = struct
         hash ?init:(Option.map init ~f:(State.map ~f:constant)) params xs)
 
   let pack_input =
-    Input.pack_to_fields ~size_in_bits:Field.size_in_bits ~pack:Field.Var.pack
+    Input.pack_to_fields
+      ~pow2:(Fn.compose Field.Var.constant pow2)
+      (module Pickles.Impls.Step.Field)
 
   let digest xs = xs.(0)
 end
 
 [%%endif]
 
-let pack_input =
-  Input.pack_to_fields ~size_in_bits:Field.size_in_bits ~pack:Field.project
+let pack_input = Input.pack_to_fields ~pow2 (module Field)
 
 let prefix_to_field (s : string) =
   let bits_per_character = 8 in
@@ -188,6 +195,8 @@ let%test_unit "check rust implementation of block-cipher" =
 [%%endif]
 
 module Legacy = struct
+  module Input = Random_oracle_input.Legacy
+
   let params : Field.t Sponge.Params.t =
     Sponge.Params.(map pasta_p ~f:Field.of_string)
 
@@ -224,14 +233,16 @@ module Legacy = struct
 
   let salt (s : string) = update ~state:initial_state [| prefix_to_field s |]
 
-  let pack_input = pack_input
+  let pack_input =
+    Input.pack_to_fields ~size_in_bits:Field.size_in_bits ~pack:Field.project
 
   module Digest = Digest
 
   [%%ifdef consensus_mechanism]
 
   module Checked = struct
-    let pack_input = Checked.pack_input
+    let pack_input =
+      Input.pack_to_fields ~size_in_bits:Field.size_in_bits ~pack:Field.Var.pack
 
     module Digest = Checked.Digest
 

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -139,7 +139,7 @@ module Checked = struct
         hash ?init:(Option.map init ~f:(State.map ~f:constant)) params xs)
 
   let pack_input =
-    Input.pack_to_fields
+    Input.Chunked.pack_to_fields
       ~pow2:(Fn.compose Field.Var.constant pow2)
       (module Pickles.Impls.Step.Field)
 
@@ -148,7 +148,7 @@ end
 
 [%%endif]
 
-let pack_input = Input.pack_to_fields ~pow2 (module Field)
+let pack_input = Input.Chunked.pack_to_fields ~pow2 (module Field)
 
 let prefix_to_field (s : string) =
   let bits_per_character = 8 in

--- a/src/lib/random_oracle/random_oracle.mli
+++ b/src/lib/random_oracle/random_oracle.mli
@@ -26,7 +26,7 @@ include
      and type field_constant := Field.t
      and type bool := bool
      and module State := State
-     and type input := Field.t Random_oracle_input.t
+     and type input := Field.t Random_oracle_input.Chunked.t
 
 val salt : string -> Field.t State.t
 
@@ -38,7 +38,7 @@ module Checked :
      and type field_constant := Field.t
      and type bool := Boolean.var
      and module State := State
-     and type input := Field.Var.t Random_oracle_input.t
+     and type input := Field.Var.t Random_oracle_input.Chunked.t
 
 [%%endif]
 

--- a/src/lib/random_oracle/random_oracle.mli
+++ b/src/lib/random_oracle/random_oracle.mli
@@ -26,6 +26,7 @@ include
      and type field_constant := Field.t
      and type bool := bool
      and module State := State
+     and type input := Field.t Random_oracle_input.t
 
 val salt : string -> Field.t State.t
 
@@ -37,16 +38,20 @@ module Checked :
      and type field_constant := Field.t
      and type bool := Boolean.var
      and module State := State
+     and type input := Field.Var.t Random_oracle_input.t
 
 [%%endif]
 
 module Legacy : sig
+  module Input = Random_oracle_input.Legacy
+
   include
     Intf.S
       with type field := Field.t
        and type field_constant := Field.t
        and type bool := bool
        and module State := State
+       and type input := (Field.t, bool) Random_oracle_input.Legacy.t
 
   val salt : string -> Field.t State.t
 
@@ -58,6 +63,7 @@ module Legacy : sig
        and type field_constant := Field.t
        and type bool := Boolean.var
        and module State := State
+       and type input := (Field.Var.t, Boolean.var) Random_oracle_input.Legacy.t
 
   [%%endif]
 end

--- a/src/lib/random_oracle/random_oracle.mli
+++ b/src/lib/random_oracle/random_oracle.mli
@@ -40,6 +40,16 @@ module Checked :
      and module State := State
      and type input := Field.Var.t Random_oracle_input.Chunked.t
 
+(** Read a value stored within a circuit. Must only be used in an [As_prover]
+    block.
+*)
+val read_typ : Field.Var.t Input.Chunked.t -> Field.t Input.Chunked.t
+
+(** Read a value stored within a circuit. *)
+val read_typ' :
+     Field.Var.t Input.Chunked.t
+  -> (Field.t Input.Chunked.t, _) Pickles.Impls.Step.Internal_Basic.As_prover.t
+
 [%%endif]
 
 module Legacy : sig

--- a/src/lib/random_oracle_input/random_oracle_input.ml
+++ b/src/lib/random_oracle_input/random_oracle_input.ml
@@ -1,255 +1,312 @@
 open Core_kernel
 
-type ('field, 'bool) t =
-  { field_elements : 'field array; bitstrings : 'bool list array }
+type 'field t =
+  { field_elements : 'field array; packeds : ('field * int) array }
 [@@deriving sexp, compare]
 
-let append t1 t2 =
+let append (t1 : _ t) (t2 : _ t) =
   { field_elements = Array.append t1.field_elements t2.field_elements
-  ; bitstrings = Array.append t1.bitstrings t2.bitstrings
+  ; packeds = Array.append t1.packeds t2.packeds
   }
 
-let field_elements x = { field_elements = x; bitstrings = [||] }
+let field_elements (a : 'f array) : 'f t =
+  { field_elements = a; packeds = [||] }
 
-let field x = { field_elements = [| x |]; bitstrings = [||] }
+let field x : _ t = field_elements [| x |]
 
-let bitstring x = { field_elements = [||]; bitstrings = [| x |] }
+let packeds a = { field_elements = [||]; packeds = a }
 
-let bitstrings x = { field_elements = [||]; bitstrings = x }
+let packed xn : _ t = packeds [| xn |]
 
-let pack_bits ~max_size ~pack { field_elements = _; bitstrings } =
-  let rec pack_full_fields rev_fields bits length =
-    if length >= max_size then
-      let field_bits, bits = List.split_n bits max_size in
-      pack_full_fields (pack field_bits :: rev_fields) bits (length - max_size)
-    else (rev_fields, bits, length)
-  in
-  let packed_field_elements, remaining_bits, remaining_length =
-    Array.fold bitstrings ~init:([], [], 0) ~f:(fun (acc, bits, n) bitstring ->
-        let n = n + List.length bitstring in
-        let bits = bits @ bitstring in
-        let acc, bits, n = pack_full_fields acc bits n in
-        (acc, bits, n))
-  in
-  if remaining_length = 0 then packed_field_elements
-  else pack remaining_bits :: packed_field_elements
+module type Field_intf = sig
+  type t
 
-let pack_to_fields ~size_in_bits ~pack { field_elements; bitstrings } =
-  let max_size = size_in_bits - 1 in
-  let packed_bits = pack_bits ~max_size ~pack { field_elements; bitstrings } in
-  Array.append field_elements (Array.of_list_rev packed_bits)
+  val size_in_bits : int
 
-let to_bits ~unpack { field_elements; bitstrings } =
-  let field_bits = Array.map ~f:unpack field_elements in
-  List.concat @@ Array.to_list @@ Array.append field_bits bitstrings
+  val zero : t
 
-module Coding = struct
-  (** See https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md for details on schema *)
+  val ( + ) : t -> t -> t
 
-  (** Serialize a random oracle input with 32byte fields into bytes according to the RFC0038 specification *)
-  let serialize ~string_of_field ~to_bool ~of_bool t =
-    let len_to_string x =
-      String.of_char_list
-        Char.
-          [ of_int_exn @@ ((x lsr 24) land 0xff)
-          ; of_int_exn @@ ((x lsr 16) land 0xff)
-          ; of_int_exn @@ ((x lsr 8) land 0xff)
-          ; of_int_exn @@ (x land 0xff)
-          ]
-    in
-    let len1 = len_to_string @@ Array.length t.field_elements in
-    let fields =
-      (* We only support 32byte fields *)
-      let () =
-        if Array.length t.field_elements > 0 then
-          assert (String.length (string_of_field t.field_elements.(0)) = 32)
-        else ()
-      in
-      Array.map t.field_elements ~f:string_of_field |> String.concat_array
-    in
-    let len2 =
-      len_to_string
-      @@ Array.sum (module Int) t.bitstrings ~f:(fun x -> List.length x)
-    in
-    let packed =
-      pack_bits t ~max_size:8 ~pack:(fun bs ->
-          let rec go i acc = function
-            | [] ->
-                acc
-            | b :: bs ->
-                go (i + 1) ((acc * 2) + if to_bool b then 1 else 0) bs
-          in
-          let pad =
-            List.init (8 - List.length bs) ~f:(Fn.const (of_bool false))
-          in
-          let combined = bs @ pad in
-          assert (List.length combined = 8) ;
-          go 0 0 combined)
-      |> List.map ~f:Char.of_int_exn
-      |> List.rev |> String.of_char_list
-    in
-    len1 ^ fields ^ len2 ^ packed
-
-  module Parser = struct
-    (* TODO: Before using this too much; use a solid parser library instead or beef this one up with more debugging info *)
-
-    (* The parser is a function over this monad-fail *)
-    module M = Result
-
-    module T = struct
-      type ('a, 'e) t = char list -> ('a * char list, 'e) M.t
-
-      let return a cs = M.return (a, cs)
-
-      let bind : ('a, 'e) t -> f:('a -> ('b, 'e) t) -> ('b, 'e) t =
-       fun t ~f cs ->
-        let open M.Let_syntax in
-        let%bind a, rest = t cs in
-        f a rest
-
-      let map = `Define_using_bind
-    end
-
-    include Monad.Make2 (T)
-
-    let run p cs =
-      p cs
-      |> M.bind ~f:(fun (a, cs') ->
-             match cs' with [] -> M.return a | _ -> M.fail `Expected_eof)
-
-    let fail why _ = M.fail why
-
-    let char c = function
-      | c' :: cs when Char.equal c c' ->
-          M.return (c', cs)
-      | c' :: _ ->
-          M.fail (`Unexpected_char c')
-      | [] ->
-          M.fail `Unexpected_eof
-
-    let u8 = function
-      | c :: cs ->
-          M.return (c, cs)
-      | [] ->
-          M.fail `Unexpected_eof
-
-    let u32 =
-      let open Let_syntax in
-      let open Char in
-      let%map a = u8 and b = u8 and c = u8 and d = u8 in
-      (to_int a lsl 24) lor (to_int b lsl 16) lor (to_int c lsl 8) lor to_int d
-
-    let eof = function [] -> M.return ((), []) | _ -> M.fail `Expected_eof
-
-    let take n cs =
-      if List.length cs < n then M.fail `Unexpected_eof
-      else M.return (List.split_n cs n)
-
-    (** p zero or more times, never fails *)
-    let many p =
-      (fun cs ->
-        let rec go xs acc =
-          match p xs with Ok (a, xs) -> go xs (a :: acc) | Error _ -> (acc, xs)
-        in
-        M.return @@ go cs [])
-      |> map ~f:List.rev
-
-    let%test_unit "many" =
-      [%test_eq: (char list, [ `Expected_eof ]) Result.t]
-        (run (many u8) [ 'a'; 'b'; 'c' ])
-        (Result.return [ 'a'; 'b'; 'c' ])
-
-    (** p exactly n times *)
-    let exactly n p =
-      (fun cs ->
-        let rec go xs acc = function
-          | 0 ->
-              M.return (acc, xs)
-          | i ->
-              let open M.Let_syntax in
-              let%bind a, xs = p xs in
-              go xs (a :: acc) (i - 1)
-        in
-        go cs [] n)
-      |> map ~f:List.rev
-
-    let%test_unit "exactly" =
-      [%test_eq:
-        (char list * char list, [ `Expected_eof | `Unexpected_eof ]) Result.t]
-        ((exactly 3 u8) [ 'a'; 'b'; 'c'; 'd' ])
-        (Result.return ([ 'a'; 'b'; 'c' ], [ 'd' ]))
-
-    let return_res r cs = r |> Result.map ~f:(fun x -> (x, cs))
-  end
-
-  let bits_of_byte ~of_bool b =
-    let b = Char.to_int b in
-    let f x =
-      of_bool
-        ( match x with
-        | 0 ->
-            false
-        | 1 ->
-            true
-        | _ ->
-            failwith "Unexpected boolean integer" )
-    in
-    [ (b land (0x1 lsl 7)) lsr 7
-    ; (b land (0x1 lsl 6)) lsr 6
-    ; (b land (0x1 lsl 5)) lsr 5
-    ; (b land (0x1 lsl 4)) lsr 4
-    ; (b land (0x1 lsl 3)) lsr 3
-    ; (b land (0x1 lsl 2)) lsr 2
-    ; (b land (0x1 lsl 1)) lsr 1
-    ; b land 0x1
-    ]
-    |> List.map ~f
-
-  (** Deserialize bytes into a random oracle input with 32byte fields according to the RFC0038 specification *)
-  let deserialize ~field_of_string ~of_bool s =
-    let field =
-      let open Parser.Let_syntax in
-      let%bind u8x32 = Parser.take 32 in
-      let s = String.of_char_list u8x32 in
-      Parser.return_res (field_of_string s)
-    in
-    let parser =
-      let open Parser.Let_syntax in
-      let%bind len1 = Parser.u32 in
-      let%bind fields = Parser.exactly len1 field in
-      let%bind len2 = Parser.u32 in
-      let%map bytes = Parser.(many u8) in
-      let bits = List.concat_map ~f:(bits_of_byte ~of_bool) bytes in
-      let bitstring = List.take bits len2 in
-      { field_elements = Array.of_list fields; bitstrings = [| bitstring |] }
-    in
-    Parser.run parser s
-
-  (** String of field as bits *)
-  let string_of_field xs =
-    List.chunks_of xs ~length:8
-    |> List.map ~f:(fun xs ->
-           let rec go i acc = function
-             | [] ->
-                 acc
-             | b :: bs ->
-                 go (i + 1) ((acc * 2) + if b then 1 else 0) bs
-           in
-           let pad = List.init (8 - List.length xs) ~f:(Fn.const false) in
-           let combined = xs @ pad in
-           assert (List.length combined = 8) ;
-           go 0 0 combined)
-    |> List.map ~f:Char.of_int_exn
-    |> String.of_char_list
-
-  (** Field of string as bits *)
-  let field_of_string s ~size_in_bits =
-    List.concat_map (String.to_list s) ~f:(bits_of_byte ~of_bool:Fn.id)
-    |> Fn.flip List.take size_in_bits
-    |> Result.return
+  val ( * ) : t -> t -> t
 end
 
-(** Coding2 is an alternate binary coding setup where we pass two arrays of
+let pack_to_fields (type t) (module F : Field_intf with type t = t)
+    ~(pow2 : int -> t) { field_elements; packeds } =
+  let shift_left acc n = F.( * ) acc (pow2 n) in
+  let open F in
+  let packed_bits =
+    let xs, acc, acc_n =
+      Array.fold packeds ~init:([], zero, 0) ~f:(fun (xs, acc, acc_n) (x, n) ->
+          let n' = Int.(n + acc_n) in
+          if Int.(n' < size_in_bits) then (xs, shift_left acc n + x, n')
+          else (acc :: xs, zero, 0))
+    in
+    let xs = if acc_n > 0 then acc :: xs else xs in
+    Array.of_list_rev xs
+  in
+  Array.append field_elements packed_bits
+
+module Legacy = struct
+  type ('field, 'bool) t =
+    { field_elements : 'field array; bitstrings : 'bool list array }
+  [@@deriving sexp, compare]
+
+  let append t1 t2 =
+    { field_elements = Array.append t1.field_elements t2.field_elements
+    ; bitstrings = Array.append t1.bitstrings t2.bitstrings
+    }
+
+  let field_elements x = { field_elements = x; bitstrings = [||] }
+
+  let field x = { field_elements = [| x |]; bitstrings = [||] }
+
+  let bitstring x = { field_elements = [||]; bitstrings = [| x |] }
+
+  let bitstrings x = { field_elements = [||]; bitstrings = x }
+
+  let pack_bits ~max_size ~pack { field_elements = _; bitstrings } =
+    let rec pack_full_fields rev_fields bits length =
+      if length >= max_size then
+        let field_bits, bits = List.split_n bits max_size in
+        pack_full_fields (pack field_bits :: rev_fields) bits (length - max_size)
+      else (rev_fields, bits, length)
+    in
+    let packed_field_elements, remaining_bits, remaining_length =
+      Array.fold bitstrings ~init:([], [], 0)
+        ~f:(fun (acc, bits, n) bitstring ->
+          let n = n + List.length bitstring in
+          let bits = bits @ bitstring in
+          let acc, bits, n = pack_full_fields acc bits n in
+          (acc, bits, n))
+    in
+    if remaining_length = 0 then packed_field_elements
+    else pack remaining_bits :: packed_field_elements
+
+  let pack_to_fields ~size_in_bits ~pack { field_elements; bitstrings } =
+    let max_size = size_in_bits - 1 in
+    let packed_bits =
+      pack_bits ~max_size ~pack { field_elements; bitstrings }
+    in
+    Array.append field_elements (Array.of_list_rev packed_bits)
+
+  let to_bits ~unpack { field_elements; bitstrings } =
+    let field_bits = Array.map ~f:unpack field_elements in
+    List.concat @@ Array.to_list @@ Array.append field_bits bitstrings
+
+  module Coding = struct
+    (** See https://github.com/CodaProtocol/coda/blob/develop/rfcs/0038-rosetta-construction-api.md for details on schema *)
+
+    (** Serialize a random oracle input with 32byte fields into bytes according to the RFC0038 specification *)
+    let serialize ~string_of_field ~to_bool ~of_bool t =
+      let len_to_string x =
+        String.of_char_list
+          Char.
+            [ of_int_exn @@ ((x lsr 24) land 0xff)
+            ; of_int_exn @@ ((x lsr 16) land 0xff)
+            ; of_int_exn @@ ((x lsr 8) land 0xff)
+            ; of_int_exn @@ (x land 0xff)
+            ]
+      in
+      let len1 = len_to_string @@ Array.length t.field_elements in
+      let fields =
+        (* We only support 32byte fields *)
+        let () =
+          if Array.length t.field_elements > 0 then
+            assert (String.length (string_of_field t.field_elements.(0)) = 32)
+          else ()
+        in
+        Array.map t.field_elements ~f:string_of_field |> String.concat_array
+      in
+      let len2 =
+        len_to_string
+        @@ Array.sum (module Int) t.bitstrings ~f:(fun x -> List.length x)
+      in
+      let packed =
+        pack_bits t ~max_size:8 ~pack:(fun bs ->
+            let rec go i acc = function
+              | [] ->
+                  acc
+              | b :: bs ->
+                  go (i + 1) ((acc * 2) + if to_bool b then 1 else 0) bs
+            in
+            let pad =
+              List.init (8 - List.length bs) ~f:(Fn.const (of_bool false))
+            in
+            let combined = bs @ pad in
+            assert (List.length combined = 8) ;
+            go 0 0 combined)
+        |> List.map ~f:Char.of_int_exn
+        |> List.rev |> String.of_char_list
+      in
+      len1 ^ fields ^ len2 ^ packed
+
+    module Parser = struct
+      (* TODO: Before using this too much; use a solid parser library instead or beef this one up with more debugging info *)
+
+      (* The parser is a function over this monad-fail *)
+      module M = Result
+
+      module T = struct
+        type ('a, 'e) t = char list -> ('a * char list, 'e) M.t
+
+        let return a cs = M.return (a, cs)
+
+        let bind : ('a, 'e) t -> f:('a -> ('b, 'e) t) -> ('b, 'e) t =
+         fun t ~f cs ->
+          let open M.Let_syntax in
+          let%bind a, rest = t cs in
+          f a rest
+
+        let map = `Define_using_bind
+      end
+
+      include Monad.Make2 (T)
+
+      let run p cs =
+        p cs
+        |> M.bind ~f:(fun (a, cs') ->
+               match cs' with [] -> M.return a | _ -> M.fail `Expected_eof)
+
+      let fail why _ = M.fail why
+
+      let char c = function
+        | c' :: cs when Char.equal c c' ->
+            M.return (c', cs)
+        | c' :: _ ->
+            M.fail (`Unexpected_char c')
+        | [] ->
+            M.fail `Unexpected_eof
+
+      let u8 = function
+        | c :: cs ->
+            M.return (c, cs)
+        | [] ->
+            M.fail `Unexpected_eof
+
+      let u32 =
+        let open Let_syntax in
+        let open Char in
+        let%map a = u8 and b = u8 and c = u8 and d = u8 in
+        (to_int a lsl 24)
+        lor (to_int b lsl 16)
+        lor (to_int c lsl 8)
+        lor to_int d
+
+      let eof = function [] -> M.return ((), []) | _ -> M.fail `Expected_eof
+
+      let take n cs =
+        if List.length cs < n then M.fail `Unexpected_eof
+        else M.return (List.split_n cs n)
+
+      (** p zero or more times, never fails *)
+      let many p =
+        (fun cs ->
+          let rec go xs acc =
+            match p xs with
+            | Ok (a, xs) ->
+                go xs (a :: acc)
+            | Error _ ->
+                (acc, xs)
+          in
+          M.return @@ go cs [])
+        |> map ~f:List.rev
+
+      let%test_unit "many" =
+        [%test_eq: (char list, [ `Expected_eof ]) Result.t]
+          (run (many u8) [ 'a'; 'b'; 'c' ])
+          (Result.return [ 'a'; 'b'; 'c' ])
+
+      (** p exactly n times *)
+      let exactly n p =
+        (fun cs ->
+          let rec go xs acc = function
+            | 0 ->
+                M.return (acc, xs)
+            | i ->
+                let open M.Let_syntax in
+                let%bind a, xs = p xs in
+                go xs (a :: acc) (i - 1)
+          in
+          go cs [] n)
+        |> map ~f:List.rev
+
+      let%test_unit "exactly" =
+        [%test_eq:
+          (char list * char list, [ `Expected_eof | `Unexpected_eof ]) Result.t]
+          ((exactly 3 u8) [ 'a'; 'b'; 'c'; 'd' ])
+          (Result.return ([ 'a'; 'b'; 'c' ], [ 'd' ]))
+
+      let return_res r cs = r |> Result.map ~f:(fun x -> (x, cs))
+    end
+
+    let bits_of_byte ~of_bool b =
+      let b = Char.to_int b in
+      let f x =
+        of_bool
+          ( match x with
+          | 0 ->
+              false
+          | 1 ->
+              true
+          | _ ->
+              failwith "Unexpected boolean integer" )
+      in
+      [ (b land (0x1 lsl 7)) lsr 7
+      ; (b land (0x1 lsl 6)) lsr 6
+      ; (b land (0x1 lsl 5)) lsr 5
+      ; (b land (0x1 lsl 4)) lsr 4
+      ; (b land (0x1 lsl 3)) lsr 3
+      ; (b land (0x1 lsl 2)) lsr 2
+      ; (b land (0x1 lsl 1)) lsr 1
+      ; b land 0x1
+      ]
+      |> List.map ~f
+
+    (** Deserialize bytes into a random oracle input with 32byte fields according to the RFC0038 specification *)
+    let deserialize ~field_of_string ~of_bool s =
+      let field =
+        let open Parser.Let_syntax in
+        let%bind u8x32 = Parser.take 32 in
+        let s = String.of_char_list u8x32 in
+        Parser.return_res (field_of_string s)
+      in
+      let parser =
+        let open Parser.Let_syntax in
+        let%bind len1 = Parser.u32 in
+        let%bind fields = Parser.exactly len1 field in
+        let%bind len2 = Parser.u32 in
+        let%map bytes = Parser.(many u8) in
+        let bits = List.concat_map ~f:(bits_of_byte ~of_bool) bytes in
+        let bitstring = List.take bits len2 in
+        { field_elements = Array.of_list fields; bitstrings = [| bitstring |] }
+      in
+      Parser.run parser s
+
+    (** String of field as bits *)
+    let string_of_field xs =
+      List.chunks_of xs ~length:8
+      |> List.map ~f:(fun xs ->
+             let rec go i acc = function
+               | [] ->
+                   acc
+               | b :: bs ->
+                   go (i + 1) ((acc * 2) + if b then 1 else 0) bs
+             in
+             let pad = List.init (8 - List.length xs) ~f:(Fn.const false) in
+             let combined = xs @ pad in
+             assert (List.length combined = 8) ;
+             go 0 0 combined)
+      |> List.map ~f:Char.of_int_exn
+      |> String.of_char_list
+
+    (** Field of string as bits *)
+    let field_of_string s ~size_in_bits =
+      List.concat_map (String.to_list s) ~f:(bits_of_byte ~of_bool:Fn.id)
+      |> Fn.flip List.take size_in_bits
+      |> Result.return
+  end
+
+  (** Coding2 is an alternate binary coding setup where we pass two arrays of
  *  field elements instead of a single structure to simplify manipulation
  *  outside of the Mina construction API
  *
@@ -257,217 +314,220 @@ end
  * RFC0038
  *
 *)
-module Coding2 = struct
-  module Rendered = struct
-    (* as bytes, you must hex this later *)
-    type 'field t_ = { prefix : 'field array; suffix : 'field array }
-    [@@deriving yojson]
+  module Coding2 = struct
+    module Rendered = struct
+      (* as bytes, you must hex this later *)
+      type 'field t_ = { prefix : 'field array; suffix : 'field array }
+      [@@deriving yojson]
 
-    type t = string t_ [@@deriving yojson]
+      type t = string t_ [@@deriving yojson]
 
-    let map ~f { prefix; suffix } =
-      { prefix = Array.map ~f prefix; suffix = Array.map ~f suffix }
+      let map ~f { prefix; suffix } =
+        { prefix = Array.map ~f prefix; suffix = Array.map ~f suffix }
+    end
+
+    let string_of_field : bool list -> string = Coding.string_of_field
+
+    let field_of_string = Coding.field_of_string
+
+    let serialize' t ~pack =
+      { Rendered.prefix = t.field_elements
+      ; suffix = pack_bits ~max_size:254 ~pack t |> Array.of_list_rev
+      }
+
+    let serialize t ~string_of_field ~pack =
+      let () =
+        if Array.length t.field_elements > 0 then
+          assert (String.length (string_of_field t.field_elements.(0)) = 32)
+        else ()
+      in
+      serialize' t ~pack |> Rendered.map ~f:string_of_field
   end
 
-  let string_of_field : bool list -> string = Coding.string_of_field
+  let%test_module "random_oracle input" =
+    ( module struct
+      let gen_field ~size_in_bits =
+        let open Quickcheck.Generator in
+        list_with_length size_in_bits bool
 
-  let field_of_string = Coding.field_of_string
+      let gen_input ?size_in_bits () =
+        let open Quickcheck.Generator in
+        let open Let_syntax in
+        let%bind size_in_bits =
+          size_in_bits |> Option.map ~f:return
+          |> Option.value ~default:(Int.gen_incl 2 3000)
+        in
+        let%bind field_elements =
+          (* Treat a field as a list of bools of length [size_in_bits]. *)
+          list (gen_field ~size_in_bits)
+        in
+        let%map bitstrings = list (list bool) in
+        ( size_in_bits
+        , { field_elements = Array.of_list field_elements
+          ; bitstrings = Array.of_list bitstrings
+          } )
 
-  let serialize' t ~pack =
-    { Rendered.prefix = t.field_elements
-    ; suffix = pack_bits ~max_size:254 ~pack t |> Array.of_list_rev
-    }
+      let%test_unit "coding2 equiv to hash directly" =
+        let size_in_bits = 255 in
+        let field = gen_field ~size_in_bits in
+        Quickcheck.test ~trials:300
+          Quickcheck.Generator.(
+            tuple2 (gen_input ~size_in_bits ()) (tuple2 field field))
+          ~f:(fun ((_, input), (x, y)) ->
+            let middle = [| x; y |] in
+            let expected =
+              append input (field_elements middle)
+              |> pack_to_fields ~size_in_bits ~pack:Fn.id
+            in
+            let { Coding2.Rendered.prefix; suffix } =
+              Coding2.serialize' input ~pack:Fn.id
+            in
+            let actual = Array.(concat [ prefix; middle; suffix ]) in
+            [%test_eq: bool list array] expected actual)
 
-  let serialize t ~string_of_field ~pack =
-    let () =
-      if Array.length t.field_elements > 0 then
-        assert (String.length (string_of_field t.field_elements.(0)) = 32)
-      else ()
-    in
-    serialize' t ~pack |> Rendered.map ~f:string_of_field
+      let%test_unit "field/string partial isomorphism bitstrings" =
+        Quickcheck.test ~trials:300
+          Quickcheck.Generator.(list_with_length 255 bool)
+          ~f:(fun input ->
+            let serialized = Coding.string_of_field input in
+            let deserialized =
+              Coding.field_of_string serialized ~size_in_bits:255
+            in
+            [%test_eq: (bool list, unit) Result.t] (input |> Result.return)
+              deserialized)
+
+      let%test_unit "serialize/deserialize partial isomorphism 32byte fields" =
+        let size_in_bits = 255 in
+        Quickcheck.test ~trials:3000 (gen_input ~size_in_bits ())
+          ~f:(fun (_, input) ->
+            let serialized =
+              Coding.(
+                serialize ~string_of_field ~to_bool:Fn.id ~of_bool:Fn.id input)
+            in
+            let deserialized =
+              Coding.(
+                deserialize
+                  (String.to_list serialized)
+                  ~field_of_string:(field_of_string ~size_in_bits)
+                  ~of_bool:Fn.id)
+            in
+            let normalized t =
+              { t with
+                bitstrings =
+                  ( t.bitstrings |> Array.to_list |> List.concat
+                  |> fun xs -> [| xs |] )
+              }
+            in
+            assert (
+              Array.for_all input.field_elements ~f:(fun el ->
+                  List.length el = size_in_bits) ) ;
+            Result.iter deserialized ~f:(fun x ->
+                assert (
+                  Array.for_all x.field_elements ~f:(fun el ->
+                      List.length el = size_in_bits) )) ;
+            [%test_eq:
+              ( (bool list, bool) t
+              , [ `Expected_eof | `Unexpected_eof ] )
+              Result.t]
+              (normalized input |> Result.return)
+              (deserialized |> Result.map ~f:normalized))
+
+      let%test_unit "data is preserved by to_bits" =
+        Quickcheck.test ~trials:300 (gen_input ())
+          ~f:(fun (size_in_bits, input) ->
+            let bits = to_bits ~unpack:Fn.id input in
+            let bools_equal = [%equal: bool list] in
+            (* Fields are accumulated at the front, check them first. *)
+            let bitstring_bits =
+              Array.fold ~init:bits input.field_elements ~f:(fun bits field ->
+                  (* The next chunk of [size_in_bits] bits is for the field
+                           element.
+                  *)
+                  let field_bits, rest = List.split_n bits size_in_bits in
+                  assert (bools_equal field_bits field) ;
+                  rest)
+            in
+            (* Bits come after. *)
+            let remaining_bits =
+              Array.fold ~init:bitstring_bits input.bitstrings
+                ~f:(fun bits bitstring ->
+                  (* The next bits match the bitstring. *)
+                  let bitstring_bits, rest =
+                    List.split_n bits (List.length bitstring)
+                  in
+                  assert (bools_equal bitstring_bits bitstring) ;
+                  rest)
+            in
+            (* All bits should have been consumed. *)
+            assert (List.is_empty remaining_bits))
+
+      let%test_unit "data is preserved by pack_to_fields" =
+        Quickcheck.test ~trials:300 (gen_input ())
+          ~f:(fun (size_in_bits, input) ->
+            let fields = pack_to_fields ~size_in_bits ~pack:Fn.id input in
+            (* Fields are accumulated at the front, check them first. *)
+            let fields = Array.to_list fields in
+            let bitstring_fields =
+              Array.fold ~init:fields input.field_elements
+                ~f:(fun fields input_field ->
+                  (* The next field element should be the literal field element
+                                     passed in.
+                  *)
+                  match fields with
+                  | [] ->
+                      failwith "Too few field elements"
+                  | field :: rest ->
+                      assert ([%equal: bool list] field input_field) ;
+                      rest)
+            in
+            (* Check that the remaining fields have the correct size. *)
+            let final_field_idx = List.length bitstring_fields - 1 in
+            List.iteri bitstring_fields ~f:(fun i field_bits ->
+                if i < final_field_idx then
+                  (* This field should be densely packed, but should contain
+                         fewer bits than the maximum field element to ensure that it
+                         doesn't overflow, so we expect [size_in_bits - 1] bits for
+                         maximum safe density.
+                  *)
+                  assert (List.length field_bits = size_in_bits - 1)
+                else (
+                  (* This field will be comprised of the remaining bits, up to a
+                         maximum of [size_in_bits - 1]. It should not be empty.
+                  *)
+                  assert (not (List.is_empty field_bits)) ;
+                  assert (List.length field_bits < size_in_bits) )) ;
+            let rec go input_bitstrings packed_fields =
+              match (input_bitstrings, packed_fields) with
+              | [], [] ->
+                  (* We have consumed all bitstrings and fields in parallel, with
+                     no bits left over. Success.
+                  *)
+                  ()
+              | [] :: input_bitstrings, packed_fields
+              | input_bitstrings, [] :: packed_fields ->
+                  (* We have consumed the whole of an input bitstring or the whole
+                     of a packed field, move onto the next one.
+                  *)
+                  go input_bitstrings packed_fields
+              | ( (bi :: input_bitstring) :: input_bitstrings
+                , (bp :: packed_field) :: packed_fields ) ->
+                  (* Consume the next bit from the next input bitstring, and the
+                     next bit from the next packed field. They must match.
+                  *)
+                  assert (Bool.equal bi bp) ;
+                  go
+                    (input_bitstring :: input_bitstrings)
+                    (packed_field :: packed_fields)
+              | [], _ ->
+                  failwith "Packed fields contain more bits than were provided"
+              | _, [] ->
+                  failwith
+                    "There are input bits that were not present in the packed \
+                     fields"
+            in
+            (* Check that the bits match between the input bitstring and the
+                   remaining fields.
+            *)
+            go (Array.to_list input.bitstrings) bitstring_fields)
+    end )
 end
-
-let%test_module "random_oracle input" =
-  ( module struct
-    let gen_field ~size_in_bits =
-      let open Quickcheck.Generator in
-      list_with_length size_in_bits bool
-
-    let gen_input ?size_in_bits () =
-      let open Quickcheck.Generator in
-      let open Let_syntax in
-      let%bind size_in_bits =
-        size_in_bits |> Option.map ~f:return
-        |> Option.value ~default:(Int.gen_incl 2 3000)
-      in
-      let%bind field_elements =
-        (* Treat a field as a list of bools of length [size_in_bits]. *)
-        list (gen_field ~size_in_bits)
-      in
-      let%map bitstrings = list (list bool) in
-      ( size_in_bits
-      , { field_elements = Array.of_list field_elements
-        ; bitstrings = Array.of_list bitstrings
-        } )
-
-    let%test_unit "coding2 equiv to hash directly" =
-      let size_in_bits = 255 in
-      let field = gen_field ~size_in_bits in
-      Quickcheck.test ~trials:300
-        Quickcheck.Generator.(
-          tuple2 (gen_input ~size_in_bits ()) (tuple2 field field))
-        ~f:(fun ((_, input), (x, y)) ->
-          let middle = [| x; y |] in
-          let expected =
-            append input (field_elements middle)
-            |> pack_to_fields ~size_in_bits ~pack:Fn.id
-          in
-          let { Coding2.Rendered.prefix; suffix } =
-            Coding2.serialize' input ~pack:Fn.id
-          in
-          let actual = Array.(concat [ prefix; middle; suffix ]) in
-          [%test_eq: bool list array] expected actual)
-
-    let%test_unit "field/string partial isomorphism bitstrings" =
-      Quickcheck.test ~trials:300
-        Quickcheck.Generator.(list_with_length 255 bool)
-        ~f:(fun input ->
-          let serialized = Coding.string_of_field input in
-          let deserialized =
-            Coding.field_of_string serialized ~size_in_bits:255
-          in
-          [%test_eq: (bool list, unit) Result.t] (input |> Result.return)
-            deserialized)
-
-    let%test_unit "serialize/deserialize partial isomorphism 32byte fields" =
-      let size_in_bits = 255 in
-      Quickcheck.test ~trials:3000 (gen_input ~size_in_bits ())
-        ~f:(fun (_, input) ->
-          let serialized =
-            Coding.(
-              serialize ~string_of_field ~to_bool:Fn.id ~of_bool:Fn.id input)
-          in
-          let deserialized =
-            Coding.(
-              deserialize
-                (String.to_list serialized)
-                ~field_of_string:(field_of_string ~size_in_bits)
-                ~of_bool:Fn.id)
-          in
-          let normalized t =
-            { t with
-              bitstrings =
-                ( t.bitstrings |> Array.to_list |> List.concat
-                |> fun xs -> [| xs |] )
-            }
-          in
-          assert (
-            Array.for_all input.field_elements ~f:(fun el ->
-                List.length el = size_in_bits) ) ;
-          Result.iter deserialized ~f:(fun x ->
-              assert (
-                Array.for_all x.field_elements ~f:(fun el ->
-                    List.length el = size_in_bits) )) ;
-          [%test_eq:
-            ((bool list, bool) t, [ `Expected_eof | `Unexpected_eof ]) Result.t]
-            (normalized input |> Result.return)
-            (deserialized |> Result.map ~f:normalized))
-
-    let%test_unit "data is preserved by to_bits" =
-      Quickcheck.test ~trials:300 (gen_input ())
-        ~f:(fun (size_in_bits, input) ->
-          let bits = to_bits ~unpack:Fn.id input in
-          let bools_equal = [%equal: bool list] in
-          (* Fields are accumulated at the front, check them first. *)
-          let bitstring_bits =
-            Array.fold ~init:bits input.field_elements ~f:(fun bits field ->
-                (* The next chunk of [size_in_bits] bits is for the field
-                         element.
-                *)
-                let field_bits, rest = List.split_n bits size_in_bits in
-                assert (bools_equal field_bits field) ;
-                rest)
-          in
-          (* Bits come after. *)
-          let remaining_bits =
-            Array.fold ~init:bitstring_bits input.bitstrings
-              ~f:(fun bits bitstring ->
-                (* The next bits match the bitstring. *)
-                let bitstring_bits, rest =
-                  List.split_n bits (List.length bitstring)
-                in
-                assert (bools_equal bitstring_bits bitstring) ;
-                rest)
-          in
-          (* All bits should have been consumed. *)
-          assert (List.is_empty remaining_bits))
-
-    let%test_unit "data is preserved by pack_to_fields" =
-      Quickcheck.test ~trials:300 (gen_input ())
-        ~f:(fun (size_in_bits, input) ->
-          let fields = pack_to_fields ~size_in_bits ~pack:Fn.id input in
-          (* Fields are accumulated at the front, check them first. *)
-          let fields = Array.to_list fields in
-          let bitstring_fields =
-            Array.fold ~init:fields input.field_elements
-              ~f:(fun fields input_field ->
-                (* The next field element should be the literal field element
-                                   passed in.
-                *)
-                match fields with
-                | [] ->
-                    failwith "Too few field elements"
-                | field :: rest ->
-                    assert ([%equal: bool list] field input_field) ;
-                    rest)
-          in
-          (* Check that the remaining fields have the correct size. *)
-          let final_field_idx = List.length bitstring_fields - 1 in
-          List.iteri bitstring_fields ~f:(fun i field_bits ->
-              if i < final_field_idx then
-                (* This field should be densely packed, but should contain
-                       fewer bits than the maximum field element to ensure that it
-                       doesn't overflow, so we expect [size_in_bits - 1] bits for
-                       maximum safe density.
-                *)
-                assert (List.length field_bits = size_in_bits - 1)
-              else (
-                (* This field will be comprised of the remaining bits, up to a
-                       maximum of [size_in_bits - 1]. It should not be empty.
-                *)
-                assert (not (List.is_empty field_bits)) ;
-                assert (List.length field_bits < size_in_bits) )) ;
-          let rec go input_bitstrings packed_fields =
-            match (input_bitstrings, packed_fields) with
-            | [], [] ->
-                (* We have consumed all bitstrings and fields in parallel, with
-                   no bits left over. Success.
-                *)
-                ()
-            | [] :: input_bitstrings, packed_fields
-            | input_bitstrings, [] :: packed_fields ->
-                (* We have consumed the whole of an input bitstring or the whole
-                   of a packed field, move onto the next one.
-                *)
-                go input_bitstrings packed_fields
-            | ( (bi :: input_bitstring) :: input_bitstrings
-              , (bp :: packed_field) :: packed_fields ) ->
-                (* Consume the next bit from the next input bitstring, and the
-                   next bit from the next packed field. They must match.
-                *)
-                assert (Bool.equal bi bp) ;
-                go
-                  (input_bitstring :: input_bitstrings)
-                  (packed_field :: packed_fields)
-            | [], _ ->
-                failwith "Packed fields contain more bits than were provided"
-            | _, [] ->
-                failwith
-                  "There are input bits that were not present in the packed \
-                   fields"
-          in
-          (* Check that the bits match between the input bitstring and the
-                 remaining fields.
-          *)
-          go (Array.to_list input.bitstrings) bitstring_fields)
-  end )

--- a/src/lib/secrets/hardware_wallets.ml
+++ b/src/lib/secrets/hardware_wallets.ml
@@ -97,10 +97,10 @@ let sign ~hd_index ~public_key ~user_command_payload :
     (Signed_command.With_valid_signature.t, string) Deferred.Result.t =
   let open Deferred.Result.Let_syntax in
   let input =
-    Transaction_union_payload.to_input
+    Transaction_union_payload.to_input_legacy
     @@ Transaction_union_payload.of_user_command_payload user_command_payload
   in
-  let fields = Random_oracle.pack_input input in
+  let fields = Random_oracle.Legacy.pack_input input in
   let messages =
     Array.map fields ~f:(fun field -> Tick.Field.to_string field)
   in

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -80,7 +80,9 @@ module Compressed : sig
 
   include Hashable.S_binable with type t := t
 
-  val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+  val to_input_legacy : t -> (Field.t, bool) Random_oracle.Input.Legacy.t
+
+  val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 
   val to_string : t -> string
 
@@ -101,7 +103,10 @@ module Compressed : sig
   module Checked : sig
     val equal : var -> var -> (Boolean.var, _) Checked.t
 
-    val to_input : var -> (Field.Var.t, Boolean.var) Random_oracle.Input.t
+    val to_input_legacy :
+      var -> (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
+
+    val to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
 
     val if_ : Boolean.var -> then_:var -> else_:var -> (var, _) Checked.t
 

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -494,10 +494,6 @@ open Hash_prefix_states_nonconsensus
 [%%endif]
 
 module Message = struct
-  open Tick
-
-  type t = (Field.t, bool) Random_oracle.Input.t [@@deriving sexp]
-
   let network_id_mainnet = Char.of_int_exn 1
 
   let network_id_testnet = Char.of_int_exn 0
@@ -509,83 +505,164 @@ module Message = struct
     | Testnet ->
         network_id_testnet
 
-  let make_derive ~network_id t ~private_key ~public_key =
-    let input =
-      let x, y = Tick.Inner_curve.to_affine_exn public_key in
-      Random_oracle.Input.append t
-        { field_elements = [| x; y |]
-        ; bitstrings =
-            [| Tock.Field.unpack private_key
-             ; Fold_lib.Fold.(to_list (string_bits (String.of_char network_id)))
-            |]
-        }
-    in
-    Random_oracle.Input.to_bits ~unpack:Field.unpack input
-    |> Array.of_list |> Blake2.bits_to_string |> Blake2.digest_string
-    |> Blake2.to_raw_string |> Blake2.string_to_bits |> Array.to_list
-    |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
-    |> Tock.Field.project
+  module Legacy = struct
+    open Tick
 
-  let derive = make_derive ~network_id
+    type t = (Field.t, bool) Random_oracle.Input.Legacy.t [@@deriving sexp]
 
-  let derive_for_mainnet = make_derive ~network_id:network_id_mainnet
+    let make_derive ~network_id t ~private_key ~public_key =
+      let input =
+        let x, y = Tick.Inner_curve.to_affine_exn public_key in
+        Random_oracle.Input.Legacy.append t
+          { field_elements = [| x; y |]
+          ; bitstrings =
+              [| Tock.Field.unpack private_key
+               ; Fold_lib.Fold.(
+                   to_list (string_bits (String.of_char network_id)))
+              |]
+          }
+      in
+      Random_oracle.Input.Legacy.to_bits ~unpack:Field.unpack input
+      |> Array.of_list |> Blake2.bits_to_string |> Blake2.digest_string
+      |> Blake2.to_raw_string |> Blake2.string_to_bits |> Array.to_list
+      |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
+      |> Tock.Field.project
 
-  let derive_for_testnet = make_derive ~network_id:network_id_testnet
+    let derive = make_derive ~network_id
 
-  let make_hash ~init t ~public_key ~r =
-    let input =
-      let px, py = Inner_curve.to_affine_exn public_key in
-      Random_oracle.Input.append t
-        { field_elements = [| px; py; r |]; bitstrings = [||] }
-    in
-    let open Random_oracle in
-    hash ~init (pack_input input)
-    |> Digest.to_bits ~length:Field.size_in_bits
-    |> Inner_curve.Scalar.of_bits
+    let derive_for_mainnet = make_derive ~network_id:network_id_mainnet
 
-  let hash = make_hash ~init:Hash_prefix_states.signature
+    let derive_for_testnet = make_derive ~network_id:network_id_testnet
 
-  let hash_for_mainnet =
-    make_hash ~init:Hash_prefix_states.signature_for_mainnet
+    let make_hash ~init t ~public_key ~r =
+      let input =
+        let px, py = Inner_curve.to_affine_exn public_key in
+        Random_oracle.Input.Legacy.append t
+          { field_elements = [| px; py; r |]; bitstrings = [||] }
+      in
+      let open Random_oracle.Legacy in
+      hash ~init (pack_input input)
+      |> Digest.to_bits ~length:Field.size_in_bits
+      |> Inner_curve.Scalar.of_bits
 
-  let hash_for_testnet =
-    make_hash ~init:Hash_prefix_states.signature_for_testnet
+    let hash = make_hash ~init:Hash_prefix_states.signature
 
-  [%%ifdef consensus_mechanism]
+    let hash_for_mainnet =
+      make_hash ~init:Hash_prefix_states.signature_for_mainnet
 
-  type var = (Field.Var.t, Boolean.var) Random_oracle.Input.t
+    let hash_for_testnet =
+      make_hash ~init:Hash_prefix_states.signature_for_testnet
 
-  let%snarkydef hash_checked t ~public_key ~r =
-    let input =
-      let px, py = public_key in
-      Random_oracle.Input.append t
-        { field_elements = [| px; py; r |]; bitstrings = [||] }
-    in
-    make_checked (fun () ->
-        let open Random_oracle.Checked in
-        hash ~init:Hash_prefix_states.signature (pack_input input)
-        |> Digest.to_bits ~length:Field.size_in_bits
-        |> Bitstring_lib.Bitstring.Lsb_first.of_list)
+    [%%ifdef consensus_mechanism]
 
-  [%%endif]
+    type var = (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
+
+    let%snarkydef hash_checked t ~public_key ~r =
+      let input =
+        let px, py = public_key in
+        Random_oracle.Input.Legacy.append t
+          { field_elements = [| px; py; r |]; bitstrings = [||] }
+      in
+      make_checked (fun () ->
+          let open Random_oracle.Legacy.Checked in
+          hash ~init:Hash_prefix_states.signature (pack_input input)
+          |> Digest.to_bits ~length:Field.size_in_bits
+          |> Bitstring_lib.Bitstring.Lsb_first.of_list)
+
+    [%%endif]
+  end
+
+  module Chunked = struct
+    open Tick
+
+    type t = Field.t Random_oracle.Input.Chunked.t [@@deriving sexp]
+
+    let make_derive ~network_id t ~private_key ~public_key =
+      let input =
+        let x, y = Tick.Inner_curve.to_affine_exn public_key in
+        let id =
+          Fold_lib.Fold.(to_list (string_bits (String.of_char network_id)))
+        in
+        Random_oracle.Input.Chunked.append t
+          { field_elements =
+              [| x; y; Field.project (Tock.Field.unpack private_key) |]
+          ; packeds = [| (Field.project id, List.length id) |]
+          }
+      in
+      Array.map (Random_oracle.pack_input input) ~f:Tick.Field.unpack
+      |> Array.to_list |> List.concat |> Array.of_list |> Blake2.bits_to_string
+      |> Blake2.digest_string |> Blake2.to_raw_string |> Blake2.string_to_bits
+      |> Array.to_list
+      |> Fn.flip List.take (Int.min 256 (Tock.Field.size_in_bits - 1))
+      |> Tock.Field.project
+
+    let derive = make_derive ~network_id
+
+    let derive_for_mainnet = make_derive ~network_id:network_id_mainnet
+
+    let derive_for_testnet = make_derive ~network_id:network_id_testnet
+
+    let make_hash ~init t ~public_key ~r =
+      let input =
+        let px, py = Inner_curve.to_affine_exn public_key in
+        Random_oracle.Input.Chunked.append t
+          { field_elements = [| px; py; r |]; packeds = [||] }
+      in
+      let open Random_oracle in
+      hash ~init (pack_input input)
+      |> Digest.to_bits ~length:Field.size_in_bits
+      |> Inner_curve.Scalar.of_bits
+
+    let hash = make_hash ~init:Hash_prefix_states.signature
+
+    let hash_for_mainnet =
+      make_hash ~init:Hash_prefix_states.signature_for_mainnet
+
+    let hash_for_testnet =
+      make_hash ~init:Hash_prefix_states.signature_for_testnet
+
+    [%%ifdef consensus_mechanism]
+
+    type var = Field.Var.t Random_oracle.Input.Chunked.t
+
+    let%snarkydef hash_checked t ~public_key ~r =
+      let input =
+        let px, py = public_key in
+        Random_oracle.Input.Chunked.append t
+          { field_elements = [| px; py; r |]; packeds = [||] }
+      in
+      make_checked (fun () ->
+          let open Random_oracle.Checked in
+          hash ~init:Hash_prefix_states.signature (pack_input input)
+          |> Digest.to_bits ~length:Field.size_in_bits
+          |> Bitstring_lib.Bitstring.Lsb_first.of_list)
+
+    [%%endif]
+  end
 end
 
-module S = Make (Tick) (Tick.Inner_curve) (Message)
+module Legacy = Make (Tick) (Tick.Inner_curve) (Message.Legacy)
+module Chunked = Make (Tick) (Tick.Inner_curve) (Message.Chunked)
 
 [%%ifdef consensus_mechanism]
 
-let gen =
+let gen_legacy =
   let open Quickcheck.Let_syntax in
   let%map pk = Private_key.gen and msg = Tick.Field.gen in
-  (pk, Random_oracle.Input.field_elements [| msg |])
+  (pk, Random_oracle.Input.Legacy.field_elements [| msg |])
+
+let gen_chunked =
+  let open Quickcheck.Let_syntax in
+  let%map pk = Private_key.gen and msg = Tick.Field.gen in
+  (pk, Random_oracle.Input.Chunked.field_elements [| msg |])
 
 (* Use for reading only. *)
-let message_typ () : (Message.var, Message.t) Tick.Typ.t =
+let legacy_message_typ () : (Message.Legacy.var, Message.Legacy.t) Tick.Typ.t =
   let open Tick.Typ in
-  { alloc = Alloc.return (Random_oracle.Input.field_elements [||])
+  { alloc = Alloc.return (Random_oracle.Input.Legacy.field_elements [||])
   ; store =
       Store.Let_syntax.(
-        fun { Random_oracle.Input.field_elements; bitstrings } ->
+        fun { Random_oracle.Input.Legacy.field_elements; bitstrings } ->
           let%bind field_elements =
             Store.all @@ Array.to_list
             @@ Array.map ~f:(store Tick.Field.typ) field_elements
@@ -595,12 +672,13 @@ let message_typ () : (Message.var, Message.t) Tick.Typ.t =
             @@ Array.map bitstrings ~f:(fun l ->
                    Store.all @@ List.map ~f:(store Tick.Boolean.typ) l)
           in
-          { Random_oracle.Input.field_elements = Array.of_list field_elements
+          { Random_oracle.Input.Legacy.field_elements =
+              Array.of_list field_elements
           ; bitstrings = Array.of_list bitstrings
           })
   ; read =
       Read.Let_syntax.(
-        fun { Random_oracle.Input.field_elements; bitstrings } ->
+        fun { Random_oracle.Input.Legacy.field_elements; bitstrings } ->
           let%bind field_elements =
             Read.all @@ Array.to_list
             @@ Array.map ~f:(read Tick.Field.typ) field_elements
@@ -610,29 +688,100 @@ let message_typ () : (Message.var, Message.t) Tick.Typ.t =
             @@ Array.map bitstrings ~f:(fun l ->
                    Read.all @@ List.map ~f:(read Tick.Boolean.typ) l)
           in
-          { Random_oracle.Input.field_elements = Array.of_list field_elements
+          { Random_oracle.Input.Legacy.field_elements =
+              Array.of_list field_elements
           ; bitstrings = Array.of_list bitstrings
           })
   ; check = (fun _ -> Tick.Checked.return ())
   }
 
+(* Use for reading only. *)
+let chunked_message_typ () : (Message.Chunked.var, Message.Chunked.t) Tick.Typ.t
+    =
+  let open Tick.Typ in
+  { alloc = Alloc.return (Random_oracle.Input.Chunked.field_elements [||])
+  ; store =
+      Store.Let_syntax.(
+        fun { Random_oracle.Input.Chunked.field_elements; packeds } ->
+          let%bind field_elements =
+            Store.all @@ Array.to_list
+            @@ Array.map ~f:(store Tick.Field.typ) field_elements
+          in
+          let packeds2 =
+            Array.init (Array.length packeds) ~f:(fun _ ->
+                (Tick.Field.Var.constant Tick.Field.zero, 0))
+          in
+          let%map () =
+            Array.foldi packeds ~init:(Store.return ())
+              ~f:(fun i acc (fld, len) ->
+                let%bind () = acc in
+                let%map x = store Tick.Field.typ fld in
+                packeds2.(i) <- (x, len))
+          in
+          { Random_oracle.Input.Chunked.field_elements =
+              Array.of_list field_elements
+          ; packeds = packeds2
+          })
+  ; read =
+      Read.Let_syntax.(
+        fun { Random_oracle.Input.Chunked.field_elements; packeds } ->
+          let%bind field_elements =
+            Read.all @@ Array.to_list
+            @@ Array.map ~f:(read Tick.Field.typ) field_elements
+          in
+          let packeds2 =
+            Array.init (Array.length packeds) ~f:(fun _ -> (Tick.Field.zero, 0))
+          in
+          let%map () =
+            Array.foldi packeds ~init:(Read.return ())
+              ~f:(fun i acc (fld, len) ->
+                let%bind () = acc in
+                let%map x = read Tick.Field.typ fld in
+                packeds2.(i) <- (x, len))
+          in
+          { Random_oracle.Input.Chunked.field_elements =
+              Array.of_list field_elements
+          ; packeds = packeds2
+          })
+  ; check = (fun _ -> Tick.Checked.return ())
+  }
+
 let%test_unit "schnorr checked + unchecked" =
-  Quickcheck.test ~trials:5 gen ~f:(fun (pk, msg) ->
-      let s = S.sign pk msg in
+  Quickcheck.test ~trials:5 gen_legacy ~f:(fun (pk, msg) ->
+      let s = Legacy.sign pk msg in
       let pubkey = Tick.Inner_curve.(scale one pk) in
-      assert (S.verify s pubkey msg) ;
+      assert (Legacy.verify s pubkey msg) ;
       (Tick.Test.test_equal ~sexp_of_t:[%sexp_of: bool] ~equal:Bool.equal
-         Tick.Typ.(tuple3 Tick.Inner_curve.typ (message_typ ()) S.Signature.typ)
+         Tick.Typ.(
+           tuple3 Tick.Inner_curve.typ (legacy_message_typ ())
+             Legacy.Signature.typ)
          Tick.Boolean.typ
          (fun (public_key, msg, s) ->
            let open Tick.Checked in
            let%bind (module Shifted) =
              Tick.Inner_curve.Checked.Shifted.create ()
            in
-           S.Checked.verifies (module Shifted) s public_key msg)
+           Legacy.Checked.verifies (module Shifted) s public_key msg)
+         (fun _ -> true))
+        (pubkey, msg, s))
+
+let%test_unit "schnorr checked + unchecked" =
+  Quickcheck.test ~trials:5 gen_chunked ~f:(fun (pk, msg) ->
+      let s = Chunked.sign pk msg in
+      let pubkey = Tick.Inner_curve.(scale one pk) in
+      assert (Chunked.verify s pubkey msg) ;
+      (Tick.Test.test_equal ~sexp_of_t:[%sexp_of: bool] ~equal:Bool.equal
+         Tick.Typ.(
+           tuple3 Tick.Inner_curve.typ (chunked_message_typ ())
+             Chunked.Signature.typ)
+         Tick.Boolean.typ
+         (fun (public_key, msg, s) ->
+           let open Tick.Checked in
+           let%bind (module Shifted) =
+             Tick.Inner_curve.Checked.Shifted.create ()
+           in
+           Chunked.Checked.verifies (module Shifted) s public_key msg)
          (fun _ -> true))
         (pubkey, msg, s))
 
 [%%endif]
-
-include S

--- a/src/lib/string_sign/string_sign.ml
+++ b/src/lib/string_sign/string_sign.ml
@@ -60,7 +60,7 @@ let char_bits c =
   List.concat_map [ hi; lo ] ~f:nybble_bits
 
 let string_to_input s =
-  Random_oracle.Input.
+  Random_oracle.Input.Legacy.
     { field_elements = [||]
     ; bitstrings = Stdlib.(Array.of_seq (Seq.map char_bits (String.to_seq s)))
     }
@@ -68,11 +68,11 @@ let string_to_input s =
 let verify ?signature_kind signature pk s =
   let m = string_to_input s in
   let inner_curve = Inner_curve.of_affine pk in
-  Schnorr.verify ?signature_kind signature inner_curve m
+  Schnorr.Legacy.verify ?signature_kind signature inner_curve m
 
 let sign ?signature_kind sk s =
   let m = string_to_input s in
-  Schnorr.sign ?signature_kind sk m
+  Schnorr.Legacy.sign ?signature_kind sk m
 
 let%test_module "Sign_string tests" =
   ( module struct

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -54,9 +54,9 @@ module Pending_coinbase_stack_state : sig
 
   val typ : (var, t) Typ.t
 
-  val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+  val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 
-  val var_to_input : var -> (Field.Var.t, Boolean.var) Random_oracle.Input.t
+  val var_to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
 end
 
 module Statement : sig
@@ -176,7 +176,7 @@ module Statement : sig
 
     val typ : (var, t) Typ.t
 
-    val to_input : t -> (Field.t, bool) Random_oracle.Input.t
+    val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 
     val to_field_elements : t -> Field.t array
 
@@ -184,7 +184,7 @@ module Statement : sig
       type t = var
 
       val to_input :
-        var -> ((Field.Var.t, Boolean.var) Random_oracle.Input.t, _) Checked.t
+        var -> (Field.Var.t Random_oracle.Input.Chunked.t, _) Checked.t
 
       (* This is actually a checked function. *)
       val to_field_elements : var -> Field.Var.t array

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -45,10 +45,10 @@ let sign_blake2_hash ~private_key s =
   let bitstrings =
     [| Blake2.to_raw_string blake2 |> Blake2.string_to_bits |> Array.to_list |]
   in
-  let input : (Field.t, bool) Random_oracle.Input.t =
+  let input : (Field.t, bool) Random_oracle.Legacy.Input.t =
     { field_elements; bitstrings }
   in
-  Schnorr.sign private_key input
+  Schnorr.Legacy.sign private_key input
 
 let send_uptime_data ~logger ~interruptor ~(submitter_keypair : Keypair.t) ~url
     ~state_hash ~produced block_data =


### PR DESCRIPTION
This PR is based off PR #9935, but refactored to change only the code that relates to random oracle input. In order to compile, this includes changes that were previously scattered across PRs #9933, #9934, #9935, #9936, #9937, #9938, #9939, #9940, with some modifications to separate out the other unrelated changes that were also bundled with them.

This PR takes a slightly different strategy to #9935, by keeping the random oracle inputs (and the signatures derived from them) separated as `Random_oracle.Input.Chunked` and `Random_oracle.Input.Legacy` (equivalently `Schnorr.Chunked`, `Schnorr.Legacy`), so that it is clear at every usage which of the two input systems is used.

This also makes the requisite changes for the client SDK and for rosetta, ensuring that both continue to use the `Legacy` hashing/signature mode for compatibility purposes. As in the original, 'signed transactions' also use the `Legacy` hashing/signature mode, to ensure that various implementations do not need to be updated.

----------------------------------------

The term 'chunk' refers to a number less than the size of a field element, which we treat as an indivisible bitstring and chain together to form field elements by computing `a + b * 2^n + c * 2^(n+m) + ...`. For example, consider
```
u16 // 8-bit integer
u32 // 32-bit integer
u64 // 64-bit integer
// The 'chunking' algorithm will group the following
[u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u32, u32, u32, u32, u32, u32, u32, u32, u64, u64, u64, u64]
// into the following batches
[ [u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16], // 240 bits
  [u16, u32, u32, u32, u32, u32, u32, u32], // 240 bits
  [u32, u64, u64, u64], // 224 bits
  [u64] // 64 bits
]
```

This differs from the original implementation, which decomposed all non-field-element data into bits and recombined those bits back into field elements. This decomposition and recomposition is significantly more expensive than the extra hashing we incur by not doing so.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them