### PR TITLE
Fix Result module in register_event parser

### DIFF
--- a/src/lib/ppx_register_event/register_event.ml
+++ b/src/lib/ppx_register_event/register_event.ml
@@ -168,11 +168,12 @@ let generate_loggers_and_parsers ~loc:_ ~path ty_ext msg_opt =
                       ~f:(fun { pld_name = { txt = name; _ }; pld_type; _ } acc ->
                         Ppx_deriving_yojson.wrap_runtime
                         @@ [%expr
+                             let module Result = Core_kernel.Result in
                              match
                                Core_kernel.Map.find args_list [%e estring name]
                              with
                              | Some [%p pvar name] ->
-                                 Core_kernel.Result.bind
+                                 Result.bind
                                    ([%e
                                       of_yojson
                                         ~path:(split_path @ [ ctor; name ])
@@ -180,7 +181,7 @@ let generate_loggers_and_parsers ~loc:_ ~path ty_ext msg_opt =
                                       [%e evar name] )
                                    ~f:(fun [%p pvar name] -> [%e acc])
                              | None ->
-                                 Core_kernel.Result.fail
+                                 Result.fail
                                    [%e
                                      estring
                                        (sprintf "%s, parse: missing argument %s"


### PR DESCRIPTION
The JSON parser generated by `register_event` could generate code in the wrong `Result` monad.

In one instance, the code generated was:
```
function
 | `String time -> Ok (Time.Span.of_string time)
 | _ -> Error "Snark_worker.Functor: Could not parse timespan"
```
The constructors `Ok` and `Error` build an instance of `Core_kernel.Result.t`, the stdlib's `result` type.

In another instance:
```
function
| `String x -> Result.Ok x
| _ -> Result.Error "src/lib/snark_worker/tester.ml.Test_type.x"
```
where  the opened module `Ppx_deriving_yojson_runtime` captures `Result`.

Because that code is used in a monadic fold over the `Core_kernel.Result` monad, we always want that monad. So generate: `let module Result = Core_kernel.Result` to avoid the capture.

Fixes an issue seen by @deepthiskumar when adding a new event.




