### PR TITLE
Update proof-systems for `PointEvaluations`

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
@@ -229,28 +229,31 @@ module Make (Inputs : Inputs_intf) = struct
     ; challenge_polynomial_commitment = g t.sg
     }
 
+  let lookup_eval_of_backend
+      ({ sorted; aggreg; table; runtime } : 'f Kimchi_types.lookup_evaluations)
+      : _ Pickles_types.Plonk_types.Evals.Lookup.t =
+    { sorted; aggreg; table; runtime }
+
+  let eval_of_backend
+      ({ w; coefficients; z; s; generic_selector; poseidon_selector; lookup } :
+        Evaluations_backend.t ) : _ Pickles_types.Plonk_types.Evals.t =
+    { w = tuple15_to_vec w
+    ; coefficients = tuple15_to_vec coefficients
+    ; z
+    ; s = tuple6_to_vec s
+    ; generic_selector
+    ; poseidon_selector
+    ; lookup = Option.map ~f:lookup_eval_of_backend lookup
+    }
+
   let of_backend (t : Backend.t) : t =
     let proof = opening_proof_of_backend_exn t.proof in
-    let e1, e2 = t.evals in
     let evals =
-      let open Pickles_types.Plonk_types.Evals in
-      { w = Vector.zip (tuple15_to_vec e1.w) (tuple15_to_vec e2.w)
-      ; coefficients =
-          Vector.zip
-            (tuple15_to_vec e1.coefficients)
-            (tuple15_to_vec e2.coefficients)
-      ; s = Vector.zip (tuple6_to_vec e1.s) (tuple6_to_vec e2.s)
-      ; z = (e1.z, e2.z)
-      ; generic_selector = (e1.generic_selector, e2.generic_selector)
-      ; poseidon_selector = (e1.poseidon_selector, e2.poseidon_selector)
-      ; lookup =
-          Option.map2 e1.lookup e2.lookup ~f:(fun l1 l2 ->
-              { Lookup.aggreg = (l1.aggreg, l2.aggreg)
-              ; table = (l1.table, l2.table)
-              ; sorted = Array.map2_exn l1.sorted l2.sorted ~f:Tuple2.create
-              ; runtime = Option.map2 l1.runtime l2.runtime ~f:Tuple2.create
-              } )
-      }
+      let evals_to_tuple
+          ({ zeta; zeta_omega } : _ Kimchi_types.point_evaluations) =
+        (zeta, zeta_omega)
+      in
+      Plonk_types.Evals.map ~f:evals_to_tuple (eval_of_backend t.evals)
     in
     let wo x : Inputs.Curve.Affine.t array =
       match Poly_comm.of_backend_without_degree_bound x with
@@ -317,6 +320,9 @@ module Make (Inputs : Inputs_intf) = struct
     let g x = G.Affine.to_backend (Pickles_types.Or_infinity.Finite x) in
     let pcwo t = Poly_comm.to_backend (`Without_degree_bound t) in
     let lr = Array.map lr ~f:(fun (x, y) -> (g x, g y)) in
+    let evals_of_tuple (zeta, zeta_omega) : _ Kimchi_types.point_evaluations =
+      { zeta; zeta_omega }
+    in
     { commitments =
         { w_comm = tuple15_of_vec (Pickles_types.Vector.map ~f:pcwo w_comm)
         ; z_comm = pcwo z_comm
@@ -335,9 +341,7 @@ module Make (Inputs : Inputs_intf) = struct
         ; z2 = z_2
         ; sg = g challenge_polynomial_commitment
         }
-    ; evals =
-        ( eval_to_backend (Plonk_types.Evals.map ~f:fst evals)
-        , eval_to_backend (Plonk_types.Evals.map ~f:snd evals) )
+    ; evals = eval_to_backend (Plonk_types.Evals.map ~f:evals_of_tuple evals)
     ; ft_eval1
     ; public = primary_input
     ; prev_challenges =

--- a/src/lib/crypto/kimchi_bindings/js/bindings.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings.js
@@ -1703,49 +1703,13 @@ var PERMUTS_MINUS_1 = 6;
 // Provides: caml_pasta_fp_proof_evaluations_to_rust
 // Requires: plonk_wasm, caml_fp_vector_to_rust, PERMUTS_MINUS_1, COLUMNS
 var caml_pasta_fp_proof_evaluations_to_rust = function(x) {
-    var w = new plonk_wasm.WasmVecVecFp(COLUMNS);
-    for (var i = 0; i < COLUMNS; ++i) {
-      w.push(caml_fp_vector_to_rust(x[1][i + 1]));
-    }
-
-    var coefficients = new plonk_wasm.WasmVecVecFp(COLUMNS);
-    for (var i = 0; i < COLUMNS; ++i) {
-      coefficients.push(caml_fp_vector_to_rust(x[2][i + 1]));
-    }
-
-    var z = caml_fp_vector_to_rust(x[3]);
-
-    var s = new plonk_wasm.WasmVecVecFp(PERMUTS_MINUS_1);
-    for (i = 0; i < PERMUTS_MINUS_1; ++i) {
-      s.push(caml_fp_vector_to_rust(x[4][i + 1]));
-    }
-
-    var generic_selector = caml_fp_vector_to_rust(x[5]);
-    var poseidon_selector = caml_fp_vector_to_rust(x[6]);
-
-    return new plonk_wasm.WasmFpProofEvaluations(w, coefficients, z, s, generic_selector, poseidon_selector);
+    return x;
 };
 
 // Provides: caml_pasta_fp_proof_evaluations_of_rust
 // Requires: plonk_wasm, caml_fp_vector_of_rust, COLUMNS, PERMUTS_MINUS_1
 var caml_pasta_fp_proof_evaluations_of_rust = function(x) {
-    var convertArray = function(v, n) {
-        var res = [0];
-        for (var i = 0; i < n; ++i) {
-            res.push(caml_fp_vector_of_rust(v.get(i)));
-        }
-        return res;
-    };
-
-    var w = convertArray(x.w, COLUMNS);
-    var coefficients = convertArray(x.coefficients, COLUMNS);
-    var z = caml_fp_vector_of_rust(x.z);
-    var s = convertArray(x.s, PERMUTS_MINUS_1);
-    var generic_selector = caml_fp_vector_of_rust(x.generic_selector);
-    var poseidon_selector = caml_fp_vector_of_rust(x.poseidon_selector);
-
-    x.free();
-    return [0, w, coefficients, z, s, generic_selector, poseidon_selector];
+    return x;
 };
 
 // Provides: caml_pasta_fp_opening_proof_to_rust
@@ -1843,8 +1807,7 @@ var caml_pasta_fp_commitments_of_rust = function(x) {
 var caml_pasta_fp_proof_to_rust = function(x) {
     var commitments = caml_pasta_fp_commitments_to_rust(x[1]);
     var proof = caml_pasta_fp_opening_proof_to_rust(x[2]);
-    var evals0 = caml_pasta_fp_proof_evaluations_to_rust(x[3][1]);
-    var evals1 = caml_pasta_fp_proof_evaluations_to_rust(x[3][2]);
+    var evals = caml_pasta_fp_proof_evaluations_to_rust(x[3]);
     var ft_eval1 = x[4];
     var public_ = caml_fp_vector_to_rust(x[5]);
     var prev_challenges = x[6];
@@ -1856,7 +1819,7 @@ var caml_pasta_fp_proof_to_rust = function(x) {
         prev_challenges_comms[i-1] = caml_vesta_poly_comm_to_rust(prev_challenges[i][2]);
     }
     prev_challenges_comms = js_class_vector_to_rust_vector(prev_challenges_comms);
-    return new plonk_wasm.WasmFpProverProof(commitments, proof, evals0, evals1, ft_eval1, public_, prev_challenges_scalars, prev_challenges_comms);
+    return new plonk_wasm.WasmFpProverProof(commitments, proof, evals, ft_eval1, public_, prev_challenges_scalars, prev_challenges_comms);
 };
 
 // Provides: caml_pasta_fp_proof_of_rust
@@ -1864,8 +1827,7 @@ var caml_pasta_fp_proof_to_rust = function(x) {
 var caml_pasta_fp_proof_of_rust = function(x) {
     var messages = caml_pasta_fp_commitments_of_rust(x.commitments);
     var proof = caml_pasta_fp_opening_proof_of_rust(x.proof);
-    var evals0 = caml_pasta_fp_proof_evaluations_of_rust(x.evals0);
-    var evals1 = caml_pasta_fp_proof_evaluations_of_rust(x.evals1);
+    var evals = caml_pasta_fp_proof_evaluations_of_rust(x.evals);
     var ft_eval1 = x.ft_eval1;
     var public_ = caml_fp_vector_of_rust(x.public_);
     var prev_challenges_scalars = x.prev_challenges_scalars;
@@ -1881,7 +1843,7 @@ var caml_pasta_fp_proof_of_rust = function(x) {
         res[2] = caml_vesta_poly_comm_of_rust(prev_challenges_comms[i]);
         prev_challenges[i] = res;
     }
-    return [0, messages, proof, [0, evals0, evals1], ft_eval1, public_, prev_challenges];
+    return [0, messages, proof, evals, ft_eval1, public_, prev_challenges];
 };
 
 // Provides: caml_pasta_fp_plonk_proof_create
@@ -2073,8 +2035,7 @@ var caml_pasta_fq_commitments_of_rust = function(x) {
 var caml_pasta_fq_proof_to_rust = function(x) {
     var messages = caml_pasta_fq_commitments_to_rust(x[1]);
     var proof = caml_pasta_fq_opening_proof_to_rust(x[2]);
-    var evals0 = caml_pasta_fq_proof_evaluations_to_rust(x[3][1]);
-    var evals1 = caml_pasta_fq_proof_evaluations_to_rust(x[3][2]);
+    var evals = caml_pasta_fq_proof_evaluations_to_rust(x[3]);
     var ft_eval1 = x[4];
     var public_ = caml_fq_vector_to_rust(x[5]);
     var prev_challenges = x[6];
@@ -2086,7 +2047,7 @@ var caml_pasta_fq_proof_to_rust = function(x) {
         prev_challenges_comms[i-1] = caml_pallas_poly_comm_to_rust(prev_challenges[i][2]);
     }
     prev_challenges_comms = js_class_vector_to_rust_vector(prev_challenges_comms);
-    return new plonk_wasm.WasmFqProverProof(messages, proof, evals0, evals1, ft_eval1, public_, prev_challenges_scalars, prev_challenges_comms);
+    return new plonk_wasm.WasmFqProverProof(messages, proof, evals, ft_eval1, public_, prev_challenges_scalars, prev_challenges_comms);
 };
 
 // Provides: caml_pasta_fq_proof_of_rust
@@ -2094,7 +2055,7 @@ var caml_pasta_fq_proof_to_rust = function(x) {
 var caml_pasta_fq_proof_of_rust = function(x) {
     var messages = caml_pasta_fq_commitments_of_rust(x.commitments);
     var proof = caml_pasta_fq_opening_proof_of_rust(x.proof);
-    var evals0 = caml_pasta_fq_proof_evaluations_of_rust(x.evals0);
+    var evals = caml_pasta_fq_proof_evaluations_of_rust(x.evals);
     var evals1 = caml_pasta_fq_proof_evaluations_of_rust(x.evals1);
     var ft_eval1 = x.ft_eval1;
     var public_ = caml_fq_vector_of_rust(x.public_);
@@ -2110,7 +2071,7 @@ var caml_pasta_fq_proof_of_rust = function(x) {
         res[2] = caml_pallas_poly_comm_of_rust(prev_challenges_comms[i]);
         prev_challenges[i] = res;
     }
-    return [0, messages, proof, [0, evals0, evals1], ft_eval1, public_, prev_challenges];
+    return [0, messages, proof, evals, ft_eval1, public_, prev_challenges];
 };
 
 // Provides: caml_pasta_fq_plonk_proof_create

--- a/src/lib/crypto/kimchi_bindings/js/bindings.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings.js
@@ -1896,27 +1896,7 @@ var caml_pasta_fp_plonk_proof_deep_copy = function(proof) {
 // Provides: caml_pasta_fq_proof_evaluations_to_rust
 // Requires: plonk_wasm, caml_fq_vector_to_rust, PERMUTS_MINUS_1, COLUMNS
 var caml_pasta_fq_proof_evaluations_to_rust = function(x) {
-    var w = new plonk_wasm.WasmVecVecFq(COLUMNS);
-    for (var i = 0; i < COLUMNS; ++i) {
-      w.push(caml_fq_vector_to_rust(x[1][i + 1]));
-    }
-
-    var coefficients = new plonk_wasm.WasmVecVecFq(COLUMNS);
-    for (var i = 0; i < COLUMNS; ++i) {
-      coefficients.push(caml_fq_vector_to_rust(x[2][i + 1]));
-    }
-
-    var z = caml_fq_vector_to_rust(x[3]);
-
-    var s = new plonk_wasm.WasmVecVecFq(PERMUTS_MINUS_1);
-    for (i = 0; i < PERMUTS_MINUS_1; ++i) {
-      s.push(caml_fq_vector_to_rust(x[4][i + 1]));
-    }
-
-    var generic_selector = caml_fq_vector_to_rust(x[5]);
-    var poseidon_selector = caml_fq_vector_to_rust(x[6]);
-
-    return new plonk_wasm.WasmFqProofEvaluations(w, coefficients, z, s, generic_selector, poseidon_selector);
+    return x;
 };
 
 // Provides: caml_pasta_fq_proof_evaluations_of_rust

--- a/src/lib/crypto/kimchi_bindings/js/bindings.js
+++ b/src/lib/crypto/kimchi_bindings/js/bindings.js
@@ -1922,23 +1922,7 @@ var caml_pasta_fq_proof_evaluations_to_rust = function(x) {
 // Provides: caml_pasta_fq_proof_evaluations_of_rust
 // Requires: plonk_wasm, caml_fq_vector_of_rust, COLUMNS, PERMUTS_MINUS_1
 var caml_pasta_fq_proof_evaluations_of_rust = function(x) {
-    var convertArray = function(v, n) {
-        var res = [0];
-        for (var i = 0; i < n; ++i) {
-            res.push(caml_fq_vector_of_rust(v.get(i)));
-        }
-        return res;
-    };
-
-    var w = convertArray(x.w, COLUMNS);
-    var coefficients = convertArray(x.coefficients, COLUMNS);
-    var z = caml_fq_vector_of_rust(x.z);
-    var s = convertArray(x.s, PERMUTS_MINUS_1);
-    var generic_selector = caml_fq_vector_of_rust(x.generic_selector);
-    var poseidon_selector = caml_fq_vector_of_rust(x.poseidon_selector);
-
-    x.free();
-    return [0, w, coefficients, z, s, generic_selector, poseidon_selector];
+    return x;
 };
 
 // Provides: caml_pasta_fq_opening_proof_to_rust

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -18,57 +18,60 @@ type nonrec 'caml_f random_oracles =
   }
 [@@boxed]
 
+type nonrec 'evals point_evaluations = { zeta : 'evals; zeta_omega : 'evals }
+[@@boxed]
+
 type nonrec 'caml_f lookup_evaluations =
-  { sorted : 'caml_f array array
-  ; aggreg : 'caml_f array
-  ; table : 'caml_f array
-  ; runtime : 'caml_f array option
+  { sorted : 'caml_f array point_evaluations array
+  ; aggreg : 'caml_f array point_evaluations
+  ; table : 'caml_f array point_evaluations
+  ; runtime : 'caml_f array point_evaluations option
   }
 [@@boxed]
 
 type nonrec 'caml_f proof_evaluations =
   { w :
-      'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
+      'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
   ; coefficients :
-      'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-  ; z : 'caml_f array
+      'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+  ; z : 'caml_f array point_evaluations
   ; s :
-      'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-      * 'caml_f array
-  ; generic_selector : 'caml_f array
-  ; poseidon_selector : 'caml_f array
+      'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+  ; generic_selector : 'caml_f array point_evaluations
+  ; poseidon_selector : 'caml_f array point_evaluations
   ; lookup : 'caml_f lookup_evaluations option
   }
 [@@boxed]
@@ -118,7 +121,7 @@ type nonrec 'caml_g prover_commitments =
 type nonrec ('caml_g, 'caml_f) prover_proof =
   { commitments : 'caml_g prover_commitments
   ; proof : ('caml_g, 'caml_f) opening_proof
-  ; evals : 'caml_f proof_evaluations * 'caml_f proof_evaluations
+  ; evals : 'caml_f proof_evaluations
   ; ft_eval1 : 'caml_f
   ; public : 'caml_f array
   ; prev_challenges : ('caml_g, 'caml_f) recursion_challenge array

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -46,6 +46,14 @@ type nonrec 'caml_f proof_evaluations =
       * 'caml_f array point_evaluations
       * 'caml_f array point_evaluations
       * 'caml_f array point_evaluations
+  ; z : 'caml_f array point_evaluations
+  ; s :
+      'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
+      * 'caml_f array point_evaluations
   ; coefficients :
       'caml_f array point_evaluations
       * 'caml_f array point_evaluations
@@ -62,17 +70,9 @@ type nonrec 'caml_f proof_evaluations =
       * 'caml_f array point_evaluations
       * 'caml_f array point_evaluations
       * 'caml_f array point_evaluations
-  ; z : 'caml_f array point_evaluations
-  ; s :
-      'caml_f array point_evaluations
-      * 'caml_f array point_evaluations
-      * 'caml_f array point_evaluations
-      * 'caml_f array point_evaluations
-      * 'caml_f array point_evaluations
-      * 'caml_f array point_evaluations
+  ; lookup : 'caml_f lookup_evaluations option
   ; generic_selector : 'caml_f array point_evaluations
   ; poseidon_selector : 'caml_f array point_evaluations
-  ; lookup : 'caml_f lookup_evaluations option
   }
 [@@boxed]
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -1,5 +1,5 @@
 use kimchi::circuits::expr::FeatureFlag;
-use kimchi::proof::caml::CamlRecursionChallenge;
+use kimchi::proof::{caml::CamlRecursionChallenge, PointEvaluations};
 use ocaml_gen::{decl_fake_generic, decl_func, decl_module, decl_type, decl_type_alias, Env};
 use std::fs::File;
 use std::io::Write;
@@ -92,6 +92,7 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
     decl_type!(w, env, CamlGroupAffine<T1> => "or_infinity");
     decl_type!(w, env, CamlScalarChallenge::<T1> => "scalar_challenge");
     decl_type!(w, env, CamlRandomOracles::<T1> => "random_oracles");
+    decl_type!(w, env, PointEvaluations::<T1> => "point_evaluations");
     decl_type!(w, env, CamlLookupEvaluations<T1> => "lookup_evaluations");
     decl_type!(w, env, CamlProofEvaluations::<T1> => "proof_evaluations");
     decl_type!(w, env, CamlPolyComm::<T1> => "poly_comm");

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -11,7 +11,9 @@ use array_init::array_init;
 use commitment_dlog::commitment::{CommitmentCurve, PolyComm};
 use commitment_dlog::evaluation_proof::OpeningProof;
 use groupmap::GroupMap;
-use kimchi::proof::{ProofEvaluations, ProverCommitments, ProverProof, RecursionChallenge};
+use kimchi::proof::{
+    PointEvaluations, ProofEvaluations, ProverCommitments, ProverProof, RecursionChallenge,
+};
 use kimchi::prover::caml::CamlProverProof;
 use kimchi::prover_index::ProverIndex;
 use kimchi::{circuits::polynomial::COLUMNS, verifier::batch_verify};
@@ -261,16 +263,19 @@ pub fn caml_pasta_fp_plonk_proof_dummy() -> CamlProverProof<CamlGVesta, CamlFp> 
         delta: g,
         sg: g,
     };
-    let proof_evals = ProofEvaluations {
-        w: array_init(|_| vec![Fp::one()]),
-        coefficients: array_init(|_| vec![Fp::one()]),
-        z: vec![Fp::one()],
-        s: array_init(|_| vec![Fp::one()]),
-        lookup: None,
-        generic_selector: vec![Fp::one()],
-        poseidon_selector: vec![Fp::one()],
+    let eval = || PointEvaluations {
+        zeta: vec![Fp::one()],
+        zeta_omega: vec![Fp::one()],
     };
-    let evals = [proof_evals.clone(), proof_evals];
+    let evals = ProofEvaluations {
+        w: array_init(|_| eval()),
+        coefficients: array_init(|_| eval()),
+        z: eval(),
+        s: array_init(|_| eval()),
+        lookup: None,
+        generic_selector: eval(),
+        poseidon_selector: eval(),
+    };
 
     let dlogproof = ProverProof {
         commitments: ProverCommitments {

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -10,7 +10,9 @@ use array_init::array_init;
 use commitment_dlog::commitment::{CommitmentCurve, PolyComm};
 use commitment_dlog::evaluation_proof::OpeningProof;
 use groupmap::GroupMap;
-use kimchi::proof::{ProofEvaluations, ProverCommitments, ProverProof, RecursionChallenge};
+use kimchi::proof::{
+    PointEvaluations, ProofEvaluations, ProverCommitments, ProverProof, RecursionChallenge,
+};
 use kimchi::prover::caml::CamlProverProof;
 use kimchi::prover_index::ProverIndex;
 use kimchi::{circuits::polynomial::COLUMNS, verifier::batch_verify};
@@ -142,16 +144,19 @@ pub fn caml_pasta_fq_plonk_proof_dummy() -> CamlProverProof<CamlGPallas, CamlFq>
         delta: g,
         sg: g,
     };
-    let proof_evals = ProofEvaluations {
-        w: array_init(|_| vec![Fq::one()]),
-        coefficients: array_init(|_| vec![Fq::one()]),
-        z: vec![Fq::one()],
-        s: array_init(|_| vec![Fq::one()]),
-        lookup: None,
-        generic_selector: vec![Fq::one()],
-        poseidon_selector: vec![Fq::one()],
+    let eval = || PointEvaluations {
+        zeta: vec![Fq::one()],
+        zeta_omega: vec![Fq::one()],
     };
-    let evals = [proof_evals.clone(), proof_evals];
+    let evals = ProofEvaluations {
+        w: array_init(|_| eval()),
+        coefficients: array_init(|_| eval()),
+        z: eval(),
+        s: array_init(|_| eval()),
+        lookup: None,
+        generic_selector: eval(),
+        poseidon_selector: eval(),
+    };
 
     let dlogproof = ProverProof {
         commitments: ProverCommitments {

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.lock
@@ -655,6 +655,7 @@ dependencies = [
  "mina-poseidon",
  "num-bigint",
  "num-derive",
+ "num-integer",
  "num-traits",
  "o1-utils",
  "once_cell",
@@ -848,6 +849,10 @@ dependencies = [
  "bcs",
  "hex",
  "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand",
+ "rand_core",
  "rayon",
  "serde",
  "serde_with 1.14.0",
@@ -891,6 +896,7 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom",
  "groupmap",
+ "js-sys",
  "kimchi",
  "libc",
  "mina-curves",
@@ -903,6 +909,7 @@ dependencies = [
  "rayon",
  "rmp-serde",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "serde_with 2.0.1",
  "sprs",
@@ -1082,6 +1089,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfc62771e7b829b517cb213419236475f434fb480eddd76112ae182d274434a"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/wasm/Cargo.toml
@@ -49,6 +49,8 @@ sprs = { version = "0.11.0" }
 serde = "1.0.130"
 serde_json = "1.0"
 serde_with = "2.0.1"
+serde-wasm-bindgen = "0.4"
+js-sys = "0.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/src/lib/crypto/kimchi_bindings/wasm/src/lib.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/lib.rs
@@ -109,3 +109,5 @@ pub mod poseidon;
 
 // exposes circuit for inspection
 pub mod circuit;
+
+pub mod wasm_ocaml_serde;

--- a/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/plonk_proof.rs
@@ -19,13 +19,16 @@ use commitment_dlog::{
     evaluation_proof::OpeningProof,
 };
 use groupmap::GroupMap;
-use kimchi::proof::{ProofEvaluations, ProverCommitments, ProverProof, RecursionChallenge};
+use kimchi::proof::{
+    PointEvaluations, ProofEvaluations, ProverCommitments, ProverProof, RecursionChallenge,
+};
 use kimchi::prover_index::ProverIndex;
 use kimchi::verifier::batch_verify;
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
     sponge::{DefaultFqSponge, DefaultFrSponge},
 };
+use serde::{Deserialize, Serialize};
 
 #[wasm_bindgen]
 extern "C" {
@@ -78,153 +81,63 @@ macro_rules! impl_proof {
                 }
             }
 
-            #[wasm_bindgen]
             #[derive(Clone)]
-            pub struct [<Wasm $field_name:camel ProofEvaluations>] {
-                #[wasm_bindgen(skip)]
-                pub w: Vec<Vec<$F>>,
-                #[wasm_bindgen(skip)]
-                pub coefficients: Vec<Vec<$F>>,
-                #[wasm_bindgen(skip)]
-                pub z: WasmFlatVector<$WasmF>,
-                #[wasm_bindgen(skip)]
-                pub s: Vec<Vec<$F>>,
-                #[wasm_bindgen(skip)]
-                pub generic_selector: WasmFlatVector<$WasmF>,
-                #[wasm_bindgen(skip)]
-                pub poseidon_selector: WasmFlatVector<$WasmF>,
-                // TODO: Lookup
-            }
+            pub struct [<Wasm $field_name:camel ProofEvaluations>](
+                ProofEvaluations<PointEvaluations<Vec<$F>>>
+            );
             type WasmProofEvaluations = [<Wasm $field_name:camel ProofEvaluations>];
 
-            #[wasm_bindgen]
-            impl [<Wasm $field_name:camel ProofEvaluations>] {
-                #[wasm_bindgen(constructor)]
-                pub fn new(
-                    w: WasmVecVecF,
-                    coefficients: WasmVecVecF,
-                    z: WasmFlatVector<$WasmF>,
-                    s: WasmVecVecF,
-                    generic_selector: WasmFlatVector<$WasmF>,
-                    poseidon_selector: WasmFlatVector<$WasmF>) -> Self {
-                    WasmProofEvaluations {
-                        w: w.0,
-                        coefficients: coefficients.0,
-                        z,
-                        s: s.0,
-                        generic_selector, poseidon_selector
-                    }
-                }
-
-                #[wasm_bindgen(getter)]
-                pub fn w(&self) -> WasmVecVecF {
-                    [<WasmVecVec $field_name:camel>](self.w.clone())
-                }
-
-                #[wasm_bindgen(getter)]
-                pub fn coefficients(&self) -> WasmVecVecF {
-                    [<WasmVecVec $field_name:camel>](self.coefficients.clone())
-                }
-
-                #[wasm_bindgen(getter)]
-                pub fn z(&self) -> WasmFlatVector<$WasmF> {
-                    self.z.clone()
-                }
-
-                #[wasm_bindgen(getter)]
-                pub fn s(&self) -> WasmVecVecF {
-                    [<WasmVecVec $field_name:camel>](self.s.clone())
-                }
-
-                #[wasm_bindgen(getter)]
-                pub fn generic_selector(&self) -> WasmFlatVector<$WasmF> {
-                    self.generic_selector.clone()
-                }
-
-                #[wasm_bindgen(getter)]
-                pub fn poseidon_selector(&self) -> WasmFlatVector<$WasmF> {
-                    self.poseidon_selector.clone()
-                }
-
-                #[wasm_bindgen(setter)]
-                pub fn set_w(&mut self, x: WasmVecVecF) {
-                    self.w = x.0
-                }
-                #[wasm_bindgen(setter)]
-                pub fn set_coefficients(&mut self, x: WasmVecVecF) {
-                    self.coefficients = x.0
-                }
-                #[wasm_bindgen(setter)]
-                pub fn set_s(&mut self, x: WasmVecVecF) {
-                    self.s = x.0
-                }
-                #[wasm_bindgen(setter)]
-                pub fn set_z(&mut self, x: WasmFlatVector<$WasmF>) {
-                    self.z = x
-                }
-                #[wasm_bindgen(setter)]
-                pub fn set_generic_selector(&mut self, x: WasmFlatVector<$WasmF>) {
-                    self.generic_selector = x
-                }
-                #[wasm_bindgen(setter)]
-                pub fn set_poseidon_selector(&mut self, x: WasmFlatVector<$WasmF>) {
-                    self.poseidon_selector = x
+            impl wasm_bindgen::describe::WasmDescribe for WasmProofEvaluations {
+                fn describe() {
+                    <JsValue as wasm_bindgen::describe::WasmDescribe>::describe()
                 }
             }
 
-            impl From<&WasmProofEvaluations> for ProofEvaluations<Vec<$F>> {
+            impl wasm_bindgen::convert::FromWasmAbi for WasmProofEvaluations {
+                type Abi = <JsValue as wasm_bindgen::convert::FromWasmAbi>::Abi;
+                unsafe fn from_abi(js: Self::Abi) -> Self {
+                    let js: JsValue = wasm_bindgen::convert::FromWasmAbi::from_abi(js);
+                    Self(
+                        ProofEvaluations::deserialize(
+                            crate::wasm_ocaml_serde::de::Deserializer::from(js),
+                        )
+                        .unwrap(),
+                    )
+                }
+            }
+
+            impl wasm_bindgen::convert::IntoWasmAbi for WasmProofEvaluations {
+                type Abi = <JsValue as wasm_bindgen::convert::IntoWasmAbi>::Abi;
+                fn into_abi(self) -> Self::Abi {
+                    let js = self
+                        .0
+                        .serialize(&crate::wasm_ocaml_serde::ser::Serializer::new())
+                        .unwrap();
+                    wasm_bindgen::convert::IntoWasmAbi::into_abi(js)
+                }
+            }
+
+            impl From<&WasmProofEvaluations> for ProofEvaluations<PointEvaluations<Vec<$F>>> {
                 fn from(x: &WasmProofEvaluations) -> Self {
-                    ProofEvaluations {
-                        w: array_init(|i| x.w[i].clone()),
-                        coefficients: array_init(|i| x.coefficients[i].clone()),
-                        s: array_init(|i| x.s[i].clone()),
-                        z: x.z.iter().map(|a| a.clone().into()).collect(),
-                        generic_selector: x.generic_selector.iter().map(|a| a.clone().into()).collect(),
-                        poseidon_selector: x.poseidon_selector.iter().map(|a| a.clone().into()).collect(),
-                        // TODO
-                        lookup: None
-                    }
+                    x.0.clone()
                 }
             }
 
-            impl From<WasmProofEvaluations> for ProofEvaluations<Vec<$F>> {
+            impl From<WasmProofEvaluations> for ProofEvaluations<PointEvaluations<Vec<$F>>> {
                 fn from(x: WasmProofEvaluations) -> Self {
-                    ProofEvaluations {
-                        w: array_init(|i| x.w[i].clone()),
-                        coefficients: array_init(|i| x.coefficients[i].clone()),
-                        s: array_init(|i| x.s[i].clone()),
-                        z: x.z.into_iter().map(Into::into).collect(),
-                        generic_selector: x.generic_selector.into_iter().map(Into::into).collect(),
-                        poseidon_selector: x.poseidon_selector.into_iter().map(Into::into).collect(),
-                        // TODO
-                        lookup: None
-                    }
+                    x.0
                 }
             }
 
-            impl From<&ProofEvaluations<Vec<$F>>> for WasmProofEvaluations {
-                fn from(x: &ProofEvaluations<Vec<$F>>) -> Self {
-                    WasmProofEvaluations {
-                        w: x.w.to_vec(),
-                        coefficients: x.coefficients.to_vec(),
-                        s: x.s.to_vec(),
-                        z: x.z.iter().map(|a| a.clone().into()).collect(),
-                        generic_selector: x.generic_selector.iter().map(|a| a.clone().into()).collect(),
-                        poseidon_selector: x.poseidon_selector.iter().map(|a| a.clone().into()).collect(),
-                    }
+            impl From<&ProofEvaluations<PointEvaluations<Vec<$F>>>> for WasmProofEvaluations {
+                fn from(x: &ProofEvaluations<PointEvaluations<Vec<$F>>>) -> Self {
+                    Self(x.clone())
                 }
             }
 
-            impl From<ProofEvaluations<Vec<$F>>> for WasmProofEvaluations {
-                fn from(x: ProofEvaluations<Vec<$F>>) -> Self {
-                    WasmProofEvaluations {
-                        w: x.w.to_vec(),
-                        coefficients: x.coefficients.to_vec(),
-                        s: x.s.to_vec(),
-                        z: x.z.into_iter().map(Into::into).collect(),
-                        generic_selector: x.generic_selector.into_iter().map(Into::into).collect(),
-                        poseidon_selector: x.poseidon_selector.into_iter().map(Into::into).collect(),
-                    }
+            impl From<ProofEvaluations<PointEvaluations<Vec<$F>>>> for WasmProofEvaluations {
+                fn from(x: ProofEvaluations<PointEvaluations<Vec<$F>>>) -> Self {
+                    Self(x)
                 }
             }
 
@@ -451,9 +364,7 @@ macro_rules! impl_proof {
                 pub proof: WasmOpeningProof,
                 // OCaml doesn't have sized arrays, so we have to convert to a tuple..
                 #[wasm_bindgen(skip)]
-                pub evals0: WasmProofEvaluations,
-                #[wasm_bindgen(skip)]
-                pub evals1: WasmProofEvaluations,
+                pub evals: WasmProofEvaluations,
                 pub ft_eval1: $WasmF,
                 #[wasm_bindgen(skip)]
                 pub public: WasmFlatVector<$WasmF>,
@@ -476,8 +387,7 @@ macro_rules! impl_proof {
                     WasmProverProof {
                         commitments: x.commitments.clone().into(),
                         proof: x.proof.clone().into(),
-                        evals0: x.evals[0].clone().into(),
-                        evals1: x.evals[1].clone().into(),
+                        evals: x.evals.clone().into(),
                         ft_eval1: x.ft_eval1.clone().into(),
                         public: x.public.clone().into_iter().map(Into::into).collect(),
                         prev_challenges_scalars: scalars,
@@ -488,7 +398,7 @@ macro_rules! impl_proof {
 
             impl From<ProverProof<$G>> for WasmProverProof {
                 fn from(x: ProverProof<$G>) -> Self {
-                    let ProverProof {ft_eval1, commitments, proof, evals: [evals0, evals1], public, prev_challenges} = x;
+                    let ProverProof {ft_eval1, commitments, proof, evals , public, prev_challenges} = x;
                     let (scalars, comms) =
                         prev_challenges
                             .into_iter()
@@ -497,8 +407,7 @@ macro_rules! impl_proof {
                     WasmProverProof {
                         commitments: commitments.into(),
                         proof: proof.into(),
-                        evals0: evals0.into(),
-                        evals1: evals1.into(),
+                        evals: evals.into(),
                         ft_eval1: ft_eval1.clone().into(),
                         public: public.into_iter().map(Into::into).collect(),
                         prev_challenges_scalars: scalars,
@@ -512,7 +421,7 @@ macro_rules! impl_proof {
                     ProverProof {
                         commitments: x.commitments.clone().into(),
                         proof: x.proof.clone().into(),
-                        evals: [x.evals0.clone().into(), x.evals1.clone().into()],
+                        evals: x.evals.clone().into(),
                         public: x.public.clone().into_iter().map(Into::into).collect(),
                         prev_challenges:
                             (&x.prev_challenges_scalars)
@@ -535,7 +444,7 @@ macro_rules! impl_proof {
                     ProverProof {
                         commitments: x.commitments.into(),
                         proof: x.proof.into(),
-                        evals: [x.evals0.into(), x.evals1.into()],
+                        evals: x.evals.into(),
                         public: x.public.into_iter().map(Into::into).collect(),
                         prev_challenges:
                             (x.prev_challenges_scalars)
@@ -559,8 +468,7 @@ macro_rules! impl_proof {
                 pub fn new(
                     commitments: WasmProverCommitments,
                     proof: WasmOpeningProof,
-                    evals0: WasmProofEvaluations,
-                    evals1: WasmProofEvaluations,
+                    evals: WasmProofEvaluations,
                     ft_eval1: $WasmF,
                     public_: WasmFlatVector<$WasmF>,
                     prev_challenges_scalars: WasmVecVecF,
@@ -568,8 +476,7 @@ macro_rules! impl_proof {
                     WasmProverProof {
                         commitments,
                         proof,
-                        evals0,
-                        evals1,
+                        evals,
                         ft_eval1,
                         public: public_,
                         prev_challenges_scalars: prev_challenges_scalars.0,
@@ -586,12 +493,8 @@ macro_rules! impl_proof {
                     self.proof.clone()
                 }
                 #[wasm_bindgen(getter)]
-                pub fn evals0(&self) -> WasmProofEvaluations {
-                    self.evals0.clone()
-                }
-                #[wasm_bindgen(getter)]
-                pub fn evals1(&self) -> WasmProofEvaluations {
-                    self.evals1.clone()
+                pub fn evals(&self) -> WasmProofEvaluations {
+                    self.evals.clone()
                 }
                 #[wasm_bindgen(getter)]
                 pub fn public_(&self) -> WasmFlatVector<$WasmF> {
@@ -615,12 +518,8 @@ macro_rules! impl_proof {
                     self.proof = proof
                 }
                 #[wasm_bindgen(setter)]
-                pub fn set_evals0(&mut self, evals0: WasmProofEvaluations) {
-                    self.evals0 = evals0
-                }
-                #[wasm_bindgen(setter)]
-                pub fn set_evals1(&mut self, evals1: WasmProofEvaluations) {
-                    self.evals1 = evals1
+                pub fn set_evals(&mut self, evals: WasmProofEvaluations) {
+                    self.evals = evals
                 }
                 #[wasm_bindgen(setter)]
                 pub fn set_public_(&mut self, public_: WasmFlatVector<$WasmF>) {
@@ -796,16 +695,19 @@ macro_rules! impl_proof {
                     delta: g,
                     sg: g,
                 };
-                let proof_evals = ProofEvaluations {
-                    w: array_init(|_| vec![$F::one()]),
-                    coefficients: array_init(|_| vec![$F::one()]),
-                    z: vec![$F::one()],
-                    s: array_init(|_| vec![$F::one()]),
-                    lookup: None,
-                    generic_selector: vec![$F::one()],
-                    poseidon_selector: vec![$F::one()],
+                let eval = || PointEvaluations {
+                    zeta: vec![$F::one()],
+                    zeta_omega: vec![$F::one()],
                 };
-                let evals = [proof_evals.clone(), proof_evals];
+                let evals = ProofEvaluations {
+                    w: array_init(|_| eval()),
+                    coefficients: array_init(|_| eval()),
+                    z: eval(),
+                    s: array_init(|_| eval()),
+                    lookup: None,
+                    generic_selector: eval(),
+                    poseidon_selector: eval(),
+                };
 
                 let dlogproof = ProverProof {
                     commitments: ProverCommitments {

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_flat_vector.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_flat_vector.rs
@@ -4,6 +4,21 @@
 //! The wasmvector is a normal heap-allocated vector,
 //! where we leave it on the rust heap and just keep a pointer around.
 //! We use flat for fields, normal for gates etc.
+//!
+//! Accessing Rust vector values is not the same as accessing an array.
+//! Each indexing (e.g. `some_vec[3]`) is costly as it is implemented as a function call.
+//! Knowing that, plus the fact that field elements are implemented as `[u32; 8]`, we know that we incur the cost of following several pointers.
+//! To decrease that cost, we flatten such arrays, going from something like
+//!
+//! ```ignore
+//! [[a0, a1, ..., a7], [b0, b1, ..., b7], ...]
+//! ```
+//!
+//! to a flattened vector like:
+//!
+//! ```ignore
+//! [a0, a1, ..., a7, b0, b1, ..., b7, ...]
+//! ```
 
 use wasm_bindgen::convert::{FromWasmAbi, IntoWasmAbi, OptionFromWasmAbi, OptionIntoWasmAbi};
 

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/de.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/de.rs
@@ -1,0 +1,301 @@
+use js_sys::{Array, ArrayBuffer, Number, Uint8Array};
+use serde::de::value::SeqDeserializer;
+use serde::de::{self, Error as _, IntoDeserializer};
+use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
+
+use super::{Error, Result};
+
+struct SeqAccess {
+    iter: js_sys::IntoIter,
+}
+
+impl<'de> de::SeqAccess<'de> for SeqAccess {
+    type Error = Error;
+
+    fn next_element_seed<T: de::DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>> {
+        Ok(match self.iter.next().transpose()? {
+            Some(value) => Some(seed.deserialize(Deserializer::from(value))?),
+            None => None,
+        })
+    }
+}
+
+struct ObjectAccess {
+    data: Array,
+    fields: std::slice::Iter<'static, &'static str>,
+    idx: u32,
+    next_value: Option<Deserializer>,
+}
+
+impl ObjectAccess {
+    fn new(data: Array, fields: &'static [&'static str]) -> Self {
+        Self {
+            data,
+            idx: 1,
+            fields: fields.iter(),
+            next_value: None,
+        }
+    }
+}
+
+fn str_deserializer(s: &str) -> de::value::StrDeserializer<Error> {
+    de::IntoDeserializer::into_deserializer(s)
+}
+
+impl<'de> de::MapAccess<'de> for ObjectAccess {
+    type Error = Error;
+
+    fn next_key_seed<K: de::DeserializeSeed<'de>>(&mut self, seed: K) -> Result<Option<K::Value>> {
+        debug_assert!(self.next_value.is_none());
+
+        match self.fields.next() {
+            None => Ok(None),
+            Some(field) => {
+                self.next_value = Some(Deserializer::from(self.data.get(self.idx)));
+                self.idx += 1;
+                return Ok(Some(seed.deserialize(str_deserializer(field))?));
+            }
+        }
+    }
+
+    fn next_value_seed<V: de::DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value> {
+        seed.deserialize(self.next_value.take().unwrap_throw())
+    }
+}
+
+pub struct Deserializer(JsValue);
+
+// Can't use `serde_wasm_bindgen::de::Deserializer`, its `value` field is private.
+impl From<JsValue> for Deserializer {
+    fn from(value: JsValue) -> Self {
+        Self(value)
+    }
+}
+
+// Ideally this would be implemented for `JsValue` instead, but we can't because
+// of the orphan rule.
+impl<'de> IntoDeserializer<'de, Error> for Deserializer {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
+impl Deserializer {
+    fn as_bytes(&self) -> Option<Vec<u8>> {
+        if let Some(v) = self.0.dyn_ref::<Uint8Array>() {
+            Some(v.to_vec())
+        } else if let Some(v) = self.0.dyn_ref::<ArrayBuffer>() {
+            /* We can hit this case when the values have come from the non-serde conversions. */
+            Some(Uint8Array::new(v).to_vec())
+        } else {
+            None
+        }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for Deserializer {
+    type Error = Error;
+
+    fn deserialize_any<V: de::Visitor<'de>>(self, _: V) -> Result<V::Value> {
+        Err(Error::custom(
+            "Inferring the serialized type is not implemented",
+        ))
+    }
+
+    fn deserialize_unit<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V: de::Visitor<'de>>(
+        self,
+        _: &'static str,
+        _: V,
+    ) -> Result<V::Value> {
+        Err(Error::custom(
+            "Deserializing unit structs is not implemented",
+        ))
+    }
+
+    fn deserialize_bool<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        let x = self.0.unchecked_into::<Number>().as_f64().unwrap() as u32;
+        visitor.visit_bool(x != 0)
+    }
+
+    fn deserialize_f32<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_f32(self.0.unchecked_into::<Number>().as_f64().unwrap() as f32)
+    }
+
+    fn deserialize_f64<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_f64(self.0.unchecked_into::<Number>().as_f64().unwrap())
+    }
+
+    fn deserialize_identifier<V: de::Visitor<'de>>(self, _: V) -> Result<V::Value> {
+        Err(Error::custom("Deserializing strings is not implemented"))
+    }
+
+    fn deserialize_str<V: de::Visitor<'de>>(self, _: V) -> Result<V::Value> {
+        Err(Error::custom("Deserializing strings is not implemented"))
+    }
+
+    fn deserialize_string<V: de::Visitor<'de>>(self, _: V) -> Result<V::Value> {
+        Err(Error::custom("Deserializing strings is not implemented"))
+    }
+
+    fn deserialize_i8<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_i8(self.0.unchecked_into::<Number>().as_f64().unwrap() as i8)
+    }
+
+    fn deserialize_i16<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_i16(self.0.unchecked_into::<Number>().as_f64().unwrap() as i16)
+    }
+
+    fn deserialize_i32<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_i32(self.0.unchecked_into::<Number>().as_f64().unwrap() as i32)
+    }
+
+    fn deserialize_u8<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_u8(self.0.unchecked_into::<Number>().as_f64().unwrap() as u8)
+    }
+
+    fn deserialize_u16<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_u16(self.0.unchecked_into::<Number>().as_f64().unwrap() as u16)
+    }
+
+    fn deserialize_u32<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_u32(self.0.unchecked_into::<Number>().as_f64().unwrap() as u32)
+    }
+
+    fn deserialize_i64<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        Err(Error::custom("Deserializing i64 is not implemented"))
+    }
+
+    fn deserialize_u64<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        Err(Error::custom("Deserializing u64 is not implemented"))
+    }
+
+    fn deserialize_i128<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        Err(Error::custom("Deserializing i128 is not implemented"))
+    }
+
+    fn deserialize_u128<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        Err(Error::custom("Deserializing u128 is not implemented"))
+    }
+
+    fn deserialize_char<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_char((self.0.unchecked_into::<Number>().as_f64().unwrap() as u8) as char)
+    }
+
+    // Serde can deserialize `visit_unit` into `None`, but can't deserialize arbitrary value
+    // as `Some`, so we need to provide own simple implementation.
+    fn deserialize_option<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        if let Ok(arr) = self.0.dyn_into::<Array>() {
+            visitor.visit_some(Into::<Deserializer>::into(arr.get(1)))
+        } else {
+            visitor.visit_none()
+        }
+    }
+
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value> {
+        Err(Error::custom(
+            "Deserializing newtype structus is not implemented",
+        ))
+    }
+
+    fn deserialize_seq<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        let arr = self.0.unchecked_into::<Array>();
+        visitor.visit_seq(SeqDeserializer::new(
+            arr.iter().skip(1).map(Deserializer::from),
+        ))
+    }
+
+    fn deserialize_tuple<V: de::Visitor<'de>>(self, _len: usize, visitor: V) -> Result<V::Value> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_tuple_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value> {
+        Err(Error::custom(
+            "Deserializing tuple structs is not implemented",
+        ))
+    }
+
+    fn deserialize_map<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        Err(Error::custom("Deserializing maps is not implemented"))
+    }
+
+    fn deserialize_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value> {
+        let arr = self.0.unchecked_into::<Array>();
+        visitor.visit_map(ObjectAccess::new(arr, fields))
+    }
+
+    fn deserialize_enum<V: de::Visitor<'de>>(
+        self,
+        _: &'static str,
+        _: &'static [&'static str],
+        _: V,
+    ) -> Result<V::Value> {
+        Err(Error::custom("Deserializing enums is not implemented"))
+    }
+
+    fn deserialize_ignored_any<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_bytes<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        self.deserialize_byte_buf(visitor)
+    }
+
+    fn deserialize_byte_buf<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        if let Some(bytes) = self.as_bytes() {
+            visitor.visit_byte_buf(bytes)
+        } else {
+            Err(Error::custom("Type error while deserializing bytes"))
+        }
+    }
+
+    fn is_human_readable(&self) -> bool {
+        true
+    }
+}
+
+impl<'de> de::VariantAccess<'de> for Deserializer {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        Err(Error::custom("Deserializing variants is not implemented"))
+    }
+
+    fn newtype_variant_seed<T: de::DeserializeSeed<'de>>(self, _: T) -> Result<T::Value> {
+        Err(Error::custom("Deserializing variants is not implemented"))
+    }
+
+    fn tuple_variant<V: de::Visitor<'de>>(self, _: usize, _: V) -> Result<V::Value> {
+        Err(Error::custom("Deserializing variants is not implemented"))
+    }
+
+    fn struct_variant<V: de::Visitor<'de>>(
+        self,
+        _: &'static [&'static str],
+        _: V,
+    ) -> Result<V::Value> {
+        Err(Error::custom("Deserializing variants is not implemented"))
+    }
+}

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/de.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/de.rs
@@ -32,6 +32,8 @@ struct ObjectAccess {
 
 impl ObjectAccess {
     fn new(data: Array, fields: &'static [&'static str]) -> Self {
+        // We start the index at 1, due to some js-of-ocaml expecting the first element to be 0
+        // this is due to OCaml implementation details.
         Self {
             data,
             idx: 1,

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/mod.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/mod.rs
@@ -1,0 +1,8 @@
+use wasm_bindgen::prelude::*;
+
+pub mod de;
+pub mod ser;
+
+pub use serde_wasm_bindgen::Error;
+
+pub type Result<T = JsValue> = core::result::Result<T, Error>;

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/mod.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/mod.rs
@@ -1,3 +1,17 @@
+//! This module constructs a serde serializer (and deserializer) to convert Rust structures to (and from) Js types expected by js-of-ocaml.
+//! js-of-ocaml expects arrays of values instead of objects, so a Rust structure like:
+//!
+//! ```ignore
+//! { a: F, b: Vec<F>, c: SomeType }
+//! ```
+//!
+//! must be converted to an array that looks like this:
+//!
+//! ```ignore
+//! // notice the leading 0, which is an artifact of OCaml's memory layout and how js-of-ocaml is implemented.
+//! [0, a, b, c]
+//! ```
+
 use wasm_bindgen::prelude::*;
 
 pub mod de;

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/mod.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/mod.rs
@@ -11,6 +11,17 @@
 //! // notice the leading 0, which is an artifact of OCaml's memory layout and how js-of-ocaml is implemented.
 //! [0, a, b, c]
 //! ```
+//! See the following example on how to use it:
+//!
+//! ```
+//! #[derive(serde::Serialize, serde::Deserialize)]
+//! struct Thing { a: usize, b: u32 }
+//!
+//! let serializer = crate::wasm_ocaml_serde::ser::Serializer::new();
+//! let thing = Thing { a: 5, b: 6 };
+//! let js_value = serde::Serialize::serialize(thing, &mut serializer).unwrap();
+//! assert_eq!(format!("{}", js_value), "[0, 5, 6]");
+//! ```
 
 use wasm_bindgen::prelude::*;
 

--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/ser.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/ser.rs
@@ -1,0 +1,314 @@
+use js_sys::{Array, Uint8Array};
+use serde::ser::{self, Error as _, Serialize};
+use wasm_bindgen::prelude::*;
+
+use super::{Error, Result};
+
+pub struct ErrorSerializer;
+
+impl ser::SerializeTupleVariant for ErrorSerializer {
+    type Ok = JsValue;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, _: &T) -> Result<()> {
+        Err(Error::custom("Serializing variants is not implemented"))
+    }
+
+    fn end(self) -> Result {
+        Err(Error::custom("Serializing variants is not implemented"))
+    }
+}
+
+impl ser::SerializeStructVariant for ErrorSerializer {
+    type Ok = JsValue;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, _: &'static str, _: &T) -> Result<()> {
+        Err(Error::custom("Serializing variants is not implemented"))
+    }
+
+    fn end(self) -> Result {
+        Err(Error::custom("Serializing variants is not implemented"))
+    }
+}
+
+pub struct ArraySerializer<'s> {
+    serializer: &'s Serializer,
+    res: Array,
+    idx: u32,
+}
+
+impl<'s> ArraySerializer<'s> {
+    pub fn new(serializer: &'s Serializer) -> Self {
+        let res = Array::new();
+        res.set(0, JsValue::from(0u32));
+        Self {
+            serializer,
+            res,
+            idx: 1,
+        }
+    }
+}
+
+impl ser::SerializeSeq for ArraySerializer<'_> {
+    type Ok = JsValue;
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
+        self.res.set(self.idx, value.serialize(self.serializer)?);
+        self.idx += 1;
+        Ok(())
+    }
+
+    fn end(self) -> Result {
+        Ok(self.res.into())
+    }
+}
+
+impl ser::SerializeTuple for ArraySerializer<'_> {
+    type Ok = JsValue;
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result {
+        Ok(self.res.into())
+    }
+}
+
+impl ser::SerializeTupleStruct for ArraySerializer<'_> {
+    type Ok = JsValue;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<()> {
+        ser::SerializeTuple::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result {
+        Ok(self.res.into())
+    }
+}
+
+impl ser::SerializeMap for ErrorSerializer {
+    type Ok = JsValue;
+    type Error = Error;
+
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, _: &T) -> Result<()> {
+        Err(Error::custom("Serializing maps is not implemented"))
+    }
+
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, _: &T) -> Result<()> {
+        Err(Error::custom("Serializing maps is not implemented"))
+    }
+
+    fn end(self) -> Result {
+        Err(Error::custom("Serializing maps is not implemented"))
+    }
+}
+
+impl ser::SerializeStruct for ArraySerializer<'_> {
+    type Ok = JsValue;
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, _: &'static str, value: &T) -> Result<()> {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result {
+        Ok(self.res.into())
+    }
+}
+
+#[derive(Default)]
+pub struct Serializer(serde_wasm_bindgen::Serializer);
+
+impl Serializer {
+    pub const fn new() -> Self {
+        Self(serde_wasm_bindgen::Serializer::new())
+    }
+}
+
+impl<'s> ser::Serializer for &'s Serializer {
+    type Ok = JsValue;
+    type Error = Error;
+
+    type SerializeSeq = ArraySerializer<'s>;
+    type SerializeTuple = ArraySerializer<'s>;
+    type SerializeTupleStruct = ArraySerializer<'s>;
+    type SerializeTupleVariant = ErrorSerializer;
+    type SerializeMap = ErrorSerializer;
+    type SerializeStruct = ArraySerializer<'s>;
+    type SerializeStructVariant = ErrorSerializer;
+
+    fn serialize_bool(self, v: bool) -> Result {
+        if v {
+            self.0.serialize_u32(1)
+        } else {
+            self.0.serialize_u32(0)
+        }
+    }
+
+    fn serialize_i8(self, v: i8) -> Result {
+        self.0.serialize_i8(v)
+    }
+
+    fn serialize_i16(self, v: i16) -> Result {
+        self.0.serialize_i16(v)
+    }
+
+    fn serialize_i32(self, v: i32) -> Result {
+        self.0.serialize_i32(v)
+    }
+
+    fn serialize_u8(self, v: u8) -> Result {
+        self.0.serialize_u8(v)
+    }
+
+    fn serialize_u16(self, v: u16) -> Result {
+        self.0.serialize_u16(v)
+    }
+
+    fn serialize_u32(self, v: u32) -> Result {
+        self.0.serialize_u32(v)
+    }
+
+    fn serialize_f32(self, v: f32) -> Result {
+        self.0.serialize_f32(v)
+    }
+
+    fn serialize_f64(self, v: f64) -> Result {
+        self.0.serialize_f64(v)
+    }
+
+    fn serialize_str(self, _: &str) -> Result {
+        /* The bindings call caml_string_of_jsstring; not clear what to do here without digging in
+        further. */
+        Err(Error::custom("Serializing strings is not implemented"))
+    }
+
+    fn serialize_i64(self, _: i64) -> Result {
+        /* Custom type in OCaml */
+        Err(Error::custom("Serializing i64 is not implemented"))
+    }
+
+    fn serialize_u64(self, _: u64) -> Result {
+        /* Custom type in OCaml */
+        Err(Error::custom("Serializing u64 is not implemented"))
+    }
+
+    fn serialize_i128(self, _: i128) -> Result {
+        /* Custom type in OCaml */
+        Err(Error::custom("Serializing i128 is not implemented"))
+    }
+
+    fn serialize_u128(self, _: u128) -> Result {
+        /* Custom type in OCaml */
+        Err(Error::custom("Serializing u128 is not implemented"))
+    }
+
+    fn serialize_char(self, v: char) -> Result {
+        self.0.serialize_u32(v as u32)
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result {
+        Ok(JsValue::from(Uint8Array::new(
+            unsafe { Uint8Array::view(v) }.as_ref(),
+        )))
+    }
+
+    fn serialize_none(self) -> Result {
+        self.0.serialize_u32(0)
+    }
+
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result {
+        let res = Array::new();
+        res.set(0, JsValue::from(0u32));
+        res.set(1, value.serialize(self)?);
+        Ok(res.into())
+    }
+
+    fn serialize_unit(self) -> Result {
+        self.0.serialize_u32(0)
+    }
+
+    fn serialize_unit_struct(self, _: &'static str) -> Result {
+        Err(Error::custom("Serializing unit structs is not implemented"))
+    }
+
+    fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Result {
+        Err(Error::custom(
+            "Serializing unit variants is not implemented",
+        ))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(self, _: &'static str, _: &T) -> Result {
+        Err(Error::custom(
+            "Serializing newtype structs is not implemented",
+        ))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: &T,
+    ) -> Result {
+        Err(Error::custom(
+            "Serializing newtype variants is not implemented",
+        ))
+    }
+
+    // TODO: Figure out if there is a way to detect and serialise `Set` differently.
+    fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq> {
+        Ok(ArraySerializer::new(self))
+    }
+
+    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple> {
+        Ok(ArraySerializer::new(self))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Err(Error::custom(
+            "Serializing tuple structs is not implemented",
+        ))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(Error::custom(
+            "Serializing tuple variants is not implemented",
+        ))
+    }
+
+    fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap> {
+        Err(Error::custom("Serializing maps is not implemented"))
+    }
+
+    fn serialize_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeStruct> {
+        Ok(ArraySerializer::new(self))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Err(Error::custom(
+            "Serializing struct variants is not implemented",
+        ))
+    }
+}


### PR DESCRIPTION
This PR
* updates the proof-systems submodule to include https://github.com/o1-labs/proof-systems/pull/833, which switches to using a `PointEvaluations` wrapper for evaluations.
  - it would be nice to propagate this change upwards into pickles at some point; this PR does not seek to do that
* updates the bindings.

The most notable part of this PR is the partial new approach to converting rust values in WASM to js_of_ocaml-compatible values in javascript: for the `ProofEvaluations` struct, we now use a special serde `Serializer` / `Deserializer` pair instead of performing the manual conversions. This comes with some caveats; to quote commit 25dad1ee2e6f0e718f03d6e225fcb5b54f901950:

>    This commit copies the strategy of serde_wasm_bindgen, using serde to
>    emit JS values that match the format expected by js_of_ocaml for the
>    `ProofEvaluations` struct. This change may appear invasive and complex,
>    but the manual mapping over the internal structures in javascript proved
>    much more complex and error prone. This has the additional bonus that,
>    if any new evaluations are added, it will not be necessary to change the
>    WASM bindings in any way.
>
>    Note that we do not do this for the whole `ProverProof` structure. In
>    particular, the representation of affine group elements given by serde
>    is a binary one, whereas we want an `(F * F) or_infinity`. Fixing this
>    issue also proved very complex, so this commit walks the middle path of
>    only serde-serializing the `ProofEvaluations` struct, where no group
>    elements appear.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them