### PR TITLE
Base64 for transaction ids

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -8650,7 +8650,7 @@
         {
           "kind": "SCALAR",
           "name": "TransactionId",
-          "description": "Base64-encoded transaction id",
+          "description": "Base64-encoded transaction",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -9013,7 +9013,11 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TransactionId",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -6390,6 +6390,16 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "CompletedWork",
           "description": "Completed snark works",
@@ -8220,30 +8230,20 @@
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "ZkappCommandBase58",
-          "description": "A Base58Check string representing the command",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "ZkappCommandResult",
           "description": null,
           "fields": [
             {
               "name": "id",
-              "description": "A Base58Check string representing the command",
+              "description": "A Base64 string representing the zkApp command",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "ZkappCommandBase58",
+                  "name": "TransactionId",
                   "ofType": null
                 }
               },
@@ -8317,7 +8317,11 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TransactionId",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -8645,8 +8649,8 @@
         },
         {
           "kind": "SCALAR",
-          "name": "ID",
-          "description": null,
+          "name": "TransactionId",
+          "description": "Base64-encoded transaction id",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -8697,7 +8701,11 @@
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
-                "ofType": { "kind": "SCALAR", "name": "ID", "ofType": null }
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TransactionId",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -11377,7 +11385,7 @@
             },
             {
               "name": "receiptChainHash",
-              "description": "Top hash of the receipt chain merkle-list",
+              "description": "Top hash of the receipt chain Merkle-list",
               "args": [],
               "type": {
                 "kind": "SCALAR",

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -679,26 +679,6 @@ module Export_logs = struct
        run ~tarfile ~conf_dir )
 end
 
-let get_transaction_status =
-  Command.async ~summary:"Get the status of a transaction"
-    (Cli_lib.Background_daemon.rpc_init
-       Command.Param.(anon @@ ("txn-id" %: string))
-       ~f:(fun port serialized_transaction ->
-         match Signed_command.of_base64 serialized_transaction with
-         | Ok user_command ->
-             Daemon_rpcs.Client.dispatch_with_message
-               Daemon_rpcs.Get_transaction_status.rpc user_command port
-               ~success:(fun status ->
-                 sprintf !"Transaction status : %s\n"
-                 @@ Transaction_inclusion_status.State.to_string status )
-               ~error:(fun e ->
-                 sprintf "Failed to get transaction status : %s"
-                   (Error.to_string_hum e) )
-               ~join_error:Or_error.join
-         | Error _e ->
-             eprintf "Could not deserialize user command" ;
-             exit 16 ) )
-
 let wrap_key =
   Command.async ~summary:"Wrap a private key into a private key file"
     (let open Command.Let_syntax in

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -496,6 +496,12 @@ let batch_send_payments =
        (Args.zip2 Cli_lib.Flag.privkey_read_path payment_path_flag)
        ~f:main )
 
+let transaction_id_to_string = function
+  | `String s ->
+      s
+  | _ ->
+      "Unexpected JSON for transaction id"
+
 let send_payment_graphql =
   let open Command.Param in
   let open Cli_lib.Arg_type in
@@ -527,7 +533,7 @@ let send_payment_graphql =
              graphql_endpoint
          in
          printf "Dispatched payment with ID %s\n"
-           response.sendPayment.payment.id ) )
+           (transaction_id_to_string response.sendPayment.payment.id) ) )
 
 let delegate_stake_graphql =
   let open Command.Param in
@@ -554,7 +560,7 @@ let delegate_stake_graphql =
              graphql_endpoint
          in
          printf "Dispatched stake delegation with ID %s\n"
-           response.sendDelegation.delegation.id ) )
+           (transaction_id_to_string response.sendDelegation.delegation.id) ) )
 
 let cancel_transaction_graphql =
   let txn_id_flag =
@@ -596,7 +602,8 @@ let cancel_transaction_graphql =
            Graphql_client.query_exn cancel_query graphql_endpoint
          in
          printf "🛑 Cancelled transaction! Cancel ID: %s\n"
-           cancel_response.sendPayment.payment.id ) )
+           (transaction_id_to_string cancel_response.sendPayment.payment.id) )
+    )
 
 let send_rosetta_transactions_graphql =
   Command.async
@@ -621,7 +628,8 @@ let send_rosetta_transactions_graphql =
                          graphql_endpoint
                      in
                      printf "Dispatched command with TRANSACTION_ID %s\n"
-                       response.sendRosettaTransaction.userCommand.id ;
+                       (transaction_id_to_string
+                          response.sendRosettaTransaction.userCommand.id ) ;
                      `Repeat ()
                    with Yojson.End_of_input -> return (`Finished ()) ) )
          with

--- a/src/lib/cli_lib/arg_type.ml
+++ b/src/lib/cli_lib/arg_type.ml
@@ -111,10 +111,11 @@ let log_level =
 
 let user_command =
   Command.Arg_type.create (fun s ->
-      try Mina_base.Signed_command.of_base58_check_exn s
-      with e ->
-        Error.tag (Error.of_exn e) ~tag:"Couldn't decode transaction id"
-        |> Error.raise )
+      match Mina_base.Signed_command.of_base64 s with
+      | Ok s ->
+          s
+      | Error err ->
+          Error.tag err ~tag:"Couldn't decode transaction id" |> Error.raise )
 
 module Work_selection_method = struct
   [%%versioned

--- a/src/lib/codable/codable.ml
+++ b/src/lib/codable/codable.ml
@@ -125,3 +125,28 @@ module type Base58_check_intf = sig
 
   include Base58_check_base_intf with type t := t
 end
+
+module Make_base64 (T : sig
+  type t [@@deriving bin_io]
+end) =
+struct
+  let to_base64 (t : T.t) : string =
+    Binable.to_string (module T) t
+    |> (* raises only on errors from invalid optional arguments *)
+    Base64.encode_exn
+
+  let of_base64 b64 : T.t Or_error.t =
+    match Base64.decode b64 with
+    | Ok s ->
+        Ok (Binable.of_string (module T) s)
+    | Error (`Msg msg) ->
+        Error (Error.of_string msg)
+end
+
+module type Base64_intf = sig
+  type t
+
+  val to_base64 : t -> string
+
+  val of_base64 : string -> t Or_error.t
+end

--- a/src/lib/codable/dune
+++ b/src/lib/codable/dune
@@ -6,6 +6,7 @@
  (libraries
    ;; opam libraries
    core_kernel
+   base64
    ppx_deriving_yojson.runtime
    yojson
    result

--- a/src/lib/graphql_basic_scalars/graphql_basic_scalars.ml
+++ b/src/lib/graphql_basic_scalars/graphql_basic_scalars.ml
@@ -145,6 +145,29 @@ end) : Json_intf with type t = T.t = struct
     Graphql_async.Schema.scalar Scalar.name ~doc:Scalar.doc ~coerce:serialize
 end
 
+module Make_scalar_using_base64 (T : sig
+  type t
+
+  val to_base64 : t -> string
+
+  val of_base64 : string -> t Core_kernel.Or_error.t
+end) (Scalar : sig
+  val name : string
+
+  val doc : string
+end) : Json_intf with type t = T.t = struct
+  type t = T.t
+
+  let parse json =
+    Yojson.Basic.Util.to_string json
+    |> T.of_base64 |> Core_kernel.Or_error.ok_exn
+
+  let serialize x = `String (T.to_base64 x)
+
+  let typ () =
+    Graphql_async.Schema.scalar Scalar.name ~doc:Scalar.doc ~coerce:serialize
+end
+
 module InetAddr =
   Make_scalar_using_to_string
     (Core.Unix.Inet_addr)

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -645,6 +645,12 @@ module Node = struct
     ; nonce : Mina_numbers.Account_nonce.t
     }
 
+  let transaction_id_to_string = function
+    | `String s ->
+        s
+    | _ ->
+        failwith "Unexpected JSON for transaction ID"
+
   (* if we expect failure, might want retry_on_graphql_error to be false *)
   let send_payment ~logger t ~sender_pub_key ~receiver_pub_key ~amount ~fee =
     [%log info] "Sending a payment" ~metadata:(logger_metadata t) ;
@@ -678,7 +684,7 @@ module Node = struct
     let%map sent_payment_obj = send_payment_graphql () in
     let return_obj = sent_payment_obj.sendPayment.payment in
     let res =
-      { id = return_obj.id
+      { id = transaction_id_to_string return_obj.id
       ; hash = return_obj.hash
       ; nonce = Mina_numbers.Account_nonce.of_int return_obj.nonce
       }
@@ -733,8 +739,7 @@ module Node = struct
             |> Yojson.Safe.to_string )
     in
     let zkapp_id =
-      Mina_base.Zkapp_command.to_base58_check
-        sent_zkapp_obj.internalSendZkapp.zkapp.id
+      transaction_id_to_string sent_zkapp_obj.internalSendZkapp.zkapp.id
     in
     [%log info] "Sent zkapp" ~metadata:[ ("zkapp_id", `String zkapp_id) ] ;
     return zkapp_id
@@ -772,7 +777,7 @@ module Node = struct
     let%map result_obj = send_delegation_graphql () in
     let return_obj = result_obj.sendDelegation.delegation in
     let res =
-      { id = return_obj.id
+      { id = transaction_id_to_string return_obj.id
       ; hash = return_obj.hash
       ; nonce = Mina_numbers.Account_nonce.of_int return_obj.nonce
       }
@@ -816,7 +821,7 @@ module Node = struct
     let%map sent_payment_obj = send_payment_graphql () in
     let return_obj = sent_payment_obj.sendPayment.payment in
     let res =
-      { id = return_obj.id
+      { id = transaction_id_to_string return_obj.id
       ; hash = return_obj.hash
       ; nonce = Mina_numbers.Account_nonce.of_int return_obj.nonce
       }

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -354,6 +354,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
   [%%define_locally
   Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
 
+  include Codable.Make_base64 (Stable.Latest)
+
   let check_signature ?signature_kind ({ payload; signer; signature } : t) =
     Signature_lib.Schnorr.Legacy.verify ?signature_kind signature
       (Snark_params.Tick.Inner_curve.of_affine signer)

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -198,6 +198,8 @@ module type S = sig
   val filter_by_participant : t list -> Public_key.Compressed.t -> t list
 
   include Codable.Base58_check_intf with type t := t
+
+  include Codable.Base64_intf with type t := t
 end
 
 module type Full = sig

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -72,6 +72,28 @@ module Stable = struct
   end
 end]
 
+let to_base64 : t -> string = function
+  | Signed_command sc ->
+      Signed_command.to_base64 sc
+  | Zkapp_command zc ->
+      Zkapp_command.to_base64 zc
+
+let of_base64 s : t Or_error.t =
+  match Signed_command.of_base64 s with
+  | Ok sc ->
+      Ok (Signed_command sc)
+  | Error err1 -> (
+      match Zkapp_command.of_base64 s with
+      | Ok zc ->
+          Ok (Zkapp_command zc)
+      | Error err2 ->
+          Error
+            (Error.of_string
+               (sprintf
+                  "Could decode Base64 neither to signed command (%s), nor to \
+                   zkApp (%s)"
+                  (Error.to_string_hum err1) (Error.to_string_hum err2) ) ) )
+
 (*
 include Allocation_functor.Make.Versioned_v1.Full_compare_eq_hash (struct
   let id = "user_command"

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1518,6 +1518,8 @@ include Codable.Make_base58_check (Stable.Latest)
 (* shadow the definitions from Make_base58_check *)
 [%%define_locally Stable.Latest.(of_yojson, to_yojson)]
 
+include Codable.Make_base64 (Stable.Latest)
+
 type account_updates =
   (Account_update.t, Digest.Account_update.t, Digest.Forest.t) Call_forest.t
 

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -209,6 +209,8 @@ module Types = struct
 
     let transaction_hash = TransactionHash.typ ()
 
+    let transaction_id = TransactionId.typ ()
+
     let precomputed_block_proof = PrecomputedBlockProof.typ ()
   end
 
@@ -1240,7 +1242,7 @@ module Types = struct
                             $error" ;
                          None ) )
              ; field "receiptChainHash" ~typ:chain_hash
-                 ~doc:"Top hash of the receipt chain merkle-list"
+                 ~doc:"Top hash of the receipt chain Merkle-list"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
                    account.Account.Poly.receipt_chain_hash )
@@ -1572,9 +1574,9 @@ module Types = struct
         , (Signed_command.t, Transaction_hash.t) With_hash.t With_status.t )
         field
         list =
-      [ field_no_status "id" ~typ:(non_null guid) ~args:[]
+      [ field_no_status "id" ~typ:(non_null transaction_id) ~args:[]
           ~resolve:(fun _ user_command ->
-            Signed_command.to_base58_check user_command.With_hash.data )
+            Signed_command user_command.With_hash.data )
       ; field_no_status "hash" ~typ:(non_null transaction_hash) ~args:[]
           ~resolve:(fun _ user_command -> user_command.With_hash.hash)
       ; field_no_status "kind" ~typ:(non_null kind) ~args:[]
@@ -1736,12 +1738,10 @@ module Types = struct
       in
       obj "ZkappCommandResult" ~fields:(fun _ ->
           [ field_no_status "id"
-              ~doc:"A Base58Check string representing the command"
-              ~typ:
-                ( non_null
-                @@ Mina_base_unix.Graphql_scalars.ZkappCommandBase58.typ () )
-              ~args:[]
-              ~resolve:(fun _ zkapp_command -> zkapp_command.With_hash.data)
+              ~doc:"A Base64 string representing the zkApp command"
+              ~typ:(non_null transaction_id) ~args:[]
+              ~resolve:(fun _ zkapp_command ->
+                Zkapp_command zkapp_command.With_hash.data )
           ; field_no_status "hash"
               ~doc:"A cryptographic hash of the zkApp command"
               ~typ:(non_null transaction_hash) ~args:[]

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4018,7 +4018,7 @@ module Queries = struct
           match txns_opt with
           | Some txns ->
               List.filter_map txns ~f:(fun serialized_txn ->
-                  Signed_command.of_base58_check serialized_txn
+                  Signed_command.of_base64 serialized_txn
                   |> Result.map ~f:(fun signed_command ->
                          (* These commands get piped through [forget_check]
                             below; this is just to make the types work
@@ -4319,11 +4319,11 @@ module Queries = struct
             match serialized_txn with
             | `Signed_command cmd ->
                 Or_error.(
-                  Signed_command.of_base58_check cmd
+                  Signed_command.of_base64 cmd
                   >>| fun c -> User_command.Signed_command c)
             | `Zkapp_command cmd ->
                 Or_error.(
-                  Zkapp_command.of_base58_check cmd
+                  Zkapp_command.of_base64 cmd
                   >>| fun c -> User_command.Zkapp_command c)
           in
           result_of_or_error res ~error:"Invalid transaction provided"

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1501,7 +1501,7 @@ module Types = struct
         typ =
       interface "UserCommand" ~doc:"Common interface for user commands"
         ~fields:(fun _ ->
-          [ abstract_field "id" ~typ:(non_null guid) ~args:[]
+          [ abstract_field "id" ~typ:(non_null transaction_id) ~args:[]
           ; abstract_field "hash" ~typ:(non_null transaction_hash) ~args:[]
           ; abstract_field "kind" ~typ:(non_null kind) ~args:[]
               ~doc:"String describing the kind of user command"

--- a/src/lib/transaction/transaction_id.ml
+++ b/src/lib/transaction/transaction_id.ml
@@ -1,0 +1,7 @@
+(* transaction_id.ml : type and Base64 conversions for GraphQL *)
+
+module User_command = Mina_base.User_command
+
+type t = User_command.t
+
+[%%define_locally User_command.(to_base64, of_base64)]

--- a/src/lib/transaction/unix/graphql_scalars.ml
+++ b/src/lib/transaction/unix/graphql_scalars.ml
@@ -15,5 +15,5 @@ module TransactionId =
     (struct
       let name = "TransactionId"
 
-      let doc = "Base64-encoded transaction id"
+      let doc = "Base64-encoded transaction"
     end)

--- a/src/lib/transaction/unix/graphql_scalars.ml
+++ b/src/lib/transaction/unix/graphql_scalars.ml
@@ -8,3 +8,12 @@ module TransactionHash =
 
       let doc = "Base58Check-encoded transaction hash"
     end)
+
+module TransactionId =
+  Make_scalar_using_base64
+    (Mina_transaction.Transaction_id)
+    (struct
+      let name = "TransactionId"
+
+      let doc = "Base64-encoded transaction id"
+    end)


### PR DESCRIPTION
GraphQL returns transaction id's that were the Base58Check encoding of user commands. For zkApps especially, that's computationally expensive.

Instead, return a Base64 encoding derived from the `Bin_prot` serialization of the commands. Add a new functor to `Codable` for this purpose, which might be useful more generally.

In `Mina_graphql`, introduce a type `transaction_id` to perform the conversion, using the same pattern as the existing `transaction_hash`.

Closes #11505.