### PR TITLE
leaderboard: Add easy debugging

### DIFF
--- a/frontend/leaderboard/init_db.sh
+++ b/frontend/leaderboard/init_db.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -x
+set -eo pipefail
+
+# Check if a custom user has been set, otherwise default to 'postgres'
+DB_USER="${POSTGRES_USER:=postgres}"
+# Check if a custom password has been set, otherwise default to 'password'
+DB_PASSWORD="${POSTGRES_PASSWORD:=password}"
+# Check if a custom database name has been set, otherwise default to 'archive'
+DB_NAME="${POSTGRES_DB:=archive}"
+# Check if a custom port has been set, otherwise default to '5432'
+DB_PORT="${POSTGRES_PORT:=5432}"
+# Check if a custom host has been set, otherwise default to 'localhost'
+DB_HOST="${POSTGRES_HOST:=localhost}"
+
+CONTAINER_NAME="postgres_$(date '+%s')"
+PG_DUMP="berkeley_archive.sql"
+
+if [ ! -f "./data/${PG_DUMP}" ]
+then
+	echo "SQL dump not found. Make sure you have a sql dump at the path: $(pwd)/data/${PG_DUMP}"
+  exit 1
+fi
+
+
+# if a postgres container is running, print instructions to kill it and exit
+RUNNING_POSTGRES_CONTAINER=$(docker ps --filter 'name=postgres' --format '{{.ID}}')
+if [[ -n $RUNNING_POSTGRES_CONTAINER ]]; then
+  echo >&2 "there is a postgres container already running, kill it with"
+  echo >&2 "    docker kill ${RUNNING_POSTGRES_CONTAINER}"
+  docker kill ${RUNNING_POSTGRES_CONTAINER}
+fi
+# Launch postgres using Docker
+docker run \
+    -e POSTGRES_USER=${DB_USER} \
+    -e POSTGRES_PASSWORD=${DB_PASSWORD} \
+    -e POSTGRES_DB=${DB_NAME} \
+    -p "${DB_PORT}":5432 \
+    -v "$(pwd)/data/${PG_DUMP}":"/data/${PG_DUMP}" \
+    -d \
+    --name ${CONTAINER_NAME} \
+    postgres -N 1000
+    # ^ Increased maximum number of connections for testing purposes
+
+# Keep pinging Postgres until it's ready to accept commands
+until PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -U "${DB_USER}" -p "${DB_PORT}" -d "postgres" -c '\q'; do
+  >&2 echo "Postgres is still unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Postgres is up and running on port ${DB_PORT}!"
+
+# zkapps_monitor role creation seems to be missing from the sql dump. We'll create it here.
+>&2 echo "Creating zkapps_monitor role..."
+docker exec \
+	-d \
+	${CONTAINER_NAME} \
+	bash -c "psql -U ${DB_USER} CREATE USER zkapps_monitor"
+
+>&2 echo "Creating ${DB_NAME} database..."
+# Import the SQL dump from the data directory
+docker exec \
+	-d \
+	${CONTAINER_NAME} \
+	bash -c "psql -U ${DB_USER} ${DB_NAME} < /data/${PG_DUMP}"
+
+# Export the connection string as an environment variable
+export DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@localhost:${DB_PORT}/${DB_NAME}
+echo DATABASE_URL
+>&2 echo "Postgres has been initalized and is ready to go!"

--- a/frontend/leaderboard/package.json
+++ b/frontend/leaderboard/package.json
@@ -6,7 +6,7 @@
     "build": "bsb -make-world",
     "clean": "bsb -clean-world",
     "reformat": "bsrefmt --in-place src/**/*.re",
-    "start": "node ./lib/js/src/Main.bs.js"
+    "start": "npm run build && node ./lib/js/src/Main.bs.js"
   },
   "license": "ISC",
   "dependencies": {

--- a/frontend/leaderboard/src/Metrics.re
+++ b/frontend/leaderboard/src/Metrics.re
@@ -177,6 +177,9 @@ let calculateMetricsAndUploadPoints = (pgPool, spreadsheetId) => {
          |> resolve
        });
 
+  Js.log("Public Keys:")
+  users |> then_(users => {Js.log(users); resolve(users)});
+
   let blocksChallenge =
     getPromisifiedChallenge(
       users,


### PR DESCRIPTION
Adds a script to initialize a docker Postgres container with a Berkeley SQL dump for easy debugging!

Make sure you have docker installed on your local machine. Spin up the container with the following command:
`./init_db.sh`

Then, to run the leaderboard, you can use the following command:
```sh
PGCONN=postgres://postgres:password@localhost:5432/archive SPREADSHEET_ID="" yarn start
```

I have added a log statement to print all keys in the `public_keys` table. Currently, the leaderboard has invalid queries in the `Postgres` module since the schema has changed drastically since the last time a leaderboard has been run. The current stacktrace is:

```sh
~/Code/o1/mina/frontend/leaderboard > PGCONN=postgres://postgres:password@localhost:5432/archive SPREADSHEET_ID="" yarn start

yarn run v1.22.19
$ npm run build && node ./lib/js/src/Main.bs.js

> leaderboard@1.0.0 build
> bsb -make-world

Public Keys:
[
  ....
  'B62qnWnds7tBr4veLk49Axv8SnTSCxGPdPbg1DEDc6Mi77JCbYTNzuo',
  'B62qrnrmfGJNmUFqWCoy19wPGo9zZKSTt1utoLLHjgUobJsq7LScyWF',
  'B62qkLH3YiLPkjbsYXsjECQx1oY8LF4HfyCMezoRm24wZYBvsS5BWGy',
  'B62qjkurLhFUS52gvYNJzgMCpmUajv3atW5iCjHr4zYJ5pko4rYPrAc',
  'B62qnKLGpXEJz7YQq4hKkqz2vQyH8bVixr16ojw6nvnVmSy2VvW5c6a',
  'B62qmGErkUtR8S3HEQ999UFWPY6vsygCRzZ6TzYoXoDLA7CvNJaAHYf',
  'B62qrqrL4QrEpSMiRfC24jFcHW78UwgSJiYgr52zrvzZn6u1xGMRZeG',
  ... 44103 more items
]

/home/martin/Code/o1/mina/frontend/leaderboard/node_modules/bs-platform/lib/js/pervasives.js:16
  throw [
  ^
[
  [ 'Failure', -2, tag: 248 ],
  error: column "global_slot" does not exist
      at Parser.parseErrorMessage (/home/martin/Code/o1/mina/frontend/leaderboard/node_modules/pg-protocol/dist/parser.js:287:98)
      at Parser.handlePacket (/home/martin/Code/o1/mina/frontend/leaderboard/node_modules/pg-protocol/dist/parser.js:126:29)
      at Parser.parse (/home/martin/Code/o1/mina/frontend/leaderboard/node_modules/pg-protocol/dist/parser.js:39:38)
      at Socket.<anonymous> (/home/martin/Code/o1/mina/frontend/leaderboard/node_modules/pg-protocol/dist/index.js:11:42)
      at Socket.emit (node:events:526:28)
      at addChunk (node:internal/streams/readable:315:12)
      at readableAddChunk (node:internal/streams/readable:289:9)
      at Socket.Readable.push (node:internal/streams/readable:228:10)
      at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
    length: 111,
    severity: 'ERROR',
    code: '42703',
    detail: undefined,
    hint: undefined,
    position: '71',
    internalPosition: undefined,
    internalQuery: undefined,
    where: undefined,
    schema: undefined,
    table: undefined,
    column: undefined,
    dataType: undefined,
    constraint: undefined,
    file: 'parse_relation.c',
    line: '3589',
    routine: 'errorMissingColumn'
  }
]
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```