### PR TITLE
Rosetta: add operation types related to zkApps.

### DIFF
--- a/src/lib/rosetta_lib/operation_types.ml
+++ b/src/lib/rosetta_lib/operation_types.ml
@@ -12,7 +12,9 @@ type t =
   | `Fee_payment
   | `Delegate_change
   | `Create_token
-  | `Mint_tokens ]
+  | `Mint_tokens
+  | `Zkapp_fee_payer_dec
+  | `Zkapp_balance_update ]
 [@@deriving to_representatives]
 
 let name = function
@@ -40,5 +42,9 @@ let name = function
       "create_token"
   | `Mint_tokens ->
       "mint_tokens"
+  | `Zkapp_fee_payer_dec ->
+      "zkapp_fee_payer_dec"
+  | `Zkapp_balance_update ->
+      "zkapp_balance_update"
 
 let all = to_representatives |> Lazy.map ~f:(List.map ~f:name)


### PR DESCRIPTION
Add operation types introduced with ZKApps to Rosetta. This change is necessary for the hard fork so that Coinbase correctly displays operations created by ZKApps.

The code still compiles and passes the tests.

* Closes #11848
