### PR TITLE
Tests for fee related functions in Zk App Commands

### DIFF
--- a/src/lib/mina_base/test/zkapp_command/fee_related.ml
+++ b/src/lib/mina_base/test/zkapp_command/fee_related.ml
@@ -15,8 +15,7 @@ let%test_module "fee_related_tests" =
       let%bind currency = Currency.Fee.gen in
       let%map nonce = Int.quickcheck_generator in
       { Mina_wire_types.Mina_base.Account_update.Body.Fee_payer.V1.public_key =
-          { x = Field.of_int 1; is_odd = false }
-          (* How can I generate Fee rather than have it fixed as one? *)
+          { x = Field.of_int public_key; is_odd }
       ; fee = currency
       ; valid_until = Some (Mina_numbers.Global_slot.random ())
       ; nonce = Unsigned.UInt32.of_int nonce

--- a/src/lib/mina_base/test/zkapp_command/fee_related.ml
+++ b/src/lib/mina_base/test/zkapp_command/fee_related.ml
@@ -1,0 +1,53 @@
+open Core_kernel
+open Mina_base.Zkapp_command
+open Mina_base
+open Snarky_backendless
+open Snark_params.Tick
+
+let%test_module "fee_related_tests" =
+  ( module struct
+    let feepayer_body_generator :
+        Mina_wire_types.Mina_base.Account_update.Body.Fee_payer.V1.t
+        Quickcheck.Generator.t =
+      let open Quickcheck.Generator.Let_syntax in
+      let%bind public_key = Int.quickcheck_generator in
+      let%bind is_odd = Bool.quickcheck_generator in
+      let%map nonce = Int.quickcheck_generator in
+      { Mina_wire_types.Mina_base.Account_update.Body.Fee_payer.V1.public_key =
+          { x = Field.of_int 1; is_odd = false }
+          (* How can I generate Fee rather than have it fixed as one? *)
+      ; fee = Currency.Fee.one
+      ; valid_until = Some (Mina_numbers.Global_slot.random ())
+      ; nonce = Unsigned.UInt32.of_int nonce
+      }
+
+    let body_maker input : T.t =
+      let fee_payer : Account_update.Fee_payer.Stable.V1.t =
+        { body = input; authorization = Signature.dummy }
+      and account_updates = []
+      and memo = Signed_command_memo.empty in
+      { fee_payer; account_updates; memo }
+
+    (* Tests for fee *)
+    let%test_unit "fee" =
+      Quickcheck.test feepayer_body_generator ~f:(fun x ->
+          [%test_eq: Currency.Fee.t] x.fee (fee @@ body_maker x) )
+
+    (* Tests for fee_payer_account_update *)
+    let%test_unit "fee_payer_account_update" =
+      Quickcheck.test feepayer_body_generator ~f:(fun x ->
+          [%test_eq: Account_update.Fee_payer.Stable.V1.t]
+            (body_maker x).fee_payer
+            (fee_payer_account_update @@ body_maker x) )
+
+    (* Tests for fee_payer_pk *)
+    let%test_unit "fee_payer_pk" =
+      Quickcheck.test feepayer_body_generator ~f:(fun x ->
+          [%test_eq: Signature_lib.Public_key.Compressed.Stable.V1.t]
+            x.public_key
+            (fee_payer_pk @@ body_maker x) )
+
+    (* Tests for fee_excess *)
+    (* let%test_unit "fee_excess" =
+       [%test_eq: Currency.Fee.t] () (fee_excess @@ body_maker x) *)
+  end )

--- a/src/lib/mina_base/test/zkapp_command/fee_related.ml
+++ b/src/lib/mina_base/test/zkapp_command/fee_related.ml
@@ -1,28 +1,27 @@
 open Core_kernel
-open Mina_base.Zkapp_command
 open Mina_base
 open Snarky_backendless
 open Snark_params.Tick
 
 let%test_module "fee_related_tests" =
   ( module struct
-    let feepayer_body_generator = Zkapp_command.T.Stable.Latest.Wire.gen
+    let feepayer_body_generator = Zkapp_command.gen
 
     let%test_unit "fee" =
       Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
           [%test_eq: Currency.Fee.t] x.fee_payer.body.fee
-            (fee @@ Zkapp_command.of_wire x) )
+            Zkapp_command.(fee @@ of_wire x) )
 
     let%test_unit "fee_payer_account_update" =
       Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
           [%test_eq: Account_update.Fee_payer.t] x.fee_payer
-            (fee_payer_account_update @@ Zkapp_command.of_wire x) )
+            Zkapp_command.(fee_payer_account_update @@ of_wire x) )
 
     let%test_unit "fee_payer_pk" =
       Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
           [%test_eq: Signature_lib.Public_key.Compressed.t]
             x.fee_payer.body.public_key
-            (fee_payer_pk @@ Zkapp_command.of_wire x) )
+            Zkapp_command.(fee_payer_pk @@ of_wire x) )
 
     let%test_unit "fee_excess" =
       Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
@@ -33,5 +32,5 @@ let%test_module "fee_related_tests" =
             ; fee_token_r = Token_id.default
             ; fee_excess_r = Currency.Fee.Signed.zero
             }
-            (fee_excess @@ Zkapp_command.of_wire x) )
+            Zkapp_command.(fee_excess @@ of_wire x) )
   end )

--- a/src/lib/mina_base/test/zkapp_command/fee_related.ml
+++ b/src/lib/mina_base/test/zkapp_command/fee_related.ml
@@ -11,27 +11,27 @@ let%test_module "fee_related_tests" =
     let%test_unit "fee" =
       Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
           [%test_eq: Currency.Fee.t] x.fee_payer.body.fee
-            (fee @@ Zkapp_command.T.Stable.Latest.of_wire x) )
+            (fee @@ Zkapp_command.of_wire x) )
 
     let%test_unit "fee_payer_account_update" =
       Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
-          [%test_eq: Account_update.Fee_payer.Stable.V1.t] x.fee_payer
-            (fee_payer_account_update @@ Zkapp_command.T.Stable.Latest.of_wire x) )
+          [%test_eq: Account_update.Fee_payer.t] x.fee_payer
+            (fee_payer_account_update @@ Zkapp_command.of_wire x) )
 
     let%test_unit "fee_payer_pk" =
       Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
-          [%test_eq: Signature_lib.Public_key.Compressed.Stable.V1.t]
+          [%test_eq: Signature_lib.Public_key.Compressed.t]
             x.fee_payer.body.public_key
-            (fee_payer_pk @@ Zkapp_command.T.Stable.Latest.of_wire x) )
+            (fee_payer_pk @@ Zkapp_command.of_wire x) )
 
     let%test_unit "fee_excess" =
       Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
-          [%test_eq: (Token_id.t, Currency.Fee.Signed.t) Fee_excess.Poly.t]
+          [%test_eq: Fee_excess.t]
             { fee_token_l = Token_id.default
             ; fee_excess_l =
                 Currency.Fee.Signed.of_unsigned @@ x.fee_payer.body.fee
             ; fee_token_r = Token_id.default
             ; fee_excess_r = Currency.Fee.Signed.zero
             }
-            (fee_excess @@ Zkapp_command.T.Stable.Latest.of_wire x) )
+            (fee_excess @@ Zkapp_command.of_wire x) )
   end )

--- a/src/lib/mina_base/test/zkapp_command/fee_related.ml
+++ b/src/lib/mina_base/test/zkapp_command/fee_related.ml
@@ -48,9 +48,15 @@ let%test_module "fee_related_tests" =
             (fee_payer_pk @@ body_maker x) )
 
     (* Tests for fee_excess *)
-    (* let%test_unit "fee_excess" =
-       Quickcheck.test feepayer_body_generator ~f:(fun x ->
-           [%test_eq: (Token_id.t, Currency.Fee.Signed.t) Fee_excess.Poly.t]
-             (fee_excess @@ body_maker x)
-             (fee_excess @@ body_maker x) ) *)
+    let%test_unit "fee_excess" =
+      Quickcheck.test feepayer_body_generator ~f:(fun x ->
+          [%test_eq: (Token_id.t, Currency.Fee.Signed.t) Fee_excess.Poly.t]
+            { fee_token_l = Token_id.default
+            ; fee_excess_l =
+                Currency.Fee.Signed.of_unsigned
+                @@ (body_maker x).fee_payer.body.fee
+            ; fee_token_r = Token_id.default
+            ; fee_excess_r = Currency.Fee.Signed.zero
+            }
+            (fee_excess @@ body_maker x) )
   end )

--- a/src/lib/mina_base/test/zkapp_command/fee_related.ml
+++ b/src/lib/mina_base/test/zkapp_command/fee_related.ml
@@ -6,57 +6,32 @@ open Snark_params.Tick
 
 let%test_module "fee_related_tests" =
   ( module struct
-    let feepayer_body_generator :
-        Mina_wire_types.Mina_base.Account_update.Body.Fee_payer.V1.t
-        Quickcheck.Generator.t =
-      let open Quickcheck.Generator.Let_syntax in
-      let%bind public_key = Int.quickcheck_generator in
-      let%bind is_odd = Bool.quickcheck_generator in
-      let%bind currency = Currency.Fee.gen in
-      let%map nonce = Int.quickcheck_generator in
-      { Mina_wire_types.Mina_base.Account_update.Body.Fee_payer.V1.public_key =
-          { x = Field.of_int public_key; is_odd }
-      ; fee = currency
-      ; valid_until = Some (Mina_numbers.Global_slot.random ())
-      ; nonce = Unsigned.UInt32.of_int nonce
-      }
+    let feepayer_body_generator = Zkapp_command.T.Stable.Latest.Wire.gen
 
-    let body_maker input : T.t =
-      let fee_payer : Account_update.Fee_payer.Stable.V1.t =
-        { body = input; authorization = Signature.dummy }
-      and account_updates = []
-      and memo = Signed_command_memo.empty in
-      { fee_payer; account_updates; memo }
-
-    (* Tests for fee *)
     let%test_unit "fee" =
-      Quickcheck.test feepayer_body_generator ~f:(fun x ->
-          [%test_eq: Currency.Fee.t] x.fee (fee @@ body_maker x) )
+      Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
+          [%test_eq: Currency.Fee.t] x.fee_payer.body.fee
+            (fee @@ Zkapp_command.T.Stable.Latest.of_wire x) )
 
-    (* Tests for fee_payer_account_update *)
     let%test_unit "fee_payer_account_update" =
-      Quickcheck.test feepayer_body_generator ~f:(fun x ->
-          [%test_eq: Account_update.Fee_payer.Stable.V1.t]
-            (body_maker x).fee_payer
-            (fee_payer_account_update @@ body_maker x) )
+      Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
+          [%test_eq: Account_update.Fee_payer.Stable.V1.t] x.fee_payer
+            (fee_payer_account_update @@ Zkapp_command.T.Stable.Latest.of_wire x) )
 
-    (* Tests for fee_payer_pk *)
     let%test_unit "fee_payer_pk" =
-      Quickcheck.test feepayer_body_generator ~f:(fun x ->
+      Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
           [%test_eq: Signature_lib.Public_key.Compressed.Stable.V1.t]
-            x.public_key
-            (fee_payer_pk @@ body_maker x) )
+            x.fee_payer.body.public_key
+            (fee_payer_pk @@ Zkapp_command.T.Stable.Latest.of_wire x) )
 
-    (* Tests for fee_excess *)
     let%test_unit "fee_excess" =
-      Quickcheck.test feepayer_body_generator ~f:(fun x ->
+      Quickcheck.test ~trials:50 feepayer_body_generator ~f:(fun x ->
           [%test_eq: (Token_id.t, Currency.Fee.Signed.t) Fee_excess.Poly.t]
             { fee_token_l = Token_id.default
             ; fee_excess_l =
-                Currency.Fee.Signed.of_unsigned
-                @@ (body_maker x).fee_payer.body.fee
+                Currency.Fee.Signed.of_unsigned @@ x.fee_payer.body.fee
             ; fee_token_r = Token_id.default
             ; fee_excess_r = Currency.Fee.Signed.zero
             }
-            (fee_excess @@ body_maker x) )
+            (fee_excess @@ Zkapp_command.T.Stable.Latest.of_wire x) )
   end )

--- a/src/lib/mina_base/test/zkapp_command/fee_related.ml
+++ b/src/lib/mina_base/test/zkapp_command/fee_related.ml
@@ -12,11 +12,12 @@ let%test_module "fee_related_tests" =
       let open Quickcheck.Generator.Let_syntax in
       let%bind public_key = Int.quickcheck_generator in
       let%bind is_odd = Bool.quickcheck_generator in
+      let%bind currency = Currency.Fee.gen in
       let%map nonce = Int.quickcheck_generator in
       { Mina_wire_types.Mina_base.Account_update.Body.Fee_payer.V1.public_key =
           { x = Field.of_int 1; is_odd = false }
           (* How can I generate Fee rather than have it fixed as one? *)
-      ; fee = Currency.Fee.one
+      ; fee = currency
       ; valid_until = Some (Mina_numbers.Global_slot.random ())
       ; nonce = Unsigned.UInt32.of_int nonce
       }
@@ -49,5 +50,8 @@ let%test_module "fee_related_tests" =
 
     (* Tests for fee_excess *)
     (* let%test_unit "fee_excess" =
-       [%test_eq: Currency.Fee.t] () (fee_excess @@ body_maker x) *)
+       Quickcheck.test feepayer_body_generator ~f:(fun x ->
+           [%test_eq: (Token_id.t, Currency.Fee.Signed.t) Fee_excess.Poly.t]
+             (fee_excess @@ body_maker x)
+             (fee_excess @@ body_maker x) ) *)
   end )

--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -890,6 +890,8 @@ include T
 
 [%%define_locally Stable.Latest.(of_wire, to_wire)]
 
+[%%define_locally Stable.Latest.Wire.(gen)]
+
 let of_simple (w : Simple.t) : t =
   { fee_payer = w.fee_payer
   ; memo = w.memo


### PR DESCRIPTION
Branched off another non-develop branch, so ignore all files other than `fee_related.ml` The other branch will be merged first.

Explain your changes:
* Property based tests for the following functions in `src/lib/mina_base/zkapp_command`:
1. `fee`
2. `fee_payer_pk`
3.  `fee_payer_account_update`
4. `fee_excess`

* Closes #12625 
