### PR TITLE
Use public key encoding for GraphQL

### DIFF
--- a/scripts/run_local_network.sh
+++ b/scripts/run_local_network.sh
@@ -484,8 +484,8 @@ fi
 
 if $transactions; then
   folder=$nodesfolder/fish_1
-  keyfile=$ledgerfolder/online_fish_keys/online_fish_account_1
-  pubkey=$(cat $ledgerfolder/online_fish_keys/online_fish_account_1.pub)
+  keyfile=$ledgerfolder/online_fish_keys/online_fish_account_0
+  pubkey=$(cat $ledgerfolder/online_fish_keys/online_fish_account_0.pub)
   rest_server="http://127.0.0.1:$(($FISH_START_PORT + 1))/graphql"
   printf "\n"
   echo "Waiting for node to be up to start sending transactions..."

--- a/src/lib/graphql_lib/serializing.ml
+++ b/src/lib/graphql_lib/serializing.ml
@@ -117,7 +117,7 @@ struct
 
   let parse = Decoders.public_key
 
-  let serialize = unimplemented_serializer "public_key"
+  let serialize = Encoders.public_key
 end
 
 module Public_key_s :


### PR DESCRIPTION
Use the existing encoding for public keys in GraphQL, instead of leaving the encoding unimplemented.

Closes #11511.

Also, fix an off-by-one error in the local network script.

Tested by running a local network, and using the CLI command `advanced pooled-user-command`.