### PR TITLE
Add `add_check` helper function to Parties_logic, use it for `Check_fee_excess`

### DIFF
--- a/src/lib/mina_base/parties_logic.ml
+++ b/src/lib/mina_base/parties_logic.ml
@@ -308,6 +308,22 @@ module type Inputs_intf = sig
     val full_commitment : party:Party.t -> commitment:t -> t
   end
 
+  module Local_state : sig
+    type failure_status
+
+    type t =
+      ( Parties.t
+      , Token_id.t
+      , Amount.t
+      , Ledger.t
+      , Bool.t
+      , Transaction_commitment.t
+      , failure_status )
+      Local_state.t
+
+    val add_check : t -> Transaction_status.Failure.t -> Bool.t -> t
+  end
+
   module Global_state : sig
     type t
 
@@ -396,8 +412,8 @@ module Make (Inputs : Inputs_intf) = struct
          ; .. >
          as
          'env)
-        handler)
-      ((global_state : Global_state.t), (local_state : _ Local_state.t)) =
+        handler) ((global_state : Global_state.t), (local_state : Local_state.t))
+      =
     let open Inputs in
     let is_start' =
       let is_start' = Ps.is_empty local_state.parties in

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1734,10 +1734,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
               Account.Nonce.equal account.nonce n
           | Full p ->
               Or_error.is_ok (Snapp_predicate.Account.check p account) )
-      | Check_fee_excess (valid_fee_excess, prev_failure_status) ->
-          if not valid_fee_excess then
-            Some Transaction_status.Failure.Invalid_fee_excess
-          else prev_failure_status
       | Check_auth_and_update_account
           { is_start
           ; at_party = _

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1665,6 +1665,30 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
 
       let push_stack x ~onto : t = Stack (x, ()) :: onto
     end
+
+    module Local_state = struct
+      type failure_status = Transaction_status.Failure.t option
+
+      type t =
+        ( Parties.t
+        , Token_id.t
+        , Amount.t
+        , Ledger.t
+        , Bool.t
+        , Transaction_commitment.t
+        , failure_status )
+        Parties_logic.Local_state.t
+
+      let add_check (t : t) failure b =
+        let failure_status =
+          match t.failure_status with
+          | None when not b ->
+              Some failure
+          | old_failure_status ->
+              old_failure_status
+        in
+        { t with failure_status; success = t.success && b }
+    end
   end
 
   module Env = struct

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1916,6 +1916,23 @@ module Base = struct
           type t = Field.t
         end
 
+        module Local_state = struct
+          type failure_status = unit
+
+          type t =
+            ( Parties.t
+            , Token_id.t
+            , Amount.t
+            , Ledger.t
+            , Bool.t
+            , Transaction_commitment.t
+            , failure_status )
+            Parties_logic.Local_state.t
+
+          let add_check (t : t) _failure b =
+            { t with success = Bool.(t.success &&& b) }
+        end
+
         module Global_state = struct
           type t = Global_state.t =
             { ledger : Ledger_hash.var * Sparse_ledger.t Prover_value.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1994,9 +1994,6 @@ module Base = struct
         | Check_predicate (_is_start, { party; _ }, account, _global) ->
             Snapp_predicate.Account.Checked.check party.data.predicate
               account.data
-        | Check_fee_excess (valid_fee_excess, ()) ->
-            with_label __LOC__ (fun () ->
-                Boolean.Assert.is_true valid_fee_excess)
         | Check_auth_and_update_account
             { is_start
             ; at_party = at_party, _


### PR DESCRIPTION
This PR introduces an `add_check` function, which we can use to verify checks in both the transaction logic and the snark logic using the `Parties_logic` functor. This function is designed so that it can collect the informative `Failure_reason.t` error for the transaction logic, while ensuring that the failure cases are identical between the two versions. This is then used to replace the `Check_fee_excess` effect

This is part of the work for #10033.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them