### PR TITLE
wasm-bindgen-rayon: change from submodule to cargo git dep

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,9 +29,6 @@
 [submodule "src/external/capnp-ocaml"]
 	path = src/external/capnp-ocaml
 	url = https://github.com/o1-labs/capnp-ocaml.git
-[submodule "src/external/wasm-bindgen-rayon"]
-	path = src/external/wasm-bindgen-rayon
-	url = https://github.com/o1-labs/wasm-bindgen-rayon.git
 [submodule "src/lib/snarky_js_bindings/snarkyjs"]
 	path = src/lib/snarky_js_bindings/snarkyjs
 	url = https://github.com/o1-labs/snarkyjs.git

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -13,6 +13,7 @@ let
     # copy this line with the correct toolchain name
     "placeholder" = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
   };
+  cargoHashes = narHashesFromCargoLock ../src/lib/crypto/Cargo.lock;
   rustChannelFromToolchainFileOf = file: with pkgs.lib; let
     inherit (pkgs.lib) hasPrefix removePrefix readFile warn;
     toolchain = (builtins.fromTOML (readFile file)).toolchain;
@@ -24,6 +25,26 @@ let
       sha256 = toolchainHashes.${toolchain.channel} or
         (warn ''Please add the rust toolchain hash (see error message below) for "${toolchain.channel}" at ${placeholderPos.file}:${toString placeholderPos.line}'' toolchainHashes.placeholder);
     };
+
+  # mapFilterListToAttrs :: (x -> {name: str, value: b}) -> (x -> bool) -> [x] -> {b}
+  mapFilterListToAttrs = f: m: l:
+    builtins.listToAttrs (map m (builtins.filter f l));
+
+  # extract git rev & urls from cargo lockfile, feed them to fetchgit to acquire
+  # the sha256 hash that's used at build time
+  # narHashesfromcargolock :: path -> {pkgname: hash}
+  narHashesFromCargoLock = file:
+    let
+      inherit (pkgs.lib) hasPrefix last head;
+      inherit (builtins) split readFile;
+      package = (fromTOML (readFile file)).package;
+    in mapFilterListToAttrs (x: x ? source && hasPrefix "git+" x.source) (x: {
+      name = "${x.name}-${x.version}";
+      value = (fetchGit {
+        rev = last (split "#" x.source);
+        url = last (split "\\+" (head (split "\\?" x.source)));
+      }).narHash;
+    }) package;
 in {
   # nixpkgs + musl problems
   postgresql =
@@ -206,10 +227,10 @@ in {
       version = deps.wasm-bindgen.version;
       src = final.fetchCrate {
         inherit pname version;
-        sha256 = "sha256-f3XRVuK892TE6xP7eq3aKpl9d3fnOFxLh+/K59iWPAg=";
+        sha256 = "sha256-DUcY22b9+PD6RD53CwcoB+ynGulYTEYjkkonDNeLbGM=";
       };
 
-      cargoSha256 = "sha256-WJ5hPw2mzZB+GMoqo3orhl4fCFYKWXOWqaFj1EMrb2Q=";
+      cargoSha256 = "sha256-mfVQ6rSzCgwYrN9WwydEpkm6k0E3302Kfs/LaGzRSHE=";
       nativeBuildInputs = [ final.pkg-config ];
 
       buildInputs = with final;
@@ -228,11 +249,11 @@ in {
       "^lib/crypto/Cargo\.(lock|toml)$"
       "^lib(/crypto(/kimchi_bindings(/wasm(/.*)?)?)?)?$"
       "^lib(/crypto(/proof-systems(/.*)?)?)?$"
-      "^external(/wasm-bindgen-rayon(/.*)?)?"
     ];
     sourceRoot = "source/lib/crypto";
     nativeBuildInputs = [ pkgs.wasm-pack wasm-bindgen-cli ];
     cargoLock.lockFile = lock;
+    cargoLock.outputHashes = cargoHashes;
 
     # Work around https://github.com/rust-lang/wg-cargo-std-aware/issues/23
     # Want to run after cargoSetupPostUnpackHook

--- a/src/lib/crypto/Cargo.lock
+++ b/src/lib/crypto/Cargo.lock
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -518,9 +518,9 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1139,15 +1139,15 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum_macros"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+checksum = "9550962e7cf70d9980392878dfaf1dcc3ece024f4cf3bf3c46b978d0bad61d6c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1228,9 +1228,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-xid"
@@ -1246,15 +1246,15 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1289,9 +1289,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1313,6 +1313,7 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-rayon"
 version = "1.0.3"
+source = "git+https://github.com/o1-labs/wasm-bindgen-rayon?branch=feature/nodejs-support#6a2b0d7dc6dda9d9a15cc471a3c9a5a70d34f5a8"
 dependencies = [
  "js-sys",
  "rayon",
@@ -1322,15 +1323,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4464b3f74729a25f42b1a0cd9e6a515d2f25001f3535a6cfaf35d34a4de3bab"
+checksum = "68b30cf2cba841a812f035c40c50f53eb9c56181192a9dd2c71b65e6a87a05ba"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1342,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c5a6f82cc6093a321ca5fb3dc9327fe51675d477b3799b4a9375bac3b7b4c"
+checksum = "88ad594bf33e73cafcac2ae9062fc119d4f75f9c77e25022f91c9a64bd5b6463"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1352,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src/lib/crypto/kimchi_bindings/js/chrome/dune
+++ b/src/lib/crypto/kimchi_bindings/js/chrome/dune
@@ -18,7 +18,6 @@
   ../../wasm/Cargo.toml
   (source_tree ../../wasm/src)
   (source_tree ../../wasm/.cargo/config)
-  (source_tree ../../../../../external/wasm-bindgen-rayon)
   (source_tree ../../../proof-systems) )
  (locks /cargo-lock) ; lock for rustup
  (action

--- a/src/lib/crypto/kimchi_bindings/js/node_js/dune
+++ b/src/lib/crypto/kimchi_bindings/js/node_js/dune
@@ -17,7 +17,6 @@
   ../../wasm/Cargo.toml
   (source_tree ../../wasm/src)
   (source_tree ../../wasm/.cargo/config)
-  (source_tree ../../../../../external/wasm-bindgen-rayon)
   (source_tree ../../stubs)
   ../../../Cargo.toml
   (source_tree ../../../proof-systems) )

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -21,7 +21,6 @@
   (source_tree src)
   (source_tree binding_generation)
   (source_tree ../wasm)
-  (source_tree ../../../../external/wasm-bindgen-rayon)
   (source_tree ../../proof-systems)
   (env_var MARLIN_PLONK_STUBS))
  (locks /cargo-lock) ;; lock for rustup
@@ -92,7 +91,6 @@
   Cargo.toml
   ../../../../.ocamlformat
   ../../Cargo.toml
-  (source_tree ../../../../external/wasm-bindgen-rayon)
   (source_tree ../../stubs)
   (source_tree ../wasm)
   (source_tree src)

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 #wasm-bindgen-rayon = { version = "1.0", features = ["no-bundler"] }
-wasm-bindgen-rayon = { path = "../../../../external/wasm-bindgen-rayon", features = ["no-bundler"] }
+wasm-bindgen-rayon = { git = "https://github.com/o1-labs/wasm-bindgen-rayon", branch = "feature/nodejs-support", features = ["no-bundler"]}
 wasm-bindgen = { version = "0.2.78" }
 console_error_panic_hook = { version = "0.1.6" }
 web-sys = { version = "0.3.35", features = ["Window", "Document", "HtmlElement", "Text", "Node", "Element" ] }


### PR DESCRIPTION

* Change wasm-bindgen-rayon from a git submodule to a cargo git dep. Tracks the branch at o1-labs/wasm-bindgen-rayon/feature/nodejs-support. Update using `cargo generate-lockfile` or `cargo update`.

This dep is an excellent candidate for this because it's very infrequently updated.


cc @mrmr1993 

Part of #11212 