### PR TITLE
Specify libp2p-keypair explicitly

### DIFF
--- a/automation/scripts/gen-keys-ledger.sh
+++ b/automation/scripts/gen-keys-ledger.sh
@@ -70,7 +70,7 @@ done
 echo "generating seeds' libp2p keys"
 mkdir "${KEYSDIR}/libp2p-keys"
 for i in $(seq 1 $SEEDS); do
-    mina advanced generate-libp2p-keypair --privkey-path "${KEYSDIR}/libp2p-keys/seed-${i}" 2>/dev/null
+    mina libp2p generate-keypair --privkey-path "${KEYSDIR}/libp2p-keys/seed-${i}" 2>/dev/null
 done
 
 

--- a/automation/scripts/generate-keys-and-ledger.sh
+++ b/automation/scripts/generate-keys-and-ledger.sh
@@ -110,7 +110,7 @@ function generate_key_files {
     docker run \
       --mount type=bind,source=${output_dir},target=/keys \
       --entrypoint /bin/bash $MINA_DAEMON_IMAGE \
-      -c "MINA_LIBP2P_PASS='${privkey_pass}' mina advanced generate-libp2p-keypair -privkey-path /keys/${name_prefix}_libp2p_${k}"
+      -c "MINA_LIBP2P_PASS='${privkey_pass}' mina libp2p generate-keypair -privkey-path /keys/${name_prefix}_libp2p_${k}"
   done
 
   # ensure proper r+w permissions for access to keys external to container

--- a/automation/terraform/modules/google-cloud/coda-seed-node/main.tf
+++ b/automation/terraform/modules/google-cloud/coda-seed-node/main.tf
@@ -1,5 +1,5 @@
 locals {
-  container_command = format("mina daemon -log-level Info -config-directory /root/.mina-config -client-port 8301 -rest-port 8304 -external-port 10001 -metrics-port 10000 -discovery-keypair %s -seed %s -config-file /root/daemon.json | tee log.txt", var.discovery_keypair, var.seed_peers)
+  container_command = format("mina daemon -log-level Info -config-directory /root/.mina-config -client-port 8301 -rest-port 8304 -external-port 10001 -metrics-port 10000 -libp2p-keypair %s -seed %s -config-file /root/daemon.json | tee log.txt", var.discovery_keypair, var.seed_peers)
 }
 
 resource "google_compute_address" "external_ip" {

--- a/automation/terraform/modules/kubernetes/testnet/helm.tf
+++ b/automation/terraform/modules/kubernetes/testnet/helm.tf
@@ -26,7 +26,7 @@ resource "helm_release" "seeds" {
   name       = "${var.testnet_name}-seeds"
   repository = var.use_local_charts ? "" : local.mina_helm_repo
   chart      = var.use_local_charts ? "../../../../helm/seed-node" : "seed-node"
-  version    = "1.0.6"
+  version    = "1.0.8"
   namespace  = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.seed_vars)
@@ -47,7 +47,7 @@ resource "helm_release" "block_producers" {
   name       = "${var.testnet_name}-block-producers"
   repository = var.use_local_charts ? "" : local.mina_helm_repo
   chart      = var.use_local_charts ? "../../../../helm/block-producer" : "block-producer"
-  version    = "1.0.5"
+  version    = "1.0.7"
   namespace  = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.block_producer_vars)
@@ -83,7 +83,7 @@ resource "helm_release" "snark_workers" {
   name       = "${var.testnet_name}-snark-set-${count.index + 1}"
   repository = var.use_local_charts ? "" : local.mina_helm_repo
   chart      = var.use_local_charts ? "../../../../helm/snark-worker" : "snark-worker"
-  version    = "1.0.3"
+  version    = "1.0.5"
   namespace  = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.snark_vars[count.index])
@@ -102,7 +102,7 @@ resource "helm_release" "archive_node" {
   name       = "archive-${count.index + 1}"
   repository = var.use_local_charts ? "" : local.mina_helm_repo
   chart      = var.use_local_charts ? "../../../../helm/archive-node" : "archive-node"
-  version    = "1.0.5"
+  version    = "1.0.7"
   namespace  = kubernetes_namespace.testnet_namespace.metadata[0].name
   values = [
     yamlencode(local.archive_vars[count.index])

--- a/buildkite/scripts/unit-test.sh
+++ b/buildkite/scripts/unit-test.sh
@@ -12,8 +12,10 @@ path=$2
 
 source ~/.profile
 
+export MINA_LIBP2P_PASS="naughty blue worm"
+
 echo "--- Make build"
-export LIBP2P_NIXLESS=1 PATH=/usr/lib/go/bin:$PATH GO=/usr/lib/go/bin/go 
+export LIBP2P_NIXLESS=1 PATH=/usr/lib/go/bin:$PATH GO=/usr/lib/go/bin/go
 time make build
 
 # Note: By attempting a re-run on failure here, we can avoid rebuilding and

--- a/flake.nix
+++ b/flake.nix
@@ -351,6 +351,8 @@
         devShells.default = self.devShell.${system};
 
         devShells.with-lsp = ocamlPackages.mina-dev.overrideAttrs (oa: {
+          buildInputs = oa.buildInputs
+            ++ [ pkgs.go_1_18 ];
           nativeBuildInputs = oa.nativeBuildInputs
             ++ [ ocamlPackages.ocaml-lsp-server ];
           shellHook = ''

--- a/helm/archive-node/Chart.yaml
+++ b/helm/archive-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: archive-node
 description: A Helm chart for Mina Protocol's archive node
 type: application
-version: 1.0.6
+version: 1.0.7
 appVersion: 1.16.0
 annotations:
   artifacthub.io/changes: |

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -24,6 +24,19 @@ spec:
         prometheus.io/port: {{ .Values.archive.ports.metrics | quote }}
         prometheus.io/path: '/metrics'
     spec:
+      initContainers:
+      - name: libp2p-perms
+        image: {{ $.Values.mina.image | quote }}
+        command:
+        - bash
+        - -c
+        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key
+        volumeMounts:
+        - name: actual-libp2p
+          mountPath: /root/libp2p-keys
+        env:
+          - name: MINA_LIBP2P_PASS
+            value: {{ $.Values.mina.privkeyPass | quote }}
       containers:
 {{- if .Values.archive.enableLocalDaemon }}
       - name: mina
@@ -60,6 +73,7 @@ spec:
           {{- if .Values.mina.seedPeersURL }}
           "-peer-list-url", {{ .Values.mina.seedPeersURL | quote }},
           {{- end -}}
+          "-libp2p-keypair", "/root/libp2p-keys/key",
           "-config-directory", "/root/.mina-config",
           "-client-port", "$(DAEMON_CLIENT_PORT)",
           "-rest-port", "$(DAEMON_REST_PORT)",
@@ -85,6 +99,8 @@ spec:
           value: {{ .Values.mina.ports.p2p | quote }}
         - name: MINA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
+        - name: MINA_LIBP2P_PASS
+          value: {{ $.Values.mina.privkeyPass | quote }}
         ports:
         - name: client-port
           protocol: TCP 
@@ -110,6 +126,8 @@ spec:
         - name: daemon-config
           mountPath: "/config/"
         {{- end }}
+        - name: actual-libp2p
+          mountPath: /root/libp2p-keys
 {{- end }}
       # Archive Process
       - name: archive
@@ -151,3 +169,5 @@ spec:
         configMap:
           name: "{{ template "archive-node.fullname" . }}-daemon-config"
       {{- end }}
+      - name: actual-libp2p
+        emptyDir: {}

--- a/helm/archive-node/templates/archive.yaml
+++ b/helm/archive-node/templates/archive.yaml
@@ -30,7 +30,7 @@ spec:
         command:
         - bash
         - -c
-        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key
+        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key && /bin/chmod -R 0700 /root/libp2p-keys/
         volumeMounts:
         - name: actual-libp2p
           mountPath: /root/libp2p-keys

--- a/helm/block-producer/Chart.yaml
+++ b/helm/block-producer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: block-producer
 description: A Helm chart for Mina Protocol's block producing network nodes
 type: application
-version: 1.0.6
+version: 1.0.7
 appVersion: 1.16.0
 annotations:
   artifacthub.io/changes: |

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -197,7 +197,7 @@ spec:
           "-enable-flooding", "true",
           {{- end -}}
           {{- if $config.libp2pSecret }}
-          "-discovery-keypair", "/root/libp2p-keys/key",
+          "-libp2p-keypair", "/root/libp2p-keys/key",
           {{- end -}}
           {{- range $.Values.mina.seedPeers }}
           "-peer", {{ . | quote }},

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -79,7 +79,7 @@ spec:
         command:
         - bash
         - -c
-        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key
+        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key && /bin/chmod -R 0700 /root/libp2p-keys/
         volumeMounts:
         - name: actual-libp2p
           mountPath: /root/libp2p-keys

--- a/helm/block-producer/templates/block-producer.yaml
+++ b/helm/block-producer/templates/block-producer.yaml
@@ -73,6 +73,19 @@ spec:
           mountPath: /libp2p-keys
         - name: actual-libp2p
           mountPath: /root/libp2p-keys
+      {{- else -}}
+      - name: libp2p-perms
+        image: {{ $.Values.mina.image | quote }}
+        command:
+        - bash
+        - -c
+        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key
+        volumeMounts:
+        - name: actual-libp2p
+          mountPath: /root/libp2p-keys
+        env:
+          - name: MINA_LIBP2P_PASS
+            value: {{ $.Values.mina.privkeyPass | quote }}
       {{- end }}
       containers:
       {{ if $config.runWithUserAgent -}}
@@ -196,9 +209,7 @@ spec:
           {{- if $config.enableGossipFlooding }}
           "-enable-flooding", "true",
           {{- end -}}
-          {{- if $config.libp2pSecret }}
           "-libp2p-keypair", "/root/libp2p-keys/key",
-          {{- end -}}
           {{- range $.Values.mina.seedPeers }}
           "-peer", {{ . | quote }},
           {{- end -}}
@@ -244,10 +255,8 @@ spec:
           value: "mina_network_block_data"
         - name: MINA_PRIVKEY_PASS
           value: {{ $.Values.mina.privkeyPass | quote }}
-        {{- if $config.libp2pSecret }}
         - name: MINA_LIBP2P_PASS
           value: {{ $.Values.mina.privkeyPass | quote }}
-        {{- end }}
         - name: MINA_CLIENT_TRUSTLIST
           value: "10.0.0.0/8"
         ports:
@@ -272,10 +281,8 @@ spec:
           mountPath: /root/wallet-keys
         - name: config-dir
           mountPath: /root/.mina-config
-        {{- if $config.libp2pSecret }}
         - name: actual-libp2p
           mountPath: /root/libp2p-keys
-        {{- end }}
         {{- if $.Values.mina.uploadBlocksToGCloud }}
         - name: gcloud-keyfile
           mountPath: "/gcloud/"

--- a/helm/block-producer/values.yaml
+++ b/helm/block-producer/values.yaml
@@ -51,7 +51,6 @@ blockProducerConfigs:
     isolated: false
     enableGossipFlooding: false
     enablePeerExchange: false
-    libp2pSecret: "libp2pYolo"
     enableArchive: true
     archiveAddress: archive-1:3086
   - name: "test-2"
@@ -61,7 +60,6 @@ blockProducerConfigs:
     isolated: false
     enableGossipFlooding: false
     enablePeerExchange: false
-    libp2pSecret: "libp2pYolo"
     enableArchive: false
     archiveAddress: archive-1:3086
   - name: "test-3"

--- a/helm/seed-node/Chart.yaml
+++ b/helm/seed-node/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: seed-node
 description: A Helm chart for Mina Protocol's seed nodes
 type: application
-version: 1.0.7
+version: 1.0.8
 appVersion: 1.16.0
 annotations:
   artifacthub.io/changes: |

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -37,6 +37,19 @@ spec:
           mountPath: /libp2p-keys
         - name: actual-libp2p
           mountPath: /root/libp2p-keys
+      {{- else -}}
+      - name: libp2p-perms
+        image: {{ $.Values.mina.image | quote }}
+        command:
+        - bash
+        - -c
+        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key
+        volumeMounts:
+        - name: actual-libp2p
+          mountPath: /root/libp2p-keys
+        env:
+          - name: MINA_LIBP2P_PASS
+            value: {{ $.Values.mina.privkeyPass | quote }}
       {{- end }}
       containers:
       - name: mina
@@ -77,9 +90,7 @@ spec:
           {{- if $.Values.mina.runtimeConfig }}
           "-config-file", "/config/daemon.json",
           {{- end }}
-          {{- if $config.libp2pSecret }}
           "-libp2p-keypair", "/root/libp2p-keys/key",
-          {{- end -}}
           {{- range $.Values.mina.seedPeers }}
           "-peer", {{ . | quote }},
           {{- end }}
@@ -111,10 +122,8 @@ spec:
           value: "mina_network_block_data"
         - name: DAEMON_EXTERNAL_PORT
           value: {{ default $.Values.mina.ports.p2p $config.externalPort | quote }}
-        {{- if $config.libp2pSecret }}
         - name: MINA_LIBP2P_PASS
           value: {{ $.Values.mina.privkeyPass | quote }}
-        {{- end }}
         ports:
         - name: client-port
           protocol: TCP
@@ -133,10 +142,8 @@ spec:
 {{- include "healthcheck.seed.allChecks" $data | indent 8 }}
         imagePullPolicy: Always
         volumeMounts:
-        {{- if $config.libp2pSecret }}
         - name: actual-libp2p
           mountPath: /root/libp2p-keys
-        {{- end }}
         {{- if $.Values.mina.uploadBlocksToGCloud }}
         - name: gcloud-keyfile
           mountPath: "/gcloud/"

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -78,7 +78,7 @@ spec:
           "-config-file", "/config/daemon.json",
           {{- end }}
           {{- if $config.libp2pSecret }}
-          "-discovery-keypair", "/root/libp2p-keys/key",
+          "-libp2p-keypair", "/root/libp2p-keys/key",
           {{- end -}}
           {{- range $.Values.mina.seedPeers }}
           "-peer", {{ . | quote }},

--- a/helm/seed-node/templates/seed-node.yaml
+++ b/helm/seed-node/templates/seed-node.yaml
@@ -43,7 +43,7 @@ spec:
         command:
         - bash
         - -c
-        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key
+        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key && /bin/chmod -R 0700 /root/libp2p-keys/
         volumeMounts:
         - name: actual-libp2p
           mountPath: /root/libp2p-keys

--- a/helm/seed-node/values.yaml
+++ b/helm/seed-node/values.yaml
@@ -8,6 +8,7 @@ mina:
   image: gcr.io/o1labs-192920/mina-daemon:1.2.0beta8-5b35b27-devnet
   useCustomEntrypoint: false
   customEntrypoint: ""
+  privkeyPass: "naughty blue worm"
   seedPeers:
     - /ip4/35.185.66.37/tcp/10105/p2p/12D3KooWQ7Pz3SPizarzx9ZhCJ6jNmQ2iDPgHQxVzRzqYU2SgRSd
     - /ip4/35.237.214.144/tcp/10120/p2p/12D3KooWGtjWnCcvkaSEbKuNbPivEogxqtLWcsJiQtURydptvrsA

--- a/helm/snark-worker/Chart.yaml
+++ b/helm/snark-worker/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: snark-worker
 description: A Helm chart for Mina Protocol's SNARK worker nodes
 type: application
-version: 1.0.4
+version: 1.0.5
 appVersion: 1.16.0
 annotations:
   artifacthub.io/changes: |

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -28,7 +28,7 @@ spec:
         command:
         - bash
         - -c
-        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key
+        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key && /bin/chmod -R 0700 /root/libp2p-keys/
         volumeMounts:
         - name: actual-libp2p
           mountPath: /root/libp2p-keys

--- a/helm/snark-worker/templates/snark-coordinator.yaml
+++ b/helm/snark-worker/templates/snark-coordinator.yaml
@@ -22,6 +22,19 @@ spec:
         prometheus.io/port: {{ $.Values.mina.ports.metrics | quote }}
         prometheus.io/path: '/metrics'
     spec:
+      initContainers:
+      - name: libp2p-perms
+        image: {{ $.Values.mina.image | quote }}
+        command:
+        - bash
+        - -c
+        - mina libp2p generate-keypair --privkey-path /root/libp2p-keys/key
+        volumeMounts:
+        - name: actual-libp2p
+          mountPath: /root/libp2p-keys
+        env:
+          - name: MINA_LIBP2P_PASS
+            value: {{ $.Values.mina.privkeyPass | quote }}
       containers:
       - name: mina
         resources:
@@ -46,6 +59,7 @@ spec:
           "-snark-worker-fee", "$(CODA_SNARK_FEE)",
           "-work-selection", "$(WORK_SELECTION)",
           "-enable-peer-exchange", "true",
+          "-libp2p-keypair", "/root/libp2p-keys/key",
           {{- if $.Values.mina.logTxnPoolGossip }}
           "-log-txn-pool-gossip", "true",
           {{- end -}}
@@ -82,6 +96,8 @@ spec:
           value: {{ $.Values.mina.ports.p2p | quote }}
         - name: WORK_SELECTION
           value: {{$.Values.workSelectionAlgorithm | quote }}
+        - name: MINA_LIBP2P_PASS
+          value: {{ $.Values.mina.privkeyPass | quote }}
         ports:
         - name: client-port
           protocol: TCP 
@@ -100,13 +116,19 @@ spec:
 {{$data := dict "name" $name "healthcheck" $.Values.healthcheck }}
 {{- include "healthcheck.snarkCoordinator.allChecks" $data | indent 8 }}
         imagePullPolicy: Always
-      {{- if $.Values.mina.runtimeConfig }}
         volumeMounts:
+        {{- if $.Values.mina.runtimeConfig }}
         - name: daemon-config
           mountPath: "/config/"
+        {{- end }}
+        - name: actual-libp2p
+          mountPath: /root/libp2p-keys
       volumes:
+      {{- if $.Values.mina.runtimeConfig }}
       - name: daemon-config
         configMap:
           name: {{$.Values.coordinatorName }}-daemon-config
       {{- end }}
+      - name: actual-libp2p
+        emptyDir: {}
 {{- include "nodeSelector.preemptible" $.Values | indent 6 }}

--- a/helm/snark-worker/values.yaml
+++ b/helm/snark-worker/values.yaml
@@ -13,6 +13,7 @@ mina:
   image: gcr.io/o1labs-192920/mina-daemon:1.2.0beta8-5b35b27-devnet
   useCustomEntrypoint: false
   customEntrypoint: ""
+  privkeyPass: "naughty blue worm"
   seedPeers:
     - /ip4/35.185.66.37/tcp/10105/p2p/12D3KooWQ7Pz3SPizarzx9ZhCJ6jNmQ2iDPgHQxVzRzqYU2SgRSd
     - /ip4/35.237.214.144/tcp/10120/p2p/12D3KooWGtjWnCcvkaSEbKuNbPivEogxqtLWcsJiQtURydptvrsA

--- a/nix/modules/mina.nix
+++ b/nix/modules/mina.nix
@@ -66,7 +66,7 @@ inputs:
           type = nullOr path;
           default = null;
         };
-        discovery-keypair = lib.mkOption {
+        libp2p-keypair = lib.mkOption {
           type = nullOr path;
           default = null;
         };
@@ -114,7 +114,7 @@ inputs:
           ${arg "external-ip"} \
           ${arg "protocol-version"} \
           ${arg "block-producer-key"} \
-          ${arg "discovery-keypair"} \
+          ${arg "libp2p-keypair"} \
           ${
             optionalString cfg.generate-genesis-proof
             "--generate-genesis-proof true"

--- a/nix/modules/mina.nix
+++ b/nix/modules/mina.nix
@@ -67,8 +67,7 @@ inputs:
           default = null;
         };
         libp2p-keypair = lib.mkOption {
-          type = nullOr path;
-          default = null;
+          type = path;
         };
 
         waitForRpc = lib.mkOption {

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -436,7 +436,7 @@ fi
 
 # ----------
 
-spawn-node ${NODES_FOLDER}/seed ${SEED_START_PORT} -seed -discovery-keypair ${SEED_PEER_KEY} ${ARCHIVE_ADDRESS_CLI_ARG}
+spawn-node ${NODES_FOLDER}/seed ${SEED_START_PORT} -seed -libp2p-keypair ${SEED_PEER_KEY} ${ARCHIVE_ADDRESS_CLI_ARG}
 SEED_PID=$!
 
 echo 'Waiting for seed to go up...'

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -249,8 +249,7 @@ let setup_daemon logger =
          work in a block (default: true)"
       (optional bool)
   and libp2p_keypair =
-    flag "--discovery-keypair" ~aliases:[ "discovery-keypair" ]
-      (optional string)
+    flag "--libp2p-keypair" ~aliases:[ "libp2p-keypair" ] (optional string)
       ~doc:
         "KEYFILE Keypair (generated from `mina advanced \
          generate-libp2p-keypair`) to use with libp2p discovery (default: \
@@ -555,8 +554,8 @@ let setup_daemon logger =
                 | Error _ ->
                     if String.contains s ',' then
                       [%log warn]
-                        "I think -discovery-keypair is in the old format, but \
-                         I failed to parse it! Using it as a path..." ;
+                        "I think -libp2p-keypair is in the old format, but I \
+                         failed to parse it! Using it as a path..." ;
                     None )
           in
           match libp2p_keypair_old_format with

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -249,11 +249,10 @@ let setup_daemon logger =
          work in a block (default: true)"
       (optional bool)
   and libp2p_keypair =
-    flag "--libp2p-keypair" ~aliases:[ "libp2p-keypair" ] (optional string)
+    flag "--libp2p-keypair" ~aliases:[ "libp2p-keypair" ] (required string)
       ~doc:
-        "KEYFILE Keypair (generated from `mina advanced \
-         generate-libp2p-keypair`) to use with libp2p discovery (default: \
-         generate per-run temporary keypair)"
+        "KEYFILE Keypair (generated from `mina libp2p generate-keypair`) to \
+         use with libp2p discovery"
   and is_seed =
     flag "--seed" ~aliases:[ "seed" ] ~doc:"Start the node as a seed node"
       no_arg
@@ -547,28 +546,23 @@ let setup_daemon logger =
         in
         let%bind libp2p_keypair =
           let libp2p_keypair_old_format =
-            Option.bind libp2p_keypair ~f:(fun s ->
-                match Mina_net2.Keypair.of_string s with
-                | Ok kp ->
-                    Some kp
-                | Error _ ->
-                    if String.contains s ',' then
-                      [%log warn]
-                        "I think -libp2p-keypair is in the old format, but I \
-                         failed to parse it! Using it as a path..." ;
-                    None )
+            match Mina_net2.Keypair.of_string libp2p_keypair with
+            | Ok kp ->
+                Some kp
+            | Error _ ->
+                if String.contains libp2p_keypair ',' then
+                  [%log warn]
+                    "I think -libp2p-keypair is in the old format, but I \
+                     failed to parse it! Using it as a path..." ;
+                None
           in
-          match libp2p_keypair_old_format with
-          | Some kp ->
-              return (Some kp)
-          | None -> (
-              match libp2p_keypair with
-              | None ->
-                  return None
-              | Some s ->
-                  Secrets.Libp2p_keypair.Terminal_stdin.read_exn
-                    ~should_prompt_user:false ~which:"libp2p keypair" s
-                  |> Deferred.map ~f:Option.some )
+          Option.value_map
+            ~default:(fun () ->
+              Secrets.Libp2p_keypair.Terminal_stdin.read_exn
+                ~should_prompt_user:false ~which:"libp2p keypair" libp2p_keypair
+              )
+            ~f:(Fn.compose const Deferred.return)
+            libp2p_keypair_old_format ()
         in
         let%bind () =
           let version_filename = conf_dir ^/ "mina.version" in

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1728,6 +1728,7 @@ let mina_commands logger =
   ; ("client", Client.client)
   ; ("advanced", Client.advanced)
   ; ("ledger", Client.ledger)
+  ; ("libp2p", Client.libp2p)
   ; ( "internal"
     , Command.group ~summary:"Internal commands" (internal_commands logger) )
   ; (Parallel.worker_command_name, Parallel.worker_command)

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1587,7 +1587,7 @@ let generate_libp2p_keypair =
       (* FIXME: I'd like to accumulate messages into this logger and only dump them out in failure paths. *)
       let logger = Logger.null () in
       (* Using the helper only for keypair generation requires no state. *)
-      File_system.with_temp_dir "coda-generate-libp2p-keypair" ~f:(fun tmpd ->
+      File_system.with_temp_dir "mina-generate-libp2p-keypair" ~f:(fun tmpd ->
           match%bind
             Mina_net2.create ~logger ~conf_dir:tmpd ~all_peers_seen_metric:false
               ~pids:(Child_processes.Termination.create_pid_table ())
@@ -2261,7 +2261,6 @@ let advanced =
     ; ("pooled-zkapp-commands", pooled_zkapp_commands)
     ; ("snark-pool-list", snark_pool_list)
     ; ("pending-snark-work", pending_snark_work)
-    ; ("generate-libp2p-keypair", generate_libp2p_keypair)
     ; ("compile-time-constants", compile_time_constants)
     ; ("node-status", node_status)
     ; ("visualization", Visualization.command_group)
@@ -2290,3 +2289,7 @@ let ledger =
     ; ("hash", hash_ledger)
     ; ("currency", currency_in_ledger)
     ]
+
+let libp2p =
+  Command.group ~summary:"Libp2p commands"
+    [ ("generate-keypair", generate_libp2p_keypair) ]

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -440,7 +440,7 @@ module T = struct
               ; validation_queue_size = 150
               ; peer_exchange = true
               ; peer_protection_ratio = 0.2
-              ; keypair = Some libp2p_keypair
+              ; keypair = libp2p_keypair
               ; all_peers_seen_metric = false
               ; known_private_ip_nets = []
               ; time_controller

--- a/src/lib/command_line_tests/command_line_tests.ml
+++ b/src/lib/command_line_tests/command_line_tests.ml
@@ -21,7 +21,8 @@ let%test_module "Command line tests" =
     *)
     let coda_exe = "../../app/cli/src/mina.exe"
 
-    let create_daemon_process config_dir genesis_ledger_dir port =
+    let create_daemon_process config_dir genesis_ledger_dir libp2p_keypair_path
+        port =
       let%bind working_dir = Sys.getcwd () in
       Core.printf "Starting daemon inside %s\n" working_dir ;
       Process.create ~prog:coda_exe
@@ -40,10 +41,12 @@ let%test_module "Command line tests" =
           ; "0.0.0"
           ; "-external-ip"
           ; "0.0.0.0"
+          ; "-libp2p-keypair"
+          ; libp2p_keypair_path
           ]
         ()
 
-    let start_daemon config_dir genesis_ledger_dir port =
+    let start_daemon config_dir genesis_ledger_dir libp2p_keypair_path port =
       let%bind working_dir = Sys.getcwd () in
       Core.printf "Starting daemon inside %s\n" working_dir ;
       let%map _ =
@@ -65,6 +68,8 @@ let%test_module "Command line tests" =
               ; "0.0.0"
               ; "-external-ip"
               ; "0.0.0.0"
+              ; "-libp2p-keypair"
+              ; libp2p_keypair_path
               ]
             ()
         with
@@ -84,16 +89,25 @@ let%test_module "Command line tests" =
         ~args:[ "client"; "status"; "-daemon-port"; sprintf "%d" port ]
         ()
 
-    let create_config_directories () =
+    let libp2p_keypath dir = String.concat [ dir; "/privkey" ]
+
+    let create_config_files_and_dirs () =
       (* create empty config dir to avoid any issues with the default config dir *)
       let conf = Filename.temp_dir ~in_dir:"/tmp" "coda_spun_test" "" in
       let genesis = Filename.temp_dir ~in_dir:"/tmp" "coda_genesis_state" "" in
-      (conf, genesis)
+      let libp2p_keypair_dir =
+        Filename.temp_dir ~in_dir:"/tmp" "mina_test_libp2p_keypair" ""
+      in
+      let libp2p_keypair_path = libp2p_keypath libp2p_keypair_dir in
+      let%map () =
+        Init.Client.generate_libp2p_keypair_do libp2p_keypair_path ()
+      in
+      (conf, genesis, libp2p_keypair_dir)
 
-    let remove_config_directory config_dir genesis_dir =
-      let%bind _ = Process.run_exn ~prog:"rm" ~args:[ "-rf"; config_dir ] () in
-      Process.run_exn ~prog:"rm" ~args:[ "-rf"; genesis_dir ] ()
-      |> Deferred.ignore_m
+    let remove_config_dirs dirs =
+      Deferred.List.iter dirs ~f:(fun dir ->
+          Deferred.ignore_m
+          @@ Process.run_exn ~prog:"rm" ~args:[ "-rf"; dir ] () )
 
     let test_background_daemon () =
       let test_failed = ref false in
@@ -101,7 +115,9 @@ let%test_module "Command line tests" =
       let client_delay = 40. in
       let retry_delay = 30. in
       let retry_attempts = 30 in
-      let config_dir, genesis_ledger_dir = create_config_directories () in
+      let%bind config_dir, genesis_ledger_dir, libp2p_keypair_dir =
+        create_config_files_and_dirs ()
+      in
       Monitor.protect
         ~finally:(fun () ->
           ( if !test_failed then
@@ -112,11 +128,16 @@ let%test_module "Command line tests" =
             Core.Printf.printf
               !"**** DAEMON CRASHED (OUTPUT BELOW) ****\n%s\n************\n%!"
               contents ) ;
-          remove_config_directory config_dir genesis_ledger_dir )
+          remove_config_dirs
+            [ config_dir; genesis_ledger_dir; libp2p_keypair_dir ] )
         (fun () ->
           match%map
             let open Deferred.Or_error.Let_syntax in
-            let%bind _ = start_daemon config_dir genesis_ledger_dir port in
+            let%bind _ =
+              start_daemon config_dir genesis_ledger_dir
+                (libp2p_keypath libp2p_keypair_dir)
+                port
+            in
             (* It takes a while for the daemon to become available. *)
             let%bind () =
               Deferred.map
@@ -154,7 +175,9 @@ let%test_module "Command line tests" =
       let client_delay = 40. in
       let retry_delay = 30. in
       let retry_attempts = 5 in
-      let config_dir, genesis_ledger_dir = create_config_directories () in
+      let%bind config_dir, genesis_ledger_dir, libp2p_keypair_dir =
+        create_config_files_and_dirs ()
+      in
       Monitor.protect
         ~finally:(fun () ->
           ( if !test_failed then
@@ -165,12 +188,15 @@ let%test_module "Command line tests" =
             Core.Printf.printf
               !"**** DAEMON CRASHED (OUTPUT BELOW) ****\n%s\n************\n%!"
               contents ) ;
-          remove_config_directory config_dir genesis_ledger_dir )
+          remove_config_dirs
+            [ config_dir; genesis_ledger_dir; libp2p_keypair_dir ] )
         (fun () ->
           match%map
             let open Deferred.Or_error.Let_syntax in
+            let libp2p_keypair_path = libp2p_keypath libp2p_keypair_dir in
             let%bind p =
-              create_daemon_process config_dir genesis_ledger_dir port
+              create_daemon_process config_dir genesis_ledger_dir
+                libp2p_keypair_path port
             in
             let%bind () =
               Deferred.map
@@ -195,7 +221,10 @@ let%test_module "Command line tests" =
             let%bind (_ : Unix.Exit_or_signal.t) =
               Deferred.map (Process.wait p) ~f:Or_error.return
             in
-            let%bind _ = start_daemon config_dir genesis_ledger_dir port in
+            let%bind _ =
+              start_daemon config_dir genesis_ledger_dir libp2p_keypair_path
+                port
+            in
             let%bind () =
               Deferred.map
                 (after @@ Time.Span.of_sec client_delay)

--- a/src/lib/command_line_tests/dune
+++ b/src/lib/command_line_tests/dune
@@ -11,6 +11,8 @@
    core
    async_unix
    stdio
+   ;; mina libraries
+   init
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version ppx_jane ppx_compare))


### PR DESCRIPTION
:warning: After this PR is merged each node on every deployment should be configured with `--libp2p-keypair` flag :warning: 

Explain your changes:
* Rename `--discovery-keypair` to `--libp2p-keypair`
* Rename `mina advanced generate-libp2p-keypair` to `mina libp2p generate-keypair`

Explain how you tested your changes:
* existing unit and integration tests

Deployment update strategy:

* Rename `--discovery-keypair` to `--libp2p-keypair` whenever the former is used
* For each node in every deployment generate a libp2p keypair with `mina libp2p generate-keypair`
   * Before generation, check if the key already exists
   * The goal is to reuse the same keypair across restarts, if possible
* Pass libp2p keypair to the node with `--libp2p-keypair`

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #9320
