### PR TITLE
 txn model- ignore zkapp proofs for failed zkapp updates

### DIFF
--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -520,7 +520,7 @@ let profile_user_command (module T : Transaction_snark.S) sparse_ledger0
     Async.Deferred.List.fold transitions
       ~init:((Time.Span.zero, sparse_ledger0, Pending_coinbase.Stack.empty), [])
       ~f:(fun ((max_span, sparse_ledger, coinbase_stack_source), proofs) t ->
-        let sparse_ledger', _applied =
+        let sparse_ledger', applied =
           Sparse_ledger.apply_transaction ~constraint_constants ~txn_state_view
             sparse_ledger (Transaction.forget t)
           |> Or_error.ok_exn
@@ -558,6 +558,9 @@ let profile_user_command (module T : Transaction_snark.S) sparse_ledger0
               ; fee_excess =
                   Transaction.fee_excess (Transaction.forget t)
                   |> Or_error.ok_exn
+              ; zkapp_updates_applied =
+                  Mina_ledger.Ledger.Transaction_applied.zkapp_updates_applied
+                    applied
               }
             ~init_stack:coinbase_stack_source
             { Transaction_protocol_state.Poly.transaction = t

--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -619,7 +619,9 @@ let profile_zkapps ~verifier ledger zkapp_commands =
           Verifier.verify_commands verifier
             [ User_command.to_verifiable ~ledger ~get:Mina_ledger.Ledger.get
                 ~location_of_account:Mina_ledger.Ledger.location_of_account
-                (Zkapp_command zkapp_command)
+                { With_status.data = Zkapp_command zkapp_command
+                ; status = Transaction_status.Applied
+                }
               |> Or_error.ok_exn
             ]
         in

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -42,7 +42,8 @@ module type Blockchain_state = sig
          , 'signed_amount
          , 'pending_coinbase_stack
          , 'fee_excess
-         , 'sok_digest )
+         , 'sok_digest
+         , 'bool )
          t
     [@@deriving sexp]
   end
@@ -57,7 +58,8 @@ module type Blockchain_state = sig
       , Amount.Signed.t
       , Pending_coinbase.Stack_versioned.Stable.V1.t
       , Fee_excess.Stable.V1.t
-      , Sok_message.Digest.Stable.V1.t )
+      , Sok_message.Digest.Stable.V1.t
+      , bool )
       Poly.t
     [@@deriving sexp]
   end
@@ -71,22 +73,26 @@ module type Blockchain_state = sig
     , Currency.Amount.Signed.var
     , Pending_coinbase.Stack.var
     , Fee_excess.var
-    , Sok_message.Digest.Checked.t )
+    , Sok_message.Digest.Checked.t
+    , Snark_params.Tick.Boolean.var )
     Poly.t
 
   val staged_ledger_hash :
-    ('staged_ledger_hash, _, _, _, _, _, _, _, _) Poly.t -> 'staged_ledger_hash
+       ('staged_ledger_hash, _, _, _, _, _, _, _, _, _) Poly.t
+    -> 'staged_ledger_hash
 
   val snarked_ledger_hash :
-    (_, 'frozen_ledger_hash, _, _, _, _, _, _, _) Poly.t -> 'frozen_ledger_hash
+       (_, 'frozen_ledger_hash, _, _, _, _, _, _, _, _) Poly.t
+    -> 'frozen_ledger_hash
 
   val genesis_ledger_hash :
-    (_, 'frozen_ledger_hash, _, _, _, _, _, _, _) Poly.t -> 'frozen_ledger_hash
+       (_, 'frozen_ledger_hash, _, _, _, _, _, _, _, _) Poly.t
+    -> 'frozen_ledger_hash
 
-  val timestamp : (_, _, _, 'time, _, _, _, _, _) Poly.t -> 'time
+  val timestamp : (_, _, _, 'time, _, _, _, _, _, _) Poly.t -> 'time
 
   val body_reference :
-    (_, _, _, _, 'body_reference, _, _, _, _) Poly.t -> 'body_reference
+    (_, _, _, _, 'body_reference, _, _, _, _, _) Poly.t -> 'body_reference
 end
 
 module type Protocol_state = sig

--- a/src/lib/mina_base/transaction_status.ml
+++ b/src/lib/mina_base/transaction_status.ml
@@ -475,7 +475,7 @@ module Stable = struct
     type t = Mina_wire_types.Mina_base.Transaction_status.V2.t =
       | Applied
       | Failed of Failure.Collection.Stable.V1.t
-    [@@deriving sexp, yojson, equal, compare]
+    [@@deriving sexp, yojson, equal, hash, compare]
 
     let to_latest = Fn.id
   end

--- a/src/lib/mina_base/user_command.ml
+++ b/src/lib/mina_base/user_command.ml
@@ -156,16 +156,18 @@ module Verifiable = struct
     | Signed_command x ->
         Signed_command.fee_payer x
     | Zkapp_command p ->
-        Account_update.Fee_payer.account_id p.fee_payer
+        Account_update.Fee_payer.account_id
+          (Zkapp_command.Verifiable.fee_payer p)
 end
 
-let to_verifiable (t : t) ~ledger ~get ~location_of_account :
+let to_verifiable (t : t With_status.t) ~ledger ~get ~location_of_account :
     Verifiable.t Or_error.t =
-  match t with
+  match t.data with
   | Signed_command c ->
       Ok (Signed_command c)
   | Zkapp_command cmd ->
-      Zkapp_command.Verifiable.create ~ledger ~get ~location_of_account cmd
+      Zkapp_command.Verifiable.create ~ledger ~get ~location_of_account
+        { t with data = cmd }
       |> Or_error.map ~f:(fun cmd -> Zkapp_command cmd)
 
 let of_verifiable (t : Verifiable.t) : t =
@@ -250,19 +252,6 @@ module Valid = struct
 
   module Gen = Gen_make (Signed_command.With_valid_signature)
 end
-
-let check ~ledger ~get ~location_of_account (t : t) : Valid.t Or_error.t =
-  match t with
-  | Signed_command x -> (
-      match Signed_command.check x with
-      | Some c ->
-          Ok (Signed_command c)
-      | None ->
-          Or_error.error_string "Invalid signature" )
-  | Zkapp_command p ->
-      Or_error.map
-        (Zkapp_command.Valid.to_valid ~ledger ~get ~location_of_account p)
-        ~f:(fun p -> Zkapp_command p)
 
 let forget_check (t : Valid.t) : t =
   match t with

--- a/src/lib/mina_base/with_status.ml
+++ b/src/lib/mina_base/with_status.ml
@@ -5,7 +5,7 @@ module Stable = struct
   module V2 = struct
     type 'a t = 'a Mina_wire_types.Mina_base.With_status.V2.t =
       { data : 'a; status : Transaction_status.Stable.V2.t }
-    [@@deriving sexp, yojson, equal, compare, fields]
+    [@@deriving sexp, yojson, equal, compare, hash, fields]
 
     let to_latest data_latest (t : _ t) =
       { data = data_latest t.data; status = t.status }

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -133,6 +133,8 @@ module Transaction_applied : sig
       ; new_accounts : Account_id.t list
       }
     [@@deriving sexp]
+
+    val zkapp_updates_applied : t -> bool
   end
 
   module Command_applied : sig

--- a/src/lib/mina_ledger/ledger.mli
+++ b/src/lib/mina_ledger/ledger.mli
@@ -177,6 +177,8 @@ module Transaction_applied : sig
   val transaction : t -> Transaction.t With_status.t
 
   val transaction_status : t -> Transaction_status.t
+
+  val zkapp_updates_applied : t -> bool
 end
 
 (** Raises if the ledger is full, or if an account already exists for the given

--- a/src/lib/mina_state/blockchain_state.ml
+++ b/src/lib/mina_state/blockchain_state.ml
@@ -15,7 +15,8 @@ module Poly = struct
            , 'signed_amount
            , 'pending_coinbase_stack
            , 'fee_excess
-           , 'sok_digest )
+           , 'sok_digest
+           , 'bool )
            t =
             ( 'staged_ledger_hash
             , 'snarked_ledger_hash
@@ -25,7 +26,8 @@ module Poly = struct
             , 'signed_amount
             , 'pending_coinbase_stack
             , 'fee_excess
-            , 'sok_digest )
+            , 'sok_digest
+            , 'bool )
             Mina_wire_types.Mina_state.Blockchain_state.Poly.V2.t =
         { staged_ledger_hash : 'staged_ledger_hash
         ; genesis_ledger_hash : 'snarked_ledger_hash
@@ -35,7 +37,8 @@ module Poly = struct
             , 'pending_coinbase_stack
             , 'fee_excess
             , 'sok_digest
-            , 'local_state )
+            , 'local_state
+            , 'bool )
             Snarked_ledger_state.Poly.Stable.V2.t
         ; timestamp : 'time
         ; body_reference : 'body_reference
@@ -74,7 +77,8 @@ module Value = struct
         , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
         , Pending_coinbase.Stack_versioned.Stable.V1.t
         , Fee_excess.Stable.V1.t
-        , Sok_message.Digest.Stable.V1.t )
+        , Sok_message.Digest.Stable.V1.t
+        , bool )
         Poly.Stable.V2.t
       [@@deriving sexp, equal, compare, hash, yojson]
 
@@ -92,7 +96,8 @@ type var =
   , Currency.Amount.Signed.var
   , Pending_coinbase.Stack.var
   , Fee_excess.var
-  , Sok_message.Digest.Checked.t )
+  , Sok_message.Digest.Checked.t
+  , Boolean.var )
   Poly.t
 
 let create_value ~staged_ledger_hash ~genesis_ledger_hash ~timestamp
@@ -182,7 +187,8 @@ type display =
   , string
   , string
   , int
-  , string )
+  , string
+  , bool )
   Poly.t
 [@@deriving yojson]
 

--- a/src/lib/mina_state/blockchain_state.mli
+++ b/src/lib/mina_state/blockchain_state.mli
@@ -15,7 +15,8 @@ module Poly : sig
            , 'signed_amount
            , 'pending_coinbase_stack
            , 'fee_excess
-           , 'sok_digest )
+           , 'sok_digest
+           , 'bool )
            t =
             ( 'staged_ledger_hash
             , 'snarked_ledger_hash
@@ -25,7 +26,8 @@ module Poly : sig
             , 'signed_amount
             , 'pending_coinbase_stack
             , 'fee_excess
-            , 'sok_digest )
+            , 'sok_digest
+            , 'bool )
             Mina_wire_types.Mina_state.Blockchain_state.Poly.V2.t =
         { staged_ledger_hash : 'staged_ledger_hash
         ; genesis_ledger_hash : 'snarked_ledger_hash
@@ -35,7 +37,8 @@ module Poly : sig
             , 'pending_coinbase_stack
             , 'fee_excess
             , 'sok_digest
-            , 'local_state )
+            , 'local_state
+            , 'bool )
             Snarked_ledger_state.Poly.Stable.V2.t
         ; timestamp : 'time
         ; body_reference : 'body_reference
@@ -58,7 +61,8 @@ module Value : sig
         , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
         , Pending_coinbase.Stack_versioned.Stable.V1.t
         , Fee_excess.Stable.V1.t
-        , Sok_message.Digest.Stable.V1.t )
+        , Sok_message.Digest.Stable.V1.t
+        , bool )
         Poly.Stable.V2.t
       [@@deriving sexp, equal, compare, hash, yojson]
 
@@ -78,21 +82,24 @@ include
       , Currency.Amount.Signed.var
       , Pending_coinbase.Stack.var
       , Fee_excess.var
-      , Sok_message.Digest.Checked.t )
+      , Sok_message.Digest.Checked.t
+      , Boolean.var )
       Poly.t
      and type value := Value.t
 
 val staged_ledger_hash :
-  ('staged_ledger_hash, _, _, _, _, _, _, _, _) Poly.t -> 'staged_ledger_hash
+  ('staged_ledger_hash, _, _, _, _, _, _, _, _, _) Poly.t -> 'staged_ledger_hash
 
 val snarked_ledger_hash :
-  (_, 'snarked_ledger_hash, _, _, _, _, _, _, _) Poly.t -> 'snarked_ledger_hash
+     (_, 'snarked_ledger_hash, _, _, _, _, _, _, _, _) Poly.t
+  -> 'snarked_ledger_hash
 
 val snarked_local_state :
-  (_, _, 'local_state, _, _, _, _, _, _) Poly.t -> 'local_state
+  (_, _, 'local_state, _, _, _, _, _, _, _) Poly.t -> 'local_state
 
 val genesis_ledger_hash :
-  (_, 'snarked_ledger_hash, _, _, _, _, _, _, _) Poly.t -> 'snarked_ledger_hash
+     (_, 'snarked_ledger_hash, _, _, _, _, _, _, _, _) Poly.t
+  -> 'snarked_ledger_hash
 
 val ledger_proof_statement :
      ( _
@@ -103,19 +110,21 @@ val ledger_proof_statement :
      , 'signed_amount
      , 'pending_coinbase_stack
      , 'fee_excess
-     , 'sok_digest )
+     , 'sok_digest
+     , 'bool )
      Poly.t
   -> ( 'snarked_ledger_hash
      , 'signed_amount
      , 'pending_coinbase_stack
      , 'fee_excess
      , 'sok_digest
-     , 'local_state )
+     , 'local_state
+     , 'bool )
      Snarked_ledger_state.Poly.t
 
-val timestamp : (_, _, _, 'time, _, _, _, _, _) Poly.t -> 'time
+val timestamp : (_, _, _, 'time, _, _, _, _, _, _) Poly.t -> 'time
 
-val body_reference : (_, _, _, _, 'ref, _, _, _, _) Poly.t -> 'ref
+val body_reference : (_, _, _, _, 'ref, _, _, _, _, _) Poly.t -> 'ref
 
 val create_value :
      staged_ledger_hash:Staged_ledger_hash.t
@@ -148,7 +157,8 @@ val set_timestamp :
      , 'signed_amount
      , 'pending_coinbase_stack
      , 'fee_excess
-     , 'sok_digest )
+     , 'sok_digest
+     , 'bool )
      Poly.t
   -> 'time
   -> ( 'staged_ledger_hash
@@ -159,7 +169,8 @@ val set_timestamp :
      , 'signed_amount
      , 'pending_coinbase_stack
      , 'fee_excess
-     , 'sok_digest )
+     , 'sok_digest
+     , 'bool )
      Poly.t
 
 val to_input : Value.t -> Field.t Random_oracle.Input.Chunked.t
@@ -175,7 +186,8 @@ type display =
   , string
   , string
   , int
-  , string )
+  , string
+  , bool )
   Poly.t
 [@@deriving yojson]
 

--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -559,9 +559,11 @@ module Make_str (A : Wire_types.Concrete) = struct
       |> option "Error adding supply_increase"
     in
     (*Ignore [zkapp_updates_applied] in merge statements since we don't care
-       whether or not account updates were applied, just that the proofs are
-       valid and state transition is correct*)
-    let zkapp_updates_applied = true in
+      whether or not account updates were applied, just that they were computed correctly.
+      If one of the updates fail, then none are applied*)
+    let zkapp_updates_applied =
+      s1.target.local_state.success && s2.target.local_state.success
+    in
     ( { source = s1.source
       ; target = s2.target
       ; connecting_ledger_left

--- a/src/lib/mina_state/snarked_ledger_state.mli
+++ b/src/lib/mina_state/snarked_ledger_state.mli
@@ -5,12 +5,14 @@ include
               , 'pending_coinbase
               , 'fee_excess
               , 'sok_digest
-              , 'local_state )
+              , 'local_state
+              , 'bool )
               Poly.Stable.V2.t =
       ( 'ledger_hash
       , 'amount
       , 'pending_coinbase
       , 'fee_excess
       , 'sok_digest
-      , 'local_state )
+      , 'local_state
+      , 'bool )
       Mina_wire_types.Mina_state.Snarked_ledger_state.Poly.V2.t

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -69,7 +69,8 @@ module type Full = sig
              , 'pending_coinbase
              , 'fee_excess
              , 'sok_digest
-             , 'local_state )
+             , 'local_state
+             , 'bool )
              t =
           { source :
               ( 'ledger_hash
@@ -85,6 +86,7 @@ module type Full = sig
           ; connecting_ledger_right : 'ledger_hash
           ; supply_increase : 'amount
           ; fee_excess : 'fee_excess
+          ; zkapp_updates_applied : 'bool
           ; sok_digest : 'sok_digest
           }
         [@@deriving compare, equal, hash, sexp, yojson]
@@ -103,12 +105,14 @@ module type Full = sig
       -> connecting_ledger_right:'ledger_hash
       -> pending_coinbase_stack_state:
            'pending_coinbase Pending_coinbase_stack_state.poly
+      -> zkapp_updates_applied:'bool
       -> ( 'ledger_hash
          , 'amount
          , 'pending_coinbase
          , 'fee_excess
          , 'sok_digest
-         , Mina_transaction_logic.Zkapp_command_logic.Local_state.Value.t )
+         , Mina_transaction_logic.Zkapp_command_logic.Local_state.Value.t
+         , 'bool )
          t
   end
 
@@ -123,7 +127,7 @@ module type Full = sig
       }
     [@@deriving compare, equal, hash, sexp, yojson]
 
-    val of_statement : ('a, _, _, _, _, _) Poly.t -> 'a t
+    val of_statement : ('a, _, _, _, _, _, _) Poly.t -> 'a t
   end
 
   [%%versioned:
@@ -135,7 +139,8 @@ module type Full = sig
         , Pending_coinbase.Stack_versioned.Stable.V1.t
         , Fee_excess.Stable.V1.t
         , unit
-        , Local_state.Stable.V1.t )
+        , Local_state.Stable.V1.t
+        , bool )
         Poly.Stable.V2.t
       [@@deriving compare, equal, hash, sexp, yojson]
     end
@@ -147,7 +152,8 @@ module type Full = sig
     , Pending_coinbase.Stack.var
     , Fee_excess.var
     , unit
-    , Local_state.Checked.t )
+    , Local_state.Checked.t
+    , Tick.Boolean.var )
     Poly.t
 
   val typ : (var, t) Tick.Typ.t
@@ -162,14 +168,15 @@ module type Full = sig
           , Pending_coinbase.Stack_versioned.Stable.V1.t
           , Fee_excess.Stable.V1.t
           , Sok_message.Digest.Stable.V1.t
-          , Local_state.Stable.V1.t )
+          , Local_state.Stable.V1.t
+          , bool )
           Poly.Stable.V2.t
         [@@deriving compare, equal, hash, sexp, yojson]
       end
     end]
 
     type display =
-      (string, string, string, int, string, Local_state.display) Poly.t
+      (string, string, string, int, string, Local_state.display, bool) Poly.t
 
     val display : Stable.Latest.t -> display
 
@@ -181,7 +188,8 @@ module type Full = sig
       , Pending_coinbase.Stack.var
       , Fee_excess.var
       , Sok_message.Digest.Checked.t
-      , Local_state.Checked.t )
+      , Local_state.Checked.t
+      , Tick.Boolean.var )
       Poly.t
 
     open Tick

--- a/src/lib/mina_wire_types/mina_state/mina_state_blockchain_state.ml
+++ b/src/lib/mina_wire_types/mina_state/mina_state_blockchain_state.ml
@@ -8,7 +8,8 @@ module Poly = struct
          , 'signed_amount
          , 'pending_coinbase_stack
          , 'fee_excess
-         , 'sok_digest )
+         , 'sok_digest
+         , 'bool )
          t =
       { staged_ledger_hash : 'staged_ledger_hash
       ; genesis_ledger_hash : 'snarked_ledger_hash
@@ -18,7 +19,8 @@ module Poly = struct
           , 'pending_coinbase_stack
           , 'fee_excess
           , 'sok_digest
-          , 'local_state )
+          , 'local_state
+          , 'bool )
           Mina_state_snarked_ledger_state.Poly.V2.t
       ; timestamp : 'time
       ; body_reference : 'body_reference
@@ -37,7 +39,8 @@ module Value = struct
       , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
       , Mina_base.Pending_coinbase.Stack_versioned.V1.t
       , Mina_base.Fee_excess.V1.t
-      , Mina_base.Sok_message.Digest.V1.t )
+      , Mina_base.Sok_message.Digest.V1.t
+      , bool )
       Poly.V2.t
   end
 end

--- a/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.ml
+++ b/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.ml
@@ -9,7 +9,8 @@ module Types = struct
              , 'pending_coinbase
              , 'fee_excess
              , 'sok_digest
-             , 'local_state )
+             , 'local_state
+             , 'bool )
              t =
           { source :
               ( 'ledger_hash
@@ -25,6 +26,7 @@ module Types = struct
           ; connecting_ledger_right : 'ledger_hash
           ; supply_increase : 'amount
           ; fee_excess : 'fee_excess
+          ; zkapp_updates_applied : 'bool
           ; sok_digest : 'sok_digest
           }
       end
@@ -37,7 +39,8 @@ module Types = struct
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V1.t
         , unit
-        , Mina_state_local_state.V1.t )
+        , Mina_state_local_state.V1.t
+        , bool )
         Poly.V2.t
     end
 
@@ -49,7 +52,8 @@ module Types = struct
           , Mina_base.Pending_coinbase.Stack_versioned.V1.t
           , Mina_base.Fee_excess.V1.t
           , Mina_base.Sok_message.Digest.V1.t
-          , Mina_state_local_state.V1.t )
+          , Mina_state_local_state.V1.t
+          , bool )
           Poly.V2.t
       end
     end
@@ -64,7 +68,8 @@ module type Concrete = sig
            , 'pending_coinbase
            , 'fee_excess
            , 'sok_digest
-           , 'local_state )
+           , 'local_state
+           , 'bool )
            t =
         { source :
             ( 'ledger_hash
@@ -80,6 +85,7 @@ module type Concrete = sig
         ; connecting_ledger_right : 'ledger_hash
         ; supply_increase : 'amount
         ; fee_excess : 'fee_excess
+        ; zkapp_updates_applied : 'bool
         ; sok_digest : 'sok_digest
         }
     end
@@ -92,7 +98,8 @@ module type Concrete = sig
       , Mina_base.Pending_coinbase.Stack_versioned.V1.t
       , Mina_base.Fee_excess.V1.t
       , unit
-      , Mina_state_local_state.V1.t )
+      , Mina_state_local_state.V1.t
+      , bool )
       Poly.V2.t
   end
 
@@ -104,7 +111,8 @@ module type Concrete = sig
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V1.t
         , Mina_base.Sok_message.Digest.V1.t
-        , Mina_state_local_state.V1.t )
+        , Mina_state_local_state.V1.t
+        , bool )
         Poly.V2.t
     end
   end
@@ -118,7 +126,8 @@ module M = struct
            , 'pending_coinbase
            , 'fee_excess
            , 'sok_digest
-           , 'local_state )
+           , 'local_state
+           , 'bool )
            t =
         { source :
             ( 'ledger_hash
@@ -134,6 +143,7 @@ module M = struct
         ; connecting_ledger_right : 'ledger_hash
         ; supply_increase : 'amount
         ; fee_excess : 'fee_excess
+        ; zkapp_updates_applied : 'bool
         ; sok_digest : 'sok_digest
         }
     end
@@ -146,7 +156,8 @@ module M = struct
       , Mina_base.Pending_coinbase.Stack_versioned.V1.t
       , Mina_base.Fee_excess.V1.t
       , unit
-      , Mina_state_local_state.V1.t )
+      , Mina_state_local_state.V1.t
+      , bool )
       Poly.V2.t
   end
 
@@ -158,7 +169,8 @@ module M = struct
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V1.t
         , Mina_base.Sok_message.Digest.V1.t
-        , Mina_state_local_state.V1.t )
+        , Mina_state_local_state.V1.t
+        , bool )
         Poly.V2.t
     end
   end

--- a/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.mli
+++ b/src/lib/mina_wire_types/mina_state/mina_state_snarked_ledger_state.mli
@@ -9,7 +9,8 @@ module Types : sig
              , 'pending_coinbase
              , 'fee_excess
              , 'sok_digest
-             , 'local_state )
+             , 'local_state
+             , 'bool )
              t =
           { source :
               ( 'ledger_hash
@@ -25,6 +26,7 @@ module Types : sig
           ; connecting_ledger_right : 'ledger_hash
           ; supply_increase : 'amount
           ; fee_excess : 'fee_excess
+          ; zkapp_updates_applied : 'bool
           ; sok_digest : 'sok_digest
           }
       end
@@ -37,7 +39,8 @@ module Types : sig
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V1.t
         , unit
-        , Mina_state_local_state.V1.t )
+        , Mina_state_local_state.V1.t
+        , bool )
         Poly.V2.t
     end
 
@@ -49,7 +52,8 @@ module Types : sig
           , Mina_base.Pending_coinbase.Stack_versioned.V1.t
           , Mina_base.Fee_excess.V1.t
           , Mina_base.Sok_message.Digest.V1.t
-          , Mina_state_local_state.V1.t )
+          , Mina_state_local_state.V1.t
+          , bool )
           Poly.V2.t
       end
     end
@@ -64,7 +68,8 @@ module type Concrete = sig
            , 'pending_coinbase
            , 'fee_excess
            , 'sok_digest
-           , 'local_state )
+           , 'local_state
+           , 'bool )
            t =
         { source :
             ( 'ledger_hash
@@ -80,6 +85,7 @@ module type Concrete = sig
         ; connecting_ledger_right : 'ledger_hash
         ; supply_increase : 'amount
         ; fee_excess : 'fee_excess
+        ; zkapp_updates_applied : 'bool
         ; sok_digest : 'sok_digest
         }
     end
@@ -92,7 +98,8 @@ module type Concrete = sig
       , Mina_base.Pending_coinbase.Stack_versioned.V1.t
       , Mina_base.Fee_excess.V1.t
       , unit
-      , Mina_state_local_state.V1.t )
+      , Mina_state_local_state.V1.t
+      , bool )
       Poly.V2.t
   end
 
@@ -104,7 +111,8 @@ module type Concrete = sig
         , Mina_base.Pending_coinbase.Stack_versioned.V1.t
         , Mina_base.Fee_excess.V1.t
         , Mina_base.Sok_message.Digest.V1.t
-        , Mina_state_local_state.V1.t )
+        , Mina_state_local_state.V1.t
+        , bool )
         Poly.V2.t
     end
   end

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1065,10 +1065,14 @@ struct
                   Envelope.Incoming.map diff
                     ~f:
                       (List.map ~f:(fun cmd ->
+                           (*Verifying assuming the transaction will be successfully applied; Thsi involves checking all the proofs*)
                            User_command.to_verifiable ~ledger
                              ~get:Base_ledger.get
                              ~location_of_account:
-                               Base_ledger.location_of_account cmd
+                               Base_ledger.location_of_account
+                             { With_status.data = cmd
+                             ; status = Transaction_status.Applied
+                             }
                            |> Or_error.ok_exn ) ) ) )
           |> Result.map_error ~f:(Error.tag ~tag:"Verification_failed")
           |> Deferred.return

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1044,7 +1044,7 @@ module T = struct
       =
     (List.map ~f:(With_status.map ~f:Transaction.forget) a, b, c, d)
 
-  let check_commands ledger ~verifier (cs : User_command.t list) =
+  let check_commands ledger ~verifier (cs : User_command.t With_status.t list) =
     let open Deferred.Or_error.Let_syntax in
     let%bind cs =
       Or_error.try_with (fun () ->

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -574,6 +574,8 @@ module T = struct
       ; fee_excess
       ; supply_increase
       ; sok_digest = ()
+      ; zkapp_updates_applied =
+          Ledger.Transaction_applied.zkapp_updates_applied applied_txn
       }
     , { Stack_state_with_init_stack.pc =
           { source = pending_coinbase_target; target = pending_coinbase_target }

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -265,7 +265,7 @@ val all_work_statements_exn : t -> Transaction_snark_work.Statement.t list
 val check_commands :
      Ledger.t
   -> verifier:Verifier.t
-  -> User_command.t list
+  -> User_command.t With_status.t list
   -> (User_command.Valid.t list, Verifier.Failure.t) Result.t
      Deferred.Or_error.t
 

--- a/src/lib/staged_ledger_diff/diff.ml
+++ b/src/lib/staged_ledger_diff/diff.ml
@@ -332,13 +332,12 @@ module Make_str (A : Wire_types.Concrete) = struct
 
   let validate_commands (t : t)
       ~(check :
-            User_command.t list
+            User_command.t With_status.t list
          -> (User_command.Valid.t list, 'e) Result.t Async.Deferred.Or_error.t
          ) : (With_valid_signatures.t, 'e) Result.t Async.Deferred.Or_error.t =
     let map t ~f = Async.Deferred.Or_error.map t ~f:(Result.map ~f) in
     let validate cs =
-      map
-        (check (List.map cs ~f:With_status.data))
+      map (check cs)
         ~f:
           (List.map2_exn cs ~f:(fun c data ->
                { With_status.data; status = c.status } ) )

--- a/src/lib/staged_ledger_diff/diff_intf.ml
+++ b/src/lib/staged_ledger_diff/diff_intf.ml
@@ -177,7 +177,7 @@ module type Full = sig
   val validate_commands :
        t
     -> check:
-         (   User_command.t list
+         (   User_command.t With_status.t list
           -> (User_command.Valid.t list, 'e) Result.t Async.Deferred.Or_error.t
          )
     -> (With_valid_signatures.t, 'e) Result.t Async.Deferred.Or_error.t

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -73,6 +73,13 @@ module Transaction_applied = struct
         let to_latest = Fn.id
       end
     end]
+
+    let zkapp_updates_applied (t : t) =
+      match t.command.status with
+      | Transaction_status.Applied ->
+          true
+      | _ ->
+          false
   end
 
   module Command_applied = struct
@@ -250,12 +257,8 @@ module Transaction_applied = struct
   let zkapp_updates_applied : t -> bool =
    fun { varying; _ } ->
     match varying with
-    | Command (Zkapp_command c) -> (
-        match c.command.status with
-        | Transaction_status.Applied ->
-            true
-        | _ ->
-            false )
+    | Command (Zkapp_command c) ->
+        Zkapp_command_applied.zkapp_updates_applied c
     | _ ->
         false
 end
@@ -292,6 +295,8 @@ module type S = sig
         ; new_accounts : Account_id.t list
         }
       [@@deriving sexp]
+
+      val zkapp_updates_applied : t -> bool
     end
 
     module Command_applied : sig

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -246,6 +246,18 @@ module Transaction_applied = struct
         f.fee_transfer.status
     | Coinbase c ->
         c.coinbase.status
+
+  let zkapp_updates_applied : t -> bool =
+   fun { varying; _ } ->
+    match varying with
+    | Command (Zkapp_command c) -> (
+        match c.command.status with
+        | Transaction_status.Applied ->
+            true
+        | _ ->
+            false )
+    | _ ->
+        false
 end
 
 module type S = sig
@@ -326,6 +338,8 @@ module type S = sig
     val transaction : t -> Transaction.t With_status.t
 
     val transaction_status : t -> Transaction_status.t
+
+    val zkapp_updates_applied : t -> bool
   end
 
   module Global_state : sig

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -73,7 +73,7 @@ let%test_module "Transaction union tests" =
               ~connecting_ledger_right:target ~sok_digest
               ~fee_excess:(Or_error.ok_exn (Transaction.fee_excess txn))
               ~supply_increase:user_command_supply_increase
-              ~pending_coinbase_stack_state
+              ~pending_coinbase_stack_state ~zkapp_updates_applied:false
           in
           T.of_user_command ~init_stack ~statement user_command_in_block handler )
 

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1934,6 +1934,9 @@ module Make_str (A : Wire_types.Concrete) = struct
             ~else_:statement.target.local_state.stack_frame
         in
         with_label __LOC__ (fun () ->
+            Boolean.Assert.(
+              local.success = statement.target.local_state.success) ) ;
+        with_label __LOC__ (fun () ->
             Local_state.Checked.assert_equal statement.target.local_state
               { local with
                 stack_frame = local_state_ledger
@@ -2016,6 +2019,10 @@ module Make_str (A : Wire_types.Concrete) = struct
                   let zkapp_input =
                     main ?witness:!witness s ~constraint_constants stmt
                   in
+                  let proof_must_verify =
+                    Run.run_checked
+                      (Boolean.all [ b; stmt.target.local_state.success ])
+                  in
                   let proof =
                     Run.exists (Typ.Internal.ref ()) ~request:(fun () ->
                         Zkapp_proof )
@@ -2023,7 +2030,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   { previous_proof_statements =
                       [ { public_input = Option.value_exn zkapp_input
                         ; proof
-                        ; proof_must_verify = b
+                        ; proof_must_verify
                         }
                       ]
                   ; public_output = ()

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -213,6 +213,9 @@ let create_expected_statement ~constraint_constants
   let { With_status.data = transaction; status = _ } =
     Ledger.Transaction_applied.transaction transaction_with_info
   in
+  let zkapp_updates_applied =
+    Ledger.Transaction_applied.zkapp_updates_applied transaction_with_info
+  in
   let%bind protocol_state = get_state (fst state_hash) in
   let state_view = Mina_state.Protocol_state.Body.view protocol_state.body in
   let empty_local_state = Mina_state.Local_state.empty () in
@@ -269,6 +272,7 @@ let create_expected_statement ~constraint_constants
   ; fee_excess
   ; supply_increase
   ; sok_digest = ()
+  ; zkapp_updates_applied
   }
 
 let completed_work_to_scanable_work (job : job) (fee, current_proof, prover) :
@@ -301,6 +305,10 @@ let completed_work_to_scanable_work (job : job) (fee, current_proof, prover) :
         then Ok ()
         else Or_error.error_string "Invalid pending coinbase stack state"
       in
+      (*Ignore [zkapp_updates_applied] in merge statements since we don't care
+        whether or not account updates were applied, just that the proofs are
+        valid and state transition is correct. Set to true always*)
+      let zkapp_updates_applied = true in
       let connecting_ledger_left = failwith "TODO merge rules" in
       let connecting_ledger_right = failwith "TODO merge rules" in
       let statement : Transaction_snark.Statement.t =
@@ -311,6 +319,7 @@ let completed_work_to_scanable_work (job : job) (fee, current_proof, prover) :
         ; supply_increase
         ; fee_excess
         ; sok_digest = ()
+        ; zkapp_updates_applied
         }
       in
       ( Ledger_proof.create ~statement ~sok_digest ~proof
@@ -621,6 +630,7 @@ struct
         ; connecting_ledger_right = _
         ; supply_increase = _
         ; sok_digest = ()
+        ; zkapp_updates_applied = _
         } ->
         let open Or_error.Let_syntax in
         let _connecting_ledger_left = failwith "TODO check connecting ledger" in

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -306,9 +306,11 @@ let completed_work_to_scanable_work (job : job) (fee, current_proof, prover) :
         else Or_error.error_string "Invalid pending coinbase stack state"
       in
       (*Ignore [zkapp_updates_applied] in merge statements since we don't care
-        whether or not account updates were applied, just that the proofs are
-        valid and state transition is correct. Set to true always*)
-      let zkapp_updates_applied = true in
+        whether or not account updates were applied, just that they were computed correctly.
+        If one of the updates fail, then none are applied*)
+      let zkapp_updates_applied =
+        s.target.local_state.success && s'.target.local_state.success
+      in
       let connecting_ledger_left = failwith "TODO merge rules" in
       let connecting_ledger_right = failwith "TODO merge rules" in
       let statement : Transaction_snark.Statement.t =

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -40,8 +40,10 @@ let check :
             `Valid (User_command.Signed_command c)
         | None ->
             `Invalid_signature (Signed_command.public_keys c) )
-  | Zkapp_command ({ fee_payer; account_updates; memo } as zkapp_command_with_vk)
-    ->
+  | Zkapp_command
+      ( { With_status.data = { fee_payer; account_updates; memo }; status } as
+      zkapp_command_with_vk ) ->
+      let verify_proofs = match status with Applied -> true | _ -> false in
       with_return (fun { return } ->
           let account_updates_hash =
             Zkapp_command.Call_forest.hash account_updates
@@ -91,16 +93,18 @@ let check :
                     None
                 | None_given ->
                     None
-                | Proof pi -> (
-                    match vk_opt with
-                    | None ->
-                        return
-                          (`Missing_verification_key
-                            [ Account_id.public_key
-                              @@ Account_update.account_id p
-                            ] )
-                    | Some (vk : _ With_hash.t) ->
-                        Some (vk.data, stmt, pi) ) )
+                | Proof pi ->
+                    if verify_proofs then
+                      match vk_opt with
+                      | None ->
+                          return
+                            (`Missing_verification_key
+                              [ Account_id.public_key
+                                @@ Account_update.account_id p
+                              ] )
+                      | Some (vk : _ With_hash.t) ->
+                          Some (vk.data, stmt, pi)
+                    else None )
           in
           let v : User_command.Valid.t =
             (*Verification keys should be present if it reaches here*)


### PR DESCRIPTION
In transaction snark, for proof updates don't require proof verification to succeed if the current or prior update has failures

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
