### PR TITLE
Use LLD as a linker

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -2,10 +2,10 @@
 -- NOTE: minaToolchainStretch is also used for building Ubuntu Bionic packages in CI
 {
   toolchainBase = "codaprotocol/ci-toolchain-base:v3",
-  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@sha256:74af314c348585d2aac91496cd37ca076b75b9059e399c5bed525690ba104f53",
-  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:62ab1dd64fe532f6042d406dfce5e4774929af608f198bdd5a6a1584b0e3f2c8",
-  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:01270ff28f56cd0be8049079c30449d1d94c6b9de32eef8ca75e4abcbe0b6cf8",
-  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@sha256:ebf70399228f88c2f48d24a3d833173be6bf7040aaa6a018890f0c5030fa98e9",
+  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@sha256:55a2fa7edd8d89f4627e4a84956004b375294379611035f2834aef00b6a3b6ba",
+  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:abd774ddf4810a97427991992d6ba588fc677cc4416fd00e095c60f7efda6db4",
+  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:045148c3005a7ee50c6895efbd40d45c24b74551d8e60a4af12a2fc0d59b46a8",
+  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@sha256:5ed1d97522ab5ce173022752ef293386d67c8a6bcdf7882bf2064292a703ab9e",
   delegationBackendToolchain = "gcr.io/o1labs-192920/delegation-backend-production@sha256:8ca5880845514ef56a36bf766a0f9de96e6200d61b51f80d9f684a0ec9c031f4",
   elixirToolchain = "elixir:1.10-alpine",
   rustToolchain = "codaprotocol/coda:toolchain-rust-e855336d087a679f76f2dd2bbdc3fdfea9303be3",

--- a/dockerfiles/stages/1-build-deps
+++ b/dockerfiles/stages/1-build-deps
@@ -49,12 +49,17 @@ RUN apt-get update \
     curl \
     file \
     git \
+    '(^lld-10$|^lld-11$)' \
     m4 \
     pkg-config \
     rsync \
     sudo \
     unzip \
     zlib1g-dev
+
+# Symlink image-specific lld version to a single lld executable
+RUN if command -v ld.lld-10 &> /dev/null; then ln -sf $(which ld.lld-10) /usr/bin/ld.lld; fi
+RUN if command -v ld.lld-11 &> /dev/null; then ln -sf $(which ld.lld-11) /usr/bin/ld.lld; fi
 
 # --- Create opam user (for later) and give sudo to make opam happy
 RUN adduser --uid 65533 --disabled-password --gecos '' opam \

--- a/src/dune.flags.inc
+++ b/src/dune.flags.inc
@@ -1,3 +1,3 @@
 (env
   (_
-    (flags (:standard -short-paths -cclib -ljemalloc -w @a-4-29-40-41-42-44-45-48-58-59-60-66))))
+    (flags (:standard -short-paths -ccopt=-fuse-ld=lld -cclib -ljemalloc -w @a-4-29-40-41-42-44-45-48-58-59-60-66))))

--- a/src/external/ocaml-rocksdb/dune
+++ b/src/external/ocaml-rocksdb/dune
@@ -5,7 +5,6 @@
     (libraries ctypes ctypes.foreign)
     (modules (:standard \ rocks_linker_flags_gen rocks_test))
     (c_library_flags (:standard (:include flags.sexp)))
-    (self_build_stubs_archive (rocksdb))
     )
 
 (executable
@@ -16,6 +15,7 @@
 
 (rule
  (targets flags.sexp)
+ (deps librocksdb_stubs.a)
  (action (run ./rocks_linker_flags_gen.exe)))
 
 (rule

--- a/src/external/ocaml-rocksdb/rocks_linker_flags_gen.ml
+++ b/src/external/ocaml-rocksdb/rocks_linker_flags_gen.ml
@@ -14,9 +14,11 @@ let () =
         ; "-lc++abi"
         ; "-lc++" ]
     | "Linux" ->
-        [ "-Wl,--push-state,-whole-archive"
+        [ sprintf "-L%s" cwd
+        ; "-fuse-ld=lld"
+        ; "-Wl,--whole-archive"
         ; "-lrocksdb_stubs"
-        ; "-Wl,--pop-state"
+        ; "-Wl,--no-whole-archive"
         ; "-lz"
         ; "-lbz2"
         ; "-lstdc++" ]


### PR DESCRIPTION
Analysis in https://github.com/MinaProtocol/mina/issues/10503 has shown that switching from the GNU linker to LLVM's lld improves build times, especially when building incrementally (where linking is a significant bottleneck).

This PR makes that change by:
- adding `lld` to the toolchain
- passing a global compiler flag for the internal code, to use `lld`
- adapting `ocaml-rocksdb` so that it correctly links with `lld`, which is more strict than the GNU linker with respect to duplicate symbols

Closes #10761 