### PR TITLE
Add provedState field to graphQL account

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11659,6 +11659,15 @@
               "deprecationReason": null
             },
             {
+              "name": "provedState",
+              "description":
+                "Boolean indicating whether all 8 fields on zkAppState where last set by a proof-authorized account update",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "permissions",
               "description":
                 "Permissions for updating certain fields of this account",

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11661,7 +11661,7 @@
             {
               "name": "provedState",
               "description":
-                "Boolean indicating whether all 8 fields on zkAppState where last set by a proof-authorized account update",
+                "Boolean indicating whether all 8 fields on zkAppState were last set by a proof-authorized account update",
               "args": [],
               "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
               "isDeprecated": false,

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1398,8 +1398,8 @@ module Types = struct
                           zkapp_account.app_state |> Zkapp_state.V.to_list ) )
              ; field "provedState" ~typ:bool
                  ~doc:
-                   "Boolean indicating whether all 8 fields on zkAppState \
-                    where last set by a proof-authorized account update"
+                   "Boolean indicating whether all 8 fields on zkAppState were \
+                    last set by a proof-authorized account update"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
                    account.Account.Poly.zkapp

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1396,6 +1396,15 @@ module Types = struct
                    account.Account.Poly.zkapp
                    |> Option.map ~f:(fun zkapp_account ->
                           zkapp_account.app_state |> Zkapp_state.V.to_list ) )
+             ; field "provedState" ~typ:bool
+                 ~doc:
+                   "Boolean indicating whether all 8 fields on zkAppState \
+                    where last set by a proof-authorized account update"
+                 ~args:Arg.[]
+                 ~resolve:(fun _ { account; _ } ->
+                   account.Account.Poly.zkapp
+                   |> Option.map ~f:(fun zkapp_account ->
+                          zkapp_account.proved_state ) )
              ; field "permissions" ~typ:account_permissions
                  ~doc:"Permissions for updating certain fields of this account"
                  ~args:Arg.[]


### PR DESCRIPTION
Enables retrieving the `provedState` flag from an account via graphql. This is needed to support the currently unimplemented `isProved` precondition in snarkyjs.

note: this is stacked on top of https://github.com/MinaProtocol/mina/pull/12166 (bringing `rampup` up to date with `develop`)