### PR TITLE
Update snarkyjs & tweak build

### DIFF
--- a/scripts/update-snarkyjs-bindings.sh
+++ b/scripts/update-snarkyjs-bindings.sh
@@ -16,9 +16,13 @@ sed -i 's/function failwith(s){throw \[0,Failure,s\]/function failwith(s){throw 
 sed -i 's/function invalid_arg(s){throw \[0,Invalid_argument,s\]/function invalid_arg(s){throw joo_global_object.Error(s.c)/' "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.js
 sed -i 's/return \[0,Exn,t\]/return joo_global_object.Error(t.c)/' "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.js
 
+# optimize wasm / minify JS (we don't do this with jsoo to not break the error message fix above)
 pushd "$SNARKY_JS_PATH"/src/node_bindings
   wasm-opt --detect-features --enable-mutable-globals -O4 plonk_wasm_bg.wasm -o plonk_wasm_bg.wasm.opt
   mv plonk_wasm_bg.wasm.opt plonk_wasm_bg.wasm
+  npx esbuild --minify --log-level=error snarky_js_node.bc.js > snarky_js_node.bc.min.js
+  mv snarky_js_node.bc.min.js snarky_js_node.bc.js
+  rm snarky_js_node.bc.runtime.js
 popd
 
 npm run build --prefix="$SNARKY_JS_PATH"
@@ -35,9 +39,13 @@ sed -i 's/function failwith(s){throw \[0,Failure,s\]/function failwith(s){throw 
 sed -i 's/function invalid_arg(s){throw \[0,Invalid_argument,s\]/function invalid_arg(s){throw joo_global_object.Error(s.c)/' "$SNARKY_JS_PATH"/src/chrome_bindings/snarky_js_chrome.bc.js
 sed -i 's/return \[0,Exn,t\]/return joo_global_object.Error(t.c)/' "$SNARKY_JS_PATH"/src/chrome_bindings/snarky_js_chrome.bc.js
 
+# optimize wasm / minify JS (we don't do this with jsoo to not break the error message fix above)
 pushd "$SNARKY_JS_PATH"/src/chrome_bindings
   wasm-opt --detect-features --enable-mutable-globals -O4 plonk_wasm_bg.wasm -o plonk_wasm_bg.wasm.opt
   mv plonk_wasm_bg.wasm.opt plonk_wasm_bg.wasm
+  npx esbuild --minify --log-level=error snarky_js_chrome.bc.js > snarky_js_chrome.bc.min.js
+  mv snarky_js_chrome.bc.min.js snarky_js_chrome.bc.js
+  rm snarky_js_chrome.bc.runtime.js
 popd
 
 npm run build:web --prefix="$SNARKY_JS_PATH"

--- a/src/lib/snarky_js_bindings/dune
+++ b/src/lib/snarky_js_bindings/dune
@@ -1,5 +1,7 @@
 (env
-  (_ (js_of_ocaml (compilation_mode whole_program))))
+ (_
+  (js_of_ocaml
+   (compilation_mode whole_program))))
 
 (executable
  (name snarky_js_node)
@@ -7,7 +9,7 @@
  (modes js)
  (link_flags (-noautolink))
  (js_of_ocaml
-  (flags +toplevel.js +dynlink.js))
+  (flags +toplevel.js +dynlink.js --pretty))
  (libraries snarky_js_bindings_lib node_backend)
  (link_deps
   ../crypto/kimchi_bindings/js/node_js/plonk_wasm.js
@@ -24,7 +26,7 @@
  (modes js)
  (link_flags (-noautolink))
  (js_of_ocaml
-  (flags +toplevel.js +dynlink.js))
+  (flags +toplevel.js +dynlink.js --pretty))
  (libraries snarky_js_bindings_lib chrome_backend)
  (link_deps
   ../crypto/kimchi_bindings/js/chrome/plonk_wasm.js


### PR DESCRIPTION
This syncs the snarkyjs submodule to latest `main`, which includes substantial recent changes.

Following up with the recent switch to `whole_program` compilation of the snarkyjs bindings, this also includes a tweak to the build process: Instead of minifying the bindings with JSOO, we do this step later with `esbuild`, the advantages of which are that
* a hack to get better error messages in snarkyjs is not broken by minifying
* we get unminified bindings during development, which makes debugging easier
