### PR TITLE
[WIP][crypto] increase size of URS to 2^18

### DIFF
--- a/src/lib/crypto/kimchi_backend/pasta/basic/kimchi_pasta_basic.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/basic/kimchi_pasta_basic.ml
@@ -14,7 +14,7 @@ module Rounds : sig
 end = struct
   open Pickles_types
   module Wrap = Nat.N15
-  module Step = Nat.N16
+  module Step = Nat.N17
 
   (* Think about versioning here! These vector types *will* change
      serialization if the numbers above change, and so will require a new
@@ -50,17 +50,17 @@ end = struct
       [@@@no_toplevel_latest_type]
 
       module V1 = struct
-        type 'a t = 'a Vector.Vector_16.Stable.V1.t
+        type 'a t = 'a Vector.Vector_17.Stable.V1.t
         [@@deriving compare, yojson, sexp, hash, equal]
       end
     end]
 
-    type 'a t = 'a Vector.Vector_16.t
+    type 'a t = 'a Vector.Vector_17.t
     [@@deriving compare, yojson, sexp, hash, equal]
 
     let map = Vector.map
 
-    let of_list_exn = Vector.Vector_16.of_list_exn
+    let of_list_exn = Vector.Vector_17.of_list_exn
 
     let to_list = Vector.to_list
   end

--- a/src/lib/crypto/kimchi_backend/pasta/basic/kimchi_pasta_basic.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/basic/kimchi_pasta_basic.ml
@@ -14,7 +14,7 @@ module Rounds : sig
 end = struct
   open Pickles_types
   module Wrap = Nat.N15
-  module Step = Nat.N17
+  module Step = Nat.N18
 
   (* Think about versioning here! These vector types *will* change
      serialization if the numbers above change, and so will require a new
@@ -50,17 +50,17 @@ end = struct
       [@@@no_toplevel_latest_type]
 
       module V1 = struct
-        type 'a t = 'a Vector.Vector_17.Stable.V1.t
+        type 'a t = 'a Vector.Vector_18.Stable.V1.t
         [@@deriving compare, yojson, sexp, hash, equal]
       end
     end]
 
-    type 'a t = 'a Vector.Vector_17.t
+    type 'a t = 'a Vector.Vector_18.t
     [@@deriving compare, yojson, sexp, hash, equal]
 
     let map = Vector.map
 
-    let of_list_exn = Vector.Vector_17.of_list_exn
+    let of_list_exn = Vector.Vector_18.of_list_exn
 
     let to_list = Vector.to_list
   end

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
@@ -143,6 +143,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,12 +171,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake2"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b12e5fd123190ce1c2e559308a94c9bacad77907d4c6005d9e58fe1a0689e55e"
 dependencies = [
  "digest 0.10.6",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -240,6 +275,12 @@ dependencies = [
  "proc-macro-hack",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -403,10 +444,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -427,6 +485,23 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -524,6 +599,12 @@ dependencies = [
  "thiserror",
  "turshi",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -677,9 +758,12 @@ dependencies = [
  "ark-serialize",
  "bcs",
  "hex",
+ "mina-curves",
  "num-bigint",
  "num-integer",
  "num-traits",
+ "pasta-msm",
+ "pasta_curves",
  "rand",
  "rand_core",
  "rayon",
@@ -773,6 +857,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
+name = "pasta-msm"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40dc8bdddb15a18fdf7c398f341a5ef2632a287419bbeeb64c61dec25091627"
+dependencies = [
+ "cc",
+ "pasta_curves",
+ "semolina",
+ "sppark",
+ "which",
+]
+
+[[package]]
+name = "pasta_curves"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +929,12 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -937,6 +1055,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "semolina"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90759f733a01b95d6ba70180b954d1d96e3e7e11f86c3fb0da0231300972e05"
+dependencies = [
+ "cc",
+ "glob",
+]
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1153,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "sppark"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfb9486baeb35ca1197c4df27451d4df5bd321e15da94c1ddb89670f9e94896a"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "sprs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1236,12 @@ dependencies = [
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
@@ -1180,6 +1324,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
 name = "wires_15_stubs"
 version = "0.1.0"
 dependencies = [
@@ -1206,6 +1361,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sprs",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
@@ -31,12 +31,12 @@ ark-ec = { version = "0.3.0", features = ["parallel"] }
 ark-poly = { version = "0.3.0", features = ["parallel"] }
 
 # proof-systems
-commitment_dlog = { path = "../../proof-systems/poly-commitment", features = ["ocaml_types"] }
+commitment_dlog = { path = "../../proof-systems/poly-commitment", features = ["ocaml_types", "gpu"] }
 groupmap = { path = "../../proof-systems/groupmap" }
 mina-curves = { path = "../../proof-systems/curves" }
-o1-utils = { path = "../../proof-systems/utils" }
+o1-utils = { path = "../../proof-systems/utils", features = ["gpu"] }
 mina-poseidon = { path = "../../proof-systems/poseidon" }
-kimchi = { path = "../../proof-systems/kimchi", features = ["ocaml_types"] }
+kimchi = { path = "../../proof-systems/kimchi", features = ["ocaml_types", "gpu"] }
 
 # ocaml-specific
 ocaml = { version = "0.22.2", features = ["no-caml-startup"] }

--- a/src/lib/mina_base/call_stack_digest.ml
+++ b/src/lib/mina_base/call_stack_digest.ml
@@ -35,6 +35,8 @@ module Make_str (A : Wire_types.Concrete) = struct
         [| (h :> Field.t); t |]
   end
 
+  let to_field = Fn.id
+
   let constant = Field.constant
 
   let typ = Field.typ

--- a/src/lib/mina_base/digest_intf.ml
+++ b/src/lib/mina_base/digest_intf.ml
@@ -62,6 +62,8 @@ module type S = sig
     Base_internalhash_types.state -> t -> Base_internalhash_types.state
 
   val hash : t -> int
+
+  val to_field : t -> Zkapp_basic.F.t
 end
 
 module type S_checked = sig

--- a/src/lib/mina_base/stack_frame.ml
+++ b/src/lib/mina_base/stack_frame.ml
@@ -111,6 +111,8 @@ module Make_str (A : Wire_types.Concrete) = struct
   end
 
   let typ = Field.typ
+
+  let to_field = Fn.id
 end
 
 module Digest = Wire_types.Make (Make_sig) (Make_str)

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -228,6 +228,8 @@ module Call_forest = struct
       end
 
       let create : Account_update.t -> t = Account_update.digest
+
+      let to_field = Fn.id
     end
 
     module Forest = struct
@@ -250,6 +252,8 @@ module Call_forest = struct
           Random_oracle.Checked.hash
             ~init:Hash_prefix_states.account_update_cons [| hash; h_tl |]
       end
+
+      let to_field = Fn.id
 
       let empty = empty
 
@@ -288,6 +292,8 @@ module Call_forest = struct
         in
         Random_oracle.hash ~init:Hash_prefix_states.account_update_node
           [| account_update_digest; stack_hash |]
+
+      let to_field = Fn.id
     end
   end
 

--- a/src/lib/pickles_types/vector.ml
+++ b/src/lib/pickles_types/vector.ml
@@ -712,3 +712,28 @@ module Vector_17 = struct
     in
     ()
 end
+
+module Vector_18 = struct
+  module T = With_length (Nat.N18)
+
+  [%%versioned_binable
+  module Stable = struct
+    [@@@no_toplevel_latest_type]
+
+    module V1 = struct
+      type 'a t = ('a, Nat.N18.n) vec
+
+      include Make.Binable (Nat.N18)
+
+      include (T : module type of T with type 'a t := 'a t)
+    end
+  end]
+
+  include T
+
+  let () =
+    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
+     fun () -> Type_equal.T
+    in
+    ()
+end

--- a/src/lib/pickles_types/vector.ml
+++ b/src/lib/pickles_types/vector.ml
@@ -687,3 +687,28 @@ module Vector_16 = struct
     in
     ()
 end
+
+module Vector_17 = struct
+  module T = With_length (Nat.N17)
+
+  [%%versioned_binable
+  module Stable = struct
+    [@@@no_toplevel_latest_type]
+
+    module V1 = struct
+      type 'a t = ('a, Nat.N17.n) vec
+
+      include Make.Binable (Nat.N17)
+
+      include (T : module type of T with type 'a t := 'a t)
+    end
+  end]
+
+  include T
+
+  let () =
+    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
+     fun () -> Type_equal.T
+    in
+    ()
+end

--- a/src/lib/pickles_types/vector.mli
+++ b/src/lib/pickles_types/vector.mli
@@ -78,6 +78,8 @@ module Vector_15 : VECTOR with type 'a t = ('a, Nat.N15.n) vec
 (** Vector of size 16 *)
 module Vector_16 : VECTOR with type 'a t = ('a, Nat.N16.n) vec
 
+module Vector_17 : VECTOR with type 'a t = ('a, Nat.N17.n) vec
+
 (** Vector of size 8 *)
 module Vector_8 : VECTOR with type 'a t = ('a, Nat.N8.n) vec
 

--- a/src/lib/pickles_types/vector.mli
+++ b/src/lib/pickles_types/vector.mli
@@ -80,6 +80,8 @@ module Vector_16 : VECTOR with type 'a t = ('a, Nat.N16.n) vec
 
 module Vector_17 : VECTOR with type 'a t = ('a, Nat.N17.n) vec
 
+module Vector_18 : VECTOR with type 'a t = ('a, Nat.N18.n) vec
+
 (** Vector of size 8 *)
 module Vector_8 : VECTOR with type 'a t = ('a, Nat.N8.n) vec
 

--- a/src/lib/transaction_snark/test/zkapps_examples/big_circuit/dune
+++ b/src/lib/transaction_snark/test/zkapps_examples/big_circuit/dune
@@ -12,6 +12,7 @@
   yojson
   ;; local libraries
   cache_dir
+  crypto_params
   currency
   data_hash_lib
   genesis_constants


### PR DESCRIPTION
This increases the upperbound for zkapp circuits from 2^16 to 2^18.

Last time we checked that benchs didn't seem great, but this PR introduce a new GPU-accelerated MSM implementation and so it'll probably be more acceptable.

I'd be nice to do some benchmarks before merging this, but unfortunately it seems like proof systems is currently not in sync with this repo so I can't test this. 