### PR TITLE
Initial integration of ppx_annot with fields-derivers

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -681,7 +681,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "FeePayerPartyBodyInput",
-          "description": "Body component of a snapp Fee Payer Party",
+          "description": "Body component of a party",
           "fields": [
             {
               "name": "publicKey",
@@ -1070,9 +1070,8 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "SnappPartyPredicatedFeePayerInput",
-          "description":
-            "A party to a snapp transaction with a nonce predicate",
+          "name": "ZkappPartyPredicatedFeePayerInput",
+          "description": null,
           "fields": [
             {
               "name": "body",
@@ -1143,9 +1142,8 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "SnappPartyFeePayerInput",
-          "description":
-            "A party to a snapp transaction with a signature authorization",
+          "name": "ZkappPartyFeePayerInput",
+          "description": null,
           "fields": [
             {
               "name": "data",
@@ -1156,7 +1154,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "SnappPartyPredicatedFeePayerInput",
+                  "name": "ZkappPartyPredicatedFeePayerInput",
                   "ofType": null
                 }
               },
@@ -1189,7 +1187,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "SnappPartyPredicatedFeePayerInput",
+                  "name": "ZkappPartyPredicatedFeePayerInput",
                   "ofType": null
                 }
               },
@@ -1217,7 +1215,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "VerificationKeyWithHashInput",
-          "description": "Verification key with hash",
+          "description": null,
           "fields": [
             {
               "name": "data",
@@ -1972,7 +1970,7 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "Balance ChangeInput",
+          "name": "BalanceChangeInput",
           "description": null,
           "fields": [
             {
@@ -2829,7 +2827,7 @@
         {
           "kind": "INPUT_OBJECT",
           "name": "PartyBodyInput",
-          "description": "Body component of a snapp Party",
+          "description": "Body component of a party",
           "fields": [
             {
               "name": "publicKey",
@@ -2888,7 +2886,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "Balance ChangeInput",
+                  "name": "BalanceChangeInput",
                   "ofType": null
                 }
               },
@@ -3087,7 +3085,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "Balance ChangeInput",
+                  "name": "BalanceChangeInput",
                   "ofType": null
                 }
               },
@@ -3662,8 +3660,8 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "SnappPartyInput",
-          "description": "A party to a snapp transaction",
+          "name": "ZkappPartyInput",
+          "description": "A party to a zkApp transaction",
           "fields": [
             {
               "name": "data",
@@ -3746,7 +3744,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "SnappPartyFeePayerInput",
+                  "name": "ZkappPartyFeePayerInput",
                   "ofType": null
                 }
               },
@@ -3768,7 +3766,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "SnappPartyInput",
+                      "name": "ZkappPartyInput",
                       "ofType": null
                     }
                   }
@@ -3803,7 +3801,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "SnappPartyFeePayerInput",
+                  "name": "ZkappPartyFeePayerInput",
                   "ofType": null
                 }
               },
@@ -3823,7 +3821,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "SnappPartyInput",
+                      "name": "ZkappPartyInput",
                       "ofType": null
                     }
                   }
@@ -7825,7 +7823,7 @@
         },
         {
           "kind": "OBJECT",
-          "name": "Balance Change",
+          "name": "BalanceChange",
           "description": null,
           "fields": [
             {
@@ -7869,7 +7867,7 @@
         {
           "kind": "OBJECT",
           "name": "PartyBody",
-          "description": "Body component of a snapp Party",
+          "description": "Body component of a party",
           "fields": [
             {
               "name": "publicKey",
@@ -7928,7 +7926,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "Balance Change",
+                  "name": "BalanceChange",
                   "ofType": null
                 }
               },
@@ -8126,8 +8124,8 @@
         },
         {
           "kind": "OBJECT",
-          "name": "SnappParty",
-          "description": "A party to a snapp transaction",
+          "name": "ZkappParty",
+          "description": "A party to a zkApp transaction",
           "fields": [
             {
               "name": "data",
@@ -9008,7 +9006,7 @@
         {
           "kind": "OBJECT",
           "name": "VerificationKeyWithHash",
-          "description": "Verification key with hash",
+          "description": null,
           "fields": [
             {
               "name": "data",
@@ -9160,7 +9158,7 @@
         {
           "kind": "OBJECT",
           "name": "FeePayerPartyBody",
-          "description": "Body component of a snapp Fee Payer Party",
+          "description": "Body component of a party",
           "fields": [
             {
               "name": "publicKey",
@@ -9370,9 +9368,8 @@
         },
         {
           "kind": "OBJECT",
-          "name": "SnappPartyPredicatedFeePayer",
-          "description":
-            "A party to a snapp transaction with a nonce predicate",
+          "name": "ZkappPartyPredicatedFeePayer",
+          "description": null,
           "fields": [
             {
               "name": "body",
@@ -9414,9 +9411,8 @@
         },
         {
           "kind": "OBJECT",
-          "name": "SnappPartyFeePayer",
-          "description":
-            "A party to a snapp transaction with a signature authorization",
+          "name": "ZkappPartyFeePayer",
+          "description": null,
           "fields": [
             {
               "name": "data",
@@ -9427,7 +9423,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "SnappPartyPredicatedFeePayer",
+                  "name": "ZkappPartyPredicatedFeePayer",
                   "ofType": null
                 }
               },
@@ -9470,7 +9466,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "SnappPartyFeePayer",
+                  "name": "ZkappPartyFeePayer",
                   "ofType": null
                 }
               },
@@ -9492,7 +9488,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "SnappParty",
+                      "name": "ZkappParty",
                       "ofType": null
                     }
                   }

--- a/src/lib/currency/dune
+++ b/src/lib/currency/dune
@@ -35,6 +35,7 @@
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps
+   ppx_annot
    ppx_coda
    ppx_version
    ppx_let

--- a/src/lib/currency/signed_poly.ml
+++ b/src/lib/currency/signed_poly.ml
@@ -4,7 +4,7 @@ open Core_kernel
 module Stable = struct
   module V1 = struct
     type ('magnitude, 'sgn) t = { magnitude : 'magnitude; sgn : 'sgn }
-    [@@deriving sexp, hash, compare, equal, yojson, fields]
+    [@@deriving annot, sexp, hash, compare, equal, yojson, fields]
   end
 end]
 

--- a/src/lib/fields_derivers/dune
+++ b/src/lib/fields_derivers/dune
@@ -1,7 +1,7 @@
 (library
  (name fields_derivers)
  (public_name fields_derivers)
- (libraries core_kernel ppx_inline_test.config fieldslib)
+ (libraries core_kernel ppx_inline_test.config fieldslib sexplib0 base.caml)
  (instrumentation (backend bisect_ppx))
  (inline_tests)
- (preprocess (pps ppx_jane ppx_fields_conv ppx_let ppx_inline_test ppx_custom_printf ppx_version)))
+ (preprocess (pps ppx_annot ppx_jane ppx_fields_conv ppx_let ppx_inline_test ppx_custom_printf ppx_version)))

--- a/src/lib/fields_derivers_graphql/dune
+++ b/src/lib/fields_derivers_graphql/dune
@@ -16,4 +16,4 @@
  )
  (instrumentation (backend bisect_ppx))
  (inline_tests)
- (preprocess (pps ppx_jane ppx_fields_conv ppx_let ppx_inline_test ppx_custom_printf ppx_version)))
+ (preprocess (pps ppx_annot ppx_jane ppx_fields_conv ppx_let ppx_inline_test ppx_custom_printf ppx_version)))

--- a/src/lib/fields_derivers_graphql/fields_derivers_graphql.ml
+++ b/src/lib/fields_derivers_graphql/fields_derivers_graphql.ml
@@ -45,17 +45,21 @@ module Graphql_raw = struct
             ('row, 'c, 'ty, 'nullable) Input.t
       end
 
-      let add_field (type f f' ty ty' nullable1 nullable2) :
+      let add_field (type f f' ty ty' nullable1 nullable2)
+          ~(annotations : Fields_derivers.Annotations.Fields.t) :
              ('f_row, f', f, nullable1) Input.t
           -> ([< `Read | `Set_and_create ], _, _) Field.t_with_perm
           -> ('row, ty', ty, nullable2) Acc.t
           -> (('row, ty', ty, nullable2) Creator.t -> f')
              * ('row_after, ty', ty, nullable2) Acc.t =
        fun f_input field acc ->
+        let annotations = annotations (Field.name field) in
         let ref_as_pipe = ref None in
         let arg =
           Schema.Arg.arg
-            (Fields_derivers.name_under_to_camel field)
+            (Option.value annotations.name
+               ~default:(Fields_derivers.name_under_to_camel field))
+            ?doc:annotations.doc
             ~typ:(!(f_input#graphql_arg) ())
         in
         let () =
@@ -94,7 +98,8 @@ module Graphql_raw = struct
         ( (fun _creator_input -> !(f_input#map) @@ Option.value_exn !ref_as_pipe)
         , acc )
 
-      let finish ?doc ~name (type ty result nullable) :
+      let finish ~(annotations : Fields_derivers.Annotations.Top.t)
+          (type ty result nullable) :
              (('row, result, ty, nullable) Input.t -> result)
              * ('row, result, ty, nullable) Acc.t
           -> _ Output.t =
@@ -110,8 +115,9 @@ module Graphql_raw = struct
                   * expression and remove Obj.magic. *)
                  Obj.magic
                  @@ Schema.Arg.(
-                      obj ?doc (name ^ "Input") ~fields:graphql_arg_fields
-                        ~coerce:graphql_arg_coerce
+                      obj ?doc:annotations.doc
+                        (annotations.name ^ "Input")
+                        ~fields:graphql_arg_fields ~coerce:graphql_arg_coerce
                       |> non_null)) ;
         (acc#nullable_graphql_arg :=
            fun () ->
@@ -122,8 +128,9 @@ module Graphql_raw = struct
                  (* TODO: See above *)
                  Obj.magic
                  @@ Schema.Arg.(
-                      obj ?doc (name ^ "Input") ~fields:graphql_arg_fields
-                        ~coerce:graphql_arg_coerce)) ;
+                      obj ?doc:annotations.doc
+                        (annotations.name ^ "Input")
+                        ~fields:graphql_arg_fields ~coerce:graphql_arg_coerce)) ;
         acc
 
       let int obj =
@@ -202,33 +209,41 @@ module Graphql_raw = struct
             ('input_type, 'a, 'c, 'nullable) Input.t
       end
 
-      let add_field (type f input_type orig nullable c' nullable') :
+      let add_field (type f input_type orig nullable c' nullable')
+          ~(annotations : Fields_derivers.Annotations.Fields.t) :
              (orig, 'a, f, nullable) Input.t
           -> ([< `Read | `Set_and_create ], c', f) Fieldslib.Field.t_with_perm
           -> (input_type, 'row2, c', nullable') Accumulator.t
           -> (_ -> f) * (input_type, 'row2, c', nullable') Accumulator.t =
        fun t_field field acc ->
         let rest = !(acc#graphql_fields_accumulator) in
+        let annotations = annotations (Field.name field) in
         acc#graphql_fields_accumulator :=
           { Accumulator.T.run =
               (fun () ->
                 Schema.field
-                  (Fields_derivers.name_under_to_camel field)
+                  (Option.value annotations.name
+                     ~default:(Fields_derivers.name_under_to_camel field))
                   ~args:Schema.Arg.[]
-                  ?doc:None ?deprecated:None
+                  ?doc:annotations.doc
+                  ~deprecated:
+                    ( Option.map annotations.deprecated ~f:(fun msg ->
+                          Schema.Deprecated (Some msg))
+                    |> Option.value ~default:Schema.NotDeprecated )
                   ~typ:(!(t_field#graphql_fields).Input.T.run ())
                   ~resolve:(fun _ x -> !(t_field#contramap) (Field.get field x)))
           }
           :: rest ;
         ((fun _ -> failwith "Unused"), acc)
 
-      let finish ~name ?doc ((_creator, obj) : 'u * _ Accumulator.t) : _ Input.t
-          =
+      let finish ~(annotations : Fields_derivers.Annotations.Top.t)
+          ((_creator, obj) : 'u * _ Accumulator.t) : _ Input.t =
         let graphql_fields_accumulator = !(obj#graphql_fields_accumulator) in
         let graphql_fields =
           { Input.T.run =
               (fun () ->
-                Schema.obj name ?doc ~fields:(fun _ ->
+                Schema.obj annotations.name ?doc:annotations.doc
+                  ~fields:(fun _ ->
                     List.rev
                     @@ List.map graphql_fields_accumulator ~f:(fun g ->
                            g.Accumulator.T.run ()))
@@ -238,7 +253,8 @@ module Graphql_raw = struct
         let nullable_graphql_fields =
           { Input.T.run =
               (fun () ->
-                Schema.obj name ?doc ~fields:(fun _ ->
+                Schema.obj annotations.name ?doc:annotations.doc
+                  ~fields:(fun _ ->
                     List.rev
                     @@ List.map graphql_fields_accumulator ~f:(fun g ->
                            g.Accumulator.T.run ())))
@@ -346,11 +362,15 @@ module Graphql_query = struct
       constraint 'a t = 'a Input.t
   end
 
-  let add_field : 'a Input.t -> 'field -> 'obj -> 'creator * 'obj =
+  let add_field ~(annotations : Fields_derivers.Annotations.Fields.t) :
+      'a Input.t -> 'field -> 'obj -> 'creator * 'obj =
    fun t_field field acc_obj ->
+    let annotations = annotations (Field.name field) in
     let rest = !(acc_obj#graphql_query_accumulator) in
     acc_obj#graphql_query_accumulator :=
-      (Fields_derivers.name_under_to_camel field, !(t_field#graphql_query))
+      ( Option.value annotations.name
+          ~default:(Fields_derivers.name_under_to_camel field)
+      , !(t_field#graphql_query) )
       :: rest ;
     ((fun _ -> failwith "unused"), acc_obj)
 
@@ -497,11 +517,12 @@ let%test_module "Test" =
 
     let o () = deriver ()
 
-    let raw_server q c =
+    let raw_server ?(print = false) q c =
       let schema = Schema.(schema [ q ] ~mutations:[] ~subscriptions:[]) in
       let res = Schema.execute schema () c in
       match res with
       | Ok (`Response data) ->
+          if print then Yojson.Basic.pretty_print Format.std_formatter data ;
           data |> Yojson.Basic.to_string
       | Error err ->
           failwithf "Unexpected error: %s" (Yojson.Basic.to_string err) ()
@@ -518,7 +539,7 @@ let%test_module "Test" =
     let query_for_all typ v str =
       raw_server (query_schema typ v) (Test.parse_query str)
 
-    let hit_server q = raw_server q (Test.introspection_query ())
+    let hit_server ?print q = raw_server ?print q (Test.introspection_query ())
 
     let hit_server_query (typ : _ Schema.typ) v =
       hit_server (query_schema typ v)
@@ -532,18 +553,22 @@ let%test_module "Test" =
             ~resolve:(fun _ _ _ -> 0))
 
     module T1 = struct
-      type t = { foo_hello : int option; bar : string list } [@@deriving fields]
+      (** T1 is foo *)
+      type t = { foo_hello : int option; bar : string list [@name "bar1"] }
+      [@@deriving annot, fields]
 
       let _v = { foo_hello = Some 1; bar = [ "baz1"; "baz2" ] }
 
+      let doc = "T1 is foo"
+
       let manual_typ =
         Schema.(
-          obj "T1" ?doc:None ~fields:(fun _ ->
+          obj "T1" ~doc ~fields:(fun _ ->
               [ field "fooHello"
                   ~args:Arg.[]
                   ~typ:int
                   ~resolve:(fun _ t -> t.foo_hello)
-              ; field "bar"
+              ; field "bar1"
                   ~args:Arg.[]
                   ~typ:(non_null (list (non_null string)))
                   ~resolve:(fun _ t -> t.bar)
@@ -551,35 +576,59 @@ let%test_module "Test" =
 
       let derived init =
         let open Graphql_fields in
-        let ( !. ) x fd acc = add_field (x (o ())) fd acc in
+        let ( !. ) x fd acc =
+          add_field
+            ~annotations:
+              (Fields_derivers.Annotations.Fields.of_annots t_fields_annots)
+            (x (o ()))
+            fd acc
+        in
         Fields.make_creator init
           ~foo_hello:!.(option @@ int @@ o ())
           ~bar:!.(list @@ string @@ o ())
-        |> finish ~name:"T1" ?doc:None
+        |> finish
+             ~annotations:
+               (Fields_derivers.Annotations.Top.of_annots t_toplevel_annots
+                  ~name:"T1")
 
       module Args = struct
         let manual_typ =
           Schema.Arg.(
-            obj "T1_argInput" ?doc:None
+            obj "T1Input" ~doc
               ~fields:
-                [ arg "bar" ~typ:(non_null (list (non_null string)))
+                [ arg "bar1" ~typ:(non_null (list (non_null string)))
                 ; arg "fooHello" ~typ:int
                 ]
               ~coerce:(fun bar foo_hello -> { bar; foo_hello }))
 
         let derived init =
           let open Graphql_args in
-          let ( !. ) x fd acc = add_field (x (o ())) fd acc in
+          let ( !. ) x fd acc =
+            add_field
+              ~annotations:
+                (Fields_derivers.Annotations.Fields.of_annots t_fields_annots)
+              (x (o ()))
+              fd acc
+          in
           Fields.make_creator init
             ~foo_hello:!.(option @@ int @@ o ())
             ~bar:!.(list @@ string @@ o ())
-          |> finish ~name:"T1_arg" ?doc:None
+          |> finish
+               ~annotations:
+                 (Fields_derivers.Annotations.Top.of_annots t_toplevel_annots
+                    ~name:"T1")
       end
 
       module Query = struct
         let derived init =
           let open Graphql_query in
-          let ( !. ) x fd acc = add_field (x (o ())) fd acc in
+          let ( !. ) x fd acc =
+            add_field
+              ~annotations:
+                (Fields_derivers.Annotations.Fields.of_annots t_fields_annots)
+              (x (o ()))
+              fd acc
+          in
           Fields.make_creator init
             ~foo_hello:!.(option @@ int @@ o ())
             ~bar:!.(list @@ string @@ o ())
@@ -616,7 +665,7 @@ let%test_module "Test" =
     end
 
     module T2 = struct
-      type t = { foo : T1.t Or_ignore_test.t } [@@deriving fields]
+      type t = { foo : T1.t Or_ignore_test.t } [@@deriving annot, fields]
 
       let v1 =
         { foo = Check { T1.foo_hello = Some 1; bar = [ "baz1"; "baz2" ] } }
@@ -634,24 +683,42 @@ let%test_module "Test" =
 
       let derived init =
         let open Graphql_fields in
-        let ( !. ) x fd acc = add_field (x (o ())) fd acc in
+        let ( !. ) x fd acc =
+          add_field
+            ~annotations:
+              (Fields_derivers.Annotations.Fields.of_annots t_fields_annots)
+            (x (o ()))
+            fd acc
+        in
         Fields.make_creator init
           ~foo:!.(Or_ignore_test.derived @@ T1.derived @@ o ())
-        |> finish ~name:"T2" ?doc:None
+        |> finish
+             ~annotations:
+               (Fields_derivers.Annotations.Top.of_annots t_toplevel_annots
+                  ~name:"T2")
 
       module Args = struct
         let manual_typ =
           Schema.Arg.(
-            obj "T2_argInput" ?doc:None
+            obj "T2Input" ?doc:None
               ~fields:[ arg "foo" ~typ:T1.Args.manual_typ ] ~coerce:(fun foo ->
                 Or_ignore_test.of_option foo))
 
         let derived init =
           let open Graphql_args in
-          let ( !. ) x fd acc = add_field (x (o ())) fd acc in
+          let ( !. ) x fd acc =
+            add_field
+              ~annotations:
+                (Fields_derivers.Annotations.Fields.of_annots t_fields_annots)
+              (x (o ()))
+              fd acc
+          in
           Fields.make_creator init
             ~foo:!.(Or_ignore_test.Args.derived @@ T1.Args.derived @@ o ())
-          |> finish ~name:"T2_arg" ?doc:None
+          |> finish
+               ~annotations:
+                 (Fields_derivers.Annotations.Top.of_annots t_toplevel_annots
+                    ~name:"T2")
       end
 
       module Query = struct
@@ -660,14 +727,20 @@ let%test_module "Test" =
             {
               foo {
                 fooHello
-                bar
+                bar1
               }
             }
           |}
 
         let derived init =
           let open Graphql_query in
-          let ( !. ) x fd acc = add_field (x (o ())) fd acc in
+          let ( !. ) x fd acc =
+            add_field
+              ~annotations:
+                (Fields_derivers.Annotations.Fields.of_annots t_fields_annots)
+              (x (o ()))
+              fd acc
+          in
           Fields.make_creator init
             ~foo:!.(Or_ignore_test.Query.derived @@ T1.Query.derived @@ o ())
           |> finish

--- a/src/lib/fields_derivers_json/dune
+++ b/src/lib/fields_derivers_json/dune
@@ -13,4 +13,4 @@
  )
  (instrumentation (backend bisect_ppx))
  (inline_tests)
- (preprocess (pps ppx_deriving_yojson ppx_jane ppx_fields_conv ppx_let ppx_inline_test ppx_custom_printf ppx_version)))
+ (preprocess (pps ppx_annot ppx_deriving_yojson ppx_jane ppx_fields_conv ppx_let ppx_inline_test ppx_custom_printf ppx_version)))

--- a/src/lib/fields_derivers_snapps/dune
+++ b/src/lib/fields_derivers_snapps/dune
@@ -29,6 +29,7 @@
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps
+   ppx_annot
    ppx_deriving_yojson
    ppx_optcomp
    ppx_base

--- a/src/lib/mina_base/control.ml
+++ b/src/lib/mina_base/control.ml
@@ -100,14 +100,15 @@ module As_record = struct
     { proof : Pickles.Side_loaded.Proof.t option
     ; signature : Signature.t option
     }
-  [@@deriving fields]
+  [@@deriving annot, fields]
 
   let deriver obj =
     let open Fields_derivers_snapps in
+    let ( !. ) = ( !. ) ~t_fields_annots in
     Fields.make_creator obj
       ~proof:!.(option @@ proof @@ o ())
       ~signature:!.(option @@ signature_deriver @@ o ())
-    |> finish ~name:"Control"
+    |> finish "Control" ~t_toplevel_annots
 end
 
 let to_record = function

--- a/src/lib/mina_base/dune
+++ b/src/lib/mina_base/dune
@@ -69,7 +69,7 @@
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_snarky ppx_here ppx_coda ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord
+  (pps ppx_annot ppx_snarky ppx_here ppx_coda ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord
        ppx_base ppx_bench ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test h_list.ppx
  ))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/mina_base/epoch_data.ml
+++ b/src/lib/mina_base/epoch_data.ml
@@ -19,7 +19,7 @@ module Poly = struct
         ; lock_checkpoint : 'lock_checkpoint
         ; epoch_length : 'length
         }
-      [@@deriving hlist, sexp, equal, compare, hash, yojson, fields]
+      [@@deriving annot, hlist, sexp, equal, compare, hash, yojson, fields]
     end
   end]
 end

--- a/src/lib/mina_base/epoch_ledger.ml
+++ b/src/lib/mina_base/epoch_ledger.ml
@@ -8,7 +8,7 @@ module Poly = struct
     module V1 = struct
       type ('ledger_hash, 'amount) t =
         { hash : 'ledger_hash; total_currency : 'amount }
-      [@@deriving sexp, equal, compare, hash, yojson, hlist, fields]
+      [@@deriving annot, sexp, equal, compare, hash, yojson, hlist, fields]
     end
   end]
 end

--- a/src/lib/mina_base/parties.ml
+++ b/src/lib/mina_base/parties.ml
@@ -201,7 +201,7 @@ module Stable = struct
       ; other_parties : Party.Stable.V1.t list
       ; memo : Signed_command_memo.Stable.V1.t
       }
-    [@@deriving sexp, compare, equal, hash, yojson, fields]
+    [@@deriving annot, sexp, compare, equal, hash, yojson, fields]
 
     let to_latest = Fn.id
 
@@ -427,10 +427,11 @@ let weight (parties : t) : int =
 
 let deriver obj =
   let open Fields_derivers_snapps.Derivers in
+  let ( !. ) = ( !. ) ~t_fields_annots in
   Fields.make_creator obj ~fee_payer:!.Party.Fee_payer.deriver
     ~other_parties:!.(list @@ Party.deriver @@ o ())
     ~memo:!.Signed_command_memo.deriver
-  |> finish ~name:"Parties"
+  |> finish "Parties" ~t_toplevel_annots
 
 let arg_typ () = Fields_derivers_snapps.(arg_typ (deriver @@ Derivers.o ()))
 

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -32,7 +32,7 @@ module Update = struct
           ; vesting_period : Global_slot.Stable.V1.t
           ; vesting_increment : Amount.Stable.V1.t
           }
-        [@@deriving compare, equal, sexp, hash, yojson, hlist, fields]
+        [@@deriving annot, compare, equal, sexp, hash, yojson, hlist, fields]
 
         let to_latest = Fn.id
       end
@@ -167,10 +167,11 @@ module Update = struct
 
     let deriver obj =
       let open Fields_derivers_snapps.Derivers in
+      let ( !. ) = ( !. ) ~t_fields_annots in
       Fields.make_creator obj ~initial_minimum_balance:!.balance
         ~cliff_time:!.global_slot ~cliff_amount:!.amount
         ~vesting_period:!.global_slot ~vesting_increment:!.amount
-      |> finish ~name:"Timing"
+      |> finish "Timing" ~t_toplevel_annots
   end
 
   open Snapp_basic
@@ -195,7 +196,7 @@ module Update = struct
         ; timing : Timing_info.Stable.V1.t Set_or_keep.Stable.V1.t
         ; voting_for : State_hash.Stable.V1.t Set_or_keep.Stable.V1.t
         }
-      [@@deriving compare, equal, sexp, hash, yojson, fields, hlist]
+      [@@deriving annot, compare, equal, sexp, hash, yojson, fields, hlist]
 
       let to_latest = Fn.id
     end
@@ -408,7 +409,8 @@ module Update = struct
 
   let deriver obj =
     let open Fields_derivers_snapps in
-    finish ~name:"PartyUpdate"
+    let ( !. ) = ( !. ) ~t_fields_annots in
+    finish "PartyUpdate" ~t_toplevel_annots
     @@ Fields.make_creator
          ~app_state:!.(Snapp_state.deriver @@ Set_or_keep.deriver field)
          ~delegate:!.(Set_or_keep.deriver public_key)
@@ -459,6 +461,7 @@ module Body = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
+        (** Body component of a party *)
         type ( 'pk
              , 'update
              , 'token_id
@@ -481,7 +484,7 @@ module Body = struct
           ; protocol_state : 'protocol_state
           ; use_full_commitment : 'bool
           }
-        [@@deriving hlist, sexp, equal, yojson, hash, compare, fields]
+        [@@deriving annot, hlist, sexp, equal, yojson, hash, compare, fields]
       end
     end]
   end
@@ -558,6 +561,7 @@ module Body = struct
         iso_string obj ~name:"Fee" ~to_string:Fee.to_string
           ~of_string:Fee.of_string
       in
+      let ( !. ) = ( !. ) ~t_fields_annots:Poly.t_fields_annots in
       Poly.Fields.make_creator obj ~public_key:!.public_key
         ~update:!.Update.deriver ~token_id:!.unit ~balance_change:!.fee
         ~increment_nonce:!.unit
@@ -566,8 +570,7 @@ module Body = struct
         ~call_data:!.field ~call_depth:!.int
         ~protocol_state:!.Snapp_predicate.Protocol_state.deriver
         ~use_full_commitment:!.unit
-      |> finish ~name:"FeePayerPartyBody"
-           ~doc:"Body component of a snapp Fee Payer Party"
+      |> finish "FeePayerPartyBody" ~t_toplevel_annots:Poly.t_toplevel_annots
 
     let%test_unit "json roundtrip" =
       let open Fields_derivers_snapps.Derivers in
@@ -692,10 +695,15 @@ module Body = struct
         iso_string ~name:"Sign" ~to_string:sign_to_string
           ~of_string:sign_of_string
       in
+      let ( !. ) =
+        ( !. ) ~t_fields_annots:Currency.Signed_poly.t_fields_annots
+      in
       Currency.Signed_poly.Fields.make_creator obj ~magnitude:!.amount
         ~sgn:!.sign_deriver
-      |> finish ~name:"Balance Change"
+      |> finish "BalanceChange"
+           ~t_toplevel_annots:Currency.Signed_poly.t_toplevel_annots
     in
+    let ( !. ) = ( !. ) ~t_fields_annots:Poly.t_fields_annots in
     Poly.Fields.make_creator obj ~public_key:!.public_key
       ~update:!.Update.deriver ~token_id:!.token_id_deriver
       ~balance_change:!.balance_change_deriver ~increment_nonce:!.bool
@@ -704,7 +712,7 @@ module Body = struct
       ~call_data:!.field ~call_depth:!.int
       ~protocol_state:!.Snapp_predicate.Protocol_state.deriver
       ~use_full_commitment:!.bool
-    |> finish ~name:"PartyBody" ~doc:"Body component of a snapp Party"
+    |> finish "PartyBody" ~t_toplevel_annots:Poly.t_toplevel_annots
 
   let%test_unit "json roundtrip" =
     let open Fields_derivers_snapps.Derivers in
@@ -875,7 +883,7 @@ module Predicated = struct
     module Stable = struct
       module V1 = struct
         type ('body, 'predicate) t = { body : 'body; predicate : 'predicate }
-        [@@deriving hlist, sexp, equal, yojson, hash, compare, fields]
+        [@@deriving annot, hlist, sexp, equal, yojson, hash, compare, fields]
       end
     end]
   end
@@ -892,9 +900,10 @@ module Predicated = struct
 
   let deriver obj =
     let open Fields_derivers_snapps.Derivers in
+    let ( !. ) = ( !. ) ~t_fields_annots:Poly.t_fields_annots in
     Poly.Fields.make_creator obj ~body:!.Body.deriver
       ~predicate:!.Predicate.deriver
-    |> finish ~name:"SnappPartyPredicated"
+    |> finish "SnappPartyPredicated" ~t_toplevel_annots:Poly.t_toplevel_annots
 
   let to_input ({ body; predicate } : t) =
     List.reduce_exn ~f:Random_oracle_input.Chunked.append
@@ -997,10 +1006,11 @@ module Predicated = struct
 
     let deriver obj =
       let open Fields_derivers_snapps.Derivers in
+      let ( !. ) = ( !. ) ~t_fields_annots:Poly.t_fields_annots in
       Poly.Fields.make_creator obj ~body:!.Body.Fee_payer.deriver
         ~predicate:!.uint32
-      |> finish ~name:"SnappPartyPredicatedFeePayer"
-           ~doc:"A party to a snapp transaction with a nonce predicate"
+      |> finish "ZkappPartyPredicatedFeePayer"
+           ~t_toplevel_annots:Poly.t_toplevel_annots
   end
 
   module Empty = struct
@@ -1074,7 +1084,7 @@ module Fee_payer = struct
         { data : Predicated.Fee_payer.Stable.V1.t
         ; authorization : Signature.Stable.V1.t
         }
-      [@@deriving sexp, equal, yojson, hash, compare, fields]
+      [@@deriving annot, sexp, equal, yojson, hash, compare, fields]
 
       let to_latest = Fn.id
     end
@@ -1090,11 +1100,11 @@ module Fee_payer = struct
 
   let deriver obj =
     let open Fields_derivers_snapps.Derivers in
+    let ( !. ) = ( !. ) ~t_fields_annots in
     Fields.make_creator obj
       ~data:!.Predicated.Fee_payer.deriver
       ~authorization:!.Control.signature_deriver
-    |> finish ~name:"SnappPartyFeePayer"
-         ~doc:"A party to a snapp transaction with a signature authorization"
+    |> finish "ZkappPartyFeePayer" ~t_toplevel_annots
 
   let%test_unit "json roundtrip" =
     let dummy : t =
@@ -1112,7 +1122,7 @@ module Empty = struct
     module V1 = struct
       type t = Poly(Predicated.Empty.Stable.V1)(Unit.Stable.V1).t =
         { data : Predicated.Empty.Stable.V1.t; authorization : unit }
-      [@@deriving sexp, equal, yojson, hash, compare]
+      [@@deriving annot, sexp, equal, yojson, hash, compare]
 
       let to_latest = Fn.id
     end
@@ -1122,9 +1132,10 @@ end
 [%%versioned
 module Stable = struct
   module V1 = struct
+    (** A party to a zkApp transaction *)
     type t = Poly(Predicated.Stable.V1)(Control.Stable.V2).t =
       { data : Predicated.Stable.V1.t; authorization : Control.Stable.V2.t }
-    [@@deriving sexp, equal, yojson, hash, compare, fields]
+    [@@deriving annot, sexp, equal, yojson, hash, compare, fields]
 
     let to_latest = Fn.id
   end
@@ -1162,9 +1173,10 @@ let increment_nonce (t : t) : bool = t.data.body.increment_nonce
 
 let deriver obj =
   let open Fields_derivers_snapps.Derivers in
+  let ( !. ) = ( !. ) ~t_fields_annots in
   Fields.make_creator obj ~data:!.Predicated.deriver
     ~authorization:!.Control.deriver
-  |> finish ~name:"SnappParty" ~doc:"A party to a snapp transaction"
+  |> finish "ZkappParty" ~t_toplevel_annots
 
 let%test_unit "json roundtrip dummy" =
   let dummy : t =

--- a/src/lib/mina_base/permissions.ml
+++ b/src/lib/mina_base/permissions.ml
@@ -320,7 +320,7 @@ module Poly = struct
         ; increment_nonce : 'controller
         ; set_voting_for : 'controller
         }
-      [@@deriving sexp, equal, compare, hash, yojson, hlist, fields]
+      [@@deriving annot, sexp, equal, compare, hash, yojson, hlist, fields]
     end
   end]
 
@@ -494,13 +494,14 @@ let auth_required =
 
 let deriver obj =
   let open Fields_derivers_snapps.Derivers in
+  let ( !. ) = ( !. ) ~t_fields_annots:Poly.t_fields_annots in
   Poly.Fields.make_creator obj ~edit_state:!.auth_required ~send:!.auth_required
     ~receive:!.auth_required ~set_delegate:!.auth_required
     ~set_permissions:!.auth_required ~set_verification_key:!.auth_required
     ~set_snapp_uri:!.auth_required ~edit_sequence_state:!.auth_required
     ~set_token_symbol:!.auth_required ~increment_nonce:!.auth_required
     ~set_voting_for:!.auth_required
-  |> finish ~name:"Permissions"
+  |> finish "Permissions" ~t_toplevel_annots:Poly.t_toplevel_annots
 
 let%test_unit "json roundtrip" =
   let open Fields_derivers_snapps.Derivers in

--- a/src/lib/with_hash/dune
+++ b/src/lib/with_hash/dune
@@ -6,6 +6,7 @@
   (backend bisect_ppx))
  (preprocess
   (pps
+   ppx_annot
    ppx_jane
    ppx_deriving_yojson
    ppx_deriving.std

--- a/src/lib/with_hash/with_hash.ml
+++ b/src/lib/with_hash/with_hash.ml
@@ -6,7 +6,7 @@ module Stable = struct
 
   module V1 = struct
     type ('a, 'h) t = { data : 'a; hash : 'h }
-    [@@deriving sexp, equal, compare, hash, yojson, fields]
+    [@@deriving annot, sexp, equal, compare, hash, yojson, fields]
 
     let to_latest data_latest hash_latest { data; hash } =
       { data = data_latest data; hash = hash_latest hash }
@@ -14,7 +14,7 @@ module Stable = struct
 end]
 
 type ('a, 'h) t = ('a, 'h) Stable.Latest.t = { data : 'a; hash : 'h }
-[@@deriving sexp, equal, compare, hash, yojson]
+[@@deriving annot, sexp, equal, compare, hash, yojson]
 
 let data { data; _ } = data
 

--- a/src/nonconsensus/currency/dune
+++ b/src/nonconsensus/currency/dune
@@ -28,6 +28,6 @@
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_coda ppx_version ppx_let ppx_assert ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp ppx_custom_printf ppx_deriving.std ppx_deriving_yojson h_list.ppx ppx_inline_test ppx_fields_conv))
+  (pps ppx_annot ppx_coda ppx_version ppx_let ppx_assert ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp ppx_custom_printf ppx_deriving.std ppx_deriving_yojson h_list.ppx ppx_inline_test ppx_fields_conv))
  (instrumentation (backend bisect_ppx))
  (synopsis "Currency types"))

--- a/src/nonconsensus/fields_derivers_snapps/dune
+++ b/src/nonconsensus/fields_derivers_snapps/dune
@@ -28,6 +28,7 @@
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps
+   ppx_annot
    ppx_deriving_yojson
    ppx_optcomp
    ppx_base

--- a/src/nonconsensus/mina_base/dune
+++ b/src/nonconsensus/mina_base/dune
@@ -49,7 +49,7 @@
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_coda ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord
+  (pps ppx_annot ppx_coda ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord
        ppx_base ppx_bench ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson h_list.ppx ppx_inline_test
  ))
  (instrumentation (backend bisect_ppx))


### PR DESCRIPTION
Explain your changes:
* Uses `ppx_annot` to pull annotations into derivers
* Looks for `name` and `doc` on both top-level and fields and `depr` (deprecated) and `skip` on fields
* Note: I thought about sticking the relevant derived annots into the "god object" that the rest of the derivers rely on, but it's syntactically awkward to inject it in. The approach taken here to change the DSL seems the least syntactically messy.
* This PR doesn't address: Using `skip` nor actually thoroughly renaming/documenting the structures. These will be addressed in follow-up PRs

Explain how you tested your changes:
* Unit tests in the annots parsers
* Adjust fields_derivers_* tests to use annotations
* Full e2e party derivers tests pass

Closes #10485 
