### PR TITLE
Snarkyjs: add CI test for recursion

### DIFF
--- a/buildkite/scripts/test-snarkyjs-bindings.sh
+++ b/buildkite/scripts/test-snarkyjs-bindings.sh
@@ -26,3 +26,4 @@ cd ../../../..
 echo "Run SnarkyJS + MinaSigner tests..."
 node src/lib/snarky_js_bindings/test_module/simple-zkapp-mina-signer.js
 node src/lib/snarky_js_bindings/test_module/simple-zkapp-mock-apply.js
+node src/lib/snarky_js_bindings/test_module/inductive-proofs.js

--- a/src/lib/snarky_js_bindings/test_module/inductive-proofs.js
+++ b/src/lib/snarky_js_bindings/test_module/inductive-proofs.js
@@ -1,0 +1,47 @@
+import { SelfProof, Field, ZkProgram, isReady, shutdown } from "snarkyjs";
+import { tic, toc } from "./tictoc.js";
+
+await isReady;
+
+let MyProgram = ZkProgram({
+  publicInput: Field,
+
+  methods: {
+    baseCase: {
+      privateInputs: [],
+
+      method(publicInput) {
+        publicInput.assertEquals(Field.zero);
+      },
+    },
+
+    inductiveCase: {
+      privateInputs: [SelfProof],
+
+      method(publicInput, earlierProof) {
+        earlierProof.verify();
+        earlierProof.publicInput.add(1).assertEquals(publicInput);
+      },
+    },
+  },
+});
+
+tic("compiling MyProgram");
+await MyProgram.compile();
+toc();
+
+tic("proving base case");
+let proof = await MyProgram.baseCase(Field.zero);
+toc();
+
+tic("proving step 1");
+proof = await MyProgram.inductiveCase(Field.one, proof);
+toc();
+
+tic("proving step 2");
+proof = await MyProgram.inductiveCase(Field(2), proof);
+toc();
+
+console.log("ok?", proof.publicInput.toString() === "2");
+
+shutdown();


### PR DESCRIPTION
* [x] Fixes proof recursiion in snarkyjs, which was recently broken without noticing
* [x] To catch this the next time, adds unit test
* [x] ~~Fix recursion without resorting to `Obj.magic`~~ done by https://github.com/MinaProtocol/mina/pull/11340
