### PR TITLE
Integration test and gating config fixes

### DIFF
--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -24,7 +24,7 @@ in Pipeline.build Pipeline.Config::{
   },
   steps = [
     TestExecutive.build "integration_tests",
-    -- TestExecutive.execute "peers-reliability" dependsOn,
+    TestExecutive.execute "peers-reliability" dependsOn,
     TestExecutive.execute "chain-reliability" dependsOn,
     TestExecutive.execute "payment" dependsOn,
     TestExecutive.execute "gossip-consis" dependsOn,

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -42,6 +42,6 @@ These flags are supported in the `daemon` object of the config file:
 
 The daemon will read some environment variables on startup.
 
-`CODA_CLIENT_TRUSTLIST` is a comma-separated list of CIDR masks, for example `10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` would allow any client on an RFC1918 private network to control the daemon. This list can be edited with `mina advanced client-trustlist` commands.
+`MINA_CLIENT_TRUSTLIST` is a comma-separated list of CIDR masks, for example `10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` would allow any client on an RFC1918 private network to control the daemon. This list can be edited with `mina advanced client-trustlist` commands.
 
 There are other environment variables, but they aren't documented yet.

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -85,8 +85,6 @@ spec:
           value: {{ .Values.mina.ports.p2p | quote }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
-        - name: CONNECT_PRIVATE_IPS
-          value: "true"
         ports:
         - name: client-port
           protocol: TCP 

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -83,7 +83,7 @@ spec:
           value: {{ .Values.mina.ports.metrics | quote }}
         - name: DAEMON_EXTERNAL_PORT
           value: {{ .Values.mina.ports.p2p | quote }}
-        - name: CODA_CLIENT_TRUSTLIST
+        - name: MINA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
         ports:
         - name: client-port

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -248,7 +248,7 @@ spec:
         - name: MINA_LIBP2P_PASS
           value: {{ $.Values.mina.privkeyPass | quote }}
         {{- end }}
-        - name: CODA_CLIENT_TRUSTLIST
+        - name: MINA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
         ports:
         - name: client-port

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -250,8 +250,6 @@ spec:
         {{- end }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
-        - name: CONNECT_PRIVATE_IPS
-          value: "true"
         ports:
         - name: client-port
           protocol: TCP

--- a/helm/plain-node/templates/plain-node.yaml
+++ b/helm/plain-node/templates/plain-node.yaml
@@ -74,7 +74,7 @@ spec:
           value: {{ $.Values.mina.ports.client | quote }}
         - name: DAEMON_METRICS_PORT
           value: {{ $.Values.mina.ports.metrics | quote }}
-        - name: CODA_CLIENT_TRUSTLIST
+        - name: MINA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
         - name: GCLOUD_KEYFILE
           value: "/gcloud/keyfile.json"

--- a/helm/plain-node/templates/plain-node.yaml
+++ b/helm/plain-node/templates/plain-node.yaml
@@ -76,8 +76,6 @@ spec:
           value: {{ $.Values.mina.ports.metrics | quote }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
-        - name: CONNECT_PRIVATE_IPS
-          value: "true"
         - name: GCLOUD_KEYFILE
           value: "/gcloud/keyfile.json"
         - name: NETWORK_NAME

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -101,7 +101,7 @@ spec:
           value: {{ $.Values.mina.ports.client | quote }}
         - name: DAEMON_METRICS_PORT
           value: {{ $.Values.mina.ports.metrics | quote }}
-        - name: CODA_CLIENT_TRUSTLIST
+        - name: MINA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
         - name: GCLOUD_KEYFILE
           value: "/gcloud/keyfile.json"

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -103,8 +103,6 @@ spec:
           value: {{ $.Values.mina.ports.metrics | quote }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
-        - name: CONNECT_PRIVATE_IPS
-          value: "true"
         - name: GCLOUD_KEYFILE
           value: "/gcloud/keyfile.json"
         - name: NETWORK_NAME

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -74,8 +74,6 @@ spec:
           value: {{ $.Values.mina.ports.metrics | quote }}
         - name: CODA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
-        - name: CONNECT_PRIVATE_IPS
-          value: "true"
         - name: CODA_SNARK_KEY
           value: {{ $.Values.publicKey | quote }}
         - name: CODA_SNARK_FEE

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -72,7 +72,7 @@ spec:
           value: {{ $.Values.mina.ports.client | quote }}
         - name: DAEMON_METRICS_PORT
           value: {{ $.Values.mina.ports.metrics | quote }}
-        - name: CODA_CLIENT_TRUSTLIST
+        - name: MINA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
         - name: CODA_SNARK_KEY
           value: {{ $.Values.publicKey | quote }}

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1096,6 +1096,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
           ; isolate = Option.value ~default:false isolate
           ; keypair = libp2p_keypair
           ; all_peers_seen_metric
+          ; known_private_ip_nets = Option.value ~default:[] client_trustlist
           }
       in
       let net_config =

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -432,6 +432,7 @@ module T = struct
               ; mina_peer_exchange = true
               ; keypair = Some libp2p_keypair
               ; all_peers_seen_metric = false
+              ; known_private_ip_nets = []
               }
           in
           let net_config =

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -147,6 +147,7 @@ let run_test () : unit Deferred.t =
           ; validation_queue_size = 150
           ; keypair = None
           ; all_peers_seen_metric = false
+          ; known_private_ip_nets = []
           }
       in
       let net_config =

--- a/src/app/libp2p_helper/Makefile
+++ b/src/app/libp2p_helper/Makefile
@@ -14,7 +14,7 @@ libp2p_helper: ../../libp2p_ipc/libp2p_ipc.capnp.go
 test: ../../libp2p_ipc/libp2p_ipc.capnp.go
 	cd src/libp2p_helper \
 		&& (ulimit -n 65536 || true) \
-		&& $(GO) test -short -timeout 25m
+		&& $(GO) test -short -timeout 40m
 
 test-bs-qc: ../../libp2p_ipc/libp2p_ipc.capnp.go
 	cd src/libp2p_helper \

--- a/src/app/libp2p_helper/Makefile
+++ b/src/app/libp2p_helper/Makefile
@@ -12,12 +12,14 @@ libp2p_helper: ../../libp2p_ipc/libp2p_ipc.capnp.go
 	$(WRAPAPP) ../../../scripts/build-go-helper.sh libp2p_helper
 
 test: ../../libp2p_ipc/libp2p_ipc.capnp.go
-	cd src/libp2p_helper && $(GO) test -short -timeout 15m
+	cd src/libp2p_helper \
+		&& (ulimit -n 65536 || true) \
+		&& $(GO) test -short -timeout 25m
 
 test-bs-qc: ../../libp2p_ipc/libp2p_ipc.capnp.go
 	cd src/libp2p_helper \
 		&& (ulimit -n 65536 || true) \
-		&& $(GO) test -timeout 40m -run "^TestBitswapQC$$"
+		&& $(GO) test -timeout 60m -run "^TestBitswapQC$$"
 
 test-large: ../../libp2p_ipc/libp2p_ipc.capnp.go
 	cd src/libp2p_helper \

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -400,7 +400,7 @@ func (h *Helper) SetGatingState(gs *CodaGatingConfig) {
 	for _, c := range h.Host.Network().Conns() {
 		pid := c.RemotePeer()
 		maddr := c.RemoteMultiaddr()
-		if !h.gatingState.isAllowedPeerWithAddr(pid, maddr) {
+		if h.gatingState.checkAllowedPeerWithAddr(pid, maddr).isDeny() {
 			go func() {
 				if err := h.Host.Network().ClosePeer(pid); err != nil {
 					h.gatingState.logger.Infof("failed to close banned peer %v: %v", pid, err)
@@ -428,36 +428,101 @@ func (gs *CodaGatingState) MarkPrivateAddrAsKnown(addr ma.Multiaddr) {
 	}
 }
 
-func (gs *CodaGatingState) isPeerTrusted(p peer.ID) bool {
-	return gs.TrustedPeers.Contains(p)
+type connectionAllowance int
+
+const (
+	Undecided connectionAllowance = iota
+	DenyUnknownPrivateAddress
+	DenyBannedPeer
+	DenyBannedAddress
+	Accept
+)
+
+var connectionAllowanceStrings = map[connectionAllowance]string{
+	Undecided:                 "Undecided",
+	DenyUnknownPrivateAddress: "DenyUnknownPrivateAddress",
+	DenyBannedPeer:            "DenyBannedPeer",
+	DenyBannedAddress:         "DenyBannedAddress",
+	Accept:                    "Allow",
 }
 
-func (gs *CodaGatingState) isPeerBanned(p peer.ID) bool {
-	return gs.BannedPeers.Contains(p)
+func (ca connectionAllowance) String() string {
+	return connectionAllowanceStrings[ca]
+}
+
+func (c connectionAllowance) isDeny() bool {
+	return !(c == Accept || c == Undecided)
+}
+
+func (gs *CodaGatingState) checkPeerTrusted(p peer.ID) connectionAllowance {
+	if gs.TrustedPeers.Contains(p) {
+		return Accept
+	}
+	return Undecided
+}
+
+func (gs *CodaGatingState) checkPeerBanned(p peer.ID) connectionAllowance {
+	if gs.BannedPeers.Contains(p) {
+		return DenyBannedPeer
+	}
+	return Undecided
+}
+
+// bothAccept makes sure neither allowance denies the connection
+func bothAccept(a connectionAllowance, b connectionAllowance) connectionAllowance {
+	if a == Undecided {
+		return b
+	}
+	if a == Accept {
+		if b == Undecided {
+			return Accept
+		}
+		return b
+	}
+	return a
+}
+
+// eitherAccepts makes sure either allowance allows the connection (or both are undecided)
+func eitherAccepts(a connectionAllowance, b connectionAllowance) connectionAllowance {
+	if a == Undecided {
+		return b
+	}
+	return a
 }
 
 // checks if a peer id is allowed to dial/accept
-func (gs *CodaGatingState) isAllowedPeer(p peer.ID) bool {
-	return gs.isPeerTrusted(p) || !gs.isPeerBanned(p)
+func (gs *CodaGatingState) checkAllowedPeer(p peer.ID) connectionAllowance {
+	return eitherAccepts(gs.checkPeerTrusted(p), gs.checkPeerBanned(p))
 }
 
-func (gs *CodaGatingState) isAddrTrusted(addr ma.Multiaddr) bool {
-	return !gs.TrustedAddrFilters.AddrBlocked(addr)
+func (gs *CodaGatingState) checkAddrTrusted(addr ma.Multiaddr) connectionAllowance {
+	if !gs.TrustedAddrFilters.AddrBlocked(addr) {
+		return Accept
+	}
+	return Undecided
 }
 
-func (gs *CodaGatingState) isAddrBanned(addr ma.Multiaddr) bool {
-	return gs.BannedAddrFilters.AddrBlocked(addr)
+func (gs *CodaGatingState) checkAddrBanned(addr ma.Multiaddr) connectionAllowance {
+	if gs.BannedAddrFilters.AddrBlocked(addr) {
+		return DenyBannedAddress
+	}
+	return Undecided
 }
 
 // checks if an address is allowed to dial/accept
-func (gs *CodaGatingState) isAllowedAddr(addr ma.Multiaddr) bool {
-	publicOrKnownPrivate := !isPrivateAddr(addr) || !gs.KnownPrivateAddrFilters.AddrBlocked(addr)
-	return gs.isAddrTrusted(addr) || (!gs.isAddrBanned(addr) && publicOrKnownPrivate)
+func (gs *CodaGatingState) checkAllowedAddr(addr ma.Multiaddr) connectionAllowance {
+	if st := gs.checkAddrTrusted(addr); st != Undecided {
+		return st
+	}
+	if isPrivateAddr(addr) && gs.KnownPrivateAddrFilters.AddrBlocked(addr) {
+		return DenyUnknownPrivateAddress
+	}
+	return gs.checkAddrBanned(addr)
 }
 
 // checks if a peer is allowed to dial/accept; if the peer is in the trustlist, the address checks are overriden
-func (gs *CodaGatingState) isAllowedPeerWithAddr(p peer.ID, addr ma.Multiaddr) bool {
-	return gs.isPeerTrusted(p) || (gs.isAllowedPeer(p) && gs.isAllowedAddr(addr))
+func (gs *CodaGatingState) checkAllowedPeerWithAddr(p peer.ID, addr ma.Multiaddr) connectionAllowance {
+	return eitherAccepts(gs.checkPeerTrusted(p), bothAccept(gs.checkAllowedPeer(p), gs.checkAllowedAddr(addr)))
 }
 
 func (gs *CodaGatingState) logGate() {
@@ -467,15 +532,14 @@ func (gs *CodaGatingState) logGate() {
 // InterceptPeerDial tests whether we're permitted to Dial the specified peer.
 //
 // This is called by the network.Network implementation when dialling a peer.
-func (gs *CodaGatingState) InterceptPeerDial(p peer.ID) (allow bool) {
-	allow = gs.isAllowedPeer(p)
-
-	if !allow {
-		gs.logger.Infof("disallowing peer dial to: %v (peer)", p)
+func (gs *CodaGatingState) InterceptPeerDial(p peer.ID) bool {
+	allowance := gs.checkAllowedPeer(p)
+	if allowance.isDeny() {
+		gs.logger.Infof("disallowing peer dial to: %v (peer, %s)", p, allowance)
 		gs.logGate()
+		return false
 	}
-
-	return
+	return true
 }
 
 // InterceptAddrDial tests whether we're permitted to dial the specified
@@ -483,37 +547,32 @@ func (gs *CodaGatingState) InterceptPeerDial(p peer.ID) (allow bool) {
 //
 // This is called by the network.Network implementation after it has
 // resolved the peer's addrs, and prior to dialling each.
-func (gs *CodaGatingState) InterceptAddrDial(id peer.ID, addr ma.Multiaddr) (allow bool) {
-	allow = gs.isAllowedPeerWithAddr(id, addr)
-
-	if !allow {
-		gs.logger.Infof("disallowing peer dial to: %v + %v (peer + address)", id, addr)
+func (gs *CodaGatingState) InterceptAddrDial(id peer.ID, addr ma.Multiaddr) bool {
+	allowance := gs.checkAllowedPeerWithAddr(id, addr)
+	if allowance.isDeny() {
+		gs.logger.Infof("disallowing peer dial to: %v + %v (peer + address, %s)", id, addr, allowance)
 		gs.logGate()
+		return false
 	}
-
-	return
+	return true
 }
 
 // InterceptAccept tests whether an incipient inbound connection is allowed.
 //
 // This is called by the upgrader, or by the transport directly (e.g. QUIC,
 // Bluetooth), straight after it has accepted a connection from its socket.
-func (gs *CodaGatingState) InterceptAccept(addrs network.ConnMultiaddrs) (allow bool) {
+func (gs *CodaGatingState) InterceptAccept(addrs network.ConnMultiaddrs) bool {
 	remoteAddr := addrs.RemoteMultiaddr()
-	allow = gs.isAddrTrusted(remoteAddr) || !gs.isAddrBanned(remoteAddr)
-
-	if !allow {
-		gs.logger.Infof("refusing to accept inbound connection from addr: %v", remoteAddr)
+	allowance := eitherAccepts(gs.checkAddrTrusted(remoteAddr), gs.checkAddrBanned(remoteAddr))
+	if allowance.isDeny() {
+		gs.logger.Infof("refusing to accept inbound connection from addr: %v (%s)", remoteAddr, allowance)
 		gs.logGate()
+		return false
 	}
-
 	// If we are receiving a connection, and the remote address is private,
 	// then we infer that we should be able to connect to that private address.
-	if allow {
-		gs.MarkPrivateAddrAsKnown(remoteAddr)
-	}
-
-	return
+	gs.MarkPrivateAddrAsKnown(remoteAddr)
+	return true
 }
 
 // InterceptSecured tests whether a given connection, now authenticated,
@@ -522,19 +581,18 @@ func (gs *CodaGatingState) InterceptAccept(addrs network.ConnMultiaddrs) (allow 
 // This is called by the upgrader, after it has performed the security
 // handshake, and before it negotiates the muxer, or by the directly by the
 // transport, at the exact same checkpoint.
-func (gs *CodaGatingState) InterceptSecured(_ network.Direction, id peer.ID, addrs network.ConnMultiaddrs) (allow bool) {
+func (gs *CodaGatingState) InterceptSecured(_ network.Direction, id peer.ID, addrs network.ConnMultiaddrs) bool {
 	// note: we don't care about the direction (inbound/outbound). all
 	// connections in coda are symmetric: if i am allowed to connect to
 	// you, you are allowed to connect to me.
 	remoteAddr := addrs.RemoteMultiaddr()
-	allow = gs.isAllowedPeerWithAddr(id, remoteAddr)
-
-	if !allow {
-		gs.logger.Infof("refusing to accept inbound connection from authenticated addr: %v", remoteAddr)
+	allowance := gs.checkAllowedPeerWithAddr(id, remoteAddr)
+	if allowance.isDeny() {
+		gs.logger.Infof("refusing to accept inbound connection from authenticated addr: %v (%s)", remoteAddr, allowance)
 		gs.logGate()
+		return false
 	}
-
-	return
+	return true
 }
 
 // InterceptUpgraded tests whether a fully capable connection is allowed.

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -38,7 +38,7 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	record "github.com/libp2p/go-libp2p-record"
 	p2pconfig "github.com/libp2p/go-libp2p/config"
-	mdns "github.com/libp2p/go-libp2p/p2p/discovery/mdns_legacy"
+	mdns "github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 	"golang.org/x/crypto/blake2b"
@@ -266,7 +266,7 @@ type Helper struct {
 	Host              host.Host
 	Bitswap           *bitswap.Bitswap
 	BitswapStorage    BitswapStorage
-	Mdns              *mdns.Service
+	Mdns              mdns.Service
 	Dht               *dual.DHT
 	Ctx               context.Context
 	Pubsub            *pubsub.PubSub

--- a/src/app/libp2p_helper/src/codanet_test.go
+++ b/src/app/libp2p_helper/src/codanet_test.go
@@ -29,7 +29,7 @@ func TestTrustedPrivateConnectionGating(t *testing.T) {
 	}
 
 	require.True(t, isPrivateAddr(testMa))
-	require.False(t, gs.isAddrTrusted(testMa))
+	require.Equal(t, Undecided, gs.checkAddrTrusted(testMa))
 
 	allowed := gs.InterceptAddrDial(testInfo.ID, testMa)
 	require.False(t, allowed)

--- a/src/app/libp2p_helper/src/codanet_test.go
+++ b/src/app/libp2p_helper/src/codanet_test.go
@@ -18,7 +18,7 @@ func TestTrustedPrivateConnectionGating(t *testing.T) {
 	trustedAddrFilters := ma.NewFilters()
 	trustedAddrFilters.AddFilter(*totalIpNet, ma.ActionDeny)
 
-	gs := NewCodaGatingState(nil, trustedAddrFilters, nil, nil)
+	gs := NewCodaGatingState(&CodaGatingConfig{TrustedAddrFilters: trustedAddrFilters})
 
 	testMa, err := ma.NewMultiaddr("/ip4/10.0.0.1/tcp/80")
 	require.NoError(t, err)

--- a/src/app/libp2p_helper/src/codanet_test.go
+++ b/src/app/libp2p_helper/src/codanet_test.go
@@ -15,10 +15,13 @@ func TestTrustedPrivateConnectionGating(t *testing.T) {
 
 	_, totalIpNet, err := gonet.ParseCIDR("0.0.0.0/0")
 	require.NoError(t, err)
+	knownPrivateAddrFilters := ma.NewFilters()
+	knownPrivateAddrFilters.AddFilter(*totalIpNet, ma.ActionDeny)
+
 	trustedAddrFilters := ma.NewFilters()
 	trustedAddrFilters.AddFilter(*totalIpNet, ma.ActionDeny)
 
-	gs := NewCodaGatingState(&CodaGatingConfig{TrustedAddrFilters: trustedAddrFilters})
+	gs := NewCodaGatingState(&CodaGatingConfig{TrustedAddrFilters: trustedAddrFilters}, knownPrivateAddrFilters)
 
 	testMa, err := ma.NewMultiaddr("/ip4/10.0.0.1/tcp/80")
 	require.NoError(t, err)

--- a/src/app/libp2p_helper/src/go.mod
+++ b/src/app/libp2p_helper/src/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.9.0
 	github.com/libp2p/go-libp2p-discovery v0.5.1
 	github.com/libp2p/go-libp2p-kad-dht v0.13.1
-	github.com/libp2p/go-libp2p-kbucket v0.4.7 
+	github.com/libp2p/go-libp2p-kbucket v0.4.7
 	github.com/libp2p/go-libp2p-mplex v0.4.1
 	github.com/libp2p/go-libp2p-peerstore v0.3.0
 	github.com/libp2p/go-libp2p-pubsub v0.5.4

--- a/src/app/libp2p_helper/src/go.sum
+++ b/src/app/libp2p_helper/src/go.sum
@@ -1059,7 +1059,6 @@ github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=
 github.com/whyrusleeping/go-logging v0.0.1/go.mod h1:lDPYj54zutzG1XYfHAhcc7oNXEburHQBn+Iqd4yS4vE=
 github.com/whyrusleeping/mafmt v1.2.8/go.mod h1:faQJFPbLSxzD9xpA02ttW/tS9vZykNvXwGvqIpk20FA=
-github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9 h1:Y1/FEOpaCpD21WxrmfeIYCFPuVPRCY2XZTWzTNHGw30=
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7 h1:E9S12nwJwEOXe2d6gT6qxdvqMnNq+VnSsKPgm2ZZNds=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=

--- a/src/app/libp2p_helper/src/libp2p_helper/app.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/app.go
@@ -18,7 +18,7 @@ import (
 	net "github.com/libp2p/go-libp2p-core/network"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	mdns "github.com/libp2p/go-libp2p/p2p/discovery/mdns_legacy"
+	mdns "github.com/libp2p/go-libp2p/p2p/discovery/mdns"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -360,11 +360,8 @@ func handleStreamReads(app *app, stream net.Stream, idx uint64) {
 }
 
 func beginMDNS(app *app, foundPeerCh chan peerDiscovery) error {
-	mdns, err := mdns.NewMdnsService(app.Ctx, app.P2p.Host, time.Minute, "_coda-discovery._udp.local")
-	if err != nil {
-		return err
-	}
-	app.P2p.Mdns = &mdns
+	mdns := mdns.NewMdnsService(app.P2p.Host, "_coda-discovery._udp.local")
+	app.P2p.Mdns = mdns
 	l := &mdnsListener{
 		FoundPeer: foundPeerCh,
 		app:       app,

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap.go
@@ -116,11 +116,11 @@ func (bs *BitswapCtx) deleteRoot(root BitswapBlockLink) error {
 
 func ClearRootDownloadState(bs BitswapState, root root) {
 	rootStates := bs.RootDownloadStates()
-	nodeParams := bs.NodeDownloadParams()
 	state, has := rootStates[root]
 	if !has {
 		return
 	}
+	nodeParams := bs.NodeDownloadParams()
 	delete(rootStates, root)
 	state.allDescendants.ForEach(func(c cid.Cid) error {
 		np, hasNp := nodeParams[c]
@@ -173,9 +173,7 @@ func (bs *BitswapCtx) NewSession(downloadTimeout time.Duration) (BlockRequester,
 func (bs *BitswapCtx) RegisterDeadlineTracker(root_ root, downloadTimeout time.Duration) {
 	go func() {
 		<-time.After(downloadTimeout)
-		if _, has := bs.rootDownloadStates[root_]; has {
-			bs.deadlineChan <- root_
-		}
+		bs.deadlineChan <- root_
 	}()
 }
 func (bs *BitswapCtx) GetStatus(key [32]byte) (codanet.RootBlockStatus, error) {

--- a/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
@@ -400,16 +400,16 @@ func (m SetGatingConfigReq) handle(app *app, seqno uint64) *capnp.Message {
 	if app.P2p == nil {
 		return mkRpcRespError(seqno, needsConfigure())
 	}
-	var newState *codanet.CodaGatingState
+	var gatingConfig *codanet.CodaGatingConfig
 	gc, err := SetGatingConfigReqT(m).GatingConfig()
 	if err == nil {
-		newState, err = readGatingConfig(gc, app.AddedPeers)
+		gatingConfig, err = readGatingConfig(gc, app.AddedPeers)
 	}
 	if err != nil {
 		return mkRpcRespError(seqno, badRPC(err))
 	}
 
-	app.P2p.SetGatingState(newState)
+	app.P2p.SetGatingState(gatingConfig)
 
 	return mkRpcRespSuccess(seqno, func(m *ipc.Libp2pHelperInterface_RpcResponseSuccess) {
 		_, err := m.NewSetGatingConfig()

--- a/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	cryptorand "crypto/rand"
+	gonet "net"
 	"time"
 
 	"codanet"
@@ -252,7 +253,37 @@ func (msg ConfigureReq) handle(app *app, seqno uint64) *capnp.Message {
 		return mkRpcRespError(seqno, badRPC(err))
 	}
 
-	helper, err := codanet.MakeHelper(app.Ctx, listenOn, externalMaddr, stateDir, privk, netId, seeds, gatingConfig, int(m.MinConnections()), int(m.MaxConnections()), m.MinaPeerExchange(), time.Millisecond)
+	knownPrivateIpNetsRaw, err := m.KnownPrivateIpNets()
+	if err != nil {
+		return mkRpcRespError(seqno, badRPC(err))
+	}
+	knownPrivateIpNets := make([]gonet.IPNet, 0, knownPrivateIpNetsRaw.Len())
+	err = textListForeach(knownPrivateIpNetsRaw, func(v string) error {
+		_, addr, err := gonet.ParseCIDR(v)
+		if err == nil {
+			knownPrivateIpNets = append(knownPrivateIpNets, *addr)
+		}
+		return err
+	})
+	if err != nil {
+		return mkRpcRespError(seqno, badRPC(err))
+	}
+
+	helper, err := codanet.MakeHelper(
+		app.Ctx,
+		listenOn,
+		externalMaddr,
+		stateDir,
+		privk,
+		netId,
+		seeds,
+		gatingConfig,
+		int(m.MinConnections()),
+		int(m.MaxConnections()),
+		m.MinaPeerExchange(),
+		time.Millisecond,
+		knownPrivateIpNets,
+	)
 	if err != nil {
 		return mkRpcRespError(seqno, badHelper(err))
 	}

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -139,8 +139,7 @@ func main() {
 	setLogLevel("routedhost", "debug")
 	setLogLevel("swarm2", "info") // Logs a new stream to each peer when opended at debug
 	setLogLevel("peerstore/ds", "debug")
-	setLogLevel("mdns", "debug")        // Logs each mdns call
-	setLogLevel("bootstrap", "debug")
+	setLogLevel("mdns", "debug") // Logs each mdns call
 	setLogLevel("reuseport-transport", "debug")
 
 	decoder := capnp.NewDecoder(os.Stdin)

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -93,6 +93,13 @@ func main() {
 
 	helperLog.Infof("libp2p_helper has the following logging subsystems active: %v", logging.GetSubsystems())
 
+	setLogLevel := func(name, level string) {
+		err := logging.SetLogLevel(name, level)
+		if err != nil {
+			helperLog.Errorf("failed to set log level %s for %s: %v", level, name, err)
+		}
+	}
+
 	// === Set subsystem log levels ===
 	// All subsystems that have been considered are explicitly listed. Any that
 	// are added when modifying this code should be considered and added to
@@ -100,41 +107,41 @@ func main() {
 	// The levels below set the **minimum** log level for each subsystem.
 	// Messages emitted at lower levels than the given level will not be
 	// emitted.
-	_ = logging.SetLogLevel("mplex", "debug")
-	_ = logging.SetLogLevel("addrutil", "info")     // Logs every resolve call at debug
-	_ = logging.SetLogLevel("net/identify", "info") // Logs every message sent/received at debug
-	_ = logging.SetLogLevel("ping", "info")         // Logs every ping timeout at debug
-	_ = logging.SetLogLevel("basichost", "info")    // Spammy at debug
-	_ = logging.SetLogLevel("test-logger", "debug")
-	_ = logging.SetLogLevel("blankhost", "debug")
-	_ = logging.SetLogLevel("connmgr", "debug")
-	_ = logging.SetLogLevel("eventlog", "debug")
-	_ = logging.SetLogLevel("p2p-config", "debug")
-	_ = logging.SetLogLevel("ipns", "debug")
-	_ = logging.SetLogLevel("nat", "debug")
-	_ = logging.SetLogLevel("autorelay", "info") // Logs relayed byte counts spammily
-	_ = logging.SetLogLevel("providers", "debug")
-	_ = logging.SetLogLevel("dht/RtRefreshManager", "warn") // Ping logs are spammy at debug, cpl logs are spammy at info
-	_ = logging.SetLogLevel("dht", "info")                  // Logs every operation to debug
-	_ = logging.SetLogLevel("peerstore", "debug")
-	_ = logging.SetLogLevel("diversityFilter", "debug")
-	_ = logging.SetLogLevel("table", "debug")
-	_ = logging.SetLogLevel("stream-upgrader", "debug")
-	_ = logging.SetLogLevel("helper top-level JSON handling", "debug")
-	_ = logging.SetLogLevel("dht.pb", "debug")
-	_ = logging.SetLogLevel("tcp-tpt", "debug")
-	_ = logging.SetLogLevel("autonat", "debug")
-	_ = logging.SetLogLevel("discovery", "debug")
-	_ = logging.SetLogLevel("routing/record", "debug")
-	_ = logging.SetLogLevel("pubsub", "debug") // Spammy about blacklisted peers, maybe should be info?
-	_ = logging.SetLogLevel("badger", "debug")
-	_ = logging.SetLogLevel("relay", "info") // Log relayed byte counts spammily
-	_ = logging.SetLogLevel("routedhost", "debug")
-	_ = logging.SetLogLevel("swarm2", "info") // Logs a new stream to each peer when opended at debug
-	_ = logging.SetLogLevel("peerstore/ds", "debug")
-	_ = logging.SetLogLevel("mdns", "info") // Logs each mdns call
-	_ = logging.SetLogLevel("bootstrap", "debug")
-	_ = logging.SetLogLevel("reuseport-transport", "debug")
+	setLogLevel("mplex", "debug")
+	setLogLevel("addrutil", "info")     // Logs every resolve call at debug
+	setLogLevel("net/identify", "info") // Logs every message sent/received at debug
+	setLogLevel("ping", "info")         // Logs every ping timeout at debug
+	setLogLevel("basichost", "info")    // Spammy at debug
+	setLogLevel("test-logger", "debug")
+	setLogLevel("blankhost", "debug")
+	setLogLevel("connmgr", "debug")
+	setLogLevel("eventlog", "debug")
+	setLogLevel("p2p-config", "debug")
+	setLogLevel("ipns", "debug")
+	setLogLevel("nat", "debug")
+	setLogLevel("autorelay", "info") // Logs relayed byte counts spammily
+	setLogLevel("providers", "debug")
+	setLogLevel("dht/RtRefreshManager", "warn") // Ping logs are spammy at debug, cpl logs are spammy at info
+	setLogLevel("dht", "info")                  // Logs every operation to debug
+	setLogLevel("peerstore", "debug")
+	setLogLevel("diversityFilter", "debug")
+	setLogLevel("table", "debug")
+	setLogLevel("stream-upgrader", "debug")
+	setLogLevel("helper top-level JSON handling", "debug")
+	setLogLevel("dht.pb", "debug")
+	setLogLevel("tcp-tpt", "debug")
+	setLogLevel("autonat", "debug")
+	setLogLevel("discovery", "debug")
+	setLogLevel("routing/record", "debug")
+	setLogLevel("pubsub", "debug") // Spammy about blacklisted peers, maybe should be info?
+	setLogLevel("badger", "debug")
+	setLogLevel("relay", "info") // Log relayed byte counts spammily
+	setLogLevel("routedhost", "debug")
+	setLogLevel("swarm2", "info") // Logs a new stream to each peer when opended at debug
+	setLogLevel("peerstore/ds", "debug")
+	setLogLevel("mdns", "debug")        // Logs each mdns call
+	setLogLevel("bootstrap", "debug")
+	setLogLevel("reuseport-transport", "debug")
 
 	decoder := capnp.NewDecoder(os.Stdin)
 

--- a/src/app/libp2p_helper/src/libp2p_helper/main_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 	for i := 0; i < 100; i++ {
 		logging.Logger(fmt.Sprintf("node%d", i))
 	}
-  // Uncomment for more logging (ERROR by default)
+	// Uncomment for more logging (ERROR by default)
 	// _ = logging.SetLogLevel("mina.helper.bitswap", "WARN")
 	// _ = logging.SetLogLevel("engine", "DEBUG")
 	// _ = logging.SetLogLevel("codanet.Helper", "WARN")

--- a/src/app/libp2p_helper/src/libp2p_helper/msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/msg.go
@@ -98,7 +98,7 @@ func capnpTextListForeach(l capnp.TextList, f func(string) error) error {
 	return nil
 }
 
-func readGatingConfig(gc ipc.GatingConfig, addedPeers []peer.AddrInfo) (*codanet.CodaGatingState, error) {
+func readGatingConfig(gc ipc.GatingConfig, addedPeers []peer.AddrInfo) (*codanet.CodaGatingConfig, error) {
 	_, totalIpNet, err := gonet.ParseCIDR("0.0.0.0/0")
 	if err != nil {
 		return nil, err
@@ -168,7 +168,11 @@ func readGatingConfig(gc ipc.GatingConfig, addedPeers []peer.AddrInfo) (*codanet
 		trustedPeers.Add(peer.ID)
 	}
 
-	return codanet.NewCodaGatingState(bannedAddrFilters, trustedAddrFilters, bannedPeers, trustedPeers), nil
+	return &codanet.CodaGatingConfig{
+		BannedAddrFilters:  bannedAddrFilters,
+		TrustedAddrFilters: trustedAddrFilters,
+		BannedPeers:        bannedPeers,
+		TrustedPeers:       trustedPeers}, nil
 }
 
 func panicOnErr(err error) {

--- a/src/app/libp2p_helper/src/libp2p_helper/msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/msg.go
@@ -157,8 +157,10 @@ func readGatingConfig(gc ipc.GatingConfig, addedPeers []peer.AddrInfo) (*codanet
 	}
 	trustedPeers := peer.NewSet()
 	err = capnpPeerIdListForeach(trustedPeerIds, func(peerID string) error {
-		id := peer.ID(peerID)
-		trustedPeers.Add(id)
+		id, err := peer.Decode(peerID)
+		if err == nil {
+			trustedPeers.Add(id)
+		}
 		return nil
 	})
 	if err != nil {

--- a/src/app/libp2p_helper/src/libp2p_helper/msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/msg.go
@@ -70,7 +70,7 @@ func multiaddrListForeach(l ipc.Multiaddr_List, f func(string) error) error {
 	return nil
 }
 
-func capnpPeerIdListForeach(l ipc.PeerId_List, f func(string) error) error {
+func peerIdListForeach(l ipc.PeerId_List, f func(string) error) error {
 	for i := 0; i < l.Len(); i++ {
 		el, err := l.At(i).Id()
 		if err != nil {
@@ -84,7 +84,7 @@ func capnpPeerIdListForeach(l ipc.PeerId_List, f func(string) error) error {
 	return nil
 }
 
-func capnpTextListForeach(l capnp.TextList, f func(string) error) error {
+func textListForeach(l capnp.TextList, f func(string) error) error {
 	for i := 0; i < l.Len(); i++ {
 		el, err := l.At(i)
 		if err != nil {
@@ -114,7 +114,7 @@ func readGatingConfig(gc ipc.GatingConfig, addedPeers []peer.AddrInfo) (*codanet
 	if err != nil {
 		return nil, err
 	}
-	err = capnpTextListForeach(bannedIps, func(ip string) error {
+	err = textListForeach(bannedIps, func(ip string) error {
 		return filterIPString(bannedAddrFilters, ip, ma.ActionDeny)
 	})
 	if err != nil {
@@ -128,7 +128,7 @@ func readGatingConfig(gc ipc.GatingConfig, addedPeers []peer.AddrInfo) (*codanet
 	if err != nil {
 		return nil, err
 	}
-	err = capnpTextListForeach(trustedIps, func(ip string) error {
+	err = textListForeach(trustedIps, func(ip string) error {
 		return filterIPString(trustedAddrFilters, ip, ma.ActionAccept)
 	})
 	if err != nil {
@@ -140,7 +140,7 @@ func readGatingConfig(gc ipc.GatingConfig, addedPeers []peer.AddrInfo) (*codanet
 		return nil, err
 	}
 	bannedPeers := peer.NewSet()
-	err = capnpPeerIdListForeach(bannedPeerIds, func(peerID string) error {
+	err = peerIdListForeach(bannedPeerIds, func(peerID string) error {
 		id, err := peer.Decode(peerID)
 		if err == nil {
 			bannedPeers.Add(id)
@@ -156,7 +156,7 @@ func readGatingConfig(gc ipc.GatingConfig, addedPeers []peer.AddrInfo) (*codanet
 		return nil, err
 	}
 	trustedPeers := peer.NewSet()
-	err = capnpPeerIdListForeach(trustedPeerIds, func(peerID string) error {
+	err = peerIdListForeach(trustedPeerIds, func(peerID string) error {
 		id, err := peer.Decode(peerID)
 		if err == nil {
 			trustedPeers.Add(id)

--- a/src/app/libp2p_helper/src/libp2p_helper/util_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/util_test.go
@@ -66,7 +66,8 @@ func newTestAppWithMaxConnsAndCtx(t *testing.T, privkey crypto.PrivKey, seeds []
 		minConns,
 		maxConns,
 		minaPeerExchange,
-		10 * time.Second,
+		10*time.Second,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/src/app/libp2p_helper/src/libp2p_helper/util_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/util_test.go
@@ -62,7 +62,7 @@ func newTestAppWithMaxConnsAndCtx(t *testing.T, privkey crypto.PrivKey, seeds []
 		privkey,
 		string(testProtocol),
 		seeds,
-		codanet.NewCodaGatingState(nil, nil, nil, nil),
+		&codanet.CodaGatingConfig{},
 		minConns,
 		maxConns,
 		minaPeerExchange,

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -289,7 +289,7 @@ let main inputs =
              (sprintf
                 !"log engine fatal error: %s"
                 (Yojson.Safe.to_string (Logger.Message.to_yojson message)))
-           ~test_result:(Malleable_error.return ()))
+           ~test_result:(Malleable_error.hard_error_string "fatal error"))
     in
     Monitor.try_with ~here:[%here] ~extract_exn:false (fun () ->
         let init_result =

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -37,6 +37,7 @@ module Config = struct
     ; validation_queue_size : int
     ; mutable keypair : Mina_net2.Keypair.t option
     ; all_peers_seen_metric : bool
+    ; known_private_ip_nets : Core.Unix.Cidr.t list
     }
   [@@deriving make]
 end
@@ -246,6 +247,7 @@ module Make (Rpc_intf : Mina_base.Rpc_intf.Rpc_interface_intf) :
                 ~min_connections:config.min_connections
                 ~max_connections:config.max_connections
                 ~validation_queue_size:config.validation_queue_size
+                ~known_private_ip_nets:config.known_private_ip_nets
                 ~initial_gating_config:
                   Mina_net2.
                     { banned_peers =

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -192,7 +192,7 @@ let bandwidth_info t =
 let configure t ~me ~external_maddr ~maddrs ~network_id ~metrics_port
     ~unsafe_no_trust_ip ~flooding ~direct_peers ~peer_exchange
     ~mina_peer_exchange ~seed_peers ~initial_gating_config ~min_connections
-    ~max_connections ~validation_queue_size =
+    ~max_connections ~validation_queue_size ~known_private_ip_nets =
   let open Deferred.Or_error.Let_syntax in
   let libp2p_config =
     Libp2p_ipc.create_libp2p_config ~private_key:(Keypair.secret me)
@@ -203,6 +203,8 @@ let configure t ~me ~external_maddr ~maddrs ~network_id ~metrics_port
       ~network_id ~unsafe_no_trust_ip ~flood:flooding
       ~direct_peers:(List.map ~f:Multiaddr.to_libp2p_ipc direct_peers)
       ~seed_peers:(List.map ~f:Multiaddr.to_libp2p_ipc seed_peers)
+      ~known_private_ip_nets:
+        (List.map ~f:Core.Unix.Cidr.to_string known_private_ip_nets)
       ~peer_exchange ~mina_peer_exchange ~min_connections ~max_connections
       ~validation_queue_size
       ~gating_config:(gating_config_to_helper_format initial_gating_config)

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -160,6 +160,7 @@ val configure :
   -> min_connections:int
   -> max_connections:int
   -> validation_queue_size:int
+  -> known_private_ip_nets:Core.Unix.Cidr.t list
   -> unit Deferred.Or_error.t
 
 (** The keypair the network was configured with.

--- a/src/lib/mina_net2/tests/all_ipc.ml
+++ b/src/lib/mina_net2/tests/all_ipc.ml
@@ -553,6 +553,7 @@ let%test_module "all-ipc test" =
           ~direct_peers:[] ~seed_peers ~flooding:false ~metrics_port:None
           ~unsafe_no_trust_ip:true ~min_connections:25 ~max_connections:50
           ~validation_queue_size:150 ~initial_gating_config:gating_config
+          ~known_private_ip_nets:[]
         >>| Or_error.ok_exn
       in
       let%bind raw_seed_peers = listening_addrs node >>| Or_error.ok_exn in

--- a/src/lib/mina_net2/tests/tests.ml
+++ b/src/lib/mina_net2/tests/tests.ml
@@ -52,6 +52,7 @@ let%test_module "coda network tests" =
           ~validation_queue_size:150
           ~initial_gating_config:
             { trusted_peers = []; banned_peers = []; isolate = false }
+          ~known_private_ip_nets:[]
         >>| Or_error.ok_exn
       in
       let%bind raw_seed_peers = listening_addrs a >>| Or_error.ok_exn in
@@ -72,6 +73,7 @@ let%test_module "coda network tests" =
           ~max_connections:50 ~validation_queue_size:150
           ~initial_gating_config:
             { trusted_peers = []; banned_peers = []; isolate = false }
+          ~known_private_ip_nets:[]
         >>| Or_error.ok_exn
       and () =
         configure c ~external_maddr:(List.hd_exn maddrs) ~me:kp_c ~maddrs
@@ -81,6 +83,7 @@ let%test_module "coda network tests" =
           ~min_connections:20 ~validation_queue_size:150
           ~initial_gating_config:
             { trusted_peers = []; banned_peers = []; isolate = false }
+          ~known_private_ip_nets:[]
         >>| Or_error.ok_exn
       in
       let%bind b_advert = begin_advertising b in

--- a/src/lib/mina_net2/tests/tests.ml
+++ b/src/lib/mina_net2/tests/tests.ml
@@ -86,6 +86,7 @@ let%test_module "coda network tests" =
           ~known_private_ip_nets:[]
         >>| Or_error.ok_exn
       in
+      let%bind () = after (Time.Span.of_sec 10.) in
       let%bind b_advert = begin_advertising b in
       Or_error.ok_exn b_advert ;
       let%bind c_advert = begin_advertising c in
@@ -105,7 +106,7 @@ let%test_module "coda network tests" =
     (* TODO fails occasionally, uncomment after debugging it *)
     let%test_unit "b_stream_c" =
       let () = Core.Backtrace.elide := false in
-      let test_def =
+      let test_def () =
         let open Deferred.Let_syntax in
         let%bind b, c, shutdown = setup_two_nodes "test_stream" in
         let%bind b_peerid = me b >>| Keypair.to_peer_id in
@@ -160,11 +161,11 @@ let%test_module "coda network tests" =
         let%bind _msgs = Pipe.read_all r in
         shutdown ()
       in
-      Async.Thread_safe.block_on_async_exn (fun () -> test_def)
+      Async.Thread_safe.block_on_async_exn test_def
 
     let%test_unit "stream" =
       let () = Core.Backtrace.elide := false in
-      let test_def =
+      let test_def () =
         let open Deferred.Let_syntax in
         let%bind b, c, shutdown = setup_two_nodes "test_stream" in
         let%bind b_peerid = me b >>| Keypair.to_peer_id in
@@ -193,8 +194,7 @@ let%test_module "coda network tests" =
         assert (String.equal msg testmsg) ;
         let%bind () = Ivar.read handler_finished in
         let%bind () = close_protocol b ~protocol:"echo" in
-        let%map () = shutdown () in
-        ()
+        shutdown ()
       in
-      Async.Thread_safe.block_on_async_exn (fun () -> test_def)
+      Async.Thread_safe.block_on_async_exn test_def
   end )

--- a/src/libp2p_ipc/libp2p_ipc.capnp
+++ b/src/libp2p_ipc/libp2p_ipc.capnp
@@ -73,6 +73,7 @@ struct Libp2pConfig {
   validationQueueSize @13 :UInt32;
   minaPeerExchange @14 :Bool;
   minConnections @15 :UInt32;
+  knownPrivateIpNets @16 :List(Text);
 }
 
 # Resource status updated

--- a/src/libp2p_ipc/libp2p_ipc.ml
+++ b/src/libp2p_ipc/libp2p_ipc.ml
@@ -132,8 +132,8 @@ let create_peer_id peer_id =
 
 let create_libp2p_config ~private_key ~statedir ~listen_on ?metrics_port
     ~external_multiaddr ~network_id ~unsafe_no_trust_ip ~flood ~direct_peers
-    ~seed_peers ~peer_exchange ~mina_peer_exchange ~min_connections
-    ~max_connections ~validation_queue_size ~gating_config =
+    ~seed_peers ~known_private_ip_nets ~peer_exchange ~mina_peer_exchange
+    ~min_connections ~max_connections ~validation_queue_size ~gating_config =
   build
     (module Builder.Libp2pConfig)
     Builder.Libp2pConfig.(
@@ -147,6 +147,7 @@ let create_libp2p_config ~private_key ~statedir ~listen_on ?metrics_port
       *> op flood_set flood
       *> list_op direct_peers_set_list direct_peers
       *> list_op seed_peers_set_list seed_peers
+      *> list_op known_private_ip_nets_set_list known_private_ip_nets
       *> op peer_exchange_set peer_exchange
       *> op mina_peer_exchange_set mina_peer_exchange
       *> op min_connections_set_int_exn min_connections

--- a/src/libp2p_ipc/libp2p_ipc.mli
+++ b/src/libp2p_ipc/libp2p_ipc.mli
@@ -63,6 +63,7 @@ val create_libp2p_config :
   -> flood:bool
   -> direct_peers:multiaddr list
   -> seed_peers:multiaddr list
+  -> known_private_ip_nets:string list
   -> peer_exchange:bool
   -> mina_peer_exchange:bool
   -> min_connections:int


### PR DESCRIPTION
This is the same fix as #10229 and #10276. So many PRs were created due branch compatibility issues.

This PR:
* Fixes peers reliability test
   * _Revert "remove peer reliability"_
   * _Whitelist ip nets from client trustlist as known_
* Fixes some issues with gating config
   * _Do not reset known private addresses_
   * _Fix bug in trustedPeers of gating config_
* Fixes a race condition in Bitswap implementation
   * _Fix concurrent error in bitswap implementation_
* Removes some flakiness from test suite
   * _Update MDNS unit test_
   * _Update libp2p_helper test launching_
   * _Don't exit silently on fatal error_
* Nits
   * _Print reason of disallowed connection_: rewrote peer gating logic
   * _Use mdns instead of mdns_legacy_

Most fixes are result of the investigation into why is peers reliability test failing. This investigation revealed that mDNS discovery upon which the test relied stopped working in kubernetes cluster after recent change of firewall policy. Change in firewall policy can not be reverted as it was dictated by some security concerns. This PR implements an alternative solution: it allows to connect to peers from the `10.0.0.0/8` network even when they are not discovered through mDNS.

Explain how you tested your changes:
Existing tests provide a good coverage.

Checklist:

- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? https://github.com/MinaProtocol/mina/issues/10107