### PR TITLE
nix: fix error about wasm-bindgen-rayon

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -43,6 +43,7 @@ let
       value = (fetchGit {
         rev = last (split "#" x.source);
         url = last (split "\\+" (head (split "\\?" x.source)));
+        allRefs = true;
       }).narHash;
     }) package;
 in {
@@ -135,6 +136,7 @@ in {
         # FIXME: tests fail
         doCheck = false;
         cargoLock.lockFile = ../src/lib/crypto/Cargo.lock;
+        cargoLock.outputHashes = cargoHashes;
       };
 
   go-capnproto2 = pkgs.buildGoModule rec {


### PR DESCRIPTION
Forgot a `cargoHashes`, and forgot to add `allRefs = true` to fetch certain refs.