### PR TITLE
Simplify per branch data

### DIFF
--- a/src/lib/pickles/cache.ml
+++ b/src/lib/pickles/cache.ml
@@ -179,7 +179,7 @@ module Wrap = struct
                 (Kimchi_bindings.Protocol.Index.Fq.write (Some true) t.index)
               header path))
 
-  let read_or_generate step_domains cache k_p k_v typ main =
+  let read_or_generate cache k_p k_v typ main =
     let module Vk = Verification_key in
     let open Impls.Wrap in
     let s_p = storable in
@@ -249,7 +249,6 @@ module Wrap = struct
                { index = vk
                ; commitments =
                    Kimchi_pasta.Pallas_based_plonk.Keypair.vk_commitments vk
-               ; step_domains
                ; data =
                    (let open Kimchi_bindings.Protocol.Index.Fq in
                    { constraints = domain_d1_size pk.index })

--- a/src/lib/pickles/composition_types/branch_data.ml
+++ b/src/lib/pickles/composition_types/branch_data.ml
@@ -1,0 +1,166 @@
+open Core_kernel
+open Pickles_types
+
+(** Data specific to a branch of a proof-system that's necessary for
+    finalizing the deferred-values in a wrap proof of that branch. *)
+
+(** Inside the circuit, we will represent a value of this type
+    as a sequence of 2 bits:
+    00: N0
+    10: N1
+    11: N2 *)
+module Proofs_verified = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = N0 | N1 | N2
+      [@@deriving sexp, sexp, compare, yojson, hash, equal]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  module Checked = struct
+    type 'f boolean = 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
+
+    type 'f t = ('f boolean, Nat.N2.n) Vector.t
+  end
+
+  let to_mask : t -> (bool, Nat.N2.n) Vector.t = function
+    | N0 ->
+        [ false; false ]
+    | N1 ->
+        [ true; false ]
+    | N2 ->
+        [ true; true ]
+
+  let of_mask_exn : (bool, Nat.N2.n) Vector.t -> t = function
+    | [ false; false ] ->
+        N0
+    | [ true; false ] ->
+        N1
+    | [ true; true ] ->
+        N2
+    | [ false; true ] ->
+        failwith "Invalid mask"
+end
+
+module Domain_log2 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = char [@@deriving compare, sexp, yojson, hash, equal]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  let of_int_exn : int -> t = Char.of_int_exn
+
+  let of_bits_msb (bs : bool list) : t =
+    List.fold bs ~init:0 ~f:(fun acc b ->
+        let acc = acc lsl 1 in
+        if b then acc + 1 else acc)
+    |> of_int_exn
+
+  let of_field_exn (type f)
+      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+      (x : f) : t =
+    Impl.Field.Constant.unpack x
+    |> Fn.flip List.take 8 |> List.rev |> of_bits_msb
+end
+
+(* We pack this into a single field element as follows:
+   First 2 bits: proofs_verified
+   Next 8 bits: domain_log2 *)
+[%%versioned
+module Stable = struct
+  module V1 = struct
+    type t =
+      { proofs_verified : Proofs_verified.Stable.V1.t
+      ; domain_log2 : Domain_log2.Stable.V1.t
+      }
+    [@@deriving hlist, compare, sexp, yojson, hash, equal]
+
+    let to_latest = Fn.id
+  end
+end]
+
+let length_in_bits = 10
+
+let pack (type f)
+    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+    ({ proofs_verified; domain_log2 } : t) : f =
+  let open Impl.Field.Constant in
+  let double x = x + x in
+  let times4 x = double (double x) in
+  let domain_log2 = of_int (Char.to_int domain_log2) in
+  (* shift domain_log2 over by 2 bits (multiply by 4) *)
+  times4 domain_log2
+  + project
+      (Pickles_types.Vector.to_list (Proofs_verified.to_mask proofs_verified))
+
+let unpack (type f)
+    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+    (x : f) : t =
+  match Impl.Field.Constant.unpack x with
+  | x0 :: x1 :: y0 :: y1 :: y2 :: y3 :: y4 :: y5 :: y6 :: y7 :: _ ->
+      { proofs_verified = Proofs_verified.of_mask_exn [ x0; x1 ]
+      ; domain_log2 = Domain_log2.of_bits_msb [ y7; y6; y5; y4; y3; y2; y1; y0 ]
+      }
+  | _ ->
+      assert false
+
+module Checked = struct
+  type 'f t =
+    { proofs_verified_mask : 'f Proofs_verified.Checked.t
+    ; domain_log2 : 'f Snarky_backendless.Cvar.t
+    }
+  [@@deriving hlist]
+
+  (* TODO: Make sure the typ checks the number of bits and so on *)
+
+  let pack (type f)
+      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+      ({ proofs_verified_mask; domain_log2 } : f t) : Impl.Field.t =
+    let open Impl.Field in
+    let four = of_int 4 in
+    (four * domain_log2)
+    + pack (Pickles_types.Vector.to_list proofs_verified_mask)
+end
+
+let packed_typ (type f)
+    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) =
+  Impl.Typ.transport Impl.Typ.field
+    ~there:(pack (module Impl))
+    ~back:(unpack (module Impl))
+
+let typ (type f)
+    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+    ~(* We actually only need it to be less than 252 bits in order to pack
+        the whole branch_data struct safely, but it's cheapest to check that it's
+        under 16 bits *)
+    (assert_16_bits : Impl.Field.t -> unit) : (f Checked.t, t) Impl.Typ.t =
+  let open Impl in
+  let proofs_verified_mask :
+      (f Proofs_verified.Checked.t, Proofs_verified.t) Typ.t =
+    Typ.transport
+      (Vector.typ Boolean.typ Nat.N2.n)
+      ~there:Proofs_verified.to_mask ~back:Proofs_verified.of_mask_exn
+  in
+  let domain_log2 : (Field.t, Domain_log2.t) Typ.t =
+    let (Typ t) =
+      Typ.transport Field.typ
+        ~there:(fun (x : char) -> Field.Constant.of_int (Char.to_int x))
+        ~back:(Domain_log2.of_field_exn (module Impl))
+    in
+    let check (x : Field.t) = make_checked (fun () -> assert_16_bits x) in
+    Typ { t with check }
+  in
+  Typ.of_hlistable
+    [ proofs_verified_mask; domain_log2 ]
+    ~value_of_hlist:of_hlist ~value_to_hlist:to_hlist
+    ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
+
+let domain { domain_log2; _ } =
+  Pickles_base.Domain.Pow_2_roots_of_unity (Char.to_int domain_log2)

--- a/src/lib/pickles/composition_types/branch_data.mli
+++ b/src/lib/pickles/composition_types/branch_data.mli
@@ -1,0 +1,66 @@
+open Core_kernel
+
+module Proofs_verified : sig
+  [%%versioned:
+  module Stable : sig
+    module V1 : sig
+      type t = N0 | N1 | N2
+      [@@deriving sexp, sexp, compare, yojson, hash, equal]
+    end
+  end]
+
+  module Checked : sig
+    type 'f boolean = 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
+
+    open Pickles_types
+
+    type 'f t = ('f boolean, Nat.N2.n) Vector.t
+  end
+end
+
+module Domain_log2 : sig
+  [%%versioned:
+  module Stable : sig
+    module V1 : sig
+      type t [@@deriving compare, sexp, yojson, hash, equal]
+    end
+  end]
+
+  val of_int_exn : int -> t
+end
+
+[%%versioned:
+module Stable : sig
+  module V1 : sig
+    type t =
+      { proofs_verified : Proofs_verified.Stable.V1.t
+      ; domain_log2 : Domain_log2.Stable.V1.t
+      }
+    [@@deriving hlist, compare, sexp, yojson, hash, equal]
+  end
+end]
+
+module Checked : sig
+  type 'f t =
+    { proofs_verified_mask : 'f Proofs_verified.Checked.t
+    ; domain_log2 : 'f Snarky_backendless.Cvar.t
+    }
+
+  val pack :
+       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+    -> 'f t
+    -> 'f Snarky_backendless.Cvar.t
+end
+
+val typ :
+     (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> assert_16_bits:('f Snarky_backendless.Cvar.t -> unit)
+  -> ('f Checked.t, t, 'f) Snarky_backendless.Typ.t
+
+val packed_typ :
+     (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> ('f Snarky_backendless.Cvar.t, t, 'f) Snarky_backendless.Typ.t
+
+val length_in_bits : int
+
+val domain : t -> Pickles_base.Domain.t

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -2,6 +2,7 @@ open Pickles_types
 module Scalar_challenge = Kimchi_backend_common.Scalar_challenge
 module Bulletproof_challenge = Bulletproof_challenge
 module Index = Index
+module Branch_data = Branch_data
 module Digest = Digest
 module Spec = Spec
 open Core_kernel
@@ -141,7 +142,7 @@ module Wrap = struct
                , 'fp
                , 'fq
                , 'bulletproof_challenges
-               , 'index )
+               , 'branch_data )
                t =
             { plonk : 'plonk
             ; combined_inner_product : 'fp
@@ -154,8 +155,8 @@ module Wrap = struct
                   (** The challenge used for combining polynomials *)
             ; bulletproof_challenges : 'bulletproof_challenges
                   (** The challenges from the inner-product argument that was partially verified. *)
-            ; which_branch : 'index
-                  (** Which step branch of the proof-system was verified? *)
+            ; branch_data : 'branch_data
+                  (** Data specific to which step branch of the proof-system was verified *)
             }
           [@@deriving sexp, compare, yojson, hlist, hash, equal]
 
@@ -168,21 +169,21 @@ module Wrap = struct
            , 'fp
            , 'fq
            , 'bulletproof_challenges
-           , 'index )
+           , 'branch_data )
            t =
             ( 'plonk
             , 'scalar_challenge
             , 'fp
             , 'fq
             , 'bulletproof_challenges
-            , 'index )
+            , 'branch_data )
             Stable.Latest.t =
         { plonk : 'plonk
         ; combined_inner_product : 'fp
         ; b : 'fp
         ; xi : 'scalar_challenge
         ; bulletproof_challenges : 'bulletproof_challenges
-        ; which_branch : 'index
+        ; branch_data : 'branch_data
         }
       [@@deriving sexp, compare, yojson, hlist, hash, equal]
 
@@ -210,14 +211,14 @@ module Wrap = struct
           ; b : 'fp
           ; xi
           ; bulletproof_challenges
-          ; which_branch
+          ; branch_data
           } ~f ~scalar =
         { xi = scalar xi
         ; combined_inner_product
         ; b
         ; plonk
         ; bulletproof_challenges
-        ; which_branch
+        ; branch_data
         }
 
       module In_circuit = struct
@@ -226,14 +227,14 @@ module Wrap = struct
              , 'fp
              , 'fq
              , 'bulletproof_challenges
-             , 'index )
+             , 'branch_data )
              t =
           ( ('challenge, 'scalar_challenge, 'fp) Plonk.In_circuit.t
           , 'scalar_challenge
           , 'fp
           , 'fq
           , 'bulletproof_challenges
-          , 'index )
+          , 'branch_data )
           Stable.Latest.t
         [@@deriving sexp, compare, yojson, hash, equal]
 
@@ -568,7 +569,7 @@ module Wrap = struct
           ; Vector (Scalar Challenge, Nat.N3.n)
           ; Vector (B Digest, Nat.N3.n)
           ; Vector (B Bulletproof_challenge, Backend.Tick.Rounds.n)
-          ; Vector (B Index, Nat.N1.n)
+          ; Vector (B Branch_data, Nat.N1.n)
           ]
 
       (** Convert a statement (as structured data) into the flat data-based representation. *)
@@ -578,7 +579,7 @@ module Wrap = struct
                    { xi
                    ; combined_inner_product
                    ; b
-                   ; which_branch
+                   ; branch_data
                    ; bulletproof_challenges
                    ; plonk =
                        { alpha
@@ -615,7 +616,7 @@ module Wrap = struct
         let digest =
           [ sponge_digest_before_evaluations; me_only; pass_through ]
         in
-        let index = [ which_branch ] in
+        let index = [ branch_data ] in
         Hlist.HlistId.
           [ fp
           ; challenge
@@ -651,13 +652,13 @@ module Wrap = struct
         let [ sponge_digest_before_evaluations; me_only; pass_through ] =
           digest
         in
-        let [ which_branch ] = index in
+        let [ branch_data ] = index in
         { proof_state =
             { deferred_values =
                 { xi
                 ; combined_inner_product
                 ; b
-                ; which_branch
+                ; branch_data
                 ; bulletproof_challenges
                 ; plonk =
                     { alpha
@@ -962,7 +963,7 @@ module Step = struct
         }
     end
 
-    let typ impl proofs_verified fq :
+    let typ impl ~assert_16_bits proofs_verified fq :
         ( ((_, _) Vector.t, _) t
         , ((_, _) Vector.t, _) t
         , _ )
@@ -972,8 +973,7 @@ module Step = struct
         Vector (Per_proof.In_circuit.spec Backend.Tock.Rounds.n, proofs_verified)
       in
       spec unfinalized_proofs (B Spec.Digest)
-      |> Spec.typ impl fq ~challenge:`Constrained
-           ~scalar_challenge:`Unconstrained
+      |> Spec.typ impl fq ~assert_16_bits
       |> Snarky_backendless.Typ.transport ~there:to_data ~back:of_data
       |> Snarky_backendless.Typ.transport_var ~there:to_data ~back:of_data
   end

--- a/src/lib/pickles/import.ml
+++ b/src/lib/pickles/import.ml
@@ -5,6 +5,7 @@ module Types = Composition_types
 module Digest = Types.Digest
 module Spec = Types.Spec
 module Index = Types.Index
+module Branch_data = Composition_types.Branch_data
 module Step_bp_vec = Types.Step_bp_vec
 module Nvector = Types.Nvector
 module Bulletproof_challenge = Types.Bulletproof_challenge

--- a/src/lib/pickles/one_hot_vector/one_hot_vector.ml
+++ b/src/lib/pickles/one_hot_vector/one_hot_vector.ml
@@ -21,6 +21,8 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
     Boolean.Assert.any (Vector.to_list v) ;
     v
 
+  let of_vector_unsafe = Fn.id
+
   let typ (n : 'n Nat.t) : ('n t, Constant.t) Typ.t =
     let (Typ typ) = Vector.typ Boolean.typ n in
     let typ : _ Typ.t =

--- a/src/lib/pickles/one_hot_vector/one_hot_vector.mli
+++ b/src/lib/pickles/one_hot_vector/one_hot_vector.mli
@@ -16,5 +16,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) : sig
 
   val of_index : Field.t -> length:'n Nat.t -> 'n t
 
+  val of_vector_unsafe : (Impl.Boolean.var, 'n) Vector.t -> 'n t
+
   val typ : 'n Nat.t -> ('n t, Constant.t) Typ.t
 end

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -61,7 +61,7 @@ type ('app_state, 'max_proofs_verified, 'num_branches) t =
       , Digest.Make(Impl).t
       , Challenge.Make(Impl).t Scalar_challenge.t Types.Bulletproof_challenge.t
         Types.Step_bp_vec.t
-      , 'num_branches One_hot_vector.t )
+      , Impl.field Branch_data.Checked.t )
       Types.Wrap.Proof_state.In_circuit.t
         (** The accumulator state corresponding to the above proof. Contains
       - `deferred_values`: The values necessary for finishing the deferred "scalar field" computations.
@@ -100,7 +100,7 @@ module Constant = struct
         , Digest.Constant.t
         , Challenge.Constant.t Scalar_challenge.t Types.Bulletproof_challenge.t
           Types.Step_bp_vec.t
-        , Types.Index.t )
+        , Branch_data.t )
         Types.Wrap.Proof_state.In_circuit.t
     ; prev_proof_evals :
         (Tick.Field.t, Tick.Field.t array) Plonk_types.All_evals.t
@@ -120,10 +120,6 @@ let typ (type n avar aval m) (statement : (avar, aval) Impls.Step.Typ.t)
   let open Impls.Step in
   let open Step_main_inputs in
   let open Step_verifier in
-  let index =
-    Typ.transport (One_hot_vector.typ branches) ~there:Types.Index.to_int
-      ~back:(fun x -> Option.value_exn (Types.Index.of_int x))
-  in
   Snarky_backendless.Typ.of_hlistable ~var_to_hlist:to_hlist
     ~var_of_hlist:of_hlist ~value_to_hlist:Constant.to_hlist
     ~value_of_hlist:Constant.of_hlist
@@ -134,7 +130,10 @@ let typ (type n avar aval m) (statement : (avar, aval) Impls.Step.Typ.t)
         (Shifted_value.Type1.typ Field.typ)
         Other_field.typ
         (Snarky_backendless.Typ.unit ())
-        Digest.typ index
+        Digest.typ
+        (Branch_data.typ
+           (module Impl)
+           ~assert_16_bits:(Step_verifier.assert_n_bits ~n:16))
     ; (let lengths = Evaluation_lengths.create ~of_int:Fn.id in
        Plonk_types.All_evals.typ lengths Field.typ ~default:Field.Constant.zero)
     ; Vector.typ (Vector.typ Field.typ Tick.Rounds.n) max_proofs_verified

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1144,7 +1144,8 @@ let%test_module "test no side-loaded" =
       let example =
         let s_neg_one = Field.Constant.(negate one) in
         let b_neg_one : (Nat.N1.n, Nat.N1.n) Proof0.t =
-          Proof0.dummy Nat.N1.n Nat.N1.n Nat.N1.n
+          Proof0.dummy Nat.N1.n Nat.N1.n Nat.N1.n ~domain_log2:14
+            ~proofs_verified:N1
         in
         let b0 =
           Common.time "b0" (fun () ->
@@ -1213,7 +1214,8 @@ let%test_module "test no side-loaded" =
       let example =
         let s_neg_one = Field.Constant.(negate one) in
         let b_neg_one : (Nat.N2.n, Nat.N2.n) Proof0.t =
-          Proof0.dummy Nat.N2.n Nat.N2.n Nat.N2.n
+          Proof0.dummy Nat.N2.n Nat.N2.n Nat.N2.n ~domain_log2:15
+            ~proofs_verified:N2
         in
         let b0 =
           Common.time "tree b0" (fun () ->

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -693,9 +693,8 @@ module Make (A : Statement_var_intf) (A_value : Statement_value_intf) = struct
       in
       let r =
         Common.time "wrap read or generate " (fun () ->
-            Cache.Wrap.read_or_generate
-              (Vector.to_array step_domains)
-              cache disk_key_prover disk_key_verifier typ main)
+            Cache.Wrap.read_or_generate cache disk_key_prover disk_key_verifier
+              typ main)
       in
       (r, disk_key_verifier)
     in
@@ -836,11 +835,6 @@ module Side_loaded = struct
       ; wrap_index = Lazy.force d.wrap_key
       ; max_width =
           Width.of_int_exn (Nat.to_int (Nat.Add.n d.max_proofs_verified))
-      ; step_data =
-          At_most.of_vector
-            (Vector.map2 d.proofs_verifieds d.step_domains ~f:(fun width ds ->
-                 ({ Domains.h = ds.h }, Width.of_int_exn width)))
-            (Nat.lte_exn (Vector.length d.step_domains) Max_branches.n)
       }
 
     module Max_width = Width.Max
@@ -881,9 +875,6 @@ module Side_loaded = struct
         List.map ts ~f:(fun (vk, x, p) ->
             let vk : V.t =
               { commitments = vk.wrap_index
-              ; step_domains =
-                  Array.map (At_most.to_array vk.step_data) ~f:(fun (d, w) ->
-                      { Domains.h = d.h })
               ; index =
                   ( match vk.wrap_vk with
                   | None ->

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -766,7 +766,7 @@ module Make (A : Statement_var_intf) (A_value : Statement_value_intf) = struct
             Wrap.wrap ~max_proofs_verified:Max_proofs_verified.n
               full_signature.maxes wrap_requests
               ~dlog_plonk_index:wrap_vk.commitments wrap_main
-              A_value.to_field_elements ~step_vk ~step_domains:b.domains
+              A_value.to_field_elements ~step_vk
               ~step_plonk_indices:(Lazy.force step_vks) ~wrap_domains
               (Impls.Wrap.Keypair.pk (fst (Lazy.force wrap_pk)))
               proof

--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -73,7 +73,13 @@ end
 module Proof : sig
   type ('max_width, 'mlmb) t
 
-  val dummy : 'w Nat.t -> 'm Nat.t -> _ Nat.t -> ('w, 'm) t
+  val dummy :
+       'w Nat.t
+    -> 'm Nat.t
+    -> _ Nat.t
+    -> proofs_verified:Composition_types.Branch_data.Proofs_verified.t
+    -> domain_log2:int
+    -> ('w, 'm) t
 
   module Make (W : Nat.Intf) (MLMB : Nat.Intf) : sig
     type nonrec t = (W.n, MLMB.n) t [@@deriving sexp, compare, yojson, hash]

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -11,8 +11,7 @@ type 'field vanishing_polynomial_domain =
 type 'field plonk_domain =
   < vanishing_polynomial : 'field -> 'field
   ; shifts : 'field Plonk_types.Shifts.t
-  ; generator : 'field
-  ; size : 'field >
+  ; generator : 'field >
 
 type 'field domain = < size : 'field ; vanishing_polynomial : 'field -> 'field >
 
@@ -55,13 +54,10 @@ let vanishing_polynomial (type t) ((module F) : t field) domain x =
 
 let domain (type t) ((module F) : t field) ~shifts ~domain_generator
     (domain : Domain.t) : t plonk_domain =
-  let size = F.of_int (Domain.size domain) in
   let log2_size = Domain.log2_size domain in
   let shifts = shifts ~log2_size in
   let generator = domain_generator ~log2_size in
   object
-    method size = size
-
     method shifts = shifts
 
     method vanishing_polynomial x = vanishing_polynomial (module F) domain x

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -60,7 +60,7 @@ module Base = struct
                 Scalar_challenge.Stable.V2.t
                 Bulletproof_challenge.Stable.V1.t
                 Step_bp_vec.Stable.V1.t
-              , Index.Stable.V1.t )
+              , Branch_data.Stable.V1.t )
               Types.Wrap.Statement.Minimal.Stable.V1.t
           ; prev_evals :
               ( Tick.Field.Stable.V1.t
@@ -84,7 +84,7 @@ module Base = struct
           , 'step_me_only
           , Challenge.Constant.t Scalar_challenge.t Bulletproof_challenge.t
             Step_bp_vec.t
-          , Index.t )
+          , Branch_data.t )
           Types.Wrap.Statement.Minimal.t
       ; prev_evals : (Tick.Field.t, Tick.Field.t array) Plonk_types.All_evals.t
       ; proof : Tock.Proof.t
@@ -114,7 +114,7 @@ end
 type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) With_data.t
 
 let dummy (type w h r) (_w : w Nat.t) (h : h Nat.t)
-    (most_recent_width : r Nat.t) : (w, h) t =
+    (most_recent_width : r Nat.t) ~proofs_verified ~domain_log2 : (w, h) t =
   let open Ro in
   let g0 = Tock.Curve.(to_affine_exn one) in
   let g len = Array.create ~len g0 in
@@ -127,7 +127,11 @@ let dummy (type w h r) (_w : w Nat.t) (h : h Nat.t)
                 { xi = scalar_chal ()
                 ; combined_inner_product = Shifted_value (tick ())
                 ; b = Shifted_value (tick ())
-                ; which_branch = Option.value_exn (Index.of_int 0)
+                ; branch_data =
+                    { proofs_verified
+                    ; domain_log2 =
+                        Branch_data.Domain_log2.of_int_exn domain_log2
+                    }
                 ; bulletproof_challenges = Dummy.Ipa.Step.challenges
                 ; plonk =
                     { alpha = scalar_chal ()

--- a/src/lib/pickles/pseudo/pseudo.ml
+++ b/src/lib/pickles/pseudo/pseudo.ml
@@ -57,8 +57,6 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
 
     let to_domain ~shifts:s ~domain_generator (type n) (t : n t) :
         Field.t Plonk_checks.plonk_domain =
-      (* TODO: Special case when all the domains happen to be the same. *)
-      let size = seal (choose t ~f:(fun d -> Field.of_int (Domain.size d))) in
       let log2_sizes = Vector.map (snd t) ~f:Domain.log2_size in
       let shifts = shifts (fst t, log2_sizes) ~shifts:s in
       let generator = generator (fst t, log2_sizes) ~domain_generator in
@@ -68,8 +66,6 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
             Int.max acc (Domain.log2_size d))
       in
       object
-        method size = size
-
         method shifts = shifts
 
         method generator = generator

--- a/src/lib/pickles/requests.ml
+++ b/src/lib/pickles/requests.ml
@@ -23,6 +23,7 @@ module Wrap = struct
           , max_proofs_verified )
           Vector.t
           t
+      | Which_branch : Index.t t
       | Step_accs : (Tock.Inner_curve.Affine.t, max_proofs_verified) Vector.t t
       | Old_bulletproof_challenges :
           max_local_max_proofs_verifieds H1.T(Challenges_vector.Constant).t t
@@ -68,6 +69,7 @@ module Wrap = struct
       type _ t +=
         | Evals :
             (Tock.Field.t, Tock.Field.t array) Plonk_types.All_evals.t vec t
+        | Which_branch : Index.t t
         | Step_accs : Tock.Inner_curve.Affine.t vec t
         | Old_bulletproof_challenges :
             max_local_max_proofs_verifieds H1.T(Challenges_vector.Constant).t t

--- a/src/lib/pickles/scalar_challenge.ml
+++ b/src/lib/pickles/scalar_challenge.ml
@@ -49,6 +49,7 @@ let to_field_checked' (type f) ?(num_bits = num_bits)
   in
   let nybbles_per_row = 8 in
   let bits_per_row = 2 * nybbles_per_row in
+  [%test_eq: int] (num_bits mod bits_per_row) 0 ;
   let rows = num_bits / bits_per_row in
   let nybbles_by_row =
     lazy

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -143,14 +143,8 @@ module Domains = struct
       ~var_of_hlist:of_hlist ~value_of_hlist:of_hlist
 end
 
-(* TODO: Probably better to have these match the step rounds. *)
-let max_domains = { Domains.h = Domain.Pow_2_roots_of_unity 20 }
-
-let max_domains_with_x =
-  let conv (Domain.Pow_2_roots_of_unity n) =
-    Plonk_checks.Domain.Pow_2_roots_of_unity n
-  in
-  { Ds.h = conv max_domains.h }
+let max_domains =
+  { Domains.h = Domain.Pow_2_roots_of_unity (Nat.to_int Backend.Tick.Rounds.n) }
 
 module Vk = struct
   type t = (Impls.Wrap.Verification_key.t[@sexp.opaque]) [@@deriving sexp]
@@ -193,12 +187,11 @@ module Stable = struct
 
       let version_byte = Base58_check.Version_bytes.verification_key
 
-      let to_repr { Poly.step_data; max_width; wrap_index; wrap_vk = _ } =
-        { Repr.Stable.V2.step_data; max_width; wrap_index }
+      let to_repr { Poly.max_width; wrap_index; wrap_vk = _ } =
+        { Repr.Stable.V2.max_width; wrap_index }
 
-      let of_repr
-          ({ Repr.Stable.V2.step_data; max_width; wrap_index = c } :
-            R.Stable.V2.t) : t =
+      let of_repr ({ Repr.Stable.V2.max_width; wrap_index = c } : R.Stable.V2.t)
+          : t =
         let d =
           (Common.wrap_domains ~proofs_verified:(Width.to_int max_width)).h
         in
@@ -238,7 +231,7 @@ module Stable = struct
               ; lookup_index = None
               })
         in
-        { Poly.step_data; max_width; wrap_index = c; wrap_vk }
+        { Poly.max_width; wrap_index = c; wrap_vk }
 
       (* Proxy derivers to [R.t]'s, ignoring [wrap_vk] *)
 
@@ -283,8 +276,7 @@ Stable.Latest.
   , compare )]
 
 let dummy : t =
-  { step_data = At_most.[]
-  ; max_width = Width.zero
+  { max_width = Width.zero
   ; wrap_index =
       (let g = Backend.Tock.Curve.(to_affine_exn one) in
        { sigma_comm = Vector.init Plonk_types.Permuts.n ~f:(fun _ -> g)
@@ -304,18 +296,13 @@ module Checked = struct
   open Impl
 
   type t =
-    { step_domains : (Field.t Domain.t Domains.t, Max_branches.n) Vector.t
-          (** The domain size for proofs of each branch. *)
-    ; step_widths : (Width.Checked.t, Max_branches.n) Vector.t
-          (** The width for for proofs of each branch. *)
-    ; max_width : Width.Checked.t
+    { (* TODO: Not sure this is used *)
+      max_width : Width.Checked.t
           (** The maximum of all of the [step_widths]. *)
     ; wrap_index : Inner_curve.t Plonk_verification_key_evals.t
           (** The plonk verification key for the 'wrapping' proof that this key
               is used to verify.
           *)
-    ; num_branches : (Boolean.var, Max_branches.Log2.n) Vector.t
-          (** The number of branches, encoded as a bitstring. *)
     }
   [@@deriving hlist, fields]
 
@@ -324,22 +311,13 @@ module Checked = struct
 
   let to_input =
     let open Random_oracle_input.Chunked in
-    let map_reduce t ~f = Array.map t ~f |> Array.reduce_exn ~f:append in
-    fun { step_domains; step_widths; max_width; wrap_index; num_branches } :
-        _ Random_oracle_input.Chunked.t ->
+    fun { max_width; wrap_index } : _ Random_oracle_input.Chunked.t ->
       let width w = (Width.Checked.to_field w, width_size) in
       List.reduce_exn ~f:append
-        [ map_reduce (Vector.to_array step_domains) ~f:(fun { Domains.h } ->
-              map_reduce [| h |] ~f:(fun (Domain.Pow_2_roots_of_unity x) ->
-                  packed (x, max_log2_degree)))
-        ; Array.map (Vector.to_array step_widths) ~f:width |> packeds
-        ; packed (width max_width)
+        [ packed (width max_width)
         ; wrap_index_to_input
             (Fn.compose Array.of_list Inner_curve.to_field_elements)
             wrap_index
-        ; packed
-            ( Field.project (Vector.to_list num_branches)
-            , Nat.to_int Max_branches.Log2.n )
         ]
 end
 
@@ -360,24 +338,9 @@ let typ : (Checked.t, t) Impls.Step.Typ.t =
   let open Step_main_inputs in
   let open Impl in
   Typ.of_hlistable
-    [ Vector.typ Domains.typ Max_branches.n
-    ; Vector.typ Width.typ Max_branches.n
-    ; Width.typ
-    ; Plonk_verification_key_evals.typ Inner_curve.typ
-    ; Vector.typ Boolean.typ Max_branches.Log2.n
-    ]
+    [ Width.typ; Plonk_verification_key_evals.typ Inner_curve.typ ]
     ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
     ~value_of_hlist:(fun _ ->
       failwith "Side_loaded_verification_key: value_of_hlist")
-    ~value_to_hlist:(fun { Poly.step_data; wrap_index; max_width; _ } ->
-      [ At_most.extend_to_vector
-          (At_most.map step_data ~f:fst)
-          dummy_domains Max_branches.n
-      ; At_most.extend_to_vector
-          (At_most.map step_data ~f:snd)
-          dummy_width Max_branches.n
-      ; max_width
-      ; wrap_index
-      ; (let n = At_most.length step_data in
-         Vector.init Max_branches.Log2.n ~f:(fun i -> (n lsr i) land 1 = 1))
-      ])
+    ~value_to_hlist:(fun { Poly.wrap_index; max_width; _ } ->
+      [ max_width; wrap_index ])

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -108,7 +108,7 @@ struct
         , Digest.Constant.t
         , Challenge.Constant.t Scalar_challenge.t Bulletproof_challenge.t
           Step_bp_vec.t
-        , Index.t )
+        , Branch_data.t )
         Wrap.Statement.In_circuit.t
     end in
     let challenge_polynomial =
@@ -139,11 +139,8 @@ struct
         let plonk0 = t.statement.proof_state.deferred_values.plonk in
         let plonk =
           let domain =
-            (Vector.to_array (Types_map.lookup_step_domains tag)).(Index.to_int
-                                                                     t.statement
-                                                                       .proof_state
-                                                                       .deferred_values
-                                                                       .which_branch)
+            Branch_data.domain
+              t.statement.proof_state.deferred_values.branch_data
           in
           let to_field =
             SC.to_field_constant

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -84,12 +84,17 @@ struct
   let scalar_to_field s =
     SC.to_field_checked (module Impl) s ~endo:Endo.Wrap_inner_curve.scalar
 
+  let assert_n_bits ~n a =
+    (* Scalar_challenge.to_field_checked has the side effect of
+        checking that the input fits in n bits. *)
+    ignore
+      ( SC.to_field_checked
+          (module Impl)
+          (SC.SC.create a) ~endo:Endo.Wrap_inner_curve.scalar ~num_bits:n
+        : Field.t )
+
   let lowest_128_bits ~constrain_low_bits x =
-    let assert_128_bits a =
-      (* Scalar_challenge.to_field_checked has the side effect of
-         checking that the input fits in 128 bits. *)
-      ignore (scalar_to_field (SC.SC.create a) : Field.t)
-    in
+    let assert_128_bits = assert_n_bits ~n:128 in
     Util.lowest_128_bits ~constrain_low_bits ~assert_128_bits (module Impl) x
 
   module Scalar_challenge =

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -482,53 +482,11 @@ struct
 
   module O = One_hot_vector.Make (Impl)
 
-  let side_loaded_input_domain =
+  let side_loaded_domain (type branches) =
     let open Side_loaded_verification_key in
-    let input_size = input_size ~of_int:Fn.id ~add:( + ) ~mul:( * ) in
-    let max_width = Width.Max.n in
-    let domain_log2s =
-      Vector.init (S max_width) ~f:(fun w -> Int.ceil_log2 (input_size w))
-    in
-    let (T max_log2_size) =
-      let n = Int.ceil_log2 (input_size (Nat.to_int max_width)) in
-      assert (List.last_exn (Vector.to_list domain_log2s) = n) ;
-      Nat.of_int n
-    in
-    fun ~width ->
-      let mask = O.of_index width ~length:(S max_width) in
-      let shifts = lazy (Pseudo.Domain.shifts (mask, domain_log2s) ~shifts) in
-      let generator =
-        lazy (Pseudo.Domain.generator (mask, domain_log2s) ~domain_generator)
-      in
-      let vp =
-        let log2_size = Pseudo.choose (mask, domain_log2s) ~f:Field.of_int in
-        let mask =
-          ones_vector (module Impl) max_log2_size ~first_zero:log2_size
-        in
-        vanishing_polynomial mask
-      in
-      let size =
-        lazy
-          (Pseudo.choose (mask, domain_log2s) ~f:(fun x ->
-               Field.of_int (1 lsl x)))
-      in
-      object
-        method shifts = Lazy.force shifts
-
-        method generator = Lazy.force generator
-
-        method size = Lazy.force size
-
-        method vanishing_polynomial = vp
-      end
-
-  let side_loaded_domains (type branches) =
-    let open Side_loaded_verification_key in
-    fun (domains : (Field.t Domain.t Domains.t, branches) Vector.t)
-        (branch : branches One_hot_vector.T(Impl).t) ->
-      let domain v ~max =
+    fun ~(log2_size : Field.t) ->
+      let domain ~max =
         let (T max_n) = Nat.of_int max in
-        let log2_size = Pseudo.choose ~f:Domain.log2_size (branch, v) in
         let mask = ones_vector (module Impl) max_n ~first_zero:log2_size in
         let log2_sizes =
           (O.of_index log2_size ~length:max_n, Vector.init max_n ~f:Fn.id)
@@ -536,16 +494,7 @@ struct
         let shifts = Pseudo.Domain.shifts log2_sizes ~shifts in
         let generator = Pseudo.Domain.generator log2_sizes ~domain_generator in
         let vanishing_polynomial = vanishing_polynomial mask in
-        let size =
-          Vector.map mask ~f:(fun b ->
-              (* 0 -> 1
-                  1 -> 2 *)
-              Field.((b :> t) + one))
-          |> Vector.reduce_exn ~f:Field.( * )
-        in
         object
-          method size = size
-
           method log2_size = log2_size
 
           method vanishing_polynomial x = vanishing_polynomial x
@@ -555,11 +504,7 @@ struct
           method generator = generator
         end
       in
-      { Domains.h =
-          domain
-            (Vector.map domains ~f:(fun { h; _ } -> h))
-            ~max:(Domain.log2_size max_domains.h)
-      }
+      domain ~max:(Domain.log2_size max_domains.h)
 
   let%test_module "side loaded domains" =
     ( module struct
@@ -572,61 +517,23 @@ struct
         in
         y
 
-      let%test_unit "side loaded input domain" =
+      let%test_unit "side loaded domains" =
+        let module O = One_hot_vector.Make (Impl) in
         let open Side_loaded_verification_key in
-        let input_size = input_size ~of_int:Fn.id ~add:( + ) ~mul:( * ) in
-        let possibilities =
-          Vector.init (S Width.Max.n) ~f:(fun w -> Int.ceil_log2 (input_size w))
-        in
+        let domains = [ { Domains.h = 10 }; { h = 15 } ] in
         let pt = Field.Constant.random () in
-        List.iteri (Vector.to_list possibilities) ~f:(fun i d ->
+        List.iteri domains ~f:(fun i ds ->
             let d_unchecked =
               Plonk_checks.domain
                 (module Field.Constant)
-                (Pow_2_roots_of_unity d) ~shifts:Common.tick_shifts
+                (Pow_2_roots_of_unity ds.h) ~shifts:Common.tick_shifts
                 ~domain_generator:Backend.Tick.Field.domain_generator
             in
-            let checked_domain () =
-              side_loaded_input_domain ~width:(Field.of_int i)
-            in
+            let checked_domain () = side_loaded_domain (Field.of_int ds.h) in
             [%test_eq: Field.Constant.t]
               (d_unchecked#vanishing_polynomial pt)
               (run (fun () ->
                    (checked_domain ())#vanishing_polynomial (Field.constant pt))))
-
-      let%test_unit "side loaded domains" =
-        let module O = One_hot_vector.Make (Impl) in
-        let open Side_loaded_verification_key in
-        let branches = Nat.N2.n in
-        let domains = Vector.[ { Domains.h = 10 }; { h = 15 } ] in
-        let pt = Field.Constant.random () in
-        List.iteri (Vector.to_list domains) ~f:(fun i ds ->
-            let check field1 field2 =
-              let d_unchecked =
-                Plonk_checks.domain
-                  (module Field.Constant)
-                  (Pow_2_roots_of_unity (field1 ds))
-                  ~shifts:Common.tick_shifts
-                  ~domain_generator:Backend.Tick.Field.domain_generator
-              in
-              let checked_domain () =
-                side_loaded_domains
-                  (Vector.map domains
-                     ~f:
-                       (Domains.map ~f:(fun x ->
-                            Domain.Pow_2_roots_of_unity (Field.of_int x))))
-                  (O.of_index (Field.of_int i) ~length:branches)
-                |> field2
-              in
-              [%test_eq: Field.Constant.t] d_unchecked#size
-                (run (fun () -> (checked_domain ())#size)) ;
-              [%test_eq: Field.Constant.t]
-                (d_unchecked#vanishing_polynomial pt)
-                (run (fun () ->
-                     (checked_domain ())#vanishing_polynomial
-                       (Field.constant pt)))
-            in
-            check Domains.h Domains.h)
     end )
 
   module Split_evaluations = struct
@@ -751,6 +658,28 @@ struct
     include Plonk_checks.Make (Shifted_value.Type1) (Plonk_checks.Scalars.Tick)
   end
 
+  let domain_for_compiled (type branches)
+      (domains : (Domains.t, branches) Vector.t)
+      (branch_data : Impl.field Branch_data.Checked.t) :
+      Field.t Plonk_checks.plonk_domain =
+    let (T unique_domains) =
+      List.map (Vector.to_list domains) ~f:Domains.h
+      |> List.dedup_and_sort ~compare:(fun d1 d2 ->
+             Int.compare (Domain.log2_size d1) (Domain.log2_size d2))
+      |> Vector.of_list
+    in
+    let which_log2 =
+      Vector.map unique_domains ~f:(fun d ->
+          Field.equal
+            (Field.of_int (Domain.log2_size d))
+            branch_data.domain_log2)
+      |> O.of_vector_unsafe
+      (* This should be ok... think it through a little more *)
+    in
+    Pseudo.Domain.to_domain
+      (which_log2, unique_domains)
+      ~shifts ~domain_generator
+
   (* This finalizes the "deferred values" coming from a previous proof over the same field.
      It
      1. Checks that [xi] and [r] where sampled correctly. I.e., by absorbing all the
@@ -765,19 +694,14 @@ struct
   let finalize_other_proof (type b branches)
       (module Proofs_verified : Nat.Add.Intf with type n = b) ~max_width
       ~(step_domains :
-         [ `Known of (Domains.t, branches) Vector.t
-         | `Side_loaded of
-           ( Field.t Side_loaded_verification_key.Domain.t
-             Side_loaded_verification_key.Domains.t
-           , branches )
-           Vector.t ]) ~step_widths
+         [ `Known of (Domains.t, branches) Vector.t | `Side_loaded ])
       ~(* TODO: Add "actual proofs verified" so that proofs don't
           carry around dummy "old bulletproof challenges" *)
       sponge ~(prev_challenges : (_, b) Vector.t)
       ({ xi
        ; combined_inner_product
        ; bulletproof_challenges
-       ; which_branch
+       ; branch_data
        ; b
        ; plonk
        } :
@@ -786,7 +710,7 @@ struct
         , Field.t Shifted_value.Type1.t
         , _
         , _
-        , _ )
+        , Field.Constant.t Branch_data.Checked.t )
         Types.Wrap.Proof_state.Deferred_values.In_circuit.t)
       { Plonk_types.All_evals.ft_eval1
       ; evals =
@@ -794,15 +718,7 @@ struct
           , { evals = evals2; public_input = x_hat2 } )
       } =
     let open Vector in
-    let step_domains =
-      with_label "step_domains" (fun () ->
-          match step_domains with
-          | `Known domains ->
-              `Known domains
-          | `Side_loaded ds ->
-              `Side_loaded (side_loaded_domains ds which_branch))
-    in
-    let actual_width = Pseudo.choose (which_branch, step_widths) ~f:Fn.id in
+    let actual_width_mask = branch_data.proofs_verified_mask in
     let T = Proofs_verified.eq in
     (* You use the NEW bulletproof challenges to check b. Not the old ones. *)
     let absorb_evals x_hat e =
@@ -832,10 +748,10 @@ struct
     let domain =
       match step_domains with
       | `Known ds ->
-          let hs = map ds ~f:(fun { Domains.h; _ } -> h) in
-          Pseudo.Domain.to_domain (which_branch, hs) ~shifts ~domain_generator
-      | `Side_loaded { h } ->
-          (h :> _ Plonk_checks.plonk_domain)
+          domain_for_compiled ds branch_data
+      | `Side_loaded ->
+          ( side_loaded_domain ~log2_size:branch_data.domain_log2
+            :> _ Plonk_checks.plonk_domain )
     in
     let zetaw = Field.mul domain#generator plonk.zeta in
     let xi = scalar xi in
@@ -882,9 +798,8 @@ struct
           let a, b = Evals.to_vectors (e : Field.t array Evals.t) in
           let sg_evals =
             Vector.map2
-              (ones_vector
-                 (module Impl)
-                 ~first_zero:actual_width Proofs_verified.n)
+              (Vector.trim actual_width_mask
+                 (Nat.lte_exn Proofs_verified.n Nat.N2.n))
               sg_olds
               ~f:(fun keep f -> [| (keep, f pt) |])
           in
@@ -899,7 +814,7 @@ struct
           | `Known _ ->
               Split_evaluations.combine_split_evaluations' pi ~xi
                 ~evaluation_point:pt v b
-          | `Side_loaded _ ->
+          | `Side_loaded ->
               Split_evaluations.combine_split_evaluations_side_loaded pi ~xi
                 ~evaluation_point:pt v b
         in
@@ -985,22 +900,16 @@ struct
         ~f:(fun x -> Sponge.absorb sponge (`Field x)) ;
       sponge
     in
-    stage (fun t ~widths ~max_width ~which_branch ->
-        let mask =
-          ones_vector
-            (module Impl)
-            max_width
-            ~first_zero:(Pseudo.choose ~f:Fn.id (which_branch, widths))
-        in
+    stage (fun t ~widths ~max_width ~proofs_verified_mask ->
         let sponge = Sponge.copy after_index in
         let t =
           { t with
             old_bulletproof_challenges =
-              Vector.map2 mask t.old_bulletproof_challenges ~f:(fun b v ->
-                  Vector.map v ~f:(fun x -> `Opt (b, x)))
+              Vector.map2 proofs_verified_mask t.old_bulletproof_challenges
+                ~f:(fun b v -> Vector.map v ~f:(fun x -> `Opt (b, x)))
           ; challenge_polynomial_commitments =
-              Vector.map2 mask t.challenge_polynomial_commitments ~f:(fun b g ->
-                  (b, g))
+              Vector.map2 proofs_verified_mask
+                t.challenge_polynomial_commitments ~f:(fun b g -> (b, g))
           }
         in
         let not_opt x = `Not_opt x in

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -146,19 +146,14 @@ module For_step = struct
     { branches : 'branches Nat.t
     ; max_proofs_verified :
         (module Nat.Add.Intf with type n = 'max_proofs_verified)
-    ; proofs_verifieds : (Impls.Step.Field.t, 'branches) Vector.t
+    ; proofs_verifieds :
+        [ `Known of (Impls.Step.Field.t, 'branches) Vector.t | `Side_loaded ]
     ; typ : ('a_var, 'a_value) Impls.Step.Typ.t
     ; value_to_field_elements : 'a_value -> Tick.Field.t array
     ; var_to_field_elements : 'a_var -> Impls.Step.Field.t array
     ; wrap_key : inner_curve_var Plonk_verification_key_evals.t
     ; wrap_domains : Domains.t
-    ; step_domains :
-        [ `Known of (Domains.t, 'branches) Vector.t
-        | `Side_loaded of
-          ( Impls.Step.Field.t Side_loaded_verification_key.Domain.t
-            Side_loaded_verification_key.Domains.t
-          , 'branches )
-          Vector.t ]
+    ; step_domains : [ `Known of (Domains.t, 'branches) Vector.t | `Side_loaded ]
     ; max_width : Side_loaded_verification_key.Width.Checked.t option
     }
 
@@ -183,9 +178,7 @@ module For_step = struct
     let T = Nat.eq_exn branches Side_loaded_verification_key.Max_branches.n in
     { branches
     ; max_proofs_verified
-    ; proofs_verifieds =
-        Vector.map index.step_widths
-          ~f:Side_loaded_verification_key.Width.Checked.to_field
+    ; proofs_verifieds = `Side_loaded
     ; typ
     ; value_to_field_elements
     ; var_to_field_elements
@@ -193,7 +186,7 @@ module For_step = struct
     ; wrap_domains =
         Common.wrap_domains
           ~proofs_verified:(Nat.to_int (Nat.Add.n max_proofs_verified))
-    ; step_domains = `Side_loaded index.step_domains
+    ; step_domains = `Side_loaded
     ; max_width = Some index.max_width
     }
 
@@ -212,7 +205,8 @@ module For_step = struct
     { branches
     ; max_width = None
     ; max_proofs_verified
-    ; proofs_verifieds = Vector.map proofs_verifieds ~f:Impls.Step.Field.of_int
+    ; proofs_verifieds =
+        `Known (Vector.map proofs_verifieds ~f:Impls.Step.Field.of_int)
     ; typ
     ; value_to_field_elements
     ; var_to_field_elements
@@ -258,25 +252,6 @@ let lookup_basic : type a b n m. (a, b, n, m) Tag.t -> (a, b, n, m) Basic.t =
       Compiled.to_basic (lookup_compiled t.id)
   | Side_loaded ->
       Side_loaded.to_basic (lookup_side_loaded t.id)
-
-let lookup_step_domains :
-    type a b n m. (a, b, n, m) Tag.t -> (Domain.t, m) Vector.t =
- fun t ->
-  let f = Vector.map ~f:Domains.h in
-  match t.kind with
-  | Compiled ->
-      f (lookup_compiled t.id).step_domains
-  | Side_loaded -> (
-      let t = lookup_side_loaded t.id in
-      match t.ephemeral with
-      | Some { index = `In_circuit _ } | None ->
-          failwith __LOC__
-      | Some { index = `In_prover k } ->
-          let a =
-            At_most.to_array (At_most.map k.step_data ~f:(fun (ds, _) -> ds.h))
-          in
-          Vector.init t.permanent.branches ~f:(fun i ->
-              try a.(i) with _ -> Domain.Pow_2_roots_of_unity 0) )
 
 let max_proofs_verified :
     type n1. (_, _, n1, _) Tag.t -> (module Nat.Add.Intf with type n = n1) =

--- a/src/lib/pickles/verification_key.ml
+++ b/src/lib/pickles/verification_key.ml
@@ -84,7 +84,6 @@ module Repr = struct
         { commitments :
             Backend.Tock.Curve.Affine.Stable.V1.t
             Plonk_verification_key_evals.Stable.V2.t
-        ; step_domains : Domains.Stable.V2.t array
         ; data : Data.Stable.V1.t
         }
       [@@deriving to_yojson]
@@ -99,7 +98,6 @@ module Stable = struct
   module V2 = struct
     type t =
       { commitments : Backend.Tock.Curve.Affine.t Plonk_verification_key_evals.t
-      ; step_domains : Domains.t array
       ; index :
           (Impls.Wrap.Verification_key.t
           [@to_yojson
@@ -111,7 +109,7 @@ module Stable = struct
 
     let to_latest = Fn.id
 
-    let of_repr srs { Repr.commitments = c; step_domains; data = d } =
+    let of_repr srs { Repr.commitments = c; data = d } =
       let t : Impls.Wrap.Verification_key.t =
         let log2_size = Int.ceil_log2 d.constraints in
         let d = Domain.Pow_2_roots_of_unity log2_size in
@@ -144,15 +142,15 @@ module Stable = struct
         ; lookup_index = None
         }
       in
-      { commitments = c; step_domains; data = d; index = t }
+      { commitments = c; data = d; index = t }
 
     include Binable.Of_binable
               (Repr.Stable.V2)
               (struct
                 type nonrec t = t
 
-                let to_binable { commitments; step_domains; data; index = _ } =
-                  { Repr.commitments; data; step_domains }
+                let to_binable { commitments; data; index = _ } =
+                  { Repr.commitments; data }
 
                 let of_binable r = of_repr (Backend.Tock.Keypair.load_urs ()) r
               end)
@@ -178,8 +176,5 @@ let dummy =
   lazy
     (let rows = Domain.size (Common.wrap_domains ~proofs_verified:2).h in
      let g = Backend.Tock.Curve.(to_affine_exn one) in
-     { Repr.commitments = dummy_commitments g
-     ; step_domains = [||]
-     ; data = { constraints = rows }
-     }
+     { Repr.commitments = dummy_commitments g; data = { constraints = rows } }
      |> Stable.Latest.of_repr (Kimchi_bindings.Protocol.SRS.Fq.create 1))

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -74,7 +74,7 @@ let verify_heterogenous (ts : Instance.t list) =
         let { Deferred_values.xi
             ; plonk = plonk0
             ; combined_inner_product
-            ; which_branch
+            ; branch_data
             ; bulletproof_challenges
             } =
           Deferred_values.map_challenges ~f:Challenge.Constant.to_tick_field
@@ -82,10 +82,9 @@ let verify_heterogenous (ts : Instance.t list) =
         in
         let zeta = sc plonk0.zeta in
         let alpha = sc plonk0.alpha in
-        let step_domains = key.step_domains.(Index.to_int which_branch) in
+        let step_domain = Branch_data.domain branch_data in
         let w =
-          Tick.Field.domain_generator
-            ~log2_size:(Domain.log2_size step_domains.h)
+          Tick.Field.domain_generator ~log2_size:(Domain.log2_size step_domain)
         in
         let zetaw = Tick.Field.mul zeta w in
         let tick_plonk_minimal :
@@ -103,7 +102,7 @@ let verify_heterogenous (ts : Instance.t list) =
         let tick_domain =
           Plonk_checks.domain
             (module Tick.Field)
-            step_domains.h ~shifts:Common.tick_shifts
+            step_domain ~shifts:Common.tick_shifts
             ~domain_generator:Backend.Tick.Field.domain_generator
         in
         let tick_env =
@@ -178,7 +177,7 @@ let verify_heterogenous (ts : Instance.t list) =
             ~old_bulletproof_challenges:
               (Vector.map ~f:Ipa.Step.compute_challenges
                  statement.pass_through.old_bulletproof_challenges)
-            ~r:r_actual ~xi ~zeta ~zetaw ~step_branch_domains:step_domains
+            ~r:r_actual ~xi ~zeta ~zetaw
         in
         let check_eq lab x y =
           check

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -36,8 +36,7 @@ let combined_inner_product (type actual_proofs_verified) ~env ~domain ~ft_eval1
     ~actual_proofs_verified:
       (module AB : Nat.Add.Intf with type n = actual_proofs_verified) (e1, e2)
     ~(old_bulletproof_challenges : (_, actual_proofs_verified) Vector.t) ~r
-    ~plonk ~xi ~zeta ~zetaw ~x_hat:(x_hat_1, x_hat_2)
-    ~(step_branch_domains : Domains.t) =
+    ~plonk ~xi ~zeta ~zetaw ~x_hat:(x_hat_1, x_hat_2) =
   let combined_evals =
     Plonk_checks.evals_of_split_evals ~zeta ~zetaw
       (module Tick.Field)
@@ -91,8 +90,8 @@ let wrap
     (( module
       Req ) :
       (max_proofs_verified, max_local_max_proofs_verifieds) Requests.Wrap.t)
-    ~dlog_plonk_index wrap_main to_field_elements ~step_vk ~step_domains
-    ~wrap_domains ~step_plonk_indices pk
+    ~dlog_plonk_index wrap_main to_field_elements ~step_vk ~wrap_domains
+    ~step_plonk_indices pk
     ({ statement = prev_statement; prev_evals; proof; index = which_index } :
       ( _
       , _
@@ -172,6 +171,8 @@ let wrap
         k proof.openings.proof
     | Proof_state ->
         k prev_statement_with_hashes.proof_state
+    | Which_branch ->
+        k which_index
     | _ ->
         Snarky_backendless.Request.unhandled
   in
@@ -278,7 +279,6 @@ let wrap
       combined_inner_product (* Note: We do not pad here. *)
         ~actual_proofs_verified:(Nat.Add.create actual_proofs_verified)
         proof.openings.evals ~x_hat ~r ~xi ~zeta ~zetaw
-        ~step_branch_domains:step_domains
         ~old_bulletproof_challenges:prev_challenges ~env:tick_env
         ~domain:tick_domain ~ft_eval1:proof.openings.ft_eval1
         ~plonk:tick_plonk_minimal
@@ -320,6 +320,21 @@ let wrap
     let shift_value =
       Shifted_value.Type1.of_field (module Tick.Field) ~shift:Shifts.tick1
     in
+    let branch_data : Branch_data.t =
+      { proofs_verified =
+          ( match actual_proofs_verified with
+          | Z ->
+              Branch_data.Proofs_verified.N0
+          | S Z ->
+              N1
+          | S (S Z) ->
+              N2
+          | _ ->
+              assert false )
+      ; domain_log2 =
+          Branch_data.Domain_log2.of_int_exn step_vk.domain.log_size_of_group
+      }
+    in
     { proof_state =
         { deferred_values =
             { xi
@@ -328,7 +343,7 @@ let wrap
                 Vector.of_array_and_length_exn new_bulletproof_challenges
                   Tick.Rounds.n
             ; combined_inner_product = shift_value combined_inner_product
-            ; which_branch = which_index
+            ; branch_data
             ; plonk =
                 { plonk with
                   zeta = plonk0.zeta

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -120,12 +120,17 @@ struct
   let scalar_to_field s =
     SC.to_field_checked (module Impl) s ~endo:Endo.Step_inner_curve.scalar
 
+  let assert_n_bits ~n a =
+    (* Scalar_challenge.to_field_checked has the side effect of
+        checking that the input fits in n bits. *)
+    ignore
+      ( SC.to_field_checked
+          (module Impl)
+          (SC.SC.create a) ~endo:Endo.Step_inner_curve.scalar ~num_bits:n
+        : Field.t )
+
   let lowest_128_bits ~constrain_low_bits x =
-    let assert_128_bits a =
-      (* Scalar_challenge.to_field_checked has the side effect of
-         checking that the input fits in 128 bits. *)
-      ignore (scalar_to_field (SC.SC.create a) : Field.t)
-    in
+    let assert_128_bits = assert_n_bits ~n:128 in
     Util.lowest_128_bits ~constrain_low_bits ~assert_128_bits (module Impl) x
 
   let squeeze_challenge sponge : Field.t =

--- a/src/lib/pickles_base/side_loaded_verification_key.ml
+++ b/src/lib/pickles_base/side_loaded_verification_key.ml
@@ -148,10 +148,7 @@ module Repr = struct
   module Stable = struct
     module V2 = struct
       type 'g t =
-        { step_data :
-            (Domain.Stable.V1.t Domains.Stable.V1.t * Width.Stable.V1.t)
-            Max_branches_vec.Stable.V1.t
-        ; max_width : Width.Stable.V1.t
+        { max_width : Width.Stable.V1.t
         ; wrap_index : 'g Plonk_verification_key_evals.Stable.V2.t
         }
       [@@deriving sexp, equal, compare, yojson]
@@ -166,10 +163,7 @@ module Poly = struct
   module Stable = struct
     module V2 = struct
       type ('g, 'vk) t =
-        { step_data :
-            (Domain.Stable.V1.t Domains.Stable.V1.t * Width.Stable.V1.t)
-            Max_branches_vec.Stable.V1.t
-        ; max_width : Width.Stable.V1.t
+        { max_width : Width.Stable.V1.t
         ; wrap_index : 'g Plonk_verification_key_evals.Stable.V2.t
         ; wrap_vk : 'vk option
         }
@@ -199,27 +193,11 @@ let width_size = Nat.to_int Width.Length.n
 let to_input (type a) ~(field_of_int : int -> a) :
     (a * a, _) Poly.t -> a Random_oracle_input.Chunked.t =
   let open Random_oracle_input.Chunked in
-  let map_reduce t ~f = Array.map t ~f |> Array.reduce_exn ~f:append in
-  fun { step_data; max_width; wrap_index } : _ Random_oracle_input.Chunked.t ->
-    let num_branches =
-      packed
-        (field_of_int (At_most.length step_data), Nat.to_int Max_branches.Log2.n)
-    in
-    let step_domains, step_widths =
-      At_most.extend_to_vector step_data
-        (dummy_domains, dummy_width)
-        Max_branches.n
-      |> Vector.unzip
-    in
+  fun { max_width; wrap_index } : _ Random_oracle_input.Chunked.t ->
     let width w = (field_of_int (Width.to_int w), width_size) in
     List.reduce_exn ~f:append
-      [ map_reduce (Vector.to_array step_domains) ~f:(fun { Domains.h } ->
-            map_reduce [| h |] ~f:(fun (Pow_2_roots_of_unity x) ->
-                packed (field_of_int x, max_log2_degree)))
-      ; Array.map (Vector.to_array step_widths) ~f:width |> packeds
-      ; packed (width max_width)
+      [ packed (width max_width)
       ; wrap_index_to_input
           (Fn.compose Array.of_list (fun (x, y) -> [ x; y ]))
           wrap_index
-      ; num_branches
       ]


### PR DESCRIPTION
Currently, the wrap proof has as one of its public inputs the index of the step "branch" whose proof was wrapped. It does this so that the next step proof can finalize that proof by looking up the PLONK domain and "max proofs verified" corresponding to that branch, as these two values are needed to finalize verification.

However, this means that the step circuits have a component which is linear in the number of branches in the proof-systems they recursively verify.

Instead, we modify the wrap circuit so that instead of exposing the index, we expose the PLONK domain and "max proofs verified" values we would have looked up using the index. This is actually quite a small amount of data, about 10 bits. Therefore, we can avoid any cost linear in the number of branches and allow for an essentially unbounded number of branches.