### PR TITLE
Increase timeout in snapps integration test

### DIFF
--- a/src/app/test_executive/snapps_constructed.ml
+++ b/src/app/test_executive/snapps_constructed.ml
@@ -134,7 +134,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (let%map () =
            wait_for t
            @@ Wait_condition.with_timeouts ~soft_timeout:timeout
-                ~hard_timeout:timeout
            @@ Wait_condition.snapp_to_be_included_in_frontier
                 ~parties:parties_create_account
          in
@@ -162,7 +161,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (let%map () =
            wait_for t
            @@ Wait_condition.with_timeouts ~soft_timeout:timeout
-                ~hard_timeout:timeout
            @@ Wait_condition.snapp_to_be_included_in_frontier
                 ~parties:parties_update_state
          in

--- a/src/app/test_executive/snapps_constructed.ml
+++ b/src/app/test_executive/snapps_constructed.ml
@@ -111,7 +111,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       Transaction_snark.For_tests.update_state ~constraint_constants
         parties_spec
     in
-    let timeout = Network_time_span.Slots 2 in
+    let timeout = Network_time_span.Slots 3 in
     let%bind () =
       section "send a snapp to create a snapp account"
         ( [%log info] "Sending valid snapp" ;


### PR DESCRIPTION
This PR increases the timeouts in the snapps integration test from 2 to 3, to reduce the number of flakes. This is similar to #10286.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
