### PR TITLE
Generate OCaml source maps

### DIFF
--- a/src/lib/snarky_js_bindings/dune
+++ b/src/lib/snarky_js_bindings/dune
@@ -13,7 +13,7 @@
  (modes js)
  (link_flags (-noautolink))
  (js_of_ocaml
-  (flags +toplevel.js +dynlink.js --pretty)
+  (flags +toplevel.js +dynlink.js --pretty --source-map-inline)
   (javascript_files overrides.js))
  (libraries snarky_js_bindings_lib node_backend)
  (link_deps
@@ -31,7 +31,7 @@
  (modes js)
  (link_flags (-noautolink))
  (js_of_ocaml
-  (flags +toplevel.js +dynlink.js --pretty)
+  (flags +toplevel.js +dynlink.js --pretty --source-map-inline)
   (javascript_files overrides.js))
  (libraries snarky_js_bindings_lib chrome_backend)
  (link_deps


### PR DESCRIPTION
This PR builds upon #12513, adding inline source maps for the OCaml code.

They probably shouldn't be inline, but I probably also shouldn't have had to suggest and do this :man_shrugging: 

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them