### PR TITLE
Add .direnv to reformat's trusted list

### DIFF
--- a/src/app/reformat/reformat.ml
+++ b/src/app/reformat/reformat.ml
@@ -17,7 +17,8 @@ let dirs_trustlist =
   ; "zexe"
   ; "marlin"
   ; "snarky"
-  ; "_opam" ]
+  ; "_opam"
+  ; ".direnv" ]
 
 let rec fold_over_files ~path ~process_path ~init ~f =
   let%bind all = Sys.ls_dir path in


### PR DESCRIPTION
`.direnv` might contain arbitrary files, including ocaml files, used for caching. It is therefore useful to ignore it when reformatting or checking formatting.