### PR TITLE
Transaction pool parties async bug fix

### DIFF
--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -20,7 +20,8 @@ module Send_user_commands = struct
   [@@deriving bin_io_unversioned]
 
   type response =
-    ( Network_pool.Transaction_pool.Diff_versioned.Stable.Latest.t
+    ( [ `Broadcasted | `Not_broadcasted ]
+    * Network_pool.Transaction_pool.Diff_versioned.Stable.Latest.t
     * Network_pool.Transaction_pool.Diff_versioned.Rejected.Stable.Latest.t )
     Or_error.t
   [@@deriving bin_io_unversioned]

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -71,22 +71,29 @@ let setup_and_submit_user_command t (user_command_input : User_command_input.t)
   let%map result = Mina_lib.add_transactions t [ user_command_input ] in
   txn_count := !txn_count + 1 ;
   match result with
-  | Ok ([], [ failed_txn ]) ->
+  | Ok (_, [], [ failed_txn ]) ->
       Error
         (Error.of_string
            (sprintf !"%s"
               ( Network_pool.Transaction_pool.Resource_pool.Diff.Diff_error
                 .to_yojson (snd failed_txn)
               |> Yojson.Safe.to_string ) ) )
-  | Ok ([ Signed_command txn ], []) ->
+  | Ok (`Broadcasted, [ Signed_command txn ], []) ->
       [%log' info (Mina_lib.top_level_logger t)]
         ~metadata:[ ("command", User_command.to_yojson (Signed_command txn)) ]
         "Scheduled command $command" ;
       Ok txn
-  | Ok (valid_commands, invalid_commands) ->
+  | Ok (decision, valid_commands, invalid_commands) ->
       [%log' info (Mina_lib.top_level_logger t)]
         ~metadata:
-          [ ( "valid_commands"
+          [ ( "decision"
+            , `String
+                ( match decision with
+                | `Broadcasted ->
+                    "broadcasted"
+                | `Not_broadcasted ->
+                    "not_broadcasted" ) )
+          ; ( "valid_commands"
             , `List (List.map ~f:User_command.to_yojson valid_commands) )
           ; ( "invalid_commands"
             , `List
@@ -120,22 +127,29 @@ let setup_and_submit_snapp_command t (snapp_parties : Parties.t) =
   let%map result = Mina_lib.add_snapp_transactions t [ snapp_parties ] in
   txn_count := !txn_count + 1 ;
   match result with
-  | Ok ([], [ failed_txn ]) ->
+  | Ok (_, [], [ failed_txn ]) ->
       Error
         (Error.of_string
            (sprintf !"%s"
               ( Network_pool.Transaction_pool.Resource_pool.Diff.Diff_error
                 .to_yojson (snd failed_txn)
               |> Yojson.Safe.to_string ) ) )
-  | Ok ([ User_command.Parties txn ], []) ->
+  | Ok (`Broadcasted, [ User_command.Parties txn ], []) ->
       [%log' info (Mina_lib.top_level_logger t)]
         ~metadata:[ ("snapp_command", Parties.to_yojson txn) ]
         "Scheduled Snapp command $snapp_command" ;
       Ok txn
-  | Ok (valid_commands, invalid_commands) ->
+  | Ok (decision, valid_commands, invalid_commands) ->
       [%log' info (Mina_lib.top_level_logger t)]
         ~metadata:
-          [ ( "valid_snapp_commands"
+          [ ( "decision"
+            , `String
+                ( match decision with
+                | `Broadcasted ->
+                    "broadcasted"
+                | `Not_broadcasted ->
+                    "not_broadcasted" ) )
+          ; ( "valid_snapp_commands"
             , `List (List.map ~f:User_command.to_yojson valid_commands) )
           ; ( "invalid_snapp_commands"
             , `List

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3693,8 +3693,10 @@ module Mutations = struct
           Mina_lib.add_full_transactions mina
             [ User_command.Signed_command signed_command ]
         with
-        | Ok ([ (User_command.Signed_command signed_command as transaction) ], _)
-          ->
+        | Ok
+            ( `Broadcasted
+            , [ (User_command.Signed_command signed_command as transaction) ]
+            , _ ) ->
             Ok
               (Types.User_command.mk_user_command
                  { status = Enqueued
@@ -3705,7 +3707,7 @@ module Mutations = struct
                  } )
         | Error err ->
             Error (Error.to_string_hum err)
-        | Ok ([], [ (_, diff_error) ]) ->
+        | Ok (_, [], [ (_, diff_error) ]) ->
             let diff_error =
               Network_pool.Transaction_pool.Resource_pool.Diff.Diff_error
               .to_string_hum diff_error

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -83,7 +83,8 @@ type pipes =
       Strict_pipe.Writer.t
   ; user_command_input_writer :
       ( command_inputs
-        * (   ( Network_pool.Transaction_pool.Resource_pool.Diff.t
+        * (   ( [ `Broadcasted | `Not_broadcasted ]
+              * Network_pool.Transaction_pool.Resource_pool.Diff.t
               * Network_pool.Transaction_pool.Resource_pool.Diff.Rejected.t )
               Or_error.t
            -> unit )

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -91,21 +91,24 @@ val get_current_nonce :
 val add_transactions :
      t
   -> User_command_input.t list
-  -> ( Network_pool.Transaction_pool.Resource_pool.Diff.t
+  -> ( [ `Broadcasted | `Not_broadcasted ]
+     * Network_pool.Transaction_pool.Resource_pool.Diff.t
      * Network_pool.Transaction_pool.Resource_pool.Diff.Rejected.t )
      Deferred.Or_error.t
 
 val add_full_transactions :
      t
   -> User_command.t list
-  -> ( Network_pool.Transaction_pool.Resource_pool.Diff.t
+  -> ( [ `Broadcasted | `Not_broadcasted ]
+     * Network_pool.Transaction_pool.Resource_pool.Diff.t
      * Network_pool.Transaction_pool.Resource_pool.Diff.Rejected.t )
      Deferred.Or_error.t
 
 val add_snapp_transactions :
      t
   -> Parties.t list
-  -> ( Network_pool.Transaction_pool.Resource_pool.Diff.t
+  -> ( [ `Broadcasted | `Not_broadcasted ]
+     * Network_pool.Transaction_pool.Resource_pool.Diff.t
      * Network_pool.Transaction_pool.Resource_pool.Diff.Rejected.t )
      Deferred.Or_error.t
 

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -94,7 +94,6 @@ module Command_error = struct
         | `Timestamp_predicate of string ]
         * [ `Global_slot_since_genesis of Mina_numbers.Global_slot.t ]
     | Unwanted_fee_token of Token_id.t
-    | Verification_failed
   [@@deriving sexp, to_yojson]
 
   let grounds_for_diff_rejection : t -> bool = function
@@ -103,7 +102,7 @@ module Command_error = struct
     | Insufficient_funds _
     | Insufficient_replace_fee _ ->
         false
-    | Overflow | Bad_token | Unwanted_fee_token _ | Verification_failed ->
+    | Overflow | Bad_token | Unwanted_fee_token _ ->
         true
 end
 
@@ -312,6 +311,9 @@ let member : t -> Transaction_hash.User_command.t -> bool =
  fun t cmd ->
   Option.is_some
     (Map.find t.all_by_hash (Transaction_hash.User_command.hash cmd))
+
+let has_commands_for_fee_payer : t -> Account_id.t -> bool =
+ fun t account_id -> Map.mem t.all_by_sender account_id
 
 let all_from_account :
        t
@@ -983,10 +985,7 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
 
   let rec add_from_gossip_exn :
          config:Config.t
-      -> verify:(User_command.Verifiable.t -> (User_command.Valid.t, _, _) M.t)
-      -> [ `Unchecked of
-           Transaction_hash.User_command.t * User_command.Verifiable.t
-         | `Checked of Transaction_hash.User_command_with_valid_signature.t ]
+      -> Transaction_hash.User_command_with_valid_signature.t
       -> Account_nonce.t
       -> Currency.Amount.t
       -> Sender_local_state.t ref
@@ -995,27 +994,11 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
          , Update.single
          , Command_error.t )
          M.t =
-   fun ~config:({ constraint_constants; expiry_ns; _ } as config) ~verify cmd0
+   fun ~config:({ constraint_constants; expiry_ns; _ } as config) cmd
        current_nonce balance by_sender ->
     let open Command_error in
-    let unchecked_cmd =
-      match cmd0 with
-      | `Unchecked (x, _) ->
-          x
-      | `Checked x ->
-          Transaction_hash.User_command.of_checked x
-    in
+    let unchecked_cmd = Transaction_hash.User_command.of_checked cmd in
     let open M.Let_syntax in
-    let verified () =
-      match cmd0 with
-      | `Checked x ->
-          return x
-      | `Unchecked (_, unchecked) ->
-          let%map x = verify unchecked in
-          Transaction_hash.(
-            User_command_with_valid_signature.make x
-              (User_command.hash unchecked_cmd))
-    in
     let unchecked = Transaction_hash.User_command.data unchecked_cmd in
     let fee = User_command.fee unchecked in
     let fee_per_wu = User_command.fee_per_wu unchecked in
@@ -1070,7 +1053,6 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
               in
               ())
         in
-        let%bind cmd = verified () in
         let%map () =
           M.write
             (Update.Add
@@ -1111,7 +1093,6 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
                 in
                 reserved_currency')
           in
-          let%bind cmd = verified () in
           let new_state =
             (F_sequence.snoc queued_cmds cmd, reserved_currency')
           in
@@ -1180,12 +1161,10 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
             Transaction_hash.User_command_with_valid_signature.t Sequence.t]
             dropped
             (F_sequence.to_seq drop_queue) ;
-          let%bind cmd = verified () in
           (* Add the new transaction *)
           let%bind cmd, _ =
             let%map v, dropped' =
-              add_from_gossip_exn ~config ~verify (`Checked cmd) current_nonce
-                balance by_sender
+              add_from_gossip_exn ~config cmd current_nonce balance by_sender
             in
             (* We've already removed them, so this should always be empty. *)
             assert (Sequence.is_empty dropped') ;
@@ -1224,19 +1203,18 @@ module Add_from_gossip_exn (M : Writer_result.S) = struct
                   let current_nonce = Account_nonce.succ current_nonce in
                   let by_sender_pre = !by_sender in
                   M.catch
-                    (add_from_gossip_exn ~config ~verify (`Checked cmd)
-                       current_nonce balance by_sender )
-                    ~f:(function
-                      | Ok ((_v, dropped_), ups) ->
-                          assert (Sequence.is_empty dropped_) ;
-                          let%bind () = M.write_all ups in
-                          go increment dropped' None current_nonce
-                      | Error _err ->
-                          by_sender := by_sender_pre ;
-                          (* Re-evaluate with the same [dropped] to calculate the new
-                             fee increment.
-                          *)
-                          go increment dropped (Some dropped') current_nonce )
+                    (add_from_gossip_exn ~config cmd current_nonce balance
+                       by_sender ) ~f:(function
+                    | Ok ((_v, dropped_), ups) ->
+                        assert (Sequence.is_empty dropped_) ;
+                        let%bind () = M.write_all ups in
+                        go increment dropped' None current_nonce
+                    | Error _err ->
+                        by_sender := by_sender_pre ;
+                        (* Re-evaluate with the same [dropped] to calculate the new
+                           fee increment.
+                        *)
+                        go increment dropped (Some dropped') current_nonce )
             in
             go increment drop_tail None current_nonce
           in
@@ -1259,47 +1237,14 @@ end
 
 module Add_from_gossip_exn0 = Add_from_gossip_exn (Writer_result)
 
-let add_from_gossip_exn t ~verify cmd0 nonce balance :
-    ( Transaction_hash.User_command_with_valid_signature.t
-      * t
-      * Transaction_hash.User_command_with_valid_signature.t Sequence.t
-    , Command_error.t )
-    Result.t =
-  let x =
-    Add_from_gossip_exn0.add_from_gossip_exn ~config:t.config
-      ~verify:(fun c ->
-        Result.of_option (verify c) ~error:Command_error.Verification_failed
-        |> Writer_result.of_result )
-      cmd0 nonce balance
+let add_from_gossip_exn t cmd nonce balance =
+  let open Result.Let_syntax in
+  let%map (c, cs), t =
+    run' t cmd
+      (Add_from_gossip_exn0.add_from_gossip_exn ~config:t.config cmd nonce
+         balance )
   in
-  Result.map
-    ~f:(fun ((c, cs), t) -> (c, t, cs))
-    ( match cmd0 with
-    | `Checked cmd ->
-        run' t cmd x
-    | `Unchecked (cmd, _) ->
-        run t
-          ~sender:
-            (User_command.fee_payer (Transaction_hash.User_command.command cmd))
-          x )
-
-module Add_from_gossip_exn_async = Add_from_gossip_exn (Writer_result.Deferred)
-
-let add_from_gossip_exn_async ~config
-    ~(sender_local_state : Sender_local_state.t) ~verify cmd0 nonce balance =
-  let open Async in
-  let r = ref sender_local_state in
-  let x =
-    Add_from_gossip_exn_async.add_from_gossip_exn ~config
-      ~verify:(fun c ->
-        Writer_result.Deferred.Deferred
-          (Deferred.map (verify c) ~f:(fun r ->
-               Result.of_option r ~error:Command_error.Verification_failed
-               |> Writer_result.of_result ) ) )
-      cmd0 nonce balance r
-  in
-  Deferred.Result.map (Writer_result.Deferred.run x) ~f:(fun ((c, cs), us) ->
-      ((c, Sequence.to_list cs), !r, us) )
+  (c, t, cs)
 
 (** Add back the commands that were removed due to a reorg*)
 let add_from_backtrack :
@@ -1426,14 +1371,11 @@ let%test_module _ =
 
     let%test_unit "empty invariants" = assert_invariants empty
 
-    let don't_verify _ = None
-
     let%test_unit "singleton properties" =
       Quickcheck.test (gen_cmd ()) ~f:(fun cmd ->
           let pool = empty in
           let add_res =
-            add_from_gossip_exn pool (`Checked cmd) Account_nonce.zero
-              ~verify:don't_verify
+            add_from_gossip_exn pool cmd Account_nonce.zero
               (Currency.Amount.of_int 500)
           in
           if
@@ -1474,8 +1416,7 @@ let%test_module _ =
               config = { empty.config with expiry_ns = Time_ns.Span.of_sec 5.0 }
             }
           in
-          add_from_gossip_exn pool (`Checked cmd) Account_nonce.zero
-            ~verify:don't_verify
+          add_from_gossip_exn pool cmd Account_nonce.zero
             (Currency.Amount.of_int 3000_000_000_000_000)
           |> function
           | Ok (_, pool', dropped) ->
@@ -1533,7 +1474,7 @@ let%test_module _ =
                 let account_id = User_command.fee_payer unchecked in
                 let pk = Account_id.public_key account_id in
                 let add_res =
-                  add_from_gossip_exn !pool (`Checked cmd) ~verify:don't_verify
+                  add_from_gossip_exn !pool cmd
                     (Hashtbl.find_exn nonces pk)
                     (Hashtbl.find_exn balances pk)
                 in
@@ -1571,9 +1512,6 @@ let%test_module _ =
                     failwith "Overflow."
                 | Error Bad_token ->
                     failwith "Token is incompatible with the command."
-                | Error Verification_failed ->
-                    failwith
-                      "Transaction had invalid proof/signature or was malformed"
                 | Error (Unwanted_fee_token fee_token) ->
                     failwithf
                       !"Bad fee token. The fees are paid in token %{sexp: \
@@ -1709,10 +1647,7 @@ let%test_module _ =
         ~f:(fun (init_nonce, init_balance, setup_cmds, replace_cmd) ->
           let t =
             List.fold_left setup_cmds ~init:empty ~f:(fun t cmd ->
-                match
-                  add_from_gossip_exn t (`Checked cmd) init_nonce init_balance
-                    ~verify:don't_verify
-                with
+                match add_from_gossip_exn t cmd init_nonce init_balance with
                 | Ok (_, t', removed) ->
                     [%test_eq:
                       Transaction_hash.User_command_with_valid_signature.t
@@ -1771,8 +1706,7 @@ let%test_module _ =
               Currency.Amount.(a + replacer_currency_consumed))
           in
           let add_res =
-            add_from_gossip_exn t (`Checked replace_cmd) init_nonce init_balance
-              ~verify:don't_verify
+            add_from_gossip_exn t replace_cmd init_nonce init_balance
           in
           if Currency.Amount.(currency_consumed_post_replace <= init_balance)
           then
@@ -1806,8 +1740,7 @@ let%test_module _ =
         , List.tl_exn cmds_sorted_by_fee_per_wu )
       in
       let insert_cmd pool cmd =
-        add_from_gossip_exn ~verify:don't_verify pool (`Checked cmd)
-          Account_nonce.zero
+        add_from_gossip_exn pool cmd Account_nonce.zero
           (Currency.Amount.of_int (500 * 10_000_000))
         |> Result.ok |> Option.value_exn
         |> fun (_, pool, _) -> pool
@@ -1848,8 +1781,7 @@ let%test_module _ =
       in
       let max_by_fee_per_wu = List.max_elt ~compare cmds |> Option.value_exn in
       let insert_cmd pool cmd =
-        add_from_gossip_exn ~verify:don't_verify pool (`Checked cmd)
-          Account_nonce.zero
+        add_from_gossip_exn pool cmd Account_nonce.zero
           (Currency.Amount.of_int (500 * 10_000_000))
         |> Result.ok |> Option.value_exn
         |> fun (_, pool, _) -> pool
@@ -1884,8 +1816,7 @@ let%test_module _ =
 
     let add_to_pool ~nonce ~balance pool cmd =
       let _, pool', dropped =
-        add_from_gossip_exn pool (`Checked cmd) ~verify:don't_verify nonce
-          balance
+        add_from_gossip_exn pool cmd nonce balance
         |> Result.map_error
              ~f:(Fn.compose Sexp.to_string Command_error.sexp_of_t)
         |> Result.ok_or_failwith

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -28,7 +28,6 @@ module Command_error : sig
         | `Timestamp_predicate of string ]
         * [ `Global_slot_since_genesis of Mina_numbers.Global_slot.t ]
     | Unwanted_fee_token of Mina_base.Token_id.t
-    | Verification_failed
   [@@deriving sexp, to_yojson]
 
   val grounds_for_diff_rejection : t -> bool
@@ -107,36 +106,9 @@ val get_highest_fee :
     are required to keep the pool in sync with the ledger you are applying
     transactions against.
 *)
-val add_from_gossip_exn_async :
-     config:Config.t
-  -> sender_local_state:Sender_local_state.t
-  -> verify:
-       (   User_command.Verifiable.t
-        -> User_command.Valid.t option Async.Deferred.t )
-  -> [ `Unchecked of Transaction_hash.User_command.t * User_command.Verifiable.t
-     | `Checked of Transaction_hash.User_command_with_valid_signature.t ]
-  -> Account_nonce.t
-  -> Currency.Amount.t
-  -> ( ( Transaction_hash.User_command_with_valid_signature.t
-       * Transaction_hash.User_command_with_valid_signature.t list )
-       * Sender_local_state.t
-       * Update.t
-     , Command_error.t )
-     Async.Deferred.Result.t
-(** Returns the commands dropped as a result of adding the command, which will
-    be empty unless we're replacing one. *)
-
-(** Add a command to the pool. Pass the current nonce for the account and
-    its current balance. Throws if the contents of the pool before adding the
-    new command are invalid given the supplied current nonce and balance - you
-    are required to keep the pool in sync with the ledger you are applying
-    transactions against.
-*)
 val add_from_gossip_exn :
      t
-  -> verify:(User_command.Verifiable.t -> User_command.Valid.t option)
-  -> [ `Unchecked of Transaction_hash.User_command.t * User_command.Verifiable.t
-     | `Checked of Transaction_hash.User_command_with_valid_signature.t ]
+  -> Transaction_hash.User_command_with_valid_signature.t
   -> Account_nonce.t
   -> Currency.Amount.t
   -> ( Transaction_hash.User_command_with_valid_signature.t
@@ -157,6 +129,9 @@ val add_from_backtrack :
 
 (** Check whether a command is in the pool *)
 val member : t -> Transaction_hash.User_command.t -> bool
+
+(** Check whether the pool has any commands for a given fee payer *)
+val has_commands_for_fee_payer : t -> Account_id.t -> bool
 
 (** Get all the user commands sent by a user with a particular account *)
 val all_from_account :

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -59,7 +59,7 @@ end)
     let reject accepted rejected =
       Fn.compose Deferred.return (function
         | Local f ->
-            f (Ok (`Broadcasted, accepted, rejected))
+            f (Ok (`Not_broadcasted, accepted, rejected))
         | External cb ->
             fire_if_not_already_fired cb `Reject )
 

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -34,7 +34,10 @@ end)
 
     type t =
       | Local of
-          (   (Resource_pool.Diff.t * Resource_pool.Diff.rejected) Or_error.t
+          (   ( [ `Broadcasted | `Not_broadcasted ]
+              * Resource_pool.Diff.t
+              * Resource_pool.Diff.rejected )
+              Or_error.t
            -> unit )
       | External of Mina_net2.Validation_callback.t
 
@@ -53,28 +56,27 @@ end)
         | External cb ->
             fire_if_not_already_fired cb `Reject )
 
+    let reject accepted rejected =
+      Fn.compose Deferred.return (function
+        | Local f ->
+            f (Ok (`Broadcasted, accepted, rejected))
+        | External cb ->
+            fire_if_not_already_fired cb `Reject )
+
     let drop accepted rejected =
       Fn.compose Deferred.return (function
         | Local f ->
-            f (Ok (accepted, rejected))
+            f (Ok (`Not_broadcasted, accepted, rejected))
         | External cb ->
             fire_if_not_already_fired cb `Ignore )
 
     let forward broadcast_pipe accepted rejected = function
       | Local f ->
-          f (Ok (accepted, rejected)) ;
+          f (Ok (`Broadcasted, accepted, rejected)) ;
           Linear_pipe.write broadcast_pipe accepted
       | External cb ->
           fire_if_not_already_fired cb `Accept ;
           Deferred.unit
-
-    let _replace broadcast_pipe accepted rejected = function
-      | Local f ->
-          f (Ok (accepted, rejected)) ;
-          Linear_pipe.write broadcast_pipe accepted
-      | External cb ->
-          fire_if_not_already_fired cb `Ignore ;
-          Linear_pipe.write broadcast_pipe accepted
   end
 
   module Remote_sink =
@@ -132,8 +134,10 @@ end)
     in
     O1trace.sync_thread apply_and_broadcast_thread_label (fun () ->
         match%bind Resource_pool.Diff.unsafe_apply t.resource_pool diff with
-        | Ok res ->
-            rebroadcast res
+        | Ok (`Accept, accepted, rejected) ->
+            rebroadcast (accepted, rejected)
+        | Ok (`Reject, accepted, rejected) ->
+            Broadcast_callback.reject accepted rejected cb
         | Error (`Locally_generated res) ->
             rebroadcast res
         | Error (`Other e) ->

--- a/src/lib/network_pool/pool_sink.ml
+++ b/src/lib/network_pool/pool_sink.ml
@@ -228,13 +228,21 @@ module Local_sink
      and type unwrapped_t = Diff.verified Envelope.Incoming.t * BC.t
      and type msg :=
       BC.resource_pool_diff
-      * ((BC.resource_pool_diff * BC.rejected_diff) Or_error.t -> unit) =
+      * (   ( [ `Broadcasted | `Not_broadcasted ]
+            * BC.resource_pool_diff
+            * BC.rejected_diff )
+            Or_error.t
+         -> unit ) =
   Base (Diff) (BC)
     (struct
       type raw_msg = BC.resource_pool_diff
 
       type raw_callback =
-        (BC.resource_pool_diff * BC.rejected_diff) Or_error.t -> unit
+           ( [ `Broadcasted | `Not_broadcasted ]
+           * BC.resource_pool_diff
+           * BC.rejected_diff )
+           Or_error.t
+        -> unit
 
       let convert_callback cb = BC.Local cb
 

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -1183,7 +1183,8 @@ let%test_module "random set test" =
           in
           ignore
             ( ok_exn res1
-              : Mock_snark_pool.Resource_pool.Diff.verified
+              : [ `Accept | `Reject ]
+                * Mock_snark_pool.Resource_pool.Diff.verified
                 * Mock_snark_pool.Resource_pool.Diff.rejected ) ;
           let rebroadcastable1 =
             Mock_snark_pool.For_tests.get_rebroadcastable resource_pool
@@ -1194,7 +1195,8 @@ let%test_module "random set test" =
           let proof2 = One_or_two.map ~f:mk_dummy_proof stmt2 in
           ignore
             ( ok_exn res2
-              : Mock_snark_pool.Resource_pool.Diff.verified
+              : [ `Accept | `Reject ]
+                * Mock_snark_pool.Resource_pool.Diff.verified
                 * Mock_snark_pool.Resource_pool.Diff.rejected ) ;
           let rebroadcastable2 =
             Mock_snark_pool.For_tests.get_rebroadcastable resource_pool
@@ -1207,7 +1209,8 @@ let%test_module "random set test" =
           let proof3 = One_or_two.map ~f:mk_dummy_proof stmt3 in
           ignore
             ( ok_exn res3
-              : Mock_snark_pool.Resource_pool.Diff.verified
+              : [ `Accept | `Reject ]
+                * Mock_snark_pool.Resource_pool.Diff.verified
                 * Mock_snark_pool.Resource_pool.Diff.rejected ) ;
           let rebroadcastable3 =
             Mock_snark_pool.For_tests.get_rebroadcastable resource_pool
@@ -1234,7 +1237,8 @@ let%test_module "random set test" =
           let proof4 = One_or_two.map ~f:mk_dummy_proof stmt4 in
           ignore
             ( ok_exn res6
-              : Mock_snark_pool.Resource_pool.Diff.verified
+              : [ `Accept | `Reject ]
+                * Mock_snark_pool.Resource_pool.Diff.verified
                 * Mock_snark_pool.Resource_pool.Diff.rejected ) ;
           (* Mark best tip as not including stmt3. *)
           let%bind () =

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -149,7 +149,10 @@ module Make
         in
         match has_lower_fee pool work ~fee:fee.fee ~sender with
         | Ok () ->
-            Pool.add_snark ~is_local pool ~work ~proof ~fee >>| to_or_error
+            let%map.Deferred.Result accepted, rejected =
+              Pool.add_snark ~is_local pool ~work ~proof ~fee >>| to_or_error
+            in
+            (`Accept, accepted, rejected)
         | Error e ->
             Deferred.return
               ( if is_local then Error (`Locally_generated (diff, ()))

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1135,14 +1135,14 @@ struct
             ~f:(fun pool cmd ->
               let result =
                 let%bind.Result () = check_command pool cmd in
-                let account = Map.find_exn fee_payer_accounts (fee_payer cmd) in
-                let balance =
-                  Currency.Amount.of_uint64
-                  @@ Currency.Balance.to_uint64 account.balance
+                let global_slot =
+                  Indexed_pool.global_slot_since_genesis t.pool
                 in
+                let account = Map.find_exn fee_payer_accounts (fee_payer cmd) in
                 match
                   Indexed_pool.add_from_gossip_exn pool cmd account.nonce
-                    balance
+                    ( Account.liquid_balance_at_slot ~global_slot account
+                    |> Currency.Balance.to_amount )
                 with
                 | Ok x ->
                     Ok x

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -561,7 +561,6 @@ struct
               @@ Currency.Balance.to_uint64 account.balance )
           in
           let empty_state = (Account.Nonce.zero, Currency.Amount.zero) in
-          (* TODO: it occurs to me that this batch logic is duplicated during the staged ledger apply... we should try and share data *)
           let existing_account_states_by_id =
             preload_accounts best_tip_ledger accounts_to_check
           in
@@ -939,7 +938,7 @@ struct
         [%log' error t.logger] ~metadata
           "Error verifying transaction pool diff from $sender: $error" ;
         if punish && not is_local then
-          (* TODO: Make this error more specific (could also be a bad signature. *)
+          (* TODO: Make this error more specific (could also be a bad signature). *)
           trust_record
             ( Trust_system.Actions.Sent_invalid_proof
             , Some ("Error verifying transaction pool diff: $error", metadata)
@@ -987,7 +986,7 @@ struct
           Envelope.Sender.(equal Local) (Envelope.Incoming.sender diff)
         in
         let%bind () =
-          (* TODO: we should probably remove this -- the libp2p gossip cache should cover this already *)
+          (* TODO: we should probably remove this -- the libp2p gossip cache should cover this already (#11704) *)
           let (`Already_mem already_mem) =
             Lru_cache.add t.recently_seen (Lru_cache.T.hash diff.data)
           in
@@ -1013,7 +1012,7 @@ struct
             (List.is_empty cmds_with_insufficient_fees)
             ~error:"Some commands have insufficient fee"
         in
-        (* TODO: batch `to_verifiable` *)
+        (* TODO: batch `to_verifiable` (#11705) *)
         let%bind ledger =
           match t.best_tip_ledger with
           | Some ledger ->
@@ -1056,7 +1055,7 @@ struct
             in
             Error Error.(tag (of_string msg) ~tag:"Verification_failed")
         | Ok (Ok commands) ->
-            (* TODO: we don't hash this anywhere prior to this? *)
+            (* TODO: avoid duplicate hashing (#11706) *)
             O1trace.sync_thread "hashing_transactions_after_verification"
               (fun () ->
                 Deferred.return
@@ -1109,7 +1108,6 @@ struct
               |> User_command.fee_payer )
           |> Account_id.Set.of_list
         in
-        (* TODO: do we need to load all of these? or just the ones that aren't already in the Indexed_pool? I think we can compute some of this info from the pool *)
         let fee_payer_accounts =
           preload_accounts ledger fee_payer_account_ids
         in
@@ -1132,7 +1130,6 @@ struct
             ~f:(fun pool cmd ->
               let result =
                 let%bind.Result () = check_command pool cmd in
-                (* TODO: compute from pool (when possible) *)
                 let account = Map.find_exn fee_payer_accounts (fee_payer cmd) in
                 let balance =
                   Currency.Amount.of_uint64

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -983,12 +983,17 @@ struct
           Deferred.return
             (Result.ok_if_true cond ~error:(Error.of_string error))
         in
+        let is_sender_local =
+          Envelope.Sender.(equal Local) (Envelope.Incoming.sender diff)
+        in
         let%bind () =
           (* TODO: we should probably remove this -- the libp2p gossip cache should cover this already *)
           let (`Already_mem already_mem) =
             Lru_cache.add t.recently_seen (Lru_cache.T.hash diff.data)
           in
-          ok_if_true (not already_mem) ~error:"Recently seen"
+          ok_if_true
+            (not (already_mem && not is_sender_local))
+            ~error:"Recently seen"
         in
         let%bind () =
           let cmds_with_insufficient_fees =

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1019,14 +1019,18 @@ struct
                  unable to verify any transactions."
         in
         let diff' =
-          Envelope.Incoming.map diff
-            ~f:
-              (List.map
-                 ~f:
-                   (User_command.to_verifiable ~ledger ~get:Base_ledger.get
-                      ~location_of_account:Base_ledger.location_of_account ) )
+          O1trace.sync_thread "convert_transactions_to_verifiable" (fun () ->
+              Envelope.Incoming.map diff
+                ~f:
+                  (List.map
+                     ~f:
+                       (User_command.to_verifiable ~ledger ~get:Base_ledger.get
+                          ~location_of_account:Base_ledger.location_of_account ) ) )
         in
-        match%bind.Deferred Batcher.verify t.batcher diff' with
+        match%bind.Deferred
+          O1trace.thread "batching_transaction_verification" (fun () ->
+              Batcher.verify t.batcher diff' )
+        with
         | Error e ->
             [%log' error t.logger] "Transaction verification error: $error"
               ~metadata:[ ("error", `String (Error.to_string_hum e)) ] ;
@@ -1048,15 +1052,17 @@ struct
             Error Error.(tag (of_string msg) ~tag:"Verification_failed")
         | Ok (Ok commands) ->
             (* TODO: we don't hash this anywhere prior to this? *)
-            Deferred.return
-              (Ok
-                 { diff with
-                   data =
-                     List.map commands
-                       ~f:
-                         Transaction_hash.User_command_with_valid_signature
-                         .create
-                 } )
+            O1trace.sync_thread "hashing_transactions_after_verification"
+              (fun () ->
+                Deferred.return
+                  (Ok
+                     { diff with
+                       data =
+                         List.map commands
+                           ~f:
+                             Transaction_hash.User_command_with_valid_signature
+                             .create
+                     } ) )
 
       let register_locally_generated t txn =
         Hashtbl.update t.locally_generated_uncommitted txn ~f:(function


### PR DESCRIPTION
Closes #11393.

To fix this bug, I removed the asynchronous computation of indexed pool updates from the `verify` entirely. Instead, that logic is moved into `apply`, where all of the commands in a transaction pool diff are applied to the pool within a single scheduler cycle, preventing race conditions with `handle_transition_frontier_diff`. The `verify` function still runs asynchronously, but it is now only responsible for validating transactions in isolation to the pool state (validating proofs, signatures, and global restrictions such as minimum fee).