### PR TITLE
Remove previous_receipt_chain_hash

### DIFF
--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -108,15 +108,13 @@ module Transaction_applied : sig
   module Signed_command_applied : sig
     module Common : sig
       type t = Transaction_applied.Signed_command_applied.Common.t =
-        { user_command : Signed_command.t With_status.t
-        ; previous_receipt_chain_hash : Receipt.Chain_hash.t
-        }
+        { user_command : Signed_command.t With_status.t }
       [@@deriving sexp]
     end
 
     module Body : sig
       type t = Transaction_applied.Signed_command_applied.Body.t =
-        | Payment of { previous_empty_accounts : Account_id.t list }
+        | Payment of { new_accounts : Account_id.t list }
         | Stake_delegation of
             { previous_delegate : Public_key.Compressed.t option }
         | Failed
@@ -132,7 +130,7 @@ module Transaction_applied : sig
     type t = Transaction_applied.Parties_applied.t =
       { accounts : (Account_id.t * Account.t option) list
       ; command : Parties.t With_status.t
-      ; previous_empty_accounts : Account_id.t list
+      ; new_accounts : Account_id.t list
       }
     [@@deriving sexp]
   end
@@ -146,15 +144,13 @@ module Transaction_applied : sig
 
   module Fee_transfer_applied : sig
     type t = Transaction_applied.Fee_transfer_applied.t =
-      { fee_transfer : Fee_transfer.t
-      ; previous_empty_accounts : Account_id.t list
-      }
+      { fee_transfer : Fee_transfer.t; new_accounts : Account_id.t list }
     [@@deriving sexp]
   end
 
   module Coinbase_applied : sig
     type t = Transaction_applied.Coinbase_applied.t =
-      { coinbase : Coinbase.t; previous_empty_accounts : Account_id.t list }
+      { coinbase : Coinbase.t; new_accounts : Account_id.t list }
     [@@deriving sexp]
   end
 

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2013,18 +2013,18 @@ module T = struct
     List.map block_transactions_applied ~f:(function
       | Command (Signed_command cmd) -> (
           match cmd.body with
-          | Payment { previous_empty_accounts } ->
-              previous_empty_accounts
+          | Payment { new_accounts } ->
+              new_accounts
           | Stake_delegation _ ->
               []
           | Failed ->
               [] )
-      | Command (Parties { previous_empty_accounts; _ }) ->
-          previous_empty_accounts
-      | Fee_transfer { previous_empty_accounts; _ } ->
-          previous_empty_accounts
-      | Coinbase { previous_empty_accounts; _ } ->
-          previous_empty_accounts )
+      | Command (Parties { new_accounts; _ }) ->
+          new_accounts
+      | Fee_transfer { new_accounts; _ } ->
+          new_accounts
+      | Coinbase { new_accounts; _ } ->
+          new_accounts )
     |> List.concat
 end
 

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -221,7 +221,7 @@ val check_commands :
   -> (User_command.Valid.t list, Verifier.Failure.t) Result.t
      Deferred.Or_error.t
 
-(** account ids created in the latest block, taken from the previous_empty_accounts
+(** account ids created in the latest block, taken from the new_accounts
     in the latest and next-to-latest trees of the scan state
 *)
 val latest_block_accounts_created :


### PR DESCRIPTION
`previous_receipt_chain_hash` in `Signed_command_applied.Common.t` had been used for undoing transactions, the code for which has been removed. So remove that field.

This issue came up when thinking about receipt chain hashes for zkApp transactions.

Also, while looking at that code, rename `previous_empty_accounts` to `new_accounts`, which better indicates the status of those accounts. (That change will trigger the version linter, so this PR will require a manual merge.)
