### PR TITLE
Add inline test for signature consistency

### DIFF
--- a/src/lib/signature_lib/test/dune
+++ b/src/lib/signature_lib/test/dune
@@ -1,0 +1,12 @@
+(library
+ (name signature_lib_tests)
+ (libraries
+   random_oracle_input
+   signature_lib
+   snark_params)
+ (instrumentation (backend bisect_ppx))
+ (inline_tests)
+ (preprocess
+  (pps
+    ppx_inline_test
+    ppx_version)))

--- a/src/lib/signature_lib/test/signature_lib_tests.ml
+++ b/src/lib/signature_lib/test/signature_lib_tests.ml
@@ -1,0 +1,39 @@
+open Signature_lib
+
+let%test_module "Signatures are unchanged test" =
+  ( module struct
+    let privkey =
+      Private_key.of_base58_check_exn
+        "EKE2M5q5afTtdzZTzyKu89Pzc7274BD6fm2fsDLgLt5zy34TAN5N"
+
+    let signature_expected =
+      ( Snark_params.Tick.Field.of_string
+          "22392589120931543014785073787084416773963960016576902579504636013984435243005"
+      , Snark_params.Tock.Field.of_string
+          "21219227048859428590456415944357352158328885122224477074004768710152393114331"
+      )
+
+    let%test "signature of empty random oracle input matches" =
+      let signature_got =
+        Schnorr.sign privkey (Random_oracle_input.field_elements [||])
+      in
+      Snark_params.Tick.Field.equal (fst signature_expected) (fst signature_got)
+      && Snark_params.Tock.Field.equal (snd signature_expected)
+           (snd signature_got)
+
+    let%test "signature of signature matches" =
+      let signature_got =
+        Schnorr.sign privkey
+          (Random_oracle_input.field_elements [| fst signature_expected |])
+      in
+      let signature_expected =
+        ( Snark_params.Tick.Field.of_string
+            "7379148532947400206038414977119655575287747480082205647969258483647762101030"
+        , Snark_params.Tock.Field.of_string
+            "26901815964642131149392134713980873704065643302140817442239336405283236628658"
+        )
+      in
+      Snark_params.Tick.Field.equal (fst signature_expected) (fst signature_got)
+      && Snark_params.Tock.Field.equal (snd signature_expected)
+           (snd signature_got)
+  end )


### PR DESCRIPTION
This PR adds a simple test to ensure that signing still works and is compatible with mainnet. This would have caught the Client SDK breakage if we had had it previously.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
