### PR TITLE
Log snark work failures in the daemon, expose them in the test executive

### DIFF
--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -437,6 +437,15 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
                   Perf_histograms.add_span ~name:"snark_worker_transition_time"
                     total ) ;
           Deferred.return @@ Mina_lib.add_work coda work )
+    ; implement Snark_worker.Rpcs_versioned.Failed_to_generate_snark.Latest.rpc
+        (fun
+          ()
+          ((_work_spec, _prover_pk) :
+            Snark_worker.Work.Spec.t * Signature_lib.Public_key.Compressed.t )
+        ->
+          [%str_log error] Snark_worker.Generating_snark_work_failed ;
+          Mina_metrics.(Counter.inc_one Snark_work.snark_work_failed_rpc) ;
+          Deferred.unit )
     ]
   in
   let create_graphql_server ~bind_to_address ~schema ~server_description port =

--- a/src/lib/integration_test_lib/dune
+++ b/src/lib/integration_test_lib/dune
@@ -46,4 +46,5 @@
    data_hash_lib
    integers
    transition_handler
+   snark_worker
 ))

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -329,6 +329,24 @@ module Gossip = struct
   end
 end
 
+module Snark_work_failed = struct
+  type t = unit [@@deriving yojson]
+
+  let name = "Transactions_gossip"
+
+  let id = Snark_worker.generating_snark_work_failed_structured_events_id
+
+  let parse_func message =
+    let open Or_error.Let_syntax in
+    match%bind parse id message with
+    | Snark_worker.Generating_snark_work_failed ->
+        Ok ()
+    | _ ->
+        bad_parse
+
+  let parse = From_daemon_log (id, parse_func)
+end
+
 type 'a t =
   | Log_error : Log_error.t t
   | Node_initialization : Node_initialization.t t
@@ -340,6 +358,7 @@ type 'a t =
   | Block_gossip : Gossip.Block.t t
   | Snark_work_gossip : Gossip.Snark_work.t t
   | Transactions_gossip : Gossip.Transactions.t t
+  | Snark_work_failed : Snark_work_failed.t t
 
 type existential = Event_type : 'a t -> existential
 
@@ -362,6 +381,8 @@ let existential_to_string = function
       "Snark_work_gossip"
   | Event_type Transactions_gossip ->
       "Transactions_gossip"
+  | Event_type Snark_work_failed ->
+      "Snark_work_failed"
 
 let to_string e = existential_to_string (Event_type e)
 
@@ -384,6 +405,8 @@ let existential_of_string_exn = function
       Event_type Snark_work_gossip
   | "Transactions_gossip" ->
       Event_type Transactions_gossip
+  | "Snark_work_failed" ->
+      Event_type Snark_work_failed
   | _ ->
       failwith "invalid event type string"
 
@@ -424,6 +447,7 @@ let all_event_types =
   ; Event_type Block_gossip
   ; Event_type Snark_work_gossip
   ; Event_type Transactions_gossip
+  ; Event_type Snark_work_failed
   ]
 
 let event_type_module : type a. a t -> (module Event_type_intf with type t = a)
@@ -446,6 +470,8 @@ let event_type_module : type a. a t -> (module Event_type_intf with type t = a)
       (module Gossip.Snark_work)
   | Transactions_gossip ->
       (module Gossip.Transactions)
+  | Snark_work_failed ->
+      (module Snark_work_failed)
 
 let event_to_yojson event =
   let (Event (t, d)) = event in

--- a/src/lib/integration_test_lib/event_type.mli
+++ b/src/lib/integration_test_lib/event_type.mli
@@ -115,6 +115,12 @@ module Gossip : sig
   end
 end
 
+module Snark_work_failed : sig
+  type t = unit
+
+  include Event_type_intf with type t := t
+end
+
 type 'a t =
   | Log_error : Log_error.t t
   | Node_initialization : Node_initialization.t t
@@ -126,6 +132,7 @@ type 'a t =
   | Block_gossip : Gossip.Block.t t
   | Snark_work_gossip : Gossip.Snark_work.t t
   | Transactions_gossip : Gossip.Transactions.t t
+  | Snark_work_failed : Snark_work_failed.t t
 
 val to_string : 'a t -> string
 

--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -320,6 +320,8 @@ module Snark_work : sig
 
   val snark_work_timed_out_rpc : Counter.t
 
+  val snark_work_failed_rpc : Counter.t
+
   val snark_pool_size : Gauge.t
 
   val pending_snark_work : Gauge.t

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -332,6 +332,8 @@ module Snark_work = struct
 
   let snark_work_timed_out_rpc : Counter.t = ()
 
+  let snark_work_failed_rpc : Counter.t = ()
+
   let snark_pool_size : Gauge.t = ()
 
   let pending_snark_work : Gauge.t = ()

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -1019,6 +1019,10 @@ module Snark_work = struct
     in
     Counter.v "snark_work_timed_out_rpc" ~help ~namespace ~subsystem
 
+  let snark_work_failed_rpc : Counter.t =
+    let help = "# of snark work failures reported by snark workers" in
+    Counter.v "snark_work_failed_rpc" ~help ~namespace ~subsystem
+
   let snark_pool_size : Gauge.t =
     let help = "# of completed snark work bundles in the snark pool" in
     Gauge.v "snark_pool_size" ~help ~namespace ~subsystem

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -9,6 +9,7 @@
    sexplib0
    async_kernel
    base
+   base.caml
    async
    core
    core_kernel.hash_heap

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -107,6 +107,19 @@ module type Rpcs_versioned_S = sig
 
     module Latest = V2
   end
+
+  module Failed_to_generate_snark : sig
+    module V2 : sig
+      type query = Work.Spec.t * Signature_lib.Public_key.Compressed.t
+      [@@deriving bin_io]
+
+      type response = unit [@@deriving bin_io]
+
+      val rpc : (query, response) Rpc.Rpc.t
+    end
+
+    module Latest = V2
+  end
 end
 
 (* result of Functor.Make *)
@@ -125,6 +138,12 @@ module type S0 = sig
     module Submit_work :
       Rpc_master
         with type Master.T.query = Work.Result.t
+         and type Master.T.response = unit
+
+    module Failed_to_generate_snark :
+      Rpc_master
+        with type Master.T.query =
+          Work.Spec.t * Signature_lib.Public_key.Compressed.t
          and type Master.T.response = unit
   end
 

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -59,4 +59,24 @@ module Make (Inputs : Intf.Inputs_intf) = struct
     include Master.T
     include Versioned_rpc.Both_convert.Plain.Make (Master)
   end
+
+  module Failed_to_generate_snark = struct
+    module Master = struct
+      let name = "failed_to_generate_snark"
+
+      module T = struct
+        type query =
+          (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t Work.Spec.t
+          * Public_key.Compressed.t
+
+        type response = unit
+      end
+
+      module Caller = T
+      module Callee = T
+    end
+
+    include Master.T
+    include Versioned_rpc.Both_convert.Plain.Make (Master)
+  end
 end

--- a/src/lib/snark_worker/snark_worker.mli
+++ b/src/lib/snark_worker/snark_worker.mli
@@ -1,3 +1,6 @@
+type Structured_log_events.t += Generating_snark_work_failed
+  [@@deriving register_event]
+
 module Prod = Prod
 
 module Intf : module type of Intf


### PR DESCRIPTION
This PR
* adds an RPC for snark workers to inform the daemon that snark work has failed
* adds a structured log message that the daemon emits when it's informed about a snark failure
* adds a metric for the number of snark work failures seen
* consumes the structured log message in the integration test library to generate an event
* logs when snark work failures occur in the zkApps integration test

This will help us to determine whether snark work failures are the cause of failures in the zkApp integration test, as well as giving us better visibility into the reliability of snark workers and the existence of invalid work statements.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
