### PR TITLE
Mina-signer: Transaction hash

### DIFF
--- a/src/lib/mina_base/signed_command_payload.mli
+++ b/src/lib/mina_base/signed_command_payload.mli
@@ -95,7 +95,7 @@ module Common : sig
         , Mina_numbers.Global_slot.Stable.V1.t
         , Signed_command_memo.Stable.V1.t )
         Poly.Stable.V2.t
-      [@@deriving compare, equal, sexp, hash]
+      [@@deriving compare, equal, sexp, hash, yojson]
     end
 
     module V1 : sig

--- a/src/lib/snarky_js_bindings/lib/dune
+++ b/src/lib/snarky_js_bindings/lib/dune
@@ -8,6 +8,7 @@
   integers
   sexplib0
   yojson
+  ppx_deriving_yojson.runtime
   ;; local libraries ;;
   mina_wire_types
   mina_base

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -3390,6 +3390,50 @@ module Ledger = struct
     method_ "applyJsonTransaction" apply_json_transaction
 end
 
+let test =
+  let module Signed_command = Mina_base.Signed_command in
+  let module Signed_command_payload = Mina_base.Signed_command_payload in
+  let open Ppx_deriving_yojson_runtime.Result in
+  let ok_exn result =
+    match result with Ok c -> c | Error _ -> failwith "not ok"
+  in
+  let keypair () = Signature_lib.Keypair.create () in
+  object%js
+    val transactionHash =
+      object%js
+        method serializeCommon (command : Js.js_string Js.t) =
+          let command : Signed_command_payload.Common.t =
+            command |> Js.to_string |> Yojson.Safe.from_string
+            |> Signed_command_payload.Common.of_yojson |> ok_exn
+          in
+          Binable.to_bigstring
+            (module Signed_command_payload.Common.Stable.Latest)
+            command
+
+        method serializePayment (command : Js.js_string Js.t) =
+          let command : Signed_command.t =
+            command |> Js.to_string |> Yojson.Safe.from_string
+            |> Signed_command.of_yojson |> ok_exn
+          in
+          Binable.to_bigstring (module Signed_command.Stable.Latest) command
+
+        method examplePayment =
+          let kp = keypair () in
+          let payload : Signed_command_payload.t =
+            { Signed_command_payload.dummy with
+              body =
+                Payment
+                  { Mina_base.Payment_payload.dummy with
+                    source_pk = Signature_lib.Public_key.compress kp.public_key
+                  }
+            }
+          in
+          let payment = Signed_command.sign kp payload in
+          (payment :> Signed_command.t)
+          |> Signed_command.to_yojson |> Yojson.Safe.to_string |> Js.string
+      end
+  end
+
 (* export stuff *)
 
 let export () =
@@ -3400,7 +3444,8 @@ let export () =
   Js.export "Poseidon" poseidon ;
   Js.export "Circuit" Circuit.circuit ;
   Js.export "Ledger" Ledger.ledger_class ;
-  Js.export "Pickles" pickles
+  Js.export "Pickles" pickles ;
+  Js.export "Test" test
 
 let export_global () =
   let snarky_obj =
@@ -3415,6 +3460,7 @@ let export_global () =
          ; ("Circuit", i Circuit.circuit)
          ; ("Ledger", i Ledger.ledger_class)
          ; ("Pickles", i pickles)
+         ; ("Test", i test)
         |])
   in
   Js.Unsafe.(set global (Js.string "__snarky") snarky_obj)

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -3409,6 +3409,14 @@ let test =
           Mina_transaction.Transaction_hash.(
             command |> hash_signed_command |> to_base58_check |> Js.string)
 
+        method hashPaymentV1 (command : Js.js_string Js.t) =
+          let command : Signed_command.t_v1 =
+            command |> Js.to_string |> Yojson.Safe.from_string
+            |> Signed_command.Stable.V1.of_yojson |> ok_exn
+          in
+          Mina_transaction.Transaction_hash.(
+            command |> hash_signed_command_v1 |> to_base58_check |> Js.string)
+
         method serializeCommon (command : Js.js_string Js.t) =
           let command : Signed_command_payload.Common.t =
             command |> Js.to_string |> Yojson.Safe.from_string
@@ -3424,6 +3432,13 @@ let test =
             |> Signed_command.of_yojson |> ok_exn
           in
           Binable.to_bigstring (module Signed_command.Stable.Latest) command
+
+        method serializePaymentV1 (command : Js.js_string Js.t) =
+          let command : Signed_command.t_v1 =
+            command |> Js.to_string |> Yojson.Safe.from_string
+            |> Signed_command.Stable.V1.of_yojson |> ok_exn
+          in
+          Signed_command.Base58_check_v1.to_base58_check command |> Js.string
 
         method examplePayment =
           let kp = keypair () in

--- a/src/lib/snarky_js_bindings/snarky_js_constants.ml
+++ b/src/lib/snarky_js_bindings/snarky_js_constants.ml
@@ -31,6 +31,7 @@ let version_bytes =
     ; ("privateKey", `Int (Char.to_int private_key))
     ; ("signature", `Int (Char.to_int signature))
     ; ("transactionHash", `Int (Char.to_int transaction_hash))
+    ; ("signedCommandV1", `Int (Char.to_int signed_command_v1))
     ]
 
 let poseidon_params_kimchi =

--- a/src/lib/snarky_js_bindings/snarky_js_constants.ml
+++ b/src/lib/snarky_js_bindings/snarky_js_constants.ml
@@ -30,6 +30,7 @@ let version_bytes =
     ; ("userCommandMemo", `Int (Char.to_int user_command_memo))
     ; ("privateKey", `Int (Char.to_int private_key))
     ; ("signature", `Int (Char.to_int signature))
+    ; ("transactionHash", `Int (Char.to_int transaction_hash))
     ]
 
 let poseidon_params_kimchi =

--- a/src/lib/transaction/transaction_hash.mli
+++ b/src/lib/transaction/transaction_hash.mli
@@ -20,6 +20,8 @@ val to_base58_check : t -> string
 
 val hash_signed_command : Signed_command.t -> t
 
+val hash_signed_command_v1 : Signed_command.Stable.V1.t -> t
+
 val hash_command : User_command.t -> t
 
 val hash_fee_transfer : Fee_transfer.Single.t -> t


### PR DESCRIPTION
Companion of https://github.com/o1-labs/snarkyjs/pull/666

This exposes a new module called `Test` from OCaml, which currently only contains function related to transaction hashing. These are used in https://github.com/o1-labs/snarkyjs/pull/666 to check correctness of the JS implementation of tx hashes. Two small interface changes in the main Mina code base had to be made.