### PR TITLE
Rosetta offline network endpoints

### DIFF
--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -31,8 +31,7 @@ let router ~graphql_uri ~pool ~logger route body =
   try
     match route with
     | "network" :: tl ->
-        let%bind graphql_uri = get_graphql_uri_or_error () in
-        Network.router tl body ~graphql_uri ~logger ~with_db
+        Network.router tl body ~get_graphql_uri_or_error ~logger ~with_db
     | "account" :: tl ->
         let%bind graphql_uri = get_graphql_uri_or_error () in
         Account.router tl body ~graphql_uri ~logger ~with_db


### PR DESCRIPTION
As required by
https://www.rosetta-api.org/docs/node_deployment.html#offline-mode-endpoints

Explain your changes:
* Pass in the thunked graphql URI into the network route (like construction) to support offline endpoints
* Make those two endpoints offline: /options remains relatively similar, /list lists all networks (which it should have done anyway)

Explain how you tested your changes:
* Hit these endpoints with the relevant test-curl scripts and they still work even on a rosetta instance that is in "offline mode"