### PR TITLE
Fix snark worker support in integration tests

### DIFF
--- a/automation/terraform/modules/kubernetes/testnet/locals.tf
+++ b/automation/terraform/modules/kubernetes/testnet/locals.tf
@@ -164,10 +164,10 @@ locals {
       mina        = local.daemon
       healthcheck = local.healthcheck_vars
 
-      coordinatorName = "snark-coordinator-${lower(substr(snark.snark_worker_public_key,0,6))}"
-      workerName = "snark-worker-${lower(substr(snark.snark_worker_public_key,0,6))}"
+      coordinatorName = "snark-coordinator-${lower(substr(snark.snark_worker_public_key,-6,-1))}"
+      workerName = "snark-worker-${lower(substr(snark.snark_worker_public_key,-6,-1))}"
       workerReplicas = snark.snark_worker_replicas
-      coordinatorHostName = "snark-coordinator-${lower(substr(snark.snark_worker_public_key,0,6))}.${var.testnet_name}"
+      coordinatorHostName = "snark-coordinator-${lower(substr(snark.snark_worker_public_key,-6,-1))}.${var.testnet_name}"
       coordinatorRpcPort = 8301
       coordinatorHostPort = snark.snark_coordinators_host_port
       publicKey =snark.snark_worker_public_key

--- a/automation/terraform/modules/o1-integration/locals.tf
+++ b/automation/terraform/modules/o1-integration/locals.tf
@@ -23,7 +23,7 @@ locals {
     archiveAddress     = null
   }
 
-  snark_coordinator_name = "snark-coordinator-${lower(substr(var.snark_worker_public_key, length(var.snark_worker_public_key) - 6, 6))}"
+  snark_coordinator_name = "snark-coordinator-${lower(substr(var.snark_worker_public_key, -6, -1))}"
 
   default_archive_node = {
     image                   = var.mina_archive_image

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -23,7 +23,7 @@ spec:
         prometheus.io/path: '/metrics'
     spec:
       containers:
-      - name: coordinator
+      - name: mina
         resources:
           limits:
           requests:

--- a/helm/snark-worker/templates/snark-worker.yaml
+++ b/helm/snark-worker/templates/snark-worker.yaml
@@ -32,10 +32,14 @@ spec:
         image: {{ $.Values.mina.image }}
         {{ if $.Values.mina.useCustomEntrypoint -}}
         command: [{{ $.Values.mina.customEntrypoint }}]
-        {{- else }}
-        command: ["bash", "-c"]
         {{- end }}
-        args: [ "sleep 120 && mina internal snark-worker -proof-level full -daemon-address '{{ $.Values.coordinatorHostName }}:{{ $.Values.coordinatorRpcPort }}'" ]
+        args: [
+          "internal", 
+          "snark-worker", 
+          "-proof-level","full",
+          "-shutdown-on-disconnect", "false", "-daemon-address",
+          "{{ $.Values.coordinatorHostName }}:{{ $.Values.coordinatorRpcPort }}"
+        ]
         env:
           - name: "RAYON_NUM_THREADS"
             value: "4"

--- a/src/app/test_executive/README.md
+++ b/src/app/test_executive/README.md
@@ -16,10 +16,9 @@ Note: this environment setup assumes that one is a member of o(1) labs and has a
 
 ![automated-validation service account "Keys" tab](https://user-images.githubusercontent.com/3465290/112069746-9aaed080-8b29-11eb-83f1-f36876f3ac3d.png)
 
-4) Other than `GCLOUD_API_KEY`, ensure the following other environment variables are also properly set (preferably in in .bashrc or .profile.):
+4) In addition to `GCLOUD_API_KEY` and `GOOGLE_CLOUD_KEYFILE_JSON`, ensure the following other environment variables are also properly set (preferably in in .bashrc or .profile.):
 - `KUBE_CONFIG_PATH`.  this should usually be `~/.kube/config`
-- any other vars relating to Google cloud access,
-- any AWS related vars, namely: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION=us-west-2`,
+- the following AWS related vars, namely: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION=us-west-2`,
 - vars relating to ocaml compilation
 
 5) Run the following commands in order to log in to Google Cloud, and activate the service account for one's work machine.

--- a/src/app/test_executive/archive_node_test.ml
+++ b/src/app/test_executive/archive_node_test.ml
@@ -39,10 +39,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let all_nodes = Network.all_nodes network in
     (* waiting for archive_node does not seem to work *)
     [%log info] "archive node test: waiting for block producers to initialize" ;
-    let%bind () =
-      Malleable_error.List.iter all_nodes ~f:(fun bp ->
-          wait_for t (Wait_condition.node_to_initialize bp))
-    in
+    let%bind () = wait_for t (Wait_condition.nodes_to_initialize all_nodes) in
     [%log info] "archive node test: waiting for archive node to initialize" ;
     let%bind () = wait_for t (Wait_condition.node_to_initialize archive_node) in
     [%log info] "archive node test: running network for %0.1f minutes"

--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -31,14 +31,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_nodes = Network.all_nodes network in
-
+    let%bind () = wait_for t (Wait_condition.nodes_to_initialize all_nodes) in
     let[@warning "-8"] [ node_a; node_b; node_c ] =
       Network.block_producers network
-    in
-    (* TODO: let%bind () = wait_for t (Wait_condition.nodes_to_initialize [node_a; node_b; node_c]) in *)
-    let%bind () =
-      Malleable_error.List.iter all_nodes
-        ~f:(Fn.compose (wait_for t) Wait_condition.node_to_initialize)
     in
     let%bind _ =
       section "blocks are produced"

--- a/src/app/test_executive/gossip_consistency.ml
+++ b/src/app/test_executive/gossip_consistency.ml
@@ -27,18 +27,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             })
     }
 
-  let wait_for_all_to_initialize ~logger network t =
-    let open Malleable_error.Let_syntax in
-    let all_nodes = Network.all_nodes network in
-    let n = List.length all_nodes in
-    List.mapi all_nodes ~f:(fun i node ->
-        let%map () = wait_for t (Wait_condition.node_to_initialize node) in
-        [%log info]
-          "gossip_consistency test: Block producer %d (of %d) initialized"
-          (i + 1) n ;
-        ())
-    |> Malleable_error.all_unit
-
   let send_payments ~logger ~sender_pub_key ~receiver_pub_key ~amount ~fee ~node
       n =
     let open Malleable_error.Let_syntax in
@@ -84,7 +72,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     [%log info] "gossip_consistency test: starting..." ;
-    let%bind () = wait_for_all_to_initialize ~logger network t in
+    let%bind () =
+      wait_for t
+        (Wait_condition.nodes_to_initialize (Network.all_nodes network))
+    in
     [%log info] "gossip_consistency test: done waiting for initializations" ;
     let receiver_bp = Caml.List.nth (Network.block_producers network) 0 in
     let%bind receiver_pub_key = Util.pub_key_of_node receiver_bp in

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -57,10 +57,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     (* fee for user commands *)
     let fee = Currency.Fee.of_int 10_000_000 in
     let all_nodes = Network.all_nodes network in
-    let%bind () =
-      Malleable_error.List.iter all_nodes
-        ~f:(Fn.compose (wait_for t) Wait_condition.node_to_initialize)
-    in
+    let%bind () = wait_for t (Wait_condition.nodes_to_initialize all_nodes) in
     let[@warning "-8"] [ untimed_node_a; untimed_node_b; timed_node_a ] =
       Network.block_producers network
     in

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -45,7 +45,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                 ~vesting_increment:500_000_000_000
           }
         ]
-    ; num_snark_workers = 0
+    ; num_snark_workers =
+        3
+        (* this test doesn't need snark workers, however turning it on in this test just to make sure the snark workers function within integration tests *)
     }
 
   let run network t =

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -36,13 +36,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     { default with
       requires_graphql = true
     ; block_producers =
-        [ { balance = "4000"; timing = Untimed }
-        ; { balance = "3000"; timing = Untimed }
-        ; { balance = "1000"
+        [ { balance = "40000"; timing = Untimed }
+        ; { balance = "30000"; timing = Untimed }
+        ; { balance = "10000"
           ; timing =
-              make_timing ~min_balance:100_000_000_000 ~cliff_time:4
-                ~cliff_amount:0 ~vesting_period:2
-                ~vesting_increment:50_000_000_000
+              make_timing ~min_balance:1_000_000_000_000 ~cliff_time:8
+                ~cliff_amount:0 ~vesting_period:4
+                ~vesting_increment:500_000_000_000
           }
         ]
     ; num_snark_workers = 0
@@ -64,7 +64,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section "send a single payment between 2 untimed accounts"
-        (let amount = Currency.Amount.of_int 200_000_000 in
+        (let amount = Currency.Amount.of_int 2_000_000_000 in
          let fee = Currency.Fee.of_int 10_000_000 in
          let receiver = untimed_node_a in
          let%bind receiver_pub_key = Util.pub_key_of_node receiver in
@@ -80,7 +80,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section "send a single payment from timed account using available liquid"
-        (let amount = Currency.Amount.of_int 300_000_000_000 in
+        (let amount = Currency.Amount.of_int 3_000_000_000_000 in
          let receiver = untimed_node_a in
          let%bind receiver_pub_key = Util.pub_key_of_node receiver in
          let sender = timed_node_a in
@@ -94,7 +94,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
               ~receiver_pub_key ~amount))
     in
     section "unable to send payment from timed account using illiquid tokens"
-      (let amount = Currency.Amount.of_int 600_000_000_000 in
+      (let amount = Currency.Amount.of_int 6_900_000_000_000 in
        let receiver = untimed_node_b in
        let%bind receiver_pub_key = Util.pub_key_of_node receiver in
        let sender = timed_node_a in

--- a/src/app/test_executive/peers_reliability_test.ml
+++ b/src/app/test_executive/peers_reliability_test.ml
@@ -32,17 +32,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let all_nodes = Network.all_nodes network in
-    let[@warning "-8"] [ node_a; node_b; node_c ] =
-      Network.block_producers network
-    in
     [%log info] "peers_list"
       ~metadata:
         [ ("peers", `List (List.map all_nodes ~f:(fun n -> `String (Node.id n))))
         ] ;
-    (* TODO: let%bind () = wait_for t (Wait_condition.nodes_to_initialize [node_a; node_b; node_c]) in *)
-    let%bind () =
-      Malleable_error.List.iter all_nodes
-        ~f:(Fn.compose (wait_for t) Wait_condition.node_to_initialize)
+    let%bind () = wait_for t (Wait_condition.nodes_to_initialize all_nodes) in
+    let[@warning "-8"] [ node_a; node_b; node_c ] =
+      Network.block_producers network
     in
     let%bind initial_connectivity_data =
       Util.fetch_connectivity_data ~logger all_nodes

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -245,6 +245,7 @@ let main inputs =
     ; points = "codaprotocol/coda-points-hack:32b.4"
     }
   in
+  [%log trace] "expanding network config" ;
   let network_config =
     Engine.Network_config.expand ~logger ~test_name ~cli_inputs
       ~debug:inputs.debug ~test_config:T.config ~images
@@ -255,6 +256,7 @@ let main inputs =
   let error_accumulator_ref = ref None in
   let network_state_writer_ref = ref None in
   let cleanup_deferred_ref = ref None in
+  [%log trace] "preparing up cleanup phase" ;
   let f_dispatch_cleanup =
     let pause_cleanup_func () =
       if inputs.debug then
@@ -272,6 +274,7 @@ let main inputs =
       ~network_state_writer_ref ~cleanup_deferred_ref
   in
   (* run test while gracefully recovering handling exceptions and interrupts *)
+  [%log trace] "attaching signal handler" ;
   Signal.handle Signal.terminating ~f:(fun signal ->
       [%log info] "handling signal %s" (Signal.to_string signal) ;
       let error =
@@ -295,13 +298,16 @@ let main inputs =
         let init_result =
           let open Deferred.Or_error.Let_syntax in
           let lift = Deferred.map ~f:Or_error.return in
+          [%log trace] "initializing network manager" ;
           let%bind net_manager =
             lift @@ Engine.Network_manager.create ~logger network_config
           in
           net_manager_ref := Some net_manager ;
+          [%log trace] "deploying network" ;
           let%bind network =
             lift @@ Engine.Network_manager.deploy net_manager
           in
+          [%log trace] "initializing log engine" ;
           let%map log_engine = Engine.Log_engine.create ~logger ~network in
           log_engine_ref := Some log_engine ;
           let event_router =
@@ -310,10 +316,12 @@ let main inputs =
           in
           error_accumulator_ref :=
             Some (Dsl.watch_log_errors ~logger ~event_router ~on_fatal_error) ;
+          [%log trace] "beginning to process network events" ;
           let network_state_reader, network_state_writer =
             Dsl.Network_state.listen ~logger event_router
           in
           network_state_writer_ref := Some network_state_writer ;
+          [%log trace] "initializing dsl" ;
           let (`Don't_call_in_tests dsl) =
             Dsl.create ~logger ~network ~event_router ~network_state_reader
           in
@@ -323,7 +331,9 @@ let main inputs =
         let%bind network, dsl =
           Deferred.bind init_result ~f:Malleable_error.or_hard_error
         in
+        [%log trace] "initializing network abstraction" ;
         let%bind () = Engine.Network.initialize ~logger network in
+        [%log trace] "executing test" ;
         T.run network dsl)
   in
   let exit_reason, test_result =

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -5,142 +5,85 @@ open Integration_test_lib
 (* exclude from bisect_ppx to avoid type error on GraphQL modules *)
 [@@@coverage exclude_file]
 
+let mina_archive_container_id = "archive"
+
+type config =
+  { testnet_name : string
+  ; cluster : string
+  ; namespace : string
+  ; graphql_enabled : bool
+  }
+
+let base_kube_args { cluster; namespace; _ } =
+  [ "--cluster"; cluster; "--namespace"; namespace ]
+
 module Node = struct
-  type t =
-    { testnet_name : string
-    ; cluster : string
-    ; namespace : string
-    ; pod_id : string
-          (* name of the containers inside the pod.  most pods have only a mina container, archive nodes have that and an archive container *)
-    ; mina_container_id : string
-    ; mina_archive_container_id : string option
-    ; graphql_enabled : bool
-    ; network_keypair : Network_keypair.t option
+  type info =
+    { network_keypair : Network_keypair.t option
+    ; has_archive_container : bool
+    ; primary_container_id : string
     }
+
+  type t = { app_id : string; pod_id : string; info : info; config : config }
 
   let id { pod_id; _ } = pod_id
 
-  let network_keypair { network_keypair; _ } = network_keypair
+  let network_keypair { info = { network_keypair; _ }; _ } = network_keypair
 
   let base_kube_args t = [ "--cluster"; t.cluster; "--namespace"; t.namespace ]
 
-  let get_logs_in_container ?container node =
-    let container_id : string =
-      match container with None -> node.mina_container_id | Some id -> id
+  let get_logs_in_container ?container_id { pod_id; config; info; _ } =
+    let container_id =
+      Option.value container_id ~default:info.primary_container_id
     in
-    let base_args = base_kube_args node in
-    let base_kube_cmd = "kubectl " ^ String.concat ~sep:" " base_args in
-    let pod_cmd =
-      sprintf "%s get pod -l \"app=%s\" -o name" base_kube_cmd node.pod_id
-    in
-    let%bind.Deferred cwd = Unix.getcwd () in
-    let%bind pod = Util.run_cmd_exn cwd "sh" [ "-c"; pod_cmd ] in
-    let kubectl_cmd =
-      Printf.sprintf "%s logs -c %s -n %s %s" base_kube_cmd container_id
-        node.namespace pod
-    in
-    Util.run_cmd_exn cwd "sh" [ "-c"; kubectl_cmd ]
+    let%bind cwd = Unix.getcwd () in
+    Util.run_cmd_exn cwd "kubectl"
+      (base_kube_args config @ [ "logs"; "-c"; container_id; pod_id ])
 
-  let run_in_container node ~container_id ~cmd =
-    let base_args = base_kube_args node in
-    let base_kube_cmd = "kubectl " ^ String.concat ~sep:" " base_args in
-    let kubectl_cmd =
-      Printf.sprintf
-        "%s -c %s exec -i $( %s get pod -l \"app=%s\" -o name) -- %s"
-        base_kube_cmd container_id base_kube_cmd node.pod_id cmd
+  let run_in_container ?container_id ~cmd { pod_id; config; info; _ } =
+    let container_id =
+      Option.value container_id ~default:info.primary_container_id
     in
-    let%bind.Deferred cwd = Unix.getcwd () in
-    Util.run_cmd_exn cwd "sh" [ "-c"; kubectl_cmd ]
-
-  let run_in_container_unit node ~container_id ~cmd =
-    let%map (_output : string) = run_in_container node ~container_id ~cmd in
-    ()
-
-  (* we dont use this functionality atm but if we need logic that runs commands in all containers a whole pod at a time, here it is *)
-  (* let run_in_pod node ~cmd =
-     (* run the cmd in every single container in a pod *)
-     let call_run container_id =
-       let%map res = run_in_container node ~container_id ~cmd in
-       res
-     in
-     let foldh accum m =
-       let open Deferred.Let_syntax in
-       let%bind acc = accum in
-       Deferred.map m ~f:(function s -> acc ^ s)
-     in
-     let container_list : string list =
-       List.append [ node.mina_container_id ]
-       (Option.to_list node.mina_archive_container_id)
-     in
-     let result_list = List.map container_list ~f:call_run in
-     List.fold result_list ~init:(Deferred.return "") ~f:foldh *)
+    let%bind cwd = Unix.getcwd () in
+    Util.run_cmd_exn cwd "kubectl"
+      ( base_kube_args config
+      @ [ "exec"; "-c"; container_id; "-i"; pod_id; "--" ]
+      @ cmd )
 
   let start ~fresh_state node : unit Malleable_error.t =
     let open Deferred.Let_syntax in
     let%bind () =
-      run_in_container_unit node ~container_id:node.mina_container_id
-        ~cmd:"ps aux"
-    in
-    let%bind () =
       if fresh_state then
-        run_in_container_unit node ~container_id:node.mina_container_id
-          ~cmd:"rm -rf .mina-config/*"
+        Deferred.ignore_m
+          (run_in_container node ~cmd:[ "sh"; "-c"; "rm -rf .mina-config/*" ])
       else Deferred.return ()
     in
     let%bind () =
-      run_in_container_unit node ~container_id:node.mina_container_id
-        ~cmd:"/start.sh"
+      Deferred.ignore_m (run_in_container node ~cmd:[ "/start.sh" ])
     in
     Malleable_error.return ()
 
   let stop node =
     let open Deferred.Let_syntax in
     let%bind () =
-      run_in_container_unit node ~container_id:node.mina_container_id
-        ~cmd:"ps aux"
-    in
-    let%bind () =
-      run_in_container_unit node ~container_id:node.mina_container_id
-        ~cmd:"/stop.sh"
-    in
-    let%bind () =
-      run_in_container_unit node ~container_id:node.mina_container_id
-        ~cmd:"ps aux"
+      Deferred.ignore_m (run_in_container node ~cmd:[ "/stop.sh" ])
     in
     Malleable_error.return ()
 
-  let get_pod_name t : string Malleable_error.t =
-    let open Malleable_error.Let_syntax in
-    let args =
-      List.append (base_kube_args t)
-        [ "get"
-        ; "pod"
-        ; "-l"
-        ; sprintf "app=%s" t.pod_id
-        ; "-o=custom-columns=NAME:.metadata.name"
-        ; "--no-headers"
-        ]
-    in
-    let%bind run_result =
-      Deferred.bind ~f:Malleable_error.or_hard_error
-        (Process.run_lines ~prog:"kubectl" ~args ())
-    in
-    match run_result with
-    | [] ->
-        Malleable_error.hard_error_string "get_pod_name: no result"
-    | [ pod_name ] ->
-        return pod_name
-    | _ ->
-        Malleable_error.hard_error_string "get_pod_name: too many results"
+  let logger_metadata node =
+    [ ("namespace", `String node.config.namespace)
+    ; ("app_id", `String node.app_id)
+    ; ("pod_id", `String node.pod_id)
+    ]
 
   module Decoders = Graphql_lib.Decoders
 
   module Graphql = struct
     let ingress_uri node =
       let host =
-        Printf.sprintf "%s.graphql.test.o1test.net" node.testnet_name
+        Printf.sprintf "%s.graphql.test.o1test.net" node.config.testnet_name
       in
-      let path = Printf.sprintf "/%s/graphql" node.pod_id in
+      let path = Printf.sprintf "/%s/graphql" node.app_id in
       Uri.make ~scheme:"http" ~host ~path ~port:80 ()
 
     module Client = Graphql_lib.Client.Make (struct
@@ -221,7 +164,7 @@ module Node = struct
   let exec_graphql_request ?(num_tries = 10) ?(retry_delay_sec = 30.0)
       ?(initial_delay_sec = 30.0) ~logger ~node ~query_name query_obj =
     let open Deferred.Let_syntax in
-    if not node.graphql_enabled then
+    if not node.config.graphql_enabled then
       Deferred.Or_error.error_string
         "graphql is not enabled (hint: set `requires_graphql= true` in the \
          test config)"
@@ -270,8 +213,7 @@ module Node = struct
   let get_peer_id ~logger t =
     let open Deferred.Or_error.Let_syntax in
     [%log info] "Getting node's peer_id, and the peer_ids of node's peers"
-      ~metadata:
-        [ ("namespace", `String t.namespace); ("pod_id", `String t.pod_id) ] ;
+      ~metadata:(logger_metadata t) ;
     let query_obj = Graphql.Query_peer_id.make () in
     let%bind query_result_obj =
       exec_graphql_request ~logger ~node:t ~query_name:"query_peer_id" query_obj
@@ -315,10 +257,8 @@ module Node = struct
     let open Deferred.Or_error.Let_syntax in
     [%log info] "Getting account balance"
       ~metadata:
-        [ ("namespace", `String t.namespace)
-        ; ("pod_id", `String t.pod_id)
-        ; ("account_id", Mina_base.Account_id.to_yojson account_id)
-        ] ;
+        ( ("account_id", Mina_base.Account_id.to_yojson account_id)
+        :: logger_metadata t ) ;
     let pk = Mina_base.Account_id.public_key account_id in
     let token = Mina_base.Account_id.token_id account_id in
     let get_balance_obj =
@@ -345,9 +285,7 @@ module Node = struct
 
   (* if we expect failure, might want retry_on_graphql_error to be false *)
   let send_payment ~logger t ~sender_pub_key ~receiver_pub_key ~amount ~fee =
-    [%log info] "Sending a payment"
-      ~metadata:
-        [ ("namespace", `String t.namespace); ("pod_id", `String t.pod_id) ] ;
+    [%log info] "Sending a payment" ~metadata:(logger_metadata t) ;
     let open Deferred.Or_error.Let_syntax in
     let sender_pk_str =
       Signature_lib.Public_key.Compressed.to_string sender_pub_key
@@ -390,22 +328,22 @@ module Node = struct
 
   let dump_archive_data ~logger (t : t) ~data_file =
     (* this function won't work if t doesn't happen to be an archive node *)
-    let archive_container_id =
-      if Option.is_none t.mina_archive_container_id then
-        failwith
-          "No archive container found.  One can only dump archive data of an \
-           archive node."
-      else Option.value ~default:"" t.mina_archive_container_id
-    in
+    if not t.info.has_archive_container then
+      failwith
+        "No archive container found.  One can only dump archive data of an \
+         archive node." ;
     let open Malleable_error.Let_syntax in
     [%log info] "Dumping archive data from (node: %s, container: %s)" t.pod_id
-      archive_container_id ;
+      mina_archive_container_id ;
     let%map data =
       Deferred.bind ~f:Malleable_error.return
-        (run_in_container t ~container_id:archive_container_id
+        (run_in_container t ~container_id:mina_archive_container_id
            ~cmd:
-             "pg_dump --create --no-owner \
-              postgres://postgres:foobar@archive-1-postgresql:5432/archive")
+             [ "pg_dump"
+             ; "--create"
+             ; "--no-owner"
+             ; "postgres://postgres:foobar@archive-1-postgresql:5432/archive"
+             ])
     in
     [%log info] "Dumping archive data to file %s" data_file ;
     Out_channel.with_file data_file ~f:(fun out_ch ->
@@ -414,7 +352,7 @@ module Node = struct
   let dump_mina_logs ~logger (t : t) ~log_file =
     let open Malleable_error.Let_syntax in
     [%log info] "Dumping container logs from (node: %s, container: %s)" t.pod_id
-      t.mina_container_id ;
+      t.info.primary_container_id ;
     let%map logs =
       Deferred.bind ~f:Malleable_error.return (get_logs_in_container t)
     in
@@ -426,7 +364,7 @@ module Node = struct
     let open Malleable_error.Let_syntax in
     [%log info]
       "Dumping precomputed blocks from logs for (node: %s, container: %s)"
-      t.pod_id t.mina_container_id ;
+      t.pod_id t.info.primary_container_id ;
     let%bind logs =
       Deferred.bind ~f:Malleable_error.return (get_logs_in_container t)
     in
@@ -503,16 +441,51 @@ module Node = struct
     Malleable_error.return ()
 end
 
+module Workload = struct
+  type t = { workload_id : string; node_info : Node.info list }
+
+  let get_nodes t ~config =
+    let%bind cwd = Unix.getcwd () in
+    let%bind app_id =
+      Util.run_cmd_exn cwd "kubectl"
+        ( base_kube_args config
+        @ [ "get"
+          ; "deployment"
+          ; t.workload_id
+          ; "-o"
+          ; "jsonpath={.spec.selector.matchLabels.app}"
+          ] )
+    in
+    let%map pod_ids_str =
+      Util.run_cmd_exn cwd "kubectl"
+        ( base_kube_args config
+        @ [ "get"; "pod"; "-l"; "app=" ^ app_id; "-o"; "name" ] )
+    in
+    let pod_ids =
+      String.split pod_ids_str ~on:'\n'
+      |> List.filter ~f:(Fn.compose not String.is_empty)
+      |> List.map ~f:(String.substr_replace_first ~pattern:"pod/" ~with_:"")
+    in
+    if List.length t.node_info <> List.length pod_ids then
+      failwithf
+        "Unexpected number of replicas in kubernetes deployment for workload \
+         %s: expected %d, got %d"
+        t.workload_id (List.length t.node_info) (List.length pod_ids) () ;
+    List.zip_exn t.node_info pod_ids
+    |> List.map ~f:(fun (info, pod_id) -> { Node.app_id; pod_id; info; config })
+end
+
 type t =
   { namespace : string
   ; constants : Test_config.constants
   ; seeds : Node.t list
   ; block_producers : Node.t list
   ; snark_coordinators : Node.t list
+  ; snark_workers : Node.t list
   ; archive_nodes : Node.t list
   ; testnet_log_filter : string
   ; keypairs : Signature_lib.Keypair.t list
-  ; nodes_by_app_id : Node.t String.Map.t
+  ; nodes_by_pod_id : Node.t String.Map.t
   }
 
 let constants { constants; _ } = constants
@@ -527,15 +500,27 @@ let block_producers { block_producers; _ } = block_producers
 
 let snark_coordinators { snark_coordinators; _ } = snark_coordinators
 
+let snark_workers { snark_workers; _ } = snark_workers
+
 let archive_nodes { archive_nodes; _ } = archive_nodes
 
 (* TODO: snark workers (until then, pretty sure snark work won't be done) *)
-let all_nodes { seeds; block_producers; snark_coordinators; archive_nodes; _ } =
-  List.concat [ seeds; block_producers; snark_coordinators; archive_nodes ]
+let all_nodes
+    { seeds
+    ; block_producers
+    ; snark_coordinators
+    ; snark_workers
+    ; archive_nodes
+    ; _
+    } =
+  List.concat
+    [ seeds; block_producers; snark_coordinators; snark_workers; archive_nodes ]
 
 let keypairs { keypairs; _ } = keypairs
 
-let lookup_node_by_app_id t = Map.find t.nodes_by_app_id
+let lookup_node_by_pod_id t = Map.find t.nodes_by_pod_id
+
+let all_pod_ids t = Map.keys t.nodes_by_pod_id
 
 let initialize ~logger network =
   let open Malleable_error.Let_syntax in
@@ -553,89 +538,69 @@ let initialize ~logger network =
       ; "get"
       ; "pods"
       ; "-ojsonpath={range \
-         .items[*]}{.metadata.labels.app}{':'}{.status.phase}{'\\n'}{end}"
+         .items[*]}{.metadata.name}{':'}{.status.phase}{'\\n'}{end}"
       ]
   in
-  let process_pod_statuses result_str =
+  let parse_pod_statuses result_str =
     result_str |> String.split_lines
     |> List.map ~f:(fun line ->
            let parts = String.split line ~on:':' in
            assert (List.length parts = 2) ;
            (List.nth_exn parts 0, List.nth_exn parts 1))
     |> List.filter ~f:(fun (pod_name, _) -> String.Set.mem all_pods pod_name)
+    |> String.Map.of_alist_exn
   in
   let rec poll n =
     [%log debug] "Checking kubernetes pod statuses, n=%d" n ;
-    let%bind run_result =
-      Deferred.bind ~f:Malleable_error.return (kube_get_pods ())
+    let is_successful_pod_status = String.equal "Running" in
+    let poll_again () =
+      if n < max_polls then
+        let%bind () =
+          after poll_interval |> Deferred.bind ~f:Malleable_error.return
+        in
+        poll (n + 1)
+      else (
+        [%log fatal] "Not all pods were assigned to nodes and ready in time." ;
+        Malleable_error.hard_error_string
+          "Some pods either were not assigned to nodes or did not deploy \
+           properly." )
     in
-    let bad_pod_statuses_opt =
-      match run_result with
-      | Ok str ->
-          let pod_statuses = process_pod_statuses str in
-          (* TODO: detect "bad statuses" (eg CrashLoopBackoff) and terminate early *)
-          let filtered =
-            List.filter pod_statuses ~f:(fun (_, status) ->
-                not (String.equal status "Running"))
-          in
-          Some filtered
-      | Error _ ->
-          None
-    in
-    match bad_pod_statuses_opt with
-    | Some [] ->
-        return ()
-    | _ ->
-        if n < max_polls then
-          let%bind () =
-            after poll_interval |> Deferred.bind ~f:Malleable_error.return
-          in
-          let () =
-            if Option.is_none bad_pod_statuses_opt then
-              [%log debug] "`kubectl get pods` timed out, polling again"
-          in
-          let () =
-            if Option.is_some bad_pod_statuses_opt then (
-              let rec print_tuples = function
-                | [] ->
-                    ()
-                | (a, b) :: rest ->
-                    [%log debug] "(pod: %s, status: %s) " a b ;
-                    print_tuples rest
-              in
-              let statuses = Option.value_exn bad_pod_statuses_opt in
-              [%log debug] "Got bad pod statuses, polling again" ;
-              print_tuples statuses )
-          in
-          poll (n + 1)
-        else if Option.is_some bad_pod_statuses_opt then (
-          let bad_pod_statuses_json =
-            `List
-              (List.map (Option.value_exn bad_pod_statuses_opt)
-                 ~f:(fun (pod_name, status) ->
-                   `Assoc
-                     [ ("pod_name", `String pod_name)
-                     ; ("status", `String status)
-                     ]))
-          in
+    match%bind Deferred.bind ~f:Malleable_error.return (kube_get_pods ()) with
+    | Ok str ->
+        let pod_statuses = parse_pod_statuses str in
+        let all_pods_are_present =
+          List.for_all (String.Set.elements all_pods) ~f:(fun pod_id ->
+              String.Map.mem pod_statuses pod_id)
+        in
+        let any_pods_are_not_running =
+          List.exists
+            (String.Map.data pod_statuses)
+            ~f:(Fn.compose not is_successful_pod_status)
+        in
+        if not all_pods_are_present then (
           [%log fatal]
-            "Not all pods were assigned to nodes and ready in time: \
-             $bad_pod_statuses"
-            ~metadata:[ ("bad_pod_statuses", bad_pod_statuses_json) ] ;
-          Malleable_error.hard_error_format
-            "Some pods either were not assigned to nodes or did not deploy \
-             properly (errors: %s)"
-            (Yojson.Safe.to_string bad_pod_statuses_json) )
-        else
-          let%bind () = Malleable_error.return () in
-          [%log fatal]
-            "`kubectl get pods` timed out (at least on the latest poll).  This \
-             probably means that not all pods were assigned to nodes and ready \
-             in time" ;
+            "Not all pods were found when querying namespace; this indicates a \
+             deployment error. Refusing to continue. Expected pods: [%s]"
+            (String.Set.elements all_pods |> String.concat ~sep:"; ") ;
           Malleable_error.hard_error_string
-            "`kubectl get pods` timed out (at least on the latest poll).  This \
-             probably means that not all pods were assigned to nodes and ready \
-             in time"
+            "Some pods were not found in namespace." )
+        else if any_pods_are_not_running then (
+          let failed_pod_statuses =
+            List.filter (String.Map.to_alist pod_statuses)
+              ~f:(fun (_, status) -> not (is_successful_pod_status status))
+          in
+          [%log debug] "Got bad pod statuses, polling again ($failed_statuses"
+            ~metadata:
+              [ ( "failed_statuses"
+                , `Assoc
+                    (List.Assoc.map failed_pod_statuses ~f:(fun v -> `String v))
+                )
+              ] ;
+          poll_again () )
+        else return ()
+    | Error _ ->
+        [%log debug] "`kubectl get pods` timed out, polling again" ;
+        poll_again ()
   in
   [%log info] "Waiting for pods to be assigned nodes and become ready" ;
   let res = poll 0 in

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -301,16 +301,19 @@ end
 module Network_manager = struct
   type t =
     { logger : Logger.t
+    ; testnet_name : string
     ; cluster : string
     ; namespace : string
+    ; graphql_enabled : bool
     ; testnet_dir : string
     ; testnet_log_filter : string
     ; constants : Test_config.constants
-    ; seed_nodes : Kubernetes_network.Node.t list
-    ; block_producer_nodes : Kubernetes_network.Node.t list
-    ; snark_coordinator_nodes : Kubernetes_network.Node.t list
-    ; archive_nodes : Kubernetes_network.Node.t list
-    ; nodes_by_app_id : Kubernetes_network.Node.t String.Map.t
+    ; seed_workloads : Kubernetes_network.Workload.t list
+    ; block_producer_workloads : Kubernetes_network.Workload.t list
+    ; snark_coordinator_workloads : Kubernetes_network.Workload.t list
+    ; snark_worker_workloads : Kubernetes_network.Workload.t list
+    ; archive_workloads : Kubernetes_network.Workload.t list
+    ; workloads_by_id : Kubernetes_network.Workload.t String.Map.t
     ; mutable deployed : bool
     ; keypairs : Keypair.t list
     }
@@ -376,65 +379,73 @@ module Network_manager = struct
         |> Terraform.to_string
         |> Out_channel.output_string ch) ;
     let testnet_log_filter = Network_config.testnet_log_filter network_config in
-    let cons_node pod_id mina_container_id mina_archive_container_id
-        network_keypair_opt =
-      { Kubernetes_network.Node.testnet_name =
-          network_config.terraform.testnet_name
-      ; cluster = cluster_id
-      ; namespace = network_config.terraform.testnet_name
-      ; pod_id
-      ; mina_container_id
-      ; mina_archive_container_id
-      ; graphql_enabled = network_config.terraform.deploy_graphql_ingress
-      ; network_keypair = network_keypair_opt
-      }
+    let cons_workload workload_id node_info : Kubernetes_network.Workload.t =
+      { workload_id; node_info }
+    in
+    let cons_node_info ?network_keypair ?(has_archive_container = false)
+        primary_container_id : Kubernetes_network.Node.info =
+      { network_keypair; has_archive_container; primary_container_id }
     in
     (* we currently only deploy 1 seed and coordinator per deploy (will be configurable later) *)
-    let seed_nodes = [ cons_node "seed" "mina" None None ] in
-    let snark_coordinator_name =
-      "snark-coordinator-"
-      ^ String.lowercase
-          (String.sub network_config.terraform.snark_worker_public_key
-             ~pos:
-               ( String.length network_config.terraform.snark_worker_public_key
-               - 6 )
-             ~len:6)
+    let seed_workloads = [ cons_workload "seed" [ cons_node_info "mina" ] ] in
+    let snark_coordinator_id =
+      String.lowercase
+        (String.sub network_config.terraform.snark_worker_public_key
+           ~pos:
+             (String.length network_config.terraform.snark_worker_public_key - 6)
+           ~len:6)
     in
-    let snark_coordinator_nodes =
+    let snark_coordinator_workloads =
       if network_config.terraform.snark_worker_replicas > 0 then
-        [ cons_node snark_coordinator_name "coordinator" None None ]
+        [ cons_workload
+            ("snark-coordinator-" ^ snark_coordinator_id)
+            [ cons_node_info "mina" ]
+        ]
       else []
     in
-    let block_producer_nodes =
+    let snark_worker_workloads =
+      [ cons_workload
+          ("snark-worker-" ^ snark_coordinator_id)
+          (List.init network_config.terraform.snark_worker_replicas
+             ~f:(fun _i -> cons_node_info "worker"))
+      ]
+    in
+    let block_producer_workloads =
       List.map network_config.terraform.block_producer_configs
         ~f:(fun bp_config ->
-          cons_node bp_config.name "mina" None (Some bp_config.keypair))
+          cons_workload bp_config.name
+            [ cons_node_info ~network_keypair:bp_config.keypair "mina" ])
     in
-    let archive_nodes =
+    let archive_workloads =
       List.init network_config.terraform.archive_node_count ~f:(fun i ->
-          cons_node (sprintf "archive-%d" (i + 1)) "mina" (Some "archive") None)
+          cons_workload
+            (sprintf "archive-%d" (i + 1))
+            [ cons_node_info ~has_archive_container:true "mina" ])
     in
-    let nodes_by_app_id =
-      let all_nodes =
-        seed_nodes @ snark_coordinator_nodes @ block_producer_nodes
-        @ archive_nodes
+    let workloads_by_id =
+      let all_workloads =
+        seed_workloads @ snark_coordinator_workloads @ snark_worker_workloads
+        @ block_producer_workloads @ archive_workloads
       in
-      all_nodes
-      |> List.map ~f:(fun node -> (node.pod_id, node))
+      all_workloads
+      |> List.map ~f:(fun w -> (w.workload_id, w))
       |> String.Map.of_alist_exn
     in
     let t =
       { logger
       ; cluster = cluster_id
       ; namespace = network_config.terraform.testnet_name
+      ; testnet_name = network_config.terraform.testnet_name
+      ; graphql_enabled = network_config.terraform.deploy_graphql_ingress
       ; testnet_dir
       ; testnet_log_filter
       ; constants = network_config.constants
-      ; seed_nodes
-      ; block_producer_nodes
-      ; snark_coordinator_nodes
-      ; archive_nodes
-      ; nodes_by_app_id
+      ; seed_workloads
+      ; block_producer_workloads
+      ; snark_coordinator_workloads
+      ; snark_worker_workloads
+      ; archive_workloads
+      ; workloads_by_id
       ; deployed = false
       ; keypairs =
           List.map network_config.keypairs ~f:(fun { keypair; _ } -> keypair)
@@ -446,18 +457,52 @@ module Network_manager = struct
     t
 
   let deploy t =
+    let logger = t.logger in
     if t.deployed then failwith "network already deployed" ;
-    [%log' info t.logger] "Deploying network" ;
-    let%map _ = run_cmd_exn t "terraform" [ "apply"; "-auto-approve" ] in
+    [%log info] "Deploying network" ;
+    let%bind _ = run_cmd_exn t "terraform" [ "apply"; "-auto-approve" ] in
     t.deployed <- true ;
+    let config : Kubernetes_network.config =
+      { testnet_name = t.testnet_name
+      ; cluster = t.cluster
+      ; namespace = t.namespace
+      ; graphql_enabled = t.graphql_enabled
+      }
+    in
+    let%map seeds =
+      Deferred.List.concat_map t.seed_workloads
+        ~f:(Kubernetes_network.Workload.get_nodes ~config)
+    and block_producers =
+      Deferred.List.concat_map t.block_producer_workloads
+        ~f:(Kubernetes_network.Workload.get_nodes ~config)
+    and snark_coordinators =
+      Deferred.List.concat_map t.snark_coordinator_workloads
+        ~f:(Kubernetes_network.Workload.get_nodes ~config)
+    and snark_workers =
+      Deferred.List.concat_map t.snark_worker_workloads
+        ~f:(Kubernetes_network.Workload.get_nodes ~config)
+    and archive_nodes =
+      Deferred.List.concat_map t.archive_workloads
+        ~f:(Kubernetes_network.Workload.get_nodes ~config)
+    in
+    let all_nodes =
+      seeds @ block_producers @ snark_coordinators @ snark_workers
+      @ archive_nodes
+    in
+    let nodes_by_pod_id =
+      all_nodes
+      |> List.map ~f:(fun node -> (node.pod_id, node))
+      |> String.Map.of_alist_exn
+    in
     let result =
       { Kubernetes_network.namespace = t.namespace
       ; constants = t.constants
-      ; seeds = t.seed_nodes
-      ; block_producers = t.block_producer_nodes
-      ; snark_coordinators = t.snark_coordinator_nodes
-      ; archive_nodes = t.archive_nodes
-      ; nodes_by_app_id = t.nodes_by_app_id
+      ; seeds
+      ; block_producers
+      ; snark_coordinators
+      ; snark_workers
+      ; archive_nodes
+      ; nodes_by_pod_id
       ; testnet_log_filter = t.testnet_log_filter
       ; keypairs = t.keypairs
       }
@@ -466,14 +511,13 @@ module Network_manager = struct
       Fn.compose (String.concat ~sep:", ")
         (List.map ~f:Kubernetes_network.Node.id)
     in
-    [%log' info t.logger] "Network deployed" ;
-    [%log' info t.logger] "testnet namespace: %s" t.namespace ;
-    [%log' info t.logger] "snark coordinators: %s"
+    [%log info] "Network deployed" ;
+    [%log info] "testnet namespace: %s" t.namespace ;
+    [%log info] "snark coordinators: %s"
       (nodes_to_string result.snark_coordinators) ;
-    [%log' info t.logger] "block producers: %s"
-      (nodes_to_string result.block_producers) ;
-    [%log' info t.logger] "archive nodes: %s"
-      (nodes_to_string result.archive_nodes) ;
+    [%log info] "snark workers: %s" (nodes_to_string result.snark_workers) ;
+    [%log info] "block producers: %s" (nodes_to_string result.block_producers) ;
+    [%log info] "archive nodes: %s" (nodes_to_string result.archive_nodes) ;
     result
 
   let destroy t =

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -404,11 +404,13 @@ module Network_manager = struct
       else []
     in
     let snark_worker_workloads =
-      [ cons_workload
-          ("snark-worker-" ^ snark_coordinator_id)
-          (List.init network_config.terraform.snark_worker_replicas
-             ~f:(fun _i -> cons_node_info "worker"))
-      ]
+      if network_config.terraform.snark_worker_replicas > 0 then
+        [ cons_workload
+            ("snark-worker-" ^ snark_coordinator_id)
+            (List.init network_config.terraform.snark_worker_replicas
+               ~f:(fun _i -> cons_node_info "worker"))
+        ]
+      else []
     in
     let block_producer_workloads =
       List.map network_config.terraform.block_producer_configs

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -255,12 +255,17 @@ let event_reader { event_reader; _ } = event_reader
 let parse_event_from_log_entry ~logger ~network log_entry =
   let open Or_error.Let_syntax in
   let open Json_parsing in
-  let%bind app_id = find string log_entry [ "labels"; "k8s-pod/app" ] in
+  let%bind pod_id =
+    find string log_entry [ "resource"; "labels"; "pod_name" ]
+  in
   let%bind node =
-    Kubernetes_network.lookup_node_by_app_id network app_id
+    Kubernetes_network.lookup_node_by_pod_id network pod_id
     |> Option.value_map ~f:Or_error.return
          ~default:
-           (Or_error.errorf "failed to find node by pod app id \"%s\"" app_id)
+           (Or_error.errorf
+              "failed to find node by pod id \"%s\"; known pod ids = [%s]"
+              pod_id
+              (Kubernetes_network.all_pod_ids network |> String.concat ~sep:"; "))
   in
   let%bind payload = find json log_entry [ "jsonPayload" ] in
   let%map event =

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -238,6 +238,8 @@ module Dsl = struct
 
     val node_to_initialize : Engine.Network.Node.t -> t
 
+    val nodes_to_initialize : Engine.Network.Node.t list -> t
+
     val blocks_to_be_produced : int -> t
 
     val nodes_to_synchronize : Engine.Network.Node.t list -> t

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -45,12 +45,6 @@ struct
     ; hard_timeout = Option.value hard_timeout ~default:t.hard_timeout
     }
 
-  (* TODO: does this actually work if it's run twice? I think not *)
-  (*
-   * options:
-   *   - assume nodes have not yet initialized by the time we get here
-   *   - associate additional state to see when initialization was last checked
-   *)
   let nodes_to_initialize nodes =
     let open Network_state in
     let check () (state : Network_state.t) =


### PR DESCRIPTION
Integration test framework supports snark workers by design. This functionality wasn't used and well-maintained. This PR brings it up-to-date, read to be used.

Checklist:

- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None