### PR TITLE
Rosetta: Adds nonce to the /account/balance response

### DIFF
--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -324,7 +324,7 @@ module Balance = struct
             let balance_info : Balance_info.t =
               {liquid_balance= 0L; total_balance= 0L}
             in
-            Result.return @@ (dummy_block_identifier, balance_info, UInt64.zero) )
+            Result.return @@ (dummy_block_identifier, balance_info, Unsigned.UInt64.zero) )
       ; validate_network_choice= Network.Validate_choice.Mock.succeed }
   end
 


### PR DESCRIPTION
Explain your changes:
* Adds nonce to the /account/balance response via archive DB query change

Explain how you tested your changes:
* Manually connected to mainnet nodes and tried queries -- the correct nonce is retrieved on non-historical queries and what looks to be correct nonces are returned on historical ones.
