### PR TITLE
Fix --version output

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1737,7 +1737,7 @@ let () =
      use the Jane Street scripts that generate their version information
   *)
   (let make_list_mem ss s = List.mem ss s ~equal:String.equal in
-   let is_version_cmd = make_list_mem [ "version"; "-version" ] in
+   let is_version_cmd = make_list_mem [ "version"; "-version"; "--version" ] in
    let is_help_flag = make_list_mem [ "-help"; "-?" ] in
    match Sys.get_argv () with
    | [| _coda_exe; version |] when is_version_cmd version ->


### PR DESCRIPTION
Fix the output of `--version` to match the output of `version` and `-version`, instead of showing a weird `NO_VERSION_UTIL` message.