### PR TITLE
Add a test runner for small gadget circuits.

### DIFF
--- a/src/lib/crypto/kimchi_backend/gadgets/runner/dune
+++ b/src/lib/crypto/kimchi_backend/gadgets/runner/dune
@@ -1,0 +1,47 @@
+(library
+ (name kimchi_gadgets_test_runner)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson))
+ (libraries
+   ;; opam libraries
+   stdio
+   integers
+   result
+   base.caml
+   bignum.bigint
+   core_kernel
+   base64
+   digestif
+   ppx_inline_test.config
+   sexplib0
+   base
+   async_kernel
+   bin_prot.shape
+   ;; local libraries
+   mina_wire_types
+   kimchi_bindings
+   kimchi_types
+   pasta_bindings
+   kimchi_backend.pasta
+   kimchi_backend.pasta.basic
+   kimchi_backend.pasta.constraint_system
+   bitstring_lib
+   snarky.intf
+   snarky.backendless
+   snarky_group_map
+   sponge
+   kimchi_backend
+   mina_version
+   base58_check
+   codable
+   random_oracle_input
+   snarky_log
+   group_map
+   snarky_curve
+   key_cache
+   snark_keys_header
+   tuple_lib
+   promise
+   kimchi_backend.common
+   ppx_version.runtime
+))

--- a/src/lib/crypto/kimchi_backend/gadgets/runner/example/dune
+++ b/src/lib/crypto/kimchi_backend/gadgets/runner/example/dune
@@ -1,0 +1,48 @@
+(executable
+ (name example)
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson))
+ (libraries
+   ;; opam libraries
+   stdio
+   integers
+   result
+   base.caml
+   bignum.bigint
+   core_kernel
+   base64
+   digestif
+   ppx_inline_test.config
+   sexplib0
+   base
+   async_kernel
+   bin_prot.shape
+   ;; local libraries
+   mina_wire_types
+   kimchi_bindings
+   kimchi_types
+   pasta_bindings
+   kimchi_backend.pasta
+   kimchi_backend.pasta.basic
+   kimchi_backend.pasta.constraint_system
+   bitstring_lib
+   snarky.intf
+   snarky.backendless
+   snarky_group_map
+   sponge
+   kimchi_backend
+   mina_version
+   base58_check
+   codable
+   random_oracle_input
+   snarky_log
+   group_map
+   snarky_curve
+   key_cache
+   snark_keys_header
+   tuple_lib
+   promise
+   kimchi_backend.common
+   ppx_version.runtime
+   kimchi_gadgets_test_runner
+))

--- a/src/lib/crypto/kimchi_backend/gadgets/runner/example/example.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/runner/example/example.ml
@@ -1,0 +1,52 @@
+open Kimchi_gadgets_test_runner.Runner
+
+(* Initialize the SRS cache. Normally Mina does this for us, but we're not
+   using the Mina stdlib.
+*)
+let () = Tick.Keypair.set_urs_info []
+
+(* Trivial example. The valid_witness parameter determines whether we should
+   provide a satisfying witness or not.
+
+   Note that this adds more than 1 constraint, because there is an assertion in
+   kimchi that there is more than 1 gate (which is probably an error).
+*)
+let example ~valid_witness () =
+  let _proof_keypair, _proof =
+    generate_and_verify_proof (fun () ->
+        let open Impl in
+        (* Create a fresh snarky variable. *)
+        let a =
+          exists Field.typ ~compute:(fun () ->
+              if valid_witness then Field.Constant.of_int 5
+              else Field.Constant.of_int 4 )
+        in
+        (* Create a snarky constant. *)
+        let b = Field.of_int 20 in
+        (* Create a new snarky variable, equal to the square of a. *)
+        let a_squared = Field.(a * a) in
+        (* Create a new snarky variable, equal to the sum of a and b. *)
+        let a_plus_b = Field.(a + b) in
+        (* Create a boolean, which is true iff a_squared equal a_plus_b.
+           Note that, under the hood, this creates an intermediate variable.
+        *)
+        let is_equal = Field.equal a_squared a_plus_b in
+        (* Assert that the boolean is true. *)
+        Boolean.Assert.is_true is_equal ;
+        (* Assert equality directly via the permutation argument. *)
+        Field.Assert.equal a_squared a_plus_b )
+  in
+  ()
+
+(* Generate a proof with a valid witness. *)
+let () = example ~valid_witness:true ()
+
+(* Sanity-check: ensure that the proof with an invalid witness fails. *)
+let () =
+  let test_failed =
+    try
+      example ~valid_witness:false () ;
+      false
+    with _ -> true
+  in
+  assert test_failed

--- a/src/lib/crypto/kimchi_backend/gadgets/runner/runner.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/runner/runner.ml
@@ -1,0 +1,37 @@
+(* Step circuit Impl *)
+module Tick = Kimchi_backend.Pasta.Vesta_based_plonk
+module Impl = Snarky_backendless.Snark.Run.Make (Tick)
+
+let generate_and_verify_proof circuit =
+  (* Generate constraint system for the circuit *)
+  let constraint_system =
+    Impl.constraint_system ~input_typ:Impl.Typ.unit ~return_typ:Impl.Typ.unit
+      (fun () () -> circuit ())
+  in
+  (* Generate the indexes from the constraint system *)
+  let proof_keypair =
+    Tick.Keypair.create ~prev_challenges:0 constraint_system
+  in
+  let prover_index = Tick.Keypair.pk proof_keypair in
+  let proof, (() as _public_output) =
+    Impl.generate_witness_conv
+      ~f:(fun { Impl.Proof_inputs.auxiliary_inputs; public_inputs }
+              next_statement_hashed ->
+        let proof =
+          (* Only block_on_async for testing; do not do this in production!! *)
+          Promise.block_on_async_exn (fun () ->
+              Tick.Proof.create_async ~primary:public_inputs
+                ~auxiliary:auxiliary_inputs ~message:[] prover_index )
+        in
+        (proof, next_statement_hashed) )
+      ~input_typ:Impl.Typ.unit ~return_typ:Impl.Typ.unit
+      (fun () () -> circuit ())
+      ()
+  in
+  (* Verify proof *)
+  let verifier_index = Tick.Keypair.vk proof_keypair in
+  (* We have an empty public input; create an empty vector. *)
+  let public_input = Kimchi_bindings.FieldVectors.Fp.create () in
+  (* Assert that the proof verifies. *)
+  assert (Tick.Proof.verify ~message:[] proof verifier_index public_input) ;
+  (proof_keypair, proof)


### PR DESCRIPTION
This PR creates a small test runner for gadgets.

This explicitly doesn't use pickles, so that we can still test the new kimchi custom gates before their implementation in pickles is finished.

See the example in `example.ml` for a small test circuit. This example can be run with `dune exec src/lib/crypto/kimchi_backend/gadgets/runner/example/example.exe`.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them