### PR TITLE
Lk86/change cronjob granularity 10min

### DIFF
--- a/helm/cron_jobs/devnet-dump-archive-cronjob.yaml
+++ b/helm/cron_jobs/devnet-dump-archive-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             echo "installed gsutil";
 
             DATE="$(date +%F_%H%M)";
-            FILENAME=devnet-archive-dump-"$DATE".sql;
+            FILENAME=devnet-archive-dump-"${DATE:: -1}0".sql;
 
             pg_dump --no-owner --create postgres://postgres:foobar@archive-1-postgresql:5432/archive > $FILENAME;
 

--- a/helm/cron_jobs/devnet-dump-archive-cronjob.yaml
+++ b/helm/cron_jobs/devnet-dump-archive-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             DATE="$(date +%F_%H%M)";
             FILENAME=devnet-archive-dump-"${DATE:: -1}0".sql;
 
-            pg_dump --no-owner --create postgres://postgres:foobar@archive-1-postgresql:5432/archive > $FILENAME;
+            pg_dump --no-owner --create postgres://postgres:foobar@archive-1-postgresql:5432/archive_balances_migrated > $FILENAME;
 
             tar -czvf $FILENAME.tar.gz $FILENAME;
 

--- a/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             DATE="$(date +%F_%H%M)";
             FILENAME=mainnet-archive-dump-"${DATE:: -1}0".sql;
 
-            pg_dump --no-owner --create postgres://postgres:foobar@archive-3-postgresql:5432/archive > $FILENAME;
+            pg_dump --no-owner --create postgres://postgres:foobar@archive-3-postgresql:5432/archive_balances_migrated > $FILENAME;
 
             tar -czvf $FILENAME.tar.gz $FILENAME;
 

--- a/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-dump-archive-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             echo "installed gsutil";
 
             DATE="$(date +%F_%H%M)";
-            FILENAME=mainnet-archive-dump-"$DATE".sql;
+            FILENAME=mainnet-archive-dump-"${DATE:: -1}0".sql;
 
             pg_dump --no-owner --create postgres://postgres:foobar@archive-3-postgresql:5432/archive > $FILENAME;
 

--- a/helm/cron_jobs/mainnet-dump-staking-ledger-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-dump-staking-ledger-cronjob.yaml
@@ -42,13 +42,13 @@ spec:
                EPOCHNUM="$(mina client status|grep "Best tip consensus time"|grep -o "epoch=[0-9]*"|sed "s/[^0-9]*//g")";
                STAKING_HASH="$(mina ledger hash --ledger-file staking_epoch_ledger.json)";
                STAKING_MD5="$(md5sum staking_epoch_ledger.json|cut -d " " -f 1)";
-               LEDGER_FILENAME=staking-"$EPOCHNUM"-"$STAKING_HASH"-"$STAKING_MD5"-"$DATE".json;
+               LEDGER_FILENAME=staking-"$EPOCHNUM"-"$STAKING_HASH"-"$STAKING_MD5"-"${DATE:: -1}0".json;
                mv ./staking_epoch_ledger.json ./$LEDGER_FILENAME;NEXT_STAKING_HASH="$(mina ledger hash --ledger-file next_epoch_ledger.json)";
                NEXT_STAKING_MD5="$(md5sum next_epoch_ledger.json|cut -d " " -f 1)";
                NEXT_FILENAME=next-staking-"$EPOCHNUM"-"$NEXT_STAKING_HASH"-"$NEXT_STAKING_MD5"-"$DATE".json;
                mv ./next_epoch_ledger.json ./$NEXT_FILENAME;
                EXPORTED_LOGS="local-logs";
-               LOGS_FILENAME="daemon-logs-epoch-$EPOCHNUM-"$DATE".tgz";
+               LOGS_FILENAME="daemon-logs-epoch-$EPOCHNUM-"${DATE:: -1}0".tgz";
                mina client export-local-logs --tarfile $EXPORTED_LOGS;
                mv /root/.mina-config/exported_logs/$EXPORTED_LOGS.tar.gz $LOGS_FILENAME;
                echo "upload to a GCP cloud storage bucket";


### PR DESCRIPTION
To ensure that all backups to GCP buckets complete in-time and result with the correct filename at midnight (but to still allow manual runs at other times of day), this PR rewrites the datestamp in our cronjobs to always end in 0. This means if a job starts running at midnight (00:00) but does not complete successfully until 00:01 or up to 9 minutes past the hour, the timestamp will still read 00:00.