### PR TITLE
Improve error message printing when there is an available failure_status

### DIFF
--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1316,6 +1316,10 @@ module Base = struct
           type t = var
 
           let assert_ = Assert.is_true
+
+          type failure_status = unit
+
+          let assert_with_failure_status b _failure_status = Assert.is_true b
         end
 
         module Controller = struct
@@ -2032,8 +2036,6 @@ module Base = struct
         end
 
         module Local_state = struct
-          type failure_status = unit
-
           type t =
             ( Parties.t
             , Call_stack.t
@@ -2042,7 +2044,7 @@ module Base = struct
             , Ledger.t
             , Bool.t
             , Transaction_commitment.t
-            , failure_status )
+            , Bool.failure_status )
             Parties_logic.Local_state.t
 
           let add_check (t : t) _failure b =


### PR DESCRIPTION
This PR tweaks the handling of fee-payer failures to return a descriptive error string based on the `Transaction_status.Failure.t`, if available. This allows the fix in #10318 and the (unmerged) follow-up fix in #10329 to work correctly while still making information about the failure available.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
