### PR TITLE
Use upgraded rpc_parallel

### DIFF
--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -9,7 +9,7 @@ type t = Coda_worker.Connection.t * Process.t * Coda_worker.Input.t
 let spawn_exn (config : Coda_worker.Input.t) =
   let%bind conn, process =
     Coda_worker.spawn_in_foreground_exn ~env:config.env ~on_failure:Error.raise
-      ~cd:config.program_dir ~shutdown_on:Disconnect
+      ~cd:config.program_dir ~shutdown_on:Connection_closed
       ~connection_state_init_arg:() ~connection_timeout:(Time.Span.of_sec 15.)
       config
   in

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -304,7 +304,7 @@ let create ~logger ~pids ~conf_dir ~proof_level ~constraint_constants =
   let%map connection, process =
     (* HACK: Need to make connection_timeout long since creating a prover can take a long time*)
     Worker.spawn_in_foreground_exn ~connection_timeout:(Time.Span.of_min 1.)
-      ~on_failure ~shutdown_on:Disconnect ~connection_state_init_arg:()
+      ~on_failure ~shutdown_on:Connection_closed ~connection_state_init_arg:()
       { conf_dir; logger; proof_level; constraint_constants }
   in
   [%log info]

--- a/src/lib/uptime_service/uptime_snark_worker.ml
+++ b/src/lib/uptime_service/uptime_snark_worker.ml
@@ -105,7 +105,8 @@ let create ~logger ~pids : t Deferred.t =
   [%log info] "Starting a new uptime service SNARK worker process" ;
   let%map connection, process =
     Worker.spawn_in_foreground_exn ~connection_timeout:(Time.Span.of_min 1.)
-      ~on_failure ~shutdown_on:Disconnect ~connection_state_init_arg:() logger
+      ~on_failure ~shutdown_on:Connection_closed ~connection_state_init_arg:()
+      logger
   in
   [%log info]
     "Daemon started process of kind $process_kind with pid \

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -269,7 +269,7 @@ let create ~logger ~proof_level ~constraint_constants ~pids ~conf_dir :
         (fun () ->
           Worker.spawn_in_foreground_exn
             ~connection_timeout:(Time.Span.of_min 1.) ~on_failure
-            ~shutdown_on:Disconnect ~connection_state_init_arg:()
+            ~shutdown_on:Connection_closed ~connection_state_init_arg:()
             { conf_dir; logger; proof_level; constraint_constants } )
       |> Deferred.Result.map_error ~f:Error.of_exn
     in

--- a/src/lib/vrf_evaluator/vrf_evaluator.ml
+++ b/src/lib/vrf_evaluator/vrf_evaluator.ml
@@ -392,7 +392,7 @@ let create ~constraint_constants ~pids ~consensus_constants ~conf_dir ~logger
   [%log info] "Starting a new vrf-evaluator process" ;
   let%bind connection, process =
     Worker.spawn_in_foreground_exn ~connection_timeout:(Time.Span.of_min 1.)
-      ~on_failure ~shutdown_on:Disconnect ~connection_state_init_arg:()
+      ~on_failure ~shutdown_on:Connection_closed ~connection_state_init_arg:()
       { constraint_constants; consensus_constants; conf_dir; logger }
   in
   [%log info]


### PR DESCRIPTION
This updates the submodule to use the [upgraded version of `rpc_parallel`](https://github.com/MinaProtocol/rpc_parallel/pull/3).

As a result, it also fixes uses of the variant `Disconnect` that has been renamed to `Connection_closed` in the latest version.