### PR TITLE
Update snarky to remove `Data_spec.t` from API

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -413,7 +413,7 @@ let constraint_system_digests ~proof_level ~constraint_constants () =
            in
            ()
          in
-         Tick.constraint_system ~exposing:[ typ ]
+         Tick.constraint_system ~input_typ:typ
            ~return_typ:(Snarky_backendless.Typ.unit ())
            main ) )
   ]

--- a/src/lib/consensus/constants.ml
+++ b/src/lib/consensus/constants.ml
@@ -309,8 +309,8 @@ let to_protocol_constants
   ; slots_per_epoch
   }
 
-let data_spec =
-  Data_spec.
+let typ =
+  Typ.of_hlistable
     [ Length.Checked.typ
     ; Length.Checked.typ
     ; Length.Checked.typ
@@ -326,11 +326,8 @@ let data_spec =
     ; Block_time.Span.Checked.typ
     ; Block_time.Checked.typ
     ]
-
-let typ =
-  Typ.of_hlistable data_spec ~var_to_hlist:Poly.to_hlist
-    ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
-    ~value_of_hlist:Poly.of_hlist
+    ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
+    ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
 let to_input (t : t) =
   Array.reduce_exn ~f:Random_oracle.Input.Chunked.append

--- a/src/lib/consensus/global_slot.ml
+++ b/src/lib/consensus/global_slot.ml
@@ -29,12 +29,11 @@ type value = t [@@deriving sexp, compare, hash, yojson]
 
 type var = (T.Checked.t, Length.Checked.t) Poly.t
 
-let data_spec = Data_spec.[ T.Checked.typ; Length.Checked.typ ]
-
 let typ =
-  Typ.of_hlistable data_spec ~var_to_hlist:Poly.to_hlist
-    ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
-    ~value_of_hlist:Poly.of_hlist
+  Typ.of_hlistable
+    [ T.Checked.typ; Length.Checked.typ ]
+    ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
+    ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
 let to_input (t : value) =
   Array.reduce_exn ~f:Random_oracle.Input.Chunked.append

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -943,19 +943,16 @@ module Data = struct
         [@@deriving sexp, compare, hash, to_yojson]
       end
 
-      let data_spec =
-        let open Tick.Data_spec in
-        [ Epoch_ledger.typ
-        ; Epoch_seed.typ
-        ; Mina_base.State_hash.typ
-        ; Lock_checkpoint.typ
-        ; Length.typ
-        ]
-
       let typ : (var, Value.t) Typ.t =
-        Typ.of_hlistable data_spec ~var_to_hlist:Poly.to_hlist
-          ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
-          ~value_of_hlist:Poly.of_hlist
+        Typ.of_hlistable
+          [ Epoch_ledger.typ
+          ; Epoch_seed.typ
+          ; Mina_base.State_hash.typ
+          ; Lock_checkpoint.typ
+          ; Length.typ
+          ]
+          ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
+          ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
       let graphql_type name =
         let open Graphql_async in
@@ -1760,32 +1757,28 @@ module Data = struct
       , Public_key.Compressed.var )
       Poly.t
 
-    let data_spec
-        ~(constraint_constants : Genesis_constants.Constraint_constants.t) =
-      let open Snark_params.Tick.Data_spec in
+    let typ ~(constraint_constants : Genesis_constants.Constraint_constants.t) :
+        (var, Value.t) Typ.t =
       let sub_windows_per_window =
         constraint_constants.sub_windows_per_window
       in
-      [ Length.typ
-      ; Length.typ
-      ; Length.typ
-      ; Typ.list ~length:sub_windows_per_window Length.typ
-      ; Vrf.Output.Truncated.typ
-      ; Amount.typ
-      ; Global_slot.typ
-      ; Mina_numbers.Global_slot.typ
-      ; Epoch_data.Staking.typ
-      ; Epoch_data.Next.typ
-      ; Boolean.typ
-      ; Public_key.Compressed.typ
-      ; Public_key.Compressed.typ
-      ; Public_key.Compressed.typ
-      ; Boolean.typ
-      ]
-
-    let typ ~constraint_constants : (var, Value.t) Typ.t =
       Snark_params.Tick.Typ.of_hlistable
-        (data_spec ~constraint_constants)
+        [ Length.typ
+        ; Length.typ
+        ; Length.typ
+        ; Typ.list ~length:sub_windows_per_window Length.typ
+        ; Vrf.Output.Truncated.typ
+        ; Amount.typ
+        ; Global_slot.typ
+        ; Mina_numbers.Global_slot.typ
+        ; Epoch_data.Staking.typ
+        ; Epoch_data.Next.typ
+        ; Boolean.typ
+        ; Public_key.Compressed.typ
+        ; Public_key.Compressed.typ
+        ; Public_key.Compressed.typ
+        ; Boolean.typ
+        ]
         ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
         ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 

--- a/src/lib/consensus/vrf/consensus_vrf.ml
+++ b/src/lib/consensus/vrf/consensus_vrf.ml
@@ -102,18 +102,14 @@ module Message = struct
            ~ledger_depth:constraint_constants.ledger_depth delegator
       |]
 
-  let data_spec
-      ~(constraint_constants : Genesis_constants.Constraint_constants.t) =
-    let open Tick.Data_spec in
-    [ Global_slot.typ
-    ; Mina_base.Epoch_seed.typ
-    ; Mina_base.Account.Index.Unpacked.typ
-        ~ledger_depth:constraint_constants.ledger_depth
-    ]
-
-  let typ ~constraint_constants : (var, value) Tick.Typ.t =
+  let typ ~(constraint_constants : Genesis_constants.Constraint_constants.t) :
+      (var, value) Tick.Typ.t =
     Tick.Typ.of_hlistable
-      (data_spec ~constraint_constants)
+      [ Global_slot.typ
+      ; Mina_base.Epoch_seed.typ
+      ; Mina_base.Account.Index.Unpacked.typ
+          ~ledger_depth:constraint_constants.ledger_depth
+      ]
       ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
       ~value_of_hlist:of_hlist
 

--- a/src/lib/crypto/kimchi_backend/tests.ml
+++ b/src/lib/crypto/kimchi_backend/tests.ml
@@ -48,9 +48,12 @@ let%test_module "pallas" =
 
     let%test_unit "test snarky instance" =
       Kimchi_pasta.Pallas_based_plonk.Keypair.set_urs_info [] ;
-      let _cs = Impl.constraint_system ~exposing:[ Field.typ ] main in
-      let _witness =
-        Impl.generate_witness [ Field.typ ] main (Field.Constant.of_int 4)
+      let (_ : Impl.R1CS_constraint_system.t) =
+        Impl.constraint_system ~input_typ:Field.typ ~return_typ:Typ.unit main
+      in
+      let (_ : Impl.Proof_inputs.t) =
+        Impl.generate_witness ~input_typ:Field.typ ~return_typ:Typ.unit main
+          (Field.Constant.of_int 4)
       in
       ()
   end )
@@ -62,9 +65,12 @@ let%test_module "vesta" =
 
     let%test_unit "test snarky instance" =
       Kimchi_pasta.Vesta_based_plonk.Keypair.set_urs_info [] ;
-      let _cs = Impl.constraint_system ~exposing:[ Field.typ ] main in
-      let _witness =
-        Impl.generate_witness [ Field.typ ] main (Field.Constant.of_int 4)
+      let (_ : Impl.R1CS_constraint_system.t) =
+        Impl.constraint_system ~input_typ:Field.typ ~return_typ:Typ.unit main
+      in
+      let (_ : Impl.Proof_inputs.t) =
+        Impl.generate_witness ~input_typ:Field.typ ~return_typ:Typ.unit main
+          (Field.Constant.of_int 4)
       in
       ()
   end )

--- a/src/lib/crypto/kimchi_bindings/js/test/bindings_js_test.ml
+++ b/src/lib/crypto/kimchi_bindings/js/test/bindings_js_test.ml
@@ -632,21 +632,21 @@ let _ =
            let _ = go 1000 x in
            ()
          in
-         let input = Data_spec.[ Typ.field ] in
-         let _pk =
+         let () =
            time "generate_keypair" (fun () ->
-               constraint_system ~return_typ:Typ.unit ~exposing:input main
+               constraint_system ~input_typ:Typ.field ~return_typ:Typ.unit main
                |> Backend.Keypair.create ~prev_challenges:0 )
          in
-         let pk =
+         let () =
            time "generate_keypair2" (fun () ->
-               constraint_system ~return_typ:Typ.unit ~exposing:input main
+               constraint_system ~input_typ:Typ.field ~return_typ:Typ.unit main
                |> Backend.Keypair.create ~prev_challenges:0 )
          in
          let x = Backend.Field.of_int 2 in
-         let pi =
+         let (_ : Backend.Proof.t) =
            time "generate witness conv" (fun () ->
-               Impl.generate_witness_conv input main
+               Impl.generate_witness_conv ~input_typ:Typ.field
+                 ~return_typ:Typ.unit main
                  ~f:(fun { Proof_inputs.auxiliary_inputs; public_inputs } () ->
                    time "create proof" (fun () ->
                        Backend.Proof.create pk ~auxiliary:auxiliary_inputs

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -491,27 +491,25 @@ let identifier_of_var ({ public_key; token_id; _ } : var) =
   Account_id.Checked.create public_key token_id
 
 let typ' zkapp =
-  let spec =
-    Data_spec.
-      [ Public_key.Compressed.typ
-      ; Token_id.typ
-      ; Token_permissions.typ
-      ; Token_symbol.typ
-      ; Balance.typ
-      ; Nonce.typ
-      ; Receipt.Chain_hash.typ
-      ; Typ.transport Public_key.Compressed.typ ~there:delegate_opt
-          ~back:(fun delegate ->
-            if Public_key.Compressed.(equal empty) delegate then None
-            else Some delegate )
-      ; State_hash.typ
-      ; Timing.typ
-      ; Permissions.typ
-      ; zkapp
-      ; Data_as_hash.typ ~hash:hash_zkapp_uri
-      ]
-  in
-  Typ.of_hlistable spec ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
+  Typ.of_hlistable
+    [ Public_key.Compressed.typ
+    ; Token_id.typ
+    ; Token_permissions.typ
+    ; Token_symbol.typ
+    ; Balance.typ
+    ; Nonce.typ
+    ; Receipt.Chain_hash.typ
+    ; Typ.transport Public_key.Compressed.typ ~there:delegate_opt
+        ~back:(fun delegate ->
+          if Public_key.Compressed.(equal empty) delegate then None
+          else Some delegate )
+    ; State_hash.typ
+    ; Timing.typ
+    ; Permissions.typ
+    ; zkapp
+    ; Data_as_hash.typ ~hash:hash_zkapp_uri
+    ]
+    ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
     ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
 let typ : (var, value) Typ.t =

--- a/src/lib/mina_base/account_timing.ml
+++ b/src/lib/mina_base/account_timing.ml
@@ -161,16 +161,6 @@ let var_of_t (t : t) : var =
 let untimed_var = var_of_t Untimed
 
 let typ : (var, t) Typ.t =
-  let spec =
-    let open Data_spec in
-    [ Boolean.typ
-    ; Balance.typ
-    ; Global_slot.typ
-    ; Amount.typ
-    ; Global_slot.typ
-    ; Amount.typ
-    ]
-  in
   (* because we represent the types t (a sum type) and var (a record) differently,
       we can't use the trick, used elsewhere, of polymorphic to_hlist and of_hlist
       functions to handle both types
@@ -226,8 +216,15 @@ let typ : (var, t) Typ.t =
   in
   let var_of_hlist = As_record.of_hlist in
   let var_to_hlist = As_record.to_hlist in
-  Typ.of_hlistable spec ~var_to_hlist ~var_of_hlist ~value_to_hlist
-    ~value_of_hlist
+  Typ.of_hlistable
+    [ Boolean.typ
+    ; Balance.typ
+    ; Global_slot.typ
+    ; Amount.typ
+    ; Global_slot.typ
+    ; Amount.typ
+    ]
+    ~var_to_hlist ~var_of_hlist ~value_to_hlist ~value_of_hlist
 
 (* we can't use the generic if_ with the above typ, because Global_slot.typ doesn't work correctly with it
     so we define a custom if_

--- a/src/lib/mina_base/epoch_ledger.ml
+++ b/src/lib/mina_base/epoch_ledger.ml
@@ -35,12 +35,11 @@ let to_input ({ hash; total_currency } : Value.t) =
 
 type var = (Frozen_ledger_hash0.var, Amount.var) Poly.t
 
-let data_spec = Data_spec.[ Frozen_ledger_hash0.typ; Amount.typ ]
-
 let typ : (var, Value.t) Typ.t =
-  Typ.of_hlistable data_spec ~var_to_hlist:Poly.to_hlist
-    ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
-    ~value_of_hlist:Poly.of_hlist
+  Typ.of_hlistable
+    [ Frozen_ledger_hash0.typ; Amount.typ ]
+    ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
+    ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
 let var_to_input ({ Poly.hash; total_currency } : var) =
   let total_currency = Amount.var_to_input total_currency in

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -51,10 +51,6 @@ module Coinbase_data = struct
   end
 
   let typ : (var, t) Typ.t =
-    let spec =
-      let open Data_spec in
-      [ Public_key.Compressed.typ; Amount.typ ]
-    in
     let of_hlist
           : 'public_key 'amount.
                (unit, 'public_key -> 'amount -> unit) H_list.t
@@ -63,8 +59,10 @@ module Coinbase_data = struct
       fun [ public_key; amount ] -> (public_key, amount)
     in
     let to_hlist (public_key, amount) = H_list.[ public_key; amount ] in
-    Typ.of_hlistable spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
-      ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
+    Typ.of_hlistable
+      [ Public_key.Compressed.typ; Amount.typ ]
+      ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
+      ~value_of_hlist:of_hlist
 
   let empty = (Public_key.Compressed.empty, Amount.zero)
 
@@ -277,12 +275,11 @@ module State_stack = struct
     ; curr = Stack_hash.var_of_t t.curr
     }
 
-  let data_spec = Snark_params.Tick.Data_spec.[ Stack_hash.typ; Stack_hash.typ ]
-
   let typ : (var, t) Typ.t =
-    Snark_params.Tick.Typ.of_hlistable data_spec ~var_to_hlist:Poly.to_hlist
-      ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
-      ~value_of_hlist:Poly.of_hlist
+    Snark_params.Tick.Typ.of_hlistable
+      [ Stack_hash.typ; Stack_hash.typ ]
+      ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
+      ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
   let to_bits (t : t) = Stack_hash.to_bits t.init @ Stack_hash.to_bits t.curr
 
@@ -603,13 +600,11 @@ module T = struct
       let%map state = State_stack.gen in
       { Poly.data; state }
 
-    let data_spec =
-      Snark_params.Tick.Data_spec.[ Coinbase_stack.typ; State_stack.typ ]
-
     let typ : (var, t) Typ.t =
-      Snark_params.Tick.Typ.of_hlistable data_spec ~var_to_hlist:Poly.to_hlist
-        ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
-        ~value_of_hlist:Poly.of_hlist
+      Snark_params.Tick.Typ.of_hlistable
+        [ Coinbase_stack.typ; State_stack.typ ]
+        ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
+        ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
     let num_pad_bits =
       let len = List.length Coinbase_stack.(to_bits empty) in

--- a/src/lib/mina_base/protocol_constants_checked.ml
+++ b/src/lib/mina_base/protocol_constants_checked.ml
@@ -79,19 +79,16 @@ let to_input (t : value) =
 
 type var = (T.Checked.t, T.Checked.t, Block_time.Checked.t) Poly.t
 
-let data_spec =
-  Data_spec.
+let typ =
+  Typ.of_hlistable
     [ T.Checked.typ
     ; T.Checked.typ
     ; T.Checked.typ
     ; T.Checked.typ
     ; Block_time.Checked.typ
     ]
-
-let typ =
-  Typ.of_hlistable data_spec ~var_to_hlist:Poly.to_hlist
-    ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
-    ~value_of_hlist:Poly.of_hlist
+    ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
+    ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
 let var_to_input (var : var) =
   let k = T.Checked.to_input var.k

--- a/src/lib/mina_base/staged_ledger_hash.ml
+++ b/src/lib/mina_base/staged_ledger_hash.ml
@@ -275,11 +275,8 @@ let var_to_input ({ non_snark; pending_coinbase_hash } : var) =
       (Non_snark.var_to_input non_snark)
       (field (Pending_coinbase.Hash.var_to_hash_packed pending_coinbase_hash)))
 
-let data_spec =
-  let open Data_spec in
-  [ Non_snark.typ; Pending_coinbase.Hash.typ ]
-
 let typ : (var, t) Typ.t =
-  Typ.of_hlistable data_spec ~var_to_hlist:Poly.to_hlist
-    ~var_of_hlist:Poly.of_hlist ~value_to_hlist:Poly.to_hlist
-    ~value_of_hlist:Poly.of_hlist
+  Typ.of_hlistable
+    [ Non_snark.typ; Pending_coinbase.Hash.typ ]
+    ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
+    ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist

--- a/src/lib/mina_base/transaction_union_payload.ml
+++ b/src/lib/mina_base/transaction_union_payload.ml
@@ -117,8 +117,8 @@ module Body = struct
     , Boolean.var )
     t_
 
-  let spec =
-    Data_spec.
+  let typ =
+    Typ.of_hlistable
       [ Tag.unpacked_typ
       ; Public_key.Compressed.typ
       ; Public_key.Compressed.typ
@@ -126,9 +126,7 @@ module Body = struct
       ; Currency.Amount.typ
       ; Boolean.typ
       ]
-
-  let typ =
-    Typ.of_hlistable spec ~var_to_hlist:t__to_hlist ~value_to_hlist:t__to_hlist
+      ~var_to_hlist:t__to_hlist ~value_to_hlist:t__to_hlist
       ~var_of_hlist:t__of_hlist ~value_of_hlist:t__of_hlist
 
   module Checked = struct

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -71,18 +71,16 @@ let create_value ~staged_ledger_hash ~genesis_ledger_hash ~registers ~timestamp
   ; body_reference
   }
 
-let data_spec =
-  let open Data_spec in
-  [ Staged_ledger_hash.typ
-  ; Frozen_ledger_hash.typ
-  ; Registers.typ [ Frozen_ledger_hash.typ; Typ.unit; Local_state.typ ]
-  ; Block_time.Checked.typ
-  ; Consensus.Body_reference.typ
-  ]
-
 let typ : (var, Value.t) Typ.t =
-  Typ.of_hlistable data_spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
-    ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
+  Typ.of_hlistable
+    [ Staged_ledger_hash.typ
+    ; Frozen_ledger_hash.typ
+    ; Registers.typ [ Frozen_ledger_hash.typ; Typ.unit; Local_state.typ ]
+    ; Block_time.Checked.typ
+    ; Consensus.Body_reference.typ
+    ]
+    ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
+    ~value_of_hlist:of_hlist
 
 module Impl = Pickles.Impls.Step
 

--- a/src/lib/mina_state/protocol_state.ml
+++ b/src/lib/mina_state/protocol_state.ml
@@ -77,17 +77,13 @@ module Body = struct
     , Protocol_constants_checked.var )
     Poly.t
 
-  let data_spec ~constraint_constants =
-    Data_spec.
+  let typ ~constraint_constants =
+    Typ.of_hlistable
       [ State_hash.typ
       ; Blockchain_state.typ
       ; Consensus.Data.Consensus_state.typ ~constraint_constants
       ; Protocol_constants_checked.typ
       ]
-
-  let typ ~constraint_constants =
-    Typ.of_hlistable
-      (data_spec ~constraint_constants)
       ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
       ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 
@@ -231,12 +227,9 @@ let constants { Poly.Stable.Latest.body = { Body.Poly.constants; _ }; _ } =
 
 let create_var = create'
 
-let data_spec ~constraint_constants =
-  Data_spec.[ State_hash.typ; Body.typ ~constraint_constants ]
-
 let typ ~constraint_constants =
   Typ.of_hlistable
-    (data_spec ~constraint_constants)
+    [ State_hash.typ; Body.typ ~constraint_constants ]
     ~var_to_hlist:Poly.to_hlist ~var_of_hlist:Poly.of_hlist
     ~value_to_hlist:Poly.to_hlist ~value_of_hlist:Poly.of_hlist
 

--- a/src/lib/pickles/cache.ml
+++ b/src/lib/pickles/cache.ml
@@ -98,7 +98,7 @@ module Step = struct
         | Error _e ->
             let r =
               Common.time "stepkeygen" (fun () ->
-                  constraint_system ~exposing:[ typ ] ~return_typ main
+                  constraint_system ~input_typ:typ ~return_typ main
                   |> Keypair.generate ~prev_challenges )
             in
             Timer.clock __LOC__ ;
@@ -196,7 +196,7 @@ module Wrap = struct
          | Error _e ->
              let r =
                Common.time "wrapkeygen" (fun () ->
-                   constraint_system ~exposing:[ typ ] ~return_typ main
+                   constraint_system ~input_typ:typ ~return_typ main
                    |> Keypair.generate ~prev_challenges )
              in
              ignore

--- a/src/lib/pickles/common.ml
+++ b/src/lib/pickles/common.ml
@@ -202,7 +202,7 @@ end
 let tock_unpadded_public_input_of_statement prev_statement =
   let input =
     let (T (typ, _conv, _conv_inv)) = Impls.Wrap.input () in
-    Impls.Wrap.generate_public_input [ typ ] prev_statement
+    Impls.Wrap.generate_public_input typ prev_statement
   in
   List.init
     (Backend.Tock.Field.Vector.length input)
@@ -217,7 +217,7 @@ let tick_public_input_of_statement ~max_proofs_verified ~uses_lookup
       Impls.Step.input ~proofs_verified:max_proofs_verified
         ~wrap_rounds:Tock.Rounds.n ~uses_lookup
     in
-    Impls.Step.generate_public_input [ input ] prev_statement
+    Impls.Step.generate_public_input input prev_statement
   in
   List.init
     (Backend.Tick.Field.Vector.length input)

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -25,4 +25,4 @@ let domains (type field)
     in
     { h = Pow_2_roots_of_unity Int.(ceil_log2 rows) }
   in
-  domains2 (Impl.constraint_system ~exposing:[ typ ] ~return_typ main)
+  domains2 (Impl.constraint_system ~input_typ:typ ~return_typ main)

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -594,7 +594,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
               let f (T b : _ Branch_data.t) =
                 let (T (typ, _conv, conv_inv)) = etyp in
-                let main () =
+                let main () () =
                   let res = b.main ~step_domains () in
                   Impls.Step.with_label "conv_inv" (fun () -> conv_inv res)
                 in
@@ -604,13 +604,15 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 if return_early_digest_exception then
                   raise
                     (Return_digest
-                       ( constraint_system ~exposing:[] ~return_typ:typ main
+                       ( constraint_system ~input_typ:Typ.unit ~return_typ:typ
+                           main
                        |> R1CS_constraint_system.digest ) ) ;
 
                 let k_p =
                   lazy
                     (let cs =
-                       constraint_system ~exposing:[] ~return_typ:typ main
+                       constraint_system ~input_typ:Typ.unit ~return_typ:typ
+                         main
                      in
                      let cs_hash =
                        Md5.to_hex (R1CS_constraint_system.digest cs)
@@ -647,8 +649,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                         ~prev_challenges:(Nat.to_int (fst b.proofs_verified))
                         cache k_p k_v
                         (Snarky_backendless.Typ.unit ())
-                        typ
-                        (fun () -> main) )
+                        typ main )
                 in
                 accum_dirty (Lazy.map pk ~f:snd) ;
                 accum_dirty (Lazy.map vk ~f:snd) ;
@@ -679,7 +680,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
         let disk_key_prover =
           lazy
             (let cs =
-               constraint_system ~exposing:[ typ ]
+               constraint_system ~input_typ:typ
                  ~return_typ:(Snarky_backendless.Typ.unit ())
                  main
              in
@@ -2048,14 +2049,16 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~wrap_rounds:Tock.Rounds.n
             in
             let (T (typ, _conv, conv_inv)) = etyp in
-            let main () =
+            let main () () =
               let res = inner_step_data.main ~step_domains () in
               Impls.Step.with_label "conv_inv" (fun () -> conv_inv res)
             in
             let open Impls.Step in
             let k_p =
               lazy
-                (let cs = constraint_system ~exposing:[] ~return_typ:typ main in
+                (let cs =
+                   constraint_system ~input_typ:Typ.unit ~return_typ:typ main
+                 in
                  let cs_hash = Md5.to_hex (R1CS_constraint_system.digest cs) in
                  ( Type_equal.Id.uid self.id
                  , snark_keys_header
@@ -2084,8 +2087,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 (Nat.to_int (fst inner_step_data.proofs_verified))
               [] k_p k_v
               (Snarky_backendless.Typ.unit ())
-              typ
-              (fun () -> main)
+              typ main
           in
           let step_vks =
             let module V = H4.To_vector (Lazy_keys) in
@@ -2135,7 +2137,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
             let disk_key_prover =
               lazy
                 (let cs =
-                   constraint_system ~exposing:[ typ ] ~return_typ:Typ.unit main
+                   constraint_system ~input_typ:typ ~return_typ:Typ.unit main
                  in
                  let cs_hash = Md5.to_hex (R1CS_constraint_system.digest cs) in
                  ( self_id
@@ -2600,7 +2602,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                                         ; challenges = Vector.to_array chals
                                         } )
                                   |> Wrap_hack.pad_accumulator ) )
-                            [ input ]
+                            ~input_typ:input
                             ~return_typ:(Snarky_backendless.Typ.unit ())
                             (fun x () : unit -> wrap_main (conv x))
                             { messages_for_next_step_proof =
@@ -2972,14 +2974,16 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~wrap_rounds:Tock.Rounds.n
             in
             let (T (typ, _conv, conv_inv)) = etyp in
-            let main () =
+            let main () () =
               let res = inner_step_data.main ~step_domains () in
               Impls.Step.with_label "conv_inv" (fun () -> conv_inv res)
             in
             let open Impls.Step in
             let k_p =
               lazy
-                (let cs = constraint_system ~exposing:[] ~return_typ:typ main in
+                (let cs =
+                   constraint_system ~input_typ:Typ.unit ~return_typ:typ main
+                 in
                  let cs_hash = Md5.to_hex (R1CS_constraint_system.digest cs) in
                  ( Type_equal.Id.uid self.id
                  , snark_keys_header
@@ -3008,8 +3012,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 (Nat.to_int (fst inner_step_data.proofs_verified))
               [] k_p k_v
               (Snarky_backendless.Typ.unit ())
-              typ
-              (fun () -> main)
+              typ main
           in
           let step_vks =
             let module V = H4.To_vector (Lazy_keys) in
@@ -3059,7 +3062,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
             let disk_key_prover =
               lazy
                 (let cs =
-                   constraint_system ~exposing:[ typ ] ~return_typ:Typ.unit main
+                   constraint_system ~input_typ:typ ~return_typ:Typ.unit main
                  in
                  let cs_hash = Md5.to_hex (R1CS_constraint_system.digest cs) in
                  ( self_id
@@ -3490,7 +3493,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                                         ; challenges = Vector.to_array chals
                                         } )
                                   |> Wrap_hack.pad_accumulator ) )
-                            [ input ]
+                            ~input_typ:input
                             ~return_typ:(Snarky_backendless.Typ.unit ())
                             (fun x () : unit -> wrap_main (conv x))
                             { messages_for_next_step_proof =

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -41,11 +41,11 @@ let input_size ~of_int ~add ~mul w =
   let open Composition_types in
   (* This should be an affine function in [a]. *)
   let size a =
-    let (T (typ, _conv, _conv_inv)) =
+    let (T (Typ typ, _conv, _conv_inv)) =
       Impls.Step.input ~proofs_verified:a ~wrap_rounds:Backend.Tock.Rounds.n
         ~uses_lookup:No
     in
-    Impls.Step.Data_spec.size [ typ ]
+    typ.size_in_field_elements
   in
   let f0 = size Nat.N0.n in
   let slope = size Nat.N1.n - f0 in
@@ -351,11 +351,11 @@ let%test_unit "input_size" =
       [%test_eq: int]
         (input_size ~of_int:Fn.id ~add:( + ) ~mul:( * ) n)
         (let (T a) = Nat.of_int n in
-         let (T (typ, _conv, _conv_inv)) =
+         let (T (Typ typ, _conv, _conv_inv)) =
            Impls.Step.input ~proofs_verified:a
              ~wrap_rounds:Backend.Tock.Rounds.n ~uses_lookup:No
          in
-         Impls.Step.Data_spec.size [ typ ] ) )
+         typ.size_in_field_elements ) )
 
 let typ : (Checked.t, t) Impls.Step.Typ.t =
   let open Step_main_inputs in

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -712,7 +712,8 @@ struct
         List.nth_exn (Vector.to_list step_domains) branch_data.index
       in
       ksprintf Common.time "step-prover %d (%d)" branch_data.index
-        (Domain.size h) (fun () ->
+        (Domain.size h)
+        (fun () ->
           Impls.Step.generate_witness_conv
             ~f:(fun { Impls.Step.Proof_inputs.auxiliary_inputs; public_inputs }
                     next_statement_hashed ->
@@ -723,11 +724,12 @@ struct
                   pk
               in
               (proof, next_statement_hashed) )
-            [] ~return_typ:input
-            (fun () ->
+            ~input_typ:Impls.Step.Typ.unit ~return_typ:input
+            (fun () () ->
               Impls.Step.handle
                 (fun () -> conv_inv (branch_data.main ~step_domains ()))
                 handler ) )
+        ()
     in
     let prev_evals =
       extract_from_proofs

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -604,7 +604,7 @@ let wrap
                       ; challenges = Vector.to_array chals
                       } )
                 |> Wrap_hack.pad_accumulator ) )
-          [ input ]
+          ~input_typ:input
           ~return_typ:(Snarky_backendless.Typ.unit ())
           (fun x () : unit ->
             Impls.Wrap.handle (fun () : unit -> wrap_main (conv x)) handler )

--- a/src/lib/snarky_js_bindings/tests/tests.ml
+++ b/src/lib/snarky_js_bindings/tests/tests.ml
@@ -3,9 +3,10 @@ module Impl = Pickles.Impls.Step
 module Field = Impl.Field
 
 (* function to check a circuit defined by a 'main' function *)
-let keygen_prove_verify (main : ?w:'a -> 'b -> unit -> unit) spec ?priv pub =
+let keygen_prove_verify (main : ?w:'a -> 'b -> unit -> unit) input_typ ?priv pub
+    =
   let kp =
-    Impl.constraint_system ~input_typ:spec
+    Impl.constraint_system ~input_typ
       ~return_typ:(Snarky_backendless.Typ.unit ())
       (main ?w:None)
     |> Impl.Keypair.generate ~prev_challenges:0
@@ -16,7 +17,7 @@ let keygen_prove_verify (main : ?w:'a -> 'b -> unit -> unit) spec ?priv pub =
       ~f:(fun { Impl.Proof_inputs.auxiliary_inputs; public_inputs } _ ->
         Backend.Proof.create pk ~auxiliary:auxiliary_inputs
           ~primary:public_inputs )
-      spec
+      ~input_typ
       ~return_typ:(Snarky_backendless.Typ.unit ())
       (main ?w:priv) pub
   in

--- a/src/lib/snarky_js_bindings/tests/tests.ml
+++ b/src/lib/snarky_js_bindings/tests/tests.ml
@@ -5,7 +5,7 @@ module Field = Impl.Field
 (* function to check a circuit defined by a 'main' function *)
 let keygen_prove_verify (main : ?w:'a -> 'b -> unit -> unit) spec ?priv pub =
   let kp =
-    Impl.constraint_system ~exposing:spec
+    Impl.constraint_system ~input_typ:spec
       ~return_typ:(Snarky_backendless.Typ.unit ())
       (main ?w:None)
     |> Impl.Keypair.generate ~prev_challenges:0
@@ -47,15 +47,13 @@ let%test_unit "poseidon" =
     let preimage = read_witness Field.typ w in
     Field.Assert.equal (poseidon_hash [| preimage |]) z
   in
-  keygen_prove_verify main
-    Impl.Data_spec.[ Field.typ ]
-    (to_unchecked hash) ~priv:(to_unchecked preimage)
+  keygen_prove_verify main Field.typ (to_unchecked hash)
+    ~priv:(to_unchecked preimage)
 
 let%test_unit "sqrt" =
   let main ?w z () =
     let x = read_witness Field.typ w in
     Field.Assert.equal (Field.mul x x) z
   in
-  keygen_prove_verify main
-    Impl.Data_spec.[ Field.typ ]
-    (Field.Constant.of_int 4) ~priv:(Field.Constant.of_int 2)
+  keygen_prove_verify main Field.typ (Field.Constant.of_int 4)
+    ~priv:(Field.Constant.of_int 2)

--- a/src/lib/snarky_log/snarky_log.ml
+++ b/src/lib/snarky_log/snarky_log.ml
@@ -46,9 +46,8 @@ let () = Snarky_log.to_file "output.json" @@
   Constraints.log_func ~input:Data_spec.[Field.typ; Field.typ] Field.Checked.mul
     ~apply_args:(fun mul -> mul Field.one Field.one)
     }] *)
-  let log_func ~(input : ('r_value, 'r_value, 'k_var, 'k_value) Data_spec.t)
-      ~return_typ ~(apply_args : 'k_value -> _ Checked.t) (f : 'k_var) : events
-      =
-    let f' = conv (fun c -> c) input return_typ f in
+  let log_func ~input_typ ~return_typ ~(apply_args : 'k_value -> _ Checked.t)
+      (f : 'k_var) : events =
+    let f' = conv (fun c -> c) input_typ return_typ f in
     log (apply_args f')
 end

--- a/src/lib/transaction/transaction_union.ml
+++ b/src/lib/transaction/transaction_union.ml
@@ -15,10 +15,9 @@ type t = (Payload.t, Public_key.t, Signature.t) t_
 type var = (Payload.var, Public_key.var, Signature.var) t_
 
 let typ : (var, t) Typ.t =
-  let spec =
-    Data_spec.[ Payload.typ; Public_key.typ; Schnorr.Chunked.Signature.typ ]
-  in
-  Typ.of_hlistable spec ~var_to_hlist:t__to_hlist ~var_of_hlist:t__of_hlist
+  Typ.of_hlistable
+    [ Payload.typ; Public_key.typ; Schnorr.Chunked.Signature.typ ]
+    ~var_to_hlist:t__to_hlist ~var_of_hlist:t__of_hlist
     ~value_to_hlist:t__to_hlist ~value_of_hlist:t__of_hlist
 
 (** For SNARK purposes, we inject [Transaction.t]s into a single-variant 'tagged-union' record capable of

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3537,7 +3537,7 @@ let generate_transaction_union_witness ?(preeval = false) ~constraint_constants
   in
   let open Tick in
   let main x = handle (Base.main ~constraint_constants x) handler in
-  generate_auxiliary_input [ Statement.With_sok.typ ]
+  generate_auxiliary_input ~input_typ:Statement.With_sok.typ
     ~return_typ:(Snarky_backendless.Typ.unit ())
     main statement
 
@@ -3581,14 +3581,14 @@ let constraint_system_digests ~constraint_constants () =
   [ ( "transaction-merge"
     , digest
         Merge.(
-          Tick.constraint_system ~exposing:[ Statement.With_sok.typ ]
+          Tick.constraint_system ~input_typ:Statement.With_sok.typ
             ~return_typ:(Snarky_backendless.Typ.unit ()) (fun x ->
               let open Tick in
               Checked.map ~f:ignore @@ main x )) )
   ; ( "transaction-base"
     , digest
         Base.(
-          Tick.constraint_system ~exposing:[ Statement.With_sok.typ ]
+          Tick.constraint_system ~input_typ:Statement.With_sok.typ
             ~return_typ:(Snarky_backendless.Typ.unit ())
             (main ~constraint_constants)) )
   ]

--- a/src/lib/vrf_lib/tests/integrated_test.ml
+++ b/src/lib/vrf_lib/tests/integrated_test.ml
@@ -30,11 +30,11 @@ module Message = struct
 
   type var = Mina_base.State_hash.var t
 
-  let data_spec = Tick.Data_spec.[ Mina_base.State_hash.typ ]
-
   let typ =
-    Tick.Typ.of_hlistable data_spec ~var_to_hlist:to_hlist
-      ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
+    Tick.Typ.of_hlistable
+      [ Mina_base.State_hash.typ ]
+      ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
+      ~value_of_hlist:of_hlist
 
   let gen =
     let open Quickcheck.Let_syntax in


### PR DESCRIPTION
This PR is a companion to o1-labs/snarky#649, which modifies snarky to remove the `Data_spec.t` container for `Typ.t`s from the main API. This change makes the code significantly easier to follow for non-OCaml developers.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them