### PR TITLE
Add `rosetta-cli` to the nix development shells.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -191,6 +191,10 @@
         ocamlPackages = pkgs.ocamlPackages_mina;
 
         debianPackages = pkgs.callPackage ./nix/debian.nix { };
+
+        # Packages for the development environment that are not needed to build mina-dev.
+        # For instance dependencies for tests.
+        devShellPackages = [ pkgs.rosetta-cli ];
       in {
 
         # Jobs/Lint/Rust.dhall
@@ -350,6 +354,7 @@
         packages.mina-deb = debianPackages.mina;
 
         devShell = ocamlPackages.mina-dev.overrideAttrs (oa: {
+          buildInputs = oa.buildInputs ++ devShellPackages;
           shellHook = ''
             ${oa.shellHook}
             unset MINA_COMMIT_DATE MINA_COMMIT_SHA1 MINA_BRANCH
@@ -359,7 +364,7 @@
 
         devShells.with-lsp = ocamlPackages.mina-dev.overrideAttrs (oa: {
           name = "mina-with-lsp";
-          buildInputs = oa.buildInputs ++ [ pkgs.go_1_18 ];
+          buildInputs = oa.buildInputs ++ [ pkgs.go_1_18 ] ++ devShellPackages;
           nativeBuildInputs = oa.nativeBuildInputs
             ++ [ ocamlPackages.ocaml-lsp-server ];
           shellHook = ''
@@ -382,6 +387,7 @@
         # However, this is a useful balance between purity and convenience for Rust development.
         devShells.rust-impure = ocamlPackages.mina-dev.overrideAttrs (oa: {
           name = "mina-rust-shell";
+          buildInputs = oa.buildInputs ++ devShellPackages;
           nativeBuildInputs = oa.nativeBuildInputs ++ [
             pkgs.rustup
             pkgs.libiconv # needed on macOS for one of the rust dep

--- a/flake.nix
+++ b/flake.nix
@@ -364,7 +364,7 @@
 
         devShells.with-lsp = ocamlPackages.mina-dev.overrideAttrs (oa: {
           name = "mina-with-lsp";
-          buildInputs = oa.buildInputs ++ [ pkgs.go_1_18 ] ++ devShellPackages;
+          buildInputs = oa.buildInputs ++ devShellPackages;
           nativeBuildInputs = oa.nativeBuildInputs
             ++ [ ocamlPackages.ocaml-lsp-server ];
           shellHook = ''

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -75,4 +75,17 @@ final: prev: {
       sed -i 's/.*libp2p_ipc.*//' go.mod
     '';
   };
+
+  # Tool for testing implementation of the rosetta api
+  rosetta-cli = final.buildGoModule rec {
+    pname = "rosetta-cli";
+    version = "0.10.0";
+    src = final.fetchFromGitHub {
+      owner = "coinbase";
+      repo = "rosetta-cli";
+      rev = "085f95c85c99f607a82fb1814594d95dc9fefb55";
+      sha256 = "I3fNRiMwuk5FWiECu31Z5A23djUR0GHugy1OqNruzj8=";
+    };
+    vendorSha256 = "sha256-ooFpB17Yu9aILx3kl2o6WVbbX110YeSdcC0RIaBUwzM=";
+  };
 }

--- a/nix/impure-shell.nix
+++ b/nix/impure-shell.nix
@@ -20,6 +20,7 @@ pkgs.mkShell {
     rustup
     wasm-pack
     lmdb
+    rosetta-cli
   ];
   OPAMSWITCH = "mina";
   shellHook = ''


### PR DESCRIPTION
This PR adds the `rosetta-cli` tool to the nix development environments, the plan is to use this tool to test the implementation of the rosetta protocol.

I did not find it on nixpkgs so it is built using `buildGoModule`.