### PR TITLE
Add other_parties_ledger to the txn snark global state

### DIFF
--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -162,11 +162,15 @@ let profile (module T : Transaction_snark.S) sparse_ledger0
                       { sok_digest = Sok_message.Digest.default
                       ; source =
                           { ledger = Sparse_ledger.merkle_root sparse_ledger
+                          ; other_parties_ledger =
+                              Frozen_ledger_hash.empty_hash (* TODO *)
                           ; pending_coinbase_stack = coinbase_stack_source
                           ; local_state = Mina_state.Local_state.empty ()
                           }
                       ; target =
                           { ledger = Sparse_ledger.merkle_root sparse_ledger'
+                          ; other_parties_ledger =
+                              Frozen_ledger_hash.empty_hash (* TODO *)
                           ; pending_coinbase_stack = coinbase_stack_target
                           ; local_state = Mina_state.Local_state.empty ()
                           }

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -74,6 +74,7 @@ let non_pc_registers_equal_var t1 t2 =
       let f eq acc field = eq (F.get field t1) (F.get field t2) :: acc in
       Registers.Fields.fold ~init:[]
         ~ledger:(f !Frozen_ledger_hash.equal_var)
+        ~other_parties_ledger:(f !Frozen_ledger_hash.equal_var)
         ~pending_coinbase_stack:(fun acc f ->
           let () = F.get f t1 and () = F.get f t2 in
           acc )

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -448,6 +448,7 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
     ~precomputed_values ~verifier ~parent_staged_ledger ~parent_protocol_state
     (t, validation) =
   let target_hash_of_ledger_proof =
+    (* TODO: Change this to other_parties_ledger *)
     Fn.compose Registers.ledger
     @@ Fn.compose Ledger_proof.statement_target Ledger_proof.statement
   in

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -596,7 +596,8 @@ module Types = struct
             ~doc:"Base58Check-encoded hash of the target ledger"
             ~args:Arg.[]
             ~resolve:(fun _ { Transaction_snark.Statement.target; _ } ->
-              Frozen_ledger_hash.to_base58_check target.ledger )
+              Frozen_ledger_hash.to_base58_check target.ledger
+              (* TODO: change this to other_parties_ledger *) )
         ; field "feeExcess" ~typ:(non_null signed_fee)
             ~doc:
               "Total transaction fee that is not accounted for in the \

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -130,7 +130,9 @@ module Body = struct
       =
     let module C = Consensus.Proof_of_stake.Exported.Consensus_state in
     let cs : Consensus.Data.Consensus_state.var = t.consensus_state in
-    { snarked_ledger_hash = t.blockchain_state.registers.ledger
+    { snarked_ledger_hash =
+        t.blockchain_state.registers.ledger
+        (* TODO: Change to other_parties_ledger when wired in. *)
     ; timestamp = t.blockchain_state.timestamp
     ; blockchain_length = C.blockchain_length_var cs
     ; min_window_density = C.min_window_density_var cs
@@ -152,7 +154,9 @@ module Body = struct
   let view (t : Value.t) : Zkapp_precondition.Protocol_state.View.t =
     let module C = Consensus.Proof_of_stake.Exported.Consensus_state in
     let cs = t.consensus_state in
-    { snarked_ledger_hash = t.blockchain_state.registers.ledger
+    { snarked_ledger_hash =
+        t.blockchain_state.registers.ledger
+        (* TODO: Change to other_parties_ledger when wired in. *)
     ; timestamp = t.blockchain_state.timestamp
     ; blockchain_length = C.blockchain_length cs
     ; min_window_density = C.min_window_density cs

--- a/src/lib/mina_state/registers.ml
+++ b/src/lib/mina_state/registers.ml
@@ -7,6 +7,7 @@ module Stable = struct
   module V1 = struct
     type ('ledger, 'pending_coinbase_stack, 'local_state) t =
       { ledger : 'ledger
+      ; other_parties_ledger : 'ledger
       ; pending_coinbase_stack : 'pending_coinbase_stack
       ; local_state : 'local_state
       }
@@ -17,13 +18,16 @@ end]
 let gen =
   let open Quickcheck.Generator.Let_syntax in
   let%map ledger = Frozen_ledger_hash.gen
+  and other_parties_ledger = Frozen_ledger_hash.gen
   and pending_coinbase_stack = Pending_coinbase.Stack.gen
   and local_state = Local_state.gen in
-  { ledger; pending_coinbase_stack; local_state }
+  { ledger; other_parties_ledger; pending_coinbase_stack; local_state }
 
-let to_input { ledger; pending_coinbase_stack; local_state } =
+let to_input
+    { ledger; other_parties_ledger; pending_coinbase_stack; local_state } =
   Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
     [| Frozen_ledger_hash.to_input ledger
+     ; Frozen_ledger_hash.to_input other_parties_ledger
      ; Pending_coinbase.Stack.to_input pending_coinbase_stack
      ; Local_state.to_input local_state
     |]
@@ -56,9 +60,11 @@ module Checked = struct
   type nonrec t =
     (Ledger_hash.var, Pending_coinbase.Stack.var, Local_state.Checked.t) t
 
-  let to_input { ledger; pending_coinbase_stack; local_state } =
+  let to_input
+      { ledger; other_parties_ledger; pending_coinbase_stack; local_state } =
     Array.reduce_exn ~f:Random_oracle.Input.Chunked.append
       [| Frozen_ledger_hash.var_to_input ledger
+       ; Frozen_ledger_hash.var_to_input other_parties_ledger
        ; Pending_coinbase.Stack.var_to_input pending_coinbase_stack
        ; Local_state.Checked.to_input local_state
       |]
@@ -67,6 +73,7 @@ module Checked = struct
     let ( ! ) eq x1 x2 = Impl.run_checked (eq x1 x2) in
     let f eq acc field = eq (Field.get field t1) (Field.get field t2) :: acc in
     Fields.fold ~init:[] ~ledger:(f !Frozen_ledger_hash.equal_var)
+      ~other_parties_ledger:(f !Frozen_ledger_hash.equal_var)
       ~pending_coinbase_stack:(f !Pending_coinbase.Stack.equal_var)
       ~local_state:(fun acc f ->
         Local_state.Checked.equal' (Field.get f t1) (Field.get f t2) @ acc )

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -98,6 +98,8 @@ module Statement : sig
       -> sok_digest:'sok_digest
       -> source:'ledger_hash
       -> target:'ledger_hash
+      -> other_parties_source:'ledger_hash
+      -> other_parties_target:'ledger_hash
       -> pending_coinbase_stack_state:
            'pending_coinbase Pending_coinbase_stack_state.poly
       -> ( 'ledger_hash

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -225,11 +225,13 @@ let create_expected_statement ~constraint_constants
   let%map supply_increase = Transaction.supply_increase transaction in
   { Transaction_snark.Statement.source =
       { ledger = source_merkle_root
+      ; other_parties_ledger = Frozen_ledger_hash.empty_hash (* TODO *)
       ; pending_coinbase_stack = statement.source.pending_coinbase_stack
       ; local_state = empty_local_state
       }
   ; target =
       { ledger = target_merkle_root
+      ; other_parties_ledger = Frozen_ledger_hash.empty_hash (* TODO *)
       ; pending_coinbase_stack = pending_coinbase_after
       ; local_state = empty_local_state
       }
@@ -539,6 +541,11 @@ struct
         clarify_error
           (Frozen_ledger_hash.equal reg1.ledger reg2.ledger)
           "did not connect with snarked ledger hash"
+      and () =
+        clarify_error
+          (Frozen_ledger_hash.equal reg1.other_parties_ledger
+             reg2.other_parties_ledger )
+          "did not connect with snarked other_parties_ledger hash"
       and () =
         clarify_error
           (Pending_coinbase.Stack.connected ~first:reg1.pending_coinbase_stack

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -404,7 +404,9 @@ module For_tests = struct
         Protocol_state.hashes previous_protocol_state
       in
       let consensus_state =
-        make_next_consensus_state ~snarked_ledger_hash:previous_registers.ledger
+        make_next_consensus_state
+          ~snarked_ledger_hash:previous_registers.ledger
+            (* TODO: change to other_parties_ledger *)
           ~previous_protocol_state:
             With_hash.
               { data = previous_protocol_state; hash = previous_state_hashes }

--- a/src/lib/uptime_service/uptime_service.ml
+++ b/src/lib/uptime_service/uptime_service.ml
@@ -327,6 +327,7 @@ let send_block_and_transaction_snark ~logger ~interruptor ~url ~snark_worker
                   match transition with
                   | Snark_work_lib.Work.Single.Spec.Transition ({ target; _ }, _)
                     ->
+                      (* TODO: Change this to other_parties_ledger *)
                       Pasta_bindings.Fp.equal target.ledger
                         (Staged_ledger_hash.ledger_hash staged_ledger_hash)
                   | Merge _ ->


### PR DESCRIPTION
This PR adds an `other_parties_ledger` field to the transaction snark's global state, and updates the merge proof to merge this second pair of hashes.

Currently, the values are all `empty_hash`, pending the ability to generate the required hashes.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them