### PR TITLE
Tests for latest command versions

### DIFF
--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -445,6 +445,12 @@ module Make_str (_ : Wire_types.Concrete) = struct
             (Fn.compose
                (Public_key.Compressed.equal public_key)
                Account_id.public_key ) )
+
+  let%test "latest signed command version" =
+    (* if this test fails, update `Transaction_hash.hash_of_transaction_id`
+       for latest version, then update this test
+    *)
+    Int.equal Stable.Latest.version 2
 end
 
 include Wire_types.Make (Make_sig) (Make_str)

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -2054,4 +2054,10 @@ let%test_module "Test" =
     let%test_unit "full circuit" =
       Run_in_thread.block_on_async_exn
       @@ fun () -> Fields_derivers_zkapps.Test.Loop.run full dummy
+
+    let%test "latest zkApp version" =
+      (* if this test fails, update `Transaction_hash.hash_of_transaction_id`
+         for latest version, then update this test
+      *)
+      Stable.Latest.version = 1
   end )


### PR DESCRIPTION
Unit tests to confirm latest versions of `Signed_command` and `Zkapp_command`. Failure of these tests means there's a new version in town, and `hash_of_transaction_id` needs to accommodate that new version.

Followup to #12021.
