### PR TITLE
Protocol version 3.0

### DIFF
--- a/src/config/protocol_version/current.mlh
+++ b/src/config/protocol_version/current.mlh
@@ -1,1 +1,1 @@
-[%%define current_protocol_version "2.0.0"]
+[%%define current_protocol_version "3.0.0"]


### PR DESCRIPTION
Update protocol version to 3.0. The chain id uses the major version, 3.

Closes #11687.