### PR TITLE
Parties limit based on a cost function

### DIFF
--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -325,8 +325,10 @@ module T = struct
     ; txpool_max_size : int
     ; num_accounts : int option
     ; transaction_expiry_hr : int
-    ; max_proof_zkapp_command : int
-    ; max_zkapp_command : int
+    ; zkapp_proof_update_cost : float
+    ; zkapp_signed_single_update_cost : float
+    ; zkapp_signed_pair_update_cost : float
+    ; zkapp_transaction_cost_limit : float
     ; max_event_elements : int
     ; max_sequence_event_elements : int
     }
@@ -381,8 +383,13 @@ let compiled : t =
   ; txpool_max_size = pool_max_size
   ; num_accounts = None
   ; transaction_expiry_hr = Mina_compile_config.transaction_expiry_hr
-  ; max_proof_zkapp_command = Mina_compile_config.max_proof_zkapp_command
-  ; max_zkapp_command = Mina_compile_config.max_zkapp_command
+  ; zkapp_proof_update_cost = Mina_compile_config.zkapp_proof_update_cost
+  ; zkapp_signed_single_update_cost =
+      Mina_compile_config.zkapp_signed_single_update_cost
+  ; zkapp_signed_pair_update_cost =
+      Mina_compile_config.zkapp_signed_pair_update_cost
+  ; zkapp_transaction_cost_limit =
+      Mina_compile_config.zkapp_transaction_cost_limit
   ; max_event_elements = Mina_compile_config.max_event_elements
   ; max_sequence_event_elements =
       Mina_compile_config.max_sequence_event_elements

--- a/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
+++ b/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
@@ -630,7 +630,7 @@ let runtime_config_of_precomputed_values (precomputed_values : Genesis_proof.t)
                   .zkapp_signed_single_update_cost
           ; zkapp_signed_pair_update_cost =
               Some
-                precomputed_values.genesis_constant
+                precomputed_values.genesis_constants
                   .zkapp_signed_pair_update_cost
           ; zkapp_transaction_cost_limit =
               Some

--- a/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
+++ b/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
@@ -576,12 +576,18 @@ let make_genesis_constants ~logger ~(default : Genesis_constants.t)
   ; transaction_expiry_hr =
       Option.value ~default:default.transaction_expiry_hr
         (config.daemon >>= fun cfg -> cfg.transaction_expiry_hr)
-  ; max_proof_zkapp_command =
-      Option.value ~default:default.max_proof_zkapp_command
-        (config.daemon >>= fun cfg -> cfg.max_proof_zkapp_command)
-  ; max_zkapp_command =
-      Option.value ~default:default.max_zkapp_command
-        (config.daemon >>= fun cfg -> cfg.max_zkapp_command)
+  ; zkapp_proof_update_cost =
+      Option.value ~default:default.zkapp_proof_update_cost
+        (config.daemon >>= fun cfg -> cfg.zkapp_proof_update_cost)
+  ; zkapp_signed_single_update_cost =
+      Option.value ~default:default.zkapp_signed_single_update_cost
+        (config.daemon >>= fun cfg -> cfg.zkapp_signed_single_update_cost)
+  ; zkapp_signed_pair_update_cost =
+      Option.value ~default:default.zkapp_signed_pair_update_cost
+        (config.daemon >>= fun cfg -> cfg.zkapp_signed_pair_update_cost)
+  ; zkapp_transaction_cost_limit =
+      Option.value ~default:default.zkapp_transaction_cost_limit
+        (config.daemon >>= fun cfg -> cfg.zkapp_transaction_cost_limit)
   ; max_event_elements =
       Option.value ~default:default.max_event_elements
         (config.daemon >>= fun cfg -> cfg.max_event_elements)
@@ -616,10 +622,20 @@ let runtime_config_of_precomputed_values (precomputed_values : Genesis_proof.t)
           ; peer_list_url = None
           ; transaction_expiry_hr =
               Some precomputed_values.genesis_constants.transaction_expiry_hr
-          ; max_proof_zkapp_command =
-              Some precomputed_values.genesis_constants.max_proof_zkapp_command
-          ; max_zkapp_command =
-              Some precomputed_values.genesis_constants.max_zkapp_command
+          ; zkapp_proof_update_cost =
+              Some precomputed_values.genesis_constants.zkapp_proof_update_cost
+          ; zkapp_signed_single_update_cost =
+              Some
+                precomputed_values.genesis_constants
+                  .zkapp_signed_single_update_cost
+          ; zkapp_signed_pair_update_cost =
+              Some
+                precomputed_values.genesis_constant
+                  .zkapp_signed_pair_update_cost
+          ; zkapp_transaction_cost_limit =
+              Some
+                precomputed_values.genesis_constants
+                  .zkapp_transaction_cost_limit
           ; max_event_elements =
               Some precomputed_values.genesis_constants.max_event_elements
           ; max_sequence_event_elements =

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -219,8 +219,10 @@ module Network_config = struct
             { txpool_max_size = Some txpool_max_size
             ; peer_list_url = None
             ; transaction_expiry_hr = None
-            ; max_proof_zkapp_command = None
-            ; max_zkapp_command = None
+            ; zkapp_proof_update_cost = None
+            ; zkapp_signed_single_update_cost = None
+            ; zkapp_signed_pair_update_cost = None
+            ; zkapp_transaction_cost_limit = None
             ; max_event_elements = None
             ; max_sequence_event_elements = None
             }

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1949,7 +1949,8 @@ let valid_size ~(genesis_constants : Genesis_constants.t) (t : t) :
   in
   let groups =
     Update_group.group_by_zkapp_command_rev ([] :: [ all_updates ])
-      ([ ((), ()) ] :: [ List.map all_updates ~f:(fun _ -> ((), ())) ])
+      ( [ ((), ()) ]
+      :: [ ((), ()) :: List.map all_updates ~f:(fun _ -> ((), ())) ] )
   in
   let proof_segments, signed_singles, signed_pairs =
     List.fold ~init:(0, 0, 0) groups

--- a/src/lib/mina_compile_config/mina_compile_config.ml
+++ b/src/lib/mina_compile_config/mina_compile_config.ml
@@ -53,9 +53,13 @@ let transaction_expiry_hr = 2
 
 (* limits on Zkapp_command.t size *)
 
-let max_proof_zkapp_command = 4
+let zkapp_proof_update_cost = 10.26
 
-let max_zkapp_command = 8
+let zkapp_signed_single_update_cost = 10.08
+
+let zkapp_signed_pair_update_cost = 9.14
+
+let zkapp_transaction_cost_limit = 69.45
 
 let max_event_elements = 16
 

--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -328,8 +328,10 @@ module Json_layout = struct
       { txpool_max_size : int option [@default None]
       ; peer_list_url : string option [@default None]
       ; transaction_expiry_hr : int option [@default None]
-      ; max_proof_zkapp_command : int option [@default None]
-      ; max_zkapp_command : int option [@default None]
+      ; zkapp_proof_update_cost : float option [@default None]
+      ; zkapp_signed_single_update_cost : float option [@default None]
+      ; zkapp_signed_pair_update_cost : float option [@default None]
+      ; zkapp_transaction_cost_limit : float option [@default None]
       ; max_event_elements : int option [@default None]
       ; max_sequence_event_elements : int option [@default None]
       }
@@ -785,8 +787,10 @@ module Daemon = struct
     { txpool_max_size : int option
     ; peer_list_url : string option
     ; transaction_expiry_hr : int option
-    ; max_proof_zkapp_command : int option [@default None]
-    ; max_zkapp_command : int option [@default None]
+    ; zkapp_proof_update_cost : float option [@default None]
+    ; zkapp_signed_single_update_cost : float option [@default None]
+    ; zkapp_signed_pair_update_cost : float option [@default None]
+    ; zkapp_transaction_cost_limit : float option [@default None]
     ; max_event_elements : int option [@default None]
     ; max_sequence_event_elements : int option [@default None]
     }
@@ -809,11 +813,18 @@ module Daemon = struct
     ; transaction_expiry_hr =
         opt_fallthrough ~default:t1.transaction_expiry_hr
           t2.transaction_expiry_hr
-    ; max_proof_zkapp_command =
-        opt_fallthrough ~default:t1.max_proof_zkapp_command
-          t2.max_proof_zkapp_command
-    ; max_zkapp_command =
-        opt_fallthrough ~default:t1.max_zkapp_command t2.max_zkapp_command
+    ; zkapp_proof_update_cost =
+        opt_fallthrough ~default:t1.zkapp_proof_update_cost
+          t2.zkapp_proof_update_cost
+    ; zkapp_signed_single_update_cost =
+        opt_fallthrough ~default:t1.zkapp_signed_single_update_cost
+          t2.zkapp_signed_single_update_cost
+    ; zkapp_signed_pair_update_cost =
+        opt_fallthrough ~default:t1.zkapp_signed_pair_update_cost
+          t2.zkapp_signed_pair_update_cost
+    ; zkapp_transaction_cost_limit =
+        opt_fallthrough ~default:t1.zkapp_transaction_cost_limit
+          t2.zkapp_transaction_cost_limit
     ; max_event_elements =
         opt_fallthrough ~default:t1.max_event_elements t2.max_event_elements
     ; max_sequence_event_elements =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3569,302 +3569,25 @@ let constraint_system_digests ~constraint_constants () =
             (main ~constraint_constants)) )
   ]
 
-type local_state =
-  ( Stack_frame.value
-  , Stack_frame.value list
-  , Token_id.t
-  , Currency.Amount.Signed.t
-  , Sparse_ledger.t
-  , bool
-  , Zkapp_command.Transaction_commitment.t
-  , Mina_numbers.Index.t
-  , Transaction_status.Failure.Collection.t )
-  Mina_transaction_logic.Zkapp_command_logic.Local_state.t
+module Account_update_group = Zkapp_command.Make_update_group (struct
+  type local_state =
+    ( Stack_frame.value
+    , Stack_frame.value list
+    , Token_id.t
+    , Currency.Amount.Signed.t
+    , Sparse_ledger.t
+    , bool
+    , Zkapp_command.Transaction_commitment.t
+    , Mina_numbers.Index.t
+    , Transaction_status.Failure.Collection.t )
+    Mina_transaction_logic.Zkapp_command_logic.Local_state.t
 
-type global_state = Sparse_ledger.Global_state.t
+  type global_state = Sparse_ledger.Global_state.t
 
-module Zkapp_command_intermediate_state = struct
-  type state = { global : global_state; local : local_state }
+  type spec = Zkapp_command_segment.Basic.t
 
-  type t =
-    { kind : [ `Same | `New | `Two_new ]
-    ; spec : Zkapp_command_segment.Basic.t
-    ; state_before : state
-    ; state_after : state
-    }
-end
-
-(** [group_by_zkapp_command_rev zkapp_commands stmtss] identifies before/after pairs of
-    statements, corresponding to zkapp_command in [zkapp_commands] which minimize the
-    number of snark proofs needed to prove all of the zkapp_command.
-
-    This function is intended to take the zkapp_command from multiple transactions as
-    its input, which may be converted from a [Zkapp_command.t list] using
-    [List.map ~f:Zkapp_command.zkapp_command]. The [stmtss] argument should be a list of
-    the same length, with 1 more state than the number of zkapp_command for each
-    transaction.
-
-    For example, two transactions made up of zkapp_command [[p1; p2; p3]] and
-    [[p4; p5]] should have the statements [[[s0; s1; s2; s3]; [s3; s4; s5]]],
-    where each [s_n] is the state after applying [p_n] on top of [s_{n-1}], and
-    where [s0] is the initial state before any of the transactions have been
-    applied.
-
-    Each pair is also identified with one of [`Same], [`New], or [`Two_new],
-    indicating that the next one ([`New]) or next two ([`Two_new]) [Zkapp_command.t]s
-    will need to be passed as part of the snark witness while applying that
-    pair.
-*)
-let group_by_zkapp_command_rev (zkapp_commands : Account_update.t list list)
-    (stmtss : (global_state * local_state) list list) :
-    Zkapp_command_intermediate_state.t list =
-  let intermediate_state ~kind ~spec ~before ~after =
-    { Zkapp_command_intermediate_state.kind
-    ; spec
-    ; state_before = { global = fst before; local = snd before }
-    ; state_after = { global = fst after; local = snd after }
-    }
-  in
-  let rec group_by_zkapp_command_rev
-      (zkapp_commands : Account_update.t list list) stmtss acc =
-    match (zkapp_commands, stmtss) with
-    | ([] | [ [] ]), [ _ ] ->
-        (* We've associated statements with all given zkapp_command. *)
-        acc
-    | [ [ { authorization = a1; _ } ] ], [ [ before; after ] ] ->
-        (* There are no later zkapp_command to pair this one with. Prove it on its
-           own.
-        *)
-        intermediate_state ~kind:`Same
-          ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-          ~before ~after
-        :: acc
-    | [ []; [ { authorization = a1; _ } ] ], [ [ _ ]; [ before; after ] ] ->
-        (* This account_update is part of a new transaction, and there are no later
-           zkapp_command to pair it with. Prove it on its own.
-        *)
-        intermediate_state ~kind:`New
-          ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-          ~before ~after
-        :: acc
-    | ( ({ authorization = Proof _ as a1; _ } :: zkapp_command) :: zkapp_commands
-      , (before :: (after :: _ as stmts)) :: stmtss ) ->
-        (* This account_update contains a proof, don't pair it with other zkapp_command. *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`Same
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-              ~before ~after
-          :: acc )
-    | ( []
-        :: ({ authorization = Proof _ as a1; _ } :: zkapp_command)
-           :: zkapp_commands
-      , [ _ ] :: (before :: (after :: _ as stmts)) :: stmtss ) ->
-        (* This account_update is part of a new transaction, and contains a proof, don't
-           pair it with other zkapp_command.
-        *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`New
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-              ~before ~after
-          :: acc )
-    | ( ({ authorization = a1; _ }
-        :: ({ authorization = Proof _; _ } :: _ as zkapp_command) )
-        :: zkapp_commands
-      , (before :: (after :: _ as stmts)) :: stmtss ) ->
-        (* The next account_update contains a proof, don't pair it with this account_update. *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`Same
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-              ~before ~after
-          :: acc )
-    | ( ({ authorization = a1; _ } :: ([] as zkapp_command))
-        :: (({ authorization = Proof _; _ } :: _) :: _ as zkapp_commands)
-      , (before :: (after :: _ as stmts)) :: stmtss ) ->
-        (* The next account_update is in the next transaction and contains a proof,
-           don't pair it with this account_update.
-        *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`Same
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-              ~before ~after
-          :: acc )
-    | ( ({ authorization = (Signature _ | None_given) as a1; _ }
-        :: { authorization = (Signature _ | None_given) as a2; _ }
-           :: zkapp_command )
-        :: zkapp_commands
-      , (before :: _ :: (after :: _ as stmts)) :: stmtss ) ->
-        (* The next two zkapp_command do not contain proofs, and are within the same
-           transaction. Pair them.
-           Ok to get "use_full_commitment" of [a1] because neither of them
-           contain a proof.
-        *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`Same
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1; a2 ])
-              ~before ~after
-          :: acc )
-    | ( []
-        :: ({ authorization = a1; _ }
-           :: ({ authorization = Proof _; _ } :: _ as zkapp_command) )
-           :: zkapp_commands
-      , [ _ ] :: (before :: (after :: _ as stmts)) :: stmtss ) ->
-        (* This account_update is in the next transaction, and the next account_update contains a
-           proof, don't pair it with this account_update.
-        *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`New
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-              ~before ~after
-          :: acc )
-    | ( []
-        :: ({ authorization = (Signature _ | None_given) as a1; _ }
-           :: { authorization = (Signature _ | None_given) as a2; _ }
-              :: zkapp_command )
-           :: zkapp_commands
-      , [ _ ] :: (before :: _ :: (after :: _ as stmts)) :: stmtss ) ->
-        (* The next two zkapp_command do not contain proofs, and are within the same
-           new transaction. Pair them.
-           Ok to get "use_full_commitment" of [a1] because neither of them
-           contain a proof.
-        *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`New
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1; a2 ])
-              ~before ~after
-          :: acc )
-    | ( [ { authorization = (Signature _ | None_given) as a1; _ } ]
-        :: ({ authorization = (Signature _ | None_given) as a2; _ }
-           :: zkapp_command )
-           :: zkapp_commands
-      , (before :: _after1) :: (_before2 :: (after :: _ as stmts)) :: stmtss )
-      ->
-        (* The next two zkapp_command do not contain proofs, and the second is within
-           a new transaction. Pair them.
-           Ok to get "use_full_commitment" of [a1] because neither of them
-           contain a proof.
-        *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`New
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1; a2 ])
-              ~before ~after
-          :: acc )
-    | ( []
-        :: ({ authorization = a1; _ } :: zkapp_command)
-           :: (({ authorization = Proof _; _ } :: _) :: _ as zkapp_commands)
-      , [ _ ] :: (before :: ([ after ] as stmts)) :: (_ :: _ as stmtss) ) ->
-        (* The next transaction contains a proof, and this account_update is in a new
-           transaction, don't pair it with the next account_update.
-        *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`New
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-              ~before ~after
-          :: acc )
-    | ( []
-        :: [ { authorization = (Signature _ | None_given) as a1; _ } ]
-           :: ({ authorization = (Signature _ | None_given) as a2; _ }
-              :: zkapp_command )
-              :: zkapp_commands
-      , [ _ ]
-        :: [ before; _after1 ] :: (_before2 :: (after :: _ as stmts)) :: stmtss
-      ) ->
-        (* The next two zkapp_command do not contain proofs, the first is within a
-           new transaction, and the second is within another new transaction.
-           Pair them.
-           Ok to get "use_full_commitment" of [a1] because neither of them
-           contain a proof.
-        *)
-        group_by_zkapp_command_rev
-          (zkapp_command :: zkapp_commands)
-          (stmts :: stmtss)
-          ( intermediate_state ~kind:`Two_new
-              ~spec:(Zkapp_command_segment.Basic.of_controls [ a1; a2 ])
-              ~before ~after
-          :: acc )
-    | [ [ { authorization = a1; _ } ] ], (before :: after :: _) :: _ ->
-        (* This account_update is the final account_update given. Prove it on its own. *)
-        intermediate_state ~kind:`Same
-          ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-          ~before ~after
-        :: acc
-    | ( [] :: [ { authorization = a1; _ } ] :: [] :: _
-      , [ _ ] :: (before :: after :: _) :: _ ) ->
-        (* This account_update is the final account_update given, in a new transaction. Prove it
-           on its own.
-        *)
-        intermediate_state ~kind:`New
-          ~spec:(Zkapp_command_segment.Basic.of_controls [ a1 ])
-          ~before ~after
-        :: acc
-    | _, [] ->
-        failwith "group_by_zkapp_command_rev: No statements remaining"
-    | ([] | [ [] ]), _ ->
-        failwith "group_by_zkapp_command_rev: Unmatched statements remaining"
-    | [] :: _, [] :: _ ->
-        failwith
-          "group_by_zkapp_command_rev: No final statement for current \
-           transaction"
-    | [] :: _, (_ :: _ :: _) :: _ ->
-        failwith
-          "group_by_zkapp_command_rev: Unmatched statements for current \
-           transaction"
-    | [] :: [ _ ] :: _, [ _ ] :: (_ :: _ :: _ :: _) :: _ ->
-        failwith
-          "group_by_zkapp_command_rev: Unmatched statements for next \
-           transaction"
-    | [ []; [ _ ] ], [ _ ] :: [ _; _ ] :: _ :: _ ->
-        failwith
-          "group_by_zkapp_command_rev: Unmatched statements after next \
-           transaction"
-    | (_ :: _) :: _, ([] | [ _ ]) :: _ | (_ :: _ :: _) :: _, [ _; _ ] :: _ ->
-        failwith
-          "group_by_zkapp_command_rev: Too few statements remaining for the \
-           current transaction"
-    | ([] | [ _ ]) :: [] :: _, _ ->
-        failwith
-          "group_by_zkapp_command_rev: The next transaction has no \
-           zkapp_command"
-    | [] :: (_ :: _) :: _, _ :: ([] | [ _ ]) :: _
-    | [] :: (_ :: _ :: _) :: _, _ :: [ _; _ ] :: _ ->
-        failwith
-          "group_by_zkapp_command_rev: Too few statements remaining for the \
-           next transaction"
-    | [ _ ] :: (_ :: _) :: _, _ :: ([] | [ _ ]) :: _ ->
-        failwith
-          "group_by_zkapp_command_rev: Too few statements remaining for the \
-           next transaction"
-    | [] :: [ _ ] :: (_ :: _) :: _, _ :: _ :: ([] | [ _ ]) :: _ ->
-        failwith
-          "group_by_zkapp_command_rev: Too few statements remaining for the \
-           transaction after next"
-    | ([] | [ _ ]) :: (_ :: _) :: _, [ _ ] ->
-        failwith
-          "group_by_zkapp_command_rev: No statements given for the next \
-           transaction"
-    | [] :: [ _ ] :: (_ :: _) :: _, [ _; _ :: _ :: _ ] ->
-        failwith
-          "group_by_zkapp_command_rev: No statements given for transaction \
-           after next"
-  in
-  group_by_zkapp_command_rev zkapp_commands stmtss []
+  let zkapp_segment_of_controls = Zkapp_command_segment.Basic.of_controls
+end)
 
 let rec accumulate_call_stack_hashes
     ~(hash_frame : 'frame -> Stack_frame.Digest.t) (frames : 'frame list) :
@@ -3912,7 +3635,7 @@ let zkapp_command_witnesses_exn ~constraint_constants ~state_body ~fee_excess
   in
   let states = List.rev states_rev in
   let states_rev =
-    group_by_zkapp_command_rev
+    Account_update_group.group_by_zkapp_command_rev
       ( []
       :: List.map
            ~f:(fun (_, _, zkapp_command) ->
@@ -3952,7 +3675,7 @@ let zkapp_command_witnesses_exn ~constraint_constants ~state_body ~fee_excess
     match states_rev with
     | [] ->
         sparse_ledger
-    | { Zkapp_command_intermediate_state.state_after =
+    | { Account_update_group.Zkapp_command_intermediate_state.state_after =
           { global = { ledger; _ }; _ }
       ; _
       }
@@ -3961,7 +3684,7 @@ let zkapp_command_witnesses_exn ~constraint_constants ~state_body ~fee_excess
   in
   ( List.fold_right states_rev ~init:[]
       ~f:(fun
-           { Zkapp_command_intermediate_state.kind
+           { Account_update_group.Zkapp_command_intermediate_state.kind
            ; spec
            ; state_before = { global = source_global; local = source_local }
            ; state_after = { global = target_global; local = target_local }

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -349,59 +349,6 @@ module type S = sig
     t -> t -> sok_digest:Sok_message.Digest.t -> t Async.Deferred.Or_error.t
 end
 
-type local_state =
-  ( Stack_frame.value
-  , Stack_frame.value list
-  , Token_id.t
-  , Currency.Amount.Signed.t
-  , Mina_ledger.Sparse_ledger.t
-  , bool
-  , Zkapp_command.Transaction_commitment.t
-  , Mina_numbers.Index.t
-  , Transaction_status.Failure.Collection.t )
-  Mina_transaction_logic.Zkapp_command_logic.Local_state.t
-
-type global_state = Mina_ledger.Sparse_ledger.Global_state.t
-
-(** Represents before/after pairs of states, corresponding to zkapp_command in a list of zkapp_command transactions.
- *)
-module Zkapp_command_intermediate_state : sig
-  type state = { global : global_state; local : local_state }
-
-  type t =
-    { kind : [ `Same | `New | `Two_new ]
-    ; spec : Zkapp_command_segment.Basic.t
-    ; state_before : state
-    ; state_after : state
-    }
-end
-
-(** [group_by_zkapp_command_rev zkapp_commands stmtss] identifies before/after pairs of
-    statements, corresponding to zkapp_command in [zkapp_commands] which minimize the
-    number of snark proofs needed to prove all of the zkapp_command.
-
-    This function is intended to take the zkapp_command from multiple transactions as
-    its input, which may be converted from a [Zkapp_command.t list] using
-    [List.map ~f:Zkapp_command.zkapp_command]. The [stmtss] argument should be a list of
-    the same length, with 1 more state than the number of zkapp_command for each
-    transaction.
-
-    For example, two transactions made up of zkapp_command [[p1; p2; p3]] and
-    [[p4; p5]] should have the statements [[[s0; s1; s2; s3]; [s3; s4; s5]]],
-    where each [s_n] is the state after applying [p_n] on top of [s_{n-1}], and
-    where [s0] is the initial state before any of the transactions have been
-    applied.
-
-    Each pair is also identified with one of [`Same], [`New], or [`Two_new],
-    indicating that the next one ([`New]) or next two ([`Two_new]) [Zkapp_command.t]s
-    will need to be passed as part of the snark witness while applying that
-    pair.
-*)
-val group_by_zkapp_command_rev :
-     Account_update.t list list
-  -> (global_state * local_state) list list
-  -> Zkapp_command_intermediate_state.t list
-
 (** [zkapp_command_witnesses_exn ledger zkapp_commands] generates the zkapp_command segment witnesses
     and corresponding statements needed to prove the application of each
     zkapp_command transaction in [zkapp_commands] on top of ledger. If multiple zkapp_command are


### PR DESCRIPTION
Based on cost(in seconds) for proving a zkapp update with proof, a pair of updates with signatures/none and a single update with signature or none. 
The cost function was derived from the result transaction snark benchmark for zkapp transactions with different combinations of proof and signature updates