### PR TITLE
Triple number of transactions in zkapps test

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -701,7 +701,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let%bind () =
       let padding_payments =
         (* for work_delay=1 and transaction_capacity=4 per block*)
-        let needed = 12 in
+        let needed = 36 in
         if !transactions_sent >= needed then 0 else needed - !transactions_sent
       in
       let fee = Currency.Fee.of_int 1_000_000 in


### PR DESCRIPTION
This should force snark work to be purchased and a ledger proof to be emitted. With any luck, this will stop the zkApps integration test flakes we've been seeing.