### PR TITLE
Token integration test

### DIFF
--- a/src/app/test_executive/dune
+++ b/src/app/test_executive/dune
@@ -42,6 +42,7 @@
    integers
    user_command_input
    participating_state
+   parties_builder
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_coda ppx_version)))

--- a/src/app/test_executive/snarkyjs.ml
+++ b/src/app/test_executive/snarkyjs.ml
@@ -55,7 +55,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       let%map () =
         wait_for t @@ with_timeout
-        @@ Wait_condition.snapp_to_be_included_in_frontier ~has_failures:false
+        @@ Wait_condition.zkapp_to_be_included_in_frontier ~has_failures:false
              ~parties
       in
       [%log info] "zkApp transaction included in transition frontier"

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -25,8 +25,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ; { balance = "1000000000"; timing = Untimed }
         ]
     ; extra_genesis_accounts =
-        [ { balance = "1000"; timing = Untimed }
-        ; { balance = "1000"; timing = Untimed }
+        [ { balance = "2000000000"; timing = Untimed }
+        ; { balance = "2000000000"; timing = Untimed }
         ]
     ; num_archive_nodes = 1
     ; num_snark_workers = 2
@@ -71,7 +71,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let open Malleable_error.Let_syntax in
     let logger = Logger.create () in
     let block_producer_nodes = Network.block_producers network in
-    (*TODO: capture snark worker processes' failures*)
+    (* TODO: capture snark worker processes' failures *)
     let%bind () =
       section_hard "Wait for nodes to initialize"
         (wait_for t
@@ -96,8 +96,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
             (zkapp_keypair.public_key |> Signature_lib.Public_key.compress)
             Token_id.default )
     in
-    let%bind parties_create_account =
-      (* construct a Parties.t, similar to zkapp_test_transaction create-snapp-account *)
+    let%bind parties_create_accounts =
+      (* construct a Parties.t, similar to zkapp_test_transaction create-zkapp-account *)
       let amount = Currency.Amount.of_int 10_000_000_000 in
       let nonce = Account.Nonce.zero in
       let memo =
@@ -131,7 +131,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let memo =
         Signed_command_memo.create_from_string_exn "Zkapp update permissions"
       in
-      (*Lower fee so that parties_create_account gets applied first*)
+      (* Lower fee so that parties_create_accounts gets applied first *)
       let fee = Currency.Fee.of_int 10_000_000 in
       let new_permissions : Permissions.t =
         { Permissions.user_default with
@@ -316,6 +316,93 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       in
       Transaction_snark.For_tests.update_states ~constraint_constants spec
     in
+    let parties_mint_token, parties_token_transfer =
+      (* similar to tokens tests in transaction_snark/tests/zkapp_tokens.ml
+         and `Mina_ledger.Ledger`
+
+         the token owner account has already been created here, so don't
+         need that as a separate transaction
+      *)
+      let account_creation_fee_int =
+        Currency.Fee.to_int constraint_constants.account_creation_fee
+      in
+      let token_funder = fish1_kp in
+      let token_owner = fish2_kp in
+      let token_account1 = Signature_lib.Keypair.create () in
+      let token_account2 = Signature_lib.Keypair.create () in
+      let custom_token_id =
+        Account_id.derive_token_id
+          ~owner:
+            (Account_id.create
+               (Signature_lib.Public_key.compress token_owner.public_key)
+               Token_id.default )
+      in
+      let keymap =
+        List.fold [ token_funder; token_owner; token_account1; token_account2 ]
+          ~init:Signature_lib.Public_key.Compressed.Map.empty
+          ~f:(fun map { private_key; public_key } ->
+            Signature_lib.Public_key.Compressed.Map.add_exn map
+              ~key:(Signature_lib.Public_key.compress public_key)
+              ~data:private_key )
+      in
+      let parties_mint_token =
+        let open Parties_builder in
+        let fee_payer_pk =
+          Signature_lib.Public_key.compress token_funder.public_key
+        in
+        let with_dummy_signatures =
+          mk_forest
+            [ mk_node
+                (mk_party_body Call token_owner Token_id.default
+                   (-account_creation_fee_int) )
+                [ mk_node
+                    (mk_party_body Call token_account1 custom_token_id 10000)
+                    []
+                ]
+            ]
+          |> mk_parties_transaction ~fee:12_000_000 ~fee_payer_pk
+               ~fee_payer_nonce:(Account.Nonce.of_int 2)
+        in
+        replace_authorizations ~keymap with_dummy_signatures
+      in
+      let parties_token_transfer =
+        let open Parties_builder in
+        let fee_payer_pk =
+          Signature_lib.Public_key.compress token_funder.public_key
+        in
+        (* lower fee than minting Parties.t *)
+        let with_dummy_signatures =
+          mk_forest
+            [ mk_node
+                (mk_party_body Call token_owner Token_id.default
+                   (-account_creation_fee_int) )
+                [ mk_node
+                    (mk_party_body Call token_account1 custom_token_id (-30))
+                    []
+                ; mk_node
+                    (mk_party_body Call token_account2 custom_token_id 30)
+                    []
+                ; mk_node
+                    (mk_party_body Call token_account1 custom_token_id (-10))
+                    []
+                ; mk_node
+                    (mk_party_body Call token_account2 custom_token_id 10)
+                    []
+                ; mk_node
+                    (mk_party_body Call token_account2 custom_token_id (-5))
+                    []
+                ; mk_node
+                    (mk_party_body Call token_account1 custom_token_id 5)
+                    []
+                ]
+            ]
+          |> mk_parties_transaction ~fee:11_000_000 ~fee_payer_pk
+               ~fee_payer_nonce:(Account.Nonce.of_int 3)
+        in
+        replace_authorizations ~keymap with_dummy_signatures
+      in
+      (parties_mint_token, parties_token_transfer)
+    in
     let with_timeout =
       let soft_slots = 4 in
       let soft_timeout = Network_time_span.Slots soft_slots in
@@ -401,7 +488,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let wait_for_zkapp parties =
       let%map () =
         wait_for t @@ with_timeout
-        @@ Wait_condition.snapp_to_be_included_in_frontier ~has_failures:false
+        @@ Wait_condition.zkapp_to_be_included_in_frontier ~has_failures:false
              ~parties
       in
       [%log info] "ZkApp transactions included in transition frontier"
@@ -413,7 +500,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section_hard "Send a zkApp transaction to create zkApp accounts"
-        (send_zkapp ~logger node parties_create_account)
+        (send_zkapp ~logger node parties_create_accounts)
     in
     let%bind () =
       section_hard "Send a zkApp transaction to update permissions"
@@ -433,7 +520,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section_hard
         "Wait for zkapp to create accounts to be included in transition \
          frontier"
-        (wait_for_zkapp parties_create_account)
+        (wait_for_zkapp parties_create_accounts)
     in
     let%bind () =
       section_hard
@@ -504,6 +591,22 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section_hard "Send a zkApp transaction with a nonexistent fee payer"
         (send_invalid_zkapp ~logger node parties_nonexistent_fee_payer
            "Fee_payer_account_not_found" )
+    in
+    let%bind () =
+      section_hard "Send a zkApp transaction to mint token"
+        (send_zkapp ~logger node parties_mint_token)
+    in
+    let%bind () =
+      section_hard "Send a zkApp transaction to transfer tokens"
+        (send_zkapp ~logger node parties_token_transfer)
+    in
+    let%bind () =
+      section_hard "Wait for zkApp transaction to mint token"
+        (wait_for_zkapp parties_mint_token)
+    in
+    let%bind () =
+      section_hard "Wait for zkApp transaction to transfer tokens"
+        (wait_for_zkapp parties_token_transfer)
     in
     let%bind () =
       section_hard "Verify zkApp transaction updates in ledger"

--- a/src/app/test_executive/zkapps_timing.ml
+++ b/src/app/test_executive/zkapps_timing.ml
@@ -57,7 +57,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let nonce = Account.Nonce.of_int 0 in
       let memo =
         Signed_command_memo.create_from_string_exn
-          "Snapp create account with timing"
+          "zkApp create account with timing"
       in
       let snapp_keypair = Signature_lib.Keypair.create () in
       let (parties_spec : Transaction_snark.For_tests.Spec.t) =
@@ -108,7 +108,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let nonce = Account.Nonce.zero in
       let memo =
         Signed_command_memo.create_from_string_exn
-          "Snapp transfer, timed account"
+          "zkApp transfer, timed account"
       in
       let sender_keypair = timed_account_keypair in
       let receiver_key =
@@ -172,7 +172,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let nonce = Account.Nonce.of_int 2 in
       let memo =
         Signed_command_memo.create_from_string_exn
-          "Snapp, invalid update timing"
+          "zkApp, invalid update timing"
       in
       let snapp_update : Party.Update.t =
         { Party.Update.dummy with
@@ -212,26 +212,26 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       let hard_timeout = Network_time_span.Slots (soft_slots * 2) in
       Wait_condition.with_timeouts ~soft_timeout ~hard_timeout
     in
-    let wait_for_snapp ~has_failures parties =
+    let wait_for_zkapp ~has_failures parties =
       let%map () =
         wait_for t @@ with_timeout
-        @@ Wait_condition.snapp_to_be_included_in_frontier ~has_failures
+        @@ Wait_condition.zkapp_to_be_included_in_frontier ~has_failures
              ~parties
       in
-      [%log info] "Snapps transaction included in transition frontier"
+      [%log info] "zkApp transaction included in transition frontier"
     in
     let%bind () =
-      section "Send a snapp to create a snapp account with timing"
+      section "Send a zkApp to create a zkApp account with timing"
         (send_zkapp ~logger node parties_create_account_with_timing)
     in
     let%bind () =
       section
         "Wait for snapp to create account with timing to be included in \
          transition frontier"
-        (wait_for_snapp ~has_failures:false parties_create_account_with_timing)
+        (wait_for_zkapp ~has_failures:false parties_create_account_with_timing)
     in
     let%bind () =
-      section "Verify snapp timing in ledger"
+      section "Verify zkApp timing in ledger"
         (let%bind ledger_update =
            get_account_update ~logger node timing_account_id
          in
@@ -264,12 +264,12 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          get_account_balance ~logger node timing_account_id
        in *)
     let%bind () =
-      section "Send a snapp with transfer from timed account that succeeds"
+      section "Send a zkApp with transfer from timed account that succeeds"
         (send_zkapp ~logger node parties_transfer_from_timed_account)
     in
     let%bind () =
       section "Waiting for snapp with transfer from timed account that succeeds"
-        (wait_for_snapp ~has_failures:false parties_transfer_from_timed_account)
+        (wait_for_zkapp ~has_failures:false parties_transfer_from_timed_account)
     in
     (* let%bind after_balance =
          get_account_balance ~logger node timing_account_id
@@ -321,7 +321,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section
-        "Send a snapp with transfer from timed account that fails due to min \
+        "Send a zkApp with transfer from timed account that fails due to min \
          balance"
         (let sender_party =
            (List.hd_exn
@@ -367,9 +367,9 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     in
     let%bind () =
       section
-        "Waiting for snapp with transfer from timed account that fails due to \
+        "Waiting for zkApp with transfer from timed account that fails due to \
          min balance"
-        (wait_for_snapp ~has_failures:true
+        (wait_for_zkapp ~has_failures:true
            parties_invalid_transfer_from_timed_account )
     in
     (* TODO: use transaction status to see that the transaction failed
@@ -411,12 +411,12 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
                    expected_after_invalid_balance_as_amount ) ) )
     in
     let%bind () =
-      section "Send a snapp with invalid timing update"
+      section "Send a zkApp with invalid timing update"
         (send_zkapp ~logger node parties_update_timing)
     in
     let%bind () =
       section "Wait for snapp with invalid timing update"
-        (wait_for_snapp ~has_failures:true parties_update_timing)
+        (wait_for_zkapp ~has_failures:true parties_update_timing)
     in
     let%bind () =
       section "Verify timing has not changed"

--- a/src/lib/integration_test_lib/dune
+++ b/src/lib/integration_test_lib/dune
@@ -21,6 +21,7 @@
    async_unix
    stdio
    extlib
+   sexp_diff_kernel
    ;; local libraries
    key_gen
    visualization

--- a/src/lib/integration_test_lib/intf.ml
+++ b/src/lib/integration_test_lib/intf.ml
@@ -372,7 +372,7 @@ module Dsl = struct
 
     val ledger_proofs_emitted_since_genesis : num_proofs:int -> t
 
-    val snapp_to_be_included_in_frontier :
+    val zkapp_to_be_included_in_frontier :
       has_failures:bool -> parties:Mina_base.Parties.t -> t
   end
 

--- a/src/lib/integration_test_lib/wait_condition.ml
+++ b/src/lib/integration_test_lib/wait_condition.ml
@@ -172,7 +172,7 @@ struct
     ; hard_timeout = Slots 20
     }
 
-  let snapp_to_be_included_in_frontier ~has_failures ~parties =
+  let zkapp_to_be_included_in_frontier ~has_failures ~parties =
     let command_matches_parties cmd =
       let open User_command in
       match cmd with
@@ -209,7 +209,7 @@ struct
     let soft_timeout_in_slots = 8 in
     let is_first = ref true in
     { description =
-        sprintf "snapp with fee payer %s and other parties (%s)"
+        sprintf "zkApp with fee payer %s and other parties (%s)"
           (Signature_lib.Public_key.Compressed.to_base58_check
              parties.fee_payer.body.public_key )
           (Parties.Call_forest.Tree.fold_forest ~init:"" parties.other_parties


### PR DESCRIPTION
Add token tests to the `zkApps` integration test.

These are the same as the tests in the transaction snark tokens tests, except that the token owner party has already been created. There's not a check for the post-transfer balances, which could be added.

Part of #9264.