### PR TITLE
Rosetta: MF takes responsibility for the project.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,6 +26,7 @@
 /src/app/archive_blocks/ @MinaProtocol/protocol-eng-reviewers
 /src/app/extract_blocks/ @MinaProtocol/protocol-eng-reviewers
 /src/app/patch_archive_test/ @MinaProtocol/protocol-eng-reviewers
+/src/app/rosetta/ @MinaProtocol/mina-foundation-eng
 
 /src/lib/ @MinaProtocol/protocol-eng-reviewers
 


### PR DESCRIPTION
Explain your changes:
* Transfer responsibility for Rosetta project from O(1) to Mina Foundation.
