### PR TITLE
Check verification key hash in `apply`

### DIFF
--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -609,8 +609,11 @@ let profile_zkapps ~verifier ledger zkapp_commands =
         let v_start_time = Time.now () in
         let%bind res =
           Verifier.verify_commands verifier
-            [ User_command.to_verifiable ~find_vk:(Zkapp_command.Verifiable.find_vk_via_ledger ~ledger ~get:Mina_ledger.Ledger.get
-                ~location_of_account:Mina_ledger.Ledger.location_of_account)
+            [ User_command.to_verifiable
+                ~find_vk:
+                  (Zkapp_command.Verifiable.find_vk_via_ledger ~ledger
+                     ~get:Mina_ledger.Ledger.get
+                     ~location_of_account:Mina_ledger.Ledger.location_of_account )
                 (Zkapp_command zkapp_command)
               |> Or_error.ok_exn
             ]

--- a/src/lib/mina_base/transaction_status.ml
+++ b/src/lib/mina_base/transaction_status.ml
@@ -46,6 +46,7 @@ module Failure = struct
         | Account_proved_state_precondition_unsatisfied
         | Account_is_new_precondition_unsatisfied
         | Protocol_state_precondition_unsatisfied
+        | Unexpected_verification_key_hash
         | Incorrect_nonce
         | Invalid_fee_excess
         | Cancelled
@@ -127,7 +128,8 @@ module Failure = struct
         List.init 8 ~f:var.constructor @ acc )
       ~account_proved_state_precondition_unsatisfied:add
       ~account_is_new_precondition_unsatisfied:add
-      ~protocol_state_precondition_unsatisfied:add ~incorrect_nonce:add
+      ~protocol_state_precondition_unsatisfied:add
+      ~unexpected_verification_key_hash:add ~incorrect_nonce:add
       ~invalid_fee_excess:add ~cancelled:add
 
   let gen = Quickcheck.Generator.of_list all
@@ -211,6 +213,8 @@ module Failure = struct
         "Account_is_new_precondition_unsatisfied"
     | Protocol_state_precondition_unsatisfied ->
         "Protocol_state_precondition_unsatisfied"
+    | Unexpected_verification_key_hash ->
+        "Unexpected_verification_key_hash"
     | Incorrect_nonce ->
         "Incorrect_nonce"
     | Invalid_fee_excess ->
@@ -295,6 +299,8 @@ module Failure = struct
         Ok Account_is_new_precondition_unsatisfied
     | "Protocol_state_precondition_unsatisfied" ->
         Ok Protocol_state_precondition_unsatisfied
+    | "Unexpected_verification_key_hash" ->
+        Ok Unexpected_verification_key_hash
     | "Incorrect_nonce" ->
         Ok Incorrect_nonce
     | "Invalid_fee_excess" ->
@@ -436,6 +442,9 @@ module Failure = struct
         "The account update's account is-new state precondition was unsatisfied"
     | Protocol_state_precondition_unsatisfied ->
         "The account update's protocol state precondition unsatisfied"
+    | Unexpected_verification_key_hash ->
+        "The account update's verification key hash does not match the \
+         verification key in the ledger account"
     | Incorrect_nonce ->
         "Incorrect nonce"
     | Invalid_fee_excess ->

--- a/src/lib/mina_ledger/dune
+++ b/src/lib/mina_ledger/dune
@@ -51,5 +51,6 @@
    quickcheck_lib
    snarky.backendless
    unsigned_extended
+   with_hash
    ppx_version.runtime
 ))

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -529,9 +529,8 @@ let%test_unit "tokens test" =
                (-(4 * account_creation_fee)) )
             []
         ; mk_node
-            (mk_account_update_body
-               (Proof (Zkapp_account.dummy_vk_hash ()))
-               Call token_owner Token_id.default (3 * account_creation_fee) )
+            (mk_account_update_body Signature Call token_owner Token_id.default
+               (3 * account_creation_fee) )
             []
         ]
     in

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -479,7 +479,7 @@ let%test_unit "tokens test" =
   in
   let main (ledger : t) =
     let execute_zkapp_command_transaction
-        (zkapp_command :
+        (account_updates :
           (Account_update.Body.Simple.t, unit, unit) Zkapp_command.Call_forest.t
           ) : unit =
       let _, ({ nonce; _ } : Account.t), _ =
@@ -487,11 +487,13 @@ let%test_unit "tokens test" =
           (Account_id.create pk Token_id.default)
         |> Or_error.ok_exn
       in
+      let zkapp_command =
+        mk_zkapp_command ~fee:7 ~fee_payer_pk:pk ~fee_payer_nonce:nonce
+          account_updates
+      in
       match
         apply_zkapp_command_unchecked ~constraint_constants ~state_view:view
-          ledger
-          (mk_zkapp_command ~fee:7 ~fee_payer_pk:pk ~fee_payer_nonce:nonce
-             zkapp_command )
+          ledger zkapp_command
       with
       | Ok ({ command = { status; _ }; _ }, _) -> (
           match status with
@@ -515,9 +517,37 @@ let%test_unit "tokens test" =
             ()
     in
     let token_funder, _ = keypair_and_amounts.(1) in
+    let token_funder_pk = token_funder.public_key |> Public_key.compress in
     let token_owner = Keypair.create () in
+    let token_owner_pk = token_owner.public_key |> Public_key.compress in
     let token_account1 = Keypair.create () in
     let token_account2 = Keypair.create () in
+    (* patch ledger so that token funder account has Proof send permission and a
+       zkapp acount dummy verification key
+
+       allows use of Proof authorization in `create_token` zkApp, below
+    *)
+    iteri ledger ~f:(fun _n acct ->
+        if Public_key.Compressed.equal acct.public_key token_funder_pk then
+          let acct_id = Account_id.create token_funder_pk Token_id.default in
+          let loc = Option.value_exn @@ location_of_account ledger acct_id in
+          let acct_with_zkapp =
+            { acct with
+              permissions =
+                { acct.permissions with send = Permissions.Auth_required.Proof }
+            ; zkapp =
+                Some
+                  { Zkapp_account.default with
+                    verification_key =
+                      Some
+                        With_hash.
+                          { data = Side_loaded_verification_key.dummy
+                          ; hash = Zkapp_account.dummy_vk_hash ()
+                          }
+                  }
+            }
+          in
+          set ledger loc acct_with_zkapp ) ;
     let account_creation_fee =
       Currency.Fee.to_nanomina_int constraint_constants.account_creation_fee
     in
@@ -525,7 +555,9 @@ let%test_unit "tokens test" =
         (Account_update.Body.Simple.t, unit, unit) Zkapp_command.Call_forest.t =
       mk_forest
         [ mk_node
-            (mk_account_update_body Signature Call token_funder Token_id.default
+            (mk_account_update_body
+               (Proof (Zkapp_account.dummy_vk_hash ()))
+               Call token_funder Token_id.default
                (-(4 * account_creation_fee)) )
             []
         ; mk_node
@@ -536,10 +568,7 @@ let%test_unit "tokens test" =
     in
     let custom_token_id =
       Account_id.derive_token_id
-        ~owner:
-          (Account_id.create
-             (Public_key.compress token_owner.public_key)
-             Token_id.default )
+        ~owner:(Account_id.create token_owner_pk Token_id.default)
     in
     let token_minting =
       mk_forest
@@ -595,10 +624,7 @@ let%test_unit "tokens test" =
     in
     execute_zkapp_command_transaction create_token ;
     (* Check that token_owner exists *)
-    ledger_get_exn ledger
-      (Public_key.compress token_owner.public_key)
-      Token_id.default
-    |> ignore ;
+    ledger_get_exn ledger token_owner_pk Token_id.default |> ignore ;
     execute_zkapp_command_transaction token_minting ;
     check_token_balance token_account1 100 ;
     execute_zkapp_command_transaction token_transfers ;

--- a/src/lib/mina_wire_types/mina_base/mina_base_transaction_status.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_transaction_status.ml
@@ -40,6 +40,7 @@ module Failure = struct
       | Account_proved_state_precondition_unsatisfied
       | Account_is_new_precondition_unsatisfied
       | Protocol_state_precondition_unsatisfied
+      | Unexpected_verification_key_hash
       | Incorrect_nonce
       | Invalid_fee_excess
       | Cancelled

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1009,6 +1009,8 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
       type t = Snark_params.Tick.Field.t
 
       let if_ = value_if
+
+      let equal = Snark_params.Tick.Field.equal
     end
 
     module Bool = struct
@@ -1214,6 +1216,12 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
       let if_ = value_if
     end
 
+    module Verification_key_hash = struct
+      type t = Field.t option
+
+      let equal vk1 vk2 = Option.equal Field.equal vk1 vk2
+    end
+
     module Actions = struct
       type t = Zkapp_account.Actions.t
 
@@ -1348,6 +1356,13 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
 
       let set_verification_key verification_key (a : t) =
         set_zkapp a ~f:(fun zkapp -> { zkapp with verification_key })
+
+      let verification_key_hash (a : t) =
+        match a.zkapp with
+        | None ->
+            None
+        | Some zkapp ->
+            Option.map zkapp.verification_key ~f:With_hash.hash
 
       let last_sequence_slot (a : t) = (get_zkapp a).last_sequence_slot
 
@@ -1493,6 +1508,13 @@ module Make (L : Ledger_intf.S) : S with type ledger := L.t = struct
             true
         | Proof _ | None_given ->
             false
+
+      let verification_key_hash (p : t) =
+        match p.body.authorization_kind with
+        | Proof vk_hash ->
+            Some vk_hash
+        | _ ->
+            None
 
       module Update = struct
         open Zkapp_basic

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -133,6 +133,14 @@ module type Global_slot_intf = sig
   val equal : t -> t -> bool
 end
 
+module type Verification_key_hash_intf = sig
+  type t
+
+  type bool
+
+  val equal : t -> t -> bool
+end
+
 module type Timing_intf = sig
   include Iffable
 
@@ -304,6 +312,8 @@ module type Account_update_intf = sig
 
   type nonce
 
+  type verification_key_hash
+
   type _ or_ignore
 
   val balance_change : t -> signed_amount
@@ -331,6 +341,8 @@ module type Account_update_intf = sig
   val is_signed : t -> bool
 
   val is_proved : t -> bool
+
+  val verification_key_hash : t -> verification_key_hash
 
   module Update : sig
     type _ set_or_keep
@@ -543,10 +555,10 @@ module type Account_intf = sig
 
   val set_receipt_chain_hash : t -> receipt_chain_hash -> t
 
-  (** Fill the snapp field of the account if it's currently [None] *)
+  (** Fill the zkapp field of the account if it's currently [None] *)
   val make_zkapp : t -> t
 
-  (** If the current account has no snapp fields set, reset its snapp field to
+  (** If the current account has no zkApp fields set, reset its zkapp field to
       [None].
   *)
   val unmake_zkapp : t -> t
@@ -568,6 +580,10 @@ module type Account_intf = sig
   val verification_key : t -> verification_key
 
   val set_verification_key : verification_key -> t -> t
+
+  type verification_key_hash
+
+  val verification_key_hash : t -> verification_key_hash
 
   val last_sequence_slot : t -> global_slot
 
@@ -690,8 +706,6 @@ module type Inputs_intf = sig
   module Timing :
     Timing_intf with type bool := Bool.t and type global_slot := Global_slot.t
 
-  module Verification_key : Iffable with type bool := Bool.t
-
   module Zkapp_uri : Iffable with type bool := Bool.t
 
   module Token_symbol : Iffable with type bool := Bool.t
@@ -704,6 +718,10 @@ module type Inputs_intf = sig
        and type transaction_commitment := Transaction_commitment.t
        and type index := Index.t)
 
+  and Verification_key : (Iffable with type bool := Bool.t)
+  and Verification_key_hash :
+    (Verification_key_hash_intf with type bool := Bool.t)
+
   and Account :
     (Account_intf
       with type Permissions.controller := Controller.t
@@ -714,6 +732,7 @@ module type Inputs_intf = sig
        and type global_slot := Global_slot.t
        and type field := Field.t
        and type verification_key := Verification_key.t
+       and type verification_key_hash := Verification_key_hash.t
        and type zkapp_uri := Zkapp_uri.t
        and type token_symbol := Token_symbol.t
        and type public_key := Public_key.t
@@ -735,6 +754,7 @@ module type Inputs_intf = sig
        and type public_key := Public_key.t
        and type nonce := Nonce.t
        and type account_id := Account_id.t
+       and type verification_key_hash := Verification_key_hash.t
        and type Update.timing := Timing.t
        and type 'a Update.set_or_keep := 'a Set_or_keep.t
        and type Update.field := Field.t
@@ -884,7 +904,7 @@ module Make (Inputs : Inputs_intf) = struct
     }
 
   let get_next_account_update (current_forest : Stack_frame.t)
-      (* The stack for the most recent snapp *)
+      (* The stack for the most recent zkApp *)
         (call_stack : Call_stack.t) (* The partially-completed parent stacks *)
       : get_next_account_update_result =
     (* If the current stack is complete, 'return' to the previous
@@ -1142,6 +1162,14 @@ module Make (Inputs : Inputs_intf) = struct
         (Account_update.token_id account_update)
         (a, inclusion_proof)
     in
+    let matching_verification_key_hashes =
+      Inputs.Bool.(
+        (not (Account_update.is_proved account_update))
+        ||| Verification_key_hash.equal
+              (Account.verification_key_hash a)
+              (Account_update.verification_key_hash account_update))
+    in
+    assert_ ~pos:__POS__ matching_verification_key_hashes ;
     let local_state =
       h.perform
         (Check_account_precondition
@@ -1334,11 +1362,11 @@ module Make (Inputs : Inputs_intf) = struct
         (* The [proved_state] tracks whether the app state has been entirely
            determined by proofs ([true] if so), to allow zkApp authors to be
            confident that their initialization logic has been run, rather than
-           some malicious deployer instantiating the snapp in an account with
+           some malicious deployer instantiating the zkApp in an account with
            some fake non-initial state.
            The logic here is:
            * if the state is unchanged, keep the previous value;
-           * if the state has been entriely replaced, and the authentication
+           * if the state has been entirely replaced, and the authentication
              was a proof, the state has been 'proved' and [proved_state] is set
              to [true];
            * if the state has been partially updated by a proof, the

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -1169,7 +1169,10 @@ module Make (Inputs : Inputs_intf) = struct
               (Account.verification_key_hash a)
               (Account_update.verification_key_hash account_update))
     in
-    assert_ ~pos:__POS__ matching_verification_key_hashes ;
+    let local_state =
+      Local_state.add_check local_state Unexpected_verification_key_hash
+        matching_verification_key_hashes
+    in
     let local_state =
       h.perform
         (Check_account_precondition

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -366,8 +366,7 @@ let%test_module "multisig_account" =
                         }
                     ; use_full_commitment = false
                     ; caller = Call
-                    ; authorization_kind =
-                        Proof (Mina_base.Zkapp_account.dummy_vk_hash ())
+                    ; authorization_kind = Proof (With_hash.hash vk)
                     }
                 ; authorization = Proof Mina_base.Proof.transaction_dummy
                 }

--- a/src/lib/transaction_snark/test/zkapps_examples/actions/actions.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/actions/actions.ml
@@ -183,81 +183,80 @@ let%test_module "Sequence events test" =
       let last_seq_slot = zkapp.last_sequence_slot in
       (Pickles_types.Vector.Vector_5.to_list seq_state, last_seq_slot)
 
-    (* let%test_unit "Initialize" =
-         let zkapp_command, account =
-           let ledger = create_ledger () in
-           []
-           |> Zkapp_command.Call_forest.cons_tree
-                Initialize_account_update.account_update
-           |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-           |> test_zkapp_command ~ledger
-         in
-         assert (Option.is_some account) ;
-         let account_updates =
-           Zkapp_command.Call_forest.to_list zkapp_command.account_updates
-         in
-         (* we haven't added any sequence events *)
-         List.iter account_updates ~f:(fun account_update ->
-             assert (List.is_empty account_update.body.actions) )
+    let%test_unit "Initialize" =
+      let zkapp_command, account =
+        let ledger = create_ledger () in
+        []
+        |> Zkapp_command.Call_forest.cons_tree
+             Initialize_account_update.account_update
+        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> test_zkapp_command ~ledger
+      in
+      assert (Option.is_some account) ;
+      let account_updates =
+        Zkapp_command.Call_forest.to_list zkapp_command.account_updates
+      in
+      (* we haven't added any sequence events *)
+      List.iter account_updates ~f:(fun account_update ->
+          assert (List.is_empty account_update.body.actions) )
 
-       let%test_unit "Initialize and add sequence events" =
-         let zkapp_command0, account0 =
-           let ledger = create_ledger () in
-           []
-           |> Zkapp_command.Call_forest.cons_tree
-                Initialize_account_update.account_update
-           |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-           |> test_zkapp_command ~ledger
-         in
-         let account_updates0 =
-           Zkapp_command.Call_forest.to_list zkapp_command0.account_updates
-         in
-         List.iter account_updates0 ~f:(fun account_update ->
-             assert (List.is_empty account_update.body.actions) ) ;
-         assert (Option.is_some account0) ;
-         (* sequence state unmodified *)
-         let seq_state_elts0, last_seq_slot0 =
-           seq_state_elts_of_account account0
-         in
-         List.iter seq_state_elts0 ~f:(fun elt ->
-             assert (
-               Impl.Field.Constant.equal elt
-                 Zkapp_account.Actions.empty_state_element ) ) ;
-         (* last seq slot is 0 *)
-         assert (Mina_numbers.Global_slot.(equal zero) last_seq_slot0) ;
-         let zkapp_command1, account1 =
-           let ledger = create_ledger () in
-           []
-           |> Zkapp_command.Call_forest.cons_tree Add_actions.account_update
-           |> Zkapp_command.Call_forest.cons_tree
-                Initialize_account_update.account_update
-           |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-           |> test_zkapp_command ~ledger
-         in
-         assert (Option.is_some account1) ;
-         let account_updates1 =
-           Zkapp_command.Call_forest.to_list zkapp_command1.account_updates
-         in
-         List.iteri account_updates1 ~f:(fun i account_update ->
-             if i > 1 then assert (not @@ List.is_empty account_update.body.actions)
-             else assert (List.is_empty account_update.body.actions) ) ;
-         let seq_state_elts1, last_seq_slot1 =
-           seq_state_elts_of_account account1
-         in
-         (* we changed the 0th sequence state element *)
-         List.iteri seq_state_elts1 ~f:(fun i elt ->
-             if i = 0 then
-               assert (
-                 not
-                 @@ Impl.Field.Constant.equal elt
-                      Zkapp_account.Actions.empty_state_element )
-             else
-               assert (
-                 Impl.Field.Constant.equal elt
-                   Zkapp_account.Actions.empty_state_element ) ) ;
-         (* last seq slot still 0 *)
-         assert (Mina_numbers.Global_slot.(equal zero) last_seq_slot1)
-    *)
+    let%test_unit "Initialize and add sequence events" =
+      let zkapp_command0, account0 =
+        let ledger = create_ledger () in
+        []
+        |> Zkapp_command.Call_forest.cons_tree
+             Initialize_account_update.account_update
+        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> test_zkapp_command ~ledger
+      in
+      let account_updates0 =
+        Zkapp_command.Call_forest.to_list zkapp_command0.account_updates
+      in
+      List.iter account_updates0 ~f:(fun account_update ->
+          assert (List.is_empty account_update.body.actions) ) ;
+      assert (Option.is_some account0) ;
+      (* sequence state unmodified *)
+      let seq_state_elts0, last_seq_slot0 =
+        seq_state_elts_of_account account0
+      in
+      List.iter seq_state_elts0 ~f:(fun elt ->
+          assert (
+            Impl.Field.Constant.equal elt
+              Zkapp_account.Actions.empty_state_element ) ) ;
+      (* last seq slot is 0 *)
+      assert (Mina_numbers.Global_slot.(equal zero) last_seq_slot0) ;
+      let zkapp_command1, account1 =
+        let ledger = create_ledger () in
+        []
+        |> Zkapp_command.Call_forest.cons_tree Add_actions.account_update
+        |> Zkapp_command.Call_forest.cons_tree
+             Initialize_account_update.account_update
+        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+        |> test_zkapp_command ~ledger
+      in
+      assert (Option.is_some account1) ;
+      let account_updates1 =
+        Zkapp_command.Call_forest.to_list zkapp_command1.account_updates
+      in
+      List.iteri account_updates1 ~f:(fun i account_update ->
+          if i > 1 then assert (not @@ List.is_empty account_update.body.actions)
+          else assert (List.is_empty account_update.body.actions) ) ;
+      let seq_state_elts1, last_seq_slot1 =
+        seq_state_elts_of_account account1
+      in
+      (* we changed the 0th sequence state element *)
+      List.iteri seq_state_elts1 ~f:(fun i elt ->
+          if i = 0 then
+            assert (
+              not
+              @@ Impl.Field.Constant.equal elt
+                   Zkapp_account.Actions.empty_state_element )
+          else
+            assert (
+              Impl.Field.Constant.equal elt
+                Zkapp_account.Actions.empty_state_element ) ) ;
+      (* last seq slot still 0 *)
+      assert (Mina_numbers.Global_slot.(equal zero) last_seq_slot1)
 
     let%test_unit "Add sequence events in different slots" =
       let make_state_body slot =

--- a/src/lib/transaction_snark/test/zkapps_examples/actions/actions.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/actions/actions.ml
@@ -95,7 +95,10 @@ let%test_module "Sequence events test" =
     end
 
     let test_zkapp_command ?expected_failure ?state_body ?(fee_payer_nonce = 0)
-        ~ledger zkapp_command =
+        ~ledger zkapp_command0 =
+      let zkapp_command =
+        Zkapps_examples.patch_verification_key_hashes ~ledger zkapp_command0
+      in
       let memo = Signed_command_memo.empty in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         let account_updates_hash =
@@ -180,80 +183,81 @@ let%test_module "Sequence events test" =
       let last_seq_slot = zkapp.last_sequence_slot in
       (Pickles_types.Vector.Vector_5.to_list seq_state, last_seq_slot)
 
-    let%test_unit "Initialize" =
-      let zkapp_command, account =
-        let ledger = create_ledger () in
-        []
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-        |> test_zkapp_command ~ledger
-      in
-      assert (Option.is_some account) ;
-      let account_updates =
-        Zkapp_command.Call_forest.to_list zkapp_command.account_updates
-      in
-      (* we haven't added any sequence events *)
-      List.iter account_updates ~f:(fun account_update ->
-          assert (List.is_empty account_update.body.actions) )
+    (* let%test_unit "Initialize" =
+         let zkapp_command, account =
+           let ledger = create_ledger () in
+           []
+           |> Zkapp_command.Call_forest.cons_tree
+                Initialize_account_update.account_update
+           |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+           |> test_zkapp_command ~ledger
+         in
+         assert (Option.is_some account) ;
+         let account_updates =
+           Zkapp_command.Call_forest.to_list zkapp_command.account_updates
+         in
+         (* we haven't added any sequence events *)
+         List.iter account_updates ~f:(fun account_update ->
+             assert (List.is_empty account_update.body.actions) )
 
-    let%test_unit "Initialize and add sequence events" =
-      let zkapp_command0, account0 =
-        let ledger = create_ledger () in
-        []
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-        |> test_zkapp_command ~ledger
-      in
-      let account_updates0 =
-        Zkapp_command.Call_forest.to_list zkapp_command0.account_updates
-      in
-      List.iter account_updates0 ~f:(fun account_update ->
-          assert (List.is_empty account_update.body.actions) ) ;
-      assert (Option.is_some account0) ;
-      (* sequence state unmodified *)
-      let seq_state_elts0, last_seq_slot0 =
-        seq_state_elts_of_account account0
-      in
-      List.iter seq_state_elts0 ~f:(fun elt ->
-          assert (
-            Impl.Field.Constant.equal elt
-              Zkapp_account.Actions.empty_state_element ) ) ;
-      (* last seq slot is 0 *)
-      assert (Mina_numbers.Global_slot.(equal zero) last_seq_slot0) ;
-      let zkapp_command1, account1 =
-        let ledger = create_ledger () in
-        []
-        |> Zkapp_command.Call_forest.cons_tree Add_actions.account_update
-        |> Zkapp_command.Call_forest.cons_tree
-             Initialize_account_update.account_update
-        |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
-        |> test_zkapp_command ~ledger
-      in
-      assert (Option.is_some account1) ;
-      let account_updates1 =
-        Zkapp_command.Call_forest.to_list zkapp_command1.account_updates
-      in
-      List.iteri account_updates1 ~f:(fun i account_update ->
-          if i > 1 then assert (not @@ List.is_empty account_update.body.actions)
-          else assert (List.is_empty account_update.body.actions) ) ;
-      let seq_state_elts1, last_seq_slot1 =
-        seq_state_elts_of_account account1
-      in
-      (* we changed the 0th sequence state element *)
-      List.iteri seq_state_elts1 ~f:(fun i elt ->
-          if i = 0 then
-            assert (
-              not
-              @@ Impl.Field.Constant.equal elt
-                   Zkapp_account.Actions.empty_state_element )
-          else
-            assert (
-              Impl.Field.Constant.equal elt
-                Zkapp_account.Actions.empty_state_element ) ) ;
-      (* last seq slot still 0 *)
-      assert (Mina_numbers.Global_slot.(equal zero) last_seq_slot1)
+       let%test_unit "Initialize and add sequence events" =
+         let zkapp_command0, account0 =
+           let ledger = create_ledger () in
+           []
+           |> Zkapp_command.Call_forest.cons_tree
+                Initialize_account_update.account_update
+           |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+           |> test_zkapp_command ~ledger
+         in
+         let account_updates0 =
+           Zkapp_command.Call_forest.to_list zkapp_command0.account_updates
+         in
+         List.iter account_updates0 ~f:(fun account_update ->
+             assert (List.is_empty account_update.body.actions) ) ;
+         assert (Option.is_some account0) ;
+         (* sequence state unmodified *)
+         let seq_state_elts0, last_seq_slot0 =
+           seq_state_elts_of_account account0
+         in
+         List.iter seq_state_elts0 ~f:(fun elt ->
+             assert (
+               Impl.Field.Constant.equal elt
+                 Zkapp_account.Actions.empty_state_element ) ) ;
+         (* last seq slot is 0 *)
+         assert (Mina_numbers.Global_slot.(equal zero) last_seq_slot0) ;
+         let zkapp_command1, account1 =
+           let ledger = create_ledger () in
+           []
+           |> Zkapp_command.Call_forest.cons_tree Add_actions.account_update
+           |> Zkapp_command.Call_forest.cons_tree
+                Initialize_account_update.account_update
+           |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
+           |> test_zkapp_command ~ledger
+         in
+         assert (Option.is_some account1) ;
+         let account_updates1 =
+           Zkapp_command.Call_forest.to_list zkapp_command1.account_updates
+         in
+         List.iteri account_updates1 ~f:(fun i account_update ->
+             if i > 1 then assert (not @@ List.is_empty account_update.body.actions)
+             else assert (List.is_empty account_update.body.actions) ) ;
+         let seq_state_elts1, last_seq_slot1 =
+           seq_state_elts_of_account account1
+         in
+         (* we changed the 0th sequence state element *)
+         List.iteri seq_state_elts1 ~f:(fun i elt ->
+             if i = 0 then
+               assert (
+                 not
+                 @@ Impl.Field.Constant.equal elt
+                      Zkapp_account.Actions.empty_state_element )
+             else
+               assert (
+                 Impl.Field.Constant.equal elt
+                   Zkapp_account.Actions.empty_state_element ) ) ;
+         (* last seq slot still 0 *)
+         assert (Mina_numbers.Global_slot.(equal zero) last_seq_slot1)
+    *)
 
     let%test_unit "Add sequence events in different slots" =
       let make_state_body slot =

--- a/src/lib/transaction_snark/test/zkapps_examples/add_events/add_events.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/add_events/add_events.ml
@@ -94,7 +94,10 @@ let%test_module "Add events test" =
              ~handler:(Zkapps_add_events.update_events_handler events) )
     end
 
-    let test_zkapp_command ?expected_failure zkapp_command =
+    let test_zkapp_command ?expected_failure zkapp_command0 =
+      let zkapp_command =
+        Zkapps_examples.patch_verification_key_hashes zkapp_command0
+      in
       let memo = Signed_command_memo.empty in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         let account_updates_hash =

--- a/src/lib/transaction_snark/test/zkapps_examples/calls/calls.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/calls/calls.ml
@@ -211,8 +211,10 @@ let%test_module "Composability test" =
         |> fst
     end
 
-    let test_zkapp_command ?expected_failure zkapp_command =
-      let memo = Signed_command_memo.empty in
+    let test_zkapp_command ?expected_failure zkapp_command0 =
+      let zkapp_command =
+        Zkapps_examples.patch_verification_key_hashes zkapp_command0
+      in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         (* TODO: This is a pain. *)
         let account_updates_hash =
@@ -229,6 +231,7 @@ let%test_module "Composability test" =
         ; authorization = Signature.dummy
         }
       in
+      let memo = Signed_command_memo.empty in
       let memo_hash = Signed_command_memo.hash memo in
       let full_commitment =
         Zkapp_command.Transaction_commitment.create_complete

--- a/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/empty_update/empty_update.ml
@@ -68,6 +68,7 @@ let account_updates =
   []
   |> Zkapp_command.Call_forest.cons_tree account_update
   |> Zkapp_command.Call_forest.cons deploy_account_update
+  |> Zkapps_examples.patch_verification_key_hashes
 
 let memo = Signed_command_memo.empty
 

--- a/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
@@ -102,7 +102,10 @@ let%test_module "Initialize state test" =
              ~handler:(Zkapps_initialize_state.update_state_handler new_state) )
     end
 
-    let test_zkapp_command ?expected_failure zkapp_command =
+    let test_zkapp_command ?expected_failure zkapp_command0 =
+      let zkapp_command =
+        Zkapps_examples.patch_verification_key_hashes zkapp_command0
+      in
       let memo = Signed_command_memo.empty in
       let transaction_commitment : Zkapp_command.Transaction_commitment.t =
         (* TODO: This is a pain. *)

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1171,6 +1171,12 @@ module Make_str (A : Wire_types.Concrete) = struct
             Zkapp_basic.Flagged_option.if_ ~if_:Data_as_hash.if_ b ~then_ ~else_
         end
 
+        module Verification_key_hash = struct
+          type t = Field.t
+
+          let equal = Field.equal
+        end
+
         module Actions = struct
           type t = Zkapp_account.Actions.var
 
@@ -1310,6 +1316,10 @@ module Make_str (A : Wire_types.Concrete) = struct
             { data = { a with zkapp = { a.zkapp with verification_key } }
             ; hash
             }
+
+          let verification_key_hash (a : t) : Verification_key_hash.t =
+            verification_key a |> Zkapp_basic.Flagged_option.data
+            |> Data_as_hash.hash
 
           let last_sequence_slot (a : t) = a.data.zkapp.last_sequence_slot
 
@@ -1914,6 +1924,9 @@ module Make_str (A : Wire_types.Concrete) = struct
 
             let is_signed ({ account_update; _ } : t) =
               account_update.data.authorization_kind.is_signed
+
+            let verification_key_hash ({ account_update; _ } : t) =
+              account_update.data.authorization_kind.verification_key_hash
 
             module Update = struct
               open Zkapp_basic

--- a/src/lib/zkapps_examples/dune
+++ b/src/lib/zkapps_examples/dune
@@ -14,6 +14,8 @@
    kimchi_pasta
    kimchi_backend.pasta.basic
    mina_base
+   mina_base.import
+   mina_ledger
    pickles
    pickles.backend
    pickles_types

--- a/src/lib/zkapps_examples/zkapps_examples.ml
+++ b/src/lib/zkapps_examples/zkapps_examples.ml
@@ -259,9 +259,10 @@ module Account_update_under_construction = struct
             ; account = Account_condition.to_predicate t.account_condition
             }
         ; use_full_commitment = Boolean.false_
-        ; caller = t.caller
+        ; caller =
+            t.caller
+            (* the vk hash is a dummy, to be patched with `patch_verification_key_hashes`, below *)
         ; authorization_kind =
-            (* TODO: is there a valid vk hash available? *)
             { is_signed = Boolean.false_
             ; is_proved = Boolean.true_
             ; verification_key_hash = Field.zero
@@ -597,3 +598,44 @@ let compile :
     go provers
   in
   (tag, cache_handle, proof, provers)
+
+(* replace dummy vk hashes in account updates *)
+let patch_verification_key_hashes ?ledger account_updates =
+  (* update vk hashes if Set in an account update *)
+  let vk_hash_tbl : Impl.field Public_key.Compressed.Table.t =
+    Public_key.Compressed.Table.create ()
+  in
+  (* if ledger provided, add vk hashes from those accounts *)
+  Option.iter ledger ~f:(fun (ledger : Mina_ledger.Ledger.t) ->
+      Mina_ledger.Ledger.iteri ledger ~f:(fun _n acct ->
+          Option.iter acct.zkapp ~f:(fun zkapp ->
+              Option.iter zkapp.verification_key ~f:(fun vk ->
+                  let pk : Public_key.Compressed.t = acct.public_key in
+                  Public_key.Compressed.Table.set vk_hash_tbl ~key:pk
+                    ~data:(With_hash.hash vk) ) ) ) ) ;
+  Zkapp_command.Call_forest.map account_updates
+    ~f:(fun (acct_update : Account_update.t) ->
+      let pk = acct_update.body.public_key in
+      let acct_update' =
+        match Public_key.Compressed.Table.find vk_hash_tbl pk with
+        | None ->
+            acct_update
+        | Some vk_hash -> (
+            match acct_update.body.authorization_kind with
+            | Proof _ ->
+                { acct_update with
+                  body =
+                    { acct_update.body with authorization_kind = Proof vk_hash }
+                }
+            | Signature | None_given ->
+                acct_update )
+      in
+      (* add entry for subsequent updates *)
+      ( match acct_update.body.update.verification_key with
+      | Set vk ->
+          let vk_hash = With_hash.hash vk in
+          Public_key.Compressed.Table.set vk_hash_tbl ~key:pk ~data:vk_hash
+      | Keep ->
+          () ) ;
+      acct_update' )
+  |> Zkapp_command.Call_forest.accumulate_hashes'


### PR DESCRIPTION
When calling `Zkapp_command_logic.apply`, for each account update, check its verification key hash against the hash in the account in the local state.

For the `Zkapps_examples` tests, each account update is given a 0 verification key hash. We patch those account updates with the hash from the corresponding account in the test ledger, if that ledger is given, and with any hashes from keys that are `Set` in preceding account updates.

Closes #12392.