### PR TITLE
Add dependencies for developing zkapps to nix shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -102,11 +102,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1635165013,
-        "narHash": "sha256-o/BdVjNwcB6jOmzZjOH703BesSkkS5O7ej3xhyO8hAY=",
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "5b9e0ff9d3b551234b4f3eb3983744fa354b17f1",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1645371475,
-        "narHash": "sha256-z2n0y5ME7yQTqzzGWnQTVd1MG5Bp1E+of7ZgA861/9E=",
+        "lastModified": 1666547822,
+        "narHash": "sha256-razwnAybPHyoAyhkKCwXdxihIqJi1G6e1XP4FQOJTEs=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "38bc843f1ce76958a9f6f0a1e4e3455221c8ecf6",
+        "rev": "1a3b735e13e90a8d2fd5629f2f8363bd7ffbbec7",
         "type": "github"
       },
       "original": {
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662627485,
-        "narHash": "sha256-Kg8u2ekU0+MsuLzgKqiaus3HquLLo2Qq+oGbQfIppos=",
+        "lastModified": 1670813451,
+        "narHash": "sha256-v0IvQ35CMKtPreGlxWb1FvFUraJNZd144+MbiDwGoAA=",
         "owner": "serokell",
         "repo": "nix-npm-buildpackage",
-        "rev": "cab951dd024dd367511d48440de6f93664ee35aa",
+        "rev": "ec0365cd14a3359a23b80a9e2531a09afc3488fc",
         "type": "github"
       },
       "original": {
@@ -233,11 +233,11 @@
     "nixpkgs-mozilla": {
       "flake": false,
       "locked": {
-        "lastModified": 1638887313,
-        "narHash": "sha256-FMYV6rVtvSIfthgC1sK1xugh3y7muoQcvduMdriz4ag=",
+        "lastModified": 1664789696,
+        "narHash": "sha256-UGWJHQShiwLCr4/DysMVFrYdYYHcOqAOVsWNUu+l6YU=",
         "owner": "mozilla",
         "repo": "nixpkgs-mozilla",
-        "rev": "7c1e8b1dd6ed0043fb4ee0b12b815256b0b9de6f",
+        "rev": "80627b282705101e7b38e19ca6e8df105031b072",
         "type": "github"
       },
       "original": {
@@ -248,11 +248,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1661404419,
-        "narHash": "sha256-7+xPaxDIH9TIiv1AnKe8T7G/yKER0oXvhXdF5nRw1WI=",
+        "lastModified": 1670837426,
+        "narHash": "sha256-VGm7k7R+zxZa5oZXGT/79SUlihzFxeWVcPmIn0k1y+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3bbe5c61d3b8aaa7af8bf375dce2858385607186",
+        "rev": "f277f5a27a877f9ceaaeecc8161c9f6d3b7f4f7c",
         "type": "github"
       },
       "original": {
@@ -277,11 +277,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1667491541,
-        "narHash": "sha256-Yq/wEQC7fz4A5zIhu6fymheUJdWBKx/Te7PMMb7lS2w=",
+        "lastModified": 1670004517,
+        "narHash": "sha256-7SffiN2S9pVfOoBCcEdY/iJe28p/eiRqVLXG7/8Jb3I=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "c3db5fdf0f2b4aba3f052a9b9b787303aa268a2f",
+        "rev": "b12b7fcd6f9ea0a8a939c05c68a95525f0d80af6",
         "type": "github"
       },
       "original": {
@@ -309,11 +309,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1666777200,
-        "narHash": "sha256-JYyJVt6cKsG9jxpNKbINb9Kp8AUvOqaNDuUtd1gz9J8=",
+        "lastModified": 1670841293,
+        "narHash": "sha256-ehLsAf9va4d3YZXKhWSu88cYdRZ/6HuPPQ+TXToypTg=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "445ff10841f25868d96c33b756783bfa4ceb4f44",
+        "rev": "bad686eebec3198d02a1599eccb361596421832b",
         "type": "github"
       },
       "original": {
@@ -364,11 +364,11 @@
         "flake-utils": "flake-utils_3"
       },
       "locked": {
-        "lastModified": 1638172912,
-        "narHash": "sha256-jxhQGNEsZTdop/Br3JPS+xmBf6t9cIWRzVZFxbT76Rw=",
+        "lastModified": 1657226504,
+        "narHash": "sha256-GIYNjuq4mJlFgqKsZ+YrgzWm0IpA4axA3MCrdKYj7gs=",
         "owner": "gytis-ivaskevicius",
         "repo": "flake-utils-plus",
-        "rev": "166d6ebd9f0de03afc98060ac92cba9c71cfe550",
+        "rev": "2bf0f91643c2e5ae38c1b26893ac2927ac9bd82a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -285,7 +285,7 @@
             mina mina_tests mina-ocaml-format mina_client_sdk test_executive;
           inherit (pkgs)
             libp2p_helper kimchi_bindings_stubs client_sdk snarky_js leaderboard
-            mina-signer validation trace-tool;
+            mina-signer validation trace-tool zkapp-cli;
           inherit (dockerImages)
             mina-image-slim mina-image-full mina-archive-image-full;
           mina-deb = debianPackages.mina;
@@ -350,9 +350,20 @@
             pkgs.rustup
             pkgs.libiconv # needed on macOS for one of the rust dep
           ];
-          MARLIN_PLONK_STUBS = "n";
-          PLONK_WASM_WEB = "n";
-          PLONK_WASM_NODEJS = "n";
+        });
+
+        # A shell from which we can compile snarky_js and use zkapp-cli to write and deploy zkapps
+        devShells.zkapp-impure = ocamlPackages.mina-dev.overrideAttrs (oa: {
+          name = "mina-zkapp-shell";
+          buildInputs = oa.buildInputs ++ devShellPackages;
+          nativeBuildInputs = oa.nativeBuildInputs ++ [
+            pkgs.rustup
+            pkgs.libiconv # needed on macOS for one of the rust dep
+            pkgs.git
+            pkgs.nodejs
+            pkgs.zkapp-cli
+            pkgs.binaryen # provides wasm-opt
+          ];
         });
 
         inherit checks;

--- a/nix/javascript.nix
+++ b/nix/javascript.nix
@@ -1,7 +1,7 @@
 final: prev:
 let
   inherit (final)
-    stdenv writeScript nix-npm-buildPackage ocamlPackages_mina plonk_wasm;
+    pkgs stdenv writeScript nix-npm-buildPackage ocamlPackages_mina plonk_wasm;
 in {
   client_sdk = nix-npm-buildPackage.buildYarnPackage {
     name = "client_sdk";
@@ -81,4 +81,22 @@ in {
       rm -rf yarn-cache
     '';
   };
+
+  zkapp-cli = nix-npm-buildPackage.buildNpmPackage {
+    src = pkgs.fetchFromGitHub {
+      owner = "o1-labs";
+      repo = "zkapp-cli";
+      rev = "b6542ccca0ce94d61c29edf519cd0eecaf9332fb";
+      sha256 = "sha256-R1Pb1OcjzvuJ0t/7+tq+QDke7E9aRmNmUxbR7QtVJOE=";
+    };
+    doCheck = true;
+    preInstall = "npm prune";
+    dontNpmPrune = true; # running npm prune --production removes husky which seems actually needed
+    postInstall = ''
+      ln -s $out/src/bin/index.js $out/bin/zk
+      ln -s $out/src/bin/index.js $out/bin/zkapp
+      ln -s $out/src/bin/index.js $out/bin/zkapp-cli
+    '';
+  };
 }
+

--- a/nix/misc.nix
+++ b/nix/misc.nix
@@ -29,7 +29,7 @@ final: prev: {
   # Jobs/Lint/ValidationService
   # Jobs/Test/ValidationService
   validation = ((final.mix-to-nix.override {
-    beamPackages = final.beam.packagesWith final.erlangR22; # todo: jose
+    beamPackages = final.beam.packagesWith final.erlangR23; # todo: jose
   }).mixToNix {
     src = ../src/app/validation;
     # todo: think about fixhexdep overlay


### PR DESCRIPTION
This PR adds  a `zkapp-impure` devShell, which contains `nmp` and other dependencies needed to compile snarkyjs 
as well as compile and deploy zkapps.

I needed to update the `nixpkgs` version because `binaryen` did not compile with the previous one (I also updated the whole `flake.lock`  as IIUC it should be done from time to time).

It seems that in the recent `nixpkgs`  there is a security issue with `erlangR22` (see [here](https://buildkite.com/tweag-mina-demo/mina/builds/4105#0185072f-35fa-4e0c-b249-28cf8b2daea2/101-104)) so I switched it to `erlangR23` in `misc.nix`.


Closes #12218
