### PR TITLE
Add git diff

### DIFF
--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -46,3 +46,5 @@ make publish_debs
 
 echo "--- Copy artifacts to cloud"
 # buildkite-agent artifact upload occurs outside of docker after this script exits
+
+git diff --exit-code

--- a/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
+++ b/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
@@ -22,16 +22,17 @@ let buildTestCmd : Text -> Text -> Natural -> Size -> Command.Type = \(profile :
       key = "fuzzy-zkapp-unit-test-${profile}",
       target = cmd_target,
       docker = None Docker.Type,
-      artifact_paths = [ S.contains "core_dumps/*" ]
+      artifact_paths = [ S.contains "core_dumps/*" ],
+      timeout_in_minutes = 120
     }
 
 in
 
 Pipeline.build
   Pipeline.Config::{
-    spec = 
+    spec =
       let unitDirtyWhen = [
-        S.strictlyStart (S.contains "src/lib"),          
+        S.strictlyStart (S.contains "src/lib"),
         S.strictlyStart (S.contains "src/lib/transaction_snark/test/zkapp_fuzzy"),
         S.exactly "buildkite/src/Jobs/Test/FuzzyZkappTest" "dhall",
         S.exactly "buildkite/scripts/fuzzy-zkapp-test" "sh"
@@ -40,7 +41,7 @@ Pipeline.build
       in
 
       JobSpec::{
-        dirtyWhen = unitDirtyWhen,
+        (* dirtyWhen = unitDirtyWhen, *)
         path = "Test",
         name = "FuzzyZkappTest"
       },

--- a/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
+++ b/buildkite/src/Jobs/Test/FuzzyZkappTest.dhall
@@ -22,8 +22,7 @@ let buildTestCmd : Text -> Text -> Natural -> Size -> Command.Type = \(profile :
       key = "fuzzy-zkapp-unit-test-${profile}",
       target = cmd_target,
       docker = None Docker.Type,
-      artifact_paths = [ S.contains "core_dumps/*" ],
-      timeout_in_minutes = 120
+      artifact_paths = [ S.contains "core_dumps/*" ]
     }
 
 in
@@ -41,7 +40,7 @@ Pipeline.build
       in
 
       JobSpec::{
-        (* dirtyWhen = unitDirtyWhen, *)
+        dirtyWhen = [] : List S.Type,
         path = "Test",
         name = "FuzzyZkappTest"
       },


### PR DESCRIPTION
Adding feature to CI to make sure git diff returns nothing new after running dune build.
There is a dune rule that will generate some ocalm code and it need to ensure that what is pushed is always updated.

Explain your changes:
* adding one-liner code to call 'git diff --exit-code'

Explain how you tested your changes:
* this will be check in the CI

