### PR TITLE
Add dhall to toolchain

### DIFF
--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -9,6 +9,9 @@ ARG deb_codename=focal
 ARG DOCKER_VERSION=19.03.4
 ARG TERRAFORM_VERSION=0.14.11
 ARG DEBS3_VERSION=0.11.6
+ARG DHALL_VERSION=1.41.1
+ARG DHALL_JSON_VERSION=1.7.10
+ARG DHALL_BASH_VERSION=1.0.40
 
 # location of repo used for pins and external package commits
 ARG MINA_DIR=mina
@@ -30,7 +33,6 @@ RUN sudo apt-get update -y \
     apt-utils \
     awscli \
     cmake \
-    dhall \
     jq \
     libboost-dev \
     libboost-program-options-dev \
@@ -105,3 +107,11 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
     && sudo apt update \
     && sudo apt install -y nodejs yarn
+
+# Dhall
+RUN curl -sL https://github.com/dhall-lang/dhall-haskell/releases/download/$DHALL_VERSION/dhall-$DHALL_VERSION-x86_64-linux.tar.bz2 \
+    | sudo tar --extract --file=- --bzip2 --directory=/usr ./bin/dhall
+RUN curl -sL https://github.com/dhall-lang/dhall-haskell/releases/download/$DHALL_VERSION/dhall-bash-$DHALL_BASH_VERSION-x86_64-linux.tar.bz2 \
+    | sudo tar --extract --file=- --bzip2 --directory=/usr ./bin/dhall-to-bash
+RUN curl -sL https://github.com/dhall-lang/dhall-haskell/releases/download/$DHALL_VERSION/dhall-json-$DHALL_JSON_VERSION-x86_64-linux.tar.bz2 \
+    | sudo tar --extract --file=- --bzip2 --directory=/usr ./bin/dhall-to-yaml

--- a/dockerfiles/stages/3-toolchain
+++ b/dockerfiles/stages/3-toolchain
@@ -30,6 +30,7 @@ RUN sudo apt-get update -y \
     apt-utils \
     awscli \
     cmake \
+    dhall \
     jq \
     libboost-dev \
     libboost-program-options-dev \


### PR DESCRIPTION
Adds dhall to Mina toolchain. Needed for https://github.com/MinaProtocol/mina/pull/10939
