### PR TITLE
Attach `/cargo-lock` locks to all dune rules using rustup or cargo

### DIFF
--- a/src/lib/crypto/kimchi_bindings/js/chrome/dune
+++ b/src/lib/crypto/kimchi_bindings/js/chrome/dune
@@ -19,6 +19,7 @@
   (source_tree ../../wasm/.cargo/config)
   (source_tree ../../../../../external/wasm-bindgen-rayon)
   (source_tree ../../../proof-systems) )
+ (locks /cargo-lock)
  (action
   (progn
    (run chmod -R +w ../../wasm .)

--- a/src/lib/crypto/kimchi_bindings/js/node_js/dune
+++ b/src/lib/crypto/kimchi_bindings/js/node_js/dune
@@ -18,6 +18,7 @@
   (source_tree ../../wasm/.cargo/config)
   (source_tree ../../../../../external/wasm-bindgen-rayon)
   (source_tree ../../../proof-systems) )
+ (locks /cargo-lock)
  (action
   (progn
    (run chmod -R +w ../../wasm .)

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -6,6 +6,7 @@
 
 (rule
  (targets cargo-target-path)
+ (locks /cargo-lock)
  (action
   (with-stdout-to cargo-target-path
    (pipe-stdout
@@ -18,6 +19,7 @@
   Cargo.toml
   (source_tree src)
   (source_tree ../../proof-systems))
+ (locks /cargo-lock)
  (action
   (progn
    (setenv
@@ -75,6 +77,7 @@
   (source_tree src)
   (source_tree binding_generation)
   (source_tree ../../proof-systems))
+ (locks /cargo-lock)
  (action
   (chdir
    binding_generation


### PR DESCRIPTION
There is currently [an issue with `rustup`](https://github.com/rust-lang/rustup/issues/988) that can cause the
toolchain to fall into an unusable state if multiple instances are run
simultaneously. Since `cargo` may use `rustup` when
`rust-toolchain.toml` is specified, we need to make sure that there is
only 1 active `cargo` call at any time.

This adds a global `/cargo-lock` dune lock, which we can use to ensure
that only one of the offending commands can be running at a time. Most
importantly, this should remove the errors in the `dune runtest src/lib`
unit tests (e.g. [here](https://buildkite.com/o-1-labs-2/mina/builds/22966#12db5d05-1db0-479e-9b07-0d14969cd552)).

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
