### PR TITLE
Updated ci builds to use generic K8s pod sizing #2

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -118,10 +118,10 @@ let Config =
   }
 
 let targetToAgent = \(target : Size) ->
-  merge { XLarge = toMap { size = "xlarge" },
-          Large = toMap { size = "large" },
-          Medium = toMap { size = "medium" },
-          Small = toMap { size = "small" }
+  merge { XLarge = toMap { size = "generic" },
+          Large = toMap { size = "generic" },
+          Medium = toMap { size = "generic" },
+          Small = toMap { size = "generic" }
         }
         target
 

--- a/buildkite/src/Command/DockerLogin/Type.dhall
+++ b/buildkite/src/Command/DockerLogin/Type.dhall
@@ -10,7 +10,7 @@
         server: Text
     },
     default = {
-        username = "o1bot",
+        username = "o1botdockerhub",
         `password-env` = "DOCKER_PASSWORD",
         server = ""
     }


### PR DESCRIPTION
Explain your changes:

40 new Buildkite CI nodes have been deployed to Kubernetes. These have better security configurations and eventually will replace the currently running buildkite nodes.
This PR is to test the cutover process and changes the pod assignments used in CI to point to the new nodes (these are the edits in Base.dhall).
An additional edit is made in Type.dhall to change the Dockerhub account used for pushing packages to Dockerhub. It is currently manually assign to point to an old account that does not exist in the new Buildkite nodes.
Explain how you tested your changes:

The new nodes have been assigned into the Buildkite "smokescreen" pipeline to confirm all credentials are valid and authorized.
The new nodes have also been installed into the existing Mina build pipeline in small amounts (4 nodes) over the last 2 weeks to watch them build various jobs. At this time, all build and credentials appears healthy.
Checklist:

- [ ]  Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ]  Document code purpose, how to use it
- [ ] Mention expected invariants, implicit constraints
- [ ]  Tests were added for the new behavior
- [ ] Document test purpose, significance of failures
- [ ] Test names should reflect their purpose
- [ ]  All tests pass (CI will check this if you didn't)
- [ ]  Serialized types are in stable-versioned modules
- [ ]  Does this close issues? List them
