### PR TITLE
Version JSON

### DIFF
--- a/src/lib/mina_block/precomputed_block.ml
+++ b/src/lib/mina_block/precomputed_block.ml
@@ -69,6 +69,8 @@ include T
 module Stable = struct
   [@@@no_toplevel_latest_type]
 
+  [@@@with_versioned_json]
+
   module V3 = struct
     type t = T.t =
       { scheduled_time : Block_time.Stable.V1.t
@@ -88,6 +90,9 @@ module Stable = struct
     let to_latest = Fn.id
   end
 end]
+
+(* functions for the versioned json, not the unversioned ones provide by `T` *)
+[%%define_locally Stable.Latest.(to_yojson, of_yojson)]
 
 let of_block ~logger
     ~(constraint_constants : Genesis_constants.Constraint_constants.t)

--- a/src/lib/mina_block/sample_precomputed_block.ml
+++ b/src/lib/mina_block/sample_precomputed_block.ml
@@ -459,1033 +459,1036 @@ let sample_block_sexp =
 let sample_block_json =
   {json|
 {
-  "scheduled_time": "1655382227041",
-  "protocol_state": {
-    "previous_state_hash": "3NKNNu4AwgzyTcmjZAeak516KdwtkFtL39YumhbKrvzVBcX4sr1G",
-    "body": {
-      "genesis_state_hash": "3NKNNu4AwgzyTcmjZAeak516KdwtkFtL39YumhbKrvzVBcX4sr1G",
-      "blockchain_state": {
-        "staged_ledger_hash": {
-          "non_snark": {
-            "ledger_hash": "jwN1bzJ7UPe39bSLW37ik6HNqtoCfvsjdb7NAg6JDQLTFZhj5jd",
-            "aux_hash": "V28ppM4mPwb4wEHafihEdCxSGYfqwYaPUy2CyvNBHLNhtsWpu2",
-            "pending_coinbase_aux": "XH9htC21tQMDKM6hhATkQjecZPRUGpofWATXPkjB5QKxpTBv7H"
+  "version": 3,
+  "data": {
+    "scheduled_time": "1655382227041",
+    "protocol_state": {
+      "previous_state_hash": "3NKNNu4AwgzyTcmjZAeak516KdwtkFtL39YumhbKrvzVBcX4sr1G",
+      "body": {
+        "genesis_state_hash": "3NKNNu4AwgzyTcmjZAeak516KdwtkFtL39YumhbKrvzVBcX4sr1G",
+        "blockchain_state": {
+          "staged_ledger_hash": {
+            "non_snark": {
+              "ledger_hash": "jwN1bzJ7UPe39bSLW37ik6HNqtoCfvsjdb7NAg6JDQLTFZhj5jd",
+              "aux_hash": "V28ppM4mPwb4wEHafihEdCxSGYfqwYaPUy2CyvNBHLNhtsWpu2",
+              "pending_coinbase_aux": "XH9htC21tQMDKM6hhATkQjecZPRUGpofWATXPkjB5QKxpTBv7H"
+            },
+            "pending_coinbase_hash": "2n23E7Ty9K2efaVgAzBaYmwH97NsX63ciF2SSLniJBh9pJM2AsBL"
           },
-          "pending_coinbase_hash": "2n23E7Ty9K2efaVgAzBaYmwH97NsX63ciF2SSLniJBh9pJM2AsBL"
+          "genesis_ledger_hash": "jwhzN7vCf9ykq6SmNe1EuGQYTAjLDTA8D4bQm5K57ZHVKSi5rUR",
+          "registers": {
+            "ledger": "jwhzN7vCf9ykq6SmNe1EuGQYTAjLDTA8D4bQm5K57ZHVKSi5rUR",
+            "pending_coinbase_stack": null,
+            "local_state": {
+              "stack_frame": "0x02F99BCFB0AA7F48C1888DA5A67196A2410FB084CD2DB1AF5216C5122AEBC054",
+              "call_stack": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "full_transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+              "excess": {
+                "magnitude": "0",
+                "sgn": [
+                  "Pos"
+                ]
+              },
+              "ledger": "jw6bz2wud1N6itRUHZ5ypo3267stk4UgzkiuWtAMPRZo9g4Udyd",
+              "success": true,
+              "failure_status_tbl": []
+            }
+          },
+          "timestamp": "1655382227041",
+          "body_reference": "158c69ce6fe799bfd4690b384f26e6beb1d936106838ee54387b15c223df9e89"
         },
-        "genesis_ledger_hash": "jwhzN7vCf9ykq6SmNe1EuGQYTAjLDTA8D4bQm5K57ZHVKSi5rUR",
-        "registers": {
-          "ledger": "jwhzN7vCf9ykq6SmNe1EuGQYTAjLDTA8D4bQm5K57ZHVKSi5rUR",
-          "pending_coinbase_stack": null,
-          "local_state": {
-            "stack_frame": "0x02F99BCFB0AA7F48C1888DA5A67196A2410FB084CD2DB1AF5216C5122AEBC054",
-            "call_stack": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "full_transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-            "excess": {
-              "magnitude": "0",
-              "sgn": [
-                "Pos"
+        "consensus_state": {
+          "blockchain_length": "2",
+          "epoch_count": "0",
+          "min_window_density": "6",
+          "sub_window_densities": [
+            "1",
+            "0",
+            "0"
+          ],
+          "last_vrf_output": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "total_currency": "10016120000000000",
+          "curr_global_slot": {
+            "slot_number": "6",
+            "slots_per_epoch": "576"
+          },
+          "global_slot_since_genesis": "6",
+          "staking_epoch_data": {
+            "ledger": {
+              "hash": "jwhzN7vCf9ykq6SmNe1EuGQYTAjLDTA8D4bQm5K57ZHVKSi5rUR",
+              "total_currency": "10016100000000000"
+            },
+            "seed": "2va9BGv9JrLTtrzZttiEMDYw1Zj6a6EHzXjmP9evHDTG3oEquURA",
+            "start_checkpoint": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+            "lock_checkpoint": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+            "epoch_length": "1"
+          },
+          "next_epoch_data": {
+            "ledger": {
+              "hash": "jwhzN7vCf9ykq6SmNe1EuGQYTAjLDTA8D4bQm5K57ZHVKSi5rUR",
+              "total_currency": "10016100000000000"
+            },
+            "seed": "2vaXVbnZUEmF2jd8TSWu59Y1pjnh97PmC9jRq5x1UHF5zBs83ygF",
+            "start_checkpoint": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+            "lock_checkpoint": "3NKNNu4AwgzyTcmjZAeak516KdwtkFtL39YumhbKrvzVBcX4sr1G",
+            "epoch_length": "3"
+          },
+          "has_ancestor_in_same_checkpoint_window": true,
+          "block_stake_winner": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+          "block_creator": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+          "coinbase_receiver": "B62qpPjYco6oESJyGjdFNjmBnwEyzsujJ785aMAzygzSF4X9g4g1uEo",
+          "supercharge_coinbase": true
+        },
+        "constants": {
+          "k": "24",
+          "slots_per_epoch": "576",
+          "slots_per_sub_window": "2",
+          "delta": "0",
+          "genesis_state_timestamp": "1548878400000"
+        }
+      }
+    },
+    "protocol_state_proof": "_NXzOpIGeLEB_Ayp3waPKGt3APwMxWnKbTOhCPyLhhJ9-g_wwwD8iQCz_prWi3v8ESi5ao3S87MA_MEHNYZwuM9z_Jzn68Ml7JtyAACdCffOVUZW4gI_IpwEhZc-V2_3Eo1FkGiWw61W-xkgAQCtC9t5svFvTRQn4Nr-cMBjEPpGBrk-tEKCU4-D2ijxP_wlT6tXKLZbCvzygOs6g5ivsQD8uSqnVrRwc638_J7x1SP5TzYA_AB8L45iHIdZ_IfMJqJz9secAPyv8raeHYJUI_x-9X320Wu51QD89oaQoND3exT8aCokQM5iXmIA_A6tVjJjG8av_PvhH6EQcoAJAPyRQazKvh5Y-fymybc-mdUeVwD8vcNkzaNQTqr8aMX-wQrnFNgA_G3eXoLfrB2y_KUH28UXogj-APx_qubp1g9Ogvwsf7lOmDr2_AD8ygQbcSuIMcP8KSautsesOZEA_O9Rgf1Hjw_c_IeVO8RDeqkAAPy_MobRHtg4YPyrBaqicLyz-QD8Wkev5eDSdZT89tLDrgKny9EA_AR8Lfn2D3i-_FTi-zKRWD3hAPwTdTG4ErdwxvwIPkiaM8x1FgD80bjKsaKwwUj8zrFxwOMEZhsAAAIQAAAAAABimVRJFfCb58F5EUQtJUhAU7RZBdufQVYwYf19vDLTD6zXUoX3waJPx7Hm4nw8FjpVprHnNjkDHQTrpV5QBAUW_G-_5qzJs4Iz_GMYdvlYQ5d5APyXh4jpBis63fzHoUQpQOZ63QD8y5-c9DDl6Mb83ZygzWW73QcA_BMaaYeiWSxT_HtvZSqwvCGpAPyLBxCPsXec4vzuDGvfAF9c-AD8h5ywBy2nvR38oCZf6eKXG00A_BFfgFZ8dHWc_OjxzvppY_6hAPxNYOnb34orXPyb9xDyjHGMWgD8SGvgUVyzwCL87W2pQHOLiKYA_G5kdl611weQ_BKOTts5i8bBAPzJKz83XuNFRPzlzYz8FcdAnQD8Tqq8S4SCmEL8vLev0NcnqZcA_Hdu_f9bPcqZ_JRCXBVVaubvAPxUmZchcbJ9S_xAyJNh4KIflQD8s0cHsr7M0Sz8HQJk8jze0VsAAPxvv-asybOCM_xjGHb5WEOXeQD8l4eI6QYrOt38x6FEKUDmet0A_MufnPQw5ejG_N2coM1lu90HAPwTGmmHolksU_x7b2UqsLwhqQD8iwcQj7F3nOL87gxr3wBfXPgA_IecsActp70d_KAmX-nilxtNAPwRX4BWfHR1nPzo8c76aWP-oQD8TWDp29-KK1z8m_cQ8oxxjFoA_Ehr4FFcs8Ai_O1tqUBzi4imAPxuZHZetdcHkPwSjk7bOYvGwQD8ySs_N17jRUT85c2M_BXHQJ0A_E6qvEuEgphC_Ly3r9DXJ6mXAPx3bv3_Wz3KmfyUQlwVVWrm7wD8VJmXIXGyfUv8QMiTYeCiH5UA_LNHB7K-zNEs_B0CZPI83tFbAAAAAAJItTboRlSlX0_9__31kb2dPKFwS87wXKWdwmRI3t_TEWsaLETdIcfNWVXvGcPzq7hCDht65RcU3teKhE0iB_UFSLU26EZUpV9P_f_99ZG9nTyhcEvO8FylncJkSN7f0xFrGixE3SHHzVlV7xnD86u4Qg4beuUXFN7XioRNIgf1BQL8uSqnVrRwc638_J7x1SP5TzYA_AB8L45iHIdZ_IfMJqJz9secAPyv8raeHYJUI_x-9X320Wu51QD89oaQoND3exT8aCokQM5iXmIA_A6tVjJjG8av_PvhH6EQcoAJAPyRQazKvh5Y-fymybc-mdUeVwD8vcNkzaNQTqr8aMX-wQrnFNgA_G3eXoLfrB2y_KUH28UXogj-APx_qubp1g9Ogvwsf7lOmDr2_AD8ygQbcSuIMcP8KSautsesOZEA_O9Rgf1Hjw_c_IeVO8RDeqkAAPy_MobRHtg4YPyrBaqicLyz-QD8Wkev5eDSdZT89tLDrgKny9EA_AR8Lfn2D3i-_FTi-zKRWD3hAPwTdTG4ErdwxvwIPkiaM8x1FgD80bjKsaKwwUj8zrFxwOMEZhsAAPy5KqdWtHBzrfz8nvHVI_lPNgD8AHwvjmIch1n8h8wmonP2x5wA_K_ytp4dglQj_H71ffbRa7nVAPz2hpCg0Pd7FPxoKiRAzmJeYgD8Dq1WMmMbxq_8--EfoRBygAkA_JFBrMq-Hlj5_KbJtz6Z1R5XAPy9w2TNo1BOqvxoxf7BCucU2AD8bd5egt-sHbL8pQfbxReiCP4A_H-q5unWD06C_Cx_uU6YOvb8APzKBBtxK4gxw_wpJq62x6w5kQD871GB_UePD9z8h5U7xEN6qQAA_L8yhtEe2Dhg_KsFqqJwvLP5APxaR6_l4NJ1lPz20sOuAqfL0QD8BHwt-fYPeL78VOL7MpFYPeEA_BN1MbgSt3DG_Ag-SJozzHUWAPzRuMqxorDBSPzOsXHA4wRmGwAAUtK3gb4cMAwdy0AgX2AkB1qZCz7WQGhepIYvZelG6Ro2iY4ANf6-Fu6V2JAx31oQ1WHZmK7QZi9deLsMF8vYDAFxI5ougXdG8pcPqt7xrkNRXIrf_CCxbxlGt8LnQLK-MgEhErp_10lnQVY7lIh4YSpf6hH-4X9Iu7ALrs9733jkIwHu3CQpAe6rrMu2XSVx_8Jo__W7ZvdUJaWnt1n_4rMoDwF7DTz4lANzls8z1DLGEf_TNvmGWkqP0h9NuNNHbmBoOwFdyzC-_PLz2ZYuTi5MogrWTHpyxzBwlHIaR1F3n8oiIwHEbrA7kGr-BD0iUMbnHPhQd3bBvCJGInmA_EJ3BP4qBQEKzCtv_aYC-uIHNevghsaQ__iLWwvw3e2xnwM6vm3wJgE3jMlSF-_fiEjkbNvvN-xMoO8jqbkknuJIHbkZU5CCCwHhXODBNtpjzl85oYYtmwUEuH7GswTgiAeZfYZLKuXnAwENViE30_FxaxBbMuOMCBvP-iB4vqKIjSdvNUlKRR2ZMAG7wdpIm816ZRuiURpesbuExUAOd4IrVVru3_BarFqZGAFXzb1Ke2lZRwF_8Qw00e8J5Amy1Wvmx1y8wnSsHygTCwHmfEbSm7zz9JhzAnA_Y4w2DABjmIxM_PL6LQTr-clhAgE2UeOYb14khXPRV7mNhBzZXQm-zOQGSghRK_9pOIFfEQGRF9HtRRuJy7tDdTHSQMC1RmrWUR_NGb4AGrz0YbR-CwFsw2cP7MfLQA1G7MePPyAHoM6iXjrMdjBp3nwxS_e_LAGlY8mV8f-Px-qgGxOywW301TZCoZuobwfO4e3v-zItHgGLn3KkrMs34UEblCpceb73vxW2dKSyuq6hrSM1J3gVFgF5PVHTzv6k90PIbpYsCsMX634CwZIIFGgJln0oBJBeOwH5pqK5yQpGt0OQozIY9TfNYVfubRpsu5t5cm45cp-7OQEADEZptNyvuzC6VEKWLA41KBizlxVqpZwAfh8q-Ym5OAFAX7cR6un8p4h12422YYnFbUJv6gaPKCb-XLCwr-BqDgEOUBnvWVt5b4cu2uh03z5r0elEJK7Xuk16xf5a4iUkFQHOzpJK8SibIm-7bL74CblEIqnZHweCraDYfvyD0Bm5GwFKTunYzvN-cE1Xg24r1CxpZGbicZfhZuWkrIevbxepJAHeflftAjXtExXufHZYL-he8TQQVxp1N7zXvTkZ8mbsHgF-qMD7JX5RGOVI2cfVn1hYyhU7n3hQYjE9JQ4k4gMpFAGdU8hb28i5-JX9PPKFQJreJNB3xrH7iEvo7QOmCSB6FQGZhN5a0wkcUj-Q22eSUms2s9CTa9qKqKqCESdI4ar7LQHSPURVXFaTJAZ9goF2MqS0i-MUJnEBoJhzGXJ10ChPBQABjR744krPNeaPQESAMkNS6SFkW8NUsFZE571Os6gOnRMBrbGvz6_-dWlla1TVzjn3wRpVlY9j9DLvupqpYzTj8BMBDRntusuc8Cu_XBwQU9QiR5UmhVA4wHJ3KgqXDzpU1SUBiaxwUsNvUKibzQYLpn-pRG3-sLbYCnTvYX3Ur2bMIDkBrF0QVebcheaWzeLkzVjkEXVWYi3mFsBLNCfrz055ITkBouBUxluRSy7Mo6m6ozWg1qUBnPuxnOBz6tUuHw-WPzAB3mS_8xYzg68iaHdNKflzgmVpJaOEbgjRudv9gQcJUAgBGnnJIGevOpPjjjt6tVHtMMslmL49Uxr8sxYf9GRSeQwBwxgdh9CrSpnOyIWz1N5RsLyjKzBuvs6NyhqHK8DvxB0BKIjCcWS5CzQal6iCxUVPWGio1oeWs_GO9UKA7j-WKDoBz-b1_MdSOT3L_JQSVsK6hJnTIiiuGt0SDQ--zNk4kjMBF-b82gBjIdJvaOKWiwhIdjYH-DL5rbC6pxoVuS95iCUB_9tOkJ13KWV17xYttzFYFpOorhomKOnXsRT25kgyMAoBQBKK3DI87NJLX03v-DS-lgyQpcl9Fs5tEj7ejJWyvzwAAZL1_NwMTNP23kJ5SLB4MS4LN0S2STK1WvYUHOj-btgsAUyx4bzshD-rfjd4D0SIDVjr-jwotMDJE65BSVpbz1sZAcDITf6hUwa7licVuSHAEX_enz-d_6lzT8qXfK6GVJA3Aa1s8ln_6tGNOv04L0EOdxo9XQ8mFFT6aZaT2BxFzIA8AJXRYizAp_LbipnYFWU01XIHqvO7xqWmoaMVzZJCaIIfAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbBwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsADwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0G2kKmNlLIXDt-z9Wm9be76nMoTsJPZWbE27gHS-Yaw0kbo6G89tRSj39rPd1BmgL6jDQ6EXDwNZX-kxkyVobJSgBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwE8YarsOpthEm-zgZWflXYHlK8dYqU5SCMwvEg7uWlMBgG1lDFQ8arF3lNiO4utX_pjZY6rvGOOemMnsf-pKzF6HgGyc7C8cf_r8cXE4BSKZekGWySIh7vomWB9AvEXDHtGAgHlSbmjbLnGgXUX59Zt-nH7ttgJlNtTf5tRknzzDXCEJwF1M96_qj16L7hWfRm_YlYUbKK8EhtSPPvkJ5Lgs1MiLAFX-p-2cb4NijEVBPExIhGGoYvgRHcQcwxLuqdMo0jeMgH00fCHMH6Wpd0tQf0iAXwJ5JBvViTJqecOhRWDK9RMNQEBhe9XkAAcvm5OCJRA_FIknHm7TTEgivfF2IEI3MeJFgHcPj_HougTcGBQNflgy4hU-4M1GYbMiDP933r_OvywFQFTSa9QkePNGMCS7ZV743HXm8o-GjO_D4OIrBiRJZRBBAHnIr8LOE_BSDulDYlGBNxVRuQ0xMq2ABzCvFn6x5haKgF6SoSnVl8V8rXKTA3N8Z-Zk3EJuWsh56VB0UIBJBZRNgHoCT9WxI5UAP7Vwqhq6NszhWP1p-oxpmstCDPitzrWDAGmYWM-1Jcew6UBONu2fH1IQr_-77ED5Y2TQBr3BPTMHQH2gT5x8SH7qmYdy4CUXvEYPsPPELfGNxhKUDsarpEICwFSvpvw8LsRkZ1QbfA7uJ_2tTqS1vgPAZYdxUAlXJhUIAF-WLJP0invsW4SBaZLXLuYZWavhBrsak2NpUIAXTl2FQGXmvgmC8zpJ5X0EjjPNNd7Q2Dh5BTRx5N9rGt5503lOQHzco0WgOEJaBtLb4AR_qanWPjpJ9wuFuzzxBm-b5V2FgF4ZP81nWoge3I_GH93hhXS8HMrN68WmXeUz4NJZNh5OQEnpnU-PBa5iSHVPRhUAuh08xioGf3y86xmZyYgRaqKJgFmTnym_pPxUfBpUIuCatXQbHFUkxjLyRHaa3TQbv4oBgEuU2BbgBrX_qdF6XZq3Y2p7TNYnXWPszn-1AwynFmqJwG3eoeIsH980cnGFhh1XMo9DTA6ewlhJM4MAtxfRRoPAwEuHmhzHQC4RyADiCN3fsZSLZoenjZZIMPnzgZK3gwuHgHZbWLlSgpJ06RMkZ60sIkzPWSiNu3NoZISdKxpA7rZNwHM46eN-iQtjFPolGfMmG39My25h9dsZudzWkfvNOkPKAHDfWkshHOqmiRruF5cQyPNDFpp5LnOGuFg-WFEfDGuLgHYLThxeEK94xcVft8YalsqWsKgNaBpsYobt5DYobYOJgFplOJw8oSlV8QYr-v6rKJ5TIr2pHbLG5R4wgXoqQEXDwABcXEV5ZcTyE-Iur4uwCklGAYNLMgrVOmpyaLSqHzpHhUBXdk8myw_zuMPo0lg8kcvzQTZ3oSG9jXJuW13b64xIh8BqE-UoNbWS-C5cEm5KuLFioy5Pnkhefq1f6MsRpWr5yQBLHxqpRI7QaqOrOhafu6467IiGck1O5J2cRGZqqgBghcBFuui69qf6sRC4p75KT9cRXaTPVMabjwHUY41IkEFXz0B3PWy4SRTuDacQg52raD7bG4XPyJxqhnsbbgBARJhFgUBNTYtmG8gxZjlPD3guPxBMASEJDFyr4k8yZyhmaoWFjwB8JUeajhftOqLXizw6J5UgHqZk4sKtpx38bmyEKBdFS4BN776nYDGKPuLP39TFpEsF1QmoK2ag9t4CEfWNvHMqwkB4A02zCtgdsIxhARsCioGIIUhVkT-KVSaYlICUFW9-xwBa98jDsB6kVMZxgatkwxB3X8JciKtondqSE51X-stSRwB7oAr6vTduvO2lphonX52tnDKpl3b2SGXInqwyN-6NiQBtcmNOogeqtVgDYmSDf-DAlB50nvePOrdFEJb_IpA0xABwEQWKAElGddv7wEHQ03Fa7F059FhDN4vyG1qpyt1rRoAAc1xyK_hpxny5eg_znlB-5oxPiuSYkgK-mhnXc-rZLIKAeWACT0kBAb2aEsxPOQGab1bocjfPtU87S9HPAN68ZoIAZrMlNnD573fZqMj2Cv1RRm7jy9b3Uj-zrRai94Kp6A5AZahBkIRtSvDTSZYeHUHJOjVUq6c6PrlSSx9FKnmbnUXABL2qIf5m8UVM-ZRmBDHndf-fNgPjYy0g6T2UmRnynMe",
+    "staged_ledger_diff": {
+      "diff": [
+        {
+          "completed_works": [],
+          "commands": [
+            {
+              "data": [
+                "Signed_command",
+                {
+                  "payload": {
+                    "common": {
+                      "fee": "0",
+                      "fee_payer_pk": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+                      "nonce": "0",
+                      "valid_until": "4294967295",
+                      "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
+                    },
+                    "body": [
+                      "Payment",
+                      {
+                        "source_pk": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+                        "receiver_pk": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+                        "amount": "1000000001"
+                      }
+                    ]
+                  },
+                  "signer": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                }
+              ],
+              "status": [
+                "Applied"
               ]
             },
-            "ledger": "jw6bz2wud1N6itRUHZ5ypo3267stk4UgzkiuWtAMPRZo9g4Udyd",
-            "success": true,
-            "failure_status_tbl": []
-          }
+            {
+              "data": [
+                "Signed_command",
+                {
+                  "payload": {
+                    "common": {
+                      "fee": "0",
+                      "fee_payer_pk": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
+                      "nonce": "0",
+                      "valid_until": "4294967295",
+                      "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
+                    },
+                    "body": [
+                      "Payment",
+                      {
+                        "source_pk": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
+                        "receiver_pk": "B62qkYgXYkzT5fuPNhMEHk8ouiThjNNDSTMnpBAuaf6q7pNnCFkUqtz",
+                        "amount": "1000000001"
+                      }
+                    ]
+                  },
+                  "signer": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
+                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                }
+              ],
+              "status": [
+                "Applied"
+              ]
+            },
+            {
+              "data": [
+                "Signed_command",
+                {
+                  "payload": {
+                    "common": {
+                      "fee": "0",
+                      "fee_payer_pk": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
+                      "nonce": "0",
+                      "valid_until": "4294967295",
+                      "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
+                    },
+                    "body": [
+                      "Payment",
+                      {
+                        "source_pk": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
+                        "receiver_pk": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
+                        "amount": "1000000001"
+                      }
+                    ]
+                  },
+                  "signer": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
+                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                }
+              ],
+              "status": [
+                "Applied"
+              ]
+            },
+            {
+              "data": [
+                "Signed_command",
+                {
+                  "payload": {
+                    "common": {
+                      "fee": "0",
+                      "fee_payer_pk": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
+                      "nonce": "0",
+                      "valid_until": "4294967295",
+                      "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
+                    },
+                    "body": [
+                      "Payment",
+                      {
+                        "source_pk": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
+                        "receiver_pk": "B62qji8zLZEuMUpZnRN3FHgsgnybYhhMFBBMcLAwGGLR3hTdfkhmM4X",
+                        "amount": "1000000001"
+                      }
+                    ]
+                  },
+                  "signer": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
+                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                }
+              ],
+              "status": [
+                "Applied"
+              ]
+            },
+            {
+              "data": [
+                "Signed_command",
+                {
+                  "payload": {
+                    "common": {
+                      "fee": "0",
+                      "fee_payer_pk": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
+                      "nonce": "0",
+                      "valid_until": "4294967295",
+                      "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
+                    },
+                    "body": [
+                      "Payment",
+                      {
+                        "source_pk": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
+                        "receiver_pk": "B62qqMGFkBEtgGs2Gi6AWd1Abn9yzXdj5HRMzm95uwbJ8Wa88C7urCD",
+                        "amount": "1000000001"
+                      }
+                    ]
+                  },
+                  "signer": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
+                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                }
+              ],
+              "status": [
+                "Applied"
+              ]
+            },
+            {
+              "data": [
+                "Signed_command",
+                {
+                  "payload": {
+                    "common": {
+                      "fee": "0",
+                      "fee_payer_pk": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
+                      "nonce": "0",
+                      "valid_until": "4294967295",
+                      "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
+                    },
+                    "body": [
+                      "Payment",
+                      {
+                        "source_pk": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
+                        "receiver_pk": "B62qpaA93gHfmvNoH9DLGgxreGnijhh5aui4duxiV3foX4p5ay5RNis",
+                        "amount": "1000000001"
+                      }
+                    ]
+                  },
+                  "signer": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
+                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                }
+              ],
+              "status": [
+                "Applied"
+              ]
+            },
+            {
+              "data": [
+                "Signed_command",
+                {
+                  "payload": {
+                    "common": {
+                      "fee": "0",
+                      "fee_payer_pk": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
+                      "nonce": "0",
+                      "valid_until": "4294967295",
+                      "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
+                    },
+                    "body": [
+                      "Payment",
+                      {
+                        "source_pk": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
+                        "receiver_pk": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
+                        "amount": "1000000001"
+                      }
+                    ]
+                  },
+                  "signer": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
+                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                }
+              ],
+              "status": [
+                "Applied"
+              ]
+            }
+          ],
+          "coinbase": [
+            "One",
+            null
+          ]
         },
-        "timestamp": "1655382227041",
-        "body_reference": "158c69ce6fe799bfd4690b384f26e6beb1d936106838ee54387b15c223df9e89"
-      },
-      "consensus_state": {
-        "blockchain_length": "2",
-        "epoch_count": "0",
-        "min_window_density": "6",
-        "sub_window_densities": [
-          "1",
-          "0",
-          "0"
-        ],
-        "last_vrf_output": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-        "total_currency": "10016120000000000",
-        "curr_global_slot": {
-          "slot_number": "6",
-          "slots_per_epoch": "576"
-        },
-        "global_slot_since_genesis": "6",
-        "staking_epoch_data": {
-          "ledger": {
-            "hash": "jwhzN7vCf9ykq6SmNe1EuGQYTAjLDTA8D4bQm5K57ZHVKSi5rUR",
-            "total_currency": "10016100000000000"
-          },
-          "seed": "2va9BGv9JrLTtrzZttiEMDYw1Zj6a6EHzXjmP9evHDTG3oEquURA",
-          "start_checkpoint": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-          "lock_checkpoint": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-          "epoch_length": "1"
-        },
-        "next_epoch_data": {
-          "ledger": {
-            "hash": "jwhzN7vCf9ykq6SmNe1EuGQYTAjLDTA8D4bQm5K57ZHVKSi5rUR",
-            "total_currency": "10016100000000000"
-          },
-          "seed": "2vaXVbnZUEmF2jd8TSWu59Y1pjnh97PmC9jRq5x1UHF5zBs83ygF",
-          "start_checkpoint": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-          "lock_checkpoint": "3NKNNu4AwgzyTcmjZAeak516KdwtkFtL39YumhbKrvzVBcX4sr1G",
-          "epoch_length": "3"
-        },
-        "has_ancestor_in_same_checkpoint_window": true,
-        "block_stake_winner": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-        "block_creator": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-        "coinbase_receiver": "B62qpPjYco6oESJyGjdFNjmBnwEyzsujJ785aMAzygzSF4X9g4g1uEo",
-        "supercharge_coinbase": true
-      },
-      "constants": {
-        "k": "24",
-        "slots_per_epoch": "576",
-        "slots_per_sub_window": "2",
-        "delta": "0",
-        "genesis_state_timestamp": "1548878400000"
-      }
-    }
-  },
-  "protocol_state_proof": "_NXzOpIGeLEB_Ayp3waPKGt3APwMxWnKbTOhCPyLhhJ9-g_wwwD8iQCz_prWi3v8ESi5ao3S87MA_MEHNYZwuM9z_Jzn68Ml7JtyAACdCffOVUZW4gI_IpwEhZc-V2_3Eo1FkGiWw61W-xkgAQCtC9t5svFvTRQn4Nr-cMBjEPpGBrk-tEKCU4-D2ijxP_wlT6tXKLZbCvzygOs6g5ivsQD8uSqnVrRwc638_J7x1SP5TzYA_AB8L45iHIdZ_IfMJqJz9secAPyv8raeHYJUI_x-9X320Wu51QD89oaQoND3exT8aCokQM5iXmIA_A6tVjJjG8av_PvhH6EQcoAJAPyRQazKvh5Y-fymybc-mdUeVwD8vcNkzaNQTqr8aMX-wQrnFNgA_G3eXoLfrB2y_KUH28UXogj-APx_qubp1g9Ogvwsf7lOmDr2_AD8ygQbcSuIMcP8KSautsesOZEA_O9Rgf1Hjw_c_IeVO8RDeqkAAPy_MobRHtg4YPyrBaqicLyz-QD8Wkev5eDSdZT89tLDrgKny9EA_AR8Lfn2D3i-_FTi-zKRWD3hAPwTdTG4ErdwxvwIPkiaM8x1FgD80bjKsaKwwUj8zrFxwOMEZhsAAAIQAAAAAABimVRJFfCb58F5EUQtJUhAU7RZBdufQVYwYf19vDLTD6zXUoX3waJPx7Hm4nw8FjpVprHnNjkDHQTrpV5QBAUW_G-_5qzJs4Iz_GMYdvlYQ5d5APyXh4jpBis63fzHoUQpQOZ63QD8y5-c9DDl6Mb83ZygzWW73QcA_BMaaYeiWSxT_HtvZSqwvCGpAPyLBxCPsXec4vzuDGvfAF9c-AD8h5ywBy2nvR38oCZf6eKXG00A_BFfgFZ8dHWc_OjxzvppY_6hAPxNYOnb34orXPyb9xDyjHGMWgD8SGvgUVyzwCL87W2pQHOLiKYA_G5kdl611weQ_BKOTts5i8bBAPzJKz83XuNFRPzlzYz8FcdAnQD8Tqq8S4SCmEL8vLev0NcnqZcA_Hdu_f9bPcqZ_JRCXBVVaubvAPxUmZchcbJ9S_xAyJNh4KIflQD8s0cHsr7M0Sz8HQJk8jze0VsAAPxvv-asybOCM_xjGHb5WEOXeQD8l4eI6QYrOt38x6FEKUDmet0A_MufnPQw5ejG_N2coM1lu90HAPwTGmmHolksU_x7b2UqsLwhqQD8iwcQj7F3nOL87gxr3wBfXPgA_IecsActp70d_KAmX-nilxtNAPwRX4BWfHR1nPzo8c76aWP-oQD8TWDp29-KK1z8m_cQ8oxxjFoA_Ehr4FFcs8Ai_O1tqUBzi4imAPxuZHZetdcHkPwSjk7bOYvGwQD8ySs_N17jRUT85c2M_BXHQJ0A_E6qvEuEgphC_Ly3r9DXJ6mXAPx3bv3_Wz3KmfyUQlwVVWrm7wD8VJmXIXGyfUv8QMiTYeCiH5UA_LNHB7K-zNEs_B0CZPI83tFbAAAAAAJItTboRlSlX0_9__31kb2dPKFwS87wXKWdwmRI3t_TEWsaLETdIcfNWVXvGcPzq7hCDht65RcU3teKhE0iB_UFSLU26EZUpV9P_f_99ZG9nTyhcEvO8FylncJkSN7f0xFrGixE3SHHzVlV7xnD86u4Qg4beuUXFN7XioRNIgf1BQL8uSqnVrRwc638_J7x1SP5TzYA_AB8L45iHIdZ_IfMJqJz9secAPyv8raeHYJUI_x-9X320Wu51QD89oaQoND3exT8aCokQM5iXmIA_A6tVjJjG8av_PvhH6EQcoAJAPyRQazKvh5Y-fymybc-mdUeVwD8vcNkzaNQTqr8aMX-wQrnFNgA_G3eXoLfrB2y_KUH28UXogj-APx_qubp1g9Ogvwsf7lOmDr2_AD8ygQbcSuIMcP8KSautsesOZEA_O9Rgf1Hjw_c_IeVO8RDeqkAAPy_MobRHtg4YPyrBaqicLyz-QD8Wkev5eDSdZT89tLDrgKny9EA_AR8Lfn2D3i-_FTi-zKRWD3hAPwTdTG4ErdwxvwIPkiaM8x1FgD80bjKsaKwwUj8zrFxwOMEZhsAAPy5KqdWtHBzrfz8nvHVI_lPNgD8AHwvjmIch1n8h8wmonP2x5wA_K_ytp4dglQj_H71ffbRa7nVAPz2hpCg0Pd7FPxoKiRAzmJeYgD8Dq1WMmMbxq_8--EfoRBygAkA_JFBrMq-Hlj5_KbJtz6Z1R5XAPy9w2TNo1BOqvxoxf7BCucU2AD8bd5egt-sHbL8pQfbxReiCP4A_H-q5unWD06C_Cx_uU6YOvb8APzKBBtxK4gxw_wpJq62x6w5kQD871GB_UePD9z8h5U7xEN6qQAA_L8yhtEe2Dhg_KsFqqJwvLP5APxaR6_l4NJ1lPz20sOuAqfL0QD8BHwt-fYPeL78VOL7MpFYPeEA_BN1MbgSt3DG_Ag-SJozzHUWAPzRuMqxorDBSPzOsXHA4wRmGwAAUtK3gb4cMAwdy0AgX2AkB1qZCz7WQGhepIYvZelG6Ro2iY4ANf6-Fu6V2JAx31oQ1WHZmK7QZi9deLsMF8vYDAFxI5ougXdG8pcPqt7xrkNRXIrf_CCxbxlGt8LnQLK-MgEhErp_10lnQVY7lIh4YSpf6hH-4X9Iu7ALrs9733jkIwHu3CQpAe6rrMu2XSVx_8Jo__W7ZvdUJaWnt1n_4rMoDwF7DTz4lANzls8z1DLGEf_TNvmGWkqP0h9NuNNHbmBoOwFdyzC-_PLz2ZYuTi5MogrWTHpyxzBwlHIaR1F3n8oiIwHEbrA7kGr-BD0iUMbnHPhQd3bBvCJGInmA_EJ3BP4qBQEKzCtv_aYC-uIHNevghsaQ__iLWwvw3e2xnwM6vm3wJgE3jMlSF-_fiEjkbNvvN-xMoO8jqbkknuJIHbkZU5CCCwHhXODBNtpjzl85oYYtmwUEuH7GswTgiAeZfYZLKuXnAwENViE30_FxaxBbMuOMCBvP-iB4vqKIjSdvNUlKRR2ZMAG7wdpIm816ZRuiURpesbuExUAOd4IrVVru3_BarFqZGAFXzb1Ke2lZRwF_8Qw00e8J5Amy1Wvmx1y8wnSsHygTCwHmfEbSm7zz9JhzAnA_Y4w2DABjmIxM_PL6LQTr-clhAgE2UeOYb14khXPRV7mNhBzZXQm-zOQGSghRK_9pOIFfEQGRF9HtRRuJy7tDdTHSQMC1RmrWUR_NGb4AGrz0YbR-CwFsw2cP7MfLQA1G7MePPyAHoM6iXjrMdjBp3nwxS_e_LAGlY8mV8f-Px-qgGxOywW301TZCoZuobwfO4e3v-zItHgGLn3KkrMs34UEblCpceb73vxW2dKSyuq6hrSM1J3gVFgF5PVHTzv6k90PIbpYsCsMX634CwZIIFGgJln0oBJBeOwH5pqK5yQpGt0OQozIY9TfNYVfubRpsu5t5cm45cp-7OQEADEZptNyvuzC6VEKWLA41KBizlxVqpZwAfh8q-Ym5OAFAX7cR6un8p4h12422YYnFbUJv6gaPKCb-XLCwr-BqDgEOUBnvWVt5b4cu2uh03z5r0elEJK7Xuk16xf5a4iUkFQHOzpJK8SibIm-7bL74CblEIqnZHweCraDYfvyD0Bm5GwFKTunYzvN-cE1Xg24r1CxpZGbicZfhZuWkrIevbxepJAHeflftAjXtExXufHZYL-he8TQQVxp1N7zXvTkZ8mbsHgF-qMD7JX5RGOVI2cfVn1hYyhU7n3hQYjE9JQ4k4gMpFAGdU8hb28i5-JX9PPKFQJreJNB3xrH7iEvo7QOmCSB6FQGZhN5a0wkcUj-Q22eSUms2s9CTa9qKqKqCESdI4ar7LQHSPURVXFaTJAZ9goF2MqS0i-MUJnEBoJhzGXJ10ChPBQABjR744krPNeaPQESAMkNS6SFkW8NUsFZE571Os6gOnRMBrbGvz6_-dWlla1TVzjn3wRpVlY9j9DLvupqpYzTj8BMBDRntusuc8Cu_XBwQU9QiR5UmhVA4wHJ3KgqXDzpU1SUBiaxwUsNvUKibzQYLpn-pRG3-sLbYCnTvYX3Ur2bMIDkBrF0QVebcheaWzeLkzVjkEXVWYi3mFsBLNCfrz055ITkBouBUxluRSy7Mo6m6ozWg1qUBnPuxnOBz6tUuHw-WPzAB3mS_8xYzg68iaHdNKflzgmVpJaOEbgjRudv9gQcJUAgBGnnJIGevOpPjjjt6tVHtMMslmL49Uxr8sxYf9GRSeQwBwxgdh9CrSpnOyIWz1N5RsLyjKzBuvs6NyhqHK8DvxB0BKIjCcWS5CzQal6iCxUVPWGio1oeWs_GO9UKA7j-WKDoBz-b1_MdSOT3L_JQSVsK6hJnTIiiuGt0SDQ--zNk4kjMBF-b82gBjIdJvaOKWiwhIdjYH-DL5rbC6pxoVuS95iCUB_9tOkJ13KWV17xYttzFYFpOorhomKOnXsRT25kgyMAoBQBKK3DI87NJLX03v-DS-lgyQpcl9Fs5tEj7ejJWyvzwAAZL1_NwMTNP23kJ5SLB4MS4LN0S2STK1WvYUHOj-btgsAUyx4bzshD-rfjd4D0SIDVjr-jwotMDJE65BSVpbz1sZAcDITf6hUwa7licVuSHAEX_enz-d_6lzT8qXfK6GVJA3Aa1s8ln_6tGNOv04L0EOdxo9XQ8mFFT6aZaT2BxFzIA8AJXRYizAp_LbipnYFWU01XIHqvO7xqWmoaMVzZJCaIIfAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAAEBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbBwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsADwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAuyrtyiN6zxlxRz0z1Ftlj1TueGPwqd9TfJMSCqO1dBsBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0G2kKmNlLIXDt-z9Wm9be76nMoTsJPZWbE27gHS-Yaw0kbo6G89tRSj39rPd1BmgL6jDQ6EXDwNZX-kxkyVobJSgBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALsq7cojes8ZcUc9M9RbZY9U7nhj8KnfU3yTEgqjtXQbAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC7Ku3KI3rPGXFHPTPUW2WPVO54Y_Cp31N8kxIKo7V0GwE8YarsOpthEm-zgZWflXYHlK8dYqU5SCMwvEg7uWlMBgG1lDFQ8arF3lNiO4utX_pjZY6rvGOOemMnsf-pKzF6HgGyc7C8cf_r8cXE4BSKZekGWySIh7vomWB9AvEXDHtGAgHlSbmjbLnGgXUX59Zt-nH7ttgJlNtTf5tRknzzDXCEJwF1M96_qj16L7hWfRm_YlYUbKK8EhtSPPvkJ5Lgs1MiLAFX-p-2cb4NijEVBPExIhGGoYvgRHcQcwxLuqdMo0jeMgH00fCHMH6Wpd0tQf0iAXwJ5JBvViTJqecOhRWDK9RMNQEBhe9XkAAcvm5OCJRA_FIknHm7TTEgivfF2IEI3MeJFgHcPj_HougTcGBQNflgy4hU-4M1GYbMiDP933r_OvywFQFTSa9QkePNGMCS7ZV743HXm8o-GjO_D4OIrBiRJZRBBAHnIr8LOE_BSDulDYlGBNxVRuQ0xMq2ABzCvFn6x5haKgF6SoSnVl8V8rXKTA3N8Z-Zk3EJuWsh56VB0UIBJBZRNgHoCT9WxI5UAP7Vwqhq6NszhWP1p-oxpmstCDPitzrWDAGmYWM-1Jcew6UBONu2fH1IQr_-77ED5Y2TQBr3BPTMHQH2gT5x8SH7qmYdy4CUXvEYPsPPELfGNxhKUDsarpEICwFSvpvw8LsRkZ1QbfA7uJ_2tTqS1vgPAZYdxUAlXJhUIAF-WLJP0invsW4SBaZLXLuYZWavhBrsak2NpUIAXTl2FQGXmvgmC8zpJ5X0EjjPNNd7Q2Dh5BTRx5N9rGt5503lOQHzco0WgOEJaBtLb4AR_qanWPjpJ9wuFuzzxBm-b5V2FgF4ZP81nWoge3I_GH93hhXS8HMrN68WmXeUz4NJZNh5OQEnpnU-PBa5iSHVPRhUAuh08xioGf3y86xmZyYgRaqKJgFmTnym_pPxUfBpUIuCatXQbHFUkxjLyRHaa3TQbv4oBgEuU2BbgBrX_qdF6XZq3Y2p7TNYnXWPszn-1AwynFmqJwG3eoeIsH980cnGFhh1XMo9DTA6ewlhJM4MAtxfRRoPAwEuHmhzHQC4RyADiCN3fsZSLZoenjZZIMPnzgZK3gwuHgHZbWLlSgpJ06RMkZ60sIkzPWSiNu3NoZISdKxpA7rZNwHM46eN-iQtjFPolGfMmG39My25h9dsZudzWkfvNOkPKAHDfWkshHOqmiRruF5cQyPNDFpp5LnOGuFg-WFEfDGuLgHYLThxeEK94xcVft8YalsqWsKgNaBpsYobt5DYobYOJgFplOJw8oSlV8QYr-v6rKJ5TIr2pHbLG5R4wgXoqQEXDwABcXEV5ZcTyE-Iur4uwCklGAYNLMgrVOmpyaLSqHzpHhUBXdk8myw_zuMPo0lg8kcvzQTZ3oSG9jXJuW13b64xIh8BqE-UoNbWS-C5cEm5KuLFioy5Pnkhefq1f6MsRpWr5yQBLHxqpRI7QaqOrOhafu6467IiGck1O5J2cRGZqqgBghcBFuui69qf6sRC4p75KT9cRXaTPVMabjwHUY41IkEFXz0B3PWy4SRTuDacQg52raD7bG4XPyJxqhnsbbgBARJhFgUBNTYtmG8gxZjlPD3guPxBMASEJDFyr4k8yZyhmaoWFjwB8JUeajhftOqLXizw6J5UgHqZk4sKtpx38bmyEKBdFS4BN776nYDGKPuLP39TFpEsF1QmoK2ag9t4CEfWNvHMqwkB4A02zCtgdsIxhARsCioGIIUhVkT-KVSaYlICUFW9-xwBa98jDsB6kVMZxgatkwxB3X8JciKtondqSE51X-stSRwB7oAr6vTduvO2lphonX52tnDKpl3b2SGXInqwyN-6NiQBtcmNOogeqtVgDYmSDf-DAlB50nvePOrdFEJb_IpA0xABwEQWKAElGddv7wEHQ03Fa7F059FhDN4vyG1qpyt1rRoAAc1xyK_hpxny5eg_znlB-5oxPiuSYkgK-mhnXc-rZLIKAeWACT0kBAb2aEsxPOQGab1bocjfPtU87S9HPAN68ZoIAZrMlNnD573fZqMj2Cv1RRm7jy9b3Uj-zrRai94Kp6A5AZahBkIRtSvDTSZYeHUHJOjVUq6c6PrlSSx9FKnmbnUXABL2qIf5m8UVM-ZRmBDHndf-fNgPjYy0g6T2UmRnynMe",
-  "staged_ledger_diff": {
-    "diff": [
-      {
-        "completed_works": [],
-        "commands": [
-          {
-            "data": [
-              "Signed_command",
-              {
-                "payload": {
-                  "common": {
-                    "fee": "0",
-                    "fee_payer_pk": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-                    "nonce": "0",
-                    "valid_until": "4294967295",
-                    "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
-                  },
-                  "body": [
-                    "Payment",
-                    {
-                      "source_pk": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-                      "receiver_pk": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-                      "amount": "1000000001"
-                    }
-                  ]
-                },
-                "signer": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-                "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
-              }
+        null
+      ]
+    },
+    "delta_transition_chain_proof": [
+      "jwS686H1zvTjvdHULJkz9xjarjiZeuLFHhUchnHTfhf5yJmouon",
+      []
+    ],
+    "accounts_accessed": [
+      [
+        2,
+        {
+          "public_key": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "1000000000000",
+          "nonce": "1",
+          "receipt_chain_hash": "2n25EYLf61vHTACzFgXp64JB2oH79s8TD8pp7YWEBMeoCPWSDZnZ",
+          "delegate": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
             ],
-            "status": [
-              "Applied"
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
             ]
           },
-          {
-            "data": [
-              "Signed_command",
-              {
-                "payload": {
-                  "common": {
-                    "fee": "0",
-                    "fee_payer_pk": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
-                    "nonce": "0",
-                    "valid_until": "4294967295",
-                    "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
-                  },
-                  "body": [
-                    "Payment",
-                    {
-                      "source_pk": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
-                      "receiver_pk": "B62qkYgXYkzT5fuPNhMEHk8ouiThjNNDSTMnpBAuaf6q7pNnCFkUqtz",
-                      "amount": "1000000001"
-                    }
-                  ]
-                },
-                "signer": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
-                "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
-              }
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        1,
+        {
+          "public_key": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "98999999999",
+          "nonce": "1",
+          "receipt_chain_hash": "2n2GwSeZ7VPL6WxCddqAU9BCe8cCypKU7PQ5MVrmTm8P6M3QhHVc",
+          "delegate": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
             ],
-            "status": [
-              "Applied"
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
             ]
           },
-          {
-            "data": [
-              "Signed_command",
-              {
-                "payload": {
-                  "common": {
-                    "fee": "0",
-                    "fee_payer_pk": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
-                    "nonce": "0",
-                    "valid_until": "4294967295",
-                    "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
-                  },
-                  "body": [
-                    "Payment",
-                    {
-                      "source_pk": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
-                      "receiver_pk": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
-                      "amount": "1000000001"
-                    }
-                  ]
-                },
-                "signer": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
-                "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
-              }
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        14,
+        {
+          "public_key": "B62qpaA93gHfmvNoH9DLGgxreGnijhh5aui4duxiV3foX4p5ay5RNis",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "1001000000001",
+          "nonce": "0",
+          "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
+          "delegate": "B62qpaA93gHfmvNoH9DLGgxreGnijhh5aui4duxiV3foX4p5ay5RNis",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
             ],
-            "status": [
-              "Applied"
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
             ]
           },
-          {
-            "data": [
-              "Signed_command",
-              {
-                "payload": {
-                  "common": {
-                    "fee": "0",
-                    "fee_payer_pk": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
-                    "nonce": "0",
-                    "valid_until": "4294967295",
-                    "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
-                  },
-                  "body": [
-                    "Payment",
-                    {
-                      "source_pk": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
-                      "receiver_pk": "B62qji8zLZEuMUpZnRN3FHgsgnybYhhMFBBMcLAwGGLR3hTdfkhmM4X",
-                      "amount": "1000000001"
-                    }
-                  ]
-                },
-                "signer": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
-                "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
-              }
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        3,
+        {
+          "public_key": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "998999999999",
+          "nonce": "1",
+          "receipt_chain_hash": "2n1pWSqUYXzdxVYo2eTfUroAUyTgRLnUwWsrxKfTDFr46aN8mfqi",
+          "delegate": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
             ],
-            "status": [
-              "Applied"
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
             ]
           },
-          {
-            "data": [
-              "Signed_command",
-              {
-                "payload": {
-                  "common": {
-                    "fee": "0",
-                    "fee_payer_pk": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
-                    "nonce": "0",
-                    "valid_until": "4294967295",
-                    "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
-                  },
-                  "body": [
-                    "Payment",
-                    {
-                      "source_pk": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
-                      "receiver_pk": "B62qqMGFkBEtgGs2Gi6AWd1Abn9yzXdj5HRMzm95uwbJ8Wa88C7urCD",
-                      "amount": "1000000001"
-                    }
-                  ]
-                },
-                "signer": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
-                "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
-              }
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        15,
+        {
+          "public_key": "B62qqMGFkBEtgGs2Gi6AWd1Abn9yzXdj5HRMzm95uwbJ8Wa88C7urCD",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "1001000000001",
+          "nonce": "0",
+          "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
+          "delegate": "B62qqMGFkBEtgGs2Gi6AWd1Abn9yzXdj5HRMzm95uwbJ8Wa88C7urCD",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
             ],
-            "status": [
-              "Applied"
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
             ]
           },
-          {
-            "data": [
-              "Signed_command",
-              {
-                "payload": {
-                  "common": {
-                    "fee": "0",
-                    "fee_payer_pk": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
-                    "nonce": "0",
-                    "valid_until": "4294967295",
-                    "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
-                  },
-                  "body": [
-                    "Payment",
-                    {
-                      "source_pk": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
-                      "receiver_pk": "B62qpaA93gHfmvNoH9DLGgxreGnijhh5aui4duxiV3foX4p5ay5RNis",
-                      "amount": "1000000001"
-                    }
-                  ]
-                },
-                "signer": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
-                "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
-              }
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        6,
+        {
+          "public_key": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "998999999999",
+          "nonce": "1",
+          "receipt_chain_hash": "2mznCm9RjqfzRwnrvhNanSEG5haCvtaBsktfXPV7K27RXQFmwEUV",
+          "delegate": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
             ],
-            "status": [
-              "Applied"
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
             ]
           },
-          {
-            "data": [
-              "Signed_command",
-              {
-                "payload": {
-                  "common": {
-                    "fee": "0",
-                    "fee_payer_pk": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
-                    "nonce": "0",
-                    "valid_until": "4294967295",
-                    "memo": "E4QqiVG8rCzSPqdgMPUP59hA8yMWV6m8YSYGSYBAofr6mLp16UFnM"
-                  },
-                  "body": [
-                    "Payment",
-                    {
-                      "source_pk": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
-                      "receiver_pk": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
-                      "amount": "1000000001"
-                    }
-                  ]
-                },
-                "signer": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
-                "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
-              }
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        7,
+        {
+          "public_key": "B62qkYgXYkzT5fuPNhMEHk8ouiThjNNDSTMnpBAuaf6q7pNnCFkUqtz",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "1001000000001",
+          "nonce": "0",
+          "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
+          "delegate": "B62qkYgXYkzT5fuPNhMEHk8ouiThjNNDSTMnpBAuaf6q7pNnCFkUqtz",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
             ],
-            "status": [
-              "Applied"
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
             ]
-          }
-        ],
-        "coinbase": [
-          "One",
-          null
-        ]
-      },
-      null
+          },
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        5,
+        {
+          "public_key": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "998999999999",
+          "nonce": "1",
+          "receipt_chain_hash": "2n21swLakzABLQTJ1WBuMJDXW7wy8YhFJVZQuSEiZVX9Npr44iuL",
+          "delegate": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
+            ],
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
+            ]
+          },
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        11,
+        {
+          "public_key": "B62qji8zLZEuMUpZnRN3FHgsgnybYhhMFBBMcLAwGGLR3hTdfkhmM4X",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "1001000000001",
+          "nonce": "0",
+          "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
+          "delegate": "B62qji8zLZEuMUpZnRN3FHgsgnybYhhMFBBMcLAwGGLR3hTdfkhmM4X",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
+            ],
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
+            ]
+          },
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        0,
+        {
+          "public_key": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "10000000000000000",
+          "nonce": "1",
+          "receipt_chain_hash": "2n1ZipMa9aDQbCZ3KNxn6Na2UQAxKR9e8amsKaBBBtKYnFcksQrN",
+          "delegate": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
+            ],
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
+            ]
+          },
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        4,
+        {
+          "public_key": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "1000000000000",
+          "nonce": "1",
+          "receipt_chain_hash": "2n2B5BzSt5qoZAmZ3znSb9z3QtXbtJD4kMzcioMkZX3YfmfSdquy",
+          "delegate": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
+            ],
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
+            ]
+          },
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ],
+      [
+        8,
+        {
+          "public_key": "B62qpPjYco6oESJyGjdFNjmBnwEyzsujJ785aMAzygzSF4X9g4g1uEo",
+          "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+          "token_permissions": [
+            "Not_owned",
+            {
+              "account_disabled": false
+            }
+          ],
+          "token_symbol": "",
+          "balance": "1040000000000",
+          "nonce": "0",
+          "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
+          "delegate": "B62qpPjYco6oESJyGjdFNjmBnwEyzsujJ785aMAzygzSF4X9g4g1uEo",
+          "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
+          "timing": [
+            "Untimed"
+          ],
+          "permissions": {
+            "edit_state": [
+              "Signature"
+            ],
+            "send": [
+              "Signature"
+            ],
+            "receive": [
+              "None"
+            ],
+            "set_delegate": [
+              "Signature"
+            ],
+            "set_permissions": [
+              "Signature"
+            ],
+            "set_verification_key": [
+              "Signature"
+            ],
+            "set_zkapp_uri": [
+              "Signature"
+            ],
+            "edit_sequence_state": [
+              "Signature"
+            ],
+            "set_token_symbol": [
+              "Signature"
+            ],
+            "increment_nonce": [
+              "Signature"
+            ],
+            "set_voting_for": [
+              "Signature"
+            ]
+          },
+          "zkapp": null,
+          "zkapp_uri": ""
+        }
+      ]
+    ],
+    "accounts_created": [],
+    "tokens_used": [
+      [
+        "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
+        null
+      ]
     ]
-  },
-  "delta_transition_chain_proof": [
-    "jwS686H1zvTjvdHULJkz9xjarjiZeuLFHhUchnHTfhf5yJmouon",
-    []
-  ],
-  "accounts_accessed": [
-    [
-      2,
-      {
-        "public_key": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "1000000000000",
-        "nonce": "1",
-        "receipt_chain_hash": "2n25EYLf61vHTACzFgXp64JB2oH79s8TD8pp7YWEBMeoCPWSDZnZ",
-        "delegate": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      1,
-      {
-        "public_key": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "98999999999",
-        "nonce": "1",
-        "receipt_chain_hash": "2n2GwSeZ7VPL6WxCddqAU9BCe8cCypKU7PQ5MVrmTm8P6M3QhHVc",
-        "delegate": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      14,
-      {
-        "public_key": "B62qpaA93gHfmvNoH9DLGgxreGnijhh5aui4duxiV3foX4p5ay5RNis",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "1001000000001",
-        "nonce": "0",
-        "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
-        "delegate": "B62qpaA93gHfmvNoH9DLGgxreGnijhh5aui4duxiV3foX4p5ay5RNis",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      3,
-      {
-        "public_key": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "998999999999",
-        "nonce": "1",
-        "receipt_chain_hash": "2n1pWSqUYXzdxVYo2eTfUroAUyTgRLnUwWsrxKfTDFr46aN8mfqi",
-        "delegate": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      15,
-      {
-        "public_key": "B62qqMGFkBEtgGs2Gi6AWd1Abn9yzXdj5HRMzm95uwbJ8Wa88C7urCD",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "1001000000001",
-        "nonce": "0",
-        "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
-        "delegate": "B62qqMGFkBEtgGs2Gi6AWd1Abn9yzXdj5HRMzm95uwbJ8Wa88C7urCD",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      6,
-      {
-        "public_key": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "998999999999",
-        "nonce": "1",
-        "receipt_chain_hash": "2mznCm9RjqfzRwnrvhNanSEG5haCvtaBsktfXPV7K27RXQFmwEUV",
-        "delegate": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      7,
-      {
-        "public_key": "B62qkYgXYkzT5fuPNhMEHk8ouiThjNNDSTMnpBAuaf6q7pNnCFkUqtz",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "1001000000001",
-        "nonce": "0",
-        "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
-        "delegate": "B62qkYgXYkzT5fuPNhMEHk8ouiThjNNDSTMnpBAuaf6q7pNnCFkUqtz",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      5,
-      {
-        "public_key": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "998999999999",
-        "nonce": "1",
-        "receipt_chain_hash": "2n21swLakzABLQTJ1WBuMJDXW7wy8YhFJVZQuSEiZVX9Npr44iuL",
-        "delegate": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      11,
-      {
-        "public_key": "B62qji8zLZEuMUpZnRN3FHgsgnybYhhMFBBMcLAwGGLR3hTdfkhmM4X",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "1001000000001",
-        "nonce": "0",
-        "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
-        "delegate": "B62qji8zLZEuMUpZnRN3FHgsgnybYhhMFBBMcLAwGGLR3hTdfkhmM4X",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      0,
-      {
-        "public_key": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "10000000000000000",
-        "nonce": "1",
-        "receipt_chain_hash": "2n1ZipMa9aDQbCZ3KNxn6Na2UQAxKR9e8amsKaBBBtKYnFcksQrN",
-        "delegate": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      4,
-      {
-        "public_key": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "1000000000000",
-        "nonce": "1",
-        "receipt_chain_hash": "2n2B5BzSt5qoZAmZ3znSb9z3QtXbtJD4kMzcioMkZX3YfmfSdquy",
-        "delegate": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ],
-    [
-      8,
-      {
-        "public_key": "B62qpPjYco6oESJyGjdFNjmBnwEyzsujJ785aMAzygzSF4X9g4g1uEo",
-        "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-        "token_permissions": [
-          "Not_owned",
-          {
-            "account_disabled": false
-          }
-        ],
-        "token_symbol": "",
-        "balance": "1040000000000",
-        "nonce": "0",
-        "receipt_chain_hash": "2n1hGCgg3jCKQJzVBgfujGqyV6D9riKgq27zhXqYgTRVZM5kqfkm",
-        "delegate": "B62qpPjYco6oESJyGjdFNjmBnwEyzsujJ785aMAzygzSF4X9g4g1uEo",
-        "voting_for": "3NK2tkzqqK5spR2sZ7tujjqPksL45M3UUrcA4WhCkeiPtnugyE2x",
-        "timing": [
-          "Untimed"
-        ],
-        "permissions": {
-          "edit_state": [
-            "Signature"
-          ],
-          "send": [
-            "Signature"
-          ],
-          "receive": [
-            "None"
-          ],
-          "set_delegate": [
-            "Signature"
-          ],
-          "set_permissions": [
-            "Signature"
-          ],
-          "set_verification_key": [
-            "Signature"
-          ],
-          "set_zkapp_uri": [
-            "Signature"
-          ],
-          "edit_sequence_state": [
-            "Signature"
-          ],
-          "set_token_symbol": [
-            "Signature"
-          ],
-          "increment_nonce": [
-            "Signature"
-          ],
-          "set_voting_for": [
-            "Signature"
-          ]
-        },
-        "zkapp": null,
-        "zkapp_uri": ""
-      }
-    ]
-  ],
-  "accounts_created": [],
-  "tokens_used": [
-    [
-      "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
-      null
-    ]
-  ]
+  }
 }
-|json}
+  |json}

--- a/src/lib/ppx_version/versioned_module.ml
+++ b/src/lib/ppx_version/versioned_module.ml
@@ -12,6 +12,8 @@ let with_top_version_tag = "with_top_version_tag"
 
 let with_top_version_tag_module = String.capitalize with_top_version_tag
 
+let with_versioned_json = "with_versioned_json"
+
 let no_toplevel_latest_type_str = "no_toplevel_latest_type"
 
 (* option to `deriving version' *)
@@ -293,7 +295,7 @@ let mk_all_version_tags_type_decl =
   end
 
 let version_type ~version_option version stri ~all_version_tagged
-    ~top_version_tag =
+    ~top_version_tag ~json_version_tag =
   let loc = stri.pstr_loc in
   let find_t_stri stri =
     let is_t_stri stri =
@@ -383,6 +385,27 @@ let version_type ~version_option version stri ~all_version_tagged
           (Located.mk (Ldot (Ldot (Lident "Bin_prot", "Type_class"), fld))))
     in
     let open Ast_builder in
+    let yojson_tag_shadows =
+      if not json_version_tag then []
+      else
+        [%str
+          let to_yojson item =
+            `Assoc
+              [ ("version", `Int [%e eint version]); ("data", to_yojson item) ]
+
+          let of_yojson json =
+            match json with
+            | `Assoc [ ("version", `Int n); ("data", data_json) ] ->
+                if n = [%e eint version] then of_yojson data_json
+                else
+                  Error
+                    (Core_kernel.sprintf "In JSON, expected version %d, got %d"
+                       [%e eint version] n )
+            | _ ->
+                Error "Expected versioned JSON"
+
+          let (_ : _) = (to_yojson, of_yojson)]
+    in
     let deriving_bin_io =
       lazy (create_attr ~loc (Located.mk "deriving") (PStr [ [%stri bin_io] ]))
     in
@@ -613,16 +636,16 @@ let version_type ~version_option version stri ~all_version_tagged
         in
         make_tag_module typ_decl with_top_version_tag_module
     in
-    let version_tag_modules =
-      all_version_tag_modules @ top_version_tag_modules
+    let version_tag_items =
+      yojson_tag_shadows @ all_version_tag_modules @ top_version_tag_modules
     in
     let to_latest_guard_modules =
-      (* use of `to_latest`, in case neither all_version_tagged nor top_version_tag *)
-      if empty_params && List.is_empty version_tag_modules then
+      (* use of `to_latest`, in case no version tag items *)
+      if empty_params && List.is_empty version_tag_items then
         [%str let (_ : _) = to_latest]
       else []
     in
-    to_latest_guard_modules @ version_tag_modules
+    to_latest_guard_modules @ version_tag_items
   in
   match stri.pstr_desc with
   | Pstr_type _ ->
@@ -669,7 +692,8 @@ let is_attr_sigitem_with_name name = function
   | _ ->
       false
 
-let convert_module_stri ~version_option ~top_version_tag last_version stri =
+let convert_module_stri ~version_option ~top_version_tag ~json_version_tag
+    last_version stri =
   let module_pattern =
     Ast_pattern.(
       pstr_module (module_binding ~name:(some __') ~expr:(pmod_structure __')))
@@ -724,7 +748,7 @@ let convert_module_stri ~version_option ~top_version_tag last_version stri =
   in
   let should_convert, type_str, extra_stris =
     version_type ~version_option version stri ~all_version_tagged
-      ~top_version_tag
+      ~top_version_tag ~json_version_tag
   in
   (* TODO: If [should_convert] then look for [to_latest]. *)
   let open Ast_builder.Default in
@@ -744,14 +768,21 @@ let convert_modbody ~loc ~version_option body =
     !no_toplevel_latest_type
     || List.exists attrs ~f:(is_attr_stri_with_name no_toplevel_latest_type_str)
   in
+  let json_version_tag =
+    List.exists attrs ~f:(is_attr_stri_with_name with_versioned_json)
+  in
   let top_version_tag =
     List.exists attrs ~f:(is_attr_stri_with_name with_top_version_tag)
   in
-  let _, rev_str, type_stri, top_tag_convs, all_tag_convs =
-    List.fold ~init:(None, [], None, [], []) body_no_attrs
-      ~f:(fun (version, rev_str, type_stri, top_taggeds, all_taggeds) stri ->
+  let _, rev_str, type_stri, top_tag_convs, all_tag_convs, json_tag_convs =
+    List.fold ~init:(None, [], None, [], [], []) body_no_attrs
+      ~f:(fun
+           (version, rev_str, type_stri, top_taggeds, all_taggeds, json_taggeds)
+           stri
+         ->
         let version, stri, should_convert, current_type_stri, is_all_tagged =
-          convert_module_stri ~version_option ~top_version_tag version stri
+          convert_module_stri ~version_option ~top_version_tag ~json_version_tag
+            version stri
         in
         let type_stri =
           if no_toplevel_type then None
@@ -771,7 +802,16 @@ let convert_modbody ~loc ~version_option body =
           if is_all_tagged && should_convert then version :: all_taggeds
           else all_taggeds
         in
-        (Some version, stri :: rev_str, type_stri, top_tag_convs, all_tag_convs) )
+        let json_tag_convs =
+          if json_version_tag && should_convert then version :: json_taggeds
+          else json_taggeds
+        in
+        ( Some version
+        , stri :: rev_str
+        , type_stri
+        , top_tag_convs
+        , all_tag_convs
+        , json_tag_convs ) )
   in
   let (module Ast_builder) = Ast_builder.make loc in
   let rev_str =
@@ -949,7 +989,82 @@ let convert_modbody ~loc ~version_option body =
               in
               [ all_tag_convert_guard; all_tag_convert; all_tag_versions ]
           in
-          top_tag_modules @ all_tag_modules
+          let json_tag_modules =
+            if not json_version_tag then []
+            else
+              let json_tag_versions =
+                [%stri
+                  let (json_tag_versions :
+                        ( int
+                        * (Yojson.Safe.t -> Latest.t Core_kernel.Or_error.t) )
+                        array ) =
+                    [%e
+                      let open Ast_builder in
+                      pexp_array
+                        (List.map json_tag_convs ~f:(fun version ->
+                             let version_module =
+                               Longident.Lident (sprintf "V%i" version)
+                             in
+                             let dot x =
+                               let open Longident in
+                               Located.mk (Ldot (version_module, x))
+                             in
+                             pexp_tuple
+                               [ eint version
+                               ; [%expr
+                                   fun json ->
+                                     match
+                                       [%e
+                                         pexp_apply
+                                           (pexp_ident (dot "of_yojson"))
+                                           [ ( Nolabel
+                                             , pexp_ident
+                                                 (Located.mk (Lident "json")) )
+                                           ]]
+                                     with
+                                     | Ok v ->
+                                         Ok
+                                           [%e
+                                             pexp_apply
+                                               (pexp_ident (dot "to_latest"))
+                                               [ ( Nolabel
+                                                 , pexp_ident
+                                                     (Located.mk (Lident "v"))
+                                                 )
+                                               ]]
+                                     | Error err ->
+                                         Error (Error.of_string err)]
+                               ] ) )]]
+              in
+              let json_tag_convert =
+                [%stri
+                  (** deserializes JSON to the latest module version's type *)
+                  let of_yojson_to_latest (json : Yojson.Safe.t) :
+                      Latest.t Core_kernel.Or_error.t =
+                    match json with
+                    | `Assoc [ ("version", `Int version); ("data", _) ] -> (
+                        match
+                          Array.find_map json_tag_versions ~f:(fun (i, f) ->
+                              if Int.equal i version then Some (f json)
+                              else None )
+                        with
+                        | Some v ->
+                            v
+                        | None ->
+                            Error
+                              (Error.of_string
+                                 (sprintf
+                                    "Could not find json-tagged version %d"
+                                    version ) ) )
+                    | _ ->
+                        Error (Error.of_string "Expected versioned JSON")]
+              in
+              let json_tag_convert_guard =
+                [%stri let (_ : _) = of_yojson_to_latest]
+              in
+              [ json_tag_convert_guard; json_tag_convert; json_tag_versions ]
+          in
+          json_tag_modules @ top_tag_modules @ all_tag_modules
         in
         converter_modules @ rev_str
     | _ ->
@@ -986,8 +1101,9 @@ let version_module ~loc ~version_option ~path:_ modname modbody =
    - add deriving bin_io, version to list of deriving items for the type "t" in versioned modules
    - add "module Latest = Vn" to Stable module
    - if Stable.Latest.t has no parameters:
-     - if "with_top_version_tag" annotation present, add item for "bin_read_top_tagged_to_latest"
-     - if any "with_all_version_tags" annotation present, add "bin_read_all_tagged_to_latest" item
+     - if "with_versioned_json" annotation present, add "of_yojson_to_latest"
+     - if "with_top_version_tag" annotation present, add "bin_read_top_tagged_to_latest"
+     - if any "with_all_version_tags" annotation is present, add "bin_read_all_tagged_to_latest"
 *)
 
 (* parameterless_t means the type t in the module type has no parameters *)
@@ -1166,13 +1282,16 @@ let convert_module_decls signature =
   , List.fold signature_no_attrs ~init
       ~f:(convert ~no_toplevel_latest ~top_version_tagged) )
 
-let version_module_decl ~loc ~path:_ modname signature =
+let version_module_decl ~loc ~path modname signature =
   Printexc.record_backtrace true ;
   try
     let open Ast_helper in
     let modname = map_loc ~f:(check_modname ~loc:modname.loc) modname in
     let sig_attrs, { latest; sigitems; convertible; extra_sigitems; _ } =
       convert_module_decls signature.txt
+    in
+    let json_version_tag =
+      List.exists sig_attrs ~f:(is_attr_sigitem_with_name with_versioned_json)
     in
     let top_version_tag =
       List.exists sig_attrs ~f:(is_attr_sigitem_with_name with_top_version_tag)
@@ -1206,6 +1325,14 @@ let version_module_decl ~loc ~path:_ modname signature =
           in
           let defs =
             if convertible then
+              let json_version_modules =
+                if json_version_tag then
+                  [ [%sigi:
+                      val of_yojson_to_latest :
+                        Yojson.Safe.t -> Latest.t Core_kernel.Or_error.t]
+                  ]
+                else []
+              in
               let top_version_modules =
                 if top_version_tag then
                   [ [%sigi:
@@ -1226,7 +1353,7 @@ let version_module_decl ~loc ~path:_ modname signature =
                   ]
                 else []
               in
-              top_version_modules @ all_version_modules
+              json_version_modules @ top_version_modules @ all_version_modules
             else []
           in
           (* insert Latest alias after latest version module decl


### PR DESCRIPTION
Implement versioning of JSON per RFC 0046.

The annotation `with_versioned_json` can be added to `Stable` modules or module signatures.

Added that annotation to `Precomputed_block.Stable`, and added the version number to the sample precomputed block JSON. (We should update those blocks sometime, they contain dummy proofs and signatures, and empty lists for accounts and tokens.)

Tested by adding the annotation to a type in matching .ml/.mli files, verifying it compiled and examining the preprocessed output.