### PR TITLE
Improve rust error message for `Field.of_bigint`

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fp.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fp.rs
@@ -279,9 +279,13 @@ pub fn caml_pasta_fp_to_bigint(x: ocaml::Pointer<CamlFp>) -> CamlBigInteger256 {
 #[ocaml_gen::func]
 #[ocaml::func]
 pub fn caml_pasta_fp_of_bigint(x: CamlBigInteger256) -> Result<CamlFp, ocaml::Error> {
-    Fp::from_repr(x.0).map(CamlFp).ok_or(ocaml::Error::Message(
-        "caml_pasta_fp_of_bigint was given an invalid CamlBigInteger256",
-    ))
+    Fp::from_repr(x.0).map(CamlFp).ok_or_else(|| {
+        let err = format!(
+            "caml_pasta_fp_of_bigint was given an invalid CamlBigInteger256: {}",
+            x.0
+        );
+        ocaml::Error::Error(err.into())
+    })
 }
 
 #[ocaml_gen::func]

--- a/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fq.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/arkworks/pasta_fq.rs
@@ -281,8 +281,11 @@ pub fn caml_pasta_fq_to_bigint(x: ocaml::Pointer<CamlFq>) -> CamlBigInteger256 {
 #[ocaml::func]
 pub fn caml_pasta_fq_of_bigint(x: CamlBigInteger256) -> Result<CamlFq, ocaml::Error> {
     Fq::from_repr(x.0).map(CamlFq).ok_or_else(|| {
-        println!("invalid?: {:?}", CamlBigInteger256::to_string(&x));
-        ocaml::Error::Message("caml_pasta_fq_of_bigint was given an invalid CamlBigInteger256")
+        let err = format!(
+            "caml_pasta_fq_of_bigint was given an invalid CamlBigInteger256: {}",
+            x.0
+        );
+        ocaml::Error::Error(err.into())
     })
 }
 


### PR DESCRIPTION


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
