### PR TITLE
Filter command ids in SQL (for develop)

### DIFF
--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -38,6 +38,16 @@ type output =
   }
 [@@deriving yojson]
 
+type command_type = [ `Internal_command | `User_command | `Snapp_command ]
+
+module type Get_command_ids = sig
+  val run :
+       Caqti_async.connection
+    -> state_hash:string
+    -> start_slot:int64
+    -> (int list, [> Caqti_error.call_or_retrieve ]) Deferred.Result.t
+end
+
 type balance_block_data =
   { block_id : int
   ; block_height : int64
@@ -1074,37 +1084,28 @@ let main ~input_file ~output_file_opt ~archive_uri ~set_nonces ~repair_nonces
           "Block chain leading to target state hash does not include genesis \
            block" ;
         Core_kernel.exit 1 ) ;
-      [%log info] "Loading user command ids" ;
-      let%bind user_cmd_ids =
+      let get_command_ids (module Command_ids : Get_command_ids) name =
         match%bind
           Caqti_async.Pool.use
             (fun db ->
-              Sql.User_command_ids.run db ~state_hash:target_state_hash
+              Command_ids.run db ~state_hash:target_state_hash
                 ~start_slot:input.start_slot_since_genesis)
             pool
         with
         | Ok ids ->
             return ids
         | Error msg ->
-            [%log error] "Error getting user command ids"
+            [%log error] "Error getting %s command ids" name
               ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
             exit 1
       in
+      [%log info] "Loading user command ids" ;
+      let%bind user_cmd_ids =
+        get_command_ids (module Sql.User_command_ids) "user"
+      in
       [%log info] "Loading internal command ids" ;
       let%bind internal_cmd_ids =
-        match%bind
-          Caqti_async.Pool.use
-            (fun db ->
-              Sql.Internal_command_ids.run db ~state_hash:target_state_hash
-                ~start_slot:input.start_slot_since_genesis)
-            pool
-        with
-        | Ok ids ->
-            return ids
-        | Error msg ->
-            [%log error] "Error getting user command ids"
-              ~metadata:[ ("error", `String (Caqti_error.show msg)) ] ;
-            exit 1
+        get_command_ids (module Sql.Internal_command_ids) "internal"
       in
       [%log info] "Obtained %d user command ids and %d internal command ids"
         (List.length user_cmd_ids)

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -50,11 +50,12 @@ let find_command_ids_query s =
   sprintf
     {sql| WITH RECURSIVE chain AS (
 
-            SELECT id,parent_id FROM blocks b WHERE b.state_hash = ?
+            SELECT id,parent_id,global_slot_since_genesis FROM blocks b
+            WHERE b.state_hash = $1
 
             UNION ALL
 
-            SELECT b.id,b.parent_id FROM blocks b
+            SELECT b.id,b.parent_id,b.global_slot_since_genesis FROM blocks b
 
             INNER JOIN chain
 
@@ -66,6 +67,8 @@ let find_command_ids_query s =
           INNER JOIN blocks_%s_commands bc
 
           ON bc.block_id = c.id
+
+          WHERE c.global_slot_since_genesis >= $2
 
      |sql}
     s s
@@ -147,11 +150,13 @@ end
 
 module User_command_ids = struct
   let query =
-    Caqti_request.collect Caqti_type.string Caqti_type.int
+    Caqti_request.collect
+      Caqti_type.(tup2 string int64)
+      Caqti_type.int
       (find_command_ids_query "user")
 
-  let run (module Conn : Caqti_async.CONNECTION) state_hash =
-    Conn.collect_list query state_hash
+  let run (module Conn : Caqti_async.CONNECTION) ~state_hash ~start_slot =
+    Conn.collect_list query (state_hash, start_slot)
 end
 
 module User_command = struct
@@ -218,7 +223,7 @@ module User_command = struct
                    sequence_no,status,created_token,
                    fee_payer_balance, source_balance, receiver_balance
 
-            FROM (SELECT * FROM user_commands WHERE id = ?) AS uc
+            FROM (SELECT * FROM user_commands WHERE id = $1) AS uc
 
             INNER JOIN blocks_user_commands AS buc
 
@@ -240,11 +245,13 @@ end
 
 module Internal_command_ids = struct
   let query =
-    Caqti_request.collect Caqti_type.string Caqti_type.int
+    Caqti_request.collect
+      Caqti_type.(tup2 string int64)
+      Caqti_type.int
       (find_command_ids_query "internal")
 
-  let run (module Conn : Caqti_async.CONNECTION) state_hash =
-    Conn.collect_list query state_hash
+  let run (module Conn : Caqti_async.CONNECTION) ~state_hash ~start_slot =
+    Conn.collect_list query (state_hash, start_slot)
 end
 
 module Internal_command = struct
@@ -296,7 +303,7 @@ module Internal_command = struct
                    receiver_account_creation_fee_paid,
                    sequence_no,secondary_sequence_no
 
-            FROM (SELECT * FROM internal_commands WHERE id = ?) AS ic
+            FROM (SELECT * FROM internal_commands WHERE id = $1) AS ic
 
             INNER JOIN blocks_internal_commands AS bic
 


### PR DESCRIPTION
Same as #10312, but for `develop`, so we can get a clean merge with `develop` there.