### PR TITLE
Final touches, ppx_version

### DIFF
--- a/src/lib/consensus/vrf/consensus_vrf.ml
+++ b/src/lib/consensus/vrf/consensus_vrf.ml
@@ -426,8 +426,8 @@ module Output_hash = struct
 
     module V1 = struct
       module T = struct
-        type t = Snark_params.Tick.Field.t
-        [@@deriving sexp, compare, hash, version { asserted }]
+        type t = (Snark_params.Tick.Field.t[@version_asserted])
+        [@@deriving sexp, compare, hash]
       end
 
       include T

--- a/src/lib/crypto/kimchi_backend/common/curve.ml
+++ b/src/lib/crypto/kimchi_backend/common/curve.ml
@@ -97,9 +97,13 @@ struct
       module V1 = struct
         module T = struct
           type t = BaseField.Stable.Latest.t * BaseField.Stable.Latest.t
-          [@@deriving
-            version { asserted }, equal, bin_io, sexp, compare, yojson, hash]
+          [@@deriving equal, bin_io, sexp, compare, yojson, hash]
         end
+
+        (* asserts the versioned-ness of V1
+           to do this properly, we'd move the Stable module outside the functor
+        *)
+        let __versioned__ = ()
 
         include T
 

--- a/src/lib/crypto/kimchi_backend/common/field.ml
+++ b/src/lib/crypto/kimchi_backend/common/field.ml
@@ -145,7 +145,7 @@ module Make (F : Input_intf) :
 
   module Stable = struct
     module V1 = struct
-      type t = F.t [@@deriving version { asserted }]
+      type t = (F.t[@version_asserted]) [@@deriving version]
 
       include
         Binable.Of_binable

--- a/src/lib/data_hash_lib/data_hash.ml
+++ b/src/lib/data_hash_lib/data_hash.ml
@@ -105,13 +105,12 @@ struct
 end
 
 module T0 = struct
-  [%%versioned_asserted
+  [%%versioned
   module Stable = struct
     module V1 = struct
       [@@@with_all_version_tags]
 
-      type t = Field.t
-      [@@deriving sexp, compare, hash, version { asserted }, bin_io]
+      type t = (Field.t[@version_asserted]) [@@deriving sexp, compare, hash]
 
       let to_latest = Fn.id
     end

--- a/src/lib/data_hash_lib/state_hash.ml
+++ b/src/lib/data_hash_lib/state_hash.ml
@@ -40,7 +40,7 @@ module Stable = struct
 
   module V1 = struct
     module T = struct
-      type t = Field.t [@@deriving sexp, compare, hash, version { asserted }]
+      type t = (Field.t[@version_asserted]) [@@deriving sexp, compare, hash]
     end
 
     include T

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -248,10 +248,10 @@ module Protocol = struct
     end]
   end
 
-  [%%versioned_asserted
+  [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = (int, int, Int64.t) Poly.Stable.V1.t
+      type t = (int, int, (Int64.t[@version_asserted])) Poly.Stable.V1.t
       [@@deriving equal, ord, hash]
 
       let to_latest = Fn.id

--- a/src/lib/mina_base/epoch_seed.ml
+++ b/src/lib/mina_base/epoch_seed.ml
@@ -16,8 +16,8 @@ module Stable = struct
 
   module V1 = struct
     module T = struct
-      type t = Snark_params.Tick.Field.t
-      [@@deriving sexp, compare, hash, version { asserted }]
+      type t = (Snark_params.Tick.Field.t[@version_asserted])
+      [@@deriving sexp, compare, hash]
     end
 
     include T

--- a/src/lib/mina_base/ledger_hash0.ml
+++ b/src/lib/mina_base/ledger_hash0.ml
@@ -15,7 +15,7 @@ module Stable = struct
 
   module V1 = struct
     module T = struct
-      type t = Field.t [@@deriving sexp, compare, hash, version { asserted }]
+      type t = (Field.t[@version_asserted]) [@@deriving sexp, compare, hash]
     end
 
     include T

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -148,7 +148,7 @@ module Coinbase_stack = struct
 
     module V1 = struct
       module T = struct
-        type t = Field.t [@@deriving sexp, compare, hash, version { asserted }]
+        type t = (Field.t[@version_asserted]) [@@deriving sexp, compare, hash]
       end
 
       include T
@@ -208,7 +208,7 @@ module Stack_hash = struct
 
     module V1 = struct
       module T = struct
-        type t = Field.t [@@deriving sexp, compare, hash, version { asserted }]
+        type t = (Field.t[@version_asserted]) [@@deriving sexp, compare, hash]
       end
 
       include T
@@ -354,7 +354,7 @@ module Hash_builder = struct
 
     module V1 = struct
       module T = struct
-        type t = Field.t [@@deriving sexp, compare, hash, version { asserted }]
+        type t = (Field.t[@version_asserted]) [@@deriving sexp, compare, hash]
       end
 
       include T

--- a/src/lib/mina_base/receipt.ml
+++ b/src/lib/mina_base/receipt.ml
@@ -27,7 +27,7 @@ module Chain_hash = struct
 
     module V1 = struct
       module T = struct
-        type t = Field.t [@@deriving sexp, compare, hash, version { asserted }]
+        type t = (Field.t[@version_asserted]) [@@deriving sexp, compare, hash]
       end
 
       include T

--- a/src/lib/mina_base/signature.ml
+++ b/src/lib/mina_base/signature.ml
@@ -12,10 +12,13 @@ module Arg = struct
   let version_byte = Base58_check.Version_bytes.signature
 end
 
-[%%versioned_asserted
+[%%versioned
 module Stable = struct
   module V1 = struct
-    type t = (Field.t, Inner_curve.Scalar.t) Signature_poly.Stable.V1.t
+    type t =
+      ( (Field.t[@version_asserted])
+      , (Inner_curve.Scalar.t[@version_asserted]) )
+      Signature_poly.Stable.V1.t
     [@@deriving sexp, compare, equal, hash]
 
     type _unused = unit constraint t = Arg.t

--- a/src/lib/mina_base/state_body_hash.ml
+++ b/src/lib/mina_base/state_body_hash.ml
@@ -17,7 +17,7 @@ module Stable = struct
 
   module V1 = struct
     module T = struct
-      type t = Field.t [@@deriving sexp, compare, hash, version { asserted }]
+      type t = (Field.t[@version_asserted]) [@@deriving sexp, compare, hash]
     end
 
     include T

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -24,12 +24,12 @@ module Compressed = struct
 
   module Arg = struct
     (* module with same type t as Stable below, to build functor argument *)
-    [%%versioned_asserted
+    [%%versioned
     module Stable = struct
       module V1 = struct
         [@@@with_all_version_tags]
 
-        type t = (Field.t, bool) Poly.Stable.V1.t
+        type t = ((Field.t[@version_asserted]), bool) Poly.Stable.V1.t
 
         let to_latest = Fn.id
       end
@@ -38,11 +38,11 @@ module Compressed = struct
 
   let compress (x, y) = { Poly.x; is_odd = parity y }
 
-  [%%versioned_asserted
+  [%%versioned
   module Stable = struct
     module V1 = struct
       module T = struct
-        type t = (Field.t, bool) Poly.Stable.V1.t
+        type t = ((Field.t[@version_asserted]), bool) Poly.Stable.V1.t
         [@@deriving equal, compare, hash]
 
         let to_latest = Fn.id

--- a/src/lib/pickles/limb_vector/constant.ml
+++ b/src/lib/pickles/limb_vector/constant.ml
@@ -52,12 +52,13 @@ module Hex64 = struct
 
   include T
 
-  [%%versioned_asserted
+  [%%versioned
   module Stable = struct
     [@@@no_toplevel_latest_type]
 
     module V1 = struct
-      type t = T.t [@@deriving compare, sexp, yojson, hash, equal]
+      type t = (T.t[@version_asserted])
+      [@@deriving compare, sexp, yojson, hash, equal]
 
       let to_latest = Fn.id
     end

--- a/src/lib/ppx_version/test/versioned_good.ml
+++ b/src/lib/ppx_version/test/versioned_good.ml
@@ -139,10 +139,10 @@ end
 
 (* assert versionedness *)
 module M8 = struct
-  [%%versioned_asserted
+  [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = Int.t List.t
+      type t = ((Int.t[@version_asserted]) List.t[@version_asserted])
 
       let to_latest = Fn.id
     end

--- a/src/lib/ppx_version/versioned_module.ml
+++ b/src/lib/ppx_version/versioned_module.ml
@@ -17,8 +17,7 @@ let with_versioned_json = "with_versioned_json"
 let no_toplevel_latest_type_str = "no_toplevel_latest_type"
 
 (* option to `deriving version' *)
-type version_option = No_version_option | Asserted | Binable
-[@@deriving equal]
+type version_option = No_version_option | Binable [@@deriving equal]
 
 let create_attr ~loc attr_name attr_payload =
   { attr_name; attr_payload; attr_loc = loc }
@@ -35,8 +34,6 @@ let rec add_deriving ~loc ~version_option attributes : attributes =
     match version_option with
     | No_version_option ->
         [%expr version]
-    | Asserted ->
-        [%expr version { asserted }]
     | Binable ->
         [%expr version { binable }]
   in
@@ -45,7 +42,7 @@ let rec add_deriving ~loc ~version_option attributes : attributes =
       let attr_name = mk_loc ~loc "deriving" in
       let attr_payload =
         match version_option with
-        | No_version_option | Asserted ->
+        | No_version_option ->
             payload [ [%expr bin_io]; version_expr ]
         | Binable ->
             payload [ version_expr ]
@@ -76,7 +73,7 @@ let rec add_deriving ~loc ~version_option attributes : attributes =
           in
           let needs_bin_io =
             match version_option with
-            | No_version_option | Asserted ->
+            | No_version_option ->
                 true
             | Binable ->
                 false
@@ -434,21 +431,16 @@ let version_type ~version_option version stri ~all_version_tagged
       in
       let t =
         (* type `t` is equal to `typ`, but serialized/deserialized as `t_tagged` *)
-        let ty_decl =
-          type_declaration ~name:(Located.mk "t") ~params ~cstrs:[]
-            ~private_:Public
-            ~manifest:
-              (Some
-                 (ptyp_constr (Located.lident "typ") (List.map ~f:fst params))
-              )
-            ~kind:Ptype_abstract
-        in
-        { ty_decl with ptype_attributes = [ Lazy.force deriving_bin_io ] }
+        type_declaration ~name:(Located.mk "t") ~params ~cstrs:[]
+          ~private_:Public
+          ~manifest:
+            (Some (ptyp_constr (Located.lident "typ") (List.map ~f:fst params)))
+          ~kind:Ptype_abstract
       in
       let create = [%stri let create t = { t; version = [%e eint version] }] in
-      let bin_io_tagged_shadows =
+      let bin_io_t =
         [ [%stri
-            let bin_read_t_tagged =
+            let bin_read_t =
               [%e
                 fun_args
                   [%expr
@@ -463,12 +455,12 @@ let version_type ~version_option version stri ~all_version_tagged
                       then
                         failwith
                           (Core_kernel.sprintf
-                             "bin_read_t_tagged: version read %d does not \
-                              match expected version %d"
+                             "bin_read_t: version read %d does not match \
+                              expected version %d"
                              read_version [%e eint version] ) ;
                       t]]]
         ; [%stri
-            let __bin_read_t_tagged__ =
+            let __bin_read_t__ =
               [%e
                 fun_args
                   [%expr
@@ -484,34 +476,31 @@ let version_type ~version_option version stri ~all_version_tagged
                       then
                         failwith
                           (Core_kernel.sprintf
-                             "__bin_read_t_tagged__: version read %d does not \
-                              match expected version %d"
+                             "__bin_read_t__: version read %d does not match \
+                              expected version %d"
                              read_version version ) ;
                       t]]]
         ; [%stri
-            let bin_reader_t_tagged =
+            let bin_reader_t =
               [%e
                 fun_args
                   [%expr
                     { Bin_prot.Type_class.read =
-                        [%e
-                          apply_args ~f:(mk_field "read")
-                            [%expr bin_read_t_tagged]]
+                        [%e apply_args ~f:(mk_field "read") [%expr bin_read_t]]
                     ; vtag_read =
                         [%e
-                          apply_args ~f:(mk_field "read")
-                            [%expr __bin_read_t_tagged__]]
+                          apply_args ~f:(mk_field "read") [%expr __bin_read_t__]]
                     }]]]
         ; [%stri
-            let bin_size_t_tagged =
+            let bin_size_t =
               [%e
                 fun_args
                   [%expr
                     fun t ->
                       create t |> [%e apply_args [%expr bin_size_t_tagged]]]]]
-        ; [%stri let bin_shape_t_tagged = bin_shape_t_tagged]
+        ; [%stri let bin_shape_t = bin_shape_t_tagged]
         ; [%stri
-            let bin_write_t_tagged =
+            let bin_write_t =
               [%e
                 fun_args
                   [%expr
@@ -519,58 +508,31 @@ let version_type ~version_option version stri ~all_version_tagged
                       create t
                       |> [%e apply_args [%expr bin_write_t_tagged]] buf ~pos]]]
         ; [%stri
-            let bin_writer_t_tagged =
+            let bin_writer_t =
               [%e
                 fun_args
                   [%expr
                     { Bin_prot.Type_class.size =
-                        [%e
-                          apply_args ~f:(mk_field "size")
-                            [%expr bin_size_t_tagged]]
+                        [%e apply_args ~f:(mk_field "size") [%expr bin_size_t]]
                     ; write =
                         [%e
-                          apply_args ~f:(mk_field "write")
-                            [%expr bin_write_t_tagged]]
+                          apply_args ~f:(mk_field "write") [%expr bin_write_t]]
                     }]]]
         ; [%stri
-            let bin_t_tagged =
+            let bin_t =
               [%e
                 fun_args
                   [%expr
                     { Bin_prot.Type_class.shape =
                         [%e
-                          apply_args ~f:(mk_field "shape")
-                            [%expr bin_shape_t_tagged]]
+                          apply_args ~f:(mk_field "shape") [%expr bin_shape_t]]
                     ; writer =
                         [%e
-                          apply_args ~f:(mk_field "writer")
-                            [%expr bin_writer_t_tagged]]
+                          apply_args ~f:(mk_field "writer") [%expr bin_writer_t]]
                     ; reader =
                         [%e
-                          apply_args ~f:(mk_field "reader")
-                            [%expr bin_reader_t_tagged]]
+                          apply_args ~f:(mk_field "reader") [%expr bin_reader_t]]
                     }]]]
-        ; [%stri
-            let (_ : _) =
-              ( bin_read_t_tagged
-              , __bin_read_t_tagged__
-              , bin_reader_t_tagged
-              , bin_size_t_tagged
-              , bin_shape_t_tagged
-              , bin_write_t_tagged
-              , bin_writer_t_tagged
-              , bin_t_tagged )]
-        ]
-      in
-      let bin_io_t =
-        [ [%stri let bin_read_t = bin_read_t_tagged]
-        ; [%stri let __bin_read_t__ = __bin_read_t_tagged__]
-        ; [%stri let bin_reader_t = bin_reader_t_tagged]
-        ; [%stri let bin_size_t = bin_size_t_tagged]
-        ; [%stri let bin_shape_t = bin_shape_t_tagged]
-        ; [%stri let bin_write_t = bin_write_t_tagged]
-        ; [%stri let bin_writer_t = bin_writer_t_tagged]
-        ; [%stri let bin_t = bin_t_tagged]
         ; [%stri
             let (_ : _) =
               ( bin_read_t
@@ -593,7 +555,7 @@ let version_type ~version_option version stri ~all_version_tagged
                     ; pstr_type Recursive [ t ]
                     ; create
                     ]
-                  @ bin_io_tagged_shadows @ bin_io_t ) ) )
+                  @ bin_io_t ) ) )
       ]
     in
     let all_version_tag_modules =
@@ -815,6 +777,13 @@ let convert_modbody ~loc ~version_option body =
         , json_tag_convs ) )
   in
   let (module Ast_builder) = Ast_builder.make loc in
+  let alert_prolog, alert_epilog =
+    let open Ast_builder in
+    if equal_version_option version_option Binable then
+      ( [ [%stri [@@@alert "-legacy-deprecated"]] ]
+      , [ [%stri [@@@alert "+legacy+deprecated"]] ] )
+    else ([], [])
+  in
   let rev_str =
     match !latest_version with
     | Some latest_version -> (
@@ -838,7 +807,7 @@ let convert_modbody ~loc ~version_option body =
     | None ->
         rev_str
   in
-  let rev_str =
+  let rev_str_with_converters =
     match !may_convert_latest with
     | Some true ->
         let converter_modules =
@@ -1073,7 +1042,10 @@ let convert_modbody ~loc ~version_option body =
     | _ ->
         rev_str
   in
-  (List.rev rev_str, type_stri)
+  let rev_str_with_all =
+    alert_epilog @ rev_str_with_converters @ alert_prolog
+  in
+  (List.rev rev_str_with_all, type_stri)
 
 let version_module ~loc ~version_option ~path:_ modname modbody =
   Printexc.record_backtrace true ;
@@ -1398,11 +1370,6 @@ let () =
       declare "versioned" Context.structure_item module_ast_pattern
         (version_module ~version_option:No_version_option))
   in
-  let module_extension_asserted =
-    Extension.(
-      declare "versioned_asserted" Context.structure_item module_ast_pattern
-        (version_module ~version_option:Asserted))
-  in
   let module_extension_binable =
     Extension.(
       declare "versioned_binable" Context.structure_item module_ast_pattern
@@ -1421,16 +1388,11 @@ let () =
         version_module_decl)
   in
   let module_rule = Context_free.Rule.extension module_extension in
-  let module_rule_asserted =
-    Context_free.Rule.extension module_extension_asserted
-  in
   let module_rule_binable =
     Context_free.Rule.extension module_extension_binable
   in
   let module_decl_rule = Context_free.Rule.extension module_decl_extension in
-  let rules =
-    [ module_rule; module_rule_asserted; module_rule_binable; module_decl_rule ]
-  in
+  let rules = [ module_rule; module_rule_binable; module_decl_rule ] in
   Driver.register_transformation "ppx_version/versioned_module" ~rules ;
   Ppxlib.Driver.add_arg "--no-toplevel-latest-type"
     (Caml.Arg.Unit (fun () -> no_toplevel_latest_type := true))

--- a/src/lib/ppx_version/versioned_type.ml
+++ b/src/lib/ppx_version/versioned_type.ml
@@ -19,18 +19,16 @@
 
      [@@deriving version { option }]
 
-   where option is one of "rpc", "asserted", or "binable".
+   where option is one of "rpc" or "binable".
 
    Without options (the common case), the type must be named "t", and its definition
    occurs in the module hierarchy "Stable.Vn" or "Stable.Vn.T", where n is a positive integer.
 
-   The "asserted" option asserts that the type is versioned, to allow compilation
+   The "binable" option asserts that the type is versioned, to allow compilation
    to proceed. The types referred to in the type are not checked for versioning
-   with this option.
-
-   The "binable" option is a synonym for "asserted". It assumes that the type
-   will be serialized using a "Binable.Of_..." or "Make_binable" functors, which relies
-   on the serialization of some other type.
+   with this option. It assumes that the type will be serialized using a
+   "Binable.Of_..." or "Make_binable" functors, which relies on the serialization of
+   some other type.
 
    If "rpc" is true, again, the type must be named "query", "response", or "msg",
    and the type definition occurs in the hierarchy "Vn.T".
@@ -145,7 +143,7 @@ module Printing = struct
     }
 
   (* prints path_to_type:type_definition *)
-  let print_type ~loc:_ ~path (_rec_flag, type_decls) _rpc _asserted _binable =
+  let print_type ~loc:_ ~path (_rec_flag, type_decls) _rpc _binable =
     let module_path = module_path_list path in
     let path_len = List.length module_path in
     List.iteri module_path ~f:(fun i s ->
@@ -250,7 +248,7 @@ module Deriving = struct
       let version = [%e eint version]
 
       (* to prevent unused value warnings *)
-      let __ = version]
+      let (_ : _) = version]
 
   let ocaml_builtin_types =
     [ "bytes"
@@ -323,6 +321,7 @@ module Deriving = struct
           false
 
   let rec generate_core_type_version_decls type_name core_type =
+    let version_asserted_str = "version_asserted" in
     match core_type.ptyp_desc with
     | Ptyp_constr ({ txt; _ }, core_types) -> (
         match txt with
@@ -361,8 +360,16 @@ module Deriving = struct
             let core_type_decls =
               generate_version_lets_for_core_types type_name core_types
             in
-            if trustlisted_prefix prefix ~loc:core_type.ptyp_loc then
-              core_type_decls
+            (* type t = M.t [@version_asserted] *)
+            let version_asserted =
+              List.find core_type.ptyp_attributes ~f:(fun attr ->
+                  String.equal attr.attr_name.txt version_asserted_str )
+              |> Option.is_some
+            in
+            if
+              version_asserted
+              || trustlisted_prefix prefix ~loc:core_type.ptyp_loc
+            then core_type_decls
             else
               let loc = core_type.ptyp_loc in
               let pexp_loc = loc in
@@ -389,7 +396,7 @@ module Deriving = struct
                 ; pexp_attributes = []
                 }
               in
-              [%str let __ = [%e versioned_ident]] @ core_type_decls
+              [%str let (_ : _) = [%e versioned_ident]] @ core_type_decls
         | _ ->
             Location.raise_errorf ~loc:core_type.ptyp_loc
               "Unrecognized type constructor for versioned type" )
@@ -483,13 +490,13 @@ module Deriving = struct
     in
     constraint_type_version_decls @ main_type_version_decls
 
-  let generate_versioned_decls ~asserted generation_kind type_decl =
+  let generate_versioned_decls ~binable generation_kind type_decl =
     let module E = Ppxlib.Ast_builder.Make (struct
       let loc = type_decl.ptype_loc
     end) in
     let open E in
     let versioned_current = [%stri let __versioned__ = ()] in
-    if asserted then [ versioned_current ]
+    if binable then [ versioned_current ]
     else
       match generation_kind with
       | Rpc ->
@@ -515,15 +522,11 @@ module Deriving = struct
     type_decl1
 
   let generate_let_bindings_for_type_decl_str ~loc ~path (_rec_flag, type_decls)
-      rpc asserted binable =
-    (* binable is synonym for asserted,
-       in the sense that we don't require the type to be versioned
-    *)
-    let asserted = asserted || binable in
+      rpc binable =
     let type_decl = get_type_decl_representative type_decls in
-    if asserted && rpc then
+    if binable && rpc then
       Location.raise_errorf ~loc:type_decl.ptype_loc
-        "Options \"asserted\" and \"rpc\" cannot be combined" ;
+        "Options \"binable\" and \"rpc\" cannot be combined" ;
     let generation_kind = if rpc then Rpc else Plain in
     let module_path = module_path_list path in
     let inner3_modules = List.take (List.rev module_path) 3 in
@@ -536,7 +539,7 @@ module Deriving = struct
     else (
       validate_type_decl inner3_modules generation_kind type_decl ;
       let versioned_decls =
-        generate_versioned_decls ~asserted generation_kind type_decl
+        generate_versioned_decls ~binable generation_kind type_decl
       in
       let type_name = type_decl.ptype_name.txt in
       (* generate version number for Rpc response, but not for query, so we
@@ -574,12 +577,12 @@ let str_type_decl :
     (structure, rec_flag * type_declaration list) Ppxlib.Deriving.Generator.t =
   let args =
     let open Ppxlib.Deriving.Args in
-    empty +> flag "rpc" +> flag "asserted" +> flag "binable"
+    empty +> flag "rpc" +> flag "binable"
   in
-  let deriver ~loc ~path (rec_flag, type_decls) rpc asserted binable =
+  let deriver ~loc ~path (rec_flag, type_decls) rpc binable =
     (choose_deriver ~printing:Printing.print_type
        ~deriving:Deriving.generate_let_bindings_for_type_decl_str )
-      ~loc ~path (rec_flag, type_decls) rpc asserted binable
+      ~loc ~path (rec_flag, type_decls) rpc binable
   in
   Ppxlib.Deriving.Generator.make args deriver
 

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -3,12 +3,13 @@
 open Core_kernel
 open Snark_params.Tick
 
-[%%versioned_asserted
+[%%versioned
 module Stable = struct
   module V1 = struct
     [@@@with_all_version_tags]
 
-    type t = Inner_curve.Scalar.t [@@deriving compare, sexp]
+    type t = (Inner_curve.Scalar.t[@version_asserted])
+    [@@deriving compare, sexp]
 
     (* deriver not working, apparently *)
     let sexp_of_t = [%sexp_of: Inner_curve.Scalar.t]

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -373,8 +373,7 @@ module Proof = struct
   module Stable = struct
     module V2 = struct
       type t = Pickles.Proof.Proofs_verified_2.Stable.V2.t
-      [@@deriving
-        version { asserted }, yojson, bin_io, compare, equal, sexp, hash]
+      [@@deriving yojson, compare, equal, sexp, hash]
 
       let to_latest = Fn.id
     end

--- a/src/lib/transition_frontier/frontier_base/diff.ml
+++ b/src/lib/transition_frontier/frontier_base/diff.ml
@@ -6,6 +6,8 @@ type full = Full
 
 type lite = Lite
 
+[@@@alert "-deprecated"]
+
 module Dummy_binable1 (T : sig
   type 'a t
 end) =
@@ -35,6 +37,8 @@ end) =
 
       let of_binable _ = assert false
     end)
+
+[@@@alert "+deprecated"]
 
 module Node = struct
   [%%versioned_binable

--- a/src/lib/trust_system/banned_status.ml
+++ b/src/lib/trust_system/banned_status.ml
@@ -1,10 +1,9 @@
 open Core_kernel
 
-[%%versioned_asserted
+[%%versioned
 module Stable = struct
   module V1 = struct
-    (* there's no Time.Stable.Vn, assert version *)
-    type t = Unbanned | Banned_until of Time.t
+    type t = Unbanned | Banned_until of (Time.t[@version_asserted])
 
     let to_latest = Fn.id
 

--- a/src/nonconsensus/snark_params/tick.ml
+++ b/src/nonconsensus/snark_params/tick.ml
@@ -29,12 +29,12 @@ open Snarkette
 module Field = struct
   open Core_kernel
 
-  [%%versioned_asserted
+  [%%versioned
   module Stable = struct
     [@@@no_toplevel_latest_type]
 
     module V1 = struct
-      type t = Pasta.Fp.t [@@deriving equal, compare, yojson, sexp, hash]
+      type t = Pasta.Fp.t [@version_asserted] [@@deriving equal, compare, yojson, sexp, hash]
 
       let to_latest x = x
     end


### PR DESCRIPTION
- Instead of a `Stable`-level `%%versioned_asserted`, which generated a type-declaration-level `@@deriving version {asserted}`, allow an annotation `[@version_asserted]` on individual types. That gives finer control on where you're allowing omission of versioned types, and reduces complexity in the ppx code.

- For all-tagged and top-tagged modules, we shadowed the generated `bin_io` functions for the `t_tagged` type, and then had the functions for the `t` type. Eliminate an indirection by writing the functions for the `t` directly.

- For `%%versioned_binable` `Stable` modules, generate a prolog `[@@@alert "-legacy-deprecated"] and a matching re-enabling epilog to silence the compilation alerts for the `Binable` functors. Added those annotations explicitly in one file where such a functor was called outside of `%%versioned_binable`. The crypto code contains a few more such uses, the annotations can be added to silence alerts there.

- Patched the `versioned_module_good` test, which exercises the all-tagged and top-tagged feature.