### PR TITLE
Lift pipe logic out of initial validator

### DIFF
--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -330,9 +330,9 @@ module type Transition_router_intf = sig
          * [ `Valid_cb of Mina_net2.Validation_callback.t ] )
          Strict_pipe.Reader.t
     -> producer_transition_reader:breadcrumb Strict_pipe.Reader.t
-    -> most_recent_valid_block:
-         Mina_block.initial_valid_block Broadcast_pipe.Reader.t
-         * Mina_block.initial_valid_block Broadcast_pipe.Writer.t
+    -> get_current_transition:(unit -> Mina_block.initial_valid_block)
+    -> most_recent_valid_block_writer:
+         Mina_block.initial_valid_block Broadcast_pipe.Writer.t
     -> precomputed_values:Precomputed_values.t
     -> catchup_mode:[ `Normal | `Super ]
     -> notify_online:(unit -> unit Deferred.t)

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -321,9 +321,9 @@ module type Transition_router_intf = sig
     -> consensus_local_state:Consensus.Data.Local_state.t
     -> persistent_root_location:string
     -> persistent_frontier_location:string
-    -> frontier_broadcast_pipe:
-         transition_frontier option Pipe_lib.Broadcast_pipe.Reader.t
-         * transition_frontier option Pipe_lib.Broadcast_pipe.Writer.t
+    -> get_current_frontier:(unit -> transition_frontier option)
+    -> frontier_broadcast_writer:
+         transition_frontier option Pipe_lib.Broadcast_pipe.Writer.t
     -> network_transition_reader:
          ( [ `Transition of Mina_block.t Envelope.Incoming.t ]
          * [ `Time_received of Block_time.t ]

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1790,9 +1790,9 @@ let create ?wallets (config : Config.t) =
               ~consensus_local_state:config.consensus_local_state
               ~persistent_root_location:config.persistent_root_location
               ~persistent_frontier_location:config.persistent_frontier_location
-              ~frontier_broadcast_pipe:
-                (frontier_broadcast_pipe_r, frontier_broadcast_pipe_w)
-              ~catchup_mode ~network_transition_reader:block_reader
+              ~get_current_frontier
+              ~frontier_broadcast_writer:frontier_broadcast_pipe_w ~catchup_mode
+              ~network_transition_reader:block_reader
               ~producer_transition_reader ~get_current_transition
               ~most_recent_valid_block_writer
               ~precomputed_values:config.precomputed_values ~notify_online

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1779,11 +1779,14 @@ let create ?wallets (config : Config.t) =
                           User_command.Parties cmd )
                     , result_cb ) )
           |> Deferred.don't_wait_for ;
-          let ((most_recent_valid_block_reader, _) as most_recent_valid_block) =
+          let most_recent_valid_block_reader, most_recent_valid_block_writer =
             Broadcast_pipe.create
               ( Mina_block.genesis ~precomputed_values:config.precomputed_values
               |> Validation.reset_frontier_dependencies_validation
               |> Validation.reset_staged_ledger_diff_validation )
+          in
+          let get_current_transition () =
+            Broadcast_pipe.Reader.peek most_recent_valid_block_reader
           in
           let valid_transitions, initialization_finish_signal =
             Transition_router.run ~logger:config.logger
@@ -1796,7 +1799,8 @@ let create ?wallets (config : Config.t) =
               ~frontier_broadcast_pipe:
                 (frontier_broadcast_pipe_r, frontier_broadcast_pipe_w)
               ~catchup_mode ~network_transition_reader:block_reader
-              ~producer_transition_reader ~most_recent_valid_block
+              ~producer_transition_reader ~get_current_transition
+              ~most_recent_valid_block_writer
               ~precomputed_values:config.precomputed_values ~notify_online
           in
           let ( valid_transitions_for_network

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -463,8 +463,8 @@ let wait_till_genesis ~logger ~time_controller
 
 let run ~logger ~trust_system ~verifier ~network ~is_seed ~is_demo_mode
     ~time_controller ~consensus_local_state ~persistent_root_location
-    ~persistent_frontier_location
-    ~frontier_broadcast_pipe:(frontier_r, frontier_w) ~network_transition_reader
+    ~persistent_frontier_location ~get_current_frontier
+    ~frontier_broadcast_writer:frontier_w ~network_transition_reader
     ~producer_transition_reader ~get_current_transition
     ~most_recent_valid_block_writer ~precomputed_values ~catchup_mode
     ~notify_online =
@@ -580,7 +580,7 @@ let run ~logger ~trust_system ~verifier ~network ~is_seed ~is_demo_mode
                   let incoming_transition =
                     Envelope.Incoming.data enveloped_transition
                   in
-                  match Broadcast_pipe.Reader.peek frontier_r with
+                  match get_current_frontier () with
                   | Some frontier ->
                       if
                         is_transition_for_bootstrap ~logger frontier

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -465,10 +465,9 @@ let run ~logger ~trust_system ~verifier ~network ~is_seed ~is_demo_mode
     ~time_controller ~consensus_local_state ~persistent_root_location
     ~persistent_frontier_location
     ~frontier_broadcast_pipe:(frontier_r, frontier_w) ~network_transition_reader
-    ~producer_transition_reader
-    ~most_recent_valid_block:
-      (most_recent_valid_block_reader, most_recent_valid_block_writer)
-    ~precomputed_values ~catchup_mode ~notify_online =
+    ~producer_transition_reader ~get_current_transition
+    ~most_recent_valid_block_writer ~precomputed_values ~catchup_mode
+    ~notify_online =
   let initialization_finish_signal = Ivar.create () in
   let clear_reader, clear_writer =
     Strict_pipe.create ~name:"clear" Synchronous
@@ -556,9 +555,7 @@ let run ~logger ~trust_system ~verifier ~network ~is_seed ~is_demo_mode
              let incoming_transition =
                Envelope.Incoming.data enveloped_transition
              in
-             let current_transition =
-               Broadcast_pipe.Reader.peek most_recent_valid_block_reader
-             in
+             let current_transition = get_current_transition () in
              if
                Consensus.Hooks.equal_select_status `Take
                  (Consensus.Hooks.select


### PR DESCRIPTION
This PR makes some small refactors to replace the pipe logic in and around the `Initial_validator.t` with calls from the parent module.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them