### PR TITLE
#8084 - Add Check Fee functionality for Parse Endpoint in Rosetta Construction API 

### DIFF
--- a/src/lib/rosetta_lib/transaction.ml
+++ b/src/lib/rosetta_lib/transaction.ml
@@ -24,6 +24,10 @@ module Unsigned = struct
         ; valid_until : Unsigned_extended.UInt32.t option
         }
       [@@deriving yojson]
+
+      let is_fee_sufficient (payment : t) : bool =
+        let open Currency.Fee in
+        of_uint64 payment.fee >= Mina_compile_config.minimum_user_command_fee
     end
 
     module Delegation = struct


### PR DESCRIPTION
closes #8084 Add checkfee method to ensure that when request is sent to Rosetta Parse endpoint that an error will be thrown (for both signed and unsigned transactions) if the minimum fee is too small.