### PR TITLE
[Trivial] Use DUNE_PROFILE when building test_executive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ build_rosetta_all_sigs: ocaml_checks
 
 build_intgtest: ocaml_checks
 	$(info Starting Build)
-	dune build --profile=integration_tests src/app/test_executive/test_executive.exe src/app/logproc/logproc.exe
+	dune build --profile=$(DUNE_PROFILE) src/app/test_executive/test_executive.exe src/app/logproc/logproc.exe
 	$(info Build complete)
 
 client_sdk: ocaml_checks


### PR DESCRIPTION
The `test_executive.exe` binary doesn't use any features from the `integration_test` profile -- which only serves to enable the old-style integration tests in the CLI -- so we can use the same profile instead of blowing away the old artifacts.

Encountered this while trying to build all relevant executables to test a build.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
