### PR TITLE
Lint for multiple versioned types in module

### DIFF
--- a/scripts/compare_versioned_items.py
+++ b/scripts/compare_versioned_items.py
@@ -44,7 +44,7 @@ def compare_items (item_kind,fn,original,modified) :
             mod = None
         if not (mod is None or mod == orig) :
             print ('In file: ' + fn)
-            print ('  ' + item_kind + ' changed at module path: ' + path)
+            print ('  ' + item_kind + ' changed at path: ' + path)
             print ('  Was: ' + orig)
             print ('  Now: ' + mod)
             global exit_code


### PR DESCRIPTION
The versioned type linter was detecting changes to at most one type in a module, because the Python script builds a dictionary where the key was a module path printed by `print_versioned_types`. That tool relies on the printer invoked by `deriving version`.

That mean that changes to `query` types in RPC modules were not being detected in CI; the dictionary entry was overwritten with an entry for the `response` type.

Modify the printer to append the type to the module path.