### PR TITLE
Optimize parties transaction hashing

### DIFF
--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -31,17 +31,26 @@ let of_yojson = function
   | _ ->
       Error "Transaction_hash.of_yojson: Expected a string"
 
-let hash_signed_command =
-  Fn.compose digest_string Signed_command.to_base58_check
+let hash_signed_command cmd =
+  cmd |> Signed_command.to_base58_check |> digest_string
+
+let hash_parties_command cmd =
+  cmd |> Binable.to_string (module Parties.Stable.Latest) |> digest_string
 
 [%%ifdef consensus_mechanism]
 
-let hash_command = Fn.compose digest_string User_command.to_base58_check
+let hash_command cmd =
+  match cmd with
+  | User_command.Signed_command s ->
+      hash_signed_command s
+  | User_command.Parties p ->
+      hash_parties_command p
 
-let hash_fee_transfer =
-  Fn.compose digest_string Fee_transfer.Single.to_base58_check
+let hash_fee_transfer fee_transfer =
+  fee_transfer |> Fee_transfer.Single.to_base58_check |> digest_string
 
-let hash_coinbase = Fn.compose digest_string Coinbase.to_base58_check
+let hash_coinbase coinbase =
+  coinbase |> Coinbase.to_base58_check |> digest_string
 
 module User_command_with_valid_signature = struct
   type hash = T.t [@@deriving sexp, compare, hash]


### PR DESCRIPTION
Optimize parties transaction hashing by hashing the raw binable representation rather than the base58check encoded representation. TBD if we will also do the same for signed commands.

Addresses #11430