### PR TITLE
Nix: set libp2p helper path in the nix develop

### DIFF
--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -177,6 +177,7 @@ let
           mv _build/default/src/app/generate_keypair/generate_keypair.exe $generate_keypair/bin/generate_keypair
           remove-references-to -t $(dirname $(dirname $(command -v ocaml))) {$out/bin/*,$mainnet/bin/*,$testnet/bin*,$genesis/bin/*,$generate_keypair/bin/*}
         '';
+        shellHook = "export MINA_LIBP2P_HELPER_PATH=${pkgs.libp2p_helper}/bin/libp2p_helper";
       } // pkgs.lib.optionalAttrs static { OCAMLPARAM = "_,ccopt=-static"; }
         // pkgs.lib.optionalAttrs pkgs.stdenv.isDarwin {
           OCAMLPARAM = "_,cclib=-lc++";


### PR DESCRIPTION
Allows to run the daemon while in `nix develop`