### PR TITLE
fix the fuzzy zkapp test

### DIFF
--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -620,11 +620,11 @@ end
    The type `d` is associated with the `account_precondition` field, which is
    a nonce for the fee payer, and `Account_precondition.t` for other zkapp_command
 *)
-let gen_account_update_body_components (type a b c d) ?(update = None)
-    ?account_id ?token_id ?may_use_token ?account_ids_seen ~account_state_tbl
-    ?vk ?failure ?(new_account = false) ?(zkapp_account = false)
-    ?(is_fee_payer = false) ?available_public_keys ?permissions_auth
-    ?(required_balance_change : a option) ?protocol_state_view
+let gen_account_update_body_components (type a b c d) ?global_slot
+    ?(update = None) ?account_id ?token_id ?may_use_token ?account_ids_seen
+    ~account_state_tbl ?vk ?failure ?(new_account = false)
+    ?(zkapp_account = false) ?(is_fee_payer = false) ?available_public_keys
+    ?permissions_auth ?(required_balance_change : a option) ?protocol_state_view
     ~zkapp_account_ids
     ~(gen_balance_change : Account.t -> a Quickcheck.Generator.t)
     ~(gen_use_full_commitment :
@@ -809,10 +809,10 @@ let gen_account_update_body_components (type a b c d) ?(update = None)
             gen_protocol_state_precondition )
       ~default:(return Zkapp_precondition.Protocol_state.accept)
   and valid_while_precondition =
-    match protocol_state_view with
+    match global_slot with
     | None ->
         return Zkapp_basic.Or_ignore.Ignore
-    | Some psv ->
+    | Some global_slot ->
         let open Mina_numbers in
         let%bind epsilon1 =
           Global_slot.gen_incl (Global_slot.of_int 0) (Global_slot.of_int 10)
@@ -822,9 +822,9 @@ let gen_account_update_body_components (type a b c d) ?(update = None)
         in
         Zkapp_precondition.Closed_interval.
           { lower =
-              Global_slot.sub psv.global_slot_since_genesis epsilon1
+              Global_slot.sub global_slot epsilon1
               |> Option.value ~default:Global_slot.zero
-          ; upper = Global_slot.add psv.global_slot_since_genesis epsilon2
+          ; upper = Global_slot.add global_slot epsilon2
           }
         |> return |> Zkapp_basic.Or_ignore.gen
   and may_use_token =
@@ -971,10 +971,10 @@ let gen_account_update_body_components (type a b c d) ?(update = None)
   ; authorization_kind
   }
 
-let gen_account_update_from ?(update = None) ?failure ?(new_account = false)
-    ?(zkapp_account = false) ?account_id ?token_id ?may_use_token
-    ?permissions_auth ?required_balance_change ~zkapp_account_ids ~authorization
-    ~account_ids_seen ~available_public_keys ~account_state_tbl
+let gen_account_update_from ?global_slot ?(update = None) ?failure
+    ?(new_account = false) ?(zkapp_account = false) ?account_id ?token_id
+    ?may_use_token ?permissions_auth ?required_balance_change ~zkapp_account_ids
+    ~authorization ~account_ids_seen ~available_public_keys ~account_state_tbl
     ?protocol_state_view ?vk () =
   let open Quickcheck.Let_syntax in
   let increment_nonce =
@@ -992,8 +992,8 @@ let gen_account_update_from ?(update = None) ?failure ?(new_account = false)
         false
   in
   let%bind body_components =
-    gen_account_update_body_components ~update ?failure ~new_account
-      ~zkapp_account
+    gen_account_update_body_components ?global_slot ~update ?failure
+      ~new_account ~zkapp_account
       ~increment_nonce:(increment_nonce, increment_nonce)
       ?permissions_auth ?account_id ?token_id ?may_use_token
       ?protocol_state_view ?vk ~zkapp_account_ids ~account_ids_seen
@@ -1017,17 +1017,17 @@ let gen_account_update_from ?(update = None) ?failure ?(new_account = false)
   return { Account_update.Simple.body; authorization }
 
 (* takes an account id, if we want to sign this data *)
-let gen_account_update_body_fee_payer ?failure ?permissions_auth ~account_id ?vk
-    ?protocol_state_view ~account_state_tbl () :
+let gen_account_update_body_fee_payer ?global_slot ?failure ?permissions_auth
+    ~account_id ?vk ?protocol_state_view ~account_state_tbl () :
     Account_update.Body.Fee_payer.t Quickcheck.Generator.t =
   let open Quickcheck.Let_syntax in
   let account_precondition_gen (account : Account.t) =
     Quickcheck.Generator.return account.nonce
   in
   let%map body_components =
-    gen_account_update_body_components ?failure ?permissions_auth ~account_id
-      ~account_state_tbl ?vk ~zkapp_account_ids:[] ~is_fee_payer:true
-      ~increment_nonce:((), true) ~gen_balance_change:gen_fee
+    gen_account_update_body_components ?global_slot ?failure ?permissions_auth
+      ~account_id ~account_state_tbl ?vk ~zkapp_account_ids:[]
+      ~is_fee_payer:true ~increment_nonce:((), true) ~gen_balance_change:gen_fee
       ~f_balance_change:fee_to_amt
       ~f_token_id:(fun token_id ->
         (* make sure the fee payer's token id is the default,
@@ -1043,13 +1043,13 @@ let gen_account_update_body_fee_payer ?failure ?permissions_auth ~account_id ?vk
   in
   Account_update_body_components.to_fee_payer body_components
 
-let gen_fee_payer ?failure ?permissions_auth ~account_id ?protocol_state_view
-    ?vk ~account_state_tbl () :
+let gen_fee_payer ?global_slot ?failure ?permissions_auth ~account_id
+    ?protocol_state_view ?vk ~account_state_tbl () :
     Account_update.Fee_payer.t Quickcheck.Generator.t =
   let open Quickcheck.Let_syntax in
   let%map body =
-    gen_account_update_body_fee_payer ?failure ?permissions_auth ~account_id ?vk
-      ?protocol_state_view ~account_state_tbl ()
+    gen_account_update_body_fee_payer ?global_slot ?failure ?permissions_auth
+      ~account_id ?vk ?protocol_state_view ~account_state_tbl ()
   in
   (* real signature to be added when this data inserted into a Zkapp_command.t *)
   let authorization = Signature.dummy in
@@ -1069,7 +1069,8 @@ let max_account_updates = 2
 
 let max_token_updates = 2
 
-let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
+let gen_zkapp_command_from ?global_slot ?failure
+    ?(max_account_updates = max_account_updates)
     ?(max_token_updates = max_token_updates)
     ~(fee_payer_keypair : Signature_lib.Keypair.t)
     ~(keymap :
@@ -1136,7 +1137,7 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
   *)
   let account_ids_seen = Account_id.Hash_set.create () in
   let%bind fee_payer =
-    gen_fee_payer ?failure ~permissions_auth:Control.Tag.Signature
+    gen_fee_payer ?global_slot ?failure ~permissions_auth:Control.Tag.Signature
       ~account_id:fee_payer_acct_id ?vk ~account_state_tbl ()
   in
   let zkapp_account_ids =
@@ -1253,19 +1254,19 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
               (tag, None)
         in
         let zkapp_account =
-          match permissions_auth with
-          | Proof ->
+          match (failure, permissions_auth) with
+          | Some (Update_not_permitted _), _ | _, Proof ->
               true
-          | Signature | None_given ->
+          | _, Signature | _, None_given ->
               false
         in
         let%bind account_update0 =
           (* Signature authorization to start *)
           let authorization = Control.Signature Signature.dummy in
-          gen_account_update_from ~zkapp_account_ids ~account_ids_seen ~update
-            ?failure ~authorization ~new_account ~permissions_auth
-            ~zkapp_account ~available_public_keys ~account_state_tbl
-            ?protocol_state_view ?vk ()
+          gen_account_update_from ?global_slot ~zkapp_account_ids
+            ~account_ids_seen ~update ?failure ~authorization ~new_account
+            ~permissions_auth ~zkapp_account ~available_public_keys
+            ~account_state_tbl ?protocol_state_view ?vk ()
         in
         let%bind account_update =
           (* authorization according to chosen permissions auth *)
@@ -1336,10 +1337,10 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
               account_update0.body.token_id
           in
           let permissions_auth = Control.Tag.Signature in
-          gen_account_update_from ~update ?failure ~zkapp_account_ids
-            ~account_ids_seen ~account_id ~authorization ~permissions_auth
-            ~zkapp_account ~available_public_keys ~account_state_tbl
-            ?protocol_state_view ?vk ()
+          gen_account_update_from ?global_slot ~update ?failure
+            ~zkapp_account_ids ~account_ids_seen ~account_id ~authorization
+            ~permissions_auth ~zkapp_account ~available_public_keys
+            ~account_state_tbl ?protocol_state_view ?vk ()
         in
         (* this list will be reversed, so `account_update0` will execute before `account_update` *)
         go
@@ -1392,10 +1393,11 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
   let balance_change = Currency.Amount.Signed.negate balance_change_sum in
   let%bind balancing_account_update =
     let authorization = Control.Signature Signature.dummy in
-    gen_account_update_from ?failure ~permissions_auth:Control.Tag.Signature
-      ~zkapp_account_ids ~account_ids_seen ~authorization ~new_account:false
-      ~available_public_keys ~account_state_tbl
-      ~required_balance_change:balance_change ?protocol_state_view ?vk ()
+    gen_account_update_from ?global_slot ?failure
+      ~permissions_auth:Control.Tag.Signature ~zkapp_account_ids
+      ~account_ids_seen ~authorization ~new_account:false ~available_public_keys
+      ~account_state_tbl ~required_balance_change:balance_change
+      ?protocol_state_view ?vk ()
   in
   let gen_zkapp_command_with_token_accounts ~num_zkapp_command =
     let authorization = Control.Signature Signature.dummy in
@@ -1412,10 +1414,10 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
                       Genesis_constants.Constraint_constants.compiled
                         .account_creation_fee ) ))
           in
-          gen_account_update_from ~zkapp_account_ids ~account_ids_seen
-            ~authorization ~permissions_auth ~available_public_keys
-            ~may_use_token:No ~account_state_tbl ~required_balance_change
-            ?protocol_state_view ?vk ()
+          gen_account_update_from ?global_slot ~zkapp_account_ids
+            ~account_ids_seen ~authorization ~permissions_auth
+            ~available_public_keys ~may_use_token:No ~account_state_tbl
+            ~required_balance_change ?protocol_state_view ?vk ()
         in
         let token_id =
           Account_id.derive_token_id
@@ -1423,10 +1425,11 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
               (Account_id.create parent.body.public_key parent.body.token_id)
         in
         let%bind child =
-          gen_account_update_from ~zkapp_account_ids ~account_ids_seen
-            ~new_account:true ~token_id ~may_use_token:Parents_own_token
-            ~authorization ~permissions_auth ~available_public_keys
-            ~account_state_tbl ?protocol_state_view ?vk ()
+          gen_account_update_from ?global_slot ~zkapp_account_ids
+            ~account_ids_seen ~new_account:true ~token_id
+            ~may_use_token:Parents_own_token ~authorization ~permissions_auth
+            ~available_public_keys ~account_state_tbl ?protocol_state_view ?vk
+            ()
         in
         gen_tree (mk_node parent [ mk_node child [] ] :: acc) (n - 1)
     in
@@ -1501,7 +1504,7 @@ let gen_zkapp_command_from ?failure ?(max_account_updates = max_account_updates)
           () ) ;
   zkapp_command_dummy_authorizations
 
-let gen_list_of_zkapp_command_from ?failure ?max_account_updates
+let gen_list_of_zkapp_command_from ?global_slot ?failure ?max_account_updates
     ?max_token_updates ~(fee_payer_keypairs : Signature_lib.Keypair.t list)
     ~keymap ?account_state_tbl ~ledger ?protocol_state_view ?vk ?length () =
   (* Since when generating multiple zkapp_command the fee payer's nonce should only
@@ -1545,9 +1548,9 @@ let gen_list_of_zkapp_command_from ?failure ?max_account_updates
         Quickcheck.Generator.of_list fee_payer_keypairs
       in
       let%bind new_zkapp_command =
-        gen_zkapp_command_from ?failure ?max_account_updates ?max_token_updates
-          ~fee_payer_keypair ~keymap ~account_state_tbl ~ledger
-          ?protocol_state_view ?vk ()
+        gen_zkapp_command_from ?global_slot ?failure ?max_account_updates
+          ?max_token_updates ~fee_payer_keypair ~keymap ~account_state_tbl
+          ~ledger ?protocol_state_view ?vk ()
       in
       go (n - 1) (new_zkapp_command :: acc)
     else return (List.rev acc)

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -44,7 +44,8 @@ val gen_protocol_state_precondition :
     Generated zkapp_command uses dummy signatures and dummy proofs.
   *)
 val gen_zkapp_command_from :
-     ?failure:failure
+     ?global_slot:Mina_numbers.Global_slot.t
+  -> ?failure:failure
   -> ?max_account_updates:int
   -> ?max_token_updates:int
   -> fee_payer_keypair:Signature_lib.Keypair.t
@@ -60,7 +61,8 @@ val gen_zkapp_command_from :
 (** Generate a list of zkapp_command, `fee_payer_keypairs` contains a list of possible fee payers
   *)
 val gen_list_of_zkapp_command_from :
-     ?failure:failure
+     ?global_slot:Mina_numbers.Global_slot.t
+  -> ?failure:failure
   -> ?max_account_updates:int
   -> ?max_token_updates:int
   -> fee_payer_keypairs:Signature_lib.Keypair.t list


### PR DESCRIPTION
Explain your changes:
There's 2 fixes in this PR
1. The` generation of failed zkapps would always include `proof` authorization, so we should always use zkapp for that.
2. added an optional `global_slot` argument for the zkapp_command_generator, which is meant to be the global_slot that we apply the transactions.

Explain how you tested your changes:
With those fixes the fuzzy zkapp tests pass on my machine.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #12590
