### PR TITLE
Make Truth.t cases exhaustive

### DIFF
--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -539,8 +539,6 @@ module Validation = struct
           , frontier_dependencies
           , staged_ledger_diff
           , protocol_versions )
-      | _ ->
-          failwith "why can't this be refuted?"
 
     let set_valid_proof :
            ( 'time_received
@@ -573,8 +571,6 @@ module Validation = struct
           , frontier_dependencies
           , staged_ledger_diff
           , protocol_versions )
-      | _ ->
-          failwith "why can't this be refuted?"
 
     let set_valid_genesis_state :
            ( 'time_received
@@ -607,8 +603,6 @@ module Validation = struct
           , frontier_dependencies
           , staged_ledger_diff
           , protocol_versions )
-      | _ ->
-          failwith "why can't this be refuted?"
 
     let set_valid_delta_transition_chain :
            ( 'time_received
@@ -646,8 +640,6 @@ module Validation = struct
           , frontier_dependencies
           , staged_ledger_diff
           , protocol_versions )
-      | _ ->
-          failwith "why can't this be refuted?"
 
     let set_valid_frontier_dependencies :
            ( 'time_received
@@ -680,8 +672,6 @@ module Validation = struct
           , (`Frontier_dependencies, Truth.True ())
           , staged_ledger_diff
           , protocol_versions )
-      | _ ->
-          failwith "why can't this be refuted?"
 
     let set_valid_staged_ledger_diff :
            ( 'time_received
@@ -714,8 +704,6 @@ module Validation = struct
           , frontier_dependencies
           , (`Staged_ledger_diff, Truth.True ())
           , protocol_versions )
-      | _ ->
-          failwith "why can't this be refuted?"
 
     let set_valid_protocol_versions :
            ( 'time_received
@@ -748,8 +736,6 @@ module Validation = struct
           , frontier_dependencies
           , staged_ledger_diff
           , (`Protocol_versions, Truth.True ()) )
-      | _ ->
-          failwith "why can't this be refuted?"
   end
 end
 

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -157,12 +157,7 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
               in
               Catchup_scheduler.watch catchup_scheduler ~timeout_duration
                 ~cached_transition:cached_initially_validated_transition ;
-              return (Error ())
-          | _ ->
-              failwith
-                "This is impossible since the transition just passed \
-                 initial_validation so delta_transition_chain_proof must be \
-                 true" )
+              return (Error ()) )
     in
     (* TODO: only access parent in transition frontier once (already done in call to validate dependencies) #2485 *)
     let parent_hash =

--- a/src/lib/truth/truth.ml
+++ b/src/lib/truth/truth.ml
@@ -1,11 +1,11 @@
 include Core_kernel
 
 module True = struct
-  type t = unit
+  type t = True
 end
 
 module False = struct
-  type t = unit
+  type t = False
 end
 
 type true_ = True.t

--- a/src/lib/truth/truth.mli
+++ b/src/lib/truth/truth.mli
@@ -1,9 +1,9 @@
 module True : sig
-  type t
+  type t = True
 end
 
 module False : sig
-  type t
+  type t = False
 end
 
 type true_ = True.t


### PR DESCRIPTION
This PR does a small amount of housekeeping, removing some unreachable branches from the code.

This is done by expanding `Truth.True.t` and `Truth.False.t` to have incompatible type declarations. Previously, the typechecker was unable to determine that `Truth.True.t` and `Truth.False.t` were not equal, because they were abstract.

Indeed, it was correct to do so, because both were aliased to `unit`, and thus the true types of the constructors were:
```ocaml
  type (_, _) t =
  | True : 'witness -> ('witness, unit) t
  | False : ('witness, unit) t
```
Naturally, any code consuming a `_ t` must by construction have type `('witness, unit) Truth.t`, and thus must be matched against both.

By giving the types distinct, non-abstract declarations, the typechecker can infer that the types could never be the same, and thus eliminate the other branch of the GADT.

This PR is a no-op.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them