### PR TITLE
Snarkyjs hashing primitives

### DIFF
--- a/src/lib/snarky_js_bindings/lib/dune
+++ b/src/lib/snarky_js_bindings/lib/dune
@@ -26,6 +26,7 @@
    block_time
    currency
    data_hash_lib
+   hash_prefixes
    fields_derivers
    fields_derivers_zkapps
    genesis_constants

--- a/src/lib/snarky_js_bindings/tests/basic-circuit.mjs
+++ b/src/lib/snarky_js_bindings/tests/basic-circuit.mjs
@@ -14,7 +14,7 @@ let FieldArrayTyp = (size) => ({
 });
 class Main extends Circuit {
   static snarkyMain(preimage, [hash]) {
-    Poseidon.hash(preimage).assertEquals(hash);
+    Poseidon.hash(preimage, true).assertEquals(hash);
   }
   static snarkyWitnessTyp = FieldArrayTyp(4);
   static snarkyPublicTyp = FieldArrayTyp(1);
@@ -29,7 +29,7 @@ function basicCircuit() {
     Field.random(),
     Field.random(),
   ];
-  let hash = Poseidon.hash(preimage);
+  let hash = Poseidon.hash(preimage, false);
 
   console.log("generating keypair...");
   let kp = Main.generateKeypair();

--- a/src/lib/snarky_js_bindings/tests/pickles-proof.mjs
+++ b/src/lib/snarky_js_bindings/tests/pickles-proof.mjs
@@ -9,14 +9,14 @@ export { picklesProof };
 const trueFactors = [Field.random(), Field.random()];
 const trueProduct = trueFactors[0].mul(trueFactors[1]);
 const truePrehash = Field.random();
-const trueHash = Poseidon.hash([truePrehash]);
+const trueHash = Poseidon.hash([truePrehash], false);
 
 function factors(x, y) {
   x.mul(y).assertEquals(trueProduct);
 }
 
 function hash(x) {
-  Poseidon.hash([x]).assertEquals(trueHash);
+  Poseidon.hash([x], true).assertEquals(trueHash);
 }
 
 async function picklesProof() {


### PR DESCRIPTION
* Mina companion for https://github.com/o1-labs/snarkyjs/pull/270
* Exposes hashing building blocks to give snarkyjs the power to implement the hashes it needs
* The alternative would have been exposing many custom hashing methods like `Event.hash` one-by-one. I think what we do here is much better in terms of amount of glue code, inspectability of snarkyjs, and decoupling from OCaml