### PR TITLE
Annotate status field of blocks_zkapp_commands; allow nullable cols

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2254,6 +2254,7 @@ module Zkapp_party_failures = struct
     in
     Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
       ~table_name
+      ~tannot:(function "failures" -> Some "text[]" | _ -> None)
       ~cols:([ "index"; "failures" ], typ)
       (module Conn)
       { index; failures }

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -47,13 +47,13 @@ CREATE TABLE zkapp_state_data_array
 */
 CREATE TABLE zkapp_states
 ( id                       serial           PRIMARY KEY
-, element_ids              int[]
+, element_ids              int[]            NOT NULL
 );
 
 /* like zkapp_states, but for sequences */
 CREATE TABLE zkapp_sequence_states
 ( id                       serial           PRIMARY KEY
-, element_ids              int[]
+, element_ids              int[]            NOT NULL
 );
 
 /* the element_ids are non-NULL, and refer to zkapp_state_data_array
@@ -61,7 +61,7 @@ CREATE TABLE zkapp_sequence_states
 */
 CREATE TABLE zkapp_events
 ( id                       serial           PRIMARY KEY
-, element_ids              int[]
+, element_ids              int[]            NOT NULL
 );
 
 CREATE TABLE zkapp_verification_keys

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -199,41 +199,22 @@ let add_if_zkapp_check (f : 'arg -> ('res, 'err) Deferred.Result.t) :
 
 (* `select_cols ~select:"s0" ~table_name:"t0" ~cols:["col0";"col1";...] ()`
    creates the string
-   `"SELECT s0 FROM t0 WHERE col0 = $1 AND col1 = $2 AND..."`.
+   `"SELECT s0 FROM t0 WHERE (col0 = $1 OR (col0 IS NULL AND $1 IS NULL)) AND ..."`
 
    The optional `tannot` function maps column names to type annotations.
-
-   The optional `nullable_cols` is a list of columns that may have NULLs.
-   For a column `col` appearing in that list, in the WHERE clause, the generated
-   comparison is of the form
-     `(col = $n OR (col IS NULL AND $n IS NULL))`
 *)
 
 let select_cols ~(select : string) ~(table_name : string)
-    ?(tannot : string -> string option = Fn.const None)
-    ?(nullable_cols : string list option) ~(cols : string list) () : string =
-  let where_checks =
-    match nullable_cols with
-    | None ->
-        (* common case *)
-        List.mapi cols ~f:(fun ndx col ->
-            let param = ndx + 1 in
-            let annot =
-              match tannot col with None -> "" | Some tannot -> "::" ^ tannot
-            in
-            sprintf "%s = $%d%s" col param annot)
-    | Some nullables ->
-        List.mapi cols ~f:(fun ndx col ->
-            let param = ndx + 1 in
-            let annot =
-              match tannot col with None -> "" | Some tannot -> "::" ^ tannot
-            in
-            if List.mem nullables col ~equal:String.equal then
-              sprintf "(%s = $%d%s OR (%s IS NULL AND $%d IS NULL))" col param
-                annot col param
-            else sprintf "%s = $%d%s" col param annot)
-  in
-  where_checks |> String.concat ~sep:" AND "
+    ?(tannot : string -> string option = Fn.const None) ~(cols : string list) ()
+    : string =
+  List.mapi cols ~f:(fun ndx col ->
+      let param = ndx + 1 in
+      let annot =
+        match tannot col with None -> "" | Some tannot -> "::" ^ tannot
+      in
+      sprintf "(%s = $%d%s OR (%s IS NULL AND $%d IS NULL))" col param annot col
+        param)
+  |> String.concat ~sep:" AND "
   |> sprintf "SELECT %s FROM %s WHERE %s" select table_name
 
 (* `select_cols_from_id ~table_name:"t0" ~cols:["col0";"col1";...]`
@@ -262,14 +243,13 @@ let insert_into_cols ~(returning : string) ~(table_name : string)
     values returning
 
 let select_insert_into_cols ~(select : string * 'select Caqti_type.t)
-    ~(table_name : string) ?tannot ?nullable_cols
-    ~(cols : string list * 'cols Caqti_type.t) (module Conn : CONNECTION)
-    (value : 'cols) =
+    ~(table_name : string) ?tannot ~(cols : string list * 'cols Caqti_type.t)
+    (module Conn : CONNECTION) (value : 'cols) =
   let open Deferred.Result.Let_syntax in
   Conn.find_opt
     ( Caqti_request.find_opt (snd cols) (snd select)
-    @@ select_cols ~select:(fst select) ~table_name ?tannot ?nullable_cols
-         ~cols:(fst cols) () )
+    @@ select_cols ~select:(fst select) ~table_name ?tannot ~cols:(fst cols) ()
+    )
     value
   >>= function
   | Some id ->


### PR DESCRIPTION
Update `select_cols` and `select_insert_into_cols` to generate checks in the `WHERE` clause that allow valid comparisons in the case of NULL values.

In `Block_and_zkapp_command.add_if_doesn't_exist`, add a type annotation for the `status` column. That should fix an error seen on today's QA net.

Use the new mechanism for the default token in `Token.add_if_doesn't_exist`.

Tested by running a local network. The default token was added to an empty archive db, and a zkApp was added to the `blocks_zkapp_commands` table.