### PR TITLE
[develop] dune: add (sandbox none) to mina_version, ocaml-rocksdb

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/dune
+++ b/src/lib/crypto/kimchi_backend/common/dune
@@ -45,6 +45,7 @@
  (targets version.ml)
  (deps
   (:< gen_version.sh)
-  (source_tree ../../proof-systems))
+  (source_tree ../../proof-systems)
+  (sandbox none))
  (action
   (run %{<} %{targets})))


### PR DESCRIPTION
Companion PR for https://github.com/MinaProtocol/mina/pull/11173

- dune: add (sandbox none) to mina_version, ocaml-rocksdb
- dune: add (sandbox none) to zexe_backend_common/version.ml
- dune: add (sandbox dune) to kimchi_backend/common/version.ml

