### PR TITLE
Add more fields to accounts in graphql

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -2930,425 +2930,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "AuthRequired",
-          "description": "Kind of authorization required",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "None",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "Either",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "Proof",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "Signature",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "Both",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "Impossible",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "Permissions",
-          "description": null,
-          "fields": [
-            {
-              "name": "setVotingFor",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "incrementNonce",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "setTokenSymbol",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "editSequenceState",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "setSnappUri",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "setVerificationKey",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "setPermissions",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "setDelegate",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "receive",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "send",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "editState",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "stake",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": [
-            {
-              "name": "setVotingFor",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "incrementNonce",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "setTokenSymbol",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "editSequenceState",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "setSnappUri",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "setVerificationKey",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "setPermissions",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "setDelegate",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "receive",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "send",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "editState",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "AuthRequired",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "stake",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "INPUT_OBJECT",
           "name": "VerificationKeyWithHash",
           "description": "Verification key with hash",
@@ -11180,6 +10761,260 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "AuthRequired",
+          "description": "Kind of authorization required",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "None",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Either",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Proof",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Signature",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Both",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Impossible",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Permissions",
+          "description": null,
+          "fields": [
+            {
+              "name": "stake",
+              "description": "Permission to stake",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editState",
+              "description": "Authorization required to edit snapp state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "send",
+              "description": "Authorization required to send tokens",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "receive",
+              "description": "Authorization required to receive tokens",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setDelegate",
+              "description": "Authorization required to set the delegate",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setPermissions",
+              "description": "Authorization required to change permissions",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setVerificationKey",
+              "description":
+                "Authorization required to set the verification key of the snapp associated with the account",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setSnappUri",
+              "description":
+                "Authorization required to change the URI of the snapp associated with the account ",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editSequenceState",
+              "description":
+                "Authorization required to edit the sequence state",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setTokenSymbol",
+              "description": "Authorization required to set the token symbol",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "incrementNonce",
+              "description": "Authorization required to increment the nonce",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setVotingFor",
+              "description":
+                "Authorization required to set the state hash the account is voting for",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "SCALAR",
           "name": "Boolean",
           "description": null,
@@ -11637,10 +11472,52 @@
               "deprecationReason": null
             },
             {
+              "name": "permissions",
+              "description":
+                "Permissions for updating certain fields of this account",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Permissions",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tokenSymbol",
               "description": "The token symbol associated with this account",
               "args": [],
               "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "verificationKey",
+              "description":
+                "Hash of the verification key associated with this account",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "sequenceEvents",
+              "description": "Sequence events associated with this account",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -2930,6 +2930,425 @@
           "possibleTypes": null
         },
         {
+          "kind": "ENUM",
+          "name": "AuthRequired",
+          "description": "Kind of authorization required",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "None",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Either",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Proof",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Signature",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Both",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Impossible",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "Permissions",
+          "description": null,
+          "fields": [
+            {
+              "name": "setVotingFor",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "incrementNonce",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setTokenSymbol",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editSequenceState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setSnappUri",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setVerificationKey",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setPermissions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "setDelegate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "receive",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "send",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "editState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stake",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "setVotingFor",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "incrementNonce",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setTokenSymbol",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "editSequenceState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setSnappUri",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setVerificationKey",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setPermissions",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setDelegate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "receive",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "send",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "editState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AuthRequired",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "stake",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "VerificationKeyWithHash",
           "description": "Verification key with hash",
@@ -10762,7 +11181,7 @@
         },
         {
           "kind": "ENUM",
-          "name": "AuthRequired",
+          "name": "AccountAuthRequired",
           "description": "Kind of authorization required",
           "fields": null,
           "inputFields": null,
@@ -10809,7 +11228,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "Permissions",
+          "name": "AccountPermissions",
           "description": null,
           "fields": [
             {
@@ -10837,7 +11256,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -10853,7 +11272,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -10869,7 +11288,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -10885,7 +11304,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -10901,7 +11320,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -10918,7 +11337,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -10935,7 +11354,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -10952,7 +11371,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -10968,7 +11387,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -10984,7 +11403,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -11001,7 +11420,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "AuthRequired",
+                  "name": "AccountAuthRequired",
                   "ofType": null
                 }
               },
@@ -11478,7 +11897,7 @@
               "args": [],
               "type": {
                 "kind": "OBJECT",
-                "name": "Permissions",
+                "name": "AccountPermissions",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11180,6 +11180,49 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "AccountVerificationKeyWithHash",
+          "description": "Verification key with hash",
+          "fields": [
+            {
+              "name": "verificationKey",
+              "description": "Verification key in Base58Check format",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hash",
+              "description": "Hash of verification key",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "AccountAuthRequired",
           "description": "Kind of authorization required",
@@ -11913,10 +11956,13 @@
             },
             {
               "name": "verificationKey",
-              "description":
-                "Hash of the verification key associated with this account",
+              "description": "Verification key associated with this account",
               "args": [],
-              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "type": {
+                "kind": "OBJECT",
+                "name": "AccountVerificationKeyWithHash",
+                "ofType": null
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },

--- a/src/app/snapp_test_transaction/lib/commands.ml
+++ b/src/app/snapp_test_transaction/lib/commands.ml
@@ -354,9 +354,11 @@ module Events = struct
 end
 
 module Util = struct
-  let keypair_of_file =
-    Secrets.Keypair.Terminal_stdin.read_exn ~should_prompt_user:false
-      ~which:"payment keypair"
+  let keypair_of_file ?(which = "Fee Payer") f =
+    printf "%s keyfile\n" which ;
+    Secrets.Keypair.Terminal_stdin.read_exn ~which f
+
+  let snapp_keypair_of_file = keypair_of_file ~which:"Snapp Account"
 
   let print_snapp_transaction parties =
     printf !"Parties sexp:\n %{sexp: Parties.t}\n\n%!" parties ;
@@ -370,7 +372,12 @@ module Util = struct
         Signed_command_memo.create_from_string_exn m)
 
   let app_state_of_list lst =
-    List.map ~f:App_state.of_string lst |> Snapp_state.V.of_list_exn
+    let app_state = List.map ~f:App_state.of_string lst in
+    List.append app_state
+      (List.init
+         (8 - List.length app_state)
+         ~f:(fun _ -> Snapp_basic.Set_or_keep.Keep))
+    |> Snapp_state.V.of_list_exn
 
   let sequence_state_of_list array_lst : Snark_params.Tick.Field.t array list =
     List.map ~f:Events.of_string_array array_lst
@@ -422,7 +429,7 @@ let create_snapp_account ~debug ~keyfile ~fee ~snapp_keyfile ~amount ~nonce
     ~memo =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_keypair = Util.keypair_of_file snapp_keyfile in
+  let%bind snapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
     ; fee
@@ -448,7 +455,7 @@ let upgrade_snapp ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ~verification_key ~snapp_uri ~auth =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_account_keypair = Util.keypair_of_file snapp_keyfile in
+  let%bind snapp_account_keypair = Util.snapp_keypair_of_file snapp_keyfile in
   let verification_key =
     let data =
       Side_loaded_verification_key.of_base58_check_exn verification_key
@@ -517,7 +524,7 @@ let transfer_funds ~debug ~keyfile ~fee ~nonce ~memo ~receivers =
 let update_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~app_state =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_keypair = Util.keypair_of_file snapp_keyfile in
+  let%bind snapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
   let app_state = Util.app_state_of_list app_state in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
@@ -550,7 +557,7 @@ let update_snapp_uri ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~snapp_uri
     ~auth =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_account_keypair = Util.keypair_of_file snapp_keyfile in
+  let%bind snapp_account_keypair = Util.snapp_keypair_of_file snapp_keyfile in
   let snapp_uri = Snapp_basic.Set_or_keep.Set snapp_uri in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
@@ -585,7 +592,7 @@ let update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ~sequence_state =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_keypair = Util.keypair_of_file snapp_keyfile in
+  let%bind snapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
   let sequence_events = Util.sequence_state_of_list sequence_state in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
@@ -618,7 +625,7 @@ let update_token_symbol ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ~token_symbol ~auth =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_account_keypair = Util.keypair_of_file snapp_keyfile in
+  let%bind snapp_account_keypair = Util.snapp_keypair_of_file snapp_keyfile in
   let token_symbol = Snapp_basic.Set_or_keep.Set token_symbol in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
@@ -653,7 +660,7 @@ let update_permissions ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ~permissions ~current_auth =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_keypair = Util.keypair_of_file snapp_keyfile in
+  let%bind snapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
     ; fee

--- a/src/app/snapp_test_transaction/snapp_test_transaction.ml
+++ b/src/app/snapp_test_transaction/snapp_test_transaction.ml
@@ -38,13 +38,6 @@ module Flags = struct
     Param.flag "--nonce" ~doc:"NN Nonce of the fee payer account"
       Param.(required txn_nonce)
 
-  let snapp_state =
-    Param.flag "--snapp-state"
-      ~doc:
-        "FIELDS A list of 8 values that can be Integers, arbitrarty strings,  \
-         hashes, or field elements"
-      Param.(required txn_nonce)
-
   let common_flags =
     Command.(
       let open Let_syntax in
@@ -224,7 +217,7 @@ let update_state =
          Param.flag "--snapp-state"
            ~doc:
              "String(hash)|Integer(field element) a list of 8 elements that \
-              represent the snapp state (null if unspecified)"
+              represent the snapp state (Use empty string for no-op)"
            Param.(listed string)
        in
        let fee = Option.value ~default:Flags.default_fee fee in

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -967,7 +967,7 @@ module Types = struct
 
     let auth_required =
       let open Permissions.Auth_required in
-      enum "AuthRequired" ~doc:"Kind of authorization required"
+      enum "AccountAuthRequired" ~doc:"Kind of authorization required"
         ~values:
           [ enum_value "None" ~value:None
           ; enum_value "Either" ~value:Either
@@ -978,7 +978,7 @@ module Types = struct
           ]
 
     let account_permissions =
-      obj "Permissions" ~fields:(fun _ ->
+      obj "AccountPermissions" ~fields:(fun _ ->
           [ field "stake" ~typ:(non_null bool) ~doc:"Permission to stake"
               ~args:Arg.[]
               ~resolve:(fun _ permission -> permission.Permissions.Poly.stake)

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -965,6 +965,84 @@ module Types = struct
     let account_id { Account.Poly.public_key; token_id; _ } =
       Account_id.create public_key token_id
 
+    let auth_required =
+      let open Permissions.Auth_required in
+      enum "AuthRequired" ~doc:"Kind of authorization required"
+        ~values:
+          [ enum_value "None" ~value:None
+          ; enum_value "Either" ~value:Either
+          ; enum_value "Proof" ~value:Proof
+          ; enum_value "Signature" ~value:Signature
+          ; enum_value "Both" ~value:Both
+          ; enum_value "Impossible" ~value:Impossible
+          ]
+
+    let account_permissions =
+      obj "Permissions" ~fields:(fun _ ->
+          [ field "stake" ~typ:(non_null bool) ~doc:"Permission to stake"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission -> permission.Permissions.Poly.stake)
+          ; field "editState" ~typ:(non_null auth_required)
+              ~doc:"Authorization required to edit snapp state"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission ->
+                permission.Permissions.Poly.edit_state)
+          ; field "send" ~typ:(non_null auth_required)
+              ~doc:"Authorization required to send tokens"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission -> permission.Permissions.Poly.send)
+          ; field "receive" ~typ:(non_null auth_required)
+              ~doc:"Authorization required to receive tokens"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission -> permission.Permissions.Poly.receive)
+          ; field "setDelegate" ~typ:(non_null auth_required)
+              ~doc:"Authorization required to set the delegate"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission ->
+                permission.Permissions.Poly.set_delegate)
+          ; field "setPermissions" ~typ:(non_null auth_required)
+              ~doc:"Authorization required to change permissions"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission ->
+                permission.Permissions.Poly.set_permissions)
+          ; field "setVerificationKey" ~typ:(non_null auth_required)
+              ~doc:
+                "Authorization required to set the verification key of the \
+                 snapp associated with the account"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission ->
+                permission.Permissions.Poly.set_verification_key)
+          ; field "setSnappUri" ~typ:(non_null auth_required)
+              ~doc:
+                "Authorization required to change the URI of the snapp \
+                 associated with the account "
+              ~args:Arg.[]
+              ~resolve:(fun _ permission ->
+                permission.Permissions.Poly.set_snapp_uri)
+          ; field "editSequenceState" ~typ:(non_null auth_required)
+              ~doc:"Authorization required to edit the sequence state"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission ->
+                permission.Permissions.Poly.edit_sequence_state)
+          ; field "setTokenSymbol" ~typ:(non_null auth_required)
+              ~doc:"Authorization required to set the token symbol"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission ->
+                permission.Permissions.Poly.set_token_symbol)
+          ; field "incrementNonce" ~typ:(non_null auth_required)
+              ~doc:"Authorization required to increment the nonce"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission ->
+                permission.Permissions.Poly.increment_nonce)
+          ; field "setVotingFor" ~typ:(non_null auth_required)
+              ~doc:
+                "Authorization required to set the state hash the account is \
+                 voting for"
+              ~args:Arg.[]
+              ~resolve:(fun _ permission ->
+                permission.Permissions.Poly.set_voting_for)
+          ])
+
     let rec account =
       lazy
         (obj "Account" ~doc:"An account record according to the daemon"
@@ -1213,11 +1291,36 @@ module Types = struct
                    |> Option.map ~f:(fun snapp_account ->
                           snapp_account.app_state |> Snapp_state.V.to_list
                           |> List.map ~f:Snapp_basic.F.to_string))
+             ; field "permissions" ~typ:account_permissions
+                 ~doc:"Permissions for updating certain fields of this account"
+                 ~args:Arg.[]
+                 ~resolve:(fun _ { account; _ } ->
+                   account.Account.Poly.permissions)
              ; field "tokenSymbol" ~typ:string
                  ~doc:"The token symbol associated with this account"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
                    account.Account.Poly.token_symbol)
+             ; field "verificationKey" ~typ:string
+                 ~doc:
+                   "Hash of the verification key associated with this account"
+                 ~args:Arg.[]
+                 ~resolve:(fun _ { account; _ } ->
+                   Option.value_map account.Account.Poly.snapp ~default:None
+                     ~f:(fun snapp_account ->
+                       Option.map snapp_account.verification_key ~f:(fun vk ->
+                           With_hash.hash vk
+                           |> Pickles.Backend.Tick.Field.to_string)))
+             ; field "sequenceEvents"
+                 ~doc:"Sequence events associated with this account"
+                 ~typ:(list (non_null string))
+                 ~args:Arg.[]
+                 ~resolve:(fun _ { account; _ } ->
+                   Option.map account.Account.Poly.snapp
+                     ~f:(fun snapp_account ->
+                       List.map ~f:Snark_params.Tick.Field.to_string
+                         (Pickles_types.Vector.to_list
+                            snapp_account.sequence_state)))
              ]))
 
     let account = Lazy.force account


### PR DESCRIPTION
Added permissions, verification key, sequence state


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
