### PR TITLE
[deb-s3] Do not lock while uploading (unique) .deb files

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -2,10 +2,10 @@
 -- NOTE: minaToolchainStretch is also used for building Ubuntu Bionic packages in CI
 {
   toolchainBase = "codaprotocol/ci-toolchain-base:v3",
-  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:8a67b7e0ce956f961c656eae15588db0b4a3841cab9fd0b81c5a513b8604cf5a",
-  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:db7af91a3c979eb8a9c3bd852ce5ab52b73a9cc24d74b453c2d01605ce5a35f9",
-  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@sha256:bfa9a77e31d06f14ef4ecbb9131ab50ac5c6c5b95b9a52d0e4b70071d876b613",
-  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@sha256:0c2e2e7e7906a3a801c0126671305c0dad3391db37e48bcfb6e9e2567472301b",
+  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:ed8d107ec52af0e33307105bea67567eded51c4db06956af389bbdf305c91b8a",
+  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:5efd404184a292826ec1130919a7df46c97d2fd756fffefca112a08683af0518",
+  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@sha256:99a98309104230dbaad6074e0c226e78f8b4c973edd5fed624f3817a24b56a62",
+  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@sha256:75a0f3f3fb870505ce30e8b8a0929f9f1c60e554869a72a42f9d5fb508e7bac5",
   delegationBackendToolchain = "gcr.io/o1labs-192920/delegation-backend-production@sha256:8ca5880845514ef56a36bf766a0f9de96e6200d61b51f80d9f684a0ec9c031f4",
   elixirToolchain = "elixir:1.10-alpine",
   rustToolchain = "codaprotocol/coda:toolchain-rust-e855336d087a679f76f2dd2bbdc3fdfea9303be3",

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -74,9 +74,10 @@ RUN test "$deb_codename" = "buster" \
       || exit 0
 
 # --- deb-s3 tool
-RUN curl -sLO https://github.com/deb-s3/deb-s3/releases/download/0.11.3/deb-s3-0.11.3.gem \
-    && sudo gem install deb-s3-0.11.3.gem \
-    && rm -f deb-s3-0.11.3.gem
+# tweag version, with lock only on manifest upload
+RUN curl -sLO https://github.com/tweag/deb-s3/releases/download/0.11.4/deb-s3-0.11.4.gem \
+    && sudo gem install deb-s3-0.11.4.gem \
+    && rm -f deb-s3-0.11.4.gem
 
 # --- Docker Daemon
 RUN curl -L -o /tmp/docker-${DOCKER_VERSION}.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz \


### PR DESCRIPTION
Explain your changes:
* Use [tweag's](https://github.com/tweag/deb-s3) version of deb-s3, which do not lock during .deb upload. An attempt to avoid long locks during CI builds. The lock is still held during retrieval/update of the package lists, but released before uploading the packages themselves.
* Use the rebuilt debian Docker images for Buildkite

Explain how you tested your changes:
* Tested multiple parallel jobs on a test S3 bucket with firefox .deb.
* See also the CI for this PR