### PR TITLE
[Easy] Small pickles refactors

### DIFF
--- a/src/lib/pickles/pairing_main.ml
+++ b/src/lib/pickles/pairing_main.ml
@@ -714,19 +714,6 @@ struct
         in
         go pt n)
 
-  let actual_evaluation (e : (Boolean.var * Field.t) array) ~(pt_to_n : Field.t)
-      : Field.t =
-    with_label "actual_evaluation" (fun () ->
-        match List.rev (Array.to_list e) with
-        | (b, e) :: es ->
-            List.fold
-              ~init:Field.((b :> t) * e)
-              es
-              ~f:(fun acc (keep, fx) ->
-                Field.if_ keep ~then_:Field.(fx + (pt_to_n * acc)) ~else_:acc)
-        | [] ->
-            failwith "empty list")
-
   let actual_evaluation (e : Field.t array) ~(pt_to_n : Field.t) : Field.t =
     with_label "actual_evaluation" (fun () ->
         match List.rev (Array.to_list e) with

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -45,7 +45,7 @@ end
 open Core_kernel
 
 let typ (type n avar aval m) (statement : (avar, aval) Impls.Step.Typ.t)
-    (local_max_branching : n Nat.t) (local_branches : m Nat.t) ~step_domains :
+    (local_max_branching : n Nat.t) (local_branches : m Nat.t) :
     ((avar, n, m) t, (aval, n, m) Constant.t) Impls.Step.Typ.t =
   let open Impls.Step in
   let open Step_main_inputs in

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -163,15 +163,8 @@ let step_main :
                 match Type_equal.Id.same_witness self.id d.id with
                 | Some T ->
                     basic.typ
-                | None -> (
-                    (* TODO: Abstract this into a function in Types_map *)
-                    match d.kind with
-                    | Compiled ->
-                        let d = Types_map.lookup_compiled d.id in
-                        d.typ
-                    | Side_loaded ->
-                        let d = Types_map.lookup_side_loaded d.id in
-                        d.permanent.typ )
+                | None ->
+                    Types_map.typ d
               in
               typ)
               d

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -157,30 +157,26 @@ let step_main :
       | [], [], [], Z, Z, Z ->
           []
       | d :: ds, n1 :: ns1, n2 :: ns2, S ld, S ln1, S ln2 ->
-          let step_domains, typ =
+          let typ =
             (fun (type var value n m) (d : (var, value, n, m) Tag.t) ->
-              let typ : (_, m) Vector.t * (var, value) Typ.t =
+              let typ : (var, value) Typ.t =
                 match Type_equal.Id.same_witness self.id d.id with
                 | Some T ->
-                    (basic.step_domains, basic.typ)
+                    basic.typ
                 | None -> (
                     (* TODO: Abstract this into a function in Types_map *)
                     match d.kind with
                     | Compiled ->
                         let d = Types_map.lookup_compiled d.id in
-                        (d.step_domains, d.typ)
+                        d.typ
                     | Side_loaded ->
                         let d = Types_map.lookup_side_loaded d.id in
-                        (* TODO: This replication to please the type checker is
-                           pointless... *)
-                        ( Vector.init d.permanent.branches ~f:(fun _ ->
-                              Side_loaded_verification_key.max_domains_with_x)
-                        , d.permanent.typ ) )
+                        d.permanent.typ )
               in
               typ)
               d
           in
-          let t = Per_proof_witness.typ ~step_domains typ n1 n2 in
+          let t = Per_proof_witness.typ typ n1 n2 in
           t :: join ds ns1 ns2 ld ln1 ln2
       | [], _, _, _, _, _ ->
           .


### PR DESCRIPTION
This PR breaks out some small refactors to pickles coming from the documentation effort. This
* moves the logic for verifying a proof into a `verify_one` function, out of the nasty multi-hlist map
* removes an unused parameter and the logic for constructing its input
* remove an unused function

The commits are self-contained; it may be easier to review them individually.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
