### PR TITLE
[Pickles] Allow side-loaded proofs to use different wrap domains

### DIFF
--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -3521,235 +3521,346 @@ let%test_module "test uncorrelated deferred b" =
       with _ -> true
   end )
 
-(*
-let%test_module "test" =
+let%test_module "domain too small" =
   ( module struct
-    let () =
-      Tock.Keypair.set_urs_info
-        [On_disk {directory= "/tmp/"; should_write= true}]
-
-    let () =
-      Tick.Keypair.set_urs_info
-        [On_disk {directory= "/tmp/"; should_write= true}]
-
     open Impls.Step
 
-    module Txn_snark = struct
-      module Statement = struct
-        type t = Field.t
+    module Statement = struct
+      type t = Field.t
 
-        let to_field_elements x = [|x|]
+      let to_field_elements x = [| x |]
 
-        module Constant = struct
-          type t = Field.Constant.t [@@deriving bin_io]
+      module Constant = struct
+        type t = Field.Constant.t [@@deriving bin_io]
 
-          let to_field_elements x = [|x|]
-        end
+        let to_field_elements x = [| x |]
       end
-
-      (* A snark proving one knows a preimage of a hash *)
-      module Know_preimage = struct
-        module Statement = Statement
-
-        type _ Snarky_backendless.Request.t +=
-          | Preimage : Field.Constant.t Snarky_backendless.Request.t
-
-        let hash_checked x =
-          let open Step_main_inputs in
-          let s = Sponge.create sponge_params in
-          Sponge.absorb s (`Field x) ;
-          Sponge.squeeze_field s
-
-        let hash x =
-          let open Tick_field_sponge in
-          let s = Field.create params in
-          Field.absorb s x ; Field.squeeze s
-
-        let tag, _, p, Provers.[prove; _] =
-          compile
-            ~typ:Field.typ
-            ~return_typ:Typ.unit
-            ~branches:(module Nat.N2) (* Should be able to set to 1 *)
-            ~max_proofs_verified:
-              (module Nat.N2) (* TODO: Should be able to set this to 0 *)
-            ~name:"preimage"
-            ~choices:(fun ~self ->
-              (* TODO: Make it possible to have a system that doesn't use its "self" *)
-              [ { prevs= []
-                ; main=
-                    (fun [] s ->
-                       dummy_constraints () ;
-                      let x = exists ~request:(fun () -> Preimage) Field.typ in
-                      Field.Assert.equal s (hash_checked x) ;
-                      [] ) }
-                (* TODO: Shouldn't have to have this dummy *)
-              ; { prevs= [self; self]
-                ; main=
-                    (fun [_; _] s ->
-                       dummy_constraints () ;
-                       (* Unsatisfiable. *)
-                      Field.(Assert.equal s (s + one)) ;
-                      [Boolean.true_; Boolean.true_] ) } ] )
-
-        let prove ~preimage =
-          let h = hash preimage in
-          ( h
-          , prove [] h ~handler:(fun (With {request; respond}) ->
-                match request with
-                | Preimage ->
-                    respond (Provide preimage)
-                | _ ->
-                    unhandled ) )
-
-        module Proof = (val p)
-
-        let side_loaded_vk = Side_loaded.Verification_key.of_compiled tag
-      end
-
-      let side_loaded =
-        Side_loaded.create
-          ~max_proofs_verified:(module Nat.N2)
-          ~name:"side-loaded"
-          ~value_to_field_elements:Statement.to_field_elements
-          ~var_to_field_elements:Statement.to_field_elements ~typ:Field.typ
-
-      let tag, _, p, Provers.[base; preimage_base; merge] =
-        compile
-          ~typ:Field.typ
-          ~return_typ:Typ.unit
-          ~branches:(module Nat.N3)
-          ~max_proofs_verified:(module Nat.N2)
-          ~name:"txn-snark"
-          ~choices:(fun ~self ->
-            [ { prevs= []
-              ; main=
-                  (fun [] x ->
-                    let t = (Field.is_square x :> Field.t) in
-                    for i = 0 to 10_000 do
-                      assert_r1cs t t t
-                    done ;
-                    [] ) }
-            ; { prevs= [side_loaded]
-              ; main=
-                  (fun [hash] x ->
-                    Side_loaded.in_circuit side_loaded
-                      (exists Side_loaded_verification_key.typ
-                         ~compute:(fun () -> Know_preimage.side_loaded_vk)) ;
-                    Field.Assert.equal hash x ;
-                    [Boolean.true_] ) }
-            ; { prevs= [self; self]
-              ; main=
-                  (fun [l; r] res ->
-                    assert_r1cs l r res ;
-                    [Boolean.true_; Boolean.true_] ) } ] )
-
-      module Proof = (val p)
     end
 
-    let t_proof =
-      let preimage = Field.Constant.of_int 10 in
-(*       let base1 = preimage in *)
-      let base1, preimage_proof = Txn_snark.Know_preimage.prove ~preimage in
-      let base2 = Field.Constant.of_int 9 in
-      let base12 = Field.Constant.(base1 * base2) in
-(*       let t1 = Common.time "t1" (fun () -> Txn_snark.base [] base1) in *)
-      let t1 =
-        Common.time "t1" (fun () ->
-            Side_loaded.in_prover Txn_snark.side_loaded
-              Txn_snark.Know_preimage.side_loaded_vk ;
-            Txn_snark.preimage_base [(base1, preimage_proof)] base1 )
-      in
-      let module M = struct
-        type t = Field.Constant.t * Txn_snark.Proof.t [@@deriving bin_io]
-      end in
-      Common.time "verif" (fun () ->
-          assert (
-            Txn_snark.Proof.verify (List.init 2 ~f:(fun _ -> (base1, t1))) ) ) ;
-      Common.time "verif" (fun () ->
-          assert (
-            Txn_snark.Proof.verify (List.init 4 ~f:(fun _ -> (base1, t1))) ) ) ;
-      Common.time "verif" (fun () ->
-          assert (
-            Txn_snark.Proof.verify (List.init 8 ~f:(fun _ -> (base1, t1))) ) ) ;
-      let t2 = Common.time "t2" (fun () -> Txn_snark.base [] base2) in
-      assert (Txn_snark.Proof.verify [(base1, t1); (base2, t2)]) ;
-      (* Need two separate booleans.
-         Should carry around prev should verify and self should verify *)
-      let t12 =
-        Common.time "t12" (fun () ->
-            Txn_snark.merge [(base1, t1); (base2, t2)] base12 )
-      in
-      assert (Txn_snark.Proof.verify [(base1, t1); (base2, t2); (base12, t12)]) ;
-      Common.time "verify" (fun () ->
-          assert (
-            Verify.verify_heterogenous
-              [ T
-                  ( (module Nat.N2)
-                  , (module Txn_snark.Know_preimage.Statement.Constant)
-                  , Lazy.force Txn_snark.Know_preimage.Proof.verification_key
-                  , base1
-                  , preimage_proof )
-              ; T
-                  ( (module Nat.N2)
-                  , (module Txn_snark.Statement.Constant)
-                  , Lazy.force Txn_snark.Proof.verification_key
-                  , base1
-                  , t1 )
-              ; T
-                  ( (module Nat.N2)
-                  , (module Txn_snark.Statement.Constant)
-                  , Lazy.force Txn_snark.Proof.verification_key
-                  , base2
-                  , t2 )
-              ; T
-                  ( (module Nat.N2)
-                  , (module Txn_snark.Statement.Constant)
-                  , Lazy.force Txn_snark.Proof.verification_key
-                  , base12
-                  , t12 ) ] ) ) ;
-      (base12, t12)
+    (* Currently, a circuit must have at least 1 of every type of constraint. *)
+    let dummy_constraints () =
+      Impl.(
+        let x = exists Field.typ ~compute:(fun () -> Field.Constant.of_int 3) in
+        let g =
+          exists Step_main_inputs.Inner_curve.typ ~compute:(fun _ ->
+              Tick.Inner_curve.(to_affine_exn one) )
+        in
+        ignore
+          ( SC.to_field_checked'
+              (module Impl)
+              ~num_bits:16
+              (Kimchi_backend_common.Scalar_challenge.create x)
+            : Field.t * Field.t * Field.t ) ;
+        ignore
+          ( Step_main_inputs.Ops.scale_fast g ~num_bits:5 (Shifted_value x)
+            : Step_main_inputs.Inner_curve.t ) ;
+        ignore
+          ( Step_main_inputs.Ops.scale_fast g ~num_bits:5 (Shifted_value x)
+            : Step_main_inputs.Inner_curve.t ) ;
+        ignore
+          ( Step_verifier.Scalar_challenge.endo g ~num_bits:4
+              (Kimchi_backend_common.Scalar_challenge.create x)
+            : Field.t * Field.t ))
 
-    module Blockchain_snark = struct
-      module Statement = Txn_snark.Statement
+    module No_recursion = struct
+      module Statement = Statement
 
-      let tag, _, p, Provers.[step] =
+      let tag, _, p, Provers.[ step ] =
         Common.time "compile" (fun () ->
-            compile
-              ~return_typ:(Input Field.typ)
+            compile_promise () ~public_input:(Input Field.typ)
+              ~auxiliary_typ:Typ.unit
+              ~branches:(module Nat.N1)
+              ~max_proofs_verified:(module Nat.N0)
+              ~name:"blockchain-snark"
+              ~constraint_constants:
+                (* Dummy values *)
+                { sub_windows_per_window = 0
+                ; ledger_depth = 0
+                ; work_delay = 0
+                ; block_window_duration_ms = 0
+                ; transaction_capacity = Log_2 0
+                ; pending_coinbase_depth = 0
+                ; coinbase_amount = Unsigned.UInt64.of_int 0
+                ; supercharged_coinbase_factor = 0
+                ; account_creation_fee = Unsigned.UInt64.of_int 0
+                ; fork = None
+                }
+              ~choices:(fun ~self ->
+                [ { identifier = "main"
+                  ; prevs = []
+                  ; uses_lookup = false
+                  ; main =
+                      (fun { public_input = self } ->
+                        dummy_constraints () ;
+                        Field.Assert.equal self Field.zero ;
+                        { previous_proof_statements = []
+                        ; public_output = ()
+                        ; auxiliary_output = ()
+                        } )
+                  }
+                ] ) )
+
+      module Proof = (val p)
+
+      let example =
+        let (), (), b0 =
+          Common.time "b0" (fun () ->
+              Promise.block_on_async_exn (fun () -> step Field.Constant.zero) )
+        in
+        assert (
+          Promise.block_on_async_exn (fun () ->
+              Proof.verify_promise [ (Field.Constant.zero, b0) ] ) ) ;
+        (Field.Constant.zero, b0)
+
+      let example_input, example_proof = example
+    end
+
+    module Fake_1_recursion = struct
+      module Statement = Statement
+
+      let tag, _, p, Provers.[ step ] =
+        Common.time "compile" (fun () ->
+            compile_promise () ~public_input:(Input Field.typ)
+              ~auxiliary_typ:Typ.unit
+              ~branches:(module Nat.N1)
+              ~max_proofs_verified:(module Nat.N1)
+              ~name:"blockchain-snark"
+              ~constraint_constants:
+                (* Dummy values *)
+                { sub_windows_per_window = 0
+                ; ledger_depth = 0
+                ; work_delay = 0
+                ; block_window_duration_ms = 0
+                ; transaction_capacity = Log_2 0
+                ; pending_coinbase_depth = 0
+                ; coinbase_amount = Unsigned.UInt64.of_int 0
+                ; supercharged_coinbase_factor = 0
+                ; account_creation_fee = Unsigned.UInt64.of_int 0
+                ; fork = None
+                }
+              ~choices:(fun ~self ->
+                [ { identifier = "main"
+                  ; prevs = []
+                  ; uses_lookup = false
+                  ; main =
+                      (fun { public_input = self } ->
+                        dummy_constraints () ;
+                        Field.Assert.equal self Field.zero ;
+                        { previous_proof_statements = []
+                        ; public_output = ()
+                        ; auxiliary_output = ()
+                        } )
+                  }
+                ] ) )
+
+      module Proof = (val p)
+
+      let example =
+        let (), (), b0 =
+          Common.time "b0" (fun () ->
+              Promise.block_on_async_exn (fun () -> step Field.Constant.zero) )
+        in
+        assert (
+          Promise.block_on_async_exn (fun () ->
+              Proof.verify_promise [ (Field.Constant.zero, b0) ] ) ) ;
+        (Field.Constant.zero, b0)
+
+      let example_input, example_proof = example
+    end
+
+    module Fake_2_recursion = struct
+      module Statement = Statement
+
+      let tag, _, p, Provers.[ step ] =
+        Common.time "compile" (fun () ->
+            compile_promise () ~public_input:(Input Field.typ)
+              ~auxiliary_typ:Typ.unit
               ~branches:(module Nat.N1)
               ~max_proofs_verified:(module Nat.N2)
               ~name:"blockchain-snark"
+              ~constraint_constants:
+                (* Dummy values *)
+                { sub_windows_per_window = 0
+                ; ledger_depth = 0
+                ; work_delay = 0
+                ; block_window_duration_ms = 0
+                ; transaction_capacity = Log_2 0
+                ; pending_coinbase_depth = 0
+                ; coinbase_amount = Unsigned.UInt64.of_int 0
+                ; supercharged_coinbase_factor = 0
+                ; account_creation_fee = Unsigned.UInt64.of_int 0
+                ; fork = None
+                }
               ~choices:(fun ~self ->
-                [ { prevs= [self; Txn_snark.tag]
-                  ; main=
-                      (fun [prev; txn_snark] self ->
-                        let is_base_case = Field.equal Field.zero self in
-                        let proof_must_verify = Boolean.not is_base_case in
-                        Boolean.Assert.any
-                          [Field.(equal (one + prev) self); is_base_case] ;
-                        [proof_must_verify; proof_must_verify] ) } ] ) )
+                [ { identifier = "main"
+                  ; prevs = []
+                  ; uses_lookup = false
+                  ; main =
+                      (fun { public_input = self } ->
+                        dummy_constraints () ;
+                        Field.Assert.equal self Field.zero ;
+                        { previous_proof_statements = []
+                        ; public_output = ()
+                        ; auxiliary_output = ()
+                        } )
+                  }
+                ] ) )
 
       module Proof = (val p)
+
+      let example =
+        let (), (), b0 =
+          Common.time "b0" (fun () ->
+              Promise.block_on_async_exn (fun () -> step Field.Constant.zero) )
+        in
+        assert (
+          Promise.block_on_async_exn (fun () ->
+              Proof.verify_promise [ (Field.Constant.zero, b0) ] ) ) ;
+        (Field.Constant.zero, b0)
+
+      let example_input, example_proof = example
     end
 
-    let xs =
-      let s_neg_one = Field.Constant.(negate one) in
-      let b_neg_one : (Nat.N2.n, Nat.N2.n) Proof0.t =
-        Proof0.dummy Nat.N2.n Nat.N2.n Nat.N2.n
-      in
-      let b0 =
-        Common.time "b0" (fun () ->
-            Blockchain_snark.step
-              [(s_neg_one, b_neg_one); t_proof]
-              Field.Constant.zero )
-      in
-      let b1 =
-        Common.time "b1" (fun () ->
-            Blockchain_snark.step
-              [(Field.Constant.zero, b0); t_proof]
-              Field.Constant.one )
-      in
-      [(Field.Constant.zero, b0); (Field.Constant.one, b1)]
+    module Simple_chain = struct
+      module Statement = Statement
 
-    let%test_unit "verify" = assert (Blockchain_snark.Proof.verify xs)
-  end ) *)
+      type _ Snarky_backendless.Request.t +=
+        | Prev_input : Field.Constant.t Snarky_backendless.Request.t
+        | Proof : Side_loaded.Proof.t Snarky_backendless.Request.t
+        | Verifier_index :
+            Side_loaded.Verification_key.t Snarky_backendless.Request.t
+
+      let handler (prev_input : Field.Constant.t) (proof : _ Proof.t)
+          (verifier_index : Side_loaded.Verification_key.t)
+          (Snarky_backendless.Request.With { request; respond }) =
+        match request with
+        | Prev_input ->
+            respond (Provide prev_input)
+        | Proof ->
+            respond (Provide proof)
+        | Verifier_index ->
+            respond (Provide verifier_index)
+        | _ ->
+            respond Unhandled
+
+      let side_loaded_tag =
+        Side_loaded.create ~name:"foo"
+          ~max_proofs_verified:(Nat.Add.create Nat.N2.n) ~uses_lookup:No
+          ~typ:Field.typ
+
+      let tag, _, p, Provers.[ step ] =
+        Common.time "compile" (fun () ->
+            compile_promise () ~public_input:(Input Field.typ)
+              ~auxiliary_typ:Typ.unit
+              ~branches:(module Nat.N1)
+              ~max_proofs_verified:(module Nat.N1)
+              ~name:"blockchain-snark"
+              ~constraint_constants:
+                (* Dummy values *)
+                { sub_windows_per_window = 0
+                ; ledger_depth = 0
+                ; work_delay = 0
+                ; block_window_duration_ms = 0
+                ; transaction_capacity = Log_2 0
+                ; pending_coinbase_depth = 0
+                ; coinbase_amount = Unsigned.UInt64.of_int 0
+                ; supercharged_coinbase_factor = 0
+                ; account_creation_fee = Unsigned.UInt64.of_int 0
+                ; fork = None
+                }
+              ~choices:(fun ~self ->
+                [ { identifier = "main"
+                  ; prevs = [ side_loaded_tag ]
+                  ; uses_lookup = false
+                  ; main =
+                      (fun { public_input = self } ->
+                        let prev =
+                          exists Field.typ ~request:(fun () -> Prev_input)
+                        in
+                        let proof =
+                          exists (Typ.Internal.ref ()) ~request:(fun () ->
+                              Proof )
+                        in
+                        let vk =
+                          exists (Typ.Internal.ref ()) ~request:(fun () ->
+                              Verifier_index )
+                        in
+                        as_prover (fun () ->
+                            let vk = As_prover.Ref.get vk in
+                            Side_loaded.in_prover side_loaded_tag vk ) ;
+                        let vk =
+                          exists Side_loaded_verification_key.typ
+                            ~compute:(fun () -> As_prover.Ref.get vk)
+                        in
+                        Side_loaded.in_circuit side_loaded_tag vk ;
+                        let is_base_case = Field.equal Field.zero self in
+                        let self_correct = Field.(equal (one + prev) self) in
+                        Boolean.Assert.any [ self_correct; is_base_case ] ;
+                        { previous_proof_statements =
+                            [ { public_input = prev
+                              ; proof
+                              ; proof_must_verify = Boolean.true_
+                              }
+                            ]
+                        ; public_output = ()
+                        ; auxiliary_output = ()
+                        } )
+                  }
+                ] ) )
+
+      module Proof = (val p)
+
+      let example1 =
+        let (), (), b1 =
+          Common.time "b1" (fun () ->
+              Promise.block_on_async_exn (fun () ->
+                  step
+                    ~handler:
+                      (handler No_recursion.example_input
+                         (Side_loaded.Proof.of_proof No_recursion.example_proof)
+                         (Side_loaded.Verification_key.of_compiled
+                            No_recursion.tag ) )
+                    Field.Constant.one ) )
+        in
+        assert (
+          Promise.block_on_async_exn (fun () ->
+              Proof.verify_promise [ (Field.Constant.one, b1) ] ) ) ;
+        (Field.Constant.one, b1)
+
+      let example2 =
+        let (), (), b2 =
+          Common.time "b2" (fun () ->
+              Promise.block_on_async_exn (fun () ->
+                  step
+                    ~handler:
+                      (handler Fake_1_recursion.example_input
+                         (Side_loaded.Proof.of_proof
+                            Fake_1_recursion.example_proof )
+                         (Side_loaded.Verification_key.of_compiled
+                            Fake_1_recursion.tag ) )
+                    Field.Constant.one ) )
+        in
+        assert (
+          Promise.block_on_async_exn (fun () ->
+              Proof.verify_promise [ (Field.Constant.one, b2) ] ) ) ;
+        (Field.Constant.one, b2)
+
+      let example3 =
+        let (), (), b3 =
+          Common.time "b3" (fun () ->
+              Promise.block_on_async_exn (fun () ->
+                  step
+                    ~handler:
+                      (handler Fake_2_recursion.example_input
+                         (Side_loaded.Proof.of_proof
+                            Fake_2_recursion.example_proof )
+                         (Side_loaded.Verification_key.of_compiled
+                            Fake_2_recursion.tag ) )
+                    Field.Constant.one ) )
+        in
+        assert (
+          Promise.block_on_async_exn (fun () ->
+              Proof.verify_promise [ (Field.Constant.one, b3) ] ) ) ;
+        (Field.Constant.one, b3)
+    end
+  end )

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -642,39 +642,8 @@ struct
     in
     Timer.clock __LOC__ ;
     let wrap_requests, wrap_main =
-      Timer.clock __LOC__ ;
-      let prev_wrap_domains =
-        let module M =
-          H4.Map (IR) (H4.T (E04 (Domains)))
-            (struct
-              let f :
-                  type a b c d.
-                  (a, b, c, d) IR.t -> (a, b, c, d) H4.T(E04(Domains)).t =
-               fun rule ->
-                let module M =
-                  H4.Map (Tag) (E04 (Domains))
-                    (struct
-                      let f (type a b c d) (t : (a, b, c, d) Tag.t) : Domains.t
-                          =
-                        Types_map.lookup_map t ~self:self.id
-                          ~default:wrap_domains ~f:(function
-                          | `Compiled d ->
-                              d.wrap_domains
-                          | `Side_loaded d ->
-                              Common.wrap_domains
-                                ~proofs_verified:
-                                  ( d.permanent.max_proofs_verified |> Nat.Add.n
-                                  |> Nat.to_int ) )
-                    end)
-                in
-                M.f rule.Inductive_rule.prevs
-            end)
-        in
-        M.f choices
-      in
-      Timer.clock __LOC__ ;
       Wrap_main.wrap_main full_signature prev_varss_length step_vks
-        proofs_verifieds step_domains prev_wrap_domains max_proofs_verified
+        proofs_verifieds step_domains max_proofs_verified
     in
     Timer.clock __LOC__ ;
     let (wrap_pk, wrap_vk), disk_key =

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -789,7 +789,7 @@ struct
             Wrap.wrap ~max_proofs_verified:Max_proofs_verified.n
               full_signature.maxes wrap_requests
               ~dlog_plonk_index:wrap_vk.commitments wrap_main ~typ ~step_vk
-              ~step_plonk_indices:(Lazy.force step_vks) ~wrap_domains
+              ~step_plonk_indices:(Lazy.force step_vks) ~actual_wrap_domains
               (Impls.Wrap.Keypair.pk (fst (Lazy.force wrap_pk)))
               proof
           in

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -768,7 +768,10 @@ struct
         let step_vk = fst (Lazy.force step_vk) in
         let wrap ?handler next_state =
           let wrap_vk = Lazy.force wrap_vk in
-          let%bind.Promise proof, return_value, auxiliary_value =
+          let%bind.Promise ( proof
+                           , return_value
+                           , auxiliary_value
+                           , actual_wrap_domains ) =
             step handler ~maxes:(module Maxes) next_state
           in
           let proof =
@@ -2173,7 +2176,7 @@ let%test_module "test uncorrelated bulletproof_challenges" =
             let pairing_vk = fst (Lazy.force step_vk) in
             let wrap =
               let wrap_vk = Lazy.force wrap_vk in
-              let%bind.Promise proof, (), () = step ~maxes:(module Maxes) in
+              let%bind.Promise proof, (), (), _ = step ~maxes:(module Maxes) in
               let proof =
                 { proof with
                   statement =
@@ -3045,7 +3048,7 @@ let%test_module "test uncorrelated deferred b" =
             let pairing_vk = fst (Lazy.force step_vk) in
             let wrap =
               let wrap_vk = Lazy.force wrap_vk in
-              let%bind.Promise proof, (), () = step ~maxes:(module Maxes) in
+              let%bind.Promise proof, (), (), _ = step ~maxes:(module Maxes) in
               let proof =
                 { proof with
                   statement =

--- a/src/lib/pickles/requests.ml
+++ b/src/lib/pickles/requests.ml
@@ -52,6 +52,7 @@ module Wrap = struct
           , Tick.Field.t )
           Plonk_types.Openings.Bulletproof.t
           t
+      | Wrap_domain_indices : (Field.Constant.t, max_proofs_verified) Vector.t t
   end
 
   type ('mb, 'ml) t =
@@ -104,6 +105,7 @@ module Wrap = struct
             , Tick.Field.t )
             Plonk_types.Openings.Bulletproof.t
             t
+        | Wrap_domain_indices : (Tock.Field.t, max_proofs_verified) Vector.t t
     end in
     (module R)
 end

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -81,7 +81,8 @@ struct
         , (_, Max_proofs_verified.n) Vector.t )
         P.Base.Step.t
       * ret_value
-      * auxiliary_value )
+      * auxiliary_value
+      * (int, prevs_length) Vector.t )
       Promise.t =
     let _, prev_vars_length = branch_data.proofs_verified in
     let T = Length.contr prev_vars_length prevs_length in
@@ -132,7 +133,8 @@ struct
            * ( value
              , local_max_proofs_verified
              , m )
-             Per_proof_witness.Constant.No_app_state.t =
+             Per_proof_witness.Constant.No_app_state.t
+           * [ `Actual_wrap_domain of int ] =
      fun dlog_vk dlog_index app_state (T t) tag ~must_verify ->
       let t =
         { t with
@@ -461,7 +463,8 @@ struct
         }
       , prev_statement_with_hashes
       , x_hat
-      , witness )
+      , witness
+      , `Actual_wrap_domain dlog_vk.domain.log_size_of_group )
     in
     let challenge_polynomial_commitments = ref None in
     let unfinalized_proofs = ref None in
@@ -471,13 +474,15 @@ struct
     let prev_proofs = ref None in
     let return_value = ref None in
     let auxiliary_value = ref None in
+    let actual_wrap_domains = ref None in
     let compute_prev_proof_parts prev_proof_requests =
       let ( challenge_polynomial_commitments'
           , unfinalized_proofs'
           , statements_with_hashes'
           , x_hats'
           , witnesses'
-          , prev_proofs' ) =
+          , prev_proofs'
+          , actual_wrap_domains' ) =
         let rec go :
             type vars values ns ms k.
                (vars, values, ns, ms) H4.T(Tag).t
@@ -493,11 +498,12 @@ struct
                  , ns
                  , ms )
                  H3.T(Per_proof_witness.Constant.No_app_state).t
-               * (ns, ns) H2.T(Proof).t =
+               * (ns, ns) H2.T(Proof).t
+               * (int, k) Vector.t =
          fun ts prev_proof_stmts l ->
           match (ts, prev_proof_stmts, l) with
           | [], [], Z ->
-              ([], [], [], [], [], [])
+              ([], [], [], [], [], [], [])
           | ( t :: ts
             , { public_input = app_state
               ; proof = p
@@ -512,10 +518,16 @@ struct
                   let d = Types_map.lookup_basic t in
                   (d.wrap_vk, d.wrap_key)
               in
-              let `Sg sg, u, s, x, w =
+              let `Sg sg, u, s, x, w, `Actual_wrap_domain domain =
                 expand_proof dlog_vk dlog_index app_state p t ~must_verify
-              and sgs, us, ss, xs, ws, ps = go ts prev_proof_stmts l in
-              (sg :: sgs, u :: us, s :: ss, x :: xs, w :: ws, p :: ps)
+              and sgs, us, ss, xs, ws, ps, domains = go ts prev_proof_stmts l in
+              ( sg :: sgs
+              , u :: us
+              , s :: ss
+              , x :: xs
+              , w :: ws
+              , p :: ps
+              , domain :: domains )
           | _, _ :: _, _ ->
               .
           | _, [], _ ->
@@ -528,7 +540,8 @@ struct
       statements_with_hashes := Some statements_with_hashes' ;
       x_hats := Some x_hats' ;
       witnesses := Some witnesses' ;
-      prev_proofs := Some prev_proofs'
+      prev_proofs := Some prev_proofs' ;
+      actual_wrap_domains := Some actual_wrap_domains'
     in
     let unfinalized_proofs_extended =
       lazy
@@ -747,5 +760,6 @@ struct
             lte Max_proofs_verified.n Dummy.evals
       }
     , Option.value_exn !return_value
-    , Option.value_exn !auxiliary_value )
+    , Option.value_exn !auxiliary_value
+    , Option.value_exn !actual_wrap_domains )
 end

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -211,6 +211,25 @@ let verify_heterogenous (ts : Instance.t list) =
           in
           Tick.Field.(challenge_poly zeta + (r_actual * challenge_poly zetaw))
         in
+        let () =
+          let [ Pow_2_roots_of_unity greatest_wrap_domain
+              ; _
+              ; Pow_2_roots_of_unity least_wrap_domain
+              ] =
+            Wrap_verifier.all_possible_domains ()
+          in
+          let actual_wrap_domain = key.index.domain.log_size_of_group in
+          check
+            ( lazy
+                (sprintf !"wrap_domain: %i > %i" actual_wrap_domain
+                   least_wrap_domain )
+            , Int.( <= ) actual_wrap_domain least_wrap_domain ) ;
+          check
+            ( lazy
+                (sprintf !"wrap_domain: %i < %i" actual_wrap_domain
+                   greatest_wrap_domain )
+            , Int.( >= ) actual_wrap_domain greatest_wrap_domain )
+        in
         List.iter
           ~f:(fun (s, x, y) -> check_eq s x y)
           (* Both these values can actually be omitted from the proof on the wire since we recompute them

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -17,38 +17,6 @@ struct
     Inductive_rule.T (A) (A_value) (Ret_var) (Ret_value) (Auxiliary_var)
       (Auxiliary_value)
 
-  let prev (type a1 a2 ws hs) ~self ~(choices : (a1, a2, ws, hs) H4.T(I).t) =
-    let module M_inner =
-      H4.Map (Tag) (E04 (Domains))
-        (struct
-          let f : type a1 a2 a3 a4. (a1, a2, a3, a4) Tag.t -> Domains.t =
-           fun t ->
-            Types_map.lookup_map t ~self:self.Tag.id
-              ~default:(fun () -> assert false)
-              ~f:(function
-                | `Side_loaded d ->
-                    fun () ->
-                      Common.wrap_domains
-                        ~proofs_verified:
-                          (Nat.to_int
-                             (Nat.Add.n d.permanent.max_proofs_verified) )
-                | `Compiled d ->
-                    fun () -> d.wrap_domains )
-              ()
-        end)
-    in
-    let module M =
-      H4.Map (I) (H4.T (E04 (Domains)))
-        (struct
-          let f :
-              type vars values env widths heights.
-                 (vars, values, widths, heights) I.t
-              -> (vars, values, widths, heights) H4.T(E04(Domains)).t =
-           fun rule -> M_inner.f rule.prevs
-        end)
-    in
-    M.f choices
-
   let f_debug full_signature num_choices choices_length ~self ~choices
       ~max_proofs_verified =
     let num_choices = Hlist.Length.to_nat choices_length in
@@ -65,11 +33,10 @@ struct
              let g = Backend.Tock.Inner_curve.(to_affine_exn one) in
              Verification_key.dummy_commitments g ) )
     in
-    let prev_domains = prev ~self ~choices in
     Timer.clock __LOC__ ;
     let _, main =
       Wrap_main.wrap_main full_signature choices_length dummy_step_keys
-        dummy_step_widths dummy_step_domains prev_domains max_proofs_verified
+        dummy_step_widths dummy_step_domains max_proofs_verified
     in
     Timer.clock __LOC__ ;
     let t =

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -336,27 +336,12 @@ let wrap_main
                         , Vector.map ~f:(fun ds -> ds.h) possible_wrap_domains
                         ) )
                 in
-                let max_quot_sizes =
-                  Vector.map domainses ~f:(fun ds ->
-                      ( which_branch
-                      , Vector.map ds ~f:(fun d ->
-                            Common.max_quot_size_int (Domain.size d.h) ) ) )
-                in
-                let actual_proofs_verifieds =
-                  padded
-                  |> Vector.map ~f:(fun proofs_verifieds_in_slot ->
-                         Pseudo.choose
-                           (which_branch, proofs_verifieds_in_slot)
-                           ~f:Field.of_int )
-                in
                 Vector.mapn
                   [ (* This is padded to max_proofs_verified for the benefit of wrapping with dummy unfinalized proofs *)
                     prev_proof_state.unfinalized_proofs
                   ; old_bp_chals
-                  ; actual_proofs_verifieds
                   ; evals
                   ; wrap_domains
-                  ; max_quot_sizes
                   ]
                   ~f:(fun
                        [ { deferred_values
@@ -364,10 +349,8 @@ let wrap_main
                          ; should_finalize
                          }
                        ; old_bulletproof_challenges
-                       ; actual_proofs_verified
                        ; evals
                        ; wrap_domain
-                       ; max_quot_size
                        ]
                      ->
                     let sponge =
@@ -397,7 +380,6 @@ let wrap_main
                       with_label __LOC__ (fun () ->
                           finalize_other_proof
                             (module Wrap_hack.Padded_length)
-                            ~actual_proofs_verified
                             ~domain:(wrap_domain :> _ Plonk_checks.plonk_domain)
                             ~sponge ~old_bulletproof_challenges deferred_values
                             evals )

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -37,9 +37,10 @@ let challenge_polynomial ~one ~add ~mul chals =
 
 let num_possible_domains = Nat.S Wrap_hack.Padded_length.n
 
-let all_possible_domains () =
-  Vector.init num_possible_domains ~f:(fun proofs_verified ->
-      (Common.wrap_domains ~proofs_verified).h )
+let all_possible_domains =
+  Memo.unit (fun () ->
+      Vector.init num_possible_domains ~f:(fun proofs_verified ->
+          (Common.wrap_domains ~proofs_verified).h ) )
 
 module Make
     (Inputs : Inputs

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -35,6 +35,12 @@ let challenge_polynomial ~one ~add ~mul chals =
       in
       prod (fun i -> one + (chals.(i) * pow_two_pows.(k - 1 - i))) )
 
+let num_possible_domains = Nat.S Wrap_hack.Padded_length.n
+
+let all_possible_domains () =
+  Vector.init num_possible_domains ~f:(fun proofs_verified ->
+      (Common.wrap_domains ~proofs_verified).h )
+
 module Make
     (Inputs : Inputs
                 with type Impl.field = Tock.Field.t
@@ -71,6 +77,10 @@ struct
         match x with Shifted_value x -> Sponge.absorb sponge x
     end
   end
+
+  let num_possible_domains = num_possible_domains
+
+  let all_possible_domains = all_possible_domains
 
   let print_g lab (x, y) =
     if debug then

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -774,8 +774,7 @@ struct
      3. Check that the "b" value was computed correctly.
      4. Perform the arithmetic checks from marlin. *)
   let finalize_other_proof (type b)
-      (module Proofs_verified : Nat.Add.Intf with type n = b)
-      ?actual_proofs_verified ~domain ~sponge
+      (module Proofs_verified : Nat.Add.Intf with type n = b) ~domain ~sponge
       ~(old_bulletproof_challenges : (_, b) Vector.t)
       ({ xi; combined_inner_product; bulletproof_challenges; b; plonk } :
         ( _


### PR DESCRIPTION
This PR builds upon #11616.

This PR changes the way that pickles determines the domains for side-loaded proofs, so that a proof built with a `max_proofs_verified` different from that provided to `Pickles.Side_loaded.create` can still be accepted.

For example, this is important for accepting proofs built with `max_proofs_verified: 0` (e.g. by SnarkyJS) in the transaction snark (which sets `max_proofs_verified: 2`).

Note that such a proof will pass `Pickles.verify`, but would render the wrap proof statement unsatisfiable, so this is a must-have!

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them