### PR TITLE
Debug intgtest

### DIFF
--- a/dockerfiles/Dockerfile-mina-daemon
+++ b/dockerfiles/Dockerfile-mina-daemon
@@ -37,6 +37,7 @@ RUN apt-get -y update && \
     libssl1.1 \
     libpq-dev \
     procps \
+    python3 \
     tzdata && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
the integration tests were hitting a "container not found" bug, i found out later that this is because there is no longer python in the mina daemon containers, for mysterious reasons.

it looks like one of our packages that we install in the dockerfile of the mina daemon image used to depend on python but no longer does so python no longer appears in our container.  this is fixed by just manually installing it