### PR TITLE
[Trivial] Remove unused type parameter in kimchi constraint system

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
+++ b/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
@@ -45,7 +45,7 @@ module type Inputs_intf = sig
   end
 
   module Constraint_system : sig
-    type t = (Gate_vector.t, Scalar_field.t) Plonk_constraint_system.t
+    type t = Scalar_field.t Plonk_constraint_system.t
 
     val finalize_and_get_gates : t -> Gate_vector.t
   end
@@ -92,8 +92,7 @@ module Make (Inputs : Inputs_intf) = struct
 
   type t =
     { index : Inputs.Index.t
-    ; cs :
-        (Inputs.Gate_vector.t, Inputs.Scalar_field.t) Plonk_constraint_system.t
+    ; cs : Inputs.Scalar_field.t Plonk_constraint_system.t
     }
 
   let name =

--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -255,7 +255,7 @@ module V = struct
   include Hashable.Make (T)
 end
 
-type ('a, 'f) t =
+type 'f t =
   { (* map of cells that share the same value (enforced by to the permutation) *)
     equivalence_classes : Row.t Position.t list V.Table.t
   ; (* How to compute each internal variable (as a linear combination of other variables) *)
@@ -311,7 +311,7 @@ struct
   open Core
   open Pickles_types
 
-  type nonrec t = (Gates.t, Fp.t) t
+  type nonrec t = Fp.t t
 
   module H = Digestif.SHA256
 

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -16,11 +16,10 @@ let rough_domains : Domains.t =
   let d = Domain.Pow_2_roots_of_unity 20 in
   { h = d; x = Pow_2_roots_of_unity 6 }
 
-let domains (type field a)
+let domains (type field)
     (module Impl : Snarky_backendless.Snark_intf.Run
       with type field = field
-       and type R1CS_constraint_system.t = ( a
-                                           , field )
+       and type R1CS_constraint_system.t = field
                                            Kimchi_backend_common
                                            .Plonk_constraint_system
                                            .t) (Spec.ETyp.T (typ, conv)) main =


### PR DESCRIPTION
This PR removes an unused type parameter. This is a no-op.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them