### PR TITLE
Add types to shape dump

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1421,7 +1421,8 @@ let dump_type_shapes =
   in
   Command.basic ~summary:"Print serialization shapes of versioned types"
     (Command.Param.map max_depth_flag ~f:(fun max_depth () ->
-         Ppx_version_runtime.Shapes.iteri ~f:(fun ~key:path ~data:shape ->
+         Ppx_version_runtime.Shapes.iteri
+           ~f:(fun ~key:path ~data:(shape, ty_decl) ->
              let open Bin_prot.Shape in
              let canonical = eval shape in
              let digest = Canonical.to_digest canonical |> Digest.to_hex in
@@ -1453,7 +1454,8 @@ let dump_type_shapes =
                in
                Sexp.to_string summary_sexp
              in
-             Core_kernel.printf "%s, %s, %s\n" path digest shape_summary ) ) )
+             Core_kernel.printf "%s, %s, %s, %s\n" path digest shape_summary
+               ty_decl ) ) )
 
 [%%if force_updates]
 

--- a/src/lib/ppx_version/runtime/shapes.ml
+++ b/src/lib/ppx_version/runtime/shapes.ml
@@ -3,7 +3,7 @@
 open Core_kernel
 module Shape_tbl = Hashtbl.Make (Base.String)
 
-let shape_tbl : Bin_prot.Shape.t Shape_tbl.t = Shape_tbl.create ()
+let shape_tbl : (Bin_prot.Shape.t * string) Shape_tbl.t = Shape_tbl.create ()
 
 let find path_to_type = Shape_tbl.find shape_tbl path_to_type
 
@@ -14,8 +14,8 @@ let equal_shapes shape1 shape2 =
   let canonical2 = Bin_prot.Shape.eval shape2 in
   Bin_prot.Shape.Canonical.compare canonical1 canonical2 = 0
 
-let register path_to_type (shape : Bin_prot.Shape.t) =
-  match Shape_tbl.add shape_tbl ~key:path_to_type ~data:shape with
+let register path_to_type (shape : Bin_prot.Shape.t) (ty_decl : string) =
+  match Shape_tbl.add shape_tbl ~key:path_to_type ~data:(shape, ty_decl) with
   | `Ok ->
       ()
   | `Duplicate -> (
@@ -23,7 +23,7 @@ let register path_to_type (shape : Bin_prot.Shape.t) =
          once will yield duplicates; OK if the shapes are the same
       *)
       match find path_to_type with
-      | Some shape' ->
+      | Some (shape', _ty_decl) ->
           if not (equal_shapes shape shape') then
             failwithf "Different type shapes at path %s" path_to_type ()
           else ()

--- a/src/lib/ppx_version/tools/print_binable_functors.ml
+++ b/src/lib/ppx_version/tools/print_binable_functors.ml
@@ -68,8 +68,9 @@ let print_included_binable_functor_app ~path inc =
       printf "%s" s ;
       if i < path_len - 1 then printf "." ) ;
   printf ":%!" ;
-  Pprintast.structure_item Versioned_util.diff_formatter inc ;
-  Format.pp_print_flush Versioned_util.diff_formatter () ;
+  let formatter = Versioned_util.diff_formatter Format.std_formatter in
+  Pprintast.structure_item formatter inc ;
+  Format.pp_print_flush formatter () ;
   printf "\n%!"
 
 let traverse_ast =

--- a/src/lib/ppx_version/versioned_type.ml
+++ b/src/lib/ppx_version/versioned_type.ml
@@ -169,8 +169,9 @@ module Printing = struct
       List.map type_decls_filtered_attrs ~f:filter_type_manifests
     in
     let stri = type_decls_to_stri type_decls_filtered_manifests in
-    Pprintast.structure_item Versioned_util.diff_formatter stri ;
-    Format.pp_print_flush Versioned_util.diff_formatter () ;
+    let formatter = Versioned_util.diff_formatter Format.std_formatter in
+    Pprintast.structure_item formatter stri ;
+    Format.pp_print_flush formatter () ;
     printf "\n%!" ;
     []
 

--- a/src/lib/ppx_version/versioned_util.ml
+++ b/src/lib/ppx_version/versioned_util.ml
@@ -17,10 +17,10 @@ let check_modname ~loc name : string =
     Location.raise_errorf ~loc
       "Expected a module named Stable, but got a module named %s." name
 
-(* for diffing types and binable functors, replace newlines in standard formatter
+(* for diffing types and binable functors, replace newlines in formatter
    with a space, so string is all on one line *)
-let diff_formatter =
-  let out_funs = Format.(pp_get_formatter_out_functions std_formatter ()) in
+let diff_formatter formatter =
+  let out_funs = Format.(pp_get_formatter_out_functions formatter ()) in
   let out_funs' =
     { out_funs with
       out_newline = (fun () -> out_funs.out_spaces 1)


### PR DESCRIPTION
Add a string representation of types to the output of `dump-type-shapes`, which the version linter can use when reporting errors.

Sample line of output: 
```
src/lib/pickles_base/proofs_verified.ml:Pickles_base__Proofs_verified.Stable.V1.t, 9d312ca152cee7839dbdfc6bef04ae56, (Exp(Variant((N0())(N1())(N2())))), | N0  | N1  | N2 
```