### PR TITLE
Fix for go.mod hash mismatch

### DIFF
--- a/nix/libp2p_helper.json
+++ b/nix/libp2p_helper.json
@@ -1,1 +1,1 @@
-{"go.mod":"ebe735fd7b9f93a563c56dc31290b8b9200fb15e6fff98f7be248ffccee88c6c","go.sum":"930cea1dc3c81e8bc009bab4cc51703294bc6a4195bac387a11dda93bfa16a35","vendorSha256":"sha256-obKl4KUyisLrCFGfHZ7AX8e2uQicmnY2b1EflZq/I8E="}
+{"go.mod":"b6ae9a87b95e27779acf57dcd77fdcf1e7a0f093f1d86d716e6334ab77bfbf9c","go.sum":"91314d339b53b15a6896cbbfd914abf28248c3e5094185ee0a0acda877007fbc","vendorSha256":"sha256-hY3Ym19Bj5qFbjXukrt/2l39yUB1/9KehM2dMoBSXVQ="}

--- a/src/app/libp2p_helper/README.md
+++ b/src/app/libp2p_helper/README.md
@@ -1,8 +1,10 @@
-# mina go-libp2p helper
+# Mina `go-libp2p` Helper
 
-## libp2p_helper hints
+## Contrubution
 
-## building
+After changing the `go.mod` or `go.sum` please run the `nix build mina#libp2p_helper` and follow the instructions in order to resolve possible hash mismatch.
+
+## Building
 
 ### Makefile
 
@@ -18,7 +20,7 @@ $ bazel build src:codanet
 $ bazel build src/libp2p_helper
 ```
 
-#### using as an external repo
+#### Using as an external repo
 
 Add a repository rule to your root WORKSPACE(.bazel) file to import this repo.  For example, if you embed this repo as a git submodule:
 
@@ -34,7 +36,7 @@ file. Change the line: `load("//bzl/libp2p:deps.bzl",
 "libp2p_bootstrap")` to use the fully-qualified label, e.g.
 `load("@libp2p_helper//bzl/libp2p:deps.bzl", "libp2p_bootstrap")`.
 
-#### maintenance
+#### Maintenance
 
 Install [Gazelle](https://github.com/bazelbuild/bazel-gazelle).
 
@@ -51,12 +53,12 @@ See [Go Protocol buffers - avoiding
 conflicts](https://github.com/bazelbuild/rules_go/blob/master/proto/core.rst#avoiding-conflicts): [Option 2: Use pre-generated .pb.go files](https://github.com/bazelbuild/rules_go/blob/master/proto/core.rst#option-2-use-pre-generated-pb-go-files).
 for more info.
 
-# How it works
+## How it works
 
 libp2p_helper serves as a middleware between libp2p and Ocaml process. They communicate using a number of internal messages.
 Below we enumerate all message types along with description of how Helper handles the message.
 
-## config_msg.go
+### config_msg.go
 
 Messages serving to configure libp2p helper.
 
@@ -79,7 +81,7 @@ Messages serving to configure libp2p helper.
     * Sets a node status
     * Node status is a bytestring without particular structure (as of the libp2p_helper's view)
 
-## peer_msg.go
+### peer_msg.go
 
 Messages to add a new peer or get information about existing peers.
 
@@ -96,7 +98,7 @@ Messages to add a new peer or get information about existing peers.
  * listPeers
     * Return a list of peer information for each open connection
 
-## pubsub_msg.go
+### pubsub_msg.go
 
 Messages to interact with pubsub protocol.
 
@@ -119,7 +121,7 @@ Messages to interact with pubsub protocol.
     * Performs the action under app-global `ValidatorMutex`
     * Logs an error if validation has already timed out
 
-## stream_msg.go
+### stream_msg.go
 
 Messages to open, maintain and send messages to streams towards other peers (connected directly to our node).
 


### PR DESCRIPTION
Fix for:

```
trace: warning: Below, you will find an error about a hash mismatch.
This is likely because you have updated go.mod and/or go.sum in libp2p_helper.
Please, locate the "got: " hash in the aforementioned error. If it's in SRI format (sha256-<...>), copy the entire hash, including the `sha256-'. Otherwise (if it's in the base32 format, like `sha256:<...>'), copy only the base32 part, without `sha256:'.
Then, run ./nix/update-libp2p-hashes.sh "<got hash here>"

error: hash mismatch in fixed-output derivation '/nix/store/sa5qm2j8ia34hp97kmvg7n7ry9f1wdc5-libp2p_helper-0.1-go-modules.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-hY3Ym19Bj5qFbjXukrt/2l39yUB1/9KehM2dMoBSXVQ=
error: 1 dependencies of derivation '/nix/store/fvprvmlb7adbdwba2shb87ds7pqpn60q-libp2p_helper-0.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/ab3fhxjy9456wscwvaax21srkxihnm7r-mina-dev-env.drv' failed to build
```

And Readme reminder.