### PR TITLE
set (implicit_transitive_dependencies false) in src/nonconsensus

### DIFF
--- a/src/nonconsensus/currency/dune
+++ b/src/nonconsensus/currency/dune
@@ -3,8 +3,29 @@
  (public_name currency_nonconsensus)
  (library_flags -linkall)
  (inline_tests)
- (libraries core_kernel fold_lib tuple_lib snark_bits_nonconsensus bignum_bigint random_oracle_nonconsensus sgn_nonconsensus snark_params_nonconsensus
-            unsigned_extended_nonconsensus codable ppx_dhall_type)
+ (libraries
+   ;;opam libraries
+   result
+   zarith
+   integers
+   sexplib0
+   bin_prot.shape
+   core_kernel
+   base.caml
+   base
+   base.base_internalhash_types
+   ppx_inline_test.config
+   ;;local libraries
+   codable
+   bignum_bigint
+   ppx_dhall_type
+   random_oracle_input
+   snark_params_nonconsensus
+   random_oracle_nonconsensus
+   snark_bits_nonconsensus
+   unsigned_extended_nonconsensus
+   sgn_nonconsensus
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_coda ppx_version ppx_let ppx_assert ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp ppx_custom_printf ppx_deriving.std ppx_deriving_yojson h_list.ppx ppx_inline_test ppx_fields_conv))

--- a/src/nonconsensus/data_hash_lib/dune
+++ b/src/nonconsensus/data_hash_lib/dune
@@ -3,7 +3,29 @@
  (public_name data_hash_lib_nonconsensus)
  (inline_tests)
  (library_flags -linkall)
- (libraries core_kernel codable snark_params_nonconsensus outside_hash_image_nonconsensus random_oracle_nonconsensus fields_derivers fields_derivers_snapps_nonconsensus)
+ (libraries
+   ;;opam libraries
+   ppx_inline_test.config
+   base.caml
+   sexplib0
+   core_kernel
+   base
+   bin_prot.shape
+   base.base_internalhash_types
+   result
+   ;;local libraries
+   base58_check
+   fields_derivers.json
+   random_oracle_input
+   fields_derivers
+   codable
+   fields_derivers.graphql
+   fold_lib
+   outside_hash_image_nonconsensus
+   snark_params_nonconsensus
+   random_oracle_nonconsensus
+   fields_derivers_snapps_nonconsensus
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_coda ppx_version ppx_inline_test ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp))

--- a/src/nonconsensus/dune-project
+++ b/src/nonconsensus/dune-project
@@ -1,1 +1,2 @@
 (lang dune 2.7)
+(implicit_transitive_deps false)

--- a/src/nonconsensus/fields_derivers_snapps/dune
+++ b/src/nonconsensus/fields_derivers_snapps/dune
@@ -4,18 +4,25 @@
  (library_flags -linkall)
  (inline_tests)
  (libraries
-   ;; opam libraries
-   core_kernel
+   ;;opam libraries
+   sexplib0
+   graphql_parser
+   integers
+   graphql
    fieldslib
-   ;; local libraries
-   signature_lib_nonconsensus
-   unsigned_extended_nonconsensus
-   mina_numbers_nonconsensus
-   currency_nonconsensus
+   core_kernel
+   base.caml
+   base
+   ppx_inline_test.config
+   result
+   ;;local libraries
+   fields_derivers.json
    fields_derivers.graphql
    fields_derivers
-   fields_derivers.json
-   with_hash
+   unsigned_extended_nonconsensus
+   signature_lib_nonconsensus
+   currency_nonconsensus
+   snark_params_nonconsensus
  )
  (instrumentation (backend bisect_ppx))
  (preprocessor_deps ../../config.mlh)

--- a/src/nonconsensus/hash_prefix_states/dune
+++ b/src/nonconsensus/hash_prefix_states/dune
@@ -3,7 +3,16 @@
  (public_name hash_prefix_states_nonconsensus)
  (library_flags -linkall)
  (inline_tests)
- (libraries hash_prefixes mina_compile_config_nonconsensus random_oracle_nonconsensus mina_signature_kind)
+ (libraries
+   ;;opam libraries
+   core_kernel
+   base
+   ;;local libraries
+   hash_prefixes
+   random_oracle_nonconsensus
+   snark_params_nonconsensus
+   mina_signature_kind
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_version ppx_optcomp ppx_compare ppx_deriving_yojson ppx_inline_test))

--- a/src/nonconsensus/hex/dune
+++ b/src/nonconsensus/hex/dune
@@ -4,4 +4,4 @@
  (inline_tests)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_version ppx_inline_test))
- (libraries core_kernel))
+ (libraries core_kernel ppx_inline_test.config))

--- a/src/nonconsensus/mina_base/dune
+++ b/src/nonconsensus/mina_base/dune
@@ -4,24 +4,48 @@
  (inline_tests)
  (library_flags -linkall)
  (libraries
-   mina_numbers_nonconsensus
-   mina_compile_config_nonconsensus
-   currency_nonconsensus
-   data_hash_lib_nonconsensus
-   hash_prefix_states_nonconsensus
-   hex_nonconsensus
-   outside_hash_image_nonconsensus
-   rosetta_coding_nonconsensus
-   signature_lib_nonconsensus
-   snark_params_nonconsensus
-   quickcheck_lib_nonconsensus
-   random_oracle_nonconsensus
-   mina_base_nonconsensus.util
-   mina_base_nonconsensus.import
-   pickles_types
-   pickles_base
-   with_hash
+   ;;opam libraries
+   result
+   base.base_internalhash_types
+   bin_prot.shape
+   base
+   core_kernel
    yojson
+   sexplib0
+   base.caml
+   ppx_inline_test.config
+   integers
+   base_quickcheck
+   ;;local libraries
+   fields_derivers_snapps_nonconsensus
+   sgn_nonconsensus
+   mina_base_nonconsensus.import
+   random_oracle_nonconsensus
+   unsigned_extended_nonconsensus
+   snark_params_nonconsensus
+   rosetta_coding_nonconsensus
+   hex_nonconsensus
+   data_hash_lib_nonconsensus
+   mina_compile_config_nonconsensus
+   mina_numbers_nonconsensus
+   currency_nonconsensus
+   hash_prefix_states_nonconsensus
+   outside_hash_image_nonconsensus
+   signature_lib_nonconsensus
+   quickcheck_lib_nonconsensus
+   mina_base_nonconsensus.util
+   mina_signature_kind
+   fold_lib
+   snarkette
+   fields_derivers.graphql
+   base58_check
+   pickles_base
+   pickles_types
+   with_hash
+   random_oracle_input
+   fields_derivers.json
+   codable
+   blake2
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess

--- a/src/nonconsensus/mina_base/util/dune
+++ b/src/nonconsensus/mina_base/util/dune
@@ -1,7 +1,7 @@
 (library
  (public_name mina_base_nonconsensus.util)
  (name mina_base_util)
- (libraries snark_params_nonconsensus)
+ (libraries snark_params_nonconsensus core_kernel bignum_bigint)
  (preprocess (pps
     ppx_version
     ppx_optcomp))

--- a/src/nonconsensus/mina_numbers/dune
+++ b/src/nonconsensus/mina_numbers/dune
@@ -3,8 +3,28 @@
  (public_name mina_numbers_nonconsensus)
  (inline_tests)
  (library_flags -linkall)
- (libraries fold_lib tuple_lib bignum_bigint snark_bits_nonconsensus unsigned_extended_nonconsensus random_oracle_nonconsensus
-            core_kernel codable ppx_dhall_type)
+ (libraries
+   ;;opam libraries
+   base.base_internalhash_types
+   bin_prot.shape
+   base
+   integers
+   core_kernel
+   sexplib0
+   base.caml
+   result
+   ;;local libraries
+   ppx_dhall_type
+   bignum_bigint
+   fold_lib
+   tuple_lib
+   codable
+   random_oracle_input
+   unsigned_extended_nonconsensus
+   snark_bits_nonconsensus
+   random_oracle_nonconsensus
+   snark_params_nonconsensus
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_version ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_compare ppx_deriving_yojson

--- a/src/nonconsensus/non_zero_curve_point/dune
+++ b/src/nonconsensus/non_zero_curve_point/dune
@@ -4,7 +4,21 @@
  (flags :standard -short-paths)
  (inline_tests)
  (library_flags -linkall)
- (libraries core_kernel snark_params_nonconsensus random_oracle_nonconsensus fold_lib codable ppx_version)
+ (libraries
+   ;;opam libraries
+   ppx_inline_test.config
+   base.caml
+   core_kernel
+   bin_prot.shape
+   base
+   base.base_internalhash_types
+   ;;local libraries
+   base58_check
+   codable
+   random_oracle_input
+   random_oracle_nonconsensus
+   snark_params_nonconsensus
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_coda ppx_version ppx_optcomp ppx_let ppx_hash ppx_compare ppx_sexp_conv ppx_bin_prot ppx_inline_test ppx_deriving_yojson ppx_compare h_list.ppx))

--- a/src/nonconsensus/quickcheck_lib/dune
+++ b/src/nonconsensus/quickcheck_lib/dune
@@ -1,7 +1,15 @@
 (library
  (name quickcheck_lib)
  (public_name quickcheck_lib_nonconsensus)
- (libraries core_kernel currency_nonconsensus rose_tree)
+ (libraries
+   ;;opam libraries
+   core_kernel
+   base
+   ppx_inline_test.config
+   ;;local libraries
+   rose_tree
+   currency_nonconsensus
+ )
  (inline_tests)
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/nonconsensus/random_oracle/dune
+++ b/src/nonconsensus/random_oracle/dune
@@ -6,7 +6,14 @@
  (preprocess (pps ppx_version ppx_optcomp ppx_sexp_conv ppx_compare ppx_inline_test ppx_assert ppx_compare ppx_deriving_yojson ppx_let))
  (inline_tests)
  (libraries
+   ;;opam libraries
+   ppx_inline_test.config
+   base
    core_kernel
+   sexplib0
+   ;;local libraries
    random_oracle_input
    snark_params_nonconsensus
-   sponge))
+   sponge
+   fold_lib
+))

--- a/src/nonconsensus/rosetta_coding/dune
+++ b/src/nonconsensus/rosetta_coding/dune
@@ -3,7 +3,16 @@
  (public_name rosetta_coding_nonconsensus)
  (library_flags -linkall)
  (inline_tests)
- (libraries core_kernel snark_params_nonconsensus signature_lib_nonconsensus)
+ (libraries
+   ;;opam libraries
+   ppx_deriving.runtime
+   core_kernel
+   ppx_inline_test.config
+   base
+   ;;local libraries
+   signature_lib_nonconsensus
+   snark_params_nonconsensus
+ )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_optcomp ppx_let ppx_inline_test))

--- a/src/nonconsensus/rosetta_lib/dune
+++ b/src/nonconsensus/rosetta_lib/dune
@@ -3,8 +3,30 @@
  (public_name rosetta_lib_nonconsensus)
  (library_flags -linkall)
  (inline_tests)
- (libraries core_kernel caqti rosetta_models mina_base_nonconsensus currency_nonconsensus
-            snark_params_nonconsensus signature_lib_nonconsensus unsigned_extended_nonconsensus)
+ (libraries
+   ;;opam libraries
+   ppx_inline_test.config
+   integers
+   sexplib0
+   base
+   caqti
+   core_kernel
+   async_kernel
+   base.caml
+   result
+   ;;local libraries
+   rosetta_models
+   random_oracle_input
+   mina_numbers_nonconsensus
+   mina_compile_config_nonconsensus
+   mina_base_nonconsensus.import
+   hex_nonconsensus
+   signature_lib_nonconsensus
+   mina_base_nonconsensus
+   currency_nonconsensus
+   snark_params_nonconsensus
+   unsigned_extended_nonconsensus
+ )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_optcomp ppx_assert ppx_let ppx_sexp_conv

--- a/src/nonconsensus/rosetta_lib/test/dune
+++ b/src/nonconsensus/rosetta_lib/test/dune
@@ -2,7 +2,15 @@
  (name test_encodings)
  (modes native)
  (modules test_encodings)
- (libraries core_kernel signature_lib_nonconsensus rosetta_lib_nonconsensus)
+ (libraries
+   ;;opam libraries
+   core_kernel
+   base
+   ;;local libraries
+   rosetta_lib_nonconsensus
+   rosetta_coding_nonconsensus
+   signature_lib_nonconsensus
+ )
  (preprocessor_deps ../../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_optcomp)))

--- a/src/nonconsensus/sgn/dune
+++ b/src/nonconsensus/sgn/dune
@@ -2,8 +2,17 @@
  (name sgn)
  (public_name sgn_nonconsensus)
  (library_flags -linkall)
- (libraries sgn_type snark_params_nonconsensus core_kernel ppx_deriving_yojson.runtime
-            yojson)
+ (libraries
+   ;;opam libraries
+   bin_prot.shape
+   sexplib0
+   core_kernel
+   base
+   base.caml
+   ;;local libraries
+   snark_params_nonconsensus
+   sgn_type
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_version ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp ppx_compare ppx_deriving_yojson))

--- a/src/nonconsensus/signature_lib/dune
+++ b/src/nonconsensus/signature_lib/dune
@@ -4,16 +4,29 @@
  (library_flags -linkall)
  (inline_tests)
  (libraries
-   bignum_bigint
-   blake2
+   ;;opam libraries
+   bignum.bigint
+   ppx_inline_test.config
+   bin_prot.shape
+   base
+   sexplib0
    core_kernel
+   js_of_ocaml
+   base.caml
+   result
+   ;;local libraries
+   base58_check
+   blake2
+   mina_signature_kind
+   random_oracle_input
+   fold_lib
+   snarkette
+   codable
+   snark_params_nonconsensus
+   random_oracle_nonconsensus
    hash_prefix_states_nonconsensus
    non_zero_curve_point_nonconsensus
-   random_oracle_nonconsensus
-   mina_signature_kind
-   snark_params_nonconsensus
-   js_of_ocaml
-   yojson)
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_coda ppx_version ppx_optcomp ppx_sexp_conv

--- a/src/nonconsensus/snark_bits/dune
+++ b/src/nonconsensus/snark_bits/dune
@@ -2,9 +2,20 @@
  (name snark_bits)
  (public_name snark_bits_nonconsensus)
  (library_flags -linkall)
- (libraries fold_lib bitstring_lib core_kernel integers)
+ (libraries
+   ;;opam libraries
+   core_kernel
+   integers
+   base
+   ;;local libraries
+   snarky.backendless
+   fold_lib
+   bitstring_lib
+   tuple_lib
+   snarky.intf
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_version ppx_optcomp ppx_let ppx_compare ppx_inline_test))
+  (pps ppx_version ppx_optcomp ppx_let ppx_compare ppx_inline_test ppx_snarky))
  (instrumentation (backend bisect_ppx))
  (synopsis "Snark parameters"))

--- a/src/nonconsensus/snark_params/dune
+++ b/src/nonconsensus/snark_params/dune
@@ -2,7 +2,19 @@
  (name snark_params)
  (public_name snark_params_nonconsensus)
  (library_flags -linkall)
- (libraries core_kernel bignum_bigint snarkette)
+ (libraries
+   ;; opam libraries
+   base.caml
+   sexplib0
+   bin_prot.shape
+   core_kernel
+   ppx_inline_test.config
+   base
+   bignum.bigint
+   ;; local libraries
+   bignum_bigint
+   snarkette
+ )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_custom_printf ppx_coda ppx_version ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_let ppx_deriving.std ppx_compare ppx_deriving_yojson ppx_hash))

--- a/src/nonconsensus/string_sign/dune
+++ b/src/nonconsensus/string_sign/dune
@@ -3,8 +3,19 @@
  (public_name string_sign_nonconsensus)
  (inline_tests)
  (library_flags -linkall)
- (libraries snark_params_nonconsensus mina_base_nonconsensus random_oracle_nonconsensus
-            signature_lib_nonconsensus digestif.ocaml)
+ (libraries
+   ;;opam libraries
+   ppx_inline_test.config
+   core_kernel
+   digestif.ocaml
+   ;;local libraries
+   random_oracle_input
+   mina_signature_kind
+   signature_lib_nonconsensus
+   mina_base_nonconsensus
+   snark_params_nonconsensus
+   random_oracle_nonconsensus
+ )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_snarky ppx_optcomp ppx_inline_test))

--- a/src/nonconsensus/unsigned_extended/dune
+++ b/src/nonconsensus/unsigned_extended/dune
@@ -3,7 +3,23 @@
  (public_name unsigned_extended_nonconsensus)
  (library_flags -linkall)
  (inline_tests)
- (libraries core_kernel integers snark_params_nonconsensus ppx_dhall_type ppx_version)
+ (libraries
+   ;;opam libraries
+   base.caml
+   result
+   base
+   integers
+   core_kernel
+   sexplib0
+   bignum.bigint
+   base.base_internalhash_types
+   bin_prot.shape
+   ppx_inline_test.config
+   ;;local libraries
+   bignum_bigint
+   ppx_dhall_type
+   snark_params_nonconsensus
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_coda ppx_version ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_hash ppx_compare


### PR DESCRIPTION
This PR sets the `(implicit_transitive_deps false)` option in `src/nonconsensus` and adds the needed direct dependencies to the dune files.

#### Explain how you tested your changes
```
- make build
- make client_sdk
- make client_sdk_test_sigs_nonconsensus
- make rosetta_lib_encodings_nonconsensus
- dune build src/nonconsensus --profile=nonconsensus_mainnet
```
- The CI failure seems unrelated

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them