### PR TITLE
Remove unnecessary `public_key` field from account precondition

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -2750,14 +2750,6 @@
               "deprecationReason": null
             },
             {
-              "name": "publicKey",
-              "description": null,
-              "args": [],
-              "type": { "kind": "SCALAR", "name": "Field", "ofType": null },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "delegate",
               "description": null,
               "args": [],
@@ -2825,12 +2817,6 @@
             },
             {
               "name": "receiptChainHash",
-              "description": null,
-              "type": { "kind": "SCALAR", "name": "Field", "ofType": null },
-              "defaultValue": null
-            },
-            {
-              "name": "publicKey",
               "description": null,
               "type": { "kind": "SCALAR", "name": "Field", "ofType": null },
               "defaultValue": null
@@ -6862,14 +6848,6 @@
             },
             {
               "name": "receiptChainHash",
-              "description": null,
-              "args": [],
-              "type": { "kind": "SCALAR", "name": "Field", "ofType": null },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "publicKey",
               "description": null,
               "args": [],
               "type": { "kind": "SCALAR", "name": "Field", "ofType": null },

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -447,7 +447,6 @@ module Zkapp_account = struct
     { balance_id : int option
     ; nonce_id : int option
     ; receipt_chain_hash : string option
-    ; public_key_id : int option
     ; delegate_id : int option
     ; state_id : int
     ; sequence_state_id : int option
@@ -461,7 +460,6 @@ module Zkapp_account = struct
         [ option int
         ; option int
         ; option string
-        ; option int
         ; option int
         ; int
         ; option int
@@ -482,11 +480,6 @@ module Zkapp_account = struct
       Mina_caqti.add_if_zkapp_check
         (Zkapp_nonce_bounds.add_if_doesn't_exist (module Conn))
         acct.nonce
-    in
-    let%bind public_key_id =
-      Mina_caqti.add_if_zkapp_check
-        (Public_key.add_if_doesn't_exist (module Conn))
-        acct.public_key
     in
     let%bind delegate_id =
       Mina_caqti.add_if_zkapp_check
@@ -511,7 +504,6 @@ module Zkapp_account = struct
       { balance_id
       ; nonce_id
       ; receipt_chain_hash
-      ; public_key_id
       ; delegate_id
       ; state_id
       ; sequence_state_id

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -25,7 +25,10 @@ let%test_module "Archive node unit tests" =
     module Genesis_ledger = (val Genesis_ledger.for_unit_tests)
 
     let archive_uri =
-      Uri.of_string (Option.value (Sys.getenv "MINA_TEST_POSTGRES") ~default:"postgres://admin:codarules@localhost:5432/archiver")
+      Uri.of_string
+        (Option.value
+           (Sys.getenv "MINA_TEST_POSTGRES")
+           ~default:"postgres://admin:codarules@localhost:5432/archiver")
 
     let conn_lazy =
       lazy

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -115,7 +115,6 @@ CREATE TABLE zkapp_account
 , balance_id               int                    REFERENCES zkapp_balance_bounds(id)
 , nonce_id                 int                    REFERENCES zkapp_nonce_bounds(id)
 , receipt_chain_hash       text
-, public_key_id            int                    REFERENCES public_keys(id)
 , delegate_id              int                    REFERENCES public_keys(id)
 , state_id                 int                    NOT NULL REFERENCES zkapp_states(id)
 , sequence_state_id        int                    REFERENCES zkapp_state_data(id)

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -1377,9 +1377,6 @@ module Snapp_helpers = struct
                   let%map pk = pk_of_pk_id pool pk_id in
                   Zkapp_basic.Or_ignore.Check pk)
             in
-            let%bind public_key =
-              pk_check_or_ignore_of_id zkapp_account_data.public_key_id
-            in
             let%bind delegate =
               pk_check_or_ignore_of_id zkapp_account_data.delegate_id
             in
@@ -1414,7 +1411,6 @@ module Snapp_helpers = struct
               ( { balance
                 ; nonce
                 ; receipt_chain_hash
-                ; public_key
                 ; delegate
                 ; state
                 ; sequence_state

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -556,6 +556,7 @@ module Account_precondition = struct
       Full
         { Zkapp_precondition.Account.accept with
           nonce = Check { lower = n; upper = n }
+        ; delegate = Check Public_key.Compressed.empty
         }
     in
     let module Fd = Fields_derivers_zkapps.Derivers in
@@ -572,7 +573,7 @@ module Account_precondition = struct
       ( {json|{
           balance: null,
           nonce: {lower: "34928", upper: "34928"},
-          receiptChainHash: null, publicKey: null, delegate: null,
+          receiptChainHash: null, delegate: null,
           state: [null,null,null,null,null,null,null,null],
           sequenceState: null, provedState: null
         }|json}

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -556,7 +556,6 @@ module Account_precondition = struct
       Full
         { Zkapp_precondition.Account.accept with
           nonce = Check { lower = n; upper = n }
-        ; public_key = Check Public_key.Compressed.empty
         }
     in
     let module Fd = Fields_derivers_zkapps.Derivers in

--- a/src/lib/mina_base/zkapp_precondition.ml
+++ b/src/lib/mina_base/zkapp_precondition.ml
@@ -489,7 +489,6 @@ module Account = struct
           { balance : 'balance
           ; nonce : 'nonce
           ; receipt_chain_hash : 'receipt_chain_hash
-          ; public_key : 'pk
           ; delegate : 'pk
           ; state : 'field Zkapp_state.V.Stable.V1.t
           ; sequence_state : 'field
@@ -539,12 +538,17 @@ module Account = struct
       [@@deriving sexp, equal, yojson, hash, compare]
 
       let to_latest
-          ({ balance; nonce; receipt_chain_hash; public_key; delegate; state } :
+          ({ balance
+           ; nonce
+           ; receipt_chain_hash
+           ; public_key = _
+           ; delegate
+           ; state
+           } :
             t) : V2.t =
         { balance
         ; nonce
         ; receipt_chain_hash
-        ; public_key
         ; delegate
         ; state
         ; sequence_state = Ignore
@@ -558,7 +562,6 @@ module Account = struct
     let%bind balance = Numeric.gen Balance.gen Balance.compare in
     let%bind nonce = Numeric.gen Account_nonce.gen Account_nonce.compare in
     let%bind receipt_chain_hash = Or_ignore.gen Receipt.Chain_hash.gen in
-    let%bind public_key = Eq_data.gen Public_key.Compressed.gen in
     let%bind delegate = Eq_data.gen Public_key.Compressed.gen in
     let%bind state =
       let%bind fields =
@@ -577,7 +580,6 @@ module Account = struct
     { Poly.balance
     ; nonce
     ; receipt_chain_hash
-    ; public_key
     ; delegate
     ; state
     ; sequence_state
@@ -588,7 +590,6 @@ module Account = struct
     { balance = Ignore
     ; nonce = Ignore
     ; receipt_chain_hash = Ignore
-    ; public_key = Ignore
     ; delegate = Ignore
     ; state =
         Vector.init Zkapp_state.Max_state_size.n ~f:(fun _ -> Or_ignore.Ignore)
@@ -604,7 +605,6 @@ module Account = struct
     Poly.Fields.make_creator obj ~balance:!.Numeric.Derivers.balance
       ~nonce:!.Numeric.Derivers.nonce
       ~receipt_chain_hash:!.(Or_ignore.deriver field)
-      ~public_key:!.(Or_ignore.deriver public_key)
       ~delegate:!.(Or_ignore.deriver public_key)
       ~state:!.(Zkapp_state.deriver @@ Or_ignore.deriver field)
       ~sequence_state:!.(Or_ignore.deriver field)
@@ -616,7 +616,6 @@ module Account = struct
     let predicate : t =
       { accept with
         balance = Or_ignore.Check { Closed_interval.lower = b; upper = b }
-      ; public_key = Or_ignore.Check Public_key.Compressed.empty
       ; sequence_state = Or_ignore.Check (Field.of_int 99)
       ; proved_state = Or_ignore.Check true
       }
@@ -629,7 +628,6 @@ module Account = struct
       ({ balance
        ; nonce
        ; receipt_chain_hash
-       ; public_key
        ; delegate
        ; state
        ; sequence_state
@@ -641,7 +639,6 @@ module Account = struct
       [ Numeric.(to_input Tc.balance balance)
       ; Numeric.(to_input Tc.nonce nonce)
       ; Hash.(to_input Tc.receipt_chain_hash receipt_chain_hash)
-      ; Eq_data.(to_input_explicit (Tc.public_key ()) public_key)
       ; Eq_data.(to_input_explicit (Tc.public_key ()) delegate)
       ; Vector.reduce_exn ~f:append
           (Vector.map state ~f:Eq_data.(to_input_explicit Tc.field))
@@ -669,7 +666,6 @@ module Account = struct
         ({ balance
          ; nonce
          ; receipt_chain_hash
-         ; public_key
          ; delegate
          ; state
          ; sequence_state
@@ -681,7 +677,6 @@ module Account = struct
         [ Numeric.(Checked.to_input Tc.balance balance)
         ; Numeric.(Checked.to_input Tc.nonce nonce)
         ; Hash.(to_input_checked Tc.receipt_chain_hash receipt_chain_hash)
-        ; Eq_data.(to_input_checked (Tc.public_key ()) public_key)
         ; Eq_data.(to_input_checked (Tc.public_key ()) delegate)
         ; Vector.reduce_exn ~f:append
             (Vector.map state ~f:Eq_data.(to_input_checked Tc.field))
@@ -696,7 +691,6 @@ module Account = struct
         ({ balance
          ; nonce
          ; receipt_chain_hash
-         ; public_key
          ; delegate
          ; state = _
          ; sequence_state = _
@@ -709,7 +703,6 @@ module Account = struct
           check_checked Tc.receipt_chain_hash receipt_chain_hash
             a.receipt_chain_hash)
       ; Eq_data.(check_checked (Tc.public_key ()) delegate a.delegate)
-      ; Eq_data.(check_checked (Tc.public_key ()) public_key a.public_key)
       ]
 
     let check_nonsnapp t a = Boolean.all (nonsnapp t a)
@@ -718,7 +711,6 @@ module Account = struct
         ({ balance = _
          ; nonce = _
          ; receipt_chain_hash = _
-         ; public_key = _
          ; delegate = _
          ; state
          ; sequence_state
@@ -755,7 +747,6 @@ module Account = struct
       ; nonce
       ; receipt_chain_hash
       ; public_key ()
-      ; public_key ()
       ; Zkapp_state.typ (Or_ignore.typ_explicit Field.typ ~ignore:Field.zero)
       ; Or_ignore.typ_implicit Field.typ ~equal:Field.equal
           ~ignore:(Lazy.force Zkapp_account.Sequence_events.empty_hash)
@@ -768,7 +759,6 @@ module Account = struct
       ({ balance
        ; nonce
        ; receipt_chain_hash
-       ; public_key
        ; delegate
        ; state
        ; sequence_state
@@ -790,10 +780,6 @@ module Account = struct
       Eq_data.(
         check ~label:"delegate" tc delegate
           (Option.value ~default:tc.default a.delegate))
-    in
-    let%bind () =
-      Eq_data.(
-        check ~label:"public_key" (Tc.public_key ()) public_key a.public_key)
     in
     let%bind () =
       match a.zkapp with

--- a/src/lib/mina_generators/parties_generators.ml
+++ b/src/lib/mina_generators/parties_generators.ml
@@ -11,14 +11,7 @@ module Ledger = Mina_ledger.Ledger
 let gen_account_precondition_from_account ?(succeed = true) account =
   let open Quickcheck.Let_syntax in
   let%bind b = Quickcheck.Generator.bool in
-  let { Account.Poly.public_key
-      ; balance
-      ; nonce
-      ; receipt_chain_hash
-      ; delegate
-      ; zkapp
-      ; _
-      } =
+  let { Account.Poly.balance; nonce; receipt_chain_hash; delegate; zkapp; _ } =
     account
   in
   (* choose constructor *)
@@ -72,7 +65,6 @@ let gen_account_precondition_from_account ?(succeed = true) account =
           (return { Zkapp_precondition.Closed_interval.lower; upper })
       in
       let receipt_chain_hash = Or_ignore.Check receipt_chain_hash in
-      let public_key = Or_ignore.Check public_key in
       let%bind delegate =
         match delegate with
         | None ->
@@ -112,7 +104,6 @@ let gen_account_precondition_from_account ?(succeed = true) account =
         { Zkapp_precondition.Account.Poly.balance
         ; nonce
         ; receipt_chain_hash
-        ; public_key
         ; delegate
         ; state
         ; sequence_state

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -2213,7 +2213,6 @@ module Ledger = struct
                    (Fn.compose Mina_numbers.Account_nonce.of_uint32 uint32)
                    p##.nonce)
           ; receipt_chain_hash = or_ignore field p##.receiptChainHash
-          ; public_key = or_ignore public_key p##.publicKey
           ; delegate = or_ignore public_key p##.delegate
           ; state =
               Pickles_types.Vector.init Zkapp_state.Max_state_size.n
@@ -2396,7 +2395,6 @@ module Ledger = struct
                    (Fn.compose Mina_numbers.Account_nonce.of_uint32 uint32)
                    p##.nonce)
           ; receipt_chain_hash = or_ignore field p##.receiptChainHash
-          ; public_key = or_ignore public_key p##.publicKey
           ; delegate = or_ignore public_key p##.delegate
           ; state =
               Pickles_types.Vector.init Zkapp_state.Max_state_size.n
@@ -2613,7 +2611,6 @@ module Ledger = struct
       ; nonce = numeric nonce max_interval_uint32
       ; receipt_chain_hash =
           ignore (Mina_base.Receipt.Chain_hash.var_of_hash_packed Field.zero)
-      ; public_key = ignore pk_dummy
       ; delegate = ignore pk_dummy
       ; state =
           Pickles_types.Vector.init Zkapp_state.Max_state_size.n ~f:(fun _ ->
@@ -2640,7 +2637,6 @@ module Ledger = struct
                 (* TODO: assumes constant *)
                 (Mina_base.Receipt.Chain_hash.var_of_t ^ field_value)
                 p##.receiptChainHash
-          ; public_key = or_ignore public_key p##.publicKey
           ; delegate = or_ignore public_key p##.delegate
           ; state =
               Pickles_types.Vector.init Zkapp_state.Max_state_size.n

--- a/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
+++ b/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
@@ -396,8 +396,7 @@ let%test_module "Account precondition tests" =
       let interval v =
         { Closed_interval.lower = v; Closed_interval.upper = v }
       in
-      let { Mina_base.Account.Poly.public_key
-          ; balance
+      let { Mina_base.Account.Poly.balance
           ; nonce
           ; receipt_chain_hash
           ; delegate
@@ -410,7 +409,6 @@ let%test_module "Account precondition tests" =
         let balance = Or_ignore.Check (interval balance) in
         let nonce = Or_ignore.Check (interval nonce) in
         let receipt_chain_hash = Or_ignore.Check receipt_chain_hash in
-        let public_key = Or_ignore.Check public_key in
         let delegate =
           match delegate with
           | None ->
@@ -448,7 +446,6 @@ let%test_module "Account precondition tests" =
         { Zkapp_precondition.Account.Poly.balance
         ; nonce
         ; receipt_chain_hash
-        ; public_key
         ; delegate
         ; state
         ; sequence_state

--- a/src/lib/zkapps_examples/zkapps_examples.ml
+++ b/src/lib/zkapps_examples/zkapps_examples.ml
@@ -17,7 +17,6 @@ module Party_under_construction = struct
         { balance = Ignore
         ; nonce = Ignore
         ; receipt_chain_hash = Ignore
-        ; public_key = Ignore
         ; delegate = Ignore
         ; state =
             [ Ignore; Ignore; Ignore; Ignore; Ignore; Ignore; Ignore; Ignore ]
@@ -187,7 +186,6 @@ module Party_under_construction = struct
                { balance = Ignore
                ; nonce = Ignore
                ; receipt_chain_hash = Ignore
-               ; public_key = Ignore
                ; delegate = Ignore
                ; state =
                    [ Ignore


### PR DESCRIPTION
This PR removes the `public_key` field from account precondition.

This field adds no value -- the `public_key` is already explicitly exposed in the `Party.t` -- so we lose nothing by removing it. This also decreases the size of transactions and reduces the amount of hashing that we have to do inside and out of the circuit.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them