### PR TITLE
Update snarky for Typ.t generalized over Cvar.t

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/kimchi_backend_common.mli
+++ b/src/lib/crypto/kimchi_backend/common/kimchi_backend_common.mli
@@ -50,8 +50,8 @@ module Scalar_challenge : sig
   val create : 'a -> 'a t
 
   val typ :
-       ('a, 'b, 'c) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'c) Snarky_backendless.Typ.t
+       ('a, 'b, 'c, 'd) Snarky_backendless.Typ.t
+    -> ('a t, 'b t, 'c, 'd) Snarky_backendless.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 end

--- a/src/lib/crypto/kimchi_backend/common/scalar_challenge.mli
+++ b/src/lib/crypto/kimchi_backend/common/scalar_challenge.mli
@@ -92,8 +92,8 @@ val create : 'a -> 'a t
 
 (* pickles required *)
 val typ :
-     ('a, 'b, 'c) Snarky_backendless.Typ.t
-  -> ('a t, 'b t, 'c) Snarky_backendless.Typ.t
+     ('a, 'b, 'c, 'd) Snarky_backendless.Typ.t
+  -> ('a t, 'b t, 'c, 'd) Snarky_backendless.Typ.t
 
 (* pickles required *)
 val map : 'a t -> f:('a -> 'b) -> 'b t

--- a/src/lib/pickles/common.ml
+++ b/src/lib/pickles/common.ml
@@ -263,8 +263,7 @@ let ft_comm ~add:( + ) ~scale ~endoscale ~negate
   f_comm + chunked_t_comm
   + negate (scale chunked_t_comm plonk.zeta_to_domain_size)
 
-let combined_evaluation (type f)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+let combined_evaluation (type f) ((module Impl) : f Snarky_backendless.Snark.m)
     ~(xi : Impl.Field.t) (without_degree_bound : _ list) =
   let open Impl in
   let open Field in

--- a/src/lib/pickles/common.mli
+++ b/src/lib/pickles/common.mli
@@ -64,7 +64,7 @@ val dlog_pcs_batch :
   -> ('a, 'total, Pickles_types.Nat.z) Pickles_types.Pcs_batch.t
 
 val combined_evaluation :
-     (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+     'f Snarky_backendless.Snark.m
   -> xi:'f Snarky_backendless.Cvar.t
   -> ( 'f Snarky_backendless.Cvar.t
      , 'f Snarky_backendless.Cvar.t Snarky_backendless.Snark_intf.Boolean0.t )

--- a/src/lib/pickles/composition_types/branch_data.ml
+++ b/src/lib/pickles/composition_types/branch_data.ml
@@ -92,8 +92,7 @@ module Make_str (A : Wire_types.Concrete) = struct
       }
     [@@deriving hlist]
 
-    let pack (type f)
-        (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+    let pack (type f) ((module Impl) : f Snarky_backendless.Snark.m)
         ({ proofs_verified_mask; domain_log2 } : f t) : Impl.Field.t =
       let open Impl.Field in
       let four = of_int 4 in
@@ -101,14 +100,12 @@ module Make_str (A : Wire_types.Concrete) = struct
       + pack (Pickles_types.Vector.to_list proofs_verified_mask)
   end
 
-  let packed_typ (type f)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) =
+  let packed_typ (type f) ((module Impl) : f Snarky_backendless.Snark.m) =
     Impl.Typ.transport Impl.Typ.field
       ~there:(pack (module Impl))
       ~back:(unpack (module Impl))
 
-  let typ (type f)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+  let typ (type f) ((module Impl) : f Snarky_backendless.Snark.m)
       ~(* We actually only need it to be less than 252 bits in order to pack
           the whole branch_data struct safely, but it's cheapest to check that it's
           under 16 bits *)

--- a/src/lib/pickles/composition_types/branch_data_intf.ml
+++ b/src/lib/pickles/composition_types/branch_data_intf.ml
@@ -31,19 +31,25 @@ module type S = sig
       }
 
     val pack :
-         (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-      -> 'f t
-      -> 'f Snarky_backendless.Cvar.t
+      'f Snarky_backendless.Snark.m -> 'f t -> 'f Snarky_backendless.Cvar.t
   end
 
   val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+       'f Snarky_backendless.Snark.m
     -> assert_16_bits:('f Snarky_backendless.Cvar.t -> unit)
-    -> ('f Checked.t, t, 'f) Snarky_backendless.Typ.t
+    -> ( 'f Checked.t
+       , t
+       , 'f
+       , 'f Snarky_backendless.Cvar.t )
+       Snarky_backendless.Typ.t
 
   val packed_typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> ('f Snarky_backendless.Cvar.t, t, 'f) Snarky_backendless.Typ.t
+       'f Snarky_backendless.Snark.m
+    -> ( 'f Snarky_backendless.Cvar.t
+       , t
+       , 'f
+       , 'f Snarky_backendless.Cvar.t )
+       Snarky_backendless.Typ.t
 
   val length_in_bits : int
 

--- a/src/lib/pickles/composition_types/bulletproof_challenge.mli
+++ b/src/lib/pickles/composition_types/bulletproof_challenge.mli
@@ -19,8 +19,9 @@ val unpack : 'a -> 'a t
 val map : 'a t -> f:('a -> 'b) -> 'b t
 
 val typ :
-     ('a, 'b, 'c) Snarky_backendless.Typ.t
+     ('a, 'b, 'c, 'd) Snarky_backendless.Typ.t
   -> ( 'a Kimchi_backend_common.Scalar_challenge.t t
      , 'b Kimchi_backend_common.Scalar_challenge.t t
-     , 'c )
+     , 'c
+     , 'd )
      Snarky_backendless.Typ.t

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -305,9 +305,8 @@ module Wrap = struct
                 ; opt_spec f12
                 ]
 
-            let typ (type f fp)
-                (module Impl : Snarky_backendless.Snark_intf.Run
-                  with type field = f ) (fp : (fp, _) Impl.Typ.t) ~dummy_scalar
+            let typ (type f fp) ((module Impl) : f Snarky_backendless.Snark.m)
+                (fp : (fp, _) Impl.Typ.t) ~dummy_scalar
                 (feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t)
                 =
               let opt_typ flag =
@@ -392,11 +391,10 @@ module Wrap = struct
                   t.optional_column_scalars
             }
 
-          let typ (type f fp)
-              (module Impl : Snarky_backendless.Snark_intf.Run
-                with type field = f ) ~dummy_scalar ~dummy_scalar_challenge
-              ~challenge ~scalar_challenge ~bool ~feature_flags
-              (fp : (fp, _, f) Snarky_backendless.Typ.t) =
+          let typ (type f fp) ((module Impl) : f Snarky_backendless.Snark.m)
+              ~dummy_scalar ~dummy_scalar_challenge ~challenge ~scalar_challenge
+              ~bool ~feature_flags (fp : (fp, _, f, _) Snarky_backendless.Typ.t)
+              =
             Snarky_backendless.Typ.of_hlistable
               [ Scalar_challenge.typ scalar_challenge
               ; challenge
@@ -569,10 +567,9 @@ module Wrap = struct
         let to_hlist, of_hlist = (to_hlist, of_hlist)
 
         let typ (type f fp)
-            ((module Impl) as impl :
-              (module Snarky_backendless.Snark_intf.Run with type field = f) )
-            ~dummy_scalar ~dummy_scalar_challenge ~challenge ~scalar_challenge
-            ~feature_flags (fp : (fp, _, f) Snarky_backendless.Typ.t) index =
+            ((module Impl) as impl : f Snarky_backendless.Snark.m) ~dummy_scalar
+            ~dummy_scalar_challenge ~challenge ~scalar_challenge ~feature_flags
+            (fp : (fp, _, f, _) Snarky_backendless.Typ.t) index =
           Snarky_backendless.Typ.of_hlistable
             [ Plonk.In_circuit.typ impl ~dummy_scalar ~dummy_scalar_challenge
                 ~challenge ~scalar_challenge ~bool:Impl.Boolean.typ
@@ -715,10 +712,9 @@ module Wrap = struct
 
       let to_hlist, of_hlist = (to_hlist, of_hlist)
 
-      let typ (type f fp)
-          (impl : (module Snarky_backendless.Snark_intf.Run with type field = f))
+      let typ (type f fp) ((module Impl) as impl : f Snarky_backendless.Snark.m)
           ~dummy_scalar ~dummy_scalar_challenge ~challenge ~scalar_challenge
-          ~feature_flags (fp : (fp, _, f) Snarky_backendless.Typ.t)
+          ~feature_flags (fp : (fp, _, f, _) Snarky_backendless.Typ.t)
           messages_for_next_wrap_proof digest index =
         Snarky_backendless.Typ.of_hlistable
           [ Deferred_values.In_circuit.typ impl ~dummy_scalar
@@ -1521,13 +1517,13 @@ module Step = struct
         }
     end
 
-    let typ (type n f)
-        ( (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
-        as impl ) zero ~assert_16_bits
+    let typ (type n f) ((module Impl) as impl : f Snarky_backendless.Snark.m)
+        zero ~assert_16_bits
         (proofs_verified :
           (Plonk_types.Opt.Flag.t Plonk_types.Features.t, n) Vector.t ) fq :
         ( ((_, _) Vector.t, _) t
         , ((_, _) Vector.t, _) t
+        , _
         , _ )
         Snarky_backendless.Typ.t =
       let per_proof feature_flags =

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -4,7 +4,12 @@ module Opt = Plonk_types.Opt
 type ('a, 'b) opt := ('a, 'b) Opt.t
 
 type ('var, 'value, 'field, 'checked) snarky_typ :=
-  ('var, 'value, 'field, 'checked) Snarky_backendless.Types.Typ.t
+  ( 'var
+  , 'value
+  , 'field
+  , 'field Snarky_backendless.Cvar.t
+  , 'checked )
+  Snarky_backendless.Types.Typ.t
 
 (** {2 Module aliases} *)
 
@@ -89,11 +94,16 @@ module Wrap : sig
                  ( 'a
                  , 'b
                  , 'f
+                 , 'f Snarky_backendless.Cvar.t
                  , ( unit
                    , 'f )
                    Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
                  Snarky_backendless.Types.Typ.t
-              -> ('a t, 'b t, 'f) Snarky_backendless.Typ.t
+              -> ( 'a t
+                 , 'b t
+                 , 'f
+                 , 'f Snarky_backendless.Cvar.t )
+                 Snarky_backendless.Typ.t
           end
 
           module Optional_column_scalars : sig
@@ -174,20 +184,31 @@ module Wrap : sig
                  ( 'c
                  , 'd
                  , 'f
+                 , 'f Snarky_backendless.Cvar.t
                  , ( unit
                    , 'f )
                    Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
                  Snarky_backendless.Types.Typ.t
-            -> scalar_challenge:('e, 'b, 'f) Snarky_backendless.Typ.t
+            -> scalar_challenge:
+                 ( 'e
+                 , 'b
+                 , 'f
+                 , 'f Snarky_backendless.Cvar.t )
+                 Snarky_backendless.Typ.t
             -> bool:
                  ( ('f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
                     as
                     'boolean )
                  , bool
-                 , 'f )
+                 , 'f
+                 , 'f Snarky_backendless.Cvar.t )
                  Snarky_backendless.Typ.t
             -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
-            -> ('fp, 'a, 'f) Snarky_backendless.Typ.t
+            -> ( 'fp
+               , 'a
+               , 'f
+               , 'f Snarky_backendless.Cvar.t )
+               Snarky_backendless.Typ.t
             -> ( ( 'c
                  , 'e Scalar_challenge.t
                  , 'fp
@@ -202,7 +223,8 @@ module Wrap : sig
                  , 'b Scalar_challenge.t Lookup.t option
                  , bool )
                  t
-               , 'f )
+               , 'f
+               , 'f Snarky_backendless.Cvar.t )
                Snarky_backendless.Typ.t
         end
 
@@ -344,7 +366,7 @@ module Wrap : sig
         [@@deriving sexp, compare, yojson, hash, equal]
 
         val typ :
-             (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+             'f Snarky_backendless.Snark.m
           -> dummy_scalar:'a
           -> dummy_scalar_challenge:'b Scalar_challenge.t
           -> challenge:
@@ -355,9 +377,18 @@ module Wrap : sig
                  , 'f )
                  Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
                snarky_typ
-          -> scalar_challenge:('e, 'b, 'f) Snarky_backendless.Typ.t
+          -> scalar_challenge:
+               ( 'e
+               , 'b
+               , 'f
+               , 'f Snarky_backendless.Cvar.t )
+               Snarky_backendless.Typ.t
           -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
-          -> ('fp, 'a, 'f) Snarky_backendless.Typ.t
+          -> ( 'fp
+             , 'a
+             , 'f
+             , 'f Snarky_backendless.Cvar.t )
+             Snarky_backendless.Typ.t
           -> ( 'g
              , 'h
              , 'f
@@ -400,7 +431,8 @@ module Wrap : sig
                  Vector.vec
                , 'h )
                Stable.Latest.t
-             , 'f )
+             , 'f
+             , 'f Snarky_backendless.Cvar.t )
              Snarky_backendless.Typ.t
       end
 
@@ -516,11 +548,12 @@ module Wrap : sig
            , (unit, 'c) Snarky_backendless.Checked_runner.Simple.Types.Checked.t
            )
            snarky_typ
-        -> ('d, 'e, 'c) Snarky_backendless.Typ.t
+        -> ('d, 'e, 'c, 'c Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
         -> length:'f Nat.nat
         -> ( ('a, ('d, 'f) Vector.vec) t
            , ('b, ('e, 'f) Vector.vec) t
-           , 'c )
+           , 'c
+           , 'c Snarky_backendless.Cvar.t )
            Snarky_backendless.Typ.t
     end
 
@@ -574,7 +607,7 @@ module Wrap : sig
       [@@deriving sexp, compare, yojson, hash, equal]
 
       val typ :
-           (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+           'f Snarky_backendless.Snark.m
         -> dummy_scalar:'a
         -> dummy_scalar_challenge:'b Scalar_challenge.t
         -> challenge:
@@ -585,9 +618,10 @@ module Wrap : sig
                , 'f )
                Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
              snarky_typ
-        -> scalar_challenge:('e, 'b, 'f) Snarky_backendless.Typ.t
+        -> scalar_challenge:
+             ('e, 'b, 'f, 'f Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
         -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
-        -> ('fp, 'a, 'f) Snarky_backendless.Typ.t
+        -> ('fp, 'a, 'f, 'f Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
         -> ( 'g
            , 'h
            , 'f
@@ -645,7 +679,8 @@ module Wrap : sig
                Vector.vec
              , 'l )
              Stable.Latest.t
-           , 'f )
+           , 'f
+           , 'f Snarky_backendless.Cvar.t )
            Snarky_backendless.Typ.t
     end
 
@@ -688,8 +723,8 @@ module Wrap : sig
       -> 'f Core_kernel.Array.t
 
     val typ :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
-      -> ('d, 'e, 'c) Snarky_backendless.Typ.t
+         ('a, 'b, 'c, 'c Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
+      -> ('d, 'e, 'c, 'c Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
       -> ( 'f
          , 'g
          , 'c
@@ -705,7 +740,8 @@ module Wrap : sig
       -> 'j Nat.nat
       -> ( ('a, 'f, ('d, 'j) Vector.vec, 'h) t
          , ('b, 'g, ('e, 'j) Vector.vec, 'i) t
-         , 'c )
+         , 'c
+         , 'c Snarky_backendless.Cvar.t )
          Snarky_backendless.Typ.t
   end
 
@@ -1356,7 +1392,8 @@ module Step : sig
              , (Limb_vector.Constant.Hex64.t, Digest.Limbs.n) Vector.t
              , bool )
              In_circuit.t
-           , 'a )
+           , 'a
+           , 'a Snarky_backendless.Cvar.t )
            Snarky_backendless.Typ.t
     end
 
@@ -1449,7 +1486,8 @@ module Step : sig
              Vector.t
            , (Limb_vector.Constant.Hex64.t, Digest.Limbs.n) Vector.t )
            t
-         , 'f )
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
          Snarky_backendless.Typ.t
   end
 

--- a/src/lib/pickles/composition_types/spec.mli
+++ b/src/lib/pickles/composition_types/spec.mli
@@ -1,4 +1,4 @@
-type 'f impl = (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+type 'f impl = 'f Snarky_backendless.Snark.m
 
 type (_, _, _) basic =
   | Unit : (unit, unit, < .. >) basic
@@ -86,6 +86,7 @@ val typ :
   -> ( 'b
      , 'c
      , 'a
+     , 'a Snarky_backendless.Cvar.t
      , (unit, 'a) Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
      Snarky_backendless.Types.Typ.t
   -> ( 'd
@@ -113,12 +114,16 @@ val typ :
        ; field2 : 'b
        ; .. > )
      T.t
-  -> ('e, 'd, 'a) Snarky_backendless.Typ.t
+  -> ('e, 'd, 'a, 'a Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
 
 module ETyp : sig
   type ('var, 'value, 'f) t =
     | T :
-        ('inner, 'value, 'f) Snarky_backendless.Typ.t
+        ( 'inner
+        , 'value
+        , 'f
+        , 'f Snarky_backendless.Cvar.t )
+        Snarky_backendless.Typ.t
         * ('inner -> 'var)
         * ('var -> 'inner)
         -> ('var, 'value, 'f) t

--- a/src/lib/pickles/fix_domains.ml
+++ b/src/lib/pickles/fix_domains.ml
@@ -7,8 +7,7 @@ let rough_domains : Domains.t =
   let d = Domain.Pow_2_roots_of_unity 20 in
   { h = d }
 
-let domains (type field)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = field)
+let domains (type field) ((module Impl) : field Snarky_backendless.Snark.m)
     (Spec.ETyp.T (typ, conv, _conv_inv))
     (Spec.ETyp.T (return_typ, _ret_conv, ret_conv_inv)) main =
   let main x () = ret_conv_inv (main (conv x)) in

--- a/src/lib/pickles/fix_domains.mli
+++ b/src/lib/pickles/fix_domains.mli
@@ -1,5 +1,5 @@
 val domains :
-     (module Snarky_backendless.Snark_intf.Run with type field = 'field)
+     'field Snarky_backendless.Snark.m
   -> ('a, 'b, 'field) Import.Spec.ETyp.t
   -> ('c, 'd, 'field) Import.Spec.ETyp.t
   -> ('a -> 'c)

--- a/src/lib/pickles/impls.mli
+++ b/src/lib/pickles/impls.mli
@@ -33,7 +33,12 @@ module Step : sig
 
     val typ_unchecked : (t, Constant.t) Typ.t
 
-    val typ : (t, Constant.t, Internal_Basic.field) Snarky_backendless.Typ.t
+    val typ :
+      ( t
+      , Constant.t
+      , Internal_Basic.field
+      , Internal_Basic.field_var )
+      Snarky_backendless.Typ.t
   end
 
   val input :
@@ -145,7 +150,8 @@ module Wrap : sig
     val typ :
       ( Impl.Field.t
       , Backend.Tick.Field.t
-      , Wrap_impl.Internal_Basic.Field.t )
+      , Wrap_impl.Internal_Basic.Field.t
+      , Wrap_impl.Internal_Basic.field_var )
       Snarky_backendless.Typ.t
   end
 

--- a/src/lib/pickles/intf.ml
+++ b/src/lib/pickles/intf.ml
@@ -7,29 +7,62 @@ module Snarkable = struct
     type _ t
 
     val typ :
-         ('var, 'value, 'f) Snarky_backendless.Typ.t
-      -> ('var t, 'value t, 'f) Snarky_backendless.Typ.t
+         ( 'var
+         , 'value
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var t
+         , 'value t
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
   end
 
   module type S2 = sig
     type (_, _) t
 
     val typ :
-         ('var1, 'value1, 'f) Snarky_backendless.Typ.t
-      -> ('var2, 'value2, 'f) Snarky_backendless.Typ.t
-      -> (('var1, 'var2) t, ('value1, 'value2) t, 'f) Snarky_backendless.Typ.t
+         ( 'var1
+         , 'value1
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var2
+         , 'value2
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( ('var1, 'var2) t
+         , ('value1, 'value2) t
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
   end
 
   module type S3 = sig
     type (_, _, _) t
 
     val typ :
-         ('var1, 'value1, 'f) Snarky_backendless.Typ.t
-      -> ('var2, 'value2, 'f) Snarky_backendless.Typ.t
-      -> ('var3, 'value3, 'f) Snarky_backendless.Typ.t
+         ( 'var1
+         , 'value1
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var2
+         , 'value2
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var3
+         , 'value3
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
       -> ( ('var1, 'var2, 'var3) t
          , ('value1, 'value2, 'value3) t
-         , 'f )
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
          Snarky_backendless.Typ.t
   end
 
@@ -37,13 +70,30 @@ module Snarkable = struct
     type (_, _, _, _) t
 
     val typ :
-         ('var1, 'value1, 'f) Snarky_backendless.Typ.t
-      -> ('var2, 'value2, 'f) Snarky_backendless.Typ.t
-      -> ('var3, 'value3, 'f) Snarky_backendless.Typ.t
-      -> ('var4, 'value4, 'f) Snarky_backendless.Typ.t
+         ( 'var1
+         , 'value1
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var2
+         , 'value2
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var3
+         , 'value3
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var4
+         , 'value4
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
       -> ( ('var1, 'var2, 'var3, 'var4) t
          , ('value1, 'value2, 'value3, 'value4) t
-         , 'f )
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
          Snarky_backendless.Typ.t
   end
 
@@ -51,14 +101,35 @@ module Snarkable = struct
     type (_, _, _, _, _) t
 
     val typ :
-         ('var1, 'value1, 'f) Snarky_backendless.Typ.t
-      -> ('var2, 'value2, 'f) Snarky_backendless.Typ.t
-      -> ('var3, 'value3, 'f) Snarky_backendless.Typ.t
-      -> ('var4, 'value4, 'f) Snarky_backendless.Typ.t
-      -> ('var5, 'value5, 'f) Snarky_backendless.Typ.t
+         ( 'var1
+         , 'value1
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var2
+         , 'value2
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var3
+         , 'value3
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var4
+         , 'value4
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var5
+         , 'value5
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
       -> ( ('var1, 'var2, 'var3, 'var4, 'var5) t
          , ('value1, 'value2, 'value3, 'value4, 'value5) t
-         , 'f )
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
          Snarky_backendless.Typ.t
   end
 
@@ -66,15 +137,40 @@ module Snarkable = struct
     type (_, _, _, _, _, _) t
 
     val typ :
-         ('var1, 'value1, 'f) Snarky_backendless.Typ.t
-      -> ('var2, 'value2, 'f) Snarky_backendless.Typ.t
-      -> ('var3, 'value3, 'f) Snarky_backendless.Typ.t
-      -> ('var4, 'value4, 'f) Snarky_backendless.Typ.t
-      -> ('var5, 'value5, 'f) Snarky_backendless.Typ.t
-      -> ('var6, 'value6, 'f) Snarky_backendless.Typ.t
+         ( 'var1
+         , 'value1
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var2
+         , 'value2
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var3
+         , 'value3
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var4
+         , 'value4
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var5
+         , 'value5
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var6
+         , 'value6
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
       -> ( ('var1, 'var2, 'var3, 'var4, 'var5, 'var6) t
          , ('value1, 'value2, 'value3, 'value4, 'value5, 'value6) t
-         , 'f )
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
          Snarky_backendless.Typ.t
   end
 
@@ -82,16 +178,45 @@ module Snarkable = struct
     type (_, _, _, _, _, _, _) t
 
     val typ :
-         ('var1, 'value1, 'f) Snarky_backendless.Typ.t
-      -> ('var2, 'value2, 'f) Snarky_backendless.Typ.t
-      -> ('var3, 'value3, 'f) Snarky_backendless.Typ.t
-      -> ('var4, 'value4, 'f) Snarky_backendless.Typ.t
-      -> ('var5, 'value5, 'f) Snarky_backendless.Typ.t
-      -> ('var6, 'value6, 'f) Snarky_backendless.Typ.t
-      -> ('var7, 'value7, 'f) Snarky_backendless.Typ.t
+         ( 'var1
+         , 'value1
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var2
+         , 'value2
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var3
+         , 'value3
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var4
+         , 'value4
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var5
+         , 'value5
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var6
+         , 'value6
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var7
+         , 'value7
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
       -> ( ('var1, 'var2, 'var3, 'var4, 'var5, 'var6, 'var7) t
          , ('value1, 'value2, 'value3, 'value4, 'value5, 'value6, 'value7) t
-         , 'f )
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
          Snarky_backendless.Typ.t
   end
 
@@ -99,14 +224,46 @@ module Snarkable = struct
     type (_, _, _, _, _, _, _, _) t
 
     val typ :
-         ('var1, 'value1, 'f) Snarky_backendless.Typ.t
-      -> ('var2, 'value2, 'f) Snarky_backendless.Typ.t
-      -> ('var3, 'value3, 'f) Snarky_backendless.Typ.t
-      -> ('var4, 'value4, 'f) Snarky_backendless.Typ.t
-      -> ('var5, 'value5, 'f) Snarky_backendless.Typ.t
-      -> ('var6, 'value6, 'f) Snarky_backendless.Typ.t
-      -> ('var7, 'value7, 'f) Snarky_backendless.Typ.t
-      -> ('var8, 'value8, 'f) Snarky_backendless.Typ.t
+         ( 'var1
+         , 'value1
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var2
+         , 'value2
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var3
+         , 'value3
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var4
+         , 'value4
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var5
+         , 'value5
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var6
+         , 'value6
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var7
+         , 'value7
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
+      -> ( 'var8
+         , 'value8
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
+         Snarky_backendless.Typ.t
       -> ( ('var1, 'var2, 'var3, 'var4, 'var5, 'var6, 'var7, 'var8) t
          , ( 'value1
            , 'value2
@@ -117,7 +274,8 @@ module Snarkable = struct
            , 'value7
            , 'value8 )
            t
-         , 'f )
+         , 'f
+         , 'f Snarky_backendless.Cvar.t )
          Snarky_backendless.Typ.t
   end
 end
@@ -168,9 +326,19 @@ module Group (Impl : Snarky_backendless.Snark_intf.Run) = struct
       val of_affine : field * field -> t
     end
 
-    val typ_unchecked : (t, Constant.t, field) Snarky_backendless.Typ.t
+    val typ_unchecked :
+      ( t
+      , Constant.t
+      , field
+      , field Snarky_backendless.Cvar.t )
+      Snarky_backendless.Typ.t
 
-    val typ : (t, Constant.t, field) Snarky_backendless.Typ.t
+    val typ :
+      ( t
+      , Constant.t
+      , field
+      , field Snarky_backendless.Cvar.t )
+      Snarky_backendless.Typ.t
 
     val ( + ) : t -> t -> t
 
@@ -210,7 +378,7 @@ module Sponge (Impl : Snarky_backendless.Snark_intf.Run) = struct
 end
 
 module type Inputs_base = sig
-  module Impl : Snarky_backendless.Snark_intf.Run
+  module Impl : Snarky_backendless.Snark_intf.Run_with_cvar
 
   module Inner_curve : sig
     open Impl

--- a/src/lib/pickles/limb_vector/challenge.ml
+++ b/src/lib/pickles/limb_vector/challenge.ml
@@ -5,7 +5,7 @@ type 'f t = 'f Snarky_backendless.Cvar.t
 module Constant = Constant.Make (Nat.N2)
 
 module type S = sig
-  module Impl : Snarky_backendless.Snark_intf.Run
+  module Impl : Snarky_backendless.Snark_intf.Run_with_cvar
 
   open Impl
 
@@ -26,6 +26,6 @@ module type S = sig
   val length : int
 end
 
-module Make (Impl : Snarky_backendless.Snark_intf.Run) :
+module Make (Impl : Snarky_backendless.Snark_intf.Run_with_cvar) :
   S with module Impl := Impl =
   Make.T (Impl) (Nat.N2)

--- a/src/lib/pickles/limb_vector/challenge.mli
+++ b/src/lib/pickles/limb_vector/challenge.mli
@@ -3,7 +3,7 @@ type 'f t = 'f Snarky_backendless.Cvar.t
 module Constant : module type of Constant.Make (Pickles_types.Nat.N2)
 
 module type S = sig
-  module Impl : Snarky_backendless.Snark_intf.Run
+  module Impl : Snarky_backendless.Snark_intf.Run_with_cvar
 
   type nonrec t = Impl.field t
 
@@ -22,5 +22,5 @@ module type S = sig
   val length : int
 end
 
-module Make (Impl : Snarky_backendless.Snark_intf.Run) :
+module Make (Impl : Snarky_backendless.Snark_intf.Run_with_cvar) :
   S with module Impl := Impl

--- a/src/lib/pickles/one_hot_vector/one_hot_vector.ml
+++ b/src/lib/pickles/one_hot_vector/one_hot_vector.ml
@@ -14,7 +14,7 @@ module T (Impl : Snarky_backendless.Snark_intf.Run) = struct
   type nonrec 'n t = (Impl.field, 'n) t
 end
 
-module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
+module Make (Impl : Snarky_backendless.Snark_intf.Run_with_cvar) = struct
   module Constant = Constant
   open Impl
   include T (Impl)

--- a/src/lib/pickles/one_hot_vector/one_hot_vector.mli
+++ b/src/lib/pickles/one_hot_vector/one_hot_vector.mli
@@ -12,7 +12,7 @@ module T (Impl : Snarky_backendless.Snark_intf.Run) : sig
   type nonrec 'n t = (Impl.field, 'n) t
 end
 
-module Make (Impl : Snarky_backendless.Snark_intf.Run) : sig
+module Make (Impl : Snarky_backendless.Snark_intf.Run_with_cvar) : sig
   open Impl
   module Constant = Constant
 

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -566,10 +566,9 @@ module Make (Shifted_value : Shifted_value.S) (Sc : Scalars.S) = struct
     but we deferred the arithmetic checks until here
     so that we have the efficiency of the native field.
   *)
-  let checked (type t)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = t)
-      ~shift ~env ~feature_flags
-      (plonk : (_, _, _, _ Opt.t, _ Opt.t, _) In_circuit.t) evals =
+  let checked (type t) ((module Impl) : t Snarky_backendless.Snark.m) ~shift
+      ~env ~feature_flags (plonk : (_, _, _, _ Opt.t, _ Opt.t, _) In_circuit.t)
+      evals =
     let actual =
       derive_plonk ~with_label:Impl.with_label
         (module Impl.Field)

--- a/src/lib/pickles/plonk_checks/plonk_checks.mli
+++ b/src/lib/pickles/plonk_checks/plonk_checks.mli
@@ -129,7 +129,7 @@ module Make (Shifted_value : Pickles_types.Shifted_value.S) (Sc : Scalars.S) : s
        Composition_types.Wrap.Proof_state.Deferred_values.Plonk.In_circuit.t
 
   val checked :
-       (module Snarky_backendless.Snark_intf.Run with type field = 't)
+       't Snarky_backendless.Snark.m
     -> shift:'t Snarky_backendless.Cvar.t Shifted_value.Shift.t
     -> env:'t Snarky_backendless.Cvar.t Scalars.Env.t
     -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t

--- a/src/lib/pickles/plonk_curve_ops.ml
+++ b/src/lib/pickles/plonk_curve_ops.ml
@@ -4,8 +4,7 @@ open Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint
 
 let seal i = Tuple_lib.Double.map ~f:(Util.seal i)
 
-let add_fast (type f)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+let add_fast (type f) ((module Impl) : f Snarky_backendless.Snark.m)
     ?(check_finite = true) ((x1, y1) as p1) ((x2, y2) as p2) :
     Impl.Field.t * Impl.Field.t =
   let p1 = seal (module Impl) p1 in
@@ -54,7 +53,7 @@ let add_fast (type f)
       p3 )
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Impl : Snarky_backendless.Snark_intf.Run_with_cvar)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) =
 struct
   open Impl

--- a/src/lib/pickles/plonk_curve_ops.mli
+++ b/src/lib/pickles/plonk_curve_ops.mli
@@ -1,12 +1,12 @@
 val add_fast :
-     (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+     'f Snarky_backendless.Snark.m
   -> ?check_finite:bool
   -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t * 'f Snarky_backendless.Cvar.t
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Impl : Snarky_backendless.Snark_intf.Run_with_cvar)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t) : sig
   type var := Impl.field Snarky_backendless.Cvar.t
 

--- a/src/lib/pickles/pseudo/pseudo.ml
+++ b/src/lib/pickles/pseudo/pseudo.ml
@@ -2,7 +2,7 @@ open Core_kernel
 open Pickles_types
 module Domain = Plonk_checks.Domain
 
-module Make (Impl : Snarky_backendless.Snark_intf.Run) = struct
+module Make (Impl : Snarky_backendless.Snark_intf.Run_with_cvar) = struct
   open Impl
 
   type ('a, 'n) t = 'n One_hot_vector.T(Impl).t * ('a, 'n) Vector.t

--- a/src/lib/pickles/pseudo/pseudo.mli
+++ b/src/lib/pickles/pseudo/pseudo.mli
@@ -1,6 +1,6 @@
 (* Pseudo *)
 
-module Make (Impl : Snarky_backendless.Snark_intf.Run) : sig
+module Make (Impl : Snarky_backendless.Snark_intf.Run_with_cvar) : sig
   type ('a, 'n) t =
     'n One_hot_vector.T(Impl).t * ('a, 'n) Pickles_types.Vector.t
 

--- a/src/lib/pickles/scalar_challenge.ml
+++ b/src/lib/pickles/scalar_challenge.ml
@@ -10,7 +10,7 @@ let num_bits = 128
 
 (* Has the side effect of checking that [scalar] fits in 128 bits. *)
 let to_field_checked' (type f) ?(num_bits = num_bits)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+    ((module Impl) : f Snarky_backendless.Snark.m)
     { SC.inner = (scalar : Impl.Field.t) } =
   let open Impl in
   let neg_one = Field.Constant.(negate one) in
@@ -128,7 +128,7 @@ let to_field_checked' (type f) ?(num_bits = num_bits)
   (!a, !b, !n)
 
 let to_field_checked (type f) ?num_bits
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) ~endo
+    ((module Impl) : f Snarky_backendless.Snark.m) ~endo
     ({ SC.inner = (scalar : Impl.Field.t) } as s) =
   let open Impl in
   let a, b, n = to_field_checked' ?num_bits (module Impl) s in
@@ -151,9 +151,7 @@ let to_field_constant (type f) ~endo
   done ;
   F.((!a * endo) + !b)
 
-let test (type f)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
-    ~(endo : f) =
+let test (type f) ((module Impl) : f Snarky_backendless.Snark.m) ~(endo : f) =
   let open Impl in
   let module T = Internal_Basic in
   let n = 128 in
@@ -189,7 +187,7 @@ let test (type f)
         raise e )
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run)
+    (Impl : Snarky_backendless.Snark_intf.Run_with_cvar)
     (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t)
     (Challenge : Challenge.S with module Impl := Impl) (Endo : sig
       val base : Impl.Field.Constant.t

--- a/src/lib/pickles/scalar_challenge.mli
+++ b/src/lib/pickles/scalar_challenge.mli
@@ -10,7 +10,7 @@ val to_field_constant :
 
 val to_field_checked' :
      ?num_bits:int
-  -> (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> 'f Snarky_backendless.Snark.m
   -> 'f Snarky_backendless.Cvar.t Import.Scalar_challenge.t
   -> 'f Snarky_backendless.Cvar.t
      * 'f Snarky_backendless.Cvar.t
@@ -18,7 +18,7 @@ val to_field_checked' :
 
 val to_field_checked :
      ?num_bits:int
-  -> (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> 'f Snarky_backendless.Snark.m
   -> endo:'f
   -> 'f Snarky_backendless.Cvar.t Import.Scalar_challenge.t
   -> 'f Snarky_backendless.Cvar.t
@@ -26,7 +26,7 @@ val to_field_checked :
 val test : 'f Import.Spec.impl -> endo:'f -> unit
 
 module Make : functor
-  (Impl : Snarky_backendless.Snark_intf.Run)
+  (Impl : Snarky_backendless.Snark_intf.Run_with_cvar)
   (G : Intf.Group(Impl).S with type t = Impl.Field.t * Impl.Field.t)
   (Challenge : Import.Challenge.S with module Impl := Impl)
   (Endo : sig

--- a/src/lib/pickles/sponge_inputs.ml
+++ b/src/lib/pickles/sponge_inputs.ml
@@ -7,7 +7,7 @@ module type Field = sig
 end
 
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run) (B : sig
+    (Impl : Snarky_backendless.Snark_intf.Run_with_cvar) (B : sig
       open Impl
 
       val params : field Sponge.Params.t

--- a/src/lib/pickles/sponge_inputs.mli
+++ b/src/lib/pickles/sponge_inputs.mli
@@ -1,5 +1,5 @@
 module Make
-    (Impl : Snarky_backendless.Snark_intf.Run) (B : sig
+    (Impl : Snarky_backendless.Snark_intf.Run_with_cvar) (B : sig
       val params : Impl.field Sponge.Params.t
 
       val to_the_alpha : Impl.field -> Impl.field

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -31,7 +31,8 @@ module Other_field : sig
   val typ :
     ( t
     , Impls.Step.Other_field.Constant.t
-    , Impls.Step.Internal_Basic.field )
+    , Impls.Step.Internal_Basic.field
+    , Impls.Step.Internal_Basic.field_var )
     Snarky_backendless.Typ.t
 end
 

--- a/src/lib/pickles/util.ml
+++ b/src/lib/pickles/util.ml
@@ -43,7 +43,7 @@ let rec absorb :
 let ones_vector :
     type f n.
        first_zero:f Snarky_backendless.Cvar.t
-    -> (module Snarky_backendless.Snark_intf.Run with type field = f)
+    -> f Snarky_backendless.Snark.m
     -> n Nat.t
     -> (f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t, n) Vector.t =
  fun ~first_zero (module Impl) n ->
@@ -62,8 +62,7 @@ let ones_vector :
   in
   go Boolean.true_ 0 n
 
-let seal (type f)
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
+let seal (type f) ((module Impl) : f Snarky_backendless.Snark.m)
     (x : Impl.Field.t) : Impl.Field.t =
   let open Impl in
   match Field.to_constant_and_terms x with
@@ -76,7 +75,7 @@ let seal (type f)
       Field.Assert.equal x y ; y
 
 let lowest_128_bits (type f) ~constrain_low_bits ~assert_128_bits
-    (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) x =
+    ((module Impl) : f Snarky_backendless.Snark.m) x =
   let open Impl in
   let pow2 =
     (* 2 ^ n *)

--- a/src/lib/pickles/util.mli
+++ b/src/lib/pickles/util.mli
@@ -13,20 +13,20 @@ val absorb :
 val ones_vector :
   'f 'n.
      first_zero:'f Snarky_backendless.Cvar.t
-  -> (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> 'f Snarky_backendless.Snark.m
   -> 'n Pickles_types.Nat.t
   -> ( 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
      , 'n )
      Pickles_types.Vector.t
 
 val seal :
-     (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+     'f Snarky_backendless.Snark.m
   -> 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t
 
 val lowest_128_bits :
      constrain_low_bits:bool
   -> assert_128_bits:('f Snarky_backendless.Cvar.t -> unit)
-  -> (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> 'f Snarky_backendless.Snark.m
   -> 'f Snarky_backendless.Cvar.t
   -> 'f Snarky_backendless.Cvar.t

--- a/src/lib/pickles/wrap_verifier.mli
+++ b/src/lib/pickles/wrap_verifier.mli
@@ -27,7 +27,8 @@ module Other_field : sig
     val typ :
       ( Impls.Wrap.Impl.Field.t
       , Backend.Tick.Field.t
-      , Impls.Wrap_impl.Internal_Basic.Field.t )
+      , Impls.Wrap_impl.Internal_Basic.Field.t
+      , Impls.Wrap_impl.Internal_Basic.Field.Var.t )
       Snarky_backendless.Typ.t
   end
 end

--- a/src/lib/pickles_base/proofs_verified.ml
+++ b/src/lib/pickles_base/proofs_verified.ml
@@ -90,8 +90,7 @@ module Prefix_mask = struct
     | [ true; false ] ->
         invalid_arg "Prefix_mask.back: invalid mask [false; true]"
 
-  let typ (type f)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) :
+  let typ (type f) ((module Impl) : f Snarky_backendless.Snark.m) :
       (f Checked.t, proofs_verified) Impl.Typ.t =
     let open Impl in
     Typ.transport
@@ -134,8 +133,7 @@ module One_hot = struct
     in
     Random_oracle_input.Chunked.packeds (Array.map one_hot ~f:(fun b -> (b, 1)))
 
-  let typ (type f)
-      (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) :
+  let typ (type f) ((module Impl) : f Snarky_backendless.Snark.m) :
       (f Checked.t, proofs_verified) Impl.Typ.t =
     let module M = One_hot_vector.Make (Impl) in
     let open Impl in

--- a/src/lib/pickles_base/proofs_verified.mli
+++ b/src/lib/pickles_base/proofs_verified.mli
@@ -29,8 +29,12 @@ module One_hot : sig
   val to_input : zero:'a -> one:'a -> t -> 'a Random_oracle_input.Chunked.t
 
   val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> ('f Checked.t, t, 'f) Snarky_backendless.Typ.t
+       'f Snarky_backendless.Snark.m
+    -> ( 'f Checked.t
+       , t
+       , 'f
+       , 'f Snarky_backendless.Cvar.t )
+       Snarky_backendless.Typ.t
 end
 
 type 'f boolean = 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t
@@ -47,10 +51,11 @@ module Prefix_mask : sig
   val back : bool vec2 -> t
 
   val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+       'f Snarky_backendless.Snark.m
     -> ( 'f Checked.t
        , t
        , 'f
+       , 'f Snarky_backendless.Cvar.t
        , (unit, 'f) Snarky_backendless.Checked_runner.Simple.t )
        Snarky_backendless__.Types.Typ.t
 end

--- a/src/lib/pickles_types/hlist.ml
+++ b/src/lib/pickles_types/hlist.ml
@@ -160,17 +160,29 @@ module H1 = struct
 
   module Typ (Impl : sig
     type field
+
+    type field_var
   end)
   (F : T1)
   (Var : T1)
   (Val : T1) (C : sig
-    val f : 'a F.t -> ('a Var.t, 'a Val.t, Impl.field) Snarky_backendless.Typ.t
+    val f :
+         'a F.t
+      -> ( 'a Var.t
+         , 'a Val.t
+         , Impl.field
+         , Impl.field_var )
+         Snarky_backendless.Typ.t
   end) =
   struct
     let rec f :
         type xs.
            xs T(F).t
-        -> (xs T(Var).t, xs T(Val).t, Impl.field) Snarky_backendless.Typ.t =
+        -> ( xs T(Var).t
+           , xs T(Val).t
+           , Impl.field
+           , Impl.field_var )
+           Snarky_backendless.Typ.t =
       let transport, transport_var, tuple2, unit =
         Snarky_backendless.Typ.(transport, transport_var, tuple2, unit)
       in
@@ -243,8 +255,11 @@ module H2 = struct
   module Typ (Impl : sig
     type field
 
+    type field_var
+
     module Typ : sig
-      type ('var, 'value) t = ('var, 'value, field) Snarky_backendless.Typ.t
+      type ('var, 'value) t =
+        ('var, 'value, field, field_var) Snarky_backendless.Typ.t
     end
   end) =
   struct
@@ -256,7 +271,8 @@ module H2 = struct
            (vars, values) T(Impl.Typ).t
         -> ( vars H1.T(Id).t
            , values H1.T(Id).t
-           , Impl.field )
+           , Impl.field
+           , Impl.field_var )
            Snarky_backendless.Typ.t =
      fun ts ->
       match ts with
@@ -680,6 +696,8 @@ module H4 = struct
 
   module Typ (Impl : sig
     type field
+
+    type field_var
   end)
   (F : T4)
   (Var : T3)
@@ -688,7 +706,8 @@ module H4 = struct
          ('var, 'value, 'n1, 'n2) F.t
       -> ( ('var, 'n1, 'n2) Var.t
          , ('value, 'n1, 'n2) Val.t
-         , Impl.field )
+         , Impl.field
+         , Impl.field_var )
          Snarky_backendless.Typ.t
   end) =
   struct
@@ -700,7 +719,8 @@ module H4 = struct
            (vars, values, ns1, ns2) T(F).t
         -> ( (vars, ns1, ns2) H3.T(Var).t
            , (values, ns1, ns2) H3.T(Val).t
-           , Impl.field )
+           , Impl.field
+           , Impl.field_var )
            Snarky_backendless.Typ.t =
      fun ts ->
       match ts with
@@ -824,6 +844,8 @@ module H6 = struct
 
   module Typ (Impl : sig
     type field
+
+    type field_var
   end)
   (F : T6)
   (Var : T4)
@@ -832,7 +854,8 @@ module H6 = struct
          ('var, 'value, 'ret_var, 'ret_value, 'n1, 'n2) F.t
       -> ( ('var, 'ret_var, 'n1, 'n2) Var.t
          , ('value, 'ret_value, 'n1, 'n2) Val.t
-         , Impl.field )
+         , Impl.field
+         , Impl.field_var )
          Snarky_backendless.Typ.t
   end) =
   struct
@@ -844,7 +867,8 @@ module H6 = struct
            (vars, values, ret_vars, ret_values, ns1, ns2) T(F).t
         -> ( (vars, ret_vars, ns1, ns2) H4.T(Var).t
            , (values, ret_values, ns1, ns2) H4.T(Val).t
-           , Impl.field )
+           , Impl.field
+           , Impl.field_var )
            Snarky_backendless.Typ.t =
      fun ts ->
       match ts with

--- a/src/lib/pickles_types/hlist.mli
+++ b/src/lib/pickles_types/hlist.mli
@@ -330,18 +330,29 @@ module H1 : sig
   module Typ : functor
     (Impl : sig
        type field
+
+       type field_var
      end)
     (A : T1)
     (Var : T1)
     (Val : T1)
     (_ : sig
        val f :
-         'a A.t -> ('a Var.t, 'a Val.t, Impl.field) Snarky_backendless.Typ.t
+            'a A.t
+         -> ( 'a Var.t
+            , 'a Val.t
+            , Impl.field
+            , Impl.field_var )
+            Snarky_backendless.Typ.t
      end)
     -> sig
     val f :
          'xs T(A).t
-      -> ('xs T(Var).t, 'xs T(Val).t, Impl.field) Snarky_backendless.Typ.t
+      -> ( 'xs T(Var).t
+         , 'xs T(Val).t
+         , Impl.field
+         , Impl.field_var )
+         Snarky_backendless.Typ.t
   end
 end
 
@@ -406,8 +417,11 @@ module H2 : sig
     (Impl : sig
        type field
 
+       type field_var
+
        module Typ : sig
-         type ('var, 'value) t = ('var, 'value, field) Snarky_backendless.Typ.t
+         type ('var, 'value) t =
+           ('var, 'value, field, field_var) Snarky_backendless.Typ.t
        end
      end)
     -> sig
@@ -415,7 +429,8 @@ module H2 : sig
          ('vars, 'values) T(Impl.Typ).t
       -> ( 'vars H1.T(Id).t
          , 'values H1.T(Id).t
-         , Impl.field )
+         , Impl.field
+         , Impl.field_var )
          Snarky_backendless.Typ.t
   end
 end
@@ -792,6 +807,8 @@ module H4 : sig
   module Typ : functor
     (Impl : sig
        type field
+
+       type field_var
      end)
     (A : T4)
     (Var : T3)
@@ -801,34 +818,36 @@ module H4 : sig
             ('var, 'value, 'n1, 'n2) A.t
          -> ( ('var, 'n1, 'n2) Var.t
             , ('value, 'n1, 'n2) Val.t
-            , Impl.field )
+            , Impl.field
+            , Impl.field_var )
             Snarky_backendless.Typ.t
      end)
     -> sig
     val transport :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
+         ('a, 'b, 'c, 'field_var) Snarky_backendless.Typ.t
       -> there:('d -> 'b)
       -> back:('b -> 'd)
-      -> ('a, 'd, 'c) Snarky_backendless.Typ.t
+      -> ('a, 'd, 'c, 'field_var) Snarky_backendless.Typ.t
 
     val transport_var :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
+         ('a, 'b, 'c, 'field_var) Snarky_backendless.Typ.t
       -> there:('d -> 'a)
       -> back:('a -> 'd)
-      -> ('d, 'b, 'c) Snarky_backendless.Typ.t
+      -> ('d, 'b, 'c, 'field_var) Snarky_backendless.Typ.t
 
     val tuple2 :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
-      -> ('d, 'e, 'c) Snarky_backendless.Typ.t
-      -> ('a * 'd, 'b * 'e, 'c) Snarky_backendless.Typ.t
+         ('a, 'b, 'c, 'field_var) Snarky_backendless.Typ.t
+      -> ('d, 'e, 'c, 'field_var) Snarky_backendless.Typ.t
+      -> ('a * 'd, 'b * 'e, 'c, 'field_var) Snarky_backendless.Typ.t
 
-    val unit : unit -> (unit, unit, 'a) Snarky_backendless.Typ.t
+    val unit : unit -> (unit, unit, 'a, 'field_var) Snarky_backendless.Typ.t
 
     val f :
          ('vars, 'values, 'ns1, 'ns2) T(A).t
       -> ( ('vars, 'ns1, 'ns2) H3.T(Var).t
          , ('values, 'ns1, 'ns2) H3.T(Val).t
-         , Impl.field )
+         , Impl.field
+         , Impl.field_var )
          Snarky_backendless.Typ.t
   end
 end
@@ -932,6 +951,8 @@ module H6 : sig
   module Typ : functor
     (Impl : sig
        type field
+
+       type field_var
      end)
     (A : T6)
     (Var : T4)
@@ -941,34 +962,36 @@ module H6 : sig
             ('var, 'value, 'ret_var, 'ret_value, 'n1, 'n2) A.t
          -> ( ('var, 'ret_var, 'n1, 'n2) Var.t
             , ('value, 'ret_value, 'n1, 'n2) Val.t
-            , Impl.field )
+            , Impl.field
+            , Impl.field_var )
             Snarky_backendless.Typ.t
      end)
     -> sig
     val transport :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
+         ('a, 'b, 'c, 'field_var) Snarky_backendless.Typ.t
       -> there:('d -> 'b)
       -> back:('b -> 'd)
-      -> ('a, 'd, 'c) Snarky_backendless.Typ.t
+      -> ('a, 'd, 'c, 'field_var) Snarky_backendless.Typ.t
 
     val transport_var :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
+         ('a, 'b, 'c, 'field_var) Snarky_backendless.Typ.t
       -> there:('d -> 'a)
       -> back:('a -> 'd)
-      -> ('d, 'b, 'c) Snarky_backendless.Typ.t
+      -> ('d, 'b, 'c, 'field_var) Snarky_backendless.Typ.t
 
     val tuple2 :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
-      -> ('d, 'e, 'c) Snarky_backendless.Typ.t
-      -> ('a * 'd, 'b * 'e, 'c) Snarky_backendless.Typ.t
+         ('a, 'b, 'c, 'field_var) Snarky_backendless.Typ.t
+      -> ('d, 'e, 'c, 'field_var) Snarky_backendless.Typ.t
+      -> ('a * 'd, 'b * 'e, 'c, 'field_var) Snarky_backendless.Typ.t
 
-    val unit : unit -> (unit, unit, 'a) Snarky_backendless.Typ.t
+    val unit : unit -> (unit, unit, 'a, 'field_var) Snarky_backendless.Typ.t
 
     val f :
          ('vars, 'values, 'ret_vars, 'ret_values, 'ns1, 'ns2) T(A).t
       -> ( ('vars, 'ret_vars, 'ns1, 'ns2) H4.T(Var).t
          , ('values, 'ret_values, 'ns1, 'ns2) H4.T(Val).t
-         , Impl.field )
+         , Impl.field
+         , Impl.field_var )
          Snarky_backendless.Typ.t
   end
 end

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -26,21 +26,29 @@ module Opt : sig
   end
 
   val constant_layout_typ :
-       ('b, bool, 'f) Snarky_backendless.Typ.t
+       ('b, bool, 'f, 'f Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
     -> true_:'b
     -> false_:'b
     -> Flag.t
-    -> ('a_var, 'a, 'f) Snarky_backendless.Typ.t
+    -> ('a_var, 'a, 'f, 'f Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
     -> dummy:'a
     -> dummy_var:'a_var
-    -> (('a_var, 'b) t, 'a option, 'f) Snarky_backendless.Typ.t
+    -> ( ('a_var, 'b) t
+       , 'a option
+       , 'f
+       , 'f Snarky_backendless.Cvar.t )
+       Snarky_backendless.Typ.t
 
   val typ :
-       ('b, bool, 'f) Snarky_backendless.Typ.t
+       ('b, bool, 'f, 'f Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
     -> Flag.t
-    -> ('a_var, 'a, 'f) Snarky_backendless.Typ.t
+    -> ('a_var, 'a, 'f, 'f Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
     -> dummy:'a
-    -> (('a_var, 'b) t, 'a option, 'f) Snarky_backendless.Typ.t
+    -> ( ('a_var, 'b) t
+       , 'a option
+       , 'f
+       , 'f Snarky_backendless.Cvar.t )
+       Snarky_backendless.Typ.t
 
   (** A sequence that should be considered to have stopped at
        the first occurence of {!Flag.No} *)
@@ -93,9 +101,13 @@ module Features : sig
     -> 'a t
 
   val typ :
-       ('var, bool, 'f) Snarky_backendless.Typ.t
+       ('var, bool, 'f, 'f Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
     -> feature_flags:options
-    -> ('var t, bool t, 'f) Snarky_backendless.Typ.t
+    -> ( 'var t
+       , bool t
+       , 'f
+       , 'f Snarky_backendless.Cvar.t )
+       Snarky_backendless.Typ.t
 
   val none : options
 
@@ -177,17 +189,19 @@ module Messages : sig
   end
 
   val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> ('a, 'b, 'f) Snarky_backendless.Typ.t
+       'f Snarky_backendless.Snark.m
+    -> ('a, 'b, 'f, 'f Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
     -> Opt.Flag.t Features.t
     -> dummy:'b
     -> commitment_lengths:((int, 'n) Vector.vec, int, int) Poly.t
-    -> bool:('c, bool, 'f) Snarky_backendless.Typ.t
+    -> bool:
+         ('c, bool, 'f, 'f Snarky_backendless.Cvar.t) Snarky_backendless.Typ.t
     -> ( ( 'a
          , 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t )
          In_circuit.t
        , 'b t
-       , 'f )
+       , 'f
+       , 'f Snarky_backendless.Cvar.t )
        Snarky_backendless.Typ.t
 end
 
@@ -280,15 +294,17 @@ module Openings : sig
          ( 'a
          , 'b
          , 'c
+         , 'field_var
          , (unit, 'c) Snarky_backendless.Checked_runner.Simple.t )
          Snarky_backendless.Types.Typ.typ
       -> ( 'd
          , 'e
          , 'c
+         , 'field_var
          , (unit, 'c) Snarky_backendless.Checked_runner.Simple.t )
          Snarky_backendless.Types.Typ.typ
       -> length:int
-      -> (('d, 'a) t, ('e, 'b) t, 'c) Snarky_backendless.Typ.t
+      -> (('d, 'a) t, ('e, 'b) t, 'c, 'field_var) Snarky_backendless.Typ.t
   end
 
   module Stable : sig
@@ -362,7 +378,7 @@ module All_evals : sig
   val map : ('a, 'b) t -> f1:('a -> 'c) -> f2:('b -> 'd) -> ('c, 'd) t
 
   val typ :
-       (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+       'f Snarky_backendless.Snark.m
     -> Opt.Flag.t Features.t
     -> ( ( 'f Snarky_backendless.Cvar.t
          , 'f Snarky_backendless.Cvar.t array
@@ -370,6 +386,7 @@ module All_evals : sig
          In_circuit.t
        , ('f, 'f array) t
        , 'f
+       , 'f Snarky_backendless.Cvar.t
        , (unit, 'f) Snarky_backendless.Checked_runner.Simple.t )
        Snarky_backendless.Types.Typ.typ
 end

--- a/src/lib/pickles_types/plonk_verification_key_evals.mli
+++ b/src/lib/pickles_types/plonk_verification_key_evals.mli
@@ -32,8 +32,8 @@ type 'comm t = 'comm Stable.Latest.t =
 [@@deriving sexp, equal, compare, hash, yojson, hlist]
 
 val typ :
-     ('a, 'b, 'c) Snarky_backendless.Typ.t
-  -> ('a t, 'b t, 'c) Snarky_backendless.Typ.t
+     ('a, 'b, 'c, 'd) Snarky_backendless.Typ.t
+  -> ('a t, 'b t, 'c, 'd) Snarky_backendless.Typ.t
 
 (** [map t ~f] applies [f] to all elements of type ['a] within record [t] and
     returns the result. In particular, [f] is applied to the elements of

--- a/src/lib/pickles_types/shifted_value.ml
+++ b/src/lib/pickles_types/shifted_value.ml
@@ -67,8 +67,8 @@ module type S = sig
   end]
 
   val typ :
-       ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'f) Snarky_backendless.Typ.t
+       ('a, 'b, 'f, 'field_var) Snarky_backendless.Typ.t
+    -> ('a t, 'b t, 'f, 'field_var) Snarky_backendless.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 

--- a/src/lib/pickles_types/shifted_value.mli
+++ b/src/lib/pickles_types/shifted_value.mli
@@ -33,8 +33,8 @@ module type S = sig
   type 'f t = 'f Stable.V1.t
 
   val typ :
-       ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'f) Snarky_backendless.Typ.t
+       ('a, 'b, 'f, 'field_var) Snarky_backendless.Typ.t
+    -> ('a t, 'b t, 'f, 'field_var) Snarky_backendless.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 
@@ -70,8 +70,8 @@ module Type1 : sig
   val equal : ('a, 'res) Sigs.rel2 -> ('a t, 'res) Sigs.rel2
 
   val typ :
-       ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'f) Snarky_backendless.Typ.t
+       ('a, 'b, 'f, 'field_var) Snarky_backendless.Typ.t
+    -> ('a t, 'b t, 'f, 'field_var) Snarky_backendless.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 
@@ -105,8 +105,8 @@ module Type2 : sig
   val equal : ('a, 'res) Sigs.rel2 -> ('a t, 'res) Sigs.rel2
 
   val typ :
-       ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> ('a t, 'b t, 'f) Snarky_backendless.Typ.t
+       ('a, 'b, 'f, 'field_var) Snarky_backendless.Typ.t
+    -> ('a t, 'b t, 'f, 'field_var) Snarky_backendless.Typ.t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 

--- a/src/lib/pickles_types/vector.ml
+++ b/src/lib/pickles_types/vector.ml
@@ -337,9 +337,9 @@ module With_length (N : Nat.Intf) = struct
 end
 
 let rec typ' :
-    type f var value n.
-       ((var, value, f) Snarky_backendless.Typ.t, n) t
-    -> ((var, n) t, (value, n) t, f) Snarky_backendless.Typ.t =
+    type f f_var var value n.
+       ((var, value, f, f_var) Snarky_backendless.Typ.t, n) t
+    -> ((var, n) t, (value, n) t, f, f_var) Snarky_backendless.Typ.t =
   let open Snarky_backendless.Typ in
   fun elts ->
     match elts with

--- a/src/lib/pickles_types/vector.mli
+++ b/src/lib/pickles_types/vector.mli
@@ -96,13 +96,13 @@ module With_length (N : Nat_intf) : S with type 'a t = ('a, N.n) vec
 (** {1 Functions} *)
 
 val typ :
-     ('a, 'b, 'c) Snarky_backendless.Typ.t
+     ('a, 'b, 'c, 'field_var) Snarky_backendless.Typ.t
   -> 'd Nat.nat
-  -> (('a, 'd) vec, ('b, 'd) vec, 'c) Snarky_backendless.Typ.t
+  -> (('a, 'd) vec, ('b, 'd) vec, 'c, 'field_var) Snarky_backendless.Typ.t
 
 val typ' :
-     (('var, 'value, 'f) Snarky_backendless.Typ.t, 'n) t
-  -> (('var, 'n) t, ('value, 'n) t, 'f) Snarky_backendless.Typ.t
+     (('var, 'value, 'f, 'field_var) Snarky_backendless.Typ.t, 'n) t
+  -> (('var, 'n) t, ('value, 'n) t, 'f, 'field_var) Snarky_backendless.Typ.t
 
 val of_list : 'a list -> 'a e
 

--- a/src/lib/snarky_group_map/checked_map.ml
+++ b/src/lib/snarky_group_map/checked_map.ml
@@ -55,7 +55,7 @@ let wrap (type f) ((module Impl) : f Snarky_backendless.Snark0.m) ~potential_xs
       , Field.((x1_is_first * y1) + (x2_is_first * y2) + (x3_is_first * y3)) ) )
 
 module Make
-    (M : Snarky_backendless.Snark_intf.Run) (P : sig
+    (M : Snarky_backendless.Snark_intf.Run_with_cvar) (P : sig
       val params : M.field Group_map.Params.t
     end) =
 struct

--- a/src/lib/snarky_group_map/checked_map.mli
+++ b/src/lib/snarky_group_map/checked_map.mli
@@ -8,7 +8,7 @@ val wrap :
   -> ('input -> 'f Cvar.t * 'f Cvar.t) Staged.t
 
 module Make
-    (M : Snarky_backendless.Snark_intf.Run) (Params : sig
+    (M : Snarky_backendless.Snark_intf.Run_with_cvar) (Params : sig
       val params : M.field Group_map.Params.t
     end) : sig
   val to_group : M.Field.t -> M.Field.t * M.Field.t

--- a/src/lib/snarky_group_map/snarky_group_map.ml
+++ b/src/lib/snarky_group_map/snarky_group_map.ml
@@ -29,8 +29,7 @@ module Checked = struct
 
   let wrap = Checked_map.wrap
 
-  let to_group (type f) (module M : Snark_intf.Run with type field = f) ~params
-      t =
+  let to_group (type f) ((module M) : f Snark.m) ~params t =
     let module G =
       Checked_map.Make
         (M)

--- a/src/lib/snarky_group_map/snarky_group_map.mli
+++ b/src/lib/snarky_group_map/snarky_group_map.mli
@@ -23,8 +23,5 @@ module Checked : sig
     -> ('input -> 'f Cvar.t * 'f Cvar.t) Core_kernel.Staged.t
 
   val to_group :
-       (module Snark_intf.Run with type field = 'f)
-    -> params:'f Params.t
-    -> 'f Cvar.t
-    -> 'f Cvar.t * 'f Cvar.t
+    'f Snark.m -> params:'f Params.t -> 'f Cvar.t -> 'f Cvar.t * 'f Cvar.t
 end


### PR DESCRIPTION
This is the counterpart of https://github.com/o1-labs/snarky/pull/791, generalizing `Typ.t` over `Cvar.t` on the snarky side.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them