### PR TITLE
Log snark work in zkapps integration test

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -527,6 +527,18 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                     "Ledger update and requested update are incompatible" ) ) )
         )
     in
+    (* Log snark work as it comes in. *)
+    don't_wait_for
+      (let rec go () =
+         let open Deferred.Let_syntax in
+         match%bind wait_for t (Wait_condition.snark_work ()) with
+         | Ok _ ->
+             [%log info] "Received new snark work" ;
+             go ()
+         | Error _ ->
+             Deferred.return ()
+       in
+       go () ) ;
     let%bind () =
       section_hard "Wait for proof to be emitted"
         (wait_for t

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -406,6 +406,25 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       [%log info] "ZkApp transactions included in transition frontier"
     in
+    let stop_logging_snark_work = Ivar.create () in
+    (* Log snark work as it comes in. *)
+    don't_wait_for
+      (let rec go () =
+         let open Deferred.Let_syntax in
+         match%bind
+           Deferred.any
+             [ Deferred.Result.map_error ~f:ignore
+                 (wait_for t (Wait_condition.snark_work ()))
+             ; Ivar.read stop_logging_snark_work
+             ]
+         with
+         | Ok _ ->
+             [%log info] "Received new snark work" ;
+             go ()
+         | Error () ->
+             Deferred.return ()
+       in
+       go () ) ;
     let%bind () =
       section_hard "Send a zkApp transaction to create zkApp accounts"
         (send_zkapp ~logger node parties_create_account)
@@ -527,25 +546,6 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                     "Ledger update and requested update are incompatible" ) ) )
         )
     in
-    let stop_logging_snark_work = Ivar.create () in
-    (* Log snark work as it comes in. *)
-    don't_wait_for
-      (let rec go () =
-         let open Deferred.Let_syntax in
-         match%bind
-           Deferred.any
-             [ Deferred.Result.map_error ~f:ignore
-                 (wait_for t (Wait_condition.snark_work ()))
-             ; Ivar.read stop_logging_snark_work
-             ]
-         with
-         | Ok _ ->
-             [%log info] "Received new snark work" ;
-             go ()
-         | Error () ->
-             Deferred.return ()
-       in
-       go () ) ;
     let%bind () =
       section_hard "Wait for proof to be emitted"
         (wait_for t

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -374,6 +374,8 @@ module Dsl = struct
 
     val snapp_to_be_included_in_frontier :
       has_failures:bool -> parties:Mina_base.Parties.t -> t
+
+    val snark_work : unit -> t
   end
 
   module type Util_intf = sig

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -226,4 +226,12 @@ struct
     ; soft_timeout = Slots soft_timeout_in_slots
     ; hard_timeout = Slots (soft_timeout_in_slots * 2)
     }
+
+  let snark_work () =
+    let check () _ _ = Predicate_passed in
+    { description = "snark work was received"
+    ; predicate = Event_predicate (Event_type.Snark_work_gossip, (), check)
+    ; soft_timeout = Slots 1
+    ; hard_timeout = Slots 1
+    }
 end


### PR DESCRIPTION
This PR adds snark work gossip logs to the zkapps integration test.

This test often fails after a long wait with no progress; adding these logs will give us a better indication of the cause of these failures, and can operate as a kind of 'progress bar' while we wait.

To keep this PR small and simple, this abuses the `Wait_condition` logic rather than creating a more-complete event logging system.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them