### PR TITLE
Fix off-by-1 error in pickles, check domain size in verify

### DIFF
--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -685,7 +685,8 @@ struct
         let (T max_n) = Nat.of_int max in
         let mask = ones_vector (module Impl) max_n ~first_zero:log2_size in
         let log2_sizes =
-          (O.of_index log2_size ~length:max_n, Vector.init max_n ~f:Fn.id)
+          ( O.of_index log2_size ~length:(S max_n)
+          , Vector.init (S max_n) ~f:Fn.id )
         in
         let shifts = Pseudo.Domain.shifts log2_sizes ~shifts in
         let generator = Pseudo.Domain.generator log2_sizes ~domain_generator in

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -85,6 +85,9 @@ let verify_heterogenous (ts : Instance.t list) =
         let zeta = sc plonk0.zeta in
         let alpha = sc plonk0.alpha in
         let step_domain = Branch_data.domain branch_data in
+        check
+          ( lazy "domain size is small enough"
+          , Domain.log2_size step_domain <= Nat.to_int Backend.Tick.Rounds.n ) ;
         let w =
           Tick.Field.domain_generator ~log2_size:(Domain.log2_size step_domain)
         in


### PR DESCRIPTION
This PR
* fixes an off-by-1 error, where we were not accounting for the largest step domain size in side-loaded proofs
* adds a check for the (alleged) step domain size in the `Pickles.verify` function, to ensure that we don't accept proofs with a larger domain size than the maximum that we support.

Tests elided, TODO later.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Nope!
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them