### PR TITLE
Add interface files to `lib/pickles_base`

### DIFF
--- a/src/lib/pickles_base/domain.mli
+++ b/src/lib/pickles_base/domain.mli
@@ -1,0 +1,25 @@
+(* Domain specification *)
+
+module Stable : sig
+  module V1 : sig
+    type t = Pow_2_roots_of_unity of int
+    [@@deriving sexp, equal, compare, hash, yojson]
+
+    include Pickles_types.Sigs.Binable.S with type t := t
+
+    include Pickles_types.Sigs.VERSIONED
+  end
+
+  module Latest = V1
+end
+
+type t = Stable.Latest.t = Pow_2_roots_of_unity of int
+[@@deriving sexp, equal, compare, hash, yojson]
+
+include Core_kernel.Hashable.S with type t := t
+
+(** {2 Size computation} *)
+
+val log2_size : t -> int
+
+val size : t -> int

--- a/src/lib/pickles_base/domains.mli
+++ b/src/lib/pickles_base/domains.mli
@@ -1,0 +1,13 @@
+(* Domains *)
+
+module Stable : sig
+  module V2 : sig
+    type t = { h : Domain.Stable.V1.t }
+    [@@deriving fields, sexp, compare, yojson]
+  end
+
+  module Latest = V2
+end
+
+type t = Stable.Latest.t = { h : Domain.Stable.V1.t }
+[@@deriving fields, sexp, compare, yojson]

--- a/src/lib/pickles_base/proofs_verified.mli
+++ b/src/lib/pickles_base/proofs_verified.mli
@@ -1,0 +1,58 @@
+module Stable : sig
+  module V1 : sig
+    type t = Mina_wire_types.Pickles_base.Proofs_verified.V1.t = N0 | N1 | N2
+    [@@deriving sexp, sexp, compare, yojson, hash, equal]
+
+    include Pickles_types.Sigs.Binable.S with type t := t
+
+    include Pickles_types.Sigs.VERSIONED
+  end
+end
+
+type t = Stable.V1.t = N0 | N1 | N2
+[@@deriving sexp, sexp, compare, yojson, hash, equal]
+
+val of_nat : 'n Pickles_types.Nat.t -> t
+
+val to_int : t -> int
+
+module One_hot : sig
+  module Checked : sig
+    type 'f t = ('f, Pickles_types.Nat.N3.n) One_hot_vector.t
+
+    val to_input :
+      'f t -> 'f Snarky_backendless.Cvar.t Random_oracle_input.Chunked.t
+  end
+
+  val to_input : zero:'a -> one:'a -> t -> 'a Random_oracle_input.Chunked.t
+
+  val typ :
+       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+    -> ( 'f Checked.t
+       , t
+       , 'f
+       , (unit, 'f) Snarky_backendless.Checked_ast.t )
+       Snarky_backendless__.Types.Typ.t
+end
+
+type 'f boolean = 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
+
+type 'a vec2 = ('a, Pickles_types.Nat.N2.n) Pickles_types.Vector.t
+
+module Prefix_mask : sig
+  module Checked : sig
+    type 'f t = 'f boolean vec2
+  end
+
+  val there : t -> bool vec2
+
+  val back : bool vec2 -> t
+
+  val typ :
+       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+    -> ( 'f Checked.t
+       , t
+       , 'f
+       , (unit, 'f) Snarky_backendless.Checked_ast.t )
+       Snarky_backendless__.Types.Typ.t
+end

--- a/src/lib/pickles_base/side_loaded_verification_key.ml
+++ b/src/lib/pickles_base/side_loaded_verification_key.ml
@@ -129,6 +129,7 @@ module Max_branches_vec = struct
     ()
 end
 
+(* TODO: remove since it looks very much like the Domains module in the same directory *)
 module Domains = struct
   [%%versioned
   module Stable = struct

--- a/src/lib/pickles_base/side_loaded_verification_key.mli
+++ b/src/lib/pickles_base/side_loaded_verification_key.mli
@@ -1,0 +1,153 @@
+(* Module Side_loaded_verification_key *)
+
+module Poly : sig
+  module Stable : sig
+    module V2 : sig
+      type ('g, 'proofs_verified, 'vk) t =
+            ( 'g
+            , 'proofs_verified
+            , 'vk )
+            Mina_wire_types.Pickles_base.Side_loaded_verification_key.Poly.V2.t =
+        { max_proofs_verified : 'proofs_verified
+        ; wrap_index : 'g Pickles_types.Plonk_verification_key_evals.Stable.V2.t
+        ; wrap_vk : 'vk option
+        }
+      [@@deriving hash]
+
+      include
+        Pickles_types.Sigs.Binable.S3 with type ('a, 'b, 'c) t := ('a, 'b, 'c) t
+
+      include Pickles_types.Sigs.VERSIONED
+    end
+
+    module Latest = V2
+  end
+
+  type ('g, 'proofs_verified, 'vk) t =
+        ('g, 'proofs_verified, 'vk) Stable.Latest.t =
+    { max_proofs_verified : 'proofs_verified
+    ; wrap_index : 'g Pickles_types.Plonk_verification_key_evals.t
+    ; wrap_vk : 'vk option
+    }
+  [@@deriving hash]
+end
+
+val wrap_index_to_input :
+     ('gs -> 'f array)
+  -> 'gs Pickles_types.Plonk_verification_key_evals.t
+  -> 'f Random_oracle_input.Chunked.t
+
+val index_to_field_elements :
+     'a Pickles_types.Plonk_verification_key_evals.t
+  -> g:('a -> 'b Core_kernel.Array.t)
+  -> 'b Core_kernel.Array.t
+
+val to_input :
+     field_of_int:(int -> 'a)
+  -> ('a * 'a, Pickles_base__Proofs_verified.t, 'b) Poly.t
+  -> 'a Random_oracle_input.Chunked.t
+
+val max_log2_degree : int
+
+val bits : len:int -> int -> bool list
+
+module Repr : sig
+  module Stable : sig
+    module V2 : sig
+      type 'g t =
+        { max_proofs_verified : Proofs_verified.Stable.V1.t
+        ; wrap_index : 'g Pickles_types.Plonk_verification_key_evals.Stable.V2.t
+        }
+      [@@deriving sexp, equal, compare, yojson]
+
+      include Pickles_types.Sigs.Binable.S1 with type 'a t := 'a t
+
+      val __versioned__ : unit
+    end
+
+    module Latest = V2
+  end
+
+  type 'g t = 'g Stable.Latest.t =
+    { max_proofs_verified : Proofs_verified.t
+    ; wrap_index : 'g Pickles_types.Plonk_verification_key_evals.t
+    }
+end
+
+module Width : sig
+  module Stable : sig
+    module V1 : sig
+      type t [@@deriving sexp, equal, compare, hash, yojson]
+
+      include Pickles_types.Sigs.Binable.S with type t := t
+
+      val __versioned__ : unit
+    end
+
+    module Latest = V1
+  end
+
+  type t = Stable.Latest.t [@@deriving sexp, equal, compare, hash, yojson]
+
+  val of_int_exn : int -> t
+
+  val to_int : t -> int
+
+  val to_bits : t -> bool list
+
+  val zero : t
+
+  module Max = Pickles_types.Nat.N2
+
+  module Max_vector : Pickles_types.Vector.With_version(Max).S
+
+  module Max_at_most : sig
+    module Stable : sig
+      module V1 : sig
+        type 'a t = ('a, Max.n) Pickles_types.At_most.t
+        [@@deriving sexp, equal, compare, hash, yojson]
+
+        include Pickles_types.Sigs.Binable.S1 with type 'a t := 'a t
+
+        val __versioned__ : unit
+      end
+
+      module Latest = V1
+    end
+
+    type 'a t = 'a Stable.Latest.t
+    [@@deriving sexp, equal, compare, hash, yojson]
+  end
+
+  module Length : Pickles_types.Nat.Add.Intf_transparent
+end
+
+module Domains : sig
+  module Stable : sig
+    module V1 : sig
+      type 'a t = { h : 'a }
+      [@@deriving sexp, equal, compare, hash, yojson, hlist, fields]
+    end
+  end
+
+  type 'a t = { h : 'a }
+  [@@deriving sexp, equal, compare, hash, yojson, hlist, fields]
+end
+
+(** [Max_branches] is mostly an alias for {!Pickles_types.Nat.N8} *)
+module Max_branches : sig
+  type 'a plus_n = 'a Pickles_types.Nat.N7.plus_n Pickles_types.Nat.s
+
+  type n = Pickles_types.Nat.z plus_n
+
+  val eq : (n, n) Base.Type_equal.t
+
+  val n : Pickles_types.Nat.z plus_n Pickles_types.Nat.nat
+
+  val add :
+       'm Pickles_types.Nat.nat
+    -> 'm plus_n Pickles_types.Nat.nat
+       * (Pickles_types.Nat.z plus_n, 'm, 'm plus_n) Pickles_types.Nat.Adds.t
+
+  module Log2 = Pickles_types.Nat.N3
+end


### PR DESCRIPTION
This PR is a refactoring PR that adds interface files to all modules inside `lib/pickles_base`.
Whenever possible, this also adds some lightweight documentation inside these files.


# Dependencies

Merge after #11858 
