### PR TITLE
Verification key NULLable; topo sort tokens

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -2,10 +2,10 @@
 -- NOTE: minaToolchainStretch is also used for building Ubuntu Bionic packages in CI
 {
   toolchainBase = "codaprotocol/ci-toolchain-base:v3",
-  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:77108b9985e1e65ae3d3dc22c6fe2114530ba44e9a1d890642b9aefc7f44ef3c
-  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:b90422fb481d197187e09c34712f776f2fd2f81acf35041840a833c641c59fc5
-  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:fbf9d1264ae445ec85c2aff0ba181b352c308ddff8498ef46c1bd2ada446dd30
-  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:6621e0ec569c49fd00efc381f897c8a11c9aa6828cb448267c57ff36e7612c1a
+  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:77108b9985e1e65ae3d3dc22c6fe2114530ba44e9a1d890642b9aefc7f44ef3c",
+  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:b90422fb481d197187e09c34712f776f2fd2f81acf35041840a833c641c59fc5",
+  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:fbf9d1264ae445ec85c2aff0ba181b352c308ddff8498ef46c1bd2ada446dd30",
+  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:6621e0ec569c49fd00efc381f897c8a11c9aa6828cb448267c57ff36e7612c1a",
   delegationBackendToolchain = "gcr.io/o1labs-192920/delegation-backend-production@sha256:8ca5880845514ef56a36bf766a0f9de96e6200d61b51f80d9f684a0ec9c031f4",
   elixirToolchain = "elixir:1.10-alpine",
   nodeToolchain = "node:14.13.1-stretch-slim",

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -2,10 +2,10 @@
 -- NOTE: minaToolchainStretch is also used for building Ubuntu Bionic packages in CI
 {
   toolchainBase = "codaprotocol/ci-toolchain-base:v3",
-  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:77108b9985e1e65ae3d3dc22c6fe2114530ba44e9a1d890642b9aefc7f44ef3c",
-  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:b90422fb481d197187e09c34712f776f2fd2f81acf35041840a833c641c59fc5",
-  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:fbf9d1264ae445ec85c2aff0ba181b352c308ddff8498ef46c1bd2ada446dd30",
-  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:6621e0ec569c49fd00efc381f897c8a11c9aa6828cb448267c57ff36e7612c1a",
+  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@sha256:77108b9985e1e65ae3d3dc22c6fe2114530ba44e9a1d890642b9aefc7f44ef3c",
+  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:b90422fb481d197187e09c34712f776f2fd2f81acf35041840a833c641c59fc5",
+  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:fbf9d1264ae445ec85c2aff0ba181b352c308ddff8498ef46c1bd2ada446dd30",
+  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@sha256:6621e0ec569c49fd00efc381f897c8a11c9aa6828cb448267c57ff36e7612c1a",
   delegationBackendToolchain = "gcr.io/o1labs-192920/delegation-backend-production@sha256:8ca5880845514ef56a36bf766a0f9de96e6200d61b51f80d9f684a0ec9c031f4",
   elixirToolchain = "elixir:1.10-alpine",
   nodeToolchain = "node:14.13.1-stretch-slim",

--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -2,10 +2,10 @@
 -- NOTE: minaToolchainStretch is also used for building Ubuntu Bionic packages in CI
 {
   toolchainBase = "codaprotocol/ci-toolchain-base:v3",
-  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@sha256:3062c8363df424c4dad1f325b7bbceb82b299485e8e820d1ae21dd1b33d975ed",
-  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:0a4d8ec1c1b5ad3988d70b1c012af5d97e66874a985478fee8e5aefd27359569",
-  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:fbd3b1dbb11472e00c22e6babc511ca51fe00db62fb7736ef568b01fb7f49a31",
-  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@sha256:13628b16a56628960260598f6021222e5ab6e9f3f5b64c13292a34f71a686d7d",
+  minaToolchainStretch = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:77108b9985e1e65ae3d3dc22c6fe2114530ba44e9a1d890642b9aefc7f44ef3c
+  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:b90422fb481d197187e09c34712f776f2fd2f81acf35041840a833c641c59fc5
+  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:fbf9d1264ae445ec85c2aff0ba181b352c308ddff8498ef46c1bd2ada446dd30
+  minaToolchainFocal = "gcr.io/o1labs-192920/mina-toolchain@gcr.io/o1labs-192920/mina-toolchain@sha256:6621e0ec569c49fd00efc381f897c8a11c9aa6828cb448267c57ff36e7612c1a
   delegationBackendToolchain = "gcr.io/o1labs-192920/delegation-backend-production@sha256:8ca5880845514ef56a36bf766a0f9de96e6200d61b51f80d9f684a0ec9c031f4",
   elixirToolchain = "elixir:1.10-alpine",
   nodeToolchain = "node:14.13.1-stretch-slim",

--- a/opam.export
+++ b/opam.export
@@ -232,6 +232,7 @@ installed: [
   "time_now.v0.14.0"
   "timezone.v0.14.0"
   "topkg.1.0.3"
+  "topological_sort.v0.14.0"
   "trie.1.0.0"
   "typerep.v0.14.0"
   "tyxml.4.5.0"

--- a/src/app/archive/lib/dune
+++ b/src/app/archive/lib/dune
@@ -8,6 +8,7 @@
    base64
    async_rpc_kernel
    base.caml
+   base.base_internalhash_types
    bin_prot.shape
    async_kernel
    caqti-driver-postgresql
@@ -20,6 +21,7 @@
    integers
    ppx_inline_test.config
    uri
+   topological_sort
    ;;local libraries
    mina_wire_types
    kimchi_backend
@@ -69,6 +71,7 @@
    protocol_version
    mina_version
    staged_ledger_diff
+   error_json
    ppx_version.runtime
  )
  (inline_tests)

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -171,7 +171,7 @@ CREATE TABLE zkapp_account_precondition
 CREATE TABLE zkapp_accounts
 ( id                   serial  PRIMARY KEY
 , app_state_id         int     NOT NULL  REFERENCES zkapp_states(id)
-, verification_key_id  int     NOT NULL  REFERENCES zkapp_verification_keys(id)
+, verification_key_id  int               REFERENCES zkapp_verification_keys(id)
 , zkapp_version        bigint  NOT NULL
 , sequence_state_id    int     NOT NULL  REFERENCES zkapp_sequence_states(id)
 , last_sequence_slot   bigint  NOT NULL


### PR DESCRIPTION
In the archive db schema, allow the verification key in zkApp accounts to be NULLable; it's an option in the OCaml code.

When adding the tokens used in a block to the db, topologically sort them, so that if token B's owner is an account id with token A, add token A first.

There were related issues with the Berkeley testnet that these changes attempt to fix.