### PR TITLE
Bump ocaml-lsp-server version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1670841293,
-        "narHash": "sha256-ehLsAf9va4d3YZXKhWSu88cYdRZ/6HuPPQ+TXToypTg=",
+        "lastModified": 1675103944,
+        "narHash": "sha256-V5Nnh0bPP+1oRpxAoY8Ps+pzTj/y3pIU4qJ/RHKy/Ms=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "bad686eebec3198d02a1599eccb361596421832b",
+        "rev": "3d52404962379752da1a2ff28a5ec1d2b7c33771",
         "type": "github"
       },
       "original": {

--- a/nix/ocaml.nix
+++ b/nix/ocaml.nix
@@ -29,7 +29,8 @@ let
     dyn = "3.5.0";
     fiber = "3.5.0";
     chrome-trace = "3.5.0";
-    ocaml-lsp-server = "1.14.1";
+    ocaml-lsp-server = "1.15.1-4.14";
+    ocamlc-loc = "3.5.0";
     ocaml-system = ocaml;
     ocamlformat-rpc-lib = "0.22.4";
     omd = "1.3.2";


### PR DESCRIPTION
This PR bumps `ocaml-lsp-server` to the latest version. It fixes some issues I was personally having while running `dune build` in watch mode.

I tested it in my VSCode setup, and all is okay. It shouldn't break anyone's setup, but I'll request someone else to test it using (at least) emacs and vim.