### PR TITLE
[Fix] Don't allow tokens to overflow

### DIFF
--- a/src/lib/transaction_logic/parties_logic.ml
+++ b/src/lib/transaction_logic/parties_logic.ml
@@ -1435,8 +1435,7 @@ module Make (Inputs : Inputs_intf) = struct
       in
       ( Amount.if_ party_token_is_default ~then_:new_local_fee_excess
           ~else_:local_state.excess
-      , (* No overflow if we aren't using the result of the addition (which we don't in the case that party token is not default). *)
-        `Overflow (Bool.( &&& ) party_token_is_default overflow) )
+      , `Overflow overflow )
     in
     (* The first party must succeed. *)
     Bool.(assert_ (not (is_start' &&& overflowed))) ;


### PR DESCRIPTION
This PR fixes a bug introduced in the recent tokens changes.

Token accounts must obey the normal overflow checks that we apply to normal accounts, since a token contract (by default) has no way to know whether or not there was an overflow, and removing this check allows overflows / underflows to mint or burn tokens when this was not intended by the contract.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
