### PR TITLE
Libp2p_ipc: remove warning 16

### DIFF
--- a/src/lib/block_storage/block_storage.ml
+++ b/src/lib/block_storage/block_storage.ml
@@ -194,7 +194,7 @@ let%test_module "Block storage tests" =
                   ~peer_protection_ratio:0.2 ~min_connections:20
                   ~max_connections:40 ~validation_queue_size:250
                   ~gating_config:empty_libp2p_ipc_gating_config
-                  ?metrics_port:None ~topic_config:[]
+                  ?metrics_port:None ~topic_config:[] ()
               in
               let%bind _ =
                 Helper.do_rpc helper

--- a/src/lib/mina_net2/mina_net2.ml
+++ b/src/lib/mina_net2/mina_net2.ml
@@ -222,7 +222,7 @@ let configure t ~me ~external_maddr ~maddrs ~network_id ~metrics_port
       ~peer_exchange ~peer_protection_ratio ~min_connections ~max_connections
       ~validation_queue_size
       ~gating_config:(gating_config_to_helper_format initial_gating_config)
-      ~topic_config
+      ~topic_config ()
   in
   let%map _ =
     Libp2p_helper.do_rpc t.helper

--- a/src/libp2p_ipc/libp2p_ipc.ml
+++ b/src/libp2p_ipc/libp2p_ipc.ml
@@ -138,7 +138,7 @@ let create_libp2p_config ~private_key ~statedir ~listen_on ?metrics_port
     ~external_multiaddr ~network_id ~unsafe_no_trust_ip ~flood ~direct_peers
     ~seed_peers ~known_private_ip_nets ~peer_exchange ~peer_protection_ratio
     ~min_connections ~max_connections ~validation_queue_size ~gating_config
-    ~topic_config =
+    ~topic_config () =
   build
     (module Builder.Libp2pConfig)
     Builder.Libp2pConfig.(

--- a/src/libp2p_ipc/libp2p_ipc.mli
+++ b/src/libp2p_ipc/libp2p_ipc.mli
@@ -71,6 +71,7 @@ val create_libp2p_config :
   -> validation_queue_size:int
   -> gating_config:gating_config
   -> topic_config:string list list
+  -> unit
   -> libp2p_config
 
 val create_gating_config :


### PR DESCRIPTION
Add an extra unit () parameter to function create_libp2p_config to avoid the emission of warning 16.

