### PR TITLE
Fix for `unknown flag -ccopt=ocamllsp`

### DIFF
--- a/src/dune.flags.inc
+++ b/src/dune.flags.inc
@@ -3,6 +3,5 @@
 (env
   (_
     (flags (:standard -short-paths
-            -ccopt=%{read:dune-linker}
             -cclib -ljemalloc
             -w @a-4-29-40-41-42-44-45-48-58-59-60-66))))

--- a/src/dune.linker.inc
+++ b/src/dune.linker.inc
@@ -5,7 +5,7 @@
 (rule
   (target dune-linker)
   (enabled_if %{bin-available:lld})
-  (action (with-stdout-to dune-linker (echo "-fuse-ld=lld"))))
+  (action (with-stdout-to dune-linker (echo "-ccopt=%{read:dune-linker} -fuse-ld=lld"))))
 
 (rule
   (target dune-linker)


### PR DESCRIPTION
As per discussion with @mrmr1993:
- Lowering the `--ccopt` from `dune.flags.inc` into `dune.linker.inc` to fix the:  
<img width="431" alt="Screenshot 2022-06-09 at 17 17 26" src="https://user-images.githubusercontent.com/4096154/172918979-382a288f-2c92-4286-9b81-c0190090f670.png">
 