### PR TITLE
Add log when adding block

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2061,7 +2061,7 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
         | Ok _ ->
             [%log info] "Committing block data for $state_hash"
               ~metadata:
-                [("state_hash", Mina_base.State_hash.to_yojson (hash block))];
+                [ ("state_hash", Mina_base.State_hash.to_yojson (hash block)) ] ;
             Conn.commit () )
       pool
   in

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2062,7 +2062,7 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
             [%log info] "Committing block data for $state_hash"
               ~metadata:
                 [ ("state_hash", Mina_base.State_hash.to_yojson (hash block)) ] ;
-            Conn.commit () )
+            Conn.commit ())
       pool
   in
   retry ~f:add ~logger ~error_str:"add_block_aux" retries

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2023,13 +2023,12 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
   let add () =
     Caqti_async.Pool.use
       (fun (module Conn : CONNECTION) ->
-         let state_hash_json = hash block |> Mina_base.State_hash.to_yojson in
          let%bind res =
           let open Deferred.Result.Let_syntax in
           let%bind () = Conn.start () in
           [%log info] "Attempting to add block data for $state_hash"
             ~metadata:
-              [("state_hash", state_hash_json)] ;
+              [("state_hash", Mina_base.State_hash.to_yojson (hash block))];
           let%bind block_id = add_block (module Conn : CONNECTION) block in
           (* if an existing block has a parent hash that's for the block just added,
              set its parent id
@@ -2062,7 +2061,7 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
         | Ok _ ->
             [%log info] "Committing block data for $state_hash"
               ~metadata:
-                [("state_hash", state_hash_json)] ;
+                [("state_hash", Mina_base.State_hash.to_yojson (hash block))];
             Conn.commit () )
       pool
   in


### PR DESCRIPTION
Add a log in `add_block_aux` when a block is added.

That will help to know how long it takes to add a block, or fail to do so.