### PR TITLE
Include location of assert_ failures

### DIFF
--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -61,6 +61,6 @@
    ppx_version.runtime
  )
  (preprocess
-  (pps ppx_snarky ppx_version ppx_jane ppx_deriving.std ppx_deriving_yojson h_list.ppx))
+  (pps ppx_snarky ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson h_list.ppx))
  (instrumentation (backend bisect_ppx))
  (synopsis "Transaction state transition snarking library"))


### PR DESCRIPTION
In `Zkapp_command_logic`, pass `__LOC__` to `assert_`, so we can know which assertion failed.

We trap both `Assert_failed`, generated by OCaml `assert` in unchecked code, and `Failure`, generated by Snarky, which calls `failwithf`, add the location information, then re-raise the exception.

@MartinMinkov tested this branch with a zkApp known to fail, and it gave a correct location of the assertion failure.