### PR TITLE
Merge `compatible` to `develop`

### DIFF
--- a/src/external/ocaml-rocksdb/dune
+++ b/src/external/ocaml-rocksdb/dune
@@ -15,9 +15,10 @@
  (libraries dune.configurator)
  )
 
+;; todo: fails with sandbox, since the generated flags are opaque to dune
 (rule
  (targets flags.sexp)
- (deps librocksdb_stubs.a)
+ (deps librocksdb_stubs.a (sandbox none))
  (action (run ./rocks_linker_flags_gen.exe)))
 
 (rule

--- a/src/lib/mina_version/normal/dune
+++ b/src/lib/mina_version/normal/dune
@@ -8,5 +8,8 @@
 
 (rule
  (targets mina_version.ml)
- (deps (:< gen.sh) (universe))
+ (deps
+   (sandbox none)
+   (:< gen.sh)
+   (universe))
  (action (run %{<} %{targets})))


### PR DESCRIPTION
Merge `compatible` to `develop`.

When merging there was a conflict of `src/lib/zexe_backend/zexe_backend_common/dune` being absent in `develop` and present `compatible`, which was simply ignored.