### PR TITLE
Snapp integration test

### DIFF
--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -28,7 +28,7 @@ in Pipeline.build Pipeline.Config::{
     TestExecutive.execute "chain-reliability" dependsOn,
     TestExecutive.execute "payment" dependsOn,
     TestExecutive.execute "gossip-consis" dependsOn,
-    TestExecutive.execute "archive-node" dependsOn
-
+    TestExecutive.execute "archive-node" dependsOn,
+    TestExecutive.execute "snapps" dependsOn
   ]
 }

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -816,6 +816,16 @@
         },
         {
           "kind": "SCALAR",
+          "name": "SendTestSnappInput",
+          "description": "Parties for a test snapp",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
           "name": "SnappProof",
           "description": null,
           "fields": null,
@@ -6230,6 +6240,37 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "SendSnappInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SendSnappPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sendTestSnapp",
+              "description": "Send a test snapp",
+              "args": [
+                {
+                  "name": "parties",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "SendTestSnappInput",
                       "ofType": null
                     }
                   },

--- a/src/app/test_executive/snapps_test.ml
+++ b/src/app/test_executive/snapps_test.ml
@@ -1,0 +1,87 @@
+open Core
+open Async
+open Integration_test_lib
+
+module Make (Inputs : Intf.Test.Inputs_intf) = struct
+  open Inputs
+  open Engine
+  open Dsl
+
+  (* TODO: find a way to avoid this type alias (first class module signatures restrictions make this tricky) *)
+  type network = Network.t
+
+  type node = Network.Node.t
+
+  type dsl = Dsl.t
+
+  let config =
+    let open Test_config in
+    let open Test_config.Block_producer in
+    { default with
+      requires_graphql = true
+    ; block_producers = [ { balance = "4000000000"; timing = Untimed } ]
+    ; num_snark_workers = 0
+    }
+
+  let run network t =
+    let open Malleable_error.Let_syntax in
+    let logger = Logger.create () in
+    let block_producer_nodes = Network.block_producers network in
+    let%bind () =
+      Malleable_error.List.iter block_producer_nodes
+        ~f:(Fn.compose (wait_for t) Wait_condition.node_to_initialize)
+    in
+    let node = List.hd_exn block_producer_nodes in
+    let%map () =
+      section "send a snapp"
+        (let (user_cmd : Mina_base.User_command.t), _, _, _ =
+           Quickcheck.random_value
+             (Mina_base.User_command_generators.parties_with_ledger ())
+         in
+         let parties0 =
+           match user_cmd with
+           | Parties p ->
+               p
+           | Signed_command _ ->
+               failwith "Expected a Parties command"
+         in
+         let%bind fee_payer_pk = Util.pub_key_of_node node in
+         (* substitute key in test ledger into generated Parties.t
+            substitute dummy signature
+         *)
+         let parties =
+           { parties0 with
+             fee_payer =
+               { data =
+                   { parties0.fee_payer.data with
+                     body =
+                       { parties0.fee_payer.data.body with
+                         public_key = fee_payer_pk
+                       }
+                   }
+               ; authorization = Mina_base.Signature.dummy
+               }
+           }
+         in
+         match%bind.Deferred Network.Node.send_snapp ~logger node ~parties with
+         | Ok () ->
+             [%log error]
+               "Snapps transaction succeeded, expected failure due to invalid \
+                signature" ;
+             Malleable_error.soft_error_format ~value:()
+               "Snapps transaction succeeded despite invalid signature"
+         | Error err ->
+             let err_str = Error.to_string_mach err in
+             if String.is_substring ~substring:"Invalid_signature" err_str then (
+               [%log info] "Snapps failed as expected with invalid signature" ;
+               Malleable_error.return () )
+             else (
+               [%log error]
+                 "Error sending snapp, for a reason other than the expected \
+                  invalid signature"
+                 ~metadata:[ ("error", `String err_str) ] ;
+               Malleable_error.soft_error_format ~value:()
+                 "Snapp failed in unexpected way: %s" err_str ))
+    in
+    ()
+end

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -47,6 +47,7 @@ let tests : test list =
   ; ("payments", (module Payments_test.Make : Intf.Test.Functor_intf))
   ; ("archive-node", (module Archive_node_test.Make : Intf.Test.Functor_intf))
   ; ("gossip-consis", (module Gossip_consistency.Make : Intf.Test.Functor_intf))
+  ; ("snapps", (module Snapps_test.Make : Intf.Test.Functor_intf))
   ]
 
 let report_test_errors ~log_error_set ~internal_error_set =

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -79,9 +79,11 @@ module Time = struct
               | Some tm ->
                   Int.of_string tm
               | None ->
+                  let default = 0 in
                   eprintf
-                    "Environment variable %s not found, using default of 0" env ;
-                  0
+                    "Environment variable %s not found, using default of %d\n%!"
+                    env default ;
+                  default
             in
             Core_kernel.Time.Span.of_int_sec env_offset
           in

--- a/src/lib/integration_test_cloud_engine/dune
+++ b/src/lib/integration_test_cloud_engine/dune
@@ -3,7 +3,8 @@
  (name integration_test_cloud_engine)
  (inline_tests)
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_coda ppx_version ppx_optcomp graphql_ppx ppx_let ppx_inline_test ppx_custom_printf ppx_deriving_yojson lens.ppx_deriving ppx_pipebang ppx_sexp_conv))
+ (preprocessor_deps ../../../graphql_schema.json)
+ (preprocess (pps ppx_coda graphql_ppx ppx_optcomp ppx_version ppx_let ppx_inline_test ppx_custom_printf ppx_deriving_yojson ppx_pipebang ppx_sexp_conv))
  (libraries
-   core async lens mina_base pipe_lib runtime_config genesis_constants graphql_lib transition_frontier user_command_input genesis_ledger_helper integration_test_lib block_time interruptible exit_handlers transition_router block_producer)
+   core async mina_base pipe_lib runtime_config genesis_constants graphql_lib transition_frontier user_command_input genesis_ledger_helper integration_test_lib block_time interruptible exit_handlers transition_router block_producer)
 )

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -451,10 +451,17 @@ module Node = struct
       exec_graphql_request ~logger ~node:t ~query_name:"send_snapp_graphql"
         send_snapp_obj
     in
-    let%map sent_snapp_obj = send_snapp_graphql () in
-    assert (Option.is_none sent_snapp_obj#sendTestSnapp#snapp#failureReason) ;
+    let%bind sent_snapp_obj = send_snapp_graphql () in
+    let%bind () =
+      match sent_snapp_obj#sendTestSnapp#snapp#failureReason with
+      | None ->
+          return ()
+      | Some s ->
+          Deferred.Or_error.errorf "Snapp failed, reason: %s" s
+    in
     let snapp_id = sent_snapp_obj#sendTestSnapp#snapp#id in
-    [%log info] "Sent snapp" ~metadata:[ ("snapp_id", `String snapp_id) ]
+    return
+      ([%log info] "Sent snapp" ~metadata:[ ("snapp_id", `String snapp_id) ])
 
   let dump_archive_data ~logger (t : t) ~data_file =
     (* this function won't work if t doesn't happen to be an archive node *)

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -127,6 +127,25 @@ module Network_config = struct
                   ; vesting_increment = t.vesting_increment
                   }
           in
+          (* an account may be used for snapp transactions, so add
+             permissions and snapp account
+          *)
+          let (permissions
+                : Runtime_config.Accounts.Single.Permissions.t option) =
+            Some
+              { stake = false
+              ; edit_state = None
+              ; send = None
+              ; receive = None
+              ; set_delegate = None
+              ; set_permissions = None
+              ; set_verification_key = None
+              ; set_snapp_uri = None
+              ; edit_sequence_state = None
+              ; set_token_symbol = None
+              ; increment_nonce = None
+              }
+          in
           let default = Runtime_config.Accounts.Single.default in
           { default with
             pk = Some (Public_key.Compressed.to_string pk)
@@ -136,6 +155,7 @@ module Network_config = struct
               (* delegation currently unsupported *)
           ; delegate = None
           ; timing
+          ; permissions
           }
         in
         let secret_name = "test-keypair-" ^ Int.to_string index in

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -57,6 +57,12 @@ module Engine = struct
         -> fee:Currency.Fee.t
         -> unit Malleable_error.t
 
+      val send_snapp :
+           logger:Logger.t
+        -> t
+        -> parties:Mina_base.Parties.t
+        -> unit Deferred.Or_error.t
+
       val get_balance :
            logger:Logger.t
         -> t
@@ -247,6 +253,8 @@ module Dsl = struct
       -> receiver_pub_key:Public_key.Compressed.t
       -> amount:Amount.t
       -> t
+
+    val snapp_to_be_included_in_frontier : parties:Mina_base.Parties.t -> t
   end
 
   module type Util_intf = sig

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -172,4 +172,51 @@ struct
     ; soft_timeout = Slots soft_timeout_in_slots
     ; hard_timeout = Slots (soft_timeout_in_slots * 2)
     }
+
+  let snapp_to_be_included_in_frontier ~parties =
+    let command_matches_parties cmd =
+      let open User_command in
+      match cmd with
+      | Parties p ->
+          Mina_base.Parties.equal p parties
+      | Signed_command _ ->
+          false
+    in
+    let check () _node (breadcrumb_added : Event_type.Breadcrumb_added.t) =
+      let snapp_opt =
+        List.find breadcrumb_added.user_commands ~f:(fun cmd_with_status ->
+            cmd_with_status.With_status.data |> User_command.forget_check
+            |> command_matches_parties)
+      in
+      match snapp_opt with
+      | Some cmd_with_status ->
+          let actual_status = cmd_with_status.With_status.status in
+          let was_applied =
+            match actual_status with
+            | Transaction_status.Applied _ ->
+                true
+            | _ ->
+                false
+          in
+          if was_applied then Predicate_passed
+          else
+            Predicate_failure
+              (Error.createf "Unexpected status in matching payment: %s"
+                 ( Transaction_status.to_yojson actual_status
+                 |> Yojson.Safe.to_string ))
+      | None ->
+          Predicate_continuation ()
+    in
+    let soft_timeout_in_slots = 8 in
+    { description =
+        sprintf "snapp with fee payer %s and other parties (%s)"
+          (Public_key.Compressed.to_base58_check
+             parties.fee_payer.data.body.public_key)
+          ( List.map parties.other_parties ~f:(fun party ->
+                Public_key.Compressed.to_base58_check party.data.body.public_key)
+          |> String.concat ~sep:", " )
+    ; predicate = Event_predicate (Event_type.Breadcrumb_added, (), check)
+    ; soft_timeout = Slots soft_timeout_in_slots
+    ; hard_timeout = Slots (soft_timeout_in_slots * 2)
+    }
 end

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -111,7 +111,7 @@ module Token_symbol = struct
 
         let max_length = 6
 
-        let check (x : t) = assert (String.length x < max_length)
+        let check (x : t) = assert (String.length x <= max_length)
 
         let t_of_sexp sexp =
           let res = t_of_sexp sexp in

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2893,6 +2893,12 @@ module Types = struct
             ]
     end
 
+    let send_test_snapp =
+      scalar "SendTestSnappInput" ~doc:"Parties for a test snapp"
+        ~coerce:(fun json ->
+          let json = to_yojson json in
+          Mina_base.Parties.of_yojson json)
+
     let precomputed_block =
       scalar "PrecomputedBlock" ~doc:"Block encoded in precomputed block format"
         ~coerce:(fun json ->
@@ -4049,6 +4055,13 @@ module Mutations = struct
       ~doc:"Mock a snapp transaction, no effect on blockchain"
       ~f:mock_snapp_command
 
+  let send_test_snapp =
+    io_field "sendTestSnapp" ~doc:"Send a test snapp"
+      ~args:Arg.[ arg "parties" ~typ:(non_null Types.Input.send_test_snapp) ]
+      ~typ:(non_null Types.Payload.send_snapp)
+      ~resolve:(fun { ctx = mina; _ } () parties ->
+        send_snapp_command mina parties)
+
   let create_token =
     io_field "createToken" ~doc:"Create a new token"
       ~typ:(non_null Types.Payload.create_token)
@@ -4394,6 +4407,7 @@ module Mutations = struct
     ; mint_tokens
     ; send_snapp
     ; mock_snapp
+    ; send_test_snapp
     ; export_logs
     ; set_staking
     ; set_coinbase_receiver

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1291,7 +1291,6 @@ let create ?wallets (config : Config.t) =
   let monitor = Option.value ~default:(Monitor.create ()) config.monitor in
   Async.Scheduler.within' ~monitor (fun () ->
       trace "mina_lib" (fun () ->
-          let start = Time.now () in
           let block_production_keypairs =
             Agent.create
               ~f:(fun kps ->
@@ -1301,6 +1300,7 @@ let create ?wallets (config : Config.t) =
                 |> Keypair.And_compressed_pk.Set.of_list)
               config.initial_block_production_keypairs
           in
+          let start = Time.now () in
           let%bind prover =
             Monitor.try_with ~here:[%here]
               ~rest:

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -32,7 +32,7 @@ module Cache_handle = Cache_handle
 module Step_main_inputs = Step_main_inputs
 module Pairing_main = Pairing_main
 
-let profile_constraints = true
+let profile_constraints = false
 
 let verify = Verify.verify
 

--- a/src/lib/snarky_log/snarky_log.ml
+++ b/src/lib/snarky_log/snarky_log.ml
@@ -10,7 +10,9 @@ let to_channel ?buf ?len ?std out_channel events =
   to_channel ?buf ?len ?std out_channel @@ json_of_events events
 
 let to_file ?buf ?len ?std filename events =
-  to_channel ?buf ?len ?std (open_out filename) events
+  let oc = open_out filename in
+  to_channel ?buf ?len ?std oc events ;
+  close_out oc
 
 module Constraints (Snarky_backendless : Snark_intf.Basic) = struct
   (** Create flamechart events for Snarky_backendless constraints.


### PR DESCRIPTION
Create an integration test for snapps.

Strategy:
 - generate a `Parties.t` using QC generators
 - integration test ledgers have a `snapp` field
 - substitute fee payer key from an account in the integration test ledger
 - substitute a dummy signature for the fee payer, so the snapp is expected to fail

Other changes:
 - add a new GraphQL endpoint `sendTestSnapp` that accepts a `scalar`, so programatically, we can just send a `Yojson.Basic.t`; the extant `sendSnapp` requires an OCaml object ; the upcoming derivers may make this extra endpoint unnecessary
 - the length check on token symbols updated to use nonstrict inequality
 - define `snapp_to_be_included_in_frontier` for future tests
 - disable `profile_constraints` in `Pickles` due to an exception opening a log file; added a close for that file, which didn't help

Part of #10067.
