### PR TITLE
Test block production under load

### DIFF
--- a/buildkite/scripts/run-test-executive.sh
+++ b/buildkite/scripts/run-test-executive.sh
@@ -5,6 +5,11 @@ TEST_NAME="$1"
 MINA_IMAGE="gcr.io/o1labs-192920/mina-daemon:$MINA_DOCKER_TAG-devnet"
 ARCHIVE_IMAGE="gcr.io/o1labs-192920/mina-archive:$MINA_DOCKER_TAG"
 
+if [[ "${TEST_NAME:0:4}" == "opt-" ]] && [[ "$RUN_OPT_TESTS" == "" ]]; then
+  echo "Skipping $TEST_NAME"
+  exit 0
+fi
+
 ./test_executive.exe cloud "$TEST_NAME" \
   --mina-image "$MINA_IMAGE" \
   --archive-image "$ARCHIVE_IMAGE" \

--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -185,7 +185,11 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
                     c.retries)
                 in
                 B/Retry.ListAutomaticRetry/Type xs),
-              manual = None B/Manual
+              manual = Some (B/Manual.Manual/Type {
+                allowed = Some True,
+                permit_on_passed = Some True,
+                reason = None Text
+              })
           },
     soft_fail = c.soft_fail,
     skip = c.skip,

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -29,7 +29,7 @@ in Pipeline.build Pipeline.Config::{
     TestExecutive.execute "payment" dependsOn,
     TestExecutive.execute "delegation" dependsOn,
     TestExecutive.execute "gossip-consis" dependsOn,
-    TestExecutive.execute "block-prod" dependsOn,
+    TestExecutive.execute "opt-block-prod" dependsOn,
     TestExecutive.execute "archive-node" dependsOn
 
   ]

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -29,6 +29,7 @@ in Pipeline.build Pipeline.Config::{
     TestExecutive.execute "payment" dependsOn,
     TestExecutive.execute "delegation" dependsOn,
     TestExecutive.execute "gossip-consis" dependsOn,
+    TestExecutive.execute "block-prod" dependsOn,
     TestExecutive.execute "archive-node" dependsOn
 
   ]

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -1473,6 +1473,16 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "PrivateKey",
+          "description": "Base58Check-encoded private key",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "SendPaymentPayload",
           "description": null,
@@ -2390,6 +2400,114 @@
                   "name": "SendPaymentPayload",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sendTestPayments",
+              "description": "Send a series of test payments",
+              "args": [
+                {
+                  "name": "repeat_delay_ms",
+                  "description":
+                    "Delay with which a transaction shall be repeated",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UInt32",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "repeat_count",
+                  "description":
+                    "How many times shall transaction be repeated",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UInt32",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "fee",
+                  "description": "The fee of each payment",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UInt64",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "amount",
+                  "description": "The amount of each payment",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "UInt64",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "receiver",
+                  "description": "The receiver of the payments",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "PublicKey",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "senders",
+                  "description":
+                    "The private keys from which to sign the payments",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "PrivateKey",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -7055,6 +7173,19 @@
               "deprecationReason": null
             },
             {
+              "name": "commandTransactionCount",
+              "description":
+                "Count of user command transactions in the block",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "snarkJobs",
               "description": null,
               "args": [],
@@ -7700,6 +7831,89 @@
                 "The index of this account in the ledger, or null if this account does not yet have a known position in the best tip ledger",
               "args": [],
               "type": { "kind": "SCALAR", "name": "Int", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Metrics",
+          "description": null,
+          "fields": [
+            {
+              "name": "blockProductionDelay",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "transactionPoolDiffReceived",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "transactionPoolDiffBroadcasted",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "transactionsAddedToPool",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "transactionPoolSize",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             }
@@ -8867,6 +9081,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "AddrsAndPorts",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "metrics",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Metrics",
                   "ofType": null
                 }
               },

--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -1,0 +1,157 @@
+open Core
+open Integration_test_lib
+
+module Make (Inputs : Intf.Test.Inputs_intf) = struct
+  open Inputs
+  open Engine
+  open Dsl
+
+  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  type network = Network.t
+
+  type node = Network.Node.t
+
+  type dsl = Dsl.t
+
+  let config =
+    let open Test_config in
+    { default with
+      requires_graphql = true
+    ; block_producers =
+        { Block_producer.balance = "9999999"; timing = Untimed }
+        :: List.init 4
+             ~f:(const { Block_producer.balance = "0"; timing = Untimed })
+    ; num_snark_workers = 2
+    ; aux_account_balance = Some "1000"
+    ; txpool_max_size = 10_000_000
+    ; snark_worker_fee = "0.0001"
+    }
+
+  let run network t =
+    let open Malleable_error.Let_syntax in
+    let logger = Logger.create () in
+    [%log info] "starting..." ;
+    let%bind () =
+      Malleable_error.List.iter
+        ( Network.seeds network
+        @ Network.block_producers network
+        @ Network.snark_coordinators network )
+        ~f:(Fn.compose (wait_for t) Wait_condition.node_to_initialize)
+    in
+    [%log info] "done waiting for initializations" ;
+    let%bind receiver, senders =
+      match Network.block_producers network with
+      | [] ->
+          Malleable_error.hard_error_string "no block producers"
+      | [ r ] ->
+          (* Sender and receiver are the same node *)
+          return (r, [ r ])
+      | r :: rs ->
+          return (r, rs)
+    in
+    let%bind receiver_pub_key = Util.pub_key_of_node receiver in
+    let pk_to_string = Signature_lib.Public_key.Compressed.to_base58_check in
+    [%log info] "receiver: %s" (pk_to_string receiver_pub_key) ;
+    let%bind () =
+      Malleable_error.List.iter senders ~f:(fun s ->
+          let%map pk = Util.pub_key_of_node s in
+          [%log info] "sender: %s" (pk_to_string pk))
+    in
+    let tx_delay_ms = 500 in
+    let window_ms =
+      (Network.constraint_constants network).block_window_duration_ms
+    in
+    let num_slots = 15 in
+    let min_resulting_blocks = 12 in
+    let num_payments = num_slots * window_ms / tx_delay_ms in
+    let fee = Currency.Fee.of_int 10_000_000 in
+    let amount = Currency.Amount.of_int 10_000_000 in
+    [%log info] "will now send %d payments" num_payments ;
+    let get_metrics node =
+      Async_kernel.Deferred.bind
+        (Network.Node.get_metrics ~logger node)
+        ~f:Malleable_error.or_hard_error
+    in
+    let%bind () = wait_for t (Wait_condition.blocks_to_be_produced 3) in
+    (* check account nonce on both nodes *)
+    let end_t =
+      Time.add (Time.now ())
+        (Time.Span.of_ms @@ float_of_int (num_slots * window_ms))
+    in
+    let num_senders = List.length senders in
+    let sender_keys =
+      List.map ~f:snd
+      @@ List.drop
+           (Array.to_list @@ Lazy.force @@ Mina_base.Sample_keypairs.keypairs)
+           (num_senders + 2)
+    in
+    let num_sender_keys = List.length sender_keys in
+    let keys_per_sender = num_sender_keys / num_senders in
+    let%bind () =
+      Malleable_error.ok_if_true ~error_type:`Hard
+        ~error:(Error.of_string "not enough sender keys")
+        (keys_per_sender > 0)
+    in
+    let repeat_count = Unsigned.UInt32.of_int num_payments in
+    let repeat_delay_ms = Unsigned.UInt32.of_int tx_delay_ms in
+    let%bind _ =
+      Malleable_error.List.fold ~init:sender_keys senders ~f:(fun keys node ->
+          let keys0, rest = List.split_n keys keys_per_sender in
+          Network.Node.must_send_test_payments ~repeat_count ~repeat_delay_ms
+            ~logger ~senders:keys0 ~receiver_pub_key ~amount ~fee node
+          >>| const rest)
+    in
+    let%bind () = Async.(at end_t >>= const Malleable_error.ok_unit) in
+    let%bind blocks =
+      Network.Node.must_get_best_chain ~logger ~max_length:(2 * num_slots)
+        receiver
+    in
+    let tx_counts =
+      Array.of_list
+      @@ List.drop_while ~f:(( = ) 0)
+      @@ List.map ~f:(fun b -> b.command_transaction_count) blocks
+    in
+    Array.sort ~compare tx_counts ;
+    let non_zero_tx_counts = Array.length tx_counts in
+    let tx_counts_med =
+      ( tx_counts.(non_zero_tx_counts / 2)
+      + tx_counts.((non_zero_tx_counts - 1) / 2) )
+      / 2
+    in
+    let res_num_payments = Array.fold ~init:0 ~f:( + ) tx_counts in
+    [%log info] "Total %d payments in blocks, see $blocks for details"
+      res_num_payments
+      ~metadata:
+        [ ( "blocks"
+          , `List
+              (List.map blocks ~f:(fun b ->
+                   `Tuple
+                     [ `String b.state_hash
+                     ; `Int b.command_transaction_count
+                     ; `String b.creator_pk
+                     ])) )
+        ] ;
+    let%bind { block_production_delay = rcv_delay; _ } = get_metrics receiver in
+    (* We omit the result because we just want to query senders to see some useful
+       output in test logs *)
+    let%bind () =
+      Malleable_error.List.iter senders
+        ~f:
+          (Fn.compose Malleable_error.soften_error
+             (Fn.compose Malleable_error.ignore_m get_metrics))
+    in
+    let rcv_delay_rest = List.fold ~init:0 ~f:( + ) @@ List.drop rcv_delay 1 in
+    let ok_if_true s =
+      Malleable_error.ok_if_true ~error:(Error.of_string s) ~error_type:`Soft
+    in
+    ok_if_true "not enough blocks" (List.length blocks >= min_resulting_blocks)
+    >>= fun () ->
+    (* First two slots might be delayed because of test's bootstrap, so we have 2 as a threshold *)
+    ok_if_true "block production was delayed" (rcv_delay_rest <= 2)
+    >>= fun () ->
+    (* TODO Use protocol constants to derive 125 *)
+    ok_if_true "blocks are not full (median test)" (tx_counts_med = 125)
+    >>= fun () ->
+    [%log info] "block_production_priority test: test finished!!" ;
+    Malleable_error.ok_unit
+end

--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -27,18 +27,19 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; snark_worker_fee = "0.0001"
     }
 
+  let fee = Currency.Fee.of_int 10_000_000
+
+  let amount = Currency.Amount.of_int 10_000_000
+
+  let tx_delay_ms = 500
+
+  let num_slots = 15
+
+  let min_resulting_blocks = 12
+
   let run network t =
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
-    [%log info] "starting..." ;
-    let%bind () =
-      Malleable_error.List.iter
-        ( Network.seeds network
-        @ Network.block_producers network
-        @ Network.snark_coordinators network )
-        ~f:(Fn.compose (wait_for t) Wait_condition.node_to_initialize)
-    in
-    [%log info] "done waiting for initializations" ;
     let%bind receiver, senders =
       match Network.block_producers network with
       | [] ->
@@ -57,101 +58,120 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           let%map pk = Util.pub_key_of_node s in
           [%log info] "sender: %s" (pk_to_string pk))
     in
-    let tx_delay_ms = 500 in
     let window_ms =
       (Network.constraint_constants network).block_window_duration_ms
     in
-    let num_slots = 15 in
-    let min_resulting_blocks = 12 in
-    let num_payments = num_slots * window_ms / tx_delay_ms in
-    let fee = Currency.Fee.of_int 10_000_000 in
-    let amount = Currency.Amount.of_int 10_000_000 in
-    [%log info] "will now send %d payments" num_payments ;
+    let%bind () =
+      section_hard "wait for nodes to initialize"
+        (Malleable_error.List.iter
+           ( Network.seeds network
+           @ Network.block_producers network
+           @ Network.snark_coordinators network )
+           ~f:(Fn.compose (wait_for t) Wait_condition.node_to_initialize))
+    in
+    let%bind () =
+      section_hard "wait for 3 blocks to be produced (warm-up)"
+        (wait_for t (Wait_condition.blocks_to_be_produced 3))
+    in
+    let end_t =
+      Time.add (Time.now ())
+        (Time.Span.of_ms @@ float_of_int (num_slots * window_ms))
+    in
+    let%bind () =
+      section_hard "spawn transaction sending"
+        (let num_senders = List.length senders in
+         let sender_keys =
+           List.map ~f:snd
+           @@ List.drop
+                ( Array.to_list @@ Lazy.force
+                @@ Mina_base.Sample_keypairs.keypairs )
+                (num_senders + 2)
+         in
+         let num_sender_keys = List.length sender_keys in
+         let keys_per_sender = num_sender_keys / num_senders in
+         let%bind () =
+           Malleable_error.ok_if_true ~error_type:`Hard
+             ~error:(Error.of_string "not enough sender keys")
+             (keys_per_sender > 0)
+         in
+         let num_payments = num_slots * window_ms / tx_delay_ms in
+         let repeat_count = Unsigned.UInt32.of_int num_payments in
+         let repeat_delay_ms = Unsigned.UInt32.of_int tx_delay_ms in
+         [%log info] "will now send %d payments" num_payments ;
+         Malleable_error.List.fold ~init:sender_keys senders
+           ~f:(fun keys node ->
+             let keys0, rest = List.split_n keys keys_per_sender in
+             Network.Node.must_send_test_payments ~repeat_count ~repeat_delay_ms
+               ~logger ~senders:keys0 ~receiver_pub_key ~amount ~fee node
+             >>| const rest)
+         >>| const ())
+    in
+    let%bind () =
+      section "wait for payments to be processed"
+        Async.(at end_t >>= const Malleable_error.ok_unit)
+    in
+    let ok_if_true s =
+      Malleable_error.ok_if_true ~error:(Error.of_string s) ~error_type:`Soft
+    in
+    let%bind () =
+      section "checked produced blocks"
+        (let%bind blocks =
+           Network.Node.must_get_best_chain ~logger ~max_length:(2 * num_slots)
+             receiver
+         in
+         let%bind () =
+           ok_if_true "not enough blocks"
+             (List.length blocks >= min_resulting_blocks)
+         in
+         let tx_counts =
+           Array.of_list
+           @@ List.drop_while ~f:(( = ) 0)
+           @@ List.map ~f:(fun b -> b.command_transaction_count) blocks
+         in
+         Array.sort ~compare tx_counts ;
+         let non_zero_tx_counts = Array.length tx_counts in
+         let tx_counts_med =
+           ( tx_counts.(non_zero_tx_counts / 2)
+           + tx_counts.((non_zero_tx_counts - 1) / 2) )
+           / 2
+         in
+         let res_num_payments = Array.fold ~init:0 ~f:( + ) tx_counts in
+         [%log info] "Total %d payments in blocks, see $blocks for details"
+           res_num_payments
+           ~metadata:
+             [ ( "blocks"
+               , `List
+                   (List.map blocks ~f:(fun b ->
+                        `Tuple
+                          [ `String b.state_hash
+                          ; `Int b.command_transaction_count
+                          ; `String b.creator_pk
+                          ])) )
+             ] ;
+         (* TODO Use protocol constants to derive 125 *)
+         ok_if_true "blocks are not full (median test)" (tx_counts_med = 125))
+    in
     let get_metrics node =
       Async_kernel.Deferred.bind
         (Network.Node.get_metrics ~logger node)
         ~f:Malleable_error.or_hard_error
     in
-    let%bind () = wait_for t (Wait_condition.blocks_to_be_produced 3) in
-    (* check account nonce on both nodes *)
-    let end_t =
-      Time.add (Time.now ())
-        (Time.Span.of_ms @@ float_of_int (num_slots * window_ms))
-    in
-    let num_senders = List.length senders in
-    let sender_keys =
-      List.map ~f:snd
-      @@ List.drop
-           (Array.to_list @@ Lazy.force @@ Mina_base.Sample_keypairs.keypairs)
-           (num_senders + 2)
-    in
-    let num_sender_keys = List.length sender_keys in
-    let keys_per_sender = num_sender_keys / num_senders in
     let%bind () =
-      Malleable_error.ok_if_true ~error_type:`Hard
-        ~error:(Error.of_string "not enough sender keys")
-        (keys_per_sender > 0)
+      section "check metrics of tx receiver node"
+        (let%bind { block_production_delay = rcv_delay; _ } =
+           get_metrics receiver
+         in
+         let rcv_delay_rest =
+           List.fold ~init:0 ~f:( + ) @@ List.drop rcv_delay 1
+         in
+         (* First two slots might be delayed because of test's bootstrap, so we have 2 as a threshold *)
+         ok_if_true "block production was delayed" (rcv_delay_rest <= 2))
     in
-    let repeat_count = Unsigned.UInt32.of_int num_payments in
-    let repeat_delay_ms = Unsigned.UInt32.of_int tx_delay_ms in
-    let%bind _ =
-      Malleable_error.List.fold ~init:sender_keys senders ~f:(fun keys node ->
-          let keys0, rest = List.split_n keys keys_per_sender in
-          Network.Node.must_send_test_payments ~repeat_count ~repeat_delay_ms
-            ~logger ~senders:keys0 ~receiver_pub_key ~amount ~fee node
-          >>| const rest)
-    in
-    let%bind () = Async.(at end_t >>= const Malleable_error.ok_unit) in
-    let%bind blocks =
-      Network.Node.must_get_best_chain ~logger ~max_length:(2 * num_slots)
-        receiver
-    in
-    let tx_counts =
-      Array.of_list
-      @@ List.drop_while ~f:(( = ) 0)
-      @@ List.map ~f:(fun b -> b.command_transaction_count) blocks
-    in
-    Array.sort ~compare tx_counts ;
-    let non_zero_tx_counts = Array.length tx_counts in
-    let tx_counts_med =
-      ( tx_counts.(non_zero_tx_counts / 2)
-      + tx_counts.((non_zero_tx_counts - 1) / 2) )
-      / 2
-    in
-    let res_num_payments = Array.fold ~init:0 ~f:( + ) tx_counts in
-    [%log info] "Total %d payments in blocks, see $blocks for details"
-      res_num_payments
-      ~metadata:
-        [ ( "blocks"
-          , `List
-              (List.map blocks ~f:(fun b ->
-                   `Tuple
-                     [ `String b.state_hash
-                     ; `Int b.command_transaction_count
-                     ; `String b.creator_pk
-                     ])) )
-        ] ;
-    let%bind { block_production_delay = rcv_delay; _ } = get_metrics receiver in
-    (* We omit the result because we just want to query senders to see some useful
-       output in test logs *)
-    let%bind () =
-      Malleable_error.List.iter senders
-        ~f:
-          (Fn.compose Malleable_error.soften_error
-             (Fn.compose Malleable_error.ignore_m get_metrics))
-    in
-    let rcv_delay_rest = List.fold ~init:0 ~f:( + ) @@ List.drop rcv_delay 1 in
-    let ok_if_true s =
-      Malleable_error.ok_if_true ~error:(Error.of_string s) ~error_type:`Soft
-    in
-    ok_if_true "not enough blocks" (List.length blocks >= min_resulting_blocks)
-    >>= fun () ->
-    (* First two slots might be delayed because of test's bootstrap, so we have 2 as a threshold *)
-    ok_if_true "block production was delayed" (rcv_delay_rest <= 2)
-    >>= fun () ->
-    (* TODO Use protocol constants to derive 125 *)
-    ok_if_true "blocks are not full (median test)" (tx_counts_med = 125)
-    >>= fun () ->
-    [%log info] "block_production_priority test: test finished!!" ;
-    Malleable_error.ok_unit
+    section "retrieve metrics of tx sender nodes"
+      (* We omit the result because we just want to query senders to see some useful
+          output in test logs *)
+      (Malleable_error.List.iter senders
+         ~f:
+           (Fn.compose Malleable_error.soften_error
+              (Fn.compose Malleable_error.ignore_m get_metrics)))
 end

--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -21,7 +21,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         { Block_producer.balance = "9999999"; timing = Untimed }
         :: List.init 4
              ~f:(const { Block_producer.balance = "0"; timing = Untimed })
-    ; num_snark_workers = 2
+    ; num_snark_workers = 25
     ; aux_account_balance = Some "1000"
     ; txpool_max_size = 10_000_000
     ; snark_worker_fee = "0.0001"

--- a/src/app/test_executive/block_production_priority.mli
+++ b/src/app/test_executive/block_production_priority.mli
@@ -1,0 +1,1 @@
+module Make : Integration_test_lib.Intf.Test.Functor_intf

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -21,7 +21,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; block_producers =
         [ { balance = "1000"; timing = Untimed }
         ; { balance = "1000"; timing = Untimed }
-        ; { balance = "1000"; timing = Untimed }
+        ; { balance = "0"; timing = Untimed }
         ]
     ; num_snark_workers = 0
     }

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -68,7 +68,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       (let%bind (labeled_chains : (string * string list) list) =
          Malleable_error.List.map all_nodes ~f:(fun node ->
              let%map chain = Network.Node.must_get_best_chain ~logger node in
-             (Node.id node, chain))
+             (Node.id node, List.map ~f:(fun b -> b.state_hash) chain))
        in
        let (chains : string list list) =
          List.map labeled_chains ~f:(fun (_, chain) -> chain)

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -22,7 +22,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     ; block_producers =
         [ { balance = "1000"; timing = Untimed }
         ; { balance = "1000"; timing = Untimed }
-        ; { balance = "1000"; timing = Untimed }
+        ; { balance = "0"; timing = Untimed }
         ]
     ; num_snark_workers = 0
     }

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -48,6 +48,8 @@ let tests : test list =
   ; ("delegation", (module Delegation_test.Make : Intf.Test.Functor_intf))
   ; ("archive-node", (module Archive_node_test.Make : Intf.Test.Functor_intf))
   ; ("gossip-consis", (module Gossip_consistency.Make : Intf.Test.Functor_intf))
+  ; ( "block-prod"
+    , (module Block_production_priority.Make : Intf.Test.Functor_intf) )
   ]
 
 let report_test_errors ~log_error_set ~internal_error_set =

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -48,7 +48,7 @@ let tests : test list =
   ; ("delegation", (module Delegation_test.Make : Intf.Test.Functor_intf))
   ; ("archive-node", (module Archive_node_test.Make : Intf.Test.Functor_intf))
   ; ("gossip-consis", (module Gossip_consistency.Make : Intf.Test.Functor_intf))
-  ; ( "block-prod"
+  ; ( "opt-block-prod"
     , (module Block_production_priority.Make : Intf.Test.Functor_intf) )
   ]
 

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -4,7 +4,6 @@ open Pipe_lib
 open Mina_base
 open Mina_state
 open Mina_transition
-module Time = Block_time
 
 type Structured_log_events.t += Block_produced
   [@@deriving register_event { msg = "Successfully produced a new block" }]
@@ -53,9 +52,9 @@ end
 module Transition_frontier_validation =
   External_transition.Transition_frontier_validation (Transition_frontier)
 
-let time_to_ms = Fn.compose Time.Span.to_ms Time.to_span_since_epoch
+let time_to_ms = Fn.compose Block_time.Span.to_ms Block_time.to_span_since_epoch
 
-let time_of_ms = Fn.compose Time.of_span_since_epoch Time.Span.of_ms
+let time_of_ms = Fn.compose Block_time.of_span_since_epoch Block_time.Span.of_ms
 
 let lift_sync f =
   Interruptible.uninterruptible
@@ -67,14 +66,14 @@ let lift_sync f =
 module Singleton_scheduler : sig
   type t
 
-  val create : Time.Controller.t -> t
+  val create : Block_time.Controller.t -> t
 
   (** If you reschedule when already scheduled, take the min of the two schedulings *)
-  val schedule : t -> Time.t -> f:(unit -> unit) -> unit
+  val schedule : t -> Block_time.t -> f:(unit -> unit) -> unit
 end = struct
   type t =
-    { mutable timeout : unit Time.Timeout.t option
-    ; time_controller : Time.Controller.t
+    { mutable timeout : unit Block_time.Timeout.t option
+    ; time_controller : Block_time.Controller.t
     }
 
   let create time_controller = { time_controller; timeout = None }
@@ -82,26 +81,30 @@ end = struct
   let cancel t =
     match t.timeout with
     | Some timeout ->
-        Time.Timeout.cancel t.time_controller timeout () ;
+        Block_time.Timeout.cancel t.time_controller timeout () ;
         t.timeout <- None
     | None ->
         ()
 
   let schedule t time ~f =
-    let remaining_time = Option.map t.timeout ~f:Time.Timeout.remaining_time in
+    let remaining_time =
+      Option.map t.timeout ~f:Block_time.Timeout.remaining_time
+    in
     cancel t ;
-    let span_till_time = Time.diff time (Time.now t.time_controller) in
+    let span_till_time =
+      Block_time.diff time (Block_time.now t.time_controller)
+    in
     let wait_span =
       match remaining_time with
-      | Some remaining when Time.Span.(remaining > Time.Span.of_ms Int64.zero)
-        ->
-          let min a b = if Time.Span.(a < b) then a else b in
+      | Some remaining
+        when Block_time.Span.(remaining > Block_time.Span.of_ms Int64.zero) ->
+          let min a b = if Block_time.Span.(a < b) then a else b in
           min remaining span_till_time
       | None | Some _ ->
           span_till_time
     in
     let timeout =
-      Time.Timeout.create t.time_controller wait_span ~f:(fun _ ->
+      Block_time.Timeout.create t.time_controller wait_span ~f:(fun _ ->
           t.timeout <- None ;
           f ())
     in
@@ -272,8 +275,8 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
                 ~staged_ledger_hash:next_staged_ledger_hash
             in
             let current_time =
-              Time.now time_controller |> Time.to_span_since_epoch
-              |> Time.Span.to_ms
+              Block_time.now time_controller
+              |> Block_time.to_span_since_epoch |> Block_time.Span.to_ms
             in
             O1trace.sync_thread "generate_consensus_transition" (fun () ->
                 Consensus_state_hooks.generate_transition
@@ -310,7 +313,7 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
 
 module Precomputed_block = struct
   type t = External_transition.Precomputed_block.t =
-    { scheduled_time : Time.t
+    { scheduled_time : Block_time.t
     ; protocol_state : Protocol_state.value
     ; protocol_state_proof : Proof.t
     ; staged_ledger_diff : Staged_ledger_diff.t
@@ -335,7 +338,7 @@ let handle_block_production_errors ~logger ~rejected_blocks_logger
     |> Error.raise
   in
   let time_metadata =
-    ("time", `Int (Time.Span.to_ms span |> Int64.to_int_exn))
+    ("time", `Int (Block_time.Span.to_ms span |> Int64.to_int_exn))
   in
   let state_metadata =
     ("protocol_state", Protocol_state.Value.to_yojson protocol_state)
@@ -436,11 +439,12 @@ let handle_block_production_errors ~logger ~rejected_blocks_logger
 
 let time ~logger ~time_controller label f =
   let open Deferred.Result.Let_syntax in
-  let t0 = Time.now time_controller in
+  let t0 = Block_time.now time_controller in
   let%map x = f () in
-  let span = Time.diff (Time.now time_controller) t0 in
+  let span = Block_time.diff (Block_time.now time_controller) t0 in
   [%log info]
-    ~metadata:[ ("time", `Int (Time.Span.to_ms span |> Int64.to_int_exn)) ]
+    ~metadata:
+      [ ("time", `Int (Block_time.Span.to_ms span |> Int64.to_int_exn)) ]
     !"%s: $time %!" label ;
   x
 
@@ -495,7 +499,7 @@ module Vrf_evaluation_state = struct
           (*try again*)
           let%bind () =
             Async.after
-              (Core.Time.Span.of_ms
+              (Time.Span.of_ms
                  (Mina_compile_config.vrf_poll_interval_ms |> Int.to_float))
           in
           poll_vrf_evaluator vrf_evaluator ~logger
@@ -614,7 +618,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                   (Breadcrumb.parent_hash crumb)
               else crumb
             in
-            let start = Time.now time_controller in
+            let start = Block_time.now time_controller in
             [%log info]
               ~metadata:[ ("breadcrumb", Breadcrumb.to_yojson crumb) ]
               "Producing new block with parent $breadcrumb%!" ;
@@ -769,9 +773,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                             ~consensus_constants
                       |> Deferred.return
                     in
-                    let transition_receipt_time =
-                      Some (Core_kernel.Time.now ())
-                    in
+                    let transition_receipt_time = Some (Time.now ()) in
                     let%bind breadcrumb =
                       time ~logger ~time_controller
                         "Build breadcrumb on produced block" (fun () ->
@@ -800,6 +802,13 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                     Bvar.broadcast block_produced_bvar breadcrumb ;
                     Mina_metrics.(
                       Counter.inc_one Block_producer.blocks_produced) ;
+                    Mina_metrics.Block_producer.(
+                      Block_production_delay_histogram.observe
+                        block_production_delay
+                        Time.(
+                          Span.to_ms
+                          @@ diff (now ())
+                          @@ Block_time.to_time scheduled_time)) ;
                     let%bind.Async.Deferred () =
                       Strict_pipe.Writer.write transition_writer breadcrumb
                     in
@@ -818,7 +827,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                              protocol_state_hashes.state_hash)
                           (Fn.const (Ok `Transition_accepted))
                       ; Deferred.choice
-                          ( Time.Timeout.create time_controller
+                          ( Block_time.Timeout.create time_controller
                               (* We allow up to 20 seconds for the transition
                                  to make its way from the transition_writer to
                                  the frontier.
@@ -828,9 +837,9 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                                  our system, and with medium curves those long
                                  cycles can be substantial.
                               *)
-                              (Time.Span.of_ms 20000L)
+                              (Block_time.Span.of_ms 20000L)
                               ~f:(Fn.const ())
-                          |> Time.Timeout.to_deferred )
+                          |> Block_time.Timeout.to_deferred )
                           (Fn.const (Ok `Timed_out))
                       ]
                     >>= function
@@ -850,10 +859,14 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                            mean your CPU is overloaded. Consider disabling \
                            `-run-snark-worker` if it's configured."
                         in
-                        let span = Time.diff (Time.now time_controller) start in
+                        let span =
+                          Block_time.diff (Block_time.now time_controller) start
+                        in
                         let metadata =
                           [ ( "time"
-                            , `Int (Time.Span.to_ms span |> Int64.to_int_exn) )
+                            , `Int
+                                (Block_time.Span.to_ms span |> Int64.to_int_exn)
+                            )
                           ; ( "protocol_state"
                             , Protocol_state.Value.to_yojson protocol_state )
                           ]
@@ -864,7 +877,9 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                         return ()
                   in
                   let%bind res = emit_breadcrumb () in
-                  let span = Time.diff (Time.now time_controller) start in
+                  let span =
+                    Block_time.diff (Block_time.now time_controller) start
+                  in
                   handle_block_production_errors ~logger ~rejected_blocks_logger
                     ~time_taken:span ~previous_protocol_state ~protocol_state
                     res) )
@@ -889,7 +904,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                   Transition_frontier.best_tip transition_frontier
                   |> Breadcrumb.consensus_state
                 in
-                let now = Time.now time_controller in
+                let now = Block_time.now time_controller in
                 let epoch_data_for_vrf, ledger_snapshot =
                   O1trace.sync_thread "get_epoch_data_for_vrf" (fun () ->
                       Consensus.Hooks.get_epoch_data_for_vrf
@@ -945,7 +960,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                        let poll () =
                          let%bind () =
                            Async.after
-                             (Core.Time.Span.of_ms
+                             (Time.Span.of_ms
                                 ( Mina_compile_config.vrf_poll_interval_ms
                                 |> Int.to_float ))
                          in
@@ -954,7 +969,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                              vrf_evaluation_state
                          in
                          Singleton_scheduler.schedule scheduler
-                           (Time.now time_controller)
+                           (Block_time.now time_controller)
                            ~f:(check_next_block_timing new_global_slot i')
                        in
                        match
@@ -997,7 +1012,7 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                            [ ("slot", Mina_numbers.Global_slot.to_yojson slot)
                            ; ("epoch", Mina_numbers.Length.to_yojson epoch)
                            ] ;
-                       let now = Time.now time_controller in
+                       let now = Block_time.now time_controller in
                        let curr_global_slot =
                          Consensus.Data.Consensus_time.(
                            of_time_exn ~constants:consensus_constants now
@@ -1059,7 +1074,8 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                                    (of_global_slot
                                       ~constants:consensus_constants
                                       winning_global_slot))
-                               |> Time.to_span_since_epoch |> Time.Span.to_ms
+                               |> Block_time.to_span_since_epoch
+                               |> Block_time.Span.to_ms
                              in
                              set_next_producer_timing
                                (`Produce (time, data, winner_pk))
@@ -1085,9 +1101,9 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                                             .block_window_duration_ms)
                                 in
                                 let span_till_time =
-                                  Time.diff scheduled_genesis_time
-                                    (Time.now time_controller)
-                                  |> Time.Span.to_time_span
+                                  Block_time.diff scheduled_genesis_time
+                                    (Block_time.now time_controller)
+                                  |> Block_time.Span.to_time_span
                                 in
                                 let%bind () = after span_till_time in
                                 generate_genesis_proof_if_needed ()) ;
@@ -1112,21 +1128,23 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
         consensus_constants.genesis_state_timestamp
       in
       (* if the producer starts before genesis, sleep until genesis *)
-      let now = Time.now time_controller in
-      if Time.( >= ) now genesis_state_timestamp then start ()
+      let now = Block_time.now time_controller in
+      if Block_time.( >= ) now genesis_state_timestamp then start ()
       else
-        let time_till_genesis = Time.diff genesis_state_timestamp now in
+        let time_till_genesis = Block_time.diff genesis_state_timestamp now in
         [%log warn]
           ~metadata:
             [ ( "time_till_genesis"
-              , `Int (Int64.to_int_exn (Time.Span.to_ms time_till_genesis)) )
+              , `Int
+                  (Int64.to_int_exn (Block_time.Span.to_ms time_till_genesis))
+              )
             ]
           "Node started before genesis: waiting $time_till_genesis \
            milliseconds before starting block producer" ;
         ignore
-          ( Time.Timeout.create time_controller time_till_genesis ~f:(fun _ ->
-                start ())
-            : unit Time.Timeout.t ))
+          ( Block_time.Timeout.create time_controller time_till_genesis
+              ~f:(fun _ -> start ())
+            : unit Block_time.Timeout.t ))
 
 let run_precomputed ~logger ~verifier ~trust_system ~time_controller
     ~frontier_reader ~transition_writer ~precomputed_blocks
@@ -1138,10 +1156,10 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
   let rejected_blocks_logger =
     Logger.create ~id:Logger.Logger_id.rejected_blocks ()
   in
-  let start = Time.now time_controller in
+  let start = Block_time.now time_controller in
   let module Breadcrumb = Transition_frontier.Breadcrumb in
   let produce
-      { Precomputed_block.scheduled_time = _
+      { Precomputed_block.scheduled_time
       ; protocol_state
       ; protocol_state_proof
       ; staged_ledger_diff
@@ -1259,6 +1277,10 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
             ]
           in
           Mina_metrics.(Counter.inc_one Block_producer.blocks_produced) ;
+          Mina_metrics.Block_producer.(
+            Block_production_delay_histogram.observe block_production_delay
+              Time.(
+                Span.to_ms @@ diff (now ()) @@ Block_time.to_time scheduled_time)) ;
           let%bind.Async.Deferred () =
             Strict_pipe.Writer.write transition_writer breadcrumb
           in
@@ -1270,9 +1292,10 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
                    protocol_state_hashes.state_hash)
                 (Fn.const (Ok `Transition_accepted))
             ; Deferred.choice
-                ( Time.Timeout.create time_controller (Time.Span.of_ms 20000L)
+                ( Block_time.Timeout.create time_controller
+                    (Block_time.Span.of_ms 20000L)
                     ~f:(Fn.const ())
-                |> Time.Timeout.to_deferred )
+                |> Block_time.Timeout.to_deferred )
                 (Fn.const (Ok `Timed_out))
             ]
           >>= function
@@ -1293,7 +1316,7 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
               return ()
         in
         let%bind res = emit_breadcrumb () in
-        let span = Time.diff (Time.now time_controller) start in
+        let span = Block_time.diff (Block_time.now time_controller) start in
         handle_block_production_errors ~logger ~rejected_blocks_logger
           ~time_taken:span ~previous_protocol_state ~protocol_state res
   in
@@ -1311,7 +1334,7 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
         match Sequence.next precomputed_blocks with
         | Some (precomputed_block, precomputed_blocks) ->
             let new_time_offset =
-              Core_kernel.Time.diff (Core_kernel.Time.now ())
+              Time.diff (Time.now ())
                 (Block_time.to_time
                    precomputed_block.Precomputed_block.scheduled_time)
             in
@@ -1320,11 +1343,10 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
               ~metadata:
                 [ ( "old_time_offset"
                   , `String
-                      (Core_kernel.Time.Span.to_string_hum
+                      (Time.Span.to_string_hum
                          (Block_time.Controller.get_time_offset ~logger)) )
                 ; ( "new_time_offset"
-                  , `String
-                      (Core_kernel.Time.Span.to_string_hum new_time_offset) )
+                  , `String (Time.Span.to_string_hum new_time_offset) )
                 ] ;
             Block_time.Controller.set_time_offset new_time_offset ;
             let%bind () = produce precomputed_block in

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -181,6 +181,17 @@ module Status = struct
     [@@deriving to_yojson, bin_io_unversioned]
   end
 
+  module Metrics = struct
+    type t =
+      { block_production_delay : int list
+      ; transaction_pool_diff_received : int
+      ; transaction_pool_diff_broadcasted : int
+      ; transactions_added_to_pool : int
+      ; transaction_pool_size : int
+      }
+    [@@deriving to_yojson, bin_io_unversioned, fields]
+  end
+
   module Make_entries (FieldT : sig
     type 'a t
 
@@ -204,13 +215,15 @@ module Status = struct
 
     let int_option_entry = option_entry ~f:Int.to_string
 
+    let list_mapper ~to_string list =
+      let len = List.length list in
+      let list_str =
+        if len > 0 then " " ^ List.to_string ~f:to_string list else ""
+      in
+      Printf.sprintf "%d%s" len list_str
+
     let list_string_entry name ~to_string =
-      map_entry name ~f:(fun list ->
-          let len = List.length list in
-          let list_str =
-            if len > 0 then " " ^ List.to_string ~f:to_string list else ""
-          in
-          Printf.sprintf "%d%s" len list_str)
+      map_entry name ~f:(list_mapper ~to_string)
 
     let num_accounts = int_option_entry "Global number of accounts"
 
@@ -386,6 +399,34 @@ module Status = struct
         |> digest_entries ~title:""
       in
       option_entry "Catchup status" ~f:render
+
+    let metrics =
+      let render conf =
+        let fmt_field name op field = [ (name, op (Field.get field conf)) ] in
+        let block_production_delay =
+          fmt_field "block_production_delay"
+          @@ list_mapper ~to_string:string_of_int
+        in
+        let transaction_pool_diff_received =
+          fmt_field "transaction_pool_diff_received" string_of_int
+        in
+        let transaction_pool_diff_broadcasted =
+          fmt_field "transaction_pool_diff_broadcasted" string_of_int
+        in
+        let transactions_added_to_pool =
+          fmt_field "transactions_added_to_pool" string_of_int
+        in
+        let transaction_pool_size =
+          fmt_field "transaction_pool_size" string_of_int
+        in
+        Metrics.Fields.to_list ~block_production_delay
+          ~transaction_pool_diff_received ~transaction_pool_diff_broadcasted
+          ~transactions_added_to_pool ~transaction_pool_size
+        |> List.concat
+        |> List.map ~f:(fun (s, v) -> ("\t" ^ s, v))
+        |> digest_entries ~title:""
+      in
+      map_entry "Metrics" ~f:render
   end
 
   type t =
@@ -418,6 +459,7 @@ module Status = struct
     ; consensus_mechanism : string
     ; consensus_configuration : Consensus.Configuration.Stable.Latest.t
     ; addrs_and_ports : Node_addrs_and_ports.Display.Stable.Latest.t
+    ; metrics : Metrics.t
     }
   [@@deriving to_yojson, bin_io_unversioned, fields]
 
@@ -435,7 +477,7 @@ module Status = struct
       ~coinbase_receiver ~histograms ~consensus_time_best_tip
       ~global_slot_since_genesis_best_tip ~consensus_time_now
       ~consensus_mechanism ~consensus_configuration ~next_block_production
-      ~snark_work_fee ~addrs_and_ports ~catchup_status
+      ~snark_work_fee ~addrs_and_ports ~catchup_status ~metrics
     |> List.filter_map ~f:Fn.id
 
   let to_text (t : t) =

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -102,6 +102,22 @@ module Node = struct
       }
     |}]
 
+    module Send_test_payments =
+    [%graphql
+    {|
+      mutation ($senders: [PrivateKey!]!,
+      $receiver: PublicKey!,
+      $amount: UInt64!,
+      $fee: UInt64!,
+      $repeat_count: UInt32!,
+      $repeat_delay_ms: UInt32!) {
+        sendTestPayments(
+          senders: $senders, receiver: $receiver, amount: $amount, fee: $fee,
+          repeat_count: $repeat_count,
+          repeat_delay_ms: $repeat_delay_ms) 
+      }
+    |}]
+
     module Send_payment =
     [%graphql
     {|
@@ -175,9 +191,29 @@ module Node = struct
     module Best_chain =
     [%graphql
     {|
-      query {
-        bestChain {
+      query ($max_length: Int) {
+        bestChain (maxLength: $max_length) {
           stateHash
+          commandTransactionCount
+          creatorAccount {
+            publicKey
+          }
+        }
+      }
+    |}]
+
+    module Query_metrics =
+    [%graphql
+    {|
+      query {
+        daemonStatus {
+          metrics {
+            blockProductionDelay
+            transactionPoolDiffReceived
+            transactionPoolDiffBroadcasted
+            transactionsAddedToPool
+            transactionPoolSize
+          }
         }
       }
     |}]
@@ -194,9 +230,14 @@ module Node = struct
     else
       let uri = Graphql.ingress_uri node in
       let metadata =
-        [ ("query", `String query_name); ("uri", `String (Uri.to_string uri)) ]
+        [ ("query", `String query_name)
+        ; ("uri", `String (Uri.to_string uri))
+        ; ("init_delay", `Float initial_delay_sec)
+        ]
       in
-      [%log info] "Attempting to send GraphQL request \"$query\" to \"$uri\""
+      [%log info]
+        "Attempting to send GraphQL request \"$query\" to \"$uri\" after \
+         $init_delay sec"
         ~metadata ;
       let rec retry n =
         if n <= 0 then (
@@ -260,9 +301,9 @@ module Node = struct
   let must_get_peer_id ~logger t =
     get_peer_id ~logger t |> Deferred.bind ~f:Malleable_error.or_hard_error
 
-  let get_best_chain ~logger t =
+  let get_best_chain ?max_length ~logger t =
     let open Deferred.Or_error.Let_syntax in
-    let query = Graphql.Best_chain.make () in
+    let query = Graphql.Best_chain.make ?max_length () in
     let%bind result =
       exec_graphql_request ~logger ~node:t ~query_name:"best_chain" query
     in
@@ -271,10 +312,23 @@ module Node = struct
         Deferred.Or_error.error_string "failed to get best chains"
     | Some chain ->
         return
-        @@ List.map ~f:(fun block -> block#stateHash) (Array.to_list chain)
+        @@ List.map
+             ~f:(fun block ->
+               Intf.
+                 { state_hash = block#stateHash
+                 ; command_transaction_count = block#commandTransactionCount
+                 ; creator_pk =
+                     ( match block#creatorAccount#publicKey with
+                     | `String pk ->
+                         pk
+                     | _ ->
+                         "unknown" )
+                 })
+             (Array.to_list chain)
 
-  let must_get_best_chain ~logger t =
-    get_best_chain ~logger t |> Deferred.bind ~f:Malleable_error.or_hard_error
+  let must_get_best_chain ?max_length ~logger t =
+    get_best_chain ?max_length ~logger t
+    |> Deferred.bind ~f:Malleable_error.or_hard_error
 
   let get_balance ~logger t ~account_id =
     let open Deferred.Or_error.Let_syntax in
@@ -324,7 +378,7 @@ module Node = struct
           ~public_key:(Graphql_lib.Encoders.public_key sender_pub_key)
           ()
       in
-      exec_graphql_request ~logger ~node:t
+      exec_graphql_request ~logger ~node:t ~initial_delay_sec:0.
         ~query_name:"unlock_sender_account_graphql" unlock_account_obj
     in
     let%bind _ = unlock_sender_account_graphql () in
@@ -410,6 +464,36 @@ module Node = struct
   let must_send_delegation ~logger t ~sender_pub_key ~receiver_pub_key ~amount
       ~fee =
     send_delegation ~logger t ~sender_pub_key ~receiver_pub_key ~amount ~fee
+    |> Deferred.bind ~f:Malleable_error.or_hard_error
+
+  let send_test_payments ~repeat_count ~repeat_delay_ms ~logger t ~senders
+      ~receiver_pub_key ~amount ~fee =
+    [%log info] "Sending a series of test payments"
+      ~metadata:(logger_metadata t) ;
+    let open Deferred.Or_error.Let_syntax in
+    let send_payment_graphql () =
+      let send_payment_obj =
+        Graphql.Send_test_payments.make
+          ~senders:
+            (Array.of_list
+               (List.map ~f:Signature_lib.Private_key.to_yojson senders))
+          ~receiver:(Graphql_lib.Encoders.public_key receiver_pub_key)
+          ~amount:(Graphql_lib.Encoders.amount amount)
+          ~fee:(Graphql_lib.Encoders.fee fee)
+          ~repeat_count:(Graphql_lib.Encoders.uint32 repeat_count)
+          ~repeat_delay_ms:(Graphql_lib.Encoders.uint32 repeat_delay_ms)
+          ()
+      in
+      exec_graphql_request ~logger ~node:t ~query_name:"send_payment_graphql"
+        send_payment_obj
+    in
+    let%map _ = send_payment_graphql () in
+    [%log info] "Sent test payments"
+
+  let must_send_test_payments ~repeat_count ~repeat_delay_ms ~logger t ~senders
+      ~receiver_pub_key ~amount ~fee =
+    send_test_payments ~repeat_count ~repeat_delay_ms ~logger t ~senders
+      ~receiver_pub_key ~amount ~fee
     |> Deferred.bind ~f:Malleable_error.or_hard_error
 
   let dump_archive_data ~logger (t : t) ~data_file =
@@ -525,6 +609,42 @@ module Node = struct
                   Out_channel.output_string out_ch block))
     in
     Malleable_error.return ()
+
+  let get_metrics ~logger t =
+    let open Deferred.Or_error.Let_syntax in
+    [%log info] "Getting node's metrics" ~metadata:(logger_metadata t) ;
+    let query_obj = Graphql.Query_metrics.make () in
+    let%bind query_result_obj =
+      exec_graphql_request ~logger ~node:t ~query_name:"query_metrics" query_obj
+    in
+    [%log info] "get_metrics, finished exec_graphql_request" ;
+    let block_production_delay =
+      Array.to_list
+      @@ query_result_obj#daemonStatus#metrics#blockProductionDelay
+    in
+    let metrics = query_result_obj#daemonStatus#metrics in
+    let transaction_pool_diff_received = metrics#transactionPoolDiffReceived in
+    let transaction_pool_diff_broadcasted =
+      metrics#transactionPoolDiffBroadcasted
+    in
+    let transactions_added_to_pool = metrics#transactionsAddedToPool in
+    let transaction_pool_size = metrics#transactionPoolSize in
+    [%log info]
+      "get_metrics, result of graphql query (block_production_delay; \
+       tx_received; tx_broadcasted; txs_added_to_pool; tx_pool_size) (%s; %d; \
+       %d; %d; %d)"
+      ( String.concat ~sep:", "
+      @@ List.map ~f:string_of_int block_production_delay )
+      transaction_pool_diff_received transaction_pool_diff_broadcasted
+      transactions_added_to_pool transaction_pool_size ;
+    return
+      Intf.
+        { block_production_delay
+        ; transaction_pool_diff_broadcasted
+        ; transaction_pool_diff_received
+        ; transactions_added_to_pool
+        ; transaction_pool_size
+        }
 end
 
 module Workload = struct

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -89,6 +89,7 @@ module Network_config = struct
         ; log_precomputed_blocks
         ; snark_worker_fee
         ; snark_worker_public_key
+        ; aux_account_balance
         } =
       test_config
     in
@@ -103,16 +104,34 @@ module Network_config = struct
     let testnet_name = "it-" ^ user ^ "-" ^ git_commit ^ "-" ^ test_name in
     (* GENERATE ACCOUNTS AND KEYPAIRS *)
     let num_block_producers = List.length block_producers in
-    let block_producer_keypairs, runtime_accounts =
-      (* the first keypair is the genesis winner and is assumed to be untimed. Therefore dropping it, and not assigning it to any block producer *)
-      let keypairs =
-        List.drop (Array.to_list (Lazy.force Sample_keypairs.keypairs)) 1
-      in
-      if num_block_producers > List.length keypairs then
-        failwith
-          "not enough sample keypairs for specified number of block producers" ;
-      let f index ({ Test_config.Block_producer.balance; timing }, (pk, sk)) =
-        let runtime_account =
+    let bp_keypairs, aux_keypairs =
+      List.split_n
+        (* the first keypair is the genesis winner and is assumed to be untimed. Therefore dropping it, and not assigning it to any block producer *)
+        (List.drop (Array.to_list (Lazy.force Sample_keypairs.keypairs)) 1)
+        num_block_producers
+    in
+    if List.length bp_keypairs < num_block_producers then
+      failwith
+        "not enough sample keypairs for specified number of block producers" ;
+    let aux_accounts, aux_keypairs =
+      match aux_account_balance with
+      | None ->
+          ([], [])
+      | Some balance when List.length aux_keypairs > 0 ->
+          let balance = Balance.of_formatted_string balance in
+          let default = Runtime_config.Accounts.Single.default in
+          ( List.map aux_keypairs ~f:(fun (pk, _) ->
+                { default with
+                  pk = Some (Public_key.Compressed.to_string pk)
+                ; balance
+                })
+          , aux_keypairs )
+      | _ ->
+          failwith "there should be at least one aux keypair"
+    in
+    let bp_accounts =
+      List.map (List.zip_exn block_producers bp_keypairs)
+        ~f:(fun ({ Test_config.Block_producer.balance; timing }, (pk, _)) ->
           let timing =
             match timing with
             | Account.Timing.Untimed ->
@@ -136,21 +155,7 @@ module Network_config = struct
               (* delegation currently unsupported *)
           ; delegate = None
           ; timing
-          }
-        in
-        let secret_name = "test-keypair-" ^ Int.to_string index in
-        let keypair =
-          { Keypair.public_key = Public_key.decompress_exn pk
-          ; private_key = sk
-          }
-        in
-        ( Network_keypair.create_network_keypair ~keypair ~secret_name
-        , runtime_account )
-      in
-      List.mapi ~f
-        (List.zip_exn block_producers
-           (List.take keypairs (List.length block_producers)))
-      |> List.unzip
+          })
     in
     (* DAEMON CONFIG *)
     let proof_config =
@@ -188,7 +193,7 @@ module Network_config = struct
           (* was: Some proof_config; TODO: prebake ledger and only set hash *)
       ; ledger =
           Some
-            { base = Accounts runtime_accounts
+            { base = Accounts (bp_accounts @ aux_accounts)
             ; add_genesis_winner = None
             ; num_accounts = None
             ; balances = []
@@ -220,10 +225,19 @@ module Network_config = struct
     let mina_archive_schema =
       "https://raw.githubusercontent.com/MinaProtocol/mina/develop/src/app/archive/create_schema.sql"
     in
+    let mk_net_keypair index (pk, sk) =
+      let secret_name = "test-keypair-" ^ Int.to_string index in
+      let keypair =
+        { Keypair.public_key = Public_key.decompress_exn pk; private_key = sk }
+      in
+      Network_keypair.create_network_keypair ~keypair ~secret_name
+    in
+    let aux_net_keypairs = List.mapi aux_keypairs ~f:mk_net_keypair in
+    let bp_net_keypairs = List.mapi bp_keypairs ~f:mk_net_keypair in
     (* NETWORK CONFIG *)
     { mina_automation_location = cli_inputs.mina_automation_location
     ; debug_arg = debug
-    ; keypairs = block_producer_keypairs
+    ; keypairs = bp_net_keypairs @ aux_net_keypairs
     ; constants
     ; terraform =
         { cluster_name
@@ -238,7 +252,7 @@ module Network_config = struct
         ; mina_archive_image = images.archive_node
         ; runtime_config = Runtime_config.to_yojson runtime_config
         ; block_producer_configs =
-            List.mapi block_producer_keypairs ~f:block_producer_config
+            List.mapi bp_net_keypairs ~f:block_producer_config
         ; log_precomputed_blocks
         ; archive_node_count = num_archive_nodes
         ; mina_archive_schema

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -5,6 +5,17 @@ open Mina_base
 open Pipe_lib
 open Signature_lib
 
+type metrics_t =
+  { block_production_delay : int list
+  ; transaction_pool_diff_received : int
+  ; transaction_pool_diff_broadcasted : int
+  ; transactions_added_to_pool : int
+  ; transaction_pool_size : int
+  }
+
+type best_chain_block =
+  { state_hash : string; command_transaction_count : int; creator_pk : string }
+
 (* TODO: malleable error -> or error *)
 
 module Engine = struct
@@ -78,6 +89,17 @@ module Engine = struct
         -> fee:Currency.Fee.t
         -> signed_command_result Malleable_error.t
 
+      val must_send_test_payments :
+           repeat_count:Unsigned.uint32
+        -> repeat_delay_ms:Unsigned.uint32
+        -> logger:Logger.t
+        -> t
+        -> senders:Signature_lib.Private_key.t list
+        -> receiver_pub_key:Signature_lib.Public_key.Compressed.t
+        -> amount:Currency.Amount.t
+        -> fee:Currency.Fee.t
+        -> unit Malleable_error.t
+
       val get_balance :
            logger:Logger.t
         -> t
@@ -99,10 +121,16 @@ module Engine = struct
         logger:Logger.t -> t -> (string * string list) Malleable_error.t
 
       val get_best_chain :
-        logger:Logger.t -> t -> string list Async_kernel.Deferred.Or_error.t
+           ?max_length:int
+        -> logger:Logger.t
+        -> t
+        -> best_chain_block list Async_kernel.Deferred.Or_error.t
 
       val must_get_best_chain :
-        logger:Logger.t -> t -> string list Malleable_error.t
+           ?max_length:int
+        -> logger:Logger.t
+        -> t
+        -> best_chain_block list Malleable_error.t
 
       val dump_archive_data :
         logger:Logger.t -> t -> data_file:string -> unit Malleable_error.t
@@ -112,6 +140,9 @@ module Engine = struct
 
       val dump_precomputed_blocks :
         logger:Logger.t -> t -> unit Malleable_error.t
+
+      val get_metrics :
+        logger:Logger.t -> t -> metrics_t Async_kernel.Deferred.Or_error.t
     end
 
     type t

--- a/src/lib/integration_test_lib/test_config.ml
+++ b/src/lib/integration_test_lib/test_config.ml
@@ -33,6 +33,7 @@ type t =
   ; log_precomputed_blocks : bool
   ; snark_worker_fee : string
   ; snark_worker_public_key : string
+  ; aux_account_balance : string option
   }
 
 let default =
@@ -51,4 +52,5 @@ let default =
   ; snark_worker_public_key =
       (let pk, _ = (Lazy.force Mina_base.Sample_keypairs.keypairs).(0) in
        Signature_lib.Public_key.Compressed.to_string pk)
+  ; aux_account_balance = None
   }

--- a/src/lib/mina_base/gen/gen.ml
+++ b/src/lib/mina_base/gen/gen.ml
@@ -6,7 +6,7 @@ open Core_kernel
 open Signature_lib
 
 let keypairs =
-  let n = 120 in
+  let n = 1200 in
   let generated_keypairs =
     let sks =
       Quickcheck.(

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -365,6 +365,22 @@ let get_status ~flag t =
     | _ ->
         None
   in
+  let metrics =
+    let open Mina_metrics.Block_producer in
+    Mina_metrics.
+      { Daemon_rpcs.Types.Status.Metrics.block_production_delay =
+          Block_production_delay_histogram.buckets block_production_delay
+      ; transaction_pool_diff_received =
+          Float.to_int @@ Gauge.value Network.transaction_pool_diff_received
+      ; transaction_pool_diff_broadcasted =
+          Float.to_int @@ Gauge.value Network.transaction_pool_diff_broadcasted
+      ; transaction_pool_size =
+          Float.to_int @@ Gauge.value Transaction_pool.pool_size
+      ; transactions_added_to_pool =
+          Float.to_int
+          @@ Counter.value Transaction_pool.transactions_added_to_pool
+      }
+  in
   { Daemon_rpcs.Types.Status.num_accounts
   ; sync_status
   ; catchup_status
@@ -397,6 +413,7 @@ let get_status ~flag t =
   ; consensus_mechanism
   ; consensus_configuration
   ; addrs_and_ports
+  ; metrics
   }
 
 let clear_hist_status ~flag t = Perf_histograms.wipe () ; get_status ~flag t

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -89,6 +89,8 @@ module Reflection = struct
 
     let nn_int a x = id ~typ:(non_null int) a x
 
+    let nn_int_list a x = id ~typ:(non_null (list (non_null int))) a x
+
     let int a x = id ~typ:int a x
 
     let nn_bool a x = id ~typ:(non_null bool) a x
@@ -370,6 +372,16 @@ module Types = struct
                ~external_ip:nn_string ~bind_ip:nn_string ~client_port:nn_int
                ~libp2p_port:nn_int ~peer:(id ~typ:peer))
 
+    let metrics : (_, Daemon_rpcs.Types.Status.Metrics.t option) typ =
+      obj "Metrics" ~fields:(fun _ ->
+          let open Reflection.Shorthand in
+          List.rev
+          @@ Daemon_rpcs.Types.Status.Metrics.Fields.fold ~init:[]
+               ~block_production_delay:nn_int_list
+               ~transaction_pool_diff_received:nn_int
+               ~transaction_pool_diff_broadcasted:nn_int
+               ~transactions_added_to_pool:nn_int ~transaction_pool_size:nn_int)
+
     let t : (_, Daemon_rpcs.Types.Status.t option) typ =
       obj "DaemonStatus" ~fields:(fun _ ->
           let open Reflection.Shorthand in
@@ -396,7 +408,8 @@ module Types = struct
                ~consensus_configuration:
                  (id ~typ:(non_null consensus_configuration))
                ~highest_block_length_received:nn_int
-               ~highest_unvalidated_block_length_received:nn_int)
+               ~highest_unvalidated_block_length_received:nn_int
+               ~metrics:(id ~typ:(non_null metrics)))
   end
 
   let fee_transfer =
@@ -1615,6 +1628,11 @@ module Types = struct
         ; field "transactions" ~typ:(non_null transactions)
             ~args:Arg.[]
             ~resolve:(fun _ { With_hash.data; _ } -> data.transactions)
+        ; field "commandTransactionCount" ~typ:(non_null int)
+            ~doc:"Count of user command transactions in the block"
+            ~args:Arg.[]
+            ~resolve:(fun _ { With_hash.data; _ } ->
+              List.length data.transactions.commands)
         ; field "snarkJobs"
             ~typ:(non_null @@ list @@ non_null completed_work)
             ~args:Arg.[]
@@ -1926,6 +1944,10 @@ module Types = struct
           | _ ->
               Error "Invalid format for public key.")
 
+    let private_key_arg =
+      scalar "PrivateKey" ~doc:"Base58Check-encoded private key"
+        ~coerce:Signature_lib.Private_key.of_yojson
+
     let token_id_arg =
       scalar "TokenId"
         ~doc:"String representation of a token's UInt64 identifier"
@@ -2124,6 +2146,8 @@ module Types = struct
 
       let fee ~doc = arg "fee" ~typ:(non_null uint64_arg) ~doc
 
+      let amount ~doc = arg "amount" ~typ:(non_null uint64_arg) ~doc
+
       let memo =
         arg "memo" ~typ:string
           ~doc:"Short arbitrary message provided by the sender"
@@ -2146,6 +2170,19 @@ module Types = struct
             "If a signature is provided, this transaction is considered signed \
              and will be broadcasted to the network without requiring a \
              private key"
+
+      let senders =
+        arg "senders"
+          ~typ:(non_null (list (non_null private_key_arg)))
+          ~doc:"The private keys from which to sign the payments"
+
+      let repeat_count =
+        arg "repeat_count" ~typ:(non_null uint32_arg)
+          ~doc:"How many times shall transaction be repeated"
+
+      let repeat_delay_ms =
+        arg "repeat_delay_ms" ~typ:(non_null uint32_arg)
+          ~doc:"Delay with which a transaction shall be repeated"
     end
 
     let send_payment =
@@ -2157,8 +2194,7 @@ module Types = struct
           [ from ~doc:"Public key of sender of payment"
           ; to_ ~doc:"Public key of recipient of payment"
           ; token_opt ~doc:"Token to send"
-          ; arg "amount" ~doc:"Amount of mina to send to receiver"
-              ~typ:(non_null uint64_arg)
+          ; amount ~doc:"Amount of mina to send to receiver"
           ; fee ~doc:"Fee amount in order to send payment"
           ; valid_until
           ; memo
@@ -2911,6 +2947,77 @@ module Mutations = struct
               ~fee_token ~fee_payer_pk:from ~valid_until ~body ~signature
             |> Deferred.Result.map ~f:Types.UserCommand.mk_user_command)
 
+  let send_test_payments =
+    io_field "sendTestPayments" ~doc:"Send a series of test payments"
+      ~typ:(non_null int)
+      ~args:
+        Types.Input.Fields.
+          [ senders
+          ; receiver ~doc:"The receiver of the payments"
+          ; amount ~doc:"The amount of each payment"
+          ; fee ~doc:"The fee of each payment"
+          ; repeat_count
+          ; repeat_delay_ms
+          ]
+      ~resolve:
+        (fun { ctx = coda; _ } () senders_list receiver_pk amount fee
+             repeat_count repeat_delay_ms ->
+        let dumb_password = lazy (return (Bytes.of_string "dumb")) in
+        let senders = Array.of_list senders_list in
+        let repeat_delay =
+          Time.Span.of_ms @@ float_of_int
+          @@ Unsigned.UInt32.to_int repeat_delay_ms
+        in
+        let fee_token = Token_id.default in
+        let start = Time.now () in
+        let send_tx i =
+          let source_privkey = senders.(i % Array.length senders) in
+          let source_pk_decompressed =
+            Signature_lib.Public_key.of_private_key_exn source_privkey
+          in
+          let source_pk =
+            Signature_lib.Public_key.compress source_pk_decompressed
+          in
+          let body =
+            Signed_command_payload.Body.Payment
+              { source_pk
+              ; receiver_pk
+              ; token_id = Token_id.default
+              ; amount = Amount.of_uint64 amount
+              }
+          in
+          let memo = "" in
+          let kp =
+            Keypair.
+              { private_key = source_privkey
+              ; public_key = source_pk_decompressed
+              }
+          in
+          let%bind _ =
+            Secrets.Wallets.import_keypair (Mina_lib.wallets coda) kp
+              ~password:dumb_password
+          in
+          send_unsigned_user_command ~coda ~nonce_opt:None ~signer:source_pk
+            ~memo:(Some memo) ~fee ~fee_token ~fee_payer_pk:source_pk
+            ~valid_until:None ~body
+          |> Deferred.Result.map ~f:(const 0)
+        in
+
+        let do_ i =
+          let pause =
+            Time.diff
+              (Time.add start @@ Time.Span.scale repeat_delay @@ float_of_int i)
+            @@ Time.now ()
+          in
+          (if Time.Span.(pause > zero) then after pause else Deferred.unit)
+          >>= fun () -> send_tx i >>| const ()
+        in
+        for i = 2 to Unsigned.UInt32.to_int repeat_count do
+          don't_wait_for (do_ i)
+        done ;
+        (* don't_wait_for (Deferred.for_ 2 ~to_:repeat_count ~do_) ; *)
+        send_tx 1)
+
   let create_token =
     io_field "createToken" ~doc:"Create a new token"
       ~typ:(non_null Types.Payload.create_token)
@@ -3237,6 +3344,7 @@ module Mutations = struct
     ; import_account
     ; reload_wallets
     ; send_payment
+    ; send_test_payments
     ; send_delegation
     ; create_token
     ; create_token_account

--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -33,6 +33,8 @@ module type Histogram = sig
   type t
 
   val observe : t -> float -> unit
+
+  val buckets : t -> int list
 end
 
 module Runtime : sig
@@ -67,6 +69,8 @@ module Transaction_pool : sig
   val useful_transactions_received_time_sec : Gauge.t
 
   val pool_size : Gauge.t
+
+  val transactions_added_to_pool : Counter.t
 end
 
 module Network : sig
@@ -329,6 +333,10 @@ module Block_producer : sig
   val slots_won : Counter.t
 
   val blocks_produced : Counter.t
+
+  module Block_production_delay_histogram : Histogram
+
+  val block_production_delay : Block_production_delay_histogram.t
 end
 
 module Transition_frontier : sig

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -35,12 +35,16 @@ module type Histogram = sig
   type t
 
   val observe : t -> float -> unit
+
+  val buckets : t -> int list
 end
 
 module Histogram = struct
   type t = unit
 
   let observe : t -> float -> unit = fun _ _ -> ()
+
+  let buckets () = []
 end
 
 module Runtime = struct
@@ -75,6 +79,8 @@ module Transaction_pool = struct
   let useful_transactions_received_time_sec : Gauge.t = ()
 
   let pool_size : Gauge.t = ()
+
+  let transactions_added_to_pool : Counter.t = ()
 end
 
 module Network = struct
@@ -337,6 +343,10 @@ module Block_producer = struct
   let slots_won : Counter.t = ()
 
   let blocks_produced : Counter.t = ()
+
+  module Block_production_delay_histogram = Histogram
+
+  let block_production_delay : Block_production_delay_histogram.t = ()
 end
 
 module Transition_frontier = struct

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1153,7 +1153,9 @@ struct
                               in
                               Mina_metrics.(
                                 Gauge.set Transaction_pool.pool_size
-                                  (Float.of_int (Indexed_pool.size pool''))) ;
+                                  (Float.of_int (Indexed_pool.size pool'')) ;
+                                Counter.inc_one
+                                  Transaction_pool.transactions_added_to_pool) ;
                               t.pool <- pool'' ;
                               let%bind _ =
                                 trust_record


### PR DESCRIPTION
On some block producing nodes blocks are created with a significant lag, apparently due to being overwhelmed with transactions.

Problem: there is no good way to reproduce the condition in test environment

Solution: implement an integration test that tests this condition with a high probability.

The test implemented fails on current `develop` with ~25% probability. By default this test is turned off, provide `RUN_OPT_TESTS=1` environment variable via Buildkite custom build to see the test executed.

The test launches:
* 4 transaction producers, each generating a transaction each 2 seconds
* a block producer
* a snark coordinator with 25 snark workers

Result of the test is expected to be:
1. Median of transaction count in blocks is ~125 (first few empty blocks are ignored)
2. All blocks are produced within 60s after slot start

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None