### PR TITLE
Fix JS integer overflows

### DIFF
--- a/src/lib/pickles/limb_vector/constant.ml
+++ b/src/lib/pickles/limb_vector/constant.ml
@@ -31,11 +31,10 @@ module Hex64 = struct
     include (Int64 : module type of Int64 with type t := t)
 
     let to_hex t =
-      let mask = of_int 0xffffffff in
-      let lo, hi =
-        (to_int_exn (t land mask), to_int_exn ((t lsr 32) land mask))
-      in
-      sprintf "%08x%08x" hi lo
+      let lo = t land of_int 0xffffff in
+      let mi = (t lsr 24) land of_int 0xffffff in
+      let hi = (t lsr 48) land of_int 0xffff in
+      sprintf "%04x%06x%06x" (to_int_exn hi) (to_int_exn mi) (to_int_exn lo)
 
     let of_hex h =
       let f s = Hex.of_string ("0x" ^ s) in

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2235,9 +2235,9 @@ module For_tests = struct
     [@@deriving sexp, compare]
   end
 
-  let min_init_balance = 8_000_000_000
+  let min_init_balance = Int64.of_string "8000000000"
 
-  let max_init_balance = 8_000_000_000_000
+  let max_init_balance = Int64.of_string "8000000000000"
 
   let num_accounts = 10
 
@@ -2246,7 +2246,7 @@ module For_tests = struct
   let depth = Int.ceil_log2 (num_accounts + num_transactions)
 
   module Init_ledger = struct
-    type t = (Keypair.t * int) array [@@deriving sexp]
+    type t = (Keypair.t * int64) array [@@deriving sexp]
 
     let init (type l) (module L : Ledger_intf.S with type t = l)
         (init_ledger : t) (l : L.t) =
@@ -2258,7 +2258,11 @@ module For_tests = struct
                  Token_id.default)
             |> Or_error.ok_exn
           in
-          L.set l loc { account with balance = Currency.Balance.of_int amount })
+          L.set l loc
+            { account with
+              balance =
+                Currency.Balance.of_uint64 (Unsigned.UInt64.of_int64 amount)
+            })
 
     let gen () : t Quickcheck.Generator.t =
       let tbl = Public_key.Compressed.Hash_set.create () in
@@ -2270,7 +2274,7 @@ module For_tests = struct
           let%bind kp =
             filter Keypair.gen ~f:(fun kp ->
                 not (Hash_set.mem tbl (Public_key.compress kp.public_key)))
-          and amount = Int.gen_incl min_init_balance max_init_balance in
+          and amount = Int64.gen_incl min_init_balance max_init_balance in
           Hash_set.add tbl (Public_key.compress kp.public_key) ;
           go ((kp, amount) :: acc) (n - 1)
       in


### PR DESCRIPTION
This PR fixes two integer overflows that were previously occuring in the JS build. One of them had caused a bug in serializing Pickles proofs to strings in JS.
The problem in both cases was that OCaml's `int` was assumed to hold more than 32 bits, or be equivalent to `int64`. This is not the case in JS, where `int64` is implemented correctly but `int` has only 32 bits.

The solution is to avoid `int` for large integers, and use `int64` instead. For creating large integers, `Int64.of_string` can be used instead of `Int64.of_int`.