### PR TITLE
Rosetta construction tests

### DIFF
--- a/src/app/rosetta/rosetta-cli-config/config.json
+++ b/src/app/rosetta/rosetta-cli-config/config.json
@@ -3,7 +3,7 @@
   "blockchain": "mina",
   "network": "debug"
  },
- "online_url": "http://localhost:3087",
+ "online_url": "http://localhost:PLACEHOLDER_ROSETTA_ONLINE_PORT",
  "data_directory": "",
  "http_timeout": 10,
  "max_retries": 5,
@@ -19,7 +19,18 @@
  "error_stack_trace_disabled": false,
  "coin_supported": false,
  "construction": {
-   "offline_url":                "http://localhost:3088",
+ "prefunded_accounts":[
+   {
+     "privkey": "PLACEHOLDER_PREFUNDED_PRIVKEY",
+     "account_identifier":{
+     "address": "PLACEHOLDER_PREFUNDED_ADDRESS",
+     "metadata": {"token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"}
+     },
+     "curve_type":"pallas",
+     "currency":{"symbol":"MINA", "decimals":9}
+   }
+   ],
+   "offline_url":                "http://localhost:PLACEHOLDER_ROSETTA_OFFLINE_PORT",
    "max_offline_connections":    4,
    "force_retry":                false,
    "stale_depth":                3,
@@ -36,7 +47,7 @@
    "initial_balance_fetch_disabled": false,
    "end_conditions": {
      "create_account":         10,
-     "transfer":               20
+     "transfer":               10
    }
  },
  "data": {

--- a/src/app/rosetta/rosetta-cli-config/mina.ros
+++ b/src/app/rosetta/rosetta-cli-config/mina.ros
@@ -1,11 +1,14 @@
+// Workflow used to create new accounts
 create_account(1){
-  create_account{
+  create{
     network = {"network":"debug", "blockchain":"mina"};
-    key = generate_key({"curve_type":"pallas"});
+    key = generate_key({"curve_type": "pallas"});
     account = derive({
       "network_identifier": {{network}},
       "public_key": {{key.public_key}}
     });
+
+    // If the account is not saved, the key will be lost!
     save_account({
       "account_identifier": {{account.account_identifier}},
       "keypair": {{key}}
@@ -13,29 +16,77 @@ create_account(1){
   }
 }
 
-request_funds(1){
-  find_account{
-    currency = {
-      "symbol":"mina",
-      "decimals":9
-    };
-    random_account = find_balance({
+// Workflow used to generate payment transactions
+transfer(10){
+  transfer{
+    transfer.network = {"network":"debug", "blockchain":"mina"};
+    currency = {"symbol":"MINA", "decimals":9};
+    sender = find_balance({
+      "minimum_balance":{
+        "value": "20000000000",
+        "currency": {{currency}}
+      }
+    });
+
+    // The fee must be at least the creation fee of the account if it
+    // did not exist before the transaction
+    max_fee = "4000000000";
+    min_fee = "2000000000";
+
+    // We limit the amount to genereate multiple transactions with the
+    // same prefunded account
+    available_amount = "6000000000";
+
+    // Find recipient and construct operations
+    recipient_amount = random_number({"minimum": {{max_fee}}, "maximum": {{available_amount}}});
+    sender_amount = 0 - {{recipient_amount}};
+    fee = random_number({"minimum": {{min_fee}}, "maximum": {{max_fee}}});
+    minus_fee = 0 - {{fee}};
+    recipient = find_balance({
+      "not_account_identifier":[{{sender.account_identifier}}],
       "minimum_balance":{
         "value": "0",
         "currency": {{currency}}
       },
-      "create_limit":1
+      "create_limit": 100,
+      "create_probability": 50
     });
-  },
-  request{
-    min_balance = load_env("MIN_BALANCE");
-    adjusted_min = {{min_balance}} + 600;
-    loaded_account = find_balance({
-      "account_identifier": {{random_account.account_identifier}},
-      "minimum_balance":{
-        "value": {{adjusted_min}},
-        "currency": {{currency}}
+    transfer.confirmation_depth = "1";
+
+    // The valid_until field must be provided explicitely until the
+    // default value is fixed
+    // See https://github.com/coinbase/rosetta-sdk-go/pull/457
+    transfer.preprocess_metadata={"valid_until": "4294967295"};
+
+    // Operations for a payment transaction
+    transfer.operations = [
+      {
+        "operation_identifier":{"index":0},
+        "type":"fee_payment",
+        "account":{{sender.account_identifier}},
+        "amount":{
+          "value": {{minus_fee}},
+          "currency":{{currency}}
+        }
+      },
+      {
+        "operation_identifier":{"index":1},
+        "type":"payment_source_dec",
+        "account":{{sender.account_identifier}},
+        "amount":{
+          "value":{{sender_amount}},
+          "currency":{{currency}}
+        }
+      },
+      {
+        "operation_identifier":{"index":2},
+        "type": "payment_receiver_inc",
+        "account":{{recipient.account_identifier}},
+        "amount":{
+          "value":{{recipient_amount}},
+          "currency":{{currency}}
+        }
       }
-    });
+    ];
   }
 }


### PR DESCRIPTION
This PR:
- Updates the `rosetta-cli` configuration files to add tests for the construction API.
- Updates the `rosetta-integration-tests.sh` script to run these tests in the CI.

Changes:
- The `mina.ros` file describe the construction api tests and is updated to create accounts and generate payment transactions.
- The `rosetta-cli` configuration files now contain some placeholder that must be replaced after the sandbox is generated.
- Tests are run against `mina-dev` because `rosetta-cli` assumes we are using a `testnet` (See [here](https://github.com/coinbase/rosetta-sdk-go/blob/master/keys/signer_pallas.go#L22)).

Tests:
- The CI job may still fails at a later step (it is left optional) but we can see that the construction tests are successful [here](https://buildkite.com/o-1-labs-2/mina/builds/26189#0184ecae-90fe-4d3e-b1c2-f82c9f3045c1/64-1752).


