### PR TITLE
Update zkapps_examples API to return a `Parties.Call_forest.Tree.t`

### DIFF
--- a/src/lib/mina_base/parties.ml
+++ b/src/lib/mina_base/parties.ml
@@ -452,14 +452,17 @@ module Call_forest = struct
     | x :: _ ->
         With_stack_hash.stack_hash x
 
+  let cons_tree tree (forest : _ t) : _ t =
+    { elt = tree
+    ; stack_hash = Digest.Forest.cons (Digest.Tree.create tree) (hash forest)
+    }
+    :: forest
+
   let cons_aux (type p) ~(digest_party : p -> _) ?(calls = []) (party : p)
       (xs : _ t) : _ t =
     let party_digest = digest_party party in
     let tree : _ Tree.t = { party; party_digest; calls } in
-    { elt = tree
-    ; stack_hash = Digest.Forest.cons (Digest.Tree.create tree) (hash xs)
-    }
-    :: xs
+    cons_tree tree xs
 
   let cons ?calls (party : Party.t) xs =
     cons_aux ~digest_party:Digest.Party.create ?calls party xs

--- a/src/lib/mina_base/zkapp_basic.ml
+++ b/src/lib/mina_base/zkapp_basic.ml
@@ -198,8 +198,7 @@ module Set_or_keep = struct
         ~back:(function
           | { Flagged_option.is_some = true; data = x } ->
               Set (Option.value_exn (to_option x))
-          | { Flagged_option.is_some = false; data = x } ->
-              assert (Option.is_none (to_option x)) ;
+          | { Flagged_option.is_some = false; data = _ } ->
               Keep )
 
     let to_input (t : _ t) ~f =

--- a/src/lib/transaction_snark/test/zkapps_examples/empty_update/dune
+++ b/src/lib/transaction_snark/test/zkapps_examples/empty_update/dune
@@ -38,6 +38,7 @@
    transaction_snark_tests
    with_hash
    zkapps_empty_update
+   zkapps_examples
    )
   (preprocess
     (pps ppx_snarky ppx_version ppx_jane))

--- a/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
@@ -26,7 +26,8 @@ let tag, _, p_module, Pickles.Provers.[ prover ] =
   Pickles.compile ~cache:Cache_dir.cache
     (module Statement)
     (module Statement)
-    ~public_input:(Output Zkapp_statement.typ) ~auxiliary_typ:Impl.Typ.unit
+    ~public_input:(Output Zkapp_statement.typ)
+    ~auxiliary_typ:(Prover_value.typ ())
     ~branches:(module Nat.N1)
     ~max_proofs_verified:(module Nat.N0)
     ~name:"empty_update"
@@ -42,7 +43,7 @@ let vk = Pickles.Side_loaded.Verification_key.of_compiled tag
 (* TODO: This should be entirely unnecessary. *)
 let party_body = Zkapps_empty_update.generate_party pk_compressed
 
-let _stmt, (), party_proof = Async.Thread_safe.block_on_async_exn prover
+let _stmt, _res, party_proof = Async.Thread_safe.block_on_async_exn prover
 
 let party_proof = Pickles.Side_loaded.Proof.of_proof party_proof
 

--- a/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
@@ -16,18 +16,8 @@ let pk_compressed = Public_key.compress pk
 
 let account_id = Account_id.create pk_compressed Token_id.default
 
-module Statement = struct
-  type t = unit
-
-  let to_field_elements () = [||]
-end
-
 let tag, _, p_module, Pickles.Provers.[ prover ] =
-  Pickles.compile ~cache:Cache_dir.cache
-    (module Statement)
-    (module Statement)
-    ~public_input:(Output Zkapp_statement.typ)
-    ~auxiliary_typ:(Prover_value.typ ())
+  Zkapps_examples.compile () ~cache:Cache_dir.cache ~auxiliary_typ:Impl.Typ.unit
     ~branches:(module Nat.N1)
     ~max_proofs_verified:(module Nat.N0)
     ~name:"empty_update"
@@ -40,20 +30,11 @@ module P = (val p_module)
 
 let vk = Pickles.Side_loaded.Verification_key.of_compiled tag
 
-(* TODO: This should be entirely unnecessary. *)
-let party_body = Zkapps_empty_update.generate_party pk_compressed
+let party, () = Async.Thread_safe.block_on_async_exn prover
 
-let _stmt, _res, party_proof = Async.Thread_safe.block_on_async_exn prover
-
-let party_proof = Pickles.Side_loaded.Proof.of_proof party_proof
-
-let party : Party.Graphql_repr.t =
-  Party.to_graphql_repr ~call_depth:0
-    { body = party_body; authorization = Proof party_proof }
-
-let deploy_party_body : Party.Body.Graphql_repr.t =
+let deploy_party_body : Party.Body.t =
   (* TODO: This is a pain. *)
-  { Party.Body.Graphql_repr.dummy with
+  { Party.Body.dummy with
     public_key = pk_compressed
   ; update =
       { Party.Update.dummy with
@@ -75,23 +56,20 @@ let deploy_party_body : Party.Body.Graphql_repr.t =
   ; use_full_commitment = true
   }
 
-let deploy_party : Party.Graphql_repr.t =
+let deploy_party : Party.t =
   (* TODO: This is a pain. *)
   { body = deploy_party_body; authorization = Signature Signature.dummy }
 
-let ps =
-  (* TODO: This is a pain. *)
-  Parties.Call_forest.of_parties_list
-    ~party_depth:(fun (p : Party.Graphql_repr.t) -> p.body.call_depth)
-    [ deploy_party; party ]
-  |> Parties.Call_forest.map ~f:Party.of_graphql_repr
-  |> Parties.Call_forest.accumulate_hashes_predicated
+let other_parties =
+  []
+  |> Parties.Call_forest.cons_tree party
+  |> Parties.Call_forest.cons deploy_party
 
 let memo = Signed_command_memo.empty
 
 let transaction_commitment : Parties.Transaction_commitment.t =
   (* TODO: This is a pain. *)
-  let other_parties_hash = Parties.Call_forest.hash ps in
+  let other_parties_hash = Parties.Call_forest.hash other_parties in
   Parties.Transaction_commitment.create ~other_parties_hash
 
 let fee_payer =
@@ -149,11 +127,7 @@ let sign_all ({ fee_payer; other_parties; memo } : Parties.t) : Parties.t =
 let parties : Parties.t =
   sign_all
     { fee_payer = { body = fee_payer.body; authorization = Signature.dummy }
-    ; other_parties =
-        Parties.Call_forest.of_parties_list [ deploy_party; party ]
-          ~party_depth:(fun (p : Party.Graphql_repr.t) -> p.body.call_depth)
-        |> Parties.Call_forest.map ~f:Party.of_graphql_repr
-        |> Parties.Call_forest.accumulate_hashes'
+    ; other_parties
     ; memo
     }
 

--- a/src/lib/transaction_snark/test/zkapps_examples/initialize_state/dune
+++ b/src/lib/transaction_snark/test/zkapps_examples/initialize_state/dune
@@ -39,6 +39,7 @@
    transaction_snark_tests
    with_hash
    zkapps_initialize_state
+   zkapps_examples
    )
   (inline_tests)
   (preprocess

--- a/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
@@ -34,7 +34,8 @@ let%test_module "Initialize state test" =
       Pickles.compile ~cache:Cache_dir.cache
         (module Statement)
         (module Statement)
-        ~public_input:(Output Zkapp_statement.typ) ~auxiliary_typ:Impl.Typ.unit
+        ~public_input:(Output Zkapp_statement.typ)
+        ~auxiliary_typ:(Prover_value.typ ())
         ~branches:(module Nat.N2)
         ~max_proofs_verified:(module Nat.N0)
         ~name:"empty_update"
@@ -97,7 +98,7 @@ let%test_module "Initialize state test" =
       let party_body =
         Zkapps_initialize_state.generate_initialize_party pk_compressed
 
-      let _stmt, (), party_proof =
+      let _stmt, _res, party_proof =
         Async.Thread_safe.block_on_async_exn initialize_prover
 
       let party_proof = Pickles.Side_loaded.Proof.of_proof party_proof
@@ -114,7 +115,7 @@ let%test_module "Initialize state test" =
         Zkapps_initialize_state.generate_update_state_party pk_compressed
           new_state
 
-      let _stmt, (), party_proof =
+      let _stmt, _res, party_proof =
         Async.Thread_safe.block_on_async_exn
           (update_state_prover
              ~handler:(Zkapps_initialize_state.update_state_handler new_state) )

--- a/src/lib/zkapps_examples/dune
+++ b/src/lib/zkapps_examples/dune
@@ -2,6 +2,7 @@
  (name zkapps_examples)
  (libraries
    ;; opam libraries
+   async_kernel
    core_kernel
    ;; local libraries
    crypto_params
@@ -24,4 +25,5 @@
  (instrumentation (backend bisect_ppx))
  (preprocess
   (pps
+   ppx_let
    ppx_version)))

--- a/src/lib/zkapps_examples/dune
+++ b/src/lib/zkapps_examples/dune
@@ -19,7 +19,8 @@
    snark_params
    sgn
    signature_lib
-   tuple_lib)
+   tuple_lib
+   with_hash)
  (instrumentation (backend bisect_ppx))
  (preprocess
   (pps

--- a/src/lib/zkapps_examples/empty_update/zkapps_empty_update.ml
+++ b/src/lib/zkapps_examples/empty_update/zkapps_empty_update.ml
@@ -6,7 +6,7 @@ open Zkapps_examples
          Modify snarky to do this.
 *)
 let main public_key =
-  Zkapps_examples.party_circuit (fun () ->
+  Zkapps_examples.wrap_main (fun () ->
       Party_under_construction.In_circuit.create
         ~public_key:(Public_key.Compressed.var_of_t public_key)
         ~token_id:Token_id.(Checked.constant default)

--- a/src/lib/zkapps_examples/initialize_state/zkapps_initialize_state.ml
+++ b/src/lib/zkapps_examples/initialize_state/zkapps_initialize_state.ml
@@ -17,7 +17,7 @@ let initial_state =
     ]
 
 let initialize public_key =
-  Zkapps_examples.party_circuit (fun () ->
+  Zkapps_examples.wrap_main (fun () ->
       let party =
         Party_under_construction.In_circuit.create
           ~public_key:(Public_key.Compressed.var_of_t public_key)
@@ -42,7 +42,7 @@ let update_state_handler (new_state : Field.Constant.t list)
       respond Unhandled
 
 let update_state public_key =
-  Zkapps_examples.party_circuit (fun () ->
+  Zkapps_examples.wrap_main (fun () ->
       let party =
         Party_under_construction.In_circuit.create
           ~public_key:(Public_key.Compressed.var_of_t public_key)


### PR DESCRIPTION
This PR builds upon #11418, extending the `Zkapps_examples` API to return a `Parties.Call_forest.Tree.t` from each prover.

This lays the foundation for testing calls between zkApps using this `Zkapps_examples` API.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them