### PR TITLE
[nix prep] mina_version/gen.sh: make version info generation more reselient and flexible

### DIFF
--- a/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
+++ b/src/lib/zexe_backend/zexe_backend_common/gen_version.sh
@@ -1,6 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e -o pipefail
-marlin_submodule_dir=$(git submodule status | grep marlin | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
-marlin_repo_sha=$(cd $marlin_submodule_dir && git rev-parse --short=8 --verify HEAD)
+if [ -z ${MARLIN_REPO_SHA+x} ]; then
+    marlin_submodule_dir=$(git submodule status | grep marlin | sed 's/^[-\ ]//g' | cut -d ' ' -f 2)
+    marlin_repo_sha=$(cd $marlin_submodule_dir && git rev-parse --short=8 --verify HEAD)
+else
+    marlin_repo_sha=$(cut -b -8 <<< "$MARLIN_REPO_SHA")
+fi
 
 echo "let marlin_repo_sha = \"$marlin_repo_sha\"" >> "$1"


### PR DESCRIPTION
Make the version info generation more flexible (by allowing to
override various information with env variables) and reselient (by
allowing `git` to not be present in PATH).
