### PR TITLE
Make jemalloc an optional dependency

### DIFF
--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -56,11 +56,11 @@ let
   dds = x: x.overrideAttrs (o: { dontDisableStatic = true; });
 
   external-libs = with pkgs;
-    if static then
+    lib.optional (! (stdenv.isDarwin && stdenv.isAarch64)) jemalloc ++
+    (if static then
       map dds [
         (zlib.override { splitStaticOutput = false; })
         (bzip2.override { linkStatic = true; })
-        (jemalloc)
         (gmp.override { withStatic = true; })
         (openssl.override { static = true; })
         libffi
@@ -68,11 +68,10 @@ let
     else [
       zlib
       bzip2
-      jemalloc
       gmp
       openssl
       libffi
-    ];
+    ]);
 
   filtered-src = with inputs.nix-filter.lib;
     filter {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -14,17 +14,6 @@ in {
   else
     prev.openssh);
 
-  # jemalloc = prev.jemalloc.overrideAttrs (_: {
-  #   nativeBuildInputs = [ final.autoconf ];
-  #   preConfigure = "./autogen.sh";
-  #   src = final.fetchFromGitHub {
-  #     owner = "jemalloc";
-  #     repo = "jemalloc";
-  #     rev = "011449f17bdddd4c9e0510b27a3fb34e88d072ca";
-  #     sha256 = "FwMs8m/yYsXCEOd94ZWgpwqtVrTLncEQCSDj/FqGewE=";
-  #   };
-  # });
-
   git = prev.git.overrideAttrs
     (o: { doCheck = o.doCheck && !prev.stdenv.hostPlatform.isMusl; });
 

--- a/src/dune.alloc.inc
+++ b/src/dune.alloc.inc
@@ -1,0 +1,13 @@
+;; Check whether jemalloc is available to the compiler. Use it as an allocator if that's the case, and use libc otherwise.
+(rule
+  (target dune-alloc)
+  (action (with-stdout-to dune-alloc
+    (bash "
+        printf 'Checking if jemalloc is available... ' 1>&2
+        echo 'int main(){}' > .jemalloc_test.c
+        if [ -z ${CC-} ]; then if command -v gcc > /dev/null; then CC=gcc; else CC=clang; fi; fi
+        if $CC -ljemalloc .jemalloc_test.c -o /dev/null
+            then printf 'Yes, using jemalloc as an allocator\n' 1>&2; printf jemalloc
+            else printf 'No, using the default allocator from libc\n' 1>&2; printf c
+        fi
+    "))))

--- a/src/dune.flags.inc
+++ b/src/dune.flags.inc
@@ -1,8 +1,9 @@
 (include dune.linker.inc)
+(include dune.alloc.inc)
 
 (env
   (_
     (flags (:standard -short-paths
             -ccopt=%{read:dune-linker}
-            -cclib -ljemalloc
+            -cclib=-l%{read:dune-alloc}
             -w @a-4-16-29-40-41-42-44-45-48-58-59-60-66-67-69-70))))

--- a/src/lib/memory_stats/dune
+++ b/src/lib/memory_stats/dune
@@ -6,7 +6,6 @@
    ;; opam libraries
    async_unix
    core_kernel
-   jemalloc
    async_kernel
    core
    async
@@ -16,4 +15,4 @@
  (preprocess
   (pps ppx_snarky ppx_coda ppx_version ppx_let))
  (instrumentation (backend bisect_ppx))
- (synopsis "Memory statistics for OCaml and jemalloc"))
+ (synopsis "Memory statistics for OCaml"))

--- a/src/lib/memory_stats/memory_stats.ml
+++ b/src/lib/memory_stats/memory_stats.ml
@@ -1,4 +1,4 @@
-(* memory_stats.ml -- log OCaml, jemalloc memory data *)
+(* memory_stats.ml -- log OCaml memory data *)
 
 open Core_kernel
 open Async
@@ -13,16 +13,6 @@ let ocaml_memory_stats () =
   ; ("live_size_bytes", `Int (stat.live_words * bytes_per_word))
   ; ("live_blocks", `Int stat.live_blocks)
   ; ("fragments", `Int stat.fragments)
-  ]
-
-let jemalloc_memory_stats () =
-  let { Jemalloc.active; resident; allocated; mapped } =
-    Jemalloc.get_memory_stats ()
-  in
-  [ ("active", `Int active)
-  ; ("resident", `Int resident)
-  ; ("allocated", `Int allocated)
-  ; ("mapped", `Int mapped)
   ]
 
 let log_memory_stats logger ~process =
@@ -62,9 +52,7 @@ let log_memory_stats logger ~process =
      let log_stats suffix =
        let proc = ("process", `String process) in
        [%log debug] "OCaml memory statistics, %s" suffix
-         ~metadata:(proc :: ocaml_memory_stats ()) ;
-       [%log debug] "Jemalloc memory statistics (in bytes)"
-         ~metadata:(proc :: jemalloc_memory_stats ())
+         ~metadata:(proc :: ocaml_memory_stats ())
      in
      let rec loop () =
        log_stats "before major gc" ;

--- a/src/lib/mina_metrics/prometheus_metrics/dune
+++ b/src/lib/mina_metrics/prometheus_metrics/dune
@@ -12,7 +12,6 @@
    async_kernel
    core_kernel
    prometheus
-   jemalloc
    cohttp-async
    cohttp
    async

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -131,8 +131,6 @@ module Runtime = struct
 
   let current_gc = ref (Gc.stat ())
 
-  let current_jemalloc = ref (Jemalloc.get_memory_stats ())
-
   let gc_stat_interval_mins = ref 15.
 
   let gc_allocated_bytes = ref (Gc.allocated_bytes ())
@@ -140,7 +138,6 @@ module Runtime = struct
   let rec gc_stat () =
     let%bind () = after (Time_ns.Span.of_min !gc_stat_interval_mins) in
     current_gc := Gc.stat () ;
-    current_jemalloc := Jemalloc.get_memory_stats () ;
     gc_allocated_bytes := Gc.allocated_bytes () ;
     gc_stat ()
 
@@ -222,28 +219,6 @@ module Runtime = struct
       (fun () -> float_of_int !current_gc.Gc.Stat.stack_size)
       ~help:"Current stack size."
 
-  let jemalloc_active_bytes =
-    simple_metric ~metric_type:Gauge "jemalloc_active_bytes"
-      (fun () -> float_of_int !current_jemalloc.active)
-      ~help:"active memory in bytes"
-
-  let jemalloc_resident_bytes =
-    simple_metric ~metric_type:Gauge "jemalloc_resident_bytes"
-      (fun () -> float_of_int !current_jemalloc.resident)
-      ~help:
-        "resident memory in bytes (may be zero depending on jemalloc compile \
-         options)"
-
-  let jemalloc_allocated_bytes =
-    simple_metric ~metric_type:Gauge "jemalloc_allocated_bytes"
-      (fun () -> float_of_int !current_jemalloc.allocated)
-      ~help:"memory allocated to heap objects in bytes"
-
-  let jemalloc_mapped_bytes =
-    simple_metric ~metric_type:Gauge "jemalloc_mapped_bytes"
-      (fun () -> float_of_int !current_jemalloc.mapped)
-      ~help:"memory mapped into process address space in bytes"
-
   let process_cpu_seconds_total =
     simple_metric ~metric_type:Counter "process_cpu_seconds_total" Sys.time
       ~help:"Total user and system CPU time spent in seconds."
@@ -267,10 +242,6 @@ module Runtime = struct
     ; ocaml_gc_largest_free
     ; ocaml_gc_fragments
     ; ocaml_gc_stack_size
-    ; jemalloc_active_bytes
-    ; jemalloc_resident_bytes
-    ; jemalloc_allocated_bytes
-    ; jemalloc_mapped_bytes
     ; process_cpu_seconds_total
     ; process_uptime_ms_total
     ]

--- a/src/opam.export
+++ b/src/opam.export
@@ -118,7 +118,6 @@ installed: [
   "ipaddr.5.0.1"
   "ipaddr-sexp.5.0.1"
   "jane-street-headers.v0.14.0"
-  "jemalloc.0.2"
   "js_of_ocaml.4.0.0"
   "js_of_ocaml-compiler.4.0.0"
   "js_of_ocaml-ppx.4.0.0"


### PR DESCRIPTION
Rip out all hard dependencies on jemalloc, and only use it as an
allocator if it is available.

Closes https://github.com/MinaProtocol/mina/issues/11491