### PR TITLE
Informative structured log error message

### DIFF
--- a/src/lib/structured_log_events/structured_log_events.ml
+++ b/src/lib/structured_log_events/structured_log_events.ml
@@ -33,7 +33,18 @@ let parse_exn id json_pairs =
             List.filter json_pairs ~f:(fun (field_name, _) ->
                 Set.mem repr.arguments field_name)
           in
-          repr.parse json_pairs
+          match repr.parse json_pairs with
+          | Some t ->
+              Some t
+          | None ->
+              failwithf
+                "parse_exn: parser for id %s found, but failed when applied to \
+                 arguments: %s"
+                id
+                ( List.map json_pairs ~f:(fun (name, json) ->
+                      sprintf "%s = %s" name (Yojson.Safe.to_string json))
+                |> String.concat ~sep:"," )
+                ()
         else None)
   in
   match result with


### PR DESCRIPTION
When a structured log parser failed, there was a failure raised indicating that the parser was missing for the particular structured log id.

Instead, fail with a message indicating that the parser was found, but failed when applied to particular arguments.

This may help debug the issues we're seeing in CI for the structured log `Snark_work_received`. Constructing that log manually succeeds, so there may be something about the particular arguments fed to the parser.