### PR TITLE
[crypto][kimchi] compute circuit digest via compiled gates (instead of IR)

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
+++ b/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
@@ -45,7 +45,7 @@ module type Inputs_intf = sig
   end
 
   module Constraint_system : sig
-    type t = Scalar_field.t Plonk_constraint_system.t
+    type t = (Scalar_field.t, Gate_vector.t) Plonk_constraint_system.t
 
     val finalize_and_get_gates : t -> Gate_vector.t
   end
@@ -92,7 +92,8 @@ module Make (Inputs : Inputs_intf) = struct
 
   type t =
     { index : Inputs.Index.t
-    ; cs : Inputs.Scalar_field.t Plonk_constraint_system.t
+    ; cs :
+        (Inputs.Scalar_field.t, Inputs.Gate_vector.t) Plonk_constraint_system.t
     }
 
   let name =

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
@@ -32,6 +32,7 @@ ark-poly = { version = "0.3.0", features = ["parallel"] }
 commitment_dlog = { path = "../../proof-systems/poly-commitment", features = ["ocaml_types"] }
 groupmap = { path = "../../proof-systems/groupmap" }
 mina-curves = { path = "../../proof-systems/curves" }
+o1-utils = { path = "../../proof-systems/utils" }
 oracle = { path = "../../proof-systems/oracle" }
 kimchi = { path = "../../proof-systems/kimchi", features = ["ocaml_types"] }
 

--- a/src/lib/crypto/kimchi_bindings/stubs/binding_generation/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/binding_generation/src/main.rs
@@ -264,6 +264,7 @@ fn generate_bindings(mut w: impl std::io::Write) {
                     decl_func!(w, env, caml_pasta_fp_plonk_gate_vector_add => "add");
                     decl_func!(w, env, caml_pasta_fp_plonk_gate_vector_get => "get");
                     decl_func!(w, env, caml_pasta_fp_plonk_gate_vector_wrap => "wrap");
+                    decl_func!(w, env, caml_pasta_fp_plonk_gate_vector_digest => "digest");
                 });
                 decl_module!(w, env, "Fq", {
                     decl_type!(w, env, CamlPastaFqPlonkGateVector => "t");
@@ -273,6 +274,7 @@ fn generate_bindings(mut w: impl std::io::Write) {
                     decl_func!(w, env, caml_pasta_fq_plonk_gate_vector_add => "add");
                     decl_func!(w, env, caml_pasta_fq_plonk_gate_vector_get => "get");
                     decl_func!(w, env, caml_pasta_fq_plonk_gate_vector_wrap => "wrap");
+                    decl_func!(w, env, caml_pasta_fq_plonk_gate_vector_digest => "digest");
                 });
             });
         });

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi.ml
@@ -434,6 +434,8 @@ module Protocol = struct
 
         external wrap : t -> wire -> wire -> unit
           = "caml_pasta_fp_plonk_gate_vector_wrap"
+
+        external digest : t -> bytes = "caml_pasta_fp_plonk_gate_vector_digest"
       end
 
       module Fq = struct
@@ -451,6 +453,8 @@ module Protocol = struct
 
         external wrap : t -> wire -> wire -> unit
           = "caml_pasta_fq_plonk_gate_vector_wrap"
+
+        external digest : t -> bytes = "caml_pasta_fq_plonk_gate_vector_digest"
       end
     end
   end

--- a/src/lib/crypto/kimchi_bindings/stubs/src/gate_vector.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/gate_vector.rs
@@ -1,9 +1,10 @@
 //! A GateVector: this is used to represent a list of gates.
 
 use kimchi::circuits::{
-    gate::{caml::CamlCircuitGate, CircuitGate},
+    gate::{caml::CamlCircuitGate, Circuit, CircuitGate},
     wires::caml::CamlWire,
 };
+use o1_utils::hasher::CryptoDigest;
 
 // TODO: get rid of this
 
@@ -75,6 +76,12 @@ pub mod fp {
     ) {
         (v.as_mut().0)[t.row as usize].wires[t.col as usize] = h.into();
     }
+
+    #[ocaml_gen::func]
+    #[ocaml::func]
+    pub fn caml_pasta_fp_plonk_gate_vector_digest(v: CamlPastaFpPlonkGateVectorPtr) -> [u8; 32] {
+        Circuit(&v.as_ref().0).digest()
+    }
 }
 
 //
@@ -142,5 +149,11 @@ pub mod fq {
         h: CamlWire,
     ) {
         (v.as_mut().0)[t.row as usize].wires[t.col as usize] = h.into();
+    }
+
+    #[ocaml_gen::func]
+    #[ocaml::func]
+    pub fn caml_pasta_fq_plonk_gate_vector_digest(v: CamlPastaFqPlonkGateVectorPtr) -> [u8; 32] {
+        Circuit(&v.as_ref().0).digest()
     }
 }

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -16,10 +16,11 @@ let rough_domains : Domains.t =
   let d = Domain.Pow_2_roots_of_unity 20 in
   { h = d; x = Pow_2_roots_of_unity 6 }
 
-let domains (type field)
+let domains (type field rust_gates)
     (module Impl : Snarky_backendless.Snark_intf.Run
       with type field = field
-       and type R1CS_constraint_system.t = field
+       and type R1CS_constraint_system.t = ( field
+                                           , rust_gates )
                                            Kimchi_backend_common
                                            .Plonk_constraint_system
                                            .t) (Spec.ETyp.T (typ, conv)) main =


### PR DESCRIPTION
To obtain a hash for a circuit, we currently hash the intermediate snarky representation (before it gets compiled to the actual gates). I don't think this is a good idea as different IR might lead to the same compiled circuit (gates). Thus, different circuits could have the same hash.

This PR proposes to compute the digest from the compiled circuit directly, which is implemented on the Rust side much more easily using serde's Serialization: https://github.com/o1-labs/proof-systems/pull/321

**Note: this change means that you can't obtain a digest from an unfinalized circuit, which sounds to me like it's a feature. But I need to see if things need fixing because of that.**