### PR TITLE
adding timeout period

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -95,6 +95,7 @@ let Config =
       , artifact_paths : List SelectFiles.Type
       , env : List TaggedKey.Type
       , label : Text
+      , timeout_in_minutes : Text
       , key : Text
       , target : Size
       , docker : Optional Docker.Type
@@ -151,6 +152,7 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
                      then None B/ArtifactPaths
                      else Some (B/ArtifactPaths.String (SelectFiles.compile c.artifact_paths)),
     key = Some c.key,
+    timeout_in_minutes = Some 60,
     label = Some c.label,
     retry =
           Some {
@@ -241,4 +243,3 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
   }
 
 in {Config = Config, build = build, Type = B/Command.Type, TaggedKey = TaggedKey, Retry = Retry, ExitStatus = ExitStatus}
-

--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -152,7 +152,7 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
                      then None B/ArtifactPaths
                      else Some (B/ArtifactPaths.String (SelectFiles.compile c.artifact_paths)),
     key = Some c.key,
-    timeout_in_minutes = Some 60,
+    timeout_in_minutes = Some 120,
     label = Some c.label,
     retry =
           Some {


### PR DESCRIPTION


## PLEASE DELETE EVERYTHING ABOVE THIS LINE
---

Explain your changes:
* Adding timeout_in_minutes parameter to the Base dhall files that instantiate BuildKite jobs.
* This change will be affected by all integration tests that uses Base.dhall
* With this we want to limit the max amount of time a unit test run in our CI system
* Source: https://buildkite.com/docs/pipelines/command-step#timeout_in_minutes

Explain how you tested your changes:
* I have not performed a local test, for this we want to deploy to our CI and check if long running tests will continue to run for over 5 hours such as 'zkapps integration test'


Checklist:

- [ ] merge changes
- [ ] Monitor if process are terminated if they run for over 60 minutes
- [ ] BK should see the expiration timer, terminate the job and retry the test
- [ ] If 60 minutes is too aggressive for some test, than increase value to 120 minutes.
