### PR TITLE
Move `User_command` out of `Mina_base`

### DIFF
--- a/src/app/archive/archive_lib/diff.ml
+++ b/src/app/archive/archive_lib/diff.ml
@@ -1,6 +1,7 @@
 open Mina_transition
 open Core_kernel
 open Mina_base
+open Mina_transaction
 module Breadcrumb = Transition_frontier.Breadcrumb
 
 (* TODO: We should be able to fully deserialize and serialize via json *)

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2506,11 +2506,11 @@ module Block = struct
                 let nonce_map =
                   Signature_lib.Public_key.Compressed.Map.change
                     initial_nonce_map
-                    ( Mina_base.User_command.fee_payer command
+                    ( Mina_transaction.User_command.fee_payer command
                     |> Account_id.public_key )
                     ~f:(fun _ ->
                       Some
-                        ( Mina_base.User_command.nonce_exn command
+                        ( Mina_transaction.User_command.nonce_exn command
                         |> Unsigned.UInt32.succ ))
                 in
                 let%bind id =
@@ -3295,7 +3295,8 @@ let run pool reader ~constraint_constants ~logger ~delete_older_than =
                           ~metadata:
                             [ ("error", `String (Caqti_error.show e))
                             ; ( "command"
-                              , Mina_base.User_command.to_yojson command )
+                              , Mina_transaction.User_command.to_yojson command
+                              )
                             ]
                           "Failed to archive user command $command from \
                            transaction pool: $block, see $error")

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -2,6 +2,7 @@ open Core
 open Async
 open Signature_lib
 open Mina_base
+open Mina_transaction
 open Pipe_lib
 
 module Api = struct

--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -9,9 +9,9 @@ module Signature = Mina_base.Signature
 module Transaction = Rosetta_lib.Transaction
 module Public_key = Signature_lib.Public_key
 module Signed_command_payload = Mina_base.Signed_command_payload
-module User_command = Mina_base.User_command
+module User_command = Mina_transaction.User_command
 module Signed_command = Mina_base.Signed_command
-module Transaction_hash = Mina_base.Transaction_hash
+module Transaction_hash = Mina_transaction.Transaction_hash
 
 module Get_options_metadata =
 [%graphql

--- a/src/app/rosetta/lib/signer.ml
+++ b/src/app/rosetta/lib/signer.ml
@@ -5,7 +5,7 @@ open Signature_lib
 open Rosetta_lib
 open Rosetta_coding
 module Signature = Mina_base.Signature
-module User_command = Mina_base.User_command
+module User_command = Mina_transaction.User_command
 module Signed_command = Mina_base.Signed_command
 
 module Keys = struct

--- a/src/lib/cli_lib/dune
+++ b/src/lib/cli_lib/dune
@@ -32,6 +32,7 @@
    rosetta_lib
    secrets
    mina_base
+   mina_transaction
    work_selector
    rosetta_coding
    logger

--- a/src/lib/cli_lib/render.ml
+++ b/src/lib/cli_lib/render.ml
@@ -1,5 +1,6 @@
 open Core_kernel
 open Mina_base
+open Mina_transaction
 
 module type Printable_intf = sig
   type t [@@deriving to_yojson]

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -1,6 +1,7 @@
 open Core_kernel
 open Async
 open Mina_base
+open Mina_transaction
 module Types = Types
 module Client = Client
 

--- a/src/lib/daemon_rpcs/dune
+++ b/src/lib/daemon_rpcs/dune
@@ -30,6 +30,7 @@
    consensus
    mina_networking
    mina_base
+   mina_transaction
    user_command_input
    perf_histograms
    sync_status

--- a/src/lib/gossip_net/dune
+++ b/src/lib/gossip_net/dune
@@ -29,6 +29,7 @@
    mina_net2
    mina_transition
    mina_base
+   mina_transaction
    perf_histograms
    o1trace
    node_addrs_and_ports

--- a/src/lib/mina_base/mina_base.ml
+++ b/src/lib/mina_base/mina_base.ml
@@ -57,6 +57,5 @@ module Token_permissions = Token_permissions
 module Transaction_status = Transaction_status
 module Transaction_union_payload = Transaction_union_payload
 module Transaction_union_tag = Transaction_union_tag
-module User_command = User_command
 module With_stack_hash = With_stack_hash
 module With_status = With_status

--- a/src/lib/mina_commands/dune
+++ b/src/lib/mina_commands/dune
@@ -28,6 +28,7 @@
    daemon_rpcs
    mina_lib
    mina_base
+   mina_transaction
    user_command_input
    mina_version
    node_addrs_and_ports

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -3,6 +3,7 @@ open Async
 open Signature_lib
 open Mina_numbers
 open Mina_base
+open Mina_transaction
 
 (** For status *)
 let txn_count = ref 0

--- a/src/lib/mina_generators/dune
+++ b/src/lib/mina_generators/dune
@@ -21,6 +21,7 @@
    signature_lib
    mina_ledger
    mina_base
+   mina_transaction
    random_oracle
    with_hash
    mina_base.import

--- a/src/lib/mina_generators/user_command_generators.ml
+++ b/src/lib/mina_generators/user_command_generators.ml
@@ -6,6 +6,7 @@
 
 open Core_kernel
 open Mina_base
+open Mina_transaction
 module Ledger = Mina_ledger.Ledger
 include User_command.Gen
 

--- a/src/lib/mina_lib/coda_subscriptions.ml
+++ b/src/lib/mina_lib/coda_subscriptions.ml
@@ -2,6 +2,7 @@ open Core_kernel
 open Async_kernel
 open Pipe_lib
 open Mina_base
+open Mina_transaction
 open Signature_lib
 open O1trace
 

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -1,6 +1,7 @@
 open Async_kernel
 open Core
 open Mina_base
+open Mina_transaction
 open Mina_state
 open Mina_transition
 open Pipe_lib

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -1,6 +1,7 @@
 open Async_kernel
 open Core_kernel
 open Mina_base
+open Mina_transaction
 open Mina_state
 
 module Validate_content = struct

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -234,6 +234,7 @@ let compare_envelope (e1 : _ Envelope.Incoming.t) (e2 : _ Envelope.Incoming.t) =
 
 module Transaction_pool = struct
   open Mina_base
+  open Mina_transaction
 
   type diff = User_command.Verifiable.t list Envelope.Incoming.t
   [@@deriving sexp]

--- a/src/lib/network_pool/batcher.mli
+++ b/src/lib/network_pool/batcher.mli
@@ -38,7 +38,7 @@ val verify :
 val compare_envelope : _ Envelope.Incoming.t -> _ Envelope.Incoming.t -> int
 
 module Transaction_pool : sig
-  open Mina_base
+  open Mina_transaction
 
   type t [@@deriving sexp]
 

--- a/src/lib/staged_ledger/diff_creation_log.ml
+++ b/src/lib/staged_ledger/diff_creation_log.ml
@@ -1,5 +1,6 @@
 open Core_kernel
 open Mina_base
+open Mina_transaction
 
 type count_and_fee = int * Currency.Fee.t [@@deriving sexp, to_yojson]
 

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2572,10 +2572,8 @@ let%test_module "staged ledger tests" =
       Quickcheck.test (gen_at_capacity_fixed_blocks expected_proof_count)
         ~sexp_of:
           [%sexp_of:
-            Ledger.init_state
-            * Mina_base.User_command.Valid.t list
-            * int option list] ~trials:1
-        ~f:(fun (ledger_init_state, cmds, iters) ->
+            Ledger.init_state * User_command.Valid.t list * int option list]
+        ~trials:1 ~f:(fun (ledger_init_state, cmds, iters) ->
           async_with_ledgers ledger_init_state (fun sl test_mask ->
               test_simple
                 (init_pks ledger_init_state)
@@ -2586,10 +2584,8 @@ let%test_module "staged ledger tests" =
       Quickcheck.test gen_at_capacity
         ~sexp_of:
           [%sexp_of:
-            Ledger.init_state
-            * Mina_base.User_command.Valid.t list
-            * int option list] ~trials:15
-        ~f:(fun (ledger_init_state, cmds, iters) ->
+            Ledger.init_state * User_command.Valid.t list * int option list]
+        ~trials:15 ~f:(fun (ledger_init_state, cmds, iters) ->
           async_with_ledgers ledger_init_state (fun sl test_mask ->
               test_simple
                 (init_pks ledger_init_state)
@@ -3167,7 +3163,7 @@ let%test_module "staged ledger tests" =
         ~sexp_of:
           [%sexp_of:
             Ledger.init_state
-            * Mina_base.User_command.Valid.t list
+            * User_command.Valid.t list
             * int option list
             * (int * Fee.t list) list] ~trials:10
         ~f:(fun (ledger_init_state, cmds, iters, proofs_available) ->

--- a/src/lib/staged_ledger_diff/dune
+++ b/src/lib/staged_ledger_diff/dune
@@ -10,6 +10,7 @@
    base.caml
    ;; local libraries
    mina_base
+   mina_transaction
    transaction_snark_work
    genesis_constants
    currency

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.ml
@@ -1,5 +1,6 @@
 open Core_kernel
 open Mina_base
+open Mina_transaction
 
 module At_most_two = struct
   [%%versioned

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.mli
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.mli
@@ -1,5 +1,6 @@
 open Core_kernel
 open Mina_base
+open Mina_transaction
 
 module At_most_two : sig
   type 'a t = Zero | One of 'a option | Two of ('a * 'a option) option

--- a/src/lib/transaction/dune
+++ b/src/lib/transaction/dune
@@ -17,6 +17,7 @@
    currency
    mina_base
    mina_base.import
+   mina_compile_config
    mina_numbers
    one_or_two
    pickles

--- a/src/lib/transaction/user_command.ml
+++ b/src/lib/transaction/user_command.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Mina_base
 
 module Poly = struct
   [%%versioned

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.mli
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.mli
@@ -1,6 +1,6 @@
 open Core_kernel
 open Pipe_lib
-open Mina_base
+open Mina_transaction
 
 module State : sig
   module Stable : sig

--- a/src/lib/transition_frontier/dune
+++ b/src/lib/transition_frontier/dune
@@ -34,6 +34,7 @@
    transition_frontier_persistent_frontier
    transition_frontier_extensions
    mina_base
+   mina_transaction
    cache_lib
    data_hash_lib
    network_peer

--- a/src/lib/transition_frontier/extensions/best_tip_diff.ml
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.ml
@@ -1,5 +1,6 @@
 open Core_kernel
 open Mina_base
+open Mina_transaction
 open Frontier_base
 
 module T = struct

--- a/src/lib/transition_frontier/extensions/best_tip_diff.mli
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.mli
@@ -1,4 +1,5 @@
 open Mina_base
+open Mina_transaction
 
 type view =
   { new_commands : User_command.Valid.t With_status.t list

--- a/src/lib/transition_frontier/extensions/dune
+++ b/src/lib/transition_frontier/extensions/dune
@@ -16,6 +16,7 @@
    data_hash_lib
    pipe_lib
    mina_base
+   mina_transaction
    transition_frontier_base
    transition_frontier_full_frontier
    mina_ledger

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -1,6 +1,7 @@
 open Async_kernel
 open Core
 open Mina_base
+open Mina_transaction
 open Mina_state
 open Mina_transition
 open Network_peer

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -7,6 +7,7 @@ open Async_kernel
 open Core_kernel
 open Signature_lib
 open Mina_base
+open Mina_transaction
 open Mina_state
 open Mina_transition
 open Network_peer

--- a/src/lib/transition_frontier/frontier_base/dune
+++ b/src/lib/transition_frontier/frontier_base/dune
@@ -31,6 +31,7 @@
    mina_transition
    mina_ledger
    mina_base
+   mina_transaction
    mina_transaction_logic
    mina_state
    staged_ledger

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -6,6 +6,7 @@ open Core
 
 open Async_kernel
 open Mina_base
+open Mina_transaction
 module Ledger = Mina_ledger.Ledger
 open Mina_transition
 include Frontier_base

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -1,5 +1,6 @@
 open Core_kernel
 open Mina_base
+open Mina_transaction
 
 type invalid =
   [ `Invalid_keys of Signature_lib.Public_key.Compressed.Stable.Latest.t list

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -1,6 +1,7 @@
 open Core_kernel
 open Async_kernel
 open Mina_base
+open Mina_transaction
 
 type t = unit
 
@@ -23,7 +24,7 @@ let verify_blockchain_snarks _ _ = Deferred.Or_error.return true
    containing Valid_assuming to match the expected type
 *)
 let verify_commands _ (cs : User_command.Verifiable.t list) :
-    [ `Valid of Mina_base.User_command.Valid.t
+    [ `Valid of User_command.Valid.t
     | `Valid_assuming of
       ( Pickles.Side_loaded.Verification_key.t
       * Mina_base.Snapp_statement.t

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -27,6 +27,7 @@
    blockchain_snark
    mina_base
    mina_state
+   mina_transaction
    pickles
    genesis_constants
    signature_lib

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -3,6 +3,7 @@
 open Core_kernel
 open Async
 open Mina_base
+open Mina_transaction
 open Mina_state
 open Blockchain_snark
 open O1trace
@@ -19,8 +20,8 @@ module Worker_state = struct
       (Protocol_state.Value.t * Proof.t) list -> bool Deferred.t
 
     val verify_commands :
-         Mina_base.User_command.Verifiable.t list
-      -> [ `Valid of Mina_base.User_command.Valid.t
+         User_command.Verifiable.t list
+      -> [ `Valid of User_command.Valid.t
          | `Valid_assuming of
            ( Pickles.Side_loaded.Verification_key.t
            * Mina_base.Snapp_statement.t

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -19,10 +19,10 @@ module Base = struct
 
     val verify_commands :
          t
-      -> Mina_base.User_command.Verifiable.t list
+      -> Mina_transaction.User_command.Verifiable.t list
          (* The first level of error represents failure to verify, the second a failure in
             communicating with the verifier. *)
-      -> [ `Valid of Mina_base.User_command.Valid.t
+      -> [ `Valid of Mina_transaction.User_command.Valid.t
          | `Valid_assuming of
            ( Pickles.Side_loaded.Verification_key.t
            * Mina_base.Snapp_statement.t


### PR DESCRIPTION
This PR moves `User_command` out of `Mina_base` and into Mina_transaction.

This is some housekeeping prework to allow https://github.com/MinaProtocol/mina/issues/10520 to be implemented without injecting a large number of new modules into `Mina_base`.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them