### PR TITLE
Make currency conversions more intuitive.

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -203,7 +203,8 @@ let setup_daemon logger =
         (sprintf
            "FEE Amount a worker wants to get compensated for generating a \
             snark proof (default: %d)"
-           (Currency.Fee.to_int Mina_compile_config.default_snark_worker_fee) )
+           (Currency.Fee.int_of_nanomina
+              Mina_compile_config.default_snark_worker_fee ) )
       (optional txn_fee)
   and work_reassignment_wait =
     flag "--work-reassignment-wait"
@@ -788,7 +789,7 @@ let setup_daemon logger =
           let client_port = get_port client_port in
           let snark_work_fee_flag =
             let json_to_currency_fee_option json =
-              YJ.Util.to_int_option json |> Option.map ~f:Currency.Fee.of_int
+              YJ.Util.to_int_option json |> Option.map ~f:Currency.Fee.nanomina
             in
             or_from_config json_to_currency_fee_option "snark-worker-fee"
               ~default:Mina_compile_config.default_snark_worker_fee

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -454,8 +454,8 @@ let batch_send_payments =
               Public_key.(
                 Compressed.to_base58_check (compress keypair.public_key))
           ; valid_until = Some (Mina_numbers.Global_slot.random ())
-          ; amount = Currency.Amount.of_int (Random.int 100)
-          ; fee = Currency.Fee.of_int (Random.int 100)
+          ; amount = Currency.Amount.nanomina (Random.int 100)
+          ; fee = Currency.Fee.nanomina (Random.int 100)
           }
         in
         eprintf "Could not read payments from %s.\n" payments_path ;
@@ -1167,8 +1167,9 @@ let set_snark_work_fee =
            ~f:(fun response ->
              printf
                !"Updated snark work fee: %i\nOld snark work fee: %i\n"
-               (Currency.Fee.to_int fee)
-               (Currency.Fee.to_int response.setSnarkWorkFee.lastFee) ) )
+               (Currency.Fee.int_of_nanomina fee)
+               (Currency.Fee.int_of_nanomina response.setSnarkWorkFee.lastFee) )
+         )
 
 let import_key =
   Command.async

--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -58,8 +58,8 @@ let create_ledger_and_transactions num_transactions :
     let sender_pk = Public_key.compress sender.public_key in
     let nonce = Hashtbl.find_exn nonces sender_pk in
     Hashtbl.change nonces sender_pk ~f:(Option.map ~f:Account.Nonce.succ) ;
-    let fee = Currency.Fee.of_int (1 + Random.int 100) in
-    let amount = Currency.Amount.of_int (1 + Random.int 100) in
+    let fee = Currency.Fee.nanomina (1 + Random.int 100) in
+    let amount = Currency.Amount.nanomina (1 + Random.int 100) in
     txn sender receiver amount fee nonce
   in
   match num_transactions with
@@ -95,12 +95,12 @@ let create_ledger_and_transactions num_transactions :
   | `Two_from_same ->
       let a =
         txn keys.(0) keys.(1)
-          (Currency.Amount.of_int 10)
+          (Currency.Amount.nanomina 10)
           Currency.Fee.zero Account.Nonce.zero
       in
       let b =
         txn keys.(0) keys.(1)
-          (Currency.Amount.of_int 10)
+          (Currency.Amount.nanomina 10)
           Currency.Fee.zero
           (Account.Nonce.succ Account.Nonce.zero)
       in

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -495,10 +495,10 @@ module T = struct
                  ~persistent_frontier_location:(conf_dir ^/ "frontier")
                  ~epoch_ledger_location
                  ~wallets_disk_location:(conf_dir ^/ "wallets") ~time_controller
-                 ~snark_work_fee:(Currency.Fee.of_int 0)
-                 ~block_production_keypairs ~monitor ~consensus_local_state
-                 ~is_archive_rocksdb ~work_reassignment_wait:420000
-                 ~precomputed_values ~start_time ~upload_blocks_to_gcloud:false
+                 ~snark_work_fee:Currency.Fee.zero ~block_production_keypairs
+                 ~monitor ~consensus_local_state ~is_archive_rocksdb
+                 ~work_reassignment_wait:420000 ~precomputed_values ~start_time
+                 ~upload_blocks_to_gcloud:false
                  ~archive_process_location:
                    (Option.map archive_process_location ~f:(fun host_and_port ->
                         Cli_lib.Flag.Types.

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -564,7 +564,7 @@ module Payments : sig
 end = struct
   let send_several_payments ?acceptable_delay:(delay = 7) (testnet : Api.t)
       ~node ~keypairs ~n =
-    let amount = Currency.Amount.of_int 10 in
+    let amount = Currency.Amount.nanomina 10 in
     let valid_until = None in
     let fee = Signed_command.minimum_fee in
     let%bind (_ : unit option list) =
@@ -627,7 +627,7 @@ end = struct
      This is most appropriate todo when #2336 is completed *)
   let send_batch_consecutive_payments (testnet : Api.t) ~node ~sender
       ~(keypairs : Keypair.t list) ~n =
-    let amount = Currency.Amount.of_int 10 in
+    let amount = Currency.Amount.nanomina 10 in
     let fee = Signed_command.minimum_fee in
     let valid_until = None in
     let%bind new_payment_readers =

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -211,8 +211,8 @@ module Vrf = struct
                     vrf_threshold =
                       Some
                         { delegated_stake =
-                            Currency.Balance.of_int delegated_stake
-                        ; total_stake = Currency.Amount.of_int total_stake
+                            Currency.Balance.nanomina delegated_stake
+                        ; total_stake = Currency.Amount.nanomina total_stake
                         }
                   }
               | _ ->

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -860,8 +860,8 @@ module Data = struct
                 [ ("delegator", `Int (Mina_base.Account.Index.to_int delegator))
                 ; ( "delegator_pk"
                   , Public_key.Compressed.to_yojson account.public_key )
-                ; ("balance", `Int (Balance.to_int account.balance))
-                ; ("amount", `Int (Amount.to_int total_stake))
+                ; ("balance", `Int (Balance.int_of_nanomina account.balance))
+                ; ("amount", `Int (Amount.int_of_nanomina total_stake))
                 ; ( "result"
                   , `String
                       (* use sexp representation; int might be too small *)
@@ -2301,7 +2301,7 @@ module Data = struct
       ; curr_slot = Segment_id.to_int slot
       ; global_slot_since_genesis =
           Mina_numbers.Global_slot.to_int t.global_slot_since_genesis
-      ; total_currency = Amount.to_int t.total_currency
+      ; total_currency = Amount.int_of_nanomina t.total_currency
       }
 
     let curr_global_slot (t : Value.t) = t.curr_global_slot
@@ -3665,7 +3665,9 @@ let%test_module "Proof of stake tests" =
       let consensus_transition : Consensus_transition.t =
         Global_slot.slot_number global_slot
       in
-      let supply_increase = Currency.Amount.(Signed.of_unsigned (of_int 42)) in
+      let supply_increase =
+        Currency.Amount.(Signed.of_unsigned (nanomina 42))
+      in
       (* setup ledger, needed to compute producer_vrf_result here and handler below *)
       let open Mina_base in
       (* choose largest account as most likely to produce a block *)
@@ -3868,8 +3870,8 @@ let%test_module "Proof of stake tests" =
         ; ledger = Genesis_epoch_ledger ledger
         }
       in
-      let balance = Balance.to_int account.balance in
-      let total_stake_int = Currency.Amount.to_int total_stake in
+      let balance = Balance.int_of_nanomina account.balance in
+      let total_stake_int = Currency.Amount.int_of_nanomina total_stake in
       let stake_fraction =
         float_of_int balance /. float_of_int total_stake_int
       in
@@ -3984,7 +3986,8 @@ let%test_module "Proof of stake tests" =
       Option.value_exn
         Amount.(
           genesis_currency
-          + of_int (height * to_int constraint_constants.coinbase_amount))
+          + nanomina
+              (height * int_of_nanomina constraint_constants.coinbase_amount))
 
     (* TODO: Deprecate this in favor of just returning a constant in the monad from the outside. *)
     let opt_gen opt ~gen =
@@ -4069,7 +4072,7 @@ let%test_module "Proof of stake tests" =
      *)
     let gen_spot ?root_epoch_position ?(slot_fill_rate = default_slot_fill_rate)
         ?(slot_fill_rate_delta = default_slot_fill_rate_delta)
-        ?(genesis_currency = Currency.Amount.of_int 200000)
+        ?(genesis_currency = Currency.Amount.nanomina 200_000)
         ?gen_staking_epoch_length ?gen_next_epoch_length
         ?gen_curr_epoch_position ?staking_start_checkpoint
         ?staking_lock_checkpoint ?next_start_checkpoint ?next_lock_checkpoint

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -352,6 +352,18 @@ module Make_str (A : Wire_types.Concrete) = struct
 
     let one = Unsigned.one
 
+    let nanomina = of_int
+
+    let centimina i = of_int (10_000_000 * i)
+
+    let mina i = of_int (1_000_000_000 * i)
+
+    let int_of_nanomina = to_int
+
+    let int_of_centimina m = to_int m / 10_000_000
+
+    let int_of_mina m = to_int m / 1_000_000_000
+
     let sub x y = if x < y then None else Some (Unsigned.sub x y)
 
     let sub_flagged x y =

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -50,6 +50,18 @@ module type Basic = sig
 
   val of_uint64 : uint64 -> t
 
+  val mina : int -> t
+
+  val centimina : int -> t
+
+  val nanomina : int -> t
+
+  val int_of_mina : t -> int
+
+  val int_of_centimina : t -> int
+
+  val int_of_nanomina : t -> int
+
   [%%ifdef consensus_mechanism]
 
   type var

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -42,10 +42,6 @@ module type Basic = sig
 
   val to_formatted_string : t -> string
 
-  val of_int : int -> t
-
-  val to_int : t -> int
-
   val to_uint64 : t -> uint64
 
   val of_uint64 : uint64 -> t

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -11,11 +11,11 @@ let account_with_timing account_id balance (timing : Intf.Timing.t) =
       Account.create account_id balance
   | Timed t ->
       let initial_minimum_balance =
-        Currency.Balance.of_int t.initial_minimum_balance
+        Currency.Balance.nanomina t.initial_minimum_balance
       in
       let cliff_time = Mina_numbers.Global_slot.of_int t.cliff_time in
-      let cliff_amount = Currency.Amount.of_int t.cliff_amount in
-      let vesting_increment = Currency.Amount.of_int t.vesting_increment in
+      let cliff_amount = Currency.Amount.nanomina t.cliff_amount in
+      let vesting_increment = Currency.Amount.nanomina t.vesting_increment in
       let vesting_period = Mina_numbers.Global_slot.of_int t.vesting_period in
       Account.create_timed account_id balance ~initial_minimum_balance
         ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment
@@ -41,7 +41,7 @@ module Public_accounts (Accounts : Intf.Public_accounts.S) = struct
     let%map accounts = Accounts.accounts in
     List.map accounts ~f:(fun { pk; balance; delegate; timing } ->
         let account_id = Account_id.create pk Token_id.default in
-        let balance = Balance.of_int balance in
+        let balance = Balance.nanomina balance in
         let base_acct = account_with_timing account_id balance timing in
         (None, { base_acct with delegate = Option.value ~default:pk delegate }) )
 end

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -264,7 +264,7 @@ module Ledger = struct
             ( None
             , Account.create
                 (Account_id.create pk Token_id.default)
-                (Currency.Balance.of_int 1000) )
+                (Currency.Balance.nanomina 1000) )
             :: accounts
       else accounts
     in

--- a/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
+++ b/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
@@ -353,7 +353,7 @@ module Accounts = struct
 
   let gen : (Private_key.t option * Account.t) Quickcheck.Generator.t =
     let open Quickcheck.Generator.Let_syntax in
-    let%bind balance = Int.gen_incl 10 500 >>| Currency.Balance.of_int in
+    let%bind balance = Int.gen_incl 10 500 >>| Currency.Balance.nanomina in
     gen_with_balance balance
 
   let generate n : (Private_key.t option * Account.t) list =

--- a/src/lib/mina_base/coinbase.ml
+++ b/src/lib/mina_base/coinbase.ml
@@ -137,7 +137,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         Quickcheck_lib.of_array keys
         >>| fun keypair -> Public_key.compress keypair.Keypair.public_key
       and amount =
-        Int.gen_incl min_amount max_amount >>| Currency.Amount.of_int
+        Int.gen_incl min_amount max_amount >>| Currency.Amount.nanomina
       in
       let%map fee_transfer =
         Option.quickcheck_generator (fee_transfer ~coinbase_amount:amount)

--- a/src/lib/mina_base/fee_transfer.ml
+++ b/src/lib/mina_base/fee_transfer.ml
@@ -56,7 +56,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           let open Signature_lib in
           Quickcheck_lib.of_array keys
           >>| fun keypair -> Public_key.compress keypair.Keypair.public_key
-        and fee = Int.gen_incl min_fee max_fee >>| Currency.Fee.of_int
+        and fee = Int.gen_incl min_fee max_fee >>| Currency.Fee.nanomina
         and fee_token = token in
         { receiver_pk; fee; fee_token }
     end

--- a/src/lib/mina_base/party.ml
+++ b/src/lib/mina_base/party.ml
@@ -87,7 +87,7 @@ module Update = struct
         Global_slot.gen_incl Global_slot.(succ zero) (Global_slot.of_int 10)
       in
       let%map vesting_increment =
-        Amount.gen_incl Amount.one (Amount.of_int 100)
+        Amount.gen_incl Amount.one (Amount.nanomina 100)
       in
       { initial_minimum_balance
       ; cliff_time

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -142,12 +142,14 @@ module Make_str (_ : Wire_types.Concrete) = struct
     let gen_inner (sign' : Signature_lib.Keypair.t -> Payload.t -> t) ~key_gen
         ?(nonce = Account_nonce.zero) ~fee_range create_body =
       let open Quickcheck.Generator.Let_syntax in
-      let min_fee = Fee.to_int Mina_compile_config.minimum_user_command_fee in
+      let min_fee =
+        Fee.int_of_nanomina Mina_compile_config.minimum_user_command_fee
+      in
       let max_fee = min_fee + fee_range in
       let%bind (signer : Signature_keypair.t), (receiver : Signature_keypair.t)
           =
         key_gen
-      and fee = Int.gen_incl min_fee max_fee >>| Currency.Fee.of_int
+      and fee = Int.gen_incl min_fee max_fee >>| Currency.Fee.nanomina
       and memo = String.quickcheck_generator in
       let%map body = create_body signer receiver in
       let payload : Payload.t =
@@ -170,7 +172,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
         @@ fun { public_key = signer; _ } { public_key = receiver; _ } ->
         let open Quickcheck.Generator.Let_syntax in
         let%map amount =
-          Int.gen_incl min_amount max_amount >>| Currency.Amount.of_int
+          Int.gen_incl min_amount max_amount >>| Currency.Amount.nanomina
         in
         Signed_command_payload.Body.Payment
           { receiver_pk = Public_key.compress receiver
@@ -255,7 +257,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
                  let amount_to_spend =
                    if spend_all then balance
                    else
-                     Currency.Amount.of_int (Currency.Amount.to_int balance / 2)
+                     Currency.Amount.nanomina
+                       (Currency.Amount.int_of_nanomina balance / 2)
                  in
                  Quickcheck_lib.gen_division_currency amount_to_spend
                    command_splits'.(i) )
@@ -271,7 +274,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
           Quickcheck.Generator.filter ~f:(fun (_, splits) ->
               Array.for_all splits ~f:(fun split ->
                   List.for_all split ~f:(fun amt ->
-                      Currency.Amount.(amt >= of_int 2_000_000_000) ) ) )
+                      Currency.Amount.(amt >= mina 2) ) ) )
         in
         let account_nonces =
           Array.map ~f:(fun (_, _, nonce, _) -> nonce) account_info

--- a/src/lib/mina_base/zkapp_precondition.ml
+++ b/src/lib/mina_base/zkapp_precondition.ml
@@ -546,7 +546,7 @@ module Account = struct
     |> finish "AccountPrecondition" ~t_toplevel_annots
 
   let%test_unit "json roundtrip" =
-    let b = Balance.of_int 1000 in
+    let b = Balance.nanomina 1000 in
     let predicate : t =
       { accept with
         balance = Or_ignore.Check { Closed_interval.lower = b; upper = b }

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -34,7 +34,7 @@ let get_keys_with_details t =
   let%map accounts = get_accounts t in
   List.map accounts ~f:(fun account ->
       ( string_of_public_key account
-      , account.Account.Poly.balance |> Currency.Balance.to_int
+      , account.Account.Poly.balance |> Currency.Balance.int_of_nanomina
       , account.Account.Poly.nonce |> Account.Nonce.to_int ) )
 
 let get_nonce t (addr : Account_id.t) =
@@ -263,7 +263,9 @@ let get_status ~flag t =
       (Mina_lib.snark_worker_key t)
       ~f:Public_key.Compressed.to_base58_check
   in
-  let snark_work_fee = Currency.Fee.to_int @@ Mina_lib.snark_work_fee t in
+  let snark_work_fee =
+    Currency.Fee.int_of_nanomina @@ Mina_lib.snark_work_fee t
+  in
   let block_production_keys = Mina_lib.block_production_pubkeys t in
   let coinbase_receiver =
     match Mina_lib.coinbase_receiver t with

--- a/src/lib/mina_generators/parties_generators.ml
+++ b/src/lib/mina_generators/parties_generators.ml
@@ -32,7 +32,7 @@ let gen_account_precondition_from_account ?failure ~first_use_of_account account
     let%bind (predicate_account : Zkapp_precondition.Account.t) =
       let%bind balance =
         let%bind balance_change_int = Int.gen_uniform_incl 1 10_000_000 in
-        let balance_change = Currency.Amount.of_int balance_change_int in
+        let balance_change = Currency.Amount.nanomina balance_change_int in
         let lower =
           match Currency.Balance.sub_amount balance balance_change with
           | None ->
@@ -396,12 +396,8 @@ let gen_protocol_state_precondition
   in
   let%bind total_currency =
     let open Currency in
-    let%bind epsilon1 =
-      Amount.gen_incl (Amount.of_int 0) (Amount.of_int 1_000_000_000)
-    in
-    let%bind epsilon2 =
-      Amount.gen_incl (Amount.of_int 0) (Amount.of_int 1_000_000_000)
-    in
+    let%bind epsilon1 = Amount.gen_incl Amount.zero (Amount.mina 1) in
+    let%bind epsilon2 = Amount.gen_incl Amount.zero (Amount.mina 1) in
     { lower =
         Amount.sub psv.total_currency epsilon1
         |> Option.value ~default:Amount.zero
@@ -540,9 +536,7 @@ let gen_invalid_protocol_state_precondition
   | Total_currency ->
       let open Currency in
       let%map total_currency =
-        let%map epsilon =
-          Amount.(gen_incl (of_int 1_000) (of_int 1_000_000_000))
-        in
+        let%map epsilon = Amount.(gen_incl (nanomina 1_000) (mina 1)) in
         if lower || Amount.(psv.total_currency > epsilon) then
           { lower = Amount.zero
           ; upper =
@@ -733,7 +727,7 @@ let gen_party_body_components (type a b c d) ?(update = None) ?account_id
             available_pk ;
           let account_id = Account_id.create available_pk Token_id.default in
           let account_with_pk =
-            Account.create account_id (Currency.Balance.of_int 0)
+            Account.create account_id Currency.Balance.zero
           in
           let account =
             if zkapp_account then

--- a/src/lib/mina_generators/user_command_generators.ml
+++ b/src/lib/mina_generators/user_command_generators.ml
@@ -57,9 +57,9 @@ let parties_with_ledger ?num_keypairs ?max_other_parties ?account_state_tbl ?vk
   let%bind balances =
     let min_cmd_fee = Mina_compile_config.minimum_user_command_fee in
     let min_balance =
-      Currency.Fee.to_int min_cmd_fee
+      Currency.Fee.int_of_nanomina min_cmd_fee
       |> Int.( + ) 100_000_000_000_000_000
-      |> Currency.Balance.of_int
+      |> Currency.Balance.nanomina
     in
     (* max balance to avoid overflow when adding deltas *)
     let max_balance =

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -95,7 +95,13 @@ module Ledger_inner = struct
     module Key = Public_key.Compressed
     module Token_id = Token_id
     module Account_id = Account_id
-    module Balance = Currency.Balance
+
+    module Balance = struct
+      include Currency.Balance
+
+      let to_int = int_of_nanomina
+    end
+
     module Account = Account.Stable.Latest
     module Hash = Hash.Stable.Latest
     module Kvdb = Kvdb
@@ -412,7 +418,7 @@ let gen_initial_ledger_state : init_state Quickcheck.Generator.t =
   let%bind balances =
     let gen_balance =
       let%map whole_balance = Int.gen_incl 500_000_000 1_000_000_000 in
-      Currency.Amount.of_int (whole_balance * 1_000_000_000)
+      Currency.Amount.mina whole_balance
     in
     Quickcheck_lib.replicate_gen gen_balance n_accounts
   in
@@ -441,7 +447,8 @@ let apply_initial_ledger_state : t -> init_state -> unit =
       let account = Account.initialize account_id in
       let account' =
         { account with
-          balance = Currency.Balance.of_int (Currency.Amount.to_int balance)
+          balance =
+            Currency.Balance.nanomina (Currency.Amount.int_of_nanomina balance)
         ; nonce
         ; timing
         }
@@ -509,7 +516,7 @@ let%test_unit "tokens test" =
     let token_account1 = Keypair.create () in
     let token_account2 = Keypair.create () in
     let account_creation_fee =
-      Currency.Fee.to_int constraint_constants.account_creation_fee
+      Currency.Fee.int_of_nanomina constraint_constants.account_creation_fee
     in
     let create_token : (Party.Body.Simple.t, unit, unit) Parties.Call_forest.t =
       mk_forest
@@ -565,7 +572,7 @@ let%test_unit "tokens test" =
            (Public_key.compress k.Keypair.public_key)
            custom_token_id )
           .balance
-        (Currency.Balance.of_int balance)
+        (Currency.Balance.nanomina balance)
     in
     execute_parties_transaction create_token ;
     (* Check that token_owner exists *)
@@ -591,7 +598,7 @@ let%test_unit "parties payment test" =
   let module L = Ledger_inner in
   let constraint_constants =
     { Genesis_constants.Constraint_constants.for_unit_tests with
-      account_creation_fee = Currency.Fee.of_int 1
+      account_creation_fee = Currency.Fee.nanomina 1
     }
   in
   Quickcheck.test ~trials:1 Test_spec.gen ~f:(fun { init_ledger; specs } ->

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -6,7 +6,7 @@ open Mina_numbers
 open Signature_lib
 
 (* Fee increase required to replace a transaction. *)
-let replace_fee : Currency.Fee.t = Currency.Fee.of_int 1
+let replace_fee : Currency.Fee.t = Currency.Fee.nanomina 1
 
 (* Invariants, maintained whenever a t is exposed from this module:
    * Iff a command is in all_by_fee it is also in all_by_sender.
@@ -1383,11 +1383,11 @@ let%test_module _ =
           let pool = empty in
           let add_res =
             add_from_gossip_exn pool cmd Account_nonce.zero
-              (Currency.Amount.of_int 500)
+              (Currency.Amount.nanomina 500)
           in
           if
             Option.value_exn (currency_consumed ~constraint_constants cmd)
-            |> Currency.Amount.to_int > 500
+            |> Currency.Amount.int_of_nanomina > 500
           then
             match add_res with
             | Error (Insufficient_funds _) ->
@@ -1424,7 +1424,7 @@ let%test_module _ =
             }
           in
           add_from_gossip_exn pool cmd Account_nonce.zero
-            (Currency.Amount.of_int 3000_000_000_000_000)
+            (Currency.Amount.mina 3_000_000)
           |> function
           | Ok (_, pool', dropped) ->
               assert (Sequence.is_empty dropped) ;
@@ -1577,7 +1577,7 @@ let%test_module _ =
           Quickcheck.Generator.map ~f:Account_nonce.of_int
           @@ Int.gen_incl 0 1000
         in
-        let init_balance = Currency.Amount.of_int 100_000_000_000_000 in
+        let init_balance = Currency.Amount.mina 100_000 in
         let%bind size = Quickcheck.Generator.size in
         let%bind amounts =
           Quickcheck.Generator.map ~f:Array.of_list
@@ -1595,7 +1595,7 @@ let%test_module _ =
             in
             let cmd_currency = amounts.(n - 1) in
             let%bind fee =
-              Currency.Amount.(gen_incl zero (min (of_int 10) cmd_currency))
+              Currency.Amount.(gen_incl zero (min (nanomina 10) cmd_currency))
             in
             let amount =
               Option.value_exn Currency.Amount.(cmd_currency - fee)
@@ -1631,16 +1631,13 @@ let%test_module _ =
           Mina_generators.User_command_generators.payment ~sign_type:`Fake
             ~key_gen
             ~nonce:(Account_nonce.of_int replaced_nonce)
-            ~max_amount:(Currency.Amount.to_int init_balance)
+            ~max_amount:(Currency.Amount.int_of_nanomina init_balance)
             ~fee_range:0 ()
         in
         let replace_cmd =
           modify_payment replace_cmd_skeleton ~sender ~body:Fn.id
             ~common:(fun c ->
-              { c with
-                fee =
-                  Currency.Fee.of_int ((10 + (5 * (size + 1))) * 1_000_000_000)
-              } )
+              { c with fee = Currency.Fee.mina (10 + (5 * (size + 1))) } )
         in
         (init_nonce, init_balance, setup_cmds, replace_cmd)
       in
@@ -1747,8 +1744,7 @@ let%test_module _ =
         , List.tl_exn cmds_sorted_by_fee_per_wu )
       in
       let insert_cmd pool cmd =
-        add_from_gossip_exn pool cmd Account_nonce.zero
-          (Currency.Amount.of_int (500 * 10_000_000))
+        add_from_gossip_exn pool cmd Account_nonce.zero (Currency.Amount.mina 5)
         |> Result.ok |> Option.value_exn
         |> fun (_, pool, _) -> pool
       in
@@ -1788,8 +1784,7 @@ let%test_module _ =
       in
       let max_by_fee_per_wu = List.max_elt ~compare cmds |> Option.value_exn in
       let insert_cmd pool cmd =
-        add_from_gossip_exn pool cmd Account_nonce.zero
-          (Currency.Amount.of_int (500 * 10_000_000))
+        add_from_gossip_exn pool cmd Account_nonce.zero (Currency.Amount.mina 5)
         |> Result.ok |> Option.value_exn
         |> fun (_, pool, _) -> pool
       in
@@ -1841,7 +1836,7 @@ let%test_module _ =
           let account_id =
             Account_id.create (Public_key.compress public_key) Token_id.default
           in
-          let balance = Balance.of_int @@ Amount.to_int amount in
+          let balance = Balance.nanomina @@ Amount.int_of_nanomina amount in
           let _tag, account, location =
             Or_error.ok_exn (get_or_create ledger account_id)
           in
@@ -1981,7 +1976,7 @@ let%test_module _ =
       let open Currency in
       (* let open Mina_transaction_logic.For_tests in *)
       let fee = Mina_compile_config.minimum_user_command_fee in
-      let amount = Amount.of_int @@ Fee.to_int fee in
+      let amount = Amount.nanomina @@ Fee.int_of_nanomina fee in
       let balance = Option.value_exn (Amount.scale amount 100) in
       let kp1 =
         Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
@@ -2016,7 +2011,7 @@ let%test_module _ =
                    properly" =
       let open Currency in
       let fee = Mina_compile_config.minimum_user_command_fee in
-      let amount = Amount.of_int @@ Fee.to_int fee in
+      let amount = Amount.nanomina @@ Fee.int_of_nanomina fee in
       let balance = Option.value_exn (Amount.scale amount 100) in
       let kp1 =
         Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
@@ -2055,7 +2050,7 @@ let%test_module _ =
                    not trigger a crash" =
       let open Currency in
       let fee = Mina_compile_config.minimum_user_command_fee in
-      let amount = Amount.of_int @@ Fee.to_int fee in
+      let amount = Amount.nanomina @@ Fee.int_of_nanomina fee in
       let balance = Option.value_exn (Amount.scale amount 100) in
       let kp1 =
         Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -436,8 +436,8 @@ struct
                   Gauge.set Snark_work.snark_pool_size
                     (Float.of_int @@ Hashtbl.length t.snark_tables.all) ;
                   Snark_work.Snark_fee_histogram.observe Snark_work.snark_fee
-                    ( fee.Mina_base.Fee_with_prover.fee |> Currency.Fee.to_int
-                    |> Float.of_int )) ;
+                    ( fee.Mina_base.Fee_with_prover.fee
+                    |> Currency.Fee.int_of_nanomina |> Float.of_int )) ;
                 `Added )
               else
                 let origin =
@@ -1018,7 +1018,7 @@ let%test_module "random set test" =
                         ~seed:(`Deterministic "test proof")
                         Transaction_snark.Statement.gen ) )
             ; fee =
-                { fee = Currency.Fee.of_int 0
+                { fee = Currency.Fee.zero
                 ; prover = Signature_lib.Public_key.Compressed.empty
                 }
             }
@@ -1064,7 +1064,7 @@ let%test_module "random set test" =
               , Priced_proof.
                   { proof = One_or_two.map ~f:mk_dummy_proof work
                   ; fee =
-                      { fee = Currency.Fee.of_int 0
+                      { fee = Currency.Fee.zero
                       ; prover = Signature_lib.Public_key.Compressed.empty
                       }
                   } )

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -53,7 +53,7 @@ let%test_module "network pool test" =
         { Priced_proof.proof =
             One_or_two.map ~f:Ledger_proof.For_tests.mk_dummy_proof work
         ; fee =
-            { fee = Currency.Fee.of_int 0
+            { fee = Currency.Fee.zero
             ; prover = Signature_lib.Public_key.Compressed.empty
             }
         }
@@ -105,7 +105,7 @@ let%test_module "network pool test" =
               { proof =
                   One_or_two.map ~f:Ledger_proof.For_tests.mk_dummy_proof work
               ; fee =
-                  { fee = Currency.Fee.of_int 0
+                  { fee = Currency.Fee.zero
                   ; prover = Signature_lib.Public_key.Compressed.empty
                   }
               } )

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1456,7 +1456,7 @@ let%test_module _ =
     let proof_level = precomputed_values.proof_level
 
     let minimum_fee =
-      Currency.Fee.to_int Mina_compile_config.minimum_user_command_fee
+      Currency.Fee.int_of_nanomina Mina_compile_config.minimum_user_command_fee
 
     let logger = Logger.create ()
 
@@ -1729,7 +1729,8 @@ let%test_module _ =
         () =
       let get_pk idx = Public_key.compress test_keys.(idx).public_key in
       Signed_command.sign test_keys.(sender_idx)
-        (Signed_command_payload.create ~fee:(Currency.Fee.of_int fee)
+        (Signed_command_payload.create
+           ~fee:(Currency.Fee.nanomina fee)
            ~fee_payer_pk:(get_pk sender_idx) ~valid_until
            ~nonce:(Account.Nonce.of_int nonce)
            ~memo:(Signed_command_memo.create_by_digesting_string_exn "foo")
@@ -1737,7 +1738,7 @@ let%test_module _ =
              (Signed_command_payload.Body.Payment
                 { source_pk = get_pk sender_idx
                 ; receiver_pk = get_pk receiver_idx
-                ; amount = Currency.Amount.of_int amount
+                ; amount = Currency.Amount.nanomina amount
                 } ) )
 
     let mk_transfer_parties ?valid_period ?fee_payer_idx ~sender_idx
@@ -1745,7 +1746,7 @@ let%test_module _ =
       let sender_kp = test_keys.(sender_idx) in
       let sender_nonce = Account.Nonce.of_int nonce in
       let sender = (sender_kp, sender_nonce) in
-      let amount = Currency.Amount.of_int amount in
+      let amount = Currency.Amount.nanomina amount in
       let receiver_kp = test_keys.(receiver_idx) in
       let receiver =
         receiver_kp.public_key |> Signature_lib.Public_key.compress
@@ -1759,7 +1760,7 @@ let%test_module _ =
             let fee_payer_nonce = Account.Nonce.of_int nonce in
             Some (fee_payer_kp, fee_payer_nonce)
       in
-      let fee = Currency.Fee.of_int fee in
+      let fee = Currency.Fee.nanomina fee in
       let protocol_state_precondition =
         match valid_period with
         | None ->
@@ -2030,7 +2031,7 @@ let%test_module _ =
       let account = Option.value_exn @@ Mina_ledger.Ledger.get ledger loc in
       Mina_ledger.Ledger.set ledger loc
         { account with
-          balance = Currency.Balance.of_int balance
+          balance = Currency.Balance.nanomina balance
         ; nonce = Account.Nonce.of_int nonce
         }
 
@@ -2452,14 +2453,18 @@ let%test_module _ =
       let replace_txs =
         [ (* sufficient fee *)
           mk_payment ~sender_idx:0
-            ~fee:(minimum_fee + Currency.Fee.to_int Indexed_pool.replace_fee)
+            ~fee:
+              ( minimum_fee
+              + Currency.Fee.int_of_nanomina Indexed_pool.replace_fee )
             ~nonce:0 ~receiver_idx:1 ~amount:440_000_000_000 ()
         ; (* insufficient fee *)
           mk_payment ~sender_idx:1 ~fee:minimum_fee ~nonce:0 ~receiver_idx:1
             ~amount:788_000_000_000 ()
         ; (* sufficient *)
           mk_payment ~sender_idx:2
-            ~fee:(minimum_fee + Currency.Fee.to_int Indexed_pool.replace_fee)
+            ~fee:
+              ( minimum_fee
+              + Currency.Fee.int_of_nanomina Indexed_pool.replace_fee )
             ~nonce:1 ~receiver_idx:4 ~amount:721_000_000_000 ()
         ; (* insufficient *)
           (let amount = 927_000_000_000 in
@@ -2478,7 +2483,7 @@ let%test_module _ =
              let account =
                Mock_base_ledger.get ledger location |> Option.value_exn
              in
-             Currency.Balance.to_int account.balance - amount
+             Currency.Balance.int_of_nanomina account.balance - amount
            in
            mk_payment ~sender_idx:3 ~fee ~nonce:1 ~receiver_idx:4 ~amount () )
         ]

--- a/src/lib/parties_builder/parties_builder.ml
+++ b/src/lib/parties_builder/parties_builder.ml
@@ -16,7 +16,7 @@ let mk_party_body caller kp token_id balance_change : Party.Body.Simple.t =
   ; token_id
   ; balance_change =
       Currency.Amount.Signed.create
-        ~magnitude:(Currency.Amount.of_int (Int.abs balance_change))
+        ~magnitude:(Currency.Amount.nanomina (Int.abs balance_change))
         ~sgn:(if Int.is_negative balance_change then Sgn.Neg else Pos)
   ; increment_nonce = false
   ; events = []
@@ -36,7 +36,7 @@ let mk_parties_transaction ?memo ~fee ~fee_payer_pk ~fee_payer_nonce
   let fee_payer : Party.Fee_payer.t =
     { body =
         { public_key = fee_payer_pk
-        ; fee = Currency.Fee.of_int fee
+        ; fee = Currency.Fee.nanomina fee
         ; valid_until = None
         ; nonce = fee_payer_nonce
         }

--- a/src/lib/quickcheck_lib/quickcheck_lib.ml
+++ b/src/lib/quickcheck_lib/quickcheck_lib.ml
@@ -130,6 +130,10 @@ let gen_division_currency =
       let ( + ) a b = Option.value_exn (a + b)
 
       let ( - ) a b = Option.value_exn (a - b)
+
+      let of_int = nanomina
+
+      let to_int = int_of_nanomina
     end )
 
 let imperative_fixed_point root ~f =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1004,9 +1004,9 @@ module T = struct
     Or_error.try_with (fun () ->
         let open Mina_metrics in
         Gauge.set Scan_state_metrics.snark_fee_per_block
-          (Int.to_float @@ Fee.to_int total_snark_fee) ;
+          (Int.to_float @@ Fee.int_of_nanomina total_snark_fee) ;
         Gauge.set Scan_state_metrics.transaction_fees_per_block
-          (Int.to_float @@ Fee.to_int total_txn_fee) ;
+          (Int.to_float @@ Fee.int_of_nanomina total_txn_fee) ;
         Gauge.set Scan_state_metrics.purchased_snark_work_per_block
           (Float.of_int @@ List.length work) ;
         Gauge.set Scan_state_metrics.snark_work_required
@@ -2863,7 +2863,7 @@ let%test_module "staged ledger tests" =
         let prover = stmt_to_prover stmts in
         Some
           { Transaction_snark_work.Checked.fee =
-              Currency.Fee.(sub work_fee (of_int 1)) |> Option.value_exn
+              Currency.Fee.(sub work_fee (nanomina 1)) |> Option.value_exn
           ; proofs = proofs stmts
           ; prover
           }
@@ -3191,7 +3191,7 @@ let%test_module "staged ledger tests" =
               in
               let%map fees =
                 Quickcheck.Generator.list_with_length number_of_proofs
-                  Fee.(gen_incl (of_int 1) (of_int 20))
+                  Fee.(gen_incl (nanomina 1) (nanomina 20))
               in
               (number_of_proofs, fees) )
         in
@@ -3215,7 +3215,7 @@ let%test_module "staged ledger tests" =
               in
               let%map fees =
                 Quickcheck.Generator.list_with_length number_of_proofs
-                  Fee.(gen_incl (of_int 1) (of_int 20))
+                  Fee.(gen_incl (nanomina 1) (nanomina 20))
               in
               (number_of_proofs, fees) )
         in
@@ -3387,14 +3387,14 @@ let%test_module "staged ledger tests" =
           (Public_key.compress keypair.public_key)
           Token_id.default
       in
-      let balance = Balance.of_int 100_000_000_000 in
+      let balance = Balance.mina 100 in
       (*Should fully vest by slot = 7*)
       let acc =
         Account.create_timed account_id balance ~initial_minimum_balance:balance
           ~cliff_time:(Mina_numbers.Global_slot.of_int 4)
           ~cliff_amount:Amount.zero
           ~vesting_period:(Mina_numbers.Global_slot.of_int 2)
-          ~vesting_increment:(Amount.of_int 50_000_000_000)
+          ~vesting_increment:(Amount.mina 50)
         |> Or_error.ok_exn
       in
       (keypair, acc)
@@ -3410,7 +3410,7 @@ let%test_module "staged ledger tests" =
           (Public_key.compress keypair.public_key)
           Token_id.default
       in
-      let balance = Balance.of_int 100_000_000_000 in
+      let balance = Balance.mina 100 in
       let acc = Account.create account_id balance in
       (keypair, acc)
 
@@ -3610,8 +3610,9 @@ let%test_module "staged ledger tests" =
           Public_key.Compressed.gen
       in
       let insufficient_account_creation_fee =
-        Currency.Fee.to_int constraint_constants.account_creation_fee / 2
-        |> Currency.Amount.of_int
+        Currency.Fee.int_of_nanomina constraint_constants.account_creation_fee
+        / 2
+        |> Currency.Amount.nanomina
       in
       let source_pk = Public_key.compress kp.public_key in
       let body =
@@ -3679,9 +3680,10 @@ let%test_module "staged ledger tests" =
                     |> Option.value_exn ) )
             | `Invalid ->
                 (* Not enough account creation fee and using full balance for fee*)
-                ( Currency.Fee.to_int constraint_constants.account_creation_fee
+                ( Currency.Fee.int_of_nanomina
+                    constraint_constants.account_creation_fee
                   / 2
-                  |> Currency.Amount.of_int
+                  |> Currency.Amount.nanomina
                 , Currency.Amount.to_fee balance )
           in
           let source_pk = Public_key.compress kp.public_key in
@@ -3786,8 +3788,8 @@ let%test_module "staged ledger tests" =
       in
       Quickcheck.test ~trials:1 gen
         ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-          let fee = Fee.of_int 1_000_000 in
-          let amount = Amount.of_int 10_000_000_000 in
+          let fee = Fee.nanomina 1_000_000 in
+          let amount = Amount.mina 10 in
           let snapp_pk = Signature_lib.Public_key.compress new_kp.public_key in
           let snapp_update =
             { Party.Update.dummy with

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2161,10 +2161,10 @@ module For_tests = struct
         fst init_ledger.(i)
       in
       let gen_amount () =
-        Currency.Amount.(gen_incl (of_int 1_000_000) (of_int 100_000_000))
+        Currency.Amount.(gen_incl (nanomina 1_000_000) (centimina 10))
       in
       let gen_fee () =
-        Currency.Fee.(gen_incl (of_int 1_000_000) (of_int 100_000_000))
+        Currency.Fee.(gen_incl (nanomina 1_000_000) (centimina 10))
       in
       let nonce : Account_nonce.t = Map.find_exn nonces sender in
       let%bind fee = gen_fee () in

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -81,13 +81,13 @@ let%test_module "account timing check" =
     let%test "before_cliff_time" =
       let pk = Public_key.Compressed.empty in
       let account_id = Account_id.create pk Token_id.default in
-      let balance = Balance.of_int 100_000_000_000_000 in
-      let initial_minimum_balance = Balance.of_int 80_000_000_000_000 in
+      let balance = Balance.mina 100_000 in
+      let initial_minimum_balance = Balance.mina 80_000 in
       let cliff_time = Mina_numbers.Global_slot.of_int 1000 in
-      let cliff_amount = Amount.of_int 500_000_000 in
+      let cliff_amount = Amount.centimina 50 in
       let vesting_period = Mina_numbers.Global_slot.of_int 10 in
-      let vesting_increment = Amount.of_int 1_000_000_000 in
-      let txn_amount = Currency.Amount.of_int 100_000_000_000 in
+      let vesting_increment = Amount.mina 1 in
+      let txn_amount = Currency.Amount.mina 100 in
       let txn_global_slot = Mina_numbers.Global_slot.of_int 45 in
       let account =
         Or_error.ok_exn
@@ -108,22 +108,22 @@ let%test_module "account timing check" =
     let%test "positive min balance" =
       let pk = Public_key.Compressed.empty in
       let account_id = Account_id.create pk Token_id.default in
-      let balance = Balance.of_int 100_000_000_000_000 in
-      let initial_minimum_balance = Balance.of_int 10_000_000_000_000 in
+      let balance = Balance.mina 100_000 in
+      let initial_minimum_balance = Balance.mina 10_000 in
       let cliff_time = Mina_numbers.Global_slot.of_int 1000 in
       let cliff_amount = Amount.zero in
       let vesting_period = Mina_numbers.Global_slot.of_int 10 in
-      let vesting_increment = Amount.of_int 100_000_000_000 in
+      let vesting_increment = Amount.mina 100 in
       let account =
         Or_error.ok_exn
         @@ Account.create_timed account_id balance ~initial_minimum_balance
              ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment
       in
-      let txn_amount = Currency.Amount.of_int 100_000_000_000 in
+      let txn_amount = Currency.Amount.mina 100 in
       let txn_global_slot = Mina_numbers.Global_slot.of_int 1_900 in
       let timing_with_min_balance =
         validate_timing_with_min_balance ~account
-          ~txn_amount:(Currency.Amount.of_int 100_000_000_000)
+          ~txn_amount:(Currency.Amount.mina 100)
           ~txn_global_slot:(Mina_numbers.Global_slot.of_int 1_900)
       in
       (* we're 900 slots past the cliff, which is 90 vesting periods
@@ -141,18 +141,18 @@ let%test_module "account timing check" =
     let%test "curr min balance of zero" =
       let pk = Public_key.Compressed.empty in
       let account_id = Account_id.create pk Token_id.default in
-      let balance = Balance.of_int 100_000_000_000_000 in
-      let initial_minimum_balance = Balance.of_int 10_000_000_000_000 in
+      let balance = Balance.mina 100_000 in
+      let initial_minimum_balance = Balance.mina 10_000 in
       let cliff_time = Mina_numbers.Global_slot.of_int 1_000 in
-      let cliff_amount = Amount.of_int 900_000_000 in
+      let cliff_amount = Amount.centimina 90 in
       let vesting_period = Mina_numbers.Global_slot.of_int 10 in
-      let vesting_increment = Amount.of_int 100_000_000_000 in
+      let vesting_increment = Amount.mina 100 in
       let account =
         Or_error.ok_exn
         @@ Account.create_timed account_id balance ~initial_minimum_balance
              ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment
       in
-      let txn_amount = Currency.Amount.of_int 100_000_000_000 in
+      let txn_amount = Currency.Amount.mina 100 in
       let txn_global_slot = Mina_numbers.Global_slot.of_int 2_000 in
       let timing_with_min_balance =
         validate_timing_with_min_balance ~txn_amount ~txn_global_slot ~account
@@ -172,18 +172,18 @@ let%test_module "account timing check" =
     let%test "below calculated min balance" =
       let pk = Public_key.Compressed.empty in
       let account_id = Account_id.create pk Token_id.default in
-      let balance = Balance.of_int 10_000_000_000_000 in
-      let initial_minimum_balance = Balance.of_int 10_000_000_000_000 in
+      let balance = Balance.mina 10_000 in
+      let initial_minimum_balance = Balance.mina 10_000 in
       let cliff_time = Mina_numbers.Global_slot.of_int 1_000 in
       let cliff_amount = Amount.zero in
       let vesting_period = Mina_numbers.Global_slot.of_int 10 in
-      let vesting_increment = Amount.of_int 100_000_000_000 in
+      let vesting_increment = Amount.mina 100 in
       let account =
         Or_error.ok_exn
         @@ Account.create_timed account_id balance ~initial_minimum_balance
              ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment
       in
-      let txn_amount = Currency.Amount.of_int 101_000_000_000 in
+      let txn_amount = Currency.Amount.mina 101 in
       let txn_global_slot = Mina_numbers.Global_slot.of_int 1_010 in
       let timing = validate_timing ~txn_amount ~txn_global_slot ~account in
       match timing with
@@ -199,18 +199,18 @@ let%test_module "account timing check" =
     let%test "insufficient balance" =
       let pk = Public_key.Compressed.empty in
       let account_id = Account_id.create pk Token_id.default in
-      let balance = Balance.of_int 100_000_000_000_000 in
-      let initial_minimum_balance = Balance.of_int 10_000_000_000_000 in
+      let balance = Balance.mina 100_000 in
+      let initial_minimum_balance = Balance.mina 10_000 in
       let cliff_time = Mina_numbers.Global_slot.of_int 1000 in
       let cliff_amount = Amount.zero in
       let vesting_period = Mina_numbers.Global_slot.of_int 10 in
-      let vesting_increment = Amount.of_int 100_000_000_000 in
+      let vesting_increment = Amount.mina 100 in
       let account =
         Or_error.ok_exn
         @@ Account.create_timed account_id balance ~initial_minimum_balance
              ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment
       in
-      let txn_amount = Currency.Amount.of_int 100_001_000_000_000 in
+      let txn_amount = Currency.Amount.mina 100_001 in
       let txn_global_slot = Mina_numbers.Global_slot.of_int 2000_000_000_000 in
       let timing = validate_timing ~txn_amount ~txn_global_slot ~account in
       match timing with
@@ -226,19 +226,19 @@ let%test_module "account timing check" =
     let%test "past full vesting" =
       let pk = Public_key.Compressed.empty in
       let account_id = Account_id.create pk Token_id.default in
-      let balance = Balance.of_int 100_000_000_000_000 in
-      let initial_minimum_balance = Balance.of_int 10_000_000_000_000 in
+      let balance = Balance.mina 100_000 in
+      let initial_minimum_balance = Balance.mina 10_000 in
       let cliff_time = Mina_numbers.Global_slot.of_int 1000 in
       let cliff_amount = Amount.zero in
       let vesting_period = Mina_numbers.Global_slot.of_int 10 in
-      let vesting_increment = Amount.of_int 100_000_000_000 in
+      let vesting_increment = Amount.mina 100 in
       let account =
         Or_error.ok_exn
         @@ Account.create_timed account_id balance ~initial_minimum_balance
              ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment
       in
       (* fully vested, curr min balance = 0, so we can spend the whole balance *)
-      let txn_amount = Currency.Amount.of_int 100_000_000_000_000 in
+      let txn_amount = Currency.Amount.mina 100_000 in
       let txn_global_slot = Mina_numbers.Global_slot.of_int 3000 in
       let timing_with_min_balance =
         validate_timing_with_min_balance ~txn_amount ~txn_global_slot ~account
@@ -254,8 +254,8 @@ let%test_module "account timing check" =
     let make_cliff_amount_test slot =
       let pk = Public_key.Compressed.empty in
       let account_id = Account_id.create pk Token_id.default in
-      let balance = Balance.of_int 100_000_000_000_000 in
-      let initial_minimum_balance = Balance.of_int 10_000_000_000_000 in
+      let balance = Balance.mina 100_000 in
+      let initial_minimum_balance = Balance.mina 10_000 in
       let cliff_time = Mina_numbers.Global_slot.of_int 1000 in
       let cliff_amount =
         Balance.to_uint64 initial_minimum_balance |> Amount.of_uint64
@@ -267,7 +267,7 @@ let%test_module "account timing check" =
         @@ Account.create_timed account_id balance ~initial_minimum_balance
              ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment
       in
-      let txn_amount = Currency.Amount.of_int 100_000_000_000_000 in
+      let txn_amount = Currency.Amount.mina 100_000 in
       let txn_global_slot = Mina_numbers.Global_slot.of_int slot in
       (txn_amount, txn_global_slot, account)
 
@@ -450,16 +450,15 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 10_000_000_000_000 in
+              let balance = Currency.Balance.mina 10_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 50_000_000_000
+                  { initial_minimum_balance = Currency.Balance.mina 50
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 100
+                  ; cliff_amount = Currency.Amount.nanomina 100
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -501,16 +500,15 @@ let%test_module "account timing check" =
         (* high init min balance, payment amount enough to violate *)
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 10_000_000_000_000 in
+              let balance = Currency.Balance.mina 10_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 9_995_000_000_000
-                  ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 100
+                  { initial_minimum_balance = Currency.Balance.mina 9_995
+                  ; cliff_time = Mina_numbers.Global_slot.of_int 10_000
+                  ; cliff_amount = Currency.Amount.nanomina 100
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -564,16 +562,15 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 10_000_000_000_000 in
+              let balance = Currency.Balance.mina 10_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 9_995_000_000_000
+                  { initial_minimum_balance = Currency.Balance.mina 9_995
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 9_995_000_000_000
+                  ; cliff_amount = Currency.Amount.mina 9_995
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -618,16 +615,15 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 10_000_000_000_000 in
+              let balance = Currency.Balance.mina 10_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 9_995_000_000_000
+                  { initial_minimum_balance = Currency.Balance.mina 9_995
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 9_995_000_000_000
+                  ; cliff_amount = Currency.Amount.mina 9_995
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -666,16 +662,16 @@ let%test_module "account timing check" =
         let balance_int = 10_000_000_000_000 in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int balance_int in
+              let balance = Currency.Balance.nanomina balance_int in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
                   { initial_minimum_balance =
-                      Currency.Balance.of_int init_min_bal_int
+                      Currency.Balance.nanomina init_min_bal_int
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10000
                   ; cliff_amount = Currency.Amount.zero
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -690,7 +686,7 @@ let%test_module "account timing check" =
         *)
         let amount =
           liquid_bal_100_slots
-          - Fee.to_int Mina_compile_config.minimum_user_command_fee
+          - Fee.int_of_nanomina Mina_compile_config.minimum_user_command_fee
         in
         let%map user_command =
           let%map payment =
@@ -723,16 +719,15 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 10_000_000_000_000 in
+              let balance = Currency.Balance.mina 10_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 9_995_000_000_000
+                  { initial_minimum_balance = Currency.Balance.mina 9_995
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 9_995_000_000_000
+                  ; cliff_amount = Currency.Amount.mina 9_995
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -770,16 +765,15 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 10_000_000_000_000 in
+              let balance = Currency.Balance.mina 10_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 9_995_000_000_000
+                  { initial_minimum_balance = Currency.Balance.mina 9_995
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 9_995_000_000_000
+                  ; cliff_amount = Currency.Amount.mina 9_995
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -870,16 +864,15 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 10_000_000_000_000 in
+              let balance = Currency.Balance.mina 10_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 50_000_000_000
-                  ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 100
+                  { initial_minimum_balance = Currency.Balance.mina 50
+                  ; cliff_time = Mina_numbers.Global_slot.of_int 10_000
+                  ; cliff_amount = Currency.Amount.nanomina 100
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -888,8 +881,8 @@ let%test_module "account timing check" =
         in
         let parties =
           let open Mina_base in
-          let fee = Currency.Fee.of_int 1_000_000 in
-          let amount = Currency.Amount.of_int 1_500_000 in
+          let fee = Currency.Fee.nanomina 1_000_000 in
+          let amount = Currency.Amount.nanomina 1_500_000 in
           let nonce = Account.Nonce.zero in
           let memo =
             Signed_command_memo.create_from_string_exn
@@ -938,17 +931,16 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 100_000_000_000_000 in
+              let balance = Currency.Balance.mina 100_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               (* high init min balance, payment amount enough to violate *)
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 99_000_000_000_000
-                  ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 100
+                  { initial_minimum_balance = Currency.Balance.mina 99_000
+                  ; cliff_time = Mina_numbers.Global_slot.of_int 10_000
+                  ; cliff_amount = Currency.Amount.nanomina 100
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -957,8 +949,8 @@ let%test_module "account timing check" =
         in
         let parties_command =
           let open Mina_base in
-          let fee = Currency.Fee.of_int 1_000_000 in
-          let amount = Currency.Amount.of_int 10_000_000_000_000 in
+          let fee = Currency.Fee.nanomina 1_000_000 in
+          let amount = Currency.Amount.mina 10_000 in
           let nonce = Account.Nonce.zero in
           let memo =
             Signed_command_memo.create_from_string_exn
@@ -1014,7 +1006,7 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 100_000_000_000_000 in
+              let balance = Currency.Balance.mina 100_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               (* high init min balance, payment amount enough to violate *)
               let (timing : Account_timing.t) =
@@ -1022,12 +1014,11 @@ let%test_module "account timing check" =
                    fee, before considering transfer
                 *)
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 100_000_000_000_000
+                  { initial_minimum_balance = Currency.Balance.mina 100_000
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 100
+                  ; cliff_amount = Currency.Amount.nanomina 100
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -1036,8 +1027,8 @@ let%test_module "account timing check" =
         in
         let parties_command =
           let open Mina_base in
-          let fee = Currency.Fee.of_int 1_000_000 in
-          let amount = Currency.Amount.of_int 10_000_000_000_000 in
+          let fee = Currency.Fee.nanomina 1_000_000 in
+          let amount = Currency.Amount.mina 10_000 in
           let nonce = Account.Nonce.zero in
           let memo =
             Signed_command_memo.create_from_string_exn
@@ -1101,7 +1092,7 @@ let%test_module "account timing check" =
       let open Quickcheck.Generator.Let_syntax in
       let untimed =
         let keypair = List.nth_exn keypairs 0 in
-        let balance = Currency.Balance.of_int 200_000_000_000_000 in
+        let balance = Currency.Balance.mina 200_000 in
         let nonce = Mina_numbers.Account_nonce.zero in
         let balance_as_amount = Currency.Balance.to_amount balance in
         (keypair, balance_as_amount, nonce, Account_timing.Untimed)
@@ -1112,13 +1103,13 @@ let%test_module "account timing check" =
       let fee = 1_000_000 in
       let (create_timed_account_spec : Transaction_snark.For_tests.Spec.t) =
         { sender = (sender_keypair, Account.Nonce.zero)
-        ; fee = Currency.Fee.of_int fee
+        ; fee = Currency.Fee.nanomina fee
         ; fee_payer = None
         ; receivers = []
         ; amount =
             Option.value_exn
               Currency.Amount.(
-                add (of_int balance)
+                add (nanomina balance)
                   (of_fee constraint_constants.account_creation_fee))
         ; zkapp_account_keypairs = [ zkapp_keypair ]
         ; memo =
@@ -1129,11 +1120,11 @@ let%test_module "account timing check" =
             (let timing =
                Zkapp_basic.Set_or_keep.Set
                  ( { initial_minimum_balance =
-                       Currency.Balance.of_int min_balance
+                       Currency.Balance.nanomina min_balance
                    ; cliff_time = Mina_numbers.Global_slot.of_int 1000
-                   ; cliff_amount = Currency.Amount.of_int 100_000_000
+                   ; cliff_amount = Currency.Amount.centimina 10
                    ; vesting_period = Mina_numbers.Global_slot.of_int 10
-                   ; vesting_increment = Currency.Amount.of_int 100_000_000
+                   ; vesting_increment = Currency.Amount.centimina 10
                    }
                    : Party.Update.Timing_info.value )
              in
@@ -1224,16 +1215,15 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 100_000_000_000_000 in
+              let balance = Currency.Balance.mina 100_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 100_000_000_000_000
+                  { initial_minimum_balance = Currency.Balance.mina 100_000
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 100_000_000_000_000
+                  ; cliff_amount = Currency.Amount.mina 100_000
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -1243,8 +1233,8 @@ let%test_module "account timing check" =
         (* min balance = balance, spending anything before cliff should trigger min balance violation *)
         let parties_command =
           let open Mina_base in
-          let fee = Currency.Fee.of_int 1_000_000 in
-          let amount = Currency.Amount.of_int 10_000_000_000_000 in
+          let fee = Currency.Fee.nanomina 1_000_000 in
+          let amount = Currency.Amount.mina 10_000 in
           let nonce = Account.Nonce.zero in
           let memo =
             Signed_command_memo.create_from_string_exn
@@ -1310,16 +1300,15 @@ let%test_module "account timing check" =
         let open Quickcheck.Generator.Let_syntax in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int 100_000_000_000_000 in
+              let balance = Currency.Balance.mina 100_000 in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
-                  { initial_minimum_balance =
-                      Currency.Balance.of_int 100_000_000_000_000
+                  { initial_minimum_balance = Currency.Balance.mina 100_000
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10000
-                  ; cliff_amount = Currency.Amount.of_int 100_000_000_000_000
+                  ; cliff_amount = Currency.Amount.mina 100_000
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 10
+                  ; vesting_increment = Currency.Amount.nanomina 10
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -1328,8 +1317,8 @@ let%test_module "account timing check" =
         in
         let parties =
           let open Mina_base in
-          let fee = Currency.Fee.of_int 1_000_000 in
-          let amount = Currency.Amount.of_int 10_000_000_000_000 in
+          let fee = Currency.Fee.nanomina 1_000_000 in
+          let amount = Currency.Amount.mina 10_000 in
           let nonce = Account.Nonce.zero in
           let memo =
             Signed_command_memo.create_from_string_exn
@@ -1379,16 +1368,16 @@ let%test_module "account timing check" =
         let init_min_balance_int = 100_000_000_000_000 in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int balance_int in
+              let balance = Currency.Balance.nanomina balance_int in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
                   { initial_minimum_balance =
-                      Currency.Balance.of_int init_min_balance_int
+                      Currency.Balance.nanomina init_min_balance_int
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10_000
                   ; cliff_amount = Currency.Amount.zero
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 100_000
+                  ; vesting_increment = Currency.Amount.nanomina 100_000
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -1402,8 +1391,8 @@ let%test_module "account timing check" =
         let amount_int = liquid_balance - fee_int in
         let parties =
           let open Mina_base in
-          let fee = Currency.Fee.of_int 1_000_000 in
-          let amount = Currency.Amount.of_int amount_int in
+          let fee = Currency.Fee.nanomina 1_000_000 in
+          let amount = Currency.Amount.nanomina amount_int in
           let nonce = Account.Nonce.zero in
           let memo =
             Signed_command_memo.create_from_string_exn
@@ -1453,16 +1442,16 @@ let%test_module "account timing check" =
         let init_min_balance_int = 100_000_000_000_000 in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int balance_int in
+              let balance = Currency.Balance.nanomina balance_int in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
                   { initial_minimum_balance =
-                      Currency.Balance.of_int init_min_balance_int
+                      Currency.Balance.nanomina init_min_balance_int
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10_000
                   ; cliff_amount = Currency.Amount.zero
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 100_000
+                  ; vesting_increment = Currency.Amount.nanomina 100_000
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -1477,8 +1466,8 @@ let%test_module "account timing check" =
         let amount_int = liquid_balance - fee_int + 1 in
         let parties =
           let open Mina_base in
-          let fee = Currency.Fee.of_int 1_000_000 in
-          let amount = Currency.Amount.of_int amount_int in
+          let fee = Currency.Fee.nanomina 1_000_000 in
+          let amount = Currency.Amount.nanomina amount_int in
           let nonce = Account.Nonce.zero in
           let memo =
             Signed_command_memo.create_from_string_exn
@@ -1536,16 +1525,16 @@ let%test_module "account timing check" =
         let init_min_balance_int = 100_000_000_000_000 in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int balance_int in
+              let balance = Currency.Balance.nanomina balance_int in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
                   { initial_minimum_balance =
-                      Currency.Balance.of_int init_min_balance_int
+                      Currency.Balance.nanomina init_min_balance_int
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10_000
                   ; cliff_amount = Currency.Amount.zero
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 1_000_000_000
+                  ; vesting_increment = Currency.Amount.mina 1
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -1556,8 +1545,8 @@ let%test_module "account timing check" =
         let amount_int = balance_int - fee_int in
         let parties =
           let open Mina_base in
-          let fee = Currency.Fee.of_int fee_int in
-          let amount = Currency.Amount.of_int amount_int in
+          let fee = Currency.Fee.nanomina fee_int in
+          let amount = Currency.Amount.nanomina amount_int in
           let nonce = Account.Nonce.zero in
           let memo =
             Signed_command_memo.create_from_string_exn
@@ -1608,16 +1597,16 @@ let%test_module "account timing check" =
         let init_min_balance_int = 100_000_000_000_000 in
         let ledger_init_state =
           List.map keypairs ~f:(fun keypair ->
-              let balance = Currency.Balance.of_int balance_int in
+              let balance = Currency.Balance.nanomina balance_int in
               let nonce = Mina_numbers.Account_nonce.zero in
               let (timing : Account_timing.t) =
                 Timed
                   { initial_minimum_balance =
-                      Currency.Balance.of_int init_min_balance_int
+                      Currency.Balance.nanomina init_min_balance_int
                   ; cliff_time = Mina_numbers.Global_slot.of_int 10_000
                   ; cliff_amount = Currency.Amount.zero
                   ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                  ; vesting_increment = Currency.Amount.of_int 1_000_000_000
+                  ; vesting_increment = Currency.Amount.mina 1
                   }
               in
               let balance_as_amount = Currency.Balance.to_amount balance in
@@ -1629,8 +1618,8 @@ let%test_module "account timing check" =
         let amount_int = balance_int - fee_int + 1 in
         let parties_command =
           let open Mina_base in
-          let fee = Currency.Fee.of_int fee_int in
-          let amount = Currency.Amount.of_int amount_int in
+          let fee = Currency.Fee.nanomina fee_int in
+          let amount = Currency.Amount.nanomina amount_int in
           let nonce = Account.Nonce.zero in
           let memo =
             Signed_command_memo.create_from_string_exn
@@ -1684,7 +1673,7 @@ let%test_module "account timing check" =
         =
       let ledger_init_state =
         List.map keypairs ~f:(fun keypair ->
-            let balance = Currency.Amount.of_int 100_000_000_000_000 in
+            let balance = Currency.Amount.mina 100_000 in
             let nonce = Mina_numbers.Account_nonce.zero in
             (keypair, balance, nonce, Account_timing.Untimed) )
         |> Array.of_list
@@ -1693,10 +1682,10 @@ let%test_module "account timing check" =
       let zkapp_keypair = Signature_lib.Keypair.create () in
       let (create_timed_account_spec : Transaction_snark.For_tests.Spec.t) =
         { sender = (sender_keypair, Account.Nonce.zero)
-        ; fee = Currency.Fee.of_int 1_000_000
+        ; fee = Currency.Fee.nanomina 1_000_000
         ; fee_payer = None
         ; receivers = []
-        ; amount = Currency.Amount.of_int 50_000_000_000_000
+        ; amount = Currency.Amount.mina 50_000
         ; zkapp_account_keypairs = [ zkapp_keypair ]
         ; memo =
             Signed_command_memo.create_from_string_exn
@@ -1705,12 +1694,11 @@ let%test_module "account timing check" =
         ; snapp_update =
             (let timing =
                Zkapp_basic.Set_or_keep.Set
-                 ( { initial_minimum_balance =
-                       Currency.Balance.of_int 1_000_000_000
+                 ( { initial_minimum_balance = Currency.Balance.mina 1
                    ; cliff_time = Mina_numbers.Global_slot.of_int 10
-                   ; cliff_amount = Currency.Amount.of_int 1_000_000_000
+                   ; cliff_amount = Currency.Amount.mina 1
                    ; vesting_period = Mina_numbers.Global_slot.of_int 10
-                   ; vesting_increment = Currency.Amount.of_int 1_000_000_000
+                   ; vesting_increment = Currency.Amount.mina 1
                    }
                    : Party.Update.Timing_info.value )
              in
@@ -1764,7 +1752,7 @@ let%test_module "account timing check" =
           Backtrace.elide := false ;
           let ledger_init_state =
             List.map keypairs ~f:(fun keypair ->
-                let balance = Currency.Amount.of_int 100_000_000_000_000 in
+                let balance = Currency.Amount.mina 100_000 in
                 let nonce = Mina_numbers.Account_nonce.zero in
                 (keypair, balance, nonce, Account_timing.Untimed) )
             |> Array.of_list
@@ -1773,7 +1761,7 @@ let%test_module "account timing check" =
           let zkapp_keypair = List.nth_exn keypairs 1 in
           let (update_timing_spec : Transaction_snark.For_tests.Spec.t) =
             { sender = (sender_keypair, Account.Nonce.zero)
-            ; fee = Currency.Fee.of_int 1_000_000
+            ; fee = Currency.Fee.nanomina 1_000_000
             ; fee_payer = None
             ; receivers = []
             ; amount = Currency.Amount.zero
@@ -1784,13 +1772,11 @@ let%test_module "account timing check" =
             ; snapp_update =
                 (let timing =
                    Zkapp_basic.Set_or_keep.Set
-                     ( { initial_minimum_balance =
-                           Currency.Balance.of_int 1_000_000_000
+                     ( { initial_minimum_balance = Currency.Balance.mina 1
                        ; cliff_time = Mina_numbers.Global_slot.of_int 10
-                       ; cliff_amount = Currency.Amount.of_int 1_000_000_000
+                       ; cliff_amount = Currency.Amount.mina 1
                        ; vesting_period = Mina_numbers.Global_slot.of_int 10
-                       ; vesting_increment =
-                           Currency.Amount.of_int 1_000_000_000
+                       ; vesting_increment = Currency.Amount.mina 1
                        }
                        : Party.Update.Timing_info.value )
                  in
@@ -1830,19 +1816,18 @@ let%test_module "account timing check" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           let ledger_init_state =
             List.mapi keypairs ~f:(fun i keypair ->
-                let balance = Currency.Amount.of_int 100_000_000_000_000 in
+                let balance = Currency.Amount.mina 100_000 in
                 let nonce = Mina_numbers.Account_nonce.zero in
                 ( keypair
                 , balance
                 , nonce
                 , if i = 1 then
                     Account_timing.Timed
-                      { initial_minimum_balance =
-                          Currency.Balance.of_int 10_000_000_000
+                      { initial_minimum_balance = Currency.Balance.mina 10
                       ; cliff_time = Mina_numbers.Global_slot.of_int 10_000
                       ; cliff_amount = Currency.Amount.zero
                       ; vesting_period = Mina_numbers.Global_slot.of_int 1
-                      ; vesting_increment = Currency.Amount.of_int 100_000
+                      ; vesting_increment = Currency.Amount.nanomina 100_000
                       }
                   else Account_timing.Untimed ) )
             |> Array.of_list
@@ -1851,7 +1836,7 @@ let%test_module "account timing check" =
           let zkapp_keypair = List.nth_exn keypairs 1 in
           let (update_timing_spec : Transaction_snark.For_tests.Spec.t) =
             { sender = (sender_keypair, Account.Nonce.zero)
-            ; fee = Currency.Fee.of_int 1_000_000
+            ; fee = Currency.Fee.nanomina 1_000_000
             ; fee_payer = None
             ; receivers = []
             ; amount = Currency.Amount.zero
@@ -1862,13 +1847,11 @@ let%test_module "account timing check" =
             ; snapp_update =
                 (let timing =
                    Zkapp_basic.Set_or_keep.Set
-                     ( { initial_minimum_balance =
-                           Currency.Balance.of_int 1_000_000_000
+                     ( { initial_minimum_balance = Currency.Balance.mina 1
                        ; cliff_time = Mina_numbers.Global_slot.of_int 10
-                       ; cliff_amount = Currency.Amount.of_int 1_000_000_000
+                       ; cliff_amount = Currency.Amount.mina 1
                        ; vesting_period = Mina_numbers.Global_slot.of_int 10
-                       ; vesting_increment =
-                           Currency.Amount.of_int 1_000_000_000
+                       ; vesting_increment = Currency.Amount.mina 1
                        }
                        : Party.Update.Timing_info.value )
                  in

--- a/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
+++ b/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
@@ -26,8 +26,8 @@ let%test_module "Fee payer tests" =
                    snapp account" =
       Quickcheck.test ~trials:1 U.gen_snapp_ledger
         ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-          let fee = Fee.of_int 1_000_000 in
-          let amount = Amount.of_int 10_000_000_000 in
+          let fee = Fee.nanomina 1_000_000 in
+          let amount = Amount.mina 10 in
           let test_spec : Spec.t =
             { sender = (new_kp, Mina_base.Account.Nonce.zero)
             ; fee
@@ -52,7 +52,7 @@ let%test_module "Fee payer tests" =
                    non-snapp account" =
       Quickcheck.test ~trials:1 U.gen_snapp_ledger
         ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_int 1_000_000 in
+          let fee = Fee.nanomina 1_000_000 in
           let amount = Amount.zero in
           let spec = List.hd_exn specs in
           let test_spec : Spec.t =
@@ -79,8 +79,8 @@ let%test_module "Fee payer tests" =
                    account" =
       Quickcheck.test ~trials:1 U.gen_snapp_ledger
         ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-          let fee = Fee.of_int 1_000_000 in
-          let amount = Amount.of_int 10_000_000_000 in
+          let fee = Fee.nanomina 1_000_000 in
+          let amount = Amount.mina 10 in
           let test_spec : Spec.t =
             { sender = (new_kp, Mina_base.Account.Nonce.zero)
             ; fee
@@ -108,8 +108,8 @@ let%test_module "Fee payer tests" =
                    non-snapp account" =
       Quickcheck.test ~trials:1 U.gen_snapp_ledger
         ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_int 1_000_000 in
-          let amount = Amount.of_int 10_000_000_000 in
+          let fee = Fee.nanomina 1_000_000 in
+          let amount = Amount.mina 10 in
           let spec = List.hd_exn specs in
           let test_spec : Spec.t =
             { sender = spec.sender
@@ -140,8 +140,8 @@ let%test_module "Fee payer tests" =
         ~f:(fun ({ init_ledger; specs }, new_kp) ->
           Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               let spec = List.hd_exn specs in
-              let fee = Fee.of_int 1_000_000 in
-              let amount = Amount.of_int 10_000_000_000 in
+              let fee = Fee.nanomina 1_000_000 in
+              let amount = Amount.mina 10 in
               (*making new_kp the fee-payer for this to fail*)
               let test_spec : Spec.t =
                 { sender = (new_kp, Account.Nonce.zero)

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -292,7 +292,7 @@ let%test_module "multisig_account" =
                    Account_id.create multisig_account_pk Token_id.default
                  in
                  Ledger.get_or_create_account ledger id
-                   (Account.create id Currency.Balance.(of_int 0))
+                   (Account.create id Currency.Balance.zero)
                  |> Or_error.ok_exn
                in
                let a = Ledger.get ledger loc |> Option.value_exn in

--- a/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
+++ b/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
@@ -60,8 +60,8 @@ let%test_module "Protocol state precondition tests" =
       Quickcheck.test ~trials:1 U.gen_snapp_ledger
         ~f:(fun ({ init_ledger; specs }, new_kp) ->
           let state_body = U.genesis_state_body in
-          let fee = Fee.of_int 1_000_000 in
-          let _amount = Amount.of_int 10_000_000_000 in
+          let fee = Fee.nanomina 1_000_000 in
+          let _amount = Amount.mina 10 in
           let spec = List.hd_exn specs in
           let test_spec : Spec.t =
             { sender = spec.sender
@@ -103,8 +103,7 @@ let%test_module "Protocol state precondition tests" =
       in
       Quickcheck.test ~trials:2 gen
         ~f:(fun (({ init_ledger; specs }, new_kp), network_precondition) ->
-          let fee = Fee.of_int 1_000_000 in
-          let _amount = Amount.of_int 10_000_000_000 in
+          let fee = Fee.nanomina 1_000_000 in
           let spec = List.hd_exn specs in
           let test_spec : Spec.t =
             { sender = spec.sender
@@ -146,8 +145,8 @@ let%test_module "Protocol state precondition tests" =
         ~f:(fun (({ init_ledger; specs }, new_kp), network_precondition) ->
           Mina_ledger.Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Async.Thread_safe.block_on_async_exn (fun () ->
-                  let fee = Fee.of_int 1_000_000 in
-                  let amount = Amount.of_int 10_000_000_000 in
+                  let fee = Fee.nanomina 1_000_000 in
+                  let amount = Amount.mina 10 in
                   let spec = List.hd_exn specs in
                   let new_slot =
                     Mina_numbers.Global_slot.succ psv.global_slot_since_genesis
@@ -382,8 +381,7 @@ let%test_module "Account precondition tests" =
           Mina_ledger.Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Async.Thread_safe.block_on_async_exn (fun () ->
                   let state_body = U.genesis_state_body in
-                  let fee = Fee.of_int 1_000_000 in
-                  let _amount = Amount.of_int 10_000_000_000 in
+                  let fee = Fee.nanomina 1_000_000 in
                   let spec = List.hd_exn specs in
                   let snapp_pk =
                     Signature_lib.Public_key.compress new_kp.public_key
@@ -447,8 +445,7 @@ let%test_module "Account precondition tests" =
           Mina_ledger.Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Async.Thread_safe.block_on_async_exn (fun () ->
                   let state_body = U.genesis_state_body in
-                  let fee = Fee.of_int 1_000_000 in
-                  let _amount = Amount.of_int 10_000_000_000 in
+                  let fee = Fee.nanomina 1_000_000 in
                   let spec = List.hd_exn specs in
                   let snapp_pk =
                     Signature_lib.Public_key.compress new_kp.public_key
@@ -508,8 +505,8 @@ let%test_module "Account precondition tests" =
         ~f:(fun (({ init_ledger; specs }, new_kp), account_precondition) ->
           Mina_ledger.Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Async.Thread_safe.block_on_async_exn (fun () ->
-                  let fee = Fee.of_int 1_000_000 in
-                  let _amount = Amount.of_int 10_000_000_000 in
+                  let fee = Fee.nanomina 1_000_000 in
+                  let _amount = Amount.mina 10 in
                   let spec = List.hd_exn specs in
                   let test_spec : Spec.t =
                     { sender = spec.sender
@@ -559,8 +556,8 @@ let%test_module "Account precondition tests" =
       Quickcheck.test ~trials:1 U.gen_snapp_ledger
         ~f:(fun ({ init_ledger; specs }, new_kp) ->
           Mina_ledger.Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
-              let fee = Fee.of_int 1_000_000 in
-              let amount = Amount.of_int 10_000_000_000 in
+              let fee = Fee.nanomina 1_000_000 in
+              let amount = Amount.mina 10 in
               let spec = List.hd_exn specs in
               let sender, sender_nonce = spec.sender in
               let sender_pk =

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -162,7 +162,7 @@ let%test_unit "ring-signature snapp tx with 3 parties" =
            let _is_new, loc =
              let id = Account_id.create ringsig_account_pk Token_id.default in
              Ledger.get_or_create_account ledger id
-               (Account.create id Balance.(of_int 0))
+               (Account.create id Balance.zero)
              |> Or_error.ok_exn
            in
            let a = Ledger.get ledger loc |> Option.value_exn in

--- a/src/lib/transaction_snark/test/test_zkapp_update.ml
+++ b/src/lib/transaction_snark/test/test_zkapp_update.ml
@@ -25,8 +25,8 @@ module Make (Input : Input_intf) = struct
   let%test_unit "update a snapp account with signature" =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
       ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-        let fee = Fee.of_int 1_000_000 in
-        let amount = Amount.of_int 10_000_000_000 in
+        let fee = Fee.nanomina 1_000_000 in
+        let amount = Amount.mina 10 in
         let test_spec : Spec.t =
           { sender = (new_kp, Mina_base.Account.Nonce.zero)
           ; fee
@@ -50,8 +50,8 @@ module Make (Input : Input_intf) = struct
   let%test_unit "update a snapp account with proof" =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
       ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-        let fee = Fee.of_int 1_000_000 in
-        let amount = Amount.of_int 10_000_000_000 in
+        let fee = Fee.nanomina 1_000_000 in
+        let amount = Amount.mina 10 in
         let test_spec : Spec.t =
           { sender = (new_kp, Mina_base.Account.Nonce.zero)
           ; fee
@@ -78,8 +78,8 @@ module Make (Input : Input_intf) = struct
   let%test_unit "update a snapp account with None permission" =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
       ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_int 1_000_000 in
-        let amount = Amount.of_int 10_000_000_000 in
+        let fee = Fee.nanomina 1_000_000 in
+        let amount = Amount.mina 10 in
         let spec = List.hd_exn specs in
         let test_spec : Spec.t =
           { sender = spec.sender
@@ -107,8 +107,8 @@ module Make (Input : Input_intf) = struct
       =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
       ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_int 1_000_000 in
-        let amount = Amount.of_int 10_000_000_000 in
+        let fee = Fee.nanomina 1_000_000 in
+        let amount = Amount.mina 10 in
         let spec = List.hd_exn specs in
         let test_spec : Spec.t =
           { sender = spec.sender
@@ -135,8 +135,8 @@ module Make (Input : Input_intf) = struct
   let%test_unit "update a snapp account with None permission and Proof auth" =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
       ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_int 1_000_000 in
-        let amount = Amount.of_int 10_000_000_000 in
+        let fee = Fee.nanomina 1_000_000 in
+        let amount = Amount.mina 10 in
         let spec = List.hd_exn specs in
         let test_spec : Spec.t =
           { sender = spec.sender
@@ -164,8 +164,8 @@ module Make (Input : Input_intf) = struct
                  auth" =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
       ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_int 1_000_000 in
-        let amount = Amount.of_int 10_000_000_000 in
+        let fee = Fee.nanomina 1_000_000 in
+        let amount = Amount.mina 10 in
         let spec = List.hd_exn specs in
         let test_spec : Spec.t =
           { sender = spec.sender
@@ -193,8 +193,8 @@ module Make (Input : Input_intf) = struct
   let%test_unit "update a snapp account with Either permission and Proof auth" =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
       ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_int 1_000_000 in
-        let amount = Amount.of_int 10_000_000_000 in
+        let fee = Fee.nanomina 1_000_000 in
+        let amount = Amount.mina 10 in
         let spec = List.hd_exn specs in
         let test_spec : Spec.t =
           { sender = spec.sender
@@ -222,8 +222,8 @@ module Make (Input : Input_intf) = struct
   let%test_unit "update a snapp account with Either permission and None auth" =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
       ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_int 1_000_000 in
-        let amount = Amount.of_int 10_000_000_000 in
+        let fee = Fee.nanomina 1_000_000 in
+        let amount = Amount.mina 10_000_000_000 in
         let spec = List.hd_exn specs in
         let test_spec : Spec.t =
           { sender = spec.sender
@@ -254,8 +254,8 @@ module Make (Input : Input_intf) = struct
       ~f:(fun ({ init_ledger; specs }, new_kp) ->
         Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
             let spec = List.hd_exn specs in
-            let fee = Fee.of_int 1_000_000 in
-            let amount = Amount.of_int 10_000_000_000 in
+            let fee = Fee.nanomina 1_000_000 in
+            let amount = Amount.mina 10_000_000_000 in
             let test_spec : Spec.t =
               { sender = spec.sender
               ; fee

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -87,9 +87,7 @@ let%test_module "Transaction union tests" =
       let other_id = Account_id.create other Token_id.default in
       let pending_coinbase_init = Pending_coinbase.Stack.empty in
       let cb =
-        Coinbase.create
-          ~amount:(Currency.Amount.of_int 10_000_000_000)
-          ~receiver
+        Coinbase.create ~amount:(Currency.Amount.mina 10) ~receiver
           ~fee_transfer:
             (Some
                (Coinbase.Fee_transfer.create ~receiver_pk:other
@@ -164,7 +162,7 @@ let%test_module "Transaction union tests" =
               let t1 =
                 U.Wallet.user_command_with_wallet wallets ~sender:1 ~receiver:0
                   8_000_000_000
-                  (Fee.of_int (Random.int 20 * 1_000_000_000))
+                  (Fee.mina @@ Random.int 20)
                   Account.Nonce.zero
                   (Signed_command_memo.create_by_digesting_string_exn
                      (Test_util.arbitrary_string
@@ -210,7 +208,8 @@ let%test_module "Transaction union tests" =
                 { transaction = t1; block_data = state_body }
                 (unstage @@ Sparse_ledger.handler sparse_ledger) ) )
 
-    let account_fee = Fee.to_int constraint_constants.account_creation_fee
+    let account_fee =
+      Fee.int_of_nanomina constraint_constants.account_creation_fee
 
     let%test_unit "account creation fee - user commands" =
       Test_util.with_randomness 123456789 (fun () ->
@@ -237,7 +236,7 @@ let%test_module "Transaction union tests" =
                     let uc =
                       U.Wallet.user_command ~fee_payer:sender
                         ~receiver_pk:(Account.public_key receiver.account)
-                        amount (Fee.of_int txn_fee) nonce memo
+                        amount (Fee.nanomina txn_fee) nonce memo
                     in
                     (Account.Nonce.succ nonce, txns @ [ uc ]) )
               in
@@ -256,7 +255,7 @@ let%test_module "Transaction union tests" =
                     ledger ) ;
               U.check_balance
                 (Account.identifier sender.account)
-                ( Balance.to_int sender.account.balance
+                ( Balance.int_of_nanomina sender.account.balance
                 - (amount + txn_fee) * txns_per_receiver * List.length receivers
                 )
                 ledger ) )
@@ -280,7 +279,7 @@ let%test_module "Transaction union tests" =
                       @@ One_or_two.map receiver ~f:(fun receiver ->
                              Fee_transfer.Single.create
                                ~receiver_pk:receiver.account.public_key
-                               ~fee:(Currency.Fee.of_int fee)
+                               ~fee:(Currency.Fee.nanomina fee)
                                ~fee_token:receiver.account.token_id )
                     in
                     txns @ [ ft ] )
@@ -303,7 +302,9 @@ let%test_module "Transaction union tests" =
           let other = wallets.(1) in
           let dummy_account = wallets.(2) in
           let reward = 10_000_000_000 in
-          let fee = Fee.to_int constraint_constants.account_creation_fee in
+          let fee =
+            Fee.int_of_nanomina constraint_constants.account_creation_fee
+          in
           let coinbase_count = 3 in
           let ft_count = 2 in
           Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
@@ -318,7 +319,7 @@ let%test_module "Transaction union tests" =
                   ~f:(fun (fts, cbs) _ ->
                     let cb =
                       Coinbase.create
-                        ~amount:(Currency.Amount.of_int reward)
+                        ~amount:(Currency.Amount.nanomina reward)
                         ~receiver:receiver.account.public_key
                         ~fee_transfer:(List.hd fts)
                       |> Or_error.ok_exn
@@ -371,13 +372,13 @@ let%test_module "Transaction union tests" =
               let t1 =
                 U.Wallet.user_command_with_wallet wallets ~sender:0 ~receiver:1
                   8_000_000_000
-                  (Fee.of_int (Random.int 20 * 1_000_000_000))
+                  (Fee.mina @@ Random.int 20)
                   Account.Nonce.zero memo
               in
               let t2 =
                 U.Wallet.user_command_with_wallet wallets ~sender:1 ~receiver:2
                   8_000_000_000
-                  (Fee.of_int (Random.int 20 * 1_000_000_000))
+                  (Fee.mina @@ Random.int 20)
                   Account.Nonce.zero memo
               in
               let sok_digest =
@@ -567,7 +568,7 @@ let%test_module "Transaction union tests" =
         ~carryforward1:false ~carryforward2:false
 
     let create_account pk token balance =
-      Account.create (Account_id.create pk token) (Balance.of_int balance)
+      Account.create (Account_id.create pk token) (Balance.nanomina balance)
 
     let test_user_command_with_accounts ~ledger ~accounts ~signer ~fee
         ~fee_payer_pk ~fee_token ?memo ?valid_until ?nonce body =
@@ -833,7 +834,7 @@ let%test_module "Transaction union tests" =
               let accounts =
                 [| create_account fee_payer_pk fee_token 20_000_000_000 |]
               in
-              let fee = Fee.of_int (random_int_incl 2 15 * 1_000_000_000) in
+              let fee = Fee.mina @@ random_int_incl 2 15 in
               let ( `Fee_payer_account fee_payer_account
                   , `Source_account source_account
                   , `Receiver_account receiver_account ) =
@@ -873,7 +874,7 @@ let%test_module "Transaction union tests" =
                  ; create_account receiver_pk token_id 30_000_000_000
                 |]
               in
-              let fee = Fee.of_int (random_int_incl 2 15 * 1_000_000_000) in
+              let fee = Fee.mina @@ random_int_incl 2 15 in
               let ( `Fee_payer_account fee_payer_account
                   , `Source_account source_account
                   , `Receiver_account receiver_account ) =
@@ -907,12 +908,12 @@ let%test_module "Transaction union tests" =
               (Test_util.arbitrary_string
                  ~len:Signed_command_memo.max_digestible_string_length )
           in
-          let balance = Balance.of_int 100_000_000_000_000 in
-          let initial_minimum_balance = Balance.of_int 80_000_000_000_000 in
+          let balance = Balance.mina 100_000 in
+          let initial_minimum_balance = Balance.mina 80_000 in
           let cliff_time = Mina_numbers.Global_slot.of_int 1000 in
-          let cliff_amount = Amount.of_int 10000 in
+          let cliff_amount = Amount.nanomina 10_000 in
           let vesting_period = Mina_numbers.Global_slot.of_int 10 in
-          let vesting_increment = Amount.of_int 1 in
+          let vesting_increment = Amount.nanomina 1 in
           let txn_global_slot = Mina_numbers.Global_slot.of_int 1002 in
           let sender =
             { sender with
@@ -938,7 +939,7 @@ let%test_module "Transaction union tests" =
                   ~f:(fun (nonce, txns) receiver ->
                     let uc =
                       U.Wallet.user_command_with_wallet wallets ~sender:0
-                        ~receiver amount (Fee.of_int txn_fee) nonce memo
+                        ~receiver amount (Fee.nanomina txn_fee) nonce memo
                     in
                     (Account.Nonce.succ nonce, txns @ [ uc ]) )
               in
@@ -957,7 +958,7 @@ let%test_module "Transaction union tests" =
                     ledger ) ;
               U.check_balance
                 (Account.identifier sender.account)
-                ( Balance.to_int sender.account.balance
+                ( Balance.int_of_nanomina sender.account.balance
                 - (amount + txn_fee) * txns_per_receiver * List.length receivers
                 )
                 ledger ) )
@@ -1848,12 +1849,12 @@ let%test_module "Transaction union tests" =
           in
           let timed_account pk =
             let account_id = Account_id.create pk Token_id.default in
-            let balance = Balance.of_int 100_000_000_000_000 in
-            let initial_minimum_balance = Balance.of_int 80_000_000_000 in
+            let balance = Balance.mina 100_000 in
+            let initial_minimum_balance = Balance.mina 80 in
             let cliff_time = Mina_numbers.Global_slot.of_int 2 in
-            let cliff_amount = Amount.of_int 5_000_000_000 in
+            let cliff_amount = Amount.mina 5 in
             let vesting_period = Mina_numbers.Global_slot.of_int 2 in
-            let vesting_increment = Amount.of_int 40_000_000_000 in
+            let vesting_increment = Amount.mina 40 in
             Or_error.ok_exn
             @@ Account.create_timed account_id balance ~initial_minimum_balance
                  ~cliff_time ~cliff_amount ~vesting_period ~vesting_increment
@@ -1864,11 +1865,13 @@ let%test_module "Transaction union tests" =
           let ft1, ft2 =
             let single1 =
               Fee_transfer.Single.create ~receiver_pk:receivers.(0)
-                ~fee:(Currency.Fee.of_int fee) ~fee_token:Token_id.default
+                ~fee:(Currency.Fee.nanomina fee)
+                ~fee_token:Token_id.default
             in
             let single2 =
               Fee_transfer.Single.create ~receiver_pk:receivers.(1)
-                ~fee:(Currency.Fee.of_int fee) ~fee_token:Token_id.default
+                ~fee:(Currency.Fee.nanomina fee)
+                ~fee_token:Token_id.default
             in
             ( Fee_transfer.create single1 (Some single2) |> Or_error.ok_exn
             , Fee_transfer.create single1 None |> Or_error.ok_exn )
@@ -1876,14 +1879,12 @@ let%test_module "Transaction union tests" =
           let coinbase_with_ft, coinbase_wo_ft =
             let ft =
               Coinbase.Fee_transfer.create ~receiver_pk:receivers.(0)
-                ~fee:(Currency.Fee.of_int fee)
+                ~fee:(Currency.Fee.nanomina fee)
             in
-            ( Coinbase.create
-                ~amount:(Currency.Amount.of_int 10_000_000_000)
+            ( Coinbase.create ~amount:(Currency.Amount.mina 10)
                 ~receiver:receivers.(1) ~fee_transfer:(Some ft)
               |> Or_error.ok_exn
-            , Coinbase.create
-                ~amount:(Currency.Amount.of_int 10_000_000_000)
+            , Coinbase.create ~amount:(Currency.Amount.mina 10)
                 ~receiver:receivers.(1) ~fee_transfer:None
               |> Or_error.ok_exn )
           in
@@ -1931,7 +1932,7 @@ let%test_module "legacy transactions using zkApp accounts" =
       let snapp_pk = Signature_lib.Public_key.compress new_kp.public_key in
       Transaction_snark.For_tests.create_trivial_zkapp_account ?permissions ~vk
         ~ledger snapp_pk ;
-      let txn_fee = Fee.of_int 1000000 in
+      let txn_fee = Fee.nanomina 1_000_000 in
       let amount = 100 in
       (*send from a zkApp account*)
       let signed_command1 =
@@ -2082,7 +2083,7 @@ let%test_module "legacy transactions using zkApp accounts" =
       let snapp_pk = Signature_lib.Public_key.compress new_kp.public_key in
       Transaction_snark.For_tests.create_trivial_zkapp_account ?permissions ~vk
         ~ledger snapp_pk ;
-      let txn_fee = Fee.of_int 1000000 in
+      let txn_fee = Fee.nanomina 1_000_000 in
       let sender_kp, sender_nonce = spec.sender in
       (*Delegator is a zkapp account*)
       let stake_delegation1 =
@@ -2203,7 +2204,7 @@ let%test_module "legacy transactions using zkApp accounts" =
       let snapp_pk = Signature_lib.Public_key.compress new_kp.public_key in
       Transaction_snark.For_tests.create_trivial_zkapp_account ?permissions ~vk
         ~ledger snapp_pk ;
-      let fee = Fee.of_int 1000000 in
+      let fee = Fee.nanomina 1_000_000 in
       let amount = U.constraint_constants.coinbase_amount in
       (*send coinbase reward to a zkApp account*)
       let coinbase1 =

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -343,9 +343,7 @@ module Wallet = struct
       in
       let account_id = Account_id.create public_key Token_id.default in
       { private_key
-      ; account =
-          Account.create account_id
-            (Balance.of_int ((50 + Random.int 100) * 1_000_000_000))
+      ; account = Account.create account_id (Balance.mina (50 + Random.int 100))
       }
     in
     Array.init n ~f:(fun _ -> random_wallet ())
@@ -356,7 +354,7 @@ module Wallet = struct
       Signed_command.Payload.create ~fee
         ~fee_payer_pk:(Account.public_key fee_payer.account)
         ~nonce ~memo ~valid_until:None
-        ~body:(Payment { source_pk; receiver_pk; amount = Amount.of_int amt })
+        ~body:(Payment { source_pk; receiver_pk; amount = Amount.nanomina amt })
     in
     let signature = Signed_command.sign_payload fee_payer.private_key payload in
     Signed_command.check
@@ -415,7 +413,7 @@ let pending_coinbase_stack_target (t : Mina_transaction.Transaction.Valid.t)
 let check_balance pk balance ledger =
   let loc = Ledger.location_of_account ledger pk |> Option.value_exn in
   let acc = Ledger.get ledger loc |> Option.value_exn in
-  [%test_eq: Balance.t] acc.balance (Balance.of_int balance)
+  [%test_eq: Balance.t] acc.balance (Balance.nanomina balance)
 
 (** Test legacy transactions*)
 let test_transaction_union ?expected_failure ?txn_global_slot ledger txn =

--- a/src/lib/transaction_snark/test/zkapp_deploy/zkapp_deploy.ml
+++ b/src/lib/transaction_snark/test/zkapp_deploy/zkapp_deploy.ml
@@ -17,8 +17,8 @@ let%test_module "Snapp deploy tests" =
           Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Async.Thread_safe.block_on_async_exn (fun () ->
                   let spec = List.hd_exn specs in
-                  let fee = Currency.Fee.of_int 1_000_000 in
-                  let amount = Currency.Amount.of_int 10_000_000_000 in
+                  let fee = Currency.Fee.nanomina 1_000_000 in
+                  let amount = Currency.Amount.mina 10 in
                   let test_spec : Spec.t =
                     { sender = spec.sender
                     ; fee
@@ -59,8 +59,8 @@ let%test_module "Snapp deploy tests" =
           Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Async.Thread_safe.block_on_async_exn (fun () ->
                   let spec = List.hd_exn specs in
-                  let fee = Currency.Fee.of_int 1_000_000 in
-                  let amount = Currency.Amount.of_int 7_000_000_000 in
+                  let fee = Currency.Fee.nanomina 1_000_000 in
+                  let amount = Currency.Amount.mina 7 in
                   let test_spec : Spec.t =
                     { sender = spec.sender
                     ; fee
@@ -95,8 +95,8 @@ let%test_module "Snapp deploy tests" =
           Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Async.Thread_safe.block_on_async_exn (fun () ->
                   let spec = List.hd_exn specs in
-                  let fee = Currency.Fee.of_int 1_000_000 in
-                  let amount = Currency.Amount.of_int 10_000_000_000 in
+                  let fee = Currency.Fee.nanomina 1_000_000 in
+                  let amount = Currency.Amount.mina 10 in
                   let test_spec : Spec.t =
                     { sender = spec.sender
                     ; fee
@@ -132,8 +132,8 @@ let%test_module "Snapp deploy tests" =
               Async.Thread_safe.block_on_async_exn (fun () ->
                   let spec0 = List.nth_exn specs 0 in
                   let spec1 = List.nth_exn specs 1 in
-                  let fee = Currency.Fee.of_int 1_000_000 in
-                  let amount = Currency.Amount.of_int 10_000_000_000 in
+                  let fee = Currency.Fee.nanomina 1_000_000 in
+                  let amount = Currency.Amount.mina 10 in
                   let test_spec : Spec.t =
                     { sender = spec0.sender
                     ; fee
@@ -168,7 +168,7 @@ let%test_module "Snapp deploy tests" =
           Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Async.Thread_safe.block_on_async_exn (fun () ->
                   let spec = List.hd_exn specs in
-                  let fee = Currency.Fee.of_int 1_000_000 in
+                  let fee = Currency.Fee.nanomina 1_000_000 in
                   (*transfering zero should cause the transaction to fail if the account is not already created*)
                   let amount = Currency.Amount.zero in
                   let test_spec : Spec.t =

--- a/src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.ml
+++ b/src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.ml
@@ -5,7 +5,7 @@ module U = Transaction_snark_tests.Util
 
 let logger = Logger.create ()
 
-let `VK vk, `Prover prover = Lazy.force U.trivial_zkapp
+let `VK vk, `Prover _ = Lazy.force U.trivial_zkapp
 
 let mk_ledgers_and_fee_payers ?(is_timed = false) ~num_of_fee_payers () =
   let fee_payer_keypairs =
@@ -20,17 +20,15 @@ let mk_ledgers_and_fee_payers ?(is_timed = false) ~num_of_fee_payers () =
         Account_id.create fee_payer_pk Token_id.default )
   in
   let (initial_balance : Currency.Balance.t) =
-    Currency.Balance.of_int 1_000_000_000_000_000
+    Currency.Balance.mina 1_000_000
   in
   let (fee_payer_accounts : Account.t array) =
     if is_timed then
-      let initial_minimum_balance =
-        Currency.Balance.of_int 1_000_000_000_000_000
-      in
+      let initial_minimum_balance = Currency.Balance.mina 1_000_000 in
       let cliff_time = Mina_numbers.Global_slot.of_int 1_000 in
       let cliff_amount = Currency.Amount.zero in
       let vesting_period = Mina_numbers.Global_slot.of_int 10 in
-      let vesting_increment = Currency.Amount.of_int 100_000_000_000 in
+      let vesting_increment = Currency.Amount.mina 100 in
       Array.map fee_payer_account_ids ~f:(fun fee_payer_account_id ->
           Account.create_timed fee_payer_account_id initial_balance
             ~initial_minimum_balance ~cliff_time ~cliff_amount ~vesting_period

--- a/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
+++ b/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
@@ -22,9 +22,9 @@ let%test_module "Zkapp payments tests" =
 
     let signed_signed ~(wallets : U.Wallet.t array) i j : Parties.t =
       let full_amount = 8_000_000_000 in
-      let fee = Fee.of_int (Random.int full_amount) in
+      let fee = Fee.nanomina (Random.int full_amount) in
       let receiver_amount =
-        Amount.sub (Amount.of_int full_amount) (Amount.of_fee fee)
+        Amount.sub (Amount.nanomina full_amount) (Amount.of_fee fee)
         |> Option.value_exn
       in
       let acct1 = wallets.(i) in
@@ -36,7 +36,7 @@ let%test_module "Zkapp payments tests" =
         { fee_payer =
             { body =
                 { public_key = acct1.account.public_key
-                ; fee = Fee.of_int full_amount
+                ; fee = Fee.nanomina full_amount
                 ; valid_until = None
                 ; nonce = acct1.account.nonce
                 }
@@ -160,8 +160,8 @@ let%test_module "Zkapp payments tests" =
         ~f:(fun ({ init_ledger; specs }, new_kp) ->
           Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
               Async.Thread_safe.block_on_async_exn (fun () ->
-                  let fee = Fee.of_int 1_000_000 in
-                  let amount = Amount.of_int 1_000_000_000 in
+                  let fee = Fee.nanomina 1_000_000 in
+                  let amount = Amount.mina 1 in
                   let spec = List.hd_exn specs in
                   let receiver_count = 3 in
                   let total_amount =
@@ -213,7 +213,7 @@ let%test_module "Zkapp payments tests" =
                   Init_ledger.init
                     (module Ledger.Ledger_inner)
                     init_ledger ledger ;
-                  let fee = Fee.of_int 1_000_000 in
+                  let fee = Fee.nanomina 1_000_000 in
                   let spec = List.hd_exn specs in
                   let sender_pk =
                     (fst spec.sender).public_key
@@ -233,7 +233,7 @@ let%test_module "Zkapp payments tests" =
                   let amount =
                     Amount.add
                       Balance.(to_amount sender_balance)
-                      Amount.(of_int 1_000_000)
+                      Amount.(nanomina 1_000_000)
                     |> Option.value_exn
                   in
                   let receiver_count = 3 in

--- a/src/lib/transaction_snark/test/zkapp_tokens/zkapp_tokens.ml
+++ b/src/lib/transaction_snark/test/zkapp_tokens/zkapp_tokens.ml
@@ -13,7 +13,7 @@ let%test_module "Zkapp tokens tests" =
     let constraint_constants = U.constraint_constants
 
     let account_creation_fee =
-      Currency.Fee.to_int constraint_constants.account_creation_fee
+      Currency.Fee.int_of_nanomina constraint_constants.account_creation_fee
 
     let keypair_and_amounts = Quickcheck.random_value (Init_ledger.gen ())
 
@@ -58,7 +58,7 @@ let%test_module "Zkapp tokens tests" =
                      (Public_key.compress keypair.public_key)
                      token_id )
                     .balance
-                  (Currency.Balance.of_int balance)
+                  (Currency.Balance.nanomina balance)
               in
               Async.Thread_safe.block_on_async_exn (fun () ->
                   let open Async.Deferred.Let_syntax in

--- a/src/lib/transaction_snark/test/zkapps_examples/add_events/add_events.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/add_events/add_events.ml
@@ -100,7 +100,7 @@ let%test_module "Add events test" =
         { body =
             { Party.Body.Fee_payer.dummy with
               public_key = pk_compressed
-            ; fee = Currency.Fee.(of_int 100)
+            ; fee = Currency.Fee.(nanomina 100)
             }
         ; authorization = Signature.dummy
         }
@@ -154,7 +154,7 @@ let%test_module "Add events test" =
       in
       Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
           let account =
-            Account.create account_id Currency.Balance.(of_int 500)
+            Account.create account_id Currency.Balance.(nanomina 500)
           in
           let _, loc =
             Ledger.get_or_create_account ledger account_id account

--- a/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
@@ -77,7 +77,7 @@ let fee_payer =
   { Party.Fee_payer.body =
       { Party.Body.Fee_payer.dummy with
         public_key = pk_compressed
-      ; fee = Currency.Fee.(of_int 100)
+      ; fee = Currency.Fee.(nanomina 100)
       }
   ; authorization = Signature.dummy
   }
@@ -137,6 +137,6 @@ let () =
         Ledger.get_or_create_account ledger account_id
           (Account.create account_id
              Currency.Balance.(
-               Option.value_exn (add_amount zero (Currency.Amount.of_int 500))) )
+               Option.value_exn (add_amount zero (Currency.Amount.nanomina 500))) )
       in
       ignore (apply_parties ledger [ parties ] : Sparse_ledger.t) )

--- a/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
@@ -109,7 +109,7 @@ let%test_module "Initialize state test" =
         { body =
             { Party.Body.Fee_payer.dummy with
               public_key = pk_compressed
-            ; fee = Currency.Fee.(of_int 100)
+            ; fee = Currency.Fee.(nanomina 100)
             }
         ; authorization = Signature.dummy
         }
@@ -165,7 +165,8 @@ let%test_module "Initialize state test" =
           let account =
             Account.create account_id
               Currency.Balance.(
-                Option.value_exn (add_amount zero (Currency.Amount.of_int 500)))
+                Option.value_exn
+                  (add_amount zero (Currency.Amount.nanomina 500)))
           in
           let _, loc =
             Ledger.get_or_create_account ledger account_id account

--- a/src/lib/transaction_snark/test/zkapps_examples/sequence_events/sequence_events.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/sequence_events/sequence_events.ml
@@ -103,7 +103,7 @@ let%test_module "Sequence events test" =
         { body =
             { Party.Body.Fee_payer.dummy with
               public_key = pk_compressed
-            ; fee = Currency.Fee.(of_int 50)
+            ; fee = Currency.Fee.(nanomina 50)
             ; nonce = Account.Nonce.of_int fee_payer_nonce
             }
         ; authorization = Signature.dummy
@@ -156,7 +156,7 @@ let%test_module "Sequence events test" =
       let parties : Parties.t =
         sign_all { fee_payer; other_parties = parties; memo }
       in
-      let account = Account.create account_id Currency.Balance.(of_int 500) in
+      let account = Account.create account_id Currency.Balance.(nanomina 500) in
       let _, loc =
         Ledger.get_or_create_account ledger account_id account
         |> Or_error.ok_exn

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4735,7 +4735,7 @@ module For_tests = struct
 
   let trivial_zkapp_account ?(permissions = Permissions.user_default) ~vk pk =
     let id = Account_id.create pk Token_id.default in
-    { (Account.create id Balance.(of_int 1_000_000_000_000_000)) with
+    { (Account.create id Balance.(mina 1_000_000)) with
       permissions
     ; zkapp = Some { Zkapp_account.default with verification_key = Some vk }
     }
@@ -4779,7 +4779,7 @@ module For_tests = struct
         |> fun pk -> Account_id.create pk Token_id.default
       in
       Ledger.get_or_create_account ledger id
-        (Account.create id Balance.(of_int 888_888))
+        (Account.create id Balance.(nanomina 888_888))
       |> Or_error.ok_exn
     in
     let () =

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -277,7 +277,7 @@ module For_tests = struct
           (Option.value_exn (Mina_ledger.Ledger.get ledger account_location))
             .nonce
         in
-        let send_amount = Currency.Amount.of_int 1000000001 in
+        let send_amount = Currency.Amount.nanomina 1_000_000_001 in
         let sender_account_amount =
           sender_account.Account.Poly.balance |> Currency.Balance.to_amount
         in
@@ -324,7 +324,7 @@ module For_tests = struct
         let prover = Public_key.compress public_key in
         Some
           Transaction_snark_work.Checked.
-            { fee = Fee.of_int 1
+            { fee = Fee.nanomina 1
             ; proofs =
                 One_or_two.map stmts ~f:(fun statement ->
                     Ledger_proof.create ~statement

--- a/src/lib/work_selector/test.ml
+++ b/src/lib/work_selector/test.ml
@@ -99,7 +99,7 @@ struct
 
   let%test_unit "selector shouldn't get work that it cannot outbid" =
     Backtrace.elide := false ;
-    let my_fee = Currency.Fee.of_int 2 in
+    let my_fee = Currency.Fee.nanomina 2 in
     let p = 50 in
     let logger = Logger.null () in
     let g =
@@ -112,7 +112,7 @@ struct
                   (Lazy.force precomputed_values).protocol_state_with_hashes
                     .data )
           |> Or_error.ok_exn )
-          (Currency.Fee.of_int 2)
+          (Currency.Fee.nanomina 2)
       in
       (sl, pool)
     in


### PR DESCRIPTION
This is a small improvement to Currency API. In `Currency` submodules (`Currency.Balance`, `Currency.Amount`, `Currency.Fee`) functions `of_int` and `to_int` are repleced by more intuitive `nanomina`, `centimina`, `mina`, `int_of_nanomina`, `int_of_centimina`, `int_of_mina`. This way there is no cofusion about the unit of currency we're converting to (or from). This also provides a way to easily round the amounts upon conversion. Finally thanks to these conversion functions we can use much smaller numbers in tests, which makes it easier to read and understand those tests.

Explain how you tested your changes:
* Just made sure the project still does compile and passes the CI. Removing old-style functions from the signature forced the propagation of the change to other parts of the system.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
