### PR TITLE
don't check for fee excess for empty account update zkapp commands

### DIFF
--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -1603,11 +1603,13 @@ module Make (Inputs : Inputs_intf) = struct
       let delta_settled =
         Amount.Signed.equal local_state.excess Amount.(Signed.of_unsigned zero)
       in
-      let is_empty_account_update =
-        Bool.(is_start' &&& is_last_account_update)
-      in
-      Bool.(
-        is_empty_account_update ||| not is_last_account_update ||| delta_settled)
+      (* 1) ignore local excess if it is_start because it will be promoted to global
+             excess and then set to zero later in the code
+         2) ignore everything but last account update since the excess wouldn't have
+            been settled
+         3) Excess should be settled after the last account update has been applied.
+      *)
+      Bool.(is_start' ||| not is_last_account_update ||| delta_settled)
     in
     let local_state =
       Local_state.add_check local_state Invalid_fee_excess valid_fee_excess

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -1603,7 +1603,11 @@ module Make (Inputs : Inputs_intf) = struct
       let delta_settled =
         Amount.Signed.equal local_state.excess Amount.(Signed.of_unsigned zero)
       in
-      Bool.((not is_last_account_update) ||| delta_settled)
+      let is_empty_account_update =
+        Bool.(is_start' &&& is_last_account_update)
+      in
+      Bool.(
+        is_empty_account_update ||| not is_last_account_update ||| delta_settled)
     in
     let local_state =
       Local_state.add_check local_state Invalid_fee_excess valid_fee_excess


### PR DESCRIPTION
Explain your changes:
This PR fixes the `Invalid_fee_excess` error that we've seen in zkApp transactions with empty account updates.

Explain how you tested your changes:
*


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
