### PR TITLE
Return the cause of the verification error from Pickles.verify

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1679,11 +1679,12 @@ let internal_commands logger =
                 Verifier.verify_blockchain_snarks verifier input
           in
           match result with
-          | Ok true ->
+          | Ok (Ok ()) ->
               printf "Proofs verified successfully" ;
               exit 0
-          | Ok false ->
-              printf "Proofs failed to verify" ;
+          | Ok (Error err) ->
+              printf "Proofs failed to verify:\n%s\n"
+                (Yojson.Safe.pretty_to_string (Error_json.error_to_yojson err)) ;
               exit 1
           | Error err ->
               printf "Failed while verifying proofs:\n%s"

--- a/src/lib/best_tip_prover/best_tip_prover.ml
+++ b/src/lib/best_tip_prover/best_tip_prover.ml
@@ -105,17 +105,16 @@ module Make (Inputs : Inputs_intf) :
     match validation with
     | Ok block ->
         Ok block
-    | Error err ->
-        Or_error.error_string
-          ( match err with
-          | `Invalid_genesis_protocol_state ->
-              "invalid genesis state"
-          | `Invalid_protocol_version | `Mismatched_protocol_version ->
-              "invalid protocol version"
-          | `Invalid_proof ->
-              "invalid proof"
-          | `Verifier_error e ->
-              Printf.sprintf "verifier error: %s" (Error.to_string_hum e) )
+    | Error err -> (
+        match err with
+        | `Invalid_genesis_protocol_state ->
+            Or_error.error_string "invalid genesis state"
+        | `Invalid_protocol_version | `Mismatched_protocol_version ->
+            Or_error.error_string "invalid protocol version"
+        | `Invalid_proof e ->
+            Error (Error.tag ~tag:"invalid proof" e)
+        | `Verifier_error e ->
+            Error (Error.tag ~tag:"verifier proof" e) )
 
   let verify ~verifier ~genesis_constants ~precomputed_values
       { Proof_carrying_data.data = best_tip; proof = merkle_list, root } =

--- a/src/lib/blockchain_snark/blockchain_snark_state.mli
+++ b/src/lib/blockchain_snark/blockchain_snark_state.mli
@@ -23,7 +23,7 @@ type tag =
 val verify :
      (Protocol_state.Value.t * Proof.t) list
   -> key:Pickles.Verification_key.t
-  -> bool Async.Deferred.t
+  -> unit Or_error.t Async.Deferred.t
 
 val check :
      Witness.t

--- a/src/lib/ledger_catchup/normal_catchup.ml
+++ b/src/lib/ledger_catchup/normal_catchup.ml
@@ -505,12 +505,12 @@ let verify_transitions_and_build_breadcrumbs ~context:(module Context : CONTEXT)
              ledger catchup: $error" ;
           Deferred.Or_error.fail
             (Error.tag ~tag:"verifier threw an error" error)
-      | Error `Invalid_proof ->
+      | Error (`Invalid_proof err) ->
           let%map () =
             (* TODO: Isolate and punish all the evil sender *)
             Deferred.unit
           in
-          Error (Error.of_string "invalid proof")
+          Error (Error.tag ~tag:"invalid proof" err)
     in
     let verification_end_time = Core.Time.now () in
     [%log debug]

--- a/src/lib/mina_block/validation.ml
+++ b/src/lib/mina_block/validation.ml
@@ -338,16 +338,16 @@ let validate_proofs ~verifier ~genesis_state_hash tvs =
     match to_verify with
     | [] ->
         (* Skip calling the verifier, nothing here to verify. *)
-        return (Ok true)
+        return (Ok (Ok ()))
     | _ ->
         Verifier.verify_blockchain_snarks verifier to_verify
   with
-  | Ok verified ->
-      if verified then
-        Ok
-          (List.map tvs ~f:(fun (t, validation) ->
-               (t, Unsafe.set_valid_proof validation) ) )
-      else Error `Invalid_proof
+  | Ok (Ok ()) ->
+      Ok
+        (List.map tvs ~f:(fun (t, validation) ->
+             (t, Unsafe.set_valid_proof validation) ) )
+  | Ok (Error err) ->
+      Error (`Invalid_proof err)
   | Error e ->
       Error (`Verifier_error e)
 

--- a/src/lib/mina_block/validation.mli
+++ b/src/lib/mina_block/validation.mli
@@ -113,7 +113,7 @@ val validate_proofs :
   -> genesis_state_hash:State_hash.t
   -> ('a, 'b, [ `Proof ] * unit Truth.false_t, 'c, 'd, 'e, 'f) with_block list
   -> ( ('a, 'b, [ `Proof ] * unit Truth.true_t, 'c, 'd, 'e, 'f) with_block list
-     , [> `Invalid_proof | `Verifier_error of Error.t ] )
+     , [> `Invalid_proof of Error.t | `Verifier_error of Error.t ] )
      Deferred.Result.t
 
 val validate_single_proof :
@@ -121,7 +121,7 @@ val validate_single_proof :
   -> genesis_state_hash:State_hash.t
   -> ('a, 'b, [ `Proof ] * unit Truth.false_t, 'c, 'd, 'e, 'f) with_block
   -> ( ('a, 'b, [ `Proof ] * unit Truth.true_t, 'c, 'd, 'e, 'f) with_block
-     , [> `Invalid_proof | `Verifier_error of Error.t ] )
+     , [> `Invalid_proof of Error.t | `Verifier_error of Error.t ] )
      Deferred.Result.t
 
 val skip_proof_validation :

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -37,7 +37,7 @@ type ('init, 'partially_validated, 'result) t =
          [ `Init of 'init | `Partially_validated of 'partially_validated ] list
       -> [ `Valid of 'result
          | Verifier.invalid
-         | `Potentially_invalid of 'partially_validated ]
+         | `Potentially_invalid of 'partially_validated * Error.t ]
          list
          Deferred.Or_error.t
         [@sexp.opaque]
@@ -65,7 +65,10 @@ let call_verifier t (ps : 'proof list) = t.verifier ps
 let rec determine_outcome :
     type p r partial.
        (p, r) elt list
-    -> [ `Valid of r | `Potentially_invalid of partial | Verifier.invalid ] list
+    -> [ `Valid of r
+       | `Potentially_invalid of partial * Error.t
+       | Verifier.invalid ]
+       list
     -> (p, partial, r) t
     -> unit Deferred.Or_error.t =
  fun ps res v ->
@@ -90,28 +93,28 @@ let rec determine_outcome :
                   [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
                 Ivar.fill elt.res (Ok (Error (`Invalid_signature keys))) ;
                 None
-            | `Invalid_proof ->
+            | `Invalid_proof err ->
                 if Ivar.is_full elt.res then
                   [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-                Ivar.fill elt.res (Ok (Error `Invalid_proof)) ;
+                Ivar.fill elt.res (Ok (Error (`Invalid_proof err))) ;
                 None
             | `Missing_verification_key keys ->
                 if Ivar.is_full elt.res then
                   [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
                 Ivar.fill elt.res (Ok (Error (`Missing_verification_key keys))) ;
                 None
-            | `Potentially_invalid new_hint ->
-                Some (elt, new_hint) )
+            | `Potentially_invalid (new_hint, err) ->
+                Some (elt, new_hint, err) )
       in
       let open Deferred.Or_error.Let_syntax in
       match potentially_invalid with
       | [] ->
           (* All results are known *)
           return ()
-      | [ ({ res; _ }, _) ] ->
+      | [ ({ res; _ }, _, err) ] ->
           if Ivar.is_full res then
             [%log' error (Logger.create ())] "Ivar.fill bug is here!" ;
-          Ivar.fill res (Ok (Error `Invalid_proof)) ;
+          Ivar.fill res (Ok (Error (`Invalid_proof err))) ;
           (* If there is a potentially invalid proof in this batch of size 1, then
              that proof is itself invalid. *)
           return ()
@@ -119,10 +122,10 @@ let rec determine_outcome :
           let outcome xs =
             let%bind res_xs =
               call_verifier v
-                (List.map xs ~f:(fun (_e, new_hint) ->
+                (List.map xs ~f:(fun (_e, new_hint, _) ->
                      `Partially_validated new_hint ) )
             in
-            determine_outcome (List.map xs ~f:fst) res_xs v
+            determine_outcome (List.map xs ~f:(fun (e, _, _) -> e)) res_xs v
           in
           let length = List.length potentially_invalid in
           let left, right = List.split_n potentially_invalid (length / 2) in
@@ -329,14 +332,14 @@ module Transaction_pool = struct
                 | `Missing_verification_key keys ->
                     (* Invalidate the whole diff *)
                     result.(i) <- `Missing_verification_key keys
-                | `Invalid_proof ->
+                | `Invalid_proof err ->
                     (* Invalidate the whole diff *)
-                    result.(i) <- `Invalid_proof
+                    result.(i) <- `Invalid_proof err
                 | `Valid_assuming xs -> (
                     match result.(i) with
                     | `Invalid_keys _
                     | `Invalid_signature _
-                    | `Invalid_proof
+                    | `Invalid_proof _
                     | `Missing_verification_key _ ->
                         (* If this diff has already been declared invalid, knowing that one of its
                            transactions is partially valid is not useful. *)
@@ -349,7 +352,7 @@ module Transaction_pool = struct
                     match result.(i) with
                     | `Invalid_keys _
                     | `Invalid_signature _
-                    | `Invalid_proof
+                    | `Invalid_proof _
                     | `Missing_verification_key _ ->
                         ()
                     | `In_progress a ->
@@ -359,8 +362,8 @@ module Transaction_pool = struct
                   `Invalid_keys keys
               | `Invalid_signature keys ->
                   `Invalid_signature keys
-              | `Invalid_proof ->
-                  `Invalid_proof
+              | `Invalid_proof err ->
+                  `Invalid_proof err
               | `Missing_verification_key keys ->
                   `Missing_verification_key keys
               | `In_progress a -> (
@@ -371,13 +374,14 @@ module Transaction_pool = struct
                       `Valid res
                   | None ->
                       `Potentially_invalid
-                        (list_of_array_map a ~f:(function
-                          | `Unknown ->
-                              assert false
-                          | `Valid c ->
-                              `Valid c
-                          | `Valid_assuming (v, xs) ->
-                              `Valid_assuming (v, xs) ) ) ) ) ) )
+                        ( list_of_array_map a ~f:(function
+                            | `Unknown ->
+                                assert false
+                            | `Valid c ->
+                                `Valid c
+                            | `Valid_assuming (v, xs) ->
+                                `Valid_assuming (v, xs) )
+                        , Error.of_string "In progress" ) ) ) ) )
 
   let verify (t : t) = verify t
 end
@@ -418,11 +422,11 @@ module Snark_pool = struct
         let open Deferred.Or_error.Let_syntax in
         let%map result = Verifier.verify_transaction_snarks verifier ps in
         match result with
-        | true ->
+        | Ok () ->
             List.map ps0 ~f:(fun _ -> `Valid ())
-        | false ->
+        | Error err ->
             List.map ps0 ~f:(function `Partially_validated env | `Init env ->
-                `Potentially_invalid env ) )
+                `Potentially_invalid (env, err) ) )
 
   module Work_key = struct
     module T = struct

--- a/src/lib/network_pool/batcher.mli
+++ b/src/lib/network_pool/batcher.mli
@@ -24,7 +24,7 @@ val create :
   -> ?max_weight_per_call:int
   -> (   [ `Init of 'init | `Partially_validated of 'partially_validated ] list
       -> [ `Valid of 'result
-         | `Potentially_invalid of 'partially_validated
+         | `Potentially_invalid of 'partially_validated * Error.t
          | Verifier.invalid ]
          list
          Deferred.Or_error.t )

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1081,10 +1081,10 @@ struct
                 ] ;
             Deferred.return (Error (Error.tag e ~tag:"Internal_error"))
         | Ok (Error invalid) ->
-            let msg = Verifier.invalid_to_string invalid in
+            let err = Verifier.invalid_to_error invalid in
             [%log' error t.logger]
               "Batch verification failed when adding from gossip"
-              ~metadata:[ ("error", `String msg) ] ;
+              ~metadata:[ ("error", Error_json.error_to_yojson err) ] ;
             let%map.Deferred () =
               Trust_system.record_envelope_sender t.config.trust_system t.logger
                 (Envelope.Incoming.sender diff)
@@ -1093,7 +1093,7 @@ struct
                     ( "rejecting command because had invalid signature or proof"
                     , [] ) )
             in
-            Error Error.(tag (of_string msg) ~tag:"Verification_failed")
+            Error (Error.tag err ~tag:"Verification_failed")
         | Ok (Ok commands) ->
             (* TODO: avoid duplicate hashing (#11706) *)
             O1trace.sync_thread "hashing_transactions_after_verification"

--- a/src/lib/pickles/pickles_intf.ml
+++ b/src/lib/pickles/pickles_intf.ml
@@ -68,9 +68,9 @@ module type S = sig
 
     val id : Verification_key.Id.t Lazy.t
 
-    val verify : (statement * t) list -> bool Deferred.t
+    val verify : (statement * t) list -> unit Or_error.t Deferred.t
 
-    val verify_promise : (statement * t) list -> bool Promise.t
+    val verify_promise : (statement * t) list -> unit Or_error.t Promise.t
   end
 
   module Proof : sig
@@ -242,14 +242,14 @@ module type S = sig
     -> (module Statement_value_intf with type t = 'a)
     -> Verification_key.t
     -> ('a * ('n, 'n) Proof.t) list
-    -> bool Promise.t
+    -> unit Or_error.t Promise.t
 
   val verify :
        (module Nat.Intf with type n = 'n)
     -> (module Statement_value_intf with type t = 'a)
     -> Verification_key.t
     -> ('a * ('n, 'n) Proof.t) list
-    -> bool Deferred.t
+    -> unit Or_error.t Deferred.t
 
   module Prover : sig
     type ('prev_values, 'local_widths, 'local_heights, 'a_value, 'proof) t =
@@ -340,12 +340,12 @@ module type S = sig
     val verify_promise :
          typ:('var, 'value) Impls.Step.Typ.t
       -> (Verification_key.t * 'value * Proof.t) list
-      -> bool Promise.t
+      -> unit Or_error.t Promise.t
 
     val verify :
          typ:('var, 'value) Impls.Step.Typ.t
       -> (Verification_key.t * 'value * Proof.t) list
-      -> bool Deferred.t
+      -> unit Or_error.t Deferred.t
 
     (* Must be called in the inductive rule snarky function defining a
        rule for which this tag is used as a predecessor. *)

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -39,8 +39,9 @@ let verify_heterogenous (ts : Instance.t list) =
           Ok ()
       | _ ->
           Error
-            (String.concat ~sep:"\n"
-               (List.map !r ~f:(fun lab -> Lazy.force lab)) )
+            ( Error.tag ~tag:"Pickles.verify"
+            @@ Error.of_list
+            @@ List.map !r ~f:(fun lab -> Error.of_string (Lazy.force lab)) )
     in
     ((fun (lab, b) -> if not b then r := lab :: !r), result)
   in
@@ -323,12 +324,7 @@ let verify_heterogenous (ts : Instance.t list) =
                        .old_bulletproof_challenges ) ) ) ) )
   in
   Common.time "dlog_check" (fun () -> check (lazy "dlog_check", dlog_check)) ;
-  match result () with
-  | Ok () ->
-      true
-  | Error e ->
-      eprintf !"bad verify: %s\n%!" e ;
-      false
+  result ()
 
 let verify (type a return_typ n)
     (max_proofs_verified : (module Nat.Intf with type n = n))

--- a/src/lib/pickles/verify.mli
+++ b/src/lib/pickles/verify.mli
@@ -1,3 +1,5 @@
+open Core_kernel
+
 module Instance : sig
   type t =
     | T :
@@ -14,6 +16,6 @@ val verify :
   -> (module Intf.Statement_value with type t = 'a)
   -> Verification_key.t
   -> ('a * ('n, 'n) Proof.t) list
-  -> bool Promise.t
+  -> unit Or_error.t Promise.t
 
-val verify_heterogenous : Instance.t list -> bool Promise.t
+val verify_heterogenous : Instance.t list -> unit Or_error.t Promise.t

--- a/src/lib/prover/dune
+++ b/src/lib/prover/dune
@@ -51,4 +51,4 @@
  )
  (preprocessor_deps "../../config.mlh")
  (instrumentation (backend bisect_ppx))
- (preprocess (pps ppx_mina ppx_version ppx_jane)))
+ (preprocess (pps ppx_mina ppx_version ppx_jane ppx_bin_prot)))

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -51,7 +51,7 @@ module Worker_state = struct
       -> Pending_coinbase_witness.t
       -> Blockchain.t Async.Deferred.Or_error.t
 
-    val verify : Protocol_state.Value.t -> Proof.t -> bool Deferred.t
+    val verify : Protocol_state.Value.t -> Proof.t -> unit Or_error.t Deferred.t
   end
 
   (* bin_io required by rpc_parallel *)
@@ -176,7 +176,7 @@ module Worker_state = struct
                        "Prover threw an error while extending block: $error" ) ;
                  Async.Deferred.return res
 
-               let verify _state _proof = Deferred.return true
+               let verify _state _proof = Deferred.return (Ok ())
              end : S )
          | None ->
              ( module struct
@@ -190,7 +190,7 @@ module Worker_state = struct
                          ~proof:Mina_base.Proof.blockchain_dummy
                          ~state:next_state )
 
-               let verify _ _ = Deferred.return true
+               let verify _ _ = Deferred.return (Ok ())
              end : S )
        in
        Memory_stats.log_memory_stats logger ~process:"prover" ;
@@ -230,7 +230,8 @@ module Functions = struct
           pending_coinbase )
 
   let verify_blockchain =
-    create Blockchain.Stable.Latest.bin_t bin_bool (fun w chain ->
+    create Blockchain.Stable.Latest.bin_t
+      [%bin_type_class: unit Core_kernel.Or_error.Stable.V2.t] (fun w chain ->
         let (module W) = Worker_state.get w in
         W.verify
           (Blockchain_snark.Blockchain.state chain)
@@ -245,7 +246,7 @@ module Worker = struct
       { initialized : ('w, unit, [ `Initialized ]) F.t
       ; extend_blockchain :
           ('w, Extend_blockchain_input.t, Blockchain.t Or_error.t) F.t
-      ; verify_blockchain : ('w, Blockchain.t, bool) F.t
+      ; verify_blockchain : ('w, Blockchain.t, unit Or_error.t) F.t
       }
 
     module Worker_state = Worker_state

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -2292,7 +2292,8 @@ let pickles_compile (choices : pickles_rule_js Js.js_array Js.t)
   let verify (public_input_js : public_input_js) (proof : _ Pickles.Proof.t) =
     let public_input = Public_input.(public_input_js |> of_js |> to_constant) in
     Proof.verify_promise [ (public_input, proof) ]
-    |> Promise.map ~f:Js.bool |> Promise_js_helpers.to_js
+    |> Promise.map ~f:(fun x -> Js.bool (Or_error.is_ok x))
+    |> Promise_js_helpers.to_js
   in
   object%js
     val provers = Obj.magic provers
@@ -2360,7 +2361,8 @@ let verify (public_input : public_input_js) (proof : proof)
           (Error.to_string_hum err) ()
   in
   Pickles.Side_loaded.verify_promise ~typ [ (vk, public_input, proof) ]
-  |> Promise.map ~f:Js.bool |> Promise_js_helpers.to_js
+  |> Promise.map ~f:(fun x -> Js.bool (Or_error.is_ok x))
+  |> Promise_js_helpers.to_js
 
 let dummy_base64_proof () =
   let n2 = Pickles_types.Nat.N2.n in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -29,6 +29,7 @@ module T = struct
           * Transaction_snark.Statement.t
           * Mina_base.Sok_message.t )
           list
+          * Error.t
       | Couldn't_reach_verifier of Error.t
       | Pre_diff of Pre_diff_info.Error.t
       | Insufficient_work of string
@@ -53,16 +54,19 @@ module T = struct
           Format.asprintf
             !"Pre_diff_info.Error error: %{sexp:Pre_diff_info.Error.t}"
             pre_diff_error
-      | Invalid_proofs ts ->
+      | Invalid_proofs (ts, err) ->
           Format.asprintf
             !"Verification failed for proofs with (statement, work_id, \
               prover): %{sexp: (Transaction_snark.Statement.t * int * string) \
-              list}\n"
+              list}\n\
+              Error:\n\
+              %s"
             (List.map ts ~f:(fun (_p, s, m) ->
                  ( s
                  , Transaction_snark.Statement.hash s
                  , Yojson.Safe.to_string
                    @@ Public_key.Compressed.to_yojson m.prover ) ) )
+            (Yojson.Safe.pretty_to_string (Error_json.error_to_yojson err))
       | Insufficient_work str ->
           str
       | Mismatched_statuses (transaction, status) ->
@@ -176,10 +180,11 @@ module T = struct
           |> to_staged_ledger_or_error )
     | Some proof_statement_msgs -> (
         match%map verify_proofs ~logger ~verifier proof_statement_msgs with
-        | Ok true ->
+        | Ok (Ok ()) ->
             Ok ()
-        | Ok false ->
-            Error (Staged_ledger_error.Invalid_proofs proof_statement_msgs)
+        | Ok (Error err) ->
+            Error
+              (Staged_ledger_error.Invalid_proofs (proof_statement_msgs, err))
         | Error e ->
             Error (Couldn't_reach_verifier e) )
 
@@ -187,7 +192,7 @@ module T = struct
     include Scan_state.Make_statement_scanner (struct
       type t = unit
 
-      let verify ~verifier:() _proofs = Deferred.Or_error.return true
+      let verify ~verifier:() _proofs = Deferred.Or_error.return (Ok ())
     end)
   end
 
@@ -1039,13 +1044,12 @@ module T = struct
             Ok x
         | ( `Invalid_keys _
           | `Invalid_signature _
-          | `Invalid_proof
+          | `Invalid_proof _
           | `Missing_verification_key _ ) as invalid ->
             Error
               (Verifier.Failure.Verification_failed
-                 (Error.of_string
-                    (sprintf "verification failed on command, %s"
-                       (Verifier.invalid_to_string invalid) ) ) )
+                 (Error.tag ~tag:"verification failed on command"
+                    (Verifier.invalid_to_error invalid) ) )
         | `Valid_assuming _ ->
             Error
               (Verifier.Failure.Verification_failed

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -69,6 +69,7 @@ module Staged_ledger_error : sig
         * Transaction_snark.Statement.t
         * Mina_base.Sok_message.t )
         list
+        * Error.t
     | Couldn't_reach_verifier of Error.t
     | Pre_diff of Pre_diff_info.Error.t
     | Insufficient_work of string

--- a/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
+++ b/src/lib/transaction_snark/test/transaction_union/transaction_union.ml
@@ -537,10 +537,11 @@ let%test_module "Transaction union tests" =
               in
               Async.Thread_safe.block_on_async (fun () ->
                   T.verify_against_digest proof13 )
-              |> Result.ok_exn ) )
+              |> Result.ok_exn |> Or_error.ok_exn ) )
 
-    let%test "base_and_merge: transactions in one block (t1,t2 in b1), \
-              carryforward the state from a previous transaction t0 in b1" =
+    let%test_unit "base_and_merge: transactions in one block (t1,t2 in b1), \
+                   carryforward the state from a previous transaction t0 in b1"
+        =
       let state_hash_and_body1 = (state_body_hash, state_body) in
       test_base_and_merge ~state_hash_and_body1
         ~state_hash_and_body2:state_hash_and_body1 ~carryforward1:true
@@ -548,16 +549,17 @@ let%test_module "Transaction union tests" =
 
     (* No new state body, carryforward the stack from the previous transaction*)
 
-    let%test "base_and_merge: transactions in one block (t1,t2 in b1), don't \
-              carryforward the state from a previous transaction t0 in b1" =
+    let%test_unit "base_and_merge: transactions in one block (t1,t2 in b1), \
+                   don't carryforward the state from a previous transaction t0 \
+                   in b1" =
       let state_hash_and_body1 = (state_body_hash, state_body) in
       test_base_and_merge ~state_hash_and_body1
         ~state_hash_and_body2:state_hash_and_body1 ~carryforward1:false
         ~carryforward2:true
 
-    let%test "base_and_merge: transactions in two different blocks (t1,t2 in \
-              b1, b2 resp.), carryforward the state from a previous \
-              transaction t0 in b1" =
+    let%test_unit "base_and_merge: transactions in two different blocks (t1,t2 \
+                   in b1, b2 resp.), carryforward the state from a previous \
+                   transaction t0 in b1" =
       let state_hash_and_body1 =
         let open Staged_ledger_diff in
         let state_body0 =
@@ -578,9 +580,9 @@ let%test_module "Transaction union tests" =
 
     (*t2 is in a new state, therefore do not carryforward the previous state*)
 
-    let%test "base_and_merge: transactions in two different blocks (t1,t2 in \
-              b1, b2 resp.), don't carryforward the state from a previous \
-              transaction t0 in b1" =
+    let%test_unit "base_and_merge: transactions in two different blocks (t1,t2 \
+                   in b1, b2 resp.), don't carryforward the state from a \
+                   previous transaction t0 in b1" =
       let state_hash_and_body1 =
         let state_body0 =
           let open Staged_ledger_diff in

--- a/src/lib/transaction_snark/test/verify-simple-test/transaction_snark_tests_verify_simple_test.ml
+++ b/src/lib/transaction_snark/test/verify-simple-test/transaction_snark_tests_verify_simple_test.ml
@@ -31,6 +31,7 @@ let%test_module "Simple verifies test" =
 
     let () = Pickles.Side_loaded.srs_precomputation ()
 
-    let%test "Verifies" =
-      Async.Thread_safe.block_on_async_exn (fun () -> verify ())
+    let%test_unit "Verifies" =
+      Or_error.ok_exn
+      @@ Async.Thread_safe.block_on_async_exn (fun () -> verify ())
   end )

--- a/src/lib/transaction_snark/test/zkapps_examples/big_circuit/big_circuit.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/big_circuit/big_circuit.ml
@@ -48,7 +48,7 @@ let deploy_account_update_body : Account_update.Body.t =
       ; account = Accept
       ; valid_while = Ignore
       }
-  ; call_type = Call
+  ; may_use_token = No
   ; use_full_commitment = true
   ; authorization_kind = Signature
   }

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3536,13 +3536,13 @@ module Make_str (A : Wire_types.Concrete) = struct
     module type S = sig
       val tag : tag
 
-      val verify : (t * Sok_message.t) list -> bool Async.Deferred.t
+      val verify : (t * Sok_message.t) list -> unit Or_error.t Async.Deferred.t
 
       val id : Pickles.Verification_key.Id.t Lazy.t
 
       val verification_key : Pickles.Verification_key.t Lazy.t
 
-      val verify_against_digest : t -> bool Async.Deferred.t
+      val verify_against_digest : t -> unit Or_error.t Async.Deferred.t
 
       val constraint_system_digests : (string * Md5_lib.t) list Lazy.t
     end
@@ -3712,7 +3712,10 @@ module Make_str (A : Wire_types.Concrete) = struct
         (module Statement.With_sok)
         key
         (List.map ts ~f:(fun ({ statement; proof }, _) -> (statement, proof)))
-    else Async.return false
+    else
+      Async.return
+        (Or_error.error_string
+           "Transaction_snark.verify: Mismatched sok_message" )
 
   let constraint_system_digests ~constraint_constants () =
     let digest = Tick.R1CS_constraint_system.digest in
@@ -4129,7 +4132,10 @@ module Make_str (A : Wire_types.Concrete) = struct
       then
         Proof.verify
           (List.map ts ~f:(fun ({ statement; proof }, _) -> (statement, proof)))
-      else Async.return false
+      else
+        Async.return
+          (Or_error.error_string
+             "Transaction_snark.verify: Mismatched sok_message" )
 
     let first_account_update
         (witness : Transaction_witness.Zkapp_command_segment_witness.t) =

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -230,19 +230,19 @@ module type Full = sig
   val verify :
        (t * Sok_message.t) list
     -> key:Pickles.Verification_key.t
-    -> bool Async.Deferred.t
+    -> unit Or_error.t Async.Deferred.t
 
   module Verification : sig
     module type S = sig
       val tag : tag
 
-      val verify : (t * Sok_message.t) list -> bool Async.Deferred.t
+      val verify : (t * Sok_message.t) list -> unit Or_error.t Async.Deferred.t
 
       val id : Pickles.Verification_key.Id.t Lazy.t
 
       val verification_key : Pickles.Verification_key.t Lazy.t
 
-      val verify_against_digest : t -> bool Async.Deferred.t
+      val verify_against_digest : t -> unit Or_error.t Async.Deferred.t
 
       val constraint_system_digests : (string * Md5_lib.t) list Lazy.t
     end

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -296,7 +296,7 @@ end
 module Make_statement_scanner (Verifier : sig
   type t
 
-  val verify : verifier:t -> P.t list -> bool Deferred.Or_error.t
+  val verify : verifier:t -> P.t list -> unit Or_error.t Deferred.Or_error.t
 end) =
 struct
   module Fold = Parallel_scan.State.Make_foldable (Deferred)
@@ -512,10 +512,10 @@ struct
         Deferred.return (Error `Empty)
     | Ok (Some (res, proofs), _) -> (
         match%map.Deferred Verifier.verify ~verifier proofs with
-        | Ok true ->
+        | Ok (Ok ()) ->
             Ok res
-        | Ok false ->
-            Error (`Error (Error.of_string "Bad proofs"))
+        | Ok (Error err) ->
+            Error (`Error (Error.tag ~tag:"Verifier issue" err))
         | Error e ->
             Error (`Error e) )
     | Error e ->

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -48,7 +48,7 @@ module Make_statement_scanner (Verifier : sig
   val verify :
        verifier:t
     -> Ledger_proof_with_sok_message.t list
-    -> bool Deferred.Or_error.t
+    -> unit Or_error.t Deferred.Or_error.t
 end) : sig
   val scan_statement :
        constraint_constants:Genesis_constants.Constraint_constants.t

--- a/src/lib/verifier/common.ml
+++ b/src/lib/verifier/common.ml
@@ -5,12 +5,12 @@ type invalid =
   [ `Invalid_keys of Signature_lib.Public_key.Compressed.Stable.Latest.t list
   | `Invalid_signature of
     Signature_lib.Public_key.Compressed.Stable.Latest.t list
-  | `Invalid_proof
+  | `Invalid_proof of (Error.t[@to_yojson Error_json.error_to_yojson])
   | `Missing_verification_key of
     Signature_lib.Public_key.Compressed.Stable.Latest.t list ]
 [@@deriving bin_io_unversioned, to_yojson]
 
-let invalid_to_string (invalid : invalid) =
+let invalid_to_error (invalid : invalid) : Error.t =
   let keys_to_string keys =
     List.map keys ~f:(fun key ->
         Signature_lib.Public_key.Compressed.to_base58_check key )
@@ -18,13 +18,13 @@ let invalid_to_string (invalid : invalid) =
   in
   match invalid with
   | `Invalid_keys keys ->
-      sprintf "Invalid_keys: [%s]" (keys_to_string keys)
+      Error.createf "Invalid_keys: [%s]" (keys_to_string keys)
   | `Invalid_signature keys ->
-      sprintf "Invalid_signature: [%s]" (keys_to_string keys)
+      Error.createf "Invalid_signature: [%s]" (keys_to_string keys)
   | `Missing_verification_key keys ->
-      sprintf "Missing_verification_key: [%s]" (keys_to_string keys)
-  | `Invalid_proof ->
-      "Invalid_proof"
+      Error.createf "Missing_verification_key: [%s]" (keys_to_string keys)
+  | `Invalid_proof err ->
+      Error.tag ~tag:"Invalid_proof" err
 
 let check :
        User_command.Verifiable.t

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -9,7 +9,7 @@ type t =
 
 type invalid = Common.invalid [@@deriving bin_io_unversioned, to_yojson]
 
-let invalid_to_string = Common.invalid_to_string
+let invalid_to_error = Common.invalid_to_error
 
 type ledger_proof = Ledger_proof.t
 
@@ -20,7 +20,7 @@ let create ~logger:_ ~proof_level ~constraint_constants ~pids:_ ~conf_dir:_ =
   | Check | None ->
       Deferred.return { proof_level; constraint_constants }
 
-let verify_blockchain_snarks _ _ = Deferred.Or_error.return true
+let verify_blockchain_snarks _ _ = Deferred.Or_error.return (Ok ())
 
 (* N.B.: Valid_assuming is never returned, in fact; we assert a return type
    containing Valid_assuming to match the expected type
@@ -45,8 +45,8 @@ let verify_commands _ (cs : User_command.Verifiable.t list) :
           `Invalid_keys keys
       | `Invalid_signature keys ->
           `Invalid_signature keys
-      | `Invalid_proof ->
-          `Invalid_proof
+      | `Invalid_proof err ->
+          `Invalid_proof err
       | `Missing_verification_key keys ->
           `Missing_verification_key keys )
   |> Deferred.Or_error.return
@@ -58,12 +58,16 @@ let verify_transaction_snarks _ ts =
      This is particularly used to test that invalid proofs are not added to the
      snark pool
   *)
-  List.for_all ts ~f:(fun (proof, message) ->
-      let msg_digest = Sok_message.digest message in
-      let sok_digest = Transaction_snark.sok_digest proof in
-      Sok_message.Digest.(equal sok_digest default)
-      || Mina_base.Sok_message.Digest.equal sok_digest msg_digest )
-  |> Deferred.Or_error.return
+  if
+    List.for_all ts ~f:(fun (proof, message) ->
+        let msg_digest = Sok_message.digest message in
+        let sok_digest = Transaction_snark.sok_digest proof in
+        Sok_message.Digest.(equal sok_digest default)
+        || Mina_base.Sok_message.Digest.equal sok_digest msg_digest )
+  then Deferred.Or_error.return (Ok ())
+  else
+    Deferred.Or_error.return
+      (Or_error.error_string "Transaction_snark.verify: Mismatched sok_message")
 
 let get_blockchain_verification_key { proof_level; constraint_constants } =
   Deferred.Or_error.try_with (fun () ->

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -8,14 +8,14 @@ open Blockchain_snark
 
 type invalid = Common.invalid [@@deriving bin_io_unversioned, to_yojson]
 
-let invalid_to_string = Common.invalid_to_string
+let invalid_to_error = Common.invalid_to_error
 
 type ledger_proof = Ledger_proof.Prod.t
 
 module Worker_state = struct
   module type S = sig
     val verify_blockchain_snarks :
-      (Protocol_state.Value.t * Proof.t) list -> bool Deferred.t
+      (Protocol_state.Value.t * Proof.t) list -> unit Or_error.t Deferred.t
 
     val verify_commands :
          Mina_base.User_command.Verifiable.t list
@@ -30,7 +30,7 @@ module Worker_state = struct
          Deferred.t
 
     val verify_transaction_snarks :
-      (Transaction_snark.t * Sok_message.t) list -> bool Deferred.t
+      (Transaction_snark.t * Sok_message.t) list -> unit Or_error.t Deferred.t
 
     val get_blockchain_verification_key : unit -> Pickles.Verification_key.t
   end
@@ -78,7 +78,7 @@ module Worker_state = struct
                        xs
                    | `Invalid_keys _
                    | `Invalid_signature _
-                   | `Invalid_proof
+                   | `Invalid_proof _
                    | `Missing_verification_key _ ->
                        [] )
                in
@@ -89,13 +89,14 @@ module Worker_state = struct
                  | `Valid c ->
                      `Valid c
                  | `Valid_assuming (c, xs) ->
-                     if all_verified then `Valid c else `Valid_assuming xs
+                     if Or_error.is_ok all_verified then `Valid c
+                     else `Valid_assuming xs
                  | `Invalid_keys keys ->
                      `Invalid_keys keys
                  | `Invalid_signature keys ->
                      `Invalid_signature keys
-                 | `Invalid_proof ->
-                     `Invalid_proof
+                 | `Invalid_proof err ->
+                     `Invalid_proof err
                  | `Missing_verification_key keys ->
                      `Missing_verification_key keys )
 
@@ -130,15 +131,15 @@ module Worker_state = struct
                        `Invalid_keys keys
                    | `Invalid_signature keys ->
                        `Invalid_signature keys
-                   | `Invalid_proof ->
-                       `Invalid_proof
+                   | `Invalid_proof err ->
+                       `Invalid_proof err
                    | `Missing_verification_key keys ->
                        `Missing_verification_key keys )
                |> Deferred.return
 
-             let verify_blockchain_snarks _ = Deferred.return true
+             let verify_blockchain_snarks _ = Deferred.return (Ok ())
 
-             let verify_transaction_snarks _ = Deferred.return true
+             let verify_transaction_snarks _ = Deferred.return (Ok ())
 
              let vk =
                lazy
@@ -167,9 +168,9 @@ module Worker = struct
     module F = Rpc_parallel.Function
 
     type 'w functions =
-      { verify_blockchains : ('w, Blockchain.t list, bool) F.t
+      { verify_blockchains : ('w, Blockchain.t list, unit Or_error.t) F.t
       ; verify_transaction_snarks :
-          ('w, (Transaction_snark.t * Sok_message.t) list, bool) F.t
+          ('w, (Transaction_snark.t * Sok_message.t) list, unit Or_error.t) F.t
       ; verify_commands :
           ( 'w
           , User_command.Verifiable.t list
@@ -228,7 +229,7 @@ module Worker = struct
         { verify_blockchains =
             f
               ( [%bin_type_class: Blockchain.Stable.Latest.t list]
-              , Bool.bin_t
+              , [%bin_type_class: unit Or_error.t]
               , verify_blockchains )
         ; verify_transaction_snarks =
             f
@@ -236,7 +237,7 @@ module Worker = struct
                   ( Transaction_snark.Stable.Latest.t
                   * Sok_message.Stable.Latest.t )
                   list]
-              , Bool.bin_t
+              , [%bin_type_class: unit Or_error.t]
               , verify_transaction_snarks )
         ; verify_commands =
             f
@@ -502,11 +503,17 @@ let verify_transaction_snarks { worker; logger } ts =
               ~f:Worker.functions.verify_transaction_snarks ~arg:ts
             |> Deferred.Or_error.map ~f:(fun x -> `Continue x) )
       in
+      let res_json =
+        match res with
+        | Ok (Ok ()) ->
+            `String "ok"
+        | Error err ->
+            Error_json.error_to_yojson (Error.tag ~tag:"Verifier issue" err)
+        | Ok (Error err) ->
+            Error_json.error_to_yojson err
+      in
       [%log trace] "verify $n transaction_snarks (after)!"
-        ~metadata:
-          ( ( "result"
-            , `String (Sexp.to_string ([%sexp_of: bool Or_error.t] res)) )
-          :: metadata ) ;
+        ~metadata:(("result", res_json) :: metadata) ;
       res )
 
 let verify_commands { worker; logger } ts =

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -10,12 +10,12 @@ module Base = struct
     type invalid =
       [ `Invalid_keys of Signature_lib.Public_key.Compressed.t list
       | `Invalid_signature of Signature_lib.Public_key.Compressed.t list
-      | `Invalid_proof
+      | `Invalid_proof of Error.t
       | `Missing_verification_key of Signature_lib.Public_key.Compressed.t list
       ]
     [@@deriving bin_io, to_yojson]
 
-    val invalid_to_string : invalid -> string
+    val invalid_to_error : invalid -> Error.t
 
     val verify_commands :
          t
@@ -33,12 +33,14 @@ module Base = struct
          Deferred.Or_error.t
 
     val verify_blockchain_snarks :
-      t -> Blockchain_snark.Blockchain.t list -> bool Or_error.t Deferred.t
+         t
+      -> Blockchain_snark.Blockchain.t list
+      -> unit Or_error.t Or_error.t Deferred.t
 
     val verify_transaction_snarks :
          t
       -> (ledger_proof * Mina_base.Sok_message.t) list
-      -> bool Or_error.t Deferred.t
+      -> unit Or_error.t Or_error.t Deferred.t
 
     val get_blockchain_verification_key :
       t -> Pickles.Verification_key.t Or_error.t Deferred.t


### PR DESCRIPTION
This PR tweaks `Pickles.verify` to return a `unit Or_error.t`, to make it easier to debug proof failures (e.g. in https://github.com/MinaProtocol/mina/pull/12342).

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them