### PR TITLE
Lk86/remove stretch from rosetta tag

### DIFF
--- a/buildkite/src/Jobs/Release/MinaRosettaUbuntu.dhall
+++ b/buildkite/src/Jobs/Release/MinaRosettaUbuntu.dhall
@@ -38,7 +38,7 @@ Pipeline.build
       let rosettaUbuntuSpec = DockerImage.ReleaseSpec::{
         deps=dependsOn,
         service="mina-rosetta-ubuntu",
-        deb_codename="stretch",
+        deb_codename="focal",
         extra_args="--no-cache",
         step_key="mina-rosetta-ubuntu-docker-image"
       }

--- a/src/app/rosetta/README.md
+++ b/src/app/rosetta/README.md
@@ -10,6 +10,7 @@ Implementation of the [Rosetta API](https://www.rosetta-api.org/) for Mina.
    on the ability to enable and disable staking via GrapQL.
    That feature of the daemon had been deprecated, and has been
    removed. A new test-agent may appear in the future.
+- Update for release/1.3.0 as opposed to purpose-built rosetta branches
 
 2022/01/18:
 
@@ -167,11 +168,13 @@ Implementation of the [Rosetta API](https://www.rosetta-api.org/) for Mina.
 
 ## How to build your own docker image
 
-Checkout the "rosetta-v16" branch of the mina repository, ensure your Docker configuration has a large amount of RAM (at least 12GB, recommended 16GB) and then run the following:
+Checkout the "release/1.3.0" branch of the mina repository, ensure your Docker configuration has a large amount of RAM (at least 12GB, recommended 16GB) and then run the following:
 
-`cat dockerfiles/stages/1-build-deps-ubuntu dockerfiles/stages/2-opam-deps dockerfiles/stages/3-builder dockerfiles/stages/4-prod-ubuntu | docker build -t mina-rosetta:v16 --build-arg "MINA_BRANCH=rosetta-v16" -`
+`cat dockerfiles/stages/1-build-deps-ubuntu dockerfiles/stages/2-opam-deps dockerfiles/stages/3-builder dockerfiles/stages/4-prod-ubuntu | docker build -t mina-rosetta-ubuntu:v1.3.0 --build-arg "MINA_BRANCH=release/1.3.0" -`
 
-This creates an image (mina-rosetta:vX) based on the most up-to-date changes that support rosetta.
+This creates an image (mina-rosetta-ubuntu:v1.3.0) based on Ubuntu 20.04 and includes the most recent release of the mina daemon along with mina-archive and mina-rosetta.
+
+Alternatively, you could use the official image `minaprotocol/mina-rosetta-ubuntu:1.3.0beta1-087f715-stretch` which is built in exactly this way by buildkite CI/CD.
 
 ## How to Run
 
@@ -184,7 +187,7 @@ The container includes 4 scripts in /rosetta which run a different set of servic
 For example, to run the `docker-devnet-start.sh` and connect to the live devnet:
 
 ```
-docker run -it --rm --name rosetta --entrypoint=./docker-devnet-start.sh -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 minaprotocol/mina-rosetta:v16
+docker run -it --rm --name rosetta --entrypoint=./docker-devnet-start.sh -p 10101:10101 -p 3085:3085 -p 3086:3086 -p 3087:3087 minaprotocol/mina-rosetta-ubuntu:v1.3.0
 ```
 
 Note: It will take 20min-1hr for your node to sync
@@ -282,13 +285,13 @@ The Construction API is _not_ validated using `rosetta-cli` as this would requir
 
 ### Reproduce agent and rosetta-cli validation
 
-`minaprotocol/mina-rosetta:v16` and `rosetta-cli @ v0.5.12`
+`minaprotocol/mina-rosetta-ubuntu:v1.3.0` and `rosetta-cli @ v0.5.12`
 using this [`rosetta.conf`](https://github.com/MinaProtocol/mina/blob/2b43c8cccfb9eb480122d207c5a3e6e58c4bbba3/src/app/rosetta/rosetta.conf) and the [`bootstrap_balances.json`](https://github.com/MinaProtocol/mina/blob/2b43c8cccfb9eb480122d207c5a3e6e58c4bbba3/src/app/rosetta/bootstrap_balances.json) next to it.
 
 **Run a fast sandbox network forever and test with rosetta-cli**
 
 ```
-$ docker run --rm --publish 3087:3087 --publish 3086:3086 --publish 3085:3085 --name mina-rosetta-demo --entrypoint ./docker-demo-start.sh -d minaprotocol/mina-rosetta:v16
+$ docker run --rm --publish 3087:3087 --publish 3086:3086 --publish 3085:3085 --name mina-rosetta-demo --entrypoint ./docker-demo-start.sh -d minaprotocol/mina-rosetta-ubuntu:v1.3.0
 
 $ docker logs --follow mina-rosetta-demo
 
@@ -333,3 +336,4 @@ In the generated files, the type `deriving` clauses will need to have `eq` added
 Any record types with a field named `_type` will need annotate that field with `[@key "type"]`.
 In `lib/network.ml`, update the two instances of the version number.
 Check the diff after regeneration and be sure to add `[@default None]` and `[@default []]` to all relevant fields of the models
+


### PR DESCRIPTION
Explain your changes:
* Rosetta ubuntu containers were reporting as "stretch" in the docker tag due to old debian-centric defaults, this PR attempts to refactor the docker release script and/or job to use an ubuntu-specific codename in place of stretch to signify ubuntu 20.04

Explain how you tested your changes:
* CI


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
