### PR TITLE
Fix use of Format in printers

### DIFF
--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -120,8 +120,9 @@ let validate_transaction =
                 | Error err ->
                     incr num_fails ;
                     Format.eprintf
-                      "Failed to validate transaction:@.%s@.Failed with \
-                       error:%s@."
+                      "@[<v>Failed to validate transaction:@,\
+                       %s@,\
+                       Failed with error:%s@]@."
                       (Yojson.Safe.pretty_to_string transaction_json)
                       (Yojson.Safe.pretty_to_string
                          (Error_json.error_to_yojson err) ) )
@@ -130,7 +131,7 @@ let validate_transaction =
     | Ok () ->
         ()
     | Error err ->
-        Format.eprintf "Error:@.%s@.@."
+        Format.eprintf "@[<v>Error:@,%s@,@]@."
           (Yojson.Safe.pretty_to_string (Error_json.error_to_yojson err)) ;
         Format.printf "Invalid transaction.@." ;
         Core_kernel.exit 1 ) ;
@@ -284,7 +285,7 @@ module Vrf = struct
                 | Ok x ->
                     x
                 | Error err ->
-                    Format.eprintf "Error:@.%s@.@."
+                    Format.eprintf "@[<v>Error:@,%s@,@]@."
                       (Yojson.Safe.pretty_to_string
                          (Error_json.error_to_yojson err) ) ;
                     `Repeat () )
@@ -338,7 +339,7 @@ module Vrf = struct
             | Ok x ->
                 x
             | Error err ->
-                Format.eprintf "Error:@.%s@.@."
+                Format.eprintf "@[<v>Error:@,%s@,@]@."
                   (Yojson.Safe.pretty_to_string
                      (Error_json.error_to_yojson err) ) ;
                 `Repeat () )

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -94,7 +94,7 @@ module TextFormat_0_0_4 = struct
   let output f =
     MetricFamilyMap.iter (fun metric samples ->
         let { MetricInfo.name; metric_type; help; label_names } = metric in
-        Fmt.pf f "#HELP %a %a@.#TYPE %a %a@.%a" MetricName.pp name
+        Fmt.pf f "@[<v>#HELP %a %a@,#TYPE %a %a@,%a@]" MetricName.pp name
           output_unquoted help MetricName.pp name output_metric_type metric_type
           (LabelSetMap.pp ~sep:Fmt.nop (output_metric ~name ~label_names))
           samples )

--- a/src/lib/snark_worker/standalone/run_snark_worker.ml
+++ b/src/lib/snark_worker/standalone/run_snark_worker.ml
@@ -30,13 +30,14 @@ let command =
        match%bind Prod.perform_single worker_state ~message spec with
        | Ok (proof, time) ->
            Caml.Format.printf
-             !"Successfully proved in %{sexp: Time.Span.t}.@.Proof \
-               was:@.%{sexp: Transaction_snark.t}@."
+             !"@[<v>Successfully proved in %{sexp: Time.Span.t}.@,\
+               Proof was:@,\
+               %{sexp: Transaction_snark.t}@]@."
              time proof ;
            exit 0
        | Error err ->
            Caml.Format.printf
-             !"Proving failed with error:@.%s"
+             !"Proving failed with error: %s@."
              (Error.to_string_hum err) ;
            exit 1 )
 

--- a/src/lib/transaction_consistency_tests/transaction_consistency_tests.ml
+++ b/src/lib/transaction_consistency_tests/transaction_consistency_tests.ml
@@ -364,8 +364,10 @@ let%test_module "transaction logic consistency" =
             let error = Error.of_exn ~backtrace:`Get exn in
             passed := false ;
             Format.printf
-              "The following transaction was inconsistently \
-               applied:@.%s@.%s@.%s@."
+              "@[<v>The following transaction was inconsistently applied:@,\
+               %s@,\
+               %s@,\
+               %s@]@."
               (Yojson.Safe.pretty_to_string
                  (Transaction.Valid.to_yojson transaction) )
               (Yojson.Safe.to_string (Sparse_ledger.to_yojson ledger))
@@ -590,8 +592,10 @@ let%test_module "transaction logic consistency" =
             let error = Error.of_exn ~backtrace:`Get exn in
             passed := false ;
             Format.printf
-              "The following transaction was inconsistently \
-               applied:@.%s@.%s@.%s@."
+              "@[<v>The following transaction was inconsistently applied:@,\
+               %s@,\
+               %s@,\
+               %s@]@."
               (Yojson.Safe.pretty_to_string
                  (Transaction.Valid.to_yojson transaction) )
               (Yojson.Safe.to_string (Sparse_ledger.to_yojson ledger))

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -260,8 +260,8 @@ module Statement = struct
       in
       if !top_hash_logging_enabled then
         Format.eprintf
-          !"Generating unchecked top hash from:@.%{sexp: Tick.Field.t \
-            Random_oracle.Input.Chunked.t}@."
+          !"@[<v>Generating unchecked top hash from:@,\
+            %{sexp: Tick.Field.t Random_oracle.Input.Chunked.t}@]@."
           input ;
       input
 
@@ -294,8 +294,8 @@ module Statement = struct
               if !top_hash_logging_enabled then
                 let%map input = Random_oracle.read_typ' input in
                 Format.eprintf
-                  !"Generating checked top hash from:@.%{sexp: Field.t \
-                    Random_oracle.Input.Chunked.t}@."
+                  !"@[<v>Generating checked top hash from:@,\
+                    %{sexp: Field.t Random_oracle.Input.Chunked.t}@]@."
                   input
               else return ())
         in


### PR DESCRIPTION
The `@.` indication  in  `Format` inserts a newline *and* flushes. When outputting multiple lines, you usually want to avoid flushing after every line.

Mainly, one just wants new lines inserted, e.g., with a single v-box to also benefit from Format's indenting capabilities (see https://caml.inria.fr/resources/doc/guides/format.en.html#boxes for the different kinds of boxes) and flush at the end only.

This PR refactors several occurrences of overuse of `@.`, sometimes going as far as grouping together within a single formatting string several consecutive calls to pretty-printers.




