### PR TITLE
Enable `whole_program` compilation for SnarkyJS

### DIFF
--- a/scripts/build-snarkyjs-node.sh
+++ b/scripts/build-snarkyjs-node.sh
@@ -6,7 +6,8 @@ pushd "$SNARKY_JS_PATH"
 popd
 
 dune b src/lib/crypto/kimchi_bindings/js/node_js \
-&& dune b src/lib/snarky_js_bindings/snarky_js_node.bc.js src/lib/snarky_js_bindings/snarkyjs/src/snarky/gen/js-layout.ts || exit 1
+&& dune b src/lib/snarky_js_bindings/snarky_js_node.bc.js \
+&& dune b src/lib/snarky_js_bindings/snarkyjs/src/snarky/gen/js-layout.ts || exit 1
 
 BINDINGS_PATH="$SNARKY_JS_PATH"/dist/server/node_bindings/
 mkdir -p "$BINDINGS_PATH"

--- a/scripts/build-snarkyjs-node.sh
+++ b/scripts/build-snarkyjs-node.sh
@@ -5,6 +5,8 @@ pushd "$SNARKY_JS_PATH"
   [ -d node_modules ] || npm i
 popd
 
+export DUNE_USE_DEFAULT_LINKER="y"
+
 dune b src/lib/crypto/kimchi_bindings/js/node_js \
 && dune b src/lib/snarky_js_bindings/snarky_js_node.bc.js \
 && dune b src/lib/snarky_js_bindings/snarkyjs/src/snarky/gen/js-layout.ts || exit 1

--- a/src/dune.linker.inc
+++ b/src/dune.linker.inc
@@ -9,5 +9,8 @@
 
 (rule
   (target dune-linker)
-  (enabled_if (= %{bin-available:lld} false))
+  (enabled_if
+    (or
+      (= %{bin-available:lld} false)
+      (= %{env:DUNE_USE_DEFAULT_LINKER=n} n)))
   (action (with-stdout-to dune-linker (echo " "))))

--- a/src/lib/crypto/kimchi_bindings/dune
+++ b/src/lib/crypto/kimchi_bindings/dune
@@ -1,2 +1,0 @@
-(data_only_dirs wasm)
-

--- a/src/lib/crypto/kimchi_bindings/js/chrome/dune
+++ b/src/lib/crypto/kimchi_bindings/js/chrome/dune
@@ -15,7 +15,8 @@
    flags.sexp
    snippets/)
  (deps
-  (source_tree ../../wasm)
+  ../../wasm/Cargo.toml
+  (source_tree ../../wasm/src)
   (source_tree ../../wasm/.cargo/config)
   (source_tree ../../../../../external/wasm-bindgen-rayon)
   (source_tree ../../../proof-systems) )

--- a/src/lib/crypto/kimchi_bindings/js/node_js/dune
+++ b/src/lib/crypto/kimchi_bindings/js/node_js/dune
@@ -14,7 +14,8 @@
    plonk_wasm.js
    flags.sexp)
  (deps
-  (source_tree ../../wasm)
+  ../../wasm/Cargo.toml
+  (source_tree ../../wasm/src)
   (source_tree ../../wasm/.cargo/config)
   (source_tree ../../../../../external/wasm-bindgen-rayon)
   (source_tree ../../../proof-systems) )

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [lib]
 name = "wires_15_stubs"
-crate-type = ["lib", "staticlib"]
+crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
 array-init = "2.0.0"

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -15,7 +15,7 @@
 
 (rule
  (enabled_if (= %{env:MARLIN_PLONK_STUBS=n} n))
- (targets libwires_15_stubs.a)
+ (targets libwires_15_stubs.a dllwires_15_stubs.so)
  (deps
   Cargo.toml
   (source_tree src)
@@ -27,7 +27,8 @@
     RUSTFLAGS
     "-C target-feature=+bmi2,+adx"
     (run cargo build --release))
-   (run cp %{read:cargo-target-path}/release/libwires_15_stubs.a .))))
+   (run cp %{read:cargo-target-path}/release/libwires_15_stubs.a .)
+   (run cp %{read:cargo-target-path}/release/libwires_15_stubs.so dllwires_15_stubs.so))))
 
 ;; copy from $MARLIN_PLONK_STUBS if this exists
 (copy_files

--- a/src/lib/crypto/kimchi_bindings/wasm/dune
+++ b/src/lib/crypto/kimchi_bindings/wasm/dune
@@ -1,0 +1,3 @@
+(data_only_dirs src)
+
+(dirs :standard \ target)

--- a/src/lib/dummy_values/gen_values/dune
+++ b/src/lib/dummy_values/gen_values/dune
@@ -1,5 +1,6 @@
 (executable
  (name gen_values)
+ (link_flags (-linkall))
  (libraries
    ;; opam libraries
    async_unix

--- a/src/lib/pickles/plonk_checks/gen_scalars/dune
+++ b/src/lib/pickles/plonk_checks/gen_scalars/dune
@@ -1,5 +1,7 @@
 (executable
  (name gen_scalars)
+ (modes native)
+ (link_flags (-linkall))
  (libraries
    ;; opam libraries
    core_kernel

--- a/src/lib/snarky_js_bindings/dune
+++ b/src/lib/snarky_js_bindings/dune
@@ -1,7 +1,11 @@
+(env
+  (_ (js_of_ocaml (compilation_mode whole_program))))
+
 (executable
  (name snarky_js_node)
  (modules snarky_js_node)
  (modes js)
+ (link_flags (-noautolink))
  (js_of_ocaml
   (flags +toplevel.js +dynlink.js))
  (libraries snarky_js_bindings_lib node_backend)
@@ -18,6 +22,7 @@
  (name snarky_js_chrome)
  (modules snarky_js_chrome)
  (modes js)
+ (link_flags (-noautolink))
  (js_of_ocaml
   (flags +toplevel.js +dynlink.js))
  (libraries snarky_js_bindings_lib chrome_backend)

--- a/src/lib/snarky_js_bindings/dune
+++ b/src/lib/snarky_js_bindings/dune
@@ -38,6 +38,7 @@
 (executable
  (name snarky_js_types)
  (modules snarky_js_types)
+ (link_flags (-linkall))
  (modes native)
  (libraries mina_base fields_derivers_zkapps yojson)
  (instrumentation


### PR DESCRIPTION
This PR tinkers with some dune flags to allow us to compile SnarkyJS in `whole_program` mode. This reduces the size of `snarky_js_node.bc.js` to 5.1 MB.

This is the spiritual successor to #11103, but is actually in a mergeable state.

```bash
$ ls -Alh _build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.js
-r--r--r-- 1 matthew matthew 5.1M Jun  3 04:48 _build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.js
```

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them