### PR TITLE
Add top version tag for Base58Check signatures

### DIFF
--- a/frontend/mina-signer/package.json
+++ b/frontend/mina-signer/package.json
@@ -9,7 +9,7 @@
     "chmod-wasm": "chmod 0666 src/plonk_wasm.js && chmod 0666 src/plonk_wasm_bg.wasm",
     "copy-wasm": "cp ../../_build/default/src/lib/crypto/kimchi_bindings/js/node_js/plonk_wasm.js src && cp ../../_build/default/src/lib/crypto/kimchi_bindings/js/node_js/plonk_wasm_bg.wasm src && npm run chmod-wasm",
     "make-jsoo": "make -C ../.. client_sdk && npm run copy-jsoo",
-    "test": "jest",
+    "test": "for f in ./tests/*.test.ts; do jest $f || exit 1; done",
     "prepublishOnly": "npm run make-jsoo && npm run copy-wasm && npm run build && npm run test"
   },
   "keywords": [

--- a/frontend/mina-signer/tests/party.test.ts
+++ b/frontend/mina-signer/tests/party.test.ts
@@ -95,7 +95,7 @@ let mockedZkappCommand = {
       authorization: {
         proof: null,
         signature:
-          "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt",
+          "7mX5N5V5mW1HtH6X2bVNadxkqQLtSyDDsp8RSgWxCwweAy2mjjuifxRMcpFNnyru2LerpNtkxrHmHCczyS8uqHpQQXQUzgNF",
       },
     },
   ],

--- a/src/lib/mina_base/signature.ml
+++ b/src/lib/mina_base/signature.ml
@@ -4,7 +4,13 @@ open Core_kernel
 open Snark_params.Tick
 
 module Arg = struct
-  type t = (Field.t, Inner_curve.Scalar.t) Signature_poly.Stable.Latest.t
+  (* top version tag for compatibility with pre-Berkeley hard fork
+     Base58Check-serialized signatures
+  *)
+  type t =
+    ( Field.t
+    , Inner_curve.Scalar.t )
+    Signature_poly.Stable.Latest.With_top_version_tag.t
   [@@deriving bin_io_unversioned]
 
   let description = "Signature"
@@ -59,3 +65,10 @@ type var = Field.Var.t * Inner_curve.Scalar.var
 [%%define_locally
 Stable.Latest.
   (of_base58_check_exn, of_base58_check, of_yojson, to_yojson, to_base58_check)]
+
+let%test "Base58Check is stable" =
+  let expected =
+    "7mWxjLYgbJUkZNcGouvhVj5tJ8yu9hoexb9ntvPK8t5LHqzmrL6QJjjKtf5SgmxB4QWkDw7qoMMbbNGtHVpsbJHPyTy2EzRQ"
+  in
+  let got = to_base58_check dummy in
+  String.equal got expected

--- a/src/lib/mina_base/signature_poly.ml
+++ b/src/lib/mina_base/signature_poly.ml
@@ -2,6 +2,8 @@ open Core_kernel
 
 [%%versioned
 module Stable = struct
+  [@@@with_top_version_tag]
+
   module V1 = struct
     type ('field, 'scalar) t = 'field * 'scalar
     [@@deriving sexp, compare, equal, hash]

--- a/src/lib/mina_block/sample_precomputed_block.ml
+++ b/src/lib/mina_block/sample_precomputed_block.ml
@@ -591,7 +591,7 @@ let sample_block_json =
                     ]
                   },
                   "signer": "B62qiy32p8kAKnny8ZFwoMhYpBppM1DWVCqAPBYNcXnsAHhnfAAuXgg",
-                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                  "signature": "7mWxjLYgbJUkZNcGouvhVj5tJ8yu9hoexb9ntvPK8t5LHqzmrL6QJjjKtf5SgmxB4QWkDw7qoMMbbNGtHVpsbJHPyTy2EzRQ"
                 }
               ],
               "status": [
@@ -620,7 +620,7 @@ let sample_block_json =
                     ]
                   },
                   "signer": "B62qrA2eWb592uRLtH5ohzQnx7WTLYp2jGirCw5M7Fb9gTf1RrvTPqX",
-                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                  "signature": "7mWxjLYgbJUkZNcGouvhVj5tJ8yu9hoexb9ntvPK8t5LHqzmrL6QJjjKtf5SgmxB4QWkDw7qoMMbbNGtHVpsbJHPyTy2EzRQ"
                 }
               ],
               "status": [
@@ -649,7 +649,7 @@ let sample_block_json =
                     ]
                   },
                   "signer": "B62qpkCEM5N5ddVsYNbFtwWV4bsT9AwuUJXoehFhHUbYYvZ6j3fXt93",
-                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                  "signature": "7mWxjLYgbJUkZNcGouvhVj5tJ8yu9hoexb9ntvPK8t5LHqzmrL6QJjjKtf5SgmxB4QWkDw7qoMMbbNGtHVpsbJHPyTy2EzRQ"
                 }
               ],
               "status": [
@@ -678,7 +678,7 @@ let sample_block_json =
                     ]
                   },
                   "signer": "B62qp5sdhH48MurWgtHNkXUTphEmUfcKVmZFspYAqxcKZ7YxaPF1pyF",
-                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                  "signature": "7mWxjLYgbJUkZNcGouvhVj5tJ8yu9hoexb9ntvPK8t5LHqzmrL6QJjjKtf5SgmxB4QWkDw7qoMMbbNGtHVpsbJHPyTy2EzRQ"
                 }
               ],
               "status": [
@@ -707,7 +707,7 @@ let sample_block_json =
                     ]
                   },
                   "signer": "B62qqR5XfP9CoC5DALUJX2jBoY6aaoLrN46YpM2NQTSV14qgpoWibL7",
-                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                  "signature": "7mWxjLYgbJUkZNcGouvhVj5tJ8yu9hoexb9ntvPK8t5LHqzmrL6QJjjKtf5SgmxB4QWkDw7qoMMbbNGtHVpsbJHPyTy2EzRQ"
                 }
               ],
               "status": [
@@ -736,7 +736,7 @@ let sample_block_json =
                     ]
                   },
                   "signer": "B62qr4GMdg4ZVk1Y6BXaDHxgFRtCsZm2sZiyn7PCmubTZnAi3iZDDxq",
-                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                  "signature": "7mWxjLYgbJUkZNcGouvhVj5tJ8yu9hoexb9ntvPK8t5LHqzmrL6QJjjKtf5SgmxB4QWkDw7qoMMbbNGtHVpsbJHPyTy2EzRQ"
                 }
               ],
               "status": [
@@ -765,7 +765,7 @@ let sample_block_json =
                     ]
                   },
                   "signer": "B62qpgjtMzVpodthL3kMfXAAzzv1kgGZRMEeLv592u4hSVQKCzTGLvA",
-                  "signature": "2Xvuve2hGHS8UTZSKJrqqkySBvsM4gLz3cJns3BoYo3vtEbfKnfZqG3SHU9gLSBpjV3H7Sho3sha7wDUvqvk88wVp6mdLMt"
+                  "signature": "7mWxjLYgbJUkZNcGouvhVj5tJ8yu9hoexb9ntvPK8t5LHqzmrL6QJjjKtf5SgmxB4QWkDw7qoMMbbNGtHVpsbJHPyTy2EzRQ"
                 }
               ],
               "status": [


### PR DESCRIPTION
The Base58Check representation of signatures in `develop` differed from those in `compatible`, because version tags were removed in the serialization of the type `Signature_poly.Stable.V1.t`.

Add the tag back in using `@@@with_top_version_tag`. Use that `Bin_prot` serialization only for Base58Check.

Add a test to compare the Base58Check representation of the dummy signature with an expected result, obtained from serializing that signature in the `compatible` branch.