### PR TITLE
Temporarily revert LLD linking

### DIFF
--- a/src/dune.flags.inc
+++ b/src/dune.flags.inc
@@ -1,3 +1,3 @@
 (env
   (_
-    (flags (:standard -short-paths -ccopt=-fuse-ld=lld -cclib -ljemalloc -w @a-4-29-40-41-42-44-45-48-58-59-60-66))))
+    (flags (:standard -short-paths -cclib -ljemalloc -w @a-4-29-40-41-42-44-45-48-58-59-60-66))))

--- a/src/external/ocaml-rocksdb/dune
+++ b/src/external/ocaml-rocksdb/dune
@@ -5,6 +5,7 @@
     (libraries ctypes ctypes.foreign)
     (modules (:standard \ rocks_linker_flags_gen rocks_test))
     (c_library_flags (:standard (:include flags.sexp)))
+    (self_build_stubs_archive (rocksdb))
     )
 
 (executable
@@ -15,7 +16,6 @@
 
 (rule
  (targets flags.sexp)
- (deps librocksdb_stubs.a)
  (action (run ./rocks_linker_flags_gen.exe)))
 
 (rule

--- a/src/external/ocaml-rocksdb/rocks_linker_flags_gen.ml
+++ b/src/external/ocaml-rocksdb/rocks_linker_flags_gen.ml
@@ -14,11 +14,9 @@ let () =
         ; "-lc++abi"
         ; "-lc++" ]
     | "Linux" ->
-        [ sprintf "-L%s" cwd
-        ; "-fuse-ld=lld"
-        ; "-Wl,--whole-archive"
+        [ "-Wl,--push-state,-whole-archive"
         ; "-lrocksdb_stubs"
-        ; "-Wl,--no-whole-archive"
+        ; "-Wl,--pop-state"
         ; "-lz"
         ; "-lbz2"
         ; "-lstdc++" ]


### PR DESCRIPTION
https://github.com/MinaProtocol/mina/pull/10768 seems to have broken some local builds where `lld` is not available or badly packaged. This reverts changes in the flags while devising a solution that supports both environments.