### PR TITLE
[nix prep] libp2p: allow disabling MDNS test

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/config_msg_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/config_msg_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"testing"
 	"time"
+	"os"
 
 	ipc "libp2p_ipc"
 
@@ -91,6 +92,9 @@ func TestDHTDiscovery_ThreeNodes(t *testing.T) {
 }
 
 func TestMDNSDiscovery(t *testing.T) {
+	if os.Getenv("NO_MDNS_TEST") != "" {
+		return
+	}
 	appA, appAPort := newTestApp(t, nil, true)
 	appA.NoDHT = true
 


### PR DESCRIPTION
(Preparation for Nix packaging)

libp2p_helper: allow disabling MDNS test. The Nix Sandbox doesn't
allow MDNS, so the test can't pass. Allow disabling it.
