### PR TITLE
Nix: Add back vend

### DIFF
--- a/nix/go.nix
+++ b/nix/go.nix
@@ -55,6 +55,15 @@ final: prev: {
         final.lib.fakeHash;
     NO_MDNS_TEST = 1; # no multicast support inside the nix sandbox
     overrideModAttrs = n: {
+      # Yo dawg
+      # proxyVendor doesn't work (cannot find package "." in:)
+      # And runVend was removed from nixpkgs
+      # So we vendor the vend package in yo repo
+      # So yo can vendor while u vendor
+      postBuild = ''
+        rm vendor -rf
+        ${final.vend}/bin/vend
+      '';
       # remove libp2p_ipc from go.mod, inject it back in postconfigure
       postConfigure = ''
         sed -i 's/.*libp2p_ipc.*//' go.mod


### PR DESCRIPTION
The vend run has been removed accidentally from the packaging for
libp2p_helper. Add it back.