### PR TITLE
Rosetta: Fix malformed version number returned by Rosetta.

### DIFF
--- a/src/app/rosetta/lib/network.ml
+++ b/src/app/rosetta/lib/network.ml
@@ -394,7 +394,7 @@ module Options = struct
     let handle (_network : Network_request.t) =
       M.return @@
       { Network_options_response.version=
-          Version.create "1.4.9" "v1.0"
+          Version.create "1.4.9" "1.0.0"
       ; allow=
           { Allow.operation_statuses= Lazy.force Operation_statuses.all
           ; operation_types= Lazy.force Operation_types.all


### PR DESCRIPTION
Rosetta API is required to provide version numbers of the software running the network it describes. According to the documentation these version numbers should consist of the 3 standard components (major version, minor version and patch number). In our implementation some of these versions are preceded by `v` character, which is redundant, since it's obvious from the context that it's a version number. Also it only has 2 components rather than 3. This PR fixes this by switching to 3-component version numbers everywhere.

Testing:
* Spin up the Rosetta node and query the `/network/options` endpoint. All the version numbers returned should consist of 3 components.