### PR TITLE
Print Wasm errors in JS console

### DIFF
--- a/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fp_plonk_index.rs
@@ -37,6 +37,8 @@ pub fn caml_pasta_fp_plonk_index_create(
     prev_challenges: i32,
     srs: &WasmSrs,
 ) -> Result<WasmPastaFpPlonkIndex, JsValue> {
+    console_error_panic_hook::set_once();
+
     // flatten the permutation information (because OCaml has a different way of keeping track of permutations)
     let gates: Vec<_> = gates
         .0

--- a/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fq_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/pasta_fq_plonk_index.rs
@@ -37,6 +37,8 @@ pub fn caml_pasta_fq_plonk_index_create(
     prev_challenges: i32,
     srs: &WasmSrs,
 ) -> Result<WasmPastaFqPlonkIndex, JsValue> {
+    console_error_panic_hook::set_once();
+
     // flatten the permutation information (because OCaml has a different way of keeping track of permutations)
     let gates: Vec<_> = gates
         .0

--- a/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
@@ -621,6 +621,7 @@ macro_rules! impl_proof {
                 prev_challenges: WasmFlatVector<$WasmF>,
                 prev_sgs: WasmVector<$WasmG>,
             ) -> WasmProverProof {
+                console_error_panic_hook::set_once();
                 {
                     let ptr: &mut commitment_dlog::srs::SRS<GAffine> =
                         unsafe { &mut *(std::sync::Arc::as_ptr(&index.0.as_ref().srs) as *mut _) };


### PR DESCRIPTION
this uses https://github.com/rustwasm/console_error_panic_hook to make Rust `panic` log messages with `console.error`, in Wasm. This makes error messages thrown in Rust much more useful. I checked that it doesn't harm prover performance