### PR TITLE
Improvements for local network spinning up script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ maintenance/*.dot
 maintenance/*.png
 
 scripts/genesis_ledger.json
+scripts/annotated_ledger.json
 
 automation/*config.json
 automation/!bsconfig.json
@@ -81,3 +82,14 @@ automation/services/watchdog/check_libp2p/check_libp2p
 
 *.terraform.lock.hcl
 _opam
+
+target
+release
+Cargo.lock
+.vscode
+
+### IntelliJ IDEA ###
+**/.idea/
+*.iws
+*.iml
+*.ipr

--- a/scripts/run_local_network.sh
+++ b/scripts/run_local_network.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# set -x
 
 # exit script when commands fail
 set -e
@@ -13,12 +14,12 @@ LOGPROC=_build/default/src/app/logproc/logproc.exe
 
 export MINA_PRIVKEY_PASS='naughty blue worm'
 SEED_PEER_KEY="CAESQNf7ldToowe604aFXdZ76GqW/XVlDmnXmBT+otorvIekBmBaDWu/6ZwYkZzqfr+3IrEh6FLbHQ3VSmubV9I9Kpc=,CAESIAZgWg1rv+mcGJGc6n6/tyKxIehS2x0N1Uprm1fSPSqX,12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr"
-SEED_PEER_ID="/ip4/127.0.0.1/tcp/3002/p2p/12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr"
 
 SNARK_WORKER_FEE=0.01
 
 TRANSACTION_FREQUENCY=5
 
+SEED_START_PORT=3000
 WHALE_START_PORT=4000
 FISH_START_PORT=5000
 NODE_START_PORT=6000
@@ -29,6 +30,8 @@ NODE_START_PORT=6000
 whales=1
 fish=1
 nodes=1
+log_level="Trace"
+file_log_level=$log_level
 transactions=false
 reset=false
 
@@ -51,6 +54,12 @@ help() {
   echo "-w|--whales #"
   echo "-f|--fish #"
   echo "-n|--nodes #"
+  echo "-sp|--seed-start-port #"
+  echo "-wp|--whale-start-port #"
+  echo "-fp|--fish-start-port #"
+  echo "-np|--node-start-port #"
+  echo "-ll|--log-level <Spam | Trace | Debug | Info | Warn | Error | Faulty_peer | Fatal>"
+  echo "-fll|--file-log-level <Same as above values>"
   echo "-t|--transactions"
   echo "-r|--reset"
   echo "-h|--help"
@@ -83,9 +92,9 @@ exec-daemon() {
     -metrics-port $daemon_metrics_port \
     -libp2p-metrics-port $libp2p_metrics_port \
     -config-file $config \
-    -generate-genesis-proof true \
     -log-json \
-    -log-level Trace \
+    -log-level $log_level \
+    -file-log-level $file_log_level \
     $@
   exec $MINA daemon \
     -client-port $client_port \
@@ -94,9 +103,9 @@ exec-daemon() {
     -metrics-port $daemon_metrics_port \
     -libp2p-metrics-port $libp2p_metrics_port \
     -config-file $config \
-    -generate-genesis-proof true \
     -log-json \
-    -log-level Trace \
+    -log-level $log_level \
+    -file-log-level $file_log_level \
     $@
 }
 
@@ -116,6 +125,12 @@ while [[ "$#" -gt 0 ]]; do
         -w|--whales) whales="$2"; shift ;;
         -f|--fish) fish="$2"; shift ;;
         -n|--nodes) nodes="$2"; shift ;;
+        -sp|--seed-start-port) SEED_START_PORT="$2"; shift ;;
+        -wp|--whale-start-port) WHALE_START_PORT="$2"; shift ;;
+        -fp|--fish-start-port) FISH_START_PORT="$2"; shift ;;
+        -np|--node-start-port) NODE_START_PORT="$2"; shift ;;
+        -ll|--log-level) log_level="$2"; shift ;;
+        -fll|--file-log-level) file_log_level="$2"; shift ;;
         -t|--transactions) transactions=true ;;
         -r|--reset) reset=true ;;
         -h|--help) help ;;
@@ -124,9 +139,11 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+SEED_PEER_ID="/ip4/127.0.0.1/tcp/$(($SEED_START_PORT+2))/p2p/12D3KooWAFFq2yEQFFzhU5dt64AWqawRuomG9hL8rSmm5vxhAsgr"
+
 if $transactions; then
   if [ "$fish" -eq "0" ]; then
-    echo "sending transactions require at least one fish"
+    echo "Sending transactions require at least one fish"
     exit
   fi
 fi
@@ -136,21 +153,23 @@ echo -e "\t1 seed"
 echo -e "\t$whales whales"
 echo -e "\t$fish fish"
 echo -e "\t$nodes non block-producing nodes"
-echo -e "\tsending transactions: $transactions"
+echo -e "\tSending transactions: $transactions"
 
 # ================================================
 # Create genesis ledger
 
-ledgerfolder="/tmp/mina-local-network-$whales-$fish-$nodes"
+ledgerfolder="${HOME}/.mina-network/mina-local-network-$whales-$fish-$nodes"
 
 if $reset; then
   rm -rf "$ledgerfolder"
 fi
 
 if [ ! -d "$ledgerfolder" ]; then
-  echo "making ledger"
-  
-  mkdir $ledgerfolder
+  printf "\n"
+  echo "Making ledger"
+  printf "\n"
+
+  mkdir -p $ledgerfolder
 
   clean-dir $ledgerfolder/offline_whale_keys
   clean-dir $ledgerfolder/offline_fish_keys
@@ -159,11 +178,11 @@ if [ ! -d "$ledgerfolder" ]; then
   clean-dir $ledgerfolder/service-keys
 
   generate-keypair $ledgerfolder/snark_worker_keys/snark_worker_account
-  for i in $(seq 1 $fish); do
+  for ((i = 0; i < $fish; i++)); do
     generate-keypair $ledgerfolder/offline_fish_keys/offline_fish_account_$i
     generate-keypair $ledgerfolder/online_fish_keys/online_fish_account_$i
   done
-  for i in $(seq 1 $whales); do
+  for ((i = 0; i < $whales; i++)); do
     generate-keypair $ledgerfolder/offline_whale_keys/offline_whale_account_$i
     generate-keypair $ledgerfolder/online_whale_keys/online_whale_account_$i
   done
@@ -202,26 +221,32 @@ snark_worker_pubkey=$(cat $ledgerfolder/snark_worker_keys/snark_worker_account.p
 # Update Timestamp
 
 config=$ledgerfolder/daemon.json
-jq "{genesis: {genesis_state_timestamp:\"$(date +"%Y-%m-%dT%H:%M:%S.%6NZ")\"}, ledger:.}" \
-  < $ledgerfolder/genesis_ledger.json \
-  > $config
+
+if $reset; then
+  jq "{genesis: {genesis_state_timestamp:\"$(date +"%Y-%m-%dT%H:%M:%S%z")\"}, ledger:.}" \
+    < $ledgerfolder/genesis_ledger.json \
+    > $config
+fi
 
 # ================================================
 # Launch nodes
 
 nodesfolder=$ledgerfolder/nodes
-clean-dir $nodesfolder
+
+if $reset; then
+  clean-dir $nodesfolder
+  mkdir -p $nodesfolder/seed
+fi
 
 # ----------
 
-mkdir $nodesfolder/seed
-
-spawn-node $nodesfolder/seed 3000 -seed -discovery-keypair $SEED_PEER_KEY
+spawn-node $nodesfolder/seed ${SEED_START_PORT} -seed -discovery-keypair $SEED_PEER_KEY
 seed_pid=$!
 
-echo 'waiting for seed to go up...'
+printf "\n"
+echo 'Waiting for seed to go up...'
 
-until $MINA client status -daemon-port 3000 &> /dev/null
+until $MINA client status -daemon-port ${SEED_START_PORT} &> /dev/null
 do
   sleep 1
 done
@@ -230,66 +255,73 @@ done
 
 snark_worker_flags="-snark-worker-fee $SNARK_WORKER_FEE -run-snark-worker $snark_worker_pubkey -work-selection seq"
 
-for i in $(seq 1 $whales); do
+for ((i = 0; i < $whales; i++)); do
   folder=$nodesfolder/whale_$i
   keyfile=$ledgerfolder/online_whale_keys/online_whale_account_$i
-  mkdir $folder
-  spawn-node $folder $(($WHALE_START_PORT+($i-1)*5)) -peer $SEED_PEER_ID -block-producer-key $keyfile $snark_worker_flags
+  mkdir -p $folder
+  spawn-node $folder $(($WHALE_START_PORT+($i * 5))) -peer $SEED_PEER_ID -block-producer-key $keyfile $snark_worker_flags
   whale_pids[${i}]=$!
 done
 
 # ----------
 
-for i in $(seq 1 $fish); do
+for ((i = 0; i < $fish; i++)); do
   folder=$nodesfolder/fish_$i
   keyfile=$ledgerfolder/online_fish_keys/online_fish_account_$i
-  mkdir $folder
-  spawn-node $folder $(($FISH_START_PORT+($i-1)*5)) -peer $SEED_PEER_ID -block-producer-key $keyfile $snark_worker_flags
+  mkdir -p $folder
+  spawn-node $folder $(($FISH_START_PORT+($i * 5))) -peer $SEED_PEER_ID -block-producer-key $keyfile $snark_worker_flags
   fish_pids[${i}]=$!
 done
 
 # ----------
 
-for i in $(seq 1 $nodes); do
+for ((i = 0; i < $nodes; i++)); do
   folder=$nodesfolder/node_$i
-  mkdir $folder
-  spawn-node $folder $(($NODE_START_PORT+($i-1)*5)) -peer $SEED_PEER_ID
+  mkdir -p $folder
+  spawn-node $folder $(($NODE_START_PORT+($i * 5))) -peer $SEED_PEER_ID
   node_pids[${i}]=$!
 done
 
 # ================================================
 
-echo "Node information:"
+printf "\n"
+echo "Network participants information:"
 
-echo -e "\tseed"
-echo -e "\t\t1"
+echo -e "\tSeed"
+echo -e "\t\tInstance #0"
 echo -e "\t\t  pid $seed_pid"
-echo -e "\t\t  status: $MINA client status -daemon-port 3000"
+echo -e "\t\t  status: $MINA client status -daemon-port ${SEED_START_PORT}"
 echo -e "\t\t  logs: cat $nodesfolder/seed/log.txt | $LOGPROC"
 
-echo -e "\twhales"
-for i in $(seq 1 $whales); do
-  echo -e "\t\t$i"
-  echo -e "\t\t  pid ${whale_pids[${i}]}"
-  echo -e "\t\t  status: $MINA client status -daemon-port $(($WHALE_START_PORT+($i-1)*5))"
-  echo -e "\t\t  logs: cat $nodesfolder/whale_$i/log.txt | $LOGPROC"
-done
+if [ "$whales" -gt "0" ]; then
+  echo -e "\tWhales"
+  for ((i = 0; i < $whales; i++)); do
+    echo -e "\t\tInstance #$i"
+    echo -e "\t\t  pid ${whale_pids[${i}]}"
+    echo -e "\t\t  status: $MINA client status -daemon-port $(($WHALE_START_PORT+($i * 5)))"
+    echo -e "\t\t  logs: cat $nodesfolder/whale_$i/log.txt | $LOGPROC"
+  done
+fi
 
-echo -e "\tfish"
-for i in $(seq 1 $fish); do
-  echo -e "\t\t$i"
-  echo -e "\t\t  pid ${fish_pids[${i}]}"
-  echo -e "\t\t  status: $MINA client status -daemon-port $(($FISH_START_PORT+($i-1)*5))"
-  echo -e "\t\t  logs: cat $nodesfolder/fish_$i/log.txt | $LOGPROC"
-done
+if [ "$fish" -gt "0" ]; then
+  echo -e "\tFish"
+  for ((i = 0; i < $fish; i++)); do
+    echo -e "\t\tInstance #$i"
+    echo -e "\t\t  pid ${fish_pids[${i}]}"
+    echo -e "\t\t  status: $MINA client status -daemon-port $(($FISH_START_PORT+($i * 5)))"
+    echo -e "\t\t  logs: cat $nodesfolder/fish_$i/log.txt | $LOGPROC"
+  done
+fi
 
-echo -e "\tnodes"
-for i in $(seq 1 $nodes); do
-  echo -e "\t\t$i"
-  echo -e "\t\t  pid ${node_pids[${i}]}"
-  echo -e "\t\t  status: $MINA client status -daemon-port $(($NODE_START_PORT+($i-1)*5))"
-  echo -e "\t\t  logs: cat $nodesfolder/node_$i/log.txt | $LOGPROC"
-done
+if [ "$nodes" -gt "0" ]; then
+  echo -e "\tNon block-producing nodes"
+  for ((i = 0; i < $nodes; i++)); do
+    echo -e "\t\tInstance #$i"
+    echo -e "\t\t  pid ${node_pids[${i}]}"
+    echo -e "\t\t  status: $MINA client status -daemon-port $(($NODE_START_PORT+($i * 5)))"
+    echo -e "\t\t  logs: cat $nodesfolder/node_$i/log.txt | $LOGPROC"
+  done
+fi
 
 # ================================================
 # Start sending transactions
@@ -298,16 +330,16 @@ if $transactions; then
   folder=$nodesfolder/fish_1
   keyfile=$ledgerfolder/online_fish_keys/online_fish_account_1
   pubkey=$(cat $ledgerfolder/online_fish_keys/online_fish_account_1.pub)
-  rest_server="http://127.0.0.1:5001/graphql"
+  rest_server="http://127.0.0.1:$(($FISH_START_PORT+1))/graphql"
+  printf "\n"
+  echo "Waiting for node to be up to start sending transactions..."
 
-  echo "waiting for node to be up to start sending transactions..."
-
-  until $MINA client status -daemon-port 5000 &> /dev/null
+  until $MINA client status -daemon-port $FISH_START_PORT &> /dev/null
   do
     sleep 1
   done
 
-  echo "starting to send transactions every $transaction_frequency seconds"
+  echo "Starting to send transactions every $transaction_frequency seconds"
 
   set +e
 


### PR DESCRIPTION
* The real issue we address here is the way of `genesis_state_timestamp` updating.
  * Using previous date-time formatting string `%Y-%m-%dT%H:%M:%S.%6NZ` (time-zone specifically) is not acceptable by Node at least on `macOS` (on `compatible` and `develop` branches).
* `BREAKING CHANGES` introduced, hence, targets `develop`:
  * The `ledgerfolder` default path was changed in order to preserve `work-dir` after the OS restart.
* Everything else is just a usability/cosmetic improvements.
* The `-generate-genesis-proof` Daemon's CLI arg was removed since it was deprecated;
* Fix bug with `reset=false` option in order to prevent the `work-dir` cleaning up between scrip restarts.