### PR TITLE
Revert to having fee payer possibly bundled with another update

### DIFF
--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -3795,16 +3795,16 @@ module Make_str (A : Wire_types.Concrete) = struct
           let target_first_pass_ledger_root =
             Sparse_ledger.merkle_root target_global.first_pass_ledger
           in
-          (* 1. empty ledger hash in the local state at the beginning of each
-             transaction
-             `zkapp_command` in local state is empty for the first segment
-             2. Target ledger for the first segment (fee payer segment) gets replaced with second pass ledger and so use the target global first pass ledger*)
-          let source_local_ledger, target_local_ledger =
-            if Zkapp_command.Call_forest.is_empty source_local.stack_frame.calls
-            then (Frozen_ledger_hash.empty_hash, target_first_pass_ledger_root)
-            else
-              ( Sparse_ledger.merkle_root source_local.ledger
-              , Sparse_ledger.merkle_root target_local.ledger )
+          (* Empty ledger hash in the local state at the beginning of each
+             transaction`zkapp_command` in local state is empty for the first
+             segment
+          *)
+          let fee_payer_segment =
+            Zkapp_command.Call_forest.is_empty source_local.stack_frame.calls
+          in
+          let source_local_ledger_hash =
+            if fee_payer_segment then Frozen_ledger_hash.empty_hash
+            else Sparse_ledger.merkle_root source_local.ledger
           in
           { source =
               { first_pass_ledger =
@@ -3817,7 +3817,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                     stack_frame =
                       Stack_frame.Digest.create source_local.stack_frame
                   ; call_stack = call_stack_hash source_local.call_stack
-                  ; ledger = source_local_ledger
+                  ; ledger = source_local_ledger_hash
                   }
               }
           ; target =
@@ -3830,7 +3830,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                     stack_frame =
                       Stack_frame.Digest.create target_local.stack_frame
                   ; call_stack = call_stack_hash target_local.call_stack
-                  ; ledger = target_local_ledger
+                  ; ledger = Sparse_ledger.merkle_root target_local.ledger
                   }
               }
           ; connecting_ledger_left = connecting_ledger


### PR DESCRIPTION
#12554 does the first pass to second pass ledger transition (in the local state) within the zkapp application logic and so fee payers can be combined with another update when generating snarks 

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
