### PR TITLE
Add `Zkapp_examples` tests for delegate calls

### DIFF
--- a/src/lib/zkapps_examples/calls/dune
+++ b/src/lib/zkapps_examples/calls/dune
@@ -12,6 +12,7 @@
    kimchi_backend_common
    kimchi_pasta
    mina_base
+   mina_base.import
    pickles
    pickles.backend
    pickles_types


### PR DESCRIPTION
This PR
* adds support for setting the `caller` separately from the `token_id` in the `Zkapp_examples` test API
* updates the current composability test to exercise delegate calls

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them

This PR closes https://github.com/MinaProtocol/mina/issues/10825.