### PR TITLE
Raise with error string on application

### DIFF
--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -2958,7 +2958,7 @@ module Ledger = struct
       (network_state : Mina_base.Zkapp_precondition.Protocol_state.View.t) =
     check_account_update_signatures txn ;
     let ledger = l##.value in
-    let applied_exn =
+    let application_result =
       T.apply_zkapp_command_unchecked ~state_view:network_state
         ~constraint_constants:
           { Genesis_constants.Constraint_constants.compiled with
@@ -2966,7 +2966,13 @@ module Ledger = struct
           }
         ledger txn
     in
-    let applied, _ = Or_error.ok_exn applied_exn in
+    let applied, _ =
+      match application_result with
+      | Ok res ->
+          res
+      | Error err ->
+          raise_error (Error.to_string_hum err)
+    in
     let T.Transaction_applied.Zkapp_command_applied.{ accounts; command; _ } =
       applied
     in


### PR DESCRIPTION
In `Snarky_js_bindings`, when calling `apply_zkapp_command_unchecked`, raise an exception containing the error string, in case of an error, instead of calling `Or_error.ok_exn`.

Not sure this will help a lot, because the error is derived from an exception in `Zkapp_command_logic.apply`, which might only be something like "Assertion failed". Still, that's an improvement.