### PR TITLE
Trivial: fix snark work logging in test_executive

### DIFF
--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -624,8 +624,13 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
         ~f:Fn.id
     in
     let snark_work_event_subscription =
-      Event_router.on (event_router t) Snark_work_gossip ~f:(fun _ _ ->
-          [%log info] "Received new snark work" ;
+      Event_router.on (event_router t) Snark_work_gossip
+        ~f:(fun _ (_, direction) ->
+          ( match direction with
+          | Sent ->
+              ()
+          | Received ->
+              [%log info] "Received new snark work" ) ;
           Deferred.return `Continue )
     in
     let snark_work_failure_subscription =

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -308,7 +308,7 @@ module Gossip = struct
           { work; sender = _ } ->
           Ok ({ work }, Direction.Received)
       | Mina_networking.Gossip_snark_pool_diff { work } ->
-          Ok ({ work }, Direction.Received)
+          Ok ({ work }, Direction.Sent)
       | _ ->
           bad_parse
 


### PR DESCRIPTION
This PR fixes a bug where outgoing snark work was logged as incoming snark work in the test executive.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them