### PR TITLE
Receipt chain hash precondition for 1st occurrence

### DIFF
--- a/src/lib/mina_generators/parties_generators.ml
+++ b/src/lib/mina_generators/parties_generators.ml
@@ -854,8 +854,10 @@ let gen_party_body_components (type a b c d) ?(update = None) ?account_id
     let account_id = Account_id.create public_key token_id in
     match account_ids_seen with
     | None ->
+        (* fee payer *)
         true
     | Some hash_set ->
+        (* other partys *)
         not @@ Hash_set.mem hash_set account_id
   in
   let%bind account_precondition =

--- a/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
+++ b/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
@@ -436,6 +436,7 @@ let%test_module "Account precondition tests" =
         let%map account_precondition =
           Mina_generators.Parties_generators
           .gen_account_precondition_from_account snapp_account
+            ~first_use_of_account:true
         in
         (l, account_precondition)
       in
@@ -496,7 +497,7 @@ let%test_module "Account precondition tests" =
         in
         let%map account_precondition =
           Mina_generators.Parties_generators.(
-            gen_account_precondition_from_account
+            gen_account_precondition_from_account ~first_use_of_account:true
               ~failure:Invalid_account_precondition snapp_account)
         in
         (l, account_precondition)


### PR DESCRIPTION
In the parties generators, pass a set of "seen" account ids, so we can generate a receipt chain hash precondition for the first-occurrence of an account in a zkApp.

Closes #11454.