### PR TITLE
Add a README chapter on running the Mina in dev environment.

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -118,8 +118,9 @@ Please note, that default configuration of the node depends on the build profile
 used during compilation, so in order to connect to some networks it might be
 necessary to compile the daemon with a specific profile.
 
-Before this can be done, however, some setup is required. First a key pair needs to be generated so that the
-daemon can sign blocks that it produces. This can be done using the same `mina.exe` binary:
+Before this can be done, however, some setup is required. First a key
+pair needs to be generated so that the daemon can create an account to
+issue blocks from. This can be done using the same `mina.exe` binary:
 
 ```shell
 $ dune exec src/app/cli/src/mina.exe -- libp2p generate-keypair --privkey-path /path/to/key


### PR DESCRIPTION
I believe there is no instruction anywhere in the READMEs on how to run a manually compiled mina daemon and Rosetta server. I wanted to provide such an instruction, or at least a seed of it. For Mina daemon it only explains the seed mode, because that's what I figured out so far. As far as I understand, a seed deamon tries to initiate a new network of its ownand does not actively try to connect with peers. If that's inaccurate, please propose a correction.

This PR only touches READMEs.