### PR TITLE
Assert fee/weight ordering of transactions

### DIFF
--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -911,8 +911,12 @@ let remove_lowest_fee :
 let get_highest_fee :
     t -> Transaction_hash.User_command_with_valid_signature.t option =
  fun t ->
-  Option.map ~f:(Fn.compose Set.min_elt_exn Tuple2.get2)
-  @@ Map.max_elt t.applicable_by_fee
+  Option.map
+    ~f:
+      (Fn.compose
+         Transaction_hash.User_command_with_valid_signature.Set.min_elt_exn
+         Tuple2.get2)
+  @@ Currency.Fee_rate.Map.max_elt t.applicable_by_fee
 
 (* Add a command that came in from gossip, or return an error. We need to check
    a whole bunch of conditions here and return the appropriate errors.

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1683,6 +1683,34 @@ let%test_module _ =
             , Time.t * [ `Batch of int ] )
             Hashtbl.t )
 
+    let assert_fee_wu_ordering (pool : Test.Resource_pool.t) =
+      let txns =
+        Test.Resource_pool.transactions pool ~logger |> Sequence.to_list
+      in
+      let fee_wu_sorted_txns =
+        List.stable_sort txns ~compare:(fun txn1 txn2 ->
+            let open Transaction_hash.User_command_with_valid_signature in
+            let cmd1 = command txn1 in
+            let cmd2 = command txn2 in
+            (* ascending order of nonces, if same fee payer *)
+            if
+              Account_id.equal
+                (User_command.fee_payer cmd1)
+                (User_command.fee_payer cmd2)
+            then
+              Account.Nonce.compare
+                (User_command.nonce_exn cmd1)
+                (User_command.nonce_exn cmd2)
+            else
+              let get_fee_wu cmd = User_command.fee_per_wu cmd in
+              (* descending order of fee/weight *)
+              Int.neg
+              @@ Currency.Fee_rate.compare (get_fee_wu cmd1) (get_fee_wu cmd2))
+      in
+      assert (
+        [%equal: Transaction_hash.User_command_with_valid_signature.t list] txns
+          fee_wu_sorted_txns )
+
     let setup_test () =
       let tf, best_tip_diff_w = Mock_transition_frontier.create () in
       let tf_pipe_r, _tf_pipe_w = Broadcast_pipe.create @@ Some tf in
@@ -1706,6 +1734,7 @@ let%test_module _ =
       ( (fun txs ->
           Indexed_pool.For_tests.assert_invariants pool.pool ;
           assert_locally_generated pool ;
+          assert_fee_wu_ordering pool ;
           [%test_eq: User_command.t List.t]
             ( Test.Resource_pool.transactions ~logger pool
             |> Sequence.map


### PR DESCRIPTION
In the `Transaction_pool` unit tests, add another assertion on the pool, that `transactions` provides commands ordered in decreasing fee/weight order, subject to nonce ordering for fee payers.

In `Indexed_pool.get_highest_fee`, use specific `Set` and `Map` modules, rather than the `Stdlib` ones.

Note: `get_highest_fee` seems to use `min_elt_exn` as a tie-breaker, when multiple commands have the same fee/weight. Adding that tie-breaker to the sort breaks the assertion for some tests. Omitting the tie-breaker allows all tests to succeed. I don't understand why adding the tie-breaker breaks tests, but I think omitting it is OK, because the assertion nonetheless establishes that transactions are ordered by decreasing fee/weight.

Part of #10067.