### PR TITLE
Support flexible circuit values

### DIFF
--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -403,7 +403,7 @@ let () =
     Js.wrap_callback
       (fun (x : As_field.t) : field_class Js.t Js.js_array Js.t ->
         (As_field.to_field_obj x)##toFields ) ;
-  field_class##.ofFields :=
+  field_class##.fromFields :=
     Js.wrap_callback
       (fun (xs : field_class Js.t Js.js_array Js.t) : field_class Js.t ->
         array_check_length xs 1 ; array_get_exn xs 0 ) ;
@@ -417,7 +417,7 @@ let () =
     Js.wrap_callback (fun (x : As_field.t) : bool_class Js.t ->
         new%js bool_constr
           (As_bool.of_boolean (Field.equal (As_field.value x) Field.zero)) ) ;
-  field_class##.ofBits :=
+  field_class##.fromBits :=
     Js.wrap_callback
       (fun (bs : As_bool.t Js.js_array Js.t) : field_class Js.t ->
         try
@@ -624,7 +624,7 @@ let () =
     (fun (x : As_bool.t) : field_class Js.t Js.js_array Js.t ->
       singleton_array
         (new%js field_constr (As_field.of_field (As_bool.value x :> Field.t))) ) ;
-  static_method "ofFields"
+  static_method "fromFields"
     (fun (xs : field_class Js.t Js.js_array Js.t) : bool_class Js.t ->
       if xs##.length = 1 then
         Js.Optdef.case (Js.array_get xs 0)
@@ -863,7 +863,7 @@ let () =
     (fun (x : scalar_class Js.t) : field_class Js.t Js.js_array Js.t ->
       (Js.Unsafe.coerce x)##toFields ) ;
   static_method "sizeInFields" (fun () : int -> num_bits) ;
-  static_method "ofFields"
+  static_method "fromFields"
     (fun (xs : field_class Js.t Js.js_array Js.t) : scalar_class Js.t ->
       new%js scalar_constr
         (Array.map (Js.to_array xs) ~f:(fun x ->
@@ -871,7 +871,7 @@ let () =
   static_method "random" (fun () : scalar_class Js.t ->
       let x = Other_backend.Field.random () in
       new%js scalar_constr_const (bits x) x ) ;
-  static_method "ofBits"
+  static_method "fromBits"
     (fun (bits : bool_class Js.t Js.js_array Js.t) : scalar_class Js.t ->
       new%js scalar_constr
         (Array.map (Js.to_array bits) ~f:(fun b ->
@@ -1004,7 +1004,7 @@ let () =
       arr##push p1##.y |> ignore ;
       arr ) ;
   static_method "toFields" (fun (p1 : group_class Js.t) -> p1##toFields) ;
-  static_method "ofFields" (fun (xs : field_class Js.t Js.js_array Js.t) ->
+  static_method "fromFields" (fun (xs : field_class Js.t Js.js_array Js.t) ->
       array_check_length xs 2 ;
       new%js group_constr
         (As_field.of_field_obj (array_get_exn xs 0))
@@ -1037,7 +1037,7 @@ class type ['a] as_field_elements =
   object
     method toFields : 'a -> field_class Js.t Js.js_array Js.t Js.meth
 
-    method ofFields : field_class Js.t Js.js_array Js.t -> 'a Js.meth
+    method fromFields : field_class Js.t Js.js_array Js.t -> 'a Js.meth
 
     method sizeInFields : int Js.meth
   end
@@ -1282,7 +1282,7 @@ module Circuit = struct
          let ctor1 : _ Js.Optdef.t = (Obj.magic t1)##.constructor in
          let has_methods ctor =
            let has s = Js.to_bool (ctor##hasOwnProperty (Js.string s)) in
-           has "toFields" && has "ofFields"
+           has "toFields" && has "fromFields"
          in
          match Js.Optdef.(to_option ctor1) with
          | Some ctor1 when has_methods ctor1 ->
@@ -1360,7 +1360,7 @@ module Circuit = struct
         let t1 = ctor##toFields x1 in
         let t2 = ctor##toFields x2 in
         let arr = if_array b t1 t2 in
-        ctor##ofFields arr
+        ctor##fromFields arr
 
   let rec if_magic : type a. As_bool.t -> a Js.t -> a Js.t -> a Js.t =
     fun (type a) (b : As_bool.t) (t1 : a Js.t) (t2 : a Js.t) : a Js.t ->
@@ -1380,7 +1380,7 @@ module Circuit = struct
          let ctor2 : _ Js.Optdef.t = (Obj.magic t2)##.constructor in
          let has_methods ctor =
            let has s = Js.Optdef.test (Js.Unsafe.get ctor (Js.string s)) in
-           has "toFields" && has "ofFields"
+           has "toFields" && has "fromFields"
          in
          if not (js_equal ctor1 ctor2) then
            raise_error "if: Mismatched argument types" ;
@@ -1421,7 +1421,7 @@ module Circuit = struct
       Js.to_array (typ##toFields a) |> Array.map ~f:(fun x -> conv x##.value)
     in
     let of_array conv xs =
-      typ##ofFields
+      typ##fromFields
         (Js.array
            (Array.map xs ~f:(fun x ->
                 new%js field_constr (As_field.of_field (conv x)) ) ) )

--- a/src/lib/snarky_js_bindings/test_module/simple-zkapp-mina-signer-quick.js
+++ b/src/lib/snarky_js_bindings/test_module/simple-zkapp-mina-signer-quick.js
@@ -47,7 +47,7 @@ let zkappAddress = zkappKey.toPublicKey();
 // compile smart contract (= Pickles.compile)
 tic("compile smart contract");
 let verificationKey = await cached(
-  async () => (await SimpleZkapp.compile(zkappAddress)).verificationKey
+  async () => (await SimpleZkapp.compile()).verificationKey
 );
 toc();
 

--- a/src/lib/snarky_js_bindings/test_module/simple-zkapp-mina-signer.js
+++ b/src/lib/snarky_js_bindings/test_module/simple-zkapp-mina-signer.js
@@ -46,7 +46,7 @@ let zkappAddress = zkappKey.toPublicKey();
 
 // compile smart contract (= Pickles.compile)
 tic("compile smart contract");
-await SimpleZkapp.compile(zkappAddress);
+await SimpleZkapp.compile();
 toc();
 
 // deploy transaction

--- a/src/lib/snarky_js_bindings/test_module/simple-zkapp-mock-apply-quick.js
+++ b/src/lib/snarky_js_bindings/test_module/simple-zkapp-mock-apply-quick.js
@@ -57,7 +57,7 @@ let zkappAddress = zkappKey.toPublicKey();
 // compile smart contract (= Pickles.compile)
 tic("compile smart contract");
 let verificationKey = await cached(
-  async () => (await SimpleZkapp.compile(zkappAddress)).verificationKey
+  async () => (await SimpleZkapp.compile()).verificationKey
 );
 toc();
 

--- a/src/lib/snarky_js_bindings/test_module/simple-zkapp-mock-apply.js
+++ b/src/lib/snarky_js_bindings/test_module/simple-zkapp-mock-apply.js
@@ -62,12 +62,12 @@ let zkappKey = PrivateKey.random();
 let zkappAddress = zkappKey.toPublicKey();
 
 tic("compute circuit digest");
-let digest = SimpleZkapp.digest(zkappAddress);
+SimpleZkapp.digest();
 toc();
 
 // compile smart contract (= Pickles.compile)
 tic("compile smart contract");
-let { verificationKey } = await SimpleZkapp.compile(zkappAddress);
+let { verificationKey } = await SimpleZkapp.compile();
 toc();
 
 tic("create deploy transaction");
@@ -88,9 +88,13 @@ let transaction = await Mina.transaction(() => {
 });
 let [proof] = await transaction.prove();
 let zkappCommandJsonInitialize = transaction.toJSON();
-zkappCommandJsonInitialize = signFeePayer(zkappCommandJsonInitialize, senderKey, {
-  transactionFee,
-});
+zkappCommandJsonInitialize = signFeePayer(
+  zkappCommandJsonInitialize,
+  senderKey,
+  {
+    transactionFee,
+  }
+);
 toc();
 
 // verify the proof

--- a/src/lib/snarky_js_bindings/test_module/simple-zkapp.js
+++ b/src/lib/snarky_js_bindings/test_module/simple-zkapp.js
@@ -63,7 +63,7 @@ if (command === "deploy") {
     nonce: feePayerNonce,
   });
 
-  let { verificationKey } = await SimpleZkapp.compile(zkappAddress);
+  let { verificationKey } = await SimpleZkapp.compile();
   let zkappCommandJson = await deploy(SimpleZkapp, {
     zkappKey,
     verificationKey,
@@ -93,7 +93,7 @@ if (command === "update") {
     publicKey: zkappAddress,
     zkapp: { appState: [initialState, 0, 0, 0, 0, 0, 0, 0] },
   });
-  let { verificationKey } = await SimpleZkapp.compile(zkappAddress);
+  let { verificationKey } = await SimpleZkapp.compile();
   let transaction = await Mina.transaction(() => {
     new SimpleZkapp(zkappAddress).update(Field(2));
   });

--- a/src/lib/snarky_js_bindings/tests/basic-circuit.mjs
+++ b/src/lib/snarky_js_bindings/tests/basic-circuit.mjs
@@ -9,7 +9,7 @@ export { basicCircuit };
 let FieldArrayTyp = (size) => ({
   sizeInFields: () => size,
   toFields: (f) => f,
-  ofFields: (f) => f,
+  fromFields: (f) => f,
   check: () => {},
 });
 class Main extends Circuit {

--- a/src/lib/snarky_js_bindings/tests/pickles-proof.mjs
+++ b/src/lib/snarky_js_bindings/tests/pickles-proof.mjs
@@ -43,7 +43,7 @@ async function picklesProof() {
   console.log("verify...");
   let ok = await verify(publicInput, proof);
 
-  console.log("ok?", ok === 1);
+  console.log("ok?", ok === 1 || ok === true);
   if (!ok) throw Error(`${name} failed`);
 }
 
@@ -73,7 +73,8 @@ function createDummyRule(name, func, witnessTypes) {
     let { witnesses } = mainContext;
     witnesses = witnessTypes.map(
       witnesses
-        ? (type, i) => Circuit.witness(type, () => witnesses[i])
+        ? (type, i) =>
+            type.fromFields(Circuit._witness(type, () => witnesses[i]))
         : emptyWitness
     );
     func(...witnesses);
@@ -84,8 +85,10 @@ function createDummyRule(name, func, witnessTypes) {
 }
 
 function emptyWitness(typ) {
-  return Circuit.witness(typ, () =>
-    typ.fromFields(Array(typ.sizeInFields()).fill(Field.zero))
+  return typ.fromFields(
+    Circuit._witness(typ, () =>
+      typ.fromFields(Array(typ.sizeInFields()).fill(Field.zero))
+    )
   );
 }
 

--- a/src/lib/snarky_js_bindings/tests/pickles-proof.mjs
+++ b/src/lib/snarky_js_bindings/tests/pickles-proof.mjs
@@ -85,13 +85,13 @@ function createDummyRule(name, func, witnessTypes) {
 
 function emptyWitness(typ) {
   return Circuit.witness(typ, () =>
-    typ.ofFields(Array(typ.sizeInFields()).fill(Field.zero))
+    typ.fromFields(Array(typ.sizeInFields()).fill(Field.zero))
   );
 }
 
 let FieldTyp = {
   sizeInFields: () => 1,
   toFields: (f) => [f],
-  ofFields: ([f]) => f,
+  fromFields: ([f]) => f,
   check: () => {},
 };


### PR DESCRIPTION
- companion to https://github.com/o1-labs/snarkyjs/pull/416
- changes methods on primitive types: `ofFields` -> `fromFields`, `ofBits` -> `fromBits`, to be compatible with the new generalized `typ` / CircuitValue in JS
- expose a more low-level variant of `exists` to JS, and define the public-facing `Circuit.witness` on the JS side instead, so that we can manage our CircuitValues in JS (the OCaml side will just witness an array of field elements)
