### PR TITLE
Remove archive-processor-test from test.py

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -74,10 +74,6 @@ medium_curves_and_other_tests = {
     'test_postake_full_epoch': ['full-test'],
 }
 
-archive_processor_test = {
-    'test_archive_processor': ['coda-archive-processor-test'],
-}
-
 medium_curve_profiles_full = [
     'test_postake_medium_curves', 'testnet_postake_medium_curves',
     'testnet_postake_many_producers_medium_curves'
@@ -406,7 +402,6 @@ class OutDirectory:
 def run(args):
     all_tests = small_curves_tests
     all_tests.update(medium_curves_and_other_tests)
-    all_tests.update(archive_processor_test)
     all_tests.update({
         profile: compile_config_agnostic_tests
         for profile in compile_config_agnostic_profiles


### PR DESCRIPTION
Remove mention of the deleted `coda-archive-processor-test` in `test.py`.

That was done in `compatible` in #11155, this is for `develop`.