### PR TITLE
Move fee-payer success assertions to a single final check

### DIFF
--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -25,7 +25,10 @@ let%test_module "Archive node unit tests" =
     module Genesis_ledger = (val Genesis_ledger.for_unit_tests)
 
     let archive_uri =
-      Uri.of_string (Option.value (Sys.getenv "MINA_TEST_POSTGRES") ~default:"postgres://admin:codarules@localhost:5432/archiver")
+      Uri.of_string
+        (Option.value
+           (Sys.getenv "MINA_TEST_POSTGRES")
+           ~default:"postgres://admin:codarules@localhost:5432/archiver")
 
     let conn_lazy =
       lazy

--- a/src/lib/transaction_logic/parties_logic.ml
+++ b/src/lib/transaction_logic/parties_logic.ml
@@ -1405,11 +1405,6 @@ module Make (Inputs : Inputs_intf) = struct
     (* DO NOT ADD ANY UPDATES HERE. They must be earlier in the code.
        See comment above.
     *)
-    (* The first party must succeed. *)
-    Bool.(
-      assert_with_failure_status_tbl
-        ((not is_start') ||| local_state.success)
-        local_state.failure_status_tbl) ;
     let local_delta =
       (* NOTE: It is *not* correct to use the actual change in balance here.
          Indeed, if the account creation fee is paid, using that amount would
@@ -1438,8 +1433,6 @@ module Make (Inputs : Inputs_intf) = struct
       , (* No overflow if we aren't using the result of the addition (which we don't in the case that party token is not default). *)
         `Overflow (Bool.( &&& ) party_token_is_default overflow) )
     in
-    (* The first party must succeed. *)
-    Bool.(assert_ (not (is_start' &&& overflowed))) ;
     let local_state =
       { local_state with
         excess = new_local_fee_excess
@@ -1508,12 +1501,16 @@ module Make (Inputs : Inputs_intf) = struct
             ~else_:local_state.excess
       }
     in
-    Bool.(assert_ (not (is_start' &&& global_excess_update_failed))) ;
     let local_state =
       { local_state with
         success = Bool.(local_state.success &&& not global_excess_update_failed)
       }
     in
+    (* The first party must succeed. *)
+    Bool.(
+      assert_with_failure_status_tbl
+        ((not is_start') ||| local_state.success)
+        local_state.failure_status_tbl) ;
     let global_state =
       Global_state.set_ledger ~should_update:update_global_state global_state
         local_state.ledger


### PR DESCRIPTION
This PR combines several `assert_` checks used to ensure the success of a fee-payer into a single final check.

This makes the circuit more efficient, but will also make the errors far more descriptive once #10812 is merged and its labelled overflow failures are available.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
