### PR TITLE
Use feature flags for lookup gate

### DIFF
--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -423,7 +423,7 @@ let rule ~proof_level ~constraint_constants transaction_snark self :
         ; public_output = ()
         ; auxiliary_output = ()
         } )
-  ; uses_lookup = false
+  ; feature_flags = Plonk_types.Features.create_all false
   }
 
 module type S = sig

--- a/src/lib/pickles/inductive_rule.ml
+++ b/src/lib/pickles/inductive_rule.ml
@@ -116,7 +116,7 @@ type ( 'prev_vars
   ; main :
          'a_var main_input
       -> ('prev_vars, 'widths, 'ret_var, 'auxiliary_var) main_return
-  ; uses_lookup : bool
+  ; feature_flags : Pickles_types.Plonk_types.Features.with_bools
   }
 
 module T

--- a/src/lib/pickles/inductive_rule.mli
+++ b/src/lib/pickles/inductive_rule.mli
@@ -113,7 +113,7 @@ type ( 'prev_vars
   ; main :
          'a_var main_input
       -> ('prev_vars, 'widths, 'ret_var, 'auxiliary_var) main_return
-  ; uses_lookup : bool
+  ; feature_flags : Pickles_types.Plonk_types.Features.with_bools
   }
 
 module T

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -164,7 +164,7 @@ let typ (type n avar aval m) ~lookup (statement : (avar, aval) Impls.Step.Typ.t)
     ; Plonk_types.All_evals.typ
         (module Impl)
         (* Assume we have lookup iff we have runtime tables *)
-        { lookup; runtime = lookup }
+        { lookup; runtime_tables = lookup }
     ; Vector.typ (Vector.typ Field.typ Tick.Rounds.n) max_proofs_verified
     ; Vector.typ Inner_curve.typ max_proofs_verified
     ]

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -602,7 +602,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 Timer.clock __LOC__ ;
                 let res =
                   Common.time "make step data" (fun () ->
-                      Step_branch_data.create ~index:!i ~step_uses_lookup
+                      Step_branch_data.create ~index:!i ~feature_flags
                         ~max_proofs_verified:Max_proofs_verified.n
                         ~branches:Branches.n ~self ~public_input ~auxiliary_typ
                         Arg_var.to_field_elements Arg_value.to_field_elements
@@ -2097,7 +2097,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
           end in
           let proofs_verifieds = Vector.[ 2 ] in
           let (T inner_step_data as step_data) =
-            Step_branch_data.create ~index:0 ~step_uses_lookup:No
+            Step_branch_data.create ~index:0
+              ~feature_flags:
+                Pickles_types.Plonk_types.(Features.create_all Opt.Flag.No)
               ~max_proofs_verified:Max_proofs_verified.n ~branches:Branches.n
               ~self ~public_input:(Input typ) ~auxiliary_typ:typ
               A.to_field_elements A_value.to_field_elements rule ~wrap_domains
@@ -3022,7 +3024,9 @@ module Make_str (_ : Wire_types.Concrete) = struct
           end in
           let proofs_verifieds = Vector.[ 2 ] in
           let (T inner_step_data as step_data) =
-            Step_branch_data.create ~index:0 ~step_uses_lookup:No
+            Step_branch_data.create ~index:0
+              ~feature_flags:
+                Pickles_types.Plonk_types.(Features.create_all Opt.Flag.No)
               ~max_proofs_verified:Max_proofs_verified.n ~branches:Branches.n
               ~self ~public_input:(Input typ) ~auxiliary_typ:typ
               A.to_field_elements A_value.to_field_elements rule ~wrap_domains

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -568,7 +568,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
               No
           | r :: rules -> (
               let rest_usage = go rules in
-              match (r.uses_lookup, rest_usage) with
+              match (r.feature_flags.lookup, rest_usage) with
               | true, Yes ->
                   Yes
               | false, No ->
@@ -798,7 +798,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
             S.f ?handler branch_data next_state ~prevs_length:prev_vars_length
               ~self ~step_domains ~self_dlog_plonk_index:wrap_vk.commitments
               ~public_input ~auxiliary_typ
-              ~uses_lookup:(if b.rule.uses_lookup then Yes else No)
+              ~uses_lookup:(if b.rule.feature_flags.lookup then Yes else No)
               (Impls.Step.Keypair.pk (fst (Lazy.force step_pk)))
               wrap_vk.index
           in
@@ -1302,7 +1302,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
                     ; prevs = []
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; main =
                         (fun { public_input = self } ->
                           dummy_constraints () ;
@@ -1365,7 +1365,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
                     ; prevs = []
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; main =
                         (fun _ ->
                           dummy_constraints () ;
@@ -1432,7 +1432,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
                     ; prevs = [ self ]
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; main =
                         (fun { public_input = self } ->
                           let prev =
@@ -1539,7 +1539,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                   }
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; prevs = [ No_recursion.tag; self ]
                     ; main =
                         (fun { public_input = self } ->
@@ -1673,7 +1673,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                   }
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; prevs = [ No_recursion_return.tag; self ]
                     ; main =
                         (fun { public_input = () } ->
@@ -1797,7 +1797,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                   }
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; prevs = []
                     ; main =
                         (fun { public_input = x } ->
@@ -1862,7 +1862,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                   }
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; prevs = []
                     ; main =
                         (fun { public_input = input } ->
@@ -1969,7 +1969,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
               ; public_output = ()
               ; auxiliary_output = ()
               } )
-        ; uses_lookup = false
+        ; feature_flags = Plonk_types.Features.create_all false
         }
 
       module M = struct
@@ -2792,7 +2792,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~name:"recurse-on-bad" ~constraint_constants
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; prevs = [ tag; tag ]
                     ; main =
                         (fun { public_input = () } ->
@@ -2874,7 +2874,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
       let rule : _ Inductive_rule.t =
         let open Impls.Step in
         { identifier = "main"
-        ; uses_lookup = false
+        ; feature_flags = Plonk_types.Features.create_all false
         ; prevs = [ tag; tag ]
         ; main =
             (fun { public_input = () } ->
@@ -3682,7 +3682,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~name:"recurse-on-bad" ~constraint_constants
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; prevs = [ tag; tag ]
                     ; main =
                         (fun { public_input = () } ->
@@ -3793,7 +3793,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
                     ; prevs = []
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; main =
                         (fun { public_input = self } ->
                           dummy_constraints () ;
@@ -3846,7 +3846,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
                     ; prevs = []
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; main =
                         (fun { public_input = self } ->
                           dummy_constraints () ;
@@ -3899,7 +3899,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
                     ; prevs = []
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; main =
                         (fun { public_input = self } ->
                           dummy_constraints () ;
@@ -3976,7 +3976,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                 ~choices:(fun ~self ->
                   [ { identifier = "main"
                     ; prevs = [ side_loaded_tag ]
-                    ; uses_lookup = false
+                    ; feature_flags = Plonk_types.Features.create_all false
                     ; main =
                         (fun { public_input = self } ->
                           let prev =

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -587,7 +587,6 @@ module Make_str (_ : Wire_types.Concrete) = struct
         in
         go choices
       in
-      let step_uses_lookup = feature_flags.lookup in
       let step_data =
         let i = ref 0 in
         Timer.clock __LOC__ ;
@@ -887,7 +886,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
         ; wrap_vk = Lazy.map wrap_vk ~f:Verification_key.index
         ; wrap_domains
         ; step_domains
-        ; step_uses_lookup
+        ; feature_flags
         }
       in
       Timer.clock __LOC__ ;
@@ -931,7 +930,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
         { max_proofs_verified
         ; public_input = typ
         ; branches = Verification_key.Max_branches.n
-        ; step_uses_lookup = uses_lookup
+        ; feature_flags = { lookup = uses_lookup; runtime_tables = uses_lookup }
         }
 
     module Proof = struct
@@ -2731,7 +2730,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
           in
           let data : _ Types_map.Compiled.t =
             { branches = Branches.n
-            ; step_uses_lookup = No
+            ; feature_flags =
+                Plonk_types.Features.create_all Plonk_types.Opt.Flag.No
             ; proofs_verifieds
             ; max_proofs_verified = (module Max_proofs_verified)
             ; public_input = typ
@@ -3623,7 +3623,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
           in
           let data : _ Types_map.Compiled.t =
             { branches = Branches.n
-            ; step_uses_lookup = No
+            ; feature_flags =
+                Plonk_types.Features.create_all Plonk_types.Opt.Flag.No
             ; proofs_verifieds
             ; max_proofs_verified = (module Max_proofs_verified)
             ; public_input = typ

--- a/src/lib/pickles/pickles_intf.ml
+++ b/src/lib/pickles/pickles_intf.ml
@@ -233,7 +233,7 @@ module type S = sig
       ; main :
              'a_var main_input
           -> ('prev_vars, 'widths, 'ret_var, 'auxiliary_var) main_return
-      ; uses_lookup : bool
+      ; feature_flags : Pickles_types.Plonk_types.Features.with_bools
       }
   end
 

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -73,7 +73,7 @@ let create
     (type branches max_proofs_verified local_signature local_branches var value
     a_var a_value ret_var ret_value prev_vars prev_values ) ~index
     ~(self : (var, value, max_proofs_verified, branches) Tag.t) ~wrap_domains
-    ~(step_uses_lookup : Pickles_types.Plonk_types.Opt.Flag.t)
+    ~(feature_flags : Plonk_types.Features.with_flags)
     ~(max_proofs_verified : max_proofs_verified Nat.t)
     ~(proofs_verifieds : (int, branches) Vector.t) ~(branches : branches Nat.t)
     ~(public_input :
@@ -140,7 +140,7 @@ let create
         ; proofs_verifieds
         ; wrap_domains
         ; step_domains
-        ; step_uses_lookup
+        ; step_uses_lookup = feature_flags.lookup
         }
       ~public_input ~auxiliary_typ ~self_branches:branches ~proofs_verified
       ~local_signature:widths ~local_signature_length ~local_branches:heights

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -140,7 +140,7 @@ let create
         ; proofs_verifieds
         ; wrap_domains
         ; step_domains
-        ; step_uses_lookup = feature_flags.lookup
+        ; feature_flags
         }
       ~public_input ~auxiliary_typ ~self_branches:branches ~proofs_verified
       ~local_signature:widths ~local_signature_length ~local_branches:heights

--- a/src/lib/pickles/step_branch_data.mli
+++ b/src/lib/pickles/step_branch_data.mli
@@ -67,7 +67,7 @@ val create :
      index:int
   -> self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
   -> wrap_domains:Import.Domains.t
-  -> step_uses_lookup:Pickles_types.Plonk_types.Opt.Flag.t
+  -> feature_flags:Pickles_types.Plonk_types.Features.with_flags
   -> max_proofs_verified:'max_proofs_verified Pickles_types.Nat.t
   -> proofs_verifieds:(int, 'branches) Pickles_types.Vector.t
   -> branches:'branches Pickles_types.Nat.t

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -46,7 +46,7 @@ let verify_one ~srs
         in
         (* TODO: Refactor args into an "unfinalized proof" struct *)
         finalize_other_proof d.max_proofs_verified ~step_domains:d.step_domains
-          ~step_uses_lookup:d.step_uses_lookup ~sponge ~prev_challenges
+          ~step_uses_lookup:d.feature_flags.lookup ~sponge ~prev_challenges
           proof_state.deferred_values prev_proof_evals )
   in
   let branch_data = proof_state.deferred_values.branch_data in
@@ -88,7 +88,7 @@ let verify_one ~srs
     with_label __LOC__ (fun () ->
         verify ~srs
           ~lookup_parameters:
-            { use = d.step_uses_lookup
+            { use = d.feature_flags.lookup
             ; zero =
                 { var =
                     { challenge = Field.zero
@@ -200,7 +200,7 @@ let step_main :
       Typ.t
   end in
   let uses_lookup (d : _ Tag.t) =
-    if Type_equal.Id.same self.id d.id then basic.step_uses_lookup
+    if Type_equal.Id.same self.id d.id then basic.feature_flags.lookup
     else Types_map.uses_lookup d
   in
   let lookup_usage =
@@ -483,7 +483,7 @@ let step_main :
                     ; wrap_domain = `Known basic.wrap_domains.h
                     ; step_domains = `Known basic.step_domains
                     ; wrap_key = dlog_plonk_index
-                    ; step_uses_lookup = basic.step_uses_lookup
+                    ; feature_flags = basic.feature_flags
                     }
                   in
                   let module M =

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -18,7 +18,7 @@ module Basic = struct
     ; wrap_domains : Domains.t
     ; wrap_key : Tick.Inner_curve.Affine.t Plonk_verification_key_evals.t
     ; wrap_vk : Impls.Wrap.Verification_key.t
-    ; step_uses_lookup : Plonk_types.Opt.Flag.t
+    ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
     }
 end
 
@@ -38,7 +38,7 @@ module Side_loaded = struct
     type ('var, 'value, 'n1, 'n2) t =
       { max_proofs_verified : (module Nat.Add.Intf with type n = 'n1)
       ; public_input : ('var, 'value) Impls.Step.Typ.t
-      ; step_uses_lookup : Plonk_types.Opt.Flag.t
+      ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
       ; branches : 'n2 Nat.t
       }
   end
@@ -53,7 +53,7 @@ module Side_loaded = struct
 
   let to_basic
       { permanent =
-          { max_proofs_verified; public_input; branches; step_uses_lookup }
+          { max_proofs_verified; public_input; branches; feature_flags }
       ; ephemeral
       } =
     let wrap_key, wrap_vk =
@@ -71,7 +71,7 @@ module Side_loaded = struct
     ; branches
     ; wrap_domains = Common.wrap_domains ~proofs_verified
     ; wrap_key
-    ; step_uses_lookup
+    ; feature_flags
     }
 end
 
@@ -84,7 +84,7 @@ module Compiled = struct
           (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; wrap_domains : Domains.t
     ; step_domains : (Domains.t, 'branches) Vector.t
-    ; step_uses_lookup : Plonk_types.Opt.Flag.t
+    ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
     }
 
   (* This is the data associated to an inductive proof system with statement type
@@ -101,7 +101,7 @@ module Compiled = struct
     ; wrap_vk : Impls.Wrap.Verification_key.t Lazy.t
     ; wrap_domains : Domains.t
     ; step_domains : (Domains.t, 'branches) Vector.t
-    ; step_uses_lookup : Plonk_types.Opt.Flag.t
+    ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
     }
 
   type packed =
@@ -116,7 +116,7 @@ module Compiled = struct
       ; wrap_domains
       ; step_domains
       ; wrap_key
-      ; step_uses_lookup
+      ; feature_flags
       } =
     { Basic.max_proofs_verified
     ; wrap_domains
@@ -124,7 +124,7 @@ module Compiled = struct
     ; branches = Vector.length step_domains
     ; wrap_key = Lazy.force wrap_key
     ; wrap_vk = Lazy.force wrap_vk
-    ; step_uses_lookup
+    ; feature_flags
     }
 end
 
@@ -142,13 +142,13 @@ module For_step = struct
         | `Side_loaded of
           Impls.Step.field Pickles_base.Proofs_verified.One_hot.Checked.t ]
     ; step_domains : [ `Known of (Domains.t, 'branches) Vector.t | `Side_loaded ]
-    ; step_uses_lookup : Plonk_types.Opt.Flag.t
+    ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
     }
 
   let of_side_loaded (type a b c d e f)
       ({ ephemeral
        ; permanent =
-           { branches; max_proofs_verified; public_input; step_uses_lookup }
+           { branches; max_proofs_verified; public_input; feature_flags }
        } :
         (a, b, c, d) Side_loaded.t ) : (a, b, c, d) t =
     let index =
@@ -166,7 +166,7 @@ module For_step = struct
     ; wrap_key = index.wrap_index
     ; wrap_domain = `Side_loaded index.actual_wrap_domain_size
     ; step_domains = `Side_loaded
-    ; step_uses_lookup
+    ; feature_flags
     }
 
   let of_compiled
@@ -177,7 +177,7 @@ module For_step = struct
        ; wrap_key
        ; wrap_domains
        ; step_domains
-       ; step_uses_lookup
+       ; feature_flags
        } :
         _ Compiled.t ) =
     { branches
@@ -190,7 +190,7 @@ module For_step = struct
           ~f:Step_main_inputs.Inner_curve.constant
     ; wrap_domain = `Known wrap_domains.h
     ; step_domains = `Known step_domains
-    ; step_uses_lookup
+    ; feature_flags
     }
 end
 
@@ -255,9 +255,9 @@ let uses_lookup :
  fun tag ->
   match tag.kind with
   | Compiled ->
-      (lookup_compiled tag.id).step_uses_lookup
+      (lookup_compiled tag.id).feature_flags.lookup
   | Side_loaded ->
-      (lookup_side_loaded tag.id).permanent.step_uses_lookup
+      (lookup_side_loaded tag.id).permanent.feature_flags.lookup
 
 let value_to_field_elements :
     type a. (_, a, _, _) Tag.t -> a -> Tick.Field.t array =

--- a/src/lib/pickles/types_map.mli
+++ b/src/lib/pickles/types_map.mli
@@ -12,7 +12,7 @@ module Basic : sig
         Backend.Tick.Inner_curve.Affine.t
         Pickles_types.Plonk_verification_key_evals.t
     ; wrap_vk : Impls.Wrap.Verification_key.t
-    ; step_uses_lookup : Pickles_types.Plonk_types.Opt.Flag.t
+    ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
     }
 end
 
@@ -33,7 +33,7 @@ module Side_loaded : sig
       { max_proofs_verified :
           (module Pickles_types.Nat.Add.Intf with type n = 'n1)
       ; public_input : ('var, 'value) Impls.Step.Typ.t
-      ; step_uses_lookup : Pickles_types.Plonk_types.Opt.Flag.t
+      ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
       ; branches : 'n2 Pickles_types.Nat.t
       }
   end
@@ -56,7 +56,7 @@ module Compiled : sig
           (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; wrap_domains : Import.Domains.t
     ; step_domains : (Import.Domains.t, 'branches) Pickles_types.Vector.t
-    ; step_uses_lookup : Pickles_types.Plonk_types.Opt.Flag.t
+    ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
     }
 
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) t =
@@ -73,7 +73,7 @@ module Compiled : sig
     ; wrap_vk : Impls.Wrap.Verification_key.t Lazy.t
     ; wrap_domains : Import.Domains.t
     ; step_domains : (Import.Domains.t, 'branches) Pickles_types.Vector.t
-    ; step_uses_lookup : Pickles_types.Plonk_types.Opt.Flag.t
+    ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
     }
 end
 
@@ -94,7 +94,7 @@ module For_step : sig
     ; step_domains :
         [ `Known of (Import.Domains.t, 'branches) Pickles_types.Vector.t
         | `Side_loaded ]
-    ; step_uses_lookup : Pickles_types.Plonk_types.Opt.Flag.t
+    ; feature_flags : Pickles_types.Plonk_types.Features.with_flags
     }
 
   val of_side_loaded : ('a, 'b, 'c, 'd) Side_loaded.t -> ('a, 'b, 'c, 'd) t

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -300,7 +300,7 @@ let%test "lookup finalization" =
     constant
       (Plonk_types.All_evals.typ
          (module Impls.Step)
-         { lookup = Maybe; runtime = Maybe } )
+         { lookup = Maybe; runtime_tables = Maybe } )
       { evals = { public_input = x_hat_evals; evals = proof.openings.evals }
       ; ft_eval1 = proof.openings.ft_eval1
       }

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -82,10 +82,11 @@ let split_field (x : Field.t) : Field.t * Boolean.var =
   Field.(Assert.equal ((of_int 2 * y) + (is_odd :> t)) x) ;
   res
 
-let lookup_config = { Plonk_types.Lookup_config.lookup = No; runtime = No }
+let lookup_config : Plonk_types.Features.with_flags =
+  { lookup = No; runtime_tables = No }
 
-let commitment_lookup_config =
-  { Plonk_types.Lookup_config.lookup = No; runtime = No }
+let commitment_lookup_config : Plonk_types.Features.with_flags =
+  { lookup = No; runtime_tables = No }
 
 let lookup_config_for_pack =
   { Types.Wrap.Lookup_parameters.zero = Common.Lookup_parameters.tock_zero

--- a/src/lib/pickles/wrap_proof.ml
+++ b/src/lib/pickles/wrap_proof.ml
@@ -37,7 +37,7 @@ let typ : (Checked.t, Constant.t) Typ.t =
     [ Plonk_types.Messages.typ
         (module Impl)
         Inner_curve.typ
-        { lookup = No; runtime = No }
+        { lookup = No; runtime_tables = No }
         ~bool:Boolean.typ ~dummy:Inner_curve.Params.one
         ~commitment_lengths:(Commitment_lengths.create ~of_int:(fun x -> x))
     ; Types.Step.Bulletproof.typ ~length:(Nat.to_int Tock.Rounds.n)

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -177,7 +177,7 @@ module Features = struct
 
   type with_flags = Opt.Flag.t t
 
-  type with_booleans = bool t
+  type with_bools = bool t
 
   let create_all flag = { lookup = flag; runtime_tables = flag }
 

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -178,6 +178,11 @@ module Features = struct
   type with_flags = Opt.Flag.t t
 
   type with_booleans = bool t
+
+  let create_all flag = { lookup = flag; runtime_tables = flag }
+
+  let map { lookup; runtime_tables } ~f =
+    { lookup = f lookup; runtime_tables = f runtime_tables }
 end
 
 module Evals = struct

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -167,6 +167,19 @@ module Opt = struct
   end
 end
 
+module Features = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type 'flag t = { lookup : 'flag; runtime_tables : 'flag }
+    end
+  end]
+
+  type with_flags = Opt.Flag.t t
+
+  type with_booleans = bool t
+end
+
 module Lookup_config = struct
   type t = { lookup : Opt.Flag.t; runtime : Opt.Flag.t }
 end

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -183,6 +183,11 @@ module Features = struct
 
   let map { lookup; runtime_tables } ~f =
     { lookup = f lookup; runtime_tables = f runtime_tables }
+
+  let map2 t1 t2 ~f =
+    { lookup = f t1.lookup t2.lookup
+    ; runtime_tables = f t1.runtime_tables t2.runtime_tables
+    }
 end
 
 module Evals = struct

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -180,10 +180,6 @@ module Features = struct
   type with_booleans = bool t
 end
 
-module Lookup_config = struct
-  type t = Features.with_flags
-end
-
 module Evals = struct
   module Lookup = struct
     [%%versioned
@@ -249,8 +245,8 @@ module Evals = struct
         ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
         ~var_to_hlist:In_circuit.to_hlist ~var_of_hlist:In_circuit.of_hlist
 
-    let opt_typ impl ({ lookup; runtime_tables } : Lookup_config.t) ~dummy:z elt
-        =
+    let opt_typ impl ({ lookup; runtime_tables } : Features.with_flags) ~dummy:z
+        elt =
       Opt.typ impl lookup
         ~dummy:(dummy z ~runtime:(Opt.Flag.equal runtime_tables Yes))
         (typ impl ~runtime_tables ~dummy:z elt)
@@ -696,7 +692,7 @@ module Messages = struct
 
   let typ (type n f)
       (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) g
-      ({ lookup; runtime_tables } : Lookup_config.t) ~dummy
+      ({ lookup; runtime_tables } : Features.with_flags) ~dummy
       ~(commitment_lengths : (((int, n) Vector.t as 'v), int, int) Poly.t) ~bool
       =
     let open Snarky_backendless.Typ in

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -82,6 +82,10 @@ module Features : sig
   type with_flags = Opt.Flag.t t
 
   type with_booleans = bool t
+
+  val create_all : 'a -> 'a t
+
+  val map : 'a t -> f:('a -> 'b) -> 'b t
 end
 
 module Messages : sig

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -71,6 +71,19 @@ module Permuts = Nat.N7
 module Permuts_minus_1 = Nat.N6
 module Permuts_minus_1_vec = Vector.Vector_6
 
+module Features : sig
+  [%%versioned:
+  module Stable : sig
+    module V1 : sig
+      type 'flag t = { lookup : 'flag; runtime_tables : 'flag }
+    end
+  end]
+
+  type with_flags = Opt.Flag.t t
+
+  type with_booleans = bool t
+end
+
 module Lookup_config : sig
   type t = { lookup : Opt.Flag.t; runtime : Opt.Flag.t }
 end

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -86,6 +86,8 @@ module Features : sig
   val create_all : 'a -> 'a t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
+
+  val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
 end
 
 module Messages : sig

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -84,10 +84,6 @@ module Features : sig
   type with_booleans = bool t
 end
 
-module Lookup_config : sig
-  type t = Features.with_flags
-end
-
 module Messages : sig
   module Poly : sig
     type ('w, 'z, 't) t = { w : 'w; z : 'z; t : 't }
@@ -144,7 +140,7 @@ module Messages : sig
   val typ :
        (module Snarky_backendless.Snark_intf.Run with type field = 'f)
     -> ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> Lookup_config.t
+    -> Features.with_flags
     -> dummy:'b
     -> commitment_lengths:((int, 'n) Vector.vec, int, int) Poly.t
     -> bool:('c, bool, 'f) Snarky_backendless.Typ.t
@@ -328,7 +324,7 @@ module All_evals : sig
 
   val typ :
        (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> Lookup_config.t
+    -> Features.with_flags
     -> ( ( 'f Snarky_backendless.Cvar.t
          , 'f Snarky_backendless.Cvar.t array
          , 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t )

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -85,7 +85,7 @@ module Features : sig
 end
 
 module Lookup_config : sig
-  type t = { lookup : Opt.Flag.t; runtime : Opt.Flag.t }
+  type t = Features.with_flags
 end
 
 module Messages : sig

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -81,7 +81,7 @@ module Features : sig
 
   type with_flags = Opt.Flag.t t
 
-  type with_booleans = bool t
+  type with_bools = bool t
 
   val create_all : 'a -> 'a t
 

--- a/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
+++ b/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml
@@ -1944,7 +1944,7 @@ module Choices = struct
         (fun ~self ->
           let prevs = prevs ~self in
           { Pickles.Inductive_rule.identifier = Js.to_string rule##.identifier
-          ; uses_lookup = false
+          ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
           ; prevs
           ; main =
               (fun { public_input } ->

--- a/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
+++ b/src/lib/transaction_snark/test/multisig_account/multisig_account.ml
@@ -210,7 +210,8 @@ let%test_module "multisig_account" =
                         ; public_output = ()
                         ; auxiliary_output = ()
                         } )
-                  ; uses_lookup = false
+                  ; feature_flags =
+                      Pickles_types.Plonk_types.Features.create_all false
                   }
                 in
                 Pickles.compile () ~cache:Cache_dir.cache
@@ -258,7 +259,8 @@ let%test_module "multisig_account" =
                             ; public_output = ()
                             ; auxiliary_output = ()
                             } )
-                      ; uses_lookup = false
+                      ; feature_flags =
+                          Pickles_types.Plonk_types.Features.create_all false
                       }
                     ] )
               in

--- a/src/lib/transaction_snark/test/ring_sig.ml
+++ b/src/lib/transaction_snark/test/ring_sig.ml
@@ -56,7 +56,7 @@ let ring_sig_rule (ring_member_pks : Schnorr.Chunked.Public_key.t list) :
         ; public_output = ()
         ; auxiliary_output = ()
         } )
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }
 
 let%test_unit "1-of-1" =

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -290,7 +290,7 @@ let dummy_rule self : _ Pickles.Inductive_rule.t =
         ; public_output = ()
         ; auxiliary_output = ()
         } )
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }
 
 let gen_snapp_ledger =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2081,7 +2081,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   ; public_output = ()
                   ; auxiliary_output = ()
                   } )
-            ; uses_lookup = false
+            ; feature_flags = Plonk_types.Features.create_all false
             }
         | Opt_signed_opt_signed ->
             { identifier = "opt_signed-opt_signed"
@@ -2096,7 +2096,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   ; public_output = ()
                   ; auxiliary_output = ()
                   } )
-            ; uses_lookup = false
+            ; feature_flags = Plonk_types.Features.create_all false
             }
         | Opt_signed ->
             { identifier = "opt_signed"
@@ -2111,7 +2111,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                   ; public_output = ()
                   ; auxiliary_output = ()
                   } )
-            ; uses_lookup = false
+            ; feature_flags = Plonk_types.Features.create_all false
             }
     end
 
@@ -3071,7 +3071,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             ; public_output = ()
             ; auxiliary_output = ()
             } )
-      ; uses_lookup = false
+      ; feature_flags = Plonk_types.Features.create_all false
       }
 
     let transaction_union_handler handler (transaction : Transaction_union.t)
@@ -3231,7 +3231,7 @@ module Make_str (A : Wire_types.Concrete) = struct
             ; public_output = ()
             ; auxiliary_output = ()
             } )
-      ; uses_lookup = false
+      ; feature_flags = Plonk_types.Features.create_all false
       }
   end
 
@@ -4111,7 +4111,7 @@ module Make_str (A : Wire_types.Concrete) = struct
                 ; public_output = ()
                 ; auxiliary_output = ()
                 } )
-          ; uses_lookup = false
+          ; feature_flags = Plonk_types.Features.create_all false
           }
         in
         Pickles.compile () ~cache:Cache_dir.cache

--- a/src/lib/zkapps_examples/actions/zkapps_actions.ml
+++ b/src/lib/zkapps_examples/actions/zkapps_actions.ml
@@ -40,12 +40,12 @@ let initialize_rule public_key : _ Pickles.Inductive_rule.t =
   { identifier = "Initialize zkApp"
   ; prevs = []
   ; main = initialize public_key
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }
 
 let update_actions_rule public_key : _ Pickles.Inductive_rule.t =
   { identifier = "Update sequence events"
   ; prevs = []
   ; main = update_actions public_key
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }

--- a/src/lib/zkapps_examples/add_events/zkapps_add_events.ml
+++ b/src/lib/zkapps_examples/add_events/zkapps_add_events.ml
@@ -40,12 +40,12 @@ let initialize_rule public_key : _ Pickles.Inductive_rule.t =
   { identifier = "Initialize zkApp"
   ; prevs = []
   ; main = initialize public_key
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }
 
 let update_events_rule public_key : _ Pickles.Inductive_rule.t =
   { identifier = "Update events"
   ; prevs = []
   ; main = update_events public_key
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }

--- a/src/lib/zkapps_examples/big_circuit/zkapps_big_circuit.ml
+++ b/src/lib/zkapps_examples/big_circuit/zkapps_big_circuit.ml
@@ -40,5 +40,5 @@ let rule ~num_constraints public_key : _ Pickles.Inductive_rule.t =
   { identifier = "Empty update with a large circuit"
   ; prevs = []
   ; main = main ~num_constraints public_key
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }

--- a/src/lib/zkapps_examples/calls/zkapps_calls.ml
+++ b/src/lib/zkapps_examples/calls/zkapps_calls.ml
@@ -197,7 +197,11 @@ module Rules = struct
         input
 
     let rule : _ Pickles.Inductive_rule.t =
-      { identifier = "Initialize snapp"; prevs = []; main; uses_lookup = false }
+      { identifier = "Initialize snapp"
+      ; prevs = []
+      ; main
+      ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
+      }
   end
 
   (** Rule to update the zkApp state.
@@ -253,7 +257,11 @@ module Rules = struct
         input
 
     let rule : _ Pickles.Inductive_rule.t =
-      { identifier = "Update state"; prevs = []; main; uses_lookup = false }
+      { identifier = "Update state"
+      ; prevs = []
+      ; main
+      ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
+      }
   end
 
   (** Callable zkApp addition rule.
@@ -316,7 +324,11 @@ module Rules = struct
         input
 
     let rule : _ Pickles.Inductive_rule.t =
-      { identifier = "Add method"; prevs = []; main; uses_lookup = false }
+      { identifier = "Add method"
+      ; prevs = []
+      ; main
+      ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
+      }
   end
 
   (** Callable zkApp addition-and-call rule.
@@ -408,7 +420,7 @@ module Rules = struct
       { identifier = "Add-and-call method"
       ; prevs = []
       ; main
-      ; uses_lookup = false
+      ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
       }
   end
 end

--- a/src/lib/zkapps_examples/empty_update/zkapps_empty_update.ml
+++ b/src/lib/zkapps_examples/empty_update/zkapps_empty_update.ml
@@ -9,5 +9,5 @@ let rule public_key : _ Pickles.Inductive_rule.t =
   { identifier = "Empty update"
   ; prevs = []
   ; main = main public_key
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }

--- a/src/lib/zkapps_examples/initialize_state/zkapps_initialize_state.ml
+++ b/src/lib/zkapps_examples/initialize_state/zkapps_initialize_state.ml
@@ -39,12 +39,12 @@ let initialize_rule public_key : _ Pickles.Inductive_rule.t =
   { identifier = "Initialize snapp"
   ; prevs = []
   ; main = initialize public_key
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }
 
 let update_state_rule public_key : _ Pickles.Inductive_rule.t =
   { identifier = "Update state"
   ; prevs = []
   ; main = update_state public_key
-  ; uses_lookup = false
+  ; feature_flags = Pickles_types.Plonk_types.Features.create_all false
   }

--- a/src/lib/zkapps_examples/zkapps_examples.ml
+++ b/src/lib/zkapps_examples/zkapps_examples.ml
@@ -528,10 +528,10 @@ let compile :
            H4_6.T(Pickles.Inductive_rule).t = function
       | [] ->
           []
-      | { identifier; prevs; main; uses_lookup } :: choices ->
+      | { identifier; prevs; main; feature_flags } :: choices ->
           { identifier
           ; prevs
-          ; uses_lookup
+          ; feature_flags
           ; main =
               (fun { Pickles.Inductive_rule.public_input = () } ->
                 let vk_hash =


### PR DESCRIPTION
This PR recreates some changes from #12342 using only feature flags for the lookup-related components. This builds upon #12605, as part of reducing the diff of #12342 for the purposes of debugging.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them