### PR TITLE
Tune parameters for libp2p ipc

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/app.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/app.go
@@ -24,7 +24,7 @@ import (
 )
 
 func newApp() *app {
-	outChan := make(chan *capnp.Message, 64)
+	outChan := make(chan *capnp.Message, 1<<12) // 4kb
 	ctx := context.Background()
 	return &app{
 		P2p:                      nil,
@@ -329,7 +329,7 @@ func setMultiaddrList(m ipc.Multiaddr_List, addrs []multiaddr.Multiaddr) {
 
 func handleStreamReads(app *app, stream net.Stream, idx uint64) {
 	go func() {
-		buf := make([]byte, 4096)
+		buf := make([]byte, 1<<17) // 128kb
 		tot := uint64(0)
 		for {
 			n, err := stream.Read(buf)


### PR DESCRIPTION
Bumped the stream response chunk size from 4kb -> 128kb, and bumped the internal IPC message queue from 64 -> 4096.