### PR TITLE
Detect LLD linker and use it if available

### DIFF
--- a/src/app/cli/src/dune-project
+++ b/src/app/cli/src/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.7)
+(lang dune 3.1)
 (name graphql)
 (implicit_transitive_deps false)

--- a/src/dune.flags.inc
+++ b/src/dune.flags.inc
@@ -3,6 +3,6 @@
 (env
   (_
     (flags (:standard -short-paths
-            -ccopt=-fuse-ld=%{read:dune-linker}
+            -ccopt=%{read:dune-linker}
             -cclib -ljemalloc
             -w @a-4-29-40-41-42-44-45-48-58-59-60-66))))

--- a/src/dune.flags.inc
+++ b/src/dune.flags.inc
@@ -1,3 +1,8 @@
+(include dune.linker.inc)
+
 (env
   (_
-    (flags (:standard -short-paths -cclib -ljemalloc -w @a-4-29-40-41-42-44-45-48-58-59-60-66))))
+    (flags (:standard -short-paths
+            -ccopt=-fuse-ld=%{read:dune-linker}
+            -cclib -ljemalloc
+            -w @a-4-29-40-41-42-44-45-48-58-59-60-66))))

--- a/src/dune.linker.inc
+++ b/src/dune.linker.inc
@@ -1,9 +1,13 @@
+; The content of 'dune-linker' is to be passed as a -ccopt to ocamlopt
+; or directly to the C compiler.
+; ocamlopt -ccopt=<dune-linker> behaves correctly if <dune-linker> is empty
+
 (rule
   (target dune-linker)
   (enabled_if %{bin-available:lld})
-  (action (with-stdout-to dune-linker (echo "lld"))))
+  (action (with-stdout-to dune-linker (echo "-fuse-ld=lld"))))
 
 (rule
   (target dune-linker)
   (enabled_if (= %{bin-available:lld} false))
-  (action (with-stdout-to dune-linker (echo "bfd"))))
+  (action (with-stdout-to dune-linker (echo " "))))

--- a/src/dune.linker.inc
+++ b/src/dune.linker.inc
@@ -1,0 +1,9 @@
+(rule
+  (target dune-linker)
+  (enabled_if %{bin-available:lld})
+  (action (with-stdout-to dune-linker (echo "lld"))))
+
+(rule
+  (target dune-linker)
+  (enabled_if (= %{bin-available:lld} false))
+  (action (with-stdout-to dune-linker (echo "bfd"))))

--- a/src/external/ocaml-rocksdb/dune
+++ b/src/external/ocaml-rocksdb/dune
@@ -1,11 +1,12 @@
+(include ../../dune.linker.inc)
+
 (library
     (name rocks)
     (public_name rocks)
     (no_dynlink)
     (libraries ctypes ctypes.foreign)
     (modules (:standard \ rocks_linker_flags_gen rocks_test))
-    (c_library_flags (:standard (:include flags.sexp)))
-    (self_build_stubs_archive (rocksdb))
+    (c_library_flags (:standard (:include flags.sexp) -fuse-ld=%{read:dune-linker}))
     )
 
 (executable
@@ -16,6 +17,7 @@
 
 (rule
  (targets flags.sexp)
+ (deps librocksdb_stubs.a)
  (action (run ./rocks_linker_flags_gen.exe)))
 
 (rule

--- a/src/external/ocaml-rocksdb/dune
+++ b/src/external/ocaml-rocksdb/dune
@@ -6,7 +6,7 @@
     (no_dynlink)
     (libraries ctypes ctypes.foreign)
     (modules (:standard \ rocks_linker_flags_gen rocks_test))
-    (c_library_flags (:standard (:include flags.sexp) -fuse-ld=%{read:dune-linker}))
+    (c_library_flags (:standard (:include flags.sexp) %{read:dune-linker}))
     )
 
 (executable

--- a/src/external/ocaml-rocksdb/dune-project
+++ b/src/external/ocaml-rocksdb/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.6)
+(lang dune 3.1)

--- a/src/external/ocaml-rocksdb/rocks_linker_flags_gen.ml
+++ b/src/external/ocaml-rocksdb/rocks_linker_flags_gen.ml
@@ -14,9 +14,10 @@ let () =
         ; "-lc++abi"
         ; "-lc++" ]
     | "Linux" ->
-        [ "-Wl,--push-state,-whole-archive"
+        [ sprintf "-L%s" cwd
+        ; "-Wl,--whole-archive"
         ; "-lrocksdb_stubs"
-        ; "-Wl,--pop-state"
+        ; "-Wl,--no-whole-archive"
         ; "-lz"
         ; "-lbz2"
         ; "-lstdc++" ]


### PR DESCRIPTION
Closes https://github.com/MinaProtocol/mina/issues/10761

We now detect if `lld` is installed via dune 3's `bin-available`stanza, and use it globally and in `ocaml-rocksdb` when available.
If not, we fall back on the default linker, BFD.

`ocaml-rocksdb` linker flags are slightly altered to be compatible with both `bfd` and `lld`, and the `dune lang` version is raised in places that make use of the linker detection.
