### PR TITLE
Buidlkite test deps fix for GraphQL Schema and Snarky Integration tests

### DIFF
--- a/buildkite/src/Command/CheckGraphQLSchema.dhall
+++ b/buildkite/src/Command/CheckGraphQLSchema.dhall
@@ -8,7 +8,7 @@ let RunInToolchain = ./RunInToolchain.dhall in
     Command.build
       Command.Config::{
         commands =
-          RunInToolchain.runInToolchainStretch ([] : List Text)
+          RunInToolchain.runInToolchainBullseye ([] : List Text)
             "./buildkite/scripts/check-graphql-schema.sh",
         label = "Check GraphQL Schema",
         key = "check-graphql-schema",

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -84,7 +84,7 @@ in
               Cmd.run "artifact-cache-helper.sh snarkyjs_test.tar.gz && tar -xzf snarkyjs_test.tar.gz",
 
               -- Execute test based on BUILD image
-              Cmd.run "MINA_DEB_CODENAME=buster ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName}"
+              Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName}"
             ],
         artifact_paths = [SelectFiles.exactly "." "${testName}.test.log"],
         label = "${testName} integration test",

--- a/buildkite/src/Jobs/Test/CheckGraphQLSchema.dhall
+++ b/buildkite/src/Jobs/Test/CheckGraphQLSchema.dhall
@@ -6,7 +6,7 @@ let Pipeline = ../../Pipeline/Dsl.dhall
 let CheckGraphQLSchema = ../../Command/CheckGraphQLSchema.dhall
 
 let dependsOn = [
-    { name = "MinaArtifactStretch", key = "build-deb-pkg" }
+    { name = "MinaArtifactBullseye", key = "build-deb-pkg" }
 ]
 
 in Pipeline.build Pipeline.Config::{

--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -13,8 +13,8 @@ let dependsOn = [
 let dependsOnJs = [
     { name = "TestnetIntegrationTests", key = "build-test-executive" },
     { name = "TestnetIntegrationTests", key = "build-js-tests" },
-    { name = "MinaArtifactBuster", key = "daemon-devnet-buster-docker-image" },
-    { name = "MinaArtifactBuster", key = "archive-buster-docker-image" }
+    { name = "MinaArtifactBullseye", key = "daemon-devnet-bullseye-docker-image" },
+    { name = "MinaArtifactBullseye", key = "archive-bullseye-docker-image" }
 ]
 
 in Pipeline.build Pipeline.Config::{


### PR DESCRIPTION
Explain your changes:
* This PR makes changes to the dhal configurations for the `GraphQL Schema` and `Snarky Integration` tests. Currently in certain PRs these tests stick in a permanent pending state because they are waiting on older "stretch" debian builds that are no longer part of the pipeline. These tests have been updated to use newer "bullseye" Debian versions which are included and supported.

Explain how you tested your changes:
* This changed has been tested using a manual run of the Buildkite CI pipeline. The two tests correctly show updated dependencies and pass as expected.


Checklist:

- [ NA ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [X] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ NA ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [X] All tests pass (CI will check this if you didn't)
- [ NA ] Serialized types are in stable-versioned modules
- [ NA ] Does this close issues? List them

