### PR TITLE
Test executive: log the actual error, work spec from snark work failures

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -489,10 +489,17 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
     ; implement Snark_worker.Rpcs_versioned.Failed_to_generate_snark.Latest.rpc
         (fun
           ()
-          ((_work_spec, _prover_pk) :
-            Snark_worker.Work.Spec.t * Signature_lib.Public_key.Compressed.t )
+          ((error, work_spec, prover_public_key) :
+            Error.t
+            * Snark_worker.Work.Spec.t
+            * Signature_lib.Public_key.Compressed.t )
         ->
-          [%str_log error] Snark_worker.Generating_snark_work_failed ;
+          [%str_log error]
+            (Snark_worker.Generating_snark_work_failed
+               { error = Error_json.error_to_yojson error
+               ; work_spec
+               ; prover_public_key
+               } ) ;
           Mina_metrics.(Counter.inc_one Snark_work.snark_work_failed_rpc) ;
           Deferred.unit )
     ]

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -629,9 +629,12 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           Deferred.return `Continue )
     in
     let snark_work_failure_subscription =
-      Event_router.on (event_router t) Snark_work_failed ~f:(fun _ _ ->
+      Event_router.on (event_router t) Snark_work_failed ~f:(fun _ failure ->
           [%log error]
-            "A snark worker encountered an error while creating a proof" ;
+            "A snark worker encountered an error while creating a proof: \
+             $failure"
+            ~metadata:
+              [ ("failure", Event_type.Snark_work_failed.to_yojson failure) ] ;
           Deferred.return `Continue )
     in
     let%bind () =

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -343,7 +343,12 @@ module Gossip = struct
 end
 
 module Snark_work_failed = struct
-  type t = unit [@@deriving yojson]
+  type t =
+    { error : Yojson.Safe.t
+    ; work_spec : Snark_worker.Work.Spec.t
+    ; prover_public_key : Signature_lib.Public_key.Compressed.t
+    }
+  [@@deriving yojson]
 
   let name = "Snark_work_failed"
 
@@ -352,8 +357,9 @@ module Snark_work_failed = struct
   let parse_func message =
     let open Or_error.Let_syntax in
     match%bind parse id message with
-    | Snark_worker.Generating_snark_work_failed ->
-        Ok ()
+    | Snark_worker.Generating_snark_work_failed
+        { error; work_spec; prover_public_key } ->
+        Ok { error; work_spec; prover_public_key }
     | _ ->
         bad_parse
 

--- a/src/lib/integration_test_lib/event_type.mli
+++ b/src/lib/integration_test_lib/event_type.mli
@@ -122,7 +122,11 @@ module Gossip : sig
 end
 
 module Snark_work_failed : sig
-  type t = unit
+  type t =
+    { error : Yojson.Safe.t
+    ; work_spec : Snark_worker.Work.Spec.t
+    ; prover_public_key : Signature_lib.Public_key.Compressed.t
+    }
 
   include Event_type_intf with type t := t
 end

--- a/src/lib/mina_base/sparse_ledger_base.mli
+++ b/src/lib/mina_base/sparse_ledger_base.mli
@@ -9,7 +9,7 @@ module Stable : sig
       , Account_id.Stable.V2.t
       , Account.Stable.V2.t )
       Sparse_ledger_lib.Sparse_ledger.T.Stable.V2.t
-    [@@deriving sexp, to_yojson]
+    [@@deriving sexp, yojson]
 
     val to_latest : t -> t
   end

--- a/src/lib/snark_work_lib/work.ml
+++ b/src/lib/snark_work_lib/work.ml
@@ -23,7 +23,7 @@ module Single = struct
           ('witness, 'ledger_proof) Stable.Latest.t =
       | Transition of Transaction_snark.Statement.t * 'witness
       | Merge of Transaction_snark.Statement.t * 'ledger_proof * 'ledger_proof
-    [@@deriving sexp, to_yojson]
+    [@@deriving sexp, yojson]
 
     let witness (t : (_, _) t) =
       match t with Transition (_, witness) -> Some witness | Merge _ -> None
@@ -80,7 +80,7 @@ module Spec = struct
 
   type 'single t = 'single Stable.Latest.t =
     { instances : 'single One_or_two.t; fee : Currency.Fee.t }
-  [@@deriving fields, sexp, to_yojson]
+  [@@deriving fields, sexp, yojson]
 end
 
 module Result = struct

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -18,6 +18,7 @@
    async.async_command
    base.base_internalhash_types
    ppx_hash.runtime-lib
+   result
    async_unix
    bin_prot.shape
    ;; local libraries

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -68,7 +68,7 @@ module Make (Inputs : Intf.Inputs_intf) :
     module Single = struct
       module Spec = struct
         type t = (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t
-        [@@deriving sexp, to_yojson]
+        [@@deriving sexp, yojson]
 
         let transaction t =
           Option.map (Work.Single.Spec.witness t) ~f:(fun w ->
@@ -79,7 +79,7 @@ module Make (Inputs : Intf.Inputs_intf) :
     end
 
     module Spec = struct
-      type t = Single.Spec.t Work.Spec.t [@@deriving sexp, to_yojson]
+      type t = Single.Spec.t Work.Spec.t [@@deriving sexp, yojson]
 
       let instances = Work.Spec.instances
     end
@@ -305,7 +305,7 @@ module Make (Inputs : Intf.Inputs_intf) :
               let%bind () =
                 match%map
                   dispatch Rpcs_versioned.Failed_to_generate_snark.Latest.rpc
-                    shutdown_on_disconnect (work, public_key) daemon_address
+                    shutdown_on_disconnect (e, work, public_key) daemon_address
                 with
                 | Error e ->
                     [%log error]

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -66,12 +66,12 @@ module type Work_S = sig
   module Single : sig
     module Spec : sig
       type t = (Transaction_witness.t, ledger_proof) Work.Single.Spec.t
-      [@@deriving sexp, to_yojson]
+      [@@deriving sexp, yojson]
     end
   end
 
   module Spec : sig
-    type t = Single.Spec.t Work.Spec.t [@@deriving sexp, to_yojson]
+    type t = Single.Spec.t Work.Spec.t [@@deriving sexp, yojson]
   end
 
   module Result : sig
@@ -113,7 +113,7 @@ module type Rpcs_versioned_S = sig
 
   module Failed_to_generate_snark : sig
     module V2 : sig
-      type query = Work.Spec.t * Signature_lib.Public_key.Compressed.t
+      type query = Error.t * Work.Spec.t * Signature_lib.Public_key.Compressed.t
       [@@deriving bin_io]
 
       type response = unit [@@deriving bin_io]
@@ -146,7 +146,7 @@ module type S0 = sig
     module Failed_to_generate_snark :
       Rpc_master
         with type Master.T.query =
-          Work.Spec.t * Signature_lib.Public_key.Compressed.t
+          Error.t * Work.Spec.t * Signature_lib.Public_key.Compressed.t
          and type Master.T.response = unit
   end
 

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -1,3 +1,4 @@
+open Core_kernel
 open Async
 open Signature_lib
 
@@ -66,7 +67,9 @@ module Make (Inputs : Intf.Inputs_intf) = struct
 
       module T = struct
         type query =
-          (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t Work.Spec.t
+          Error.t
+          * (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t
+            Work.Spec.t
           * Public_key.Compressed.t
 
         type response = unit

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -2,11 +2,17 @@ module Prod = Prod
 module Intf = Intf
 module Inputs = Prod.Inputs
 
-type Structured_log_events.t += Generating_snark_work_failed
-  [@@deriving register_event { msg = "Failed to generate SNARK work" }]
-
 module Worker = struct
   include Functor.Make (Inputs)
+
+  type Structured_log_events.t +=
+    | Generating_snark_work_failed of
+        { error : Yojson.Safe.t
+        ; work_spec : Work.Spec.t
+        ; prover_public_key : Signature_lib.Public_key.Compressed.t (* FOO *)
+        }
+    [@@deriving
+      register_event { msg = "Failed to generate SNARK work: $error" }]
 
   module Rpcs_versioned = struct
     open Core_kernel
@@ -85,10 +91,11 @@ module Worker = struct
       module V2 = struct
         module T = struct
           type query =
-            ( Transaction_witness.Stable.V2.t
-            , Inputs.Ledger_proof.Stable.V2.t )
-            Snark_work_lib.Work.Single.Spec.Stable.V2.t
-            Snark_work_lib.Work.Spec.Stable.V1.t
+            Core_kernel.Error.Stable.V2.t
+            * ( Transaction_witness.Stable.V2.t
+              , Inputs.Ledger_proof.Stable.V2.t )
+              Snark_work_lib.Work.Single.Spec.Stable.V2.t
+              Snark_work_lib.Work.Spec.Stable.V1.t
             * Public_key.Compressed.Stable.V1.t
 
           type response = unit

--- a/src/lib/snark_worker/snark_worker.mli
+++ b/src/lib/snark_worker/snark_worker.mli
@@ -1,8 +1,13 @@
-type Structured_log_events.t += Generating_snark_work_failed
-  [@@deriving register_event]
-
 module Prod = Prod
 
 module Intf : module type of Intf
 
 include Intf.S with type ledger_proof := Ledger_proof.t
+
+type Structured_log_events.t +=
+  | Generating_snark_work_failed of
+      { error : Yojson.Safe.t
+      ; work_spec : Work.Spec.t
+      ; prover_public_key : Signature_lib.Public_key.Compressed.t
+      }
+  [@@deriving register_event]

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -41,7 +41,7 @@ module Zkapp_command_segment_witness = struct
         ; init_stack : Mina_base.Pending_coinbase.Stack_versioned.Stable.V1.t
         ; block_global_slot : Mina_numbers.Global_slot.Stable.V1.t
         }
-      [@@deriving sexp, to_yojson]
+      [@@deriving sexp, yojson]
 
       let to_latest = Fn.id
     end
@@ -59,7 +59,7 @@ module Stable = struct
       ; status : Mina_base.Transaction_status.Stable.V2.t
       ; block_global_slot : Mina_numbers.Global_slot.Stable.V1.t
       }
-    [@@deriving sexp, to_yojson]
+    [@@deriving sexp, yojson]
 
     let to_latest = Fn.id
   end

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -56,6 +56,6 @@ module Stable : sig
       ; status : Mina_base.Transaction_status.Stable.V2.t
       ; block_global_slot : Mina_numbers.Global_slot.Stable.V1.t
       }
-    [@@deriving sexp, to_yojson]
+    [@@deriving sexp, yojson]
   end
 end]


### PR DESCRIPTION
This PR breaks out a commit from #12342, as part of the effort to home in on the CI failure there.

This tweaks the test executive to give more details about the actual error and the snark work statement when we see a prover failure.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them