### PR TITLE
Change permissions hash input

### DIFF
--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -495,7 +495,7 @@ module Update = struct
       ; Set_or_keep.to_input
           (Set_or_keep.map verification_key ~f:With_hash.hash)
           ~dummy:Field.zero ~f:field
-      ; Set_or_keep.to_input permissions ~dummy:Permissions.user_default
+      ; Set_or_keep.to_input permissions ~dummy:Permissions.empty
           ~f:Permissions.to_input
       ; Set_or_keep.to_input
           (Set_or_keep.map ~f:Zkapp_account.hash_zkapp_uri zkapp_uri)

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -536,7 +536,7 @@ module Update = struct
                    { Zkapp_basic.Flagged_option.data
                    ; is_some = Set_or_keep.Checked.is_set x
                    } ) )
-      ; Set_or_keep.typ ~dummy:Permissions.user_default Permissions.typ
+      ; Set_or_keep.typ ~dummy:Permissions.empty Permissions.typ
       ; Set_or_keep.optional_typ
           (Data_as_hash.optional_typ ~hash:Zkapp_account.hash_zkapp_uri
              ~non_preimage:(Zkapp_account.hash_zkapp_uri_opt None)


### PR DESCRIPTION
This is to ease compatibility of the hash inputs in JS, without having to add mechanisms to have special annotations for high-level types

Slack thread: https://o1-labs.slack.com/archives/C02ASV6BZCY/p1667999296834509

Snarkyjs companion: https://github.com/o1-labs/snarkyjs/pull/622
