### PR TITLE
Feature/snapps protocol refactor party or stack

### DIFF
--- a/src/lib/hash_prefix_states/hash_prefix_states.ml
+++ b/src/lib/hash_prefix_states/hash_prefix_states.ml
@@ -105,6 +105,8 @@ let party_predicate = salt party_predicate
 
 let party_cons = salt party_cons
 
+let party_node = salt party_node
+
 let party_with_protocol_state_predicate =
   salt party_with_protocol_state_predicate
 

--- a/src/lib/hash_prefix_states/hash_prefix_states.mli
+++ b/src/lib/hash_prefix_states/hash_prefix_states.mli
@@ -65,6 +65,8 @@ val party : Field.t State.t
 
 val party_cons : Field.t State.t
 
+val party_node : Field.t State.t
+
 val party_with_protocol_state_predicate : Field.t State.t
 
 val receipt_chain_user_command : Field.t State.t

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -87,6 +87,8 @@ let party = create "MinaParty"
 
 let party_cons = create "MinaPartyCons"
 
+let party_node = create "MinaPartyNode"
+
 let party_with_protocol_state_predicate = create "MinaPartyStatePred"
 
 let snapp_uri = create "MinaSnappUri"

--- a/src/lib/mina_base/ledger.mli
+++ b/src/lib/mina_base/ledger.mli
@@ -143,8 +143,8 @@ val apply_parties_unchecked :
   -> t
   -> Parties.t
   -> ( Transaction_applied.Parties_applied.t
-     * ( ( (Party.t, unit) Parties.Party_or_stack.t list
-         , (Party.t, unit) Parties.Party_or_stack.t list list
+     * ( ( (Party.t, unit) Parties.Call_forest.t
+         , (Party.t, unit) Parties.Call_forest.t list
          , Token_id.t
          , Currency.Amount.t
          , t

--- a/src/lib/mina_base/parties.ml
+++ b/src/lib/mina_base/parties.ml
@@ -54,7 +54,7 @@ module Call_forest = struct
         []
     | p :: ps ->
         let depth = party_depth p in
-        let children, post =
+        let children, siblings =
           List.split_while ps ~f:(fun p' -> party_depth p' > depth)
         in
         { With_stack_hash.elt =
@@ -64,17 +64,17 @@ module Call_forest = struct
             }
         ; stack_hash = ()
         }
-        :: of_parties_list ~party_depth post
+        :: of_parties_list ~party_depth siblings
 
   let to_parties_list (xs : _ t) =
-    let rec collect acc (xs : _ t) =
+    let rec collect (xs : _ t) acc =
       match xs with
       | [] ->
           acc
       | { elt = { party; calls; party_digest = _ }; stack_hash = _ } :: xs ->
-          collect (collect (party :: acc) calls) xs
+          party :: acc |> collect calls |> collect xs
     in
-    List.rev (collect [] xs)
+    List.rev (collect xs [])
 
   let%test_unit "Party_or_stack.of_parties_list" =
     let parties_list_1 = [ 0; 0; 0; 0 ] in
@@ -123,14 +123,14 @@ module Call_forest = struct
       parties_list_4
 
   let to_parties_with_hashes_list (xs : _ t) =
-    let rec collect acc (xs : _ t) =
+    let rec collect (xs : _ t) acc =
       match xs with
       | [] ->
           acc
       | { elt = { party; calls; party_digest = _ }; stack_hash } :: xs ->
-          collect (collect ((party, stack_hash) :: acc) calls) xs
+          (party, stack_hash) :: acc |> collect calls |> collect xs
     in
-    List.rev (collect [] xs)
+    List.rev (collect xs [])
 
   let hash_cons hash h_tl =
     Random_oracle.hash ~init:Hash_prefix_states.party_cons [| hash; h_tl |]
@@ -185,8 +185,6 @@ module Call_forest = struct
     let to_parties_list (x : _ t) = to_parties_list x
 
     let to_parties_with_hashes_list (x : _ t) = to_parties_with_hashes_list x
-
-    (*     let hash x = hash ~hash_party x *)
 
     let other_parties_hash' xs = of_parties_list xs |> hash
 

--- a/src/lib/mina_base/snapp_generators.ml
+++ b/src/lib/mina_base/snapp_generators.ml
@@ -890,7 +890,7 @@ let gen_parties_from ?(succeed = true)
     }
   in
   let other_parties_hash =
-    Parties.Party_or_stack.With_hashes.other_parties_hash
+    Parties.Call_forest.With_hashes.other_parties_hash
       parties_dummy_signatures.other_parties
   in
   let protocol_state_predicate_hash =

--- a/src/lib/mina_base/sparse_ledger.mli
+++ b/src/lib/mina_base/sparse_ledger.mli
@@ -92,8 +92,8 @@ val apply_parties_unchecked_with_states :
   -> Parties.t
   -> ( Transaction_logic.Transaction_applied.Parties_applied.t
      * ( Global_state.t
-       * ( (Party.t, unit) Parties.Party_or_stack.t list
-         , (Party.t, unit) Parties.Party_or_stack.t list list
+       * ( (Party.t, unit) Parties.Call_forest.t
+         , (Party.t, unit) Parties.Call_forest.t list
          , Token_id.t
          , Currency.Amount.t
          , t

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -162,7 +162,7 @@ let to_verifiable (t : t) ~ledger ~get ~location_of_account : Verifiable.t =
         ; other_parties =
             other_parties
             |> List.map ~f:(fun party -> (party, find_vk party))
-            |> Parties.Party_or_stack.With_hashes.of_parties_list
+            |> Parties.Call_forest.With_hashes.of_parties_list
         ; memo
         }
 

--- a/src/lib/mina_state/local_state.ml
+++ b/src/lib/mina_state/local_state.ml
@@ -48,8 +48,8 @@ let display
   }
 
 let dummy : t =
-  { parties = Parties.Party_or_stack.With_hashes.empty
-  ; call_stack = Parties.Party_or_stack.With_hashes.empty
+  { parties = Parties.Call_forest.With_hashes.empty
+  ; call_stack = Parties.Call_forest.With_hashes.empty
   ; transaction_commitment = Parties.Transaction_commitment.empty
   ; full_transaction_commitment = Parties.Transaction_commitment.empty
   ; token_id = Token_id.default

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2495,7 +2495,7 @@ let%test_module "staged ledger tests" =
               in
               let memo_hash = Signed_command_memo.hash parties.memo in
               let other_parties_hash =
-                Parties.Party_or_stack.With_hashes.other_parties_hash
+                Parties.Call_forest.With_hashes.other_parties_hash
                   parties.other_parties
               in
               let sign_for_other_party ~use_full_commitment sk protocol_state =

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -235,12 +235,12 @@ let%test_unit "ring-signature snapp tx with 3 parties" =
           in
           let protocol_state = Snapp_predicate.Protocol_state.accept in
           let ps =
-            Parties.Party_or_stack.of_parties_list
+            Parties.Call_forest.of_parties_list
               ~party_depth:(fun (p : Party.Predicated.t) -> p.body.call_depth)
               [ sender_party_data; snapp_party_data ]
-            |> Parties.Party_or_stack.accumulate_hashes_predicated
+            |> Parties.Call_forest.accumulate_hashes_predicated
           in
-          let other_parties_hash = Parties.Party_or_stack.stack_hash ps in
+          let other_parties_hash = Parties.Call_forest.hash ps in
           let protocol_state_predicate_hash =
             Snapp_predicate.Protocol_state.digest protocol_state
           in
@@ -250,7 +250,7 @@ let%test_unit "ring-signature snapp tx with 3 parties" =
             Parties.Transaction_commitment.create ~other_parties_hash
               ~protocol_state_predicate_hash ~memo_hash
           in
-          let at_party = Parties.Party_or_stack.stack_hash ps in
+          let at_party = Parties.Call_forest.hash ps in
           let tx_statement : Snapp_statement.t = { transaction; at_party } in
           let msg =
             tx_statement |> Snapp_statement.to_field_elements

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1759,7 +1759,7 @@ module Base = struct
             ; data = V.if_ b ~then_:t.data ~else_:e.data
             }
 
-          let empty_constant = Parties.Party_or_stack.With_hashes.empty
+          let empty_constant = Parties.Call_forest.With_hashes.empty
 
           let empty = Field.constant empty_constant
 
@@ -1826,21 +1826,8 @@ module Base = struct
         end
 
         module Parties = struct
-          module Elt = struct
-            type t = (Party.t * unit, Parties.Digest.t) Parties.Party_or_stack.t
-          end
-
-          type elt = (Elt.t V.t, Field.t) With_hash.t
-
-          type party_or_stack = elt
-
-          (* TODO: This module should be refactored to make it so we can just
-             use the Stack functor, but that would require refactoring Party_or_stack.t
-             to not contain the stack hash inside of the element value itself, so that
-             we could instead wrap it in a With_stack_hash.t. *)
           type t =
-            ( (Party.t * unit, Parties.Digest.t) Parties.Party_or_stack.t list
-              V.t
+            ( (Party.t * unit, Parties.Digest.t) Parties.Call_forest.t V.t
             , Field.t )
             With_hash.t
 
@@ -1849,7 +1836,7 @@ module Base = struct
             ; data = V.if_ b ~then_:t.data ~else_:e.data
             }
 
-          let empty = Field.constant Parties.Party_or_stack.With_hashes.empty
+          let empty = Field.constant Parties.Call_forest.With_hashes.empty
 
           let is_empty ({ hash = x; _ } : t) = Field.equal empty x
 
@@ -1859,211 +1846,61 @@ module Base = struct
             Random_oracle.Checked.hash ~init:Hash_prefix_states.party_cons
               [| hash; h_tl |]
 
-          let pop_exn ({ hash = h; data = r } : t) : elt * t =
-            let hd_r = V.create (fun () -> V.get r |> List.hd_exn) in
-            let tl_r = V.create (fun () -> V.get r |> List.tl_exn) in
-            let party_or_stack, stack =
-              exists
-                Typ.(Field.typ * Field.typ)
-                ~compute:(fun () ->
-                  ( V.get hd_r |> Parties.Party_or_stack.With_hashes.hash
-                  , V.get tl_r |> Parties.Party_or_stack.With_hashes.stack_hash
-                  ))
+          let pop_exn ({ hash = h; data = r } : t) : (party * t) * t =
+            let hd_r =
+              V.create (fun () -> V.get r |> List.hd_exn |> With_stack_hash.elt)
             in
-            let h' = hash_cons party_or_stack stack in
-            with_label __LOC__ (fun () -> Field.Assert.equal h h') ;
-            ( { hash = party_or_stack; data = hd_r }
-            , { hash = stack; data = tl_r } )
-
-          let as_stack ({ hash = h; data = r } : elt) : t Opt.t =
-            (* NB: Don't need to check here, since interpreting a stack as a
-               party or party as a stack implies a hash collision.
-            *)
-            let is_some =
-              exists Boolean.typ ~compute:(fun () ->
-                  match V.get r with Party _ -> false | Stack _ -> true)
-            in
-            let data : t =
-              { hash = h
-              ; data =
-                  V.create (fun () ->
-                      match V.get r with Party _ -> [] | Stack (xs, _) -> xs)
-              }
-            in
-            { Snapp_basic.Flagged_option.is_some; data }
-
-          let pop_party_exn ({ hash = h; data = r } : t) : party * t =
-            let first_party =
-              V.create (fun () ->
-                  match V.get r |> List.hd_exn with
-                  | Party ((party, ()), _) ->
-                      party
-                  | Stack _ ->
-                      failwith "pop_party_exn")
-            in
-            let body, tl =
-              exists
-                Typ.(Party.Body.typ () * field)
-                ~compute:(fun () ->
-                  let p = V.get first_party in
-                  let h =
-                    V.get r |> List.tl_exn
-                    |> Parties.Party_or_stack.With_hashes.stack_hash
-                  in
-                  (p.data.body, h))
+            let party = V.create (fun () -> (V.get hd_r).party |> fst) in
+            let body =
+              exists (Party.Body.typ ()) ~compute:(fun () ->
+                  (V.get party).data.body)
             in
             let predicate : Party.Predicate.Checked.t =
               exists (Party.Predicate.typ ()) ~compute:(fun () ->
-                  (V.get first_party).data.predicate)
+                  (V.get party).data.predicate)
             in
-            let auth =
-              V.(create (fun () -> (V.get first_party).authorization))
-            in
+            let auth = V.(create (fun () -> (V.get party).authorization)) in
             let party : Party.Predicated.Checked.t = { body; predicate } in
             let party =
               With_hash.of_data party ~hash_data:Party.Predicated.Checked.digest
             in
-            let actual_h =
-              Random_oracle.Checked.hash ~init:Hash_prefix_states.party_cons
-                [| party.hash; tl |]
+            let subforest : t =
+              let subforest = V.create (fun () -> (V.get hd_r).calls) in
+              let subforest_hash =
+                exists Field.typ ~compute:(fun () ->
+                    Parties.Call_forest.hash (V.get subforest))
+              in
+              { hash = subforest_hash; data = subforest }
             in
-            with_label __LOC__ (fun () -> Field.Assert.equal h actual_h) ;
-            ( { party; control = auth }
-            , { hash = tl; data = V.(create (fun () -> List.tl_exn (get r))) }
-            )
-
-          let pop_stack ({ hash = h; data = r } : t) : (t * t) Opt.t =
-            let hd_r =
-              V.create (fun () ->
-                  match V.get r |> List.hd with
-                  | Some (Stack (x, _)) ->
-                      x
-                  | _ ->
-                      [])
+            let tl_hash =
+              exists Field.typ ~compute:(fun () ->
+                  V.get r |> List.tl_exn |> Parties.Call_forest.hash)
             in
-            let tl_r =
-              V.create (fun () ->
-                  V.get r |> List.tl |> Option.value ~default:[])
+            let tree_hash =
+              Random_oracle.Checked.hash ~init:Hash_prefix_states.party_node
+                [| party.hash; subforest.hash |]
             in
-            let party_or_stack, stack =
-              exists
-                Typ.(Field.typ * Field.typ)
-                ~compute:(fun () ->
-                  ( V.get hd_r |> Parties.Party_or_stack.With_hashes.stack_hash
-                  , V.get tl_r |> Parties.Party_or_stack.With_hashes.stack_hash
-                  ))
-            in
-            let h' = hash_cons party_or_stack stack in
-            (* NB: Don't need to check here, since interpreting a stack as a
-               party or party as a stack implies a hash collision.
-            *)
-            let is_some = Field.equal h h' in
-            let data : t * t =
-              ( { hash = party_or_stack; data = hd_r }
-              , { hash = stack; data = tl_r } )
-            in
-            { Snapp_basic.Flagged_option.is_some; data }
+            Field.Assert.equal (hash_cons tree_hash tl_hash) h ;
+            ( ({ party; control = auth }, subforest)
+            , { hash = tl_hash
+              ; data = V.(create (fun () -> List.tl_exn (get r)))
+              } )
         end
 
-        module Call_stack
-            (*: Parties_logic.Call_stack_intf
-              with type parties := Parties.t
-               and type bool := Bool.t
-               and module Opt := Opt *) =
-        Stack (struct
+        module Call_stack = Stack (struct
           module Parties = Mina_base.Parties
 
           type t =
-            (Party.t * unit, Parties.Digest.t) Parties.Party_or_stack.t list
+            (Party.t * unit, Parties.Digest.t) Mina_base.Parties.Call_forest.t
 
           let default : t = []
 
-          let hash : t -> Field.Constant.t =
-            Parties.Party_or_stack.With_hashes.stack_hash
+          let hash : t -> Field.Constant.t = Mina_base.Parties.Call_forest.hash
 
           let push ~consed_hash (t : t) (xs : (t, _) With_stack_hash.t list) :
               (t, _) With_stack_hash.t list =
             { stack_hash = consed_hash; elt = t } :: xs
         end)
-
-        (*
-
-          type elt = (Elt.t V.t, Field.t) With_hash.t
-
-          type t = ((Elt.t, Field.Constant.t) With_stack_hash.t list V.t, Field.t) With_hash.t
-
-          let if_ b ~then_:(t : t) ~else_:(e : t): t =
-            { hash= Field.if_ b ~then_:t.hash ~else_:e.hash
-            ; data= V.if_ b ~then_:t.data ~else_:e.data
-            }
-
-          let empty = Field.constant empty_constant
-
-          let is_empty ({ hash=x; _} : t) = Field.equal empty x
-
-          let empty : t = { hash=empty ; data= V.create (fun () -> []) }
-
-          let stack_hash (type a) (xs: (a, Field.Constant.t) With_stack_hash.t list) : Field.Constant.t =
-                   match xs with
-                  | [] -> empty_constant
-                  | e :: _ -> e.stack_hash
-
-          let pop ({ hash=h; data= r} as t : t) : (elt * t) Opt.t =
-            let input_is_empty = is_empty t in
-            let hd_r = V.create (fun () ->
-                V.get r
-                |> List.hd
-                |> Option.value_map
-                  ~default:Elt.default
-                  ~f:(fun x -> x.elt) )
-            in
-            let tl_r = V.create (fun () -> V.get r |> List.tl |> Option.value ~default:[]) in
-            let elt, stack =
-              exists
-                Typ.(Field.typ * Field.typ)
-                ~compute:(fun () ->
-                  ( V.get hd_r |> Elt.hash
-                  , stack_hash (V.get tl_r)
-                  ))
-            in
-            let h' = Elt.hash_cons elt stack in
-            with_label __LOC__ (fun () -> 
-                Boolean.Assert.any
-                  [ input_is_empty
-                  ; Field.equal h h'
-                  ]
-                ) ;
-            { is_some= Boolean.not input_is_empty
-            ; data= ({hash=elt;data= hd_r}, {hash=stack;data= tl_r})
-            }
-
-          let pop_exn ({hash=h;data= r} : t) : elt * t =
-            let hd_r = V.create (fun () -> (V.get r |> List.hd_exn).elt) in
-            let tl_r = V.create (fun () -> V.get r |> List.tl_exn) in
-            let elt, stack =
-              exists
-                Typ.(Field.typ * Field.typ)
-                ~compute:(fun () ->
-                  ( V.get hd_r |> Elt.hash
-                  , stack_hash (V.get tl_r)
-                  ))
-            in
-            let h' = Elt.hash_cons elt stack in
-            with_label __LOC__ (fun () -> Field.Assert.equal h h') ;
-            ({hash=elt;data= hd_r}, {hash=stack;data= tl_r})
-
-          let push ({hash=h_hd;data= r_hd} : elt) 
-              ~onto:({hash=h_tl;data= r_tl} : t) : t =
-            let h = Elt.hash_cons h_hd h_tl in
-            let r =
-              V.create (fun () ->
-                  let hd = V.get r_hd in
-                  let tl = V.get r_tl in
-                  Elt.push ~consed_hash:(As_prover.read Field.typ h)
-                    hd tl )
-            in
-            {hash=h;data= r}
-        end *)
 
         module Party = struct
           type t = party
@@ -2420,11 +2257,11 @@ module Base = struct
                       Party.of_fee_payer p.parties.Parties.fee_payer
                       :: p.parties.Parties.other_parties
                       |> List.map ~f:(fun party -> (party, ()))
-                      |> Parties.Party_or_stack.With_hashes.of_parties_list)
+                      |> Parties.Call_forest.With_hashes.of_parties_list)
               in
               let h =
                 exists Field.typ ~compute:(fun () ->
-                    Parties.Party_or_stack.With_hashes.stack_hash (V.get ps))
+                    Parties.Call_forest.hash (V.get ps))
               in
               let start_data =
                 { Parties_logic.Start_data.parties =
@@ -2471,7 +2308,7 @@ module Base = struct
                           `Skip
                       | p :: ps ->
                           let should_pop =
-                            Field.Constant.equal Parties.Party_or_stack.empty
+                            Field.Constant.equal Parties.Call_forest.empty
                               (As_prover.read_var local.parties.hash)
                           in
                           if should_pop then (
@@ -2484,7 +2321,7 @@ module Base = struct
                     As_prover.(
                       fun () ->
                         [%test_eq: Impl.Field.Constant.t]
-                          Parties.Party_or_stack.empty
+                          Parties.Call_forest.empty
                           (read_var local.parties.hash)) ;
                   V.create (fun () ->
                       match As_prover.Ref.get start_parties with
@@ -4036,13 +3873,9 @@ let rec accumulate_call_stack_hashes ~(hash_frame : 'frame -> field)
       let h_f = hash_frame f in
       let tl = accumulate_call_stack_hashes ~hash_frame fs in
       let h_tl =
-        match tl with
-        | [] ->
-            Parties.Party_or_stack.empty
-        | t :: _ ->
-            t.stack_hash
+        match tl with [] -> Parties.Call_forest.empty | t :: _ -> t.stack_hash
       in
-      { stack_hash = Parties.Party_or_stack.hash_cons h_f h_tl; elt = f } :: tl
+      { stack_hash = Parties.Call_forest.hash_cons h_f h_tl; elt = f } :: tl
 
 let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
     ~pending_coinbase_init_stack ledger partiess =
@@ -4074,10 +3907,10 @@ let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
       ([ List.hd_exn (List.hd_exn states) ] :: states)
   in
   let tx_statement transaction
-      (remaining_parties : (Party.t, _) Parties.Party_or_stack.t list) :
+      (remaining_parties : (Party.t, _) Parties.Call_forest.t) :
       Snapp_statement.t =
     let at_party =
-      Parties.Party_or_stack.(stack_hash (accumulate_hashes' remaining_parties))
+      Parties.Call_forest.(hash (accumulate_hashes' remaining_parties))
     in
     { transaction; at_party }
   in
@@ -4167,24 +4000,22 @@ let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
       in
       let hash_local_state (local : _ Parties_logic.Local_state.t) =
         let hash_parties_stack ps =
-          ps |> Parties.Party_or_stack.accumulate_hashes'
-          |> List.map ~f:(Parties.Party_or_stack.map ~f:(fun p -> (p, ())))
+          ps |> Parties.Call_forest.accumulate_hashes'
+          |> Parties.Call_forest.map ~f:(fun p -> (p, ()))
         in
-        let call_stack : (Party.t, unit) Parties.Party_or_stack.t list list =
+        let call_stack : (Party.t, unit) Parties.Call_forest.t list =
           local.call_stack
         in
         let call_stack :
-            (unit Parties.Party_or_stack.With_hashes.t, field) With_stack_hash.t
+            (unit Parties.Call_forest.With_hashes.t, field) With_stack_hash.t
             list =
           accumulate_call_stack_hashes
-            (List.map call_stack ~f:Parties.Party_or_stack.accumulate_hashes')
-            ~hash_frame:Parties.Party_or_stack.With_hashes.stack_hash
+            (List.map call_stack ~f:Parties.Call_forest.accumulate_hashes')
+            ~hash_frame:Parties.Call_forest.hash
           |> List.map
                ~f:
                  (With_stack_hash.map
-                    ~f:
-                      (List.map ~f:(fun p ->
-                           Parties.Party_or_stack.map p ~f:(fun p -> (p, ())))))
+                    ~f:(Parties.Call_forest.map ~f:(fun p -> (p, ()))))
         in
         { local with
           Parties_logic.Local_state.parties = hash_parties_stack local.parties
@@ -4235,7 +4066,7 @@ let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
       in
       let call_stack_hash s =
         List.hd s
-        |> Option.value_map ~default:Parties.Party_or_stack.empty
+        |> Option.value_map ~default:Parties.Call_forest.empty
              ~f:With_stack_hash.stack_hash
       in
       let statement : Statement.With_sok.t =
@@ -4254,8 +4085,7 @@ let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
             ; pending_coinbase_stack = pending_coinbase_init_stack
             ; local_state =
                 { source_local with
-                  parties =
-                    Parties.Party_or_stack.stack_hash source_local.parties
+                  parties = Parties.Call_forest.hash source_local.parties
                 ; call_stack = call_stack_hash source_local.call_stack
                 ; ledger = source_local_ledger
                 }
@@ -4269,8 +4099,7 @@ let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
                   pending_coinbase_init_stack
             ; local_state =
                 { target_local with
-                  parties =
-                    Parties.Party_or_stack.stack_hash target_local.parties
+                  parties = Parties.Call_forest.hash target_local.parties
                 ; call_stack = call_stack_hash target_local.call_stack
                 ; ledger = Sparse_ledger.merkle_root target_local.ledger
                 }
@@ -4350,7 +4179,7 @@ struct
                   List.concat_map witness.start_parties ~f:(fun s ->
                       s.parties.other_parties)
               | xs ->
-                  Parties.Party_or_stack.to_parties_list xs |> List.map ~f:fst
+                  Parties.Call_forest.to_parties_list xs |> List.map ~f:fst
             in
             List.filter_map parties ~f:(fun p ->
                 let%bind tag, snapp_statement = snapp_statement in
@@ -4661,12 +4490,12 @@ module For_tests = struct
       Snapp_predicate.Protocol_state.digest protocol_state
     in
     let ps =
-      Parties.Party_or_stack.of_parties_list
+      Parties.Call_forest.of_parties_list
         ~party_depth:(fun (p : Party.Predicated.t) -> p.body.call_depth)
         other_parties_data
-      |> Parties.Party_or_stack.accumulate_hashes_predicated
+      |> Parties.Call_forest.accumulate_hashes_predicated
     in
-    let other_parties_hash = Parties.Party_or_stack.stack_hash ps in
+    let other_parties_hash = Parties.Call_forest.hash ps in
     let commitment : Parties.Transaction_commitment.t =
       Parties.Transaction_commitment.create ~other_parties_hash
         ~protocol_state_predicate_hash
@@ -4768,12 +4597,12 @@ module For_tests = struct
       | Permissions.Auth_required.Proof ->
           let proof_party =
             let ps =
-              Parties.Party_or_stack.of_parties_list
+              Parties.Call_forest.of_parties_list
                 ~party_depth:(fun (p : Party.Predicated.t) -> p.body.call_depth)
                 [ snapp_party.data ]
-              |> Parties.Party_or_stack.accumulate_hashes_predicated
+              |> Parties.Call_forest.accumulate_hashes_predicated
             in
-            Parties.Party_or_stack.stack_hash ps
+            Parties.Call_forest.hash ps
           in
           let tx_statement : Snapp_statement.t =
             { transaction = commitment; at_party = proof_party }
@@ -4932,12 +4761,12 @@ module For_tests = struct
     let protocol_state = Snapp_predicate.Protocol_state.accept in
     let memo = Signed_command_memo.empty in
     let ps =
-      Parties.Party_or_stack.of_parties_list
+      Parties.Call_forest.of_parties_list
         ~party_depth:(fun (p : Party.Predicated.t) -> p.body.call_depth)
         [ sender_party_data; snapp_party_data ]
-      |> Parties.Party_or_stack.accumulate_hashes_predicated
+      |> Parties.Call_forest.accumulate_hashes_predicated
     in
-    let other_parties_hash = Parties.Party_or_stack.stack_hash ps in
+    let other_parties_hash = Parties.Call_forest.hash ps in
     let protocol_state_predicate_hash =
       (*FIXME: is this ok? *)
       Snapp_predicate.Protocol_state.digest protocol_state
@@ -4950,12 +4779,12 @@ module For_tests = struct
     in
     let proof_party =
       let ps =
-        Parties.Party_or_stack.of_parties_list
+        Parties.Call_forest.of_parties_list
           ~party_depth:(fun (p : Party.Predicated.t) -> p.body.call_depth)
           [ snapp_party_data ]
-        |> Parties.Party_or_stack.accumulate_hashes_predicated
+        |> Parties.Call_forest.accumulate_hashes_predicated
       in
-      Parties.Party_or_stack.stack_hash ps
+      Parties.Call_forest.hash ps
     in
     let tx_statement : Snapp_statement.t =
       { transaction; at_party = proof_party }
@@ -5947,15 +5776,13 @@ let%test_module "transaction_snark" =
                   let protocol_state = Snapp_predicate.Protocol_state.accept in
                   let memo = Signed_command_memo.empty in
                   let ps =
-                    Parties.Party_or_stack.of_parties_list
+                    Parties.Call_forest.of_parties_list
                       ~party_depth:(fun (p : Party.Predicated.t) ->
                         p.body.call_depth)
                       [ sender_party_data; snapp_party_data ]
-                    |> Parties.Party_or_stack.accumulate_hashes_predicated
+                    |> Parties.Call_forest.accumulate_hashes_predicated
                   in
-                  let other_parties_hash =
-                    Parties.Party_or_stack.stack_hash ps
-                  in
+                  let other_parties_hash = Parties.Call_forest.hash ps in
                   let protocol_state_predicate_hash =
                     (*FIXME: is this ok? *)
                     Snapp_predicate.Protocol_state.digest protocol_state
@@ -5966,7 +5793,7 @@ let%test_module "transaction_snark" =
                       ~protocol_state_predicate_hash
                       ~memo_hash:(Signed_command_memo.hash memo)
                   in
-                  let at_party = Parties.Party_or_stack.stack_hash ps in
+                  let at_party = Parties.Call_forest.hash ps in
                   let tx_statement : Snapp_statement.t =
                     { transaction; at_party }
                   in

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -10,8 +10,8 @@ module Parties_segment_witness = struct
       type t =
         { global_ledger : Sparse_ledger.Stable.V2.t
         ; local_state_init :
-            ( unit Parties.Party_or_stack.With_hashes.Stable.V1.t
-            , ( unit Parties.Party_or_stack.With_hashes.Stable.V1.t
+            ( unit Parties.Call_forest.With_hashes.Stable.V1.t
+            , ( unit Parties.Call_forest.With_hashes.Stable.V1.t
               , Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t )
               With_stack_hash.Stable.V1.t
               list

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -10,8 +10,8 @@ module Parties_segment_witness : sig
       type t =
         { global_ledger : Sparse_ledger.Stable.V2.t
         ; local_state_init :
-            ( unit Parties.Party_or_stack.With_hashes.Stable.V1.t
-            , ( unit Parties.Party_or_stack.With_hashes.Stable.V1.t
+            ( unit Parties.Call_forest.With_hashes.Stable.V1.t
+            , ( unit Parties.Call_forest.With_hashes.Stable.V1.t
               , Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t )
               With_stack_hash.Stable.V1.t
               list

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -42,9 +42,7 @@ let check :
             `Invalid_signature (Signed_command.public_keys c) )
   | Parties { fee_payer; other_parties; memo } ->
       with_return (fun { return } ->
-          let other_parties_hash =
-            Parties.Party_or_stack.With_hashes.stack_hash other_parties
-          in
+          let other_parties_hash = Parties.Call_forest.hash other_parties in
           let tx_commitment =
             Parties.Transaction_commitment.create ~other_parties_hash
               ~protocol_state_predicate_hash:
@@ -77,7 +75,7 @@ let check :
           check_signature fee_payer.authorization fee_payer.data.body.public_key
             full_tx_commitment ;
           let parties_with_hashes_list =
-            Parties.Party_or_stack.With_hashes.to_parties_with_hashes_list
+            Parties.Call_forest.With_hashes.to_parties_with_hashes_list
               other_parties
           in
           let valid_assuming =


### PR DESCRIPTION
This PR makes explicit the invariant of Party_or_stack that a "Stack" element always followed a "Party" element by refactoring into a single "Tree" type which always has a party and a possibly empty list of children. This had the knock-on effect of simplifying a lot of stuff, especially the parties logic.