### PR TITLE
Add support for zkapps balance changing operations to Rosetta Data API

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -689,7 +689,7 @@ WITH RECURSIVE chain AS (
         ; nonce : int64
         ; sequence_no : int
         ; status : string
-        ; failure_reasons : string array
+        ; failure_reasons : string array option
         }
       [@@deriving hlist]
 
@@ -712,7 +712,7 @@ WITH RECURSIVE chain AS (
             ; int64
             ; int
             ; string
-            ; Mina_caqti.array_string_typ
+            ; option Mina_caqti.array_string_typ
             ]
     end
 
@@ -759,7 +759,7 @@ SELECT zaub.account_identifier_id, zaub.id,
     zaub.balance_change, zaub.increment_nonce, zaub.events_id,
     zaub.sequence_events_id, zaub.call_data_id, zaub.call_depth,
     zaub.zkapp_network_precondition_id, zaub.zkapp_account_precondition_id,
-    zaub.use_full_commitment, zaub.caller, zau.authorization_kind,
+    zaub.use_full_commitment, zaub.caller, zaub.authorization_kind,
     pk.value as account, bzc.status
 FROM zkapp_commands zc
  INNER JOIN blocks_zkapp_commands bzc on bzc.zkapp_command_id = zc.id
@@ -970,7 +970,8 @@ WHERE zc.id = ?
           ; sequence_no = cmd.sequence_no
           ; memo = (if String.equal cmd.memo "" then None else Some cmd.memo)
           ; hash = cmd.hash
-          ; failure_reasons = Array.to_list cmd.failure_reasons
+          ; failure_reasons =
+              Option.value_map ~default:[] ~f:Array.to_list cmd.failure_reasons
           ; account_updates
           } )
     in

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -713,6 +713,8 @@ WITH RECURSIVE chain AS (
 
       let fee_payer t = `Pk t.fee_payer
 
+      let fee t = t.fee
+
       let typ =
         Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
           Caqti_type.
@@ -744,6 +746,43 @@ FROM blocks_zkapp_commands bzc
  LEFT JOIN zkapp_account_update_failures zauf on zauf.id = ANY(bzc.failure_reasons_ids)
 WHERE bzc.block_id = ?
       |}
+
+    let run (module Conn : Caqti_async.CONNECTION) id =
+      Conn.collect_list query id
+  end
+
+  module Zkapp_account_update = struct
+    module Extras = struct
+      type t = { account : string; status : string } [@@deriving hlist]
+
+      let account t = `Pk t.account
+
+      let typ =
+        Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+          Caqti_type.[ string; string ]
+    end
+
+    let typ =
+      Caqti_type.(
+        tup2 Archive_lib.Processor.Zkapp_account_update_body.typ Extras.typ)
+
+    let query =
+      Caqti_request.collect Caqti_type.int typ
+        {|
+SELECT zaub.account_identifier_id, zaub.id,
+    zaub.balance_change, zaub.increment_nonce, zaub.events_id,
+    zaub.sequence_events_id, zaub.call_data_id, zaub.call_depth,
+    zaub.zkapp_network_precondition_id, zaub.zkapp_account_precondition_id,
+    zaub.use_full_commitment, zaub.caller, zau.authorization_kind,
+    pk.value as account, bzc.status
+FROM zkapp_commands zc
+ INNER JOIN blocks_zkapp_commands bzc on bzc.zkapp_command_id = zc.id
+ INNER JOIN zkapp_account_update zau on zau.id = ANY(zc.zkapp_account_updates_ids)
+ INNER JOIN zkapp_account_update_body zaub on zaub.update_id = zau.id
+ INNER JOIN account_identifiers ai on ai.id = zaub.account_identifier_id
+ INNER JOIN public_keys pk on ai.public_key_id = pk.id
+WHERE zc.id = ?
+    |}
 
     let run (module Conn : Caqti_async.CONNECTION) id =
       Conn.collect_list query id
@@ -803,6 +842,21 @@ WHERE bzc.block_id = ?
       Internal_commands.run (module Conn) block_id
       |> Errors.Lift.sql ~context:"Finding internal commands within block"
     in
+    let%bind raw_zkapp_commands =
+      Zkapp_commands.run (module Conn) block_id
+      |> Errors.Lift.sql ~context:"Finding zkapp commands within block"
+    in
+    let%bind raw_zkapp_account_update =
+      List.fold_left raw_zkapp_commands ~init:(M.return [])
+        ~f:(fun acc (cmd_id, _) ->
+          let%bind acc = acc in
+          let%bind account_updates =
+            Zkapp_account_update.run (module Conn) cmd_id
+            |> Errors.Lift.sql
+                 ~context:"Finding zkapp account updates within block"
+          in
+          M.return (acc @ account_updates) )
+    in
     let%bind internal_commands =
       M.List.map raw_internal_commands ~f:(fun (_, ic, extras) ->
           let%map kind =
@@ -841,7 +895,7 @@ WHERE bzc.block_id = ?
           ; hash = ic.hash
           } )
     in
-    let%map user_commands =
+    let%bind user_commands =
       M.List.map raw_user_commands ~f:(fun (_, uc, extras) ->
           let open M.Let_syntax in
           let%bind kind =
@@ -897,8 +951,50 @@ WHERE bzc.block_id = ?
           ; memo = (if String.equal uc.memo "" then None else Some uc.memo)
           } )
     in
-    let zkapp_commands = (*TODO: *) Zkapp_command_info.dummies in
-    let zkapps_account_updates = (*TODO: *) Zkapp_account_update_info.dummies in
+    let%bind zkapp_commands =
+      M.List.map raw_zkapp_commands ~f:(fun (_, cmd) ->
+          (* TODO: check if this holds *)
+          let token = Mina_base.Token_id.(to_string default) in
+          M.return
+            { Zkapp_command_info.fee =
+                Unsigned.UInt64.of_string @@ Zkapp_commands.Extras.fee cmd
+            ; fee_payer = Zkapp_commands.Extras.fee_payer cmd
+            ; valid_until =
+                Option.map ~f:Unsigned.UInt32.of_int64 cmd.valid_until
+            ; nonce = Unsigned.UInt32.of_int64 cmd.nonce
+            ; token = `Token_id token
+            ; sequence_no = cmd.sequence_no
+            ; memo = (if String.equal cmd.memo "" then None else Some cmd.memo)
+            ; hash = cmd.hash
+            ; failure_reasons = Array.to_list cmd.failure_reasons
+            } )
+    in
+    let%map zkapps_account_updates =
+      M.List.map raw_zkapp_account_update ~f:(fun (upd, extras) ->
+          (* TODO: check if this holds *)
+          let token = Mina_base.Token_id.(to_string default) in
+          let status =
+            match extras.Zkapp_account_update.Extras.status with
+            | "applied" ->
+                `Success
+            | _ ->
+                `Failed
+          in
+          M.return
+            { Zkapp_account_update_info.authorization_kind =
+                upd
+                  .Archive_lib.Processor.Zkapp_account_update_body
+                   .authorization_kind
+            ; account = Zkapp_account_update.Extras.account extras
+            ; balance_change = upd.balance_change
+            ; increment_nonce = upd.increment_nonce
+            ; caller = upd.caller
+            ; call_depth = Unsigned.UInt64.of_int upd.call_depth
+            ; use_full_commitment = upd.use_full_commitment
+            ; status
+            ; token = `Token_id token
+            } )
+    in
     { Block_info.block_identifier =
         { Block_identifier.index = raw_block.height
         ; hash = raw_block.state_hash

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -302,9 +302,8 @@ module Zkapp_account_update_info = struct
             } )
   end
 
-  let dummies = [
-    {
-      authorization_kind = "OK"
+  let dummies =
+    [ { authorization_kind = "OK"
       ; account = `Pk "Eve"
       ; balance_change = "-1000000"
       ; increment_nonce = false
@@ -312,10 +311,9 @@ module Zkapp_account_update_info = struct
       ; call_depth = Unsigned.UInt64.of_int 10
       ; use_full_commitment = true
       ; status = `Success
-      ; token = `Token_id Amount_of.Token_id.default 
-    };
-    {
-      authorization_kind = "NOK"
+      ; token = `Token_id Amount_of.Token_id.default
+      }
+    ; { authorization_kind = "NOK"
       ; account = `Pk "Alice"
       ; balance_change = "20000000"
       ; increment_nonce = true
@@ -323,9 +321,9 @@ module Zkapp_account_update_info = struct
       ; call_depth = Unsigned.UInt64.of_int 20
       ; use_full_commitment = false
       ; status = `Failed
-      ; token = `Token_id Amount_of.Token_id.default 
-    }
-  ]
+      ; token = `Token_id Amount_of.Token_id.default
+      }
+    ]
 end
 
 module Zkapp_command_info = struct
@@ -350,9 +348,8 @@ module Zkapp_command_info = struct
        * canonical user command that created them so we are able consistently
        * produce more balance changing operations in the mempool or a block.
        * *)
-      Op_build.build
-        ~a_eq:[%equal: [ `Zkapp_fee_payer_dec ]]
-        ~plan:[] ~f:(fun ~related_operations ~operation_identifier op ->
+      Op_build.build ~a_eq:[%equal: [ `Zkapp_fee_payer_dec ]] ~plan:[]
+        ~f:(fun ~related_operations ~operation_identifier op ->
           let status =
             match t.failure_reasons with
             | [] ->
@@ -377,13 +374,11 @@ module Zkapp_command_info = struct
                          t.fee )
                 ; coin_change = None
                 ; metadata = None
-                }
-           )
+                } )
   end
 
   let dummies =
-    [ { 
-        fee_payer = `Pk "Eve"
+    [ { fee_payer = `Pk "Eve"
       ; fee = Unsigned.UInt64.of_int 20_000_000_000
       ; token = `Token_id Amount_of.Token_id.default
       ; sequence_no = 1
@@ -393,17 +388,16 @@ module Zkapp_command_info = struct
       ; nonce = Unsigned.UInt32.of_int 3
       ; memo = Some "Hey"
       }
-    ; { 
-      fee_payer = `Pk "Alice"
-    ; fee = Unsigned.UInt64.of_int 10_000_000_000
-    ; token = `Token_id Amount_of.Token_id.default
-    ; sequence_no = 2
-    ; hash = "COMMAND_2"
-    ; failure_reasons = ["Failure1"]
-    ; valid_until = Some (Unsigned.UInt32.of_int 20_000)
-    ; nonce = Unsigned.UInt32.of_int 2
-    ; memo = None
-    }
+    ; { fee_payer = `Pk "Alice"
+      ; fee = Unsigned.UInt64.of_int 10_000_000_000
+      ; token = `Token_id Amount_of.Token_id.default
+      ; sequence_no = 2
+      ; hash = "COMMAND_2"
+      ; failure_reasons = [ "Failure1" ]
+      ; valid_until = Some (Unsigned.UInt32.of_int 20_000)
+      ; nonce = Unsigned.UInt32.of_int 2
+      ; memo = None
+      }
     ]
 end
 
@@ -700,32 +694,55 @@ WITH RECURSIVE chain AS (
 
   module Zkapp_commands = struct
     module Extras = struct
-      (* TODO: A few of these actually aren't used; should we leave in for future or remove? *)
       type t =
-        { account_pk : string
-        ; status : string option
-        ; failure_reason : string option
-        ; account_creation_fee_paid : int64 option
+        { memo : string
+        ; hash : string
+        ; fee_payer : string
+        ; fee : string
+        ; valid_until : int64 option
+        ; nonce : int64
+        ; sequence_no : int
+        ; status : string
+        ; failure_reasons : string array
         }
       [@@deriving hlist]
 
-      let account_pk t = `Pk t.account_pk
+      let memo t = t.memo
 
-      let status t = t.status
+      let hash t = t.hash
 
-      let failure_reason t = t.failure_reason
-
-      let account_creation_fee_paid t = t.account_creation_fee_paid
+      let fee_payer t = `Pk t.fee_payer
 
       let typ =
         Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-          Caqti_type.[ string; option string; option string; option int64 ]
+          Caqti_type.
+            [ string
+            ; string
+            ; string
+            ; string
+            ; option int64
+            ; int64
+            ; int
+            ; string
+            ; Mina_caqti.array_string_typ
+            ]
     end
 
-    let typ =
-      Caqti_type.(tup3 int Archive_lib.Processor.Zkapp_updates.typ Extras.typ)
+    let typ = Caqti_type.(tup2 int Extras.typ)
 
-    let query = Caqti_request.collect Caqti_type.int typ {| 
+    let query =
+      Caqti_request.collect Caqti_type.int typ
+        {| 
+  SELECT zc.id, zc.memo, zc.hash,
+    pk_fee_payer.value as fee_payer, zfpb.fee, zfpb.valid_until, zfpb.nonce,
+    bzc.sequence_no, bzc.status, zauf.failures
+FROM blocks_zkapp_commands bzc
+ INNER JOIN zkapp_commands zc on zc.id = bzc.zkapp_command_id
+ INNER JOIN zkapp_fee_payer_body zfpb on zc.zkapp_fee_payer_body_id = zfpb.id
+ INNER JOIN account_identifiers ai_fee_payer on ai_fee_payer.id = zfpb.account_identifier_id
+ INNER JOIN public_keys pk_fee_payer on ai_fee_payer.public_key_id = pk_fee_payer.id
+ LEFT JOIN zkapp_account_update_failures zauf on zauf.id = ANY(bzc.failure_reasons_ids)
+WHERE bzc.block_id = ?
       |}
 
     let run (module Conn : Caqti_async.CONNECTION) id =
@@ -880,8 +897,8 @@ WITH RECURSIVE chain AS (
           ; memo = (if String.equal uc.memo "" then None else Some uc.memo)
           } )
     in
-    let%map zkapp_commands = M.return Zkapp_command_info.dummies (*TODO: *) in
-    let%map zkapps_account_updates = M.return Zkapp_account_update_info.dummies (*TODO: *) in
+    let zkapp_commands = (*TODO: *) Zkapp_command_info.dummies in
+    let zkapps_account_updates = (*TODO: *) Zkapp_account_update_info.dummies in
     { Block_info.block_identifier =
         { Block_identifier.index = raw_block.height
         ; hash = raw_block.state_hash

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -772,7 +772,7 @@ SELECT zaub.account_identifier_id, zaub.id,
 FROM zkapp_commands zc
  INNER JOIN blocks_zkapp_commands bzc on bzc.zkapp_command_id = zc.id
  INNER JOIN zkapp_account_update zau on zau.id = ANY(zc.zkapp_account_updates_ids)
- INNER JOIN zkapp_account_update_body zaub on zaub.update_id = zau.id
+ INNER JOIN zkapp_account_update_body zaub on zaub.id = zau.body_id
  INNER JOIN account_identifiers ai on ai.id = zaub.account_identifier_id
  INNER JOIN public_keys pk on ai.public_key_id = pk.id
 WHERE zc.id = ?

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -319,19 +319,12 @@ module Zkapp_command_info = struct
                  { Op.label = `Zkapp_account_update upd; related_to = None } )
           )
         ~f:(fun ~related_operations ~operation_identifier op ->
-          let status =
-            match t.failure_reasons with
-            | [] ->
-                Some (Operation_statuses.name `Success)
-            | _ ->
-                Some (Operation_statuses.name `Failed)
-          in
           match op.label with
           | `Zkapp_fee_payer_dec ->
               M.return
                 { Operation.operation_identifier
                 ; related_operations
-                ; status
+                ; status=Some (Operation_statuses.name `Success)
                 ; account =
                     Some
                       (account_id t.fee_payer
@@ -347,7 +340,7 @@ module Zkapp_command_info = struct
           | `Zkapp_account_update upd ->
               let status = Some (Operation_statuses.name upd.status) in
               let amount =
-                match String.chop_prefix ~prefix:"-" upd.balance_change with                
+                match String.chop_prefix ~prefix:"-" upd.balance_change with
                 | Some amount ->
                   Some
                       Amount_of.(

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -339,28 +339,24 @@ module Zkapp_command_info = struct
                 ; _type = Operation_types.name `Zkapp_fee_payer_dec
                 ; amount =
                     Some
-                      (Amount_of.token (`Token_id Amount_of.Token_id.default)
-                         t.fee )
+                      (Amount_of.(negated @@ token (`Token_id Amount_of.Token_id.default)
+                         t.fee ))
                 ; coin_change = None
                 ; metadata = None
                 }
           | `Zkapp_account_update upd ->
               let status = Some (Operation_statuses.name upd.status) in
               let amount =
-                match
-                  (upd.status, String.chop_prefix upd.balance_change ~prefix:"-")
-                with
-                | `Failed, _ ->
-                    None
-                | `Success, Some amount ->
-                    Some
-                      Amount_of.(
-                        token upd.token
-                        @@ Unsigned_extended.UInt64.of_string amount)
-                | `Success, None ->
-                    Some
+                match String.chop_prefix ~prefix:"-" upd.balance_change with                
+                | Some amount ->
+                  Some
                       Amount_of.(
                         negated @@ token upd.token
+                        @@ Unsigned_extended.UInt64.of_string amount)
+                | None ->
+                  Some
+                      Amount_of.(
+                        token upd.token
                         @@ Unsigned_extended.UInt64.of_string upd.balance_change)
               in
               M.return

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -37,7 +37,7 @@ open Rosetta_models
 let account_id = User_command_info.account_id
 
 module Block_query = struct
-  type t = ([`Height of int64], [`Hash of string]) These.t option
+  type t = ([ `Height of int64 ], [ `Hash of string ]) These.t option
 
   module T (M : Monad_fail.S) = struct
     let of_partial_identifier (identifier : Partial_block_identifier.t) =
@@ -51,8 +51,11 @@ module Block_query = struct
       | Some index, Some hash ->
           M.return (Some (`Those (`Height index, `Hash hash)))
 
-    let of_partial_identifier' (identifier : Partial_block_identifier.t option) =
-      of_partial_identifier (Option.value identifier ~default:{Partial_block_identifier.index = None; hash = None })
+    let of_partial_identifier' (identifier : Partial_block_identifier.t option)
+        =
+      of_partial_identifier
+        (Option.value identifier
+           ~default:{ Partial_block_identifier.index = None; hash = None } )
 
     let is_genesis ~hash ~block_height = function
       | Some (`This (`Height index)) ->
@@ -60,21 +63,20 @@ module Block_query = struct
       | Some (`That (`Hash hash')) ->
           String.equal hash hash'
       | Some (`Those (`Height index, `Hash hash')) ->
-          Int64.equal index block_height
-          && String.equal hash hash'
+          Int64.equal index block_height && String.equal hash hash'
       | None ->
           false
   end
 
   let to_string : t -> string = function
     | Some (`This (`Height h)) ->
-      sprintf "height = %Ld" h
+        sprintf "height = %Ld" h
     | Some (`That (`Hash h)) ->
-      sprintf "hash = %s" h
+        sprintf "hash = %s" h
     | Some (`Those (`Height height, `Hash hash)) ->
-      sprintf "height = %Ld, hash = %s" height hash
+        sprintf "height = %Ld, hash = %s" height hash
     | None ->
-      sprintf "(no height or hash given)"
+        sprintf "(no height or hash given)"
 end
 
 module Op = User_command_info.Op
@@ -84,25 +86,29 @@ module Op = User_command_info.Op
 
 module Internal_command_info = struct
   module Kind = struct
-    type t = [`Coinbase | `Fee_transfer | `Fee_transfer_via_coinbase]
+    type t = [ `Coinbase | `Fee_transfer | `Fee_transfer_via_coinbase ]
     [@@deriving equal, to_yojson]
 
     let to_string (t : t) =
       match t with
-      | `Coinbase -> "coinbase"
-      | `Fee_transfer -> "fee_transfer"
-      | `Fee_transfer_via_coinbase -> "fee_transfer_via_coinbase"
+      | `Coinbase ->
+          "coinbase"
+      | `Fee_transfer ->
+          "fee_transfer"
+      | `Fee_transfer_via_coinbase ->
+          "fee_transfer_via_coinbase"
   end
 
   type t =
-    { kind: Kind.t
-    ; receiver: [`Pk of string]
-    ; receiver_account_creation_fee_paid: Unsigned_extended.UInt64.t option
-    ; fee: Unsigned_extended.UInt64.t
-    ; token: [`Token_id of string]
-    ; sequence_no: int
-    ; secondary_sequence_no: int
-    ; hash: string }
+    { kind : Kind.t
+    ; receiver : [ `Pk of string ]
+    ; receiver_account_creation_fee_paid : Unsigned_extended.UInt64.t option
+    ; fee : Unsigned_extended.UInt64.t
+    ; token : [ `Token_id of string ]
+    ; sequence_no : int
+    ; secondary_sequence_no : int
+    ; hash : string
+    }
   [@@deriving to_yojson]
 
   module T (M : Monad_fail.S) = struct
@@ -114,31 +120,39 @@ module Internal_command_info = struct
        * canonical user command that created them so we are able consistently
        * produce more balance changing operations in the mempool or a block.
        * *)
-      let plan : 'a Op.t list = 
+      let plan : 'a Op.t list =
         let mk_account_creation_fee related =
           match t.receiver_account_creation_fee_paid with
-          | None -> []
+          | None ->
+              []
           | Some fee ->
-            [{Op.label= `Account_creation_fee_via_fee_receiver fee
-             ; related_to= Some related}]
+              [ { Op.label = `Account_creation_fee_via_fee_receiver fee
+                ; related_to = Some related
+                }
+              ]
         in
-        (match t.kind with
+        match t.kind with
         | `Coinbase ->
             (* The coinbase transaction is really incrementing by the coinbase
-           * amount  *)
-          [{Op.label= `Coinbase_inc; related_to= None}]
-          @ (mk_account_creation_fee `Coinbase_inc)
+               * amount *)
+            [ { Op.label = `Coinbase_inc; related_to = None } ]
+            @ mk_account_creation_fee `Coinbase_inc
         | `Fee_transfer ->
-          [{Op.label= `Fee_receiver_inc; related_to= None}]
-        @ (mk_account_creation_fee `Fee_receiver_inc)
+            [ { Op.label = `Fee_receiver_inc; related_to = None } ]
+            @ mk_account_creation_fee `Fee_receiver_inc
         | `Fee_transfer_via_coinbase ->
-            [ {Op.label= `Fee_receiver_inc; related_to= None}
-            ; {Op.label= `Fee_payer_dec; related_to= Some `Fee_receiver_inc} ]
-            @ (mk_account_creation_fee `Fee_receiver_inc)
-        )
+            [ { Op.label = `Fee_receiver_inc; related_to = None }
+            ; { Op.label = `Fee_payer_dec; related_to = Some `Fee_receiver_inc }
+            ]
+            @ mk_account_creation_fee `Fee_receiver_inc
       in
       Op_build.build
-        ~a_eq:[%equal: [`Coinbase_inc | `Fee_payer_dec | `Fee_receiver_inc | `Account_creation_fee_via_fee_receiver of Unsigned.UInt64.t]]
+        ~a_eq:
+          [%equal:
+            [ `Coinbase_inc
+            | `Fee_payer_dec
+            | `Fee_receiver_inc
+            | `Account_creation_fee_via_fee_receiver of Unsigned.UInt64.t ]]
         ~plan ~f:(fun ~related_operations ~operation_identifier op ->
           (* All internal commands succeed if they're in blocks *)
           let status = Some (Operation_statuses.name `Success) in
@@ -148,22 +162,29 @@ module Internal_command_info = struct
                 { Operation.operation_identifier
                 ; related_operations
                 ; status
-                ; account=
-                    Some (account_id t.receiver (`Token_id Amount_of.Token_id.default))
-                ; _type= Operation_types.name `Coinbase_inc
-                ; amount= Some (Amount_of.token (`Token_id Amount_of.Token_id.default) t.fee)
-                ; coin_change= None
-                ; metadata= None }
+                ; account =
+                    Some
+                      (account_id t.receiver
+                         (`Token_id Amount_of.Token_id.default) )
+                ; _type = Operation_types.name `Coinbase_inc
+                ; amount =
+                    Some
+                      (Amount_of.token (`Token_id Amount_of.Token_id.default)
+                         t.fee )
+                ; coin_change = None
+                ; metadata = None
+                }
           | `Fee_receiver_inc ->
-            M.return
+              M.return
                 { Operation.operation_identifier
                 ; related_operations
                 ; status
-                ; account= Some (account_id t.receiver t.token)
-                ; _type= Operation_types.name `Fee_receiver_inc
-                ; amount= Some (Amount_of.token t.token t.fee)
-                ; coin_change= None
-                ; metadata= None }
+                ; account = Some (account_id t.receiver t.token)
+                ; _type = Operation_types.name `Fee_receiver_inc
+                ; amount = Some (Amount_of.token t.token t.fee)
+                ; coin_change = None
+                ; metadata = None
+                }
           | `Fee_payer_dec ->
               let open M.Let_syntax in
               let%map coinbase_receiver =
@@ -177,77 +198,248 @@ module Internal_command_info = struct
                            "This operation existing (fee payer dec within \
                             Internal_command) demands a coinbase receiver to \
                             exist. Please report this bug."
-                         `Invariant_violation)
+                         `Invariant_violation )
               in
               { Operation.operation_identifier
               ; related_operations
               ; status
-              ; account=
+              ; account =
                   Some
-                    (account_id coinbase_receiver (`Token_id Amount_of.Token_id.default) )
-              ; _type= Operation_types.name `Fee_payer_dec
-              ; amount= Some Amount_of.(negated (mina t.fee))
-              ; coin_change= None
-              ; metadata= None }
+                    (account_id coinbase_receiver
+                       (`Token_id Amount_of.Token_id.default) )
+              ; _type = Operation_types.name `Fee_payer_dec
+              ; amount = Some Amount_of.(negated (mina t.fee))
+              ; coin_change = None
+              ; metadata = None
+              }
           | `Account_creation_fee_via_fee_receiver account_creation_fee ->
               M.return
                 { Operation.operation_identifier
                 ; related_operations
                 ; status
-                ; account=
-                    Some (account_id t.receiver (`Token_id Amount_of.Token_id.default))
-                ; _type= Operation_types.name `Account_creation_fee_via_fee_receiver
-                ; amount= Some Amount_of.(negated @@ mina account_creation_fee)
-                ; coin_change= None
-                ; metadata= None }
-          )
+                ; account =
+                    Some
+                      (account_id t.receiver
+                         (`Token_id Amount_of.Token_id.default) )
+                ; _type =
+                    Operation_types.name `Account_creation_fee_via_fee_receiver
+                ; amount = Some Amount_of.(negated @@ mina account_creation_fee)
+                ; coin_change = None
+                ; metadata = None
+                } )
   end
 
   let dummies =
-    [ { kind= `Coinbase
-      ; receiver= `Pk "Eve"
-      ; receiver_account_creation_fee_paid= None
-      ; fee= Unsigned.UInt64.of_int 20_000_000_000
-      ; token= (`Token_id Amount_of.Token_id.default)
-      ; sequence_no=1
-      ; secondary_sequence_no=0
-      ; hash= "COINBASE_1" }
-    ; { kind= `Fee_transfer
-      ; receiver= `Pk "Alice"
-      ; receiver_account_creation_fee_paid= None
-      ; fee= Unsigned.UInt64.of_int 30_000_000_000
-      ; token= (`Token_id Amount_of.Token_id.default)
-      ; sequence_no=1
-      ; secondary_sequence_no=0
-      ; hash= "FEE_TRANSFER" } ]
+    [ { kind = `Coinbase
+      ; receiver = `Pk "Eve"
+      ; receiver_account_creation_fee_paid = None
+      ; fee = Unsigned.UInt64.of_int 20_000_000_000
+      ; token = `Token_id Amount_of.Token_id.default
+      ; sequence_no = 1
+      ; secondary_sequence_no = 0
+      ; hash = "COINBASE_1"
+      }
+    ; { kind = `Fee_transfer
+      ; receiver = `Pk "Alice"
+      ; receiver_account_creation_fee_paid = None
+      ; fee = Unsigned.UInt64.of_int 30_000_000_000
+      ; token = `Token_id Amount_of.Token_id.default
+      ; sequence_no = 1
+      ; secondary_sequence_no = 0
+      ; hash = "FEE_TRANSFER"
+      }
+    ]
+end
+
+module Zkapp_account_update_info = struct
+  type t =
+    { authorization_kind : string
+    ; account : [ `Pk of string ]
+    ; balance_change : string
+    ; increment_nonce : bool
+    ; caller : string
+    ; call_depth : Unsigned_extended.UInt64.t
+    ; use_full_commitment : bool
+    ; status : [ `Success | `Failed ]
+    ; token : [ `Token_id of string ]
+    }
+  [@@deriving to_yojson]
+
+  module T (M : Monad_fail.S) = struct
+    module Op_build = Op.T (M)
+
+    let to_operations (t : t) : (Operation.t list, Errors.t) M.t =
+      let label =
+        if String.is_prefix t.balance_change ~prefix:"-" then `Balance_dec
+        else `Balance_inc
+      in
+      let plan = [ { Op.label; related_to = None } ] in
+      Op_build.build ~a_eq:[%equal: [ `Balance_inc | `Balance_dec ]] ~plan
+        ~f:(fun ~related_operations ~operation_identifier op ->
+          let status = Some (Operation_statuses.name t.status) in
+          let amount =
+            let amount =
+              Unsigned_extended.UInt64.of_string
+              @@ String.chop_prefix_if_exists ~prefix:"-" t.balance_change
+            in
+            match (t.status, op.label) with
+            | `Success, `Balance_inc ->
+                Some Amount_of.(token t.token amount)
+            | `Success, `Balance_dec ->
+                Some Amount_of.(negated @@ token t.token amount)
+            | `Failed, _ ->
+                None
+          in
+          M.return
+            { Operation.operation_identifier
+            ; related_operations
+            ; status
+            ; account = Some (account_id t.account t.token)
+            ; _type = Operation_types.name `Zkapp_balance_update
+            ; amount
+            ; coin_change = None
+            ; metadata = None
+            } )
+  end
+
+  let dummies = [
+    {
+      authorization_kind = "OK"
+      ; account = `Pk "Eve"
+      ; balance_change = "-1000000"
+      ; increment_nonce = false
+      ; caller = "caller1"
+      ; call_depth = Unsigned.UInt64.of_int 10
+      ; use_full_commitment = true
+      ; status = `Success
+      ; token = `Token_id Amount_of.Token_id.default 
+    };
+    {
+      authorization_kind = "NOK"
+      ; account = `Pk "Alice"
+      ; balance_change = "20000000"
+      ; increment_nonce = true
+      ; caller = "caller2"
+      ; call_depth = Unsigned.UInt64.of_int 20
+      ; use_full_commitment = false
+      ; status = `Failed
+      ; token = `Token_id Amount_of.Token_id.default 
+    }
+  ]
+end
+
+module Zkapp_command_info = struct
+  type t =
+    { fee : Unsigned_extended.UInt64.t
+    ; fee_payer : [ `Pk of string ]
+    ; valid_until : Unsigned_extended.UInt32.t option
+    ; nonce : Unsigned_extended.UInt32.t
+    ; token : [ `Token_id of string ]
+    ; sequence_no : int
+    ; memo : string option
+    ; hash : string
+    ; failure_reasons : string list
+    }
+  [@@deriving to_yojson]
+
+  module T (M : Monad_fail.S) = struct
+    module Op_build = Op.T (M)
+
+    let to_operations (t : t) : (Operation.t list, Errors.t) M.t =
+      (* We choose to represent the dec-side of fee transfers from txns from the
+       * canonical user command that created them so we are able consistently
+       * produce more balance changing operations in the mempool or a block.
+       * *)
+      Op_build.build
+        ~a_eq:[%equal: [ `Zkapp_fee_payer_dec ]]
+        ~plan:[] ~f:(fun ~related_operations ~operation_identifier op ->
+          let status =
+            match t.failure_reasons with
+            | [] ->
+                Some (Operation_statuses.name `Success)
+            | _ ->
+                Some (Operation_statuses.name `Failed)
+          in
+          match op.label with
+          | `Zkapp_fee_payer_dec ->
+              M.return
+                { Operation.operation_identifier
+                ; related_operations
+                ; status
+                ; account =
+                    Some
+                      (account_id t.fee_payer
+                         (`Token_id Amount_of.Token_id.default) )
+                ; _type = Operation_types.name `Zkapp_fee_payer_dec
+                ; amount =
+                    Some
+                      (Amount_of.token (`Token_id Amount_of.Token_id.default)
+                         t.fee )
+                ; coin_change = None
+                ; metadata = None
+                }
+           )
+  end
+
+  let dummies =
+    [ { 
+        fee_payer = `Pk "Eve"
+      ; fee = Unsigned.UInt64.of_int 20_000_000_000
+      ; token = `Token_id Amount_of.Token_id.default
+      ; sequence_no = 1
+      ; hash = "COMMAND_1"
+      ; failure_reasons = []
+      ; valid_until = Some (Unsigned.UInt32.of_int 10_000)
+      ; nonce = Unsigned.UInt32.of_int 3
+      ; memo = Some "Hey"
+      }
+    ; { 
+      fee_payer = `Pk "Alice"
+    ; fee = Unsigned.UInt64.of_int 10_000_000_000
+    ; token = `Token_id Amount_of.Token_id.default
+    ; sequence_no = 2
+    ; hash = "COMMAND_2"
+    ; failure_reasons = ["Failure1"]
+    ; valid_until = Some (Unsigned.UInt32.of_int 20_000)
+    ; nonce = Unsigned.UInt32.of_int 2
+    ; memo = None
+    }
+    ]
 end
 
 module Block_info = struct
   (* TODO: should timestamp be string?; Block_time.t is an unsigned 64-bit int *)
   type t =
-    { block_identifier: Block_identifier.t
-    ; parent_block_identifier: Block_identifier.t
-    ; creator: [`Pk of string]
-    ; winner: [`Pk of string]
-    ; timestamp: int64
-    ; internal_info: Internal_command_info.t list
-    ; user_commands: User_command_info.t list }
+    { block_identifier : Block_identifier.t
+    ; parent_block_identifier : Block_identifier.t
+    ; creator : [ `Pk of string ]
+    ; winner : [ `Pk of string ]
+    ; timestamp : int64
+    ; internal_info : Internal_command_info.t list
+    ; user_commands : User_command_info.t list
+    ; zkapp_commands : Zkapp_command_info.t list
+    ; zkapps_account_updates : Zkapp_account_update_info.t list
+    }
 
-  let creator_metadata {creator= `Pk pk; _} = `Assoc [("creator", `String pk)]
+  let creator_metadata { creator = `Pk pk; _ } =
+    `Assoc [ ("creator", `String pk) ]
 
-  let block_winner_metadata {winner= `Pk pk; _} =
-    `Assoc [("winner", `String pk)]
+  let block_winner_metadata { winner = `Pk pk; _ } =
+    `Assoc [ ("winner", `String pk) ]
 
   let dummy =
-    { block_identifier=
+    { block_identifier =
         Block_identifier.create (Int64.of_int_exn 4) "STATE_HASH_BLOCK"
-    ; creator= `Pk "Alice"
-    ; winner= `Pk "Babu"
-    ; parent_block_identifier=
+    ; creator = `Pk "Alice"
+    ; winner = `Pk "Babu"
+    ; parent_block_identifier =
         Block_identifier.create (Int64.of_int_exn 3) "STATE_HASH_PARENT"
-    ; timestamp= Int64.of_int_exn 1594937771
-    ; internal_info= Internal_command_info.dummies
-    ; user_commands= User_command_info.dummies }
+    ; timestamp = Int64.of_int_exn 1594937771
+    ; internal_info = Internal_command_info.dummies
+    ; user_commands = User_command_info.dummies
+    ; zkapp_commands = Zkapp_command_info.dummies
+    ; zkapps_account_updates = Zkapp_account_update_info.dummies
+    }
 end
 
 module Sql = struct
@@ -282,7 +474,6 @@ SELECT c.id, c.state_hash, c.parent_id, c.parent_hash, c.creator_id, c.block_win
   ON bw.id = c.block_winner_id
   WHERE c.height = ? AND c.chain_status = 'canonical'
       |}
-
 
     let query_height_pending =
       Caqti_request.find_opt Caqti_type.int64 typ
@@ -360,48 +551,52 @@ WITH RECURSIVE chain AS (
     let run_by_id (module Conn : Caqti_async.CONNECTION) id =
       Conn.find_opt query_by_id id
 
-    let run_has_canonical_height (module Conn : Caqti_async.CONNECTION) ~height =
+    let run_has_canonical_height (module Conn : Caqti_async.CONNECTION) ~height
+        =
       let open Deferred.Result.Let_syntax in
       let%map num_canonical_at_height =
         Conn.find query_count_canonical_at_height height
       in
-      Int64.(>) num_canonical_at_height Int64.zero
+      Int64.( > ) num_canonical_at_height Int64.zero
 
     let run (module Conn : Caqti_async.CONNECTION) = function
       | Some (`This (`Height h)) ->
-        let open Deferred.Result.Let_syntax in
-        let%bind has_canonical_height = run_has_canonical_height (module Conn) ~height:h in
-        if has_canonical_height then
-          Conn.find_opt query_height_canonical h
-        else
-          let%bind max_height = Conn.find
-              (Caqti_request.find Caqti_type.unit Caqti_type.int64
-                 {sql| SELECT MAX(height) FROM blocks |sql}) ()
+          let open Deferred.Result.Let_syntax in
+          let%bind has_canonical_height =
+            run_has_canonical_height (module Conn) ~height:h
           in
-          let max_queryable_height = Int64.(-) max_height Network.Sql.max_height_delta in
-          if Int64.(<=) h max_queryable_height then
-            Conn.find_opt query_height_pending h
+          if has_canonical_height then Conn.find_opt query_height_canonical h
           else
-            return None
+            let%bind max_height =
+              Conn.find
+                (Caqti_request.find Caqti_type.unit Caqti_type.int64
+                   {sql| SELECT MAX(height) FROM blocks |sql} )
+                ()
+            in
+            let max_queryable_height =
+              Int64.( - ) max_height Network.Sql.max_height_delta
+            in
+            if Int64.( <= ) h max_queryable_height then
+              Conn.find_opt query_height_pending h
+            else return None
       | Some (`That (`Hash h)) ->
-        Conn.find_opt query_hash h
+          Conn.find_opt query_hash h
       | Some (`Those (`Height height, `Hash hash)) ->
-        Conn.find_opt query_both (hash, height)
+          Conn.find_opt query_both (hash, height)
       | None ->
-        Conn.find_opt query_best ()
-
+          Conn.find_opt query_best ()
   end
 
   module User_commands = struct
     module Extras = struct
       (* TODO: A few of these actually aren't used; should we leave in for future or remove? *)
       type t =
-        { fee_payer: string
-        ; source: string
-        ; receiver: string
-        ; status: string option
-        ; failure_reason: string option
-        ; account_creation_fee_paid: int64 option
+        { fee_payer : string
+        ; source : string
+        ; receiver : string
+        ; status : string option
+        ; failure_reason : string option
+        ; account_creation_fee_paid : int64 option
         }
       [@@deriving hlist]
 
@@ -415,10 +610,10 @@ WITH RECURSIVE chain AS (
 
       let failure_reason t = t.failure_reason
 
-      let account_creation_fee_paid t =
-        t.account_creation_fee_paid
+      let account_creation_fee_paid t = t.account_creation_fee_paid
 
-      let typ = Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+      let typ =
+        Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
           Caqti_type.
             [ string
             ; string
@@ -471,10 +666,13 @@ WITH RECURSIVE chain AS (
 
   module Internal_commands = struct
     module Extras = struct
-      let receiver (_,x,_,_) = `Pk x
-      let receiver_account_creation_fee_paid (fee,_,_,_) = fee
-      let sequence_no (_,_,seq_no,_) = seq_no
-      let secondary_sequence_no (_,_,_,secondary_seq_no) = secondary_seq_no
+      let receiver (_, x, _, _) = `Pk x
+
+      let receiver_account_creation_fee_paid (fee, _, _, _) = fee
+
+      let sequence_no (_, _, seq_no, _) = seq_no
+
+      let secondary_sequence_no (_, _, _, secondary_seq_no) = secondary_seq_no
 
       let typ = Caqti_type.(tup4 (option int64) string int int)
     end
@@ -494,6 +692,40 @@ WITH RECURSIVE chain AS (
         LEFT JOIN accounts_created ac on ac.account_identifier_id = ai.id
         INNER JOIN public_keys pk ON pk.id = ai.public_key_id
         WHERE bic.block_id = ?
+      |}
+
+    let run (module Conn : Caqti_async.CONNECTION) id =
+      Conn.collect_list query id
+  end
+
+  module Zkapp_commands = struct
+    module Extras = struct
+      (* TODO: A few of these actually aren't used; should we leave in for future or remove? *)
+      type t =
+        { account_pk : string
+        ; status : string option
+        ; failure_reason : string option
+        ; account_creation_fee_paid : int64 option
+        }
+      [@@deriving hlist]
+
+      let account_pk t = `Pk t.account_pk
+
+      let status t = t.status
+
+      let failure_reason t = t.failure_reason
+
+      let account_creation_fee_paid t = t.account_creation_fee_paid
+
+      let typ =
+        Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
+          Caqti_type.[ string; option string; option string; option int64 ]
+    end
+
+    let typ =
+      Caqti_type.(tup3 int Archive_lib.Processor.Zkapp_updates.typ Extras.typ)
+
+    let query = Caqti_request.collect Caqti_type.int typ {| 
       |}
 
     let run (module Conn : Caqti_async.CONNECTION) id =
@@ -520,13 +752,18 @@ WITH RECURSIVE chain AS (
         |> Errors.Lift.sql ~context:"Finding block"
       with
       | None ->
-        M.fail (Errors.create @@ `Block_missing (Block_query.to_string input))
+          M.fail (Errors.create @@ `Block_missing (Block_query.to_string input))
       | Some (block_id, raw_block, block_extras) ->
           M.return (block_id, raw_block, block_extras)
     in
     let%bind parent_id =
       Option.value_map raw_block.parent_id
-        ~default:(M.fail (Errors.create @@ `Block_missing (sprintf "parent block of: %s" (Block_query.to_string input))))
+        ~default:
+          (M.fail
+             ( Errors.create
+             @@ `Block_missing
+                  (sprintf "parent block of: %s" (Block_query.to_string input))
+             ) )
         ~f:M.return
     in
     let%bind raw_parent_block, _parent_block_extras =
@@ -535,7 +772,9 @@ WITH RECURSIVE chain AS (
         |> Errors.Lift.sql ~context:"Finding parent block"
       with
       | None ->
-        M.fail (Errors.create ~context:"Parent block" @@ `Block_missing (sprintf "parent_id = %d" parent_id))
+          M.fail
+            ( Errors.create ~context:"Parent block"
+            @@ `Block_missing (sprintf "parent_id = %d" parent_id) )
       | Some (_, raw_parent_block, parent_block_extras) ->
           M.return (raw_parent_block, parent_block_extras)
     in
@@ -565,25 +804,33 @@ WITH RECURSIVE chain AS (
                           "The archive database is storing internal commands \
                            with %s; this is neither fee_transfer nor coinbase \
                            not fee_transfer_via_coinbase. Please report a bug!"
-                          other)
-                     `Invariant_violation)
+                          other )
+                     `Invariant_violation )
           in
           (* internal commands always use the default token *)
           let token_id = Mina_base.Token_id.(to_string default) in
           { Internal_command_info.kind
-          ; receiver= Internal_commands.Extras.receiver extras
-          ; receiver_account_creation_fee_paid= Option.map (Internal_commands.Extras.receiver_account_creation_fee_paid extras) ~f:Unsigned.UInt64.of_int64
-          ; fee= Unsigned.UInt64.of_string ic.fee
-          ; token= `Token_id token_id
-          ; sequence_no=Internal_commands.Extras.sequence_no extras
-          ; secondary_sequence_no=Internal_commands.Extras.secondary_sequence_no extras
-          ; hash= ic.hash } )
+          ; receiver = Internal_commands.Extras.receiver extras
+          ; receiver_account_creation_fee_paid =
+              Option.map
+                (Internal_commands.Extras.receiver_account_creation_fee_paid
+                   extras )
+                ~f:Unsigned.UInt64.of_int64
+          ; fee = Unsigned.UInt64.of_string ic.fee
+          ; token = `Token_id token_id
+          ; sequence_no = Internal_commands.Extras.sequence_no extras
+          ; secondary_sequence_no =
+              Internal_commands.Extras.secondary_sequence_no extras
+          ; hash = ic.hash
+          } )
     in
     let%map user_commands =
       M.List.map raw_user_commands ~f:(fun (_, uc, extras) ->
           let open M.Let_syntax in
           let%bind kind =
-            match uc.Archive_lib.Processor.User_command.Signed_command.command_type with
+            match
+              uc.Archive_lib.Processor.User_command.Signed_command.command_type
+            with
             | "payment" ->
                 M.return `Payment
             | "delegation" ->
@@ -595,8 +842,8 @@ WITH RECURSIVE chain AS (
                        (sprintf
                           "The archive database is storing user commands with \
                            %s; this is not a known type. Please report a bug!"
-                          other)
-                     `Invariant_violation)
+                          other )
+                     `Invariant_violation )
           in
           (* TODO: do we want to mention tokens at all here? *)
           let fee_token = Mina_base.Token_id.(to_string default) in
@@ -604,45 +851,53 @@ WITH RECURSIVE chain AS (
           let%map failure_status =
             match User_commands.Extras.failure_reason extras with
             | None -> (
-              match User_commands.Extras.account_creation_fee_paid extras with
-              | None ->
-               M.return
-               @@ `Applied
-                    User_command_info.Account_creation_fees_paid.By_no_one
-              | Some receiver ->
-                  M.return
-                  @@ `Applied
-                       (User_command_info.Account_creation_fees_paid
-                        .By_receiver
-                          (Unsigned.UInt64.of_int64 receiver)))
+                match User_commands.Extras.account_creation_fee_paid extras with
+                | None ->
+                    M.return
+                    @@ `Applied
+                         User_command_info.Account_creation_fees_paid.By_no_one
+                | Some receiver ->
+                    M.return
+                    @@ `Applied
+                         (User_command_info.Account_creation_fees_paid
+                          .By_receiver
+                            (Unsigned.UInt64.of_int64 receiver) ) )
             | Some status ->
                 M.return @@ `Failed status
           in
           { User_command_info.kind
-          ; fee_payer= User_commands.Extras.fee_payer extras
-          ; source= User_commands.Extras.source extras
-          ; receiver= User_commands.Extras.receiver extras
-          ; fee_token= `Token_id fee_token
-          ; token= `Token_id token
-          ; nonce= Unsigned.UInt32.of_int64 uc.nonce
-          ; amount= Option.map ~f:Unsigned.UInt64.of_string uc.amount
-          ; fee= Unsigned.UInt64.of_string uc.fee
-          ; hash= uc.hash
-          ; failure_status= Some failure_status
-          ; valid_until= Option.map ~f:Unsigned.UInt32.of_int64 uc.valid_until
-          ; memo = if String.equal uc.memo "" then None else Some uc.memo
+          ; fee_payer = User_commands.Extras.fee_payer extras
+          ; source = User_commands.Extras.source extras
+          ; receiver = User_commands.Extras.receiver extras
+          ; fee_token = `Token_id fee_token
+          ; token = `Token_id token
+          ; nonce = Unsigned.UInt32.of_int64 uc.nonce
+          ; amount = Option.map ~f:Unsigned.UInt64.of_string uc.amount
+          ; fee = Unsigned.UInt64.of_string uc.fee
+          ; hash = uc.hash
+          ; failure_status = Some failure_status
+          ; valid_until = Option.map ~f:Unsigned.UInt32.of_int64 uc.valid_until
+          ; memo = (if String.equal uc.memo "" then None else Some uc.memo)
           } )
     in
-    { Block_info.block_identifier=
-        {Block_identifier.index= raw_block.height; hash= raw_block.state_hash}
-    ; creator= Block.Extras.creator block_extras
-    ; winner= Block.Extras.winner block_extras
-    ; parent_block_identifier=
-        { Block_identifier.index= raw_parent_block.height
-        ; hash= raw_parent_block.state_hash }
-    ; timestamp= Int64.of_string raw_block.timestamp
-    ; internal_info= internal_commands
-    ; user_commands }
+    let%map zkapp_commands = M.return Zkapp_command_info.dummies (*TODO: *) in
+    let%map zkapps_account_updates = M.return Zkapp_account_update_info.dummies (*TODO: *) in
+    { Block_info.block_identifier =
+        { Block_identifier.index = raw_block.height
+        ; hash = raw_block.state_hash
+        }
+    ; creator = Block.Extras.creator block_extras
+    ; winner = Block.Extras.winner block_extras
+    ; parent_block_identifier =
+        { Block_identifier.index = raw_parent_block.height
+        ; hash = raw_parent_block.state_hash
+        }
+    ; timestamp = Int64.of_string raw_block.timestamp
+    ; internal_info = internal_commands
+    ; user_commands
+    ; zkapp_commands
+    ; zkapps_account_updates
+    }
 end
 
 module Specific = struct
@@ -650,10 +905,14 @@ module Specific = struct
     (* All side-effects go in the env so we can mock them out later *)
     module T (M : Monad_fail.S) = struct
       type 'gql t =
-        { gql: unit -> ('gql, Errors.t) M.t
-        ; logger: Logger.t
-        ; db_block: Block_query.t -> (Block_info.t, Errors.t) M.t
-        ; validate_network_choice: network_identifier:Network_identifier.t -> graphql_uri:Uri.t -> (unit, Errors.t) M.t }
+        { gql : unit -> ('gql, Errors.t) M.t
+        ; logger : Logger.t
+        ; db_block : Block_query.t -> (Block_info.t, Errors.t) M.t
+        ; validate_network_choice :
+               network_identifier:Network_identifier.t
+            -> graphql_uri:Uri.t
+            -> (unit, Errors.t) M.t
+        }
     end
 
     (* The real environment does things asynchronously *)
@@ -668,19 +927,22 @@ module Specific = struct
         -> graphql_uri:Uri.t
         -> 'gql Real.t =
      fun ~logger ~db ~graphql_uri ->
-      { gql=
-          (Memoize.build @@ fun ~graphql_uri () ->
-             Graphql.query (Get_coinbase_and_genesis.make ()) graphql_uri ) ~graphql_uri
+      { gql =
+          ( Memoize.build
+          @@ fun ~graphql_uri () ->
+          Graphql.query (Get_coinbase_and_genesis.make ()) graphql_uri )
+            ~graphql_uri
       ; logger
-      ; db_block=
+      ; db_block =
           (fun query ->
             let (module Conn : Caqti_async.CONNECTION) = db in
             Sql.run (module Conn) query )
-      ; validate_network_choice= Network.Validate_choice.Real.validate }
+      ; validate_network_choice = Network.Validate_choice.Real.validate
+      }
 
     let mock : logger:Logger.t -> 'gql Mock.t =
      fun ~logger ->
-      { gql=
+      { gql =
           (fun () ->
             Result.return
             @@ object
@@ -691,8 +953,9 @@ module Specific = struct
                end )
           (* TODO: Add variants to cover every branch *)
       ; logger
-      ; db_block= (fun _query -> Result.return @@ Block_info.dummy)
-      ; validate_network_choice= Network.Validate_choice.Mock.succeed }
+      ; db_block = (fun _query -> Result.return @@ Block_info.dummy)
+      ; validate_network_choice = Network.Validate_choice.Mock.succeed
+      }
   end
 
   module Impl (M : Monad_fail.S) = struct
@@ -700,7 +963,7 @@ module Specific = struct
     module Internal_command_info_ops = Internal_command_info.T (M)
 
     let handle :
-      graphql_uri:Uri.t
+           graphql_uri:Uri.t
         -> env:'gql Env.T(M).t
         -> Block_request.t
         -> (Block_response.t, Errors.t) M.t =
@@ -719,23 +982,27 @@ module Specific = struct
         |> Unsigned.UInt32.to_int64
       in
       let%bind block_info =
-        if Query.is_genesis ~block_height ~hash:genesisBlock.stateHash query then
+        if Query.is_genesis ~block_height ~hash:genesisBlock.stateHash query
+        then
           let genesis_block_identifier =
             { Block_identifier.index = block_height
-            ; hash= genesisBlock.stateHash }
+            ; hash = genesisBlock.stateHash
+            }
           in
           M.return
-            { Block_info.block_identifier=
+            { Block_info.block_identifier =
                 genesis_block_identifier
                 (* parent_block_identifier for genesis block should be the same as block identifier as described https://www.rosetta-api.org/docs/common_mistakes.html.correct-example *)
-            ; parent_block_identifier= genesis_block_identifier
-            ; creator= `Pk (genesisBlock.creatorAccount).publicKey
-            ; winner= `Pk (genesisBlock.winnerAccount).publicKey
-            ; timestamp=
-                Int64.of_string
-                  ((genesisBlock.protocolState).blockchainState).date
-            ; internal_info= []
-            ; user_commands= [] }
+            ; parent_block_identifier = genesis_block_identifier
+            ; creator = `Pk genesisBlock.creatorAccount.publicKey
+            ; winner = `Pk genesisBlock.winnerAccount.publicKey
+            ; timestamp =
+                Int64.of_string genesisBlock.protocolState.blockchainState.date
+            ; internal_info = []
+            ; user_commands = []
+            ; zkapp_commands = []
+            ; zkapps_account_updates = []
+            }
         else env.db_block query
       in
       let coinbase_receiver =
@@ -752,35 +1019,36 @@ module Specific = struct
               Internal_command_info_ops.to_operations ~coinbase_receiver info
             in
             [%log debug]
-              ~metadata:[("info", Internal_command_info.to_yojson info)]
+              ~metadata:[ ("info", Internal_command_info.to_yojson info) ]
               "Block internal received $info" ;
-            { Transaction.transaction_identifier=
+            { Transaction.transaction_identifier =
                 (* prepend the sequence number, secondary sequence number and kind to the transaction hash
                    duplicate hashes are possible in the archive database, with differing
                    "type" fields, which correspond to the "kind" here
                 *)
-                {Transaction_identifier.hash=
-                   sprintf "%s:%s:%s:%s"
-                     (Internal_command_info.Kind.to_string info.kind)
-                     (Int.to_string info.sequence_no)
-                     (Int.to_string info.secondary_sequence_no)
-                     info.hash}
+                { Transaction_identifier.hash =
+                    sprintf "%s:%s:%s:%s"
+                      (Internal_command_info.Kind.to_string info.kind)
+                      (Int.to_string info.sequence_no)
+                      (Int.to_string info.secondary_sequence_no)
+                      info.hash
+                }
             ; operations
             ; metadata= None
             ; related_transactions= [] }
             :: acc )
         |> M.map ~f:List.rev
       in
-      { Block_response.block=
+      { Block_response.block =
           Some
-            { Block.block_identifier= block_info.block_identifier
-            ; parent_block_identifier= block_info.parent_block_identifier
-            ; timestamp= block_info.timestamp
-            ; transactions=
+            { Block.block_identifier = block_info.block_identifier
+            ; parent_block_identifier = block_info.parent_block_identifier
+            ; timestamp = block_info.timestamp
+            ; transactions =
                 internal_transactions
                 @ List.map block_info.user_commands ~f:(fun info ->
                       [%log debug]
-                        ~metadata:[("info", User_command_info.to_yojson info)]
+                        ~metadata:[ ("info", User_command_info.to_yojson info) ]
                         "Block user received $info" ;
                       { Transaction.transaction_identifier=
                           {Transaction_identifier.hash= info.hash}
@@ -826,14 +1094,13 @@ end
 let router ~graphql_uri ~logger ~with_db (route : string list) body =
   let open Async.Deferred.Result.Let_syntax in
   [%log debug] "Handling /block/ $route"
-    ~metadata:[("route", `List (List.map route ~f:(fun s -> `String s)))] ;
-  [%log info] "Block query" ~metadata:[("query",body)];
+    ~metadata:[ ("route", `List (List.map route ~f:(fun s -> `String s))) ] ;
+  [%log info] "Block query" ~metadata:[ ("query", body) ] ;
   match route with
-  | [] | [""] ->
+  | [] | [ "" ] ->
       with_db (fun ~db ->
           let%bind req =
-            Errors.Lift.parse ~context:"Request"
-            @@ Block_request.of_yojson body
+            Errors.Lift.parse ~context:"Request" @@ Block_request.of_yojson body
             |> Errors.Lift.wrap
           in
           let%map res =


### PR DESCRIPTION
Add support for zkApps balance changing operations to the Rosetta Data API. With this, these operations are now included in the `/block` endpoint response.

Each zkApp command is encoded as a transaction, with the respective fee payment and balance updates encoded as operations part of that transaction.

This was tested in a local sandbox node by deploying several zkApps, interacting with them, and emitting payment operations from within those zkApps. The responses to some calls to the API were manually compared to the expected response. The `rosetta-cli` tool was also used, and all tests in the `check:data` test suite passed successfully.

The CI will be updated on a different PR to include this test suite.

Closes #11847.