### PR TITLE
Valid output for Full predicate

### DIFF
--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -37,6 +37,7 @@ RUN apt-get -y update && \
     libssl1.1 \
     libpq-dev \
     procps \
+    python3 \
     tzdata && \
   rm -rf /var/lib/apt/lists/*
 

--- a/src/app/snapp_test_transaction/snapp_test_transaction.ml
+++ b/src/app/snapp_test_transaction/snapp_test_transaction.ml
@@ -58,36 +58,8 @@ let jsobj_of_json ?(fee_payer = false) (json : Yojson.Safe.t) : string =
         go (`Assoc [ ("account", `Null); ("nonce", `Null) ]) level
     | `List [ `String "Nonce"; n ] ->
         go (`Assoc [ ("nonce", n) ]) level
-    | `List [ `String "Full"; _ ] ->
-        (* TODO: issue #10008 *)
-        go
-          (`Assoc
-            [ ( "account"
-              , `Assoc
-                  [ ("balance", `Null)
-                  ; ("nonce", `Null)
-                  ; ("receiptChainHash", `Null)
-                  ; ("publicKey", `Null)
-                  ; ("delegate", `Null)
-                  ; ( "state"
-                    , `Assoc
-                        [ ( "elements"
-                          , `List
-                              [ `Null
-                              ; `Null
-                              ; `Null
-                              ; `Null
-                              ; `Null
-                              ; `Null
-                              ; `Null
-                              ; `Null
-                              ] )
-                        ] )
-                  ; ("sequenceState", `Null)
-                  ; ("provedState", `Null)
-                  ] )
-            ])
-          level
+    | `List [ `String "Full"; account ] ->
+        go (`Assoc [ ("account", account) ]) level
     (* other constructors *)
     | `List [ `String name; value ] ->
         go (`Assoc [ (Mina_graphql.Reflection.underToCamel name, value) ]) level


### PR DESCRIPTION
In `snapp_test_transaction`, we were printing a dummy record for the `Full` predicate.

The code to transform JSON to a string had most of the machinery to handle this case (camelCasing field names, etc.). The only additional mechanism needed was to add an "account" field to the record for this case.

Tested by QC-generating an instance of `Snapp_predicate.Account.t`, using `jsobj_of_json` to convert it to a string, and inspecting the printed result.

Closes #10008.