### PR TITLE
Allow OCaml GC to reason about the size of rust memory held for snark proof indexes

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
@@ -21,9 +21,17 @@ extern "C" fn caml_pasta_fp_plonk_index_finalize(v: ocaml::Raw) {
     }
 }
 
-ocaml::custom!(CamlPastaFpPlonkIndex {
-    finalize: caml_pasta_fp_plonk_index_finalize,
-});
+impl ocaml::custom::Custom for CamlPastaFpPlonkIndex {
+    const NAME: &'static str = "CamlPastaFpPlonkIndex\0";
+    const USED: usize = 1;
+    /// Encourage the GC to free when there are > 12 in memory
+    const MAX: usize = 12;
+    const OPS: ocaml::custom::CustomOps = ocaml::custom::CustomOps {
+        identifier: Self::NAME.as_ptr() as *const ocaml::sys::Char,
+        finalize: Some(caml_pasta_fp_plonk_index_finalize),
+        ..ocaml::custom::DEFAULT_CUSTOM_OPS
+    };
+}
 
 #[ocaml_gen::func]
 #[ocaml::func]

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
@@ -21,9 +21,17 @@ extern "C" fn caml_pasta_fq_plonk_index_finalize(v: ocaml::Raw) {
     }
 }
 
-ocaml::custom!(CamlPastaFqPlonkIndex {
-    finalize: caml_pasta_fq_plonk_index_finalize,
-});
+impl ocaml::custom::Custom for CamlPastaFqPlonkIndex {
+    const NAME: &'static str = "CamlPastaFqPlonkIndex\0";
+    const USED: usize = 1;
+    /// Encourage the GC to free when there are > 12 in memory
+    const MAX: usize = 12;
+    const OPS: ocaml::custom::CustomOps = ocaml::custom::CustomOps {
+        identifier: Self::NAME.as_ptr() as *const ocaml::sys::Char,
+        finalize: Some(caml_pasta_fq_plonk_index_finalize),
+        ..ocaml::custom::DEFAULT_CUSTOM_OPS
+    };
+}
 
 #[ocaml_gen::func]
 #[ocaml::func]


### PR DESCRIPTION
This PR adds `USED` and `MAX` parameters to the OCaml allocations used for proof indexes. This information allows the OCaml GC to better reason about how many of these allocations should normally co-exist in memory, and to attempt to free accordingly when this limit is reached.

For example, when running the `transaction_snark` unit tests, several proof systems are initialised in order to run the various different tests. Without this PR, the proof index for each remains in memory, as OCaml considers the data used by the allocation to be negligible (a single pointer of size 1 machine word). In practice, this means that the memory usage of the test would otherwise continue to increase as we add more tests.

The `MAX` parameter is chosen to be `12=2*6` to match the 2 (step and wrap) keys for each of the 6 transaction snark rules. This ensures that the snark worker process will be at the limit, and all other standard processes will be below it for the keys they actively require.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them