### PR TITLE
Make rust target-feature flag customisable with an env var

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -17,10 +17,13 @@
   (system "printf \"%s\" $(realpath %{workspace_root}/..) > %{target}")))
 
 ;;
-;; rules to build the static library for kimchi
+;; Rules to set the optimisation flags for the rust compiler.
 ;;
-
-;; note: to build Mina, nix will set `MARLIN_PLONK_STUBS` and ignore this rule
+;; By default, we compile with optimisations enabled. The instructions that
+;; these generate may not be available on all CPU architectures; to build a
+;; slower version that does not use these instructions, set the environment
+;; variable `RUST_TARGET_FEATURE_OPTIMISATIONS=n`.
+;;
 
 (rule
  (enabled_if
@@ -37,6 +40,12 @@
  (action
   (with-stdout-to rustflags.sexp
    (echo "-C target-feature=-bmi2,-adx"))))
+
+;;
+;; rules to build the static library for kimchi
+;;
+
+;; note: to build Mina, nix will set `MARLIN_PLONK_STUBS` and ignore this rule
 
 (rule
  (enabled_if

--- a/src/lib/crypto/kimchi_bindings/stubs/dune
+++ b/src/lib/crypto/kimchi_bindings/stubs/dune
@@ -24,6 +24,22 @@
 
 (rule
  (enabled_if
+  (<> %{env:RUST_TARGET_FEATURE_OPTIMISATIONS=y} n))
+ (targets rustflags.sexp)
+ (action
+  (with-stdout-to rustflags.sexp
+   (echo "-C target-feature=+bmi2,+adx"))))
+
+(rule
+ (enabled_if
+  (= %{env:RUST_TARGET_FEATURE_OPTIMISATIONS=y} n))
+ (targets rustflags.sexp)
+ (action
+  (with-stdout-to rustflags.sexp
+   (echo "-C target-feature=-bmi2,-adx"))))
+
+(rule
+ (enabled_if
   (= %{env:MARLIN_PLONK_STUBS=n} n))
  (targets libwires_15_stubs.a)
  (deps
@@ -40,7 +56,7 @@
     "%{read:dune-build-root}/cargo_kimchi_stubs"
     (setenv
      RUSTFLAGS
-     "-C target-feature=+bmi2,+adx"
+     %{read:rustflags.sexp}
      (run cargo build --release)))
    (run
     cp


### PR DESCRIPTION
This PR tweaks the build of the rust bindings so that the optimisation flags can be enabled or disabled using the `RUST_TARGET_FEATURE_OPTIMISATIONS`.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them