### PR TITLE
Load `Side_loaded_verification_key.t` from `Party.t` in snark logic

### DIFF
--- a/src/lib/mina_base/snapp_account.ml
+++ b/src/lib/mina_base/snapp_account.ml
@@ -161,14 +161,18 @@ let digest_vk (t : Side_loaded_verification_key.t) =
     hash ~init:Hash_prefix_states.side_loaded_vk
       (pack_input (Side_loaded_verification_key.to_input t)))
 
+let dummy_vk_hash =
+  Memo.unit (fun () -> digest_vk Side_loaded_verification_key.dummy)
+
 [%%ifdef consensus_mechanism]
 
 module Checked = struct
   type t =
     ( Pickles.Impls.Step.Field.t Snapp_state.V.t
-    , ( Pickles.Side_loaded.Verification_key.Checked.t Lazy.t
-      , Pickles.Impls.Step.Field.t Lazy.t )
-      With_hash.t
+    , ( Boolean.var
+      , (Side_loaded_verification_key.t option, Field.t) With_hash.t
+        Data_as_hash.t )
+      Flagged_option.t
     , Mina_numbers.Snapp_version.Checked.t
     , Pickles.Impls.Step.Field.t
     , Mina_numbers.Global_slot.Checked.t
@@ -194,7 +198,8 @@ module Checked = struct
     |> List.reduce_exn ~f:append
 
   let to_input (t : t) =
-    to_input' { t with verification_key = Lazy.force t.verification_key.hash }
+    to_input'
+      { t with verification_key = Data_as_hash.hash t.verification_key.data }
 
   let digest_vk t =
     Random_oracle.Checked.(
@@ -214,19 +219,13 @@ let typ : (Checked.t, t) Typ.t =
   let open Poly in
   Typ.of_hlistable
     [ Snapp_state.typ Field.typ
-    ; Typ.transport Pickles.Side_loaded.Verification_key.typ
-        ~there:(function
-          | None ->
-              Pickles.Side_loaded.Verification_key.dummy
-          | Some x ->
-              With_hash.data x)
-        ~back:(fun x -> Some (With_hash.of_data x ~hash_data:digest_vk))
-      |> Typ.transport_var
-           ~there:(fun wh -> Lazy.force (With_hash.data wh))
-           ~back:(fun x ->
-             With_hash.of_data
-               (lazy x)
-               ~hash_data:(fun _ -> lazy (Checked.digest_vk x)))
+    ; Flagged_option.option_typ
+        ~default:{ With_hash.data = None; hash = dummy_vk_hash () }
+        (Data_as_hash.typ ~hash:With_hash.hash)
+      |> Typ.transport
+           ~there:(Option.map ~f:(With_hash.map ~f:Option.some))
+           ~back:
+             (Option.map ~f:(With_hash.map ~f:(fun x -> Option.value_exn x)))
     ; Mina_numbers.Snapp_version.typ
     ; Pickles_types.Vector.typ Field.typ Pickles_types.Nat.N5.n
     ; Mina_numbers.Global_slot.typ
@@ -236,9 +235,6 @@ let typ : (Checked.t, t) Typ.t =
     ~value_of_hlist:of_hlist
 
 [%%endif]
-
-let dummy_vk_hash =
-  Memo.unit (fun () -> digest_vk Side_loaded_verification_key.dummy)
 
 let to_input (t : t) =
   let open Random_oracle.Input.Chunked in

--- a/src/lib/mina_base/snapp_basic.ml
+++ b/src/lib/mina_base/snapp_basic.ml
@@ -74,6 +74,13 @@ module Flagged_option = struct
 
   let map ~f { is_some; data } = { is_some; data = f data }
 
+  let if_ ~(if_ : 'b -> then_:'var -> else_:'var -> 'var) b ~then_ ~else_ =
+    { is_some =
+        Run.run_checked
+          (Boolean.if_ b ~then_:then_.is_some ~else_:else_.is_some)
+    ; data = if_ b ~then_:then_.data ~else_:else_.data
+    }
+
   [%%ifdef consensus_mechanism]
 
   let typ t =
@@ -133,6 +140,12 @@ module Set_or_keep = struct
     val typ :
       dummy:'a -> ('a_var, 'a) Typ.t -> ('a_var t, 'a Stable.Latest.t) Typ.t
 
+    val optional_typ :
+         to_option:('new_value -> 'value option)
+      -> of_option:('value option -> 'new_value)
+      -> ('var, 'new_value) Typ.t
+      -> ('var t, 'value Stable.Latest.t) Typ.t
+
     val map : f:('a -> 'b) -> 'a t -> 'b t
 
     val to_input :
@@ -160,6 +173,25 @@ module Set_or_keep = struct
         (Flagged_option.option_typ ~default:dummy t)
         ~there:to_option ~back:of_option
 
+    let optional_typ (type new_value value var) :
+           to_option:(new_value -> value option)
+        -> of_option:(value option -> new_value)
+        -> (var, new_value) Typ.t
+        -> (var t, value Stable.Latest.t) Typ.t =
+     fun ~to_option ~of_option t ->
+      Typ.transport (Flagged_option.typ t)
+        ~there:(function
+          | Set x ->
+              { Flagged_option.is_some = true; data = of_option (Some x) }
+          | Keep ->
+              { Flagged_option.is_some = false; data = of_option None })
+        ~back:(function
+          | { Flagged_option.is_some = true; data = x } ->
+              Set (Option.value_exn (to_option x))
+          | { Flagged_option.is_some = false; data = x } ->
+              assert (Option.is_none (to_option x)) ;
+              Keep)
+
     let to_input (t : _ t) ~f =
       Flagged_option.to_input' t ~f ~field_of_bool:(fun (b : Boolean.var) ->
           (b :> Field.Var.t))
@@ -168,6 +200,8 @@ module Set_or_keep = struct
   end
 
   let typ = Checked.typ
+
+  let optional_typ = Checked.optional_typ
 
   [%%endif]
 

--- a/src/lib/mina_base/snapp_basic.ml
+++ b/src/lib/mina_base/snapp_basic.ml
@@ -74,14 +74,14 @@ module Flagged_option = struct
 
   let map ~f { is_some; data } = { is_some; data = f data }
 
+  [%%ifdef consensus_mechanism]
+
   let if_ ~(if_ : 'b -> then_:'var -> else_:'var -> 'var) b ~then_ ~else_ =
     { is_some =
         Run.run_checked
           (Boolean.if_ b ~then_:then_.is_some ~else_:else_.is_some)
     ; data = if_ b ~then_:then_.data ~else_:else_.data
     }
-
-  [%%ifdef consensus_mechanism]
 
   let typ t =
     Typ.of_hlistable [ Boolean.typ; t ] ~var_to_hlist:to_hlist

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1699,7 +1699,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
 
       type transaction_commitment = Transaction_commitment.t
 
-      let check_authorization ~account:_ ~commitment:_ ~at_party:_ (party : t) =
+      let check_authorization ~commitment:_ ~at_party:_ (party : t) =
         (* The transaction's validity should already have been checked before
            this point.
         *)

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1921,14 +1921,12 @@ module Base = struct
 
           let increment_nonce (t : t) = t.party.data.body.increment_nonce
 
-          let check_authorization ~(account : Account.t) ~commitment
+          let check_authorization ~commitment
               ~at_party:({ hash = at_party; _ } : Parties.t)
               ({ party; control; _ } : t) =
             let proof_verifies =
               match (auth_type, snapp_statement) with
-              | Proof, Some (i, s) ->
-                  Pickles.Side_loaded.in_circuit (side_loaded i)
-                    (Lazy.force account.data.snapp.verification_key.data) ;
+              | Proof, Some (_i, s) ->
                   with_label __LOC__ (fun () ->
                       Snapp_statement.Checked.Assert.equal
                         { transaction = commitment; at_party }


### PR DESCRIPTION
This PR loads the `Side_loaded_verification_key.t` contained in the updates of a `Party.t` for transaction snark logic, and uses it to update the sparse ledger. This is intended as a fix for the recent QANet crash.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them