### PR TITLE
Extract blocks, add missing fields to block queries

### DIFF
--- a/src/app/extract_blocks/sql.ml
+++ b/src/app/extract_blocks/sql.ml
@@ -5,14 +5,16 @@ module Subchain = struct
     Core_kernel.sprintf
       {sql| WITH RECURSIVE chain AS (
 
-              SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
-                     next_epoch_data_id,ledger_hash,height,global_slot_since_hard_fork,global_slot_since_genesis,timestamp,chain_status
+              SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,
+                     staking_epoch_data_id,next_epoch_data_id,min_window_density,total_currency,ledger_hash,
+                     height,global_slot_since_hard_fork,global_slot_since_genesis,timestamp,chain_status
               FROM blocks b WHERE b.state_hash = $1
 
               UNION ALL
 
-              SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,b.snarked_ledger_hash_id,b.staking_epoch_data_id,
-                     b.next_epoch_data_id,b.ledger_hash,b.height,b.global_slot_since_hard_fork,b.global_slot_since_genesis,b.timestamp,b.chain_status
+              SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,b.snarked_ledger_hash_id,
+                     b.staking_epoch_data_id,b.next_epoch_data_id,b.min_window_density,b.total_currency,b.ledger_hash,
+                     b.height,b.global_slot_since_hard_fork,b.global_slot_since_genesis,b.timestamp,b.chain_status
               FROM blocks b
 
               INNER JOIN chain
@@ -20,8 +22,9 @@ module Subchain = struct
               ON %s
            )
 
-           SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,staking_epoch_data_id,
-                  next_epoch_data_id,ledger_hash,height,global_slot_since_hard_fork,global_slot_since_genesis,timestamp,chain_status
+           SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,
+                  staking_epoch_data_id,next_epoch_data_id,min_window_density,total_currency,ledger_hash,
+                  height,global_slot_since_hard_fork,global_slot_since_genesis,timestamp,chain_status
            FROM chain
       |sql}
       join_condition


### PR DESCRIPTION
Add missing `min_window_density` and `total_currency` fields to `blocks` queries for the `extract_blocks` app.

While that fixes the issue reported in #12127, the app does not succeed with dumps from the `berkeley` testnet, because the `authorization_kind` column does not exist in the `account_update_body` table in the dumps, while it does exist in the current schema. Also, the `command_type` columns for user and internal commands are still named `typ` in the dumps.

Closes #12127.