### PR TITLE
Run replayer in payments integration test

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2836,15 +2836,6 @@ module Block = struct
                           (module Conn)
                           fee_transfer `Via_coinbase
                       in
-                      let%bind _receiver_account_identifier_id =
-                        (* fee transfer via coinbase uses default token *)
-                        let account_id =
-                          Account_id.create receiver_pk Token_id.default
-                        in
-                        Account_identifiers.add_if_doesn't_exist
-                          (module Conn)
-                          ~token_owner:None account_id
-                      in
                       Block_and_internal_command.add
                         (module Conn)
                         ~block_id ~internal_command_id:id ~sequence_no

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -2822,6 +2822,34 @@ module Block = struct
                 in
                 sequence_no + 1
             | { data = Coinbase coinbase; _ } ->
+                let%bind () =
+                  match Mina_base.Coinbase.fee_transfer coinbase with
+                  | None ->
+                      return ()
+                  | Some { receiver_pk; fee } ->
+                      let fee_transfer =
+                        Mina_base.Fee_transfer.Single.create ~receiver_pk ~fee
+                          ~fee_token:Token_id.default
+                      in
+                      let%bind id =
+                        Fee_transfer.add_if_doesn't_exist
+                          (module Conn)
+                          fee_transfer `Via_coinbase
+                      in
+                      let%bind _receiver_account_identifier_id =
+                        (* fee transfer via coinbase uses default token *)
+                        let account_id =
+                          Account_id.create receiver_pk Token_id.default
+                        in
+                        Account_identifiers.add_if_doesn't_exist
+                          (module Conn)
+                          ~token_owner:None account_id
+                      in
+                      Block_and_internal_command.add
+                        (module Conn)
+                        ~block_id ~internal_command_id:id ~sequence_no
+                        ~secondary_sequence_no:0
+                in
                 let%bind id =
                   Coinbase.add_if_doesn't_exist (module Conn) coinbase
                 in

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -1088,7 +1088,8 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                       "Balance in ledger does not match balance in account \
                        accessed"
                       ~metadata:
-                        [ ( "balance_in_ledger"
+                        [ ("account_id", Account_id.to_yojson account_id)
+                        ; ( "balance_in_ledger"
                           , Currency.Balance.to_yojson balance_in_ledger )
                         ; ( "balance_in_account_accessed"
                           , Currency.Balance.to_yojson balance )
@@ -1102,10 +1103,11 @@ let main ~input_file ~output_file_opt ~archive_uri ~continue_on_error () =
                     [%log error]
                       "Nonce in ledger does not match nonce in account accessed"
                       ~metadata:
-                        [ ( "balance_in_ledger"
+                        [ ("account_id", Account_id.to_yojson account_id)
+                        ; ( "nonce_in_ledger"
                           , Mina_numbers.Account_nonce.to_yojson nonce_in_ledger
                           )
-                        ; ( "balance_in_account_accessed"
+                        ; ( "nonce_in_account_accessed"
                           , Mina_numbers.Account_nonce.to_yojson nonce )
                         ] ;
                     if continue_on_error then incr error_count

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -420,7 +420,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                  "Payment failed for unexpected reason: %s" err_str ))
     in
     let%bind () =
-      section
+      section_hard
         "send out a bunch more txns to fill up the snark ledger, then wait for \
          proofs to be emitted"
         (let receiver = untimed_node_a in
@@ -451,7 +451,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          wait_for t
            (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:1))
     in
-    section "Running replayer"
+    section_hard "running replayer"
       (let%bind logs =
          Network.Node.run_replayer ~logger
            (List.hd_exn @@ Network.archive_nodes network)

--- a/src/app/test_executive/payments_test.ml
+++ b/src/app/test_executive/payments_test.ml
@@ -49,6 +49,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         [ { balance = "1000"; timing = Untimed }
         ; { balance = "1000"; timing = Untimed }
         ]
+    ; num_archive_nodes = 1
     ; num_snark_workers = 4
     ; snark_worker_fee = "0.0001"
     ; proof_config =
@@ -418,15 +419,16 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                Malleable_error.soft_error_format ~value:()
                  "Payment failed for unexpected reason: %s" err_str ))
     in
-    section
-      "send out a bunch more txns to fill up the snark ledger, then wait for \
-       proofs to be emitted"
-      (let receiver = untimed_node_a in
-       let%bind receiver_pub_key = Util.pub_key_of_node receiver in
-       let sender = untimed_node_b in
-       let%bind sender_pub_key = Util.pub_key_of_node sender in
-       let%bind () =
-         (*
+    let%bind () =
+      section
+        "send out a bunch more txns to fill up the snark ledger, then wait for \
+         proofs to be emitted"
+        (let receiver = untimed_node_a in
+         let%bind receiver_pub_key = Util.pub_key_of_node receiver in
+         let sender = untimed_node_b in
+         let%bind sender_pub_key = Util.pub_key_of_node sender in
+         let%bind () =
+           (*
             To fill up a `small` transaction capacity with work delay of 1, 
             there needs to be 12 total txns sent.
 
@@ -441,11 +443,29 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
 
             2 successful txn are sent in the prior course of this test,
             so spamming out at least 10 more here will trigger a ledger proof to be emitted *)
-         repeat_seq ~n:10 ~f:(fun () ->
-             Network.Node.must_send_payment ~logger sender ~sender_pub_key
-               ~receiver_pub_key ~amount:Currency.Amount.one ~fee
-             >>| ignore)
+           repeat_seq ~n:10 ~f:(fun () ->
+               Network.Node.must_send_payment ~logger sender ~sender_pub_key
+                 ~receiver_pub_key ~amount:Currency.Amount.one ~fee
+               >>| ignore)
+         in
+         wait_for t
+           (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:1))
+    in
+    section "Running replayer"
+      (let%bind logs =
+         Network.Node.run_replayer ~logger
+           (List.hd_exn @@ Network.archive_nodes network)
        in
-       wait_for t
-         (Wait_condition.ledger_proofs_emitted_since_genesis ~num_proofs:1))
+       let error_logs =
+         String.split logs ~on:'\n'
+         |> List.filter ~f:(fun log ->
+                String.is_substring log ~substring:{|"level":"Error"|}
+                || String.is_substring log ~substring:{|"level":"Fatal"|})
+       in
+       if List.is_empty error_logs then (
+         [%log info] "The replayer encountered no errors" ;
+         return () )
+       else
+         let error = String.concat error_logs ~sep:"\n  " in
+         Malleable_error.hard_error_string ("Replayer errors:\n  " ^ error))
 end

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -43,7 +43,8 @@ module Node = struct
     Integration_test_lib.Util.run_cmd_exn cwd "kubectl"
       (base_kube_args config @ [ "logs"; "-c"; container_id; pod_id ])
 
-  let run_in_container ?container_id ~cmd { pod_id; config; info; _ } =
+  let run_in_container ?container_id ~cmd t =
+    let { pod_id; config; info; _ } = t in
     let container_id =
       Option.value container_id ~default:info.primary_container_id
     in
@@ -52,6 +53,22 @@ module Node = struct
       ( base_kube_args config
       @ [ "exec"; "-c"; container_id; "-i"; pod_id; "--" ]
       @ cmd )
+
+  let cp_string_to_container_file ?container_id ~str ~dest t =
+    let { pod_id; config; info; _ } = t in
+    let container_id =
+      Option.value container_id ~default:info.primary_container_id
+    in
+    let tmp_file, oc =
+      Caml.Filename.open_temp_file ~temp_dir:Filename.temp_dir_name
+        "integration_test_cp_string" ".tmp"
+    in
+    Out_channel.output_string oc str ;
+    Out_channel.close oc ;
+    let%bind cwd = Unix.getcwd () in
+    let dest_file = sprintf "%s/%s:%s" config.namespace pod_id dest in
+    Integration_test_lib.Util.run_cmd_exn cwd "kubectl"
+      (base_kube_args config @ [ "cp"; "-c"; container_id; tmp_file; dest_file ])
 
   let start ~fresh_state node : unit Malleable_error.t =
     let open Deferred.Let_syntax in
@@ -933,6 +950,39 @@ module Node = struct
     [%log info] "Dumping archive data to file %s" data_file ;
     Out_channel.with_file data_file ~f:(fun out_ch ->
         Out_channel.output_string out_ch data)
+
+  let run_replayer ~logger (t : t) =
+    [%log info] "Running replayer on archived data (node: %s, container: %s)"
+      t.pod_id mina_archive_container_id ;
+    let open Malleable_error.Let_syntax in
+    let%bind accounts =
+      Deferred.bind ~f:Malleable_error.return
+        (run_in_container t
+           ~cmd:[ "jq"; "-c"; ".ledger.accounts"; "/config/daemon.json" ])
+    in
+    let replayer_input =
+      sprintf
+        {| { "genesis_ledger": { "accounts": %s, "add_genesis_winner": true }} |}
+        accounts
+    in
+    let dest = "replayer-input.json" in
+    let%bind _res =
+      Deferred.bind ~f:Malleable_error.return
+        (cp_string_to_container_file t ~container_id:mina_archive_container_id
+           ~str:replayer_input ~dest)
+    in
+    Deferred.bind ~f:Malleable_error.return
+      (run_in_container t ~container_id:mina_archive_container_id
+         ~cmd:
+           [ "mina-replayer"
+           ; "--archive-uri"
+           ; "postgres://postgres:foobar@archive-1-postgresql:5432/archive"
+           ; "--input-file"
+           ; dest
+           ; "--output-file"
+           ; "/dev/null"
+           ; "--continue-on-error"
+           ])
 
   let dump_mina_logs ~logger (t : t) ~log_file =
     let open Malleable_error.Let_syntax in

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -150,7 +150,7 @@ module Engine = struct
            logger:Logger.t
         -> t
         -> account_id:Mina_base.Account_id.t
-        -> account_data Async_kernel.Deferred.Or_error.t
+        -> account_data Deferred.Or_error.t
 
       val must_get_account_data :
            logger:Logger.t
@@ -174,9 +174,7 @@ module Engine = struct
         -> Mina_base.Party.Update.t Deferred.Or_error.t
 
       val get_peer_id :
-           logger:Logger.t
-        -> t
-        -> (string * string list) Async_kernel.Deferred.Or_error.t
+        logger:Logger.t -> t -> (string * string list) Deferred.Or_error.t
 
       val must_get_peer_id :
         logger:Logger.t -> t -> (string * string list) Malleable_error.t
@@ -185,7 +183,7 @@ module Engine = struct
            ?max_length:int
         -> logger:Logger.t
         -> t
-        -> best_chain_block list Async_kernel.Deferred.Or_error.t
+        -> best_chain_block list Deferred.Or_error.t
 
       val must_get_best_chain :
            ?max_length:int
@@ -196,14 +194,15 @@ module Engine = struct
       val dump_archive_data :
         logger:Logger.t -> t -> data_file:string -> unit Malleable_error.t
 
+      val run_replayer : logger:Logger.t -> t -> string Malleable_error.t
+
       val dump_mina_logs :
         logger:Logger.t -> t -> log_file:string -> unit Malleable_error.t
 
       val dump_precomputed_blocks :
         logger:Logger.t -> t -> unit Malleable_error.t
 
-      val get_metrics :
-        logger:Logger.t -> t -> metrics_t Async_kernel.Deferred.Or_error.t
+      val get_metrics : logger:Logger.t -> t -> metrics_t Deferred.Or_error.t
     end
 
     type t
@@ -394,7 +393,7 @@ module Dsl = struct
       -> ( unit Malleable_error.Result_accumulator.t
          , Malleable_error.Hard_fail.t )
          result
-         Async_kernel.Deferred.t
+         Deferred.t
 
     val fetch_connectivity_data :
          logger:Logger.t


### PR DESCRIPTION
In the payments integration test, add an archive node, and as a final step, run the replayer on the archive db. Generate a hard error if the replayer creates `Error` or `Fatal` logs.

To run the replayer:
- use `jq` to pull out the accounts from `daemon.json` on the archive node
- create a local file as the replayer input, use `kubectl cp` to copy it back to the archive node
- run `mina-replayer` on the archive node with `--continue-on-error`
- look for offending logs in the output

In experiments, running the replayer added 10 seconds to the time for the test.

Restored code to save fee-transfers-via-coinbases in the archive processor, erroneously deleted during refactoring.

Improved some logs in the replayer.

If this approach is OK, we can add similar code to the delegation and zkApps integration tests.