### PR TITLE
Remove global silencing of unused module warnings

### DIFF
--- a/src/dune.flags.inc
+++ b/src/dune.flags.inc
@@ -6,4 +6,4 @@
     (flags (:standard -short-paths
             -ccopt=%{read:dune-linker}
             -cclib=-l%{read:dune-alloc}
-            -w @a-4-16-29-40-41-42-44-45-48-58-59-60-66-67-69-70))))
+            -w @a-4-16-29-40-41-42-44-45-48-58-59-66-67-69-70))))

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -899,7 +899,7 @@ module Data = struct
       go None delegators
   end
 
-  module Optional_state_hash = struct
+(*  module Optional_state_hash = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
@@ -909,7 +909,7 @@ module Data = struct
         let to_latest = Fn.id
       end
     end]
-  end
+  end *)
 
   module Epoch_data = struct
     include Mina_base.Epoch_data
@@ -2540,7 +2540,7 @@ module Hooks = struct
         include Master
       end)
 
-      module V2 = struct
+      (* module V2 = struct
         module T = struct
           type query = Mina_base.Ledger_hash.Stable.V1.t
 
@@ -2568,7 +2568,7 @@ module Hooks = struct
 
         include T'
         include Register (T')
-      end
+      end*)
 
       let implementation ~context:(module Context : CONTEXT) ~local_state
           ~genesis_ledger_hash conn ~version:_ ledger_hash =

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -899,18 +899,6 @@ module Data = struct
       go None delegators
   end
 
-(*  module Optional_state_hash = struct
-    [%%versioned
-    module Stable = struct
-      module V1 = struct
-        type t = Mina_base.State_hash.Stable.V1.t option
-        [@@deriving sexp, compare, hash, to_yojson]
-
-        let to_latest = Fn.id
-      end
-    end]
-  end *)
-
   module Epoch_data = struct
     include Mina_base.Epoch_data
 
@@ -2540,7 +2528,7 @@ module Hooks = struct
         include Master
       end)
 
-      (* module V2 = struct
+      module V2 = struct
         module T = struct
           type query = Mina_base.Ledger_hash.Stable.V1.t
 
@@ -2568,7 +2556,7 @@ module Hooks = struct
 
         include T'
         include Register (T')
-      end*)
+      end
 
       let implementation ~context:(module Context : CONTEXT) ~local_state
           ~genesis_ledger_hash conn ~version:_ ledger_hash =

--- a/src/lib/consensus/slot.ml
+++ b/src/lib/consensus/slot.ml
@@ -42,7 +42,7 @@ let gen (constants : Constants.t) =
 
 let%test_unit "in_seed_update_range unchecked vs. checked equality" =
   let constants = Lazy.force Constants.for_unit_tests in
-  let module Length = Mina_numbers.Length in
+  (* let module Length = Mina_numbers.Length in *)
   let test x =
     Test_util.test_equal
       (Snarky_backendless.Typ.tuple2 Constants.typ typ)

--- a/src/lib/consensus/slot.ml
+++ b/src/lib/consensus/slot.ml
@@ -42,7 +42,6 @@ let gen (constants : Constants.t) =
 
 let%test_unit "in_seed_update_range unchecked vs. checked equality" =
   let constants = Lazy.force Constants.for_unit_tests in
-  (* let module Length = Mina_numbers.Length in *)
   let test x =
     Test_util.test_equal
       (Snarky_backendless.Typ.tuple2 Constants.typ typ)

--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -2,7 +2,6 @@
 
 open Ppxlib
 open Core_kernel
-(* module Impl = Pickles.Impls.Step.Internal_Basic *)
 module Group = Pickles.Backend.Tick.Inner_curve
 
 let group_map_params =

--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -2,7 +2,7 @@
 
 open Ppxlib
 open Core_kernel
-module Impl = Pickles.Impls.Step.Internal_Basic
+(* module Impl = Pickles.Impls.Step.Internal_Basic *)
 module Group = Pickles.Backend.Tick.Inner_curve
 
 let group_map_params =

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -2,7 +2,6 @@ open Async
 open Core
 open Integration_test_lib.Util
 open Integration_test_lib
-module Timeout = Timeout_lib.Core_time
 module Node = Kubernetes_network.Node
 
 (** This implements Log_engine_intf for stack driver logs for integration tests

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -311,7 +311,7 @@ end
 
 let%test_module "Address" =
   ( module struct
-     module _ = Make_test (struct
+    module _ = Make_test (struct
       let depth = 4
     end)
 

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -260,7 +260,7 @@ module Range = struct
                   (current_node, (next_node, `Don't_stop)) ) )
 end
 
-(* module Make_test (Input : sig
+module Make_test (Input : sig
   val depth : int
 end) =
 struct
@@ -307,19 +307,19 @@ struct
             ()
         | Some addr' ->
             [%test_result: t option] ~expect:(Some address) (prev addr') )
-end*)
+end
 
 let%test_module "Address" =
   ( module struct
-    (* module Test4 = Make_test (struct
+     module _ = Make_test (struct
       let depth = 4
     end)
 
-    module Test16 = Make_test (struct
+    module _ = Make_test (struct
       let depth = 16
     end)
 
-    module Test30 = Make_test (struct
+    module _ = Make_test (struct
       let depth = 30
-    end) *)
+    end)
   end )

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -260,7 +260,7 @@ module Range = struct
                   (current_node, (next_node, `Don't_stop)) ) )
 end
 
-module Make_test (Input : sig
+(* module Make_test (Input : sig
   val depth : int
 end) =
 struct
@@ -307,11 +307,11 @@ struct
             ()
         | Some addr' ->
             [%test_result: t option] ~expect:(Some address) (prev addr') )
-end
+end*)
 
 let%test_module "Address" =
   ( module struct
-    module Test4 = Make_test (struct
+    (* module Test4 = Make_test (struct
       let depth = 4
     end)
 
@@ -321,5 +321,5 @@ let%test_module "Address" =
 
     module Test30 = Make_test (struct
       let depth = 30
-    end)
+    end) *)
   end )

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -556,6 +556,7 @@ let%test_module "test functor on in memory databases" =
     end
 
     [@@@warning "-60"]
+
     module Mdb_d4 = Make_db (Depth_4)
 
     module Depth_30 = struct
@@ -563,10 +564,6 @@ let%test_module "test functor on in memory databases" =
     end
 
     module Mdb_d30 = Make_db (Depth_30)
-    [@@@warning "+60"]                   
+
+    [@@@warning "+60"]
   end )
-
-
-
-
-

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -3,7 +3,6 @@ open Test_stubs
 
 let%test_module "test functor on in memory databases" =
   ( module struct
-    module Intf = Merkle_ledger.Intf
     module Database = Merkle_ledger.Database
 
     module type DB =
@@ -556,6 +555,7 @@ let%test_module "test functor on in memory databases" =
       let depth = 4
     end
 
+    [@@@warning "-60"]
     module Mdb_d4 = Make_db (Depth_4)
 
     module Depth_30 = struct
@@ -563,4 +563,10 @@ let%test_module "test functor on in memory databases" =
     end
 
     module Mdb_d30 = Make_db (Depth_30)
+    [@@@warning "+60"]                   
   end )
+
+
+
+
+

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -858,6 +858,7 @@ let%test_module "Test mask connected to underlying Merkle tree" =
       let depth = 4
     end
 
+    [@@@warning "-60"]                   
     module Mdb_d4 = Make_maskable_and_mask (Depth_4)
 
     module Depth_30 = struct
@@ -865,4 +866,5 @@ let%test_module "Test mask connected to underlying Merkle tree" =
     end
 
     module Mdb_d30 = Make_maskable_and_mask (Depth_30)
+    [@@@warning "+60"]                  
   end )

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -858,7 +858,8 @@ let%test_module "Test mask connected to underlying Merkle tree" =
       let depth = 4
     end
 
-    [@@@warning "-60"]                   
+    [@@@warning "-60"]
+
     module Mdb_d4 = Make_maskable_and_mask (Depth_4)
 
     module Depth_30 = struct
@@ -866,5 +867,6 @@ let%test_module "Test mask connected to underlying Merkle tree" =
     end
 
     module Mdb_d30 = Make_maskable_and_mask (Depth_30)
-    [@@@warning "+60"]                  
+
+    [@@@warning "+60"]
   end )

--- a/src/lib/mina_base/payment_payload.ml
+++ b/src/lib/mina_base/payment_payload.ml
@@ -5,7 +5,7 @@
 open Core_kernel
 open Signature_lib
 module Amount = Currency.Amount
-module Fee = Currency.Fee
+(* module Fee = Currency.Fee *)
 
 module Poly = struct
   [%%versioned

--- a/src/lib/mina_base/payment_payload.ml
+++ b/src/lib/mina_base/payment_payload.ml
@@ -5,7 +5,6 @@
 open Core_kernel
 open Signature_lib
 module Amount = Currency.Amount
-(* module Fee = Currency.Fee *)
 
 module Poly = struct
   [%%versioned

--- a/src/lib/mina_base/permissions.ml
+++ b/src/lib/mina_base/permissions.ml
@@ -9,9 +9,6 @@ open Snark_params.Tick
 
 [%%endif]
 
-(* module Frozen_ledger_hash = Frozen_ledger_hash0 *)
-(* module Ledger_hash = Ledger_hash0 *)
-
 (* Semantically this type represents a function
      { has_valid_signature: bool; has_valid_proof: bool } -> bool
 

--- a/src/lib/mina_base/permissions.ml
+++ b/src/lib/mina_base/permissions.ml
@@ -9,8 +9,8 @@ open Snark_params.Tick
 
 [%%endif]
 
-module Frozen_ledger_hash = Frozen_ledger_hash0
-module Ledger_hash = Ledger_hash0
+(* module Frozen_ledger_hash = Frozen_ledger_hash0 *)
+(* module Ledger_hash = Ledger_hash0 *)
 
 (* Semantically this type represents a function
      { has_valid_signature: bool; has_valid_proof: bool } -> bool

--- a/src/lib/mina_base/receipt.ml
+++ b/src/lib/mina_base/receipt.ml
@@ -3,7 +3,6 @@
 [%%import "/src/config.mlh"]
 
 open Core_kernel
-(* module B58_lib = Base58_check *)
 open Snark_params.Tick
 
 module Signed_command_elt = struct

--- a/src/lib/mina_base/receipt.ml
+++ b/src/lib/mina_base/receipt.ml
@@ -3,7 +3,7 @@
 [%%import "/src/config.mlh"]
 
 open Core_kernel
-module B58_lib = Base58_check
+(* module B58_lib = Base58_check *)
 open Snark_params.Tick
 
 module Signed_command_elt = struct

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -53,7 +53,7 @@ module Common = struct
         [@@deriving compare, equal, sexp, hash, yojson, hlist]
       end
 
-      (* module V1 = struct
+      module V1 = struct
         type ('fee, 'public_key, 'token_id, 'nonce, 'global_slot, 'memo) t =
               ( 'fee
               , 'public_key
@@ -70,7 +70,7 @@ module Common = struct
           ; memo : 'memo
           }
         [@@deriving compare, equal, sexp, hash, yojson, hlist]
-      end*)
+      end
     end]
   end
 
@@ -195,8 +195,6 @@ module Body = struct
       let to_latest = Fn.id
     end
   end]
-
-  (* module Tag = Transaction_union_tag *)
 
   let gen ?source_pk ~max_amount =
     let open Quickcheck.Generator in

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -53,7 +53,7 @@ module Common = struct
         [@@deriving compare, equal, sexp, hash, yojson, hlist]
       end
 
-      module V1 = struct
+      (* module V1 = struct
         type ('fee, 'public_key, 'token_id, 'nonce, 'global_slot, 'memo) t =
               ( 'fee
               , 'public_key
@@ -70,7 +70,7 @@ module Common = struct
           ; memo : 'memo
           }
         [@@deriving compare, equal, sexp, hash, yojson, hlist]
-      end
+      end*)
     end]
   end
 
@@ -196,7 +196,7 @@ module Body = struct
     end
   end]
 
-  module Tag = Transaction_union_tag
+  (* module Tag = Transaction_union_tag *)
 
   let gen ?source_pk ~max_amount =
     let open Quickcheck.Generator in

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -1588,7 +1588,8 @@ module Object_lifetime_statistics = struct
     Gauge_map.add lifetime_quartile_ms_table ~name ~help
 end
 
-(* module Execution_times = struct
+[@@@warning "-60"]
+module Execution_times = struct
   let tracked_metrics = String.Table.create ()
 
   let create_metric thread =
@@ -1616,7 +1617,8 @@ end
           Hashtbl.add_exn tracked_metrics ~key:name ~data:(create_metric thread) )
 
   let () = CollectorRegistry.(register_pre_collect default sync_metrics)
-end *)
+end
+[@@@warning "+60"]
 
 let generic_server ?forward_uri ~port ~logger ~registry () =
   let open Cohttp in

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -1589,6 +1589,7 @@ module Object_lifetime_statistics = struct
 end
 
 [@@@warning "-60"]
+
 module Execution_times = struct
   let tracked_metrics = String.Table.create ()
 
@@ -1618,6 +1619,7 @@ module Execution_times = struct
 
   let () = CollectorRegistry.(register_pre_collect default sync_metrics)
 end
+
 [@@@warning "+60"]
 
 let generic_server ?forward_uri ~port ~logger ~registry () =

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -1588,7 +1588,7 @@ module Object_lifetime_statistics = struct
     Gauge_map.add lifetime_quartile_ms_table ~name ~help
 end
 
-module Execution_times = struct
+(* module Execution_times = struct
   let tracked_metrics = String.Table.create ()
 
   let create_metric thread =
@@ -1616,7 +1616,7 @@ module Execution_times = struct
           Hashtbl.add_exn tracked_metrics ~key:name ~data:(create_metric thread) )
 
   let () = CollectorRegistry.(register_pre_collect default sync_metrics)
-end
+end *)
 
 let generic_server ?forward_uri ~port ~logger ~registry () =
   let open Cohttp in

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -83,7 +83,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V1 = struct
+     module V1 = struct
       module T = struct
         type query = unit
 
@@ -157,7 +157,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V2 = struct
+     module V2 = struct
       module T = struct
         type query = State_hash.Stable.V1.t
 
@@ -226,7 +226,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V2 = struct
+     module V2 = struct
       module T = struct
         type query = Ledger_hash.Stable.V1.t * Sync_ledger.Query.Stable.V1.t
         [@@deriving sexp]
@@ -292,7 +292,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V2 = struct
+     module V2 = struct
       module T = struct
         type query = State_hash.Stable.V1.t list [@@deriving sexp]
 
@@ -356,7 +356,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V1 = struct
+     module V1 = struct
       module T = struct
         type query = State_hash.Stable.V1.t [@@deriving sexp]
 
@@ -421,7 +421,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V1 = struct
+     module V1 = struct
       module T = struct
         type query = unit [@@deriving sexp]
 
@@ -491,7 +491,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V2 = struct
+     module V2 = struct
       module T = struct
         type query =
           ( Consensus.Data.Consensus_state.Value.Stable.V1.t
@@ -563,7 +563,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V1 = struct
+     module V1 = struct
       module T = struct
         type query = Core.Time.Stable.V1.t [@@deriving sexp]
 
@@ -630,7 +630,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V2 = struct
+     module V2 = struct
       module T = struct
         type query = unit [@@deriving sexp]
 
@@ -702,7 +702,7 @@ module Rpcs = struct
           let to_latest = Fn.id
         end
 
-        module V1 = struct
+         module V1 = struct
           type t =
             { node_ip_addr : Core.Unix.Inet_addr.Stable.V1.t
                   [@to_yojson
@@ -791,7 +791,7 @@ module Rpcs = struct
       include Master
     end)
 
-    module V2 = struct
+     module V2 = struct
       module T = struct
         type query = unit [@@deriving sexp]
 
@@ -816,9 +816,9 @@ module Rpcs = struct
 
       include T'
       include Register (T')
-    end
+    end 
 
-    module V1 = struct
+   module V1 = struct
       module T = struct
         type query = unit [@@deriving sexp]
 

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -84,8 +84,6 @@ let typ : (var, Value.t) Typ.t =
   Typ.of_hlistable data_spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
     ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
 
-(* module Impl = Pickles.Impls.Step *)
-
 let var_to_input
     ({ staged_ledger_hash
      ; genesis_ledger_hash

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -84,7 +84,7 @@ let typ : (var, Value.t) Typ.t =
   Typ.of_hlistable data_spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
     ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
 
-module Impl = Pickles.Impls.Step
+(* module Impl = Pickles.Impls.Step *)
 
 let var_to_input
     ({ staged_ledger_hash

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -192,7 +192,7 @@ type var = (State_hash.var, Body.var) Poly.t
 
 [%%endif]
 
-module Proof = Proof
+(* module Proof = Proof *)
 module Hash = State_hash
 
 let create ~previous_state_hash ~body =

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -192,7 +192,6 @@ type var = (State_hash.var, Body.var) Poly.t
 
 [%%endif]
 
-(* module Proof = Proof *)
 module Hash = State_hash
 
 let create ~previous_state_hash ~body =

--- a/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
+++ b/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
@@ -1,7 +1,6 @@
 open Core
 open Async
 open Webkit_trace_event
-(* module Scheduler = Async_kernel_scheduler *)
 
 let current_wr = ref None
 

--- a/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
+++ b/src/lib/o1trace/webkit_event/o1trace_webkit_event.ml
@@ -1,7 +1,7 @@
 open Core
 open Async
 open Webkit_trace_event
-module Scheduler = Async_kernel_scheduler
+(* module Scheduler = Async_kernel_scheduler *)
 
 let current_wr = ref None
 

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -146,7 +146,7 @@ module Worker_state = struct
              end : S )
          | Check ->
              ( module struct
-               module Transaction_snark = Transaction_snark
+                 (* module Transaction_snark = Transaction_snark *)
 
                let extend_blockchain (chain : Blockchain.t)
                    (next_state : Protocol_state.Value.t)
@@ -180,7 +180,7 @@ module Worker_state = struct
              end : S )
          | None ->
              ( module struct
-               module Transaction_snark = Transaction_snark
+                 (* module Transaction_snark = Transaction_snark *)
 
                let extend_blockchain _chain next_state _block _ledger_proof
                    _state_for_handler _pending_coinbase =
@@ -209,7 +209,7 @@ module Functions = struct
 
   let initialized =
     create bin_unit [%bin_type_class: [ `Initialized ]] (fun w () ->
-        let (module W) = Worker_state.get w in
+        let (module _) = Worker_state.get w in
         Deferred.return `Initialized )
 
   let extend_blockchain =

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -146,7 +146,6 @@ module Worker_state = struct
              end : S )
          | Check ->
              ( module struct
-                 (* module Transaction_snark = Transaction_snark *)
 
                let extend_blockchain (chain : Blockchain.t)
                    (next_state : Protocol_state.Value.t)
@@ -179,8 +178,7 @@ module Worker_state = struct
                let verify _state _proof = Deferred.return true
              end : S )
          | None ->
-             ( module struct
-                 (* module Transaction_snark = Transaction_snark *)
+             ( module struct                 
 
                let extend_blockchain _chain next_state _block _ledger_proof
                    _state_for_handler _pending_coinbase =

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -146,7 +146,6 @@ module Worker_state = struct
              end : S )
          | Check ->
              ( module struct
-
                let extend_blockchain (chain : Blockchain.t)
                    (next_state : Protocol_state.Value.t)
                    (block : Snark_transition.value) (t : Ledger_proof.t option)
@@ -178,8 +177,7 @@ module Worker_state = struct
                let verify _state _proof = Deferred.return true
              end : S )
          | None ->
-             ( module struct                 
-
+             ( module struct
                let extend_blockchain _chain next_state _block _ledger_proof
                    _state_for_handler _pending_coinbase =
                  Deferred.return

--- a/src/lib/snarky_blake2/uint32.ml
+++ b/src/lib/snarky_blake2/uint32.ml
@@ -26,7 +26,6 @@ end
 
 module Make (Impl : Snarky_backendless.Snark_intf.S) :
   S with module Impl := Impl = struct
-  module B = Bigint
   open Impl
   open Let_syntax
   module Unchecked = Unsigned.UInt32

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -2112,14 +2112,7 @@ let constraint_constants =
 let pickles_digest (choices : pickles_rule_js Js.js_array Js.t)
     (public_input_size : int) =
   let branches = choices##.length in
-  let max_proofs =
-    let choices = choices |> Js.to_array |> Array.to_list in
-    List.map choices ~f:(fun c ->
-        c##.proofsToVerify |> Js.to_array |> Array.length )
-    |> List.max_elt ~compare |> Option.value ~default:0
-  in
   let (module Branches) = nat_module branches in
-  let (module Max_proofs_verified) = nat_add_module max_proofs in
   let (Choices choices) = Choices.of_js ~public_input_size choices in
   try
     let _ =
@@ -2358,7 +2351,6 @@ module Ledger = struct
     module Account = Mina_base.Account
     module Account_id = Mina_base.Account_id
     module Ledger_hash = Mina_base.Ledger_hash
-    module Token_id = Mina_base.Token_id
 
     type t_ =
       { next_location : int

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -163,7 +163,7 @@ let%test_module "multisig_account" =
           Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Init_ledger.init (module Ledger.Ledger_inner) init_ledger ledger ;
               let spec = List.hd_exn specs in
-              let tag, _, (module P), Pickles.Provers.[ multisig_prover; _ ] =
+              let tag, _, (module _), Pickles.Provers.[ multisig_prover; _ ] =
                 let multisig_rule : _ Pickles.Inductive_rule.t =
                   let multisig_main (tx_commitment : Zkapp_statement.Checked.t)
                       : unit Checked.t =

--- a/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
@@ -3,10 +3,7 @@ open Core_kernel
 open Mina_base
 open Signature_lib
 module Impl = Pickles.Impls.Step
-module Inner_curve = Snark_params.Tick.Inner_curve
 module Nat = Pickles_types.Nat
-module Local_state = Mina_state.Local_state
-module Parties_segment = Transaction_snark.Parties_segment
 
 let sk = Private_key.create ()
 
@@ -16,7 +13,7 @@ let pk_compressed = Public_key.compress pk
 
 let account_id = Account_id.create pk_compressed Token_id.default
 
-let tag, _, p_module, Pickles.Provers.[ prover ] =
+let tag, _, _p_module, Pickles.Provers.[ prover ] =
   Zkapps_examples.compile () ~cache:Cache_dir.cache ~auxiliary_typ:Impl.Typ.unit
     ~branches:(module Nat.N1)
     ~max_proofs_verified:(module Nat.N0)
@@ -25,8 +22,6 @@ let tag, _, p_module, Pickles.Provers.[ prover ] =
       (Genesis_constants.Constraint_constants.to_snark_keys_header
          constraint_constants )
     ~choices:(fun ~self:_ -> [ Zkapps_empty_update.rule pk_compressed ])
-
-module P = (val p_module)
 
 let vk = Pickles.Side_loaded.Verification_key.of_compiled tag
 

--- a/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
@@ -23,7 +23,7 @@ let%test_module "Initialize state test" =
 
     let ( tag
         , _
-        , p_module
+        , _p_module
         , Pickles.Provers.[ initialize_prover; update_state_prover ] ) =
       Zkapps_examples.compile () ~cache:Cache_dir.cache
         ~auxiliary_typ:Impl.Typ.unit
@@ -37,8 +37,6 @@ let%test_module "Initialize state test" =
           [ Zkapps_initialize_state.initialize_rule pk_compressed
           ; Zkapps_initialize_state.update_state_rule pk_compressed
           ] )
-
-    module P = (val p_module)
 
     let vk = Pickles.Side_loaded.Verification_key.of_compiled tag
 

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -36,7 +36,7 @@ let with_top_hash_logging f =
     top_hash_logging_enabled := old ;
     raise err
 
-module Proof_type = struct
+(* module Proof_type = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
@@ -46,7 +46,7 @@ module Proof_type = struct
       let to_latest = Fn.id
     end
   end]
-end
+end *)
 
 module Pending_coinbase_stack_state = struct
   module Init_stack = struct
@@ -1614,7 +1614,7 @@ module Base = struct
 
       let { auth_type; is_start = _ } = spec
 
-      module V = Prover_value
+      (* module V = Prover_value *)
       open Impl
 
       module Inputs = struct
@@ -3202,7 +3202,7 @@ module Base = struct
         handler r
 end
 
-module Transition_data = struct
+(* module Transition_data = struct
   type t =
     { proof : Proof_type.t
     ; supply_increase : (Amount.t, Sgn.t) Signed_poly.t
@@ -3211,7 +3211,7 @@ module Transition_data = struct
     ; pending_coinbase_stack_state : Pending_coinbase_stack_state.t
     }
   [@@deriving fields]
-end
+end *)
 
 module Merge = struct
   open Tick
@@ -4299,7 +4299,7 @@ module For_tests = struct
   end
 
   let create_trivial_snapp ~constraint_constants () =
-    let tag, _, (module P), Pickles.Provers.[ trivial_prover; _ ] =
+    let tag, _, (module _), Pickles.Provers.[ trivial_prover; _ ] =
       let trivial_rule : _ Pickles.Inductive_rule.t =
         let trivial_main (tx_commitment : Zkapp_statement.Checked.t) :
             unit Checked.t =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -36,18 +36,6 @@ let with_top_hash_logging f =
     top_hash_logging_enabled := old ;
     raise err
 
-(* module Proof_type = struct
-  [%%versioned
-  module Stable = struct
-    module V1 = struct
-      type t = [ `Base | `Merge ]
-      [@@deriving compare, equal, hash, sexp, yojson]
-
-      let to_latest = Fn.id
-    end
-  end]
-end *)
-
 module Pending_coinbase_stack_state = struct
   module Init_stack = struct
     [%%versioned
@@ -1614,7 +1602,6 @@ module Base = struct
 
       let { auth_type; is_start = _ } = spec
 
-      (* module V = Prover_value *)
       open Impl
 
       module Inputs = struct
@@ -3201,17 +3188,6 @@ module Base = struct
     | _ ->
         handler r
 end
-
-(* module Transition_data = struct
-  type t =
-    { proof : Proof_type.t
-    ; supply_increase : (Amount.t, Sgn.t) Signed_poly.t
-    ; fee_excess : Fee_excess.t
-    ; sok_digest : Sok_message.Digest.t
-    ; pending_coinbase_stack_state : Pending_coinbase_stack_state.t
-    }
-  [@@deriving fields]
-end *)
 
 module Merge = struct
   open Tick

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -22,13 +22,14 @@ module type Monad_with_Or_error_intf = sig
   type 'a t
 
   include Monad.S with type 'a t := 'a t
-     
-   module Or_error : sig
+
+  module Or_error : sig
     type nonrec 'a t = 'a Or_error.t t
 
     include Monad.S with type 'a t := 'a t
   end
-end[@@warning "-60"]
+end
+[@@warning "-60"]
 
 module Transaction_with_witness = struct
   [%%versioned

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -23,11 +23,11 @@ module type Monad_with_Or_error_intf = sig
 
   include Monad.S with type 'a t := 'a t
 
-  module Or_error : sig
+  (* module Or_error : sig
     type nonrec 'a t = 'a Or_error.t t
 
     include Monad.S with type 'a t := 'a t
-  end
+  end *)
 end
 
 module Transaction_with_witness = struct
@@ -735,7 +735,7 @@ let all_work_pairs t
     list
     Or_error.t =
   let all_jobs = all_jobs t in
-  let module A = Available_job in
+  (* let module A = Available_job in *)
   let open Or_error.Let_syntax in
   let single_spec (job : job) =
     match extract_from_job job with

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -22,13 +22,13 @@ module type Monad_with_Or_error_intf = sig
   type 'a t
 
   include Monad.S with type 'a t := 'a t
-
-  (* module Or_error : sig
+     
+   module Or_error : sig
     type nonrec 'a t = 'a Or_error.t t
 
     include Monad.S with type 'a t := 'a t
-  end *)
-end
+  end
+end[@@warning "-60"]
 
 module Transaction_with_witness = struct
   [%%versioned
@@ -735,7 +735,6 @@ let all_work_pairs t
     list
     Or_error.t =
   let all_jobs = all_jobs t in
-  (* let module A = Available_job in *)
   let open Or_error.Let_syntax in
   let single_spec (job : job) =
     match extract_from_job job with

--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -232,7 +232,7 @@ let%test_module "peer_trust" =
       let advance span = current_time := Time.add !current_time span
     end
 
-    module Mock_record = Record.Make (Mock_now)
+    (* module Mock_record = Record.Make (Mock_now) *)
     module Db = Key_value_database.Make_mock (Int) (Record)
 
     module Peer_id = struct

--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -232,7 +232,6 @@ let%test_module "peer_trust" =
       let advance span = current_time := Time.add !current_time span
     end
 
-    (* module Mock_record = Record.Make (Mock_now) *)
     module Db = Key_value_database.Make_mock (Int) (Record)
 
     module Peer_id = struct

--- a/src/lib/vrf_evaluator/vrf_evaluator.ml
+++ b/src/lib/vrf_evaluator/vrf_evaluator.ml
@@ -103,7 +103,7 @@ module Worker_state = struct
     }
 
   let make_last_checked_slot_and_epoch_table old_table new_keys ~default =
-    let module Set = Public_key.Compressed.Set in
+    (* let module Set = Public_key.Compressed.Set in *)
     let module Table = Public_key.Compressed.Table in
     let last_checked_slot_and_epoch = Table.create () in
     List.iter new_keys ~f:(fun (_, pk) ->

--- a/src/lib/vrf_evaluator/vrf_evaluator.ml
+++ b/src/lib/vrf_evaluator/vrf_evaluator.ml
@@ -103,7 +103,6 @@ module Worker_state = struct
     }
 
   let make_last_checked_slot_and_epoch_table old_table new_keys ~default =
-    (* let module Set = Public_key.Compressed.Set in *)
     let module Table = Public_key.Compressed.Table in
     let last_checked_slot_and_epoch = Table.create () in
     List.iter new_keys ~f:(fun (_, pk) ->

--- a/src/lib/work_selector/random.ml
+++ b/src/lib/work_selector/random.ml
@@ -22,5 +22,5 @@ end
 
 let%test_module "test" =
   ( module struct
-    module Test = Test.Make_test (Make)
+      (* module Test = Test.Make_test (Make) *)
   end )

--- a/src/lib/work_selector/random.ml
+++ b/src/lib/work_selector/random.ml
@@ -22,5 +22,5 @@ end
 
 let%test_module "test" =
   ( module struct
-      module _ = Test.Make_test (Make)
+    module _ = Test.Make_test (Make)
   end )

--- a/src/lib/work_selector/random.ml
+++ b/src/lib/work_selector/random.ml
@@ -22,5 +22,5 @@ end
 
 let%test_module "test" =
   ( module struct
-      (* module Test = Test.Make_test (Make) *)
+      module _ = Test.Make_test (Make)
   end )

--- a/src/lib/work_selector/sequence.ml
+++ b/src/lib/work_selector/sequence.ml
@@ -18,5 +18,5 @@ end
 
 let%test_module "test" =
   ( module struct
-      (* module Test = Test.Make_test (Make) *)
+      module _ = Test.Make_test (Make)
   end )

--- a/src/lib/work_selector/sequence.ml
+++ b/src/lib/work_selector/sequence.ml
@@ -18,5 +18,5 @@ end
 
 let%test_module "test" =
   ( module struct
-      module _ = Test.Make_test (Make)
+    module _ = Test.Make_test (Make)
   end )

--- a/src/lib/work_selector/sequence.ml
+++ b/src/lib/work_selector/sequence.ml
@@ -18,5 +18,5 @@ end
 
 let%test_module "test" =
   ( module struct
-    module Test = Test.Make_test (Make)
+      (* module Test = Test.Make_test (Make) *)
   end )

--- a/src/nonconsensus/snark_params/tick.ml
+++ b/src/nonconsensus/snark_params/tick.ml
@@ -39,6 +39,7 @@ module Field = struct
       let to_latest x = x
     end
 
+    module Tests = struct end              
   end]
 
   include Pasta.Fp

--- a/src/nonconsensus/snark_params/tick.ml
+++ b/src/nonconsensus/snark_params/tick.ml
@@ -38,8 +38,6 @@ module Field = struct
 
       let to_latest x = x
     end
-
-    module Tests = struct end              
   end]
 
   include Pasta.Fp

--- a/src/nonconsensus/snark_params/tick.ml
+++ b/src/nonconsensus/snark_params/tick.ml
@@ -39,7 +39,6 @@ module Field = struct
       let to_latest x = x
     end
 
-    module Tests = struct end
   end]
 
   include Pasta.Fp


### PR DESCRIPTION
This PR removes the global flag to silence unused modules warnings, and removes the unused modules. 

Closes #11049.

