### PR TITLE
Move Parties_logic out of Mina_base

### DIFF
--- a/src/lib/block_producer/dune
+++ b/src/lib/block_producer/dune
@@ -31,6 +31,7 @@
    mina_intf
    mina_ledger
    mina_base
+   mina_transaction_logic
    mina_transition
    consensus
    interruptible

--- a/src/lib/blockchain_snark/dune
+++ b/src/lib/blockchain_snark/dune
@@ -23,6 +23,7 @@
    snarky.backendless
    snark_params
    mina_base
+   mina_transaction_logic
    mina_state
    pickles_types
    pickles

--- a/src/lib/bootstrap_controller/dune
+++ b/src/lib/bootstrap_controller/dune
@@ -34,6 +34,7 @@
    mina_transition
    mina_base
    mina_ledger
+   mina_transaction_logic
    syncable_ledger
    consensus
    mina_networking

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -47,6 +47,7 @@
    consensus.vrf
    snarky_taylor
    mina_base
+   mina_transaction_logic
    key_gen
    block_time
    perf_histograms

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -34,7 +34,7 @@ module type Blockchain_state = sig
     type t =
       ( Staged_ledger_hash.t
       , Frozen_ledger_hash.t
-      , Parties_logic.Local_state.Value.t
+      , Mina_transaction_logic.Parties_logic.Local_state.Value.t
       , Block_time.t )
       Poly.t
     [@@deriving sexp]
@@ -43,7 +43,7 @@ module type Blockchain_state = sig
   type var =
     ( Staged_ledger_hash.var
     , Frozen_ledger_hash.var
-    , Parties_logic.Local_state.Checked.t
+    , Mina_transaction_logic.Parties_logic.Local_state.Checked.t
     , Block_time.Checked.t )
     Poly.t
 

--- a/src/lib/ledger_proof/dune
+++ b/src/lib/ledger_proof/dune
@@ -12,6 +12,7 @@
    transaction_snark
    mina_base
    mina_state
+   mina_transaction_logic
 )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_bin_prot ppx_sexp_conv ppx_hash ppx_compare ppx_version ppx_deriving_yojson)))

--- a/src/lib/mina_base/mina_base.ml
+++ b/src/lib/mina_base/mina_base.ml
@@ -25,7 +25,6 @@ module Ledger_hash_intf = Ledger_hash_intf
 module Ledger_hash_intf0 = Ledger_hash_intf0
 module Ledger_intf = Ledger_intf
 module Parties = Parties
-module Parties_logic = Parties_logic
 module Party = Party
 module Payment_payload = Payment_payload
 module Pending_coinbase = Pending_coinbase

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -228,7 +228,7 @@ val apply_parties_unchecked :
          , bool
          , unit
          , Transaction_status.Failure.t option )
-         Parties_logic.Local_state.t
+         Mina_transaction_logic.Parties_logic.Local_state.t
        * Currency.Amount.Signed.t ) )
      Or_error.t
 

--- a/src/lib/mina_state/dune
+++ b/src/lib/mina_state/dune
@@ -24,6 +24,7 @@
    genesis_constants
    block_time
    mina_base
+   mina_transaction_logic
    snark_params
    consensus
    bitstring_lib

--- a/src/lib/mina_state/local_state.ml
+++ b/src/lib/mina_state/local_state.ml
@@ -2,7 +2,8 @@ open Core_kernel
 open Currency
 open Mina_base
 module Impl = Pickles.Impls.Step
-include Parties_logic.Local_state.Value
+
+include Mina_transaction_logic.Parties_logic.Local_state.Value
 
 type display =
   ( string
@@ -13,7 +14,7 @@ type display =
   , bool
   , string
   , string )
-  Parties_logic.Local_state.t
+  Mina_transaction_logic.Parties_logic.Local_state.t
 [@@deriving yojson]
 
 let display
@@ -32,7 +33,7 @@ let display
     Visualization.display_prefix_of_string
       Kimchi_backend.Pasta.Basic.(Bigint256.to_hex_string (Fp.to_bigint x))
   in
-  { Parties_logic.Local_state.parties = f parties
+  { Mina_transaction_logic.Parties_logic.Local_state.parties = f parties
   ; call_stack = f call_stack
   ; transaction_commitment = f transaction_commitment
   ; full_transaction_commitment = f full_transaction_commitment
@@ -74,7 +75,7 @@ let gen : t Quickcheck.Generator.t =
     let%bind failure = Transaction_status.Failure.gen in
     Quickcheck.Generator.of_list [ None; Some failure ]
   in
-  { Parties_logic.Local_state.parties
+  { Mina_transaction_logic.Parties_logic.Local_state.parties
   ; call_stack
   ; transaction_commitment
   ; full_transaction_commitment = transaction_commitment
@@ -111,7 +112,8 @@ let to_input
 
 module Checked = struct
   open Impl
-  include Parties_logic.Local_state.Checked
+
+  include Mina_transaction_logic.Parties_logic.Local_state.Checked
 
   let assert_equal (t1 : t) (t2 : t) =
     let ( ! ) f x y = Impl.run_checked (f x y) in
@@ -119,8 +121,8 @@ module Checked = struct
       Impl.with_label (Core_kernel.Field.name f) (fun () ->
           Core_kernel.Field.(eq (get f t1) (get f t2)))
     in
-    Parties_logic.Local_state.Fields.iter ~parties:(f Field.Assert.equal)
-      ~call_stack:(f Field.Assert.equal)
+    Mina_transaction_logic.Parties_logic.Local_state.Fields.iter
+      ~parties:(f Field.Assert.equal) ~call_stack:(f Field.Assert.equal)
       ~transaction_commitment:(f Field.Assert.equal)
       ~full_transaction_commitment:(f Field.Assert.equal)
       ~token_id:(f Token_id.Checked.Assert.equal)
@@ -132,8 +134,9 @@ module Checked = struct
   let equal' (t1 : t) (t2 : t) =
     let ( ! ) f x y = Impl.run_checked (f x y) in
     let f eq acc f = Core_kernel.Field.(eq (get f t1) (get f t2)) :: acc in
-    Parties_logic.Local_state.Fields.fold ~init:[] ~parties:(f Field.equal)
-      ~call_stack:(f Field.equal) ~transaction_commitment:(f Field.equal)
+    Mina_transaction_logic.Parties_logic.Local_state.Fields.fold ~init:[]
+      ~parties:(f Field.equal) ~call_stack:(f Field.equal)
+      ~transaction_commitment:(f Field.equal)
       ~full_transaction_commitment:(f Field.equal)
       ~token_id:(f Token_id.Checked.equal)
       ~excess:(f !Currency.Amount.Checked.equal)
@@ -178,7 +181,7 @@ let failure_status_typ : (unit, Transaction_status.Failure.t option) Impl.Typ.t
     ~back:(fun () -> None)
 
 let typ : (Checked.t, t) Impl.Typ.t =
-  let open Parties_logic.Local_state in
+  let open Mina_transaction_logic.Parties_logic.Local_state in
   let open Impl in
   Typ.of_hlistable
     [ Field.typ

--- a/src/lib/staged_ledger/dune
+++ b/src/lib/staged_ledger/dune
@@ -37,6 +37,7 @@
    transaction_snark_scan_state
    sgn
    mina_base
+   mina_transaction_logic
    verifier
    staged_ledger_diff
    signature_lib

--- a/src/lib/transaction_logic/dune
+++ b/src/lib/transaction_logic/dune
@@ -39,15 +39,20 @@
    random_oracle_input
    signature_lib
    sgn
+   snarky.backendless
    snark_params
    unsigned_extended
    with_hash)
  (instrumentation (backend bisect_ppx))
  (preprocess
   (pps
+   h_list.ppx
    ppx_assert
    ppx_compare
    ppx_custom_printf
+   ppx_deriving_yojson
+   ppx_fields_conv
    ppx_let
+   ppx_hash
    ppx_sexp_conv
    ppx_version)))

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open Mina_base
 open Currency
 open Signature_lib
+module Parties_logic = Parties_logic
 module Global_slot = Mina_numbers.Global_slot
 
 module Transaction_applied = struct
@@ -2244,8 +2245,8 @@ module For_tests = struct
   module Init_ledger = struct
     type t = (Keypair.t * int) array [@@deriving sexp]
 
-    let init (type l) (module L : Ledger_intf.S with type t = l) (init_ledger : t)
-        (l : L.t) =
+    let init (type l) (module L : Ledger_intf.S with type t = l)
+        (init_ledger : t) (l : L.t) =
       Array.iter init_ledger ~f:(fun (kp, amount) ->
           let _tag, account, loc =
             L.get_or_create l

--- a/src/lib/transaction_logic/parties_logic.ml
+++ b/src/lib/transaction_logic/parties_logic.ml
@@ -1,6 +1,7 @@
 (* parties_logic.ml *)
 
 open Core_kernel
+open Mina_base
 
 module type Iffable = sig
   type bool

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1462,7 +1462,7 @@ module Base = struct
             -> (t, Field.Constant.t) With_stack_hash.t list
             -> (t, Field.Constant.t) With_stack_hash.t list
         end) :
-          Parties_logic.Stack_intf
+          Mina_transaction_logic.Parties_logic.Stack_intf
             with type elt = (Elt.t V.t, Field.t) With_hash.t
              and type t =
                   ( (Elt.t, Field.Constant.t) With_stack_hash.t list V.t
@@ -1803,7 +1803,7 @@ module Base = struct
             , Bool.t
             , Transaction_commitment.t
             , Bool.failure_status )
-            Parties_logic.Local_state.t
+            Mina_transaction_logic.Parties_logic.Local_state.t
 
           let add_check (t : t) _failure b =
             { t with success = Bool.(t.success &&& b) }
@@ -1858,7 +1858,7 @@ module Base = struct
               , Bool.t
               , Transaction_commitment.t
               , unit )
-              Parties_logic.Local_state.t
+              Mina_transaction_logic.Parties_logic.Local_state.t
           ; protocol_state_predicate : Snapp_predicate.Protocol_state.Checked.t
           ; transaction_commitment : Transaction_commitment.t
           ; full_transaction_commitment : Transaction_commitment.t
@@ -1866,9 +1866,10 @@ module Base = struct
           ; failure : unit >
       end
 
-      include Parties_logic.Make (Inputs)
+      include Mina_transaction_logic.Parties_logic.Make (Inputs)
 
-      let perform (type r) (eff : (r, Env.t) Parties_logic.Eff.t) : r =
+      let perform (type r)
+          (eff : (r, Env.t) Mina_transaction_logic.Parties_logic.Eff.t) : r =
         match eff with
         | Check_protocol_state_predicate (protocol_state_predicate, global_state)
           ->
@@ -1939,7 +1940,9 @@ module Base = struct
              statement.source.pending_coinbase_stack
            ~pending_coinbase_stack_after:statement.target.pending_coinbase_stack
            state_body) ;
-      let init : Global_state.t * _ Parties_logic.Local_state.t =
+      let init :
+          Global_state.t * _ Mina_transaction_logic.Parties_logic.Local_state.t
+          =
         let g : Global_state.t =
           { ledger =
               ( statement.source.ledger
@@ -1949,7 +1952,7 @@ module Base = struct
               Mina_state.Protocol_state.Body.view_checked state_body
           }
         in
-        let l : _ Parties_logic.Local_state.t =
+        let l : _ Mina_transaction_logic.Parties_logic.Local_state.t =
           { parties =
               { With_hash.hash = statement.source.local_state.parties
               ; data = V.create (fun () -> !witness.local_state_init.parties)
@@ -1998,7 +2001,7 @@ module Base = struct
               let snapp_statement = snapp_statement
             end) in
             let finish v =
-              let open Parties_logic.Start_data in
+              let open Mina_transaction_logic.Parties_logic.Start_data in
               let ps =
                 V.map v ~f:(function
                   | `Skip ->
@@ -2014,7 +2017,7 @@ module Base = struct
                     Parties.Call_forest.hash (V.get ps))
               in
               let start_data =
-                { Parties_logic.Start_data.parties =
+                { Mina_transaction_logic.Parties_logic.Start_data.parties =
                     { With_hash.hash = h; data = ps }
                 ; memo_hash =
                     exists Field.typ ~compute:(fun () ->
@@ -3323,7 +3326,7 @@ type local_state =
   , bool
   , unit
   , Transaction_status.Failure.t option )
-  Parties_logic.Local_state.t
+  Mina_transaction_logic.Parties_logic.Local_state.t
 
 type global_state = Sparse_ledger.Global_state.t
 
@@ -3646,7 +3649,8 @@ let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
   let full_commitment = ref Local_state.dummy.full_transaction_commitment in
   let remaining_parties =
     let partiess =
-      List.map partiess ~f:(fun parties : _ Parties_logic.Start_data.t ->
+      List.map partiess
+        ~f:(fun parties : _ Mina_transaction_logic.Parties_logic.Start_data.t ->
           { parties; memo_hash = Signed_command_memo.hash parties.memo })
     in
     ref partiess
@@ -3731,7 +3735,8 @@ let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
             | _ ->
                 failwith "Not enough remaining parties" )
       in
-      let hash_local_state (local : _ Parties_logic.Local_state.t) =
+      let hash_local_state
+          (local : _ Mina_transaction_logic.Parties_logic.Local_state.t) =
         let hash_parties_stack ps =
           ps |> Parties.Call_forest.accumulate_hashes'
           |> Parties.Call_forest.map ~f:(fun p -> (p, ()))
@@ -3751,7 +3756,8 @@ let parties_witnesses_exn ~constraint_constants ~state_body ~fee_excess
                     ~f:(Parties.Call_forest.map ~f:(fun p -> (p, ()))))
         in
         { local with
-          Parties_logic.Local_state.parties = hash_parties_stack local.parties
+          Mina_transaction_logic.Parties_logic.Local_state.parties =
+            hash_parties_stack local.parties
         ; call_stack
         }
       in

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -344,7 +344,7 @@ type local_state =
   , bool
   , unit
   , Transaction_status.Failure.t option )
-  Parties_logic.Local_state.t
+  Mina_transaction_logic.Parties_logic.Local_state.t
 
 type global_state = Mina_ledger.Sparse_ledger.Global_state.t
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -560,8 +560,8 @@ struct
           "did not connect with pending-coinbase stack"
       and () =
         clarify_error
-          (Parties_logic.Local_state.Value.equal reg1.local_state
-             reg2.local_state)
+          (Mina_transaction_logic.Parties_logic.Local_state.Value.equal
+             reg1.local_state reg2.local_state)
           "did not connect with local state"
       in
       ()

--- a/src/lib/transaction_witness/dune
+++ b/src/lib/transaction_witness/dune
@@ -14,6 +14,7 @@
    mina_ledger
    mina_state
    mina_base
+   mina_transaction_logic
    kimchi_backend
    kimchi_backend.pasta
    )

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -22,11 +22,11 @@ module Parties_segment_witness = struct
             , bool
             , Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t
             , Transaction_status.Failure.Stable.V1.t option )
-            Parties_logic.Local_state.Stable.V1.t
+            Mina_transaction_logic.Parties_logic.Local_state.Stable.V1.t
         ; start_parties :
             ( Parties.Stable.V1.t
             , Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t )
-            Parties_logic.Start_data.Stable.V1.t
+            Mina_transaction_logic.Parties_logic.Start_data.Stable.V1.t
             list
         ; state_body : Mina_state.Protocol_state.Body.Value.Stable.V2.t
         ; init_stack : Mina_base.Pending_coinbase.Stack_versioned.Stable.V1.t

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -22,11 +22,11 @@ module Parties_segment_witness : sig
             , bool
             , Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t
             , Transaction_status.Failure.t option )
-            Parties_logic.Local_state.Stable.V1.t
+            Mina_transaction_logic.Parties_logic.Local_state.Stable.V1.t
         ; start_parties :
             ( Parties.Stable.V1.t
             , Kimchi_backend.Pasta.Basic.Fp.Stable.V1.t )
-            Parties_logic.Start_data.Stable.V1.t
+            Mina_transaction_logic.Parties_logic.Start_data.Stable.V1.t
             list
         ; state_body : Mina_state.Protocol_state.Body.Value.Stable.V2.t
         ; init_stack : Mina_base.Pending_coinbase.Stack_versioned.Stable.V1.t

--- a/src/lib/transition_frontier/frontier_base/dune
+++ b/src/lib/transition_frontier/frontier_base/dune
@@ -31,6 +31,7 @@
    mina_transition
    mina_ledger
    mina_base
+   mina_transaction_logic
    mina_state
    staged_ledger
    data_hash_lib

--- a/src/lib/transition_frontier/persistent_frontier/dune
+++ b/src/lib/transition_frontier/persistent_frontier/dune
@@ -30,6 +30,7 @@
    block_time
    transition_frontier_extensions
    mina_base
+   mina_transaction_logic
    rocksdb
    mina_transition
    mina_state


### PR DESCRIPTION
This PR moves `Parties_logic` out of `Mina_base` and into `Mina_transaction_logic`.

This is some housekeeping prework to allow https://github.com/MinaProtocol/mina/issues/10520 to be implemented without injecting a large number of new modules into Mina_base.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
