### PR TITLE
Report failures to include transactions in blocks

### DIFF
--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -55,6 +55,7 @@
    blake2
    mina_metrics
    mina_compile_config
+   node_error_service
    mina_user_error
    file_system
    mina_version

--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -658,7 +658,7 @@ let handle_crash e ~time_controller ~conf_dir ~child_pids ~top_logger coda_ref =
   Core.print_string message
 
 let handle_shutdown ~monitor ~time_controller ~conf_dir ~child_pids ~top_logger
-    ~node_error_url ~contact_info coda_ref =
+    coda_ref =
   Monitor.detach_and_iter_errors monitor ~f:(fun exn ->
       don't_wait_for
         (let%bind () =
@@ -708,12 +708,7 @@ let handle_shutdown ~monitor ~time_controller ~conf_dir ~child_pids ~top_logger
            | _exn ->
                let error = Error.of_exn ~backtrace:`Get exn in
                let%bind () =
-                 match node_error_url with
-                 | Some node_error_url ->
-                     Node_error_service.send_report ~logger:top_logger
-                       ~node_error_url ~mina_ref:coda_ref ~error ~contact_info
-                 | None ->
-                     Deferred.unit
+                 Node_error_service.send_report ~logger:top_logger ~error
                in
                handle_crash exn ~time_controller ~conf_dir ~child_pids
                  ~top_logger coda_ref

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -497,8 +497,7 @@ module T = struct
           in
           let coda_ref : Mina_lib.t option ref = ref None in
           Coda_run.handle_shutdown ~monitor ~time_controller ~conf_dir
-            ~child_pids:pids ~top_logger:logger ~node_error_url:None
-            ~contact_info:None coda_ref ;
+            ~child_pids:pids ~top_logger:logger coda_ref ;
           let%map coda =
             with_monitor
               (fun () ->

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -109,6 +109,47 @@ end = struct
     t.timeout <- Some timeout
 end
 
+(** Sends an error to the reporting service containing as many failed transactions as we can fit. *)
+let report_transaction_inclusion_failures ~logger failed_txns =
+  let num_failures = List.length failed_txns in
+  let count_size = Fn.compose String.length Yojson.Safe.to_string in
+  let wrap_error failed_txns_json =
+    `Assoc
+      [ ( "message"
+        , `String
+            "Some transactions failed to apply to the ledger when creating the \
+             staged ledger diff" )
+      ; ("num_failures", `Int num_failures)
+      ; ("sampled_failures", failed_txns_json)
+      ]
+  in
+  let rec generate_errors failures available_bytes =
+    if available_bytes <= 0 then []
+    else
+      match failures with
+      | [] ->
+          []
+      | (txn, error) :: remaining_failures ->
+          let element =
+            `Assoc
+              [ ("transaction", User_command.Valid.to_yojson txn)
+              ; ("error", Error_json.error_to_yojson error)
+              ]
+          in
+          let element_size = count_size element in
+          (* subtract an additional byte for each element here to account for commas *)
+          element
+          :: generate_errors remaining_failures
+               (available_bytes - element_size - 1)
+  in
+  Node_error_service.send_dynamic_report ~logger
+    ~generate_error:(fun available_bytes ->
+      (* subtract 2 bytes to account for empty string *)
+      let base_error_size = count_size (wrap_error (`String "")) - 2 in
+      (* subtract 2 bytes to account for list brackets that wrap failed_txns *)
+      let leftover_bytes = available_bytes - base_error_size - 2 in
+      wrap_error (`List (generate_errors failed_txns leftover_bytes)) )
+
 let generate_next_state ~constraint_constants ~previous_protocol_state
     ~time_controller ~staged_ledger ~transactions ~get_completed_work ~logger
     ~(block_data : Consensus.Data.Block_data.t) ~winner_pk ~scheduled_time
@@ -143,24 +184,31 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
 
       let diff =
         O1trace.sync_thread "create_staged_ledger_diff" (fun () ->
-            let diff =
+            (* TODO: handle transaction inclusion failures here *)
+            let diff_result =
               Staged_ledger.create_diff ~constraint_constants staged_ledger
                 ~coinbase_receiver ~logger
                 ~current_state_view:previous_state_view
                 ~transactions_by_fee:transactions ~get_completed_work
                 ~log_block_creation ~supercharge_coinbase
+              |> Result.map ~f:(fun (diff, failed_txns) ->
+                     if not (List.is_empty failed_txns) then
+                       don't_wait_for
+                         (report_transaction_inclusion_failures ~logger
+                            failed_txns ) ;
+                     diff )
               |> Result.map_error ~f:(fun err ->
                      Staged_ledger.Staged_ledger_error.Pre_diff err )
             in
-            match (diff, block_reward_threshold) with
-            | Ok d, Some threshold ->
+            match (diff_result, block_reward_threshold) with
+            | Ok diff, Some threshold ->
                 let net_return =
                   Option.value ~default:Currency.Amount.zero
                     (Staged_ledger_diff.net_return ~constraint_constants
                        ~supercharge_coinbase
-                       (Staged_ledger_diff.forget d) )
+                       (Staged_ledger_diff.forget diff) )
                 in
-                if Currency.Amount.(net_return >= threshold) then diff
+                if Currency.Amount.(net_return >= threshold) then diff_result
                 else (
                   [%log info]
                     "Block reward $reward is less than the min-block-reward \
@@ -173,7 +221,7 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
                     Staged_ledger_diff.With_valid_signatures_and_proofs
                     .empty_diff )
             | _ ->
-                diff )
+                diff_result )
       in
       match%map
         let%bind.Deferred.Result diff = return diff in

--- a/src/lib/block_producer/dune
+++ b/src/lib/block_producer/dune
@@ -55,6 +55,7 @@
    genesis_constants
    data_hash_lib
    sgn
+   node_error_service
  )
  (preprocess
   (pps ppx_coda ppx_version ppx_jane ppx_register_event))

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -92,6 +92,7 @@
    data_hash_lib
    transition_handler
    ppx_version.runtime
+   node_error_service
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_coda ppx_version ppx_inline_test ppx_deriving.std))

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -116,6 +116,8 @@ val get_inferred_nonce_from_transaction_pool_and_ledger :
 
 val active_or_bootstrapping : t -> unit Participating_state.t
 
+val get_node_state : t -> Node_error_service.node_state Deferred.t
+
 val best_staged_ledger : t -> Staged_ledger.t Participating_state.t
 
 val best_ledger : t -> Mina_ledger.Ledger.t Participating_state.t

--- a/src/lib/node_error_service/dune
+++ b/src/lib/node_error_service/dune
@@ -28,7 +28,6 @@
     pipe_lib
     transition_frontier
     logger
-    mina_lib
     node_addrs_and_ports
     mina_version
     participating_state

--- a/src/lib/node_error_service/node_error_service.ml
+++ b/src/lib/node_error_service/node_error_service.ml
@@ -1,20 +1,23 @@
 open Async
 open Core
-open Pipe_lib
 open Signature_lib
 
-type catchup_job_states = Transition_frontier.Full_catchup_tree.job_states =
-  { finished : int
-  ; failed : int
-  ; to_download : int
-  ; to_initial_validate : int
-  ; wait_for_parent : int
-  ; to_verify : int
-  ; to_build_breadcrumb : int
-  }
-[@@deriving to_yojson]
+(* needs to be kept in sync with the constant in minaprotocol/mina-deployments:src/node-status-error-system-backend/node_error/src/index.js *)
+let max_report_bytes = 10_000
 
-type node_error_data =
+type node_state =
+  { peer_id : string
+  ; ip_address : string
+  ; chain_id : string
+  ; public_key : Public_key.Compressed.t option
+  ; catchup_job_states : Transition_frontier.Full_catchup_tree.job_states option
+  ; block_height_at_best_tip : int option
+  ; sync_status : Sync_status.t
+  ; hardware_info : string list option
+  ; uptime_of_node : string
+  }
+
+type node_error_report =
   { version : int
   ; peer_id : string
   ; ip_address : string
@@ -27,7 +30,7 @@ type node_error_data =
   ; timestamp : string
   ; id : string
   ; error : Yojson.Safe.t
-  ; catchup_job_states : catchup_job_states option
+  ; catchup_job_states : Transition_frontier.Full_catchup_tree.job_states option
   ; sync_status : Sync_status.t
   ; block_height_at_best_tip : int option
   ; max_observed_block_height : int
@@ -36,125 +39,147 @@ type node_error_data =
   }
 [@@deriving to_yojson]
 
-let send_node_error_data ~logger ~url node_error_data =
-  let node_error_json = node_error_data_to_yojson node_error_data in
-  let json = `Assoc [ ("data", node_error_json) ] in
-  let headers =
-    Cohttp.Header.of_list [ ("Content-Type", "application/json") ]
-  in
-  match%map
-    Async.try_with (fun () ->
-        Cohttp_async.Client.post ~headers
-          ~body:(Yojson.Safe.to_string json |> Cohttp_async.Body.of_string)
-          url )
-  with
-  | Ok ({ status; _ }, body) ->
-      let metadata =
-        [ ("data", node_error_json); ("url", `String (Uri.to_string url)) ]
-      in
-      if Cohttp.Code.code_of_status status = 200 then
-        [%log info] "Sent node error data to URL $url" ~metadata
-      else
-        let extra_metadata =
-          match body with
-          | `String s ->
-              [ ("error", `String s) ]
-          | `Strings ss ->
-              [ ("error", `List (List.map ss ~f:(fun s -> `String s))) ]
-          | `Empty | `Pipe _ ->
-              []
+type config =
+  { get_node_state : unit -> node_state option Deferred.t
+  ; node_error_url : Uri.t
+  ; contact_info : string option
+  }
+
+let config = ref None
+
+let set_config ~get_node_state ~node_error_url ~contact_info =
+  if Option.is_some !config then
+    failwith "Node_error_service.set_config called more than once"
+  else config := Some { get_node_state; node_error_url; contact_info }
+
+let serialize_report report =
+  `Assoc [ ("data", node_error_report_to_yojson report) ]
+
+let send_node_error_report ~logger ~url report =
+  let json = serialize_report report in
+  let json_string = Yojson.Safe.to_string json in
+  (* TODO: move length check to to send_node_error_data *)
+  if String.length json_string > max_report_bytes then (
+    [%log error]
+      "Could not send error report because generated error exceeded max report \
+       size" ;
+    Deferred.unit )
+  else
+    let headers =
+      Cohttp.Header.of_list [ ("Content-Type", "application/json") ]
+    in
+    match%map
+      Async.try_with (fun () ->
+          Cohttp_async.Client.post ~headers
+            ~body:(Cohttp_async.Body.of_string json_string)
+            url )
+    with
+    | Ok ({ status; _ }, body) ->
+        let metadata =
+          [ ("data", json); ("url", `String (Uri.to_string url)) ]
         in
+        if Cohttp.Code.code_of_status status = 200 then
+          [%log info] "Sent node error data to URL $url" ~metadata
+        else
+          let extra_metadata =
+            match body with
+            | `String s ->
+                [ ("error", `String s) ]
+            | `Strings ss ->
+                [ ("error", `List (List.map ss ~f:(fun s -> `String s))) ]
+            | `Empty | `Pipe _ ->
+                []
+          in
+          [%log error] "Failed to send node error data to URL $url"
+            ~metadata:(metadata @ extra_metadata)
+    | Error e ->
         [%log error] "Failed to send node error data to URL $url"
-          ~metadata:(metadata @ extra_metadata)
-  | Error e ->
-      [%log error] "Failed to send node error data to URL $url"
-        ~metadata:
-          [ ("error", `String (Exn.to_string e))
-          ; ("url", `String (Uri.to_string url))
-          ]
+          ~metadata:
+            [ ("error", `String (Exn.to_string e))
+            ; ("url", `String (Uri.to_string url))
+            ]
 
-let send_report ~logger ~node_error_url ~mina_ref ~error ~contact_info =
-  match !mina_ref with
+let with_deps ~logger ~f =
+  match !config with
   | None ->
-      [%log info] "Crashed before mina instance was created." ;
+      [%log error]
+        "Could not send error report: Node_error_service was not configured" ;
       Deferred.unit
-  | Some mina ->
-      let config = Mina_lib.config mina in
-      let addrs_and_ports = config.gossip_net_params.addrs_and_ports in
-      let peer_id =
-        (Node_addrs_and_ports.to_peer_exn addrs_and_ports).peer_id
-      in
-      let ip_address =
-        Node_addrs_and_ports.external_ip addrs_and_ports
-        |> Core.Unix.Inet_addr.to_string
-      in
-      let commit_hash = Mina_version.commit_id in
-      let git_branch = Mina_version.branch in
-      let chain_id = config.chain_id in
-      let public_key =
-        let key_list =
-          Mina_lib.block_production_pubkeys mina
-          |> Public_key.Compressed.Set.to_list
-        in
-        if List.is_empty key_list then None else Some (List.hd_exn key_list)
-      in
-      let timestamp = Rfc3339_time.get_rfc3339_time () in
-      let id = Uuid_unix.create () |> Uuid.to_string in
-      let catchup_job_states =
-        match
-          Broadcast_pipe.Reader.peek @@ Mina_lib.transition_frontier mina
-        with
-        | None ->
-            None
-        | Some tf -> (
-            match Transition_frontier.catchup_tree tf with
-            | Full catchup_tree ->
-                Some
-                  (Transition_frontier.Full_catchup_tree.to_node_status_report
-                     catchup_tree )
-            | _ ->
-                None )
-      in
-      let block_height_at_best_tip =
-        Mina_lib.best_tip mina
-        |> Participating_state.map ~f:(fun b ->
-               Transition_frontier.Breadcrumb.consensus_state b
-               |> Consensus.Data.Consensus_state.blockchain_length
-               |> Mina_numbers.Length.to_uint32 )
-        |> Participating_state.map ~f:Unsigned.UInt32.to_int
-        |> Participating_state.active
-      in
+  | Some { get_node_state; node_error_url; contact_info } -> (
+      match%bind get_node_state () with
+      | None ->
+          [%log info]
+            "Could not send error report: mina instance has not been created \
+             yet." ;
+          Deferred.unit
+      | Some node_state ->
+          f ~node_state ~node_error_url ~contact_info )
 
-      let sync_status =
-        Mina_lib.sync_status mina |> Mina_incremental.Status.Observer.value_exn
-      in
-      let%bind hardware_info = Mina_lib.Conf_dir.get_hw_info () in
-      send_node_error_data ~logger
-        ~url:(Uri.of_string node_error_url)
-        { version = 1
-        ; peer_id
-        ; ip_address
-        ; public_key
-        ; git_branch
-        ; commit_hash
-        ; chain_id
-        ; contact_info
-        ; hardware_info
-        ; timestamp
-        ; id
-        ; error = Error_json.error_to_yojson error
-        ; catchup_job_states
-        ; sync_status
-        ; block_height_at_best_tip
-        ; max_observed_block_height =
-            !Mina_metrics.Transition_frontier.max_blocklength_observed
-        ; max_observed_unvalidated_block_height =
-            !Mina_metrics.Transition_frontier
-             .max_unvalidated_blocklength_observed
-        ; uptime_of_node =
-            Time.(
-              Span.to_string_hum
-              @@ Time.diff (now ())
-                   (Time_ns.to_time_float_round_nearest_microsecond
-                      Mina_lib.daemon_start_time ))
-        }
+let generate_report ~node_state ~contact_info error =
+  let commit_hash = Mina_version.commit_id in
+  let git_branch = Mina_version.branch in
+  let timestamp = Rfc3339_time.get_rfc3339_time () in
+  let id = Uuid_unix.create () |> Uuid.to_string in
+  let ({ peer_id
+       ; ip_address
+       ; public_key
+       ; chain_id
+       ; hardware_info
+       ; catchup_job_states
+       ; sync_status
+       ; block_height_at_best_tip
+       ; uptime_of_node
+       }
+        : node_state ) =
+    node_state
+  in
+  Some
+    { version = 1
+    ; peer_id
+    ; ip_address
+    ; public_key
+    ; git_branch
+    ; commit_hash
+    ; chain_id
+    ; contact_info
+    ; hardware_info
+    ; timestamp
+    ; id
+    ; error
+    ; catchup_job_states
+    ; sync_status
+    ; block_height_at_best_tip
+    ; max_observed_block_height =
+        !Mina_metrics.Transition_frontier.max_blocklength_observed
+    ; max_observed_unvalidated_block_height =
+        !Mina_metrics.Transition_frontier.max_unvalidated_blocklength_observed
+    ; uptime_of_node
+    }
+
+let send_dynamic_report ~logger ~generate_error =
+  with_deps ~logger ~f:(fun ~node_state ~node_error_url ~contact_info ->
+      match generate_report ~node_state ~contact_info (`String "") with
+      | None ->
+          Deferred.unit
+      | Some base_report ->
+          (* subtract 2 bytes for the size of empty string in json *)
+          let base_report_size =
+            String.length (Yojson.Safe.to_string @@ serialize_report base_report)
+            - 2
+          in
+          let available_bytes = max_report_bytes - base_report_size in
+          let report =
+            { base_report with error = generate_error available_bytes }
+          in
+          send_node_error_report ~logger ~url:node_error_url report )
+
+let send_report ~logger ~error =
+  with_deps ~logger ~f:(fun ~node_state ~node_error_url ~contact_info ->
+      match
+        generate_report ~node_state ~contact_info
+          (Error_json.error_to_yojson error)
+      with
+      | None ->
+          Deferred.unit
+      | Some report ->
+          send_node_error_report ~logger ~url:node_error_url report )

--- a/src/lib/node_error_service/node_error_service.mli
+++ b/src/lib/node_error_service/node_error_service.mli
@@ -1,0 +1,26 @@
+open Async
+open Core
+open Signature_lib
+
+type node_state =
+  { peer_id : string
+  ; ip_address : string
+  ; chain_id : string
+  ; public_key : Public_key.Compressed.t option
+  ; catchup_job_states : Transition_frontier.Full_catchup_tree.job_states option
+  ; block_height_at_best_tip : int option
+  ; sync_status : Sync_status.t
+  ; hardware_info : string list option
+  ; uptime_of_node : string
+  }
+
+val set_config :
+     get_node_state:(unit -> node_state option Deferred.t)
+  -> node_error_url:Uri.t
+  -> contact_info:string option
+  -> unit
+
+val send_dynamic_report :
+  logger:Logger.t -> generate_error:(int -> Yojson.Safe.t) -> unit Deferred.t
+
+val send_report : logger:Logger.t -> error:Error.t -> unit Deferred.t

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -173,6 +173,7 @@ val create_diff :
         -> Transaction_snark_work.Checked.t option )
   -> supercharge_coinbase:bool
   -> ( Staged_ledger_diff.With_valid_signatures_and_proofs.t
+       * (User_command.Valid.t * Error.t) list
      , Pre_diff_info.Error.t )
      Result.t
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -347,7 +347,7 @@ module For_tests = struct
           , Option.value_exn prev_state_hashes.state_body_hash ) )
       in
       let coinbase_receiver = largest_account_public_key in
-      let staged_ledger_diff =
+      let staged_ledger_diff, _invalid_txns =
         Staged_ledger.create_diff parent_staged_ledger ~logger
           ~constraint_constants:precomputed_values.constraint_constants
           ~coinbase_receiver ~current_state_view ~supercharge_coinbase


### PR DESCRIPTION
For #11272.

This PR updates the daemon to send error reports whenever it produces a block, but fails to include transactions into that block. In order to facilitate this change, the `Node_error_service` had to be refactored some to fix a circular dependency and to allow external code to generate error data based on the available space in the report. This logic is used to include as many failed transactions as we can in the error report without exceeding the maximum message size.