### PR TITLE
buildkite: remove "optional" from job names

### DIFF
--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -52,8 +52,8 @@ in  Pipeline.build
                   , "BASE_BRANCH_NAME=\$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
                   ]
                   "./scripts/compare_ci_diff_types.sh"
-            , label = "Optional fast lint steps; versions compatibility changes"
-            , key = "lint-optional-types"
+            , label = "Fast lint steps; versions compatibility changes"
+            , key = "lint-types"
             , target = Size.Medium
             , docker = None Docker.Type
             }
@@ -65,8 +65,8 @@ in  Pipeline.build
                   , "BASE_BRANCH_NAME=\$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
                   ]
                   "./scripts/compare_ci_diff_binables.sh"
-            , label = "Optional fast lint steps; binable compatibility changes"
-            , key = "lint-optional-binable"
+            , label = "Fast lint steps; binable compatibility changes"
+            , key = "lint-binable"
             , target = Size.Medium
             , docker = None Docker.Type
             }


### PR DESCRIPTION
Jobs currently named "optional" are in fact mandatory. Remove
confusing naming.
