### PR TITLE
Add Raw gate constructor to Plonk_constraint_system

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -4,6 +4,34 @@ open Unsigned.Size_t
 
 (* TODO: open Core here instead of opening it multiple times below *)
 
+module Kimchi_gate_type = struct
+  (* Alias to allow deriving sexp *)
+  type t = Kimchi_types.gate_type =
+    | Zero
+    | Generic
+    | Poseidon
+    | CompleteAdd
+    | VarBaseMul
+    | EndoMul
+    | EndoMulScalar
+    | ChaCha0
+    | ChaCha1
+    | ChaCha2
+    | ChaChaFinal
+    | Lookup
+    | CairoClaim
+    | CairoInstruction
+    | CairoFlags
+    | CairoTransition
+    | RangeCheck0
+    | RangeCheck1
+    | ForeignFieldAdd
+    | ForeignFieldMul
+    | Xor16
+    | Rot64
+  [@@deriving sexp]
+end
+
 (** A gate interface, parameterized by a field. *)
 module type Gate_vector_intf = sig
   open Unsigned
@@ -88,7 +116,7 @@ module Gate_spec = struct
 
   (** A gate/row/constraint consists of a type (kind), a row, the other cells its columns/cells are connected to (wired_to), and the selector polynomial associated with the gate. *)
   type ('row, 'f) t =
-    { kind : (Kimchi_types.gate_type[@sexp.opaque])
+    { kind : Kimchi_gate_type.t
     ; wired_to : 'row Position.t array
     ; coeffs : 'f array
     }
@@ -144,6 +172,8 @@ module Plonk_constraint = struct
       | EC_endoscale of
           { state : 'v Endoscale_round.t array; xs : 'v; ys : 'v; n_acc : 'v }
       | EC_endoscalar of { state : 'v Endoscale_scalar_round.t array }
+      | Raw of
+          { kind : Kimchi_gate_type.t; values : 'v array; coeffs : 'f array }
     [@@deriving sexp]
 
     (** map t *)
@@ -181,6 +211,8 @@ module Plonk_constraint = struct
             { state =
                 Array.map ~f:(fun x -> Endoscale_scalar_round.map ~f x) state
             }
+      | Raw { kind; values; coeffs } ->
+          Raw { kind; values = Array.map ~f values; coeffs }
 
     (** [eval (module F) get_variable gate] checks that [gate]'s polynomial is
         satisfied by the assignments given by [get_variable].
@@ -1242,6 +1274,15 @@ end = struct
           ~f:
             (Fn.compose add_endoscale_scalar_round
                (Endoscale_scalar_round.map ~f:reduce_to_v) )
+    | Plonk_constraint.T (Raw { kind; values; coeffs }) ->
+        let values =
+          Array.init 15 ~f:(fun i ->
+              (* Insert [None] if the index is beyond the end of the [values]
+                 array.
+              *)
+              Option.try_with (fun () -> reduce_to_v values.(i)) )
+        in
+        add_row sys values kind coeffs
     | constr ->
         failwithf "Unhandled constraint %s"
           Obj.(Extension_constructor.name (Extension_constructor.of_val constr))


### PR DESCRIPTION
This adds a `Raw` snarky constraint to let us manually construct kimchi gates for tests.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them