### PR TITLE
Lookup token accounts after filtering on token id

### DIFF
--- a/helm/archive-node/templates/db-bootstrap.yaml
+++ b/helm/archive-node/templates/db-bootstrap.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: create-db
-        image: bitnami/postgresql
+        image: bitnami/postgresql:13.8.0
         command: ["bash", "-c"]
         args: ["PGPASSWORD={{ .Values.postgresql.postgresqlPassword }} createdb --username {{ .Values.postgresql.postgresqlUsername }} --host {{ tpl .Values.archive.postgresHost . }} --port {{ .Values.archive.ports.postgres }} --echo {{ .Values.archive.postgresDB}}"]
       - name: import-schema

--- a/helm/archive-node/templates/db-bootstrap.yaml
+++ b/helm/archive-node/templates/db-bootstrap.yaml
@@ -12,11 +12,11 @@ spec:
         command: ["bash", "-c"]
         args: ["PGPASSWORD={{ .Values.postgresql.postgresqlPassword }} createdb --username {{ .Values.postgresql.postgresqlUsername }} --host {{ tpl .Values.archive.postgresHost . }} --port {{ .Values.archive.ports.postgres }} --echo {{ .Values.archive.postgresDB}}"]
       - name: import-schema
-        image: bitnami/postgresql
+        image: bitnami/postgresql:13.8.0
         command: ["bash", "-c"]
         args: ["cd /tmp && {{ range .Values.archive.remoteSchemaAuxFiles }} curl -O {{.}} && {{ end }} PGPASSWORD={{ .Values.postgresql.postgresqlPassword }} psql --username {{ .Values.postgresql.postgresqlUsername }} --host {{ tpl .Values.archive.postgresHost . }} --port {{ .Values.archive.ports.postgres }} --dbname {{ .Values.archive.postgresDB}} -f /tmp/{{ .Values.archive.remoteSchemaFile }} "]
       - name: update-transaction-isolation-level
-        image: bitnami/postgresql
+        image: bitnami/postgresql:13.8.0
         command: ["bash", "-c"]
         args: ["PGPASSWORD={{ .Values.postgresql.postgresqlPassword }} psql --username {{ .Values.postgresql.postgresqlUsername }} --host {{ tpl .Values.archive.postgresHost . }} --port {{ .Values.archive.ports.postgres }} --dbname {{ .Values.archive.postgresDB }} -c 'ALTER DATABASE {{ .Values.archive.postgresDB }} SET DEFAULT_TRANSACTION_ISOLATION TO SERIALIZABLE;'"]
       restartPolicy: Never

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4283,21 +4283,22 @@ module Queries = struct
       ~resolve:(fun { ctx = mina; _ } () token_id ->
         match get_ledger_and_breadcrumb mina with
         | Some (ledger, breadcrumb) ->
-            let token_accounts =
-              Ledger.accounts ledger
-              |> Account_id.Set.filter ~f:(fun acct_id ->
-                     Token_id.equal (Account_id.token_id acct_id) token_id )
-              |> Account_id.Set.to_list
-            in
-            List.map token_accounts ~f:(fun acct_id ->
-                (* we found these account ids in the ledger, lookup should always succeed *)
-                let loc =
-                  Option.value_exn @@ Ledger.location_of_account ledger acct_id
-                in
-                let account = Option.value_exn @@ Ledger.get ledger loc in
-                Types.AccountObj.Partial_account.of_full_account ~breadcrumb
-                  account
-                |> Types.AccountObj.lift mina account.public_key )
+            let accounts = Ledger.accounts ledger in
+            Account_id.Set.fold accounts ~init:[] ~f:(fun acct_objs acct_id ->
+                if Token_id.equal (Account_id.token_id acct_id) token_id then
+                  (* account id in the ledger, lookup should always succeed *)
+                  let loc =
+                    Option.value_exn
+                    @@ Ledger.location_of_account ledger acct_id
+                  in
+                  let account = Option.value_exn @@ Ledger.get ledger loc in
+                  let partial_account =
+                    Types.AccountObj.Partial_account.of_full_account ~breadcrumb
+                      account
+                  in
+                  Types.AccountObj.lift mina account.public_key partial_account
+                  :: acct_objs
+                else acct_objs )
         | None ->
             [] )
 

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4285,7 +4285,9 @@ module Queries = struct
         | Some (ledger, breadcrumb) ->
             let accounts = Ledger.accounts ledger in
             Account_id.Set.fold accounts ~init:[] ~f:(fun acct_objs acct_id ->
-                if Token_id.equal (Account_id.token_id acct_id) token_id then
+                if Token_id.(Account_id.token_id acct_id <> token_id) then
+                  acct_objs
+                else
                   (* account id in the ledger, lookup should always succeed *)
                   let loc =
                     Option.value_exn
@@ -4297,8 +4299,7 @@ module Queries = struct
                       account
                   in
                   Types.AccountObj.lift mina account.public_key partial_account
-                  :: acct_objs
-                else acct_objs )
+                  :: acct_objs )
         | None ->
             [] )
 


### PR DESCRIPTION
In GraphQL, the `tokenAccounts` query was loading every account in the ledger, then filtering them by token id.  As reported in #11950, that could take a very long time.

Instead, obtain the account ids in the ledger, filter them by the token id, then lookup just those accounts.

Tested by applying these changes to the `release/2.0.0` branch, connecting to berkeley testnet. For the query mentioned in that issue, the time is reduced from minutes to less than a second.

Closes #11950.