### PR TITLE
Fix a bug and re-enable TestBitswapSmoke

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -351,6 +351,8 @@
         devShells.default = self.devShell.${system};
 
         devShells.with-lsp = ocamlPackages.mina-dev.overrideAttrs (oa: {
+          buildInputs = oa.buildInputs
+            ++ [ pkgs.go_1_18 ];
           nativeBuildInputs = oa.nativeBuildInputs
             ++ [ ocamlPackages.ocaml-lsp-server ];
           shellHook = ''

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -226,7 +226,7 @@ type Helper struct {
 	MsgStats          *MessageStats
 	Seeds             []peer.AddrInfo
 	NodeStatus        []byte
-	HeartbeatPeer func(peer.ID)
+	HeartbeatPeer     func(peer.ID)
 }
 
 type MessageStats struct {
@@ -700,7 +700,7 @@ func MakeHelper(ctx context.Context, listenOn []ma.Multiaddr, externalAddr ma.Mu
 		return nil, err
 	}
 	bitswapNetwork := bitnet.NewFromIpfsHost(host, kad, bitnet.Prefix(BitSwapExchange))
-	bs := bitswap.New(context.Background(), bitswapNetwork, bstore.Blockstore()).(*bitswap.Bitswap)
+	bs := bitswap.New(context.Background(), bitswapNetwork, bstore.Blockstore())
 
 	// nil fields are initialized by beginAdvertising
 	h := &Helper{

--- a/src/app/libp2p_helper/src/go.mod
+++ b/src/app/libp2p_helper/src/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	capnproto.org/go/capnp/v3 v3.0.0-alpha.5
 	github.com/go-errors/errors v1.4.2
-	github.com/ipfs/go-bitswap v0.8.0
+	github.com/ipfs/go-bitswap v0.9.0
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.2.0
 	github.com/ipfs/go-ds-badger v0.3.0

--- a/src/app/libp2p_helper/src/go.sum
+++ b/src/app/libp2p_helper/src/go.sum
@@ -381,8 +381,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
-github.com/ipfs/go-bitswap v0.8.0 h1:UEV7kogQu2iGggkE9GhLykDrRCUpsNnpu2NODww/srw=
-github.com/ipfs/go-bitswap v0.8.0/go.mod h1:/h8sBij8UVEaNWl8ABzpLRA5Y1cttdNUnpeGo2AA/LQ=
+github.com/ipfs/go-bitswap v0.9.0 h1:/dZi/XhUN/aIk78pI4kaZrilUglJ+7/SCmOHWIpiy8E=
+github.com/ipfs/go-bitswap v0.9.0/go.mod h1:zkfBcGWp4dQTQd0D0akpudhpOVUAJT9GbH9tDmR8/s4=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
 github.com/ipfs/go-block-format v0.0.3 h1:r8t66QstRp/pd/or4dpnbVfXT5Gt7lOqRvC+/dDTpMc=
 github.com/ipfs/go-block-format v0.0.3/go.mod h1:4LmD4ZUw0mhO+JSKdpWwrzATiEfM7WWgQ8H5l6P8MVk=

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap.go
@@ -197,8 +197,12 @@ func (bs *BitswapCtx) DeleteBlocks(keys [][32]byte) error {
 func (bs *BitswapCtx) ViewBlock(key [32]byte, callback func([]byte) error) error {
 	return bs.storage.ViewBlock(bs.ctx, key, callback)
 }
-func (bs *BitswapCtx) StoreBlock(block blocks.Block) error {
-	return bs.storage.StoreBlocks(bs.ctx, []blocks.Block{block})
+func (bs *BitswapCtx) StoreDownloadedBlock(block blocks.Block) error {
+	err := bs.storage.StoreBlocks(bs.ctx, []blocks.Block{block})
+	if err != nil {
+		return err
+	}
+	return bs.engine.Server.NotifyNewBlocks(bs.ctx, block)
 }
 
 type BitswapBlockRequester struct {

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader.go
@@ -78,7 +78,7 @@ type BitswapState interface {
 	DeleteStatus(key [32]byte) error
 	DeleteBlocks(keys [][32]byte) error
 	ViewBlock(key [32]byte, callback func([]byte) error) error
-	StoreBlock(block blocks.Block) error
+	StoreDownloadedBlock(block blocks.Block) error
 	NodeDownloadParams() map[cid.Cid]map[root][]NodeIndex
 	RootDownloadStates() map[root]*RootDownloadState
 	MaxBlockSize() int
@@ -251,7 +251,7 @@ func processDownloadedBlockStep(params map[root][]NodeIndex, block blocks.Block,
 func processDownloadedBlock(block blocks.Block, bs BitswapState) {
 	bs.CheckInvariants()
 	id := block.Cid()
-	err := bs.StoreBlock(block)
+	err := bs.StoreDownloadedBlock(block)
 	if err != nil {
 		bitswapLogger.Errorf("Failed to store block %s", id)
 	}

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_downloader_test.go
@@ -702,7 +702,7 @@ func (bs *testBitswapState) ViewBlock(key [32]byte, callback func([]byte) error)
 	}
 	return callback(b)
 }
-func (bs *testBitswapState) StoreBlock(block blocks.Block) error {
+func (bs *testBitswapState) StoreDownloadedBlock(block blocks.Block) error {
 	bs.blocks[block.Cid()] = block.RawData()
 	return nil
 }

--- a/src/app/libp2p_helper/src/libp2p_helper/bitswap_test.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/bitswap_test.go
@@ -546,10 +546,6 @@ func TestBitswapMedium(t *testing.T) {
 }
 
 func TestBitswapSmoke(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping TestBitswapSmoke in short mode")
-		return
-	}
 	testBitswap(t, 50, 1, 1, 1<<16, true)
 }
 


### PR DESCRIPTION
Problem: when updating go-bitswap to v0.8.0, an integration was made improperly which led to TestBitswapSmoke failing.

Solution: fix the bug in integration, namely call
`bitswap.Server.NotifyNewBlocks` on every downloaded block.

Additionally, go-bitswap is bumped to v0.9.0 and a small fix is applied to flake.nix.

Explain how you tested your changes:
* `TestBitswapSmoke` is re-enabled and now passes

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
