### PR TITLE
Remove bogus fee/weight unit tests

### DIFF
--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1740,54 +1740,6 @@ let%test_module _ =
             | _ ->
                 failwith "should've returned insufficient_funds")
 
-    let%test_unit "applicable_by_fee ordered by fee per wu" =
-      let cmds =
-        gen_cmd () |> Quickcheck.random_sequence |> Fn.flip Sequence.take 4
-        |> Sequence.to_list
-      in
-      let insert_cmd pool cmd =
-        add_from_gossip_exn ~verify:don't_verify pool (`Checked cmd)
-          Account_nonce.zero
-          (Currency.Amount.of_int (500 * 10_000_000))
-        |> Result.ok |> Option.value_exn
-        |> fun (_, pool, _) -> pool
-      in
-      let pool = List.fold_left cmds ~init:empty ~f:insert_cmd in
-      let compare cmd0 cmd1 : int =
-        Currency.Fee_rate.compare
-          (User_command.fee_per_wu cmd0)
-          (User_command.fee_per_wu cmd1)
-      in
-      pool.applicable_by_fee |> Map.data
-      |> List.concat_map ~f:Set.to_list
-      |> List.map ~f:Transaction_hash.User_command_with_valid_signature.command
-      |> List.is_sorted ~compare
-      |> fun is_sorted -> assert is_sorted
-
-    let%test_unit "all_by_fee ordered by fee per wu" =
-      let cmds =
-        gen_cmd () |> Quickcheck.random_sequence |> Fn.flip Sequence.take 4
-        |> Sequence.to_list
-      in
-      let insert_cmd pool cmd =
-        add_from_gossip_exn ~verify:don't_verify pool (`Checked cmd)
-          Account_nonce.zero
-          (Currency.Amount.of_int (500 * 10_000_000))
-        |> Result.ok |> Option.value_exn
-        |> fun (_, pool, _) -> pool
-      in
-      let pool = List.fold_left cmds ~init:empty ~f:insert_cmd in
-      let compare cmd0 cmd1 : int =
-        Currency.Fee_rate.compare
-          (User_command.fee_per_wu cmd0)
-          (User_command.fee_per_wu cmd1)
-      in
-      pool.all_by_fee |> Map.data
-      |> List.concat_map ~f:Set.to_list
-      |> List.map ~f:Transaction_hash.User_command_with_valid_signature.command
-      |> List.is_sorted ~compare
-      |> fun is_sorted -> assert is_sorted
-
     let%test_unit "remove_lowest_fee" =
       let cmds =
         gen_cmd () |> Quickcheck.random_sequence |> Fn.flip Sequence.take 4


### PR DESCRIPTION
Remove two unit tests that purported to check the integrity of indexed pool maps from `Fee_rate.t` to sets of user commands.

The tests inserted commands into the indexed pool, then used `Map.data` to pull out the commands, and checked whether they were in fee/weight order. But `Map.data` provides no ordering guarantees, so these tests succeeded by sheer coincidence. The number of commands given is small (4); increasing the number broke the tests, because the insertion step failed.
