### PR TITLE
exposes permissions to SnarkyJS

### DIFF
--- a/src/lib/mina_base/permissions.ml
+++ b/src/lib/mina_base/permissions.ml
@@ -86,6 +86,32 @@ module Auth_required = struct
   let gen_for_none_given_authorization : t Quickcheck.Generator.t =
     Quickcheck.Generator.return None
 
+  let to_string = function
+    | None ->
+        "None"
+    | Either ->
+        "Either"
+    | Proof ->
+        "Proof"
+    | Signature ->
+        "Signature"
+    | Impossible ->
+        "Impossible"
+
+  let of_string = function
+    | "None" ->
+        Stable.Latest.None
+    | "Either" ->
+        Either
+    | "Proof" ->
+        Proof
+    | "Signature" ->
+        Signature
+    | "Impossible" ->
+        Impossible
+    | _ ->
+        failwith "auth_required_of_string: unknown variant"
+
   (* The encoding is chosen so that it is easy to write this function
 
       let spec_eval t ~signature_verifies =
@@ -472,36 +498,11 @@ let empty : t =
   }
 
 (* deriving-fields-related stuff *)
-let auth_required_to_string = function
-  | Auth_required.Stable.Latest.None ->
-      "None"
-  | Either ->
-      "Either"
-  | Proof ->
-      "Proof"
-  | Signature ->
-      "Signature"
-  | Impossible ->
-      "Impossible"
-
-let auth_required_of_string = function
-  | "None" ->
-      Auth_required.Stable.Latest.None
-  | "Either" ->
-      Either
-  | "Proof" ->
-      Proof
-  | "Signature" ->
-      Signature
-  | "Impossible" ->
-      Impossible
-  | _ ->
-      failwith "auth_required_of_string: unknown variant"
 
 let auth_required =
   Fields_derivers_zkapps.Derivers.iso_string ~name:"AuthRequired"
     ~js_type:(Custom "AuthRequired") ~doc:"Kind of authorization required"
-    ~to_string:auth_required_to_string ~of_string:auth_required_of_string
+    ~to_string:Auth_required.to_string ~of_string:Auth_required.of_string
 
 let deriver obj =
   let open Fields_derivers_zkapps.Derivers in

--- a/src/lib/mina_base/permissions.mli
+++ b/src/lib/mina_base/permissions.mli
@@ -23,6 +23,10 @@ module Auth_required : sig
 
   val check : t -> Control.Tag.t -> bool
 
+  val to_string : t -> string
+
+  val of_string : string -> t
+
   [%%ifdef consensus_mechanism]
 
   module Checked : sig

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -2924,8 +2924,7 @@ module Ledger = struct
       account Js.optdef =
     let loc = L.location_of_account l##.value (account_id pk token) in
     let account = Option.bind loc ~f:(L.get l##.value) in
-    let acc = To_js.option To_js.account account in
-    acc
+    To_js.option To_js.account account
 
   let add_account l (pk : public_key) (balance : Js.js_string Js.t) =
     add_account_exn l##.value pk (Js.to_string balance)

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -9,7 +9,6 @@ module Sc =
     (Pickles.Endo.Step_inner_curve)
 module Js = Js_of_ocaml.Js
 
-
 let console_log_string s = Js_of_ocaml.Firebug.console##log (Js.string s)
 
 let console_log s = Js_of_ocaml.Firebug.console##log s
@@ -2322,7 +2321,17 @@ module Ledger = struct
     Js.t
 
   type permissions =
-    < editState : Mina_base.Permissions.Auth_required.t Js.readonly_prop > 
+    < editState : Js.js_string Js.t Js.readonly_prop
+    ; send : Js.js_string Js.t Js.readonly_prop
+    ; receive : Js.js_string Js.t Js.readonly_prop
+    ; setDelegate : Js.js_string Js.t Js.readonly_prop
+    ; setPermissions : Js.js_string Js.t Js.readonly_prop
+    ; setVerificationKey : Js.js_string Js.t Js.readonly_prop
+    ; setZkappUri : Js.js_string Js.t Js.readonly_prop
+    ; editSequenceState : Js.js_string Js.t Js.readonly_prop
+    ; setTokenSymbol : Js.js_string Js.t Js.readonly_prop
+    ; incrementNonce : Js.js_string Js.t Js.readonly_prop
+    ; setVotingFor : Js.js_string Js.t Js.readonly_prop >
     Js.t
 
   type account =
@@ -2335,9 +2344,8 @@ module Ledger = struct
     ; receiptChainHash : field_class Js.t Js.readonly_prop
     ; delegate : public_key Js.optdef Js.readonly_prop
     ; votingFor : field_class Js.t Js.readonly_prop
-    ; zkapp : zkapp_account Js.optdef Js.readonly_prop 
-    ; permissions : permissions Js.readonly_prop 
-    >
+    ; zkapp : zkapp_account Js.optdef Js.readonly_prop
+    ; permissions : permissions Js.readonly_prop >
     Js.t
 
   let ledger_class : < .. > Js.t =
@@ -2579,11 +2587,6 @@ module Ledger = struct
         val hash = field (With_hash.hash vk)
 
         val data = With_hash.data vk
-      end 
-
-    let permissions (p : Mina_base.Permissions.t) : permissions =
-      object%js
-        val editState = p.edit_state (* I would like to get the type of p.edit_state and derive a string from it *)
       end
 
     let zkapp_account (a : Mina_base.Zkapp_account.t) : zkapp_account =
@@ -2601,6 +2604,51 @@ module Ledger = struct
 
         val provedState =
           new%js bool_constr (As_bool.of_js_bool @@ Js.bool a.proved_state)
+      end
+
+    let permissions (p : Mina_base.Permissions.t) : permissions =
+      object%js
+        val editState =
+          Js.string (Mina_base.Permissions.Auth_required.to_string p.edit_state)
+
+        val send =
+          Js.string (Mina_base.Permissions.Auth_required.to_string p.send)
+
+        val receive =
+          Js.string (Mina_base.Permissions.Auth_required.to_string p.receive)
+
+        val setDelegate =
+          Js.string
+            (Mina_base.Permissions.Auth_required.to_string p.set_delegate)
+
+        val setPermissions =
+          Js.string
+            (Mina_base.Permissions.Auth_required.to_string p.set_permissions)
+
+        val setVerificationKey =
+          Js.string
+            (Mina_base.Permissions.Auth_required.to_string
+               p.set_verification_key )
+
+        val setZkappUri =
+          Js.string
+            (Mina_base.Permissions.Auth_required.to_string p.set_zkapp_uri)
+
+        val editSequenceState =
+          Js.string
+            (Mina_base.Permissions.Auth_required.to_string p.edit_sequence_state)
+
+        val setTokenSymbol =
+          Js.string
+            (Mina_base.Permissions.Auth_required.to_string p.set_token_symbol)
+
+        val incrementNonce =
+          Js.string
+            (Mina_base.Permissions.Auth_required.to_string p.increment_nonce)
+
+        val setVotingFor =
+          Js.string
+            (Mina_base.Permissions.Auth_required.to_string p.set_voting_for)
       end
 
     let account (a : Mina_base.Account.t) : account =


### PR DESCRIPTION

- exposes permissions of an account to SnarkyJS, required for https://github.com/o1-labs/snarkyjs/issues/391
- moves `auth_required_of_string`/`auth_required_from_string` under the Auth_required module as `to_string`/`of_string`

https://github.com/o1-labs/snarkyjs/pull/405