### PR TITLE
txn model- maintain and generate snarked ledgers

### DIFF
--- a/src/lib/parallel_scan/parallel_scan.ml
+++ b/src/lib/parallel_scan/parallel_scan.ml
@@ -1461,9 +1461,7 @@ let next_on_new_tree t =
   curr_tree_space = t.max_base_jobs
 
 let pending_data t =
-  List.concat_map
-    Mina_stdlib.Nonempty_list.(to_list @@ rev t.trees)
-    ~f:Tree.base_jobs
+  List.map Mina_stdlib.Nonempty_list.(to_list @@ rev t.trees) ~f:Tree.base_jobs
 
 let view_jobs_with_position (state : ('merge, 'base) State.t) fa fd =
   List.fold ~init:[] (Mina_stdlib.Nonempty_list.to_list state.trees)

--- a/src/lib/parallel_scan/parallel_scan.mli
+++ b/src/lib/parallel_scan/parallel_scan.mli
@@ -303,8 +303,9 @@ val base_jobs_on_earlier_tree :
 on a new tree*)
 val next_on_new_tree : ('merge, 'base) State.t -> bool
 
-(** All the 'ds (in the order in which they were added) for which scan results are yet to computed*)
-val pending_data : ('merge, 'base) State.t -> 'base list
+(** All the 'ds (in the order in which they were added) for each tree for which
+    scan results are yet to computed*)
+val pending_data : ('merge, 'base) State.t -> 'base list list
 
 (**update tree level metrics*)
 val update_metrics : ('merge, 'base) State.t -> unit Or_error.t

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -17,7 +17,7 @@ module Transaction_applied = struct
           type t =
             { user_command : Signed_command.Stable.V2.t With_status.Stable.V2.t
             }
-          [@@deriving sexp]
+          [@@deriving sexp, to_yojson]
 
           let to_latest = Fn.id
         end
@@ -33,7 +33,7 @@ module Transaction_applied = struct
             | Stake_delegation of
                 { previous_delegate : Public_key.Compressed.Stable.V1.t option }
             | Failed
-          [@@deriving sexp]
+          [@@deriving sexp, to_yojson]
 
           let to_latest = Fn.id
         end
@@ -44,7 +44,7 @@ module Transaction_applied = struct
     module Stable = struct
       module V2 = struct
         type t = { common : Common.Stable.V2.t; body : Body.Stable.V2.t }
-        [@@deriving sexp]
+        [@@deriving sexp, to_yojson]
 
         let to_latest = Fn.id
       end
@@ -68,7 +68,7 @@ module Transaction_applied = struct
           ; command : Zkapp_command.Stable.V1.t With_status.Stable.V2.t
           ; new_accounts : Account_id.Stable.V2.t list
           }
-        [@@deriving sexp]
+        [@@deriving sexp, to_yojson]
 
         let to_latest = Fn.id
       end
@@ -82,7 +82,7 @@ module Transaction_applied = struct
         type t =
           | Signed_command of Signed_command_applied.Stable.V2.t
           | Zkapp_command of Zkapp_command_applied.Stable.V1.t
-        [@@deriving sexp]
+        [@@deriving sexp, to_yojson]
 
         let to_latest = Fn.id
       end
@@ -98,7 +98,7 @@ module Transaction_applied = struct
           ; new_accounts : Account_id.Stable.V2.t list
           ; burned_tokens : Currency.Amount.Stable.V1.t
           }
-        [@@deriving sexp]
+        [@@deriving sexp, to_yojson]
 
         let to_latest = Fn.id
       end
@@ -114,7 +114,7 @@ module Transaction_applied = struct
           ; new_accounts : Account_id.Stable.V2.t list
           ; burned_tokens : Currency.Amount.Stable.V1.t
           }
-        [@@deriving sexp]
+        [@@deriving sexp, to_yojson]
 
         let to_latest = Fn.id
       end
@@ -129,7 +129,7 @@ module Transaction_applied = struct
           | Command of Command_applied.Stable.V2.t
           | Fee_transfer of Fee_transfer_applied.Stable.V2.t
           | Coinbase of Coinbase_applied.Stable.V2.t
-        [@@deriving sexp]
+        [@@deriving sexp, to_yojson]
 
         let to_latest = Fn.id
       end
@@ -143,7 +143,7 @@ module Transaction_applied = struct
         { previous_hash : Ledger_hash.Stable.V1.t
         ; varying : Varying.Stable.V2.t
         }
-      [@@deriving sexp]
+      [@@deriving sexp, to_yojson]
 
       let to_latest = Fn.id
     end


### PR DESCRIPTION
With the two-pass transaction application model, a scan state tree can have transactions with ledger assumptions that might be confirmed only in the next tree- as a result the proof corresponding to a tree will have a verified first pass ledger without ledger assumptions and a verified second pass ledger possibly with ledger assumptions.
Given the first pass ledgers are always verified without any ledger assumptions, using that as snarked ledger in the protocol (for epoch ledgers).

The scan state (`Transaction_snark_scan_state`) now keeps track of transactions `previous_incomplete_zkapp_updates` from a prior tree that were included in the most recently emitted ledger proof

When maintaining/generating snarked ledger, apply transactions from a previous tree that had ledger assumptions and were applied to the first pass ledger in the subsequent tree. Calling these `previous_incomplete` in the code

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
