### PR TITLE
Add missig dependency to batch_txn_tool

### DIFF
--- a/src/app/batch_txn_tool/dune
+++ b/src/app/batch_txn_tool/dune
@@ -22,6 +22,7 @@
    mina_numbers
    snark_params
    unsigned_extended
+   mina_wire_types
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps 


### PR DESCRIPTION
This PR adds the missing `mina_wire_types` dependency needed for `src/app/batch_txn_tool` to compile.