### PR TITLE
Fix Nix devShells by reusing existing shellHook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -244,6 +244,7 @@
 
         devShell = ocamlPackages.mina-dev.overrideAttrs (oa: {
           shellHook = ''
+            ${oa.shellHook}
             unset MINA_COMMIT_DATE MINA_COMMIT_SHA1 MINA_BRANCH
           '';
         });
@@ -253,6 +254,7 @@
           nativeBuildInputs = oa.nativeBuildInputs
             ++ [ ocamlPackages.ocaml-lsp-server ];
           shellHook = ''
+            ${oa.shellHook}
             unset MINA_COMMIT_DATE MINA_COMMIT_SHA1 MINA_BRANCH
             # TODO: dead code doesn't allow us to have nice things
             pushd src/app/cli


### PR DESCRIPTION
The `shellHook` was overriden in the `devShells`, which prevented Mina from finding the libp2p helper. Fix that. Fixes https://github.com/MinaProtocol/mina/issues/11666