### PR TITLE
Version Kimchi bigint type

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/bigint.ml
+++ b/src/lib/crypto/kimchi_backend/common/bigint.ml
@@ -81,10 +81,13 @@ module Make
   include Bin_prot.Utils.Of_minimal (struct
     type nonrec t = t
 
+    (* increment if serialization changes *)
+    let version = 1
+
     let bin_shape_t =
       Bin_prot.Shape.basetype
         (Bin_prot.Shape.Uuid.of_string
-           (sprintf "kimchi_backend_bigint_%d" M.length_in_bytes) )
+           (sprintf "kimchi_backend_bigint_%d_V%d" M.length_in_bytes version) )
         []
 
     let __bin_read_t__ _buf ~pos_ref _vint =


### PR DESCRIPTION
Add version number to the `Bin_prot` shape of the Kimchi bigint type.

That will allow detecting serialization changes by the version linter in types that include this type.