### PR TITLE
Add genesis block, accounts at archive startup

### DIFF
--- a/src/app/archive/archive_lib/dune
+++ b/src/app/archive/archive_lib/dune
@@ -62,6 +62,8 @@
    quickcheck_lib
    snark_params
    mina_transaction
+   protocol_version
+   mina_version
  )
  (inline_tests)
  (modes native)

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -3505,7 +3505,7 @@ let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
              here, we just set the protocol version to a dummy value
           *)
           Protocol_version.(set_current zero) ;
-          let proof_level = Genesis_constants.Proof_level.Full in
+          let proof_level = Genesis_constants.Proof_level.compiled in
           let%bind precomputed_values =
             match%map
               Genesis_ledger_helper.init_from_config_file ~logger

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -49,13 +49,11 @@ CREATE TABLE account_identifiers
 , UNIQUE (public_key_id,token_id)
 );
 
-/* the initial balance is the balance at genesis, whether the account is timed or not
-   for untimed accounts, the fields other than id, account_identifier_id, and token are 0
+/* for untimed accounts, the fields other than id, account_identifier_id, and token are 0
 */
 CREATE TABLE timing_info
 ( id                      serial    PRIMARY KEY
 , account_identifier_id   int       NOT NULL UNIQUE REFERENCES account_identifiers(id)
-, initial_balance         bigint    NOT NULL
 , initial_minimum_balance bigint    NOT NULL
 , cliff_time              bigint    NOT NULL
 , cliff_amount            bigint    NOT NULL
@@ -152,7 +150,6 @@ CREATE TABLE blocks
 , chain_status                 chain_status_type NOT NULL
 );
 
-CREATE INDEX idx_blocks_id         ON blocks(id);
 CREATE INDEX idx_blocks_parent_id  ON blocks(parent_id);
 CREATE INDEX idx_blocks_creator_id ON blocks(creator_id);
 CREATE INDEX idx_blocks_height     ON blocks(height);

--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -483,10 +483,11 @@ AS combo GROUP BY combo.pk_id
           (* Could not get a nonce, return 0 *)
           Deferred.Result.return (last_relevant_command_balance, UInt64.zero)
         | None, Some timing_info ->
-          (* This account hasn't seen any transactions but was in the genesis ledger, so compute its balance at the start block *)
-          let balance_at_genesis : int64 =
-            Int64.(
-              timing_info.initial_balance - timing_info.initial_minimum_balance)
+          (* This account hasn't seen any transactions but was in the genesis ledger, so compute its balance at the start block
+             TODO: this is probably wrong now, because we have timing info for all accounts, in every block
+          *)
+          let balance_at_genesis : int64 = failwith "TODO: LOOK UP BALANCE"
+              (* WAS : timing_info.initial_balance - timing_info.initial_minimum_balance) *)
           in
           let incremental_balance_since_genesis : UInt64.t =
             compute_incremental_balance timing_info
@@ -546,7 +547,8 @@ AS combo GROUP BY combo.pk_id
           Deferred.Result.return last_relevant_command_balance
         | None, Some timing_info ->
           (* This account hasn't seen any transactions but was in the genesis ledger, so use its genesis balance  *)
-          Deferred.Result.return timing_info.initial_balance
+          failwith "LOOKUP BALANCE, NONCE IN ACCOUNTS_ACCESSED; timing_info isn't just genesis ledger any longer"
+          (* WAS:    Deferred.Result.return timing_info.initial_balance *)
       in
       let balance_info : Balance_info.t = {liquid_balance; total_balance} in
       Deferred.Result.return (requested_block_identifier, balance_info, nonce)

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -929,7 +929,8 @@ let init_from_inputs ?(genesis_dir = Cache_dir.autogen_path) ~logger
   values
 
 let init_from_config_file ?genesis_dir ~logger ~proof_level
-    (config : Runtime_config.t) =
+    (config : Runtime_config.t) :
+    (Precomputed_values.t * Runtime_config.t) Deferred.Or_error.t =
   let open Deferred.Or_error.Let_syntax in
   let%map inputs, config =
     inputs_from_config_file ?genesis_dir ~logger ~proof_level config

--- a/src/lib/mina_base/dune
+++ b/src/lib/mina_base/dune
@@ -69,7 +69,7 @@
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_annot ppx_snarky ppx_here ppx_coda ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord ppx_deriving.make 
+  (pps ppx_annot ppx_snarky ppx_here ppx_coda ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord ppx_deriving.make
        ppx_base ppx_bench ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test h_list.ppx
  ))
  (instrumentation (backend bisect_ppx))


### PR DESCRIPTION
When starting the archive process, if a runtime config is provided, archive the genesis block into the `blocks` table, and the genesis accounts into the `accounts_accessed` table. The archive processor creates an internal ledger for this purpose, and its Merkle root is compared against the ledger hash stored for the genesis block.

Other changes:
- remove the `initial_balance` column of `timing_info`, it's redundant with the `accounts_accessed` balance
- remove the explicit index on `block(id)`, because it's a primary key
- log the commit info on the archive process startup
- hacks to get Rosetta to compile after these changes

Tested by running a local network, verifying that the accounts appear in `accounts_accessed`.

Closes #10912.
Closes #10904.