### PR TITLE
Version-tag transaction ids

### DIFF
--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -36,7 +36,8 @@ let state_body_hash : t = '\x11'
 
 let transaction_hash : t = '\x12'
 
-let user_command : t = '\x13'
+(* used only to deserialize transaction ids, pre-Berkeley hard fork *)
+let signed_command_legacy : t = '\x13'
 
 let user_command_memo : t = '\x14'
 

--- a/src/lib/mina_base/payment_payload.ml
+++ b/src/lib/mina_base/payment_payload.ml
@@ -18,6 +18,16 @@ module Poly = struct
         { source_pk : 'public_key; receiver_pk : 'public_key; amount : 'amount }
       [@@deriving equal, sexp, hash, yojson, compare, hlist]
     end
+
+    module V1 = struct
+      type ('public_key, 'token_id, 'amount) t =
+        { source_pk : 'public_key
+        ; receiver_pk : 'public_key
+        ; token_id : 'token_id
+        ; amount : 'amount
+        }
+      [@@deriving equal, sexp, hash, yojson, compare, hlist]
+    end
   end]
 end
 
@@ -29,6 +39,18 @@ module Stable = struct
     [@@deriving equal, sexp, hash, compare, yojson]
 
     let to_latest = Fn.id
+  end
+
+  module V1 = struct
+    type t =
+      ( Public_key.Compressed.Stable.V1.t
+      , Token_id.Stable.V1.t
+      , Amount.Stable.V1.t )
+      Poly.Stable.V1.t
+    [@@deriving equal, sexp, hash, compare, yojson]
+
+    (* don't need to coerce old payments to new ones *)
+    let to_latest _ = failwith "Not implemented"
   end
 end]
 

--- a/src/lib/mina_base/payment_payload.mli
+++ b/src/lib/mina_base/payment_payload.mli
@@ -11,7 +11,12 @@ module Poly : sig
 
   module Stable : sig
     module V2 : sig
-      type nonrec ('pk, 'amount) t
+      type ('pk, 'amount) t
+      [@@deriving bin_io, equal, sexp, hash, yojson, version]
+    end
+
+    module V1 : sig
+      type ('pk, 'token_id, 'amount) t
       [@@deriving bin_io, equal, sexp, hash, yojson, version]
     end
 
@@ -28,6 +33,17 @@ module Stable : sig
       , Currency.Amount.Stable.V1.t )
       Poly.Stable.V2.t
     [@@deriving compare, equal, sexp, hash, compare, yojson]
+  end
+
+  module V1 : sig
+    type t =
+      ( Public_key.Compressed.Stable.V1.t
+      , Token_id.Stable.V1.t
+      , Currency.Amount.Stable.V1.t )
+      Poly.Stable.V1.t
+    [@@deriving compare, equal, sexp, hash, compare, yojson]
+
+    val to_latest : t -> Latest.t
   end
 end]
 

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -88,6 +88,20 @@ module Common = struct
 
       let to_latest = Fn.id
     end
+
+    module V1 = struct
+      type t =
+        ( Currency.Fee.Stable.V1.t
+        , Public_key.Compressed.Stable.V1.t
+        , Token_id.Stable.V1.t
+        , Account_nonce.Stable.V1.t
+        , Global_slot.Stable.V1.t
+        , Memo.Stable.V1.t )
+        Poly.Stable.V1.t
+      [@@deriving compare, equal, sexp, hash, yojson]
+
+      let to_latest _ = failwith "Not implemented"
+    end
   end]
 
   let to_input_legacy ({ fee; fee_payer_pk; nonce; valid_until; memo } : t) =
@@ -170,29 +184,27 @@ module Common = struct
 end
 
 module Body = struct
-  module Binable_arg = struct
-    [%%versioned
-    module Stable = struct
-      module V2 = struct
-        type t = Mina_wire_types.Mina_base.Signed_command_payload.Body.V2.t =
-          | Payment of Payment_payload.Stable.V2.t
-          | Stake_delegation of Stake_delegation.Stable.V1.t
-        [@@deriving sexp]
-
-        let to_latest = Fn.id
-      end
-    end]
-  end
-
   [%%versioned
   module Stable = struct
     module V2 = struct
-      type t = Binable_arg.Stable.V2.t =
+      type t = Mina_wire_types.Mina_base.Signed_command_payload.Body.V2.t =
         | Payment of Payment_payload.Stable.V2.t
         | Stake_delegation of Stake_delegation.Stable.V1.t
-      [@@deriving compare, equal, sexp, hash, yojson]
+      [@@deriving sexp, compare, equal, sexp, hash, yojson]
 
       let to_latest = Fn.id
+    end
+
+    module V1 = struct
+      type t =
+        | Payment of Payment_payload.Stable.V1.t
+        | Stake_delegation of Stake_delegation.Stable.V1.t
+      (* omitting token commands, none were ever created
+         such omission doesn't affect serialization/Base58Check of payments, delegations
+      *)
+      [@@deriving sexp, compare, equal, sexp, hash, yojson]
+
+      let to_latest _ = failwith "Not implemented"
     end
   end]
 
@@ -276,6 +288,14 @@ module Stable = struct
     [@@deriving compare, equal, sexp, hash, yojson]
 
     let to_latest = Fn.id
+  end
+
+  module V1 = struct
+    type t = (Common.Stable.V1.t, Body.Stable.V1.t) Poly.Stable.V1.t
+    [@@deriving compare, equal, sexp, hash, yojson]
+
+    (* don't need to coerce old transactions to newer version *)
+    let to_latest _ = failwith "Not implemented"
   end
 end]
 

--- a/src/lib/mina_base/signed_command_payload.mli
+++ b/src/lib/mina_base/signed_command_payload.mli
@@ -33,6 +33,10 @@ module Body : sig
     module V2 : sig
       type nonrec t = t [@@deriving compare, equal, sexp, hash, yojson]
     end
+
+    module V1 : sig
+      type t [@@deriving compare, equal, sexp, hash, yojson]
+    end
   end]
 
   val tag : t -> Transaction_union_tag.t
@@ -66,6 +70,18 @@ module Common : sig
           }
         [@@deriving equal, sexp, hash, yojson]
       end
+
+      module V1 : sig
+        type ('fee, 'public_key, 'token_id, 'nonce, 'global_slot, 'memo) t =
+          { fee : 'fee
+          ; fee_token : 'token_id
+          ; fee_payer_pk : 'public_key
+          ; nonce : 'nonce
+          ; valid_until : 'global_slot
+          ; memo : 'memo
+          }
+        [@@deriving compare, equal, sexp, hash, yojson, hlist]
+      end
     end]
   end
 
@@ -77,9 +93,21 @@ module Common : sig
         , Public_key.Compressed.Stable.V1.t
         , Mina_numbers.Account_nonce.Stable.V1.t
         , Mina_numbers.Global_slot.Stable.V1.t
-        , Signed_command_memo.t )
+        , Signed_command_memo.Stable.V1.t )
         Poly.Stable.V2.t
       [@@deriving compare, equal, sexp, hash]
+    end
+
+    module V1 : sig
+      type t =
+        ( Currency.Fee.Stable.V1.t
+        , Public_key.Compressed.Stable.V1.t
+        , Token_id.Stable.V1.t
+        , Mina_numbers.Account_nonce.Stable.V1.t
+        , Mina_numbers.Global_slot.Stable.V1.t
+        , Signed_command_memo.Stable.V1.t )
+        Poly.Stable.V1.t
+      [@@deriving compare, equal, sexp, hash, yojson]
     end
   end]
 
@@ -136,6 +164,13 @@ module Stable : sig
   module V2 : sig
     type t = (Common.Stable.V2.t, Body.Stable.V2.t) Poly.Stable.V1.t
     [@@deriving compare, equal, sexp, hash, yojson]
+  end
+
+  module V1 : sig
+    type t = (Common.Stable.V1.t, Body.Stable.V1.t) Poly.Stable.V1.t
+    [@@deriving compare, equal, sexp, hash, yojson]
+
+    val to_latest : t -> Latest.t
   end
 end]
 

--- a/src/lib/mina_base/unix/graphql_scalars.ml
+++ b/src/lib/mina_base/unix/graphql_scalars.ml
@@ -97,12 +97,3 @@ module TransactionStatusFailure :
     Graphql_async.Schema.scalar "TransactionStatusFailure"
       ~doc:"transaction status failure" ~coerce:serialize
 end
-
-module ZkappCommandBase58 =
-  Make_scalar_using_base58_check
-    (Mina_base.Zkapp_command)
-    (struct
-      let name = "ZkappCommandBase58"
-
-      let doc = "A Base58Check string representing the command"
-    end)

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -197,13 +197,6 @@ let accounts_accessed (t : t) (status : Transaction_status.t) =
 
 let accounts_referenced (t : t) = accounts_accessed t Applied
 
-let to_base58_check (t : t) =
-  match t with
-  | Signed_command x ->
-      Signed_command.to_base58_check x
-  | Zkapp_command ps ->
-      Zkapp_command.to_base58_check ps
-
 let fee_payer (t : t) =
   match t with
   | Signed_command x ->

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -944,6 +944,8 @@ module Digest = Call_forest.Digest
 module T = struct
   [%%versioned_binable
   module Stable = struct
+    [@@@with_top_version_tag]
+
     module V1 = struct
       type t = Mina_wire_types.Mina_base.Zkapp_command.V1.t =
         { fee_payer : Account_update.Fee_payer.Stable.V1.t
@@ -957,10 +959,6 @@ module T = struct
       [@@deriving annot, sexp, compare, equal, hash, yojson, fields]
 
       let to_latest = Fn.id
-
-      let version_byte = Base58_check.Version_bytes.zkapp_command
-
-      let description = "Zkapp_command"
 
       module Wire = struct
         [%%versioned
@@ -1530,12 +1528,10 @@ struct
     create ~verification_keys:(Account_id.Table.to_alist tbl) t
 end
 
-include Codable.Make_base58_check (Stable.Latest)
-
-(* shadow the definitions from Make_base58_check *)
 [%%define_locally Stable.Latest.(of_yojson, to_yojson)]
 
-include Codable.Make_base64 (Stable.Latest)
+(* so transaction ids have a version tag *)
+include Codable.Make_base64 (Stable.Latest.With_top_version_tag)
 
 type account_updates =
   (Account_update.t, Digest.Account_update.t, Digest.Forest.t) Call_forest.t


### PR DESCRIPTION
Add a top version tag to the `Bin_prot`-serialization of transaction ids, so that we can create transaction hashes for any extant transaction id (the hashing is not part of this PR).

Remove most of the Base58Check code for signed commands and zkApp commands, because we don't want to create any new such serializations.  

Restore `V1` of `Signed_command.Stable`, so that we can deserialize old, Base58Check transaction ids. Add `Signed_command.of_base58_check_exn_legacy` to deserialize to that type.  `Signed_command.t_legacy` is added as a name for that type. Rename `Version_bytes.user_command` to `signed_command_legacy`. Restoration required restoring a number of associated types; the `to_latest` functions are unimplemented, because there isn't need to coerce old transactions to the latest type, I believe.

The version linter failure here is benign: the type `Binable_arg.Stable.V2.t`, removed here, was simply adding a level of indirection in the type definition. In `compatible`, the module containing that type was used as an argument to a `Binable` functor, but is no longer used that way.

Part of #11821.

Part of #11935.


