### PR TITLE
Support larger ledgers in IPC communication

### DIFF
--- a/src/lib/mina_net2/libp2p_stream.ml
+++ b/src/lib/mina_net2/libp2p_stream.ml
@@ -126,6 +126,40 @@ let stream_closed ~logger ~who_closed t =
         ] ;
   `Stream_should_be_released (equal_state FullyOpen t.state)
 
+let max_message_size = 16777216 (* 16 MiB *)
+
+let split_string ~every b =
+  let blen = String.length b in
+  let rec isplit sofar pos =
+    if blen - pos > every then
+      let chunk = String.sub b ~pos ~len:every in
+      isplit (chunk :: sofar) @@ (pos + every)
+    else if blen - pos = 0 then sofar
+    else String.sub ~pos ~len:(blen - pos) b :: sofar
+  in
+  List.rev (isplit [] 0)
+
+let%test_unit "split_string" =
+  let gen =
+    let module Gen = Quickcheck.Generator in
+    let%bind.Gen every = Gen.small_positive_int in
+    let%bind.Gen total = Gen.small_non_negative_int in
+    let%bind.Gen last =
+      if total % every = 0 then Gen.return []
+      else
+        let%map.Gen s = String.gen_with_length (total % every) Gen.char_print in
+        [ s ]
+    in
+    let%map.Gen rest =
+      Gen.list_with_length (total / every)
+        (String.gen_with_length every Gen.char_print)
+    in
+    (every, List.append rest last)
+  in
+  Quickcheck.test gen ~f:(fun (every, expected) ->
+      let s = String.concat expected in
+      assert (List.equal String.equal expected @@ split_string ~every s) )
+
 let create_from_existing ~logger ~helper ~stream_id ~protocol ~peer
     ~release_stream =
   let incoming_r, incoming_w = Pipe.create () in
@@ -142,10 +176,13 @@ let create_from_existing ~logger ~helper ~stream_id ~protocol ~peer
   in
   let send_outgoing_messages_task =
     Pipe.iter outgoing_r ~f:(fun msg ->
+        let parts = split_string msg ~every:max_message_size in
         match%map
-          Libp2p_helper.do_rpc helper
-            (module Libp2p_ipc.Rpcs.SendStream)
-            (Libp2p_ipc.Rpcs.SendStream.create_request ~stream_id ~data:msg)
+          Deferred.Or_error.List.iter parts ~f:(fun data ->
+              Deferred.Or_error.map ~f:(const ())
+              @@ Libp2p_helper.do_rpc helper
+                   (module Libp2p_ipc.Rpcs.SendStream)
+                   (Libp2p_ipc.Rpcs.SendStream.create_request ~stream_id ~data) )
         with
         | Ok _ ->
             ()

--- a/src/lib/mina_net2/libp2p_stream.mli
+++ b/src/lib/mina_net2/libp2p_stream.mli
@@ -41,3 +41,5 @@ val stream_closed :
   -> who_closed:participant
   -> t
   -> [ `Stream_should_be_released of bool ]
+
+val max_chunk_size : int

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -275,6 +275,8 @@ module Libp2p_stream : sig
   val pipes : t -> string Pipe.Reader.t * string Pipe.Writer.t
 
   val remote_peer : t -> Peer.t
+
+  val max_chunk_size : int
 end
 
 (** Opens a stream with a peer on a particular protocol.


### PR DESCRIPTION
Split larger messages on IPC to support larger ledger sizes.

Explain your changes:
* When a large message is sent over a stream, split it to a few smaller

Explain how you tested your changes:
* Existing test is modified to support large messages
* After test on cluster, issue #13965 was gone

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues?

* Closes #13965 