### PR TITLE
deriver for network state view, expose in snarkyjs

### DIFF
--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -2870,6 +2870,16 @@ module Ledger = struct
   let add_account l (pk : public_key) (balance : Js.js_string Js.t) =
     add_account_exn l##.value pk (Js.to_string balance)
 
+  let protocol_state_of_json =
+    let deriver =
+      Mina_base.Zkapp_precondition.Protocol_state.View.deriver
+      @@ Fields_derivers_zkapps.o ()
+    in
+    let of_json = Fields_derivers_zkapps.of_json deriver in
+    fun (json : Js.js_string Js.t) :
+        Mina_base.Zkapp_precondition.Protocol_state.View.t ->
+      json |> Js.to_string |> Yojson.Safe.from_string |> of_json
+
   let dummy_state_view : Mina_base.Zkapp_precondition.Protocol_state.View.t =
     let epoch_data =
       { Mina_base.Zkapp_precondition.Protocol_state.Epoch_data.Poly.ledger =

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -2882,7 +2882,8 @@ module Ledger = struct
       json |> Js.to_string |> Yojson.Safe.from_string |> of_json
 
   let apply_parties_transaction l (txn : Parties.t)
-      (account_creation_fee : string) (network_state : Mina_base.Zkapp_precondition.Protocol_state.View.t) =
+      (account_creation_fee : string)
+      (network_state : Mina_base.Zkapp_precondition.Protocol_state.View.t) =
     check_party_signatures txn ;
     let ledger = l##.value in
     let applied_exn =
@@ -2912,14 +2913,15 @@ module Ledger = struct
     Js.array @@ Array.of_list account_list
 
   let apply_json_transaction l (tx_json : Js.js_string Js.t)
-      (account_creation_fee : Js.js_string Js.t) (network_json : Js.js_string Js.t) =
+      (account_creation_fee : Js.js_string Js.t)
+      (network_json : Js.js_string Js.t) =
     let txn =
       Parties.of_json @@ Yojson.Safe.from_string @@ Js.to_string tx_json
     in
-    let network_state =
-      protocol_state_of_json network_json
-    in
-    apply_parties_transaction l txn (Js.to_string account_creation_fee) network_state
+    let network_state = protocol_state_of_json network_json in
+    apply_parties_transaction l txn
+      (Js.to_string account_creation_fee)
+      network_state
 
   let create_token_account pk token =
     account_id pk token |> Mina_base.Account_id.public_key


### PR DESCRIPTION
allows SnarkyJS to pass in a custom network state and set custom network preconditions when evaluating transactions via `apply_json_transaction`

Instead of using a hard-coded network state, the state will now be maintained within SnarkyJS

accompanies https://github.com/o1-labs/snarkyjs/pull/329