### PR TITLE
Pad with format strings

### DIFF
--- a/src/lib/cli_lib/render.ml
+++ b/src/lib/cli_lib/render.ml
@@ -23,11 +23,20 @@ module String_list_formatter = struct
 
   let to_text pks =
     let max_padding = Int.max 1 (List.length pks) |> log10 in
-    List.mapi pks ~f:(fun i pk ->
-        let i = i + 1 in
-        let padding = String.init (max_padding - log10 i) ~f:(fun _ -> ' ') in
-        sprintf "%s%i, %s" padding i pk )
-    |> String.concat ~sep:"\n"
+    (* Create a format-string with padded integer *)
+    let fmt =
+      Scanf.format_from_string (Printf.sprintf "%%%di, %%s" max_padding) "%i%s"
+    in
+    let i = ref (-1) in
+    Format.pp_open_vbox ppf 0 ;
+    Format.pp_print_list ~pp_sep:Format.pp_print_cut
+      (fun ppf e ->
+        incr i ;
+        Format.fprintf ppf fmt !i e )
+      ppf pks ;
+    Format.pp_close_box ppf ()
+
+  let to_text pks = Format.asprintf "%a" pp pks
 end
 
 module Prove_receipt = struct

--- a/src/lib/cli_lib/render.ml
+++ b/src/lib/cli_lib/render.ml
@@ -21,7 +21,7 @@ module String_list_formatter = struct
 
   let log10 i = i |> Float.of_int |> Float.log10 |> Float.to_int
 
-  let to_text pks =
+  let pp ppf pks =
     let max_padding = Int.max 1 (List.length pks) |> log10 in
     (* Create a format-string with padded integer *)
     let fmt =
@@ -67,6 +67,6 @@ module Public_key_with_details = struct
 
   let to_text account =
     List.map account ~f:(fun (public_key, balance, nonce) ->
-        sprintf !"%s, %d, %d" public_key balance nonce )
+        sprintf "%s, %d, %d" public_key balance nonce )
     |> String.concat ~sep:"\n"
 end


### PR DESCRIPTION
Don't manually pad input with strings, use built-in specifiers in format string.