### PR TITLE
[crypto] fix public input commitment

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_dlog_oracles.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_dlog_oracles.ml
@@ -57,9 +57,9 @@ module Make (Inputs : Inputs_intf) = struct
 
   let u (t : t) = t.o.u_chal
 
-  let p_eval_1 (t : t) = fst t.p_eval
+  let p_eval_1 (t : t) = fst t.public_evals
 
-  let p_eval_2 (t : t) = snd t.p_eval
+  let p_eval_2 (t : t) = snd t.public_evals
 
   let opening_prechallenges (t : t) =
     Array.map ~f:scalar_challenge t.opening_prechallenges

--- a/src/lib/crypto/kimchi_bindings/js/chrome/build.sh
+++ b/src/lib/crypto/kimchi_bindings/js/chrome/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ -z "${PLONK_WASM_WEB-}" ]]; then
+if [[ "${PLONK_WASM_WEB-n}" == "n" ]]; then
     export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--no-check-features -C link-arg=--max-memory=4294967296"
     rustup run nightly-2021-11-16 wasm-pack build --target web --out-dir ../js/chrome ../../wasm -- -Z build-std=panic_abort,std
 else

--- a/src/lib/crypto/kimchi_bindings/js/node_js/build.sh
+++ b/src/lib/crypto/kimchi_bindings/js/node_js/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ -z "${PLONK_WASM_NODEJS-}" ]]; then
+if [[ "${PLONK_WASM_NODEJS-n}" == "n" ]]; then
     export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--no-check-features -C link-arg=--max-memory=4294967296"
     rustup run nightly-2021-11-16 wasm-pack build --target nodejs --out-dir ../js/node_js ../../wasm -- -Z build-std=panic_abort,std --features nodejs
 else

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
@@ -400,6 +400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "disjoint-set"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d102f1a462fdcdddce88d6d46c06c074a2d2749b262230333726b06c52bb7585"
+
+[[package]]
 name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +504,7 @@ dependencies = [
  "blake2",
  "cairo",
  "commitment_dlog",
+ "disjoint-set",
  "groupmap",
  "hex",
  "itertools",

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -132,7 +132,7 @@ type nonrec curr_or_next = Curr | Next
 
 type nonrec 'f oracles =
   { o : 'f random_oracles
-  ; p_eval : 'f * 'f
+  ; public_evals : 'f * 'f
   ; opening_prechallenges : 'f array
   ; digest_before_evaluations : 'f
   }

--- a/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
@@ -14,7 +14,7 @@ use paste::paste;
 #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
 pub struct CamlOracles<F> {
     pub o: CamlRandomOracles<F>,
-    pub p_eval: (F, F),
+    pub public_evals: (F, F),
     pub opening_prechallenges: Vec<F>,
     pub digest_before_evaluations: F,
 }
@@ -54,10 +54,10 @@ macro_rules! impl_oracles {
                 let oracles_result =
                     proof.oracles::<DefaultFqSponge<$curve_params, PlonkSpongeConstantsKimchi>, DefaultFrSponge<$F, PlonkSpongeConstantsKimchi>>(&index, &p_comm)?;
 
-                let (mut sponge, combined_inner_product, p_eval, digest, oracles) = (
+                let (mut sponge, combined_inner_product, public_evals, digest, oracles) = (
                     oracles_result.fq_sponge,
                     oracles_result.combined_inner_product,
-                    oracles_result.p_eval,
+                    oracles_result.public_evals,
                     oracles_result.digest,
                     oracles_result.oracles,
                 );
@@ -73,7 +73,7 @@ macro_rules! impl_oracles {
 
                 Ok(CamlOracles {
                     o: oracles.into(),
-                    p_eval: (p_eval[0][0].into(), p_eval[1][0].into()),
+                    public_evals: (public_evals[0][0].into(), public_evals[1][0].into()),
                     opening_prechallenges,
                     digest_before_evaluations: digest.into(),
                 })

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.lock
@@ -368,6 +368,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "disjoint-set"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d102f1a462fdcdddce88d6d46c06c074a2d2749b262230333726b06c52bb7585"
+
+[[package]]
 name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +489,7 @@ dependencies = [
  "blake2",
  "cairo",
  "commitment_dlog",
+ "disjoint-set",
  "groupmap",
  "hex",
  "itertools",

--- a/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
@@ -201,10 +201,10 @@ macro_rules! impl_oracles {
                 let oracles_result =
                     proof.oracles::<DefaultFqSponge<$curve_params, PlonkSpongeConstantsKimchi>, DefaultFrSponge<$F, PlonkSpongeConstantsKimchi>>(&index, &p_comm).map_err(|e| JsValue::from_str(&format!("oracles_create: {}", e)))?;
 
-                let (mut sponge, combined_inner_product, p_eval, digest, oracles) = (
+                let (mut sponge, combined_inner_product, public_evals, digest, oracles) = (
                     oracles_result.fq_sponge,
                     oracles_result.combined_inner_product,
-                    oracles_result.p_eval,
+                    oracles_result.public_evals,
                     oracles_result.digest,
                     oracles_result.oracles,
                 );
@@ -220,8 +220,8 @@ macro_rules! impl_oracles {
 
                 Ok([<Wasm $field_name:camel Oracles>] {
                     o: oracles.into(),
-                    p_eval0: p_eval[0][0].into(),
-                    p_eval1: p_eval[1][0].into(),
+                    p_eval0: public_evals[0][0].into(),
+                    p_eval1: public_evals[1][0].into(),
                     opening_prechallenges,
                     digest_before_evaluations: digest.into(),
                 })


### PR DESCRIPTION
update proof system to fix an issue with zkapps, see https://github.com/o1-labs/proof-systems/pull/717 and https://github.com/o1-labs/snarkyjs/issues/344

```
cargo test --package kimchi --lib -- tests::chacha::chacha_prover --exact --nocapture
```

^ the test still doesn't pass, if I comment the evaluation proof of the public_comm on both sides (prover & verifier) it works. I suspect that the aggregation of the evaluation proof does not work well with zero polynomials. This change might involve more investigation (related to https://github.com/o1-labs/proof-systems/pull/448 and https://github.com/o1-labs/proof-systems/pull/680)