### PR TITLE
disable dirtywhen and adding timeout

### DIFF
--- a/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
+++ b/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
@@ -22,16 +22,17 @@ let buildTestCmd : Text -> Text -> Natural -> Size -> Command.Type = \(profile :
       key = "fuzzy-zkapp-unit-test-${profile}",
       target = cmd_target,
       docker = None Docker.Type,
-      artifact_paths = [ S.contains "core_dumps/*" ]
+      artifact_paths = [ S.contains "core_dumps/*" ],
+      timeout_in_minutes = 120
     }
 
 in
 
 Pipeline.build
   Pipeline.Config::{
-    spec = 
+    spec =
       let unitDirtyWhen = [
-        S.strictlyStart (S.contains "src/lib"),          
+        S.strictlyStart (S.contains "src/lib"),
         S.strictlyStart (S.contains "src/lib/transaction_snark/test/zkapp_fuzzy"),
         S.exactly "buildkite/src/Jobs/Test/FuzzyZkappTest" "dhall",
         S.exactly "buildkite/scripts/fuzzy-zkapp-test" "sh"
@@ -40,7 +41,7 @@ Pipeline.build
       in
 
       JobSpec::{
-        dirtyWhen = unitDirtyWhen,
+        (* dirtyWhen = unitDirtyWhen, *)
         path = "Test",
         name = "FuzzyZkappTest"
       },

--- a/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
+++ b/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
@@ -22,8 +22,7 @@ let buildTestCmd : Text -> Text -> Natural -> Size -> Command.Type = \(profile :
       key = "fuzzy-zkapp-unit-test-${profile}",
       target = cmd_target,
       docker = None Docker.Type,
-      artifact_paths = [ S.contains "core_dumps/*" ],
-      timeout_in_minutes = 120
+      artifact_paths = [ S.contains "core_dumps/*" ]
     }
 
 in
@@ -41,7 +40,7 @@ Pipeline.build
       in
 
       JobSpec::{
-        (* dirtyWhen = unitDirtyWhen, *)
+        dirtyWhen = [] : List S.Type,
         path = "Test",
         name = "FuzzyZkappTest"
       },


### PR DESCRIPTION

Explain your changes:
* adding timeout parameter and disable dirtyWhen method.

Explain how you tested your changes:
* this will be tested in our integration pipeline


Checklist:
The proposal is to create a new FuzzyZkappTest.dhall file with different settings:

    Overwrite Timeout variable to a longer period
    Parametrize how many times it will run
    Check if environmental variable NIGHTLY=true is set and decide to run if True
    Disable the DirtyWhen method
    After this changes, we will create a new scheduled job using the develop Branch, instead of the existing compatible Branch.


* Closes #0000
