### PR TITLE
Fix bestChain graphql query

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11761,19 +11761,6 @@
               "deprecationReason": null
             },
             {
-              "name": "genesis_balance",
-              "description":
-                "The amount of MINA owned by the account at Genesis",
-              "args": [],
-              "type": {
-                "kind": "OBJECT",
-                "name": "AnnotatedBalance",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "nonce",
               "description":
                 "A natural number that increases with each transaction (stringified uint32)",

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1027,35 +1027,17 @@ module Types = struct
           , Permissions.t option
           , Zkapp_account.t option )
           Account.Poly.t
-      ; genesis_balance : AnnotatedBalance.t option
       ; locked : bool option
       ; is_actively_staking : bool
       ; path : string
       ; index : Account.Index.t option
       }
 
-    let genesis_balance mina public_key =
-      let gl = Mina_lib.genesis_ledger mina in
-      Ledger.fold_until (Lazy.force gl) ~init:()
-        ~f:(fun () a ->
-          if Account.Key.compare (Account.public_key a) public_key = 0 then
-            Stop
-              (Some
-                 AnnotatedBalance.
-                   { total = a.balance
-                   ; unknown = Balance.zero
-                   ; timing = a.timing
-                   ; breadcrumb = None
-                   } )
-          else Continue () )
-        ~finish:(Fun.const None)
-
     let lift mina pk account =
       let block_production_pubkeys = Mina_lib.block_production_pubkeys mina in
       let accounts = Mina_lib.wallets mina in
       let best_tip_ledger = Mina_lib.best_ledger mina in
       { account
-      ; genesis_balance = genesis_balance mina account.public_key
       ; locked = Secrets.Wallets.check_locked accounts ~needle:pk
       ; is_actively_staking =
           ( if Token_id.(equal default) account.token_id then
@@ -1205,10 +1187,6 @@ module Types = struct
                  ~doc:"The amount of MINA owned by the account"
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } -> account.Account.Poly.balance)
-             ; field "genesis_balance" ~typ:AnnotatedBalance.obj
-                 ~doc:"The amount of MINA owned by the account at Genesis"
-                 ~args:Arg.[]
-                 ~resolve:(fun _ (b : t) -> b.genesis_balance)
              ; field "nonce" ~typ:account_nonce
                  ~doc:
                    "A natural number that increases with each transaction \
@@ -1314,8 +1292,6 @@ module Types = struct
                    List.map
                      ~f:(fun a ->
                        { account = Partial_account.of_full_account a
-                       ; genesis_balance =
-                           genesis_balance mina account.public_key
                        ; locked = None
                        ; is_actively_staking = true
                        ; path = ""
@@ -1347,8 +1323,6 @@ module Types = struct
                    List.map
                      ~f:(fun a ->
                        { account = Partial_account.of_full_account a
-                       ; genesis_balance =
-                           genesis_balance mina account.public_key
                        ; locked = None
                        ; is_actively_staking = true
                        ; path = ""
@@ -4215,7 +4189,6 @@ module Queries = struct
     |> List.map ~f:(fun pk ->
            { Types.AccountObj.account =
                Types.AccountObj.Partial_account.of_pk mina pk
-           ; genesis_balance = Types.AccountObj.genesis_balance mina pk
            ; locked = Secrets.Wallets.check_locked wallets ~needle:pk
            ; is_actively_staking =
                Public_key.Compressed.Set.mem block_production_pubkeys pk

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -866,7 +866,7 @@ let best_chain ?max_length t =
   let best_tip_path = Transition_frontier.best_tip_path ?max_length frontier in
   match max_length with
   | Some max_length
-    when Mina_stdlib.List.Length.Compare.(best_tip_path > max_length) ->
+    when Mina_stdlib.List.Length.Compare.(best_tip_path >= max_length) ->
       (* The [best_tip_path] has already been truncated to the correct length,
          we skip adding the root to stay below the maximum.
       *)


### PR DESCRIPTION
Fixes #12622. Also includes a fix for a separate bug that was discovered in the same query where we always included the root block into the best chain.