### PR TITLE
Remove `feature_tokens`, `feature_zkapps` flags in configurations

### DIFF
--- a/src/config/features/dev.mlh
+++ b/src/config/features/dev.mlh
@@ -1,3 +1,1 @@
-[%%define feature_tokens true]
-[%%define feature_zkapps true]
 [%%define mainnet false]

--- a/src/config/features/mainnet.mlh
+++ b/src/config/features/mainnet.mlh
@@ -1,3 +1,1 @@
-[%%define feature_tokens false]
-[%%define feature_zkapps true]
 [%%define mainnet true]

--- a/src/config/features/public_testnet.mlh
+++ b/src/config/features/public_testnet.mlh
@@ -1,3 +1,1 @@
-[%%define feature_tokens false]
-[%%define feature_zkapps true]
 [%%define mainnet false]

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -337,27 +337,6 @@ end
 
 let check = Fn.id
 
-[%%if not feature_zkapps]
-
-let check (t : Binable_arg.t) =
-  let t = check t in
-  match t.zkapp with
-  | None ->
-      t
-  | Some _ ->
-      failwith "Snapp accounts not supported"
-
-[%%endif]
-
-[%%if not feature_tokens]
-
-let check (t : Binable_arg.t) =
-  let t = check t in
-  if Token_id.equal Token_id.default t.token_id then t
-  else failwith "Token accounts not supported"
-
-[%%endif]
-
 [%%versioned_binable
 module Stable = struct
   module V2 = struct


### PR DESCRIPTION
`feature_zkapps` was `true` for all configurations, so it wasn't useful.

`feature_tokens` was `false` for `public_testnet`, which meant that token transfers failed mysteriously in integration tests.

