### PR TITLE
Adding additional engineers to the CI trigger logic

### DIFF
--- a/frontend/ci-build-me/src/index.js
+++ b/frontend/ci-build-me/src/index.js
@@ -113,7 +113,10 @@ const handler = async (event, req) => {
       const orgData = await getRequest(req.body.sender.organizations_url);
       // and the comment author is part of the core team
       if (
-        orgData.data.filter((org) => org.login == "MinaProtocol").length > 0
+          orgData.data.filter((org) => org.login == "MinaProtocol").length > 0 ||
+          req.body.sender.login == "ylecornec" ||
+          req.body.sender.login == "balsoft" ||
+          req.body.sender.login == "bryanhonof"
       ) {
         const prData = await getRequest(req.body.issue.pull_request.url);
         const buildkite = await runBuild(


### PR DESCRIPTION
This PR is to manually add specific external engineers to our CI trigger logic as a short term fix to enable them to manually trigger CI. This is a stop gap fix to unblock them quickly with better logic to be provided in the near future.

