### PR TITLE
archive_lib tests: allow configuring postgres

### DIFF
--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -24,7 +24,7 @@ let%test_module "Archive node unit tests" =
     module Genesis_ledger = (val Genesis_ledger.for_unit_tests)
 
     let archive_uri =
-      Uri.of_string "postgres://admin:codarules@localhost:5432/archiver"
+      Uri.of_string (Option.value (Sys.getenv "MINA_TEST_POSTGRES") ~default:"postgres://admin:codarules@localhost:5432/archiver")
 
     let conn_lazy =
       lazy


### PR DESCRIPTION
Allow configuring postgres connstring in archive_lib tests. Useful for testing with `pg_tmp` instead of a system-wide postgres.
