### PR TITLE
Nix: speed up mina-release build

### DIFF
--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -199,8 +199,9 @@ let
         cp -R ${self.mina-dev.${output}} ${placeholder output}
         chmod 700 ${placeholder output} -R
         for i in $(find "${placeholder output}/bin" -type f); do
-          sed 's/__commit_sha1___________________________/${commit_sha1}/' -i "$i"
-          sed 's/__commit_date_/${commit_date}/' -i "$i"
+          if [[ "$(basename "$i")" == mina ]]; then
+            sed -e 's/__commit_sha1___________________________/${commit_sha1}/' -e 's/__commit_date_/${commit_date}/' -i "$i"
+          fi
           wrapProgram "$i" \
             --prefix PATH : ${makeBinPath [ pkgs.gnutar pkgs.gzip ]} \
             --set MINA_LIBP2P_HELPER_PATH ${pkgs.libp2p_helper}/bin/libp2p_helper


### PR DESCRIPTION
The nix build of mina-release unnecessary `sed`-ded a lot of big binaries, and did so in two passes. Remove unnecessary `sed`-ding. Speeds up CI for PRs which don't touch `src` by about 30-40 seconds.

Based on #11801 so that CI passes