### PR TITLE
Revalidate transaction pool off of ledger state when updating best tip

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -714,7 +714,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                   @@ Mina_block.header (With_hash.data previous_transition) )
             in
             let transactions =
-              Network_pool.Transaction_pool.Resource_pool.transactions ~logger
+              Network_pool.Transaction_pool.Resource_pool.transactions
                 transaction_resource_pool
               |> Sequence.map
                    ~f:Transaction_hash.User_command_with_valid_signature.data

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -848,7 +848,7 @@ let has_permission ~to_ (account : t) =
       Permissions.Auth_required.check account.permissions.set_delegate
         Control.Tag.Signature
 
-let balance_at_slot ~global_slot (account : t) =
+let liquid_balance_at_slot ~global_slot (account : t) =
   match account.timing with
   | Untimed ->
       account.balance

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -848,6 +848,23 @@ let has_permission ~to_ (account : t) =
       Permissions.Auth_required.check account.permissions.set_delegate
         Control.Tag.Signature
 
+let balance_at_slot ~global_slot (account : t) =
+  match account.timing with
+  | Untimed ->
+      account.balance
+  | Timed
+      { initial_minimum_balance
+      ; cliff_time
+      ; cliff_amount
+      ; vesting_period
+      ; vesting_increment
+      } ->
+      Balance.sub_amount account.balance
+        (Balance.to_amount
+           (min_balance_at_slot ~global_slot ~cliff_time ~cliff_amount
+              ~vesting_period ~vesting_increment ~initial_minimum_balance ) )
+      |> Option.value_exn
+
 let gen =
   let open Quickcheck.Let_syntax in
   let%bind public_key = Public_key.Compressed.gen in

--- a/src/lib/mina_base/dune
+++ b/src/lib/mina_base/dune
@@ -72,7 +72,7 @@
  (preprocess
   (pps ppx_annot ppx_snarky ppx_here ppx_coda ppx_version ppx_compare ppx_deriving.enum ppx_deriving.ord ppx_deriving.make
        ppx_base base_quickcheck.ppx_quickcheck ppx_bench ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test h_list.ppx
-       ppx_variants_conv
+       ppx_variants_conv ppx_pipebang
  ))
  (instrumentation (backend bisect_ppx))
  (synopsis "Snarks and friends necessary for keypair generation"))

--- a/src/lib/mina_base/parties.ml
+++ b/src/lib/mina_base/parties.ml
@@ -1107,18 +1107,6 @@ let accounts_accessed (t : t) =
 
 let fee_payer_pk (t : t) = t.fee_payer.body.public_key
 
-(*
-type account_mutations =
-  { nonce_increase : int
-  ; balance_delta : Currency.Amount.Signed.t }
-
-let account_mutations (t : t) : (Account_id.t * [`Nonce_increase | `Balance_increase | `Balance_decrease]) Account_id.Map.t =
-  let mutations =
-    let fee_payer_account_id = (t.fee_payer.body.public_key, fee_token t) in
-    Account_id.Map.of_alist_exn [(t.fee_payer.body.public_key, {nonce_increase = 1; balance_delta = Currency.Amount.Signed.zero})]
-  in
-*)
-
 let value_if b ~then_ ~else_ = if b then then_ else else_
 
 module Virtual = struct

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -18,6 +18,7 @@
    base.caml
    bin_prot.shape
    ppx_inline_test.config
+   integers
    ;; local libraries
    mina_compile_config
    mina_generators
@@ -42,6 +43,7 @@
    quickcheck_lib
    mina_base
    mina_transaction
+   mina_state
    transaction_snark
    transaction_snark_tests
    consensus
@@ -54,7 +56,6 @@
    inline_test_quiet_logs
    pickles
    pickles_types
-   kimchi_backend.pasta
    pickles.backend
    random_oracle
    error_json
@@ -68,6 +69,12 @@
    snark_params
    parties_builder
    ppx_version.runtime
+   random_oracle_input
+   kimchi_backend
+   kimchi_backend_common
+   kimchi_backend.pasta
+   genesis_ledger
+   staged_ledger_diff
  )
  (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1855,6 +1855,7 @@ let%test_module _ =
             ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
             ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
             ~constraint_constants ~consensus_constants
+            ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
         in
         compile_time_genesis.data |> Mina_state.Protocol_state.body
       in

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -211,17 +211,6 @@ module For_tests = struct
           Transaction_hash.User_command_with_valid_signature.command applicable
         in
         check_consistent applicable ;
-        (*
-        Printf.printf !"fee_per_wu = %{Sexp}\n" (Currency.Fee_rate.sexp_of_t @@ User_command.fee_per_wu applicable_unchecked) ;
-        Printf.printf !"applicable_by_fee = [%s]\n" (
-          Map.to_alist applicable_by_fee
-          |> List.map ~f:(fun (fee, applicable) ->
-              Sexp.to_string @@
-                Sexp.List
-                  [ Currency.Fee_rate.sexp_of_t fee
-                  ; Int.sexp_of_t @@ Set.length applicable (* Set.sexp_of_m__t (module Transaction_hash.User_command_with_valid_signature) applicable *) ])
-          |> String.concat ~sep:", " ) ;
-        *)
         assert (
           Set.mem
             (Map.find_exn applicable_by_fee
@@ -598,24 +587,6 @@ let transactions t =
               (applicable_by_fee', Map.remove all_by_sender sender)
         in
         Some (txn, (applicable_by_fee'', all_by_sender')) )
-
-(*
-  Sequence.unfold ~init:t.all_by_fee ~f:(fun all_by_fee ->
-    if Map.is_empty all_by_fee then
-      None
-    else
-      let fee, set = Map.max_elt_exn all_by_fee in
-      assert (Set.length set > 0) ;
-      let txn = Set.min_elt_exn set in
-      let set' = Set.remove set txn in
-      let all_by_fee' =
-        if Set.is_empty set' then
-          Map.remove all_by_fee fee
-        else
-          Map.set all_by_fee ~key:fee ~data:set'
-      in
-      Some (txn, all_by_fee'))
-  *)
 
 let run :
     type a e.
@@ -1978,11 +1949,6 @@ let%test_module _ =
       [%test_eq: Transaction_hash.t list]
         (lower (Sequence.to_list dropped))
         (lower expected_drops) ;
-      (*
-      [%test_eq:
-        Transaction_hash.User_command_with_valid_signature.t list]
-        (Sequence.to_list dropped) (cmd :: expected_drops) ;
-      *)
       assert_invariants pool ;
       pool
 

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -194,6 +194,7 @@ module For_tests = struct
             assert_all_by_hash tx ) ) ;
     Map.iteri all_by_sender
       ~f:(fun ~key:fee_payer ~data:(tx_seq, currency_reserved) ->
+        (*Printf.printf !"asserting invariants on %{Sexp}\n" (Account_id.sexp_of_t fee_payer) ;*)
         assert (F_sequence.length tx_seq > 0) ;
         let check_consistent tx =
           [%test_eq: Account_id.t]
@@ -210,6 +211,17 @@ module For_tests = struct
           Transaction_hash.User_command_with_valid_signature.command applicable
         in
         check_consistent applicable ;
+        (*
+        Printf.printf !"fee_per_wu = %{Sexp}\n" (Currency.Fee_rate.sexp_of_t @@ User_command.fee_per_wu applicable_unchecked) ;
+        Printf.printf !"applicable_by_fee = [%s]\n" (
+          Map.to_alist applicable_by_fee
+          |> List.map ~f:(fun (fee, applicable) ->
+              Sexp.to_string @@
+                Sexp.List
+                  [ Currency.Fee_rate.sexp_of_t fee
+                  ; Int.sexp_of_t @@ Set.length applicable (* Set.sexp_of_m__t (module Transaction_hash.User_command_with_valid_signature) applicable *) ])
+          |> String.concat ~sep:", " ) ;
+        *)
         assert (
           Set.mem
             (Map.find_exn applicable_by_fee
@@ -537,6 +549,74 @@ module Update = struct
   let empty : t = Empty
 end
 
+(* Returns a sequence of commands in the pool in descending fee order *)
+let transactions t =
+  let insert_applicable applicable_by_fee txn =
+    let fee =
+      User_command.fee_per_wu
+      @@ Transaction_hash.User_command_with_valid_signature.command txn
+    in
+    Map.update applicable_by_fee fee ~f:(function
+      | Some set ->
+          Set.add set txn
+      | None ->
+          Transaction_hash.User_command_with_valid_signature.Set.singleton txn )
+  in
+  Sequence.unfold
+    ~init:(t.applicable_by_fee, Map.map ~f:fst t.all_by_sender)
+    ~f:(fun (applicable_by_fee, all_by_sender) ->
+      if Map.is_empty applicable_by_fee then (
+        assert (Map.is_empty all_by_sender) ;
+        None )
+      else
+        let fee, set = Map.max_elt_exn applicable_by_fee in
+        assert (Set.length set > 0) ;
+        let txn = Set.min_elt_exn set in
+        let applicable_by_fee' =
+          let set' = Set.remove set txn in
+          if Set.is_empty set' then Map.remove applicable_by_fee fee
+          else Map.set applicable_by_fee ~key:fee ~data:set'
+        in
+        let applicable_by_fee'', all_by_sender' =
+          let sender =
+            User_command.fee_payer
+            @@ Transaction_hash.User_command_with_valid_signature.command txn
+          in
+          let sender_queue = Map.find_exn all_by_sender sender in
+          let head_txn, sender_queue' =
+            Option.value_exn (F_sequence.uncons sender_queue)
+          in
+          assert (
+            Transaction_hash.equal
+              (Transaction_hash.User_command_with_valid_signature.hash txn)
+              (Transaction_hash.User_command_with_valid_signature.hash head_txn) ) ;
+          match F_sequence.uncons sender_queue' with
+          | Some (next_txn, _) ->
+              ( insert_applicable applicable_by_fee' next_txn
+              , Map.set all_by_sender ~key:sender ~data:sender_queue' )
+          | None ->
+              (applicable_by_fee', Map.remove all_by_sender sender)
+        in
+        Some (txn, (applicable_by_fee'', all_by_sender')) )
+
+(*
+  Sequence.unfold ~init:t.all_by_fee ~f:(fun all_by_fee ->
+    if Map.is_empty all_by_fee then
+      None
+    else
+      let fee, set = Map.max_elt_exn all_by_fee in
+      assert (Set.length set > 0) ;
+      let txn = Set.min_elt_exn set in
+      let set' = Set.remove set txn in
+      let all_by_fee' =
+        if Set.is_empty set' then
+          Map.remove all_by_fee fee
+        else
+          Map.set all_by_fee ~key:fee ~data:set'
+      in
+      Some (txn, all_by_fee'))
+  *)
+
 let run :
     type a e.
        sender:Account_id.t
@@ -669,79 +749,126 @@ let drop_until_sufficient_balance :
   in
   go queue currency_reserved Sequence.empty
 
-(* Iterate over all commands in the pool, removing them if they require too much
-   currency or have too low of a nonce.
+(* Iterate over commands in the pool, removing them if they require too much
+   currency or have too low of a nonce. An argument is provided to instruct
+   which commands require revalidation.
 *)
 let revalidate :
        t
+    -> [ `Entire_pool | `Subset of Account_id.Set.t ]
     -> (Account_id.t -> Account_nonce.t * Currency.Amount.t)
     -> t * Transaction_hash.User_command_with_valid_signature.t Sequence.t =
- fun ({ config = { constraint_constants; _ }; _ } as t) f ->
+ fun ({ config = { constraint_constants; _ }; _ } as t) scope f ->
+  let requires_revalidation =
+    match scope with
+    | `Entire_pool ->
+        Fn.const true
+    | `Subset subset ->
+        Set.mem subset
+  in
   Map.fold t.all_by_sender ~init:(t, Sequence.empty)
     ~f:(fun
          ~key:sender
          ~data:(queue, currency_reserved)
          ((t', dropped_acc) as acc)
        ->
-      let current_nonce, current_balance = f sender in
-      let first_cmd = F_sequence.head_exn queue in
-      let first_nonce =
-        first_cmd |> Transaction_hash.User_command_with_valid_signature.command
-        |> User_command.applicable_at_nonce
-      in
-      if Account_nonce.(current_nonce < first_nonce) then
-        let dropped, t'' = remove_with_dependents_exn' t first_cmd in
-        (t'', Sequence.append dropped_acc dropped)
+      if not (requires_revalidation sender) then acc
       else
-        (* current_nonce >= first_nonce *)
-        let first_applicable_nonce_index =
-          F_sequence.findi queue ~f:(fun cmd' ->
-              let nonce =
-                Transaction_hash.User_command_with_valid_signature.command cmd'
-                |> User_command.applicable_at_nonce
+        let current_nonce, current_balance = f sender in
+        Printf.printf
+          "revalidating %s; current_nonce = %d, current_balance = %s\n"
+          (Sexp.to_string @@ Account_id.sexp_of_t sender)
+          (Account_nonce.to_int current_nonce)
+          (Currency.Amount.to_formatted_string current_balance) ;
+        Printf.printf "nonces in queue: [%s]\n"
+          ( F_sequence.to_list queue
+          |> List.map ~f:(fun cmd ->
+                 Transaction_hash.User_command_with_valid_signature.command cmd
+                 |> User_command.applicable_at_nonce |> Account_nonce.to_string )
+          |> String.concat ~sep:", " ) ;
+        let first_cmd = F_sequence.head_exn queue in
+        let first_nonce =
+          first_cmd
+          |> Transaction_hash.User_command_with_valid_signature.command
+          |> User_command.applicable_at_nonce
+        in
+        if Account_nonce.(current_nonce < first_nonce) then (
+          Printf.printf "current nonce precedes first nonce; dropping queue\n" ;
+          let dropped, t'' = remove_with_dependents_exn' t first_cmd in
+          (t'', Sequence.append dropped_acc dropped) )
+        else
+          (* current_nonce >= first_nonce *)
+          let first_applicable_nonce_index =
+            F_sequence.findi queue ~f:(fun cmd' ->
+                let nonce =
+                  Transaction_hash.User_command_with_valid_signature.command
+                    cmd'
+                  |> User_command.applicable_at_nonce
+                in
+                Account_nonce.equal nonce current_nonce )
+            |> Option.value ~default:(F_sequence.length queue)
+          in
+          Printf.printf
+            "current nonce succeeds first nonce; splitting queue at index %d\n"
+            first_applicable_nonce_index ;
+          let drop_queue, keep_queue =
+            F_sequence.split_at queue first_applicable_nonce_index
+          in
+          let currency_reserved' =
+            F_sequence.foldl
+              (fun c cmd ->
+                Option.value_exn
+                  Currency.Amount.(
+                    c
+                    - Option.value_exn
+                        (currency_consumed ~constraint_constants cmd)) )
+              currency_reserved drop_queue
+          in
+          let keep_queue', currency_reserved'', dropped_for_balance =
+            drop_until_sufficient_balance ~constraint_constants
+              (keep_queue, currency_reserved')
+              current_balance
+          in
+          let to_drop =
+            Sequence.append (F_sequence.to_seq drop_queue) dropped_for_balance
+          in
+          match Sequence.next to_drop with
+          | None ->
+              acc
+          | Some (head, tail) ->
+              let t'' =
+                Sequence.fold tail
+                  ~init:
+                    (remove_all_by_fee_and_hash_and_expiration_exn
+                       (remove_applicable_exn t' head)
+                       head )
+                  ~f:remove_all_by_fee_and_hash_and_expiration_exn
               in
-              Account_nonce.equal nonce current_nonce )
-          |> Option.value ~default:(F_sequence.length queue)
-        in
-        let drop_queue, keep_queue =
-          F_sequence.split_at queue first_applicable_nonce_index
-        in
-        let currency_reserved' =
-          F_sequence.foldl
-            (fun c cmd ->
-              Option.value_exn
-                Currency.Amount.(
-                  c
-                  - Option.value_exn
-                      (currency_consumed ~constraint_constants cmd)) )
-            currency_reserved drop_queue
-        in
-        let keep_queue', currency_reserved'', dropped_for_balance =
-          drop_until_sufficient_balance ~constraint_constants
-            (keep_queue, currency_reserved')
-            current_balance
-        in
-        let to_drop =
-          Sequence.append (F_sequence.to_seq drop_queue) dropped_for_balance
-        in
-        match Sequence.next to_drop with
-        | None ->
-            acc
-        | Some (head, tail) ->
-            let t'' =
-              Sequence.fold tail
-                ~init:
-                  (remove_all_by_fee_and_hash_and_expiration_exn
-                     (remove_applicable_exn t' head)
-                     head )
-                ~f:remove_all_by_fee_and_hash_and_expiration_exn
-            in
-            ( { t'' with
-                all_by_sender =
-                  Map.set t''.all_by_sender ~key:sender
-                    ~data:(keep_queue', currency_reserved'')
-              }
-            , Sequence.append dropped_acc to_drop ) )
+              let t''' =
+                match F_sequence.uncons keep_queue' with
+                | None ->
+                    { t'' with
+                      all_by_sender = Map.remove t''.all_by_sender sender
+                    }
+                | Some (first_kept, _) ->
+                    let first_kept_unchecked =
+                      Transaction_hash.User_command_with_valid_signature.command
+                        first_kept
+                    in
+                    { t'' with
+                      all_by_sender =
+                        Map.set t''.all_by_sender ~key:sender
+                          ~data:(keep_queue', currency_reserved'')
+                    ; applicable_by_fee =
+                        Map_set.insert
+                          ( module Transaction_hash
+                                   .User_command_with_valid_signature )
+                          t''.applicable_by_fee
+                          (User_command.fee_per_wu first_kept_unchecked)
+                          first_kept
+                    }
+              in
+              (t''', Sequence.append dropped_acc to_drop) )
 
 let expired_by_predicate (t : t) :
     Transaction_hash.User_command_with_valid_signature.t Sequence.t =
@@ -798,135 +925,6 @@ let remove_expired t :
         let removed, t' = remove_with_dependents_exn' t cmd in
         (Sequence.append dropped_acc removed, t')
       else acc )
-
-let actual_target_nonce cmd ~application_status =
-  match cmd with
-  | User_command.Signed_command x ->
-      Account.Nonce.succ (Signed_command.nonce x)
-  | Parties p -> (
-      match application_status with
-      | None | Some (Transaction_status.Failed _) ->
-          User_command.expected_target_nonce cmd
-      | _ ->
-          Parties.target_nonce_on_success p )
-
-let handle_committed_txn :
-       t
-    -> Transaction_hash.User_command_with_valid_signature.t
-    -> application_status:Transaction_status.t option
-    -> fee_payer_balance:Currency.Amount.t
-    -> fee_payer_nonce:Mina_base.Account.Nonce.t
-    -> ( t * Transaction_hash.User_command_with_valid_signature.t Sequence.t
-       , [ `Queued_txns_by_sender of
-           string
-           * Transaction_hash.User_command_with_valid_signature.t Sequence.t ]
-       )
-       Result.t =
- fun ({ config = { constraint_constants; _ }; _ } as t) committed
-     ~application_status ~fee_payer_balance ~fee_payer_nonce ->
-  let committed' =
-    Transaction_hash.User_command_with_valid_signature.command committed
-  in
-  let fee_payer = User_command.fee_payer committed' in
-  match Map.find t.all_by_sender fee_payer with
-  | None ->
-      Ok (t, Sequence.empty)
-  | Some (cmds, currency_reserved) ->
-      let first_cmd, rest_cmds = Option.value_exn (F_sequence.uncons cmds) in
-      let first_cmd' =
-        Transaction_hash.User_command_with_valid_signature.command first_cmd
-      in
-      let actual_target_nonce =
-        actual_target_nonce committed' ~application_status
-      in
-      if
-        Account_nonce.(
-          User_command.applicable_at_nonce committed'
-          <> User_command.applicable_at_nonce first_cmd')
-      then
-        Error
-          (`Queued_txns_by_sender
-            ( "Tried to handle a committed transaction in the pool but its \
-               nonce doesn't match the head of the queue for that sender"
-            , F_sequence.to_seq cmds ) )
-      else if
-        Account_nonce.(
-          actual_target_nonce <> User_command.expected_target_nonce first_cmd')
-      then
-        (*The committed transaction invalidates the rest of sequence*)
-        let dropped_cmds = F_sequence.to_seq cmds in
-        let t = remove_applicable_exn t first_cmd in
-        let t =
-          Sequence.fold dropped_cmds ~init:t
-            ~f:remove_all_by_fee_and_hash_and_expiration_exn
-        in
-        let t =
-          { t with all_by_sender = Map.remove t.all_by_sender fee_payer }
-        in
-        Ok (t, dropped_cmds)
-      else
-        let first_cmd_consumed =
-          (* safe since we checked this when we added it to the pool originally *)
-          Option.value_exn (currency_consumed ~constraint_constants first_cmd)
-        in
-        let currency_reserved' =
-          (* safe since the sum reserved must be >= reserved by any individual
-             command *)
-          Option.value_exn
-            Currency.Amount.(currency_reserved - first_cmd_consumed)
-        in
-        let t1 =
-          t
-          |> Fn.flip remove_applicable_exn first_cmd
-          |> Fn.flip remove_all_by_fee_and_hash_and_expiration_exn first_cmd
-        in
-        let new_queued_cmds, currency_reserved'', dropped_cmds =
-          (*removed the first cmd, check if there are anymore committed transactions from the fee payer*)
-          if Mina_base.Account.Nonce.(equal actual_target_nonce fee_payer_nonce)
-          then
-            (* remove user_commands that consume more currency than what the latest fee_payer_balance is*)
-            drop_until_sufficient_balance ~constraint_constants
-              (rest_cmds, currency_reserved')
-              fee_payer_balance
-          else
-            (* Don't check if the balance is sufficient, there are other committed user_commands in the pool from the current fee payer that has been accounted for in the fee_payer_balance*)
-            (rest_cmds, currency_reserved', Sequence.empty)
-        in
-        let t2 =
-          Sequence.fold dropped_cmds ~init:t1
-            ~f:remove_all_by_fee_and_hash_and_expiration_exn
-        in
-        let set_all_by_sender account_id commands currency_reserved t =
-          match F_sequence.uncons commands with
-          | None ->
-              { t with all_by_sender = Map.remove t.all_by_sender account_id }
-          | Some (head_cmd, _) ->
-              { t with
-                all_by_sender =
-                  Map.set t.all_by_sender ~key:account_id
-                    ~data:(commands, currency_reserved)
-              ; applicable_by_fee =
-                  Map_set.insert
-                    (module Transaction_hash.User_command_with_valid_signature)
-                    t.applicable_by_fee
-                    ( head_cmd
-                    |> Transaction_hash.User_command_with_valid_signature
-                       .command |> User_command.fee_per_wu )
-                    head_cmd
-              }
-        in
-        let t3 =
-          set_all_by_sender fee_payer new_queued_cmds currency_reserved'' t2
-        in
-        Ok
-          ( t3
-          , Sequence.append
-              ( if
-                Transaction_hash.User_command_with_valid_signature.equal
-                  committed first_cmd
-              then Sequence.empty
-              else Sequence.singleton first_cmd )
-              dropped_cmds )
 
 let remove_lowest_fee :
     t -> Transaction_hash.User_command_with_valid_signature.t Sequence.t * t =
@@ -1752,19 +1750,6 @@ let%test_module _ =
                 Account_nonce.compare replace_nonce cmd_nonce <= 0 )
             |> Option.value_exn
           in
-          let deprecated_replaced_idx =
-            Account_nonce.to_int
-              ( replace_cmd
-              |> Transaction_hash.User_command_with_valid_signature.command
-              |> User_command.applicable_at_nonce )
-            - Account_nonce.to_int
-                ( List.hd_exn setup_cmds
-                |> Transaction_hash.User_command_with_valid_signature.command
-                |> User_command.applicable_at_nonce )
-          in
-          Printf.printf
-            !"replacement indices: new=%d, old=%d\n%!"
-            replaced_idx deprecated_replaced_idx ;
           let currency_consumed_pre_replace =
             List.fold_left
               (List.take setup_cmds (replaced_idx + 1))
@@ -1885,121 +1870,287 @@ let%test_module _ =
       get_highest_fee pool |> Option.value_exn
       |> fun highest_fee -> assert (cmd_equal highest_fee max_by_fee_per_wu)
 
+    let dummy_state_view =
+      let state_body =
+        let consensus_constants =
+          let genesis_constants = Genesis_constants.for_unit_tests in
+          Consensus.Constants.create ~constraint_constants
+            ~protocol_constants:genesis_constants.protocol
+        in
+        let compile_time_genesis =
+          (*not using Precomputed_values.for_unit_test because of dependency cycle*)
+          Mina_state.Genesis_protocol_state.t
+            ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+            ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
+            ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
+            ~constraint_constants ~consensus_constants
+        in
+        compile_time_genesis.data |> Mina_state.Protocol_state.body
+      in
+      { (Mina_state.Protocol_state.Body.view state_body) with
+        global_slot_since_genesis = Mina_numbers.Global_slot.zero
+      }
+
+    let add_to_pool ~nonce ~balance pool cmd =
+      let _, pool', dropped =
+        add_from_gossip_exn pool (`Checked cmd) ~verify:don't_verify nonce
+          balance
+        |> Result.map_error
+             ~f:(Fn.compose Sexp.to_string Command_error.sexp_of_t)
+        |> Result.ok_or_failwith
+      in
+      [%test_eq:
+        Transaction_hash.User_command_with_valid_signature.t Sequence.t] dropped
+        Sequence.empty ;
+      assert_invariants pool' ;
+      pool'
+
+    let init_permissionless_ledger ledger account_info =
+      let open Currency in
+      let open Mina_ledger.Ledger.Ledger_inner in
+      List.iter account_info ~f:(fun (public_key, amount) ->
+          let account_id =
+            Account_id.create (Public_key.compress public_key) Token_id.default
+          in
+          let balance = Balance.of_int @@ Amount.to_int amount in
+          let _tag, account, location =
+            Or_error.ok_exn (get_or_create ledger account_id)
+          in
+          set ledger location
+            { account with balance; permissions = Permissions.empty } )
+
+    let apply_to_ledger ledger cmd =
+      match Transaction_hash.User_command_with_valid_signature.command cmd with
+      | User_command.Signed_command c ->
+          let (`If_this_is_used_it_should_have_a_comment_justifying_it v) =
+            Signed_command.to_valid_unsafe c
+          in
+          ignore
+            ( Mina_ledger.Ledger.apply_user_command ~constraint_constants
+                ~txn_global_slot:Mina_numbers.Global_slot.zero ledger v
+              |> Or_error.ok_exn
+              : Mina_transaction_logic.Transaction_applied
+                .Signed_command_applied
+                .t )
+      | User_command.Parties p -> (
+          let applied, _ =
+            Mina_ledger.Ledger.apply_parties_unchecked ~constraint_constants
+              ~state_view:dummy_state_view ledger p
+            |> Or_error.ok_exn
+          in
+          match With_status.status applied.command with
+          | Transaction_status.Applied ->
+              ()
+          | Transaction_status.Failed failure ->
+              failwithf "failed to apply parties transaction to ledger: [%s]"
+                ( String.concat ~sep:", "
+                @@ List.bind
+                     ~f:(List.map ~f:Transaction_status.Failure.to_string)
+                     failure )
+                () )
+
+    let commit_to_pool ledger pool cmd expected_drops =
+      apply_to_ledger ledger cmd ;
+      let accounts_to_check =
+        Transaction_hash.User_command_with_valid_signature.command cmd
+        |> User_command.accounts_accessed |> Account_id.Set.of_list
+      in
+      let pool, dropped =
+        revalidate pool (`Subset accounts_to_check) (fun sender ->
+            match Mina_ledger.Ledger.location_of_account ledger sender with
+            | None ->
+                (Account.Nonce.zero, Currency.Amount.zero)
+            | Some loc ->
+                let acc =
+                  Option.value_exn
+                    ~message:
+                      "Somehow a public key has a location but no account"
+                    (Mina_ledger.Ledger.get ledger loc)
+                in
+                ( acc.nonce
+                , Account.balance_at_slot
+                    ~global_slot:Mina_numbers.Global_slot.zero acc
+                  |> Currency.Balance.to_amount ) )
+      in
+      let lower =
+        List.map ~f:Transaction_hash.User_command_with_valid_signature.hash
+      in
+      [%test_eq: Transaction_hash.t list]
+        (lower (Sequence.to_list dropped))
+        (lower expected_drops) ;
+      (*
+      [%test_eq:
+        Transaction_hash.User_command_with_valid_signature.t list]
+        (Sequence.to_list dropped) (cmd :: expected_drops) ;
+      *)
+      assert_invariants pool ;
+      pool
+
+    let make_parties_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
+        ~double_increment_sender ~increment_receiver ~amount ~fee nonce_int =
+      let open Currency in
+      let nonce = Account.Nonce.of_int nonce_int in
+      let sender_pk = Public_key.compress sender.public_key in
+      let receiver_pk = Public_key.compress receiver.public_key in
+      let parties_wire : Parties.Stable.Latest.Wire.t =
+        { fee_payer =
+            { Party.Fee_payer.body =
+                { public_key = sender_pk; fee; nonce; valid_until = None }
+                (* Real signature added in below *)
+            ; authorization = Signature.dummy
+            }
+        ; other_parties =
+            Parties.Call_forest.of_parties_list ~party_depth:(Fn.const 0)
+              [ { Party.Wire.body =
+                    { public_key = sender_pk
+                    ; update = Party.Update.noop
+                    ; token_id = Token_id.default
+                    ; balance_change =
+                        Amount.Signed.(negate @@ of_unsigned amount)
+                    ; increment_nonce = double_increment_sender
+                    ; events = []
+                    ; sequence_events = []
+                    ; call_data = Snark_params.Tick.Field.zero
+                    ; preconditions =
+                        { Party.Preconditions.network =
+                            Zkapp_precondition.Protocol_state.accept
+                        ; account =
+                            Party.Account_precondition.Nonce
+                              (Account.Nonce.succ nonce)
+                        }
+                    ; caller = Call
+                    ; use_full_commitment = not double_increment_sender
+                    }
+                ; authorization = None_given
+                }
+              ; { Party.Wire.body =
+                    { public_key = receiver_pk
+                    ; update = Party.Update.noop
+                    ; token_id = Token_id.default
+                    ; balance_change = Amount.Signed.of_unsigned amount
+                    ; increment_nonce = increment_receiver
+                    ; events = []
+                    ; sequence_events = []
+                    ; call_data = Snark_params.Tick.Field.zero
+                    ; preconditions =
+                        { Party.Preconditions.network =
+                            Zkapp_precondition.Protocol_state.accept
+                        ; account = Party.Account_precondition.Accept
+                        }
+                    ; caller = Call
+                    ; use_full_commitment = not increment_receiver
+                    }
+                ; authorization = None_given
+                }
+              ]
+        ; memo = Signed_command_memo.empty
+        }
+      in
+      let parties = Parties.of_wire parties_wire in
+      (* We skip signing the commitment and updating the authorization as it is not necessary to have a valid transaction for these tests. *)
+      let (`If_this_is_used_it_should_have_a_comment_justifying_it cmd) =
+        User_command.to_valid_unsafe (User_command.Parties parties)
+      in
+      Transaction_hash.User_command_with_valid_signature.create cmd
+
     let%test_unit "support for parties commands" =
-      let open Mina_transaction_logic.For_tests in
+      let open Currency in
+      (* let open Mina_transaction_logic.For_tests in *)
       let fee = Mina_compile_config.minimum_user_command_fee in
-      let amount = Currency.(Amount.of_int @@ Fee.to_int fee) in
-      let balance = Option.value_exn (Currency.Amount.scale amount 100) in
+      let amount = Amount.of_int @@ Fee.to_int fee in
+      let balance = Option.value_exn (Amount.scale amount 100) in
       let kp1 =
         Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
       in
       let kp2 =
         Quickcheck.random_value ~seed:(`Deterministic "orange") Keypair.gen
       in
-      let pk2 = Public_key.compress kp2.public_key in
-      let add_to_pool cmd pool =
-        let _, pool', dropped =
-          add_from_gossip_exn pool (`Checked cmd) ~verify:don't_verify
-            Account_nonce.zero balance
-          |> Result.map_error
-               ~f:(Fn.compose Sexp.to_string Command_error.sexp_of_t)
-          |> Result.ok_or_failwith
-        in
-        [%test_eq:
-          Transaction_hash.User_command_with_valid_signature.t Sequence.t]
-          dropped Sequence.empty ;
-        assert_invariants pool' ;
-        pool'
-      in
-      let commit_to_pool cmd ~application_status ~fee_payer_balance
-          ~expected_drops pool =
-        let fee_payer_nonce =
-          User_command.expected_target_nonce
-          @@ Transaction_hash.User_command_with_valid_signature.command cmd
-        in
-        let pool, dropped =
-          handle_committed_txn pool cmd
-            ~application_status:(Some application_status) ~fee_payer_balance
-            ~fee_payer_nonce
-          |> Result.map_error ~f:(fun (`Queued_txns_by_sender (error, _)) ->
-                 error )
-          |> Result.ok_or_failwith
-        in
-        [%test_eq:
-          Transaction_hash.User_command_with_valid_signature.t Sequence.t]
-          dropped expected_drops ;
-        assert_invariants pool ;
-        pool
-      in
-      let make_cmd ~double_increment nonce =
-        let (`If_this_is_used_it_should_have_a_comment_justifying_it c) =
-          User_command.to_valid_unsafe
-            (User_command.Parties
-               (party_send ~use_full_commitment:(not double_increment)
-                  ~double_sender_nonce:false ~constraint_constants
-                  { fee
-                  ; sender = (kp1, Account_nonce.of_int nonce)
-                  ; receiver = pk2
-                  ; amount
-                  ; receiver_is_new = false
-                  } ) )
-        in
-        Transaction_hash.User_command_with_valid_signature.create c
-      in
-      let balance_after_cmd n =
-        Option.value_exn
-          Currency.Amount.(sub balance (scale amount n |> Option.value_exn))
+      let add_cmd = add_to_pool ~nonce:Account_nonce.zero ~balance in
+      let make_cmd =
+        make_parties_payment ~sender:kp1 ~receiver:kp2 ~increment_receiver:false
+          ~amount ~fee
       in
       Mina_ledger.Ledger.with_ledger ~depth:4 ~f:(fun ledger ->
-          Init_ledger.init
-            (module Mina_ledger.Ledger.Ledger_inner)
-            [| (kp1, Int64.(of_int @@ Currency.Amount.to_int balance))
-             ; (kp2, 0L)
-            |]
-            ledger ;
-          let cmd1 = make_cmd ~double_increment:false 0 in
-          let cmd2 = make_cmd ~double_increment:false 1 in
-          let cmd3 = make_cmd ~double_increment:false 2 in
-          let cmd4 = make_cmd ~double_increment:false 3 in
-          let cmd5 = make_cmd ~double_increment:false 4 in
-          let cmd6 = make_cmd ~double_increment:false 5 in
-          let cmd7 = make_cmd ~double_increment:false 6 in
+          init_permissionless_ledger ledger
+            [ (kp1.public_key, balance); (kp2.public_key, Amount.zero) ] ;
+          let commit = commit_to_pool ledger in
+          let cmd1 = make_cmd ~double_increment_sender:false 0 in
+          let cmd2 = make_cmd ~double_increment_sender:false 1 in
+          let cmd3 = make_cmd ~double_increment_sender:false 2 in
+          let cmd4 = make_cmd ~double_increment_sender:false 3 in
           (* used to break the sequence *)
-          (* same as cmd3. should not drop anything*)
-          let cmd3' = make_cmd ~double_increment:false 2 in
-          (*command with multiple fee payer increments but failed. Equivalent to one fee payer increment, drops cmd4 because it is a different command but keeps the rest*)
-          let cmd4_failed = make_cmd ~double_increment:true 3 in
-          (*command with multiple fee payer increments but applied. drops cmd5 because it is different and invalidates the rest of the queue*)
-          let cmd5' = make_cmd ~double_increment:true 4 in
-          ignore
-            ( empty |> add_to_pool cmd1 |> add_to_pool cmd2 |> add_to_pool cmd3
-              |> add_to_pool cmd4 |> add_to_pool cmd5 |> add_to_pool cmd6
-              |> add_to_pool cmd7
-              |> commit_to_pool cmd1 ~application_status:Applied
-                   ~fee_payer_balance:(balance_after_cmd 1)
-                   ~expected_drops:Sequence.empty
-              |> commit_to_pool cmd2 ~application_status:Applied
-                   ~fee_payer_balance:(balance_after_cmd 2)
-                   ~expected_drops:Sequence.empty
-              |> commit_to_pool cmd3' ~application_status:Applied
-                   ~fee_payer_balance:(balance_after_cmd 3)
-                   ~expected_drops:Sequence.empty
-              |> commit_to_pool cmd4_failed
-                   ~application_status:
-                     (Failed
-                        Transaction_status.Failure.(
-                          Collection.of_single_failure
-                            Update_not_permitted_balance) )
-                   ~fee_payer_balance:(balance_after_cmd 4)
-                   ~expected_drops:(Sequence.singleton cmd4)
-              |> commit_to_pool cmd5' ~application_status:Applied
-                   ~fee_payer_balance:(balance_after_cmd 5)
-                   ~expected_drops:(Sequence.of_list [ cmd5; cmd6; cmd7 ])
-              : t )
-          (*
-          |> apply_to_pool (balance_after_cmd 0) cmd1
-          |> apply_to_pool (balance_after_cmd 1) cmd2
-          |> apply_to_pool (balance_after_cmd 2) cmd3
-          |> apply_to_pool (balance_after_cmd 3) cmd4
-          *) )
+          let cmd3' = make_cmd ~double_increment_sender:true 2 in
+          let pool =
+            List.fold_left [ cmd1; cmd2; cmd3; cmd4 ] ~init:empty ~f:add_cmd
+          in
+          let pool = commit pool cmd1 [ cmd1 ] in
+          let pool = commit pool cmd2 [ cmd2 ] in
+          let _pool = commit pool cmd3' [ cmd3; cmd4 ] in
+          () )
+
+    let%test_unit "nonce increment side effects from other parties are handled \
+                   properly" =
+      let open Currency in
+      let fee = Mina_compile_config.minimum_user_command_fee in
+      let amount = Amount.of_int @@ Fee.to_int fee in
+      let balance = Option.value_exn (Amount.scale amount 100) in
+      let kp1 =
+        Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
+      in
+      let kp2 =
+        Quickcheck.random_value ~seed:(`Deterministic "orange") Keypair.gen
+      in
+      let add_cmd = add_to_pool ~nonce:Account_nonce.zero ~balance in
+      let make_cmd = make_parties_payment ~amount ~fee in
+      Mina_ledger.Ledger.with_ledger ~depth:4 ~f:(fun ledger ->
+          init_permissionless_ledger ledger
+            [ (kp1.public_key, balance); (kp2.public_key, balance) ] ;
+          let kp1_cmd1 =
+            make_cmd ~sender:kp1 ~receiver:kp2 ~double_increment_sender:false
+              ~increment_receiver:true 0
+          in
+          let kp2_cmd1 =
+            make_cmd ~sender:kp2 ~receiver:kp1 ~double_increment_sender:false
+              ~increment_receiver:false 0
+          in
+          let kp2_cmd2 =
+            make_cmd ~sender:kp2 ~receiver:kp1 ~double_increment_sender:false
+              ~increment_receiver:false 1
+          in
+          let pool =
+            List.fold_left
+              [ kp1_cmd1; kp2_cmd1; kp2_cmd2 ]
+              ~init:empty ~f:add_cmd
+          in
+          let _pool =
+            commit_to_pool ledger pool kp1_cmd1 [ kp2_cmd1; kp1_cmd1 ]
+          in
+          () )
+
+    let%test_unit "nonce invariant violations on committed transactions does \
+                   not trigger a crash" =
+      let open Currency in
+      let fee = Mina_compile_config.minimum_user_command_fee in
+      let amount = Amount.of_int @@ Fee.to_int fee in
+      let balance = Option.value_exn (Amount.scale amount 100) in
+      let kp1 =
+        Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
+      in
+      let kp2 =
+        Quickcheck.random_value ~seed:(`Deterministic "orange") Keypair.gen
+      in
+      let add_cmd = add_to_pool ~nonce:Account_nonce.zero ~balance in
+      let make_cmd =
+        make_parties_payment ~sender:kp1 ~receiver:kp2
+          ~double_increment_sender:false ~increment_receiver:false ~amount ~fee
+      in
+      Mina_ledger.Ledger.with_ledger ~depth:4 ~f:(fun ledger ->
+          init_permissionless_ledger ledger
+            [ (kp1.public_key, balance); (kp2.public_key, Amount.zero) ] ;
+          let cmd1 = make_cmd 0 in
+          let cmd2 = make_cmd 1 in
+          let pool = List.fold_left [ cmd1; cmd2 ] ~init:empty ~f:add_cmd in
+          apply_to_ledger ledger cmd1 ;
+          let _pool = commit_to_pool ledger pool cmd2 [ cmd1; cmd2 ] in
+          () )
   end )

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -84,7 +84,9 @@ val size : t -> int
 val min_fee : t -> Currency.Fee_rate.t option
 
 val transactions :
-  t -> Transaction_hash.User_command_with_valid_signature.t Sequence.t
+     logger:Logger.t
+  -> t
+  -> Transaction_hash.User_command_with_valid_signature.t Sequence.t
 
 (** Remove the command from the pool with the lowest fee per wu,
     along with any others from the same account with higher nonces. *)

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -173,6 +173,7 @@ val find_by_hash :
 *)
 val revalidate :
      t
+  -> logger:Logger.t
   -> [ `Entire_pool | `Subset of Account_id.Set.t ]
   -> (Account_id.t -> Account_nonce.t * Currency.Amount.t)
      (** Lookup an account in the new ledger *)

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -83,6 +83,9 @@ val size : t -> int
 (* The least fee per weight unit of all transactions in the transaction pool *)
 val min_fee : t -> Currency.Fee_rate.t option
 
+val transactions :
+  t -> Transaction_hash.User_command_with_valid_signature.t Sequence.t
+
 (** Remove the command from the pool with the lowest fee per wu,
     along with any others from the same account with higher nonces. *)
 val remove_lowest_fee :
@@ -95,26 +98,6 @@ val remove_expired :
 (** Get the applicable command in the pool with the highest fee per wu *)
 val get_highest_fee :
   t -> Transaction_hash.User_command_with_valid_signature.t option
-
-(** Call this when a transaction is added to the best tip or when generating a
-    sequence of transactions to apply. This will drop any transactions at that
-    nonce from the pool. May also drop queued commands for that sender if there
-    was a different queued transaction from that sender at that nonce, and the
-    committed one consumes more currency than the queued one. In that case it'll
-    return the dropped ones in the sequence, including the one with the same
-    nonce as the committed one if it's different.
-*)
-val handle_committed_txn :
-     t
-  -> Transaction_hash.User_command_with_valid_signature.t
-  -> application_status:Transaction_status.t option
-  -> fee_payer_balance:Currency.Amount.t
-  -> fee_payer_nonce:Mina_base.Account.Nonce.t
-  -> ( t * Transaction_hash.User_command_with_valid_signature.t Sequence.t
-     , [ `Queued_txns_by_sender of
-         string
-         * Transaction_hash.User_command_with_valid_signature.t Sequence.t ] )
-     Result.t
 
 (** Add a command to the pool. Pass the current nonce for the account and
     its current balance. Throws if the contents of the pool before adding the
@@ -190,6 +173,7 @@ val find_by_hash :
 *)
 val revalidate :
      t
+  -> [ `Entire_pool | `Subset of Account_id.Set.t ]
   -> (Account_id.t -> Account_nonce.t * Currency.Amount.t)
      (** Lookup an account in the new ledger *)
   -> t * Transaction_hash.User_command_with_valid_signature.t Sequence.t

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -347,9 +347,7 @@ module type Transaction_resource_pool_intf = sig
   val member : t -> Transaction_hash.User_command_with_valid_signature.t -> bool
 
   val transactions :
-       logger:Logger.t
-    -> t
-    -> Transaction_hash.User_command_with_valid_signature.t Sequence.t
+    t -> Transaction_hash.User_command_with_valid_signature.t Sequence.t
 
   val all_from_account :
        t

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -4,7 +4,7 @@
 *)
 
 (* Only show stdout for failed inline tests.*)
-(*open Inline_test_quiet_logs*)
+open Inline_test_quiet_logs
 open Core
 open Async
 open Mina_base

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1693,6 +1693,7 @@ let%test_module _ =
             ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
             ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
             ~constraint_constants ~consensus_constants
+            ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
         in
         compile_time_genesis.data |> Mina_state.Protocol_state.body
       in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -358,7 +358,7 @@ struct
     let member t x =
       Indexed_pool.member t.pool (Transaction_hash.User_command.of_checked x)
 
-    let transactions t = Indexed_pool.transactions t.pool
+    let transactions t = Indexed_pool.transactions ~logger:t.logger t.pool
 
     let all_from_account { pool; _ } = Indexed_pool.all_from_account pool
 

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -4,13 +4,12 @@
 *)
 
 (* Only show stdout for failed inline tests.*)
-open Inline_test_quiet_logs
+(*open Inline_test_quiet_logs*)
 open Core
 open Async
 open Mina_base
 open Mina_transaction
 open Pipe_lib
-open Signature_lib
 open Network_peer
 
 let max_per_15_seconds = 10
@@ -359,45 +358,7 @@ struct
     let member t x =
       Indexed_pool.member t.pool (Transaction_hash.User_command.of_checked x)
 
-    let transactions' ~logger p =
-      Sequence.unfold ~init:p ~f:(fun pool ->
-          match Indexed_pool.get_highest_fee pool with
-          | Some cmd -> (
-              match
-                Indexed_pool.handle_committed_txn pool cmd
-                  ~application_status:None
-                    (* we have the invariant that the transactions currently
-                       in the pool are always valid against the best tip, so
-                       no need to check balances here *)
-                  ~fee_payer_balance:Currency.Amount.max_int
-                  ~fee_payer_nonce:
-                    ( Transaction_hash.User_command_with_valid_signature.command
-                        cmd
-                    |> User_command.applicable_at_nonce )
-              with
-              | Ok (t, _) ->
-                  Some (cmd, t)
-              | Error (`Queued_txns_by_sender (error_str, queued_cmds)) ->
-                  [%log error]
-                    "Error handling committed transaction $cmd: $error "
-                    ~metadata:
-                      [ ( "cmd"
-                        , Transaction_hash.User_command_with_valid_signature
-                          .to_yojson cmd )
-                      ; ("error", `String error_str)
-                      ; ( "queue"
-                        , `List
-                            (List.map (Sequence.to_list queued_cmds)
-                               ~f:(fun c ->
-                                 Transaction_hash
-                                 .User_command_with_valid_signature
-                                 .to_yojson c ) ) )
-                      ] ;
-                  failwith error_str )
-          | None ->
-              None )
-
-    let transactions ~logger t = transactions' ~logger t.pool
+    let transactions t = Indexed_pool.transactions t.pool
 
     let all_from_account { pool; _ } = Indexed_pool.all_from_account pool
 
@@ -497,24 +458,6 @@ struct
           (diff_error_of_indexed_pool_error e)
       , indexed_pool_error_metadata e )
 
-    let balance_of_account ~global_slot (account : Account.t) =
-      match account.timing with
-      | Untimed ->
-          account.balance
-      | Timed
-          { initial_minimum_balance
-          ; cliff_time
-          ; cliff_amount
-          ; vesting_period
-          ; vesting_increment
-          } ->
-          Currency.Balance.sub_amount account.balance
-            (Currency.Balance.to_amount
-               (Account.min_balance_at_slot ~global_slot ~cliff_time
-                  ~cliff_amount ~vesting_period ~vesting_increment
-                  ~initial_minimum_balance ) )
-          |> Option.value ~default:Currency.Balance.zero
-
     let handle_transition_frontier_diff
         ( ({ new_commands; removed_commands; reorg_best_tip = _ } :
             Transition_frontier.best_tip_diff )
@@ -607,90 +550,95 @@ struct
                        Transaction_hash.User_command_with_valid_signature
                        .to_yojson locally_generated_dropped ) )
             ] ;
-      let pool'', dropped_commit_conflicts =
-        List.fold new_commands ~init:(pool', Sequence.empty)
-          ~f:(fun (p, dropped_so_far) cmd ->
-            let balance account_id =
-              match
-                Base_ledger.location_of_account best_tip_ledger account_id
-              with
-              | None ->
-                  (Currency.Amount.zero, Mina_base.Account.Nonce.zero)
-              | Some loc ->
-                  let acc =
-                    Option.value_exn
-                      ~message:"public key has location but no account"
-                      (Base_ledger.get best_tip_ledger loc)
-                  in
-                  ( Currency.Balance.to_amount
-                      (balance_of_account ~global_slot acc)
-                  , acc.nonce )
+      let pool'', dropped_commands =
+        let accounts_to_check =
+          List.fold (new_commands @ removed_commands) ~init:Account_id.Set.empty
+            ~f:(fun set cmd ->
+              let set' =
+                With_status.data cmd |> User_command.forget_check
+                |> User_command.accounts_accessed |> Account_id.Set.of_list
+              in
+              Set.union set set' )
+        in
+        let get_account =
+          let empty_state = (Account.Nonce.zero, Currency.Amount.zero) in
+          let existing_account_states_by_id =
+            (* TODO: it occurs to me that this batch logic is duplicated during the staged ledger apply... we should try and share data *)
+            let existing_account_ids, existing_account_locs =
+              Set.to_list accounts_to_check
+              |> Base_ledger.location_of_account_batch best_tip_ledger
+              |> List.filter_map ~f:(function
+                   | id, Some loc ->
+                       Some (id, loc)
+                   | _, None ->
+                       None )
+              |> List.unzip
             in
-            let fee_payer = User_command.(fee_payer (forget_check cmd.data)) in
-            let fee_payer_balance, fee_payer_nonce = balance fee_payer in
-            let cmd' =
-              Transaction_hash.User_command_with_valid_signature.create cmd.data
-            in
-            ( match
-                Hashtbl.find_and_remove t.locally_generated_uncommitted cmd'
-              with
+            Base_ledger.get_batch best_tip_ledger existing_account_locs
+            |> List.map ~f:snd
+            |> List.zip_exn existing_account_ids
+            |> List.fold ~init:Account_id.Map.empty
+                 ~f:(fun map (id, maybe_account) ->
+                   let account =
+                     Option.value_exn maybe_account
+                       ~message:
+                         "Somehow a public key has a location but no account"
+                   in
+                   Map.add_exn map ~key:id
+                     ~data:
+                       ( account.nonce
+                       , Currency.Amount.of_uint64
+                         @@ Currency.Balance.to_uint64 account.balance ) )
+          in
+          fun id ->
+            match Map.find existing_account_states_by_id id with
+            | Some state ->
+                state
             | None ->
-                ()
-            | Some time_added ->
-                [%log' info t.logger]
-                  "Locally generated command $cmd committed in a block!"
-                  ~metadata:
-                    [ ( "cmd"
-                      , With_status.to_yojson User_command.Valid.to_yojson cmd
-                      )
-                    ] ;
-                Hashtbl.add_exn t.locally_generated_committed ~key:cmd'
-                  ~data:time_added ) ;
-            let p', dropped =
-              match
-                Indexed_pool.handle_committed_txn p cmd'
-                  ~application_status:(Some cmd.status) ~fee_payer_balance
-                  ~fee_payer_nonce
-              with
-              | Ok res ->
-                  res
-              | Error (`Queued_txns_by_sender (error_str, queued_cmds)) ->
-                  [%log' error t.logger]
-                    "Error handling committed transaction $cmd: $error "
-                    ~metadata:
-                      [ ( "cmd"
-                        , With_status.to_yojson User_command.Valid.to_yojson cmd
-                        )
-                      ; ("error", `String error_str)
-                      ; ( "queue"
-                        , `List
-                            (List.map (Sequence.to_list queued_cmds)
-                               ~f:(fun c ->
-                                 Transaction_hash
-                                 .User_command_with_valid_signature
-                                 .to_yojson c ) ) )
-                      ] ;
-                  failwith error_str
-            in
-            (p', Sequence.append dropped_so_far dropped) )
+                if Set.mem accounts_to_check id then empty_state
+                else
+                  failwith
+                    "did not expect Indexed_pool.revalidate to call \
+                     get_account on account not in accounts_to_check"
+        in
+        Indexed_pool.revalidate pool' (`Subset accounts_to_check) get_account
       in
+      let committed_commands, dropped_commit_conflicts =
+        let command_hashes =
+          List.fold_left new_commands ~init:Transaction_hash.Set.empty
+            ~f:(fun set cmd ->
+              let cmd_hash =
+                With_status.data cmd
+                |> Transaction_hash.User_command_with_valid_signature.create
+                |> Transaction_hash.User_command_with_valid_signature.hash
+              in
+              Set.add set cmd_hash )
+        in
+        Sequence.to_list dropped_commands
+        |> List.partition_tf ~f:(fun cmd ->
+               Set.mem command_hashes
+                 (Transaction_hash.User_command_with_valid_signature.hash cmd) )
+      in
+      List.iter committed_commands ~f:(fun cmd ->
+          Hashtbl.find_and_remove t.locally_generated_uncommitted cmd
+          |> Option.iter ~f:(fun data ->
+                 Hashtbl.add_exn t.locally_generated_committed ~key:cmd ~data ) ) ;
       let commit_conflicts_locally_generated =
-        Sequence.filter dropped_commit_conflicts ~f:(fun cmd ->
+        List.filter dropped_commit_conflicts ~f:(fun cmd ->
             Hashtbl.find_and_remove t.locally_generated_uncommitted cmd
             |> Option.is_some )
       in
-      if not @@ Sequence.is_empty commit_conflicts_locally_generated then
+      if not @@ List.is_empty commit_conflicts_locally_generated then
         [%log' info t.logger]
           "Locally generated commands $cmds dropped because they conflicted \
            with a committed command."
           ~metadata:
             [ ( "cmds"
               , `List
-                  (Sequence.to_list
-                     (Sequence.map commit_conflicts_locally_generated
-                        ~f:
-                          Transaction_hash.User_command_with_valid_signature
-                          .to_yojson ) ) )
+                  (List.map commit_conflicts_locally_generated
+                     ~f:
+                       Transaction_hash.User_command_with_valid_signature
+                       .to_yojson ) )
             ] ;
       [%log' debug t.logger]
         !"Finished handling diff. Old pool size %i, new pool size %i. Dropped \
@@ -746,7 +694,7 @@ struct
                     Indexed_pool.add_from_gossip_exn t.pool (`Checked cmd)
                       acct.nonce
                       ~verify:(fun _ -> assert false)
-                      ( balance_of_account ~global_slot acct
+                      ( Account.balance_at_slot ~global_slot acct
                       |> Currency.Balance.to_amount )
                   with
                   | Error e ->
@@ -853,7 +801,7 @@ struct
                    Indexed_pool.global_slot_since_genesis t.pool
                  in
                  let new_pool, dropped =
-                   Indexed_pool.revalidate t.pool (fun sender ->
+                   Indexed_pool.revalidate t.pool `Entire_pool (fun sender ->
                        match
                          Base_ledger.location_of_account validation_ledger
                            sender
@@ -869,7 +817,7 @@ struct
                                (Base_ledger.get validation_ledger loc)
                            in
                            ( acc.nonce
-                           , balance_of_account ~global_slot acc
+                           , Account.balance_at_slot ~global_slot acc
                              |> Currency.Balance.to_amount ) )
                  in
                  let dropped_locally_generated =
@@ -1317,7 +1265,7 @@ struct
                                           , c ) )
                                         account.nonce
                                         (Currency.Balance.to_amount
-                                           (balance_of_account ~global_slot
+                                           (Account.balance_at_slot ~global_slot
                                               account ) )
                                     with
                                     | Error e -> (
@@ -1686,8 +1634,13 @@ include
 
 let%test_module _ =
   ( module struct
+    open Signature_lib
     module Mock_base_ledger = Mocks.Base_ledger
     module Mock_staged_ledger = Mocks.Staged_ledger
+
+    let () =
+      Core.Backtrace.elide := false ;
+      Async.Scheduler.set_record_backtraces true
 
     let num_test_keys = 10
 
@@ -1709,7 +1662,7 @@ let%test_module _ =
 
     let proof_level = precomputed_values.proof_level
 
-    let logger = Logger.null ()
+    let logger = Logger.create ()
 
     let time_controller = Block_time.Controller.basic ~logger
 
@@ -1725,6 +1678,27 @@ let%test_module _ =
 
     let `VK vk, `Prover prover =
       Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()
+
+    let dummy_state_view =
+      let state_body =
+        let consensus_constants =
+          let genesis_constants = Genesis_constants.for_unit_tests in
+          Consensus.Constants.create ~constraint_constants
+            ~protocol_constants:genesis_constants.protocol
+        in
+        let compile_time_genesis =
+          (*not using Precomputed_values.for_unit_test because of dependency cycle*)
+          Mina_state.Genesis_protocol_state.t
+            ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+            ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
+            ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
+            ~constraint_constants ~consensus_constants
+        in
+        compile_time_genesis.data |> Mina_state.Protocol_state.body
+      in
+      { (Mina_state.Protocol_state.Body.view state_body) with
+        global_slot_since_genesis = Mina_numbers.Global_slot.zero
+      }
 
     module Mock_transition_frontier = struct
       module Breadcrumb = struct
@@ -1743,33 +1717,40 @@ let%test_module _ =
 
       let create : unit -> t * best_tip_diff Broadcast_pipe.Writer.t =
        fun () ->
-        let pipe_r, pipe_w =
-          Broadcast_pipe.create
-            { new_commands = []; removed_commands = []; reorg_best_tip = false }
-        in
-        let accounts =
-          List.map (Array.to_list test_keys) ~f:(fun kp ->
-              let compressed = Public_key.compress kp.public_key in
-              let account_id = Account_id.create compressed Token_id.default in
-              ( account_id
-              , Account.create account_id
-                @@ Currency.Balance.of_formatted_string "900000000.0" ) )
-        in
         let zkappify_account (account : Account.t) : Account.t =
           let zkapp =
             Some { Zkapp_account.default with verification_key = Some vk }
           in
           { account with zkapp }
         in
-        let accounts =
-          List.mapi accounts ~f:(fun ndx (account_id, account) ->
-              if ndx mod 2 = 0 then (account_id, account)
-              else (account_id, zkappify_account account) )
+        let pipe_r, pipe_w =
+          Broadcast_pipe.create
+            { new_commands = []; removed_commands = []; reorg_best_tip = false }
         in
-        let ledger = Account_id.Table.of_alist_exn accounts in
+        let initial_balance =
+          Currency.Balance.of_formatted_string "900000000.0"
+        in
+        let ledger = Mina_ledger.Ledger.create_ephemeral ~depth:10 () in
+        Array.iteri test_keys ~f:(fun i kp ->
+            let account_id =
+              Account_id.create
+                (Public_key.compress kp.public_key)
+                Token_id.default
+            in
+            let _tag, account, loc =
+              Or_error.ok_exn
+              @@ Mina_ledger.Ledger.Ledger_inner.get_or_create ledger account_id
+            in
+            (* set the account balance *)
+            let account = { account with balance = initial_balance } in
+            (* zkappify every other account *)
+            let account =
+              if i mod 2 = 0 then account else zkappify_account account
+            in
+            Mina_ledger.Ledger.Ledger_inner.set ledger loc account ) ;
         ((pipe_r, ref ledger), pipe_w)
 
-      let best_tip (_, best_tip_ref) = !best_tip_ref
+      let best_tip (_, best_tip) = !best_tip
 
       let best_tip_diff_pipe (pipe, _) = pipe
     end
@@ -1777,24 +1758,50 @@ let%test_module _ =
     module Test =
       Make0 (Mock_base_ledger) (Mock_staged_ledger) (Mock_transition_frontier)
 
+    type test =
+      { txn_pool : Test.Resource_pool.t
+      ; best_tip_diff_w :
+          Mock_transition_frontier.best_tip_diff Broadcast_pipe.Writer.t
+      ; best_tip_ref : Mina_ledger.Ledger.t ref
+      ; frontier_pipe_w :
+          Mock_transition_frontier.t option Broadcast_pipe.Writer.t
+      }
+
     let pool_max_size = 25
 
-    let () =
-      Core.Backtrace.elide := false ;
-      Async.Scheduler.set_record_backtraces true
-
-    let replace_parties_authorizations ~keymap cmds =
-      Deferred.List.map
-        (cmds : User_command.t list)
-        ~f:(function
-          | Parties parties_dummy_auths ->
-              let%map parties =
-                Parties_builder.replace_authorizations ~keymap ~prover
-                  parties_dummy_auths
-              in
-              User_command.Parties parties
-          | Signed_command _ ->
-              failwith "Expected Parties user command" )
+    let assert_user_command_sets_equal cs1 cs2 =
+      let index cs =
+        let decompose c =
+          ( Transaction_hash.User_command.hash c
+          , Transaction_hash.User_command.command c )
+        in
+        List.map cs ~f:decompose |> Transaction_hash.Map.of_alist_exn
+      in
+      let index1 = index cs1 in
+      let index2 = index cs2 in
+      let set1 = Transaction_hash.Set.of_list @@ Map.keys index1 in
+      let set2 = Transaction_hash.Set.of_list @@ Map.keys index2 in
+      if not (Set.equal set1 set2) then (
+        let additional1, additional2 =
+          Set.symmetric_diff set1 set2
+          |> Sequence.map
+               ~f:
+                 (Either.map ~first:(Map.find_exn index1)
+                    ~second:(Map.find_exn index2) )
+          |> Sequence.to_list
+          |> List.partition_map ~f:Fn.id
+        in
+        assert (List.length additional1 + List.length additional2 > 0) ;
+        let report_additional commands a b =
+          Core.Printf.printf "%s user commands not in %s:\n" a b ;
+          List.iter commands ~f:(fun c ->
+              Core.Printf.printf !"  %{Sexp}\n" (User_command.sexp_of_t c) )
+        in
+        if List.length additional1 > 0 then
+          report_additional additional1 "actual" "expected" ;
+        if List.length additional2 > 0 then
+          report_additional additional2 "expected" "actual" ) ;
+      [%test_eq: Transaction_hash.Set.t] set1 set2
 
     let replace_valid_parties_authorizations ~keymap ~ledger valid_cmds :
         User_command.Valid.t list Deferred.t =
@@ -1849,9 +1856,7 @@ let%test_module _ =
             Hashtbl.t )
 
     let assert_fee_wu_ordering (pool : Test.Resource_pool.t) =
-      let txns =
-        Test.Resource_pool.transactions pool ~logger |> Sequence.to_list
-      in
+      let txns = Test.Resource_pool.transactions pool |> Sequence.to_list in
       let compare txn1 txn2 =
         let open Transaction_hash.User_command_with_valid_signature in
         let cmd1 = command txn1 in
@@ -1872,9 +1877,26 @@ let%test_module _ =
       in
       assert (List.is_sorted txns ~compare)
 
+    let assert_pool_txs test txs =
+      Indexed_pool.For_tests.assert_invariants test.txn_pool.pool ;
+      assert_locally_generated test.txn_pool ;
+      assert_fee_wu_ordering test.txn_pool ;
+      assert_user_command_sets_equal
+        ( Sequence.to_list
+        @@ Sequence.map ~f:Transaction_hash.User_command.of_checked
+        @@ Test.Resource_pool.transactions test.txn_pool )
+        (List.map
+           ~f:
+             (Fn.compose Transaction_hash.User_command.create
+                User_command.forget_check )
+           txs )
+
     let setup_test ?expiry () =
-      let tf, best_tip_diff_w = Mock_transition_frontier.create () in
-      let tf_pipe_r, _tf_pipe_w = Broadcast_pipe.create @@ Some tf in
+      let frontier, best_tip_diff_w = Mock_transition_frontier.create () in
+      let _, best_tip_ref = frontier in
+      let frontier_pipe_r, frontier_pipe_w =
+        Broadcast_pipe.create @@ Some frontier
+      in
       let trust_system = Trust_system.null () in
       let config =
         Test.Resource_pool.make_config ~trust_system ~pool_max_size ~verifier
@@ -1882,25 +1904,12 @@ let%test_module _ =
       let expiry_ns = match expiry with None -> expiry_ns | Some t -> t in
       let pool_, _, _ =
         Test.create ~config ~logger ~constraint_constants ~consensus_constants
-          ~time_controller ~expiry_ns ~frontier_broadcast_pipe:tf_pipe_r
+          ~time_controller ~expiry_ns ~frontier_broadcast_pipe:frontier_pipe_r
           ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
       in
-      let pool = Test.resource_pool pool_ in
-      let%map () = Async.Scheduler.yield () in
-      ( (fun txs ->
-          Indexed_pool.For_tests.assert_invariants pool.pool ;
-          assert_locally_generated pool ;
-          assert_fee_wu_ordering pool ;
-          [%test_eq: User_command.t List.t]
-            ( Test.Resource_pool.transactions ~logger pool
-            |> Sequence.map
-                 ~f:Transaction_hash.User_command_with_valid_signature.command
-            |> Sequence.to_list
-            |> List.sort ~compare:User_command.compare )
-            (List.sort ~compare:User_command.compare txs) )
-      , pool
-      , best_tip_diff_w
-      , tf )
+      let txn_pool = Test.resource_pool pool_ in
+      let%map () = Async.Scheduler.yield_until_no_jobs_remain () in
+      { txn_pool; best_tip_diff_w; best_tip_ref; frontier_pipe_w }
 
     let independent_cmds : User_command.Valid.t list =
       let rec go n cmds =
@@ -1918,258 +1927,6 @@ let%test_module _ =
         else Quickcheck.Generator.return @@ List.rev cmds
       in
       Quickcheck.random_value ~seed:(`Deterministic "constant") (go 0 [])
-
-    let independent_cmds' : User_command.t list =
-      List.map independent_cmds ~f:User_command.forget_check
-
-    let mk_parties_cmds (pool : Test.Resource_pool.t) :
-        Mina_ledger.Ledger.t
-        * Private_key.t Public_key.Compressed.Map.t
-        * User_command.Valid.t list =
-      let best_tip_ledger = Option.value_exn pool.best_tip_ledger in
-      let mk_ledger () =
-        (* the Snapp generators want a Ledger.t, these tests have Base_ledger.t map, so
-           we build the Ledger.t from the map
-        *)
-        let ledger =
-          Mina_ledger.Ledger.create
-            ~depth:precomputed_values.constraint_constants.ledger_depth ()
-        in
-        Account_id.Table.iteri best_tip_ledger
-          ~f:(fun ~key:acct_id ~data:acct ->
-            match
-              Mina_ledger.Ledger.get_or_create_account ledger acct_id acct
-            with
-            | Error err ->
-                failwithf
-                  "mk_parties_cmds: error adding account for account id: %s, \
-                   error: %s@."
-                  (Account_id.to_yojson acct_id |> Yojson.Safe.to_string)
-                  (Error.to_string_hum err) ()
-            | Ok (`Existed, _) ->
-                failwithf
-                  "mk_parties_cmds: account for account id already exists: %s@."
-                  (Account_id.to_yojson acct_id |> Yojson.Safe.to_string)
-                  ()
-            | Ok (`Added, _) ->
-                () ) ;
-        ledger
-      in
-      let keymap =
-        Array.fold (Array.append test_keys extra_keys)
-          ~init:Public_key.Compressed.Map.empty
-          ~f:(fun map { public_key; private_key } ->
-            let key = Public_key.compress public_key in
-            Public_key.Compressed.Map.add_exn map ~key ~data:private_key )
-      in
-      let ledger = mk_ledger () in
-      let rec go n cmds =
-        let open Quickcheck.Generator.Let_syntax in
-        if n < Array.length test_keys / 2 then
-          let%bind cmd =
-            let fee_payer_keypair = test_keys.(n) in
-            let%map (parties_dummy_auths : Parties.t) =
-              Mina_generators.Parties_generators.gen_parties_from ~keymap
-                ~fee_payer_keypair ~ledger ()
-            in
-            let parties =
-              Option.value_exn
-                (Parties.Valid.to_valid ~ledger ~get:Mina_ledger.Ledger.get
-                   ~location_of_account:Mina_ledger.Ledger.location_of_account
-                   parties_dummy_auths )
-            in
-            User_command.Parties parties
-          in
-          go (n + 1) (cmd :: cmds)
-        else Quickcheck.Generator.return @@ List.rev cmds
-      in
-      let result =
-        Quickcheck.random_value ~seed:(`Deterministic "parties") (go 0 [])
-      in
-      (ledger, keymap, result)
-
-    let mk_parties_cmds' (pool : Test.Resource_pool.t) :
-        Private_key.t Public_key.Compressed.Map.t * User_command.t list =
-      let _ledger, keymap, cmds = mk_parties_cmds pool in
-      (* don't need to return the ledger, which is needed to re-validate Parties.t after
-         replacing authorizations; unlike mk_parties_cmds, the returned commands are not
-         User_command.Valid.t's
-      *)
-      (keymap, List.map cmds ~f:User_command.forget_check)
-
-    type pool_apply = (User_command.t list, [ `Other of Error.t ]) Result.t
-    [@@deriving sexp, compare]
-
-    let canonicalize t =
-      Result.map t ~f:(List.sort ~compare:User_command.compare)
-
-    let compare_pool_apply (t1 : pool_apply) (t2 : pool_apply) =
-      compare_pool_apply (canonicalize t1) (canonicalize t2)
-
-    let accepted_commands = Result.map ~f:fst
-
-    let mk_with_status (cmd : User_command.Valid.t) =
-      { With_status.data = cmd; status = Applied }
-
-    let verify_and_apply (pool : Test.Resource_pool.t) cs =
-      let tm0 = Time.now () in
-      let%bind verified =
-        Test.Resource_pool.Diff.verify' ~allow_failures_for_tests:true pool
-          (Envelope.Incoming.local cs)
-        >>| Or_error.ok_exn
-      in
-      let result = Test.Resource_pool.Diff.unsafe_apply pool verified in
-      let tm1 = Time.now () in
-      [%log' info pool.logger] "Time for verify_and_apply: %0.04f sec"
-        (Time.diff tm1 tm0 |> Time.Span.to_sec) ;
-      result
-
-    let mk_linear_case_test assert_pool_txs pool best_tip_diff_w cmds =
-      assert_pool_txs [] ;
-      let%bind apply_res = verify_and_apply pool cmds in
-      [%test_eq: pool_apply] (accepted_commands apply_res) (Ok cmds) ;
-      assert_pool_txs cmds ;
-      let%bind () =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands = [ mk_with_status (List.hd_exn independent_cmds) ]
-            ; removed_commands = []
-            ; reorg_best_tip = false
-            }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-      assert_pool_txs (List.tl_exn cmds) ;
-      let%bind () =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          { new_commands =
-              List.map ~f:mk_with_status
-                (List.take (List.tl_exn independent_cmds) 2)
-          ; removed_commands = []
-          ; reorg_best_tip = false
-          }
-      in
-      let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-      assert_pool_txs (List.drop cmds 3) ;
-      Deferred.unit
-
-    let%test_unit "transactions are removed in linear case (user cmds)" =
-      Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, _frontier =
-            setup_test ()
-          in
-          mk_linear_case_test assert_pool_txs pool best_tip_diff_w
-            independent_cmds' )
-
-    let%test_unit "transactions are removed in linear case (zkapps)" =
-      Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, _frontier =
-            setup_test ()
-          in
-          let keymap, parties_dummy_auths = mk_parties_cmds' pool in
-          let%bind parties =
-            replace_parties_authorizations ~keymap parties_dummy_auths
-          in
-          mk_linear_case_test assert_pool_txs pool best_tip_diff_w parties )
-
-    let modify_ledger ~best_tip_ledger ~idx ~balance ~nonce =
-      let acct_id =
-        Account_id.create
-          (Signature_lib.Public_key.compress test_keys.(idx).public_key)
-          Token_id.default
-      in
-      Account_id.Table.update best_tip_ledger acct_id ~f:(function
-        | None ->
-            failwith "modify_ledger: fail to find the account"
-        | Some account ->
-            ( { account with
-                balance = Currency.Balance.of_int balance
-              ; nonce = Account.Nonce.of_int nonce
-              }
-              : Account.t ) )
-
-    let mk_remove_and_add_test assert_pool_txs pool best_tip_diff_w best_tip_ref
-        valid_cmds =
-      let cmds' = List.map valid_cmds ~f:User_command.forget_check in
-      assert_pool_txs [] ;
-      (* omit the 1st (0-based) command *)
-      let cmds_to_apply = List.hd_exn cmds' :: List.drop cmds' 2 in
-      let%bind apply_res = verify_and_apply pool cmds_to_apply in
-      [%test_eq: pool_apply] (accepted_commands apply_res) (Ok cmds_to_apply) ;
-      modify_ledger ~best_tip_ledger:!best_tip_ref ~idx:1
-        ~balance:1_000_000_000_000 ~nonce:1 ;
-      let%bind () =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands = List.map ~f:mk_with_status @@ List.take valid_cmds 1
-            ; removed_commands =
-                List.map ~f:mk_with_status @@ [ List.nth_exn valid_cmds 1 ]
-            ; reorg_best_tip = true
-            }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      assert_pool_txs (List.tl_exn cmds') ;
-      Deferred.unit
-
-    let%test_unit "Transactions are removed and added back in fork changes \
-                   (user cmds)" =
-      Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref) =
-            setup_test ()
-          in
-          mk_remove_and_add_test assert_pool_txs pool best_tip_diff_w
-            best_tip_ref independent_cmds )
-
-    let%test_unit "Transactions are removed and added back in fork changes \
-                   (zkapps)" =
-      Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref) =
-            setup_test ()
-          in
-          let ledger, keymap, parties_dummy_auths = mk_parties_cmds pool in
-          let%bind parties =
-            replace_valid_parties_authorizations ~keymap ~ledger
-              parties_dummy_auths
-          in
-          mk_remove_and_add_test assert_pool_txs pool best_tip_diff_w
-            best_tip_ref parties )
-
-    let mk_invalid_test assert_pool_txs pool best_tip_diff_w best_tip_ref cmds'
-        =
-      assert_pool_txs [] ;
-      modify_ledger ~best_tip_ledger:!best_tip_ref ~idx:0 ~balance:0 ~nonce:0 ;
-      modify_ledger ~best_tip_ledger:!best_tip_ref ~idx:1
-        ~balance:1_000_000_000_000 ~nonce:1 ;
-      (* need a best tip diff so the ref is actually read *)
-      let%bind _ =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands = []; removed_commands = []; reorg_best_tip = false }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      let%bind apply_res = verify_and_apply pool cmds' in
-      [%test_eq: pool_apply]
-        (Ok (List.drop cmds' 2))
-        (accepted_commands apply_res) ;
-      assert_pool_txs (List.drop cmds' 2) ;
-      Deferred.unit
-
-    let%test_unit "invalid transactions are not accepted (user cmds)" =
-      Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref) =
-            setup_test ()
-          in
-          mk_invalid_test assert_pool_txs pool best_tip_diff_w best_tip_ref
-            independent_cmds' )
-
-    let%test_unit "invalid transactions are not accepted (zkapps)" =
-      Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref) =
-            setup_test ()
-          in
-          let keymap, parties_dummy_auths = mk_parties_cmds' pool in
-          let%bind parties =
-            replace_parties_authorizations ~keymap parties_dummy_auths
-          in
-          mk_invalid_test assert_pool_txs pool best_tip_diff_w best_tip_ref
-            parties )
 
     let mk_payment' ?valid_until ~sender_idx ~receiver_idx ~fee ~nonce ~amount
         () =
@@ -2230,7 +1987,11 @@ let%test_module _ =
         ; preconditions =
             Some
               { Party.Preconditions.network = protocol_state_precondition
-              ; account = Party.Account_precondition.Accept
+              ; account =
+                  Party.Account_precondition.Nonce
+                    ( if Option.is_none fee_payer then
+                      Account.Nonce.succ sender_nonce
+                    else sender_nonce )
               }
         }
       in
@@ -2251,89 +2012,317 @@ let%test_module _ =
         (mk_payment' ?valid_until ~sender_idx ~fee ~nonce ~receiver_idx ~amount
            () )
 
+    let mk_parties_cmds (pool : Test.Resource_pool.t) :
+        User_command.Valid.t list Deferred.t =
+      let num_cmds = 7 in
+      assert (num_cmds < Array.length test_keys - 1) ;
+      let best_tip_ledger = Option.value_exn pool.best_tip_ledger in
+      let keymap =
+        Array.fold (Array.append test_keys extra_keys)
+          ~init:Public_key.Compressed.Map.empty
+          ~f:(fun map { public_key; private_key } ->
+            let key = Public_key.compress public_key in
+            Public_key.Compressed.Map.add_exn map ~key ~data:private_key )
+      in
+      let account_state_tbl =
+        List.take (Array.to_list test_keys) num_cmds
+        |> List.map ~f:(fun kp ->
+               let id =
+                 Account_id.create
+                   (Public_key.compress kp.public_key)
+                   Token_id.default
+               in
+               let state =
+                 Option.value_exn
+                   (let%bind.Option loc =
+                      Mina_ledger.Ledger.location_of_account best_tip_ledger id
+                    in
+                    Mina_ledger.Ledger.get best_tip_ledger loc )
+               in
+               (id, (state, `Fee_payer)) )
+        |> Account_id.Table.of_alist_exn
+      in
+      let rec go n cmds =
+        let open Quickcheck.Generator.Let_syntax in
+        if n < num_cmds then
+          let%bind cmd =
+            let fee_payer_keypair = test_keys.(n) in
+            let%map (parties : Parties.t) =
+              Mina_generators.Parties_generators.gen_parties_from ~keymap
+                ~account_state_tbl ~fee_payer_keypair ~ledger:best_tip_ledger ()
+            in
+            let parties =
+              { parties with
+                other_parties =
+                  Parties.Call_forest.map parties.other_parties
+                    ~f:(fun (p : Party.t) ->
+                      { p with
+                        body =
+                          { p.body with
+                            preconditions =
+                              { p.body.preconditions with
+                                account =
+                                  ( match p.body.preconditions.account with
+                                  | Party.Account_precondition.Full
+                                      { nonce =
+                                          Zkapp_basic.Or_ignore.Check n as c
+                                      ; _
+                                      }
+                                    when Zkapp_precondition.Numeric.(
+                                           is_constant Tc.nonce c) ->
+                                      Party.Account_precondition.Nonce n.lower
+                                  | Party.Account_precondition.Full _ ->
+                                      Party.Account_precondition.Accept
+                                  | pre ->
+                                      pre )
+                              }
+                          }
+                      } )
+              }
+            in
+            let parties =
+              Option.value_exn
+                (Parties.Valid.to_valid ~ledger:best_tip_ledger
+                   ~get:Mina_ledger.Ledger.get
+                   ~location_of_account:Mina_ledger.Ledger.location_of_account
+                   parties )
+            in
+            User_command.Parties parties
+          in
+          go (n + 1) (cmd :: cmds)
+        else Quickcheck.Generator.return @@ List.rev cmds
+      in
+      let result =
+        Quickcheck.random_value ~seed:(`Deterministic "parties") (go 0 [])
+      in
+      replace_valid_parties_authorizations ~keymap ~ledger:best_tip_ledger
+        result
+
+    type pool_apply = (User_command.t list, [ `Other of Error.t ]) Result.t
+    [@@deriving sexp, compare]
+
+    let canonicalize t =
+      Result.map t ~f:(List.sort ~compare:User_command.compare)
+
+    let compare_pool_apply (t1 : pool_apply) (t2 : pool_apply) =
+      compare_pool_apply (canonicalize t1) (canonicalize t2)
+
+    let assert_pool_apply expected_commands result =
+      let accepted_commands = Result.map result ~f:fst in
+      [%test_eq: pool_apply] accepted_commands
+        (Ok (List.map ~f:User_command.forget_check expected_commands))
+
+    let mk_with_status (cmd : User_command.Valid.t) =
+      { With_status.data = cmd; status = Applied }
+
+    let add_commands ?(local = true) test cs =
+      let sender =
+        if local then Envelope.Sender.Local
+        else
+          Envelope.Sender.Remote
+            (Peer.create
+               (Unix.Inet_addr.of_string "1.2.3.4")
+               ~peer_id:
+                 (Peer.Id.unsafe_of_string "contents should be irrelevant")
+               ~libp2p_port:8302 )
+      in
+      let tm0 = Time.now () in
+      let%bind verified =
+        Test.Resource_pool.Diff.verify' ~allow_failures_for_tests:true
+          test.txn_pool
+          (Envelope.Incoming.wrap
+             ~data:(List.map ~f:User_command.forget_check cs)
+             ~sender )
+        >>| Or_error.ok_exn
+      in
+      let result =
+        Test.Resource_pool.Diff.unsafe_apply test.txn_pool verified
+      in
+      let tm1 = Time.now () in
+      [%log' info test.txn_pool.logger] "Time for add_commands: %0.04f sec"
+        (Time.diff tm1 tm0 |> Time.Span.to_sec) ;
+      result
+
+    let add_commands' ?local test cs =
+      add_commands ?local test cs >>| assert_pool_apply cs
+
+    let reorg ?(reorg_best_tip = false) test new_commands removed_commands =
+      let%bind () =
+        Broadcast_pipe.Writer.write test.best_tip_diff_w
+          { Mock_transition_frontier.new_commands =
+              List.map ~f:mk_with_status new_commands
+          ; removed_commands = List.map ~f:mk_with_status removed_commands
+          ; reorg_best_tip
+          }
+      in
+      Async.Scheduler.yield_until_no_jobs_remain ()
+
+    let commit_commands test cs =
+      let ledger = Option.value_exn test.txn_pool.best_tip_ledger in
+      List.iter cs ~f:(fun c ->
+          match User_command.forget_check c with
+          | User_command.Signed_command c -> (
+              let (`If_this_is_used_it_should_have_a_comment_justifying_it valid)
+                  =
+                Signed_command.to_valid_unsafe c
+              in
+              let applied =
+                Or_error.ok_exn
+                @@ Mina_ledger.Ledger.apply_user_command ~constraint_constants
+                     ~txn_global_slot:Mina_numbers.Global_slot.zero ledger valid
+              in
+              match applied.body with
+              | Failed ->
+                  failwith "failed to apply user command to ledger"
+              | _ ->
+                  () )
+          | User_command.Parties p -> (
+              let applied, _ =
+                Or_error.ok_exn
+                @@ Mina_ledger.Ledger.apply_parties_unchecked
+                     ~constraint_constants ~state_view:dummy_state_view ledger p
+              in
+              match With_status.status applied.command with
+              | Failed failures ->
+                  failwithf
+                    "failed to apply parties transaction to ledger: [%s]"
+                    ( String.concat ~sep:", "
+                    @@ List.bind
+                         ~f:(List.map ~f:Transaction_status.Failure.to_string)
+                         failures )
+                    ()
+              | Applied ->
+                  () ) )
+
+    let commit_commands' test cs =
+      let open Mina_ledger in
+      let ledger = Option.value_exn test.txn_pool.best_tip_ledger in
+      test.best_tip_ref :=
+        Ledger.Maskable.register_mask
+          (Ledger.Any_ledger.cast (module Mina_ledger.Ledger) ledger)
+          (Ledger.Mask.create ~depth:(Ledger.depth ledger) ()) ;
+      let%map () = reorg test [] [] in
+      commit_commands test cs ; ledger
+
+    let advance_chain test cs = commit_commands test cs ; reorg test cs []
+
+    (* TODO: remove this (all of these test should be expressed by committing txns to the ledger, not mutating accounts *)
+    let modify_ledger ledger ~idx ~balance ~nonce =
+      let id =
+        Account_id.create
+          (Signature_lib.Public_key.compress test_keys.(idx).public_key)
+          Token_id.default
+      in
+      let loc =
+        Option.value_exn @@ Mina_ledger.Ledger.location_of_account ledger id
+      in
+      let account = Option.value_exn @@ Mina_ledger.Ledger.get ledger loc in
+      Mina_ledger.Ledger.set ledger loc
+        { account with
+          balance = Currency.Balance.of_int balance
+        ; nonce = Account.Nonce.of_int nonce
+        }
+
+    let mk_linear_case_test t cmds =
+      assert_pool_txs t [] ;
+      let%bind () = add_commands' t cmds in
+      let%bind () = advance_chain t (List.take independent_cmds 1) in
+      assert_pool_txs t (List.drop cmds 1) ;
+      let%bind () =
+        advance_chain t (List.take (List.drop independent_cmds 1) 2)
+      in
+      assert_pool_txs t (List.drop cmds 3) ;
+      Deferred.unit
+
+    let%test_unit "transactions are removed in linear case (user cmds)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind test = setup_test () in
+          mk_linear_case_test test independent_cmds )
+
+    let%test_unit "transactions are removed in linear case (zkapps)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind test = setup_test () in
+          mk_parties_cmds test.txn_pool >>= mk_linear_case_test test )
+
+    let mk_remove_and_add_test t cmds =
+      assert_pool_txs t [] ;
+      (* omit the 1st (0-based) command *)
+      let%bind () = add_commands' t (List.hd_exn cmds :: List.drop cmds 2) in
+      commit_commands t (List.take cmds 1) ;
+      let%bind () = reorg t (List.take cmds 1) (List.slice cmds 1 2) in
+      assert_pool_txs t (List.tl_exn cmds) ;
+      Deferred.unit
+
+    let%test_unit "Transactions are removed and added back in fork changes \
+                   (user cmds)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind test = setup_test () in
+          mk_remove_and_add_test test independent_cmds )
+
+    let%test_unit "Transactions are removed and added back in fork changes \
+                   (zkapps)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind test = setup_test () in
+          mk_parties_cmds test.txn_pool >>= mk_remove_and_add_test test )
+
+    let mk_invalid_test t cmds =
+      assert_pool_txs t [] ;
+      let%bind () = advance_chain t (List.take cmds 2) in
+      let%bind () =
+        add_commands t cmds >>| assert_pool_apply (List.drop cmds 2)
+      in
+      assert_pool_txs t (List.drop cmds 2) ;
+      Deferred.unit
+
+    let%test_unit "invalid transactions are not accepted (user cmds)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind test = setup_test () in
+          mk_invalid_test test independent_cmds )
+
+    let%test_unit "invalid transactions are not accepted (zkapps)" =
+      Thread_safe.block_on_async_exn (fun () ->
+          let%bind test = setup_test () in
+          mk_parties_cmds test.txn_pool >>= mk_invalid_test test )
+
     let current_global_slot () =
       let current_time = Block_time.now time_controller in
       Consensus.Data.Consensus_time.(
         of_time_exn ~constants:consensus_constants current_time
         |> to_global_slot)
 
-    let mk_now_invalid_test assert_pool_txs pool best_tip_diff_w best_tip_ref
-        cmds =
-      let cmds' = List.map cmds ~f:User_command.forget_check in
-      assert_pool_txs [] ;
-      modify_ledger ~best_tip_ledger:!best_tip_ref ~idx:0
-        ~balance:1_000_000_000_000 ~nonce:1 ;
-      let%bind _ =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands = List.map ~f:mk_with_status @@ List.take cmds 2
-            ; removed_commands = []
-            ; reorg_best_tip = false
-            }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      assert_pool_txs [] ;
+    let mk_now_invalid_test t _cmds ~mk_command =
       let cmd1 =
-        let sender = test_keys.(0) in
-        Quickcheck.random_value
-          (User_command.Valid.Gen.payment ~sign_type:`Real
-             ~key_gen:
-               Quickcheck.Generator.(
-                 tuple2 (return sender) (Quickcheck_lib.of_array test_keys))
-             ~nonce:(Account.Nonce.of_int 1) ~max_amount:100_000_000_000
-             ~fee_range:10_000_000_000 () )
+        mk_command ~sender_idx:0 ~receiver_idx:5 ~fee:1_000_000_000 ~nonce:0
+          ~amount:99_999_999_999 ()
       in
-      let%bind apply_res =
-        verify_and_apply pool [ User_command.forget_check cmd1 ]
-      in
-      [%test_eq: pool_apply]
-        (accepted_commands apply_res)
-        (Ok [ User_command.forget_check cmd1 ]) ;
-      assert_pool_txs [ User_command.forget_check cmd1 ] ;
       let cmd2 =
-        mk_payment ~sender_idx:0 ~fee:1_000_000_000 ~nonce:0 ~receiver_idx:5
+        mk_command ~sender_idx:0 ~receiver_idx:5 ~fee:1_000_000_000 ~nonce:0
           ~amount:999_000_000_000 ()
       in
-      modify_ledger ~best_tip_ledger:!best_tip_ref ~idx:0 ~balance:0 ~nonce:1 ;
-      let%bind _ =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands =
-                List.map ~f:mk_with_status @@ (cmd2 :: List.drop cmds 2)
-            ; removed_commands = List.map ~f:mk_with_status @@ List.take cmds 2
-            ; reorg_best_tip = true
-            }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      (* first cmd from removed_commands gets replaced by cmd2 (same sender), cmd1 is invalid because of insufficient balance,
-         and so only the second cmd from removed_commands is expected to be in the pool
-      *)
-      assert_pool_txs [ List.nth_exn cmds' 1 ] ;
-      Deferred.unit
+      assert_pool_txs t [] ;
+      let%bind () = add_commands' t [ cmd1 ] in
+      assert_pool_txs t [ cmd1 ] ;
+      let%bind () = advance_chain t [ cmd2 ] in
+      assert_pool_txs t [] ; Deferred.unit
 
     let%test_unit "Now-invalid transactions are removed from the pool on fork \
                    changes (user cmds)" =
       Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref) =
-            setup_test ()
-          in
-          mk_now_invalid_test assert_pool_txs pool best_tip_diff_w best_tip_ref
-            independent_cmds )
+          let%bind test = setup_test () in
+          mk_now_invalid_test test independent_cmds
+            ~mk_command:(mk_payment ?valid_until:None) )
 
     let%test_unit "Now-invalid transactions are removed from the pool on fork \
                    changes (zkapps)" =
       Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref) =
-            setup_test ()
-          in
-          let ledger, keymap, parties_dummy_auths = mk_parties_cmds pool in
-          let%bind parties =
-            replace_valid_parties_authorizations ~keymap ~ledger
-              parties_dummy_auths
-          in
-          mk_now_invalid_test assert_pool_txs pool best_tip_diff_w best_tip_ref
-            parties )
+          let%bind test = setup_test () in
+          mk_parties_cmds test.txn_pool
+          >>= mk_now_invalid_test test
+                ~mk_command:
+                  (mk_transfer_parties ?valid_period:None ?fee_payer_idx:None) )
 
-    let mk_expired_not_accepted_test assert_pool_txs pool ~padding cmds =
-      assert_pool_txs [] ;
+    let mk_expired_not_accepted_test t ~padding cmds =
+      assert_pool_txs t [] ;
       let%bind () =
         let current_time = Block_time.now time_controller in
         let slot_end =
@@ -2350,7 +2339,7 @@ let%test_module _ =
       in
       let valid_command =
         mk_payment ~valid_until:curr_slot_plus_padding ~sender_idx:1
-          ~fee:1_000_000_000 ~nonce:1 ~receiver_idx:9 ~amount:1_000_000_000 ()
+          ~fee:1_000_000_000 ~nonce:1 ~receiver_idx:7 ~amount:1_000_000_000 ()
       in
       let expired_commands =
         [ mk_payment ~valid_until:curr_slot ~sender_idx:0 ~fee:1_000_000_000
@@ -2368,47 +2357,30 @@ let%test_module _ =
              consensus_constants.block_window_duration_ms )
       in
       let all_valid_commands = cmds @ [ valid_command ] in
-      let%bind apply_res =
-        verify_and_apply pool
-          (List.map
-             (all_valid_commands @ expired_commands)
-             ~f:User_command.forget_check )
+      let%bind () =
+        add_commands t (all_valid_commands @ expired_commands)
+        >>| assert_pool_apply all_valid_commands
       in
-      let cmds_wo_check =
-        List.map all_valid_commands ~f:User_command.forget_check
-      in
-      [%test_eq: pool_apply] (Ok cmds_wo_check) (accepted_commands apply_res) ;
-      assert_pool_txs cmds_wo_check ;
+      assert_pool_txs t all_valid_commands ;
       Deferred.unit
 
     let%test_unit "expired transactions are not accepted (user cmds)" =
       Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, _best_tip_diff_w, (_, _best_tip_ref) =
-            setup_test ()
-          in
-          mk_expired_not_accepted_test assert_pool_txs pool ~padding:10
-            independent_cmds )
+          let%bind test = setup_test () in
+          mk_expired_not_accepted_test test ~padding:10 independent_cmds )
 
     let%test_unit "expired transactions are not accepted (zkapps)" =
       Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, _best_tip_diff_w, (_, _best_tip_ref) =
-            setup_test ()
-          in
-          let ledger, keymap, parties_dummy_auths = mk_parties_cmds pool in
-          let%bind parties =
-            replace_valid_parties_authorizations ~keymap ~ledger
-              parties_dummy_auths
-          in
-          mk_expired_not_accepted_test assert_pool_txs pool ~padding:55 parties )
+          let%bind test = setup_test () in
+          mk_parties_cmds test.txn_pool
+          >>= mk_expired_not_accepted_test test ~padding:55 )
 
     let%test_unit "Expired transactions that are already in the pool are \
                    removed from the pool when best tip changes (user commands)"
         =
       Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref) =
-            setup_test ()
-          in
-          assert_pool_txs [] ;
+          let%bind t = setup_test () in
+          assert_pool_txs t [] ;
           let curr_slot = current_global_slot () in
           let curr_slot_plus_three =
             Mina_numbers.Global_slot.(add curr_slot (of_int 3))
@@ -2430,32 +2402,15 @@ let%test_module _ =
               ()
           in
           let valid_commands = few_now @ [ expires_later1; expires_later2 ] in
-          let cmds_wo_check =
-            List.map valid_commands ~f:User_command.forget_check
-          in
-          let%bind apply_res = verify_and_apply pool cmds_wo_check in
-          [%test_eq: pool_apply] (accepted_commands apply_res) (Ok cmds_wo_check) ;
-          assert_pool_txs cmds_wo_check ;
+          let%bind () = add_commands' t valid_commands in
+          assert_pool_txs t valid_commands ;
           (* new commands from best tip diff should be removed from the pool *)
           (* update the nonce to be consistent with the commands in the block *)
-          modify_ledger ~best_tip_ledger:!best_tip_ref ~idx:0
-            ~balance:1_000_000_000_000_000 ~nonce:2 ;
-          let%bind _ =
-            Broadcast_pipe.Writer.write best_tip_diff_w
-              ( { new_commands =
-                    List.map ~f:mk_with_status
-                      [ List.nth_exn few_now 0; expires_later1 ]
-                ; removed_commands = []
-                ; reorg_best_tip = false
-                }
-                : Mock_transition_frontier.best_tip_diff )
-          in
-          let cmds_wo_check =
-            List.map ~f:User_command.forget_check
-              (expires_later2 :: List.drop few_now 1)
-          in
+          modify_ledger !(t.best_tip_ref) ~idx:0 ~balance:1_000_000_000_000_000
+            ~nonce:2 ;
+          let%bind () = reorg t [ List.nth_exn few_now 0; expires_later1 ] [] in
           let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-          assert_pool_txs cmds_wo_check ;
+          assert_pool_txs t (expires_later2 :: List.drop few_now 1) ;
           (* Add new commands, remove old commands some of which are now expired *)
           let expired_command =
             mk_payment ~valid_until:curr_slot ~sender_idx:9 ~fee:1_000_000_000
@@ -2473,7 +2428,6 @@ let%test_module _ =
             ; expired_command
             ; unexpired_command
             ]
-            |> List.map ~f:mk_with_status
           in
           let n_block_times n =
             Int64.(
@@ -2484,41 +2438,21 @@ let%test_module _ =
           let%bind () =
             after (Block_time.Span.to_time_span (n_block_times 3L))
           in
-          let%bind _ =
-            Broadcast_pipe.Writer.write best_tip_diff_w
-              ( { new_commands = [ mk_with_status valid_forever ]
-                ; removed_commands
-                ; reorg_best_tip = true
-                }
-                : Mock_transition_frontier.best_tip_diff )
-          in
+          modify_ledger !(t.best_tip_ref) ~idx:0 ~balance:1_000_000_000_000_000
+            ~nonce:1 ;
+          let%bind _ = reorg t [ valid_forever ] removed_commands in
           (* expired_command should not be in the pool because they are expired
              and (List.nth few_now 0) because it was committed in a block
           *)
-          let cmds_wo_check =
-            List.map ~f:User_command.forget_check
-              ( expires_later1 :: expires_later2 :: unexpired_command
-              :: List.drop few_now 1 )
-          in
-          let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-          assert_pool_txs cmds_wo_check ;
+          assert_pool_txs t
+            ( expires_later1 :: expires_later2 :: unexpired_command
+            :: List.drop few_now 1 ) ;
           (* after 5 block times there should be no expired transactions *)
           let%bind () =
             after (Block_time.Span.to_time_span (n_block_times 5L))
           in
-          let%bind _ =
-            Broadcast_pipe.Writer.write best_tip_diff_w
-              ( { new_commands = []
-                ; removed_commands = []
-                ; reorg_best_tip = false
-                }
-                : Mock_transition_frontier.best_tip_diff )
-          in
-          let cmds_wo_check =
-            List.map ~f:User_command.forget_check (List.drop few_now 1)
-          in
-          let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-          assert_pool_txs cmds_wo_check ;
+          let%bind _ = reorg t [] [] in
+          assert_pool_txs t (List.drop few_now 1) ;
           Deferred.unit )
 
     let%test_unit "Expired transactions that are already in the pool are \
@@ -2536,10 +2470,8 @@ let%test_module _ =
             Block_time.Span.of_time_span
             @@ Time_ns.Span.to_span_float_round_nearest eight_block_time
           in
-          let%bind assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref) =
-            setup_test ~expiry ()
-          in
-          assert_pool_txs [] ;
+          let%bind t = setup_test ~expiry () in
+          assert_pool_txs t [] ;
           let curr_time =
             Block_time.sub (Block_time.of_time (Time.now ())) eight_block
           in
@@ -2569,34 +2501,16 @@ let%test_module _ =
               ~fee:1_000_000_000 ~amount:10_000_000_000 ~nonce:2 ()
           in
           let valid_commands = few_now @ [ expires_later1; expires_later2 ] in
-          let cmds_wo_check =
-            List.map valid_commands ~f:User_command.forget_check
-          in
-          let%bind apply_res = verify_and_apply pool cmds_wo_check in
-          [%test_eq: pool_apply] (accepted_commands apply_res) (Ok cmds_wo_check) ;
-          assert_pool_txs cmds_wo_check ;
+          let%bind () = add_commands' t valid_commands in
+          assert_pool_txs t valid_commands ;
           (* new commands from best tip diff should be removed from the pool *)
           (* update the nonce to be consistent with the commands in the block *)
-          modify_ledger ~best_tip_ledger:!best_tip_ref ~idx:0
-            ~balance:1_000_000_000_000_000 ~nonce:2 ;
-          modify_ledger ~best_tip_ledger:!best_tip_ref ~idx:1
-            ~balance:1_000_000_000_000_000 ~nonce:2 ;
-          let%bind _ =
-            Broadcast_pipe.Writer.write best_tip_diff_w
-              ( { new_commands =
-                    List.map ~f:mk_with_status
-                      [ List.nth_exn few_now 0; expires_later1 ]
-                ; removed_commands = []
-                ; reorg_best_tip = false
-                }
-                : Mock_transition_frontier.best_tip_diff )
-          in
-          let cmds_wo_check =
-            List.map ~f:User_command.forget_check
-              (expires_later2 :: List.drop few_now 1)
-          in
-          let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-          assert_pool_txs cmds_wo_check ;
+          modify_ledger !(t.best_tip_ref) ~idx:0 ~balance:1_000_000_000_000_000
+            ~nonce:2 ;
+          modify_ledger !(t.best_tip_ref) ~idx:1 ~balance:1_000_000_000_000_000
+            ~nonce:2 ;
+          let%bind () = reorg t (List.take few_now 2 @ [ expires_later1 ]) [] in
+          assert_pool_txs t (expires_later2 :: List.drop few_now 2) ;
           (* Add new commands, remove old commands some of which are now expired *)
           let expired_zkapp =
             mk_transfer_parties
@@ -2613,7 +2527,6 @@ let%test_module _ =
           let valid_forever = List.nth_exn few_now 0 in
           let removed_commands =
             [ valid_forever; expires_later1; expired_zkapp; unexpired_zkapp ]
-            |> List.map ~f:mk_with_status
           in
           let n_block_times n =
             Int64.(
@@ -2624,131 +2537,70 @@ let%test_module _ =
           let%bind () =
             after (Block_time.Span.to_time_span (n_block_times 3L))
           in
-          let%bind _ =
-            Broadcast_pipe.Writer.write best_tip_diff_w
-              ( { new_commands = [ mk_with_status valid_forever ]
-                ; removed_commands
-                ; reorg_best_tip = true
-                }
-                : Mock_transition_frontier.best_tip_diff )
-          in
+          modify_ledger !(t.best_tip_ref) ~idx:0 ~balance:1_000_000_000_000_000
+            ~nonce:1 ;
+          modify_ledger !(t.best_tip_ref) ~idx:1 ~balance:1_000_000_000_000_000
+            ~nonce:1 ;
+          let%bind () = reorg t [ valid_forever ] removed_commands in
           (* expired_command should not be in the pool because they are expired
              and (List.nth few_now 0) because it was committed in a block
           *)
-          let cmds_wo_check =
-            List.map ~f:User_command.forget_check
-              ( expires_later1 :: expires_later2 :: unexpired_zkapp
-              :: List.drop few_now 1 )
-          in
-          let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-          assert_pool_txs cmds_wo_check ;
+          assert_pool_txs t
+            ( expires_later1 :: expires_later2 :: unexpired_zkapp
+            :: List.drop few_now 2 ) ;
           (* after 5 block times there should be no expired transactions *)
           let%bind () =
             after (Block_time.Span.to_time_span (n_block_times 5L))
           in
-          let%bind _ =
-            Broadcast_pipe.Writer.write best_tip_diff_w
-              ( { new_commands = []
-                ; removed_commands = []
-                ; reorg_best_tip = false
-                }
-                : Mock_transition_frontier.best_tip_diff )
-          in
-          let cmds_wo_check =
-            List.map ~f:User_command.forget_check (List.drop few_now 1)
-          in
-          let%bind () = Async.Scheduler.yield_until_no_jobs_remain () in
-          assert_pool_txs cmds_wo_check ;
+          let%bind () = reorg t [] [] in
+          assert_pool_txs t (List.drop few_now 2) ;
           Deferred.unit )
 
     let%test_unit "Aged-based expiry (zkapps)" =
       Thread_safe.block_on_async_exn (fun () ->
           let expiry = Time_ns.Span.of_sec 1. in
-          let%bind assert_pool_txs, pool, best_tip_diff_w, _ =
-            setup_test ~expiry ()
-          in
-          assert_pool_txs [] ;
+          let%bind t = setup_test ~expiry () in
+          assert_pool_txs t [] ;
           let party_transfer =
             mk_transfer_parties ~fee_payer_idx:(0, 0) ~sender_idx:1
               ~receiver_idx:9 ~fee:1_000_000_000 ~amount:10_000_000_000 ~nonce:0
               ()
           in
           let valid_commands = [ party_transfer ] in
-          let cmds_wo_check =
-            List.map valid_commands ~f:User_command.forget_check
-          in
-          let%bind apply_res = verify_and_apply pool cmds_wo_check in
-          [%test_eq: pool_apply] (accepted_commands apply_res) (Ok cmds_wo_check) ;
-          assert_pool_txs cmds_wo_check ;
+          let%bind () = add_commands' t valid_commands in
+          assert_pool_txs t valid_commands ;
           let%bind () = after (Time.Span.of_sec 2.) in
-          let%map _ =
-            Broadcast_pipe.Writer.write best_tip_diff_w
-              ( { new_commands = []
-                ; removed_commands = []
-                ; reorg_best_tip = false
-                }
-                : Mock_transition_frontier.best_tip_diff )
-          in
-          assert_pool_txs [] )
+          let%bind () = reorg t [] [] in
+          assert_pool_txs t [] ; Deferred.unit )
 
     let%test_unit "Now-invalid transactions are removed from the pool when the \
                    transition frontier is recreated (user cmds)" =
       Thread_safe.block_on_async_exn (fun () ->
           (* Set up initial frontier *)
-          let frontier_pipe_r, frontier_pipe_w = Broadcast_pipe.create None in
-          let trust_system = Trust_system.null () in
-          let config =
-            Test.Resource_pool.make_config ~trust_system ~pool_max_size
-              ~verifier
-          in
-          let pool_, _, _ =
-            Test.create ~config ~logger ~constraint_constants
-              ~consensus_constants ~time_controller ~expiry_ns
-              ~frontier_broadcast_pipe:frontier_pipe_r ~log_gossip_heard:false
-              ~on_remote_push:(Fn.const Deferred.unit)
-          in
-          let pool = Test.resource_pool pool_ in
-          let assert_pool_txs txs =
-            [%test_eq: User_command.t List.t]
-              ( Test.Resource_pool.transactions ~logger pool
-              |> Sequence.map
-                   ~f:Transaction_hash.User_command_with_valid_signature.command
-              |> Sequence.to_list
-              |> List.sort ~compare:User_command.compare )
-            @@ List.sort ~compare:User_command.compare txs
-          in
-          assert_pool_txs [] ;
-          let frontier1, best_tip_diff_w1 =
-            Mock_transition_frontier.create ()
-          in
-          let%bind _ =
-            Broadcast_pipe.Writer.write frontier_pipe_w (Some frontier1)
-          in
-          let%bind _ = verify_and_apply pool independent_cmds' in
-          assert_pool_txs independent_cmds' ;
+          let%bind t = setup_test () in
+          assert_pool_txs t [] ;
+          let%bind _ = add_commands t independent_cmds in
+          assert_pool_txs t independent_cmds ;
           (* Destroy initial frontier *)
-          Broadcast_pipe.Writer.close best_tip_diff_w1 ;
-          let%bind _ = Broadcast_pipe.Writer.write frontier_pipe_w None in
+          Broadcast_pipe.Writer.close t.best_tip_diff_w ;
+          let%bind _ = Broadcast_pipe.Writer.write t.frontier_pipe_w None in
           (* Set up second frontier *)
           let ((_, ledger_ref2) as frontier2), _best_tip_diff_w2 =
             Mock_transition_frontier.create ()
           in
-          modify_ledger ~best_tip_ledger:!ledger_ref2 ~idx:0
-            ~balance:20_000_000_000_000 ~nonce:5 ;
-          modify_ledger ~best_tip_ledger:!ledger_ref2 ~idx:1 ~balance:0 ~nonce:0 ;
-          modify_ledger ~best_tip_ledger:!ledger_ref2 ~idx:2 ~balance:0 ~nonce:1 ;
+          modify_ledger !ledger_ref2 ~idx:0 ~balance:20_000_000_000_000 ~nonce:5 ;
+          modify_ledger !ledger_ref2 ~idx:1 ~balance:0 ~nonce:0 ;
+          modify_ledger !ledger_ref2 ~idx:2 ~balance:0 ~nonce:1 ;
           let%bind _ =
-            Broadcast_pipe.Writer.write frontier_pipe_w (Some frontier2)
+            Broadcast_pipe.Writer.write t.frontier_pipe_w (Some frontier2)
           in
-          assert_pool_txs @@ List.drop independent_cmds' 3 ;
+          assert_pool_txs t (List.drop independent_cmds 3) ;
           Deferred.unit )
 
     let%test_unit "transaction replacement works" =
       Thread_safe.block_on_async_exn
       @@ fun () ->
-      let%bind assert_pool_txs, pool, _best_tip_diff_w, frontier =
-        setup_test ()
-      in
+      let%bind t = setup_test () in
       let set_sender idx (tx : Signed_command.t) =
         let sender_kp = test_keys.(idx) in
         let sender_pk = Public_key.compress sender_kp.public_key in
@@ -2784,10 +2636,8 @@ let%test_module _ =
         List.map ~f:(fun x -> User_command.Signed_command x) txs0
         @ txs1 @ txs2 @ txs3
       in
-      let txs_all = List.map txs_all ~f:User_command.forget_check in
-      let%bind apply_res = verify_and_apply pool txs_all in
-      [%test_eq: pool_apply] (Ok txs_all) (accepted_commands apply_res) ;
-      assert_pool_txs @@ txs_all ;
+      let%bind () = add_commands' t txs_all in
+      assert_pool_txs t txs_all ;
       let replace_txs =
         [ (* sufficient fee *)
           mk_payment ~sender_idx:0 ~fee:16_000_000_000 ~nonce:0 ~receiver_idx:1
@@ -2801,7 +2651,7 @@ let%test_module _ =
         ; (* insufficient *)
           (let amount = 927_000_000_000 in
            let fee =
-             let ledger = Mock_transition_frontier.best_tip frontier in
+             let ledger = !(t.best_tip_ref) in
              let sender_kp = test_keys.(3) in
              let sender_pk = Public_key.compress sender_kp.public_key in
              let sender_aid = Account_id.create sender_pk Token_id.default in
@@ -2820,20 +2670,15 @@ let%test_module _ =
            mk_payment ~sender_idx:3 ~fee ~nonce:1 ~receiver_idx:4 ~amount () )
         ]
       in
-      let replace_txs = List.map replace_txs ~f:User_command.forget_check in
-      let%bind apply_res_2 = verify_and_apply pool replace_txs in
-      [%test_eq: pool_apply]
-        (Ok [ List.nth_exn replace_txs 0; List.nth_exn replace_txs 2 ])
-        (accepted_commands apply_res_2) ;
-      Deferred.unit
+      add_commands t replace_txs
+      >>| assert_pool_apply
+            [ List.nth_exn replace_txs 0; List.nth_exn replace_txs 2 ]
 
     let%test_unit "it drops queued transactions if a committed one makes there \
                    be insufficient funds" =
       Thread_safe.block_on_async_exn
       @@ fun () ->
-      let%bind assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref) =
-        setup_test ()
-      in
+      let%bind t = setup_test () in
       let txs =
         [ mk_payment ~sender_idx:0 ~fee:5_000_000_000 ~nonce:0 ~receiver_idx:9
             ~amount:20_000_000_000 ()
@@ -2847,20 +2692,11 @@ let%test_module _ =
         mk_payment ~sender_idx:0 ~fee:5_000_000_000 ~nonce:0 ~receiver_idx:2
           ~amount:25_000_000_000 ()
       in
-      let txs = txs |> List.map ~f:User_command.forget_check in
-      let%bind apply_res = verify_and_apply pool txs in
-      [%test_eq: pool_apply] (Ok txs) (accepted_commands apply_res) ;
-      assert_pool_txs @@ txs ;
-      modify_ledger ~best_tip_ledger:!best_tip_ref ~idx:0
-        ~balance:970_000_000_000 ~nonce:1 ;
-      let%bind () =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          { new_commands = List.map ~f:mk_with_status @@ [ committed_tx ]
-          ; removed_commands = []
-          ; reorg_best_tip = false
-          }
-      in
-      assert_pool_txs [ List.nth_exn txs 1 ] ;
+      let%bind () = add_commands' t txs in
+      assert_pool_txs t txs ;
+      modify_ledger !(t.best_tip_ref) ~idx:0 ~balance:970_000_000_000 ~nonce:1 ;
+      let%bind () = reorg t [ committed_tx ] [] in
+      assert_pool_txs t [ List.nth_exn txs 1 ] ;
       Deferred.unit
 
     let%test_unit "max size is maintained" =
@@ -2877,200 +2713,110 @@ let%test_module _ =
         return (init_ledger_state, cmds))
         ~f:(fun (init_ledger_state, cmds) ->
           Thread_safe.block_on_async_exn (fun () ->
-              let%bind _assert_pool_txs, pool, best_tip_diff_w, (_, best_tip_ref)
-                  =
-                setup_test ()
+              let%bind t = setup_test () in
+              let new_ledger =
+                Mina_ledger.Ledger.create_ephemeral
+                  ~depth:(Mina_ledger.Ledger.depth !(t.best_tip_ref))
+                  ()
               in
-              let mock_ledger =
-                Account_id.Table.of_alist_exn
-                  ( init_ledger_state |> Array.to_sequence
-                  |> Sequence.map ~f:(fun (kp, balance, nonce, timing) ->
-                         let public_key = Public_key.compress kp.public_key in
-                         let account_id =
-                           Account_id.create public_key Token_id.default
-                         in
-                         ( account_id
-                         , { (Account.initialize account_id) with
-                             balance =
-                               Currency.Balance.of_uint64
-                                 (Currency.Amount.to_uint64 balance)
-                           ; nonce
-                           ; timing
-                           } ) )
-                  |> Sequence.to_list )
-              in
-              best_tip_ref := mock_ledger ;
-              let%bind () =
-                Broadcast_pipe.Writer.write best_tip_diff_w
-                  { new_commands = []
-                  ; removed_commands = []
-                  ; reorg_best_tip = true
-                  }
-              in
+              Mina_ledger.Ledger.apply_initial_ledger_state new_ledger
+                init_ledger_state ;
+              t.best_tip_ref := new_ledger ;
+              let%bind () = reorg ~reorg_best_tip:true t [] [] in
               let cmds1, cmds2 = List.split_n cmds pool_max_size in
-              let%bind apply_res1 =
-                verify_and_apply pool
-                  (List.map cmds1 ~f:User_command.forget_check)
-              in
+              let%bind apply_res1 = add_commands t cmds1 in
               assert (Result.is_ok apply_res1) ;
-              [%test_eq: int] pool_max_size (Indexed_pool.size pool.pool) ;
-              let%map _apply_res2 =
-                verify_and_apply pool
-                  (List.map cmds2 ~f:User_command.forget_check)
-              in
+              [%test_eq: int] pool_max_size (Indexed_pool.size t.txn_pool.pool) ;
+              let%map _apply_res2 = add_commands t cmds2 in
               (* N.B. Adding a transaction when the pool is full may drop > 1
                  command, so the size now is not necessarily the maximum.
                  Applying the diff may also return an error if none of the new
                  commands have higher fee than the lowest one already in the
                  pool.
               *)
-              assert (Indexed_pool.size pool.pool <= pool_max_size) ) )
+              assert (Indexed_pool.size t.txn_pool.pool <= pool_max_size) ) )
 
-    let assert_rebroadcastable pool cmds =
-      let normalize = List.sort ~compare:User_command.compare in
+    let assert_rebroadcastable test cmds =
       let expected =
-        match normalize cmds with [] -> [] | normalized -> [ normalized ]
+        if List.is_empty cmds then []
+        else
+          [ List.map cmds
+              ~f:
+                (Fn.compose Transaction_hash.User_command.create
+                   User_command.forget_check )
+          ]
       in
-      [%test_eq: User_command.t list list]
-        ( List.map ~f:normalize
-        @@ Test.Resource_pool.get_rebroadcastable pool
-             ~has_timed_out:(Fn.const `Ok) )
-        expected
+      let actual =
+        Test.Resource_pool.get_rebroadcastable test.txn_pool
+          ~has_timed_out:(Fn.const `Ok)
+        |> List.map ~f:(List.map ~f:Transaction_hash.User_command.create)
+      in
+      if List.length actual > 1 then
+        failwith "unexpected number of rebroadcastable diffs" ;
 
-    let mock_sender =
-      Envelope.Sender.Remote
-        (Peer.create
-           (Unix.Inet_addr.of_string "1.2.3.4")
-           ~peer_id:(Peer.Id.unsafe_of_string "contents should be irrelevant")
-           ~libp2p_port:8302 )
+      List.iter (List.zip_exn actual expected) ~f:(fun (a, b) ->
+          assert_user_command_sets_equal a b )
 
-    let mk_rebroadcastable_test assert_pool_txs pool best_tip_diff_w cmds =
-      assert_pool_txs [] ;
-      let local_cmds = List.take cmds 5 in
-      let local_cmds' = List.map local_cmds ~f:User_command.forget_check in
-      let remote_cmds = List.drop cmds 5 in
-      let remote_cmds' = List.map remote_cmds ~f:User_command.forget_check in
+    let mk_rebroadcastable_test t cmds =
+      assert_pool_txs t [] ;
+      assert_rebroadcastable t [] ;
       (* Locally generated transactions are rebroadcastable *)
-      let%bind apply_res_1 = verify_and_apply pool local_cmds' in
-      [%test_eq: pool_apply] (accepted_commands apply_res_1) (Ok local_cmds') ;
-      assert_pool_txs local_cmds' ;
-      assert_rebroadcastable pool local_cmds' ;
+      let%bind () = add_commands' ~local:true t (List.take cmds 2) in
+      assert_pool_txs t (List.take cmds 2) ;
+      assert_rebroadcastable t (List.take cmds 2) ;
       (* Adding non-locally-generated transactions doesn't affect
          rebroadcastable pool *)
-      let%bind apply_res_2 =
-        let%bind verified =
-          Test.Resource_pool.Diff.verify pool
-            (Envelope.Incoming.wrap ~data:remote_cmds' ~sender:mock_sender)
-          >>| Or_error.ok_exn
-        in
-        Test.Resource_pool.Diff.unsafe_apply pool verified
-      in
-      [%test_eq: pool_apply] (accepted_commands apply_res_2) (Ok remote_cmds') ;
-      assert_pool_txs (local_cmds' @ remote_cmds') ;
-      assert_rebroadcastable pool local_cmds' ;
+      let%bind () = add_commands' ~local:false t (List.slice cmds 2 5) in
+      assert_pool_txs t (List.take cmds 5) ;
+      assert_rebroadcastable t (List.take cmds 2) ;
       (* When locally generated transactions are committed they are no
          longer rebroadcastable *)
-      let%bind () =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands =
-                List.map ~f:mk_with_status @@ List.take local_cmds 2
-                @ List.take remote_cmds 3
-            ; removed_commands = []
-            ; reorg_best_tip = false
-            }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      assert_pool_txs (List.drop local_cmds' 2 @ List.drop remote_cmds' 3) ;
-      assert_rebroadcastable pool (List.drop local_cmds' 2) ;
+      let%bind () = add_commands' ~local:true t (List.slice cmds 5 7) in
+      let%bind checkpoint_1 = commit_commands' t (List.take cmds 1) in
+      let%bind checkpoint_2 = commit_commands' t (List.slice cmds 1 5) in
+      let%bind () = reorg t (List.take cmds 5) [] in
+      assert_pool_txs t (List.slice cmds 5 7) ;
+      assert_rebroadcastable t (List.slice cmds 5 7) ;
       (* Reorgs put locally generated transactions back into the
          rebroadcastable pool, if they were removed and not re-added *)
-      let%bind () =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands = List.map ~f:mk_with_status @@ List.take local_cmds 1
-            ; removed_commands =
-                List.map ~f:mk_with_status @@ List.take local_cmds 2
-            ; reorg_best_tip = true
-            }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      assert_pool_txs (List.tl_exn local_cmds' @ List.drop remote_cmds' 3) ;
-      assert_rebroadcastable pool (List.tl_exn local_cmds') ;
+      (* restore up to after the application of the first command *)
+      t.best_tip_ref := checkpoint_2 ;
+      (* reorge both removes and re-adds the first command (which is local) *)
+      let%bind () = reorg t (List.take cmds 1) (List.take cmds 5) in
+      assert_pool_txs t (List.slice cmds 1 7) ;
+      assert_rebroadcastable t (List.nth_exn cmds 1 :: List.slice cmds 5 7) ;
       (* Committing them again removes them from the pool again. *)
-      let%bind () =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands =
-                List.map ~f:mk_with_status @@ List.tl_exn local_cmds
-                @ List.drop remote_cmds 3
-            ; removed_commands = []
-            ; reorg_best_tip = false
-            }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      assert_pool_txs [] ;
-      assert_rebroadcastable pool [] ;
-      (* A reorg that doesn't re-add anything puts the right things back
-         into the rebroadcastable pool. *)
-      let%bind () =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands = []
-            ; removed_commands =
-                List.map ~f:mk_with_status @@ List.drop local_cmds 3
-                @ remote_cmds
-            ; reorg_best_tip = true
-            }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      assert_pool_txs (List.drop local_cmds' 3 @ remote_cmds') ;
-      assert_rebroadcastable pool (List.drop local_cmds' 3) ;
-      (* Committing again removes them. (Checking this works in both one and
-         two step reorg processes) *)
-      let%bind () =
-        Broadcast_pipe.Writer.write best_tip_diff_w
-          ( { new_commands =
-                List.map ~f:mk_with_status @@ [ List.nth_exn local_cmds 3 ]
-            ; removed_commands = []
-            ; reorg_best_tip = false
-            }
-            : Mock_transition_frontier.best_tip_diff )
-      in
-      assert_pool_txs (List.drop local_cmds' 4 @ remote_cmds') ;
-      assert_rebroadcastable pool (List.drop local_cmds' 4) ;
+      commit_commands t (List.slice cmds 1 7) ;
+      let%bind () = reorg t (List.slice cmds 1 7) [] in
+      assert_pool_txs t [] ;
+      assert_rebroadcastable t [] ;
       (* When transactions expire from rebroadcast pool they are gone. This
          doesn't affect the main pool.
       *)
+      t.best_tip_ref := checkpoint_1 ;
+      let%bind () = reorg t [] (List.take cmds 7) in
+      assert_pool_txs t (List.take cmds 7) ;
+      assert_rebroadcastable t (List.take cmds 2 @ List.slice cmds 5 7) ;
       ignore
-        ( Test.Resource_pool.get_rebroadcastable pool
+        ( Test.Resource_pool.get_rebroadcastable t.txn_pool
             ~has_timed_out:(Fn.const `Timed_out)
           : User_command.t list list ) ;
-      assert_pool_txs (List.drop local_cmds' 4 @ remote_cmds') ;
-      assert_rebroadcastable pool [] ;
+      assert_rebroadcastable t [] ;
       Deferred.unit
 
     let%test_unit "rebroadcastable transaction behavior (user cmds)" =
       Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, _frontier =
-            setup_test ()
-          in
-          mk_rebroadcastable_test assert_pool_txs pool best_tip_diff_w
-            independent_cmds )
+          let%bind test = setup_test () in
+          mk_rebroadcastable_test test independent_cmds )
 
     let%test_unit "rebroadcastable transaction behavior (zkapps)" =
       Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, best_tip_diff_w, _frontier =
-            setup_test ()
-          in
-          let ledger, keymap, parties_dummy_auths = mk_parties_cmds pool in
-          let%bind parties =
-            replace_valid_parties_authorizations ~keymap ~ledger
-              parties_dummy_auths
-          in
-          mk_rebroadcastable_test assert_pool_txs pool best_tip_diff_w parties )
+          let%bind test = setup_test () in
+          mk_parties_cmds test.txn_pool >>= mk_rebroadcastable_test test )
 
     let%test_unit "apply user cmds and zkapps" =
       Thread_safe.block_on_async_exn (fun () ->
-          let%bind assert_pool_txs, pool, _best_tip_diff_w, _frontier =
-            setup_test ()
-          in
+          let%bind t = setup_test () in
           let num_cmds = Array.length test_keys in
           (* the user cmds and snapp cmds are taken from the same list of keys,
              so splitting by the order from that list makes sure that they
@@ -3078,16 +2824,13 @@ let%test_module _ =
              therefore, the original nonces in the accounts are valid
           *)
           let take_len = num_cmds / 2 in
-          let keymap, parties_dummy_auths = mk_parties_cmds' pool in
-          let%bind zkapp_cmds =
-            replace_parties_authorizations ~keymap
-              (List.take parties_dummy_auths take_len)
+          let%bind snapp_cmds =
+            let%map cmds = mk_parties_cmds t.txn_pool in
+            List.take cmds take_len
           in
-          let user_cmds = List.drop independent_cmds' take_len in
-          let all_cmds = zkapp_cmds @ user_cmds in
-          assert_pool_txs [] ;
-          let%bind apply_res = verify_and_apply pool all_cmds in
-          [%test_eq: pool_apply] (accepted_commands apply_res) (Ok all_cmds) ;
-          assert_pool_txs all_cmds ;
-          Deferred.unit )
+          let user_cmds = List.drop independent_cmds take_len in
+          let all_cmds = snapp_cmds @ user_cmds in
+          assert_pool_txs t [] ;
+          let%bind () = add_commands' t all_cmds in
+          assert_pool_txs t all_cmds ; Deferred.unit )
   end )


### PR DESCRIPTION
Closes #10879.

This PR addresses bugs in which the application of parties transactions can invalidate transactions enqueued by other fee payers within the transaction pool. To solve the bug, I took the approach to just simplify the transaction pool by having it perform revalidation on the pool whenever the frontier's best tip changes, instead of incrementally updating the pool. There is an increased performance cost to doing this, but we now have a higher degree of confidence that the implementation will correctly prune invalid transactions.

The increased performance cost comes from the fact that we now need to load account states from the ledger in order to process best tip diffs from the frontier, which was previously not necessary. However, since the accounts we request from the best tip ledger are accounts which have been interacted with from the transactions contained in the chain reorg, we they should be available from "nearby" ledger masks in most cases, removing database interactions in naive cases. Additionally, the new implementation operates in `O(n)` in terms of number of accounts accessed and not `O(n)` in terms of number of transactions in the reorg, which will also show some improvement in performance.

One outstanding question about the PR: many of the accounts requested when processing a reorg were already requested from the ledger when the staged ledger diff was applied (in the naive case of a chain extension, this will be entire set of accounts we need). It is possible to try and share data between these 2 parts of the code, but this requires additional lift and will make things a bit ugly at the frontier level. Still, this may be a optimization worth visiting before we merge this.