### PR TITLE
Fix /block endpoint in Rosetta

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -416,7 +416,7 @@ WITH RECURSIVE chain AS (
 
     let query =
       Caqti_request.collect Caqti_type.int typ
-        {| SELECT u.id, u.typ, u.fee_payer_id, u.source_id, u.receiver_id, u.nonce, u.amount, u.fee,
+        {| SELECT u.id, u.comamnd_type, u.fee_payer_id, u.source_id, u.receiver_id, u.nonce, u.amount, u.fee,
         u.valid_until, u.memo, u.hash,
         pk1.value as fee_payer, pk2.value as source, pk3.value as receiver,
         blocks_user_commands.status,
@@ -448,9 +448,9 @@ WITH RECURSIVE chain AS (
 
     let query =
       Caqti_request.collect Caqti_type.int typ
-        {| SELECT DISTINCT ON (i.hash,i.typ,bic.sequence_no,bic.secondary_sequence_no) i.id, i.typ, i.receiver_id, i.fee, i.hash,
+        {| SELECT DISTINCT ON (i.hash,i.command_type,bic.sequence_no,bic.secondary_sequence_no) i.id, i.command_type, i.receiver_id, i.fee, i.hash,
             pk.value as receiver,
-            bic.sequence_no, bic.secondary_sequence_no
+            bic.sequence_nocommand_, beic.secondarapp/rosetta/lib/y_sequence_no
         FROM internal_commands i
         INNER JOIN blocks_internal_commands bic ON bic.internal_command_id = i.id
         INNER JOIN public_keys pk ON pk.id = i.receiver_id

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -97,7 +97,6 @@ module Internal_command_info = struct
   type t =
     { kind: Kind.t
     ; receiver: [`Pk of string]
-    ; receiver_account_creation_fee_paid: Unsigned_extended.UInt64.t option
     ; fee: Unsigned_extended.UInt64.t
     ; token: [`Token_id of string]
     ; sequence_no: int
@@ -114,27 +113,17 @@ module Internal_command_info = struct
        * canonical user command that created them so we are able consistently
        * produce more balance changing operations in the mempool or a block.
        * *)
-      let plan : 'a Op.t list =
-        let mk_account_creation_fee related =
-          match t.receiver_account_creation_fee_paid with
-          | None -> []
-          | Some fee ->
-            [{Op.label= `Account_creation_fee_via_fee_receiver fee
-             ; related_to= Some related}]
-        in
+      let plan : 'a Op.t list = 
         (match t.kind with
         | `Coinbase ->
             (* The coinbase transaction is really incrementing by the coinbase
            * amount  *)
           [{Op.label= `Coinbase_inc; related_to= None}]
-          @ (mk_account_creation_fee `Coinbase_inc)
         | `Fee_transfer ->
           [{Op.label= `Fee_receiver_inc; related_to= None}]
-        @ (mk_account_creation_fee `Fee_receiver_inc)
         | `Fee_transfer_via_coinbase ->
             [ {Op.label= `Fee_receiver_inc; related_to= None}
             ; {Op.label= `Fee_payer_dec; related_to= Some `Fee_receiver_inc} ]
-            @ (mk_account_creation_fee `Fee_receiver_inc)
         )
       in
       Op_build.build
@@ -206,7 +195,6 @@ module Internal_command_info = struct
   let dummies =
     [ { kind= `Coinbase
       ; receiver= `Pk "Eve"
-      ; receiver_account_creation_fee_paid= None
       ; fee= Unsigned.UInt64.of_int 20_000_000_000
       ; token= (`Token_id Amount_of.Token_id.default)
       ; sequence_no=1
@@ -214,7 +202,6 @@ module Internal_command_info = struct
       ; hash= "COINBASE_1" }
     ; { kind= `Fee_transfer
       ; receiver= `Pk "Alice"
-      ; receiver_account_creation_fee_paid= None
       ; fee= Unsigned.UInt64.of_int 30_000_000_000
       ; token= (`Token_id Amount_of.Token_id.default)
       ; sequence_no=1
@@ -400,10 +387,7 @@ WITH RECURSIVE chain AS (
         ; source: string
         ; receiver: string
         ; status: string option
-        ; failure_reason: string option
-        ; fee_payer_account_creation_fee_paid: int64 option
-        ; receiver_account_creation_fee_paid: int64 option
-        ; created_token: int64 option }
+        ; failure_reason: string option }
       [@@deriving hlist]
 
       let fee_payer t = `Pk t.fee_payer
@@ -416,24 +400,13 @@ WITH RECURSIVE chain AS (
 
       let failure_reason t = t.failure_reason
 
-      let fee_payer_account_creation_fee_paid t =
-        t.fee_payer_account_creation_fee_paid
-
-      let receiver_account_creation_fee_paid t =
-        t.receiver_account_creation_fee_paid
-
-      let created_token t = t.created_token
-
       let typ = Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
           Caqti_type.
             [ string
             ; string
             ; string
             ; option string
-            ; option string
-            ; option int64
-            ; option int64
-            ; option int64 ]
+            ; option string ]
     end
 
     let typ =
@@ -447,8 +420,7 @@ WITH RECURSIVE chain AS (
         u.valid_until, u.memo, u.hash,
         pk1.value as fee_payer, pk2.value as source, pk3.value as receiver,
         blocks_user_commands.status,
-        blocks_user_commands.failure_reason,
-        NULL, NULL, NULL
+        blocks_user_commands.failure_reason
         FROM user_commands u
         INNER JOIN blocks_user_commands ON blocks_user_commands.user_command_id = u.id
         INNER JOIN public_keys pk1 ON pk1.id = u.fee_payer_id
@@ -463,12 +435,11 @@ WITH RECURSIVE chain AS (
 
   module Internal_commands = struct
     module Extras = struct
-      let receiver (_,x,_,_) = `Pk x
-      let receiver_account_creation_fee_paid (fee,_,_,_) = fee
-      let sequence_no (_,_,seq_no,_) = seq_no
-      let secondary_sequence_no (_,_,_,secondary_seq_no) = secondary_seq_no
+      let receiver (x,_,_) = `Pk x
+      let sequence_no (_,seq_no,_) = seq_no
+      let secondary_sequence_no (_,_,secondary_seq_no) = secondary_seq_no
 
-      let typ = Caqti_type.(tup4 (option int64) string int int)
+      let typ = Caqti_type.(tup3 string int int)
     end
 
     let typ =
@@ -478,7 +449,7 @@ WITH RECURSIVE chain AS (
     let query =
       Caqti_request.collect Caqti_type.int typ
         {| SELECT DISTINCT ON (i.hash,i.typ,bic.sequence_no,bic.secondary_sequence_no) i.id, i.typ, i.receiver_id, i.fee, i.hash,
-            NULL as receiver_account_creation_fee_paid, pk.value as receiver,
+            pk.value as receiver,
             bic.sequence_no, bic.secondary_sequence_no
         FROM internal_commands i
         INNER JOIN blocks_internal_commands bic ON bic.internal_command_id = i.id
@@ -562,7 +533,6 @@ WITH RECURSIVE chain AS (
           let token_id = Mina_base.Token_id.(to_string default) in
           { Internal_command_info.kind
           ; receiver= Internal_commands.Extras.receiver extras
-          ; receiver_account_creation_fee_paid= Option.map (Internal_commands.Extras.receiver_account_creation_fee_paid extras) ~f:Unsigned.UInt64.of_int64
           ; fee= Unsigned.UInt64.of_string ic.fee
           ; token= `Token_id token_id
           ; sequence_no=Internal_commands.Extras.sequence_no extras
@@ -593,36 +563,10 @@ WITH RECURSIVE chain AS (
           let token = Mina_base.Token_id.(to_string default) in
           let%map failure_status =
             match User_commands.Extras.failure_reason extras with
-            | None -> (
-              match
-                ( User_commands.Extras.fee_payer_account_creation_fee_paid
-                    extras
-                , User_commands.Extras.receiver_account_creation_fee_paid
-                    extras )
-              with
-              | None, None ->
-                  M.return
-                  @@ `Applied
-                       User_command_info.Account_creation_fees_paid.By_no_one
-              | Some fee_payer, None ->
-                  M.return
-                  @@ `Applied
-                       (User_command_info.Account_creation_fees_paid
-                        .By_fee_payer
-                          (Unsigned.UInt64.of_int64 fee_payer))
-              | None, Some receiver ->
-                  M.return
-                  @@ `Applied
-                       (User_command_info.Account_creation_fees_paid
-                        .By_receiver
-                          (Unsigned.UInt64.of_int64 receiver))
-              | Some _, Some _ ->
-                  M.fail
-                    (Errors.create
-                       ~context:
-                         "The archive database is storing creation fees paid \
-                          by two different pks. This is impossible."
-                       `Invariant_violation) )
+            | None ->
+               M.return
+               @@ `Applied
+                    User_command_info.Account_creation_fees_paid.By_no_one
             | Some status ->
                 M.return @@ `Failed status
           in

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -275,7 +275,7 @@ module Sql = struct
          * blocks older than k + epsilon
          *)
         {|
-SELECT c.id, c.state_hash, c.parent_id, c.parent_hash, c.creator_id, c.block_winner_id, c.snarked_ledger_hash_id, c.staking_epoch_data_id, c.next_epoch_data_id, c.ledger_hash, c.height, c.global_slot, c.global_slot_since_genesis, c.timestamp, c.chain_status, pk.value as creator, bw.value as winner FROM blocks c
+SELECT c.id, c.state_hash, c.parent_id, c.parent_hash, c.creator_id, c.block_winner_id, c.snarked_ledger_hash_id, c.staking_epoch_data_id, c.next_epoch_data_id, c.min_window_density, c.total_currency, c.ledger_hash, c.height, c.global_slot_since_hard_fork, c.global_slot_since_genesis, c.timestamp, c.chain_status, pk.value as creator, bw.value as winner FROM blocks c
   INNER JOIN public_keys pk
   ON pk.id = c.creator_id
   INNER JOIN public_keys bw
@@ -300,16 +300,16 @@ SELECT c.id, c.state_hash, c.parent_id, c.parent_hash, c.creator_id, c.block_win
          *)
         {|
 WITH RECURSIVE chain AS (
-  (SELECT id, state_hash, parent_id, parent_hash, creator_id, block_winner_id, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id, ledger_hash, height, global_slot, global_slot_since_genesis, timestamp, chain_status FROM blocks b WHERE height = (select MAX(height) from blocks)
+  (SELECT id, state_hash, parent_id, parent_hash, creator_id, block_winner_id, snarked_ledger_hash_id, staking_epoch_data_id, next_epoch_data_id, min_window_density, total_currency, ledger_hash, height, global_slot_since_hard_fork, global_slot_since_genesis, timestamp, chain_status FROM blocks b WHERE height = (select MAX(height) from blocks)
   ORDER BY timestamp ASC, state_hash ASC
   LIMIT 1)
 
   UNION ALL
 
-  SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.global_slot_since_genesis, b.timestamp, b.chain_status FROM blocks b
+  SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.min_window_density, b.total_currency, b.ledger_hash, b.height, b.global_slot_since_hard_fork, b.global_slot_since_genesis, b.timestamp, b.chain_status FROM blocks b
   INNER JOIN chain
   ON b.id = chain.parent_id AND chain.id <> chain.parent_id AND chain.chain_status <> 'canonical'
-) SELECT c.id, c.state_hash, c.parent_id, c.parent_hash, c.creator_id, c.block_winner_id, c.snarked_ledger_hash_id, c.staking_epoch_data_id, c.next_epoch_data_id, c.ledger_hash, c.height, c.global_slot, c.global_slot_since_genesis, c.timestamp, c.chain_status, pk.value as creator, bw.value as winner FROM chain c
+) SELECT c.id, c.state_hash, c.parent_id, c.parent_hash, c.creator_id, c.block_winner_id, c.snarked_ledger_hash_id, c.staking_epoch_data_id, c.next_epoch_data_id, c.min_window_density, c.total_currency, c.ledger_hash, c.height, c.global_slot_since_hard_fork, c.global_slot_since_genesis, c.timestamp, c.chain_status, pk.value as creator, bw.value as winner FROM chain c
   INNER JOIN public_keys pk
   ON pk.id = c.creator_id
   INNER JOIN public_keys bw
@@ -319,7 +319,7 @@ WITH RECURSIVE chain AS (
 
     let query_hash =
       Caqti_request.find_opt Caqti_type.string typ
-        {| SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.global_slot_since_genesis, b.timestamp, b.chain_status, pk.value as creator, bw.value as winner FROM blocks b
+        {| SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.min_window_density, b.total_currency, b.ledger_hash, b.height, b.global_slot_since_hard_fork, b.global_slot_since_genesis, b.timestamp, b.chain_status, pk.value as creator, bw.value as winner FROM blocks b
         INNER JOIN public_keys pk
         ON pk.id = b.creator_id
         INNER JOIN public_keys bw
@@ -330,7 +330,7 @@ WITH RECURSIVE chain AS (
       Caqti_request.find_opt
         Caqti_type.(tup2 string int64)
         typ
-        {| SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.global_slot_since_genesis, b.timestamp, b.chain_status, pk.value as creator, bw.value as winner FROM blocks b
+        {| SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.min_window_density, b.total_currency, b.ledger_hash, b.height, b.global_slot_since_hard_fork, b.global_slot_since_genesis, b.timestamp, b.chain_status, pk.value as creator, bw.value as winner FROM blocks b
         INNER JOIN public_keys pk
         ON pk.id = b.creator_id
         INNER JOIN public_keys bw
@@ -339,7 +339,7 @@ WITH RECURSIVE chain AS (
 
     let query_by_id =
       Caqti_request.find_opt Caqti_type.int typ
-        {| SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.global_slot_since_genesis, b.timestamp, b.chain_status, pk.value as creator, bw.value as winner FROM blocks b
+        {| SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.min_window_density, b.total_currency, b.ledger_hash, b.height, b.global_slot_since_hard_fork, b.global_slot_since_genesis, b.timestamp, b.chain_status, pk.value as creator, bw.value as winner FROM blocks b
         INNER JOIN public_keys pk
         ON pk.id = b.creator_id
         INNER JOIN public_keys bw
@@ -348,7 +348,7 @@ WITH RECURSIVE chain AS (
 
     let query_best =
       Caqti_request.find_opt Caqti_type.unit typ
-        {| SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.ledger_hash, b.height, b.global_slot, b.global_slot_since_genesis, b.timestamp, b.chain_status, pk.value as creator, bw.value as winner FROM blocks b
+        {| SELECT b.id, b.state_hash, b.parent_id, b.parent_hash, b.creator_id, b.block_winner_id, b.snarked_ledger_hash_id, b.staking_epoch_data_id, b.next_epoch_data_id, b.min_window_density, b.total_currency, b.ledger_hash, b.height, b.global_slot_since_hard_fork, b.global_slot_since_genesis, b.timestamp, b.chain_status, pk.value as creator, bw.value as winner FROM blocks b
            INNER JOIN public_keys pk
            ON pk.id = b.creator_id
            INNER JOIN public_keys bw
@@ -443,14 +443,12 @@ WITH RECURSIVE chain AS (
 
     let query =
       Caqti_request.collect Caqti_type.int typ
-        {| SELECT u.id, u.type, u.fee_payer_id, u.source_id, u.receiver_id, u.fee_token, u.token, u.nonce, u.amount, u.fee,
+        {| SELECT u.id, u.typ, u.fee_payer_id, u.source_id, u.receiver_id, u.nonce, u.amount, u.fee,
         u.valid_until, u.memo, u.hash,
         pk1.value as fee_payer, pk2.value as source, pk3.value as receiver,
         blocks_user_commands.status,
         blocks_user_commands.failure_reason,
-        blocks_user_commands.fee_payer_account_creation_fee_paid,
-        blocks_user_commands.receiver_account_creation_fee_paid,
-        blocks_user_commands.created_token
+        NULL, NULL, NULL
         FROM user_commands u
         INNER JOIN blocks_user_commands ON blocks_user_commands.user_command_id = u.id
         INNER JOIN public_keys pk1 ON pk1.id = u.fee_payer_id
@@ -479,8 +477,8 @@ WITH RECURSIVE chain AS (
 
     let query =
       Caqti_request.collect Caqti_type.int typ
-        {| SELECT DISTINCT ON (i.hash,i.type,bic.sequence_no,bic.secondary_sequence_no) i.id, i.type, i.receiver_id, i.fee, i.token, i.hash,
-            bic.receiver_account_creation_fee_paid, pk.value as receiver,
+        {| SELECT DISTINCT ON (i.hash,i.typ,bic.sequence_no,bic.secondary_sequence_no) i.id, i.typ, i.receiver_id, i.fee, i.hash,
+            NULL as receiver_account_creation_fee_paid, pk.value as receiver,
             bic.sequence_no, bic.secondary_sequence_no
         FROM internal_commands i
         INNER JOIN blocks_internal_commands bic ON bic.internal_command_id = i.id


### PR DESCRIPTION
Explain your changes:
The SQL queries to the archive database contained in Rosetta API implementation have gone out of sync with the database schema, which makes it fail on virtually any request to `/block` endpoint. Errors are talking about inability to convert data types or even about unknown columns in queries. This PR aims to update the queries to conform to the current DB schema and cleans up the code meant to handle data that is no longer there.

Explain how you tested your changes:
I set up the Rosetta endpoint and queried for blocks by their height and state hashes as specified by the Rosetta API spec. These requests used to fail with SQL errors; now they return correct information on requested blocks. Tested on Berkeley testnet.
