### PR TITLE
fix verification key json format in parties

### DIFF
--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -188,69 +188,75 @@ end
 [%%versioned_binable
 module Stable = struct
   module V2 = struct
-    type t = (Backend.Tock.Curve.Affine.t, Vk.t) Poly.Stable.V2.t
-    [@@deriving sexp, equal, compare, hash, yojson]
+    module T = struct
+      type t = (Backend.Tock.Curve.Affine.t, Vk.t) Poly.Stable.V2.t
+      [@@deriving sexp, equal, compare, hash, yojson]
 
-    let to_latest = Fn.id
+      let to_latest = Fn.id
 
-    let description = "Verification key"
+      let description = "Verification key"
 
-    let version_byte = Base58_check.Version_bytes.verification_key
+      let version_byte = Base58_check.Version_bytes.verification_key
 
-    let to_repr { Poly.step_data; max_width; wrap_index; wrap_vk = _ } =
-      { Repr.Stable.V2.step_data; max_width; wrap_index }
+      let to_repr { Poly.step_data; max_width; wrap_index; wrap_vk = _ } =
+        { Repr.Stable.V2.step_data; max_width; wrap_index }
 
-    let of_repr
-        ({ Repr.Stable.V2.step_data; max_width; wrap_index = c } :
-          R.Stable.V2.t) : t =
-      let d = Common.wrap_domains.h in
-      let log2_size = Import.Domain.log2_size d in
-      let max_quot_size = Common.max_quot_size_int (Import.Domain.size d) in
-      let wrap_vk : Impls.Wrap.Verification_key.t =
-        { domain =
-            { log_size_of_group = log2_size
-            ; group_gen = Backend.Tock.Field.domain_generator log2_size
-            }
-        ; max_poly_size = 1 lsl Nat.to_int Backend.Tock.Rounds.n
-        ; max_quot_size
-        ; srs = Backend.Tock.Keypair.load_urs ()
-        ; evals =
-            (let g (x, y) =
-               { Kimchi.Protocol.unshifted =
-                   [| Kimchi.Foundations.Finite (x, y) |]
-               ; shifted = None
-               }
-             in
-             { sigma_comm = Array.map ~f:g (Vector.to_array c.sigma_comm)
-             ; coefficients_comm =
-                 Array.map ~f:g (Vector.to_array c.coefficients_comm)
-             ; generic_comm = g c.generic_comm
-             ; mul_comm = g c.mul_comm
-             ; psm_comm = g c.psm_comm
-             ; emul_comm = g c.emul_comm
-             ; complete_add_comm = g c.complete_add_comm
-             ; endomul_scalar_comm = g c.endomul_scalar_comm
-             ; chacha_comm = None
-             })
-        ; shifts = Common.tock_shifts ~log2_size
-        ; lookup_index = None
-        }
-      in
-      { Poly.step_data; max_width; wrap_index = c; wrap_vk = Some wrap_vk }
+      let of_repr
+          ({ Repr.Stable.V2.step_data; max_width; wrap_index = c } :
+            R.Stable.V2.t) : t =
+        let d = Common.wrap_domains.h in
+        let log2_size = Import.Domain.log2_size d in
+        let max_quot_size = Common.max_quot_size_int (Import.Domain.size d) in
+        let wrap_vk : Impls.Wrap.Verification_key.t =
+          { domain =
+              { log_size_of_group = log2_size
+              ; group_gen = Backend.Tock.Field.domain_generator log2_size
+              }
+          ; max_poly_size = 1 lsl Nat.to_int Backend.Tock.Rounds.n
+          ; max_quot_size
+          ; srs = Backend.Tock.Keypair.load_urs ()
+          ; evals =
+              (let g (x, y) =
+                 { Kimchi.Protocol.unshifted =
+                     [| Kimchi.Foundations.Finite (x, y) |]
+                 ; shifted = None
+                 }
+               in
+               { sigma_comm = Array.map ~f:g (Vector.to_array c.sigma_comm)
+               ; coefficients_comm =
+                   Array.map ~f:g (Vector.to_array c.coefficients_comm)
+               ; generic_comm = g c.generic_comm
+               ; mul_comm = g c.mul_comm
+               ; psm_comm = g c.psm_comm
+               ; emul_comm = g c.emul_comm
+               ; complete_add_comm = g c.complete_add_comm
+               ; endomul_scalar_comm = g c.endomul_scalar_comm
+               ; chacha_comm = None
+               })
+          ; shifts = Common.tock_shifts ~log2_size
+          ; lookup_index = None
+          }
+        in
+        { Poly.step_data; max_width; wrap_index = c; wrap_vk = Some wrap_vk }
 
-    include Binable.Of_binable
-              (R.Stable.V2)
-              (struct
-                type nonrec t = t
+      include Binable.Of_binable
+                (R.Stable.V2)
+                (struct
+                  type nonrec t = t
 
-                let to_binable r = to_repr r
+                  let to_binable r = to_repr r
 
-                let of_binable r = of_repr r
-              end)
+                  let of_binable r = of_repr r
+                end)
+    end
+
+    include T
+    include Codable.Make_base58_check (T)
   end
 end]
 
-include Codable.Make_base58_check (Stable.Latest)
+[%%define_locally
+Stable.Latest.(to_base58_check, of_base58_check, of_base58_check_exn)]
 
 let dummy : t =
   { step_data = At_most.[]


### PR DESCRIPTION
Use base58 format when representing verification key in yojson

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
