### PR TITLE
Add test harness for SnarkyJS bindings

### DIFF
--- a/buildkite/scripts/test-snarkyjs-bindings.sh
+++ b/buildkite/scripts/test-snarkyjs-bindings.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# TODO(mitschabaude): add tests for bindings to be run here.

--- a/buildkite/src/Jobs/Test/SnarkyJSTest.dhall
+++ b/buildkite/src/Jobs/Test/SnarkyJSTest.dhall
@@ -1,0 +1,35 @@
+let S = ../../Lib/SelectFiles.dhall
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+let RunInToolchain = ../../Command/RunInToolchain.dhall
+let Docker = ../../Command/Docker/Type.dhall
+let Size = ../../Command/Size.dhall
+
+in
+
+Pipeline.build
+  Pipeline.Config::{
+    spec =
+      JobSpec::{
+        dirtyWhen = [
+          S.strictlyStart (S.contains "buildkite/src/Jobs/Test/SnarkyJSTest"),
+          S.strictlyStart (S.contains "buildkite/scripts/test-snarkyjs-bindings.sh"),
+          S.strictlyStart (S.contains "src")
+        ],
+        path = "Test",
+        name = "SnarkyJSTest"
+      },
+    steps = [
+      Command.build
+        Command.Config::{
+            commands = RunInToolchain.runInToolchainBuster ([] : List Text) "buildkite/scripts/test-snarkyjs-bindings.sh"
+          , label = "Run SnarkyJS bindings tests"
+          , key = "snarkyjs-bindings-test"
+          , target = Size.XLarge
+          , docker = None Docker.Type
+        }
+    ]
+  }


### PR DESCRIPTION
This PR adds a test harness for the SnarkyJS bindings on CI. This is intended to support the effort to merge the bindings into `develop` via #10267. The script is currently a no-op, whose contents will be filled by @mitschabaude in that PR.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
