### PR TITLE
Improve error messages around invalid zkApp commands

### DIFF
--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -611,6 +611,7 @@ let profile_zkapps ~verifier ledger zkapp_commands =
             [ User_command.to_verifiable ~ledger ~get:Mina_ledger.Ledger.get
                 ~location_of_account:Mina_ledger.Ledger.location_of_account
                 (Zkapp_command zkapp_command)
+              |> Or_error.ok_exn
             ]
         in
         let proof_count, signature_count =

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -159,13 +159,14 @@ module Verifiable = struct
         Account_update.Fee_payer.account_id p.fee_payer
 end
 
-let to_verifiable (t : t) ~ledger ~get ~location_of_account : Verifiable.t =
+let to_verifiable (t : t) ~ledger ~get ~location_of_account :
+    Verifiable.t Or_error.t =
   match t with
   | Signed_command c ->
-      Signed_command c
+      Ok (Signed_command c)
   | Zkapp_command cmd ->
-      Zkapp_command
-        (Zkapp_command.Verifiable.create ~ledger ~get ~location_of_account cmd)
+      Zkapp_command.Verifiable.create ~ledger ~get ~location_of_account cmd
+      |> Or_error.map ~f:(fun cmd -> Zkapp_command cmd)
 
 let of_verifiable (t : Verifiable.t) : t =
   match t with

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -160,27 +160,12 @@ module Verifiable = struct
 end
 
 let to_verifiable (t : t) ~ledger ~get ~location_of_account : Verifiable.t =
-  let find_vk (p : Account_update.t) =
-    let ( ! ) x = Option.value_exn x in
-    let id = Account_update.account_id p in
-    Option.try_with (fun () ->
-        let account : Account.t =
-          !(get ledger !(location_of_account ledger id))
-        in
-        !(!(account.zkapp).verification_key) )
-  in
   match t with
   | Signed_command c ->
       Signed_command c
-  | Zkapp_command { fee_payer; account_updates; memo } ->
+  | Zkapp_command cmd ->
       Zkapp_command
-        { fee_payer
-        ; account_updates =
-            account_updates
-            |> Zkapp_command.Call_forest.map ~f:(fun account_update ->
-                   (account_update, find_vk account_update) )
-        ; memo
-        }
+        (Zkapp_command.Verifiable.create ~ledger ~get ~location_of_account cmd)
 
 let of_verifiable (t : Verifiable.t) : t =
   match t with

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -265,12 +265,16 @@ module Valid = struct
   module Gen = Gen_make (Signed_command.With_valid_signature)
 end
 
-let check ~ledger ~get ~location_of_account (t : t) : Valid.t option =
+let check ~ledger ~get ~location_of_account (t : t) : Valid.t Or_error.t =
   match t with
-  | Signed_command x ->
-      Option.map (Signed_command.check x) ~f:(fun c -> Signed_command c)
+  | Signed_command x -> (
+      match Signed_command.check x with
+      | Some c ->
+          Ok (Signed_command c)
+      | None ->
+          Or_error.error_string "Invalid signature" )
   | Zkapp_command p ->
-      Option.map
+      Or_error.map
         (Zkapp_command.Valid.to_valid ~ledger ~get ~location_of_account p)
         ~f:(fun p -> Zkapp_command p)
 

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -100,10 +100,11 @@ module Call_forest = struct
       fold2_exn ts1 ts2 ~init:() ~f:(fun () p1 p2 -> f p1 p2)
 
     let rec mapi_with_trees' ~i (t : _ t) ~f =
+      let account_update = f i t.account_update t in
       let l, calls = mapi_forest_with_trees' ~i:(i + 1) t.calls ~f in
       ( l
       , { calls
-        ; account_update = f i t.account_update t
+        ; account_update
         ; account_update_digest = t.account_update_digest
         } )
 

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1323,6 +1323,20 @@ module Virtual = struct
   end
 end
 
+let check_authorization (p : Account_update.t) : unit Or_error.t =
+  match (p.authorization, p.body.authorization_kind) with
+  | None_given, None_given | Proof _, Proof | Signature _, Signature ->
+      Ok ()
+  | _ ->
+      let err =
+        Error.create "Authorization kind does not match the authorization"
+          [ ("expected", p.body.authorization_kind)
+          ; ("got", Control.tag p.authorization)
+          ]
+          [%sexp_of: (string * Account_update.Authorization_kind.t) list]
+      in
+      Error err
+
 module Verifiable : sig
   [%%versioned:
   module Stable : sig
@@ -1348,7 +1362,7 @@ module Verifiable : sig
     -> ledger:'a
     -> get:('a -> 'b -> Account.t option)
     -> location_of_account:('a -> Account_id.t -> 'b option)
-    -> t
+    -> t Or_error.t
 end = struct
   [%%versioned
   module Stable = struct
@@ -1369,24 +1383,94 @@ end = struct
     end
   end]
 
-  let create (t : T.t) ~ledger ~get ~location_of_account : t =
-    let find_vk (p : Account_update.t) =
-      let ( ! ) x = Option.value_exn x in
-      let id = Account_update.account_id p in
-      Option.try_with (fun () ->
-          let account : Account.t =
-            !(get ledger !(location_of_account ledger id))
-          in
-          !(!(account.zkapp).verification_key) )
-    in
-    let ({ fee_payer; account_updates; memo } : T.t) = t in
-    { fee_payer
-    ; account_updates =
-        account_updates
-        |> Call_forest.map ~f:(fun account_update ->
-               (account_update, find_vk account_update) )
-    ; memo
-    }
+  (* Ensures that there's a verification_key available for all account_updates
+   * and creates a valid command associating the correct keys with each
+   * account_id.
+   *
+   * If an account_update replaces the verification_key (or deletes it),
+   * subsequent account_updates use the replaced key instead of looking in the
+   * ledger for the key (ie set by a previous transaction).
+   *)
+  let create ({ fee_payer; account_updates; memo } : T.t) ~ledger ~get
+      ~location_of_account : t Or_error.t =
+    With_return.with_return (fun { return } ->
+        let find_vk account_id =
+          match
+            let open Option.Let_syntax in
+            let%bind location = location_of_account ledger account_id in
+            let%bind (account : Account.t) = get ledger location in
+            let%bind zkapp = account.zkapp in
+            zkapp.verification_key
+          with
+          | Some vk ->
+              vk
+          | None ->
+              let err =
+                Error.create
+                  "No verification key found for proved account update"
+                  ("account_id", account_id) [%sexp_of: string * Account_id.t]
+              in
+              return (Error err)
+        in
+        let tbl = Account_id.Table.create () in
+        let vks_overridden =
+          (* Keep track of the verification keys that have been set so far
+             during this transaction.
+          *)
+          ref Account_id.Map.empty
+        in
+        let account_updates =
+          Call_forest.map account_updates ~f:(fun p ->
+              let account_id = Account_update.account_id p in
+              let vks_overriden' =
+                match Account_update.verification_key_update_to_option p with
+                | Zkapp_basic.Set_or_keep.Set vk_next ->
+                    Account_id.Map.set !vks_overridden ~key:account_id
+                      ~data:vk_next
+                | Zkapp_basic.Set_or_keep.Keep ->
+                    !vks_overridden
+              in
+              let () =
+                match check_authorization p with
+                | Ok () ->
+                    ()
+                | Error _ as err ->
+                    return err
+              in
+              if Control.(Tag.equal Tag.Proof (Control.tag p.authorization))
+              then (
+                let prioritized_vk =
+                  (* only lookup _past_ vk setting, ie exclude the new one we
+                   * potentially set in this account_update (use the non-'
+                   * vks_overrided) . *)
+                  match Account_id.Map.find !vks_overridden account_id with
+                  | Some (Some vk) ->
+                      vk
+                  | Some None ->
+                      (* we explicitly have erased the key *)
+                      let err =
+                        Error.create
+                          "No verification key found for proved account \
+                           update: the verification key was removed by a \
+                           previous account update"
+                          ("account_id", account_id)
+                          [%sexp_of: string * Account_id.t]
+                      in
+                      return (Error err)
+                  | None ->
+                      (* we haven't set anything; lookup the vk in the ledger *)
+                      find_vk account_id
+                in
+                Account_id.Table.update tbl account_id ~f:(fun _ ->
+                    With_hash.hash prioritized_vk ) ;
+                (* return the updated overrides *)
+                vks_overridden := vks_overriden' ;
+                (p, Some prioritized_vk) )
+              else (
+                vks_overridden := vks_overriden' ;
+                (p, None) ) )
+        in
+        Ok { fee_payer; account_updates; memo } )
 end
 
 let of_verifiable (t : Verifiable.t) : t =
@@ -1529,20 +1613,6 @@ struct
   let create ~verification_keys zkapp_command : t =
     { zkapp_command; verification_keys }
 
-  let check_authorization (p : Account_update.t) : unit Or_error.t =
-    match (p.authorization, p.body.authorization_kind) with
-    | None_given, None_given | Proof _, Proof | Signature _, Signature ->
-        Ok ()
-    | _ ->
-        let err =
-          Error.create "Authorization kind does not match the authorization"
-            [ ("expected", p.body.authorization_kind)
-            ; ("got", Control.tag p.authorization)
-            ]
-            [%sexp_of: (string * Account_update.Authorization_kind.t) list]
-        in
-        Error err
-
   let of_verifiable (t : Verifiable.t) : t Or_error.t =
     let open Or_error.Let_syntax in
     let tbl = Account_id.Table.create () in
@@ -1575,82 +1645,9 @@ struct
 
   let forget (t : t) : T.t = t.zkapp_command
 
-  (* Ensures that there's a verification_key available for all account_updates
-   * and creates a valid command associating the correct keys with each
-   * account_id.
-   *
-   * If an account_update replaces the verification_key (or deletes it),
-   * subsequent account_updates use the replaced key instead of looking in the
-   * ledger for the key (ie set by a previous transaction).
-   *)
   let to_valid (t : T.t) ~ledger ~get ~location_of_account : t Or_error.t =
-    let open Or_error.Let_syntax in
-    let find_vk account_id =
-      match
-        let open Option.Let_syntax in
-        let%bind location = location_of_account ledger account_id in
-        let%bind (account : Account.t) = get ledger location in
-        let%bind zkapp = account.zkapp in
-        zkapp.verification_key
-      with
-      | Some vk ->
-          Ok vk
-      | None ->
-          let err =
-            Error.create "No verification key found for proved account update"
-              ("account_id", account_id) [%sexp_of: string * Account_id.t]
-          in
-          Error err
-    in
-    let tbl = Account_id.Table.create () in
-    let%map (_all_succeeded : _ Account_id.Map.t) =
-      Call_forest.fold t.account_updates
-        ~init:
-          ((* keep track of the verification keys that have been set so far
-            * during this transaction -- the option tracks if we should stop
-            * early due to an error *)
-             Ok
-             Account_id.Map.empty ) ~f:(fun acc p ->
-          let%bind vks_overriden = acc in
-          let account_id = Account_update.account_id p in
-          let vks_overriden' =
-            match Account_update.verification_key_update_to_option p with
-            | Zkapp_basic.Set_or_keep.Set vk_next ->
-                Account_id.Map.set vks_overriden ~key:account_id ~data:vk_next
-            | Zkapp_basic.Set_or_keep.Keep ->
-                vks_overriden
-          in
-          let%bind () = check_authorization p in
-          if Control.(Tag.equal Tag.Proof (Control.tag p.authorization)) then (
-            let%map prioritized_vk =
-              (* only lookup _past_ vk setting, ie exclude the new one we
-               * potentially set in this account_update (use the non-'
-               * vks_overrided) . *)
-              match Account_id.Map.find vks_overriden account_id with
-              | Some (Some vk) ->
-                  Ok vk
-              | Some None ->
-                  (* we explicitly have erased the key *)
-                  let err =
-                    Error.create
-                      "No verification key found for proved account update: \
-                       the verification key was removed by a previous account \
-                       update"
-                      ("account_id", account_id)
-                      [%sexp_of: string * Account_id.t]
-                  in
-                  Error err
-              | None ->
-                  (* we haven't set anything; lookup the vk in the ledger *)
-                  find_vk account_id
-            in
-            Account_id.Table.update tbl account_id ~f:(fun _ ->
-                With_hash.hash prioritized_vk ) ;
-            (* return the updated overrides *)
-            vks_overriden' )
-          else Ok vks_overriden' )
-    in
-    create ~verification_keys:(Account_id.Table.to_alist tbl) t
+    Verifiable.create t ~ledger ~get ~location_of_account
+    |> Or_error.bind ~f:of_verifiable
 end
 
 [%%define_locally Stable.Latest.(of_yojson, to_yojson)]

--- a/src/lib/mina_generators/user_command_generators.ml
+++ b/src/lib/mina_generators/user_command_generators.ml
@@ -135,7 +135,7 @@ let zkapp_command_with_ledger ?num_keypairs ?max_account_updates
       ?vk ?failure ()
   in
   let zkapp_command =
-    Option.value_exn
+    Or_error.ok_exn
       (Zkapp_command.Valid.to_valid ~ledger ~get:Ledger.get
          ~location_of_account:Ledger.location_of_account zkapp_command )
   in
@@ -181,7 +181,7 @@ let sequence_zkapp_command_with_ledger ?max_account_updates ?max_token_updates
           ~account_state_tbl ?vk ?failure ()
       in
       let valid_zkapp_command =
-        Option.value_exn
+        Or_error.ok_exn
           (Zkapp_command.Valid.to_valid ~ledger ~get:Ledger.get
              ~location_of_account:Ledger.location_of_account zkapp_command )
       in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1615,10 +1615,12 @@ let%test_module _ =
                   Zkapp_command.Valid.to_valid ~ledger ~get ~location_of_account
                     zkapp_command
                 with
-                | Some ps ->
+                | Ok ps ->
                     ps
-                | None ->
-                    failwith "Could not create Zkapp_command.Valid.t"
+                | Error err ->
+                    Error.raise
+                    @@ Error.tag ~tag:"Could not create Zkapp_command.Valid.t"
+                         err
               in
               User_command.Zkapp_command valid_zkapp_command
           | Signed_command _ ->
@@ -1797,7 +1799,7 @@ let%test_module _ =
         Transaction_snark.For_tests.multiple_transfers test_spec
       in
       let zkapp_command =
-        Option.value_exn
+        Or_error.ok_exn
           (Zkapp_command.Valid.to_valid ~ledger:()
              ~get:(fun _ _ -> failwith "Not expecting proof zkapp_command")
              ~location_of_account:(fun _ _ ->
@@ -1884,7 +1886,7 @@ let%test_module _ =
               }
             in
             let zkapp_command =
-              Option.value_exn
+              Or_error.ok_exn
                 (Zkapp_command.Valid.to_valid ~ledger:best_tip_ledger
                    ~get:Mina_ledger.Ledger.get
                    ~location_of_account:Mina_ledger.Ledger.location_of_account

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1018,13 +1018,15 @@ module T = struct
     (List.map ~f:(With_status.map ~f:Transaction.forget) a, b, c, d)
 
   let check_commands ledger ~verifier (cs : User_command.t list) =
-    let cs =
-      List.map cs
-        ~f:
-          (let open Ledger in
-          User_command.to_verifiable ~ledger ~get ~location_of_account)
-    in
     let open Deferred.Or_error.Let_syntax in
+    let%bind cs =
+      Or_error.try_with (fun () ->
+          List.map cs ~f:(fun cmd ->
+              let open Ledger in
+              User_command.to_verifiable ~ledger ~get ~location_of_account cmd
+              |> Or_error.ok_exn ) )
+      |> Deferred.return
+    in
     let%map xs = Verifier.verify_commands verifier cs in
     Result.all
       (List.map xs ~f:(function

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2545,10 +2545,12 @@ let%test_module "staged ledger tests" =
                     ~get:Ledger.get
                     ~location_of_account:Ledger.location_of_account
                 with
-                | Some ps ->
+                | Ok ps ->
                     ps
-                | None ->
-                    failwith "Could not create Zkapp_command.Valid.t"
+                | Error err ->
+                    Error.raise
+                    @@ Error.tag ~tag:"Could not create Zkapp_command.Valid.t"
+                         err
               in
               User_command.Zkapp_command valid_zkapp_command_with_auths
           | Signed_command _, _, _ ->
@@ -3860,7 +3862,7 @@ let%test_module "staged ledger tests" =
                       ~constraint_constants test_spec
                   in
                   let valid_zkapp_command =
-                    Option.value_exn
+                    Or_error.ok_exn
                       (Zkapp_command.Valid.to_valid ~ledger:valid_against_ledger
                          ~get:Ledger.get
                          ~location_of_account:Ledger.location_of_account

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -105,7 +105,7 @@ let check :
           let v : User_command.Valid.t =
             (*Verification keys should be present if it reaches here*)
             let zkapp_command =
-              Option.value_exn
+              Or_error.ok_exn
                 (Zkapp_command.Valid.of_verifiable zkapp_command_with_vk)
             in
             User_command.Poly.Zkapp_command zkapp_command


### PR DESCRIPTION
This PR replaces the non-descriptive `option` type with an `Or_error.t`, containing information about the specific error that has occurred.

This makes debugging easier, and gives better feedback to users that attempt to send invalid transactions.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them