### PR TITLE
Fix message id function for long topics

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
@@ -141,7 +141,12 @@ func configurePubsub(app *app, validationQueueSize int, directPeers []peer.AddrI
 			pubsub.WithDirectPeers(directPeers),
 			pubsub.WithValidateQueueSize(validationQueueSize),
 			pubsub.WithMessageIdFn(func(pmsg *pb.Message) string {
-				hash, err := blake2b.New256([]byte(pmsg.GetTopic()))
+				hmacKey := []byte(pmsg.GetTopic())
+				if len(hmacKey) > 64 {
+					hmacKey2 := blake2b.Sum256(hmacKey)
+					hmacKey = hmacKey2[:]
+				}
+				hash, err := blake2b.New256(hmacKey)
 				panicOnErr(err)
 				_, err = hash.Write(pmsg.GetData())
 				panicOnErr(err)

--- a/src/app/libp2p_helper/src/libp2p_helper/message_id_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/message_id_test.go
@@ -11,7 +11,7 @@ import (
 
 // This file contains test for the use of message id function
 
-func TestPubsubMsgIdFun(t *testing.T) {
+func testPubsubMsgIdFun(t *testing.T, topic string) {
 	newProtocol := "/mina/97"
 	var mask uint32 = upcallDropAllMask ^ (1 << IncomingStreamChan) ^ (1 << GossipReceivedChan)
 	errChan := make(chan error, 3)
@@ -47,7 +47,6 @@ func TestPubsubMsgIdFun(t *testing.T) {
 	require.NoError(t, configurePubsub(carol, 100, nil, pubsub.WithGossipSubParams(gossipSubp)))
 
 	// Subscribe to the topic
-	topic := "test"
 	testSubscribeDo(t, alice, topic, 21, 58)
 	testSubscribeDo(t, bob, topic, 21, 58)
 	testSubscribeDo(t, carol, topic, 21, 58)
@@ -74,4 +73,12 @@ loop:
 		n++
 	}
 	require.Equal(t, 1, n)
+}
+
+func TestPubsubMsgIdFun(t *testing.T) {
+	testPubsubMsgIdFun(t, "test")
+}
+
+func TestPubsubMsgIdFunLongTopic(t *testing.T) {
+	testPubsubMsgIdFun(t, "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789")
 }


### PR DESCRIPTION
Problem: topics long topics (more than 64 bytes) message id calculation fails.

Solution: follow the RFC-2104 closely and hash the long topic before using it as argument to blake2b function.

Explain how you tested your changes:
* Test was added for long topics


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
