### PR TITLE
Optimization: Make hashing over transactions snarks partial (ledger hashes)

### DIFF
--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -199,6 +199,48 @@ module Make_str (A : Wire_types.Concrete) = struct
       [@@deriving compare, equal, hash, sexp, yojson]
 
       let to_latest = Fn.id
+
+      (* `work_id` is computed by hashing the full statement *)
+
+      let work_id = hash
+
+      (* Override hash functions with faster partial versions.
+       * The assumption here is that the combination of source and target ledger
+       * hashes is unique enough to differentiate between statements, so
+       * there will be no clashes.
+       *)
+
+      let hash_fold_t state (t : t) =
+        let { source =
+                { first_pass_ledger = source_first_pass_ledger
+                ; second_pass_ledger = source_second_pass_ledger
+                ; pending_coinbase_stack = _
+                ; local_state = _
+                }
+            ; target =
+                { first_pass_ledger = target_first_pass_ledger
+                ; second_pass_ledger = target_second_pass_ledger
+                ; pending_coinbase_stack = _
+                ; local_state = _
+                }
+            ; connecting_ledger_left = _
+            ; connecting_ledger_right = _
+            ; supply_increase = _
+            ; fee_excess = _
+            ; sok_digest = ()
+            } =
+          t
+        in
+        let hash_fold_t hash state =
+          Frozen_ledger_hash.Stable.V1.hash_fold_t state hash
+        in
+        state
+        |> hash_fold_t source_first_pass_ledger
+        |> hash_fold_t source_second_pass_ledger
+        |> hash_fold_t target_first_pass_ledger
+        |> hash_fold_t target_second_pass_ledger
+
+      let hash = Ppx_hash_lib.Std.Hash.of_fold hash_fold_t
     end
   end]
 
@@ -288,6 +330,8 @@ module Make_str (A : Wire_types.Concrete) = struct
     input
 
   let to_field_elements t = Random_oracle.pack_input (to_input t)
+
+  let work_id = Stable.V2.work_id
 
   module Checked = struct
     type t = var

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -182,6 +182,8 @@ module type Full = sig
 
   val to_field_elements : t -> Tick.Field.t array
 
+  val work_id : t -> int
+
   module Checked : sig
     type t = var
 

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -43,7 +43,7 @@ module Statement = struct
       |> One_or_two.to_list )
 
   let work_ids t : int One_or_two.t =
-    One_or_two.map t ~f:Transaction_snark.Statement.hash
+    One_or_two.map t ~f:Transaction_snark.Statement.work_id
 end
 
 module Info = struct


### PR DESCRIPTION
(was #12321, but that PR was made against `compatible`, this one is against `develop`)

The patch submitted here was originally made and tested against the `release/2.0.0` branch (connected to berkeleynet and in a private cluster) when investigating where the node spends time when processing a block.

This is the small-patch version of this change, an alternative implementation (with a considerably bigger patch) instead defines alternative hash table and hash set modules that partially hash the transaction snark work that is used as a key.

Please let me know if there is a better way and I will look into it.

### Explain your changes:

This patch changes how transaction snark statements are hashed (as per OCaml's `hash` functions) so that only the source and target ledger hashes are used to compute the hash of the statement, instead of the full statement.

The reason is that hashing the full statement is quite expensive, and because of this the reference-count tables used in the snark pool and the snark-pool-refcount frontier extension are costly to maintain. Updating such tables accounts for a big part of the amount of the time that it takes for a node to process a block.

**A big assumption being made here is that the combination of source target ledger hash contained in the statement is unique enough (different statements will not contain the same hashes) to avoid `work_id` clashes.**
    
NOTE: This results in different `work_id` values. Also, **scan states serialized before this patch may load but will be invalid. Should I also bump the version of the serialized structure?**

### Explain how you tested your changes:

We are running two servers extended with internal tracing [here](https://openmina-tracing.web.app/tracing/blocks), one patched, and the other unpatched.

Example results for block at height 4669 on previous berkeleynet (these were taken on Dec 2nd fo 2022):

Full hash (4.32s total) |  Partial hash (1.62s total)
:-------------------------:|:-------------------------:
![full-hash-totals](https://user-images.githubusercontent.com/13744/205333488-43fd66ef-9844-4745-abd7-1b0c8dc3f20f.png)  | ![partial-hash-totals](https://user-images.githubusercontent.com/13744/205333107-0823c532-64ae-4d6e-bdf1-a1582225f372.png)

Expanded view on Snark-pool-Refcount frontier extension

Full hash (3.11s) |  Partial hash (442.23ms)
:-------------------------:|:-------------------------:
![full-hash-extensions](https://user-images.githubusercontent.com/13744/205333061-fdd823d6-1071-4d3a-8704-ffffba2836ed.png) | ![partial-hash-extensions](https://user-images.githubusercontent.com/13744/205333102-36fe614f-1839-475c-971d-5fd0a3d5b200.png)


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

