### PR TITLE
Snapps GraphQL, derive from JSON

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -883,7 +883,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "SnappState",
-          "description": "Snapp state, a list of 8 field elements",
+          "description": "snapp state, a list of 8 field elements",
           "fields": [
             {
               "name": "elements",
@@ -1416,7 +1416,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "PartyBody",
-          "description": "Body component of a Snapp Party",
+          "description": "Body component of a snapp Party",
           "fields": [
             {
               "name": "useFullCommitment",
@@ -1437,7 +1437,7 @@
             },
             {
               "name": "protocolState",
-              "description": "The protocol state in a Snapp transaction",
+              "description": "The protocol state in a snapp transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1454,7 +1454,7 @@
             {
               "name": "callDepth",
               "description":
-                "The number of nested Snapp calls in the transaction before reaching this party.",
+                "The number of nested snapp calls in the transaction before reaching this party.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1467,7 +1467,7 @@
             {
               "name": "callData",
               "description":
-                "A commitment to the arguments passed to the Snapp and the returned value, for internal use by the calling Snapp. This commitment is opaque to ensure that private data can be passed between Snapps without revealing it on chain.",
+                "A commitment to the arguments passed to the snapp and the returned value, for internal use by the calling snapp. This commitment is opaque to ensure that private data can be passed between snapps without revealing it on chain.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1484,7 +1484,7 @@
             {
               "name": "sequenceEvents",
               "description":
-                "A list of sequence events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic. A commitment to these events is added to the sequenceState of the Snapp account for later use",
+                "A list of sequence events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic. A commitment to these events is added to the sequenceState of the snapp account for later use",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1517,7 +1517,7 @@
             {
               "name": "events",
               "description":
-                "A list of events emitted by the Snapp. Each event is a list of field elements, the particular meaning of each event is determined by the Snapp's internal logic.",
+                "A list of events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1647,7 +1647,7 @@
             },
             {
               "name": "protocolState",
-              "description": "The protocol state in a Snapp transaction",
+              "description": "The protocol state in a snapp transaction",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1662,7 +1662,7 @@
             {
               "name": "callDepth",
               "description":
-                "The number of nested Snapp calls in the transaction before reaching this party.",
+                "The number of nested snapp calls in the transaction before reaching this party.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1673,7 +1673,7 @@
             {
               "name": "callData",
               "description":
-                "A commitment to the arguments passed to the Snapp and the returned value, for internal use by the calling Snapp. This commitment is opaque to ensure that private data can be passed between Snapps without revealing it on chain.",
+                "A commitment to the arguments passed to the snapp and the returned value, for internal use by the calling snapp. This commitment is opaque to ensure that private data can be passed between snapps without revealing it on chain.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1688,7 +1688,7 @@
             {
               "name": "sequenceEvents",
               "description":
-                "A list of sequence events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic. A commitment to these events is added to the sequenceState of the Snapp account for later use",
+                "A list of sequence events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic. A commitment to these events is added to the sequenceState of the snapp account for later use",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1719,7 +1719,7 @@
             {
               "name": "events",
               "description":
-                "A list of events emitted by the Snapp. Each event is a list of field elements, the particular meaning of each event is determined by the Snapp's internal logic.",
+                "A list of events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1898,7 +1898,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "SnappParty",
-          "description": "A party to a Snapp transaction",
+          "description": "A party to a snapp transaction",
           "fields": [
             {
               "name": "authorization",
@@ -2606,7 +2606,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "SnappProtocolState",
-          "description": "Protocol state for a Snapp transaction",
+          "description": "Protocol state for a snapp transaction",
           "fields": [
             {
               "name": "nextEpochData",
@@ -3539,7 +3539,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "PartyUpdate",
-          "description": "Update component of a Snapp Party",
+          "description": "Update component of a snapp Party",
           "fields": [
             {
               "name": "timing",
@@ -3715,11 +3715,11 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "FeePayerPartyBody",
-          "description": "Body component of a Snapp Fee Payer Party",
+          "description": "Body component of a snapp Fee Payer Party",
           "fields": [
             {
               "name": "protocolState",
-              "description": "The protocol state in a Snapp transaction",
+              "description": "The protocol state in a snapp transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3736,7 +3736,7 @@
             {
               "name": "callDepth",
               "description":
-                "The number of nested Snapp calls in the transaction before reaching the fee payer.",
+                "The number of nested snapp calls in the transaction before reaching the fee payer.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -3874,7 +3874,7 @@
           "inputFields": [
             {
               "name": "protocolState",
-              "description": "The protocol state in a Snapp transaction",
+              "description": "The protocol state in a snapp transaction",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -3889,7 +3889,7 @@
             {
               "name": "callDepth",
               "description":
-                "The number of nested Snapp calls in the transaction before reaching the fee payer.",
+                "The number of nested snapp calls in the transaction before reaching the fee payer.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4018,7 +4018,7 @@
           "kind": "INPUT_OBJECT",
           "name": "SnappPartyPredicatedFeePayer",
           "description":
-            "A party to a Snapp transaction with a nonce predicate",
+            "A party to a snapp transaction with a nonce predicate",
           "fields": [
             {
               "name": "predicate",
@@ -4091,7 +4091,7 @@
           "kind": "INPUT_OBJECT",
           "name": "SnappPartyFeePayer",
           "description":
-            "A party to a Snapp transaction with a signature authorization",
+            "A party to a snapp transaction with a signature authorization",
           "fields": [
             {
               "name": "authorization",
@@ -4176,7 +4176,7 @@
             {
               "name": "otherParties",
               "description":
-                "The parties other than the fee payer in a Snapp transaction",
+                "The parties other than the fee payer in a snapp transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4200,7 +4200,7 @@
             },
             {
               "name": "feePayer",
-              "description": "The fee payer party to a Snapp transaction",
+              "description": "The fee payer party to a snapp transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4225,7 +4225,7 @@
             {
               "name": "otherParties",
               "description":
-                "The parties other than the fee payer in a Snapp transaction",
+                "The parties other than the fee payer in a snapp transaction",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4247,7 +4247,7 @@
             },
             {
               "name": "feePayer",
-              "description": "The fee payer party to a Snapp transaction",
+              "description": "The fee payer party to a snapp transaction",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -4271,7 +4271,7 @@
           "fields": [
             {
               "name": "snapp",
-              "description": "Snapp transaction that was sent",
+              "description": "snapp transaction that was sent",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -6187,7 +6187,7 @@
             },
             {
               "name": "sendSnapp",
-              "description": "Send a Snapp transaction",
+              "description": "Send a snapp transaction",
               "args": [
                 {
                   "name": "input",
@@ -8030,7 +8030,7 @@
             },
             {
               "name": "hash",
-              "description": "A cryptographic hash of the Snapp command",
+              "description": "A cryptographic hash of the snapp command",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8047,7 +8047,7 @@
             {
               "name": "nonce",
               "description":
-                "Sequence number of the Snapp transaction for the fee-payer's account",
+                "Sequence number of the snapp transaction for the fee-payer's account",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8060,7 +8060,7 @@
             {
               "name": "feePayer",
               "description":
-                "Account that pays the fees for the Snapp transaction",
+                "Account that pays the fees for the snapp transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8077,7 +8077,7 @@
             {
               "name": "accountsAccessed",
               "description":
-                "List of accounts accessed to complete the Snapp transaction",
+                "List of accounts accessed to complete the snapp transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8102,7 +8102,7 @@
             {
               "name": "fee",
               "description":
-                "Transaction fee paid by the fee-payer for the Snapp transaction",
+                "Transaction fee paid by the fee-payer for the snapp transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -8135,7 +8135,7 @@
             {
               "name": "failureReason",
               "description":
-                "The reason for the Snapp transaction failure; null means success or the status is unknown",
+                "The reason for the snapp transaction failure; null means success or the status is unknown",
               "args": [],
               "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
@@ -8143,7 +8143,7 @@
             },
             {
               "name": "parties",
-              "description": "Parties involved in the Snapp transaction",
+              "description": "Parties involved in the snapp transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -10210,7 +10210,7 @@
             },
             {
               "name": "snappCommands",
-              "description": "List of Snapp commands included in this block",
+              "description": "List of snapp commands included in this block",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -11669,7 +11669,7 @@
             {
               "name": "snappUri",
               "description":
-                "The URI associated with this account, usually pointing to the Snapp source code",
+                "The URI associated with this account, usually pointing to the snapp source code",
               "args": [],
               "type": { "kind": "SCALAR", "name": "String", "ofType": null },
               "isDeprecated": false,
@@ -11678,7 +11678,7 @@
             {
               "name": "snappState",
               "description":
-                "The 8 field elements comprising the Snapp state associated with this account encoded as bignum strings",
+                "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -13380,11 +13380,11 @@
             {
               "name": "pooledSnappCommands",
               "description":
-                "Retrieve all the scheduled Snapp commands for a specified sender that the current daemon sees in its transaction pool. All scheduled commands are queried if no sender is specified",
+                "Retrieve all the scheduled snapp commands for a specified sender that the current daemon sees in its transaction pool. All scheduled commands are queried if no sender is specified",
               "args": [
                 {
                   "name": "ids",
-                  "description": "Ids of Snapp commands",
+                  "description": "Ids of snapp commands",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -13403,7 +13403,7 @@
                 {
                   "name": "hashes",
                   "description":
-                    "Hashes of the Snapp commands to find in the pool",
+                    "Hashes of the snapp commands to find in the pool",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -13422,7 +13422,7 @@
                 {
                   "name": "publicKey",
                   "description":
-                    "Public key of sender of pooled Snapp commands",
+                    "Public key of sender of pooled snapp commands",
                   "type": {
                     "kind": "SCALAR",
                     "name": "PublicKey",
@@ -13457,7 +13457,7 @@
               "args": [
                 {
                   "name": "snappTransaction",
-                  "description": "Id of a Snapp transaction",
+                  "description": "Id of a snapp transaction",
                   "type": { "kind": "SCALAR", "name": "ID", "ofType": null },
                   "defaultValue": null
                 },

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -1419,7 +1419,7 @@
           "description": "Body component of a Snapp Party",
           "fields": [
             {
-              "name": "use_full_commitment",
+              "name": "useFullCommitment",
               "description":
                 "Use the full or partial commitment when checking the party predicate.",
               "args": [],
@@ -1454,7 +1454,7 @@
             {
               "name": "callDepth",
               "description":
-                "The number of nested snapp calls in the transaction before reaching this party.",
+                "The number of nested Snapp calls in the transaction before reaching this party.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1467,7 +1467,7 @@
             {
               "name": "callData",
               "description":
-                "A commitment to the arguments passed to the snapp and the returned value, for internal use by the calling snapp. This commitment is opaque to ensure that private data can be passed between snapps without revealing it on chain.",
+                "A commitment to the arguments passed to the Snapp and the returned value, for internal use by the calling Snapp. This commitment is opaque to ensure that private data can be passed between Snapps without revealing it on chain.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1484,7 +1484,7 @@
             {
               "name": "sequenceEvents",
               "description":
-                "A list of sequence events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic. A commitment to these events is added to the sequenceState of the snapp account for later use",
+                "A list of sequence events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic. A commitment to these events is added to the sequenceState of the Snapp account for later use",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1517,7 +1517,7 @@
             {
               "name": "events",
               "description":
-                "A list of events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic.",
+                "A list of events emitted by the Snapp. Each event is a list of field elements, the particular meaning of each event is determined by the Snapp's internal logic.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -1564,7 +1564,7 @@
               "deprecationReason": null
             },
             {
-              "name": "balance_change",
+              "name": "balanceChange",
               "description":
                 "Signed amount representing the amount to change for this particular relevant party.",
               "args": [],
@@ -1631,7 +1631,7 @@
           ],
           "inputFields": [
             {
-              "name": "use_full_commitment",
+              "name": "useFullCommitment",
               "description":
                 "Use the full or partial commitment when checking the party predicate.",
               "type": {
@@ -1662,7 +1662,7 @@
             {
               "name": "callDepth",
               "description":
-                "The number of nested snapp calls in the transaction before reaching this party.",
+                "The number of nested Snapp calls in the transaction before reaching this party.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1673,7 +1673,7 @@
             {
               "name": "callData",
               "description":
-                "A commitment to the arguments passed to the snapp and the returned value, for internal use by the calling snapp. This commitment is opaque to ensure that private data can be passed between snapps without revealing it on chain.",
+                "A commitment to the arguments passed to the Snapp and the returned value, for internal use by the calling Snapp. This commitment is opaque to ensure that private data can be passed between Snapps without revealing it on chain.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1688,7 +1688,7 @@
             {
               "name": "sequenceEvents",
               "description":
-                "A list of sequence events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic. A commitment to these events is added to the sequenceState of the snapp account for later use",
+                "A list of sequence events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic. A commitment to these events is added to the sequenceState of the Snapp account for later use",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1719,7 +1719,7 @@
             {
               "name": "events",
               "description":
-                "A list of events emitted by the snapp. Each event is a list of field elements, the particular meaning of each event is determined by the snapp's internal logic.",
+                "A list of events emitted by the Snapp. Each event is a list of field elements, the particular meaning of each event is determined by the Snapp's internal logic.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1762,7 +1762,7 @@
               "defaultValue": null
             },
             {
-              "name": "balance_change",
+              "name": "balanceChange",
               "description":
                 "Signed amount representing the amount to change for this particular relevant party.",
               "type": {
@@ -3735,16 +3735,13 @@
             },
             {
               "name": "callDepth",
-              "description": "An integer in string format",
+              "description":
+                "The number of nested Snapp calls in the transaction before reaching the fee payer.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -3858,7 +3855,7 @@
               "deprecationReason": null
             },
             {
-              "name": "pk",
+              "name": "publicKey",
               "description": "Public key as a Base58Check string",
               "args": [],
               "type": {
@@ -3891,15 +3888,12 @@
             },
             {
               "name": "callDepth",
-              "description": "An integer in string format",
+              "description":
+                "The number of nested Snapp calls in the transaction before reaching the fee payer.",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "defaultValue": null
             },
@@ -4002,7 +3996,7 @@
               "defaultValue": null
             },
             {
-              "name": "pk",
+              "name": "publicKey",
               "description": "Public key as a Base58Check string",
               "type": {
                 "kind": "NON_NULL",
@@ -8149,7 +8143,7 @@
             },
             {
               "name": "parties",
-              "description": "Parties involved in the snapp transaction",
+              "description": "Parties involved in the Snapp transaction",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -11684,7 +11678,7 @@
             {
               "name": "snappState",
               "description":
-                "The 8 field elements comprising the snapp state associated with this account encoded as bignum strings",
+                "The 8 field elements comprising the Snapp state associated with this account encoded as bignum strings",
               "args": [],
               "type": {
                 "kind": "LIST",
@@ -13463,7 +13457,7 @@
               "args": [
                 {
                   "name": "snappTransaction",
-                  "description": "Id of a snapp transaction",
+                  "description": "Id of a Snapp transaction",
                   "type": { "kind": "SCALAR", "name": "ID", "ofType": null },
                   "defaultValue": null
                 },

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1117,7 +1117,7 @@ module Snapp_party_body = struct
   let add_if_doesn't_exist (module Conn : CONNECTION) (body : Party.Body.t) =
     let open Deferred.Result.Let_syntax in
     let%bind public_key_id =
-      Public_key.add_if_doesn't_exist (module Conn) body.pk
+      Public_key.add_if_doesn't_exist (module Conn) body.public_key
     in
     let%bind update_id =
       Snapp_updates.add_if_doesn't_exist (module Conn) body.update

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -854,7 +854,7 @@ module Snapp_helpers = struct
         ~f:(fun db -> Processor.Snapp_party_body.load db body_id)
         ~item:"Snapp party body"
     in
-    let%bind pk = pk_of_pk_id pool body_data.public_key_id in
+    let%bind public_key = pk_of_pk_id pool body_data.public_key_id in
     let%bind update_data =
       query_db pool
         ~f:(fun db -> Processor.Snapp_updates.load db body_data.update_id)
@@ -1178,7 +1178,7 @@ module Snapp_helpers = struct
     in
     let use_full_commitment = body_data.use_full_commitment in
     return
-      ( { pk
+      ( { public_key
         ; update
         ; token_id
         ; balance_change
@@ -1206,7 +1206,7 @@ module Snapp_helpers = struct
             "fee_payer_body_of_id: expected positive balance change for fee \
              payer"
     in
-    ( { pk = body.pk
+    ( { public_key = body.public_key
       ; update = body.update
       ; token_id = ()
       ; balance_change

--- a/src/app/snapp_test_transaction/dune
+++ b/src/app/snapp_test_transaction/dune
@@ -12,6 +12,7 @@
    currency
    archive_lib
    mina_base
+   mina_graphql
    mina_state
    genesis_constants
    genesis_ledger_helper

--- a/src/lib/mina_base/parties.ml
+++ b/src/lib/mina_base/parties.ml
@@ -298,10 +298,10 @@ let fee_excess (t : t) =
 
 let accounts_accessed (t : t) =
   List.map (parties t) ~f:(fun p ->
-      Account_id.create p.data.body.pk p.data.body.token_id)
+      Account_id.create p.data.body.public_key p.data.body.token_id)
   |> List.stable_dedup
 
-let fee_payer_pk (t : t) = t.fee_payer.data.body.pk
+let fee_payer_pk (t : t) = t.fee_payer.data.body.public_key
 
 let value_if b ~then_ ~else_ = if b then then_ else else_
 

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -377,7 +377,7 @@ module Body = struct
              , 'bool
              , 'protocol_state )
              t =
-          { pk : 'pk
+          { public_key : 'pk
           ; update : 'update
           ; token_id : 'token_id
           ; balance_change : 'amount
@@ -446,7 +446,7 @@ module Body = struct
     end]
 
     let dummy : t =
-      { pk = Public_key.Compressed.empty
+      { public_key = Public_key.Compressed.empty
       ; update = Update.dummy
       ; token_id = ()
       ; balance_change = Fee.zero
@@ -485,7 +485,7 @@ module Body = struct
       Poly.t
 
     let to_input
-        ({ pk
+        ({ public_key
          ; update
          ; token_id
          ; balance_change
@@ -499,7 +499,7 @@ module Body = struct
          } :
           t) =
       List.reduce_exn ~f:Random_oracle_input.append
-        [ Public_key.Compressed.Checked.to_input pk
+        [ Public_key.Compressed.Checked.to_input public_key
         ; Update.Checked.to_input update
         ; Impl.run_checked (Token_id.Checked.to_input token_id)
         ; Amount.Signed.Checked.to_input balance_change
@@ -535,7 +535,7 @@ module Body = struct
       ~value_of_hlist:of_hlist
 
   let dummy : t =
-    { pk = Public_key.Compressed.empty
+    { public_key = Public_key.Compressed.empty
     ; update = Update.dummy
     ; token_id = Token_id.default
     ; balance_change = Amount.Signed.zero
@@ -549,7 +549,7 @@ module Body = struct
     }
 
   let to_input
-      ({ pk
+      ({ public_key
        ; update
        ; token_id
        ; balance_change
@@ -563,7 +563,7 @@ module Body = struct
        } :
         t) =
     List.reduce_exn ~f:Random_oracle_input.append
-      [ Public_key.Compressed.to_input pk
+      [ Public_key.Compressed.to_input public_key
       ; Update.to_input update
       ; Token_id.to_input token_id
       ; Amount.Signed.to_input balance_change
@@ -827,7 +827,7 @@ module Signed = struct
   end]
 
   let account_id (t : t) : Account_id.t =
-    Account_id.create t.data.body.pk t.data.body.token_id
+    Account_id.create t.data.body.public_key t.data.body.token_id
 end
 
 module Fee_payer = struct
@@ -845,7 +845,7 @@ module Fee_payer = struct
   end]
 
   let account_id (t : t) : Account_id.t =
-    Account_id.create t.data.body.pk Token_id.default
+    Account_id.create t.data.body.public_key Token_id.default
 
   let to_signed (t : t) : Signed.t =
     { authorization = t.authorization
@@ -878,7 +878,7 @@ module Stable = struct
 end]
 
 let account_id (t : t) : Account_id.t =
-  Account_id.create t.data.body.pk t.data.body.token_id
+  Account_id.create t.data.body.public_key t.data.body.token_id
 
 let of_signed ({ data; authorization } : Signed.t) : t =
   { authorization = Signature authorization; data = Predicated.of_signed data }

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1248,7 +1248,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       ~(state_view : Snapp_predicate.Protocol_state.View.t) ~check_auth
       ~has_proof ~is_new ~global_slot_since_genesis ~is_start
       ({ body =
-           { pk = _
+           { public_key = _
            ; token_id
            ; update =
                { app_state
@@ -2591,7 +2591,7 @@ module For_tests = struct
       { fee_payer =
           { Party.Fee_payer.data =
               { body =
-                  { pk = sender_pk
+                  { public_key = sender_pk
                   ; update = Party.Update.noop
                   ; token_id = ()
                   ; balance_change = fee
@@ -2611,7 +2611,7 @@ module For_tests = struct
       ; other_parties =
           [ { data =
                 { body =
-                    { pk = sender_pk
+                    { public_key = sender_pk
                     ; update = Party.Update.noop
                     ; token_id = Token_id.default
                     ; balance_change =
@@ -2630,7 +2630,7 @@ module For_tests = struct
             }
           ; { data =
                 { body =
-                    { pk = receiver
+                    { public_key = receiver
                     ; update = Party.Update.noop
                     ; token_id = Token_id.default
                     ; balance_change = Amount.Signed.(of_unsigned amount)

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1194,14 +1194,14 @@ module Types = struct
              ; field "snappUri" ~typ:string
                  ~doc:
                    "The URI associated with this account, usually pointing to \
-                    the Snapp source code"
+                    the snapp source code"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
                    account.Account.Poly.snapp_uri)
              ; field "snappState"
                  ~typ:(list @@ non_null string)
                  ~doc:
-                   "The 8 field elements comprising the Snapp state associated \
+                   "The 8 field elements comprising the snapp state associated \
                     with this account encoded as bignum strings"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
@@ -1606,24 +1606,24 @@ module Types = struct
               ~typ:(non_null guid) ~args:[] ~resolve:(fun _ parties ->
                 Parties.to_base58_check parties.With_hash.data)
           ; field_no_status "hash"
-              ~doc:"A cryptographic hash of the Snapp command"
+              ~doc:"A cryptographic hash of the snapp command"
               ~typ:(non_null string) ~args:[] ~resolve:(fun _ parties ->
                 Transaction_hash.to_base58_check parties.With_hash.hash)
           ; field_no_status "nonce" ~typ:(non_null int) ~args:[]
               ~doc:
-                "Sequence number of the Snapp transaction for the fee-payer's \
+                "Sequence number of the snapp transaction for the fee-payer's \
                  account" ~resolve:(fun _ parties ->
                 Parties.nonce parties.With_hash.data |> Unsigned.UInt32.to_int)
           ; field_no_status "feePayer" ~typ:(non_null AccountObj.account)
               ~args:[]
-              ~doc:"Account that pays the fees for the Snapp transaction"
+              ~doc:"Account that pays the fees for the snapp transaction"
               ~resolve:(fun { ctx = coda; _ } cmd ->
                 AccountObj.get_best_ledger_account coda
                   (Parties.fee_payer cmd.With_hash.data))
           ; field_no_status "accountsAccessed"
               ~typ:(non_null (list (non_null AccountObj.account)))
               ~args:[]
-              ~doc:"List of accounts accessed to complete the Snapp transaction"
+              ~doc:"List of accounts accessed to complete the snapp transaction"
               ~resolve:(fun { ctx = coda; _ } parties ->
                 let account_ids =
                   Parties.accounts_accessed parties.With_hash.data
@@ -1632,7 +1632,7 @@ module Types = struct
                     AccountObj.get_best_ledger_account coda acct_id))
           ; field_no_status "fee" ~typ:(non_null uint64) ~args:[]
               ~doc:
-                "Transaction fee paid by the fee-payer for the Snapp \
+                "Transaction fee paid by the fee-payer for the snapp \
                  transaction" ~resolve:(fun _ parties ->
                 Parties.fee parties.With_hash.data |> Currency.Fee.to_uint64)
           ; field_no_status "feeToken" ~typ:(non_null token_id) ~args:[]
@@ -1640,7 +1640,7 @@ module Types = struct
                 Parties.fee_token parties.With_hash.data)
           ; field "failureReason" ~typ:string ~args:[]
               ~doc:
-                "The reason for the Snapp transaction failure; null means \
+                "The reason for the snapp transaction failure; null means \
                  success or the status is unknown" ~resolve:(fun _ cmd ->
                 match cmd.With_status.status with
                 | Applied | Enqueued ->
@@ -1649,7 +1649,7 @@ module Types = struct
                     Some (Transaction_status.Failure.to_string failure))
           ; field_no_status "parties"
               ~typ:(non_null (list (non_null party_display)))
-              ~args:[] ~doc:"Parties involved in the Snapp transaction"
+              ~args:[] ~doc:"Parties involved in the snapp transaction"
               ~resolve:(fun _ cmd -> Parties.parties cmd.With_hash.data)
           ])
   end
@@ -1681,7 +1681,7 @@ module Types = struct
                   | Parties _ ->
                       None))
         ; field "snappCommands"
-            ~doc:"List of Snapp commands included in this block"
+            ~doc:"List of snapp commands included in this block"
             ~typ:(non_null @@ list @@ non_null Snapp_command.snapp_command)
             ~args:Arg.[]
             ~resolve:(fun _ { commands; _ } ->
@@ -1969,7 +1969,7 @@ module Types = struct
       obj "SendSnappPayload" ~fields:(fun _ ->
           [ field "snapp"
               ~typ:(non_null Snapp_command.snapp_command)
-              ~doc:"Snapp transaction that was sent"
+              ~doc:"snapp transaction that was sent"
               ~args:Arg.[]
               ~resolve:(fun _ -> Fn.id)
           ])
@@ -2340,7 +2340,7 @@ module Types = struct
             ]
 
       let snapp_update : (Party.Update.t, string) Result.t option arg_typ =
-        obj "PartyUpdate" ~doc:"Update component of a Snapp Party"
+        obj "PartyUpdate" ~doc:"Update component of a snapp Party"
           ~coerce:
             (fun app_state_elts delegate vk perms snapp_uri tok_sym timing ->
             let open Result.Let_syntax in
@@ -2494,7 +2494,7 @@ module Types = struct
 
       let snapp_protocol_state_arg :
           (Snapp_predicate.Protocol_state.t, string) result option arg_typ =
-        obj "SnappProtocolState" ~doc:"Protocol state for a Snapp transaction"
+        obj "SnappProtocolState" ~doc:"Protocol state for a snapp transaction"
           ~coerce:
             (fun snarked_ledger_hash snarked_next_available_token timestamp
                  blockchain_length min_window_density last_vrf_output_opt
@@ -2557,7 +2557,7 @@ module Types = struct
             ]
 
       let snapp_party_body : (Party.Body.t, string) Result.t option arg_typ =
-        obj "PartyBody" ~doc:"Body component of a Snapp Party"
+        obj "PartyBody" ~doc:"Body component of a snapp Party"
           ~coerce:
             (fun pk update_result token_id balance_change increment_nonce events
                  sequence_events call_data call_depth protocol_state
@@ -2611,9 +2611,9 @@ module Types = struct
               (* TODO: Do we want fields in base58 in graphQL? Should we use a string of the base10 number like in other parts? Should we use a hex 32bytes -- that seems most natural to me? *)
             ; arg "events"
                 ~doc:
-                  "A list of events emitted by the Snapp. Each event is a list \
+                  "A list of events emitted by the snapp. Each event is a list \
                    of field elements, the particular meaning of each event is \
-                   determined by the Snapp's internal logic."
+                   determined by the snapp's internal logic."
                 ~typ:(non_null (list (non_null (list (non_null string)))))
             ; arg "sequenceEvents"
                 ~doc:
@@ -2621,23 +2621,23 @@ module Types = struct
                    is a list of field elements, the particular meaning of each \
                    event is determined by the snapp's internal logic. A \
                    commitment to these events is added to the sequenceState of \
-                   the Snapp account for later use"
+                   the snapp account for later use"
                 ~typ:(non_null (list (non_null (list (non_null string)))))
             ; arg "callData"
                 ~doc:
-                  "A commitment to the arguments passed to the Snapp and the \
-                   returned value, for internal use by the calling Snapp. This \
+                  "A commitment to the arguments passed to the snapp and the \
+                   returned value, for internal use by the calling snapp. This \
                    commitment is opaque to ensure that private data can be \
-                   passed between Snapps without revealing it on chain."
+                   passed between snapps without revealing it on chain."
                 ~typ:(non_null string)
             ; arg "callDepth"
                 ~doc:
-                  "The number of nested Snapp calls in the transaction before \
+                  "The number of nested snapp calls in the transaction before \
                    reaching this party."
                 ~typ:(non_null int)
             ; arg "protocolState"
                 ~typ:(non_null snapp_protocol_state_arg)
-                ~doc:"The protocol state in a Snapp transaction"
+                ~doc:"The protocol state in a snapp transaction"
             ; arg "useFullCommitment"
                 ~doc:
                   "Use the full or partial commitment when checking the party \
@@ -2646,7 +2646,7 @@ module Types = struct
             ]
 
       let snapp_fee_payer_party_body =
-        obj "FeePayerPartyBody" ~doc:"Body component of a Snapp Fee Payer Party"
+        obj "FeePayerPartyBody" ~doc:"Body component of a snapp Fee Payer Party"
           ~coerce:
             (fun pk update_result fee events sequence_events call_data
                  call_depth protocol_state ->
@@ -2698,18 +2698,18 @@ module Types = struct
                 ~typ:(non_null string)
             ; arg "callDepth"
                 ~doc:
-                  "The number of nested Snapp calls in the transaction before \
+                  "The number of nested snapp calls in the transaction before \
                    reaching the fee payer."
                 ~typ:(non_null int)
             ; arg "protocolState"
                 ~typ:(non_null snapp_protocol_state_arg)
-                ~doc:"The protocol state in a Snapp transaction"
+                ~doc:"The protocol state in a snapp transaction"
             ]
 
       let snapp_party_predicated_fee_payer :
           (Party.Predicated.Fee_payer.t, string) Result.t option arg_typ =
         obj "SnappPartyPredicatedFeePayer"
-          ~doc:"A party to a Snapp transaction with a nonce predicate"
+          ~doc:"A party to a snapp transaction with a nonce predicate"
           ~coerce:(fun body nonce ->
             let open Result.Let_syntax in
             let%map body = body in
@@ -2736,7 +2736,7 @@ module Types = struct
       *)
       let snapp_party_fee_payer =
         obj "SnappPartyFeePayer"
-          ~doc:"A party to a Snapp transaction with a signature authorization"
+          ~doc:"A party to a snapp transaction with a signature authorization"
           ~coerce:(fun data authorization ->
             let open Result.Let_syntax in
             let%bind data = data in
@@ -2760,7 +2760,7 @@ module Types = struct
             with exn -> Error (Exn.to_string exn))
 
       let snapp_state =
-        obj "SnappState" ~doc:"Snapp state, a list of 8 field elements"
+        obj "SnappState" ~doc:"snapp state, a list of 8 field elements"
           ~coerce:(fun element_results ->
             let elements =
               List.map ~f:Snapp_basic.Or_ignore.of_option element_results
@@ -2768,7 +2768,7 @@ module Types = struct
             if List.length elements = 8 then
               (* length check means this won't raise *)
               Ok (Snapp_state.V.of_list_exn elements)
-            else Error "Expected 8 elements for Snapp state")
+            else Error "Expected 8 elements for snapp state")
           ~fields:[ arg "elements" ~typ:(non_null (list field)) ]
 
       let snapp_predicate_account =
@@ -2855,7 +2855,7 @@ module Types = struct
             | `String s ->
                 Pickles.Side_loaded.Proof.of_base64 s
             | _ ->
-                Error "Expected Snapp proof as base64-encoded string")
+                Error "Expected snapp proof as base64-encoded string")
 
       let snapp_control =
         obj "Control"
@@ -2875,7 +2875,7 @@ module Types = struct
             ]
 
       let snapp_party_arg =
-        obj "SnappParty" ~doc:"A party to a Snapp transaction"
+        obj "SnappParty" ~doc:"A party to a snapp transaction"
           ~coerce:(fun predicated_result authorization_result ->
             let open Result.Let_syntax in
             let%bind data = predicated_result in
@@ -3102,17 +3102,17 @@ module Types = struct
       let snapp_fee_payer =
         arg "feePayer"
           ~typ:(non_null Snapp_inputs.snapp_party_fee_payer)
-          ~doc:"The fee payer party to a Snapp transaction"
+          ~doc:"The fee payer party to a snapp transaction"
 
       let snapp_other_parties =
         arg "otherParties"
           ~typ:(non_null (list (non_null Snapp_inputs.snapp_party_arg)))
-          ~doc:"The parties other than the fee payer in a Snapp transaction"
+          ~doc:"The parties other than the fee payer in a snapp transaction"
 
       let snapp_protocol_state =
         arg "protocolState"
           ~typ:(non_null Snapp_inputs.snapp_protocol_state_arg)
-          ~doc:"The protocol state in a Snapp transaction"
+          ~doc:"The protocol state in a snapp transaction"
     end
 
     let send_payment =
@@ -3754,7 +3754,7 @@ module Mutations = struct
             in
             Ok cmd_with_hash
         | Error e ->
-            Error ("Couldn't send Snapp command: " ^ Error.to_string_hum e) )
+            Error ("Couldn't send snapp command: " ^ Error.to_string_hum e) )
     | `Bootstrapping ->
         return (Error "Daemon is bootstrapping")
 
@@ -3907,7 +3907,7 @@ module Mutations = struct
             |> Deferred.Result.map ~f:Types.User_command.mk_user_command)
 
   let send_snapp =
-    io_field "sendSnapp" ~doc:"Send a Snapp transaction"
+    io_field "sendSnapp" ~doc:"Send a snapp transaction"
       ~typ:(non_null Types.Payload.send_snapp)
       ~args:Arg.[ arg "input" ~typ:(non_null Types.Input.send_snapp) ]
       ~resolve:
@@ -4422,17 +4422,17 @@ module Queries = struct
   let pooled_snapp_commands =
     field "pooledSnappCommands"
       ~doc:
-        "Retrieve all the scheduled Snapp commands for a specified sender that \
+        "Retrieve all the scheduled snapp commands for a specified sender that \
          the current daemon sees in its transaction pool. All scheduled \
          commands are queried if no sender is specified"
       ~typ:(non_null @@ list @@ non_null Types.Snapp_command.snapp_command)
       ~args:
         Arg.
-          [ arg "publicKey" ~doc:"Public key of sender of pooled Snapp commands"
+          [ arg "publicKey" ~doc:"Public key of sender of pooled snapp commands"
               ~typ:Types.Input.public_key_arg
-          ; arg "hashes" ~doc:"Hashes of the Snapp commands to find in the pool"
+          ; arg "hashes" ~doc:"Hashes of the snapp commands to find in the pool"
               ~typ:(list (non_null string))
-          ; arg "ids" ~typ:(list (non_null guid)) ~doc:"Ids of Snapp commands"
+          ; arg "ids" ~typ:(list (non_null guid)) ~doc:"Ids of snapp commands"
           ]
       ~resolve:(fun { ctx = coda; _ } () pk_opt hashes_opt txns_opt ->
         let transaction_pool = Mina_lib.transaction_pool coda in
@@ -4628,7 +4628,7 @@ module Queries = struct
       ~args:
         Arg.
           [ arg "payment" ~typ:guid ~doc:"Id of a Payment"
-          ; arg "snappTransaction" ~typ:guid ~doc:"Id of a Snapp transaction"
+          ; arg "snappTransaction" ~typ:guid ~doc:"Id of a snapp transaction"
           ]
       ~resolve:
         (fun { ctx = coda; _ } () (serialized_payment : string option)
@@ -4655,7 +4655,7 @@ module Queries = struct
           match (serialized_payment, serialized_snapp) with
           | None, None | Some _, Some _ ->
               Error
-                "Invalid query: Specify either a payment ID or a Snapp \
+                "Invalid query: Specify either a payment ID or a snapp \
                  transaction ID"
           | Some payment, None ->
               deserialize_txn (`Signed_command payment)

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2460,7 +2460,7 @@ let%test_module "staged ledger tests" =
                     let authorization_with_valid_signature =
                       match authorization with
                       | Control.Signature _dummy ->
-                          let pk = data.body.pk in
+                          let pk = data.body.public_key in
                           let sk =
                             match
                               Signature_lib.Public_key.Compressed.Map.find

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -181,7 +181,7 @@ let%test_unit "ring-signature snapp tx with 3 parties" =
           let fee_payer =
             { Party.Fee_payer.data =
                 { body =
-                    { pk = sender_pk
+                    { public_key = sender_pk
                     ; update = Party.Update.noop
                     ; token_id = ()
                     ; balance_change = Amount.to_fee fee
@@ -201,7 +201,7 @@ let%test_unit "ring-signature snapp tx with 3 parties" =
           in
           let sender_party_data : Party.Predicated.t =
             { body =
-                { pk = sender_pk
+                { public_key = sender_pk
                 ; update = Party.Update.noop
                 ; token_id = Token_id.default
                 ; balance_change = Amount.(Signed.(negate (of_unsigned amount)))
@@ -218,7 +218,7 @@ let%test_unit "ring-signature snapp tx with 3 parties" =
           in
           let snapp_party_data : Party.Predicated.t =
             { Party.Predicated.Poly.body =
-                { pk = ringsig_account_pk
+                { public_key = ringsig_account_pk
                 ; update = Party.Update.noop
                 ; token_id = Token_id.default
                 ; balance_change = Amount.Signed.(of_unsigned amount)

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -68,7 +68,7 @@ let check :
                       [ Signature_lib.Public_key.compress pk ])
                 else ()
           in
-          check_signature fee_payer.authorization fee_payer.data.body.pk
+          check_signature fee_payer.authorization fee_payer.data.body.public_key
             (Parties.Transaction_commitment.with_fee_payer commitment
                ~fee_payer_hash:
                  (Party.Predicated.digest
@@ -82,7 +82,7 @@ let check :
               ~f:(fun ((p, vk_opt), at_party) ->
                 match p.authorization with
                 | Signature s ->
-                    check_signature s p.data.body.pk commitment ;
+                    check_signature s p.data.body.public_key commitment ;
                     None
                 | None_given ->
                     None


### PR DESCRIPTION
For the GraphQL input produced by `snapps_test_transaction`, instead of filling in fields in a string, traverse JSON derived from a `Parties.t` to build a string.

The Snapps GraphQL input is a Javascript object almost isomorphic to JSON; the main difference is that field names are not double-quoted. But the GraphQL schema has some differences  -- `Keep` is encoded as a `null`, for example. Those elements of special-handling are called out in comments.

In `Party.Body.t`, change `pk` to `public_key`, so that the GraphQL name is the more-informative `publicKey`. This change will trigger the version linter, of course.

In the GraphQL schema, camelCase `balance_change` and `use_full_commitment`, to avoid special handling for the underscored names.

Tested by running the app with sample inputs, confirming that the `sendSnapp` mutation accepted the syntax.

Closes #10017.


