### PR TITLE
Fix duplicate block bug

### DIFF
--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -544,13 +544,17 @@ let apply_diff (type mutant) t (diff : (Diff.full, mutant) Diff.t)
       let breadcrumb_hash = Breadcrumb.state_hash breadcrumb in
       let parent_hash = Breadcrumb.parent_hash breadcrumb in
       let parent_node = Hashtbl.find_exn t.table parent_hash in
-      Hashtbl.add_exn t.table ~key:breadcrumb_hash
-        ~data:{breadcrumb; successor_hashes= []; length= parent_node.length + 1} ;
-      Hashtbl.set t.table ~key:parent_hash
-        ~data:
-          { parent_node with
-            successor_hashes= breadcrumb_hash :: parent_node.successor_hashes
-          } ;
+      if Hashtbl.mem t.table breadcrumb_hash then
+        [%log' error t.logger] "Same block ($state_hash) was applied to transition frontier more than once; this could indicate that you are running multiple block producers with the same keypair"
+          ~metadata:[("state_hash", State_hash.to_yojson breadcrumb_hash)]
+      else (
+        Hashtbl.add_exn t.table ~key:breadcrumb_hash
+          ~data:{breadcrumb; successor_hashes= []; length= parent_node.length + 1} ;
+        Hashtbl.set t.table ~key:parent_hash
+          ~data:
+            { parent_node with
+              successor_hashes= breadcrumb_hash :: parent_node.successor_hashes
+            } ) ;
       ((), None)
   | Best_tip_changed new_best_tip ->
       let old_best_tip = t.best_tip in

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -544,17 +544,17 @@ let apply_diff (type mutant) t (diff : (Diff.full, mutant) Diff.t)
       let breadcrumb_hash = Breadcrumb.state_hash breadcrumb in
       let parent_hash = Breadcrumb.parent_hash breadcrumb in
       let parent_node = Hashtbl.find_exn t.table parent_hash in
-      if Hashtbl.mem t.table breadcrumb_hash then
-        [%log' error t.logger] "Same block ($state_hash) was applied to transition frontier more than once; this could indicate that you are running multiple block producers with the same keypair"
-          ~metadata:[("state_hash", State_hash.to_yojson breadcrumb_hash)]
-      else (
-        Hashtbl.add_exn t.table ~key:breadcrumb_hash
-          ~data:{breadcrumb; successor_hashes= []; length= parent_node.length + 1} ;
-        Hashtbl.set t.table ~key:parent_hash
-          ~data:
-            { parent_node with
-              successor_hashes= breadcrumb_hash :: parent_node.successor_hashes
-            } ) ;
+      let node = {Node.breadcrumb; successor_hashes= []; length= parent_node.length + 1} in
+      ( match Hashtbl.add t.table ~key:breadcrumb_hash ~data:node with
+        | `Duplicate ->
+          [%log' error t.logger] "Same block ($state_hash) was applied to transition frontier more than once; this could indicate that you are running multiple block producers with the same keypair"
+            ~metadata:[("state_hash", State_hash.to_yojson breadcrumb_hash)]
+        | `Ok ->
+          Hashtbl.set t.table ~key:parent_hash
+            ~data:
+              { parent_node with
+                successor_hashes= breadcrumb_hash :: parent_node.successor_hashes
+              } ) ;
       ((), None)
   | Best_tip_changed new_best_tip ->
       let old_best_tip = t.best_tip in


### PR DESCRIPTION
Fixes bug reported in #10717.

The transition frontier would crash if a diff was applied to it which adds a breadcrumb that already exists in the frontier. If 2 block producing nodes are running with the same keypair, and generate the same staged ledger diff when producing their block, then this issue can happen. The fix is to just log a message instead of crashing.