### PR TITLE
Nix: switch to google cloud storage substituter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1650549377,
-        "narHash": "sha256-if2xXtEnJTtc3olurH4LKlAt70dpGGxJhkctCCIqgyQ=",
+        "lastModified": 1654768881,
+        "narHash": "sha256-XuSUp870TDDETi5rs+R7VklxMm29u8BUVnM6lfbQq7w=",
         "owner": "tweag",
         "repo": "flake-buildkite-pipeline",
-        "rev": "0b5f41b562cf2f5be0cf07b9980a87bcebfadb68",
+        "rev": "d420396096b405c8eae22801b3723a30a8ff48f4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
           commonExtraStepConfig = {
             agents = [ "nix" ];
             soft_fail = "true";
+            env.BUILDKITE_REPO = "";
           };
         } self;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,9 @@
         ];
       };
       pipeline = with flake-buildkite-pipeline.lib; {
-        steps = flakeStepsCachix {
-          pushToBinaryCaches = [ "mina-demo" ];
+        steps = flakeSteps {
+          pushToBinaryCaches = [ "s3://mina-nix-cache?endpoint=https://storage.googleapis.com" ];
+          signWithKeys = [ "/var/secrets/nix-cache-key.sec" ];
           commonExtraStepConfig = {
             agents = [ "nix" ];
             soft_fail = "true";

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
   description = "Mina, a cryptocurrency with a lightweight, constant-size blockchain";
   nixConfig = {
     allow-import-from-derivation = "true";
-    extra-substituters = [ "https://mina-demo.cachix.org" ];
+    extra-substituters = [ "https://storage.googleapis.com/mina-nix-cache" ];
     extra-trusted-public-keys =
-      [ "mina-demo.cachix.org-1:PpQXDRNR3QkXI0487WY3TDTk5+7bsOImKj5+A79aMg8=" ];
+      [ "nix-cache.minaprotocol.org:D3B1W+V7ND1Fmfii8EhbAbF1JXoe2Ct4N34OKChwk2c=" ];
   };
 
   inputs.utils.url = "github:gytis-ivaskevicius/flake-utils-plus";


### PR DESCRIPTION
Use a google cloud storage substituter instead of the cachix one.