### PR TITLE
Remove indirection table zkapp_fee_payer

### DIFF
--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -106,13 +106,18 @@ CREATE INDEX idx_voting_for_value ON voting_for(value);
 /* import supporting Zkapp-related tables */
 \ir zkapp_tables.sql
 
-/* zkapp_other_parties_ids refers to a list of ids in zkapp_party.
+/* in OCaml, there's a Fee_payer type, which contains a
+   a signature and a reference to the fee payer body. Because
+   we don't store a signature, the fee payer here refers
+   directly to the fee payer body.
+
+   zkapp_other_parties_ids refers to a list of ids in zkapp_party.
    The values in zkapp_other_parties_ids are unenforced foreign keys
    that reference zkapp_party_body(id), and not NULL.
 */
 CREATE TABLE zkapp_commands
 ( id                                    serial         PRIMARY KEY
-, zkapp_fee_payer_id                    int            NOT NULL REFERENCES zkapp_fee_payers(id)
+, zkapp_fee_payer_body_id               int            NOT NULL REFERENCES zkapp_fee_payer_body(id)
 , zkapp_other_parties_ids               int[]          NOT NULL
 , memo                                  text           NOT NULL
 , hash                                  text           NOT NULL UNIQUE

--- a/src/app/archive/drop_tables.sql
+++ b/src/app/archive/drop_tables.sql
@@ -34,11 +34,9 @@ DROP TYPE user_command_status;
 
 DROP TABLE zkapp_commands;
 
-DROP TABLE zkapp_other_party;
-
-DROP TABLE zkapp_fee_payers;
-
 DROP TABLE zkapp_fee_payer_body;
+
+DROP TABLE zkapp_other_party;
 
 DROP TABLE zkapp_other_party_body;
 

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -239,11 +239,6 @@ CREATE TABLE zkapp_fee_payer_body
 , nonce                                 bigint    NOT NULL
 );
 
-CREATE TABLE zkapp_fee_payers
-( id                       serial           PRIMARY KEY
-, body_id                  int              NOT NULL REFERENCES zkapp_fee_payer_body(id)
-);
-
 CREATE TYPE call_type_type AS ENUM ('call', 'delegate_call');
 
 /* events_ids and sequence_events_ids indicate a list of ids in

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -289,11 +289,7 @@ let fill_in_zkapp_commands pool block_state_hash =
             Processor.User_command.Zkapp_command.load db zkapp_command_id)
       in
       let%bind fee_payer =
-        let%bind body_id =
-          query_db ~f:(fun db ->
-              Processor.Zkapp_fee_payers.load db zkapp_cmd.zkapp_fee_payer_id)
-        in
-        Load_data.get_fee_payer_body ~pool body_id
+        Load_data.get_fee_payer_body ~pool zkapp_cmd.zkapp_fee_payer_body_id
       in
       let%bind other_parties =
         Deferred.List.map

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -633,14 +633,10 @@ end
 let parties_of_zkapp_command ~pool (cmd : Sql.Zkapp_command.t) :
     Parties.t Deferred.t =
   let query_db = Mina_caqti.query pool in
-  let%bind fee_payer_body_id =
-    query_db ~f:(fun db ->
-        Processor.Zkapp_fee_payers.load db cmd.zkapp_fee_payer_id)
-  in
   (* use dummy authorizations *)
   let%bind (fee_payer : Party.Fee_payer.t) =
     let%map (body : Party.Body.Fee_payer.t) =
-      Archive_lib.Load_data.get_fee_payer_body ~pool fee_payer_body_id
+      Archive_lib.Load_data.get_fee_payer_body ~pool cmd.zkapp_fee_payer_body_id
     in
     ({ body; authorization = Signature.dummy } : Party.Fee_payer.t)
   in

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -246,7 +246,7 @@ end
 
 module Zkapp_command = struct
   type t =
-    { zkapp_fee_payer_id : int
+    { zkapp_fee_payer_body_id : int
     ; zkapp_other_parties_ids : int array
     ; memo : string
     ; block_id : int
@@ -272,7 +272,7 @@ module Zkapp_command = struct
 
   let query =
     Caqti_request.collect Caqti_type.int typ
-      {sql| SELECT zkapp_fee_payer_id,zkapp_other_parties_ids,memo,
+      {sql| SELECT zkapp_fee_payer_body_id,zkapp_other_parties_ids,memo,
                    blocks.id,blocks.global_slot_since_genesis,
                    parent.global_slot_since_genesis,
                    sequence_no,hash

--- a/src/app/replayer/test/archive_db.sql
+++ b/src/app/replayer/test/archive_db.sql
@@ -704,7 +704,7 @@ ALTER SEQUENCE public.zkapp_balance_bounds_id_seq OWNED BY public.zkapp_balance_
 
 CREATE TABLE public.zkapp_commands (
     id integer NOT NULL,
-    zkapp_fee_payer_id integer NOT NULL,
+    zkapp_fee_payer_body_id integer NOT NULL,
     zkapp_other_parties_ids integer[] NOT NULL,
     memo text NOT NULL,
     hash text NOT NULL
@@ -860,37 +860,6 @@ CREATE SEQUENCE public.zkapp_fee_payer_body_id_seq
 --
 
 ALTER SEQUENCE public.zkapp_fee_payer_body_id_seq OWNED BY public.zkapp_fee_payer_body.id;
-
-
---
--- Name: zkapp_fee_payers; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.zkapp_fee_payers (
-    id integer NOT NULL,
-    body_id integer NOT NULL
-);
-
-
---
--- Name: zkapp_fee_payers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.zkapp_fee_payers_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: zkapp_fee_payers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.zkapp_fee_payers_id_seq OWNED BY public.zkapp_fee_payers.id;
-
 
 --
 -- Name: zkapp_global_slot_bounds; Type: TABLE; Schema: public; Owner: -
@@ -1657,13 +1626,6 @@ ALTER TABLE ONLY public.zkapp_fee_payer_body ALTER COLUMN id SET DEFAULT nextval
 
 
 --
--- Name: zkapp_fee_payers id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.zkapp_fee_payers ALTER COLUMN id SET DEFAULT nextval('public.zkapp_fee_payers_id_seq'::regclass);
-
-
---
 -- Name: zkapp_global_slot_bounds id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2329,7 +2291,7 @@ COPY public.zkapp_balance_bounds (id, balance_lower_bound, balance_upper_bound) 
 -- Data for Name: zkapp_commands; Type: TABLE DATA; Schema: public; Owner: -
 --
 
-COPY public.zkapp_commands (id, zkapp_fee_payer_id, zkapp_other_parties_ids, memo, hash) FROM stdin;
+COPY public.zkapp_commands (id, zkapp_fee_payer_body_id, zkapp_other_parties_ids, memo, hash) FROM stdin;
 1	1	{1,2}	E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4TVDDpTTSsv8mK6YaH	CkpZBMeciXqFVuGDtGLHLbhMNKZukmYHoSqMWYYXUWgWxnvX6ZaMu
 2	2	{3}	E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4TVDDpTTSsv8mK6YaH	CkpaFUKBY891HvtBAfMKayPSzyCYcGiqU8Mvs3LWoKBXSBpyG6JEZ
 3	3	{4}	E4YM2vTHhWEg66xpj52JErHUBU4pZ1yageL4TVDDpTTSsv8mK6YaH	CkpZqhmFm7hKcpfqa9yFHZbBqNzDNcXpmzyXBMwf4jkuJU9B3L7Q6
@@ -2407,18 +2369,6 @@ COPY public.zkapp_fee_payer_body (id, account_identifier_id, update_id, fee, eve
 2	4	4	1000000000	1	1	4	2
 3	4	6	1000000000	1	1	6	3
 4	4	8	1000000000	1	1	8	4
-\.
-
-
---
--- Data for Name: zkapp_fee_payers; Type: TABLE DATA; Schema: public; Owner: -
---
-
-COPY public.zkapp_fee_payers (id, body_id) FROM stdin;
-1	1
-2	2
-3	3
-4	4
 \.
 
 
@@ -2740,13 +2690,6 @@ SELECT pg_catalog.setval('public.zkapp_events_id_seq', 1, true);
 --
 
 SELECT pg_catalog.setval('public.zkapp_fee_payer_body_id_seq', 4, true);
-
-
---
--- Name: zkapp_fee_payers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
---
-
-SELECT pg_catalog.setval('public.zkapp_fee_payers_id_seq', 4, true);
 
 
 --
@@ -3152,14 +3095,6 @@ ALTER TABLE ONLY public.zkapp_events
 
 ALTER TABLE ONLY public.zkapp_fee_payer_body
     ADD CONSTRAINT zkapp_fee_payer_body_pkey PRIMARY KEY (id);
-
-
---
--- Name: zkapp_fee_payers zkapp_fee_payers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.zkapp_fee_payers
-    ADD CONSTRAINT zkapp_fee_payers_pkey PRIMARY KEY (id);
 
 
 --
@@ -3790,11 +3725,11 @@ ALTER TABLE ONLY public.zkapp_accounts
 
 
 --
--- Name: zkapp_commands zkapp_commands_zkapp_fee_payer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: zkapp_commands zkapp_commands_zkapp_fee_payer_body_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.zkapp_commands
-    ADD CONSTRAINT zkapp_commands_zkapp_fee_payer_id_fkey FOREIGN KEY (zkapp_fee_payer_id) REFERENCES public.zkapp_fee_payers(id);
+    ADD CONSTRAINT zkapp_commands_zkapp_fee_payer_body_id_fkey FOREIGN KEY (zkapp_fee_payer_body_id) REFERENCES public.zkapp_fee_payer_body(id);
 
 
 --
@@ -3867,14 +3802,6 @@ ALTER TABLE ONLY public.zkapp_fee_payer_body
 
 ALTER TABLE ONLY public.zkapp_fee_payer_body
     ADD CONSTRAINT zkapp_fee_payer_body_zkapp_protocol_state_precondition_id_fkey FOREIGN KEY (zkapp_protocol_state_precondition_id) REFERENCES public.zkapp_protocol_state_precondition(id);
-
-
---
--- Name: zkapp_fee_payers zkapp_fee_payers_body_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.zkapp_fee_payers
-    ADD CONSTRAINT zkapp_fee_payers_body_id_fkey FOREIGN KEY (body_id) REFERENCES public.zkapp_fee_payer_body(id);
 
 
 --


### PR DESCRIPTION
In OCaml, `Fee_payer.t` refers to `Body.Fee_payer.t` and a signature. In the archive db, we don't store the signature, so the table `zkapp_fee_payer` referred to entries in `zkapp_fee_payer_body`, and contained no other information. Therefore, that table can be removed.

This change required small changes to `extract_blocks` and the `replayer`, and editing the SQL for the replayer test, which succeeded locally. Also tested that `extract_blocks` works on the data in the replayer test.

Closes #10916.