### PR TITLE
Add gap estimate to missing block log

### DIFF
--- a/src/app/missing_blocks_auditor/sql.ml
+++ b/src/app/missing_blocks_auditor/sql.ml
@@ -14,6 +14,16 @@ module Unparented_blocks = struct
   let run (module Conn : Caqti_async.CONNECTION) () = Conn.collect_list query ()
 end
 
+module Missing_blocks_gap = struct
+  let query =
+    Caqti_request.find Caqti_type.int Caqti_type.int
+      {sql| SELECT $1 - MAX(height) - 1 FROM blocks
+            WHERE height < $1
+      |sql}
+
+  let run (module Conn : Caqti_async.CONNECTION) height = Conn.find query height
+end
+
 module Chain_status = struct
   let query_highest_canonical =
     Caqti_request.find Caqti_type.unit Caqti_type.int64


### PR DESCRIPTION
In `missing_blocks_auditor`, add an estimate of the gap size when there's a missing block.

The gap estimate is the height of the unparented block, minus the maximum block height less than that height, minus 1.

It's an estimate, because we don't know there's a chain between the unparented block and that block of maximum height.

Tested with a gappy archive db.