### PR TITLE
UNIQUE constraint for epoch_data

### DIFF
--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -63,6 +63,7 @@ CREATE TABLE epoch_data
 ( id             serial PRIMARY KEY
 , seed           text   NOT NULL
 , ledger_hash_id int    NOT NULL REFERENCES snarked_ledger_hashes(id)
+, UNIQUE (seed,ledger_hash_id)
 );
 
 CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned', 'pending');


### PR DESCRIPTION
The seed and snarked ledger hash are meant to be unique in `epoch_data`, but there was no constraint to enforce that. `Epoch_data.add_if_doesn't_exist` was meant to enforce that; better to have Postgresql enforce that as a backstop.

(We saw non-unique entries in a db that was not running with the `SERIALIZABLE` isolation policy; the constraint would have prevented that.)