### PR TITLE
Move Transaction_hash out of Mina_base

### DIFF
--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -2,6 +2,7 @@
 
 open Core_kernel
 open Mina_base
+open Mina_transaction
 open Signature_lib
 
 (* the tables in the archive db uses foreign keys to refer to other

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -1,6 +1,7 @@
 open Async
 open Core
 open Mina_base
+open Mina_transaction
 open Pipe_lib
 open Signature_lib
 

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2,6 +2,7 @@ open Core
 open Async
 open Signature_lib
 open Mina_base
+open Mina_transaction
 
 module Client = Graphql_lib.Client.Make (struct
   let preprocess_variables_string = Fn.id

--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -11,6 +11,7 @@
 open Js_of_ocaml
 open Signature_lib
 open Mina_base
+open Mina_transaction
 open Rosetta_lib
 open Rosetta_coding
 open Js_util

--- a/src/app/client_sdk/dune
+++ b/src/app/client_sdk/dune
@@ -26,6 +26,7 @@
    random_oracle_nonconsensus
    mina_base_nonconsensus
    mina_base_nonconsensus.import
+   mina_transaction_nonconsensus
    snark_params_nonconsensus
    hex_nonconsensus
    mina_signature_kind

--- a/src/app/extract_blocks/dune
+++ b/src/app/extract_blocks/dune
@@ -25,6 +25,7 @@
    block_time
    mina_numbers
    mina_base
+   mina_transaction
    currency
    unsigned_extended
    error_json

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -3,6 +3,7 @@
 open Core_kernel
 open Async
 open Mina_base
+open Mina_transaction
 open Signature_lib
 open Archive_lib
 

--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -11,7 +11,7 @@ module Public_key = Signature_lib.Public_key
 module Signed_command_payload = Mina_base.Signed_command_payload
 module User_command = Mina_base.User_command
 module Signed_command = Mina_base.Signed_command
-module Transaction_hash = Mina_base.Transaction_hash
+module Transaction_hash = Mina_transaction.Transaction_hash
 
 module Get_options_metadata =
 [%graphql

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -2,6 +2,7 @@ open Core
 open Async
 open Pipe_lib
 open Mina_base
+open Mina_transaction
 open Mina_state
 open Mina_transition
 open O1trace

--- a/src/lib/block_producer/dune
+++ b/src/lib/block_producer/dune
@@ -31,6 +31,7 @@
    mina_intf
    mina_ledger
    mina_base
+   mina_transaction
    mina_transaction_logic
    mina_transition
    consensus

--- a/src/lib/mina_base/mina_base.ml
+++ b/src/lib/mina_base/mina_base.ml
@@ -54,7 +54,6 @@ module State_body_hash = State_body_hash
 module State_hash = State_hash
 module Token_id = Token_id
 module Token_permissions = Token_permissions
-module Transaction_hash = Transaction_hash
 module Transaction_status = Transaction_status
 module Transaction_union_payload = Transaction_union_payload
 module Transaction_union_tag = Transaction_union_tag

--- a/src/lib/mina_graphql/dune
+++ b/src/lib/mina_graphql/dune
@@ -52,6 +52,7 @@
    node_addrs_and_ports
    network_peer
    mina_base
+   mina_transaction
    mina_transition
    user_command_input
    signature_lib

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2,6 +2,7 @@ open Core
 open Async
 open Graphql_async
 open Mina_base
+open Mina_transaction
 module Ledger = Mina_ledger.Ledger
 open Signature_lib
 open Currency

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -69,6 +69,7 @@
    cli_lib
    signature_lib
    mina_base
+   mina_transaction
    mina_transition
    transition_frontier_extensions
    block_time

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open Async
 open Unsigned
 open Mina_base
+open Mina_transaction
 module Ledger = Mina_ledger.Ledger
 open Mina_transition
 open Pipe_lib

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -38,6 +38,7 @@
    one_or_two
    quickcheck_lib
    mina_base
+   mina_transaction
    transaction_snark
    consensus
    network_peer

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1,6 +1,7 @@
 (* See the .mli for a description of the purpose of this module. *)
 open Core
 open Mina_base
+open Mina_transaction
 open Mina_numbers
 open Signature_lib
 

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -6,6 +6,7 @@
 open Core
 
 open Mina_base
+open Mina_transaction
 open Mina_numbers
 
 module Command_error : sig

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -1,6 +1,7 @@
 open Async_kernel
 open Core_kernel
 open Mina_base
+open Mina_transaction
 open Pipe_lib
 open Network_peer
 

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -8,6 +8,7 @@ open Inline_test_quiet_logs
 open Core
 open Async
 open Mina_base
+open Mina_transaction
 open Pipe_lib
 open Signature_lib
 open Network_peer

--- a/src/lib/transaction/dune
+++ b/src/lib/transaction/dune
@@ -26,6 +26,7 @@
    snarky.backendless
    with_hash)
  (instrumentation (backend bisect_ppx))
+ (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps
     h_list.ppx

--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Mina_base
 
 [%%import "/src/config.mlh"]
 

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -1,4 +1,5 @@
 open Core_kernel
+open Mina_base
 
 [%%versioned:
 module Stable : sig

--- a/src/lib/transaction_inclusion_status/dune
+++ b/src/lib/transaction_inclusion_status/dune
@@ -23,6 +23,7 @@
    mina_numbers
    pipe_lib
    mina_base
+   mina_transaction
    transition_frontier
    network_pool
    transition_frontier_base

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -1,6 +1,7 @@
 open Inline_test_quiet_logs
 open Core_kernel
 open Mina_base
+open Mina_transaction
 open Pipe_lib
 open Network_pool
 

--- a/src/nonconsensus/mina_base/mina_base_nonconsensus.ml
+++ b/src/nonconsensus/mina_base/mina_base_nonconsensus.ml
@@ -26,6 +26,5 @@ module Stake_delegation = Stake_delegation
 module State_hash = State_hash
 module Token_id = Token_id
 module Token_permissions = Token_permissions
-module Transaction_hash = Transaction_hash
 module Transaction_union_payload = Transaction_union_payload
 module Transaction_union_tag = Transaction_union_tag

--- a/src/nonconsensus/mina_base/transaction_hash.ml
+++ b/src/nonconsensus/mina_base/transaction_hash.ml
@@ -1,1 +1,0 @@
-../../lib/mina_base/transaction_hash.ml

--- a/src/nonconsensus/mina_transaction_nonconsensus.opam
+++ b/src/nonconsensus/mina_transaction_nonconsensus.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+

--- a/src/nonconsensus/transaction/dune
+++ b/src/nonconsensus/transaction/dune
@@ -1,34 +1,20 @@
 (library
  (name mina_transaction)
- (public_name mina_transaction)
+ (public_name mina_transaction_nonconsensus)
  (libraries
    ;; opam libraries
-   base.caml
    base
-   base.base_internalhash_types
    bin_prot.shape
    core_kernel
-   result
-   sexplib0
    ;; local libraries
    base58_check
    blake2
    codable
-   currency
-   mina_base
-   mina_base.import
-   mina_numbers
-   one_or_two
-   pickles
-   signature_lib
-   sgn
-   snark_params
-   snarky.backendless
-   with_hash)
+   mina_base_nonconsensus)
  (instrumentation (backend bisect_ppx))
+ (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps
-    h_list.ppx
     ppx_coda
     ppx_compare
     ppx_deriving_yojson
@@ -36,4 +22,3 @@
     ppx_optcomp
     ppx_sexp_conv
     ppx_version)))
-

--- a/src/nonconsensus/transaction/transaction_hash.ml
+++ b/src/nonconsensus/transaction/transaction_hash.ml
@@ -1,0 +1,1 @@
+../../lib/transaction/transaction_hash.ml


### PR DESCRIPTION
This PR moves `Transaction_hash` out of `Mina_base` and into `Mina_transaction`.

This is some housekeeping prework to allow https://github.com/MinaProtocol/mina/issues/10520 to be implemented without injecting a large number of new modules into Mina_base.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them