### PR TITLE
Use text columns for OCaml unsigned 64-bit values

### DIFF
--- a/src/app/archive/archive_lib/load_data.ml
+++ b/src/app/archive/archive_lib/load_data.ml
@@ -455,7 +455,7 @@ let get_other_party_body ~pool body_id =
       match String.split balance_change ~on:'-' with
       | [ s ] ->
           (Currency.Amount.of_string s, Sgn.Pos)
-      | [ _; s ] ->
+      | [ ""; s ] ->
           (Currency.Amount.of_string s, Sgn.Neg)
       | _ ->
           failwith "Ill-formatted string for balance change"

--- a/src/app/archive/archive_lib/load_data.ml
+++ b/src/app/archive/archive_lib/load_data.ml
@@ -39,14 +39,8 @@ let get_amount_bounds pool amount_id =
   let amount_opt =
     Option.map amount_db_opt
       ~f:(fun { amount_lower_bound; amount_upper_bound } ->
-        let lower =
-          amount_lower_bound |> Unsigned.UInt64.of_int64
-          |> Currency.Amount.of_uint64
-        in
-        let upper =
-          amount_upper_bound |> Unsigned.UInt64.of_int64
-          |> Currency.Amount.of_uint64
-        in
+        let lower = Currency.Amount.of_string amount_lower_bound in
+        let upper = Currency.Amount.of_string amount_upper_bound in
         ( { lower; upper }
           : Currency.Amount.t Zkapp_precondition.Closed_interval.t ) )
   in
@@ -215,25 +209,18 @@ let update_of_id pool update_id =
             query_db ~f:(fun db -> Processor.Zkapp_timing_info.load db id)
           in
           let initial_minimum_balance =
-            initial_minimum_balance |> Unsigned.UInt64.of_int64
-            |> Currency.Balance.of_uint64
+            Currency.Balance.of_string initial_minimum_balance
           in
           let cliff_time =
             cliff_time |> Unsigned.UInt32.of_int64
             |> Mina_numbers.Global_slot.of_uint32
           in
-          let cliff_amount =
-            cliff_amount |> Unsigned.UInt64.of_int64
-            |> Currency.Amount.of_uint64
-          in
+          let cliff_amount = Currency.Amount.of_string cliff_amount in
           let vesting_period =
             vesting_period |> Unsigned.UInt32.of_int64
             |> Mina_numbers.Global_slot.of_uint32
           in
-          let vesting_increment =
-            vesting_increment |> Unsigned.UInt64.of_int64
-            |> Currency.Amount.of_uint64
-          in
+          let vesting_increment = Currency.Amount.of_string vesting_increment in
           Some
             ( { initial_minimum_balance
               ; cliff_time
@@ -354,8 +341,8 @@ let protocol_state_precondition_of_id pool id =
     let ts_opt =
       Option.map ts_db_opt
         ~f:(fun { timestamp_lower_bound; timestamp_upper_bound } ->
-          let lower = Block_time.of_int64 timestamp_lower_bound in
-          let upper = Block_time.of_int64 timestamp_upper_bound in
+          let lower = Block_time.of_string_exn timestamp_lower_bound in
+          let upper = Block_time.of_string_exn timestamp_upper_bound in
           ({ lower; upper } : Block_time.t Zkapp_precondition.Closed_interval.t) )
     in
     Or_ignore.of_option ts_opt
@@ -420,11 +407,7 @@ let get_fee_payer_body ~pool body_id =
   let%bind account_id = account_identifier_of_id pool account_identifier_id in
   let public_key = Account_id.public_key account_id in
   let%bind update = update_of_id pool update_id in
-  let fee =
-    (* fee payer balance change stored unsigned *)
-    assert (Int64.is_non_negative fee) ;
-    fee |> Unsigned.UInt64.of_int64 |> Currency.Fee.of_uint64
-  in
+  let fee = Currency.Fee.of_string fee in
   let%bind events = load_events pool events_id in
   let%bind sequence_events = load_events pool sequence_events_id in
   let%bind protocol_state_precondition =
@@ -468,11 +451,15 @@ let get_other_party_body ~pool body_id =
   let token_id = Account_id.token_id account_id in
   let%bind update = update_of_id pool update_id in
   let balance_change =
-    let magnitude =
-      balance_change |> Int64.abs |> Unsigned.UInt64.of_int64
-      |> Currency.Amount.of_uint64
+    let magnitude, sgn =
+      match String.split balance_change ~on:'-' with
+      | [ s ] ->
+          (Currency.Amount.of_string s, Sgn.Pos)
+      | [ _; s ] ->
+          (Currency.Amount.of_string s, Sgn.Neg)
+      | _ ->
+          failwith "Ill-formatted string for balance change"
     in
-    let sgn = if Int64.is_negative balance_change then Sgn.Neg else Sgn.Pos in
     Currency.Amount.Signed.create ~magnitude ~sgn
   in
   let%bind events = load_events pool events_id in
@@ -524,12 +511,8 @@ let get_other_party_body ~pool body_id =
                   query_db ~f:(fun db ->
                       Processor.Zkapp_balance_bounds.load db id )
                 in
-                let balance_of_int64 int64 =
-                  int64 |> Unsigned.UInt64.of_int64
-                  |> Currency.Balance.of_uint64
-                in
-                let lower = balance_of_int64 balance_lower_bound in
-                let upper = balance_of_int64 balance_upper_bound in
+                let lower = Currency.Balance.of_string balance_lower_bound in
+                let upper = Currency.Balance.of_string balance_upper_bound in
                 Some ({ lower; upper } : _ Zkapp_precondition.Closed_interval.t) )
           in
           Or_ignore.of_option balance_opt
@@ -657,9 +640,7 @@ let get_account_accessed ~pool (account : Processor.Accounts_accessed.t) :
   let%bind token_symbol =
     query_db ~f:(fun db -> Processor.Token_symbols.load db token_symbol_id)
   in
-  let balance =
-    balance |> Unsigned.UInt64.of_int64 |> Currency.Balance.of_uint64
-  in
+  let balance = Currency.Balance.of_string balance in
   let nonce = nonce |> Unsigned.UInt32.of_int64 |> Account.Nonce.of_uint32 in
   let receipt_chain_hash =
     receipt_chain_hash |> Receipt.Chain_hash.of_base58_check_exn
@@ -696,36 +677,25 @@ let get_account_accessed ~pool (account : Processor.Accounts_accessed.t) :
           timing
         in
         if
-          List.for_all
-            [ initial_minimum_balance
-            ; cliff_time
-            ; cliff_amount
-            ; vesting_period
-            ; vesting_increment
-            ]
-            ~f:Int64.(equal zero)
+          List.for_all [ cliff_time; vesting_period ] ~f:Int64.(equal zero)
+          && List.for_all
+               [ initial_minimum_balance; cliff_amount; vesting_increment ]
+               ~f:String.(equal "0")
         then Untimed
         else
           let initial_minimum_balance =
-            initial_minimum_balance |> Unsigned.UInt64.of_int64
-            |> Currency.Balance.of_uint64
+            Currency.Balance.of_string initial_minimum_balance
           in
           let cliff_time =
             cliff_time |> Unsigned.UInt32.of_int64
             |> Mina_numbers.Global_slot.of_uint32
           in
-          let cliff_amount =
-            cliff_amount |> Unsigned.UInt64.of_int64
-            |> Currency.Amount.of_uint64
-          in
+          let cliff_amount = Currency.Amount.of_string cliff_amount in
           let vesting_period =
             vesting_period |> Unsigned.UInt32.of_int64
             |> Mina_numbers.Global_slot.of_uint32
           in
-          let vesting_increment =
-            vesting_increment |> Unsigned.UInt64.of_int64
-            |> Currency.Amount.of_uint64
-          in
+          let vesting_increment = Currency.Amount.of_string vesting_increment in
           Timed
             { initial_minimum_balance
             ; cliff_time

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -451,37 +451,32 @@ end
 
 module Zkapp_timing_info = struct
   type t =
-    { initial_minimum_balance : int64
+    { initial_minimum_balance : string
     ; cliff_time : int64
-    ; cliff_amount : int64
+    ; cliff_amount : string
     ; vesting_period : int64
-    ; vesting_increment : int64
+    ; vesting_increment : string
     }
   [@@deriving fields, hlist]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int64; int64; int64; int64; int64 ]
+      Caqti_type.[ string; int64; string; int64; string ]
 
   let table_name = "zkapp_timing_info"
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (timing_info : Party.Update.Timing_info.t) =
     let initial_minimum_balance =
-      timing_info.initial_minimum_balance |> Currency.Balance.to_uint64
-      |> Unsigned.UInt64.to_int64
+      Currency.Balance.to_string timing_info.initial_minimum_balance
     in
     let cliff_time = timing_info.cliff_time |> Unsigned.UInt32.to_int64 in
-    let cliff_amount =
-      timing_info.cliff_amount |> Currency.Amount.to_uint64
-      |> Unsigned.UInt64.to_int64
-    in
+    let cliff_amount = Currency.Amount.to_string timing_info.cliff_amount in
     let vesting_period =
       timing_info.vesting_period |> Unsigned.UInt32.to_int64
     in
     let vesting_increment =
-      timing_info.vesting_increment |> Currency.Amount.to_uint64
-      |> Unsigned.UInt64.to_int64
+      Currency.Amount.to_string timing_info.vesting_increment
     in
     let value =
       { initial_minimum_balance
@@ -618,26 +613,20 @@ module Zkapp_updates = struct
 end
 
 module Zkapp_balance_bounds = struct
-  type t = { balance_lower_bound : int64; balance_upper_bound : int64 }
+  type t = { balance_lower_bound : string; balance_upper_bound : string }
   [@@deriving fields, hlist]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int64; int64 ]
+      Caqti_type.[ string; string ]
 
   let table_name = "zkapp_balance_bounds"
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (balance_bounds :
         Currency.Balance.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
-    let balance_lower_bound =
-      balance_bounds.lower |> Currency.Balance.to_uint64
-      |> Unsigned.UInt64.to_int64
-    in
-    let balance_upper_bound =
-      balance_bounds.upper |> Currency.Balance.to_uint64
-      |> Unsigned.UInt64.to_int64
-    in
+    let balance_lower_bound = Currency.Balance.to_string balance_bounds.lower in
+    let balance_upper_bound = Currency.Balance.to_string balance_bounds.upper in
     let value = { balance_lower_bound; balance_upper_bound } in
     Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
       ~table_name ~cols:(Fields.names, typ)
@@ -856,20 +845,20 @@ module Zkapp_token_id_bounds = struct
 end
 
 module Zkapp_timestamp_bounds = struct
-  type t = { timestamp_lower_bound : int64; timestamp_upper_bound : int64 }
+  type t = { timestamp_lower_bound : string; timestamp_upper_bound : string }
   [@@deriving fields, hlist]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int64; int64 ]
+      Caqti_type.[ string; string ]
 
   let table_name = "zkapp_timestamp_bounds"
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (timestamp_bounds :
         Block_time.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
-    let timestamp_lower_bound = Block_time.to_int64 timestamp_bounds.lower in
-    let timestamp_upper_bound = Block_time.to_int64 timestamp_bounds.upper in
+    let timestamp_lower_bound = Block_time.to_string timestamp_bounds.lower in
+    let timestamp_upper_bound = Block_time.to_string timestamp_bounds.upper in
     let value = { timestamp_lower_bound; timestamp_upper_bound } in
     Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
       ~table_name ~cols:(Fields.names, typ)
@@ -912,24 +901,20 @@ module Zkapp_length_bounds = struct
 end
 
 module Zkapp_amount_bounds = struct
-  type t = { amount_lower_bound : int64; amount_upper_bound : int64 }
+  type t = { amount_lower_bound : string; amount_upper_bound : string }
   [@@deriving fields, hlist]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int64; int64 ]
+      Caqti_type.[ string; string ]
 
   let table_name = "zkapp_amount_bounds"
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (amount_bounds :
         Currency.Amount.t Mina_base.Zkapp_precondition.Closed_interval.t ) =
-    let amount_lower_bound =
-      Currency.Amount.to_uint64 amount_bounds.lower |> Unsigned.UInt64.to_int64
-    in
-    let amount_upper_bound =
-      Currency.Amount.to_uint64 amount_bounds.upper |> Unsigned.UInt64.to_int64
-    in
+    let amount_lower_bound = Currency.Amount.to_string amount_bounds.lower in
+    let amount_upper_bound = Currency.Amount.to_string amount_bounds.upper in
     let value = { amount_lower_bound; amount_upper_bound } in
     Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
       ~table_name ~cols:(Fields.names, typ)
@@ -981,17 +966,17 @@ end
 module Timing_info = struct
   type t =
     { account_identifier_id : int
-    ; initial_minimum_balance : int64
+    ; initial_minimum_balance : string
     ; cliff_time : int64
-    ; cliff_amount : int64
+    ; cliff_amount : string
     ; vesting_period : int64
-    ; vesting_increment : int64
+    ; vesting_increment : string
     }
   [@@deriving hlist, fields]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int; int64; int64; int64; int64; int64 ]
+      Caqti_type.[ int; string; int64; string; int64; string ]
 
   let table_name = "timing_info"
 
@@ -1026,10 +1011,6 @@ module Timing_info = struct
   let add_if_doesn't_exist (module Conn : CONNECTION) account_identifier_id
       (timing : Account_timing.t) =
     let open Deferred.Result.Let_syntax in
-    let amount_to_int64 x =
-      Unsigned.UInt64.to_int64 (Currency.Amount.to_uint64 x)
-    in
-    let balance_to_int64 x = amount_to_int64 (Currency.Balance.to_amount x) in
     let slot_to_int64 x =
       Mina_numbers.Global_slot.to_uint32 x |> Unsigned.UInt32.to_int64
     in
@@ -1047,19 +1028,20 @@ module Timing_info = struct
           | Timed timing ->
               { account_identifier_id
               ; initial_minimum_balance =
-                  balance_to_int64 timing.initial_minimum_balance
+                  Currency.Balance.to_string timing.initial_minimum_balance
               ; cliff_time = slot_to_int64 timing.cliff_time
-              ; cliff_amount = amount_to_int64 timing.cliff_amount
+              ; cliff_amount = Currency.Amount.to_string timing.cliff_amount
               ; vesting_period = slot_to_int64 timing.vesting_period
-              ; vesting_increment = amount_to_int64 timing.vesting_increment
+              ; vesting_increment =
+                  Currency.Amount.to_string timing.vesting_increment
               }
           | Untimed ->
-              let zero = Int64.zero in
+              let zero = "0" in
               { account_identifier_id
               ; initial_minimum_balance = zero
-              ; cliff_time = zero
+              ; cliff_time = 0L
               ; cliff_amount = zero
-              ; vesting_period = zero
+              ; vesting_period = 0L
               ; vesting_increment = zero
               }
         in
@@ -1352,7 +1334,7 @@ module Zkapp_other_party_body = struct
   type t =
     { account_identifier_id : int
     ; update_id : int
-    ; balance_change : int64
+    ; balance_change : string
     ; increment_nonce : bool
     ; events_id : int
     ; sequence_events_id : int
@@ -1368,7 +1350,7 @@ module Zkapp_other_party_body = struct
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
       Caqti_type.
-        [ int; int; int64; bool; int; int; int; int; int; int; bool; string ]
+        [ int; int; string; bool; int; int; int; int; int; int; bool; string ]
 
   let table_name = "zkapp_other_party_body"
 
@@ -1403,15 +1385,12 @@ module Zkapp_other_party_body = struct
         body.account_precondition
     in
     let balance_change =
-      let magnitude =
-        Currency.Amount.to_uint64 body.balance_change.magnitude
-        |> Unsigned.UInt64.to_int64
-      in
+      let magnitude = Currency.Amount.to_string body.balance_change.magnitude in
       match body.balance_change.sgn with
       | Sgn.Pos ->
           magnitude
       | Sgn.Neg ->
-          Int64.neg magnitude
+          "-" ^ magnitude
     in
     let call_depth = body.call_depth in
     let use_full_commitment = body.use_full_commitment in
@@ -1504,7 +1483,7 @@ module Zkapp_fee_payer_body = struct
   type t =
     { account_identifier_id : int
     ; update_id : int
-    ; fee : int64
+    ; fee : string
     ; events_id : int
     ; sequence_events_id : int
     ; zkapp_protocol_state_precondition_id : int
@@ -1514,7 +1493,7 @@ module Zkapp_fee_payer_body = struct
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int; int; int64; int; int; int; int64 ]
+      Caqti_type.[ int; int; string; int; int; int; int64 ]
 
   let table_name = "zkapp_fee_payer_body"
 
@@ -1545,7 +1524,7 @@ module Zkapp_fee_payer_body = struct
       body.nonce |> Mina_numbers.Account_nonce.to_uint32
       |> Unsigned.UInt32.to_int64
     in
-    let fee = Currency.Fee.to_uint64 body.fee |> Unsigned.UInt64.to_int64 in
+    let fee = Currency.Fee.to_string body.fee in
     let value =
       { account_identifier_id
       ; update_id
@@ -1574,7 +1553,7 @@ module Epoch_data = struct
   type t =
     { seed : string
     ; ledger_hash_id : int
-    ; total_currency : int64
+    ; total_currency : string
     ; start_checkpoint : string
     ; lock_checkpoint : string
     ; epoch_length : int64
@@ -1583,7 +1562,7 @@ module Epoch_data = struct
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ string; int; int64; string; string; int64 ]
+      Caqti_type.[ string; int; string; string; string; int64 ]
 
   let table_name = "epoch_data"
 
@@ -1597,9 +1576,7 @@ module Epoch_data = struct
       Snarked_ledger_hash.add_if_doesn't_exist (module Conn) hash
     in
     let seed = t.seed |> Epoch_seed.to_base58_check in
-    let total_currency =
-      total_currency |> Currency.Amount.to_uint64 |> Unsigned.UInt64.to_int64
-    in
+    let total_currency = Currency.Amount.to_string total_currency in
     let start_checkpoint = t.start_checkpoint |> State_hash.to_base58_check in
     let lock_checkpoint = t.lock_checkpoint |> State_hash.to_base58_check in
     let epoch_length =
@@ -1632,8 +1609,8 @@ module User_command = struct
       ; source_id : int
       ; receiver_id : int
       ; nonce : int64
-      ; amount : int64 option
-      ; fee : int64
+      ; amount : string option
+      ; fee : string
       ; valid_until : int64 option
       ; memo : string
       ; hash : string
@@ -1648,8 +1625,8 @@ module User_command = struct
           ; int
           ; int
           ; int64
-          ; option int64
-          ; int64
+          ; option string
+          ; string
           ; option int64
           ; string
           ; string
@@ -1737,13 +1714,9 @@ module User_command = struct
             ; receiver_id
             ; nonce = Signed_command.nonce t |> Unsigned.UInt32.to_int64
             ; amount =
-                Signed_command.amount t
-                |> Core.Option.map ~f:(fun amt ->
-                       Currency.Amount.to_uint64 amt |> Unsigned.UInt64.to_int64 )
-            ; fee =
-                ( Signed_command.fee t
-                |> fun amt ->
-                Currency.Fee.to_uint64 amt |> Unsigned.UInt64.to_int64 )
+                Option.map (Signed_command.amount t)
+                  ~f:Currency.Amount.to_string
+            ; fee = Currency.Fee.to_string (Signed_command.fee t)
             ; valid_until
             ; memo =
                 Signed_command.memo t |> Signed_command_memo.to_base58_check
@@ -1757,10 +1730,6 @@ module User_command = struct
       | Some id ->
           return id
       | None ->
-          let amount_opt_to_int64_opt amt_opt =
-            Option.map amt_opt
-              ~f:(Fn.compose Unsigned.UInt64.to_int64 Currency.Amount.to_uint64)
-          in
           let open Deferred.Result.Let_syntax in
           let%bind fee_payer_id =
             Account_identifiers.add_if_doesn't_exist
@@ -1788,10 +1757,8 @@ module User_command = struct
             ; source_id
             ; receiver_id
             ; nonce = user_cmd.nonce |> Unsigned.UInt32.to_int64
-            ; amount = user_cmd.amount |> amount_opt_to_int64_opt
-            ; fee =
-                user_cmd.fee
-                |> Fn.compose Unsigned.UInt64.to_int64 Currency.Fee.to_uint64
+            ; amount = Option.map user_cmd.amount ~f:Currency.Amount.to_string
+            ; fee = Currency.Fee.to_string user_cmd.fee
             ; valid_until =
                 Option.map user_cmd.valid_until
                   ~f:
@@ -1881,12 +1848,12 @@ module User_command = struct
 end
 
 module Internal_command = struct
-  type t = { typ : string; receiver_id : int; fee : int64; hash : string }
+  type t = { typ : string; receiver_id : int; fee : string; hash : string }
   [@@deriving hlist, fields]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ string; int; int64; string ]
+      Caqti_type.[ string; int; string; string ]
 
   let table_name = "internal_commands"
 
@@ -1932,9 +1899,7 @@ module Internal_command = struct
                 ~cols:Fields.names () ) )
           { typ = internal_cmd.typ
           ; receiver_id
-          ; fee =
-              internal_cmd.fee |> Currency.Fee.to_uint64
-              |> Unsigned.UInt64.to_int64
+          ; fee = Currency.Fee.to_string internal_cmd.fee
           ; hash = internal_cmd.hash |> Transaction_hash.to_base58_check
           }
 end
@@ -2374,7 +2339,7 @@ module Accounts_accessed = struct
     ; block_id : int
     ; account_identifier_id : int
     ; token_symbol_id : int
-    ; balance : int64
+    ; balance : string
     ; nonce : int64
     ; receipt_chain_hash : string
     ; delegate_id : int option
@@ -2392,7 +2357,7 @@ module Accounts_accessed = struct
         ; int
         ; int
         ; int
-        ; int64
+        ; string
         ; int64
         ; string
         ; option int
@@ -2433,10 +2398,7 @@ module Accounts_accessed = struct
         let%bind token_symbol_id =
           Token_symbols.add_if_doesn't_exist (module Conn) account.token_symbol
         in
-        let balance =
-          account.balance |> Currency.Balance.to_uint64
-          |> Unsigned.UInt64.to_int64
-        in
+        let balance = Currency.Balance.to_string account.balance in
         let nonce =
           account.nonce |> Account.Nonce.to_uint32 |> Unsigned.UInt32.to_int64
         in
@@ -2506,12 +2468,13 @@ module Accounts_accessed = struct
 end
 
 module Accounts_created = struct
-  type t = { block_id : int; account_identifier_id : int; creation_fee : int64 }
+  type t =
+    { block_id : int; account_identifier_id : int; creation_fee : string }
   [@@deriving hlist, fields]
 
   let typ =
     Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int; int; int64 ]
+      Caqti_type.[ int; int; string ]
 
   let table_name = "accounts_created"
 
@@ -2521,9 +2484,7 @@ module Accounts_created = struct
     let%bind account_identifier_id =
       Account_identifiers.add_if_doesn't_exist (module Conn) account_id
     in
-    let creation_fee =
-      Currency.Fee.to_uint64 creation_fee |> Unsigned.UInt64.to_int64
-    in
+    let creation_fee = Currency.Fee.to_string creation_fee in
     Mina_caqti.select_insert_into_cols
       ~select:("block_id,account_identifier_id", Caqti_type.(tup2 int int))
       ~table_name ~cols:(Fields.names, typ)
@@ -2559,12 +2520,12 @@ module Block = struct
     ; staking_epoch_data_id : int
     ; next_epoch_data_id : int
     ; min_window_density : int64
-    ; total_currency : int64
+    ; total_currency : string
     ; ledger_hash : string
     ; height : int64
     ; global_slot_since_hard_fork : int64
     ; global_slot_since_genesis : int64
-    ; timestamp : int64
+    ; timestamp : string
     ; chain_status : string
     }
   [@@deriving hlist, fields]
@@ -2581,12 +2542,12 @@ module Block = struct
         ; int
         ; int
         ; int64
-        ; int64
+        ; string
         ; string
         ; int64
         ; int64
         ; int64
-        ; int64
+        ; string
         ; string
         ]
 
@@ -2702,7 +2663,7 @@ module Block = struct
             ; total_currency =
                 Protocol_state.consensus_state protocol_state
                 |> Consensus.Data.Consensus_state.total_currency
-                |> Currency.Amount.to_uint64 |> Unsigned.UInt64.to_int64
+                |> Currency.Amount.to_string
             ; ledger_hash =
                 Protocol_state.blockchain_state protocol_state
                 |> Blockchain_state.staged_ledger_hash
@@ -2715,7 +2676,7 @@ module Block = struct
                 |> Unsigned.UInt32.to_int64
             ; timestamp =
                 Protocol_state.blockchain_state protocol_state
-                |> Blockchain_state.timestamp |> Block_time.to_int64
+                |> Blockchain_state.timestamp |> Block_time.to_string
             ; chain_status
             }
         in
@@ -2906,16 +2867,14 @@ module Block = struct
             ; min_window_density =
                 block.min_window_density |> Mina_numbers.Length.to_uint32
                 |> Unsigned.UInt32.to_int64
-            ; total_currency =
-                block.total_currency |> Currency.Amount.to_uint64
-                |> Unsigned.UInt64.to_int64
+            ; total_currency = Currency.Amount.to_string block.total_currency
             ; ledger_hash = block.ledger_hash |> Ledger_hash.to_base58_check
             ; height = block.height |> Unsigned.UInt32.to_int64
             ; global_slot_since_hard_fork =
                 block.global_slot_since_hard_fork |> Unsigned.UInt32.to_int64
             ; global_slot_since_genesis =
                 block.global_slot_since_genesis |> Unsigned.UInt32.to_int64
-            ; timestamp = block.timestamp |> Block_time.to_int64
+            ; timestamp = Block_time.to_string block.timestamp
             ; chain_status = Chain_status.to_string block.chain_status
             }
     in

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -1,14 +1,10 @@
 /* the Postgresql schema used by the Mina archive database */
 
-/* there are a number of values represented by a Postgresql bigint here, which is a 64-bit signed value,
-   while in OCaml, the value is represented by a 64-bit unsigned value, so that overflow is
-   possible
+/* Unsigned 64-bit values in OCaml are represented by text values in the database,
+   and string values in the type `t`s in the modules below
 
-   while overflow is unlikely, because a bigint can be very large, it's possible in theory
-
-   that describes almost all the bigint values below, except for those representing
-   nonces and slots, which are unsigned 32-bit values in OCaml
-
+   Unsigned 32-bit values are represented by bigint values in the database, and
+   int64 values in the `t`s
 */
 
 /* the tables below named `blocks_xxx_commands`, where xxx is `user`, `internal`, or `zkapps`,
@@ -54,11 +50,11 @@ CREATE TABLE account_identifiers
 CREATE TABLE timing_info
 ( id                      serial    PRIMARY KEY
 , account_identifier_id   int       NOT NULL UNIQUE REFERENCES account_identifiers(id)
-, initial_minimum_balance bigint    NOT NULL
+, initial_minimum_balance text      NOT NULL
 , cliff_time              bigint    NOT NULL
-, cliff_amount            bigint    NOT NULL
+, cliff_amount            text      NOT NULL
 , vesting_period          bigint    NOT NULL
-, vesting_increment       bigint    NOT NULL
+, vesting_increment       text      NOT NULL
 );
 
 CREATE TABLE snarked_ledger_hashes
@@ -77,8 +73,8 @@ CREATE TABLE user_commands
 , source_id      int                 NOT NULL REFERENCES account_identifiers(id)
 , receiver_id    int                 NOT NULL REFERENCES account_identifiers(id)
 , nonce          bigint              NOT NULL
-, amount         bigint
-, fee            bigint              NOT NULL
+, amount         text
+, fee            text                NOT NULL
 , valid_until    bigint
 , memo           text                NOT NULL
 , hash           text                NOT NULL UNIQUE
@@ -90,7 +86,7 @@ CREATE TABLE internal_commands
 ( id          serial                PRIMARY KEY
 , typ         internal_command_type NOT NULL
 , receiver_id int                   NOT NULL REFERENCES account_identifiers(id)
-, fee         bigint                NOT NULL
+, fee         text                  NOT NULL
 , hash        text                  NOT NULL
 , UNIQUE (hash,typ)
 );
@@ -127,7 +123,7 @@ CREATE TABLE epoch_data
 ( id               serial PRIMARY KEY
 , seed             text   NOT NULL
 , ledger_hash_id   int    NOT NULL REFERENCES snarked_ledger_hashes(id)
-, total_currency   bigint NOT NULL
+, total_currency   text   NOT NULL
 , start_checkpoint text   NOT NULL
 , lock_checkpoint  text   NOT NULL
 , epoch_length     bigint NOT NULL
@@ -146,12 +142,12 @@ CREATE TABLE blocks
 , staking_epoch_data_id        int    NOT NULL        REFERENCES epoch_data(id)
 , next_epoch_data_id           int    NOT NULL        REFERENCES epoch_data(id)
 , min_window_density           bigint NOT NULL
-, total_currency               bigint NOT NULL
+, total_currency               text   NOT NULL
 , ledger_hash                  text   NOT NULL
 , height                       bigint NOT NULL
 , global_slot_since_hard_fork  bigint NOT NULL
 , global_slot_since_genesis    bigint NOT NULL
-, timestamp                    bigint NOT NULL
+, timestamp                    text   NOT NULL
 , chain_status                 chain_status_type NOT NULL
 );
 
@@ -168,7 +164,7 @@ CREATE TABLE accounts_accessed
 , block_id                int     NOT NULL  REFERENCES blocks(id)
 , account_identifier_id   int     NOT NULL  REFERENCES account_identifiers(id)
 , token_symbol_id         int     NOT NULL  REFERENCES token_symbols(id)
-, balance                 bigint  NOT NULL
+, balance                 text    NOT NULL
 , nonce                   bigint  NOT NULL
 , receipt_chain_hash      text    NOT NULL
 , delegate_id             int               REFERENCES public_keys(id)
@@ -186,7 +182,7 @@ CREATE INDEX idx_accounts_accessed_block_account_identifier_id ON accounts_acces
 CREATE TABLE accounts_created
 ( block_id                int     NOT NULL  REFERENCES blocks(id)
 , account_identifier_id   int     NOT NULL  REFERENCES account_identifiers(id)
-, creation_fee            bigint  NOT NULL
+, creation_fee            text    NOT NULL
 , PRIMARY KEY (block_id,account_identifier_id)
 );
 

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -89,11 +89,11 @@ CREATE TABLE zkapp_permissions
 
 CREATE TABLE zkapp_timing_info
 ( id                       serial  PRIMARY KEY
-, initial_minimum_balance  bigint  NOT NULL
+, initial_minimum_balance  text    NOT NULL
 , cliff_time               bigint  NOT NULL
-, cliff_amount             bigint  NOT NULL
+, cliff_amount             text    NOT NULL
 , vesting_period           bigint  NOT NULL
-, vesting_increment        bigint  NOT NULL
+, vesting_increment        text    NOT NULL
 );
 
 CREATE TABLE zkapp_uris
@@ -116,8 +116,8 @@ CREATE TABLE zkapp_updates
 
 CREATE TABLE zkapp_balance_bounds
 ( id                       serial           PRIMARY KEY
-, balance_lower_bound      bigint           NOT NULL
-, balance_upper_bound      bigint           NOT NULL
+, balance_lower_bound      text             NOT NULL
+, balance_upper_bound      text             NOT NULL
 );
 
 CREATE TABLE zkapp_nonce_bounds
@@ -171,8 +171,8 @@ CREATE TABLE zkapp_token_id_bounds
 
 CREATE TABLE zkapp_timestamp_bounds
 ( id                        serial          PRIMARY KEY
-, timestamp_lower_bound     bigint          NOT NULL
-, timestamp_upper_bound     bigint          NOT NULL
+, timestamp_lower_bound     text            NOT NULL
+, timestamp_upper_bound     text            NOT NULL
 );
 
 CREATE TABLE zkapp_length_bounds
@@ -183,8 +183,8 @@ CREATE TABLE zkapp_length_bounds
 
 CREATE TABLE zkapp_amount_bounds
 ( id                       serial          PRIMARY KEY
-, amount_lower_bound       bigint          NOT NULL
-, amount_upper_bound       bigint          NOT NULL
+, amount_lower_bound       text            NOT NULL
+, amount_upper_bound       text            NOT NULL
 );
 
 CREATE TABLE zkapp_global_slot_bounds
@@ -232,7 +232,7 @@ CREATE TABLE zkapp_fee_payer_body
 ( id                                    serial    PRIMARY KEY
 , account_identifier_id                 int       NOT NULL REFERENCES account_identifiers(id)
 , update_id                             int       NOT NULL REFERENCES zkapp_updates(id)
-, fee                                   bigint    NOT NULL
+, fee                                   text      NOT NULL
 , events_id                             int       NOT NULL REFERENCES zkapp_events(id)
 , sequence_events_id                    int       NOT NULL REFERENCES zkapp_events(id)
 , zkapp_protocol_state_precondition_id  int       NOT NULL REFERENCES zkapp_protocol_state_precondition(id)
@@ -248,7 +248,7 @@ CREATE TABLE zkapp_other_party_body
 ( id                                    serial          PRIMARY KEY
 , account_identifier_id                 int             NOT NULL  REFERENCES account_identifiers(id)
 , update_id                             int             NOT NULL  REFERENCES zkapp_updates(id)
-, balance_change                        bigint          NOT NULL
+, balance_change                        text            NOT NULL
 , increment_nonce                       boolean         NOT NULL
 , events_id                             int             NOT NULL  REFERENCES zkapp_events(id)
 , sequence_events_id                    int             NOT NULL  REFERENCES zkapp_events(id)

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -543,7 +543,7 @@ module Zkapp_helpers = struct
           let snarked_ledger_hash =
             Frozen_ledger_hash.of_base58_check_exn snarked_ledger_hash_str
           in
-          let timestamp = parent_block.timestamp |> Block_time.of_int64 in
+          let timestamp = Block_time.of_string_exn parent_block.timestamp in
           let blockchain_length =
             parent_block.height |> Unsigned.UInt32.of_int64
             |> Mina_numbers.Length.of_uint32
@@ -555,8 +555,7 @@ module Zkapp_helpers = struct
           (* TODO : this will change *)
           let last_vrf_output = () in
           let total_currency =
-            parent_block.total_currency |> Unsigned.UInt64.of_int64
-            |> Currency.Amount.of_uint64
+            Currency.Amount.of_string parent_block.total_currency
           in
           let global_slot_since_hard_fork =
             parent_block.global_slot_since_hard_fork |> Unsigned.UInt32.of_int64
@@ -575,8 +574,7 @@ module Zkapp_helpers = struct
             in
             let hash = Frozen_ledger_hash.of_base58_check_exn hash_str in
             let total_currency =
-              raw_epoch_data.total_currency |> Unsigned.UInt64.of_int64
-              |> Currency.Amount.of_uint64
+              Currency.Amount.of_string raw_epoch_data.total_currency
             in
             let ledger = { Mina_base.Epoch_ledger.Poly.hash; total_currency } in
             let seed = raw_epoch_data.seed |> Epoch_seed.of_base58_check_exn in

--- a/src/app/replayer/test/archive_db.sql
+++ b/src/app/replayer/test/archive_db.sql
@@ -168,7 +168,7 @@ CREATE TABLE public.accounts_accessed (
     block_id integer NOT NULL,
     account_identifier_id integer NOT NULL,
     token_symbol_id integer NOT NULL,
-    balance bigint NOT NULL,
+    balance text NOT NULL,
     nonce bigint NOT NULL,
     receipt_chain_hash text NOT NULL,
     delegate_id integer,
@@ -186,7 +186,7 @@ CREATE TABLE public.accounts_accessed (
 CREATE TABLE public.accounts_created (
     block_id integer NOT NULL,
     account_identifier_id integer NOT NULL,
-    creation_fee bigint NOT NULL
+    creation_fee text NOT NULL
 );
 
 
@@ -205,12 +205,12 @@ CREATE TABLE public.blocks (
     staking_epoch_data_id integer NOT NULL,
     next_epoch_data_id integer NOT NULL,
     min_window_density bigint NOT NULL,
-    total_currency bigint NOT NULL,
+    total_currency text NOT NULL,
     ledger_hash text NOT NULL,
     height bigint NOT NULL,
     global_slot_since_hard_fork bigint NOT NULL,
     global_slot_since_genesis bigint NOT NULL,
-    "timestamp" bigint NOT NULL,
+    "timestamp" text NOT NULL,
     chain_status public.chain_status_type NOT NULL
 );
 
@@ -281,7 +281,7 @@ CREATE TABLE public.epoch_data (
     id integer NOT NULL,
     seed text NOT NULL,
     ledger_hash_id integer NOT NULL,
-    total_currency bigint NOT NULL,
+    total_currency text NOT NULL,
     start_checkpoint text NOT NULL,
     lock_checkpoint text NOT NULL,
     epoch_length bigint NOT NULL
@@ -316,7 +316,7 @@ CREATE TABLE public.internal_commands (
     id integer NOT NULL,
     typ public.internal_command_type NOT NULL,
     receiver_id integer NOT NULL,
-    fee bigint NOT NULL,
+    fee text NOT NULL,
     hash text NOT NULL
 );
 
@@ -409,11 +409,11 @@ CREATE TABLE public.timing_info (
     id integer NOT NULL,
     account_identifier_id integer NOT NULL,
     initial_balance bigint NOT NULL,
-    initial_minimum_balance bigint NOT NULL,
+    initial_minimum_balance text NOT NULL,
     cliff_time bigint NOT NULL,
-    cliff_amount bigint NOT NULL,
+    cliff_amount text NOT NULL,
     vesting_period bigint NOT NULL,
-    vesting_increment bigint NOT NULL
+    vesting_increment text NOT NULL
 );
 
 
@@ -510,8 +510,8 @@ CREATE TABLE public.user_commands (
     source_id integer NOT NULL,
     receiver_id integer NOT NULL,
     nonce bigint NOT NULL,
-    amount bigint,
-    fee bigint NOT NULL,
+    amount text,
+    fee text NOT NULL,
     valid_until bigint,
     memo text NOT NULL,
     hash text NOT NULL
@@ -642,8 +642,8 @@ ALTER SEQUENCE public.zkapp_accounts_id_seq OWNED BY public.zkapp_accounts.id;
 
 CREATE TABLE public.zkapp_amount_bounds (
     id integer NOT NULL,
-    amount_lower_bound bigint NOT NULL,
-    amount_upper_bound bigint NOT NULL
+    amount_lower_bound text NOT NULL,
+    amount_upper_bound text NOT NULL
 );
 
 
@@ -673,8 +673,8 @@ ALTER SEQUENCE public.zkapp_amount_bounds_id_seq OWNED BY public.zkapp_amount_bo
 
 CREATE TABLE public.zkapp_balance_bounds (
     id integer NOT NULL,
-    balance_lower_bound bigint NOT NULL,
-    balance_upper_bound bigint NOT NULL
+    balance_lower_bound text NOT NULL,
+    balance_upper_bound text NOT NULL
 );
 
 
@@ -834,7 +834,7 @@ CREATE TABLE public.zkapp_fee_payer_body (
     id integer NOT NULL,
     account_identifier_id integer NOT NULL,
     update_id integer NOT NULL,
-    fee bigint NOT NULL,
+    fee text NOT NULL,
     events_id integer NOT NULL,
     sequence_events_id integer NOT NULL,
     zkapp_protocol_state_precondition_id integer NOT NULL,
@@ -860,6 +860,37 @@ CREATE SEQUENCE public.zkapp_fee_payer_body_id_seq
 --
 
 ALTER SEQUENCE public.zkapp_fee_payer_body_id_seq OWNED BY public.zkapp_fee_payer_body.id;
+
+
+--
+-- Name: zkapp_fee_payers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.zkapp_fee_payers (
+    id integer NOT NULL,
+    body_id integer NOT NULL
+);
+
+
+--
+-- Name: zkapp_fee_payers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.zkapp_fee_payers_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: zkapp_fee_payers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.zkapp_fee_payers_id_seq OWNED BY public.zkapp_fee_payers.id;
+
 
 --
 -- Name: zkapp_global_slot_bounds; Type: TABLE; Schema: public; Owner: -
@@ -973,7 +1004,7 @@ CREATE TABLE public.zkapp_other_party_body (
     id integer NOT NULL,
     account_identifier_id integer NOT NULL,
     update_id integer NOT NULL,
-    balance_change bigint NOT NULL,
+    balance_change text NOT NULL,
     increment_nonce boolean NOT NULL,
     events_id integer NOT NULL,
     sequence_events_id integer NOT NULL,
@@ -1297,8 +1328,8 @@ ALTER SEQUENCE public.zkapp_states_id_seq OWNED BY public.zkapp_states.id;
 
 CREATE TABLE public.zkapp_timestamp_bounds (
     id integer NOT NULL,
-    timestamp_lower_bound bigint NOT NULL,
-    timestamp_upper_bound bigint NOT NULL
+    timestamp_lower_bound text NOT NULL,
+    timestamp_upper_bound text NOT NULL
 );
 
 
@@ -1328,11 +1359,11 @@ ALTER SEQUENCE public.zkapp_timestamp_bounds_id_seq OWNED BY public.zkapp_timest
 
 CREATE TABLE public.zkapp_timing_info (
     id integer NOT NULL,
-    initial_minimum_balance bigint NOT NULL,
+    initial_minimum_balance text NOT NULL,
     cliff_time bigint NOT NULL,
-    cliff_amount bigint NOT NULL,
+    cliff_amount text NOT NULL,
     vesting_period bigint NOT NULL,
-    vesting_increment bigint NOT NULL
+    vesting_increment text NOT NULL
 );
 
 
@@ -1626,6 +1657,13 @@ ALTER TABLE ONLY public.zkapp_fee_payer_body ALTER COLUMN id SET DEFAULT nextval
 
 
 --
+-- Name: zkapp_fee_payers id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.zkapp_fee_payers ALTER COLUMN id SET DEFAULT nextval('public.zkapp_fee_payers_id_seq'::regclass);
+
+
+--
 -- Name: zkapp_global_slot_bounds id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1759,22 +1797,22 @@ ALTER TABLE ONLY public.zkapp_verification_keys ALTER COLUMN id SET DEFAULT next
 
 
 --
--- Data for Name: zkapp_uris; Type: TABLE DATA; Schema: public; Owner: -
---
-
-COPY public.zkapp_uris (id, value) FROM stdin;
-1	
-2	https://www.example.com
-\.
-
-
---
 -- Data for Name: token_symbols; Type: TABLE DATA; Schema: public; Owner: -
 --
 
 COPY public.token_symbols (id, value) FROM stdin;
 1	
 2	BOLSYM
+\.
+
+
+--
+-- Data for Name: zkapp_uris; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.zkapp_uris (id, value) FROM stdin;
+1	
+2	https://www.example.com
 \.
 
 
@@ -2077,6 +2115,7 @@ COPY public.timing_info (id, account_identifier_id, initial_balance, initial_min
 5	5	11000000000	0	0	0	0	0
 \.
 
+
 --
 -- Data for Name: tokens; Type: TABLE DATA; Schema: public; Owner: -
 --
@@ -2373,6 +2412,18 @@ COPY public.zkapp_fee_payer_body (id, account_identifier_id, update_id, fee, eve
 
 
 --
+-- Data for Name: zkapp_fee_payers; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+COPY public.zkapp_fee_payers (id, body_id) FROM stdin;
+1	1
+2	2
+3	3
+4	4
+\.
+
+
+--
 -- Data for Name: zkapp_global_slot_bounds; Type: TABLE DATA; Schema: public; Owner: -
 --
 
@@ -2543,6 +2594,7 @@ COPY public.zkapp_updates (id, app_state_id, delegate_id, verification_key_id, p
 9	1	\N	\N	\N	\N	2	\N	\N
 \.
 
+
 --
 -- Data for Name: zkapp_verification_keys; Type: TABLE DATA; Schema: public; Owner: -
 --
@@ -2690,6 +2742,13 @@ SELECT pg_catalog.setval('public.zkapp_events_id_seq', 1, true);
 --
 
 SELECT pg_catalog.setval('public.zkapp_fee_payer_body_id_seq', 4, true);
+
+
+--
+-- Name: zkapp_fee_payers_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.zkapp_fee_payers_id_seq', 4, true);
 
 
 --
@@ -3095,6 +3154,14 @@ ALTER TABLE ONLY public.zkapp_events
 
 ALTER TABLE ONLY public.zkapp_fee_payer_body
     ADD CONSTRAINT zkapp_fee_payer_body_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: zkapp_fee_payers zkapp_fee_payers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.zkapp_fee_payers
+    ADD CONSTRAINT zkapp_fee_payers_pkey PRIMARY KEY (id);
 
 
 --
@@ -3725,11 +3792,11 @@ ALTER TABLE ONLY public.zkapp_accounts
 
 
 --
--- Name: zkapp_commands zkapp_commands_zkapp_fee_payer_body_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: zkapp_commands zkapp_commands_zkapp_fee_payer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.zkapp_commands
-    ADD CONSTRAINT zkapp_commands_zkapp_fee_payer_body_id_fkey FOREIGN KEY (zkapp_fee_payer_body_id) REFERENCES public.zkapp_fee_payer_body(id);
+    ADD CONSTRAINT zkapp_commands_zkapp_fee_payer_id_fkey FOREIGN KEY (zkapp_fee_payer_body_id) REFERENCES public.zkapp_fee_payers(id);
 
 
 --
@@ -3802,6 +3869,14 @@ ALTER TABLE ONLY public.zkapp_fee_payer_body
 
 ALTER TABLE ONLY public.zkapp_fee_payer_body
     ADD CONSTRAINT zkapp_fee_payer_body_zkapp_protocol_state_precondition_id_fkey FOREIGN KEY (zkapp_protocol_state_precondition_id) REFERENCES public.zkapp_protocol_state_precondition(id);
+
+
+--
+-- Name: zkapp_fee_payers zkapp_fee_payers_body_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.zkapp_fee_payers
+    ADD CONSTRAINT zkapp_fee_payers_body_id_fkey FOREIGN KEY (body_id) REFERENCES public.zkapp_fee_payer_body(id);
 
 
 --
@@ -4047,3 +4122,4 @@ ALTER TABLE ONLY public.zkapp_updates
 --
 -- PostgreSQL database dump complete
 --
+

--- a/src/app/rosetta/lib/account.ml
+++ b/src/app/rosetta/lib/account.ml
@@ -450,18 +450,17 @@ AS combo GROUP BY combo.pk_id
           UInt32.of_int (Int.of_int64_exn timing_info.cliff_time)
         in
         let cliff_amount =
-          MinaCurrency.Amount.of_int (Int.of_int64_exn timing_info.cliff_amount)
+          MinaCurrency.Amount.of_string timing_info.cliff_amount
         in
         let vesting_period =
           UInt32.of_int (Int.of_int64_exn timing_info.vesting_period)
         in
         let vesting_increment =
-          MinaCurrency.Amount.of_int
-            (Int.of_int64_exn timing_info.vesting_increment)
+          MinaCurrency.Amount.of_string
+            timing_info.vesting_increment
         in
         let initial_minimum_balance =
-          MinaCurrency.Balance.of_int
-            (Int.of_int64_exn timing_info.initial_minimum_balance)
+          MinaCurrency.Balance.of_string timing_info.initial_minimum_balance
         in
         Mina_base.Account.incremental_balance_between_slots ~start_slot ~end_slot
           ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -216,6 +216,7 @@ module Internal_command_info = struct
 end
 
 module Block_info = struct
+  (* TODO: should timestamp be string?; Block_time.t is an unsigned 64-bit int *)
   type t =
     { block_identifier: Block_identifier.t
     ; parent_block_identifier: Block_identifier.t
@@ -557,7 +558,7 @@ WITH RECURSIVE chain AS (
           { Internal_command_info.kind
           ; receiver= Internal_commands.Extras.receiver extras
           ; receiver_account_creation_fee_paid= Option.map (Internal_commands.Extras.receiver_account_creation_fee_paid extras) ~f:Unsigned.UInt64.of_int64
-          ; fee= Unsigned.UInt64.of_int64 ic.fee
+          ; fee= Unsigned.UInt64.of_string ic.fee
           ; token= `Token_id token_id
           ; sequence_no=Internal_commands.Extras.sequence_no extras
           ; secondary_sequence_no=Internal_commands.Extras.secondary_sequence_no extras
@@ -627,8 +628,8 @@ WITH RECURSIVE chain AS (
           ; fee_token= `Token_id fee_token
           ; token= `Token_id token
           ; nonce= Unsigned.UInt32.of_int64 uc.nonce
-          ; amount= Option.map ~f:Unsigned.UInt64.of_int64 uc.amount
-          ; fee= Unsigned.UInt64.of_int64 uc.fee
+          ; amount= Option.map ~f:Unsigned.UInt64.of_string uc.amount
+          ; fee= Unsigned.UInt64.of_string uc.fee
           ; hash= uc.hash
           ; failure_status= Some failure_status
           ; valid_until= Option.map ~f:Unsigned.UInt32.of_int64 uc.valid_until
@@ -642,7 +643,7 @@ WITH RECURSIVE chain AS (
     ; parent_block_identifier=
         { Block_identifier.index= raw_parent_block.height
         ; hash= raw_parent_block.state_hash }
-    ; timestamp= raw_block.timestamp
+    ; timestamp= Int64.of_string raw_block.timestamp
     ; internal_info= internal_commands
     ; user_commands }
 end


### PR DESCRIPTION
In the archive database, for columns representing OCaml unsigned 64-bit ints, use the Postgresql `text` type, to prevent any possibility of overflow. We retain the `bigint` type for values representing unsigned 32-bit values (slots and nonces).

Update the replayer and extract-blocks apps accordingly. For the replayer test data, ran `ALTER COLUMN .. TYPE text` on the affected columns, made sure the test succeeded locally.

Tested by running a local network, making sure payments and a zkApp were archived.

Part of #9182.