### PR TITLE
Housekeeping: Uniform type equality assertions

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1100,7 +1100,8 @@ module Make_str (A : Wire_types.Concrete) = struct
             end
           end]
 
-          type _unused = unit constraint Stable.Latest.t = Staking.Value.t
+          let (_ : (Stable.Latest.t, Staking.Value.t) Type_equal.t) =
+            Type_equal.T
         end
       end
 

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -949,7 +949,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       end
     end]
 
-    type _unused = unit constraint Signed.t = (t, Sgn.t) Signed_poly.t
+    let (_ : (Signed.t, (t, Sgn.t) Signed_poly.t) Type_equal.t) = Type_equal.T
   end
 
   module Amount = struct

--- a/src/lib/data_hash_lib/state_hash.ml
+++ b/src/lib/data_hash_lib/state_hash.ml
@@ -56,7 +56,7 @@ module Stable = struct
   end
 end]
 
-type _unused = unit constraint t = Stable.Latest.t
+let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
 
 let deriver obj =
   Fields_derivers_zkapps.iso_string obj ~name:"StateHash" ~js_type:Field

--- a/src/lib/mina_base/ledger_hash0.ml
+++ b/src/lib/mina_base/ledger_hash0.ml
@@ -29,4 +29,4 @@ module Stable = struct
   end
 end]
 
-type _unused = unit constraint t = Stable.Latest.t
+let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T

--- a/src/lib/mina_base/pending_coinbase.ml
+++ b/src/lib/mina_base/pending_coinbase.ml
@@ -171,7 +171,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       end
     end]
 
-    type _unused = unit constraint t = Stable.Latest.t
+    let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
 
     let push (h : t) cb =
       let coinbase = Coinbase_data.of_coinbase cb in
@@ -231,7 +231,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       end
     end]
 
-    type _unused = unit constraint t = Stable.Latest.t
+    let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
 
     let dummy = of_hash Outside_hash_image.t
   end
@@ -384,7 +384,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       end
     end]
 
-    type _unused = unit constraint t = Stable.Latest.t
+    let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
 
     let merge ~height (h1 : t) (h2 : t) =
       Random_oracle.hash
@@ -554,13 +554,14 @@ module Make_str (A : Wire_types.Concrete) = struct
       end
     end]
 
-    type _unused = unit
-      constraint
-        t =
-        ( Hash_versioned.t
-        , Stack_id.t
-        , Stack_versioned.t )
-        Sparse_ledger_lib.Sparse_ledger.T.t
+    let (_ :
+          ( t
+          , ( Hash_versioned.t
+            , Stack_id.t
+            , Stack_versioned.t )
+            Sparse_ledger_lib.Sparse_ledger.T.t )
+          Type_equal.t ) =
+      Type_equal.T
   end
 
   module T = struct
@@ -582,8 +583,8 @@ module Make_str (A : Wire_types.Concrete) = struct
 
       type t = Stack_versioned.t [@@deriving yojson, equal, compare, sexp, hash]
 
-      type _unused = unit
-        constraint t = (Coinbase_stack.t, State_stack.t) Poly.t
+      let (_ : (t, (Coinbase_stack.t, State_stack.t) Poly.t) Type_equal.t) =
+        Type_equal.T
 
       type var = (Coinbase_stack.var, State_stack.var) Poly.t
 
@@ -756,10 +757,12 @@ module Make_str (A : Wire_types.Concrete) = struct
     module Merkle_tree = struct
       type t = Merkle_tree_versioned.t [@@deriving sexp, to_yojson]
 
-      type _unused = unit
-        constraint
-          t =
-          (Hash.t, Stack_id.t, Stack.t) Sparse_ledger_lib.Sparse_ledger.T.t
+      let (_ :
+            ( t
+            , (Hash.t, Stack_id.t, Stack.t) Sparse_ledger_lib.Sparse_ledger.T.t
+            )
+            Type_equal.t ) =
+        Type_equal.T
 
       module M = Sparse_ledger_lib.Sparse_ledger.Make (Hash) (Stack_id) (Stack)
 
@@ -1285,7 +1288,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     end
   end]
 
-  type _unused = unit constraint Stable.Latest.t = t
+  let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
 
   let%test_unit "add stack + remove stack = initial tree " =
     let constraint_constants =

--- a/src/lib/mina_base/receipt.ml
+++ b/src/lib/mina_base/receipt.ml
@@ -43,7 +43,7 @@ module Chain_hash = struct
     end
   end]
 
-  type _unused = unit constraint t = Stable.Latest.t
+  let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
 
   let equal = Stable.Latest.equal
 

--- a/src/lib/mina_base/signature.ml
+++ b/src/lib/mina_base/signature.ml
@@ -40,7 +40,7 @@ module Stable = struct
     end
 
     (* Base58Check encodes t *)
-    let _f : unit -> (t, Codable_arg.t) Type_equal.t = fun () -> Type_equal.T
+    let (_ : (t, Codable_arg.t) Type_equal.t) = Type_equal.T
 
     include Codable.Make_base58_check (Codable_arg)
 

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -94,8 +94,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
   (* type of signed commands, pre-Berkeley hard fork *)
   type t_v1 = Stable.V1.t
 
-  type _unused = unit
-    constraint (Payload.t, Public_key.t, Signature.t) Poly.t = t
+  let (_ : (t, (Payload.t, Public_key.t, Signature.t) Poly.t) Type_equal.t) =
+    Type_equal.T
 
   include (Stable.Latest : module type of Stable.Latest with type t := t)
 

--- a/src/lib/mina_base/state_body_hash.ml
+++ b/src/lib/mina_base/state_body_hash.ml
@@ -31,4 +31,4 @@ module Stable = struct
   end
 end]
 
-type _unused = unit constraint t = Stable.Latest.t
+let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T

--- a/src/lib/mina_base/zkapp_state.ml
+++ b/src/lib/mina_base/zkapp_state.ml
@@ -29,13 +29,9 @@ module V = struct
   let to_list = Vector.to_list
 end
 
-let () =
-  let _f :
-      type a.
-      unit -> (a V.t, a Vector.With_length(Max_state_size).t) Type_equal.t =
-   fun () -> Type_equal.T
-  in
-  ()
+let _type_equal :
+    type a. (a V.t, a Vector.With_length(Max_state_size).t) Type_equal.t =
+  Type_equal.T
 
 let typ t = Vector.typ t Max_state_size.n
 
@@ -56,11 +52,7 @@ module Value = struct
 
   type t = Zkapp_basic.F.t V.t [@@deriving sexp, equal, yojson, hash, compare]
 
-  let () =
-    let _f : unit -> (t, Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
 end
 
 let to_input (t : _ V.t) ~f =

--- a/src/lib/mina_ledger/ledger.ml
+++ b/src/lib/mina_ledger/ledger.ml
@@ -44,7 +44,7 @@ module Ledger_inner = struct
         type t = Ledger_hash.Stable.V1.t
         [@@deriving sexp, compare, hash, equal, yojson]
 
-        type _unused = unit constraint t = Arg.t
+        let (_ : (t, Arg.t) Type_equal.t) = Type_equal.T
 
         let to_latest = Fn.id
 

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -904,7 +904,7 @@ struct
     module Diff = struct
       type t = User_command.t list [@@deriving sexp, yojson]
 
-      type _unused = unit constraint t = Diff_versioned.t
+      let (_ : (t, Diff_versioned.t) Type_equal.t) = Type_equal.T
 
       module Diff_error = struct
         type t = Diff_versioned.Diff_error.t =
@@ -951,7 +951,7 @@ struct
         type t = (User_command.t * Diff_error.t) list
         [@@deriving sexp, yojson, compare]
 
-        type _unused = unit constraint t = Diff_versioned.Rejected.t
+        let (_ : (t, Diff_versioned.Rejected.t) Type_equal.t) = Type_equal.T
       end
 
       type rejected = Rejected.t [@@deriving sexp, yojson, compare]

--- a/src/lib/pickles/composition_types/digest.ml
+++ b/src/lib/pickles/composition_types/digest.ml
@@ -19,11 +19,7 @@ module Constant = struct
   end]
 
   (* Force the typechecker to verify that these types are equal. *)
-  let () =
-    let _f : unit -> (t, Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
 
   open Backend
 

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -367,11 +367,7 @@ module Proofs_verified_2 = struct
     include T.Repr
 
     (* Force the typechecker to verify that these types are equal. *)
-    let () =
-      let _f : unit -> (t, Stable.Latest.t) Type_equal.t =
-       fun () -> Type_equal.T
-      in
-      ()
+    let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
   end
 
   [%%versioned_binable
@@ -441,11 +437,7 @@ module Proofs_verified_max = struct
     include T.Repr
 
     (* Force the typechecker to verify that these types are equal. *)
-    let () =
-      let _f : unit -> (t, Stable.Latest.t) Type_equal.t =
-       fun () -> Type_equal.T
-      in
-      ()
+    let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
   end
 
   [%%versioned_binable

--- a/src/lib/pickles/reduced_messages_for_next_proof_over_same_field.ml
+++ b/src/lib/pickles/reduced_messages_for_next_proof_over_same_field.ml
@@ -70,11 +70,7 @@ module Wrap = struct
       Wrap_bp_vec.t
     [@@deriving sexp, compare, yojson, hash, equal]
 
-    let () =
-      let _f : unit -> (t, Stable.Latest.t) Type_equal.t =
-       fun () -> Type_equal.T
-      in
-      ()
+    let (_ : (t, Stable.Latest.t) Type_equal.t) = Type_equal.T
 
     module Prepared = struct
       type t = (Tock.Field.t, Tock.Rounds.n) Vector.t

--- a/src/lib/pickles_types/vector.ml
+++ b/src/lib/pickles_types/vector.ml
@@ -506,11 +506,7 @@ module Vector_2 = struct
 
   include T
 
-  let () =
-    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
 end
 
 module Vector_4 = struct
@@ -531,11 +527,7 @@ module Vector_4 = struct
 
   include T
 
-  let () =
-    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
 end
 
 module Vector_5 = struct
@@ -556,11 +548,7 @@ module Vector_5 = struct
 
   include T
 
-  let () =
-    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
 end
 
 module Vector_6 = struct
@@ -581,11 +569,7 @@ module Vector_6 = struct
 
   include T
 
-  let () =
-    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
 end
 
 module Vector_7 = struct
@@ -606,11 +590,7 @@ module Vector_7 = struct
 
   include T
 
-  let () =
-    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
 end
 
 module Vector_8 = struct
@@ -631,11 +611,7 @@ module Vector_8 = struct
 
   include T
 
-  let () =
-    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
 end
 
 module Vector_15 = struct
@@ -656,11 +632,7 @@ module Vector_15 = struct
 
   include T
 
-  let () =
-    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
 end
 
 module Vector_16 = struct
@@ -681,9 +653,5 @@ module Vector_16 = struct
 
   include T
 
-  let () =
-    let _f : type a. unit -> (a t, a Stable.Latest.t) Type_equal.t =
-     fun () -> Type_equal.T
-    in
-    ()
+  let _type_equal : type a. (a t, a Stable.Latest.t) Type_equal.t = Type_equal.T
 end

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -25,7 +25,7 @@ module Statement = struct
 
       let to_latest = Fn.id
 
-      type _unused = unit constraint t = Arg.Stable.V2.t
+      let (_ : (t, Arg.Stable.V2.t) Type_equal.t) = Type_equal.T
 
       include Hashable.Make_binable (Arg.Stable.V2)
     end

--- a/src/nonconsensus/snark_params/tick.ml
+++ b/src/nonconsensus/snark_params/tick.ml
@@ -88,7 +88,7 @@ module Inner_curve = struct
     *)
     type t = Pasta.Fq.t [@@deriving bin_io_unversioned, sexp]
 
-    type _unused = unit constraint t = Tock.Field.t
+    let (_ : (t, Tock.Field.t) Type_equal.t) = Type_equal.T
 
     let size = Pasta.Fq.order
 


### PR DESCRIPTION
In the code, type equalities were asserted in two ways:
- via an `_unused` type declaration with a `constraint`
- via a value defined with `Type_equal.T`, sometimes wrapped in a function

On grounds that "neatness counts" (even if it doesn't), make all those assertions uniform, either:
- `let (_ : (t1,t2) Type_equal.t) = Type_equal.T`, or
- `let _type_equal : type a. (a t1,a t2) Type_equal.t = Type_equal.T` for types with a parameter

The second form requires a name for some reason, a single underscore gives a syntax error.
