### PR TITLE
Filter out account ids on failed transactions

### DIFF
--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -434,7 +434,7 @@ let run ~user_command_profiler ~zkapp_profiler num_transactions repeats preeval
       Mina_ledger.Sparse_ledger.of_ledger_subset_exn ledger
         (List.fold ~init:[] transactions ~f:(fun participants t ->
              List.rev_append
-               (Transaction.accounts_accessed (Transaction.forget t))
+               (Transaction.accounts_referenced (Transaction.forget t))
                participants ) )
     in
     let rec go n =

--- a/src/lib/filtered_external_transition/filtered_external_transition.ml
+++ b/src/lib/filtered_external_transition/filtered_external_transition.ml
@@ -74,7 +74,7 @@ let participants
   let user_command_set =
     List.fold commands ~init:empty ~f:(fun set user_command ->
         union set
-          (of_list @@ User_command.accounts_accessed user_command.data.data) )
+          (of_list @@ User_command.accounts_referenced user_command.data.data) )
   in
   let fee_transfer_participants =
     List.fold fee_transfers ~init:empty ~f:(fun set (ft, _) ->
@@ -93,7 +93,7 @@ let participant_pks
     List.fold commands ~init:empty ~f:(fun set user_command ->
         union set @@ of_list
         @@ List.map ~f:Account_id.public_key
-        @@ User_command.accounts_accessed user_command.data.data )
+        @@ User_command.accounts_referenced user_command.data.data )
   in
   let fee_transfer_participants =
     List.fold fee_transfers ~init:empty ~f:(fun set (ft, _) ->
@@ -150,7 +150,7 @@ let of_transition block tracked_participants
       | { data = Command command; status } -> (
           let command = (command :> User_command.t) in
           let should_include_transaction command participants =
-            List.exists (User_command.accounts_accessed command)
+            List.exists (User_command.accounts_referenced command)
               ~f:(fun account_id ->
                 Public_key.Compressed.Set.mem participants
                   (Account_id.public_key account_id) )

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -59,8 +59,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
       include Comparable.Make (T)
       include Hashable.Make (T)
 
-      let accounts_accessed ({ payload; _ } : t) =
-        Payload.accounts_accessed payload
+      let accounts_accessed ({ payload; _ } : t) status =
+        Payload.accounts_accessed payload status
+
+      let accounts_referenced (t : t) = accounts_accessed t Applied
     end
   end]
 
@@ -403,7 +405,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
   let filter_by_participant user_commands public_key =
     List.filter user_commands ~f:(fun user_command ->
         Core_kernel.List.exists
-          (accounts_accessed user_command)
+          (accounts_referenced user_command)
           ~f:
             (Fn.compose
                (Public_key.Compressed.equal public_key)

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -193,7 +193,11 @@ module type S = sig
   (** Forget the signature check. *)
   val forget_check : With_valid_signature.t -> t
 
-  val accounts_accessed : t -> Account_id.t list
+  (** account ids accessed, given a transaction status *)
+  val accounts_accessed : t -> Transaction_status.t -> Account_id.t list
+
+  (** all account ids mentioned in a command *)
+  val accounts_referenced : t -> Account_id.t list
 
   val filter_by_participant : t list -> Public_key.Compressed.t -> t list
 
@@ -238,7 +242,9 @@ module type Full = sig
 
       include Hashable.S with type t := t
 
-      val accounts_accessed : t -> Account_id.t list
+      val accounts_accessed : t -> Transaction_status.t -> Account_id.t list
+
+      val accounts_referenced : t -> Account_id.t list
     end
   end]
 

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -328,7 +328,12 @@ let amount (t : t) =
 let fee_excess (t : t) =
   Fee_excess.of_single (fee_token t, Currency.Fee.Signed.of_unsigned (fee t))
 
-let accounts_accessed (t : t) = [ fee_payer t; source t; receiver t ]
+let accounts_accessed (t : t) (status : Transaction_status.t) =
+  match status with
+  | Applied ->
+      [ fee_payer t; source t; receiver t ]
+  | Failed _ ->
+      [ fee_payer t ]
 
 let dummy : t =
   { common =

--- a/src/lib/mina_base/signed_command_payload.mli
+++ b/src/lib/mina_base/signed_command_payload.mli
@@ -178,7 +178,7 @@ val token : t -> Token_id.t
 
 val amount : t -> Currency.Amount.t option
 
-val accounts_accessed : t -> Account_id.t list
+val accounts_accessed : t -> Transaction_status.t -> Account_id.t list
 
 val tag : t -> Transaction_union_tag.t
 

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -188,12 +188,14 @@ let minimum_fee = Mina_compile_config.minimum_user_command_fee
 
 let has_insufficient_fee t = Currency.Fee.(fee t < minimum_fee)
 
-let accounts_accessed (t : t) =
+let accounts_accessed (t : t) (status : Transaction_status.t) =
   match t with
   | Signed_command x ->
-      Signed_command.accounts_accessed x
+      Signed_command.accounts_accessed x status
   | Zkapp_command ps ->
-      Zkapp_command.accounts_accessed ps
+      Zkapp_command.accounts_accessed ps status
+
+let accounts_referenced (t : t) = accounts_accessed t Applied
 
 let to_base58_check (t : t) =
   match t with
@@ -292,7 +294,7 @@ let to_valid_unsafe (t : t) =
 let filter_by_participant (commands : t list) public_key =
   List.filter commands ~f:(fun user_command ->
       Core_kernel.List.exists
-        (accounts_accessed user_command)
+        (accounts_referenced user_command)
         ~f:
           (Fn.compose
              (Signature_lib.Public_key.Compressed.equal public_key)

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1228,11 +1228,17 @@ let zkapp_command_list (t : t) : Account_update.t list =
 let fee_excess (t : t) =
   Fee_excess.of_single (fee_token t, Currency.Fee.Signed.of_unsigned (fee t))
 
-let accounts_accessed (t : t) =
-  Call_forest.fold t.account_updates
-    ~init:[ fee_payer t ]
-    ~f:(fun acc p -> Account_update.account_id p :: acc)
-  |> List.rev |> List.stable_dedup
+let accounts_accessed (t : t) (status : Transaction_status.t) =
+  match status with
+  | Applied ->
+      Call_forest.fold t.account_updates
+        ~init:[ fee_payer t ]
+        ~f:(fun acc p -> Account_update.account_id p :: acc)
+      |> List.rev |> List.stable_dedup
+  | Failed _ ->
+      [ fee_payer t ]
+
+let accounts_referenced (t : t) = accounts_accessed t Applied
 
 let fee_payer_pk (t : t) = t.fee_payer.body.public_key
 

--- a/src/lib/mina_block/block.ml
+++ b/src/lib/mina_block/block.ml
@@ -118,7 +118,7 @@ let account_ids_accessed t =
     transactions
       ~constraint_constants:Genesis_constants.Constraint_constants.compiled t
   in
-  List.map transactions ~f:(fun { data = txn; _ } ->
-      Mina_transaction.Transaction.accounts_accessed txn )
+  List.map transactions ~f:(fun { data = txn; status } ->
+      Mina_transaction.Transaction.accounts_accessed txn status )
   |> List.concat
   |> List.dedup_and_sort ~compare:Account_id.compare

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -630,7 +630,7 @@ let%test_unit "zkapp_command payment test" =
                       ~state_view:view )
               in
               let accounts =
-                List.concat_map ~f:Zkapp_command.accounts_accessed ts2
+                List.concat_map ~f:Zkapp_command.accounts_referenced ts2
               in
               (* TODO: Hack. The nonces are inconsistent between the 2
                  versions. See the comment in

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1912,7 +1912,7 @@ let%test_module _ =
       apply_to_ledger ledger cmd ;
       let accounts_to_check =
         Transaction_hash.User_command_with_valid_signature.command cmd
-        |> User_command.accounts_accessed |> Account_id.Set.of_list
+        |> User_command.accounts_referenced |> Account_id.Set.of_list
       in
       let pool, dropped =
         revalidate pool ~logger (`Subset accounts_to_check) (fun sender ->

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -554,7 +554,7 @@ struct
             ~f:(fun set cmd ->
               let set' =
                 With_status.data cmd |> User_command.forget_check
-                |> User_command.accounts_accessed |> Account_id.Set.of_list
+                |> User_command.accounts_referenced |> Account_id.Set.of_list
               in
               Set.union set set' )
         in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -565,7 +565,7 @@ module T = struct
           Fee_transfer.receivers t
       | Command t ->
           let t = (t :> User_command.t) in
-          User_command.accounts_accessed t
+          User_command.accounts_referenced t
       | Coinbase c ->
           let ft_receivers =
             Option.map ~f:Coinbase.Fee_transfer.receiver c.fee_transfer

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -89,21 +89,25 @@ let public_keys : t -> _ = function
       ; Signed_command.receiver_pk cmd
       ]
   | Command (Zkapp_command t) ->
-      Zkapp_command.accounts_accessed t |> List.map ~f:Account_id.public_key
+      Zkapp_command.accounts_referenced t |> List.map ~f:Account_id.public_key
   | Fee_transfer ft ->
       Fee_transfer.receiver_pks ft
   | Coinbase cb ->
       Coinbase.accounts_accessed cb |> List.map ~f:Account_id.public_key
 
-let accounts_accessed : t -> _ = function
+let accounts_accessed (t : t) (status : Transaction_status.t) =
+  match t with
   | Command (Signed_command cmd) ->
-      Signed_command.accounts_accessed cmd
+      Signed_command.accounts_accessed cmd status
   | Command (Zkapp_command t) ->
-      Zkapp_command.accounts_accessed t
+      Zkapp_command.accounts_accessed t status
   | Fee_transfer ft ->
+      assert (Transaction_status.equal Applied status) ;
       Fee_transfer.receivers ft
   | Coinbase cb ->
       Coinbase.accounts_accessed cb
+
+let accounts_referenced (t : t) = accounts_accessed t Applied
 
 let fee_payer_pk (t : t) =
   match t with

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1626,7 +1626,7 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
       (Transaction_applied.Zkapp_command_applied.t * user_acc) Or_error.t =
     let open Or_error.Let_syntax in
     let original_account_states =
-      List.map (Zkapp_command.accounts_accessed c) ~f:(fun id ->
+      List.map (Zkapp_command.accounts_referenced c) ~f:(fun id ->
           ( id
           , Option.Let_syntax.(
               let%bind loc = L.location_of_account ledger id in
@@ -1675,7 +1675,7 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
             { perform } initial_state )
     in
     let account_states_after_fee_payer =
-      List.map (Zkapp_command.accounts_accessed c) ~f:(fun id ->
+      List.map (Zkapp_command.accounts_referenced c) ~f:(fun id ->
           ( id
           , Option.Let_syntax.(
               let%bind loc = L.location_of_account ledger id in

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -416,7 +416,7 @@ let%test_module "account timing check" =
               in
               let validated_uc = validate_user_command uc in
               let account_ids =
-                Mina_transaction.Transaction.accounts_accessed txn
+                Mina_transaction.Transaction.accounts_referenced txn
               in
               let sparse_ledger_before =
                 Mina_ledger.Sparse_ledger.of_ledger_subset_exn ledger

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -179,7 +179,7 @@ let%test_module "Transaction union tests" =
                   ~txn_global_slot:current_global_slot t1
               in
               let mentioned_keys =
-                Signed_command.accounts_accessed
+                Signed_command.accounts_referenced
                   (Signed_command.forget_check t1)
               in
               let sparse_ledger =
@@ -393,7 +393,7 @@ let%test_module "Transaction union tests" =
                           for each command normally, but we know statically
                           that these are payments in this test.
                        *)
-                       Signed_command.accounts_accessed
+                       Signed_command.accounts_referenced
                          (Signed_command.forget_check t) )
                      [ t1; t2 ] )
               in

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -477,7 +477,7 @@ let test_transaction_union ?expected_failure ?txn_global_slot ledger txn =
     in
     match txn_unchecked with
     | Command (Signed_command uc) ->
-        ( Signed_command.accounts_accessed (uc :> Signed_command.t)
+        ( Signed_command.accounts_referenced (uc :> Signed_command.t)
         , pending_coinbase_stack )
     | Command (Zkapp_command _) ->
         failwith "Zkapp_command commands not supported here"

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3893,7 +3893,7 @@ let zkapp_command_witnesses_exn ~constraint_constants ~state_body ~fee_excess
         Sparse_ledger.of_ledger_subset_exn ledger
           (List.concat_map
              ~f:(fun (_, _, zkapp_command) ->
-               Zkapp_command.accounts_accessed zkapp_command )
+               Zkapp_command.accounts_referenced zkapp_command )
              zkapp_commands )
     | `Sparse_ledger sparse_ledger ->
         sparse_ledger


### PR DESCRIPTION
In `Block.account_ids_accessed`, filter out signed command receivers and zkApps account updates for failed transactions. We were getting errors looking up accounts in the staged ledger when creating precomputed blocks for account ids claimed to be accessed in blocks.

The function `accounts_accessed`, in `Signed_command`, `Zkapp_command`, `Transaction`, and `User_command`,  now takes a transaction status, to do the filtering needed. Add a new function `accounts_referenced` that does not filter out any account ids.

This may be a fix for #11861.