### PR TITLE
[mina-signer] Bump version to 1.3.0

### DIFF
--- a/frontend/mina-signer/package-lock.json
+++ b/frontend/mina-signer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mina-signer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mina-signer",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^13.7.0",

--- a/frontend/mina-signer/package.json
+++ b/frontend/mina-signer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mina-signer",
   "description": "Node API for signing transactions on various networks for Mina Protocol",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "scripts": {
     "build": "tsc && cp src/client_sdk.bc.js dist/src && cp src/plonk_wasm.js dist/src && cp src/plonk_wasm_bg.wasm dist/src",
     "clean": "rm -rf dist",


### PR DESCRIPTION
**Description**

This bumps the `mina-signer` package.json value to `1.3.0`. These new sets of changes should include a fix to signing on the Berkeley QA network. Additionally, this includes the `signParty` and `signTransaction` methods on the `mina-signer`.

**Tested By**
Creating a link with `npm link` and then running a test script to verify all signing transactions.

EDIT: `mina-signer` still does not work with signatures on the Berkeley QA network. Do not merge for now.