### PR TITLE
[DO NOT MERGE] Sample .ocamlclose run

### DIFF
--- a/.ocamlclose
+++ b/.ocamlclose
@@ -1,0 +1,42 @@
+(root) ; ocaml-close will not look for .ocamlclose files in parent directories
+
+; The order in which rules are matched
+; (e.g., we keep opens matched by the 'keep' rule no matter the other rules)
+(precedence (keep remove local structure move))
+
+; An 'open <X>' statement is...
+(rules
+
+  ; - left untouched if...
+  (keep
+    ; ...either it is whitelisted, ...
+    (or (in-list ("Base" "Core" "Core_kernel" "Async" "Async_kernel" "Mina_base" "Import" "Currency" "Signature_lib" "Unsigned"))
+        ; ...it is used for infix operators, ...
+        exports-syntax
+        ; ...it is only for its exposed submodules, ...
+        exports-modules-only
+        ; ...or its scope is roughly a screen.
+        (<= scope-lines 40)))
+
+  ; - removed, and its uses re-qualified, if...
+  ;   ... it is not used much and X is not too long and can be qualified easily.
+  (remove (and (<= uses 5) (<= name-length 15) (not ghost-use)))
+
+  ; - replaced by an explicit structured open, if...
+  (structure
+    ;   ... it exports few different identifiers, and...
+    (and (<= symbols 5)
+         ; ... it is used enough times, and...
+         (>= uses 15)
+         ; ... it only exports direct symbols, not from submodules, and...
+         (not exports-subvalues)
+         ; ... it does not exports types (avoid using ppx_import).
+         (not exports-types)))
+
+  ; - removed and replaced by local 'let open <X> in's if...
+  ;   ... it is used only by only a few functions.
+  (local (<= functions 4))
+
+  ; - moved closer to its first actual use if...
+  ;   ... it is too far from that optimal placement.
+  (move (>= dist-to-optimal 40)))

--- a/src/lib/allocation_functor/make.ml
+++ b/src/lib/allocation_functor/make.ml
@@ -3,7 +3,6 @@ open Core_kernel
 module Partial = struct
   module Bin_io (M : Intf.Input.Bin_io_intf) :
     Intf.Partial.Bin_io_intf with type t := M.t = struct
-    open Bin_prot.Type_class
 
     let bin_size_t = M.bin_size_t
 
@@ -19,9 +18,11 @@ module Partial = struct
 
     let bin_writer_t = M.bin_writer_t
 
-    let bin_reader_t = { read = bin_read_t; vtag_read = __bin_read_t__ }
+    let bin_reader_t = let open Bin_prot.Type_class in
+                       { read = bin_read_t; vtag_read = __bin_read_t__ }
 
     let bin_t =
+      let open Bin_prot.Type_class in
       { shape = bin_shape_t; writer = bin_writer_t; reader = bin_reader_t }
   end
 

--- a/src/lib/best_tip_prover/best_tip_prover.ml
+++ b/src/lib/best_tip_prover/best_tip_prover.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Mina_base
-open Mina_state
 open Async_kernel
 open Mina_transition
 
@@ -22,12 +21,12 @@ module Make (Inputs : Inputs_intf) :
 
     let to_proof_elem external_transition =
       external_transition |> External_transition.Validated.protocol_state
-      |> Protocol_state.body |> Protocol_state.Body.hash
+      |> Mina_state.Protocol_state.body |> Mina_state.Protocol_state.Body.hash
 
     let get_previous ~context transition =
       let parent_hash =
         transition |> External_transition.Validated.protocol_state
-        |> Protocol_state.previous_state_hash
+        |> Mina_state.Protocol_state.previous_state_hash
       in
       let open Option.Let_syntax in
       let%map breadcrumb = Transition_frontier.find context parent_hash in
@@ -40,7 +39,7 @@ module Make (Inputs : Inputs_intf) :
     type proof_elem = State_body_hash.t
 
     let hash acc body_hash =
-      Protocol_state.hash_abstract ~hash_body:Fn.id
+      Mina_state.Protocol_state.hash_abstract ~hash_body:Fn.id
         { previous_state_hash = acc; body = body_hash }
   end)
 

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -2,7 +2,6 @@
 
 open Core_kernel
 open Snark_params
-open Tick
 open Unsigned_extended
 open Snark_bits
 
@@ -237,7 +236,7 @@ module Time = struct
 
   let unpacked_to_number var =
     let bits = Span.Unpacked.var_to_bits var in
-    Number.of_bits (bits :> Boolean.var list)
+    Tick.Number.of_bits (bits :> Tick.Boolean.var list)
 
   let to_int64 = Fn.compose Span.to_ms to_span_since_epoch
 

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -1,9 +1,7 @@
 open Core_kernel
 open Snark_params
-open Tick
 open Mina_base
 open Mina_state
-open Pickles_types
 
 include struct
   open Snarky_backendless.Request
@@ -67,6 +65,8 @@ let with_handler k w ?handler =
         transition consensus data is valid
         new consensus state is a function of the old consensus state
 *)
+open Pickles_types
+open Tick
 let%snarkydef step ~(logger : Logger.t)
     ~(proof_level : Genesis_constants.Proof_level.t)
     ~(constraint_constants : Genesis_constants.Constraint_constants.t)

--- a/src/lib/consensus/constants.ml
+++ b/src/lib/consensus/constants.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Snarky_backendless
-open Snark_params.Tick
 open Unsigned
 module Length = Mina_numbers.Length
 
@@ -132,6 +131,7 @@ module N =
     (Unsigned_extended.UInt64)
     (Snark_bits.Bits.UInt64)
 
+open Snark_params.Tick
 module Constants_checked :
   M_intf
     with type length = Length.Checked.t

--- a/src/lib/consensus/epoch.ml
+++ b/src/lib/consensus/epoch.ml
@@ -1,7 +1,6 @@
 open Core
 open Signed
 open Unsigned
-open Num_util
 
 include Mina_numbers.Nat.Make32 ()
 
@@ -13,7 +12,7 @@ let of_time_exn ~(constants : Constants.t) t : t =
       (Invalid_argument
          "Epoch.of_time: time is earlier than genesis block timestamp") ;
   let time_since_genesis = Time.diff t constants.genesis_state_timestamp in
-  uint32_of_int64
+  Num_util.uint32_of_int64
     Int64.Infix.(
       Time.Span.to_ms time_since_genesis
       / Time.Span.(to_ms constants.epoch_duration))
@@ -23,7 +22,7 @@ let start_time ~(constants : Constants.t) (epoch : t) =
     let open Int64.Infix in
     Block_time.Span.to_ms
       Block_time.(to_span_since_epoch constants.genesis_state_timestamp)
-    + (int64_of_uint32 epoch * Block_time.Span.(to_ms constants.epoch_duration))
+    + (Num_util.int64_of_uint32 epoch * Block_time.Span.(to_ms constants.epoch_duration))
   in
   Block_time.of_span_since_epoch (Block_time.Span.of_ms ms)
 
@@ -35,7 +34,7 @@ let slot_start_time ~(constants : Constants.t) (epoch : t) (slot : Slot.t) =
     (start_time epoch ~constants)
     (Block_time.Span.of_ms
        Int64.Infix.(
-         int64_of_uint32 slot * Time.Span.to_ms constants.slot_duration_ms))
+         Num_util.int64_of_uint32 slot * Time.Span.to_ms constants.slot_duration_ms))
 
 let slot_end_time ~(constants : Constants.t) (epoch : t) (slot : Slot.t) =
   Time.add (slot_start_time epoch slot ~constants) constants.slot_duration_ms
@@ -44,7 +43,7 @@ let epoch_and_slot_of_time_exn ~(constants : Constants.t) tm : t * Slot.t =
   let epoch = of_time_exn tm ~constants in
   let time_since_epoch = Block_time.diff tm (start_time epoch ~constants) in
   let slot =
-    uint32_of_int64
+    Num_util.uint32_of_int64
     @@ Int64.Infix.(
          Time.Span.to_ms time_since_epoch
          / Time.Span.to_ms constants.slot_duration_ms)

--- a/src/lib/consensus/slot.ml
+++ b/src/lib/consensus/slot.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-open Snark_params
 open Unsigned
 
 module T = Mina_numbers.Nat.Make32 ()
@@ -16,7 +15,7 @@ module Checked = struct
   include T.Checked
 
   let in_seed_update_range ~(constants : Constants.var) (slot : var) =
-    let open Tick in
+    let open Snark_params.Tick in
     let module Length = Mina_numbers.Length in
     let constant c =
       Length.Checked.Unsafe.of_field (Field.Var.constant (Field.of_int c))
@@ -46,7 +45,7 @@ let%test_unit "in_seed_update_range unchecked vs. checked equality" =
   let test x =
     Test_util.test_equal
       (Snarky_backendless.Typ.tuple2 Constants.typ typ)
-      Tick.Boolean.typ
+      Snark_params.Tick.Boolean.typ
       (fun (c, x) -> Checked.in_seed_update_range ~constants:c x)
       (fun (c, x) -> in_seed_update_range ~constants:c x)
       (constants, x)

--- a/src/lib/consensus/vrf/consensus_vrf.ml
+++ b/src/lib/consensus/vrf/consensus_vrf.ml
@@ -233,11 +233,10 @@ module Output = struct
       |> Random_oracle.Input.Chunked.packeds
   end
 
-  open Tick
 
-  let typ = Field.typ
+  let typ = Tick.Field.typ
 
-  let gen = Field.gen
+  let gen = Tick.Field.gen
 
   let truncate x =
     Random_oracle.Digest.to_bits ~length:Truncated.length_in_bits x
@@ -266,7 +265,7 @@ module Output = struct
       let input =
         Random_oracle.Input.Chunked.(append msg (field_elements [| x; y |]))
       in
-      make_checked (fun () ->
+      Tick.make_checked (fun () ->
           let open Random_oracle.Checked in
           hash ~init:Hash_prefix_states.vrf_output (pack_input input))
   end
@@ -288,7 +287,7 @@ module Output = struct
     in
     Quickcheck.test ~trials:10 gen_message_and_curve_point
       ~f:
-        (Test_util.test_equal ~equal:Field.equal
+        (Test_util.test_equal ~equal:Tick.Field.equal
            Snark_params.Tick.Typ.(
              Message.typ ~constraint_constants
              * Snark_params.Tick.Inner_curve.typ)

--- a/src/lib/crypto/kimchi_backend/common/dlog_urs.ml
+++ b/src/lib/crypto/kimchi_backend/common/dlog_urs.ml
@@ -19,14 +19,15 @@ module type Inputs_intf = sig
 end
 
 module Make (Inputs : Inputs_intf) = struct
-  open Inputs
 
   let name =
+    let open Inputs in
     sprintf "%s_%d_%s_v3" name
       (Pickles_types.Nat.to_int Rounds.n)
       Version.marlin_repo_sha
 
   let set_urs_info, load_urs =
+    let open Inputs in
     let urs_info = Set_once.create () in
     let urs = ref None in
     let degree = 1 lsl Pickles_types.Nat.to_int Rounds.n in

--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -1,5 +1,4 @@
 (* TODO: remove these openings *)
-open Sponge
 open Unsigned.Size_t
 
 (* TODO: open Core here instead of opening it multiple times below *)
@@ -305,7 +304,7 @@ module Make
     (* We create a type for gate vector, instead of using `Gate.t list`. If we did, we would have to convert it to a `Gate.t array` to pass it across the FFI boundary, where then it gets converted to a `Vec<Gate>`; it's more efficient to just create the `Vec<Gate>` directly. *)
     (Gates : Gate_vector_intf with type field := Fp.t)
     (Params : sig
-      val params : Fp.t Params.t
+      val params : Fp.t Sponge.Params.t
     end) =
 struct
   open Core

--- a/src/lib/crypto/kimchi_backend/common/plonk_dlog_oracles.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_dlog_oracles.ml
@@ -1,8 +1,7 @@
 open Core_kernel
-open Intf
 
 module type Inputs_intf = sig
-  module Verifier_index : T0
+  module Verifier_index : Intf.T0
 
   module Field : sig
     type t
@@ -11,7 +10,7 @@ module type Inputs_intf = sig
   module Proof : sig
     type t
 
-    module Challenge_polynomial : T0
+    module Challenge_polynomial : Intf.T0
 
     module Backend : sig
       type t

--- a/src/lib/crypto/kimchi_backend/pasta/precomputed.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/precomputed.ml
@@ -26,10 +26,9 @@ module Lagrange_precomputations = struct
 
   let max_public_input_size = 150
 
-  open Basic
 
   let vesta =
-    let f s = Fq.of_bigint (Bigint256.of_hex_string ~reverse:true (g s)) in
+    let f s = Basic.Fq.of_bigint (Basic.Bigint256.of_hex_string ~reverse:true (g s)) in
     [| [| [| ( f
                  "0x68fe06f08453cb5167c77c7420a9c361707aa89b4606f3ad395f757f2d55c33f"
              , f
@@ -10023,7 +10022,7 @@ module Lagrange_precomputations = struct
     |]
 
   let pallas =
-    let f s = Fp.of_bigint (Bigint256.of_hex_string ~reverse:true (g s)) in
+    let f s = Basic.Fp.of_bigint (Basic.Bigint256.of_hex_string ~reverse:true (g s)) in
     [| [| [| ( f
                  "0xf3ea7359f0d7b7ebc106234ed8dd59d753a344fe432d455c00bf9792c2fe1834"
              , f

--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -1,9 +1,7 @@
 [%%import "/src/config.mlh"]
 
-open Ppxlib
-open Asttypes
-open Parsetree
-open Longident
+open Ppxlib.Parsetree
+open Ppxlib.Longident
 open Core_kernel
 module Impl = Pickles.Impls.Step.Internal_Basic
 module Group = Pickles.Backend.Tick.Inner_curve
@@ -14,6 +12,7 @@ let group_map_params =
     Group.Params.{ a; b }
 
 let group_map_params_structure ~loc =
+  let open Asttypes in
   let module T = struct
     type t = Pickles.Backend.Tick.Field.Stable.Latest.t Group_map.Params.t
     [@@deriving bin_io_unversioned]
@@ -37,7 +36,7 @@ let group_map_params_structure ~loc =
 
 let generate_ml_file filename structure =
   let fmt = Format.formatter_of_out_channel (Out_channel.create filename) in
-  Pprintast.top_phrase fmt (Ptop_def (structure ~loc:Ppxlib.Location.none))
+  Ppxlib.Pprintast.top_phrase fmt (Ptop_def (structure ~loc:Ppxlib.Location.none))
 
 let () =
   generate_ml_file "group_map_params.ml" group_map_params_structure ;

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -4,7 +4,6 @@ open Core_kernel
 
 [%%ifdef consensus_mechanism]
 
-open Snark_bits
 open Snark_params.Tick
 
 [%%else]
@@ -36,7 +35,7 @@ module type Basic = sig
 
   val gen : t Quickcheck.Generator.t
 
-  include Bits_intf.Convertible_bits with type t := t
+  include Snark_bits.Bits_intf.Convertible_bits with type t := t
 
   val to_input : t -> Field.t Random_oracle.Input.Chunked.t
 

--- a/src/lib/data_hash_lib/data_hash.ml
+++ b/src/lib/data_hash_lib/data_hash.ml
@@ -7,7 +7,6 @@ open Core_kernel
 [%%ifdef consensus_mechanism]
 
 open Snark_params.Tick
-open Bitstring_lib
 
 [%%else]
 
@@ -52,7 +51,7 @@ struct
 
   type var =
     { digest : Random_oracle.Checked.Digest.t
-    ; mutable bits : Boolean.var Bitstring.Lsb_first.t option
+    ; mutable bits : Boolean.var Bitstring_lib.Bitstring.Lsb_first.t option
     }
 
   let var_of_t t =
@@ -60,7 +59,7 @@ struct
     { digest = Field.Var.constant t
     ; bits =
         Some
-          (Bitstring.Lsb_first.of_list
+          (Bitstring_lib.Bitstring.Lsb_first.of_list
              (List.init M.length_in_bits ~f:(fun i ->
                   Boolean.var_of_value (Bigint.test_bit n i))))
     }
@@ -82,7 +81,7 @@ struct
         return (bits :> Boolean.var list)
     | None ->
         let%map bits = unpack t.digest in
-        t.bits <- Some (Bitstring.Lsb_first.of_list bits) ;
+        t.bits <- Some (Bitstring_lib.Bitstring.Lsb_first.of_list bits) ;
         bits
 
   let var_to_input (t : var) = Random_oracle.Input.Chunked.field t.digest

--- a/src/lib/data_hash_lib/data_hash_intf.ml
+++ b/src/lib/data_hash_lib/data_hash_intf.ml
@@ -5,7 +5,6 @@ open Core_kernel
 [%%ifdef consensus_mechanism]
 
 open Snark_params.Tick
-open Snark_bits
 
 [%%else]
 
@@ -50,7 +49,7 @@ module type Basic = sig
   (* TODO : define bit ops using Random_oracle instead of Pedersen.Digest,
      move this outside of consensus_mechanism guard
   *)
-  include Bits_intf.S with type t := t
+  include Snark_bits.Bits_intf.S with type t := t
 
   [%%endif]
 

--- a/src/lib/data_hash_lib/state_hash.ml
+++ b/src/lib/data_hash_lib/state_hash.ml
@@ -12,7 +12,6 @@ open Snark_params_nonconsensus
 
 [%%else]
 
-open Snark_params.Tick
 
 [%%endif]
 
@@ -51,6 +50,7 @@ module Stable = struct
 
   module V1 = struct
     module T = struct
+      let open Snark_params.Tick in
       type t = Field.t [@@deriving sexp, compare, hash, version { asserted }]
     end
 

--- a/src/lib/distributed_dsl/distributed_dsl.ml
+++ b/src/lib/distributed_dsl/distributed_dsl.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Async_kernel
-open Pipe_lib
 
 module Ident = struct
   let state = ref 0
@@ -161,7 +160,7 @@ struct
 
   type t =
     { network :
-        (message Linear_pipe.Reader.t * message Linear_pipe.Writer.t)
+        (message Pipe_lib.Linear_pipe.Reader.t * message Pipe_lib.Linear_pipe.Writer.t)
         Peer.Table.t
     ; q : action Time_queue.t
     ; timer_stoppers : [ `Cancelled | `Finished ] Ivar.t Token.Table.t
@@ -187,8 +186,8 @@ struct
                 (Peer.sexp_of_t p |> Sexp.to_string_hum)
                 ()
           | Some (r, w) ->
-              Linear_pipe.write_or_exn ~capacity:1024 w r m ;
-              Linear_pipe.values_available r >>| Fn.const () ))
+              Pipe_lib.Linear_pipe.write_or_exn ~capacity:1024 w r m ;
+              Pipe_lib.Linear_pipe.values_available r >>| Fn.const () ))
 
   let wait t ts =
     let tok = Ident.next () in
@@ -220,7 +219,7 @@ struct
         Deferred.Or_error.return ()
 
   let listen t ~me =
-    let r, w = Linear_pipe.create () in
+    let r, w = Pipe_lib.Linear_pipe.create () in
     Peer.Table.add_exn t.network ~key:me ~data:(r, w) ;
     r
 

--- a/src/lib/downloader/downloader.ml
+++ b/src/lib/downloader/downloader.ml
@@ -1,6 +1,5 @@
 open Async
 open Core
-open Pipe_lib
 open Network_peer
 
 module Job = struct
@@ -44,6 +43,7 @@ module Claimed_knowledge = struct
         f k
 end
 
+open Pipe_lib
 module Make (Key : sig
   type t [@@deriving to_yojson, hash, sexp, compare]
 

--- a/src/lib/dummy_values/gen_values/gen_values.ml
+++ b/src/lib/dummy_values/gen_values/gen_values.ml
@@ -1,7 +1,6 @@
-open Ppxlib
-open Asttypes
-open Parsetree
-open Longident
+open Ppxlib.Asttypes
+open Ppxlib.Parsetree
+open Ppxlib.Longident
 open Core
 open Async
 open Pickles_types
@@ -33,7 +32,7 @@ let main () =
     Format.formatter_of_out_channel (Out_channel.create "dummy_values.ml")
   in
   let loc = Ppxlib.Location.none in
-  Pprintast.top_phrase fmt (Ptop_def (str ~loc)) ;
+  Ppxlib.Pprintast.top_phrase fmt (Ptop_def (str ~loc)) ;
   ignore (exit 0 : 'a Deferred.t)
 
 let () =

--- a/src/lib/exit_handlers/exit_handlers.ml
+++ b/src/lib/exit_handlers/exit_handlers.ml
@@ -2,7 +2,6 @@
 
 open Core_kernel
 open Async_kernel
-open Async_unix
 
 (* register a thunk to be called at exit; log registration and execution *)
 let register_handler ~logger ~description (f : unit -> unit) =
@@ -46,4 +45,4 @@ let register_async_shutdown_handler ~logger ~description
     in
     ()
   in
-  Shutdown.at_shutdown logging_thunk
+  Async_unix.Shutdown.at_shutdown logging_thunk

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -143,8 +143,6 @@ let setup (type n) ~logger ?(trust_system = Trust_system.null ())
   { fake_gossip_network; peer_networks }
 
 module Generator = struct
-  open Quickcheck
-  open Generator.Let_syntax
 
   type peer_config =
        logger:Logger.t
@@ -152,7 +150,7 @@ module Generator = struct
     -> verifier:Verifier.t
     -> max_frontier_length:int
     -> use_super_catchup:bool
-    -> peer_state Generator.t
+    -> peer_state Quickcheck.Generator.t
 
   let make_peer_state ?get_staged_ledger_aux_and_pending_coinbases_at_hash
       ?get_some_initial_peers ?answer_sync_ledger_query ?get_ancestry
@@ -273,6 +271,7 @@ module Generator = struct
       ?get_best_tip ?get_node_status ?get_transition_knowledge
       ?get_transition_chain_proof ?get_transition_chain ~logger
       ~precomputed_values ~verifier ~max_frontier_length ~use_super_catchup =
+    let open Generator.Let_syntax in
     let epoch_ledger_location =
       Filename.temp_dir_name ^/ "epoch_ledger"
       ^ (Uuid_unix.create () |> Uuid.to_string)
@@ -314,6 +313,7 @@ module Generator = struct
       ?get_best_tip ?get_node_status ?get_transition_knowledge
       ?get_transition_chain_proof ?get_transition_chain ~logger
       ~precomputed_values ~verifier ~max_frontier_length ~use_super_catchup =
+    let open Generator.Let_syntax in
     let epoch_ledger_location =
       Filename.temp_dir_name ^/ "epoch_ledger"
       ^ (Uuid_unix.create () |> Uuid.to_string)
@@ -357,6 +357,7 @@ module Generator = struct
   let gen ?(logger = Logger.null ()) ~precomputed_values ~verifier
       ~max_frontier_length ~use_super_catchup
       (configs : (peer_config, 'n num_peers) Gadt_lib.Vect.t) =
+    let open Generator.Let_syntax in
     let open Quickcheck.Generator.Let_syntax in
     let%map states =
       Vect.Quickcheck_generator.map configs ~f:(fun (config : peer_config) ->

--- a/src/lib/filtered_external_transition/filtered_external_transition.ml
+++ b/src/lib/filtered_external_transition/filtered_external_transition.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Mina_base
-open Mina_transition
 open Signature_lib
 
 module Fee_transfer_type = struct
@@ -110,6 +109,7 @@ let participant_pks
 let commands { transactions = { Transactions.commands; _ }; _ } = commands
 
 let validate_transactions ((transition_with_hash, _validity) as transition) =
+  let open Mina_transition in
   let staged_ledger_diff =
     External_transition.Validated.staged_ledger_diff transition
   in
@@ -125,6 +125,7 @@ let validate_transactions ((transition_with_hash, _validity) as transition) =
 
 let of_transition external_transition tracked_participants
     (calculated_transactions : Transaction.t With_status.t list) =
+  let open Mina_transition in
   let open External_transition.Validated in
   let creator = block_producer external_transition in
   let winner = block_winner external_transition in

--- a/src/lib/gossip_net/any.ml
+++ b/src/lib/gossip_net/any.ml
@@ -21,7 +21,6 @@ end
 
 module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
   S with module Rpc_intf := Rpc_intf = struct
-  open Rpc_intf
 
   module type Implementation_intf =
     Intf.Gossip_net_intf with module Rpc_intf := Rpc_intf
@@ -30,7 +29,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
 
   type t = Any : 't implementation * 't -> t
 
-  type 't creator = rpc_handler list -> 't Deferred.t
+  type 't creator = Rpc_intf.rpc_handler list -> 't Deferred.t
 
   type creatable = Creatable : 't implementation * 't creator -> creatable
 

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -19,7 +19,6 @@ end
 
 module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
   S with module Rpc_intf := Rpc_intf = struct
-  open Intf
   open Rpc_intf
 
   module Network = struct
@@ -128,8 +127,8 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
           , Strict_pipe.crash Strict_pipe.buffered
           , unit )
           Strict_pipe.Writer.t
-      ; ban_notification_reader : ban_notification Linear_pipe.Reader.t
-      ; ban_notification_writer : ban_notification Linear_pipe.Writer.t
+      ; ban_notification_reader : Intf.ban_notification Linear_pipe.Reader.t
+      ; ban_notification_writer : Intf.ban_notification Linear_pipe.Writer.t
       }
 
     let rpc_hook t rpc_handlers =

--- a/src/lib/gossip_net/intf.ml
+++ b/src/lib/gossip_net/intf.ml
@@ -1,7 +1,6 @@
 open Async
 open Core_kernel
 open Network_peer
-open Pipe_lib
 open Mina_base.Rpc_intf
 
 type ban_creator = { banned_peer : Peer.t; banned_until : Time.t }
@@ -76,7 +75,7 @@ module type Gossip_net_intf = sig
   val received_message_reader :
        t
     -> (Message.msg Envelope.Incoming.t * Mina_net2.Validation_callback.t)
-       Strict_pipe.Reader.t
+       Pipe_lib.Strict_pipe.Reader.t
 
-  val ban_notification_reader : t -> ban_notification Linear_pipe.Reader.t
+  val ban_notification_reader : t -> ban_notification Pipe_lib.Linear_pipe.Reader.t
 end

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -1,6 +1,5 @@
 open Async
 open Core
-open Integration_test_lib.Util
 open Integration_test_lib
 module Timeout = Timeout_lib.Core_time
 module Node = Kubernetes_network.Node
@@ -78,6 +77,7 @@ module Subscription = struct
        from the sink on your project's Activity page; you can ignore them.
   *)
   let create_sink ~topic ~filter ~key ~logger name =
+    let open Integration_test_lib.Util in
     let open Deferred.Or_error.Let_syntax in
     let url =
       "https://logging.googleapis.com/v2/projects/o1labs-192920/sinks?key="
@@ -139,6 +139,7 @@ module Subscription = struct
     { name; topic; sink }
 
   let create ~name ~filter ~logger =
+    let open Integration_test_lib.Util in
     let open Deferred.Or_error.Let_syntax in
     let gcloud_key_file_env = "GCLOUD_API_KEY" in
     let%bind key =
@@ -176,6 +177,7 @@ module Subscription = struct
     t
 
   let delete t =
+    let open Integration_test_lib.Util in
     let open Deferred.Let_syntax in
     let%bind delete_subscription_res =
       run_cmd_or_error "." prog
@@ -213,6 +215,7 @@ module Subscription = struct
         Deferred.Or_error.return res
 
   let pull ~logger t =
+    let open Integration_test_lib.Util in
     let open Deferred.Or_error.Let_syntax in
     let subscription_id =
       String.concat ~sep:"/" [ "projects"; project_id; "subscriptions"; t.name ]

--- a/src/lib/integration_test_lib/dsl.ml
+++ b/src/lib/integration_test_lib/dsl.ml
@@ -1,6 +1,5 @@
 open Async_kernel
 open Core_kernel
-open Pipe_lib
 module Timeout = Timeout_lib.Core_time
 
 let broadcast_pipe_fold_until_with_timeout reader ~timeout_duration
@@ -9,7 +8,7 @@ let broadcast_pipe_fold_until_with_timeout reader ~timeout_duration
   let result = ref None in
   let acc = ref init in
   let read_deferred =
-    Broadcast_pipe.Reader.iter_until reader ~f:(fun msg ->
+    Pipe_lib.Broadcast_pipe.Reader.iter_until reader ~f:(fun msg ->
         Deferred.return
           ( if !timed_out then true
           else
@@ -43,10 +42,10 @@ module Make (Engine : Intf.Engine.S) () :
     { logger : Logger.t
     ; network : Engine.Network.t
     ; event_router : Event_router.t
-    ; network_state_reader : Network_state.t Broadcast_pipe.Reader.t
+    ; network_state_reader : Network_state.t Pipe_lib.Broadcast_pipe.Reader.t
     }
 
-  let network_state t = Broadcast_pipe.Reader.peek t.network_state_reader
+  let network_state t = Pipe_lib.Broadcast_pipe.Reader.peek t.network_state_reader
 
   let create ~logger ~network ~event_router ~network_state_reader =
     let t = { logger; network; event_router; network_state_reader } in
@@ -74,7 +73,7 @@ module Make (Engine : Intf.Engine.S) () :
     in
     [%log debug] "Initializing network state predicate" ;
     match
-      Broadcast_pipe.Reader.peek network_state_reader
+      Pipe_lib.Broadcast_pipe.Reader.peek network_state_reader
       |> init |> handle_predicate_result
     with
     | `Stop result ->

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -225,7 +225,6 @@ module Breadcrumb_added = struct
 end
 
 module Gossip = struct
-  open Or_error.Let_syntax
 
   module Direction = struct
     type t = Sent | Received [@@deriving yojson]
@@ -245,6 +244,7 @@ module Gossip = struct
     let id = Mina_networking.block_received_structured_events_id
 
     let parse_func message =
+      let open Or_error.Let_syntax in
       match%bind parse id message with
       | Mina_networking.Block_received { state_hash; sender = _ } ->
           Ok ({ state_hash }, Direction.Received)
@@ -267,6 +267,7 @@ module Gossip = struct
     let id = Mina_networking.snark_work_received_structured_events_id
 
     let parse_func message =
+      let open Or_error.Let_syntax in
       match%bind parse id message with
       | Mina_networking.Snark_work_received { work; sender = _ } ->
           Ok ({ work }, Direction.Received)
@@ -290,6 +291,7 @@ module Gossip = struct
     let id = Mina_networking.transactions_received_structured_events_id
 
     let parse_func message =
+      let open Or_error.Let_syntax in
       match%bind parse id message with
       | Mina_networking.Transactions_received { txns; sender = _ } ->
           Ok ({ txns }, Direction.Received)

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -2,7 +2,6 @@ open Async_kernel
 open Core_kernel
 open Currency
 open Mina_base
-open Pipe_lib
 open Signature_lib
 
 (* TODO: malleable error -> or error *)
@@ -215,7 +214,7 @@ module Dsl = struct
     val listen :
          logger:Logger.t
       -> Event_router.t
-      -> t Broadcast_pipe.Reader.t * t Broadcast_pipe.Writer.t
+      -> t Pipe_lib.Broadcast_pipe.Reader.t * t Pipe_lib.Broadcast_pipe.Writer.t
   end
 
   module type Wait_condition_intf = sig
@@ -323,7 +322,7 @@ module Dsl = struct
          logger:Logger.t
       -> network:Engine.Network.t
       -> event_router:Event_router.t
-      -> network_state_reader:Network_state.t Broadcast_pipe.Reader.t
+      -> network_state_reader:Network_state.t Pipe_lib.Broadcast_pipe.Reader.t
       -> [ `Don't_call_in_tests of t ]
 
     type log_error_accumulator

--- a/src/lib/integration_test_lib/network_state.ml
+++ b/src/lib/integration_test_lib/network_state.ml
@@ -1,6 +1,5 @@
 open Async_kernel
 open Core_kernel
-open Pipe_lib
 open Mina_base
 
 module Make
@@ -41,13 +40,13 @@ module Make
     }
 
   let listen ~logger event_router =
-    let r, w = Broadcast_pipe.create empty in
+    let r, w = Pipe_lib.Broadcast_pipe.create empty in
     let update ~f =
       (* should be safe to ignore the write here, so long as `f` is synchronous *)
-      let state = f (Broadcast_pipe.Reader.peek r) in
+      let state = f (Pipe_lib.Broadcast_pipe.Reader.peek r) in
       [%log debug] "updated network state to: $state"
         ~metadata:[ ("state", to_yojson state) ] ;
-      ignore (Broadcast_pipe.Writer.write w state : unit Deferred.t) ;
+      ignore (Pipe_lib.Broadcast_pipe.Writer.write w state : unit Deferred.t) ;
       Deferred.return `Continue
     in
     (* handle_block_produced *)

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -14,7 +14,6 @@ module Make
                        with module Engine := Engine
                         and module Event_router := Event_router) =
 struct
-  open Network_state
   module Node = Engine.Network.Node
 
   type 'a predicate_result =
@@ -56,7 +55,7 @@ struct
     let check () (state : Network_state.t) =
       if
         List.for_all nodes ~f:(fun node ->
-            String.Map.find state.node_initialization (Node.id node)
+            String.Map.find Network_state.state.node_initialization (Node.id node)
             |> Option.value ~default:false)
       then Predicate_passed
       else Predicate_continuation ()
@@ -75,9 +74,9 @@ struct
 
   (* let blocks_produced ?(active_stake_percentage = 1.0) n = *)
   let blocks_to_be_produced n =
-    let init state = Predicate_continuation state.blocks_generated in
+    let init state = Predicate_continuation Network_state.state.blocks_generated in
     let check init_blocks_generated state =
-      if state.blocks_generated - init_blocks_generated >= n then
+      if Network_state.state.blocks_generated - init_blocks_generated >= n then
         Predicate_passed
       else Predicate_continuation init_blocks_generated
     in
@@ -96,7 +95,7 @@ struct
       in
       let best_tips =
         List.map nodes ~f:(fun node ->
-            String.Map.find state.best_tips_by_node (Node.id node))
+            String.Map.find Network_state.state.best_tips_by_node (Node.id node))
       in
       if
         List.for_all best_tips ~f:Option.is_some

--- a/src/lib/ledger_catchup/normal_catchup.ml
+++ b/src/lib/ledger_catchup/normal_catchup.ml
@@ -1,12 +1,7 @@
 (* Only show stdout for failed inline tests. *)
-open Inline_test_quiet_logs
 open Core
 open Async
-open Cache_lib
-open Pipe_lib
 open Mina_base
-open Mina_transition
-open Network_peer
 
 (** [Ledger_catchup] is a procedure that connects a foreign external transition
     into a transition frontier by requesting a path of external_transitions
@@ -46,6 +41,8 @@ open Network_peer
     After building the breadcrumb path, [Ledger_catchup] will then send it to
     the [Processor] via writing them to catchup_breadcrumbs_writer. *)
 
+open Network_peer
+open Mina_transition
 let verify_transition ~logger ~consensus_constants ~trust_system ~frontier
     ~unprocessed_transition_cache enveloped_transition =
   let sender = Envelope.Incoming.sender enveloped_transition in
@@ -458,6 +455,7 @@ let download_transitions ~target_hash ~logger ~trust_system ~network
       in
       go [])
 
+open Cache_lib
 let verify_transitions_and_build_breadcrumbs ~logger
     ~(precomputed_values : Precomputed_values.t) ~trust_system ~verifier
     ~frontier ~unprocessed_transition_cache ~transitions ~target_hash ~subtrees
@@ -601,6 +599,7 @@ let garbage_collect_subtrees ~logger ~subtrees =
           : 'a Rose_tree.t )) ;
   [%log trace] "garbage collected failed cached transitions"
 
+open Pipe_lib
 let run ~logger ~precomputed_values ~trust_system ~verifier ~network ~frontier
     ~catchup_job_reader
     ~(catchup_breadcrumbs_writer :
@@ -823,6 +822,7 @@ let run ~logger ~precomputed_values ~trust_system ~verifier ~network ~frontier
 
 (* Unit tests *)
 
+open Inline_test_quiet_logs
 let%test_module "Ledger_catchup tests" =
   ( module struct
     let () =

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1,13 +1,7 @@
 (* Only show stdout for failed inline tests. *)
-open Inline_test_quiet_logs
 open Core
 open Async
-open Cache_lib
-open Pipe_lib
-open Mina_numbers
 open Mina_base
-open Mina_transition
-open Network_peer
 
 (** [Ledger_catchup] is a procedure that connects a foreign external transition
     into a transition frontier by requesting a path of external_transitions
@@ -119,6 +113,8 @@ let write_graph (_ : t) =
   let _ = G.output_graph in
   ()
 
+open Network_peer
+open Mina_transition
 let verify_transition ~logger ~consensus_constants ~trust_system ~frontier
     ~unprocessed_transition_cache enveloped_transition =
   let sender = Envelope.Incoming.sender enveloped_transition in
@@ -351,6 +347,7 @@ let try_to_connect_hash_chain t hashes ~frontier
       then Result.fail `No_common_ancestor
       else Result.fail `Peer_moves_too_fast)
 
+open Mina_numbers
 module Downloader = struct
   module Key = struct
     module T = struct
@@ -624,6 +621,7 @@ let download s d ~key ~attempts =
     "Download download $key" ;
   Downloader.download d ~key ~attempts
 
+open Cache_lib
 let create_node ~downloader t x =
   let attempts = Attempt_history.empty in
   let state, h, blockchain_length, parent, result =
@@ -684,6 +682,7 @@ let forest_pick forest =
       List.iter forest ~f:(Rose_tree.iter ~f:return) ;
       assert false)
 
+open Pipe_lib
 let setup_state_machine_runner ~t ~verifier ~downloader ~logger
     ~precomputed_values ~trust_system ~frontier ~unprocessed_transition_cache
     ~catchup_breadcrumbs_writer
@@ -1257,6 +1256,7 @@ let run ~logger ~precomputed_values ~trust_system ~verifier ~network ~frontier
     ~catchup_breadcrumbs_writer ~build_func:(Transition_frontier.Breadcrumb.For_tests.build_fail)
   |> don't_wait_for *)
 
+open Inline_test_quiet_logs
 let%test_module "Ledger_catchup tests" =
   ( module struct
     let () =

--- a/src/lib/logproc_lib/filter.ml
+++ b/src/lib/logproc_lib/filter.ml
@@ -257,7 +257,6 @@ module Parser = struct
 end
 
 module Interpreter = struct
-  open Ast
   open Option.Let_syntax
 
   let option_list_map ls ~f =
@@ -270,7 +269,8 @@ module Interpreter = struct
     in
     loop [] ls >>| List.rev
 
-  let json_value = function
+  let json_value = let open Ast in
+                   function
     | Bool b ->
         `Bool b
     | String s ->
@@ -288,7 +288,8 @@ module Interpreter = struct
   let access_int json i =
     match json with `List ls -> List.nth ls i | _ -> None
 
-  let rec interpret_value_exp (json : Yojson.Safe.t) = function
+  let rec interpret_value_exp (json : Yojson.Safe.t) = let open Ast in
+                                                       function
     | Value_lit v ->
         Some (json_value v)
     | Value_list ls ->
@@ -301,7 +302,8 @@ module Interpreter = struct
     | Value_access_int (parent, i) ->
         interpret_value_exp json parent >>= (Fn.flip access_int) i
 
-  let interpret_cmp_exp json = function
+  let interpret_cmp_exp json = let open Ast in
+                               function
     | Cmp_eq (x, y) ->
         Option.map2
           (interpret_value_exp json x)
@@ -326,7 +328,8 @@ module Interpreter = struct
             match value with `String str -> Re2.matches regex str | _ -> false)
         |> Option.value ~default:false
 
-  let rec interpret_bool_exp json = function
+  let rec interpret_bool_exp json = let open Ast in
+                                    function
     | Bool_lit b ->
         b
     | Bool_cmp cmp ->

--- a/src/lib/memory_stats/memory_stats.ml
+++ b/src/lib/memory_stats/memory_stats.ml
@@ -2,9 +2,9 @@
 
 open Core_kernel
 open Async
-open Gc.Stat
 
 let ocaml_memory_stats () =
+  let open Gc.Stat in
   let bytes_per_word = Sys.word_size / 8 in
   let stat = Gc.stat () in
   [ ("heap_size_bytes", `Int (stat.heap_words * bytes_per_word))

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -3,7 +3,6 @@
 [%%import "/src/config.mlh"]
 
 open Core_kernel
-open Util
 
 [%%ifdef consensus_mechanism]
 
@@ -21,9 +20,6 @@ module Mina_compile_config =
 [%%endif]
 
 open Currency
-open Mina_numbers
-open Fold_lib
-open Import
 
 module Index = struct
   [%%versioned
@@ -62,11 +58,11 @@ module Index = struct
   let of_bits = List.foldi ~init:Vector.empty ~f:(fun i t b -> Vector.set t i b)
 
   let to_input ~ledger_depth x =
-    List.map (to_bits ~ledger_depth x) ~f:(fun b -> (field_of_bool b, 1))
+    List.map (to_bits ~ledger_depth x) ~f:(fun b -> (Util.field_of_bool b, 1))
     |> List.to_array |> Random_oracle.Input.Chunked.packeds
 
   let fold_bits ~ledger_depth t =
-    { Fold.fold =
+    Fold_lib.{ Fold.fold =
         (fun ~init ~f ->
           let rec go acc i =
             if i = ledger_depth then acc else go (f acc (Vector.get t i)) (i + 1)
@@ -75,7 +71,7 @@ module Index = struct
     }
 
   let fold ~ledger_depth t =
-    Fold.group3 ~default:false (fold_bits ~ledger_depth t)
+    Fold_lib.Fold.group3 ~default:false (fold_bits ~ledger_depth t)
 
   [%%ifdef consensus_mechanism]
 
@@ -97,6 +93,7 @@ module Index = struct
   [%%endif]
 end
 
+open Mina_numbers
 module Nonce = Account_nonce
 
 module Poly = struct
@@ -132,6 +129,7 @@ module Poly = struct
   end]
 end
 
+open Import
 module Key = struct
   [%%versioned
   module Stable = struct

--- a/src/lib/mina_base/account_timing.ml
+++ b/src/lib/mina_base/account_timing.ml
@@ -5,7 +5,6 @@ open Core_kernel
 [%%ifdef consensus_mechanism]
 
 open Snark_params
-open Tick
 
 [%%else]
 
@@ -108,6 +107,7 @@ let to_record t =
         ; vesting_increment
         }
 
+open Tick
 let to_input t =
   let As_record.
         { is_timed

--- a/src/lib/mina_base/gen/gen.ml
+++ b/src/lib/mina_base/gen/gen.ml
@@ -1,7 +1,3 @@
-open Ppxlib
-open Asttypes
-open Parsetree
-open Longident
 open Core_kernel
 open Signature_lib
 
@@ -24,6 +20,8 @@ let keypairs =
     generated_keypairs
 
 let expr ~loc =
+  let open Longident in
+  let open Asttypes in
   let module E = Ppxlib.Ast_builder.Make (struct
     let loc = loc
   end) in
@@ -53,6 +51,8 @@ let expr ~loc =
   Array.map conv [%e earray]
 
 let structure ~loc =
+  let open Parsetree in
+  let open Asttypes in
   let module E = Ppxlib.Ast_builder.Make (struct
     let loc = loc
   end) in
@@ -72,9 +72,10 @@ let json =
            ]))
 
 let main () =
+  let open Parsetree in
   Out_channel.with_file "sample_keypairs.ml" ~f:(fun ml_file ->
       let fmt = Format.formatter_of_out_channel ml_file in
-      Pprintast.top_phrase fmt (Ptop_def (structure ~loc:Ppxlib.Location.none))) ;
+      Ppxlib.Pprintast.top_phrase fmt (Ptop_def (structure ~loc:Ppxlib.Location.none))) ;
   Out_channel.with_file "sample_keypairs.json" ~f:(fun json_file ->
       Yojson.pretty_to_channel json_file json) ;
   exit 0

--- a/src/lib/mina_base/ledger_hash.ml
+++ b/src/lib/mina_base/ledger_hash.ml
@@ -1,8 +1,5 @@
 open Core
-open Import
-open Snark_params
-open Snarky_backendless
-open Tick
+open Snark_params.Tick
 open Let_syntax
 
 let merge_var ~height h1 h2 =
@@ -10,7 +7,7 @@ let merge_var ~height h1 h2 =
 
 module Merkle_tree =
   Snarky_backendless.Merkle_tree.Checked
-    (Tick)
+    (Snark_params.Tick)
     (struct
       type value = Field.t
 
@@ -19,7 +16,7 @@ module Merkle_tree =
       let typ = Field.typ
 
       let merge ~height h1 h2 =
-        Tick.make_checked (fun () -> merge_var ~height h1 h2)
+        Snark_params.Tick.make_checked (fun () -> merge_var ~height h1 h2)
 
       let assert_equal h1 h2 = Field.Checked.Assert.equal h1 h2
 
@@ -49,6 +46,7 @@ let of_digest = Fn.compose Fn.id of_hash
 
 type path = Random_oracle.Digest.t list
 
+open Snarky_backendless
 type _ Request.t +=
   | Get_path : Account.Index.t -> path Request.t
   | Get_element : Account.Index.t -> (Account.t * path) Request.t
@@ -112,8 +110,8 @@ let%snarkydef modify_account_send ~depth t aid ~is_writeable ~f =
            Account_id.Checked.equal (Account.identifier_of_var account) aid
          in
          let%bind account_not_there =
-           Public_key.Compressed.Checked.equal account.public_key
-             Public_key.Compressed.(var_of_t empty)
+           Import.Public_key.Compressed.Checked.equal account.public_key
+             Import.Public_key.Compressed.(var_of_t empty)
          in
          let%bind not_there_but_writeable =
            Boolean.(account_not_there && is_writeable)
@@ -142,8 +140,8 @@ let%snarkydef modify_account_recv ~depth t aid ~f =
            Account_id.Checked.equal (Account.identifier_of_var account) aid
          in
          let%bind account_not_there =
-           Public_key.Compressed.Checked.equal account.public_key
-             Public_key.Compressed.(var_of_t empty)
+           Import.Public_key.Compressed.Checked.equal account.public_key
+             Import.Public_key.Compressed.(var_of_t empty)
          in
          let%bind () =
            [%with_label "account is either present or empty"]

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -18,9 +18,7 @@ module Random_oracle = Random_oracle_nonconsensus.Random_oracle
 [%%endif]
 
 module Impl = Pickles.Impls.Step
-open Mina_numbers
 open Currency
-open Pickles_types
 module Digest = Random_oracle.Digest
 
 module type Type = sig
@@ -89,7 +87,7 @@ module Update = struct
 
   let noop : t =
     { app_state =
-        Vector.init Snapp_state.Max_state_size.n ~f:(fun _ -> Set_or_keep.Keep)
+        Pickles_types.Vector.init Snapp_state.Max_state_size.n ~f:(fun _ -> Set_or_keep.Keep)
     ; delegate = Keep
     ; verification_key = Keep
     ; permissions = Keep
@@ -364,6 +362,7 @@ module Predicated = struct
   end
 
   module Signed = struct
+    open Mina_numbers
     [%%versioned
     module Stable = struct
       module V1 = struct

--- a/src/lib/mina_base/payment_payload.ml
+++ b/src/lib/mina_base/payment_payload.ml
@@ -6,7 +6,6 @@ open Core_kernel
 
 [%%ifdef consensus_mechanism]
 
-open Snark_params.Tick
 open Signature_lib
 
 [%%else]
@@ -62,6 +61,7 @@ let token { Poly.token_id; _ } = token_id
 
 type var = (Public_key.Compressed.var, Token_id.var, Amount.var) Poly.t
 
+open Snark_params.Tick
 let typ : (var, t) Typ.t =
   let spec =
     let open Data_spec in

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -2,7 +2,6 @@ open Core_kernel
 open Import
 open Snarky_backendless
 module Coda_base_util = Util
-open Snark_params
 open Snark_params.Tick
 open Let_syntax
 open Currency
@@ -112,6 +111,7 @@ end = struct
     if t2 < t1 then Or_error.error_string "Stack_id overflow" else Ok t2
 end
 
+open Snark_params
 module type Data_hash_intf = sig
   type t = private Field.t [@@deriving sexp, compare, equal, yojson, hash]
 

--- a/src/lib/mina_base/permissions.ml
+++ b/src/lib/mina_base/permissions.ml
@@ -1,11 +1,9 @@
 [%%import "/src/config.mlh"]
 
 open Core_kernel
-open Util
 
 [%%ifdef consensus_mechanism]
 
-open Snark_params.Tick
 module Mina_numbers = Mina_numbers
 
 [%%else]
@@ -53,6 +51,7 @@ module Ledger_hash = Ledger_hash0
      "Making sense" can be captured by the idea that these are the *increasing*
      boolean functions on the type { has_valid_signature: bool; has_valid_proof: bool }.
   *)
+open Snark_params.Tick
 module Auth_required = struct
   [%%versioned
   module Stable = struct
@@ -265,7 +264,7 @@ module Auth_required = struct
 
   [%%endif]
 
-  let to_input x = Encoding.to_input (encode x) ~field_of_bool
+  let to_input x = Encoding.to_input (encode x) ~Util.field_of_bool
 
   let check (t : t) (c : Control.Tag.t) =
     match (t, c) with
@@ -374,7 +373,7 @@ let typ =
 
 [%%endif]
 
-let to_input (x : t) = Poly.to_input ~field_of_bool Auth_required.to_input x
+let to_input (x : t) = Poly.to_input ~Util.field_of_bool Auth_required.to_input x
 
 let user_default : t =
   { stake = true

--- a/src/lib/mina_base/protocol_constants_checked.ml
+++ b/src/lib/mina_base/protocol_constants_checked.ml
@@ -4,7 +4,6 @@ open Core_kernel
 
 [%%ifdef consensus_mechanism]
 
-open Snark_params.Tick
 
 [%%else]
 
@@ -91,6 +90,7 @@ let to_input (t : value) =
 type var = (T.Checked.t, T.Checked.t, Block_time.Checked.t) Poly.t
 
 let data_spec =
+  let open Snark_params.Tick in
   Data_spec.
     [ T.Checked.typ
     ; T.Checked.typ
@@ -100,6 +100,7 @@ let data_spec =
     ]
 
 let typ =
+  let open Snark_params.Tick in
   Typ.of_hlistable data_spec ~var_to_hlist:Poly.to_hlist
     ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
     ~value_of_hlist:Poly.of_hlist
@@ -121,6 +122,7 @@ let var_to_input (var : var) =
     |]
 
 let%test_unit "value = var" =
+  let open Snark_params.Tick in
   let compiled = Genesis_constants.for_unit_tests.protocol in
   let test protocol_constants =
     let open Snarky_backendless in

--- a/src/lib/mina_base/rpc_intf.ml
+++ b/src/lib/mina_base/rpc_intf.ml
@@ -1,15 +1,14 @@
 open Async
 open Core
-open Network_peer
 
-type state = Peer.t
+type state = Network_peer.Peer.t
 
 type ('query, 'response) rpc_fn =
   state -> version:int -> 'query -> 'response Deferred.t
 
 type 'r rpc_response =
   | Failed_to_connect of Error.t
-  | Connected of 'r Or_error.t Envelope.Incoming.t
+  | Connected of 'r Or_error.t Network_peer.Envelope.Incoming.t
 
 module type Rpc_implementation_intf = sig
   type query

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -11,7 +11,6 @@ module Quickcheck_lib = Quickcheck_lib_nonconsensus.Quickcheck_lib
 
 [%%endif]
 
-open Mina_numbers
 module Fee = Currency.Fee
 module Payload = Signed_command_payload
 
@@ -158,7 +157,7 @@ end
 
 module Gen = struct
   let gen_inner (sign' : Signature_lib.Keypair.t -> Payload.t -> t) ~key_gen
-      ?(nonce = Account_nonce.zero) ?(fee_token = Token_id.default) ~fee_range
+      ?(nonce = Mina_numbers.Account_nonce.zero) ?(fee_token = Token_id.default) ~fee_range
       create_body =
     let open Quickcheck.Generator.Let_syntax in
     let min_fee = Fee.to_int Mina_compile_config.minimum_user_command_fee in
@@ -305,7 +304,7 @@ module Gen = struct
           let sender_pk, _, _, _ = account_info.(sender) in
           currency_splits.(sender) <- rest_splits ;
           let nonce = account_nonces.(sender) in
-          account_nonces.(sender) <- Account_nonce.succ nonce ;
+          account_nonces.(sender) <- Mina_numbers.Account_nonce.succ nonce ;
           let%bind fee =
             (* use of_string here because json_of_ocaml won't handle
                equivalent integer constants

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -8,7 +8,6 @@ open Core_kernel
 [%%ifdef consensus_mechanism]
 
 open Mina_numbers
-open Snark_params.Tick
 
 [%%else]
 
@@ -89,6 +88,7 @@ module type Gen_intf = sig
   end
 end
 
+open Snark_params.Tick
 module type S = sig
   type t [@@deriving sexp, yojson, hash]
 

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -6,7 +6,6 @@ open Core_kernel
 
 [%%ifdef consensus_mechanism]
 
-open Snark_params.Tick
 open Signature_lib
 module Mina_numbers = Mina_numbers
 
@@ -155,6 +154,7 @@ module Common = struct
     Poly.t
 
   let typ =
+    let open Snark_params.Tick in
     Typ.of_hlistable
       [ Currency.Fee.typ
       ; Token_id.typ
@@ -179,6 +179,7 @@ module Common = struct
 
     let to_input_legacy
         ({ fee; fee_token; fee_payer_pk; nonce; valid_until; memo } : var) =
+      let open Snark_params.Tick in
       let%map nonce = Account_nonce.Checked.to_input_legacy nonce
       and valid_until = Global_slot.Checked.to_input_legacy valid_until
       and fee_token = Token_id.Checked.to_input_legacy fee_token

--- a/src/lib/mina_base/snapp_account.ml
+++ b/src/lib/mina_base/snapp_account.ml
@@ -4,7 +4,6 @@ open Core_kernel
 
 [%%ifdef consensus_mechanism]
 
-open Snark_params.Tick
 module Mina_numbers = Mina_numbers
 module Hash_prefix_states = Hash_prefix_states
 
@@ -49,7 +48,6 @@ module Stable = struct
   end
 end]
 
-open Pickles_types
 
 let digest_vk (t : Side_loaded_verification_key.t) =
   Random_oracle.(
@@ -70,7 +68,7 @@ module Checked = struct
     let open Random_oracle.Input.Chunked in
     let f mk acc field = mk (Core_kernel.Field.get field t) :: acc in
     let app_state v =
-      Random_oracle.Input.Chunked.field_elements (Vector.to_array v)
+      Random_oracle.Input.Chunked.field_elements (Pickles_types.Vector.to_array v)
     in
     Poly.Fields.fold ~init:[] ~app_state:(f app_state)
       ~verification_key:(f (fun x -> field x))
@@ -93,6 +91,7 @@ module Checked = struct
       hash ~init:Hash_prefix_states.snapp_account (pack_input (to_input' t)))
 end
 
+open Snark_params.Tick
 let typ : (Checked.t, t) Typ.t =
   let open Poly in
   Typ.of_hlistable
@@ -123,7 +122,7 @@ let to_input (t : t) =
   let open Random_oracle.Input.Chunked in
   let f mk acc field = mk (Core_kernel.Field.get field t) :: acc in
   let app_state v =
-    Random_oracle.Input.Chunked.field_elements (Vector.to_array v)
+    Random_oracle.Input.Chunked.field_elements (Pickles_types.Vector.to_array v)
   in
   Poly.Fields.fold ~init:[] ~app_state:(f app_state)
     ~verification_key:
@@ -134,7 +133,7 @@ let to_input (t : t) =
 
 let default : _ Poly.t =
   (* These are the permissions of a "user"/"non snapp" account. *)
-  { app_state = Vector.init Snapp_state.Max_state_size.n ~f:(fun _ -> F.zero)
+  { app_state = Pickles_types.Vector.init Snapp_state.Max_state_size.n ~f:(fun _ -> F.zero)
   ; verification_key = None
   }
 

--- a/src/lib/mina_base/snapp_command.ml
+++ b/src/lib/mina_base/snapp_command.ml
@@ -20,7 +20,6 @@ module Random_oracle = Random_oracle_nonconsensus.Random_oracle
 module Impl = Pickles.Impls.Step
 open Mina_numbers
 open Currency
-open Pickles_types
 module Digest = Random_oracle.Digest
 module Predicate = Snapp_predicate
 
@@ -97,7 +96,7 @@ module Party = struct
 
     let dummy : t =
       { app_state =
-          Vector.init Snapp_state.Max_state_size.n ~f:(fun _ ->
+          Pickles_types.Vector.init Snapp_state.Max_state_size.n ~f:(fun _ ->
               Set_or_keep.Keep)
       ; delegate = Keep
       ; verification_key = Keep

--- a/src/lib/mina_base/snapp_predicate.ml
+++ b/src/lib/mina_base/snapp_predicate.ml
@@ -21,7 +21,6 @@ module A = Account
 open Mina_numbers
 open Currency
 open Snapp_basic
-open Pickles_types
 module Impl = Pickles.Impls.Step
 
 module Closed_interval = struct
@@ -382,6 +381,7 @@ module Account = struct
     end
   end]
 
+  open Pickles_types
   let accept : t =
     { balance = Ignore
     ; nonce = Ignore

--- a/src/lib/mina_base/snapp_statement.ml
+++ b/src/lib/mina_base/snapp_statement.ml
@@ -117,14 +117,13 @@ module Complement = struct
       [@@deriving hlist, sexp, equal, yojson, hash, compare]
     end
 
-    open Mina_numbers
 
     module Checked = struct
       type t =
         ( Boolean.var
         , Token_id.Checked.t
         , (Boolean.var, Other_fee_payer.Payload.Checked.t) Flagged_option.t
-        , Account_nonce.Checked.t )
+        , Mina_numbers.Account_nonce.Checked.t )
         Poly.t
 
       let complete
@@ -153,7 +152,7 @@ module Complement = struct
       ( bool
       , Token_id.t
       , Other_fee_payer.Payload.t option
-      , Account_nonce.t )
+      , Mina_numbers.Account_nonce.t )
       Poly.t
 
     let typ : (Checked.t, t) Typ.t =
@@ -162,7 +161,7 @@ module Complement = struct
         [ Boolean.typ
         ; Boolean.typ
         ; Token_id.typ
-        ; Account_nonce.typ
+        ; Mina_numbers.Account_nonce.typ
         ; Flagged_option.typ Other_fee_payer.Payload.typ
           |> Typ.transport
                ~there:

--- a/src/lib/mina_base/sok_message.ml
+++ b/src/lib/mina_base/sok_message.ml
@@ -1,5 +1,4 @@
 open Core
-open Util
 open Import
 
 [%%versioned
@@ -45,7 +44,7 @@ module Digest = struct
         Random_oracle.Input.Chunked.packeds
           (Array.of_list_map
              Fold_lib.Fold.(to_list (string_bits t))
-             ~f:(fun b -> (field_of_bool b, 1)))
+             ~f:(fun b -> (Util.field_of_bool b, 1)))
 
       let typ =
         Typ.array ~length:Blake2.digest_size_in_bits Boolean.typ

--- a/src/lib/mina_base/sparse_ledger.ml
+++ b/src/lib/mina_base/sparse_ledger.ml
@@ -2,8 +2,6 @@
 (* TODO: refactor the misleading implementation of Ledger.foldi that confused me so much in the first place. *)
 
 open Core
-open Import
-open Snark_params.Tick
 
 let dedup_list ls ~comparator =
   let ls', _ =
@@ -46,6 +44,7 @@ module M =
 
 type account_state = [ `Added | `Existed ] [@@deriving equal]
 
+open Import
 module L = struct
   type t = M.t ref
 
@@ -537,6 +536,7 @@ let merkle_root t = Ledger_hash.of_hash (merkle_root t :> Random_oracle.Digest.t
 let depth t = M.depth t
 
 let handler t =
+  let open Snark_params.Tick in
   let ledger = ref t in
   let path_exn idx =
     List.map (path_exn !ledger idx) ~f:(function `Left h -> h | `Right h -> h)

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1193,7 +1193,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
 
   let check e b = if b then Ok () else Error (failure e)
 
-  open Pickles_types
 
   let apply_body
       ~(constraint_constants : Genesis_constants.Constraint_constants.t)
@@ -1266,8 +1265,8 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
     let%bind snapp =
       let%map app_state =
         update a.permissions.edit_state app_state init.app_state
-          ~is_keep:(Vector.for_all ~f:Set_or_keep.is_keep)
-          ~update:(Vector.map2 ~f:Set_or_keep.set_or_keep)
+          ~is_keep:(Pickles_types.Vector.for_all ~f:Set_or_keep.is_keep)
+          ~update:(Pickles_types.Vector.map2 ~f:Set_or_keep.set_or_keep)
       and verification_key =
         update a.permissions.set_verification_key verification_key
           init.verification_key ~is_keep:Set_or_keep.is_keep ~update:(fun u x ->

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -1,9 +1,7 @@
 open Core
 open Async
 open Signature_lib
-open Mina_numbers
 open Mina_base
-open Mina_state
 
 (** For status *)
 let txn_count = ref 0
@@ -274,7 +272,7 @@ let get_status ~flag t =
         None
   in
   let new_block_length_received =
-    Length.to_int @@ Consensus.Data.Consensus_state.blockchain_length
+    Mina_numbers.Length.to_int @@ Consensus.Data.Consensus_state.blockchain_length
     @@ Mina_transition.External_transition.Initial_validated.consensus_state
     @@ Pipe_lib.Broadcast_pipe.Reader.peek
          (Mina_lib.most_recent_valid_transition t)
@@ -292,10 +290,10 @@ let get_status ~flag t =
     in
     let num_accounts = Ledger.num_accounts ledger in
     let%bind state = Mina_lib.best_protocol_state t in
-    let state_hash = Protocol_state.hash state |> State_hash.to_base58_check in
-    let consensus_state = state |> Protocol_state.consensus_state in
+    let state_hash = Mina_state.Protocol_state.hash state |> State_hash.to_base58_check in
+    let consensus_state = state |> Mina_state.Protocol_state.consensus_state in
     let blockchain_length =
-      Length.to_int
+      Mina_numbers.Length.to_int
       @@ Consensus.Data.Consensus_state.blockchain_length consensus_state
     in
     let%map sync_status =

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1,6 +1,5 @@
 open Core
 open Async
-open Graphql_async
 open Mina_base
 open Signature_lib
 open Currency
@@ -40,6 +39,7 @@ let result_of_or_error ?error v =
       | Some error ->
           sprintf "%s (%s)" error str_error)
 
+open Graphql_async
 let result_field_no_inputs ~resolve =
   Schema.io_field ~resolve:(fun resolve_info src ->
       Deferred.return @@ resolve resolve_info src)
@@ -81,7 +81,15 @@ module Reflection = struct
       :: acc)
 
   module Shorthand = struct
-    open Schema
+    open struct
+  open Schema
+  let list = list
+  let int = int
+  let non_null = non_null
+  let string = string
+  let bool = bool
+end
+    
 
     (* Note: Eta expansion is needed here to combat OCaml's weak polymorphism nonsense *)
 
@@ -2550,9 +2558,9 @@ module Types = struct
 end
 
 module Subscriptions = struct
-  open Schema
 
   let new_sync_update =
+    let open Schema in
     subscription_field "newSyncUpdate"
       ~doc:"Event that triggers when the network sync status changes"
       ~deprecated:NotDeprecated
@@ -2563,6 +2571,7 @@ module Subscriptions = struct
         |> Deferred.Result.return)
 
   let new_block =
+    let open Schema in
     subscription_field "newBlock"
       ~doc:
         "Event that triggers when a new block is created that either contains \
@@ -2580,6 +2589,7 @@ module Subscriptions = struct
         @@ Mina_commands.Subscriptions.new_block coda public_key)
 
   let chain_reorganization =
+    let open Schema in
     subscription_field "chainReorganization"
       ~doc:
         "Event that triggers when the best tip changes in a way that is not a \

--- a/src/lib/mina_incremental/mina_incremental.ml
+++ b/src/lib/mina_incremental/mina_incremental.ml
@@ -4,7 +4,6 @@
     dependencies. We have this modue to prevent adding dependencies to
     different functors*)
 
-open Pipe_lib
 open Async_kernel
 
 module Make
@@ -15,6 +14,7 @@ struct
   include Incremental
 
   let to_pipe observer =
+    let open Pipe_lib in
     let reader, writer =
       Strict_pipe.(
         create
@@ -31,6 +31,7 @@ struct
     (Strict_pipe.Reader.to_linear_pipe reader).Linear_pipe.Reader.pipe
 
   let of_broadcast_pipe pipe =
+    let open Pipe_lib in
     let init = Broadcast_pipe.Reader.peek pipe in
     let var = Var.create init in
     Broadcast_pipe.Reader.iter pipe ~f:(fun value ->

--- a/src/lib/mina_lib/coda_subscriptions.ml
+++ b/src/lib/mina_lib/coda_subscriptions.ml
@@ -1,9 +1,7 @@
 open Core_kernel
 open Async_kernel
-open Pipe_lib
 open Mina_base
 open Signature_lib
-open O1trace
 
 type 'a reader_and_writer = 'a Pipe.Reader.t * 'a Pipe.Writer.t
 
@@ -44,6 +42,7 @@ let add_new_subscription (t : t) ~pk =
 let create ~logger ~constraint_constants ~wallets ~new_blocks
     ~transition_frontier ~is_storing_all ~time_controller
     ~upload_blocks_to_gcloud ~precomputed_block_writer =
+  let open Pipe_lib in
   let subscribed_block_users =
     Optional_public_key.Table.of_alist_multi
     @@ List.map (Secrets.Wallets.pks wallets) ~f:(fun wallet ->
@@ -114,7 +113,7 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
         ( Core.Sys.command
             (sprintf "gcloud auth activate-service-account --key-file=%s" path)
           : int )) ;
-  trace_task "subscriptions new block loop" (fun () ->
+  O1trace.trace_task "subscriptions new block loop" (fun () ->
       Strict_pipe.Reader.iter new_blocks ~f:(fun new_block ->
           let hash =
             new_block

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2,13 +2,8 @@ open Core_kernel
 open Async
 open Unsigned
 open Mina_base
-open Mina_transition
 open Pipe_lib
-open Strict_pipe
 open Signature_lib
-open O1trace
-open Otp_lib
-open Network_peer
 module Archive_client = Archive_client
 module Config = Config
 module Conf_dir = Conf_dir
@@ -58,6 +53,7 @@ type processes =
   ; uptime_snark_worker_opt : Uptime_service.Uptime_snark_worker.t option
   }
 
+open Mina_transition
 type components =
   { net : Mina_networking.t
   ; transaction_pool : Network_pool.Transaction_pool.t
@@ -68,6 +64,7 @@ type components =
   ; block_produced_bvar : (Transition_frontier.Breadcrumb.t, read_write) Bvar.t
   }
 
+open Network_peer
 type pipes =
   { validated_transitions_reader :
       External_transition.Validated.t Strict_pipe.Reader.t
@@ -115,6 +112,7 @@ type pipes =
       Strict_pipe.Writer.t
   }
 
+open Otp_lib
 type t =
   { config : Config.t
   ; processes : processes
@@ -413,6 +411,7 @@ exception Offline_shutdown
 let create_sync_status_observer ~logger ~is_seed ~demo_mode ~net
     ~transition_frontier_and_catchup_signal_incr ~online_status_incr
     ~first_connection_incr ~first_message_incr =
+  let open O1trace in
   let open Mina_incremental.Status in
   let restart_delay = Time.Span.of_min 5. in
   let offline_shutdown_delay = Time.Span.of_min 25. in
@@ -763,6 +762,8 @@ let initialization_finish_signal t = t.initialization_finish_signal
  *     items from the identity extension with no route for termination
  *)
 let root_diff t =
+  let open O1trace in
+  let open Strict_pipe in
   let root_diff_reader, root_diff_writer =
     Strict_pipe.create ~name:"root diff"
       (Buffered (`Capacity 30, `Overflow Crash))
@@ -1273,6 +1274,8 @@ let send_resource_pool_diff_or_wait ~rl ~diff_score ~max_per_15_seconds diff =
   able_to_send_or_wait ()
 
 let create ?wallets (config : Config.t) =
+  let open O1trace in
+  let open Strict_pipe in
   let catchup_mode = if config.super_catchup then `Super else `Normal in
   let constraint_constants = config.precomputed_values.constraint_constants in
   let consensus_constants = config.precomputed_values.consensus_constants in

--- a/src/lib/mina_metrics/prometheus_metrics/metric_generators.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/metric_generators.ml
@@ -1,7 +1,5 @@
 open Core_kernel
 open Async_kernel
-open Prometheus
-open Namespace
 
 module type Metric_spec_intf = sig
   val subsystem : string
@@ -32,7 +30,7 @@ end
 module type Moving_average_metric_intf = sig
   type datum
 
-  val v : Gauge.t
+  val v : Prometheus.Gauge.t
 
   val update : datum -> unit
 
@@ -43,7 +41,7 @@ module Moving_bucketed_average (Spec : Bucketed_average_spec_intf) () :
   Moving_average_metric_intf with type datum := float = struct
   open Spec
 
-  let v = Gauge.v name ~subsystem ~namespace ~help
+  let v = Prometheus.Gauge.v name ~subsystem ~Namespace.namespace ~help
 
   let empty_bucket_entry = (0.0, 0)
 
@@ -68,7 +66,7 @@ module Moving_bucketed_average (Spec : Bucketed_average_spec_intf) () :
         (fun () ->
           if Option.is_none !buckets then buckets := Some (empty_buckets ()) ;
           let buckets_val = Option.value_exn !buckets in
-          Gauge.set v (render_average buckets_val) ;
+          Prometheus.Gauge.set v (render_average buckets_val) ;
           buckets :=
             Some (empty_bucket_entry :: List.take buckets_val (num_buckets - 1)) ;
           tick ())

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -7,7 +7,11 @@ open Core_kernel
 *)
 include Prometheus
 open Prometheus
-open Namespace
+open struct
+  open Namespace
+  let namespace = namespace
+end
+
 open Metric_generators
 open Async_kernel
 

--- a/src/lib/mina_net2/keypair.ml
+++ b/src/lib/mina_net2/keypair.ml
@@ -1,11 +1,11 @@
 open Core
 open Async
-open Network_peer
 
 [%%versioned
 module Stable = struct
   module V1 = struct
-    type t = { secret : string; public : string; peer_id : Peer.Id.Stable.V1.t }
+    type t = { secret : string; public : string; peer_id : let open Network_peer in
+                                                           Peer.Id.Stable.V1.t }
 
     let to_latest = Fn.id
   end
@@ -14,6 +14,7 @@ end]
 let secret { secret; _ } = secret
 
 let generate_random helper =
+  let open Network_peer in
   match%map
     Libp2p_helper.do_rpc helper
       (module Libp2p_ipc.Rpcs.GenerateKeypair)
@@ -44,10 +45,12 @@ let of_b64_data s =
 let to_b64_data (s : string) = Base64.encode_string ~pad:true s
 
 let to_string ({ secret; public; peer_id } : t) =
+  let open Network_peer in
   String.concat ~sep:","
     [ to_b64_data secret; to_b64_data public; Peer.Id.to_string peer_id ]
 
 let of_string s =
+  let open Network_peer in
   let parse_with_sep sep =
     match String.split s ~on:sep with
     | [ secret_b64; public_b64; peer_id ] ->

--- a/src/lib/mina_net2/libp2p_stream.ml
+++ b/src/lib/mina_net2/libp2p_stream.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Async_kernel
-open Network_peer
 
 type participant = Us | Them [@@deriving equal, show]
 
@@ -22,7 +21,7 @@ type t =
   { protocol : string
   ; id : Libp2p_ipc.stream_id
   ; mutable state : state
-  ; peer : Peer.t
+  ; peer : Network_peer.Peer.t
   ; incoming_r : string Pipe.Reader.t
   ; incoming_w : string Pipe.Writer.t
   ; outgoing_w : string Pipe.Writer.t

--- a/src/lib/mina_net2/multiaddr.ml
+++ b/src/lib/mina_net2/multiaddr.ml
@@ -1,5 +1,4 @@
 open Core
-open Network_peer
 
 type t = string [@@deriving compare, bin_io_unversioned]
 
@@ -17,7 +16,7 @@ let to_peer t =
       try
         let host = Unix.Inet_addr.of_string ip4_str in
         let libp2p_port = Int.of_string tcp_str in
-        Some (Peer.create host ~libp2p_port ~peer_id)
+        Some (Network_peer.Peer.create host ~libp2p_port ~peer_id)
       with _ -> None )
   | _ ->
       None

--- a/src/lib/mina_net2/tests/all_ipc.ml
+++ b/src/lib/mina_net2/tests/all_ipc.ml
@@ -20,7 +20,6 @@ All upcalls and RPC request/response pairs are tested this way. *)
 
 open Core
 open Async
-open Mina_net2
 
 (* Only show stdout for failed inline tests. *)
 open Inline_test_quiet_logs
@@ -87,6 +86,7 @@ let%test_module "all-ipc test" =
       ; stream_2_msg_1 : string
       }
 
+    open Mina_net2
     let check_msg (env : 'a Network_peer.Envelope.Incoming.t) cb has_received
         expected_sender vr =
       assert (not !has_received) ;

--- a/src/lib/mina_net2/tests/tests.ml
+++ b/src/lib/mina_net2/tests/tests.ml
@@ -1,6 +1,5 @@
 open Core
 open Async
-open Mina_net2
 
 (* Only show stdout for failed inline tests. *)
 open Inline_test_quiet_logs
@@ -16,6 +15,7 @@ let%test_module "coda network tests" =
     let pids = Child_processes.Termination.create_pid_table ()
 
     let setup_two_nodes network_id =
+      let open Mina_net2 in
       let%bind a_tmp = Unix.mkdtemp "p2p_helper_test_a" in
       let%bind b_tmp = Unix.mkdtemp "p2p_helper_test_b" in
       let%bind c_tmp = Unix.mkdtemp "p2p_helper_test_c" in
@@ -101,6 +101,7 @@ let%test_module "coda network tests" =
 
     (* TODO fails occasionally, uncomment after debugging it *)
     let%test_unit "b_stream_c" =
+      let open Mina_net2 in
       let () = Core.Backtrace.elide := false in
       let test_def =
         let open Deferred.Let_syntax in
@@ -160,6 +161,7 @@ let%test_module "coda network tests" =
       Async.Thread_safe.block_on_async_exn (fun () -> test_def)
 
     let%test_unit "stream" =
+      let open Mina_net2 in
       let () = Core.Backtrace.elide := false in
       let test_def =
         let open Deferred.Let_syntax in

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -1,11 +1,8 @@
 open Core
 open Async
 open Mina_base
-open Mina_state
-open Mina_transition
 open Network_peer
 open Network_pool
-open Pipe_lib
 
 let refused_answer_query_string = "Refused to answer_query"
 
@@ -55,6 +52,7 @@ type Structured_log_events.t +=
  *      new constructor to the new module for your RPC
  *   - add a match case to `match_handler`, below
  *)
+open Mina_transition
 module Rpcs = struct
   (* for versioning of the types here, see
 
@@ -1029,6 +1027,7 @@ module Config = struct
   [@@deriving make]
 end
 
+open Pipe_lib
 type t =
   { logger : Logger.t
   ; trust_system : Trust_system.t
@@ -1503,8 +1502,8 @@ let create (config : Config.t)
               (Core.Time.abs_diff
                  Block_time.(now config.time_controller |> to_time)
                  ( External_transition.protocol_state state
-                 |> Protocol_state.blockchain_state
-                 |> Blockchain_state.timestamp |> Block_time.to_time )) ;
+                 |> Mina_state.Protocol_state.blockchain_state
+                 |> Mina_state.Blockchain_state.timestamp |> Block_time.to_time )) ;
             Mina_metrics.(Gauge.inc_one Network.new_state_received) ;
             if config.log_gossip_heard.new_state then
               [%str_log info]

--- a/src/lib/mina_numbers/intf.ml
+++ b/src/lib/mina_numbers/intf.ml
@@ -1,13 +1,10 @@
 [%%import "/src/config.mlh"]
 
 open Core_kernel
-open Fold_lib
-open Tuple_lib
 open Unsigned
 
 [%%ifdef consensus_mechanism]
 
-open Snark_bits
 open Snark_params.Tick
 
 [%%else]
@@ -58,7 +55,7 @@ module type S_unchecked = sig
 
   val to_string : t -> string
 
-  module Bits : Bits_intf.Convertible_bits with type t := t
+  module Bits : Snark_bits.Bits_intf.Convertible_bits with type t := t
 
   val to_bits : t -> bool list
 
@@ -68,7 +65,7 @@ module type S_unchecked = sig
 
   val to_input_legacy : t -> (_, bool) Random_oracle.Legacy.Input.t
 
-  val fold : t -> bool Triple.t Fold.t
+  val fold : t -> bool Tuple_lib.Triple.t Fold_lib.Fold.t
 end
 
 [%%ifdef consensus_mechanism]
@@ -202,14 +199,14 @@ module type F = functor
 
      val random : unit -> t
    end)
-  (Bits : Bits_intf.Convertible_bits with type t := N.t)
+  (Bits : Snark_bits.Bits_intf.Convertible_bits with type t := N.t)
   -> S with type t := N.t and module Bits := Bits
 
 [%%ifdef consensus_mechanism]
 
 module type F_checked = functor
   (N : Unsigned_extended.S)
-  (Bits : Bits_intf.Convertible_bits with type t := N.t)
+  (Bits : Snark_bits.Bits_intf.Convertible_bits with type t := N.t)
   -> S_checked with type unchecked := N.t
 [@@warning "-67"]
 

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Mina_base
-open Snark_params.Tick
 
 module Poly = struct
   [%%versioned
@@ -61,6 +60,7 @@ let create_value ~staged_ledger_hash ~snarked_ledger_hash ~genesis_ledger_hash
   ; timestamp
   }
 
+open Snark_params.Tick
 let data_spec =
   let open Data_spec in
   [ Staged_ledger_hash.typ

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -1,9 +1,7 @@
 open Core_kernel
 open Async_kernel
-open Network_peer
 
 (* Only show stdout for failed inline tests. *)
-open Inline_test_quiet_logs
 
 module Id = Unique_id.Int ()
 
@@ -214,6 +212,7 @@ let verify (type p r partial) (t : (p, partial, r) t) (proof : p) :
 
 type ('a, 'b, 'c) batcher = ('a, 'b, 'c) t [@@deriving sexp]
 
+open Network_peer
 let compare_envelope (e1 : _ Envelope.Incoming.t) (e2 : _ Envelope.Incoming.t) =
   Envelope.Sender.compare e1.sender e2.sender
 
@@ -338,6 +337,7 @@ module Transaction_pool = struct
   let verify (t : t) = verify t
 end
 
+open Inline_test_quiet_logs
 module Snark_pool = struct
   type proof_envelope =
     (Ledger_proof.t One_or_two.t * Mina_base.Sok_message.t) Envelope.Incoming.t

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1019,7 +1019,6 @@ open Inline_test_quiet_logs
 
 let%test_module _ =
   ( module struct
-    open For_tests
 
     let test_keys = Array.init 10 ~f:(fun _ -> Signature_lib.Keypair.create ())
 
@@ -1043,7 +1042,7 @@ let%test_module _ =
     let empty =
       empty ~constraint_constants ~consensus_constants ~time_controller
 
-    let%test_unit "empty invariants" = assert_invariants empty
+    let%test_unit "empty invariants" = For_tests.assert_invariants empty
 
     let don't_verify _ = None
 
@@ -1067,7 +1066,7 @@ let%test_module _ =
           else
             match add_res with
             | Ok (_, pool', dropped) ->
-                assert_invariants pool' ;
+                For_tests.assert_invariants pool' ;
                 assert (Sequence.is_empty dropped) ;
                 [%test_eq: int] (size pool') 1 ;
                 [%test_eq:
@@ -1137,7 +1136,7 @@ let%test_module _ =
                     [%test_eq:
                       Transaction_hash.User_command_with_valid_signature.t
                       Sequence.t] dropped Sequence.empty ;
-                    assert_invariants pool' ;
+                    For_tests.assert_invariants pool' ;
                     pool := pool' ;
                     go rest
                 | Error (Invalid_nonce (`Expected want, got)) ->
@@ -1356,7 +1355,7 @@ let%test_module _ =
             match add_res with
             | Ok (_, t', dropped) ->
                 assert (not (Sequence.is_empty dropped)) ;
-                assert_invariants t'
+                For_tests.assert_invariants t'
             | Error _ ->
                 failwith "adding command failed"
           else

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -2,7 +2,6 @@ open Async_kernel
 open Core_kernel
 open Mina_base
 open Pipe_lib
-open Network_peer
 
 (** A [Resource_pool_base_intf] is a mutable pool of resources that supports
  *  mutation via some [Resource_pool_diff_intf]. A [Resource_pool_base_intf]
@@ -45,6 +44,7 @@ end
  *  perform on a [Resource_pool_base_intf]. It includes the logic for
  *  processing this mutation and applying it to an underlying
  *  [Resource_pool_base_intf]. *)
+open Network_peer
 module type Resource_pool_diff_intf = sig
   type pool
 

--- a/src/lib/network_pool/mocks.ml
+++ b/src/lib/network_pool/mocks.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Async_kernel
-open Pipe_lib
 open Mina_base
 
 let trust_system = Trust_system.null ()
@@ -44,6 +43,7 @@ module Transition_frontier = struct
     let staged_ledger = Fn.id
   end
 
+  open Pipe_lib
   type t =
     { refcount_table : table
     ; best_tip_table : Transaction_snark_work.Statement.Hash_set.t

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -3,7 +3,6 @@ open Async_kernel
 module Work = Transaction_snark_work.Statement
 module Ledger_proof = Ledger_proof
 module Work_info = Transaction_snark_work.Info
-open Network_peer
 
 module Rejected = struct
   [%%versioned
@@ -96,7 +95,7 @@ module Make
         "Rejecting snark work $work from $sender: $reason"
         ~metadata:
           [ ("work", Work.compact_json work)
-          ; ("sender", Envelope.Sender.to_yojson sender)
+          ; ("sender", Network_peer.Envelope.Sender.to_yojson sender)
           ; ("reason", `String reason)
           ] ;
       Or_error.error_string reason
@@ -115,7 +114,7 @@ module Make
         | _ ->
             failwith "compare didn't return -1, 0, or 1!" )
 
-  let verify pool ({ data; sender; _ } as t : t Envelope.Incoming.t) =
+  let verify pool ({ data; sender; _ } as t : t Network_peer.Envelope.Incoming.t) =
     match data with
     | Empty ->
         Deferred.Or_error.error_string "cannot verify empty snark pool diff"
@@ -136,8 +135,8 @@ module Make
               Deferred.return (Error e) )
 
   (* This is called after verification has occurred.*)
-  let unsafe_apply (pool : Pool.t) (t : t Envelope.Incoming.t) =
-    let { Envelope.Incoming.data = diff; sender; _ } = t in
+  let unsafe_apply (pool : Pool.t) (t : t Network_peer.Envelope.Incoming.t) =
+    let Network_peer.{ Envelope.Incoming.data = diff; sender; _ } = t in
     match diff with
     | Empty ->
         Deferred.return

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -8,7 +8,6 @@ open Async
 open Mina_base
 open Pipe_lib
 open Signature_lib
-open Network_peer
 
 let max_per_15_seconds = 10
 
@@ -197,6 +196,7 @@ end
 
 (* Functor over user command, base ledger and transaction validator for
    mocking. *)
+open Network_peer
 module Make0
     (Base_ledger : Intf.Base_ledger_intf) (Staged_ledger : sig
       type t

--- a/src/lib/node_status_service/node_status_service.ml
+++ b/src/lib/node_status_service/node_status_service.ml
@@ -1,6 +1,5 @@
 open Async
 open Core
-open Pipe_lib
 
 type catchup_job_states =
   { finished : int
@@ -159,7 +158,7 @@ let start ~logger ~node_status_url ~transition_frontier ~sync_status ~network
   @@ fun () ->
   don't_wait_for
   @@
-  match Broadcast_pipe.Reader.peek transition_frontier with
+  match Pipe_lib.Broadcast_pipe.Reader.peek transition_frontier with
   | None ->
       [%log info] "Transition frontier not available for node status service" ;
       Deferred.unit

--- a/src/lib/otp_lib/capped_supervisor.ml
+++ b/src/lib/otp_lib/capped_supervisor.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 open Async_kernel
-open Pipe_lib
-open Strict_pipe
+open Pipe_lib.Strict_pipe
 
 type 'data t =
   { job_writer : ('data, crash buffered, unit) Writer.t
@@ -10,7 +9,7 @@ type 'data t =
 
 let create ?(buffer_capacity = 30) ~job_capacity f =
   let job_reader, job_writer =
-    Strict_pipe.create (Buffered (`Capacity buffer_capacity, `Overflow Crash))
+    Pipe_lib.Strict_pipe.create (Buffered (`Capacity buffer_capacity, `Overflow Crash))
   in
   let active_jobs = ref 0 in
   let pending_jobs = ref [] in

--- a/src/lib/pickles/common.ml
+++ b/src/lib/pickles/common.ml
@@ -122,7 +122,6 @@ let or_infinite_conv :
       Infinity
 
 module Ipa = struct
-  open Backend
 
   (* TODO: Make all this completely generic over backend *)
 
@@ -136,7 +135,7 @@ module Ipa = struct
 
   module Wrap = struct
     let field =
-      (module Tock.Field : Kimchi_backend.Field.S with type t = Tock.Field.t)
+      (module Backend.Tock.Field : Kimchi_backend.Field.S with type t = Backend.Tock.Field.t)
 
     let endo_to_field = Endo.Step_inner_curve.to_field
 
@@ -155,7 +154,7 @@ module Ipa = struct
 
   module Step = struct
     let field =
-      (module Tick.Field : Kimchi_backend.Field.S with type t = Tick.Field.t)
+      (module Backend.Tick.Field : Kimchi_backend.Field.S with type t = Backend.Tick.Field.t)
 
     let endo_to_field = Endo.Wrap_inner_curve.to_field
 

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -30,8 +30,7 @@ module Dlog_based = struct
           end]
         end
 
-        open Pickles_types
-        module Generic_coeffs_vec = Vector.With_length (Nat.N5)
+        module Generic_coeffs_vec = Pickles_types.Vector.With_length (Pickles_types.Nat.N5)
 
         module In_circuit = struct
           type ('challenge, 'scalar_challenge, 'fp) t =
@@ -72,7 +71,7 @@ module Dlog_based = struct
             ; endomul = f t.endomul
             ; endomul_scalar = f t.endomul_scalar
             ; perm = f t.perm
-            ; generic = Vector.map ~f t.generic
+            ; generic = Pickles_types.Vector.map ~f t.generic
             }
 
           let typ (type f fp) ~challenge ~scalar_challenge
@@ -90,7 +89,7 @@ module Dlog_based = struct
               ; fp
               ; fp
               ; fp
-              ; Vector.typ fp Nat.N5.n
+              ; Pickles_types.Vector.typ fp Pickles_types.Nat.N5.n
               ]
               ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
               ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist

--- a/src/lib/pickles/dummy.ml
+++ b/src/lib/pickles/dummy.ml
@@ -1,8 +1,5 @@
 open Core_kernel
 open Pickles_types
-open Backend
-open Composition_types
-open Common
 
 let wrap_domains = Common.wrap_domains
 
@@ -24,31 +21,33 @@ let evals_combined =
 module Ipa = struct
   module Wrap = struct
     let challenges =
-      Vector.init Tock.Rounds.n ~f:(fun _ ->
+      let open Composition_types in
+      Vector.init Backend.Tock.Rounds.n ~f:(fun _ ->
           let prechallenge = Ro.scalar_chal () in
           { Bulletproof_challenge.prechallenge })
 
     let challenges_computed =
-      Vector.map challenges ~f:(fun { prechallenge } : Tock.Field.t ->
-          Ipa.Wrap.compute_challenge prechallenge)
+      Vector.map challenges ~f:(fun { prechallenge } : Backend.Tock.Field.t ->
+          Common.Ipa.Wrap.compute_challenge prechallenge)
 
     let sg =
       lazy
-        (Common.time "dummy wrap sg" (fun () -> Ipa.Wrap.compute_sg challenges))
+        (Common.time "dummy wrap sg" (fun () -> Common.Ipa.Wrap.compute_sg challenges))
   end
 
   module Step = struct
     let challenges =
-      Vector.init Tick.Rounds.n ~f:(fun _ ->
+      let open Composition_types in
+      Vector.init Backend.Tick.Rounds.n ~f:(fun _ ->
           let prechallenge = Ro.scalar_chal () in
           { Bulletproof_challenge.prechallenge })
 
     let challenges_computed =
-      Vector.map challenges ~f:(fun { prechallenge } : Tick.Field.t ->
-          Ipa.Step.compute_challenge prechallenge)
+      Vector.map challenges ~f:(fun { prechallenge } : Backend.Tick.Field.t ->
+          Common.Ipa.Step.compute_challenge prechallenge)
 
     let sg =
       lazy
-        (Common.time "dummy wrap sg" (fun () -> Ipa.Step.compute_sg challenges))
+        (Common.time "dummy wrap sg" (fun () -> Common.Ipa.Step.compute_sg challenges))
   end
 end

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -1,4 +1,3 @@
-open Pickles_types
 open Core_kernel
 open Import
 open Backend
@@ -119,8 +118,8 @@ module Step = struct
       Spec.packed_typ
         (module Impl)
         (T
-           ( Shifted_value.Type2.typ Other_field.typ_unchecked
-           , fun (Shifted_value.Type2.Shifted_value x as t) ->
+           ( Pickles_types.Shifted_value.Type2.typ Other_field.typ_unchecked
+           , fun (Pickles_types.Shifted_value.Type2.Shifted_value x as t) ->
                Impl.run_checked (Other_field.check x) ;
                t ))
         spec
@@ -200,7 +199,7 @@ module Wrap = struct
       Spec.packed_typ
         (module Impl)
         (T
-           ( Shifted_value.Type1.typ fp
+           ( Pickles_types.Shifted_value.Type1.typ fp
            , fun (Shifted_value x as t) ->
                Impl.run_checked (Other_field.check x) ;
                t ))

--- a/src/lib/pickles/intf.ml
+++ b/src/lib/pickles/intf.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-open Pickles_types
 module Sponge_lib = Sponge
 
 module Snarkable = struct
@@ -126,9 +125,9 @@ module Evals = struct
   module type S = sig
     type n
 
-    val n : n Vector.nat
+    val n : n Pickles_types.Vector.nat
 
-    include Binable.S1 with type 'a t = ('a, n) Vector.t
+    include Binable.S1 with type 'a t = ('a, n) Pickles_types.Vector.t
 
     include Snarkable.S1 with type 'a t := 'a t
   end
@@ -227,7 +226,7 @@ module type Inputs_base = sig
   module Other_field : sig
     type t = Inner_curve.Constant.Scalar.t [@@deriving sexp]
 
-    include Shifted_value.Field_intf with type t := t
+    include Pickles_types.Shifted_value.Field_intf with type t := t
 
     val to_bigint : t -> Impl.Bigint.t
 

--- a/src/lib/pickles/opt_sponge.ml
+++ b/src/lib/pickles/opt_sponge.ml
@@ -29,7 +29,6 @@ module Make
     (Impl : Snarky_backendless.Snark_intf.Run with type prover_state = unit)
     (P : Sponge.Intf.Permutation with type Field.t = Impl.Field.t) =
 struct
-  open P
   open Impl
 
   type nonrec t = Field.t t
@@ -212,7 +211,7 @@ struct
     match t.sponge_state with
     | Squeezed n ->
         if n = rate then (
-          t.state <- block_cipher t.params t.state ;
+          t.state <- P.block_cipher t.params t.state ;
           t.sponge_state <- Squeezed 1 ;
           t.state.(0) )
         else (

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -14,12 +14,8 @@ module SC = Scalar_challenge
 open Core_kernel
 open Async_kernel
 open Import
-open Types
 open Pickles_types
-open Poly_types
-open Hlist
 open Common
-open Backend
 module Backend = Backend
 module Sponge_inputs = Sponge_inputs
 module Util = Util
@@ -120,6 +116,7 @@ let verify = Verify.verify
       and use *that* in the "verifies" computation.
 *)
 
+open Hlist
 let pad_local_max_branchings
     (type prev_varss prev_valuess env max_branching branches)
     (max_branching : max_branching Nat.t)
@@ -166,6 +163,7 @@ module Statement_with_proof = struct
     's * ('max_width, 'max_width) Proof.t
 end
 
+open Types
 let pad_pass_throughs
     (type local_max_branchings max_local_max_branchings max_branching)
     (module M : Hlist.Maxes.S
@@ -337,7 +335,7 @@ module Make (A : Statement_var_intf) (A_value : Statement_value_intf) = struct
     let padded = V.f branches (M.f choices) |> Vector.transpose in
     (padded, Maxes.m padded)
 
-  module Lazy_ (A : T0) = struct
+  module Lazy_ (A : Poly_types.T0) = struct
     type t = A.t Lazy.t
   end
 
@@ -549,7 +547,7 @@ module Make (A : Statement_var_intf) (A_value : Statement_value_intf) = struct
           (struct
             let etyp =
               Impls.Step.input ~branching:Max_branching.n
-                ~wrap_rounds:Tock.Rounds.n
+                ~wrap_rounds:Backend.Tock.Rounds.n
 
             let f (T b : _ Branch_data.t) =
               let (T (typ, conv)) = etyp in
@@ -608,7 +606,7 @@ module Make (A : Statement_var_intf) (A_value : Statement_value_intf) = struct
       let module V = H4.To_vector (Lazy_keys) in
       lazy
         (Vector.map (V.f prev_varss_length step_keypairs) ~f:(fun (_, vk) ->
-             Tick.Keypair.vk_commitments (fst (Lazy.force vk))))
+             Backend.Tick.Keypair.vk_commitments (fst (Lazy.force vk))))
     in
     Timer.clock __LOC__ ;
     let wrap_requests, wrap_main =
@@ -980,9 +978,9 @@ module Proof0 = Proof
 
 let%test_module "test no side-loaded" =
   ( module struct
-    let () = Tock.Keypair.set_urs_info []
+    let () = Backend.Tock.Keypair.set_urs_info []
 
-    let () = Tick.Keypair.set_urs_info []
+    let () = Backend.Tick.Keypair.set_urs_info []
 
     open Impls.Step
 

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 open Pickles_types
 open Pickles_base
-open Tuple_lib
 module Scalars = Scalars
 module Domain = Domain
 
@@ -85,7 +84,7 @@ let actual_evaluation (type f) (module Field : Field_intf with type t = f)
       failwith "empty list"
 
 let evals_of_split_evals field ~zeta ~zetaw
-    ((es1, es2) : _ Dlog_plonk_types.Evals.t Double.t) ~rounds =
+    ((es1, es2) : _ Dlog_plonk_types.Evals.t Tuple_lib.Double.t) ~rounds =
   let e = Fn.flip (actual_evaluation field ~rounds) in
   Dlog_plonk_types.Evals.(map es1 ~f:(e zeta), map es2 ~f:(e zetaw))
 
@@ -94,7 +93,7 @@ open Composition_types.Dlog_based.Proof_state.Deferred_values.Plonk
 let scalars_env (type c t) (module F : Field_intf with type t = t) ~endo ~mds
     ~field_of_hex ~domain ~srs_length_log2
     ({ alpha; beta = _; gamma = _; zeta } : (c, _) Minimal.t)
-    ((e0, e1) : _ Dlog_plonk_types.Evals.t Double.t) =
+    ((e0, e1) : _ Dlog_plonk_types.Evals.t Tuple_lib.Double.t) =
   let w0 = Vector.to_array e0.w in
   let w1 = Vector.to_array e1.w in
   let var (col, row) =
@@ -175,7 +174,7 @@ let perm_alpha0 : int = 2 + 15
 module Make (Shifted_value : Shifted_value.S) (Sc : Scalars.S) = struct
   let ft_eval0 (type t) (module F : Field_intf with type t = t) ~domain
       ~(env : t Scalars.Env.t) ({ alpha = _; beta; gamma; zeta } : _ Minimal.t)
-      ((e0, e1) : _ Dlog_plonk_types.Evals.t Double.t) p_eval0 =
+      ((e0, e1) : _ Dlog_plonk_types.Evals.t Tuple_lib.Double.t) p_eval0 =
     let zkp = env.zk_polynomial in
     let alpha_pow = env.alpha_pow in
     let zeta1m1 = env.zeta_to_n_minus_1 in
@@ -215,7 +214,7 @@ module Make (Shifted_value : Shifted_value.S) (Sc : Scalars.S) = struct
     let _ = with_label in
     let open F in
     fun ({ alpha; beta; gamma; zeta } : _ Minimal.t)
-        ((e0, e1) : _ Dlog_plonk_types.Evals.t Double.t) ->
+        ((e0, e1) : _ Dlog_plonk_types.Evals.t Tuple_lib.Double.t) ->
       let zkp = env.zk_polynomial in
       let index_terms = Sc.index_terms env in
       let alpha_pow = env.alpha_pow in

--- a/src/lib/pickles/plonk_checks/scalars.ml
+++ b/src/lib/pickles/plonk_checks/scalars.ml
@@ -24,8 +24,6 @@ module Column = struct
   include T
 end
 
-open Gate_type
-open Column
 
 module Env = struct
   type 'a t =
@@ -75,6 +73,8 @@ module Tick : S = struct
        ; srs_length_log2 = _
        } :
         a Env.t) =
+    let open Column in
+    let open Gate_type in
     let x_0 = pow (cell (var (Witness 0, Curr)), 7) in
     let x_1 = pow (cell (var (Witness 1, Curr)), 7) in
     let x_2 = pow (cell (var (Witness 2, Curr)), 7) in
@@ -156,6 +156,8 @@ module Tick : S = struct
        ; srs_length_log2 = _
        } :
         a Env.t) =
+    let open Column in
+    let open Gate_type in
     Column.Table.of_alist_exn
       [ ( Index CompleteAdd
         , lazy
@@ -1066,6 +1068,8 @@ module Tock : S = struct
        ; srs_length_log2 = _
        } :
         a Env.t) =
+    let open Column in
+    let open Gate_type in
     let x_0 = pow (cell (var (Witness 0, Curr)), 7) in
     let x_1 = pow (cell (var (Witness 1, Curr)), 7) in
     let x_2 = pow (cell (var (Witness 2, Curr)), 7) in
@@ -1147,6 +1151,8 @@ module Tock : S = struct
        ; srs_length_log2 = _
        } :
         a Env.t) =
+    let open Column in
+    let open Gate_type in
     Column.Table.of_alist_exn
       [ ( Index CompleteAdd
         , lazy

--- a/src/lib/pickles/plonk_curve_ops.ml
+++ b/src/lib/pickles/plonk_curve_ops.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 
-open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 
 let seal i = Tuple_lib.Double.map ~f:(Util.seal i)
 
@@ -9,6 +8,7 @@ let add_fast (type f)
     ?(check_finite = true) ((x1, y1) as p1) ((x2, y2) as p2) :
     Impl.Field.t * Impl.Field.t =
   let p1 = seal (module Impl) p1 in
+  let open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint in
   let p2 = seal (module Impl) p2 in
   let open Impl in
   let open Field.Constant in
@@ -78,6 +78,7 @@ struct
       (Pickles_types.Shifted_value.Type1.Shifted_value (scalar : Field.t))
       ~num_bits : (Field.t * Field.t) * Boolean.var array =
     let ((x_base, y_base) as base) = seal base in
+    let open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint in
     let ( !! ) = As_prover.read_var in
     let mk f = exists Field.typ ~compute:f in
     (* MSB bits *)

--- a/src/lib/pickles/precomputed/gen_values/gen_values.ml
+++ b/src/lib/pickles/precomputed/gen_values/gen_values.ml
@@ -1,12 +1,7 @@
-open Ppxlib
-open Asttypes
-open Parsetree
-open Longident
 open Core_kernel
-open Kimchi_pasta.Pasta
-open Pickles_types
 
 let () =
+  let open Kimchi_pasta.Pasta in
   Vesta_based_plonk.Keypair.set_urs_info [] ;
   Pallas_based_plonk.Keypair.set_urs_info []
 
@@ -26,7 +21,8 @@ let unwrap = function
 let max_public_input_size = 128
 
 let vesta =
-  let max_domain_log2 = Nat.to_int Vesta_based_plonk.Rounds.n in
+  let open Kimchi_pasta.Pasta in
+  let max_domain_log2 = Pickles_types.Nat.to_int Vesta_based_plonk.Rounds.n in
   List.map
     (List.range ~start:`inclusive ~stop:`inclusive 1 max_domain_log2)
     ~f:(fun d ->
@@ -41,7 +37,8 @@ let vesta =
           |> unwrap))
 
 let pallas =
-  let max_domain_log2 = Nat.to_int Pallas_based_plonk.Rounds.n in
+  let open Kimchi_pasta.Pasta in
+  let max_domain_log2 = Pickles_types.Nat.to_int Pallas_based_plonk.Rounds.n in
   List.map
     (List.range ~start:`inclusive ~stop:`inclusive 1 max_domain_log2)
     ~f:(fun d ->
@@ -57,7 +54,7 @@ let pallas =
 
 let mk xss ~f =
   let module E = Ppxlib.Ast_builder.Make (struct
-    let loc = Location.none
+    let loc = Ppxlib.Location.none
   end) in
   let open E in
   pexp_array
@@ -65,6 +62,10 @@ let mk xss ~f =
          pexp_array (List.map xs ~f:(fun g -> pexp_array (List.map g ~f)))))
 
 let structure =
+  let open Kimchi_pasta.Pasta in
+  let open Longident in
+  let open Parsetree in
+  let open Asttypes in
   let loc = Ppxlib.Location.none in
   let module E = Ppxlib.Ast_builder.Make (struct
     let loc = loc
@@ -94,7 +95,8 @@ let structure =
     end]
 
 let () =
+  let open Parsetree in
   let target = Sys.argv.(1) in
   let fmt = Format.formatter_of_out_channel (Out_channel.create target) in
-  Pprintast.top_phrase fmt (Ptop_def structure) ;
+  Ppxlib.Pprintast.top_phrase fmt (Ptop_def structure) ;
   exit 0

--- a/src/lib/pickles/reduced_me_only.ml
+++ b/src/lib/pickles/reduced_me_only.ml
@@ -2,8 +2,6 @@ open Core_kernel
 open Import
 open Pickles_types
 open Types
-open Common
-open Backend
 
 (* The pairing-based "reduced" me-only contains the data of the standard me-only
    but without the wrap verification key. The purpose of this type is for sending
@@ -24,7 +22,7 @@ module Pairing_based = struct
     ; sg
     ; dlog_plonk_index
     ; old_bulletproof_challenges =
-        Vector.map ~f:Ipa.Step.compute_challenges old_bulletproof_challenges
+        Vector.map ~f:Common.Ipa.Step.compute_challenges old_bulletproof_challenges
     }
 end
 
@@ -58,18 +56,18 @@ module Dlog_based = struct
       ()
 
     module Prepared = struct
-      type t = (Tock.Field.t, Tock.Rounds.n) Vector.t
+      type t = (Backend.Tock.Field.t, Backend.Tock.Rounds.n) Vector.t
     end
   end
 
   type 'max_local_max_branching t =
-    ( Tock.Inner_curve.Affine.t
+    ( Backend.Tock.Inner_curve.Affine.t
     , (Challenges_vector.t, 'max_local_max_branching) Vector.t )
     Dlog_based.Proof_state.Me_only.t
 
   module Prepared = struct
     type 'max_local_max_branching t =
-      ( Tock.Inner_curve.Affine.t
+      ( Backend.Tock.Inner_curve.Affine.t
       , (Challenges_vector.Prepared.t, 'max_local_max_branching) Vector.t )
       Dlog_based.Proof_state.Me_only.t
   end
@@ -77,6 +75,6 @@ module Dlog_based = struct
   let prepare ({ sg; old_bulletproof_challenges } : _ t) =
     { Dlog_based.Proof_state.Me_only.sg
     ; old_bulletproof_challenges =
-        Vector.map ~f:Ipa.Wrap.compute_challenges old_bulletproof_challenges
+        Vector.map ~f:Common.Ipa.Wrap.compute_challenges old_bulletproof_challenges
     }
 end

--- a/src/lib/pickles/scalar_challenge.ml
+++ b/src/lib/pickles/scalar_challenge.ml
@@ -1,6 +1,5 @@
 open Core_kernel
-open Import
-module SC = Scalar_challenge
+module SC = Import.Scalar_challenge
 
 (* Implementation of the algorithm described on page 29 of the Halo paper
    https://eprint.iacr.org/2019/1021.pdf
@@ -137,7 +136,7 @@ let to_field_checked (type f) ?num_bits
 
 let to_field_constant (type f) ~endo
     (module F : Plonk_checks.Field_intf with type t = f) { SC.inner = c } =
-  let bits = Array.of_list (Challenge.Constant.to_bits c) in
+  let bits = Array.of_list (Import.Challenge.Constant.to_bits c) in
   let a = ref (F.of_int 2) in
   let b = ref (F.of_int 2) in
   let one = F.of_int 1 in
@@ -176,7 +175,7 @@ let test (type f)
             to_field_constant
               (module Field.Constant)
               ~endo
-              (SC.create (Challenge.Constant.of_bits s)))
+              (SC.create (Import.Challenge.Constant.of_bits s)))
           xs
       with e ->
         eprintf !"Input %{sexp: bool list}\n%!" xs ;
@@ -185,7 +184,7 @@ let test (type f)
 module Make
     (Impl : Snarky_backendless.Snark_intf.Run with type prover_state = unit)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t)
-    (Challenge : Challenge.S with module Impl := Impl) (Endo : sig
+    (Challenge : Import.Challenge.S with module Impl := Impl) (Endo : sig
       val base : Impl.Field.Constant.t
 
       val scalar : G.Constant.Scalar.t

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -26,7 +26,6 @@
 open Core_kernel
 open Pickles_types
 open Common
-open Import
 module V = Pickles_base.Side_loaded_verification_key
 
 include (
@@ -286,6 +285,7 @@ module Checked = struct
   open Step_main_inputs
   open Impl
 
+  open Import
   type t =
     { step_domains : (Field.t Domain.t Domains.t, Max_branches.n) Vector.t
           (** The domain size for proofs of each branch. *)

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -3,28 +3,24 @@ open Core_kernel
 open Async_kernel
 module P = Proof
 open Pickles_types
-open Poly_types
 open Hlist
 open Backend
-open Tuple_lib
 open Import
-open Types
-open Common
 
 (* This contains the "step" prover *)
 
 module Make
-    (A : T0) (A_value : sig
+    (A : Poly_types.T0) (A_value : sig
       type t
 
       val to_field_elements : t -> Tick.Field.t array
     end)
     (Max_branching : Nat.Add.Intf_transparent) =
 struct
-  let double_zip = Double.map2 ~f:Core_kernel.Tuple2.create
+  let double_zip = Tuple_lib.Double.map2 ~f:Core_kernel.Tuple2.create
 
   module E = struct
-    type t = Tock.Field.t array Dlog_plonk_types.Evals.t Double.t * Tock.Field.t
+    type t = Tock.Field.t array Dlog_plonk_types.Evals.t Tuple_lib.Double.t * Tock.Field.t
   end
 
   module Plonk_checks = struct
@@ -64,6 +60,8 @@ struct
       P.Base.Pairing_based.t
       Deferred.t =
     let _, prev_vars_length = branch_data.branching in
+    let open Common in
+    let open Types in
     let T = Length.contr prev_vars_length prevs_length in
     let (module Req) = branch_data.requests in
     let T = Hlist.Length.contr (snd branch_data.branching) prev_vars_length in
@@ -86,7 +84,7 @@ struct
       branch_data.rule.main_value prevs next_state
     in
     let module X_hat = struct
-      type t = Tock.Field.t Double.t
+      type t = Tock.Field.t Tuple_lib.Double.t
     end in
     let module Statement_with_hashes = struct
       type t =
@@ -141,7 +139,7 @@ struct
           let combined_evals =
             Plonk_checks.evals_of_split_evals
               (module Tick.Field)
-              (Double.map t.prev_evals.evals ~f:(fun e -> e.evals))
+              (Tuple_lib.Double.map t.prev_evals.evals ~f:(fun e -> e.evals))
               ~rounds:(Nat.to_int Tick.Rounds.n) ~zeta ~zetaw
           in
           let plonk_minimal =
@@ -614,7 +612,7 @@ struct
                Dlog_plonk_types.All_evals.
                  { ft_eval1
                  ; evals =
-                     Double.map2 es x_hat ~f:(fun es x_hat ->
+                     Tuple_lib.Double.map2 es x_hat ~f:(fun es x_hat ->
                          { With_public_input.evals = es; public_input = x_hat })
                  }))
           lte Max_branching.n Dummy.evals

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -1,8 +1,6 @@
 open Core_kernel
 open Pickles_types
-open Hlist
 open Common
-open Import
 
 (* The data obtained from "compiling" an inductive rule into a circuit. *)
 type ( 'a_var
@@ -16,9 +14,9 @@ type ( 'a_var
      t =
   | T :
       { branching : 'branching Nat.t * ('prev_vars, 'branching) Hlist.Length.t
-      ; index : Types.Index.t
+      ; index : Import.Types.Index.t
       ; lte : ('branching, 'max_branching) Nat.Lte.t
-      ; domains : Domains.t
+      ; domains : Import.Domains.t
       ; rule :
           ( 'prev_vars
           , 'prev_values
@@ -28,11 +26,11 @@ type ( 'a_var
           , 'a_value )
           Inductive_rule.t
       ; main :
-             step_domains:(Domains.t, 'branches) Vector.t
+             step_domains:(Import.Domains.t, 'branches) Vector.t
           -> ( (Unfinalized.t, 'max_branching) Vector.t
              , Impls.Step.Field.t
              , (Impls.Step.Field.t, 'max_branching) Vector.t )
-             Types.Pairing_based.Statement.t
+             Import.Types.Pairing_based.Statement.t
           -> unit
       ; requests :
           (module Requests.Step.S
@@ -60,6 +58,7 @@ let create
     ~(max_branching : max_branching Nat.t)
     ~(branchings : (int, branches) Vector.t) ~(branches : branches Nat.t) ~typ
     var_to_field_elements value_to_field_elements (rule : _ Inductive_rule.t) =
+  let open Hlist in
   Timer.clock __LOC__ ;
   let module HT = H4.T (Tag) in
   let (T (self_width, branching)) = HT.length rule.prevs in

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -2,11 +2,9 @@ module S = Sponge
 open Core_kernel
 open Pickles_types
 open Common
-open Poly_types
 open Hlist
 open Import
 open Impls.Step
-open Step_main_inputs
 module B = Inductive_rule.B
 
 (* The SNARK function corresponding to the input inductive rule. *)
@@ -47,7 +45,8 @@ let step_main :
  fun (module Req) (module Max_branching) ~self_branches ~local_signature
      ~local_signature_length ~local_branches ~local_branches_length ~branching
      ~lte ~basic ~self rule ->
-  let module T (F : T4) = struct
+  let open Step_main_inputs in
+  let module T (F : Poly_types.T4) = struct
     type ('a, 'b, 'n, 'm) t =
       | Other of ('a, 'b, 'n, 'm) F.t
       | Self : (a_var, a_value, max_branching, self_branches) t

--- a/src/lib/pickles/step_main_inputs.ml
+++ b/src/lib/pickles/step_main_inputs.ml
@@ -1,9 +1,7 @@
 open Core_kernel
-open Common
 open Backend
 open Pickles_types
 module Impl = Impls.Step
-open Import
 
 let high_entropy_bits = 128
 
@@ -11,15 +9,15 @@ let sponge_params_constant =
   Sponge.Params.(map pasta_p_3 ~f:Impl.Field.Constant.of_string)
 
 let tick_field_random_oracle ?(length = Tick.Field.size_in_bits - 1) s =
-  Tick.Field.of_bits (bits_random_oracle ~length s)
+  Tick.Field.of_bits (Common.bits_random_oracle ~length s)
 
 let unrelated_g =
   let group_map =
     unstage
-      (group_map
+      (Common.group_map
          (module Tick.Field)
          ~a:Tick.Inner_curve.Params.a ~b:Tick.Inner_curve.Params.b)
-  and str = Fn.compose bits_to_bytes Tick.Field.to_bits in
+  and str = Fn.compose Common.bits_to_bytes Tick.Field.to_bits in
   fun (x, y) -> group_map (tick_field_random_oracle (str x ^ str y))
 
 open Impl
@@ -78,12 +76,12 @@ let%test_unit "sponge" =
   T.test Tick_field_sponge.params
 
 module Input_domain = struct
-  let domain = Domain.Pow_2_roots_of_unity 6
+  let domain = Import.Domain.Pow_2_roots_of_unity 6
 
   let lagrange_commitments =
     lazy
-      (let domain_size = Domain.size domain in
-       time "lagrange" (fun () ->
+      (let domain_size = Import.Domain.size domain in
+       Common.time "lagrange" (fun () ->
            Array.init domain_size ~f:(fun i ->
                let v =
                  (Kimchi.Protocol.SRS.Fq.lagrange_commitment

--- a/src/lib/pickles/unfinalized.ml
+++ b/src/lib/pickles/unfinalized.ml
@@ -1,9 +1,7 @@
 open Backend
 open Impls.Step
-open Pickles_types
-open Common
 open Import
-module Shifted_value = Shifted_value.Type2
+module Shifted_value = Pickles_types.Shifted_value.Type2
 
 (* Unfinalized dlog-based proof, along with a flag which is true iff it
    is expected to verify. This allows for situations like the blockchain
@@ -32,7 +30,7 @@ module Constant = struct
     , Tock.Field.t Shifted_value.t
     , ( Challenge.Constant.t Scalar_challenge.t Bulletproof_challenge.t
       , Tock.Rounds.n )
-      Vector.t
+      Pickles_types.Vector.t
     , Digest.Constant.t
     , bool )
     Types.Pairing_based.Proof_state.Per_proof.In_circuit.t
@@ -70,7 +68,7 @@ module Constant = struct
         ~domain:
           (Plonk_checks.domain
              (module Tock.Field)
-             wrap_domains.h ~shifts:Common.tock_shifts
+             Common.wrap_domains.h ~shifts:Common.tock_shifts
              ~domain_generator:Tock.Field.domain_generator)
         chals evals
     in

--- a/src/lib/pickles/verification_key.ml
+++ b/src/lib/pickles/verification_key.ml
@@ -1,7 +1,4 @@
 open Core_kernel
-open Pickles_types
-open Import
-open Kimchi_pasta.Pasta
 
 module Data = struct
   [%%versioned
@@ -20,9 +17,11 @@ module Repr = struct
     module V2 = struct
       type t =
         { commitments :
+            let open Pickles_types in
             Backend.Tock.Curve.Affine.Stable.V1.t
             Plonk_verification_key_evals.Stable.V2.t
-        ; step_domains : Domains.Stable.V1.t array
+        ; step_domains : let open Import in
+                         Domains.Stable.V1.t array
         ; data : Data.Stable.V1.t
         }
 
@@ -34,6 +33,8 @@ end
 [%%versioned_binable
 module Stable = struct
   module V2 = struct
+    let open Import in
+    let open Pickles_types in
     type t =
       { commitments : Backend.Tock.Curve.Affine.t Plonk_verification_key_evals.t
       ; step_domains : Domains.t array
@@ -45,6 +46,9 @@ module Stable = struct
     let to_latest = Fn.id
 
     let of_repr srs { Repr.commitments = c; step_domains; data = d } =
+      let open Kimchi_pasta.Pasta in
+      let open Import in
+      let open Pickles_types in
       let t : Impls.Wrap.Verification_key.t =
         let log2_size = Int.ceil_log2 d.constraints in
         let d = Domain.Pow_2_roots_of_unity log2_size in
@@ -94,6 +98,7 @@ module Stable = struct
 end]
 
 let dummy_commitments g =
+  let open Pickles_types in
   let open Dlog_plonk_types in
   { Plonk_verification_key_evals.sigma_comm =
       Vector.init Permuts.n ~f:(fun _ -> g)
@@ -107,6 +112,7 @@ let dummy_commitments g =
   }
 
 let dummy =
+  let open Import in
   lazy
     (let rows = Domain.size Common.wrap_domains.h in
      let g = Backend.Tock.Curve.(to_affine_exn one) in

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -1,13 +1,9 @@
 module SC = Scalar_challenge
 module P = Proof
 open Pickles_types
-open Hlist
-open Tuple_lib
-open Common
 open Core_kernel
 open Async_kernel
 open Import
-open Types
 open Backend
 
 (* This contains the "wrap" prover *)
@@ -36,6 +32,7 @@ let combined_inner_product (type actual_branching) ~env ~domain ~ft_eval1
     (e1, e2) ~(old_bulletproof_challenges : (_, actual_branching) Vector.t) ~r
     ~plonk ~xi ~zeta ~zetaw ~x_hat:(x_hat_1, x_hat_2)
     ~(step_branch_domains : Domains.t) =
+  let open Common in
   let combined_evals =
     Plonk_checks.evals_of_split_evals ~zeta ~zetaw
       (module Tick.Field)
@@ -79,6 +76,7 @@ let combined_inner_product (type actual_branching) ~env ~domain ~ft_eval1
 module Pairing_acc = Tock.Inner_curve.Affine
 
 (* The prover for wrapping a proof *)
+open Hlist
 let wrap (type actual_branching max_branching max_local_max_branchings)
     ~(max_branching : max_branching Nat.t)
     (module Max_local_max_branchings : Hlist.Maxes.S
@@ -102,6 +100,8 @@ let wrap (type actual_branching max_branching max_local_max_branchings)
     (Vector.to_array pairing_marlin_indices).(Index.to_int which_index)
   in
 *)
+  let open Types in
+  let open Common in
   let prev_me_only =
     let module M =
       H1.Map (P.Base.Me_only.Dlog_based) (P.Base.Me_only.Dlog_based.Prepared)
@@ -385,7 +385,7 @@ let wrap (type actual_branching max_branching max_local_max_branchings)
     ; statement = Types.Dlog_based.Statement.to_minimal next_statement
     ; prev_evals =
         { Dlog_plonk_types.All_evals.evals =
-            Double.map2 x_hat proof.openings.evals ~f:(fun p e ->
+            Tuple_lib.Double.map2 x_hat proof.openings.evals ~f:(fun p e ->
                 { Dlog_plonk_types.All_evals.With_public_input.public_input = p
                 ; evals = e
                 })

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -1,11 +1,10 @@
 open Core_kernel
 open Pickles_types
 open Import
-open Poly_types
 open Hlist
 
 (* Compute the domains corresponding to wrap_main *)
-module Make (A : T0) (A_value : T0) = struct
+module Make (A : Poly_types.T0) (A_value : Poly_types.T0) = struct
   module I = Inductive_rule.T (A) (A_value)
 
   let prev (type xs ys ws hs) ~self ~(choices : (xs, ys, ws, hs) H4.T(I).t) =

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -1,11 +1,9 @@
 open Core_kernel
 open Pickles_types
 open Hlist
-open Common
 open Import
 open Types
 open Wrap_main_inputs
-open Impl
 module SC = Scalar_challenge
 
 (* Let's define an OCaml encoding for inductive NP sets. Let A be an inductive NP set.
@@ -106,6 +104,7 @@ module Old_bulletproof_chals = struct
         -> t
 end
 
+open Impl
 let pack_statement max_branching t =
   with_label __LOC__ (fun () ->
       Spec.pack
@@ -387,7 +386,7 @@ let wrap_main
           }
         in
         let openings_proof =
-          let shift = Shifts.tick1 in
+          let shift = Common.Shifts.tick1 in
           exists
             (Dlog_plonk_types.Openings.Bulletproof.typ
                ( Typ.transport Other_field.Packed.typ

--- a/src/lib/pickles/wrap_proof.ml
+++ b/src/lib/pickles/wrap_proof.ml
@@ -1,9 +1,8 @@
 open Pickles_types
-open Import
 open Backend
 
 type dlog_opening =
-  (Tock.Curve.Affine.t, Tock.Field.t) Types.Pairing_based.Openings.Bulletproof.t
+  (Tock.Curve.Affine.t, Tock.Field.t) Import.Types.Pairing_based.Openings.Bulletproof.t
 
 type t = dlog_opening * Tock.Curve.Affine.t Dlog_plonk_types.Messages.t
 
@@ -12,7 +11,7 @@ open Step_main_inputs
 type var =
   ( Inner_curve.t
   , Impls.Step.Other_field.t Shifted_value.Type2.t )
-  Types.Pairing_based.Openings.Bulletproof.t
+  Import.Types.Pairing_based.Openings.Bulletproof.t
   * Inner_curve.t Dlog_plonk_types.Messages.t
 
 open Impls.Step
@@ -20,7 +19,7 @@ open Impls.Step
 let typ : (var, t) Typ.t =
   let shift = Shifted_value.Type2.Shift.create (module Tock.Field) in
   Typ.tuple2
-    (Types.Pairing_based.Openings.Bulletproof.typ
+    (Import.Types.Pairing_based.Openings.Bulletproof.typ
        ~length:(Nat.to_int Tock.Rounds.n)
        ( Typ.transport Other_field.typ
            ~there:(fun x ->

--- a/src/lib/pickles_types/hlist.ml
+++ b/src/lib/pickles_types/hlist.ml
@@ -1,5 +1,13 @@
 open Core_kernel
-open Poly_types
+open struct
+  open Poly_types
+  module type T4 = T4
+  module type T3 = T3
+  module type T2 = T2
+  module type T0 = T0
+  module type T1 = T1
+end
+
 
 module E13 (T : T1) = struct
   type ('a, _, _) t = 'a T.t

--- a/src/lib/ppx_coda/define_from_scope.ml
+++ b/src/lib/ppx_coda/define_from_scope.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Ppxlib
-open Asttypes
 
 (* define_from_scope creates local definitions from those in scope
 
@@ -25,6 +24,7 @@ open Asttypes
 let name = "define_from_scope"
 
 let expr_to_id loc expr =
+  let open Asttypes in
   match expr.pexp_desc with
   | Pexp_ident { txt = Lident s; _ } ->
       s
@@ -32,6 +32,7 @@ let expr_to_id loc expr =
       Location.raise_errorf ~loc "Expected identifier"
 
 let expand ~loc ~path:_ (items : expression list) =
+  let open Asttypes in
   let (module Ast_builder) = Ast_builder.make loc in
   let open Ast_builder in
   let ids = List.map items ~f:(expr_to_id loc) in

--- a/src/lib/ppx_coda/define_locally.ml
+++ b/src/lib/ppx_coda/define_locally.ml
@@ -1,7 +1,5 @@
 open Core_kernel
 open Ppxlib
-open Asttypes
-open Ast_helper
 
 (* define_locally mirrors local definitions from some other module
 
@@ -20,6 +18,7 @@ let name = "define_locally"
 let raise_errorf = Location.raise_errorf
 
 let expr_to_id loc expr =
+  let open Asttypes in
   match expr.pexp_desc with
   | Pexp_ident { txt = Lident s; _ } ->
       s
@@ -27,6 +26,8 @@ let expr_to_id loc expr =
       Location.raise_errorf ~loc "Expected identifier"
 
 let expand ~loc ~path:_ open_decl defs =
+  let open Ast_helper in
+  let open Asttypes in
   match defs.pexp_desc with
   | Pexp_tuple exps ->
       let (module Ast_builder) = Ast_builder.make loc in

--- a/src/lib/ppx_coda/expires_after.ml
+++ b/src/lib/ppx_coda/expires_after.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Ppxlib
-open Asttypes
 
 (** This is a ppx to flag code that will expire after a certain date
 
@@ -17,6 +16,7 @@ open Asttypes
 let name = "expires_after"
 
 let expand ~loc ~path:_ str _delimiter =
+  let open Asttypes in
   let date =
     try
       (* the of_string function below allows too-long strings, as long as it starts

--- a/src/lib/ppx_coda/log.ml
+++ b/src/lib/ppx_coda/log.ml
@@ -1,5 +1,4 @@
 open Ppxlib
-open Asttypes
 
 (* `log` reduces the boilerplate needed to call the logger
 
@@ -32,6 +31,7 @@ module Make (Info : Ppxinfo) = struct
   let prime s = s ^ "'"
 
   let expand ~loc (log_level : longident) (logger : expression) =
+    let open Asttypes in
     let module E = Ppxlib.Ast_builder.Make (struct
       let loc = loc
     end) in
@@ -49,6 +49,7 @@ module Make (Info : Ppxinfo) = struct
         [%e log_level_expr] [%e logger] ~module_:__MODULE__ ~location:__LOC__]
 
   let expand_capture_logger ~loc ~path:_ log_level =
+    let open Asttypes in
     expand ~loc log_level [%expr logger]
 
   let expand_explicit_logger ~loc ~path:_ (log_level : longident)

--- a/src/lib/precomputed_values/gen_values/gen_values.ml
+++ b/src/lib/precomputed_values/gen_values/gen_values.ml
@@ -1,12 +1,7 @@
 [%%import "/src/config.mlh"]
 
-open Ppxlib
-open Asttypes
-open Parsetree
-open Longident
 open Core
 open Async
-open Mina_state
 
 (* TODO: refactor to do compile time selection *)
 [%%if proof_level = "full"]
@@ -41,6 +36,8 @@ let hashes =
      ts @ bs)
 
 let hashes_to_expr ~loc hashes =
+  let open Longident in
+  let open Asttypes in
   let open Ppxlib.Ast_builder.Default in
   elist ~loc
   @@ List.map hashes ~f:(fun (x, y) ->
@@ -49,6 +46,8 @@ let hashes_to_expr ~loc hashes =
            , Core.Md5.of_hex_exn [%e estring ~loc (Core.Md5.to_hex y)]])
 
 let vk_id_to_expr ~loc vk_id =
+  let open Longident in
+  let open Asttypes in
   let open Ppxlib.Ast_builder.Default in
   [%expr
     let t =
@@ -76,7 +75,7 @@ module Inputs = struct
       ~protocol_constants:genesis_constants.protocol
 
   let protocol_state_with_hash =
-    Genesis_protocol_state.t ~genesis_ledger:Test_genesis_ledger.t
+    Mina_state.Genesis_protocol_state.t ~genesis_ledger:Test_genesis_ledger.t
       ~genesis_epoch_data ~constraint_constants ~consensus_constants
 end
 
@@ -84,6 +83,8 @@ module Dummy = struct
   let loc = Ppxlib.Location.none
 
   let base_proof_expr =
+    let open Longident in
+    let open Asttypes in
     if generate_genesis_proof then
       Some (Async.return [%expr Mina_base.Proof.blockchain_dummy])
     else None
@@ -142,6 +143,9 @@ module Make_real () = struct
 end
 
 let main () =
+  let open Longident in
+  let open Parsetree in
+  let open Asttypes in
   let open Ppxlib.Ast_builder.Default in
   let target = (Sys.get_argv ()).(1) in
   let fmt = Format.formatter_of_out_channel (Out_channel.create target) in
@@ -275,7 +279,7 @@ let main () =
           | None ->
               [%expr None]]]
   in
-  Pprintast.top_phrase fmt (Ptop_def structure) ;
+  Ppxlib.Pprintast.top_phrase fmt (Ptop_def structure) ;
   exit 0
 
 let () =

--- a/src/lib/prover/intf.ml
+++ b/src/lib/prover/intf.ml
@@ -1,7 +1,5 @@
 open Async_kernel
 open Mina_base
-open Mina_state
-open Mina_transition
 open Blockchain_snark
 
 module type S = sig
@@ -28,8 +26,8 @@ module type S = sig
   val extend_blockchain :
        t
     -> Blockchain.t
-    -> Protocol_state.Value.t
-    -> Snark_transition.value
+    -> Mina_state.Protocol_state.Value.t
+    -> Mina_state.Snark_transition.value
     -> Ledger_proof.t option
     -> Consensus.Data.Prover_state.t
     -> Pending_coinbase_witness.t
@@ -37,10 +35,10 @@ module type S = sig
 
   val prove :
        t
-    -> prev_state:Protocol_state.Value.t
+    -> prev_state:Mina_state.Protocol_state.Value.t
     -> prev_state_proof:Proof.t
-    -> next_state:Protocol_state.Value.t
-    -> Internal_transition.t
+    -> next_state:Mina_state.Protocol_state.Value.t
+    -> Mina_transition.Internal_transition.t
     -> Pending_coinbase_witness.t
     -> Proof.t Deferred.Or_error.t
 

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -2,7 +2,6 @@ open Core
 open Async
 open Mina_base
 open Mina_state
-open Mina_transition
 open Blockchain_snark
 
 module type S = Intf.S
@@ -411,16 +410,16 @@ let extend_blockchain { connection; logger; _ } chain next_state block
       Error e
 
 let prove t ~prev_state ~prev_state_proof ~next_state
-    (transition : Internal_transition.t) pending_coinbase =
+    (transition : Mina_transition.Internal_transition.t) pending_coinbase =
   let open Deferred.Or_error.Let_syntax in
   let start_time = Core.Time.now () in
   let%map chain =
     extend_blockchain t
       (Blockchain.create ~proof:prev_state_proof ~state:prev_state)
       next_state
-      (Internal_transition.snark_transition transition)
-      (Internal_transition.ledger_proof transition)
-      (Internal_transition.prover_state transition)
+      (Mina_transition.Internal_transition.snark_transition transition)
+      (Mina_transition.Internal_transition.ledger_proof transition)
+      (Mina_transition.Internal_transition.prover_state transition)
       pending_coinbase
   in
   Mina_metrics.(

--- a/src/lib/secrets/hardware_wallets.ml
+++ b/src/lib/secrets/hardware_wallets.ml
@@ -1,4 +1,3 @@
-open Snark_params
 open Core
 open Signature_lib
 open Mina_base
@@ -102,7 +101,7 @@ let sign ~hd_index ~public_key ~user_command_payload :
   in
   let fields = Random_oracle.Legacy.pack_input input in
   let messages =
-    Array.map fields ~f:(fun field -> Tick.Field.to_string field)
+    Array.map fields ~f:(fun field -> Snark_params.Tick.Field.to_string field)
   in
   if Array.length messages <> 2 then
     Deferred.Result.fail "Malformed user command"

--- a/src/lib/secrets/keypair_common.ml
+++ b/src/lib/secrets/keypair_common.ml
@@ -1,6 +1,5 @@
 open Core
 open Async
-open Async.Deferred.Let_syntax
 
 let error_raise e ~error_ctx = Error.tag ~tag:error_ctx e |> Error.raise
 
@@ -18,9 +17,10 @@ module Make_terminal_stdin (KP : sig
     t -> privkey_path:string -> password:Secret_file.password -> unit Deferred.t
 end) =
 struct
-  open KP
 
   let rec prompt_password prompt =
+    let open KP in
+    let open Async.Deferred.Let_syntax in
     let open Deferred.Let_syntax in
     let%bind pw1 = Password.hidden_line_or_env prompt ~env in
     let%bind pw2 = Password.hidden_line_or_env "Again to confirm: " ~env in
@@ -30,6 +30,8 @@ struct
     else return pw2
 
   let read_exn ?(should_prompt_user = true) ?(should_reask = true) ~which path =
+    let open KP in
+    let open Async.Deferred.Let_syntax in
     let read_privkey password = read ~privkey_path:path ~password in
     let%bind result =
       match Sys.getenv env with
@@ -68,6 +70,7 @@ struct
         Privkey_error.raise ~which e
 
   let write_exn kp ~privkey_path =
+    let open KP in
     write_exn kp ~privkey_path
       ~password:(lazy (prompt_password "Password for new private key file: "))
 end

--- a/src/lib/secrets/keypair_read_write.ml
+++ b/src/lib/secrets/keypair_read_write.ml
@@ -10,14 +10,13 @@ module Make (Env : sig
   val which : string
 end) =
 struct
-  open Env
 
   (* avoid spurious cyclic dependency *)
   module Keypair = Signature_lib.Keypair
 
   type t = Keypair.t
 
-  let env = env
+  let env = Env.env
 
   (** Writes a keypair to [privkey_path] and [privkey_path ^ ".pub"] using [Secret_file] *)
   let write_exn { Keypair.private_key; public_key } ~(privkey_path : string)
@@ -41,7 +40,7 @@ struct
         Writer.write_line pubkey_f pubkey_string ;
         Writer.close pubkey_f
     | Error e ->
-        Privkey_error.raise ~which e
+        Privkey_error.raise ~Env.which e
 
   (** Reads a private key from [privkey_path] using [Secret_file] *)
   let read ~(privkey_path : string) ~(password : Secret_file.password) :
@@ -74,7 +73,7 @@ struct
     | Ok keypair ->
         keypair
     | Error priv_key_error ->
-        Privkey_error.raise ~which priv_key_error
+        Privkey_error.raise ~Env.which priv_key_error
 
   let read_exn' path =
     let password =

--- a/src/lib/secrets/libp2p_keypair.ml
+++ b/src/lib/secrets/libp2p_keypair.ml
@@ -1,6 +1,5 @@
 open Core
 open Async
-open Async.Deferred.Let_syntax
 open Keypair_common
 
 module T = struct
@@ -14,6 +13,7 @@ module T = struct
   let write_exn kp ~(privkey_path : string) ~(password : Secret_file.password) :
       unit Deferred.t =
     let str = Mina_net2.Keypair.to_string kp in
+    let open Async.Deferred.Let_syntax in
     match%bind
       Secret_file.write ~path:privkey_path ~mkdir:true
         ~plaintext:(Bytes.of_string str) ~password
@@ -45,6 +45,7 @@ module T = struct
   (** Reads a private key from [privkey_path] using [Secret_file], throws on failure *)
   let read_exn ~(privkey_path : string) ~(password : Secret_file.password) :
       t Deferred.t =
+    let open Async.Deferred.Let_syntax in
     match%map read ~privkey_path ~password with
     | Ok keypair ->
         keypair

--- a/src/lib/secrets/secret_box.ml
+++ b/src/lib/secrets/secret_box.ml
@@ -1,5 +1,4 @@
 open Core
-open Sodium
 
 module BytesWr = struct
   include Bytes
@@ -80,6 +79,7 @@ let of_yojson (t : Yojson.Safe.t) =
 
 (** warning: this will zero [password] *)
 let encrypt ~(password : Bytes.t) ~(plaintext : Bytes.t) =
+  let open Sodium in
   let nonce = Secret_box.random_nonce () in
   let salt = Password_hash.random_salt () in
   let ({ Password_hash.mem_limit; ops_limit } as diff) =
@@ -105,6 +105,7 @@ let decrypt ~(password : Bytes.t)
     ; pwdiff = mem_limit, ops_limit
     ; ciphertext
     } =
+  let open Sodium in
   if not (String.equal box_primitive Secret_box.primitive) then
     Error
       (`Corrupted_privkey

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -331,7 +331,6 @@ module Make
   end
 end
 
-open Snark_params
 
 [%%else]
 
@@ -493,6 +492,7 @@ open Hash_prefix_states_nonconsensus
 
 [%%endif]
 
+open Snark_params
 module Message = struct
   let network_id_mainnet = Char.of_int_exn 1
 

--- a/src/lib/snark_bits/bits.ml
+++ b/src/lib/snark_bits/bits.ml
@@ -3,8 +3,6 @@
 [%%import "/src/config.mlh"]
 
 open Core_kernel
-open Fold_lib
-open Bitstring_lib
 
 (* Someday: Make more efficient by giving Field.unpack a length argument in
 camlsnark *)
@@ -12,7 +10,7 @@ let unpack_field unpack ~bit_length x = List.take (unpack x) bit_length
 
 let bits_per_char = 8
 
-let pad (type a) ~length ~default (bs : a Bitstring.Lsb_first.t) =
+let pad (type a) ~length ~default (bs : a Bitstring_lib.Bitstring.Lsb_first.t) =
   let bs = (bs :> a list) in
   let padding = length - List.length bs in
   assert (padding >= 0) ;
@@ -67,7 +65,7 @@ module Vector = struct
     type t = V.t
 
     let fold t =
-      { Fold.fold =
+      Fold_lib.{ Fold.fold =
           (fun ~init ~f ->
             let rec go acc i =
               if i = V.length then acc else go (f acc (V.get t i)) (i + 1)
@@ -113,7 +111,7 @@ module Make_field0
   type t = Field.t
 
   let fold t =
-    { Fold.fold =
+    Fold_lib.{ Fold.fold =
         (fun ~init ~f ->
           let n = Bigint.of_field t in
           let rec go acc i =
@@ -246,7 +244,7 @@ module Snarkable = struct
           (Typ.list ~length:V.length Boolean.typ)
           ~there:(v_to_list V.length) ~back:v_of_list
 
-      let var_to_bits = Bitstring.Lsb_first.of_list
+      let var_to_bits = Bitstring_lib.Bitstring.Lsb_first.of_list
 
       let var_of_bits = pad ~length:V.length ~default:Boolean.false_
 

--- a/src/lib/snark_bits/bits_intf.ml
+++ b/src/lib/snark_bits/bits_intf.ml
@@ -2,12 +2,11 @@
 
 [%%import "/src/config.mlh"]
 
-open Fold_lib
 
 module type Basic = sig
   type t
 
-  val fold : t -> bool Fold.t
+  val fold : t -> bool Fold_lib.Fold.t
 
   val size_in_bits : int
 end
@@ -28,7 +27,6 @@ end
 
 [%%ifdef consensus_mechanism]
 
-open Tuple_lib
 
 module Snarkable = struct
   module type Basic = sig
@@ -61,7 +59,7 @@ module Snarkable = struct
 
       val var_of_bits : boolean_var Bitstring_lib.Bitstring.Lsb_first.t -> var
 
-      val var_to_triples : var -> boolean_var Triple.t list
+      val var_to_triples : var -> boolean_var Tuple_lib.Triple.t list
 
       val var_of_value : value -> var
 

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -1,7 +1,6 @@
-open Ppxlib
-open Asttypes
-open Parsetree
-open Longident
+open Ppxlib.Asttypes
+open Ppxlib.Parsetree
+open Ppxlib.Longident
 open Core
 
 let hashes ~constraint_constants ~loc =
@@ -219,10 +218,10 @@ let main () =
   in
   if Array.mem ~equal:String.equal Sys.argv "--download-keys" then
     Key_cache.set_downloads_enabled true ;
-  let%bind str = str ~proof_level ~constraint_constants ~loc:Location.none in
+  let%bind str = str ~proof_level ~constraint_constants ~loc:Ppxlib.Location.none in
   (* End comment started at the top of this function *)
   Format.printf "*)@." ;
-  Pprintast.top_phrase Format.std_formatter (Ptop_def str) ;
+  Ppxlib.Pprintast.top_phrase Format.std_formatter (Ptop_def str) ;
   exit 0
 
 let () =

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -1,6 +1,4 @@
 open Core_kernel
-open Bitstring_lib
-open Snark_bits
 
 module Make_snarkable (Impl : Snarky_backendless.Snark_intf.S) = struct
   open Impl
@@ -15,19 +13,19 @@ module Make_snarkable (Impl : Snarky_backendless.Snark_intf.S) = struct
 
   module Bits = struct
     module type Lossy =
-      Bits_intf.Snarkable.Lossy
+      Snark_bits.Bits_intf.Snarkable.Lossy
         with type ('a, 'b) typ := ('a, 'b) Typ.t
          and type ('a, 'b) checked := ('a, 'b) Checked.t
          and type boolean_var := Boolean.var
 
     module type Faithful =
-      Bits_intf.Snarkable.Faithful
+      Snark_bits.Bits_intf.Snarkable.Faithful
         with type ('a, 'b) typ := ('a, 'b) Typ.t
          and type ('a, 'b) checked := ('a, 'b) Checked.t
          and type boolean_var := Boolean.var
 
     module type Small =
-      Bits_intf.Snarkable.Small
+      Snark_bits.Bits_intf.Snarkable.Small
         with type ('a, 'b) typ := ('a, 'b) Typ.t
          and type ('a, 'b) checked := ('a, 'b) Checked.t
          and type boolean_var := Boolean.var
@@ -87,6 +85,7 @@ struct
 
   open Impl
 
+  open Bitstring_lib
   type var = Boolean.var Bitstring.Lsb_first.t
 
   let typ : (var, t) Typ.t =
@@ -181,7 +180,7 @@ module Tick = struct
   module Field = struct
     include Tick0.Field
     include Hashable.Make (Tick0.Field)
-    module Bits = Bits.Make_field (Tick0.Field) (Tick0.Bigint)
+    module Bits = Snark_bits.Bits.Make_field (Tick0.Field) (Tick0.Bigint)
 
     let size_in_triples = Int.((size_in_bits + 2) / 3)
   end

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -15,8 +15,6 @@ open Signature_lib
 *)
 
 module Make (Inputs : Intf.Inputs_intf) = struct
-  open Inputs
-  open Snark_work_lib
 
   module Get_work = struct
     module Master = struct
@@ -28,9 +26,9 @@ module Make (Inputs : Intf.Inputs_intf) = struct
         type response =
           ( ( Transaction.t
             , Transaction_witness.t
-            , Ledger_proof.t )
-            Work.Single.Spec.t
-            Work.Spec.t
+            , Inputs.Ledger_proof.t )
+            Snark_work_lib.Work.Single.Spec.t
+            Snark_work_lib.Work.Spec.t
           * Public_key.Compressed.t )
           option
       end
@@ -51,11 +49,11 @@ module Make (Inputs : Intf.Inputs_intf) = struct
         type query =
           ( ( Transaction.t
             , Transaction_witness.t
-            , Ledger_proof.t )
-            Work.Single.Spec.t
-            Work.Spec.t
-          , Ledger_proof.t )
-          Work.Result.t
+            , Inputs.Ledger_proof.t )
+            Snark_work_lib.Work.Single.Spec.t
+            Snark_work_lib.Work.Spec.t
+          , Inputs.Ledger_proof.t )
+          Snark_work_lib.Work.Result.t
 
         type response = unit
       end

--- a/src/lib/snarky_blake2/uint32.ml
+++ b/src/lib/snarky_blake2/uint32.ml
@@ -28,7 +28,6 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) :
   S with module Impl := Impl = struct
   module B = Bigint
   open Impl
-  open Let_syntax
   module Unchecked = Unsigned.UInt32
 
   type t = Boolean.var array
@@ -58,7 +57,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) :
   let xor t1 t2 =
     let res = Array.create ~len:length Boolean.false_ in
     let rec go i =
-      if i < 0 then return res
+      if i < 0 then Let_syntax.return res
       else
         let%bind ri = Boolean.( lxor ) t1.(i) t2.(i) in
         res.(i) <- ri ;
@@ -103,7 +102,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) :
     in
     match vars with
     | [] ->
-        return (constant (Unchecked.of_int (c mod (1 lsl 32))))
+        Let_syntax.return (constant (Unchecked.of_int (c mod (1 lsl 32))))
     | _ ->
         let max_length =
           Int.(

--- a/src/lib/snarky_field_extensions/field_extensions.ml
+++ b/src/lib/snarky_field_extensions/field_extensions.ml
@@ -306,7 +306,6 @@ module E2
 
   val unitary_inverse : t -> t
 end = struct
-  open Params
 
   module T = struct
     module Base = F
@@ -353,6 +352,7 @@ end = struct
 
        so this is correct as well.
     *)
+    open Params
     let square (a, b) =
       let open F in
       let%map ab = a * b and t = (a + b) * (a + mul_by_non_residue b) in
@@ -604,7 +604,6 @@ module F3
     module Base = F
     module Unchecked = Snarkette.Fields.Make_fp3 (F.Unchecked) (Params)
     module Impl = F.Impl
-    open Impl
 
     let mul_by_primitive_element (a, b, c) = (F.scale c Params.non_residue, a, b)
 
@@ -612,6 +611,7 @@ module F3
       include T3
 
       let sequence (x, y, z) =
+        let open Impl in
         let%map x = x and y = y and z = z in
         (x, y, z)
     end
@@ -620,15 +620,18 @@ module F3
 
     include Make_applicative (Base) (A)
 
-    let typ = Typ.tuple3 F.typ F.typ F.typ
+    let typ = let open Impl in
+              Typ.tuple3 F.typ F.typ F.typ
 
     let mul_field (a, b, c) x =
+      let open Impl in
       let%map a = Base.mul_field a x
       and b = Base.mul_field b x
       and c = Base.mul_field c x in
       (a, b, c)
 
     let assert_r1cs (a0, a1, a2) (b0, b1, b2) (c0, c1, c2) =
+      let open Impl in
       let open F in
       let%bind v0 = a0 * b0 and v4 = a2 * b2 in
       let beta = Params.non_residue in

--- a/src/lib/snarky_log/snarky_log.ml
+++ b/src/lib/snarky_log/snarky_log.ml
@@ -1,12 +1,12 @@
 open Snarky_backendless
 open Webkit_trace_event
-open Webkit_trace_event.Output.JSON
-open Yojson
 
 let to_string ?buf ?len ?std events =
+  Yojson.let open Webkit_trace_event.Output.JSON in
   to_string ?buf ?len ?std @@ json_of_events events
 
 let to_channel ?buf ?len ?std out_channel events =
+  Yojson.let open Webkit_trace_event.Output.JSON in
   to_channel ?buf ?len ?std out_channel @@ json_of_events events
 
 let to_file ?buf ?len ?std filename events =

--- a/src/lib/snarky_pairing/final_exponentiation.ml
+++ b/src/lib/snarky_pairing/final_exponentiation.ml
@@ -29,21 +29,20 @@ end
 module Make (Inputs : Inputs_intf) = struct
   open Inputs
   open Impl
-  open Let_syntax
 
   let exponentiate elt power =
     let naf = Snarkette.Fields.find_wnaf (module N) 1 power in
     let%bind elt_inv = Fqk.inv_exn elt in
     let rec go i found_nonzero acc =
-      if i < 0 then return acc
+      if i < 0 then Let_syntax.return acc
       else
         let%bind acc =
-          if found_nonzero then Fqk.cyclotomic_square acc else return acc
+          if found_nonzero then Fqk.cyclotomic_square acc else Let_syntax.return acc
         in
         let%bind acc =
           if naf.(i) > 0 then Fqk.(acc * elt)
           else if naf.(i) < 0 then Fqk.(acc * elt_inv)
-          else return acc
+          else Let_syntax.return acc
         in
         go (i - 1) (found_nonzero || naf.(i) <> 0) acc
     in
@@ -59,7 +58,7 @@ module Make (Inputs : Inputs_intf) = struct
     let%bind w0 =
       let%bind base =
         if Params.final_exponent_last_chunk_is_w0_neg then Fqk.inv_exn beta
-        else return beta
+        else Let_syntax.return beta
       in
       exponentiate base Params.final_exponent_last_chunk_abs_of_w0
     and w1 =
@@ -79,7 +78,7 @@ module Make (Inputs : Inputs_intf) = struct
       let%bind base =
         if Params.final_exponent_last_chunk_is_w0_neg then
           Fqk.(el * Fqk.frobenius el_inv 2) (* el_inv_q_2_minus_1 *)
-        else return el_q_2_minus_1
+        else Let_syntax.return el_q_2_minus_1
       in
       exponentiate base Params.final_exponent_last_chunk_abs_of_w0
     in

--- a/src/lib/snarky_pairing/g2_precomputation.ml
+++ b/src/lib/snarky_pairing/g2_precomputation.ml
@@ -35,7 +35,6 @@ struct
   type t = { q : g2; coeffs : Coeff.t list }
 
   open Impl
-  open Let_syntax
 
   let if_g2 b ~then_:(tx, ty) ~else_:(ex, ey) =
     let%map x = Fqe.if_ b ~then_:tx ~else_:ex
@@ -263,7 +262,7 @@ struct
   let create ((qx, qy) as q) =
     let naf = Snarkette.Fields.find_wnaf (module N) 1 Params.loop_count in
     let rec go i found_nonzero (s : Fqe.t loop_state) acc =
-      if i < 0 then return (List.rev acc)
+      if i < 0 then Let_syntax.return (List.rev acc)
       else if not found_nonzero then
         go (i - 1) (found_nonzero || naf.(i) <> 0) s acc
       else

--- a/src/lib/snarky_pairing/miller_loop.ml
+++ b/src/lib/snarky_pairing/miller_loop.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-open Sgn_type
 
 module type Inputs_intf = sig
   module Impl : Snarky_backendless.Snark_intf.S
@@ -106,14 +105,14 @@ module Make (Inputs : Inputs_intf) = struct
     >>| finalize
 
   let batch_miller_loop
-      (pairs : (Sgn.t * G1_precomputation.t * G2_precomputation.t) list) =
+      (pairs : (Sgn_type.Sgn.t * G1_precomputation.t * G2_precomputation.t) list) =
     let naf = Snarkette.Fields.find_wnaf (module N) 1 Params.loop_count in
     let accum f acc pairs =
       Checked.List.fold_map pairs ~init:acc ~f:(fun acc (sgn, p, q) ->
           let c, coeffs = uncons_exn q.G2_precomputation.coeffs in
           let%bind a = f p c q.q in
           let%map acc =
-            match (sgn : Sgn.t) with
+            match (sgn : Sgn_type.Sgn.t) with
             | Pos ->
                 Fqk.special_mul acc a
             | Neg ->

--- a/src/lib/snarky_taylor/floating_point.ml
+++ b/src/lib/snarky_taylor/floating_point.ml
@@ -1,8 +1,6 @@
 open Core_kernel
 open Snarky_backendless
 open Snark
-open Snarky_integer
-open Util
 module B = Bigint
 
 (* This module is for representing arbitrary precision rationals in the interval
@@ -22,7 +20,7 @@ let to_bignum (type f) ~m:((module M) as m : f m) t =
   let d = t.precision in
   fun () ->
     let t = As_prover.read_var t.value in
-    Bignum.(of_bigint (bigint_of_field ~m t) / of_bigint B.(one lsl d))
+    Bignum.(of_bigint (Util.bigint_of_field ~m t) / of_bigint B.(one lsl d))
 
 (*
     x      y        x*y
@@ -38,7 +36,7 @@ let mul (type f) ~m:((module I) : f m) x y =
 let constant (type f) ~m:((module M) as m : f m) ~value ~precision =
   assert (B.(value < one lsl precision)) ;
   let open M in
-  { value = Field.constant (bigint_to_field ~m value); precision }
+  { value = Field.constant (Util.bigint_to_field ~m value); precision }
 
 (* x, x^2, ..., x^n *)
 let powers ~m x n =
@@ -116,8 +114,8 @@ let le (type f) ~m:((module M) : f m) t1 t2 =
     top / bottom as floor(2^k * top / bottom).
 *)
 let of_quotient ~m ~precision ~top ~bottom ~top_is_less_than_bottom:() =
-  let q, _r = Integer.(div_mod ~m (shift_left ~m top precision) bottom) in
-  { value = Integer.to_field q; precision }
+  let q, _r = Snarky_integer.Integer.(div_mod ~m (shift_left ~m top precision) bottom) in
+  { value = Snarky_integer.Integer.to_field q; precision }
 
 let of_bits (type f) ~m:((module M) : f m) bits ~precision =
   assert (List.length bits <= precision) ;

--- a/src/lib/snarky_verifier/inputs.ml
+++ b/src/lib/snarky_verifier/inputs.ml
@@ -1,4 +1,3 @@
-open Sgn_type
 
 module type S = sig
   module Impl : Snarky_backendless.Snark_intf.S
@@ -108,7 +107,7 @@ module type S = sig
   end
 
   val batch_miller_loop :
-       (Sgn.t * G1_precomputation.t * G2_precomputation.t) list
+       (Sgn_type.Sgn.t * G1_precomputation.t * G2_precomputation.t) list
     -> (Fqk.t, _) Checked.t
 
   val final_exponentiation : Fqk.t -> (Fqk.t, _) Checked.t

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -1,7 +1,5 @@
 open Core_kernel
 open Async_kernel
-open Pipe_lib
-open Network_peer
 
 type Structured_log_events.t += Snarked_ledger_synced
   [@@deriving register_event { msg = "Snarked database sync'd. All done" }]
@@ -70,6 +68,8 @@ module type Inputs_intf = sig
   val account_subtree_height : int
 end
 
+open Network_peer
+open Pipe_lib
 module type S = sig
   type 'a t [@@deriving sexp]
 

--- a/src/lib/test_util/test_util.ml
+++ b/src/lib/test_util/test_util.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-open Fold_lib
 
 module Make (Impl : Snarky_backendless.Snark_intf.S) = struct
   let triple_string trips =
@@ -34,7 +33,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) = struct
         ()
       |> Or_error.ok_exn
     in
-    let unchecked = Fold.to_list (fold input) in
+    let unchecked = Fold_lib.Fold.to_list (fold input) in
     if not ([%equal: (bool * bool * bool) list] checked unchecked) then
       failwithf
         !"Got %s (%d)\nexpected %s (%d)"

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 open Mina_base
 open Pipe_lib
-open Network_pool
 
 module State = struct
   [%%versioned
@@ -24,6 +23,7 @@ end
 
 (* TODO: this is extremely expensive as implemented and needs to be replaced with an extension *)
 let get_status ~frontier_broadcast_pipe ~transaction_pool cmd =
+  let open Network_pool in
   let open Or_error.Let_syntax in
   let%map check_cmd =
     Result.of_option (Signed_command.check cmd)
@@ -63,7 +63,6 @@ let get_status ~frontier_broadcast_pipe ~transaction_pool cmd =
 let%test_module "transaction_status" =
   ( module struct
     open Async
-    open Mina_numbers
 
     let max_length = 10
 
@@ -106,9 +105,10 @@ let%test_module "transaction_status" =
 
     let gen_user_command =
       Signed_command.Gen.payment ~sign_type:`Real ~max_amount:100 ~fee_range:10
-        ~key_gen ~nonce:(Account_nonce.of_int 1) ()
+        ~key_gen ~nonce:(Mina_numbers.Account_nonce.of_int 1) ()
 
     let create_pool ~frontier_broadcast_pipe =
+      let open Network_pool in
       let pool_reader, _ =
         Strict_pipe.(
           create ~name:"transaction_status incomming diff" Synchronous)

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -2,7 +2,6 @@ open Core_kernel
 open Async
 open Mina_base
 open Currency
-open O1trace
 
 let option lab =
   Option.value_map ~default:(Or_error.error_string lab) ~f:(fun x -> Ok x)
@@ -308,7 +307,7 @@ struct
   let time label f =
     let logger = Lazy.force logger in
     let start = Core.Time.now () in
-    let%map x = trace_recurring label f in
+    let%map x = O1trace.trace_recurring label f in
     [%log debug]
       ~metadata:
         [ ("time_elapsed", `Float Core.Time.(Span.to_ms @@ diff (now ()) start))

--- a/src/lib/transition_chain_prover/transition_chain_prover.ml
+++ b/src/lib/transition_chain_prover/transition_chain_prover.ml
@@ -1,7 +1,5 @@
 open Core
 open Mina_base
-open Mina_state
-open Mina_transition
 
 module type Inputs_intf = sig
   module Transition_frontier : module type of Transition_frontier
@@ -10,35 +8,34 @@ end
 module Make (Inputs : Inputs_intf) :
   Mina_intf.Transition_chain_prover_intf
     with type transition_frontier := Inputs.Transition_frontier.t = struct
-  open Inputs
 
   let find_in_root_history frontier state_hash =
-    let open Transition_frontier.Extensions in
+    let open Inputs.Transition_frontier.Extensions in
     let open Option.Let_syntax in
     let root_history =
-      get_extension (Transition_frontier.extensions frontier) Root_history
+      get_extension (Inputs.Transition_frontier.extensions frontier) Root_history
     in
     let%map root_data = Root_history.lookup root_history state_hash in
     Frontier_base.Root_data.Historical.transition root_data
 
   module Merkle_list = Merkle_list_prover.Make_ident (struct
-    type value = External_transition.Validated.t
+    type value = Mina_transition.External_transition.Validated.t
 
-    type context = Transition_frontier.t
+    type context = Inputs.Transition_frontier.t
 
     type proof_elem = State_body_hash.t
 
     let to_proof_elem transition =
-      transition |> External_transition.Validated.protocol_state
-      |> Protocol_state.body |> Protocol_state.Body.hash
+      transition |> Mina_transition.External_transition.Validated.protocol_state
+      |> Mina_state.Protocol_state.body |> Mina_state.Protocol_state.Body.hash
 
     let get_previous ~context transition =
       let parent_hash =
-        transition |> External_transition.Validated.parent_hash
+        transition |> Mina_transition.External_transition.Validated.parent_hash
       in
       let open Option.Let_syntax in
       Option.merge
-        Transition_frontier.(
+        Inputs.Transition_frontier.(
           find context parent_hash >>| Breadcrumb.validated_transition)
         (find_in_root_history context parent_hash)
         ~f:Fn.const
@@ -48,7 +45,7 @@ module Make (Inputs : Inputs_intf) :
     let open Option.Let_syntax in
     let%map requested_transition =
       Option.merge
-        Transition_frontier.(
+        Inputs.Transition_frontier.(
           find frontier state_hash >>| Breadcrumb.validated_transition)
         (find_in_root_history frontier state_hash)
         ~f:Fn.const
@@ -56,7 +53,7 @@ module Make (Inputs : Inputs_intf) :
     let first_transition, merkle_list =
       Merkle_list.prove ?length ~context:frontier requested_transition
     in
-    (External_transition.Validated.state_hash first_transition, merkle_list)
+    (Mina_transition.External_transition.Validated.state_hash first_transition, merkle_list)
 end
 
 include Make (struct

--- a/src/lib/transition_frontier/catchup_hash_tree.ml
+++ b/src/lib/transition_frontier/catchup_hash_tree.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Mina_base
-open Frontier_base
 
 module Catchup_job_id = Unique_id.Int ()
 
@@ -83,6 +82,7 @@ let max_catchup_chain_length t =
   Hash_set.fold t.tips ~init:0 ~f:(fun acc tip ->
       Int.max acc (missing_length 0 (Hashtbl.find_exn t.nodes tip)) )
 
+open Frontier_base
 let create ~root =
   let root_hash = Breadcrumb.state_hash root in
   let parent = Breadcrumb.parent_hash root in

--- a/src/lib/transition_frontier/extensions/extensions.ml
+++ b/src/lib/transition_frontier/extensions/extensions.ml
@@ -1,6 +1,5 @@
 open Async_kernel
 open Core_kernel
-open Pipe_lib
 module Best_tip_diff = Best_tip_diff
 module Identity = Identity
 module Root_history = Root_history
@@ -136,7 +135,7 @@ let get_extension : type ext view. t -> (ext, view) access -> ext =
   B.extension ext
 
 let get_view_pipe : type ext view.
-    t -> (ext, view) access -> view Broadcast_pipe.Reader.t =
+    t -> (ext, view) access -> view Pipe_lib.Broadcast_pipe.Reader.t =
  fun t access ->
   let (Broadcasted_extension ((module B), ext)) = get t access in
   B.reader ext

--- a/src/lib/transition_frontier/extensions/intf.ml
+++ b/src/lib/transition_frontier/extensions/intf.ml
@@ -1,6 +1,4 @@
 open Async_kernel
-open Pipe_lib
-open Frontier_base
 
 module type Extension_base_intf = sig
   type t
@@ -11,7 +9,7 @@ module type Extension_base_intf = sig
 
   (* It is of upmost importance to make this synchronous. To prevent data races via context switching *)
   val handle_diffs :
-    t -> Full_frontier.t -> Diff.Full.With_mutant.t list -> view option
+    t -> Full_frontier.t -> Frontier_base.Diff.Full.With_mutant.t list -> view option
 end
 
 module type Broadcasted_extension_intf = sig
@@ -29,10 +27,10 @@ module type Broadcasted_extension_intf = sig
 
   val peek : t -> view
 
-  val reader : t -> view Broadcast_pipe.Reader.t
+  val reader : t -> view Pipe_lib.Broadcast_pipe.Reader.t
 
   val update :
-    t -> Full_frontier.t -> Diff.Full.With_mutant.t list -> unit Deferred.t
+    t -> Full_frontier.t -> Frontier_base.Diff.Full.With_mutant.t list -> unit Deferred.t
 end
 
 module type Extension_intf = sig

--- a/src/lib/transition_frontier/extensions/ledger_table.ml
+++ b/src/lib/transition_frontier/extensions/ledger_table.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Mina_base
-open Frontier_base
 
 (* WARNING: don't use this code until @nholland has landed a PR that
    synchronize the read/write of transition frontier
@@ -36,7 +35,7 @@ module T = struct
     in
     let breadcrumbs = Full_frontier.all_breadcrumbs frontier in
     List.iter breadcrumbs ~f:(fun bc ->
-        let ledger = Staged_ledger.ledger @@ Breadcrumb.staged_ledger bc in
+        let ledger = Staged_ledger.ledger @@ Frontier_base.Breadcrumb.staged_ledger bc in
         let ledger_hash = Ledger.merkle_root ledger in
         add_entry t ~ledger_hash ~ledger ) ;
     (t, ())
@@ -44,11 +43,11 @@ module T = struct
   let lookup t ledger_hash = Ledger_hash.Table.find t.ledgers ledger_hash
 
   let handle_diffs t _frontier diffs_with_mutants =
-    let open Diff.Full.With_mutant in
+    let open Frontier_base.Diff.Full.With_mutant in
     List.iter diffs_with_mutants ~f:(function
       | E (New_node (Full breadcrumb), _) ->
           let ledger =
-            Staged_ledger.ledger @@ Breadcrumb.staged_ledger breadcrumb
+            Staged_ledger.ledger @@ Frontier_base.Breadcrumb.staged_ledger breadcrumb
           in
           let ledger_hash = Ledger.merkle_root ledger in
           add_entry t ~ledger_hash ~ledger

--- a/src/lib/transition_frontier/extensions/root_history.ml
+++ b/src/lib/transition_frontier/extensions/root_history.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Mina_base
-open Mina_transition
 open Frontier_base
 module Queue = Hash_queue.Make (State_hash)
 
@@ -44,10 +43,10 @@ module T = struct
           ~new_scan_state:(scan_state new_oldest_root)
           ~old_root_state:
             { With_hash.data=
-                External_transition.Validated.protocol_state
+                Mina_transition.External_transition.Validated.protocol_state
                   (transition oldest_root)
             ; hash=
-                External_transition.Validated.state_hash
+                Mina_transition.External_transition.Validated.state_hash
                   (transition oldest_root) }
         |> State_hash.Map.of_alist_exn
       in
@@ -55,7 +54,7 @@ module T = struct
     assert (
       [%equal: [`Ok | `Key_already_present]] `Ok
         (Queue.enqueue_back t.history
-           (External_transition.Validated.state_hash
+           (Mina_transition.External_transition.Validated.state_hash
               (transition t.current_root))
            t.current_root) ) ;
     t.current_root <- new_root
@@ -99,7 +98,7 @@ let protocol_states_for_scan_state
         match Queue.lookup history hash with
         | Some data ->
             Some
-              (External_transition.Validated.protocol_state (transition data))
+              (Mina_transition.External_transition.Validated.protocol_state (transition data))
         | None ->
             (*Not present in the history queue, check in the protocol states map that has all the protocol states required for transactions in the root*)
             State_hash.Map.find protocol_states_for_root_scan_state hash

--- a/src/lib/transition_frontier/extensions/snark_pool_refcount.ml
+++ b/src/lib/transition_frontier/extensions/snark_pool_refcount.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-open Frontier_base
 module Work = Transaction_snark_work.Statement
 
 module T = struct
@@ -66,6 +65,7 @@ module T = struct
     remove_from_table ~get_work ~get_statement:Fn.id table scan_state
 
   let create ~logger:_ frontier =
+    let open Frontier_base in
     let t =
       { refcount_table= Work.Table.create ()
       ; best_tip_table= Work.Hash_set.create () }
@@ -85,6 +85,7 @@ module T = struct
   type diff_update = {num_removed: int; is_added: bool}
 
   let handle_diffs t frontier diffs_with_mutants =
+    let open Frontier_base in
     let open Diff.Full.With_mutant in
     let {num_removed; is_added} =
       List.fold diffs_with_mutants ~init:{num_removed= 0; is_added= false}

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -1,9 +1,7 @@
 open Async_kernel
 open Core
 open Mina_base
-open Mina_state
 open Mina_transition
-open Network_peer
 
 module T = struct
   let id = "breadcrumb"
@@ -101,9 +99,9 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
           let message = "invalid staged ledger diff: incorrect " ^ reasons in
           let%map () =
             match sender with
-            | None | Some Envelope.Sender.Local ->
+            | None | Some Network_peer.Envelope.Sender.Local ->
                 return ()
-            | Some (Envelope.Sender.Remote peer) ->
+            | Some Network_peer.(Envelope.Sender.Remote peer) ->
                 Trust_system.(
                   record trust_system logger peer
                     Actions.(Gossiped_invalid_transition, Some (message, [])))
@@ -112,9 +110,9 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values
       | Error (`Staged_ledger_application_failed staged_ledger_error) ->
           let%map () =
             match sender with
-            | None | Some Envelope.Sender.Local ->
+            | None | Some Network_peer.Envelope.Sender.Local ->
                 return ()
-            | Some (Envelope.Sender.Remote peer) ->
+            | Some Network_peer.(Envelope.Sender.Remote peer) ->
                 let error_string =
                   Staged_ledger.Staged_ledger_error.to_string
                     staged_ledger_error
@@ -193,6 +191,7 @@ let name t =
   Visualization.display_prefix_of_string @@ State_hash.to_base58_check
   @@ state_hash t
 
+open Mina_state
 type display =
   { state_hash: string
   ; blockchain_state: Blockchain_state.display

--- a/src/lib/transition_frontier/full_catchup_tree.ml
+++ b/src/lib/transition_frontier/full_catchup_tree.ml
@@ -1,10 +1,8 @@
 open Core
 open Async
-open Cache_lib
 open Mina_base
 open Mina_transition
 open Network_peer
-open Mina_numbers
 
 module Attempt_history = struct
   module Attempt = struct
@@ -28,7 +26,7 @@ open Frontier_base
 
 module Downloader_job = struct
   type t =
-    ( State_hash.t * Length.t
+    ( State_hash.t * Mina_numbers.Length.t
     , Attempt_history.Attempt.t
     , External_transition.t )
     Downloader.Job.t
@@ -37,12 +35,13 @@ module Downloader_job = struct
     let h, l = t.key in
     `Assoc
       [ ("hash", State_hash.to_yojson h)
-      ; ("length", Length.to_yojson l)
+      ; ("length", Mina_numbers.Length.to_yojson l)
       ; ("attempts", Attempt_history.to_yojson t.attempts) ]
 
   let result (t : t) = Ivar.read t.res
 end
 
+open Cache_lib
 module Node = struct
   module State = struct
     type t =
@@ -107,7 +106,7 @@ module Node = struct
     { mutable state: State.t
     ; mutable attempts: Attempt_history.t
     ; state_hash: State_hash.t
-    ; blockchain_length: Length.t
+    ; blockchain_length: Mina_numbers.Length.t
     ; parent: State_hash.t
     ; result: ([`Added_to_frontier], Attempt_history.t) Result.t Ivar.t }
 end

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 open Mina_base
 open Mina_state
-open Mina_transition
 open Frontier_base
 
 module Node = struct
@@ -92,7 +91,7 @@ let find_protocol_state (t : t) hash =
   | Some breadcrumb ->
       Some
         ( Breadcrumb.validated_transition breadcrumb
-        |> External_transition.Validated.protocol_state )
+        |> Mina_transition.External_transition.Validated.protocol_state )
 
 let root t = find_exn t t.root
 
@@ -113,13 +112,13 @@ let create ~logger ~root_data ~root_ledger ~consensus_local_state ~max_length
   let open Root_data in
   let transition_receipt_time = None in
   let root_hash =
-    External_transition.Validated.state_hash root_data.transition
+    Mina_transition.External_transition.Validated.state_hash root_data.transition
   in
   let protocol_states_for_root_scan_state =
     State_hash.Map.of_alist_exn root_data.protocol_states
   in
   let root_protocol_state =
-    External_transition.Validated.protocol_state root_data.transition
+    Mina_transition.External_transition.Validated.protocol_state root_data.transition
   in
   let root_blockchain_state =
     Protocol_state.blockchain_state root_protocol_state
@@ -392,7 +391,7 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
     (* STEP 1 *)
     List.iter garbage ~f:(fun node ->
         let open Diff.Node_list in
-        let hash = External_transition.Validated.state_hash node.transition in
+        let hash = Mina_transition.External_transition.Validated.state_hash node.transition in
         let breadcrumb = find_exn t hash in
         let mask = Breadcrumb.mask breadcrumb in
         (* this should get garbage collected and should not require additional destruction *)
@@ -618,7 +617,7 @@ module Metrics = struct
   let has_coinbase b =
     let d1, d2 =
       ( Breadcrumb.validated_transition b
-      |> External_transition.Validated.staged_ledger_diff )
+      |> Mina_transition.External_transition.Validated.staged_ledger_diff )
         .diff
     in
     match (d1.coinbase, d2) with

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -17,7 +17,6 @@ let rec deferred_list_result_iter ls ~f =
       deferred_list_result_iter t ~f
 
 (* TODO: should debug assert garbage checks be added? *)
-open Result.Let_syntax
 
 (* TODO: implement versions with module versioning. For
  * now, this is just stubbed so we can add db migrations
@@ -223,6 +222,7 @@ let get db ~key ~error =
 
 (* TODO: check that best tip is connected to root *)
 (* TODO: check for garbage *)
+open Result.Let_syntax
 let check t ~genesis_state_hash =
   Or_error.try_with (fun () ->
       let check_version () =

--- a/src/lib/transition_frontier/persistent_frontier/diff_buffer.ml
+++ b/src/lib/transition_frontier/persistent_frontier/diff_buffer.ml
@@ -1,7 +1,6 @@
 (* TODO: flush on timeout interval in addition to meeting flush capacity *)
 open Async_kernel
 open Core_kernel
-open Frontier_base
 
 let max_latency
     {Genesis_constants.Constraint_constants.block_window_duration_ms; _} =
@@ -46,10 +45,10 @@ module Timer = struct
   let reset t = stop t ; start t
 end
 
-type work = {diffs: Diff.Lite.E.t list}
+type work = {diffs: Frontier_base.Diff.Lite.E.t list}
 
 type t =
-  { diff_array: Diff.Lite.E.t DynArray.t
+  { diff_array: Frontier_base.Diff.Lite.E.t DynArray.t
   ; worker: Worker.t
         (* timer unfortunately needs to be mutable to break recursion *)
   ; mutable timer: Timer.t option

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -1,7 +1,6 @@
 open Async_kernel
 open Core
 open Mina_base
-open Mina_state
 open Mina_transition
 open Frontier_base
 module Database = Database
@@ -11,6 +10,7 @@ exception Invalid_genesis_state_hash of External_transition.Validated.t
 let construct_staged_ledger_at_root
     ~(precomputed_values : Precomputed_values.t) ~root_ledger ~root_transition
     ~root ~protocol_states ~logger =
+  let open Mina_state in
   let open Deferred.Or_error.Let_syntax in
   let open Root_data.Minimal in
   let snarked_ledger_hash =
@@ -185,6 +185,7 @@ module Instance = struct
   let load_full_frontier t ~root_ledger ~consensus_local_state ~max_length
       ~ignore_consensus_local_state ~precomputed_values
       ~persistent_root_instance =
+    let open Mina_state in
     let open Deferred.Result.Let_syntax in
     let downgrade_transition transition genesis_state_hash :
         ( External_transition.Almost_validated.t

--- a/src/lib/transition_frontier/persistent_frontier/worker.ml
+++ b/src/lib/transition_frontier/persistent_frontier/worker.ml
@@ -2,9 +2,8 @@ open Async
 open Core
 open Otp_lib
 open Mina_base
-open Frontier_base
 
-type input = Diff.Lite.E.t list
+type input = Frontier_base.Diff.Lite.E.t list
 
 type create_args =
   { db: Database.t
@@ -58,7 +57,7 @@ module Worker = struct
     | `Not_found (`Arcs hash) ->
         Printf.sprintf "arcs not found for %s" (State_hash.to_base58_check hash)
 
-  let apply_diff (type mutant) (t : t) (diff : mutant Diff.Lite.t) :
+  let apply_diff (type mutant) (t : t) (diff : mutant Frontier_base.Diff.Lite.t) :
       (mutant, apply_diff_error) Result.t =
     let map_error result ~diff_type ~diff_type_name =
       Result.map_error result ~f:(fun err ->
@@ -105,7 +104,7 @@ module Worker = struct
           ( Database.set_best_tip t.db best_tip_hash
             :> (mutant, apply_diff_error_internal) Result.t )
 
-  let handle_diff t (Diff.Lite.E.E diff) =
+  let handle_diff t Frontier_base.(Diff.Lite.E.E diff) =
     let open Result.Let_syntax in
     let%map _mutant = apply_diff t diff in
     ()

--- a/src/lib/transition_frontier/persistent_root/persistent_root.ml
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.ml
@@ -1,9 +1,9 @@
 open Core
 open Mina_base
-open Frontier_base
 module Ledger_transfer = Ledger_transfer.Make (Ledger) (Ledger.Db)
 
 let genesis_root_identifier ~genesis_state_hash =
+  let open Frontier_base in
   let open Root_identifier.Stable.Latest in
   {state_hash= genesis_state_hash}
 
@@ -215,6 +215,7 @@ module Instance = struct
   let snarked_ledger {snarked_ledger; _} = snarked_ledger
 
   let set_root_identifier t new_root_identifier =
+    let open Frontier_base in
     [%log' trace t.factory.logger]
       ~metadata:
         [("root_identifier", Root_identifier.to_yojson new_root_identifier)]
@@ -229,6 +230,7 @@ module Instance = struct
 
   (* defaults to genesis *)
   let load_root_identifier t =
+    let open Frontier_base in
     let file = Locations.root_identifier t.factory.directory in
     match Unix.access file [`Exists; `Read] with
     | Error _ ->

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -4,9 +4,7 @@ open Async_kernel
 open Core_kernel
 open Signature_lib
 open Mina_base
-open Mina_transition
 open Frontier_base
-open Deferred.Let_syntax
 
 let%test_module "Full_frontier tests" =
   ( module struct
@@ -79,7 +77,7 @@ let%test_module "Full_frontier tests" =
       in
       let root_data =
         let open Root_data in
-        { transition= External_transition.For_tests.genesis ~precomputed_values
+        { transition= Mina_transition.External_transition.For_tests.genesis ~precomputed_values
         ; staged_ledger=
             Staged_ledger.create_exn ~constraint_constants ~ledger:root_ledger
         ; protocol_states= [] }
@@ -105,6 +103,7 @@ let%test_module "Full_frontier tests" =
       in
       Persistent_root.Instance.destroy persistent_root_instance
 
+    open Deferred.Let_syntax
     let%test_unit "Should be able to find a breadcrumbs after adding them" =
       Quickcheck.test gen_breadcrumb ~trials:4 ~f:(fun make_breadcrumb ->
           Async.Thread_safe.block_on_async_exn (fun () ->

--- a/src/lib/transition_handler/breadcrumb_builder.ml
+++ b/src/lib/transition_handler/breadcrumb_builder.ml
@@ -1,12 +1,10 @@
 open Mina_base
 open Core
 open Async
-open Cache_lib
-open Mina_transition
-open Network_peer
 
 let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
     ~trust_system ~frontier ~initial_hash subtrees_of_enveloped_transitions =
+  let open Cache_lib in
   let missing_parent_msg =
     Printf.sprintf
       "Transition frontier already garbage-collected the parent of %s"
@@ -28,8 +26,8 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                        Rose_tree.to_yojson
                          (fun enveloped_transitions ->
                            Cached.peek enveloped_transitions
-                           |> Envelope.Incoming.data
-                           |> External_transition.Initial_validated.state_hash
+                           |> Network_peer.Envelope.Incoming.data
+                           |> Mina_transition.External_transition.Initial_validated.state_hash
                            |> Mina_base.State_hash.to_yojson)
                          subtree)) )
             ]
@@ -60,7 +58,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
               ~f:(fun enveloped_transition ->
                 let open Deferred.Or_error.Let_syntax in
                 let transition_with_initial_validation =
-                  Envelope.Incoming.data enveloped_transition
+                  Network_peer.Envelope.Incoming.data enveloped_transition
                 in
                 let transition_receipt_time = Some (Time.now ()) in
                 let transition_with_hash, _ =
@@ -70,18 +68,18 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                   (* TODO: handle this edge case more gracefully *)
                   (* since we are building a disconnected subtree of breadcrumbs,
                    * we skip this step in validation *)
-                  External_transition.skip_frontier_dependencies_validation
+                  Mina_transition.External_transition.skip_frontier_dependencies_validation
                     `This_transition_belongs_to_a_detached_subtree
                     transition_with_initial_validation
                 in
-                let sender = Envelope.Incoming.sender enveloped_transition in
+                let sender = Network_peer.Envelope.Incoming.sender enveloped_transition in
                 let parent = Cached.peek cached_parent in
                 let expected_parent_hash =
                   Transition_frontier.Breadcrumb.state_hash parent
                 in
                 let actual_parent_hash =
                   transition_with_hash |> With_hash.data
-                  |> External_transition.parent_hash
+                  |> Mina_transition.External_transition.parent_hash
                 in
                 let%bind () =
                   Deferred.return
@@ -126,7 +124,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                         let subtree_nodes = Rose_tree.flatten subtree in
                         let ip_address_set =
                           let sender_from_tree_node node =
-                            Envelope.Incoming.sender (Cached.peek node)
+                            Network_peer.Envelope.Incoming.sender (Cached.peek node)
                           in
                           List.fold subtree_nodes
                             ~init:(Set.empty (module Network_peer.Peer))

--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -1,6 +1,5 @@
 open Core
 open Async
-open Pipe_lib
 
 let tmp_bans_are_disabled = false
 
@@ -85,6 +84,7 @@ end
 
 include Log_events
 
+open Pipe_lib
 module Make0 (Inputs : Input_intf) = struct
   open Inputs
 

--- a/src/lib/unsigned_extended/unsigned_extended.ml
+++ b/src/lib/unsigned_extended/unsigned_extended.ml
@@ -8,7 +8,6 @@ include Intf
 [%%ifdef consensus_mechanism]
 
 open Snark_params
-open Tick
 
 [%%else]
 
@@ -23,7 +22,7 @@ module Extend
       val length : int
     end) : S with type t = Unsigned.t = struct
   ;;
-  assert (M.length < Field.size_in_bits - 3)
+  assert (M.length < Tick.Field.size_in_bits - 3)
 
   let length_in_bits = M.length
 

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -3,16 +3,14 @@
 open Core_kernel
 open Async
 open Mina_base
-open Mina_state
 open Blockchain_snark
-open O1trace
 
 type ledger_proof = Ledger_proof.Prod.t
 
 module Worker_state = struct
   module type S = sig
     val verify_blockchain_snarks :
-      (Protocol_state.Value.t * Proof.t) list -> bool Deferred.t
+      (Mina_state.Protocol_state.Value.t * Proof.t) list -> bool Deferred.t
 
     val verify_commands :
          Mina_base.User_command.Verifiable.t list
@@ -416,7 +414,7 @@ let with_retry ~logger f =
   go 4
 
 let verify_blockchain_snarks { worker; logger } chains =
-  trace_recurring "Verifier.verify_blockchain_snarks" (fun () ->
+  O1trace.trace_recurring "Verifier.verify_blockchain_snarks" (fun () ->
       with_retry ~logger (fun () ->
           let%bind { connection; _ } =
             let ivar = !worker in
@@ -442,7 +440,7 @@ let verify_blockchain_snarks { worker; logger } chains =
 module Id = Unique_id.Int ()
 
 let verify_transaction_snarks { worker; logger } ts =
-  trace_recurring "Verifier.verify_transaction_snarks" (fun () ->
+  O1trace.trace_recurring "Verifier.verify_transaction_snarks" (fun () ->
       let id = Id.create () in
       let n = List.length ts in
       let metadata () =
@@ -467,7 +465,7 @@ let verify_transaction_snarks { worker; logger } ts =
       res)
 
 let verify_commands { worker; logger } ts =
-  trace_recurring "Verifier.verify_commands" (fun () ->
+  O1trace.trace_recurring "Verifier.verify_commands" (fun () ->
       with_retry ~logger (fun () ->
           let%bind { connection; _ } = Ivar.read !worker in
           Worker.Connection.run connection ~f:Worker.functions.verify_commands

--- a/src/lib/vrf_lib/tests/standalone_test.ml
+++ b/src/lib/vrf_lib/tests/standalone_test.ml
@@ -84,13 +84,13 @@ let%test_module "vrf-test" =
     end
 
     module Group = struct
-      open Impl
 
       module T = struct
         type t = Curve.t
 
         include Sexpable.Of_sexpable
                   (struct
+                    let open Impl in
                     type t = Field.t * Field.t [@@deriving sexp]
                   end)
                   (struct
@@ -122,6 +122,7 @@ let%test_module "vrf-test" =
       let typ = Curve.typ
 
       let to_bits (t : t) =
+        let open Impl in
         let x, y = Curve.to_affine_exn t in
         List.hd_exn (Field.unpack y) :: Field.unpack x
 
@@ -152,6 +153,7 @@ let%test_module "vrf-test" =
         include Curve.Checked
 
         let to_bits ((x, y) : var) =
+          let open Impl in
           let%map x =
             Field.Checked.choose_preimage_var ~length:Field.size_in_bits x
           and y =

--- a/src/lib/work_selector/test.ml
+++ b/src/lib/work_selector/test.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 open Async
 open Currency
-open Pipe_lib
 
 module Make_test (Make_selection_method : Intf.Make_selection_method_intf) =
 struct
@@ -21,12 +20,12 @@ struct
   let precomputed_values = Precomputed_values.for_unit_tests
 
   let init_state sl reassignment_wait logger =
-    let tf_reader, tf_writer = Broadcast_pipe.create None in
+    let tf_reader, tf_writer = Pipe_lib.Broadcast_pipe.create None in
     let work_state =
       Lib.State.init ~reassignment_wait ~frontier_broadcast_pipe:tf_reader
         ~logger
     in
-    let%map () = Broadcast_pipe.Writer.write tf_writer (Some sl) in
+    let%map () = Pipe_lib.Broadcast_pipe.Writer.write tf_writer (Some sl) in
     work_state
 
   let%test_unit "Workspec chunk doesn't send same things again" =


### PR DESCRIPTION
This PR updates the repo with the output of a sample run of @Firobe's tool described in #10058. This uses the `.ocamlclose` configuration file from that RFC with a few additional modules added to the whitelist (see [here](https://github.com/MinaProtocol/mina/blob/9bb9c988e59593c36798597916e23310c76133aa/.ocamlclose)).

This is intended for review of the tool's output and the choice of rules; this is not intended to be merged.

To build the tool:
```bash
git clone https://github.com/tweag/ocaml-close.git
cd ocaml-close
opam pin feather https://github.com/charlesetc/feather.git#495fb4d027503107ece462f22111e73d4f4d084c
dune build @install
```

To reproduce this output:
```bash
cd /path/to/mina
/path/to/ocaml-close/_build/default/bin/run.exe lint --silence-errors --skip-absent $(find src/lib -name '*.ml')
# The command above will spit out a filename /tmp/patchXXXXXX.close, which we use below
/path/to/ocaml-close/_build/default/bin/run.exe patch -i /tmp/patchXXXXXX.close
```

The `-i` argument to the final command will clobber the existing `.ml` files with the suggested changes, so it's recommended that you start with a clean tree. If you omit the `-i` argument and want to remove all of the generated `.ml.close.ml` files(which `git reset` will not get rid of!), you can run `rm $(find src/lib -name '*.ml.close.ml')`.