### PR TITLE
[transaction_logic] Fix sign check bug in currency amount.

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1036,7 +1036,9 @@ let pending_snark_work =
                           { Cli_lib.Graphql_types.Pending_snark_work.Work
                             .work_id = w.work_id
                           ; fee_excess =
-                              to_signed_fee_exn f.sign f.fee_magnitude
+                              Currency.Amount.Signed.of_fee
+                                (to_signed_fee_exn f.sign
+                                   (Currency.Amount.to_fee f.fee_magnitude) )
                           ; supply_increase = w.supply_increase
                           ; source_first_pass_ledger_hash =
                               w.source_first_pass_ledger_hash

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -474,18 +474,20 @@ module Make_str (A : Wire_types.Concrete) = struct
 
       type magnitude = Unsigned.t [@@deriving sexp, compare]
 
-      let create ~magnitude ~sgn = { magnitude; sgn }
+      let create ~magnitude ~sgn =
+        { magnitude
+        ; sgn = (if Unsigned.(equal magnitude zero) then Sgn.Pos else sgn)
+        }
 
       let sgn { sgn; _ } = sgn
 
       let magnitude { magnitude; _ } = magnitude
 
-      let zero : t = create ~magnitude:zero ~sgn:Sgn.Pos
+      let zero : t = { magnitude = zero; sgn = Sgn.Pos }
 
       let gen =
         Quickcheck.Generator.map2 gen Sgn.gen ~f:(fun magnitude sgn ->
-            if Unsigned.(equal zero magnitude) then zero
-            else create ~magnitude ~sgn )
+            create ~magnitude ~sgn )
 
       let sgn_to_bool = function Sgn.Pos -> true | Neg -> false
 

--- a/src/lib/currency/intf.ml
+++ b/src/lib/currency/intf.ml
@@ -123,8 +123,7 @@ module type Signed_intf = sig
 
   val gen : t Quickcheck.Generator.t
 
-  val create :
-    magnitude:'magnitude -> sgn:'sgn -> ('magnitude, 'sgn) Signed_poly.t
+  val create : magnitude:magnitude -> sgn:Sgn.t -> t
 
   val sgn : t -> Sgn.t
 

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1615,9 +1615,9 @@ module Make (L : Ledger_intf.S) :
         (* Correctness of these functions hinges on the fact that zero is
            only ever expressed as {sgn = Pos; magnitude = zero}. Sadly, this
            is not guaranteed by the module's signature, as it's internal
-           structure is exposed. Ideally, it should be hidden and create
-           function should make sure that magnitude = zero implies positive
-           sign.
+           structure is exposed. Create function never produces this unwanted
+           value, but the type's internal structure is still exposed, so it's
+           possible theoretically to obtain it.
 
            For the moment, however, there is some consolation in the fact that
            addition never produces negative zero, even if it was one of its

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -1612,7 +1612,18 @@ module Make (L : Ledger_intf.S) :
 
         let if_ = value_if
 
-        let is_pos (t : t) = Sgn.equal t.sgn Pos
+        (* Correctness of these functions hinges on the fact that zero is
+           only ever expressed as {sgn = Pos; magnitude = zero}. Sadly, this
+           is not guaranteed by the module's signature, as it's internal
+           structure is exposed. Ideally, it should be hidden and create
+           function should make sure that magnitude = zero implies positive
+           sign.
+
+           For the moment, however, there is some consolation in the fact that
+           addition never produces negative zero, even if it was one of its
+           arguments. For that reason the risk of this function misbehaving is
+           minimal and can probably be safely ignored. *)
+        let is_non_neg (t : t) = Sgn.equal t.sgn Pos
 
         let is_neg (t : t) = Sgn.equal t.sgn Neg
       end

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -87,9 +87,9 @@ module type Amount_intf = sig
 
     val equal : t -> t -> bool
 
-    val is_pos : t -> bool
-
     val is_neg : t -> bool
+
+    val is_non_neg : t -> bool
 
     val negate : t -> t
 
@@ -1418,7 +1418,7 @@ module Make (Inputs : Inputs_intf) = struct
               ~else_:local_state.supply_increase
         }
       in
-      let is_receiver = Amount.Signed.is_pos actual_balance_change in
+      let is_receiver = Amount.Signed.is_non_neg actual_balance_change in
       let local_state =
         let controller =
           Controller.if_ is_receiver
@@ -1745,7 +1745,7 @@ module Make (Inputs : Inputs_intf) = struct
         assert_ ~pos:__POS__
           ( (not is_start')
           ||| ( account_update_token_is_default
-              &&& Amount.Signed.is_pos local_delta ) )) ;
+              &&& Amount.Signed.is_non_neg local_delta ) )) ;
       let new_local_fee_excess, `Overflow overflow =
         Amount.Signed.add_flagged local_state.excess local_delta
       in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1297,7 +1297,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             let if_ b ~then_ ~else_ =
               run_checked (Amount.Signed.Checked.if_ b ~then_ ~else_)
 
-            let is_pos (t : t) =
+            let is_non_neg (t : t) =
               Sgn.Checked.is_pos
                 (run_checked (Currency.Amount.Signed.Checked.sgn t))
 


### PR DESCRIPTION
In `Mina_transaction_logic` there's an extension of `Currency.Amount.Signed` which defines functions `is_pos` and `is_neg`. For 0 `is_pos` erroneously returns `true`. Moreover, the same functionality is already implemented correctly in the base currency library, so it should be imported from there. In the future we should probably remove these synonyms in favour of original function names.

Explain your changes:
* Refactor `Amount` out of `Mina_transaction_logic.Make` functor so that it can be tested.
* Replaced the definition with functions already defined in `Currency.Amount.Signed`.

Explain how you tested your changes:
* Wrote unit tests which fail before this change and pass afterwards.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Does this close issues? List them

* Closes #12604