### PR TITLE
SnarkyJS: expose mainnet signatures

### DIFF
--- a/src/lib/snarky_js_bindings/lib/dune
+++ b/src/lib/snarky_js_bindings/lib/dune
@@ -1,63 +1,66 @@
 (library
  (name snarky_js_bindings_lib)
  (libraries
-   ;; opam libraries ;;
-   core_kernel
-   base
-   base.caml
-   integers
-   sexplib0
-   yojson
-   ;; local libraries ;;
-   mina_wire_types
-   mina_base
-   mina_base.import
-   snarky.backendless
-   h_list
-   pickles
-   pickles.backend
-   pickles.limb_vector
-   pickles_types
-   kimchi_backend
-   kimchi_backend.pasta
-   kimchi_backend.pasta.basic
-   kimchi_backend.pasta.constraint_system
-   kimchi_backend.common
-   kimchi_bindings
-   kimchi_types
-   pasta_bindings
-   base58_check
-   block_time
-   currency
-   data_hash_lib
-   hash_prefixes
-   fields_derivers
-   fields_derivers_zkapps
-   genesis_constants
-   mina_numbers
-   mina_transaction
-   mina_transaction_logic
-   random_oracle
-   random_oracle_input
-   sgn
-   signature_lib
-   snark_keys_header
-   snark_params
-   sponge
-   tuple_lib
-   unsigned_extended
-   with_hash
-   ;; js-specific libraries ;;
-   js_of_ocaml
-   bindings_js
-   integers_stubs_js
-   zarith_stubs_js
-   ;; js-specific overrides ;;
-   cache_dir.fake
-   digestif.ocaml
-   mina_metrics.none
-   promise.js
-   promise.js_helpers
-   run_in_thread.fake)
- (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_custom_printf ppx_version js_of_ocaml-ppx)))
+  ;; opam libraries ;;
+  core_kernel
+  base
+  base.caml
+  integers
+  sexplib0
+  yojson
+  ;; local libraries ;;
+  mina_wire_types
+  mina_base
+  mina_base.import
+  snarky.backendless
+  h_list
+  pickles
+  pickles.backend
+  pickles.limb_vector
+  pickles_types
+  kimchi_backend
+  kimchi_backend.pasta
+  kimchi_backend.pasta.basic
+  kimchi_backend.pasta.constraint_system
+  kimchi_backend.common
+  kimchi_bindings
+  kimchi_types
+  pasta_bindings
+  base58_check
+  block_time
+  currency
+  data_hash_lib
+  hash_prefixes
+  fields_derivers
+  fields_derivers_zkapps
+  genesis_constants
+  mina_numbers
+  mina_signature_kind
+  mina_transaction
+  mina_transaction_logic
+  random_oracle
+  random_oracle_input
+  sgn
+  signature_lib
+  snark_keys_header
+  snark_params
+  sponge
+  tuple_lib
+  unsigned_extended
+  with_hash
+  ;; js-specific libraries ;;
+  js_of_ocaml
+  bindings_js
+  integers_stubs_js
+  zarith_stubs_js
+  ;; js-specific overrides ;;
+  cache_dir.fake
+  digestif.ocaml
+  mina_metrics.none
+  promise.js
+  promise.js_helpers
+  run_in_thread.fake)
+ (instrumentation
+  (backend bisect_ppx))
+ (preprocess
+  (pps ppx_custom_printf ppx_version js_of_ocaml-ppx)))

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -2898,8 +2898,13 @@ module Ledger = struct
           (Zkapp_command.Call_forest.hash account_update.elt.calls :> Impl.field)
     end
 
-  let sign_field_element (x : field_class Js.t) (key : private_key) =
-    Signature_lib.Schnorr.Chunked.sign (private_key key)
+  let sign_field_element (x : field_class Js.t) (key : private_key)
+      (is_mainnet : bool Js.t) =
+    let network_id =
+      Mina_signature_kind.(if Js.to_bool is_mainnet then Mainnet else Testnet)
+    in
+    Signature_lib.Schnorr.Chunked.sign ~signature_kind:network_id
+      (private_key key)
       (Random_oracle.Input.Chunked.field (x |> of_js_field |> to_unchecked))
     |> Mina_base.Signature.to_base58_check |> Js.string
 


### PR DESCRIPTION
This exposes an additional option to snarkyjs in `sign_field_element`, to enable signing with both "testnet" and "mainnet" network ids. In support of https://github.com/o1-labs/snarkyjs/pull/612