### PR TITLE
adding protocol version for both node status/error service

### DIFF
--- a/rfcs/0042-node-status-collection.md
+++ b/rfcs/0042-node-status-collection.md
@@ -31,6 +31,7 @@ The node status collection system would make the following `post` request to the
   { "peer_id": "<base64 encodeing of the libp2p peer id>"
   , "ip_address": "<hash of ip address of the submitter>"
   , "mina_version": "<mina version>"
+  , "version": "<version of the node status protocol>"
   , "git_hash": "<git hash of the mina node>"
   , "timestamp": "<current time using RFC-3339 representation>"
   , "libp2p_input_bandwidth": "<input bandwidth for libp2p helper system>"

--- a/rfcs/0043-node-error-collection.md
+++ b/rfcs/0043-node-error-collection.md
@@ -36,6 +36,7 @@ The node error collection system would make the following `post` request to the 
   , "public_key": "<optional, public key of the block producer>"
   , "git_branch": "<optional, git branch of the mina node>"
   , "commit_hash": "<commit hash of the mina node>"
+  , "version": "<version of the node error protocol>"
   , "chain_id": "<a hash string to distinguish between different networks>"
   , "contact_info": "<optional, contact info provided by the block producer>"
   , "timestamp": "<current time and date>"


### PR DESCRIPTION

Explain your changes:
This PR modifies 2 existing RFCs: 0043-node-error-report and 0042-node-status-report to add the "version" fields to payloads.

Explain how you tested your changes:
*


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
