### PR TITLE
Fix warnings 16

### DIFF
--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -116,8 +116,9 @@ let%test_module "Archive node unit tests" =
       User_command.Zkapp_command zkapp_command
 
     let fee_transfer_gen =
-      Fee_transfer.Single.Gen.with_random_receivers ~keys ~min_fee:0 ~max_fee:10
+      Fee_transfer.Single.Gen.with_random_receivers ~min_fee:0 ~max_fee:10
         ~token:(Quickcheck.Generator.return Token_id.default)
+        keys
 
     let coinbase_gen =
       Coinbase.Gen.with_random_receivers ~keys ~min_amount:20 ~max_amount:100

--- a/src/lib/mina_base/fee_transfer.ml
+++ b/src/lib/mina_base/fee_transfer.ml
@@ -49,7 +49,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     let fee_token { fee_token; _ } = fee_token
 
     module Gen = struct
-      let with_random_receivers ?(min_fee = 0) ~keys ~max_fee ~token :
+      let with_random_receivers ?(min_fee = 0) ~max_fee ~token keys :
           t Quickcheck.Generator.t =
         let open Quickcheck.Generator.Let_syntax in
         let%map receiver_pk =

--- a/src/lib/mina_base/fee_transfer_intf.ml
+++ b/src/lib/mina_base/fee_transfer_intf.ml
@@ -44,9 +44,9 @@ module type Full = sig
     module Gen : sig
       val with_random_receivers :
            ?min_fee:int
-        -> keys:Signature_keypair.t array
         -> max_fee:int
         -> token:Token_id.t Quickcheck.Generator.t
+        -> Signature_keypair.t array
         -> t Quickcheck.Generator.t
     end
   end

--- a/src/lib/mina_base/payment_payload.ml
+++ b/src/lib/mina_base/payment_payload.ml
@@ -77,7 +77,7 @@ let var_of_t ({ source_pk; receiver_pk; amount } : t) : var =
 
 [%%endif]
 
-let gen_aux ?source_pk ~max_amount =
+let gen_aux ?source_pk max_amount =
   let open Quickcheck.Generator.Let_syntax in
   let%bind source_pk =
     match source_pk with
@@ -90,6 +90,6 @@ let gen_aux ?source_pk ~max_amount =
   let%map amount = Amount.gen_incl Amount.zero max_amount in
   Poly.{ source_pk; receiver_pk; amount }
 
-let gen ?source_pk ~max_amount = gen_aux ?source_pk ~max_amount
+let gen ?source_pk max_amount = gen_aux ?source_pk max_amount
 
-let gen_default_token ?source_pk ~max_amount = gen_aux ?source_pk ~max_amount
+let gen_default_token ?source_pk max_amount = gen_aux ?source_pk max_amount

--- a/src/lib/mina_base/payment_payload.mli
+++ b/src/lib/mina_base/payment_payload.mli
@@ -51,14 +51,16 @@ end]
 
 val dummy : t
 
+(** [gen ?source_pk max_amount] *)
 val gen :
      ?source_pk:Public_key.Compressed.t
-  -> max_amount:Currency.Amount.t
+  -> Currency.Amount.t
   -> t Quickcheck.Generator.t
 
+(** [gen_default_token ?source_pk max_amount] *)
 val gen_default_token :
      ?source_pk:Public_key.Compressed.t
-  -> max_amount:Currency.Amount.t
+  -> Currency.Amount.t
   -> t Quickcheck.Generator.t
 
 type var = (Public_key.Compressed.var, Currency.Amount.var) Poly.t

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -209,7 +209,7 @@ module Body = struct
 
   module Tag = Transaction_union_tag
 
-  let gen ?source_pk ~max_amount =
+  let gen ?source_pk max_amount =
     let open Quickcheck.Generator in
     let stake_delegation_gen =
       match source_pk with
@@ -220,7 +220,7 @@ module Body = struct
     in
     map
       (variant2
-         (Payment_payload.gen ?source_pk ~max_amount)
+         (Payment_payload.gen ?source_pk max_amount)
          stake_delegation_gen )
       ~f:(function `A p -> Payment p | `B d -> Stake_delegation d)
 
@@ -376,7 +376,7 @@ let gen =
     Currency.Amount.(sub max_int (of_fee common.fee))
     |> Option.value_exn ?here:None ?error:None ?message:None
   in
-  let%map body = Body.gen ~source_pk:common.fee_payer_pk ~max_amount in
+  let%map body = Body.gen ~source_pk:common.fee_payer_pk max_amount in
   Poly.{ common; body }
 
 (** This module defines a weight for each payload component *)


### PR DESCRIPTION
Fix remaining warnings 16.

This is done by making the last non-optional labeled argument into a non-labeled one, instead of adding an extra `()`  argument.

There shouldn't be any warnings generated by compiling `dune build src/app/cli/src/mina.exe --profile=dev`