### PR TITLE
Display key from private-key file as hexadecimal 

### DIFF
--- a/src/app/rosetta/ocaml-signer/dune
+++ b/src/app/rosetta/ocaml-signer/dune
@@ -23,6 +23,7 @@
    mina_base
    snark_params
    pickles.backend
+   secrets
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps

--- a/src/app/rosetta/ocaml-signer/signer_cli.ml
+++ b/src/app/rosetta/ocaml-signer/signer_cli.ml
@@ -116,6 +116,36 @@ let generate_command =
   printf "%s\n" Signer.Keys.(of_keypair keypair |> to_private_key_bytes) ;
   return ()
 
+(** Extracts an hexadecimal private key suitable for rosetta from a private-key file.
+    Similarly to the main [mina] binary, the password from the [Secrets.Keypair.env] environment variable will be used if it it set, otherwise it will be read from stdin.*)
+let hex_of_private_key_file =
+  let open Command.Let_syntax in
+  let%map_open privkey_path =
+    flag "--private-key-path" ~doc:"Path to the private key file"
+      (required string)
+  in
+  fun () ->
+    let password =
+      Lazy.return
+        ( match Sys.getenv Secrets.Keypair.env with
+        | Some password ->
+            Deferred.return (Bytes.of_string password)
+        | None ->
+            Secrets.Password.read_hidden_line ~error_help_message:""
+              "Secret key password: " )
+    in
+    let print_key =
+      let open Deferred.Result.Let_syntax in
+      let%bind keypair =
+        Secrets.Keypair.read ~privkey_path ~password
+        |> Deferred.Result.map_error ~f:Secrets.Privkey_error.to_string
+      in
+      return
+        (Format.printf "%s@."
+           (Rosetta_coding.Coding.of_scalar keypair.private_key) )
+    in
+    Deferred.map ~f:Result.ok_or_failwith print_key
+
 let convert_signature_command =
   let open Command.Let_syntax in
   let%map_open field_str =
@@ -151,4 +181,8 @@ let commands =
     , Command.async ~summary:"Convert signature from field,scalar decimal strings into Rosetta Signature" convert_signature_command )
   ; ( "verify-message"
     , Command.async ~summary:"Verify a string message was signed properly" verify_message_command )
-    ]
+  ; ( "hex-of-private-key-file"
+    , Command.async
+        ~summary:"Read a private key file and display it as hexadecimal"
+        hex_of_private_key_file )
+  ]


### PR DESCRIPTION
This PR provides a way to read a private key from a file and display it as hexadecimal suitable for rosetta (using the `Rosetta_coding.Coding.of_scalar` function).

I did not find an entry point to this function so I added one to the `ocaml-signer` binary (as it already does related things).

This is needed in order to use the `prefunded_accounts` feature of `rosetta-cli` and have it automatically use funds from a pre-existing account.

This was tested by running the `rosetta-cli` construction tests with the produced hex private key.
