### PR TITLE
Revert "use this branch for sql schemas in mina_automation.ml"

### DIFF
--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -251,8 +251,8 @@ module Network_config = struct
     in
     let mina_archive_schema = "create_schema.sql" in
     let mina_archive_schema_aux_files =
-      [ "https://raw.githubusercontent.com/MinaProtocol/mina/feature/token-id-overhaul/src/app/archive/create_schema.sql"
-      ; "https://raw.githubusercontent.com/MinaProtocol/mina/feature/token-id-overhaul/src/app/archive/snapp_tables.sql"
+      [ "https://raw.githubusercontent.com/MinaProtocol/mina/develop/src/app/archive/create_schema.sql"
+      ; "https://raw.githubusercontent.com/MinaProtocol/mina/develop/src/app/archive/snapp_tables.sql"
       ]
     in
     let mk_net_keypair index (pk, sk) =


### PR DESCRIPTION
This reverts commit f6359e079965c9cc153ede72d217ae3ff779d84b, which attempts to retrieve the archive schema from a non-extant branch.