### PR TITLE
Check for dup shape in runtime library

### DIFF
--- a/src/lib/ppx_version/runtime/shapes.ml
+++ b/src/lib/ppx_version/runtime/shapes.ml
@@ -5,9 +5,6 @@ module Shape_tbl = Hashtbl.Make (Base.String)
 
 let shape_tbl : Bin_prot.Shape.t Shape_tbl.t = Shape_tbl.create ()
 
-let register path_to_type (shape : Bin_prot.Shape.t) =
-  Shape_tbl.add shape_tbl ~key:path_to_type ~data:shape
-
 let find path_to_type = Shape_tbl.find shape_tbl path_to_type
 
 let iteri ~f = Shape_tbl.iteri shape_tbl ~f
@@ -16,3 +13,20 @@ let equal_shapes shape1 shape2 =
   let canonical1 = Bin_prot.Shape.eval shape1 in
   let canonical2 = Bin_prot.Shape.eval shape2 in
   Bin_prot.Shape.Canonical.compare canonical1 canonical2 = 0
+
+let register path_to_type (shape : Bin_prot.Shape.t) =
+  match Shape_tbl.add shape_tbl ~key:path_to_type ~data:shape with
+  | `Ok ->
+      ()
+  | `Duplicate -> (
+      (* versioned types inside functors that are called more than
+         once will yield duplicates; OK if the shapes are the same
+      *)
+      match find path_to_type with
+      | Some shape' ->
+          if not (equal_shapes shape shape') then
+            failwithf "Different type shapes at path %s" path_to_type ()
+          else ()
+      | None ->
+          failwithf "Expected to find registered shape at path %s" path_to_type
+            () )

--- a/src/lib/ppx_version/versioned_module.ml
+++ b/src/lib/ppx_version/versioned_module.ml
@@ -619,27 +619,7 @@ let version_type ~version_option ~all_version_tagged ~top_version_tag
                   Core_kernel.sprintf "%s:%s.%s" __FILE__ __FUNCTION__
                     [%e estring ptype_name.txt]
                 in
-                match Ppx_version_runtime.Shapes.register path bin_shape_t with
-                | `Ok ->
-                    ()
-                | `Duplicate -> (
-                    (* versioned types inside functors that are called more than
-                       once will yield duplicates; OK if the shapes are the same
-                    *)
-                    match Ppx_version_runtime.Shapes.find path with
-                    | Some bin_shape_t' ->
-                        if
-                          not
-                            (Ppx_version_runtime.Shapes.equal_shapes bin_shape_t
-                               bin_shape_t' )
-                        then
-                          Core_kernel.failwithf
-                            "Different type shapes at path %s" path ()
-                        else ()
-                    | None ->
-                        Core_kernel.failwithf
-                          "Expected to find registered shape at path %s" path ()
-                    )]
+                Ppx_version_runtime.Shapes.register path bin_shape_t]
           else []
       | _ ->
           failwith "Expected single type declaration in structure item"


### PR DESCRIPTION
In `ppx_version`, instead of generating a duplicate registered shape check for every versioned type, do the check in the runtime library in the registration function. Benefit: less code to generate and compile.

Tested by building mina.exe.


