### PR TITLE
Send snapp transactions all at once in integration test

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -368,6 +368,19 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section "Send a snapp to update permissions"
         (send_snapp ~logger node parties_update_permissions)
     in
+    (* Wait for account to be set up. *)
+    let%bind () =
+      section
+        "Wait for snapp to create accounts to be included in transition \
+         frontier"
+        (wait_for_snapp parties_create_account)
+    in
+    let%bind () =
+      section
+        "Wait for snapp to update permissions to be included in transition \
+         frontier"
+        (wait_for_snapp parties_update_permissions)
+    in
     (*Won't be accepted until the previous transactions are applied*)
     let%bind () =
       section "Send a snapp to update all fields"
@@ -393,18 +406,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     (* Wait for transactions to be applied, check that the updates are correct.
     *)
-    let%bind () =
-      section
-        "Wait for snapp to create accounts to be included in transition \
-         frontier"
-        (wait_for_snapp parties_create_account)
-    in
-    let%bind () =
-      section
-        "Wait for snapp to update permissions to be included in transition \
-         frontier"
-        (wait_for_snapp parties_update_permissions)
-    in
     let%bind () =
       section "Verify that updated permissions are in ledger accounts"
         (Malleable_error.List.iter snapp_account_ids ~f:(fun account_id ->

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -392,7 +392,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         let needed = 12 in
         if !transactions_sent >= needed then 0 else needed - !transactions_sent
       in
-      send_padding_transactions block_producer_nodes ~fee:small_fee  ~logger
+      send_padding_transactions block_producer_nodes ~fee:small_fee ~logger
         ~n:padding_payments
     in
     let%bind () =

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -28,8 +28,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     { default with
       requires_graphql = true
     ; block_producers =
-        [ { balance = "8_000_000_000"; timing = Untimed }
-        ; { balance = "1_000_000_000"; timing = Untimed }
+        [ { balance = "8000000000"; timing = Untimed }
+        ; { balance = "1000000000"; timing = Untimed }
         ]
     ; extra_genesis_accounts = [ { keypair; balance = "1000" } ]
     ; num_snark_workers = 2


### PR DESCRIPTION
This will hopefully speed up the snapps integration test in CI -- currently it's taking over an hour!

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them