### PR TITLE
Verify permissions changes, updates in snapp test

### DIFF
--- a/src/app/test_executive/snapps_constructed.ml
+++ b/src/app/test_executive/snapps_constructed.ml
@@ -46,6 +46,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       }
     in
     let snapp_keypair = Signature_lib.Keypair.create () in
+    let snapp_account_id =
+      Mina_base.Account_id.create
+        (snapp_keypair.public_key |> Signature_lib.Public_key.compress)
+        Mina_base.Token_id.default
+    in
     let%bind parties_create_account =
       (* construct a Parties.t, similar to snapp_test_transaction create-snapp-account *)
       let open Mina_base in
@@ -74,7 +79,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       @@ Transaction_snark.For_tests.deploy_snapp ~constraint_constants
            parties_spec
     in
-    let%bind.Deferred parties_update_permissions, _vk =
+    let%bind.Deferred parties_update_permissions, permissions_updated =
       (* construct a Parties.t, similar to snapp_test_transaction update-permissions *)
       let open Mina_base in
       let fee = Currency.Fee.of_int 1_000_000 in
@@ -104,16 +109,21 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; new_snapp_account = false
         ; snapp_update =
             { Party.Update.dummy with permissions = Set new_permissions }
-        ; current_auth = Permissions.Auth_required.Proof
+        ; current_auth =
+            (* current set_permissions permission requires Signature *)
+            Permissions.Auth_required.Signature
         ; call_data = Snark_params.Tick.Field.zero
         ; events = []
         ; sequence_events = []
         }
       in
-      Transaction_snark.For_tests.update_state ~constraint_constants
-        parties_spec
+      let%map.Deferred parties, _vk =
+        Transaction_snark.For_tests.update_state ~constraint_constants
+          parties_spec
+      in
+      (parties, new_permissions)
     in
-    let%bind.Deferred parties_update_all, _vk =
+    let%bind.Deferred snapp_update_all, parties_update_all =
       let open Mina_base in
       let fee = Currency.Fee.of_int 1_000_000 in
       let amount = Currency.Amount.zero in
@@ -172,8 +182,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; sequence_events = []
         }
       in
-      Transaction_snark.For_tests.update_state ~constraint_constants
-        parties_spec
+      let%map.Deferred parties_update_all, _vk =
+        Transaction_snark.For_tests.update_state ~constraint_constants
+          parties_spec
+      in
+      (snapp_update, parties_update_all)
     in
     let with_timeout =
       let soft_slots = 3 in
@@ -194,6 +207,36 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           Malleable_error.soft_error_format ~value:() "Error sending snapp: %s"
             err_str
     in
+    let get_account_permissions () =
+      [%log info] "Getting account permissions" ;
+      match%bind.Deferred
+        Network.Node.get_account_permissions ~logger node
+          ~account_id:snapp_account_id
+      with
+      | Ok permissions ->
+          [%log info] "Got account permissions" ;
+          Malleable_error.return permissions
+      | Error err ->
+          let err_str = Error.to_string_mach err in
+          [%log error] "Error getting account permissions"
+            ~metadata:[ ("error", `String err_str) ] ;
+          Malleable_error.hard_error (Error.of_string err_str)
+    in
+    let get_account_update () =
+      [%log info] "Getting account update" ;
+      match%bind.Deferred
+        Network.Node.get_account_update ~logger node
+          ~account_id:snapp_account_id
+      with
+      | Ok update ->
+          [%log info] "Got account update" ;
+          Malleable_error.return update
+      | Error err ->
+          let err_str = Error.to_string_mach err in
+          [%log error] "Error getting account update"
+            ~metadata:[ ("error", `String err_str) ] ;
+          Malleable_error.hard_error (Error.of_string err_str)
+    in
     let wait_for_snapp parties =
       let%map () =
         wait_for t @@ with_timeout
@@ -201,13 +244,89 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       [%log info] "Snapps transaction included in transition frontier"
     in
+    let compatible_updates (ledger_update : Mina_base.Party.Update.t)
+        (requested_update : Mina_base.Party.Update.t) : bool =
+      (* the "update" in the ledger is derived from the account
+
+         if the requested update has `Set` for a field, we
+         should see `Set` for the same value in the ledger update
+
+         if the requested update has `Keep` for a field, any
+         value in the ledger update is acceptable
+
+         for the app state, we apply this principle element-wise
+      *)
+      let open Mina_base.Snapp_basic.Set_or_keep in
+      let compat req_item ledg_item ~equal =
+        match (req_item, ledg_item) with
+        | Keep, _ ->
+            true
+        | Set v1, Set v2 ->
+            equal v1 v2
+        | Set _, Keep ->
+            false
+      in
+      let app_states_compat =
+        let fs_requested =
+          Pickles_types.Vector.Vector_8.to_list requested_update.app_state
+        in
+        let fs_ledger =
+          Pickles_types.Vector.Vector_8.to_list ledger_update.app_state
+        in
+        List.for_all2_exn fs_requested fs_ledger ~f:(fun req ledg ->
+            compat req ledg ~equal:Pickles.Backend.Tick.Field.equal)
+      in
+      let delegates_compat =
+        compat requested_update.delegate ledger_update.delegate
+          ~equal:Signature_lib.Public_key.Compressed.equal
+      in
+      let verification_keys_compat =
+        compat requested_update.verification_key ledger_update.verification_key
+          ~equal:
+            [%equal:
+              ( Pickles.Side_loaded.Verification_key.t
+              , Pickles.Backend.Tick.Field.t )
+              With_hash.t]
+      in
+      let permissions_compat =
+        compat requested_update.permissions ledger_update.permissions
+          ~equal:Mina_base.Permissions.equal
+      in
+      let snapp_uris_compat =
+        compat requested_update.snapp_uri ledger_update.snapp_uri
+          ~equal:String.equal
+      in
+      let token_symbols_compat =
+        compat requested_update.token_symbol ledger_update.token_symbol
+          ~equal:String.equal
+      in
+      let timings_compat =
+        compat requested_update.timing ledger_update.timing
+          ~equal:Mina_base.Party.Update.Timing_info.equal
+      in
+      let voting_fors_compat =
+        compat requested_update.voting_for ledger_update.voting_for
+          ~equal:Mina_base.State_hash.equal
+      in
+      List.for_all
+        [ app_states_compat
+        ; delegates_compat
+        ; verification_keys_compat
+        ; permissions_compat
+        ; snapp_uris_compat
+        ; token_symbols_compat
+        ; timings_compat
+        ; voting_fors_compat
+        ]
+        ~f:Fn.id
+    in
     let%bind () =
       section "send a snapp to create a snapp account"
         (send_snapp parties_create_account)
     in
     let%bind () =
       section
-        "wait for snapp to create account to be included in transition frontier"
+        "Wait for snapp to create account to be included in transition frontier"
         (wait_for_snapp parties_create_account)
     in
     let%bind () =
@@ -216,19 +335,56 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section
-        "wait for snapp to update permissions to be included in transition \
+        "Wait for snapp to update permissions to be included in transition \
          frontier"
         (wait_for_snapp parties_update_permissions)
     in
     let%bind () =
-      section "send a snapp to update all fields"
+      section "Verify that updated permissions are in ledger account"
+        (let%bind ledger_permissions = get_account_permissions () in
+         if Mina_base.Permissions.equal ledger_permissions permissions_updated
+         then (
+           [%log info] "Ledger, updated permissions are equal" ;
+           return () )
+         else (
+           [%log error] "Ledger, updated permissions differ"
+             ~metadata:
+               [ ( "ledger_permissions"
+                 , Mina_base.Permissions.to_yojson ledger_permissions )
+               ; ( "updated_permissions"
+                 , Mina_base.Permissions.to_yojson permissions_updated )
+               ] ;
+           Malleable_error.hard_error
+             (Error.of_string
+                "Ledger permissions do not match update permissions") ))
+    in
+    let%bind () =
+      section "Send a snapp to update all fields"
         (send_snapp parties_update_all)
     in
     let%bind () =
       section
-        "wait for snapp to update all fields to be included in transition \
+        "Wait for snapp to update all fields to be included in transition \
          frontier"
         (wait_for_snapp parties_update_all)
+    in
+    let%bind () =
+      section "Verify snapp updates in ledger"
+        (let%bind ledger_update = get_account_update () in
+         if compatible_updates ledger_update snapp_update_all then (
+           [%log info] "Ledger update and requested update are compatible" ;
+           return () )
+         else (
+           [%log error] "Ledger update and requested update are incompatible"
+             ~metadata:
+               [ ( "ledger_update"
+                 , Mina_base.Party.Update.to_yojson ledger_update )
+               ; ( "requested_update"
+                 , Mina_base.Party.Update.to_yojson snapp_update_all )
+               ] ;
+           Malleable_error.hard_error
+             (Error.of_string
+                "Ledger update and requested update are incompatible") ))
     in
     return ()
 end

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -189,6 +189,49 @@ module Node = struct
         }
       }
     |}]
+
+    module Account =
+    [%graphql
+    {|
+      query ($public_key: PublicKey, $token: UInt64) {
+        account (publicKey : $public_key, token : $token) {
+          balance { liquid
+                    locked
+                    total
+                  }
+          delegate
+          nonce
+          permissions { editSequenceState
+                        editState
+                        incrementNonce
+                        receive
+                        send
+                        setDelegate
+                        setPermissions
+                        setSnappUri
+                        setTokenSymbol
+                        setVerificationKey
+                        setVotingFor
+                        stake
+                      }
+          sequenceEvents
+          snappState
+          snappUri
+          timing { cliffTime
+                   cliffAmount
+                   vestingPeriod
+                   vestingIncrement
+                   initialMinimumBalance
+                 }
+          token
+          tokenSymbol
+          verificationKey { verificationKey
+                            hash
+                          }
+          votingFor
+        }
+      }
+    |}]
   end
 
   (* this function will repeatedly attempt to connect to graphql port <num_tries> times before giving up *)
@@ -313,6 +356,236 @@ module Node = struct
   let must_get_balance ~logger t ~account_id =
     get_balance ~logger t ~account_id
     |> Deferred.bind ~f:Malleable_error.or_hard_error
+
+  let get_account ~logger t ~account_id =
+    [%log info] "Getting account"
+      ~metadata:
+        ( ("account_id", Mina_base.Account_id.to_yojson account_id)
+        :: logger_metadata t ) ;
+    let pk = Mina_base.Account_id.public_key account_id in
+    let token = Mina_base.Account_id.token_id account_id in
+    let get_account_obj =
+      Graphql.Account.make
+        ~public_key:(Graphql_lib.Encoders.public_key pk)
+        ~token:(Graphql_lib.Encoders.token token)
+        ()
+    in
+    exec_graphql_request ~logger ~node:t ~query_name:"get_account_graphql"
+      get_account_obj
+
+  let permissions_of_account_permissions account_permissions :
+      Mina_base.Permissions.t =
+    (* the polymorphic variants come from Partial_accounts.auth_required in Mina_graphql *)
+    let to_auth_required = function
+      | `Either ->
+          Mina_base.Permissions.Auth_required.Either
+      | `Impossible ->
+          Impossible
+      | `None ->
+          None
+      | `Proof ->
+          Proof
+      | `Signature ->
+          Signature
+    in
+    { stake = account_permissions#stake
+    ; edit_sequence_state =
+        to_auth_required account_permissions#editSequenceState
+    ; edit_state = to_auth_required account_permissions#editState
+    ; increment_nonce = to_auth_required account_permissions#incrementNonce
+    ; receive = to_auth_required account_permissions#receive
+    ; send = to_auth_required account_permissions#send
+    ; set_delegate = to_auth_required account_permissions#setDelegate
+    ; set_permissions = to_auth_required account_permissions#setPermissions
+    ; set_snapp_uri = to_auth_required account_permissions#setSnappUri
+    ; set_token_symbol = to_auth_required account_permissions#setTokenSymbol
+    ; set_verification_key =
+        to_auth_required account_permissions#setVerificationKey
+    ; set_voting_for = to_auth_required account_permissions#setVotingFor
+    }
+
+  let get_account_permissions ~logger t ~account_id =
+    let open Deferred.Or_error in
+    let open Let_syntax in
+    let%bind account_obj = get_account ~logger t ~account_id in
+    match account_obj#account with
+    | Some account -> (
+        match account#permissions with
+        | Some ledger_permissions ->
+            return @@ permissions_of_account_permissions ledger_permissions
+        | None ->
+            fail
+              (Error.of_string "Could not get permissions from ledger account")
+        )
+    | None ->
+        fail (Error.of_string "Could not get account from ledger")
+
+  (* return a Party.Update.t with all fields `Set` to the
+     value in the account, or `Keep` if value unavailable,
+     as if this update had been applied to the account
+  *)
+  let get_account_update ~logger t ~account_id =
+    let open Deferred.Or_error in
+    let open Let_syntax in
+    let%bind account_obj = get_account ~logger t ~account_id in
+    match account_obj#account with
+    | Some account ->
+        let open Mina_base.Snapp_basic.Set_or_keep in
+        let%bind app_state =
+          match account#snappState with
+          | Some strs ->
+              let fields =
+                Array.to_list strs
+                |> Base.List.map ~f:(fun s ->
+                       Set (Pickles.Backend.Tick.Field.of_string s))
+              in
+              return (Mina_base.Snapp_state.V.of_list_exn fields)
+          | None ->
+              fail (Error.of_string "Expected snapp account with an app state")
+        in
+        let%bind delegate =
+          match account#delegate with
+          | Some (`String s) ->
+              return
+                (Set (Signature_lib.Public_key.Compressed.of_base58_check_exn s))
+          | Some json ->
+              fail
+                (Error.of_string
+                   (sprintf "Expected string encoding of delegate, got %s"
+                      (Yojson.Basic.to_string json)))
+          | None ->
+              fail (Error.of_string "Expected delegate in account")
+        in
+        let%bind verification_key =
+          match account#verificationKey with
+          | Some vk_obj ->
+              let data =
+                Pickles.Side_loaded.Verification_key.of_base58_check_exn
+                  vk_obj#verificationKey
+              in
+              let hash = Pickles.Backend.Tick.Field.of_string vk_obj#hash in
+              return (Set ({ data; hash } : _ With_hash.t))
+          | None ->
+              fail
+                (Error.of_string "Expected verification key in snapp account")
+        in
+        let%bind permissions =
+          match account#permissions with
+          | Some perms ->
+              return @@ Set (permissions_of_account_permissions perms)
+          | None ->
+              fail (Error.of_string "Expected permissions in account")
+        in
+        let%bind snapp_uri =
+          match account#snappUri with
+          | Some s ->
+              return @@ Set s
+          | None ->
+              fail (Error.of_string "Expected snapp URI in account")
+        in
+        let%bind token_symbol =
+          match account#tokenSymbol with
+          | Some s ->
+              return @@ Set s
+          | None ->
+              fail (Error.of_string "Expected token symbol in account")
+        in
+        let%bind timing =
+          let timing = account#timing in
+          let cliff_amount = timing#cliffAmount in
+          let cliff_time = timing#cliffTime in
+          let vesting_period = timing#vestingPeriod in
+          let vesting_increment = timing#vestingIncrement in
+          let initial_minimum_balance = timing#initialMinimumBalance in
+          match
+            ( cliff_amount
+            , cliff_time
+            , vesting_period
+            , vesting_increment
+            , initial_minimum_balance )
+          with
+          | None, None, None, None, None ->
+              return @@ Keep
+          | Some amt, Some tm, Some period, Some incr, Some bal ->
+              let%bind cliff_amount =
+                match amt with
+                | `String s ->
+                    return @@ Currency.Amount.of_string s
+                | _ ->
+                    fail
+                      (Error.of_string
+                         "Expected string for cliff amount in account timing")
+              in
+              let%bind cliff_time =
+                match tm with
+                | `String s ->
+                    return @@ Mina_numbers.Global_slot.of_string s
+                | _ ->
+                    fail
+                      (Error.of_string
+                         "Expected string for cliff time in account timing")
+              in
+              let%bind vesting_period =
+                match period with
+                | `String s ->
+                    return @@ Mina_numbers.Global_slot.of_string s
+                | _ ->
+                    fail
+                      (Error.of_string
+                         "Expected string for vesting period in account timing")
+              in
+              let%bind vesting_increment =
+                match incr with
+                | `String s ->
+                    return @@ Currency.Amount.of_string s
+                | _ ->
+                    fail
+                      (Error.of_string
+                         "Expected string for vesting increment in account \
+                          timing")
+              in
+              let%bind initial_minimum_balance =
+                match bal with
+                | `String s ->
+                    return @@ Currency.Balance.of_string s
+                | _ ->
+                    fail
+                      (Error.of_string
+                         "Expected string for vesting increment in account \
+                          timing")
+              in
+              return
+                (Set
+                   ( { initial_minimum_balance
+                     ; cliff_amount
+                     ; cliff_time
+                     ; vesting_period
+                     ; vesting_increment
+                     }
+                     : Mina_base.Party.Update.Timing_info.t ))
+          | _ ->
+              fail (Error.of_string "Some pieces of account timing are missing")
+        in
+        let%bind voting_for =
+          match account#votingFor with
+          | Some s ->
+              return @@ Set (Mina_base.State_hash.of_base58_check_exn s)
+          | None ->
+              fail (Error.of_string "Expected voting-for state hash in account")
+        in
+        return
+          ( { app_state
+            ; delegate
+            ; verification_key
+            ; permissions
+            ; snapp_uri
+            ; token_symbol
+            ; timing
+            ; voting_for
+            }
+            : Mina_base.Party.Update.t )
+    | None ->
+        fail (Error.of_string "Could not get account from ledger")
 
   (* if we expect failure, might want retry_on_graphql_error to be false *)
   let send_payment ~logger t ~sender_pub_key ~receiver_pub_key ~amount ~fee =

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -68,13 +68,28 @@ module Engine = struct
            logger:Logger.t
         -> t
         -> account_id:Mina_base.Account_id.t
-        -> Currency.Balance.t Async_kernel.Deferred.Or_error.t
+        -> Currency.Balance.t Deferred.Or_error.t
 
       val must_get_balance :
            logger:Logger.t
         -> t
         -> account_id:Mina_base.Account_id.t
         -> Currency.Balance.t Malleable_error.t
+
+      val get_account_permissions :
+           logger:Logger.t
+        -> t
+        -> account_id:Mina_base.Account_id.t
+        -> Mina_base.Permissions.t Deferred.Or_error.t
+
+      (** the returned Update.t is constructed from the fields of the
+          given account, as if it had been applied to the account
+      *)
+      val get_account_update :
+           logger:Logger.t
+        -> t
+        -> account_id:Mina_base.Account_id.t
+        -> Mina_base.Party.Update.t Deferred.Or_error.t
 
       val get_peer_id :
            logger:Logger.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -8470,7 +8470,7 @@ let%test_module "transaction_undos" =
         List.map (List.zip_exn source_accounts new_keys)
           ~f:(fun ((s, _, nonce, _), r) ->
             let sender_pk = Public_key.compress s.public_key in
-            let reciever_pk = Public_key.compress r.public_key in
+            let receiver_pk = Public_key.compress r.public_key in
             let fee = Currency.Fee.of_int 10 in
             let payload : Signed_command.Payload.t =
               Signed_command.Payload.create ~fee ~fee_token:Token_id.default
@@ -8479,7 +8479,7 @@ let%test_module "transaction_undos" =
                 ~body:
                   (Payment
                      { source_pk = sender_pk
-                     ; receiver_pk = reciever_pk
+                     ; receiver_pk
                      ; token_id = Token_id.default
                      ; amount
                      })


### PR DESCRIPTION
For the "snapps-constructed" integration test, add steps to verify that

- the changed permissions have taken effect
- the other field updates are visible 

For the permissions, we check that the new permissions equal the requested permissions.

For the other updates, we construct a `Party.Update.t` from the ledger account, as if that update had been applied. We compare that against the update that was applied. For any field where the requested update had `Keep`, we allow any value in the constructed update. (We could do more checking by verifying that such a value is the same as before the applied update, but that's less of a concern.) For any field where the requested update has `Set`, we require the same value in the constructed update.

Part of #10067.