### PR TITLE
[WIP] allow balance < min if amount is non-negative

### DIFF
--- a/src/lib/transaction_logic/parties_logic.ml
+++ b/src/lib/transaction_logic/parties_logic.ml
@@ -1157,9 +1157,12 @@ module Make (Inputs : Inputs_intf) = struct
             *)
             (`Invalid_timing invalid_timing, timing)
       in
+      let positive_balance_change =
+        Amount.Signed.is_pos @@ Party.balance_change party
+      in
       let local_state =
         Local_state.add_check local_state Source_minimum_balance_violation
-          (Bool.not invalid_timing)
+          Bool.(not (positive_balance_change &&& invalid_timing))
       in
       let a = Account.set_timing a timing in
       (a, local_state)

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -1093,6 +1093,81 @@ let%test_module "account timing check" =
                               Source_minimum_balance_violation ) )
                   then failwithf "Unexpected transaction error: %s" err_str () ) )
 
+    let%test_unit "zkApp command, non-negative balance change" =
+      let gen =
+        let open Quickcheck.Generator.Let_syntax in
+        let timed =
+          let keypair = List.nth_exn keypairs 0 in
+          let balance = Currency.Balance.of_int 100_000_000_000_000 in
+          let nonce = Mina_numbers.Account_nonce.zero in
+          let (timing : Account_timing.t) =
+            Timed
+              { initial_minimum_balance =
+                  Currency.Balance.of_int 200_000_000_000_000
+              ; cliff_time = Mina_numbers.Global_slot.of_int 10000
+              ; cliff_amount = Currency.Amount.of_int 100_000_000_000_000
+              ; vesting_period = Mina_numbers.Global_slot.of_int 1000
+              ; vesting_increment = Currency.Amount.of_int 10
+              }
+          in
+          let balance_as_amount = Currency.Balance.to_amount balance in
+          (keypair, balance_as_amount, nonce, timing)
+        in
+        let untimed =
+          let keypair = List.nth_exn keypairs 1 in
+          let balance = Currency.Balance.of_int 100_000_000_000_000 in
+          let nonce = Mina_numbers.Account_nonce.zero in
+          let balance_as_amount = Currency.Balance.to_amount balance in
+          (keypair, balance_as_amount, nonce, Account_timing.Untimed)
+        in
+        let ledger_init_state = Array.of_list [ untimed; timed ] in
+        let parties_command =
+          let open Mina_base in
+          let fee = Currency.Fee.of_int 1_000_000 in
+          let amount = Currency.Amount.of_int 3_000_000 in
+          let nonce = Account.Nonce.zero in
+          let memo =
+            Signed_command_memo.create_from_string_exn
+              "zkApp transfer, timed account"
+          in
+          let sender_keypair = List.nth_exn keypairs 0 in
+          let zkapp_keypair = List.nth_exn keypairs 1 in
+          let receiver_key =
+            zkapp_keypair.public_key |> Signature_lib.Public_key.compress
+          in
+          let (parties_spec : Transaction_snark.For_tests.Spec.t) =
+            { sender = (sender_keypair, nonce)
+            ; fee
+            ; fee_payer = None
+            ; receivers = [ (receiver_key, amount) ]
+            ; amount
+            ; zkapp_account_keypairs = []
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update = Party.Update.dummy
+            ; current_auth = Permissions.Auth_required.Signature
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; sequence_events = []
+            ; preconditions = None
+            }
+          in
+          Transaction_snark.For_tests.multiple_transfers parties_spec
+        in
+        return (ledger_init_state, parties_command)
+      in
+      Quickcheck.test
+        ~seed:(`Deterministic "zkapp command, non-negative balance change")
+        ~sexp_of:[%sexp_of: Mina_ledger.Ledger.init_state * Parties.t] ~trials:1
+        gen ~f:(fun (ledger_init_state, parties) ->
+          Mina_ledger.Ledger.with_ephemeral_ledger
+            ~depth:constraint_constants.ledger_depth ~f:(fun ledger ->
+              Mina_ledger.Ledger.apply_initial_ledger_state ledger
+                ledger_init_state ;
+              apply_zkapp_commands_at_slot ledger
+                Mina_numbers.Global_slot.(succ zero)
+                [ parties ] ) )
+
     let%test_unit "zkApp command, just before cliff time, insufficient balance"
         =
       let gen =


### PR DESCRIPTION
Explain your changes:
This PR changes parties_logic so that if the balance change is non-negative, then it's ok for the balance to be less than min-balance.

Explain how you tested your changes:
*


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #10540
