### PR TITLE
Update `kimchi_bindings` lock files

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
@@ -400,6 +400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "disjoint-set"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d102f1a462fdcdddce88d6d46c06c074a2d2749b262230333726b06c52bb7585"
+
+[[package]]
 name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +504,7 @@ dependencies = [
  "blake2",
  "cairo",
  "commitment_dlog",
+ "disjoint-set",
  "groupmap",
  "hex",
  "itertools",

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.lock
@@ -374,6 +374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "disjoint-set"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d102f1a462fdcdddce88d6d46c06c074a2d2749b262230333726b06c52bb7585"
+
+[[package]]
 name = "either"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +495,7 @@ dependencies = [
  "blake2",
  "cairo",
  "commitment_dlog",
+ "disjoint-set",
  "groupmap",
  "hex",
  "itertools",


### PR DESCRIPTION
Add missing dependencies in `kimchi_bindings` lock files which cause the build to fail in clean environments.

Closes #11695 