### PR TITLE
Pad old_bulletproof_challenges to max_proofs_verified in verifier

### DIFF
--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -48,7 +48,7 @@ let verify_heterogenous (ts : Instance.t list) =
     List.map ts
       ~f:(fun
            (T
-             ( _max_proofs_verified
+             ( (module Local_max_proofs_verified)
              , _statement
              , key
              , app_state
@@ -160,18 +160,15 @@ let verify_heterogenous (ts : Instance.t list) =
         Timer.clock __LOC__ ;
         (* TODO: The deferred values "bulletproof_challenges" should get routed
            into a "batch dlog Tick acc verifier" *)
-        let actual_proofs_verified =
-          Vector.length statement.pass_through.old_bulletproof_challenges
-        in
         Timer.clock __LOC__ ;
         let combined_inner_product_actual =
           Wrap.combined_inner_product ~env:tick_env ~plonk:tick_plonk_minimal
-            ~domain:tick_domain ~ft_eval1:evals.ft_eval1
-            ~actual_proofs_verified:(Nat.Add.create actual_proofs_verified)
-            evals.evals
+            ~domain:tick_domain ~ft_eval1:evals.ft_eval1 evals.evals
             ~old_bulletproof_challenges:
-              (Vector.map ~f:Ipa.Step.compute_challenges
-                 statement.pass_through.old_bulletproof_challenges )
+              (Vector.extend_exn
+                 (Vector.map ~f:Ipa.Step.compute_challenges
+                    statement.pass_through.old_bulletproof_challenges )
+                 Local_max_proofs_verified.n Dummy.Ipa.Step.challenges_computed )
             ~r:r_actual ~xi ~zeta ~zetaw
         in
         let check_eq lab x y =

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -33,8 +33,6 @@ let challenge_polynomial =
 let tick_rounds = Nat.to_int Tick.Rounds.n
 
 let combined_inner_product (type actual_proofs_verified) ~env ~domain ~ft_eval1
-    ~actual_proofs_verified:
-      (module AB : Nat.Add.Intf with type n = actual_proofs_verified)
     (e : _ Plonk_types.All_evals.With_public_input.t)
     ~(old_bulletproof_challenges : (_, actual_proofs_verified) Vector.t) ~r
     ~plonk ~xi ~zeta ~zetaw =
@@ -50,7 +48,6 @@ let combined_inner_product (type actual_proofs_verified) ~env ~domain ~ft_eval1
       (Plonk_types.Evals.to_in_circuit combined_evals)
       (fst e.public_input)
   in
-  let T = AB.eq in
   let challenge_polys =
     Vector.map
       ~f:(fun chals -> unstage (challenge_polynomial (Vector.to_array chals)))
@@ -275,7 +272,6 @@ let wrap
     let combined_inner_product =
       let open As_field in
       combined_inner_product (* Note: We do not pad here. *)
-        ~actual_proofs_verified:(Nat.Add.create actual_proofs_verified)
         { evals = proof.openings.evals; public_input = x_hat }
         ~r ~xi ~zeta ~zetaw ~old_bulletproof_challenges:prev_challenges
         ~env:tick_env ~domain:tick_domain ~ft_eval1:proof.openings.ft_eval1


### PR DESCRIPTION
This PR is a continuation of the 'wrap hack' work, ensuring that we always pad the `old_bulletproof_challenges` to `max_proofs_verified`. This matches what we do when processing wrap proofs in the `Step.Make(_).f` etc.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them