### PR TITLE
Better error message when check_opam_switch is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,12 @@ ocaml_word_size:
 # This check is disabled in the pure nix environment (that does not use opam).
 check_opam_switch:
 ifneq ($(DISABLE_CHECK_OPAM_SWITCH), true)
+    ifeq (, $(shell which check_opam_switch))
+	$(warning The check_opam_switch binary was not found in the PATH.)
+	$(error The current opam switch should likely be updated by running: "opam switch import opam.export")
+    else
 	check_opam_switch opam.export
+    endif
 endif
 
 ocaml_checks: ocaml_version ocaml_word_size check_opam_switch


### PR DESCRIPTION
This PR adds a better error message to the Makefile if the `check_opam_switch` tool is missing,
explaining that is is meant to be installed by running `opam switch import opam.export`.