### PR TITLE
Fixup compilation after merge from master

### DIFF
--- a/src/lib/mina_base/signed_command_memo.ml
+++ b/src/lib/mina_base/signed_command_memo.ml
@@ -148,7 +148,7 @@ type raw = Digest of string | Bytes of string
 
 let to_raw_exn memo =
   let tag = tag memo in
-  if Char.equal tag digest_tag then Digest (to_string memo)
+  if Char.equal tag digest_tag then Digest (to_base58_check memo)
   else if Char.equal tag bytes_tag then
     let len = length memo in
     Bytes (String.init len ~f:(fun idx -> memo.[idx - 2]))
@@ -163,7 +163,7 @@ let to_raw_bytes_exn memo =
 
 let of_raw_exn = function
   | Digest base58_check ->
-      of_string base58_check
+      of_base58_check_exn base58_check
   | Bytes str ->
       create_from_string_exn str
 


### PR DESCRIPTION
The recent merge from `master` removed some `to_string` / `of_string` functions that were used by new code introduced in `compatible`. This PR fixes the compilation errors by using the explicit `to_base58_check` and `of_base58_check_exn` versions.