### PR TITLE
Update src/app/batch_txn_tool after GraphQL schema change

### DIFF
--- a/src/app/batch_txn_tool/batch_txn_tool.ml
+++ b/src/app/batch_txn_tool/batch_txn_tool.ml
@@ -206,7 +206,7 @@ let there_and_back_again ~num_txn_per_acct ~txns_per_block ~slot_time ~fill_rate
       in
       match querry_result with
       | Ok n ->
-          return (UInt32.of_int n)
+          return n
       | Error _ ->
           Format.printf "txn burst tool: could not get nonce of pk= %s@."
             (pk_to_str pk) ;

--- a/src/app/batch_txn_tool/dune
+++ b/src/app/batch_txn_tool/dune
@@ -25,11 +25,9 @@
    mina_wire_types
  )
  (instrumentation (backend bisect_ppx))
+ (preprocessor_deps ../../../graphql_schema.json)
  (preprocess (pps 
               ppx_version 
               ppx_let 
-              graphql_ppx --
-               -extend-query Graphql_lib.Serializing.ExtendQuery
-               -extend-mutation Graphql_lib.Serializing.ExtendQuery
-               -future-added-value false
+              graphql_ppx -- %{read-lines:../../graphql-ppx-config.inc}
 )))

--- a/src/app/batch_txn_tool/txn_tool_graphql.ml
+++ b/src/app/batch_txn_tool/txn_tool_graphql.ml
@@ -102,7 +102,7 @@ let get_account_data ~public_key ~graphql_target_node =
   | Some acc -> (
       match acc.nonce with
       | Some s ->
-          return (int_of_string s)
+          return s
       | None ->
           Deferred.Or_error.errorf "Account with %s somehow doesnt have a nonce"
             (Public_key.Compressed.to_string pk) )


### PR DESCRIPTION
This PR fixes the build of `src/app/batch_txn_tool`, which was affected by the update of the GraphQL schema.

Since `(preprocessor_deps ../../../graphql_schema.json)` was missing in the dune file, the code generated by the ppx was not invalidated and the executable seemed to build fine locally.

This PR:
- adds the preprocessor dependency on the GraphQL schema,
- uses the same graphql_ppx configuration as in the other folders,
- adapts the code, now that decoders are applied automatically.