### PR TITLE
Better-named constructors for Receipt.Elt

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2043,7 +2043,7 @@ let receipt_chain_hash =
        *)
        let transaction = Signed_command.of_base58_check_exn transaction_id in
        let hash =
-         Receipt.Chain_hash.cons (Signed_command transaction.payload)
+         Receipt.Chain_hash.cons (Signed_command_payload transaction.payload)
            previous_hash
        in
        printf "%s\n" (Receipt.Chain_hash.to_base58_check hash) )

--- a/src/lib/mina_base/receipt.mli
+++ b/src/lib/mina_base/receipt.mli
@@ -7,8 +7,8 @@ open Snark_params.Tick
 
 module Elt : sig
   type t =
-    | Signed_command of Signed_command.Payload.t
-    | Parties of Random_oracle.Digest.t
+    | Signed_command_payload of Signed_command.Payload.t
+    | Parties_commitment of Random_oracle.Digest.t
 end
 
 module Chain_hash : sig
@@ -31,8 +31,8 @@ module Chain_hash : sig
   module Checked : sig
     module Elt : sig
       type t =
-        | Signed_command of Transaction_union_payload.var
-        | Parties of Random_oracle.Checked.Digest.t
+        | Signed_command_payload of Transaction_union_payload.var
+        | Parties_commitment of Random_oracle.Checked.Digest.t
     end
 
     val constant : t -> var

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -159,10 +159,10 @@ module Receipt_chain_verifier = Merkle_list_verifier.Make (struct
   let hash parent_hash (proof_elem : User_command.t) =
     let p =
       match proof_elem with
-      | Signed_command c ->
-          Receipt.Elt.Signed_command (Signed_command.payload c)
-      | Parties x ->
-          Receipt.Elt.Parties (Parties.commitment x)
+      | Signed_command cmd ->
+          Receipt.Elt.Signed_command_payload (Signed_command.payload cmd)
+      | Parties parties ->
+          Receipt.Elt.Parties_commitment (Parties.commitment parties)
     in
     Receipt.Chain_hash.cons p parent_hash
 end)

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -664,7 +664,8 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
       ()
     in
     let%map loc, account, account' =
-      pay_fee' ~command:(Signed_command user_command.payload) ~nonce ~fee_payer
+      pay_fee' ~command:(Signed_command_payload user_command.payload) ~nonce
+        ~fee_payer
         ~fee:(Signed_command.fee user_command)
         ~ledger ~current_global_slot
     in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2560,8 +2560,8 @@ module Base = struct
              let%bind receipt_chain_hash =
                let current = account.receipt_chain_hash in
                let%bind r =
-                 Receipt.Chain_hash.Checked.cons (Signed_command payload)
-                   current
+                 Receipt.Chain_hash.Checked.cons
+                   (Signed_command_payload payload) current
                in
                Receipt.Chain_hash.Checked.if_ is_user_command ~then_:r
                  ~else_:current


### PR DESCRIPTION
Rename the type constructors for `Receipt.Elt` and `Receipt.Chain_hash.Checked` to better indicate the contents of the type.
