### PR TITLE
ppx_version in Mina repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "src/lib/crypto/proof-systems"]
 	path = src/lib/crypto/proof-systems
 	url = https://github.com/o1-labs/proof-systems.git
-[submodule "src/external/ppx_version"]
-	path = src/external/ppx_version
-	url = https://github.com/o1-labs/ppx_version.git
 [submodule "src/external/prometheus"]
 	path = src/external/prometheus
 	url = https://github.com/MinaProtocol/prometheus.git

--- a/src/lib/blake2/blake2.ml
+++ b/src/lib/blake2/blake2.ml
@@ -94,9 +94,7 @@ include Make ()
 let%test "serialization test V1" =
   let blake2s = T0.digest_string "serialization test V1" in
   let known_good_digest = "562733d10582c5832e541fb60e38e7c8" in
-  Ppx_version_runtime.Serialization.check_serialization
-    (module Stable.V1)
-    blake2s known_good_digest
+  Test_util.check_serialization (module Stable.V1) blake2s known_good_digest
 
 let%test_unit "bits_to_string" =
   [%test_eq: string]

--- a/src/lib/blake2/dune
+++ b/src/lib/blake2/dune
@@ -9,10 +9,11 @@
    base.base_internalhash_types
    bigarray-compat
    bin_prot.shape
-   ppx_version.runtime
    core_kernel
    digestif
    sexplib0
    base.caml
    ppx_inline_test.config
-))
+   ;; local libraries
+   test_util
+ ))

--- a/src/lib/data_hash_lib/data_hash.ml
+++ b/src/lib/data_hash_lib/data_hash.ml
@@ -113,35 +113,23 @@ module T0 = struct
 
       let to_latest = Fn.id
     end
-
-    module Tests = struct end
   end]
 
-  module Tests = struct
-    (* these test the stability of the serialization derived from the
-       string representation of Field.t, not the direct serialization of
-       Field.t
-    *)
+  [%%if curve_size = 255]
 
+  let%test "Binable from stringable V1" =
     let field =
       Quickcheck.random_value ~seed:(`Deterministic "Data_hash.T0 tests")
         Field.gen
+    in
+    let known_good_digest = "fa43c8180f9f3cef1cf5767592e964c1" in
+    Test_util.check_serialization (module Stable.V1) field known_good_digest
 
-    [%%if curve_size = 255]
+  [%%else]
 
-    let%test "Binable from stringable V1" =
-      let known_good_digest = "fa43c8180f9f3cef1cf5767592e964c1" in
-      Ppx_version_runtime.Serialization.check_serialization
-        (module Stable.V1)
-        field known_good_digest
+  let%test "Binable from stringable V1" = failwith "No test for this curve size"
 
-    [%%else]
-
-    let%test "Binable from stringable V1" =
-      failwith "No test for this curve size"
-
-    [%%endif]
-  end
+  [%%endif]
 end
 
 module Make_full_size (B58_data : Data_hash_intf.Data_hash_descriptor) = struct

--- a/src/lib/data_hash_lib/dune
+++ b/src/lib/data_hash_lib/dune
@@ -31,6 +31,7 @@
    snarky.intf
    fields_derivers.zkapps
    fields_derivers.json
+   test_util
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess

--- a/src/lib/genesis_constants/dune
+++ b/src/lib/genesis_constants/dune
@@ -9,7 +9,6 @@
    base
    bin_prot.shape
    core_kernel
-   ppx_version.runtime
    base.caml
    sexplib0
    integers
@@ -24,6 +23,7 @@
    pickles.backend
    snark_keys_header
    kimchi_backend.pasta
+   test_util
    )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -313,27 +313,23 @@ module Protocol = struct
         in
         T.sexp_of_t t'
     end
-
-    module Tests = struct
-      let%test "protocol constants serialization v1" =
-        let t : V1.t =
-          { k = 1
-          ; delta = 100
-          ; slots_per_sub_window = 10
-          ; slots_per_epoch = 1000
-          ; genesis_state_timestamp =
-              Time.of_string "2019-10-08 17:51:23.050849Z" |> of_time
-          }
-        in
-        (*from the print statement in Serialization.check_serialization*)
-        let known_good_digest = "28b7c3bb5f94351f0afa6ebd83078730" in
-        Ppx_version_runtime.Serialization.check_serialization
-          (module V1)
-          t known_good_digest
-    end
   end]
 
   [%%define_locally Stable.Latest.(to_yojson)]
+
+  let%test "protocol constants serialization v1" =
+    let t : Stable.V1.t =
+      { k = 1
+      ; delta = 100
+      ; slots_per_sub_window = 10
+      ; slots_per_epoch = 1000
+      ; genesis_state_timestamp =
+          Time.of_string "2019-10-08 17:51:23.050849Z" |> of_time
+      }
+    in
+    (* from the print statement in Serialization.check_serialization *)
+    let known_good_digest = "28b7c3bb5f94351f0afa6ebd83078730" in
+    Test_util.check_serialization (module Stable.V1) t known_good_digest
 end
 
 module T = struct

--- a/src/lib/merkle_address/dune
+++ b/src/lib/merkle_address/dune
@@ -7,14 +7,14 @@
   ;; opam libraries
   base.base_internalhash_types
   bin_prot.shape
-  ppx_version.runtime
   bitstring
   core_kernel
   sexplib0
   base.caml
   ppx_inline_test.config
   ;; local libraries
-  direction)
+  direction
+  test_util)
  (preprocess
   (pps ppx_coda ppx_version ppx_jane ppx_hash ppx_compare ppx_deriving_yojson
        ppx_bitstring))

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -261,15 +261,19 @@ module Range = struct
 end
 
 let%test "Bitstring bin_io serialization does not change" =
-  (* Bitstring.t is trustlisted as a versioned type. This test assures that serializations of that type haven't changed *)
+  (* Bitstring.t is trustlisted as a versioned type. This test assures that serializations
+     of that type haven't changed
+
+     The Bin_prot shape is an int, string pair, which isn't necessarily stable
+  *)
   let text =
     "Contrary to popular belief, Lorem Ipsum is not simply random text. It has \
      roots in a piece of classical Latin literature."
   in
   let bitstring = Bitstring.bitstring_of_string text in
   let known_good_digest = "c4c7ade09ba305b69ffac494a6eab60e" in
-  Ppx_version_runtime.Serialization.check_serialization
-    (module Stable.V1)
+  Test_util.check_serialization
+    (module Stable.Latest)
     bitstring known_good_digest
 
 module Make_test (Input : sig

--- a/src/lib/mina_base/dune
+++ b/src/lib/mina_base/dune
@@ -11,7 +11,6 @@
    ppx_inline_test.config
    sexplib0
    yojson
-   ppx_version.runtime
    digestif
    sexp_diff_kernel
    core_kernel

--- a/src/lib/mina_base/proof.ml
+++ b/src/lib/mina_base/proof.ml
@@ -31,9 +31,7 @@ let%test_module "proof-tests" =
     let%test "proof serialization v2" =
       let proof = blockchain_dummy in
       let known_good_digest = "e44a234e6a1f4b7044834e33d8509c1b" in
-      Ppx_version_runtime.Serialization.check_serialization
-        (module Stable.V2)
-        proof known_good_digest
+      Test_util.check_serialization (module Stable.V2) proof known_good_digest
 
     [%%else]
 

--- a/src/lib/mina_base/signature.ml
+++ b/src/lib/mina_base/signature.ml
@@ -26,30 +26,25 @@ module Stable = struct
 
     let gen = Quickcheck.Generator.tuple2 Field.gen Inner_curve.Scalar.gen
   end
-
-  module Tests = struct
-    [%%if curve_size = 255]
-
-    let%test "signature serialization v1 (curve_size=255)" =
-      let signature =
-        Quickcheck.random_value ~seed:(`Deterministic "signature serialization")
-          V1.gen
-      in
-      let known_good_digest = "88a094d50a90b5054152af85bd6e60e8" in
-      Ppx_version_runtime.Serialization.check_serialization
-        (module V1)
-        signature known_good_digest
-
-    [%%else]
-
-    let%test "signature serialization v1" =
-      failwith "No test for this curve size"
-
-    [%%endif]
-  end
 end]
 
 let dummy = (Field.one, Inner_curve.Scalar.one)
+
+[%%if curve_size = 255]
+
+let%test "signature serialization v1 (curve_size=255)" =
+  let signature =
+    Quickcheck.random_value ~seed:(`Deterministic "signature serialization")
+      Stable.V1.gen
+  in
+  let known_good_digest = "88a094d50a90b5054152af85bd6e60e8" in
+  Test_util.check_serialization (module Stable.V1) signature known_good_digest
+
+[%%else]
+
+let%test "signature serialization v1" = failwith "No test for this curve size"
+
+[%%endif]
 
 module Raw = struct
   open Rosetta_coding.Coding

--- a/src/lib/non_zero_curve_point/dune
+++ b/src/lib/non_zero_curve_point/dune
@@ -10,7 +10,6 @@
    base.caml
    sexplib0
    core_kernel
-   ppx_version.runtime
    bin_prot.shape
    base
    base.base_internalhash_types
@@ -26,6 +25,7 @@
    random_oracle
    bitstring_lib
    kimchi_backend.pasta
+   test_util
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -36,10 +36,6 @@ module Compressed = struct
         let version_byte =
           Base58_check.Version_bytes.non_zero_curve_point_compressed
       end
-
-      module Tests = struct
-        (* actual tests in Stable below *)
-      end
     end]
   end
 
@@ -76,32 +72,24 @@ module Compressed = struct
         let%map uncompressed = gen_uncompressed in
         compress uncompressed
     end
-
-    module Tests = struct
-      (* these tests check not only whether the serialization of the version-asserted type has changed,
-         but also whether the serializations for the consensus and nonconsensus code are identical
-      *)
-
-      [%%if curve_size = 255]
-
-      let%test "nonzero_curve_point_compressed v1" =
-        let point =
-          Quickcheck.random_value
-            ~seed:(`Deterministic "nonzero_curve_point_compressed-seed") V1.gen
-        in
-        let known_good_digest = "35c836b0252293061bf974490f5bd515" in
-        Ppx_version_runtime.Serialization.check_serialization
-          (module V1)
-          point known_good_digest
-
-      [%%else]
-
-      let%test "nonzero_curve_point_compressed v1" =
-        failwith "Unknown curve size"
-
-      [%%endif]
-    end
   end]
+
+  [%%if curve_size = 255]
+
+  let%test "nonzero_curve_point_compressed v1" =
+    let point =
+      Quickcheck.random_value
+        ~seed:(`Deterministic "nonzero_curve_point_compressed-seed")
+        Stable.V1.gen
+    in
+    let known_good_digest = "35c836b0252293061bf974490f5bd515" in
+    Test_util.check_serialization (module Stable.V1) point known_good_digest
+
+  [%%else]
+
+  let%test "nonzero_curve_point_compressed v1" = failwith "Unknown curve size"
+
+  [%%endif]
 
   module Poly = Poly
   include Comparable.Make_binable (Stable.Latest)

--- a/src/lib/pickles/limb_vector/constant.ml
+++ b/src/lib/pickles/limb_vector/constant.ml
@@ -61,12 +61,6 @@ module Hex64 = struct
 
       let to_latest = Fn.id
     end
-
-    module Tests = struct
-      (* TODO: Add serialization tests here to make sure that Core doesn't
-         change it out from under us between versions.
-      *)
-    end
   end]
 end
 

--- a/src/lib/pickles_types/vector.ml
+++ b/src/lib/pickles_types/vector.ml
@@ -476,10 +476,6 @@ module Vector_2 = struct
       include Make.Binable (Nat.N2)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 
@@ -505,10 +501,6 @@ module Vector_4 = struct
       include Make.Binable (Nat.N4)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 
@@ -534,10 +526,6 @@ module Vector_5 = struct
       include Make.Binable (Nat.N5)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 
@@ -563,10 +551,6 @@ module Vector_6 = struct
       include Make.Binable (Nat.N6)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 
@@ -592,10 +576,6 @@ module Vector_7 = struct
       include Make.Binable (Nat.N7)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 
@@ -621,10 +601,6 @@ module Vector_8 = struct
       include Make.Binable (Nat.N8)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 
@@ -650,10 +626,6 @@ module Vector_15 = struct
       include Make.Binable (Nat.N15)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 
@@ -679,10 +651,6 @@ module Vector_16 = struct
       include Make.Binable (Nat.N16)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 
@@ -708,10 +676,6 @@ module Vector_17 = struct
       include Make.Binable (Nat.N17)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 
@@ -737,10 +701,6 @@ module Vector_18 = struct
       include Make.Binable (Nat.N18)
 
       include (T : module type of T with type 'a t := 'a t)
-
-      module Tests = struct
-        (* TODO *)
-      end
     end
   end]
 

--- a/src/lib/ppx_version/bin_io_unversioned.ml
+++ b/src/lib/ppx_version/bin_io_unversioned.ml
@@ -1,0 +1,115 @@
+(* bin_io_unversioned *)
+
+(* use [@@deriving bin_io_unversioned] for serialized types that
+   are not send to nodes or persisted, namely the daemon RPC
+   types for communication between the client and daemon, which
+   are known to be running the same version of the software.
+
+   The deriver here calls the derivers for bin_io after the lint
+   phase. We avoid linter errors that would occur if
+   we used [@@deriving bin_io] directly.
+*)
+
+open Core_kernel
+open Ppxlib
+open Versioned_util
+
+let deriver = "bin_io_unversioned"
+
+let bin_io_gens :
+    (   ctxt:Expansion_context.Deriver.t
+     -> rec_flag * type_declaration list
+     -> (string * expression) list
+     -> structure_item list )
+    list =
+  List.map [ "bin_shape"; "bin_read"; "bin_write"; "bin_type_class" ]
+    ~f:(fun name ->
+      let deriver = Option.value_exn (Ppx_derivers.lookup name) in
+      (* deriver is an instance of Ppxlib.Deriving.Deriver.deriver
+
+         if instead we consider it to be an instance of Ppx_deriving.t,
+           the 0th field, which should be the name, but prints out as garbage
+
+         the 0th field of deriver is a string "Ppxlib__Deriving.Deriver.T",
+           perhaps an artifact of the += type extension
+         the 1st field of deriver appears to be of type
+           Ppxlib.Deriving.Deriver.t, and the 0th field of that gives us
+           an Actual_deriver.t
+
+         the 0th field of the Actual_deriver.t should be the name, which
+           prints out as expected
+
+         the number of fields of the Actual_deriver.t is 8, which corresponds
+           to the type definition
+
+         from the Actual_deriver.t, we pull out the 1st field, the Generator.t
+           with the label str_type_decl; we then apply the generator
+      *)
+      let actual_deriver =
+        let constructor_argument_idx = 0 in
+        let extension_constructor_argument_idx = 1 in
+        Obj.(
+          repr deriver
+          (* Ppxlib.Deriving.Deriver.T x -> x *)
+          |> (fun r -> field r extension_constructor_argument_idx)
+          (* Ppxlib.Deriving.Deriver.Actual_deriver x -> x *)
+          |> fun r -> field r constructor_argument_idx)
+      in
+      let name =
+        (* Ppxlib.Deriving.Deriver.Actual_deriver.t, 0th field is name *)
+        let name_idx = 0 in
+        actual_deriver |> fun r -> Obj.(field r name_idx |> obj)
+      in
+      let generator :
+          (structure, rec_flag * type_declaration list) Deriving.Generator.t =
+        (* Ppxlib.Deriving.Deriver.Actual_deriver.t, 1st field is
+             str_type_decl *)
+        let str_type_decl_idx = 1 in
+        Option.value_exn
+          (actual_deriver |> fun r -> Obj.(field r str_type_decl_idx |> obj))
+      in
+      Deriving.Generator.apply ~name generator )
+
+let validate_type_decl inner2_modules type_decl =
+  match inner2_modules with
+  | [ module_version; "Stable" ] ->
+      let inside_stable_versioned =
+        try
+          validate_module_version module_version type_decl.ptype_loc ;
+          true
+        with _ -> false
+      in
+      if inside_stable_versioned then
+        Location.raise_errorf ~loc:type_decl.ptype_loc
+          "Cannot use \"deriving bin_io_unversioned\" for a type defined in a \
+           stable-versioned module"
+  | _ ->
+      ()
+
+let ctxt_base =
+  Expansion_context.Base.top_level ~tool_name:"ppxlib_driver" ~file_path:""
+    ~input_name:""
+
+let rewrite_to_bin_io ~loc ~path (_rec_flag, type_decls) =
+  let type_decl1 = List.hd_exn type_decls in
+  if not (Int.equal (List.length type_decls) 1) then
+    Location.raise_errorf ~loc
+      "deriving bin_io_unversioned can only be used on a single type" ;
+  let module_path = List.drop String.(split path ~on:'.') 2 in
+  let inner2_modules = List.take (List.rev module_path) 2 in
+  validate_type_decl inner2_modules type_decl1 ;
+  let ctxt =
+    let derived_item_loc = loc in
+    (* TODO: is inline:false what we want? *)
+    Expansion_context.Deriver.make ~derived_item_loc ~base:ctxt_base ()
+      ~inline:false
+  in
+  List.concat_map bin_io_gens ~f:(fun gen ->
+      gen ~ctxt (Nonrecursive, type_decls) [] )
+
+let str_type_decl :
+    (structure, rec_flag * type_declaration list) Ppxlib.Deriving.Generator.t =
+  let open Ppxlib.Deriving in
+  Generator.make_noarg rewrite_to_bin_io
+
+let () = Ppxlib.Deriving.add deriver ~str_type_decl |> Ppxlib.Deriving.ignore

--- a/src/lib/ppx_version/dune
+++ b/src/lib/ppx_version/dune
@@ -1,0 +1,14 @@
+(library
+ (name ppx_version)
+ (public_name ppx_version)
+ (kind ppx_deriver)
+ (libraries
+   ;; opam libs
+   compiler-libs.common
+   ppxlib
+   ppxlib.astlib
+   ppx_derivers
+   ppx_bin_prot
+   base base.caml
+   core_kernel)
+ (preprocess (pps ppxlib.metaquot)))

--- a/src/lib/ppx_version/lint_version_syntax.ml
+++ b/src/lib/ppx_version/lint_version_syntax.ml
@@ -1,0 +1,569 @@
+(* lint_version_syntax.ml -- static enforcement of syntactic items relating to proper versioning
+
+   - "deriving bin_io" and "deriving version" never appear in types defined inside functor bodies
+   - otherwise, "bin_io" may appear in a "deriving" attribute only if "version" also appears in that extension
+   - versioned types only appear in versioned type definitions
+   - versioned type definitions appear only in %%versioned... extensions
+   - packaged modules, like "(module Foo)", may not be stable-versioned (but allowed inside %%versioned for
+       legitimate uses)
+   - the constructs "include Stable.Latest" and "include Stable.Vn" are prohibited
+   - uses of Binable.Of... and Bin_prot.Utils.Make_binable functors are always in stable-versioned modules,
+       and always as an argument to "include"
+   - restrictions are not enforced in inline tests and inline test modules
+*)
+
+open Core_kernel
+open Ppxlib
+open Versioned_util
+
+let name = "enforce_version_syntax"
+
+let errors_as_warnings_ref = ref false
+
+let make_deriving_validator ~pred err_msg type_decl =
+  let derivers =
+    Ast_pattern.(
+      attribute ~name:(string "deriving") ~payload:(single_expr_payload __))
+  in
+  match
+    List.find_map type_decl.ptype_attributes ~f:(fun attr ->
+        parse_opt derivers Location.none attr (fun l -> Some l) )
+  with
+  | Some derivers ->
+      let derivers_loc = derivers.pexp_loc in
+      let derivers =
+        match derivers.pexp_desc with
+        | Pexp_tuple derivers ->
+            derivers
+        | _ ->
+            [ derivers ]
+      in
+      let make_lident_pattern nm =
+        Ast_pattern.(pexp_ident (lident (string nm)))
+      in
+      let version_pattern = make_lident_pattern "version" in
+      let version_with_arg_pattern =
+        Ast_pattern.(pexp_apply (make_lident_pattern "version") __)
+      in
+      let bin_io_pattern = make_lident_pattern "bin_io" in
+      let make_find_pattern handler pat =
+        List.exists derivers ~f:(fun deriver ->
+            Option.is_some @@ parse_opt pat Location.none deriver handler )
+      in
+      let find_pattern = make_find_pattern (Some ()) in
+      let find_with_arg_pattern = make_find_pattern (fun _ -> Some ()) in
+      let has_bin_io = find_pattern bin_io_pattern in
+      let has_version =
+        find_pattern version_pattern
+        || find_with_arg_pattern version_with_arg_pattern
+      in
+      if pred has_bin_io has_version then [ (derivers_loc, err_msg) ] else []
+  | None ->
+      []
+
+let validate_neither_bin_io_nor_version =
+  make_deriving_validator
+    ~pred:(fun has_bin_io has_version -> has_bin_io || has_version)
+    "Deriving bin_io and deriving version disallowed for types in functor body"
+
+let validate_version_if_bin_io =
+  make_deriving_validator
+    ~pred:(fun has_bin_io has_version -> has_bin_io && not has_version)
+    "Must have deriving version if deriving bin_io"
+
+let is_version_module vn =
+  let len = String.length vn in
+  len >= 2
+  && Char.equal vn.[0] 'V'
+  && (not @@ Char.equal vn.[1] '0')
+  && String.for_all (String.sub vn ~pos:1 ~len:(len - 1)) ~f:Char.is_digit
+
+let is_versioned_module_inc_decl inc_decl =
+  match inc_decl.pincl_mod.pmod_desc with
+  | Pmod_ident { txt = Ldot (Lident "Stable", name); _ }
+    when is_version_module name ->
+      true
+  | _ ->
+      false
+
+let versioned_in_functor_error loc =
+  (loc, "Cannot use versioned extension within a functor body")
+
+let include_stable_latest_error loc = (loc, "Cannot include Stable.Latest")
+
+type accumulator =
+  { in_functor : bool
+  ; in_include : bool
+  ; in_versioned_ext : bool
+  ; module_path : string list
+  ; errors : (Location.t * string) list
+  }
+
+let acc_with_errors acc errors = { acc with errors }
+
+let acc_with_accum_errors acc errors = { acc with errors = acc.errors @ errors }
+
+let is_longident_with_id id = function
+  | Lident s when String.equal id s ->
+      true
+  | Ldot (_lident, s) when String.equal id s ->
+      true
+  | _ ->
+      false
+
+let is_version_module vn =
+  let len = String.length vn in
+  len >= 2
+  && Char.equal vn.[0] 'V'
+  && (not @@ Char.equal vn.[1] '0')
+  && String.for_all (String.sub vn ~pos:1 ~len:(len - 1)) ~f:Char.is_digit
+
+let is_stable_prefix = is_longident_with_id "Stable"
+
+let is_stable_latest_inc_decl inc_decl =
+  match inc_decl.pincl_mod.pmod_desc with
+  | Pmod_ident { txt = Ldot (Lident "Stable", "Latest"); _ } ->
+      true
+  | _ ->
+      false
+
+let is_jane_street_prefix prefix =
+  match Longident.flatten_exn prefix with
+  (* N.B.: Uuid is in core_kernel library, but not in Core_kernel module *)
+  | core :: _
+    when List.mem [ "Core_kernel"; "Core"; "Uuid" ] core ~equal:String.equal ->
+      true
+  | _ ->
+      false
+
+(* N.B.: most versioned modules are within "Stable" modules, but that's not true
+   for modules in RPC type definitions, so we can't rely on that name
+*)
+let in_versioned_type_module module_path =
+  match module_path with
+  | "T" :: vn :: _
+    when is_version_module vn
+         (* this case will go away when all versioned modules have %%versioned *)
+    ->
+      true
+  | vn :: _ when is_version_module vn ->
+      true
+  | _ ->
+      false
+
+let is_versioned_module_ident id =
+  match id with
+  | Ldot (prefix, vn) when is_version_module vn && is_stable_prefix prefix ->
+      true
+  | _ ->
+      false
+
+let is_versioned_module_lident = function
+  | Ldot (prefix, vn)
+    when is_version_module vn
+         && (not @@ is_jane_street_prefix prefix)
+         && is_stable_prefix prefix ->
+      true
+  | _ ->
+      false
+
+let is_versioned_type_lident = function
+  | Ldot (Ldot (prefix, vn), "t")
+    when is_versioned_module_lident (Ldot (prefix, vn)) ->
+      true
+  | Ldot (Ldot (Ldot (prefix, vn), "T"), "t")
+    when is_versioned_module_lident (Ldot (prefix, vn)) ->
+      (* this case goes away when all versioned types use %%versioned *)
+      true
+  | _ ->
+      false
+
+let rec core_types_misuses core_types =
+  List.concat_map core_types ~f:get_core_type_versioned_type_misuses
+
+and get_core_type_versioned_type_misuses core_type =
+  match core_type.ptyp_desc with
+  | Ptyp_arrow (_label, core_type1, core_type2) ->
+      core_types_misuses [ core_type1; core_type2 ]
+  | Ptyp_tuple core_types ->
+      core_types_misuses core_types
+  | Ptyp_constr (lident, core_types) ->
+      let core_type_errors = core_types_misuses core_types in
+      if is_versioned_type_lident lident.txt then
+        let err =
+          ( lident.loc
+          , "Versioned type used outside a versioned type declaration" )
+        in
+        err :: core_type_errors
+      else core_type_errors
+  | Ptyp_object (fields, _closed_flag) ->
+      let core_type_of_field field =
+        match field.pof_desc with
+        | Otag (_label, core_type) ->
+            core_type
+        | Oinherit core_type ->
+            core_type
+      in
+      let core_types = List.map fields ~f:core_type_of_field in
+      core_types_misuses core_types
+  | Ptyp_class (_lident, core_types) ->
+      core_types_misuses core_types
+  | Ptyp_alias (core_type, _label) ->
+      get_core_type_versioned_type_misuses core_type
+  | Ptyp_variant (row_fields, _closed_flag, _labels_opt) ->
+      let core_types_of_row_field field =
+        match field.prf_desc with
+        | Rtag (_label, _b, core_types) ->
+            core_types
+        | Rinherit core_type ->
+            [ core_type ]
+      in
+      let core_types = List.concat_map row_fields ~f:core_types_of_row_field in
+      core_types_misuses core_types
+  | Ptyp_poly (_labels, core_type) ->
+      get_core_type_versioned_type_misuses core_type
+  | Ptyp_package (_module, type_constraints) ->
+      let core_types =
+        List.map type_constraints ~f:(fun (_ty, core_type) -> core_type)
+      in
+      core_types_misuses core_types
+  | Ptyp_extension _ext ->
+      []
+  | Ptyp_any ->
+      []
+  | Ptyp_var _ ->
+      []
+
+let types_of_constructor_args args =
+  match args with
+  | Pcstr_tuple tys ->
+      tys
+  | Pcstr_record label_decls ->
+      List.map label_decls ~f:(fun decl -> decl.pld_type)
+
+let types_of_type_kind kind =
+  match kind with
+  | Ptype_abstract ->
+      []
+  | Ptype_variant cstr_decls ->
+      List.concat_map cstr_decls ~f:(fun decl ->
+          let args_types = types_of_constructor_args decl.pcd_args in
+          match decl.pcd_res with
+          | None ->
+              args_types
+          | Some ty ->
+              ty :: args_types )
+  | Ptype_record label_decls ->
+      List.map label_decls ~f:(fun decl -> decl.pld_type)
+  | Ptype_open ->
+      []
+
+let get_versioned_type_misuses type_decl =
+  let params_types =
+    List.map type_decl.ptype_params ~f:(fun (ty, _variance) -> ty)
+  in
+  let cstr_types =
+    List.concat_map type_decl.ptype_cstrs ~f:(fun (ty1, ty2, _loc) ->
+        [ ty1; ty2 ] )
+  in
+  let kind_types = types_of_type_kind type_decl.ptype_kind in
+  let manifest_types = Option.to_list type_decl.ptype_manifest in
+  List.concat_map
+    (params_types @ cstr_types @ kind_types @ manifest_types)
+    ~f:get_core_type_versioned_type_misuses
+
+let include_versioned_module_error loc =
+  (loc, "Cannot include a stable versioned module")
+
+let in_stable_versioned_module module_path =
+  match module_path with
+  | vn :: "Stable" :: _ when is_version_module vn ->
+      true
+  (* this case goes away when explicit module registration is gone *)
+  | "T" :: vn :: "Stable" :: _ when is_version_module vn ->
+      true
+  | _ ->
+      false
+
+(* traverse AST, collect errors *)
+let lint_ast =
+  object (self)
+    inherit [accumulator] Ast_traverse.fold as super
+
+    method! expression expr acc =
+      match expr.pexp_desc with
+      | Pexp_extension (_, PTyp core_type) ->
+          (* misuses like [%bin_type_class: Foo.Stable.V1.t] *)
+          let errs = get_core_type_versioned_type_misuses core_type in
+          acc_with_accum_errors acc errs
+      | Pexp_pack mod_expr -> (
+          (* misuses like (module Foo.Stable.V1) *)
+          match mod_expr.pmod_desc with
+          | Pmod_ident id
+            when (not acc.in_versioned_ext) && is_versioned_module_lident id.txt
+            ->
+              let err = (id.loc, "Versioned module cannot be packaged") in
+              acc_with_accum_errors acc [ err ]
+          | _ ->
+              acc )
+      | _ ->
+          super#expression expr acc
+
+    method! module_expr expr acc =
+      let acc' =
+        match expr.pmod_desc with
+        (* don't match special case of functor with () argument *)
+        | Pmod_functor (Named _, body) ->
+            self#module_expr body { acc with in_functor = true }
+        | Pmod_apply
+            ( { pmod_desc =
+                  Pmod_apply
+                    ( { pmod_desc =
+                          Pmod_ident
+                            { txt = Ldot (Lident "Binable", of_binable); _ }
+                      ; _
+                      }
+                    , { pmod_desc = Pmod_ident { txt = arg; _ }; _ } )
+              ; pmod_loc
+              ; _
+              }
+            , _ )
+          when List.mem
+                 [ "Of_binable"
+                 ; "Of_binable_without_uuid"
+                 ; "Of_binable1"
+                 ; "Of_binable1_without_uuid"
+                 ; "Of_binable2"
+                 ; "Of_binable2_without_uuid"
+                 ; "Of_binable3"
+                 ; "Of_binable3_without_uuid"
+                 ]
+                 of_binable ~equal:String.equal ->
+            let include_errors =
+              if acc.in_include then []
+              else
+                [ ( pmod_loc
+                  , sprintf
+                      "Binable.%s application must be an argument to an include"
+                      of_binable )
+                ]
+            in
+            let path_errors =
+              if in_stable_versioned_module acc.module_path then []
+              else
+                [ ( pmod_loc
+                  , sprintf
+                      "Binable.%s applied outside of stable-versioned module"
+                      of_binable )
+                ]
+            in
+            let arg_errors =
+              if is_versioned_module_ident arg then []
+              else
+                [ ( pmod_loc
+                  , sprintf
+                      "First argument to Binable.%s must be a stable-versioned \
+                       module"
+                      of_binable )
+                ]
+            in
+            acc_with_accum_errors acc (include_errors @ path_errors @ arg_errors)
+        | Pmod_apply
+            ( { pmod_desc =
+                  Pmod_apply
+                    ( { pmod_desc =
+                          Pmod_ident
+                            { txt = Ldot (Lident "Binable", of_binable); _ }
+                      ; _
+                      }
+                    , _ )
+              ; pmod_loc
+              ; _
+              }
+            , _ )
+          when List.mem
+                 [ "Of_binable_with_uuid"
+                 ; "Of_binable1_with_uuid"
+                 ; "Of_binable2_with_uuid"
+                 ; "Of_binable3_with_uuid"
+                 ; "Of_stringable_with_uuid"
+                 ; "Of_sexpable_with_uuid"
+                 ]
+                 of_binable ~equal:String.equal ->
+            let errors =
+              [ ( pmod_loc
+                , sprintf
+                    "Binable.%s application not allowed, serialization may be \
+                     unstable"
+                    of_binable )
+              ]
+            in
+            acc_with_accum_errors acc errors
+        | Pmod_apply
+            ( { pmod_desc = Pmod_ident { txt = Ldot (Lident "Binable", ftor); _ }
+              ; pmod_loc
+              ; _
+              }
+            , _ )
+          when List.mem
+                 [ "Of_sexpable"; "Of_stringable" ]
+                 ftor ~equal:String.equal ->
+            let include_errors =
+              if acc.in_include then []
+              else
+                [ ( pmod_loc
+                  , sprintf
+                      "Binable.%s application must be an argument to an include"
+                      ftor )
+                ]
+            in
+            let path_errors =
+              if in_stable_versioned_module acc.module_path then []
+              else
+                [ ( pmod_loc
+                  , sprintf
+                      "Binable.%s applied outside of stable-versioned module"
+                      ftor )
+                ]
+            in
+            acc_with_accum_errors acc (include_errors @ path_errors)
+        | Pmod_apply
+            ( { pmod_desc =
+                  Pmod_ident
+                    { txt =
+                        Ldot (Ldot (Lident "Bin_prot", "Utils"), "Make_binable")
+                    ; _
+                    }
+              ; pmod_loc
+              ; _
+              }
+            , _ ) ->
+            let include_errors =
+              if acc.in_include then []
+              else
+                [ ( pmod_loc
+                  , "Bin_prot.Utils.Make_binable application must be an \
+                     argument to an include" )
+                ]
+            in
+            let path_errors =
+              if in_stable_versioned_module acc.module_path then []
+              else
+                [ ( pmod_loc
+                  , "Bin_prot.Utils.Make_binable applied outside of \
+                     stable-versioned module" )
+                ]
+            in
+            acc_with_accum_errors acc (include_errors @ path_errors)
+        | _ ->
+            super#module_expr expr acc
+      in
+      acc_with_errors acc acc'.errors
+
+    method! structure_item str acc =
+      match str.pstr_desc with
+      | Pstr_module { pmb_name = { txt = Some name; _ }; pmb_expr; _ } ->
+          let acc' =
+            self#module_expr pmb_expr
+              { acc with module_path = name :: acc.module_path }
+          in
+          acc_with_errors acc acc'.errors
+      | Pstr_type (rec_flag, type_decls) ->
+          let no_errors_fun _type_decl = [] in
+          let not_in_versioned_ext_fun type_decl =
+            let ty_name = type_decl.ptype_name.txt in
+            let err =
+              ( type_decl.ptype_loc
+              , "Versioned type must be in %%versioned extension" )
+            in
+            (* don't enforce %%versioned requirement for query, response types *)
+            if String.equal ty_name "t" then [ err ] else []
+          in
+          let deriving_errors_fun =
+            match rec_flag with
+            | Nonrecursive ->
+                no_errors_fun
+            | Recursive ->
+                if acc.in_functor then validate_neither_bin_io_nor_version
+                else validate_version_if_bin_io
+          in
+          let versioned_type_misuse_errors_fun =
+            if not @@ in_versioned_type_module acc.module_path then
+              get_versioned_type_misuses
+            else if not acc.in_versioned_ext then not_in_versioned_ext_fun
+            else no_errors_fun
+          in
+          let deriving_errors =
+            List.concat_map type_decls ~f:deriving_errors_fun
+          in
+          let versioned_type_misuse_errors =
+            List.concat_map type_decls ~f:versioned_type_misuse_errors_fun
+          in
+          acc_with_accum_errors acc
+            (deriving_errors @ versioned_type_misuse_errors)
+      | Pstr_extension ((name, _payload), _attrs)
+      (* %%versioned, %%versioned_asserted, etc. inside functor *)
+        when acc.in_functor
+             && String.length name.txt >= 9
+             && String.equal (String.sub name.txt ~pos:0 ~len:9) "versioned" ->
+          acc_with_accum_errors acc [ versioned_in_functor_error name.loc ]
+      | Pstr_extension ((name, PStr [ stri ]), _attrs)
+        when String.length name.txt >= 9
+             && String.equal (String.sub name.txt ~pos:0 ~len:9) "versioned" ->
+          let acc' =
+            self#structure_item stri { acc with in_versioned_ext = true }
+          in
+          { acc' with in_versioned_ext = false }
+      | Pstr_extension ((name, _payload), _attrs)
+        when List.mem
+               [ "test"; "test_unit"; "test_module" ]
+               name.txt ~equal:String.equal ->
+          (* don't check for errors in test code *)
+          acc
+      | Pstr_include inc_decl when is_stable_latest_inc_decl inc_decl ->
+          acc_with_errors acc [ include_stable_latest_error str.pstr_loc ]
+      | Pstr_include inc_decl when is_versioned_module_inc_decl inc_decl ->
+          acc_with_errors acc [ include_versioned_module_error str.pstr_loc ]
+      | Pstr_include inc_decl when is_stable_latest_inc_decl inc_decl ->
+          acc_with_errors acc [ include_stable_latest_error str.pstr_loc ]
+      | Pstr_include inc_decl ->
+          let acc' =
+            self#module_expr inc_decl.pincl_mod { acc with in_include = true }
+          in
+          { acc' with in_include = false }
+      | _ ->
+          let acc' = super#structure_item str acc in
+          acc_with_errors acc acc'.errors
+  end
+
+let lint_impl str =
+  let acc =
+    lint_ast#structure str
+      { in_functor = false
+      ; in_include = false
+      ; in_versioned_ext = false
+      ; module_path = []
+      ; errors = []
+      }
+  in
+  if !errors_as_warnings_ref then (
+    (* we can't print Lint_error.t's, so collect the same information
+       in a way we can print, that is, a list of location, string pairs *)
+    List.iter acc.errors ~f:(fun (loc, msg) ->
+        eprintf "File \"%s\", line %d, characters %d-%d:\n%!"
+          loc.loc_start.pos_fname loc.loc_start.pos_lnum
+          (loc.loc_start.pos_cnum - loc.loc_start.pos_bol)
+          (loc.loc_end.pos_cnum - loc.loc_start.pos_bol) ;
+        eprintf "Warning: %s\n%!" msg ) ;
+    (* don't return errors *)
+    [] )
+  else
+    (* produce Lint_error.t list from collected errors *)
+    List.map acc.errors ~f:(fun (loc, msg) ->
+        Driver.Lint_error.of_string loc msg )
+
+let () =
+  Driver.add_arg "-lint-version-syntax-warnings"
+    (Caml.Arg.Set errors_as_warnings_ref)
+    ~doc:" Version syntax errors as warnings" ;
+  Ppxlib.Driver.register_transformation name ~lint_impl

--- a/src/lib/ppx_version/test/Makefile
+++ b/src/lib/ppx_version/test/Makefile
@@ -1,0 +1,82 @@
+# Makefile for ppx_coda tests
+
+# useful for negative tests, so we know the failure is the failure
+# we expect
+
+ifdef VERBOSE
+REDIRECT=
+else
+REDIRECT= > /dev/null 2>&1
+endif
+
+.PHONY: positive-tests negative-tests
+
+# all : positive-tests negative-tests
+all : negative-tests
+
+positive-tests :
+# version syntax
+	@ echo -n "Version syntax, should succeed..."
+	dune build good_version_syntax.cma ${REDIRECT}
+	echo "OK"
+# versioning
+	@ echo -n "Versioned types, should succeed..."
+	@ dune build versioned_good.cma ${REDIRECT}
+	@ echo "OK"
+# module versioning
+	@ echo -n "Module versioning, should succeed..."
+	@ dune exec ./versioned_module_good.exe ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Module signature versioning, should succeed..."
+	@ dune exec ./versioned_sig_good.exe ${REDIRECT}
+	@ echo "OK"
+
+negative-tests :
+# version syntax
+	@ echo -n "Missing %%versioned, should fail..."
+	@ ! dune build bad_version_syntax_missing_versioned.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "%%versioned in functor body, should fail..."
+	@ ! dune build bad_versioned_in_functor.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "bin_io in nested functor body, should fail..."
+	@ ! dune build bad_versioned_in_nested_functor.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Multiple version syntax errors, use VERBOSE to see them all..."
+	@ ! dune build bad_version_syntax_multiple_errors.cma ${REDIRECT}
+	@ echo "OK"
+# versioning
+	@ echo -n "Versioned type in module with invalid name, should fail..."
+	@ ! dune build versioned_bad_module_name.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned type has wrong name, should fail..."
+	@ ! dune build versioned_bad_type_name.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned type with bad option, should fail..."
+	@ ! dune build versioned_bad_option.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned type with bad version name, should fail..."
+	@ ! dune build versioned_bad_version_name.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned types with bad contained types, should fail..."
+	@ ! dune build versioned_bad_contained_types.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned type with arrow type, should fail..."
+	@ ! dune build versioned_bad_arrow_type.cma ${REDIRECT}
+	@ echo "OK"
+# module versioning
+	@ echo -n "Module versioning with wrong module name, should fail..."
+	@ ! dune build versioned_module_bad_stable_name.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Module versioning with wrong version name, should fail..."
+	@ ! dune build versioned_module_bad_version_name.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Module versioning with missing type, should fail..."
+	@ ! dune build versioned_module_bad_missing_type.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Module versioning with incorrect version order, should fail..."
+	@ ! dune build versioned_module_bad_version_order.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Module versioning with missing to_latest, should fail..."
+	@ ! dune build versioned_module_bad_missing_to_latest.cma ${REDIRECT}
+	@ echo "OK"

--- a/src/lib/ppx_version/test/bad_version_syntax_bin_io_in_functor.ml
+++ b/src/lib/ppx_version/test/bad_version_syntax_bin_io_in_functor.ml
@@ -1,0 +1,13 @@
+open Core_kernel
+
+(* deriving bin_io in functor body *)
+
+module Functor (X : sig end) = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = string [@@deriving bin_io]
+      end
+    end
+  end
+end

--- a/src/lib/ppx_version/test/bad_version_syntax_extension.ml
+++ b/src/lib/ppx_version/test/bad_version_syntax_extension.ml
@@ -1,0 +1,8 @@
+open Core_kernel
+
+(* an extension that's not a test module *)
+
+let%not_a_test_module "bad bin_io only" =
+  ( module struct
+    type t = string [@@deriving bin_io]
+  end )

--- a/src/lib/ppx_version/test/bad_version_syntax_missing_versioned.ml
+++ b/src/lib/ppx_version/test/bad_version_syntax_missing_versioned.ml
@@ -1,0 +1,11 @@
+open Core_kernel
+
+(* deriving bin_io, version, but not wrapped in %%versioned *)
+
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      type t = int [@@deriving bin_io, version]
+    end
+  end
+end

--- a/src/lib/ppx_version/test/bad_version_syntax_multiple_errors.ml
+++ b/src/lib/ppx_version/test/bad_version_syntax_multiple_errors.ml
@@ -1,0 +1,17 @@
+open Core_kernel
+
+module Foo = struct
+  module Bar = struct
+    type t = int [@@deriving bin_io]
+  end
+
+  type t = string [@@deriving bin_io]
+
+  type t' = string [@@deriving bin_io]
+
+  module Quux = struct
+    type t = int [@@deriving bin_io]
+  end
+end
+
+type t = char [@@deriving bin_io]

--- a/src/lib/ppx_version/test/bad_version_syntax_version_in_functor.ml
+++ b/src/lib/ppx_version/test/bad_version_syntax_version_in_functor.ml
@@ -1,0 +1,11 @@
+(* deriving version in functor body *)
+
+module Functor (X : sig end) = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = string [@@deriving version]
+      end
+    end
+  end
+end

--- a/src/lib/ppx_version/test/bad_versioned_in_functor.ml
+++ b/src/lib/ppx_version/test/bad_versioned_in_functor.ml
@@ -1,0 +1,14 @@
+(* versioned in functor body *)
+
+open Core_kernel
+
+module Functor (X : sig end) = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = string
+
+      let to_latest = Fn.id
+    end
+  end]
+end

--- a/src/lib/ppx_version/test/bad_versioned_in_nested_functor.ml
+++ b/src/lib/ppx_version/test/bad_versioned_in_nested_functor.ml
@@ -1,0 +1,17 @@
+open Core_kernel
+
+(* deriving bin_io in nested functor body *)
+
+module Functor (X : sig end) (Y : sig
+  val _y : int
+end) =
+struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = string [@@deriving bin_io]
+
+      let to_latest = Fn.id
+    end
+  end]
+end

--- a/src/lib/ppx_version/test/dune
+++ b/src/lib/ppx_version/test/dune
@@ -1,0 +1,128 @@
+;;; each library below has an identical preprocess clause, because of this
+;;; dune bug: https://github.com/ocaml/dune/issues/1946
+
+;;; should succeed
+
+;; version syntax
+(library
+  (name good_version_syntax)
+  (preprocess (pps ppx_jane ppx_version ppx_deriving_yojson))
+  (libraries base.caml core_kernel bin_prot.shape)
+  (modules good_version_syntax))
+
+;; versioning
+(library
+  (name versioned_good)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_good))
+
+;; module versioning
+(executable
+  (name versioned_module_good)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_module_good))
+
+(executable
+  (name versioned_sig_good)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_sig_good))
+
+;;; should fail
+
+;; version syntax
+
+(library
+  (name bad_version_syntax_missing_versioned)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules bad_version_syntax_missing_versioned))
+
+(library
+  (name bad_versioned_in_functor)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules bad_versioned_in_functor))
+
+(library
+  (name bad_versioned_in_nested_functor)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules bad_versioned_in_nested_functor))
+
+(library
+  (name bad_version_syntax_multiple_errors)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules bad_version_syntax_multiple_errors))
+
+;; versioning
+
+(library
+ (name versioned_bad_module_name)
+ (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+ (libraries base.caml core_kernel bin_prot.shape sexplib0)
+ (modules versioned_bad_module_name))
+
+(library
+ (name versioned_bad_version_name)
+ (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+ (libraries base.caml core_kernel bin_prot.shape sexplib0)
+ (modules versioned_bad_version_name))
+
+(library
+  (name versioned_bad_type_name)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_bad_type_name))
+
+(library
+  (name versioned_bad_option)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_bad_option))
+
+(library
+  (name versioned_bad_contained_types)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_bad_contained_types))
+
+(library
+  (name versioned_bad_arrow_type)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_bad_arrow_type))
+
+;; module versioning
+(library
+  (name versioned_module_bad_stable_name)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_module_bad_stable_name))
+
+(library
+  (name versioned_module_bad_version_name)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_module_bad_version_name))
+
+(library
+  (name versioned_module_bad_missing_type)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_module_bad_missing_type))
+
+(library
+  (name versioned_module_bad_version_order)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_module_bad_version_order))
+
+(library
+  (name versioned_module_bad_missing_to_latest)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version))
+  (libraries base.caml core_kernel bin_prot.shape sexplib0)
+  (modules versioned_module_bad_missing_to_latest))

--- a/src/lib/ppx_version/test/good_version_syntax.ml
+++ b/src/lib/ppx_version/test/good_version_syntax.ml
@@ -1,0 +1,27 @@
+open Core_kernel
+
+(* (generated) deriving version and bin_io both appear; OK outside functor body *)
+
+module M1 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = int
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+(* version with an argument *)
+module M = struct
+  module V1 = struct
+    module T = struct
+      type query = Core_kernel.Int.Stable.V1.t
+      [@@deriving bin_io, version { rpc }]
+    end
+  end
+end
+
+(* deliberately unversioned *)
+type t = int [@@bin_io_unversioned]

--- a/src/lib/ppx_version/test/versioned_bad_arrow_type.ml
+++ b/src/lib/ppx_version/test/versioned_bad_arrow_type.ml
@@ -1,0 +1,13 @@
+open Core_kernel
+
+module Foo = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      (* can't version arrow type *)
+      type t = int -> string
+
+      let to_lateset = Fn.id
+    end
+  end]
+end

--- a/src/lib/ppx_version/test/versioned_bad_contained_types.ml
+++ b/src/lib/ppx_version/test/versioned_bad_contained_types.ml
@@ -1,0 +1,13 @@
+open Core_kernel
+
+module Foo = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      (* List.t is not versioned *)
+      type t = int List.t
+
+      let to_latest = Fn.id
+    end
+  end]
+end

--- a/src/lib/ppx_version/test/versioned_bad_module_name.ml
+++ b/src/lib/ppx_version/test/versioned_bad_module_name.ml
@@ -1,0 +1,14 @@
+open Core_kernel
+
+module Foo = struct
+  module Bar = struct
+    [%%versioned
+    module Stable = struct
+      module Vx = struct
+        type t = int
+
+        let to_latest = Fn.id
+      end
+    end]
+  end
+end

--- a/src/lib/ppx_version/test/versioned_bad_module_structure.ml
+++ b/src/lib/ppx_version/test/versioned_bad_module_structure.ml
@@ -1,0 +1,10 @@
+module Foo = struct
+  module Bar = struct
+    module Stable = struct
+      module V1 = struct
+        (* type t must be in module T *)
+        type t [@@deriving version]
+      end
+    end
+  end
+end

--- a/src/lib/ppx_version/test/versioned_bad_option.ml
+++ b/src/lib/ppx_version/test/versioned_bad_option.ml
@@ -1,0 +1,15 @@
+open Core_kernel
+
+module Foo = struct
+  module Bar = struct
+    [%%versioned
+    module Stable = struct
+      module V1 = struct
+        (* "option" misspelled *)
+        type t = int optin [@@deriving yojson]
+
+        let to_latest = Fn.id
+      end
+    end]
+  end
+end

--- a/src/lib/ppx_version/test/versioned_bad_type_name.ml
+++ b/src/lib/ppx_version/test/versioned_bad_type_name.ml
@@ -1,0 +1,13 @@
+module Foo = struct
+  module Bar = struct
+    [%%versioned
+    module Stable = struct
+      module V1 = struct
+        (* type name must be t *)
+        type not_t [@@deriving version]
+
+        let to_latest = Fn.id
+      end
+    end]
+  end
+end

--- a/src/lib/ppx_version/test/versioned_bad_unnumbered.ml
+++ b/src/lib/ppx_version/test/versioned_bad_unnumbered.ml
@@ -1,0 +1,9 @@
+open Core_kernel
+
+module Make (M : sig
+  type t = Int.t [@@deriving version { unnumbered }]
+end) =
+struct
+  (* unnumbered option means M.version doesn't exist *)
+  let x = M.version
+end

--- a/src/lib/ppx_version/test/versioned_bad_version_name.ml
+++ b/src/lib/ppx_version/test/versioned_bad_version_name.ml
@@ -1,0 +1,12 @@
+module Foo = struct
+  module Bar = struct
+    module Stable = struct
+      (* module name can't have 0 as first digit after V *)
+      module V01 = struct
+        module T = struct
+          type t [@@deriving version]
+        end
+      end
+    end
+  end
+end

--- a/src/lib/ppx_version/test/versioned_bad_wrapped_module_structure.ml
+++ b/src/lib/ppx_version/test/versioned_bad_wrapped_module_structure.ml
@@ -1,0 +1,9 @@
+module Foo = struct
+  module Unwrapped = struct
+    module Stable = struct
+      module V1 = struct
+        type t [@@deriving version { wrapped }]
+      end
+    end
+  end
+end

--- a/src/lib/ppx_version/test/versioned_good.ml
+++ b/src/lib/ppx_version/test/versioned_good.ml
@@ -1,0 +1,210 @@
+open Core_kernel
+
+(* a signature *)
+module type Some_intf = sig
+  type t = Quux | Zzz [@@deriving bin_io, version]
+end
+
+module M0 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = int [@@deriving yojson]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+module M1 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      (* refers to versioned type *)
+      type t = M0.Stable.V1.t [@@deriving yojson]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+module M3 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      (* tuple of versioned types *)
+      type t = M0.Stable.V1.t * M1.Stable.V1.t
+
+      let to_latest = Fn.id [@@deriving yojson]
+    end
+  end]
+end
+
+module M4 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      (* record of versioned types *)
+      type t = { one : M0.Stable.V1.t; two : M1.Stable.V1.t }
+      [@@deriving yojson]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+[%%versioned
+module Stable = struct
+  module V1 = struct
+    type t = int [@@deriving yojson, bin_io, version, sexp]
+
+    let to_latest = Fn.id
+  end
+end]
+
+(* type constructors *)
+module M5 = struct
+  [%%versioned
+  module Stable = struct
+    module V5 = struct
+      type t = (Stable.V1.t array array[@sexp.opaque]) [@@deriving sexp]
+
+      let to_latest = Fn.id
+    end
+
+    module V4 = struct
+      type t = (Stable.V1.t option[@sexp.opaque]) [@@deriving sexp]
+
+      let to_latest _ = [||]
+    end
+
+    module V3 = struct
+      type t = Stable.V1.t ref [@@deriving yojson]
+
+      let to_latest _ = [||]
+    end
+
+    module V2 = struct
+      type t = Stable.V1.t list [@@deriving yojson]
+
+      let to_latest _ = [||]
+    end
+
+    module V1 = struct
+      type t = Stable.V1.t option [@@deriving yojson]
+
+      let to_latest _ = [||]
+    end
+  end]
+end
+
+module type Intf = sig
+  type t = Int.t [@@deriving version]
+end
+
+(* recursive type *)
+module M6 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = Leaf | Node of t * t [@@deriving yojson]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+(* type with parameters *)
+module Poly = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type ('a, 'b) t = Poly of 'a * 'b [@@deriving yojson]
+    end
+  end]
+end
+
+module M7 = struct
+  module M = struct
+    [%%versioned
+    module Stable = struct
+      module V1 = struct
+        type t = (string, int) Poly.Stable.V1.t [@@deriving yojson]
+
+        let to_latest = Fn.id
+      end
+    end]
+  end
+end
+
+(* assert versionedness *)
+module M8 = struct
+  [%%versioned_asserted
+  module Stable = struct
+    module V1 = struct
+      type t = Int.t List.t
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+(* int32 *)
+module M9 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = int32
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+(* int64 *)
+module M10 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = int64
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+(* bytes *)
+module M11 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = bytes
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+(* Jane Street trustlisting *)
+module M12 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = int Core_kernel.Queue.Stable.V1.t
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+(* Jane Street special case *)
+module M13 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = Core_kernel.Time.Stable.Span.V1.t [@@deriving bin_io, version]
+
+      let to_latest = Fn.id
+    end
+  end]
+end

--- a/src/lib/ppx_version/test/versioned_module_bad_missing_to_latest.ml
+++ b/src/lib/ppx_version/test/versioned_module_bad_missing_to_latest.ml
@@ -1,0 +1,16 @@
+open Core_kernel
+
+module Type = struct
+  [%%versioned
+  module Stable = struct
+    module V2 = struct
+      type t = int
+
+      let to_latest = Fn.id
+    end
+
+    module V1 = struct
+      type t = bool
+    end
+  end]
+end

--- a/src/lib/ppx_version/test/versioned_module_bad_missing_type.ml
+++ b/src/lib/ppx_version/test/versioned_module_bad_missing_type.ml
@@ -1,0 +1,8 @@
+open Core_kernel
+
+module Type = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct end
+  end]
+end

--- a/src/lib/ppx_version/test/versioned_module_bad_stable_name.ml
+++ b/src/lib/ppx_version/test/versioned_module_bad_stable_name.ml
@@ -1,0 +1,5 @@
+open Core_kernel
+
+module Type = struct
+  [%%versioned module Bad = struct end]
+end

--- a/src/lib/ppx_version/test/versioned_module_bad_version_name.ml
+++ b/src/lib/ppx_version/test/versioned_module_bad_version_name.ml
@@ -1,0 +1,8 @@
+open Core_kernel
+
+module Type = struct
+  [%%versioned
+  module Stable = struct
+    module Bad = struct end
+  end]
+end

--- a/src/lib/ppx_version/test/versioned_module_bad_version_order.ml
+++ b/src/lib/ppx_version/test/versioned_module_bad_version_order.ml
@@ -1,0 +1,14 @@
+open Core_kernel
+
+module Type = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = int
+    end
+
+    module V2 = struct
+      type t = bool
+    end
+  end]
+end

--- a/src/lib/ppx_version/test/versioned_module_good.ml
+++ b/src/lib/ppx_version/test/versioned_module_good.ml
@@ -1,0 +1,264 @@
+open Core_kernel
+
+(* unused type *)
+[@@@warning "-34"]
+
+(* Basic test. *)
+module M1 = struct
+  [%%versioned
+  module Stable = struct
+    module V3 = struct
+      type t = int [@@deriving equal]
+
+      let to_latest = Fn.id
+    end
+
+    module V2 = struct
+      type t = int
+
+      let to_latest = Fn.id
+    end
+
+    module V1 = struct
+      type t = bool
+
+      let to_latest b = if b then 1 else 0
+    end
+  end]
+end
+
+let () =
+  let x = 15 in
+  let buf = Bigstring.create 10 in
+  (* Test writing given version. *)
+  ignore (M1.Stable.V3.bin_write_t buf ~pos:0 x : int) ;
+  (* Test that reads are compatible with [With_version]. *)
+  let y : M1.Stable.V3.With_version.t =
+    M1.Stable.V3.With_version.bin_read_t buf ~pos_ref:(ref 0)
+  in
+  assert (y.version = 3) ;
+  assert (y.t = x) ;
+  (* Test that what was read is what was written. *)
+  let z = M1.Stable.V3.bin_read_t buf ~pos_ref:(ref 0) in
+  assert (z = x) ;
+  (* Test that trying to read the wrong version results in an assertion
+     failure.
+  *)
+  ( try
+      ignore (M1.Stable.V2.bin_read_t buf ~pos_ref:(ref 0) : int) ;
+      assert false
+    with Failure _ -> () ) ;
+  (* Test that [bin_read_to_latest_opt] finds and uses the right
+     deserialisation.
+  *)
+  match M1.Stable.bin_read_to_latest_opt buf ~pos_ref:(ref 0) with
+  | Some a ->
+      assert (a = x)
+  | None ->
+      assert false
+
+(* No [to_latest] necessary because the latest version takes a parameter. *)
+module M2 = struct
+  [%%versioned
+  module Stable = struct
+    module V3 = struct
+      type 'a t = { a : 'a; b : int } [@@deriving equal]
+    end
+
+    module V2 = struct
+      type 'a t = { b : M1.Stable.V3.t; a : 'a }
+    end
+
+    module V1 = struct
+      type t = { a : M1.Stable.V1.t }
+    end
+  end]
+end
+
+(* No [to_latest] necessary when older versions have parameters. *)
+module M3 = struct
+  [%%versioned
+  module Stable = struct
+    module V3 = struct
+      type t = { a : bool; b : int }
+
+      let to_latest = Fn.id
+    end
+
+    module V2 = struct
+      type 'a t = { b : M1.Stable.V3.t; a : 'a }
+    end
+
+    module V1 = struct
+      type t = { a : M1.Stable.V1.t }
+
+      let to_latest { a } = { V3.a; b = (if a then 1 else 0) }
+    end
+  end]
+end
+
+(* Test that types with arguments are still annotated with the correct
+   versions.
+*)
+let () =
+  (* Choose a value that could deserialise to [M2.Stable.V3.t] and [V2.t] if
+     not for the versioning checks.
+  *)
+  let x : M1.Stable.V3.t M2.Stable.V3.t = { M2.a = 15; b = 15 } in
+  let buf = Bigstring.create 20 in
+  (* Test writing given version. *)
+  ignore (M2.Stable.V3.bin_write_t M1.Stable.V3.bin_write_t buf ~pos:0 x : int) ;
+  (* Test that reads are compatible with [With_version]. *)
+  let y : M1.Stable.V3.t M2.Stable.V3.With_version.t =
+    M2.Stable.V3.With_version.bin_read_t M1.Stable.V3.bin_read_t buf
+      ~pos_ref:(ref 0)
+  in
+  assert (y.version = 3) ;
+  assert (M2.Stable.V3.equal Int.equal y.t x) ;
+  (* Test that what was read is what was written. *)
+  let z =
+    M2.Stable.V3.bin_read_t M1.Stable.V3.bin_read_t buf ~pos_ref:(ref 0)
+  in
+  assert (M2.Stable.V3.equal Int.equal z x) ;
+  (* Test that trying to read the wrong version results in an assertion
+     failure.
+     Note: these types will serialise to the same thing, as
+     [int M2.Stable.V3.t = {b: M1.Stable.V3.t; a: int}]
+     [M1.Stable.V3.t M2.Stable.V3.t = {a: M1.Stable.V3.t; b: int}]
+  *)
+  try
+    ignore
+      ( M2.Stable.V3.bin_read_t bin_read_int buf ~pos_ref:(ref 0)
+        : int M2.Stable.V3.t ) ;
+    assert false
+  with Assert_failure _ -> ()
+
+(* Test that annotations on the types are accepted. *)
+module M4 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = { a : bool; b : int } [@@deriving sexp, equal]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+(* Allow binable functor *)
+module M5 = struct
+  [%%versioned_binable
+  module Stable = struct
+    module V1 = struct
+      type t = bool
+
+      let to_latest = Fn.id
+
+      module Arg = struct
+        type nonrec t = t
+
+        let to_binable = Fn.id
+
+        let of_binable = Fn.id
+      end
+
+      include Binable.Of_binable_without_uuid (Core_kernel.Bool.Stable.V1) (Arg)
+    end
+  end]
+end
+
+(* Test that a version annotation is accepted, and the standard version
+   annotation isn't also added.
+*)
+module M6 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = Bool.t [@@deriving version { asserted }]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+module M7 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = M1.Stable.V3.t M2.Stable.V3.t [@@deriving equal]
+
+      let to_latest = Fn.id
+    end
+  end]
+end
+
+(* Test that types applied to parameters are properly versioned. *)
+let () =
+  let x : M7.Stable.V1.t = { a = 15; b = 20 } in
+  let buf = Bigstring.create 20 in
+  (* Test writing given version. *)
+  ignore (M7.Stable.V1.bin_write_t buf ~pos:0 x : int) ;
+  (* Test that reads are compatible with [With_version]. *)
+  let y : M7.Stable.V1.With_version.t =
+    M7.Stable.V1.With_version.bin_read_t buf ~pos_ref:(ref 0)
+  in
+  assert (y.version = 1) ;
+  assert (M7.Stable.V1.equal y.t x) ;
+  (* Test that what was read is what was written. *)
+  let z = M7.Stable.V1.bin_read_t buf ~pos_ref:(ref 0) in
+  assert (M7.Stable.V1.equal z x)
+
+(* Test that modules may have other contents besides the type declarations. *)
+module M8 = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = int
+
+      let some = 1
+
+      let other = 2
+
+      let things = 3
+
+      let (_ : int * int * int) = (some, other, things)
+
+      let to_latest = Fn.id
+
+      module X = struct
+        type t = bool
+      end
+
+      module type Y = sig
+        type t
+      end
+
+      module F (X : Y) = struct
+        type y = t
+
+        include X
+      end
+
+      include (
+        F
+          (X) :
+            sig
+              type y = t
+            end )
+    end
+  end]
+
+  module X = struct
+    open Stable.V1
+
+    let (_ : int * int * int) = (some, other, things)
+
+    module X = X
+
+    module type Y = Y
+
+    module F = F
+
+    type y = Stable.V1.y
+  end
+end

--- a/src/lib/ppx_version/test/versioned_sig_good.ml
+++ b/src/lib/ppx_version/test/versioned_sig_good.ml
@@ -1,0 +1,21 @@
+open Core_kernel
+
+module Good = struct
+  [%%versioned
+  module Stable = struct
+    module V2 = struct
+      type t = int
+
+      let to_latest = Fn.id
+    end
+
+    module V1 = struct
+      type t = string
+
+      let to_latest = String.length
+    end
+  end]
+
+  (* make sure t is an int *)
+  let is_42 t = Int.( = ) t 42
+end

--- a/src/lib/ppx_version/test/versioned_sig_good.mli
+++ b/src/lib/ppx_version/test/versioned_sig_good.mli
@@ -1,0 +1,19 @@
+open Core_kernel
+
+module Good : sig
+  [%%versioned:
+  module Stable : sig
+    module V2 : sig
+      type t = int
+    end
+
+    module V1 : sig
+      type t = string
+
+      val to_latest : t -> V2.t
+    end
+  end]
+
+  (* make sure t is an int *)
+  val is_42 : t -> bool
+end

--- a/src/lib/ppx_version/tools/dune
+++ b/src/lib/ppx_version/tools/dune
@@ -1,0 +1,35 @@
+(executable
+ (name print_versioned_types)
+ (modules print_versioned_types)
+ (libraries ppx_version
+            ; every deriver we might encounter
+            ppx_bin_prot
+            lens.ppx_deriving
+            ppx_deriving.std
+            ppx_sexp_conv
+            ppx_compare
+            ppx_enumerate
+            ppx_fields_conv
+            ppx_hash
+            ppx_variants_conv
+            ppx_deriving_yojson
+            base_quickcheck.ppx_quickcheck)
+ (preprocess (pps ppxlib.metaquot)))
+
+(executable
+ (name print_binable_functors)
+ (modules print_binable_functors)
+ (libraries ppx_version
+            ; every deriver we might encounter
+            ppx_bin_prot
+            lens.ppx_deriving
+            ppx_deriving.std
+            ppx_sexp_conv
+            ppx_compare
+            ppx_enumerate
+            ppx_fields_conv
+            ppx_hash
+            ppx_variants_conv
+            ppx_deriving_yojson
+            base_quickcheck.ppx_quickcheck)
+ (preprocess (pps ppxlib.metaquot)))

--- a/src/lib/ppx_version/tools/print_binable_functors.ml
+++ b/src/lib/ppx_version/tools/print_binable_functors.ml
@@ -1,0 +1,106 @@
+(* print_binable_functors.ml *)
+
+(* print out applications of functors Binable.Of... or Bin_prot.Utils.Make_binable
+
+   within a versioned type, these should not change
+   and they should always appear within a versioned type
+*)
+
+open Core_kernel
+open Ppxlib
+open Ppx_version
+open Versioned_util
+
+let name = "print_binable_functors"
+
+type accumulator = { module_path : string list }
+
+let is_included_binable_functor_app (inc_decl : include_declaration) =
+  let of_binable_pattern =
+    Ast_pattern.(
+      pmod_apply
+        (pmod_apply (pmod_ident (ldot (lident (string "Binable")) __)) __)
+        __)
+  in
+  let of_binable =
+    match
+      parse_opt of_binable_pattern Location.none inc_decl.pincl_mod
+        (fun ftor _ _ -> Some ftor)
+    with
+    | Some ftor ->
+        List.mem
+          [ "Of_binable"
+          ; "Of_binable_without_uuid"
+          ; "Of_binable1"
+          ; "Of_binable1_without_uuid"
+          ; "Of_binable2"
+          ; "Of_binable2_without_uuid"
+          ; "Of_binable3"
+          ; "Of_binable3_without_uuid"
+          ; "Of_sexpable"
+          ; "Of_sexpable_without_uuid"
+          ; "Of_stringable"
+          ; "Of_stringable_without_uuid"
+          ]
+          ftor ~equal:String.equal
+    | _ ->
+        false
+  in
+  let make_binable_pattern =
+    Ast_pattern.(
+      pmod_apply
+        (pmod_ident
+           (ldot
+              (ldot (lident (string "Bin_prot")) (string "Utils"))
+              (string "Make_binable") ) )
+        __)
+  in
+  let make_binable =
+    Option.is_some
+      (parse_opt make_binable_pattern Location.none inc_decl.pincl_mod (fun _ ->
+           Some () ) )
+  in
+  of_binable || make_binable
+
+let print_included_binable_functor_app ~path inc =
+  let path_len = List.length path in
+  List.iteri path ~f:(fun i s ->
+      printf "%s" s ;
+      if i < path_len - 1 then printf "." ) ;
+  printf ":%!" ;
+  Pprintast.structure_item Versioned_util.diff_formatter inc ;
+  Format.pp_print_flush Versioned_util.diff_formatter () ;
+  printf "\n%!"
+
+let traverse_ast =
+  object (self)
+    inherit [accumulator] Ast_traverse.fold as super
+
+    method! structure_item stri acc =
+      match stri.pstr_desc with
+      | Pstr_module { pmb_name = { txt = Some name; _ }; pmb_expr; _ } ->
+          ignore
+            (self#module_expr pmb_expr
+               { module_path = name :: acc.module_path } ) ;
+          acc
+      | Pstr_extension ((name, _payload), _attrs)
+        when List.mem
+               [ "test"; "test_unit"; "test_module" ]
+               name.txt ~equal:String.equal ->
+          (* don't print functors in test code *)
+          acc
+      | Pstr_include inc_decl when is_included_binable_functor_app inc_decl ->
+          print_included_binable_functor_app ~path:acc.module_path stri ;
+          acc
+      | _ ->
+          super#structure_item stri acc
+  end
+
+let preprocess_impl str =
+  ignore (traverse_ast#structure str { module_path = [] }) ;
+  str
+
+let () =
+  Ppx_version.Dummy_derivers.register_dummies () ;
+  Ppxlib.Driver.register_transformation name ~preprocess_impl ;
+  Ppxlib.Driver.standalone ()

--- a/src/lib/ppx_version/tools/print_versioned_types.ml
+++ b/src/lib/ppx_version/tools/print_versioned_types.ml
@@ -1,0 +1,6 @@
+(* print_versioned_types.ml *)
+
+let () =
+  Ppx_version.Dummy_derivers.register_dummies () ;
+  Ppx_version.Versioned_type.set_printing () ;
+  Ppxlib.Driver.standalone ()

--- a/src/lib/ppx_version/versioned_module.ml
+++ b/src/lib/ppx_version/versioned_module.ml
@@ -1,0 +1,879 @@
+open Core_kernel
+open Ppxlib
+open Versioned_util
+
+let no_toplevel_latest_type = ref false
+
+(* option to `deriving version' *)
+type version_option = No_version_option | Asserted | Binable
+
+let create_attr ~loc attr_name attr_payload =
+  { attr_name; attr_payload; attr_loc = loc }
+
+let modify_attr_payload attr payload = { attr with attr_payload = payload }
+
+let rec add_deriving ~loc ~version_option attributes : attributes =
+  let (module Ast_builder) = Ast_builder.make loc in
+  let payload idents =
+    let payload = Ast_builder.(pstr_eval (pexp_tuple idents) []) in
+    PStr [ payload ]
+  in
+  let version_expr =
+    match version_option with
+    | No_version_option ->
+        [%expr version]
+    | Asserted ->
+        [%expr version { asserted }]
+    | Binable ->
+        [%expr version { binable }]
+  in
+  match attributes with
+  | [] ->
+      let attr_name = mk_loc ~loc "deriving" in
+      let attr_payload =
+        match version_option with
+        | No_version_option | Asserted ->
+            payload [ [%expr bin_io]; version_expr ]
+        | Binable ->
+            payload [ version_expr ]
+      in
+      [ create_attr ~loc attr_name attr_payload ]
+  | attr :: attributes -> (
+      let idents =
+        Ast_pattern.(
+          attribute ~name:(string "deriving") ~payload:(single_expr_payload __))
+      in
+      match parse_opt idents loc attr (fun l -> Some l) with
+      | None ->
+          attr :: add_deriving ~loc ~version_option attributes
+      | Some args ->
+          (* Can't use [Ast_pattern] here, because [alt] doesn't suppress the
+             errors raised from the [pexp_*] patterns..
+          *)
+          let args =
+            match args.pexp_desc with Pexp_tuple args -> args | _ -> [ args ]
+          in
+          let special_version =
+            Ast_pattern.(pexp_apply (pexp_ident (lident (string "version"))) __)
+          in
+          let has_version =
+            List.exists args ~f:(fun arg ->
+                Option.is_some
+                @@ parse_opt special_version loc arg (fun _ -> Some ()) )
+          in
+          let needs_bin_io =
+            match version_option with
+            | No_version_option | Asserted ->
+                true
+            | Binable ->
+                false
+          in
+          let extra_payload_args =
+            match (has_version, needs_bin_io) with
+            | false, false ->
+                [ version_expr ]
+            | false, true ->
+                [ [%expr bin_io]; version_expr ]
+            | true, false ->
+                []
+            | true, true ->
+                [ [%expr bin_io] ]
+          in
+          modify_attr_payload attr (payload (extra_payload_args @ args))
+          :: attributes )
+
+let erase_stable_versions =
+  object
+    inherit Ast_traverse.map as super
+
+    method! core_type typ =
+      match typ.ptyp_desc with
+      | Ptyp_constr
+          ({ txt = Ldot (Ldot (Ldot (lid, "Stable"), vn), "t"); loc }, typs)
+        when try
+               validate_module_version vn loc ;
+               true
+             with _ -> false ->
+          (* Erase [.Stable.Vn.t] to [.t] *)
+          let typ =
+            { typ with
+              ptyp_desc = Ptyp_constr ({ txt = Ldot (lid, "t"); loc }, typs)
+            }
+          in
+          super#core_type typ
+      | _ ->
+          super#core_type typ
+
+    method! type_declaration typ =
+      let typ = super#type_declaration typ in
+      let ptype_attributes : attributes =
+        List.filter_map typ.ptype_attributes
+          ~f:(fun ({ attr_name; attr_payload = payload; attr_loc } as attr) ->
+            if String.equal attr_name.txt "deriving" then
+              let remove_derivers = [| "bin_io"; "version" |] in
+              match payload with
+              | PStr
+                  [ ( { pstr_desc =
+                          Pstr_eval
+                            (({ pexp_desc = Pexp_tuple exprs; _ } as expr), _)
+                      ; _
+                      } as stri )
+                  ] -> (
+                  let exprs =
+                    List.filter exprs ~f:(function
+                      | { pexp_desc = Pexp_ident { txt = Lident name; _ }; _ }
+                      | { pexp_desc =
+                            Pexp_apply
+                              ( { pexp_desc = Pexp_ident { txt = Lident name; _ }
+                                ; _
+                                }
+                              , _ )
+                        ; _
+                        }
+                        when Array.mem ~equal:String.equal remove_derivers name
+                        ->
+                          false
+                      | _ ->
+                          true )
+                  in
+                  match exprs with
+                  | [] ->
+                      None
+                  | [ e ] ->
+                      Some
+                        { attr_name
+                        ; attr_payload =
+                            PStr [ { stri with pstr_desc = Pstr_eval (e, []) } ]
+                        ; attr_loc
+                        }
+                  | es ->
+                      Some
+                        { attr_name
+                        ; attr_payload =
+                            PStr
+                              [ { stri with
+                                  pstr_desc =
+                                    Pstr_eval
+                                      ( { expr with pexp_desc = Pexp_tuple es }
+                                      , [] )
+                                }
+                              ]
+                        ; attr_loc
+                        } )
+              | PStr
+                  [ { pstr_desc =
+                        Pstr_eval
+                          ( { pexp_desc =
+                                ( Pexp_ident { txt = Lident name; _ }
+                                | Pexp_apply
+                                    ( { pexp_desc =
+                                          Pexp_ident { txt = Lident name; _ }
+                                      ; _
+                                      }
+                                    , _ ) )
+                            ; _
+                            }
+                          , _ )
+                    ; _
+                    }
+                  ]
+                when Array.mem ~equal:String.equal remove_derivers name ->
+                  None
+              | _ ->
+                  Some attr
+            else Some attr )
+      in
+      { typ with
+        ptype_attributes
+      ; ptype_manifest =
+          Some
+            (Ast_helper.Typ.constr ~loc:typ.ptype_loc
+               { Location.txt = Longident.parse "Stable.Latest.t"
+               ; loc = typ.ptype_loc
+               }
+               (List.map ~f:fst typ.ptype_params) )
+      }
+  end
+
+let version_type ~version_option version stri =
+  let loc = stri.pstr_loc in
+  let t, params =
+    let subst_type stri =
+      (* NOTE: Can't use [Ast_pattern] here; it rejects attributes attached to
+         types..
+      *)
+      match stri.pstr_desc with
+      | Pstr_type
+          ( rec_flag
+          , [ ( { ptype_name = { txt = "t"; _ }; ptype_private = Public; _ } as
+              typ )
+            ] ) ->
+          let params = typ.ptype_params in
+          let typ =
+            { typ with
+              ptype_attributes =
+                add_deriving ~loc:typ.ptype_loc ~version_option
+                  typ.ptype_attributes
+            }
+          in
+          let t = { stri with pstr_desc = Pstr_type (rec_flag, [ typ ]) } in
+          (t, params)
+      | _ ->
+          (* TODO: Handle rpc types. *)
+          Location.raise_errorf ~loc:stri.pstr_loc
+            "Expected a single public type t."
+    in
+    match stri.pstr_desc with
+    | Pstr_type _ ->
+        subst_type stri
+    | Pstr_module
+        { pmb_expr = { pmod_desc = Pmod_structure (stri :: _); _ }; _ } ->
+        subst_type stri
+    | _ ->
+        (* TODO: Handle rpc types. *)
+        Location.raise_errorf ~loc:stri.pstr_loc
+          "Expected a single public type t, or a module T."
+  in
+  let (module Ast_builder) = Ast_builder.make loc in
+  let with_version =
+    let open Ast_builder in
+    let typ =
+      type_declaration ~name:(Located.mk "typ") ~params ~cstrs:[]
+        ~private_:Public
+        ~manifest:
+          (Some (ptyp_constr (Located.lident "t") (List.map ~f:fst params)))
+        ~kind:Ptype_abstract
+    in
+    let t_deriving =
+      create_attr ~loc (Located.mk "deriving") (PStr [ [%stri bin_io] ])
+    in
+    let typ =
+      { typ with ptype_attributes = t_deriving :: typ.ptype_attributes }
+    in
+    let t =
+      type_declaration ~name:(Located.mk "t") ~params ~cstrs:[] ~private_:Public
+        ~manifest:None
+        ~kind:
+          (Ptype_record
+             [ label_declaration ~name:(Located.mk "version")
+                 ~mutable_:Immutable
+                 ~type_:(ptyp_constr (Located.lident "int") [])
+             ; label_declaration ~name:(Located.mk "t") ~mutable_:Immutable
+                 ~type_:
+                   (ptyp_constr (Located.lident "typ") (List.map ~f:fst params))
+             ] )
+    in
+    let t = { t with ptype_attributes = t_deriving :: t.ptype_attributes } in
+    let create = [%stri let create t = { t; version = [%e eint version] }] in
+    pstr_module
+      (module_binding
+         ~name:(some_loc (Located.mk "With_version"))
+         ~expr:
+           (pmod_structure
+              [ pstr_type Recursive [ typ ]; pstr_type Recursive [ t ]; create ] ) )
+  in
+  let arg_names = List.mapi params ~f:(fun i _ -> sprintf "x%i" i) in
+  let apply_args =
+    let args =
+      List.map arg_names ~f:(fun x ->
+          (Nolabel, Ast_builder.(pexp_ident (Located.lident x))) )
+    in
+    match args with
+    | [] ->
+        fun ?f:_ e -> e
+    | _ ->
+        fun ?f e ->
+          let args =
+            match f with
+            | None ->
+                args
+            | Some f ->
+                List.map args ~f:(fun (lbl, x) -> (lbl, f x))
+          in
+          Ast_builder.(pexp_apply e args)
+  in
+  let fun_args e =
+    List.fold_right arg_names ~init:e ~f:(fun name e ->
+        Ast_builder.(pexp_fun Nolabel None (ppat_var (Located.mk name)) e) )
+  in
+  let mk_field fld e =
+    Ast_builder.(
+      pexp_field e
+        (Located.mk (Ldot (Ldot (Lident "Bin_prot", "Type_class"), fld))))
+  in
+  let bin_io_shadows =
+    [ [%stri
+        let bin_read_t =
+          [%e
+            fun_args
+              [%expr
+                fun buf ~pos_ref ->
+                  let With_version.{ version = read_version; t } =
+                    [%e apply_args [%expr With_version.bin_read_t]] buf ~pos_ref
+                  in
+                  (* sanity check *)
+                  if not (Core_kernel.Int.equal read_version version) then
+                    failwith
+                      (Core_kernel.sprintf
+                         "bin_read_t: version read %d does not match expected \
+                          version %d"
+                         read_version version ) ;
+                  t]]]
+    ; [%stri
+        let __bin_read_t__ =
+          [%e
+            fun_args
+              [%expr
+                fun buf ~pos_ref i ->
+                  let With_version.{ version = read_version; t } =
+                    [%e apply_args [%expr With_version.__bin_read_t__]]
+                      buf ~pos_ref i
+                  in
+                  (* sanity check *)
+                  if not (Core_kernel.Int.equal read_version version) then
+                    failwith
+                      (Core_kernel.sprintf
+                         "__bin_read_t__: version read %d does not match \
+                          expected version %d"
+                         read_version version ) ;
+                  t]]]
+    ; [%stri
+        let bin_size_t =
+          [%e
+            fun_args
+              [%expr
+                fun t ->
+                  With_version.create t
+                  |> [%e apply_args [%expr With_version.bin_size_t]]]]]
+    ; [%stri
+        let bin_write_t =
+          [%e
+            fun_args
+              [%expr
+                fun buf ~pos t ->
+                  With_version.create t
+                  |> [%e apply_args [%expr With_version.bin_write_t]] buf ~pos]]]
+    ; [%stri let bin_shape_t = With_version.bin_shape_t]
+    ; [%stri
+        let bin_reader_t =
+          [%e
+            fun_args
+              [%expr
+                { Bin_prot.Type_class.read =
+                    [%e apply_args ~f:(mk_field "read") [%expr bin_read_t]]
+                ; vtag_read =
+                    [%e apply_args ~f:(mk_field "read") [%expr __bin_read_t__]]
+                }]]]
+    ; [%stri
+        let bin_writer_t =
+          [%e
+            fun_args
+              [%expr
+                { Bin_prot.Type_class.size =
+                    [%e apply_args ~f:(mk_field "size") [%expr bin_size_t]]
+                ; write =
+                    [%e apply_args ~f:(mk_field "write") [%expr bin_write_t]]
+                }]]]
+    ; [%stri
+        let bin_t =
+          [%e
+            fun_args
+              [%expr
+                { Bin_prot.Type_class.shape =
+                    [%e apply_args ~f:(mk_field "shape") [%expr bin_shape_t]]
+                ; writer =
+                    [%e apply_args ~f:(mk_field "writer") [%expr bin_writer_t]]
+                ; reader =
+                    [%e apply_args ~f:(mk_field "reader") [%expr bin_reader_t]]
+                }]]]
+    ; [%stri
+        (* ppx_js_style rejects a single underscore *)
+        let __ =
+          ( bin_read_t
+          , __bin_read_t__
+          , bin_size_t
+          , bin_write_t
+          , bin_shape_t
+          , bin_reader_t
+          , bin_writer_t
+          , bin_t )]
+    ]
+  in
+  match stri.pstr_desc with
+  | Pstr_type _ ->
+      (List.is_empty params, [ t ], with_version :: bin_io_shadows)
+  | Pstr_module
+      ( { pmb_expr = { pmod_desc = Pmod_structure (stri :: str); _ } as pmod; _ }
+      as pmb ) ->
+      ( List.is_empty params
+      , [ { stri with
+            pstr_desc =
+              Pstr_module
+                { pmb with
+                  pmb_expr = { pmod with pmod_desc = Pmod_structure (t :: str) }
+                }
+          }
+        ]
+      , with_version :: bin_io_shadows )
+  | _ ->
+      assert false
+
+let convert_module_stri ~version_option last_version stri =
+  let module_pattern =
+    Ast_pattern.(
+      pstr_module (module_binding ~name:(some __') ~expr:(pmod_structure __')))
+  in
+  let loc = stri.pstr_loc in
+  let name, str =
+    Ast_pattern.parse module_pattern loc stri
+      ~on_error:(fun () ->
+        Location.raise_errorf ~loc
+          "Expected a statement of the form `module Vn = struct ... end`." )
+      (fun name str -> (name, str))
+  in
+  validate_module_version name.txt name.loc ;
+  let version = version_of_versioned_module_name name.txt in
+  Option.iter last_version ~f:(fun last_version ->
+      if version = last_version then
+        (* Mimic wording of the equivalent OCaml error. *)
+        Location.raise_errorf ~loc "Multiple definition of the module name V%i."
+          version
+      else if version >= last_version then
+        Location.raise_errorf ~loc
+          "Versioned modules must be listed in decreasing order." ) ;
+  let stri, type_stri, str_rest =
+    match str.txt with
+    | [] ->
+        Location.raise_errorf ~loc:str.loc
+          "Expected a type declaration in this structure."
+    | ( { pstr_desc =
+            Pstr_module
+              { pmb_name = { txt = Some "T"; _ }
+              ; pmb_expr = { pmod_desc = Pmod_structure (type_stri :: _); _ }
+              ; _
+              }
+        ; _
+        } as stri )
+      :: ( { pstr_desc =
+               Pstr_include
+                 { pincl_mod =
+                     { pmod_desc = Pmod_ident { txt = Lident "T"; _ }; _ }
+                 ; _
+                 }
+           ; _
+           }
+           :: _ as str ) ->
+        (stri, type_stri, str)
+    | type_stri :: str ->
+        (type_stri, type_stri, str)
+  in
+  let should_convert, type_str, with_version_bin_io_shadows =
+    version_type ~version_option version stri
+  in
+  (* TODO: If [should_convert] then look for [to_latest]. *)
+  let open Ast_builder.Default in
+  ( version
+  , pstr_module ~loc
+      (module_binding ~loc ~name:(some_loc name)
+         ~expr:
+           (pmod_structure ~loc:str.loc
+              (type_str @ str_rest @ with_version_bin_io_shadows) ) )
+  , should_convert
+  , type_stri )
+
+let convert_modbody ~loc ~version_option body =
+  let may_convert_latest = ref None in
+  let latest_version = ref None in
+  let _, rev_str, convs, type_stri, _no_toplevel_type =
+    List.fold ~init:(None, [], [], None, !no_toplevel_latest_type) body
+      ~f:(fun (version, rev_str, convs, type_stri, no_toplevel_type) stri ->
+        match stri.pstr_desc with
+        | Pstr_attribute { attr_name; _ }
+          when String.equal attr_name.txt "no_toplevel_latest_type" ->
+            (version, rev_str, convs, None, true)
+        | _ ->
+            let version, stri, should_convert, current_type_stri =
+              convert_module_stri ~version_option version stri
+            in
+            let type_stri =
+              if no_toplevel_type then None
+              else Some (Option.value ~default:current_type_stri type_stri)
+            in
+            ( match !may_convert_latest with
+            | None ->
+                may_convert_latest := Some should_convert ;
+                latest_version := Some version
+            | Some _ ->
+                () ) ;
+            let convs = if should_convert then version :: convs else convs in
+            (Some version, stri :: rev_str, convs, type_stri, no_toplevel_type) )
+  in
+  let (module Ast_builder) = Ast_builder.make loc in
+  let rev_str =
+    match !latest_version with
+    | Some latest_version -> (
+        let open Ast_builder in
+        let latest =
+          pstr_module
+            (module_binding
+               ~name:(some_loc (Located.mk "Latest"))
+               ~expr:
+                 (pmod_ident (Located.lident (sprintf "V%i" latest_version))) )
+        in
+        (* insert Latest alias after latest versioned module
+           so subsequent modules can mention it
+        *)
+        match List.rev rev_str with
+        | vn :: vs ->
+            List.rev (vn :: latest :: vs)
+        | [] ->
+            (* should be unreachable *)
+            [ latest ] )
+    | None ->
+        rev_str
+  in
+  let rev_str =
+    match !may_convert_latest with
+    | Some true ->
+        let versions =
+          [%stri
+            (* NOTE: This will give a type error if any of the [to_latest]
+               values do not convert to [Latest.t].
+            *)
+            let (versions :
+                  ( int
+                  * (Core_kernel.Bigstring.t -> pos_ref:int ref -> Latest.t) )
+                  array ) =
+              [%e
+                let open Ast_builder in
+                pexp_array
+                  (List.map convs ~f:(fun version ->
+                       let version_module =
+                         Longident.Lident (sprintf "V%i" version)
+                       in
+                       let dot x =
+                         Located.mk (Longident.Ldot (version_module, x))
+                       in
+                       pexp_tuple
+                         [ eint version
+                         ; [%expr
+                             fun buf ~pos_ref ->
+                               [%e pexp_ident (dot "bin_read_t")] buf ~pos_ref
+                               |> [%e pexp_ident (dot "to_latest")]]
+                         ] ) )]]
+        in
+        let convert =
+          [%stri
+            (** deserializes data to the latest module version's type *)
+            let bin_read_to_latest_opt buf ~pos_ref =
+              let open Core_kernel in
+              (* Rely on layout, assume that the first element of the record is
+                 at pos_ref in the buffer
+                 The reader `f` will re-read the version, so we save the
+                 position and restore pos_ref
+              *)
+              let saved_pos = !pos_ref in
+              let version = Bin_prot.Std.bin_read_int ~pos_ref buf in
+              let pos_ref = ref saved_pos in
+              Array.find_map versions ~f:(fun (i, f) ->
+                  if Int.equal i version then Some (f buf ~pos_ref) else None )]
+        in
+        let convert_guard = [%stri let __ = bin_read_to_latest_opt] in
+        convert_guard :: convert :: versions :: rev_str
+    | _ ->
+        rev_str
+  in
+  (List.rev rev_str, type_stri)
+
+let version_module ~loc ~version_option ~path:_ modname modbody =
+  Printexc.record_backtrace true ;
+  try
+    let modname = map_loc ~f:(check_modname ~loc:modname.loc) modname in
+    let modbody_txt, type_stri =
+      convert_modbody ~version_option ~loc:modbody.loc modbody.txt
+    in
+    let modbody = { Location.txt = modbody_txt; loc = modbody.loc } in
+    let open Ast_helper in
+    let type_stri =
+      Option.map ~f:erase_stable_versions#structure_item type_stri
+      |> Option.to_list
+    in
+    Str.include_ ~loc
+      (Incl.mk ~loc
+         (Ast_helper.Mod.structure ~loc
+            ( Str.module_ ~loc
+                (Mb.mk ~loc:modname.loc (some_loc modname)
+                   (Mod.structure ~loc:modbody.loc modbody.txt) )
+            :: type_stri ) ) )
+  with exn ->
+    Format.(fprintf err_formatter "%s@." (Printexc.get_backtrace ())) ;
+    raise exn
+
+(* code for module declarations in signatures
+
+   - add deriving bin_io, version to list of deriving items for the type "t" in versioned modules
+   - add "module Latest = Vn" to Stable module
+   - if Stable.Latest.t has no parameters, add signature items for "versions" and "bin_read_to_latest_opt"
+*)
+
+(* parameterless_t means the type t in the module type has no parameters *)
+type sig_accum =
+  { sigitems : signature
+  ; parameterless_t : bool
+  ; type_decl : signature_item option
+  }
+
+let convert_module_type_signature_item { sigitems; parameterless_t; type_decl }
+    sigitem : sig_accum =
+  match sigitem.psig_desc with
+  | Psig_type
+      ( recflag
+      , [ ( { ptype_name = { txt = "t"; loc }
+            ; ptype_attributes
+            ; ptype_params
+            ; _
+            } as type_ )
+        ] ) ->
+      let ptype_attributes' =
+        add_deriving ~loc ~version_option:No_version_option ptype_attributes
+      in
+      let psig_desc =
+        Psig_type
+          (recflag, [ { type_ with ptype_attributes = ptype_attributes' } ])
+      in
+      let parameterless_t = List.is_empty ptype_params in
+      let type_decl = Some (erase_stable_versions#signature_item sigitem) in
+      { sigitems = { sigitem with psig_desc } :: sigitems
+      ; parameterless_t
+      ; type_decl
+      }
+  | _ ->
+      { sigitems = sigitem :: sigitems; parameterless_t; type_decl }
+
+let convert_module_type_signature signature : sig_accum =
+  List.fold signature
+    ~init:{ sigitems = []; parameterless_t = false; type_decl = None }
+    ~f:convert_module_type_signature_item
+
+type module_type_with_convertible =
+  { module_type : module_type
+  ; convertible : bool
+  ; extra_items : signature_item list
+  }
+
+(* add deriving items to type t in module type *)
+let convert_module_type mod_ty =
+  match mod_ty.pmty_desc with
+  | Pmty_signature signature ->
+      let { sigitems; parameterless_t; type_decl } =
+        convert_module_type_signature signature
+      in
+      { module_type =
+          { mod_ty with pmty_desc = Pmty_signature (List.rev sigitems) }
+      ; convertible = parameterless_t
+      ; extra_items = Option.to_list type_decl
+      }
+  | _ ->
+      Location.raise_errorf ~loc:mod_ty.pmty_loc
+        "Expected versioned module type to be a signature"
+
+(* latest is the name of the module to be equated with Latest
+   last is the last module seen in the fold
+   convertible is true if the latest module's type t has no parameters
+   sigitems are the signature for the module, in reverse order
+*)
+type module_accum =
+  { latest : string option
+  ; last : int option
+  ; convertible : bool
+  ; sigitems : signature
+  ; extra_sigitems : signature
+  ; no_toplevel_latest : bool
+  }
+
+(* convert modules Vn ... V1 contained in Stable *)
+let convert_module_decls ~loc:_ signature =
+  let init =
+    { latest = None
+    ; last = None
+    ; convertible = false
+    ; sigitems = []
+    ; extra_sigitems = []
+    ; no_toplevel_latest = !no_toplevel_latest_type
+    }
+  in
+  let f
+      { latest
+      ; last
+      ; convertible
+      ; sigitems
+      ; extra_sigitems
+      ; no_toplevel_latest
+      } sigitem =
+    match sigitem.psig_desc with
+    | Psig_module ({ pmd_name = { txt = Some name; loc }; pmd_type; _ } as pmd)
+      ->
+        validate_module_version name loc ;
+        let version = version_of_versioned_module_name name in
+        Option.iter last ~f:(fun n ->
+            if Int.equal version n then
+              Location.raise_errorf ~loc
+                "Duplicate versions in versioned modules" ;
+            if Int.( > ) version n then
+              Location.raise_errorf ~loc
+                "Versioned modules must be listed in decreasing order" ) ;
+        let in_latest = Option.is_none latest in
+        let latest = if in_latest then Some name else latest in
+        let { module_type; convertible = module_convertible; extra_items } =
+          convert_module_type pmd_type
+        in
+        let psig_desc' = Psig_module { pmd with pmd_type = module_type } in
+        let sigitem' = { sigitem with psig_desc = psig_desc' } in
+        (* use current convertible if in latest module, else the accumulated convertible *)
+        let convertible =
+          if in_latest then module_convertible else convertible
+        in
+        let extra_sigitems =
+          if in_latest && not no_toplevel_latest then extra_items
+          else extra_sigitems
+        in
+        { latest
+        ; last = Some version
+        ; convertible
+        ; sigitems = sigitem' :: sigitems
+        ; extra_sigitems
+        ; no_toplevel_latest
+        }
+    | Psig_attribute { attr_name; _ }
+      when String.equal attr_name.txt "no_toplevel_latest_type" ->
+        { latest
+        ; last = None
+        ; convertible
+        ; sigitems
+        ; extra_sigitems = []
+        ; no_toplevel_latest = true
+        }
+    | _ ->
+        Location.raise_errorf ~loc:sigitem.psig_loc
+          "Expected versioned module declaration"
+  in
+  List.fold signature ~init ~f
+
+let version_module_decl ~loc ~path:_ modname signature =
+  Printexc.record_backtrace true ;
+  try
+    let open Ast_helper in
+    let modname = map_loc ~f:(check_modname ~loc:modname.loc) modname in
+    let { txt = { latest; sigitems; convertible; extra_sigitems; _ }; _ } =
+      map_loc ~f:(convert_module_decls ~loc:signature.loc) signature
+    in
+    let mk_module_decl name ty_desc =
+      Sig.mk ~loc
+        (Psig_module (Md.mk ~loc (some_loc name) (Mty.mk ~loc ty_desc)))
+    in
+    let signature =
+      match latest with
+      | None ->
+          List.rev sigitems
+      | Some vn ->
+          let module E = Ppxlib.Ast_builder.Make (struct
+            let loc = loc
+          end) in
+          let open E in
+          let latest =
+            mk_module_decl { txt = "Latest"; loc }
+              (Pmty_alias { txt = Lident vn; loc })
+          in
+          let defs =
+            if convertible then
+              [%sig:
+                val versions :
+                  ( int
+                  * (Core_kernel.Bigstring.t -> pos_ref:int ref -> Latest.t) )
+                  array
+
+                val bin_read_to_latest_opt :
+                  Bin_prot.Common.buf -> pos_ref:int ref -> Latest.t option]
+            else []
+          in
+          (* insert Latest alias after latest version module decl
+             so subsequent module decls can mention it
+          *)
+          let sigitems_with_latest =
+            match List.rev sigitems with
+            | vn :: vs ->
+                vn :: latest :: vs
+            | [] ->
+                (* should be unreachable *)
+                [ latest ]
+          in
+          sigitems_with_latest @ defs
+    in
+    let sigi = mk_module_decl modname (Pmty_signature signature) in
+    match extra_sigitems with
+    | [] ->
+        sigi
+    | _ ->
+        let open Ast_helper in
+        Sig.mk ~loc
+          (Psig_include
+             (Incl.mk ~loc (Mty.signature ~loc (sigi :: extra_sigitems))) )
+  with exn ->
+    Format.(fprintf err_formatter "%s@." (Printexc.get_backtrace ())) ;
+    raise exn
+
+let () =
+  let module_ast_pattern =
+    Ast_pattern.(
+      pstr
+        ( pstr_module
+            (module_binding ~name:(some __') ~expr:(pmod_structure __'))
+        ^:: nil ))
+  in
+  let module_extension =
+    Extension.(
+      declare "versioned" Context.structure_item module_ast_pattern
+        (version_module ~version_option:No_version_option))
+  in
+  let module_extension_asserted =
+    Extension.(
+      declare "versioned_asserted" Context.structure_item module_ast_pattern
+        (version_module ~version_option:Asserted))
+  in
+  let module_extension_binable =
+    Extension.(
+      declare "versioned_binable" Context.structure_item module_ast_pattern
+        (version_module ~version_option:Binable))
+  in
+  let module_decl_ast_pattern =
+    Ast_pattern.(
+      psig
+        ( psig_module
+            (module_declaration ~name:(some __') ~type_:(pmty_signature __'))
+        ^:: nil ))
+  in
+  let module_decl_extension =
+    Extension.(
+      declare "versioned" Context.signature_item module_decl_ast_pattern
+        version_module_decl)
+  in
+  let module_rule = Context_free.Rule.extension module_extension in
+  let module_rule_asserted =
+    Context_free.Rule.extension module_extension_asserted
+  in
+  let module_rule_binable =
+    Context_free.Rule.extension module_extension_binable
+  in
+  let module_decl_rule = Context_free.Rule.extension module_decl_extension in
+  let rules =
+    [ module_rule; module_rule_asserted; module_rule_binable; module_decl_rule ]
+  in
+  Driver.register_transformation "ppx_version/versioned_module" ~rules ;
+  Ppxlib.Driver.add_arg "--no-toplevel-latest-type"
+    (Caml.Arg.Unit (fun () -> no_toplevel_latest_type := true))
+    ~doc:"Disable the toplevel type t declaration for versioned type modules" ;
+  Ppxlib.Driver.add_arg "--toplevel-latest-type"
+    (Caml.Arg.Bool (fun b -> no_toplevel_latest_type := not b))
+    ~doc:
+      "Enable or disable the toplevel type t declaration for versioned type \
+       modules"

--- a/src/lib/ppx_version/versioned_type.ml
+++ b/src/lib/ppx_version/versioned_type.ml
@@ -1,0 +1,600 @@
+(* versioned_types.ml -- static enforcement of versioned types via ppx *)
+
+(* If the dune profile defines "print_versioned_types" to be true, this deriver
+    prints a representation of each versioned type to stdout. The driver "print_versioned_types"
+    can be used to print the types from a particular OCaml source file. This facility is
+    meant to be used in CI to detect changes to versioned types.
+
+    Otherwise, we use this deriver as follows:
+
+    1) check that versioned type always in valid module hierarchy
+    2) versioned types depend only on other versioned types or OCaml built-in types
+
+   to use, add coda_ppx to the dune pps list, and annotate a type declaration with
+   either
+
+     [@@deriving version]
+
+   or
+
+     [@@deriving version { option }]
+
+   where option is one of "rpc", "asserted", or "binable".
+
+   Without options (the common case), the type must be named "t", and its definition
+   occurs in the module hierarchy "Stable.Vn" or "Stable.Vn.T", where n is a positive integer.
+
+   The "asserted" option asserts that the type is versioned, to allow compilation
+   to proceed. The types referred to in the type are not checked for versioning
+   with this option.
+
+   The "binable" option is a synonym for "asserted". It assumes that the type
+   will be serialized using a "Binable.Of_..." or "Make_binable" functors, which relies
+   on the serialization of some other type.
+
+   If "rpc" is true, again, the type must be named "query", "response", or "msg",
+   and the type definition occurs in the hierarchy "Vn.T".
+
+   All these options are available for types within structures.
+
+   Within signatures, the declaration
+
+     val __versioned__ : unit
+
+   is generated. If the "numbered" option is given, then
+
+     val version : int
+
+   is also generated. This option should be needed only by the internal versioning
+   machinery, and not in ordinary code. No other options are available within signatures.
+*)
+
+open Core_kernel
+open Ppxlib
+open Versioned_util
+
+let deriver = "version"
+
+let printing_ref = ref false
+
+let set_printing () = printing_ref := true
+
+let unset_printing () = printing_ref := false
+
+(* path is filename.ml.M1.M2.... *)
+let module_path_list path = List.drop (String.split path ~on:'.') 2
+
+(* print versioned types *)
+module Printing = struct
+  let contains_deriving_bin_io (attrs : attributes) =
+    let derivers =
+      Ast_pattern.(
+        attribute ~name:(string "deriving") ~payload:(single_expr_payload __))
+    in
+    match
+      List.find_map attrs ~f:(fun attr ->
+          parse_opt derivers Location.none attr (fun l -> Some l) )
+    with
+    | Some derivers ->
+        let derivers =
+          match derivers.pexp_desc with
+          | Pexp_tuple derivers ->
+              derivers
+          | _ ->
+              [ derivers ]
+        in
+        let bin_io_pattern =
+          Ast_pattern.(pexp_ident (lident (string "bin_io")))
+        in
+        List.exists derivers ~f:(fun deriver ->
+            Option.is_some
+            @@ parse_opt bin_io_pattern Location.none deriver (Some ()) )
+    | None ->
+        false
+
+  (* singleton attribute *)
+  let just_bin_io =
+    let module E = Ppxlib.Ast_builder.Make (struct
+      let loc = Location.none
+    end) in
+    let open E in
+    { attr_name = { txt = "deriving"; loc }
+    ; attr_payload = PStr [%str bin_io]
+    ; attr_loc = Location.none
+    }
+
+  (* remove internal attributes, on core type in manifest and in records or variants in kind *)
+  let type_decl_remove_internal_attributes type_decl =
+    let removed_in_kind =
+      match type_decl.ptype_kind with
+      | Ptype_variant ctors ->
+          Ptype_variant
+            (List.map ctors ~f:(fun ctor -> { ctor with pcd_attributes = [] }))
+      | Ptype_record labels ->
+          Ptype_record
+            (List.map labels ~f:(fun label ->
+                 { label with pld_attributes = [] } ) )
+      | kind ->
+          kind
+    in
+    let removed_in_manifest =
+      Option.map type_decl.ptype_manifest ~f:(fun core_type ->
+          { core_type with ptyp_attributes = [] } )
+    in
+    { type_decl with
+      ptype_manifest = removed_in_manifest
+    ; ptype_kind = removed_in_kind
+    }
+
+  (* filter attributes from types, except for bin_io, don't care about changes to others *)
+  let filter_type_decls_attrs type_decl =
+    (* retain only `deriving bin_io` in deriving list *)
+    let ptype_attributes =
+      if contains_deriving_bin_io type_decl.ptype_attributes then
+        [ just_bin_io ]
+      else []
+    in
+    let type_decl_no_attrs = type_decl_remove_internal_attributes type_decl in
+    { type_decl_no_attrs with ptype_attributes }
+
+  (* convert type_decls to structure item so we can print it *)
+  let type_decls_to_stri type_decls =
+    (* type derivers only work with recursive types *)
+    { pstr_desc = Pstr_type (Ast.Recursive, type_decls)
+    ; pstr_loc = Location.none
+    }
+
+  (* prints path_to_type:type_definition *)
+  let print_type ~loc:_ ~path (_rec_flag, type_decls) _rpc _asserted _binable =
+    let module_path = module_path_list path in
+    let path_len = List.length module_path in
+    List.iteri module_path ~f:(fun i s ->
+        printf "%s" s ;
+        if i < path_len - 1 then printf "." ) ;
+    printf ".%s" (List.hd_exn type_decls).ptype_name.txt ;
+    printf ":%!" ;
+    let type_decls_filtered_attrs =
+      List.map type_decls ~f:filter_type_decls_attrs
+    in
+    let stri = type_decls_to_stri type_decls_filtered_attrs in
+    Pprintast.structure_item Versioned_util.diff_formatter stri ;
+    Format.pp_print_flush Versioned_util.diff_formatter () ;
+    printf "\n%!" ;
+    []
+
+  (* we're worried about changes to the serialization of types, which can occur via changes to implementations,
+     so nothing to do for signatures
+  *)
+  let gen_empty_sig ~loc:_ ~path:_ (_rec_flag, _type_decls) = []
+end
+
+(* real derivers *)
+module Deriving = struct
+  type generation_kind = Plain | Rpc
+
+  let validate_rpc_type_decl inner3_modules type_decl =
+    match List.take inner3_modules 2 with
+    | [ "T"; module_version ] ->
+        validate_module_version module_version type_decl.ptype_loc
+    | _ ->
+        Location.raise_errorf ~loc:type_decl.ptype_loc
+          "Versioned RPC type must be contained in module path Vn.T, for some \
+           number n"
+
+  let validate_plain_type_decl inner3_modules type_decl =
+    match inner3_modules with
+    | [ "T"; module_version; "Stable" ] | module_version :: "Stable" :: _ ->
+        validate_module_version module_version type_decl.ptype_loc
+    | _ ->
+        Location.raise_errorf ~loc:type_decl.ptype_loc
+          "Versioned type must be contained in module path Stable.Vn or \
+           Stable.Vn.T, for some number n"
+
+  (* check that a versioned type occurs in valid module hierarchy and is named "t"
+     (for RPC types, the name can be "query", "response", or "msg")
+  *)
+  let validate_type_decl inner3_modules generation_kind type_decl =
+    let name = type_decl.ptype_name.txt in
+    let loc = type_decl.ptype_name.loc in
+    match generation_kind with
+    | Rpc ->
+        let rpc_valid_names = [ "query"; "response"; "msg" ] in
+        if
+          List.find rpc_valid_names ~f:(fun ty -> String.equal ty name)
+          |> Option.is_none
+        then
+          Location.raise_errorf ~loc
+            "RPC versioned type must be named one of \"%s\", got: \"%s\""
+            (String.concat ~sep:"," rpc_valid_names)
+            name ;
+        validate_rpc_type_decl inner3_modules type_decl
+    | Plain ->
+        let valid_name = "t" in
+        if not (String.equal name valid_name) then
+          Location.raise_errorf ~loc
+            "Versioned type must be named \"%s\", got: \"%s\"" valid_name name ;
+        validate_plain_type_decl inner3_modules type_decl
+
+  (* module structure in this case validated by linter *)
+
+  let module_name_from_plain_path inner3_modules =
+    match inner3_modules with
+    | [ "T"; module_version; "Stable" ] | module_version :: "Stable" :: _ ->
+        module_version
+    | _ ->
+        failwith "module_name_from_plain_path: unexpected module path"
+
+  let module_name_from_rpc_path inner3_modules =
+    match List.take inner3_modules 2 with
+    | [ "T"; module_version ] ->
+        module_version
+    | _ ->
+        failwith "module_name_from_rpc_path: unexpected module path"
+
+  (* generate "let version = n", when version module is Vn *)
+  let generate_version_number_decl inner3_modules loc generation_kind =
+    (* invariant: we've checked module name already *)
+    let module E = Ppxlib.Ast_builder.Make (struct
+      let loc = loc
+    end) in
+    let open E in
+    let module_name =
+      match generation_kind with
+      | Plain ->
+          module_name_from_plain_path inner3_modules
+      | Rpc ->
+          module_name_from_rpc_path inner3_modules
+    in
+    let version = version_of_versioned_module_name module_name in
+    [%str
+      let version = [%e eint version]
+
+      (* to prevent unused value warnings *)
+      let __ = version]
+
+  let ocaml_builtin_types =
+    [ "bytes"
+    ; "int"
+    ; "int32"
+    ; "int64"
+    ; "float"
+    ; "char"
+    ; "string"
+    ; "bool"
+    ; "unit"
+    ]
+
+  let ocaml_builtin_type_constructors = [ "list"; "array"; "option"; "ref" ]
+
+  let jane_street_type_constructors = [ "sexp_opaque" ]
+
+  let is_version_module vn =
+    let len = String.length vn in
+    len > 1
+    && Char.equal vn.[0] 'V'
+    &&
+    let numeric_part = String.sub vn ~pos:1 ~len:(len - 1) in
+    String.for_all numeric_part ~f:Char.is_digit
+    && not (Int.equal (Char.get_digit_exn numeric_part.[0]) 0)
+
+  (* true iff module_path is of form M. ... .Stable.Vn, where M is Core or Core_kernel, and n is integer *)
+  let is_jane_street_stable_module module_path =
+    let hd_elt = List.hd_exn module_path in
+    List.mem jane_street_modules hd_elt ~equal:String.equal
+    &&
+    match List.rev module_path with
+    | vn :: "Stable" :: _ ->
+        is_version_module vn
+    | vn :: label :: "Stable" :: "Time" :: _
+      when List.mem [ "Span"; "With_utc_sexp" ] label ~equal:String.equal ->
+        (* special cases, maybe improper module structure *)
+        is_version_module vn
+    | _ ->
+        false
+
+  let trustlisted_prefix prefix ~loc =
+    match prefix with
+    | Lident id ->
+        String.equal id "Bitstring"
+    | Ldot _ ->
+        let module_path = Longident.flatten_exn prefix in
+        is_jane_street_stable_module module_path
+    | Lapply _ ->
+        Location.raise_errorf ~loc "Type name contains unexpected application"
+
+  (* disallow Stable.Latest types in versioned types *)
+
+  let is_stable_latest =
+    let is_longident_with_id id = function
+      | Lident s when String.equal id s ->
+          true
+      | Ldot (_lident, s) when String.equal id s ->
+          true
+      | _ ->
+          false
+    in
+    let is_stable = is_longident_with_id "Stable" in
+    let is_latest = is_longident_with_id "Latest" in
+    fun prefix ->
+      is_latest prefix
+      &&
+      match prefix with
+      | Ldot (lident, _) when is_stable lident ->
+          true
+      | _ ->
+          false
+
+  let rec generate_core_type_version_decls type_name core_type =
+    match core_type.ptyp_desc with
+    | Ptyp_constr ({ txt; _ }, core_types) -> (
+        match txt with
+        | Lident id ->
+            (* type t = id *)
+            if String.equal id type_name (* recursion *) then []
+            else if
+              List.is_empty core_types
+              && List.mem ocaml_builtin_types id ~equal:String.equal
+            then (* no versioning to worry about *)
+              []
+            else if
+              List.mem ocaml_builtin_type_constructors id ~equal:String.equal
+              || List.mem jane_street_type_constructors id ~equal:String.equal
+            then
+              match core_types with
+              | [ _ ] ->
+                  generate_version_lets_for_core_types type_name core_types
+              | _ ->
+                  Location.raise_errorf ~loc:core_type.ptyp_loc
+                    "Type constructor \"%s\" expects one type argument, got %d"
+                    id (List.length core_types)
+            else
+              Location.raise_errorf ~loc:core_type.ptyp_loc
+                "\"%s\" is neither an OCaml type constructor nor a versioned \
+                 type"
+                id
+        | Ldot (prefix, "t") ->
+            (* type t = A.B.t
+               if prefix not trustlisted, generate: let _ = A.B.__versioned__
+               disallow Stable.Latest.t
+            *)
+            if is_stable_latest prefix then
+              Location.raise_errorf ~loc:core_type.ptyp_loc
+                "Cannot use type of the form Stable.Latest.t within a \
+                 versioned type" ;
+            let core_type_decls =
+              generate_version_lets_for_core_types type_name core_types
+            in
+            if trustlisted_prefix prefix ~loc:core_type.ptyp_loc then
+              core_type_decls
+            else
+              let loc = core_type.ptyp_loc in
+              let pexp_loc = loc in
+              let new_prefix =
+                (* allow types within stable-versioned modules generated
+                   by Hashable.Make_binable, like M.Stable.Vn.Table.t;
+                   generate "let _ = M.Stable.Vn.__versioned__"
+                *)
+                match prefix with
+                | Ldot ((Ldot (_, vn) as longident), label)
+                  when is_version_module vn
+                       && List.mem
+                            [ "Table"; "Hash_set"; "Hash_queue" ]
+                            label ~equal:String.equal ->
+                    longident
+                | _ ->
+                    prefix
+              in
+              let versioned_ident =
+                { pexp_desc =
+                    Pexp_ident { txt = Ldot (new_prefix, "__versioned__"); loc }
+                ; pexp_loc
+                ; pexp_loc_stack = []
+                ; pexp_attributes = []
+                }
+              in
+              [%str let __ = [%e versioned_ident]] @ core_type_decls
+        | _ ->
+            Location.raise_errorf ~loc:core_type.ptyp_loc
+              "Unrecognized type constructor for versioned type" )
+    | Ptyp_tuple core_types ->
+        (* type t = t1 * t2 * t3 *)
+        generate_version_lets_for_core_types type_name core_types
+    | Ptyp_variant _ ->
+        (* type t = [ `A | `B ] *)
+        []
+    | Ptyp_var _ ->
+        (* type variable *)
+        []
+    | Ptyp_any ->
+        (* underscore *)
+        []
+    | _ ->
+        Location.raise_errorf ~loc:core_type.ptyp_loc
+          "Can't determine versioning for contained type"
+
+  and generate_version_lets_for_core_types type_name core_types =
+    List.fold_right core_types ~init:[] ~f:(fun core_type accum ->
+        generate_core_type_version_decls type_name core_type @ accum )
+
+  let generate_version_lets_for_label_decls type_name label_decls =
+    generate_version_lets_for_core_types type_name
+      (List.map label_decls ~f:(fun lab_decl -> lab_decl.pld_type))
+
+  let generate_constructor_decl_decls type_name ctor_decl =
+    let result_lets =
+      match ctor_decl.pcd_res with
+      | None ->
+          []
+      | Some res ->
+          (* for GADTs, check versioned-ness of parameters to result type *)
+          let ty_params =
+            match res.ptyp_desc with
+            | Ptyp_constr (_, params) ->
+                params
+            | _ ->
+                failwith
+                  "generate_constructor_decl_decls: expected type parameter \
+                   list"
+          in
+          generate_version_lets_for_core_types type_name ty_params
+    in
+    match ctor_decl.pcd_args with
+    | Pcstr_tuple core_types ->
+        (* C of T1 * ... * Tn, or GADT C : T1 -> T2 *)
+        let arg_lets =
+          generate_version_lets_for_core_types type_name core_types
+        in
+        arg_lets @ result_lets
+    | Pcstr_record label_decls ->
+        (* C of { ... }, or GADT C : { ... } -> T *)
+        let arg_lets =
+          generate_version_lets_for_label_decls type_name label_decls
+        in
+        arg_lets @ result_lets
+
+  let generate_constraint_type_decls type_name cstrs =
+    let gen_for_constraint (ty1, ty2, _loc) =
+      List.concat_map [ ty1; ty2 ]
+        ~f:(generate_core_type_version_decls type_name)
+    in
+    List.concat_map cstrs ~f:gen_for_constraint
+
+  let generate_contained_type_version_decls type_decl =
+    let type_name = type_decl.ptype_name.txt in
+    let constraint_type_version_decls =
+      generate_constraint_type_decls type_decl.ptype_name.txt
+        type_decl.ptype_cstrs
+    in
+    let main_type_version_decls =
+      match type_decl.ptype_kind with
+      | Ptype_abstract -> (
+          match type_decl.ptype_manifest with
+          | Some manifest ->
+              generate_core_type_version_decls type_name manifest
+          | None ->
+              Location.raise_errorf ~loc:type_decl.ptype_loc
+                "Versioned type, not a label or variant, must have manifest \
+                 (right-hand side)" )
+      | Ptype_variant ctor_decls ->
+          List.fold ctor_decls ~init:[] ~f:(fun accum ctor_decl ->
+              generate_constructor_decl_decls type_name ctor_decl @ accum )
+      | Ptype_record label_decls ->
+          generate_version_lets_for_label_decls type_name label_decls
+      | Ptype_open ->
+          Location.raise_errorf ~loc:type_decl.ptype_loc
+            "Versioned type may not be open"
+    in
+    constraint_type_version_decls @ main_type_version_decls
+
+  let generate_versioned_decls ~asserted generation_kind type_decl =
+    let module E = Ppxlib.Ast_builder.Make (struct
+      let loc = type_decl.ptype_loc
+    end) in
+    let open E in
+    let versioned_current = [%stri let __versioned__ = ()] in
+    if asserted then [ versioned_current ]
+    else
+      match generation_kind with
+      | Rpc ->
+          (* check whether contained types are versioned,
+             but don't assert versioned-ness of this type *)
+          generate_contained_type_version_decls type_decl
+      | Plain ->
+          (* check contained types, assert this type is versioned *)
+          versioned_current :: generate_contained_type_version_decls type_decl
+
+  let get_type_decl_representative type_decls =
+    let type_decl1 = List.hd_exn type_decls in
+    let type_decl2 = List.hd_exn (List.rev type_decls) in
+    ( if not (Int.equal (List.length type_decls) 1) then
+      let loc =
+        { loc_start = type_decl1.ptype_loc.loc_start
+        ; loc_end = type_decl2.ptype_loc.loc_end
+        ; loc_ghost = true
+        }
+      in
+      Location.raise_errorf ~loc
+        "Versioned type must be just one type \"t\", not a sequence of types" ) ;
+    type_decl1
+
+  let generate_let_bindings_for_type_decl_str ~loc ~path (_rec_flag, type_decls)
+      rpc asserted binable =
+    (* binable is synonym for asserted,
+       in the sense that we don't require the type to be versioned
+    *)
+    let asserted = asserted || binable in
+    let type_decl = get_type_decl_representative type_decls in
+    if asserted && rpc then
+      Location.raise_errorf ~loc:type_decl.ptype_loc
+        "Options \"asserted\" and \"rpc\" cannot be combined" ;
+    let generation_kind = if rpc then Rpc else Plain in
+    let module_path = module_path_list path in
+    let inner3_modules = List.take (List.rev module_path) 3 in
+    (* TODO: when Module_version.Registration goes away, remove
+       the empty list special case
+    *)
+    if List.is_empty inner3_modules then
+      (* module path doesn't seem to be tracked inside test module *)
+      []
+    else (
+      validate_type_decl inner3_modules generation_kind type_decl ;
+      let versioned_decls =
+        generate_versioned_decls ~asserted generation_kind type_decl
+      in
+      let type_name = type_decl.ptype_name.txt in
+      (* generate version number for Rpc response, but not for query, so we
+         don't get an unused value
+      *)
+      match generation_kind with
+      | Rpc when String.equal type_name "query" ->
+          versioned_decls
+      | _ ->
+          generate_version_number_decl inner3_modules loc generation_kind
+          @ versioned_decls )
+
+  let generate_val_decls_for_type_decl ~loc type_decl =
+    match type_decl.ptype_kind with
+    (* the structure of the type doesn't affect what we generate for signatures *)
+    | Ptype_abstract | Ptype_variant _ | Ptype_record _ ->
+        [ [%sigi: val __versioned__ : unit] ]
+    | Ptype_open ->
+        (* but the type can't be open, else it might vary over time *)
+        Location.raise_errorf ~loc
+          "Versioned type in a signature must not be open"
+
+  let generate_val_decls_for_type_decl_sig ~loc ~path:_ (_rec_flag, type_decls)
+      =
+    (* in a signature, the module path may vary *)
+    let type_decl = get_type_decl_representative type_decls in
+    generate_val_decls_for_type_decl ~loc type_decl
+end
+
+(* at preprocessing time, choose between printing, deriving derivers *)
+let choose_deriver ~printing ~deriving =
+  if !printing_ref then printing else deriving
+
+let str_type_decl :
+    (structure, rec_flag * type_declaration list) Ppxlib.Deriving.Generator.t =
+  let args =
+    let open Ppxlib.Deriving.Args in
+    empty +> flag "rpc" +> flag "asserted" +> flag "binable"
+  in
+  let deriver ~loc ~path (rec_flag, type_decls) rpc asserted binable =
+    (choose_deriver ~printing:Printing.print_type
+       ~deriving:Deriving.generate_let_bindings_for_type_decl_str )
+      ~loc ~path (rec_flag, type_decls) rpc asserted binable
+  in
+  Ppxlib.Deriving.Generator.make args deriver
+
+let sig_type_decl :
+    (signature, rec_flag * type_declaration list) Ppxlib.Deriving.Generator.t =
+  let deriver ~loc ~path (rec_flag, type_decls) =
+    (choose_deriver ~printing:Printing.gen_empty_sig
+       ~deriving:Deriving.generate_val_decls_for_type_decl_sig )
+      ~loc ~path (rec_flag, type_decls)
+  in
+  Ppxlib.Deriving.Generator.make_noarg deriver
+
+let () =
+  Ppxlib.Deriving.add deriver ~str_type_decl ~sig_type_decl
+  |> Ppxlib.Deriving.ignore

--- a/src/lib/ppx_version/versioned_util.ml
+++ b/src/lib/ppx_version/versioned_util.ml
@@ -1,0 +1,68 @@
+(* version_util.ml -- utility functions for versioning *)
+
+open Core_kernel
+open Ppxlib
+
+let parse_opt = Ast_pattern.parse ~on_error:(fun () -> None)
+
+let mk_loc ~loc txt = { Location.loc; txt }
+
+let map_loc ~f { Location.loc; txt } = { Location.loc; txt = f txt }
+
+let some_loc (x : 'a loc) = map_loc ~f:Option.some x
+
+let check_modname ~loc name : string =
+  if String.equal name "Stable" then name
+  else
+    Location.raise_errorf ~loc
+      "Expected a module named Stable, but got a module named %s." name
+
+(* for diffing types and binable functors, replace newlines in standard formatter
+   with a space, so string is all on one line *)
+let diff_formatter =
+  let out_funs = Format.(pp_get_formatter_out_functions std_formatter ()) in
+  let out_funs' =
+    { out_funs with
+      out_newline = (fun () -> out_funs.out_spaces 1)
+    ; out_indent = (fun _ -> ())
+    }
+  in
+  Format.formatter_of_out_functions out_funs'
+
+let validate_module_version module_version loc =
+  let len = String.length module_version in
+  if not (Char.equal module_version.[0] 'V' && len > 1) then
+    Location.raise_errorf ~loc
+      "Versioning module containing versioned type must be named Vn, for some \
+       number n"
+  else
+    let numeric_part = String.sub module_version ~pos:1 ~len:(len - 1) in
+    String.iter numeric_part ~f:(fun c ->
+        if not (Char.is_digit c) then
+          Location.raise_errorf ~loc
+            "Versioning module name must be Vn, for some positive number n, \
+             got: \"%s\""
+            module_version ) ;
+    (* invariant: 0th char is digit *)
+    if Int.equal (Char.get_digit_exn numeric_part.[0]) 0 then
+      Location.raise_errorf ~loc
+        "Versioning module name must be Vn, for a positive number n, which \
+         cannot begin with 0, got: \"%s\""
+        module_version
+
+let version_of_versioned_module_name name =
+  String.sub name ~pos:1 ~len:(String.length name - 1) |> int_of_string
+
+(* modules in core and core_kernel library which are not in Core, Core_kernel modules
+
+   see
+
+         https://ocaml.janestreet.com/ocaml-core/latest/doc/core/index.html
+         https://ocaml.janestreet.com/ocaml-core/latest/doc/core_kernel/index.html
+
+       add to this list as needed; but more items slows things down
+*)
+let jane_street_library_modules = [ "Uuid" ]
+
+let jane_street_modules =
+  [ "Core"; "Core_kernel" ] @ jane_street_library_modules

--- a/src/lib/signature_lib/dune
+++ b/src/lib/signature_lib/dune
@@ -10,7 +10,6 @@
    base
    sexplib0
    yojson
-   ppx_version.runtime
    core_kernel
    bin_prot.shape
    base.caml
@@ -36,6 +35,7 @@
    pickles.backend
    kimchi_backend
    h_list
+   test_util
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -28,32 +28,23 @@ module Stable = struct
 
     [%%endif]
   end
-
-  module Tests = struct
-    (* these tests check not only whether the serialization of the version-asserted type has changed,
-       but also whether the serializations for the consensus and nonconsensus code are identical
-    *)
-
-    [%%if curve_size = 255]
-
-    let%test "private key serialization v1" =
-      let pk =
-        Quickcheck.random_value ~seed:(`Deterministic "private key seed v1")
-          V1.gen
-      in
-      let known_good_digest = "86b85ec8a4a965c25cab59c5cb1f44ed" in
-      Ppx_version_runtime.Serialization.check_serialization
-        (module V1)
-        pk known_good_digest
-
-    [%%else]
-
-    let%test "private key serialization v1" =
-      failwith "No test for this curve size"
-
-    [%%endif]
-  end
 end]
+
+[%%if curve_size = 255]
+
+let%test "private key serialization v1" =
+  let pk =
+    Quickcheck.random_value ~seed:(`Deterministic "private key seed v1")
+      Stable.V1.gen
+  in
+  let known_good_digest = "86b85ec8a4a965c25cab59c5cb1f44ed" in
+  Test_util.check_serialization (module Stable.V1) pk known_good_digest
+
+[%%else]
+
+let%test "private key serialization v1" = failwith "No test for this curve size"
+
+[%%endif]
 
 [%%define_locally Stable.Latest.(gen)]
 

--- a/src/lib/test_util/dune
+++ b/src/lib/test_util/dune
@@ -7,6 +7,7 @@
    ;; opam libraries
    core_kernel
    base.caml
+   bin_prot
    ;; local libraries
    snark_params
    fold_lib

--- a/src/lib/test_util/test_util.ml
+++ b/src/lib/test_util/test_util.ml
@@ -54,6 +54,28 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) = struct
       let x = f () in
       Caml.Random.set_state s ; x
     with e -> Caml.Random.set_state s ; raise e
+
+  (** utility function to print digests to put in tests, see `check_serialization' below *)
+  let print_digest digest = printf "\"" ; printf "%s" digest ; printf "\"\n%!"
+
+  (** use this function to test Bin_prot serialization of types *)
+  let check_serialization (type t) (module M : Binable.S with type t = t)
+      (t : t) known_good_digest =
+    (* serialize value *)
+    let sz = M.bin_size_t t in
+    let buf = Bin_prot.Common.create_buf sz in
+    ignore (M.bin_write_t buf ~pos:0 t : int) ;
+    let bytes = Bytes.create sz in
+    Bin_prot.Common.blit_buf_bytes buf bytes ~len:sz ;
+    (* compute MD5 digest of serialization *)
+    let digest = Md5.digest_bytes bytes |> Md5.to_hex in
+    let result = String.equal digest known_good_digest in
+    if not result then (
+      printf "Expected digest: " ;
+      print_digest known_good_digest ;
+      printf "Got digest:      " ;
+      print_digest digest ) ;
+    result
 end
 
 include Make (Snark_params.Tick)

--- a/src/lib/transaction_logic/dune
+++ b/src/lib/transaction_logic/dune
@@ -9,7 +9,6 @@
    ppx_inline_test.config
    sexplib0
    yojson
-   ppx_version.runtime
    sexp_diff_kernel
    core_kernel
    base.caml

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -13,7 +13,6 @@
    sexplib0
    bignum
    core
-   ppx_version.runtime
    core_kernel
    base.md5
    base.caml

--- a/src/lib/trust_system/banned_status.ml
+++ b/src/lib/trust_system/banned_status.ml
@@ -3,7 +3,7 @@ open Core_kernel
 [%%versioned_asserted
 module Stable = struct
   module V1 = struct
-    (* there's no Time.Stable.Vn, assert version and test for changes in serialization *)
+    (* there's no Time.Stable.Vn, assert version *)
     type t = Unbanned | Banned_until of Time.t
 
     let to_latest = Fn.id
@@ -24,16 +24,6 @@ module Stable = struct
           Ok (Banned_until (Time.of_string s))
       | _ ->
           Error "Banned_status.of_yojson: unexpected JSON"
-  end
-
-  module Tests = struct
-    let%test "banned status serialization v1" =
-      let tm = Time.of_string "2019-10-08 17:51:23.050849Z" in
-      let status = V1.Banned_until tm in
-      let known_good_digest = "99a12fdb97c62ceba0c4d4f5879b0cdc" in
-      Ppx_version_runtime.Serialization.check_serialization
-        (module V1)
-        status known_good_digest
   end
 end]
 

--- a/src/lib/trust_system/dune
+++ b/src/lib/trust_system/dune
@@ -8,7 +8,6 @@
    core
    ppx_inline_test.config
    base.caml
-   ppx_version.runtime
    async_kernel
    core_kernel
    bin_prot.shape

--- a/src/lib/unsigned_extended/dune
+++ b/src/lib/unsigned_extended/dune
@@ -8,7 +8,6 @@
    base.caml
    result
    base
-   ppx_version.runtime
    core_kernel
    integers
    sexplib0

--- a/src/lib/unsigned_extended/unsigned_extended.ml
+++ b/src/lib/unsigned_extended/unsigned_extended.ml
@@ -157,19 +157,3 @@ module UInt32 = struct
 
   let of_uint32 : uint32 -> t = Fn.id
 end
-
-(* check that serializations don't change *)
-let%test_module "Unsigned serializations" =
-  ( module struct
-    open Ppx_version_runtime.Serialization
-
-    let%test "UInt32 V1 serialization" =
-      let uint32 = UInt32.of_int 9775 in
-      let known_good_digest = "b66e8ba9d68f2d08bafaa3abd3abccba" in
-      check_serialization (module UInt32.Stable.V1) uint32 known_good_digest
-
-    let%test "UInt64 V1 serialization" =
-      let uint64 = UInt64.of_int64 191797697848L in
-      let known_good_digest = "9a34874c0a6a0c797b19d1f756f39103" in
-      check_serialization (module UInt64.Stable.V1) uint64 known_good_digest
-  end )

--- a/src/ppx_version.opam
+++ b/src/ppx_version.opam
@@ -1,0 +1,21 @@
+opam-version: "2.0"
+name: "ppx_version"
+authors: "opensource@o1labs.org"
+homepage: "https://github.com/o1-labs/ppx_version"
+bug-reports: "opensource@o1labs.org"
+version: "0.1"
+descr: """
+Ocaml extension point (ppx) meant to assure the stability of types and their Bin_prot serializations
+
+See the readme at https://github.com/o1-labs/ppx_version/README.md for more information.
+"""
+dev-repo: "git+https://github.com/o1-labs/ppx_version.git"
+maintainer: "opensource@o1labs.org"
+depends: [
+  "ocaml" {= "4.11.2"}
+  "ppxlib" {>= "0.25.0"}
+  "ppx_bin_prot"
+  "core_kernel" {< "v0.15"}
+  "dune" {>= "2.5"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Remove `ppx_version` as a submodule, add it as a library in the Mina repo. 

We had created a separate repo because we thought it might be generally useful for other OCaml users, and so we could version the Snarky types. But we haven't heard interest expressed about the library from others and there's no plan to version the Snarky types. When changes were needed to the library, we had to merge them there, then bump the commit in Mina. Also, there were hacks to allow compilation with Mina (the "dummy_derivers").

Changes:
- remove the `runtime` library from `ppx_version`, move `check_serialization` to `Test_util`
- remove the "dummy_derivers"
- the module linter no longer requires a `Test` module in `version_asserted` modules (see RFC0045 for reasoning)
- move the tests that were in `Test` modules outside `Stable` (no sense discarding cheap tests)
- remove the Bazel-related files, including the `expect` directory

Ran the tests in the `test` directory, made fixes as needed. We might want to resurrect the Bazel-invoked tests that use `expect` at some point.

Creating this PR before other `ppx_version` changes, so we don't have to merge changes to a separate repo, then bump it in Mina.

Closes #11178.

We should *not* delete the `o1/ppx_version` repo just yet, we may wish to salvage some code not in this PR (layouts, maybe, the Bazel tests, maybe). 
