### PR TITLE
Remove redundant authorization kind

### DIFF
--- a/src/app/archive/drop_tables.sql
+++ b/src/app/archive/drop_tables.sql
@@ -42,6 +42,8 @@ DROP TABLE zkapp_account_update_body;
 
 DROP TYPE call_type;
 
+DROP TYPE authorization_kind_type;
+
 DROP TABLE zkapp_updates;
 
 DROP TABLE zkapp_network_precondition;
@@ -85,8 +87,6 @@ DROP TABLE zkapp_timestamp_bounds;
 DROP TABLE zkapp_token_id_bounds;
 
 DROP TYPE zkapp_auth_required_type;
-
-DROP TYPE zkapp_authorization_kind_type;
 
 DROP TYPE zkapp_precondition_type;
 

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -1580,33 +1580,10 @@ module Zkapp_account_update_body = struct
 end
 
 module Zkapp_account_update = struct
-  type t = { body_id : int; authorization_kind : Control.Tag.t }
-  [@@deriving fields, hlist]
-
-  let authorization_kind_typ =
-    let encode = function
-      | Control.Tag.Proof ->
-          "proof"
-      | Control.Tag.Signature ->
-          "signature"
-      | Control.Tag.None_given ->
-          "none_given"
-    in
-    let decode = function
-      | "proof" ->
-          Result.return Control.Tag.Proof
-      | "signature" ->
-          Result.return Control.Tag.Signature
-      | "none_given" ->
-          Result.return Control.Tag.None_given
-      | _ ->
-          Result.failf "Failed to decode authorization_kind_typ"
-    in
-    Caqti_type.enum "zkapp_authorization_kind_type" ~encode ~decode
+  type t = { body_id : int } [@@deriving fields, hlist]
 
   let typ =
-    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist
-      Caqti_type.[ int; authorization_kind_typ ]
+    Mina_caqti.Type_spec.custom_type ~to_hlist ~of_hlist Caqti_type.[ int ]
 
   let table_name = "zkapp_account_update"
 
@@ -1618,8 +1595,7 @@ module Zkapp_account_update = struct
         (module Conn)
         account_update.body
     in
-    let authorization_kind = Control.tag account_update.authorization in
-    let value = { body_id; authorization_kind } in
+    let value = { body_id } in
     Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
       ~table_name ~cols:(Fields.names, typ)
       (module Conn)

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -179,8 +179,6 @@ CREATE TABLE zkapp_accounts
 , zkapp_uri_id         int     NOT NULL  REFERENCES zkapp_uris(id)
 );
 
-CREATE TYPE zkapp_authorization_kind_type AS ENUM ('proof','signature','none_given');
-
 CREATE TABLE zkapp_token_id_bounds
 ( id                       serial           PRIMARY KEY
 , token_id_lower_bound     text             NOT NULL
@@ -278,10 +276,10 @@ CREATE TABLE zkapp_account_update_body
 , authorization_kind                    authorization_kind_type NOT NULL
 );
 
+/* possible future enhancement: add NULLable authorization column for proofs and signatures */
 CREATE TABLE zkapp_account_update
 ( id                       serial                          PRIMARY KEY
 , body_id                  int                             NOT NULL REFERENCES zkapp_account_update_body(id)
-, authorization_kind       zkapp_authorization_kind_type   NOT NULL
 );
 
 /* a list of of failures for an account update in a zkApp

--- a/src/app/replayer/replayer.ml
+++ b/src/app/replayer/replayer.ml
@@ -641,14 +641,14 @@ let zkapp_command_of_zkapp_command ~pool (cmd : Sql.Zkapp_command.t) :
   let%bind (account_updates : Account_update.Simple.t list) =
     Deferred.List.map (Array.to_list cmd.zkapp_account_updates_ids)
       ~f:(fun id ->
-        let%bind { body_id; authorization_kind } =
+        let%bind { body_id } =
           query_db ~f:(fun db -> Processor.Zkapp_account_update.load db id)
         in
         let%map body =
           Archive_lib.Load_data.get_account_update_body ~pool body_id
         in
         let (authorization : Control.t) =
-          match authorization_kind with
+          match body.authorization_kind with
           | Proof ->
               Proof Proof.transaction_dummy
           | Signature ->

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -26,12 +26,15 @@ module Authorization_kind = struct
     module V1 = struct
       type t =
             Mina_wire_types.Mina_base.Account_update.Authorization_kind.V1.t =
-        | None_given
         | Signature
         | Proof
+        | None_given
       [@@deriving sexp, equal, yojson, hash, compare]
 
       let to_latest = Fn.id
+
+      (* control tags are the same thing *)
+      let _f () : (t, Control.Tag.t) Type_equal.t = Type_equal.T
     end
   end]
 

--- a/src/lib/mina_base/control.ml
+++ b/src/lib/mina_base/control.ml
@@ -69,7 +69,11 @@ end]
 [%%endif]
 
 module Tag = struct
-  type t = Proof | Signature | None_given [@@deriving equal, compare, sexp]
+  type t = Mina_wire_types.Mina_base.Account_update.Authorization_kind.V1.t =
+    | Signature
+    | Proof
+    | None_given
+  [@@deriving equal, compare, sexp]
 
   let gen = Quickcheck.Generator.of_list [ Proof; Signature; None_given ]
 end

--- a/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
@@ -1,6 +1,6 @@
 module Authorization_kind = struct
   module V1 = struct
-    type t = None_given | Signature | Proof
+    type t = Signature | Proof | None_given
   end
 end
 


### PR DESCRIPTION
In the archive db schema, drop the `authorization_kind` column from the `zkapp_account_update` table. That column represented the actual authorization (proof or signature) in the OCaml code, but the authorization kind already appears in the `zkapp_account_update_body` table.

Update the archive processor to accommodate this change.

Also: establish a type equality between `Control.Tag.t` and `Account_update.Authorization_kind.t`, by positing a an equality with the same wire type, since they represent the same notion. The constructors needed to be reordered to make that happen.  This change may trigger the version linter, but this code has not been released to mainnet, so that's OK.

Closes #12200.