### PR TITLE
Use call_type directly instead of the caller's ID

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -2832,7 +2832,7 @@
               "deprecationReason": null
             },
             {
-              "name": "caller",
+              "name": "callType",
               "description": null,
               "args": [],
               "type": {
@@ -2840,7 +2840,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "TokenId",
+                  "name": "CallType",
                   "ofType": null
                 }
               },
@@ -3048,14 +3048,14 @@
               "defaultValue": null
             },
             {
-              "name": "caller",
+              "name": "callType",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "TokenId",
+                  "name": "CallType",
                   "ofType": null
                 }
               },
@@ -6563,6 +6563,16 @@
           "possibleTypes": null
         },
         {
+          "kind": "SCALAR",
+          "name": "CallType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "NonceInterval",
           "description": null,
@@ -7839,7 +7849,7 @@
               "deprecationReason": null
             },
             {
-              "name": "caller",
+              "name": "callType",
               "description": null,
               "args": [],
               "type": {
@@ -7847,7 +7857,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "TokenId",
+                  "name": "CallType",
                   "ofType": null
                 }
               },

--- a/src/app/archive/lib/load_data.ml
+++ b/src/app/archive/lib/load_data.ml
@@ -418,7 +418,7 @@ let get_account_update_body ~pool body_id =
            ; zkapp_network_precondition_id
            ; zkapp_account_precondition_id
            ; use_full_commitment
-           ; caller
+           ; call_type
            ; authorization_kind
            } =
     query_db ~f:(fun db -> Processor.Zkapp_account_update_body.load db body_id)
@@ -586,7 +586,7 @@ let get_account_update_body ~pool body_id =
              ; is_new
              } )
   in
-  let caller = Account_update.Call_type.of_string caller in
+  let call_type = Account_update.Call_type.of_string call_type in
   let authorization_kind =
     Account_update.Authorization_kind.of_string_exn authorization_kind
   in
@@ -605,7 +605,7 @@ let get_account_update_body ~pool body_id =
           ; account = account_precondition
           }
       ; use_full_commitment
-      ; caller
+      ; call_type
       ; authorization_kind
       }
       : Account_update.Body.Simple.t )

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -1450,7 +1450,7 @@ module Zkapp_account_update_body = struct
     ; zkapp_network_precondition_id : int
     ; zkapp_account_precondition_id : int
     ; use_full_commitment : bool
-    ; caller : string
+    ; call_type : string
     ; authorization_kind : string
     }
   [@@deriving fields, hlist]
@@ -1515,7 +1515,7 @@ module Zkapp_account_update_body = struct
     in
     let call_depth = body.call_depth in
     let use_full_commitment = body.use_full_commitment in
-    let caller = Account_update.Call_type.to_string body.caller in
+    let call_type = Account_update.Call_type.to_string body.call_type in
     let authorization_kind =
       Account_update.Authorization_kind.to_string body.authorization_kind
     in
@@ -1531,7 +1531,7 @@ module Zkapp_account_update_body = struct
       ; zkapp_network_precondition_id
       ; zkapp_account_precondition_id
       ; use_full_commitment
-      ; caller
+      ; call_type
       ; authorization_kind
       }
     in
@@ -1540,7 +1540,7 @@ module Zkapp_account_update_body = struct
       ~tannot:(function
         | "events_ids" | "actions_ids" ->
             Some "int[]"
-        | "caller" ->
+        | "call_type" ->
             Some "call_type"
         | "authorization_kind" ->
             Some "authorization_kind_type"

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -264,7 +264,7 @@ CREATE TABLE zkapp_account_update_body
 , zkapp_network_precondition_id  int             NOT NULL  REFERENCES zkapp_network_precondition(id)
 , zkapp_account_precondition_id         int             NOT NULL  REFERENCES zkapp_account_precondition(id)
 , use_full_commitment                   boolean         NOT NULL
-, caller                                call_type  NOT NULL
+, call_type                             call_type  NOT NULL
 , authorization_kind                    authorization_kind_type NOT NULL
 );
 

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -257,7 +257,7 @@ module Zkapp_account_update_info = struct
     ; account : [ `Pk of string ]
     ; balance_change : string
     ; increment_nonce : bool
-    ; caller : string
+    ; call_type : string
     ; call_depth : Unsigned_extended.UInt64.t
     ; use_full_commitment : bool
     ; status : [ `Success | `Failed ]
@@ -270,7 +270,7 @@ module Zkapp_account_update_info = struct
       ; account = `Pk "Eve"
       ; balance_change = "-1000000"
       ; increment_nonce = false
-      ; caller = "caller1"
+      ; call_type = "caller1"
       ; call_depth = Unsigned.UInt64.of_int 10
       ; use_full_commitment = true
       ; status = `Success
@@ -280,7 +280,7 @@ module Zkapp_account_update_info = struct
       ; account = `Pk "Alice"
       ; balance_change = "20000000"
       ; increment_nonce = true
-      ; caller = "caller2"
+      ; call_type = "caller2"
       ; call_depth = Unsigned.UInt64.of_int 20
       ; use_full_commitment = false
       ; status = `Failed
@@ -762,7 +762,7 @@ SELECT zaub.account_identifier_id, zaub.id,
     zaub.balance_change, zaub.increment_nonce, zaub.events_id,
     zaub.sequence_events_id, zaub.call_data_id, zaub.call_depth,
     zaub.zkapp_network_precondition_id, zaub.zkapp_account_precondition_id,
-    zaub.use_full_commitment, zaub.caller, zaub.authorization_kind,
+    zaub.use_full_commitment, zaub.call_type, zaub.authorization_kind,
     pk.value as account, bzc.status
 FROM zkapp_commands zc
  INNER JOIN blocks_zkapp_commands bzc on bzc.zkapp_command_id = zc.id
@@ -957,7 +957,7 @@ WHERE zc.id = ?
                   ; account = Zkapp_account_update.Extras.account extras
                   ; balance_change = upd.balance_change
                   ; increment_nonce = upd.increment_nonce
-                  ; caller = upd.caller
+                  ; call_type = upd.call_type
                   ; call_depth = Unsigned.UInt64.of_int upd.call_depth
                   ; use_full_commitment = upd.use_full_commitment
                   ; status

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -1,44 +1,6 @@
 open Core_kernel
 open Signature_lib
 
-let add_caller (p : Account_update.Wire.t) caller : Account_update.t =
-  let add_caller_body (p : Account_update.Body.Wire.t) caller :
-      Account_update.Body.t =
-    { public_key = p.public_key
-    ; token_id = p.token_id
-    ; update = p.update
-    ; balance_change = p.balance_change
-    ; increment_nonce = p.increment_nonce
-    ; events = p.events
-    ; actions = p.actions
-    ; call_data = p.call_data
-    ; preconditions = p.preconditions
-    ; use_full_commitment = p.use_full_commitment
-    ; caller
-    ; authorization_kind = p.authorization_kind
-    }
-  in
-  { body = add_caller_body p.body caller; authorization = p.authorization }
-
-let add_caller_simple (p : Account_update.Simple.t) caller : Account_update.t =
-  let add_caller_body (p : Account_update.Body.Simple.t) caller :
-      Account_update.Body.t =
-    { public_key = p.public_key
-    ; token_id = p.token_id
-    ; update = p.update
-    ; balance_change = p.balance_change
-    ; increment_nonce = p.increment_nonce
-    ; events = p.events
-    ; actions = p.actions
-    ; call_data = p.call_data
-    ; preconditions = p.preconditions
-    ; use_full_commitment = p.use_full_commitment
-    ; caller
-    ; authorization_kind = p.authorization_kind
-    }
-  in
-  { body = add_caller_body p.body caller; authorization = p.authorization }
-
 module Call_forest = struct
   let empty = Outside_hash_image.t
 
@@ -612,178 +574,6 @@ module Call_forest = struct
   let accumulate_hashes_predicated xs =
     accumulate_hashes ~hash_account_update:Digest.Account_update.create xs
 
-  (* Delegate_call means, preserve the current caller.
-  *)
-  let add_callers
-      (type account_update account_update_with_caller account_update_digest
-      digest id ) (ps : (account_update, account_update_digest, digest) t)
-      ~(call_type : account_update -> Account_update.Call_type.t)
-      ~(add_caller : account_update -> id -> account_update_with_caller)
-      ~(null_id : id) ~(account_update_id : account_update -> id) :
-      (account_update_with_caller, account_update_digest, digest) t =
-    let module Context = struct
-      type t = { caller : id; self : id }
-    end in
-    let open Context in
-    let rec go curr_context ps =
-      match ps with
-      | { With_stack_hash.elt =
-            { Tree.account_update = p; account_update_digest; calls }
-        ; stack_hash
-        }
-        :: ps ->
-          let elt =
-            let child_context =
-              match call_type p with
-              | Delegate_call ->
-                  curr_context
-              | Call ->
-                  { caller = curr_context.self; self = account_update_id p }
-            in
-            let account_update_caller = child_context.caller in
-            { Tree.account_update = add_caller p account_update_caller
-            ; account_update_digest
-            ; calls = go child_context calls
-            }
-          in
-          { With_stack_hash.elt; stack_hash } :: go curr_context ps
-      | [] ->
-          []
-    in
-    go { self = null_id; caller = null_id } ps
-
-  let add_callers' (type h1 h2) (ps : (Account_update.Wire.t, h1, h2) t) :
-      (Account_update.t, h1, h2) t =
-    add_callers ps
-      ~call_type:(fun p -> p.body.caller)
-      ~add_caller ~null_id:Token_id.default
-      ~account_update_id:(fun p ->
-        Account_id.(
-          derive_token_id ~owner:(create p.body.public_key p.body.token_id)) )
-
-  let add_callers_simple (type h1 h2) (ps : (Account_update.Simple.t, h1, h2) t)
-      : (Account_update.t, h1, h2) t =
-    add_callers ps
-      ~call_type:(fun p -> p.body.caller)
-      ~add_caller:add_caller_simple ~null_id:Token_id.default
-      ~account_update_id:(fun p ->
-        Account_id.(
-          derive_token_id ~owner:(create p.body.public_key p.body.token_id)) )
-
-  let remove_callers
-      (type account_update_with_caller account_update_without_sender h1 h2 h1'
-      h2' id ) ~(map_account_update_digest : h1 -> h1')
-      ~(map_stack_hash : h2 -> h2')
-      (ps : (account_update_with_caller, h1, h2) t)
-      ~(equal_id : id -> id -> bool)
-      ~(add_call_type :
-            account_update_with_caller
-         -> Account_update.Call_type.t
-         -> account_update_without_sender ) ~(null_id : id)
-      ~(account_update_caller : account_update_with_caller -> id) :
-      (account_update_without_sender, h1', h2') t =
-    let rec go ~top_level_account_update parent_caller ps =
-      let call_type_for_account_update p : Account_update.Call_type.t =
-        if top_level_account_update then Call
-        else if equal_id parent_caller (account_update_caller p) then
-          Delegate_call
-        else Call
-      in
-      match ps with
-      | { With_stack_hash.elt =
-            { Tree.account_update = p; account_update_digest; calls }
-        ; stack_hash
-        }
-        :: ps ->
-          let ty = call_type_for_account_update p in
-          { With_stack_hash.elt =
-              { Tree.account_update = add_call_type p ty
-              ; account_update_digest =
-                  map_account_update_digest account_update_digest
-              ; calls =
-                  go ~top_level_account_update:false (account_update_caller p)
-                    calls
-              }
-          ; stack_hash = map_stack_hash stack_hash
-          }
-          :: go ~top_level_account_update parent_caller ps
-      | [] ->
-          []
-    in
-    go ~top_level_account_update:true null_id ps
-
-  let%test_unit "add_callers and remove_callers" =
-    let module P = struct
-      type 'a t = { id : int; caller : 'a } [@@deriving compare, sexp]
-    end in
-    let module With_call_type = struct
-      type tmp = (Account_update.Call_type.t P.t, unit, unit) t
-      [@@deriving compare, sexp]
-
-      type t = tmp [@@deriving compare, sexp]
-    end in
-    let null_id = -1 in
-    let module With_id = struct
-      type tmp = (int P.t, unit, unit) t [@@deriving compare, sexp]
-
-      type t = tmp [@@deriving compare, sexp]
-    end in
-    let of_tree tree : _ t =
-      [ { With_stack_hash.elt = tree; stack_hash = () } ]
-    in
-    let node id caller calls =
-      { Tree.account_update = { P.id; caller }
-      ; account_update_digest = ()
-      ; calls =
-          List.map calls ~f:(fun elt ->
-              { With_stack_hash.elt; stack_hash = () } )
-      }
-    in
-    let t : With_call_type.t =
-      let open Account_update.Call_type in
-      node 0 Call
-        [ node 1 Call
-            [ node 11 Call [ node 111 Call []; node 112 Delegate_call [] ]
-            ; node 12 Delegate_call
-                [ node 121 Call []; node 122 Delegate_call [] ]
-            ]
-        ; node 2 Delegate_call
-            [ node 21 Delegate_call
-                [ node 211 Call []; node 212 Delegate_call [] ]
-            ; node 22 Call [ node 221 Call []; node 222 Delegate_call [] ]
-            ]
-        ]
-      |> of_tree
-    in
-    let expected_output : With_id.t =
-      node 0 null_id
-        [ node 1 0
-            [ node 11 1 [ node 111 11 []; node 112 1 [] ]
-            ; node 12 0 [ node 121 1 []; node 122 0 [] ]
-            ]
-        ; node 2 null_id
-            [ node 21 null_id [ node 211 0 []; node 212 null_id [] ]
-            ; node 22 0 [ node 221 22 []; node 222 0 [] ]
-            ]
-        ]
-      |> of_tree
-    in
-    let open P in
-    [%test_eq: With_id.t]
-      (add_callers t
-         ~call_type:(fun p -> p.caller)
-         ~add_caller:(fun p caller : int P.t -> { p with caller })
-         ~null_id
-         ~account_update_id:(fun p -> p.id) )
-      expected_output ;
-    [%test_eq: With_call_type.t]
-      (remove_callers expected_output ~equal_id:Int.equal
-         ~map_account_update_digest:Fn.id ~map_stack_hash:Fn.id
-         ~add_call_type:(fun p call_type -> { p with caller = call_type })
-         ~null_id
-         ~account_update_caller:(fun p -> p.caller) )
-      t
-
   module With_hashes_and_data = struct
     [%%versioned
     module Stable = struct
@@ -811,14 +601,7 @@ module Call_forest = struct
       of_account_updates xs
         ~account_update_depth:(fun ((p : Account_update.Simple.t), _) ->
           p.body.call_depth )
-      |> add_callers
-           ~call_type:(fun ((p : Account_update.Simple.t), _) -> p.body.caller)
-           ~add_caller:(fun (p, x) id -> (add_caller_simple p id, x))
-           ~null_id:Token_id.default
-           ~account_update_id:(fun ((p : Account_update.Simple.t), _) ->
-             Account_id.(
-               derive_token_id ~owner:(create p.body.public_key p.body.token_id))
-             )
+      |> map ~f:(fun (p, x) -> (Account_update.of_simple p, x))
       |> accumulate_hashes
 
     let of_account_updates (xs : (Account_update.Graphql_repr.t * 'a) list) :
@@ -867,14 +650,7 @@ module Call_forest = struct
       of_account_updates xs
         ~account_update_depth:(fun (p : Account_update.Simple.t) ->
           p.body.call_depth )
-      |> add_callers
-           ~call_type:(fun (p : Account_update.Simple.t) -> p.body.caller)
-           ~add_caller:(fun p id -> add_caller_simple p id)
-           ~null_id:Token_id.default
-           ~account_update_id:(fun (p : Account_update.Simple.t) ->
-             Account_id.(
-               derive_token_id ~owner:(create p.body.public_key p.body.token_id))
-             )
+      |> map ~f:Account_update.of_simple
       |> accumulate_hashes
 
     let of_account_updates (xs : Account_update.Graphql_repr.t list) : t =
@@ -977,7 +753,7 @@ module T = struct
             type t =
               { fee_payer : Account_update.Fee_payer.Stable.V1.t
               ; account_updates :
-                  ( Account_update.Wire.Stable.V1.t
+                  ( Account_update.Stable.V1.t
                   , unit
                   , unit )
                   Call_forest.Stable.V1.t
@@ -989,12 +765,6 @@ module T = struct
           end
         end]
 
-        let check (t : t) : unit =
-          List.iter t.account_updates ~f:(fun p ->
-              assert (
-                Account_update.Call_type.equal p.elt.account_update.body.caller
-                  Call ) )
-
         let of_graphql_repr (t : Graphql_repr.t) : t =
           { fee_payer = t.fee_payer
           ; memo = t.memo
@@ -1003,11 +773,6 @@ module T = struct
                 ~f:Account_update.of_graphql_repr
                 ~account_update_depth:(fun (p : Account_update.Graphql_repr.t)
                                       -> p.body.call_depth )
-              |> Call_forest.remove_callers ~equal_id:Token_id.equal
-                   ~map_account_update_digest:ignore ~map_stack_hash:ignore
-                   ~add_call_type:Account_update.to_wire
-                   ~null_id:Token_id.default ~account_update_caller:(fun p ->
-                     p.body.caller )
           }
 
         let to_graphql_repr (t : t) : Graphql_repr.t =
@@ -1015,13 +780,6 @@ module T = struct
           ; memo = t.memo
           ; account_updates =
               t.account_updates
-              |> Call_forest.add_callers
-                   ~call_type:(fun (p : Account_update.Wire.t) -> p.body.caller)
-                   ~add_caller ~null_id:Token_id.default
-                   ~account_update_id:(fun (p : Account_update.Wire.t) ->
-                     Account_id.(
-                       derive_token_id
-                         ~owner:(create p.body.public_key p.body.token_id)) )
               |> Call_forest.to_account_updates_map
                    ~f:(fun ~depth account_update ->
                      Account_update.to_graphql_repr account_update
@@ -1032,32 +790,18 @@ module T = struct
           let open Quickcheck.Generator in
           let open Let_syntax in
           let gen_call_forest =
-            let%map xs =
-              fixed_point (fun self ->
-                  let%bind calls_length = small_non_negative_int in
-                  list_with_length calls_length
-                    (let%map account_update = Account_update.Wire.gen
-                     and calls = self in
-                     { With_stack_hash.stack_hash = ()
-                     ; elt =
-                         { Call_forest.Tree.account_update
-                         ; account_update_digest = ()
-                         ; calls
-                         }
-                     } ) )
-            in
-            (* All top level zkapp_command should be "Call" not "Delegate_call" *)
-            List.map xs
-              ~f:
-                (With_stack_hash.map
-                   ~f:(fun (t : (Account_update.Wire.t, _, _) Call_forest.Tree.t)
-                      ->
-                     { t with
-                       account_update =
-                         { t.account_update with
-                           body = { t.account_update.body with caller = Call }
-                         }
-                     } ) )
+            fixed_point (fun self ->
+                let%bind calls_length = small_non_negative_int in
+                list_with_length calls_length
+                  (let%map account_update = Account_update.gen
+                   and calls = self in
+                   { With_stack_hash.stack_hash = ()
+                   ; elt =
+                       { Call_forest.Tree.account_update
+                       ; account_update_digest = ()
+                       ; calls
+                       }
+                   } ) )
           in
           let open Quickcheck.Let_syntax in
           let%map fee_payer = Account_update.Fee_payer.gen
@@ -1082,27 +826,32 @@ module T = struct
         ; memo = w.memo
         ; account_updates =
             w.account_updates
-            |> Call_forest.add_callers
-                 ~call_type:(fun (p : Account_update.Wire.t) -> p.body.caller)
-                 ~add_caller ~null_id:Token_id.default
-                 ~account_update_id:(fun (p : Account_update.Wire.t) ->
-                   Account_id.(
-                     derive_token_id
-                       ~owner:(create p.body.public_key p.body.token_id)) )
             |> Call_forest.accumulate_hashes
                  ~hash_account_update:(fun (p : Account_update.t) ->
                    Digest.Account_update.create p )
         }
 
       let to_wire (t : t) : Wire.t =
+        let rec forget_hashes = List.map ~f:forget_hash
+        and forget_hash = function
+          | { With_stack_hash.stack_hash = _
+            ; elt =
+                { Call_forest.Tree.account_update
+                ; account_update_digest = _
+                ; calls
+                }
+            } ->
+              { With_stack_hash.stack_hash = ()
+              ; elt =
+                  { Call_forest.Tree.account_update
+                  ; account_update_digest = ()
+                  ; calls = forget_hashes calls
+                  }
+              }
+        in
         { fee_payer = t.fee_payer
         ; memo = t.memo
-        ; account_updates =
-            Call_forest.remove_callers ~equal_id:Token_id.equal
-              ~map_account_update_digest:ignore ~map_stack_hash:ignore
-              ~add_call_type:Account_update.to_wire ~null_id:Token_id.default
-              ~account_update_caller:(fun p -> p.body.caller)
-              t.account_updates
+        ; account_updates = forget_hashes t.account_updates
         }
 
       include
@@ -1111,7 +860,7 @@ module T = struct
           (struct
             type nonrec t = t
 
-            let of_binable t = Wire.check t ; of_wire t
+            let of_binable t = of_wire t
 
             let to_binable = to_wire
           end)
@@ -1130,13 +879,7 @@ let of_simple (w : Simple.t) : t =
       Call_forest.of_account_updates w.account_updates
         ~account_update_depth:(fun (p : Account_update.Simple.t) ->
           p.body.call_depth )
-      |> Call_forest.add_callers
-           ~call_type:(fun (p : Account_update.Simple.t) -> p.body.caller)
-           ~add_caller:add_caller_simple ~null_id:Token_id.default
-           ~account_update_id:(fun (p : Account_update.Simple.t) ->
-             Account_id.(
-               derive_token_id ~owner:(create p.body.public_key p.body.token_id))
-             )
+      |> Call_forest.map ~f:Account_update.of_simple
       |> Call_forest.accumulate_hashes
            ~hash_account_update:(fun (p : Account_update.t) ->
              Digest.Account_update.create p )
@@ -1146,31 +889,28 @@ let to_simple (t : t) : Simple.t =
   { fee_payer = t.fee_payer
   ; memo = t.memo
   ; account_updates =
-      Call_forest.remove_callers ~equal_id:Token_id.equal
-        ~map_account_update_digest:ignore ~map_stack_hash:ignore
-        ~add_call_type:(fun { body = b; authorization } call_type ->
-          { Account_update.Simple.authorization
-          ; body =
-              { public_key = b.public_key
-              ; token_id = b.token_id
-              ; update = b.update
-              ; balance_change = b.balance_change
-              ; increment_nonce = b.increment_nonce
-              ; events = b.events
-              ; actions = b.actions
-              ; call_data = b.call_data
-              ; preconditions = b.preconditions
-              ; use_full_commitment = b.use_full_commitment
-              ; caller = call_type
-              ; call_depth = 0
-              ; authorization_kind = b.authorization_kind
-              }
-          } )
-        ~null_id:Token_id.default
-        ~account_update_caller:(fun (p : Account_update.t) -> p.body.caller)
-        t.account_updates
+      t.account_updates
       |> Call_forest.to_account_updates_map
-           ~f:(fun ~depth (p : Account_update.Simple.t) ->
+           ~f:(fun ~depth { Account_update.body = b; authorization } ->
+             let p =
+               { Account_update.Simple.authorization
+               ; body =
+                   { public_key = b.public_key
+                   ; token_id = b.token_id
+                   ; update = b.update
+                   ; balance_change = b.balance_change
+                   ; increment_nonce = b.increment_nonce
+                   ; events = b.events
+                   ; actions = b.actions
+                   ; call_data = b.call_data
+                   ; preconditions = b.preconditions
+                   ; use_full_commitment = b.use_full_commitment
+                   ; call_type = b.call_type
+                   ; call_depth = 0
+                   ; authorization_kind = b.authorization_kind
+                   }
+               }
+             in
              { p with body = { p.body with call_depth = depth } } )
   }
 

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -550,7 +550,7 @@ module Account_update_body_components = struct
        , 'bool
        , 'protocol_state_precondition
        , 'account_precondition
-       , 'caller
+       , 'call_type
        , 'authorization_kind )
        t =
     { public_key : 'pk
@@ -565,7 +565,7 @@ module Account_update_body_components = struct
     ; protocol_state_precondition : 'protocol_state_precondition
     ; account_precondition : 'account_precondition
     ; use_full_commitment : 'bool
-    ; caller : 'caller
+    ; call_type : 'call_type
     ; authorization_kind : 'authorization_kind
     }
 
@@ -600,7 +600,7 @@ module Account_update_body_components = struct
         ; account = t.account_precondition
         }
     ; use_full_commitment = t.use_full_commitment
-    ; caller = t.caller
+    ; call_type = t.call_type
     ; authorization_kind = t.authorization_kind
     }
 end
@@ -615,7 +615,7 @@ end
    a nonce for the fee payer, and `Account_precondition.t` for other zkapp_command
 *)
 let gen_account_update_body_components (type a b c d) ?(update = None)
-    ?account_id ?token_id ?caller ?account_ids_seen ~account_state_tbl ?vk
+    ?account_id ?token_id ?call_type ?account_ids_seen ~account_state_tbl ?vk
     ?failure ?(new_account = false) ?(zkapp_account = false)
     ?(is_fee_payer = false) ?available_public_keys ?permissions_auth
     ?(required_balance_change : a option) ?protocol_state_view
@@ -802,12 +802,12 @@ let gen_account_update_body_components (type a b c d) ?(update = None)
         | _ ->
             gen_protocol_state_precondition )
       ~default:(return Zkapp_precondition.Protocol_state.accept)
-  and caller =
-    match caller with
+  and call_type =
+    match call_type with
     | None ->
         Account_update.Call_type.quickcheck_generator
-    | Some caller ->
-        return caller
+    | Some call_type ->
+        return call_type
   in
   let token_id = f_token_id token_id in
   let authorization_kind =
@@ -941,12 +941,12 @@ let gen_account_update_body_components (type a b c d) ?(update = None)
   ; protocol_state_precondition
   ; account_precondition
   ; use_full_commitment
-  ; caller
+  ; call_type
   ; authorization_kind
   }
 
 let gen_account_update_from ?(update = None) ?failure ?(new_account = false)
-    ?(zkapp_account = false) ?account_id ?token_id ?caller ?permissions_auth
+    ?(zkapp_account = false) ?account_id ?token_id ?call_type ?permissions_auth
     ?required_balance_change ~zkapp_account_ids ~authorization ~account_ids_seen
     ~available_public_keys ~account_state_tbl ?protocol_state_view ?vk () =
   let open Quickcheck.Let_syntax in
@@ -968,8 +968,8 @@ let gen_account_update_from ?(update = None) ?failure ?(new_account = false)
     gen_account_update_body_components ~update ?failure ~new_account
       ~zkapp_account
       ~increment_nonce:(increment_nonce, increment_nonce)
-      ?permissions_auth ?account_id ?token_id ?caller ?protocol_state_view ?vk
-      ~zkapp_account_ids ~account_ids_seen ~available_public_keys
+      ?permissions_auth ?account_id ?token_id ?call_type ?protocol_state_view
+      ?vk ~zkapp_account_ids ~account_ids_seen ~available_public_keys
       ?required_balance_change ~account_state_tbl
       ~gen_balance_change:
         (gen_balance_change ?permissions_auth ~new_account ?failure)
@@ -1373,7 +1373,7 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
   let gen_zkapp_command_with_token_accounts ~num_zkapp_command =
     let authorization = Control.Signature Signature.dummy in
     let permissions_auth = Control.Tag.Signature in
-    let caller = Account_update.Call_type.Call in
+    let call_type = Account_update.Call_type.Call in
     let rec gen_tree acc n =
       if n <= 0 then return (List.rev acc)
       else
@@ -1387,7 +1387,7 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
                         .account_creation_fee ) ))
           in
           gen_account_update_from ~zkapp_account_ids ~account_ids_seen
-            ~authorization ~permissions_auth ~available_public_keys ~caller
+            ~authorization ~permissions_auth ~available_public_keys ~call_type
             ~account_state_tbl ~required_balance_change ?protocol_state_view ?vk
             ()
         in
@@ -1398,9 +1398,9 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
         in
         let%bind child =
           gen_account_update_from ~zkapp_account_ids ~account_ids_seen
-            ~new_account:true ~token_id ~caller ~authorization ~permissions_auth
-            ~available_public_keys ~account_state_tbl ?protocol_state_view ?vk
-            ()
+            ~new_account:true ~token_id ~call_type ~authorization
+            ~permissions_auth ~available_public_keys ~account_state_tbl
+            ?protocol_state_view ?vk ()
         in
         gen_tree (mk_node parent [ mk_node child [] ] :: acc) (n - 1)
     in
@@ -1423,7 +1423,8 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
   let zkapp_command_dummy_authorizations : Zkapp_command.t =
     { fee_payer
     ; account_updates =
-        account_updates |> Zkapp_command.Call_forest.add_callers_simple
+        account_updates
+        |> Zkapp_command.Call_forest.map ~f:Account_update.of_simple
         |> Zkapp_command.Call_forest.accumulate_hashes_predicated
     ; memo
     }

--- a/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_account_update.ml
@@ -4,6 +4,12 @@ module Authorization_kind = struct
   end
 end
 
+module Call_type = struct
+  module V1 = struct
+    type t = Call | Delegate_call
+  end
+end
+
 module Update = struct
   module Timing_info = struct
     module V1 = struct
@@ -89,7 +95,7 @@ module Body = struct
       ; call_data : Pickles.Backend.Tick.Field.V1.t
       ; preconditions : Preconditions.V1.t
       ; use_full_commitment : bool
-      ; caller : Mina_base_token_id.V2.t
+      ; call_type : Call_type.V1.t
       ; authorization_kind : Authorization_kind.V1.t
       }
   end

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -1803,7 +1803,7 @@ let%test_module _ =
         ; account_updates =
             Zkapp_command.Call_forest.of_account_updates
               ~account_update_depth:(Fn.const 0)
-              [ { Account_update.Wire.body =
+              [ { Account_update.body =
                     { public_key = sender_pk
                     ; update = Account_update.Update.noop
                     ; token_id = Token_id.default
@@ -1820,13 +1820,13 @@ let%test_module _ =
                             Account_update.Account_precondition.Nonce
                               (Account.Nonce.succ nonce)
                         }
-                    ; caller = Call
+                    ; call_type = Call
                     ; use_full_commitment = not double_increment_sender
                     ; authorization_kind = None_given
                     }
                 ; authorization = None_given
                 }
-              ; { Account_update.Wire.body =
+              ; { Account_update.body =
                     { public_key = receiver_pk
                     ; update = Account_update.Update.noop
                     ; token_id = Token_id.default
@@ -1840,7 +1840,7 @@ let%test_module _ =
                             Zkapp_precondition.Protocol_state.accept
                         ; account = Account_update.Account_precondition.Accept
                         }
-                    ; caller = Call
+                    ; call_type = Call
                     ; use_full_commitment = not increment_receiver
                     ; authorization_kind = None_given
                     }

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1466,7 +1466,7 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
 
       type transaction_commitment = Transaction_commitment.t
 
-      let caller (p : t) = p.body.caller
+      let is_delegate_call (p : t) = Call_type.is_delegate_call p.body.call_type
 
       let check_authorization ~commitment:_ ~calls:_ (account_update : t) =
         (* The transaction's validity should already have been checked before
@@ -2381,7 +2381,7 @@ module For_tests = struct
                         Zkapp_precondition.Protocol_state.accept
                     ; account = Nonce (Account.Nonce.succ actual_nonce)
                     }
-                ; caller = Call
+                ; call_type = Call
                 ; use_full_commitment
                 ; authorization_kind = Signature
                 }
@@ -2409,7 +2409,7 @@ module For_tests = struct
                         Zkapp_precondition.Protocol_state.accept
                     ; account = Accept
                     }
-                ; caller = Call
+                ; call_type = Call
                 ; use_full_commitment = false
                 ; authorization_kind = None_given
                 }

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -316,7 +316,7 @@ module type Account_update_intf = sig
 
   val account_id : t -> account_id
 
-  val caller : t -> token_id
+  val is_delegate_call : t -> bool
 
   val use_full_commitment : t -> bool
 
@@ -878,6 +878,7 @@ module Make (Inputs : Inputs_intf) = struct
 
   type get_next_account_update_result =
     { account_update : Account_update.t
+    ; caller_id : Token_id.t
     ; account_update_forest : Call_forest.t
     ; new_call_stack : Call_stack.t
     ; new_frame : Stack_frame.t
@@ -907,18 +908,11 @@ module Make (Inputs : Inputs_intf) = struct
     let (account_update, account_update_forest), remainder_of_current_forest =
       Call_forest.pop_exn (Stack_frame.calls current_forest)
     in
-    let account_update_caller = Account_update.caller account_update in
-    let is_normal_call =
-      Token_id.equal account_update_caller (Stack_frame.caller current_forest)
-    in
-    let () =
-      with_label ~label:"check valid caller" (fun () ->
-          let is_delegate_call =
-            Token_id.equal account_update_caller
-              (Stack_frame.caller_caller current_forest)
-          in
-          (* Check that account_update has a valid caller. *)
-          assert_ ~pos:__POS__ Bool.(is_normal_call ||| is_delegate_call) )
+    let is_delegate_call = Account_update.is_delegate_call account_update in
+    let caller_id =
+      Token_id.if_ is_delegate_call
+        ~then_:(Stack_frame.caller_caller current_forest)
+        ~else_:(Stack_frame.caller current_forest)
     in
     (* Cases:
        - [account_update_forest] is empty, [remainder_of_current_forest] is empty.
@@ -964,16 +958,21 @@ module Make (Inputs : Inputs_intf) = struct
              ~then_:newly_popped_frame ~else_:remainder_of_current_forest_frame )
         ~else_:
           (let caller =
-             Token_id.if_ is_normal_call
-               ~then_:
+             Token_id.if_ is_delegate_call
+               ~then_:(Stack_frame.caller current_forest)
+               ~else_:
                  (Account_id.derive_token_id
                     ~owner:(Account_update.account_id account_update) )
-               ~else_:(Stack_frame.caller current_forest)
-           and caller_caller = account_update_caller in
+           and caller_caller = caller_id in
            Stack_frame.make ~calls:account_update_forest ~caller ~caller_caller
           )
     in
-    { account_update; account_update_forest; new_frame; new_call_stack }
+    { account_update
+    ; caller_id
+    ; account_update_forest
+    ; new_frame
+    ; new_call_stack
+    }
 
   let update_sequence_state (sequence_state : _ Pickles_types.Vector.t) actions
       ~txn_global_slot ~last_sequence_slot =
@@ -1058,6 +1057,7 @@ module Make (Inputs : Inputs_intf) = struct
             (local_state.stack_frame, local_state.call_stack)
       in
       let { account_update
+          ; caller_id
           ; account_update_forest
           ; new_frame = remaining
           ; new_call_stack = call_stack
@@ -1076,8 +1076,7 @@ module Make (Inputs : Inputs_intf) = struct
               in
               Bool.( ||| )
                 (Token_id.equal account_update_token_id Token_id.default)
-                (Token_id.equal account_update_token_id
-                   (Account_update.caller account_update) )
+                (Token_id.equal account_update_token_id caller_id)
             in
             Local_state.add_check local_state Token_owner_not_caller
               default_token_or_token_owner_was_caller )

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -341,7 +341,7 @@ let%test_module "multisig_account" =
                         ; account = Nonce (Account.Nonce.succ sender_nonce)
                         }
                     ; use_full_commitment = false
-                    ; caller = Call
+                    ; call_type = Call
                     ; authorization_kind = Signature
                     }
                 ; authorization = Signature Signature.dummy
@@ -365,7 +365,7 @@ let%test_module "multisig_account" =
                         ; account = Full Zkapp_precondition.Account.accept
                         }
                     ; use_full_commitment = false
-                    ; caller = Call
+                    ; call_type = Call
                     ; authorization_kind = Proof
                     }
                 ; authorization = Proof Mina_base.Proof.transaction_dummy
@@ -377,7 +377,7 @@ let%test_module "multisig_account" =
                   ~account_update_depth:(fun (p : Account_update.Simple.t) ->
                     p.body.call_depth )
                   [ sender_account_update_data; snapp_account_update_data ]
-                |> Zkapp_command.Call_forest.add_callers_simple
+                |> Zkapp_command.Call_forest.map ~f:Account_update.of_simple
                 |> Zkapp_command.Call_forest.accumulate_hashes_predicated
               in
               let account_updates_hash = Zkapp_command.Call_forest.hash ps in
@@ -389,9 +389,7 @@ let%test_module "multisig_account" =
               let tx_statement : Zkapp_statement.t =
                 { account_update =
                     Account_update.Body.digest
-                      (Zkapp_command.add_caller_simple snapp_account_update_data
-                         Token_id.default )
-                        .body
+                      (Account_update.of_simple snapp_account_update_data).body
                 ; calls = (Zkapp_command.Digest.Forest.empty :> field)
                 }
               in

--- a/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
+++ b/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
@@ -195,7 +195,7 @@ let%test_module "Protocol state precondition tests" =
                             ; account = Nonce (Account.Nonce.succ sender_nonce)
                             }
                         ; use_full_commitment = false
-                        ; caller = Call
+                        ; call_type = Call
                         ; authorization_kind = Signature
                         }
                         (*To be updated later*)
@@ -227,7 +227,7 @@ let%test_module "Protocol state precondition tests" =
                                 Account_update.Account_precondition.Accept
                             }
                         ; use_full_commitment = true
-                        ; caller = Call
+                        ; call_type = Call
                         ; authorization_kind = Signature
                         }
                     ; authorization =
@@ -605,7 +605,7 @@ let%test_module "Account precondition tests" =
                         ; account = Nonce (Account.Nonce.succ sender_nonce)
                         }
                     ; use_full_commitment = false
-                    ; caller = Call
+                    ; call_type = Call
                     ; authorization_kind = Signature
                     }
                     (*To be updated later*)
@@ -634,7 +634,7 @@ let%test_module "Account precondition tests" =
                         ; account = Account_update.Account_precondition.Accept
                         }
                     ; use_full_commitment = true
-                    ; caller = Call
+                    ; call_type = Call
                     ; authorization_kind = Signature
                     }
                 ; authorization =

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -202,7 +202,7 @@ let%test_unit "ring-signature snapp tx with 3 zkapp_command" =
                         Zkapp_precondition.Protocol_state.accept
                     ; account = Nonce (Account.Nonce.succ sender_nonce)
                     }
-                ; caller = Call
+                ; call_type = Call
                 ; use_full_commitment = false
                 ; authorization_kind = Signature
                 }
@@ -226,7 +226,7 @@ let%test_unit "ring-signature snapp tx with 3 zkapp_command" =
                     ; account = Full Zkapp_precondition.Account.accept
                     }
                 ; use_full_commitment = false
-                ; caller = Call
+                ; call_type = Call
                 ; authorization_kind = Proof
                 }
             ; authorization = Proof Mina_base.Proof.transaction_dummy
@@ -246,9 +246,7 @@ let%test_unit "ring-signature snapp tx with 3 zkapp_command" =
           let tx_statement : Zkapp_statement.t =
             { account_update =
                 Account_update.Body.digest
-                  (Zkapp_command.add_caller_simple snapp_account_update_data
-                     Token_id.default )
-                    .body
+                  (Account_update.of_simple snapp_account_update_data).body
             ; calls = (Zkapp_command.Digest.Forest.empty :> field)
             }
           in

--- a/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
+++ b/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
@@ -73,7 +73,7 @@ let%test_module "Zkapp payments tests" =
                       ; account = Accept
                       }
                   ; use_full_commitment = false
-                  ; caller = Call
+                  ; call_type = Call
                   ; authorization_kind = Signature
                   }
               ; authorization = Signature Signature.dummy
@@ -94,7 +94,7 @@ let%test_module "Zkapp payments tests" =
                       ; account = Accept
                       }
                   ; use_full_commitment = false
-                  ; caller = Call
+                  ; call_type = Call
                   ; authorization_kind = None_given
                   }
               ; authorization = None_given

--- a/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
@@ -53,7 +53,7 @@ let deploy_account_update_body : Account_update.Body.t =
           Zkapp_precondition.Protocol_state.accept
       ; account = Accept
       }
-  ; caller = Token_id.default
+  ; call_type = Call
   ; use_full_commitment = true
   ; authorization_kind = Signature
   }

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -10,8 +10,8 @@ let mk_forest ps :
 let mk_node account_update calls : _ Zkapp_command.Call_forest.Tree.t =
   { account_update; account_update_digest = (); calls = mk_forest calls }
 
-let mk_account_update_body authorization_kind caller kp token_id balance_change
-    : Account_update.Body.Simple.t =
+let mk_account_update_body authorization_kind call_type kp token_id
+    balance_change : Account_update.Body.Simple.t =
   let open Signature_lib in
   { update = Account_update.Update.noop
   ; public_key = Public_key.compress kp.Keypair.public_key
@@ -31,7 +31,7 @@ let mk_account_update_body authorization_kind caller kp token_id balance_change
       ; account = Account_update.Account_precondition.Accept
       }
   ; use_full_commitment = true
-  ; caller
+  ; call_type
   ; authorization_kind
   }
 
@@ -56,8 +56,7 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
   ; account_updates =
       account_updates
       |> Zkapp_command.Call_forest.map
-           ~f:(fun (p : Account_update.Body.Simple.t) : Account_update.Simple.t
-              ->
+           ~f:(fun (p : Account_update.Body.Simple.t) : Account_update.t ->
              let authorization =
                match p.authorization_kind with
                | None_given ->
@@ -67,8 +66,7 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
                | Signature ->
                    Control.Signature Signature.dummy
              in
-             { body = p; authorization } )
-      |> Zkapp_command.Call_forest.add_callers_simple
+             { body = Account_update.Body.of_simple p; authorization } )
       |> Zkapp_command.Call_forest.accumulate_hashes_predicated
   }
 

--- a/src/lib/zkapps_examples/calls/zkapps_calls.ml
+++ b/src/lib/zkapps_examples/calls/zkapps_calls.ml
@@ -112,7 +112,7 @@ end
 (** Circuit requests, to get values and run code outside of the snark. *)
 type _ Snarky_backendless.Request.t +=
   | Public_key : Public_key.Compressed.t Snarky_backendless.Request.t
-  | Caller : Token_id.t Snarky_backendless.Request.t
+  | Call_type : Account_update.Call_type.t Snarky_backendless.Request.t
   | Old_state : Field.Constant.t Snarky_backendless.Request.t
   | (* TODO: Tweak pickles so this can be an explicit input. *)
       Get_call_input :
@@ -120,7 +120,7 @@ type _ Snarky_backendless.Request.t +=
   | Increase_amount : Field.Constant.t Snarky_backendless.Request.t
   | Delegate_call : bool Snarky_backendless.Request.t
   | Execute_call :
-      (Token_id.t * Call_data.Input.Constant.t)
+      (Account_update.Call_type.t * Call_data.Input.Constant.t)
       -> ( Call_data.Output.Constant.t
          * Zkapp_call_forest.account_update
          * Zkapp_call_forest.t )
@@ -131,7 +131,7 @@ type _ Snarky_backendless.Request.t +=
     The particular details of the called account update are determined by the handler
     for the [Execute_call] request.
 *)
-let execute_call ~caller account_update old_state =
+let execute_call ~call_type account_update old_state =
   let call_inputs = { Call_data.Input.Circuit.old_state } in
   let call_outputs, called_account_update, sub_calls =
     exists
@@ -139,9 +139,9 @@ let execute_call ~caller account_update old_state =
          (Zkapp_call_forest.Checked.account_update_typ ())
          Zkapp_call_forest.typ )
       ~request:(fun () ->
-        let caller = As_prover.read Token_id.typ caller in
+        let call_type = As_prover.read Account_update.Call_type.typ call_type in
         let input = As_prover.read Call_data.Input.typ call_inputs in
-        Execute_call (caller, input) )
+        Execute_call (call_type, input) )
   in
   let () =
     (* Check that previous account update's call data is consistent. *)
@@ -152,9 +152,10 @@ let execute_call ~caller account_update old_state =
       called_account_update.account_update.data.call_data
   in
   let () =
-    (* Check that the caller is the one that we specified *)
-    Token_id.Checked.Assert.equal caller
-      called_account_update.account_update.data.caller
+    (* Check that the call_type is the one that we specified *)
+    run_checked
+    @@ Account_update.Call_type.Checked.assert_equal call_type
+         called_account_update.account_update.data.call_type
   in
   account_update#register_call called_account_update sub_calls ;
   call_outputs.new_state
@@ -212,7 +213,7 @@ module Rules = struct
     let handler (public_key : Public_key.Compressed.t)
         (old_state : Field.Constant.t) (call_kind : Account_update.Call_type.t)
         (execute_call :
-             Token_id.t
+             Account_update.Call_type.t
           -> Call_data.Input.Constant.t
           -> Call_data.Output.Constant.t
              * Zkapp_call_forest.account_update
@@ -228,8 +229,8 @@ module Rules = struct
             match call_kind with Call -> false | Delegate_call -> true
           in
           respond (Provide delegate_call)
-      | Execute_call (caller, input) ->
-          respond (Provide (execute_call caller input))
+      | Execute_call (call_type, input) ->
+          respond (Provide (execute_call call_type input))
       | _ ->
           respond Unhandled
 
@@ -239,22 +240,14 @@ module Rules = struct
       in
       Zkapps_examples.wrap_main ~public_key
         (fun account_update ->
-          let caller =
-            let self_caller =
-              Account_id.Checked.derive_token_id
-                ~owner:
-                  (Account_id.Checked.create public_key
-                     Token_id.(Checked.constant default) )
-            in
+          let call_type =
             let delegate_call =
               exists Boolean.typ ~request:(fun () -> Delegate_call)
             in
-            Token_id.Checked.if_ delegate_call
-              ~then_:Token_id.(Checked.constant default)
-              ~else_:self_caller
+            Account_update.Call_type.Checked.from_delegate_call delegate_call
           in
           let old_state = exists Field.typ ~request:(fun () -> Old_state) in
-          let new_state = execute_call ~caller account_update old_state in
+          let new_state = execute_call ~call_type account_update old_state in
           account_update#assert_state_proved ;
           account_update#set_state 0 new_state ;
           None )
@@ -281,7 +274,8 @@ module Rules = struct
   module Add = struct
     (** The request handler for the rule. *)
     let handler (public_key : Public_key.Compressed.t)
-        (call_input : Call_data.Input.Constant.t) (caller : Token_id.t)
+        (call_input : Call_data.Input.Constant.t)
+        (call_type : Account_update.Call_type.t)
         (increase_amount : Field.Constant.t)
         (Snarky_backendless.Request.With { request; respond }) =
       match request with
@@ -291,17 +285,19 @@ module Rules = struct
           respond (Provide call_input)
       | Increase_amount ->
           respond (Provide increase_amount)
-      | Caller ->
-          respond (Provide caller)
+      | Call_type ->
+          respond (Provide call_type)
       | _ ->
           respond Unhandled
 
     let main input =
-      let caller = exists Token_id.typ ~request:(fun () -> Caller) in
+      let call_type =
+        exists Account_update.Call_type.typ ~request:(fun () -> Call_type)
+      in
       let public_key =
         exists Public_key.Compressed.typ ~request:(fun () -> Public_key)
       in
-      Zkapps_examples.wrap_main ~public_key ~caller
+      Zkapps_examples.wrap_main ~public_key ~call_type
         (fun account_update ->
           let input =
             exists Call_data.Input.typ ~request:(fun () -> Get_call_input)
@@ -344,10 +340,11 @@ module Rules = struct
     (** The request handler for the rule. *)
     let handler (public_key : Public_key.Compressed.t)
         (add_and_call_input : Call_data.Input.Constant.t)
-        (increase_amount : Field.Constant.t) (caller : Token_id.t)
+        (increase_amount : Field.Constant.t)
+        (call_type : Account_update.Call_type.t)
         (call_kind : Account_update.Call_type.t)
         (execute_call :
-             Token_id.t
+             Account_update.Call_type.t
           -> Call_data.Input.Constant.t
           -> Call_data.Output.Constant.t
              * Zkapp_call_forest.account_update
@@ -360,10 +357,10 @@ module Rules = struct
           respond (Provide add_and_call_input)
       | Increase_amount ->
           respond (Provide increase_amount)
-      | Execute_call (caller, input) ->
-          respond (Provide (execute_call caller input))
-      | Caller ->
-          respond (Provide caller)
+      | Execute_call (call_type, input) ->
+          respond (Provide (execute_call call_type input))
+      | Call_type ->
+          respond (Provide call_type)
       | Delegate_call ->
           let delegate_call =
             match call_kind with Call -> false | Delegate_call -> true
@@ -373,11 +370,13 @@ module Rules = struct
           respond Unhandled
 
     let main input =
-      let caller = exists Token_id.typ ~request:(fun () -> Caller) in
+      let call_type =
+        exists Account_update.Call_type.typ ~request:(fun () -> Call_type)
+      in
       let public_key =
         exists Public_key.Compressed.typ ~request:(fun () -> Public_key)
       in
-      Zkapps_examples.wrap_main ~public_key ~caller
+      Zkapps_examples.wrap_main ~public_key ~call_type
         (fun account_update ->
           let ({ Call_data.Input.Circuit.old_state } as call_inputs) =
             exists Call_data.Input.typ ~request:(fun () -> Get_call_input)
@@ -389,20 +388,14 @@ module Rules = struct
             exists Field.typ ~request:(fun () -> Increase_amount)
           in
           let intermediate_state = Field.add old_state increase_amount in
-          let caller =
-            let self_caller =
-              Account_id.Checked.derive_token_id
-                ~owner:
-                  (Account_id.Checked.create public_key
-                     Token_id.(Checked.constant default) )
-            in
+          let call_type =
             let delegate_call =
               exists Boolean.typ ~request:(fun () -> Delegate_call)
             in
-            Token_id.Checked.if_ delegate_call ~then_:caller ~else_:self_caller
+            Account_update.Call_type.Checked.from_delegate_call delegate_call
           in
           let new_state =
-            execute_call ~caller account_update intermediate_state
+            execute_call ~call_type account_update intermediate_state
           in
           let call_outputs =
             { Call_data.Output.Circuit.blinding_value; new_state }

--- a/src/lib/zkapps_examples/zkapps_examples.ml
+++ b/src/lib/zkapps_examples/zkapps_examples.ml
@@ -180,7 +180,7 @@ module Account_update_under_construction = struct
     type t =
       { public_key : Public_key.Compressed.var
       ; token_id : Token_id.Checked.t
-      ; caller : Token_id.Checked.t
+      ; call_type : Account_update.Call_type.Checked.t
       ; account_condition : Account_condition.t
       ; update : Update.t
       ; rev_calls :
@@ -193,10 +193,10 @@ module Account_update_under_construction = struct
       }
 
     let create ~public_key ?(token_id = Token_id.(Checked.constant default))
-        ?(caller = token_id) () =
+        ?(call_type = Account_update.Call_type.Checked.call) () =
       { public_key
       ; token_id
-      ; caller
+      ; call_type
       ; account_condition = Account_condition.create ()
       ; update = Update.create ()
       ; rev_calls = []
@@ -259,7 +259,7 @@ module Account_update_under_construction = struct
             ; account = Account_condition.to_predicate t.account_condition
             }
         ; use_full_commitment = Boolean.false_
-        ; caller = t.caller
+        ; call_type = t.call_type
         ; authorization_kind =
             { is_signed = Boolean.false_; is_proved = Boolean.true_ }
         }
@@ -302,11 +302,11 @@ module Account_update_under_construction = struct
   end
 end
 
-class account_update ~public_key ?token_id ?caller =
+class account_update ~public_key ?token_id ?call_type =
   object
     val mutable account_update =
       Account_update_under_construction.In_circuit.create ~public_key ?token_id
-        ?caller ()
+        ?call_type ()
 
     method assert_state_proved =
       account_update <-
@@ -418,9 +418,9 @@ let to_account_update (account_update : account_update) :
 open Pickles_types
 open Hlist
 
-let wrap_main ~public_key ?token_id ?caller f
+let wrap_main ~public_key ?token_id ?call_type f
     { Pickles.Inductive_rule.public_input = () } =
-  let account_update = new account_update ~public_key ?token_id ?caller in
+  let account_update = new account_update ~public_key ?token_id ?call_type in
   let auxiliary_output = f account_update in
   { Pickles.Inductive_rule.previous_proof_statements = []
   ; public_output = account_update


### PR DESCRIPTION
This PR replaces the `caller` field with `call_type` everywhere. This removes an edge case in the `Call_type.t -> Token_id.t -> Call_type.t` roundtrip where the values may be inconsistent.

This also simplifies some logic, reduces the amount of hashing that we have to do, and makes the circuit marginally smaller.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them

This fixes #12286.