### PR TITLE
Check transaction verification in Parties_logic

### DIFF
--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -902,3 +902,5 @@ let protocol_state (t : t) : Snapp_predicate.Protocol_state.t =
   t.data.body.protocol_state
 
 let token_id (t : t) : Token_id.t = t.data.body.token_id
+
+let use_full_commitment (t : t) : bool = t.data.body.use_full_commitment


### PR DESCRIPTION
This PR moves transaction verification from the catch-all `Check_auth_and_update_account` effect into a dedicated function, and calls this function from `Parties_logic`.

This is part of the work for #10033.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them