### PR TITLE
[mina-signer] - Add minimum fee for Party transactions

### DIFF
--- a/frontend/mina-signer/package-lock.json
+++ b/frontend/mina-signer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mina-signer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mina-signer",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^13.7.0",

--- a/frontend/mina-signer/package.json
+++ b/frontend/mina-signer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mina-signer",
   "description": "Node API for signing transactions on various networks for Mina Protocol",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "scripts": {
     "build": "tsc && cp src/client_sdk.bc.js dist/src && cp src/plonk_wasm.js dist/src && cp src/plonk_wasm_bg.wasm dist/src",
     "clean": "rm -rf dist",

--- a/frontend/mina-signer/src/MinaSigner.ts
+++ b/frontend/mina-signer/src/MinaSigner.ts
@@ -12,6 +12,7 @@ import type {
   StakeDelegation,
   Message,
   Party,
+  OtherParties,
   SignableData,
 } from "./TSTypes";
 
@@ -340,6 +341,14 @@ class Client {
    */
   public signParty(party: Party, privateKey: PrivateKey): Signed<Party> {
     const parties = JSON.stringify(party.parties.otherParties);
+    if (
+      party.feePayer.fee === undefined ||
+      party.feePayer.fee < this.getPartyMinimumFee(party.parties.otherParties)
+    ) {
+      throw `Fee must be greater than ${this.getPartyMinimumFee(
+        party.parties.otherParties
+      )}`;
+    }
     const memo = party.feePayer.memo ?? "";
     const fee = String(party.feePayer.fee);
     const nonce = String(party.feePayer.nonce);
@@ -423,6 +432,18 @@ class Client {
     } else {
       throw new Error(`Expected signable payload, got '${payload}'.`);
     }
+  }
+
+  /**
+   * Calculates the minimum fee of a party transaction. A fee for a party transaction is
+   * the sum of all parties plus the specified fee amount. If no fee is passed in, `0.001`
+   * is used (according to the Mina spec) by default.
+   * @param p A party object
+   * @param fee The fee per party amount
+   * @returns  The fee to be paid by the fee payer party
+   */
+  public getPartyMinimumFee(p: OtherParties, fee: number = 0.001) {
+    return p.reduce((accumulatedFee, _) => accumulatedFee + fee, 0);
   }
 }
 

--- a/frontend/mina-signer/src/TSTypes.ts
+++ b/frontend/mina-signer/src/TSTypes.ts
@@ -40,8 +40,16 @@ export type Payment = {
   readonly validUntil?: UInt32;
 };
 
+export type OtherParties = {
+  body: any;
+  authorization: any;
+}[];
+
 export type Party = {
-  readonly parties: any;
+  readonly parties: {
+    otherParties: OtherParties;
+  };
+
   readonly feePayer: {
     readonly feePayer: PublicKey;
     readonly fee: UInt64;

--- a/frontend/mina-signer/tests/party.test.ts
+++ b/frontend/mina-signer/tests/party.test.ts
@@ -8,7 +8,7 @@ import type { Party, Signed } from "../src/TSTypes";
  * TODO: When there is an example of how to do this in the SnarkyJS repo,
  * use that example instead.
  */
-let otherParties = {
+let mockedParties = {
   otherParties: [
     {
       body: {
@@ -111,7 +111,7 @@ describe("Party", () => {
     const keypair = client.genKeys();
     const parties = client.signParty(
       {
-        parties: otherParties,
+        parties: mockedParties,
         feePayer: {
           feePayer: keypair.publicKey,
           fee: "1",
@@ -129,7 +129,7 @@ describe("Party", () => {
     const keypair = client.genKeys();
     const parties = client.signTransaction(
       {
-        parties: otherParties,
+        parties: mockedParties,
         feePayer: {
           feePayer: keypair.publicKey,
           fee: "1",
@@ -141,5 +141,27 @@ describe("Party", () => {
     ) as Signed<Party>;
     expect(parties.data).toBeDefined();
     expect(parties.signature).toBeDefined();
+  });
+
+  it("should throw an error if no fee is passed to the feePayer", () => {
+    const keypair = client.genKeys();
+    expect(() => {
+      client.signParty(
+        {
+          parties: mockedParties,
+          // @ts-ignore - fee is not defined
+          feePayer: {
+            feePayer: keypair.publicKey,
+            nonce: "0",
+            memo: "test memo",
+          },
+        },
+        keypair.privateKey
+      );
+    }).toThrowError("Fee must be greater than 0.001");
+  });
+
+  it("should calculate a correct minimum fee", () => {
+    expect(client.getPartyMinimumFee(mockedParties.otherParties, 1)).toBe(1);
   });
 });


### PR DESCRIPTION
Adds a method on the MinaSigner Client class that gets the minimum fee for a parties transaction. The minimum fee for a parties transaction is defined as `0.001*numOfParties`, which is the default behavior of this new method. This method additionally adds an option for the developer to add their own fee amount per party.

Additionally, this PR adds a check for a valid fee amount when signing a parties transaction. If there is no fee available, an error is thrown. This is the same behavior as before, the only change is that we catch the error thrown from OCaml and give a more helpful message to the developer

Added unit tests to confirm the behavior

Closes #11566
