### PR TITLE
Increase 'short bootstrap' timeout for chain reliability test

### DIFF
--- a/src/app/test_executive/chain_reliability_test.ml
+++ b/src/app/test_executive/chain_reliability_test.ml
@@ -58,6 +58,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          wait_for t
            ( Wait_condition.nodes_to_synchronize [ node_a; node_b; node_c ]
            |> Wait_condition.with_timeouts
+                ~soft_timeout:(Network_time_span.Slots 3)
                 ~hard_timeout:
                   (Network_time_span.Literal
                      (Time.Span.of_ms (15. *. 60. *. 1000.))) ))


### PR DESCRIPTION
This PR increases the 'soft timeout' for the short bootstrap phase of the chain reliability test to 3 slots, up from the default 2 slots.

This test frequently fails due to the soft timeout (anecdotally, it seems to do so far more often than it succeeds), but eventually succeeds with enough retries. However, retrying is manual and wastes both developer time and CI resources. Increasing this timeout should decrease the number of flakes that we see.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them