### PR TITLE
Make the nixos-container run mina demo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,20 @@
       nixosModules.mina = import ./nix/modules/mina.nix inputs;
       nixosConfigurations.container = nixpkgs.lib.nixosSystem {
         system = "x86_64-linux";
-        modules = [
+        modules = let
+          PK = "B62qiZfzW27eavtPrnF6DeDSAKEjXuGFdkouC3T5STRa6rrYLiDUP2p";
+          wallet = {
+            box_primitive = "xsalsa20poly1305";
+            ciphertext =
+              "Dmq1Qd8uNbZRT1NT7zVbn3eubpn9Myx9Je9ZQGTKDxUv4BoPNmZAGox18qVfbbEUSuhT4ZGDt";
+            nonce = "6pcvpWSLkMi393dT5VSLR6ft56AWKkCYRqJoYia";
+            pw_primitive = "argon2i";
+            pwdiff = [ 134217728 6 ];
+            pwsalt = "ASoBkV3NsY7ZRuxztyPJdmJCiz3R";
+          };
+          wallet-file = builtins.toFile "mina-wallet" (builtins.toJSON wallet);
+          wallet-file-pub = builtins.toFile "mina-wallet-pub" PK;
+        in [
           self.nixosModules.mina
           {
             boot.isContainer = true;
@@ -52,10 +65,46 @@
 
             services.mina = {
               enable = true;
+              config = {
+                "ledger" = {
+                  "name" = "mina-demo";
+                  "accounts" = [{
+                    "pk" = PK;
+                    "balance" = "66000";
+                    "sk" = null;
+                    "delegate" = null;
+                  }];
+                };
+              };
               waitForRpc = false;
               external-ip = "0.0.0.0";
-              extraArgs = [ "--seed" ];
+              generate-genesis-proof = true;
+              seed = true;
+              block-producer-key = "/var/lib/mina/wallets/store/${PK}";
+              extraArgs = [
+                "--demo-mode"
+                "--proof-level"
+                "none"
+                "--run-snark-worker"
+                "B62qjnkjj3zDxhEfxbn1qZhUawVeLsUr2GCzEz8m1MDztiBouNsiMUL"
+                "-insecure-rest-server"
+              ];
             };
+
+            systemd.services.mina = {
+              preStart = ''
+                printf '{"genesis":{"genesis_state_timestamp":"%s"}}' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" > /var/lib/mina/daemon.json
+              '';
+              environment = {
+                MINA_TIME_OFFSET = "0";
+                MINA_PRIVKEY_PASS = "";
+              };
+            };
+
+            systemd.tmpfiles.rules = [
+              "C /var/lib/mina/wallets/store/${PK}.pub 700 mina mina - ${wallet-file-pub}"
+              "C /var/lib/mina/wallets/store/${PK}     700 mina mina - ${wallet-file}"
+            ];
           }
         ];
       };

--- a/nix/README.md
+++ b/nix/README.md
@@ -106,6 +106,26 @@ directory, which links to a tarball containing the docker image. You
 can load the image using `docker load -i result`, then note the tag it
 outputs. You can then run Mina from this docker image with `docker run mina:<tag> mina.exe <args>`.
 
+### Demo nixos-container
+
+If you're running NixOS, you can use `nixos-container` to run a demo of mina daemon from your local checkout. To do so, try
+
+```
+sudo nixos-container create mina --flake mina
+sudo nixos-container start mina
+sudo nixos-container root-login mina
+```
+
+From there, you can poke the mina daemon, e.g. with `systemctl status mina`.
+
+If you want to update the container to reflect the latest checkout, try
+
+```
+sudo nixos-container stop mina
+sudo nixos-container update mina --flake mina
+sudo nixos-container start mina
+```
+
 ### direnv
 
 It is considered as a good practice to automatically enter the Nix shell instead of keeping in mind that you need to execute the `nix develop mina` command every time you enter the Mina repo directory.  


### PR DESCRIPTION
The nixos-container in the flake was sort of useless. Make it run the mina demo so that it can be used to sanity-check mina.