### PR TITLE
tokenOwner returns full account

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -10880,49 +10880,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "AccountId",
-          "description": null,
-          "fields": [
-            {
-              "name": "publicKey",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "PublicKey",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "tokenId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "TokenId",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "SCALAR",
           "name": "InetAddr",
           "description": "network address",
@@ -11713,7 +11670,7 @@
               "deprecationReason": null
             },
             {
-              "name": "token",
+              "name": "tokenId",
               "description": "The token associated with this account",
               "args": [],
               "type": {
@@ -11727,6 +11684,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "token",
+              "description": "The token associated with this account",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "TokenId",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use tokenId"
             },
             {
               "name": "timing",
@@ -13634,11 +13607,11 @@
             },
             {
               "name": "tokenOwner",
-              "description": "Find the account ID that owns a given token",
+              "description": "Find the account that owns a given token",
               "args": [
                 {
                   "name": "tokenId",
-                  "description": "Token ID to find the owner for",
+                  "description": "Token ID to find the owning account for",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -13651,11 +13624,7 @@
                   "defaultValue": null
                 }
               ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "AccountId",
-                "ofType": null
-              },
+              "type": { "kind": "OBJECT", "name": "Account", "ofType": null },
               "isDeprecated": false,
               "deprecationReason": null
             },

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -101,7 +101,7 @@ let get_tokens_graphql =
          in
          printf "Accounts are held for token IDs:\n" ;
          Array.iter response.accounts ~f:(fun account ->
-             printf "%s " (Token_id.to_string account.token) ) ) )
+             printf "%s " (Token_id.to_string account.tokenId) ) ) )
 
 let get_time_offset_graphql =
   Command.async

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -35,7 +35,7 @@ module Get_all_accounts =
 {|
 query ($public_key: PublicKey!) @encoders(module: "Encoders"){
   accounts(publicKey: $public_key) {
-    token
+    tokenId
   }
 }
 |}]


### PR DESCRIPTION
The `tokenOwner` query returns a full account, rather than just an account id. Add the field `tokenId` to accounts, so the result is compatible with existing queries. Deprecate the `token` field in accounts in favor of this new field.

This change makes it easy to find token symbols for custom tokens, as requested in #12425.