### PR TITLE
Repro: version compatibility changes failure

### DIFF
--- a/src/nonconsensus/snark_params/tick.ml
+++ b/src/nonconsensus/snark_params/tick.ml
@@ -1,4 +1,5 @@
 (* snark_params_nonconsensus.ml *)
+(* add comment *)
 
 [%%import "/src/config.mlh"]
 

--- a/src/nonconsensus/snark_params/tick.ml
+++ b/src/nonconsensus/snark_params/tick.ml
@@ -40,7 +40,6 @@ module Field = struct
       let to_latest x = x
     end
 
-    module Tests = struct end
   end]
 
   include Pasta.Fp


### PR DESCRIPTION
In the current `develop` branch running `dune build --profile=nonconsensus_mainnet src/nonconsensus/snark_params` fails with
```
File "src/nonconsensus/snark_params/tick.ml", line 43, characters 11-16:
43 |     module Tests = struct end
                ^^^^^
Error: Versioning module containing versioned type must be named Vn, for some number n
```

The CI only does this (in the `version compatibility changes`) test if we modify the `tick.ml` file, so it may have been unnoticed until PR #11558. Moreover fixing it may require forcing the merge on red CI, because the `version compatibility changes` test tries to compile the current `develop` branch which contains the bug.

### Repro

The `add comment to tick.ml` commit below only adds a comment and CI fails [here](https://buildkite.com/o-1-labs-2/mina/builds/24447#01826cd9-4188-4bfe-b97e-dcf54f423bb3/64-108).


The `remove test module` commit below removes the `Test` module which fixes the error locally (I do not know if we really want to do this). However the CI still fail when compiling the current `develop` branch [here](https://buildkite.com/o-1-labs-2/mina/builds/24448#01826ce6-e9d0-46f8-b30d-eacea665fc91/64-109).
 