### PR TITLE
dune: add (sandbox none) to mina_version, ocaml-rocksdb

### DIFF
--- a/src/external/ocaml-rocksdb/dune
+++ b/src/external/ocaml-rocksdb/dune
@@ -15,9 +15,10 @@
  (libraries dune.configurator)
  )
 
+;; todo: fails with sandbox, since the generated flags are opaque to dune
 (rule
  (targets flags.sexp)
- (deps librocksdb_stubs.a)
+ (deps librocksdb_stubs.a (sandbox none))
  (action (run ./rocks_linker_flags_gen.exe)))
 
 (rule

--- a/src/lib/mina_version/normal/dune
+++ b/src/lib/mina_version/normal/dune
@@ -8,5 +8,8 @@
 
 (rule
  (targets mina_version.ml)
- (deps (:< gen.sh) (universe))
+ (deps
+   (sandbox none)
+   (:< gen.sh)
+   (universe))
  (action (run %{<} %{targets})))

--- a/src/lib/zexe_backend/zexe_backend_common/dune
+++ b/src/lib/zexe_backend/zexe_backend_common/dune
@@ -38,5 +38,8 @@
 
 (rule
  (targets version.ml)
- (deps (:< gen_version.sh) (source_tree src/lib/marlin))
+ (deps
+  (:< gen_version.sh)
+  (source_tree src/lib/marlin)
+  (sandbox none))
  (action (run %{<} %{targets})))


### PR DESCRIPTION
Explain your changes:
* This PR has been split from https://github.com/MinaProtocol/mina/pull/11092 because of it's (codeowners/line) percentage.
* It adds support building these targets with `DUNE_SANDBOX=symlink`, which we want to start doing in CI in the future.
* companion `develop` PR #11174

Explain how you tested your changes:
* Built these targets with `dune b --sandbox=symlink`


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
