### PR TITLE
Sparse ledger, no location for empty account

### DIFF
--- a/src/lib/mina_base/sparse_ledger_base.ml
+++ b/src/lib/mina_base/sparse_ledger_base.ml
@@ -63,7 +63,13 @@ module L = struct
     |> Option.bind ~f:Fn.id
 
   let location_of_account : t -> Account_id.t -> location option =
-   fun t id -> Option.try_with (fun () -> M.find_index_exn !t id)
+   fun t id ->
+    try
+      let loc = M.find_index_exn !t id in
+      let account = M.get_exn !t loc in
+      if Public_key.Compressed.(equal empty account.public_key) then None
+      else Some loc
+    with _ -> None
 
   let set : t -> location -> Account.t -> unit =
    fun t loc a -> t := M.set_exn !t loc a

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -541,8 +541,7 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
         | Some account ->
             Ok (`Existing location, account)
         | None ->
-            (* Needed to support sparse ledger. *)
-            Ok (`New, Account.create account_id Balance.zero) )
+            failwith "Ledger location with no account" )
     | None ->
         Ok (`New, Account.create account_id Balance.zero)
 
@@ -1727,16 +1726,8 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
         in
         (* accounts not originally in ledger, now present in ledger *)
         let new_accounts =
-          List.filter_map account_ids_originally_not_in_ledger
-            ~f:(fun acct_id ->
-              let open Option.Let_syntax in
-              let%bind loc = L.location_of_account ledger acct_id in
-              let%bind acc = L.get ledger loc in
-              (*Check account ids because sparse ledger stores empty
-                accounts at new account locations*)
-              Option.some_if
-                (Account_id.equal (Account.identifier acc) acct_id)
-                acct_id )
+          List.filter account_ids_originally_not_in_ledger ~f:(fun acct_id ->
+              Option.is_some @@ L.location_of_account ledger acct_id )
         in
         let valid_result =
           Ok
@@ -1803,10 +1794,7 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
     | Some loc -> (
         match get ledger loc with
         | None ->
-            ( init_account
-            , `Added
-            , `Has_permission_to_receive
-                (Account.has_permission ~to_:`Receive init_account) )
+            failwith "Ledger location with no account"
         | Some receiver_account ->
             ( receiver_account
             , `Existed


### PR DESCRIPTION
For an account id not in a sparse ledger, `Sparse_ledger_base.location_of_account` returned the location of an account with the `empty` public key. Then, when calling `get`, that account was filtered out, which seems peculiar.

In `Mina_transaction_logic`, that behavior was relied upon. It seems undesirable for this code to have knowledge of the quirks of the sparse ledger.

Instead, in the sparse ledger, filter locations with the empty account, and in the transaction logic, raise an exception if there's no account corresponding to a location.

Closes #11934.
