### PR TITLE
Receipt chain hash for zkApps

### DIFF
--- a/src/lib/mina_base/zkapp_command.ml
+++ b/src/lib/mina_base/zkapp_command.ml
@@ -2018,6 +2018,20 @@ let valid_size ~(genesis_constants : Genesis_constants.t) (t : t) :
     in
     Error (Error.of_string err_msg)
 
+let get_transaction_commitments (zkapp_command : t) =
+  let memo_hash = Signed_command_memo.hash zkapp_command.memo in
+  let fee_payer_hash =
+    Account_update.of_fee_payer zkapp_command.fee_payer
+    |> Digest.Account_update.create
+  in
+  let account_updates_hash = account_updates_hash zkapp_command in
+  let txn_commitment = Transaction_commitment.create ~account_updates_hash in
+  let full_txn_commitment =
+    Transaction_commitment.create_complete txn_commitment ~memo_hash
+      ~fee_payer_hash
+  in
+  (txn_commitment, full_txn_commitment)
+
 let inner_query =
   lazy
     (Option.value_exn ~message:"Invariant: All projectable derivers are Some"

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -1462,7 +1462,7 @@ let gen_zkapp_command_from ?global_slot ?failure
   let receipt_elt =
     let _txn_commitment, full_txn_commitment =
       (* also computed in replace_authorizations, but easier just to re-compute here *)
-      Zkapp_command_builder.get_transaction_commitments
+      Zkapp_command.get_transaction_commitments
         zkapp_command_dummy_authorizations
     in
     Receipt.Zkapp_command_elt.Zkapp_command_commitment full_txn_commitment

--- a/src/lib/zkapp_command_builder/zkapp_command_builder.ml
+++ b/src/lib/zkapp_command_builder/zkapp_command_builder.ml
@@ -78,29 +78,13 @@ let mk_zkapp_command ?memo ~fee ~fee_payer_pk ~fee_payer_nonce account_updates :
       |> Zkapp_command.Call_forest.accumulate_hashes_predicated
   }
 
-let get_transaction_commitments (zkapp_command : Zkapp_command.t) =
-  let memo_hash = Signed_command_memo.hash zkapp_command.memo in
-  let fee_payer_hash =
-    Account_update.of_fee_payer zkapp_command.fee_payer
-    |> Zkapp_command.Digest.Account_update.create
-  in
-  let account_updates_hash = Zkapp_command.account_updates_hash zkapp_command in
-  let txn_commitment =
-    Zkapp_command.Transaction_commitment.create ~account_updates_hash
-  in
-  let full_txn_commitment =
-    Zkapp_command.Transaction_commitment.create_complete txn_commitment
-      ~memo_hash ~fee_payer_hash
-  in
-  (txn_commitment, full_txn_commitment)
-
 (* replace dummy signatures, proofs with valid ones for fee payer, other zkapp_command
    [keymap] maps compressed public keys to private keys
 *)
 let replace_authorizations ?prover ~keymap (zkapp_command : Zkapp_command.t) :
     Zkapp_command.t Async_kernel.Deferred.t =
   let txn_commitment, full_txn_commitment =
-    get_transaction_commitments zkapp_command
+    Zkapp_command.get_transaction_commitments zkapp_command
   in
   let sign_for_account_update ~use_full_commitment sk =
     let commitment =


### PR DESCRIPTION
Add the ability to process zkApps for `advanced compute-receipt-chain-hash`.

The command now takes an additional, optional argument `--index`. If not provided, it assumes the transaction ID is for a signed command. For a zkApp, the index is 0 for the fee payer, otherwise the 1-based index of an account update, reflecting how chain hashes are computed in `Zkapp_command_logic`.

Moved `get_transaction_commitments` from `Zkapp_command_builder` to `Zkapp_command` because it's used for purposes other than building test zkApps (as here).

Fixed the existing doc strings for this command.


