### PR TITLE
Remove vestiges of coda-archive-processor-test

### DIFF
--- a/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
@@ -44,10 +44,6 @@ Pipeline.build
                   [ "bash buildkite/scripts/setup-database-for-archive-node.sh ${user} ${password} ${db}"
                   , "PGPASSWORD=${password} psql -h localhost -p 5432 -U ${user} -d ${db} -a -f src/app/archive/create_schema.sql"
                   , WithCargo.withCargo "eval \\\$(opam config env) && dune runtest src/app/archive"
-                  , "PGPASSWORD=codarules psql -h localhost -p 5432 -U admin -d archiver -a -f src/app/archive/drop_tables.sql"
-                  , "PGPASSWORD=${password} psql -h localhost -p 5432 -U ${user} -d ${db} -a -f src/app/archive/create_schema.sql"
-                  , "make libp2p_helper"
-                  , "./scripts/test.py run --non-interactive --collect-artifacts --yes --out-dir 'test_output' 'test_archive_processor:coda-archive-processor-test'"
                   ])
             , label = "Archive node unit tests"
             , key = "archive-unit-tests"

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -74,10 +74,6 @@ medium_curves_and_other_tests = {
     'test_postake_full_epoch': ['full-test'],
 }
 
-archive_processor_test = {
-    'test_archive_processor': ['coda-archive-processor-test'],
-}
-
 medium_curve_profiles_full = [
     'test_postake_medium_curves', 'testnet_postake_medium_curves',
     'testnet_postake_many_producers_medium_curves'
@@ -406,7 +402,6 @@ class OutDirectory:
 def run(args):
     all_tests = small_curves_tests
     all_tests.update(medium_curves_and_other_tests)
-    all_tests.update(archive_processor_test)
     all_tests.update({
         profile: compile_config_agnostic_tests
         for profile in compile_config_agnostic_profiles


### PR DESCRIPTION
Remove mention of coda-archive-processor-test in `ArchiveNodeUnitTest.dhall` and `test.py`.

The actual test was removed in b26ecf36d2ba0a80fa8c11ed872c3fc560be3445.