### PR TITLE
Add skip marker to fields_derivers

### DIFF
--- a/src/lib/fields_derivers_snapps/fields_derivers_snapps.ml
+++ b/src/lib/fields_derivers_snapps/fields_derivers_snapps.ml
@@ -29,7 +29,11 @@ module Make (Schema : Graphql_intf.Schema) = struct
     let contramap = ref (fun _ -> failwith "unimplemented") in
     let map = ref (fun _ -> failwith "unimplemented") in
 
+    let skip = ref false in
+
     object
+      method skip = skip
+
       method graphql_fields = graphql_fields
 
       method nullable_graphql_fields = nullable_graphql_fields

--- a/src/lib/mina_base/permissions.mli
+++ b/src/lib/mina_base/permissions.mli
@@ -135,6 +135,7 @@ val deriver :
           ref
       ; to_json_accumulator :
           (string * (Auth_required.t Poly.t -> Yojson.Safe.t)) option list ref
+      ; skip : bool ref
       ; .. >
       as
       'a)


### PR DESCRIPTION
This PR allows the use of the `skip` fields deriver without an associated `skip` annotation. This fixes the compilation error in #10189.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them