### PR TITLE
hotfix to repair ci tests for PRs into master

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -118,10 +118,11 @@ let Config =
   }
 
 let targetToAgent = \(target : Size) ->
-  merge { XLarge = toMap { size = "xlarge" },
-          Large = toMap { size = "large" },
-          Medium = toMap { size = "medium" },
-          Small = toMap { size = "small" }
+  merge { XLarge = toMap { size = "generic" },
+          Large = toMap { size = "generic" },
+          Medium = toMap { size = "generic" },
+          Small = toMap { size = "generic" },
+          Integration = toMap { size = "integration" }
         }
         target
 

--- a/buildkite/src/Command/DockerLogin/Type.dhall
+++ b/buildkite/src/Command/DockerLogin/Type.dhall
@@ -10,7 +10,7 @@
         server: Text
     },
     default = {
-        username = "o1bot",
+        username = "o1botdockerhub",
         `password-env` = "DOCKER_PASSWORD",
         server = ""
     }

--- a/buildkite/src/Command/Size.dhall
+++ b/buildkite/src/Command/Size.dhall
@@ -1,1 +1,1 @@
-<XLarge|Large|Medium|Small>
+<XLarge|Large|Medium|Small|Integration>

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -55,7 +55,7 @@ in
         artifact_paths = [SelectFiles.exactly "." "${testName}.test.log"],
         label = "${testName} integration test",
         key = "integration-test-${testName}",
-        target = Size.Medium,
+        target = Size.Integration,
         depends_on = dependsOn,
         if = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'"
       }

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -17,7 +17,8 @@ in Pipeline.build Pipeline.Config::{
     dirtyWhen = [
         S.strictlyStart (S.contains "src"),
         S.strictlyStart (S.contains "dockerfiles"),
-        S.strictlyStart (S.contains "buildkite/src/Jobs/Test/TestnetIntegrationTest")
+        S.strictlyStart (S.contains "buildkite/src/Jobs/Test/TestnetIntegrationTest"),
+        S.strictlyStart (S.contains "buildkite/src/Jobs/Command/TestExecutive")
     ],
     path = "Test",
     name = "TestnetIntegrationTests"


### PR DESCRIPTION
Explain your changes:
This PR changes the pod size used for CI tests within buildkite. It is a change that is already active within `Develop` and `Compatible`, but had not yet been ported into Master. CI test in master are currently broken while this update is not in place. This PR is to manually apply the update to Master outside of the normal merges for `Compatible` and `Develop` branches. 

Linked to the original PRs which this is based on: 
Merge into `Compatible`: https://github.com/MinaProtocol/mina/pull/10632 and https://github.com/MinaProtocol/mina/pull/10338
Merge into `Develop`: https://github.com/MinaProtocol/mina/pull/10344

Explain how you tested your changes:
Since this item related directly to CI tests, the `ci-build-me` tag is applied to this PR to run integration tests and ensure they complete as expected. 


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [X] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [X] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
