### PR TITLE
Remove Supercharged Rewards

### DIFF
--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets false]
 

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/low.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/high.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets false]
 

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets false]
 

--- a/src/config/devnet.mlh
+++ b/src/config/devnet.mlh
@@ -8,7 +8,7 @@
 [%%import "/src/config/account_creation_fee/realistic.mlh"]
 [%%import "/src/config/amount_defaults/realistic.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 (* custom consensus parameters for the testnet release *)
 [%%define consensus_mechanism "proof_of_stake"]

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/fuzz_medium.mlh
+++ b/src/config/fuzz_medium.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/fuzz_small.mlh
+++ b/src/config/fuzz_small.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/mainnet.mlh
+++ b/src/config/mainnet.mlh
@@ -8,7 +8,7 @@
 [%%import "/src/config/account_creation_fee/realistic.mlh"]
 [%%import "/src/config/amount_defaults/realistic.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 (* custom consensus parameters for the testnet release *)
 [%%define consensus_mechanism "proof_of_stake"]

--- a/src/config/nonconsensus_medium_curves.mlh
+++ b/src/config/nonconsensus_medium_curves.mlh
@@ -8,7 +8,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets false]
 

--- a/src/config/supercharged_coinbase_factor/one.mlh
+++ b/src/config/supercharged_coinbase_factor/one.mlh
@@ -1,0 +1,1 @@
+[%%define supercharged_coinbase_factor 1 ]

--- a/src/config/supercharged_coinbase_factor/two.mlh
+++ b/src/config/supercharged_coinbase_factor/two.mlh
@@ -1,1 +1,0 @@
-[%%define supercharged_coinbase_factor 2 ]

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_medium_curves.mlh
+++ b/src/config/test_postake_medium_curves.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 

--- a/src/config/test_postake_three_producers.mlh
+++ b/src/config/test_postake_three_producers.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 [%%define fake_hash true]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets false]
 [%%define cache_exceptions false]

--- a/src/config/testnet_postake_many_producers.mlh
+++ b/src/config/testnet_postake_many_producers.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets false]
 [%%define cache_exceptions false]

--- a/src/config/testnet_postake_many_producers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_producers_medium_curves.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets true]
 [%%define cache_exceptions false]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -8,7 +8,7 @@
 [%%import "/src/config/account_creation_fee/realistic.mlh"]
 [%%import "/src/config/amount_defaults/realistic.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 (* custom consensus parameters for the testnet release *)
 [%%define consensus_mechanism "proof_of_stake"]

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets false]
 [%%define cache_exceptions false]

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets false]
 [%%define delta 8]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/standard.mlh"]
 [%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/protocol_version/current.mlh"]
-[%%import "/src/config/supercharged_coinbase_factor/two.mlh"]
+[%%import "/src/config/supercharged_coinbase_factor/one.mlh"]
 
 [%%define time_offsets false]
 [%%define cache_exceptions false]


### PR DESCRIPTION
Added in  a new file `one.mhl` which defines the `supercharged_coinbase_factor` constant as 1. All other configurations files that referenced the old constant of 2 (in `two.mhl`) were updated to reference the new one.

* Closes #12578
