### PR TITLE
Minor updates for flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -371,9 +371,6 @@
             ${oa.shellHook}
             unset MINA_COMMIT_DATE MINA_COMMIT_SHA1 MINA_BRANCH
             # TODO: dead code doesn't allow us to have nice things
-            pushd src/app/cli
-            dune build @check
-            popd
           '';
         });
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -111,9 +111,12 @@ nix develop mina#with-lsp -c $EDITOR .
 if you have your `$EDITOR` variable set correctly. Otherwise, replace it with
 the editor you want to edit Mina with.
 
-This command will try to `dune build @check` in `src/app/cli`, in order to get
-type information necessary for the LSP to work. This might take a while, but
-will only happen once. After it's done, you will be dropped in your favourite editor.
+This will drop you in your favorite editor within a Nix sanbdbox containing an
+OCaml LSP server.
+
+However, for LSP to work its magic, you will need to have to make type
+informations available. They can for example be obtained by running `dune build
+@check` in `src/app/cli`, which might take a while, or by compiling the project.
 
 Don't forget to exit and re-enter the editor using this command after switching
 branches, or otherwise changing the dependency tree of Mina.


### PR DESCRIPTION
This PR modifies the `#mina-with-lsp` target in 2 ways:

1. The first commit removes a call to `dune @check` that could take time
2. The second removes the dependency on `go` which looks unnecessary

This 2 changes makes the `#mina-with-lsp` like `#mina` but with the additional `ocaml-lsp-server` dependency.
Intuitively, the name indicates this is just what it should do.
