### PR TITLE
Nix: build a deb package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -52,6 +52,21 @@
     },
     "flake-utils": {
       "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
@@ -65,7 +80,7 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
@@ -150,18 +165,36 @@
         "type": "github"
       }
     },
+    "nix-utils": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1632973430,
+        "narHash": "sha256-9G8zo+0nfYAALV5umCyQR/2hVUFNH10JropBkyxZGGw=",
+        "owner": "juliosueiras-nix",
+        "repo": "nix-utils",
+        "rev": "b44e1ffd726aa03056db9df469efb497d8b9871b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juliosueiras-nix",
+        "repo": "nix-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661404419,
-        "narHash": "sha256-7+xPaxDIH9TIiv1AnKe8T7G/yKER0oXvhXdF5nRw1WI=",
+        "lastModified": 1629252929,
+        "narHash": "sha256-Aj20gmGBs8TG7pyaQqgbsqAQ6cB+TVuL18Pk3DPBxcQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3bbe5c61d3b8aaa7af8bf375dce2858385607186",
+        "rev": "3788c68def67ca7949e0864c27638d484389363d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -199,6 +232,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1661404419,
+        "narHash": "sha256-7+xPaxDIH9TIiv1AnKe8T7G/yKER0oXvhXdF5nRw1WI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3bbe5c61d3b8aaa7af8bf375dce2858385607186",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1640418986,
         "narHash": "sha256-a8GGtxn2iL3WAkY5H+4E0s3Q7XJt6bTOvos9qqxT5OQ=",
         "owner": "NixOS",
@@ -216,7 +265,7 @@
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -257,7 +306,7 @@
     },
     "opam2json": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1651529032,
@@ -281,7 +330,8 @@
         "mix-to-nix": "mix-to-nix",
         "nix-filter": "nix-filter",
         "nix-npm-buildPackage": "nix-npm-buildPackage",
-        "nixpkgs": "nixpkgs",
+        "nix-utils": "nix-utils",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-mozilla": "nixpkgs-mozilla",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository",
@@ -290,7 +340,7 @@
     },
     "utils": {
       "inputs": {
-        "flake-utils": "flake-utils_2"
+        "flake-utils": "flake-utils_3"
       },
       "locked": {
         "lastModified": 1638172912,

--- a/nix/debian.nix
+++ b/nix/debian.nix
@@ -1,0 +1,8 @@
+{ rpmDebUtils, ocamlPackages_mina }: {
+  # FIXME: This package basically just wraps some nix store paths in the .deb format.
+  # It works, but has some problems.
+  # In particular, if there's already Nix installed on the target system, it won't work.
+  # Also, after this package is installed, installing Nix is likely to be wonky.
+  # We should fix it, e.g. by installing the nix store somewhere else, e.g. /opt/mina/nix/store, and use user namespaces to remap it to /nix/store.
+  mina = rpmDebUtils.buildFakeSingleDeb ocamlPackages_mina.mina;
+}


### PR DESCRIPTION
Build a deb package with Nix.

Caveat emptor:

> This package basically just wraps some nix store paths in the .deb format.
> It works, but has some problems.
> In particular, if there's already Nix installed on the target system, it won't work.
> Also, after this package is installed, installing Nix is likely to be wonky.
> We should fix it, e.g. by installing the nix store somewhere else, e.g. /opt/mina/nix/store, and use user namespaces to remap it to /nix/store.

We also might want to publish the package somewhere, but this can be done in the future. For now, it can be downloaded from the cache.