### PR TITLE
Retry failed unit tests using dune cache

### DIFF
--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -16,5 +16,12 @@ echo "--- Make build"
 export LIBP2P_NIXLESS=1 PATH=/usr/lib/go/bin:$PATH GO=/usr/lib/go/bin/go 
 time make build
 
+# Note: By attempting a re-run on failure here, we can avoid rebuilding and
+# skip running all of the tests that have already succeeded, since dune will
+# only retry those tests that failed.
 echo "--- Run unit tests"
-time dune runtest "${path}" --profile="${profile}" -j16 || (./scripts/link-coredumps.sh && false)
+time dune runtest "${path}" --profile="${profile}" -j16 || \
+(./scripts/link-coredumps.sh && \
+ echo "--- Retrying failed unit tests" && \
+ time dune runtest "${path}" --profile="${profile}" -j16 || \
+ (./scripts/link-coredumps.sh && false))


### PR DESCRIPTION
This PR tweaks the unit test runner script, so that it will retry the tests once within the same buildkite run. This allows any flaking test to be re-run without a rebuild, and without running the other tests that have already succeeded.

If the test still fails, either due to a badly configured/misbehaving buildkite node or a genuine error in the PR, then the normal buildkite retry process will still take effect.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them