### PR TITLE
Add a mina_version.runtime library to make the Nix build less hacky

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -256,10 +256,13 @@
         };
 
         inherit ocamlPackages;
-        packages.mina = ocamlPackages.mina;
-        packages.mina_tests = ocamlPackages.mina_tests;
-        packages.mina_ocaml_format = ocamlPackages.mina_ocaml_format;
-        packages.mina_client_sdk_binding = ocamlPackages.mina_client_sdk;
+
+        packages = {
+          inherit (ocamlPackages)
+            mina mina_tests mina-ocaml-format mina_client_sdk test_executive;
+          inherit (pkgs) libp2p_helper marlin_plonk_bindings_stubs;
+        };
+
         packages.mina-docker = pkgs.dockerTools.buildImage {
           name = "mina";
           copyToRoot = pkgs.buildEnv {
@@ -292,11 +295,6 @@
           };
         };
 
-        packages.marlin_plonk_bindings_stubs = pkgs.marlin_plonk_bindings_stubs;
-        packages.go-capnproto2 = pkgs.go-capnproto2;
-        packages.libp2p_helper = pkgs.libp2p_helper;
-        packages.mina_integration_tests = ocamlPackages.mina_integration_tests;
-
         legacyPackages.musl = pkgs.pkgsMusl;
         legacyPackages.regular = pkgs;
 
@@ -312,6 +310,7 @@
         devShells.default = self.devShell.${system};
 
         devShells.with-lsp = ocamlPackages.mina-dev.overrideAttrs (oa: {
+          name = "mina-with-lsp";
           nativeBuildInputs = oa.nativeBuildInputs
             ++ [ ocamlPackages.ocaml-lsp-server ];
           shellHook = ''

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -9,7 +9,7 @@ let
 
   inherit (pkgs.lib)
     hasPrefix last getAttrs filterAttrs optionalAttrs makeBinPath
-    optionalString;
+    optionalString escapeShellArg;
 
   external-repo =
     opam-nix.makeOpamRepoRec ../src/external; # Pin external packages
@@ -79,6 +79,27 @@ let
       lld_wrapped = pkgs.writeShellScriptBin "ld.lld"
         ''${pkgs.llvmPackages.bintools}/bin/ld.lld "$@"'';
 
+      wrapMina = let
+        commit_sha1 = inputs.self.sourceInfo.rev or "<dirty>";
+        commit_date = inputs.self.sourceInfo.lastModifiedDate or "<unknown>";
+      in package:
+      { deps ? [ pkgs.gnutar pkgs.gzip ], }:
+      pkgs.runCommand "${package.name}-release" {
+        buildInputs = [ pkgs.makeWrapper pkgs.xorg.lndir ];
+        outputs = package.outputs;
+      } (map (output: ''
+        mkdir -p ${placeholder output}
+        lndir -silent ${package.${output}} ${placeholder output}
+        for i in $(find -L "${placeholder output}/bin" -type f); do
+          wrapProgram "$i" \
+            --prefix PATH : ${makeBinPath deps} \
+            --set MINA_LIBP2P_HELPER_PATH ${pkgs.libp2p_helper}/bin/libp2p_helper \
+            --set MINA_COMMIT_SHA1 ${escapeShellArg commit_sha1} \
+            --set MINA_COMMIT_DATE ${escapeShellArg commit_date} \
+            --set MINA_BRANCH "''${MINA_BRANCH-<unknown due to nix build>}"
+        done
+      '') package.outputs);
+
       runMinaCheck = { name ? "check", extraInputs ? [ ], extraArgs ? { } }:
         check:
         self.mina-dev.overrideAttrs (oa:
@@ -91,9 +112,8 @@ let
           } // extraArgs);
     in {
       # https://github.com/Drup/ocaml-lmdb/issues/41
-      lmdb = super.lmdb.overrideAttrs (oa: {
-        buildInputs = oa.buildInputs ++ [ self.conf-pkg-config ];
-      });
+      lmdb = super.lmdb.overrideAttrs
+        (oa: { buildInputs = oa.buildInputs ++ [ self.conf-pkg-config ]; });
 
       sodium = super.sodium.overrideAttrs (_: {
         NIX_CFLAGS_COMPILE = "-I${pkgs.sodium-static.dev}/include";
@@ -114,11 +134,8 @@ let
 
         # TODO, get this from somewhere
         MARLIN_REPO_SHA = "<unknown>";
-        #MINA_COMMIT_DATE =
-        #  if sourceInfo ? rev then sourceInfo.lastModifiedDate else "<unknown>";
-        #MINA_COMMIT_SHA1 = sourceInfo.rev or "DIRTY";
-        MINA_COMMIT_DATE = "__commit_date_";
-        MINA_COMMIT_SHA1 = "__commit_sha1___________________________";
+        MINA_COMMIT_SHA1 = "<unknown>";
+        MINA_COMMIT_DATE = "<unknown>";
         MINA_BRANCH = "<unknown>";
 
         NIX_LDFLAGS =
@@ -133,6 +150,7 @@ let
           lld_wrapped
           pkgs.capnproto
           pkgs.removeReferencesTo
+          pkgs.fd
         ] ++ ocaml-libs;
 
         # todo: slimmed rocksdb
@@ -141,9 +159,16 @@ let
 
         MARLIN_PLONK_STUBS = "${pkgs.marlin_plonk_bindings_stubs}/lib";
         DISABLE_CHECK_OPAM_SWITCH = "true";
+
+        MINA_VERSION_IMPLEMENTATION = "mina_version.runtime";
+
         configurePhase = ''
           export MINA_ROOT="$PWD"
-          patchShebangs .
+          export -f patchShebangs stopNest isScript
+          fd . --type executable -x bash -c "patchShebangs {}"
+          export -n patchShebangs stopNest isScript
+          # Get the mina version at runtime, from the wrapper script. Used to prevent rebuilding everything every time commit info changes.
+          sed -i "s/default_implementation [^)]*/default_implementation $MINA_VERSION_IMPLEMENTATION/" src/lib/mina_version/dune
         '';
 
         buildPhase = ''
@@ -168,19 +193,21 @@ let
 
         installPhase = ''
           mkdir -p $out/bin $sample/share/mina $out/share/doc $generate_keypair/bin $mainnet/bin $testnet/bin $genesis/bin $genesis/var/lib/coda $batch_txn_tool/bin
-          mv _build/default/src/app/cli/src/mina.exe $out/bin/mina
-          mv _build/default/src/app/logproc/logproc.exe $out/bin/logproc
-          mv _build/default/src/app/rosetta/rosetta.exe $out/bin/rosetta
-          mv _build/default/src/app/batch_txn_tool/batch_txn_tool.exe $batch_txn_tool/bin/batch_txn_tool
-          mv _build/default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe $genesis/bin/runtime_genesis_ledger
-          mv _build/default/src/app/cli/src/mina_mainnet_signatures.exe $mainnet/bin/mina_mainnet_signatures
-          mv _build/default/src/app/rosetta/rosetta_mainnet_signatures.exe $mainnet/bin/rosetta_mainnet_signatures
-          mv _build/default/src/app/cli/src/mina_testnet_signatures.exe $testnet/bin/mina_testnet_signatures
-          mv _build/default/src/app/rosetta/rosetta_testnet_signatures.exe $testnet/bin/rosetta_testnet_signatures
           mv _build/coda_cache_dir/genesis* $genesis/var/lib/coda
-          mv _build/default/src/lib/mina_base/sample_keypairs.json $sample/share/mina
-          mv _build/default/src/app/generate_keypair/generate_keypair.exe $generate_keypair/bin/generate_keypair
-          mv _build/default/_doc/_html $out/share/doc/html
+          pushd _build/default
+          cp src/app/cli/src/mina.exe $out/bin/mina
+          cp src/app/logproc/logproc.exe $out/bin/logproc
+          cp src/app/rosetta/rosetta.exe $out/bin/rosetta
+          cp src/app/batch_txn_tool/batch_txn_tool.exe $batch_txn_tool/bin/batch_txn_tool
+          cp src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe $genesis/bin/runtime_genesis_ledger
+          cp src/app/cli/src/mina_mainnet_signatures.exe $mainnet/bin/mina_mainnet_signatures
+          cp src/app/rosetta/rosetta_mainnet_signatures.exe $mainnet/bin/rosetta_mainnet_signatures
+          cp src/app/cli/src/mina_testnet_signatures.exe $testnet/bin/mina_testnet_signatures
+          cp src/app/rosetta/rosetta_testnet_signatures.exe $testnet/bin/rosetta_testnet_signatures
+          cp src/app/generate_keypair/generate_keypair.exe $generate_keypair/bin/generate_keypair
+          cp -R _doc/_html $out/share/doc/html
+          # cp src/lib/mina_base/sample_keypairs.json $sample/share/mina
+          popd
           remove-references-to -t $(dirname $(dirname $(command -v ocaml))) {$out/bin/*,$mainnet/bin/*,$testnet/bin*,$genesis/bin/*,$generate_keypair/bin/*}
         '';
         shellHook =
@@ -189,25 +216,7 @@ let
         OCAMLPARAM = "_,cclib=-lc++";
       });
 
-      mina = let
-        commit_sha1 =
-          inputs.self.sourceInfo.rev or "<unknown>                               ";
-        commit_date =
-          inputs.self.sourceInfo.lastModifiedDate or "<unknown>     ";
-      in pkgs.runCommand "mina-release" {
-        buildInputs = [ pkgs.makeWrapper ];
-        outputs = self.mina-dev.outputs;
-      } (map (output: ''
-        cp -R ${self.mina-dev.${output}} ${placeholder output}
-        chmod 700 ${placeholder output} -R
-        for i in $(find "${placeholder output}/bin" -type f); do
-          sed 's/__commit_sha1___________________________/${commit_sha1}/' -i "$i"
-          sed 's/__commit_date_/${commit_date}/' -i "$i"
-          wrapProgram "$i" \
-            --prefix PATH : ${makeBinPath [ pkgs.gnutar pkgs.gzip ]} \
-            --set MINA_LIBP2P_HELPER_PATH ${pkgs.libp2p_helper}/bin/libp2p_helper
-        done
-      '') self.mina-dev.outputs);
+      mina = wrapMina self.mina-dev { };
 
       mina_tests = runMinaCheck {
         name = "tests";
@@ -224,7 +233,7 @@ let
         dune runtest src/app/archive src/lib/command_line_tests --display=short
       '';
 
-      mina_ocaml_format = runMinaCheck { name = "ocaml-format"; } ''
+      mina-ocaml-format = runMinaCheck { name = "ocaml-format"; } ''
         dune exec --profile=dev src/app/reformat/reformat.exe -- -path . -check
       '';
 
@@ -236,6 +245,8 @@ let
         outputs = [ "out" ];
 
         checkInputs = [ pkgs.nodejs ];
+
+        MINA_VERSION_IMPLEMENTATION = "mina_version.dummy";
 
         buildPhase = ''
           export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$opam__zarith__lib/zarith"
@@ -288,8 +299,8 @@ let
         '';
       };
 
-      mina_integration_tests = self.mina-dev.overrideAttrs (oa: {
-        pname = "mina_integration_tests";
+      test_executive-dev = self.mina-dev.overrideAttrs (oa: {
+        pname = "mina-test_executive";
         src = filtered-src;
         outputs = [ "out" ];
 
@@ -302,5 +313,7 @@ let
           mv _build/default/src/app/logproc/logproc.exe $out/bin/logproc
         '';
       });
+
+      test_executive = wrapMina self.test_executive-dev { };
     };
 in scope.overrideScope' overlay

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -85,7 +85,7 @@ let
       in package:
       { deps ? [ pkgs.gnutar pkgs.gzip ], }:
       pkgs.runCommand "${package.name}-release" {
-        buildInputs = [ pkgs.makeWrapper pkgs.xorg.lndir ];
+        buildInputs = [ pkgs.makeBinaryWrapper pkgs.xorg.lndir ];
         outputs = package.outputs;
       } (map (output: ''
         mkdir -p ${placeholder output}

--- a/src/lib/mina_version/normal/gen.sh
+++ b/src/lib/mina_version/normal/gen.sh
@@ -30,5 +30,5 @@ popd > /dev/null
     printf 'let marlin_commit_id_short = "%s"\n' "$marlin_commit_id_short"
     printf 'let marlin_commit_date = "%s"\n' "$marlin_commit_date"
 
-    printf 'let print_version () = Core_kernel.printf "Commit %%s on branch %%s\\n" commit_id branch\n'
+    printf 'let print_version () = Core_kernel.printf "Commit %%s on branch %%s\\n%%!" commit_id branch\n'
 } > "$1"

--- a/src/lib/mina_version/runtime/dune
+++ b/src/lib/mina_version/runtime/dune
@@ -1,0 +1,7 @@
+(library
+ (name mina_version_runtime)
+ (libraries core_kernel base unix)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version))
+ (public_name mina_version.runtime)
+ (implements mina_version))

--- a/src/lib/mina_version/runtime/mina_version.ml
+++ b/src/lib/mina_version/runtime/mina_version.ml
@@ -1,10 +1,10 @@
-let commit_id = "[UNKNOWN]"
+let commit_id = Unix.getenv "MINA_COMMIT_SHA1"
 
-let commit_id_short = "[UNKNOWN]"
+let commit_id_short = String.sub commit_id 0 7
 
-let branch = "[UNKNOWN]"
+let branch = Unix.getenv "MINA_BRANCH"
 
-let commit_date = "1970-01-01T00:00:00+00:00"
+let commit_date = Unix.getenv "MINA_COMMIT_DATE"
 
 let marlin_commit_id = "[UNKNOWN]"
 


### PR DESCRIPTION
Nix store paths are input-addressed, meaning the build result will only be
reused from the existing cache if the inputs match exactly. The commit ID and
date used to be inputs to the build (as read by `mina_version.normal` during
build-time). This meant that on each commit, all the ocaml components of Mina
had to be rebuilt, regardless of the commits actually touching `src/`. This was
circumvented by a semi-hack that provided "fake" commit information, and then
that was substituted in the resulting executable in a separate derivation. That
derivation had to be rebuilt every time, but was a lot faster than rebuilding a
lot of ocaml. However, this is still somewhat slow and hacky.

Instead, introduce a `mina_version.runtime` implementation of `mina_version`,
that reads some environment variables at runtime to determine which version
information to display. Then, those variables are set in the wrapper.