### PR TITLE
Nix CI: upload artifacts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1654768881,
-        "narHash": "sha256-XuSUp870TDDETi5rs+R7VklxMm29u8BUVnM6lfbQq7w=",
+        "lastModified": 1656444434,
+        "narHash": "sha256-q3v+AOzwTtfxTngPmqlt2U9OLkW1LW51RKduQ8TSHdA=",
         "owner": "tweag",
         "repo": "flake-buildkite-pipeline",
-        "rev": "d420396096b405c8eae22801b3723a30a8ff48f4",
+        "rev": "ecd0eeaab42124f4438a9b59caed0c9d2719aa0a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -59,15 +59,32 @@
           }
         ];
       };
-      pipeline = with flake-buildkite-pipeline.lib; {
-        steps = flakeSteps {
-          reproduceRepo = "mina";
-          commonExtraStepConfig = {
-            agents = [ "nix" ];
+      pipeline = with flake-buildkite-pipeline.lib;
+        let
+          pushToRegistry = package: {
+            command = runInEnv self.devShells.x86_64-linux.operations
+              ''
+                skopeo \
+                copy \
+                --insecure-policy \
+                --dest-registry-token $(gcloud auth application-default print-access-token) \
+                docker-archive:${self.packages.x86_64-linux.${package}} \
+                docker://us-west2-docker.pkg.dev/o1labs-192920/nix-containers/${package}:$BUILDKITE_BRANCH
+              '';
+            label = "Upload mina-docker to Google Artifact Registry";
+            depends_on = [ "packages_x86_64-linux_${package}" ];
             plugins = [{ "thedyrt/skip-checkout#v0.1.1" = null; }];
+            # branches = [ "compatible" "develop" ];
           };
-        } self;
-      };
+        in {
+          steps = flakeSteps {
+            reproduceRepo = "mina";
+            commonExtraStepConfig = {
+              agents = [ "nix" ];
+              plugins = [{ "thedyrt/skip-checkout#v0.1.1" = null; }];
+            };
+          } self ++ [ (pushToRegistry "mina-docker") ];
+        };
     } // utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system}.extend
@@ -230,6 +247,9 @@
             popd
           '';
         });
+
+        devShells.operations =
+          pkgs.mkShell { packages = with pkgs; [ skopeo google-cloud-sdk ]; };
 
         devShells.impure = import ./nix/impure-shell.nix pkgs;
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,9 +61,9 @@
       };
       pipeline = with flake-buildkite-pipeline.lib; {
         steps = flakeSteps {
+          reproduceRepo = "mina";
           commonExtraStepConfig = {
             agents = [ "nix" ];
-            soft_fail = "true";
             plugins = [{ "thedyrt/skip-checkout#v0.1.1" = null; }];
           };
         } self;


### PR DESCRIPTION
Upload nix-built containers to Google Artifact Registry using skopeo.

Also update flake-buildkite-pipeline to get some nice instructions on reproducing failures.

Closes #11125 