### PR TITLE
Update pool based on expected vs actual target nonces of parties transaction

### DIFF
--- a/src/lib/mina_base/parties.ml
+++ b/src/lib/mina_base/parties.ml
@@ -1059,7 +1059,7 @@ let fee_payer_party ({ fee_payer; _ } : t) = fee_payer
 
 let application_nonce (t : t) : Account.Nonce.t = (fee_payer_party t).body.nonce
 
-let target_nonce (t : t) : Account.Nonce.t =
+let target_nonce_on_success (t : t) : Account.Nonce.t =
   let base_nonce = Account.Nonce.succ (application_nonce t) in
   let fee_payer_pubkey = t.fee_payer.body.public_key in
   let fee_payer_party_increments =

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -190,13 +190,15 @@ let application_nonce (t : t) =
   | Parties p ->
       Parties.application_nonce p
 
+let expected_target_nonce t = Account.Nonce.succ (application_nonce t)
+
 (** The target nonce is what the nonce of the fee payer will be after a user command is applied. *)
-let target_nonce (t : t) =
+let target_nonce_on_success (t : t) =
   match t with
   | Signed_command x ->
       Account.Nonce.succ (Signed_command.nonce x)
   | Parties p ->
-      Parties.target_nonce p
+      Parties.target_nonce_on_success p
 
 let fee_token (t : t) =
   match t with

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -664,7 +664,7 @@ let get_inferred_nonce_from_transaction_pool_and_ledger t
     List.last pooled_transactions
     |> Option.map
          ~f:
-           (Fn.compose User_command.target_nonce
+           (Fn.compose User_command.expected_target_nonce
               Transaction_hash.User_command_with_valid_signature.command )
   in
   match txn_pool_nonce with

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -107,6 +107,7 @@ val get_highest_fee :
 val handle_committed_txn :
      t
   -> Transaction_hash.User_command_with_valid_signature.t
+  -> application_status:Transaction_status.t option
   -> fee_payer_balance:Currency.Amount.t
   -> fee_payer_nonce:Mina_base.Account.Nonce.t
   -> ( t * Transaction_hash.User_command_with_valid_signature.t Sequence.t

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -364,11 +364,11 @@ struct
           match Indexed_pool.get_highest_fee pool with
           | Some cmd -> (
               match
-                Indexed_pool.handle_committed_txn pool
-                  cmd
-                  (* we have the invariant that the transactions currently
-                     in the pool are always valid against the best tip, so
-                     no need to check balances here *)
+                Indexed_pool.handle_committed_txn pool cmd
+                  ~application_status:None
+                    (* we have the invariant that the transactions currently
+                       in the pool are always valid against the best tip, so
+                       no need to check balances here *)
                   ~fee_payer_balance:Currency.Amount.max_int
                   ~fee_payer_nonce:
                     ( Transaction_hash.User_command_with_valid_signature.command
@@ -648,7 +648,8 @@ struct
                   ~data:time_added ) ;
             let p', dropped =
               match
-                Indexed_pool.handle_committed_txn p cmd' ~fee_payer_balance
+                Indexed_pool.handle_committed_txn p cmd'
+                  ~application_status:(Some cmd.status) ~fee_payer_balance
                   ~fee_payer_nonce
               with
               | Ok res ->


### PR DESCRIPTION
Transactions are admitted into the pool based on the nonce and balance of the fee payer and assumes there are no other nonce increments to fee payer accounts in the same and no nonce increments in non-fee-payer parts of any other transactions.

 For example: Fee payer account A and B starting with nonce 0
**Valid sequence of transactions:**
I. All are included and are applied (assuming other account updates are valid)
Transaction1: Fee payer A and nonce 0, other parties does not include A or B
Transaction2: Fee payer A and nonce 1, other parties does not include A or B
Transaction3: Fee payer B and nonce 0, other parties does not include A or B
Transaction4: Fee payer B and nonce 1, other parties does not include A or B

II.
Transaction1: Fee payer A and nonce 0, other parties may or may not include nonce updates to A or B
Transaction2: Fee payer A and nonce 1, other parties may or may not include nonce updates to A or B (This transaction may fail to be included in a block after transaction1 is applied if A's nonce is not 1)
Transaction3: Fee payer B and nonce 0, other parties may or may not include nonce updates to A or B  (This transaction may fail to be included in a block after transaction1 and 2 are applied if B's nonce is not 0)
Transaction4: Fee payer B and nonce 1, other parties may or may not include nonce updates to A or B  (This transaction may fail to be included in a block after transaction 1 and/or 2 and/or 3 are applied if B's nonce is not 1)

**Transactions rejected:**

Pool: Transaction 1: Fee payer A, nonce 0, other parties may or may not contain updates to A or B

Rejected transactions based on the pool above-
 a) Transaction with fee payer A, nonce 2 (because maybe transaction 1 has another nonce incrementing update to A) is rejected because the expected nonce is 1
 b) Fee payer B nonce 1 (because maybe transaction 1 has a nonce incrementing update to B) is rejected because the account nonce is 0 and that's what the pool expects 


When handling committed transactions, the status of a transaction is used to determine the actual target nonce of the fee payer.

Explain how you tested your changes:
Updated unit test


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #11627
