### PR TITLE
Remove ocaml-extlib from .gitmodules and nix dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "src/external/async_kernel"]
 	path = src/external/async_kernel
 	url = https://github.com/MinaProtocol/async_kernel
-[submodule "src/external/ocaml-extlib"]
-	path = src/external/ocaml-extlib
-	url = https://github.com/MinaProtocol/ocaml-extlib.git
 [submodule "src/external/rpc_parallel"]
 	path = src/external/rpc_parallel
 	url = https://github.com/MinaProtocol/rpc_parallel.git

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -18,7 +18,6 @@ let
     "sodium"
     "capnp"
     "rpc_parallel"
-    "ocaml-extlib"
     "async_kernel"
     "base58"
     "graphql_ppx"


### PR DESCRIPTION
Remove ocaml-extlib from two places where it was missed. CC @Firobe
