### PR TITLE
Steven ledger gen fix

### DIFF
--- a/automation/README.md
+++ b/automation/README.md
@@ -56,7 +56,7 @@ For the purposes of this README we are assuming the following:
 
 - You have `node` version `14.x` installed to your machine. (Note that later releases of `node` and `npm` may cause compatibility issues with the `node-fetch` module used for certain scripts and ledger generation. The newer version of `node-fetch` has not been tested: https://github.com/node-fetch/node-fetch/blob/HEAD/docs/v3-UPGRADE-GUIDE.md)
 
-- You have installed and initialized the `yarn` build tool by running `yarn install` and `yarn build` from within the ./automation directory 
+- You have installed and initialized the `yarn` build tool by running `yarn install` and `yarn build` from within the ./automation directory, before building your testnet
 
 # What is a Testnet
 

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,5 +1,5 @@
 <a href="https://minaprotocol.com">
-	<img width="200" src="https://minaprotocol.com/static/Mina_Wordmark_Github.png" alt="Mina Logo" />
+	<img width="200" src="https://github.com/MinaProtocol/docs/blob/main/public/static/img/svg/mina-wordmark-redviolet.svg?raw=true&sanitize=true" alt="Mina Logo" />
 </a>
 <hr/>
 
@@ -51,6 +51,12 @@ For the purposes of this README we are assuming the following:
 
 - You have Kubectl configured for the GKE cluster of your choice: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl
   TL;DR: `gcloud container clusters get-credentials -region us-east1 coda-infra-east`
+
+- You have `jq` installed on your local machine. jq is a json processor that is used to create the testnet ledger
+
+- You have `node` version `14.x` installed to your machine. (Note that later releases of `node` and `npm` may cause compatibility issues with the `node-fetch` module used for certain scripts and ledger generation. The newer version of `node-fetch` has not been tested: https://github.com/node-fetch/node-fetch/blob/HEAD/docs/v3-UPGRADE-GUIDE.md)
+
+- You have installed and initialized the `yarn` build tool by running `yarn install` and `yarn build` from within the ./automation directory 
 
 # What is a Testnet
 
@@ -158,12 +164,14 @@ Once decided on a cluster/context to deploy, use the following command to retrie
 
 There is a testnet module variable which determines the *Kubernetes* context to deploy to. Reference the module's [variable definitions](./terraform/modules/kubernetes/testnet/variables.tf) for more details on how to properly configure.
 
-```variable "k8s_context" {
+```
+variable "k8s_context" {
   type = string
 
   description = "K8s resource provider context"
   default     = "gke_o1labs-192920_us-east1_coda-infra-east"
-}```
+}
+```
 
 #### Set Terraform Kubernetes provider configuration path
 
@@ -171,7 +179,7 @@ In order for Terraform to locate and identify the configured Kubernetes contexts
 
 ```
 export KUBE_CONFIG_PATH=~/.kube/config
-}```
+```
 
 ### Generate Keys and Genesis Ledger
 

--- a/automation/scripts/generate-keys-and-ledger.sh
+++ b/automation/scripts/generate-keys-and-ledger.sh
@@ -374,7 +374,7 @@ ${TESTNET}_extra-fish
 add_another_to_prompt ${TESTNET}_offline-whales ${WHALE_AMOUNT} ${TESTNET}_online-whales
 add_another_to_prompt ${TESTNET}_offline-fish ${FISH_AMOUNT} ${TESTNET}_online-fish
 add_another_to_prompt ${TESTNET}_online-fish ${FISH_AMOUNT} ${TESTNET}_online-fish
-add_another_to_prompt ${TESTNET}_online-o1 ${FISH_AMOUNT} ${TESTNET}_online-o1
+# add_another_to_prompt ${TESTNET}_online-o1 ${FISH_AMOUNT} ${TESTNET}_online-o1
 
 if [ -s keys/keysets/${TESTNET}_bots_keyfiles ];
 then


### PR DESCRIPTION
Explain your changes:
This PR is to update the README documentation used for deploying mina testnets using Google Cloud and Terraform infra-as-code. Additionally, this PR fixes a bug that prevented the `generate-keys-and-ledger.sh` script from properly outputing a testnet ledger. 

Explain how you tested your changes:
The change for the ledger gen script has been tested locally by running the `generate-key-and-ledger.sh` script locally on my machine, using a clean checkout from both develop and compatible to ensue compatibility. 


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [X] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them

* Closes #11139 
