### PR TITLE
epoch_data UNIQUE constraint

### DIFF
--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -127,6 +127,7 @@ CREATE TABLE epoch_data
 , start_checkpoint text   NOT NULL
 , lock_checkpoint  text   NOT NULL
 , epoch_length     bigint NOT NULL
+, UNIQUE (seed, ledger_hash_id, total_currency, start_checkpoint, lock_checkpoint, epoch_length)
 );
 
 CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned', 'pending');


### PR DESCRIPTION
Add a `UNIQUE` constraint for the `epoch_data` table of the archive database.

This is similar to the PR against `compatible`, #12292, except that the table now has more columns. @nholland94 indicates that there may be rare cases where the epoch length may be different, with other columns otherwise identical. For simplicity, the constraint is against all the columns in the table, except the id.
