### PR TITLE
Bin_prot serialization for base64 of Proof

### DIFF
--- a/src/lib/pickles/pickles_intf.ml
+++ b/src/lib/pickles/pickles_intf.ml
@@ -79,11 +79,7 @@ module type S = sig
     val dummy : 'w Nat.t -> 'm Nat.t -> _ Nat.t -> domain_log2:int -> ('w, 'm) t
 
     module Make (W : Nat.Intf) (MLMB : Nat.Intf) : sig
-      type nonrec t = (W.n, MLMB.n) t [@@deriving sexp, compare, yojson, hash]
-
-      val to_base64 : t -> string
-
-      val of_base64 : string -> (t, string) Result.t
+      type nonrec t = (W.n, MLMB.n) t [@@deriving sexp, compare, hash]
     end
 
     module Proofs_verified_2 : sig
@@ -93,11 +89,13 @@ module type S = sig
           type t = Make(Nat.N2)(Nat.N2).t
           [@@deriving sexp, compare, equal, yojson, hash]
 
-          val to_yojson_full : t -> Yojson.Safe.t
+          include Codable.Base64_intf with type t := t
         end
       end]
 
       val to_yojson_full : t -> Yojson.Safe.t
+
+      include Codable.Base64_intf with type t := t
     end
   end
 
@@ -283,6 +281,7 @@ module type S = sig
         end
       end]
 
+      (* TODO: remove Base58Check code when SnarkyJS uses Base64 *)
       include Codable.Base58_check_intf with type t := t
 
       include Codable.Base64_intf with type t := t
@@ -317,17 +316,13 @@ module type S = sig
             (Verification_key.Max_width.n, Verification_key.Max_width.n) Proof.t
           [@@deriving sexp, equal, yojson, hash, compare]
 
-          val to_base64 : t -> string
-
-          val of_base64 : string -> (t, string) Result.t
+          include Codable.Base64_intf with type t := t
         end
       end]
 
       val of_proof : _ Proof.t -> t
 
-      val to_base64 : t -> string
-
-      val of_base64 : string -> (t, string) Result.t
+      include Codable.Base64_intf with type t := t
     end
 
     val create :

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -276,6 +276,8 @@ module Stable = struct
     end
 
     include T
+
+    (* TODO: remove Base58Check code when SnarkyJS uses Base64 *)
     include Codable.Make_base58_check (T)
     include Codable.Make_base64 (T)
   end


### PR DESCRIPTION
Use `Bin_prot` serialization for Base64 serialization of `Proof` instances, instead of converting to an S-expression.

Using a dummy proof, serializing an instance takes less than 1/4 the time with this change. The Yojson conversions rely on the Base64 conversions, so that will also be faster.

Leaving as a draft until the matching changes are made on the SnarkyJS side.