### PR TITLE
Automatically deserialize TransactionId scalars with graphql_ppx

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -496,11 +496,8 @@ let batch_send_payments =
        (Args.zip2 Cli_lib.Flag.privkey_read_path payment_path_flag)
        ~f:main )
 
-let transaction_id_to_string = function
-  | `String s ->
-      s
-  | _ ->
-      "Unexpected JSON for transaction id"
+let transaction_id_to_string id =
+  Yojson.Basic.to_string (Graphql_lib.Scalars.TransactionId.serialize id)
 
 let send_payment_graphql =
   let open Command.Param in

--- a/src/graphql-ppx-config.inc
+++ b/src/graphql-ppx-config.inc
@@ -97,6 +97,9 @@ Graphql_lib.Scalars.StagedLedgerAuxHash
 -custom-field
 PendingCoinbaseHash 
 Graphql_lib.Scalars.PendingCoinbaseHash
+-custom-field
+TransactionId
+Graphql_lib.Scalars.TransactionId
 -extend-query=Graphql_lib.Serializing.ExtendQuery
 -extend-mutation=Graphql_lib.Serializing.ExtendQuery
 -future-added-value=false

--- a/src/lib/codable/codable.ml
+++ b/src/lib/codable/codable.ml
@@ -137,8 +137,10 @@ struct
 
   let of_base64 b64 : T.t Or_error.t =
     match Base64.decode b64 with
-    | Ok s ->
-        Ok (Binable.of_string (module T) s)
+    | Ok s -> (
+        try Ok (Binable.of_string (module T) s)
+        with Bin_prot.Common.Read_error _ as e ->
+          Error (Error.of_exn ~backtrace:`Get e) )
     | Error (`Msg msg) ->
         Error (Error.of_string msg)
 end

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -645,11 +645,8 @@ module Node = struct
     ; nonce : Mina_numbers.Account_nonce.t
     }
 
-  let transaction_id_to_string = function
-    | `String s ->
-        s
-    | _ ->
-        failwith "Unexpected JSON for transaction ID"
+  let transaction_id_to_string id =
+    Yojson.Basic.to_string (Graphql_lib.Scalars.TransactionId.serialize id)
 
   (* if we expect failure, might want retry_on_graphql_error to be false *)
   let send_payment ~logger t ~sender_pub_key ~receiver_pub_key ~amount ~fee =


### PR DESCRIPTION
This PR configures `graphql_ppx` to automatically decode scalars of types `TransactionId` (which was recently added in #11749), as it is the case for other types. For now it is only useful for testing purpose, as we only decode this type to convert it back to a string, but in general it should be simpler and more type safe to always use the automatic decoders.

The PR also fixes an issue with the decoding function, which was incorrectly raising an exception (See [here](https://buildkite.com/o-1-labs-2/mina/builds/25104#01833d1f-99e0-47fa-9d70-c062f13b476a/64-155) for the CI error).

The reason was that the `Signed_command.of_base64` returns an `Or_error` type, but could also raise a `Bin_prot.Common.Read_error` exception. To avoid mixing both mechanisms, the exception is now captured and propagated inside the `Or_error` type.
