### PR TITLE
Remove Account.Poly, replace with explicit record declarations

### DIFF
--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -393,7 +393,7 @@ let run_test () : unit Deferred.t =
             (List.map accounts
                ~f:(fun ((keypair : Signature_lib.Keypair.t), account) ->
                  ( Public_key.compress keypair.public_key
-                 , account.Account.Poly.balance )))
+                 , account.Account.balance )))
         in
         let%bind updated_balance_sheet =
           send_payments accounts ~txn_count balance_sheet (fun i ->

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -391,9 +391,9 @@ let run_test () : unit Deferred.t =
         let balance_sheet =
           Public_key.Compressed.Map.of_alist_exn
             (List.map accounts
-               ~f:(fun ((keypair : Signature_lib.Keypair.t), account) ->
-                 ( Public_key.compress keypair.public_key
-                 , account.Account.balance )))
+               ~f:(fun
+                    ((keypair, account) : Signature_lib.Keypair.t * Account.t)
+                  -> (Public_key.compress keypair.public_key, account.balance)))
         in
         let%bind updated_balance_sheet =
           send_payments accounts ~txn_count balance_sheet (fun i ->

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2091,8 +2091,8 @@ module Data = struct
 
     let supercharge_coinbase (t : Value.t) = t.supercharge_coinbase
 
-    let compute_supercharge_coinbase ~(winner_account : Mina_base.Account.var)
-        ~global_slot =
+    let compute_supercharge_coinbase
+        ~(winner_account : Mina_base.Account.Checked.t) ~global_slot =
       let open Snark_params.Tick in
       let%map winner_locked =
         Mina_base.Account.Checked.has_locked_tokens ~global_slot winner_account

--- a/src/lib/mina_base/ledger_hash.ml
+++ b/src/lib/mina_base/ledger_hash.ml
@@ -28,6 +28,8 @@ module Merkle_tree =
     (struct
       include Account
 
+      type var = Checked.t
+
       let hash = Checked.digest
     end)
 
@@ -82,7 +84,7 @@ let get ~depth t addr =
      account [f account] at path [addr].
 *)
 let%snarkydef modify_account ~depth t aid
-    ~(filter : Account.var -> ('a, _) Checked.t) ~f =
+    ~(filter : Account.Checked.t -> ('a, _) Checked.t) ~f =
   let%bind addr =
     request_witness
       (Account.Index.Unpacked.typ ~ledger_depth:depth)
@@ -109,7 +111,7 @@ let%snarkydef modify_account_send ~depth t aid ~is_writeable ~f =
     ~filter:(fun account ->
       [%with_label "modify_account_send filter"]
         (let%bind account_already_there =
-           Account_id.Checked.equal (Account.identifier_of_var account) aid
+           Account_id.Checked.equal (Account.Checked.identifier account) aid
          in
          let%bind account_not_there =
            Public_key.Compressed.Checked.equal account.public_key
@@ -139,7 +141,7 @@ let%snarkydef modify_account_recv ~depth t aid ~f =
     ~filter:(fun account ->
       [%with_label "modify_account_recv filter"]
         (let%bind account_already_there =
-           Account_id.Checked.equal (Account.identifier_of_var account) aid
+           Account_id.Checked.equal (Account.Checked.identifier account) aid
          in
          let%bind account_not_there =
            Public_key.Compressed.Checked.equal account.public_key

--- a/src/lib/mina_base/ledger_hash_intf.ml
+++ b/src/lib/mina_base/ledger_hash_intf.ml
@@ -14,7 +14,10 @@ module type S = sig
     | Find_index : Account_id.t -> Account.Index.t Request.t
 
   val get :
-    depth:int -> var -> Account.Index.Unpacked.var -> (Account.var, _) Checked.t
+       depth:int
+    -> var
+    -> Account.Index.Unpacked.var
+    -> (Account.Checked.t, _) Checked.t
 
   val merge : height:int -> t -> t -> t
 
@@ -31,8 +34,8 @@ module type S = sig
        depth:int
     -> var
     -> Account_id.var
-    -> filter:(Account.var -> ('a, 's) Checked.t)
-    -> f:('a -> Account.var -> (Account.var, 's) Checked.t)
+    -> filter:(Account.Checked.t -> ('a, 's) Checked.t)
+    -> f:('a -> Account.Checked.t -> (Account.Checked.t, 's) Checked.t)
     -> (var, 's) Checked.t
 
   val modify_account_send :
@@ -42,8 +45,8 @@ module type S = sig
     -> is_writeable:Boolean.var
     -> f:
          (   is_empty_and_writeable:Boolean.var
-          -> Account.var
-          -> (Account.var, 's) Checked.t)
+          -> Account.Checked.t
+          -> (Account.Checked.t, 's) Checked.t)
     -> (var, 's) Checked.t
 
   val modify_account_recv :
@@ -52,7 +55,7 @@ module type S = sig
     -> Account_id.var
     -> f:
          (   is_empty_and_writeable:Boolean.var
-          -> Account.var
-          -> (Account.var, 's) Checked.t)
+          -> Account.Checked.t
+          -> (Account.Checked.t, 's) Checked.t)
     -> (var, 's) Checked.t
 end

--- a/src/lib/mina_base/transaction_logic.ml
+++ b/src/lib/mina_base/transaction_logic.ml
@@ -497,7 +497,7 @@ let timing_error_to_user_command_status err =
         used, as it contains an incorrect placeholder value.
 *)
 let validate_timing_with_min_balance' ~account ~txn_amount ~txn_global_slot =
-  let open Account.Poly in
+  let open Account.Stable.Latest in
   let open Account.Timing.Poly in
   match account.timing with
   | Untimed -> (
@@ -550,7 +550,7 @@ let validate_timing_with_min_balance ~account ~txn_amount ~txn_global_slot =
       !"For %s account, the requested transaction for amount %{sexp: Amount.t} \
         at global slot %{sexp: Global_slot.t}, the balance %{sexp: Balance.t} \
         is insufficient"
-      kind txn_amount txn_global_slot account.Account.Poly.balance
+      kind txn_amount txn_global_slot account.Account.balance
     |> Or_error.tag ~tag:nsf_tag
   in
   let min_balance_error min_balance =
@@ -2554,22 +2554,7 @@ module For_tests = struct
   open Currency
 
   module Account_without_receipt_chain_hash = struct
-    type t =
-      ( Public_key.Compressed.t
-      , Token_id.t
-      , Token_permissions.t
-      , Account.Token_symbol.t
-      , Balance.t
-      , Account_nonce.t
-      , unit
-      , Public_key.Compressed.t option
-      , State_hash.t
-      , Account_timing.t
-      , Permissions.t
-      , Snapp_account.t option
-      , string )
-      Account.Poly.t
-    [@@deriving sexp, compare]
+    type t = Account.t [@@deriving sexp, compare]
   end
 
   let min_init_balance = 8_000_000_000
@@ -2831,8 +2816,8 @@ module For_tests = struct
                   other did not"
                 a ()
             in
-            let hide_rc (a : _ Account.Poly.t) =
-              { a with receipt_chain_hash = () }
+            let hide_rc (a : Account.t) =
+              { a with receipt_chain_hash = Snark_params.Tick.Field.zero }
             in
             match L.(location_of_account l1 a, location_of_account l2 a) with
             | None, None ->

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -32,18 +32,18 @@ let get_keys_with_details t =
   let%map accounts = get_accounts t in
   List.map accounts ~f:(fun account ->
       ( string_of_public_key account
-      , account.Account.Poly.balance |> Currency.Balance.to_int
-      , account.Account.Poly.nonce |> Account.Nonce.to_int ))
+      , account.Account.balance |> Currency.Balance.to_int
+      , account.Account.nonce |> Account.Nonce.to_int ))
 
 let get_nonce t (addr : Account_id.t) =
   let open Participating_state.Option.Let_syntax in
   let%map account = get_account t addr in
-  account.Account.Poly.nonce
+  account.Account.nonce
 
 let get_balance t (addr : Account_id.t) =
   let open Participating_state.Option.Let_syntax in
   let%map account = get_account t addr in
-  account.Account.Poly.balance
+  account.Account.balance
 
 let get_trust_status t (ip_address : Unix.Inet_addr.Blocking_sexp.t) =
   let config = Mina_lib.config t in
@@ -186,7 +186,7 @@ let verify_payment t (addr : Account_id.t) (verifying_txn : User_command.t)
   let open Participating_state.Let_syntax in
   let%map account = get_account t addr in
   let account = Option.value_exn account in
-  let resulting_receipt = account.Account.Poly.receipt_chain_hash in
+  let resulting_receipt = account.Account.receipt_chain_hash in
   let open Or_error.Let_syntax in
   let%bind (_ : Receipt.Chain_hash.t Non_empty_list.t) =
     Result.of_option

--- a/src/lib/mina_generators/snapp_generators.ml
+++ b/src/lib/mina_generators/snapp_generators.ml
@@ -35,7 +35,7 @@ let gen_predicate_from ?(succeed = true) ~account_id ~ledger () =
             "gen_predicate_from: could not find account with known location"
       | Some account ->
           let%bind b = Quickcheck.Generator.bool in
-          let { Account.Poly.public_key
+          let { Account.public_key
               ; balance
               ; nonce
               ; receipt_chain_hash
@@ -238,7 +238,7 @@ let gen_predicate_from ?(succeed = true) ~account_id ~ledger () =
               return (Party.Predicate.Full faulty_predicate_account)
           else
             (* Nonce *)
-            let { Account.Poly.nonce; _ } = account in
+            let { Account.nonce; _ } = account in
             if succeed then return (Party.Predicate.Nonce nonce)
             else return (Party.Predicate.Nonce (Account.Nonce.succ nonce)) )
 

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1024,32 +1024,27 @@ module Types = struct
              [ field "publicKey" ~typ:(non_null public_key)
                  ~doc:"The public identity of the account"
                  ~args:Arg.[]
-                 ~resolve:(fun _ { account; _ } ->
-                   account.Partial_account.public_key)
+                 ~resolve:(fun _ { account; _ } -> account.public_key)
              ; field "token" ~typ:(non_null token_id)
                  ~doc:"The token associated with this account"
                  ~args:Arg.[]
-                 ~resolve:(fun _ { account; _ } ->
-                   account.Partial_account.token_id)
+                 ~resolve:(fun _ { account; _ } -> account.token_id)
              ; field "timing" ~typ:(non_null account_timing)
                  ~doc:"The timing associated with this account"
                  ~args:Arg.[]
-                 ~resolve:(fun _ { account; _ } ->
-                   account.Partial_account.timing)
+                 ~resolve:(fun _ { account; _ } -> account.timing)
              ; field "balance"
                  ~typ:(non_null AnnotatedBalance.obj)
                  ~doc:"The amount of MINA owned by the account"
                  ~args:Arg.[]
-                 ~resolve:(fun _ { account; _ } ->
-                   account.Partial_account.balance)
+                 ~resolve:(fun _ { account; _ } -> account.balance)
              ; field "nonce" ~typ:string
                  ~doc:
                    "A natural number that increases with each transaction \
                     (stringified uint32)"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
-                   Option.map ~f:Account.Nonce.to_string
-                     account.Partial_account.nonce)
+                   Option.map ~f:Account.Nonce.to_string account.nonce)
              ; field "inferredNonce" ~typ:string
                  ~doc:
                    "Like the `nonce` field, except it includes the scheduled \
@@ -1115,7 +1110,7 @@ module Types = struct
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
                    Option.map ~f:Receipt.Chain_hash.to_base58_check
-                     account.Partial_account.receipt_chain_hash)
+                     account.receipt_chain_hash)
              ; field "delegate" ~typ:public_key
                  ~doc:
                    "The public key to which you are delegating - if you are \
@@ -1123,8 +1118,7 @@ module Types = struct
                     key"
                  ~args:Arg.[]
                  ~deprecated:(Deprecated (Some "use delegateAccount instead"))
-                 ~resolve:(fun _ { account; _ } ->
-                   account.Partial_account.delegate)
+                 ~resolve:(fun _ { account; _ } -> account.delegate)
              ; field "delegateAccount" ~typ:(Lazy.force account)
                  ~doc:
                    "The account to which you are delegating - if you are not \
@@ -1133,7 +1127,7 @@ module Types = struct
                  ~resolve:(fun { ctx = coda; _ } { account; _ } ->
                    Option.map
                      ~f:(get_best_ledger_account_pk coda)
-                     account.Partial_account.delegate)
+                     account.delegate)
              ; field "delegators"
                  ~typ:(list @@ non_null @@ Lazy.force account)
                  ~doc:
@@ -1143,7 +1137,7 @@ module Types = struct
                  ~args:Arg.[]
                  ~resolve:(fun { ctx = coda; _ } { account; _ } ->
                    let open Option.Let_syntax in
-                   let pk = account.Partial_account.public_key in
+                   let pk = account.public_key in
                    let%map delegators =
                      Mina_lib.current_epoch_delegators coda ~pk
                    in
@@ -1174,7 +1168,7 @@ module Types = struct
                  ~args:Arg.[]
                  ~resolve:(fun { ctx = coda; _ } { account; _ } ->
                    let open Option.Let_syntax in
-                   let pk = account.Partial_account.public_key in
+                   let pk = account.public_key in
                    let%map delegators =
                      Mina_lib.last_epoch_delegators coda ~pk
                    in
@@ -1202,7 +1196,7 @@ module Types = struct
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
                    Option.map ~f:Mina_base.State_hash.to_base58_check
-                     account.Partial_account.voting_for)
+                     account.voting_for)
              ; field "stakingActive" ~typ:(non_null bool)
                  ~doc:
                    "True if you are actively staking with this account on the \
@@ -1253,8 +1247,7 @@ module Types = struct
                    "The URI associated with this account, usually pointing to \
                     the snapp source code"
                  ~args:Arg.[]
-                 ~resolve:(fun _ { account; _ } ->
-                   account.Partial_account.snapp_uri)
+                 ~resolve:(fun _ { account; _ } -> account.snapp_uri)
              ; field "snappState"
                  ~typ:(list @@ non_null string)
                  ~doc:
@@ -1262,33 +1255,30 @@ module Types = struct
                     with this account encoded as bignum strings"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
-                   account.Partial_account.snapp
+                   account.snapp
                    |> Option.map ~f:(fun snapp_account ->
                           snapp_account.app_state |> Snapp_state.V.to_list
                           |> List.map ~f:Snapp_basic.F.to_string))
              ; field "permissions" ~typ:account_permissions
                  ~doc:"Permissions for updating certain fields of this account"
                  ~args:Arg.[]
-                 ~resolve:(fun _ { account; _ } ->
-                   account.Partial_account.permissions)
+                 ~resolve:(fun _ { account; _ } -> account.permissions)
              ; field "tokenSymbol" ~typ:string
                  ~doc:"The token symbol associated with this account"
                  ~args:Arg.[]
-                 ~resolve:(fun _ { account; _ } ->
-                   account.Partial_account.token_symbol)
+                 ~resolve:(fun _ { account; _ } -> account.token_symbol)
              ; field "verificationKey" ~typ:account_vk
                  ~doc:"Verification key associated with this account"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
-                   Option.value_map account.Partial_account.snapp ~default:None
+                   Option.value_map account.snapp ~default:None
                      ~f:(fun snapp_account -> snapp_account.verification_key))
              ; field "sequenceEvents"
                  ~doc:"Sequence events associated with this account"
                  ~typ:(list (non_null string))
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
-                   Option.map account.Partial_account.snapp
-                     ~f:(fun snapp_account ->
+                   Option.map account.snapp ~f:(fun snapp_account ->
                        List.map ~f:Snark_params.Tick.Field.to_string
                          (Pickles_types.Vector.to_list
                             snapp_account.sequence_state)))

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -71,9 +71,9 @@ module Ledger_inner = struct
 
         let identifier = Account.identifier
 
-        let balance Account.Poly.{ balance; _ } = balance
+        let balance = Account.balance
 
-        let token Account.Poly.{ token_id; _ } = token_id
+        let token = Account.token
 
         let empty = Account.empty
 

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -698,7 +698,7 @@ let get_inferred_nonce_from_transaction_pool_and_ledger t
   | None ->
       let open Participating_state.Option.Let_syntax in
       let%map account = get_account t account_id in
-      account.Account.Poly.nonce
+      account.Account.nonce
 
 let snark_job_state t = t.snark_job_state
 
@@ -901,7 +901,7 @@ let get_current_nonce t aid =
       let ledger_nonce =
         Participating_state.active (get_account t aid)
         |> Option.join
-        |> Option.map ~f:(fun { Account.Poly.nonce; _ } -> nonce)
+        |> Option.map ~f:(fun { Account.nonce; _ } -> nonce)
         |> Option.value ~default:nonce
       in
       Ok (`Min ledger_nonce, nonce)

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1903,7 +1903,7 @@ let%test_module _ =
     let mk_account ~idx ~balance ~nonce =
       let public_key = Public_key.compress @@ test_keys.(idx).public_key in
       ( idx
-      , { Account.Poly.Stable.Latest.public_key
+      , { Account.public_key
         ; token_id = Token_id.default
         ; token_permissions =
             Token_permissions.Not_owned { account_disabled = false }

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -260,7 +260,7 @@ module For_tests = struct
         in
         let send_amount = Currency.Amount.of_int 1 in
         let sender_account_amount =
-          sender_account.Account.Poly.balance |> Currency.Balance.to_amount
+          sender_account.Account.balance |> Currency.Balance.to_amount
         in
         let%map _ = Currency.Amount.sub sender_account_amount send_amount in
         let sender_pk = Account.public_key sender_account in


### PR DESCRIPTION
This PR removes `Account.Poly` and replaces its specialisations with explicit record types.

This vastly improves the error messages produced by the OCaml typechecker when the type for one of the fields is incorrect. This also identified some cases where the types of the record produced was invalid, revealing some unused functions.

In order to prevent the field names for `Account.var` shadowing those from `Account.t`, `Account.var` has been moved to `Account.Checked.t`.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them