### PR TITLE
Annotate column type for failure reasons

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2315,7 +2315,13 @@ module Block_and_zkapp_command = struct
           ; "failure_reasons_ids"
           ]
         , typ )
-      ~tannot:(function "status" -> Some "user_command_status" | _ -> None)
+      ~tannot:(function
+        | "status" ->
+            Some "user_command_status"
+        | "failure_reasons_ids" ->
+            Some "int[]"
+        | _ ->
+            None)
       (module Conn)
       { block_id; zkapp_command_id; sequence_no; status; failure_reasons_ids }
 


### PR DESCRIPTION
Annotate the column type for `failure_reasons_ids` when adding to the table `blocks_zkapp_commands`.

This should fix the query failure recently observed in the QA net.