### PR TITLE
[crypto] fix rust bug

### DIFF
--- a/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/ser.rs
+++ b/src/lib/crypto/kimchi_bindings/wasm/src/wasm_ocaml_serde/ser.rs
@@ -125,7 +125,7 @@ impl ser::SerializeStruct for ArraySerializer<'_> {
 pub struct Serializer(serde_wasm_bindgen::Serializer);
 
 impl Serializer {
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self(serde_wasm_bindgen::Serializer::new())
     }
 }


### PR DESCRIPTION
fix this error:

```
error[E0015]: cannot call non-const fn `serde_wasm_bindgen::Serializer::new` in constant
   --> src/wasm_ocaml_serde/ser.rs:129:14
    |
129 |         Self(serde_wasm_bindgen::Serializer::new())
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs

For more information about this error, try `rustc --explain E0015`.
warning: `plonk_wasm` (lib) generated 12 warnings
error: could not compile `plonk_wasm` due to previous error; 12 warnings emitted
Error: Compiling your crate to WebAssembly failed
```