### PR TITLE
Move timing update into combined transaction logic

### DIFF
--- a/src/lib/mina_base/parties_logic.ml
+++ b/src/lib/mina_base/parties_logic.ml
@@ -56,6 +56,24 @@ module type Amount_intf = sig
   val add_signed_flagged : t -> Signed.t -> t * [ `Overflow of bool ]
 end
 
+module type Global_slot_intf = sig
+  type t
+
+  type bool
+
+  val zero : t
+
+  val ( > ) : t -> t -> bool
+end
+
+module type Timing_intf = sig
+  include Iffable
+
+  type global_slot
+
+  val vesting_period : t -> global_slot
+end
+
 module type Token_id_intf = sig
   include Iffable
 
@@ -148,6 +166,18 @@ module Local_state = struct
   end
 end
 
+module type Set_or_keep_intf = sig
+  type _ t
+
+  type bool
+
+  val is_set : _ t -> bool
+
+  val is_keep : _ t -> bool
+
+  val set_or_keep : if_:(bool -> then_:'a -> else_:'a -> 'a) -> 'a t -> 'a -> 'a
+end
+
 module type Party_intf = sig
   type t
 
@@ -184,7 +214,15 @@ module type Party_intf = sig
     -> commitment:transaction_commitment
     -> at_party:parties
     -> t
-    -> [ `Signature_verifies of bool ]
+    -> [ `Proof_verifies of bool ] * [ `Signature_verifies of bool ]
+
+  module Update : sig
+    type _ set_or_keep
+
+    type timing
+
+    val timing : t -> timing set_or_keep
+  end
 end
 
 module type Parties_intf = sig
@@ -247,6 +285,16 @@ module type Ledger_intf = sig
     public_key -> token_id -> account * inclusion_proof -> [ `Is_new of bool ]
 end
 
+module type Account_intf = sig
+  type t
+
+  type timing
+
+  val timing : t -> timing
+
+  val set_timing : timing -> t -> t
+end
+
 module Eff = struct
   type (_, _) t =
     | Check_predicate :
@@ -302,11 +350,16 @@ module type Inputs_intf = sig
 
   module Token_id : Token_id_intf with type bool := Bool.t
 
+  module Set_or_keep : Set_or_keep_intf with type bool := Bool.t
+
   module Protocol_state_predicate : Protocol_state_predicate_intf
 
-  module Account : sig
-    type t
-  end
+  module Global_slot : Global_slot_intf with type bool := Bool.t
+
+  module Timing :
+    Timing_intf with type bool := Bool.t and type global_slot := Global_slot.t
+
+  module Account : Account_intf with type timing := Timing.t
 
   module Party :
     Party_intf
@@ -316,6 +369,8 @@ module type Inputs_intf = sig
        and type bool := Bool.t
        and type account := Account.t
        and type public_key := Public_key.t
+       and type Update.timing := Timing.t
+       and type 'a Update.set_or_keep := 'a Set_or_keep.t
 
   module Ledger :
     Ledger_intf
@@ -536,7 +591,7 @@ module Make (Inputs : Inputs_intf) = struct
         (Check_protocol_state_predicate
            (Party.protocol_state party, global_state))
     in
-    let (`Signature_verifies signature_verifies) =
+    let `Proof_verifies _, `Signature_verifies signature_verifies =
       let commitment =
         Inputs.Transaction_commitment.if_
           (Inputs.Party.use_full_commitment party)
@@ -560,6 +615,23 @@ module Make (Inputs : Inputs_intf) = struct
     let (`Is_new account_is_new) =
       Inputs.Ledger.check_account (Party.public_key party)
         (Party.token_id party) (a, inclusion_proof)
+    in
+    (* Set account timing for new accounts, if specified. *)
+    let a, local_state =
+      let timing = Party.Update.timing party in
+      let local_state =
+        Local_state.add_check local_state
+          Update_not_permitted_timing_existing_account
+          Bool.(account_is_new ||| Set_or_keep.is_keep timing)
+      in
+      let timing =
+        Set_or_keep.set_or_keep ~if_:Timing.if_ timing (Account.timing a)
+      in
+      let vesting_period = Timing.vesting_period timing in
+      (* Assert that timing is valid, otherwise we may have a division by 0. *)
+      Bool.assert_ Global_slot.(vesting_period > zero) ;
+      let a = Account.set_timing timing a in
+      (a, local_state)
     in
     let a', update_permitted, failure_status =
       h.perform

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -113,6 +113,28 @@ module Update = struct
       ; vesting_increment = amount_unused
       }
 
+    let to_account_timing (t : t) : Account_timing.t =
+      Timed
+        { initial_minimum_balance = t.initial_minimum_balance
+        ; cliff_time = t.cliff_time
+        ; cliff_amount = t.cliff_amount
+        ; vesting_period = t.vesting_period
+        ; vesting_increment = t.vesting_increment
+        }
+
+    let of_account_timing (t : Account_timing.t) : t option =
+      match t with
+      | Untimed ->
+          None
+      | Timed t ->
+          Some
+            { initial_minimum_balance = t.initial_minimum_balance
+            ; cliff_time = t.cliff_time
+            ; cliff_amount = t.cliff_amount
+            ; vesting_period = t.vesting_period
+            ; vesting_increment = t.vesting_increment
+            }
+
     module Checked = struct
       type t =
         { initial_minimum_balance : Balance.Checked.t
@@ -146,6 +168,23 @@ module Update = struct
           ; Global_slot.Checked.to_input vesting_period
           ; Amount.var_to_input vesting_increment
           ]
+
+      let to_account_timing (t : t) : Account_timing.var =
+        { is_timed = Boolean.true_
+        ; initial_minimum_balance = t.initial_minimum_balance
+        ; cliff_time = t.cliff_time
+        ; cliff_amount = t.cliff_amount
+        ; vesting_period = t.vesting_period
+        ; vesting_increment = t.vesting_increment
+        }
+
+      let of_account_timing (t : Account_timing.var) : t =
+        { initial_minimum_balance = t.initial_minimum_balance
+        ; cliff_time = t.cliff_time
+        ; cliff_amount = t.cliff_amount
+        ; vesting_period = t.vesting_period
+        ; vesting_increment = t.vesting_increment
+        }
     end
 
     let typ : (Checked.t, t) Typ.t =

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1541,9 +1541,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       type t = Public_key.Compressed.t
     end
 
-    module Global_slot = struct
-      include Mina_numbers.Global_slot
-    end
+    module Global_slot = Mina_numbers.Global_slot
 
     module Timing = struct
       type t = Party.Update.Timing_info.t option

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1258,7 +1258,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
                ; permissions
                ; snapp_uri
                ; token_symbol
-               ; timing
+               ; timing = _
                }
            ; balance_change
            ; increment_nonce
@@ -1300,33 +1300,11 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
              | Neg ->
                  a.permissions.send ))
     in
-    let%bind timing =
-      match timing with
-      | Keep ->
-          Ok a.timing
-      | Set timing_info when is_new ->
-          if Global_slot.(timing_info.vesting_period > zero) then
-            Ok
-              (Timed
-                 { initial_minimum_balance = timing_info.initial_minimum_balance
-                 ; cliff_time = timing_info.cliff_time
-                 ; cliff_amount = timing_info.cliff_amount
-                 ; vesting_period = timing_info.vesting_period
-                 ; vesting_increment = timing_info.vesting_increment
-                 })
-          else
-            (* This should be a reject, not a failure, otherwise the snark
-               circuit becomes unsatisfiable.
-            *)
-            failwith "Transaction contains invalid timing information"
-      | Set _ ->
-          Error (failure Update_not_permitted_timing_existing_account)
-    in
     (* Check timing. *)
     let%bind timing =
       match balance_change.sgn with
       | Pos when not is_new ->
-          Ok timing
+          Ok a.timing
       | _ ->
           let txn_amount =
             match balance_change.sgn with
@@ -1336,8 +1314,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
                 balance_change.magnitude
           in
           validate_timing ~txn_amount
-            ~txn_global_slot:state_view.global_slot_since_genesis
-            ~account:{ a with timing }
+            ~txn_global_slot:state_view.global_slot_since_genesis ~account:a
           |> Result.map_error ~f:timing_error_to_user_command_status
     in
     let init =
@@ -1564,8 +1541,37 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       type t = Public_key.Compressed.t
     end
 
+    module Global_slot = struct
+      include Mina_numbers.Global_slot
+    end
+
+    module Timing = struct
+      type t = Party.Update.Timing_info.t option
+
+      let if_ = Parties.value_if
+
+      let vesting_period (t : t) =
+        match t with
+        | Some t ->
+            t.vesting_period
+        | None ->
+            (Account_timing.to_record Untimed).vesting_period
+    end
+
     module Account = struct
       include Account
+
+      type timing = Party.Update.Timing_info.t option
+
+      let timing (a : t) : timing =
+        Party.Update.Timing_info.of_account_timing a.timing
+
+      let set_timing (timing : timing) (a : t) : t =
+        { a with
+          timing =
+            Option.value_map ~default:Account_timing.Untimed
+              ~f:Party.Update.Timing_info.to_account_timing timing
+        }
     end
 
     module Amount = struct
@@ -1632,9 +1638,26 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         *)
         match party.authorization with
         | Signature _ ->
-            `Signature_verifies true
-        | Proof _ | None_given ->
-            `Signature_verifies false
+            (`Proof_verifies false, `Signature_verifies true)
+        | Proof _ ->
+            (`Proof_verifies true, `Signature_verifies false)
+        | None_given ->
+            (`Proof_verifies false, `Signature_verifies false)
+
+      module Update = struct
+        open Snapp_basic
+
+        type 'a set_or_keep = 'a Snapp_basic.Set_or_keep.t
+
+        let timing (party : t) : Account.timing set_or_keep =
+          Set_or_keep.map ~f:Option.some party.data.body.update.timing
+      end
+    end
+
+    module Set_or_keep = struct
+      include Snapp_basic.Set_or_keep
+
+      let set_or_keep ~if_:_ t x = set_or_keep t x
     end
 
     module Parties = struct


### PR DESCRIPTION
This PR replaces the separate implementations of timing updates between the snark logic and the transaction logic with a unified implementation in parties logic.

This is part of the work towards #10033.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them