### PR TITLE
Remove warning 16

### DIFF
--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -121,9 +121,9 @@ let%test_module "Archive node unit tests" =
 
     let coinbase_gen =
       Coinbase.Gen.with_random_receivers ~keys ~min_amount:20 ~max_amount:100
-        ~fee_transfer:
-          (Coinbase.Fee_transfer.Gen.with_random_receivers ~keys
-             ~min_fee:Currency.Fee.zero )
+        ~fee_transfer:(fun ~coinbase_amount ->
+          Coinbase.Fee_transfer.Gen.with_random_receivers ~keys
+            ~min_fee:Currency.Fee.zero coinbase_amount )
 
     let%test_unit "User_command: read and write signed command" =
       let conn = Lazy.force conn_lazy in

--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -271,8 +271,8 @@ let%test_module "Archive node unit tests" =
                 ~precomputed_values ~verifier () )
              (Transition_frontier.Breadcrumb.For_tests.gen_non_deferred
                 ?logger:None ~precomputed_values ~verifier ?trust_system:None
-                ~accounts_with_secret_keys:(Lazy.force Genesis_ledger.accounts) )
-        )
+                ~accounts_with_secret_keys:(Lazy.force Genesis_ledger.accounts)
+                () ) )
         ~f:(fun breadcrumbs ->
           Thread_safe.block_on_async_exn
           @@ fun () ->

--- a/src/lib/mina_base/coinbase.ml
+++ b/src/lib/mina_base/coinbase.ml
@@ -116,7 +116,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       in
       let min_fee = constraint_constants.account_creation_fee in
       let%map fee_transfer =
-        Option.quickcheck_generator (Fee_transfer.Gen.gen ~min_fee ~max_fee)
+        Option.quickcheck_generator (Fee_transfer.Gen.gen ~min_fee max_fee)
       in
       let fee_transfer =
         match fee_transfer with

--- a/src/lib/mina_base/coinbase_fee_transfer.ml
+++ b/src/lib/mina_base/coinbase_fee_transfer.ml
@@ -45,14 +45,14 @@ module Make_str (A : Wire_types.Concrete) = struct
     Fee_transfer.Single.create ~receiver_pk ~fee ~fee_token:Token_id.default
 
   module Gen = struct
-    let gen ?(min_fee = Currency.Fee.zero) ~max_fee : t Quickcheck.Generator.t =
+    let gen ?(min_fee = Currency.Fee.zero) max_fee : t Quickcheck.Generator.t =
       let open Quickcheck.Generator.Let_syntax in
       let%bind receiver_pk = Public_key.Compressed.gen in
       let%map fee = Currency.Fee.gen_incl min_fee max_fee in
       { receiver_pk; fee }
 
     let with_random_receivers ~keys ?(min_fee = Currency.Fee.zero)
-        ~coinbase_amount : t Quickcheck.Generator.t =
+        coinbase_amount : t Quickcheck.Generator.t =
       let open Quickcheck.Generator.Let_syntax in
       let max_fee = Currency.Amount.to_fee coinbase_amount in
       let%map receiver_pk =

--- a/src/lib/mina_base/coinbase_fee_transfer_intf.ml
+++ b/src/lib/mina_base/coinbase_fee_transfer_intf.ml
@@ -28,16 +28,22 @@ module type Full = sig
   val to_fee_transfer : t -> Fee_transfer.Single.t
 
   module Gen : sig
-    val gen :
-         ?min_fee:Currency.Fee.t
-      -> max_fee:Currency.Fee.t
-      -> t Quickcheck.Generator.t
+    (** [gen ?min_fee max_fee] generates fee transfers between [min_fee] and
+        [max_fee].
 
-    (** Creates coinbase fee transfers with fees between [min_fee] and [coinbase_amount]*)
+        @param min_fee defaults to zero *)
+    val gen :
+      ?min_fee:Currency.Fee.t -> Currency.Fee.t -> t Quickcheck.Generator.t
+
+    (** [with_random_receivers ~key ?min_fee coinbase_amount] creates coinbase
+        fee transfers with fees between [min_fee] and [coinbase_amount]
+
+        @param min_fee defaults to {!val:Currency.Fee.zero}
+     *)
     val with_random_receivers :
          keys:Signature_keypair.t array
       -> ?min_fee:Currency.Fee.t
-      -> coinbase_amount:Currency.Amount.t
+      -> Currency.Amount.t
       -> t Quickcheck.Generator.t
   end
 end

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -465,7 +465,7 @@ module For_tests = struct
           failwithf !"Invalid staged ledger hash: %{sexp:Error.t}" e ()
 
   let gen_non_deferred ?logger ~precomputed_values ~verifier ?trust_system
-      ~accounts_with_secret_keys =
+      ~accounts_with_secret_keys () =
     let open Quickcheck.Generator.Let_syntax in
     let%map make_deferred =
       gen ?logger ~verifier ~precomputed_values ?trust_system

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -97,6 +97,7 @@ module For_tests : sig
     -> verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> accounts_with_secret_keys:(Private_key.t option * Account.t) list
+    -> unit
     -> (t -> t) Quickcheck.Generator.t
 
   val gen_seq :

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -701,7 +701,7 @@ module For_tests = struct
              (Quickcheck.Generator.return root)
              (Breadcrumb.For_tests.gen_non_deferred ~logger ~precomputed_values
                 ~verifier ~trust_system
-                ~accounts_with_secret_keys:root_ledger_accounts ) )
+                ~accounts_with_secret_keys:root_ledger_accounts () ) )
       in
       (root, branches, protocol_states)
     in


### PR DESCRIPTION
This commit patches the function triggering `warning 16` by adding an extra `()` argument.

Nothing else should change.
