### PR TITLE
Remove Tests module

### DIFF
--- a/src/nonconsensus/snark_params/tick.ml
+++ b/src/nonconsensus/snark_params/tick.ml
@@ -39,7 +39,6 @@ module Field = struct
       let to_latest x = x
     end
 
-    module Tests = struct end
   end]
 
   include Pasta.Fp


### PR DESCRIPTION
Remove the `Tests` module from a nonconsensus source file. That module will trip an error in the version linter, which is expecting only `Vn` modules. The module is a hangover from the days of `%%versioned_asserted` (replaced by assertions on individual types within versioned types).

This particular error is what led to the earlier "skip list" effort.