### PR TITLE
Update state in multiple snapp_partys with proofs

### DIFF
--- a/src/app/snapp_test_transaction/lib/commands.ml
+++ b/src/app/snapp_test_transaction/lib/commands.ml
@@ -435,7 +435,7 @@ let create_snapp_account ~debug ~keyfile ~fee ~snapp_keyfile ~amount ~nonce
     ; fee
     ; receivers = []
     ; amount
-    ; snapp_account_keypair = Some snapp_keypair
+    ; snapp_account_keypairs = [ snapp_keypair ]
     ; memo = Util.memo memo
     ; new_snapp_account = true
     ; snapp_update = Party.Update.dummy
@@ -468,7 +468,7 @@ let upgrade_snapp ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ; fee
     ; receivers = []
     ; amount = Currency.Amount.zero
-    ; snapp_account_keypair = Some snapp_account_keypair
+    ; snapp_account_keypairs = [ snapp_account_keypair ]
     ; memo = Util.memo memo
     ; new_snapp_account = false
     ; snapp_update = { Party.Update.dummy with verification_key; snapp_uri }
@@ -479,7 +479,7 @@ let upgrade_snapp ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     }
   in
   let%bind parties, vk =
-    Transaction_snark.For_tests.update_state ~constraint_constants spec
+    Transaction_snark.For_tests.update_states ~constraint_constants spec
   in
   let%map () =
     if debug then
@@ -505,7 +505,7 @@ let transfer_funds ~debug ~keyfile ~fee ~nonce ~memo ~receivers =
     ; fee
     ; receivers
     ; amount
-    ; snapp_account_keypair = None
+    ; snapp_account_keypairs = []
     ; memo = Util.memo memo
     ; new_snapp_account = false
     ; snapp_update = Party.Update.dummy
@@ -531,7 +531,7 @@ let update_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~app_state =
     ; fee
     ; receivers = []
     ; amount = Currency.Amount.zero
-    ; snapp_account_keypair = Some snapp_keypair
+    ; snapp_account_keypairs = [ snapp_keypair ]
     ; memo = Util.memo memo
     ; new_snapp_account = false
     ; snapp_update = { Party.Update.dummy with app_state }
@@ -542,7 +542,7 @@ let update_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~app_state =
     }
   in
   let%bind parties, vk =
-    Transaction_snark.For_tests.update_state ~constraint_constants spec
+    Transaction_snark.For_tests.update_states ~constraint_constants spec
   in
   let%map () =
     if debug then
@@ -564,7 +564,7 @@ let update_snapp_uri ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~snapp_uri
     ; fee
     ; receivers = []
     ; amount = Currency.Amount.zero
-    ; snapp_account_keypair = Some snapp_account_keypair
+    ; snapp_account_keypairs = [ snapp_account_keypair ]
     ; memo = Util.memo memo
     ; new_snapp_account = false
     ; snapp_update = { Party.Update.dummy with snapp_uri }
@@ -575,7 +575,7 @@ let update_snapp_uri ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~snapp_uri
     }
   in
   let%bind parties, vk =
-    Transaction_snark.For_tests.update_state ~constraint_constants spec
+    Transaction_snark.For_tests.update_states ~constraint_constants spec
   in
   let%map () =
     if debug then
@@ -599,7 +599,7 @@ let update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ; fee
     ; receivers = []
     ; amount = Currency.Amount.zero
-    ; snapp_account_keypair = Some snapp_keypair
+    ; snapp_account_keypairs = [ snapp_keypair ]
     ; memo = Util.memo memo
     ; new_snapp_account = false
     ; snapp_update = Party.Update.dummy
@@ -610,7 +610,7 @@ let update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     }
   in
   let%bind parties, vk =
-    Transaction_snark.For_tests.update_state ~constraint_constants spec
+    Transaction_snark.For_tests.update_states ~constraint_constants spec
   in
   let%map () =
     if debug then
@@ -632,7 +632,7 @@ let update_token_symbol ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ; fee
     ; receivers = []
     ; amount = Currency.Amount.zero
-    ; snapp_account_keypair = Some snapp_account_keypair
+    ; snapp_account_keypairs = [ snapp_account_keypair ]
     ; memo = Util.memo memo
     ; new_snapp_account = false
     ; snapp_update = { Party.Update.dummy with token_symbol }
@@ -643,7 +643,7 @@ let update_token_symbol ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     }
   in
   let%bind parties, vk =
-    Transaction_snark.For_tests.update_state ~constraint_constants spec
+    Transaction_snark.For_tests.update_states ~constraint_constants spec
   in
   let%map () =
     if debug then
@@ -666,7 +666,7 @@ let update_permissions ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ; fee
     ; receivers = []
     ; amount = Currency.Amount.zero
-    ; snapp_account_keypair = Some snapp_keypair
+    ; snapp_account_keypairs = [ snapp_keypair ]
     ; memo = Util.memo memo
     ; new_snapp_account = false
     ; snapp_update = { Party.Update.dummy with permissions }
@@ -677,7 +677,7 @@ let update_permissions ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     }
   in
   let%bind parties, vk =
-    Transaction_snark.For_tests.update_state ~constraint_constants spec
+    Transaction_snark.For_tests.update_states ~constraint_constants spec
   in
   (*Util.print_snapp_transaction parties ;*)
   let%map () =

--- a/src/app/test_executive/snapps.ml
+++ b/src/app/test_executive/snapps.ml
@@ -19,9 +19,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     { default with
       requires_graphql = true
     ; block_producers =
-        [ { balance = "3000000000"; timing = Untimed }
-        ; { balance = "3000000000"; timing = Untimed }
-        ; { balance = "3000000000"; timing = Untimed }
+        [ { balance = "8000000000"; timing = Untimed }
+        ; { balance = "1000000000"; timing = Untimed }
+        ; { balance = "1000000000"; timing = Untimed }
         ]
     ; num_snark_workers = 0
     }
@@ -34,7 +34,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       Malleable_error.List.iter block_producer_nodes
         ~f:(Fn.compose (wait_for t) Wait_condition.node_to_initialize)
     in
-    let node = List.nth_exn block_producer_nodes 0 in
+    let node = List.hd_exn block_producer_nodes in
     let constraint_constants =
       Genesis_constants.Constraint_constants.compiled
     in
@@ -45,11 +45,15 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       ; private_key = fee_payer_sk
       }
     in
-    let snapp_keypair = Signature_lib.Keypair.create () in
-    let snapp_account_id =
-      Mina_base.Account_id.create
-        (snapp_keypair.public_key |> Signature_lib.Public_key.compress)
-        Mina_base.Token_id.default
+    let num_snapp_accounts = 3 in
+    let snapp_keypairs =
+      List.init num_snapp_accounts ~f:(fun _ -> Signature_lib.Keypair.create ())
+    in
+    let snapp_account_ids =
+      List.map snapp_keypairs ~f:(fun snapp_keypair ->
+          Mina_base.Account_id.create
+            (snapp_keypair.public_key |> Signature_lib.Public_key.compress)
+            Mina_base.Token_id.default)
     in
     let%bind parties_create_account =
       (* construct a Parties.t, similar to snapp_test_transaction create-snapp-account *)
@@ -65,7 +69,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; fee
         ; receivers = []
         ; amount
-        ; snapp_account_keypair = Some snapp_keypair
+        ; snapp_account_keypairs = snapp_keypairs
         ; memo
         ; new_snapp_account = true
         ; snapp_update = Party.Update.dummy
@@ -104,7 +108,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; fee
         ; receivers = []
         ; amount = Currency.Amount.zero
-        ; snapp_account_keypair = Some snapp_keypair
+        ; snapp_account_keypairs = snapp_keypairs
         ; memo
         ; new_snapp_account = false
         ; snapp_update =
@@ -118,7 +122,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
       in
       let%map.Deferred parties, _vk =
-        Transaction_snark.For_tests.update_state ~constraint_constants
+        Transaction_snark.For_tests.update_states ~constraint_constants
           parties_spec
       in
       (parties, new_permissions)
@@ -172,7 +176,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; fee
         ; receivers = []
         ; amount
-        ; snapp_account_keypair = Some snapp_keypair
+        ; snapp_account_keypairs = snapp_keypairs
         ; memo
         ; new_snapp_account = false
         ; snapp_update
@@ -183,7 +187,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         }
       in
       let%map.Deferred parties_update_all, _vk =
-        Transaction_snark.For_tests.update_state ~constraint_constants
+        Transaction_snark.For_tests.update_states ~constraint_constants
           parties_spec
       in
       (snapp_update, parties_update_all)
@@ -219,7 +223,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       Wait_condition.with_timeouts ~soft_timeout ~hard_timeout
     in
     let send_snapp parties =
-      [%log info] "Sending snapp" ;
+      [%log info] "Sending snapp"
+        ~metadata:[ ("parties", Mina_base.Parties.to_yojson parties) ] ;
       match%bind.Deferred Network.Node.send_snapp ~logger node ~parties with
       | Ok _snapp_id ->
           [%log info] "Snapps transaction sent" ;
@@ -232,7 +237,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             err_str
     in
     let send_invalid_snapp parties substring =
-      [%log info] "Sending snapp" ;
+      [%log info] "Sending snapp, expected to fail" ;
       match%bind.Deferred Network.Node.send_snapp ~logger node ~parties with
       | Ok _snapp_id ->
           [%log error] "Snapps transaction succeeded, expected error \"%s\""
@@ -253,11 +258,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             Malleable_error.soft_error_format ~value:()
               "Snapp failed: %s, but expected \"%s\"" err_str substring )
     in
-    let get_account_permissions () =
-      [%log info] "Getting account permissions" ;
+    let get_account_permissions ~account_id =
+      [%log info] "Getting permissions for account"
+        ~metadata:[ ("account_id", Mina_base.Account_id.to_yojson account_id) ] ;
       match%bind.Deferred
-        Network.Node.get_account_permissions ~logger node
-          ~account_id:snapp_account_id
+        Network.Node.get_account_permissions ~logger node ~account_id
       with
       | Ok permissions ->
           [%log info] "Got account permissions" ;
@@ -268,11 +273,11 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             ~metadata:[ ("error", `String err_str) ] ;
           Malleable_error.hard_error (Error.of_string err_str)
     in
-    let get_account_update () =
-      [%log info] "Getting account update" ;
+    let get_account_update ~account_id =
+      [%log info] "Getting update for account"
+        ~metadata:[ ("account_id", Mina_base.Account_id.to_yojson account_id) ] ;
       match%bind.Deferred
-        Network.Node.get_account_update ~logger node
-          ~account_id:snapp_account_id
+        Network.Node.get_account_update ~logger node ~account_id
       with
       | Ok update ->
           [%log info] "Got account update" ;
@@ -386,23 +391,31 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         (wait_for_snapp parties_update_permissions)
     in
     let%bind () =
-      section "Verify that updated permissions are in ledger account"
-        (let%bind ledger_permissions = get_account_permissions () in
-         if Mina_base.Permissions.equal ledger_permissions permissions_updated
-         then (
-           [%log info] "Ledger, updated permissions are equal" ;
-           return () )
-         else (
-           [%log error] "Ledger, updated permissions differ"
-             ~metadata:
-               [ ( "ledger_permissions"
-                 , Mina_base.Permissions.to_yojson ledger_permissions )
-               ; ( "updated_permissions"
-                 , Mina_base.Permissions.to_yojson permissions_updated )
-               ] ;
-           Malleable_error.hard_error
-             (Error.of_string
-                "Ledger permissions do not match update permissions") ))
+      section "Verify that updated permissions are in ledger accounts"
+        (Malleable_error.List.iter snapp_account_ids ~f:(fun account_id ->
+             [%log info] "Verifying permissions for account"
+               ~metadata:
+                 [ ("account_id", Mina_base.Account_id.to_yojson account_id) ] ;
+             let%bind ledger_permissions =
+               get_account_permissions ~account_id
+             in
+             if
+               Mina_base.Permissions.equal ledger_permissions
+                 permissions_updated
+             then (
+               [%log info] "Ledger, updated permissions are equal" ;
+               return () )
+             else (
+               [%log error] "Ledger, updated permissions differ"
+                 ~metadata:
+                   [ ( "ledger_permissions"
+                     , Mina_base.Permissions.to_yojson ledger_permissions )
+                   ; ( "updated_permissions"
+                     , Mina_base.Permissions.to_yojson permissions_updated )
+                   ] ;
+               Malleable_error.hard_error
+                 (Error.of_string
+                    "Ledger permissions do not match update permissions") )))
     in
     let%bind () =
       section "Send a snapp to update all fields"
@@ -416,22 +429,29 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section "Verify snapp updates in ledger"
-        (let%bind ledger_update = get_account_update () in
-         if compatible_updates ~ledger_update ~requested_update:snapp_update_all
-         then (
-           [%log info] "Ledger update and requested update are compatible" ;
-           return () )
-         else (
-           [%log error] "Ledger update and requested update are incompatible"
-             ~metadata:
-               [ ( "ledger_update"
-                 , Mina_base.Party.Update.to_yojson ledger_update )
-               ; ( "requested_update"
-                 , Mina_base.Party.Update.to_yojson snapp_update_all )
-               ] ;
-           Malleable_error.hard_error
-             (Error.of_string
-                "Ledger update and requested update are incompatible") ))
+        (Malleable_error.List.iter snapp_account_ids ~f:(fun account_id ->
+             [%log info] "Verifying updates for account"
+               ~metadata:
+                 [ ("account_id", Mina_base.Account_id.to_yojson account_id) ] ;
+             let%bind ledger_update = get_account_update ~account_id in
+             if
+               compatible_updates ~ledger_update
+                 ~requested_update:snapp_update_all
+             then (
+               [%log info] "Ledger update and requested update are compatible" ;
+               return () )
+             else (
+               [%log error]
+                 "Ledger update and requested update are incompatible"
+                 ~metadata:
+                   [ ( "ledger_update"
+                     , Mina_base.Party.Update.to_yojson ledger_update )
+                   ; ( "requested_update"
+                     , Mina_base.Party.Update.to_yojson snapp_update_all )
+                   ] ;
+               Malleable_error.hard_error
+                 (Error.of_string
+                    "Ledger update and requested update are incompatible") )))
     in
     let%bind () =
       section "Send a snapp with an invalid nonce"

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4374,7 +4374,7 @@ module For_tests = struct
       ; receivers :
           (Signature_lib.Public_key.Compressed.t * Currency.Amount.t) list
       ; amount : Currency.Amount.t
-      ; snapp_account_keypair : Signature_lib.Keypair.t option
+      ; snapp_account_keypairs : Signature_lib.Keypair.t list
       ; memo : Signed_command_memo.t
       ; new_snapp_account : bool
       ; snapp_update : Party.Update.t
@@ -4455,7 +4455,7 @@ module For_tests = struct
         ; receivers
         ; amount
         ; new_snapp_account
-        ; snapp_account_keypair
+        ; snapp_account_keypairs
         ; memo
         ; sequence_events
         ; events
@@ -4511,13 +4511,42 @@ module For_tests = struct
             Control.Signature Signature.dummy (*To be updated later*)
         }
     in
-    let snapp_party : Party.t option =
-      Option.map snapp_account_keypair ~f:(fun snapp_account_keypair ->
+    let snapp_parties : Party.t list =
+      let num_keypairs = List.length snapp_account_keypairs in
+      let account_creation_fee =
+        Amount.of_fee
+          Genesis_constants.Constraint_constants.compiled.account_creation_fee
+      in
+      (* if creating new snapp accounts, amount must be enough for account creation fees for each *)
+      assert (
+        (not new_snapp_account) || num_keypairs = 0
+        ||
+        match Currency.Amount.scale account_creation_fee num_keypairs with
+        | None ->
+            false
+        | Some product ->
+            Currency.Amount.( >= ) amount product ) ;
+      (* "fudge factor" so that balances sum to zero *)
+      let zeroing_allotment =
+        if new_snapp_account then
+          (* value doesn't matter when num_keypairs = 0 *)
+          if num_keypairs <= 1 then amount
+          else
+            let otherwise_allotted =
+              Option.value_exn
+                (Currency.Amount.scale account_creation_fee (num_keypairs - 1))
+            in
+            Option.value_exn (Currency.Amount.sub amount otherwise_allotted)
+        else Currency.Amount.zero
+      in
+      List.mapi snapp_account_keypairs ~f:(fun ndx snapp_account_keypair ->
           let public_key =
             Signature_lib.Public_key.compress snapp_account_keypair.public_key
           in
           let delta =
-            if new_snapp_account then Amount.Signed.(of_unsigned amount)
+            if new_snapp_account then
+              if ndx = 0 then Amount.Signed.(of_unsigned zeroing_allotment)
+              else Amount.Signed.(of_unsigned account_creation_fee)
             else Amount.Signed.zero
           in
           { Party.data =
@@ -4564,8 +4593,7 @@ module For_tests = struct
     let protocol_state = Snapp_predicate.Protocol_state.accept in
     let other_parties_data =
       Option.value_map ~default:[] sender_party ~f:(fun p -> [ p.data ])
-      @ Option.value_map snapp_party ~default:[] ~f:(fun snapp_party ->
-            [ snapp_party.data ])
+      @ List.map snapp_parties ~f:(fun p -> p.data)
       @ List.map other_receivers ~f:(fun p -> p.data)
     in
     let protocol_state_predicate_hash =
@@ -4610,7 +4638,7 @@ module For_tests = struct
     in
     ( `Parties { Parties.fee_payer; other_parties = other_receivers; memo }
     , `Sender_party sender_party
-    , `Proof_party snapp_party
+    , `Proof_parties snapp_parties
     , `Txn_commitment commitment
     , `Full_txn_commitment full_commitment )
 
@@ -4632,39 +4660,39 @@ module For_tests = struct
     in
     let ( `Parties { Parties.fee_payer; other_parties; memo }
         , `Sender_party sender_party
-        , `Proof_party snapp_party
+        , `Proof_parties snapp_parties
         , `Txn_commitment commitment
         , `Full_txn_commitment full_commitment ) =
       create_parties spec ~update:update_vk ~predicate:Party.Predicate.Accept
     in
     assert (List.is_empty other_parties) ;
-    let snapp_party =
-      Option.value_map ~default:[] snapp_party ~f:(fun snapp_party ->
+    (* invariant: same number of keypairs, snapp_parties *)
+    let snapp_parties_keypairs =
+      List.zip_exn snapp_parties spec.snapp_account_keypairs
+    in
+    let snapp_parties =
+      List.map snapp_parties_keypairs ~f:(fun (snapp_party, keypair) ->
           let commitment =
             if snapp_party.data.body.use_full_commitment then full_commitment
             else commitment
           in
           let signature =
-            Signature_lib.Schnorr.Chunked.sign
-              (Option.value_exn spec.snapp_account_keypair).private_key
+            Signature_lib.Schnorr.Chunked.sign keypair.private_key
               (Random_oracle.Input.Chunked.field commitment)
           in
-          [ { Party.data = snapp_party.data
-            ; authorization = Signature signature
-            }
-          ])
+          { Party.data = snapp_party.data; authorization = Signature signature })
     in
-    let other_parties = [ Option.value_exn sender_party ] @ snapp_party in
+    let other_parties = [ Option.value_exn sender_party ] @ snapp_parties in
     let parties : Parties.t = { fee_payer; other_parties; memo } in
     parties
 
-  let update_state ~constraint_constants (spec : Spec.t) =
+  let update_states ~constraint_constants (spec : Spec.t) =
     let `VK vk, `Prover trivial_prover =
       create_trivial_snapp ~constraint_constants ()
     in
     let ( `Parties { Parties.fee_payer; other_parties; memo }
         , `Sender_party sender_party
-        , `Proof_party snapp_party
+        , `Proof_parties snapp_parties
         , `Txn_commitment commitment
         , `Full_txn_commitment full_commitment ) =
       create_parties spec ~update:spec.snapp_update
@@ -4672,69 +4700,77 @@ module For_tests = struct
     in
     assert (List.is_empty other_parties) ;
     assert (Option.is_none sender_party) ;
-    assert (Option.is_some snapp_party) ;
-    let snapp_party = Option.value_exn snapp_party in
-    let%map.Async.Deferred snapp_party =
-      match spec.current_auth with
-      | Permissions.Auth_required.Proof ->
-          let proof_party =
-            let ps =
-              Parties.Call_forest.of_parties_list
-                ~party_depth:(fun (p : Party.Predicated.t) -> p.body.call_depth)
-                [ snapp_party.data ]
-              |> Parties.Call_forest.accumulate_hashes_predicated
-            in
-            Parties.Call_forest.hash ps
-          in
-          let tx_statement : Snapp_statement.t =
-            let commitment =
-              if snapp_party.data.body.use_full_commitment then full_commitment
-              else commitment
-            in
-            { transaction = commitment; at_party = proof_party }
-          in
-          let handler (Snarky_backendless.Request.With { request; respond }) =
-            match request with _ -> respond Unhandled
-          in
-          let%map.Async.Deferred (pi : Pickles.Side_loaded.Proof.t) =
-            trivial_prover ~handler [] tx_statement
-          in
-          { Party.data = snapp_party.data; authorization = Proof pi }
-      | Signature ->
-          let commitment =
-            if snapp_party.data.body.use_full_commitment then full_commitment
-            else commitment
-          in
-          let signature =
-            Signature_lib.Schnorr.Chunked.sign
-              (Option.value_exn spec.snapp_account_keypair).private_key
-              (Random_oracle.Input.Chunked.field commitment)
-          in
-          Async.Deferred.return
-            { Party.data = snapp_party.data
-            ; authorization = Signature signature
-            }
-      | None ->
-          Async.Deferred.return
-            { Party.data = snapp_party.data; authorization = None_given }
-      | _ ->
-          failwith "Current authorization not Proof or Signature or None_given"
+    assert (not @@ List.is_empty snapp_parties) ;
+    let snapp_parties_keypairs =
+      List.zip_exn snapp_parties spec.snapp_account_keypairs
     in
-    let other_parties = [ snapp_party ] in
+    let%map.Async.Deferred snapp_parties =
+      Async.Deferred.List.mapi snapp_parties_keypairs
+        ~f:(fun ndx (snapp_party, snapp_keypair) ->
+          match spec.current_auth with
+          | Permissions.Auth_required.Proof ->
+              let proof_party =
+                let ps =
+                  Parties.Call_forest.of_parties_list
+                    ~party_depth:(fun (p : Party.Predicated.t) ->
+                      p.body.call_depth)
+                    (List.map (List.drop snapp_parties ndx) ~f:(fun p -> p.data))
+                  |> Parties.Call_forest.accumulate_hashes_predicated
+                in
+                Parties.Call_forest.hash ps
+              in
+              let tx_statement : Snapp_statement.t =
+                let commitment =
+                  if snapp_party.data.body.use_full_commitment then
+                    full_commitment
+                  else commitment
+                in
+                { transaction = commitment; at_party = proof_party }
+              in
+              let handler (Snarky_backendless.Request.With { request; respond })
+                  =
+                match request with _ -> respond Unhandled
+              in
+              let%map.Async.Deferred (pi : Pickles.Side_loaded.Proof.t) =
+                trivial_prover ~handler [] tx_statement
+              in
+              { Party.data = snapp_party.data; authorization = Proof pi }
+          | Signature ->
+              let commitment =
+                if snapp_party.data.body.use_full_commitment then
+                  full_commitment
+                else commitment
+              in
+              let signature =
+                Signature_lib.Schnorr.Chunked.sign snapp_keypair.private_key
+                  (Random_oracle.Input.Chunked.field commitment)
+              in
+              Async.Deferred.return
+                { Party.data = snapp_party.data
+                ; authorization = Signature signature
+                }
+          | None ->
+              Async.Deferred.return
+                { Party.data = snapp_party.data; authorization = None_given }
+          | _ ->
+              failwith
+                "Current authorization not Proof or Signature or None_given")
+    in
+    let other_parties = snapp_parties in
     let parties : Parties.t = { fee_payer; other_parties; memo } in
     (parties, vk)
 
   let multiple_transfers (spec : Spec.t) =
     let ( `Parties parties
         , `Sender_party sender_party
-        , `Proof_party snapp_party
+        , `Proof_parties snapp_parties
         , `Txn_commitment _commitment
         , `Full_txn_commitment _full_commitment ) =
       create_parties spec ~update:spec.snapp_update
         ~predicate:Party.Predicate.Accept
     in
     assert (Option.is_some sender_party) ;
-    assert (Option.is_none snapp_party) ;
+    assert (List.is_empty snapp_parties) ;
     let other_parties =
       Option.value_exn sender_party :: parties.other_parties
     in
@@ -5672,7 +5708,7 @@ let%test_module "transaction_snark" =
                     ; fee
                     ; receivers = []
                     ; amount
-                    ; snapp_account_keypair = Some new_kp
+                    ; snapp_account_keypairs = [ new_kp ]
                     ; memo
                     ; new_snapp_account = true
                     ; snapp_update = Party.Update.dummy
@@ -5709,7 +5745,7 @@ let%test_module "transaction_snark" =
                     ~ledger snapp_pk ;
                   let open Async.Deferred.Let_syntax in
                   let%bind parties, _ =
-                    update_state ~constraint_constants test_spec
+                    update_states ~constraint_constants test_spec
                   in
                   apply_parties_with_proof ledger [ parties ]))
 
@@ -5728,7 +5764,7 @@ let%test_module "transaction_snark" =
                 ; fee
                 ; receivers = []
                 ; amount
-                ; snapp_account_keypair = Some new_kp
+                ; snapp_account_keypairs = [ new_kp ]
                 ; memo
                 ; new_snapp_account = false
                 ; snapp_update =
@@ -5763,7 +5799,7 @@ let%test_module "transaction_snark" =
                 ; fee
                 ; receivers = []
                 ; amount
-                ; snapp_account_keypair = Some new_kp
+                ; snapp_account_keypairs = [ new_kp ]
                 ; memo
                 ; new_snapp_account = false
                 ; snapp_update =
@@ -5798,7 +5834,7 @@ let%test_module "transaction_snark" =
                 ; fee
                 ; receivers = []
                 ; amount
-                ; snapp_account_keypair = Some new_kp
+                ; snapp_account_keypairs = [ new_kp ]
                 ; memo
                 ; new_snapp_account = false
                 ; snapp_update =
@@ -5836,7 +5872,7 @@ let%test_module "transaction_snark" =
                 ; fee
                 ; receivers = []
                 ; amount
-                ; snapp_account_keypair = Some new_kp
+                ; snapp_account_keypairs = [ new_kp ]
                 ; memo
                 ; new_snapp_account = false
                 ; snapp_update =
@@ -5893,7 +5929,7 @@ let%test_module "transaction_snark" =
                     ; fee
                     ; receivers = []
                     ; amount
-                    ; snapp_account_keypair = Some (fst spec.sender)
+                    ; snapp_account_keypairs = [ fst spec.sender ]
                     ; memo
                     ; new_snapp_account = true
                     ; snapp_update = Party.Update.dummy

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -544,7 +544,7 @@ module For_tests : sig
       ; receivers :
           (Signature_lib.Public_key.Compressed.t * Currency.Amount.t) list
       ; amount : Currency.Amount.t
-      ; snapp_account_keypair : Signature_lib.Keypair.t option
+      ; snapp_account_keypairs : Signature_lib.Keypair.t list
       ; memo : Signed_command_memo.t
       ; new_snapp_account : bool
       ; snapp_update : Party.Update.t
@@ -561,7 +561,7 @@ module For_tests : sig
     -> Spec.t
     -> Parties.t
 
-  val update_state :
+  val update_states :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> Spec.t
     -> (Parties.t * (Side_loaded_verification_key.t, Tick.Field.t) With_hash.t)


### PR DESCRIPTION
Change `Transaction_snark.For_tests.spec` to allow multiple keypairs in order to create multiple `snapp_party`s, in the field `snapp_account_keypairs` (which had been an option type, allowing one keypair).

Update the `snapps` integration test to create 3 new accounts, and update their permissions, then their states. The updated permissions and states are verified. The state updates use `Proof` as their authorization.

The `snapp_test_transaction` tool is updated to use the new `spec` type.

Tested by launching the `snapps` test from the test executive locally.

Part of #10067.