### PR TITLE
Non-inline source map for snarkyjs node build

### DIFF
--- a/buildkite/scripts/test-snarkyjs-bindings.sh
+++ b/buildkite/scripts/test-snarkyjs-bindings.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export NODE_OPTIONS="--enable-source-maps --stack-trace-limit=1000"
+
 set -eo pipefail
 source ~/.profile
 

--- a/scripts/build-snarkyjs-node.sh
+++ b/scripts/build-snarkyjs-node.sh
@@ -11,21 +11,44 @@ popd
 
 export DUNE_USE_DEFAULT_LINKER="y"
 
+if [ -f _build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.js ]; then
+  echo "found snarky_js_node.bc.js"
+  if [ -f _build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.map ]; then
+    echo "found snarky_js_node.bc.map, saving at a tmp location because dune will delete it"
+    cp _build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.map _build/snarky_js_node.bc.map ;
+  else
+    echo "did not find snarky_js_node.bc.map, deleting snarky_js_node.bc.js to force calling jsoo again"
+    rm -f _build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.js
+  fi
+fi
+
 dune b src/lib/crypto/kimchi_bindings/js/node_js \
-&& dune b src/lib/snarky_js_bindings/snarky_js_node.bc.js \
-&& dune b src/lib/snarky_js_bindings/snarkyjs/src/provable/gen/js-layout.ts \
+&& dune b src/lib/snarky_js_bindings/snarky_js_node.bc.js || exit 1
+
+# update if new source map was built
+if [ -f _build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.map ]; then
+  echo "new source map created";
+  cp "_build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.map" "_build/snarky_js_node.bc.map";
+fi
+
+dune b src/lib/snarky_js_bindings/snarkyjs/src/provable/gen/js-layout.ts \
 && dune b src/lib/snarky_js_bindings/snarkyjs/src/js_crypto/constants.ts \
   src/lib/snarky_js_bindings/snarkyjs/src/js_crypto/test_vectors/poseidonKimchi.ts \
 || exit 1
 
 BINDINGS_PATH="$SNARKY_JS_PATH"/dist/node/_node_bindings/
 mkdir -p "$BINDINGS_PATH"
+chmod -R 777 "$BINDINGS_PATH"
 cp _build/default/src/lib/crypto/kimchi_bindings/js/node_js/plonk_wasm* "$BINDINGS_PATH"
 mv -f $BINDINGS_PATH/plonk_wasm.js $BINDINGS_PATH/plonk_wasm.cjs
 cp _build/default/src/lib/snarky_js_bindings/snarky_js_node*.js "$BINDINGS_PATH"
+cp "_build/snarky_js_node.bc.map" "$BINDINGS_PATH"/snarky_js_node.bc.map
 mv -f $BINDINGS_PATH/snarky_js_node.bc.js $BINDINGS_PATH/snarky_js_node.bc.cjs
 sed -i 's/plonk_wasm.js/plonk_wasm.cjs/' $BINDINGS_PATH/snarky_js_node.bc.cjs
-chmod -R 777 "$BINDINGS_PATH"
+
+# cleanup tmp source map
+cp _build/snarky_js_node.bc.map _build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.map
+rm -f _build/snarky_js_node.bc.map
 
 # better error messages
 # TODO: find a less hacky way to make adjustments to jsoo compiler output

--- a/scripts/update-snarkyjs-bindings.sh
+++ b/scripts/update-snarkyjs-bindings.sh
@@ -1,29 +1,29 @@
+#!/bin/bash
+
+set -e
+
 SNARKY_JS_PATH=src/lib/snarky_js_bindings/snarkyjs
 
 # 1. node build
 
-dune b src/lib/crypto/kimchi_bindings/js/node_js \
-&& dune b src/lib/snarky_js_bindings/snarky_js_node.bc.js || exit 1
+./scripts/build-snarkyjs-node.sh
 
-mkdir -p "$SNARKY_JS_PATH"/dist/node/node_bindings
+BINDINGS_PATH="$SNARKY_JS_PATH"/dist/node/_node_bindings/
+cp "$BINDINGS_PATH"/snarky_js_node.bc.cjs "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.cjs
+cp "$BINDINGS_PATH"/snarky_js_node.bc.map "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.map
+
 cp _build/default/src/lib/crypto/kimchi_bindings/js/node_js/plonk_wasm* "$SNARKY_JS_PATH"/src/node_bindings/
 mv -f "$SNARKY_JS_PATH"/src/node_bindings/plonk_wasm.js "$SNARKY_JS_PATH"/src/node_bindings/plonk_wasm.cjs
-cp _build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.js "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.cjs
 sed -i 's/plonk_wasm.js/plonk_wasm.cjs/' "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.cjs
-
-# better error messages
-# TODO: find a less hacky way to make adjustments to jsoo compiler output
-# `s` is the jsoo representation of the error message string, and `s.c` is the actual JS string
-sed -i 's/function failwith(s){throw \[0,Failure,s\]/function failwith(s){throw joo_global_object.Error(s.c)/' "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.cjs
-sed -i 's/function invalid_arg(s){throw \[0,Invalid_argument,s\]/function invalid_arg(s){throw joo_global_object.Error(s.c)/' "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.cjs
-sed -i 's/return \[0,Exn,t\]/return joo_global_object.Error(t.c)/' "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.cjs
-sed -i 's/function raise(t){throw caml_call1(to_exn$0,t)}/function raise(t){throw Error(t?.[1]?.c ?? "some error")}/' "$SNARKY_JS_PATH"/src/node_bindings/snarky_js_node.bc.cjs
 
 npm run build --prefix="$SNARKY_JS_PATH"
 
 # 2. web build
 
+cp "_build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.map" "_build/snarky_js_node.bc.map"
 dune b src/lib/snarky_js_bindings/snarky_js_chrome.bc.js
+cp "_build/snarky_js_node.bc.map" "_build/default/src/lib/snarky_js_bindings/snarky_js_node.bc.map" 
+
 cp _build/default/src/lib/crypto/kimchi_bindings/js/chrome/plonk_wasm* "$SNARKY_JS_PATH"/src/chrome_bindings/
 cp _build/default/src/lib/snarky_js_bindings/snarky_js_chrome*.js "$SNARKY_JS_PATH"/src/chrome_bindings/
 

--- a/src/lib/snarky_js_bindings/dune
+++ b/src/lib/snarky_js_bindings/dune
@@ -11,9 +11,12 @@
  (name snarky_js_node)
  (modules snarky_js_node)
  (modes js)
- (link_flags (-noautolink))
+ (flags (-g))
+ (link_flags
+  (-noautolink -g))
  (js_of_ocaml
-  (flags +toplevel.js +dynlink.js --pretty)
+  (flags +toplevel.js +dynlink.js --pretty --source-map)
+  (link_flags --source-map)
   (javascript_files overrides.js))
  (libraries snarky_js_bindings_lib node_backend)
  (link_deps


### PR DESCRIPTION
This follows up on https://github.com/MinaProtocol/mina/pull/12514:
* makes the source maps not inline, but a separate file
* ship source maps in the release build, not only for development
* add `--enable-source-maps` to the snarkyjs `run` script: https://github.com/o1-labs/snarkyjs/pull/697

TODOs not addressed here:
* have an easily discoverable way of running TS files in zk-CLI projects that uses `--enable-source-maps`, so that most developers benefit from this
* source maps in the web build