### PR TITLE
Remove unnecessary verbose logging

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/pubsub_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/pubsub_msg.go
@@ -138,7 +138,6 @@ func (m SubscribeReq) handle(app *app, seqno uint64) *capnp.Message {
 	app.Topics[topicName] = topic
 
 	err = app.P2p.Pubsub.RegisterTopicValidator(topicName, func(ctx context.Context, id peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
-		app.P2p.Logger.Infof("Received gossip message: %v", msg.Data)
 		if id == app.P2p.Me {
 			// messages from ourself are valid.
 			app.P2p.Logger.Info("would have validated but it's from us!")


### PR DESCRIPTION
Problem: a logging line was accidentally left unremoved after debugging process

Solution: remove the line


Checklist:

- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None