### PR TITLE
Integration tests: don't wait 30s before every GraphQL test

### DIFF
--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -185,7 +185,7 @@ module Node = struct
 
   (* this function will repeatedly attempt to connect to graphql port <num_tries> times before giving up *)
   let exec_graphql_request ?(num_tries = 10) ?(retry_delay_sec = 30.0)
-      ?(initial_delay_sec = 30.0) ~logger ~node ~query_name query_obj =
+      ?(initial_delay_sec = 0.) ~logger ~node ~query_name query_obj =
     let open Deferred.Let_syntax in
     if not node.config.graphql_enabled then
       Deferred.Or_error.error_string


### PR DESCRIPTION
We currently spend 30s waiting before sending each GraphQL request in integration tests. This PR removes that wait, since it should almost never be necessary.

For tests where we send a lot of transactions, this can add up quickly. For example, in the snapps integration test, we spend at least 6 minutes in these 30s sleeps!


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them