### PR TITLE
Add .ocamlformat to archive_lib

### DIFF
--- a/src/app/archive/archive_lib/.ocamlformat
+++ b/src/app/archive/archive_lib/.ocamlformat
@@ -1,0 +1,1 @@
+../../../.ocamlformat

--- a/src/app/archive/archive_lib/ast.ml
+++ b/src/app/archive/archive_lib/ast.ml
@@ -1,6 +1,6 @@
 module Rel_insert_input = struct
   type ('data, 'on_conflict) t =
-    < data: 'data ; on_conflict: 'on_conflict option >
+    < data : 'data ; on_conflict : 'on_conflict option >
 
   type nonrec ('data, 'on_conflict) array = ('data array, 'on_conflict) t
 end
@@ -9,7 +9,7 @@ type void
 
 module On_conflict = struct
   type ('constraint_, 'update_columns) t =
-    < constraint_: 'constraint_ ; update_columns: 'update_columns array >
+    < constraint_ : 'constraint_ ; update_columns : 'update_columns array >
 
   let create constraint_ update_columns =
     object
@@ -18,45 +18,46 @@ module On_conflict = struct
       method update_columns = Array.of_list update_columns
     end
 
-  type public_keys = ([`public_keys_value_key], [`value]) t
+  type public_keys = ([ `public_keys_value_key ], [ `value ]) t
 
-  type fee_transfers = ([`fee_transfers_hash_key], [`first_seen]) t
+  type fee_transfers = ([ `fee_transfers_hash_key ], [ `first_seen ]) t
 
-  type user_commands = ([`user_commands_hash_key], [`first_seen]) t
+  type user_commands = ([ `user_commands_hash_key ], [ `first_seen ]) t
 
-  type receipt_chain_hash = ([`receipt_chain_hashes_hash_key], [`hash]) t
+  type receipt_chain_hash = ([ `receipt_chain_hashes_hash_key ], [ `hash ]) t
 
-  type snark_jobs = ([`snark_jobs_job1_job2_key], [`job1 | `job2]) t
+  type snark_jobs = ([ `snark_jobs_job1_job2_key ], [ `job1 | `job2 ]) t
 
   type blocks_user_commands =
-    ( [`blocks_user_commands_block_id_user_command_id_receipt_chain_has]
+    ( [ `blocks_user_commands_block_id_user_command_id_receipt_chain_has ]
     , void )
     t
 
   type blocks_fee_transfers =
-    ([`blocks_fee_transfers_block_id_fee_transfer_id_key], void) t
+    ([ `blocks_fee_transfers_block_id_fee_transfer_id_key ], void) t
 
   type block_snark_jobs =
-    ([`blocks_snark_jobs_block_id_snark_job_id_key], void) t
+    ([ `blocks_snark_jobs_block_id_snark_job_id_key ], void) t
 
-  type state_hashes = ([`state_hashes_value_key], [`value]) t
+  type state_hashes = ([ `state_hashes_value_key ], [ `value ]) t
 
-  type blocks = ([`blocks_state_hash_key], [`block_length]) t
+  type blocks = ([ `blocks_state_hash_key ], [ `block_length ]) t
 
-  let public_keys : public_keys = create `public_keys_value_key [`value]
+  let public_keys : public_keys = create `public_keys_value_key [ `value ]
 
-  let state_hashes : state_hashes = create `state_hashes_value_key [`value]
+  let state_hashes : state_hashes = create `state_hashes_value_key [ `value ]
 
   let user_commands : user_commands =
-    create `user_commands_hash_key [`first_seen]
+    create `user_commands_hash_key [ `first_seen ]
 
   let fee_transfers : fee_transfers =
-    create `fee_transfers_hash_key [`first_seen]
+    create `fee_transfers_hash_key [ `first_seen ]
 
-  let snark_jobs : snark_jobs = create `snark_jobs_job1_job2_key [`job1; `job2]
+  let snark_jobs : snark_jobs =
+    create `snark_jobs_job1_job2_key [ `job1; `job2 ]
 
   let receipt_chain_hash : receipt_chain_hash =
-    create `receipt_chain_hashes_hash_key [`hash]
+    create `receipt_chain_hashes_hash_key [ `hash ]
 
   let blocks_user_commands : blocks_user_commands =
     create `blocks_user_commands_block_id_user_command_id_receipt_chain_has []
@@ -73,37 +74,35 @@ type bit = Yojson.Basic.t
 type user_command_type = Yojson.Basic.t
 
 type public_keys_insert_input =
-  < blocks: blocks_arr_rel_insert_input option
-  ; fee_transfers: fee_transfers_arr_rel_insert_input option
-  ; snark_jobs: snark_jobs_arr_rel_insert_input option
-  ; userCommandsByReceiver: user_commands_arr_rel_insert_input option
-  ; user_commands: user_commands_arr_rel_insert_input option
-  ; value: string option >
+  < blocks : blocks_arr_rel_insert_input option
+  ; fee_transfers : fee_transfers_arr_rel_insert_input option
+  ; snark_jobs : snark_jobs_arr_rel_insert_input option
+  ; userCommandsByReceiver : user_commands_arr_rel_insert_input option
+  ; user_commands : user_commands_arr_rel_insert_input option
+  ; value : string option >
 
 and public_keys_obj_rel_insert_input =
   (public_keys_insert_input, On_conflict.public_keys) Rel_insert_input.t
 
 and fee_transfers_insert_input =
-  < blocks_fee_transfers: blocks_fee_transfers_arr_rel_insert_input option
-  ; fee: bit option
-  ; first_seen: bit option
-  ; hash: string option
-  ; public_key: public_keys_obj_rel_insert_input option
-  ; receiver: int option >
+  < blocks_fee_transfers : blocks_fee_transfers_arr_rel_insert_input option
+  ; fee : bit option
+  ; first_seen : bit option
+  ; hash : string option
+  ; public_key : public_keys_obj_rel_insert_input option
+  ; receiver : int option >
 
 and fee_transfers_obj_rel_insert_input =
   (fee_transfers_insert_input, On_conflict.fee_transfers) Rel_insert_input.t
 
 and fee_transfers_arr_rel_insert_input =
-  ( fee_transfers_insert_input
-  , On_conflict.fee_transfers )
-  Rel_insert_input.array
+  (fee_transfers_insert_input, On_conflict.fee_transfers) Rel_insert_input.array
 
 and receipt_chain_hashes_insert_input =
-  < blocks_user_commands: blocks_user_commands_arr_rel_insert_input option
-  ; hash: string option
-  ; receipt_chain_hash: receipt_chain_hashes_obj_rel_insert_input option
-  ; receipt_chain_hashes: receipt_chain_hashes_arr_rel_insert_input option >
+  < blocks_user_commands : blocks_user_commands_arr_rel_insert_input option
+  ; hash : string option
+  ; receipt_chain_hash : receipt_chain_hashes_obj_rel_insert_input option
+  ; receipt_chain_hashes : receipt_chain_hashes_arr_rel_insert_input option >
 
 and receipt_chain_hashes_obj_rel_insert_input =
   ( receipt_chain_hashes_insert_input
@@ -116,21 +115,21 @@ and receipt_chain_hashes_arr_rel_insert_input =
   Rel_insert_input.array
 
 and user_commands_insert_input =
-  < amount: bit option
-  ; blocks_user_commands: blocks_user_commands_arr_rel_insert_input option
-  ; fee: bit option
-  ; first_seen: bit option
-  ; hash: string option
-  ; memo: string option
-  ; nonce: bit option
-  ; publicKeyByReceiver: public_keys_obj_rel_insert_input option
-  ; public_key: public_keys_obj_rel_insert_input option
-  ; typ: user_command_type option >
+  < amount : bit option
+  ; blocks_user_commands : blocks_user_commands_arr_rel_insert_input option
+  ; fee : bit option
+  ; first_seen : bit option
+  ; hash : string option
+  ; memo : string option
+  ; nonce : bit option
+  ; publicKeyByReceiver : public_keys_obj_rel_insert_input option
+  ; public_key : public_keys_obj_rel_insert_input option
+  ; typ : user_command_type option >
 
 and state_hashes_insert_input =
-  < block: blocks_obj_rel_insert_input option
-  ; blocks: blocks_arr_rel_insert_input option
-  ; value: string option >
+  < block : blocks_obj_rel_insert_input option
+  ; blocks : blocks_arr_rel_insert_input option
+  ; value : string option >
 
 and state_hashes_obj_rel_insert_input =
   (state_hashes_insert_input, On_conflict.state_hashes) Rel_insert_input.t
@@ -139,17 +138,15 @@ and user_commands_obj_rel_insert_input =
   (user_commands_insert_input, On_conflict.user_commands) Rel_insert_input.t
 
 and user_commands_arr_rel_insert_input =
-  ( user_commands_insert_input
-  , On_conflict.user_commands )
-  Rel_insert_input.array
+  (user_commands_insert_input, On_conflict.user_commands) Rel_insert_input.array
 
 and snark_jobs_insert_input =
-  < blocks_snark_jobs: blocks_snark_jobs_arr_rel_insert_input option
-  ; fee: bit option
-  ; job1: int option
-  ; job2: int option
-  ; prover: int option
-  ; public_key: public_keys_obj_rel_insert_input option >
+  < blocks_snark_jobs : blocks_snark_jobs_arr_rel_insert_input option
+  ; fee : bit option
+  ; job1 : int option
+  ; job2 : int option
+  ; prover : int option
+  ; public_key : public_keys_obj_rel_insert_input option >
 
 and snark_jobs_obj_rel_insert_input =
   (snark_jobs_insert_input, On_conflict.snark_jobs) Rel_insert_input.t
@@ -158,10 +155,10 @@ and snark_jobs_arr_rel_insert_input =
   (snark_jobs_insert_input, On_conflict.snark_jobs) Rel_insert_input.array
 
 and blocks_fee_transfers_insert_input =
-  < block: blocks_obj_rel_insert_input option
-  ; block_id: int option
-  ; fee_transfer: fee_transfers_obj_rel_insert_input option
-  ; fee_transfer_id: int option >
+  < block : blocks_obj_rel_insert_input option
+  ; block_id : int option
+  ; fee_transfer : fee_transfers_obj_rel_insert_input option
+  ; fee_transfer_id : int option >
 
 and blocks_fee_transfers_obj_rel_insert_input =
   ( blocks_fee_transfers_insert_input
@@ -174,9 +171,9 @@ and blocks_fee_transfers_arr_rel_insert_input =
   Rel_insert_input.array
 
 and blocks_user_commands_insert =
-  < block: blocks_obj_rel_insert_input option
-  ; receipt_chain_hash: receipt_chain_hashes_obj_rel_insert_input option
-  ; user_command: user_commands_obj_rel_insert_input option >
+  < block : blocks_obj_rel_insert_input option
+  ; receipt_chain_hash : receipt_chain_hashes_obj_rel_insert_input option
+  ; user_command : user_commands_obj_rel_insert_input option >
 
 and blocks_user_commands_arr_rel_insert_input =
   ( blocks_user_commands_insert
@@ -184,10 +181,10 @@ and blocks_user_commands_arr_rel_insert_input =
   Rel_insert_input.array
 
 and blocks_snark_jobs_insert_input =
-  < block: blocks_obj_rel_insert_input option
-  ; block_id: int option
-  ; snark_job: snark_jobs_obj_rel_insert_input option
-  ; snark_job_id: int option >
+  < block : blocks_obj_rel_insert_input option
+  ; block_id : int option
+  ; snark_job : snark_jobs_obj_rel_insert_input option
+  ; snark_job_id : int option >
 
 and blocks_snark_jobs_arr_rel_insert_input =
   ( blocks_snark_jobs_insert_input
@@ -195,18 +192,18 @@ and blocks_snark_jobs_arr_rel_insert_input =
   Rel_insert_input.array
 
 and blocks_insert_input =
-  < block_length: bit option
-  ; block_time: bit option
-  ; blocks_fee_transfers: blocks_fee_transfers_arr_rel_insert_input option
-  ; blocks_snark_jobs: blocks_snark_jobs_arr_rel_insert_input option
-  ; blocks_user_commands: blocks_user_commands_arr_rel_insert_input option
-  ; global_slot: int option
-  ; ledger_hash: string option
-  ; ledger_proof_nonce: int option
-  ; public_key: public_keys_obj_rel_insert_input option
-  ; stateHashByParentHash: state_hashes_obj_rel_insert_input option
-  ; stateHashByStateHash: state_hashes_obj_rel_insert_input option
-  ; status: int option >
+  < block_length : bit option
+  ; block_time : bit option
+  ; blocks_fee_transfers : blocks_fee_transfers_arr_rel_insert_input option
+  ; blocks_snark_jobs : blocks_snark_jobs_arr_rel_insert_input option
+  ; blocks_user_commands : blocks_user_commands_arr_rel_insert_input option
+  ; global_slot : int option
+  ; ledger_hash : string option
+  ; ledger_proof_nonce : int option
+  ; public_key : public_keys_obj_rel_insert_input option
+  ; stateHashByParentHash : state_hashes_obj_rel_insert_input option
+  ; stateHashByStateHash : state_hashes_obj_rel_insert_input option
+  ; status : int option >
 
 and blocks_obj_rel_insert_input =
   (blocks_insert_input, On_conflict.blocks) Rel_insert_input.t

--- a/src/app/archive/archive_lib/chain_status.ml
+++ b/src/app/archive/archive_lib/chain_status.ml
@@ -6,13 +6,19 @@ type t = Canonical | Orphaned | Pending
 [@@deriving yojson, equal, bin_io_unversioned]
 
 let to_string = function
-  | Canonical -> "canonical"
-  | Orphaned -> "orphaned"
-  | Pending -> "pending"
+  | Canonical ->
+      "canonical"
+  | Orphaned ->
+      "orphaned"
+  | Pending ->
+      "pending"
 
 let of_string = function
-  | "canonical" -> Canonical
-  | "orphaned" -> Orphaned
-  | "pending" -> Pending
+  | "canonical" ->
+      Canonical
+  | "orphaned" ->
+      Orphaned
+  | "pending" ->
+      Pending
   | s ->
-    failwithf "Chain_status.of_string: invalid string = %s" s ()
+      failwithf "Chain_status.of_string: invalid string = %s" s ()

--- a/src/app/archive/archive_lib/diff.ml
+++ b/src/app/archive/archive_lib/diff.ml
@@ -11,16 +11,16 @@ module Transition_frontier = struct
     module V2 = struct
       type t =
         | Breadcrumb_added of
-            { block:
+            { block :
                 ( External_transition.Raw.Stable.V1.t
                 , State_hash.Stable.V1.t )
                 With_hash.Stable.V1.t
-            ; sender_receipt_chains_from_parent_ledger:
+            ; sender_receipt_chains_from_parent_ledger :
                 (Account_id.Stable.V1.t * Receipt.Chain_hash.Stable.V1.t) list
             }
         | Root_transitioned of
             Transition_frontier.Diff.Root_transition.Lite.Stable.V2.t
-        | Bootstrap of {lost_blocks: State_hash.Stable.V1.t list}
+        | Bootstrap of { lost_blocks : State_hash.Stable.V1.t list }
 
       let to_latest = Fn.id
     end
@@ -32,8 +32,9 @@ module Transaction_pool = struct
   module Stable = struct
     module V1 = struct
       type t =
-        { added: User_command.Stable.V1.t list
-        ; removed: User_command.Stable.V1.t list }
+        { added : User_command.Stable.V1.t list
+        ; removed : User_command.Stable.V1.t list
+        }
 
       let to_latest = Fn.id
     end
@@ -53,16 +54,16 @@ end]
 
 module Builder = struct
   let breadcrumb_added breadcrumb =
-    let validated_block =
-      Breadcrumb.validated_transition breadcrumb
+    let validated_block = Breadcrumb.validated_transition breadcrumb in
+    let block, _ =
+      External_transition.Validated.Stable.V1.of_v2 validated_block
     in
-    let block, _ = External_transition.Validated.Stable.V1.of_v2 validated_block in
     let commands = External_transition.Validated.commands validated_block in
     let sender_receipt_chains_from_parent_ledger =
       let senders =
         commands
-        |> List.map ~f:(fun {data; _} ->
-               User_command.(fee_payer (forget_check data)) )
+        |> List.map ~f:(fun { data; _ } ->
+               User_command.(fee_payer (forget_check data)))
         |> Account_id.Set.of_list
       in
       let ledger =
@@ -75,14 +76,16 @@ module Builder = struct
                let%bind ledger_location =
                  Ledger.location_of_account ledger sender
                in
-               let%map {receipt_chain_hash; _} =
+               let%map { receipt_chain_hash; _ } =
                  Ledger.get ledger ledger_location
                in
-               (sender, receipt_chain_hash)) )
+               (sender, receipt_chain_hash)))
     in
     Transition_frontier.Breadcrumb_added
-      {block = With_hash.map ~f:External_transition.compose block; sender_receipt_chains_from_parent_ledger}
+      { block = With_hash.map ~f:External_transition.compose block
+      ; sender_receipt_chains_from_parent_ledger
+      }
 
   let user_commands user_commands =
-    Transaction_pool {Transaction_pool.added= user_commands; removed= []}
+    Transaction_pool { Transaction_pool.added = user_commands; removed = [] }
 end

--- a/src/app/archive/archive_lib/extensional.ml
+++ b/src/app/archive/archive_lib/extensional.ml
@@ -19,31 +19,32 @@ module User_command = struct
       top-level Transaction.t
   *)
   type t =
-    { sequence_no: int
-    ; typ: string
-    ; fee_payer: Public_key.Compressed.Stable.Latest.t
-    ; source: Public_key.Compressed.Stable.Latest.t
-    ; receiver: Public_key.Compressed.Stable.Latest.t
-    ; fee_token: Token_id.Stable.Latest.t
-    ; token: Token_id.Stable.Latest.t
-    ; nonce: Account.Nonce.Stable.Latest.t
-    ; amount: Currency.Amount.Stable.Latest.t option
-    ; fee: Currency.Fee.Stable.Latest.t
-    ; valid_until: Mina_numbers.Global_slot.Stable.Latest.t option
-    ; memo: Signed_command_memo.Stable.Latest.t
-    ; hash: Transaction_hash.Stable.Latest.t
+    { sequence_no : int
+    ; typ : string
+    ; fee_payer : Public_key.Compressed.Stable.Latest.t
+    ; source : Public_key.Compressed.Stable.Latest.t
+    ; receiver : Public_key.Compressed.Stable.Latest.t
+    ; fee_token : Token_id.Stable.Latest.t
+    ; token : Token_id.Stable.Latest.t
+    ; nonce : Account.Nonce.Stable.Latest.t
+    ; amount : Currency.Amount.Stable.Latest.t option
+    ; fee : Currency.Fee.Stable.Latest.t
+    ; valid_until : Mina_numbers.Global_slot.Stable.Latest.t option
+    ; memo : Signed_command_memo.Stable.Latest.t
+    ; hash : Transaction_hash.Stable.Latest.t
           [@to_yojson Transaction_hash.to_yojson]
           [@of_yojson Transaction_hash.of_yojson]
-    ; status: string
-    ; failure_reason: Transaction_status.Failure.Stable.Latest.t option
-    ; source_balance: Currency.Balance.Stable.Latest.t option
-    ; fee_payer_account_creation_fee_paid:
+    ; status : string
+    ; failure_reason : Transaction_status.Failure.Stable.Latest.t option
+    ; source_balance : Currency.Balance.Stable.Latest.t option
+    ; fee_payer_account_creation_fee_paid :
         Currency.Amount.Stable.Latest.t option
-    ; fee_payer_balance: Currency.Balance.Stable.Latest.t
-    ; receiver_account_creation_fee_paid:
+    ; fee_payer_balance : Currency.Balance.Stable.Latest.t
+    ; receiver_account_creation_fee_paid :
         Currency.Amount.Stable.Latest.t option
-    ; receiver_balance: Currency.Balance.Stable.Latest.t option
-    ; created_token: Token_id.Stable.Latest.t option }
+    ; receiver_balance : Currency.Balance.Stable.Latest.t option
+    ; created_token : Token_id.Stable.Latest.t option
+    }
   [@@deriving yojson, equal, bin_io_unversioned]
 end
 
@@ -52,40 +53,41 @@ module Internal_command = struct
      no existing string conversion for the original OCaml type
   *)
   type t =
-    { sequence_no: int
-    ; secondary_sequence_no: int
-    ; typ: string
-    ; receiver: Public_key.Compressed.Stable.Latest.t
-    ; receiver_account_creation_fee_paid:
+    { sequence_no : int
+    ; secondary_sequence_no : int
+    ; typ : string
+    ; receiver : Public_key.Compressed.Stable.Latest.t
+    ; receiver_account_creation_fee_paid :
         Currency.Amount.Stable.Latest.t option
-    ; receiver_balance: Currency.Balance.Stable.Latest.t
-    ; fee: Currency.Fee.Stable.Latest.t
-    ; token: Token_id.Stable.Latest.t
-    ; hash: Transaction_hash.Stable.Latest.t
+    ; receiver_balance : Currency.Balance.Stable.Latest.t
+    ; fee : Currency.Fee.Stable.Latest.t
+    ; token : Token_id.Stable.Latest.t
+    ; hash : Transaction_hash.Stable.Latest.t
           [@to_yojson Transaction_hash.to_yojson]
-          [@of_yojson Transaction_hash.of_yojson] }
+          [@of_yojson Transaction_hash.of_yojson]
+    }
   [@@deriving yojson, equal, bin_io_unversioned]
 end
 
 module Block = struct
   type t =
-    { state_hash: State_hash.Stable.Latest.t
-    ; parent_hash: State_hash.Stable.Latest.t
-    ; creator: Public_key.Compressed.Stable.Latest.t
-    ; block_winner: Public_key.Compressed.Stable.Latest.t
-    ; snarked_ledger_hash: Frozen_ledger_hash.Stable.Latest.t
-    ; staking_epoch_seed: Epoch_seed.Stable.Latest.t
-    ; staking_epoch_ledger_hash: Frozen_ledger_hash.Stable.Latest.t
-    ; next_epoch_seed: Epoch_seed.Stable.Latest.t
-    ; next_epoch_ledger_hash: Frozen_ledger_hash.Stable.Latest.t
-    ; ledger_hash: Ledger_hash.Stable.Latest.t
-    ; height: Unsigned_extended.UInt32.Stable.Latest.t
-    ; global_slot_since_hard_fork: Mina_numbers.Global_slot.Stable.Latest.t
-    ; global_slot_since_genesis: Mina_numbers.Global_slot.Stable.Latest.t
-    ; timestamp: Block_time.Stable.Latest.t
-    ; user_cmds: User_command.t list
-    ; internal_cmds: Internal_command.t list
-    ; chain_status: Chain_status.t
+    { state_hash : State_hash.Stable.Latest.t
+    ; parent_hash : State_hash.Stable.Latest.t
+    ; creator : Public_key.Compressed.Stable.Latest.t
+    ; block_winner : Public_key.Compressed.Stable.Latest.t
+    ; snarked_ledger_hash : Frozen_ledger_hash.Stable.Latest.t
+    ; staking_epoch_seed : Epoch_seed.Stable.Latest.t
+    ; staking_epoch_ledger_hash : Frozen_ledger_hash.Stable.Latest.t
+    ; next_epoch_seed : Epoch_seed.Stable.Latest.t
+    ; next_epoch_ledger_hash : Frozen_ledger_hash.Stable.Latest.t
+    ; ledger_hash : Ledger_hash.Stable.Latest.t
+    ; height : Unsigned_extended.UInt32.Stable.Latest.t
+    ; global_slot_since_hard_fork : Mina_numbers.Global_slot.Stable.Latest.t
+    ; global_slot_since_genesis : Mina_numbers.Global_slot.Stable.Latest.t
+    ; timestamp : Block_time.Stable.Latest.t
+    ; user_cmds : User_command.t list
+    ; internal_cmds : Internal_command.t list
+    ; chain_status : Chain_status.t
     }
   [@@deriving yojson, equal, bin_io_unversioned]
 end

--- a/src/app/archive/archive_lib/graphql_query/base_types.ml
+++ b/src/app/archive/archive_lib/graphql_query/base_types.ml
@@ -34,7 +34,7 @@ end = struct
 end
 
 module User_command_type = struct
-  type t = [`Payment | `Delegation]
+  type t = [ `Payment | `Delegation ]
 
   let encode = function
     | `Payment ->

--- a/src/app/archive/archive_lib/metrics.ml
+++ b/src/app/archive/archive_lib/metrics.ml
@@ -24,7 +24,7 @@ module Max_block_height = struct
         Mina_metrics.(
           Gauge.set
             (Archive.max_block_height metric_server)
-            (Float.of_int max_height)) )
+            (Float.of_int max_height)))
 end
 
 module Missing_blocks = struct
@@ -48,7 +48,7 @@ module Missing_blocks = struct
         Mina_metrics.(
           Gauge.set
             (Archive.missing_blocks metric_server)
-            (Float.of_int missing_blocks)) )
+            (Float.of_int missing_blocks)))
 end
 
 module Unparented_blocks = struct
@@ -68,26 +68,26 @@ module Unparented_blocks = struct
         Mina_metrics.(
           Gauge.set
             (Archive.unparented_blocks metric_server)
-            (Float.of_int unparented_block_count)) )
+            (Float.of_int unparented_block_count)))
 end
 
 let log_error ~logger pool metric_server
     (f :
          (module Caqti_async.CONNECTION)
       -> Mina_metrics.Archive.t
-      -> (unit, [> Caqti_error.call_or_retrieve]) Deferred.Result.t) =
+      -> (unit, [> Caqti_error.call_or_retrieve ]) Deferred.Result.t) =
   let open Deferred.Let_syntax in
   match%map
     Caqti_async.Pool.use
       (fun (module Conn : Caqti_async.CONNECTION) ->
-        f (module Conn) metric_server )
+        f (module Conn) metric_server)
       pool
   with
   | Ok () ->
       ()
   | Error e ->
       [%log warn] "Error updating archive metrics: $error"
-        ~metadata:[("error", `String (Caqti_error.show e))]
+        ~metadata:[ ("error", `String (Caqti_error.show e)) ]
 
 let update ~logger ~missing_blocks_width pool metric_server =
   Deferred.all_unit
@@ -95,4 +95,5 @@ let update ~logger ~missing_blocks_width pool metric_server =
        ~f:(log_error ~logger pool metric_server)
        [ Max_block_height.update
        ; Unparented_blocks.update
-       ; Missing_blocks.update ~missing_blocks_width ])
+       ; Missing_blocks.update ~missing_blocks_width
+       ])

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -46,8 +46,8 @@ module Caqti_type_spec = struct
          x :: tuple_to_hlist spec t
 end
 
-let rec vector : type t n.
-    n Nat.t -> t Caqti_type.t -> (t, n) Vector.t Caqti_type.t =
+let rec vector :
+    type t n. n Nat.t -> t Caqti_type.t -> (t, n) Vector.t Caqti_type.t =
  fun n t ->
   match n with
   | Z ->
@@ -119,20 +119,21 @@ end
 
 module Timing_info = struct
   type t =
-    { public_key_id: int
-    ; token: int64
-    ; initial_balance: int64
-    ; initial_minimum_balance: int64
-    ; cliff_time: int64
-    ; cliff_amount: int64
-    ; vesting_period: int64
-    ; vesting_increment: int64 }
+    { public_key_id : int
+    ; token : int64
+    ; initial_balance : int64
+    ; initial_minimum_balance : int64
+    ; cliff_time : int64
+    ; cliff_amount : int64
+    ; vesting_period : int64
+    ; vesting_increment : int64
+    }
   [@@deriving hlist]
 
   let typ =
     let open Caqti_type_spec in
     let spec =
-      Caqti_type.[int; int64; int64; int64; int64; int64; int64; int64]
+      Caqti_type.[ int; int64; int64; int64; int64; int64; int64; int64 ]
     in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
@@ -154,17 +155,18 @@ module Timing_info = struct
   let find_by_pk_opt (module Conn : CONNECTION) public_key =
     let open Deferred.Result.Let_syntax in
     match%bind Public_key.find_opt (module Conn) public_key with
-    | None -> return None
+    | None ->
+        return None
     | Some pk_id ->
-      Conn.find_opt
-        (Caqti_request.find_opt Caqti_type.int typ
-           {sql| SELECT public_key_id, token, initial_balance,
+        Conn.find_opt
+          (Caqti_request.find_opt Caqti_type.int typ
+             {sql| SELECT public_key_id, token, initial_balance,
                         initial_minimum_balance, cliff_time, cliff_amount,
                         vesting_period, vesting_increment
                FROM timing_info
                WHERE public_key_id = ?
          |sql})
-        pk_id
+          pk_id
 
   let add_if_doesn't_exist (module Conn : CONNECTION) (acc : Account.t) =
     let open Deferred.Result.Let_syntax in
@@ -195,23 +197,25 @@ module Timing_info = struct
           | Timed timing ->
               { public_key_id
               ; token
-              ; initial_balance= balance_to_int64 acc.balance
-              ; initial_minimum_balance=
+              ; initial_balance = balance_to_int64 acc.balance
+              ; initial_minimum_balance =
                   balance_to_int64 timing.initial_minimum_balance
-              ; cliff_time= slot_to_int64 timing.cliff_time
-              ; cliff_amount= amount_to_int64 timing.cliff_amount
-              ; vesting_period= slot_to_int64 timing.vesting_period
-              ; vesting_increment= amount_to_int64 timing.vesting_increment }
+              ; cliff_time = slot_to_int64 timing.cliff_time
+              ; cliff_amount = amount_to_int64 timing.cliff_amount
+              ; vesting_period = slot_to_int64 timing.vesting_period
+              ; vesting_increment = amount_to_int64 timing.vesting_increment
+              }
           | Untimed ->
               let zero = Int64.zero in
               { public_key_id
               ; token
-              ; initial_balance= balance_to_int64 acc.balance
-              ; initial_minimum_balance= zero
-              ; cliff_time= zero
-              ; cliff_amount= zero
-              ; vesting_period= zero
-              ; vesting_increment= zero }
+              ; initial_balance = balance_to_int64 acc.balance
+              ; initial_minimum_balance = zero
+              ; cliff_time = zero
+              ; cliff_amount = zero
+              ; vesting_period = zero
+              ; vesting_increment = zero
+              }
         in
         Conn.find
           (Caqti_request.find typ Caqti_type.int
@@ -232,8 +236,8 @@ module Snarked_ledger_hash = struct
          "SELECT id FROM snarked_ledger_hashes WHERE value = ?")
       hash
 
-  let add_if_doesn't_exist (module Conn : CONNECTION)
-      (t : Frozen_ledger_hash.t) =
+  let add_if_doesn't_exist (module Conn : CONNECTION) (t : Frozen_ledger_hash.t)
+      =
     let open Deferred.Result.Let_syntax in
     let hash = Frozen_ledger_hash.to_base58_check t in
     match%bind
@@ -252,11 +256,11 @@ module Snarked_ledger_hash = struct
 end
 
 module Epoch_data = struct
-  type t = {seed: string; ledger_hash_id: int}
+  type t = { seed : string; ledger_hash_id : int }
 
   let typ =
     let encode t = Ok (t.seed, t.ledger_hash_id) in
-    let decode (seed, ledger_hash_id) = Ok {seed; ledger_hash_id} in
+    let decode (seed, ledger_hash_id) = Ok { seed; ledger_hash_id } in
     let rep = Caqti_type.(tup2 string int) in
     Caqti_type.custom ~encode ~decode rep
 
@@ -269,7 +273,7 @@ module Epoch_data = struct
       Conn.find_opt
         (Caqti_request.find_opt typ Caqti_type.int
            "SELECT id FROM epoch_data WHERE seed = ? AND ledger_hash_id = ?")
-        {seed; ledger_hash_id}
+        { seed; ledger_hash_id }
     with
     | Some id ->
         return id
@@ -279,12 +283,12 @@ module Epoch_data = struct
              {sql| INSERT INTO epoch_data (seed, ledger_hash_id) VALUES (?, ?)
                    RETURNING id
              |sql})
-          {seed; ledger_hash_id}
+          { seed; ledger_hash_id }
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (t : Mina_base.Epoch_data.Value.t) =
     let open Deferred.Result.Let_syntax in
-    let Mina_base.Epoch_ledger.Poly.{hash; _} =
+    let Mina_base.Epoch_ledger.Poly.{ hash; _ } =
       Mina_base.Epoch_data.Poly.ledger t
     in
     let%bind ledger_hash_id =
@@ -299,18 +303,19 @@ end
 module User_command = struct
   module Signed_command = struct
     type t =
-      { typ: string
-      ; fee_payer_id: int
-      ; source_id: int
-      ; receiver_id: int
-      ; fee_token: int64
-      ; token: int64
-      ; nonce: int
-      ; amount: int64 option
-      ; fee: int64
-      ; valid_until: int64 option
-      ; memo: string
-      ; hash: string }
+      { typ : string
+      ; fee_payer_id : int
+      ; source_id : int
+      ; receiver_id : int
+      ; fee_token : int64
+      ; token : int64
+      ; nonce : int
+      ; amount : int64 option
+      ; fee : int64
+      ; valid_until : int64 option
+      ; memo : string
+      ; hash : string
+      }
     [@@deriving hlist]
 
     let typ =
@@ -328,14 +333,15 @@ module User_command = struct
           ; int64
           ; option int64
           ; string
-          ; string ]
+          ; string
+          ]
       in
       let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
       let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
       Caqti_type.custom ~encode ~decode (to_rep spec)
 
-    let find (module Conn : CONNECTION)
-        ~(transaction_hash : Transaction_hash.t) =
+    let find (module Conn : CONNECTION) ~(transaction_hash : Transaction_hash.t)
+        =
       Conn.find_opt
         (Caqti_request.find_opt Caqti_type.string Caqti_type.int
            "SELECT id FROM user_commands WHERE hash = ?")
@@ -353,7 +359,7 @@ module User_command = struct
         id
 
     type balance_public_key_ids =
-      {fee_payer_id: int; source_id: int; receiver_id: int}
+      { fee_payer_id : int; source_id : int; receiver_id : int }
 
     let add_balance_public_keys_if_don't_exist (module Conn : CONNECTION)
         (t : Signed_command.t) =
@@ -373,19 +379,17 @@ module User_command = struct
           (module Conn)
           (Signed_command.receiver_pk t)
       in
-      {fee_payer_id; source_id; receiver_id}
+      { fee_payer_id; source_id; receiver_id }
 
     let add_if_doesn't_exist ?(via = `Ident) (module Conn : CONNECTION)
         (t : Signed_command.t) =
       let open Deferred.Result.Let_syntax in
-      let transaction_hash =
-        Transaction_hash.hash_command (Signed_command t)
-      in
+      let transaction_hash = Transaction_hash.hash_command (Signed_command t) in
       match%bind find (module Conn) ~transaction_hash with
       | Some user_command_id ->
           return user_command_id
       | None ->
-          let%bind {fee_payer_id; source_id; receiver_id} =
+          let%bind { fee_payer_id; source_id; receiver_id } =
             add_balance_public_keys_if_don't_exist (module Conn) t
           in
           let valid_until =
@@ -405,7 +409,7 @@ module User_command = struct
                       valid_until, memo, hash)
                     VALUES (?::user_command_type, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     RETURNING id |sql})
-            { typ=
+            { typ =
                 ( match via with
                 | `Ident ->
                     Signed_command.tag_string t
@@ -414,25 +418,26 @@ module User_command = struct
             ; fee_payer_id
             ; source_id
             ; receiver_id
-            ; fee_token=
+            ; fee_token =
                 Signed_command.fee_token t |> Token_id.to_uint64
                 |> Unsigned.UInt64.to_int64
-            ; token=
+            ; token =
                 Signed_command.token t |> Token_id.to_uint64
                 |> Unsigned.UInt64.to_int64
-            ; nonce= Signed_command.nonce t |> Unsigned.UInt32.to_int
-            ; amount=
+            ; nonce = Signed_command.nonce t |> Unsigned.UInt32.to_int
+            ; amount =
                 Signed_command.amount t
                 |> Core.Option.map ~f:(fun amt ->
-                       Currency.Amount.to_uint64 amt
-                       |> Unsigned.UInt64.to_int64 )
-            ; fee=
+                       Currency.Amount.to_uint64 amt |> Unsigned.UInt64.to_int64)
+            ; fee =
                 ( Signed_command.fee t
                 |> fun amt ->
                 Currency.Fee.to_uint64 amt |> Unsigned.UInt64.to_int64 )
             ; valid_until
-            ; memo= Signed_command.memo t |> Signed_command_memo.to_base58_check
-            ; hash= transaction_hash |> Transaction_hash.to_base58_check }
+            ; memo =
+                Signed_command.memo t |> Signed_command_memo.to_base58_check
+            ; hash = transaction_hash |> Transaction_hash.to_base58_check
+            }
   end
 
   let as_signed_command (t : User_command.t) : Mina_base.Signed_command.t =
@@ -441,28 +446,32 @@ module User_command = struct
         c
     | Snapp_command c ->
         let module S = Mina_base.Snapp_command in
-        let ({source; receiver; amount} : S.transfer) = S.as_transfer c in
+        let ({ source; receiver; amount } : S.transfer) = S.as_transfer c in
         let fee_payer = S.fee_payer c in
-        { signature= Signature.dummy
-        ; signer= Snark_params.Tick.Field.(zero, zero)
-        ; payload=
-            { common=
-                { fee= S.fee_exn c
-                ; fee_token= Account_id.token_id fee_payer
-                ; fee_payer_pk= Account_id.public_key fee_payer
-                ; nonce=
+        { signature = Signature.dummy
+        ; signer = Snark_params.Tick.Field.(zero, zero)
+        ; payload =
+            { common =
+                { fee = S.fee_exn c
+                ; fee_token = Account_id.token_id fee_payer
+                ; fee_payer_pk = Account_id.public_key fee_payer
+                ; nonce =
                     Option.value (S.nonce c)
                       ~default:Mina_numbers.Account_nonce.zero
-                ; valid_until= Mina_numbers.Global_slot.max_value
-                ; memo= Signed_command_memo.create_from_string_exn "snapp" }
-            ; body=
+                ; valid_until = Mina_numbers.Global_slot.max_value
+                ; memo = Signed_command_memo.create_from_string_exn "snapp"
+                }
+            ; body =
                 Payment
-                  { source_pk= source
-                  ; receiver_pk= receiver
-                  ; token_id= S.token_id c
-                  ; amount } } }
+                  { source_pk = source
+                  ; receiver_pk = receiver
+                  ; token_id = S.token_id c
+                  ; amount
+                  }
+            }
+        }
 
-  let via (t : User_command.t) : [`Snapp_command | `Ident] =
+  let via (t : User_command.t) : [ `Snapp_command | `Ident ] =
     match t with
     | Signed_command _ ->
         `Ident
@@ -500,25 +509,26 @@ module User_command = struct
                     VALUES (?::user_command_type, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     RETURNING id
          |sql})
-      { typ= user_cmd.typ
+      { typ = user_cmd.typ
       ; fee_payer_id
       ; source_id
       ; receiver_id
-      ; fee_token=
+      ; fee_token =
           user_cmd.fee_token |> Token_id.to_uint64 |> Unsigned.UInt64.to_int64
-      ; token= user_cmd.token |> Token_id.to_uint64 |> Unsigned.UInt64.to_int64
-      ; nonce= user_cmd.nonce |> Unsigned.UInt32.to_int
-      ; amount= user_cmd.amount |> amount_opt_to_int64_opt
-      ; fee=
+      ; token = user_cmd.token |> Token_id.to_uint64 |> Unsigned.UInt64.to_int64
+      ; nonce = user_cmd.nonce |> Unsigned.UInt32.to_int
+      ; amount = user_cmd.amount |> amount_opt_to_int64_opt
+      ; fee =
           user_cmd.fee
           |> Fn.compose Unsigned.UInt64.to_int64 Currency.Fee.to_uint64
-      ; valid_until=
+      ; valid_until =
           Option.map user_cmd.valid_until
             ~f:
               (Fn.compose Unsigned.UInt32.to_int64
                  Mina_numbers.Global_slot.to_uint32)
-      ; memo= user_cmd.memo |> Signed_command_memo.to_base58_check
-      ; hash= user_cmd.hash |> Transaction_hash.to_base58_check }
+      ; memo = user_cmd.memo |> Signed_command_memo.to_base58_check
+      ; hash = user_cmd.hash |> Transaction_hash.to_base58_check
+      }
 
   let add_extensional_if_doesn't_exist (module Conn : CONNECTION)
       (user_cmd : Extensional.User_command.t) =
@@ -532,12 +542,17 @@ end
 
 module Internal_command = struct
   type t =
-    {typ: string; receiver_id: int; fee: int64; token: int64; hash: string}
+    { typ : string
+    ; receiver_id : int
+    ; fee : int64
+    ; token : int64
+    ; hash : string
+    }
 
   let typ =
     let encode t = Ok ((t.typ, t.receiver_id, t.fee, t.token), t.hash) in
     let decode ((typ, receiver_id, fee, token), hash) =
-      Ok {typ; receiver_id; fee; token; hash}
+      Ok { typ; receiver_id; fee; token; hash }
     in
     let rep = Caqti_type.(tup2 (tup4 string int int64 int64) string) in
     Caqti_type.custom ~encode ~decode rep
@@ -548,7 +563,8 @@ module Internal_command = struct
       (Caqti_request.find_opt
          Caqti_type.(tup2 string string)
          Caqti_type.int
-         "SELECT id FROM internal_commands WHERE hash = $1 AND type = $2::internal_command_type")
+         "SELECT id FROM internal_commands WHERE hash = $1 AND type = \
+          $2::internal_command_type")
       (Transaction_hash.to_base58_check transaction_hash, typ)
 
   let load (module Conn : CONNECTION) ~(id : int) =
@@ -581,20 +597,21 @@ module Internal_command = struct
                    VALUES (?::internal_command_type, ?, ?, ?, ?)
                    RETURNING id
              |sql})
-          { typ= internal_cmd.typ
+          { typ = internal_cmd.typ
           ; receiver_id
-          ; fee=
+          ; fee =
               internal_cmd.fee |> Currency.Fee.to_uint64
               |> Unsigned.UInt64.to_int64
-          ; token=
+          ; token =
               internal_cmd.token |> Token_id.to_uint64
               |> Unsigned.UInt64.to_int64
-          ; hash= internal_cmd.hash |> Transaction_hash.to_base58_check }
+          ; hash = internal_cmd.hash |> Transaction_hash.to_base58_check
+          }
 end
 
 module Fee_transfer = struct
   module Kind = struct
-    type t = [`Normal | `Via_coinbase]
+    type t = [ `Normal | `Via_coinbase ]
 
     let to_string : t -> string = function
       | `Normal ->
@@ -604,7 +621,12 @@ module Fee_transfer = struct
   end
 
   type t =
-    {kind: Kind.t; receiver_id: int; fee: int64; token: int64; hash: string}
+    { kind : Kind.t
+    ; receiver_id : int
+    ; fee : int64
+    ; token : int64
+    ; hash : string
+    }
 
   let typ =
     let encode t =
@@ -622,13 +644,13 @@ module Fee_transfer = struct
         | s ->
             Result.fail (sprintf "Bad kind %s in decode attempt" s)
       in
-      Ok {kind; receiver_id; fee; token; hash}
+      Ok { kind; receiver_id; fee; token; hash }
     in
     let rep = Caqti_type.(tup2 (tup4 string int int64 int64) string) in
     Caqti_type.custom ~encode ~decode rep
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
-      (t : Fee_transfer.Single.t) (kind : [`Normal | `Via_coinbase]) =
+      (t : Fee_transfer.Single.t) (kind : [ `Normal | `Via_coinbase ]) =
     let open Deferred.Result.Let_syntax in
     let transaction_hash = Transaction_hash.hash_fee_transfer t in
     match%bind
@@ -653,13 +675,16 @@ module Fee_transfer = struct
              |sql})
           { kind
           ; receiver_id
-          ; fee= Fee_transfer.Single.fee t |> Currency.Fee.to_uint64 |> Unsigned.UInt64.to_int64
-          ; token= Token_id.to_string t.fee_token |> Int64.of_string
-          ; hash= transaction_hash |> Transaction_hash.to_base58_check }
+          ; fee =
+              Fee_transfer.Single.fee t |> Currency.Fee.to_uint64
+              |> Unsigned.UInt64.to_int64
+          ; token = Token_id.to_string t.fee_token |> Int64.of_string
+          ; hash = transaction_hash |> Transaction_hash.to_base58_check
+          }
 end
 
 module Coinbase = struct
-  type t = {receiver_id: int; amount: int64; hash: string}
+  type t = { receiver_id : int; amount : int64; hash : string }
 
   let coinbase_typ = "coinbase"
 
@@ -673,7 +698,7 @@ module Coinbase = struct
         , t.hash )
     in
     let decode ((_, receiver_id, amount, _), hash) =
-      Ok {receiver_id; amount; hash}
+      Ok { receiver_id; amount; hash }
     in
     let rep = Caqti_type.(tup2 (tup4 string int int64 int64) string) in
     Caqti_type.custom ~encode ~decode rep
@@ -688,9 +713,7 @@ module Coinbase = struct
         return internal_command_id
     | None ->
         let%bind receiver_id =
-          Public_key.add_if_doesn't_exist
-            (module Conn)
-            (Coinbase.receiver_pk t)
+          Public_key.add_if_doesn't_exist (module Conn) (Coinbase.receiver_pk t)
         in
         Conn.find
           (Caqti_request.find typ Caqti_type.int
@@ -700,8 +723,11 @@ module Coinbase = struct
                    RETURNING id
              |sql})
           { receiver_id
-          ; amount= Coinbase.amount t |> Currency.Amount.to_uint64 |> Unsigned.UInt64.to_int64
-          ; hash= transaction_hash |> Transaction_hash.to_base58_check }
+          ; amount =
+              Coinbase.amount t |> Currency.Amount.to_uint64
+              |> Unsigned.UInt64.to_int64
+          ; hash = transaction_hash |> Transaction_hash.to_base58_check
+          }
 end
 
 module Find_nonce = struct
@@ -709,8 +735,8 @@ module Find_nonce = struct
     (* using a string containing the comma-delimited public keys list as an SQL parameter results
        in syntax errors, so we inline that list into the query
     *)
-    (sprintf
-       {sql|
+    sprintf
+      {sql|
 SELECT t.pk_id, MAX(pk), MAX(t.height) as height, MAX(t.nonce) AS nonce FROM
 (
 WITH RECURSIVE pending_chain_nonce AS (
@@ -756,17 +782,16 @@ WITH RECURSIVE pending_chain_nonce AS (
               ORDER BY (full_chain.height, busc.sequence_no) DESC
             ) t
             GROUP BY t.pk_id LIMIT $2
-    |sql} public_keys_sql_list)
+    |sql}
+      public_keys_sql_list
 
-  type t = { public_key_id: int
-           ; public_key: string
-           ; height: int
-           ; nonce: int64
-           } [@@deriving hlist]
+  type t =
+    { public_key_id : int; public_key : string; height : int; nonce : int64 }
+  [@@deriving hlist]
 
   let typ =
     let open Caqti_type_spec in
-    let spec = Caqti_type.[int; string; int; int64] in
+    let spec = Caqti_type.[ int; string; int; int64 ] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
     Caqti_type.custom ~encode ~decode (to_rep spec)
@@ -777,14 +802,17 @@ WITH RECURSIVE pending_chain_nonce AS (
       return @@ Ok []
     else
       let public_keys_sql_list =
-        (public_keys
-         |> List.map ~f:(fun pk -> sprintf "'%s'" (Signature_lib.Public_key.Compressed.to_base58_check pk))
-         |> String.concat ~sep:",")
+        public_keys
+        |> List.map ~f:(fun pk ->
+               sprintf "'%s'"
+                 (Signature_lib.Public_key.Compressed.to_base58_check pk))
+        |> String.concat ~sep:","
       in
       Conn.collect_list
         (Caqti_request.collect
            Caqti_type.(tup2 int int)
-           typ (sql_template public_keys_sql_list))
+           typ
+           (sql_template public_keys_sql_list))
         (parent_id, List.length public_keys)
 
   (* INVARIANT: The map is populated with all the public_keys present *)
@@ -793,31 +821,40 @@ WITH RECURSIVE pending_chain_nonce AS (
     let%map ts = collect (module Conn) ~public_keys ~parent_id in
     let alist =
       List.map ts ~f:(fun t ->
-        (Signature_lib.Public_key.Compressed.of_base58_check_exn t.public_key),
-        Account.Nonce.of_uint32 Unsigned.UInt32.(of_int64 t.nonce |> succ))
+          ( Signature_lib.Public_key.Compressed.of_base58_check_exn t.public_key
+          , Account.Nonce.of_uint32 Unsigned.UInt32.(of_int64 t.nonce |> succ)
+          ))
     in
     let map = Signature_lib.Public_key.Compressed.Map.of_alist_exn alist in
     List.fold public_keys ~init:map ~f:(fun map key ->
-      match Signature_lib.Public_key.Compressed.Map.add map ~key ~data:Account.Nonce.zero with
-      | `Ok map' -> map'
-      | `Duplicate -> map
-    )
+        match
+          Signature_lib.Public_key.Compressed.Map.add map ~key
+            ~data:Account.Nonce.zero
+        with
+        | `Ok map' ->
+            map'
+        | `Duplicate ->
+            map)
 end
 
 module Balance = struct
-  type t = { id: int
-           ; public_key_id: int
-           ; balance: int64
-           ; block_id: int
-           ; block_height: int64
-           ; block_sequence_no: int
-           ; block_secondary_sequence_no: int
-           ; nonce : int64 option
-           } [@@deriving hlist]
+  type t =
+    { id : int
+    ; public_key_id : int
+    ; balance : int64
+    ; block_id : int
+    ; block_height : int64
+    ; block_sequence_no : int
+    ; block_secondary_sequence_no : int
+    ; nonce : int64 option
+    }
+  [@@deriving hlist]
 
   let typ =
     let open Caqti_type_spec in
-    let spec = Caqti_type.[int; int; int64; int; int64;int;int; option int64] in
+    let spec =
+      Caqti_type.[ int; int; int64; int; int64; int; int; option int64 ]
+    in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
     Caqti_type.custom ~encode ~decode (to_rep spec)
@@ -827,8 +864,9 @@ module Balance = struct
     |> Unsigned.UInt64.to_int64
 
   let find (module Conn : CONNECTION) ~(public_key_id : int)
-      ~(balance : Currency.Balance.t) ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no =
-        (* TODO: Do we need to query with the nonce here? *)
+      ~(balance : Currency.Balance.t) ~block_id ~block_height ~block_sequence_no
+      ~block_secondary_sequence_no =
+    (* TODO: Do we need to query with the nonce here? *)
     Conn.find_opt
       (Caqti_request.find_opt
          Caqti_type.(tup2 (tup2 int int64) (tup4 int int64 int int))
@@ -841,13 +879,13 @@ module Balance = struct
                AND block_sequence_no = $5
                AND block_secondary_sequence_no = $6
          |sql})
-         ((public_key_id, balance_to_int64 balance),
-          (block_id, block_height, block_sequence_no, block_secondary_sequence_no))
+      ( (public_key_id, balance_to_int64 balance)
+      , (block_id, block_height, block_sequence_no, block_secondary_sequence_no)
+      )
 
   let load (module Conn : CONNECTION) ~(id : int) =
     Conn.find
-      (Caqti_request.find Caqti_type.int
-         typ
+      (Caqti_request.find Caqti_type.int typ
          {sql| SELECT id, public_key_id, balance,
                       block_id, block_height,
                       block_sequence_no, block_secondary_sequence_no, nonce
@@ -857,47 +895,62 @@ module Balance = struct
       id
 
   let add (module Conn : CONNECTION) ~(public_key_id : int)
-      ~(balance : Currency.Balance.t) ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no ~nonce =
+      ~(balance : Currency.Balance.t) ~block_id ~block_height ~block_sequence_no
+      ~block_secondary_sequence_no ~nonce =
     Conn.find
       (Caqti_request.find
-         Caqti_type.(tup2 (tup2 int int64) (tup4 int int64 (tup2 int int) (option int64)))
+         Caqti_type.(
+           tup2 (tup2 int int64) (tup4 int int64 (tup2 int int) (option int64)))
          Caqti_type.int
          {sql| INSERT INTO balances (public_key_id, balance,
                                      block_id, block_height, block_sequence_no, block_secondary_sequence_no, nonce)
                VALUES (?, ?, ?, ?, ?, ?, ?)
                RETURNING id |sql})
-      ((public_key_id, balance_to_int64 balance),
-       (block_id, block_height, (block_sequence_no, block_secondary_sequence_no), nonce))
+      ( (public_key_id, balance_to_int64 balance)
+      , ( block_id
+        , block_height
+        , (block_sequence_no, block_secondary_sequence_no)
+        , nonce ) )
 
   let add_if_doesn't_exist (module Conn : CONNECTION) ~(public_key_id : int)
-      ~(balance : Currency.Balance.t) ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no ~nonce =
+      ~(balance : Currency.Balance.t) ~block_id ~block_height ~block_sequence_no
+      ~block_secondary_sequence_no ~nonce =
     let open Deferred.Result.Let_syntax in
-    match%bind find (module Conn) ~public_key_id ~balance  ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no with
+    match%bind
+      find
+        (module Conn)
+        ~public_key_id ~balance ~block_id ~block_height ~block_sequence_no
+        ~block_secondary_sequence_no
+    with
     | Some balance_id ->
         return balance_id
     | None ->
-        add (module Conn) ~public_key_id ~balance ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no ~nonce
+        add
+          (module Conn)
+          ~public_key_id ~balance ~block_id ~block_height ~block_sequence_no
+          ~block_secondary_sequence_no ~nonce
 end
 
 module Block_and_internal_command = struct
   type t =
-    { block_id: int
-    ; internal_command_id: int
-    ; sequence_no: int
-    ; secondary_sequence_no: int
-    ; receiver_account_creation_fee_paid: int64 option
-    ; receiver_balance_id: int }
+    { block_id : int
+    ; internal_command_id : int
+    ; sequence_no : int
+    ; secondary_sequence_no : int
+    ; receiver_account_creation_fee_paid : int64 option
+    ; receiver_balance_id : int
+    }
   [@@deriving hlist]
 
   let typ =
     let open Caqti_type_spec in
-    let spec = Caqti_type.[int; int; int; int; option int64; int] in
+    let spec = Caqti_type.[ int; int; int; int; option int64; int ] in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
     Caqti_type.custom ~encode ~decode (to_rep spec)
 
-  let add (module Conn : CONNECTION) ~block_id ~internal_command_id
-      ~sequence_no ~secondary_sequence_no ~receiver_account_creation_fee_paid
+  let add (module Conn : CONNECTION) ~block_id ~internal_command_id ~sequence_no
+      ~secondary_sequence_no ~receiver_account_creation_fee_paid
       ~receiver_balance_id =
     Conn.exec
       (Caqti_request.exec typ
@@ -911,7 +964,8 @@ module Block_and_internal_command = struct
       ; sequence_no
       ; secondary_sequence_no
       ; receiver_account_creation_fee_paid
-      ; receiver_balance_id }
+      ; receiver_balance_id
+      }
 
   let find (module Conn : CONNECTION) ~block_id ~internal_command_id
       ~sequence_no ~secondary_sequence_no =
@@ -947,17 +1001,18 @@ end
 
 module Block_and_signed_command = struct
   type t =
-    { block_id: int
-    ; user_command_id: int
-    ; sequence_no: int
-    ; status: string
-    ; failure_reason: string option
-    ; fee_payer_account_creation_fee_paid: int64 option
-    ; receiver_account_creation_fee_paid: int64 option
-    ; created_token: int64 option
-    ; fee_payer_balance_id: int
-    ; source_balance_id: int option
-    ; receiver_balance_id: int option }
+    { block_id : int
+    ; user_command_id : int
+    ; sequence_no : int
+    ; status : string
+    ; failure_reason : string option
+    ; fee_payer_account_creation_fee_paid : int64 option
+    ; receiver_account_creation_fee_paid : int64 option
+    ; created_token : int64 option
+    ; fee_payer_balance_id : int
+    ; source_balance_id : int option
+    ; receiver_balance_id : int option
+    }
   [@@deriving hlist]
 
   let typ =
@@ -974,7 +1029,8 @@ module Block_and_signed_command = struct
         ; option int64
         ; int
         ; option int
-        ; option int ]
+        ; option int
+        ]
     in
     let encode t = Ok (hlist_to_tuple spec (to_hlist t)) in
     let decode t = Ok (of_hlist (tuple_to_hlist spec t)) in
@@ -998,7 +1054,7 @@ module Block_and_signed_command = struct
     in
     let created_token =
       Option.map created_token ~f:(fun tid ->
-          Unsigned.UInt64.to_int64 (Token_id.to_uint64 tid) )
+          Unsigned.UInt64.to_int64 (Token_id.to_uint64 tid))
     in
     Conn.exec
       (Caqti_request.exec typ
@@ -1026,11 +1082,12 @@ module Block_and_signed_command = struct
       ; created_token
       ; fee_payer_balance_id
       ; source_balance_id
-      ; receiver_balance_id }
+      ; receiver_balance_id
+      }
 
-  let add_with_status (module Conn : CONNECTION) ~block_id ~block_height ~user_command_id
-      ~sequence_no ~(status : Transaction_status.t) ~fee_payer_id ~source_id
-      ~receiver_id ~nonce_map =
+  let add_with_status (module Conn : CONNECTION) ~block_id ~block_height
+      ~user_command_id ~sequence_no ~(status : Transaction_status.t)
+      ~fee_payer_id ~source_id ~receiver_id ~nonce_map =
     let open Deferred.Result.Let_syntax in
     let ( status_str
         , failure_reason
@@ -1039,12 +1096,14 @@ module Block_and_signed_command = struct
         , created_token
         , { Transaction_status.Balance_data.fee_payer_balance
           ; source_balance
-          ; receiver_balance } ) =
+          ; receiver_balance
+          } ) =
       match status with
       | Applied
           ( { fee_payer_account_creation_fee_paid
             ; receiver_account_creation_fee_paid
-            ; created_token }
+            ; created_token
+            }
           , balances ) ->
           ( "applied"
           , None
@@ -1057,16 +1116,18 @@ module Block_and_signed_command = struct
     in
     let pk_of_id id =
       let%map pk_str = Public_key.find_by_id (module Conn) id in
-      Signature_lib.Public_key.Compressed.of_base58_check pk_str |>
-      Or_error.ok_exn
+      Signature_lib.Public_key.Compressed.of_base58_check pk_str
+      |> Or_error.ok_exn
       (* Note: This is safe because the database will already have the
-       * correctly formatted public key by this point.  *)
+       * correctly formatted public key by this point. *)
     in
     let nonce_int64_of_pk pk =
-      Signature_lib.Public_key.Compressed.Map.find nonce_map pk |>
-      Option.map ~f:(fun nonce -> Account.Nonce.to_uint32 nonce |> Unsigned.UInt32.to_int64)
+      Signature_lib.Public_key.Compressed.Map.find nonce_map pk
+      |> Option.map ~f:(fun nonce ->
+             Account.Nonce.to_uint32 nonce |> Unsigned.UInt32.to_int64)
     in
-    let add_optional_balance id balance ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no ~nonce =
+    let add_optional_balance id balance ~block_id ~block_height
+        ~block_sequence_no ~block_secondary_sequence_no ~nonce =
       match balance with
       | None ->
           Deferred.Result.return None
@@ -1074,8 +1135,8 @@ module Block_and_signed_command = struct
           let%map balance_id =
             Balance.add_if_doesn't_exist
               (module Conn)
-              ~public_key_id:id ~balance
-              ~block_id ~block_height ~block_sequence_no ~block_secondary_sequence_no ~nonce
+              ~public_key_id:id ~balance ~block_id ~block_height
+              ~block_sequence_no ~block_secondary_sequence_no ~nonce
           in
           Some balance_id
     in
@@ -1087,33 +1148,31 @@ module Block_and_signed_command = struct
       let nonce = nonce_int64_of_pk fee_payer_pk in
       Balance.add_if_doesn't_exist
         (module Conn)
-        ~public_key_id:fee_payer_id ~balance:fee_payer_balance
-        ~block_id ~block_height ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0
-        ~nonce
+        ~public_key_id:fee_payer_id ~balance:fee_payer_balance ~block_id
+        ~block_height ~block_sequence_no:sequence_no
+        ~block_secondary_sequence_no:0 ~nonce
     in
     let%bind source_balance_id =
-    let%bind source_pk = pk_of_id source_id in
+      let%bind source_pk = pk_of_id source_id in
       let nonce = nonce_int64_of_pk source_pk in
-      add_optional_balance source_id source_balance
-        ~block_id ~block_height ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0
-        ~nonce
+      add_optional_balance source_id source_balance ~block_id ~block_height
+        ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0 ~nonce
     in
     let%bind receiver_balance_id =
-      let%bind receiver_pk =pk_of_id receiver_id in
+      let%bind receiver_pk = pk_of_id receiver_id in
       let nonce = nonce_int64_of_pk receiver_pk in
-      add_optional_balance receiver_id receiver_balance
-        ~block_id ~block_height ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0
-        ~nonce
+      add_optional_balance receiver_id receiver_balance ~block_id ~block_height
+        ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0 ~nonce
     in
     add
       (module Conn)
-      ~block_id ~user_command_id ~sequence_no ~status:status_str
-      ~failure_reason ~fee_payer_account_creation_fee_paid
-      ~receiver_account_creation_fee_paid ~created_token ~fee_payer_balance_id
-      ~source_balance_id ~receiver_balance_id
+      ~block_id ~user_command_id ~sequence_no ~status:status_str ~failure_reason
+      ~fee_payer_account_creation_fee_paid ~receiver_account_creation_fee_paid
+      ~created_token ~fee_payer_balance_id ~source_balance_id
+      ~receiver_balance_id
 
-  let add_if_doesn't_exist (module Conn : CONNECTION) ~block_id
-      ~user_command_id ~sequence_no ~(status : string) ~failure_reason
+  let add_if_doesn't_exist (module Conn : CONNECTION) ~block_id ~user_command_id
+      ~sequence_no ~(status : string) ~failure_reason
       ~fee_payer_account_creation_fee_paid ~receiver_account_creation_fee_paid
       ~created_token ~fee_payer_balance_id ~source_balance_id
       ~receiver_balance_id =
@@ -1163,20 +1222,20 @@ end
 
 module Block = struct
   type t =
-    { state_hash: string
-    ; parent_id: int option
-    ; parent_hash: string
-    ; creator_id: int
-    ; block_winner_id: int
-    ; snarked_ledger_hash_id: int
-    ; staking_epoch_data_id: int
-    ; next_epoch_data_id: int
-    ; ledger_hash: string
-    ; height: int64
-    ; global_slot_since_hard_fork: int64
-    ; global_slot_since_genesis: int64
-    ; timestamp: int64
-    ; chain_status: string
+    { state_hash : string
+    ; parent_id : int option
+    ; parent_hash : string
+    ; creator_id : int
+    ; block_winner_id : int
+    ; snarked_ledger_hash_id : int
+    ; staking_epoch_data_id : int
+    ; next_epoch_data_id : int
+    ; ledger_hash : string
+    ; height : int64
+    ; global_slot_since_hard_fork : int64
+    ; global_slot_since_genesis : int64
+    ; timestamp : int64
+    ; chain_status : string
     }
   [@@deriving hlist]
 
@@ -1267,8 +1326,7 @@ module Block = struct
             (Consensus.Data.Consensus_state.next_epoch_data consensus_state)
         in
         let height =
-          consensus_state
-          |> Consensus.Data.Consensus_state.blockchain_length
+          consensus_state |> Consensus.Data.Consensus_state.blockchain_length
           |> Unsigned.UInt32.to_int64
         in
         let transactions =
@@ -1289,7 +1347,10 @@ module Block = struct
         in
         (* grab all the nonces associated with every public key in all of these
          * transactions for blocks earlier than this one. *)
-        let%bind initial_nonce_map : (Account.Nonce.t Signature_lib.Public_key.Compressed.Map.t, _) Deferred.Result.t =
+        let%bind initial_nonce_map :
+            ( Account.Nonce.t Signature_lib.Public_key.Compressed.Map.t
+            , _ )
+            Deferred.Result.t =
           let public_keys =
             transactions
             |> List.map ~f:(fun x -> Transaction.public_keys x.data)
@@ -1297,8 +1358,13 @@ module Block = struct
           in
           (* if this block is disconnected and doesn't have a parent, the nonce map will need to start empty *)
           match parent_id with
-          | None -> Deferred.Result.return Signature_lib.Public_key.Compressed.Map.empty
-          | Some parent_id -> Find_nonce.initialize_nonce_map (module Conn) ~public_keys ~parent_id
+          | None ->
+              Deferred.Result.return
+                Signature_lib.Public_key.Compressed.Map.empty
+          | Some parent_id ->
+              Find_nonce.initialize_nonce_map
+                (module Conn)
+                ~public_keys ~parent_id
         in
         let%bind block_id =
           Conn.find
@@ -1311,9 +1377,9 @@ module Block = struct
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::chain_status_type)
                      RETURNING id
                |sql})
-            { state_hash= hash |> State_hash.to_base58_check
+            { state_hash = hash |> State_hash.to_base58_check
             ; parent_id
-            ; parent_hash=
+            ; parent_hash =
                 Protocol_state.previous_state_hash protocol_state
                 |> State_hash.to_base58_check
             ; creator_id
@@ -1321,26 +1387,27 @@ module Block = struct
             ; snarked_ledger_hash_id
             ; staking_epoch_data_id
             ; next_epoch_data_id
-            ; ledger_hash=
+            ; ledger_hash =
                 Protocol_state.blockchain_state protocol_state
                 |> Blockchain_state.staged_ledger_hash
                 |> Staged_ledger_hash.ledger_hash |> Ledger_hash.to_base58_check
             ; height
-            ; global_slot_since_hard_fork=
+            ; global_slot_since_hard_fork =
                 Consensus.Data.Consensus_state.curr_global_slot consensus_state
                 |> Unsigned.UInt32.to_int64
-            ; global_slot_since_genesis=
+            ; global_slot_since_genesis =
                 consensus_state
                 |> Consensus.Data.Consensus_state.global_slot_since_genesis
                 |> Unsigned.UInt32.to_int64
-            ; timestamp=
+            ; timestamp =
                 Protocol_state.blockchain_state protocol_state
                 |> Blockchain_state.timestamp |> Block_time.to_int64
-            (* we don't yet know the chain status for a block we're adding *)
-            ; chain_status=Chain_status.(to_string Pending)
+                (* we don't yet know the chain status for a block we're adding *)
+            ; chain_status = Chain_status.(to_string Pending)
             }
         in
-        let account_creation_fee_of_fees_and_balance ?additional_fee fee balance =
+        let account_creation_fee_of_fees_and_balance ?additional_fee fee balance
+            =
           (* TODO: add transaction statuses to internal commands
              the archive lib should not know the details of
              account creation fees; the calculation below is
@@ -1348,8 +1415,8 @@ module Block = struct
           *)
           let fee_uint64 = Currency.Fee.to_uint64 fee in
           let balance_uint64 = Currency.Balance.to_uint64 balance in
-          let account_creation_fee_uint64 = Currency.Fee.to_uint64
-              constraint_constants.account_creation_fee
+          let account_creation_fee_uint64 =
+            Currency.Fee.to_uint64 constraint_constants.account_creation_fee
           in
           (* for coinbases, an associated fee transfer may reduce
              the amount given to the coinbase receiver beyond
@@ -1357,45 +1424,56 @@ module Block = struct
           *)
           let creation_deduction_uint64 =
             match additional_fee with
-            | None -> account_creation_fee_uint64
-            | Some fee' ->
-              Unsigned.UInt64.add (Currency.Fee.to_uint64 fee')
+            | None ->
                 account_creation_fee_uint64
+            | Some fee' ->
+                Unsigned.UInt64.add
+                  (Currency.Fee.to_uint64 fee')
+                  account_creation_fee_uint64
           in
           (* first compare guards against underflow in subtraction *)
-          if Unsigned.UInt64.compare fee_uint64 creation_deduction_uint64 >= 0 &&
-             Unsigned.UInt64.equal balance_uint64
-               (Unsigned.UInt64.sub fee_uint64 creation_deduction_uint64) then
-            Some (Unsigned.UInt64.to_int64 account_creation_fee_uint64)
-          else
-            None
+          if
+            Unsigned.UInt64.compare fee_uint64 creation_deduction_uint64 >= 0
+            && Unsigned.UInt64.equal balance_uint64
+                 (Unsigned.UInt64.sub fee_uint64 creation_deduction_uint64)
+          then Some (Unsigned.UInt64.to_int64 account_creation_fee_uint64)
+          else None
         in
         let nonce_int64_of_pk nonce_map pk =
-          Signature_lib.Public_key.Compressed.Map.find nonce_map pk |>
-          Option.map ~f:(fun nonce -> Account.Nonce.to_uint32 nonce |> Unsigned.UInt32.to_int64)
+          Signature_lib.Public_key.Compressed.Map.find nonce_map pk
+          |> Option.map ~f:(fun nonce ->
+                 Account.Nonce.to_uint32 nonce |> Unsigned.UInt32.to_int64)
         in
-        let%bind (_ : int * Account.Nonce.t Signature_lib.Public_key.Compressed.Map.t) =
-          deferred_result_list_fold transactions ~init:(0, initial_nonce_map) ~f:(fun (sequence_no, nonce_map) ->
-            function
+        let%bind (_
+                   : int
+                     * Account.Nonce.t Signature_lib.Public_key.Compressed.Map.t)
+            =
+          deferred_result_list_fold transactions ~init:(0, initial_nonce_map)
+            ~f:(fun (sequence_no, nonce_map) -> function
             | { Mina_base.With_status.status
-              ; data= Mina_base.Transaction.Command command } ->
+              ; data = Mina_base.Transaction.Command command
+              } ->
                 let user_command =
-                  {Mina_base.With_status.status; data= command}
+                  { Mina_base.With_status.status; data = command }
                 in
                 (* This is the only place we adjust the nonce_map -- we want to modify the public key associated with the fee_payer for this user-command to increment its nonce.
-                 Note: Intentionally shadowing `nonce_map` here as we want to pass the updated map. *)
+                   Note: Intentionally shadowing `nonce_map` here as we want to pass the updated map. *)
                 let nonce_map =
                   Signature_lib.Public_key.Compressed.Map.change
                     initial_nonce_map
-                    (Mina_base.User_command.fee_payer command |> Account_id.public_key)
-                    ~f:(fun _ -> Some (Mina_base.User_command.nonce_exn command |> Unsigned.UInt32.succ))
+                    ( Mina_base.User_command.fee_payer command
+                    |> Account_id.public_key )
+                    ~f:(fun _ ->
+                      Some
+                        ( Mina_base.User_command.nonce_exn command
+                        |> Unsigned.UInt32.succ ))
                 in
                 let%bind id =
                   User_command.add_if_doesn't_exist
                     (module Conn)
                     user_command.data
                 in
-                let%bind {fee_payer_id; source_id; receiver_id} =
+                let%bind { fee_payer_id; source_id; receiver_id } =
                   User_command.Signed_command
                   .add_balance_public_keys_if_don't_exist
                     (module Conn)
@@ -1404,12 +1482,12 @@ module Block = struct
                 let%map () =
                   Block_and_signed_command.add_with_status
                     (module Conn)
-                      ~block_id ~block_height:height ~user_command_id:id ~sequence_no
-                    ~status:user_command.status ~fee_payer_id ~source_id
-                    ~receiver_id ~nonce_map
+                    ~block_id ~block_height:height ~user_command_id:id
+                    ~sequence_no ~status:user_command.status ~fee_payer_id
+                    ~source_id ~receiver_id ~nonce_map
                 in
                 (sequence_no + 1, nonce_map)
-            | {data= Fee_transfer fee_transfer_bundled; status} ->
+            | { data = Fee_transfer fee_transfer_bundled; status } ->
                 let balances =
                   Transaction_status.Fee_transfer_balance_data
                   .of_balance_data_exn
@@ -1430,17 +1508,21 @@ module Block = struct
                           (module Conn)
                           fee_transfer `Normal
                       in
-                      (id, secondary_sequence_no, fee_transfer.fee, fee_transfer.receiver_pk)
-                      :: acc )
+                      ( id
+                      , secondary_sequence_no
+                      , fee_transfer.fee
+                      , fee_transfer.receiver_pk )
+                      :: acc)
                 in
                 let fee_transfer_infos_with_balances =
                   match fee_transfer_infos with
-                  | [id] ->
-                      [(id, balances.receiver1_balance)]
-                  | [id2; id1] ->
+                  | [ id ] ->
+                      [ (id, balances.receiver1_balance) ]
+                  | [ id2; id1 ] ->
                       (* the fold reverses the order of the infos from the fee transfers *)
                       [ (id1, balances.receiver1_balance)
-                      ; (id2, Option.value_exn balances.receiver2_balance) ]
+                      ; (id2, Option.value_exn balances.receiver2_balance)
+                      ]
                   | _ ->
                       failwith
                         "Unexpected number of single fee transfers in a fee \
@@ -1449,9 +1531,13 @@ module Block = struct
                 let%map () =
                   deferred_result_list_fold fee_transfer_infos_with_balances
                     ~init:()
-                    ~f:(fun ()
-                       ( (fee_transfer_id, secondary_sequence_no, fee, receiver_pk)
-                       , balance )
+                    ~f:(fun
+                         ()
+                         ( ( fee_transfer_id
+                           , secondary_sequence_no
+                           , fee
+                           , receiver_pk )
+                         , balance )
                        ->
                       let%bind receiver_id =
                         Public_key.add_if_doesn't_exist
@@ -1462,9 +1548,9 @@ module Block = struct
                       let%bind receiver_balance_id =
                         Balance.add_if_doesn't_exist
                           (module Conn)
-                          ~public_key_id:receiver_id ~balance
-                          ~block_id ~block_height:height
-                          ~block_sequence_no:sequence_no ~block_secondary_sequence_no:secondary_sequence_no
+                          ~public_key_id:receiver_id ~balance ~block_id
+                          ~block_height:height ~block_sequence_no:sequence_no
+                          ~block_secondary_sequence_no:secondary_sequence_no
                           ~nonce
                       in
                       let receiver_account_creation_fee_paid =
@@ -1474,12 +1560,11 @@ module Block = struct
                         (module Conn)
                         ~block_id ~internal_command_id:fee_transfer_id
                         ~sequence_no ~secondary_sequence_no
-                        ~receiver_account_creation_fee_paid
-                        ~receiver_balance_id
-                      >>| ignore )
+                        ~receiver_account_creation_fee_paid ~receiver_balance_id
+                      >>| ignore)
                 in
                 (sequence_no + 1, nonce_map)
-            | {data= Coinbase coinbase; status} ->
+            | { data = Coinbase coinbase; status } ->
                 let balances =
                   Transaction_status.Coinbase_balance_data.of_balance_data_exn
                     (Transaction_status.balance_data status)
@@ -1488,7 +1573,7 @@ module Block = struct
                   match Mina_base.Coinbase.fee_transfer coinbase with
                   | None ->
                       return None
-                  | Some {receiver_pk; fee} ->
+                  | Some { receiver_pk; fee } ->
                       let fee_transfer =
                         Mina_base.Fee_transfer.Single.create ~receiver_pk ~fee
                           ~fee_token:Token_id.default
@@ -1504,26 +1589,27 @@ module Block = struct
                           receiver_pk
                       in
                       let nonce = nonce_int64_of_pk nonce_map receiver_pk in
-                      let balance = Option.value_exn
-                          balances.fee_transfer_receiver_balance
+                      let balance =
+                        Option.value_exn balances.fee_transfer_receiver_balance
                       in
                       let%bind receiver_balance_id =
                         Balance.add_if_doesn't_exist
                           (module Conn)
-                          ~public_key_id:fee_transfer_receiver_id
-                          ~balance
-                          ~block_id ~block_height:height ~block_sequence_no:sequence_no ~block_secondary_sequence_no:0
-                          ~nonce
+                          ~public_key_id:fee_transfer_receiver_id ~balance
+                          ~block_id ~block_height:height
+                          ~block_sequence_no:sequence_no
+                          ~block_secondary_sequence_no:0 ~nonce
                       in
                       let receiver_account_creation_fee_paid =
                         account_creation_fee_of_fees_and_balance fee balance
                       in
-                      let%bind () = Block_and_internal_command.add
-                        (module Conn)
-                        ~block_id ~internal_command_id:id ~sequence_no
-                        ~secondary_sequence_no:0
-                        ~receiver_account_creation_fee_paid
-                        ~receiver_balance_id
+                      let%bind () =
+                        Block_and_internal_command.add
+                          (module Conn)
+                          ~block_id ~internal_command_id:id ~sequence_no
+                          ~secondary_sequence_no:0
+                          ~receiver_account_creation_fee_paid
+                          ~receiver_balance_id
                       in
                       return (Some fee)
                 in
@@ -1540,11 +1626,9 @@ module Block = struct
                   Balance.add_if_doesn't_exist
                     (module Conn)
                     ~public_key_id:coinbase_receiver_id
-                    ~balance:balances.coinbase_receiver_balance
-                    ~block_id ~block_height:height
-                    ~block_sequence_no:sequence_no
-                    ~block_secondary_sequence_no:0
-                    ~nonce
+                    ~balance:balances.coinbase_receiver_balance ~block_id
+                    ~block_height:height ~block_sequence_no:sequence_no
+                    ~block_secondary_sequence_no:0 ~nonce
                 in
                 let receiver_account_creation_fee_paid =
                   account_creation_fee_of_fees_and_balance ?additional_fee
@@ -1559,12 +1643,12 @@ module Block = struct
                     ~receiver_balance_id
                   >>| ignore
                 in
-                (sequence_no + 1, nonce_map) )
+                (sequence_no + 1, nonce_map))
         in
         return block_id
 
   let add_if_doesn't_exist conn ~constraint_constants
-      ({data= t; hash} : (External_transition.t, State_hash.t) With_hash.t) =
+      ({ data = t; hash } : (External_transition.t, State_hash.t) With_hash.t) =
     add_parts_if_doesn't_exist conn ~constraint_constants
       ~protocol_state:(External_transition.protocol_state t)
       ~staged_ledger_diff:(External_transition.staged_ledger_diff t)
@@ -1578,7 +1662,6 @@ module Block = struct
 
   let add_from_extensional (module Conn : CONNECTION)
       (block : Extensional.Block.t) =
-
     (* modelled on query in Rosetta.Lib.Account.query_pending
        except that all we need is the nonce, not the balance
 
@@ -1637,7 +1720,10 @@ module Block = struct
     in
     let run_nonce_query pk =
       let pk_str = Signature_lib.Public_key.Compressed.to_base58_check pk in
-      let%map last_nonce = Conn.find_opt nonce_query (pk_str,block.height |> Unsigned.UInt32.to_int64) in
+      let%map last_nonce =
+        Conn.find_opt nonce_query
+          (pk_str, block.height |> Unsigned.UInt32.to_int64)
+      in
       (* last nonce was in the last user_command for the public key, add 1 to get current nonce
          if no nonce found, leave as None (it could be 0, but could also be missing data)
       *)
@@ -1695,21 +1781,22 @@ module Block = struct
                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::chain_status_type)
                      RETURNING id
                |sql})
-            { state_hash= block.state_hash |> State_hash.to_base58_check
+            { state_hash = block.state_hash |> State_hash.to_base58_check
             ; parent_id
-            ; parent_hash= block.parent_hash |> State_hash.to_base58_check
+            ; parent_hash = block.parent_hash |> State_hash.to_base58_check
             ; creator_id
             ; block_winner_id
             ; snarked_ledger_hash_id
             ; staking_epoch_data_id
             ; next_epoch_data_id
-            ; ledger_hash= block.ledger_hash |> Ledger_hash.to_base58_check
-            ; height= block.height |> Unsigned.UInt32.to_int64
-            ; global_slot_since_hard_fork= block.global_slot_since_hard_fork |> Unsigned.UInt32.to_int64
-            ; global_slot_since_genesis=
+            ; ledger_hash = block.ledger_hash |> Ledger_hash.to_base58_check
+            ; height = block.height |> Unsigned.UInt32.to_int64
+            ; global_slot_since_hard_fork =
+                block.global_slot_since_hard_fork |> Unsigned.UInt32.to_int64
+            ; global_slot_since_genesis =
                 block.global_slot_since_genesis |> Unsigned.UInt32.to_int64
-            ; timestamp= block.timestamp |> Block_time.to_int64
-            ; chain_status= Chain_status.to_string block.chain_status
+            ; timestamp = block.timestamp |> Block_time.to_int64
+            ; chain_status = Chain_status.to_string block.chain_status
             }
     in
     (* add user commands *)
@@ -1722,46 +1809,56 @@ module Block = struct
                 (module Conn)
                 user_cmd
             in
-            cmd_id :: acc )
+            cmd_id :: acc)
       in
       List.zip_exn block.user_cmds (List.rev user_cmd_ids_rev)
     in
-    let balance_id_of_info pk balance ~block_sequence_no ~block_secondary_sequence_no ~nonce =
+    let balance_id_of_info pk balance ~block_sequence_no
+        ~block_secondary_sequence_no ~nonce =
       let%bind public_key_id =
         Public_key.add_if_doesn't_exist (module Conn) pk
       in
-      Balance.add_if_doesn't_exist (module Conn) ~public_key_id ~balance
-        ~block_id ~block_height:(block.height |> Unsigned.UInt32.to_int64) ~block_sequence_no
-        ~block_secondary_sequence_no ~nonce
+      Balance.add_if_doesn't_exist
+        (module Conn)
+        ~public_key_id ~balance ~block_id
+        ~block_height:(block.height |> Unsigned.UInt32.to_int64)
+        ~block_sequence_no ~block_secondary_sequence_no ~nonce
     in
-    let balance_id_of_info_balance_opt pk balance_opt ~block_sequence_no ~block_secondary_sequence_no ~nonce =
+    let balance_id_of_info_balance_opt pk balance_opt ~block_sequence_no
+        ~block_secondary_sequence_no ~nonce =
       Option.value_map balance_opt ~default:(Deferred.Result.return None)
         ~f:(fun balance ->
-            let%map id = balance_id_of_info pk balance
-                ~block_sequence_no ~block_secondary_sequence_no ~nonce
-            in
-            Some id )
+          let%map id =
+            balance_id_of_info pk balance ~block_sequence_no
+              ~block_secondary_sequence_no ~nonce
+          in
+          Some id)
     in
     (* add user commands to join table *)
     let%bind () =
       deferred_result_list_fold user_cmds_with_ids ~init:()
         ~f:(fun () (user_command, user_command_id) ->
-            let fee_payer_nonce = user_command.nonce |> Unsigned.UInt32.to_int64 in
-            let%bind fee_payer_balance_id =
+          let fee_payer_nonce =
+            user_command.nonce |> Unsigned.UInt32.to_int64
+          in
+          let%bind fee_payer_balance_id =
             balance_id_of_info user_command.fee_payer
               user_command.fee_payer_balance
-              ~block_sequence_no:user_command.sequence_no ~block_secondary_sequence_no:0 ~nonce:(Some fee_payer_nonce)
+              ~block_sequence_no:user_command.sequence_no
+              ~block_secondary_sequence_no:0 ~nonce:(Some fee_payer_nonce)
           in
           let%bind source_balance_id =
             balance_id_of_info_balance_opt user_command.source
               user_command.source_balance
-              ~block_sequence_no:user_command.sequence_no ~block_secondary_sequence_no:0 ~nonce:(Some fee_payer_nonce)
+              ~block_sequence_no:user_command.sequence_no
+              ~block_secondary_sequence_no:0 ~nonce:(Some fee_payer_nonce)
           in
           let%bind receiver_balance_id =
             let%bind nonce = run_nonce_query user_command.receiver in
             balance_id_of_info_balance_opt user_command.receiver
               user_command.receiver_balance
-              ~block_sequence_no:user_command.sequence_no ~block_secondary_sequence_no:0 ~nonce
+              ~block_sequence_no:user_command.sequence_no
+              ~block_secondary_sequence_no:0 ~nonce
           in
           Block_and_signed_command.add_if_doesn't_exist
             (module Conn)
@@ -1773,7 +1870,7 @@ module Block = struct
             ~receiver_account_creation_fee_paid:
               user_command.receiver_account_creation_fee_paid
             ~created_token:user_command.created_token ~fee_payer_balance_id
-            ~source_balance_id ~receiver_balance_id )
+            ~source_balance_id ~receiver_balance_id)
     in
     (* add internal commands *)
     let%bind internal_cmds_ids_and_seq_nos =
@@ -1785,37 +1882,39 @@ module Block = struct
                 (module Conn)
                 internal_cmd
             in
-            (internal_cmd, cmd_id) :: acc )
+            (internal_cmd, cmd_id) :: acc)
       in
       let sequence_nos =
         List.map block.internal_cmds ~f:(fun internal_cmd ->
-            (internal_cmd.sequence_no, internal_cmd.secondary_sequence_no) )
+            (internal_cmd.sequence_no, internal_cmd.secondary_sequence_no))
       in
       List.zip_exn (List.rev internal_cmds_and_ids_rev) sequence_nos
     in
     (* add internal commands to join table *)
     let%bind () =
       deferred_result_list_fold internal_cmds_ids_and_seq_nos ~init:()
-        ~f:(fun ()
-           ( (internal_command, internal_command_id)
-           , (sequence_no, secondary_sequence_no) )
+        ~f:(fun
+             ()
+             ( (internal_command, internal_command_id)
+             , (sequence_no, secondary_sequence_no) )
            ->
           let%bind receiver_balance_id =
             let%bind nonce = run_nonce_query internal_command.receiver in
             balance_id_of_info internal_command.receiver
               internal_command.receiver_balance
-              ~block_sequence_no:internal_command.sequence_no ~block_secondary_sequence_no:internal_command.secondary_sequence_no ~nonce
+              ~block_sequence_no:internal_command.sequence_no
+              ~block_secondary_sequence_no:
+                internal_command.secondary_sequence_no ~nonce
           in
-          let receiver_account_creation_fee_paid = internal_command.receiver_account_creation_fee_paid
-                                                   |> Option.map ~f:(fun amount ->
-                                                       Currency.Amount.to_uint64 amount |>
-                                                       Unsigned.UInt64.to_int64)
+          let receiver_account_creation_fee_paid =
+            internal_command.receiver_account_creation_fee_paid
+            |> Option.map ~f:(fun amount ->
+                   Currency.Amount.to_uint64 amount |> Unsigned.UInt64.to_int64)
           in
           Block_and_internal_command.add_if_doesn't_exist
             (module Conn)
             ~block_id ~internal_command_id ~sequence_no ~secondary_sequence_no
-            ~receiver_account_creation_fee_paid
-            ~receiver_balance_id )
+            ~receiver_account_creation_fee_paid ~receiver_balance_id)
     in
     return block_id
 
@@ -1832,8 +1931,10 @@ module Block = struct
 
   let get_subchain (module Conn : CONNECTION) ~start_block_id ~end_block_id =
     Conn.collect_list
-      (Caqti_request.collect Caqti_type.(tup2 int int) typ
-      {sql| WITH RECURSIVE chain AS (
+      (Caqti_request.collect
+         Caqti_type.(tup2 int int)
+         typ
+         {sql| WITH RECURSIVE chain AS (
               SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
                      next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp, chain_status
               FROM blocks b WHERE b.id = $1
@@ -1854,23 +1955,29 @@ module Block = struct
                   next_epoch_data_id,ledger_hash,height,global_slot,global_slot_since_genesis,timestamp,chain_status
            FROM chain ORDER BY height ASC
       |sql})
-      (end_block_id,start_block_id)
+      (end_block_id, start_block_id)
 
   let get_highest_canonical_block_opt (module Conn : CONNECTION) =
     Conn.find_opt
-      (Caqti_request.find_opt Caqti_type.unit Caqti_type.(tup2 int int64)
-         "SELECT id,height FROM blocks WHERE chain_status='canonical' ORDER BY height DESC LIMIT 1")
+      (Caqti_request.find_opt Caqti_type.unit
+         Caqti_type.(tup2 int int64)
+         "SELECT id,height FROM blocks WHERE chain_status='canonical' ORDER BY \
+          height DESC LIMIT 1")
 
   let get_nearest_canonical_block_above (module Conn : CONNECTION) height =
     Conn.find
-      (Caqti_request.find Caqti_type.int64 Caqti_type.(tup2 int int64)
-         "SELECT id,height FROM blocks WHERE chain_status='canonical' AND height > ? ORDER BY height ASC LIMIT 1")
+      (Caqti_request.find Caqti_type.int64
+         Caqti_type.(tup2 int int64)
+         "SELECT id,height FROM blocks WHERE chain_status='canonical' AND \
+          height > ? ORDER BY height ASC LIMIT 1")
       height
 
   let get_nearest_canonical_block_below (module Conn : CONNECTION) height =
     Conn.find
-      (Caqti_request.find Caqti_type.int64 Caqti_type.(tup2 int int64)
-         "SELECT id,height FROM blocks WHERE chain_status='canonical' AND height < ? ORDER BY height DESC LIMIT 1")
+      (Caqti_request.find Caqti_type.int64
+         Caqti_type.(tup2 int int64)
+         "SELECT id,height FROM blocks WHERE chain_status='canonical' AND \
+          height < ? ORDER BY height DESC LIMIT 1")
       height
 
   let mark_as_canonical (module Conn : CONNECTION) ~state_hash =
@@ -1881,48 +1988,77 @@ module Block = struct
 
   let mark_as_orphaned (module Conn : CONNECTION) ~state_hash ~height =
     Conn.exec
-      (Caqti_request.exec Caqti_type.(tup2 string int64)
+      (Caqti_request.exec
+         Caqti_type.(tup2 string int64)
          {sql| UPDATE blocks SET chain_status='orphaned'
                WHERE height = $2
                AND state_hash <> $1
          |sql})
-      (state_hash,height)
+      (state_hash, height)
 
   (* update chain_status for blocks now known to be canonical or orphaned *)
   let update_chain_status (module Conn : CONNECTION) ~block_id =
     let open Deferred.Result.Let_syntax in
     match%bind get_highest_canonical_block_opt (module Conn) () with
     | None ->
-      (* unit tests, no canonical block, can't mark any block as canonical *)
-      Deferred.Result.return ()
-    | Some (highest_canonical_block_id,greatest_canonical_height) ->
-      let k_int64 = Genesis_constants.k |> Int64.of_int in
-      let%bind block = load (module Conn) ~id:block_id in
-      if Int64.(>) block.height (Int64.(+) greatest_canonical_height k_int64) then
-        (* a new block, allows marking some pending blocks as canonical *)
-        let%bind subchain_blocks = get_subchain (module Conn) ~start_block_id:highest_canonical_block_id ~end_block_id:block_id in
-        let block_height_less_k_int64 = Int64.(-) block.height k_int64 in
-        (* mark canonical, orphaned blocks in subchain at least k behind the new block *)
-        let canonical_blocks = List.filter subchain_blocks ~f:(fun subchain_block ->
-            Int64.(<=) subchain_block.height block_height_less_k_int64) in
-        deferred_result_list_fold canonical_blocks ~init:() ~f:(fun () block ->
-            let%bind () = mark_as_canonical (module Conn) ~state_hash:block.state_hash in
-            mark_as_orphaned (module Conn) ~state_hash:block.state_hash ~height:block.height)
-      else if Int64.(<) block.height greatest_canonical_height then
-        (* a missing block added in the middle of canonical chain *)
-        let%bind canonical_block_above_id,_above_height = get_nearest_canonical_block_above (module Conn) block.height in
-        let%bind canonical_block_below_id,_below_height = get_nearest_canonical_block_below (module Conn) block.height in
-        (* we can always find this chain: the genesis block should be marked as canonical, and we've found a
-           canonical block above this one *)
-        let%bind canonical_blocks = get_subchain (module Conn) ~start_block_id:canonical_block_below_id ~end_block_id:canonical_block_above_id in
-        deferred_result_list_fold canonical_blocks ~init:() ~f:(fun () block ->
-            let%bind () = mark_as_canonical (module Conn) ~state_hash:block.state_hash in
-            mark_as_orphaned (module Conn) ~state_hash:block.state_hash ~height:block.height)
-      else
-        (* a block at or above highest canonical block, not high enough to mark any blocks as canonical *)
+        (* unit tests, no canonical block, can't mark any block as canonical *)
         Deferred.Result.return ()
+    | Some (highest_canonical_block_id, greatest_canonical_height) ->
+        let k_int64 = Genesis_constants.k |> Int64.of_int in
+        let%bind block = load (module Conn) ~id:block_id in
+        if
+          Int64.( > ) block.height
+            (Int64.( + ) greatest_canonical_height k_int64)
+        then
+          (* a new block, allows marking some pending blocks as canonical *)
+          let%bind subchain_blocks =
+            get_subchain
+              (module Conn)
+              ~start_block_id:highest_canonical_block_id ~end_block_id:block_id
+          in
+          let block_height_less_k_int64 = Int64.( - ) block.height k_int64 in
+          (* mark canonical, orphaned blocks in subchain at least k behind the new block *)
+          let canonical_blocks =
+            List.filter subchain_blocks ~f:(fun subchain_block ->
+                Int64.( <= ) subchain_block.height block_height_less_k_int64)
+          in
+          deferred_result_list_fold canonical_blocks ~init:()
+            ~f:(fun () block ->
+              let%bind () =
+                mark_as_canonical (module Conn) ~state_hash:block.state_hash
+              in
+              mark_as_orphaned
+                (module Conn)
+                ~state_hash:block.state_hash ~height:block.height)
+        else if Int64.( < ) block.height greatest_canonical_height then
+          (* a missing block added in the middle of canonical chain *)
+          let%bind canonical_block_above_id, _above_height =
+            get_nearest_canonical_block_above (module Conn) block.height
+          in
+          let%bind canonical_block_below_id, _below_height =
+            get_nearest_canonical_block_below (module Conn) block.height
+          in
+          (* we can always find this chain: the genesis block should be marked as canonical, and we've found a
+             canonical block above this one *)
+          let%bind canonical_blocks =
+            get_subchain
+              (module Conn)
+              ~start_block_id:canonical_block_below_id
+              ~end_block_id:canonical_block_above_id
+          in
+          deferred_result_list_fold canonical_blocks ~init:()
+            ~f:(fun () block ->
+              let%bind () =
+                mark_as_canonical (module Conn) ~state_hash:block.state_hash
+              in
+              mark_as_orphaned
+                (module Conn)
+                ~state_hash:block.state_hash ~height:block.height)
+        else
+          (* a block at or above highest canonical block, not high enough to mark any blocks as canonical *)
+          Deferred.Result.return ()
 
-   let delete_if_older_than ?height ?num_blocks ?timestamp
+  let delete_if_older_than ?height ?num_blocks ?timestamp
       (module Conn : CONNECTION) =
     let open Deferred.Result.Let_syntax in
     let%bind height =
@@ -1962,8 +2098,8 @@ module Block = struct
         Conn.exec
           (Caqti_request.exec
              Caqti_type.(tup2 int int64)
-             "DELETE FROM blocks WHERE blocks.height < ? OR blocks.timestamp \
-              < ?")
+             "DELETE FROM blocks WHERE blocks.height < ? OR blocks.timestamp < \
+              ?")
           (height, timestamp)
       in
       let%bind () =
@@ -2009,7 +2145,7 @@ let retry ~f ~logger ~error_str retries =
         if retry_count <= 0 then return (Error e)
         else (
           [%log warn] "Error in %s : $error. Retrying..." error_str
-            ~metadata:[("error", `String (Caqti_error.show e))] ;
+            ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
           let wait_for = Random.float_range 20. 2000. in
           let%bind () = after (Time.Span.of_ms wait_for) in
           go (retry_count - 1) )
@@ -2023,12 +2159,12 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
   let add () =
     Caqti_async.Pool.use
       (fun (module Conn : CONNECTION) ->
-         let%bind res =
+        let%bind res =
           let open Deferred.Result.Let_syntax in
           let%bind () = Conn.start () in
           [%log info] "Attempting to add block data for $state_hash"
             ~metadata:
-              [("state_hash", Mina_base.State_hash.to_yojson (hash block))];
+              [ ("state_hash", Mina_base.State_hash.to_yojson (hash block)) ] ;
           let%bind block_id = add_block (module Conn : CONNECTION) block in
           (* if an existing block has a parent hash that's for the block just added,
              set its parent id
@@ -2039,10 +2175,7 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
               ~parent_hash:(hash block) ~parent_id:block_id
           in
           (* update chain status for existing blocks *)
-          let%bind () =
-            Block.update_chain_status (module Conn)
-              ~block_id
-          in
+          let%bind () = Block.update_chain_status (module Conn) ~block_id in
           match delete_older_than with
           | Some num_blocks ->
               Block.delete_if_older_than ~num_blocks (module Conn)
@@ -2055,7 +2188,7 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
             [%log warn]
               "Error when adding block data to the database, rolling it back: \
                $error"
-              ~metadata:[("error", `String (Caqti_error.show e))] ;
+              ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
             let%map _ = Conn.rollback () in
             err
         | Ok _ ->
@@ -2070,8 +2203,9 @@ let add_block_aux ?(retries = 3) ~logger ~add_block ~hash ~delete_older_than
 let add_block_aux_precomputed ~constraint_constants =
   add_block_aux ~add_block:(Block.add_from_precomputed ~constraint_constants)
     ~hash:(fun block ->
-      (block.External_transition.Precomputed_block.protocol_state
-      |> Protocol_state.hashes).state_hash )
+      ( block.External_transition.Precomputed_block.protocol_state
+      |> Protocol_state.hashes )
+        .state_hash)
 
 let add_block_aux_extensional =
   add_block_aux ~add_block:Block.add_from_extensional
@@ -2079,23 +2213,25 @@ let add_block_aux_extensional =
 
 let run pool reader ~constraint_constants ~logger ~delete_older_than =
   Strict_pipe.Reader.iter reader ~f:(function
-    | Diff.Transition_frontier (Breadcrumb_added {block; _}) -> (
+    | Diff.Transition_frontier (Breadcrumb_added { block; _ }) -> (
         let add_block = Block.add_if_doesn't_exist ~constraint_constants in
         let hash block = With_hash.hash block in
         match%map
-          add_block_aux ~logger ~delete_older_than ~hash ~add_block pool (With_hash.map ~f:External_transition.decompose block)
+          add_block_aux ~logger ~delete_older_than ~hash ~add_block pool
+            (With_hash.map ~f:External_transition.decompose block)
         with
         | Error e ->
             [%log warn]
               ~metadata:
                 [ ("block", With_hash.hash block |> State_hash.to_yojson)
-                ; ("error", `String (Caqti_error.show e)) ]
+                ; ("error", `String (Caqti_error.show e))
+                ]
               "Failed to archive block: $block, see $error"
         | Ok () ->
             () )
     | Transition_frontier _ ->
         Deferred.return ()
-    | Transaction_pool {added; removed= _} ->
+    | Transaction_pool { added; removed = _ } ->
         let%map _ =
           Caqti_async.Pool.use
             (fun (module Conn : CONNECTION) ->
@@ -2111,17 +2247,18 @@ let run pool reader ~constraint_constants ~logger ~delete_older_than =
                           ~metadata:
                             [ ("error", `String (Caqti_error.show e))
                             ; ( "command"
-                              , Mina_base.User_command.to_yojson command ) ]
+                              , Mina_base.User_command.to_yojson command )
+                            ]
                           "Failed to archive user command $command from \
-                           transaction pool: $block, see $error" )
+                           transaction pool: $block, see $error")
               in
-              Ok () )
+              Ok ())
             pool
         in
-        () )
+        ())
 
-let add_genesis_accounts ~logger
-    ~(runtime_config_opt : Runtime_config.t option) pool =
+let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
+    pool =
   match runtime_config_opt with
   | None ->
       Deferred.unit
@@ -2131,17 +2268,17 @@ let add_genesis_accounts ~logger
         | Some (Accounts accounts) ->
             Genesis_ledger_helper.Accounts.to_full accounts
         | Some (Named name) -> (
-          match Genesis_ledger.fetch_ledger name with
-          | Some (module M) ->
-              [%log info] "Found ledger with name $ledger_name"
-                ~metadata:[("ledger_name", `String name)] ;
-              Lazy.force M.accounts
-          | None ->
-              [%log error]
-                "Could not find a built-in ledger named $ledger_name"
-                ~metadata:[("ledger_name", `String name)] ;
-              failwith "Could not add genesis accounts: Named ledger not found"
-          )
+            match Genesis_ledger.fetch_ledger name with
+            | Some (module M) ->
+                [%log info] "Found ledger with name $ledger_name"
+                  ~metadata:[ ("ledger_name", `String name) ] ;
+                Lazy.force M.accounts
+            | None ->
+                [%log error]
+                  "Could not find a built-in ledger named $ledger_name"
+                  ~metadata:[ ("ledger_name", `String name) ] ;
+                failwith
+                  "Could not add genesis accounts: Named ledger not found" )
         | _ ->
             failwith "No accounts found in runtime config file"
       in
@@ -2163,7 +2300,8 @@ let add_genesis_accounts ~logger
                       [%log error]
                         ~metadata:
                           [ ("account", Account.to_yojson account)
-                          ; ("error", `String (Caqti_error.show e)) ]
+                          ; ("error", `String (Caqti_error.show e))
+                          ]
                         "Failed to add genesis account: $account, see $error" ;
                       let%map _ = Conn.rollback () in
                       err
@@ -2171,7 +2309,7 @@ let add_genesis_accounts ~logger
                       go accounts' )
             in
             let%bind () = go accounts in
-            Conn.commit () )
+            Conn.commit ())
           pool
       in
       match%map
@@ -2179,7 +2317,7 @@ let add_genesis_accounts ~logger
       with
       | Error e ->
           [%log warn] "genesis accounts could not be added"
-            ~metadata:[("error", `String (Caqti_error.show e))] ;
+            ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
           failwith "Failed to add genesis accounts"
       | Ok () ->
           () )
@@ -2224,21 +2362,20 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
   in
   let implementations =
     [ Async.Rpc.Rpc.implement Archive_rpc.t (fun () archive_diff ->
-          Strict_pipe.Writer.write writer archive_diff )
+          Strict_pipe.Writer.write writer archive_diff)
     ; Async.Rpc.Rpc.implement Archive_rpc.precomputed_block
         (fun () precomputed_block ->
-          Strict_pipe.Writer.write precomputed_block_writer precomputed_block
-      )
+          Strict_pipe.Writer.write precomputed_block_writer precomputed_block)
     ; Async.Rpc.Rpc.implement Archive_rpc.extensional_block
         (fun () extensional_block ->
-          Strict_pipe.Writer.write extensional_block_writer extensional_block
-      ) ]
+          Strict_pipe.Writer.write extensional_block_writer extensional_block)
+    ]
   in
   match Caqti_async.connect_pool ~max_size:30 postgres_address with
   | Error e ->
       [%log error]
         "Failed to create a Caqti pool for Postgresql, see error: $error"
-        ~metadata:[("error", `String (Caqti_error.show e))] ;
+        ~metadata:[ ("error", `String (Caqti_error.show e)) ] ;
       Deferred.unit
   | Ok pool ->
       let%bind () = add_genesis_accounts pool ~logger ~runtime_config_opt in
@@ -2255,11 +2392,12 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                 "Precomputed block $block could not be archived: $error"
                 ~metadata:
                   [ ( "block"
-                    , (Protocol_state.hashes precomputed_block.protocol_state).state_hash
-                      |> State_hash.to_yojson )
-                  ; ("error", `String (Caqti_error.show e)) ]
+                    , (Protocol_state.hashes precomputed_block.protocol_state)
+                        .state_hash |> State_hash.to_yojson )
+                  ; ("error", `String (Caqti_error.show e))
+                  ]
           | Ok () ->
-              () )
+              ())
       |> don't_wait_for ;
       Strict_pipe.Reader.iter extensional_block_reader
         ~f:(fun extensional_block ->
@@ -2273,9 +2411,10 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                 ~metadata:
                   [ ( "block"
                     , extensional_block.state_hash |> State_hash.to_yojson )
-                  ; ("error", `String (Caqti_error.show e)) ]
+                  ; ("error", `String (Caqti_error.show e))
+                  ]
           | Ok () ->
-              () )
+              ())
       |> don't_wait_for ;
       Deferred.ignore_m
       @@ Tcp.Server.create
@@ -2286,7 +2425,8 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                    "Exception while handling TCP server request: $error"
                    ~metadata:
                      [ ("error", `String (Core.Exn.to_string_mach exn))
-                     ; ("context", `String "rpc_tcp_server") ] ))
+                     ; ("context", `String "rpc_tcp_server")
+                     ]))
            where_to_listen
            (fun address reader writer ->
              let address = Socket.Address.Inet.addr address in
@@ -2305,8 +2445,9 @@ let setup_server ~metrics_server_port ~constraint_constants ~logger
                          [ ("error", `String (Core.Exn.to_string_mach exn))
                          ; ("context", `String "rpc_server")
                          ; ( "address"
-                           , `String (Unix.Inet_addr.to_string address) ) ] ;
-                     Deferred.unit )) )
+                           , `String (Unix.Inet_addr.to_string address) )
+                         ] ;
+                     Deferred.unit)))
       |> don't_wait_for ;
       (*Update archive metrics*)
       create_metrics_server ~logger ~metrics_server_port ~missing_blocks_width
@@ -2320,7 +2461,7 @@ module For_test = struct
     let open Deferred.Result.Let_syntax in
     match parent_id with
     | Some id ->
-        let%map Block.{state_hash= actual; _} = Block.load conn ~id in
+        let%map Block.{ state_hash = actual; _ } = Block.load conn ~id in
         [%test_result: string]
           ~expect:(parent_hash |> State_hash.to_base58_check)
           actual

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -11,7 +11,7 @@ let%test_module "Archive node unit tests" =
     let proof_level = Genesis_constants.Proof_level.None
 
     let precomputed_values =
-      {(Lazy.force Precomputed_values.for_unit_tests) with proof_level}
+      { (Lazy.force Precomputed_values.for_unit_tests) with proof_level }
 
     let constraint_constants = precomputed_values.constraint_constants
 
@@ -19,12 +19,15 @@ let%test_module "Archive node unit tests" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ()))
 
     module Genesis_ledger = (val Genesis_ledger.for_unit_tests)
 
     let archive_uri =
-      Uri.of_string (Option.value (Sys.getenv "MINA_TEST_POSTGRES") ~default:"postgres://admin:codarules@localhost:5432/archiver")
+      Uri.of_string
+        (Option.value
+           (Sys.getenv "MINA_TEST_POSTGRES")
+           ~default:"postgres://admin:codarules@localhost:5432/archiver")
 
     let conn_lazy =
       lazy
@@ -51,8 +54,7 @@ let%test_module "Archive node unit tests" =
         ~fee_range:10 ()
 
     let fee_transfer_gen =
-      Fee_transfer.Single.Gen.with_random_receivers ~keys ~min_fee:0
-        ~max_fee:10
+      Fee_transfer.Single.Gen.with_random_receivers ~keys ~min_fee:0 ~max_fee:10
         ~token:(Quickcheck.Generator.return Token_id.default)
 
     let coinbase_gen =
@@ -82,7 +84,7 @@ let%test_module "Archive node unit tests" =
           | Ok () ->
               ()
           | Error e ->
-              failwith @@ Caqti_error.show e )
+              failwith @@ Caqti_error.show e)
 
     let%test_unit "Fee_transfer: read and write" =
       let kind_gen =
@@ -95,7 +97,7 @@ let%test_module "Archive node unit tests" =
       Thread_safe.block_on_async_exn
       @@ fun () ->
       Async.Quickcheck.async_test
-        ~sexp_of:[%sexp_of: [`Normal | `Via_coinbase] * Fee_transfer.Single.t]
+        ~sexp_of:[%sexp_of: [ `Normal | `Via_coinbase ] * Fee_transfer.Single.t]
         (Quickcheck.Generator.tuple2 kind_gen fee_transfer_gen)
         ~f:(fun (kind, fee_transfer) ->
           let transaction_hash =
@@ -104,8 +106,7 @@ let%test_module "Archive node unit tests" =
           match%map
             let open Deferred.Result.Let_syntax in
             let%bind fee_transfer_id =
-              Processor.Fee_transfer.add_if_doesn't_exist conn fee_transfer
-                kind
+              Processor.Fee_transfer.add_if_doesn't_exist conn fee_transfer kind
             in
             let%map result =
               Processor.Internal_command.find conn ~transaction_hash
@@ -117,7 +118,7 @@ let%test_module "Archive node unit tests" =
           | Ok () ->
               ()
           | Error e ->
-              failwith @@ Caqti_error.show e )
+              failwith @@ Caqti_error.show e)
 
     let%test_unit "Coinbase: read and write" =
       let conn = Lazy.force conn_lazy in
@@ -140,7 +141,7 @@ let%test_module "Archive node unit tests" =
           | Ok () ->
               ()
           | Error e ->
-              failwith @@ Caqti_error.show e )
+              failwith @@ Caqti_error.show e)
 
     let%test_unit "Block: read and write" =
       let pool = Lazy.force conn_pool_lazy in
@@ -162,14 +163,14 @@ let%test_module "Archive node unit tests" =
           in
           let processor_deferred_computation =
             Processor.run
-              ~constraint_constants:precomputed_values.constraint_constants
-              pool reader ~logger ~delete_older_than:None
+              ~constraint_constants:precomputed_values.constraint_constants pool
+              reader ~logger ~delete_older_than:None
           in
           let diffs =
             List.map
               ~f:(fun breadcrumb ->
                 Diff.Transition_frontier
-                  (Diff.Builder.breadcrumb_added breadcrumb) )
+                  (Diff.Builder.breadcrumb_added breadcrumb))
               breadcrumbs
           in
           List.iter diffs ~f:(Strict_pipe.Writer.write writer) ;
@@ -187,7 +188,7 @@ let%test_module "Archive node unit tests" =
                           (Transition_frontier.Breadcrumb.state_hash breadcrumb)
                     with
                     | Some id ->
-                        let%bind Processor.Block.{parent_id; _} =
+                        let%bind Processor.Block.{ parent_id; _ } =
                           Processor.Block.load conn ~id
                         in
                         if
@@ -204,13 +205,13 @@ let%test_module "Archive node unit tests" =
                             conn
                         else Deferred.Result.return ()
                     | None ->
-                        failwith "Failed to find saved block in database" )
-                  pool )
+                        failwith "Failed to find saved block in database")
+                  pool)
           with
           | Ok () ->
               ()
           | Error e ->
-              failwith @@ Caqti_error.show e )
+              failwith @@ Caqti_error.show e)
 
     (*
     let%test_unit "Block: read and write with pruning" =


### PR DESCRIPTION
This PR adds an `.ocamlformat` file for the `archive_lib` library.

This already exists in develop, so merging back compatible can cause formatting errors.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them