### PR TITLE
Trivial: fix snark work failure logging in test executive

### DIFF
--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -489,17 +489,14 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
     ; implement Snark_worker.Rpcs_versioned.Failed_to_generate_snark.Latest.rpc
         (fun
           ()
-          ((error, work_spec, prover_public_key) :
+          ((error, _work_spec, _prover_public_key) :
             Error.t
             * Snark_worker.Work.Spec.t
             * Signature_lib.Public_key.Compressed.t )
         ->
           [%str_log error]
             (Snark_worker.Generating_snark_work_failed
-               { error = Error_json.error_to_yojson error
-               ; work_spec
-               ; prover_public_key
-               } ) ;
+               { error = Error_json.error_to_yojson error } ) ;
           Mina_metrics.(Counter.inc_one Snark_work.snark_work_failed_rpc) ;
           Deferred.unit )
     ]

--- a/src/lib/integration_test_lib/event_type.ml
+++ b/src/lib/integration_test_lib/event_type.ml
@@ -343,12 +343,7 @@ module Gossip = struct
 end
 
 module Snark_work_failed = struct
-  type t =
-    { error : Yojson.Safe.t
-    ; work_spec : Snark_worker.Work.Spec.t
-    ; prover_public_key : Signature_lib.Public_key.Compressed.t
-    }
-  [@@deriving yojson]
+  type t = { error : Yojson.Safe.t } [@@deriving yojson]
 
   let name = "Snark_work_failed"
 
@@ -357,9 +352,8 @@ module Snark_work_failed = struct
   let parse_func message =
     let open Or_error.Let_syntax in
     match%bind parse id message with
-    | Snark_worker.Generating_snark_work_failed
-        { error; work_spec; prover_public_key } ->
-        Ok { error; work_spec; prover_public_key }
+    | Snark_worker.Generating_snark_work_failed { error } ->
+        Ok { error }
     | _ ->
         bad_parse
 

--- a/src/lib/integration_test_lib/event_type.mli
+++ b/src/lib/integration_test_lib/event_type.mli
@@ -122,11 +122,7 @@ module Gossip : sig
 end
 
 module Snark_work_failed : sig
-  type t =
-    { error : Yojson.Safe.t
-    ; work_spec : Snark_worker.Work.Spec.t
-    ; prover_public_key : Signature_lib.Public_key.Compressed.t
-    }
+  type t = { error : Yojson.Safe.t }
 
   include Event_type_intf with type t := t
 end

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -6,11 +6,7 @@ module Worker = struct
   include Functor.Make (Inputs)
 
   type Structured_log_events.t +=
-    | Generating_snark_work_failed of
-        { error : Yojson.Safe.t
-        ; work_spec : Work.Spec.t
-        ; prover_public_key : Signature_lib.Public_key.Compressed.t (* FOO *)
-        }
+    | Generating_snark_work_failed of { error : Yojson.Safe.t }
     [@@deriving
       register_event { msg = "Failed to generate SNARK work: $error" }]
 

--- a/src/lib/snark_worker/snark_worker.mli
+++ b/src/lib/snark_worker/snark_worker.mli
@@ -5,9 +5,5 @@ module Intf : module type of Intf
 include Intf.S with type ledger_proof := Ledger_proof.t
 
 type Structured_log_events.t +=
-  | Generating_snark_work_failed of
-      { error : Yojson.Safe.t
-      ; work_spec : Work.Spec.t
-      ; prover_public_key : Signature_lib.Public_key.Compressed.t
-      }
+  | Generating_snark_work_failed of { error : Yojson.Safe.t }
   [@@deriving register_event]


### PR DESCRIPTION
This PR stops logging the txn snark statement on failure. This ensures that the log messages are sufficiently small to be ingested by stackdriver, allowing them to be consumed as structured logs and thus raised to the test executive.

You can see this working in practice [here](https://buildkite.com/o-1-labs-2/mina/builds/26922#0185f445-ab06-4c8a-ab9f-f1d5f2cd793d).

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
