### PR TITLE
Remove validation_callback out of block type

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -749,9 +749,6 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                         ; data =
                             External_transition.create ~protocol_state
                               ~protocol_state_proof ~staged_ledger_diff
-                              ~validation_callback:
-                                (Mina_net2.Validation_callback
-                                 .create_without_expiration ())
                               ~delta_transition_chain_proof ()
                         }
                       |> External_transition.skip_time_received_validation
@@ -1228,9 +1225,6 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
               ; data =
                   External_transition.create ~protocol_state
                     ~protocol_state_proof ~staged_ledger_diff
-                    ~validation_callback:
-                      (Mina_net2.Validation_callback.create_without_expiration
-                         ())
                     ~delta_transition_chain_proof ()
               }
             |> External_transition.skip_time_received_validation

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -159,7 +159,7 @@ let sync_ledger t ~preferred ~root_sync_ledger ~transition_graph
   let response_writer = Sync_ledger.Db.answer_writer root_sync_ledger in
   Mina_networking.glue_sync_ledger ~preferred t.network query_reader
     response_writer ;
-  Reader.iter sync_ledger_reader ~f:(fun incoming_transition ->
+  Reader.iter sync_ledger_reader ~f:(fun (`Block incoming_transition, _) ->
       let (transition, _) : External_transition.Initial_validated.t =
         Envelope.Incoming.data incoming_transition
       in
@@ -225,13 +225,13 @@ let run ~logger ~trust_system ~verifier ~network ~consensus_local_state
                ( `Capacity 50
                , `Overflow
                    (Drop_head
-                      (fun head ->
+                      (fun (`Block block, `Valid_cb valid_cb) ->
                         Mina_metrics.(
                           Counter.inc_one
                             Pipe.Drop_on_overflow.bootstrap_sync_ledger) ;
                         External_transition.Initial_validated
-                        .handle_dropped_transition
-                          (Envelope.Incoming.data head)
+                        .handle_dropped_transition ?valid_cb
+                          (Envelope.Incoming.data block)
                           ~pipe_name:sync_ledger_pipe ~logger)) ))
         in
         don't_wait_for
@@ -736,7 +736,9 @@ let%test_module "Bootstrap_controller tests" =
               let%bind () =
                 Deferred.List.iter branch ~f:(fun breadcrumb ->
                     Strict_pipe.Writer.write sync_ledger_writer
-                      (downcast_breadcrumb ~sender:other.peer breadcrumb))
+                      ( `Block
+                          (downcast_breadcrumb ~sender:other.peer breadcrumb)
+                      , `Vallid_cb None ))
               in
               Strict_pipe.Writer.close sync_ledger_writer ;
               sync_deferred) ;
@@ -840,13 +842,16 @@ let%test_module "Bootstrap_controller tests" =
             Pipe_lib.Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
               (Buffered (`Capacity 10, `Overflow (Drop_head ignore)))
           in
-          Envelope.Incoming.wrap
-            ~data:
-              ( Transition_frontier.best_tip peer_net.state.frontier
-              |> Transition_frontier.Breadcrumb.validated_transition
-              |> External_transition.Validated.to_initial_validated )
-            ~sender:(Envelope.Sender.Remote peer_net.peer)
-          |> Pipe_lib.Strict_pipe.Writer.write transition_writer ;
+          let block =
+            Envelope.Incoming.wrap
+              ~data:
+                ( Transition_frontier.best_tip peer_net.state.frontier
+                |> Transition_frontier.Breadcrumb.validated_transition
+                |> External_transition.Validated.to_initial_validated )
+              ~sender:(Envelope.Sender.Remote peer_net.peer)
+          in
+          Pipe_lib.Strict_pipe.Writer.write transition_writer
+            (`Block block, `Valid_cb None) ;
           let new_frontier, sorted_external_transitions =
             Async.Thread_safe.block_on_async_exn (fun () ->
                 run_bootstrap

--- a/src/lib/bootstrap_controller/bootstrap_controller.mli
+++ b/src/lib/bootstrap_controller/bootstrap_controller.mli
@@ -12,7 +12,9 @@ val run :
   -> network:Mina_networking.t
   -> consensus_local_state:Consensus.Data.Local_state.t
   -> transition_reader:
-       External_transition.Initial_validated.t Envelope.Incoming.t
+       ( [ `Block of External_transition.Initial_validated.t Envelope.Incoming.t
+         ]
+       * [ `Valid_cb of Mina_net2.Validation_callback.t option ] )
        Strict_pipe.Reader.t
   -> best_seen_transition:
        External_transition.Initial_validated.t Envelope.Incoming.t option

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -366,7 +366,8 @@ module type Transition_router_intf = sig
     -> catchup_mode:[ `Normal | `Super ]
     -> notify_online:(unit -> unit Deferred.t)
     -> ( [ `Transition of External_transition.Validated.t ]
-       * [ `Source of [ `Gossip | `Catchup | `Internal ] ] )
+       * [ `Source of [ `Gossip | `Catchup | `Internal ] ]
+       * [ `Valid_cb of Mina_net2.Validation_callback.t option ] )
        Strict_pipe.Reader.t
        * unit Ivar.t
 end

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1759,35 +1759,7 @@ let create ?wallets (config : Config.t) =
               ~frontier_broadcast_pipe:
                 (frontier_broadcast_pipe_r, frontier_broadcast_pipe_w)
               ~catchup_mode ~network_transition_reader:block_reader
-              ~producer_transition_reader:
-                (Strict_pipe.Reader.map producer_transition_reader
-                   ~f:(fun breadcrumb ->
-                     let et =
-                       Transition_frontier.Breadcrumb.validated_transition
-                         breadcrumb
-                     in
-                     let validation_callback =
-                       Mina_net2.Validation_callback.create_without_expiration
-                         ()
-                     in
-                     External_transition.Validated.poke_validation_callback et
-                       validation_callback ;
-                     don't_wait_for
-                       (* this will never throw since the callback was created without expiration *)
-                       (let%bind v =
-                          Mina_net2.Validation_callback.await_exn
-                            validation_callback
-                        in
-                        if
-                          Mina_net2.Validation_callback.equal_validation_result
-                            v `Accept
-                        then
-                          Mina_networking.broadcast_state net
-                            (External_transition.Validation
-                             .forget_validation_with_hash et)
-                        else Deferred.unit) ;
-                     breadcrumb))
-              ~most_recent_valid_block
+              ~producer_transition_reader ~most_recent_valid_block
               ~precomputed_values:config.precomputed_values ~notify_online
           in
           let ( valid_transitions_for_network
@@ -1798,7 +1770,8 @@ let create ?wallets (config : Config.t) =
             in
             let api_pipe, new_blocks_pipe =
               Strict_pipe.Reader.(
-                Fork.two (map downstream_pipe ~f:(fun (`Transition t, _) -> t)))
+                Fork.two
+                  (map downstream_pipe ~f:(fun (`Transition t, _, _) -> t)))
             in
             (network_pipe, api_pipe, new_blocks_pipe)
           in
@@ -1821,7 +1794,9 @@ let create ?wallets (config : Config.t) =
           O1trace.background_thread "broadcast_blocks" (fun () ->
               Strict_pipe.Reader.iter_without_pushback
                 valid_transitions_for_network
-                ~f:(fun (`Transition transition, `Source source) ->
+                ~f:(fun
+                     (`Transition transition, `Source source, `Valid_cb valid_cb)
+                   ->
                   let hash =
                     (External_transition.Validated.state_hashes transition)
                       .state_hash
@@ -1850,13 +1825,32 @@ let create ?wallets (config : Config.t) =
                               ]
                             (Rebroadcast_transition { state_hash = hash }) ;
                           (*send callback to libp2p to forward the gossiped transition*)
-                          External_transition.Validated.accept transition
+                          Option.iter
+                            ~f:
+                              (Fn.flip
+                                 Mina_net2.Validation_callback
+                                 .fire_if_not_already_fired `Accept)
+                            valid_cb
                       | `Internal ->
                           (*Send callback to publish the new block. Don't log rebroadcast message if it is internally generated; There is a broadcast log*)
-                          External_transition.Validated.accept transition
+                          don't_wait_for
+                            (Mina_networking.broadcast_state net
+                               (External_transition.Validation
+                                .forget_validation_with_hash transition)) ;
+                          Option.iter
+                            ~f:
+                              (Fn.flip
+                                 Mina_net2.Validation_callback
+                                 .fire_if_not_already_fired `Accept)
+                            valid_cb
                       | `Catchup ->
                           (*Noop for directly downloaded transitions*)
-                          External_transition.Validated.accept transition )
+                          Option.iter
+                            ~f:
+                              (Fn.flip
+                                 Mina_net2.Validation_callback
+                                 .fire_if_not_already_fired `Accept)
+                            valid_cb )
                   | Error reason -> (
                       let timing_error_json =
                         match reason with
@@ -1873,7 +1867,12 @@ let create ?wallets (config : Config.t) =
                         ; ("timing", timing_error_json)
                         ]
                       in
-                      External_transition.Validated.reject transition ;
+                      Option.iter
+                        ~f:
+                          (Fn.flip
+                             Mina_net2.Validation_callback
+                             .fire_if_not_already_fired `Reject)
+                        valid_cb ;
                       match source with
                       | `Catchup ->
                           ()

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -3,28 +3,6 @@ open Core_kernel
 open Mina_base
 open Mina_state
 
-module Validate_content = struct
-  type t = Mina_net2.Validation_callback.t
-
-  let bin_read_t buf ~pos_ref =
-    bin_read_unit buf ~pos_ref ;
-    Mina_net2.Validation_callback.create_without_expiration ()
-
-  let bin_write_t buf ~pos _ = bin_write_unit buf ~pos ()
-
-  let bin_shape_t = bin_shape_unit
-
-  let bin_size_t _ = bin_size_unit ()
-
-  let t_of_sexp _ = Mina_net2.Validation_callback.create_without_expiration ()
-
-  let sexp_of_t _ = sexp_of_unit ()
-
-  let compare _ _ = 0
-
-  let __versioned__ = ()
-end
-
 (* do not expose refer to types in here directly; use allocation functor version instead *)
 module Raw_versioned__ = struct
   [%%versioned
@@ -38,7 +16,6 @@ module Raw_versioned__ = struct
             State_hash.Stable.V1.t * State_body_hash.Stable.V1.t list
         ; current_protocol_version : Protocol_version.Stable.V1.t
         ; proposed_protocol_version_opt : Protocol_version.Stable.V1.t option
-        ; mutable validation_callback : Validate_content.t
         }
       [@@deriving compare, sexp, fields]
 
@@ -49,22 +26,19 @@ module Raw_versioned__ = struct
         -> protocol_state_proof:Proof.t
         -> staged_ledger_diff:Staged_ledger_diff.t
         -> delta_transition_chain_proof:State_hash.t * State_body_hash.t list
-        -> validation_callback:Validate_content.t
         -> ?proposed_protocol_version_opt:Protocol_version.t
         -> unit
         -> 'a
 
       let map_creator c ~f ~protocol_state ~protocol_state_proof
-          ~staged_ledger_diff ~delta_transition_chain_proof ~validation_callback
+          ~staged_ledger_diff ~delta_transition_chain_proof
           ?proposed_protocol_version_opt () =
         f
           (c ~protocol_state ~protocol_state_proof ~staged_ledger_diff
-             ~delta_transition_chain_proof ~validation_callback
-             ?proposed_protocol_version_opt ())
+             ~delta_transition_chain_proof ?proposed_protocol_version_opt ())
 
       let create ~protocol_state ~protocol_state_proof ~staged_ledger_diff
-          ~delta_transition_chain_proof ~validation_callback
-          ?proposed_protocol_version_opt () =
+          ~delta_transition_chain_proof ?proposed_protocol_version_opt () =
         let current_protocol_version =
           try Protocol_version.get_current ()
           with _ ->
@@ -78,7 +52,6 @@ module Raw_versioned__ = struct
         ; delta_transition_chain_proof
         ; current_protocol_version
         ; proposed_protocol_version_opt
-        ; validation_callback
         }
     end
   end]
@@ -98,8 +71,6 @@ Raw_versioned__.
   , delta_transition_chain_proof
   , current_protocol_version
   , proposed_protocol_version_opt
-  , validation_callback
-  , set_validation_callback
   , compare )]
 
 [%%define_locally Stable.Latest.(create, sexp_of_t, t_of_sexp)]
@@ -114,7 +85,6 @@ type t_ = Raw_versioned__.t =
   ; delta_transition_chain_proof: State_hash.t * State_body_hash.t list
   ; current_protocol_version: Protocol_version.t
   ; proposed_protocol_version_opt: Protocol_version.t option
-  ; mutable validation_callback: Validate_content.t }
 *)
 
 module Precomputed_block = struct
@@ -323,16 +293,6 @@ let payments t =
         Some { With_status.data = c; status }
     | _ ->
         None)
-
-let accept t =
-  Mina_net2.Validation_callback.fire_if_not_already_fired
-    (validation_callback t) `Accept
-
-let reject t =
-  Mina_net2.Validation_callback.fire_if_not_already_fired
-    (validation_callback t) `Reject
-
-let poke_validation_callback t cb = set_validation_callback t cb
 
 let timestamp =
   Fn.compose Blockchain_state.timestamp
@@ -915,21 +875,19 @@ module With_validation = struct
 
   let protocol_version_status t = lift protocol_version_status t
 
-  let accept t = lift accept t
-
-  let reject t = lift reject t
-
-  let poke_validation_callback t = lift poke_validation_callback t
-
-  let handle_dropped_transition ?pipe_name ~logger t =
+  let handle_dropped_transition ?pipe_name ?valid_cb ~logger block =
     [%log warn] "Dropping state_hash $state_hash from $pipe transition pipe"
       ~metadata:
         [ ( "state_hash"
-          , State_hash.to_yojson
-              (state_hashes t).State_hash.State_hashes.state_hash )
+          , State_hash.(to_yojson (state_hashes block).State_hashes.state_hash)
+          )
         ; ("pipe", `String (Option.value pipe_name ~default:"an unknown"))
         ] ;
-    reject t
+    Option.iter
+      ~f:
+        (Fn.flip Mina_net2.Validation_callback.fire_if_not_already_fired
+           `Reject)
+      valid_cb
 end
 
 module Initial_validated = struct
@@ -1145,9 +1103,6 @@ module Validated = struct
     , current_protocol_version
     , proposed_protocol_version_opt
     , protocol_version_status
-    , accept
-    , reject
-    , poke_validation_callback
     , protocol_state_proof
     , blockchain_state
     , blockchain_length
@@ -1208,8 +1163,6 @@ let genesis ~precomputed_values =
                *)
              ~protocol_state_proof:Proof.blockchain_dummy
              ~staged_ledger_diff:empty_diff
-             ~validation_callback:
-               (Mina_net2.Validation_callback.create_without_expiration ())
              ~delta_transition_chain_proof:
                (Protocol_state.previous_state_hash protocol_state, [])
              ()))
@@ -1218,12 +1171,10 @@ let genesis ~precomputed_values =
 
 module For_tests = struct
   let create ~protocol_state ~protocol_state_proof ~staged_ledger_diff
-      ~delta_transition_chain_proof ~validation_callback
-      ?proposed_protocol_version_opt () =
+      ~delta_transition_chain_proof ?proposed_protocol_version_opt () =
     Protocol_version.(set_current zero) ;
     create ~protocol_state ~protocol_state_proof ~staged_ledger_diff
-      ~delta_transition_chain_proof ~validation_callback
-      ?proposed_protocol_version_opt ()
+      ~delta_transition_chain_proof ?proposed_protocol_version_opt ()
 
   let genesis ~precomputed_values =
     Protocol_version.(set_current zero) ;

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -3,6 +3,27 @@ open Core_kernel
 open Mina_base
 open Mina_state
 
+(* this module exists only as a stub to keep the bin_io for external transition from changing *)
+module Validate_content = struct
+  type t = unit
+
+  let bin_read_t buf ~pos_ref = bin_read_unit buf ~pos_ref
+
+  let bin_write_t buf ~pos _ = bin_write_unit buf ~pos ()
+
+  let bin_shape_t = bin_shape_unit
+
+  let bin_size_t _ = bin_size_unit ()
+
+  let t_of_sexp _ = ()
+
+  let sexp_of_t _ = sexp_of_unit ()
+
+  let compare _ _ = 0
+
+  let __versioned__ = ()
+end
+
 (* do not expose refer to types in here directly; use allocation functor version instead *)
 module Raw_versioned__ = struct
   [%%versioned
@@ -16,6 +37,7 @@ module Raw_versioned__ = struct
             State_hash.Stable.V1.t * State_body_hash.Stable.V1.t list
         ; current_protocol_version : Protocol_version.Stable.V1.t
         ; proposed_protocol_version_opt : Protocol_version.Stable.V1.t option
+        ; mutable validation_callback : Validate_content.t
         }
       [@@deriving compare, sexp, fields]
 
@@ -52,6 +74,7 @@ module Raw_versioned__ = struct
         ; delta_transition_chain_proof
         ; current_protocol_version
         ; proposed_protocol_version_opt
+        ; validation_callback = ()
         }
     end
   end]

--- a/src/lib/mina_transition/external_transition_intf.ml
+++ b/src/lib/mina_transition/external_transition_intf.ml
@@ -56,12 +56,6 @@ module type External_transition_common_intf = sig
   val current_protocol_version : t -> Protocol_version.t
 
   val proposed_protocol_version_opt : t -> Protocol_version.t option
-
-  val accept : t -> unit
-
-  val reject : t -> unit
-
-  val poke_validation_callback : t -> Mina_net2.Validation_callback.t -> unit
 end
 
 module type External_transition_base_intf = sig
@@ -300,7 +294,11 @@ module type S = sig
     [@@deriving compare]
 
     val handle_dropped_transition :
-      ?pipe_name:string -> logger:Logger.t -> t -> unit
+         ?pipe_name:string
+      -> ?valid_cb:Mina_net2.Validation_callback.t
+      -> logger:Logger.t
+      -> t
+      -> unit
 
     include External_transition_common_intf with type t := t
   end
@@ -353,7 +351,11 @@ module type S = sig
       external_transition -> [ `I_swear_this_is_safe_see_my_comment of t ]
 
     val handle_dropped_transition :
-      ?pipe_name:string -> logger:Logger.t -> t -> unit
+         ?pipe_name:string
+      -> ?valid_cb:Mina_net2.Validation_callback.t
+      -> logger:Logger.t
+      -> t
+      -> unit
 
     val commands : t -> User_command.Valid.t With_status.t list
 
@@ -367,7 +369,6 @@ module type S = sig
     -> protocol_state_proof:Proof.t
     -> staged_ledger_diff:Staged_ledger_diff.t
     -> delta_transition_chain_proof:State_hash.t * State_body_hash.t list
-    -> validation_callback:Mina_net2.Validation_callback.t
     -> ?proposed_protocol_version_opt:Protocol_version.t
     -> unit
     -> t
@@ -380,7 +381,6 @@ module type S = sig
       -> protocol_state_proof:Proof.t
       -> staged_ledger_diff:Staged_ledger_diff.t
       -> delta_transition_chain_proof:State_hash.t * State_body_hash.t list
-      -> validation_callback:Mina_net2.Validation_callback.t
       -> ?proposed_protocol_version_opt:Protocol_version.t
       -> unit
       -> t

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -414,8 +414,6 @@ module For_tests = struct
         External_transition.For_tests.create ~protocol_state
           ~protocol_state_proof:Proof.blockchain_dummy
           ~staged_ledger_diff:(Staged_ledger_diff.forget staged_ledger_diff)
-          ~validation_callback:
-            (Mina_net2.Validation_callback.create_without_expiration ())
           ~delta_transition_chain_proof:(previous_state_hashes.state_hash, []) ()
       in
       (* We manually created a verified an external_transition *)

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -36,7 +36,7 @@ let cached_transform_deferred_result ~transform_cached ~transform_result cached
 (* add a breadcrumb and perform post processing *)
 let add_and_finalize ~logger ~frontier ~catchup_scheduler
     ~processed_transition_writer ~only_if_present ~time_controller ~source
-    cached_breadcrumb ~(precomputed_values : Precomputed_values.t) =
+    ~valid_cb cached_breadcrumb ~(precomputed_values : Precomputed_values.t) =
   let breadcrumb =
     if Cached.is_pure cached_breadcrumb then Cached.peek cached_breadcrumb
     else Cached.invalidate_with_success cached_breadcrumb
@@ -75,13 +75,14 @@ let add_and_finalize ~logger ~frontier ~catchup_scheduler
       Mina_metrics.Block_latency.Inclusion_time.update
         (Block_time.Span.to_time_span time_elapsed) ) ;
   Writer.write processed_transition_writer
-    (`Transition transition, `Source source) ;
+    (`Transition transition, `Source source, `Valid_cb valid_cb) ;
   Catchup_scheduler.notify catchup_scheduler
     ~hash:(External_transition.Validated.state_hashes transition).state_hash
 
 let process_transition ~logger ~trust_system ~verifier ~frontier
     ~catchup_scheduler ~processed_transition_writer ~time_controller
-    ~transition:cached_initially_validated_transition ~precomputed_values =
+    ~transition:cached_initially_validated_transition ~valid_cb
+    ~precomputed_values =
   let enveloped_initially_validated_transition =
     Cached.peek cached_initially_validated_transition
   in
@@ -193,14 +194,16 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
     Deferred.map ~f:Result.return
       (add_and_finalize ~logger ~frontier ~catchup_scheduler
          ~processed_transition_writer ~only_if_present:false ~time_controller
-         ~source:`Gossip breadcrumb ~precomputed_values))
+         ~source:`Gossip breadcrumb ~precomputed_values ~valid_cb))
 
 let run ~logger ~(precomputed_values : Precomputed_values.t) ~verifier
     ~trust_system ~time_controller ~frontier
     ~(primary_transition_reader :
-       ( External_transition.Initial_validated.t Envelope.Incoming.t
-       , State_hash.t )
-       Cached.t
+       ( [ `Block of
+           ( External_transition.Initial_validated.t Envelope.Incoming.t
+           , State_hash.t )
+           Cached.t ]
+       * [ `Valid_cb of Mina_net2.Validation_callback.t option ] )
        Reader.t)
     ~(producer_transition_reader : Transition_frontier.Breadcrumb.t Reader.t)
     ~(clean_up_catchup_scheduler : unit Ivar.t)
@@ -275,7 +278,7 @@ let run ~logger ~(precomputed_values : Precomputed_values.t) ~verifier
                                * we're catching up *)
                             ~f:
                               (add_and_finalize ~logger ~only_if_present:true
-                                 ~source:`Catchup))
+                                 ~source:`Catchup ~valid_cb:None))
                     with
                   | Ok () ->
                       ()
@@ -315,7 +318,7 @@ let run ~logger ~(precomputed_values : Precomputed_values.t) ~verifier
                   let%map () =
                     match%map
                       add_and_finalize ~logger ~only_if_present:false
-                        ~source:`Internal breadcrumb
+                        ~source:`Internal breadcrumb ~valid_cb:None
                     with
                     | Ok () ->
                         ()
@@ -333,8 +336,9 @@ let run ~logger ~(precomputed_values : Precomputed_values.t) ~verifier
                   Mina_metrics.(
                     Gauge.dec_one
                       Transition_frontier_controller.transitions_being_processed)
-              | `Partially_valid_transition transition ->
-                  process_transition ~transition)))
+              | `Partially_valid_transition
+                  (`Block transition, `Valid_cb valid_cb) ->
+                  process_transition ~transition ~valid_cb)))
 
 let%test_module "Transition_handler.Processor tests" =
   ( module struct
@@ -412,9 +416,12 @@ let%test_module "Transition_handler.Processor tests" =
                   ~catchup_breadcrumbs_reader ~catchup_breadcrumbs_writer
                   ~processed_transition_writer ~precomputed_values ;
                 List.iter branch ~f:(fun breadcrumb ->
-                    downcast_breadcrumb breadcrumb
-                    |> Unprocessed_transition_cache.register_exn cache
-                    |> Strict_pipe.Writer.write valid_transition_writer) ;
+                    let b =
+                      downcast_breadcrumb breadcrumb
+                      |> Unprocessed_transition_cache.register_exn cache
+                    in
+                    Strict_pipe.Writer.write valid_transition_writer
+                      (`Block b, `Valid_cb None)) ;
                 match%map
                   Block_time.Timeout.await
                     ~timeout_duration:(Block_time.Span.of_ms 30000L)
@@ -423,7 +430,7 @@ let%test_module "Transition_handler.Processor tests" =
                        ~init:branch
                        ~f:(fun
                             remaining_breadcrumbs
-                            (`Transition newly_added_transition, _)
+                            (`Transition newly_added_transition, _, _)
                           ->
                          Deferred.return
                            ( match remaining_breadcrumbs with

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -298,11 +298,11 @@ let run ~logger ~trust_system ~verifier ~transition_reader
                     >>= defer validate_protocol_versions)
                 with
                 | Ok verified_transition ->
-                    External_transition.poke_validation_callback
-                      (Envelope.Incoming.data transition_env)
-                      valid_cb ;
-                    Envelope.Incoming.wrap ~data:verified_transition ~sender
-                    |> Writer.write valid_transition_writer ;
+                    Writer.write valid_transition_writer
+                      ( `Block
+                          (Envelope.Incoming.wrap ~data:verified_transition
+                             ~sender)
+                      , `Valid_cb valid_cb ) ;
                     Mina_metrics.Transition_frontier
                     .update_max_blocklength_observed blockchain_length ;
                     Queue.enqueue Transition_frontier.validated_blocks


### PR DESCRIPTION
Problem: mutable field validation_callback is misplaced in the external
transition type.

Solution: remove the field out of the block type.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
