### PR TITLE
Remove verifier memory stats logging

### DIFF
--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -439,19 +439,11 @@ let verify_blockchain_snarks { worker; logger } chains =
               |> Deferred.Or_error.map ~f:(fun x -> `Continue x)
             ]))
 
-module Id = Unique_id.Int ()
-
 let verify_transaction_snarks { worker; logger } ts =
   trace_recurring "Verifier.verify_transaction_snarks" (fun () ->
-      let id = Id.create () in
       let n = List.length ts in
-      let metadata () =
-        ("id", `String (Id.to_string id))
-        :: ("n", `Int n)
-        :: Memory_stats.(jemalloc_memory_stats () @ ocaml_memory_stats ())
-      in
-      [%log trace] "verify $n transaction_snarks (before)"
-        ~metadata:(metadata ()) ;
+      let metadata = [ ("n", `Int n) ] in
+      [%log trace] "verify $n transaction_snarks (before)" ~metadata ;
       let%map res =
         with_retry ~logger (fun () ->
             let%bind { connection; _ } = Ivar.read !worker in
@@ -463,7 +455,7 @@ let verify_transaction_snarks { worker; logger } ts =
         ~metadata:
           ( ( "result"
             , `String (Sexp.to_string ([%sexp_of: bool Or_error.t] res)) )
-          :: metadata () ) ;
+          :: metadata ) ;
       res)
 
 let verify_commands { worker; logger } ts =


### PR DESCRIPTION
My thread timing work showed that the daemon was spending a very large amount of time making 4x calls to collect GC stats every time we submit snark work to the verifier. This PR removes this logging. This change has been tested on mainnet and I've confirmed it has a significant reduction in async scheduler contention.