### PR TITLE
Optimization: Avoid redundant work when checking completed works

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -881,7 +881,8 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                       time ~logger ~time_controller
                         "Build breadcrumb on produced block" (fun () ->
                           Breadcrumb.build ~logger ~precomputed_values ~verifier
-                            ~trust_system ~parent:crumb ~transition
+                            ~get_completed_work:(Fn.const None) ~trust_system
+                            ~parent:crumb ~transition
                             ~sender:None (* Consider skipping `All here *)
                             ~skip_staged_ledger_verification:`Proofs
                             ~transition_receipt_time () )
@@ -1381,7 +1382,8 @@ let run_precomputed ~context:(module Context : CONTEXT) ~verifier ~trust_system
             time ~logger ~time_controller
               "Build breadcrumb on produced block (precomputed)" (fun () ->
                 Breadcrumb.build ~logger ~precomputed_values ~verifier
-                  ~trust_system ~parent:crumb ~transition ~sender:None
+                  ~get_completed_work:(Fn.const None) ~trust_system
+                  ~parent:crumb ~transition ~sender:None
                   ~skip_staged_ledger_verification:`Proofs
                   ~transition_receipt_time ()
                 |> Deferred.Result.map_error ~f:(function

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1370,7 +1370,9 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
         ~context:(module Context)
         ~trust_system ~verifier ~network ~frontier ~catchup_job_reader
         ~unprocessed_transition_cache ~catchup_breadcrumbs_writer
-        ~build_func:Transition_frontier.Breadcrumb.build )
+        ~build_func:
+          (Transition_frontier.Breadcrumb.build
+             ~get_completed_work:(Fn.const None) ) )
 
 (* Unit tests *)
 

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -459,8 +459,8 @@ let reset_frontier_dependencies_validation (transition_with_hash, validation) =
       failwith "why can't this be refuted?"
 
 let validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
-    ~precomputed_values ~verifier ~parent_staged_ledger ~parent_protocol_state
-    (t, validation) =
+    ~get_completed_work ~precomputed_values ~verifier ~parent_staged_ledger
+    ~parent_protocol_state (t, validation) =
   [%log internal] "Validate_staged_ledger_diff" ;
   let target_hash_of_ledger_proof =
     Fn.compose Registers.second_pass_ledger
@@ -486,6 +486,7 @@ let validate_staged_ledger_diff ?skip_staged_ledger_verification ~logger
                            , `Staged_ledger transitioned_staged_ledger
                            , `Pending_coinbase_update _ ) =
     Staged_ledger.apply ?skip_verification:skip_staged_ledger_verification
+      ~get_completed_work
       ~constraint_constants:
         precomputed_values.Precomputed_values.constraint_constants ~global_slot
       ~logger ~verifier parent_staged_ledger

--- a/src/lib/mina_block/validation.mli
+++ b/src/lib/mina_block/validation.mli
@@ -250,6 +250,9 @@ val reset_frontier_dependencies_validation :
 val validate_staged_ledger_diff :
      ?skip_staged_ledger_verification:[ `All | `Proofs ]
   -> logger:Logger.t
+  -> get_completed_work:
+       (   Transaction_snark_work.Statement.t
+        -> Transaction_snark_work.Checked.t option )
   -> precomputed_values:Genesis_proof.t
   -> verifier:Verifier.t
   -> parent_staged_ledger:Staged_ledger.t

--- a/src/lib/mina_intf/dune
+++ b/src/lib/mina_intf/dune
@@ -26,6 +26,7 @@
    verifier
    rose_tree
    mina_ledger
+   transaction_snark_work
    )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_version ppx_deriving.std ppx_deriving_yojson)))

--- a/src/lib/mina_intf/transition_frontier_components_intf.ml
+++ b/src/lib/mina_intf/transition_frontier_components_intf.ml
@@ -347,6 +347,9 @@ module type Transition_router_intf = sig
     -> most_recent_valid_block:
          Mina_block.initial_valid_block Broadcast_pipe.Reader.t
          * Mina_block.initial_valid_block Broadcast_pipe.Writer.t
+    -> get_completed_work:
+         (   Transaction_snark_work.Statement.t
+          -> Transaction_snark_work.Checked.t option )
     -> catchup_mode:[ `Normal | `Super ]
     -> notify_online:(unit -> unit Deferred.t)
     -> unit

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2020,6 +2020,8 @@ let create ?wallets (config : Config.t) =
                 (frontier_broadcast_pipe_r, frontier_broadcast_pipe_w)
               ~catchup_mode ~network_transition_reader:block_reader
               ~producer_transition_reader ~most_recent_valid_block
+              ~get_completed_work:
+                (Network_pool.Snark_pool.get_completed_work snark_pool)
               ~notify_online ()
           in
           let ( valid_transitions_for_network

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -279,8 +279,9 @@ let%test_module "Epoch ledger sync tests" =
             (make_dirname "persistent_frontier_location")
           ~frontier_broadcast_pipe:
             (frontier_broadcast_pipe_r, frontier_broadcast_pipe_w)
-          ~catchup_mode:`Normal ~network_transition_reader:block_reader
-          ~producer_transition_reader ~most_recent_valid_block ~notify_online ()
+          ~get_completed_work:(Fn.const None) ~catchup_mode:`Normal
+          ~network_transition_reader:block_reader ~producer_transition_reader
+          ~most_recent_valid_block ~notify_online ()
       in
       let%bind () = Ivar.read initialization_finish_signal in
       let network_peer =

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -711,22 +711,76 @@ module T = struct
     in
     (txns_with_witnesses, updated_stack1, updated_stack2, first_pass_ledger_end)
 
-  let check_completed_works ~logger ~verifier scan_state
+  (** Checks if the work has already been verified before by the snark pool logic *)
+  let work_already_verified_check ~get_completed_work jobs work =
+    let exception Statement_of_job_failure in
+    let statement_of_job_exn job =
+      Option.value_exn ~error:(Error.of_exn Statement_of_job_failure)
+      @@ Scan_state.statement_of_job job
+    in
+    try
+      let job_statements = One_or_two.map ~f:statement_of_job_exn jobs in
+      let work_statement = Transaction_snark_work.statement work in
+      let statements_match =
+        Transaction_snark_work.Statement.equal job_statements work_statement
+      in
+      let matching_completed_work_in_pool = get_completed_work work_statement in
+      match (statements_match, matching_completed_work_in_pool) with
+      | true, Some (completed_work : Transaction_snark_work.Checked.t) ->
+          let verified_proofs = completed_work.proofs in
+          let block_work_proofs = work.proofs in
+          if not @@ Fee.equal completed_work.fee work.fee then
+            Second "fee_not_equal"
+          else if not @@ Account.Key.equal completed_work.prover work.prover
+          then Second "prover_account_not_equal"
+          else if
+            not
+            @@ One_or_two.equal Ledger_proof.equal verified_proofs
+                 block_work_proofs
+          then Second "proof_not_equal"
+          else First ()
+      | _ ->
+          Second "not_found_in_pool"
+    with Statement_of_job_failure -> Second "statement_of_job_failure"
+
+  let check_completed_works ~logger ~verifier ~get_completed_work scan_state
       (completed_works : Transaction_snark_work.t list) =
     let work_count = List.length completed_works in
     let job_pairs =
       Scan_state.k_work_pairs_for_new_diff scan_state ~k:work_count
     in
+    let found_in_snarkpool_count = ref 0 in
+    let mismatch_reasons = String.Table.create ~size:10 () in
     let jmps =
       List.concat_map (List.zip_exn job_pairs completed_works)
         ~f:(fun (jobs, work) ->
-          let message = Sok_message.create ~fee:work.fee ~prover:work.prover in
-          One_or_two.(
-            to_list
-              (map (zip_exn jobs work.proofs) ~f:(fun (job, proof) ->
-                   (job, message, proof) ) )) )
+          match work_already_verified_check ~get_completed_work jobs work with
+          | First () ->
+              incr found_in_snarkpool_count ;
+              []
+          | Second reason ->
+              String.Table.incr mismatch_reasons reason ;
+              let message =
+                Sok_message.create ~fee:work.fee ~prover:work.prover
+              in
+              One_or_two.(
+                to_list
+                  (map (zip_exn jobs work.proofs) ~f:(fun (job, proof) ->
+                       (job, message, proof) ) )) )
     in
-    verify jmps ~logger ~verifier
+    [%log debug]
+      ~metadata:
+        [ ("completed_work_found_in_pool", `Int !found_in_snarkpool_count)
+        ; ( "non_skipped_reasons"
+          , `Assoc
+              (List.map (String.Table.to_alist mismatch_reasons)
+                 ~f:(fun (reason, count) -> (reason, `Int count)) ) )
+        ]
+      "check_completed_works: completed works found in SNARK pool: \
+       $completed_work_found_in_pool\n\
+      \      Non skipped work reasons: $non_skipped_reasons" ;
+    if List.is_empty jmps then Deferred.return (Ok ())
+    else verify jmps ~logger ~verifier
 
   (**The total fee excess caused by any diff should be zero. In the case where
      the slots are split into two partitions, total fee excess of the transactions
@@ -1163,8 +1217,9 @@ module T = struct
                  (Error.of_string "batch verification failed") ) ) )
 
   let apply ?skip_verification ~constraint_constants ~global_slot t
-      (witness : Staged_ledger_diff.t) ~logger ~verifier ~current_state_view
-      ~state_and_body_hash ~coinbase_receiver ~supercharge_coinbase =
+      ~get_completed_work (witness : Staged_ledger_diff.t) ~logger ~verifier
+      ~current_state_view ~state_and_body_hash ~coinbase_receiver
+      ~supercharge_coinbase =
     let open Deferred.Result.Let_syntax in
     let work = Staged_ledger_diff.completed_works witness in
     let%bind () =
@@ -1175,7 +1230,8 @@ module T = struct
           | None ->
               [%log internal] "Check_completed_works"
                 ~metadata:[ ("work_count", `Int (List.length work)) ] ;
-              check_completed_works ~logger ~verifier t.scan_state work )
+              check_completed_works ~get_completed_work ~logger ~verifier
+                t.scan_state work )
     in
     [%log internal] "Prediff" ;
     let%bind prediff =
@@ -2213,8 +2269,8 @@ let%test_module "staged ledger tests" =
               , `Pending_coinbase_update (is_new_stack, pc_update) ) =
         match%map
           Sl.apply ~constraint_constants ~global_slot !sl diff' ~logger
-            ~verifier ~current_state_view ~state_and_body_hash
-            ~coinbase_receiver ~supercharge_coinbase
+            ~verifier ~get_completed_work:(Fn.const None) ~current_state_view
+            ~state_and_body_hash ~coinbase_receiver ~supercharge_coinbase
         with
         | Ok x ->
             x
@@ -3194,7 +3250,8 @@ let%test_module "staged ledger tests" =
                     in
                     let%bind apply_res =
                       Sl.apply ~constraint_constants ~global_slot !sl diff
-                        ~logger ~verifier ~current_state_view:current_view
+                        ~logger ~verifier ~get_completed_work:(Fn.const None)
+                        ~current_state_view:current_view
                         ~state_and_body_hash:
                           ( state_hashes.state_hash
                           , state_hashes.state_body_hash |> Option.value_exn )
@@ -4221,7 +4278,8 @@ let%test_module "staged ledger tests" =
                   match%map
                     Sl.apply ~constraint_constants ~global_slot !sl
                       (Staged_ledger_diff.forget diff)
-                      ~logger ~verifier ~current_state_view ~state_and_body_hash
+                      ~logger ~verifier ~get_completed_work:(Fn.const None)
+                      ~current_state_view ~state_and_body_hash
                       ~coinbase_receiver ~supercharge_coinbase:false
                   with
                   | Ok _x ->
@@ -4513,7 +4571,8 @@ let%test_module "staged ledger tests" =
                       match%map
                         Sl.apply ~constraint_constants ~global_slot !sl
                           (Staged_ledger_diff.forget diff)
-                          ~logger ~verifier:verifier_full ~current_state_view
+                          ~get_completed_work:(Fn.const None) ~logger
+                          ~verifier:verifier_full ~current_state_view
                           ~state_and_body_hash ~coinbase_receiver
                           ~supercharge_coinbase:false
                       with

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -182,6 +182,9 @@ val apply :
   -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> global_slot:Mina_numbers.Global_slot_since_genesis.t
   -> t
+  -> get_completed_work:
+       (   Transaction_snark_work.Statement.t
+        -> Transaction_snark_work.Checked.t option )
   -> Staged_ledger_diff.t
   -> logger:Logger.t
   -> verifier:Verifier.t

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -91,7 +91,7 @@ let compute_block_trace_metadata transition_with_validation =
 let build ?skip_staged_ledger_verification ~logger ~precomputed_values ~verifier
     ~trust_system ~parent
     ~transition:(transition_with_validation : Mina_block.almost_valid_block)
-    ~sender ~transition_receipt_time () =
+    ~get_completed_work ~sender ~transition_receipt_time () =
   let state_hash =
     ( With_hash.hash
     @@ Mina_block.Validation.block_with_hash transition_with_validation )
@@ -106,7 +106,7 @@ let build ?skip_staged_ledger_verification ~logger ~precomputed_values ~verifier
       let open Deferred.Let_syntax in
       match%bind
         Validation.validate_staged_ledger_diff ?skip_staged_ledger_verification
-          ~logger ~precomputed_values ~verifier
+          ~get_completed_work ~logger ~precomputed_values ~verifier
           ~parent_staged_ledger:(staged_ledger parent)
           ~parent_protocol_state:
             ( parent.validated_transition |> Mina_block.Validated.header
@@ -478,7 +478,7 @@ module For_tests = struct
       let transition_receipt_time = Some (Time.now ()) in
       match%map
         build ~logger ~precomputed_values ~trust_system ~verifier
-          ~parent:parent_breadcrumb
+          ~get_completed_work:(Fn.const None) ~parent:parent_breadcrumb
           ~transition:
             ( next_block |> Mina_block.Validated.remember
             |> Validation.reset_staged_ledger_diff_validation )

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -35,6 +35,9 @@ val build :
   -> trust_system:Trust_system.t
   -> parent:t
   -> transition:Mina_block.almost_valid_block
+  -> get_completed_work:
+       (   Transaction_snark_work.Statement.t
+        -> Transaction_snark_work.Checked.t option )
   -> sender:Envelope.Sender.t option
   -> transition_receipt_time:Time.t option
   -> unit

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -314,7 +314,8 @@ module Instance = struct
                  ~logger:t.factory.logger ~precomputed_values
                  ~verifier:t.factory.verifier
                  ~trust_system:(Trust_system.null ()) ~parent ~transition
-                 ~sender:None ~transition_receipt_time ()
+                 ~get_completed_work:(Fn.const None) ~sender:None
+                 ~transition_receipt_time ()
              in
              let%map () = apply_diff Diff.(E (New_node (Full breadcrumb))) in
              [%log internal] "Breadcrumb_integrated" ;

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -14,8 +14,8 @@ module type CONTEXT = sig
 end
 
 let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
-    ~time_controller ~collected_transitions ~frontier ~network_transition_reader
-    ~producer_transition_reader ~clear_reader =
+    ~time_controller ~collected_transitions ~frontier ~get_completed_work
+    ~network_transition_reader ~producer_transition_reader ~clear_reader =
   let open Context in
   let valid_transition_pipe_capacity = 50 in
   let start_time = Time.now () in
@@ -120,7 +120,7 @@ let run ~context:(module Context : CONTEXT) ~trust_system ~verifier ~network
   let clean_up_catchup_scheduler = Ivar.create () in
   Transition_handler.Processor.run
     ~context:(module Context)
-    ~time_controller ~trust_system ~verifier ~frontier
+    ~time_controller ~trust_system ~verifier ~frontier ~get_completed_work
     ~primary_transition_reader ~producer_transition_reader
     ~clean_up_catchup_scheduler ~catchup_job_writer ~catchup_breadcrumbs_reader
     ~catchup_breadcrumbs_writer ~processed_transition_writer ;

--- a/src/lib/transition_handler/breadcrumb_builder.ml
+++ b/src/lib/transition_handler/breadcrumb_builder.ml
@@ -99,6 +99,7 @@ let build_subtrees_of_breadcrumbs ~logger ~precomputed_values ~verifier
                       Transition_frontier.Breadcrumb.build ~logger
                         ~precomputed_values ~verifier ~trust_system ~parent
                         ~transition:mostly_validated_transition
+                        ~get_completed_work:(Fn.const None)
                         ~sender:(Some sender) ~transition_receipt_time () )
                 with
                 | Error _ ->


### PR DESCRIPTION
The patch submitted here was originally made and tested against the `release/2.0.0` branch (connected to berkeleynet and in a private cluster) when investigating where the node spends time when processing a block.

Submitted as `Draft` for now because there are probably some tests need to be added for this change (in particular, making sure that only completed work that exactly matches the one in the block is considered as valid for skipping the verification).

The core logic is in the changes to the `src/lib/staged_ledger/staged_ledger.ml` file. The rest of the files had to be changed to make the `get_completed_work` function available to the block processing code that verifies the work included in the block. If there is a better way that doesn't require passing this around please let me know.

### Explain your changes:

When applying a block, when works are included, the biggest contributor to the time it takes to process the block is the "check completed works" step (on which the included completed works are verified).

But most of the time the completed work that needs to be verified has already been verified in the SNARK pool. This optimization takes advantage of that by comparing and filtering out all the completed works included in a block that are already present in the SNARK pool. As a result, the amount of work that needs to be verified is reduced (quite often to 0).

### Explain how you tested your changes:

We are running two servers extended with internal tracing [here](https://openmina-tracing.web.app/tracing/blocks), one unoptimized, and the other optimized (with this patch and #12521).

For block 7881, which includes 76 completed works, here are the times for the unpatched and patched nodes:

Unpatched (8.86s) / Block Total (12.03s) |  Patched (0.015s) / Block Total (1.5s)
:-------------------------:|:-------------------------:
![check-completed-works-7881-unpatched](https://user-images.githubusercontent.com/13744/213319169-3ef81327-75b5-480f-991a-49e74ffd43f2.png) | ![check-completed-works-7881-patched](https://user-images.githubusercontent.com/13744/213319226-56b51eb9-ca6d-4ba5-ba68-72ceb2685f1a.png)

For block 8024, which includes 126 completed works:

Unpatched (14.32s) / Block Total (16.49s) |  Patched (0.025s) / Block Total (1.48s)
:-------------------------:|:-------------------------:
![check-completed-works-8024-unpatched](https://user-images.githubusercontent.com/13744/213444833-7c397c46-2775-450f-9973-0b0bed809ca5.png) | ![check-completed-works-8024-patched](https://user-images.githubusercontent.com/13744/213444860-73fdcb10-79ce-4ffd-bd4e-3691d17a0ec1.png)

In these cases, and because on berkeleynet most of the works are completed by the same prover, the checks were completely skipped.

But with multiple provers, the chances of the node having in its SNARK pool a completed work matching the statement, but with a different prover or fee increases (and in such cases the work verification will not be skipped), because the node will only keep the completed work with the lowest fee (and if two works with the same fee reach the node, the first one will be kept).

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
