### PR TITLE
Rename state_data in table names to field

### DIFF
--- a/src/app/archive/drop_tables.sql
+++ b/src/app/archive/drop_tables.sql
@@ -60,13 +60,13 @@ DROP TABLE zkapp_epoch_ledger;
 
 DROP TABLE zkapp_permissions;
 
-DROP TABLE zkapp_state_data_array;
+DROP TABLE zkapp_field_array;
 
 DROP TABLE zkapp_states_nullable;
 
 DROP TABLE zkapp_states;
 
-DROP TABLE zkapp_state_data;
+DROP TABLE zkapp_field;
 
 DROP TABLE zkapp_timing_info;
 

--- a/src/app/archive/lib/load_data.ml
+++ b/src/app/archive/lib/load_data.ml
@@ -131,7 +131,7 @@ let update_of_id pool update_id =
       Deferred.List.map field_ids ~f:(fun id_opt ->
           Option.value_map id_opt ~default:(return None) ~f:(fun id ->
               let%map field =
-                query_db ~f:(fun db -> Processor.Zkapp_state_data.load db id)
+                query_db ~f:(fun db -> Processor.Zkapp_field.load db id)
               in
               Some field ) )
     in
@@ -378,19 +378,17 @@ let protocol_state_precondition_of_id pool id =
 let load_events pool id =
   let query_db ~f = Mina_caqti.query ~f pool in
   let%map fields_list =
-    (* each id refers to an item in 'zkapp_state_data_array' *)
+    (* each id refers to an item in 'zkapp_field_array' *)
     let%bind field_array_ids =
       query_db ~f:(fun db -> Processor.Zkapp_events.load db id)
     in
     Deferred.List.map (Array.to_list field_array_ids) ~f:(fun array_id ->
         let%bind field_ids =
-          query_db ~f:(fun db ->
-              Processor.Zkapp_state_data_array.load db array_id )
+          query_db ~f:(fun db -> Processor.Zkapp_field_array.load db array_id)
         in
         Deferred.List.map (Array.to_list field_ids) ~f:(fun field_id ->
             let%map field_str =
-              query_db ~f:(fun db ->
-                  Processor.Zkapp_state_data.load db field_id )
+              query_db ~f:(fun db -> Processor.Zkapp_field.load db field_id)
             in
             Zkapp_basic.F.of_string field_str ) )
   in
@@ -458,7 +456,7 @@ let get_account_update_body ~pool body_id =
   let%bind actions = load_events pool actions_id in
   let%bind call_data =
     let%map field_str =
-      query_db ~f:(fun db -> Processor.Zkapp_state_data.load db call_data_id)
+      query_db ~f:(fun db -> Processor.Zkapp_field.load db call_data_id)
     in
     Zkapp_basic.F.of_string field_str
   in
@@ -569,8 +567,7 @@ let get_account_update_body ~pool body_id =
             Deferred.List.map elements ~f:(fun id_opt ->
                 Option.value_map id_opt ~default:(return None) ~f:(fun id ->
                     let%map field_str =
-                      query_db ~f:(fun db ->
-                          Processor.Zkapp_state_data.load db id )
+                      query_db ~f:(fun db -> Processor.Zkapp_field.load db id)
                     in
                     Some (Zkapp_basic.F.of_string field_str) ) )
           in
@@ -581,7 +578,7 @@ let get_account_update_body ~pool body_id =
             Option.value_map sequence_state_id ~default:(return None)
               ~f:(fun id ->
                 let%map field_str =
-                  query_db ~f:(fun db -> Processor.Zkapp_state_data.load db id)
+                  query_db ~f:(fun db -> Processor.Zkapp_field.load db id)
                 in
                 Some (Zkapp_basic.F.of_string field_str) )
           in
@@ -823,7 +820,7 @@ let get_account_accessed ~pool (account : Processor.Accounts_accessed.t) :
         let%bind app_state =
           let%map field_strs =
             Deferred.List.map elements ~f:(fun id ->
-                query_db ~f:(fun db -> Processor.Zkapp_state_data.load db id) )
+                query_db ~f:(fun db -> Processor.Zkapp_field.load db id) )
           in
           let fields = List.map field_strs ~f:Zkapp_basic.F.of_string in
           Zkapp_state.V.of_list_exn fields
@@ -866,7 +863,7 @@ let get_account_accessed ~pool (account : Processor.Accounts_accessed.t) :
         let%bind sequence_state =
           let%map field_strs =
             Deferred.List.map elements ~f:(fun id ->
-                query_db ~f:(fun db -> Processor.Zkapp_state_data.load db id) )
+                query_db ~f:(fun db -> Processor.Zkapp_field.load db id) )
           in
           let fields = List.map field_strs ~f:Zkapp_basic.F.of_string in
           Pickles_types.Vector.Vector_5.of_list_exn fields

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -230,8 +230,8 @@ module Account_identifiers = struct
       id
 end
 
-module Zkapp_state_data = struct
-  let table_name = "zkapp_state_data"
+module Zkapp_field = struct
+  let table_name = "zkapp_field"
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (fp : Pickles.Backend.Tick.Field.t) =
@@ -248,15 +248,15 @@ module Zkapp_state_data = struct
       id
 end
 
-module Zkapp_state_data_array = struct
-  let table_name = "zkapp_state_data_array"
+module Zkapp_field_array = struct
+  let table_name = "zkapp_field_array"
 
   let add_if_doesn't_exist (module Conn : CONNECTION)
       (fps : Pickles.Backend.Tick.Field.t array) =
     let open Deferred.Result.Let_syntax in
     let%bind (element_ids : int array) =
       Mina_caqti.deferred_result_list_map (Array.to_list fps)
-        ~f:(Zkapp_state_data.add_if_doesn't_exist (module Conn))
+        ~f:(Zkapp_field.add_if_doesn't_exist (module Conn))
       >>| Array.of_list
     in
     Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
@@ -308,7 +308,7 @@ module Zkapp_states_nullable = struct
       Mina_caqti.deferred_result_list_map (Vector.to_list fps)
         ~f:
           ( Mina_caqti.add_if_some
-          @@ Zkapp_state_data.add_if_doesn't_exist (module Conn) )
+          @@ Zkapp_field.add_if_doesn't_exist (module Conn) )
     in
     let t =
       match element_ids with
@@ -369,7 +369,7 @@ module Zkapp_states = struct
     let open Deferred.Result.Let_syntax in
     let%bind (element_ids : int list) =
       Mina_caqti.deferred_result_list_map (Vector.to_list fps)
-        ~f:(Zkapp_state_data.add_if_doesn't_exist (module Conn))
+        ~f:(Zkapp_field.add_if_doesn't_exist (module Conn))
     in
     let t =
       match element_ids with
@@ -427,7 +427,7 @@ module Zkapp_sequence_states = struct
     let open Deferred.Result.Let_syntax in
     let%bind (element_ids : int list) =
       Mina_caqti.deferred_result_list_map (Vector.to_list fps) ~f:(fun field ->
-          Zkapp_state_data.add_if_doesn't_exist (module Conn) field )
+          Zkapp_field.add_if_doesn't_exist (module Conn) field )
     in
     let t =
       match element_ids with
@@ -872,7 +872,7 @@ module Zkapp_account_precondition_values = struct
     in
     let%bind sequence_state_id =
       Mina_caqti.add_if_zkapp_check
-        (Zkapp_state_data.add_if_doesn't_exist (module Conn))
+        (Zkapp_field.add_if_doesn't_exist (module Conn))
         acct.sequence_state
     in
     let receipt_chain_hash =
@@ -1451,7 +1451,7 @@ module Zkapp_events = struct
     let open Deferred.Result.Let_syntax in
     let%bind (element_ids : int array) =
       Mina_caqti.deferred_result_list_map events
-        ~f:(Zkapp_state_data_array.add_if_doesn't_exist (module Conn))
+        ~f:(Zkapp_field_array.add_if_doesn't_exist (module Conn))
       >>| Array.of_list
     in
     Mina_caqti.select_insert_into_cols ~select:("id", Caqti_type.int)
@@ -1530,7 +1530,7 @@ module Zkapp_account_update_body = struct
       Zkapp_events.add_if_doesn't_exist (module Conn) body.actions
     in
     let%bind call_data_id =
-      Zkapp_state_data.add_if_doesn't_exist (module Conn) body.call_data
+      Zkapp_field.add_if_doesn't_exist (module Conn) body.call_data
     in
     let%bind zkapp_network_precondition_id =
       Zkapp_network_precondition.add_if_doesn't_exist

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -14,13 +14,13 @@
 */
 
 /* the string representation of an algebraic field */
-CREATE TABLE zkapp_state_data
+CREATE TABLE zkapp_field
 ( id                       serial           PRIMARY KEY
 , field                    text             NOT NULL UNIQUE
 );
 
 /* Variable-width arrays of algebraic fields, given as
-   id's from zkapp_state_data
+   id's from zkapp_field
 
    Postgresql does not allow enforcing that the array elements are
    foreign keys
@@ -28,53 +28,53 @@ CREATE TABLE zkapp_state_data
    The elements of the array are NOT NULL (not enforced by Postgresql)
 
 */
-CREATE TABLE zkapp_state_data_array
+CREATE TABLE zkapp_field_array
 ( id                       serial  PRIMARY KEY
 , element_ids              int[]   NOT NULL
 );
 
 /* Fixed-width arrays of algebraic fields, given as id's from
-   zkapp_state_data
+   zkapp_field
 
    Any element of the array may be NULL, per the NULL convention
 */
 CREATE TABLE zkapp_states_nullable
 ( id                       serial           PRIMARY KEY
-, element0                 int              REFERENCES zkapp_state_data(id)
-, element1                 int		    REFERENCES zkapp_state_data(id)
-, element2                 int		    REFERENCES zkapp_state_data(id)
-, element3                 int		    REFERENCES zkapp_state_data(id)
-, element4                 int		    REFERENCES zkapp_state_data(id)
-, element5                 int		    REFERENCES zkapp_state_data(id)
-, element6                 int		    REFERENCES zkapp_state_data(id)
-, element7                 int		    REFERENCES zkapp_state_data(id)
+, element0                 int              REFERENCES zkapp_field(id)
+, element1                 int		    REFERENCES zkapp_field(id)
+, element2                 int		    REFERENCES zkapp_field(id)
+, element3                 int		    REFERENCES zkapp_field(id)
+, element4                 int		    REFERENCES zkapp_field(id)
+, element5                 int		    REFERENCES zkapp_field(id)
+, element6                 int		    REFERENCES zkapp_field(id)
+, element7                 int		    REFERENCES zkapp_field(id)
 );
 
 /* like zkapp_states_nullable, but elements are not NULL */
 CREATE TABLE zkapp_states
 ( id                       serial           PRIMARY KEY
-, element0                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element1                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element2                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element3                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element4                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element5                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element6                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element7                 int              NOT NULL REFERENCES zkapp_state_data(id)
+, element0                 int              NOT NULL REFERENCES zkapp_field(id)
+, element1                 int              NOT NULL REFERENCES zkapp_field(id)
+, element2                 int              NOT NULL REFERENCES zkapp_field(id)
+, element3                 int              NOT NULL REFERENCES zkapp_field(id)
+, element4                 int              NOT NULL REFERENCES zkapp_field(id)
+, element5                 int              NOT NULL REFERENCES zkapp_field(id)
+, element6                 int              NOT NULL REFERENCES zkapp_field(id)
+, element7                 int              NOT NULL REFERENCES zkapp_field(id)
 );
 
 /* like zkapp_states, but for sequence states */
 CREATE TABLE zkapp_sequence_states
 ( id                       serial           PRIMARY KEY
-, element0                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element1                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element2                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element3                 int              NOT NULL REFERENCES zkapp_state_data(id)
-, element4                 int              NOT NULL REFERENCES zkapp_state_data(id)
+, element0                 int              NOT NULL REFERENCES zkapp_field(id)
+, element1                 int              NOT NULL REFERENCES zkapp_field(id)
+, element2                 int              NOT NULL REFERENCES zkapp_field(id)
+, element3                 int              NOT NULL REFERENCES zkapp_field(id)
+, element4                 int              NOT NULL REFERENCES zkapp_field(id)
 );
 
-/* the element_ids are non-NULL, and refer to zkapp_state_data_array
-   that is, they represent a list of arrays of field elements
+/* the element_ids are non-NULL, and refer to zkapp_field_array
+   they represent a list of arrays of field elements
 */
 CREATE TABLE zkapp_events
 ( id                       serial           PRIMARY KEY
@@ -161,7 +161,7 @@ CREATE TABLE zkapp_account_precondition_values
 , receipt_chain_hash       text
 , delegate_id              int                    REFERENCES public_keys(id)
 , state_id                 int        NOT NULL    REFERENCES zkapp_states_nullable(id)
-, sequence_state_id        int                    REFERENCES zkapp_state_data(id)
+, sequence_state_id        int                    REFERENCES zkapp_field(id)
 , proved_state             boolean
 , is_new                   boolean
 );
@@ -170,10 +170,10 @@ CREATE TABLE zkapp_account_precondition_values
                nonce is not NULL iff kind is 'nonce'
 */
 CREATE TABLE zkapp_account_precondition
-( id                       serial                            PRIMARY KEY
-, kind                     zkapp_precondition_type           NOT NULL
+( id                              serial                            PRIMARY KEY
+, kind                            zkapp_precondition_type           NOT NULL
 , account_precondition_values_id  int                               REFERENCES zkapp_account_precondition_values(id)
-, nonce                    bigint
+, nonce                           bigint
 );
 
 CREATE TABLE zkapp_accounts
@@ -241,9 +241,6 @@ CREATE TABLE zkapp_network_precondition
 , next_epoch_data_id               int                            REFERENCES zkapp_epoch_data(id)
 );
 
-/* events_ids and actions_ids indicate a list of ids in
-   zkapp_state_data_array.
-*/
 CREATE TABLE zkapp_fee_payer_body
 ( id                                    serial    PRIMARY KEY
 , account_identifier_id                 int       NOT NULL REFERENCES account_identifiers(id)
@@ -256,10 +253,7 @@ CREATE TYPE may_use_token AS ENUM ('No', 'ParentsOwnToken', 'InheritFromParent')
 
 CREATE TYPE authorization_kind_type AS ENUM ('None_given', 'Signature', 'Proof');
 
-/* events_ids and actions_ids indicate a list of ids in
-   zkapp_state_data_array.
-
-   invariant: verification_key_hash_id is not NULL iff authorization_kind = Proof
+/* invariant: verification_key_hash_id is not NULL iff authorization_kind = Proof
    in OCaml, the verification key hash is stored with the Proof authorization kind
    here, they're kept separate so we can use an enum type
 */
@@ -271,7 +265,7 @@ CREATE TABLE zkapp_account_update_body
 , increment_nonce                       boolean         NOT NULL
 , events_id                             int             NOT NULL  REFERENCES zkapp_events(id)
 , actions_id                            int             NOT NULL  REFERENCES zkapp_events(id)
-, call_data_id                          int             NOT NULL  REFERENCES zkapp_state_data(id)
+, call_data_id                          int             NOT NULL  REFERENCES zkapp_field(id)
 , call_depth                            int             NOT NULL
 , zkapp_network_precondition_id         int             NOT NULL  REFERENCES zkapp_network_precondition(id)
 , zkapp_account_precondition_id         int             NOT NULL  REFERENCES zkapp_account_precondition(id)


### PR DESCRIPTION
In the archive database schema, rename:
- `zkapp_state_data` to `zkapp_field`
- `zkapp_state_data_array` to `zkapp_field_array`

`zkapp_field` contains data not only for app states, but also for events and actions.

Fixed some formatting, deleted some out-of-date comments.