### PR TITLE
Ensure that `Currency.{add,sub}_flagged` etc. is consistent in and out of snark

### DIFF
--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -275,7 +275,8 @@ end = struct
     in
     let%bind actual = range_check' t_adjusted in
     let%map () =
-      with_label "range_adjust_flagged" (Field.Checked.Assert.equal actual t_adjusted)
+      with_label "range_adjust_flagged"
+        (Field.Checked.Assert.equal actual t_adjusted)
     in
     (t_adjusted, `Overflow out_of_range)
 

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -195,6 +195,90 @@ end = struct
     let%bind actual = range_check' t in
     Field.Checked.equal actual t
 
+  let modulus_as_field =
+    lazy (Fn.apply_n_times ~n:length_in_bits Field.(mul (of_int 2)) Field.one)
+
+  let double_modulus_as_field =
+    lazy (Field.(mul (of_int 2)) (Lazy.force modulus_as_field))
+
+  let range_adjust_flagged (kind : [ `Add | `Sub | `Add_or_sub ]) t =
+    let%bind adjustment_factor =
+      exists Field.typ
+        ~compute:
+          As_prover.(
+            let%map t = read Field.typ t in
+            match kind with
+            | `Add ->
+                if Int.(Field.compare t (Lazy.force modulus_as_field) < 0) then
+                  (* Within range. *)
+                  Field.zero
+                else
+                  (* Overflowed. We compensate by subtracting [modulus_as_field]. *)
+                  Field.(negate one)
+            | `Sub ->
+                if Int.(Field.compare t (Lazy.force modulus_as_field) < 0) then
+                  (* Within range. *)
+                  Field.zero
+                else
+                  (* Underflowed, but appears as an overflow because of wrapping in
+                     the field (that is, -1 is the largest field element, -2 is the
+                     second largest, etc.). Compensate by adding [modulus_as_field].
+                  *)
+                  Field.one
+            | `Add_or_sub ->
+                (* This case is a little more nuanced: -modulus_as_field < t <
+                   2*modulus_as_field, and we need to detect which 'side of 0' we
+                   are. Thus, we have 3 cases:
+                *)
+                if Int.(Field.compare t (Lazy.force modulus_as_field) < 0) then
+                  (* 1. we are already in the desired range, no adjustment; *)
+                  Field.zero
+                else if
+                  Int.(Field.compare t (Lazy.force double_modulus_as_field) < 0)
+                then
+                  (* 2. we are in the range
+                        [modulus_as_field <= t < 2 * modulus_as_field],
+                        so this was an addition that overflowed, and we should
+                        compensate by subtracting [modulus_as_field];
+                  *)
+                  Field.(negate one)
+                else
+                  (* 3. we are outside of either range, so this must be the
+                        underflow of a subtraction, and we should compensate by
+                        adding [modulus_as_field].
+                  *)
+                  Field.one)
+    in
+    let%bind out_of_range =
+      match kind with
+      | `Add ->
+          (* 0 or -1 => 0 or 1 *)
+          Boolean.of_field (Field.Var.negate adjustment_factor)
+      | `Sub ->
+          (* Already 0 or 1 *)
+          Boolean.of_field adjustment_factor
+      | `Add_or_sub ->
+          (* The return flag [out_of_range] is a boolean represented by either 0
+             when [t] is in range or 1 when [t] is out-of-range.
+             Notice that [out_of_range = adjustment_factor^2] gives us exactly
+             the desired values, and moreover we can ensure that
+             [adjustment_factor] is exactly one of -1, 0 or 1 by checking that
+             [out_of_range] is boolean.
+          *)
+          Field.Checked.mul adjustment_factor adjustment_factor
+          >>= Boolean.of_field
+    in
+    (* [t_adjusted = t + adjustment_factor * modulus_as_field] *)
+    let t_adjusted =
+      let open Field.Var in
+      add t (scale adjustment_factor (Lazy.force modulus_as_field))
+    in
+    let%bind actual = range_check' t_adjusted in
+    let%map () =
+      with_label "range_adjust_flagged" (Field.Checked.Assert.equal actual t_adjusted)
+    in
+    (t_adjusted, `Overflow out_of_range)
+
   let of_field (x : Field.t) : t =
     of_bits (List.take (Field.unpack x) length_in_bits)
 
@@ -526,15 +610,35 @@ end = struct
             ~compute:
               (let open As_prover in
               let%map x = read typ x and y = read typ y in
-              Option.value_map (add x y) ~f:(fun r -> r.sgn) ~default:Sgn.Pos)
+              match add x y with
+              | Some r ->
+                  r.sgn
+              | None -> (
+                  match (x.sgn, y.sgn) with
+                  | Sgn.Neg, Sgn.Neg ->
+                      (* Ensure that we provide a value in the range
+                         [-modulus_as_field < magnitude < 2*modulus_as_field]
+                         for [range_adjust_flagged].
+                      *)
+                      Sgn.Neg
+                  | _ ->
+                      Sgn.Pos ))
         in
-        let%bind res_value = seal (Field.Var.add xv yv) in
+        let value = Field.Var.add xv yv in
         let%bind magnitude =
-          Tick.Field.Checked.mul (sgn :> Field.Var.t) res_value
+          Tick.Field.Checked.mul (sgn :> Field.Var.t) value
         in
-        let%map no_overflow = range_check_flag magnitude in
-        ( { Signed_var.repr = Some { magnitude; sgn }; value = Some res_value }
-        , `Overflow (Boolean.not no_overflow) )
+        let%bind res_magnitude, `Overflow overflow =
+          range_adjust_flagged `Add_or_sub magnitude
+        in
+        (* Recompute the result from [res_magnitude], since it may have been
+           adjusted.
+        *)
+        let%map res_value = Field.Checked.mul (sgn :> Field.Var.t) magnitude in
+        ( { Signed_var.repr = Some { magnitude = res_magnitude; sgn }
+          ; value = Some res_value
+          }
+        , `Overflow overflow )
 
       let add (x : var) (y : var) =
         let%bind xv = value x and yv = value y in
@@ -587,8 +691,9 @@ end = struct
 
     let sub_flagged x y =
       let%bind z = seal (Field.Var.sub x y) in
-      let%map no_underflow = range_check_flag z in
-      (z, `Underflow (Boolean.not no_underflow))
+      let%bind z, `Overflow underflow = range_adjust_flagged `Sub z in
+      let%map z = seal z in
+      (z, `Underflow underflow)
 
     let sub_or_zero x y =
       make_checked (fun () ->
@@ -638,8 +743,9 @@ end = struct
 
     let add_flagged x y =
       let%bind z = seal (Field.Var.add x y) in
-      let%map no_overflow = range_check_flag z in
-      (z, `Overflow (Boolean.not no_overflow))
+      let%bind z, `Overflow overflow = range_adjust_flagged `Add z in
+      let%map z = seal z in
+      (z, `Overflow overflow)
 
     let ( - ) = sub
 
@@ -654,8 +760,9 @@ end = struct
     let add_signed_flagged (t : var) (d : Signed.var) =
       let%bind d = Signed.Checked.to_field_var d in
       let%bind res = seal (Field.Var.add t d) in
-      let%map no_overflow = range_check_flag res in
-      (res, `Overflow (Boolean.not no_overflow))
+      let%bind res, `Overflow overflow = range_adjust_flagged `Add_or_sub res in
+      let%map res = seal res in
+      (res, `Overflow overflow)
 
     let scale (f : Field.Var.t) (t : var) =
       let%bind res = Field.Checked.mul t f in


### PR DESCRIPTION
This PR fixes the inconsistent values returned by the `*_flagged` functions when there is an overflow. In particular, when there is an underflow, the value outside of the snark would wrap around back to `2^64-1`, but the value inside of the snark would wrap around to the smaller value `Field.size-1 % 2^64`.

The code now explicitly adjusts the values before applying the range check, asserting that the adjusted value is in range rather than allowing it to be arbitrarily decided.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them