### PR TITLE
Update to new arithmetic sponge params

### DIFF
--- a/src/app/client_sdk/poseidon_hash.ml
+++ b/src/app/client_sdk/poseidon_hash.ml
@@ -82,7 +82,7 @@ module Hash = struct
   include Sponge.Make_hash (Sponge.Poseidon (Config))
 
   let params : Field.t Sponge.Params.t =
-    Sponge.Params.(map pasta_p_3 ~f:Field.of_string)
+    Sponge.Params.(map pasta_p_kimchi ~f:Field.of_string)
 
   let update ~state = update ~state params
 

--- a/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
@@ -39,7 +39,7 @@ module R1CS_constraint_system =
     (struct
       let params =
         Sponge.Params.(
-          map pasta_q_3 ~f:(fun x ->
+          map pasta_q_kimchi ~f:(fun x ->
               Field.of_bigint (Bigint256.of_decimal_string x)))
     end)
 

--- a/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
@@ -38,7 +38,7 @@ module R1CS_constraint_system =
     (struct
       let params =
         Sponge.Params.(
-          map pasta_p_3 ~f:(fun x ->
+          map pasta_p_kimchi ~f:(fun x ->
               Field.of_bigint (Bigint256.of_decimal_string x)))
     end)
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
@@ -19,10 +19,10 @@ pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
     // consistent when printing.
     index_terms.sort_by(|(x, _), (y, _)| x.cmp(y));
 
-    let constant = constant_term.to_string();
+    let constant = constant_term.ocaml_str();
     let other_terms = index_terms
         .iter()
-        .map(|(col, expr)| (format!("{:?}", col), format!("{}", expr)))
+        .map(|(col, expr)| (format!("{:?}", col), format!("{}", expr.ocaml_str())))
         .collect();
 
     (constant, other_terms)

--- a/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
@@ -5,7 +5,7 @@ use kimchi::prover::ProverProof;
 use kimchi::{index::VerifierIndex as DlogVerifierIndex, prover::caml::CamlProverProof};
 use oracle::{
     self,
-    poseidon::PlonkSpongeConstants15W,
+    poseidon::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
     FqSponge,
 };
@@ -52,7 +52,7 @@ macro_rules! impl_oracles {
                 let proof: ProverProof<$G> = proof.into();
 
                 let oracles_result =
-                    proof.oracles::<DefaultFqSponge<$curve_params, PlonkSpongeConstants15W>, DefaultFrSponge<$F, PlonkSpongeConstants15W>>(&index, &p_comm);
+                    proof.oracles::<DefaultFqSponge<$curve_params, PlonkSpongeConstantsKimchi>, DefaultFrSponge<$F, PlonkSpongeConstantsKimchi>>(&index, &p_comm);
 
                 let (mut sponge, combined_inner_product, p_eval, digest, oracles) = (
                     oracles_result.fq_sponge,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
@@ -55,7 +55,7 @@ pub fn caml_pasta_fp_plonk_index_create(
     let cs = match ConstraintSystem::<Fp>::create(
         gates,
         vec![],
-        oracle::pasta::fp_3::params(),
+        oracle::pasta::fp_kimchi::params(),
         public as usize,
     ) {
         None => {
@@ -80,7 +80,7 @@ pub fn caml_pasta_fp_plonk_index_create(
 
     // create index
     Ok(CamlPastaFpPlonkIndex(Box::new(
-        DlogIndex::<GAffine>::create(cs, oracle::pasta::fq_3::params(), endo_q, srs.clone()),
+        DlogIndex::<GAffine>::create(cs, oracle::pasta::fq_kimchi::params(), endo_q, srs.clone()),
     )))
 }
 
@@ -141,9 +141,9 @@ pub fn caml_pasta_fp_plonk_index_read(
 
     // deserialize the index
     let mut t = DlogIndex::<GAffine>::deserialize(&mut rmp_serde::Deserializer::new(r))?;
-    t.cs.fr_sponge_params = oracle::pasta::fp_3::params();
+    t.cs.fr_sponge_params = oracle::pasta::fp_kimchi::params();
     t.srs = srs.clone();
-    t.fq_sponge_params = oracle::pasta::fq_3::params();
+    t.fq_sponge_params = oracle::pasta::fq_kimchi::params();
 
     let (linearization, powers_of_alpha) = expr_linearization(t.cs.domain.d1, false, &None);
     t.linearization = linearization;

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -21,13 +21,13 @@ use mina_curves::pasta::{
     vesta::{Affine as GAffine, VestaParameters},
 };
 use oracle::{
-    poseidon::PlonkSpongeConstants15W,
+    poseidon::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use std::convert::TryInto;
 
-type EFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstants15W>;
-type EFrSponge = DefaultFrSponge<Fp, PlonkSpongeConstants15W>;
+type EFqSponge = DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>;
+type EFrSponge = DefaultFrSponge<Fp, PlonkSpongeConstantsKimchi>;
 
 #[ocaml_gen::func]
 #[ocaml::func]
@@ -99,8 +99,8 @@ pub fn caml_pasta_fp_plonk_proof_verify(
     let group_map = <GAffine as CommitmentCurve>::Map::setup();
 
     ProverProof::verify::<
-        DefaultFqSponge<VestaParameters, PlonkSpongeConstants15W>,
-        DefaultFrSponge<Fp, PlonkSpongeConstants15W>,
+        DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>,
+        DefaultFrSponge<Fp, PlonkSpongeConstantsKimchi>,
     >(
         &group_map,
         &[(&index.into(), &lgr_comm, &proof.into())].to_vec(),
@@ -125,8 +125,8 @@ pub fn caml_pasta_fp_plonk_proof_batch_verify(
     let group_map = GroupMap::<Fq>::setup();
 
     ProverProof::<GAffine>::verify::<
-        DefaultFqSponge<VestaParameters, PlonkSpongeConstants15W>,
-        DefaultFrSponge<Fp, PlonkSpongeConstants15W>,
+        DefaultFqSponge<VestaParameters, PlonkSpongeConstantsKimchi>,
+        DefaultFrSponge<Fp, PlonkSpongeConstantsKimchi>,
     >(&group_map, &ts)
     .is_ok()
 }

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -112,8 +112,8 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<GAffine> {
             lookup_index: index.lookup_index.map(Into::into),
             linearization,
 
-            fr_sponge_params: oracle::pasta::fp_3::params(),
-            fq_sponge_params: oracle::pasta::fq_3::params(),
+            fr_sponge_params: oracle::pasta::fp_kimchi::params(),
+            fq_sponge_params: oracle::pasta::fq_kimchi::params(),
         }
     }
 }
@@ -125,8 +125,8 @@ pub fn read_raw(
 ) -> Result<VerifierIndex<GAffine>, ocaml::Error> {
     let path = Path::new(&path);
     let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
-    let fq_sponge_params = oracle::pasta::fq_3::params();
-    let fr_sponge_params = oracle::pasta::fp_3::params();
+    let fq_sponge_params = oracle::pasta::fq_kimchi::params();
+    let fr_sponge_params = oracle::pasta::fp_kimchi::params();
     VerifierIndex::<GAffine>::from_file(
         srs.0,
         path,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_poseidon.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_poseidon.rs
@@ -1,6 +1,6 @@
 use crate::field_vector::fp::CamlFpVector;
 use mina_curves::pasta::fp::Fp;
-use oracle::poseidon::{poseidon_block_cipher, ArithmeticSpongeParams, PlonkSpongeConstants15W};
+use oracle::poseidon::{poseidon_block_cipher, ArithmeticSpongeParams, PlonkSpongeConstantsKimchi};
 
 pub struct CamlPastaFpPoseidonParams(ArithmeticSpongeParams<Fp>);
 pub type CamlPastaFpPoseidonParamsPtr<'a> = ocaml::Pointer<'a, CamlPastaFpPoseidonParams>;
@@ -18,7 +18,7 @@ ocaml::custom!(CamlPastaFpPoseidonParams {
 
 #[ocaml::func]
 pub fn caml_pasta_fp_poseidon_params_create() -> CamlPastaFpPoseidonParams {
-    CamlPastaFpPoseidonParams(oracle::pasta::fp_3::params())
+    CamlPastaFpPoseidonParams(oracle::pasta::fp_kimchi::params())
 }
 
 #[ocaml::func]
@@ -26,5 +26,5 @@ pub fn caml_pasta_fp_poseidon_block_cipher(
     params: CamlPastaFpPoseidonParamsPtr,
     mut state: CamlFpVector,
 ) {
-    poseidon_block_cipher::<Fp, PlonkSpongeConstants15W>(&params.as_ref().0, state.as_mut())
+    poseidon_block_cipher::<Fp, PlonkSpongeConstantsKimchi>(&params.as_ref().0, state.as_mut())
 }

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
@@ -55,7 +55,7 @@ pub fn caml_pasta_fq_plonk_index_create(
     let cs = match ConstraintSystem::<Fq>::create(
         gates,
         vec![],
-        oracle::pasta::fq_3::params(),
+        oracle::pasta::fq_kimchi::params(),
         public as usize,
     ) {
         None => {
@@ -80,7 +80,7 @@ pub fn caml_pasta_fq_plonk_index_create(
 
     // create index
     Ok(CamlPastaFqPlonkIndex(Box::new(
-        DlogIndex::<GAffine>::create(cs, oracle::pasta::fp_3::params(), endo_q, srs.clone()),
+        DlogIndex::<GAffine>::create(cs, oracle::pasta::fp_kimchi::params(), endo_q, srs.clone()),
     )))
 }
 
@@ -141,9 +141,9 @@ pub fn caml_pasta_fq_plonk_index_read(
 
     // deserialize the index
     let mut t = DlogIndex::<GAffine>::deserialize(&mut rmp_serde::Deserializer::new(r))?;
-    t.cs.fr_sponge_params = oracle::pasta::fq_3::params();
+    t.cs.fr_sponge_params = oracle::pasta::fq_kimchi::params();
     t.srs = srs.clone();
-    t.fq_sponge_params = oracle::pasta::fp_3::params();
+    t.fq_sponge_params = oracle::pasta::fp_kimchi::params();
 
     let (linearization, powers_of_alpha) = expr_linearization(t.cs.domain.d1, false, &None);
     t.linearization = linearization;

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -22,7 +22,7 @@ use kimchi::index::Index;
 use kimchi::prover::caml::CamlProverProof;
 use kimchi::prover::{ProverCommitments, ProverProof};
 use oracle::{
-    poseidon::PlonkSpongeConstants15W,
+    poseidon::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
 use std::convert::TryInto;
@@ -80,8 +80,8 @@ pub fn caml_pasta_fq_plonk_proof_create(
     runtime.releasing_runtime(|| {
         let group_map = GroupMap::<Fp>::setup();
         let proof = ProverProof::create::<
-            DefaultFqSponge<PallasParameters, PlonkSpongeConstants15W>,
-            DefaultFrSponge<Fq, PlonkSpongeConstants15W>,
+            DefaultFqSponge<PallasParameters, PlonkSpongeConstantsKimchi>,
+            DefaultFrSponge<Fq, PlonkSpongeConstantsKimchi>,
         >(&group_map, witness, index, prev)
         .map_err(|e| ocaml::Error::Error(e.into()))?;
         Ok(proof.into())
@@ -100,8 +100,8 @@ pub fn caml_pasta_fq_plonk_proof_verify(
     let group_map = <GAffine as CommitmentCurve>::Map::setup();
 
     ProverProof::verify::<
-        DefaultFqSponge<PallasParameters, PlonkSpongeConstants15W>,
-        DefaultFrSponge<Fq, PlonkSpongeConstants15W>,
+        DefaultFqSponge<PallasParameters, PlonkSpongeConstantsKimchi>,
+        DefaultFrSponge<Fq, PlonkSpongeConstantsKimchi>,
     >(
         &group_map,
         &[(&index.into(), &lgr_comm, &proof.into())].to_vec(),
@@ -126,8 +126,8 @@ pub fn caml_pasta_fq_plonk_proof_batch_verify(
     let group_map = GroupMap::<Fp>::setup();
 
     ProverProof::<GAffine>::verify::<
-        DefaultFqSponge<PallasParameters, PlonkSpongeConstants15W>,
-        DefaultFrSponge<Fq, PlonkSpongeConstants15W>,
+        DefaultFqSponge<PallasParameters, PlonkSpongeConstantsKimchi>,
+        DefaultFrSponge<Fq, PlonkSpongeConstantsKimchi>,
     >(&group_map, &ts)
     .is_ok()
 }

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
@@ -112,8 +112,8 @@ impl From<CamlPastaFqPlonkVerifierIndex> for VerifierIndex<GAffine> {
             lookup_index: index.lookup_index.map(Into::into),
             linearization,
 
-            fr_sponge_params: oracle::pasta::fq_3::params(),
-            fq_sponge_params: oracle::pasta::fp_3::params(),
+            fr_sponge_params: oracle::pasta::fq_kimchi::params(),
+            fq_sponge_params: oracle::pasta::fp_kimchi::params(),
         }
     }
 }
@@ -125,8 +125,8 @@ pub fn read_raw(
 ) -> Result<VerifierIndex<GAffine>, ocaml::Error> {
     let path = Path::new(&path);
     let (endo_q, _endo_r) = commitment_dlog::srs::endos::<GAffineOther>();
-    let fq_sponge_params = oracle::pasta::fp_3::params();
-    let fr_sponge_params = oracle::pasta::fq_3::params();
+    let fq_sponge_params = oracle::pasta::fp_kimchi::params();
+    let fr_sponge_params = oracle::pasta::fq_kimchi::params();
     VerifierIndex::<GAffine>::from_file(
         srs.0,
         path,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_poseidon.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_poseidon.rs
@@ -1,6 +1,6 @@
 use crate::field_vector::fq::CamlFqVector;
 use mina_curves::pasta::fq::Fq;
-use oracle::poseidon::{poseidon_block_cipher, ArithmeticSpongeParams, PlonkSpongeConstants15W};
+use oracle::poseidon::{poseidon_block_cipher, ArithmeticSpongeParams, PlonkSpongeConstantsKimchi};
 
 pub struct CamlPastaFqPoseidonParams(ArithmeticSpongeParams<Fq>);
 pub type CamlPastaFqPoseidonParamsPtr<'a> = ocaml::Pointer<'a, CamlPastaFqPoseidonParams>;
@@ -18,7 +18,7 @@ ocaml::custom!(CamlPastaFqPoseidonParams {
 
 #[ocaml::func]
 pub fn caml_pasta_fq_poseidon_params_create() -> CamlPastaFqPoseidonParams {
-    CamlPastaFqPoseidonParams(oracle::pasta::fq_3::params())
+    CamlPastaFqPoseidonParams(oracle::pasta::fq_kimchi::params())
 }
 
 #[ocaml::func]
@@ -26,5 +26,5 @@ pub fn caml_pasta_fq_poseidon_block_cipher(
     params: CamlPastaFqPoseidonParamsPtr,
     mut state: CamlFqVector,
 ) {
-    poseidon_block_cipher::<Fq, PlonkSpongeConstants15W>(&params.as_ref().0, state.as_mut())
+    poseidon_block_cipher::<Fq, PlonkSpongeConstantsKimchi>(&params.as_ref().0, state.as_mut())
 }

--- a/src/lib/pickles/step_main_inputs.ml
+++ b/src/lib/pickles/step_main_inputs.ml
@@ -8,7 +8,7 @@ open Import
 let high_entropy_bits = 128
 
 let sponge_params_constant =
-  Sponge.Params.(map pasta_p_3 ~f:Impl.Field.Constant.of_string)
+  Sponge.Params.(map pasta_p_kimchi ~f:Impl.Field.Constant.of_string)
 
 let tick_field_random_oracle ?(length = Tick.Field.size_in_bits - 1) s =
   Tick.Field.of_bits (bits_random_oracle ~length s)

--- a/src/lib/pickles/tick_field_sponge.ml
+++ b/src/lib/pickles/tick_field_sponge.ml
@@ -4,7 +4,7 @@ let params =
   (* HACK *)
   Sponge.Params.(
     let testbit n i = Bigint.(equal (shift_right n i land one) one) in
-    map pasta_p_3 ~f:(fun s ->
+    map pasta_p_kimchi ~f:(fun s ->
         Backend.Tick.Field.of_bits
           (List.init Backend.Tick.Field.size_in_bits
              (testbit (Bigint.of_string s)))))

--- a/src/lib/pickles/tock_field_sponge.ml
+++ b/src/lib/pickles/tock_field_sponge.ml
@@ -4,7 +4,7 @@ let params =
   (* HACK *)
   Sponge.Params.(
     let testbit n i = Bigint.(equal (shift_right n i land one) one) in
-    map pasta_q_3 ~f:(fun s ->
+    map pasta_q_kimchi ~f:(fun s ->
         Backend.Tock.Field.of_bits
           (List.init Backend.Tock.Field.size_in_bits
              (testbit (Bigint.of_string s)))))

--- a/src/lib/pickles/wrap_main_inputs.ml
+++ b/src/lib/pickles/wrap_main_inputs.ml
@@ -10,7 +10,7 @@ open Import
 let high_entropy_bits = 128
 
 let sponge_params_constant =
-  Sponge.Params.(map pasta_q_3 ~f:Impl.Field.Constant.of_string)
+  Sponge.Params.(map pasta_q_kimchi ~f:Impl.Field.Constant.of_string)
 
 let field_random_oracle ?(length = Me.Field.size_in_bits - 1) s =
   Me.Field.of_bits (bits_random_oracle ~length s)

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -21,7 +21,7 @@ end
 module Input = Random_oracle_input
 
 let params : Field.t Sponge.Params.t =
-  Sponge.Params.(map pasta_p_3 ~f:Field.of_string)
+  Sponge.Params.(map pasta_p_kimchi ~f:Field.of_string)
 
 module Operations = struct
   let add_assign ~state i x = Field.(state.(i) <- state.(i) + x)
@@ -206,7 +206,7 @@ module Legacy = struct
   module Input = Random_oracle_input.Legacy
 
   let params : Field.t Sponge.Params.t =
-    Sponge.Params.(map pasta_p ~f:Field.of_string)
+    Sponge.Params.(map pasta_p_legacy ~f:Field.of_string)
 
   module Rounds = struct
     let rounds_full = 63


### PR DESCRIPTION
    * Update to latest version
    * Update names to be more obvious and match proof-systems names
        * pasta_{p,q} -> Legacy: pasta_{p,q}_legacy
        * pasta_{q,q}_3 -> Kimchi: pasta_{p,q}_kimchi
    * Need to update submodules once proof-systems and snarky PRs are approved

* Closes #10446
