### PR TITLE
add direct dependencies to src/lib/node_error_service/dune

### DIFF
--- a/src/lib/mina_graphql/dune
+++ b/src/lib/mina_graphql/dune
@@ -91,6 +91,7 @@
    coda_runtime_config
    mina_base.import
    pickles.backend
-   pickles_types)
+   pickles_types
+   graphql)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane ppx_deriving_yojson)))

--- a/src/lib/node_error_service/dune
+++ b/src/lib/node_error_service/dune
@@ -2,7 +2,38 @@
   (name node_error_service)
   (public_name node_error_service)
   (inline_tests)
-  (libraries core mina_lib core_kernel async cohttp-async logger transition_frontier pipe_lib sync_status mina_incremental mina_networking mina_base network_peer)
+  (libraries
+    ;; opam libraries
+    core.uuid
+    uri
+    cohttp-async
+    async
+    core_kernel
+    core
+    cohttp
+    async_kernel
+    core_kernel.uuid
+    integers
+    ;; local libraries
+    error_json
+    transition_frontier_base
+    rfc3339_time
+    gossip_net
+    signature_lib
+    network_peer
+    mina_base
+    mina_networking
+    mina_incremental
+    sync_status
+    pipe_lib
+    transition_frontier
+    logger
+    mina_lib
+    node_addrs_and_ports
+    mina_version
+    participating_state
+    mina_metrics
+   )
   (preprocess (pps ppx_jane ppx_deriving.std ppx_coda ppx_version))
   (instrumentation (backend bisect_ppx))
   (synopsis "Node error service library for collection error report from nodes"))


### PR DESCRIPTION
The addition of `src/lib/node_error_service` is conflicting with the setting of `(implicit_transitive_deps false)`,
this PR should fix this by adding direct dependencies explicitly to `src/lib/node_error_service/dune`.