### PR TITLE
Blind public input commitments to avoid zero commitments

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
@@ -12,7 +12,8 @@ pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
     lookup_configuration: Option<&LookupConfiguration<F>>,
 ) -> (String, Vec<(String, String)>) {
     let evaluated_cols = linearization_columns::<F>(lookup_configuration);
-    let (linearization, _powers_of_alpha) = constraints_expr::<F>(false, false, lookup_configuration, false);
+    let (linearization, _powers_of_alpha) =
+        constraints_expr::<F>(false, false, lookup_configuration, false);
 
     let Linearization {
         constant_term,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
@@ -1,4 +1,5 @@
 use crate::pasta_fp_plonk_verifier_index::CamlPastaFpPlonkVerifierIndex;
+use ark_ff::One;
 use commitment_dlog::commitment::{caml::CamlPolyComm, shift_scalar, PolyComm};
 use kimchi::circuits::scalars::{caml::CamlRandomOracles, RandomOracles};
 use kimchi::proof::ProverProof;
@@ -10,7 +11,6 @@ use oracle::{
     FqSponge,
 };
 use paste::paste;
-use ark_ff::One;
 
 #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
 pub struct CamlOracles<F> {

--- a/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/oracles.rs
@@ -10,6 +10,7 @@ use oracle::{
     FqSponge,
 };
 use paste::paste;
+use ark_ff::One;
 
 #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
 pub struct CamlOracles<F> {
@@ -48,6 +49,17 @@ macro_rules! impl_oracles {
                         .map(|s| -s)
                         .collect::<Vec<_>>(),
                 );
+
+                let p_comm = {
+                    index
+                        .srs()
+                        .mask_custom(
+                            p_comm.clone(),
+                            &p_comm.map(|_| $F::one()),
+                        )
+                        .unwrap()
+                        .commitment
+                };
 
                 let proof: ProverProof<$G> = proof.into();
 

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.lock
@@ -585,6 +585,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fq.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/arkworks/pasta_fq.rs
@@ -5,7 +5,7 @@ use ark_ff::{
 };
 use ark_ff::{FromBytes, ToBytes};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
-use mina_curves::pasta::{Fq, fields::fq::FqParameters as Fq_params};
+use mina_curves::pasta::{fields::fq::FqParameters as Fq_params, Fq};
 use num_bigint::BigUint;
 use rand::rngs::StdRng;
 use std::cmp::Ordering::{Equal, Greater, Less};

--- a/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
@@ -13,7 +13,7 @@ use wasm_bindgen::prelude::*;
 // use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
 use crate::wasm_vector::WasmVector;
 // use crate::wasm_flat_vector::WasmFlatVector;
-use ark_ff::Zero;
+use ark_ff::{Zero, One};
 
 //
 // CamlOracles
@@ -195,6 +195,16 @@ macro_rules! impl_oracles {
                         .map(|s: $F| -s)
                         .collect::<Vec<_>>(),
                 );
+                let p_comm = {
+                    index
+                        .srs
+                        .mask_custom(
+                            p_comm.clone(),
+                            &p_comm.map(|_| $F::one()),
+                        )
+                        .unwrap()
+                        .commitment
+                };
 
                 let proof: ProverProof<$G> = proof.into();
 

--- a/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
@@ -197,7 +197,7 @@ macro_rules! impl_oracles {
                 );
                 let p_comm = {
                     index
-                        .srs
+                        .srs()
                         .mask_custom(
                             p_comm.clone(),
                             &p_comm.map(|_| $F::one()),

--- a/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/oracles.rs
@@ -13,7 +13,7 @@ use wasm_bindgen::prelude::*;
 // use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
 use crate::wasm_vector::WasmVector;
 // use crate::wasm_flat_vector::WasmFlatVector;
-use ark_ff::{Zero, One};
+use ark_ff::{One, Zero};
 
 //
 // CamlOracles

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -551,8 +551,8 @@ struct
         in
         let x_hat =
           with_label "x_hat blinding" (fun () ->
-            Ops.add_fast x_hat (Inner_curve.constant (Lazy.force Generators.h))
-          )
+              Ops.add_fast x_hat
+                (Inner_curve.constant (Lazy.force Generators.h)) )
         in
         absorb sponge PC x_hat ;
         let w_comm = messages.w_comm in

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -549,6 +549,11 @@ struct
                        [ 0; 1; 2 ] )
                     ~public_input )
         in
+        let x_hat =
+          with_label "x_hat blinding" (fun () ->
+            Ops.add_fast x_hat (Inner_curve.constant (Lazy.force Generators.h))
+          )
+        in
         absorb sponge PC x_hat ;
         let w_comm = messages.w_comm in
         Vector.iter ~f:absorb_g w_comm ;

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -609,8 +609,8 @@ struct
         in
         let x_hat =
           with_label "x_hat blinding" (fun () ->
-            Ops.add_fast x_hat (Inner_curve.constant (Lazy.force Generators.h))
-          )
+              Ops.add_fast x_hat
+                (Inner_curve.constant (Lazy.force Generators.h)) )
         in
         absorb sponge PC (Boolean.true_, x_hat) ;
         let w_comm = messages.w_comm in

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -607,6 +607,11 @@ struct
                                g x ~num_bits ) ) ) )
           |> Inner_curve.negate
         in
+        let x_hat =
+          with_label "x_hat blinding" (fun () ->
+            Ops.add_fast x_hat (Inner_curve.constant (Lazy.force Generators.h))
+          )
+        in
         absorb sponge PC (Boolean.true_, x_hat) ;
         let w_comm = messages.w_comm in
         Vector.iter ~f:absorb_g w_comm ;


### PR DESCRIPTION
This PR is the counterpart to https://github.com/o1-labs/proof-systems/pull/795, adding 'blinding' to the public input commitments in pickles, so that an all-zero public input can still be handled successfully.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them

This fixes https://github.com/MinaProtocol/mina/issues/11730