### PR TITLE
Update nix-npm-buildpackage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1654786772,
-        "narHash": "sha256-Qul9GG6EJ1IFfgnZ440KAxTEPfFpbnmf54EVFM9+iZA=",
+        "lastModified": 1662627485,
+        "narHash": "sha256-Kg8u2ekU0+MsuLzgKqiaus3HquLLo2Qq+oGbQfIppos=",
         "owner": "serokell",
         "repo": "nix-npm-buildpackage",
-        "rev": "ca922a16839ae62a568bcb0771e78e080b4d6059",
+        "rev": "cab951dd024dd367511d48440de6f93664ee35aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
nixpkgs update made nix-npm-buildpackage fail on snarkyjs. Fix this by updating nix-npm-buildpackae to a commit which includes the fix.

Flake lock file updates:

• Updated input 'nix-npm-buildPackage':
    'github:serokell/nix-npm-buildpackage/ca922a16839ae62a568bcb0771e78e080b4d6059' (2022-06-09)
  → 'github:serokell/nix-npm-buildpackage/cab951dd024dd367511d48440de6f93664ee35aa' (2022-09-08)