### PR TITLE
Use `compatible` as default base branch in linters

### DIFF
--- a/scripts/compare_ci_diff_binables.sh
+++ b/scripts/compare_ci_diff_binables.sh
@@ -15,4 +15,4 @@ rm -rf base
 # build print_binable_functors, then run Python script to compare binable functors in a pull request
 source ~/.profile && \
     (dune build --profile=dev src/external/ppx_version/tools/print_binable_functors.exe) && \
-    ./scripts/compare_pr_diff_binables.py ${BASE_BRANCH_NAME:-develop}
+    ./scripts/compare_pr_diff_binables.py ${BASE_BRANCH_NAME:-compatible}

--- a/scripts/compare_ci_diff_types.sh
+++ b/scripts/compare_ci_diff_types.sh
@@ -5,4 +5,4 @@ set -eo pipefail
 # build print_versioned_types, then run Python script to compare versioned types in a pull request
 source ~/.profile && \
     (dune build --profile=dev src/external/ppx_version/tools/print_versioned_types.exe) && \
-    ./scripts/compare_pr_diff_types.py ${BASE_BRANCH_NAME:-develop}
+    ./scripts/compare_pr_diff_types.py ${BASE_BRANCH_NAME:-compatible}


### PR DESCRIPTION
In the `compatible` branch, use `compatible` as the default base branch for the versioned type and binable linters.

This change is meant to fix the nightly CI builds for `compatible`.