### PR TITLE
Fixup error/failure handling in Transaction_logic

### DIFF
--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -1896,6 +1896,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       ~(f : user_acc -> _ -> user_acc) ?(fee_excess = Amount.Signed.zero)
       (ledger : L.t) (c : Parties.t) :
       (Transaction_applied.Parties_applied.t * user_acc) Or_error.t =
+    let open Or_error.Let_syntax in
     let original_account_states =
       List.map (Parties.accounts_accessed c) ~f:(fun id ->
           ( id
@@ -1910,15 +1911,11 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         , (l_state : _ Parties_logic.Local_state.t) ) : user_acc Or_error.t =
       if List.is_empty l_state.parties then Ok user_acc
       else
-        match M.step ~constraint_constants { perform } (g_state, l_state) with
-        | exception exn ->
-            Error (Error.of_exn ~backtrace:`Get exn)
-        | ( _global_state
-          , { Parties_logic.Local_state.failure_status = Some failure; _ } ) ->
-            Error
-              (Error.of_string @@ Transaction_status.Failure.to_string failure)
-        | states ->
-            step_all (f user_acc states) states
+        let%bind states =
+          Or_error.try_with (fun () ->
+              M.step ~constraint_constants { perform } (g_state, l_state))
+        in
+        step_all (f user_acc states) states
     in
     let initial_state : Inputs.Global_state.t * _ Parties_logic.Local_state.t =
       ( { protocol_state = state_view; ledger; fee_excess }
@@ -1934,7 +1931,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         } )
     in
     let user_acc = f init initial_state in
-    let start : Inputs.Global_state.t * _ =
+    let%bind (start : Inputs.Global_state.t * _) =
       let parties =
         let p = Party.Fee_payer.to_signed c.fee_payer in
         { Party.authorization = Control.Signature p.authorization
@@ -1943,11 +1940,12 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         }
         :: c.other_parties
       in
-      M.start ~constraint_constants
-        { parties = Inputs.Parties.of_parties_list parties
-        ; memo_hash = Signed_command_memo.hash c.memo
-        }
-        { perform } initial_state
+      Or_error.try_with (fun () ->
+          M.start ~constraint_constants
+            { parties = Inputs.Parties.of_parties_list parties
+            ; memo_hash = Signed_command_memo.hash c.memo
+            }
+            { perform } initial_state)
     in
     let accounts () =
       List.map original_account_states
@@ -1958,7 +1956,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         Error e
     | Ok s ->
         Ok
-          ( { accounts = accounts ()
+          ( { Transaction_applied.Parties_applied.accounts = accounts ()
             ; command =
                 { With_status.data = c
                 ; status =


### PR DESCRIPTION
This PR removes the erroneous failure handling in `Transaction_logic`. This approach corrects the existing behaviour and the extension in #10323.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
