### PR TITLE
Add %%versioned_rpc to ppx_version

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2490,6 +2490,7 @@ module Hooks = struct
   module Rpcs = struct
     open Async
 
+    [%%versioned_rpc
     module Get_epoch_ledger = struct
       module Master = struct
         let name = "get_epoch_ledger"
@@ -2527,13 +2528,11 @@ module Hooks = struct
       module V2 = struct
         module T = struct
           type query = Mina_base.Ledger_hash.Stable.V1.t
-          [@@deriving bin_io, version { rpc }]
 
           type response =
             ( Mina_ledger.Sparse_ledger.Stable.V2.t
             , string )
             Core_kernel.Result.Stable.V1.t
-          [@@deriving bin_io, version { rpc }]
 
           let query_of_caller_model = Fn.id
 
@@ -2619,7 +2618,7 @@ module Hooks = struct
                    from $peer: $error" ) ;
             if Ivar.is_full ivar then [%log error] "Ivar.fill bug is here!" ;
             Ivar.fill ivar response )
-    end
+    end]
 
     open Network_peer.Rpc_intf
 

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -47,6 +47,7 @@ module Rpcs = struct
      types.
   *)
 
+  [%%versioned_rpc
   module Get_some_initial_peers = struct
     module Master = struct
       let name = "get_some_initial_peers"
@@ -84,10 +85,9 @@ module Rpcs = struct
 
     module V1 = struct
       module T = struct
-        type query = unit [@@deriving bin_io, version { rpc }]
+        type query = unit
 
         type response = Network_peer.Peer.Stable.V1.t list
-        [@@deriving bin_io, version { rpc }]
 
         let query_of_caller_model = Fn.id
 
@@ -109,8 +109,9 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
+  [%%versioned_rpc
   module Get_staged_ledger_aux_and_pending_coinbases_at_hash = struct
     module Master = struct
       let name = "get_staged_ledger_aux_and_pending_coinbases_at_hash"
@@ -158,7 +159,7 @@ module Rpcs = struct
 
     module V2 = struct
       module T = struct
-        type query = State_hash.Stable.V1.t [@@deriving bin_io, version { rpc }]
+        type query = State_hash.Stable.V1.t
 
         type response =
           ( Staged_ledger.Scan_state.Stable.V2.t
@@ -166,7 +167,6 @@ module Rpcs = struct
           * Pending_coinbase.Stable.V2.t
           * Mina_state.Protocol_state.Value.Stable.V2.t list )
           option
-        [@@deriving bin_io, version { rpc }]
 
         let query_of_caller_model = Fn.id
 
@@ -188,8 +188,9 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
+  [%%versioned_rpc
   module Answer_sync_ledger_query = struct
     module Master = struct
       let name = "answer_sync_ledger_query"
@@ -228,10 +229,10 @@ module Rpcs = struct
     module V2 = struct
       module T = struct
         type query = Ledger_hash.Stable.V1.t * Sync_ledger.Query.Stable.V1.t
-        [@@deriving bin_io, sexp, version { rpc }]
+        [@@deriving sexp]
 
         type response = Sync_ledger.Answer.Stable.V2.t Core.Or_error.Stable.V1.t
-        [@@deriving bin_io, sexp, version { rpc }]
+        [@@deriving sexp]
 
         let query_of_caller_model = Fn.id
 
@@ -253,8 +254,9 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
+  [%%versioned_rpc
   module Get_transition_chain = struct
     module Master = struct
       let name = "get_transition_chain"
@@ -292,11 +294,9 @@ module Rpcs = struct
 
     module V2 = struct
       module T = struct
-        type query = State_hash.Stable.V1.t list
-        [@@deriving bin_io, sexp, version { rpc }]
+        type query = State_hash.Stable.V1.t list [@@deriving sexp]
 
         type response = Mina_block.Stable.V2.t list option
-        [@@deriving bin_io, version { rpc }]
 
         let query_of_caller_model = Fn.id
 
@@ -318,8 +318,9 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
+  [%%versioned_rpc
   module Get_transition_chain_proof = struct
     module Master = struct
       let name = "get_transition_chain_proof"
@@ -357,12 +358,10 @@ module Rpcs = struct
 
     module V1 = struct
       module T = struct
-        type query = State_hash.Stable.V1.t
-        [@@deriving bin_io, sexp, version { rpc }]
+        type query = State_hash.Stable.V1.t [@@deriving sexp]
 
         type response =
           (State_hash.Stable.V1.t * State_body_hash.Stable.V1.t list) option
-        [@@deriving bin_io, version { rpc }]
 
         let query_of_caller_model = Fn.id
 
@@ -384,8 +383,9 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
+  [%%versioned_rpc
   module Get_transition_knowledge = struct
     module Master = struct
       let name = "Get_transition_knowledge"
@@ -423,10 +423,9 @@ module Rpcs = struct
 
     module V1 = struct
       module T = struct
-        type query = unit [@@deriving bin_io, sexp, version { rpc }]
+        type query = unit [@@deriving sexp]
 
         type response = State_hash.Stable.V1.t list
-        [@@deriving bin_io, version { rpc }]
 
         let query_of_caller_model = Fn.id
 
@@ -448,8 +447,9 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
+  [%%versioned_rpc
   module Get_ancestry = struct
     module Master = struct
       let name = "get_ancestry"
@@ -497,14 +497,13 @@ module Rpcs = struct
           ( Consensus.Data.Consensus_state.Value.Stable.V1.t
           , State_hash.Stable.V1.t )
           With_hash.Stable.V1.t
-        [@@deriving bin_io, sexp, version { rpc }]
+        [@@deriving sexp]
 
         type response =
           ( Mina_block.Stable.V2.t
           , State_body_hash.Stable.V1.t list * Mina_block.Stable.V2.t )
           Proof_carrying_data.Stable.V1.t
           option
-        [@@deriving bin_io, version { rpc }]
 
         let query_of_caller_model = Fn.id
 
@@ -526,8 +525,9 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
+  [%%versioned_rpc
   module Ban_notify = struct
     module Master = struct
       let name = "ban_notify"
@@ -565,10 +565,9 @@ module Rpcs = struct
 
     module V1 = struct
       module T = struct
-        type query = Core.Time.Stable.V1.t
-        [@@deriving bin_io, sexp, version { rpc }]
+        type query = Core.Time.Stable.V1.t [@@deriving sexp]
 
-        type response = unit [@@deriving bin_io, version { rpc }]
+        type response = unit
 
         let query_of_caller_model = Fn.id
 
@@ -590,8 +589,9 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
+  [%%versioned_rpc
   module Get_best_tip = struct
     module Master = struct
       let name = "get_best_tip"
@@ -632,14 +632,13 @@ module Rpcs = struct
 
     module V2 = struct
       module T = struct
-        type query = unit [@@deriving bin_io, sexp, version { rpc }]
+        type query = unit [@@deriving sexp]
 
         type response =
           ( Mina_block.Stable.V2.t
           , State_body_hash.Stable.V1.t list * Mina_block.Stable.V2.t )
           Proof_carrying_data.Stable.V1.t
           option
-        [@@deriving bin_io, version { rpc }]
 
         let query_of_caller_model = Fn.id
 
@@ -661,8 +660,9 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
+  [%%versioned_rpc
   module Get_node_status = struct
     module Node_status = struct
       [%%versioned
@@ -793,10 +793,9 @@ module Rpcs = struct
 
     module V2 = struct
       module T = struct
-        type query = unit [@@deriving bin_io, sexp, version { rpc }]
+        type query = unit [@@deriving sexp]
 
         type response = Node_status.Stable.V2.t Core_kernel.Or_error.Stable.V1.t
-        [@@deriving bin_io, version { rpc }]
 
         let query_of_caller_model = Fn.id
 
@@ -821,10 +820,9 @@ module Rpcs = struct
 
     module V1 = struct
       module T = struct
-        type query = unit [@@deriving bin_io, sexp, version { rpc }]
+        type query = unit [@@deriving sexp]
 
         type response = Node_status.Stable.V1.t Core_kernel.Or_error.Stable.V1.t
-        [@@deriving bin_io, version { rpc }]
 
         let query_of_caller_model = Fn.id
 
@@ -866,7 +864,7 @@ module Rpcs = struct
       include T'
       include Register (T')
     end
-  end
+  end]
 
   type ('query, 'response) rpc =
     | Get_some_initial_peers

--- a/src/lib/ppx_version/versioned_module.ml
+++ b/src/lib/ppx_version/versioned_module.ml
@@ -17,7 +17,7 @@ let with_versioned_json = "with_versioned_json"
 let no_toplevel_latest_type_str = "no_toplevel_latest_type"
 
 (* option to `deriving version' *)
-type version_option = No_version_option | Binable [@@deriving equal]
+type version_option = No_version_option | Binable | Rpc [@@deriving equal]
 
 let create_attr ~loc attr_name attr_payload =
   { attr_name; attr_payload; attr_loc = loc }
@@ -36,6 +36,8 @@ let rec add_deriving ~loc ~version_option attributes : attributes =
         [%expr version]
     | Binable ->
         [%expr version { binable }]
+    | Rpc ->
+        [%expr version { rpc }]
   in
   match attributes with
   | [] ->
@@ -46,6 +48,8 @@ let rec add_deriving ~loc ~version_option attributes : attributes =
             payload [ [%expr bin_io]; version_expr ]
         | Binable ->
             payload [ version_expr ]
+        | Rpc ->
+            payload [ [%expr bin_io]; version_expr ]
       in
       [ create_attr ~loc attr_name attr_payload ]
   | attr :: attributes -> (
@@ -77,6 +81,8 @@ let rec add_deriving ~loc ~version_option attributes : attributes =
                 true
             | Binable ->
                 false
+            | Rpc ->
+                true
           in
           let extra_payload_args =
             match (has_version, needs_bin_io) with
@@ -1092,6 +1098,136 @@ let version_module ~loc ~path:_ ~version_option modname modbody =
     Format.(fprintf err_formatter "%s@." (Printexc.get_backtrace ())) ;
     raise exn
 
+let convert_rpc_version (stri : structure_item) =
+  let register_shapes =
+    let (module Ast_builder) = Ast_builder.make stri.pstr_loc in
+    let open Ast_builder in
+    [%str
+      let (_ : _) =
+        let query_path =
+          Core_kernel.sprintf "%s:%s.%s" __FILE__ __FUNCTION__
+            [%e estring "query"]
+        in
+        Ppx_version_runtime.Shapes.register query_path bin_shape_query ;
+        let response_path =
+          Core_kernel.sprintf "%s:%s.%s" __FILE__ __FUNCTION__
+            [%e estring "response"]
+        in
+        Ppx_version_runtime.Shapes.register response_path bin_shape_response]
+  in
+  let add_derivers_to_types = function
+    | { pstr_desc = Pstr_type (rec_flag, [ ty_decl ]); pstr_loc }
+      when List.mem [ "query"; "response" ] ty_decl.ptype_name.txt
+             ~equal:String.equal ->
+        let ty_decl_with_attrs =
+          { ty_decl with
+            ptype_attributes =
+              add_deriving ~loc:ty_decl.ptype_loc ~version_option:Rpc
+                ty_decl.ptype_attributes
+          }
+        in
+        { pstr_desc = Pstr_type (rec_flag, [ ty_decl_with_attrs ]); pstr_loc }
+    | item ->
+        item
+  in
+  match stri.pstr_desc with
+  | Pstr_module ({ pmb_name; pmb_expr; _ } as mod_binding)
+    when Option.is_some pmb_name.txt
+         && Versioned_util.is_version_module (Option.value_exn pmb_name.txt)
+    -> (
+      match pmb_expr with
+      | { pmod_desc =
+            Pmod_structure
+              (( { pstr_desc =
+                     Pstr_module
+                       ( { pmb_name = { txt = Some "T"; _ }
+                         ; pmb_expr =
+                             { pmod_desc = Pmod_structure str_items; _ } as
+                             inner_mod_expr
+                         ; _
+                         } as inner_mod_binding )
+                 ; _
+                 } as inner_str_item )
+              :: other_mods )
+        ; _
+        } as mod_expr ->
+          (* query, response types in module T contained in Vn module *)
+          let str_items_with_derivers =
+            List.map str_items ~f:add_derivers_to_types
+          in
+          let pmb_expr_with_derivers =
+            { mod_expr with
+              pmod_desc =
+                Pmod_structure
+                  ( { inner_str_item with
+                      pstr_desc =
+                        Pstr_module
+                          { inner_mod_binding with
+                            pmb_expr =
+                              { inner_mod_expr with
+                                pmod_desc =
+                                  Pmod_structure
+                                    (str_items_with_derivers @ register_shapes)
+                              }
+                          }
+                    }
+                  :: other_mods )
+            }
+          in
+          { stri with
+            pstr_desc =
+              Pstr_module { mod_binding with pmb_expr = pmb_expr_with_derivers }
+          }
+      | _ ->
+          failwith "Expected structure in RPC version module" )
+  | _ ->
+      stri
+
+let check_rpc_versioned_module_numbers stris =
+  ignore
+    ( List.fold stris ~init:None ~f:(fun last_vn stri ->
+          match stri.pstr_desc with
+          | Pstr_module { pmb_name; _ }
+            when Option.is_some pmb_name.txt
+                 && Versioned_util.is_version_module
+                      (Option.value_exn pmb_name.txt) -> (
+              let current_vn =
+                Versioned_util.version_of_versioned_module_name
+                  (Option.value_exn pmb_name.txt)
+              in
+              match last_vn with
+              | None ->
+                  Some current_vn
+              | Some vn ->
+                  if current_vn = vn then
+                    Location.raise_errorf ~loc:stri.pstr_loc
+                      "Duplicate versions in versioned RPC modules" ;
+                  if current_vn > vn then
+                    Location.raise_errorf ~loc:stri.pstr_loc
+                      "Versioned RPC modules must be listed in decreasing order" ;
+                  Some current_vn )
+          | _ ->
+              last_vn )
+      : int option )
+
+let version_rpc_module ~loc ~path:_ rpc_name (rpc_body : structure_item list loc)
+    =
+  Printexc.record_backtrace true ;
+  try
+    check_rpc_versioned_module_numbers rpc_body.txt ;
+    let rpc_body_txt = List.map rpc_body.txt ~f:convert_rpc_version in
+    let open Ast_helper in
+    Str.include_ ~loc
+      (Incl.mk ~loc
+         (Ast_helper.Mod.structure ~loc
+            [ Str.module_ ~loc
+                (Mb.mk ~loc:rpc_body.loc (some_loc rpc_name)
+                   (Mod.structure ~loc:rpc_body.loc rpc_body_txt) )
+            ] ) )
+  with exn ->
+    Format.(fprintf err_formatter "%s@." (Printexc.get_backtrace ())) ;
+    raise exn
+
 (* code for module declarations in signatures
 
    - add deriving bin_io, version to list of deriving items for the type "t" in versioned modules
@@ -1396,6 +1532,11 @@ let () =
       declare "versioned_binable" Context.structure_item module_ast_pattern
         (version_module ~version_option:Binable))
   in
+  let module_extension_rpc =
+    Extension.(
+      declare "versioned_rpc" Context.structure_item module_ast_pattern
+        version_rpc_module)
+  in
   let module_decl_ast_pattern =
     Ast_pattern.(
       psig
@@ -1412,8 +1553,11 @@ let () =
   let module_rule_binable =
     Context_free.Rule.extension module_extension_binable
   in
+  let module_rule_rpc = Context_free.Rule.extension module_extension_rpc in
   let module_decl_rule = Context_free.Rule.extension module_decl_extension in
-  let rules = [ module_rule; module_rule_binable; module_decl_rule ] in
+  let rules =
+    [ module_rule; module_rule_binable; module_rule_rpc; module_decl_rule ]
+  in
   Driver.register_transformation "ppx_version/versioned_module" ~rules ;
   Ppxlib.Driver.add_arg "--no-toplevel-latest-type"
     (Caml.Arg.Unit (fun () -> no_toplevel_latest_type := true))

--- a/src/lib/ppx_version/versioned_type.ml
+++ b/src/lib/ppx_version/versioned_type.ml
@@ -264,15 +264,6 @@ module Deriving = struct
 
   let ocaml_builtin_type_constructors = [ "list"; "array"; "option"; "ref" ]
 
-  let is_version_module vn =
-    let len = String.length vn in
-    len > 1
-    && Char.equal vn.[0] 'V'
-    &&
-    let numeric_part = String.sub vn ~pos:1 ~len:(len - 1) in
-    String.for_all numeric_part ~f:Char.is_digit
-    && not (Int.equal (Char.get_digit_exn numeric_part.[0]) 0)
-
   (* true iff module_path is of form M. ... .Stable.Vn, where M is Core or Core_kernel, and n is integer *)
   let is_jane_street_stable_module module_path =
     let hd_elt = List.hd_exn module_path in
@@ -280,7 +271,7 @@ module Deriving = struct
     &&
     match List.rev module_path with
     | vn :: "Stable" :: _ ->
-        is_version_module vn
+        Versioned_util.is_version_module vn
     | vn :: label :: "Stable" :: "Time" :: _
       when List.mem [ "Span"; "With_utc_sexp" ] label ~equal:String.equal ->
         (* special cases, maybe improper module structure *)

--- a/src/lib/ppx_version/versioned_util.ml
+++ b/src/lib/ppx_version/versioned_util.ml
@@ -29,6 +29,14 @@ let diff_formatter =
   in
   Format.formatter_of_out_functions out_funs'
 
+let is_version_module name =
+  let len = String.length name in
+  len > 1
+  && Char.equal name.[0] 'V'
+  &&
+  let rest = String.sub name ~pos:1 ~len:(len - 1) in
+  (not @@ Char.equal rest.[0] '0') && String.for_all rest ~f:Char.is_digit
+
 let validate_module_version module_version loc =
   let len = String.length module_version in
   if not (Char.equal module_version.[0] 'V' && len > 1) then

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -42,6 +42,7 @@
    mina_compile_config
    mina_state
    transaction_protocol_state
+   ppx_version_runtime
  )
  (preprocess
   (pps

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -15,10 +15,11 @@ module Worker = struct
       include Work
     end
 
+    [%%versioned_rpc
     module Get_work = struct
       module V2 = struct
         module T = struct
-          type query = unit [@@deriving bin_io, version { rpc }]
+          type query = unit
 
           type response =
             ( ( Transaction_witness.Stable.V2.t
@@ -27,7 +28,6 @@ module Worker = struct
               Snark_work_lib.Work.Spec.Stable.V1.t
             * Public_key.Compressed.Stable.V1.t )
             option
-          [@@deriving bin_io, version { rpc }]
 
           let query_of_caller_model = Fn.id
 
@@ -45,8 +45,9 @@ module Worker = struct
       end
 
       module Latest = V2
-    end
+    end]
 
+    [%%versioned_rpc
     module Submit_work = struct
       module V2 = struct
         module T = struct
@@ -57,9 +58,8 @@ module Worker = struct
               Snark_work_lib.Work.Spec.Stable.V1.t
             , Ledger_proof.Stable.V2.t )
             Snark_work_lib.Work.Result.Stable.V1.t
-          [@@deriving bin_io, version { rpc }]
 
-          type response = unit [@@deriving bin_io, version { rpc }]
+          type response = unit
 
           let query_of_caller_model = Fn.id
 
@@ -75,7 +75,7 @@ module Worker = struct
       end
 
       module Latest = V2
-    end
+    end]
   end
 
   let command = command_from_rpcs (module Rpcs_versioned)


### PR DESCRIPTION
Add `%%versioned_rpc` to ppx_version library, for annotating versioned RPC modules.

When used with versioned RPCs:
- you no longer need to explicitly add `@@deriving bin_io, version { rpc }` to the query and response types
- there are checks that there are no duplicate versioned modules, and they're listed in decreasing order
- the shapes of the query and response types are registered

The ppx assumes that the versioned modules contain a module `T` as the first item, and that it contains the declarations for the query and response types. That's true for all the RPCs that exist in the codebase.

Applied this annotation to all the RPCs in `Mina_networking`, `Proof_of_stake`, and `Snark_worker` modules.

Verified that the shapes show up in the `internal dump-type-shapes` CLI command.

Closes #11523.