### PR TITLE
[nix prep] buildkite: allow passing --privileged to docker

### DIFF
--- a/buildkite/src/Command/Docker/Type.dhall
+++ b/buildkite/src/Command/Docker/Type.dhall
@@ -11,12 +11,14 @@
      `propagate-environment`: Bool,
      `mount-buildkite-agent`: Bool,
      `mount-workdir`: Bool,
+     privileged: Bool,
      environment: List Text
   },
   default = {
     `propagate-environment` = True,
     `mount-buildkite-agent` = False,
     `mount-workdir` = False,
+    privileged = False,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ]
   }
 }

--- a/buildkite/src/Lib/Cmds.dhall
+++ b/buildkite/src/Lib/Cmds.dhall
@@ -17,10 +17,12 @@ let module = \(environment : List Text) ->
   let Docker = {
     Type = {
       image : Text,
-      extraEnv : List Text
+      extraEnv : List Text,
+      privileged : Bool
     },
     default = {
-      extraEnv = ([] : List Text)
+      extraEnv = ([] : List Text),
+      privileged = False
     }
   }
 
@@ -45,7 +47,7 @@ let module = \(environment : List Text) ->
       "/var/buildkite/builds/\\\$BUILDKITE_AGENT_NAME/\\\$BUILDKITE_ORGANIZATION_SLUG/\\\$BUILDKITE_PIPELINE_SLUG"
     let sharedDir : Text = "/var/buildkite/shared"
     in
-    { line = "docker run -it --rm --init --volume ${sharedDir}:/shared --volume ${outerDir}:/workdir --workdir /workdir${envVars} ${docker.image} /bin/sh -c '${inner.line}'"
+    { line = "docker run -it --rm --init --volume ${sharedDir}:/shared --volume ${outerDir}:/workdir --workdir /workdir${envVars}${if docker.privileged then " --privileged" else ""} ${docker.image} /bin/sh -c '${inner.line}'"
     , readable = Optional/map Text Text (\(readable : Text) -> "Docker@${docker.image} ( ${readable} )") inner.readable
     }
 


### PR DESCRIPTION
Nix sandboxing, which increases reproducibility and allows more
isolated builds, requires a privileged docker container. Add a way to
pass `--privileged` to docker running on buildkite builders.
