### PR TITLE
CLI command to dump versioned type shapes

### DIFF
--- a/src/app/archive/archive_lib/dune
+++ b/src/app/archive/archive_lib/dune
@@ -65,6 +65,7 @@
    protocol_version
    mina_version
    staged_ledger_diff
+   ppx_version.runtime
  )
  (inline_tests)
  (modes native)

--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -12,6 +12,8 @@
    base
    core_kernel
    core
+   bin_prot
+   bin_prot.shape
    init
    tests
    async
@@ -67,6 +69,7 @@
    blockchain_snark
    snarky.backendless
    o1trace
+   ppx_version.runtime
  )
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1381,6 +1381,40 @@ let replay_blocks logger =
            "Daemon ready, replayed precomputed blocks. Clients can now connect" ;
          Async.never () ) )
 
+let dump_type_shapes =
+  Command.basic ~summary:"Print serialization shapes of versioned types"
+    (Command.Param.return (fun () ->
+         Ppx_version_runtime.Shapes.iteri ~f:(fun ~key:path ~data:shape ->
+             let open Bin_prot.Shape in
+             let canonical = eval shape in
+             let digest = Canonical.to_digest canonical |> Digest.to_hex in
+             let shape_summary =
+               let shape_sexp =
+                 Canonical.to_string_hum canonical |> Sexp.of_string
+               in
+               (* elide the shape below specified depth, so that changes to
+                  contained types aren't considered a change to the containing
+                  type, even though the shape digests differ
+               *)
+               let summary_sexp =
+                 (* TODO: tune the depth; want least depth that reveals local changes *)
+                 let max_depth = 8 in
+                 let rec go sexp depth =
+                   if depth > max_depth then Sexp.Atom "."
+                   else
+                     match sexp with
+                     | Sexp.Atom _ ->
+                         sexp
+                     | Sexp.List items ->
+                         Sexp.List
+                           (List.map items ~f:(fun item -> go item (depth + 1)))
+                 in
+                 go shape_sexp 0
+               in
+               Sexp.to_string summary_sexp
+             in
+             Core_kernel.printf "%s, %s, %s\n" path digest shape_summary ) ) )
+
 [%%if force_updates]
 
 let rec ensure_testnet_id_still_good logger =
@@ -1648,6 +1682,7 @@ let internal_commands logger =
           | None ->
               () ) ;
           Deferred.return ()) )
+  ; ("dump-type-shapes", dump_type_shapes)
   ; ("replay-blocks", replay_blocks logger)
   ]
 

--- a/src/app/cli/src/tests/dune
+++ b/src/app/cli/src/tests/dune
@@ -69,6 +69,7 @@
    work_selector
    mina_compile_config
    unsigned_extended
+   ppx_version.runtime
  )
 
  (preprocessor_deps ../../../../config.mlh)

--- a/src/lib/allocation_functor/dune
+++ b/src/lib/allocation_functor/dune
@@ -10,6 +10,7 @@
    sexplib0
    ;; local libraries
    mina_metrics
+   ppx_version.runtime
   )
   (instrumentation (backend bisect_ppx))
   (preprocess (pps ppx_jane ppx_compare ppx_deriving_yojson ppx_version))

--- a/src/lib/blake2/dune
+++ b/src/lib/blake2/dune
@@ -16,4 +16,4 @@
    ppx_inline_test.config
    ;; local libraries
    test_util
- ))
+   ppx_version.runtime))

--- a/src/lib/block_time/dune
+++ b/src/lib/block_time/dune
@@ -27,6 +27,7 @@
    snarky.backendless
    random_oracle_input
    random_oracle
+   ppx_version.runtime
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_hash ppx_let

--- a/src/lib/blockchain_snark/blockchain.ml
+++ b/src/lib/blockchain_snark/blockchain.ml
@@ -11,9 +11,9 @@ module Stable = struct
       [@@deriving fields, sexp, yojson]
     end
 
-    let to_latest = Fn.id
-
     include T
+
+    let to_latest = Fn.id
 
     include (
       Allocation_functor.Make.Bin_io_and_sexp (struct

--- a/src/lib/blockchain_snark/dune
+++ b/src/lib/blockchain_snark/dune
@@ -33,7 +33,8 @@
    random_oracle
    kimchi_backend.pasta
    data_hash_lib
-   )
+   ppx_version.runtime
+ )
  (inline_tests)
  (preprocess
   (pps ppx_snarky ppx_coda ppx_version ppx_jane ppx_compare))

--- a/src/lib/cli_lib/dune
+++ b/src/lib/cli_lib/dune
@@ -42,6 +42,7 @@
    consensus.vrf
    error_json
    kimchi_backend.pasta
+   ppx_version.runtime
    gossip_net)
  (preprocess
   (pps ppx_version ppx_jane ppx_deriving_yojson ppx_deriving.make))

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -71,6 +71,7 @@
    sparse_ledger_lib
    trust_system
    mina_base.import
+   ppx_version.runtime
  )
  (preprocessor_deps "../../config.mlh")
  (preprocess

--- a/src/lib/consensus/vrf/dune
+++ b/src/lib/consensus/vrf/dune
@@ -45,6 +45,7 @@
    kimchi_bindings
    kimchi_types
    pasta_bindings
+   ppx_version.runtime
  )
  (inline_tests)
  (instrumentation (backend bisect_ppx))

--- a/src/lib/crypto/kimchi_backend/common/dune
+++ b/src/lib/crypto/kimchi_backend/common/dune
@@ -39,6 +39,7 @@
    allocation_functor
    snarky.intf
    promise
+   ppx_version.runtime
 ))
 
 (rule

--- a/src/lib/crypto/kimchi_backend/pasta/dune
+++ b/src/lib/crypto/kimchi_backend/pasta/dune
@@ -23,4 +23,5 @@
    kimchi_types
    pasta_bindings
    snarkette
+   ppx_version.runtime
 ))

--- a/src/lib/currency/dune
+++ b/src/lib/currency/dune
@@ -33,6 +33,7 @@
    pickles
    snarky.backendless
    kimchi_backend.common
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess

--- a/src/lib/daemon_rpcs/dune
+++ b/src/lib/daemon_rpcs/dune
@@ -39,6 +39,7 @@
    network_pool
    data_hash_lib
    trust_system
+   ppx_version.runtime
  )
  (preprocess
   (pps ppx_version ppx_jane ppx_deriving_yojson ppx_compare ppx_deriving.make

--- a/src/lib/data_hash_lib/dune
+++ b/src/lib/data_hash_lib/dune
@@ -32,6 +32,7 @@
    fields_derivers.zkapps
    fields_derivers.json
    test_util
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess

--- a/src/lib/filtered_external_transition/dune
+++ b/src/lib/filtered_external_transition/dune
@@ -24,6 +24,7 @@
    signature_lib
    mina_base.import
    mina_numbers
+   ppx_version.runtime
  )
  (preprocess
   (pps ppx_coda ppx_version ppx_deriving_yojson))

--- a/src/lib/genesis_constants/dune
+++ b/src/lib/genesis_constants/dune
@@ -24,7 +24,8 @@
    snark_keys_header
    kimchi_backend.pasta
    test_util
-   )
+   ppx_version.runtime
+ )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps

--- a/src/lib/ledger_proof/dune
+++ b/src/lib/ledger_proof/dune
@@ -13,6 +13,7 @@
    mina_base
    mina_state
    mina_transaction_logic
-)
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_bin_prot ppx_sexp_conv ppx_hash ppx_compare ppx_version ppx_deriving_yojson)))

--- a/src/lib/logger/dune
+++ b/src/lib/logger/dune
@@ -13,6 +13,7 @@
    base.base_internalhash_types
    ;; local libraries
    interpolator_lib
+   ppx_version.runtime
  )
  (preprocess
   (pps ppx_version ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson))

--- a/src/lib/merkle_address/dune
+++ b/src/lib/merkle_address/dune
@@ -14,6 +14,7 @@
   ppx_inline_test.config
   ;; local libraries
   direction
+  ppx_version.runtime
   test_util)
  (preprocess
   (pps ppx_coda ppx_version ppx_jane ppx_hash ppx_compare ppx_deriving_yojson

--- a/src/lib/merkle_ledger/dune
+++ b/src/lib/merkle_ledger/dune
@@ -28,7 +28,8 @@
    key_value_database
    non_empty_list
    visualization
-   )
+   ppx_version.runtime
+ )
  (preprocess
   (pps ppx_coda ppx_version ppx_jane ppx_compare ppx_deriving.show ppx_deriving_yojson))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/merkle_ledger_tests/dune
+++ b/src/lib/merkle_ledger_tests/dune
@@ -30,7 +30,8 @@
    data_hash_lib
    key_value_database
    merkle_address
-)
+   ppx_version.runtime
+ )
  (preprocess
   (pps ppx_version ppx_jane ppx_compare ppx_deriving.show ppx_deriving_yojson))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/mina_base/dune
+++ b/src/lib/mina_base/dune
@@ -66,6 +66,7 @@
    kimchi_backend
    hex
    snark_bits
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess

--- a/src/lib/mina_block/dune
+++ b/src/lib/mina_block/dune
@@ -54,6 +54,7 @@
    kimchi_pasta
    random_oracle
    random_oracle_input
-   )
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane ppx_deriving.std ppx_deriving_yojson)))

--- a/src/lib/mina_ledger/dune
+++ b/src/lib/mina_ledger/dune
@@ -48,4 +48,5 @@
    quickcheck_lib
    snarky.backendless
    unsigned_extended
+   ppx_version.runtime
 ))

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -91,7 +91,8 @@
    mina_base.import
    data_hash_lib
    transition_handler
-)
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_coda ppx_version ppx_inline_test ppx_deriving.std))
  (synopsis "Coda gut layer"))

--- a/src/lib/mina_net2/dune
+++ b/src/lib/mina_net2/dune
@@ -33,7 +33,8 @@
    mina_metrics
    o1trace
    staged_ledger_diff
-   )
+   ppx_version.runtime
+ )
  (inline_tests)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane ppx_deriving.std ppx_let ppx_deriving_yojson)))

--- a/src/lib/mina_networking/dune
+++ b/src/lib/mina_networking/dune
@@ -46,6 +46,7 @@
    mina_ledger
    transition_handler
    o1trace
+   ppx_version.runtime
  )
  (inline_tests)
  (preprocess

--- a/src/lib/mina_numbers/dune
+++ b/src/lib/mina_numbers/dune
@@ -31,6 +31,7 @@
    bitstring_lib
    test_util
    kimchi_backend.common
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess

--- a/src/lib/mina_state/dune
+++ b/src/lib/mina_state/dune
@@ -46,5 +46,6 @@
    unsigned_extended
    sgn
    blake2
-   )
+   ppx_version.runtime
+ )
 )

--- a/src/lib/network_peer/dune
+++ b/src/lib/network_peer/dune
@@ -15,6 +15,7 @@
    result
    async_kernel
    mina_metrics
-   )
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_compare ppx_coda ppx_version ppx_jane ppx_deriving_yojson)))

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -61,6 +61,7 @@
    mina_ledger
    mina_base.import
    snark_params
+   ppx_version.runtime
  )
  (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))

--- a/src/lib/node_addrs_and_ports/dune
+++ b/src/lib/node_addrs_and_ports/dune
@@ -12,7 +12,8 @@
    bin_prot.shape
    ;; local libraries
    network_peer
-   )
+   ppx_version.runtime
+ )
  (inline_tests)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_jane ppx_let ppx_deriving_yojson)))

--- a/src/lib/non_empty_list/dune
+++ b/src/lib/non_empty_list/dune
@@ -9,6 +9,7 @@
    sexplib0
    bin_prot.shape
    ;; local libraries
+   ppx_version.runtime
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane ppx_compare)))

--- a/src/lib/non_zero_curve_point/dune
+++ b/src/lib/non_zero_curve_point/dune
@@ -26,6 +26,7 @@
    bitstring_lib
    kimchi_backend.pasta
    test_util
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (preprocess

--- a/src/lib/one_or_two/dune
+++ b/src/lib/one_or_two/dune
@@ -12,7 +12,8 @@
   ppx_hash.runtime-lib
   sexplib0
   base.caml
-  )
+  ppx_version.runtime
+)
  (preprocess
   (pps ppx_base ppx_bin_prot ppx_version ppx_deriving.std ppx_deriving_yojson ppx_let))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/parallel_scan/dune
+++ b/src/lib/parallel_scan/dune
@@ -22,6 +22,7 @@
    non_empty_list
    pipe_lib
    state_or_error
+   ppx_version.runtime
  )
  (preprocess
   (pps ppx_jane ppx_coda ppx_version ppx_compare lens.ppx_deriving))

--- a/src/lib/pickles/composition_types/dune
+++ b/src/lib/pickles/composition_types/dune
@@ -19,5 +19,6 @@
    pickles_base
    pickles.backend
    kimchi_backend.common
+   ppx_version.runtime
  )
 )

--- a/src/lib/pickles/dune
+++ b/src/lib/pickles/dune
@@ -60,4 +60,5 @@
    tuple_lib
    promise
    kimchi_backend.common
+   ppx_version.runtime
 ))

--- a/src/lib/pickles/limb_vector/dune
+++ b/src/lib/pickles/limb_vector/dune
@@ -17,4 +17,5 @@
    pickles.backend
    pickles_types
    kimchi_backend.pasta
+   ppx_version.runtime
 ))

--- a/src/lib/pickles_base/dune
+++ b/src/lib/pickles_base/dune
@@ -19,4 +19,5 @@
    random_oracle_input
    pickles_types
    pickles.one_hot_vector
+   ppx_version.runtime
 ))

--- a/src/lib/pickles_types/dune
+++ b/src/lib/pickles_types/dune
@@ -23,4 +23,5 @@
    ;; local libraries
    snarky.backendless
    tuple_lib
+   ppx_version.runtime
 ))

--- a/src/lib/ppx_version/dune
+++ b/src/lib/ppx_version/dune
@@ -10,5 +10,7 @@
    ppx_derivers
    ppx_bin_prot
    base base.caml
-   core_kernel)
+   core_kernel
+   ppx_version.runtime
+   bin_prot)
  (preprocess (pps ppx_compare ppxlib.metaquot)))

--- a/src/lib/ppx_version/runtime/dune
+++ b/src/lib/ppx_version/runtime/dune
@@ -1,0 +1,11 @@
+(library
+ (name ppx_version_runtime)
+ (public_name ppx_version.runtime)
+ (libraries
+   base
+   core_kernel
+   sexplib0
+   bin_prot
+   bin_prot.shape))
+
+

--- a/src/lib/ppx_version/runtime/shapes.ml
+++ b/src/lib/ppx_version/runtime/shapes.ml
@@ -1,0 +1,18 @@
+(* shapes.ml -- registry of Bin_prot shapes *)
+
+open Core_kernel
+module Shape_tbl = Hashtbl.Make (Base.String)
+
+let shape_tbl : Bin_prot.Shape.t Shape_tbl.t = Shape_tbl.create ()
+
+let register path_to_type (shape : Bin_prot.Shape.t) =
+  Shape_tbl.add shape_tbl ~key:path_to_type ~data:shape
+
+let find path_to_type = Shape_tbl.find shape_tbl path_to_type
+
+let iteri ~f = Shape_tbl.iteri shape_tbl ~f
+
+let equal_shapes shape1 shape2 =
+  let canonical1 = Bin_prot.Shape.eval shape1 in
+  let canonical2 = Bin_prot.Shape.eval shape2 in
+  Bin_prot.Shape.Canonical.compare canonical1 canonical2 = 0

--- a/src/lib/proof_carrying_data/dune
+++ b/src/lib/proof_carrying_data/dune
@@ -2,6 +2,10 @@
  (name proof_carrying_data)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_jane))
- (libraries core_kernel bin_prot.shape base base.caml sexplib0)
+ (libraries
+   ;; opam libraries
+   core_kernel bin_prot.shape base base.caml sexplib0
+   ;; local libraries
+   ppx_version.runtime)
  (public_name proof_carrying_data)
 )

--- a/src/lib/protocol_version/dune
+++ b/src/lib/protocol_version/dune
@@ -9,6 +9,7 @@
    bin_prot.shape
    base.caml
    base
+   ppx_version.runtime
  )
  (preprocess
   (pps ppx_version ppx_bin_prot ppx_sexp_conv ppx_compare ppx_deriving_yojson))

--- a/src/lib/prover/dune
+++ b/src/lib/prover/dune
@@ -39,6 +39,7 @@
    logger.file_system
    data_hash_lib
    staged_ledger_diff
+   ppx_version.runtime
  )
  (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))

--- a/src/lib/sgn/dune
+++ b/src/lib/sgn/dune
@@ -16,7 +16,8 @@
    sgn_type
    pickles
    snarky.backendless
-   )
+   ppx_version.runtime
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_version ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp ppx_compare ppx_deriving_yojson))

--- a/src/lib/sgn_type/dune
+++ b/src/lib/sgn_type/dune
@@ -11,4 +11,5 @@
    sexplib0
    bin_prot.shape
    base.caml
+   ppx_version.runtime
 ))

--- a/src/lib/signature_lib/dune
+++ b/src/lib/signature_lib/dune
@@ -36,6 +36,7 @@
    kimchi_backend
    h_list
    test_util
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/lib/snark_work_lib/dune
+++ b/src/lib/snark_work_lib/dune
@@ -15,7 +15,8 @@
    signature_lib
    one_or_two
    currency
-   )
+   ppx_version.runtime
+ )
  (preprocess
   (pps ppx_jane ppx_deriving_yojson ppx_version))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/sparse_ledger_lib/dune
+++ b/src/lib/sparse_ledger_lib/dune
@@ -12,6 +12,7 @@
    ppx_inline_test.config
    bin_prot.shape
    result
+   ppx_version.runtime
  )
  (preprocess
   (pps ppx_jane ppx_compare ppx_deriving_yojson ppx_version))

--- a/src/lib/staged_ledger/dune
+++ b/src/lib/staged_ledger/dune
@@ -60,6 +60,7 @@
    random_oracle
    kimchi_backend
    pickles.backend
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/lib/staged_ledger_diff/dune
+++ b/src/lib/staged_ledger_diff/dune
@@ -23,6 +23,7 @@
    allocation_functor
    consensus
    logger
-   )
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_jane ppx_version ppx_deriving.std ppx_deriving_yojson)))

--- a/src/lib/storage/dune
+++ b/src/lib/storage/dune
@@ -17,7 +17,8 @@
    base.caml
    ;; local libraries
    logger
-   )
+   ppx_version.runtime
+ )
  (preprocess
   (pps ppx_version ppx_jane))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/sync_status/dune
+++ b/src/lib/sync_status/dune
@@ -10,7 +10,8 @@
    sexplib0
    base.base_internalhash_types
    ppx_inline_test.config
-   )
+   ppx_version.runtime
+ )
  (preprocess
   (pps ppx_jane ppx_version ppx_deriving_yojson ppx_enumerate))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/syncable_ledger/dune
+++ b/src/lib/syncable_ledger/dune
@@ -22,7 +22,8 @@
    merkle_address
    direction
    error_json
-)
+   ppx_version.runtime
+ )
  (preprocess
   (pps ppx_coda ppx_version ppx_jane ppx_compare ppx_deriving_yojson ppx_register_event))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/transaction/dune
+++ b/src/lib/transaction/dune
@@ -24,6 +24,7 @@
    sgn
    snark_params
    snarky.backendless
+   ppx_version.runtime
    with_hash)
  (instrumentation (backend bisect_ppx))
  (preprocessor_deps ../../config.mlh)
@@ -37,4 +38,3 @@
     ppx_optcomp
     ppx_sexp_conv
     ppx_version)))
-

--- a/src/lib/transaction_inclusion_status/dune
+++ b/src/lib/transaction_inclusion_status/dune
@@ -34,6 +34,7 @@
    inline_test_quiet_logs
    mina_base.import
    mina_block
-)
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_coda ppx_version)))

--- a/src/lib/transaction_logic/dune
+++ b/src/lib/transaction_logic/dune
@@ -43,6 +43,7 @@
    snarky.backendless
    snark_params
    unsigned_extended
+   ppx_version.runtime
    with_hash)
  (instrumentation (backend bisect_ppx))
  (preprocess

--- a/src/lib/transaction_protocol_state/dune
+++ b/src/lib/transaction_protocol_state/dune
@@ -17,7 +17,8 @@
    snarky.backendless
    mina_state
    sgn
-   )
+   ppx_version.runtime
+ )
  (preprocess
   (pps ppx_snarky ppx_version ppx_jane ppx_deriving.std ppx_deriving_yojson))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -57,7 +57,8 @@
    kimchi_backend.pasta
    merkle_ledger
    mina_base.util
-   )
+   ppx_version.runtime
+ )
  (preprocess
   (pps ppx_snarky ppx_version ppx_jane ppx_deriving.std ppx_deriving_yojson h_list.ppx))
  (instrumentation (backend bisect_ppx))

--- a/src/lib/transaction_snark_scan_state/dune
+++ b/src/lib/transaction_snark_scan_state/dune
@@ -38,7 +38,8 @@
    genesis_constants
    o1trace
    with_hash
-   )
+   ppx_version.runtime
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_base ppx_coda ppx_version ppx_let ppx_sexp_conv ppx_bin_prot ppx_custom_printf

--- a/src/lib/transaction_snark_work/dune
+++ b/src/lib/transaction_snark_work/dune
@@ -15,6 +15,7 @@
    one_or_two
    ledger_proof
    signature_lib
-   )
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_version ppx_compare ppx_deriving_yojson)))

--- a/src/lib/transaction_witness/dune
+++ b/src/lib/transaction_witness/dune
@@ -22,6 +22,7 @@
    kimchi_backend.pasta
    sgn
    with_hash
-   )
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_version ppx_coda)))

--- a/src/lib/transition_frontier/frontier_base/dune
+++ b/src/lib/transition_frontier/frontier_base/dune
@@ -48,6 +48,7 @@
    transaction_snark
    non_empty_list
    coda_genesis_proof
-   )
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_coda ppx_version ppx_deriving.std ppx_deriving_yojson)))

--- a/src/lib/transition_frontier/persistent_frontier/dune
+++ b/src/lib/transition_frontier/persistent_frontier/dune
@@ -41,6 +41,7 @@
    with_hash
    debug_assert
    non_empty_list
-   )
+   ppx_version.runtime
+ )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_jane ppx_compare ppx_bin_prot ppx_deriving_yojson)))

--- a/src/lib/trust_system/dune
+++ b/src/lib/trust_system/dune
@@ -24,6 +24,7 @@
    network_peer
    run_in_thread
    test_util
+   ppx_version.runtime
  )
  (inline_tests)
  (preprocess

--- a/src/lib/unsigned_extended/dune
+++ b/src/lib/unsigned_extended/dune
@@ -20,7 +20,8 @@
    snark_params
    ppx_dhall_type
    test_util
-)
+   ppx_version.runtime
+ )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_coda ppx_version ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_inline_test ppx_deriving.std ppx_deriving_yojson))

--- a/src/lib/user_command_input/dune
+++ b/src/lib/user_command_input/dune
@@ -21,6 +21,7 @@
    mina_base
    mina_numbers
    mina_base.import
+   ppx_version.runtime
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_coda ppx_version ppx_deriving_yojson ppx_jane ppx_deriving.make)))

--- a/src/lib/vrf_evaluator/dune
+++ b/src/lib/vrf_evaluator/dune
@@ -25,6 +25,7 @@
    genesis_constants
    logger
    logger.file_system
+   ppx_version.runtime
  )
  (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))

--- a/src/lib/vrf_lib/dune
+++ b/src/lib/vrf_lib/dune
@@ -19,6 +19,7 @@
    genesis_constants
    snarky_curves
    bitstring_lib
+   ppx_version.runtime
  )
  (preprocess
   (pps

--- a/src/lib/with_hash/dune
+++ b/src/lib/with_hash/dune
@@ -1,7 +1,12 @@
 (library
  (name with_hash)
  (public_name with_hash)
- (libraries bin_prot.shape sexplib0 base.caml core_kernel)
+ (libraries
+   ;; opam libraries
+   bin_prot.shape sexplib0 base.caml core_kernel
+   ;; local libraries
+   ppx_version.runtime
+ )
  (instrumentation
   (backend bisect_ppx))
  (preprocess

--- a/src/lib/work_selector/dune
+++ b/src/lib/work_selector/dune
@@ -40,7 +40,7 @@
    mina_metrics
    transition_frontier_extensions
    mina_ledger
-   )
+   ppx_version.runtime)
  (preprocess
   (pps ppx_coda ppx_version ppx_assert ppx_base ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot
        ppx_custom_printf ppx_inline_test ppx_optcomp))

--- a/src/nonconsensus/snark_params/dune
+++ b/src/nonconsensus/snark_params/dune
@@ -14,6 +14,7 @@
    ;; local libraries
    bignum_bigint
    snarkette
+   ppx_version.runtime
  )
  (preprocessor_deps ../../config.mlh)
  (instrumentation (backend bisect_ppx))


### PR DESCRIPTION
In order to implement linting of serialization changes to versioned types per RFC 0047, add a CLI command `internal dump-type-shapes`. The `%%versioned` annotation automatically adds the shapes to a registry.

The CLI command shows the path to the type, a digest of its canonicalized shape, and an S-expression of the shape. The S-expression elides elements deeper than a given depth, so that changes to contained types don't affect the printed shape of the containing type. (We'll have to tune what an appropriate depth is.)

Sample output:
```
src/lib/transaction_snark/transaction_snark.ml:Transaction_snark.Pending_coinbase_stack_state.Stable.V1.t, 
  01b6150b8dbee028561cd4e372263a3f, 
  (Exp(Record((source(Exp(Record((data(. .))(state(. .))))))(target(Exp(Record((data(. .))(state(. .)))))))))
```

Still TODO: add a `%%versioned_rpc` for the RPC types, so the query and response types get registered (issue #11523).

Part of #11432.

