### PR TITLE
Adding missing required subfield

### DIFF
--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -14,7 +14,11 @@ let graphql_zkapp_command (parties : Parties.t) =
     {|
 mutation MyMutation {
   __typename
-  sendZkapp(input: { parties: %s })
+  sendZkapp(input: { parties: %s }) {
+    zkapp {
+      hash
+    }
+  }
 }
     |}
     (Parties.arg_query_string parties)


### PR DESCRIPTION
Explain your changes:

When enforcing the GraphQL schema the produced mutation will fail with:

```
Field "sendZkapp" of type "SendZkappPayload!" must have a selection of subfields. Did you mean "sendZkapp { ... }"?
```

This PR simply returns the hash of the broadcasted tx

Explain how you tested your changes:
*

