### PR TITLE
Move replay checks into `Parties_logic`

### DIFF
--- a/src/lib/mina_base/parties_logic.ml
+++ b/src/lib/mina_base/parties_logic.ml
@@ -533,6 +533,13 @@ module Make (Inputs : Inputs_intf) = struct
       Local_state.add_check local_state Fee_payer_nonce_must_increase
         Inputs.Bool.(Inputs.Party.increment_nonce party ||| not is_start')
     in
+    let local_state =
+      Local_state.add_check local_state Parties_replay_check_failed
+        Inputs.Bool.(
+          Inputs.Party.increment_nonce party
+          ||| Inputs.Party.use_full_commitment party
+          ||| not signature_verifies)
+    in
     let a', update_permitted, failure_status =
       h.perform
         (Check_auth_and_update_account

--- a/src/lib/mina_base/parties_logic.ml
+++ b/src/lib/mina_base/parties_logic.ml
@@ -173,6 +173,8 @@ module type Party_intf = sig
 
   val use_full_commitment : t -> bool
 
+  val increment_nonce : t -> bool
+
   val check_authorization :
        account:account
     -> commitment:transaction_commitment
@@ -525,6 +527,11 @@ module Make (Inputs : Inputs_intf) = struct
           ~else_:local_state.transaction_commitment
       in
       Inputs.Party.check_authorization ~account:a ~commitment ~at_party party
+    in
+    (* The fee-payer must increment their nonce. *)
+    let local_state =
+      Local_state.add_check local_state Fee_payer_nonce_must_increase
+        Inputs.Bool.(Inputs.Party.increment_nonce party ||| not is_start')
     in
     let a', update_permitted, failure_status =
       h.perform

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -904,3 +904,5 @@ let protocol_state (t : t) : Snapp_predicate.Protocol_state.t =
 let token_id (t : t) : Token_id.t = t.data.body.token_id
 
 let use_full_commitment (t : t) : bool = t.data.body.use_full_commitment
+
+let increment_nonce (t : t) : bool = t.data.body.increment_nonce

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1762,12 +1762,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
             [%test_eq: Control.Tag.t] Signature (Control.tag p.authorization) ;
           match
             let%bind.Result () =
-              if is_start && not p.data.body.increment_nonce then
-                (* The fee-payer must increment their nonce. *)
-                Error Transaction_status.Failure.Fee_payer_nonce_must_increase
-              else Ok ()
-            in
-            let%bind.Result () =
               match
                 ( Control.tag p.authorization
                 , p.data.body.increment_nonce

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1761,19 +1761,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           if (is_start : bool) then
             [%test_eq: Control.Tag.t] Signature (Control.tag p.authorization) ;
           match
-            let%bind.Result () =
-              match
-                ( Control.tag p.authorization
-                , p.data.body.increment_nonce
-                , p.data.body.use_full_commitment )
-              with
-              | Signature, false, false ->
-                  (* If there's a signature, it must increment the nonce or use
-                     full commitment to avoid replays *)
-                  Error Transaction_status.Failure.Parties_replay_check_failed
-              | _ ->
-                  Ok ()
-            in
             apply_body ~constraint_constants ~state_view
               ~check_auth:
                 (Fn.flip Permissions.Auth_required.check

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2054,11 +2054,6 @@ module Base = struct
             } ->
             let add_check, checks_succeeded = create_checker () in
             (* If there's a valid signature, it must increment the nonce or use full commitment *)
-            add_check
-              Boolean.(
-                party.data.body.increment_nonce
-                ||| party.data.body.use_full_commitment
-                ||| not signature_verifies) ;
             let account', `proof_must_verify proof_must_verify =
               let tag =
                 Option.map snapp_statement ~f:(fun (i, _) -> side_loaded i)

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1863,6 +1863,8 @@ module Base = struct
           let use_full_commitment (t : t) =
             t.party.data.body.use_full_commitment
 
+          let increment_nonce (t : t) = t.party.data.body.increment_nonce
+
           let check_authorization ~(account : Account.t) ~commitment
               ~at_party:(at_party, _) ({ party; control; _ } : t) =
             ( match (auth_type, snapp_statement) with
@@ -2051,8 +2053,6 @@ module Base = struct
             ; inclusion_proof = _
             } ->
             let add_check, checks_succeeded = create_checker () in
-            (* The fee-payer must increment their nonce. *)
-            add_check Boolean.(party.data.body.increment_nonce ||| not is_start) ;
             (* If there's a valid signature, it must increment the nonce or use full commitment *)
             add_check
               Boolean.(


### PR DESCRIPTION
This PR deduplicates the logic for the replay checks in the transaction logic / transaction snark, moving them to a single implementation in `Parties_logic`.

This is part of #10033


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
