### PR TITLE
Build client SDK without nonconsensus flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ build_intgtest: ocaml_checks
 
 client_sdk: ocaml_checks
 	$(info Starting Build)
-	ulimit -s 65532 && (ulimit -n 10240 || true) && dune build src/app/client_sdk/client_sdk.bc.js --profile=nonconsensus_mainnet
+	ulimit -s 65532 && (ulimit -n 10240 || true) && dune build src/app/client_sdk/client_sdk.bc.js
 	$(info Build complete)
 
 client_sdk_test_sigs: ocaml_checks

--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -4,7 +4,7 @@
 
 open Js_of_ocaml
 open Signature_lib
-open Mina_base_kernel
+open Mina_base
 open Rosetta_lib
 open Rosetta_coding
 open Js_util

--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -2,15 +2,9 @@
 
 [%%import "/src/config.mlh"]
 
-[%%ifdef consensus_mechanism]
-
-[%%error "Client SDK cannot be built if \"consensus_mechanism\" is defined"]
-
-[%%endif]
-
 open Js_of_ocaml
 open Signature_lib
-open Mina_base
+open Mina_base_kernel
 open Rosetta_lib
 open Rosetta_coding
 open Js_util

--- a/src/app/client_sdk/dune
+++ b/src/app/client_sdk/dune
@@ -7,7 +7,7 @@
   core_kernel
   snark_params
   rosetta_lib
-  mina_base_kernel
+  mina_base
   mina_numbers
   data_hash_lib
   random_oracle

--- a/src/app/client_sdk/dune
+++ b/src/app/client_sdk/dune
@@ -5,20 +5,21 @@
   (flags +toplevel.js +dynlink.js))
  (libraries
   core_kernel
-  snark_params_nonconsensus
-  rosetta_lib_nonconsensus
-  mina_base_nonconsensus
-  data_hash_lib_nonconsensus
-  random_oracle_nonconsensus
-  signature_lib_nonconsensus
-  string_sign_nonconsensus
+  snark_params
+  rosetta_lib
+  mina_base_kernel
+  mina_numbers
+  data_hash_lib
+  random_oracle
+  signature_lib
+  string_sign
   zarith_stubs_js
   integers
   integers_stubs_js
   js_of_ocaml
   digestif.ocaml
   sponge
-  hex_nonconsensus)
+  hex)
  (preprocessor_deps ../../config.mlh)
  (instrumentation
   (backend bisect_ppx))

--- a/src/app/client_sdk/js_util.ml
+++ b/src/app/client_sdk/js_util.ml
@@ -2,7 +2,7 @@
 
 open Js_of_ocaml
 open Snark_params.Tick
-open Mina_base
+open Mina_base_kernel
 module Global_slot = Mina_numbers.Global_slot
 module Memo = Signed_command_memo
 

--- a/src/app/client_sdk/js_util.ml
+++ b/src/app/client_sdk/js_util.ml
@@ -2,7 +2,7 @@
 
 open Js_of_ocaml
 open Snark_params.Tick
-open Mina_base_kernel
+open Mina_base
 module Global_slot = Mina_numbers.Global_slot
 module Memo = Signed_command_memo
 

--- a/src/app/client_sdk/poseidon_hash.ml
+++ b/src/app/client_sdk/poseidon_hash.ml
@@ -10,17 +10,17 @@ module Field = struct
 
   (* Converts a byterray into a [Field.t], raises an exception if the number obtained is larger than the order *)
   let of_bytes bytearray =
+    let module N = Bignum_bigint in
     let aux i acc c =
-      let big = Nat.of_int @@ int_of_char c in
-      let offset = Nat.shift_left big (Int.( * ) i 8) in
-      Nat.(acc + offset)
+      let big = N.of_int @@ int_of_char c in
+      let offset = N.shift_left big (Int.( * ) i 8) in
+      N.(acc + offset)
     in
-    let zero = Nat.of_int 0 in
+    let zero = N.of_int 0 in
     let big = Array.foldi bytearray ~init:zero ~f:aux in
-    let one = Nat.of_int 1 in
-    if Nat.(order - one < big) then
+    if N.(size - one < big) then
       failwith "the given field is larger than the order" ;
-    of_bigint big
+    Snark_params.Tick.Bigint.(to_field (of_bignum_bigint big))
 
   (* Converts a field element into an hexadecimal string (encoding the field element in little-endian) *)
   let to_hex field =
@@ -36,7 +36,7 @@ module Field = struct
         ~f:byte_of_bits
       |> String.of_char_list
     in
-    let bytearray = to_bits field |> bits_to_bytes in
+    let bytearray = unpack field |> bits_to_bytes in
     Hex.encode bytearray
 end
 

--- a/src/lib/crypto/kimchi_bindings/dune
+++ b/src/lib/crypto/kimchi_bindings/dune
@@ -1,0 +1,2 @@
+(data_only_dirs wasm)
+

--- a/src/lib/crypto/kimchi_bindings/js/README.md
+++ b/src/lib/crypto/kimchi_bindings/js/README.md
@@ -1,0 +1,24 @@
+This library provides a wrapper around the WebAssembly prover code, which
+allows `js_of_ocaml` to compile the mina project against the WebAssembly
+backend.
+
+The different versions of the backend are generated in subdirectories; e.g. the
+NodeJS backend is generated in `node_js/` and the Chrome backend is generated
+in `chrome/`. To use a backend, run `dune build backend/plonk_wasm.js` and copy
+`backend/plonk_wasm*` to the project directory.
+
+Note that the backend code is not automatically compiled while linking against
+the backend library. You should always manually issue a build command for the
+`plonk_wasm.js` for the desired backend to ensure that it has been generated.
+For example, to run the nodejs tests in the `test/nodejs` directory you will
+need to run
+```
+dune build src/lib/marlin_plonk_bindings/js/test/nodejs/nodejs_test.bc.js
+src/lib/marlin_plonk_bindings/js/test/nodejs/copy_over.sh
+```
+Similarly, to run the chrome tests in `test/chrome`, you can run
+```
+dune build src/lib/marlin_plonk_bindings/js/test/chrome/chrome_test.bc.js
+src/lib/marlin_plonk_bindings/js/test/chrome/copy_over.sh
+```
+and then visit `http://localhost:8000` from a Chrome browser.

--- a/src/lib/crypto/kimchi_bindings/js/bindings.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings.js
@@ -1175,6 +1175,13 @@ var caml_pasta_fp_plonk_gate_vector_wrap = function(v, x, y) {
     return plonk_wasm.caml_pasta_fp_plonk_gate_vector_wrap(v, caml_plonk_wire_to_rust(x), caml_plonk_wire_to_rust(y));
 };
 
+// Provides: caml_pasta_fp_plonk_gate_vector_digest
+// Requires: plonk_wasm, caml_bytes_of_uint8array
+var caml_pasta_fp_plonk_gate_vector_digest = function(gate_vector) {
+    var uint8array = plonk_wasm.caml_pasta_fp_plonk_gate_vector_digest(gate_vector);
+    return caml_bytes_of_uint8array(uint8array);
+}
+
 
 
 
@@ -1203,6 +1210,12 @@ var caml_pasta_fq_plonk_gate_vector_wrap = function(v, x, y) {
     return plonk_wasm.caml_pasta_fq_plonk_gate_vector_wrap(v, caml_plonk_wire_to_rust(x), caml_plonk_wire_to_rust(y));
 };
 
+// Provides: caml_pasta_fq_plonk_gate_vector_digest
+// Requires: plonk_wasm, caml_bytes_of_uint8array
+var caml_pasta_fq_plonk_gate_vector_digest = function(gate_vector) {
+    var uint8array = plonk_wasm.caml_pasta_fq_plonk_gate_vector_digest(gate_vector);
+    return caml_bytes_of_uint8array(uint8array);
+}
 
 
 

--- a/src/lib/crypto/kimchi_bindings/js/bindings.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings.js
@@ -1,0 +1,2257 @@
+/* global joo_global_object, plonk_wasm, caml_js_to_bool, caml_jsstring_of_string,
+    caml_string_of_jsstring
+    caml_create_bytes, caml_bytes_unsafe_set, caml_bytes_unsafe_get, caml_ml_bytes_length
+*/
+
+// Provides: caml_bytes_of_uint8array
+// Requires: caml_create_bytes, caml_bytes_unsafe_set
+var caml_bytes_of_uint8array = function(uint8array) {
+    var length = uint8array.length;
+    var ocaml_bytes = caml_create_bytes(length);
+    for (var i = 0; i < length; i++) {
+        // No need to convert here: OCaml Char.t is just an int under the hood.
+        caml_bytes_unsafe_set(ocaml_bytes, i, uint8array[i]);
+    }
+    return ocaml_bytes;
+};
+
+// Provides: caml_bytes_to_uint8array
+// Requires: caml_ml_bytes_length, caml_bytes_unsafe_get
+var caml_bytes_to_uint8array = function(ocaml_bytes) {
+    var length = caml_ml_bytes_length(ocaml_bytes);
+    var bytes = new joo_global_object.Uint8Array(length);
+    for (var i = 0; i < length; i++) {
+        // No need to convert here: OCaml Char.t is just an int under the hood.
+        bytes[i] = caml_bytes_unsafe_get(ocaml_bytes, i);
+    }
+    return bytes;
+};
+
+// Provides: caml_bigint_256_of_numeral
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_bigint_256_of_numeral = function (s, len, base) {
+    return plonk_wasm.caml_bigint_256_of_numeral(caml_jsstring_of_string(s), len, base);
+};
+
+// Provides: caml_bigint_256_of_decimal_string
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_bigint_256_of_decimal_string = function (s) {
+    return plonk_wasm.caml_bigint_256_of_decimal_string(caml_jsstring_of_string(s));
+};
+
+// Provides: caml_bigint_256_num_limbs
+// Requires: plonk_wasm
+var caml_bigint_256_num_limbs = plonk_wasm.caml_bigint_256_num_limbs
+
+// Provides: caml_bigint_256_bytes_per_limb
+// Requires: plonk_wasm
+var caml_bigint_256_bytes_per_limb = plonk_wasm.caml_bigint_256_bytes_per_limb
+
+// Provides: caml_bigint_256_div
+// Requires: plonk_wasm
+var caml_bigint_256_div = plonk_wasm.caml_bigint_256_div
+
+// Provides: caml_bigint_256_compare
+// Requires: plonk_wasm
+var caml_bigint_256_compare = plonk_wasm.caml_bigint_256_compare
+
+// Provides: caml_bigint_256_print
+// Requires: plonk_wasm
+var caml_bigint_256_print = plonk_wasm.caml_bigint_256_print
+
+// Provides: caml_bigint_256_to_string
+// Requires: plonk_wasm, caml_string_of_jsstring
+var caml_bigint_256_to_string = function(x) {
+    return caml_string_of_jsstring(plonk_wasm.caml_bigint_256_to_string(x));
+};
+
+// Provides: caml_bigint_256_test_bit
+// Requires: plonk_wasm, caml_js_to_bool
+var caml_bigint_256_test_bit = function(x, i) {
+    return caml_js_to_bool(plonk_wasm.caml_bigint_256_test_bit(x, i));
+};
+
+// Provides: caml_bigint_256_to_bytes
+// Requires: plonk_wasm, caml_bytes_of_uint8array
+var caml_bigint_256_to_bytes = function(x) {
+    return caml_bytes_of_uint8array(plonk_wasm.caml_bigint_256_to_bytes(x));
+};
+
+// Provides: caml_bigint_256_of_bytes
+// Requires: plonk_wasm, caml_bytes_to_uint8array
+var caml_bigint_256_of_bytes = function(ocaml_bytes) {
+    return plonk_wasm.caml_bigint_256_of_bytes(caml_bytes_to_uint8array(ocaml_bytes));
+};
+
+// Provides: caml_bigint_256_deep_copy
+// Requires: plonk_wasm
+var caml_bigint_256_deep_copy = plonk_wasm.caml_bigint_256_deep_copy
+
+
+
+
+
+// Provides: caml_pasta_fp_copy
+var caml_pasta_fp_copy = function(x, y) {
+    for (var i = 0, l = x.length; i < l; i++) {
+        x[i] = y[i];
+    }
+};
+
+// Provides: caml_pasta_fp_option
+var caml_pasta_fp_option = function(x) {
+    // We encode 'none' in WASM as a biginteger formed from a series of
+    // max-size u64s, which gets split into u8s. This value is never returned
+    // as a valid field element, since it is larger than the field's modulus.
+    for (var i = 0, l = x.length; i < l; i++) {
+        if (x[i] != 255) {
+            return [0, x]; // Some(x)
+        }
+    }
+    return 0;
+};
+
+// Provides: caml_pasta_fp_size_in_bits
+// Requires: plonk_wasm
+var caml_pasta_fp_size_in_bits = plonk_wasm.caml_pasta_fp_size_in_bits
+
+// Provides: caml_pasta_fp_size
+// Requires: plonk_wasm
+var caml_pasta_fp_size = plonk_wasm.caml_pasta_fp_size
+
+// Provides: caml_pasta_fp_add
+// Requires: plonk_wasm
+var caml_pasta_fp_add = plonk_wasm.caml_pasta_fp_add
+
+// Provides: caml_pasta_fp_sub
+// Requires: plonk_wasm
+var caml_pasta_fp_sub = plonk_wasm.caml_pasta_fp_sub
+
+// Provides: caml_pasta_fp_negate
+// Requires: plonk_wasm
+var caml_pasta_fp_negate = plonk_wasm.caml_pasta_fp_negate
+
+// Provides: caml_pasta_fp_mul
+// Requires: plonk_wasm
+var caml_pasta_fp_mul = plonk_wasm.caml_pasta_fp_mul
+
+// Provides: caml_pasta_fp_div
+// Requires: plonk_wasm
+var caml_pasta_fp_div = plonk_wasm.caml_pasta_fp_div
+
+// Provides: caml_pasta_fp_inv
+// Requires: plonk_wasm, caml_pasta_fp_option
+var caml_pasta_fp_inv = function(x) {
+    return caml_pasta_fp_option(plonk_wasm.caml_pasta_fp_inv(x));
+};
+
+// Provides: caml_pasta_fp_square
+// Requires: plonk_wasm
+var caml_pasta_fp_square = plonk_wasm.caml_pasta_fp_square
+
+// Provides: caml_pasta_fp_is_square
+// Requires: plonk_wasm, caml_js_to_bool
+var caml_pasta_fp_is_square = function(x) {
+    return caml_js_to_bool(plonk_wasm.caml_pasta_fp_is_square(x));
+};
+
+// Provides: caml_pasta_fp_sqrt
+// Requires: plonk_wasm, caml_pasta_fp_option
+var caml_pasta_fp_sqrt = function(x) {
+    return caml_pasta_fp_option(plonk_wasm.caml_pasta_fp_sqrt(x));
+};
+
+// Provides: caml_pasta_fp_of_int
+// Requires: plonk_wasm
+var caml_pasta_fp_of_int = plonk_wasm.caml_pasta_fp_of_int
+
+// Provides: caml_pasta_fp_to_string
+// Requires: plonk_wasm, caml_string_of_jsstring
+var caml_pasta_fp_to_string = function(x) {
+    return caml_string_of_jsstring(plonk_wasm.caml_pasta_fp_to_string(x));
+};
+
+// Provides: caml_pasta_fp_of_string
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_pasta_fp_of_string = function (x) {
+    return plonk_wasm.caml_pasta_fp_of_string(caml_jsstring_of_string(x));
+};
+
+// Provides: caml_pasta_fp_print
+// Requires: plonk_wasm
+var caml_pasta_fp_print = plonk_wasm.caml_pasta_fp_print
+
+// Provides: caml_pasta_fp_mut_add
+// Requires: caml_pasta_fp_copy, caml_pasta_fp_add
+var caml_pasta_fp_mut_add = function(x, y) {
+    caml_pasta_fp_copy(x, caml_pasta_fp_add(x, y));
+};
+
+// Provides: caml_pasta_fp_mut_sub
+// Requires: caml_pasta_fp_copy, caml_pasta_fp_sub
+var caml_pasta_fp_mut_sub = function(x, y) {
+    caml_pasta_fp_copy(x, caml_pasta_fp_sub(x, y));
+};
+
+// Provides: caml_pasta_fp_mut_mul
+// Requires: caml_pasta_fp_copy, caml_pasta_fp_mul
+var caml_pasta_fp_mut_mul = function(x, y) {
+    caml_pasta_fp_copy(x, caml_pasta_fp_mul(x, y));
+};
+
+// Provides: caml_pasta_fp_mut_square
+// Requires: caml_pasta_fp_copy, caml_pasta_fp_square
+var caml_pasta_fp_mut_square = function(x) {
+    caml_pasta_fp_copy(x, caml_pasta_fp_square(x));
+};
+
+// Provides: caml_pasta_fp_compare
+// Requires: plonk_wasm
+var caml_pasta_fp_compare = plonk_wasm.caml_pasta_fp_compare
+
+// Provides: caml_pasta_fp_equal
+// Requires: plonk_wasm
+var caml_pasta_fp_equal = plonk_wasm.caml_pasta_fp_equal
+
+// Provides: caml_pasta_fp_random
+// Requires: plonk_wasm
+var caml_pasta_fp_random = plonk_wasm.caml_pasta_fp_random
+
+// Provides: caml_pasta_fp_rng
+// Requires: plonk_wasm
+var caml_pasta_fp_rng = plonk_wasm.caml_pasta_fp_rng
+
+// Provides: caml_pasta_fp_to_bigint
+// Requires: plonk_wasm
+var caml_pasta_fp_to_bigint = plonk_wasm.caml_pasta_fp_to_bigint
+
+// Provides: caml_pasta_fp_of_bigint
+// Requires: plonk_wasm
+var caml_pasta_fp_of_bigint = plonk_wasm.caml_pasta_fp_of_bigint
+
+// Provides: caml_pasta_fp_two_adic_root_of_unity
+// Requires: plonk_wasm
+var caml_pasta_fp_two_adic_root_of_unity = plonk_wasm.caml_pasta_fp_two_adic_root_of_unity
+
+// Provides: caml_pasta_fp_domain_generator
+// Requires: plonk_wasm
+var caml_pasta_fp_domain_generator = plonk_wasm.caml_pasta_fp_domain_generator
+
+// Provides: caml_pasta_fp_to_bytes
+// Requires: plonk_wasm, caml_bytes_of_uint8array
+var caml_pasta_fp_to_bytes = function(x) {
+    var res = plonk_wasm.caml_pasta_fp_to_bytes(x);
+    return caml_bytes_of_uint8array(plonk_wasm.caml_pasta_fp_to_bytes(x));
+};
+
+// Provides: caml_pasta_fp_of_bytes
+// Requires: plonk_wasm, caml_bytes_to_uint8array
+var caml_pasta_fp_of_bytes = function(ocaml_bytes) {
+    return plonk_wasm.caml_pasta_fp_of_bytes(caml_bytes_to_uint8array(ocaml_bytes));
+};
+
+// Provides: caml_pasta_fp_deep_copy
+// Requires: plonk_wasm
+var caml_pasta_fp_deep_copy = plonk_wasm.caml_pasta_fp_deep_copy
+
+
+
+
+
+// Provides: caml_pasta_fq_copy
+var caml_pasta_fq_copy = function(x, y) {
+    for (var i = 0, l = x.length; i < l; i++) {
+        x[i] = y[i];
+    }
+};
+
+// Provides: caml_pasta_fq_option
+var caml_pasta_fq_option = function(x) {
+    // We encode 'none' in WASM as a biginteger formed from a series of
+    // max-size u64s, which gets split into u8s. This value is never returned
+    // as a valid field element, since it is larger than the field's modulus.
+    for (var i = 0, l = x.length; i < l; i++) {
+        if (x[i] != 255) {
+            return [0, x]; // Some(x)
+        }
+    }
+    return 0;
+};
+
+// Provides: caml_pasta_fq_size_in_bits
+// Requires: plonk_wasm
+var caml_pasta_fq_size_in_bits = plonk_wasm.caml_pasta_fq_size_in_bits
+
+// Provides: caml_pasta_fq_size
+// Requires: plonk_wasm
+var caml_pasta_fq_size = plonk_wasm.caml_pasta_fq_size
+
+// Provides: caml_pasta_fq_add
+// Requires: plonk_wasm
+var caml_pasta_fq_add = plonk_wasm.caml_pasta_fq_add
+
+// Provides: caml_pasta_fq_sub
+// Requires: plonk_wasm
+var caml_pasta_fq_sub = plonk_wasm.caml_pasta_fq_sub
+
+// Provides: caml_pasta_fq_negate
+// Requires: plonk_wasm
+var caml_pasta_fq_negate = plonk_wasm.caml_pasta_fq_negate
+
+// Provides: caml_pasta_fq_mul
+// Requires: plonk_wasm
+var caml_pasta_fq_mul = plonk_wasm.caml_pasta_fq_mul
+
+// Provides: caml_pasta_fq_div
+// Requires: plonk_wasm
+var caml_pasta_fq_div = plonk_wasm.caml_pasta_fq_div
+
+// Provides: caml_pasta_fq_inv
+// Requires: plonk_wasm, caml_pasta_fq_option
+var caml_pasta_fq_inv = function(x) {
+    return caml_pasta_fq_option(plonk_wasm.caml_pasta_fq_inv(x));
+};
+
+// Provides: caml_pasta_fq_square
+// Requires: plonk_wasm
+var caml_pasta_fq_square = plonk_wasm.caml_pasta_fq_square
+
+// Provides: caml_pasta_fq_is_square
+// Requires: plonk_wasm, caml_js_to_bool
+var caml_pasta_fq_is_square = function(x) {
+    return caml_js_to_bool(plonk_wasm.caml_pasta_fq_is_square(x));
+};
+
+// Provides: caml_pasta_fq_sqrt
+// Requires: plonk_wasm, caml_pasta_fq_option
+var caml_pasta_fq_sqrt = function(x) {
+    return caml_pasta_fq_option(plonk_wasm.caml_pasta_fq_sqrt(x));
+};
+
+// Provides: caml_pasta_fq_of_int
+// Requires: plonk_wasm
+var caml_pasta_fq_of_int = plonk_wasm.caml_pasta_fq_of_int
+
+// Provides: caml_pasta_fq_to_string
+// Requires: plonk_wasm, caml_string_of_jsstring
+var caml_pasta_fq_to_string = function(x) {
+    return caml_string_of_jsstring(plonk_wasm.caml_pasta_fq_to_string(x));
+};
+
+// Provides: caml_pasta_fq_of_string
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_pasta_fq_of_string = function (x) {
+    return plonk_wasm.caml_pasta_fq_of_string(caml_jsstring_of_string(x));
+};
+
+// Provides: caml_pasta_fq_print
+// Requires: plonk_wasm
+var caml_pasta_fq_print = plonk_wasm.caml_pasta_fq_print
+
+// Provides: caml_pasta_fq_mut_add
+// Requires: caml_pasta_fq_copy, caml_pasta_fq_add
+var caml_pasta_fq_mut_add = function(x, y) {
+    caml_pasta_fq_copy(x, caml_pasta_fq_add(x, y));
+};
+
+// Provides: caml_pasta_fq_mut_sub
+// Requires: caml_pasta_fq_copy, caml_pasta_fq_sub
+var caml_pasta_fq_mut_sub = function(x, y) {
+    caml_pasta_fq_copy(x, caml_pasta_fq_sub(x, y));
+};
+
+// Provides: caml_pasta_fq_mut_mul
+// Requires: caml_pasta_fq_copy, caml_pasta_fq_mul
+var caml_pasta_fq_mut_mul = function(x, y) {
+    caml_pasta_fq_copy(x, caml_pasta_fq_mul(x, y));
+};
+
+// Provides: caml_pasta_fq_mut_square
+// Requires: caml_pasta_fq_copy, caml_pasta_fq_square
+var caml_pasta_fq_mut_square = function(x) {
+    caml_pasta_fq_copy(x, caml_pasta_fq_square(x));
+};
+
+// Provides: caml_pasta_fq_compare
+// Requires: plonk_wasm
+var caml_pasta_fq_compare = plonk_wasm.caml_pasta_fq_compare
+
+// Provides: caml_pasta_fq_equal
+// Requires: plonk_wasm
+var caml_pasta_fq_equal = plonk_wasm.caml_pasta_fq_equal
+
+// Provides: caml_pasta_fq_random
+// Requires: plonk_wasm
+var caml_pasta_fq_random = plonk_wasm.caml_pasta_fq_random
+
+// Provides: caml_pasta_fq_rng
+// Requires: plonk_wasm
+var caml_pasta_fq_rng = plonk_wasm.caml_pasta_fq_rng
+
+// Provides: caml_pasta_fq_to_bigint
+// Requires: plonk_wasm
+var caml_pasta_fq_to_bigint = plonk_wasm.caml_pasta_fq_to_bigint
+
+// Provides: caml_pasta_fq_of_bigint
+// Requires: plonk_wasm
+var caml_pasta_fq_of_bigint = plonk_wasm.caml_pasta_fq_of_bigint
+
+// Provides: caml_pasta_fq_two_adic_root_of_unity
+// Requires: plonk_wasm
+var caml_pasta_fq_two_adic_root_of_unity = plonk_wasm.caml_pasta_fq_two_adic_root_of_unity
+
+// Provides: caml_pasta_fq_domain_generator
+// Requires: plonk_wasm
+var caml_pasta_fq_domain_generator = plonk_wasm.caml_pasta_fq_domain_generator
+
+// Provides: caml_pasta_fq_to_bytes
+// Requires: plonk_wasm, caml_bytes_of_uint8array
+var caml_pasta_fq_to_bytes = function(x) {
+    var res = plonk_wasm.caml_pasta_fq_to_bytes(x);
+    return caml_bytes_of_uint8array(plonk_wasm.caml_pasta_fq_to_bytes(x));
+};
+
+// Provides: caml_pasta_fq_of_bytes
+// Requires: plonk_wasm, caml_bytes_to_uint8array
+var caml_pasta_fq_of_bytes = function(ocaml_bytes) {
+    return plonk_wasm.caml_pasta_fq_of_bytes(caml_bytes_to_uint8array(ocaml_bytes));
+};
+
+// Provides: caml_pasta_fq_deep_copy
+// Requires: plonk_wasm
+var caml_pasta_fq_deep_copy = plonk_wasm.caml_pasta_fq_deep_copy
+
+
+
+
+
+// Provides: caml_u8array_vector_to_rust_flat_vector
+var caml_u8array_vector_to_rust_flat_vector = function (v) {
+    var i = 1; // The first entry is the OCaml tag for arrays
+    var len = v.length - i;
+    if (len === 0) {
+        return new joo_global_object.Uint8Array(0);
+    }
+    var inner_len = v[i].length;
+    var res = new joo_global_object.Uint8Array(len * inner_len);
+    for (var pos = 0; i <= len; i++) {
+        for (var j = 0; j < inner_len; j++, pos++) {
+            res[pos] = v[i][j];
+        }
+    }
+    return res;
+};
+
+// Provides: caml_u8array_vector_of_rust_flat_vector
+var caml_u8array_vector_of_rust_flat_vector = function (v, inner_len) {
+    var len = v.length;
+    var output_len = len / inner_len;
+    var res = new Array(output_len + 1)
+    res[0] = 0 // OCaml tag before array contents, so that we can use this with arrays or vectors
+    for (var i = 1, pos = 0; i <= output_len; i++) {
+        var inner_res = new joo_global_object.Uint8Array(inner_len);
+        for (var j = 0; j < inner_len; j++, pos++) {
+            inner_res[j] = v[pos];
+        }
+        res[i] = inner_res;
+    }
+    return res;
+};
+
+
+
+
+
+// Provides: js_class_vector_to_rust_vector
+var js_class_vector_to_rust_vector = function (v) {
+    var len = v.length;
+    var res = new joo_global_object.Uint32Array(len);
+    for (var i = 0; i < len; i++) {
+        // Beware: caller may need to do finalizer things to avoid these
+        // pointers disappearing out from under us.
+        res[i] = v[i].ptr;
+    }
+    return res;
+};
+
+// Provides: js_class_vector_of_rust_vector
+var js_class_vector_of_rust_vector = function (v, klass) {
+    // return v.map(klass.__wrap)
+    var len = v.length;
+    var res = new Array(len);
+    for (var i = 0, pos = 0; i < len; i++) {
+        // Beware: the caller may need to add finalizers to these.
+        res[i] = klass.__wrap(v[i]);
+    }
+    return res;
+};
+
+
+
+
+
+// Provides: caml_fp_vector_create
+var caml_fp_vector_create = function() {
+    return [0]; // OCaml tag for arrays, so that we can use the same utility fns on both
+};
+
+// Provides: caml_fp_vector_length
+var caml_fp_vector_length = function (v) {
+    return v.length - 1;
+};
+
+// Provides: caml_fp_vector_emplace_back
+var caml_fp_vector_emplace_back = function (v, x) {
+    v.push(x);
+}
+
+// Provides: caml_fp_vector_get
+var caml_fp_vector_get = function (v, i) {
+    return new joo_global_object.Uint8Array(v[i+1]);
+}
+
+// Provides: caml_fp_vector_to_rust
+// Requires: caml_u8array_vector_to_rust_flat_vector
+var caml_fp_vector_to_rust = function (v) {
+    return caml_u8array_vector_to_rust_flat_vector(v);
+}
+
+// Provides: caml_fp_vector_of_rust
+// Requires: caml_u8array_vector_of_rust_flat_vector
+var caml_fp_vector_of_rust = function (v) {
+    // TODO: Hardcoding this is a little brittle
+    return caml_u8array_vector_of_rust_flat_vector(v, 32);
+}
+
+
+
+
+
+// Provides: caml_fq_vector_create
+var caml_fq_vector_create = function() {
+    return [0]; // OCaml tag for arrays, so that we can use the same utility fns on both
+};
+
+// Provides: caml_fq_vector_length
+var caml_fq_vector_length = function (v) {
+    return v.length - 1;
+};
+
+// Provides: caml_fq_vector_emplace_back
+var caml_fq_vector_emplace_back = function (v, x) {
+    v.push(x);
+}
+
+// Provides: caml_fq_vector_get
+var caml_fq_vector_get = function (v, i) {
+    return new joo_global_object.Uint8Array(v[i+1]);
+}
+
+// Provides: caml_fq_vector_to_rust
+// Requires: caml_u8array_vector_to_rust_flat_vector
+var caml_fq_vector_to_rust = function (v) {
+    return caml_u8array_vector_to_rust_flat_vector(v);
+}
+
+// Provides: caml_fq_vector_of_rust
+// Requires: caml_u8array_vector_of_rust_flat_vector
+var caml_fq_vector_of_rust = function (v) {
+    // TODO: Hardcoding this is a little brittle
+    return caml_u8array_vector_of_rust_flat_vector(v, 32);
+}
+
+
+
+
+
+// Provides: free_finalization_registry
+var free_finalization_registry =
+    new joo_global_object.FinalizationRegistry(function (instance_representative) {
+        instance_representative.free();
+    });
+
+// Provides: free_on_finalize
+// Requires: free_finalization_registry
+var free_on_finalize = function (x) {
+    // This is an unfortunate hack: we're creating a second instance of the
+    // class to be able to call free on it. We can't pass the value itself,
+    // since the registry holds a strong reference to the representative value.
+    //
+    // However, the class is only really a wrapper around a pointer, with a
+    // reference to the class' prototype as its __prototype__.
+    //
+    // It might seem cleaner to call the destructor here on the pointer
+    // directly, but unfortunately the destructor name is some mangled internal
+    // string generated by wasm_bindgen. For now, this is the best,
+    // least-brittle way to free once the original class instance gets collected.
+    var instance_representative = x.constructor.__wrap(x.ptr)
+    free_finalization_registry.register(x, instance_representative, x);
+    return x;
+};
+
+
+
+
+
+// Provides: rust_affine_to_caml_affine
+var rust_affine_to_caml_affine = function(pt) {
+    var infinity = pt.infinity;
+    if (infinity) {
+        pt.free();
+        return 0;
+    } else {
+        var x = pt.x;
+        var y = pt.y;
+        pt.free();
+        return [0, [0, x, y]];
+    }
+};
+
+// Provides: rust_affine_of_caml_affine
+var rust_affine_of_caml_affine = function(pt, klass) {
+    var res = new klass();
+    if (pt === 0) {
+        res.infinity = true;
+    } else {
+        // Layout is [0, [0, x, y]]
+        // First 0 is the tag (it's the 0th constructor that takes arguments)
+        // Second 0 is the block marker for the anonymous tuple arguments
+        res.x = pt[1][1];
+        res.y = pt[1][2];
+    }
+    return res;
+};
+
+
+
+
+
+// Provides: caml_pallas_one
+// Requires: plonk_wasm, free_on_finalize
+var caml_pallas_one = function() {
+    var res = plonk_wasm.caml_pallas_one();
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_add
+// Requires: plonk_wasm, free_on_finalize
+var caml_pallas_add = function(x, y) {
+    var res = plonk_wasm.caml_pallas_add(x, y);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_sub
+// Requires: plonk_wasm, free_on_finalize
+var caml_pallas_sub = function(x, y) {
+    var res = plonk_wasm.caml_pallas_sub(x, y);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_negate
+// Requires: plonk_wasm, free_on_finalize
+var caml_pallas_negate = function(x) {
+    var res = plonk_wasm.caml_pallas_negate(x);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_double
+// Requires: plonk_wasm, free_on_finalize
+var caml_pallas_double = function(x) {
+    var res = plonk_wasm.caml_pallas_double(x);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_scale
+// Requires: plonk_wasm, free_on_finalize
+var caml_pallas_scale = function(x, y) {
+    var res = plonk_wasm.caml_pallas_scale(x, y);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_random
+// Requires: plonk_wasm, free_on_finalize
+var caml_pallas_random = function() {
+    var res = plonk_wasm.caml_pallas_random();
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_rng
+// Requires: plonk_wasm, free_on_finalize
+var caml_pallas_rng = function(i) {
+    var res = plonk_wasm.caml_pallas_rng(i);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_to_affine
+// Requires: plonk_wasm, rust_affine_to_caml_affine
+var caml_pallas_to_affine = function(pt) {
+    var res = plonk_wasm.caml_pallas_to_affine(pt);
+    return rust_affine_to_caml_affine(res);
+};
+
+// Provides: caml_pallas_of_affine
+// Requires: plonk_wasm, rust_affine_of_caml_affine, free_on_finalize
+var caml_pallas_of_affine = function(pt) {
+    var res = plonk_wasm.caml_pallas_of_affine(rust_affine_of_caml_affine(pt, plonk_wasm.caml_pallas_affine_one));
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_of_affine_coordinates
+// Requires: plonk_wasm, free_on_finalize
+var caml_pallas_of_affine_coordinates = function(x, y) {
+    var res = plonk_wasm.caml_pallas_of_affine_coordinates(x, y);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_pallas_endo_base
+// Requires: plonk_wasm
+var caml_pallas_endo_base = plonk_wasm.caml_pallas_endo_base;
+
+// Provides: caml_pallas_endo_scalar
+// Requires: plonk_wasm
+var caml_pallas_endo_scalar = plonk_wasm.caml_pallas_endo_scalar;
+
+// Provides: caml_pallas_affine_deep_copy
+// Requires: plonk_wasm, rust_affine_of_caml_affine, rust_affine_to_caml_affine
+var caml_pallas_affine_deep_copy = function(pt) {
+    return rust_affine_to_caml_affine(plonk_wasm.caml_pallas_affine_deep_copy(rust_affine_of_caml_affine(pt, plonk_wasm.caml_pallas_affine_one)));
+};
+
+
+
+
+
+// Provides: caml_vesta_one
+// Requires: plonk_wasm, free_on_finalize
+var caml_vesta_one = function() {
+    var res = plonk_wasm.caml_vesta_one();
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_add
+// Requires: plonk_wasm, free_on_finalize
+var caml_vesta_add = function(x, y) {
+    var res = plonk_wasm.caml_vesta_add(x, y);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_sub
+// Requires: plonk_wasm, free_on_finalize
+var caml_vesta_sub = function(x, y) {
+    var res = plonk_wasm.caml_vesta_sub(x, y);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_negate
+// Requires: plonk_wasm, free_on_finalize
+var caml_vesta_negate = function(x) {
+    var res = plonk_wasm.caml_vesta_negate(x);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_double
+// Requires: plonk_wasm, free_on_finalize
+var caml_vesta_double = function(x) {
+    var res = plonk_wasm.caml_vesta_double(x);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_scale
+// Requires: plonk_wasm, free_on_finalize
+var caml_vesta_scale = function(x, y) {
+    var res = plonk_wasm.caml_vesta_scale(x, y);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_random
+// Requires: plonk_wasm, free_on_finalize
+var caml_vesta_random = function() {
+    var res = plonk_wasm.caml_vesta_random();
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_rng
+// Requires: plonk_wasm, free_on_finalize
+var caml_vesta_rng = function(i) {
+    var res = plonk_wasm.caml_vesta_rng(i);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_to_affine
+// Requires: plonk_wasm, rust_affine_to_caml_affine
+var caml_vesta_to_affine = function(pt) {
+    var res = plonk_wasm.caml_vesta_to_affine(pt);
+    return rust_affine_to_caml_affine(res);
+};
+
+// Provides: caml_vesta_of_affine
+// Requires: plonk_wasm, rust_affine_of_caml_affine, free_on_finalize
+var caml_vesta_of_affine = function(pt) {
+    var res = plonk_wasm.caml_vesta_of_affine(rust_affine_of_caml_affine(pt, plonk_wasm.caml_vesta_affine_one));
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_of_affine_coordinates
+// Requires: plonk_wasm, free_on_finalize
+var caml_vesta_of_affine_coordinates = function(x, y) {
+    var res = plonk_wasm.caml_vesta_of_affine_coordinates(x, y);
+    free_on_finalize(res);
+    return res;
+};
+
+// Provides: caml_vesta_endo_base
+// Requires: plonk_wasm
+var caml_vesta_endo_base = plonk_wasm.caml_vesta_endo_base;
+
+// Provides: caml_vesta_endo_scalar
+// Requires: plonk_wasm
+var caml_vesta_endo_scalar = plonk_wasm.caml_vesta_endo_scalar;
+
+// Provides: caml_vesta_affine_deep_copy
+// Requires: plonk_wasm, rust_affine_of_caml_affine, rust_affine_to_caml_affine
+var caml_vesta_affine_deep_copy = function(pt) {
+    return rust_affine_to_caml_affine(plonk_wasm.caml_vesta_affine_deep_copy(rust_affine_of_caml_affine(pt, plonk_wasm.caml_vesta_affine_one)));
+};
+
+
+
+
+// Provides: caml_array_of_rust_vector
+// Requires: js_class_vector_of_rust_vector
+var caml_array_of_rust_vector = function(v, klass, convert, should_free) {
+    v = js_class_vector_of_rust_vector(v, klass);
+    var len = v.length;
+    var res = new Array(len+1);
+    res[0] = 0; // OCaml tag before array contents
+    for (var i=0; i < len; i++) {
+        var rust_val = v[i];
+        res[i+1] = convert(rust_val);
+        if (should_free) { rust_val.free(); }
+    }
+    return res;
+};
+
+// Provides: caml_array_to_rust_vector
+// Requires: js_class_vector_to_rust_vector, free_finalization_registry
+var caml_array_to_rust_vector = function(v, convert, mk_new) {
+    v = v.slice(1); // Copy, dropping OCaml tag
+    for (var i=0, l=v.length; i < l; i++) {
+        var class_val = convert(v[i], mk_new);
+        v[i] = class_val;
+        // Don't free when GC runs; rust will free on its end.
+        free_finalization_registry.unregister(class_val);
+    }
+    return js_class_vector_to_rust_vector(v);
+}
+
+
+
+
+
+// Provides: caml_poly_comm_of_rust_poly_comm
+// Requires: rust_affine_to_caml_affine, caml_array_of_rust_vector
+var caml_poly_comm_of_rust_poly_comm = function(poly_comm, klass, should_free) {
+    var rust_shifted = poly_comm.shifted;
+    var rust_unshifted = poly_comm.unshifted;
+    var caml_shifted;
+    if (rust_shifted === undefined) {
+        caml_shifted = 0;
+    } else {
+        caml_shifted = [0, rust_affine_to_caml_affine(rust_shifted)];
+    }
+    var caml_unshifted = caml_array_of_rust_vector(rust_unshifted, klass, rust_affine_to_caml_affine, should_free);
+    return [0, caml_unshifted, caml_shifted];
+};
+
+// Provides: caml_poly_comm_to_rust_poly_comm
+// Requires: rust_affine_of_caml_affine, caml_array_to_rust_vector
+var caml_poly_comm_to_rust_poly_comm = function(poly_comm, poly_comm_class, mk_affine) {
+    var caml_unshifted = poly_comm[1];
+    var caml_shifted = poly_comm[2];
+    var rust_shifted = undefined;
+    if (caml_shifted !== 0) {
+        rust_shifted = rust_affine_of_caml_affine(caml_shifted[1], mk_affine);
+    }
+    var rust_unshifted = caml_array_to_rust_vector(caml_unshifted, rust_affine_of_caml_affine, mk_affine);
+    return new poly_comm_class(rust_unshifted, rust_shifted);
+};
+
+
+
+
+
+// Provides: caml_vesta_poly_comm_of_rust
+// Requires: plonk_wasm, caml_poly_comm_of_rust_poly_comm
+var caml_vesta_poly_comm_of_rust = function(x) {
+    return caml_poly_comm_of_rust_poly_comm(x, plonk_wasm.WasmGVesta, false);
+}
+
+// Provides: caml_vesta_poly_comm_to_rust
+// Requires: plonk_wasm, caml_poly_comm_to_rust_poly_comm
+var caml_vesta_poly_comm_to_rust = function(x) {
+    return caml_poly_comm_to_rust_poly_comm(x, plonk_wasm.WasmFpPolyComm, plonk_wasm.caml_vesta_affine_one);
+}
+
+
+
+
+
+// Provides: caml_pallas_poly_comm_of_rust
+// Requires: plonk_wasm, caml_poly_comm_of_rust_poly_comm
+var caml_pallas_poly_comm_of_rust = function(x) {
+    return caml_poly_comm_of_rust_poly_comm(x, plonk_wasm.WasmGPallas, false);
+}
+
+// Provides: caml_pallas_poly_comm_to_rust
+// Requires: plonk_wasm, caml_poly_comm_to_rust_poly_comm
+var caml_pallas_poly_comm_to_rust = function(x) {
+    return caml_poly_comm_to_rust_poly_comm(x, plonk_wasm.WasmFqPolyComm, plonk_wasm.caml_pallas_affine_one);
+}
+
+
+
+
+
+// Provides: caml_fp_srs_create
+// Requires: plonk_wasm, free_on_finalize
+var caml_fp_srs_create = function(i) {
+    return free_on_finalize(plonk_wasm.caml_fp_srs_create(i));
+};
+
+// Provides: caml_fp_srs_write
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_fp_srs_write = function(append, t, path) {
+    if (append === 0) {
+        append = undefined;
+    } else {
+        append = append[1];
+    }
+    return plonk_wasm.caml_fp_srs_write(append, t, caml_jsstring_of_string(path));
+};
+
+// Provides: caml_fp_srs_read
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_fp_srs_read = function (offset, path) {
+    if (offset === 0) {
+        offset = undefined;
+    } else {
+        offset = offset[1];
+    }
+    var res = plonk_wasm.caml_fp_srs_read(offset, caml_jsstring_of_string(path));
+    if (res) {
+        return [0, res]; // Some(res)
+    } else {
+        return 0; // None
+    }
+};
+
+// Provides: caml_fp_srs_lagrange_commitment
+// Requires: plonk_wasm, caml_vesta_poly_comm_of_rust
+var caml_fp_srs_lagrange_commitment = function (t, domain_size, i) {
+    var res = plonk_wasm.caml_fp_srs_lagrange_commitment(t, domain_size, i);
+    return caml_vesta_poly_comm_of_rust(res);
+};
+
+// Provides: caml_fp_srs_commit_evaluations
+// Requires: plonk_wasm, caml_vesta_poly_comm_of_rust, caml_fp_vector_to_rust
+var caml_fp_srs_commit_evaluations = function (t, domain_size, fps) {
+    var res = plonk_wasm.caml_fp_srs_commit_evaluations(t, domain_size, caml_fp_vector_to_rust(fps));
+    return caml_vesta_poly_comm_of_rust(res);
+};
+
+// Provides: caml_fp_srs_b_poly_commitment
+// Requires: plonk_wasm, caml_vesta_poly_comm_of_rust
+var caml_fp_srs_b_poly_commitment = function (t, domain_size, i) {
+    var res = plonk_wasm.caml_fp_srs_b_poly_commitment(t, domain_size, i);
+    return caml_vesta_poly_comm_of_rust(res);
+};
+
+// Provides: caml_fp_srs_batch_accumulator_check
+// Requires: plonk_wasm, rust_affine_of_caml_affine, caml_array_to_rust_vector, caml_fp_vector_to_rust
+var caml_fp_srs_batch_accumulator_check = function (t, affines, fields) {
+    var rust_affines =
+      caml_array_to_rust_vector(affines, rust_affine_of_caml_affine, plonk_wasm.caml_pallas_affine_one);
+    var rust_fields = caml_fp_vector_to_rust(fields);
+    return plonk_wasm.caml_fp_srs_batch_accumulator_check(t, rust_affines, rust_fields);
+};
+
+// Provides: caml_fp_srs_h
+// Requires: plonk_wasm, rust_affine_to_caml_affine
+var caml_fp_srs_h = function (t) {
+    return rust_affine_to_caml_affine(plonk_wasm.caml_fp_srs_h(t));
+};
+
+
+
+
+
+// Provides: caml_fq_srs_create
+// Requires: plonk_wasm, free_on_finalize
+var caml_fq_srs_create = function(i) {
+    return free_on_finalize(plonk_wasm.caml_fq_srs_create(i));
+};
+
+// Provides: caml_fq_srs_write
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_fq_srs_write = function(append, t, path) {
+    if (append === 0) {
+        append = undefined;
+    } else {
+        append = append[1];
+    }
+    return plonk_wasm.caml_fq_srs_write(append, t,  caml_jsstring_of_string(path));
+};
+
+// Provides: caml_fq_srs_read
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_fq_srs_read = function (offset, path) {
+    if (offset === 0) {
+        offset = undefined;
+    } else {
+        offset = offset[1];
+    }
+    var res = plonk_wasm.caml_fq_srs_read(offset, caml_jsstring_of_string(path));
+    if (res) {
+        return [0, res]; // Some(res)
+    } else {
+        return 0; // None
+    }
+};
+
+// Provides: caml_fq_srs_lagrange_commitment
+// Requires: plonk_wasm, caml_pallas_poly_comm_of_rust
+var caml_fq_srs_lagrange_commitment = function (t, domain_size, i) {
+    var res = plonk_wasm.caml_fq_srs_lagrange_commitment(t, domain_size, i);
+    return caml_pallas_poly_comm_of_rust(res);
+};
+
+// Provides: caml_fq_srs_commit_evaluations
+// Requires: plonk_wasm, caml_pallas_poly_comm_of_rust, caml_fq_vector_to_rust
+var caml_fq_srs_commit_evaluations = function (t, domain_size, fqs) {
+    var res = plonk_wasm.caml_fq_srs_commit_evaluations(t, domain_size, caml_fq_vector_to_rust(fqs));
+    return caml_pallas_poly_comm_of_rust(res);
+};
+
+// Provides: caml_fq_srs_b_poly_commitment
+// Requires: plonk_wasm, caml_pallas_poly_comm_of_rust
+var caml_fq_srs_b_poly_commitment = function (t, domain_size, i) {
+    var res = plonk_wasm.caml_fq_srs_b_poly_commitment(t, domain_size, i);
+    return caml_pallas_poly_comm_of_rust(res);
+};
+
+// Provides: caml_fq_srs_batch_accumulator_check
+// Requires: plonk_wasm, rust_affine_of_caml_affine, caml_array_to_rust_vector, caml_fq_vector_to_rust
+var caml_fq_srs_batch_accumulator_check = function (t, affines, fields) {
+    var rust_affines =
+      caml_array_to_rust_vector(affines, rust_affine_of_caml_affine, plonk_wasm.caml_pallas_affine_one);
+    var rust_fields = caml_fq_vector_to_rust(fields);
+    return plonk_wasm.caml_fq_srs_batch_accumulator_check(t, rust_affines, rust_fields);
+};
+
+// Provides: caml_fq_srs_h
+// Requires: plonk_wasm, rust_affine_to_caml_affine
+var caml_fq_srs_h = function (t) {
+    return rust_affine_to_caml_affine(plonk_wasm.caml_fq_srs_h(t));
+};
+
+
+
+
+
+// Provides: caml_plonk_wire_of_rust
+var caml_plonk_wire_of_rust = function(wire) {
+    var res = [0, wire.row, wire.col];
+    wire.free();
+    return res;
+};
+
+// Provides: caml_plonk_wire_to_rust
+// Requires: plonk_wasm
+var caml_plonk_wire_to_rust = function(wire) {
+    return plonk_wasm.Wire.create(wire[1], wire[2]);
+};
+
+// Provides: caml_plonk_wires_of_rust
+// Requires: caml_plonk_wire_of_rust
+var caml_plonk_wires_of_rust = function(wires) {
+    var res = [0,
+      caml_plonk_wire_of_rust(wires[0]),
+      caml_plonk_wire_of_rust(wires[1]),
+      caml_plonk_wire_of_rust(wires[2]),
+      caml_plonk_wire_of_rust(wires[3]),
+      caml_plonk_wire_of_rust(wires[4]),
+      caml_plonk_wire_of_rust(wires[5]),
+      caml_plonk_wire_of_rust(wires[6])];
+    wires.free();
+    return res;
+};
+
+// Provides: caml_plonk_wires_to_rust
+// Requires: plonk_wasm, caml_plonk_wire_to_rust
+var caml_plonk_wires_to_rust = function(wires) {
+    return new plonk_wasm.WasmGateWires(
+      caml_plonk_wire_to_rust(wires[1]),
+      caml_plonk_wire_to_rust(wires[2]),
+      caml_plonk_wire_to_rust(wires[3]),
+      caml_plonk_wire_to_rust(wires[4]),
+      caml_plonk_wire_to_rust(wires[5]),
+      caml_plonk_wire_to_rust(wires[6]),
+      caml_plonk_wire_to_rust(wires[7])
+    );
+};
+
+// Provides: caml_plonk_gate_of_rust
+// Requires: caml_plonk_wires_of_rust, caml_u8array_vector_of_rust_flat_vector
+var caml_plonk_gate_of_rust = function(gate) {
+    // TODO: Hardcoding 32 here is a little brittle
+    var res = [0, gate.typ, caml_plonk_wires_of_rust(gate.wires), caml_u8array_vector_of_rust_flat_vector(gate.c, 32)];
+    gate.free();
+    return res;
+};
+
+// Provides: caml_fp_plonk_gate_to_rust
+// Requires: plonk_wasm, caml_plonk_wires_to_rust, caml_u8array_vector_to_rust_flat_vector
+var caml_fp_plonk_gate_to_rust = function(gate) {
+    return new plonk_wasm.WasmFpGate(
+      gate[1],
+      caml_plonk_wires_to_rust(gate[2]),
+      caml_u8array_vector_to_rust_flat_vector(gate[3]));
+};
+
+// Provides: caml_fq_plonk_gate_to_rust
+// Requires: plonk_wasm, caml_plonk_wires_to_rust, caml_u8array_vector_to_rust_flat_vector
+var caml_fq_plonk_gate_to_rust = function(gate) {
+    // TODO: Hardcoding 32 here is a little brittle
+    return new plonk_wasm.WasmFqGate(
+      gate[1],
+      caml_plonk_wires_to_rust(gate[2]),
+      caml_u8array_vector_to_rust_flat_vector(gate[3]))
+};
+
+
+
+
+
+// Provides: caml_pasta_fp_plonk_gate_vector_create
+// Requires: plonk_wasm, free_on_finalize
+var caml_pasta_fp_plonk_gate_vector_create = function() {
+    return free_on_finalize(plonk_wasm.caml_pasta_fp_plonk_gate_vector_create());
+};
+
+// Provides: caml_pasta_fp_plonk_gate_vector_add
+// Requires: plonk_wasm, caml_fp_plonk_gate_to_rust
+var caml_pasta_fp_plonk_gate_vector_add = function(v, x) {
+    return plonk_wasm.caml_pasta_fp_plonk_gate_vector_add(v, caml_fp_plonk_gate_to_rust(x));
+};
+
+// Provides: caml_pasta_fp_plonk_gate_vector_get
+// Requires: plonk_wasm, caml_plonk_gate_of_rust
+var caml_pasta_fp_plonk_gate_vector_get = function(v, i) {
+    return caml_plonk_gate_of_rust(plonk_wasm.caml_pasta_fp_plonk_gate_vector_get(v, i));
+};
+
+// Provides: caml_pasta_fp_plonk_gate_vector_wrap
+// Requires: plonk_wasm, caml_plonk_wire_to_rust
+var caml_pasta_fp_plonk_gate_vector_wrap = function(v, x, y) {
+    return plonk_wasm.caml_pasta_fp_plonk_gate_vector_wrap(v, caml_plonk_wire_to_rust(x), caml_plonk_wire_to_rust(y));
+};
+
+
+
+
+
+// Provides: caml_pasta_fq_plonk_gate_vector_create
+// Requires: plonk_wasm, free_on_finalize
+var caml_pasta_fq_plonk_gate_vector_create = function() {
+    return free_on_finalize(plonk_wasm.caml_pasta_fq_plonk_gate_vector_create());
+};
+
+// Provides: caml_pasta_fq_plonk_gate_vector_add
+// Requires: plonk_wasm, caml_fq_plonk_gate_to_rust
+var caml_pasta_fq_plonk_gate_vector_add = function(v, x) {
+    return plonk_wasm.caml_pasta_fq_plonk_gate_vector_add(v, caml_fq_plonk_gate_to_rust(x));
+};
+
+// Provides: caml_pasta_fq_plonk_gate_vector_get
+// Requires: plonk_wasm, caml_plonk_gate_of_rust
+var caml_pasta_fq_plonk_gate_vector_get = function(v, i) {
+    return caml_plonk_gate_of_rust(plonk_wasm.caml_pasta_fq_plonk_gate_vector_get(v, i));
+};
+
+// Provides: caml_pasta_fq_plonk_gate_vector_wrap
+// Requires: plonk_wasm, caml_plonk_wire_to_rust
+var caml_pasta_fq_plonk_gate_vector_wrap = function(v, x, y) {
+    return plonk_wasm.caml_pasta_fq_plonk_gate_vector_wrap(v, caml_plonk_wire_to_rust(x), caml_plonk_wire_to_rust(y));
+};
+
+
+
+
+
+// Provides: caml_pasta_fp_plonk_index_create
+// Requires: plonk_wasm, free_on_finalize
+var caml_pasta_fp_plonk_index_create = function(gates, public_inputs, urs) {
+    // console.log('caml_pasta_fp_plonk_index_create');
+    var t = plonk_wasm.caml_pasta_fp_plonk_index_create(gates, public_inputs, urs);
+    return free_on_finalize(t);
+};
+
+// Provides: caml_pasta_fp_plonk_index_max_degree
+// Requires: plonk_wasm
+var caml_pasta_fp_plonk_index_max_degree = plonk_wasm.caml_pasta_fp_plonk_index_max_degree;
+
+// Provides: caml_pasta_fp_plonk_index_public_inputs
+// Requires: plonk_wasm
+var caml_pasta_fp_plonk_index_public_inputs = plonk_wasm.caml_pasta_fp_plonk_index_public_inputs;
+
+// Provides: caml_pasta_fp_plonk_index_domain_d1_size
+// Requires: plonk_wasm
+var caml_pasta_fp_plonk_index_domain_d1_size = plonk_wasm.caml_pasta_fp_plonk_index_domain_d1_size;
+
+// Provides: caml_pasta_fp_plonk_index_domain_d4_size
+// Requires: plonk_wasm
+var caml_pasta_fp_plonk_index_domain_d4_size = plonk_wasm.caml_pasta_fp_plonk_index_domain_d4_size;
+
+// Provides: caml_pasta_fp_plonk_index_domain_d8_size
+// Requires: plonk_wasm
+var caml_pasta_fp_plonk_index_domain_d8_size = plonk_wasm.caml_pasta_fp_plonk_index_domain_d8_size;
+
+// Provides: caml_pasta_fp_plonk_index_read
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_pasta_fp_plonk_index_read = function (offset, urs, path) {
+    if (offset === 0) {
+        offset = undefined;
+    } else {
+        offset = offset[1];
+    }
+    return plonk_wasm.caml_pasta_fp_plonk_index_read(offset, urs, caml_jsstring_of_string(path));
+};
+
+// Provides: caml_pasta_fp_plonk_index_write
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_pasta_fp_plonk_index_write = function(append, t, path) {
+    if (append === 0) {
+        append = undefined;
+    } else {
+        append = append[1];
+    }
+    return plonk_wasm.caml_pasta_fp_plonk_index_write(append, t, caml_jsstring_of_string(path));
+};
+
+
+
+
+
+// Provides: caml_pasta_fq_plonk_index_create
+// Requires: plonk_wasm, free_on_finalize
+var caml_pasta_fq_plonk_index_create = function(gates, public_inputs, urs) {
+    return free_on_finalize(plonk_wasm.caml_pasta_fq_plonk_index_create(gates, public_inputs, urs));
+}
+
+// Provides: caml_pasta_fq_plonk_index_max_degree
+// Requires: plonk_wasm
+var caml_pasta_fq_plonk_index_max_degree = plonk_wasm.caml_pasta_fq_plonk_index_max_degree;
+
+// Provides: caml_pasta_fq_plonk_index_public_inputs
+// Requires: plonk_wasm
+var caml_pasta_fq_plonk_index_public_inputs = plonk_wasm.caml_pasta_fq_plonk_index_public_inputs;
+
+// Provides: caml_pasta_fq_plonk_index_domain_d1_size
+// Requires: plonk_wasm
+var caml_pasta_fq_plonk_index_domain_d1_size = plonk_wasm.caml_pasta_fq_plonk_index_domain_d1_size;
+
+// Provides: caml_pasta_fq_plonk_index_domain_d4_size
+// Requires: plonk_wasm
+var caml_pasta_fq_plonk_index_domain_d4_size = plonk_wasm.caml_pasta_fq_plonk_index_domain_d4_size;
+
+// Provides: caml_pasta_fq_plonk_index_domain_d8_size
+// Requires: plonk_wasm
+var caml_pasta_fq_plonk_index_domain_d8_size = plonk_wasm.caml_pasta_fq_plonk_index_domain_d8_size;
+
+// Provides: caml_pasta_fq_plonk_index_read
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_pasta_fq_plonk_index_read = function (offset, urs, path) {
+    if (offset === 0) {
+        offset = undefined;
+    } else {
+        offset = offset[1];
+    }
+    return plonk_wasm.caml_pasta_fq_plonk_index_read(offset, urs, caml_jsstring_of_string(path));
+};
+
+// Provides: caml_pasta_fq_plonk_index_write
+// Requires: plonk_wasm, caml_jsstring_of_string
+var caml_pasta_fq_plonk_index_write = function(append, t, path) {
+    if (append === 0) {
+        append = undefined;
+    } else {
+        append = append[1];
+    }
+    return plonk_wasm.caml_pasta_fq_plonk_index_write(append, t, caml_jsstring_of_string(path));
+};
+
+
+
+
+
+// Provides: caml_plonk_domain_of_rust
+var caml_plonk_domain_of_rust = function(x) {
+    var log_size_of_group = x.log_size_of_group;
+    var group_gen = x.group_gen;
+    x.free();
+    return [0, log_size_of_group, group_gen];
+};
+
+// Provides: caml_plonk_domain_to_rust
+// Requires: free_on_finalize
+var caml_plonk_domain_to_rust = function(x, klass) {
+    // TODO: Check if this gets finalized
+    return new klass(x[1], x[2]);
+};
+
+// Provides: caml_plonk_verification_evals_of_rust
+// Requires: caml_poly_comm_of_rust_poly_comm, js_class_vector_of_rust_vector, plonk_wasm
+var caml_plonk_verification_evals_of_rust = function(x, affine_klass) {
+    var convert = function(poly_comm) {
+        return caml_poly_comm_of_rust_poly_comm(poly_comm, affine_klass, false);
+    };
+
+    // var convertArray = function(comms) {
+    //     var n = comms.length;
+    //     var res = new Array(n-1);
+    //     for (var i = 1; i < n; i++) {
+    //         res[i-1] = convert(comms[i]);
+    //     }
+    //     return js_class_vector_to_rust_vector(res);
+    //   };
+
+    // should be inverse of the above ^
+    // TODO: make work for both Wasm..PolyComm types
+    var convertArray = function(comms) {
+        comms = js_class_vector_of_rust_vector(comms, plonk_wasm.WasmFqPolyComm);
+        // comms = js_class_vector_of_rust_vector(comms, plonk_wasm.WasmFpPolyComm);
+        return [0].concat(comms.map(convert));
+    };
+
+    var sigma_comm = convertArray(x.sigma_comm);
+    var coefficients_comm = convertArray(x.coefficients_comm);
+    var generic_comm = convert(x.generic_comm);
+    var psm_comm = convert(x.psm_comm);
+    var complete_add_comm = convert(x.complete_add_comm);
+    var mul_comm = convert(x.mul_comm);
+    var emul_comm = convert(x.emul_comm);
+    var endomul_scalar_comm = convert(x.endomul_scalar_comm);
+
+    x.free();
+    return [ 0
+      , sigma_comm
+      , coefficients_comm
+      , generic_comm
+      , psm_comm
+      , complete_add_comm
+      , mul_comm
+      , emul_comm
+      , endomul_scalar_comm
+      , 0 ];
+};
+
+// Provides: caml_plonk_verification_evals_to_rust
+// Requires: caml_poly_comm_to_rust_poly_comm, js_class_vector_to_rust_vector
+var caml_plonk_verification_evals_to_rust = function(x, klass, poly_comm_class, mk_affine) {
+    var convert = function(poly_comm) {
+        return caml_poly_comm_to_rust_poly_comm(poly_comm, poly_comm_class, mk_affine);
+    };
+
+    var convertArray = function(comms) {
+      var n = comms.length;
+      var res = new Array(n-1);
+      for (var i = 1; i < n; i++) {
+          res[i-1] = convert(comms[i]);
+      }
+      return js_class_vector_to_rust_vector(res);
+    };
+
+    var sigma_comm = convertArray(x[1]);
+    var coefficients_comm = convertArray(x[2]);
+    var generic_comm = convert(x[3]);
+    var psm_comm = convert(x[4]);
+    var complete_add_comm = convert(x[5]);
+    var mul_comm = convert(x[6]);
+    var emul_comm = convert(x[7]);
+    var endomul_scalar_comm = convert(x[8]);
+    // TODO: Chacha
+
+    return new klass(
+      sigma_comm,
+      coefficients_comm,
+      generic_comm,
+      psm_comm,
+      complete_add_comm,
+      mul_comm,
+      emul_comm,
+      endomul_scalar_comm);
+};
+
+// Provides: caml_plonk_verification_shifts_of_rust
+var caml_plonk_verification_shifts_of_rust = function(x) {
+    var res = [0, x.s0, x.s1, x.s2, x.s3, x.s4, x.s5, x.s6]; 
+    x.free();
+    return res;
+};
+
+// Provides: caml_plonk_verification_shifts_to_rust
+var caml_plonk_verification_shifts_to_rust = function(x, klass) {
+    return new klass(x[1], x[2], x[3], x[4], x[5], x[6], x[7]);
+};
+
+// Provides: column_of_rust
+function column_of_rust(col) {
+    // type nonrec column = Witness of int | Z | LookupSorted of int | LookupAggreg | LookupTable | LookupKindIndex of int | Index of gate_type | Coefficient of int
+    var tag = col.tag;
+    var gate_type = col.gate_type;
+    var i = col.i;
+    col.free();
+    return {
+        0: [tag, i],
+        2: [tag, i],
+        5: [tag, i],
+        6: [tag, gate_type],
+        7: [tag, i]
+    }[tag] || tag;
+}
+
+// Provides: variable_of_rust
+// Requires: column_of_rust
+function variable_of_rust(variable) {
+    // col * row
+    var col = variable.col;
+    var row = variable.row; // 0, 1
+    variable.free();
+    return [0, column_of_rust(col), row];
+}
+
+// Provides: polish_token_of_rust
+// Requires: variable_of_rust
+function polish_token_of_rust(token) {
+    var tag = token.tag;
+    var i0 = token.i0;
+    var i1 = token.i1;
+    var f = token.f;
+    var v = variable_of_rust(token.v);
+    token.free();
+    return {
+        5: [5, i0, i1],
+        6: [6, f],
+        7: [7, v],
+        9: [9, i0],
+        14: [14, i0],
+        16: [16, i0]
+    }[tag] || tag;
+}
+
+// Provides: index_term_of_rust
+// Requires: column_of_rust, js_class_vector_of_rust_vector, polish_token_of_rust
+function index_term_of_rust(term, token_class) {
+    // pub column: WasmColumn,
+    // pub coefficient: WasmVector<WasmPolishToken>,
+    var column = column_of_rust(term.column);
+    var coefficient = js_class_vector_of_rust_vector(term.coefficient, token_class);
+    coefficient = coefficient.map(polish_token_of_rust)
+    coefficient = [0].concat(coefficient);
+    term.free();
+    return [0, column, coefficient];
+}
+
+// Provides: wrap
+function wrap(ptr, klass) {
+    var obj = Object.create(klass.prototype);
+    obj.ptr = ptr;
+    return obj;
+}
+
+// Provides: linearization_of_rust
+// Requires: plonk_wasm, js_class_vector_of_rust_vector, polish_token_of_rust, wrap, index_term_of_rust
+function linearization_of_rust(linearization, affine_class) {
+    // console.log('linearization_of_rust', affine_class);
+    var F = affine_class === plonk_wasm.WasmGVesta ? 'Fq' : 'Fp';
+    var WasmPolishToken = plonk_wasm['Wasm' + F + 'PolishToken'];
+    var WasmIndexTerm = plonk_wasm['Wasm' + F + 'IndexTerm'];
+    
+    var constant_term = js_class_vector_of_rust_vector(linearization.constant_term, WasmPolishToken);
+    constant_term = constant_term.map(polish_token_of_rust)
+    constant_term = [0].concat(constant_term);
+    
+    var index_terms = Array.from(linearization.index_terms)
+        .map(function (ptr) {
+            var wasmIndexTerm = wrap(ptr, WasmIndexTerm);
+            return index_term_of_rust(wasmIndexTerm, WasmPolishToken);
+        });
+    index_terms = [0].concat(index_terms);
+    
+    linearization.free();
+    return [0, constant_term, index_terms];
+}
+
+var None = 0;
+
+// Provides: caml_plonk_verifier_index_of_rust
+// Requires: linearization_of_rust, caml_plonk_domain_of_rust, caml_plonk_verification_evals_of_rust, caml_plonk_verification_shifts_of_rust, free_on_finalize
+var caml_plonk_verifier_index_of_rust = function(x, affine_class) {
+    // console.log('caml_plonk_verifier_index_of_rust', affine_class);
+    var domain = caml_plonk_domain_of_rust(x.domain);
+    var max_poly_size = x.max_poly_size;
+    var max_quot_size = x.max_quot_size;
+    var srs = free_on_finalize(x.srs);
+    var evals = caml_plonk_verification_evals_of_rust(x.evals, affine_class);
+    var shifts = caml_plonk_verification_shifts_of_rust(x.shifts);
+    // TODO: Handle linearization correctly!
+    // var linearization = linearization_of_rust(x.linearization, affine_class);
+    var lookup_index = None;
+    x.free();
+    return [0, domain, max_poly_size, max_quot_size, srs, evals, shifts, None];
+};
+// Provides: caml_plonk_verifier_index_to_rust
+// Requires: caml_plonk_domain_to_rust, caml_plonk_verification_evals_to_rust, caml_plonk_verification_shifts_to_rust, free_finalization_registry
+var caml_plonk_verifier_index_to_rust = function(x, klass, domain_class, verification_evals_class, poly_comm_class, mk_affine, verification_shifts_class) {
+    // console.log('caml_plonk_verifier_index_to_rust', klass);
+    var domain = caml_plonk_domain_to_rust(x[1], domain_class);
+    var max_poly_size = x[2];
+    var max_quot_size = x[3];
+    var srs = x[4];
+    var evals = caml_plonk_verification_evals_to_rust(x[5], verification_evals_class, poly_comm_class, mk_affine);
+    var shifts = caml_plonk_verification_shifts_to_rust(x[6], verification_shifts_class);
+    return new klass(domain, max_poly_size, max_quot_size, srs, evals, shifts);
+};
+
+
+
+
+
+// Provides: caml_pasta_fp_plonk_verifier_index_of_rust
+// Requires: plonk_wasm, caml_plonk_verifier_index_of_rust
+var caml_pasta_fp_plonk_verifier_index_of_rust = function(x) {
+    return caml_plonk_verifier_index_of_rust(x, plonk_wasm.WasmGVesta);
+};
+
+// Provides: caml_pasta_fp_plonk_verifier_index_to_rust
+// Requires: plonk_wasm, caml_plonk_verifier_index_to_rust
+var caml_pasta_fp_plonk_verifier_index_to_rust = function(x) {
+    return caml_plonk_verifier_index_to_rust(x, plonk_wasm.WasmFpPlonkVerifierIndex, plonk_wasm.WasmFpDomain, plonk_wasm.WasmFpPlonkVerificationEvals, plonk_wasm.WasmFpPolyComm, plonk_wasm.caml_vesta_affine_one, plonk_wasm.WasmFpShifts);
+};
+
+// Provides: caml_pasta_fp_plonk_verifier_index_create
+// Requires: plonk_wasm, caml_pasta_fp_plonk_verifier_index_of_rust
+var caml_pasta_fp_plonk_verifier_index_create = function(x) {
+    // console.log('caml_pasta_fp_plonk_verifier_index_create');
+    var vk = plonk_wasm.caml_pasta_fp_plonk_verifier_index_create(x);
+    var vk_caml = caml_pasta_fp_plonk_verifier_index_of_rust(vk);
+    return vk_caml;
+};
+
+// Provides: caml_pasta_fp_plonk_verifier_index_read
+// Requires: plonk_wasm, caml_jsstring_of_string, caml_pasta_fp_plonk_verifier_index_of_rust
+var caml_pasta_fp_plonk_verifier_index_read = function (offset, urs, path) {
+    if (offset === 0) {
+        offset = undefined;
+    } else {
+        offset = offset[1];
+    }
+    return caml_pasta_fp_plonk_verifier_index_of_rust(plonk_wasm.caml_pasta_fp_plonk_verifier_index_read(offset, urs, caml_jsstring_of_string(path)));
+};
+
+// Provides: caml_pasta_fp_plonk_verifier_index_write
+// Requires: plonk_wasm, caml_jsstring_of_string, caml_pasta_fp_plonk_verifier_index_to_rust
+var caml_pasta_fp_plonk_verifier_index_write = function (append, t, path) {
+    if (append === 0) {
+        append = undefined;
+    } else {
+        append = append[1];
+    }
+    return plonk_wasm.caml_pasta_fp_plonk_verifier_index_write(append, caml_pasta_fp_plonk_verifier_index_to_rust(t), caml_jsstring_of_string(path));
+};
+
+// Provides: caml_pasta_fp_plonk_verifier_index_shifts
+// Requires: plonk_wasm, caml_plonk_verification_shifts_of_rust
+var caml_pasta_fp_plonk_verifier_index_shifts = function(log2_size) {
+    return caml_plonk_verification_shifts_of_rust(plonk_wasm.caml_pasta_fp_plonk_verifier_index_shifts(log2_size));
+};
+
+// Provides: caml_pasta_fp_plonk_verifier_index_dummy
+// Requires: plonk_wasm, caml_pasta_fp_plonk_verifier_index_of_rust
+var caml_pasta_fp_plonk_verifier_index_dummy = function() {
+    var res = plonk_wasm.caml_pasta_fp_plonk_verifier_index_dummy();
+    return caml_pasta_fp_plonk_verifier_index_of_rust(res);
+    // return caml_pasta_fp_plonk_verifier_index_of_rust(plonk_wasm.caml_pasta_fp_plonk_verifier_index_dummy());
+};
+
+// Provides: caml_pasta_fp_plonk_verifier_index_deep_copy
+// Requires: plonk_wasm, caml_pasta_fp_plonk_verifier_index_of_rust, caml_pasta_fp_plonk_verifier_index_to_rust
+var caml_pasta_fp_plonk_verifier_index_deep_copy = function(x) {
+    return caml_pasta_fp_plonk_verifier_index_of_rust(plonk_wasm.caml_pasta_fp_plonk_verifier_index_deep_copy(caml_pasta_fp_plonk_verifier_index_to_rust(x)));
+};
+
+
+
+
+
+// Provides: caml_pasta_fq_plonk_verifier_index_of_rust
+// Requires: plonk_wasm, caml_plonk_verifier_index_of_rust
+var caml_pasta_fq_plonk_verifier_index_of_rust = function(x) {
+    return caml_plonk_verifier_index_of_rust(x, plonk_wasm.WasmGPallas);
+};
+
+// Provides: caml_pasta_fq_plonk_verifier_index_to_rust
+// Requires: plonk_wasm, caml_plonk_verifier_index_to_rust
+var caml_pasta_fq_plonk_verifier_index_to_rust = function(x) {
+    return caml_plonk_verifier_index_to_rust(x, plonk_wasm.WasmFqPlonkVerifierIndex, plonk_wasm.WasmFqDomain, plonk_wasm.WasmFqPlonkVerificationEvals, plonk_wasm.WasmFqPolyComm, plonk_wasm.caml_pallas_affine_one, plonk_wasm.WasmFqShifts);
+};
+
+// Provides: caml_pasta_fq_plonk_verifier_index_create
+// Requires: plonk_wasm, caml_pasta_fq_plonk_verifier_index_of_rust
+var caml_pasta_fq_plonk_verifier_index_create = function(x) {
+    return caml_pasta_fq_plonk_verifier_index_of_rust(plonk_wasm.caml_pasta_fq_plonk_verifier_index_create(x));
+};
+
+// Provides: caml_pasta_fq_plonk_verifier_index_read
+// Requires: plonk_wasm, caml_jsstring_of_string, caml_pasta_fq_plonk_verifier_index_of_rust
+var caml_pasta_fq_plonk_verifier_index_read = function (offset, urs, path) {
+    if (offset === 0) {
+        offset = undefined;
+    } else {
+        offset = offset[1];
+    }
+    return caml_pasta_fq_plonk_verifier_index_of_rust(plonk_wasm.caml_pasta_fq_plonk_verifier_index_read(offset, urs, caml_jsstring_of_string(path)));
+};
+
+// Provides: caml_pasta_fq_plonk_verifier_index_write
+// Requires: plonk_wasm, caml_jsstring_of_string, caml_pasta_fq_plonk_verifier_index_to_rust
+var caml_pasta_fq_plonk_verifier_index_write = function (append, t, path) {
+    if (append === 0) {
+        append = undefined;
+    } else {
+        append = append[1];
+    }
+    return plonk_wasm.caml_pasta_fq_plonk_verifier_index_write(append, caml_pasta_fq_plonk_verifier_index_to_rust(t), caml_jsstring_of_string(path));
+};
+
+// Provides: caml_pasta_fq_plonk_verifier_index_shifts
+// Requires: plonk_wasm, caml_plonk_verification_shifts_of_rust
+var caml_pasta_fq_plonk_verifier_index_shifts = function(log2_size) {
+    return caml_plonk_verification_shifts_of_rust(plonk_wasm.caml_pasta_fq_plonk_verifier_index_shifts(log2_size));
+};
+
+// Provides: caml_pasta_fq_plonk_verifier_index_dummy
+// Requires: plonk_wasm, caml_pasta_fq_plonk_verifier_index_of_rust
+var caml_pasta_fq_plonk_verifier_index_dummy = function() {
+    return caml_pasta_fq_plonk_verifier_index_of_rust(plonk_wasm.caml_pasta_fq_plonk_verifier_index_dummy());
+};
+
+// Provides: caml_pasta_fq_plonk_verifier_index_deep_copy
+// Requires: plonk_wasm, caml_pasta_fq_plonk_verifier_index_of_rust, caml_pasta_fq_plonk_verifier_index_to_rust
+var caml_pasta_fq_plonk_verifier_index_deep_copy = function(x) {
+    return caml_pasta_fq_plonk_verifier_index_of_rust(plonk_wasm.caml_pasta_fq_plonk_verifier_index_deep_copy(caml_pasta_fq_plonk_verifier_index_to_rust(x)));
+};
+
+
+// Provides: COLUMNS
+var COLUMNS = 15;
+// Provides: PERMUTS_MINUS_1
+var PERMUTS_MINUS_1 = 6;
+
+// Provides: caml_pasta_fp_proof_evaluations_to_rust
+// Requires: plonk_wasm, caml_fp_vector_to_rust, PERMUTS_MINUS_1, COLUMNS
+var caml_pasta_fp_proof_evaluations_to_rust = function(x) {
+    var w = new plonk_wasm.WasmVecVecFp(COLUMNS);
+    for (var i = 0; i < COLUMNS; ++i) {
+      w.push(caml_fp_vector_to_rust(x[1][i + 1]));
+    }
+
+    var z = caml_fp_vector_to_rust(x[2]);
+
+    var s = new plonk_wasm.WasmVecVecFp(PERMUTS_MINUS_1);
+    for (i = 0; i < PERMUTS_MINUS_1; ++i) {
+      s.push(caml_fp_vector_to_rust(x[3][i + 1]));
+    }
+
+    var generic_selector = caml_fp_vector_to_rust(x[4]);
+    var poseidon_selector = caml_fp_vector_to_rust(x[5]);
+
+    return new plonk_wasm.WasmFpProofEvaluations(w, z, s, generic_selector, poseidon_selector);
+};
+
+// Provides: caml_pasta_fp_proof_evaluations_of_rust
+// Requires: plonk_wasm, caml_fp_vector_of_rust, COLUMNS, PERMUTS_MINUS_1
+var caml_pasta_fp_proof_evaluations_of_rust = function(x) {
+    var convertArray = function(v, n) {
+        var res = [0];
+        for (var i = 0; i < n; ++i) {
+            res.push(caml_fp_vector_of_rust(v.get(i)));
+        }
+        return res;
+    };
+
+    var w = convertArray(x.w, COLUMNS);
+    var z = caml_fp_vector_of_rust(x.z);
+    var s = convertArray(x.s, PERMUTS_MINUS_1);
+    var generic_selector = caml_fp_vector_of_rust(x.generic_selector);
+    var poseidon_selector = caml_fp_vector_of_rust(x.poseidon_selector);
+
+    x.free();
+    return [0, w, z, s, generic_selector, poseidon_selector];
+};
+
+// Provides: caml_pasta_fp_opening_proof_to_rust
+// Requires: plonk_wasm, caml_array_to_rust_vector, rust_affine_of_caml_affine
+var caml_pasta_fp_opening_proof_to_rust = function(x) {
+    var convert_affines = function(affines) {
+        return caml_array_to_rust_vector(affines, rust_affine_of_caml_affine, plonk_wasm.caml_vesta_affine_one);
+    }
+    var lr = x[1];
+    var delta = rust_affine_of_caml_affine(x[2], plonk_wasm.caml_vesta_affine_one);
+    var z1 = x[3];
+    var z2 = x[4];
+    var sg = rust_affine_of_caml_affine(x[5], plonk_wasm.caml_vesta_affine_one);
+    var len = lr.length;
+    // We pass l and r as separate vectors over the FFI
+    var l_ocaml = new Array(len);
+    var r_ocaml = new Array(len);
+    for (var i = 1; i < len; i++) {
+        l_ocaml[i] = lr[i][1];
+        r_ocaml[i] = lr[i][2];
+    }
+    var l = convert_affines(l_ocaml);
+    var r = convert_affines(r_ocaml);
+    return new plonk_wasm.WasmFpOpeningProof(l, r, delta, z1, z2, sg);
+};
+
+// Provides: caml_pasta_fp_opening_proof_of_rust
+// Requires: plonk_wasm, caml_array_of_rust_vector, rust_affine_to_caml_affine
+var caml_pasta_fp_opening_proof_of_rust = function(x) {
+    var convert_affines = function(affines) {
+        return caml_array_of_rust_vector(affines, plonk_wasm.WasmGVesta, rust_affine_to_caml_affine, false);
+    }
+    var l = convert_affines(x.lr_0);
+    var r = convert_affines(x.lr_1);
+    var delta = rust_affine_to_caml_affine(x.delta);
+    var z1 = x.z1;
+    var z2 = x.z2;
+    var sg = rust_affine_to_caml_affine(x.sg);
+    x.free();
+    var len = l.length;
+    if (len !== r.length) { throw new Error("l and r lengths don't match"); }
+    var lr = new Array(len);
+    lr[0] = 0;
+    for (var i = 1; i < len; i++) {
+        var tuple = new Array(3);
+        tuple[0] = 0;
+        tuple[1] = l[i];
+        tuple[2] = r[i];
+        lr[i] = tuple;
+    }
+    return [0, lr, delta, z1, z2, sg];
+};
+
+// Provides: caml_pasta_fp_commitments_to_rust
+// Requires: plonk_wasm, caml_vesta_poly_comm_to_rust, js_class_vector_to_rust_vector
+var caml_pasta_fp_commitments_to_rust = function(x) {
+    var convertArray = function(v) {
+        var n = v.length - 1;
+        var res = new Array(n);
+        for (var i = 0; i < n; ++i) {
+            res[i] = caml_vesta_poly_comm_to_rust(v[i + 1]);
+        }
+        // TODO need to do finalizer things?
+        return js_class_vector_to_rust_vector(res);
+    };
+
+    var w_comm = convertArray(x[1]);
+    var z_comm = caml_vesta_poly_comm_to_rust(x[2]);
+    var t_comm = caml_vesta_poly_comm_to_rust(x[3]);
+    return new plonk_wasm.WasmFpProverCommitments(w_comm, z_comm, t_comm);
+};
+
+// Provides: caml_pasta_fp_commitments_of_rust
+// Requires: caml_vesta_poly_comm_of_rust, js_class_vector_of_rust_vector, plonk_wasm
+var caml_pasta_fp_commitments_of_rust = function(x) {
+    var convertArray = function(v) {
+        var a = js_class_vector_of_rust_vector(v, plonk_wasm.WasmFpPolyComm);
+        var res = [0];
+        for (var i = 0; i < a.length; ++i) {
+            // TODO Check this. Could be off by 1
+            res.push(caml_vesta_poly_comm_of_rust(a[i]))
+        }
+        return res;
+    };
+
+    var w_comm = convertArray(x.w_comm);
+    var z_comm = caml_vesta_poly_comm_of_rust(x.z_comm);
+    var t_comm = caml_vesta_poly_comm_of_rust(x.t_comm);
+    x.free();
+    return [0, w_comm, z_comm, t_comm];
+};
+
+// Provides: caml_pasta_fp_proof_to_rust
+// Requires: plonk_wasm, caml_pasta_fp_commitments_to_rust, caml_pasta_fp_opening_proof_to_rust, caml_pasta_fp_proof_evaluations_to_rust, caml_fp_vector_to_rust, caml_vesta_poly_comm_to_rust, js_class_vector_to_rust_vector
+var caml_pasta_fp_proof_to_rust = function(x) {
+    var commitments = caml_pasta_fp_commitments_to_rust(x[1]);
+    var proof = caml_pasta_fp_opening_proof_to_rust(x[2]);
+    var evals0 = caml_pasta_fp_proof_evaluations_to_rust(x[3][1]);
+    var evals1 = caml_pasta_fp_proof_evaluations_to_rust(x[3][2]);
+    var ft_eval1 = x[4];
+    var public_ = caml_fp_vector_to_rust(x[5]);
+    var prev_challenges = x[6];
+    var chals_len = prev_challenges.length;
+    var prev_challenges_scalars = new plonk_wasm.WasmVecVecFp(chals_len - 1);
+    var prev_challenges_comms = new Array(chals_len-1);
+    for (var i = 1; i < chals_len; i++) {
+        prev_challenges_scalars.push(caml_fp_vector_to_rust(prev_challenges[i][1]));
+        prev_challenges_comms[i-1] = caml_vesta_poly_comm_to_rust(prev_challenges[i][2]);
+    }
+    prev_challenges_comms = js_class_vector_to_rust_vector(prev_challenges_comms);
+    return new plonk_wasm.WasmFpProverProof(commitments, proof, evals0, evals1, ft_eval1, public_, prev_challenges_scalars, prev_challenges_comms);
+};
+
+// Provides: caml_pasta_fp_proof_of_rust
+// Requires: plonk_wasm, caml_pasta_fp_commitments_of_rust, caml_pasta_fp_opening_proof_of_rust, caml_pasta_fp_proof_evaluations_of_rust, caml_fp_vector_of_rust, js_class_vector_of_rust_vector, caml_vesta_poly_comm_of_rust
+var caml_pasta_fp_proof_of_rust = function(x) {
+    var messages = caml_pasta_fp_commitments_of_rust(x.commitments);
+    var proof = caml_pasta_fp_opening_proof_of_rust(x.proof);
+    var evals0 = caml_pasta_fp_proof_evaluations_of_rust(x.evals0);
+    var evals1 = caml_pasta_fp_proof_evaluations_of_rust(x.evals1);
+    var ft_eval1 = x.ft_eval1;
+    var public_ = caml_fp_vector_of_rust(x.public_);
+    var prev_challenges_scalars = x.prev_challenges_scalars;
+    var prev_challenges_comms = js_class_vector_of_rust_vector(x.prev_challenges_comms, plonk_wasm.WasmFpPolyComm);
+    var chals_len = prev_challenges_comms.length;
+    var prev_challenges = new Array(chals_len);
+    prev_challenges[0] = 0;
+    for (var i = 1; i < chals_len; i++) {
+        var res = new Array(3);
+        res[0] = 0;
+        res[1] = caml_fp_vector_of_rust(prev_challenges_scalars.get(i-1));
+        // TODO Check this. Could be off by 1
+        res[2] = caml_vesta_poly_comm_of_rust(prev_challenges_comms[i]);
+        prev_challenges[i] = res;
+    }
+    return [0, messages, proof, [0, evals0, evals1], ft_eval1, public_, prev_challenges];
+};
+
+// Provides: caml_pasta_fp_plonk_proof_create
+// Requires: plonk_wasm, caml_fp_vector_to_rust, caml_array_to_rust_vector, rust_affine_of_caml_affine, caml_pasta_fp_proof_of_rust
+var caml_pasta_fp_plonk_proof_create = function(index, witness_cols, prev_challenges, prev_sgs) {
+    var w = new plonk_wasm.WasmVecVecFp(witness_cols.length-1);
+    for (var i = 1; i < witness_cols.length; i++) {
+      w.push(caml_fp_vector_to_rust(witness_cols[i]));
+    }
+    witness_cols = w;
+    
+    // auxiliary_input = caml_fp_vector_to_rust(auxiliary_input);
+    prev_challenges = caml_fp_vector_to_rust(prev_challenges);
+    prev_sgs = caml_array_to_rust_vector(prev_sgs, rust_affine_of_caml_affine, plonk_wasm.caml_vesta_affine_one);
+    var res = plonk_wasm.caml_pasta_fp_plonk_proof_create(index, witness_cols, prev_challenges, prev_sgs);
+    var proof = caml_pasta_fp_proof_of_rust(res);
+    return proof;
+};
+
+// Provides: caml_pasta_fp_plonk_proof_verify
+// Requires: plonk_wasm, caml_array_to_rust_vector, caml_vesta_poly_comm_to_rust, caml_pasta_fp_plonk_verifier_index_to_rust, caml_pasta_fp_proof_to_rust
+var caml_pasta_fp_plonk_proof_verify = function(lgr_comm, index, proof) {
+    lgr_comm = caml_array_to_rust_vector(lgr_comm, caml_vesta_poly_comm_to_rust);
+    index = caml_pasta_fp_plonk_verifier_index_to_rust(index);
+    proof = caml_pasta_fp_proof_to_rust(proof);
+    return plonk_wasm.caml_pasta_fp_plonk_proof_verify(lgr_comm, index, proof);
+};
+
+// Provides: caml_pasta_fp_plonk_proof_batch_verify
+// Requires: plonk_wasm, caml_array_to_rust_vector, caml_vesta_poly_comm_to_rust, caml_pasta_fp_plonk_verifier_index_to_rust, caml_pasta_fp_proof_to_rust
+var caml_pasta_fp_plonk_proof_batch_verify = function(lgr_comm, indexes, proofs) {
+    var lgr_len = lgr_comm.length;
+    var rust_lgr_comm = new plonk_wasm.WasmVecVecVestaPolyComm(lgr_len-1);
+    for (var i = 1; i < lgr_len; i++) {
+        rust_lgr_comm.push(caml_array_to_rust_vector(lgr_comm[i], caml_vesta_poly_comm_to_rust));
+    }
+    indexes = caml_array_to_rust_vector(indexes, caml_pasta_fp_plonk_verifier_index_to_rust);
+    proofs = caml_array_to_rust_vector(proofs, caml_pasta_fp_proof_to_rust);
+    return plonk_wasm.caml_pasta_fp_plonk_proof_batch_verify(rust_lgr_comm, indexes, proofs);
+};
+
+// Provides: caml_pasta_fp_plonk_proof_dummy
+// Requires: plonk_wasm, caml_pasta_fp_proof_of_rust
+var caml_pasta_fp_plonk_proof_dummy = function() {
+    return caml_pasta_fp_proof_of_rust(plonk_wasm.caml_pasta_fp_plonk_proof_dummy());
+};
+
+// Provides: caml_pasta_fp_plonk_proof_deep_copy
+// Requires: plonk_wasm, caml_pasta_fp_proof_to_rust, caml_pasta_fp_proof_of_rust
+var caml_pasta_fp_plonk_proof_deep_copy = function(proof) {
+    return caml_pasta_fp_proof_of_rust(plonk_wasm.caml_pasta_fp_plonk_proof_deep_copy(caml_pasta_fp_proof_to_rust(proof)));
+};
+
+
+
+
+
+// Provides: caml_pasta_fq_proof_evaluations_to_rust
+// Requires: plonk_wasm, caml_fq_vector_to_rust, PERMUTS_MINUS_1, COLUMNS
+var caml_pasta_fq_proof_evaluations_to_rust = function(x) {
+    var w = new plonk_wasm.WasmVecVecFq(COLUMNS);
+    for (var i = 0; i < COLUMNS; ++i) {
+      w.push(caml_fq_vector_to_rust(x[1][i + 1]));
+    }
+
+    var z = caml_fq_vector_to_rust(x[2]);
+
+    var s = new plonk_wasm.WasmVecVecFq(PERMUTS_MINUS_1);
+    for (i = 0; i < PERMUTS_MINUS_1; ++i) {
+      s.push(caml_fq_vector_to_rust(x[3][i + 1]));
+    }
+
+    var generic_selector = caml_fq_vector_to_rust(x[4]);
+    var poseidon_selector = caml_fq_vector_to_rust(x[5]);
+
+    return new plonk_wasm.WasmFqProofEvaluations(w, z, s, generic_selector, poseidon_selector);
+};
+
+// Provides: caml_pasta_fq_proof_evaluations_of_rust
+// Requires: plonk_wasm, caml_fq_vector_of_rust, COLUMNS, PERMUTS_MINUS_1
+var caml_pasta_fq_proof_evaluations_of_rust = function(x) {
+    var convertArray = function(v, n) {
+        var res = [0];
+        for (var i = 0; i < n; ++i) {
+            res.push(caml_fq_vector_of_rust(v.get(i)));
+        }
+        return res;
+    };
+
+    var w = convertArray(x.w, COLUMNS);
+    var z = caml_fq_vector_of_rust(x.z);
+    var s = convertArray(x.s, PERMUTS_MINUS_1);
+    var generic_selector = caml_fq_vector_of_rust(x.generic_selector);
+    var poseidon_selector = caml_fq_vector_of_rust(x.poseidon_selector);
+
+    x.free();
+    return [0, w, z, s, generic_selector, poseidon_selector];
+};
+
+// Provides: caml_pasta_fq_opening_proof_to_rust
+// Requires: plonk_wasm, caml_array_to_rust_vector, rust_affine_of_caml_affine
+var caml_pasta_fq_opening_proof_to_rust = function(x) {
+    var convert_affines = function(affines) {
+        return caml_array_to_rust_vector(affines, rust_affine_of_caml_affine, plonk_wasm.caml_pallas_affine_one);
+    }
+    var lr = x[1];
+    var delta = rust_affine_of_caml_affine(x[2], plonk_wasm.caml_pallas_affine_one);
+    var z1 = x[3];
+    var z2 = x[4];
+    var sg = rust_affine_of_caml_affine(x[5], plonk_wasm.caml_pallas_affine_one);
+    var len = lr.length;
+    // We pass l and r as separate vectors over the FFI
+    var l_ocaml = new Array(len);
+    var r_ocaml = new Array(len);
+    for (var i = 1; i < len; i++) {
+        l_ocaml[i] = lr[i][1];
+        r_ocaml[i] = lr[i][2];
+    }
+    var l = convert_affines(l_ocaml);
+    var r = convert_affines(r_ocaml);
+    return new plonk_wasm.WasmFqOpeningProof(l, r, delta, z1, z2, sg);
+};
+
+// Provides: caml_pasta_fq_opening_proof_of_rust
+// Requires: plonk_wasm, caml_array_of_rust_vector, rust_affine_to_caml_affine
+var caml_pasta_fq_opening_proof_of_rust = function(x) {
+    var convert_affines = function(affines) {
+        return caml_array_of_rust_vector(affines, plonk_wasm.WasmGPallas, rust_affine_to_caml_affine, false);
+    }
+    var l = convert_affines(x.lr_0);
+    var r = convert_affines(x.lr_1);
+    var delta = rust_affine_to_caml_affine(x.delta);
+    var z1 = x.z1;
+    var z2 = x.z2;
+    var sg = rust_affine_to_caml_affine(x.sg);
+    x.free();
+    var len = l.length;
+    if (len !== r.length) { throw new Error("l and r lengths don't match"); }
+    var lr = new Array(len);
+    lr[0] = 0;
+    for (var i = 1; i < len; i++) {
+        var tuple = new Array(3);
+        tuple[0] = 0;
+        tuple[1] = l[i];
+        tuple[2] = r[i];
+        lr[i] = tuple;
+    }
+    return [0, lr, delta, z1, z2, sg];
+};
+
+// Provides: caml_pasta_fq_commitments_to_rust
+// Requires: plonk_wasm, caml_pallas_poly_comm_to_rust, js_class_vector_to_rust_vector
+var caml_pasta_fq_commitments_to_rust = function(x) {
+    var convertArray = function(v) {
+      var n = v.length - 1;
+      var res = new Array(n);
+      for (var i = 0; i < n; ++i) {
+        res[i] = caml_pallas_poly_comm_to_rust(v[i + 1]);
+      }
+      return js_class_vector_to_rust_vector(res);
+    };
+
+    var w_comm = convertArray(x[1]);
+    var z_comm = caml_pallas_poly_comm_to_rust(x[2]);
+    var t_comm = caml_pallas_poly_comm_to_rust(x[3]);
+    return new plonk_wasm.WasmFqProverCommitments(w_comm, z_comm, t_comm);
+};
+
+// Provides: caml_pasta_fq_commitments_of_rust
+// Requires: caml_pallas_poly_comm_of_rust, js_class_vector_of_rust_vector, plonk_wasm
+var caml_pasta_fq_commitments_of_rust = function(x) {
+    var convertArray = function(v) {
+      var a = js_class_vector_of_rust_vector(v, plonk_wasm.WasmFqPolyComm);
+      var res = [0];
+      for (var i = 0; i < a.length; ++i) {
+        // TODO Check this. Could be off by 1
+        res.push(caml_pallas_poly_comm_of_rust(a[i]))
+      }
+      return res;
+    };
+
+    var w_comm = convertArray(x.w_comm);
+    var z_comm = caml_pallas_poly_comm_of_rust(x.z_comm);
+    var t_comm = caml_pallas_poly_comm_of_rust(x.t_comm);
+    x.free();
+    return [0, w_comm, z_comm, t_comm];
+};
+
+// Provides: caml_pasta_fq_proof_to_rust
+// Requires: plonk_wasm, caml_pasta_fq_commitments_to_rust, caml_pasta_fq_opening_proof_to_rust, caml_pasta_fq_proof_evaluations_to_rust, caml_fq_vector_to_rust, caml_pallas_poly_comm_to_rust, js_class_vector_to_rust_vector
+var caml_pasta_fq_proof_to_rust = function(x) {
+    var messages = caml_pasta_fq_commitments_to_rust(x[1]);
+    var proof = caml_pasta_fq_opening_proof_to_rust(x[2]);
+    var evals0 = caml_pasta_fq_proof_evaluations_to_rust(x[3][1]);
+    var evals1 = caml_pasta_fq_proof_evaluations_to_rust(x[3][2]);
+    var ft_eval1 = x[4];
+    var public_ = caml_fq_vector_to_rust(x[5]);
+    var prev_challenges = x[6];
+    var chals_len = prev_challenges.length;
+    var prev_challenges_scalars = new plonk_wasm.WasmVecVecFq(chals_len - 1);
+    var prev_challenges_comms = new Array(chals_len-1);
+    for (var i = 1; i < chals_len; i++) {
+        prev_challenges_scalars.push(caml_fq_vector_to_rust(prev_challenges[i][1]));
+        prev_challenges_comms[i-1] = caml_pallas_poly_comm_to_rust(prev_challenges[i][2]);
+    }
+    prev_challenges_comms = js_class_vector_to_rust_vector(prev_challenges_comms);
+    return new plonk_wasm.WasmFqProverProof(messages, proof, evals0, evals1, ft_eval1, public_, prev_challenges_scalars, prev_challenges_comms);
+};
+
+// Provides: caml_pasta_fq_proof_of_rust
+// Requires: plonk_wasm, caml_pasta_fq_commitments_of_rust, caml_pasta_fq_opening_proof_of_rust, caml_pasta_fq_proof_evaluations_of_rust, caml_fq_vector_of_rust, js_class_vector_of_rust_vector, caml_pallas_poly_comm_of_rust
+var caml_pasta_fq_proof_of_rust = function(x) {
+    var messages = caml_pasta_fq_commitments_of_rust(x.commitments);
+    var proof = caml_pasta_fq_opening_proof_of_rust(x.proof);
+    var evals0 = caml_pasta_fq_proof_evaluations_of_rust(x.evals0);
+    var evals1 = caml_pasta_fq_proof_evaluations_of_rust(x.evals1);
+    var ft_eval1 = x.ft_eval1;
+    var public_ = caml_fq_vector_of_rust(x.public_);
+    var prev_challenges_scalars = x.prev_challenges_scalars;
+    var prev_challenges_comms = js_class_vector_of_rust_vector(x.prev_challenges_comms, plonk_wasm.WasmFqPolyComm);
+    var chals_len = prev_challenges_comms.length;
+    var prev_challenges = new Array(chals_len);
+    prev_challenges[0] = 0;
+    for (var i = 1; i < chals_len; i++) {
+        var res = new Array(3);
+        res[0] = 0;
+        res[1] = caml_fq_vector_of_rust(prev_challenges_scalars.get(i-1));
+        res[2] = caml_pallas_poly_comm_of_rust(prev_challenges_comms[i]);
+        prev_challenges[i] = res;
+    }
+    return [0, messages, proof, [0, evals0, evals1], ft_eval1, public_, prev_challenges];
+};
+
+// Provides: caml_pasta_fq_plonk_proof_create
+// Requires: plonk_wasm, caml_fq_vector_to_rust, caml_array_to_rust_vector, rust_affine_of_caml_affine, caml_pasta_fq_proof_of_rust
+var caml_pasta_fq_plonk_proof_create = function(index, primary_input, auxiliary_input, prev_challenges, prev_sgs) {
+    primary_input = caml_fq_vector_to_rust(primary_input);
+    auxiliary_input = caml_fq_vector_to_rust(auxiliary_input);
+    prev_challenges = caml_fq_vector_to_rust(prev_challenges);
+    prev_sgs = caml_array_to_rust_vector(prev_sgs, rust_affine_of_caml_affine, plonk_wasm.caml_pallas_affine_one);
+    var res = plonk_wasm.caml_pasta_fq_plonk_proof_create(index, primary_input, auxiliary_input, prev_challenges, prev_sgs);
+    return caml_pasta_fq_proof_of_rust(res);
+};
+
+// Provides: caml_pasta_fq_plonk_proof_verify
+// Requires: plonk_wasm, caml_array_to_rust_vector, caml_pallas_poly_comm_to_rust, caml_pasta_fq_plonk_verifier_index_to_rust, caml_pasta_fq_proof_to_rust
+var caml_pasta_fq_plonk_proof_verify = function(lgr_comm, index, proof) {
+    lgr_comm = caml_array_to_rust_vector(lgr_comm, caml_pallas_poly_comm_to_rust);
+    index = caml_pasta_fq_plonk_verifier_index_to_rust(index);
+    proof = caml_pasta_fq_proof_to_rust(proof);
+    return plonk_wasm.caml_pasta_fq_plonk_proof_verify(lgr_comm, index, proof);
+};
+
+// Provides: caml_pasta_fq_plonk_proof_batch_verify
+// Requires: plonk_wasm, caml_array_to_rust_vector, caml_pallas_poly_comm_to_rust, caml_pasta_fq_plonk_verifier_index_to_rust, caml_pasta_fq_proof_to_rust
+var caml_pasta_fq_plonk_proof_batch_verify = function(lgr_comm, indexes, proofs) {
+    var lgr_len = lgr_comm.length;
+    var rust_lgr_comm = new plonk_wasm.WasmVecVecPallasPolyComm(lgr_len-1);
+    for (var i = 1; i < lgr_len; i++) {
+        rust_lgr_comm.push(caml_array_to_rust_vector(lgr_comm[i], caml_pallas_poly_comm_to_rust));
+    }
+    indexes = caml_array_to_rust_vector(indexes, caml_pasta_fq_plonk_verifier_index_to_rust);
+    proofs = caml_array_to_rust_vector(proofs, caml_pasta_fq_proof_to_rust);
+    return plonk_wasm.caml_pasta_fq_plonk_proof_batch_verify(rust_lgr_comm, indexes, proofs);
+};
+
+// Provides: caml_pasta_fq_plonk_proof_dummy
+// Requires: plonk_wasm, caml_pasta_fq_proof_of_rust
+var caml_pasta_fq_plonk_proof_dummy = function() {
+    return caml_pasta_fq_proof_of_rust(plonk_wasm.caml_pasta_fq_plonk_proof_dummy());
+};
+
+// Provides: caml_pasta_fq_plonk_proof_deep_copy
+// Requires: plonk_wasm, caml_pasta_fq_proof_to_rust, caml_pasta_fq_proof_of_rust
+var caml_pasta_fq_plonk_proof_deep_copy = function(proof) {
+    return caml_pasta_fq_proof_of_rust(plonk_wasm.caml_pasta_fq_plonk_proof_deep_copy(caml_pasta_fq_proof_to_rust(proof)));
+};
+
+
+
+
+
+// Provides: caml_random_oracles_of_rust
+// Requires: caml_u8array_vector_of_rust_flat_vector
+var caml_random_oracles_of_rust = function(x) {
+    return [0,
+      [0, [0, x.joint_combiner_chal], x.joint_combiner],
+      x.beta,
+      x.gamma,
+      [0, x.alpha_chal],
+      x.alpha,
+      x.zeta,
+      x.v,
+      x.u,
+      [0, x.zeta_chal],
+      [0, x.v_chal],
+      [0, x.u_chal]];
+};
+
+// Provides: caml_random_oracles_to_rust
+// Requires: caml_u8array_vector_to_rust_flat_vector
+var caml_random_oracles_to_rust = function(x, roKlass) {
+    // var caml_vector = [0, x[1], x[2], x[3][1], x[4], x[5], x[6], x[7], x[8][1], x[9][1], x[10][1]];
+    return new roKlass(
+      x[1][1][1],
+      x[1][2],
+      x[2],
+      x[3],
+      x[4][1],
+      x[5],
+      x[6],
+      x[7],
+      x[8],
+      x[9][1],
+      x[10][1],
+      x[11][1]);
+};
+
+// Provides: caml_oracles_of_rust
+// Requires: caml_u8array_vector_of_rust_flat_vector, caml_random_oracles_of_rust
+var caml_oracles_of_rust = function(x) {
+    return [0, caml_random_oracles_of_rust(x.o), [0, x.p_eval0, x.p_eval1], caml_u8array_vector_of_rust_flat_vector(x.opening_prechallenges, 32 /* TODO: Don't hardcode */), x.digest_before_evaluations];
+};
+
+// Provides: caml_oracles_to_rust
+// Requires: caml_u8array_vector_to_rust_flat_vector, caml_random_oracles_to_rust
+var caml_oracles_to_rust = function(x, klass, roKlass) {
+    return new klass(
+        caml_random_oracles_to_rust(x[1], roKlass),
+        x[2][1],
+        x[2][2],
+        caml_u8array_vector_to_rust_flat_vector(x[3]),
+        x[4]
+    );
+};
+
+
+
+
+
+// Provides: caml_pasta_fp_plonk_oracles_create
+// Requires: plonk_wasm, caml_oracles_of_rust, caml_array_to_rust_vector, caml_vesta_poly_comm_to_rust, caml_pasta_fp_plonk_verifier_index_to_rust, caml_pasta_fp_proof_to_rust
+var caml_pasta_fp_plonk_oracles_create = function(lgr_comm, verifier_index, proof) {
+    return caml_oracles_of_rust(plonk_wasm.caml_pasta_fp_plonk_oracles_create(
+        caml_array_to_rust_vector(lgr_comm, caml_vesta_poly_comm_to_rust),
+        caml_pasta_fp_plonk_verifier_index_to_rust(verifier_index),
+        caml_pasta_fp_proof_to_rust(proof)
+    ));
+};
+
+// Provides: caml_pasta_fp_plonk_oracles_dummy
+// Requires: plonk_wasm, caml_oracles_of_rust
+var caml_pasta_fp_plonk_oracles_dummy = function() {
+    return caml_oracles_of_rust(plonk_wasm.caml_pasta_fp_plonk_oracles_dummy());
+};
+
+// Provides: caml_pasta_fp_plonk_oracles_deep_copy
+// Requires: plonk_wasm, caml_oracles_of_rust, caml_oracles_to_rust
+var caml_pasta_fp_plonk_oracles_deep_copy = function(x) {
+    return caml_oracles_of_rust(plonk_wasm.caml_pasta_fp_plonk_oracles_deep_copy(
+      caml_oracles_to_rust(x, plonk_wasm.WasmFpOracles, plonk_wasm.WasmFpRandomOracles)));
+};
+
+
+
+
+
+// Provides: caml_pasta_fq_plonk_oracles_create
+// Requires: plonk_wasm, caml_oracles_of_rust, caml_array_to_rust_vector, caml_pallas_poly_comm_to_rust, caml_pasta_fq_plonk_verifier_index_to_rust, caml_pasta_fq_proof_to_rust
+var caml_pasta_fq_plonk_oracles_create = function(lgr_comm, verifier_index, proof) {
+    return caml_oracles_of_rust(plonk_wasm.caml_pasta_fq_plonk_oracles_create(
+        caml_array_to_rust_vector(lgr_comm, caml_pallas_poly_comm_to_rust),
+        caml_pasta_fq_plonk_verifier_index_to_rust(verifier_index),
+        caml_pasta_fq_proof_to_rust(proof)
+    ));
+};
+
+// Provides: caml_pasta_fq_plonk_oracles_dummy
+// Requires: plonk_wasm, caml_oracles_of_rust
+var caml_pasta_fq_plonk_oracles_dummy = function() {
+    return caml_oracles_of_rust(plonk_wasm.caml_pasta_fq_plonk_oracles_dummy());
+};
+
+// Provides: caml_pasta_fq_plonk_oracles_deep_copy
+// Requires: plonk_wasm, caml_oracles_of_rust, caml_oracles_to_rust
+var caml_pasta_fq_plonk_oracles_deep_copy = function(x) {
+    return caml_oracles_of_rust(
+      plonk_wasm.caml_pasta_fq_plonk_oracles_deep_copy(
+        caml_oracles_to_rust(x, plonk_wasm.WasmFqOracles, plonk_wasm.WasmFqRandomOracles)));
+};
+
+
+// TODO
+// Provides: caml_pasta_fp_poseidon_params_create
+function caml_pasta_fp_poseidon_params_create() {
+    return [0];
+}
+
+// Provides: caml_pasta_fp_poseidon_block_cipher
+function caml_pasta_fp_poseidon_block_cipher(_params, field_vector) {
+    
+}

--- a/src/lib/crypto/kimchi_bindings/js/chrome/chrome_backend.js
+++ b/src/lib/crypto/kimchi_bindings/js/chrome/chrome_backend.js
@@ -1,0 +1,2 @@
+// Provides: plonk_wasm
+var plonk_wasm = joo_global_object.plonk_wasm;

--- a/src/lib/crypto/kimchi_bindings/js/chrome/dune
+++ b/src/lib/crypto/kimchi_bindings/js/chrome/dune
@@ -1,0 +1,28 @@
+(library
+ (name chrome_backend)
+ (js_of_ocaml
+  (flags (:include flags.sexp))
+  (javascript_files chrome_backend.js))
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version js_of_ocaml-ppx)))
+
+(rule
+ (targets
+   plonk_wasm_bg.wasm.d.ts
+   plonk_wasm_bg.wasm
+   plonk_wasm.d.ts
+   plonk_wasm.js
+   flags.sexp
+   snippets/)
+ (deps
+  (source_tree ../../wasm)
+  (source_tree ../../wasm/.cargo/config)
+  (source_tree ../../../../../external/wasm-bindgen-rayon) )
+ (action
+  (progn
+   (run chmod -R +w ../../wasm)
+   (setenv
+     RUSTFLAGS
+     "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--no-check-features -C link-arg=--max-memory=4294967296"
+    (run rustup run nightly-2021-10-31 wasm-pack build --target web --out-dir ../js/chrome ../../wasm -- -Z build-std=panic_abort,std))
+   (write-file flags.sexp "()"))))

--- a/src/lib/crypto/kimchi_bindings/js/dune
+++ b/src/lib/crypto/kimchi_bindings/js/dune
@@ -1,0 +1,5 @@
+(library
+ (name bindings_js)
+ (js_of_ocaml (javascript_files bindings.js))
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version)))

--- a/src/lib/crypto/kimchi_bindings/js/node_js/dune
+++ b/src/lib/crypto/kimchi_bindings/js/node_js/dune
@@ -1,0 +1,27 @@
+(library
+ (name node_backend)
+ (js_of_ocaml
+  (flags (:include flags.sexp))
+  (javascript_files node_backend.js))
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version js_of_ocaml-ppx)))
+
+(rule
+ (targets
+   plonk_wasm_bg.wasm.d.ts
+   plonk_wasm_bg.wasm
+   plonk_wasm.d.ts
+   plonk_wasm.js
+   flags.sexp)
+ (deps
+  (source_tree ../../wasm)
+  (source_tree ../../wasm/.cargo/config)
+  (source_tree ../../../../../external/wasm-bindgen-rayon) )
+ (action
+  (progn
+   (run chmod -R +w ../../wasm)
+   (setenv
+     RUSTFLAGS
+     "-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--no-check-features -C link-arg=--max-memory=4294967296"
+    (run rustup run nightly-2021-10-31 wasm-pack build --target nodejs --out-dir ../js/node_js ../../wasm -- -Z build-std=panic_abort,std --features nodejs))
+   (write-file flags.sexp "()"))))

--- a/src/lib/crypto/kimchi_bindings/js/node_js/node_backend.js
+++ b/src/lib/crypto/kimchi_bindings/js/node_js/node_backend.js
@@ -1,0 +1,114 @@
+/* workerHelpers.no-modules.js */
+
+/**
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Provides: worker_threads
+var worker_threads = require("worker_threads");
+
+// Note: this is never used, but necessary to prevent a bug in Firefox
+// (https://bugzilla.mozilla.org/show_bug.cgi?id=1702191) where it collects
+// Web Workers that have a shared WebAssembly memory with the main thread,
+// but are not explicitly rooted via a `Worker` instance.
+//
+// By storing them in a variable, we can keep `Worker` objects around and
+// prevent them from getting GC-d.
+
+// Provides: _workers
+var _workers;
+
+// Provides: wasm_ready
+// Requires: worker_threads
+var wasm_ready = function(wasm) {
+    worker_threads.parentPort.postMessage({ type: 'wasm_bindgen_worker_ready' });
+    wasm.wbg_rayon_start_worker(worker_threads.workerData.receiver);
+};
+
+// Provides: startWorkers
+// Requires: worker_threads, _workers, caml_js_export_var
+var startWorkers = (function() {
+    var snarky_ready_resolve;
+    caml_js_export_var().snarky_ready =
+        new joo_global_object.Promise(function(resolve) {
+            snarky_ready_resolve = resolve;
+        });
+    return function(worker_source, memory, builder) {
+        joo_global_object.wasm_workers = [];
+        joo_global_object.wasm_rayon_poolbuilder = builder;
+        return joo_global_object.Promise.all(
+            Array.from({ length: builder.numThreads() }, function() {
+                // Self-spawn into a new Worker.
+                // The script is fetched as a blob so it works even if this script is
+                // hosted remotely (e.g. on a CDN). This avoids a cross-origin
+                // security error.
+                var worker = new worker_threads.Worker(worker_source, {
+                    workerData: {memory: memory, receiver: builder.receiver()}
+                });
+                joo_global_object.wasm_workers.push(worker);
+                var target = worker;
+                var type = 'wasm_bindgen_worker_ready';
+                return new joo_global_object.Promise(function(resolve) {
+                    var done = false;
+                    target.on('message', function onMsg(data) {
+                        if (data == null || data.type !== type || done) return;
+                        done = true;
+                        resolve(worker);
+                    });
+                });
+            })
+        ).then(function(data) {
+            snarky_ready_resolve();
+            _workers = data;
+            try { builder.build(); }
+            catch (_e) {
+                // We 'mute' this error here, since it can only ever throw when
+                // there is something wrong with the rayon subsystem in WASM, and
+                // we deliberately introduce such a problem by destroying builder
+                // when we want to shutdown the process (and thus need to kill the
+                // child threads). The error here won't be useful to developers
+                // using the library.
+            }
+        });
+    };
+})();
+
+/* node_backend.js */
+
+// Provides: plonk_wasm
+// Requires: worker_threads, startWorkers, wasm_ready
+var plonk_wasm = (function() {
+    // Expose this globally so that it can be referenced from WASM.
+    joo_global_object.startWorkers = startWorkers;
+    var env = require("env");
+    if (worker_threads.isMainThread) {
+        env.memory =
+            new joo_global_object.WebAssembly.Memory({
+                initial: 20,
+                maximum: 65536,
+                shared: true});
+        joo_global_object.startWorkers = startWorkers;
+    } else {
+        env.memory = worker_threads.workerData.memory;
+    }
+    var plonk_wasm = require("./plonk_wasm.js");
+    // TODO: This shouldn't live here.
+    // TODO: js_of_ocaml is unhappy about __filename here, but it's in the
+    // global scope, yet not attached to the global object, so we can't access
+    // it differently.
+    if (worker_threads.isMainThread) {
+        plonk_wasm.initThreadPool(3, __filename);
+    } else {
+        wasm_ready(plonk_wasm);
+    }
+    return plonk_wasm;
+})();

--- a/src/lib/crypto/kimchi_bindings/js/test/bindings_js_test.ml
+++ b/src/lib/crypto/kimchi_bindings/js/test/bindings_js_test.ml
@@ -1,0 +1,1243 @@
+open Marlin_plonk_bindings
+open Js_of_ocaml
+
+(* NOTE: For nodejs, we need to manually add the following line to the javascript bindings, after imports['env'] has been declared.
+imports['env']['memory'] = new WebAssembly.Memory({initial: 18, maximum: 16384, shared: true});
+*)
+
+type a = { a : int; b : bool; c : int option option }
+
+type b = A | B | C | D | Aplus of b | Bplus of int | Cplus of bool
+
+let _ =
+  Js.export "testing"
+    (object%js (_self)
+       method a = { a = 15; b = true; c = Some (Some 125) }
+
+       method b = { a = 20; b = false; c = Some None }
+
+       method c = { a = 25; b = false; c = None }
+
+       method create i =
+         match i with
+         | 0 ->
+             A
+         | 1 ->
+             B
+         | 2 ->
+             C
+         | 3 ->
+             D
+         | 4 ->
+             Aplus A
+         | 5 ->
+             Aplus (Aplus (Aplus (Bplus 15)))
+         | 6 ->
+             Bplus 20
+         | 7 ->
+             Cplus true
+         | _ ->
+             A
+
+       method returnString = "String"
+
+       method returnString2 =
+         String.concat "" [ "String1"; "String2"; "String3" ]
+
+       method returnBytes = Bytes.of_string "Bytes"
+
+       method returnStringAll =
+         let bytes = Bytes.make 256 ' ' in
+         let rec go i =
+           if i < 256 then (
+             Bytes.set bytes i (Char.chr i) ;
+             go (i + 1) )
+         in
+         go 0 ; Bytes.to_string bytes
+
+       method bytesOfJsString x = Js.to_string x |> Bytes.of_string
+
+       method bytesToJsString x = Bytes.to_string x |> Js.string
+    end)
+
+let _ =
+  let open Bigint_256 in
+  Js.export "bigint_256"
+    (object%js (_self)
+       method ofNumeral x _len base = of_numeral x _len base
+
+       method ofDecimalString x = of_decimal_string x
+
+       method numLimbs = num_limbs ()
+
+       method bytesPerLimb = bytes_per_limb ()
+
+       method div x y = div x y
+
+       method compare x y = compare x y
+
+       method print x = print x
+
+       method toString x = to_string x
+
+       method testBit x i = test_bit x i
+
+       method toBytes x = to_bytes x
+
+       method ofBytes x = of_bytes x
+
+       method deepCopy x = deep_copy x
+    end)
+
+let _ =
+  let open Pasta_fp in
+  Js.export "pasta_fp"
+    (object%js (_self)
+       method sizeInBits = size_in_bits ()
+
+       method size = size ()
+
+       method add x y = add x y
+
+       method sub x y = sub x y
+
+       method negate x = negate x
+
+       method mul x y = mul x y
+
+       method div x y = div x y
+
+       method inv x = inv x
+
+       method square x = square x
+
+       method sqrt x = sqrt x
+
+       method ofInt x = of_int x
+
+       method toString x = to_string x
+
+       method ofString x = of_string x
+
+       method print x = print x
+
+       method copy x y = copy ~over:x y
+
+       method mutAdd x y = mut_add x ~other:y
+
+       method mutSub x y = mut_sub x ~other:y
+
+       method mutMul x y = mut_sub x ~other:y
+
+       method mutSquare x = mut_square x
+
+       method compare x y = compare x y
+
+       method equal x y = equal x y
+
+       method random = random ()
+
+       method rng i = rng i
+
+       method toBigint x = to_bigint x
+
+       method ofBigint x = of_bigint x
+
+       method twoAdicRootOfUnity = two_adic_root_of_unity ()
+
+       method domainGenerator i = domain_generator i
+
+       method toBytes x = to_bytes x
+
+       method ofBytes x = of_bytes x
+
+       method deepCopy x = deep_copy x
+    end)
+
+let _ =
+  let open Pasta_fq in
+  Js.export "pasta_fq"
+    (object%js (_self)
+       method sizeInBits = size_in_bits ()
+
+       method size = size ()
+
+       method add x y = add x y
+
+       method sub x y = sub x y
+
+       method negate x = negate x
+
+       method mul x y = mul x y
+
+       method div x y = div x y
+
+       method inv x = inv x
+
+       method square x = square x
+
+       method sqrt x = sqrt x
+
+       method ofInt x = of_int x
+
+       method toString x = to_string x
+
+       method ofString x = of_string x
+
+       method print x = print x
+
+       method copy x y = copy ~over:x y
+
+       method mutAdd x y = mut_add x ~other:y
+
+       method mutSub x y = mut_sub x ~other:y
+
+       method mutMul x y = mut_sub x ~other:y
+
+       method mutSquare x = mut_square x
+
+       method compare x y = compare x y
+
+       method equal x y = equal x y
+
+       method random = random ()
+
+       method rng i = rng i
+
+       method toBigint x = to_bigint x
+
+       method ofBigint x = of_bigint x
+
+       method twoAdicRootOfUnity = two_adic_root_of_unity ()
+
+       method domainGenerator i = domain_generator i
+
+       method toBytes x = to_bytes x
+
+       method ofBytes x = of_bytes x
+
+       method deepCopy x = deep_copy x
+    end)
+
+let _ =
+  let open Bigint_256 in
+  Js.export "bigint_256_test"
+    (object%js (_self)
+       method run =
+         let ten = of_numeral "A" 1 16 in
+         let two = of_numeral "10" 2 2 in
+         let five = of_numeral "5" 1 10 in
+         let six = of_decimal_string "6" in
+         let num_limbs = num_limbs () in
+         let bytes_per_limb = bytes_per_limb () in
+         assert (num_limbs * bytes_per_limb * 8 = 256) ;
+         let two_again = div ten five in
+         assert (compare ten two > 0) ;
+         assert (compare two ten < 0) ;
+         assert (compare two two = 0) ;
+         assert (compare two two_again = 0) ;
+         print ten ;
+         assert (String.equal (to_string ten) "10") ;
+         assert (String.equal (to_string two_again) "2") ;
+         assert (test_bit five 0) ;
+         assert (not (test_bit five 1)) ;
+         assert (test_bit five 2) ;
+         let ten_bytes = to_bytes ten in
+         assert (compare (of_bytes ten_bytes) ten = 0) ;
+         assert (compare (deep_copy six) six = 0)
+    end)
+
+let _ =
+  let open Pasta_fp in
+  Js.export "pasta_fp_test"
+    (object%js (_self)
+       method run =
+         let size_in_bits = size_in_bits () in
+         assert (size_in_bits = 255) ;
+         let size = size () in
+         assert (
+           String.equal
+             (Bigint_256.to_string size)
+             "28948022309329048855892746252171976963363056481941560715954676764349967630337"
+         ) ;
+         let one = of_int 1 in
+         let two = of_string "2" in
+         let rand1 = random () in
+         let rand2 = rng 15 in
+         let ten = of_bigint (Bigint_256.of_decimal_string "10") in
+         let eleven = of_bigint (Bigint_256.of_decimal_string "11") in
+         let twenty_one = add ten eleven in
+         let one_again = sub eleven ten in
+         let twenty = mul two ten in
+         let five = div ten two in
+         assert (String.equal (to_string twenty_one) "21") ;
+         assert (String.equal (to_string one_again) "1") ;
+         assert (String.equal (to_string twenty) "20") ;
+         assert (String.equal (to_string five) "5") ;
+         assert (equal (of_string "5") five) ;
+         assert (equal (of_string (to_string five)) five) ;
+         assert (
+           equal twenty_one
+             ( match sqrt (square twenty_one) with
+             | Some x ->
+                 x
+             | None ->
+                 assert false ) ) ;
+         print twenty_one ;
+         copy ~over:eleven twenty_one ;
+         assert (equal eleven twenty_one) ;
+         assert (String.equal (to_string eleven) "21") ;
+         mut_add one_again ~other:ten ;
+         assert (String.equal (to_string one_again) "11") ;
+         mut_sub one_again ~other:one ;
+         assert (String.equal (to_string one_again) "10") ;
+         mut_mul one_again ~other:ten ;
+         assert (String.equal (to_string one_again) "100") ;
+         mut_square one_again ;
+         assert (String.equal (to_string one_again) "10000") ;
+         assert (equal (of_bigint (to_bigint rand1)) rand1) ;
+         assert (compare (of_bigint (to_bigint rand1)) rand1 = 0) ;
+         assert (compare one ten < 0) ;
+         assert (compare ten one > 0) ;
+         let root_of_unity = two_adic_root_of_unity () in
+         assert (equal (of_bytes (to_bytes root_of_unity)) root_of_unity) ;
+         let gen = domain_generator 2 in
+         assert (equal (of_bytes (to_bytes gen)) gen) ;
+         assert (equal (deep_copy rand2) rand2)
+    end)
+
+let _ =
+  let open Pasta_fq in
+  Js.export "pasta_fq_test"
+    (object%js (_self)
+       method run =
+         let size_in_bits = size_in_bits () in
+         assert (size_in_bits = 255) ;
+         let size = size () in
+         assert (
+           String.equal
+             (Bigint_256.to_string size)
+             "28948022309329048855892746252171976963363056481941647379679742748393362948097"
+         ) ;
+         let one = of_int 1 in
+         let two = of_string "2" in
+         let rand1 = random () in
+         let rand2 = rng 15 in
+         let ten = of_bigint (Bigint_256.of_decimal_string "10") in
+         let eleven = of_bigint (Bigint_256.of_decimal_string "11") in
+         let twenty_one = add ten eleven in
+         let one_again = sub eleven ten in
+         let twenty = mul two ten in
+         let five = div ten two in
+         assert (String.equal (to_string twenty_one) "21") ;
+         assert (String.equal (to_string one_again) "1") ;
+         assert (String.equal (to_string twenty) "20") ;
+         assert (String.equal (to_string five) "5") ;
+         assert (equal (of_string "5") five) ;
+         assert (equal (of_string (to_string five)) five) ;
+         assert (
+           equal twenty_one
+             ( match sqrt (square twenty_one) with
+             | Some x ->
+                 x
+             | None ->
+                 assert false ) ) ;
+         print twenty_one ;
+         copy ~over:eleven twenty_one ;
+         assert (equal eleven twenty_one) ;
+         assert (String.equal (to_string eleven) "21") ;
+         mut_add one_again ~other:ten ;
+         assert (String.equal (to_string one_again) "11") ;
+         mut_sub one_again ~other:one ;
+         assert (String.equal (to_string one_again) "10") ;
+         mut_mul one_again ~other:ten ;
+         assert (String.equal (to_string one_again) "100") ;
+         mut_square one_again ;
+         assert (String.equal (to_string one_again) "10000") ;
+         assert (equal (of_bigint (to_bigint rand1)) rand1) ;
+         assert (compare (of_bigint (to_bigint rand1)) rand1 = 0) ;
+         assert (compare one ten < 0) ;
+         assert (compare ten one > 0) ;
+         let root_of_unity = two_adic_root_of_unity () in
+         assert (equal (of_bytes (to_bytes root_of_unity)) root_of_unity) ;
+         let gen = domain_generator 2 in
+         assert (equal (of_bytes (to_bytes gen)) gen) ;
+         assert (equal (deep_copy rand2) rand2)
+    end)
+
+let _ =
+  let open Pasta_fp_vector in
+  Js.export "pasta_fp_vector_test"
+    (object%js (_self)
+       method run =
+         let first = create () in
+         let second = create () in
+         assert (length first = 0) ;
+         assert (length second = 0) ;
+         assert (not (first == second)) ;
+         emplace_back first (Pasta_fp.of_int 0) ;
+         assert (length first = 1) ;
+         assert (length second = 0) ;
+         emplace_back second (Pasta_fp.of_int 1) ;
+         assert (length first = 1) ;
+         assert (length second = 1) ;
+         emplace_back first (Pasta_fp.of_int 10) ;
+         assert (length first = 2) ;
+         assert (length second = 1) ;
+         emplace_back first (Pasta_fp.of_int 30) ;
+         assert (length first = 3) ;
+         assert (length second = 1) ;
+         assert (Pasta_fp.equal (Pasta_fp.of_int 0) (get first 0)) ;
+         assert (Pasta_fp.equal (Pasta_fp.of_int 10) (get first 1)) ;
+         assert (Pasta_fp.equal (Pasta_fp.of_int 30) (get first 2)) ;
+         assert (Pasta_fp.equal (Pasta_fp.of_int 1) (get second 0))
+    end)
+
+let _ =
+  let open Pasta_fq_vector in
+  Js.export "pasta_fq_vector_test"
+    (object%js (_self)
+       method run =
+         let first = create () in
+         let second = create () in
+         assert (length first = 0) ;
+         assert (length second = 0) ;
+         assert (not (first == second)) ;
+         emplace_back first (Pasta_fq.of_int 0) ;
+         assert (length first = 1) ;
+         assert (length second = 0) ;
+         emplace_back second (Pasta_fq.of_int 1) ;
+         assert (length first = 1) ;
+         assert (length second = 1) ;
+         emplace_back first (Pasta_fq.of_int 10) ;
+         assert (length first = 2) ;
+         assert (length second = 1) ;
+         emplace_back first (Pasta_fq.of_int 30) ;
+         assert (length first = 3) ;
+         assert (length second = 1) ;
+         assert (Pasta_fq.equal (Pasta_fq.of_int 0) (get first 0)) ;
+         assert (Pasta_fq.equal (Pasta_fq.of_int 10) (get first 1)) ;
+         assert (Pasta_fq.equal (Pasta_fq.of_int 30) (get first 2)) ;
+         assert (Pasta_fq.equal (Pasta_fq.of_int 1) (get second 0))
+    end)
+
+let eq_affine ~field_equal x y =
+  match (x, y) with
+  | Types.Or_infinity.Infinity, Types.Or_infinity.Infinity ->
+      true
+  | Types.Or_infinity.Finite (x1, y1), Types.Or_infinity.Finite (x2, y2) ->
+      field_equal x1 x2 && field_equal y1 y2
+  | _ ->
+      false
+
+let _ =
+  let open Pasta_pallas in
+  Js.export "pasta_pallas_test"
+    (object%js (_self)
+       method run =
+         let eq x y = eq_affine ~field_equal:Pasta_fp.equal x y in
+         let one_ = one () in
+         let two = add one_ one_ in
+         let infinity = sub one_ one_ in
+         let one_again = sub two one_ in
+         let neg_one = negate one_ in
+         let two_again = double one_ in
+         let two_again_ = scale one_ (Pasta_fq.of_int 2) in
+         let rand1 = random () in
+         let rand2 = rng 15 in
+         let affine_one = to_affine one_ in
+         let affine_two = to_affine two in
+         assert (not (eq affine_one affine_two)) ;
+         let affine_infinity = to_affine infinity in
+         assert (not (eq affine_one affine_infinity)) ;
+         assert (not (eq affine_two affine_infinity)) ;
+         assert (eq affine_infinity Infinity) ;
+         let affine_neg_one = to_affine neg_one in
+         assert (not (eq affine_one affine_neg_one)) ;
+         assert (not (eq affine_two affine_neg_one)) ;
+         assert (not (eq affine_infinity affine_neg_one)) ;
+         let affine_one_again = to_affine one_again in
+         assert (eq affine_one affine_one_again) ;
+         let affine_two_again = to_affine two_again in
+         assert (eq affine_two affine_two_again) ;
+         let affine_two_again_ = to_affine two_again_ in
+         assert (eq affine_two affine_two_again_) ;
+         let affine_rand1 = to_affine rand1 in
+         let affine_rand2 = to_affine rand2 in
+         let copy_using_of_affine_coordinates pt =
+           match pt with
+           | Types.Or_infinity.Infinity ->
+               of_affine Types.Or_infinity.Infinity
+           | Types.Or_infinity.Finite (x, y) ->
+               of_affine_coordinates x y
+         in
+         let rand1_again = copy_using_of_affine_coordinates affine_rand1 in
+         let rand2_again = copy_using_of_affine_coordinates affine_rand2 in
+         let affine_rand1_again = to_affine rand1_again in
+         let affine_rand2_again = to_affine rand2_again in
+         ( match
+             ( eq affine_rand1 affine_rand2
+             , eq affine_rand1_again affine_rand2_again )
+           with
+         | true, true | false, false ->
+             ()
+         | _ ->
+             assert false ) ;
+         assert (eq affine_rand1 affine_rand1_again) ;
+         assert (eq affine_rand2 affine_rand2_again) ;
+         assert (
+           eq
+             (to_affine (negate (sub rand1 rand2)))
+             (to_affine (sub rand2_again rand1_again)) ) ;
+         let endo_base = endo_base () in
+         assert (
+           String.equal
+             (Pasta_fp.to_string endo_base)
+             "20444556541222657078399132219657928148671392403212669005631716460534733845831"
+         ) ;
+         let endo_scalar = endo_scalar () in
+         assert (
+           String.equal
+             (Pasta_fq.to_string endo_scalar)
+             "26005156700822196841419187675678338661165322343552424574062261873906994770353"
+         ) ;
+         let one_copied = affine_deep_copy affine_one in
+         assert (eq affine_one one_copied) ;
+         let infinity_copied = affine_deep_copy affine_infinity in
+         assert (eq affine_infinity infinity_copied) ;
+         assert (eq affine_infinity Infinity) ;
+         let infinity_copied_ = affine_deep_copy Infinity in
+         assert (eq infinity_copied_ Infinity)
+    end)
+
+let _ =
+  let open Pasta_vesta in
+  Js.export "pasta_vesta_test"
+    (object%js (_self)
+       method run =
+         let eq x y = eq_affine ~field_equal:Pasta_fq.equal x y in
+         let one_ = one () in
+         let two = add one_ one_ in
+         let infinity = sub one_ one_ in
+         let one_again = sub two one_ in
+         let neg_one = negate one_ in
+         let two_again = double one_ in
+         let two_again_ = scale one_ (Pasta_fp.of_int 2) in
+         let rand1 = random () in
+         let rand2 = rng 15 in
+         let affine_one = to_affine one_ in
+         let affine_two = to_affine two in
+         assert (not (eq affine_one affine_two)) ;
+         let affine_infinity = to_affine infinity in
+         assert (not (eq affine_one affine_infinity)) ;
+         assert (not (eq affine_two affine_infinity)) ;
+         assert (eq affine_infinity Infinity) ;
+         let affine_neg_one = to_affine neg_one in
+         assert (not (eq affine_one affine_neg_one)) ;
+         assert (not (eq affine_two affine_neg_one)) ;
+         assert (not (eq affine_infinity affine_neg_one)) ;
+         let affine_one_again = to_affine one_again in
+         assert (eq affine_one affine_one_again) ;
+         let affine_two_again = to_affine two_again in
+         assert (eq affine_two affine_two_again) ;
+         let affine_two_again_ = to_affine two_again_ in
+         assert (eq affine_two affine_two_again_) ;
+         let affine_rand1 = to_affine rand1 in
+         let affine_rand2 = to_affine rand2 in
+         let copy_using_of_affine_coordinates pt =
+           match pt with
+           | Types.Or_infinity.Infinity ->
+               of_affine Types.Or_infinity.Infinity
+           | Types.Or_infinity.Finite (x, y) ->
+               of_affine_coordinates x y
+         in
+         let rand1_again = copy_using_of_affine_coordinates affine_rand1 in
+         let rand2_again = copy_using_of_affine_coordinates affine_rand2 in
+         let affine_rand1_again = to_affine rand1_again in
+         let affine_rand2_again = to_affine rand2_again in
+         ( match
+             ( eq affine_rand1 affine_rand2
+             , eq affine_rand1_again affine_rand2_again )
+           with
+         | true, true | false, false ->
+             ()
+         | _ ->
+             assert false ) ;
+         assert (eq affine_rand1 affine_rand1_again) ;
+         assert (eq affine_rand2 affine_rand2_again) ;
+         assert (
+           eq
+             (to_affine (negate (sub rand1 rand2)))
+             (to_affine (sub rand2_again rand1_again)) ) ;
+         let endo_base = endo_base () in
+         assert (
+           String.equal
+             (Pasta_fq.to_string endo_base)
+             "2942865608506852014473558576493638302197734138389222805617480874486368177743"
+         ) ;
+         let endo_scalar = endo_scalar () in
+         assert (
+           String.equal
+             (Pasta_fp.to_string endo_scalar)
+             "8503465768106391777493614032514048814691664078728891710322960303815233784505"
+         ) ;
+         let one_copied = affine_deep_copy affine_one in
+         assert (eq affine_one one_copied) ;
+         let infinity_copied = affine_deep_copy affine_infinity in
+         assert (eq affine_infinity infinity_copied) ;
+         assert (eq affine_infinity Infinity) ;
+         let infinity_copied_ = affine_deep_copy Infinity in
+         assert (eq infinity_copied_ Infinity)
+    end)
+
+let eq_poly_comm ~field_equal (x : _ Types.Poly_comm.t)
+    (y : _ Types.Poly_comm.t) =
+  Array.for_all2 (eq_affine ~field_equal) x.unshifted y.unshifted
+  && Option.equal (eq_affine ~field_equal) x.shifted y.shifted
+
+module Backend = Zexe_backend.Pasta.Pallas_based_plonk
+
+let () = Backend.Keypair.set_urs_info []
+
+module Impl =
+  Snarky_backendless.Snark.Run.Make
+    (Zexe_backend.Pasta.Pallas_based_plonk)
+    (Unit)
+
+let _ =
+  Js.export "snarky_test"
+    (object%js (_self)
+       method run =
+         let log x = (Js.Unsafe.js_expr "console.log" : _ -> unit) x in
+         let time label f =
+           let start = new%js Js_of_ocaml.Js.date_now in
+           let x = f () in
+           let stop = new%js Js_of_ocaml.Js.date_now in
+           log
+             (Core_kernel.ksprintf Js.string "%s: %f seconds" label
+                ((stop##getTime -. start##getTime) /. 1000.)) ;
+           x
+         in
+         let open Impl in
+         let main x () =
+           let rec go i acc =
+             if i = 0 then acc else go (i - 1) (Field.mul acc acc)
+           in
+           let _ = go 1000 x in
+           ()
+         in
+         let input = Data_spec.[ Typ.field ] in
+         let _kp =
+           time "generate_keypair" (fun () ->
+               generate_keypair ~exposing:input main)
+         in
+         let kp =
+           time "generate_keypair2" (fun () ->
+               generate_keypair ~exposing:input main)
+         in
+         let pk = Keypair.pk kp in
+         let x = Backend.Field.of_int 2 in
+         let pi =
+           time "generate witness conv" (fun () ->
+               Impl.generate_witness_conv input main
+                 ~f:(fun { Proof_inputs.auxiliary_inputs; public_inputs } ->
+                   time "create proof" (fun () ->
+                       Backend.Proof.create pk ~auxiliary:auxiliary_inputs
+                         ~primary:public_inputs))
+                 () x)
+         in
+         let vk = Keypair.vk kp in
+         let vec = Backend.Field.Vector.create () in
+         Backend.Field.Vector.emplace_back vec x ;
+         assert (time "verify proof" (fun () -> Backend.Proof.verify pi vk vec))
+    end)
+
+let _ =
+  let open Pasta_fp_urs in
+  Js.export "pasta_fp_urs_test"
+    (object%js (_self)
+       method run =
+         (let time label f =
+            let start = new%js Js_of_ocaml.Js.date_now in
+            let x = f () in
+            let stop = new%js Js_of_ocaml.Js.date_now in
+            let log x = (Js.Unsafe.js_expr "console.log" : _ -> unit) x in
+            log
+              (Core_kernel.ksprintf Js.string "%s: %f seconds" label
+                 ((stop##getTime -. start##getTime) /. 1000.)) ;
+            x
+          in
+          let n = 131072 in
+          let log_n = Core_kernel.Int.ceil_log2 n in
+          let urs = time "create" (fun () -> create n) in
+          let inputs =
+            time "inputs" (fun () -> Array.init n (fun i -> Pasta_fp.of_int i))
+          in
+          let _ =
+            time "commit" (fun () ->
+                commit_evaluations urs ~domain_size:n inputs)
+          in
+          let _ =
+            let xs = Array.init log_n (fun _ -> Pasta_fp.random ()) in
+            time "b_poly" (fun () -> b_poly_commitment urs xs)
+          in
+          ()) ;
+         let eq_affine x y = eq_affine ~field_equal:Pasta_fq.equal x y in
+         let eq = eq_poly_comm ~field_equal:Pasta_fq.equal in
+         let first = create 10 in
+         let second = create 16 in
+         let lcomm1 = lagrange_commitment first ~domain_size:8 0 in
+         let lcomm1_again = lagrange_commitment second ~domain_size:8 0 in
+         assert (eq lcomm1 lcomm1_again) ;
+         let inputs = Pasta_fp.[| of_int 1; of_int 2; of_int 3; of_int 4 |] in
+         let commits = commit_evaluations second ~domain_size:8 inputs in
+         let commits_again = commit_evaluations second ~domain_size:8 inputs in
+         assert (eq commits commits_again) ;
+         let inputs2 = Array.init 64 Pasta_fp.of_int in
+         let affines =
+           Array.init 16 (fun i ->
+               try lcomm1.unshifted.(i)
+               with _ -> Pasta_vesta.random () |> Pasta_vesta.to_affine)
+         in
+         let res = batch_accumulator_check second affines inputs2 in
+         assert (res || not res) ;
+         let h_first = h first in
+         let h_second = h second in
+         let h_first_again = Pasta_vesta.affine_deep_copy h_first in
+         let h_second_again = Pasta_vesta.affine_deep_copy h_second in
+         assert (eq_affine h_first h_first_again) ;
+         assert (eq_affine h_second h_second_again)
+    end)
+
+let _ =
+  let open Pasta_fq_urs in
+  Js.export "pasta_fq_urs_test"
+    (object%js (_self)
+       method run =
+         let eq_affine x y = eq_affine ~field_equal:Pasta_fp.equal x y in
+         let eq = eq_poly_comm ~field_equal:Pasta_fp.equal in
+         let first = create 10 in
+         let second = create 16 in
+         let lcomm1 = lagrange_commitment first ~domain_size:8 0 in
+         let lcomm1_again = lagrange_commitment second ~domain_size:8 0 in
+         assert (eq lcomm1 lcomm1_again) ;
+         let inputs = Pasta_fq.[| of_int 1; of_int 2; of_int 3; of_int 4 |] in
+         let commits = commit_evaluations second ~domain_size:8 inputs in
+         let commits_again = commit_evaluations second ~domain_size:8 inputs in
+         assert (eq commits commits_again) ;
+         let inputs2 = Array.init 64 Pasta_fq.of_int in
+         let affines =
+           Array.init 16 (fun i ->
+               try lcomm1.unshifted.(i)
+               with _ -> Pasta_pallas.random () |> Pasta_pallas.to_affine)
+         in
+         let res = batch_accumulator_check second affines inputs2 in
+         assert (res || not res) ;
+         let h_first = h first in
+         let h_second = h second in
+         let h_first_again = Pasta_pallas.affine_deep_copy h_first in
+         let h_second_again = Pasta_pallas.affine_deep_copy h_second in
+         assert (eq_affine h_first h_first_again) ;
+         assert (eq_affine h_second h_second_again)
+    end)
+
+let mk_wires kind i (r1, c1) (r2, c2) (r3, c3) c : _ Types.Plonk_gate.t =
+  { kind
+  ; wires =
+      { row = i
+      ; l = { row = r1; col = c1 }
+      ; r = { row = r2; col = c2 }
+      ; o = { row = r3; col = c3 }
+      }
+  ; c
+  }
+
+let _ =
+  let open Pasta_fp_index.Gate_vector in
+  Js.export "pasta_fp_gate_vector_test"
+    (object%js (_self)
+       method run =
+         let vec1 = create () in
+         let vec2 = create () in
+         let eq { Types.Plonk_gate.kind = kind1; wires = wires1; c = c1 }
+             { Types.Plonk_gate.kind = kind2; wires = wires2; c = c2 } =
+           kind1 = kind2 && wires1 = wires2
+           && try Array.for_all2 Pasta_fp.equal c1 c2 with _ -> false
+         in
+         let assert_eq_or_log ?extra ~loc x y =
+           if not (eq x y) then (
+             let log x = (Js.Unsafe.js_expr "console.log" : _ -> unit) x in
+             log loc ;
+             Option.iter log extra ;
+             log x ;
+             log y ;
+             assert false )
+         in
+         let rand_fields i = Array.init i Pasta_fp.rng in
+         let zero = mk_wires Zero 0 (0, L) (0, R) (0, O) (rand_fields 0) in
+         let generic =
+           mk_wires Generic 1 (1, L) (1, R) (1, O) (rand_fields 1)
+         in
+         let add1 = mk_wires Add1 1 (1, L) (1, R) (1, O) (rand_fields 2) in
+         let add2 = mk_wires Add2 2 (2, L) (2, R) (2, O) (rand_fields 3) in
+         let vbmul1 = mk_wires Vbmul1 3 (3, L) (3, R) (3, O) (rand_fields 5) in
+         let vbmul2 = mk_wires Vbmul2 4 (4, L) (4, R) (4, O) (rand_fields 10) in
+         let vbmul3 = mk_wires Vbmul3 5 (5, L) (5, R) (5, O) (rand_fields 20) in
+         let endomul1 =
+           mk_wires Endomul1 6 (6, L) (6, R) (6, O) (rand_fields 30)
+         in
+         let endomul2 =
+           mk_wires Endomul2 7 (7, L) (7, R) (7, O) (rand_fields 31)
+         in
+         let endomul3 =
+           mk_wires Endomul3 8 (8, L) (8, R) (8, O) (rand_fields 32)
+         in
+         let endomul4 =
+           mk_wires Endomul4 9 (9, L) (9, R) (9, O) (rand_fields 33)
+         in
+         let poseidon =
+           mk_wires Poseidon 10 (10, L) (10, R) (10, O) (rand_fields 34)
+         in
+         let all =
+           [ zero
+           ; generic
+           ; add1
+           ; add2
+           ; vbmul1
+           ; vbmul2
+           ; vbmul3
+           ; endomul1
+           ; endomul2
+           ; endomul3
+           ; endomul4
+           ; poseidon
+           ]
+         in
+         let test_vec vec =
+           List.iter (add vec) all ;
+           List.iteri
+             (fun i x -> assert_eq_or_log ~extra:i ~loc:__LOC__ x (get vec i))
+             all ;
+           wrap vec zero.wires.l zero.wires.r ;
+           assert_eq_or_log ~loc:__LOC__ (get vec 0)
+             (mk_wires Zero 0 (0, R) (0, R) (0, O) zero.c) ;
+           wrap vec zero.wires.o zero.wires.l ;
+           assert_eq_or_log ~loc:__LOC__ (get vec 0)
+             (mk_wires Zero 0 (0, R) (0, R) (0, L) zero.c)
+         in
+         test_vec vec1 ; test_vec vec2
+    end)
+
+let _ =
+  let open Pasta_fq_index.Gate_vector in
+  Js.export "pasta_fq_gate_vector_test"
+    (object%js (_self)
+       method run =
+         let vec1 = create () in
+         let vec2 = create () in
+         let eq { Types.Plonk_gate.kind = kind1; wires = wires1; c = c1 }
+             { Types.Plonk_gate.kind = kind2; wires = wires2; c = c2 } =
+           kind1 = kind2 && wires1 = wires2
+           && try Array.for_all2 Pasta_fq.equal c1 c2 with _ -> false
+         in
+         let rand_fields i = Array.init i Pasta_fq.rng in
+         let zero = mk_wires Zero 0 (0, L) (0, R) (0, O) (rand_fields 0) in
+         let generic =
+           mk_wires Generic 1 (1, L) (1, R) (1, O) (rand_fields 1)
+         in
+         let add1 = mk_wires Add1 1 (1, L) (1, R) (1, O) (rand_fields 2) in
+         let add2 = mk_wires Add2 2 (2, L) (2, R) (2, O) (rand_fields 3) in
+         let vbmul1 = mk_wires Vbmul1 3 (3, L) (3, R) (3, O) (rand_fields 5) in
+         let vbmul2 = mk_wires Vbmul2 4 (4, L) (4, R) (4, O) (rand_fields 10) in
+         let vbmul3 = mk_wires Vbmul3 5 (5, L) (5, R) (5, O) (rand_fields 20) in
+         let endomul1 =
+           mk_wires Endomul1 6 (6, L) (6, R) (6, O) (rand_fields 30)
+         in
+         let endomul2 =
+           mk_wires Endomul2 7 (7, L) (7, R) (7, O) (rand_fields 31)
+         in
+         let endomul3 =
+           mk_wires Endomul3 8 (8, L) (8, R) (8, O) (rand_fields 32)
+         in
+         let endomul4 =
+           mk_wires Endomul4 9 (9, L) (9, R) (9, O) (rand_fields 33)
+         in
+         let poseidon =
+           mk_wires Poseidon 10 (10, L) (10, R) (10, O) (rand_fields 34)
+         in
+         let all =
+           [ zero
+           ; generic
+           ; add1
+           ; add2
+           ; vbmul1
+           ; vbmul2
+           ; vbmul3
+           ; endomul1
+           ; endomul2
+           ; endomul3
+           ; endomul4
+           ; poseidon
+           ]
+         in
+         let test_vec vec =
+           List.iter (add vec) all ;
+           List.iteri (fun i x -> assert (eq x (get vec i))) all ;
+           wrap vec zero.wires.l zero.wires.r ;
+           assert (eq (get vec 0) (mk_wires Zero 0 (0, R) (0, R) (0, O) zero.c)) ;
+           wrap vec zero.wires.o zero.wires.l ;
+           assert (eq (get vec 0) (mk_wires Zero 0 (0, R) (0, R) (0, L) zero.c))
+         in
+         test_vec vec1 ; test_vec vec2
+    end)
+
+let _ =
+  let open Pasta_fp_index in
+  Js.export "pasta_fp_index_test"
+    (object%js (_self)
+       method run =
+         let gate_vector =
+           let open Gate_vector in
+           let vec = create () in
+           let fields = Array.map Pasta_fp.of_int in
+           let zero = mk_wires Zero 0 (0, L) (0, R) (0, O) (fields [||]) in
+           let generic =
+             mk_wires Generic 1 (1, L) (1, R) (1, O)
+               (fields [| 0; 0; 0; 0; 0 |])
+           in
+           let add1 = mk_wires Add1 1 (1, L) (1, R) (1, O) (fields [||]) in
+           let add2 = mk_wires Add2 2 (2, L) (2, R) (2, O) (fields [||]) in
+           let vbmul1 = mk_wires Vbmul1 3 (3, L) (3, R) (3, O) (fields [||]) in
+           let vbmul2 = mk_wires Vbmul2 4 (4, L) (4, R) (4, O) (fields [||]) in
+           let vbmul3 = mk_wires Vbmul3 5 (5, L) (5, R) (5, O) (fields [||]) in
+           let endomul1 =
+             mk_wires Endomul1 6 (6, L) (6, R) (6, O) (fields [||])
+           in
+           let endomul2 =
+             mk_wires Endomul2 7 (7, L) (7, R) (7, O) (fields [||])
+           in
+           let endomul3 =
+             mk_wires Endomul3 8 (8, L) (8, R) (8, O) (fields [||])
+           in
+           let endomul4 =
+             mk_wires Endomul4 9 (9, L) (9, R) (9, O) (fields [||])
+           in
+           let poseidon =
+             mk_wires Poseidon 10 (10, L) (10, R) (10, O) (fields [| 0; 0; 0 |])
+           in
+           let all =
+             [ zero
+             ; generic
+             ; add1
+             ; add2
+             ; vbmul1
+             ; vbmul2
+             ; vbmul3
+             ; endomul1
+             ; endomul2
+             ; endomul3
+             ; endomul4
+             ; poseidon
+             ]
+           in
+           List.iter (add vec) all ;
+           vec
+         in
+         let urs = Pasta_fp_urs.create 16 in
+         let index0 = create gate_vector 0 urs in
+         let index2 = create gate_vector 2 urs in
+         assert (max_degree index0 = 16) ;
+         assert (max_degree index2 = 16) ;
+         assert (public_inputs index0 = 0) ;
+         assert (public_inputs index2 = 2) ;
+         assert (domain_d1_size index0 = 16) ;
+         assert (domain_d1_size index2 = 16) ;
+         assert (domain_d4_size index0 = 64) ;
+         assert (domain_d4_size index2 = 64) ;
+         assert (domain_d8_size index0 = 128) ;
+         assert (domain_d8_size index2 = 128)
+    end)
+
+let _ =
+  let open Pasta_fq_index in
+  Js.export "pasta_fq_index_test"
+    (object%js (_self)
+       method run =
+         let gate_vector =
+           let open Gate_vector in
+           let vec = create () in
+           let fields = Array.map Pasta_fq.of_int in
+           let zero = mk_wires Zero 0 (0, L) (0, R) (0, O) (fields [||]) in
+           let generic =
+             mk_wires Generic 1 (1, L) (1, R) (1, O)
+               (fields [| 0; 0; 0; 0; 0 |])
+           in
+           let add1 = mk_wires Add1 1 (1, L) (1, R) (1, O) (fields [||]) in
+           let add2 = mk_wires Add2 2 (2, L) (2, R) (2, O) (fields [||]) in
+           let vbmul1 = mk_wires Vbmul1 3 (3, L) (3, R) (3, O) (fields [||]) in
+           let vbmul2 = mk_wires Vbmul2 4 (4, L) (4, R) (4, O) (fields [||]) in
+           let vbmul3 = mk_wires Vbmul3 5 (5, L) (5, R) (5, O) (fields [||]) in
+           let endomul1 =
+             mk_wires Endomul1 6 (6, L) (6, R) (6, O) (fields [||])
+           in
+           let endomul2 =
+             mk_wires Endomul2 7 (7, L) (7, R) (7, O) (fields [||])
+           in
+           let endomul3 =
+             mk_wires Endomul3 8 (8, L) (8, R) (8, O) (fields [||])
+           in
+           let endomul4 =
+             mk_wires Endomul4 9 (9, L) (9, R) (9, O) (fields [||])
+           in
+           let poseidon =
+             mk_wires Poseidon 10 (10, L) (10, R) (10, O) (fields [| 0; 0; 0 |])
+           in
+           let all =
+             [ zero
+             ; generic
+             ; add1
+             ; add2
+             ; vbmul1
+             ; vbmul2
+             ; vbmul3
+             ; endomul1
+             ; endomul2
+             ; endomul3
+             ; endomul4
+             ; poseidon
+             ]
+           in
+           List.iter (add vec) all ;
+           vec
+         in
+         let urs = Pasta_fq_urs.create 16 in
+         let index0 = create gate_vector 0 urs in
+         let index2 = create gate_vector 2 urs in
+         assert (max_degree index0 = 16) ;
+         assert (max_degree index2 = 16) ;
+         assert (public_inputs index0 = 0) ;
+         assert (public_inputs index2 = 2) ;
+         assert (domain_d1_size index0 = 16) ;
+         assert (domain_d1_size index2 = 16) ;
+         assert (domain_d4_size index0 = 64) ;
+         assert (domain_d4_size index2 = 64) ;
+         assert (domain_d8_size index0 = 128) ;
+         assert (domain_d8_size index2 = 128)
+    end)
+
+let eq_verification_shifts ~field_equal
+    { Types.Plonk_verification_shifts.r = r0; o = o0 }
+    { Types.Plonk_verification_shifts.r = r1; o = o1 } =
+  field_equal r0 r1 && field_equal o0 o1
+
+let verification_evals_to_list
+    { Types.Plonk_verification_evals.sigma_comm_0
+    ; sigma_comm_1
+    ; sigma_comm_2
+    ; ql_comm
+    ; qr_comm
+    ; qo_comm
+    ; qm_comm
+    ; qc_comm
+    ; rcm_comm_0
+    ; rcm_comm_1
+    ; rcm_comm_2
+    ; psm_comm
+    ; add_comm
+    ; mul1_comm
+    ; mul2_comm
+    ; emul1_comm
+    ; emul2_comm
+    ; emul3_comm
+    } =
+  [ sigma_comm_0
+  ; sigma_comm_1
+  ; sigma_comm_2
+  ; ql_comm
+  ; qr_comm
+  ; qo_comm
+  ; qm_comm
+  ; qc_comm
+  ; rcm_comm_0
+  ; rcm_comm_1
+  ; rcm_comm_2
+  ; psm_comm
+  ; add_comm
+  ; mul1_comm
+  ; mul2_comm
+  ; emul1_comm
+  ; emul2_comm
+  ; emul3_comm
+  ]
+
+let eq_verifier_index ~field_equal ~other_field_equal
+    { Types.Plonk_verifier_index.domain =
+        { log_size_of_group = i1_1; group_gen = f1 }
+    ; max_poly_size = i1_2
+    ; max_quot_size = i1_3
+    ; urs = _
+    ; evals = evals1
+    ; shifts = shifts1
+    }
+    { Types.Plonk_verifier_index.domain =
+        { log_size_of_group = i2_1; group_gen = f2 }
+    ; max_poly_size = i2_2
+    ; max_quot_size = i2_3
+    ; urs = _
+    ; evals = evals2
+    ; shifts = shifts2
+    } =
+  i1_1 = i2_1 && field_equal f1 f2 && i1_2 = i2_2 && i1_3 = i2_3
+  && List.for_all2
+       (eq_poly_comm ~field_equal:other_field_equal)
+       (verification_evals_to_list evals1)
+       (verification_evals_to_list evals2)
+  && eq_verification_shifts ~field_equal shifts1 shifts2
+
+let _ =
+  let open Pasta_fp_verifier_index in
+  Js.export "pasta_fp_verifier_index_test"
+    (object%js (_self)
+       method run =
+         let gate_vector =
+           let open Pasta_fp_index.Gate_vector in
+           let vec = create () in
+           let fields = Array.map Pasta_fp.of_int in
+           let zero = mk_wires Zero 0 (0, L) (0, R) (0, O) (fields [||]) in
+           let generic =
+             mk_wires Generic 1 (1, L) (1, R) (1, O)
+               (fields [| 0; 0; 0; 0; 0 |])
+           in
+           let add1 = mk_wires Add1 1 (1, L) (1, R) (1, O) (fields [||]) in
+           let add2 = mk_wires Add2 2 (2, L) (2, R) (2, O) (fields [||]) in
+           let vbmul1 = mk_wires Vbmul1 3 (3, L) (3, R) (3, O) (fields [||]) in
+           let vbmul2 = mk_wires Vbmul2 4 (4, L) (4, R) (4, O) (fields [||]) in
+           let vbmul3 = mk_wires Vbmul3 5 (5, L) (5, R) (5, O) (fields [||]) in
+           let endomul1 =
+             mk_wires Endomul1 6 (6, L) (6, R) (6, O) (fields [||])
+           in
+           let endomul2 =
+             mk_wires Endomul2 7 (7, L) (7, R) (7, O) (fields [||])
+           in
+           let endomul3 =
+             mk_wires Endomul3 8 (8, L) (8, R) (8, O) (fields [||])
+           in
+           let endomul4 =
+             mk_wires Endomul4 9 (9, L) (9, R) (9, O) (fields [||])
+           in
+           let poseidon =
+             mk_wires Poseidon 10 (10, L) (10, R) (10, O) (fields [| 0; 0; 0 |])
+           in
+           let all =
+             [ zero
+             ; generic
+             ; add1
+             ; add2
+             ; vbmul1
+             ; vbmul2
+             ; vbmul3
+             ; endomul1
+             ; endomul2
+             ; endomul3
+             ; endomul4
+             ; poseidon
+             ]
+           in
+           List.iter (add vec) all ;
+           vec
+         in
+         let eq =
+           eq_verifier_index ~field_equal:Pasta_fp.equal
+             ~other_field_equal:Pasta_fq.equal
+         in
+         let urs = Pasta_fp_urs.create 16 in
+         let index0 = Pasta_fp_index.create gate_vector 0 urs in
+         let index2 = Pasta_fp_index.create gate_vector 2 urs in
+         let vindex0_0 = create index0 in
+         let vindex0_1 = create index0 in
+         assert (eq vindex0_0 vindex0_1) ;
+         let vindex2_0 = create index2 in
+         let vindex2_1 = create index2 in
+         assert (eq vindex2_0 vindex2_1) ;
+         let dummy0 = dummy () in
+         let dummy1 = dummy () in
+         assert (eq dummy0 dummy1) ;
+         List.iter
+           (fun x -> assert (eq (deep_copy x) x))
+           [ vindex0_0; vindex2_0; dummy0 ]
+    end)
+
+let _ =
+  let open Pasta_fq_verifier_index in
+  Js.export "pasta_fq_verifier_index_test"
+    (object%js (_self)
+       method run =
+         let gate_vector =
+           let open Pasta_fq_index.Gate_vector in
+           let vec = create () in
+           let fields = Array.map Pasta_fq.of_int in
+           let zero = mk_wires Zero 0 (0, L) (0, R) (0, O) (fields [||]) in
+           let generic =
+             mk_wires Generic 1 (1, L) (1, R) (1, O)
+               (fields [| 0; 0; 0; 0; 0 |])
+           in
+           let add1 = mk_wires Add1 1 (1, L) (1, R) (1, O) (fields [||]) in
+           let add2 = mk_wires Add2 2 (2, L) (2, R) (2, O) (fields [||]) in
+           let vbmul1 = mk_wires Vbmul1 3 (3, L) (3, R) (3, O) (fields [||]) in
+           let vbmul2 = mk_wires Vbmul2 4 (4, L) (4, R) (4, O) (fields [||]) in
+           let vbmul3 = mk_wires Vbmul3 5 (5, L) (5, R) (5, O) (fields [||]) in
+           let endomul1 =
+             mk_wires Endomul1 6 (6, L) (6, R) (6, O) (fields [||])
+           in
+           let endomul2 =
+             mk_wires Endomul2 7 (7, L) (7, R) (7, O) (fields [||])
+           in
+           let endomul3 =
+             mk_wires Endomul3 8 (8, L) (8, R) (8, O) (fields [||])
+           in
+           let endomul4 =
+             mk_wires Endomul4 9 (9, L) (9, R) (9, O) (fields [||])
+           in
+           let poseidon =
+             mk_wires Poseidon 10 (10, L) (10, R) (10, O) (fields [| 0; 0; 0 |])
+           in
+           let all =
+             [ zero
+             ; generic
+             ; add1
+             ; add2
+             ; vbmul1
+             ; vbmul2
+             ; vbmul3
+             ; endomul1
+             ; endomul2
+             ; endomul3
+             ; endomul4
+             ; poseidon
+             ]
+           in
+           List.iter (add vec) all ;
+           vec
+         in
+         let eq =
+           eq_verifier_index ~field_equal:Pasta_fq.equal
+             ~other_field_equal:Pasta_fp.equal
+         in
+         let urs = Pasta_fq_urs.create 16 in
+         let index0 = Pasta_fq_index.create gate_vector 0 urs in
+         let index2 = Pasta_fq_index.create gate_vector 2 urs in
+         let vindex0_0 = create index0 in
+         let vindex0_1 = create index0 in
+         assert (eq vindex0_0 vindex0_1) ;
+         let vindex2_0 = create index2 in
+         let vindex2_1 = create index2 in
+         assert (eq vindex2_0 vindex2_1) ;
+         let dummy0 = dummy () in
+         let dummy1 = dummy () in
+         assert (eq dummy0 dummy1) ;
+         List.iter
+           (fun x -> assert (eq (deep_copy x) x))
+           [ vindex0_0; vindex2_0; dummy0 ]
+    end)
+
+let linkme = ()

--- a/src/lib/crypto/kimchi_bindings/js/test/chrome/chrome_test.ml
+++ b/src/lib/crypto/kimchi_bindings/js/test/chrome/chrome_test.ml
@@ -1,0 +1,1 @@
+let () = Bindings_js_test.linkme

--- a/src/lib/crypto/kimchi_bindings/js/test/chrome/copy_over.sh
+++ b/src/lib/crypto/kimchi_bindings/js/test/chrome/copy_over.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+chmod -R +w _build/default/src/lib/marlin_plonk_bindings/js/test/chrome
+cp -r -t _build/default/src/lib/marlin_plonk_bindings/js/test/chrome _build/default/src/lib/marlin_plonk_bindings/js/chrome/plonk_wasm* _build/default/src/lib/marlin_plonk_bindings/js/chrome/snippets
+cp -t _build/default/src/lib/marlin_plonk_bindings/js/test/chrome src/lib/marlin_plonk_bindings/js/test/chrome/{server.py,index.html}
+(cd _build/default/src/lib/marlin_plonk_bindings/js/test/chrome/; ./server.py)

--- a/src/lib/crypto/kimchi_bindings/js/test/chrome/dune
+++ b/src/lib/crypto/kimchi_bindings/js/test/chrome/dune
@@ -1,0 +1,8 @@
+(executable
+ (name chrome_test)
+ (modes js)
+ (js_of_ocaml (flags +toplevel.js +dynlink.js))
+ (libraries bindings_js_test marlin_plonk_bindings js_of_ocaml bindings_js chrome_backend)
+ (link_deps ../../chrome/plonk_wasm.js ../../chrome/plonk_wasm.wasm)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version js_of_ocaml-ppx)))

--- a/src/lib/crypto/kimchi_bindings/js/test/chrome/index.html
+++ b/src/lib/crypto/kimchi_bindings/js/test/chrome/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>hello-wasm example</title>
+  </head>
+  <body>
+    <button id="run_all_tests" disabled=true>Run all tests</button>
+    <button id="discover_tests">Discover tests</button>
+    <div id="discovered_tests"></div>
+    <textarea id="output" style="width:100%" rows="35"></textarea>
+    <script>
+      function log_and_print(x) {
+        console.log(x);
+        document.getElementById("output").value += x + "\n";
+        return new Promise(function(resolve) {
+            // Use setTimeout to ensure that a redraw runs before continuing
+            setTimeout(function() { resolve() }, 0);
+        });
+      };
+      async function run_all_tests() {
+        for (var i in window) {
+          if(i.indexOf("_test") != -1 && typeof window[i] === "object" && typeof window[i].run === "function") {
+            await log_and_print("Running " + i);
+            try{
+              window[i].run();
+              await log_and_print("Done");
+            } catch(e) {
+              await log_and_print("Error:\n" + e);
+            }
+          }
+        };
+      }
+      function discover_tests() {
+        var discovered_tests = document.getElementById("discovered_tests");
+        while (child = discovered_tests.firstChild) {
+          discovered_tests.removeChild(firstChild);
+        };
+        for (var i in window) {
+          if(i.indexOf("_test") != -1 && typeof window[i] === "object" && typeof window[i].run === "function") {
+            var runner = (function(i) {
+                return async function () {
+                  await log_and_print("Running " + i);
+                  try{
+                    window[i].run();
+                    await log_and_print("Done");
+                  } catch(e) {
+                    await log_and_print("Error:\n" + e);
+                  }
+                }
+              })(i);
+            var button = document.createElement("button");
+            button.addEventListener("click", runner);
+            button.appendChild(document.createTextNode(i));
+            discovered_tests.appendChild(button);
+          }
+        };
+      };
+      document.getElementById("discover_tests").addEventListener("click", discover_tests);
+    </script>
+    <script type="module">
+      import init, * as plonk_wasm from "./plonk_wasm.js";
+      window.plonk_wasm = plonk_wasm;
+      await init();
+      plonk_wasm.initThreadPool(navigator.hardwareConcurrency);
+      /* Don't load the script until we're done initialising. */
+      var newScript = document.createElement("script");
+      newScript.src = "./chrome_test.bc.js";
+      document.body.appendChild(newScript);
+      var all_button = document.getElementById("run_all_tests");
+      all_button.addEventListener("click", run_all_tests);
+      all_button.disabled = false
+    </script>
+  </body>
+</html>

--- a/src/lib/crypto/kimchi_bindings/js/test/chrome/server.py
+++ b/src/lib/crypto/kimchi_bindings/js/test/chrome/server.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+from http.server import HTTPServer, SimpleHTTPRequestHandler, test
+import sys
+
+class CORSRequestHandler (SimpleHTTPRequestHandler):
+    def end_headers (self):
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        SimpleHTTPRequestHandler.end_headers(self)
+
+if __name__ == '__main__':
+    test(CORSRequestHandler, HTTPServer, port=int(sys.argv[1]) if len(sys.argv) > 1 else 8000)

--- a/src/lib/crypto/kimchi_bindings/js/test/dune
+++ b/src/lib/crypto/kimchi_bindings/js/test/dune
@@ -1,0 +1,8 @@
+(library
+ (name bindings_js_test)
+ (js_of_ocaml (flags +toplevel.js +dynlink.js))
+; (libraries zexe_backend.js marlin_plonk_bindings js_of_ocaml bindings_js node_backend integers_stubs_js)
+; (link_deps ../node_js/plonk_wasm.js ../node_js/plonk_wasm.wasm)
+ (libraries zexe_backend zexe_backend.js marlin_plonk_bindings js_of_ocaml bindings_js integers_stubs_js)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version js_of_ocaml-ppx)))

--- a/src/lib/crypto/kimchi_bindings/js/test/nodejs/copy_over.sh
+++ b/src/lib/crypto/kimchi_bindings/js/test/nodejs/copy_over.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+chmod -R +w _build/default/src/lib/marlin_plonk_bindings/js/test/nodejs
+cp -t _build/default/src/lib/marlin_plonk_bindings/js/test/nodejs _build/default/src/lib/marlin_plonk_bindings/js/node_js/plonk_wasm*
+nodejs --experimental-wasm-modules --experimental-modules --experimental-wasm-threads -i -r ./_build/default/src/lib/marlin_plonk_bindings/js/test/nodejs/nodejs_test.bc.js -e "var bindings = require('./_build/default/src/lib/marlin_plonk_bindings/js/test/nodejs/nodejs_test.bc.js'); console.log('Bindings attached to global variable \\'bindings\\'')"

--- a/src/lib/crypto/kimchi_bindings/js/test/nodejs/dune
+++ b/src/lib/crypto/kimchi_bindings/js/test/nodejs/dune
@@ -1,0 +1,8 @@
+(executable
+ (name nodejs_test)
+ (modes js)
+ (js_of_ocaml (flags +toplevel.js +dynlink.js))
+ (libraries bindings_js_test marlin_plonk_bindings js_of_ocaml bindings_js node_backend)
+ (link_deps ../../node_js/plonk_wasm.js ../../node_js/plonk_wasm.wasm)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version js_of_ocaml-ppx)))

--- a/src/lib/crypto/kimchi_bindings/js/test/nodejs/nodejs_test.ml
+++ b/src/lib/crypto/kimchi_bindings/js/test/nodejs/nodejs_test.ml
@@ -1,0 +1,1 @@
+let () = Bindings_js_test.linkme

--- a/src/lib/crypto/kimchi_bindings/wasm/.cargo/config
+++ b/src/lib/crypto/kimchi_bindings/wasm/.cargo/config
@@ -1,0 +1,11 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
+
+[target.wasm32-wasi]
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
+
+[target.wasm32-unknown-emscripten]
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
+
+[unstable]
+build-std = ["panic_abort", "std"]

--- a/src/lib/crypto/kimchi_bindings/wasm/.cargo/config
+++ b/src/lib/crypto/kimchi_bindings/wasm/.cargo/config
@@ -1,10 +1,7 @@
+[build]
+target = "wasm32-unknown-unknown"
+
 [target.wasm32-unknown-unknown]
-rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
-
-[target.wasm32-wasi]
-rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
-
-[target.wasm32-unknown-emscripten]
 rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
 
 [unstable]

--- a/src/lib/crypto/kimchi_bindings/wasm/.gitignore
+++ b/src/lib/crypto/kimchi_bindings/wasm/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [lib]
 name = "plonk_wasm"
-crate-type = ["cdylib"]
+crate-type = ["lib"]
 
 ################################# Dependencies ################################
 
@@ -32,6 +32,7 @@ ark-poly = { version = "0.3.0", features = ["parallel"] }
 commitment_dlog = { path = "../../proof-systems/poly-commitment" }
 groupmap = { path = "../../proof-systems/groupmap" }
 mina-curves = { path = "../../proof-systems/curves" }
+o1-utils = { path = "../../proof-systems/utils" }
 oracle = { path = "../../proof-systems/oracle" }
 kimchi = { path = "../../proof-systems/kimchi", features = ["wasm_types"] }
 
@@ -66,10 +67,4 @@ wasm-opt = false
 rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
 
 [target.wasm32-unknown-unknown]
-rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
-
-[target.wasm32-wasi]
-rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
-
-[target.wasm32-unknown-emscripten]
 rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [lib]
 name = "plonk_wasm"
-crate-type = ["lib"]
+crate-type = ["cdylib"]
 
 ################################# Dependencies ################################
 

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
@@ -1,0 +1,75 @@
+[package]
+name = "plonk_wasm"
+version = "0.1.0"
+authors = ["opensource@o1labs.org"]
+description = "WASM stubs for plonk proof systems"
+repository = "https://github.com/MinaProtocol/mina"
+license = "MIT/Apache-2.0"
+edition = "2018"
+
+[lib]
+name = "plonk_wasm"
+crate-type = ["cdylib"]
+
+################################# Dependencies ################################
+
+[dependencies]
+#wasm-bindgen-rayon = { version = "1.0", features = ["no-bundler"] }
+wasm-bindgen-rayon = { path = "../../../../external/wasm-bindgen-rayon", features = ["no-bundler"] }
+wasm-bindgen = { version = "0.2.78" }
+console_error_panic_hook = { version = "0.1.6" }
+web-sys = { version = "0.3.35", features = ["Window", "Document", "HtmlElement", "Text", "Node", "Element" ] }
+
+libc = { version = "0.2.0" }
+
+# arkworks
+ark-ff = { version = "0.3.0", features = ["parallel"] }
+ark-serialize = "0.3.0"
+ark-ec = { version = "0.3.0", features = ["parallel"] }
+ark-poly = { version = "0.3.0", features = ["parallel"] }
+
+# proof-systems
+commitment_dlog = { path = "../../proof-systems/poly-commitment" }
+groupmap = { path = "../../proof-systems/groupmap" }
+mina-curves = { path = "../../proof-systems/curves" }
+oracle = { path = "../../proof-systems/oracle" }
+kimchi = { path = "../../proof-systems/kimchi", features = ["wasm_types"] }
+
+rand = { version = "0.8.0" }
+getrandom = { version = "0.2", features = ["js"] }
+#num-bigint = { version = "0.2.3" }
+#sprs = { version = "0.7.1" }
+
+#rand = { version = "0.8.0", features = [ "wasm-bindgen" ] }
+num-bigint = { version = "0.4.0" }
+paste = "1.0.5"
+sprs = { version = "0.11.0" }
+rayon = { version = "1" }
+array-init = "2.0.0"
+
+serde = "1.0.130"
+rmp-serde = "1.0.0"
+serde_json = "1.0"
+
+[profile.release]
+debug = true
+
+[features]
+nodejs = ["wasm-bindgen-rayon/no-modules"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+#wasm-opt = ["-O4", "--detect-features", "--enable-mutable-globals" ]
+#wasm-opt = ["-O4", "--enable-mutable-globals"]
+
+[build]
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
+
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
+
+[target.wasm32-wasi]
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]
+
+[target.wasm32-unknown-emscripten]
+rustflags = ["-C", "target-feature=+atomics,+bulk-memory", "-C", "link-arg=--no-check-features"]

--- a/src/lib/crypto/kimchi_bindings/wasm/rust-toolchain.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2021-10-31"

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/bigint_256.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/bigint_256.rs
@@ -1,0 +1,150 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
+use ark_ff::{FromBytes, ToBytes, BigInteger as ark_BigInteger, BigInteger256};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use num_bigint::BigUint;
+use std::cmp::Ordering::{Equal, Greater, Less};
+use std::convert::TryInto;
+
+//
+// Handy constants
+//
+
+const BIGINT256_NUM_BITS: i32 = 256;
+const BIGINT256_LIMB_BITS: i32 = 64;
+const BIGINT256_LIMB_BYTES: i32 = BIGINT256_LIMB_BITS / 8;
+const BIGINT256_NUM_LIMBS: i32 =
+    (BIGINT256_NUM_BITS + BIGINT256_LIMB_BITS - 1) / BIGINT256_LIMB_BITS;
+const BIGINT256_NUM_BYTES: usize = (BIGINT256_NUM_LIMBS as usize) * 8;
+
+
+pub struct WasmBigInteger256(pub BigInteger256);
+
+impl wasm_bindgen::describe::WasmDescribe for WasmBigInteger256 {
+    fn describe() { <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe() }
+}
+
+impl FromWasmAbi for WasmBigInteger256 {
+    type Abi = <Vec<u8> as FromWasmAbi>::Abi;
+    unsafe fn from_abi(js: Self::Abi) -> Self {
+        let bytes: Vec<u8> = FromWasmAbi::from_abi(js);
+        WasmBigInteger256(BigInteger256(FromBytes::read(bytes.as_slice()).unwrap()))
+    }
+}
+
+impl IntoWasmAbi for WasmBigInteger256 {
+    type Abi = <Vec<u8> as FromWasmAbi>::Abi;
+    fn into_abi(self) -> Self::Abi {
+        let mut bytes: Vec<u8> = vec![];
+        self.0.write(&mut bytes);
+        bytes.into_abi()
+    }
+}
+
+pub fn to_biguint(x: &BigInteger256) -> BigUint {
+    let x_ = x.0.as_ptr() as *const u8;
+    let x_ = unsafe { std::slice::from_raw_parts(x_, BIGINT256_NUM_BYTES) };
+    num_bigint::BigUint::from_bytes_le(x_)
+}
+
+pub fn of_biguint(x: &BigUint) -> BigInteger256 {
+    let mut bytes = x.to_bytes_le();
+    bytes.resize(BIGINT256_NUM_BYTES, 0);
+    let limbs = bytes.as_ptr();
+    let limbs = limbs as *const [u64; BIGINT256_NUM_LIMBS as usize];
+    let limbs = unsafe { &(*limbs) };
+    BigInteger256(*limbs)
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_of_numeral(
+    s: String,
+    _len: u32,
+    base: u32,
+) -> WasmBigInteger256 {
+    match BigUint::parse_bytes(&s.into_bytes(), base) {
+        Some(data) => WasmBigInteger256(of_biguint(&data)),
+        None => panic!("caml_bigint_256_of_numeral"),
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_of_decimal_string(s: String) -> WasmBigInteger256 {
+    match BigUint::parse_bytes(&s.into_bytes(), 10) {
+        Some(data) => WasmBigInteger256(of_biguint(&data)),
+        None => panic!("caml_bigint_256_of_decimal_string"),
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_num_limbs() -> i32 {
+    return BIGINT256_NUM_LIMBS.try_into().unwrap();
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_bytes_per_limb() -> i32 {
+    return BIGINT256_LIMB_BYTES.try_into().unwrap();
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_div(
+    x: WasmBigInteger256,
+    y: WasmBigInteger256,
+) -> WasmBigInteger256 {
+    let res: BigUint = to_biguint(&x.0) / to_biguint(&y.0);
+    WasmBigInteger256(of_biguint(&res))
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_compare(
+    x: WasmBigInteger256,
+    y: WasmBigInteger256,
+) -> i8 {
+    match x.0.cmp(&y.0) {
+        Less => -1,
+        Equal => 0,
+        Greater => 1,
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_print(x: WasmBigInteger256) {
+    println!("{}", to_biguint(&x.0));
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_to_string(x: WasmBigInteger256) -> String {
+    to_biguint(&x.0).to_string()
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_test_bit(
+    x: WasmBigInteger256,
+    i: i32,
+) -> bool {
+    match i.try_into() {
+        Ok(i) => x.0.get_bit(i),
+        Err(_) => panic!("caml_bigint_256_test_bit"),
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_to_bytes(x: WasmBigInteger256) -> Vec<u8> {
+    let mut serialized_bytes = vec![];
+    x.0.serialize(&mut serialized_bytes).expect("serialize failed");
+    serialized_bytes
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_of_bytes(x: &[u8]) -> WasmBigInteger256 {
+    let len = std::mem::size_of::<WasmBigInteger256>();
+    if x.len() != len {
+        panic!("caml_bigint_256_of_bytes");
+    };
+    WasmBigInteger256(BigInteger256::deserialize(&mut &x[..]).expect("deserialization error"))
+}
+
+#[wasm_bindgen]
+pub fn caml_bigint_256_deep_copy(x: WasmBigInteger256) -> WasmBigInteger256 {
+    x
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/bigint_256.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/bigint_256.rs
@@ -1,10 +1,10 @@
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
-use ark_ff::{FromBytes, ToBytes, BigInteger as ark_BigInteger, BigInteger256};
+use ark_ff::{BigInteger as ark_BigInteger, BigInteger256, FromBytes, ToBytes};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use num_bigint::BigUint;
 use std::cmp::Ordering::{Equal, Greater, Less};
 use std::convert::TryInto;
+use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi};
+use wasm_bindgen::prelude::*;
 
 //
 // Handy constants
@@ -17,11 +17,12 @@ const BIGINT256_NUM_LIMBS: i32 =
     (BIGINT256_NUM_BITS + BIGINT256_LIMB_BITS - 1) / BIGINT256_LIMB_BITS;
 const BIGINT256_NUM_BYTES: usize = (BIGINT256_NUM_LIMBS as usize) * 8;
 
-
 pub struct WasmBigInteger256(pub BigInteger256);
 
 impl wasm_bindgen::describe::WasmDescribe for WasmBigInteger256 {
-    fn describe() { <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe() }
+    fn describe() {
+        <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe()
+    }
 }
 
 impl FromWasmAbi for WasmBigInteger256 {
@@ -57,11 +58,7 @@ pub fn of_biguint(x: &BigUint) -> BigInteger256 {
 }
 
 #[wasm_bindgen]
-pub fn caml_bigint_256_of_numeral(
-    s: String,
-    _len: u32,
-    base: u32,
-) -> WasmBigInteger256 {
+pub fn caml_bigint_256_of_numeral(s: String, _len: u32, base: u32) -> WasmBigInteger256 {
     match BigUint::parse_bytes(&s.into_bytes(), base) {
         Some(data) => WasmBigInteger256(of_biguint(&data)),
         None => panic!("caml_bigint_256_of_numeral"),
@@ -87,19 +84,13 @@ pub fn caml_bigint_256_bytes_per_limb() -> i32 {
 }
 
 #[wasm_bindgen]
-pub fn caml_bigint_256_div(
-    x: WasmBigInteger256,
-    y: WasmBigInteger256,
-) -> WasmBigInteger256 {
+pub fn caml_bigint_256_div(x: WasmBigInteger256, y: WasmBigInteger256) -> WasmBigInteger256 {
     let res: BigUint = to_biguint(&x.0) / to_biguint(&y.0);
     WasmBigInteger256(of_biguint(&res))
 }
 
 #[wasm_bindgen]
-pub fn caml_bigint_256_compare(
-    x: WasmBigInteger256,
-    y: WasmBigInteger256,
-) -> i8 {
+pub fn caml_bigint_256_compare(x: WasmBigInteger256, y: WasmBigInteger256) -> i8 {
     match x.0.cmp(&y.0) {
         Less => -1,
         Equal => 0,
@@ -118,10 +109,7 @@ pub fn caml_bigint_256_to_string(x: WasmBigInteger256) -> String {
 }
 
 #[wasm_bindgen]
-pub fn caml_bigint_256_test_bit(
-    x: WasmBigInteger256,
-    i: i32,
-) -> bool {
+pub fn caml_bigint_256_test_bit(x: WasmBigInteger256, i: i32) -> bool {
     match i.try_into() {
         Ok(i) => x.0.get_bit(i),
         Err(_) => panic!("caml_bigint_256_test_bit"),
@@ -131,7 +119,8 @@ pub fn caml_bigint_256_test_bit(
 #[wasm_bindgen]
 pub fn caml_bigint_256_to_bytes(x: WasmBigInteger256) -> Vec<u8> {
     let mut serialized_bytes = vec![];
-    x.0.serialize(&mut serialized_bytes).expect("serialize failed");
+    x.0.serialize(&mut serialized_bytes)
+        .expect("serialize failed");
     serialized_bytes
 }
 

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/group_affine.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/group_affine.rs
@@ -1,14 +1,11 @@
-use wasm_bindgen::prelude::*;
 use crate::arkworks::pasta_fp::WasmPastaFp;
 use crate::arkworks::pasta_fq::WasmPastaFq;
 use mina_curves::pasta::{
-    pallas::Affine as AffinePallas,
-    vesta::Affine as AffineVesta,
-    pallas::G_GENERATOR_X as GeneratorPallasX,
-    pallas::G_GENERATOR_Y as GeneratorPallasY,
-    vesta::G_GENERATOR_X as GeneratorVestaX,
-    vesta::G_GENERATOR_Y as GeneratorVestaY,
+    pallas::Affine as AffinePallas, pallas::G_GENERATOR_X as GeneratorPallasX,
+    pallas::G_GENERATOR_Y as GeneratorPallasY, vesta::Affine as AffineVesta,
+    vesta::G_GENERATOR_X as GeneratorVestaX, vesta::G_GENERATOR_Y as GeneratorVestaY,
 };
+use wasm_bindgen::prelude::*;
 
 //
 // handy types
@@ -37,7 +34,7 @@ impl From<AffineVesta> for WasmGVesta {
         WasmGVesta {
             x: point.x.into(),
             y: point.y.into(),
-            infinity: point.infinity
+            infinity: point.infinity,
         }
     }
 }
@@ -47,26 +44,20 @@ impl From<&AffineVesta> for WasmGVesta {
         WasmGVesta {
             x: point.x.into(),
             y: point.y.into(),
-            infinity: point.infinity
+            infinity: point.infinity,
         }
     }
 }
 
 impl From<WasmGVesta> for AffineVesta {
     fn from(point: WasmGVesta) -> Self {
-        AffineVesta::new(
-            point.x.into(),
-            point.y.into(),
-            point.infinity)
+        AffineVesta::new(point.x.into(), point.y.into(), point.infinity)
     }
 }
 
 impl From<&WasmGVesta> for AffineVesta {
     fn from(point: &WasmGVesta) -> Self {
-        AffineVesta::new(
-            point.x.into(),
-            point.y.into(),
-            point.infinity)
+        AffineVesta::new(point.x.into(), point.y.into(), point.infinity)
     }
 }
 
@@ -77,7 +68,7 @@ impl From<AffinePallas> for WasmGPallas {
         WasmGPallas {
             x: point.x.into(),
             y: point.y.into(),
-            infinity: point.infinity
+            infinity: point.infinity,
         }
     }
 }
@@ -87,26 +78,20 @@ impl From<&AffinePallas> for WasmGPallas {
         WasmGPallas {
             x: point.x.into(),
             y: point.y.into(),
-            infinity: point.infinity
+            infinity: point.infinity,
         }
     }
 }
 
 impl From<WasmGPallas> for AffinePallas {
     fn from(point: WasmGPallas) -> Self {
-        AffinePallas::new(
-            point.x.into(),
-            point.y.into(),
-            point.infinity)
+        AffinePallas::new(point.x.into(), point.y.into(), point.infinity)
     }
 }
 
 impl From<&WasmGPallas> for AffinePallas {
     fn from(point: &WasmGPallas) -> Self {
-        AffinePallas::new(
-            point.x.into(),
-            point.y.into(),
-            point.infinity)
+        AffinePallas::new(point.x.into(), point.y.into(), point.infinity)
     }
 }
 
@@ -115,7 +100,7 @@ pub fn caml_pallas_affine_one() -> WasmGPallas {
     WasmGPallas {
         x: WasmPastaFp::from(GeneratorPallasX),
         y: WasmPastaFp::from(GeneratorPallasY),
-        infinity: false
+        infinity: false,
     }
 }
 
@@ -124,7 +109,7 @@ pub fn caml_vesta_affine_one() -> WasmGVesta {
     WasmGVesta {
         x: WasmPastaFq::from(GeneratorVestaX),
         y: WasmPastaFq::from(GeneratorVestaY),
-        infinity: false
+        infinity: false,
     }
 }
 

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/group_affine.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/group_affine.rs
@@ -1,0 +1,217 @@
+use wasm_bindgen::prelude::*;
+use crate::arkworks::pasta_fp::WasmPastaFp;
+use crate::arkworks::pasta_fq::WasmPastaFq;
+use mina_curves::pasta::{
+    pallas::Affine as AffinePallas,
+    vesta::Affine as AffineVesta,
+    pallas::G_GENERATOR_X as GeneratorPallasX,
+    pallas::G_GENERATOR_Y as GeneratorPallasY,
+    vesta::G_GENERATOR_X as GeneratorVestaX,
+    vesta::G_GENERATOR_Y as GeneratorVestaY,
+};
+
+//
+// handy types
+//
+
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub struct WasmGPallas {
+    pub x: WasmPastaFp,
+    pub y: WasmPastaFp,
+    pub infinity: bool,
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub struct WasmGVesta {
+    pub x: WasmPastaFq,
+    pub y: WasmPastaFq,
+    pub infinity: bool,
+}
+
+// Conversions from/to AffineVesta
+
+impl From<AffineVesta> for WasmGVesta {
+    fn from(point: AffineVesta) -> Self {
+        WasmGVesta {
+            x: point.x.into(),
+            y: point.y.into(),
+            infinity: point.infinity
+        }
+    }
+}
+
+impl From<&AffineVesta> for WasmGVesta {
+    fn from(point: &AffineVesta) -> Self {
+        WasmGVesta {
+            x: point.x.into(),
+            y: point.y.into(),
+            infinity: point.infinity
+        }
+    }
+}
+
+impl From<WasmGVesta> for AffineVesta {
+    fn from(point: WasmGVesta) -> Self {
+        AffineVesta::new(
+            point.x.into(),
+            point.y.into(),
+            point.infinity)
+    }
+}
+
+impl From<&WasmGVesta> for AffineVesta {
+    fn from(point: &WasmGVesta) -> Self {
+        AffineVesta::new(
+            point.x.into(),
+            point.y.into(),
+            point.infinity)
+    }
+}
+
+// Conversion from/to AffinePallas
+
+impl From<AffinePallas> for WasmGPallas {
+    fn from(point: AffinePallas) -> Self {
+        WasmGPallas {
+            x: point.x.into(),
+            y: point.y.into(),
+            infinity: point.infinity
+        }
+    }
+}
+
+impl From<&AffinePallas> for WasmGPallas {
+    fn from(point: &AffinePallas) -> Self {
+        WasmGPallas {
+            x: point.x.into(),
+            y: point.y.into(),
+            infinity: point.infinity
+        }
+    }
+}
+
+impl From<WasmGPallas> for AffinePallas {
+    fn from(point: WasmGPallas) -> Self {
+        AffinePallas::new(
+            point.x.into(),
+            point.y.into(),
+            point.infinity)
+    }
+}
+
+impl From<&WasmGPallas> for AffinePallas {
+    fn from(point: &WasmGPallas) -> Self {
+        AffinePallas::new(
+            point.x.into(),
+            point.y.into(),
+            point.infinity)
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pallas_affine_one() -> WasmGPallas {
+    WasmGPallas {
+        x: WasmPastaFp::from(GeneratorPallasX),
+        y: WasmPastaFp::from(GeneratorPallasY),
+        infinity: false
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_vesta_affine_one() -> WasmGVesta {
+    WasmGVesta {
+        x: WasmPastaFq::from(GeneratorVestaX),
+        y: WasmPastaFq::from(GeneratorVestaY),
+        infinity: false
+    }
+}
+
+/*
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_one() -> WasmPallasGProjective {
+    ProjectivePallas::prime_subgroup_generator().into()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_add(
+    x: &WasmPallasGProjective,
+    y: &WasmPallasGProjective,
+) -> WasmPallasGProjective {
+    (**x + **y).into()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_sub(
+    x: &WasmPallasGProjective,
+    y: &WasmPallasGProjective,
+) -> WasmPallasGProjective {
+    (**x - **y).into()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_negate(x: &WasmPallasGProjective) -> WasmPallasGProjective {
+    (-(**x)).into()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_double(x: &WasmPallasGProjective) -> WasmPallasGProjective {
+    (x.double()).into()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_scale(x: &WasmPallasGProjective, y: WasmPastaFq) -> WasmPallasGProjective {
+    (x.mul(y.0)).into()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_random() -> WasmPallasGProjective {
+    let rng = &mut rand_core::OsRng;
+    WasmPallasGProjective(UniformRand::rand(rng))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_rng(i: u32) -> WasmPallasGProjective {
+    let i: u64 = i.into();
+    let mut rng: StdRng = rand::SeedableRng::seed_from_u64(i);
+    WasmPallasGProjective(UniformRand::rand(&mut rng))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_endo_base() -> WasmPastaFp {
+    let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffine>();
+    WasmPastaFp(endo_q)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_endo_scalar() -> WasmPastaFq {
+    let (_endo_q, endo_r) = commitment_dlog::srs::endos::<GAffine>();
+    WasmPastaFq(endo_r)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_to_affine(x: &WasmPallasGProjective) -> WasmPallasGAffine {
+    Into::<&GProjective>::into(x).into_affine().into()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_of_affine(x: &WasmPallasGAffine) -> WasmPallasGProjective {
+    Into::<GAffine>::into(x).into_projective().into()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_of_affine_coordinates(x: WasmPastaFp, y: WasmPastaFp) -> WasmPallasGProjective {
+    GProjective::new(x.0, y.0, Fp::one()).into()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_affine_deep_copy(x: &WasmPallasGAffine) -> WasmPallasGAffine {
+    x.clone()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_pallas_affine_one() -> WasmPallasGAffine {
+    GAffine::prime_subgroup_generator().into()
+}
+*/

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/group_projective.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/group_projective.rs
@@ -1,5 +1,5 @@
-use wasm_bindgen::prelude::*;
 use std::ops::{Add, Deref, Neg, Sub};
+use wasm_bindgen::prelude::*;
 
 use mina_curves::pasta::{
     pallas::Projective as ProjectivePallas, vesta::Projective as ProjectiveVesta,

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/group_projective.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/group_projective.rs
@@ -1,0 +1,194 @@
+use wasm_bindgen::prelude::*;
+use std::ops::{Add, Deref, Neg, Sub};
+
+use mina_curves::pasta::{
+    pallas::Projective as ProjectivePallas, vesta::Projective as ProjectiveVesta,
+};
+
+// Pallas
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct WasmPallasGProjective(ProjectivePallas);
+
+impl AsRef<WasmPallasGProjective> for WasmPallasGProjective {
+    fn as_ref(&self) -> &WasmPallasGProjective {
+        self
+    }
+}
+
+impl Deref for WasmPallasGProjective {
+    type Target = ProjectivePallas;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// Handy implementations
+
+impl From<ProjectivePallas> for WasmPallasGProjective {
+    fn from(x: ProjectivePallas) -> Self {
+        WasmPallasGProjective(x)
+    }
+}
+
+impl From<&ProjectivePallas> for WasmPallasGProjective {
+    fn from(x: &ProjectivePallas) -> Self {
+        WasmPallasGProjective(*x)
+    }
+}
+
+impl From<WasmPallasGProjective> for ProjectivePallas {
+    fn from(x: WasmPallasGProjective) -> Self {
+        x.0
+    }
+}
+
+impl From<&WasmPallasGProjective> for ProjectivePallas {
+    fn from(x: &WasmPallasGProjective) -> Self {
+        x.0
+    }
+}
+
+impl Add for WasmPallasGProjective {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self(self.0 + other.0)
+    }
+}
+
+impl Add for &WasmPallasGProjective {
+    type Output = WasmPallasGProjective;
+
+    fn add(self, other: Self) -> Self::Output {
+        WasmPallasGProjective(self.0 + other.0)
+    }
+}
+
+impl Sub for WasmPallasGProjective {
+    type Output = WasmPallasGProjective;
+
+    fn sub(self, other: Self) -> Self::Output {
+        WasmPallasGProjective(self.0 - other.0)
+    }
+}
+
+impl Sub for &WasmPallasGProjective {
+    type Output = WasmPallasGProjective;
+
+    fn sub(self, other: Self) -> Self::Output {
+        WasmPallasGProjective(self.0 - other.0)
+    }
+}
+
+impl Neg for WasmPallasGProjective {
+    type Output = WasmPallasGProjective;
+
+    fn neg(self) -> Self::Output {
+        WasmPallasGProjective(-self.0)
+    }
+}
+
+impl Neg for &WasmPallasGProjective {
+    type Output = WasmPallasGProjective;
+
+    fn neg(self) -> Self::Output {
+        WasmPallasGProjective(-self.0)
+    }
+}
+
+// Vesta
+
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct WasmVestaGProjective(ProjectiveVesta);
+
+impl AsRef<WasmVestaGProjective> for WasmVestaGProjective {
+    fn as_ref(&self) -> &WasmVestaGProjective {
+        self
+    }
+}
+
+impl Deref for WasmVestaGProjective {
+    type Target = ProjectiveVesta;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+//
+// Handy implementations
+//
+
+impl From<ProjectiveVesta> for WasmVestaGProjective {
+    fn from(x: ProjectiveVesta) -> Self {
+        WasmVestaGProjective(x)
+    }
+}
+
+impl From<&ProjectiveVesta> for WasmVestaGProjective {
+    fn from(x: &ProjectiveVesta) -> Self {
+        WasmVestaGProjective(*x)
+    }
+}
+
+impl From<WasmVestaGProjective> for ProjectiveVesta {
+    fn from(x: WasmVestaGProjective) -> Self {
+        x.0
+    }
+}
+
+impl From<&WasmVestaGProjective> for ProjectiveVesta {
+    fn from(x: &WasmVestaGProjective) -> Self {
+        x.0
+    }
+}
+
+impl Add for WasmVestaGProjective {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self(self.0 + other.0)
+    }
+}
+impl Add for &WasmVestaGProjective {
+    type Output = WasmVestaGProjective;
+
+    fn add(self, other: Self) -> Self::Output {
+        WasmVestaGProjective(self.0 + other.0)
+    }
+}
+
+impl Sub for WasmVestaGProjective {
+    type Output = WasmVestaGProjective;
+
+    fn sub(self, other: Self) -> Self::Output {
+        WasmVestaGProjective(self.0 - other.0)
+    }
+}
+
+impl Sub for &WasmVestaGProjective {
+    type Output = WasmVestaGProjective;
+
+    fn sub(self, other: Self) -> Self::Output {
+        WasmVestaGProjective(self.0 - other.0)
+    }
+}
+
+impl Neg for WasmVestaGProjective {
+    type Output = WasmVestaGProjective;
+
+    fn neg(self) -> Self::Output {
+        WasmVestaGProjective(-self.0)
+    }
+}
+
+impl Neg for &WasmVestaGProjective {
+    type Output = WasmVestaGProjective;
+
+    fn neg(self) -> Self::Output {
+        WasmVestaGProjective(-self.0)
+    }
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/mod.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/mod.rs
@@ -1,0 +1,32 @@
+//! This module contains wrapper types to Arkworks types.
+//! To use Arkwork types in OCaml, you have to convert to these types,
+//! and convert back from them to use them in Rust.
+//!
+//! For example:
+//!
+//! ```
+//! use marlin_plonk_bindings::arkworks::CamlBiginteger256;
+//! use ark_ff::BigInteger256;
+//!
+//! #[ocaml::func]
+//! pub fn caml_add(x: CamlBigInteger256, y: CamlBigInteger256) -> CamlBigInteger256 {
+//!    let x: BigInteger256 = x.into();
+//!    let y: BigInteger256 = y.into();
+//!    (x + y).into()
+//! }
+//! ```
+//!
+
+pub mod bigint_256;
+pub mod group_affine;
+pub mod group_projective;
+pub mod pasta_fp;
+pub mod pasta_fq;
+
+// re-export what's important
+
+pub use bigint_256::WasmBigInteger256;
+pub use group_affine::{WasmGPallas, WasmGVesta};
+pub use group_projective::{WasmPallasGProjective, WasmVestaGProjective};
+pub use pasta_fp::WasmPastaFp;
+pub use pasta_fq::WasmPastaFq;

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fp.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fp.rs
@@ -1,0 +1,237 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::convert::{OptionIntoWasmAbi, IntoWasmAbi, FromWasmAbi};
+use crate::arkworks::bigint_256::{self, WasmBigInteger256};
+use ark_ff::{FromBytes, ToBytes, BigInteger256};
+use mina_curves::pasta::fp::{Fp, FpParameters as Fp_params};
+use ark_ff::{
+    fields::{Field, FpParameters, PrimeField, SquareRootField},
+    FftField, One, UniformRand, Zero,
+};
+use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
+use num_bigint::BigUint;
+use rand::rngs::StdRng;
+use std::cmp::Ordering::{Equal, Greater, Less};
+
+#[derive(Clone, Copy, Debug)]
+pub struct WasmPastaFp(pub Fp);
+
+impl crate::wasm_flat_vector::FlatVectorElem for WasmPastaFp {
+    const FLATTENED_SIZE: usize = std::mem::size_of::<Fp>();
+    fn flatten(self) -> Vec<u8> {
+        let mut bytes: Vec<u8> = Vec::with_capacity(Self::FLATTENED_SIZE);
+        self.0.write(&mut bytes);
+        bytes
+    }
+    fn unflatten(flat: Vec<u8>) -> Self {
+        WasmPastaFp(FromBytes::read(flat.as_slice()).unwrap())
+    }
+}
+
+impl From<Fp> for WasmPastaFp {
+    fn from(x: Fp) -> Self {
+        WasmPastaFp(x)
+    }
+}
+
+impl From<WasmPastaFp> for Fp {
+    fn from(x: WasmPastaFp) -> Self {
+        x.0
+    }
+}
+
+impl<'a> From<&'a WasmPastaFp> for &'a Fp {
+    fn from(x: &'a WasmPastaFp) -> Self {
+        &x.0
+    }
+}
+
+impl wasm_bindgen::describe::WasmDescribe for WasmPastaFp {
+    fn describe() { <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe() }
+}
+
+impl FromWasmAbi for WasmPastaFp {
+    type Abi = <Vec<u8> as FromWasmAbi>::Abi;
+    unsafe fn from_abi(js: Self::Abi) -> Self {
+        let bytes: Vec<u8> = FromWasmAbi::from_abi(js);
+        WasmPastaFp(FromBytes::read(bytes.as_slice()).unwrap())
+    }
+}
+
+impl IntoWasmAbi for WasmPastaFp {
+    type Abi = <Vec<u8> as FromWasmAbi>::Abi;
+    fn into_abi(self) -> Self::Abi {
+        let mut bytes: Vec<u8> = vec![];
+        self.0.write(&mut bytes);
+        bytes.into_abi()
+    }
+}
+
+impl OptionIntoWasmAbi for WasmPastaFp {
+    fn none() -> Self::Abi {
+        let max_bigint = WasmBigInteger256(BigInteger256([u64::MAX, u64::MAX, u64::MAX, u64::MAX]));
+        max_bigint.into_abi()
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_size_in_bits() -> isize {
+    Fp_params::MODULUS_BITS as isize
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_size() -> WasmBigInteger256 {
+    WasmBigInteger256(Fp_params::MODULUS)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_add(x: WasmPastaFp, y: WasmPastaFp) -> WasmPastaFp {
+    WasmPastaFp(x.0 + y.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_sub(x: WasmPastaFp, y: WasmPastaFp) -> WasmPastaFp {
+    WasmPastaFp(x.0 - y.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_negate(x: WasmPastaFp) -> WasmPastaFp {
+    WasmPastaFp(-x.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_mul(x: WasmPastaFp, y: WasmPastaFp) -> WasmPastaFp {
+    WasmPastaFp(x.0 * y.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_div(x: WasmPastaFp, y: WasmPastaFp) -> WasmPastaFp {
+    WasmPastaFp(x.0 / y.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_inv(x: WasmPastaFp) -> Option<WasmPastaFp> {
+    x.0.inverse().map(|x| { WasmPastaFp(x) })
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_square(x: WasmPastaFp) -> WasmPastaFp {
+    WasmPastaFp(x.0.square())
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_is_square(x: WasmPastaFp) -> bool {
+    let s = x.0.pow(Fp_params::MODULUS_MINUS_ONE_DIV_TWO);
+    s.is_zero() || s.is_one()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_sqrt(x: WasmPastaFp) -> Option<WasmPastaFp> {
+    x.0.sqrt().map(|x| { WasmPastaFp(x) })
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_of_int(i: i32) -> WasmPastaFp {
+    WasmPastaFp(Fp::from(i as u64))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_to_string(x: WasmPastaFp) -> String {
+    bigint_256::to_biguint(&x.0.into_repr()).to_string()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_of_string(s: String) -> Result<WasmPastaFp, JsValue> {
+    let biguint = BigUint::parse_bytes(s.as_bytes(), 10).ok_or(
+        JsValue::from_str("caml_pasta_fp_of_string"))?;
+
+    match Fp::from_repr(bigint_256::of_biguint(&biguint)) {
+        Some(x) => Ok(x.into()),
+        None => Err(JsValue::from_str("caml_pasta_fp_of_string"))
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_print(x: WasmPastaFp) {
+    println!("{}", bigint_256::to_biguint(&(x.0.into_repr())));
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_compare(x: WasmPastaFp, y: WasmPastaFp) -> i32 {
+    match x.0.cmp(&y.0) {
+        Less => -1,
+        Equal => 0,
+        Greater => 1,
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_equal(x: WasmPastaFp, y: WasmPastaFp) -> bool {
+    x.0 == y.0
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_random() -> WasmPastaFp {
+    WasmPastaFp(UniformRand::rand(&mut rand::thread_rng()))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_rng(i: i32) -> WasmPastaFp {
+    // We only care about entropy here, so we force a conversion i32 -> u32.
+    let i: u64 = (i as u32).into();
+    let mut rng: StdRng = rand::SeedableRng::seed_from_u64(i);
+    WasmPastaFp(UniformRand::rand(&mut rng))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_to_bigint(x: WasmPastaFp) -> WasmBigInteger256 {
+    WasmBigInteger256(x.0.into_repr())
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_of_bigint(x: WasmBigInteger256) -> Result<WasmPastaFp, JsValue> {
+    match Fp::from_repr(x.0) {
+        Some(x) => Ok(x.into()),
+        None => Err(JsValue::from_str("caml_pasta_fp_of_bigint"))
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_two_adic_root_of_unity() -> WasmPastaFp {
+    WasmPastaFp(FftField::two_adic_root_of_unity())
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_domain_generator(log2_size: i32) -> WasmPastaFp {
+    match Domain::new(1 << log2_size) {
+        Some(x) => WasmPastaFp(x.group_gen),
+        None => panic!("caml_pasta_fp_domain_generator"),
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_to_bytes(x: WasmPastaFp) -> Vec<u8> {
+    let len = std::mem::size_of::<Fp>();
+    let mut str: Vec<u8> = Vec::with_capacity(len);
+    str.resize(len, 0);
+    let str_as_fp : *mut Fp = str.as_mut_ptr().cast::<Fp>();
+    unsafe {
+        *str_as_fp = x.0;
+    }
+    str
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_of_bytes(x: &[u8]) -> WasmPastaFp {
+    let len = std::mem::size_of::<Fp>();
+    if x.len() != len {
+        panic!("caml_pasta_fp_of_bytes");
+    };
+    let x = unsafe { *(x.as_ptr() as *const Fp) };
+    WasmPastaFp(x)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_deep_copy(x: WasmPastaFp) -> WasmPastaFp {
+    x
+}
+

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fp.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fp.rs
@@ -1,16 +1,16 @@
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::convert::{OptionIntoWasmAbi, IntoWasmAbi, FromWasmAbi};
 use crate::arkworks::bigint_256::{self, WasmBigInteger256};
-use ark_ff::{FromBytes, ToBytes, BigInteger256};
-use mina_curves::pasta::fp::{Fp, FpParameters as Fp_params};
 use ark_ff::{
     fields::{Field, FpParameters, PrimeField, SquareRootField},
     FftField, One, UniformRand, Zero,
 };
+use ark_ff::{BigInteger256, FromBytes, ToBytes};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
+use mina_curves::pasta::fp::{Fp, FpParameters as Fp_params};
 use num_bigint::BigUint;
 use rand::rngs::StdRng;
 use std::cmp::Ordering::{Equal, Greater, Less};
+use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionIntoWasmAbi};
+use wasm_bindgen::prelude::*;
 
 #[derive(Clone, Copy, Debug)]
 pub struct WasmPastaFp(pub Fp);
@@ -46,7 +46,9 @@ impl<'a> From<&'a WasmPastaFp> for &'a Fp {
 }
 
 impl wasm_bindgen::describe::WasmDescribe for WasmPastaFp {
-    fn describe() { <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe() }
+    fn describe() {
+        <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe()
+    }
 }
 
 impl FromWasmAbi for WasmPastaFp {
@@ -110,7 +112,7 @@ pub fn caml_pasta_fp_div(x: WasmPastaFp, y: WasmPastaFp) -> WasmPastaFp {
 
 #[wasm_bindgen]
 pub fn caml_pasta_fp_inv(x: WasmPastaFp) -> Option<WasmPastaFp> {
-    x.0.inverse().map(|x| { WasmPastaFp(x) })
+    x.0.inverse().map(|x| WasmPastaFp(x))
 }
 
 #[wasm_bindgen]
@@ -126,7 +128,7 @@ pub fn caml_pasta_fp_is_square(x: WasmPastaFp) -> bool {
 
 #[wasm_bindgen]
 pub fn caml_pasta_fp_sqrt(x: WasmPastaFp) -> Option<WasmPastaFp> {
-    x.0.sqrt().map(|x| { WasmPastaFp(x) })
+    x.0.sqrt().map(|x| WasmPastaFp(x))
 }
 
 #[wasm_bindgen]
@@ -141,12 +143,12 @@ pub fn caml_pasta_fp_to_string(x: WasmPastaFp) -> String {
 
 #[wasm_bindgen]
 pub fn caml_pasta_fp_of_string(s: String) -> Result<WasmPastaFp, JsValue> {
-    let biguint = BigUint::parse_bytes(s.as_bytes(), 10).ok_or(
-        JsValue::from_str("caml_pasta_fp_of_string"))?;
+    let biguint = BigUint::parse_bytes(s.as_bytes(), 10)
+        .ok_or(JsValue::from_str("caml_pasta_fp_of_string"))?;
 
     match Fp::from_repr(bigint_256::of_biguint(&biguint)) {
         Some(x) => Ok(x.into()),
-        None => Err(JsValue::from_str("caml_pasta_fp_of_string"))
+        None => Err(JsValue::from_str("caml_pasta_fp_of_string")),
     }
 }
 
@@ -191,7 +193,7 @@ pub fn caml_pasta_fp_to_bigint(x: WasmPastaFp) -> WasmBigInteger256 {
 pub fn caml_pasta_fp_of_bigint(x: WasmBigInteger256) -> Result<WasmPastaFp, JsValue> {
     match Fp::from_repr(x.0) {
         Some(x) => Ok(x.into()),
-        None => Err(JsValue::from_str("caml_pasta_fp_of_bigint"))
+        None => Err(JsValue::from_str("caml_pasta_fp_of_bigint")),
     }
 }
 
@@ -213,7 +215,7 @@ pub fn caml_pasta_fp_to_bytes(x: WasmPastaFp) -> Vec<u8> {
     let len = std::mem::size_of::<Fp>();
     let mut str: Vec<u8> = Vec::with_capacity(len);
     str.resize(len, 0);
-    let str_as_fp : *mut Fp = str.as_mut_ptr().cast::<Fp>();
+    let str_as_fp: *mut Fp = str.as_mut_ptr().cast::<Fp>();
     unsafe {
         *str_as_fp = x.0;
     }
@@ -234,4 +236,3 @@ pub fn caml_pasta_fp_of_bytes(x: &[u8]) -> WasmPastaFp {
 pub fn caml_pasta_fp_deep_copy(x: WasmPastaFp) -> WasmPastaFp {
     x
 }
-

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fq.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fq.rs
@@ -1,16 +1,16 @@
-use wasm_bindgen::prelude::*;
-use wasm_bindgen::convert::{OptionIntoWasmAbi, IntoWasmAbi, FromWasmAbi};
 use crate::arkworks::bigint_256::{self, WasmBigInteger256};
-use ark_ff::{FromBytes, ToBytes, BigInteger256};
-use mina_curves::pasta::fq::{Fq, FqParameters as Fq_params};
 use ark_ff::{
     fields::{Field, FpParameters, PrimeField, SquareRootField},
     FftField, One, UniformRand, Zero,
 };
+use ark_ff::{BigInteger256, FromBytes, ToBytes};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
+use mina_curves::pasta::fq::{Fq, FqParameters as Fq_params};
 use num_bigint::BigUint;
 use rand::rngs::StdRng;
 use std::cmp::Ordering::{Equal, Greater, Less};
+use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionIntoWasmAbi};
+use wasm_bindgen::prelude::*;
 
 #[derive(Clone, Copy, Debug)]
 pub struct WasmPastaFq(pub Fq);
@@ -46,7 +46,9 @@ impl<'a> From<&'a WasmPastaFq> for &'a Fq {
 }
 
 impl wasm_bindgen::describe::WasmDescribe for WasmPastaFq {
-    fn describe() { <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe() }
+    fn describe() {
+        <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe()
+    }
 }
 
 impl FromWasmAbi for WasmPastaFq {
@@ -110,7 +112,7 @@ pub fn caml_pasta_fq_div(x: WasmPastaFq, y: WasmPastaFq) -> WasmPastaFq {
 
 #[wasm_bindgen]
 pub fn caml_pasta_fq_inv(x: WasmPastaFq) -> Option<WasmPastaFq> {
-    x.0.inverse().map(|x| { WasmPastaFq(x) })
+    x.0.inverse().map(|x| WasmPastaFq(x))
 }
 
 #[wasm_bindgen]
@@ -126,7 +128,7 @@ pub fn caml_pasta_fq_is_square(x: WasmPastaFq) -> bool {
 
 #[wasm_bindgen]
 pub fn caml_pasta_fq_sqrt(x: WasmPastaFq) -> Option<WasmPastaFq> {
-    x.0.sqrt().map(|x| { WasmPastaFq(x) })
+    x.0.sqrt().map(|x| WasmPastaFq(x))
 }
 
 #[wasm_bindgen]
@@ -141,12 +143,12 @@ pub fn caml_pasta_fq_to_string(x: WasmPastaFq) -> String {
 
 #[wasm_bindgen]
 pub fn caml_pasta_fq_of_string(s: String) -> Result<WasmPastaFq, JsValue> {
-    let biguint = BigUint::parse_bytes(s.as_bytes(), 10).ok_or(
-        JsValue::from_str("caml_pasta_fq_of_string"))?;
+    let biguint = BigUint::parse_bytes(s.as_bytes(), 10)
+        .ok_or(JsValue::from_str("caml_pasta_fq_of_string"))?;
 
     match Fq::from_repr(bigint_256::of_biguint(&biguint)) {
         Some(x) => Ok(x.into()),
-        None => Err(JsValue::from_str("caml_pasta_fq_of_string"))
+        None => Err(JsValue::from_str("caml_pasta_fq_of_string")),
     }
 }
 
@@ -191,7 +193,7 @@ pub fn caml_pasta_fq_to_bigint(x: WasmPastaFq) -> WasmBigInteger256 {
 pub fn caml_pasta_fq_of_bigint(x: WasmBigInteger256) -> Result<WasmPastaFq, JsValue> {
     match Fq::from_repr(x.0) {
         Some(x) => Ok(x.into()),
-        None => Err(JsValue::from_str("caml_pasta_fq_of_bigint"))
+        None => Err(JsValue::from_str("caml_pasta_fq_of_bigint")),
     }
 }
 
@@ -213,7 +215,7 @@ pub fn caml_pasta_fq_to_bytes(x: WasmPastaFq) -> Vec<u8> {
     let len = std::mem::size_of::<Fq>();
     let mut str: Vec<u8> = Vec::with_capacity(len);
     str.resize(len, 0);
-    let str_as_fq : *mut Fq = str.as_mut_ptr().cast::<Fq>();
+    let str_as_fq: *mut Fq = str.as_mut_ptr().cast::<Fq>();
     unsafe {
         *str_as_fq = x.0;
     }
@@ -234,4 +236,3 @@ pub fn caml_pasta_fq_of_bytes(x: &[u8]) -> WasmPastaFq {
 pub fn caml_pasta_fq_deep_copy(x: WasmPastaFq) -> WasmPastaFq {
     x
 }
-

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fq.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fq.rs
@@ -1,0 +1,237 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::convert::{OptionIntoWasmAbi, IntoWasmAbi, FromWasmAbi};
+use crate::arkworks::bigint_256::{self, WasmBigInteger256};
+use ark_ff::{FromBytes, ToBytes, BigInteger256};
+use mina_curves::pasta::fq::{Fq, FqParameters as Fq_params};
+use ark_ff::{
+    fields::{Field, FpParameters, PrimeField, SquareRootField},
+    FftField, One, UniformRand, Zero,
+};
+use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
+use num_bigint::BigUint;
+use rand::rngs::StdRng;
+use std::cmp::Ordering::{Equal, Greater, Less};
+
+#[derive(Clone, Copy, Debug)]
+pub struct WasmPastaFq(pub Fq);
+
+impl crate::wasm_flat_vector::FlatVectorElem for WasmPastaFq {
+    const FLATTENED_SIZE: usize = std::mem::size_of::<Fq>();
+    fn flatten(self) -> Vec<u8> {
+        let mut bytes: Vec<u8> = Vec::with_capacity(Self::FLATTENED_SIZE);
+        self.0.write(&mut bytes);
+        bytes
+    }
+    fn unflatten(flat: Vec<u8>) -> Self {
+        WasmPastaFq(FromBytes::read(flat.as_slice()).unwrap())
+    }
+}
+
+impl From<Fq> for WasmPastaFq {
+    fn from(x: Fq) -> Self {
+        WasmPastaFq(x)
+    }
+}
+
+impl From<WasmPastaFq> for Fq {
+    fn from(x: WasmPastaFq) -> Self {
+        x.0
+    }
+}
+
+impl<'a> From<&'a WasmPastaFq> for &'a Fq {
+    fn from(x: &'a WasmPastaFq) -> Self {
+        &x.0
+    }
+}
+
+impl wasm_bindgen::describe::WasmDescribe for WasmPastaFq {
+    fn describe() { <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe() }
+}
+
+impl FromWasmAbi for WasmPastaFq {
+    type Abi = <Vec<u8> as FromWasmAbi>::Abi;
+    unsafe fn from_abi(js: Self::Abi) -> Self {
+        let bytes: Vec<u8> = FromWasmAbi::from_abi(js);
+        WasmPastaFq(FromBytes::read(bytes.as_slice()).unwrap())
+    }
+}
+
+impl IntoWasmAbi for WasmPastaFq {
+    type Abi = <Vec<u8> as FromWasmAbi>::Abi;
+    fn into_abi(self) -> Self::Abi {
+        let mut bytes: Vec<u8> = vec![];
+        self.0.write(&mut bytes);
+        bytes.into_abi()
+    }
+}
+
+impl OptionIntoWasmAbi for WasmPastaFq {
+    fn none() -> Self::Abi {
+        let max_bigint = WasmBigInteger256(BigInteger256([u64::MAX, u64::MAX, u64::MAX, u64::MAX]));
+        max_bigint.into_abi()
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_size_in_bits() -> isize {
+    Fq_params::MODULUS_BITS as isize
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_size() -> WasmBigInteger256 {
+    WasmBigInteger256(Fq_params::MODULUS)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_add(x: WasmPastaFq, y: WasmPastaFq) -> WasmPastaFq {
+    WasmPastaFq(x.0 + y.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_sub(x: WasmPastaFq, y: WasmPastaFq) -> WasmPastaFq {
+    WasmPastaFq(x.0 - y.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_negate(x: WasmPastaFq) -> WasmPastaFq {
+    WasmPastaFq(-x.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_mul(x: WasmPastaFq, y: WasmPastaFq) -> WasmPastaFq {
+    WasmPastaFq(x.0 * y.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_div(x: WasmPastaFq, y: WasmPastaFq) -> WasmPastaFq {
+    WasmPastaFq(x.0 / y.0)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_inv(x: WasmPastaFq) -> Option<WasmPastaFq> {
+    x.0.inverse().map(|x| { WasmPastaFq(x) })
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_square(x: WasmPastaFq) -> WasmPastaFq {
+    WasmPastaFq(x.0.square())
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_is_square(x: WasmPastaFq) -> bool {
+    let s = x.0.pow(Fq_params::MODULUS_MINUS_ONE_DIV_TWO);
+    s.is_zero() || s.is_one()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_sqrt(x: WasmPastaFq) -> Option<WasmPastaFq> {
+    x.0.sqrt().map(|x| { WasmPastaFq(x) })
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_of_int(i: i32) -> WasmPastaFq {
+    WasmPastaFq(Fq::from(i as u64))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_to_string(x: WasmPastaFq) -> String {
+    bigint_256::to_biguint(&x.0.into_repr()).to_string()
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_of_string(s: String) -> Result<WasmPastaFq, JsValue> {
+    let biguint = BigUint::parse_bytes(s.as_bytes(), 10).ok_or(
+        JsValue::from_str("caml_pasta_fq_of_string"))?;
+
+    match Fq::from_repr(bigint_256::of_biguint(&biguint)) {
+        Some(x) => Ok(x.into()),
+        None => Err(JsValue::from_str("caml_pasta_fq_of_string"))
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_print(x: WasmPastaFq) {
+    println!("{}", bigint_256::to_biguint(&(x.0.into_repr())));
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_compare(x: WasmPastaFq, y: WasmPastaFq) -> i32 {
+    match x.0.cmp(&y.0) {
+        Less => -1,
+        Equal => 0,
+        Greater => 1,
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_equal(x: WasmPastaFq, y: WasmPastaFq) -> bool {
+    x.0 == y.0
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_random() -> WasmPastaFq {
+    WasmPastaFq(UniformRand::rand(&mut rand::thread_rng()))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_rng(i: i32) -> WasmPastaFq {
+    // We only care about entropy here, so we force a conversion i32 -> u32.
+    let i: u64 = (i as u32).into();
+    let mut rng: StdRng = rand::SeedableRng::seed_from_u64(i);
+    WasmPastaFq(UniformRand::rand(&mut rng))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_to_bigint(x: WasmPastaFq) -> WasmBigInteger256 {
+    WasmBigInteger256(x.0.into_repr())
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_of_bigint(x: WasmBigInteger256) -> Result<WasmPastaFq, JsValue> {
+    match Fq::from_repr(x.0) {
+        Some(x) => Ok(x.into()),
+        None => Err(JsValue::from_str("caml_pasta_fq_of_bigint"))
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_two_adic_root_of_unity() -> WasmPastaFq {
+    WasmPastaFq(FftField::two_adic_root_of_unity())
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_domain_generator(log2_size: i32) -> WasmPastaFq {
+    match Domain::new(1 << log2_size) {
+        Some(x) => WasmPastaFq(x.group_gen),
+        None => panic!("caml_pasta_fq_domain_generator"),
+    }
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_to_bytes(x: WasmPastaFq) -> Vec<u8> {
+    let len = std::mem::size_of::<Fq>();
+    let mut str: Vec<u8> = Vec::with_capacity(len);
+    str.resize(len, 0);
+    let str_as_fq : *mut Fq = str.as_mut_ptr().cast::<Fq>();
+    unsafe {
+        *str_as_fq = x.0;
+    }
+    str
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_of_bytes(x: &[u8]) -> WasmPastaFq {
+    let len = std::mem::size_of::<Fq>();
+    if x.len() != len {
+        panic!("caml_pasta_fq_of_bytes");
+    };
+    let x = unsafe { *(x.as_ptr() as *const Fq) };
+    WasmPastaFq(x)
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_deep_copy(x: WasmPastaFq) -> WasmPastaFq {
+    x
+}
+

--- a/src/lib/crypto/kimchi_bindings/wasm/src/gate_vector.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/gate_vector.rs
@@ -1,8 +1,8 @@
 //! A GateVector: this is used to represent a list of gates.
 
-use wasm_bindgen::prelude::*;
-use kimchi::circuits::{gate::CircuitGate, wires::Wire, gate::GateType};
 use crate::wasm_flat_vector::WasmFlatVector;
+use kimchi::circuits::{gate::CircuitGate, gate::GateType, wires::Wire};
+use wasm_bindgen::prelude::*;
 
 use paste::paste;
 
@@ -15,7 +15,8 @@ pub struct WasmGateWires(
     pub Wire,
     pub Wire,
     pub Wire,
-    pub Wire);
+    pub Wire,
+);
 
 #[wasm_bindgen]
 impl WasmGateWires {
@@ -30,7 +31,6 @@ macro_rules! impl_gate_vector {
      $WasmF: ty,
      $F: ty,
      $field_name: ident) => {
-
         paste! {
             #[wasm_bindgen]
             pub struct [<Wasm $field_name:camel GateVector>](
@@ -145,7 +145,7 @@ macro_rules! impl_gate_vector {
                 (v.0)[t.row as usize].wires[t.col as usize] = h.into();
             }
         }
-    }
+    };
 }
 
 pub mod fp {

--- a/src/lib/crypto/kimchi_bindings/wasm/src/gate_vector.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/gate_vector.rs
@@ -1,0 +1,169 @@
+//! A GateVector: this is used to represent a list of gates.
+
+use wasm_bindgen::prelude::*;
+use kimchi::circuits::{gate::CircuitGate, wires::Wire, gate::GateType};
+use crate::wasm_flat_vector::WasmFlatVector;
+
+use paste::paste;
+
+#[wasm_bindgen]
+#[derive(Clone, Copy, Debug)]
+pub struct WasmGateWires(
+    pub Wire,
+    pub Wire,
+    pub Wire,
+    pub Wire,
+    pub Wire,
+    pub Wire,
+    pub Wire);
+
+#[wasm_bindgen]
+impl WasmGateWires {
+    #[wasm_bindgen(constructor)]
+    pub fn new(w0: Wire, w1: Wire, w2: Wire, w3: Wire, w4: Wire, w5: Wire, w6: Wire) -> Self {
+        WasmGateWires(w0, w1, w2, w3, w4, w5, w6)
+    }
+}
+
+macro_rules! impl_gate_vector {
+    ($name: ident,
+     $WasmF: ty,
+     $F: ty,
+     $field_name: ident) => {
+
+        paste! {
+            #[wasm_bindgen]
+            pub struct [<Wasm $field_name:camel GateVector>](
+                #[wasm_bindgen(skip)] pub Vec<CircuitGate<$F>>);
+            pub type WasmGateVector = [<Wasm $field_name:camel GateVector>];
+
+            #[wasm_bindgen]
+            pub struct [<Wasm $field_name:camel Gate>] {
+                pub typ: GateType, // type of the gate
+                pub wires: WasmGateWires,  // gate wires
+                #[wasm_bindgen(skip)] pub c: Vec<$WasmF>,  // constraints vector
+            }
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel Gate>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    typ: GateType,
+                    wires: WasmGateWires,
+                    c: WasmFlatVector<$WasmF>) -> Self {
+                    Self {
+                        typ,
+                        wires,
+                        c: c.into(),
+                    }
+                }
+            }
+
+            impl From<CircuitGate<$F>> for [<Wasm $field_name:camel Gate>]
+            {
+                fn from(cg: CircuitGate<$F>) -> Self {
+                    Self {
+                        typ: cg.typ,
+                        wires: WasmGateWires(
+                            cg.wires[0],
+                            cg.wires[1],
+                            cg.wires[2],
+                            cg.wires[3],
+                            cg.wires[4],
+                            cg.wires[5],
+                            cg.wires[6]),
+                        c: cg.c.into_iter().map(Into::into).collect(),
+                    }
+                }
+            }
+
+            impl From<&CircuitGate<$F>> for [<Wasm $field_name:camel Gate>]
+            {
+                fn from(cg: &CircuitGate<$F>) -> Self {
+                    Self {
+                        typ: cg.typ,
+                        wires: WasmGateWires(
+                            cg.wires[0],
+                            cg.wires[1],
+                            cg.wires[2],
+                            cg.wires[3],
+                            cg.wires[4],
+                            cg.wires[5],
+                            cg.wires[6]),
+                        c: cg.c.clone().into_iter().map(Into::into).collect(),
+                    }
+                }
+            }
+
+            impl From<[<Wasm $field_name:camel Gate>]> for CircuitGate<$F>
+            {
+                fn from(ccg: [<Wasm $field_name:camel Gate>]) -> Self {
+                    Self {
+                        typ: ccg.typ,
+                        wires: [
+                            ccg.wires.0,
+                            ccg.wires.1,
+                            ccg.wires.2,
+                            ccg.wires.3,
+                            ccg.wires.4,
+                            ccg.wires.5,
+                            ccg.wires.6
+                        ],
+                        c: ccg.c.into_iter().map(Into::into).collect(),
+                    }
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_pasta_ $name:snake _plonk_gate_vector_create>]() -> WasmGateVector {
+                [<Wasm $field_name:camel GateVector>](Vec::new())
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_pasta_ $name:snake _plonk_gate_vector_add>](
+                v: &mut WasmGateVector,
+                gate: [<Wasm $field_name:camel Gate>],
+            ) {
+                let gate: CircuitGate<$F> = gate.into();
+                v.0.push(gate);
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_pasta_ $name:snake _plonk_gate_vector_get>](
+                v: &WasmGateVector,
+                i: i32,
+            ) -> [<Wasm $field_name:camel Gate>] {
+                (&(v.0)[i as usize]).into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_pasta_ $name:snake _plonk_gate_vector_wrap>](
+                v: &mut WasmGateVector,
+                t: Wire,
+                h: Wire,
+            ) {
+                (v.0)[t.row as usize].wires[t.col as usize] = h.into();
+            }
+        }
+    }
+}
+
+pub mod fp {
+    use super::*;
+    use crate::arkworks::WasmPastaFp as WasmF;
+    use mina_curves::pasta::fp::Fp as F;
+
+    impl_gate_vector!(fp, WasmF, F, Fp);
+}
+
+//
+// Fq
+//
+
+pub mod fq {
+    use super::*;
+    use crate::arkworks::WasmPastaFq as WasmF;
+    use mina_curves::pasta::fq::Fq as F;
+
+    impl_gate_vector!(fq, WasmF, F, Fq);
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/lib.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/lib.rs
@@ -14,7 +14,7 @@ mod wasm_flat_vector;
 mod wasm_vector;
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub fn alert(s: &str);
 }
 
@@ -54,7 +54,9 @@ pub fn set_u32_ptr(ptr: *mut u32, arg: u32) {
     // The rust docs explicitly forbid using this for cross-thread syncronization. Oh well, we
     // don't have anything better. As long as it works in practice, we haven't upset the undefined
     // behavior dragons.
-    unsafe { std::ptr::write_volatile(ptr, arg); }
+    unsafe {
+        std::ptr::write_volatile(ptr, arg);
+    }
 }
 
 #[wasm_bindgen]
@@ -64,7 +66,9 @@ pub fn wait_until_non_zero(ptr: *const u32) -> u32 {
     // behavior dragons.
     loop {
         let contents = unsafe { std::ptr::read_volatile(ptr) };
-        if contents != 0 { return contents; }
+        if contents != 0 {
+            return contents;
+        }
     }
     unreachable!();
 }
@@ -80,9 +84,9 @@ pub mod urs_utils; // TODO: move this logic to proof-systems
 /// Vectors
 pub mod gate_vector;
 
+pub mod poly_comm;
 /// Curves
 pub mod projective;
-pub mod poly_comm;
 
 /// SRS
 pub mod srs;

--- a/src/lib/crypto/kimchi_bindings/wasm/src/lib.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/lib.rs
@@ -1,0 +1,116 @@
+#![feature(get_mut_unchecked)]
+//! The Marlin_plonk_stubs crate exports some functionalities
+//! and structures from the following the Rust crates to OCaml:
+//!
+//! * [Marlin](https://github.com/o1-labs/marlin),
+//!   a PLONK implementation.
+//! * [Arkworks](http://arkworks.rs/),
+//!   a math library that Marlin builds on top of.
+//!
+
+use wasm_bindgen::prelude::*;
+
+mod wasm_flat_vector;
+mod wasm_vector;
+
+#[wasm_bindgen]
+extern {
+    pub fn alert(s: &str);
+}
+
+#[wasm_bindgen]
+pub fn greet(name: &str) {
+    alert(&format!("Hello, {}!", name));
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+// produces a warning, but can be useful
+// macro_rules! console_log {
+//     ($($t:tt)*) => (crate::log(&format_args!($($t)*).to_string()))
+// }
+
+#[wasm_bindgen]
+pub fn console_log(s: &str) {
+    log(s);
+}
+
+#[wasm_bindgen]
+pub fn create_zero_u32_ptr() -> *mut u32 {
+    Box::into_raw(std::boxed::Box::new(0))
+}
+
+#[wasm_bindgen]
+pub fn free_u32_ptr(ptr: *mut u32) {
+    let _drop_me = unsafe { std::boxed::Box::from_raw(ptr) };
+}
+
+#[wasm_bindgen]
+pub fn set_u32_ptr(ptr: *mut u32, arg: u32) {
+    // The rust docs explicitly forbid using this for cross-thread syncronization. Oh well, we
+    // don't have anything better. As long as it works in practice, we haven't upset the undefined
+    // behavior dragons.
+    unsafe { std::ptr::write_volatile(ptr, arg); }
+}
+
+#[wasm_bindgen]
+pub fn wait_until_non_zero(ptr: *const u32) -> u32 {
+    // The rust docs explicitly forbid using this for cross-thread syncronization. Oh well, we
+    // don't have anything better. As long as it works in practice, we haven't upset the undefined
+    // behavior dragons.
+    loop {
+        let contents = unsafe { std::ptr::read_volatile(ptr) };
+        if contents != 0 { return contents; }
+    }
+    unreachable!();
+}
+
+pub use wasm_bindgen_rayon::init_thread_pool;
+
+/// Arkworks types
+pub mod arkworks;
+
+/// Utils
+pub mod urs_utils; // TODO: move this logic to proof-systems
+
+/// Vectors
+pub mod gate_vector;
+
+/// Curves
+pub mod projective;
+pub mod poly_comm;
+
+/// SRS
+pub mod srs;
+
+/// Indexes
+pub mod pasta_fp_plonk_index;
+pub mod pasta_fq_plonk_index;
+
+/// Verifier indexes/keys
+pub mod plonk_verifier_index;
+
+/// Oracles
+pub mod oracles;
+
+/// Proofs
+pub mod plonk_proof;
+
+/*
+/// Handy re-exports
+pub use {
+    commitment_dlog::commitment::caml::{CamlOpeningProof, CamlPolyComm},
+    kimchi::prover::caml::{CamlProverCommitments, CamlProverProof},
+    kimchi::circuits::{
+        expr::caml::{CamlColumn, CamlLinearization, CamlPolishToken, CamlVariable},
+        gate::{caml::CamlCircuitGate, CurrOrNext, GateType},
+        nolookup::scalars::caml::{CamlLookupEvaluations, CamlProofEvaluations, CamlRandomOracles},
+        wires::caml::CamlWire,
+    },
+    oracle::sponge::caml::CamlScalarChallenge,
+};
+*/

--- a/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
@@ -1,0 +1,288 @@
+use commitment_dlog::commitment::{shift_scalar, PolyComm};
+use kimchi::prover::ProverProof;
+use kimchi::{index::VerifierIndex as DlogVerifierIndex};
+use kimchi::circuits::scalars::RandomOracles;
+use oracle::{
+    self,
+    poseidon::PlonkSpongeConstants15W,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+    FqSponge,
+};
+use paste::paste;
+use wasm_bindgen::prelude::*;
+// use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
+use crate::wasm_vector::WasmVector;
+// use crate::wasm_flat_vector::WasmFlatVector;
+use ark_ff::Zero;
+
+//
+// CamlOracles
+//
+
+//
+// Implementation
+//
+
+macro_rules! impl_oracles {
+    ($WasmF: ty,
+     $F: ty,
+     $WasmG: ty,
+     $G: ty,
+     $WasmPolyComm: ty,
+     $WasmProverProof: ty,
+     $index: ty,
+     $curve_params: ty,
+     $field_name: ident) => {
+
+        paste! {
+            use crate::wasm_flat_vector::WasmFlatVector;
+            use oracle::sponge::ScalarChallenge;
+
+            #[wasm_bindgen]
+            #[derive(Clone, Copy)]
+            pub struct [<Wasm $field_name:camel RandomOracles>] {
+                pub joint_combiner_chal: $WasmF,
+                pub joint_combiner: $WasmF,
+                pub beta: $WasmF,
+                pub gamma: $WasmF,
+                pub alpha_chal: $WasmF,
+                pub alpha: $WasmF,
+                pub zeta: $WasmF,
+                pub v: $WasmF,
+                pub u: $WasmF,
+                pub zeta_chal: $WasmF,
+                pub v_chal: $WasmF,
+                pub u_chal: $WasmF,
+            }
+            type WasmRandomOracles = [<Wasm $field_name:camel RandomOracles>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel RandomOracles>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    joint_combiner_chal: $WasmF,
+                    joint_combiner: $WasmF,
+                    beta: $WasmF,
+                    gamma: $WasmF,
+                    alpha_chal: $WasmF,
+                    alpha: $WasmF,
+                    zeta: $WasmF,
+                    v: $WasmF,
+                    u: $WasmF,
+                    zeta_chal: $WasmF,
+                    v_chal: $WasmF,
+                    u_chal: $WasmF) -> Self  {
+                    Self {
+                        joint_combiner_chal,
+                        joint_combiner,
+                        beta,
+                        gamma,
+                        alpha_chal,
+                        alpha,
+                        zeta,
+                        v,
+                        u,
+                        zeta_chal,
+                        v_chal,
+                        u_chal,
+                    }
+                }
+            }
+
+            impl From<RandomOracles<$F>> for WasmRandomOracles
+            {
+                fn from(ro: RandomOracles<$F>) -> Self {
+                    Self {
+                        joint_combiner_chal: ro.joint_combiner.0.0.into(),
+                        joint_combiner: ro.joint_combiner.1.into(),
+                        beta: ro.beta.into(),
+                        gamma: ro.gamma.into(),
+                        alpha_chal: ro.alpha_chal.0.into(),
+                        alpha: ro.alpha.into(),
+                        zeta: ro.zeta.into(),
+                        v: ro.v.into(),
+                        u: ro.u.into(),
+                        zeta_chal: ro.zeta_chal.0.into(),
+                        v_chal: ro.v_chal.0.into(),
+                        u_chal: ro.u_chal.0.into(),
+                    }
+                }
+            }
+
+            impl Into<RandomOracles<$F>> for WasmRandomOracles
+            {
+                fn into(self) -> RandomOracles<$F> {
+                    RandomOracles {
+                        joint_combiner: (ScalarChallenge(self.joint_combiner_chal.into()), self.joint_combiner.into()),
+                        beta: self.beta.into(),
+                        gamma: self.gamma.into(),
+                        alpha_chal: ScalarChallenge(self.alpha_chal.into()),
+                        alpha: self.alpha.into(),
+                        zeta: self.zeta.into(),
+                        v: self.v.into(),
+                        u: self.u.into(),
+                        zeta_chal: ScalarChallenge(self.zeta_chal.into()),
+                        v_chal: ScalarChallenge(self.v_chal.into()),
+                        u_chal: ScalarChallenge(self.u_chal.into()),
+                    }
+                }
+            }
+
+            #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel Oracles>] {
+                pub o: [<Wasm $field_name:camel RandomOracles>],
+                pub p_eval0: $WasmF,
+                pub p_eval1: $WasmF,
+                #[wasm_bindgen(skip)]
+                pub opening_prechallenges: WasmFlatVector<$WasmF>,
+                pub digest_before_evaluations: $WasmF,
+            }
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel Oracles>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    o: WasmRandomOracles,
+                    p_eval0: $WasmF,
+                    p_eval1: $WasmF,
+                    opening_prechallenges: WasmFlatVector<$WasmF>,
+                    digest_before_evaluations: $WasmF) -> Self {
+                    Self {o, p_eval0, p_eval1, opening_prechallenges, digest_before_evaluations}
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$F:snake _oracles_create>](
+                lgr_comm: WasmVector<$WasmPolyComm>, // the bases to commit polynomials
+                index: $index,    // parameters
+                proof: $WasmProverProof, // the final proof (contains public elements at the beginning)
+            ) -> [<Wasm $field_name:camel Oracles>] {
+                // conversions
+
+                let index: DlogVerifierIndex<$G> = index.into();
+
+                let lgr_comm: Vec<PolyComm<$G>> = lgr_comm
+                    .into_iter()
+                    .take(proof.public.len())
+                    .map(Into::into)
+                    .collect();
+                let lgr_comm_refs: Vec<_> = lgr_comm.iter().collect();
+
+                let p_comm = PolyComm::<$G>::multi_scalar_mul(
+                    &lgr_comm_refs,
+                    &proof
+                        .public
+                        .iter()
+                        .map(|a| a.clone().into())
+                        .map(|s: $F| -s)
+                        .collect::<Vec<_>>(),
+                );
+
+                let proof: ProverProof<$G> = proof.into();
+
+                let oracles_result =
+                    proof.oracles::<DefaultFqSponge<$curve_params, PlonkSpongeConstants15W>, DefaultFrSponge<$F, PlonkSpongeConstants15W>>(&index, &p_comm);
+
+                let (mut sponge, combined_inner_product, p_eval, digest, oracles) = (
+                    oracles_result.fq_sponge,
+                    oracles_result.combined_inner_product,
+                    oracles_result.p_eval,
+                    oracles_result.digest,
+                    oracles_result.oracles,
+                );
+
+                sponge.absorb_fr(&[shift_scalar::<$G>(combined_inner_product)]);
+
+                let opening_prechallenges = proof
+                    .proof
+                    .prechallenges(&mut sponge)
+                    .into_iter()
+                    .map(|x| x.0.into())
+                    .collect();
+
+                [<Wasm $field_name:camel Oracles>] {
+                    o: oracles.into(),
+                    p_eval0: p_eval[0][0].into(),
+                    p_eval1: p_eval[1][0].into(),
+                    opening_prechallenges,
+                    digest_before_evaluations: digest.into(),
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$F:snake _oracles_dummy>]() -> [<Wasm $field_name:camel Oracles>] {
+                [<Wasm $field_name:camel Oracles>] {
+                    o: RandomOracles::<$F>::default().into(),
+                    p_eval0: $F::zero().into(),
+                    p_eval1: $F::zero().into(),
+                    opening_prechallenges: vec![].into(),
+                    digest_before_evaluations: $F::zero().into(),
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$F:snake _oracles_deep_copy>](
+                x: $WasmProverProof,
+            ) -> $WasmProverProof {
+                x
+            }
+        }
+    }
+}
+
+//
+//
+//
+
+pub mod fp {
+    use super::*;
+    use crate::{
+        arkworks::{WasmPastaFp, WasmGVesta},
+        plonk_verifier_index::fp::WasmFpPlonkVerifierIndex as WasmPlonkVerifierIndex,
+        poly_comm::vesta::WasmFpPolyComm as WasmPolyComm,
+        plonk_proof::fp::WasmFpProverProof as WasmProverProof,
+    };
+    use mina_curves::pasta::{
+        fp::Fp,
+        vesta::{Affine as GAffine, VestaParameters},
+    };
+
+    impl_oracles!(
+        WasmPastaFp,
+        Fp,
+        WasmGVesta,
+        GAffine,
+        WasmPolyComm,
+        WasmProverProof,
+        WasmPlonkVerifierIndex,
+        VestaParameters,
+        Fp
+    );
+}
+
+pub mod fq {
+    use super::*;
+    use crate::{
+        arkworks::{WasmPastaFq, WasmGPallas},
+        plonk_verifier_index::fq::WasmFqPlonkVerifierIndex as WasmPlonkVerifierIndex,
+        poly_comm::pallas::WasmFqPolyComm as WasmPolyComm,
+        plonk_proof::fq::WasmFqProverProof as WasmProverProof,
+    };
+    use mina_curves::pasta::{
+        fq::Fq,
+        pallas::{Affine as GAffine, PallasParameters},
+    };
+
+    impl_oracles!(
+        WasmPastaFq,
+        Fq,
+        WasmGPallas,
+        GAffine,
+        WasmPolyComm,
+        WasmProverProof,
+        WasmPlonkVerifierIndex,
+        PallasParameters,
+        Fq
+    );
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
@@ -1,7 +1,7 @@
 use commitment_dlog::commitment::{shift_scalar, PolyComm};
-use kimchi::prover::ProverProof;
-use kimchi::{index::VerifierIndex as DlogVerifierIndex};
 use kimchi::circuits::scalars::RandomOracles;
+use kimchi::index::VerifierIndex as DlogVerifierIndex;
+use kimchi::prover::ProverProof;
 use oracle::{
     self,
     poseidon::PlonkSpongeConstants15W,
@@ -238,10 +238,10 @@ macro_rules! impl_oracles {
 pub mod fp {
     use super::*;
     use crate::{
-        arkworks::{WasmPastaFp, WasmGVesta},
+        arkworks::{WasmGVesta, WasmPastaFp},
+        plonk_proof::fp::WasmFpProverProof as WasmProverProof,
         plonk_verifier_index::fp::WasmFpPlonkVerifierIndex as WasmPlonkVerifierIndex,
         poly_comm::vesta::WasmFpPolyComm as WasmPolyComm,
-        plonk_proof::fp::WasmFpProverProof as WasmProverProof,
     };
     use mina_curves::pasta::{
         fp::Fp,
@@ -264,10 +264,10 @@ pub mod fp {
 pub mod fq {
     use super::*;
     use crate::{
-        arkworks::{WasmPastaFq, WasmGPallas},
+        arkworks::{WasmGPallas, WasmPastaFq},
+        plonk_proof::fq::WasmFqProverProof as WasmProverProof,
         plonk_verifier_index::fq::WasmFqPlonkVerifierIndex as WasmPlonkVerifierIndex,
         poly_comm::pallas::WasmFqPolyComm as WasmPolyComm,
-        plonk_proof::fq::WasmFqProverProof as WasmProverProof,
     };
     use mina_curves::pasta::{
         fq::Fq,

--- a/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fp_plonk_index.rs
@@ -1,0 +1,183 @@
+use ark_poly::EvaluationDomain;
+
+use kimchi::index::{expr_linearization, Index as DlogIndex};
+use kimchi::circuits::{gate::CircuitGate, constraints::ConstraintSystem};
+use mina_curves::pasta::{fp::Fp, pallas::Affine as GAffineOther, vesta::Affine as GAffine};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
+};
+use crate::srs::fp::WasmFpSrs as WasmSrs;
+use crate::gate_vector::fp::WasmGateVector;
+use wasm_bindgen::prelude::*;
+
+//
+// CamlPastaFpPlonkIndex (custom type)
+//
+
+/// Boxed so that we don't store large proving indexes in the OCaml heap.
+#[wasm_bindgen]
+pub struct WasmPastaFpPlonkIndex(
+    #[wasm_bindgen(skip)]
+    pub Box<DlogIndex<GAffine>>);
+
+//
+// CamlPastaFpPlonkIndex methods
+//
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_plonk_index_create(
+    gates: &WasmGateVector,
+    public_: i32,
+    srs: &WasmSrs,
+) -> Result<WasmPastaFpPlonkIndex, JsValue> {
+    // flatten the permutation information (because OCaml has a different way of keeping track of permutations)
+    let gates: Vec<_> = gates.0
+        .iter()
+        .map(|gate| CircuitGate::<Fp> {
+            typ: gate.typ,
+            wires: gate.wires,
+            c: gate.c.clone(),
+        })
+        .collect();
+
+    // console_log("Index.create Fp");
+    // for (i, g) in gates.iter().enumerate() {
+    //     console_log(&format_circuit_gate(i, g));
+    // }
+
+    // create constraint system
+    let cs = match ConstraintSystem::<Fp>::create(
+        gates,
+        vec![],
+        oracle::pasta::fp_3::params(),
+        public_ as usize,
+    ) {
+        None => {
+            return Err(JsValue::from_str(
+                "caml_pasta_fp_plonk_index_create: could not create constraint system",
+            ));
+        }
+        Some(cs) => cs,
+    };
+
+    // endo
+    let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
+
+    // Unsafe if we are in a multi-core ocaml
+    {
+        let ptr: &mut commitment_dlog::srs::SRS<GAffine> =
+            unsafe { &mut *(std::sync::Arc::as_ptr(&srs.0) as *mut _) };
+        ptr.add_lagrange_basis(cs.domain.d1);
+    }
+
+    // create index
+    Ok(WasmPastaFpPlonkIndex(Box::new(
+        DlogIndex::<GAffine>::create(cs, oracle::pasta::fq_3::params(), endo_q, srs.0.clone()),
+    )))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_plonk_index_max_degree(index: &WasmPastaFpPlonkIndex) -> i32 {
+    index.0.srs.max_degree() as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_plonk_index_public_inputs(index: &WasmPastaFpPlonkIndex) -> i32 {
+    index.0.cs.public as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_plonk_index_domain_d1_size(index: &WasmPastaFpPlonkIndex) -> i32 {
+    index.0.cs.domain.d1.size() as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_plonk_index_domain_d4_size(index: &WasmPastaFpPlonkIndex) -> i32 {
+    index.0.cs.domain.d4.size() as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_plonk_index_domain_d8_size(index: &WasmPastaFpPlonkIndex) -> i32 {
+    index.0.cs.domain.d8.size() as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_plonk_index_read(
+    offset: Option<i32>,
+    srs: &WasmSrs,
+    path: String,
+) -> Result<WasmPastaFpPlonkIndex, JsValue> {
+    // read from file
+    let file = match File::open(path) {
+        Err(_) => {
+            return Err(JsValue::from_str("caml_pasta_fp_plonk_index_read"))
+        }
+        Ok(file) => file,
+    };
+    let mut r = BufReader::new(file);
+
+    // optional offset in file
+    if let Some(offset) = offset {
+        r.seek(Start(offset as u64)).map_err(|err| JsValue::from_str(&format!("caml_pasta_fp_plonk_index_read: {}", err)))?;
+    }
+
+    // deserialize the index
+    let mut t = DlogIndex::<GAffine>::deserialize(&mut rmp_serde::Deserializer::new(r))
+        .map_err(|err| JsValue::from_str(&format!("caml_pasta_fp_plonk_index_read: {}", err)))?;
+    t.cs.fr_sponge_params = oracle::pasta::fp_3::params();
+    t.srs = srs.0.clone();
+    t.fq_sponge_params = oracle::pasta::fq_3::params();
+    t.linearization = expr_linearization(t.cs.domain.d1, false, &None);
+
+    //
+    Ok(WasmPastaFpPlonkIndex(Box::new(t)))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fp_plonk_index_write(
+    append: Option<bool>,
+    index: &WasmPastaFpPlonkIndex,
+    path: String,
+) -> Result<(), JsValue> {
+    let file = OpenOptions::new()
+        .append(append.unwrap_or(true))
+        .open(path)
+        .map_err(|_| {
+            JsValue::from_str("caml_pasta_fp_plonk_index_write")
+        })?;
+    let w = BufWriter::new(file);
+    index
+        .0
+        .serialize(&mut rmp_serde::Serializer::new(w))
+        .map_err(|e| JsValue::from_str(&format!("caml_pasta_fp_plonk_index_read: {}", e)))
+}
+
+// helpers
+
+fn format_field(f: &Fp) -> String {
+    // TODO this could be much nicer, should end up as "1", "-1", "0" etc
+    format!("{}", f)
+}
+
+pub fn format_circuit_gate(i: usize, gate: &CircuitGate<Fp>) -> String {
+    let coeffs = gate
+        .c
+        .iter()
+        .map(|coeff: &Fp| format_field(coeff))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let wires = gate
+        .wires
+        .iter()
+        .enumerate()
+        .filter(|(j, wire)| wire.row != i || wire.col != *j)
+        .map(|(j, wire)| format!("({}, {}) --> ({}, {})", i, j, wire.row, wire.col))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "c[{}][{:?}]:\nconstraints\n{}\nwires\n{}\n",
+        i, gate.typ, coeffs, wires
+    )
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fp_plonk_index.rs
@@ -37,7 +37,7 @@ pub fn caml_pasta_fp_plonk_index_create(
         .map(|gate| CircuitGate::<Fp> {
             typ: gate.typ,
             wires: gate.wires,
-            c: gate.c.clone(),
+            coeffs: gate.coeffs.clone(),
         })
         .collect();
 
@@ -128,7 +128,9 @@ pub fn caml_pasta_fp_plonk_index_read(
     t.cs.fr_sponge_params = oracle::pasta::fp_3::params();
     t.srs = srs.0.clone();
     t.fq_sponge_params = oracle::pasta::fq_3::params();
-    t.linearization = expr_linearization(t.cs.domain.d1, false, &None);
+    let (linearization, powers_of_alpha) = expr_linearization(t.cs.domain.d1, false, &None);
+    t.linearization = linearization;
+    t.powers_of_alpha = powers_of_alpha;
 
     //
     Ok(WasmPastaFpPlonkIndex(Box::new(t)))
@@ -160,7 +162,7 @@ fn format_field(f: &Fp) -> String {
 
 pub fn format_circuit_gate(i: usize, gate: &CircuitGate<Fp>) -> String {
     let coeffs = gate
-        .c
+        .coeffs
         .iter()
         .map(|coeff: &Fp| format_field(coeff))
         .collect::<Vec<_>>()

--- a/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fp_plonk_index.rs
@@ -1,15 +1,15 @@
 use ark_poly::EvaluationDomain;
 
+use crate::gate_vector::fp::WasmGateVector;
+use crate::srs::fp::WasmFpSrs as WasmSrs;
+use kimchi::circuits::{constraints::ConstraintSystem, gate::CircuitGate};
 use kimchi::index::{expr_linearization, Index as DlogIndex};
-use kimchi::circuits::{gate::CircuitGate, constraints::ConstraintSystem};
 use mina_curves::pasta::{fp::Fp, pallas::Affine as GAffineOther, vesta::Affine as GAffine};
 use serde::{Deserialize, Serialize};
 use std::{
     fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
 };
-use crate::srs::fp::WasmFpSrs as WasmSrs;
-use crate::gate_vector::fp::WasmGateVector;
 use wasm_bindgen::prelude::*;
 
 //
@@ -18,9 +18,7 @@ use wasm_bindgen::prelude::*;
 
 /// Boxed so that we don't store large proving indexes in the OCaml heap.
 #[wasm_bindgen]
-pub struct WasmPastaFpPlonkIndex(
-    #[wasm_bindgen(skip)]
-    pub Box<DlogIndex<GAffine>>);
+pub struct WasmPastaFpPlonkIndex(#[wasm_bindgen(skip)] pub Box<DlogIndex<GAffine>>);
 
 //
 // CamlPastaFpPlonkIndex methods
@@ -33,7 +31,8 @@ pub fn caml_pasta_fp_plonk_index_create(
     srs: &WasmSrs,
 ) -> Result<WasmPastaFpPlonkIndex, JsValue> {
     // flatten the permutation information (because OCaml has a different way of keeping track of permutations)
-    let gates: Vec<_> = gates.0
+    let gates: Vec<_> = gates
+        .0
         .iter()
         .map(|gate| CircuitGate::<Fp> {
             typ: gate.typ,
@@ -111,16 +110,16 @@ pub fn caml_pasta_fp_plonk_index_read(
 ) -> Result<WasmPastaFpPlonkIndex, JsValue> {
     // read from file
     let file = match File::open(path) {
-        Err(_) => {
-            return Err(JsValue::from_str("caml_pasta_fp_plonk_index_read"))
-        }
+        Err(_) => return Err(JsValue::from_str("caml_pasta_fp_plonk_index_read")),
         Ok(file) => file,
     };
     let mut r = BufReader::new(file);
 
     // optional offset in file
     if let Some(offset) = offset {
-        r.seek(Start(offset as u64)).map_err(|err| JsValue::from_str(&format!("caml_pasta_fp_plonk_index_read: {}", err)))?;
+        r.seek(Start(offset as u64)).map_err(|err| {
+            JsValue::from_str(&format!("caml_pasta_fp_plonk_index_read: {}", err))
+        })?;
     }
 
     // deserialize the index
@@ -144,9 +143,7 @@ pub fn caml_pasta_fp_plonk_index_write(
     let file = OpenOptions::new()
         .append(append.unwrap_or(true))
         .open(path)
-        .map_err(|_| {
-            JsValue::from_str("caml_pasta_fp_plonk_index_write")
-        })?;
+        .map_err(|_| JsValue::from_str("caml_pasta_fp_plonk_index_write"))?;
     let w = BufWriter::new(file);
     index
         .0

--- a/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fq_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fq_plonk_index.rs
@@ -1,0 +1,157 @@
+use ark_poly::EvaluationDomain;
+
+use kimchi::index::{expr_linearization, Index as DlogIndex};
+use kimchi::circuits::{gate::CircuitGate, constraints::ConstraintSystem};
+use mina_curves::pasta::{fq::Fq, vesta::Affine as GAffineOther, pallas::Affine as GAffine};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
+};
+use crate::srs::fq::WasmFqSrs as WasmSrs;
+use crate::gate_vector::fq::WasmGateVector;
+use wasm_bindgen::prelude::*;
+
+//
+// CamlPastaFqPlonkIndex (custom type)
+//
+
+/// Boxed so that we don't store large proving indexes in the OCaml heap.
+#[wasm_bindgen]
+pub struct WasmPastaFqPlonkIndex(
+    #[wasm_bindgen(skip)]
+    pub Box<DlogIndex<GAffine>>);
+
+//
+// CamlPastaFqPlonkIndex methods
+//
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_plonk_index_create(
+    gates: &WasmGateVector,
+    public_: i32,
+    srs: &WasmSrs,
+) -> Result<WasmPastaFqPlonkIndex, JsValue> {
+    // flatten the permutation information (because OCaml has a different way of keeping track of permutations)
+    let gates: Vec<_> = gates.0
+        .iter()
+        .map(|gate| CircuitGate::<Fq> {
+            typ: gate.typ,
+            wires: gate.wires,
+            c: gate.c.clone(),
+        })
+        .collect();
+
+    /*
+    for (i, g) in gates.iter().enumerate() {
+        let x : Vec<_> = g.c.iter().map(|x| format!("{}", x)).collect();
+        let s = x.join(", ");
+        println!("c[{}][{:?}]: {}", i, g.typ, s);
+    } */
+
+    // create constraint system
+    let cs = match ConstraintSystem::<Fq>::create(
+        gates,
+        vec![],
+        oracle::pasta::fq_3::params(),
+        public_ as usize,
+    ) {
+        None => {
+            return Err(JsValue::from_str(
+                "caml_pasta_fq_plonk_index_create: could not create constraint system",
+            ));
+        }
+        Some(cs) => cs,
+    };
+
+    // endo
+    let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
+
+    // Unsafe if we are in a multi-core ocaml
+    {
+        let ptr: &mut commitment_dlog::srs::SRS<GAffine> =
+            unsafe { &mut *(std::sync::Arc::as_ptr(&srs.0) as *mut _) };
+        ptr.add_lagrange_basis(cs.domain.d1);
+    }
+
+    // create index
+    Ok(WasmPastaFqPlonkIndex(Box::new(
+        DlogIndex::<GAffine>::create(cs, oracle::pasta::fp_3::params(), endo_q, srs.0.clone()),
+    )))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_plonk_index_max_degree(index: &WasmPastaFqPlonkIndex) -> i32 {
+    index.0.srs.max_degree() as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_plonk_index_public_inputs(index: &WasmPastaFqPlonkIndex) -> i32 {
+    index.0.cs.public as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_plonk_index_domain_d1_size(index: &WasmPastaFqPlonkIndex) -> i32 {
+    index.0.cs.domain.d1.size() as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_plonk_index_domain_d4_size(index: &WasmPastaFqPlonkIndex) -> i32 {
+    index.0.cs.domain.d4.size() as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_plonk_index_domain_d8_size(index: &WasmPastaFqPlonkIndex) -> i32 {
+    index.0.cs.domain.d8.size() as i32
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_plonk_index_read(
+    offset: Option<i32>,
+    srs: &WasmSrs,
+    path: String,
+) -> Result<WasmPastaFqPlonkIndex, JsValue> {
+    // read from file
+    let file = match File::open(path) {
+        Err(_) => {
+            return Err(JsValue::from_str("caml_pasta_fq_plonk_index_read"))
+        }
+        Ok(file) => file,
+    };
+    let mut r = BufReader::new(file);
+
+    // optional offset in file
+    if let Some(offset) = offset {
+        r.seek(Start(offset as u64)).map_err(|err| JsValue::from_str(&format!("caml_pasta_fq_plonk_index_read: {}", err)))?;
+    }
+
+    // deserialize the index
+    let mut t = DlogIndex::<GAffine>::deserialize(&mut rmp_serde::Deserializer::new(r))
+        .map_err(|err| JsValue::from_str(&format!("caml_pasta_fq_plonk_index_read: {}", err)))?;
+    t.cs.fr_sponge_params = oracle::pasta::fq_3::params();
+    t.srs = srs.0.clone();
+    t.fq_sponge_params = oracle::pasta::fp_3::params();
+    t.linearization = expr_linearization(t.cs.domain.d1, false, &None);
+
+    //
+    Ok(WasmPastaFqPlonkIndex(Box::new(t)))
+}
+
+#[wasm_bindgen]
+pub fn caml_pasta_fq_plonk_index_write(
+    append: Option<bool>,
+    index: &WasmPastaFqPlonkIndex,
+    path: String,
+) -> Result<(), JsValue> {
+    let file = OpenOptions::new()
+        .append(append.unwrap_or(true))
+        .open(path)
+        .map_err(|_| {
+            JsValue::from_str("caml_pasta_fq_plonk_index_write")
+        })?;
+    let w = BufWriter::new(file);
+    index
+        .0
+        .serialize(&mut rmp_serde::Serializer::new(w))
+        .map_err(|e| JsValue::from_str(&format!("caml_pasta_fq_plonk_index_read: {}", e)))
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fq_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fq_plonk_index.rs
@@ -37,7 +37,7 @@ pub fn caml_pasta_fq_plonk_index_create(
         .map(|gate| CircuitGate::<Fq> {
             typ: gate.typ,
             wires: gate.wires,
-            c: gate.c.clone(),
+            coeffs: gate.coeffs.clone(),
         })
         .collect();
 
@@ -130,7 +130,9 @@ pub fn caml_pasta_fq_plonk_index_read(
     t.cs.fr_sponge_params = oracle::pasta::fq_3::params();
     t.srs = srs.0.clone();
     t.fq_sponge_params = oracle::pasta::fp_3::params();
-    t.linearization = expr_linearization(t.cs.domain.d1, false, &None);
+    let (linearization, powers_of_alpha) = expr_linearization(t.cs.domain.d1, false, &None);
+    t.linearization = linearization;
+    t.powers_of_alpha = powers_of_alpha;
 
     //
     Ok(WasmPastaFqPlonkIndex(Box::new(t)))

--- a/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
@@ -1,0 +1,832 @@
+// use kimchi::circuits::expr::{Linearization, PolishToken, Variable, Column};
+// use kimchi::circuits::gate::{GateType, CurrOrNext};
+use paste::paste;
+use crate::wasm_vector::WasmVector;
+use crate::wasm_flat_vector::WasmFlatVector;
+use wasm_bindgen::prelude::*;
+use std::convert::TryInto;
+// use std::sync::Arc;
+// use commitment_dlog::srs::SRS;
+// use kimchi::index::{expr_linearization, VerifierIndex as DlogVerifierIndex};
+// use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
+use ark_ec::AffineCurve;
+use ark_ff::One;
+use array_init::array_init;
+use kimchi::circuits::{
+    scalars::ProofEvaluations,
+    // nolookup::constraints::{zk_polynomial, zk_w3, Shifts},
+    wires::{COLUMNS},
+};
+// use std::path::Path;
+use commitment_dlog::commitment::{CommitmentCurve, OpeningProof, PolyComm};
+use kimchi::prover::{ProverCommitments, ProverProof};
+use kimchi::index::Index;
+use groupmap::GroupMap;
+use oracle::{
+    poseidon::PlonkSpongeConstants15W,
+    sponge::{DefaultFqSponge, DefaultFrSponge},
+};
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+macro_rules! impl_proof {
+    (
+     $name: ident,
+     $WasmG: ty,
+     $G: ty,
+     $WasmF: ty,
+     $F: ty,
+     $WasmPolyComm: ty,
+     $WasmSrs: ty,
+     $GOther: ty,
+     $FrSpongeParams: path,
+     $FqSpongeParams: path,
+     $WasmIndex: ty,
+     $WasmVerifierIndex: ty,
+     $field_name: ident
+     ) => {
+
+        paste! {
+            #[wasm_bindgen]
+            pub struct [<WasmVecVec $field_name:camel>](Vec<Vec<$F>>);
+            type WasmVecVecF = [<WasmVecVec $field_name:camel>];
+
+            #[wasm_bindgen]
+            impl [<WasmVecVec $field_name:camel>] {
+                #[wasm_bindgen(constructor)]
+                pub fn create(n: i32) -> Self {
+                    [<WasmVecVec $field_name:camel>](Vec::with_capacity(n as usize))
+                }
+
+                #[wasm_bindgen]
+                pub fn push(&mut self, x: WasmFlatVector<$WasmF>) {
+                    self.0.push(x.into_iter().map(Into::into).collect())
+                }
+
+                #[wasm_bindgen]
+                pub fn get(&self, i: i32) -> WasmFlatVector<$WasmF> {
+                    self.0[i as usize].clone().into_iter().map(Into::into).collect()
+                }
+
+                #[wasm_bindgen]
+                pub fn set(&mut self, i: i32, x: WasmFlatVector<$WasmF>) {
+                    self.0[i as usize] = x.into_iter().map(Into::into).collect()
+                }
+            }
+
+            #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel ProofEvaluations>] {
+                #[wasm_bindgen(skip)]
+                pub w: Vec<Vec<$F>>,
+                #[wasm_bindgen(skip)]
+                pub z: WasmFlatVector<$WasmF>,
+                #[wasm_bindgen(skip)]
+                pub s: Vec<Vec<$F>>,
+                #[wasm_bindgen(skip)]
+                pub generic_selector: WasmFlatVector<$WasmF>,
+                #[wasm_bindgen(skip)]
+                pub poseidon_selector: WasmFlatVector<$WasmF>,
+                // TODO: Lookup
+            }
+            type WasmProofEvaluations = [<Wasm $field_name:camel ProofEvaluations>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel ProofEvaluations>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    w: WasmVecVecF,
+                    z: WasmFlatVector<$WasmF>,
+                    s: WasmVecVecF,
+                    generic_selector: WasmFlatVector<$WasmF>,
+                    poseidon_selector: WasmFlatVector<$WasmF>) -> Self {
+                    WasmProofEvaluations { w: w.0, z, s: s.0, generic_selector, poseidon_selector }
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn w(&self) -> WasmVecVecF {
+                    [<WasmVecVec $field_name:camel>](self.w.clone())
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn z(&self) -> WasmFlatVector<$WasmF> {
+                    self.z.clone()
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn s(&self) -> WasmVecVecF {
+                    [<WasmVecVec $field_name:camel>](self.s.clone())
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn generic_selector(&self) -> WasmFlatVector<$WasmF> {
+                    self.generic_selector.clone()
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn poseidon_selector(&self) -> WasmFlatVector<$WasmF> {
+                    self.poseidon_selector.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_w(&mut self, x: WasmVecVecF) {
+                    self.w = x.0
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_s(&mut self, x: WasmVecVecF) {
+                    self.s = x.0
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_z(&mut self, x: WasmFlatVector<$WasmF>) {
+                    self.z = x
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_generic_selector(&mut self, x: WasmFlatVector<$WasmF>) {
+                    self.generic_selector = x
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_poseidon_selector(&mut self, x: WasmFlatVector<$WasmF>) {
+                    self.poseidon_selector = x
+                }
+            }
+
+            impl From<&WasmProofEvaluations> for ProofEvaluations<Vec<$F>> {
+                fn from(x: &WasmProofEvaluations) -> Self {
+                    ProofEvaluations {
+                        w: array_init(|i| x.w[i].clone()),
+                        s: array_init(|i| x.s[i].clone()),
+                        z: x.z.iter().map(|a| a.clone().into()).collect(),
+                        generic_selector: x.generic_selector.iter().map(|a| a.clone().into()).collect(),
+                        poseidon_selector: x.poseidon_selector.iter().map(|a| a.clone().into()).collect(),
+                        // TODO
+                        lookup: None
+                    }
+                }
+            }
+
+            impl From<WasmProofEvaluations> for ProofEvaluations<Vec<$F>> {
+                fn from(x: WasmProofEvaluations) -> Self {
+                    ProofEvaluations {
+                        w: array_init(|i| x.w[i].clone()),
+                        s: array_init(|i| x.s[i].clone()),
+                        z: x.z.into_iter().map(Into::into).collect(),
+                        generic_selector: x.generic_selector.into_iter().map(Into::into).collect(),
+                        poseidon_selector: x.poseidon_selector.into_iter().map(Into::into).collect(),
+                        // TODO
+                        lookup: None
+                    }
+                }
+            }
+
+            impl From<&ProofEvaluations<Vec<$F>>> for WasmProofEvaluations {
+                fn from(x: &ProofEvaluations<Vec<$F>>) -> Self {
+                    WasmProofEvaluations {
+                        w: x.w.to_vec(),
+                        s: x.s.to_vec(),
+                        z: x.z.iter().map(|a| a.clone().into()).collect(),
+                        generic_selector: x.generic_selector.iter().map(|a| a.clone().into()).collect(),
+                        poseidon_selector: x.poseidon_selector.iter().map(|a| a.clone().into()).collect(),
+                    }
+                }
+            }
+
+            impl From<ProofEvaluations<Vec<$F>>> for WasmProofEvaluations {
+                fn from(x: ProofEvaluations<Vec<$F>>) -> Self {
+                    WasmProofEvaluations {
+                        w: x.w.to_vec(),
+                        s: x.s.to_vec(),
+                        z: x.z.into_iter().map(Into::into).collect(),
+                        generic_selector: x.generic_selector.into_iter().map(Into::into).collect(),
+                        poseidon_selector: x.poseidon_selector.into_iter().map(Into::into).collect(),
+                    }
+                }
+            }
+
+            #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel ProverCommitments>]
+            {
+                #[wasm_bindgen(skip)]
+                pub w_comm: WasmVector<$WasmPolyComm>,
+                #[wasm_bindgen(skip)]
+                pub z_comm: $WasmPolyComm,
+                #[wasm_bindgen(skip)]
+                pub t_comm: $WasmPolyComm,
+                /* TODO
+                #[wasm_bindgen(skip)]
+                pub lookup: Option<LookupCommitments<G>>,
+                */
+            }
+            type WasmProverCommitments = [<Wasm $field_name:camel ProverCommitments>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel ProverCommitments>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    w_comm: WasmVector<$WasmPolyComm>,
+                    z_comm: $WasmPolyComm,
+                    t_comm: $WasmPolyComm) -> Self {
+                    WasmProverCommitments { w_comm, z_comm, t_comm }
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn w_comm(&self) -> WasmVector<$WasmPolyComm> {
+                    self.w_comm.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn z_comm(&self) -> $WasmPolyComm {
+                    self.z_comm.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn t_comm(&self) -> $WasmPolyComm {
+                    self.t_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_w_comm(&mut self, x: WasmVector<$WasmPolyComm>) {
+                    self.w_comm = x
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_z_comm(&mut self, x: $WasmPolyComm) {
+                    self.z_comm = x
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_t_comm(&mut self, x: $WasmPolyComm) {
+                    self.t_comm = x
+                }
+            }
+
+            impl From<&ProverCommitments<GAffine>> for WasmProverCommitments {
+                fn from(x: &ProverCommitments<GAffine>) -> Self {
+                    WasmProverCommitments {
+                        w_comm: x.w_comm.iter().map(Into::into).collect(),
+                        z_comm: x.z_comm.clone().into(),
+                        t_comm: x.t_comm.clone().into(),
+                    }
+                }
+            }
+
+            impl From<ProverCommitments<GAffine>> for WasmProverCommitments {
+                fn from(x: ProverCommitments<GAffine>) -> Self {
+                    WasmProverCommitments {
+                        w_comm: x.w_comm.iter().map(Into::into).collect(),
+                        z_comm: x.z_comm.into(),
+                        t_comm: x.t_comm.into(),
+                    }
+                }
+            }
+
+            impl From<&WasmProverCommitments> for ProverCommitments<GAffine> {
+                fn from(x: &WasmProverCommitments) -> Self {
+                    ProverCommitments {
+                        w_comm: array_init(|i| x.w_comm[i].clone().into()),
+                        z_comm: x.z_comm.clone().into(),
+                        t_comm: x.t_comm.clone().into(),
+                        // TODO
+                        lookup: None,
+                    }
+                }
+            }
+
+            impl From<WasmProverCommitments> for ProverCommitments<GAffine> {
+                fn from(x: WasmProverCommitments) -> Self {
+                    ProverCommitments {
+                        w_comm: array_init(|i| (&x.w_comm[i]).into()),
+                        z_comm: x.z_comm.into(),
+                        t_comm: x.t_comm.into(),
+                        // TODO
+                        lookup: None,
+                    }
+                }
+            }
+
+            #[wasm_bindgen]
+            #[derive(Clone, Debug)]
+            pub struct [<Wasm $field_name:camel OpeningProof>] {
+                #[wasm_bindgen(skip)]
+                pub lr_0: WasmVector<$WasmG>, // vector of rounds of L commitments
+                #[wasm_bindgen(skip)]
+                pub lr_1: WasmVector<$WasmG>, // vector of rounds of R commitments
+                #[wasm_bindgen(skip)]
+                pub delta: $WasmG,
+                pub z1: $WasmF,
+                pub z2: $WasmF,
+                #[wasm_bindgen(skip)]
+                pub sg: $WasmG,
+            }
+            type WasmOpeningProof = [<Wasm $field_name:camel OpeningProof>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel OpeningProof>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    lr_0: WasmVector<$WasmG>,
+                    lr_1: WasmVector<$WasmG>,
+                    delta: $WasmG,
+                    z1: $WasmF,
+                    z2: $WasmF,
+                    sg: $WasmG) -> Self {
+                    WasmOpeningProof { lr_0, lr_1, delta, z1, z2, sg }
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn lr_0(&self) -> WasmVector<$WasmG> {
+                    self.lr_0.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn lr_1(&self) -> WasmVector<$WasmG> {
+                    self.lr_1.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn delta(&self) -> $WasmG {
+                    self.delta.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn sg(&self) -> $WasmG {
+                    self.sg.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_lr_0(&mut self, lr_0: WasmVector<$WasmG>) {
+                    self.lr_0 = lr_0
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_lr_1(&mut self, lr_1: WasmVector<$WasmG>) {
+                    self.lr_1 = lr_1
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_delta(&mut self, delta: $WasmG) {
+                    self.delta = delta
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_sg(&mut self, sg: $WasmG) {
+                    self.sg = sg
+                }
+            }
+
+            impl From<&WasmOpeningProof> for OpeningProof<$G> {
+                fn from(x: &WasmOpeningProof) -> Self {
+                    OpeningProof {
+                        lr: x.lr_0.clone().into_iter().zip(x.lr_1.clone().into_iter()).map(|(x, y)| (x.into(), y.into())).collect(),
+                        delta: x.delta.clone().into(),
+                        z1: x.z1.into(),
+                        z2: x.z2.into(),
+                        sg: x.sg.clone().into(),
+                    }
+                }
+            }
+
+            impl From<WasmOpeningProof> for OpeningProof<$G> {
+                fn from(x: WasmOpeningProof) -> Self {
+                    let WasmOpeningProof {lr_0, lr_1, delta, z1, z2, sg} = x;
+                    OpeningProof {
+                        lr: lr_0.into_iter().zip(lr_1.into_iter()).map(|(x, y)| (x.into(), y.into())).collect(),
+                        delta: delta.into(),
+                        z1: z1.into(),
+                        z2: z2.into(),
+                        sg: sg.into(),
+                    }
+                }
+            }
+
+            impl From<&OpeningProof<$G>> for WasmOpeningProof {
+                fn from(x: &OpeningProof<$G>) -> Self {
+                    let (lr_0, lr_1) = x.lr.clone().into_iter().map(|(x, y)| (x.into(), y.into())).unzip();
+                    WasmOpeningProof {
+                        lr_0,
+                        lr_1,
+                        delta: x.delta.clone().into(),
+                        z1: x.z1.into(),
+                        z2: x.z2.into(),
+                        sg: x.sg.clone().into(),
+                    }
+                }
+            }
+
+            impl From<OpeningProof<$G>> for WasmOpeningProof {
+                fn from(x: OpeningProof<$G>) -> Self {
+                    let (lr_0, lr_1) = x.lr.clone().into_iter().map(|(x, y)| (x.into(), y.into())).unzip();
+                    WasmOpeningProof {
+                        lr_0,
+                        lr_1,
+                        delta: x.delta.clone().into(),
+                        z1: x.z1.into(),
+                        z2: x.z2.into(),
+                        sg: x.sg.clone().into(),
+                    }
+                }
+            }
+
+            #[wasm_bindgen]
+            pub struct [<Wasm $field_name:camel ProverProof>] {
+                #[wasm_bindgen(skip)]
+                pub commitments: WasmProverCommitments,
+                #[wasm_bindgen(skip)]
+                pub proof: WasmOpeningProof,
+                // OCaml doesn't have sized arrays, so we have to convert to a tuple..
+                #[wasm_bindgen(skip)]
+                pub evals0: WasmProofEvaluations,
+                #[wasm_bindgen(skip)]
+                pub evals1: WasmProofEvaluations,
+                pub ft_eval1: $WasmF,
+                #[wasm_bindgen(skip)]
+                pub public: WasmFlatVector<$WasmF>,
+                #[wasm_bindgen(skip)]
+                pub prev_challenges_scalars: Vec<Vec<$F>>,
+                #[wasm_bindgen(skip)]
+                pub prev_challenges_comms: WasmVector<$WasmPolyComm>,
+            }
+            type WasmProverProof = [<Wasm $field_name:camel ProverProof>];
+
+            impl From<&ProverProof<$G>> for WasmProverProof {
+                fn from(x: &ProverProof<$G>) -> Self {
+                    let (scalars, comms) = x.prev_challenges.iter().map(|(x, y)| (x.clone().into(), y.into())).unzip();
+                    WasmProverProof {
+                        commitments: x.commitments.clone().into(),
+                        proof: x.proof.clone().into(),
+                        evals0: x.evals[0].clone().into(),
+                        evals1: x.evals[1].clone().into(),
+                        ft_eval1: x.ft_eval1.clone().into(),
+                        public: x.public.clone().into_iter().map(Into::into).collect(),
+                        prev_challenges_scalars: scalars,
+                        prev_challenges_comms: comms,
+                    }
+                }
+            }
+
+            impl From<ProverProof<$G>> for WasmProverProof {
+                fn from(x: ProverProof<$G>) -> Self {
+                    let ProverProof {ft_eval1, commitments, proof, evals: [evals0, evals1], public, prev_challenges} = x;
+                    let (scalars, comms) = prev_challenges.into_iter().map(|(x, y)| (x.into(), y.into())).unzip();
+                    WasmProverProof {
+                        commitments: commitments.into(),
+                        proof: proof.into(),
+                        evals0: evals0.into(),
+                        evals1: evals1.into(),
+                        ft_eval1: ft_eval1.clone().into(),
+                        public: public.into_iter().map(Into::into).collect(),
+                        prev_challenges_scalars: scalars,
+                        prev_challenges_comms: comms,
+                    }
+                }
+            }
+
+            impl From<&WasmProverProof> for ProverProof<$G> {
+                fn from(x: &WasmProverProof) -> Self {
+                    ProverProof {
+                        commitments: x.commitments.clone().into(),
+                        proof: x.proof.clone().into(),
+                        evals: [x.evals0.clone().into(), x.evals1.clone().into()],
+                        public: x.public.clone().into_iter().map(Into::into).collect(),
+                        prev_challenges: (&x.prev_challenges_scalars).into_iter().zip((&x.prev_challenges_comms).into_iter()).map(|(x, y)| { (x.clone().into(), y.into()) }).collect(),
+                        ft_eval1: x.ft_eval1.clone().into()
+                    }
+                }
+            }
+
+            impl From<WasmProverProof> for ProverProof<$G> {
+                fn from(x: WasmProverProof) -> Self {
+                    ProverProof {
+                        commitments: x.commitments.into(),
+                        proof: x.proof.into(),
+                        evals: [x.evals0.into(), x.evals1.into()],
+                        public: x.public.into_iter().map(Into::into).collect(),
+                        prev_challenges: (x.prev_challenges_scalars).into_iter().zip((x.prev_challenges_comms).into_iter()).map(|(x, y)| { (x.into(), y.into()) }).collect(),
+                        ft_eval1: x.ft_eval1.into()
+                    }
+                }
+            }
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel ProverProof>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    commitments: WasmProverCommitments,
+                    proof: WasmOpeningProof,
+                    evals0: WasmProofEvaluations,
+                    evals1: WasmProofEvaluations,
+                    ft_eval1: $WasmF,
+                    public_: WasmFlatVector<$WasmF>,
+                    prev_challenges_scalars: WasmVecVecF,
+                    prev_challenges_comms: WasmVector<$WasmPolyComm>) -> Self {
+                    WasmProverProof {
+                        commitments,
+                        proof,
+                        evals0,
+                        evals1,
+                        ft_eval1,
+                        public: public_,
+                        prev_challenges_scalars: prev_challenges_scalars.0,
+                        prev_challenges_comms,
+                    }
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn commitments(&self) -> WasmProverCommitments {
+                    self.commitments.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn proof(&self) -> WasmOpeningProof {
+                    self.proof.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn evals0(&self) -> WasmProofEvaluations {
+                    self.evals0.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn evals1(&self) -> WasmProofEvaluations {
+                    self.evals1.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn public_(&self) -> WasmFlatVector<$WasmF> {
+                    self.public.clone()
+                }
+                #[wasm_bindgen(getter)]
+                pub fn prev_challenges_scalars(&self) -> WasmVecVecF {
+                    [<WasmVecVec $field_name:camel>](self.prev_challenges_scalars.clone())
+                }
+                #[wasm_bindgen(getter)]
+                pub fn prev_challenges_comms(&self) -> WasmVector<$WasmPolyComm> {
+                    self.prev_challenges_comms.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_commitments(&mut self, commitments: WasmProverCommitments) {
+                    self.commitments = commitments
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_proof(&mut self, proof: WasmOpeningProof) {
+                    self.proof = proof
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_evals0(&mut self, evals0: WasmProofEvaluations) {
+                    self.evals0 = evals0
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_evals1(&mut self, evals1: WasmProofEvaluations) {
+                    self.evals1 = evals1
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_public_(&mut self, public_: WasmFlatVector<$WasmF>) {
+                    self.public = public_
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_prev_challenges_scalars(&mut self, prev_challenges_scalars: WasmVecVecF) {
+                    self.prev_challenges_scalars = prev_challenges_scalars.0
+                }
+                #[wasm_bindgen(setter)]
+                pub fn set_prev_challenges_comms(&mut self, prev_challenges_comms: WasmVector<$WasmPolyComm>) {
+                    self.prev_challenges_comms = prev_challenges_comms
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _create>](
+                index: &$WasmIndex,
+                witness: WasmVecVecF,
+                prev_challenges: WasmFlatVector<$WasmF>,
+                prev_sgs: WasmVector<$WasmG>,
+            ) -> WasmProverProof {
+                {
+                    let ptr: &mut commitment_dlog::srs::SRS<GAffine> =
+                        unsafe { &mut *(std::sync::Arc::as_ptr(&index.0.as_ref().srs) as *mut _) };
+                    ptr.add_lagrange_basis(index.0.as_ref().cs.domain.d1);
+                }
+                let prev: Vec<(Vec<$F>, PolyComm<GAffine>)> = {
+                    if prev_challenges.is_empty() {
+                        Vec::new()
+                    } else {
+                        let challenges_per_sg = prev_challenges.len() / prev_sgs.len();
+                        prev_sgs
+                            .into_iter()
+                            .map(Into::<GAffine>::into)
+                            .enumerate()
+                            .map(|(i, sg)| {
+                                (
+                                    prev_challenges[(i * challenges_per_sg)..(i + 1) * challenges_per_sg]
+                                        .iter()
+                                        .map(|a| a.clone().into())
+                                        .collect(),
+                                    PolyComm::<GAffine> {
+                                        unshifted: vec![sg],
+                                        shifted: None,
+                                    },
+                                )
+                            })
+                            .collect()
+                    }
+                };
+
+                let witness: [Vec<_>; COLUMNS] = witness.0
+                    .try_into()
+                    .expect("the witness should be a column of 15 vectors");
+
+                let index: &Index<$G> = &index.0.as_ref();
+
+
+                // let mut vec = index.linearization.index_terms.iter().map(|i| format!("{:?}", i)).collect::<Vec<_>>();
+                // vec.sort_by(|s, t| s.cmp(&t));
+                // console_log(&format!("{:?}", vec));
+
+                // print witness
+                // for (i, w) in witness.iter().enumerate() {
+                //     let st = w.iter().map(|f| format!("{}", f)).collect::<Vec<_>>().join("\n");
+                //     console_log(&format!("witness {}\n{}\n", i, st));
+                // }
+
+                // verify witness
+                // this seems to throw in general
+                // console_log(&"verifying witness!");
+                // index.cs.verify(&witness).expect("incorrect witness");
+                // console_log(&"verifying witness ok");
+
+                // Release the runtime lock so that other threads can run using it while we generate the proof.
+                let group_map = GroupMap::<_>::setup();
+                let maybe_proof = ProverProof::create::<
+                    DefaultFqSponge<_, PlonkSpongeConstants15W>,
+                    DefaultFrSponge<_, PlonkSpongeConstants15W>,
+                >(&group_map, witness, index, prev);
+                return match maybe_proof {
+                    Ok(proof) => proof.into(),
+                    Err(err) => {
+                        log(&err.to_string());
+                        panic!("thrown an error")
+                    }
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _verify>](
+                lgr_comm: WasmVector<$WasmPolyComm>,
+                index: $WasmVerifierIndex,
+                proof: WasmProverProof,
+            ) -> bool {
+                let lgr_comm = lgr_comm.into_iter().map(|x| x.into()).collect();
+
+                let group_map = <$G as CommitmentCurve>::Map::setup();
+
+                ProverProof::verify::<
+                    DefaultFqSponge<_, PlonkSpongeConstants15W>,
+                    DefaultFrSponge<_, PlonkSpongeConstants15W>,
+                >(
+                    &group_map,
+                    &[(&index.into(), &lgr_comm, &proof.into())].to_vec(),
+                )
+                .is_ok()
+            }
+
+            #[wasm_bindgen]
+            pub struct [<WasmVecVec $field_name:camel PolyComm>](Vec<Vec<PolyComm<$G>>>);
+            type WasmVecVecPolyComm = [<WasmVecVec $field_name:camel PolyComm>];
+
+            #[wasm_bindgen]
+            impl [<WasmVecVec $field_name:camel PolyComm>] {
+                #[wasm_bindgen(constructor)]
+                pub fn create(n: i32) -> Self {
+                    [<WasmVecVec $field_name:camel PolyComm>](Vec::with_capacity(n as usize))
+                }
+
+                #[wasm_bindgen]
+                pub fn push(&mut self, x: WasmVector<$WasmPolyComm>) {
+                    self.0.push(x.into_iter().map(Into::into).collect())
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake batch_verify>](
+                lgr_comms: WasmVecVecPolyComm,
+                indexes: WasmVector<$WasmVerifierIndex>,
+                proofs: WasmVector<WasmProverProof>,
+            ) -> bool {
+                let ts: Vec<_> = indexes
+                    .into_iter()
+                    .zip(lgr_comms.0.into_iter())
+                    .zip(proofs.into_iter())
+                    .map(|((i, l), p)| (i.into(), l.into_iter().map(Into::into).collect(), p.into()))
+                    .collect();
+                let ts: Vec<_> = ts.iter().map(|(i, l, p)| (i, l, p)).collect();
+                let group_map = GroupMap::<_>::setup();
+
+                ProverProof::<$G>::verify::<
+                    DefaultFqSponge<_, PlonkSpongeConstants15W>,
+                    DefaultFrSponge<_, PlonkSpongeConstants15W>,
+                >(&group_map, &ts)
+                .is_ok()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _dummy>]() -> WasmProverProof {
+                fn comm() -> PolyComm<$G> {
+                    let g = $G::prime_subgroup_generator();
+                    PolyComm {
+                        shifted: Some(g),
+                        unshifted: vec![g, g, g],
+                    }
+                }
+
+                let prev_challenges = vec![
+                    (vec![$F::one(), $F::one()], comm()),
+                    (vec![$F::one(), $F::one()], comm()),
+                    (vec![$F::one(), $F::one()], comm()),
+                ];
+
+                let g = $G::prime_subgroup_generator();
+                let proof = OpeningProof {
+                    lr: vec![(g, g), (g, g), (g, g)],
+                    z1: $F::one(),
+                    z2: $F::one(),
+                    delta: g,
+                    sg: g,
+                };
+                let proof_evals = ProofEvaluations {
+                    w: array_init(|_| vec![$F::one()]),
+                    z: vec![$F::one()],
+                    s: array_init(|_| vec![$F::one()]),
+                    lookup: None,
+                    generic_selector: vec![$F::one()],
+                    poseidon_selector: vec![$F::one()],
+                };
+                let evals = [proof_evals.clone(), proof_evals];
+
+                let dlogproof = ProverProof {
+                    commitments: ProverCommitments {
+                        w_comm: array_init(|_| comm()),
+                        z_comm: comm(),
+                        t_comm: comm(),
+                        lookup: None,
+                    },
+                    proof,
+                    evals,
+                    ft_eval1: $F::one(),
+                    public: vec![$F::one(), $F::one()],
+                    prev_challenges,
+                };
+
+                dlogproof.into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _deep_copy>](
+                x: WasmProverProof
+            ) -> WasmProverProof {
+                x
+            }
+        }
+    }
+}
+
+pub mod fp {
+    use super::*;
+    use crate::arkworks::{WasmPastaFp, WasmGVesta};
+    use mina_curves::pasta::{fp::Fp, vesta::Affine as GAffine, pallas::Affine as GAffineOther};
+    use crate::poly_comm::vesta::WasmFpPolyComm as WasmPolyComm;
+    use crate::srs::fp::WasmFpSrs as WasmSrs;
+    use crate::pasta_fp_plonk_index::WasmPastaFpPlonkIndex;
+    use crate::plonk_verifier_index::fp::WasmFpPlonkVerifierIndex as WasmPlonkVerifierIndex;
+
+    impl_proof!(
+        caml_pasta_fp_plonk_proof,
+        WasmGVesta,
+        GAffine,
+        WasmPastaFp,
+        Fp,
+        WasmPolyComm,
+        WasmSrs,
+        GAffineOther,
+        oracle::pasta::fp_3,
+        oracle::pasta::fq_3,
+        WasmPastaFpPlonkIndex,
+        WasmPlonkVerifierIndex,
+        Fp
+        );
+}
+
+pub mod fq {
+    use super::*;
+    use crate::arkworks::{WasmPastaFq, WasmGPallas};
+    use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine, vesta::Affine as GAffineOther};
+    use crate::poly_comm::pallas::WasmFqPolyComm as WasmPolyComm;
+    use crate::srs::fq::WasmFqSrs as WasmSrs;
+    use crate::pasta_fq_plonk_index::WasmPastaFqPlonkIndex;
+    use crate::plonk_verifier_index::fq::WasmFqPlonkVerifierIndex as WasmPlonkVerifierIndex;
+
+    impl_proof!(
+        caml_pasta_fq_plonk_proof,
+        WasmGPallas,
+        GAffine,
+        WasmPastaFq,
+        Fq,
+        WasmPolyComm,
+        WasmSrs,
+        GAffineOther,
+        oracle::pasta::fq_3,
+        oracle::pasta::fp_3,
+        WasmPastaFqPlonkIndex,
+        WasmPlonkVerifierIndex,
+        Fq
+        );
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
@@ -1,10 +1,10 @@
 // use kimchi::circuits::expr::{Linearization, PolishToken, Variable, Column};
 // use kimchi::circuits::gate::{GateType, CurrOrNext};
-use paste::paste;
-use crate::wasm_vector::WasmVector;
 use crate::wasm_flat_vector::WasmFlatVector;
-use wasm_bindgen::prelude::*;
+use crate::wasm_vector::WasmVector;
+use paste::paste;
 use std::convert::TryInto;
+use wasm_bindgen::prelude::*;
 // use std::sync::Arc;
 // use commitment_dlog::srs::SRS;
 // use kimchi::index::{expr_linearization, VerifierIndex as DlogVerifierIndex};
@@ -15,13 +15,13 @@ use array_init::array_init;
 use kimchi::circuits::{
     scalars::ProofEvaluations,
     // nolookup::constraints::{zk_polynomial, zk_w3, Shifts},
-    wires::{COLUMNS},
+    wires::COLUMNS,
 };
 // use std::path::Path;
 use commitment_dlog::commitment::{CommitmentCurve, OpeningProof, PolyComm};
-use kimchi::prover::{ProverCommitments, ProverProof};
-use kimchi::index::Index;
 use groupmap::GroupMap;
+use kimchi::index::Index;
+use kimchi::prover::{ProverCommitments, ProverProof};
 use oracle::{
     poseidon::PlonkSpongeConstants15W,
     sponge::{DefaultFqSponge, DefaultFrSponge},
@@ -781,12 +781,12 @@ macro_rules! impl_proof {
 
 pub mod fp {
     use super::*;
-    use crate::arkworks::{WasmPastaFp, WasmGVesta};
-    use mina_curves::pasta::{fp::Fp, vesta::Affine as GAffine, pallas::Affine as GAffineOther};
-    use crate::poly_comm::vesta::WasmFpPolyComm as WasmPolyComm;
-    use crate::srs::fp::WasmFpSrs as WasmSrs;
+    use crate::arkworks::{WasmGVesta, WasmPastaFp};
     use crate::pasta_fp_plonk_index::WasmPastaFpPlonkIndex;
     use crate::plonk_verifier_index::fp::WasmFpPlonkVerifierIndex as WasmPlonkVerifierIndex;
+    use crate::poly_comm::vesta::WasmFpPolyComm as WasmPolyComm;
+    use crate::srs::fp::WasmFpSrs as WasmSrs;
+    use mina_curves::pasta::{fp::Fp, pallas::Affine as GAffineOther, vesta::Affine as GAffine};
 
     impl_proof!(
         caml_pasta_fp_plonk_proof,
@@ -802,17 +802,17 @@ pub mod fp {
         WasmPastaFpPlonkIndex,
         WasmPlonkVerifierIndex,
         Fp
-        );
+    );
 }
 
 pub mod fq {
     use super::*;
-    use crate::arkworks::{WasmPastaFq, WasmGPallas};
-    use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine, vesta::Affine as GAffineOther};
-    use crate::poly_comm::pallas::WasmFqPolyComm as WasmPolyComm;
-    use crate::srs::fq::WasmFqSrs as WasmSrs;
+    use crate::arkworks::{WasmGPallas, WasmPastaFq};
     use crate::pasta_fq_plonk_index::WasmPastaFqPlonkIndex;
     use crate::plonk_verifier_index::fq::WasmFqPlonkVerifierIndex as WasmPlonkVerifierIndex;
+    use crate::poly_comm::pallas::WasmFqPolyComm as WasmPolyComm;
+    use crate::srs::fq::WasmFqSrs as WasmSrs;
+    use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine, vesta::Affine as GAffineOther};
 
     impl_proof!(
         caml_pasta_fq_plonk_proof,
@@ -828,5 +828,5 @@ pub mod fq {
         WasmPastaFqPlonkIndex,
         WasmPlonkVerifierIndex,
         Fq
-        );
+    );
 }

--- a/src/lib/crypto/kimchi_bindings/wasm/src/plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/plonk_verifier_index.rs
@@ -720,6 +720,8 @@ macro_rules! impl_verification_key {
                 let (endo_q, _endo_r) = commitment_dlog::srs::endos::<$GOther>();
                 let domain = Domain::<$F>::new(1 << log_size_of_group).unwrap();
 
+                let (linearization, powers_of_alpha) = expr_linearization(domain, false, &None);
+
                 let index =
                     DlogVerifierIndex {
                         domain,
@@ -754,7 +756,8 @@ macro_rules! impl_verification_key {
                             shifts.s6.into()
                         ],
                         srs: srs.0.clone(),
-                        linearization: expr_linearization(domain, false, &None),
+                        linearization,
+                        powers_of_alpha,
                         // TODO
                         lookup_index: None,
                     };

--- a/src/lib/crypto/kimchi_bindings/wasm/src/plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/plonk_verifier_index.rs
@@ -1,0 +1,989 @@
+use crate::wasm_vector::WasmVector;
+use ark_ec::AffineCurve;
+use ark_ff::One;
+use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
+use array_init::array_init;
+use commitment_dlog::srs::SRS;
+use kimchi::index::{expr_linearization, VerifierIndex as DlogVerifierIndex};
+use kimchi::circuits::expr::{Column, PolishToken, Variable};
+use kimchi::circuits::gate::{CurrOrNext, GateType};
+use kimchi::circuits::{
+    constraints::{zk_polynomial, zk_w3, Shifts},
+    wires::{COLUMNS, PERMUTS},
+};
+use paste::paste;
+use std::convert::TryInto;
+use std::path::Path;
+use std::sync::Arc;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub enum WasmColumnTag {
+    Witness,
+    Z,
+    LookupSorted,
+    LookupAggreg,
+    LookupTable,
+    LookupKindIndex,
+    Index,
+    Coefficient,
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct WasmColumn {
+    pub tag: WasmColumnTag,
+    pub gate_type: GateType,
+    pub i: i32,
+}
+
+impl WasmColumn {
+    fn zero() -> Self {
+        Self {
+            tag: WasmColumnTag::Witness,
+            gate_type: GateType::Zero,
+            i: 0,
+        }
+    }
+}
+
+impl From<Column> for WasmColumn {
+    fn from(c: Column) -> Self {
+        let tag_i = |tag, i: usize| Self {
+            tag,
+            gate_type: GateType::Zero,
+            i: i.try_into().expect("usize -> isize"),
+        };
+        let tag = |tag| tag_i(tag, 0);
+
+        match c {
+            Column::Witness(x) => tag_i(WasmColumnTag::Witness, x),
+            Column::Z => tag(WasmColumnTag::Z),
+            Column::LookupSorted(x) => tag_i(WasmColumnTag::LookupSorted, x),
+            Column::LookupAggreg => tag(WasmColumnTag::LookupAggreg),
+            Column::LookupTable => tag(WasmColumnTag::LookupTable),
+            Column::LookupKindIndex(x) => tag_i(WasmColumnTag::LookupKindIndex, x),
+            Column::Index(x) => Self {
+                tag: WasmColumnTag::Index,
+                gate_type: x,
+                i: 0,
+            },
+            Column::Coefficient(x) => tag_i(WasmColumnTag::Coefficient, x),
+        }
+    }
+}
+
+impl From<&Column> for WasmColumn {
+    fn from(c: &Column) -> Self {
+        let tag_i = |tag, i: &usize| Self {
+            tag,
+            gate_type: GateType::Zero,
+            i: (*i).try_into().expect("usize -> isize"),
+        };
+        let tag = |tag| tag_i(tag, &0);
+
+        match c {
+            Column::Witness(x) => tag_i(WasmColumnTag::Witness, x),
+            Column::Z => tag(WasmColumnTag::Z),
+            Column::LookupSorted(x) => tag_i(WasmColumnTag::LookupSorted, x),
+            Column::LookupAggreg => tag(WasmColumnTag::LookupAggreg),
+            Column::LookupTable => tag(WasmColumnTag::LookupTable),
+            Column::LookupKindIndex(x) => tag_i(WasmColumnTag::LookupKindIndex, x),
+            Column::Index(x) => Self {
+                tag: WasmColumnTag::Index,
+                gate_type: *x,
+                i: 0,
+            },
+            Column::Coefficient(x) => tag_i(WasmColumnTag::Coefficient, x),
+        }
+    }
+}
+
+impl From<WasmColumn> for Column {
+    fn from(c: WasmColumn) -> Column {
+        match c.tag {
+            WasmColumnTag::Witness => Column::Witness(c.i.try_into().expect("usize -> isize")),
+            WasmColumnTag::Z => Column::Z,
+            WasmColumnTag::LookupSorted => {
+                Column::LookupSorted(c.i.try_into().expect("usize -> isize"))
+            }
+            WasmColumnTag::LookupAggreg => Column::LookupAggreg,
+            WasmColumnTag::LookupTable => Column::LookupTable,
+            WasmColumnTag::LookupKindIndex => {
+                Column::LookupKindIndex(c.i.try_into().expect("usize -> isize"))
+            }
+            WasmColumnTag::Index => Column::Index(c.gate_type),
+            WasmColumnTag::Coefficient => {
+                Column::Coefficient(c.i.try_into().expect("usize -> isize"))
+            }
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub struct WasmVariable {
+    pub col: WasmColumn,
+    pub row: CurrOrNext,
+}
+
+impl WasmVariable {
+    fn zero() -> Self {
+        Self {
+            col: WasmColumn::zero(),
+            row: CurrOrNext::Curr,
+        }
+    }
+}
+
+impl From<Variable> for WasmVariable {
+    fn from(c: Variable) -> WasmVariable {
+        WasmVariable {
+            col: c.col.into(),
+            row: c.row,
+        }
+    }
+}
+
+impl From<&Variable> for WasmVariable {
+    fn from(c: &Variable) -> WasmVariable {
+        WasmVariable {
+            col: c.col.into(),
+            row: c.row,
+        }
+    }
+}
+
+impl From<WasmVariable> for Variable {
+    fn from(c: WasmVariable) -> Variable {
+        Variable {
+            col: c.col.into(),
+            row: c.row,
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Clone, Copy)]
+pub enum WasmPolishTokenTag {
+    Alpha,
+    Beta,
+    Gamma,
+    JointCombiner,
+    EndoCoefficient,
+    Mds,
+    Literal,
+    Cell,
+    Dup,
+    Pow,
+    Add,
+    Mul,
+    Sub,
+    VanishesOnLast4Rows,
+    UnnormalizedLagrangeBasis,
+    Store,
+    Load,
+}
+
+macro_rules! impl_verification_key {
+    (
+     $name: ident,
+     $WasmG: ty,
+     $G: ty,
+     $WasmF: ty,
+     $F: ty,
+     $WasmPolyComm: ty,
+     $WasmSrs: ty,
+     $GOther: ty,
+     $FrSpongeParams: path,
+     $FqSpongeParams: path,
+     $WasmIndex: ty,
+     $field_name: ident
+     ) => {
+        paste! {
+            #[wasm_bindgen]
+            #[derive(Clone, Copy)]
+            pub struct [<Wasm $field_name:camel Domain>] {
+                pub log_size_of_group: i32,
+                pub group_gen: $WasmF,
+            }
+            type WasmDomain = [<Wasm $field_name:camel Domain>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel Domain>]{
+                #[wasm_bindgen(constructor)]
+                pub fn new(log_size_of_group: i32, group_gen: $WasmF) -> Self {
+                    WasmDomain {log_size_of_group, group_gen}
+                }
+            }
+
+            #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel PlonkVerificationEvals>] {
+                #[wasm_bindgen(skip)]
+                pub sigma_comm: WasmVector<$WasmPolyComm>,
+                #[wasm_bindgen(skip)]
+                pub coefficients_comm: WasmVector<$WasmPolyComm>,
+                #[wasm_bindgen(skip)]
+                pub generic_comm: $WasmPolyComm,
+                #[wasm_bindgen(skip)]
+                pub psm_comm: $WasmPolyComm,
+                #[wasm_bindgen(skip)]
+                pub complete_add_comm: $WasmPolyComm,
+                #[wasm_bindgen(skip)]
+                pub mul_comm: $WasmPolyComm,
+                #[wasm_bindgen(skip)]
+                pub emul_comm: $WasmPolyComm,
+                #[wasm_bindgen(skip)]
+                pub endomul_scalar_comm: $WasmPolyComm,
+                #[wasm_bindgen(skip)]
+                pub chacha_comm: WasmVector<$WasmPolyComm>,
+            }
+            type WasmPlonkVerificationEvals = [<Wasm $field_name:camel PlonkVerificationEvals>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel PlonkVerificationEvals>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    sigma_comm: WasmVector<$WasmPolyComm>,
+                    coefficients_comm: WasmVector<$WasmPolyComm>,
+                    generic_comm: &$WasmPolyComm,
+                    psm_comm: &$WasmPolyComm,
+                    complete_add_comm: &$WasmPolyComm,
+                    mul_comm: &$WasmPolyComm,
+                    emul_comm: &$WasmPolyComm,
+                    endomul_scalar_comm: &$WasmPolyComm,
+                    ) -> Self {
+                    WasmPlonkVerificationEvals {
+                        sigma_comm: sigma_comm.clone(),
+                        coefficients_comm: coefficients_comm.clone(),
+                        generic_comm: generic_comm.clone(),
+                        psm_comm: psm_comm.clone(),
+                        complete_add_comm: complete_add_comm.clone(),
+                        mul_comm: mul_comm.clone(),
+                        emul_comm: emul_comm.clone(),
+                        endomul_scalar_comm: endomul_scalar_comm.clone(),
+                        chacha_comm: (vec![]).into(),
+                    }
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn sigma_comm(&self) -> WasmVector<$WasmPolyComm> {
+                    self.sigma_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_sigma_comm(&mut self, x: WasmVector<$WasmPolyComm>) {
+                    self.sigma_comm = x;
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn coefficients_comm(&self) -> WasmVector<$WasmPolyComm> {
+                    self.coefficients_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_coefficients_comm(&mut self, x: WasmVector<$WasmPolyComm>) {
+                    self.coefficients_comm = x;
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn generic_comm(&self) -> $WasmPolyComm {
+                    self.generic_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_generic_comm(&mut self, x: $WasmPolyComm) {
+                    self.generic_comm = x;
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn psm_comm(&self) -> $WasmPolyComm {
+                    self.psm_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_psm_comm(&mut self, x: $WasmPolyComm) {
+                    self.psm_comm = x;
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn complete_add_comm(&self) -> $WasmPolyComm {
+                    self.complete_add_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_complete_add_comm(&mut self, x: $WasmPolyComm) {
+                    self.complete_add_comm = x;
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn mul_comm(&self) -> $WasmPolyComm {
+                    self.mul_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_mul_comm(&mut self, x: $WasmPolyComm) {
+                    self.mul_comm = x;
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn emul_comm(&self) -> $WasmPolyComm {
+                    self.emul_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_emul_comm(&mut self, x: $WasmPolyComm) {
+                    self.emul_comm = x;
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn endomul_scalar_comm(&self) -> $WasmPolyComm {
+                    self.endomul_scalar_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_endomul_scalar_comm(&mut self, x: $WasmPolyComm) {
+                    self.endomul_scalar_comm = x;
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn chacha_comm(&self) -> WasmVector<$WasmPolyComm> {
+                    self.chacha_comm.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_chacha_comm(&mut self, x: WasmVector<$WasmPolyComm>) {
+                    self.chacha_comm = x;
+                }
+            }
+
+            #[derive(Clone, Copy)]
+            #[wasm_bindgen]
+            pub struct [<Wasm $field_name:camel Shifts>] {
+                pub s0: $WasmF,
+                pub s1: $WasmF,
+                pub s2: $WasmF,
+                pub s3: $WasmF,
+                pub s4: $WasmF,
+                pub s5: $WasmF,
+                pub s6: $WasmF,
+            }
+            type WasmShifts = [<Wasm $field_name:camel Shifts>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel Shifts>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    s0: $WasmF,
+                    s1: $WasmF,
+                    s2: $WasmF,
+                    s3: $WasmF,
+                    s4: $WasmF,
+                    s5: $WasmF,
+                    s6: $WasmF
+                ) -> Self {
+                    Self { s0, s1, s2, s3, s4, s5, s6}
+                }
+            }
+
+            /* #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel Linearization>](
+                #[wasm_bindgen(skip)]
+                pub Box<Linearization<Vec<PolishToken<$F>>>>);
+            type WasmLinearization = [<Wasm $field_name:camel Linearization>]; */
+
+
+
+            #[derive(Clone, Copy)]
+            #[wasm_bindgen]
+            pub struct [<Wasm $field_name:camel PolishToken>] {
+                pub tag: WasmPolishTokenTag,
+                pub i0: i32,
+                pub i1: i32,
+                pub f: $WasmF,
+                pub v: WasmVariable,
+            }
+            type WasmPolishToken = [<Wasm $field_name:camel PolishToken>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel PolishToken>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(tag: WasmPolishTokenTag, i0: i32, i1: i32, f: $WasmF, v: WasmVariable) -> Self {
+                    Self {tag, i0, i1, f, v}
+                }
+            }
+
+            fn token(tag: WasmPolishTokenTag) -> WasmPolishToken {
+                WasmPolishToken { tag, i0: 0, i1: 0, f: ($F::from(0 as i64)).into(), v: WasmVariable::zero() }
+            }
+            fn token_with_i32(tag: WasmPolishTokenTag, i0: usize) -> WasmPolishToken {
+                WasmPolishToken { tag, i0: (i0 as i32), i1: 0, f: ($F::from(0 as i64)).into(), v: WasmVariable::zero() }
+            }
+            fn token_with_2xi32(tag: WasmPolishTokenTag, i0: usize, i1: usize) -> WasmPolishToken {
+                WasmPolishToken { tag, i0: (i0 as i32), i1: (i1 as i32), f: ($F::from(0 as i64)).into(), v: WasmVariable::zero() }
+            }
+            fn token_with_variable(tag: WasmPolishTokenTag, variable: Variable) -> WasmPolishToken {
+                WasmPolishToken { tag, i0: 0, i1: 0, f: ($F::from(0 as i64)).into(), v: variable.into() }
+            }
+            fn token_with_field(tag: WasmPolishTokenTag, field: $F) -> WasmPolishToken {
+                WasmPolishToken { tag, i0: 0, i1: 0, f: field.into(), v: WasmVariable::zero() }
+            }
+
+            impl From<PolishToken<$F>> for WasmPolishToken {
+                fn from(x: PolishToken<$F>) -> WasmPolishToken {
+                    match x {
+                        PolishToken::Alpha => token(WasmPolishTokenTag::Alpha),
+                        PolishToken::Beta => token(WasmPolishTokenTag::Beta),
+                        PolishToken::Gamma => token(WasmPolishTokenTag::Gamma),
+                        PolishToken::JointCombiner => token(WasmPolishTokenTag::JointCombiner),
+                        PolishToken::EndoCoefficient => token(WasmPolishTokenTag::EndoCoefficient),
+                        PolishToken::Mds {row, col} => token_with_2xi32(WasmPolishTokenTag::Mds, row, col),
+                        PolishToken::Literal(f) => token_with_field(WasmPolishTokenTag::Literal, f),
+                        PolishToken::Cell(variable) => token_with_variable(WasmPolishTokenTag::Cell, variable),
+                        PolishToken::Dup => token(WasmPolishTokenTag::Dup),
+                        PolishToken::Pow(size) => token_with_i32(WasmPolishTokenTag::Pow, size),
+                        PolishToken::Add => token(WasmPolishTokenTag::Add),
+                        PolishToken::Mul => token(WasmPolishTokenTag::Mul),
+                        PolishToken::Sub => token(WasmPolishTokenTag::Sub),
+                        PolishToken::VanishesOnLast4Rows => token(WasmPolishTokenTag::VanishesOnLast4Rows),
+                        PolishToken::UnnormalizedLagrangeBasis(size) => token_with_i32(WasmPolishTokenTag::UnnormalizedLagrangeBasis, size),
+                        PolishToken::Store => token(WasmPolishTokenTag::Store),
+                        PolishToken::Load(size) => token_with_i32(WasmPolishTokenTag::Load, size),
+                    }
+                }
+            }
+            impl From<WasmPolishToken> for PolishToken<$F> {
+                fn from(x: WasmPolishToken) -> PolishToken<$F> {
+                    match x.tag {
+                        WasmPolishTokenTag::Alpha => PolishToken::Alpha,
+                        WasmPolishTokenTag::Beta => PolishToken::Beta,
+                        WasmPolishTokenTag::Gamma => PolishToken::Gamma,
+                        WasmPolishTokenTag::JointCombiner => PolishToken::JointCombiner,
+                        WasmPolishTokenTag::EndoCoefficient => PolishToken::EndoCoefficient,
+                        WasmPolishTokenTag::Mds => PolishToken::Mds {row: x.i0 as usize, col: x.i1 as usize},
+                        WasmPolishTokenTag::Literal => PolishToken::Literal(x.f.into()),
+                        WasmPolishTokenTag::Cell => PolishToken::Cell(x.v.into()),
+                        WasmPolishTokenTag::Dup => PolishToken::Dup,
+                        WasmPolishTokenTag::Pow => PolishToken::Pow(x.i0 as usize),
+                        WasmPolishTokenTag::Add => PolishToken::Add,
+                        WasmPolishTokenTag::Mul => PolishToken::Mul,
+                        WasmPolishTokenTag::Sub => PolishToken::Sub,
+                        WasmPolishTokenTag::VanishesOnLast4Rows => PolishToken::VanishesOnLast4Rows,
+                        WasmPolishTokenTag::UnnormalizedLagrangeBasis => PolishToken::UnnormalizedLagrangeBasis(x.i0 as usize),
+                        WasmPolishTokenTag::Store => PolishToken::Store,
+                        WasmPolishTokenTag::Load => PolishToken::Load(x.i0 as usize)
+                    }
+                }
+            }
+
+            #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel IndexTerm>] {
+                pub column: WasmColumn,
+                #[wasm_bindgen(skip)]
+                pub coefficient: WasmVector<WasmPolishToken>,
+            }
+            type WasmIndexTerm = [<Wasm $field_name:camel IndexTerm>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel IndexTerm>] {
+                #[wasm_bindgen(getter)]
+                pub fn coefficient(&self) -> WasmVector<WasmPolishToken> {
+                    self.coefficient.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_coefficient(&mut self, x: WasmVector<WasmPolishToken>) {
+                    self.coefficient = x;
+                }
+            }
+
+            impl From<(Column, Vec<PolishToken<$F>>)> for WasmIndexTerm {
+                fn from(x: (Column, Vec<PolishToken<$F>>)) -> WasmIndexTerm {
+                    WasmIndexTerm {
+                        column: x.0.into(),
+                        coefficient: IntoIterator::into_iter(x.1).map(From::from).collect()
+                    }
+                }
+            }
+            impl From<WasmIndexTerm> for (Column, Vec<PolishToken<$F>>) {
+                fn from(x: WasmIndexTerm) -> (Column, Vec<PolishToken<$F>>) {
+                    (x.column.into(), x.coefficient.into_iter().map(From::from).collect())
+                }
+            }
+
+            #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel Linearization>] {
+                #[wasm_bindgen(skip)]
+                pub constant_term: WasmVector<WasmPolishToken>,
+                #[wasm_bindgen(skip)]
+                pub index_terms: WasmVector<WasmIndexTerm>,
+            }
+            type WasmLinearization = [<Wasm $field_name:camel Linearization>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel Linearization>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    constant_term: WasmVector<WasmPolishToken>,
+                    index_terms: WasmVector<WasmIndexTerm>,
+                ) -> Self {
+                    WasmLinearization {
+                        constant_term: constant_term.clone(),
+                        index_terms: index_terms.clone(),
+                    }
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn constant_term(&self) -> WasmVector<WasmPolishToken> {
+                    self.constant_term.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_constant_term(&mut self, x: WasmVector<WasmPolishToken>) {
+                    self.constant_term = x;
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn index_terms(&self) -> WasmVector<WasmIndexTerm> {
+                    self.index_terms.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_index_terms(&mut self, x: WasmVector<WasmIndexTerm>) {
+                    self.index_terms = x;
+                }
+
+                pub fn dummy() -> Self {
+                    Self { constant_term: vec![].into(), index_terms: vec![].into() }
+                }
+            }
+
+            #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel PlonkVerifierIndex>] {
+                pub domain: WasmDomain,
+                pub max_poly_size: i32,
+                pub max_quot_size: i32,
+                #[wasm_bindgen(skip)]
+                pub srs: $WasmSrs,
+                #[wasm_bindgen(skip)]
+                pub evals: WasmPlonkVerificationEvals,
+                pub shifts: WasmShifts,
+                // TODO: add lookup index field
+            }
+            type WasmPlonkVerifierIndex = [<Wasm $field_name:camel PlonkVerifierIndex>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel PlonkVerifierIndex>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(
+                    domain: &WasmDomain,
+                    max_poly_size: i32,
+                    max_quot_size: i32,
+                    srs: &$WasmSrs,
+                    evals: &WasmPlonkVerificationEvals,
+                    shifts: &WasmShifts,
+                ) -> Self {
+                    WasmPlonkVerifierIndex {
+                        domain: domain.clone(),
+                        max_poly_size,
+                        max_quot_size,
+                        srs: srs.clone(),
+                        evals: evals.clone(),
+                        shifts: shifts.clone(),
+                    }
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn srs(&self) -> $WasmSrs {
+                    self.srs.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_srs(&mut self, x: $WasmSrs) {
+                    self.srs = x
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn evals(&self) -> WasmPlonkVerificationEvals {
+                    self.evals.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_evals(&mut self, x: WasmPlonkVerificationEvals) {
+                    self.evals = x
+                }
+            }
+
+            pub fn to_wasm<'a>(
+                srs: &Arc<SRS<$G>>,
+                vi: DlogVerifierIndex<$G>,
+            ) -> WasmPlonkVerifierIndex {
+                WasmPlonkVerifierIndex {
+                    domain: WasmDomain {
+                        log_size_of_group: vi.domain.log_size_of_group as i32,
+                        group_gen: vi.domain.group_gen.into(),
+                    },
+                    max_poly_size: vi.max_poly_size as i32,
+                    max_quot_size: vi.max_quot_size as i32,
+                    srs: srs.into(),
+                    evals: WasmPlonkVerificationEvals {
+                        sigma_comm: IntoIterator::into_iter(vi.sigma_comm).map(From::from).collect(),
+                        coefficients_comm: IntoIterator::into_iter(vi.coefficients_comm).map(From::from).collect(),
+                        generic_comm: vi.generic_comm.into(),
+                        psm_comm: vi.psm_comm.into(),
+                        complete_add_comm: vi.complete_add_comm.into(),
+                        mul_comm: vi.mul_comm.into(),
+                        emul_comm: vi.emul_comm.into(),
+                        endomul_scalar_comm: vi.endomul_scalar_comm.into(),
+                        chacha_comm:
+                            match vi.chacha_comm {
+                                None => vec![].into(),
+                                Some(cs) => vec![(&cs[0]).into(), (&cs[1]).into(), (&cs[2]).into(), (&cs[3]).into()].into()
+                            }
+                    },
+                    shifts:
+                        WasmShifts {
+                            s0: vi.shift[0].into(),
+                            s1: vi.shift[1].into(),
+                            s2: vi.shift[2].into(),
+                            s3: vi.shift[3].into(),
+                            s4: vi.shift[4].into(),
+                            s5: vi.shift[5].into(),
+                            s6: vi.shift[6].into(),
+                        },
+                }
+            }
+
+            /* pub fn to_wasm_copy<'a>(
+                srs: &Arc<SRS<GAffine>>,
+                vi: &DlogVerifierIndex<GAffine>,
+            ) -> WasmPlonkVerifierIndex {
+                WasmPlonkVerifierIndex {
+                    domain: WasmDomain {
+                        log_size_of_group: vi.domain.log_size_of_group as i32,
+                        group_gen: vi.domain.group_gen.clone().into(),
+                    },
+                    max_poly_size: vi.max_poly_size as i32,
+                    max_quot_size: vi.max_quot_size as i32,
+                    srs: srs.clone().into(),
+                    evals: WasmPlonkVerificationEvals {
+                        sigma_comm: vi.sigma_comm.iter().map(From::from).collect(),
+                        coefficients_comm: vi.coefficients_comm.iter().map(From::from).collect(),
+                        generic_comm: vi.generic_comm.clone().into(),
+                        psm_comm: vi.psm_comm.clone().into(),
+                        complete_add_comm: vi.complete_add_comm.clone().into(),
+                        mul_comm: vi.mul_comm.clone().into(),
+                        emul_comm: vi.emul_comm.clone().into(),
+                        endomul_scalar_comm: vi.endomul_scalar_comm.clone().into(),
+                        chacha_comm:
+                            match &vi.chacha_comm {
+                                None => vec![].into(),
+                                Some(cs) => vec![cs[0].clone().into(), cs[1].clone().into(), cs[2].clone().into(), cs[3].clone().into()].into()
+                            }
+                    },
+                    shifts:
+                        WasmShifts {
+                            s0: vi.shift[0].clone().into(),
+                            s1: vi.shift[1].clone().into(),
+                            s2: vi.shift[2].clone().into(),
+                            s3: vi.shift[3].clone().into(),
+                            s4: vi.shift[4].clone().into(),
+                            s5: vi.shift[5].clone().into(),
+                            s6: vi.shift[6].clone().into(),
+                        },
+                    linearization: [<Wasm $field_name:camel Linearization>](Box::new(vi.linearization.clone())),
+                }
+            } */
+
+            pub fn of_wasm(
+                max_poly_size: i32,
+                max_quot_size: i32,
+                log_size_of_group: i32,
+                srs: &$WasmSrs,
+                evals: &WasmPlonkVerificationEvals,
+                shifts: &WasmShifts,
+            ) -> (DlogVerifierIndex<GAffine>, Arc<SRS<GAffine>>) {
+                /*
+                let urs_copy = Rc::clone(&*urs);
+                let urs_copy_outer = Rc::clone(&*urs);
+                let srs = {
+                    // We know that the underlying value is still alive, because we never convert any of our
+                    // Rc<_>s into weak pointers.
+                    SRSValue::Ref(unsafe { &*Rc::into_raw(urs_copy) })
+                }; */
+                let (endo_q, _endo_r) = commitment_dlog::srs::endos::<$GOther>();
+                let domain = Domain::<$F>::new(1 << log_size_of_group).unwrap();
+
+                let index =
+                    DlogVerifierIndex {
+                        domain,
+
+                        sigma_comm: array_init(|i| (&evals.sigma_comm[i]).into()),
+                        generic_comm: (&evals.generic_comm).into(),
+                        coefficients_comm: array_init(|i| (&evals.coefficients_comm[i]).into()),
+
+                        psm_comm: (&evals.psm_comm).into(),
+
+                        complete_add_comm: (&evals.complete_add_comm).into(),
+                        mul_comm: (&evals.mul_comm).into(),
+                        emul_comm: (&evals.emul_comm).into(),
+
+                        endomul_scalar_comm: (&evals.endomul_scalar_comm).into(),
+                        // TODO
+                        chacha_comm: None,
+                        w: zk_w3(domain),
+                        fr_sponge_params: $FrSpongeParams::params(),
+                        fq_sponge_params: $FqSpongeParams::params(),
+                        endo: endo_q,
+                        max_poly_size: max_poly_size as usize,
+                        max_quot_size: max_quot_size as usize,
+                        zkpm: zk_polynomial(domain),
+                        shift: [
+                            shifts.s0.into(),
+                            shifts.s1.into(),
+                            shifts.s2.into(),
+                            shifts.s3.into(),
+                            shifts.s4.into(),
+                            shifts.s5.into(),
+                            shifts.s6.into()
+                        ],
+                        srs: srs.0.clone(),
+                        linearization: expr_linearization(domain, false, &None),
+                        // TODO
+                        lookup_index: None,
+                    };
+                (index, srs.0.clone())
+            }
+
+            impl From<WasmPlonkVerifierIndex> for DlogVerifierIndex<$G> {
+                fn from(index: WasmPlonkVerifierIndex) -> Self {
+                    of_wasm(
+                        index.max_poly_size,
+                        index.max_quot_size,
+                        index.domain.log_size_of_group,
+                        &index.srs,
+                        &index.evals,
+                        &index.shifts,
+                    )
+                    .0
+                }
+            }
+
+            pub fn read_raw(
+                offset: Option<i32>,
+                srs: &$WasmSrs,
+                path: String,
+            ) -> Result<DlogVerifierIndex<$G>, JsValue> {
+                let path = Path::new(&path);
+                let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
+                let fq_sponge_params = $FqSpongeParams::params();
+                let fr_sponge_params = $FrSpongeParams::params();
+                DlogVerifierIndex::<$G>::from_file(
+                    srs.0.clone(),
+                    path,
+                    offset.map(|x| x as u64),
+                    endo_q,
+                    fq_sponge_params,
+                    fr_sponge_params,
+                ).map_err(|e| JsValue::from_str(format!("read_raw: {}", e).as_str()))
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _read>](
+                offset: Option<i32>,
+                srs: &$WasmSrs,
+                path: String,
+            ) -> Result<WasmPlonkVerifierIndex, JsValue> {
+                let vi = read_raw(offset, srs, path)?;
+                Ok(to_wasm(srs, vi.into()))
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _write>](
+                append: Option<bool>,
+                index: WasmPlonkVerifierIndex,
+                path: String,
+            ) -> Result<(), JsValue> {
+                let index: DlogVerifierIndex<$G> = index.into();
+                let path = Path::new(&path);
+                index.to_file(path, append).map_err(|e| {
+                    println!("{}", e);
+                    JsValue::from_str("caml_pasta_fp_plonk_verifier_index_raw_read")
+                })
+            }
+
+            // TODO understand what serialization format we need
+
+            // #[wasm_bindgen]
+            // pub fn [<$name:snake _serialize>](
+            //     index: WasmPlonkVerifierIndex,
+            // ) -> Box<[u8]> {
+            //     let index: DlogVerifierIndex<$G> = index.into();
+            //     rmp_serde::to_vec(&index).unwrap().into_boxed_slice()
+            // }
+
+            // #[wasm_bindgen]
+            // pub fn [<$name:snake _deserialize>](
+            //     srs: &$WasmSrs,
+            //     index: Box<[u8]>,
+            // ) -> WasmPlonkVerifierIndex {
+            //     let mut vi: DlogVerifierIndex<$G> = rmp_serde::from_slice(&index).unwrap();
+            //     vi.linearization = expr_linearization(vi.domain, false, false, None);
+            //     return to_wasm(srs, vi.into())
+            // }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _serialize>](
+                index: WasmPlonkVerifierIndex,
+            ) -> String {
+                let index: DlogVerifierIndex<$G> = index.into();
+                serde_json::to_string(&index).unwrap()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _deserialize>](
+                srs: &$WasmSrs,
+                index: String,
+            ) -> WasmPlonkVerifierIndex {
+                let vi: DlogVerifierIndex<$G> = serde_json::from_str(&index).unwrap();
+                return to_wasm(srs, vi.into())
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _create>](
+                index: &$WasmIndex,
+            ) -> WasmPlonkVerifierIndex {
+                {
+                    let ptr: &mut commitment_dlog::srs::SRS<GAffine> =
+                        unsafe { &mut *(std::sync::Arc::as_ptr(&index.0.as_ref().srs) as *mut _) };
+                    ptr.add_lagrange_basis(index.0.as_ref().cs.domain.d1);
+                }
+                let verifier_index = index.0.as_ref().verifier_index();
+                to_wasm(&index.0.as_ref().srs, verifier_index)
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _shifts>](log2_size: i32) -> WasmShifts {
+                let domain = Domain::<$F>::new(1 << log2_size).unwrap();
+                let shifts = Shifts::new(&domain);
+                let s = shifts.shifts();
+                WasmShifts {
+                    s0: s[0].clone().into(),
+                    s1: s[1].clone().into(),
+                    s2: s[2].clone().into(),
+                    s3: s[3].clone().into(),
+                    s4: s[4].clone().into(),
+                    s5: s[5].clone().into(),
+                    s6: s[6].clone().into(),
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _dummy>]() -> WasmPlonkVerifierIndex {
+                fn comm() -> $WasmPolyComm {
+                    let g: $WasmG = $G::prime_subgroup_generator().into();
+                    $WasmPolyComm {
+                        shifted: None,
+                        unshifted: vec![g].into(),
+                    }
+                }
+                fn vec_comm(num: usize) -> WasmVector<$WasmPolyComm> {
+                    (0..num).map(|_| comm()).collect()
+                }
+
+                WasmPlonkVerifierIndex {
+                    domain: WasmDomain {
+                        log_size_of_group: 1,
+                        group_gen: $F::one().into(),
+                    },
+                    max_poly_size: 0,
+                    max_quot_size: 0,
+                    srs: $WasmSrs(Arc::new(SRS::create(0))),
+                    evals: WasmPlonkVerificationEvals {
+                        sigma_comm: vec_comm(PERMUTS),
+                        coefficients_comm: vec_comm(COLUMNS),
+                        generic_comm: comm(),
+                        psm_comm: comm(),
+                        complete_add_comm: comm(),
+                        mul_comm: comm(),
+                        emul_comm: comm(),
+                        endomul_scalar_comm: comm(),
+                        chacha_comm: vec![].into(),
+                    },
+                    shifts:
+                        WasmShifts {
+                            s0: $F::one().into(),
+                            s1: $F::one().into(),
+                            s2: $F::one().into(),
+                            s3: $F::one().into(),
+                            s4: $F::one().into(),
+                            s5: $F::one().into(),
+                            s6: $F::one().into(),
+                        },
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _deep_copy>](
+                x: &WasmPlonkVerifierIndex,
+            ) -> WasmPlonkVerifierIndex {
+                x.clone()
+            }
+
+        }
+    }
+}
+
+pub mod fp {
+    use super::*;
+    use crate::arkworks::{WasmGVesta, WasmPastaFp};
+    use crate::pasta_fp_plonk_index::WasmPastaFpPlonkIndex;
+    use crate::poly_comm::vesta::WasmFpPolyComm as WasmPolyComm;
+    use crate::srs::fp::WasmFpSrs;
+    use mina_curves::pasta::{fp::Fp, pallas::Affine as GAffineOther, vesta::Affine as GAffine};
+
+    impl_verification_key!(
+        caml_pasta_fp_plonk_verifier_index,
+        WasmGVesta,
+        GAffine,
+        WasmPastaFp,
+        Fp,
+        WasmPolyComm,
+        WasmFpSrs,
+        GAffineOther,
+        oracle::pasta::fp_3,
+        oracle::pasta::fq_3,
+        WasmPastaFpPlonkIndex,
+        Fp
+    );
+}
+
+pub mod fq {
+    use super::*;
+    use crate::arkworks::{WasmGPallas, WasmPastaFq};
+    use crate::pasta_fq_plonk_index::WasmPastaFqPlonkIndex;
+    use crate::poly_comm::pallas::WasmFqPolyComm as WasmPolyComm;
+    use crate::srs::fq::WasmFqSrs;
+    use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine, vesta::Affine as GAffineOther};
+
+    impl_verification_key!(
+        caml_pasta_fq_plonk_verifier_index,
+        WasmGPallas,
+        GAffine,
+        WasmPastaFq,
+        Fq,
+        WasmPolyComm,
+        WasmFqSrs,
+        GAffineOther,
+        oracle::pasta::fq_3,
+        oracle::pasta::fp_3,
+        WasmPastaFqPlonkIndex,
+        Fq
+    );
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/plonk_verifier_index.rs
@@ -4,13 +4,13 @@ use ark_ff::One;
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use array_init::array_init;
 use commitment_dlog::srs::SRS;
-use kimchi::index::{expr_linearization, VerifierIndex as DlogVerifierIndex};
 use kimchi::circuits::expr::{Column, PolishToken, Variable};
 use kimchi::circuits::gate::{CurrOrNext, GateType};
 use kimchi::circuits::{
     constraints::{zk_polynomial, zk_w3, Shifts},
     wires::{COLUMNS, PERMUTS},
 };
+use kimchi::index::{expr_linearization, VerifierIndex as DlogVerifierIndex};
 use paste::paste;
 use std::convert::TryInto;
 use std::path::Path;

--- a/src/lib/crypto/kimchi_bindings/wasm/src/poly_comm.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/poly_comm.rs
@@ -1,5 +1,5 @@
-use paste::paste;
 use crate::wasm_vector::WasmVector;
+use paste::paste;
 macro_rules! impl_poly_comm {
     (
      $WasmG: ty,
@@ -11,7 +11,6 @@ macro_rules! impl_poly_comm {
      $CamlBaseField: ty,
      $Projective: ty */
      ) => {
-
         paste! {
             use wasm_bindgen::prelude::*;
             use commitment_dlog::commitment::PolyComm;
@@ -86,7 +85,7 @@ macro_rules! impl_poly_comm {
                 }
             }
         }
-    }
+    };
 }
 
 pub mod pallas {
@@ -94,11 +93,7 @@ pub mod pallas {
     use crate::arkworks::group_affine::WasmGPallas;
     use mina_curves::pasta::pallas::Affine as GAffine;
 
-    impl_poly_comm!(
-        WasmGPallas,
-        GAffine,
-        Fq
-    );
+    impl_poly_comm!(WasmGPallas, GAffine, Fq);
 }
 
 pub mod vesta {
@@ -106,9 +101,5 @@ pub mod vesta {
     use crate::arkworks::group_affine::WasmGVesta;
     use mina_curves::pasta::vesta::Affine as GAffine;
 
-    impl_poly_comm!(
-        WasmGVesta,
-        GAffine,
-        Fp
-    );
+    impl_poly_comm!(WasmGVesta, GAffine, Fp);
 }

--- a/src/lib/crypto/kimchi_bindings/wasm/src/poly_comm.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/poly_comm.rs
@@ -1,0 +1,114 @@
+use paste::paste;
+use crate::wasm_vector::WasmVector;
+macro_rules! impl_poly_comm {
+    (
+     $WasmG: ty,
+     $G: ty,
+     $field_name: ident
+     /*
+     $CamlScalarField: ty,
+     $BaseField: ty,
+     $CamlBaseField: ty,
+     $Projective: ty */
+     ) => {
+
+        paste! {
+            use wasm_bindgen::prelude::*;
+            use commitment_dlog::commitment::PolyComm;
+
+            #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel PolyComm>] {
+                #[wasm_bindgen(skip)]
+                pub unshifted: WasmVector<$WasmG>,
+                pub shifted: Option<$WasmG>,
+            }
+
+            type WasmPolyComm = [<Wasm $field_name:camel PolyComm>];
+
+            #[wasm_bindgen]
+            impl [<Wasm $field_name:camel PolyComm>] {
+                #[wasm_bindgen(constructor)]
+                pub fn new(unshifted: WasmVector<$WasmG>, shifted: Option<$WasmG>) -> Self {
+                    WasmPolyComm { unshifted, shifted }
+                }
+
+                #[wasm_bindgen(getter)]
+                pub fn unshifted(&self) -> WasmVector<$WasmG> {
+                    self.unshifted.clone()
+                }
+
+                #[wasm_bindgen(setter)]
+                pub fn set_unshifted(&mut self, x: WasmVector<$WasmG>) {
+                    self.unshifted = x
+                }
+            }
+
+            impl From<PolyComm<$G>> for WasmPolyComm {
+                fn from(x: PolyComm<$G>) -> Self {
+                    let PolyComm {unshifted, shifted} = x;
+                    let unshifted: Vec<$WasmG> =
+                        unshifted.into_iter().map(|x| x.into()).collect();
+                    WasmPolyComm {
+                        unshifted: unshifted.into(),
+                        shifted: shifted.map(|x| x.into()),
+                    }
+                }
+            }
+
+            impl From<&PolyComm<$G>> for WasmPolyComm {
+                fn from(x: &PolyComm<$G>) -> Self {
+                    let unshifted: Vec<$WasmG> =
+                        x.unshifted.iter().map(|x| x.into()).collect();
+                    WasmPolyComm {
+                        unshifted: unshifted.into(),
+                        shifted: x.shifted.map(|x| x.into()),
+                    }
+                }
+            }
+
+            impl From<WasmPolyComm> for PolyComm<$G> {
+                fn from(x: WasmPolyComm) -> Self {
+                    let WasmPolyComm {unshifted, shifted} = x;
+                    PolyComm {
+                        unshifted: (*unshifted).iter().map(|x| { (*x).into() }).collect(),
+                        shifted: shifted.map(|x| x.into()),
+                    }
+                }
+            }
+
+            impl From<&WasmPolyComm> for PolyComm<$G> {
+                fn from(x: &WasmPolyComm) -> Self {
+                    PolyComm {
+                        unshifted: x.unshifted.iter().map(|x| { (*x).into() }).collect(),
+                        shifted: x.shifted.map(|x| x.into()),
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub mod pallas {
+    use super::*;
+    use crate::arkworks::group_affine::WasmGPallas;
+    use mina_curves::pasta::pallas::Affine as GAffine;
+
+    impl_poly_comm!(
+        WasmGPallas,
+        GAffine,
+        Fq
+    );
+}
+
+pub mod vesta {
+    use super::*;
+    use crate::arkworks::group_affine::WasmGVesta;
+    use mina_curves::pasta::vesta::Affine as GAffine;
+
+    impl_poly_comm!(
+        WasmGVesta,
+        GAffine,
+        Fp
+    );
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/projective.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/projective.rs
@@ -115,10 +115,10 @@ macro_rules! impl_projective {
 
 pub mod pallas {
     use super::*;
-    use crate::arkworks::pasta_fp::WasmPastaFp;
-    use crate::arkworks::pasta_fq::WasmPastaFq;
     use crate::arkworks::group_affine::WasmGPallas;
     use crate::arkworks::group_projective::WasmPallasGProjective;
+    use crate::arkworks::pasta_fp::WasmPastaFp;
+    use crate::arkworks::pasta_fq::WasmPastaFq;
     use mina_curves::pasta::{
         fp::Fp,
         pallas::{Affine as GAffine, Projective},
@@ -137,10 +137,10 @@ pub mod pallas {
 
 pub mod vesta {
     use super::*;
-    use crate::arkworks::pasta_fp::WasmPastaFp;
-    use crate::arkworks::pasta_fq::WasmPastaFq;
     use crate::arkworks::group_affine::WasmGVesta;
     use crate::arkworks::group_projective::WasmVestaGProjective;
+    use crate::arkworks::pasta_fp::WasmPastaFp;
+    use crate::arkworks::pasta_fq::WasmPastaFq;
     use mina_curves::pasta::{
         fq::Fq,
         vesta::{Affine as GAffine, Projective},

--- a/src/lib/crypto/kimchi_bindings/wasm/src/projective.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/projective.rs
@@ -1,0 +1,179 @@
+use ark_ec::{AffineCurve, ProjectiveCurve};
+use ark_ff::UniformRand;
+use paste::paste;
+use rand::rngs::StdRng;
+
+use wasm_bindgen::prelude::*;
+
+macro_rules! impl_projective {
+    ($name: ident,
+     $GroupProjective: ty,
+     $CamlG: ty,
+     $CamlScalarField: ty,
+     $BaseField: ty,
+     $CamlBaseField: ty,
+     $Projective: ty) => {
+
+        paste! {
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _one>]() -> $GroupProjective {
+                $Projective::prime_subgroup_generator().into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _add>](
+                x: &$GroupProjective,
+                y: &$GroupProjective,
+            ) -> $GroupProjective {
+                x.as_ref() + y.as_ref()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _sub>](
+                x: &$GroupProjective,
+                y: &$GroupProjective,
+            ) -> $GroupProjective {
+                x.as_ref() - y.as_ref()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _negate>](
+                x: &$GroupProjective,
+            ) -> $GroupProjective {
+                -(*x.as_ref())
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _double>](
+                x: &$GroupProjective,
+            ) -> $GroupProjective {
+                x.as_ref().double().into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _scale>](
+                x: &$GroupProjective,
+                y: $CamlScalarField,
+            ) -> $GroupProjective {
+                let y: ark_ff::BigInteger256 = y.0.into();
+                x.as_ref().mul(&y).into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _random>]() -> $GroupProjective {
+                let rng = &mut rand::rngs::OsRng;
+                let proj: $Projective = UniformRand::rand(rng);
+                proj.into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _rng>](i: u32) -> $GroupProjective {
+                // We only care about entropy here, so we force a conversion i32 -> u32.
+                let i: u64 = (i as u32).into();
+                let mut rng: StdRng = rand::SeedableRng::seed_from_u64(i);
+                let proj: $Projective = UniformRand::rand(&mut rng);
+                proj.into()
+            }
+
+            #[wasm_bindgen]
+            pub extern "C" fn [<caml_ $name:snake _endo_base>]() -> $CamlBaseField {
+                let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffine>();
+                endo_q.into()
+            }
+
+            #[wasm_bindgen]
+            pub extern "C" fn [<caml_ $name:snake _endo_scalar>]() -> $CamlScalarField {
+                let (_endo_q, endo_r) = commitment_dlog::srs::endos::<GAffine>();
+                endo_r.into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _to_affine>](
+                x: &$GroupProjective
+                ) -> $CamlG {
+                x.as_ref().into_affine().into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _of_affine>](x: $CamlG) -> $GroupProjective {
+                Into::<GAffine>::into(x).into_projective().into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _of_affine_coordinates>](x: $CamlBaseField, y: $CamlBaseField) -> $GroupProjective {
+                let res = $Projective::new(x.into(), y.into(), <$BaseField as ark_ff::One>::one());
+                res.into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<caml_ $name:snake _affine_deep_copy>](x: $CamlG) -> $CamlG {
+                x
+            }
+        }
+    }
+}
+
+pub mod pallas {
+    use super::*;
+    use crate::arkworks::pasta_fp::WasmPastaFp;
+    use crate::arkworks::pasta_fq::WasmPastaFq;
+    use crate::arkworks::group_affine::WasmGPallas;
+    use crate::arkworks::group_projective::WasmPallasGProjective;
+    use mina_curves::pasta::{
+        fp::Fp,
+        pallas::{Affine as GAffine, Projective},
+    };
+
+    impl_projective!(
+        pallas,
+        WasmPallasGProjective,
+        WasmGPallas,
+        WasmPastaFq,
+        Fp,
+        WasmPastaFp,
+        Projective
+    );
+}
+
+pub mod vesta {
+    use super::*;
+    use crate::arkworks::pasta_fp::WasmPastaFp;
+    use crate::arkworks::pasta_fq::WasmPastaFq;
+    use crate::arkworks::group_affine::WasmGVesta;
+    use crate::arkworks::group_projective::WasmVestaGProjective;
+    use mina_curves::pasta::{
+        fq::Fq,
+        vesta::{Affine as GAffine, Projective},
+    };
+
+    impl_projective!(
+        vesta,
+        WasmVestaGProjective,
+        WasmGVesta,
+        WasmPastaFp,
+        Fq,
+        WasmPastaFq,
+        Projective
+    );
+}
+
+/*
+pub mod vesta {
+    use super::*;
+    use crate::arkworks::{CamlFp, CamlFq, CamlGVesta, CamlGroupProjectiveVesta};
+    use mina_curves::pasta::{
+        fq::Fq,
+        vesta::{Affine as GAffine, Projective},
+    };
+
+    impl_projective!(
+        vesta,
+        CamlGroupProjectiveVesta,
+        CamlGVesta,
+        CamlFp,
+        Fq,
+        CamlFq,
+        Projective
+    );
+}
+*/

--- a/src/lib/crypto/kimchi_bindings/wasm/src/srs.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/srs.rs
@@ -1,0 +1,221 @@
+use ark_poly::UVPolynomial;
+use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Evaluations};
+use commitment_dlog::{
+    commitment::b_poly_coefficients,
+    srs::{endos, SRS},
+};
+use paste::paste;
+use serde::{Deserialize, Serialize};
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufReader, BufWriter, Seek, SeekFrom::Start},
+    sync::Arc,
+};
+use wasm_bindgen::prelude::*;
+use std::ops::Deref;
+use crate::wasm_flat_vector::WasmFlatVector;
+use crate::wasm_vector::WasmVector;
+
+macro_rules! impl_srs {
+    ($name: ident,
+     $WasmF: ty,
+     $WasmG: ty,
+     $F: ty,
+     $G: ty,
+     $WasmPolyComm: ty,
+     $field_name: ident) => {
+
+        paste! {
+            #[wasm_bindgen]
+            #[derive(Clone)]
+            pub struct [<Wasm $field_name:camel Srs>](
+                #[wasm_bindgen(skip)]
+                pub Arc<SRS<$G>>);
+
+            impl Deref for [<Wasm $field_name:camel Srs>] {
+                type Target = Arc<SRS<$G>>;
+
+                fn deref(&self) -> &Self::Target { &self.0 }
+            }
+
+            impl From<Arc<SRS<$G>>> for [<Wasm $field_name:camel Srs>] {
+                fn from(x: Arc<SRS<$G>>) -> Self {
+                    [<Wasm $field_name:camel Srs>](x)
+                }
+            }
+
+            impl From<&Arc<SRS<$G>>> for [<Wasm $field_name:camel Srs>] {
+                fn from(x: &Arc<SRS<$G>>) -> Self {
+                    [<Wasm $field_name:camel Srs>](x.clone())
+                }
+            }
+
+            impl From<[<Wasm $field_name:camel Srs>]> for Arc<SRS<$G>> {
+                fn from(x: [<Wasm $field_name:camel Srs>]) -> Self {
+                    x.0
+                }
+            }
+
+            impl From<&[<Wasm $field_name:camel Srs>]> for Arc<SRS<$G>> {
+                fn from(x: &[<Wasm $field_name:camel Srs>]) -> Self {
+                    x.0.clone()
+                }
+            }
+
+            impl<'a> From<&'a [<Wasm $field_name:camel Srs>]> for &'a Arc<SRS<$G>> {
+                fn from(x: &'a [<Wasm $field_name:camel Srs>]) -> Self {
+                    &x.0
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _create>](depth: i32) -> [<Wasm $field_name:camel Srs>] {
+                Arc::new(SRS::create(depth as usize)).into()
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _write>](
+                append: Option<bool>,
+                srs: &[<Wasm $field_name:camel Srs>],
+                path: String,
+            ) -> Result<(), JsValue> {
+                let file = OpenOptions::new()
+                    .append(append.unwrap_or(true))
+                    .open(path)
+                    .map_err(|err| {
+                        JsValue::from_str(format!("caml_pasta_fp_urs_write: {}", err).as_str())
+                    })?;
+                let file = BufWriter::new(file);
+
+                srs.0.serialize(&mut rmp_serde::Serializer::new(file))
+                .map_err(|e| JsValue::from_str(format!("caml_pasta_fp_urs_write: {}", e).as_str()))
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _read>](
+                offset: Option<i32>,
+                path: String,
+            ) -> Result<Option<[<Wasm $field_name:camel Srs>]>, JsValue> {
+                let file = File::open(path).map_err(|err| {
+                    JsValue::from_str(format!("caml_pasta_fp_urs_read: {}", err).as_str())
+                })?;
+                let mut reader = BufReader::new(file);
+
+                if let Some(offset) = offset {
+                    reader.seek(Start(offset as u64)).map_err(|err| {
+                        JsValue::from_str(format!("caml_pasta_fp_urs_read: {}", err).as_str())
+                    })?;
+                }
+
+                // TODO: shouldn't we just error instead of returning None?
+                let mut srs = match SRS::<$G>::deserialize(&mut rmp_serde::Deserializer::new(reader)) {
+                    Ok(srs) => srs,
+                    Err(_) => return Ok(None),
+                };
+
+                let (endo_q, endo_r) = endos::<$G>();
+                srs.endo_q = endo_q;
+                srs.endo_r = endo_r;
+
+                Ok(Some(Arc::new(srs).into()))
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _lagrange_commitment>](
+                srs: &[<Wasm $field_name:camel Srs>],
+                domain_size: i32,
+                i: i32,
+            ) -> Result<$WasmPolyComm, JsValue> {
+                let x_domain = EvaluationDomain::<$F>::new(domain_size as usize).ok_or_else(|| {
+                    JsValue::from_str("caml_pasta_fp_urs_lagrange_commitment")
+                })?;
+
+                let evals = (0..domain_size)
+                    .map(|j| if i == j { <$F as ark_ff::One>::one() } else { <$F as ark_ff::Zero>::zero() })
+                    .collect();
+                let p = Evaluations::<$F>::from_vec_and_domain(evals, x_domain).interpolate();
+                Ok(srs.commit_non_hiding(&p, None).into())
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _commit_evaluations>](
+                srs: &[<Wasm $field_name:camel Srs>],
+                domain_size: i32,
+                evals: WasmFlatVector<$WasmF>,
+            ) -> Result<$WasmPolyComm, JsValue> {
+                let x_domain = EvaluationDomain::<$F>::new(domain_size as usize).ok_or_else(|| {
+                    JsValue::from_str("caml_pasta_fp_urs_commit_evaluations")
+                })?;
+
+                let evals = evals.into_iter().map(Into::into).collect();
+                let p = Evaluations::<$F>::from_vec_and_domain(evals, x_domain).interpolate();
+
+                Ok(srs.commit_non_hiding(&p, None).into())
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _b_poly_commitment>](
+                srs: &[<Wasm $field_name:camel Srs>],
+                chals: WasmFlatVector<$WasmF>,
+            ) -> Result<$WasmPolyComm, JsValue> {
+                let chals: Vec<$F> = chals.into_iter().map(Into::into).collect();
+                let coeffs = b_poly_coefficients(&chals);
+                let p = DensePolynomial::<$F>::from_coefficients_vec(coeffs);
+
+                Ok(srs.commit_non_hiding(&p, None).into())
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _batch_accumulator_check>](
+                srs: &[<Wasm $field_name:camel Srs>],
+                comms: WasmVector<$WasmG>,
+                chals: WasmFlatVector<$WasmF>,
+            ) -> bool {
+                let comms: Vec<_> = comms.into_iter().map(Into::into).collect();
+                let chals: Vec<_> = chals.into_iter().map(Into::into).collect();
+                crate::urs_utils::batch_dlog_accumulator_check(&srs, &comms, &chals)
+            }
+
+            #[wasm_bindgen]
+            pub fn [<$name:snake _h>](srs: &[<Wasm $field_name:camel Srs>]) -> $WasmG {
+                srs.h.into()
+            }
+        }
+    }
+}
+
+//
+// Fp
+//
+
+pub mod fp {
+    use super::*;
+    use crate::arkworks::{WasmPastaFp, WasmGVesta};
+    use mina_curves::pasta::{fp::Fp, vesta::Affine as GAffine};
+    use crate::poly_comm::vesta::WasmFpPolyComm as WasmPolyComm;
+
+    impl_srs!(
+        caml_fp_srs,
+        WasmPastaFp,
+        WasmGVesta,
+        Fp,
+        GAffine,
+        WasmPolyComm,
+        Fp);
+}
+
+pub mod fq {
+    use super::*;
+    use crate::arkworks::{WasmPastaFq, WasmGPallas};
+    use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine};
+    use crate::poly_comm::pallas::WasmFqPolyComm as WasmPolyComm;
+
+    impl_srs!(
+        caml_fq_srs,
+        WasmPastaFq,
+        WasmGPallas,
+        Fq,
+        GAffine,
+        WasmPolyComm,
+        Fq);
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/srs.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/srs.rs
@@ -1,3 +1,5 @@
+use crate::wasm_flat_vector::WasmFlatVector;
+use crate::wasm_vector::WasmVector;
 use ark_poly::UVPolynomial;
 use ark_poly::{univariate::DensePolynomial, EvaluationDomain, Evaluations};
 use commitment_dlog::{
@@ -6,15 +8,13 @@ use commitment_dlog::{
 };
 use paste::paste;
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 use std::{
     fs::{File, OpenOptions},
     io::{BufReader, BufWriter, Seek, SeekFrom::Start},
     sync::Arc,
 };
 use wasm_bindgen::prelude::*;
-use std::ops::Deref;
-use crate::wasm_flat_vector::WasmFlatVector;
-use crate::wasm_vector::WasmVector;
 
 macro_rules! impl_srs {
     ($name: ident,
@@ -190,9 +190,9 @@ macro_rules! impl_srs {
 
 pub mod fp {
     use super::*;
-    use crate::arkworks::{WasmPastaFp, WasmGVesta};
-    use mina_curves::pasta::{fp::Fp, vesta::Affine as GAffine};
+    use crate::arkworks::{WasmGVesta, WasmPastaFp};
     use crate::poly_comm::vesta::WasmFpPolyComm as WasmPolyComm;
+    use mina_curves::pasta::{fp::Fp, vesta::Affine as GAffine};
 
     impl_srs!(
         caml_fp_srs,
@@ -201,14 +201,15 @@ pub mod fp {
         Fp,
         GAffine,
         WasmPolyComm,
-        Fp);
+        Fp
+    );
 }
 
 pub mod fq {
     use super::*;
-    use crate::arkworks::{WasmPastaFq, WasmGPallas};
-    use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine};
+    use crate::arkworks::{WasmGPallas, WasmPastaFq};
     use crate::poly_comm::pallas::WasmFqPolyComm as WasmPolyComm;
+    use mina_curves::pasta::{fq::Fq, pallas::Affine as GAffine};
 
     impl_srs!(
         caml_fq_srs,
@@ -217,5 +218,6 @@ pub mod fq {
         Fq,
         GAffine,
         WasmPolyComm,
-        Fq);
+        Fq
+    );
 }

--- a/src/lib/crypto/kimchi_bindings/wasm/src/urs_utils.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/urs_utils.rs
@@ -1,0 +1,69 @@
+use ark_ec::msm::VariableBaseMSM;
+use ark_ff::{batch_inversion, One, PrimeField, UniformRand, Zero};
+use commitment_dlog::{
+    commitment::{b_poly_coefficients, CommitmentCurve},
+    srs::SRS,
+};
+use rayon::prelude::*;
+
+// TODO: Not compatible with variable rounds
+pub fn batch_dlog_accumulator_check<G: CommitmentCurve>(
+    urs: &SRS<G>,
+    comms: &[G],
+    chals: &[G::ScalarField],
+) -> bool {
+    let k = comms.len();
+
+    if k == 0 {
+        assert_eq!(chals.len(), 0);
+        return true;
+    }
+
+    let rounds = chals.len() / k;
+    assert_eq!(chals.len() % rounds, 0);
+
+    let rs = {
+        let r = G::ScalarField::rand(&mut rand::rngs::OsRng);
+        let mut rs = vec![G::ScalarField::one(); k];
+        for i in 1..k {
+            rs[i] = r * rs[i - 1];
+        }
+        rs
+    };
+
+    let mut points = urs.g.clone();
+    let n = points.len();
+    points.extend(comms);
+
+    let mut scalars = vec![G::ScalarField::zero(); n];
+    scalars.extend(&rs[..]);
+
+    let chal_invs = {
+        let mut cs = chals.to_vec();
+        batch_inversion(&mut cs);
+        cs
+    };
+
+    let termss: Vec<_> = chals
+        .par_iter()
+        .zip(chal_invs)
+        .chunks(rounds)
+        .zip(rs)
+        .map(|(chunk, r)| {
+            let chals: Vec<_> = chunk.iter().map(|(c, _)| **c).collect();
+            let mut s = b_poly_coefficients(&chals);
+            s.iter_mut().for_each(|c| *c *= &r);
+            s
+        })
+        .collect();
+
+    for terms in termss {
+        assert_eq!(terms.len(), n);
+        for i in 0..n {
+            scalars[i] -= &terms[i];
+        }
+    }
+
+    let scalars: Vec<_> = scalars.iter().map(|x| x.into_repr()).collect();
+    VariableBaseMSM::multi_scalar_mul(&points, &scalars) == G::Projective::zero()
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_flat_vector.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_flat_vector.rs
@@ -1,7 +1,7 @@
-use wasm_bindgen::convert::{OptionIntoWasmAbi, IntoWasmAbi, OptionFromWasmAbi, FromWasmAbi};
+use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi};
 
-use std::ops::Deref;
 use std::convert::From;
+use std::ops::Deref;
 
 #[derive(Clone, Debug)]
 pub struct WasmFlatVector<T>(Vec<T>);
@@ -15,7 +15,9 @@ pub trait FlatVectorElem {
 impl<T> Deref for WasmFlatVector<T> {
     type Target = Vec<T>;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl<T> From<Vec<T>> for WasmFlatVector<T> {
@@ -54,7 +56,9 @@ impl<'a, T> std::iter::IntoIterator for &'a WasmFlatVector<T> {
 
 impl<T> std::iter::FromIterator<T> for WasmFlatVector<T> {
     fn from_iter<I>(iter: I) -> WasmFlatVector<T>
-    where I: IntoIterator<Item = T> {
+    where
+        I: IntoIterator<Item = T>,
+    {
         WasmFlatVector(std::iter::FromIterator::from_iter(iter))
     }
 }
@@ -66,13 +70,18 @@ impl<T> std::default::Default for WasmFlatVector<T> {
 }
 
 impl<T> std::iter::Extend<T> for WasmFlatVector<T> {
-    fn extend<I>(&mut self, iter: I) where I: IntoIterator<Item = T> {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
         self.0.extend(iter)
     }
 }
 
 impl<T> wasm_bindgen::describe::WasmDescribe for WasmFlatVector<T> {
-    fn describe() { <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe() }
+    fn describe() {
+        <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe()
+    }
 }
 
 impl<T: FlatVectorElem> FromWasmAbi for WasmFlatVector<T> {
@@ -117,4 +126,3 @@ impl<T: FlatVectorElem> OptionIntoWasmAbi for WasmFlatVector<T> {
         <Vec<u8> as OptionIntoWasmAbi>::none()
     }
 }
-

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_flat_vector.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_flat_vector.rs
@@ -1,0 +1,120 @@
+use wasm_bindgen::convert::{OptionIntoWasmAbi, IntoWasmAbi, OptionFromWasmAbi, FromWasmAbi};
+
+use std::ops::Deref;
+use std::convert::From;
+
+#[derive(Clone, Debug)]
+pub struct WasmFlatVector<T>(Vec<T>);
+
+pub trait FlatVectorElem {
+    const FLATTENED_SIZE: usize;
+    fn flatten(self) -> Vec<u8>;
+    fn unflatten(flat: Vec<u8>) -> Self;
+}
+
+impl<T> Deref for WasmFlatVector<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl<T> From<Vec<T>> for WasmFlatVector<T> {
+    fn from(x: Vec<T>) -> Self {
+        WasmFlatVector(x)
+    }
+}
+
+impl<T> From<WasmFlatVector<T>> for Vec<T> {
+    fn from(x: WasmFlatVector<T>) -> Self {
+        x.0
+    }
+}
+
+impl<'a, T> From<&'a WasmFlatVector<T>> for &'a Vec<T> {
+    fn from(x: &'a WasmFlatVector<T>) -> Self {
+        &x.0
+    }
+}
+
+impl<T> std::iter::IntoIterator for WasmFlatVector<T> {
+    type Item = <Vec<T> as std::iter::IntoIterator>::Item;
+    type IntoIter = <Vec<T> as std::iter::IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T> std::iter::IntoIterator for &'a WasmFlatVector<T> {
+    type Item = <&'a Vec<T> as std::iter::IntoIterator>::Item;
+    type IntoIter = <&'a Vec<T> as std::iter::IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.0).into_iter()
+    }
+}
+
+impl<T> std::iter::FromIterator<T> for WasmFlatVector<T> {
+    fn from_iter<I>(iter: I) -> WasmFlatVector<T>
+    where I: IntoIterator<Item = T> {
+        WasmFlatVector(std::iter::FromIterator::from_iter(iter))
+    }
+}
+
+impl<T> std::default::Default for WasmFlatVector<T> {
+    fn default() -> Self {
+        WasmFlatVector(std::default::Default::default())
+    }
+}
+
+impl<T> std::iter::Extend<T> for WasmFlatVector<T> {
+    fn extend<I>(&mut self, iter: I) where I: IntoIterator<Item = T> {
+        self.0.extend(iter)
+    }
+}
+
+impl<T> wasm_bindgen::describe::WasmDescribe for WasmFlatVector<T> {
+    fn describe() { <Vec<u8> as wasm_bindgen::describe::WasmDescribe>::describe() }
+}
+
+impl<T: FlatVectorElem> FromWasmAbi for WasmFlatVector<T> {
+    type Abi = <Vec<u8> as FromWasmAbi>::Abi;
+    unsafe fn from_abi(js: Self::Abi) -> Self {
+        let data: Vec<u8> = FromWasmAbi::from_abi(js);
+        let mut res: Vec<T> = Vec::with_capacity(data.len() / T::FLATTENED_SIZE);
+
+        let mut buf = Vec::with_capacity(T::FLATTENED_SIZE);
+        for x in data.into_iter() {
+            assert!(buf.len() < T::FLATTENED_SIZE);
+            buf.push(x);
+            if buf.len() >= T::FLATTENED_SIZE {
+                res.push(T::unflatten(buf));
+                buf = Vec::with_capacity(T::FLATTENED_SIZE);
+            }
+        }
+        assert_eq!(buf.len(), 0);
+        WasmFlatVector(res)
+    }
+}
+
+impl<T: FlatVectorElem> OptionFromWasmAbi for WasmFlatVector<T> {
+    fn is_none(x: &Self::Abi) -> bool {
+        <Vec<u8> as OptionFromWasmAbi>::is_none(x)
+    }
+}
+
+impl<T: FlatVectorElem> IntoWasmAbi for WasmFlatVector<T> {
+    type Abi = <Vec<u8> as FromWasmAbi>::Abi;
+    fn into_abi(self) -> Self::Abi {
+        let mut data: Vec<u8> = Vec::with_capacity(self.0.len() * T::FLATTENED_SIZE);
+        for x in self.0.into_iter() {
+            data.extend(x.flatten().into_iter());
+        }
+        IntoWasmAbi::into_abi(data)
+    }
+}
+
+impl<T: FlatVectorElem> OptionIntoWasmAbi for WasmFlatVector<T> {
+    fn none() -> Self::Abi {
+        <Vec<u8> as OptionIntoWasmAbi>::none()
+    }
+}
+

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_vector.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_vector.rs
@@ -1,7 +1,7 @@
-use wasm_bindgen::convert::{OptionIntoWasmAbi, IntoWasmAbi, OptionFromWasmAbi, FromWasmAbi};
+use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi};
 
-use std::ops::Deref;
 use std::convert::From;
+use std::ops::Deref;
 
 #[derive(Clone, Debug)]
 pub struct WasmVector<T>(Vec<T>);
@@ -9,7 +9,9 @@ pub struct WasmVector<T>(Vec<T>);
 impl<T> Deref for WasmVector<T> {
     type Target = Vec<T>;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl<T> From<Vec<T>> for WasmVector<T> {
@@ -48,7 +50,9 @@ impl<'a, T> std::iter::IntoIterator for &'a WasmVector<T> {
 
 impl<T> std::iter::FromIterator<T> for WasmVector<T> {
     fn from_iter<I>(iter: I) -> WasmVector<T>
-    where I: IntoIterator<Item = T> {
+    where
+        I: IntoIterator<Item = T>,
+    {
         WasmVector(std::iter::FromIterator::from_iter(iter))
     }
 }
@@ -60,41 +64,53 @@ impl<T> std::default::Default for WasmVector<T> {
 }
 
 impl<T> std::iter::Extend<T> for WasmVector<T> {
-    fn extend<I>(&mut self, iter: I) where I: IntoIterator<Item = T> {
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = T>,
+    {
         self.0.extend(iter)
     }
 }
 
 impl<T> wasm_bindgen::describe::WasmDescribe for WasmVector<T> {
-    fn describe() { <Vec<u32> as wasm_bindgen::describe::WasmDescribe>::describe() }
-}
-
-impl<T: FromWasmAbi<Abi=u32>> FromWasmAbi for WasmVector<T> {
-    type Abi = <Vec<u32> as FromWasmAbi>::Abi;
-    unsafe fn from_abi(js: Self::Abi) -> Self {
-        let pointers: Vec<u32> = FromWasmAbi::from_abi(js);
-        WasmVector(pointers.into_iter().map(|x| FromWasmAbi::from_abi(x)).collect())
+    fn describe() {
+        <Vec<u32> as wasm_bindgen::describe::WasmDescribe>::describe()
     }
 }
 
-impl<T: FromWasmAbi<Abi=u32>> OptionFromWasmAbi for WasmVector<T> {
+impl<T: FromWasmAbi<Abi = u32>> FromWasmAbi for WasmVector<T> {
+    type Abi = <Vec<u32> as FromWasmAbi>::Abi;
+    unsafe fn from_abi(js: Self::Abi) -> Self {
+        let pointers: Vec<u32> = FromWasmAbi::from_abi(js);
+        WasmVector(
+            pointers
+                .into_iter()
+                .map(|x| FromWasmAbi::from_abi(x))
+                .collect(),
+        )
+    }
+}
+
+impl<T: FromWasmAbi<Abi = u32>> OptionFromWasmAbi for WasmVector<T> {
     fn is_none(x: &Self::Abi) -> bool {
         <Vec<u32> as OptionFromWasmAbi>::is_none(x)
     }
 }
 
-impl<T: IntoWasmAbi<Abi=u32>> IntoWasmAbi for WasmVector<T> {
+impl<T: IntoWasmAbi<Abi = u32>> IntoWasmAbi for WasmVector<T> {
     type Abi = <Vec<u32> as FromWasmAbi>::Abi;
     fn into_abi(self) -> Self::Abi {
-        let pointers: Vec<u32> =
-            self.0.into_iter().map(|x| IntoWasmAbi::into_abi(x)).collect();
+        let pointers: Vec<u32> = self
+            .0
+            .into_iter()
+            .map(|x| IntoWasmAbi::into_abi(x))
+            .collect();
         IntoWasmAbi::into_abi(pointers)
     }
 }
 
-impl<T: IntoWasmAbi<Abi=u32>> OptionIntoWasmAbi for WasmVector<T> {
+impl<T: IntoWasmAbi<Abi = u32>> OptionIntoWasmAbi for WasmVector<T> {
     fn none() -> Self::Abi {
         <Vec<u32> as OptionIntoWasmAbi>::none()
     }
 }
-

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_vector.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_vector.rs
@@ -1,0 +1,100 @@
+use wasm_bindgen::convert::{OptionIntoWasmAbi, IntoWasmAbi, OptionFromWasmAbi, FromWasmAbi};
+
+use std::ops::Deref;
+use std::convert::From;
+
+#[derive(Clone, Debug)]
+pub struct WasmVector<T>(Vec<T>);
+
+impl<T> Deref for WasmVector<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl<T> From<Vec<T>> for WasmVector<T> {
+    fn from(x: Vec<T>) -> Self {
+        WasmVector(x)
+    }
+}
+
+impl<T> From<WasmVector<T>> for Vec<T> {
+    fn from(x: WasmVector<T>) -> Self {
+        x.0
+    }
+}
+
+impl<'a, T> From<&'a WasmVector<T>> for &'a Vec<T> {
+    fn from(x: &'a WasmVector<T>) -> Self {
+        &x.0
+    }
+}
+
+impl<T> std::iter::IntoIterator for WasmVector<T> {
+    type Item = <Vec<T> as std::iter::IntoIterator>::Item;
+    type IntoIter = <Vec<T> as std::iter::IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T> std::iter::IntoIterator for &'a WasmVector<T> {
+    type Item = <&'a Vec<T> as std::iter::IntoIterator>::Item;
+    type IntoIter = <&'a Vec<T> as std::iter::IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.0).into_iter()
+    }
+}
+
+impl<T> std::iter::FromIterator<T> for WasmVector<T> {
+    fn from_iter<I>(iter: I) -> WasmVector<T>
+    where I: IntoIterator<Item = T> {
+        WasmVector(std::iter::FromIterator::from_iter(iter))
+    }
+}
+
+impl<T> std::default::Default for WasmVector<T> {
+    fn default() -> Self {
+        WasmVector(std::default::Default::default())
+    }
+}
+
+impl<T> std::iter::Extend<T> for WasmVector<T> {
+    fn extend<I>(&mut self, iter: I) where I: IntoIterator<Item = T> {
+        self.0.extend(iter)
+    }
+}
+
+impl<T> wasm_bindgen::describe::WasmDescribe for WasmVector<T> {
+    fn describe() { <Vec<u32> as wasm_bindgen::describe::WasmDescribe>::describe() }
+}
+
+impl<T: FromWasmAbi<Abi=u32>> FromWasmAbi for WasmVector<T> {
+    type Abi = <Vec<u32> as FromWasmAbi>::Abi;
+    unsafe fn from_abi(js: Self::Abi) -> Self {
+        let pointers: Vec<u32> = FromWasmAbi::from_abi(js);
+        WasmVector(pointers.into_iter().map(|x| FromWasmAbi::from_abi(x)).collect())
+    }
+}
+
+impl<T: FromWasmAbi<Abi=u32>> OptionFromWasmAbi for WasmVector<T> {
+    fn is_none(x: &Self::Abi) -> bool {
+        <Vec<u32> as OptionFromWasmAbi>::is_none(x)
+    }
+}
+
+impl<T: IntoWasmAbi<Abi=u32>> IntoWasmAbi for WasmVector<T> {
+    type Abi = <Vec<u32> as FromWasmAbi>::Abi;
+    fn into_abi(self) -> Self::Abi {
+        let pointers: Vec<u32> =
+            self.0.into_iter().map(|x| IntoWasmAbi::into_abi(x)).collect();
+        IntoWasmAbi::into_abi(pointers)
+    }
+}
+
+impl<T: IntoWasmAbi<Abi=u32>> OptionIntoWasmAbi for WasmVector<T> {
+    fn none() -> Self::Abi {
+        <Vec<u32> as OptionIntoWasmAbi>::none()
+    }
+}
+

--- a/src/lib/rosetta_coding/coding.ml
+++ b/src/lib/rosetta_coding/coding.ml
@@ -169,8 +169,6 @@ let%test "public key compressed roundtrip odd" =
 let%test "public key compressed roundtrip even" =
   pk_compressed_roundtrip_test hex_key_even ()
 
-[%%ifndef consensus_mechanism]
-
 (* for running tests from JS *)
 
 let unit_tests =
@@ -186,5 +184,3 @@ let run_unit_tests () =
   List.iter unit_tests ~f:(fun (name, test) ->
       printf "Running %s test\n%!" name ;
       assert (test ()))
-
-[%%endif]


### PR DESCRIPTION
This PR relies on the Wasm bindings and is stacked on top of `feature/wasm-bindings`.

The goal is to pull in and use fields-derivers in the client SDK.

TODO: properly bundle the wasm artifacts similar to snarkyjs.