### PR TITLE
Nix CI: skip pointless checkouts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
           commonExtraStepConfig = {
             agents = [ "nix" ];
             soft_fail = "true";
-            env.BUILDKITE_REPO = "";
+            plugins = [{ "thedyrt/skip-checkout#v0.1.1" = null; }];
           };
         } self;
       };


### PR DESCRIPTION
We don't actually nix Mina to be checked out for building the derivations. Skip that.