### PR TITLE
Fix subchain query

### DIFF
--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -191,7 +191,9 @@ let fill_in_user_commands pool block_state_hash =
       let%bind fee_payer = account_identifier_of_id user_cmd.fee_payer_id in
       let%bind source = account_identifier_of_id user_cmd.source_id in
       let%bind receiver = account_identifier_of_id user_cmd.receiver_id in
-      let nonce = user_cmd.nonce |> Account.Nonce.of_int in
+      let nonce =
+        user_cmd.nonce |> Unsigned.UInt32.of_int64 |> Account.Nonce.of_uint32
+      in
       let amount =
         Option.map user_cmd.amount ~f:(fun amt ->
             Unsigned.UInt64.of_int64 amt |> Currency.Amount.of_uint64)

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -626,7 +626,7 @@ WITH RECURSIVE chain AS (
           ; receiver= User_commands.Extras.receiver extras
           ; fee_token= `Token_id fee_token
           ; token= `Token_id token
-          ; nonce= Unsigned.UInt32.of_int uc.nonce
+          ; nonce= Unsigned.UInt32.of_int64 uc.nonce
           ; amount= Option.map ~f:Unsigned.UInt64.of_int64 uc.amount
           ; fee= Unsigned.UInt64.of_int64 uc.fee
           ; hash= uc.hash


### PR DESCRIPTION
The subchain query for blocks, used when updating chain statuses, had not been updated to use the columns `min_window_density` and `total_currency`. Added those columns.

Tested by manually calling the subchain query.

This should fix the failure to decode text to int64 error seen by QA net users.

Also: changed some OCaml types to int64, to match `bigint` in the database schema. (Not really necessary; nonces are unsigned 32-bit quantities, so they won't fit in a Postgresql int, which are signed 32-bit values, so `bigint` is required. Fitting that back into OCaml only requires an `int`, which is 63-bits. But it's easier just to remember to always use int64 with `bigint`, which we often use for unsigned 64-bit values).

Closes #10892.