### PR TITLE
Use `Field.project` instead of `Field.pack` for SnarkyJS `ofBits`

### DIFF
--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -404,7 +404,7 @@ let () =
           |> Array.to_list |> Field.Constant.project |> Field.constant |> mk
         with _ ->
           mk
-            (Field.pack
+            (Field.project
                (List.init bs##.length ~f:(fun i ->
                     Js.Optdef.case (Js.array_get bs i)
                       (fun () -> assert false)


### PR DESCRIPTION
This is intended to fix https://github.com/o1-labs/snarkyjs/issues/146

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
