### PR TITLE
Make Base64 coding available for verification keys

### DIFF
--- a/src/app/archive/archive_lib/load_data.ml
+++ b/src/app/archive/archive_lib/load_data.ml
@@ -160,18 +160,16 @@ let update_of_id pool update_id =
     in
     Set_or_keep.of_option
       (Option.map vk_opt ~f:(fun { verification_key; hash } ->
-           match Base64.decode verification_key with
-           | Ok s ->
-               let data =
-                 Binable.of_string
-                   (module Pickles.Side_loaded.Verification_key.Stable.Latest)
-                   s
-               in
+           match
+             Pickles.Side_loaded.Verification_key.of_base64 verification_key
+           with
+           | Ok vk ->
+               let data = vk in
                let hash = Pickles.Backend.Tick.Field.of_string hash in
                { With_hash.data; hash }
-           | Error (`Msg err) ->
-               failwithf "Could not Base64-decode verification key: %s" err () )
-      )
+           | Error err ->
+               failwithf "Could not Base64-decode verification key: %s"
+                 (Error.to_string_hum err) () ) )
   in
   let%bind permissions =
     let%map perms_opt =

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -464,10 +464,7 @@ module Zkapp_verification_keys = struct
         , Pickles.Backend.Tick.Field.t )
         With_hash.t ) =
     let verification_key =
-      Binable.to_string
-        (module Pickles.Side_loaded.Verification_key.Stable.Latest)
-        vk.data
-      |> Base64.encode_exn
+      Pickles.Side_loaded.Verification_key.to_base64 vk.data
     in
     let hash = Pickles.Backend.Tick.Field.to_string vk.hash in
     let value = { hash; verification_key } in

--- a/src/lib/pickles/pickles_intf.ml
+++ b/src/lib/pickles/pickles_intf.ml
@@ -283,11 +283,9 @@ module type S = sig
         end
       end]
 
-      val to_base58_check : t -> string
+      include Codable.Base58_check_intf with type t := t
 
-      val of_base58_check : string -> t Or_error.t
-
-      val of_base58_check_exn : string -> t
+      include Codable.Base64_intf with type t := t
 
       val dummy : t
 

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -277,6 +277,7 @@ module Stable = struct
 
     include T
     include Codable.Make_base58_check (T)
+    include Codable.Make_base64 (T)
   end
 end]
 
@@ -285,6 +286,8 @@ Stable.Latest.
   ( to_base58_check
   , of_base58_check
   , of_base58_check_exn
+  , to_base64
+  , of_base64
   , sexp_of_t
   , t_of_sexp
   , to_yojson


### PR DESCRIPTION
Make `to_base64`, `of_base64` available from `Pickles.Side_loaded.Verification_key`, using the `Coda.Make_base64` functor, instead of defining the code in the archive lib processor.

That will make the encoding available to other code that needs to serialize verification keys.