### PR TITLE
Use ** blob specifier for linguist-vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 # Ignore vendored code when calculating repo code %s
 # libsnark is lots of c++
-automation/* linguist-vendored
+automation/** linguist-vendored
 # PragmataPro requires a license and costs $$, let's protect it with password
 # protected zip file
 frontend/website/static/font/PragmataPro.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This is a redux of #10135; this uses `**` to match recursively in directories. Previously it was only matching at the toplevel directory level with `*`, and thus did not work as intended.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them