### PR TITLE
Distinguish docs in "zkapp-account-key" uses

### DIFF
--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -472,11 +472,11 @@ let update_zkapp_uri ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~zkapp_uri
   in
   parties
 
-let update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+let update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
     ~sequence_state =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind zkapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
+  let%bind zkapp_keypair = Util.snapp_keypair_of_file zkapp_keyfile in
   let sequence_events = Util.sequence_state_of_list sequence_state in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
@@ -544,11 +544,11 @@ let update_token_symbol ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
   in
   parties
 
-let update_permissions ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+let update_permissions ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
     ~permissions ~current_auth =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind zkapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
+  let%bind zkapp_keypair = Util.snapp_keypair_of_file zkapp_keyfile in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
     ; fee

--- a/src/app/zkapp_test_transaction/lib/commands.ml
+++ b/src/app/zkapp_test_transaction/lib/commands.ml
@@ -113,8 +113,8 @@ let gen_proof ?(zkapp_account = None) (parties : Parties.t) =
   in
   ()
 
-let generate_snapp_txn (keypair : Signature_lib.Keypair.t) (ledger : Ledger.t)
-    ~snapp_kp =
+let generate_zkapp_txn (keypair : Signature_lib.Keypair.t) (ledger : Ledger.t)
+    ~zkapp_kp =
   let open Deferred.Let_syntax in
   let receiver =
     Quickcheck.random_value Signature_lib.Public_key.Compressed.gen
@@ -149,7 +149,8 @@ let generate_snapp_txn (keypair : Signature_lib.Keypair.t) (ledger : Ledger.t)
   in
   let%bind parties =
     Transaction_snark.For_tests.create_trivial_predicate_snapp
-      ~constraint_constants ~protocol_state_predicate spec ledger ~snapp_kp
+      ~constraint_constants ~protocol_state_predicate spec ledger
+      ~snapp_kp:zkapp_kp
   in
   printf "ZkApp transaction yojson: %s\n\n%!"
     (Parties.to_yojson parties |> Yojson.Safe.to_string) ;
@@ -274,10 +275,10 @@ module Util = struct
         failwith (sprintf "Invalid authorization: %s" s)
 end
 
-let test_snapp_with_genesis_ledger_main keyfile snapp_keyfile config_file () =
+let test_zkapp_with_genesis_ledger_main keyfile zkapp_keyfile config_file () =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_kp = Util.snapp_keypair_of_file snapp_keyfile in
+  let%bind zkapp_kp = Util.snapp_keypair_of_file zkapp_keyfile in
   let%bind ledger =
     let%map config_json = Genesis_ledger_helper.load_config_json config_file in
     let runtime_config =
@@ -298,20 +299,20 @@ let test_snapp_with_genesis_ledger_main keyfile snapp_keyfile config_file () =
     in
     Lazy.force (Genesis_ledger.Packed.t packed)
   in
-  generate_snapp_txn keypair ledger ~snapp_kp
+  generate_zkapp_txn keypair ledger ~zkapp_kp
 
-let create_zkapp_account ~debug ~keyfile ~fee ~snapp_keyfile ~amount ~nonce
+let create_zkapp_account ~debug ~keyfile ~fee ~zkapp_keyfile ~amount ~nonce
     ~memo =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
+  let%bind zkapp_keypair = Util.snapp_keypair_of_file zkapp_keyfile in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
     ; fee
     ; fee_payer = None
     ; receivers = []
     ; amount
-    ; zkapp_account_keypairs = [ snapp_keypair ]
+    ; zkapp_account_keypairs = [ zkapp_keypair ]
     ; memo = Util.memo memo
     ; new_zkapp_account = true
     ; snapp_update = Party.Update.dummy
@@ -327,11 +328,11 @@ let create_zkapp_account ~debug ~keyfile ~fee ~snapp_keyfile ~amount ~nonce
   let%map () = if debug then gen_proof parties else return () in
   parties
 
-let upgrade_snapp ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+let upgrade_zkapp ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
     ~verification_key ~zkapp_uri ~auth =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind zkapp_account_keypair = Util.snapp_keypair_of_file snapp_keyfile in
+  let%bind zkapp_account_keypair = Util.snapp_keypair_of_file zkapp_keyfile in
   let verification_key =
     let data =
       Side_loaded_verification_key.of_base58_check_exn verification_key
@@ -400,10 +401,10 @@ let transfer_funds ~debug ~keyfile ~fee ~nonce ~memo ~receivers =
   in
   parties
 
-let update_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~app_state =
+let update_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile ~app_state =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
+  let%bind zkapp_keypair = Util.snapp_keypair_of_file zkapp_keyfile in
   let app_state = Util.app_state_of_list app_state in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
@@ -411,7 +412,7 @@ let update_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~app_state =
     ; fee_payer = None
     ; receivers = []
     ; amount = Currency.Amount.zero
-    ; zkapp_account_keypairs = [ snapp_keypair ]
+    ; zkapp_account_keypairs = [ zkapp_keypair ]
     ; memo = Util.memo memo
     ; new_zkapp_account = false
     ; snapp_update = { Party.Update.dummy with app_state }
@@ -429,7 +430,7 @@ let update_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile ~app_state =
     if debug then
       gen_proof parties
         ~zkapp_account:
-          (Some (Signature_lib.Public_key.compress snapp_keypair.public_key))
+          (Some (Signature_lib.Public_key.compress zkapp_keypair.public_key))
     else return ()
   in
   parties
@@ -475,7 +476,7 @@ let update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ~sequence_state =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
+  let%bind zkapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
   let sequence_events = Util.sequence_state_of_list sequence_state in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
@@ -483,7 +484,7 @@ let update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ; fee_payer = None
     ; receivers = []
     ; amount = Currency.Amount.zero
-    ; zkapp_account_keypairs = [ snapp_keypair ]
+    ; zkapp_account_keypairs = [ zkapp_keypair ]
     ; memo = Util.memo memo
     ; new_zkapp_account = false
     ; snapp_update = Party.Update.dummy
@@ -501,7 +502,7 @@ let update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     if debug then
       gen_proof parties
         ~zkapp_account:
-          (Some (Signature_lib.Public_key.compress snapp_keypair.public_key))
+          (Some (Signature_lib.Public_key.compress zkapp_keypair.public_key))
     else return ()
   in
   parties
@@ -547,14 +548,14 @@ let update_permissions ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     ~permissions ~current_auth =
   let open Deferred.Let_syntax in
   let%bind keypair = Util.keypair_of_file keyfile in
-  let%bind snapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
+  let%bind zkapp_keypair = Util.snapp_keypair_of_file snapp_keyfile in
   let spec =
     { Transaction_snark.For_tests.Spec.sender = (keypair, nonce)
     ; fee
     ; fee_payer = None
     ; receivers = []
     ; amount = Currency.Amount.zero
-    ; zkapp_account_keypairs = [ snapp_keypair ]
+    ; zkapp_account_keypairs = [ zkapp_keypair ]
     ; memo = Util.memo memo
     ; new_zkapp_account = false
     ; snapp_update = { Party.Update.dummy with permissions }
@@ -573,7 +574,7 @@ let update_permissions ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
     if debug then
       gen_proof parties
         ~zkapp_account:
-          (Some (Signature_lib.Public_key.compress snapp_keypair.public_key))
+          (Some (Signature_lib.Public_key.compress zkapp_keypair.public_key))
     else return ()
   in
   parties

--- a/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
+++ b/src/app/zkapp_test_transaction/zkapp_test_transaction.ml
@@ -70,7 +70,7 @@ let create_zkapp_account =
       (let%map keyfile, fee, nonce, memo, debug = Flags.common_flags
        and zkapp_keyfile =
          Param.flag "--zkapp-account-key"
-           ~doc:"KEYFILE Private key file to create a new zkApp account"
+           ~doc:"KEYFILE Private key file for the zkApp account to be created"
            Param.(required string)
        and amount = Flags.amount in
        let fee = Option.value ~default:Flags.default_fee fee in
@@ -98,7 +98,7 @@ let upgrade_zkapp =
       (let%map keyfile, fee, nonce, memo, debug = Flags.common_flags
        and zkapp_keyfile =
          Param.flag "--zkapp-account-key"
-           ~doc:"KEYFILE Private key file for the account to be upgraded"
+           ~doc:"KEYFILE Private key file for the zkApp account to be upgraded"
            Param.(required string)
        and verification_key =
          Param.flag "--verification-key"
@@ -206,7 +206,7 @@ let update_state =
       (let%map keyfile, fee, nonce, memo, debug = Flags.common_flags
        and zkapp_keyfile =
          Param.flag "--zkapp-account-key"
-           ~doc:"KEYFILE Private key file for account to get the updated state"
+           ~doc:"KEYFILE Private key file of the zkApp account to be updated"
            Param.(required string)
        and app_state =
          Param.flag "--zkapp-state"
@@ -241,7 +241,7 @@ let update_zkapp_uri =
       (let%map keyfile, fee, nonce, memo, debug = Flags.common_flags
        and snapp_keyfile =
          Param.flag "--zkapp-account-key"
-           ~doc:"KEYFILE Private key file to get the updated zkApp URI"
+           ~doc:"KEYFILE Private key file of the zkApp account to be updated"
            Param.(required string)
        and zkapp_uri =
          Param.flag "--zkapp-uri"
@@ -264,11 +264,11 @@ let update_zkapp_uri =
          ~zkapp_uri ~auth))
 
 let update_sequence_state =
-  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
       ~sequence_state () =
     let open Deferred.Let_syntax in
     let%map parties =
-      update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+      update_sequence_state ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
         ~sequence_state
     in
     Util.print_snapp_transaction parties ;
@@ -279,11 +279,9 @@ let update_sequence_state =
     Command.async
       ~summary:"Generate a zkApp transaction that updates zkApp state"
       (let%map keyfile, fee, nonce, memo, debug = Flags.common_flags
-       and snapp_keyfile =
+       and zkapp_keyfile =
          Param.flag "--zkapp-account-key"
-           ~doc:
-             "KEYFILE Private key file for the account to get the updated \
-              sequence state"
+           ~doc:"KEYFILE Private key file of the zkApp account to be updated"
            Param.(required string)
        and sequence_state0 =
          Param.flag "--sequence-state0"
@@ -329,7 +327,7 @@ let update_sequence_state =
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_formatted_string Flags.min_fee)) ;
-       create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+       create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
          ~sequence_state))
 
 let update_token_symbol =
@@ -350,9 +348,7 @@ let update_token_symbol =
       (let%map keyfile, fee, nonce, memo, debug = Flags.common_flags
        and snapp_keyfile =
          Param.flag "--zkapp-account-key"
-           ~doc:
-             "KEYFILE Private key file for the account to get the updated \
-              token symbol"
+           ~doc:"KEYFILE Private key file of the zkApp account to be updated"
            Param.(required string)
        and token_symbol =
          Param.flag "--token-symbol"
@@ -375,11 +371,11 @@ let update_token_symbol =
          ~token_symbol ~auth))
 
 let update_permissions =
-  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+  let create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
       ~permissions ~current_auth () =
     let open Deferred.Let_syntax in
     let%map parties =
-      update_permissions ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+      update_permissions ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
         ~permissions ~current_auth
     in
     Util.print_snapp_transaction parties ;
@@ -392,11 +388,9 @@ let update_permissions =
         "Generate a zkApp transaction that updates the permissions of a zkApp \
          account"
       (let%map keyfile, fee, nonce, memo, debug = Flags.common_flags
-       and snapp_keyfile =
+       and zkapp_keyfile =
          Param.flag "--zkapp-account-key"
-           ~doc:
-             "KEYFILE Private key file for the account to get the updated \
-              permissions"
+           ~doc:"KEYFILE Private key file of the zkApp account to be updated"
            Param.(required string)
        and edit_state =
          Param.flag "--edit-state" ~doc:"Proof|Signature|Either|None"
@@ -458,7 +452,7 @@ let update_permissions =
          failwith
            (sprintf "Fee must at least be %s"
               (Currency.Fee.to_formatted_string Flags.min_fee)) ;
-       create_command ~debug ~keyfile ~fee ~nonce ~memo ~snapp_keyfile
+       create_command ~debug ~keyfile ~fee ~nonce ~memo ~zkapp_keyfile
          ~permissions
          ~current_auth:(Util.auth_of_string current_auth)))
 


### PR DESCRIPTION
In `zkapp_test_transaction` app, distinguish uses of `zkapp-account-key` flag documentation. All the instances had mentioned a new account, even if the transaction is meant to work on an existing account.

Removed that flag from `Flags`, because unused.

Change many uses of `snapps` to `zkapps`. A few remain, because of requirements in other libraries.