### PR TITLE
Remove code to archive pooled txns

### DIFF
--- a/src/app/archive/archive_lib/diff.ml
+++ b/src/app/archive/archive_lib/diff.ml
@@ -41,9 +41,7 @@ module Transaction_pool = struct
   [@@deriving bin_io_unversioned]
 end
 
-type t =
-  | Transition_frontier of Transition_frontier.t
-  | Transaction_pool of Transaction_pool.t
+type t = Transition_frontier of Transition_frontier.t
 [@@deriving bin_io_unversioned]
 
 module Builder = struct
@@ -134,7 +132,4 @@ module Builder = struct
       ; tokens_used
       ; sender_receipt_chains_from_parent_ledger
       }
-
-  let user_commands user_commands =
-    Transaction_pool { Transaction_pool.added = user_commands; removed = [] }
 end

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -3393,32 +3393,7 @@ let run pool reader ~constraint_constants ~logger ~delete_older_than :
         | Ok () ->
             Deferred.unit )
     | Transition_frontier _ ->
-        Deferred.unit
-    | Transaction_pool { added; removed = _ } ->
-        let%map _ =
-          Caqti_async.Pool.use
-            (fun (module Conn : CONNECTION) ->
-              let%map () =
-                Deferred.List.iter added ~f:(fun command ->
-                    match%map
-                      User_command.add_if_doesn't_exist (module Conn) command
-                    with
-                    | Ok _ ->
-                        ()
-                    | Error e ->
-                        [%log warn]
-                          ~metadata:
-                            [ ("error", `String (Caqti_error.show e))
-                            ; ( "command"
-                              , Mina_base.User_command.to_yojson command )
-                            ]
-                          "Failed to archive user command $command from \
-                           transaction pool: see $error" )
-              in
-              Ok () )
-            pool
-        in
-        () )
+        Deferred.unit )
 
 let add_genesis_accounts ~logger ~(runtime_config_opt : Runtime_config.t option)
     pool =


### PR DESCRIPTION
There was code meant to archive transactions in the transaction pool, that was not called anywhere.  Remove that dead code.

Closes #11370.