### PR TITLE
Fix bitrot in benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ web:
 ## Benchmarks
 
 benchmarks: ocaml_checks
-	dune build src/app/benchmarks/main.exe
+	dune build src/app/benchmarks/benchmarks.exe
 
 ########################################
 # Coverage testing and output

--- a/scripts/benchmarks.sh
+++ b/scripts/benchmarks.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # runs inline benchmarks
-# requires that app/benchmarks/main.exe is built
+# requires that app/benchmarks/benchmarks.exe is built
 # run with -help to see available flags
 
 export BENCHMARKS_RUNNER=TRUE
@@ -9,7 +9,7 @@ export X_LIBRARY_INLINING=true
 
 GIT_ROOT="`git rev-parse --show-toplevel`"
 
-BENCHMARK_EXE=$GIT_ROOT/_build/default/src/app/benchmarks/main.exe
+BENCHMARK_EXE=$GIT_ROOT/_build/default/src/app/benchmarks/benchmarks.exe
 
 if [ ! -f "$BENCHMARK_EXE" ]; then
     echo "Please run 'make benchmarks' before running this script";

--- a/src/app/benchmarks/benchmarks.ml
+++ b/src/app/benchmarks/benchmarks.ml
@@ -10,7 +10,7 @@ open Core_kernel
 let available_libraries = ["vrf_lib_tests"; "mina_base"]
 
 let run_benchmarks_in_lib libname =
-  Core.printf "Running inline tests in library \"%s\"\n%!" libname ;
+  printf "Running inline tests in library \"%s\"\n%!" libname ;
   Inline_benchmarks_public.Runner.main ~libname
 
 let () =

--- a/src/app/benchmarks/dune
+++ b/src/app/benchmarks/dune
@@ -1,9 +1,10 @@
+(include ../../dune.flags.inc)
+
 (executable
- (name main)
+ (name benchmarks)
  (public_name main)
  (libraries core_bench.inline_benchmarks vrf_lib_tests mina_base core_kernel core base)
- ; the -w list here should be the same as in src/dune
- (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version))
+ (link_flags -linkall)
  (modes native))

--- a/src/app/benchmarks/dune-project
+++ b/src/app/benchmarks/dune-project
@@ -1,3 +1,3 @@
-(lang dune 2.7)
+(lang dune 3.3)
 (name benchmarks)
 (implicit_transitive_deps false)


### PR DESCRIPTION
Allow `make benchmarks` to work again.

Rename executable (`main.exe` isn't suggestive of purpose).

Tested by running `scripts/benchmarks.sh`.