### PR TITLE
Factor out sequence state update logic

### DIFF
--- a/src/lib/mina_generators/parties_generators.ml
+++ b/src/lib/mina_generators/parties_generators.ml
@@ -888,8 +888,6 @@ let gen_party_body_components (type a b c d) ?(update = None) ?account_id
        | None ->
            None
        | Some zk ->
-           (*TODO: Deduplicate this from what's in parties logic to get the
-              account precondition right*)
            let app_state =
              let account_app_state = zk.app_state in
              List.zip_exn
@@ -900,14 +898,7 @@ let gen_party_body_components (type a b c d) ?(update = None) ?account_id
              |> Zkapp_state.V.of_list_exn
            in
            let sequence_state =
-             let [ s1'; s2'; s3'; s4'; s5' ] = zk.sequence_state in
              let last_sequence_slot = zk.last_sequence_slot in
-             (* Push events to s1. *)
-             let is_empty = List.is_empty sequence_events in
-             let s1_updated =
-               Party.Sequence_events.push_events s1' sequence_events
-             in
-             let s1 = if is_empty then s1' else s1_updated in
              let txn_global_slot =
                Option.value_map protocol_state_view ~default:last_sequence_slot
                  ~f:(fun ps ->
@@ -915,16 +906,11 @@ let gen_party_body_components (type a b c d) ?(update = None) ?account_id
                      .Zkapp_precondition.Protocol_state.Poly
                       .global_slot_since_genesis )
              in
-             (* Shift along if last update wasn't this slot  *)
-             let is_this_slot =
-               Mina_numbers.Global_slot.equal txn_global_slot last_sequence_slot
+             let sequence_state, _last_sequence_slot =
+               Mina_ledger.Ledger.update_sequence_state zk.sequence_state
+                 sequence_events ~txn_global_slot ~last_sequence_slot
              in
-             let is_full_and_different_slot = (not is_empty) && is_this_slot in
-             let s5 = if is_full_and_different_slot then s5' else s4' in
-             let s4 = if is_full_and_different_slot then s4' else s3' in
-             let s3 = if is_full_and_different_slot then s3' else s2' in
-             let s2 = if is_full_and_different_slot then s2' else s1' in
-             ([ s1; s2; s3; s4; s5 ] : _ Pickles_types.Vector.t)
+             sequence_state
            in
            let proved_state =
              let keeping_app_state =

--- a/src/lib/mina_ledger/dune
+++ b/src/lib/mina_ledger/dune
@@ -27,6 +27,7 @@
    parties_builder
    pickles
    pickles.backend
+   pickles_types
    mina_base.import
    o1trace
    rocksdb

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -214,6 +214,17 @@ val apply_transaction :
   -> Transaction.t
   -> Transaction_applied.t Or_error.t
 
+(** update sequence state, returned slot is new last sequence slot
+    made available here so we can use this logic in the Parties generators
+*)
+val update_sequence_state :
+     Snark_params.Tick.Field.t Pickles_types.Vector.Vector_5.t
+  -> Zkapp_account.Sequence_events.t
+  -> txn_global_slot:Mina_numbers.Global_slot.t
+  -> last_sequence_slot:Mina_numbers.Global_slot.t
+  -> Snark_params.Tick.Field.t Pickles_types.Vector.Vector_5.t
+     * Mina_numbers.Global_slot.t
+
 val apply_parties_unchecked :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> state_view:Zkapp_precondition.Protocol_state.View.t
@@ -267,7 +278,7 @@ type init_state =
 [@@deriving sexp_of]
 
 (** Generate an initial ledger state. There can't be a regular Quickcheck
-    generator for this type because you need to detach a mask from it's parent
+    generator for this type because you need to detach a mask from its parent
     when you're done with it - the GC doesn't take care of that. *)
 val gen_initial_ledger_state : init_state Quickcheck.Generator.t
 

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -306,6 +306,13 @@ module type S = sig
     -> Signed_command.t
     -> Transaction_applied.Signed_command_applied.t Or_error.t
 
+  val update_sequence_state :
+       Snark_params.Tick.Field.t Pickles_types.Vector.Vector_5.t
+    -> Zkapp_account.Sequence_events.t
+    -> txn_global_slot:Global_slot.t
+    -> last_sequence_slot:Global_slot.t
+    -> Snark_params.Tick.Field.t Pickles_types.Vector.Vector_5.t * Global_slot.t
+
   val apply_parties_unchecked :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> state_view:Zkapp_precondition.Protocol_state.View.t
@@ -1592,6 +1599,14 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
   end
 
   module M = Parties_logic.Make (Inputs)
+
+  let update_sequence_state sequence_state sequence_events ~txn_global_slot
+      ~last_sequence_slot =
+    let sequence_state', last_sequence_slot' =
+      M.update_sequence_state sequence_state sequence_events ~txn_global_slot
+        ~last_sequence_slot
+    in
+    (sequence_state', last_sequence_slot')
 
   let apply_parties_unchecked_aux (type user_acc)
       ~(constraint_constants : Genesis_constants.Constraint_constants.t)


### PR DESCRIPTION
In the Parties generator, there is code to update the sequence state in the same way as `Parties_logic`. The `Parties_logic` code was updated, but the generator code did not change to match it.

Factor out the sequence update logic into a new function `update_sequence_state` in `Parties_logic`. Make that function available in unchecked code from `Mina_transaction_logic` (which includes an instantiation of `Parties_logic`).  In turn, `Mina_ledger.Ledger` includes `Mina_transaction_logic`, so we can export `update_sequence_state` from it. And so the Parties generators can use that function, instead of duplicating the update logic.

That's all a bit circuitous, imports a lot of extra code into the generators, and perhaps funny to offer that functionality from `Ledger`, but perhaps OK.

Closes #11752.