### PR TITLE
Switch from explicit `constant`/`var_of_t`s to generalised `constant`

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -150,7 +150,7 @@ let%snarkydef step ~(logger : Logger.t)
       match constraint_constants.fork with
       | Some { previous_state_hash = fork_prev; _ } ->
           State_hash.if_ is_base_case
-            ~then_:(State_hash.var_of_t fork_prev)
+            ~then_:(constant State_hash.typ fork_prev)
             ~else_:t.previous_state_hash
       | None ->
           Checked.return t.previous_state_hash
@@ -168,7 +168,7 @@ let%snarkydef step ~(logger : Logger.t)
         (previous_state |> Protocol_state.blockchain_state).registers
         { txn_snark.target with pending_coinbase_stack = () }
     and supply_increase_is_zero =
-      Currency.Amount.(equal_var txn_snark.supply_increase (var_of_t zero))
+      Currency.Amount.(equal_var txn_snark.supply_increase (constant typ zero))
     in
     let%bind new_pending_coinbase_hash, deleted_stack, no_coinbases_popped =
       let coinbase_receiver =

--- a/src/lib/consensus/constants.ml
+++ b/src/lib/consensus/constants.ml
@@ -146,7 +146,7 @@ module Constants_checked :
 
   type bool_type = Boolean.var
 
-  let constant c = N.Unsafe.of_field (Field.Var.constant (Field.of_int c))
+  let constant c = N.Unsafe.of_field (constant Field.typ (Field.of_int c))
 
   let zero = constant 0
 
@@ -405,7 +405,7 @@ module Checked = struct
     in
     let%map checkpoint_window_slots_per_year, checkpoint_window_size_in_slots =
       let constant c =
-        N.Unsafe.of_field (Field.Var.constant (Field.of_int c))
+        N.Unsafe.of_field (constant Field.typ (Field.of_int c))
       in
       let per_year = constant 12 in
       let slot_duration_ms =

--- a/src/lib/consensus/global_sub_window.ml
+++ b/src/lib/consensus/global_sub_window.ml
@@ -1,26 +1,6 @@
 open Unsigned
 open Snark_params.Tick
 
-type t = uint32
-
-let succ = UInt32.succ
-
-let equal a b = UInt32.compare a b = 0
-
-let of_global_slot ~(constants : Constants.t) (s : Global_slot.t) : t =
-  UInt32.Infix.(Global_slot.slot_number s / constants.slots_per_sub_window)
-
-let sub_window ~(constants : Constants.t) t =
-  UInt32.rem t constants.sub_windows_per_window
-
-let ( >= ) a b = UInt32.compare a b >= 0
-
-let add a b = UInt32.add a b
-
-let sub a b = UInt32.sub a b
-
-let constant a = a
-
 module Checked = struct
   module T = Mina_numbers.Global_slot
 
@@ -50,10 +30,30 @@ module Checked = struct
   let equal = T.Checked.equal
 
   let constant a =
-    T.Checked.Unsafe.of_field @@ Field.Var.constant @@ Field.of_int
+    T.Checked.Unsafe.of_field @@ constant Field.typ @@ Field.of_int
     @@ UInt32.to_int a
 
   let add a (b : Mina_numbers.Length.Checked.t) = T.Checked.add a (of_length b)
 
   let ( >= ) a b = T.Checked.( >= ) a b
 end
+
+type t = uint32
+
+let succ = UInt32.succ
+
+let equal a b = UInt32.compare a b = 0
+
+let of_global_slot ~(constants : Constants.t) (s : Global_slot.t) : t =
+  UInt32.Infix.(Global_slot.slot_number s / constants.slots_per_sub_window)
+
+let sub_window ~(constants : Constants.t) t =
+  UInt32.rem t constants.sub_windows_per_window
+
+let ( >= ) a b = UInt32.compare a b >= 0
+
+let add a b = UInt32.add a b
+
+let sub a b = UInt32.sub a b
+
+let constant a = a

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -694,7 +694,8 @@ module Data = struct
       in
       let%bind () =
         [%with_label "Account is for the default token"]
-          Token_id.(Checked.Assert.equal account.token_id (var_of_t default))
+          Token_id.(
+            Checked.Assert.equal account.token_id (constant typ default))
       in
       let%bind () =
         [%with_label "Block stake winner matches account pk"]
@@ -1332,11 +1333,11 @@ module Data = struct
           Checked.List.mapi prev_sub_window_densities ~f:(fun i density ->
               let%bind gt_prev_sub_window =
                 Sub_window.Checked.(
-                  constant (UInt32.of_int i) > prev_relative_sub_window)
+                  constant typ (UInt32.of_int i) > prev_relative_sub_window)
               in
               let%bind lt_next_sub_window =
                 Sub_window.Checked.(
-                  constant (UInt32.of_int i) < next_relative_sub_window)
+                  constant typ (UInt32.of_int i) < next_relative_sub_window)
               in
               let%bind within_range =
                 Sub_window.Checked.(
@@ -1380,7 +1381,7 @@ module Data = struct
           Checked.List.mapi current_sub_window_densities ~f:(fun i density ->
               let%bind is_next_sub_window =
                 Sub_window.Checked.(
-                  constant (UInt32.of_int i) = next_relative_sub_window)
+                  constant typ (UInt32.of_int i) = next_relative_sub_window)
               in
               if_
                 (Checked.return is_next_sub_window)
@@ -2080,7 +2081,8 @@ module Data = struct
 
     let is_genesis (global_slot : Global_slot.Checked.t) =
       let open Mina_numbers.Global_slot in
-      Checked.equal (Checked.constant zero)
+      Checked.equal
+        (constant Checked.typ zero)
         (Global_slot.slot_number global_slot)
 
     let is_genesis_state_var (t : var) = is_genesis t.curr_global_slot
@@ -2218,7 +2220,7 @@ module Data = struct
           let%bind base =
             (* TODO: Should this be zero or some other sentinel value? *)
             Mina_base.State_hash.if_ epoch_increased
-              ~then_:Mina_base.State_hash.(var_of_t (of_hash zero))
+              ~then_:Mina_base.State_hash.(constant typ (of_hash zero))
               ~else_:previous_state.next_epoch_data.lock_checkpoint
           in
           Mina_base.State_hash.if_ in_seed_update_range

--- a/src/lib/consensus/slot.ml
+++ b/src/lib/consensus/slot.ml
@@ -19,7 +19,7 @@ module Checked = struct
     let open Tick in
     let module Length = Mina_numbers.Length in
     let constant c =
-      Length.Checked.Unsafe.of_field (Field.Var.constant (Field.of_int c))
+      Length.Checked.Unsafe.of_field (constant Field.typ (Field.of_int c))
     in
     let%bind third_epoch =
       let%bind q, r =

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -56,8 +56,6 @@ module type Basic = sig
 
   val typ : (var, t) Typ.t
 
-  val var_of_t : t -> var
-
   val var_to_bits :
     var -> (Boolean.var Bitstring_lib.Bitstring.Lsb_first.t, _) Checked.t
 

--- a/src/lib/data_hash_lib/data_hash_intf.ml
+++ b/src/lib/data_hash_lib/data_hash_intf.ml
@@ -40,8 +40,6 @@ module type Basic = sig
 
   val equal_var : var -> var -> (Boolean.var, _) Checked.t
 
-  val var_of_t : t -> var
-
   (* TODO : define bit ops using Random_oracle instead of Pedersen.Digest,
      move this outside of consensus_mechanism guard
   *)

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -196,9 +196,6 @@ module Token_symbol = struct
     in
     Field.Checked.Assert.equal t actual
 
-  let var_of_value x =
-    Pickles_types.Vector.map ~f:Boolean.var_of_value (to_bits x)
-
   let of_field (x : Field.t) : t =
     of_bits
       (Pickles_types.Vector.of_list_and_length_exn
@@ -558,37 +555,6 @@ let typ : (var, value) Typ.t =
   in
   typ' snapp
 
-let var_of_t
-    ({ public_key
-     ; token_id
-     ; token_permissions
-     ; token_symbol
-     ; balance
-     ; nonce
-     ; receipt_chain_hash
-     ; delegate
-     ; voting_for
-     ; timing
-     ; permissions
-     ; snapp
-     ; snapp_uri
-     } :
-      value) =
-  { Poly.public_key = Public_key.Compressed.var_of_t public_key
-  ; token_id = Token_id.var_of_t token_id
-  ; token_permissions = Token_permissions.var_of_t token_permissions
-  ; token_symbol = Token_symbol.var_of_value token_symbol
-  ; balance = Balance.var_of_t balance
-  ; nonce = Nonce.Checked.constant nonce
-  ; receipt_chain_hash = Receipt.Chain_hash.var_of_t receipt_chain_hash
-  ; delegate = Public_key.Compressed.var_of_t (delegate_opt delegate)
-  ; voting_for = State_hash.var_of_t voting_for
-  ; timing = Timing.var_of_t timing
-  ; permissions = Permissions.Checked.constant permissions
-  ; snapp = Field.Var.constant (hash_snapp_account_opt snapp)
-  ; snapp_uri = Field.Var.constant (hash_snapp_uri snapp_uri)
-  }
-
 module Checked = struct
   module Unhashed = struct
     type t =
@@ -694,7 +660,7 @@ module Checked = struct
         ~cliff_amount ~vesting_period ~vesting_increment
     in
     let%map zero_min_balance =
-      Balance.equal_var Balance.(var_of_t zero) cur_min_balance
+      Balance.equal_var Balance.(constant typ zero) cur_min_balance
     in
     (*Note: Untimed accounts will always have zero min balance*)
     Boolean.not zero_min_balance

--- a/src/lib/mina_base/account_id.ml
+++ b/src/lib/mina_base/account_id.ml
@@ -39,9 +39,6 @@ type var = Public_key.Compressed.var * Token_id.var
 
 let typ = Snarky_backendless.Typ.(Public_key.Compressed.typ * Token_id.typ)
 
-let var_of_t (key, tid) =
-  (Public_key.Compressed.var_of_t key, Token_id.var_of_t tid)
-
 module Checked = struct
   open Snark_params
   open Tick

--- a/src/lib/mina_base/account_id.mli
+++ b/src/lib/mina_base/account_id.mli
@@ -32,8 +32,6 @@ type var
 
 val typ : (var, t) Snark_params.Tick.Typ.t
 
-val var_of_t : t -> var
-
 module Checked : sig
   open Snark_params
   open Tick

--- a/src/lib/mina_base/account_timing.ml
+++ b/src/lib/mina_base/account_timing.ml
@@ -138,28 +138,6 @@ let var_to_input
      ; Amount.var_to_input vesting_increment
     |]
 
-let var_of_t (t : t) : var =
-  let As_record.
-        { is_timed
-        ; initial_minimum_balance
-        ; cliff_time
-        ; cliff_amount
-        ; vesting_period
-        ; vesting_increment
-        } =
-    to_record t
-  in
-  As_record.
-    { is_timed = Boolean.var_of_value is_timed
-    ; initial_minimum_balance = Balance.var_of_t initial_minimum_balance
-    ; cliff_time = Global_slot.Checked.constant cliff_time
-    ; cliff_amount = Amount.var_of_t cliff_amount
-    ; vesting_period = Global_slot.Checked.constant vesting_period
-    ; vesting_increment = Amount.var_of_t vesting_increment
-    }
-
-let untimed_var = var_of_t Untimed
-
 let typ : (var, t) Typ.t =
   let spec =
     let open Data_spec in
@@ -228,6 +206,8 @@ let typ : (var, t) Typ.t =
   let var_to_hlist = As_record.to_hlist in
   Typ.of_hlistable spec ~var_to_hlist ~var_of_hlist ~value_to_hlist
     ~value_of_hlist
+
+let untimed_var = constant typ Untimed
 
 (* we can't use the generic if_ with the above typ, because Global_slot.typ doesn't work correctly with it
     so we define a custom if_

--- a/src/lib/mina_base/ledger_hash.ml
+++ b/src/lib/mina_base/ledger_hash.ml
@@ -113,7 +113,7 @@ let%snarkydef modify_account_send ~depth t aid ~is_writeable ~f =
          in
          let%bind account_not_there =
            Public_key.Compressed.Checked.equal account.public_key
-             Public_key.Compressed.(var_of_t empty)
+             Public_key.Compressed.(constant typ empty)
          in
          let%bind not_there_but_writeable =
            Boolean.(account_not_there && is_writeable)
@@ -143,7 +143,7 @@ let%snarkydef modify_account_recv ~depth t aid ~f =
          in
          let%bind account_not_there =
            Public_key.Compressed.Checked.equal account.public_key
-             Public_key.Compressed.(var_of_t empty)
+             Public_key.Compressed.(constant typ empty)
          in
          let%bind () =
            [%with_label "account is either present or empty"]

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -139,14 +139,6 @@ module Update = struct
         }
       [@@deriving hlist]
 
-      let constant (t : value) : t =
-        { initial_minimum_balance = Balance.var_of_t t.initial_minimum_balance
-        ; cliff_time = Global_slot.Checked.constant t.cliff_time
-        ; cliff_amount = Amount.var_of_t t.cliff_amount
-        ; vesting_period = Global_slot.Checked.constant t.vesting_period
-        ; vesting_increment = Amount.var_of_t t.vesting_increment
-        }
-
       let to_input
           ({ initial_minimum_balance
            ; cliff_time

--- a/src/lib/mina_base/payment_payload.ml
+++ b/src/lib/mina_base/payment_payload.ml
@@ -87,13 +87,6 @@ let var_to_input_legacy { Poly.source_pk; receiver_pk; token_id; amount } =
      ; amount
     |]
 
-let var_of_t ({ source_pk; receiver_pk; token_id; amount } : t) : var =
-  { source_pk = Public_key.Compressed.var_of_t source_pk
-  ; receiver_pk = Public_key.Compressed.var_of_t receiver_pk
-  ; token_id = Token_id.var_of_t token_id
-  ; amount = Amount.var_of_t amount
-  }
-
 [%%endif]
 
 let gen_aux ?source_pk ~token_id ~max_amount =

--- a/src/lib/mina_base/payment_payload.mli
+++ b/src/lib/mina_base/payment_payload.mli
@@ -61,5 +61,3 @@ val to_input_legacy : t -> (Field.t, bool) Random_oracle.Input.Legacy.t
 
 val var_to_input_legacy :
   var -> ((Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t, _) Checked.t
-
-val var_of_t : t -> var

--- a/src/lib/mina_base/pending_coinbase_intf.ml
+++ b/src/lib/mina_base/pending_coinbase_intf.ml
@@ -49,16 +49,12 @@ module type S = sig
     val of_coinbase : Coinbase.t -> t
 
     val genesis : t
-
-    val var_of_t : t -> var
   end
 
   module type Data_hash_intf = sig
     type t = private Field.t [@@deriving sexp, compare, equal, yojson, hash]
 
     type var
-
-    val var_of_t : t -> var
 
     val typ : (var, t) Typ.t
 
@@ -107,8 +103,6 @@ module type S = sig
     type var
 
     val data_hash : t -> Hash.t
-
-    val var_of_t : t -> var
 
     val typ : (var, t) Typ.t
 
@@ -182,8 +176,6 @@ module type S = sig
       type var = Boolean.var * Boolean.var
 
       val typ : (var, t) Typ.t
-
-      val var_of_t : t -> var
     end
 
     module Poly : sig
@@ -210,8 +202,6 @@ module type S = sig
     val genesis : t
 
     val typ : (var, t) Typ.t
-
-    val var_of_t : t -> var
   end
 
   val create : depth:int -> unit -> t Or_error.t

--- a/src/lib/mina_base/permissions.ml
+++ b/src/lib/mina_base/permissions.ml
@@ -222,8 +222,6 @@ module Auth_required = struct
       Encoding.to_input ~field_of_bool:(fun (b : Boolean.var) ->
           (b :> Field.Var.t))
 
-    let constant t = Encoding.map (encode t) ~f:Boolean.var_of_value
-
     let eval_no_proof
         ({ constant; signature_necessary = _; signature_sufficient } : t)
         ~signature_verifies =
@@ -410,15 +408,6 @@ module Checked = struct
       ~set_delegate:c ~set_permissions:c ~set_verification_key:c
       ~set_snapp_uri:c ~edit_sequence_state:c ~set_token_symbol:c
       ~increment_nonce:c ~set_voting_for:c
-
-  let constant (t : Stable.Latest.t) : t =
-    let open Core_kernel.Field in
-    let a f = Auth_required.Checked.constant (get f t) in
-    Poly.Fields.map
-      ~stake:(fun f -> Boolean.var_of_value (get f t))
-      ~edit_state:a ~send:a ~receive:a ~set_delegate:a ~set_permissions:a
-      ~set_verification_key:a ~set_snapp_uri:a ~edit_sequence_state:a
-      ~set_token_symbol:a ~increment_nonce:a ~set_voting_for:a
 end
 
 let typ =

--- a/src/lib/mina_base/permissions.mli
+++ b/src/lib/mina_base/permissions.mli
@@ -84,8 +84,6 @@ module Checked : sig
 
   val to_input : t -> Field.Var.t Random_oracle_input.Chunked.t
 
-  val constant : Stable.Latest.t -> t
-
   val if_ : Boolean.var -> then_:t -> else_:t -> t
 end
 

--- a/src/lib/mina_base/receipt.ml
+++ b/src/lib/mina_base/receipt.ml
@@ -70,7 +70,7 @@ module Chain_hash = struct
     end
 
     let constant (t : t) =
-      var_of_hash_packed (Field.Var.constant (t :> Field.t))
+      var_of_hash_packed (constant Field.typ (t :> Field.t))
 
     type t = var
 
@@ -106,10 +106,10 @@ module Chain_hash = struct
             let open Snark_params.Tick.Checked.Let_syntax in
             let payload =
               Transaction_union_payload.(
-                Checked.constant (of_user_command_payload payload))
+                constant typ (of_user_command_payload payload))
             in
             let%map res =
-              Checked.cons (Signed_command payload) (var_of_t base)
+              Checked.cons (Signed_command payload) (constant typ base)
             in
             As_prover.read typ res
           in

--- a/src/lib/mina_base/signed_command_memo.ml
+++ b/src/lib/mina_base/signed_command_memo.ml
@@ -177,12 +177,6 @@ module Checked = struct
   type unchecked = t
 
   type t = Boolean.var array
-
-  let constant unchecked =
-    assert (Int.(String.length (unchecked :> string) = memo_length)) ;
-    Array.map
-      (Blake2.string_to_bits (unchecked :> string))
-      ~f:Boolean.var_of_value
 end
 
 let length_in_bits = 8 * memo_length

--- a/src/lib/mina_base/signed_command_memo.mli
+++ b/src/lib/mina_base/signed_command_memo.mli
@@ -26,8 +26,6 @@ module Checked : sig
   type unchecked = t
 
   type t = private Boolean.var array
-
-  val constant : unchecked -> t
 end
 
 (** typ representation *)

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -159,16 +159,6 @@ module Common = struct
       ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
   module Checked = struct
-    let constant
-        ({ fee; fee_token; fee_payer_pk; nonce; valid_until; memo } : t) : var =
-      { fee = Currency.Fee.var_of_t fee
-      ; fee_token = Token_id.var_of_t fee_token
-      ; fee_payer_pk = Public_key.Compressed.var_of_t fee_payer_pk
-      ; nonce = Account_nonce.Checked.constant nonce
-      ; memo = Memo.Checked.constant memo
-      ; valid_until = Global_slot.Checked.constant valid_until
-      }
-
     let to_input_legacy
         ({ fee; fee_token; fee_payer_pk; nonce; valid_until; memo } : var) =
       let%map nonce = Account_nonce.Checked.to_input_legacy nonce

--- a/src/lib/mina_base/signed_command_payload.mli
+++ b/src/lib/mina_base/signed_command_payload.mli
@@ -91,8 +91,6 @@ module Common : sig
       -> ( (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
          , _ )
          Snark_params.Tick.Checked.t
-
-    val constant : t -> var
   end
 
   [%%endif]

--- a/src/lib/mina_base/snapp_account.ml
+++ b/src/lib/mina_base/snapp_account.ml
@@ -44,7 +44,7 @@ module Events = struct
 
   let is_empty_var (e : var) =
     Snark_params.Tick.Field.(
-      Checked.equal (Data_as_hash.hash e) (Var.constant (Lazy.force empty_hash)))
+      Checked.equal (Data_as_hash.hash e) (constant typ (Lazy.force empty_hash)))
 
   let pop_checked (events : var) : Event.t Data_as_hash.t * var =
     let open Run in

--- a/src/lib/mina_base/staged_ledger_hash.ml
+++ b/src/lib/mina_base/staged_ledger_hash.ml
@@ -152,9 +152,6 @@ module Non_snark = struct
     Array.reduce_exn ~f:append
       (Array.of_list_map t ~f:(fun b -> packed ((b :> Field.Var.t), 1)))
 
-  let var_of_t t : var =
-    List.map (Fold.to_list @@ fold t) ~f:Boolean.var_of_value
-
   [%%if proof_level = "check"]
 
   let warn_improper_transport () = ()
@@ -242,13 +239,6 @@ let genesis ~(constraint_constants : Genesis_constants.Constraint_constants.t)
   { non_snark = Non_snark.genesis ~genesis_ledger_hash
   ; pending_coinbase_hash = Pending_coinbase.merkle_root pending_coinbase
   }
-
-let var_of_t ({ pending_coinbase_hash; non_snark } : t) : var =
-  let non_snark = Non_snark.var_of_t non_snark in
-  let pending_coinbase_hash =
-    Pending_coinbase.Hash.var_of_t pending_coinbase_hash
-  in
-  { non_snark; pending_coinbase_hash }
 
 let to_input ({ non_snark; pending_coinbase_hash } : t) =
   Random_oracle.Input.Chunked.(

--- a/src/lib/mina_base/staged_ledger_hash.mli
+++ b/src/lib/mina_base/staged_ledger_hash.mli
@@ -9,8 +9,6 @@ type value [@@deriving sexp, equal, compare, hash]
 
 type var
 
-val var_of_t : t -> var
-
 val typ : (var, t) Typ.t
 
 val var_to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t

--- a/src/lib/mina_base/token_permissions.ml
+++ b/src/lib/mina_base/token_permissions.ml
@@ -33,16 +33,6 @@ open Snark_params.Tick
 
 type var = { token_owner : Boolean.var; token_locked : Boolean.var }
 
-let var_of_t = function
-  | Token_owned { disable_new_accounts } ->
-      { token_owner = Boolean.true_
-      ; token_locked = Boolean.var_of_value disable_new_accounts
-      }
-  | Not_owned { account_disabled } ->
-      { token_owner = Boolean.false_
-      ; token_locked = Boolean.var_of_value account_disabled
-      }
-
 let typ : (var, t) Typ.t =
   let open Typ in
   { alloc =

--- a/src/lib/mina_base/transaction_union_payload.ml
+++ b/src/lib/mina_base/transaction_union_payload.ml
@@ -158,17 +158,6 @@ module Body = struct
       ~var_of_hlist:t__of_hlist ~value_of_hlist:t__of_hlist
 
   module Checked = struct
-    let constant
-        ({ tag; source_pk; receiver_pk; token_id; amount; token_locked } : t) :
-        var =
-      { tag = Tag.unpacked_of_t tag
-      ; source_pk = Public_key.Compressed.var_of_t source_pk
-      ; receiver_pk = Public_key.Compressed.var_of_t receiver_pk
-      ; token_id = Token_id.var_of_t token_id
-      ; amount = Currency.Amount.var_of_t amount
-      ; token_locked = Boolean.var_of_value token_locked
-      }
-
     let to_input_legacy
         { tag; source_pk; receiver_pk; token_id; amount; token_locked } =
       let%map token_id = Token_id.Checked.to_input_legacy token_id
@@ -236,11 +225,6 @@ module Checked = struct
       Signed_command_payload.Common.Checked.to_input_legacy common
     and body = Body.Checked.to_input_legacy body in
     Random_oracle.Input.Legacy.append common body
-
-  let constant ({ common; body } : t) : var =
-    { common = Signed_command_payload.Common.Checked.constant common
-    ; body = Body.Checked.constant body
-    }
 end
 
 [%%endif]

--- a/src/lib/mina_base/transaction_union_tag.mli
+++ b/src/lib/mina_base/transaction_union_tag.mli
@@ -41,10 +41,6 @@ module Bits : sig
     var -> (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
 end
 
-val bits_of_t : t -> Bits.var
-
-val bits_typ : (Bits.var, t) Typ.t
-
 module Unpacked : sig
   (** Full representation. This pre-computes all of the tag variables, but may
       still be convered to bits without adding any constraints.
@@ -70,8 +66,6 @@ module Unpacked : sig
   val to_input_legacy :
     var -> (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
 end
-
-val unpacked_of_t : t -> Unpacked.var
 
 val unpacked_typ : (Unpacked.var, t) Typ.t
 

--- a/src/lib/mina_numbers/intf.ml
+++ b/src/lib/mina_numbers/intf.ml
@@ -68,8 +68,6 @@ module type S_checked = sig
 
   type var
 
-  val constant : unchecked -> var
-
   type t = var
 
   val zero : t

--- a/src/lib/mina_numbers/nat.ml
+++ b/src/lib/mina_numbers/nat.ml
@@ -30,10 +30,6 @@ struct
     Checked.map (to_bits t) ~f:(fun bits ->
         Random_oracle.Input.Legacy.bitstring bits)
 
-  let constant n =
-    Field.Var.constant
-      (Bigint.to_field (Bigint.of_bignum_bigint (N.to_bigint n)))
-
   let () = assert (Int.(N.length_in_bits mod 16 = 0))
 
   let range_check' (t : var) =
@@ -90,7 +86,7 @@ struct
   let is_succ ~pred ~succ =
     let open Snark_params.Tick in
     let open Field in
-    Checked.(equal (pred + Var.constant one) succ)
+    Checked.(equal (pred + constant typ one) succ)
 
   let gte x y =
     let open Pickles.Impls.Step in
@@ -134,7 +130,7 @@ struct
     Checked.return (Field.Var.add t (c :> Field.Var.t))
 
   let succ (t : var) =
-    Checked.return (Field.Var.add t (Field.Var.constant Field.one))
+    Checked.return (Field.Var.add t (constant Field.typ Field.one))
 
   let seal x = make_checked (fun () -> Pickles.Util.seal m x)
 
@@ -178,7 +174,7 @@ struct
 
   let ( = ) = equal
 
-  let zero = Field.Var.constant Field.zero
+  let zero = constant Field.typ Field.zero
 end
 
 [%%endif]

--- a/src/lib/mina_numbers/token_id.ml
+++ b/src/lib/mina_numbers/token_id.ml
@@ -85,8 +85,6 @@ type var = T.Checked.t
 
 let typ = T.typ
 
-let var_of_t = T.Checked.constant
-
 module Checked = struct
   type t = var
 
@@ -124,7 +122,7 @@ let%test_unit "var_of_t preserves the underlying value" =
   Quickcheck.test gen ~f:(fun tid ->
       [%test_eq: t] tid
         (Test_util.checked_to_unchecked Typ.unit typ
-           (fun () -> Snark_params.Tick.Checked.return (var_of_t tid))
+           (fun () -> Snark_params.Tick.Checked.return (constant typ tid))
            ()))
 
 [%%endif]

--- a/src/lib/mina_numbers/token_id.mli
+++ b/src/lib/mina_numbers/token_id.mli
@@ -62,8 +62,6 @@ type var
 
 val typ : (var, t) Typ.t
 
-val var_of_t : t -> var
-
 module Checked : sig
   val to_input : var -> Field.Var.t Random_oracle.Input.Chunked.t
 

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -137,9 +137,6 @@ module Compressed = struct
       ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
       ~value_of_hlist:Poly.of_hlist
 
-  let var_of_t ({ x; is_odd } : t) : var =
-    { x = Field.Var.constant x; is_odd = Boolean.var_of_value is_odd }
-
   let assert_equal (t1 : var) (t2 : var) =
     let%map () = Field.Checked.Assert.equal t1.x t2.x
     and () = Boolean.Assert.(t1.is_odd = t2.is_odd) in
@@ -281,8 +278,6 @@ module Uncompressed = struct
     let%bind () = equal v1_f1 v2_f1 in
     let%map () = equal v1_f2 v2_f2 in
     ()
-
-  let var_of_t (x, y) = (Field.Var.constant x, Field.Var.constant y)
 
   let typ : (var, t) Typ.t = Typ.(field * field)
 

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -109,7 +109,7 @@ module Step = struct
       let open Internal_Basic in
       let open Let_syntax in
       let equal (x1, b1) (x2, b2) =
-        let%bind x_eq = Field.Checked.equal x1 (Field.Var.constant x2) in
+        let%bind x_eq = Field.Checked.equal x1 (constant Field.typ x2) in
         let b_eq = match b2 with true -> b1 | false -> Boolean.not b1 in
         Boolean.( && ) x_eq b_eq
       in
@@ -207,7 +207,7 @@ module Wrap = struct
       let check t =
         let open Internal_Basic in
         let open Let_syntax in
-        let equal x1 x2 = Field.Checked.equal x1 (Field.Var.constant x2) in
+        let equal x1 x2 = Field.Checked.equal x1 (constant Field.typ x2) in
         let%bind () = t0.check t in
         Checked.List.map forbidden_shifted_values ~f:(equal t)
         >>= Boolean.any >>| Boolean.not >>= Boolean.Assert.is_true

--- a/src/lib/pickles/intf.ml
+++ b/src/lib/pickles/intf.ml
@@ -190,8 +190,6 @@ module Group (Impl : Snarky_backendless.Snark_intf.Run) = struct
       val create : Constant.t -> t
     end
 
-    val constant : Constant.t -> t
-
     val multiscale_known :
       (Boolean.var list * Scaling_precomputation.t) array -> t
   end

--- a/src/lib/pickles/make_sponge.ml
+++ b/src/lib/pickles/make_sponge.ml
@@ -95,7 +95,8 @@ struct
       (fun a ->
         make_checked (fun () ->
             let s =
-              S_checked.create (Sponge.Params.map ~f:Field.constant params)
+              S_checked.create
+                (Sponge.Params.map ~f:(constant Field.typ) params)
             in
             Array.iter a ~f:(S_checked.absorb s) ;
             S_checked.squeeze s))

--- a/src/lib/pickles/opt_sponge.ml
+++ b/src/lib/pickles/opt_sponge.ml
@@ -231,7 +231,7 @@ struct
       let%test_unit "correctness" =
         let params : _ Sponge.Params.t =
           let a () =
-            Array.init 3 ~f:(fun _ -> Field.(constant (Constant.random ())))
+            Array.init 3 ~f:(fun _ -> Field.(constant typ (Constant.random ())))
           in
           { mds = Array.init 3 ~f:(fun _ -> a ())
           ; round_constants = Array.init 40 ~f:(fun _ -> a ())

--- a/src/lib/pickles/pseudo/pseudo.ml
+++ b/src/lib/pickles/pseudo/pseudo.ml
@@ -14,7 +14,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
     | None, [ (x, i) ] when Field.Constant.(equal x one) ->
         Snarky_backendless.Cvar.Var (Impl.Var.index i)
     | Some c, [] ->
-        Field.constant c
+        constant Field.typ c
     | _ ->
         let y = exists Field.typ ~compute:As_prover.(fun () -> read_var x) in
         Field.Assert.equal x y ; y

--- a/src/lib/pickles/step_main_inputs.ml
+++ b/src/lib/pickles/step_main_inputs.ml
@@ -33,7 +33,7 @@ module Other_field = struct
 end
 
 let sponge_params =
-  Sponge.Params.(map sponge_params_constant ~f:Impl.Field.constant)
+  Sponge.Params.(map sponge_params_constant ~f:(constant Impl.Field.typ))
 
 module Unsafe = struct
   let unpack_unboolean ?(length = Field.size_in_bits) x =

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -215,7 +215,7 @@ module For_step = struct
     ; var_to_field_elements
     ; wrap_key =
         Plonk_verification_key_evals.map (Lazy.force wrap_key)
-          ~f:Step_main_inputs.Inner_curve.constant
+          ~f:(Step_main_inputs.Impl.constant Step_main_inputs.Inner_curve.typ)
     ; wrap_domains
     ; step_domains = `Known step_domains
     }

--- a/src/lib/pickles/util.ml
+++ b/src/lib/pickles/util.ml
@@ -82,7 +82,7 @@ let seal (type f)
   | None, [ (x, i) ] when Field.Constant.(equal x one) ->
       Snarky_backendless.Cvar.Var (Impl.Var.index i)
   | Some c, [] ->
-      Field.constant c
+      constant Field.typ c
   | _ ->
       let y = exists Field.typ ~compute:As_prover.(fun () -> read_var x) in
       Field.Assert.equal x y ; y

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -115,10 +115,10 @@ let pack_statement max_branching t =
 
 let shifts ~log2_size =
   Common.tock_shifts ~log2_size
-  |> Dlog_plonk_types.Shifts.map ~f:Impl.Field.constant
+  |> Dlog_plonk_types.Shifts.map ~f:(constant Field.typ)
 
 let domain_generator ~log2_size =
-  Backend.Tock.Field.domain_generator ~log2_size |> Impl.Field.constant
+  Backend.Tock.Field.domain_generator ~log2_size |> constant Field.typ
 
 let split_field_typ : (Field.t * Boolean.var, Field.Constant.t) Typ.t =
   Typ.transport
@@ -239,7 +239,9 @@ let wrap_main
           with_label __LOC__ (fun () ->
               choose_key which_branch
                 (Vector.map (Lazy.force step_keys)
-                   ~f:(Plonk_verification_key_evals.map ~f:Inner_curve.constant)))
+                   ~f:
+                     (Plonk_verification_key_evals.map
+                        ~f:(constant Inner_curve.typ))))
         in
         let prev_step_accs =
           with_label __LOC__ (fun () ->

--- a/src/lib/pickles/wrap_main_inputs.ml
+++ b/src/lib/pickles/wrap_main_inputs.ml
@@ -35,7 +35,7 @@ module Other_field = struct
 end
 
 let sponge_params =
-  Sponge.Params.(map sponge_params_constant ~f:Impl.Field.constant)
+  Sponge.Params.(map sponge_params_constant ~f:(constant Impl.Field.typ))
 
 module Unsafe = struct
   let unpack_unboolean ?(length = Field.size_in_bits) x =

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -126,19 +126,19 @@ module Checked = struct
 
   include Sponge.Make_hash (Inputs)
 
-  let params = Sponge.Params.map ~f:Inputs.Field.constant params
-
-  open Inputs.Field
+  let params = Sponge.Params.map ~f:Inputs.(constant Field.typ) params
 
   let update ~state xs = update params ~state xs
 
   let hash ?init xs =
     O1trace.measure "Random_oracle.hash" (fun () ->
-        hash ?init:(Option.map init ~f:(State.map ~f:constant)) params xs)
+        hash
+          ?init:(Option.map init ~f:(State.map ~f:(constant Field.typ)))
+          params xs)
 
   let pack_input =
     Input.Chunked.pack_to_fields
-      ~pow2:(Fn.compose Field.Var.constant pow2)
+      ~pow2:(Fn.compose (constant Field.typ) pow2)
       (module Pickles.Impls.Step.Field)
 
   let digest xs = xs.(0)
@@ -290,14 +290,14 @@ module Legacy = struct
 
     include Sponge.Make_hash (Sponge.Poseidon (Inputs))
 
-    let params = Sponge.Params.map ~f:Inputs.Field.constant params
-
-    open Inputs.Field
+    let params = Sponge.Params.map ~f:(constant Field.typ) params
 
     let update ~state xs = update params ~state xs
 
     let hash ?init xs =
-      hash ?init:(Option.map init ~f:(State.map ~f:constant)) params xs
+      hash
+        ?init:(Option.map init ~f:(State.map ~f:(constant Field.typ)))
+        params xs
   end
 
   [%%endif]

--- a/src/lib/sgn/sgn.ml
+++ b/src/lib/sgn/sgn.ml
@@ -34,7 +34,7 @@ type var = Field.Var.t
 
 let typ : (var, t) Typ.t =
   let open Typ in
-  { check = (fun x -> assert_r1cs x x (Field.Var.constant Field.one))
+  { check = (fun x -> assert_r1cs x x (constant Field.typ Field.one))
   ; store = (fun t -> Store.store (to_field t))
   ; read = (fun x -> Read.(read x >>| of_field_exn))
   ; alloc = Alloc.alloc
@@ -52,28 +52,26 @@ module Checked = struct
   let is_pos (v : var) =
     Boolean.Unsafe.of_cvar
       (let open Field.Checked in
-      one_half * (v + Field.Var.constant Field.one))
+      one_half * (v + constant Field.typ Field.one))
 
   let is_neg (v : var) =
     Boolean.Unsafe.of_cvar
       (let open Field.Checked in
-      neg_one_half * (v - Field.Var.constant Field.one))
+      neg_one_half * (v - constant Field.typ Field.one))
 
   let pos_if_true (b : Boolean.var) =
     let open Field.Checked in
-    (two * (b :> Field.Var.t)) - Field.Var.constant Field.one
+    (two * (b :> Field.Var.t)) - constant Field.typ Field.one
 
   let neg_if_true (b : Boolean.var) =
     let open Field.Checked in
-    (neg_two * (b :> Field.Var.t)) + Field.Var.constant Field.one
+    (neg_two * (b :> Field.Var.t)) + constant Field.typ Field.one
 
   let negate t = Field.Var.scale t neg_one
 
-  let constant = Fn.compose Field.Var.constant to_field
+  let neg = constant typ Neg
 
-  let neg = constant Neg
-
-  let pos = constant Pos
+  let pos = constant typ Pos
 
   let if_ = Field.Checked.if_
 end

--- a/src/lib/sgn/sgn.mli
+++ b/src/lib/sgn/sgn.mli
@@ -26,8 +26,6 @@ type var = private Field.Var.t
 val typ : (var, t) Typ.t
 
 module Checked : sig
-  val constant : t -> var
-
   val neg : var
 
   val pos : var

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -24,8 +24,6 @@ type var = Field.Var.t * Field.Var.t
 
 val typ : (var, t) Typ.t
 
-val var_of_t : t -> var
-
 val assert_equal : var -> var -> (unit, 'a) Checked.t
 
 [%%endif]
@@ -87,8 +85,6 @@ module Compressed : sig
   type var = (Field.Var.t, Boolean.var) Poly.t
 
   val typ : (var, t) Typ.t
-
-  val var_of_t : t -> var
 
   module Checked : sig
     val equal : var -> var -> (Boolean.var, _) Checked.t

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -705,7 +705,7 @@ let chunked_message_typ () : (Message.Chunked.var, Message.Chunked.t) Tick.Typ.t
           in
           let packeds2 =
             Array.init (Array.length packeds) ~f:(fun _ ->
-                (Tick.Field.Var.constant Tick.Field.zero, 0))
+                (Tick.Field.(Tick.constant typ zero), 0))
           in
           let%map () =
             Array.foldi packeds ~init:(Store.return ())

--- a/src/lib/snark_bits/bits.ml
+++ b/src/lib/snark_bits/bits.ml
@@ -253,9 +253,6 @@ module Snarkable = struct
       let var_to_triples (bs : var) =
         Bitstring_lib.Bitstring.pad_to_triple_list ~default:Boolean.false_ bs
 
-      let var_of_value v =
-        List.init V.length ~f:(fun i -> Boolean.var_of_value (V.get v i))
-
       let size_in_bits = size_in_bits
     end
 
@@ -279,7 +276,7 @@ module Snarkable = struct
     let%snarkydef increment_var bs =
       let open Impl in
       let v = Field.Var.pack bs in
-      let v' = Field.Var.add v (Field.Var.constant Field.one) in
+      let v' = Field.Var.add v (constant Field.typ Field.one) in
       Field.Checked.unpack v' ~length:V.length
 
     let%snarkydef equal_var (n : Unpacked.var) (n' : Unpacked.var) =
@@ -344,10 +341,6 @@ module Snarkable = struct
 
       let var_to_triples (bs : var) =
         Bitstring_lib.Bitstring.pad_to_triple_list ~default:Boolean.false_ bs
-
-      let var_of_value v =
-        unpack_field Field.unpack ~bit_length v
-        |> List.map ~f:Boolean.var_of_value
 
       let size_in_bits = size_in_bits
     end

--- a/src/lib/snark_bits/bits_intf.ml
+++ b/src/lib/snark_bits/bits_intf.ml
@@ -63,8 +63,6 @@ module Snarkable = struct
 
       val var_to_triples : var -> boolean_var Triple.t list
 
-      val var_of_value : value -> var
-
       val size_in_bits : int
     end
   end

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -56,7 +56,8 @@ let%test_unit "group-map test" =
             let x, y =
               Snarky_group_map.Checked.to_group
                 (module M)
-                ~params (M.Field.constant t)
+                ~params
+                M.(constant Field.typ t)
             in
             fun () -> M.As_prover.(read_var x, read_var y))
           ()
@@ -164,7 +165,7 @@ module Tock = struct
                   let add = None
                 end)
 
-      let add_known_unsafe t x = add_unsafe t (constant x)
+      let add_known_unsafe t x = add_unsafe t (constant typ x)
     end
 
     let typ = Checked.typ
@@ -220,7 +221,7 @@ module Tick = struct
                         Tick0.with_state (As_prover.return ()) c)
                 end)
 
-      let add_known_unsafe t x = add_unsafe t (constant x)
+      let add_known_unsafe t x = add_unsafe t (constant typ x)
     end
 
     let typ = Checked.typ

--- a/src/lib/snark_params/snark_util.ml
+++ b/src/lib/snark_params/snark_util.ml
@@ -21,9 +21,9 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) = struct
       (y - 1) * x = 0
     *)
     assert_r1cs
-      Field.Var.(sub (y :> Field.Var.t) (constant Field.one))
+      Field.Var.(sub (y :> Field.Var.t) (constant Field.typ Field.one))
       (x :> Field.Var.t)
-      (Field.Var.constant Field.zero)
+      (constant Field.typ Field.zero)
 
   let assert_decreasing : Boolean.var list -> (unit, _) Checked.t =
     let rec go prev (bs0 : Boolean.var list) =
@@ -52,7 +52,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) = struct
       | [] ->
           acc
     in
-    go (Field.Var.constant Field.zero) Field.one (bs0 :> Field.Var.t list)
+    go (constant Field.typ Field.zero) Field.one (bs0 :> Field.Var.t list)
 
   type _ Snarky_backendless.Request.t +=
     | N_ones : bool list Snarky_backendless.Request.t
@@ -146,8 +146,8 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) = struct
           let (), (less, less_or_equal) =
             run_and_check
               (let%map { less; less_or_equal } =
-                 Field.Checked.compare ~bit_length (Field.Var.constant x)
-                   (Field.Var.constant y)
+                 Field.Checked.compare ~bit_length (constant Field.typ x)
+                   (constant Field.typ y)
                in
                As_prover.(
                  map2 (read Boolean.typ less)
@@ -179,7 +179,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) = struct
 
       let%test_unit "assert_decreasing" =
         let decreasing bs =
-          check (assert_decreasing (List.map ~f:Boolean.var_of_value bs)) ()
+          check (assert_decreasing (List.map ~f:(constant Boolean.typ) bs)) ()
         in
         Or_error.ok_exn (decreasing [ true; true; true; false ]) ;
         Or_error.ok_exn (decreasing [ true; true; false; false ]) ;
@@ -188,7 +188,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) = struct
       let%test_unit "n_ones" =
         let total_length = 6 in
         let test n =
-          let t = n_ones ~total_length (Field.Var.constant (Field.of_int n)) in
+          let t = n_ones ~total_length (constant Field.typ (Field.of_int n)) in
           let handle_with (resp : bool list) =
             handle t (fun (With { request; respond }) ->
                 match request with
@@ -230,7 +230,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) = struct
         let test x =
           let handle_with resp =
             handle
-              (num_bits_upper_bound ~max_length (Field.Var.constant x))
+              (num_bits_upper_bound ~max_length (constant Field.typ x))
               (fun (With {request; respond}) ->
                 match request with
                 | Num_bits_upper_bound -> respond (Field.of_int resp)

--- a/src/lib/snarky_blake2/uint32.ml
+++ b/src/lib/snarky_blake2/uint32.ml
@@ -42,9 +42,6 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) :
     let open Infix in
     Int.equal 0 (compare ((x lsr i) land one) one)
 
-  let constant x =
-    Array.init length ~f:(Fn.compose Boolean.var_of_value (get_bit x))
-
   let typ =
     let open Unsigned.UInt32 in
     let open Infix in

--- a/src/lib/snarky_field_extensions/field_extensions.ml
+++ b/src/lib/snarky_field_extensions/field_extensions.ml
@@ -42,8 +42,6 @@ module Make (F : Intf.Basic) = struct
 
   let typ = F.typ
 
-  let constant = F.constant
-
   let scale = F.scale
 
   let assert_r1cs = F.assert_r1cs
@@ -69,14 +67,14 @@ module Make (F : Intf.Basic) = struct
 
   let negate = F.negate
 
-  let zero = constant Unchecked.zero
+  let zero = constant typ Unchecked.zero
 
-  let one = constant Unchecked.one
+  let one = constant typ Unchecked.one
 
   let div_unsafe x y =
     match (to_constant x, to_constant y) with
     | Some x, Some y ->
-        return (constant Unchecked.(x / y))
+        return (constant typ Unchecked.(x / y))
     | _, _ ->
         let%bind x_over_y =
           exists typ
@@ -101,7 +99,7 @@ module Make (F : Intf.Basic) = struct
         fun x y ->
           match (to_constant x, to_constant y) with
           | Some x, Some y ->
-              return (constant Unchecked.(x * y))
+              return (constant typ Unchecked.(x * y))
           | _, _ ->
               let%bind res =
                 exists typ
@@ -124,7 +122,7 @@ module Make (F : Intf.Basic) = struct
         fun x ->
           match to_constant x with
           | Some x ->
-              return (constant (Unchecked.square x))
+              return (constant typ (Unchecked.square x))
           | None ->
               let%bind res =
                 exists typ
@@ -145,7 +143,7 @@ module Make (F : Intf.Basic) = struct
         fun t ->
           match to_constant t with
           | Some x ->
-              return (constant (Unchecked.inv x))
+              return (constant typ (Unchecked.inv x))
           | None ->
               let%bind res =
                 exists typ
@@ -162,8 +160,6 @@ struct
   type t = F.t A.t
 
   type 'a t_ = 'a F.t_ A.t
-
-  let constant = A.map ~f:F.constant
 
   let to_constant =
     let exception None_exn in
@@ -257,8 +253,6 @@ struct
     let if_ = Field.Checked.if_
 
     let typ = Field.typ
-
-    let constant = Field.Var.constant
 
     let to_constant = Field.Var.to_constant
 

--- a/src/lib/snarky_field_extensions/intf.ml
+++ b/src/lib/snarky_field_extensions/intf.ml
@@ -46,8 +46,6 @@ module type Basic = sig
 
   val typ : (t, Unchecked.t) Typ.t
 
-  val constant : Unchecked.t -> t
-
   val to_constant : t -> Unchecked.t option
 
   val scale : t -> Field.t -> t

--- a/src/lib/snarky_group_map/checked_map.ml
+++ b/src/lib/snarky_group_map/checked_map.ml
@@ -60,7 +60,16 @@ module Make
     end) =
 struct
   open P
-  include Group_map.Make (M.Field.Constant) (M.Field) (P)
+
+  include Group_map.Make
+            (M.Field.Constant)
+            (struct
+              include M.Field
+
+              let constant = M.constant typ
+            end)
+            (P)
+
   open M
 
   let to_group =
@@ -69,5 +78,5 @@ struct
       (wrap
          (module M)
          ~potential_xs
-         ~y_squared:Field.(fun ~x -> (x * x * x) + scale x a + constant b))
+         ~y_squared:Field.(fun ~x -> (x * x * x) + scale x a + constant typ b))
 end

--- a/src/lib/snarky_taylor/floating_point.ml
+++ b/src/lib/snarky_taylor/floating_point.ml
@@ -38,7 +38,7 @@ let mul (type f) ~m:((module I) : f m) x y =
 let constant (type f) ~m:((module M) as m : f m) ~value ~precision =
   assert (B.(value < one lsl precision)) ;
   let open M in
-  { value = Field.constant (bigint_to_field ~m value); precision }
+  { value = constant Field.typ (bigint_to_field ~m value); precision }
 
 (* x, x^2, ..., x^n *)
 let powers ~m x n =
@@ -86,7 +86,7 @@ let le (type f) ~m:((module M) : f m) t1 t2 =
   let padding =
     let k = precision - min t1.precision t2.precision in
     let open Field in
-    constant (pow2 Constant.add ~one:Constant.one k)
+    constant Field.typ (pow2 Constant.add ~one:Constant.one k)
   in
   let x1, x2 =
     let open Field in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -3203,14 +3203,16 @@ let%test_module "staged ledger tests" =
         let%bind root_after_popping, _deleted_stack =
           Pending_coinbase.Checked.pop_coinbases ~constraint_constants
             ~proof_emitted
-            (Hash.var_of_t root_before)
+            (constant Hash.typ root_before)
         in
-        let pc_update_var = Update.var_of_t pc_update in
+        let pc_update_var = constant Update.typ pc_update in
         let coinbase_receiver =
-          Public_key.Compressed.(var_of_t coinbase_receiver)
+          constant Public_key.Compressed.typ coinbase_receiver
         in
-        let supercharge_coinbase = Boolean.var_of_value supercharge_coinbase in
-        let state_body_hash_var = State_body_hash.var_of_t state_body_hash in
+        let supercharge_coinbase = constant Boolean.typ supercharge_coinbase in
+        let state_body_hash_var =
+          constant State_body_hash.typ state_body_hash
+        in
         Pending_coinbase.Checked.add_coinbase ~constraint_constants
           root_after_popping pc_update_var ~coinbase_receiver
           ~supercharge_coinbase state_body_hash_var


### PR DESCRIPTION
This PR builds upon o1-labs/snarky#621 to replace the specialised `var_of_value`/`var_of_t`/`constant` functions throughout the codebase with calls to `Snarky_intf.constant : ('var, 'value) Typ.t -> 'value -> 'var`. o1-labs/snarky#621 should be reviewed and merged first.

This removes some redundant code, but should otherwise be a no-op.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them

Fixes #352