### PR TITLE
nix: run docker image upload step only on main branches, add daemon

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
             label = "Upload mina-docker to Google Artifact Registry";
             depends_on = [ "packages_x86_64-linux_${package}" ];
             plugins = [{ "thedyrt/skip-checkout#v0.1.1" = null; }];
-            # branches = [ "compatible" "develop" ];
+            branches = [ "compatible" "develop" ];
           };
         in {
           steps = flakeSteps {
@@ -83,7 +83,10 @@
               agents = [ "nix" ];
               plugins = [{ "thedyrt/skip-checkout#v0.1.1" = null; }];
             };
-          } self ++ [ (pushToRegistry "mina-docker") ];
+          } self ++ [
+            (pushToRegistry "mina-docker")
+            (pushToRegistry "mina-daemon-docker")
+          ];
         };
     } // utils.lib.eachDefaultSystem (system:
       let


### PR DESCRIPTION
Fix for previous PR. This uploads only the compatible and develop branches, and also uploads the mina-daemon image.

Closes #11125 
