### PR TITLE
Revert and adapt #11259

### DIFF
--- a/src/dune.flags.inc
+++ b/src/dune.flags.inc
@@ -3,5 +3,6 @@
 (env
   (_
     (flags (:standard -short-paths
+            -ccopt=%{read:dune-linker}
             -cclib -ljemalloc
             -w @a-4-16-29-40-41-42-44-45-48-58-59-60-66-69-70))))

--- a/src/dune.linker.inc
+++ b/src/dune.linker.inc
@@ -1,13 +1,16 @@
 ; The content of 'dune-linker' is to be passed as a -ccopt to ocamlopt
 ; or directly to the C compiler.
-; ocamlopt -ccopt=<dune-linker> behaves correctly if <dune-linker> is empty
+; since ocamlopt -ccopt=<dune-linker> does not behave correctly
+; if <dune-linker> is empty, we pass "-O2" (which is already passed by default,
+; meaning it's a no-op) in the default case (to let the compiler choose
+; the linker)
 
 (rule
   (target dune-linker)
   (enabled_if %{bin-available:lld})
-  (action (with-stdout-to dune-linker (echo "-ccopt=%{read:dune-linker} -fuse-ld=lld"))))
+  (action (with-stdout-to dune-linker (echo "-fuse-ld=lld"))))
 
 (rule
   (target dune-linker)
   (enabled_if (= %{bin-available:lld} false))
-  (action (with-stdout-to dune-linker (echo " "))))
+  (action (with-stdout-to dune-linker (echo "-O2"))))


### PR DESCRIPTION
The changes of https://github.com/MinaProtocol/mina/pull/11259 cause a dependency cycle: `dune-linker` is now required to create `dune-linker`. If `lld` is installed, the build now just fails, and since it's removed from the main dune flags, lld would almost not be used at all anyway.

The `ccopt` was not lowered before because it is sometimes needed without the `ccopt` (for example when used in an `ocamlc_flags` stanza).

The `-ccopt=` (with nothing after =) is supposed to be accepted by `ocamlc` but if it is not on some platforms, I would rather put a no-op flag in this case (for example `-O2`, which is already passed by `ocamlc`).

@shimkiv please test if this solves your original problem