### PR TITLE
Miscellaneous changes for snarky simplifications

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -101,7 +101,7 @@ let non_pc_registers_equal_var t1 t2 =
         transition consensus data is valid
         new consensus state is a function of the old consensus state
 *)
-let%snarkydef step ~(logger : Logger.t)
+let%snarkydef_ step ~(logger : Logger.t)
     ~(proof_level : Genesis_constants.Proof_level.t)
     ~(constraint_constants : Genesis_constants.Constraint_constants.t) new_state
     : _ Tick.Checked.t =

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -688,7 +688,7 @@ module Data = struct
       | Producer_private_key : Scalar.value Snarky_backendless.Request.t
       | Producer_public_key : Public_key.t Snarky_backendless.Request.t
 
-    let%snarkydef get_vrf_evaluation
+    let%snarkydef.Snark_params.Tick get_vrf_evaluation
         ~(constraint_constants : Genesis_constants.Constraint_constants.t)
         shifted ~block_stake_winner ~block_creator ~ledger ~message =
       let open Mina_base in
@@ -703,24 +703,24 @@ module Data = struct
              ledger staker_addr )
       in
       let%bind () =
-        [%with_label "Account is for the default token"]
+        [%with_label_ "Account is for the default token"]
           (make_checked (fun () ->
                Token_id.(
                  Checked.Assert.equal account.token_id
                    (Checked.constant default)) ) )
       in
       let%bind () =
-        [%with_label "Block stake winner matches account pk"]
+        [%with_label_ "Block stake winner matches account pk"]
           (Public_key.Compressed.Checked.Assert.equal block_stake_winner
              account.public_key )
       in
       let%bind () =
-        [%with_label "Block creator matches delegate pk"]
+        [%with_label_ "Block creator matches delegate pk"]
           (Public_key.Compressed.Checked.Assert.equal block_creator
              account.delegate )
       in
       let%bind delegate =
-        [%with_label "Decompress delegate pk"]
+        [%with_label_ "Decompress delegate pk"]
           (Public_key.decompress_var account.delegate)
       in
       let%map evaluation =
@@ -731,7 +731,7 @@ module Data = struct
       (evaluation, account)
 
     module Checked = struct
-      let%snarkydef check
+      let%snarkydef.Tick check
           ~(constraint_constants : Genesis_constants.Constraint_constants.t)
           shifted ~(epoch_ledger : Epoch_ledger.var) ~block_stake_winner
           ~block_creator ~global_slot ~seed =
@@ -1308,7 +1308,7 @@ module Data = struct
       (min_window_density, next_sub_window_densities)
 
     module Checked = struct
-      let%snarkydef update_min_window_density ~(constants : Constants.var)
+      let%snarkydef.Tick update_min_window_density ~(constants : Constants.var)
           ~prev_global_slot ~next_global_slot ~prev_sub_window_densities
           ~prev_min_window_density =
         (* Please see Min_window_density.update_min_window_density for documentation *)
@@ -2112,7 +2112,7 @@ module Data = struct
       in
       Boolean.not winner_locked
 
-    let%snarkydef update_var (previous_state : var)
+    let%snarkydef_ update_var (previous_state : var)
         (transition_data : Consensus_transition.var)
         (previous_protocol_state_hash : Mina_base.State_hash.var)
         ~(supply_increase : Currency.Amount.Signed.var)
@@ -2129,7 +2129,7 @@ module Data = struct
         Global_slot.Checked.of_slot_number ~constants transition_data
       in
       let%bind slot_diff =
-        [%with_label "Next global slot is less that previous global slot"]
+        [%with_label_ "Next global slot is less that previous global slot"]
           (Global_slot.Checked.sub next_global_slot prev_global_slot)
       in
       let%bind () =
@@ -2188,7 +2188,7 @@ module Data = struct
           supply_increase
       in
       let%bind () =
-        [%with_label "Total currency is greater than or equal to zero"]
+        [%with_label_ "Total currency is greater than or equal to zero"]
           (Boolean.Assert.is_true (Boolean.not overflow))
       in
       let%bind has_ancestor_in_same_checkpoint_window =
@@ -3489,7 +3489,7 @@ module Hooks = struct
       (protocol_state, consensus_transition)
 
     include struct
-      let%snarkydef next_state_checked ~constraint_constants
+      let%snarkydef.Tick next_state_checked ~constraint_constants
           ~(prev_state : Protocol_state.var)
           ~(prev_state_hash : Mina_base.State_hash.var) transition
           supply_increase =

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -1257,7 +1257,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         in
         let sub_flagged_checked =
           let f (x, y) =
-            Snarky_backendless.Checked.map (M.Checked.sub_flagged x y)
+            Tick.Checked.map (M.Checked.sub_flagged x y)
               ~f:(fun (r, `Underflow u) -> (r, u))
           in
           Test_util.checked_to_unchecked (Typ.tuple2 typ typ)

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -343,7 +343,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     let typ : (var, t) Typ.t =
       let (Typ typ) = Field.typ in
       Typ.transport
-        (Typ { typ with check = range_check })
+        (Typ { typ with check = (fun x -> make_checked_ast @@ range_check x) })
         ~there:to_field ~back:of_field
 
     [%%endif]

--- a/src/lib/data_hash_lib/data_hash.ml
+++ b/src/lib/data_hash_lib/data_hash.ml
@@ -73,7 +73,7 @@ struct
       >>| fun x -> (x :> Boolean.var list)
     else Field.Checked.unpack ~length:length_in_bits
 
-  let%snarkydef var_to_bits t =
+  let%snarkydef_ var_to_bits t =
     match t.bits with
     | Some bits ->
         return (bits :> Boolean.var list)

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -209,7 +209,7 @@ module Token_symbol = struct
   let typ : (var, t) Typ.t =
     let (Typ typ) = Field.typ in
     Typ.transport
-      (Typ { typ with check = range_check })
+      (Typ { typ with check = (fun x -> make_checked_ast @@ range_check x) })
       ~there:to_field ~back:of_field
 
   let var_to_input (x : var) = Random_oracle_input.Chunked.packed (x, num_bits)

--- a/src/lib/mina_base/fee_excess.ml
+++ b/src/lib/mina_base/fee_excess.ml
@@ -179,15 +179,15 @@ let to_input_checked { fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } =
 
 let assert_equal_checked (t1 : var) (t2 : var) =
   Checked.all_unit
-    [ [%with_label "fee_token_l"]
+    [ [%with_label_ "fee_token_l"]
         (make_checked (fun () ->
              Token_id.Checked.Assert.equal t1.fee_token_l t2.fee_token_l ) )
-    ; [%with_label "fee_excess_l"]
+    ; [%with_label_ "fee_excess_l"]
         (Fee.Signed.Checked.assert_equal t1.fee_excess_l t2.fee_excess_l)
-    ; [%with_label "fee_token_r"]
+    ; [%with_label_ "fee_token_r"]
         (make_checked (fun () ->
              Token_id.Checked.Assert.equal t1.fee_token_r t2.fee_token_r ) )
-    ; [%with_label "fee_excess_r"]
+    ; [%with_label_ "fee_excess_r"]
         (Fee.Signed.Checked.assert_equal t1.fee_excess_r t2.fee_excess_r)
     ]
 
@@ -245,7 +245,7 @@ let eliminate_fee_excess (fee_token_l, fee_excess_l) (fee_token_m, fee_excess_m)
    This optimisation saves serveral hundred constraints in the proof by not
    unpacking the result of each arithmetic operation.
 *)
-let%snarkydef eliminate_fee_excess_checked (fee_token_l, fee_excess_l)
+let%snarkydef_ eliminate_fee_excess_checked (fee_token_l, fee_excess_l)
     (fee_token_m, fee_excess_m) (fee_token_r, fee_excess_r) =
   let open Tick in
   let open Checked.Let_syntax in
@@ -285,7 +285,7 @@ let%snarkydef eliminate_fee_excess_checked (fee_token_l, fee_excess_l)
     combine (fee_token_r, fee_excess_r) fee_excess_m
   in
   let%map () =
-    [%with_label "Fee excess is eliminated"]
+    [%with_label_ "Fee excess is eliminated"]
       Field.(Checked.Assert.equal (Var.constant zero) fee_excess_m)
   in
   ((fee_token_l, fee_excess_l), (fee_token_r, fee_excess_r))
@@ -413,7 +413,7 @@ let combine
 
 [%%ifdef consensus_mechanism]
 
-let%snarkydef combine_checked
+let%snarkydef_ combine_checked
     { fee_token_l = fee_token1_l
     ; fee_excess_l = fee_excess1_l
     ; fee_token_r = fee_token1_r
@@ -433,7 +433,7 @@ let%snarkydef combine_checked
   (* Eliminations. *)
   let%bind (fee_token1_l, fee_excess1_l), (fee_token2_l, fee_excess2_l) =
     (* [1l; 1r; 2l; 2r] -> [1l; 2l; 2r] *)
-    [%with_label "Eliminate fee_excess1_r"]
+    [%with_label_ "Eliminate fee_excess1_r"]
       (eliminate_fee_excess_checked
          (fee_token1_l, fee_excess1_l)
          (fee_token1_r, fee_excess1_r)
@@ -441,7 +441,7 @@ let%snarkydef combine_checked
   in
   let%bind (fee_token1_l, fee_excess1_l), (fee_token2_r, fee_excess2_r) =
     (* [1l; 2l; 2r] -> [1l; 2r] *)
-    [%with_label "Eliminate fee_excess2_l"]
+    [%with_label_ "Eliminate fee_excess2_l"]
       (eliminate_fee_excess_checked
          (fee_token1_l, fee_excess1_l)
          (fee_token2_l, fee_excess2_l)
@@ -487,18 +487,18 @@ let%snarkydef combine_checked
       Fee.Signed.Checked.to_field_var currency_excess
     in
     let%map () =
-      [%with_label "Fee excess does not overflow"]
+      [%with_label_ "Fee excess does not overflow"]
         (Field.Checked.Assert.equal excess excess_from_currency)
     in
     currency_excess
   in
   (* Convert to currency. *)
   let%bind fee_excess_l =
-    [%with_label "Check for overflow in fee_excess_l"]
+    [%with_label_ "Check for overflow in fee_excess_l"]
       (convert_to_currency fee_excess_l)
   in
   let%map fee_excess_r =
-    [%with_label "Check for overflow in fee_excess_r"]
+    [%with_label_ "Check for overflow in fee_excess_r"]
       (convert_to_currency fee_excess_r)
   in
   { fee_token_l; fee_excess_l; fee_token_r; fee_excess_r }

--- a/src/lib/mina_base/ledger_hash.ml
+++ b/src/lib/mina_base/ledger_hash.ml
@@ -81,7 +81,7 @@ let get ~depth t addr =
    - returns a root [t'] of a tree of depth [depth] which is [t] but with the
      account [f account] at path [addr].
 *)
-let%snarkydef modify_account ~depth t aid
+let%snarkydef_ modify_account ~depth t aid
     ~(filter : Account.var -> 'a Checked.t) ~f =
   let%bind addr =
     request_witness
@@ -104,10 +104,10 @@ let%snarkydef modify_account ~depth t aid
    - returns a root [t'] of a tree of depth [depth] which is [t] but with the
      account [f account] at path [addr].
 *)
-let%snarkydef modify_account_send ~depth t aid ~is_writeable ~f =
+let%snarkydef_ modify_account_send ~depth t aid ~is_writeable ~f =
   modify_account ~depth t aid
     ~filter:(fun account ->
-      [%with_label "modify_account_send filter"]
+      [%with_label_ "modify_account_send filter"]
         (let%bind account_already_there =
            Account_id.Checked.equal (Account.identifier_of_var account) aid
          in
@@ -119,7 +119,7 @@ let%snarkydef modify_account_send ~depth t aid ~is_writeable ~f =
            Boolean.(account_not_there && is_writeable)
          in
          let%bind () =
-           [%with_label "account is either present or empty and writeable"]
+           [%with_label_ "account is either present or empty and writeable"]
              (Boolean.Assert.any
                 [ account_already_there; not_there_but_writeable ] )
          in
@@ -134,10 +134,10 @@ let%snarkydef modify_account_send ~depth t aid ~is_writeable ~f =
    - returns a root [t'] of a tree of depth [depth] which is [t] but with the
      account [f account] at path [addr].
 *)
-let%snarkydef modify_account_recv ~depth t aid ~f =
+let%snarkydef_ modify_account_recv ~depth t aid ~f =
   modify_account ~depth t aid
     ~filter:(fun account ->
-      [%with_label "modify_account_recv filter"]
+      [%with_label_ "modify_account_recv filter"]
         (let%bind account_already_there =
            Account_id.Checked.equal (Account.identifier_of_var account) aid
          in
@@ -146,7 +146,7 @@ let%snarkydef modify_account_recv ~depth t aid ~f =
              Public_key.Compressed.(var_of_t empty)
          in
          let%bind () =
-           [%with_label "account is either present or empty"]
+           [%with_label_ "account is either present or empty"]
              (Boolean.Assert.any [ account_already_there; account_not_there ])
          in
          return account_not_there ) )

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -814,7 +814,7 @@ module T = struct
         (Merkle_tree.get_req ~depth (Hash.var_to_hash_packed t) addr)
         reraise_merkle_requests
 
-    let%snarkydef add_coinbase
+    let%snarkydef_ add_coinbase
         ~(constraint_constants : Genesis_constants.Constraint_constants.t) t
         ({ action; coinbase_amount = amount } : Update.var) ~coinbase_receiver
         ~supercharge_coinbase state_body_hash =
@@ -934,7 +934,7 @@ module T = struct
       in
       Hash.var_of_hash_packed root
 
-    let%snarkydef pop_coinbases
+    let%snarkydef_ pop_coinbases
         ~(constraint_constants : Genesis_constants.Constraint_constants.t) t
         ~proof_emitted =
       let depth = constraint_constants.pending_coinbase_depth in

--- a/src/lib/mina_base/transaction_union_tag.ml
+++ b/src/lib/mina_base/transaction_union_tag.ml
@@ -219,21 +219,22 @@ module Unpacked = struct
                  ; is_user_command
                  } as t ) ->
             let open Checked.Let_syntax in
-            let%bind () = base_typ.check t in
-            let%bind () =
-              [%with_label "Only one tag is set"]
-                (Boolean.Assert.exactly_one
-                   [ is_payment
-                   ; is_stake_delegation
-                   ; is_create_account
-                   ; is_mint_tokens
-                   ; is_fee_transfer
-                   ; is_coinbase
-                   ] )
-            in
-            [%with_label "User command flag is correctly set"]
-              (Boolean.Assert.exactly_one
-                 [ is_user_command; is_fee_transfer; is_coinbase ] ) )
+            make_checked_ast
+            @@ let%bind () = run_checked_ast @@ base_typ.check t in
+               let%bind () =
+                 [%with_label_ "Only one tag is set"]
+                   (Boolean.Assert.exactly_one
+                      [ is_payment
+                      ; is_stake_delegation
+                      ; is_create_account
+                      ; is_mint_tokens
+                      ; is_fee_transfer
+                      ; is_coinbase
+                      ] )
+               in
+               [%with_label_ "User command flag is correctly set"]
+                 (Boolean.Assert.exactly_one
+                    [ is_user_command; is_fee_transfer; is_coinbase ] ) )
       }
 
   let constant

--- a/src/lib/mina_base/zkapp_call_forest.ml
+++ b/src/lib/mina_base/zkapp_call_forest.ml
@@ -73,8 +73,8 @@ module Checked = struct
           (fun ( { account_update = { hash; data = account_update }
                  ; control = _
                  } as x ) ->
-            make_checked (fun () ->
-                run_checked (typ.check x) ;
+            make_checked_ast (fun () ->
+                run_checked_ast (typ.check x) ;
                 Field.Assert.equal
                   (hash :> Field.t)
                   ( Zkapp_command.Call_forest.Digest.Account_update.Checked

--- a/src/lib/mina_numbers/nat.ml
+++ b/src/lib/mina_numbers/nat.ml
@@ -65,7 +65,9 @@ struct
   let typ : (var, N.t) Typ.t =
     let (Typ field_typ) = Field.typ in
     Typ.transport
-      (Typ { field_typ with check = range_check })
+      (Typ
+         { field_typ with check = (fun x -> make_checked_ast @@ range_check x) }
+      )
       ~there:to_field ~back:of_field
 
   let () = assert (N.length_in_bits * 2 < Field.size_in_bits + 1)

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -276,7 +276,7 @@ module Uncompressed = struct
     and () = parity_var y >>= Boolean.Assert.(( = ) is_odd) in
     (x, y)
 
-  let%snarkydef compress_var ((x, y) : var) : Compressed.var Checked.t =
+  let%snarkydef_ compress_var ((x, y) : var) : Compressed.var Checked.t =
     let open Compressed_poly in
     let%map is_odd = parity_var y in
     { Poly.x; is_odd }

--- a/src/lib/pickles/composition_types/branch_data.ml
+++ b/src/lib/pickles/composition_types/branch_data.ml
@@ -124,7 +124,7 @@ module Make_str (A : Wire_types.Concrete) = struct
           ~there:(fun (x : char) -> Field.Constant.of_int (Char.to_int x))
           ~back:(Domain_log2.of_field_exn (module Impl))
       in
-      let check (x : Field.t) = make_checked (fun () -> assert_16_bits x) in
+      let check (x : Field.t) = make_checked_ast (fun () -> assert_16_bits x) in
       Typ { t with check }
     in
     Typ.of_hlistable

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -114,9 +114,10 @@ module Step = struct
         Boolean.( && ) x_eq b_eq
       in
       let (Typ typ_unchecked) = typ_unchecked in
-      let%bind () = typ_unchecked.check t in
-      Checked.List.map forbidden_shifted_values ~f:(equal t)
-      >>= Boolean.any >>| Boolean.not >>= Boolean.Assert.is_true
+      make_checked_ast
+      @@ let%bind () = run_checked_ast @@ typ_unchecked.check t in
+         Checked.List.map forbidden_shifted_values ~f:(equal t)
+         >>= Boolean.any >>| Boolean.not >>= Boolean.Assert.is_true
 
     let typ : _ Snarky_backendless.Typ.t =
       let (Typ typ_unchecked) = typ_unchecked in
@@ -156,7 +157,7 @@ module Step = struct
         (T
            ( Shifted_value.Type2.typ Other_field.typ_unchecked
            , (fun (Shifted_value.Type2.Shifted_value x as t) ->
-               Impl.run_checked (Other_field.check x) ;
+               Impl.run_checked_ast (Other_field.check x) ;
                t )
            , Fn.id ) )
         spec
@@ -238,9 +239,10 @@ module Wrap = struct
         let open Internal_Basic in
         let open Let_syntax in
         let equal x1 x2 = Field.Checked.equal x1 (Field.Var.constant x2) in
-        let%bind () = t0.check t in
-        Checked.List.map forbidden_shifted_values ~f:(equal t)
-        >>= Boolean.any >>| Boolean.not >>= Boolean.Assert.is_true
+        make_checked_ast
+        @@ let%bind () = run_checked_ast @@ t0.check t in
+           Checked.List.map forbidden_shifted_values ~f:(equal t)
+           >>= Boolean.any >>| Boolean.not >>= Boolean.Assert.is_true
       in
       (typ_unchecked, check)
 
@@ -277,7 +279,7 @@ module Wrap = struct
         (T
            ( Shifted_value.Type1.typ fp
            , (fun (Shifted_value x as t) ->
-               Impl.run_checked (Other_field.check x) ;
+               Impl.run_checked_ast (Other_field.check x) ;
                t )
            , Fn.id ) )
         (In_circuit.spec (module Impl) lookup)

--- a/src/lib/pickles/one_hot_vector/one_hot_vector.ml
+++ b/src/lib/pickles/one_hot_vector/one_hot_vector.ml
@@ -33,9 +33,12 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
         { typ with
           check =
             (fun x ->
-              Impl.Internal_Basic.Checked.bind (typ.check x) ~f:(fun () ->
-                  make_checked (fun () ->
-                      Boolean.Assert.exactly_one (Vector.to_list x) ) ) )
+              Impl.Internal_Basic.make_checked_ast
+              @@ Impl.Internal_Basic.Checked.bind
+                   (Impl.Internal_Basic.run_checked_ast @@ typ.check x)
+                   ~f:(fun () ->
+                     make_checked (fun () ->
+                         Boolean.Assert.exactly_one (Vector.to_list x) ) ) )
         }
     in
     Typ.transport typ

--- a/src/lib/pickles/one_hot_vector/one_hot_vector.ml
+++ b/src/lib/pickles/one_hot_vector/one_hot_vector.ml
@@ -33,7 +33,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
         { typ with
           check =
             (fun x ->
-              Snarky_backendless.Checked.bind (typ.check x) ~f:(fun () ->
+              Impl.Internal_Basic.Checked.bind (typ.check x) ~f:(fun () ->
                   make_checked (fun () ->
                       Boolean.Assert.exactly_one (Vector.to_list x) ) ) )
         }

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -357,11 +357,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
       let log =
         let weight =
           let sys = Backend.Tick.R1CS_constraint_system.create () in
-          fun (c : Impls.Step.Constraint.t) ->
+          fun ({ annotation; basic } : Impls.Step.Constraint.t) ->
             let prev = sys.next_row in
-            List.iter c ~f:(fun { annotation; basic } ->
-                Backend.Tick.R1CS_constraint_system.add_constraint sys
-                  ?label:annotation basic ) ;
+            Backend.Tick.R1CS_constraint_system.add_constraint sys
+              ?label:annotation basic ;
             let next = sys.next_row in
             next - prev
         in
@@ -374,11 +373,10 @@ module Make_str (_ : Wire_types.Concrete) = struct
       let module Constraints = Snarky_log.Constraints (Impls.Wrap.Internal_Basic) in
       let log =
         let sys = Backend.Tock.R1CS_constraint_system.create () in
-        let weight (c : Impls.Wrap.Constraint.t) =
+        let weight ({ annotation; basic } : Impls.Wrap.Constraint.t) =
           let prev = sys.next_row in
-          List.iter c ~f:(fun { annotation; basic } ->
-              Backend.Tock.R1CS_constraint_system.add_constraint sys
-                ?label:annotation basic ) ;
+          Backend.Tock.R1CS_constraint_system.add_constraint sys
+            ?label:annotation basic ;
           let next = sys.next_row in
           next - prev
         in

--- a/src/lib/pickles/plonk_curve_ops.ml
+++ b/src/lib/pickles/plonk_curve_ops.ml
@@ -45,13 +45,12 @@ let add_fast (type f)
   let p3 = (x3, y3) in
   with_label "add_fast" (fun () ->
       assert_
-        [ { annotation = Some __LOC__
-          ; basic =
-              Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-                (EC_add_complete
-                   { p1; p2; p3; inf; same_x; slope = s; inf_z; x21_inv } )
-          }
-        ] ;
+        { annotation = Some __LOC__
+        ; basic =
+            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+              (EC_add_complete
+                 { p1; p2; p3; inf; same_x; slope = s; inf_z; x21_inv } )
+        } ;
       p3 )
 
 module Make
@@ -126,12 +125,11 @@ struct
         :: !rounds_rev
     done ;
     assert_
-      [ { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (EC_scale { state = Array.of_list_rev !rounds_rev })
-        }
-      ] ;
+      { annotation = Some __LOC__
+      ; basic =
+          Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+            (EC_scale { state = Array.of_list_rev !rounds_rev })
+      } ;
     (* TODO: Return n_acc ? *)
     !acc
 
@@ -202,12 +200,11 @@ struct
         :: !rounds_rev
     done ;
     assert_
-      [ { annotation = Some __LOC__
-        ; basic =
-            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
-              (EC_scale { state = Array.of_list_rev !rounds_rev })
-        }
-      ] ;
+      { annotation = Some __LOC__
+      ; basic =
+          Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
+            (EC_scale { state = Array.of_list_rev !rounds_rev })
+      } ;
     Field.Assert.equal !n_acc scalar ;
     let bits_lsb =
       let bs = Array.map bits_msb ~f:Boolean.Unsafe.of_cvar in

--- a/src/lib/pickles/scalar_challenge.ml
+++ b/src/lib/pickles/scalar_challenge.ml
@@ -120,12 +120,11 @@ let to_field_checked' (type f) ?(num_bits = num_bits)
   done ;
   with_label __LOC__ (fun () ->
       assert_
-        [ { annotation = Some __LOC__
-          ; basic =
-              Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.(
-                T (EC_endoscalar { state = Array.of_list_rev !state }))
-          }
-        ] ) ;
+        { annotation = Some __LOC__
+        ; basic =
+            Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.(
+              T (EC_endoscalar { state = Array.of_list_rev !state }))
+        } ) ;
   (!a, !b, !n)
 
 let to_field_checked (type f) ?num_bits
@@ -287,18 +286,17 @@ struct
     let xs, ys = !acc in
     with_label __LOC__ (fun () ->
         assert_
-          [ { annotation = Some __LOC__
-            ; basic =
-                Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.(
-                  T
-                    (EC_endoscale
-                       { xs
-                       ; ys
-                       ; n_acc = !n_acc
-                       ; state = Array.of_list_rev !rounds_rev
-                       } ))
-            }
-          ] ) ;
+          { annotation = Some __LOC__
+          ; basic =
+              Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.(
+                T
+                  (EC_endoscale
+                     { xs
+                     ; ys
+                     ; n_acc = !n_acc
+                     ; state = Array.of_list_rev !rounds_rev
+                     } ))
+          } ) ;
     with_label __LOC__ (fun () -> Field.Assert.equal !n_acc scalar) ;
     !acc
 

--- a/src/lib/pickles/sponge_inputs.ml
+++ b/src/lib/pickles/sponge_inputs.ml
@@ -57,10 +57,9 @@ struct
         (let open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint in
         with_label __LOC__ (fun () ->
             Impl.assert_
-              [ { basic = T (Poseidon { state = t })
-                ; annotation = Some "plonk-poseidon"
-                }
-              ] )) ;
+              { basic = T (Poseidon { state = t })
+              ; annotation = Some "plonk-poseidon"
+              } )) ;
         t.(Int.(Array.length t - 1)) )
 
   let add_assign ~state i x =

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -745,18 +745,17 @@ struct
                 (* 0 = - acc' + y + pt_n_acc *)
                 let open Field.Constant in
                 assert_
-                  [ { annotation = None
-                    ; basic =
-                        T
-                          (Basic
-                             { l = (one, y)
-                             ; r = (one, pt_n_acc)
-                             ; o = (negate one, acc')
-                             ; m = zero
-                             ; c = zero
-                             } )
-                    }
-                  ] ;
+                  { annotation = None
+                  ; basic =
+                      T
+                        (Basic
+                           { l = (one, y)
+                           ; r = (one, pt_n_acc)
+                           ; o = (negate one, acc')
+                           ; m = zero
+                           ; c = zero
+                           } )
+                  } ;
                 acc' )
         | [] ->
             failwith "empty list" )

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -127,7 +127,7 @@ module Opt = struct
         (* No need to boolean constrain in the No or Yes case *)
         match flag with
         | No | Yes ->
-            fun _ -> Checked.return ()
+            fun _ -> Checked_ast.return ()
         | Maybe ->
             bool_typ.check
       in

--- a/src/lib/sgn/sgn.ml
+++ b/src/lib/sgn/sgn.ml
@@ -35,7 +35,9 @@ type var = Field.Var.t
 let typ : (var, t) Typ.t =
   let open Typ in
   Typ
-    { check = (fun x -> assert_r1cs x x (Field.Var.constant Field.one))
+    { check =
+        (fun x ->
+          make_checked_ast @@ assert_r1cs x x (Field.Var.constant Field.one) )
     ; var_to_fields = (fun t -> ([| t |], ()))
     ; var_of_fields = (fun (ts, ()) -> ts.(0))
     ; value_to_fields = (fun t -> ([| to_field t |], ()))

--- a/src/lib/signature_lib/schnorr.ml
+++ b/src/lib/signature_lib/schnorr.ml
@@ -298,7 +298,7 @@ module Make
     (* returning r_point as a representable point ensures it is nonzero so the nonzero
      * check does not have to explicitly be performed *)
 
-    let%snarkydef verifier (type s) ~equal ~final_check
+    let%snarkydef_ verifier (type s) ~equal ~final_check
         ((module Shifted) as shifted :
           (module Curve.Checked.Shifted.S with type t = s) )
         ((r, s) : Signature.var) (public_key : Public_key.var) (m : Message.var)
@@ -553,7 +553,7 @@ module Message = struct
 
     type var = (Field.Var.t, Boolean.var) Random_oracle.Input.Legacy.t
 
-    let%snarkydef hash_checked t ~public_key ~r =
+    let%snarkydef_ hash_checked t ~public_key ~r =
       let input =
         let px, py = public_key in
         Random_oracle.Input.Legacy.append t
@@ -621,7 +621,7 @@ module Message = struct
 
     type var = Field.Var.t Random_oracle.Input.Chunked.t
 
-    let%snarkydef hash_checked t ~public_key ~r =
+    let%snarkydef_ hash_checked t ~public_key ~r =
       let input =
         let px, py = public_key in
         Random_oracle.Input.Chunked.append t
@@ -674,7 +674,7 @@ let chunked_message_typ () : (Message.Chunked.var, Message.Chunked.t) Tick.Typ.t
   let open Tick.Typ in
   let const_typ =
     Typ
-      { check = (fun _ -> Tick.Checked.return ())
+      { check = (fun _ -> Tick.make_checked_ast @@ Tick.Checked.return ())
       ; var_to_fields = (fun t -> ([||], t))
       ; var_of_fields = (fun (_, t) -> t)
       ; value_to_fields = (fun t -> ([||], t))

--- a/src/lib/snark_bits/bits.ml
+++ b/src/lib/snark_bits/bits.ml
@@ -266,22 +266,22 @@ module Snarkable = struct
     let compare_var x y =
       Impl.Field.Checked.compare ~bit_length:V.length (pack_var x) (pack_var y)
 
-    let%snarkydef increment_if_var bs (b : Boolean.var) =
+    let%snarkydef_ increment_if_var bs (b : Boolean.var) =
       let open Impl in
       let v = Field.Var.pack bs in
       let v' = Field.Var.add v (b :> Field.Var.t) in
       Field.Checked.unpack v' ~length:V.length
 
-    let%snarkydef increment_var bs =
+    let%snarkydef_ increment_var bs =
       let open Impl in
       let v = Field.Var.pack bs in
       let v' = Field.Var.add v (Field.Var.constant Field.one) in
       Field.Checked.unpack v' ~length:V.length
 
-    let%snarkydef equal_var (n : Unpacked.var) (n' : Unpacked.var) =
+    let%snarkydef_ equal_var (n : Unpacked.var) (n' : Unpacked.var) =
       Field.Checked.equal (pack_var n) (pack_var n')
 
-    let%snarkydef assert_equal_var (n : Unpacked.var) (n' : Unpacked.var) =
+    let%snarkydef_ assert_equal_var (n : Unpacked.var) (n' : Unpacked.var) =
       Field.Checked.Assert.equal (pack_var n) (pack_var n')
 
     let if_ (cond : Boolean.var) ~(then_ : Unpacked.var) ~(else_ : Unpacked.var)

--- a/src/lib/snarky_curves/snarky_curves.ml
+++ b/src/lib/snarky_curves/snarky_curves.ml
@@ -164,7 +164,8 @@ module Make_weierstrass_checked
         Typ.(tuple2 F.typ F.typ)
         ~there:Curve.to_affine_exn ~back:Curve.of_affine
     in
-    Typ { unchecked with check = assert_on_curve }
+    Typ
+      { unchecked with check = (fun x -> make_checked_ast (assert_on_curve x)) }
 
   let negate ((x, y) : t) : t = (x, F.negate y)
 
@@ -184,7 +185,7 @@ module Make_weierstrass_checked
 
   open Let_syntax
 
-  let%snarkydef add' ~div (ax, ay) (bx, by) =
+  let%snarkydef_ add' ~div (ax, ay) (bx, by) =
     let open F in
     let%bind lambda = div (by - ay) (bx - ax) in
     let%bind cx =
@@ -274,7 +275,7 @@ module Make_weierstrass_checked
       (module M : S)
   end
 
-  let%snarkydef double (ax, ay) =
+  let%snarkydef_ double (ax, ay) =
     let open F in
     let%bind x_squared = square ax in
     let%bind lambda =
@@ -323,7 +324,7 @@ module Make_weierstrass_checked
     in
     (choose x1 x2, choose y1 y2)
 
-  let%snarkydef scale (type shifted)
+  let%snarkydef_ scale (type shifted)
       (module Shifted : Shifted.S with type t = shifted) t
       (c : Boolean.var Bitstring_lib.Bitstring.Lsb_first.t) ~(init : shifted) :
       shifted Checked.t =

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -41,7 +41,6 @@ let%test_module "account timing check" =
     let run_checked_timing_and_compare account txn_amount txn_global_slot
         unchecked_timing unchecked_min_balance =
       let equal_balances_computation =
-        let open Snarky_backendless.Checked in
         let%bind checked_timing =
           make_checked_timing_computation account txn_amount txn_global_slot
         in

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -33,12 +33,12 @@ let%test_module "multisig_account" =
             let open Checked in
             Checked.List.map ~f:(fun (_, pk') -> neq_pk pk pk') xs
             >>= fun bs ->
-            [%with_label __LOC__]
+            [%with_label_ __LOC__]
               (Boolean.Assert.all bs >>= fun () -> distinct_public_keys xs)
         | [] ->
             Checked.return ()
 
-      let%snarkydef distinct_public_keys x = distinct_public_keys x
+      let%snarkydef_ distinct_public_keys x = distinct_public_keys x
 
       (* check a signature on msg against a public key *)
       let check_sig pk msg sigma : Boolean.var Checked.t =
@@ -46,7 +46,7 @@ let%test_module "multisig_account" =
         Schnorr.Chunked.Checked.verifies (module S) sigma pk msg
 
       (* verify witness signatures against public keys *)
-      let%snarkydef verify_sigs pubkeys commitment witness =
+      let%snarkydef_ verify_sigs pubkeys commitment witness =
         let%bind pubkeys =
           exists
             (Typ.list ~length:(List.length pubkeys) Inner_curve.typ)
@@ -59,7 +59,7 @@ let%test_module "multisig_account" =
               |> Checked.List.all >>= Boolean.all )
         in
         Checked.List.map witness ~f:verify_sig
-        >>= fun bs -> [%with_label __LOC__] (Boolean.Assert.all bs)
+        >>= fun bs -> [%with_label_ __LOC__] (Boolean.Assert.all bs)
 
       let check_witness m pubkeys commitment witness =
         if List.length witness <> m then

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -18,7 +18,7 @@ let check_sig pk msg sigma : Boolean.var Checked.t =
   Schnorr.Chunked.Checked.verifies (module S) sigma pk msg
 
 (* verify witness signature against public keys *)
-let%snarkydef verify_sig pubkeys msg sigma =
+let%snarkydef_ verify_sig pubkeys msg sigma =
   let%bind pubkeys =
     exists
       (Typ.list ~length:(List.length pubkeys) Inner_curve.typ)

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -753,7 +753,7 @@ module Base = struct
           | Mint_tokens | Create_account ->
               assert false )
 
-    let%snarkydef compute_as_prover ~constraint_constants ~txn_global_slot
+    let%snarkydef_ compute_as_prover ~constraint_constants ~txn_global_slot
         (txn : Transaction_union.var) =
       let%bind data =
         exists (Typ.Internal.ref ())
@@ -841,7 +841,7 @@ module Base = struct
               ~fee_payer_account ~source_account ~receiver_account txn)
   end
 
-  let%snarkydef check_signature shifted ~payload ~is_user_command ~signer
+  let%snarkydef_ check_signature shifted ~payload ~is_user_command ~signer
       ~signature =
     let%bind input =
       Transaction_union_payload.Checked.to_input_legacy payload
@@ -849,7 +849,7 @@ module Base = struct
     let%bind verifies =
       Schnorr.Legacy.Checked.verifies shifted signature signer input
     in
-    [%with_label "check signature"]
+    [%with_label_ "check signature"]
       (Boolean.Assert.any [ Boolean.not is_user_command; verifies ])
 
   let check_timing ~balance_check ~timed_balance_check ~account ~txn_amount
@@ -1227,7 +1227,7 @@ module Base = struct
           in
           let `Min_balance _, timing =
             run_checked
-            @@ [%with_label "Check zkapp timing"]
+            @@ [%with_label.Snark_params.Tick "Check zkapp timing"]
                  (check_timing ~balance_check ~timed_balance_check ~account
                     ~txn_amount:None ~txn_global_slot )
           in
@@ -1987,7 +1987,7 @@ module Base = struct
     let check_protocol_state ~pending_coinbase_stack_init
         ~pending_coinbase_stack_before ~pending_coinbase_stack_after state_body
         =
-      [%with_label "Compute pending coinbase stack"]
+      [%with_label_ "Compute pending coinbase stack"]
         (let%bind state_body_hash =
            Mina_state.Protocol_state.Body.hash_checked state_body
          in
@@ -1995,7 +1995,7 @@ module Base = struct
            Pending_coinbase.Stack.Checked.push_state state_body_hash
              pending_coinbase_stack_init
          in
-         [%with_label "Check pending coinbase stack"]
+         [%with_label_ "Check pending coinbase stack"]
            (let%bind correct_coinbase_target_stack =
               Pending_coinbase.Stack.equal_var
                 computed_pending_coinbase_stack_after
@@ -2304,7 +2304,7 @@ module Base = struct
         Mina_state.Protocol_state.Body.Value.t Snarky_backendless.Request.t
     | Init_stack : Pending_coinbase.Stack.t Snarky_backendless.Request.t
 
-  let%snarkydef add_burned_tokens acc_burned_tokens amount
+  let%snarkydef_ add_burned_tokens acc_burned_tokens amount
       ~is_coinbase_or_fee_transfer ~update_account =
     let%bind accumulate_burned_tokens =
       Boolean.all [ is_coinbase_or_fee_transfer; Boolean.not update_account ]
@@ -2318,7 +2318,7 @@ module Base = struct
     Amount.Checked.if_ accumulate_burned_tokens ~then_:amt
       ~else_:acc_burned_tokens
 
-  let%snarkydef apply_tagged_transaction
+  let%snarkydef_ apply_tagged_transaction
       ~(constraint_constants : Genesis_constants.Constraint_constants.t)
       (type shifted)
       (shifted : (module Inner_curve.Checked.Shifted.S with type t = shifted))
@@ -2328,12 +2328,12 @@ module Base = struct
     let tag = payload.body.tag in
     let is_user_command = Transaction_union.Tag.Unpacked.is_user_command tag in
     let%bind () =
-      [%with_label "Check transaction signature"]
+      [%with_label_ "Check transaction signature"]
         (check_signature shifted ~payload ~is_user_command ~signer ~signature)
     in
     let%bind signer_pk = Public_key.compress_var signer in
     let%bind () =
-      [%with_label "Fee-payer must sign the transaction"]
+      [%with_label_ "Fee-payer must sign the transaction"]
         ((* TODO: Enable multi-sig. *)
          Public_key.Compressed.Checked.Assert.equal signer_pk
            payload.common.fee_payer_pk )
@@ -2361,11 +2361,11 @@ module Base = struct
     in
     let%bind () =
       Checked.all_unit
-        [ [%with_label
+        [ [%with_label_
             "Token_locked value is compatible with the transaction kind"]
             (Boolean.Assert.any
                [ Boolean.not payload.body.token_locked; is_create_account ] )
-        ; [%with_label "Token_locked cannot be used with the default token"]
+        ; [%with_label_ "Token_locked cannot be used with the default token"]
             (Boolean.Assert.any
                [ Boolean.not payload.body.token_locked
                ; Boolean.not token_default
@@ -2374,9 +2374,9 @@ module Base = struct
     in
     let%bind () = Boolean.Assert.is_true token_default in
     let%bind () =
-      [%with_label "Validate tokens"]
+      [%with_label_ "Validate tokens"]
         (Checked.all_unit
-           [ [%with_label
+           [ [%with_label_
                "Fee token is default or command allows non-default fee"]
                (Boolean.Assert.any
                   [ fee_token_default
@@ -2387,9 +2387,9 @@ module Base = struct
            ; (* TODO: Remove this check and update the transaction snark once we
                 have an exchange rate mechanism. See issue #4447.
              *)
-             [%with_label "Fees in tokens disabled"]
+             [%with_label_ "Fees in tokens disabled"]
                (Boolean.Assert.is_true fee_token_default)
-           ; [%with_label "Command allows default token"]
+           ; [%with_label_ "Command allows default token"]
                Boolean.(
                  Assert.any
                    [ is_payment
@@ -2421,7 +2421,7 @@ module Base = struct
       Account_id.Checked.create payload.common.fee_payer_pk fee_token
     in
     let%bind () =
-      [%with_label "Check slot validity"]
+      [%with_label_ "Check slot validity"]
         ( Global_slot.Checked.(current_global_slot <= payload.common.valid_until)
         >>= Boolean.Assert.is_true )
     in
@@ -2456,7 +2456,7 @@ module Base = struct
          i + coinbase    i + state + coinbase    i + state + coinbase
     *)
     let%bind () =
-      [%with_label "Compute coinbase stack"]
+      [%with_label_ "Compute coinbase stack"]
         (let%bind state_body_hash =
            Mina_state.Protocol_state.Body.hash_checked state_body
          in
@@ -2475,7 +2475,7 @@ module Base = struct
            Pending_coinbase.Stack.Checked.if_ is_coinbase ~then_:stack'
              ~else_:pending_coinbase_stack_with_state
          in
-         [%with_label "Check coinbase stack"]
+         [%with_label_ "Check coinbase stack"]
            (let%bind correct_coinbase_target_stack =
               Pending_coinbase.Stack.equal_var
                 computed_pending_coinbase_stack_after pending_coinbase_after
@@ -2492,7 +2492,7 @@ module Base = struct
               in
               Boolean.(equal_source ||| equal_source_with_state)
             in
-            [%with_label "target stack and valid init state"]
+            [%with_label_ "target stack and valid init state"]
               (Boolean.Assert.all
                  [ correct_coinbase_target_stack; valid_init_state ] ) ) )
     in
@@ -2501,7 +2501,7 @@ module Base = struct
        consistency.
     *)
     let%bind () =
-      [%with_label "A failing user command is a user command"]
+      [%with_label_ "A failing user command is a user command"]
         Boolean.(Assert.any [ is_user_command; not user_command_fails ])
     in
     let predicate_deferred =
@@ -2520,7 +2520,7 @@ module Base = struct
       Boolean.(is_own_account ||| predicate_result)
     in
     let%bind () =
-      [%with_label "Check account_precondition failure against predicted"]
+      [%with_label_ "Check account_precondition failure against predicted"]
         (let%bind predicate_failed =
            Boolean.((not predicate_result) &&& not predicate_deferred)
          in
@@ -2549,7 +2549,7 @@ module Base = struct
     in
     let burned_tokens = ref Currency.Amount.(var_of_t zero) in
     let%bind root_after_fee_payer_update =
-      [%with_label "Update fee payer"]
+      [%with_label_ "Update fee payer"]
         (Frozen_ledger_hash.modify_account_send
            ~depth:constraint_constants.ledger_depth root
            ~is_writeable:can_create_fee_payer_account fee_payer
@@ -2566,7 +2566,7 @@ module Base = struct
                Account.Nonce.Checked.succ_if account.nonce is_user_command
              in
              let%bind () =
-               [%with_label "Check fee nonce"]
+               [%with_label_ "Check fee nonce"]
                  (let%bind nonce_matches =
                     Account.Nonce.Checked.equal nonce account.nonce
                   in
@@ -2589,7 +2589,7 @@ module Base = struct
                Account.Checked.has_permission ~to_:`Receive account
              in
              let%bind () =
-               [%with_label
+               [%with_label_
                  "Fee payer balance update should be permitted for all commands"]
                  (Boolean.Assert.any
                     [ Boolean.not is_user_command; permitted_to_send ] )
@@ -2621,7 +2621,7 @@ module Base = struct
                Boolean.(is_empty_and_writeable ||| is_create_account)
              in
              let%bind amount =
-               [%with_label "Compute fee payer amount"]
+               [%with_label_ "Compute fee payer amount"]
                  (let fee_payer_amount =
                     let sgn = Sgn.Checked.neg_if_true is_user_command in
                     Amount.Signed.create_var
@@ -2641,7 +2641,7 @@ module Base = struct
                     add fee_payer_amount account_creation_fee) )
              in
              let%bind () =
-               [%with_label "Burned tokens in fee payer"]
+               [%with_label_ "Burned tokens in fee payer"]
                  (let%map amt =
                     add_burned_tokens !burned_tokens
                       (Amount.Checked.of_fee fee)
@@ -2651,7 +2651,7 @@ module Base = struct
              in
              let txn_global_slot = current_global_slot in
              let%bind timing =
-               [%with_label "Check fee payer timing"]
+               [%with_label_ "Check fee payer timing"]
                  (let%bind txn_amount =
                     let%bind sgn = Amount.Signed.Checked.sgn amount in
                     let%bind magnitude =
@@ -2661,11 +2661,11 @@ module Base = struct
                       ~else_:Amount.(var_of_t zero)
                   in
                   let balance_check ok =
-                    [%with_label "Check fee payer balance"]
+                    [%with_label_ "Check fee payer balance"]
                       (Boolean.Assert.is_true ok)
                   in
                   let timed_balance_check ok =
-                    [%with_label "Check fee payer timed balance"]
+                    [%with_label_ "Check fee payer timed balance"]
                       (Boolean.Assert.is_true ok)
                   in
                   let%bind `Min_balance _, timing =
@@ -2676,7 +2676,7 @@ module Base = struct
                     ~else_:account.timing )
              in
              let%bind balance =
-               [%with_label "Check payer balance"]
+               [%with_label_ "Check payer balance"]
                  (let%bind updated_balance =
                     Balance.Checked.add_signed_amount account.balance amount
                   in
@@ -2720,7 +2720,7 @@ module Base = struct
          - coinbase:         payload.body.amount - payload.common.fee
          - fee transfer:     payload.body.amount
       *)
-      [%with_label "Compute receiver increase"]
+      [%with_label_ "Compute receiver increase"]
         (let%bind base_amount =
            let%bind zero_transfer =
              Boolean.any [ is_stake_delegation; is_create_account ]
@@ -2740,7 +2740,7 @@ module Base = struct
     let receiver_overflow = ref Boolean.false_ in
     let receiver_balance_update_permitted = ref Boolean.true_ in
     let%bind root_after_receiver_update =
-      [%with_label "Update receiver"]
+      [%with_label_ "Update receiver"]
         (Frozen_ledger_hash.modify_account_recv
            ~depth:constraint_constants.ledger_depth root_after_fee_payer_update
            receiver ~f:(fun ~is_empty_and_writeable account ->
@@ -2773,7 +2773,7 @@ module Base = struct
                Boolean.(is_empty_and_writeable &&& must_not_be_empty)
              in
              let%bind () =
-               [%with_label "Receiver existence failure matches predicted"]
+               [%with_label_ "Receiver existence failure matches predicted"]
                  (Boolean.Assert.( = ) is_empty_failure
                     user_command_failure.receiver_not_present )
              in
@@ -2784,7 +2784,7 @@ module Base = struct
                Boolean.(is_empty_and_writeable &&& not is_create_account)
              in
              let%bind () =
-               [%with_label
+               [%with_label_
                  "Check whether creation fails due to a non-default token"]
                  (let%bind token_should_not_create =
                     Boolean.(should_pay_to_create &&& Boolean.not token_default)
@@ -2793,7 +2793,7 @@ module Base = struct
                     Boolean.(token_should_not_create &&& is_user_command)
                   in
                   let%bind () =
-                    [%with_label
+                    [%with_label_
                       "Check that account creation is paid in the default \
                        token for non-user-commands"]
                       ((* This expands to
@@ -2808,7 +2808,7 @@ module Base = struct
                        Boolean.Assert.( = ) token_should_not_create
                          token_cannot_create )
                   in
-                  [%with_label "equal token_cannot_create"]
+                  [%with_label_ "equal token_cannot_create"]
                     (Boolean.Assert.( = ) token_cannot_create
                        user_command_failure.token_cannot_create ) )
              in
@@ -2827,7 +2827,7 @@ module Base = struct
                      account_creation_amount
                  in
                  let%bind () =
-                   [%with_label
+                   [%with_label_
                      "Receiver creation fee failure matches predicted"]
                      (Boolean.Assert.( = ) underflow
                         user_command_failure.amount_insufficient_to_create )
@@ -2856,7 +2856,7 @@ module Base = struct
                    receiver_amount
                in
                let%bind () =
-                 [%with_label "Overflow error only occurs in user commands"]
+                 [%with_label_ "Overflow error only occurs in user commands"]
                    Boolean.(Assert.any [ is_user_command; not overflow ])
                in
                receiver_overflow := overflow ;
@@ -2864,7 +2864,7 @@ module Base = struct
                  ~else_:balance
              in
              let%bind () =
-               [%with_label "Burned tokens in receiver"]
+               [%with_label_ "Burned tokens in receiver"]
                  (let%map amt =
                     add_burned_tokens !burned_tokens receiver_increase
                       ~is_coinbase_or_fee_transfer
@@ -2933,7 +2933,7 @@ module Base = struct
     in
     let%bind fee_payer_is_source = Account_id.Checked.equal fee_payer source in
     let%bind root_after_source_update =
-      [%with_label "Update source"]
+      [%with_label_ "Update source"]
         (Frozen_ledger_hash.modify_account_send
            ~depth:constraint_constants.ledger_depth
            ~is_writeable:
@@ -2949,12 +2949,12 @@ module Base = struct
                 - the second receiver for a fee transfer
              *)
              let%bind () =
-               [%with_label "Check source presence failure matches predicted"]
+               [%with_label_ "Check source presence failure matches predicted"]
                  (Boolean.Assert.( = ) is_empty_and_writeable
                     user_command_failure.source_not_present )
              in
              let%bind () =
-               [%with_label
+               [%with_label_
                  "Check source failure cases do not apply when fee-payer is \
                   source"]
                  (let num_failures =
@@ -2972,7 +2972,7 @@ module Base = struct
                      else
                        num_failures = num_failures
                   *)
-                  [%with_label "Check num_failures"]
+                  [%with_label_ "Check num_failures"]
                     (assert_r1cs not_fee_payer_is_source num_failures
                        num_failures ) )
              in
@@ -3015,16 +3015,16 @@ module Base = struct
              in
              let txn_global_slot = current_global_slot in
              let%bind timing =
-               [%with_label "Check source timing"]
+               [%with_label_ "Check source timing"]
                  (let balance_check ok =
-                    [%with_label
+                    [%with_label_
                       "Check source balance failure matches predicted"]
                       (Boolean.Assert.( = ) ok
                          (Boolean.not
                             user_command_failure.source_insufficient_balance ) )
                   in
                   let timed_balance_check ok =
-                    [%with_label
+                    [%with_label_
                       "Check source timed balance failure matches predicted"]
                       (let%bind not_ok =
                          Boolean.(
@@ -3050,7 +3050,7 @@ module Base = struct
                (* TODO: Remove the redundancy in balance calculation between
                   here and [check_timing].
                *)
-               [%with_label "Check source balance failure matches predicted"]
+               [%with_label_ "Check source balance failure matches predicted"]
                  (Boolean.Assert.( = ) underflow
                     user_command_failure.source_insufficient_balance )
              in
@@ -3105,7 +3105,7 @@ module Base = struct
            in
            let%bind () =
              (* TODO: Reject this in txn pool before fees-in-tokens. *)
-             [%with_label "Fee excess does not overflow"]
+             [%with_label_ "Fee excess does not overflow"]
                Boolean.(
                  Assert.any
                    [ not is_fee_transfer; not fee_transfer_excess_overflowed ])
@@ -3114,7 +3114,7 @@ module Base = struct
              ~else_:user_command_excess )
     in
     let%bind supply_increase =
-      [%with_label "Calculate supply increase"]
+      [%with_label_ "Calculate supply increase"]
         (let%bind expected_supply_increase =
            Amount.Signed.Checked.if_ is_coinbase
              ~then_:(Amount.Signed.Checked.of_unsigned payload.body.amount)
@@ -3159,7 +3159,7 @@ module Base = struct
         supply_increase : Amount.Signed.t
         pc: Pending_coinbase_stack_state.t
   *)
-  let%snarkydef main ~constraint_constants
+  let%snarkydef_ main ~constraint_constants
       (statement : Statement.With_sok.Checked.t) =
     let%bind () = dummy_constraints () in
     let%bind (module Shifted) = Tick.Inner_curve.Checked.Shifted.create () in
@@ -3205,18 +3205,18 @@ module Base = struct
       }
     in
     let%bind () =
-      [%with_label "local state check"]
+      [%with_label_ "local state check"]
         (make_checked (fun () ->
              Local_state.Checked.assert_equal statement.source.local_state
                statement.target.local_state ) )
     in
     Checked.all_unit
-      [ [%with_label "equal roots"]
+      [ [%with_label_ "equal roots"]
           (Frozen_ledger_hash.assert_equal root_after statement.target.ledger)
-      ; [%with_label "equal supply_increases"]
+      ; [%with_label_ "equal supply_increases"]
           (Currency.Amount.Signed.Checked.assert_equal supply_increase
              statement.supply_increase )
-      ; [%with_label "equal fee excesses"]
+      ; [%with_label_ "equal fee excesses"]
           (Fee_excess.assert_equal_checked fee_excess statement.fee_excess)
       ]
 
@@ -3291,7 +3291,7 @@ module Merge = struct
      verify_transition tock_vk _ s1 s2 pending_coinbase_stack12.source, pending_coinbase_stack12.target is true
      verify_transition tock_vk _ s2 s3 pending_coinbase_stack23.source, pending_coinbase_stack23.target is true
   *)
-  let%snarkydef main (s : Statement.With_sok.Checked.t) =
+  let%snarkydef_ main (s : Statement.With_sok.Checked.t) =
     let%bind s1, s2 =
       exists
         Typ.(Statement.With_sok.typ * Statement.With_sok.typ)
@@ -3325,16 +3325,16 @@ module Merge = struct
     in
     let%map () =
       Checked.all_unit
-        [ [%with_label "equal fee excesses"]
+        [ [%with_label_ "equal fee excesses"]
             (Fee_excess.assert_equal_checked fee_excess s.fee_excess)
-        ; [%with_label "equal supply increases"]
+        ; [%with_label_ "equal supply increases"]
             (Amount.Signed.Checked.assert_equal supply_increase
                s.supply_increase )
-        ; [%with_label "equal source ledger hashes"]
+        ; [%with_label_ "equal source ledger hashes"]
             (Frozen_ledger_hash.assert_equal s.source.ledger s1.source.ledger)
-        ; [%with_label "equal target, source ledger hashes"]
+        ; [%with_label_ "equal target, source ledger hashes"]
             (Frozen_ledger_hash.assert_equal s1.target.ledger s2.source.ledger)
-        ; [%with_label "equal target ledger hashes"]
+        ; [%with_label_ "equal target ledger hashes"]
             (Frozen_ledger_hash.assert_equal s2.target.ledger s.target.ledger)
         ]
     in


### PR DESCRIPTION
This PR is a companion to https://github.com/o1-labs/snarky/pull/650 https://github.com/o1-labs/snarky/pull/651 and https://github.com/o1-labs/snarky/pull/652, which make various small changes to simplify snarky, to ease the porting over to rust.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them