### PR TITLE
Nix: change binary cache key

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
     allow-import-from-derivation = "true";
     extra-substituters = [ "https://storage.googleapis.com/mina-nix-cache" ];
     extra-trusted-public-keys = [
+      "nix-cache.minaprotocol.org:fdcuDzmnM0Kbf7yU4yywBuUEJWClySc1WIF6t6Mm8h4="
       "nix-cache.minaprotocol.org:D3B1W+V7ND1Fmfii8EhbAbF1JXoe2Ct4N34OKChwk2c="
     ];
   };


### PR DESCRIPTION
For technical reasons, we've changed the binary cache private key. Therefore, the public key also has to be updated. Add the new key to `flake.nix`.