### PR TITLE
[WIP] burn tokens from disallowed fee transfer or coinbase transfer

### DIFF
--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -146,7 +146,7 @@ module Transaction_applied : sig
 
   module Fee_transfer_applied : sig
     type t = Transaction_applied.Fee_transfer_applied.t =
-      { fee_transfer : Fee_transfer.t
+      { fee_transfer : Fee_transfer.t With_status.t
       ; previous_empty_accounts : Account_id.t list
       }
     [@@deriving sexp]
@@ -154,7 +154,9 @@ module Transaction_applied : sig
 
   module Coinbase_applied : sig
     type t = Transaction_applied.Coinbase_applied.t =
-      { coinbase : Coinbase.t; previous_empty_accounts : Account_id.t list }
+      { coinbase : Coinbase.t With_status.t
+      ; previous_empty_accounts : Account_id.t list
+      }
     [@@deriving sexp]
   end
 
@@ -172,7 +174,7 @@ module Transaction_applied : sig
 
   val transaction : t -> Transaction.t With_status.t
 
-  val user_command_status : t -> Transaction_status.t
+  val transaction_status : t -> Transaction_status.t
 end
 
 (** Raises if the ledger is full, or if an account already exists for the given

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -338,7 +338,7 @@ module T = struct
               snarked_ledger tx.data
           in
           let computed_status =
-            Ledger.Transaction_applied.user_command_status txn_with_info
+            Ledger.Transaction_applied.transaction_status txn_with_info
           in
           if Transaction_status.equal tx.status computed_status then Ok ()
           else
@@ -579,7 +579,7 @@ module T = struct
       | Some status ->
           (* Validate that command status matches. *)
           let got_status =
-            Ledger.Transaction_applied.user_command_status applied_txn
+            Ledger.Transaction_applied.transaction_status applied_txn
           in
           if Transaction_status.equal status got_status then return ()
           else

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1750,10 +1750,6 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
             (emptys1, no_failures) )
           else Ok ([], single_failure)
         else
-          (* TODO(#4496): Do not use get_or_create here; we should not create a
-             new account before we know that the transaction will go through
-             and thus the creation fee has been paid.
-          *)
           let a2, action2, `Has_permission_to_receive can_receive2 =
             has_permission_to_receive ~ledger:t account_id2
           in
@@ -1841,10 +1837,6 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
           in
           if can_receive then
             let%map _action, transferee_account, transferee_location =
-              (* TODO(#4496): Do not use get_or_create here; we should not create
-                 a new account before we know that the transaction will go
-                 through and thus the creation fee has been paid.
-              *)
               get_or_create t transferee_id
             in
             ( receiver_reward
@@ -1881,10 +1873,6 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
     let%map failures =
       if can_receive then (
         let%map _action2, receiver_account, receiver_location =
-          (* TODO(#4496): Do not use get_or_create here; we should not create a new
-             account before we know that the transaction will go through and thus
-             the creation fee has been paid.
-          *)
           get_or_create t receiver_id
         in
         set t receiver_location

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -495,7 +495,7 @@ let test_transaction_union ?expected_failure ?txn_global_slot ledger txn =
     with
     | Ok res ->
         ( if Option.is_some expected_failure then
-          match Ledger.Transaction_applied.user_command_status res with
+          match Ledger.Transaction_applied.transaction_status res with
           | Applied ->
               failwith
                 (sprintf "Expected Ledger.apply_transaction to fail with %s"

--- a/src/lib/transaction_snark/transaction_validator.ml
+++ b/src/lib/transaction_snark/transaction_validator.ml
@@ -131,5 +131,5 @@ let apply_transaction' ~constraint_constants ~txn_state_view l t =
       apply_transaction ~constraint_constants ~txn_state_view l t )
 
 let apply_transaction ~constraint_constants ~txn_state_view l txn =
-  Result.map ~f:Transaction_applied.user_command_status
+  Result.map ~f:Transaction_applied.transaction_status
     (apply_transaction' l ~constraint_constants ~txn_state_view txn)


### PR DESCRIPTION
if snark provers and coinbase receivers are zkapp accounts and require proof/signature authorization to receive funds(by default no authorization is required to receive tokens), any fee or rewards sent to them will be burned. 

TODO: 
- [ ] Update supply increase to account for the burnt tokens
- [ ] Remove debug statements


Explain how you tested your changes:
* existing unit tests should pass


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
