### PR TITLE
Check for expected failure on first pass

### DIFF
--- a/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
+++ b/src/lib/transaction_snark/test/access_permission/transaction_snark_test_access_permission.ml
@@ -189,27 +189,35 @@ let%test_module "Access permission tests" =
     let%test_unit "Signature with None" = run_test Signature None
 
     let%test_unit "None_given with Either" =
-      run_test ~expected_failure:Update_not_permitted_access None_given Either
+      run_test
+        ~expected_failure:(Update_not_permitted_access, Pass_2)
+        None_given Either
 
     let%test_unit "Proof with Either" = run_test (Proof vk_hash) Either
 
     let%test_unit "Signature with Either" = run_test Signature Either
 
     let%test_unit "None_given with Proof" =
-      run_test ~expected_failure:Update_not_permitted_access None_given Proof
+      run_test
+        ~expected_failure:(Update_not_permitted_access, Pass_2)
+        None_given Proof
 
     let%test_unit "Proof with Proof" = run_test (Proof vk_hash) Proof
 
     let%test_unit "Signature with Proof" =
-      run_test ~expected_failure:Update_not_permitted_access Signature Proof
+      run_test
+        ~expected_failure:(Update_not_permitted_access, Pass_2)
+        Signature Proof
 
     let%test_unit "None_given with Signature" =
-      run_test ~expected_failure:Update_not_permitted_access None_given
-        Signature
+      run_test
+        ~expected_failure:(Update_not_permitted_access, Pass_2)
+        None_given Signature
 
     let%test_unit "Proof with Signature" =
-      run_test ~expected_failure:Update_not_permitted_access (Proof vk_hash)
-        Signature
+      run_test
+        ~expected_failure:(Update_not_permitted_access, Pass_2)
+        (Proof vk_hash) Signature
 
     let%test_unit "Signature with Signature" = run_test Signature Signature
   end )

--- a/src/lib/transaction_snark/test/account_timing/account_timing.ml
+++ b/src/lib/transaction_snark/test/account_timing/account_timing.ml
@@ -2022,7 +2022,9 @@ let%test_module "account timing check" =
                 ledger_init_state ;
               Transaction_snark_tests.Util.check_zkapp_command_with_merges_exn
                 ~expected_failure:
-                  Transaction_status.Failure.Update_not_permitted_timing ledger
+                  ( Transaction_status.Failure.Update_not_permitted_timing
+                  , Pass_2 )
+                ledger
                 [ create_timed_account_zkapp_command ] ) )
 
     let%test_unit "zkApp command, change untimed account to timed" =
@@ -2177,7 +2179,8 @@ let%test_module "account timing check" =
                   Transaction_snark_tests.Util
                   .check_zkapp_command_with_merges_exn
                     ~expected_failure:
-                      Transaction_status.Failure.Update_not_permitted_timing
+                      ( Transaction_status.Failure.Update_not_permitted_timing
+                      , Pass_2 )
                     ledger
                     [ update_timing_zkapp_command ] ) ) )
   end )

--- a/src/lib/transaction_snark/test/app_state/app_state.ml
+++ b/src/lib/transaction_snark/test/app_state/app_state.ml
@@ -6,7 +6,8 @@ struct
   let test_description = "app_state"
 
   let failure_expected =
-    Mina_base.Transaction_status.Failure.Update_not_permitted_app_state
+    ( Mina_base.Transaction_status.Failure.Update_not_permitted_app_state
+    , Transaction_snark_tests.Util.Pass_2 )
 
   let snapp_update =
     { Account_update.Update.dummy with

--- a/src/lib/transaction_snark/test/delegate/delegate.ml
+++ b/src/lib/transaction_snark/test/delegate/delegate.ml
@@ -1,11 +1,13 @@
 open Mina_base
+module U = Transaction_snark_tests.Util
 
 module Test_input : Transaction_snark_tests.Test_zkapp_update.Input_intf =
 struct
   let test_description = "delegate"
 
   let failure_expected =
-    Mina_base.Transaction_status.Failure.Update_not_permitted_delegate
+    ( Mina_base.Transaction_status.Failure.Update_not_permitted_delegate
+    , U.Pass_2 )
 
   let snapp_update =
     let pk =

--- a/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
+++ b/src/lib/transaction_snark/test/party_preconditions/party_preconditions.ml
@@ -88,7 +88,8 @@ let%test_module "Valid_while precondition tests" =
                       (create_spec specs new_kp global_slot)
                   in
                   U.check_zkapp_command_with_merges_exn
-                    ~expected_failure:Valid_while_precondition_unsatisfied
+                    ~expected_failure:
+                      (Valid_while_precondition_unsatisfied, U.Pass_2)
                     ~global_slot:Mina_numbers.Global_slot.zero ledger
                     [ zkapp_command ] ) ) )
   end )
@@ -388,9 +389,10 @@ let%test_module "Protocol state precondition tests" =
                     init_ledger ledger ;
                   U.check_zkapp_command_with_merges_exn
                     ~expected_failure:
-                      Transaction_status.Failure
-                      .Protocol_state_precondition_unsatisfied ~state_body
-                    ledger
+                      ( Transaction_status.Failure
+                        .Protocol_state_precondition_unsatisfied
+                      , U.Pass_2 )
+                    ~state_body ledger
                     [ zkapp_command_with_valid_fee_payer ] ) ) )
   end )
 
@@ -656,9 +658,10 @@ let%test_module "Account precondition tests" =
                     ~ledger snapp_pk ;
                   U.check_zkapp_command_with_merges_exn
                     ~expected_failure:
-                      Transaction_status.Failure
-                      .Account_nonce_precondition_unsatisfied ~state_body ledger
-                    [ zkapp_command ] ) ) )
+                      ( Transaction_status.Failure
+                        .Account_nonce_precondition_unsatisfied
+                      , U.Pass_2 )
+                    ~state_body ledger [ zkapp_command ] ) ) )
 
     let%test_unit "invalid account predicate in fee payer" =
       let state_body = U.genesis_state_body in

--- a/src/lib/transaction_snark/test/permissions/permissions.ml
+++ b/src/lib/transaction_snark/test/permissions/permissions.ml
@@ -5,7 +5,8 @@ struct
   let test_description = "permissions"
 
   let failure_expected =
-    Mina_base.Transaction_status.Failure.Update_not_permitted_permissions
+    ( Mina_base.Transaction_status.Failure.Update_not_permitted_permissions
+    , Transaction_snark_tests.Util.Pass_2 )
 
   let snapp_update =
     { Account_update.Update.dummy with

--- a/src/lib/transaction_snark/test/test_zkapp_update.ml
+++ b/src/lib/transaction_snark/test/test_zkapp_update.ml
@@ -12,7 +12,7 @@ module type Input_intf = sig
 
   val test_description : string
 
-  val failure_expected : Mina_base.Transaction_status.Failure.t
+  val failure_expected : Mina_base.Transaction_status.Failure.t * U.pass_number
 end
 
 module Make (Input : Input_intf) = struct

--- a/src/lib/transaction_snark/test/token_symbol/token_symbol.ml
+++ b/src/lib/transaction_snark/test/token_symbol/token_symbol.ml
@@ -5,7 +5,8 @@ struct
   let test_description = "token_symbol"
 
   let failure_expected =
-    Mina_base.Transaction_status.Failure.Update_not_permitted_token_symbol
+    ( Mina_base.Transaction_status.Failure.Update_not_permitted_token_symbol
+    , Transaction_snark_tests.Util.Pass_2 )
 
   let snapp_update =
     { Account_update.Update.dummy with

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -79,191 +79,215 @@ let check_zkapp_command_with_merges_exn ?expected_failure ?ignore_outside_snark
       ~default:
         (Mina_numbers.Global_slot.succ state_view.global_slot_since_genesis)
   in
-  (* Do first pass*)
-  let partial_stmts =
-    List.map zkapp_commands ~f:(fun zkapp_command ->
-        let first_pass_ledger_witness =
-          Sparse_ledger.of_ledger_subset_exn ledger
-            (Zkapp_command.accounts_referenced zkapp_command)
-        in
-        let partial_stmt =
-          Ledger.apply_transaction_first_pass ~constraint_constants ~global_slot
-            ~txn_state_view:state_view ledger
-            (Mina_transaction.Transaction.Command (Zkapp_command zkapp_command))
-          |> Or_error.ok_exn
-        in
-        (partial_stmt, first_pass_ledger_witness, Ledger.merkle_root ledger) )
+  let check_failure failure err =
+    printf
+      !"Expected failure %{sexp: Transaction_status.Failure.t} Got %s\n%!"
+      failure (Error.to_string_hum err) ;
+    assert (
+      String.is_substring (Error.to_string_hum err)
+        ~substring:(Transaction_status.Failure.to_string failure) )
   in
-  let connecting_ledger = Ledger.merkle_root ledger in
-  Async.Deferred.List.iter (List.zip_exn zkapp_commands partial_stmts)
-    ~f:(fun
-         ( zkapp_command
-         , ( partial_stmt
-           , first_pass_ledger_witness
-           , first_pass_ledger_target_hash ) )
-       ->
-      match
-        Or_error.try_with (fun () ->
-            Transaction_snark.zkapp_command_witnesses_exn ~constraint_constants
-              ~global_slot ~state_body ~fee_excess:Amount.Signed.zero
-              [ ( `Pending_coinbase_init_stack init_stack
-                , `Pending_coinbase_of_statement
-                    (pending_coinbase_state_stack ~state_body_hash ~global_slot)
-                , `Sparse_ledger first_pass_ledger_witness
-                , `Ledger ledger
-                , `Connecting_ledger_hash connecting_ledger
-                , zkapp_command )
-              ] )
-      with
-      | Error e -> (
-          match expected_failure with
-          | Some failure ->
-              Core.printf
-                !"Expected failure %{sexp: Transaction_status.Failure.t} Got %s\n\
-                  %!"
-                failure (Error.to_string_hum e) ;
-              assert (
-                String.is_substring (Error.to_string_hum e)
-                  ~substring:(Transaction_status.Failure.to_string failure) ) ;
-              Async.Deferred.unit
-          | None ->
-              failwith
-                (sprintf "apply_transaction failed with %s"
-                   (Error.to_string_hum e) ) )
-      | Ok witnesses -> (
-          let open Async.Deferred.Let_syntax in
-          let applied, statement_opt =
-            if ignore_outside_snark then
-              ( Ledger.Transaction_applied.Varying.Command
-                  (Zkapp_command
-                     { command =
-                         { With_status.status = Applied; data = zkapp_command }
-                     ; accounts = []
-                     ; new_accounts = []
-                     } )
-              , None )
-            else
-              let second_pass_ledger_source_hash = Ledger.merkle_root ledger in
-              let applied_txn =
-                Ledger.apply_transaction_second_pass ledger partial_stmt
-                |> Or_error.ok_exn
-              in
-              (*Expected transaction statement*)
-              let stmt : Transaction_snark.Statement.t =
-                { Mina_wire_types.Mina_state_snarked_ledger_state.Poly.V2.source =
-                    { first_pass_ledger =
-                        Sparse_ledger.merkle_root first_pass_ledger_witness
-                    ; second_pass_ledger = second_pass_ledger_source_hash
-                    ; pending_coinbase_stack = init_stack
-                    ; local_state = Mina_state.Local_state.empty ()
-                    }
-                ; target =
-                    { first_pass_ledger = first_pass_ledger_target_hash
-                    ; second_pass_ledger = Ledger.merkle_root ledger
-                    ; pending_coinbase_stack =
-                        Pending_coinbase.Stack.push_state state_body_hash
-                          global_slot init_stack
-                    ; local_state = Mina_state.Local_state.empty ()
-                    }
-                ; connecting_ledger_left = connecting_ledger
-                ; connecting_ledger_right = connecting_ledger
-                ; fee_excess = Zkapp_command.fee_excess zkapp_command
-                ; supply_increase =
-                    Ledger.Transaction_applied.supply_increase applied_txn
+  with_return (fun { return } ->
+      (* Do first pass, checking for expected error *)
+      let partial_stmts =
+        List.map zkapp_commands ~f:(fun zkapp_command ->
+            let first_pass_ledger_witness =
+              Sparse_ledger.of_ledger_subset_exn ledger
+                (Zkapp_command.accounts_referenced zkapp_command)
+            in
+            let partial_stmt =
+              match
+                Ledger.apply_transaction_first_pass ~constraint_constants
+                  ~global_slot ~txn_state_view:state_view ledger
+                  (Mina_transaction.Transaction.Command
+                     (Zkapp_command zkapp_command) )
+              with
+              | Error err -> (
+                  match expected_failure with
+                  | Some failure ->
+                      check_failure failure err ;
+                      (* got expected failure, let's go *)
+                      return Async.Deferred.unit
+                  | None ->
+                      failwith
+                        (sprintf "apply_transaction_first_pass failed with %s"
+                           (Error.to_string_hum err) ) )
+              | Ok stmt ->
+                  stmt
+            in
+            (partial_stmt, first_pass_ledger_witness, Ledger.merkle_root ledger) )
+      in
+      let connecting_ledger = Ledger.merkle_root ledger in
+      Async.Deferred.List.iter (List.zip_exn zkapp_commands partial_stmts)
+        ~f:(fun
+             ( zkapp_command
+             , ( partial_stmt
+               , first_pass_ledger_witness
+               , first_pass_ledger_target_hash ) )
+           ->
+          match
+            Or_error.try_with (fun () ->
+                Transaction_snark.zkapp_command_witnesses_exn
+                  ~constraint_constants ~global_slot ~state_body
+                  ~fee_excess:Amount.Signed.zero
+                  [ ( `Pending_coinbase_init_stack init_stack
+                    , `Pending_coinbase_of_statement
+                        (pending_coinbase_state_stack ~state_body_hash
+                           ~global_slot )
+                    , `Sparse_ledger first_pass_ledger_witness
+                    , `Ledger ledger
+                    , `Connecting_ledger_hash connecting_ledger
+                    , zkapp_command )
+                  ] )
+          with
+          | Error err -> (
+              match expected_failure with
+              | Some failure ->
+                  check_failure failure err ; Async.Deferred.unit
+              | None ->
+                  failwith
+                    (sprintf "zkapp_command_witnesses_exn failed with %s"
+                       (Error.to_string_hum err) ) )
+          | Ok witnesses -> (
+              let open Async.Deferred.Let_syntax in
+              let applied, statement_opt =
+                if ignore_outside_snark then
+                  ( Ledger.Transaction_applied.Varying.Command
+                      (Zkapp_command
+                         { command =
+                             { With_status.status = Applied
+                             ; data = zkapp_command
+                             }
+                         ; accounts = []
+                         ; new_accounts = []
+                         } )
+                  , None )
+                else
+                  let second_pass_ledger_source_hash =
+                    Ledger.merkle_root ledger
+                  in
+                  let applied_txn =
+                    Ledger.apply_transaction_second_pass ledger partial_stmt
                     |> Or_error.ok_exn
-                ; sok_digest = ()
-                }
+                  in
+                  (*Expected transaction statement*)
+                  let stmt : Transaction_snark.Statement.t =
+                    { Mina_wire_types.Mina_state_snarked_ledger_state.Poly.V2
+                      .source =
+                        { first_pass_ledger =
+                            Sparse_ledger.merkle_root first_pass_ledger_witness
+                        ; second_pass_ledger = second_pass_ledger_source_hash
+                        ; pending_coinbase_stack = init_stack
+                        ; local_state = Mina_state.Local_state.empty ()
+                        }
+                    ; target =
+                        { first_pass_ledger = first_pass_ledger_target_hash
+                        ; second_pass_ledger = Ledger.merkle_root ledger
+                        ; pending_coinbase_stack =
+                            Pending_coinbase.Stack.push_state state_body_hash
+                              global_slot init_stack
+                        ; local_state = Mina_state.Local_state.empty ()
+                        }
+                    ; connecting_ledger_left = connecting_ledger
+                    ; connecting_ledger_right = connecting_ledger
+                    ; fee_excess = Zkapp_command.fee_excess zkapp_command
+                    ; supply_increase =
+                        Ledger.Transaction_applied.supply_increase applied_txn
+                        |> Or_error.ok_exn
+                    ; sok_digest = ()
+                    }
+                  in
+                  (applied_txn.varying, Some stmt)
               in
-              (applied_txn.varying, Some stmt)
-          in
-          match applied with
-          | Command (Zkapp_command { command; _ }) -> (
-              let run_in_snark () =
-                let%map p =
-                  match List.rev witnesses with
-                  | [] ->
-                      failwith "no witnesses generated"
-                  | (witness, spec, stmt) :: rest ->
-                      let open Async.Deferred.Or_error.Let_syntax in
-                      let%bind p1 =
-                        Async.Deferred.Or_error.try_with (fun () ->
-                            T.of_zkapp_command_segment_exn ~statement:stmt
-                              ~witness ~spec )
-                      in
-                      Async.Deferred.List.fold ~init:(Ok p1) rest
-                        ~f:(fun acc (witness, spec, stmt) ->
-                          let%bind prev = Async.Deferred.return acc in
-                          let%bind curr =
+              match applied with
+              | Command (Zkapp_command { command; _ }) -> (
+                  let run_in_snark () =
+                    let%map p =
+                      match List.rev witnesses with
+                      | [] ->
+                          failwith "no witnesses generated"
+                      | (witness, spec, stmt) :: rest ->
+                          let open Async.Deferred.Or_error.Let_syntax in
+                          let%bind p1 =
                             Async.Deferred.Or_error.try_with (fun () ->
                                 T.of_zkapp_command_segment_exn ~statement:stmt
                                   ~witness ~spec )
                           in
-                          let sok_digest =
-                            Sok_message.create ~fee:Fee.zero
-                              ~prover:
-                                (Quickcheck.random_value
-                                   Public_key.Compressed.gen )
-                            |> Sok_message.digest
-                          in
-                          T.merge ~sok_digest prev curr )
-                in
-                let p = Or_error.ok_exn p in
-                ( match statement_opt with
-                | Some expected_stmt ->
-                    [%test_eq: Transaction_snark.Statement.t] expected_stmt
-                      (Transaction_snark.statement p)
-                | None ->
-                    () ) ;
-                if not ignore_outside_snark then
-                  let target_ledger_root_snark =
-                    (Transaction_snark.statement p).target.second_pass_ledger
-                  in
-                  let target_ledger_root = Ledger.merkle_root ledger in
-                  [%test_eq: Ledger_hash.t] target_ledger_root
-                    target_ledger_root_snark
-              in
-              match command.status with
-              | Applied -> (
-                  match expected_failure with
-                  | Some failure ->
-                      failwith
-                        (sprintf
-                           !"Application did not fail as expected. Expected \
-                             failure: \
-                             %{sexp:Mina_base.Transaction_status.Failure.t}"
-                           failure )
-                  | None ->
-                      run_in_snark () )
-              | Failed failure_tbl -> (
-                  match expected_failure with
-                  | None ->
-                      failwith
-                        (sprintf
-                           !"Application failed. Failure statuses: %{sexp: \
-                             Mina_base.Transaction_status.Failure.Collection.t}"
-                           failure_tbl )
-                  | Some failure ->
-                      let failures = List.concat failure_tbl in
-                      assert (not (List.is_empty failures)) ;
-                      let failed_as_expected =
-                        (*Check that there's at least the expected failure*)
-                        List.fold failures ~init:false ~f:(fun acc f ->
-                            acc
-                            || Mina_base.Transaction_status.Failure.(
-                                 equal failure f) )
+                          Async.Deferred.List.fold ~init:(Ok p1) rest
+                            ~f:(fun acc (witness, spec, stmt) ->
+                              let%bind prev = Async.Deferred.return acc in
+                              let%bind curr =
+                                Async.Deferred.Or_error.try_with (fun () ->
+                                    T.of_zkapp_command_segment_exn
+                                      ~statement:stmt ~witness ~spec )
+                              in
+                              let sok_digest =
+                                Sok_message.create ~fee:Fee.zero
+                                  ~prover:
+                                    (Quickcheck.random_value
+                                       Public_key.Compressed.gen )
+                                |> Sok_message.digest
+                              in
+                              T.merge ~sok_digest prev curr )
+                    in
+                    let p = Or_error.ok_exn p in
+                    ( match statement_opt with
+                    | Some expected_stmt ->
+                        [%test_eq: Transaction_snark.Statement.t] expected_stmt
+                          (Transaction_snark.statement p)
+                    | None ->
+                        () ) ;
+                    if not ignore_outside_snark then
+                      let target_ledger_root_snark =
+                        (Transaction_snark.statement p).target
+                          .second_pass_ledger
                       in
-                      if not failed_as_expected then
-                        failwith
-                          (sprintf
-                             !"Application failed but not as expected. \
-                               Expected failure: \
-                               %{sexp:Mina_base.Transaction_status.Failure.t} \
-                               Failure statuses: %{sexp: \
-                               Mina_base.Transaction_status.Failure.Collection.t}"
-                             failure failure_tbl )
-                      else run_in_snark () ) )
-          | _ ->
-              failwith "zkapp_command expected" ) )
+                      let target_ledger_root = Ledger.merkle_root ledger in
+                      [%test_eq: Ledger_hash.t] target_ledger_root
+                        target_ledger_root_snark
+                  in
+                  match command.status with
+                  | Applied -> (
+                      match expected_failure with
+                      | Some failure ->
+                          failwith
+                            (sprintf
+                               !"Application did not fail as expected. \
+                                 Expected failure: \
+                                 %{sexp:Mina_base.Transaction_status.Failure.t}"
+                               failure )
+                      | None ->
+                          run_in_snark () )
+                  | Failed failure_tbl -> (
+                      match expected_failure with
+                      | None ->
+                          failwith
+                            (sprintf
+                               !"Application failed. Failure statuses: %{sexp: \
+                                 Mina_base.Transaction_status.Failure.Collection.t}"
+                               failure_tbl )
+                      | Some failure ->
+                          let failures = List.concat failure_tbl in
+                          assert (not (List.is_empty failures)) ;
+                          let failed_as_expected =
+                            (*Check that there's at least the expected failure*)
+                            List.fold failures ~init:false ~f:(fun acc f ->
+                                acc
+                                || Mina_base.Transaction_status.Failure.(
+                                     equal failure f) )
+                          in
+                          if not failed_as_expected then
+                            failwith
+                              (sprintf
+                                 !"Application failed but not as expected. \
+                                   Expected failure: \
+                                   %{sexp:Mina_base.Transaction_status.Failure.t} \
+                                   Failure statuses: %{sexp: \
+                                   Mina_base.Transaction_status.Failure.Collection.t}"
+                                 failure failure_tbl )
+                          else run_in_snark () ) )
+              | _ ->
+                  failwith "zkapp_command expected" ) ) )
 
 let dummy_rule self : _ Pickles.Inductive_rule.t =
   let open Tick in

--- a/src/lib/transaction_snark/test/util.mli
+++ b/src/lib/transaction_snark/test/util.mli
@@ -47,12 +47,14 @@ val dummy_rule :
      , unit )
      Pickles.Inductive_rule.t
 
+type pass_number = Pass_1 | Pass_2
+
 (** Generates base and merge snarks of all the account_update segments
 
     Raises if either the snark generation or application fails
 *)
 val check_zkapp_command_with_merges_exn :
-     ?expected_failure:Mina_base.Transaction_status.Failure.t
+     ?expected_failure:Mina_base.Transaction_status.Failure.t * pass_number
   -> ?ignore_outside_snark:bool
   -> ?global_slot:Mina_numbers.Global_slot.t
   -> ?state_body:Transaction_protocol_state.Block_data.t
@@ -80,7 +82,7 @@ val gen_snapp_ledger :
   Base_quickcheck.Generator.t
 
 val test_snapp_update :
-     ?expected_failure:Mina_base.Transaction_status.Failure.t
+     ?expected_failure:Mina_base.Transaction_status.Failure.t * pass_number
   -> ?state_body:Transaction_protocol_state.Block_data.t
   -> ?snapp_permissions:Permissions.t
   -> vk:(Side_loaded_verification_key.t, Tick.Field.t) With_hash.t

--- a/src/lib/transaction_snark/test/verification_key/verification_key.ml
+++ b/src/lib/transaction_snark/test/verification_key/verification_key.ml
@@ -6,7 +6,8 @@ struct
   let test_description = "verification_key"
 
   let failure_expected =
-    Mina_base.Transaction_status.Failure.Update_not_permitted_verification_key
+    ( Mina_base.Transaction_status.Failure.Update_not_permitted_verification_key
+    , Transaction_snark_tests.Util.Pass_2 )
 
   let snapp_update : Account_update.Update.t =
     let new_verification_key :

--- a/src/lib/transaction_snark/test/voting_for/voting_for.ml
+++ b/src/lib/transaction_snark/test/voting_for/voting_for.ml
@@ -5,7 +5,8 @@ struct
   let test_description = "voting_for"
 
   let failure_expected =
-    Mina_base.Transaction_status.Failure.Update_not_permitted_voting_for
+    ( Mina_base.Transaction_status.Failure.Update_not_permitted_voting_for
+    , Transaction_snark_tests.Util.Pass_2 )
 
   let snapp_update : Account_update.Update.t =
     { Account_update.Update.dummy with

--- a/src/lib/transaction_snark/test/zkapp_deploy/zkapp_deploy.ml
+++ b/src/lib/transaction_snark/test/zkapp_deploy/zkapp_deploy.ml
@@ -176,5 +176,6 @@ let%test_module "zkApp deploy tests" =
                     (module Ledger.Ledger_inner)
                     init_ledger ledger ;
                   U.check_zkapp_command_with_merges_exn ledger
-                    ~expected_failure:Invalid_fee_excess [ zkapp_command ] ) ) )
+                    ~expected_failure:(Invalid_fee_excess, Pass_2)
+                    [ zkapp_command ] ) ) )
   end )

--- a/src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.ml
+++ b/src/lib/transaction_snark/test/zkapp_fuzzy/zkapp_fuzzy.ml
@@ -218,7 +218,8 @@ let test_timed_account ~trials ~max_account_updates () =
                   "generated zkapp_command" ;
                 U.check_zkapp_command_with_merges_exn
                   ~expected_failure:
-                    Transaction_status.Failure.Source_minimum_balance_violation
+                    ( Transaction_status.Failure.Source_minimum_balance_violation
+                    , Pass_1 )
                   ledger [ zkapp_command ] ~state_body:U.genesis_state_body ) )
       in
       for i = 0 to trials - 1 do
@@ -244,26 +245,28 @@ let () =
            ~max_account_updates () ;
          mk_invalid_test ~trials ~max_account_updates
            ~type_of_failure:Invalid_protocol_state_precondition
-           ~expected_failure_status:Protocol_state_precondition_unsatisfied ;
+           ~expected_failure_status:
+             (Protocol_state_precondition_unsatisfied, Pass_2) ;
          mk_invalid_test ~trials ~max_account_updates
            ~type_of_failure:(Update_not_permitted `App_state)
-           ~expected_failure_status:Update_not_permitted_app_state ;
+           ~expected_failure_status:(Update_not_permitted_app_state, Pass_2) ;
          mk_invalid_test ~trials ~max_account_updates
            ~type_of_failure:(Update_not_permitted `Verification_key)
-           ~expected_failure_status:Update_not_permitted_verification_key ;
+           ~expected_failure_status:
+             (Update_not_permitted_verification_key, Pass_2) ;
          mk_invalid_test ~trials ~max_account_updates
            ~type_of_failure:(Update_not_permitted `Zkapp_uri)
-           ~expected_failure_status:Update_not_permitted_zkapp_uri ;
+           ~expected_failure_status:(Update_not_permitted_zkapp_uri, Pass_2) ;
          mk_invalid_test ~trials ~max_account_updates
            ~type_of_failure:(Update_not_permitted `Token_symbol)
-           ~expected_failure_status:Update_not_permitted_token_symbol ;
+           ~expected_failure_status:(Update_not_permitted_token_symbol, Pass_2) ;
          mk_invalid_test ~trials ~max_account_updates
            ~type_of_failure:(Update_not_permitted `Voting_for)
-           ~expected_failure_status:Update_not_permitted_voting_for ;
+           ~expected_failure_status:(Update_not_permitted_voting_for, Pass_2) ;
          mk_invalid_test ~trials ~max_account_updates
            ~type_of_failure:(Update_not_permitted `Send)
-           ~expected_failure_status:Update_not_permitted_balance ;
+           ~expected_failure_status:(Update_not_permitted_balance, Pass_2) ;
          mk_invalid_test ~trials ~max_account_updates
            ~type_of_failure:(Update_not_permitted `Receive)
-           ~expected_failure_status:Update_not_permitted_balance ;
+           ~expected_failure_status:(Update_not_permitted_balance, Pass_2) ;
          test_timed_account ~trials ~max_account_updates ())

--- a/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
+++ b/src/lib/transaction_snark/test/zkapp_payments/zkapp_payments.ml
@@ -286,6 +286,7 @@ let%test_module "Zkapp payments tests" =
                     Transaction_snark.For_tests.multiple_transfers test_spec
                   in
                   U.check_zkapp_command_with_merges_exn
-                    ~expected_failure:Transaction_status.Failure.Overflow ledger
-                    [ zkapp_command ] ) ) )
+                    ~expected_failure:
+                      (Transaction_status.Failure.Overflow, Pass_2)
+                    ledger [ zkapp_command ] ) ) )
   end )

--- a/src/lib/transaction_snark/test/zkapp_uri/zkapp_uri.ml
+++ b/src/lib/transaction_snark/test/zkapp_uri/zkapp_uri.ml
@@ -5,7 +5,8 @@ struct
   let test_description = "zkapp_uri"
 
   let failure_expected =
-    Mina_base.Transaction_status.Failure.Update_not_permitted_zkapp_uri
+    ( Mina_base.Transaction_status.Failure.Update_not_permitted_zkapp_uri
+    , Transaction_snark_tests.Util.Pass_2 )
 
   let snapp_update =
     { Account_update.Update.dummy with

--- a/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
+++ b/src/lib/transaction_snark/test/zkapps_examples/initialize_state/initialize_state.ml
@@ -244,7 +244,8 @@ let%test_module "Initialize state test" =
              Update_state_account_update.account_update
         |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
         |> test_zkapp_command
-             ~expected_failure:Account_proved_state_precondition_unsatisfied
+             ~expected_failure:
+               (Account_proved_state_precondition_unsatisfied, Pass_2)
       in
       assert (Option.is_none (Option.value_exn account).zkapp)
 
@@ -257,7 +258,8 @@ let%test_module "Initialize state test" =
              Initialize_account_update.account_update
         |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
         |> test_zkapp_command
-             ~expected_failure:Account_proved_state_precondition_unsatisfied
+             ~expected_failure:
+               (Account_proved_state_precondition_unsatisfied, Pass_2)
       in
       assert (Option.is_none (Option.value_exn account).zkapp)
 
@@ -272,7 +274,8 @@ let%test_module "Initialize state test" =
              Initialize_account_update.account_update
         |> Zkapp_command.Call_forest.cons Deploy_account_update.account_update
         |> test_zkapp_command
-             ~expected_failure:Account_proved_state_precondition_unsatisfied
+             ~expected_failure:
+               (Account_proved_state_precondition_unsatisfied, Pass_2)
       in
       assert (Option.is_none (Option.value_exn account).zkapp)
 


### PR DESCRIPTION
The timed account test in the zkApp fuzzy tests was failing in nightly tests, because the expected `Source_min_balance_violation` failure occurred during the first pass for zkApp application, which wasn't detected.

Add the expected failure test for the first pass. If the expected failure occurs, return without running the second pass, because we don't have all the statements to do so.

The `expected_failure` now includes the pass where the failure is expected to occur.

Other than the new failure check, most of the diff is from the re-formatting occasioned by the `with_return` that wraps existing code.

Tested locally by running the timed account test.