### PR TITLE
Update opam-nix, add per-editor instructions to Nix readme

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -277,11 +277,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1666213087,
-        "narHash": "sha256-P9RzZE8gixLEwsHj4RPIByeTf42muIi+AjUM0nTYtSQ=",
+        "lastModified": 1667491541,
+        "narHash": "sha256-Yq/wEQC7fz4A5zIhu6fymheUJdWBKx/Te7PMMb7lS2w=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "25922a6da8410f73ffe972bf3e1fb593e028bcbf",
+        "rev": "c3db5fdf0f2b4aba3f052a9b9b787303aa268a2f",
         "type": "github"
       },
       "original": {
@@ -330,11 +330,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1651529032,
-        "narHash": "sha256-fe8bm/V/4r2iNxgbitT2sXBqDHQ0GBSnSUSBg/1aXoI=",
+        "lastModified": 1665671715,
+        "narHash": "sha256-7f75C6fIkiLzfkwLpJxlQIKf+YORGsXGV8Dr2LDDi+A=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "e8e9f2fa86ef124b9f7b8db41d3d19471c1d8901",
+        "rev": "32fa2dcd993a27f9e75ee46fb8b78a7cd5d05113",
         "type": "github"
       },
       "original": {

--- a/nix/README.md
+++ b/nix/README.md
@@ -155,7 +155,7 @@ Now, whenever you start vim from `nix develop mina#with-lsp`, it should just wor
 
 ##### Emacs
 
-You need to install the [tuareg](https://github.com/ocaml/tuareg) and [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
+You need to install [tuareg](https://github.com/ocaml/tuareg) and  a LSP client, like  [lsp-mode](https://github.com/emacs-lsp/lsp-mode) or [eglot](https://github.com/joaotavora/eglot).
 This should just work without any configuration, as long as you start it from `nix develop mina#with-lsp`.
 
 ### "Pure" build

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -8,8 +8,8 @@ let
   inherit (builtins) filterSource path;
 
   inherit (pkgs.lib)
-    hasPrefix last getAttrs filterAttrs optionalAttrs makeBinPath
-    optionalString escapeShellArg;
+    hasPrefix last getAttrs filterAttrs optionalAttrs makeBinPath optionalString
+    escapeShellArg;
 
   external-repo =
     opam-nix.makeOpamRepoRec ../src/external; # Pin external packages
@@ -44,8 +44,9 @@ let
 
   pins = builtins.mapAttrs (name: pkg: { inherit name; } // pkg) export.package;
 
-  scope = opam-nix.applyOverlays opam-nix.__overlays (opam-nix.defsToScope pkgs
-    ((opam-nix.queryToDefs repos (extra-packages // implicit-deps)) // pins));
+  scope = opam-nix.applyOverlays opam-nix.__overlays
+    (opam-nix.defsToScope pkgs { }
+      ((opam-nix.queryToDefs repos (extra-packages // implicit-deps)) // pins));
 
   installedPackageNames =
     map (x: (opam-nix.splitNameVer x).name) (builtins.attrNames implicit-deps);
@@ -126,6 +127,8 @@ let
         # Prevent unnecessary rebuilds on non-source changes
         src = filtered-src;
 
+        withFakeOpam = false;
+
         # TODO, get this from somewhere
         MARLIN_REPO_SHA = "<unknown>";
         MINA_COMMIT_SHA1 = "<unknown>";
@@ -194,8 +197,16 @@ let
           dune build @doc || true
         '';
 
-        outputs =
-          [ "out" "archive" "generate_keypair" "mainnet" "testnet" "genesis" "sample" "batch_txn_tool"];
+        outputs = [
+          "out"
+          "archive"
+          "generate_keypair"
+          "mainnet"
+          "testnet"
+          "genesis"
+          "sample"
+          "batch_txn_tool"
+        ];
 
         installPhase = ''
           mkdir -p $out/bin $archive/bin $sample/share/mina $out/share/doc $generate_keypair/bin $mainnet/bin $testnet/bin $genesis/bin $genesis/var/lib/coda $batch_txn_tool/bin


### PR DESCRIPTION
- Update opam-nix to support `withFakeOpam = false`
- Add instructions for VSCode, Vim and Emacs to the Nix README
- Add a note about shell inits to the Troubleshooting section