### PR TITLE
Add non-circuit equivalent functions to Currency, add missing functions

### DIFF
--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -151,7 +151,14 @@ module Balance : sig
 
   val add_amount : t -> Amount.t -> t option
 
+  val add_amount_flagged : t -> Amount.t -> t * [ `Overflow of bool ]
+
   val sub_amount : t -> Amount.t -> t option
+
+  val sub_amount_flagged : t -> Amount.t -> t * [ `Underflow of bool ]
+
+  val add_signed_amount_flagged :
+    t -> Amount.Signed.t -> t * [ `Overflow of bool ]
 
   val ( + ) : t -> Amount.t -> t option
 

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -268,8 +268,6 @@ module type S = sig
   module Signed :
     Signed_intf with type magnitude := t and type magnitude_var := var
 
-  val add_signed_flagged : t -> Signed.t -> t * [ `Overflow of bool ]
-
   module Checked :
     Checked_arithmetic_intf
       with type var := var
@@ -281,4 +279,6 @@ module type S = sig
   module Signed : Signed_intf with type magnitude := t
 
   [%%endif]
+
+  val add_signed_flagged : t -> Signed.t -> t * [ `Overflow of bool ]
 end

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -95,6 +95,8 @@ module type Arithmetic_intf = sig
 
   val sub : t -> t -> t option
 
+  val sub_flagged : t -> t -> t * [ `Underflow of bool ]
+
   val ( + ) : t -> t -> t option
 
   val ( - ) : t -> t -> t option
@@ -265,6 +267,8 @@ module type S = sig
 
   module Signed :
     Signed_intf with type magnitude := t and type magnitude_var := var
+
+  val add_signed_flagged : t -> Signed.t -> t * [ `Overflow of bool ]
 
   module Checked :
     Checked_arithmetic_intf


### PR DESCRIPTION
This PR
* adds some functions to the non-circuit currency interface to allow it to be used interchangeably with the circuit version (for snapps logic unification)
* exposes some new functions that are needed in the unified snapps logic.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them