### PR TITLE
Reflect recent toolchain changes in rust.nix

### DIFF
--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -9,7 +9,7 @@ let
     };
   toolchainHashes = {
     "1.67.0" = "sha256-riZUc+R9V35c/9e8KJUE+8pzpXyl0lRXt3ZkKlxoY0g=";
-    "nightly-2022-09-12" =
+    "nightly-2023-02-05" =
       "sha256-MM8fdvveBEWzpwjH7u6C0F7qSWGPIMpfZWLgVxSqtxY=";
     # copy this line with the correct toolchain name
     "placeholder" = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";


### PR DESCRIPTION
Caused by: https://github.com/MinaProtocol/mina/commit/503f6122415eda2e31ef5c95e46bd8a67e920c77