### PR TITLE
Split generated other parties in two

### DIFF
--- a/src/lib/mina_base/control.ml
+++ b/src/lib/mina_base/control.ml
@@ -89,6 +89,8 @@ end]
 
 module Tag = struct
   type t = Proof | Signature | None_given [@@deriving equal, compare, sexp]
+
+  let gen = Quickcheck.Generator.of_list [ Proof; Signature; None_given ]
 end
 
 let tag : t -> Tag.t = function
@@ -98,3 +100,17 @@ let tag : t -> Tag.t = function
       Signature
   | None_given ->
       None_given
+
+[%%ifdef consensus_mechanism]
+
+let dummy_of_tag : Tag.t -> t = function
+  | Proof ->
+      let n2 = Pickles_types.Nat.N2.n in
+      let proof = Pickles.Proof.dummy n2 n2 n2 in
+      Proof proof
+  | Signature ->
+      Signature Signature.dummy
+  | None_given ->
+      None_given
+
+[%%endif]

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -185,11 +185,9 @@ module Update = struct
     end
   end]
 
-  let gen ?(new_account = false) ?(snapp_account = false) ?permissions_auth () :
+  let gen ?(snapp_account = false) ?permissions_auth () :
       t Quickcheck.Generator.t =
     let open Quickcheck.Let_syntax in
-    if snapp_account && not new_account then
-      failwith "Party.Update.gen: got snapp_account but not new_account" ;
     let%bind app_state =
       let%bind fields =
         let field_gen = Snark_params.Tick.Field.gen in


### PR DESCRIPTION
When generating the `other_parties` field of a `Parties.t`, generate the `Party.t` in pairs.  Choose an authorization, then the first `Party.t` updates the permissions consistent with that authorization, while still using `Signature` as its own authorization. The second `Party.t` then uses the chosen authorization.

This strategy allows testing of all possible authorizations, not just `Signature`, and also tests permissions updating.

The existing staged ledger Snapps unit test passes with this change.
