### PR TITLE
Add `previous_empty_accounts` to `Parties_applied.t`

### DIFF
--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -134,6 +134,7 @@ module Transaction_applied : sig
     type t = Transaction_applied.Parties_applied.t =
       { accounts : (Account_id.t * Account.t option) list
       ; command : Parties.t With_status.t
+      ; previous_empty_accounts : Account_id.t list
       }
     [@@deriving sexp]
   end

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1962,8 +1962,8 @@ module T = struct
               []
           | Failed ->
               [] )
-      | Command (Parties _) ->
-          failwith "TODO: add previous_empty_accounts for parties"
+      | Command (Parties { previous_empty_accounts; _ }) ->
+          previous_empty_accounts
       | Fee_transfer { previous_empty_accounts; _ } ->
           previous_empty_accounts
       | Coinbase { previous_empty_accounts; _ } ->

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -58,7 +58,7 @@ module Transaction_applied = struct
   module Parties_applied = struct
     [%%versioned
     module Stable = struct
-      module V2 = struct
+      module V1 = struct
         type t =
           { accounts :
               (Account_id.Stable.V2.t * Account.Stable.V2.t option) list
@@ -78,7 +78,7 @@ module Transaction_applied = struct
       module V2 = struct
         type t =
           | Signed_command of Signed_command_applied.Stable.V2.t
-          | Parties of Parties_applied.Stable.V2.t
+          | Parties of Parties_applied.Stable.V1.t
         [@@deriving sexp]
 
         let to_latest = Fn.id

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -58,7 +58,7 @@ module Transaction_applied = struct
   module Parties_applied = struct
     [%%versioned
     module Stable = struct
-      module V1 = struct
+      module V2 = struct
         type t =
           { accounts :
               (Account_id.Stable.V2.t * Account.Stable.V2.t option) list
@@ -78,7 +78,7 @@ module Transaction_applied = struct
       module V2 = struct
         type t =
           | Signed_command of Signed_command_applied.Stable.V2.t
-          | Parties of Parties_applied.Stable.V1.t
+          | Parties of Parties_applied.Stable.V2.t
         [@@deriving sexp]
 
         let to_latest = Fn.id


### PR DESCRIPTION
Add `previous_empty_accounts` to `Parties_applied.t`.

To get those accounts, in `apply_parties_unchecked_aux`, look at accounts not in ledger, see if they've been added to the ledger after the application.

That list of account ids should be non-empty only if the failure table is empty. There's no assertion for that invariant, but it could be added.

Closes #10734.
