### PR TITLE
Monomorphise `Party.Update.t`

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2472,7 +2472,7 @@ module Types = struct
               ; timing = v timing'
               ; voting_for = v voting_for
               }
-              : _ Party.Update.Poly.t ))
+              : Party.Update.t ))
           ~fields:
             [ arg "appState"
                 ~doc:"List of _exactly_ 8 field elements (null if keep)"


### PR DESCRIPTION
This PR replaces the polymorphic `Party.Update.Poly.t` with monomorphic versions at both of its specialisations. This decreases the amount of code dedicated to type definitions, as well as providing better error messages for type errors.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
