### PR TITLE
Fix problems with balance reconciliation in rosetta-cli tests

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11254,6 +11254,19 @@
               "deprecationReason": null
             },
             {
+              "name": "genesis_balance",
+              "description":
+                "The amount of MINA owned by the account at Genesis",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "AnnotatedBalance",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "nonce",
               "description":
                 "A natural number that increases with each transaction (stringified uint32)",

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -491,7 +491,7 @@ WITH RECURSIVE chain AS (
         FROM internal_commands i
         INNER JOIN blocks_internal_commands bic ON bic.internal_command_id = i.id
         INNER JOIN account_identifiers ai on ai.id = i.receiver_id
-        INNER JOIN accounts_created ac on ac.account_identifier_id = ai.id
+        LEFT JOIN accounts_created ac on ac.account_identifier_id = ai.id
         INNER JOIN public_keys pk ON pk.id = ai.public_key_id
         WHERE bic.block_id = ?
       |}

--- a/src/app/rosetta/rosetta-cli-config/README.md
+++ b/src/app/rosetta/rosetta-cli-config/README.md
@@ -65,12 +65,21 @@ Note: the database name `archive` should be identical to
 
 ```shell
 $ "_build/default/src/app/archive/archive.exe" run \
+    --config-file daemon.json \
     --postgres-uri "postgres://localhost:5432/archive" \
     --server-port 3086
 ```
 Note that the `--server-port` param should be equal to the one we set
 previously for the node. As the node starts producing blocks, we
 should see those blocks appear in archive's logs too.
+
+`daemon.json` should be replaced with the path to the daemon's
+(see above) configuration file. When provided with this file,
+the archive will load the genesis ledger from it into its own
+database. This is strictly necessary for Rosetta – without the
+genesis ledger it will return wrong balances for genesis accounts
+when asked for blocks before the first transaction involving
+such an account was made.
 
 Also note that archive can only know about the blocks that were
 produced when it was running. This limitation also applies to

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1024,17 +1024,35 @@ module Types = struct
           , Permissions.t option
           , Zkapp_account.t option )
           Account.Poly.t
+      ; genesis_balance : AnnotatedBalance.t option
       ; locked : bool option
       ; is_actively_staking : bool
       ; path : string
       ; index : Account.Index.t option
       }
 
+    let genesis_balance mina public_key =
+      let gl = Mina_lib.genesis_ledger mina in
+      Ledger.fold_until (Lazy.force gl) ~init:()
+        ~f:(fun () a ->
+          if Account.Key.compare (Account.public_key a) public_key = 0 then
+            Stop
+              (Some
+                 AnnotatedBalance.
+                   { total = a.balance
+                   ; unknown = Balance.zero
+                   ; timing = a.timing
+                   ; breadcrumb = None
+                   } )
+          else Continue () )
+        ~finish:(Fun.const None)
+
     let lift mina pk account =
       let block_production_pubkeys = Mina_lib.block_production_pubkeys mina in
       let accounts = Mina_lib.wallets mina in
       let best_tip_ledger = Mina_lib.best_ledger mina in
       { account
+      ; genesis_balance = genesis_balance mina account.public_key
       ; locked = Secrets.Wallets.check_locked accounts ~needle:pk
       ; is_actively_staking =
           ( if Token_id.(equal default) account.token_id then
@@ -1175,6 +1193,10 @@ module Types = struct
                  ~doc:"The amount of MINA owned by the account"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } -> account.Account.Poly.balance)
+             ; field "genesis_balance" ~typ:AnnotatedBalance.obj
+                 ~doc:"The amount of MINA owned by the account at Genesis"
+                 ~args:Arg.[]
+                 ~resolve:(fun _ (b : t) -> b.genesis_balance)
              ; field "nonce" ~typ:account_nonce
                  ~doc:
                    "A natural number that increases with each transaction \
@@ -1280,6 +1302,8 @@ module Types = struct
                    List.map
                      ~f:(fun a ->
                        { account = Partial_account.of_full_account a
+                       ; genesis_balance =
+                           genesis_balance mina account.public_key
                        ; locked = None
                        ; is_actively_staking = true
                        ; path = ""
@@ -1311,6 +1335,8 @@ module Types = struct
                    List.map
                      ~f:(fun a ->
                        { account = Partial_account.of_full_account a
+                       ; genesis_balance =
+                           genesis_balance mina account.public_key
                        ; locked = None
                        ; is_actively_staking = true
                        ; path = ""
@@ -4184,6 +4210,7 @@ module Queries = struct
     |> List.map ~f:(fun pk ->
            { Types.AccountObj.account =
                Types.AccountObj.Partial_account.of_pk mina pk
+           ; genesis_balance = Types.AccountObj.genesis_balance mina pk
            ; locked = Secrets.Wallets.check_locked wallets ~needle:pk
            ; is_actively_staking =
                Public_key.Compressed.Set.mem block_production_pubkeys pk

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2172,3 +2172,5 @@ let runtime_config { config = { precomputed_values; _ }; _ } =
   Genesis_ledger_helper.runtime_config_of_precomputed_values precomputed_values
 
 let verifier { processes = { verifier; _ }; _ } = verifier
+
+let genesis_ledger t = Genesis_proof.genesis_ledger t.config.precomputed_values

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -217,3 +217,5 @@ val net : t -> Mina_networking.t
 val runtime_config : t -> Runtime_config.t
 
 val verifier : t -> Verifier.t
+
+val genesis_ledger : t -> Mina_ledger.Ledger.t Lazy.t


### PR DESCRIPTION
This PR fixes two bugs, which caused balance reconciliation failures in `rosetta-cli` tests:
* `/account/balance` when asked for a balance at a block before any transaction involving the queried account was performed, Rosetta reported the most recent balance;
* `/block` only reported internal operations when there had been an account creation fee associated with it.

In order to fix the first bug, `genesis_balance` for each account can now be obtained from GraphQL. `genesis_balance` describes the initial shape of an account it it was present in the genesis ledger or is `null` otherwise.

Manually testing changes:
Set up Rosetta server (this is the easiest to do in sandbox mode), generate some transactions and run `rosetta-cli check:data` against the blockchain. Instructions on how to do it can be found [here](https://github.com/MinaProtocol/mina/blob/develop/src/app/rosetta/rosetta-cli-config/README.md).


Checklist:

- [x] Does this close issues? List them

* Closes #12299 
