### PR TITLE
Add protocol major version to chain id

### DIFF
--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -63,6 +63,7 @@
    block_time
    coda_runtime_config
    trust_system
+   protocol_version
    coda_genesis_proof
    with_hash
    block_producer

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -2062,7 +2062,11 @@ let chain_id_inputs =
        ~f:(fun port () ->
          let open Daemon_rpcs in
          match%map Client.dispatch Chain_id_inputs.rpc () port with
-         | Ok (genesis_state_hash, genesis_constants, snark_keys) ->
+         | Ok
+             ( genesis_state_hash
+             , genesis_constants
+             , snark_keys
+             , protocol_major_version ) ->
              let open Format in
              printf "Genesis state hash: %s@."
                (State_hash.to_base58_check genesis_state_hash) ;
@@ -2079,7 +2083,8 @@ let chain_id_inputs =
                | None ->
                    "None" ) ;
              printf "Snark keys:@." ;
-             List.iter snark_keys ~f:(printf "  %s@.")
+             List.iter snark_keys ~f:(printf "  %s@.") ;
+             printf "Protocol major version: %d@." protocol_major_version
          | Error err ->
              Format.eprintf "Could not get chain id inputs: %s@."
                (Error.to_string_hum err) ) )

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -116,7 +116,8 @@ end
 module Chain_id_inputs = struct
   type query = unit [@@deriving bin_io_unversioned]
 
-  type response = State_hash.Stable.Latest.t * Genesis_constants.t * string list
+  type response =
+    State_hash.Stable.Latest.t * Genesis_constants.t * string list * int
   [@@deriving bin_io_unversioned]
 
   let rpc : (query, response) Rpc.Rpc.t =

--- a/src/lib/mina_commands/dune
+++ b/src/lib/mina_commands/dune
@@ -4,6 +4,7 @@
  (libraries
    ;; opam libraries
    async_kernel
+   base
    core_kernel
    core
    async
@@ -46,8 +47,10 @@
    mina_ledger
    kimchi_backend.pasta
    pickles
+   protocol_version
    random_oracle
    transition_frontier_base
  )
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_coda ppx_version ppx_jane ppx_compare)))
+ (preprocessor_deps ../../config.mlh)
+ (preprocess (pps ppx_coda ppx_version ppx_let ppx_optcomp ppx_custom_printf ppx_compare)))

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -1,3 +1,5 @@
+[%%import "/src/config.mlh"]
+
 open Core
 open Async
 open Signature_lib
@@ -175,6 +177,8 @@ module Receipt_chain_verifier = Merkle_list_verifier.Make (struct
      Receipt.Chain_hash.cons_parties_commitment fee_payer_index elt parent_hash *)
 end)
 
+[%%inject "compile_time_current_protocol_version", current_protocol_version]
+
 let chain_id_inputs (t : Mina_lib.t) =
   (* these are the inputs to Blake2.digest_string in Mina.chain_id *)
   let config = Mina_lib.config t in
@@ -187,7 +191,11 @@ let chain_id_inputs (t : Mina_lib.t) =
     Lazy.force precomputed_values.constraint_system_digests
     |> List.map ~f:(fun (_, digest) -> Md5.to_hex digest)
   in
-  (genesis_state_hash, genesis_constants, snark_keys)
+  let protocol_major_version =
+    Protocol_version.of_string_exn compile_time_current_protocol_version
+    |> Protocol_version.major
+  in
+  (genesis_state_hash, genesis_constants, snark_keys, protocol_major_version)
 
 let verify_payment t (addr : Account_id.t) (verifying_txn : User_command.t)
     (init_receipt, proof) =

--- a/src/lib/protocol_version/dune
+++ b/src/lib/protocol_version/dune
@@ -12,6 +12,6 @@
    ppx_version.runtime
  )
  (preprocess
-  (pps ppx_version ppx_bin_prot ppx_sexp_conv ppx_compare ppx_deriving_yojson))
+  (pps ppx_version ppx_bin_prot ppx_fields_conv ppx_sexp_conv ppx_compare ppx_deriving_yojson))
  (instrumentation (backend bisect_ppx))
  (synopsis "Protocol version representation"))

--- a/src/lib/protocol_version/protocol_version.ml
+++ b/src/lib/protocol_version/protocol_version.ml
@@ -6,7 +6,7 @@ open Core_kernel
 module Stable = struct
   module V1 = struct
     type t = { major : int; minor : int; patch : int }
-    [@@deriving compare, sexp, yojson]
+    [@@deriving compare, sexp, yojson, fields]
 
     let to_latest = Fn.id
   end

--- a/src/lib/protocol_version/protocol_version.mli
+++ b/src/lib/protocol_version/protocol_version.mli
@@ -7,6 +7,12 @@ module Stable : sig
   end
 end]
 
+val major : t -> int
+
+val minor : t -> int
+
+val patch : t -> int
+
 val create_exn : major:int -> minor:int -> patch:int -> t
 
 val create_opt : major:int -> minor:int -> patch:int -> t option


### PR DESCRIPTION
Add the protocol major version to the chain id, by computing the MD5 digest of its string representation. Though the current protocol version is mutable (in theory), we use the compiled protocol version for this purpose.

Add the protocol major version to the chain id inputs shown via `advanced chain-id-inputs`. Tested that the protocol major version appears in that output by running a local network: 
```
$ mina advanced chain-id-inputs
Genesis state hash: 3NLfyLmMsATBkcR6kYYR7uyCJdgV6pZ6tY5kLSkDFxDSZY1YCkhi
Genesis_constants:
  Protocol:          {"k":24,"slots_per_epoch":576,"slots_per_sub_window":2,"delta":0,"genesis_state_timestamp":"2022-08-25 16:09:55.000000Z"}
  Txn pool max size: 3000
  Num accounts:      250
Snark keys:
  01a1b35830913fbac2036010ba1c805d
  26a06100f7aecdec6b3d9cea1cfa37de
  4ed236a957a87819b008001cc0b189c0
Protocol major version: 2
```
