### PR TITLE
Use serialized value for hashing signed commands

### DIFF
--- a/src/lib/transaction/transaction_hash.ml
+++ b/src/lib/transaction/transaction_hash.ml
@@ -31,11 +31,14 @@ let of_yojson = function
   | _ ->
       Error "Transaction_hash.of_yojson: Expected a string"
 
-let hash_signed_command cmd =
-  cmd |> Signed_command.to_base58_check |> digest_string
-
-let hash_zkapp_command_command cmd =
-  cmd |> Binable.to_string (module Zkapp_command.Stable.Latest) |> digest_string
+let hash_signed_command, hash_zkapp_command =
+  let mk_hasher (type a) (module M : Bin_prot.Binable.S with type t = a)
+      (cmd : a) =
+    cmd |> Binable.to_string (module M) |> digest_string
+  in
+  let hash_signed_command = mk_hasher (module Signed_command.Stable.Latest) in
+  let hash_zkapp_command = mk_hasher (module Zkapp_command.Stable.Latest) in
+  (hash_signed_command, hash_zkapp_command)
 
 [%%ifdef consensus_mechanism]
 
@@ -44,7 +47,7 @@ let hash_command cmd =
   | User_command.Signed_command s ->
       hash_signed_command s
   | User_command.Zkapp_command p ->
-      hash_zkapp_command_command p
+      hash_zkapp_command p
 
 let hash_fee_transfer fee_transfer =
   fee_transfer |> Fee_transfer.Single.to_base58_check |> digest_string

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -957,7 +957,7 @@ let%test_module "account timing check" =
               (keypair, balance_as_amount, nonce, timing) )
           |> Array.of_list
         in
-        let zkapp_command_command =
+        let zkapp_command =
           let open Mina_base in
           let fee = Currency.Fee.of_int 1_000_000 in
           let amount = Currency.Amount.of_int 10_000_000_000_000 in
@@ -990,7 +990,7 @@ let%test_module "account timing check" =
           in
           Transaction_snark.For_tests.multiple_transfers zkapp_command_spec
         in
-        return (ledger_init_state, zkapp_command_command)
+        return (ledger_init_state, zkapp_command)
       in
       (* slot 1, well before cliffs *)
       Quickcheck.test ~seed:(`Deterministic "zkapp command, before cliff")
@@ -1036,7 +1036,7 @@ let%test_module "account timing check" =
               (keypair, balance_as_amount, nonce, timing) )
           |> Array.of_list
         in
-        let zkapp_command_command =
+        let zkapp_command =
           let open Mina_base in
           let fee = Currency.Fee.of_int 1_000_000 in
           let amount = Currency.Amount.of_int 10_000_000_000_000 in
@@ -1069,7 +1069,7 @@ let%test_module "account timing check" =
           in
           Transaction_snark.For_tests.multiple_transfers zkapp_command_spec
         in
-        return (ledger_init_state, zkapp_command_command)
+        return (ledger_init_state, zkapp_command)
       in
       (* slot 1, well before cliffs *)
       Quickcheck.test ~seed:(`Deterministic "zkapp command, before cliff")
@@ -1246,7 +1246,7 @@ let%test_module "account timing check" =
           |> Array.of_list
         in
         (* min balance = balance, spending anything before cliff should trigger min balance violation *)
-        let zkapp_command_command =
+        let zkapp_command =
           let open Mina_base in
           let fee = Currency.Fee.of_int 1_000_000 in
           let amount = Currency.Amount.of_int 10_000_000_000_000 in
@@ -1279,7 +1279,7 @@ let%test_module "account timing check" =
           in
           Transaction_snark.For_tests.multiple_transfers zkapp_command_spec
         in
-        return (ledger_init_state, zkapp_command_command)
+        return (ledger_init_state, zkapp_command)
       in
       Quickcheck.test ~seed:(`Deterministic "zkapp command, just before cliff")
         ~sexp_of:[%sexp_of: Mina_ledger.Ledger.init_state * Zkapp_command.t]
@@ -1632,7 +1632,7 @@ let%test_module "account timing check" =
         let fee_int = 1_000_000 in
         (* the + 1 makes the balance insufficient *)
         let amount_int = balance_int - fee_int + 1 in
-        let zkapp_command_command =
+        let zkapp_command =
           let open Mina_base in
           let fee = Currency.Fee.of_int fee_int in
           let amount = Currency.Amount.of_int amount_int in
@@ -1665,7 +1665,7 @@ let%test_module "account timing check" =
           in
           Transaction_snark.For_tests.multiple_transfers zkapp_command_spec
         in
-        return (ledger_init_state, zkapp_command_command)
+        return (ledger_init_state, zkapp_command)
       in
       Quickcheck.test ~seed:(`Deterministic "zkapp command, after vesting")
         ~sexp_of:[%sexp_of: Mina_ledger.Ledger.init_state * Zkapp_command.t]


### PR DESCRIPTION
Use `Bin_prot` serialization of `Signed_command.t` to create transaction hashes, as was already done for zkApps. Factor out the common code to create transaction hashes.

Fix some spelling gaffes (hash_zkapp_command_command, oof!).

Closes #11430.