### PR TITLE
Nix CI: don't sign or push (since we run a daemon that does that)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,9 +60,6 @@
       };
       pipeline = with flake-buildkite-pipeline.lib; {
         steps = flakeSteps {
-          pushToBinaryCaches =
-            [ "s3://mina-nix-cache?endpoint=https://storage.googleapis.com" ];
-          signWithKeys = [ "/var/secrets/nix-cache-key.sec" ];
           commonExtraStepConfig = {
             agents = [ "nix" ];
             soft_fail = "true";


### PR DESCRIPTION
We now run upload-daemon that signs and pushes paths automatically.