### PR TITLE
Expose circuit digest to SnarkyJS via hacky early return

### DIFF
--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -15,6 +15,8 @@ module Tag = Tag
 module Step_verifier = Step_verifier
 module Common = Common
 
+exception Return_digest of Md5.t
+
 module type Statement_intf = sig
   type field
 
@@ -236,6 +238,7 @@ val compile_promise :
   -> ?disk_keys:
        (Cache.Step.Key.Verification.t, 'branches) Vector.t
        * Cache.Wrap.Key.Verification.t
+  -> ?return_early_digest_exception:bool
   -> (module Statement_var_intf with type t = 'a_var)
   -> (module Statement_value_intf with type t = 'a_value)
   -> typ:('a_var, 'a_value) Impls.Step.Typ.t


### PR DESCRIPTION
Hacky early return ala discussion via slack:

"I'm trying to do the OCaml side of https://github.com/o1-labs/zkapp-cli/issues/158#issuecomment-1147621960 (tldr: extract the digest out before actually building the proving/verifying keys) and am realizing that Pickles' circuits are only transiently realized after lots of inline functor applications. I don't think it's right to make a separate function and just copy-and-paste all of this functor application because it's too brittle. There is a hacky approach: add another optional parameter that triggers an exception to get the digests out; this would super easy to implement and it definitely wouldn't break anything [..]"

TODO:
- [ ] Needs a unit test in Pickles
- [ ] a big comment explaining why this is here temporarily
- [ ] using it in the SnarkyJS bindings side

