### PR TITLE
Update Google Cloud SDK on BuildKite agents

### DIFF
--- a/automation/terraform/modules/kubernetes/buildkite-agent/variables.tf
+++ b/automation/terraform/modules/kubernetes/buildkite-agent/variables.tf
@@ -64,7 +64,7 @@ variable "gcloudsdk_download_url" {
   type = string
 
   description = "gcloud sdk tool archive download URL"
-  default = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-296.0.1-linux-x86_64.tar.gz"
+  default = "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-400.0.0-linux-x86_64.tar.gz"
 }
 
 variable "artifact_upload_bin" {


### PR DESCRIPTION
The Google Cloud SDK that is deployed on the current BuildKite agents is
quite old, and thus is missing some flags I need to be able to proceed
with #10939. Namely, the `--worker-pool` flag is missing in this
version.

Explain your changes:
* Update Google Cloud SDK download URL from version 296.0.1 to 400.0.0

Explain how you tested your changes:
* I have not. The changes first have to be applied to the agents. I don't think i can do this.