### PR TITLE
remove V1 of zkapp account precondition

### DIFF
--- a/src/lib/mina_base/zkapp_precondition.ml
+++ b/src/lib/mina_base/zkapp_precondition.ml
@@ -510,35 +510,6 @@ module Account = struct
 
       let to_latest = Fn.id
     end
-
-    module V1 = struct
-      type t =
-        ( Balance.Stable.V1.t Numeric.Stable.V1.t
-        , Account_nonce.Stable.V1.t Numeric.Stable.V1.t
-        , Receipt.Chain_hash.Stable.V1.t Hash.Stable.V1.t
-        , Public_key.Compressed.Stable.V1.t Eq_data.Stable.V1.t
-        , F.Stable.V1.t Eq_data.Stable.V1.t )
-        Poly.Stable.V1.t
-      [@@deriving sexp, equal, yojson, hash, compare]
-
-      let to_latest
-          ({ balance
-           ; nonce
-           ; receipt_chain_hash
-           ; public_key = _
-           ; delegate
-           ; state
-           } :
-            t ) : V2.t =
-        { balance
-        ; nonce
-        ; receipt_chain_hash
-        ; delegate
-        ; state
-        ; sequence_state = Ignore
-        ; proved_state = Ignore
-        }
-    end
   end]
 
   let gen : t Quickcheck.Generator.t =
@@ -1540,21 +1511,6 @@ module Other = struct
 
       let to_latest = Fn.id
     end
-
-    module V1 = struct
-      type t =
-        ( Account.Stable.V1.t
-        , Account_state.Stable.V1.t Transition.Stable.V1.t
-        , F.Stable.V1.t Hash.Stable.V1.t )
-        Poly.Stable.V1.t
-      [@@deriving sexp, equal, yojson, hash, compare]
-
-      let to_latest ({ predicate; account_transition; account_vk } : t) : V2.t =
-        { predicate = Account.Stable.V1.to_latest predicate
-        ; account_transition
-        ; account_vk
-        }
-    end
   end]
 
   module Checked = struct
@@ -1630,25 +1586,6 @@ module Stable = struct
     [@@deriving sexp, equal, yojson, hash, compare]
 
     let to_latest = Fn.id
-  end
-
-  module V1 = struct
-    type t =
-      ( Account.Stable.V1.t
-      , Protocol_state.Stable.V1.t
-      , Other.Stable.V1.t
-      , Public_key.Compressed.Stable.V1.t Eq_data.Stable.V1.t )
-      Poly.Stable.V1.t
-    [@@deriving sexp, equal, yojson, hash, compare]
-
-    let to_latest
-        ({ self_predicate; other; fee_payer; protocol_state_predicate } : t) :
-        V2.t =
-      { self_predicate = Account.Stable.V1.to_latest self_predicate
-      ; other = Other.Stable.V1.to_latest other
-      ; fee_payer
-      ; protocol_state_predicate
-      }
   end
 end]
 


### PR DESCRIPTION
Remove V1 since there is no backwards compatibility after hard fork

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
