### PR TITLE
Remove linearization on verification key

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/binding_generation/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/binding_generation/src/main.rs
@@ -15,10 +15,6 @@ use wires_15_stubs::{
     plonk_verifier_index::{CamlPlonkDomain, CamlPlonkVerificationEvals, CamlPlonkVerifierIndex},
     projective::{pallas::*, vesta::*},
     srs::{fp::*, fq::*},
-    CamlColumn,
-    CamlVariable,
-    CamlPolishToken,
-    CamlLinearization,
     CamlCircuitGate,
     CamlLookupEvaluations,
     CamlOpeningProof,
@@ -252,10 +248,6 @@ fn generate_bindings(mut w: impl std::io::Write) {
         decl_type!(w, env, CamlCircuitGate<T1> => "circuit_gate");
 
         decl_type!(w, env, CurrOrNext => "curr_or_next");
-        decl_type!(w, env, CamlColumn => "column");
-        decl_type!(w, env, CamlVariable => "variable");
-        decl_type!(w, env, CamlPolishToken<T1> => "polish_token");
-        decl_type!(w, env, CamlLinearization<T1> => "linearization");
 
         decl_type!(w, env, CamlOracles<T1> => "oracles");
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/lib.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/lib.rs
@@ -91,7 +91,6 @@ pub use {
     commitment_dlog::commitment::caml::{CamlOpeningProof, CamlPolyComm},
     kimchi::prover::caml::{CamlProverCommitments, CamlProverProof},
     kimchi::circuits::{
-        expr::caml::{CamlColumn, CamlLinearization, CamlPolishToken, CamlVariable},
         gate::{caml::CamlCircuitGate, CurrOrNext, GateType},
         scalars::caml::{CamlLookupEvaluations, CamlProofEvaluations, CamlRandomOracles},
         wires::caml::CamlWire,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/lib.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/lib.rs
@@ -89,11 +89,11 @@ pub mod linearization {
 /// Handy re-exports
 pub use {
     commitment_dlog::commitment::caml::{CamlOpeningProof, CamlPolyComm},
-    kimchi::prover::caml::{CamlProverCommitments, CamlProverProof},
     kimchi::circuits::{
         gate::{caml::CamlCircuitGate, CurrOrNext, GateType},
         scalars::caml::{CamlLookupEvaluations, CamlProofEvaluations, CamlRandomOracles},
         wires::caml::CamlWire,
     },
+    kimchi::prover::caml::{CamlProverCommitments, CamlProverProof},
     oracle::sponge::caml::CamlScalarChallenge,
 };

--- a/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
@@ -1,8 +1,8 @@
 use crate::pasta_fp_plonk_verifier_index::CamlPastaFpPlonkVerifierIndex;
 use commitment_dlog::commitment::{caml::CamlPolyComm, shift_scalar, PolyComm};
+use kimchi::circuits::scalars::{caml::CamlRandomOracles, RandomOracles};
 use kimchi::prover::ProverProof;
 use kimchi::{index::VerifierIndex as DlogVerifierIndex, prover::caml::CamlProverProof};
-use kimchi::circuits::scalars::{caml::CamlRandomOracles, RandomOracles};
 use oracle::{
     self,
     poseidon::PlonkSpongeConstants15W,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
@@ -1,7 +1,7 @@
 use crate::{gate_vector::fp::CamlPastaFpPlonkGateVectorPtr, srs::fp::CamlFpSrs};
 use ark_poly::EvaluationDomain;
+use kimchi::circuits::{constraints::ConstraintSystem, gate::CircuitGate};
 use kimchi::index::{expr_linearization, Index as DlogIndex};
-use kimchi::circuits::{gate::CircuitGate, constraints::ConstraintSystem};
 use mina_curves::pasta::{fp::Fp, pallas::Affine as GAffineOther, vesta::Affine as GAffine};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -10,11 +10,11 @@ use array_init::array_init;
 use commitment_dlog::commitment::caml::CamlPolyComm;
 use commitment_dlog::commitment::{CommitmentCurve, OpeningProof, PolyComm};
 use groupmap::GroupMap;
+use kimchi::circuits::polynomial::COLUMNS;
+use kimchi::circuits::scalars::ProofEvaluations;
 use kimchi::index::Index;
 use kimchi::prover::caml::CamlProverProof;
 use kimchi::prover::{ProverCommitments, ProverProof};
-use kimchi::circuits::scalars::ProofEvaluations;
-use kimchi::circuits::polynomial::COLUMNS;
 use mina_curves::pasta::{
     fp::Fp,
     fq::Fq,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -12,7 +12,6 @@ use commitment_dlog::{commitment::PolyComm, srs::SRS};
 use mina_curves::pasta::{fp::Fp, pallas::Affine as GAffineOther, vesta::Affine as GAffine};
 
 use kimchi::index::{expr_linearization, VerifierIndex};
-use kimchi::circuits::expr::{Linearization, PolishToken};
 use kimchi::circuits::constraints::{zk_polynomial, zk_w3, Shifts};
 use kimchi::circuits::wires::{COLUMNS, PERMUTS};
 use std::convert::TryInto;
@@ -50,7 +49,6 @@ impl From<VerifierIndex<GAffine>> for CamlPastaFpPlonkVerifierIndex {
                     .map(|x| x.to_vec().iter().map(Into::into).collect()),
             },
             shifts: vi.shift.to_vec().iter().map(Into::into).collect(),
-            linearization: vi.linearization.into(),
         }
     }
 }
@@ -82,6 +80,9 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<GAffine> {
         let shifts: Vec<Fp> = shifts.iter().map(Into::into).collect();
         let shift: [Fp; PERMUTS] = shifts.try_into().expect("wrong size");
 
+        // TODO chacha, dummy_lookup_value ?
+        let linearization = expr_linearization(domain, false, None);
+
         VerifierIndex::<GAffine> {
             domain,
             max_poly_size: index.max_poly_size as usize,
@@ -109,7 +110,7 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<GAffine> {
             lookup_used: None,
             lookup_tables: vec![],
             lookup_selectors: vec![],
-            linearization: index.linearization.into(),
+            linearization,
 
             fr_sponge_params: oracle::pasta::fp_3::params(),
             fq_sponge_params: oracle::pasta::fq_3::params(),
@@ -152,8 +153,7 @@ pub fn caml_pasta_fp_plonk_verifier_index_read(
     srs: CamlFpSrs,
     path: String,
 ) -> Result<CamlPastaFpPlonkVerifierIndex, ocaml::Error> {
-    let mut vi = read_raw(offset, srs, path)?;
-    vi.linearization = expr_linearization(vi.domain, false, None);
+    let vi = read_raw(offset, srs, path)?;
     Ok(vi.into())
 }
 
@@ -229,7 +229,6 @@ pub fn caml_pasta_fp_plonk_verifier_index_dummy() -> CamlPastaFpPlonkVerifierInd
             chacha_comm: None,
         },
         shifts: (0..PERMUTS - 1).map(|_| Fp::one().into()).collect(),
-        linearization: Linearization::<Vec<PolishToken<Fp>>>::default().into(),
     }
 }
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -11,9 +11,9 @@ use commitment_dlog::commitment::caml::CamlPolyComm;
 use commitment_dlog::{commitment::PolyComm, srs::SRS};
 use mina_curves::pasta::{fp::Fp, pallas::Affine as GAffineOther, vesta::Affine as GAffine};
 
-use kimchi::index::{expr_linearization, VerifierIndex};
 use kimchi::circuits::constraints::{zk_polynomial, zk_w3, Shifts};
 use kimchi::circuits::wires::{COLUMNS, PERMUTS};
+use kimchi::index::{expr_linearization, VerifierIndex};
 use std::convert::TryInto;
 use std::path::Path;
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
@@ -1,7 +1,7 @@
 use crate::{gate_vector::fq::CamlPastaFqPlonkGateVectorPtr, srs::fq::CamlFqSrs};
 use ark_poly::EvaluationDomain;
+use kimchi::circuits::{constraints::ConstraintSystem, gate::CircuitGate};
 use kimchi::index::{expr_linearization, Index as DlogIndex};
-use kimchi::circuits::{gate::CircuitGate, constraints::ConstraintSystem};
 use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine, vesta::Affine as GAffineOther};
 use serde::{Deserialize, Serialize};
 use std::{

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -16,11 +16,11 @@ use mina_curves::pasta::{
     pallas::{Affine as GAffine, PallasParameters},
 };
 
+use kimchi::circuits::polynomial::COLUMNS;
+use kimchi::circuits::scalars::ProofEvaluations;
 use kimchi::index::Index;
 use kimchi::prover::caml::CamlProverProof;
 use kimchi::prover::{ProverCommitments, ProverProof};
-use kimchi::circuits::scalars::ProofEvaluations;
-use kimchi::circuits::polynomial::COLUMNS;
 use oracle::{
     poseidon::PlonkSpongeConstants15W,
     sponge::{DefaultFqSponge, DefaultFrSponge},

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
@@ -11,9 +11,9 @@ use commitment_dlog::commitment::caml::CamlPolyComm;
 use commitment_dlog::{commitment::PolyComm, srs::SRS};
 use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine, vesta::Affine as GAffineOther};
 
-use kimchi::index::{expr_linearization, VerifierIndex};
 use kimchi::circuits::constraints::{zk_polynomial, zk_w3, Shifts};
 use kimchi::circuits::wires::{COLUMNS, PERMUTS};
+use kimchi::index::{expr_linearization, VerifierIndex};
 use std::convert::TryInto;
 use std::path::Path;
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
@@ -12,7 +12,6 @@ use commitment_dlog::{commitment::PolyComm, srs::SRS};
 use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine, vesta::Affine as GAffineOther};
 
 use kimchi::index::{expr_linearization, VerifierIndex};
-use kimchi::circuits::expr::{Linearization, PolishToken};
 use kimchi::circuits::constraints::{zk_polynomial, zk_w3, Shifts};
 use kimchi::circuits::wires::{COLUMNS, PERMUTS};
 use std::convert::TryInto;
@@ -50,7 +49,6 @@ impl From<VerifierIndex<GAffine>> for CamlPastaFqPlonkVerifierIndex {
                     .map(|x| x.to_vec().iter().map(Into::into).collect()),
             },
             shifts: vi.shift.to_vec().iter().map(Into::into).collect(),
-            linearization: vi.linearization.into(),
         }
     }
 }
@@ -82,6 +80,9 @@ impl From<CamlPastaFqPlonkVerifierIndex> for VerifierIndex<GAffine> {
         let shifts: Vec<Fq> = shifts.iter().map(Into::into).collect();
         let shift: [Fq; PERMUTS] = shifts.try_into().expect("wrong size");
 
+        // TODO chacha, dummy_lookup_value ?
+        let linearization = expr_linearization(domain, false, None);
+
         VerifierIndex::<GAffine> {
             domain,
             max_poly_size: index.max_poly_size as usize,
@@ -109,7 +110,7 @@ impl From<CamlPastaFqPlonkVerifierIndex> for VerifierIndex<GAffine> {
             lookup_used: None,
             lookup_tables: vec![],
             lookup_selectors: vec![],
-            linearization: index.linearization.into(),
+            linearization,
 
             fr_sponge_params: oracle::pasta::fq_3::params(),
             fq_sponge_params: oracle::pasta::fp_3::params(),
@@ -152,8 +153,7 @@ pub fn caml_pasta_fq_plonk_verifier_index_read(
     srs: CamlFqSrs,
     path: String,
 ) -> Result<CamlPastaFqPlonkVerifierIndex, ocaml::Error> {
-    let mut vi = read_raw(offset, srs, path)?;
-    vi.linearization = expr_linearization(vi.domain, false, None);
+    let vi = read_raw(offset, srs, path)?;
     Ok(vi.into())
 }
 
@@ -230,7 +230,6 @@ pub fn caml_pasta_fq_plonk_verifier_index_dummy() -> CamlPastaFqPlonkVerifierInd
             chacha_comm: None,
         },
         shifts: (0..PERMUTS - 1).map(|_| Fq::one().into()).collect(),
-        linearization: Linearization::<Vec<PolishToken<Fq>>>::default().into(),
     }
 }
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/plonk_verifier_index.rs
@@ -1,5 +1,3 @@
-use kimchi::circuits::expr::caml::{CamlLinearization, CamlPolishToken};
-
 #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
 pub struct CamlPlonkDomain<Fr> {
     pub log_size_of_group: ocaml::Int,
@@ -27,5 +25,4 @@ pub struct CamlPlonkVerifierIndex<Fr, SRS, PolyComm> {
     pub srs: SRS,
     pub evals: CamlPlonkVerificationEvals<PolyComm>,
     pub shifts: Vec<Fr>,
-    pub linearization: CamlLinearization<CamlPolishToken<Fr>>,
 }

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -221,7 +221,6 @@ module Stable = struct
                     ; max_poly_size = 1 lsl Nat.to_int Backend.Tock.Rounds.n
                     ; max_quot_size
                     ; srs = Backend.Tock.Keypair.load_urs ()
-                    ; linearization = failwith "TODO"
                     ; evals =
                         (let g (x, y) =
                            { Kimchi.Protocol.unshifted =

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -187,7 +187,7 @@ end
 
 [%%versioned_binable
 module Stable = struct
-  module V3 = struct
+  module V2 = struct
     type t = (Backend.Tock.Curve.Affine.t, Vk.t) Poly.Stable.V2.t
     [@@deriving sexp, equal, compare, hash, yojson]
 

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -187,7 +187,7 @@ end
 
 [%%versioned_binable
 module Stable = struct
-  module V2 = struct
+  module V3 = struct
     type t = (Backend.Tock.Curve.Affine.t, Vk.t) Poly.Stable.V2.t
     [@@deriving sexp, equal, compare, hash, yojson]
 

--- a/src/lib/pickles/verification_key.ml
+++ b/src/lib/pickles/verification_key.ml
@@ -56,7 +56,6 @@ module Stable = struct
         ; max_poly_size = 1 lsl Nat.to_int Rounds.Wrap.n
         ; max_quot_size
         ; srs
-        ; linearization = failwith "TODO"
         ; evals =
             (let g (x, y) =
                { Kimchi.Protocol.unshifted =


### PR DESCRIPTION
This is PR #10176 rebased back onto `develop`. Hopefully this (and a re-merge-forward) will fix the weird non-conflict merge conflict in #10163.