### PR TITLE
Avoid using List.length in comparing the length of a list

### DIFF
--- a/src/app/swap_bad_balances/dune
+++ b/src/app/swap_bad_balances/dune
@@ -19,6 +19,7 @@
    async.async_command
    ;; local libraries
    currency
+   mina_stdlib
    logger
  )
  (preprocessor_deps ../../config.mlh)

--- a/src/app/swap_bad_balances/swap_bad_balances.ml
+++ b/src/app/swap_bad_balances/swap_bad_balances.ml
@@ -30,7 +30,7 @@ let main ~archive_uri ~state_hash ~sequence_no () =
               sequence_no )
           ~item:"receiver balance ids"
       in
-      if List.length receiver_balance_ids <> 2 then (
+      if Mina_stdlib.List.Length.Compare.(receiver_balance_ids <> 2) then (
         [%log fatal]
           "Expected two receiver balance ids, one for each fee transfer" ;
         Core_kernel.exit 1 ) ;

--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -134,7 +134,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          in
          let%bind () =
            ok_if_true "not enough blocks"
-             (List.length blocks >= min_resulting_blocks)
+             Mina_stdlib.List.Length.Compare.(blocks >= min_resulting_blocks)
          in
          let tx_counts =
            Array.of_list

--- a/src/app/test_executive/dune
+++ b/src/app/test_executive/dune
@@ -24,6 +24,7 @@
    integration_test_lib
    signature_lib
    mina_base
+   mina_stdlib
    mina_transaction
    file_system
    currency

--- a/src/app/test_executive/test_common.ml
+++ b/src/app/test_executive/test_common.ml
@@ -201,11 +201,10 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       |> List.filter ~f:(fun log ->
              String.is_substring log ~substring:info_log_substring )
     in
-    let num_info_logs = List.length info_logs in
-    if num_info_logs < 25 then
+    if Mina_stdlib.List.Length.Compare.(info_logs < 25) then
       Malleable_error.hard_error_string
         (sprintf "Replayer output contains suspiciously few (%d) Info logs"
-           num_info_logs )
+           (List.length info_logs) )
     else if List.is_empty error_logs then (
       [%log info] "The replayer encountered no errors" ;
       Malleable_error.return () )

--- a/src/app/test_executive/test_executive.ml
+++ b/src/app/test_executive/test_executive.ml
@@ -132,62 +132,65 @@ let report_test_errors ~log_error_set ~internal_error_set =
         Print.eprintf "\n" )
   in
   (* check invariants *)
-  if List.length log_errors.from_current_context > 0 then
-    failwith "all error logs should be contextualized by node id" ;
-  (* report log errors *)
-  Print.eprintf "\n" ;
-  ( match log_errors_severity with
-  | `None ->
-      ()
-  | `Soft ->
-      report_log_errors "Warning"
-  | `Hard ->
-      report_log_errors "Error" ) ;
-  (* report contextualized internal errors *)
-  color_eprintf Bash_colors.magenta "=== Test Results ===\n" ;
-  Error_accumulator.iter_contexts internal_errors ~f:(fun context errors ->
-      print_category_header
-        (max_severity_of_list (List.map errors ~f:fst))
-        "%s" context ;
-      List.iter errors ~f:(fun (severity, { occurrence_time; error }) ->
+  match log_errors.from_current_context with
+  | _ :: _ ->
+      failwith "all error logs should be contextualized by node id"
+  | [] ->
+      (* report log errors *)
+      Print.eprintf "\n" ;
+      ( match log_errors_severity with
+      | `None ->
+          ()
+      | `Soft ->
+          report_log_errors "Warning"
+      | `Hard ->
+          report_log_errors "Error" ) ;
+      (* report contextualized internal errors *)
+      color_eprintf Bash_colors.magenta "=== Test Results ===\n" ;
+      Error_accumulator.iter_contexts internal_errors ~f:(fun context errors ->
+          print_category_header
+            (max_severity_of_list (List.map errors ~f:fst))
+            "%s" context ;
+          List.iter errors ~f:(fun (severity, { occurrence_time; error }) ->
+              color_eprintf
+                (color_of_severity severity)
+                "    [%s] %s\n"
+                (Time.to_string occurrence_time)
+                (Error.to_string_hum error) ) ) ;
+      (* report non-contextualized internal errors *)
+      List.iter internal_errors.from_current_context
+        ~f:(fun (severity, { occurrence_time; error }) ->
           color_eprintf
             (color_of_severity severity)
-            "    [%s] %s\n"
+            "[%s] %s\n"
             (Time.to_string occurrence_time)
-            (Error.to_string_hum error) ) ) ;
-  (* report non-contextualized internal errors *)
-  List.iter internal_errors.from_current_context
-    ~f:(fun (severity, { occurrence_time; error }) ->
-      color_eprintf
-        (color_of_severity severity)
-        "[%s] %s\n"
-        (Time.to_string occurrence_time)
-        (Error.to_string_hum error) ) ;
-  (* determine if test is passed/failed and exit accordingly *)
-  let test_failed =
-    match (log_errors_severity, internal_errors_severity) with
-    | _, `Hard | _, `Soft ->
-        true
-    (* TODO: re-enable log error checks after libp2p logs are cleaned up *)
-    | `Hard, _ | `Soft, _ | `None, `None ->
-        false
-  in
-  Print.eprintf "\n" ;
-  let exit_code =
-    if test_failed then (
-      color_eprintf Bash_colors.red
-        "The test has failed. See the above errors for details.\n\n" ;
-      match (internal_error_set.exit_code, log_error_set.exit_code) with
-      | None, None ->
-          Some 1
-      | Some exit_code, _ | None, Some exit_code ->
-          Some exit_code )
-    else (
-      color_eprintf Bash_colors.green "The test has completed successfully.\n\n" ;
-      None )
-  in
-  let%bind () = Writer.(flushed (Lazy.force stderr)) in
-  return exit_code
+            (Error.to_string_hum error) ) ;
+      (* determine if test is passed/failed and exit accordingly *)
+      let test_failed =
+        match (log_errors_severity, internal_errors_severity) with
+        | _, `Hard | _, `Soft ->
+            true
+        (* TODO: re-enable log error checks after libp2p logs are cleaned up *)
+        | `Hard, _ | `Soft, _ | `None, `None ->
+            false
+      in
+      Print.eprintf "\n" ;
+      let exit_code =
+        if test_failed then (
+          color_eprintf Bash_colors.red
+            "The test has failed. See the above errors for details.\n\n" ;
+          match (internal_error_set.exit_code, log_error_set.exit_code) with
+          | None, None ->
+              Some 1
+          | Some exit_code, _ | None, Some exit_code ->
+              Some exit_code )
+        else (
+          color_eprintf Bash_colors.green
+            "The test has completed successfully.\n\n" ;
+          None )
+      in
+      let%bind () = Writer.(flushed (Lazy.force stderr)) in
+      return exit_code
 
 (* TODO: refactor cleanup system (smells like a monad for composing linear resources would help a lot) *)
 

--- a/src/lib/bootstrap_controller/dune
+++ b/src/lib/bootstrap_controller/dune
@@ -35,6 +35,7 @@
    mina_block
    mina_base
    mina_ledger
+   mina_stdlib
    mina_transaction_logic
    syncable_ledger
    consensus

--- a/src/lib/bootstrap_controller/transition_cache.ml
+++ b/src/lib/bootstrap_controller/transition_cache.ml
@@ -29,6 +29,8 @@ let add (t : t) ~parent new_child =
 let data t =
   let collected_transitions = State_hash.Table.data t |> List.concat in
   assert (
-    List.length collected_transitions
-    = List.length (List.stable_dedup collected_transitions) ) ;
+    Stdlib.List.compare_lengths collected_transitions
+      (List.stable_dedup collected_transitions)
+    = 0 )
+  (* TODO: make this assertion more efficient *) ;
   collected_transitions

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -59,6 +59,7 @@
    mina_metrics
    mina_numbers
    mina_numbers_unix
+   mina_stdlib
    signature_lib
    snarky.backendless
    blake2

--- a/src/lib/genesis_ledger_helper/lib/dune
+++ b/src/lib/genesis_ledger_helper/lib/dune
@@ -24,6 +24,7 @@
    coda_genesis_proof
    signature_lib
    mina_numbers
+   mina_stdlib
    with_hash
    currency
    pickles.backend

--- a/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
+++ b/src/lib/genesis_ledger_helper/lib/genesis_ledger_helper_lib.ml
@@ -122,31 +122,34 @@ module Accounts = struct
             } ->
             let%bind app_state =
               if
-                Pickles_types.Nat.to_int Zkapp_state.Max_state_size.n
-                <> List.length state
-              then
+                Mina_stdlib.List.Length.Compare.(
+                  state = Pickles_types.Nat.to_int Zkapp_state.Max_state_size.n)
+              then Ok (Zkapp_state.V.of_list_exn state)
+              else
                 Or_error.errorf
                   !"Snap account state has invalid length %{sexp: \
                     Runtime_config.Accounts.Single.t} length: %d"
                   t (List.length state)
-              else Ok (Zkapp_state.V.of_list_exn state)
             in
+
             let verification_key =
               Option.map verification_key
                 ~f:(With_hash.of_data ~hash_data:Zkapp_account.digest_vk)
             in
             let%map sequence_state =
               if
-                Pickles_types.Nat.to_int Pickles_types.Nat.N5.n
-                <> List.length sequence_state
-              then
+                Mina_stdlib.List.Length.Compare.(
+                  sequence_state
+                  = Pickles_types.Nat.to_int Pickles_types.Nat.N5.n)
+              then Ok (Pickles_types.Vector.Vector_5.of_list_exn sequence_state)
+              else
                 Or_error.errorf
                   !"Snap account sequence_state has invalid length %{sexp: \
                     Runtime_config.Accounts.Single.t} length: %d"
                   t
                   (List.length sequence_state)
-              else Ok (Pickles_types.Vector.Vector_5.of_list_exn sequence_state)
             in
+
             let last_sequence_slot =
               Mina_numbers.Global_slot.of_int last_sequence_slot
             in

--- a/src/lib/integration_test_cloud_engine/dune
+++ b/src/lib/integration_test_cloud_engine/dune
@@ -40,6 +40,7 @@
    mina_version
    timeout_lib
    mina_numbers
+   mina_stdlib
    mina_transaction
    file_system
    pickles

--- a/src/lib/integration_test_cloud_engine/kubernetes_network.ml
+++ b/src/lib/integration_test_cloud_engine/kubernetes_network.ml
@@ -1071,7 +1071,7 @@ module Workload = struct
       |> List.filter ~f:(Fn.compose not String.is_empty)
       |> List.map ~f:(String.substr_replace_first ~pattern:"pod/" ~with_:"")
     in
-    if List.length t.node_info <> List.length pod_ids then
+    if Stdlib.List.compare_lengths t.node_info pod_ids <> 0 then
       failwithf
         "Unexpected number of replicas in kubernetes deployment for workload \
          %s: expected %d, got %d"
@@ -1169,7 +1169,7 @@ let initialize_infra ~logger network =
     result_str |> String.split_lines
     |> List.map ~f:(fun line ->
            let parts = String.split line ~on:':' in
-           assert (List.length parts = 2) ;
+           assert (Mina_stdlib.List.Length.Compare.(parts = 2)) ;
            (List.nth_exn parts 0, List.nth_exn parts 1) )
     |> List.filter ~f:(fun (pod_name, _) ->
            String.Set.mem all_pods_set pod_name )

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -121,14 +121,12 @@ module Network_config = struct
            1 )
         num_block_producers
     in
-    if List.length bp_keypairs < num_block_producers then
+    if Mina_stdlib.List.Length.Compare.(bp_keypairs < num_block_producers) then
       failwith
         "not enough sample keypairs for specified number of block producers" ;
-    assert (List.length bp_keypairs >= num_block_producers) ;
-    if List.length bp_keypairs < num_block_producers then
-      failwith
-        "not enough sample keypairs for specified number of extra keypairs" ;
-    assert (List.length extra_keypairs >= List.length extra_genesis_accounts) ;
+
+    assert (
+      Stdlib.List.compare_lengths extra_keypairs extra_genesis_accounts >= 0 ) ;
     let extra_keypairs_cut =
       List.take extra_keypairs (List.length extra_genesis_accounts)
     in

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -302,7 +302,7 @@ let rec pull_subscription_in_background ~logger ~network ~event_writer
     let%bind log_entries =
       Deferred.map (Subscription.pull ~logger subscription) ~f:Or_error.ok_exn
     in
-    if List.length log_entries > 0 then
+    if log_entries <> [] then
       [%log spam] "Parsing events from $n logs"
         ~metadata:[ ("n", `Int (List.length log_entries)) ]
     else [%log spam] "No logs were pulled" ;

--- a/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
+++ b/src/lib/integration_test_cloud_engine/stack_driver_log_engine.ml
@@ -302,10 +302,12 @@ let rec pull_subscription_in_background ~logger ~network ~event_writer
     let%bind log_entries =
       Deferred.map (Subscription.pull ~logger subscription) ~f:Or_error.ok_exn
     in
-    if log_entries <> [] then
-      [%log spam] "Parsing events from $n logs"
-        ~metadata:[ ("n", `Int (List.length log_entries)) ]
-    else [%log spam] "No logs were pulled" ;
+    ( match log_entries with
+    | [] ->
+        [%log spam] "No logs were pulled"
+    | log_entries ->
+        [%log spam] "Parsing events from $n logs"
+          ~metadata:[ ("n", `Int (List.length log_entries)) ] ) ;
     let%bind () =
       Deferred.List.iter ~how:`Sequential log_entries ~f:(fun log_entry ->
           ( match log_entry |> parse_event_from_log_entry ~logger ~network with

--- a/src/lib/merkle_ledger_tests/dune
+++ b/src/lib/merkle_ledger_tests/dune
@@ -27,6 +27,7 @@
    codable
    mina_base_import
    mina_numbers
+   mina_stdlib
    data_hash_lib
    key_value_database
    merkle_address

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -425,7 +425,8 @@ let%test_module "test functor on in memory databases" =
                 List.map ~f:snd
                 @@ MT.get_all_accounts_rooted_at_exn mdb (MT.Addr.root ())
               in
-              assert (List.length accounts = List.length retrieved_accounts) ;
+              assert (
+                Stdlib.List.compare_lengths accounts retrieved_accounts = 0 ) ;
               assert (List.equal Account.equal accounts retrieved_accounts) )
 
       let%test_unit "removing accounts restores Merkle root" =

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -364,7 +364,7 @@ module Make (Test : Test_intf) = struct
             @@ Mask.Attached.get_all_accounts_rooted_at_exn attached_mask
                  (Mask.Addr.root ())
           in
-          assert (List.length accounts = List.length retrieved_accounts) ;
+          assert (Stdlib.List.compare_lengths accounts retrieved_accounts = 0) ;
           assert (List.equal Account.equal accounts retrieved_accounts) )
 
   let%test_unit "get_all_accounts should preserve the ordering of accounts by \
@@ -421,9 +421,7 @@ module Make (Test : Test_intf) = struct
                  (Mask.Addr.root ())
           in
           assert (
-            Int.equal
-              (List.length base_accounts)
-              (List.length retrieved_accounts) ) ;
+            Stdlib.List.compare_lengths base_accounts retrieved_accounts = 0 ) ;
           assert (List.equal Account.equal expected_accounts retrieved_accounts) )
 
   let%test_unit "removing accounts from mask restores Merkle root" =
@@ -561,7 +559,7 @@ module Make (Test : Test_intf) = struct
             ignore @@ create_existing_account_exn attached_mask account ) ;
         let mask_list = Mask.Attached.to_list attached_mask in
         (* same number of accounts after adding them to mask *)
-        assert (Int.equal (List.length parent_list) (List.length mask_list)) ;
+        assert (Stdlib.List.compare_lengths parent_list mask_list = 0) ;
         (* should only see the zero balances in mask list *)
         let is_in_same_order =
           List.for_all2_exn parent_list mask_list
@@ -675,7 +673,7 @@ module Make (Test : Test_intf) = struct
         in
         (* the number of accounts in parent, mask should agree *)
         assert (
-          Int.equal parent_num_accounts (List.length accounts)
+          Mina_stdlib.List.Length.Compare.(accounts = parent_num_accounts)
           && Int.equal parent_num_accounts mask_num_accounts_before
           && Int.equal parent_num_accounts mask_num_accounts_after ) )
 

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -35,6 +35,7 @@
    transition_frontier_base
    with_hash
    currency
+   mina_stdlib
    mina_user_error
    gossip_net
    transition_frontier

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -874,7 +874,8 @@ let best_chain ?max_length t =
   in
   let best_tip_path = Transition_frontier.best_tip_path ?max_length frontier in
   match max_length with
-  | Some max_length when max_length <= List.length best_tip_path ->
+  | Some max_length
+    when Mina_stdlib.List.Length.Compare.(best_tip_path > max_length) ->
       (* The [best_tip_path] has already been truncated to the correct length,
          we skip adding the root to stay below the maximum.
       *)

--- a/src/lib/mina_net2/tests/all_ipc.ml
+++ b/src/lib/mina_net2/tests/all_ipc.ml
@@ -183,7 +183,7 @@ let%test_module "all-ipc test" =
       in
       (* Get addresses of Alice *)
       let%bind lAddrs = listening_addrs a >>| Or_error.ok_exn in
-      assert (List.length lAddrs > 0) ;
+      assert (Mina_stdlib.List.Length.Compare.(lAddrs > 0)) ;
       (* Await Carol to connect *)
       (* This is done mainly to test PeerConnected upcall *)
       let%bind () =
@@ -320,7 +320,7 @@ let%test_module "all-ipc test" =
 
       (* List peers of Alice *)
       let%bind peers = peers a in
-      assert (List.length peers >= 2) ;
+      assert (Mina_stdlib.List.Length.Compare.(peers >= 2)) ;
       assert (
         List.fold [ ad.y_peerid; ad.b_peerid; ad.c_peerid ] ~init:true
           ~f:(fun b_acc pid ->

--- a/src/lib/mina_net2/tests/dune
+++ b/src/lib/mina_net2/tests/dune
@@ -13,6 +13,7 @@
    base.caml
    ;; local libraries
    mina_net2
+   mina_stdlib
    inline_test_quiet_logs
    logger
    child_processes

--- a/src/lib/mina_stdlib/dune
+++ b/src/lib/mina_stdlib/dune
@@ -1,0 +1,10 @@
+(library
+ (name mina_stdlib)
+ (public_name mina_stdlib)
+ (modules_without_implementation
+  sigs)
+ (libraries base.caml)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess (pps ppx_version)))
+

--- a/src/lib/mina_stdlib/list.ml
+++ b/src/lib/mina_stdlib/list.ml
@@ -1,0 +1,29 @@
+module Length = struct
+  type 'a t = ('a list, int) Sigs.predicate2
+
+  let equal l len = Caml.List.compare_length_with l len = 0
+
+  let unequal l len = Caml.List.compare_length_with l len <> 0
+
+  let gte l len = Caml.List.compare_length_with l len >= 0
+
+  let gt l len = Caml.List.compare_length_with l len > 0
+
+  let lte l len = Caml.List.compare_length_with l len <= 0
+
+  let lt l len = Caml.List.compare_length_with l len < 0
+
+  module Compare = struct
+    let ( = ) = equal
+
+    let ( <> ) = unequal
+
+    let ( >= ) = gte
+
+    let ( > ) = gt
+
+    let ( <= ) = lte
+
+    let ( < ) = lt
+  end
+end

--- a/src/lib/mina_stdlib/list.mli
+++ b/src/lib/mina_stdlib/list.mli
@@ -1,0 +1,52 @@
+(** {1 Predicates over list lengths}*)
+
+module Length : sig
+  type 'a t = ('a list, int) Sigs.predicate2
+
+  (** [equal l len] returns [true] if [List.length l = len], [false] otherwise.
+   *)
+  val equal : 'a t
+
+  (** [gte l len] returns [true] if [List.length l >= len], [false]
+    otherwise.
+   *)
+  val gte : 'a t
+
+  (** [gt l len] returns [true] if [List.length l > len], [false]
+    otherwise.
+   *)
+  val gt : 'a t
+
+  (** [lte l len] returns [true] if [List.length l <= len], [false]
+    otherwise.
+   *)
+  val lte : 'a t
+
+  (** [lt l len] returns [true] if [List.length l < len], [false]
+    otherwise.
+   p*)
+  val lt : 'a t
+
+  (** {2 Infix comparison operators} *)
+
+  (** [Compare] contains infix aliases for functions of {!module:Length} *)
+  module Compare : sig
+    (** [( = )] is [equal] *)
+    val ( = ) : 'a t
+
+    (** [( <> )] is [unequal] *)
+    val ( <> ) : 'a t
+
+    (** [( >= )] is [gte] *)
+    val ( >= ) : 'a t
+
+    (** [l > len] is [gt] *)
+    val ( > ) : 'a t
+
+    (** [( <= )] is [lte] *)
+    val ( <= ) : 'a t
+
+    (** [l < len] is [lt] *)
+    val ( < ) : 'a t
+  end
+end

--- a/src/lib/mina_stdlib/sigs.mli
+++ b/src/lib/mina_stdlib/sigs.mli
@@ -1,0 +1,4 @@
+(** Recurrent type and signature definitions *)
+
+(** Polymorphic binary predicates *)
+type ('a, 'b) predicate2 = 'a -> 'b -> bool

--- a/src/lib/ppx_version/bin_io_unversioned.ml
+++ b/src/lib/ppx_version/bin_io_unversioned.ml
@@ -91,21 +91,24 @@ let ctxt_base =
     ~input_name:""
 
 let rewrite_to_bin_io ~loc ~path (_rec_flag, type_decls) =
-  let type_decl1 = List.hd_exn type_decls in
-  if not (Int.equal (List.length type_decls) 1) then
-    Location.raise_errorf ~loc
-      "deriving bin_io_unversioned can only be used on a single type" ;
-  let module_path = List.drop String.(split path ~on:'.') 2 in
-  let inner2_modules = List.take (List.rev module_path) 2 in
-  validate_type_decl inner2_modules type_decl1 ;
-  let ctxt =
-    let derived_item_loc = loc in
-    (* TODO: is inline:false what we want? *)
-    Expansion_context.Deriver.make ~derived_item_loc ~base:ctxt_base ()
-      ~inline:false
-  in
-  List.concat_map bin_io_gens ~f:(fun gen ->
-      gen ~ctxt (Nonrecursive, type_decls) [] )
+  match type_decls with
+  | [] ->
+      assert false (* cannot happen *)
+  | [ type_decl1 ] ->
+      let module_path = List.drop String.(split path ~on:'.') 2 in
+      let inner2_modules = List.take (List.rev module_path) 2 in
+      validate_type_decl inner2_modules type_decl1 ;
+      let ctxt =
+        let derived_item_loc = loc in
+        (* TODO: is inline:false what we want? *)
+        Expansion_context.Deriver.make ~derived_item_loc ~base:ctxt_base ()
+          ~inline:false
+      in
+      List.concat_map bin_io_gens ~f:(fun gen ->
+          gen ~ctxt (Nonrecursive, type_decls) [] )
+  | _ :: _ :: _ ->
+      Location.raise_errorf ~loc
+        "deriving bin_io_unversioned can only be used on a single type"
 
 let str_type_decl :
     (structure, rec_flag * type_declaration list) Ppxlib.Deriving.Generator.t =

--- a/src/lib/ppx_version/versioned_type.ml
+++ b/src/lib/ppx_version/versioned_type.ml
@@ -499,18 +499,22 @@ module Deriving = struct
           versioned_current :: generate_contained_type_version_decls type_decl
 
   let get_type_decl_representative type_decls =
-    let type_decl1 = List.hd_exn type_decls in
-    let type_decl2 = List.hd_exn (List.rev type_decls) in
-    ( if not (Int.equal (List.length type_decls) 1) then
-      let loc =
-        { loc_start = type_decl1.ptype_loc.loc_start
-        ; loc_end = type_decl2.ptype_loc.loc_end
-        ; loc_ghost = true
-        }
-      in
-      Location.raise_errorf ~loc
-        "Versioned type must be just one type \"t\", not a sequence of types" ) ;
-    type_decl1
+    match type_decls with
+    | [ type_decl1 ] ->
+        type_decl1
+    | type_decl1 :: type_decls ->
+        let type_decl2 = List.hd_exn (List.rev type_decls) in
+        let loc =
+          { loc_start = type_decl1.ptype_loc.loc_start
+          ; loc_end = type_decl2.ptype_loc.loc_end
+          ; loc_ghost = true
+          }
+        in
+        Location.raise_errorf ~loc
+          "Versioned type must be just one type \"t\", not a sequence of types"
+    | [] ->
+        assert false
+  (* assumed to not be possible *)
 
   let generate_let_bindings_for_type_decl_str ~loc ~path (_rec_flag, type_decls)
       rpc binable =

--- a/src/lib/rosetta_coding/coding.ml
+++ b/src/lib/rosetta_coding/coding.ml
@@ -75,7 +75,7 @@ let bits_by_8s = bits_by_n 8
 let of_unpackable (type t) (module M : Packed with type t = t)
     ?(padding_bit = false) (packed : t) =
   let bits0 = M.unpack packed |> List.rev in
-  assert (List.length bits0 = 255) ;
+  assert (Mina_stdlib.List.Length.Compare.(bits0 = 255)) ;
   (* field elements, scalars are 255 bits, left-pad to get 32 bytes *)
   let bits = padding_bit :: bits0 in
   (* break of the bits byte by byte *)

--- a/src/lib/rosetta_coding/dune
+++ b/src/lib/rosetta_coding/dune
@@ -9,6 +9,7 @@
    core_kernel
    ppx_inline_test.config
    ;; local libraries
+   mina_stdlib
    snark_params
    signature_lib
 )

--- a/src/lib/rosetta_lib/dune
+++ b/src/lib/rosetta_lib/dune
@@ -20,6 +20,7 @@
    hex
    random_oracle_input
    mina_numbers
+   mina_stdlib
    signature_lib
    snark_params
    rosetta_models

--- a/src/lib/rosetta_lib/user_command_info.ml
+++ b/src/lib/rosetta_lib/user_command_info.ml
@@ -227,7 +227,7 @@ let of_operations ?memo ?valid_until (ops : Operation.t list) :
   *)
   let payment =
     let%map () =
-      if Int.equal (List.length ops) 3 then V.return ()
+      if Mina_stdlib.List.Length.Compare.(ops = 3) then V.return ()
       else V.fail Length_mismatch
     and account_a =
       let open Result.Let_syntax in
@@ -316,7 +316,7 @@ let of_operations ?memo ?valid_until (ops : Operation.t list) :
   *)
   let delegation =
     let%map () =
-      if Int.equal (List.length ops) 2 then V.return ()
+      if Mina_stdlib.List.Length.Compare.(ops = 2) then V.return ()
       else V.fail Length_mismatch
     and account_a =
       let open Result.Let_syntax in

--- a/src/lib/snark_bits/bits.ml
+++ b/src/lib/snark_bits/bits.ml
@@ -390,7 +390,7 @@ module Snarkable = struct
     include Field_backed (Impl) (M)
 
     let pack_var bs =
-      assert (List.length bs = M.bit_length) ;
+      assert (Mina_stdlib.List.Length.Compare.(bs = M.bit_length)) ;
       project_var bs
 
     let pack_value = Fn.id

--- a/src/lib/snark_bits/dune
+++ b/src/lib/snark_bits/dune
@@ -5,16 +5,17 @@
  (inline_tests)
  (libraries
    ;; opam libraries
-   core_kernel
-   integers
-   base
-   ;; local libraries
-   fold_lib
-   snarky.backendless
-   tuple_lib
-   bitstring_lib
-   snarky.intf
-   )
+  core_kernel
+  integers
+  base
+  ;; local libraries
+  fold_lib
+  snarky.backendless
+  tuple_lib
+  bitstring_lib
+  snarky.intf
+  mina_stdlib
+  )
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_version ppx_snarky ppx_optcomp ppx_let ppx_inline_test ppx_compare))

--- a/src/lib/snarky_blake2/dune
+++ b/src/lib/snarky_blake2/dune
@@ -13,4 +13,5 @@
    ;; local libraries
    blake2
    snarky.backendless
+   mina_stdlib
 ))

--- a/src/lib/snarky_blake2/uint32.ml
+++ b/src/lib/snarky_blake2/uint32.ml
@@ -92,7 +92,7 @@ module Make (Impl : Snarky_backendless.Snark_intf.S) :
     acc
 
   let sum (xs : t list) =
-    assert (List.length xs < 30) ;
+    assert (Mina_stdlib.List.Length.Compare.(xs < 30)) ;
     let c, vars =
       List.fold xs ~init:(0, []) ~f:(fun (c, vs) t ->
           match to_constant t with

--- a/src/mina_stdlib.opam
+++ b/src/mina_stdlib.opam
@@ -1,0 +1,5 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]


### PR DESCRIPTION
This branch introduces basic functions operating on list lengths within a new library, `Mina_stdlib`.

Other commits improve a number of `List.length` uses across the codebase, either by using functions provided by `Mina_stdlib.List` (new module and library!), by OCaml's standard library, or by using pattern matching-based code patterns.