### PR TITLE
[Trivial] Silence logs from remaining noisy unit tests

### DIFF
--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -1,5 +1,6 @@
 (* child_processes.ml -- management of starting, tracking, and killing child processes. *)
 
+open Inline_test_quiet_logs
 open Core
 open Async
 open Pipe_lib

--- a/src/lib/child_processes/dune
+++ b/src/lib/child_processes/dune
@@ -7,4 +7,4 @@
  (preprocess (pps
                ppx_assert ppx_coda ppx_version ppx_here ppx_custom_printf ppx_deriving.show
                ppx_inline_test ppx_let ppx_pipebang))
- (libraries async core ctypes ctypes.foreign file_system error_json logger pipe_lib))
+ (libraries async core ctypes ctypes.foreign file_system error_json logger pipe_lib inline_test_quiet_logs))

--- a/src/lib/distributed_dsl/distributed_dsl.ml
+++ b/src/lib/distributed_dsl/distributed_dsl.ml
@@ -1,3 +1,4 @@
+open Inline_test_quiet_logs
 open Core_kernel
 open Async_kernel
 open Pipe_lib

--- a/src/lib/distributed_dsl/dune
+++ b/src/lib/distributed_dsl/dune
@@ -3,7 +3,7 @@
  (public_name distributed_dsl)
  (library_flags -linkall)
  (inline_tests)
- (libraries logger core pipe_lib async)
+ (libraries logger core pipe_lib async inline_test_quiet_logs)
  (preprocess
   (pps ppx_coda ppx_version ppx_jane ppx_compare ppx_deriving.enum ppx_deriving_yojson))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -1,3 +1,4 @@
+open Inline_test_quiet_logs
 open Core_kernel
 open Mina_base
 open Pipe_lib


### PR DESCRIPTION
This PR uses the `Inline_test_quiet_logs` open to silence output from the remaining noisy unit tests:
* `child_processes`
* `distributed_dsl`
* `transaction_inclusion_status`

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
