### PR TITLE
Add `accounts_accessed`, `accounts_created` to archive RPC

### DIFF
--- a/rfcs/0045-zkapp-balance-data-in-archive.md
+++ b/rfcs/0045-zkapp-balance-data-in-archive.md
@@ -112,7 +112,7 @@ single table, because they contain differing numbers of elements.
 Add a new table `accounts_created`:
 ```
   block_id            int                NOT NULL  REFERENCES blocks(id)
-  public_key_id       int                NOT NULL  REFERENCES public_keys(id)
+  account_id_id       int                NOT NULL  REFERENCES account_ids(id)
   creation_fee        bigint             NOT NULL
 ```
 

--- a/src/app/archive/archive_lib/diff.ml
+++ b/src/app/archive/archive_lib/diff.ml
@@ -94,15 +94,16 @@ module Builder = struct
             None)
     in
     let accounts_created =
-      let constraint_constants = precomputed_values.constraint_constants in
-      let account_creation_fee = constraint_constants.account_creation_fee in
-      let latest_block_transactions =
-        External_transition.Validated.transactions ~constraint_constants
-          validated_block
+      let account_creation_fee =
+        precomputed_values.constraint_constants.account_creation_fee
+      in
+      let previous_block_state_hash =
+        External_transition.Validated.protocol_state validated_block
+        |> Mina_state.Protocol_state.previous_state_hash
       in
       List.map
         (Staged_ledger.latest_block_accounts_created staged_ledger
-           ~latest_block_transactions) ~f:(fun acct_id ->
+           ~previous_block_state_hash) ~f:(fun acct_id ->
           (acct_id, account_creation_fee))
     in
     Transition_frontier.Breadcrumb_added

--- a/src/app/archive/archive_lib/diff.ml
+++ b/src/app/archive/archive_lib/diff.ml
@@ -17,6 +17,10 @@ module Transition_frontier = struct
         { block :
             External_transition.Stable.Latest.t
             State_hash.With_state_hashes.Stable.Latest.t
+              (* ledger index, account *)
+        ; accounts_accessed : (int * Mina_base.Account.Stable.Latest.t) list
+        ; accounts_created :
+            (Account_id.Stable.Latest.t * Currency.Fee.Stable.Latest.t) list
         ; sender_receipt_chains_from_parent_ledger :
             (Account_id.Stable.Latest.t * Receipt.Chain_hash.Stable.Latest.t)
             list
@@ -41,20 +45,19 @@ type t =
 [@@deriving bin_io_unversioned]
 
 module Builder = struct
-  let breadcrumb_added breadcrumb =
+  let breadcrumb_added ~logger breadcrumb =
     let ((block, _) as validated_block) =
       Breadcrumb.validated_transition breadcrumb
     in
     let commands = External_transition.Validated.commands validated_block in
+    let staged_ledger = Breadcrumb.staged_ledger breadcrumb in
+    let ledger = Staged_ledger.ledger staged_ledger in
     let sender_receipt_chains_from_parent_ledger =
       let senders =
         commands
         |> List.map ~f:(fun { data; _ } ->
                User_command.(fee_payer (forget_check data)))
         |> Account_id.Set.of_list
-      in
-      let ledger =
-        Staged_ledger.ledger @@ Breadcrumb.staged_ledger breadcrumb
       in
       Set.to_list senders
       |> List.map ~f:(fun sender ->
@@ -68,8 +71,40 @@ module Builder = struct
                in
                (sender, receipt_chain_hash)))
     in
+    let accounts_accessed =
+      let account_ids_accessed =
+        External_transition.Validated.account_ids_accessed validated_block
+      in
+      List.filter_map account_ids_accessed ~f:(fun acct_id ->
+          try
+            let index =
+              Mina_ledger.Ledger.index_of_account_exn ledger acct_id
+            in
+            let account = Mina_ledger.Ledger.get_at_index_exn ledger index in
+            Some (index, account)
+          with exn ->
+            [%log error]
+              "When building Breadcrumb_added RPC message, exception when \
+               finding account id in staged ledger"
+              ~metadata:
+                [ ("account_id", Account_id.to_yojson acct_id)
+                ; ("exception", `String (Exn.to_string exn))
+                ] ;
+            None)
+    in
+    let accounts_created =
+      let account_creation_fee =
+        Genesis_constants.Constraint_constants.compiled.account_creation_fee
+      in
+      List.map (Staged_ledger.accounts_created staged_ledger) ~f:(fun acct_id ->
+          (acct_id, account_creation_fee))
+    in
     Transition_frontier.Breadcrumb_added
-      { block; sender_receipt_chains_from_parent_ledger }
+      { block
+      ; accounts_accessed
+      ; accounts_created
+      ; sender_receipt_chains_from_parent_ledger
+      }
 
   let user_commands user_commands =
     Transaction_pool { Transaction_pool.added = user_commands; removed = [] }

--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -67,8 +67,7 @@ module Zkapp_command = struct
           [@to_yojson Transaction_hash.to_yojson]
           [@of_yojson Transaction_hash.of_yojson]
     ; status : string
-    ; failure_reasons :
-        Transaction_status.Failure.Collection.Stable.Latest.t option
+    ; failure_reasons : Transaction_status.Failure.Collection.display option
     }
   [@@deriving yojson, equal, bin_io_unversioned]
 end

--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -50,9 +50,6 @@ module Internal_command = struct
     ; secondary_sequence_no : int
     ; typ : string
     ; receiver : Public_key.Compressed.Stable.Latest.t
-    ; receiver_account_creation_fee_paid :
-        Currency.Amount.Stable.Latest.t option
-    ; receiver_balance : Currency.Balance.Stable.Latest.t
     ; fee : Currency.Fee.Stable.Latest.t
     ; token : Token_id.Stable.Latest.t
     ; hash : Transaction_hash.Stable.Latest.t
@@ -62,7 +59,22 @@ module Internal_command = struct
   [@@deriving yojson, equal, bin_io_unversioned]
 end
 
+module Zkapp_command = struct
+  type t =
+    { sequence_no : int
+    ; parties : Parties.Stable.Latest.t
+    ; hash : Transaction_hash.Stable.Latest.t
+          [@to_yojson Transaction_hash.to_yojson]
+          [@of_yojson Transaction_hash.of_yojson]
+    ; status : string
+    ; failure_reasons :
+        Transaction_status.Failure.Collection.Stable.Latest.t option
+    }
+  [@@deriving yojson, equal, bin_io_unversioned]
+end
+
 module Block = struct
+  (* in accounts_accessed, the int is the ledger index *)
   type t =
     { state_hash : State_hash.Stable.Latest.t
     ; parent_hash : State_hash.Stable.Latest.t
@@ -80,7 +92,11 @@ module Block = struct
     ; timestamp : Block_time.Stable.Latest.t
     ; user_cmds : User_command.t list
     ; internal_cmds : Internal_command.t list
+    ; zkapp_cmds : Zkapp_command.t list
     ; chain_status : Chain_status.t
+    ; accounts_accessed : (int * Account.Stable.Latest.t) list
+    ; accounts_created :
+        (Account_id.Stable.Latest.t * Currency.Fee.Stable.Latest.t) list
     }
   [@@deriving yojson, equal, bin_io_unversioned]
 end

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -117,6 +117,31 @@ module Zkapp_states = struct
       id
 end
 
+module Zkapp_sequence_states = struct
+  let table_name = "zkapp_sequence_states"
+
+  let add_if_doesn't_exist (module Conn : CONNECTION)
+      (fps : (Pickles.Backend.Tick.Field.t, 'n) Vector.vec) =
+    let open Deferred.Result.Let_syntax in
+    let%bind (element_ids : int array) =
+      Mina_caqti.deferred_result_list_map (Vector.to_list fps) ~f:(fun field ->
+          Zkapp_state_data.add_if_doesn't_exist (module Conn) field)
+      >>| Array.of_list
+    in
+    Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
+      ~table_name
+      ~cols:([ "element_ids" ], Mina_caqti.array_int_typ)
+      ~tannot:(function "element_ids" -> Some "int[]" | _ -> None)
+      (module Conn)
+      element_ids
+
+  let load (module Conn : CONNECTION) id =
+    Conn.find
+      (Caqti_request.find Caqti_type.int Mina_caqti.array_int_typ
+         (Mina_caqti.select_cols_from_id ~table_name ~cols:[ "element_ids" ]))
+      id
+end
+
 module Zkapp_verification_keys = struct
   type t = { verification_key : string; hash : string }
   [@@deriving fields, hlist]
@@ -131,7 +156,7 @@ module Zkapp_verification_keys = struct
       (vk :
         ( Pickles.Side_loaded.Verification_key.t
         , Pickles.Backend.Tick.Field.t )
-        With_hash.Stable.Latest.t) =
+        With_hash.t) =
     let verification_key =
       Binable.to_string
         (module Pickles.Side_loaded.Verification_key.Stable.Latest)
@@ -442,7 +467,7 @@ module Zkapp_nonce_bounds = struct
       id
 end
 
-module Zkapp_account = struct
+module Zkapp_precondition_account = struct
   type t =
     { balance_id : int option
     ; nonce_id : int option
@@ -468,7 +493,7 @@ module Zkapp_account = struct
         ; option bool
         ]
 
-  let table_name = "zkapp_account"
+  let table_name = "zkapp_precondition_accounts"
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (acct : Zkapp_precondition.Account.t) =
@@ -572,7 +597,8 @@ module Zkapp_account_precondition = struct
     let%bind account_id =
       match account_precondition with
       | Party.Account_precondition.Full acct ->
-          Zkapp_account.add_if_doesn't_exist (module Conn) acct >>| Option.some
+          Zkapp_precondition_account.add_if_doesn't_exist (module Conn) acct
+          >>| Option.some
       | _ ->
           return None
     in
@@ -2108,10 +2134,10 @@ module Block_and_signed_command = struct
           (module Conn)
           ~block_id ~user_command_id ~sequence_no ~status ~failure_reason
 
-  let load (module Conn : CONNECTION) ~block_id ~user_command_id =
+  let load (module Conn : CONNECTION) ~block_id ~user_command_id ~sequence_no =
     Conn.find
       (Caqti_request.find
-         Caqti_type.(tup2 int int)
+         Caqti_type.(tup3 int int int)
          typ
          {sql| SELECT block_id, user_command_id,
                sequence_no,
@@ -2125,8 +2151,326 @@ module Block_and_signed_command = struct
                FROM blocks_user_commands
                WHERE block_id = $1
                AND user_command_id = $2
+               AND sequence_no = $3
            |sql})
-      (block_id, user_command_id)
+      (block_id, user_command_id, sequence_no)
+end
+
+module Zkapp_party_failures = struct
+  type t = { index : int; failures : string array } [@@deriving fields, hlist]
+
+  let typ =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.[ int; Mina_caqti.array_string_typ ]
+
+  let table_name = "zkapp_party_failures"
+
+  let add_if_doesn't_exist (module Conn : CONNECTION) index failures =
+    let failures =
+      List.map failures ~f:Transaction_status.Failure.to_string |> Array.of_list
+    in
+    Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
+      ~table_name
+      ~cols:([ "index"; "failures" ], typ)
+      (module Conn)
+      { index; failures }
+
+  let load (module Conn : CONNECTION) id =
+    Conn.find
+      (Caqti_request.find Caqti_type.int typ
+         (Mina_caqti.select_cols_from_id ~table_name
+            ~cols:[ "index"; "failures" ]))
+      id
+end
+
+module Block_and_zkapp_command = struct
+  type t =
+    { block_id : int
+    ; zkapp_command_id : int
+    ; sequence_no : int
+    ; status : string
+    ; failure_reasons_ids : int array option
+    }
+  [@@deriving hlist]
+
+  let table_name = "blocks_zkapp_commands"
+
+  let typ =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.[ int; int; int; string; option Mina_caqti.array_int_typ ]
+
+  let add_if_doesn't_exist (module Conn : CONNECTION) ~block_id
+      ~zkapp_command_id ~sequence_no ~status
+      ~(failure_reasons : Transaction_status.Failure.Collection.t option) =
+    let open Deferred.Result.Let_syntax in
+    let%bind failure_reasons_ids =
+      match failure_reasons with
+      | None ->
+          return None
+      | Some reasons ->
+          let%map failure_reasons_ids_list =
+            Mina_caqti.deferred_result_list_mapi reasons
+              ~f:(fun ndx failure_reasons ->
+                Zkapp_party_failures.add_if_doesn't_exist
+                  (module Conn)
+                  ndx failure_reasons)
+          in
+          Some (Array.of_list failure_reasons_ids_list)
+    in
+    Mina_caqti.select_insert_into_cols
+      ~select:
+        ( "block_id, zkapp_command_id, sequence_no"
+        , Caqti_type.(tup3 int int int) )
+      ~table_name
+      ~cols:
+        ( [ "block_id"
+          ; "zkapp_command_id"
+          ; "sequence_no"
+          ; "status"
+          ; "failure_reasons_ids"
+          ]
+        , typ )
+      (module Conn)
+      { block_id; zkapp_command_id; sequence_no; status; failure_reasons_ids }
+
+  let load (module Conn : CONNECTION) ~block_id ~zkapp_command_id ~sequence_no =
+    Conn.find
+      (Caqti_request.find
+         Caqti_type.(tup3 int int int)
+         typ
+         (Mina_caqti.select_cols_from_id ~table_name
+            ~cols:
+              [ "block_id"
+              ; "zkapp_command_id"
+              ; "sequence_no"
+              ; "status"
+              ; "failure_reasons_ids"
+              ]))
+      (block_id, zkapp_command_id, sequence_no)
+end
+
+module Account_ids = struct
+  type t = { public_key_id : int; token : string; token_owner : int }
+  [@@deriving hlist, fields]
+
+  let typ =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.[ int; string; int ]
+
+  let table_name = "account_ids"
+
+  let add_if_doesn't_exist (module Conn : CONNECTION) ~account_id ~token_owner =
+    let open Deferred.Result.Let_syntax in
+    let pk = Account_id.public_key account_id in
+    let token = Account_id.token_id account_id |> Token_id.to_string in
+    let%bind public_key_id = Public_key.add_if_doesn't_exist (module Conn) pk in
+    let t = { public_key_id; token; token_owner } in
+    Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
+      ~table_name ~cols:(Fields.names, typ)
+      (module Conn)
+      t
+end
+
+module Zkapp_account = struct
+  type t =
+    { app_state_id : int
+    ; verification_key_id : int option
+    ; zkapp_version : int64
+    ; sequence_state_id : int
+    ; last_sequence_slot : int64
+    ; proved_state : bool
+    ; zkapp_uri_id : int
+    }
+  [@@deriving fields, hlist]
+
+  let typ =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.[ int; option int; int64; int; int64; bool; int ]
+
+  let table_name = "zkapp_accounts"
+
+  let add_if_doesn't_exist (module Conn : CONNECTION) zkapp_account =
+    let open Deferred.Result.Let_syntax in
+    let ({ app_state
+         ; verification_key
+         ; zkapp_version
+         ; sequence_state
+         ; last_sequence_slot
+         ; proved_state
+         }
+          : Mina_base.Zkapp_account.t) =
+      zkapp_account
+    in
+    (* zkapp_states table allow NULL elements in array, but the app state here
+       has no NULL elements: TODO: do we need to be able to store NULLs in zkapp_states?
+    *)
+    let app_state = Vector.map app_state ~f:(fun field -> Some field) in
+    let%bind app_state_id =
+      Zkapp_states.add_if_doesn't_exist (module Conn) app_state
+    in
+    let%bind verification_key_id =
+      Option.value_map verification_key ~default:(return None) ~f:(fun vk ->
+          let%map id =
+            Zkapp_verification_keys.add_if_doesn't_exist (module Conn) vk
+          in
+          Some id)
+    in
+    let zkapp_version = zkapp_version |> Unsigned.UInt32.to_int64 in
+    let%bind sequence_state_id =
+      Zkapp_sequence_states.add_if_doesn't_exist (module Conn) sequence_state
+    in
+    let last_sequence_slot =
+      Mina_numbers.Global_slot.to_uint32 last_sequence_slot
+      |> Unsigned.UInt32.to_int64
+    in
+    let zkapp_uri_id = 0 (* TODO!!!! TEMP!!! does this still exist? *) in
+    Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
+      ~table_name ~cols:(Fields.names, typ)
+      (module Conn)
+      { app_state_id
+      ; verification_key_id
+      ; zkapp_version
+      ; sequence_state_id
+      ; last_sequence_slot
+      ; proved_state
+      ; zkapp_uri_id
+      }
+end
+
+module Accounts_accessed = struct
+  type t =
+    { ledger_index : int
+    ; block_id : int
+    ; account_id_id : int
+    ; token_symbol : string
+    ; balance : int64
+    ; nonce : int64
+    ; receipt_chain_hash : string
+    ; delegate : string option
+    ; voting_for : string
+    ; timing_id : int
+    ; permissions_id : int
+    ; zkapp_id : int option
+    }
+  [@@deriving hlist, fields]
+
+  let typ =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.
+        [ int
+        ; int
+        ; int
+        ; string
+        ; int64
+        ; int64
+        ; string
+        ; option string
+        ; string
+        ; int
+        ; int
+        ; option int
+        ]
+
+  let table_name = "accounts_accessed"
+
+  let add_if_doesn't_exist (module Conn : CONNECTION) block_id
+      (ledger_index, (account : Account.t)) =
+    let open Deferred.Result.Let_syntax in
+    let account_id = Account_id.create account.public_key account.token_id in
+    let%bind account_id_id =
+      Account_ids.add_if_doesn't_exist (module Conn) ~account_id ~token_owner:0
+      (* TODO!!! TEMP!!!! need to get token owner *)
+    in
+    let token_symbol = account.token_symbol in
+    let balance =
+      account.balance |> Currency.Balance.to_uint64 |> Unsigned.UInt64.to_int64
+    in
+    let nonce =
+      account.nonce |> Account.Nonce.to_uint32 |> Unsigned.UInt32.to_int64
+    in
+    let receipt_chain_hash =
+      account.receipt_chain_hash |> Receipt.Chain_hash.to_base58_check
+    in
+    let delegate =
+      Option.map account.delegate
+        ~f:Signature_lib.Public_key.Compressed.to_base58_check
+    in
+    let voting_for = account.voting_for |> State_hash.to_base58_check in
+    let%bind timing_id =
+      Timing_info.add_if_doesn't_exist (module Conn) account
+    in
+    let%bind permissions_id =
+      Zkapp_permissions.add_if_doesn't_exist (module Conn) account.permissions
+    in
+    let%bind zkapp_id =
+      Option.value_map account.zkapp ~default:(return None) ~f:(fun zkapp ->
+          let%map id = Zkapp_account.add_if_doesn't_exist (module Conn) zkapp in
+          Some id)
+    in
+    let account_accessed : t =
+      { ledger_index
+      ; block_id
+      ; account_id_id
+      ; token_symbol
+      ; balance
+      ; nonce
+      ; receipt_chain_hash
+      ; delegate
+      ; voting_for
+      ; timing_id
+      ; permissions_id
+      ; zkapp_id
+      }
+    in
+    Mina_caqti.select_insert_into_cols
+      ~select:("block_id,account_id", Caqti_type.(tup2 int int))
+      ~table_name ~cols:(Fields.names, typ)
+      (module Conn)
+      account_accessed
+
+  let add_accounts_if_don't_exist (module Conn : CONNECTION) block_id
+      (accounts : (int * Account.t) list) =
+    let%map results =
+      Deferred.List.map accounts ~f:(fun account ->
+          add_if_doesn't_exist (module Conn) block_id account)
+    in
+    Result.all results
+end
+
+module Accounts_created = struct
+  type t = { block_id : int; account_id_id : int; creation_fee : int64 }
+  [@@deriving hlist, fields]
+
+  let typ =
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      Caqti_type.[ int; int; int64 ]
+
+  let table_name = "accounts_created"
+
+  let add_if_doesn't_exist (module Conn : CONNECTION) block_id account_id
+      creation_fee =
+    let open Deferred.Result.Let_syntax in
+    let%bind account_id_id =
+      (* TODO: TEMP!!!! -- add real token owner *)
+      Account_ids.add_if_doesn't_exist (module Conn) ~account_id ~token_owner:0
+    in
+    let creation_fee =
+      Currency.Fee.to_uint64 creation_fee |> Unsigned.UInt64.to_int64
+    in
+    let t = { block_id; account_id_id; creation_fee } in
+    Mina_caqti.select_insert_into_cols
+      ~select:("block_id,public_key_id", Caqti_type.(tup2 int int))
+      ~table_name ~cols:(Fields.names, typ)
+      (module Conn)
+      t
+
+  let add_accounts_created_if_don't_exist (module Conn : CONNECTION) block_id
+      accounts_created =
+    let%map results =
+      Deferred.List.map accounts_created ~f:(fun (pk, creation_fee) ->
+          add_if_doesn't_exist (module Conn) block_id pk creation_fee)
+    in
+    Result.all results
 end
 
 module Block = struct
@@ -2556,6 +2900,48 @@ module Block = struct
             (module Conn)
             ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no)
     in
+    (* add zkApp commands *)
+    let%bind zkapp_cmds_ids_and_seq_nos =
+      let%map zkapp_cmds_and_ids_rev =
+        Mina_caqti.deferred_result_list_fold block.zkapp_cmds ~init:[]
+          ~f:(fun acc ({ parties; _ } as zkapp_cmd) ->
+            let%map cmd_id =
+              User_command.Zkapp_command.add_if_doesn't_exist
+                (module Conn)
+                parties
+            in
+            (zkapp_cmd, cmd_id) :: acc)
+      in
+      let sequence_nos =
+        List.map block.zkapp_cmds ~f:(fun { sequence_no; _ } -> sequence_no)
+      in
+      List.zip_exn (List.rev zkapp_cmds_and_ids_rev) sequence_nos
+    in
+    (* add zkapp commands to join table *)
+    let%bind () =
+      Mina_caqti.deferred_result_list_fold zkapp_cmds_ids_and_seq_nos ~init:()
+        ~f:(fun () ((zkapp_command, zkapp_command_id), sequence_no) ->
+          let%map _block_id, _cmd_id, _sequence_no =
+            Block_and_zkapp_command.add_if_doesn't_exist
+              (module Conn)
+              ~block_id ~zkapp_command_id ~sequence_no
+              ~status:zkapp_command.status
+              ~failure_reasons:zkapp_command.failure_reasons
+          in
+          ())
+    in
+    (* add accounts accessed *)
+    let%bind _block_and_account_ids =
+      Accounts_accessed.add_accounts_if_don't_exist
+        (module Conn)
+        block_id block.accounts_accessed
+    in
+    (* add accounts created *)
+    let%bind _block_and_pk_ids =
+      Accounts_created.add_accounts_created_if_don't_exist
+        (module Conn)
+        block_id block.accounts_created
+    in
     return block_id
 
   let set_parent_id_if_null (module Conn : CONNECTION) ~parent_hash
@@ -2794,17 +3180,19 @@ let retry ~f ~logger ~error_str retries =
   in
   go retries
 
-let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
-    pool block =
+let add_block_aux ?(retries = 3) ~logger ~pool ~add_block ~hash
+    ~delete_older_than ~accounts_accessed ~accounts_created block =
+  let state_hash = hash block in
   let add () =
     Caqti_async.Pool.use
       (fun (module Conn : CONNECTION) ->
         let%bind res =
           let open Deferred.Result.Let_syntax in
           let%bind () = Conn.start () in
+
           [%log info] "Attempting to add block data for $state_hash"
             ~metadata:
-              [ ("state_hash", Mina_base.State_hash.to_yojson (hash block)) ] ;
+              [ ("state_hash", Mina_base.State_hash.to_yojson state_hash) ] ;
           let%bind block_id = add_block (module Conn : CONNECTION) block in
           (* if an existing block has a parent hash that's for the block just added,
              set its parent id
@@ -2826,52 +3214,136 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
         | Error e as err ->
             (*Error in the current transaction*)
             [%log warn]
-              "Error when adding block data to the database, rolling it back: \
-               $error"
+              "Error when adding block data to the database, rolling back \
+               transaction: $error"
               ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
             let%map _ = Conn.rollback () in
             err
-        | Ok _ ->
-            [%log info] "Committing block data for $state_hash"
-              ~metadata:
-                [ ("state_hash", Mina_base.State_hash.to_yojson (hash block)) ] ;
-            Conn.commit ())
+        | Ok _ -> (
+            (* added block data, now add accounts accessed *)
+            match%bind
+              Caqti_async.Pool.use
+                (fun (module Conn : CONNECTION) ->
+                  Block.find (module Conn) ~state_hash)
+                pool
+            with
+            | Error err ->
+                [%log warn]
+                  "Could not get block id for block just archived; can't store \
+                   accounts accessed, rolling back transaction"
+                  ~metadata:
+                    [ ("block", State_hash.to_yojson state_hash)
+                    ; ("error", `String (Caqti_error.show err))
+                    ] ;
+                Conn.rollback ()
+            | Ok block_id -> (
+                [%log info]
+                  "Adding accounts accessed in block to archive database"
+                  ~metadata:
+                    [ ("block", State_hash.to_yojson state_hash)
+                    ; ( "num_accounts_accessed"
+                      , `Int (List.length accounts_accessed) )
+                    ] ;
+                match%bind
+                  Caqti_async.Pool.use
+                    (fun (module Conn : CONNECTION) ->
+                      Accounts_accessed.add_accounts_if_don't_exist
+                        (module Conn)
+                        block_id accounts_accessed)
+                    pool
+                with
+                | Error err ->
+                    [%log error]
+                      "Could not add accounts accessed in block to archive \
+                       database, rolling back transaction"
+                      ~metadata:
+                        [ ("state_hash", State_hash.to_yojson state_hash)
+                        ; ("error", `String (Caqti_error.show err))
+                        ] ;
+                    Conn.rollback ()
+                | Ok _block_and_account_ids -> (
+                    [%log info]
+                      "Adding account creation fees to archive database"
+                      ~metadata:
+                        [ ("block", State_hash.to_yojson state_hash)
+                        ; ( "num_accounts_created"
+                          , `Int (List.length accounts_created) )
+                        ] ;
+                    match%bind
+                      Caqti_async.Pool.use
+                        (fun (module Conn : CONNECTION) ->
+                          Accounts_created.add_accounts_created_if_don't_exist
+                            (module Conn)
+                            block_id accounts_created)
+                        pool
+                    with
+                    | Ok _block_and_public_key_ids ->
+                        [%log info]
+                          "Added block data, accounts accessed, and accounts \
+                           created for $state_hash, committing transaction"
+                          ~metadata:
+                            [ ( "state_hash"
+                              , Mina_base.State_hash.to_yojson (hash block) )
+                            ] ;
+                        Conn.commit ()
+                    | Error err ->
+                        [%log warn]
+                          "Could not add account creation fees in block to \
+                           archive database, rolling back transaction"
+                          ~metadata:
+                            [ ("state_hash", State_hash.to_yojson state_hash)
+                            ; ("error", `String (Caqti_error.show err))
+                            ] ;
+                        Conn.rollback () ) ) ))
       pool
   in
   retry ~f:add ~logger ~error_str:"add_block_aux" retries
 
-let add_block_aux_precomputed ~constraint_constants =
-  add_block_aux ~add_block:(Block.add_from_precomputed ~constraint_constants)
+let add_block_aux_precomputed ~constraint_constants ~logger ?retries ~pool
+    ~delete_older_than block =
+  add_block_aux ~logger ?retries ~pool ~delete_older_than
+    ~add_block:(Block.add_from_precomputed ~constraint_constants)
     ~hash:(fun block ->
       ( block.External_transition.Precomputed_block.protocol_state
       |> Protocol_state.hashes )
         .state_hash)
+    ~accounts_accessed:
+      block.External_transition.Precomputed_block.accounts_accessed
+    ~accounts_created:
+      block.External_transition.Precomputed_block.accounts_created block
 
-let add_block_aux_extensional =
-  add_block_aux ~add_block:Block.add_from_extensional
+let add_block_aux_extensional ~logger ?retries ~pool ~delete_older_than block =
+  add_block_aux ~logger ?retries ~pool ~delete_older_than
+    ~add_block:Block.add_from_extensional
     ~hash:(fun (block : Extensional.Block.t) -> block.state_hash)
+    ~accounts_accessed:block.Extensional.Block.accounts_accessed
+    ~accounts_created:block.Extensional.Block.accounts_created block
 
-let run pool reader ~constraint_constants ~logger ~delete_older_than =
+let run pool reader ~constraint_constants ~logger ~delete_older_than :
+    unit Deferred.t =
   Strict_pipe.Reader.iter reader ~f:(function
-    | Diff.Transition_frontier (Breadcrumb_added { block; _ }) -> (
+    | Diff.Transition_frontier
+        (Breadcrumb_added { block; accounts_accessed; accounts_created; _ })
+      -> (
         let add_block = Block.add_if_doesn't_exist ~constraint_constants in
         let hash = State_hash.With_state_hashes.state_hash in
-        match%map
-          add_block_aux ~logger ~delete_older_than ~hash ~add_block pool block
+        let state_hash = hash block in
+        match%bind
+          add_block_aux ~logger ~delete_older_than ~hash ~add_block
+            ~accounts_accessed ~accounts_created ~pool block
         with
         | Error e ->
             [%log warn]
               ~metadata:
-                [ ( "block"
-                  , State_hash.With_state_hashes.state_hash block
-                    |> State_hash.to_yojson )
+                [ ("block", State_hash.to_yojson state_hash)
                 ; ("error", `String (Caqti_error.show e))
                 ]
-              "Failed to archive block: $block, see $error"
+              "Failed to archive block: $block, see $error" ;
+            Deferred.unit
         | Ok () ->
-            () )
+            Deferred.unit )
     | Transition_frontier _ ->
-        Deferred.return ()
+        Deferred.unit
     | Transaction_pool { added; removed = _ } ->
         let%map _ =
           Caqti_async.Pool.use
@@ -3025,8 +3497,8 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
       Strict_pipe.Reader.iter precomputed_block_reader
         ~f:(fun precomputed_block ->
           match%map
-            add_block_aux_precomputed ~logger ~constraint_constants
-              ~delete_older_than pool precomputed_block
+            add_block_aux_precomputed ~logger ~pool ~constraint_constants
+              ~delete_older_than precomputed_block
           with
           | Error e ->
               [%log warn]
@@ -3037,13 +3509,13 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                         .state_hash |> State_hash.to_yojson )
                   ; ("error", `String (Caqti_error.show e))
                   ]
-          | Ok () ->
+          | Ok _block_id ->
               ())
       |> don't_wait_for ;
       Strict_pipe.Reader.iter extensional_block_reader
         ~f:(fun extensional_block ->
           match%map
-            add_block_aux_extensional ~logger ~delete_older_than pool
+            add_block_aux_extensional ~logger ~pool ~delete_older_than
               extensional_block
           with
           | Error e ->
@@ -3054,7 +3526,7 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                     , extensional_block.state_hash |> State_hash.to_yojson )
                   ; ("error", `String (Caqti_error.show e))
                   ]
-          | Ok () ->
+          | Ok _block_id ->
               ())
       |> don't_wait_for ;
       Deferred.ignore_m

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2284,13 +2284,12 @@ module Zkapp_account = struct
     ; sequence_state_id : int
     ; last_sequence_slot : int64
     ; proved_state : bool
-    ; zkapp_uri_id : int
     }
   [@@deriving fields, hlist]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int; option int; int64; int; int64; bool; int ]
+      Caqti_type.[ int; option int; int64; int; int64; bool ]
 
   let table_name = "zkapp_accounts"
 
@@ -2306,9 +2305,6 @@ module Zkapp_account = struct
           : Mina_base.Zkapp_account.t) =
       zkapp_account
     in
-    (* zkapp_states table allow NULL elements in array, but the app state here
-       has no NULL elements: TODO: do we need to be able to store NULLs in zkapp_states?
-    *)
     let app_state = Vector.map app_state ~f:(fun field -> Some field) in
     let%bind app_state_id =
       Zkapp_states.add_if_doesn't_exist (module Conn) app_state
@@ -2328,7 +2324,6 @@ module Zkapp_account = struct
       Mina_numbers.Global_slot.to_uint32 last_sequence_slot
       |> Unsigned.UInt32.to_int64
     in
-    let zkapp_uri_id = 0 (* TODO!!!! TEMP!!! does this still exist? *) in
     Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
       ~table_name ~cols:(Fields.names, typ)
       (module Conn)
@@ -2338,7 +2333,6 @@ module Zkapp_account = struct
       ; sequence_state_id
       ; last_sequence_slot
       ; proved_state
-      ; zkapp_uri_id
       }
 end
 

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -235,7 +235,8 @@ let%test_module "Archive node unit tests" =
             List.map
               ~f:(fun breadcrumb ->
                 Diff.Transition_frontier
-                  (Diff.Builder.breadcrumb_added ~logger breadcrumb))
+                  (Diff.Builder.breadcrumb_added ~logger ~precomputed_values
+                     breadcrumb))
               breadcrumbs
           in
           List.iter diffs ~f:(Strict_pipe.Writer.write writer) ;

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -230,11 +230,12 @@ let%test_module "Archive node unit tests" =
               ~constraint_constants:precomputed_values.constraint_constants pool
               reader ~logger ~delete_older_than:None
           in
+          let logger = Logger.null () in
           let diffs =
             List.map
               ~f:(fun breadcrumb ->
                 Diff.Transition_frontier
-                  (Diff.Builder.breadcrumb_added breadcrumb))
+                  (Diff.Builder.breadcrumb_added ~logger breadcrumb))
               breadcrumbs
           in
           List.iter diffs ~f:(Strict_pipe.Writer.write writer) ;

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -142,11 +142,11 @@ CREATE INDEX idx_blocks_creator_id ON blocks(creator_id);
 CREATE INDEX idx_blocks_height     ON blocks(height);
 CREATE INDEX idx_chain_status      ON blocks(chain_status);
 
-CREATE TABLE account_ids
+CREATE TABLE account_identifiers
 ( id                 serial  PRIMARY KEY
 , public_key_id      int     NOT NULL     REFERENCES public_keys(id) ON DELETE CASCADE
 , token              text    NOT NULL
-, token_owner        int                  REFERENCES account_ids(id)
+, token_owner        int                  REFERENCES account_identifiers(id)
 );
 
 /* accounts accessed in a block, representing the account
@@ -156,7 +156,7 @@ CREATE TABLE account_ids
 CREATE TABLE accounts_accessed
 ( ledger_index            int     NOT NULL
 , block_id                int     NOT NULL  REFERENCES blocks(id)
-, account_id_id           int     NOT NULL  REFERENCES account_ids(id)
+, account_identifier_id   int     NOT NULL  REFERENCES account_identifiers(id)
 , token_symbol            text    NOT NULL
 , balance                 bigint  NOT NULL
 , nonce                   bigint  NOT NULL

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -207,8 +207,9 @@ CREATE INDEX idx_blocks_internal_commands_secondary_sequence_no ON blocks_intern
    sequence_no gives the order within all transactions in the block
 
    The `failure_reasons` column is not NULL iff `status` is `failed`. The
-   entries in the array are unenforced foreign key references to `zkapp_party_failures(id)`,
-   and are not NULL.
+   entries in the array are unenforced foreign key references to `zkapp_party_failures(id)`.
+   Each element of the array refers to the failures for a party in `other_parties`, and
+   is not NULL.
 
    Blocks command convention
 */

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -156,16 +156,16 @@ CREATE TABLE account_ids
 CREATE TABLE accounts_accessed
 ( ledger_index            int     NOT NULL
 , block_id                int     NOT NULL  REFERENCES blocks(id)
-, account_id              int     NOT NULL  REFERENCES account_ids(id)
+, account_id_id           int     NOT NULL  REFERENCES account_ids(id)
 , token_symbol            text    NOT NULL
 , balance                 bigint  NOT NULL
 , nonce                   bigint  NOT NULL
 , receipt_chain_hash      text    NOT NULL
 , delegate                int               REFERENCES public_keys(id)
 , voting_for              text    NOT NULL
-, timing                  int               REFERENCES timing_info(id)
-, permissions             int     NOT NULL  REFERENCES zkapp_permissions(id)
-, zkapp                   int               REFERENCES zkapp_accounts(id)
+, timing_id               int               REFERENCES timing_info(id)
+, permissions_id          int     NOT NULL  REFERENCES zkapp_permissions(id)
+, zkapp_id                int               REFERENCES zkapp_accounts(id)
 , PRIMARY KEY (block_id,account_id)
 );
 
@@ -218,7 +218,7 @@ CREATE TABLE blocks_zkapp_commands
 , zkapp_command_id                int                 NOT NULL REFERENCES zkapp_commands(id) ON DELETE CASCADE
 , sequence_no                     int                 NOT NULL
 , status                          user_command_status NOT NULL
-, failure_reasons                 int[]
+, failure_reasons_ids             int[]
 , PRIMARY KEY (block_id, zkapp_command_id, sequence_no)
 );
 

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -75,7 +75,7 @@ CREATE TABLE zkapp_permissions
 , edit_sequence_state      zkapp_auth_required_type    NOT NULL
 , set_token_symbol         zkapp_auth_required_type    NOT NULL
 , increment_nonce          zkapp_auth_required_type    NOT NULL
-, set_voting_for               zkapp_auth_required_type    NOT NULL
+, set_voting_for           zkapp_auth_required_type    NOT NULL
 );
 
 CREATE TABLE zkapp_timing_info

--- a/src/app/archive_blocks/archive_blocks.ml
+++ b/src/app/archive_blocks/archive_blocks.ml
@@ -53,12 +53,12 @@ let main ~archive_uri ~precomputed ~extensional ~success_file ~failure_file
           Mina_transition.External_transition.Precomputed_block.of_yojson
           (Processor.add_block_aux_precomputed
              ~constraint_constants:
-               Genesis_constants.Constraint_constants.compiled pool
+               Genesis_constants.Constraint_constants.compiled ~pool
              ~delete_older_than:None ~logger)
       in
       let add_extensional_block =
         make_add_block Archive_lib.Extensional.Block.of_yojson
-          (Processor.add_block_aux_extensional ~logger pool
+          (Processor.add_block_aux_extensional ~logger ~pool
              ~delete_older_than:None)
       in
       Deferred.List.iter files ~f:(fun file ->

--- a/src/app/extract_blocks/sql.ml
+++ b/src/app/extract_blocks/sql.ml
@@ -103,18 +103,16 @@ module Blocks_and_internal_commands = struct
     { internal_command_id : int
     ; sequence_no : int
     ; secondary_sequence_no : int
-    ; receiver_account_creation_fee_paid : int64 option
-    ; receiver_balance_id : int
     }
   [@@deriving hlist]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int; int; int; option int64; int ]
+      Caqti_type.[ int; int; int ]
 
   let query =
     Caqti_request.collect Caqti_type.int typ
-      {sql| SELECT internal_command_id, sequence_no, secondary_sequence_no, receiver_account_creation_fee_paid, receiver_balance
+      {sql| SELECT internal_command_id, sequence_no, secondary_sequence_no
             FROM (blocks_internal_commands
               INNER JOIN blocks
               ON blocks.id = blocks_internal_commands.block_id)

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -1402,8 +1402,9 @@ let parties_of_snapp_command ~pool (cmd : Sql.Snapp_command.t) :
                         "Expected account id for account precondition of kind \
                          Full"
                   | Some account_id ->
-                      query_db pool ~item:"Snapp account" ~f:(fun db ->
-                          Processor.Zkapp_account.load db account_id)
+                      query_db pool ~item:"Zkapp account" ~f:(fun db ->
+                          Processor.Zkapp_precondition_account.load db
+                            account_id)
                 in
                 let%map zkapp_account =
                   let%bind balance =

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -317,6 +317,8 @@ module Precomputed_block = struct
     ; staged_ledger_diff : Staged_ledger_diff.t
     ; delta_transition_chain_proof :
         Frozen_ledger_hash.t * Frozen_ledger_hash.t list
+    ; accounts_accessed : (int * Account.t) list
+    ; accounts_created : (Account_id.t * Currency.Fee.t) list
     }
 
   let sexp_of_t = External_transition.Precomputed_block.sexp_of_t
@@ -1156,12 +1158,18 @@ let run_precomputed ~logger ~verifier ~trust_system ~time_controller
   in
   let start = Block_time.now time_controller in
   let module Breadcrumb = Transition_frontier.Breadcrumb in
+  (* accounts_accessed, accounts_created are unused here
+     those fields are in precomputed blocks to add to the
+     archive db, they're not needed for replaying blocks
+  *)
   let produce
       { Precomputed_block.scheduled_time
       ; protocol_state
       ; protocol_state_proof
       ; staged_ledger_diff
       ; delta_transition_chain_proof
+      ; accounts_accessed = _
+      ; accounts_created = _
       } =
     let protocol_state_hashes = Protocol_state.hashes protocol_state in
     let consensus_state_with_hashes =

--- a/src/lib/mina_base/transaction_status.ml
+++ b/src/lib/mina_base/transaction_status.ml
@@ -48,7 +48,9 @@ module Failure = struct
   end]
 
   module Collection = struct
-    type display = (int * t list) list [@@deriving to_yojson]
+    (* bin_io used to archive extensional blocks, doesn't need versioning *)
+    type display = (int * Stable.Latest.t list) list
+    [@@deriving equal, yojson, bin_io_unversioned]
 
     [%%versioned
     module Stable = struct

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -134,6 +134,7 @@ module Transaction_applied : sig
     type t = Transaction_applied.Parties_applied.t =
       { accounts : (Account_id.t * Account.t option) list
       ; command : Parties.t With_status.t
+      ; previous_empty_accounts : Account_id.t list
       }
     [@@deriving sexp]
   end

--- a/src/lib/mina_lib/archive_client.ml
+++ b/src/lib/mina_lib/archive_client.ml
@@ -69,7 +69,9 @@ let transfer ~logger ~archive_location
       Broadcast_pipe.Reader.t) =
   Broadcast_pipe.Reader.iter breadcrumb_reader ~f:(fun breadcrumbs ->
       Deferred.List.iter breadcrumbs ~f:(fun breadcrumb ->
-          let diff = Archive_lib.Diff.Builder.breadcrumb_added breadcrumb in
+          let diff =
+            Archive_lib.Diff.Builder.breadcrumb_added ~logger breadcrumb
+          in
           match%map dispatch archive_location (Transition_frontier diff) with
           | Ok () ->
               ()

--- a/src/lib/mina_lib/archive_client.ml
+++ b/src/lib/mina_lib/archive_client.ml
@@ -63,14 +63,15 @@ let dispatch_precomputed_block =
 let dispatch_extensional_block =
   make_dispatch_block Archive_lib.Rpc.extensional_block
 
-let transfer ~logger ~archive_location
+let transfer ~logger ~precomputed_values ~archive_location
     (breadcrumb_reader :
       Transition_frontier.Extensions.New_breadcrumbs.view
       Broadcast_pipe.Reader.t) =
   Broadcast_pipe.Reader.iter breadcrumb_reader ~f:(fun breadcrumbs ->
       Deferred.List.iter breadcrumbs ~f:(fun breadcrumb ->
           let diff =
-            Archive_lib.Diff.Builder.breadcrumb_added ~logger breadcrumb
+            Archive_lib.Diff.Builder.breadcrumb_added ~logger
+              ~precomputed_values breadcrumb
           in
           match%map dispatch archive_location (Transition_frontier diff) with
           | Ok () ->
@@ -84,7 +85,7 @@ let transfer ~logger ~archive_location
                   ]
                 "Could not send breadcrumb to archive: $error"))
 
-let run ~logger
+let run ~logger ~precomputed_values
     ~(frontier_broadcast_pipe :
        Transition_frontier.t option Broadcast_pipe.Reader.t) archive_location =
   O1trace.background_thread "send_diffs_to_archiver" (fun () ->
@@ -99,4 +100,5 @@ let run ~logger
                  Transition_frontier.Extensions.get_view_pipe extensions
                    Transition_frontier.Extensions.New_breadcrumbs
                in
-               transfer ~logger ~archive_location breadcrumb_reader)))
+               transfer ~logger ~precomputed_values ~archive_location
+                 breadcrumb_reader)))

--- a/src/lib/mina_lib/archive_client.mli
+++ b/src/lib/mina_lib/archive_client.mli
@@ -15,6 +15,7 @@ val dispatch_extensional_block :
 
 val run :
      logger:Logger.t
+  -> precomputed_values:Precomputed_values.t
   -> frontier_broadcast_pipe:
        Transition_frontier.t option Broadcast_pipe.Reader.t
   -> Host_and_port.t Cli_lib.Flag.Types.with_name

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1979,6 +1979,7 @@ let create ?wallets (config : Config.t) =
                     , `Int (Host_and_port.port archive_process_port.value) )
                   ] ;
               Archive_client.run ~logger:config.logger
+                ~precomputed_values:config.precomputed_values
                 ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
                 archive_process_port) ;
           let precomputed_block_writer =

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -11,7 +11,7 @@ open Network_peer
 module Archive_client = Archive_client
 module Config = Config
 module Conf_dir = Conf_dir
-module Subscriptions = Coda_subscriptions
+module Subscriptions = Mina_subscriptions
 module Snark_worker_lib = Snark_worker
 module Timeout = Timeout_lib.Core_time
 
@@ -109,7 +109,7 @@ type t =
   ; snark_job_state : Work_selector.State.t
   ; mutable next_producer_timing :
       Daemon_rpcs.Types.Status.Next_producer_timing.t option
-  ; subscriptions : Coda_subscriptions.t
+  ; subscriptions : Mina_subscriptions.t
   ; sync_status : Sync_status.t Mina_incremental.Status.Observer.t
   ; precomputed_block_writer :
       ([ `Path of string ] option * [ `Log ] option) ref
@@ -681,10 +681,10 @@ let get_inferred_nonce_from_transaction_pool_and_ledger t
 let snark_job_state t = t.snark_job_state
 
 let add_block_subscriber t public_key =
-  Coda_subscriptions.add_block_subscriber t.subscriptions public_key
+  Mina_subscriptions.add_block_subscriber t.subscriptions public_key
 
 let add_payment_subscriber t public_key =
-  Coda_subscriptions.add_payment_subscriber t.subscriptions public_key
+  Mina_subscriptions.add_payment_subscriber t.subscriptions public_key
 
 let transaction_pool t = t.components.transaction_pool
 
@@ -1988,7 +1988,7 @@ let create ?wallets (config : Config.t) =
               , if config.log_precomputed_blocks then Some `Log else None )
           in
           let subscriptions =
-            Coda_subscriptions.create ~logger:config.logger
+            Mina_subscriptions.create ~logger:config.logger
               ~constraint_constants ~new_blocks ~wallets
               ~transition_frontier:frontier_broadcast_pipe_r
               ~is_storing_all:config.is_archive_rocksdb

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -8,7 +8,7 @@ open Signature_lib
 module Archive_client = Archive_client
 module Config = Config
 module Conf_dir = Conf_dir
-module Subscriptions = Coda_subscriptions
+module Subscriptions = Mina_subscriptions
 
 type t
 
@@ -29,7 +29,7 @@ exception Offline_shutdown
 
 val time_controller : t -> Block_time.Controller.t
 
-val subscription : t -> Coda_subscriptions.t
+val subscription : t -> Mina_subscriptions.t
 
 val daemon_start_time : Time_ns.t
 
@@ -187,7 +187,7 @@ val get_snarked_ledger : t -> State_hash.t option -> Account.t list Or_error.t
 
 val wallets : t -> Secrets.Wallets.t
 
-val subscriptions : t -> Coda_subscriptions.t
+val subscriptions : t -> Mina_subscriptions.t
 
 val most_recent_valid_transition :
   t -> External_transition.Initial_validated.t Broadcast_pipe.Reader.t

--- a/src/lib/mina_lib/mina_subscriptions.ml
+++ b/src/lib/mina_lib/mina_subscriptions.ml
@@ -153,8 +153,8 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                             With_hash.data block_with_hash
                           in
                           External_transition.Precomputed_block
-                          .of_external_transition ~logger ~staged_ledger
-                            ~scheduled_time external_transition
+                          .of_external_transition ~logger ~constraint_constants
+                            ~staged_ledger ~scheduled_time external_transition
                         in
                         External_transition.Precomputed_block.to_yojson
                           precomputed_block)

--- a/src/lib/mina_lib/mina_subscriptions.ml
+++ b/src/lib/mina_lib/mina_subscriptions.ml
@@ -121,117 +121,154 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
               .state_hash
           in
           (let path, log = !precomputed_block_writer in
-           let precomputed_block =
-             let open Mina_transition in
-             lazy
-               (let scheduled_time = Block_time.now time_controller in
-                let precomputed_block =
-                  new_block |> External_transition.Validated.erase |> fst
-                  |> With_hash.data
-                  |> External_transition.Precomputed_block
-                     .of_external_transition ~scheduled_time
-                in
-                External_transition.Precomputed_block.to_yojson
-                  precomputed_block)
-           in
-           if upload_blocks_to_gcloud then (
-             [%log info] "log" ;
-             let json = Yojson.Safe.to_string (Lazy.force precomputed_block) in
-             let network =
-               match Core.Sys.getenv "NETWORK_NAME" with
-               | Some network ->
-                   Some network
-               | _ ->
+           match Broadcast_pipe.Reader.peek transition_frontier with
+           | None ->
+               [%log warn]
+                 "Transition frontier not available when creating precomputed \
+                  block"
+           | Some tf -> (
+               let state_hash =
+                 let block_with_hash, _ = new_block in
+                 (With_hash.hash block_with_hash).state_hash
+               in
+               match Transition_frontier.find tf state_hash with
+               | None ->
                    [%log warn]
-                     "NETWORK_NAME environment variable not set. Must be set \
-                      to use upload_blocks_to_gcloud" ;
-                   None
-             in
-             let bucket =
-               match Core.Sys.getenv "GCLOUD_BLOCK_UPLOAD_BUCKET" with
-               | Some bucket ->
-                   Some bucket
-               | _ ->
-                   [%log warn]
-                     "GCLOUD_BLOCK_UPLOAD_BUCKET environment variable not set. \
-                      Must be set to use upload_blocks_to_gcloud" ;
-                   None
-             in
-             match (gcloud_keyfile, network, bucket) with
-             | Some _, Some network, Some bucket ->
-                 let hash_string = State_hash.to_base58_check hash in
-                 let height =
-                   Mina_transition.External_transition.Validated
-                   .blockchain_length new_block
-                   |> Mina_numbers.Length.to_string
-                 in
-                 let name =
-                   sprintf "%s-%s-%s.json" network height hash_string
-                 in
-                 (* TODO: Use a pipe to queue this if these are building up *)
-                 don't_wait_for
-                   ( Mina_metrics.(
-                       Gauge.inc_one
-                         Block_latency.Upload_to_gcloud.upload_to_gcloud_blocks) ;
-                     let tmp_file =
-                       Core.Filename.temp_file ~in_dir:"/tmp"
-                         "upload_block_file" ""
+                     "Could not find new block in transition frontier, can't \
+                      create precomputed block"
+               | Some breadcrumb ->
+                   let precomputed_block =
+                     let open Mina_transition in
+                     lazy
+                       (let scheduled_time = Block_time.now time_controller in
+                        let precomputed_block =
+                          let staged_ledger =
+                            Transition_frontier.Breadcrumb.staged_ledger
+                              breadcrumb
+                          in
+                          let external_transition =
+                            let block_with_hash, _ =
+                              External_transition.Validated.erase new_block
+                            in
+                            With_hash.data block_with_hash
+                          in
+                          External_transition.Precomputed_block
+                          .of_external_transition ~logger ~staged_ledger
+                            ~scheduled_time external_transition
+                        in
+                        External_transition.Precomputed_block.to_yojson
+                          precomputed_block)
+                   in
+                   if upload_blocks_to_gcloud then (
+                     [%log info] "log" ;
+                     let json =
+                       Yojson.Safe.to_string (Lazy.force precomputed_block)
                      in
-                     let f = Stdlib.open_out tmp_file in
-                     fprintf f "%s" json ;
-                     Stdlib.close_out f ;
-                     let command =
-                       Printf.sprintf "gsutil cp -n %s gs://%s/%s" tmp_file
-                         bucket name
+                     let network =
+                       match Core.Sys.getenv "NETWORK_NAME" with
+                       | Some network ->
+                           Some network
+                       | _ ->
+                           [%log warn]
+                             "NETWORK_NAME environment variable not set. Must \
+                              be set to use upload_blocks_to_gcloud" ;
+                           None
                      in
-                     let%map output =
-                       (* This double-wrapping of [try_with]s is protection
-                          against both immediate exceptions in process setup
-                          and exceptions in the 'deferred' part of setup.
-                          We also attach 'tags' to the errors below, so that we
-                          we have information about which of these different
-                          kinds of exception were seen, if any.
-                       *)
-                       Deferred.Or_error.try_with_join ~here:[%here] (fun () ->
-                           Or_error.try_with (fun () ->
-                               Async.Process.run () ~prog:"bash"
-                                 ~args:[ "-c"; command ]
-                               |> Deferred.Result.map_error
-                                    ~f:(Error.tag ~tag:__LOC__))
-                           |> Result.map_error ~f:(Error.tag ~tag:__LOC__)
-                           |> Deferred.return |> Deferred.Or_error.join)
+                     let bucket =
+                       match Core.Sys.getenv "GCLOUD_BLOCK_UPLOAD_BUCKET" with
+                       | Some bucket ->
+                           Some bucket
+                       | _ ->
+                           [%log warn]
+                             "GCLOUD_BLOCK_UPLOAD_BUCKET environment variable \
+                              not set. Must be set to use \
+                              upload_blocks_to_gcloud" ;
+                           None
                      in
-                     ( match output with
-                     | Ok _result ->
-                         ()
-                     | Error e ->
-                         [%log warn]
-                           ~metadata:
-                             [ ("error", Error_json.error_to_yojson e)
-                             ; ("command", `String command)
-                             ]
-                           "Uploading block to gcloud with command $command \
-                            failed: $error" ) ;
-                     Sys.remove tmp_file ;
-                     Mina_metrics.(
-                       Gauge.dec_one
-                         Block_latency.Upload_to_gcloud.upload_to_gcloud_blocks)
-                   )
-             | _ ->
-                 () ) ;
-           Option.iter path ~f:(fun (`Path path) ->
-               Out_channel.with_file ~append:true path ~f:(fun out_channel ->
-                   Out_channel.output_lines out_channel
-                     [ Yojson.Safe.to_string (Lazy.force precomputed_block) ])) ;
-           [%log info] "Saw block with state hash $state_hash"
-             ~metadata:
-               (let state_hash_data =
-                  [ ("state_hash", `String (State_hash.to_base58_check hash)) ]
-                in
-                if is_some log then
-                  state_hash_data
-                  @ [ ("precomputed_block", Lazy.force precomputed_block) ]
-                else state_hash_data)) ;
+                     match (gcloud_keyfile, network, bucket) with
+                     | Some _, Some network, Some bucket ->
+                         let hash_string = State_hash.to_base58_check hash in
+                         let height =
+                           Mina_transition.External_transition.Validated
+                           .blockchain_length new_block
+                           |> Mina_numbers.Length.to_string
+                         in
+                         let name =
+                           sprintf "%s-%s-%s.json" network height hash_string
+                         in
+                         (* TODO: Use a pipe to queue this if these are building up *)
+                         don't_wait_for
+                           ( Mina_metrics.(
+                               Gauge.inc_one
+                                 Block_latency.Upload_to_gcloud
+                                 .upload_to_gcloud_blocks) ;
+                             let tmp_file =
+                               Core.Filename.temp_file ~in_dir:"/tmp"
+                                 "upload_block_file" ""
+                             in
+                             let f = Stdlib.open_out tmp_file in
+                             fprintf f "%s" json ;
+                             Stdlib.close_out f ;
+                             let command =
+                               Printf.sprintf "gsutil cp -n %s gs://%s/%s"
+                                 tmp_file bucket name
+                             in
+                             let%map output =
+                               (* This double-wrapping of [try_with]s is protection
+                                  against both immediate exceptions in process setup
+                                  and exceptions in the 'deferred' part of setup.
+                                  We also attach 'tags' to the errors below, so that we
+                                  we have information about which of these different
+                                  kinds of exception were seen, if any.
+                               *)
+                               Deferred.Or_error.try_with_join ~here:[%here]
+                                 (fun () ->
+                                   Or_error.try_with (fun () ->
+                                       Async.Process.run () ~prog:"bash"
+                                         ~args:[ "-c"; command ]
+                                       |> Deferred.Result.map_error
+                                            ~f:(Error.tag ~tag:__LOC__))
+                                   |> Result.map_error
+                                        ~f:(Error.tag ~tag:__LOC__)
+                                   |> Deferred.return |> Deferred.Or_error.join)
+                             in
+                             ( match output with
+                             | Ok _result ->
+                                 ()
+                             | Error e ->
+                                 [%log warn]
+                                   ~metadata:
+                                     [ ("error", Error_json.error_to_yojson e)
+                                     ; ("command", `String command)
+                                     ]
+                                   "Uploading block to gcloud with command \
+                                    $command failed: $error" ) ;
+                             Sys.remove tmp_file ;
+                             Mina_metrics.(
+                               Gauge.dec_one
+                                 Block_latency.Upload_to_gcloud
+                                 .upload_to_gcloud_blocks) )
+                     | _ ->
+                         () ) ;
+                   Option.iter path ~f:(fun (`Path path) ->
+                       Out_channel.with_file ~append:true path
+                         ~f:(fun out_channel ->
+                           Out_channel.output_lines out_channel
+                             [ Yojson.Safe.to_string
+                                 (Lazy.force precomputed_block)
+                             ])) ;
+                   [%log info] "Saw block with state hash $state_hash"
+                     ~metadata:
+                       (let state_hash_data =
+                          [ ( "state_hash"
+                            , `String (State_hash.to_base58_check hash) )
+                          ]
+                        in
+                        if is_some log then
+                          state_hash_data
+                          @ [ ("precomputed_block", Lazy.force precomputed_block)
+                            ]
+                        else state_hash_data) )) ;
           match
             Filtered_external_transition.validate_transactions
               ~constraint_constants new_block

--- a/src/lib/mina_transition/dune
+++ b/src/lib/mina_transition/dune
@@ -19,6 +19,7 @@
    ;; local libraries
    mina_ledger
    mina_numbers
+   currency
    unsigned_extended
    ledger_proof
    logger

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -1341,10 +1341,12 @@ module Precomputed_block = struct
     in
     let accounts_created =
       let account_creation_fee = constraint_constants.account_creation_fee in
-      let latest_block_transactions = transactions ~constraint_constants t in
+      let previous_block_state_hash =
+        protocol_state t |> Mina_state.Protocol_state.previous_state_hash
+      in
       List.map
         (Staged_ledger.latest_block_accounts_created staged_ledger
-           ~latest_block_transactions) ~f:(fun acct_id ->
+           ~previous_block_state_hash) ~f:(fun acct_id ->
           (acct_id, account_creation_fee))
     in
     { scheduled_time

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -138,136 +138,6 @@ type t_ = Raw_versioned__.t =
   ; mutable validation_callback: Validate_content.t }
 *)
 
-module Precomputed_block = struct
-  module Proof = struct
-    type t = Proof.t
-
-    let to_bin_string proof =
-      let proof_string = Binable.to_string (module Proof.Stable.Latest) proof in
-      (* We use base64 with the uri-safe alphabet to ensure that encoding and
-         decoding is cheap, and that the proof can be easily sent over http
-         etc. without escaping or re-encoding.
-      *)
-      Base64.encode_string ~alphabet:Base64.uri_safe_alphabet proof_string
-
-    let of_bin_string str =
-      let str = Base64.decode_exn ~alphabet:Base64.uri_safe_alphabet str in
-      Binable.of_string (module Proof.Stable.Latest) str
-
-    let sexp_of_t proof = Sexp.Atom (to_bin_string proof)
-
-    let _sexp_of_t_structured = Proof.sexp_of_t
-
-    (* Supports decoding base64-encoded and structure encoded proofs. *)
-    let t_of_sexp = function
-      | Sexp.Atom str ->
-          of_bin_string str
-      | sexp ->
-          Proof.t_of_sexp sexp
-
-    let to_yojson proof = `String (to_bin_string proof)
-
-    let _to_yojson_structured = Proof.to_yojson
-
-    let of_yojson = function
-      | `String str ->
-          Or_error.try_with (fun () -> of_bin_string str)
-          |> Result.map_error ~f:(fun err ->
-                 sprintf
-                   "External_transition.Precomputed_block.Proof.of_yojson: %s"
-                   (Error.to_string_hum err))
-      | json ->
-          Proof.of_yojson json
-  end
-
-  module T = struct
-    type t =
-      { scheduled_time : Block_time.t
-      ; protocol_state : Protocol_state.value
-      ; protocol_state_proof : Proof.t
-      ; staged_ledger_diff : Staged_ledger_diff.t
-      ; delta_transition_chain_proof :
-          Frozen_ledger_hash.t * Frozen_ledger_hash.t list
-      }
-    [@@deriving sexp, yojson]
-  end
-
-  include T
-
-  [%%versioned
-  module Stable = struct
-    [@@@no_toplevel_latest_type]
-
-    module V2 = struct
-      type t = T.t =
-        { scheduled_time : Block_time.Stable.V1.t
-        ; protocol_state : Protocol_state.Value.Stable.V2.t
-        ; protocol_state_proof : Mina_base.Proof.Stable.V2.t
-        ; staged_ledger_diff : Staged_ledger_diff.Stable.V2.t
-              (* TODO: Delete this or find out why it is here. *)
-        ; delta_transition_chain_proof :
-            Frozen_ledger_hash.Stable.V1.t * Frozen_ledger_hash.Stable.V1.t list
-        }
-
-      let to_latest = Fn.id
-    end
-  end]
-
-  let of_external_transition ~scheduled_time (t : external_transition) =
-    { scheduled_time
-    ; protocol_state = t.protocol_state
-    ; protocol_state_proof = t.protocol_state_proof
-    ; staged_ledger_diff = t.staged_ledger_diff
-    ; delta_transition_chain_proof = t.delta_transition_chain_proof
-    }
-
-  (* NOTE: This serialization is used externally and MUST NOT change.
-     If the underlying types change, you should write a conversion, or add
-     optional fields and handle them appropriately.
-  *)
-  let%test_unit "Sexp serialization is stable" =
-    let serialized_block =
-      External_transition_sample_precomputed_block.sample_block_sexp
-    in
-    ignore @@ t_of_sexp @@ Sexp.of_string serialized_block
-
-  let%test_unit "Sexp serialization roundtrips" =
-    let serialized_block =
-      External_transition_sample_precomputed_block.sample_block_sexp
-    in
-    let sexp = Sexp.of_string serialized_block in
-    let sexp_roundtrip = sexp_of_t @@ t_of_sexp sexp in
-    [%test_eq: Sexp.t] sexp sexp_roundtrip
-
-  (* NOTE: This serialization is used externally and MUST NOT change.
-     If the underlying types change, you should write a conversion, or add
-     optional fields and handle them appropriately.
-  *)
-  let%test_unit "JSON serialization is stable" =
-    let serialized_block =
-      External_transition_sample_precomputed_block.sample_block_json
-    in
-    match of_yojson @@ Yojson.Safe.from_string serialized_block with
-    | Ok _ ->
-        ()
-    | Error err ->
-        failwith err
-
-  let%test_unit "JSON serialization roundtrips" =
-    let serialized_block =
-      External_transition_sample_precomputed_block.sample_block_json
-    in
-    let json = Yojson.Safe.from_string serialized_block in
-    let json_roundtrip =
-      match Result.map ~f:to_yojson @@ of_yojson json with
-      | Ok json ->
-          json
-      | Error err ->
-          failwith err
-    in
-    assert (Yojson.Safe.equal json json_roundtrip)
-end
-
 let consensus_state = Fn.compose Protocol_state.consensus_state protocol_state
 
 let blockchain_state = Fn.compose Protocol_state.blockchain_state protocol_state
@@ -336,6 +206,16 @@ let transactions ~constraint_constants t =
       transactions
   | Error e ->
       Core.Error.raise (Error.to_error e)
+
+let account_ids_accessed t =
+  let transactions =
+    transactions
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled t
+  in
+  List.map transactions ~f:(fun { data = txn; _ } ->
+      Mina_transaction.Transaction.accounts_accessed txn)
+  |> List.concat
+  |> List.dedup_and_sort ~compare:Account_id.compare
 
 let payments t =
   List.filter_map (commands t) ~f:(function
@@ -925,6 +805,8 @@ module With_validation = struct
   let transactions ~constraint_constants t =
     lift (transactions ~constraint_constants) t
 
+  let account_ids_accessed t = lift account_ids_accessed t
+
   let payments t = lift payments t
 
   let global_slot t = lift global_slot t
@@ -1103,6 +985,7 @@ module Validated = struct
     , coinbase_receiver
     , supercharge_coinbase
     , transactions
+    , account_ids_accessed
     , commands
     , completed_works
     , payments
@@ -1342,4 +1225,178 @@ module Staged_ledger_validation = struct
             , `External_transition_with_validation
                 (t, Validation.Unsafe.set_valid_staged_ledger_diff validation)
             , `Staged_ledger transitioned_staged_ledger ) )
+end
+
+module Precomputed_block = struct
+  (* precomputed blocks serve two purposes:
+     - to start the daemon with replayed blocks
+     - for archiving, so that blocks can be added to the archive database
+        if blocks are missing
+  *)
+  module Proof = struct
+    type t = Proof.t
+
+    let to_bin_string proof =
+      let proof_string = Binable.to_string (module Proof.Stable.Latest) proof in
+      (* We use base64 with the uri-safe alphabet to ensure that encoding and
+         decoding is cheap, and that the proof can be easily sent over http
+         etc. without escaping or re-encoding.
+      *)
+      Base64.encode_string ~alphabet:Base64.uri_safe_alphabet proof_string
+
+    let of_bin_string str =
+      let str = Base64.decode_exn ~alphabet:Base64.uri_safe_alphabet str in
+      Binable.of_string (module Proof.Stable.Latest) str
+
+    let sexp_of_t proof = Sexp.Atom (to_bin_string proof)
+
+    let _sexp_of_t_structured = Proof.sexp_of_t
+
+    (* Supports decoding base64-encoded and structure encoded proofs. *)
+    let t_of_sexp = function
+      | Sexp.Atom str ->
+          of_bin_string str
+      | sexp ->
+          Proof.t_of_sexp sexp
+
+    let to_yojson proof = `String (to_bin_string proof)
+
+    let _to_yojson_structured = Proof.to_yojson
+
+    let of_yojson = function
+      | `String str ->
+          Or_error.try_with (fun () -> of_bin_string str)
+          |> Result.map_error ~f:(fun err ->
+                 sprintf
+                   "External_transition.Precomputed_block.Proof.of_yojson: %s"
+                   (Error.to_string_hum err))
+      | json ->
+          Proof.of_yojson json
+  end
+
+  module T = struct
+    (* the accounts_accessed and accounts_created fields are used
+       for storing blocks in the archive db, they're not needed
+       for replaying blocks
+    *)
+    type t =
+      { scheduled_time : Block_time.t
+      ; protocol_state : Protocol_state.value
+      ; protocol_state_proof : Proof.t
+      ; staged_ledger_diff : Staged_ledger_diff.t
+      ; delta_transition_chain_proof :
+          Frozen_ledger_hash.t * Frozen_ledger_hash.t list
+      ; accounts_accessed : (int * Account.t) list
+      ; accounts_created : (Account_id.t * Currency.Fee.t) list
+      }
+    [@@deriving sexp, yojson]
+  end
+
+  include T
+
+  [%%versioned
+  module Stable = struct
+    [@@@no_toplevel_latest_type]
+
+    module V2 = struct
+      type t = T.t =
+        { scheduled_time : Block_time.Stable.V1.t
+        ; protocol_state : Protocol_state.Value.Stable.V2.t
+        ; protocol_state_proof : Mina_base.Proof.Stable.V2.t
+        ; staged_ledger_diff : Staged_ledger_diff.Stable.V2.t
+              (* TODO: Delete this or find out why it is here. *)
+        ; delta_transition_chain_proof :
+            Frozen_ledger_hash.Stable.V1.t * Frozen_ledger_hash.Stable.V1.t list
+        ; accounts_accessed : (int * Account.Stable.V2.t) list
+        ; accounts_created :
+            (Account_id.Stable.V2.t * Currency.Fee.Stable.V1.t) list
+        }
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  let of_external_transition ~logger ~scheduled_time ~staged_ledger
+      (t : external_transition) =
+    let ledger = Staged_ledger.ledger staged_ledger in
+    let account_ids_accessed = account_ids_accessed t in
+    let accounts_accessed =
+      List.filter_map account_ids_accessed ~f:(fun acct_id ->
+          try
+            let index =
+              Mina_ledger.Ledger.index_of_account_exn ledger acct_id
+            in
+            let account = Mina_ledger.Ledger.get_at_index_exn ledger index in
+            Some (index, account)
+          with exn ->
+            [%log error]
+              "When computing accounts accessed for precomputed block, \
+               exception when finding account id in staged ledger"
+              ~metadata:
+                [ ("account_id", Account_id.to_yojson acct_id)
+                ; ("exception", `String (Exn.to_string exn))
+                ] ;
+            None)
+    in
+    let accounts_created =
+      let account_creation_fee =
+        Genesis_constants.Constraint_constants.compiled.account_creation_fee
+      in
+      List.map (Staged_ledger.accounts_created staged_ledger) ~f:(fun acct_id ->
+          (acct_id, account_creation_fee))
+    in
+    { scheduled_time
+    ; protocol_state = t.protocol_state
+    ; protocol_state_proof = t.protocol_state_proof
+    ; staged_ledger_diff = t.staged_ledger_diff
+    ; delta_transition_chain_proof = t.delta_transition_chain_proof
+    ; accounts_accessed
+    ; accounts_created
+    }
+
+  (* NOTE: This serialization is used externally and MUST NOT change.
+     If the underlying types change, you should write a conversion, or add
+     optional fields and handle them appropriately.
+  *)
+  let%test_unit "Sexp serialization is stable" =
+    let serialized_block =
+      External_transition_sample_precomputed_block.sample_block_sexp
+    in
+    ignore @@ t_of_sexp @@ Sexp.of_string serialized_block
+
+  let%test_unit "Sexp serialization roundtrips" =
+    let serialized_block =
+      External_transition_sample_precomputed_block.sample_block_sexp
+    in
+    let sexp = Sexp.of_string serialized_block in
+    let sexp_roundtrip = sexp_of_t @@ t_of_sexp sexp in
+    [%test_eq: Sexp.t] sexp sexp_roundtrip
+
+  (* NOTE: This serialization is used externally and MUST NOT change.
+     If the underlying types change, you should write a conversion, or add
+     optional fields and handle them appropriately.
+  *)
+  let%test_unit "JSON serialization is stable" =
+    let serialized_block =
+      External_transition_sample_precomputed_block.sample_block_json
+    in
+    match of_yojson @@ Yojson.Safe.from_string serialized_block with
+    | Ok _ ->
+        ()
+    | Error err ->
+        failwith err
+
+  let%test_unit "JSON serialization roundtrips" =
+    let serialized_block =
+      External_transition_sample_precomputed_block.sample_block_json
+    in
+    let json = Yojson.Safe.from_string serialized_block in
+    let json_roundtrip =
+      match Result.map ~f:to_yojson @@ of_yojson json with
+      | Ok json ->
+          json
+      | Error err ->
+          failwith err
+    in
+    assert (Yojson.Safe.equal json json_roundtrip)
 end

--- a/src/lib/mina_transition/external_transition.ml
+++ b/src/lib/mina_transition/external_transition.ml
@@ -1316,8 +1316,9 @@ module Precomputed_block = struct
     end
   end]
 
-  let of_external_transition ~logger ~scheduled_time ~staged_ledger
-      (t : external_transition) =
+  let of_external_transition ~logger
+      ~(constraint_constants : Genesis_constants.Constraint_constants.t)
+      ~scheduled_time ~staged_ledger (t : external_transition) =
     let ledger = Staged_ledger.ledger staged_ledger in
     let account_ids_accessed = account_ids_accessed t in
     let accounts_accessed =
@@ -1339,10 +1340,11 @@ module Precomputed_block = struct
             None)
     in
     let accounts_created =
-      let account_creation_fee =
-        Genesis_constants.Constraint_constants.compiled.account_creation_fee
-      in
-      List.map (Staged_ledger.accounts_created staged_ledger) ~f:(fun acct_id ->
+      let account_creation_fee = constraint_constants.account_creation_fee in
+      let latest_block_transactions = transactions ~constraint_constants t in
+      List.map
+        (Staged_ledger.latest_block_accounts_created staged_ledger
+           ~latest_block_transactions) ~f:(fun acct_id ->
           (acct_id, account_creation_fee))
     in
     { scheduled_time

--- a/src/lib/mina_transition/external_transition_intf.ml
+++ b/src/lib/mina_transition/external_transition_intf.ml
@@ -44,6 +44,8 @@ module type External_transition_common_intf = sig
     -> t
     -> Transaction.t With_status.t list
 
+  val account_ids_accessed : t -> Account_id.t list
+
   val commands : t -> User_command.t With_status.t list
 
   val payments : t -> Signed_command.t With_status.t list
@@ -102,6 +104,8 @@ module type S = sig
       ; staged_ledger_diff : Staged_ledger_diff.t
       ; delta_transition_chain_proof :
           Frozen_ledger_hash.t * Frozen_ledger_hash.t list
+      ; accounts_accessed : (int * Account.t) list
+      ; accounts_created : (Account_id.t * Currency.Fee.t) list
       }
     [@@deriving sexp, yojson]
 
@@ -118,12 +122,19 @@ module type S = sig
           ; delta_transition_chain_proof :
               Frozen_ledger_hash.Stable.V1.t
               * Frozen_ledger_hash.Stable.V1.t list
+          ; accounts_accessed : (int * Account.Stable.V2.t) list
+          ; accounts_created :
+              (Account_id.Stable.V2.t * Currency.Fee.Stable.V1.t) list
           }
       end
     end]
 
     val of_external_transition :
-      scheduled_time:Block_time.Time.t -> external_transition -> t
+         logger:Logger.t
+      -> scheduled_time:Block_time.Time.t
+      -> staged_ledger:Staged_ledger.t
+      -> external_transition
+      -> t
   end
 
   module Validation : sig

--- a/src/lib/mina_transition/external_transition_intf.ml
+++ b/src/lib/mina_transition/external_transition_intf.ml
@@ -131,6 +131,7 @@ module type S = sig
 
     val of_external_transition :
          logger:Logger.t
+      -> constraint_constants:Genesis_constants.Constraint_constants.t
       -> scheduled_time:Block_time.Time.t
       -> staged_ledger:Staged_ledger.t
       -> external_transition

--- a/src/lib/mina_transition/external_transition_sample_precomputed_block.ml
+++ b/src/lib/mina_transition/external_transition_sample_precomputed_block.ml
@@ -2987,7 +2987,9 @@ let sample_block_sexp =
      ()))))
  (delta_transition_chain_proof
   (3108991348073215148864502385781811212776162989653883172258224572034746506990
-   ())))
+   ()))
+ (accounts_accessed ())
+ (accounts_created ()))
 |sexp}
 
 let sample_block_json =
@@ -7244,6 +7246,8 @@ let sample_block_json =
   },
   "delta_transition_chain_proof": [
     "jxuaqW9PAALZnZjnEP1CvtRKNhYkb3Fr8ox3gGyJdtXRy7g8wWZ", []
-  ]
+  ],
+  "accounts_accessed":[],
+  "accounts_created":[]
 }
 |json}

--- a/src/lib/parallel_scan/parallel_scan.ml
+++ b/src/lib/parallel_scan/parallel_scan.ml
@@ -1414,6 +1414,18 @@ let base_jobs_on_latest_tree t =
     (Tree.jobs_on_level ~depth ~level:depth (Non_empty_list.head t.trees))
     ~f:(fun job -> match job with Base d -> Some d | Merge _ -> None)
 
+(* 0-based indexing, so 0 indicates next-to-latest tree *)
+let base_jobs_on_earlier_tree t ~index =
+  let depth = Int.ceil_log2 t.max_base_jobs in
+  let earlier_trees = Non_empty_list.tail t.trees in
+  match List.nth earlier_trees index with
+  | None ->
+      []
+  | Some tree ->
+      let jobs = Tree.jobs_on_level ~depth ~level:depth tree in
+      List.filter_map jobs ~f:(fun job ->
+          match job with Base d -> Some d | Merge _ -> None)
+
 let partition_if_overflowing : ('merge, 'base) t -> Space_partition.t =
  fun t ->
   let cur_tree_space = free_space_on_current_tree t in

--- a/src/lib/parallel_scan/parallel_scan.mli
+++ b/src/lib/parallel_scan/parallel_scan.mli
@@ -293,6 +293,12 @@ val view_jobs_with_position :
  * promoted to the merge jobs yet*)
 val base_jobs_on_latest_tree : ('merge, 'base) State.t -> 'base list
 
+(** All the base jobs that are part of a tree before the latest tree
+    index is 0-based, 0 is the next-to-latest tree
+*)
+val base_jobs_on_earlier_tree :
+  ('merge, 'base) State.t -> index:int -> 'base list
+
 (** Returns true only if the next 'd that could be enqueued is
 on a new tree*)
 val next_on_new_tree : ('merge, 'base) State.t -> bool

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1943,28 +1943,20 @@ module T = struct
               ] ;
         { Staged_ledger_diff.With_valid_signatures_and_proofs.diff })
 
-  let latest_block_accounts_created t
-      ~(latest_block_transactions : Transaction.t With_status.t list) =
+  let latest_block_accounts_created t ~previous_block_state_hash =
     let scan_state = scan_state t in
+    (* filter leaves by state hash from previous block *)
     let base_jobs =
       Scan_state.base_jobs_on_latest_tree scan_state
       @ Scan_state.base_jobs_on_earlier_tree ~index:0 scan_state
+      |> List.filter ~f:(fun { state_hash = leaf_block_hash, _; _ } ->
+             State_hash.equal leaf_block_hash previous_block_state_hash)
     in
-    let candidate_transactions_applied =
-      List.map base_jobs ~f:(fun { transaction_with_info; _ } ->
-          transaction_with_info)
-    in
-    (* most blocks have few transactions, searching a list is acceptably fast *)
     let block_transactions_applied =
-      List.filter candidate_transactions_applied ~f:(fun txn_applied ->
-          let txn = Ledger.Transaction_applied.transaction txn_applied in
-          List.mem latest_block_transactions txn
-            ~equal:(With_status.equal Transaction.equal))
+      List.map base_jobs ~f:(fun { transaction_with_info; _ } ->
+          transaction_with_info.varying)
     in
-    let block_transactions_applied_varying =
-      List.map block_transactions_applied ~f:(fun { varying; _ } -> varying)
-    in
-    List.map block_transactions_applied_varying ~f:(function
+    List.map block_transactions_applied ~f:(function
       | Command (Signed_command cmd) -> (
           match cmd.body with
           | Payment { previous_empty_accounts } ->

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1962,8 +1962,8 @@ module T = struct
               []
           | Failed ->
               [] )
-      | Command (Parties _) ->
-          failwith "TODO: add previous_empty_accounts for parties"
+      | Command (Parties { previous_empty_accounts; _ }) ->
+          previous_empty_accounts
       | Fee_transfer { previous_empty_accounts; _ } ->
           previous_empty_accounts
       | Coinbase { previous_empty_accounts; _ } ->

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -221,10 +221,8 @@ val check_commands :
   -> (User_command.Valid.t list, Verifier.Failure.t) Result.t
      Deferred.Or_error.t
 
-(** account ids created in the latest block, given the transactions in the latest block;
-    taken from the previous_empty_accounts in the latest and next-to-latest trees of the scan state
+(** account ids created in the latest block, taken from the previous_empty_accounts
+    in the latest and next-to-latest trees of the scan state
 *)
 val latest_block_accounts_created :
-     t
-  -> latest_block_transactions:Transaction.t With_status.t list
-  -> Account_id.t list
+  t -> previous_block_state_hash:State_hash.t -> Account_id.t list

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -220,3 +220,8 @@ val check_commands :
   -> User_command.t list
   -> (User_command.Valid.t list, Verifier.Failure.t) Result.t
      Deferred.Or_error.t
+
+(** account ids from the previous_empty_accounts in the commands in the latest and next-to-latest
+    trees of the scan state
+*)
+val accounts_created : t -> Account_id.t list

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -221,7 +221,10 @@ val check_commands :
   -> (User_command.Valid.t list, Verifier.Failure.t) Result.t
      Deferred.Or_error.t
 
-(** account ids from the previous_empty_accounts in the commands in the latest and next-to-latest
-    trees of the scan state
+(** account ids created in the latest block, given the transactions in the latest block;
+    taken from the previous_empty_accounts in the latest and next-to-latest trees of the scan state
 *)
-val accounts_created : t -> Account_id.t list
+val latest_block_accounts_created :
+     t
+  -> latest_block_transactions:Transaction.t With_status.t list
+  -> Account_id.t list

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -649,6 +649,8 @@ let next_on_new_tree = Parallel_scan.next_on_new_tree
 
 let base_jobs_on_latest_tree = Parallel_scan.base_jobs_on_latest_tree
 
+let base_jobs_on_earlier_tree = Parallel_scan.base_jobs_on_earlier_tree
+
 (*All the transactions in the order in which they were applied*)
 let staged_transactions t =
   List.map ~f:(fun (t : Transaction_with_witness.t) ->

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -108,6 +108,10 @@ val free_space : t -> int
 
 val base_jobs_on_latest_tree : t -> Transaction_with_witness.t list
 
+(* a 0 index means next-to-latest tree *)
+val base_jobs_on_earlier_tree :
+  t -> index:int -> Transaction_with_witness.t list
+
 val hash : t -> Staged_ledger_hash.Aux_hash.t
 
 (** All the transactions in the order in which they were applied*)


### PR DESCRIPTION
Add `accounts_accessed` and `accounts_created` to the `Breadcrumb_added` RPC sent to the archive process.

Because we'll want to populate the same db tables when archiving blocks, add those same fields to precomputed and extensional blocks. Add those fields to the sample precomputed blocks to allow unit tests to pass (they're just empty lists). We'll want to re-create sample blocks at some point.

The `archive_blocks` and `extract_blocks` apps compile, but the latter will need more changes: see #10740.

For the `accounts_created` to be accurate in the case of zkApps, we need to add `previous_empty_accounts` to be added to `Parties_applied`: see #10734.

Rename `Coda_subscriptions` to `Mina_subscriptions`.

Closes #10507.