### PR TITLE
updated integration test pod size

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -121,7 +121,8 @@ let targetToAgent = \(target : Size) ->
   merge { XLarge = toMap { size = "xlarge" },
           Large = toMap { size = "large" },
           Medium = toMap { size = "medium" },
-          Small = toMap { size = "small" }
+          Small = toMap { size = "small" }, 
+          Integration = toMap { size = "integration" }
         }
         target
 

--- a/buildkite/src/Command/Size.dhall
+++ b/buildkite/src/Command/Size.dhall
@@ -1,1 +1,1 @@
-<XLarge|Large|Medium|Small>
+<XLarge|Large|Medium|Small|Integration>

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -55,7 +55,7 @@ in
         artifact_paths = [SelectFiles.exactly "." "${testName}.test.log"],
         label = "${testName} integration test",
         key = "integration-test-${testName}",
-        target = Size.Medium,
+        target = Size.integration,
         depends_on = dependsOn,
         if = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'"
       }

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -55,7 +55,7 @@ in
         artifact_paths = [SelectFiles.exactly "." "${testName}.test.log"],
         label = "${testName} integration test",
         key = "integration-test-${testName}",
-        target = Size.integration,
+        target = Size.Integration,
         depends_on = dependsOn,
         if = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'"
       }


### PR DESCRIPTION
Explain your changes:
* This change is to update the buildkite resources used for integration tests. Buildkite allocates pods based on the tag the job has assigned. In this case there are now 40 pods added that use the tag `integration` which are dedicated to integration tests. This specific allocation is intended to place a cap on the number of integration tests that can run in parallel, and avoid exhausting the cloud resources on the back-end. 

Explain how you tested your changes:
* Because this item is changing a setting within the CI pipeline, the ci-build-me tag is added to this PR. If these tests complete successfully, it would validate that the update does not cause issue. 


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #00000
