### PR TITLE
Fix `dune utop` in `mina_base` and friends

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
@@ -36,7 +36,7 @@ oracle = { path = "../../proof-systems/oracle" }
 kimchi = { path = "../../proof-systems/kimchi", features = ["ocaml_types"] }
 
 # ocaml-specific
-ocaml = { version = "0.22.2" }
+ocaml = { version = "0.22.2", features = ["no-caml-startup"] }
 ocaml-gen = { path = "../../proof-systems/ocaml/ocaml-gen" }
 
 [profile.release]


### PR DESCRIPTION
This PR fixes `dune utop`, by passing the `no-caml-startup` flag to `ocaml-rs`. This disables the symbol in `ocaml-rs` that previously caused a link error.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them