### PR TITLE
Add snapp with timing to integration test

### DIFF
--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4378,8 +4378,8 @@ module For_tests = struct
       ; memo : Signed_command_memo.t
       ; new_snapp_account : bool
       ; snapp_update : Party.Update.t
+            (* Authorization for the update being performed *)
       ; current_auth : Permissions.Auth_required.t
-            (*Authorization for the update being performed*)
       ; sequence_events : Tick.Field.t array list
       ; events : Tick.Field.t array list
       ; call_data : Tick.Field.t
@@ -4646,6 +4646,13 @@ module For_tests = struct
     let `VK vk, `Prover _trivial_prover =
       create_trivial_snapp ~constraint_constants ()
     in
+    (* only allow timing on a single new snapp account
+       balance changes for other new snapp accounts are just the account creation fee
+    *)
+    assert (
+      Snapp_basic.Set_or_keep.is_keep spec.snapp_update.timing
+      || (spec.new_snapp_account && List.length spec.snapp_account_keypairs = 1)
+    ) ;
     let update_vk =
       let update = spec.snapp_update in
       { update with


### PR DESCRIPTION
In the `snapp` integration test, create a new account with a timing. Verify that the timing appears in the ledger account.

Closes #10359.
