### PR TITLE
Allow returning of auxiliary inputs from pickles circuits

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -311,7 +311,7 @@ let rule ~proof_level ~constraint_constants transaction_snark self :
             (step ~proof_level ~constraint_constants ~logger:(Logger.create ())
                [ x1; x2 ] x )
         in
-        ([ b1; b2 ], ()) )
+        ([ b1; b2 ], (), ()) )
   }
 
 module Statement = struct
@@ -353,7 +353,7 @@ module type S = sig
        , N2.n * (N2.n * unit)
        , N1.n * (N5.n * unit)
        , Protocol_state.Value.t
-       , (unit * Proof.t) Async.Deferred.t )
+       , (unit * unit * Proof.t) Async.Deferred.t )
        Pickles.Prover.t
 
   val constraint_system_digests : (string * Md5_lib.t) list Lazy.t
@@ -394,7 +394,7 @@ end) : S = struct
     Pickles.compile ~cache:Cache_dir.cache
       (module Statement_var)
       (module Statement)
-      ~public_input:(Input typ)
+      ~public_input:(Input typ) ~auxiliary_typ:Typ.unit
       ~branches:(module Nat.N1)
       ~max_proofs_verified:(module Nat.N2)
       ~name:"blockchain-snark"

--- a/src/lib/blockchain_snark/blockchain_snark_state.mli
+++ b/src/lib/blockchain_snark/blockchain_snark_state.mli
@@ -47,7 +47,7 @@ module type S = sig
        , N2.n * (N2.n * unit)
        , N1.n * (N5.n * unit)
        , Protocol_state.Value.t
-       , (unit * Proof.t) Async.Deferred.t )
+       , (unit * unit * Proof.t) Async.Deferred.t )
        Pickles.Prover.t
 
   val constraint_system_digests : (string * Md5_lib.t) list Lazy.t

--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -223,7 +223,7 @@ let blockchain_snark_state (inputs : Inputs.t) :
   ((module T), (module B))
 
 let create_values txn b (t : Inputs.t) =
-  let%map.Async.Deferred (), genesis_proof = base_proof b t in
+  let%map.Async.Deferred (), (), genesis_proof = base_proof b t in
   { runtime_config = t.runtime_config
   ; constraint_constants = t.constraint_constants
   ; proof_level = t.proof_level

--- a/src/lib/parties_builder/parties_builder.ml
+++ b/src/lib/parties_builder/parties_builder.ml
@@ -138,7 +138,7 @@ let replace_authorizations ?prover ~keymap (parties : Parties.t) : Parties.t =
                       (Snarky_backendless.Request.With { request; respond }) =
                     match request with _ -> respond Unhandled
                   in
-                  let (), proof =
+                  let (), (), proof =
                     Async_unix.Thread_safe.block_on_async_exn (fun () ->
                         prover ?handler:(Some handler)
                           ( []

--- a/src/lib/pickles/inductive_rule.ml
+++ b/src/lib/pickles/inductive_rule.ml
@@ -56,6 +56,12 @@ type ('var, 'value, 'input_var, 'input_value, 'ret_var, 'ret_value) public_input
     - ['ret_var] is the in-circuit type of the [main] function's public output.
     - ['ret_value] is the out-of-circuit type of the [main] function's public
       output.
+    - ['auxiliary_var] is the in-circuit type of the [main] function's
+      auxiliary data, to be returned to the prover but not exposed in the
+      public input.
+    - ['auxiliary_value] is the out-of-circuit type of the [main] function's
+      auxiliary data, to be returned to the prover but not exposed in the
+      public input.
 *)
 type ( 'prev_vars
      , 'prev_values
@@ -64,19 +70,25 @@ type ( 'prev_vars
      , 'a_var
      , 'a_value
      , 'ret_var
-     , 'ret_value )
+     , 'ret_value
+     , 'auxiliary_var
+     , 'auxiliary_value )
      t =
   { identifier : string
   ; prevs : ('prev_vars, 'prev_values, 'widths, 'heights) H4.T(Tag).t
   ; main :
-      'prev_vars H1.T(Id).t -> 'a_var -> 'prev_vars H1.T(E01(B)).t * 'ret_var
+         'prev_vars H1.T(Id).t
+      -> 'a_var
+      -> 'prev_vars H1.T(E01(B)).t * 'ret_var * 'auxiliary_var
   }
 
 module T
     (Statement : T0)
     (Statement_value : T0)
     (Return_var : T0)
-    (Return_value : T0) =
+    (Return_value : T0)
+    (Auxiliary_var : T0)
+    (Auxiliary_value : T0) =
 struct
   type nonrec ('prev_vars, 'prev_values, 'widths, 'heights) t =
     ( 'prev_vars
@@ -86,6 +98,8 @@ struct
     , Statement.t
     , Statement_value.t
     , Return_var.t
-    , Return_value.t )
+    , Return_value.t
+    , Auxiliary_var.t
+    , Auxiliary_value.t )
     t
 end

--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -244,6 +244,7 @@ val compile_promise :
        , 'ret_var
        , 'ret_value )
        Inductive_rule.public_input
+  -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
   -> branches:(module Nat.Intf with type n = 'branches)
   -> max_proofs_verified:(module Nat.Add.Intf with type n = 'max_proofs_verified)
   -> name:string
@@ -257,8 +258,10 @@ val compile_promise :
            , 'a_var
            , 'a_value
            , 'ret_var
-           , 'ret_value )
-           H4_4.T(Inductive_rule).t )
+           , 'ret_value
+           , 'auxiliary_var
+           , 'auxiliary_value )
+           H4_6.T(Inductive_rule).t )
   -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
      * Cache_handle.t
      * (module Proof_intf
@@ -268,7 +271,9 @@ val compile_promise :
        , 'widthss
        , 'heightss
        , 'a_value
-       , ('ret_value * ('max_proofs_verified, 'max_proofs_verified) Proof.t)
+       , ( 'ret_value
+         * 'auxiliary_value
+         * ('max_proofs_verified, 'max_proofs_verified) Proof.t )
          Promise.t )
        H3_2.T(Prover).t
 
@@ -291,6 +296,7 @@ val compile :
        , 'ret_var
        , 'ret_value )
        Inductive_rule.public_input
+  -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
   -> branches:(module Nat.Intf with type n = 'branches)
   -> max_proofs_verified:(module Nat.Add.Intf with type n = 'max_proofs_verified)
   -> name:string
@@ -304,8 +310,10 @@ val compile :
            , 'a_var
            , 'a_value
            , 'ret_var
-           , 'ret_value )
-           H4_4.T(Inductive_rule).t )
+           , 'ret_value
+           , 'auxiliary_var
+           , 'auxiliary_value )
+           H4_6.T(Inductive_rule).t )
   -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
      * Cache_handle.t
      * (module Proof_intf
@@ -315,6 +323,8 @@ val compile :
        , 'widthss
        , 'heightss
        , 'a_value
-       , ('ret_value * ('max_proofs_verified, 'max_proofs_verified) Proof.t)
+       , ( 'ret_value
+         * 'auxiliary_value
+         * ('max_proofs_verified, 'max_proofs_verified) Proof.t )
          Deferred.t )
        H3_2.T(Prover).t

--- a/src/lib/pickles/requests.ml
+++ b/src/lib/pickles/requests.ml
@@ -114,6 +114,8 @@ module Step = struct
 
     type local_branches
 
+    type auxiliary_value
+
     type _ t +=
       | Compute_prev_proof_parts : prev_values H1.T(E01(Bool)).t -> unit t
       | Prev_inputs : prev_values H1.T(Id).t t
@@ -126,19 +128,21 @@ module Step = struct
       | Wrap_index : Tock.Curve.Affine.t Plonk_verification_key_evals.t t
       | App_state : statement t
       | Return_value : return_value -> unit t
+      | Auxiliary_value : auxiliary_value -> unit t
       | Unfinalized_proofs :
           (Unfinalized.Constant.t, max_proofs_verified) Vector.t t
       | Pass_through : (Digest.Constant.t, max_proofs_verified) Vector.t t
   end
 
   let create :
-      type local_signature local_branches statement return_value prev_values prev_ret_values max_proofs_verified.
+      type local_signature local_branches statement return_value auxiliary_value prev_values prev_ret_values max_proofs_verified.
          unit
       -> (module S
             with type local_signature = local_signature
              and type local_branches = local_branches
              and type statement = statement
              and type return_value = return_value
+             and type auxiliary_value = auxiliary_value
              and type prev_values = prev_values
              and type max_proofs_verified = max_proofs_verified ) =
    fun () ->
@@ -148,6 +152,8 @@ module Step = struct
       type nonrec statement = statement
 
       type nonrec return_value = return_value
+
+      type nonrec auxiliary_value = auxiliary_value
 
       type nonrec prev_values = prev_values
 
@@ -167,6 +173,7 @@ module Step = struct
         | Wrap_index : Tock.Curve.Affine.t Plonk_verification_key_evals.t t
         | App_state : statement t
         | Return_value : return_value -> unit t
+        | Auxiliary_value : auxiliary_value -> unit t
         | Unfinalized_proofs :
             (Unfinalized.Constant.t, max_proofs_verified) Vector.t t
         | Pass_through : (Digest.Constant.t, max_proofs_verified) Vector.t t

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -41,13 +41,15 @@ struct
                a rule in proof system i. max_local_max_proof_verifieds is the max of the N_i.
             *)
       max_local_max_proof_verifieds self_branches prev_vars prev_values
-      local_widths local_heights prevs_length var value ret_var ret_value )
-      ?handler
+      local_widths local_heights prevs_length var value ret_var ret_value
+      auxiliary_var auxiliary_value ) ?handler
       (T branch_data :
         ( A.t
         , A_value.t
         , ret_var
         , ret_value
+        , auxiliary_var
+        , auxiliary_value
         , Max_proofs_verified.n
         , self_branches
         , prev_vars
@@ -68,8 +70,9 @@ struct
          , A_value.t
          , ret_var
          , ret_value )
-         Inductive_rule.public_input ) pk self_dlog_vk
-      (prev_values : prev_values H1.T(Id).t)
+         Inductive_rule.public_input )
+      ~(auxiliary_typ : (auxiliary_var, auxiliary_value) Impls.Step.Typ.t) pk
+      self_dlog_vk (prev_values : prev_values H1.T(Id).t)
       (prev_proofs : (local_widths, local_widths) H2.T(P).t) :
       ( ( value
         , (_, Max_proofs_verified.n) Vector.t
@@ -78,7 +81,8 @@ struct
         , _
         , (_, Max_proofs_verified.n) Vector.t )
         P.Base.Step.t
-      * ret_value )
+      * ret_value
+      * auxiliary_value )
       Promise.t =
     let _, prev_vars_length = branch_data.proofs_verified in
     let T = Length.contr prev_vars_length prevs_length in
@@ -440,6 +444,7 @@ struct
     let x_hats = ref None in
     let witnesses = ref None in
     let return_value = ref None in
+    let auxiliary_value = ref None in
     let compute_prev_proof_parts inners_must_verify =
       let ( challenge_polynomial_commitments'
           , unfinalized_proofs'
@@ -609,6 +614,9 @@ struct
       | Req.Return_value res ->
           return_value := Some res ;
           k ()
+      | Req.Auxiliary_value res ->
+          auxiliary_value := Some res ;
+          k ()
       | Req.Unfinalized_proofs ->
           k (Lazy.force unfinalized_proofs_extended)
       | Req.Pass_through ->
@@ -708,5 +716,6 @@ struct
                    } ) )
             lte Max_proofs_verified.n Dummy.evals
       }
-    , Option.value_exn !return_value )
+    , Option.value_exn !return_value
+    , Option.value_exn !auxiliary_value )
 end

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -9,6 +9,8 @@ type ( 'a_var
      , 'a_value
      , 'ret_var
      , 'ret_value
+     , 'auxiliary_var
+     , 'auxiliary_value
      , 'max_proofs_verified
      , 'branches
      , 'prev_vars
@@ -30,7 +32,9 @@ type ( 'a_var
           , 'a_var
           , 'a_value
           , 'ret_var
-          , 'ret_value )
+          , 'ret_value
+          , 'auxiliary_var
+          , 'auxiliary_value )
           Inductive_rule.t
       ; main :
              step_domains:(Domains.t, 'branches) Vector.t
@@ -46,12 +50,15 @@ type ( 'a_var
               and type prev_values = 'prev_values
               and type local_signature = 'local_widths
               and type local_branches = 'local_heights
-              and type return_value = 'ret_value )
+              and type return_value = 'ret_value
+              and type auxiliary_value = 'auxiliary_value )
       }
       -> ( 'a_var
          , 'a_value
          , 'ret_var
          , 'ret_value
+         , 'auxiliary_var
+         , 'auxiliary_value
          , 'max_proofs_verified
          , 'branches
          , 'prev_vars
@@ -74,7 +81,7 @@ let create
        , a_value
        , ret_var
        , ret_value )
-       Inductive_rule.public_input ) var_to_field_elements
+       Inductive_rule.public_input ) ~auxiliary_typ var_to_field_elements
     value_to_field_elements (rule : _ Inductive_rule.t) =
   Timer.clock __LOC__ ;
   let module HT = H4.T (Tag) in
@@ -128,7 +135,7 @@ let create
       rule
       ~basic:
         { public_input = typ; proofs_verifieds; wrap_domains; step_domains }
-      ~public_input ~self_branches:branches ~proofs_verified
+      ~public_input ~auxiliary_typ ~self_branches:branches ~proofs_verified
       ~local_signature:widths ~local_signature_length ~local_branches:heights
       ~local_branches_length ~lte ~self
     |> unstage

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -102,14 +102,15 @@ let finalize_previous_and_verify = ()
 
 (* The SNARK function corresponding to the input inductive rule. *)
 let step_main :
-    type proofs_verified self_branches prev_vars prev_values prev_ret_vars var value a_var a_value ret_var ret_value max_proofs_verified local_branches local_signature.
+    type proofs_verified self_branches prev_vars prev_values prev_ret_vars var value a_var a_value ret_var ret_value auxiliary_var auxiliary_value max_proofs_verified local_branches local_signature.
        (module Requests.Step.S
           with type local_signature = local_signature
            and type local_branches = local_branches
            and type statement = a_value
            and type prev_values = prev_values
            and type max_proofs_verified = max_proofs_verified
-           and type return_value = ret_value )
+           and type return_value = ret_value
+           and type auxiliary_value = auxiliary_value )
     -> (module Nat.Add.Intf with type n = max_proofs_verified)
     -> self_branches:self_branches Nat.t
          (* How many branches does this proof system have *)
@@ -131,6 +132,7 @@ let step_main :
          , ret_var
          , ret_value )
          Inductive_rule.public_input
+    -> auxiliary_typ:(auxiliary_var, auxiliary_value) Typ.t
     -> basic:
          ( var
          , value
@@ -145,7 +147,9 @@ let step_main :
        , a_var
        , a_value
        , ret_var
-       , ret_value )
+       , ret_value
+       , auxiliary_var
+       , auxiliary_value )
        Inductive_rule.t
     -> (   unit
         -> ( (Unfinalized.t, max_proofs_verified) Vector.t
@@ -155,7 +159,7 @@ let step_main :
        Staged.t =
  fun (module Req) (module Max_proofs_verified) ~self_branches ~local_signature
      ~local_signature_length ~local_branches ~local_branches_length
-     ~proofs_verified ~lte ~public_input ~basic ~self rule ->
+     ~proofs_verified ~lte ~public_input ~auxiliary_typ ~basic ~self rule ->
   let module T (F : T4) = struct
     type ('a, 'b, 'n, 'm) t =
       | Other of ('a, 'b, 'n, 'm) F.t
@@ -252,7 +256,7 @@ let step_main :
           exists prev_values_typs ~request:(fun () -> Req.Prev_inputs)
         in
         let app_state = exists input_typ ~request:(fun () -> Req.App_state) in
-        let proofs_should_verify, ret_var =
+        let proofs_should_verify, ret_var, auxiliary_var =
           (* Run the application logic of the rule on the predecessor statements *)
           with_label "rule_main" (fun () ->
               rule.main prev_statements app_state )
@@ -261,6 +265,13 @@ let step_main :
           exists Typ.unit ~request:(fun () ->
               let ret_value = As_prover.read output_typ ret_var in
               Req.Return_value ret_value )
+        in
+        let () =
+          exists Typ.unit ~request:(fun () ->
+              let auxiliary_value =
+                As_prover.read auxiliary_typ auxiliary_var
+              in
+              Req.Auxiliary_value auxiliary_value )
         in
         (* Compute proof parts outside of the prover before requesting values.
         *)

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -5,8 +5,17 @@ open Poly_types
 open Hlist
 
 (* Compute the domains corresponding to wrap_main *)
-module Make (A : T0) (A_value : T0) (Ret_var : T0) (Ret_value : T0) = struct
-  module I = Inductive_rule.T (A) (A_value) (Ret_var) (Ret_value)
+module Make
+    (A : T0)
+    (A_value : T0)
+    (Ret_var : T0)
+    (Ret_value : T0)
+    (Auxiliary_var : T0)
+    (Auxiliary_value : T0) =
+struct
+  module I =
+    Inductive_rule.T (A) (A_value) (Ret_var) (Ret_value) (Auxiliary_var)
+      (Auxiliary_value)
 
   let prev (type a1 a2 ws hs) ~self ~(choices : (a1, a2, ws, hs) H4.T(I).t) =
     let module M_inner =

--- a/src/lib/pickles_types/hlist.ml
+++ b/src/lib/pickles_types/hlist.ml
@@ -908,6 +908,39 @@ module H4_4 = struct
   end
 end
 
+module H4_6 = struct
+  module T (F : sig
+    type (_, _, _, _, _, _, _, _, _, _) t
+  end) =
+  struct
+    type (_, _, _, _, 's1, 's2, 's3, 's4, 's5, 's6) t =
+      | [] : (unit, unit, unit, unit, _, _, _, _, _, _) t
+      | ( :: ) :
+          ('a1, 'a2, 'a3, 'a4, 's1, 's2, 's3, 's4, 's5, 's6) F.t
+          * ('b1, 'b2, 'b3, 'b4, 's1, 's2, 's3, 's4, 's5, 's6) t
+          -> ( 'a1 * 'b1
+             , 'a2 * 'b2
+             , 'a3 * 'b3
+             , 'a4 * 'b4
+             , 's1
+             , 's2
+             , 's3
+             , 's4
+             , 's5
+             , 's6 )
+             t
+
+    let rec length :
+        type t1 t2 t3 t4 e1 e2 e3 e4 e5 e6.
+        (t1, t2, t3, t4, e1, e2, e3, e4, e5, e6) t -> t1 Length.n = function
+      | [] ->
+          T (Z, Z)
+      | _ :: xs ->
+          let (T (n, p)) = length xs in
+          T (S n, S p)
+  end
+end
+
 module H6_2 = struct
   module T (F : sig
     type (_, _, _, _, _, _, _, _) t

--- a/src/lib/pickles_types/hlist.mli
+++ b/src/lib/pickles_types/hlist.mli
@@ -1014,6 +1014,38 @@ module H4_4 : sig
   end
 end
 
+(** Data type of heterogeneous lists whose content type varies over four type
+    parameters, but also varies homogeneously over six other type parameters.
+    It supports no operations. See {!Hlist0.H1_1}.
+*)
+module H4_6 : sig
+  module T : functor
+    (A : sig
+       type (_, _, _, _, _, _, _, _, _, _) t
+     end)
+    -> sig
+    type (_, _, _, _, 's1, 's2, 's3, 's4, 's5, 's6) t =
+      | [] : (unit, unit, unit, unit, 's1, 's2, 's3, 's4, 's5, 's6) t
+      | ( :: ) :
+          ('a1, 'a2, 'a3, 'a4, 's1, 's2, 's3, 's4, 's5, 's6) A.t
+          * ('b1, 'b2, 'b3, 'b4, 's1, 's2, 's3, 's4, 's5, 's6) t
+          -> ( 'a1 * 'b1
+             , 'a2 * 'b2
+             , 'a3 * 'b3
+             , 'a4 * 'b4
+             , 's1
+             , 's2
+             , 's3
+             , 's4
+             , 's5
+             , 's6 )
+             t
+
+    val length :
+      ('t1, 't2, 't3, 't4, 'e1, 'e2, 'e3, 'e4, 'e5, 'e6) t -> 't1 Length.n
+  end
+end
+
 (** Data type of heterogeneous lists whose content type varies over six type
     parameters, but also varies homogeneously over two other type parameters.
     It supports no operations. See {!Hlist0.H1_1}.

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -117,7 +117,7 @@ module Worker_state = struct
                        let txn_snark_statement, txn_snark_proof =
                          ledger_proof_opt chain next_state t
                        in
-                       let%map.Async.Deferred (), proof =
+                       let%map.Async.Deferred (), (), proof =
                          B.step
                            ~handler:
                              (Consensus.Data.Prover_state.handler

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -1739,7 +1739,7 @@ let pickles_compile (choices : pickles_rule_js Js.js_array Js.t) =
     Pickles.compile_promise ~choices:(Obj.magic choices)
       (module Zkapp_statement)
       (module Zkapp_statement.Constant)
-      ~public_input:(Input zkapp_statement_typ)
+      ~public_input:(Input zkapp_statement_typ) ~auxiliary_typ:Typ.unit
       ~branches:(module Branches)
       ~max_proofs_verified:(module Pickles_types.Nat.N0)
         (* ^ TODO make max_branching configurable -- needs refactor in party types *)
@@ -1765,7 +1765,7 @@ let pickles_compile (choices : pickles_rule_js Js.js_array Js.t) =
       let prevs = Obj.magic [] in
       let statement = Zkapp_statement.(statement_js |> of_js |> to_constant) in
       prover ?handler:None prevs statement
-      |> Promise.map ~f:(fun ((), proof) ->
+      |> Promise.map ~f:(fun ((), (), proof) ->
              Pickles.Side_loaded.Proof.of_proof proof )
       |> Promise_js_helpers.to_js
     in
@@ -1777,7 +1777,7 @@ let pickles_compile (choices : pickles_rule_js Js.js_array Js.t) =
          , b
          , c
          , Zkapp_statement.Constant.t
-         , (unit * proof) Promise.t )
+         , (unit * unit * proof) Promise.t )
          Pickles.Provers.t
       -> (   zkapp_statement_js
           -> Pickles.Side_loaded.Proof.t Promise_js_helpers.js_promise )

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -206,13 +206,14 @@ let%test_module "multisig_account" =
                   ; main =
                       (fun [] x ->
                         multisig_main x |> Run.run_checked ;
-                        ([], ()) )
+                        ([], (), ()) )
                   }
                 in
                 Pickles.compile ~cache:Cache_dir.cache
                   (module Zkapp_statement.Checked)
                   (module Zkapp_statement)
                   ~public_input:(Input Zkapp_statement.typ)
+                  ~auxiliary_typ:Typ.unit
                   ~branches:(module Nat.N2)
                   ~max_proofs_verified:(module Nat.N2)
                     (* You have to put 2 here... *)
@@ -234,7 +235,7 @@ let%test_module "multisig_account" =
                                   Run.Field.Constant.zero )
                             in
                             Run.Field.(Assert.equal s (s + one)) ;
-                            ([ Boolean.true_; Boolean.true_ ], ()) )
+                            ([ Boolean.true_; Boolean.true_ ], (), ()) )
                       }
                     ] )
               in
@@ -391,7 +392,7 @@ let%test_module "multisig_account" =
                 | _ ->
                     respond Unhandled
               in
-              let (), (pi : Pickles.Side_loaded.Proof.t) =
+              let (), (), (pi : Pickles.Side_loaded.Proof.t) =
                 (fun () -> multisig_prover ~handler [] tx_statement)
                 |> Async.Thread_safe.block_on_async_exn
               in

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -52,7 +52,7 @@ let ring_sig_rule (ring_member_pks : Schnorr.Chunked.Public_key.t list) :
   ; main =
       (fun [] x ->
         ring_sig_main x |> Run.run_checked ;
-        ([], ()) )
+        ([], (), ()) )
   }
 
 let%test_unit "1-of-1" =
@@ -121,7 +121,7 @@ let%test_unit "ring-signature snapp tx with 3 parties" =
             Pickles.compile ~cache:Cache_dir.cache
               (module Zkapp_statement.Checked)
               (module Zkapp_statement)
-              ~public_input:(Input Zkapp_statement.typ)
+              ~public_input:(Input Zkapp_statement.typ) ~auxiliary_typ:Typ.unit
               ~branches:(module Nat.N2)
               ~max_proofs_verified:(module Nat.N2)
                 (* You have to put 2 here... *)
@@ -260,7 +260,7 @@ let%test_unit "ring-signature snapp tx with 3 parties" =
             | _ ->
                 respond Unhandled
           in
-          let (), (pi : Pickles.Side_loaded.Proof.t) =
+          let (), (), (pi : Pickles.Side_loaded.Proof.t) =
             (fun () -> ringsig_prover ~handler [] tx_statement)
             |> Async.Thread_safe.block_on_async_exn
           in

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -249,7 +249,7 @@ let dummy_rule self : _ Pickles.Inductive_rule.t =
           Run.exists Field.typ ~compute:(fun () -> Run.Field.Constant.zero)
         in
         Run.Field.(Assert.equal s (s + one)) ;
-        ([ Boolean.true_; Boolean.true_ ], ()) )
+        ([ Boolean.true_; Boolean.true_ ], (), ()) )
   }
 
 let gen_snapp_ledger =

--- a/src/lib/transaction_snark/test/util.mli
+++ b/src/lib/transaction_snark/test/util.mli
@@ -43,7 +43,9 @@ val dummy_rule :
      , Zkapp_statement.Checked.t
      , Zkapp_statement.t
      , unit
-     , 'i )
+     , 'i
+     , unit
+     , unit )
      Pickles.Inductive_rule.t
 
 (** Generates base and merge snarks of all the party segments
@@ -66,6 +68,7 @@ val trivial_zkapp :
        , unit
        , Zkapp_statement.t
        , ( unit
+         * unit
          * (Pickles_types.Nat.N2.n, Pickles_types.Nat.N2.n) Pickles.Proof.t )
          Async.Deferred.t )
        Pickles.Prover.t ] )
@@ -86,6 +89,7 @@ val test_snapp_update :
        , unit
        , Zkapp_statement.t
        , ( unit
+         * unit
          * (Pickles_types.Nat.N2.n, Pickles_types.Nat.N2.n) Pickles.Proof.t )
          Async.Deferred.t )
        Pickles.Prover.t

--- a/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
@@ -22,6 +22,7 @@ let tag, _, p_module, Pickles.Provers.[ prover; _ ] =
     (module Zkapp_statement.Checked)
     (module Zkapp_statement)
     ~public_input:(Input Zkapp_statement.typ)
+    ~auxiliary_typ:Impl.Typ.unit
     ~branches:(module Nat.N2)
     ~max_proofs_verified:(module Nat.N2) (* You have to put 2 here... *)
     ~name:"empty_update"
@@ -38,7 +39,7 @@ let vk = Pickles.Side_loaded.Verification_key.of_compiled tag
 (* TODO: This should be entirely unnecessary. *)
 let party_body = Zkapps_empty_update.generate_party pk_compressed
 
-let (), party_proof =
+let (), (), party_proof =
   Async.Thread_safe.block_on_async_exn (fun () ->
       prover []
         { transaction = Party.Body.digest party_body

--- a/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
@@ -29,6 +29,7 @@ let%test_module "Initialize state test" =
         (module Zkapp_statement.Checked)
         (module Zkapp_statement)
         ~public_input:(Input Zkapp_statement.typ)
+        ~auxiliary_typ:Impl.Typ.unit
         ~branches:(module Nat.N3)
         ~max_proofs_verified:(module Nat.N2) (* You have to put 2 here... *)
         ~name:"empty_update"
@@ -92,7 +93,7 @@ let%test_module "Initialize state test" =
       let party_body =
         Zkapps_initialize_state.generate_initialize_party pk_compressed
 
-      let (), party_proof =
+      let (), (), party_proof =
         Async.Thread_safe.block_on_async_exn (fun () ->
             initialize_prover []
               { transaction = Party.Body.digest party_body
@@ -111,7 +112,7 @@ let%test_module "Initialize state test" =
         Zkapps_initialize_state.generate_update_state_party pk_compressed
           new_state
 
-      let (), party_proof =
+      let (), (), party_proof =
         Async.Thread_safe.block_on_async_exn (fun () ->
             update_state_prover
               ~handler:(Zkapps_initialize_state.update_state_handler new_state)

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -531,7 +531,8 @@ module For_tests : sig
          , unit
          , unit
          , Zkapp_statement.t
-         , (unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t) Async.Deferred.t )
+         , (unit * unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t) Async.Deferred.t
+         )
          Pickles.Prover.t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> Spec.t
@@ -567,7 +568,8 @@ module For_tests : sig
             , unit
             , unit
             , Zkapp_statement.t
-            , (unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t) Async.Deferred.t )
+            , (unit * unit * (Nat.N2.n, Nat.N2.n) Pickles.Proof.t)
+              Async.Deferred.t )
             Pickles.Prover.t ]
 
   val multiple_transfers : Spec.t -> Parties.t

--- a/src/lib/zkapps_examples/zkapps_examples.ml
+++ b/src/lib/zkapps_examples/zkapps_examples.ml
@@ -402,7 +402,7 @@ let dummy_constraints () =
 *)
 let party_circuit f ([] : _ H1.T(Id).t)
     ({ transaction; at_party } : Zkapp_statement.Checked.t) :
-    _ H1.T(E01(Pickles.Inductive_rule.B)).t * unit =
+    _ H1.T(E01(Pickles.Inductive_rule.B)).t * unit * unit =
   dummy_constraints () ;
   let party = f () in
   let party = Party_under_construction.In_circuit.to_party party in
@@ -415,4 +415,4 @@ let party_circuit f ([] : _ H1.T(Id).t)
   in
   Run.Field.Assert.equal returned_transaction transaction ;
   Run.Field.Assert.equal returned_at_party at_party ;
-  ([], ())
+  ([], (), ())


### PR DESCRIPTION
This PR builds upon #11282.

This is similar in spirit to #11282, adding the concept of 'auxiliary return values' to pickles circuits. This allows us to return additional information from circuits -- in particular, to expose the 'call stack' from zkApps circuits -- without affecting the shape of the public input.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them