### PR TITLE
Move unmake_zkapp after zkApp URI is set

### DIFF
--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2562,7 +2562,7 @@ module For_tests = struct
   module Init_ledger = struct
     type t = (Keypair.t * int64) array [@@deriving sexp]
 
-    let init (type l) (module L : Ledger_intf.S with type t = l)
+    let init ?(zkapp = true) (type l) (module L : Ledger_intf.S with type t = l)
         (init_ledger : t) (l : L.t) =
       Array.iter init_ledger ~f:(fun (kp, amount) ->
           let _tag, account, loc =
@@ -2589,14 +2589,16 @@ module For_tests = struct
             }
           in
           let zkapp =
-            Some
-              { Zkapp_account.default with
-                verification_key =
-                  Some
-                    { With_hash.hash = Zkapp_basic.F.zero
-                    ; data = Side_loaded_verification_key.dummy
-                    }
-              }
+            if zkapp then
+              Some
+                { Zkapp_account.default with
+                  verification_key =
+                    Some
+                      { With_hash.hash = Zkapp_basic.F.zero
+                      ; data = Side_loaded_verification_key.dummy
+                      }
+                }
+            else None
           in
           L.set l loc
             { account with

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -1571,8 +1571,6 @@ module Make (Inputs : Inputs_intf) = struct
       in
       (a, local_state)
     in
-    (* Reset zkApp state to [None] if it is unmodified. *)
-    let a = Account.unmake_zkapp a in
     (* Update zkApp URI. *)
     let a, local_state =
       let zkapp_uri = Account_update.Update.zkapp_uri account_update in
@@ -1591,6 +1589,11 @@ module Make (Inputs : Inputs_intf) = struct
       let a = Account.set_zkapp_uri zkapp_uri a in
       (a, local_state)
     in
+    (* At this point, all possible changes have been made to the zkapp
+       part of an account. Reset zkApp state to [None] if that part
+       is unmodified.
+    *)
+    let a = Account.unmake_zkapp a in
     (* Update token symbol. *)
     let a, local_state =
       let token_symbol = Account_update.Update.token_symbol account_update in

--- a/src/lib/transaction_snark/test/app_state/app_state.ml
+++ b/src/lib/transaction_snark/test/app_state/app_state.ml
@@ -15,6 +15,8 @@ struct
         Vector.init Zkapp_state.Max_state_size.n ~f:(fun i ->
             Zkapp_basic.Set_or_keep.Set (Snark_params.Tick.Field.of_int i) )
     }
+
+  let is_non_zkapp_update = false
 end
 
 let%test_module "Update account app_state" =

--- a/src/lib/transaction_snark/test/delegate/delegate.ml
+++ b/src/lib/transaction_snark/test/delegate/delegate.ml
@@ -16,6 +16,8 @@ struct
     { Account_update.Update.dummy with
       delegate = Zkapp_basic.Set_or_keep.Set pk
     }
+
+  let is_non_zkapp_update = true
 end
 
 let%test_module "Update account delegate" =

--- a/src/lib/transaction_snark/test/dune
+++ b/src/lib/transaction_snark/test/dune
@@ -12,6 +12,7 @@
    core_kernel
    base64
    yojson
+   integers
    ;; local libraries
    random_oracle_input
    pickles.backend

--- a/src/lib/transaction_snark/test/fee_payer/dune
+++ b/src/lib/transaction_snark/test/fee_payer/dune
@@ -5,10 +5,13 @@
    ppx_inline_test.config
    async_unix
    async
+   async_kernel
    core
    base
    core_kernel
    yojson
+   sexplib0
+   integers
    ;; local libraries
    mina_base.import
    pickles

--- a/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
+++ b/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
@@ -16,184 +16,184 @@ let%test_module "Fee payer tests" =
     let constraint_constants = U.constraint_constants
 
     let snapp_update : Account_update.Update.t =
-        { Account_update.Update.dummy with
-          app_state =
-            Pickles_types.Vector.init Zkapp_state.Max_state_size.n ~f:(fun i ->
-                Zkapp_basic.Set_or_keep.Set (Pickles.Backend.Tick.Field.of_int i) )
-        }
+      { Account_update.Update.dummy with
+        app_state =
+          Pickles_types.Vector.init Zkapp_state.Max_state_size.n ~f:(fun i ->
+              Zkapp_basic.Set_or_keep.Set (Pickles.Backend.Tick.Field.of_int i) )
+      }
 
-      let%test_unit "update a snapp account with signature and fee paid by the \
-                     snapp account" =
-        Quickcheck.test ~trials:1 U.gen_snapp_ledger
-          ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-            let fee = Fee.of_nanomina_int_exn 1_000_000 in
-            let amount = Amount.of_mina_int_exn 10 in
-            let test_spec : Spec.t =
-              { sender = (new_kp, Mina_base.Account.Nonce.zero)
-              ; fee
-              ; fee_payer = None
-              ; receivers = []
-              ; amount
-              ; zkapp_account_keypairs = [ new_kp ]
-              ; memo
-              ; new_zkapp_account = false
-              ; snapp_update
-              ; current_auth = Permissions.Auth_required.Signature
-              ; call_data = Snark_params.Tick.Field.zero
-              ; events = []
-              ; actions = []
-              ; preconditions = None
-              }
-            in
-            U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
-              ~snapp_pk:(Public_key.compress new_kp.public_key) )
+    let%test_unit "update a snapp account with signature and fee paid by the \
+                   snapp account" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let test_spec : Spec.t =
+            { sender = (new_kp, Mina_base.Account.Nonce.zero)
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Signature
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-      let%test_unit "update a snapp account with signature and fee paid by a \
-                     non-snapp account" =
-        Quickcheck.test ~trials:1 U.gen_snapp_ledger
-          ~f:(fun ({ init_ledger; specs }, new_kp) ->
-            let fee = Fee.of_nanomina_int_exn 1_000_000 in
-            let amount = Amount.zero in
-            let spec = List.hd_exn specs in
-            let test_spec : Spec.t =
-              { sender = spec.sender
-              ; fee
-              ; fee_payer = None
-              ; receivers = []
-              ; amount
-              ; zkapp_account_keypairs = [ new_kp ]
-              ; memo
-              ; new_zkapp_account = false
-              ; snapp_update
-              ; current_auth = Permissions.Auth_required.Signature
-              ; call_data = Snark_params.Tick.Field.zero
-              ; events = []
-              ; actions = []
-              ; preconditions = None
-              }
-            in
-            U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
-              ~snapp_pk:(Public_key.compress new_kp.public_key) )
+    let%test_unit "update a snapp account with signature and fee paid by a \
+                   non-snapp account" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.zero in
+          let spec = List.hd_exn specs in
+          let test_spec : Spec.t =
+            { sender = spec.sender
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Signature
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-      let%test_unit "update a snapp account with proof and fee paid by the snapp \
-                     account" =
-        Quickcheck.test ~trials:1 U.gen_snapp_ledger
-          ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-            let fee = Fee.of_nanomina_int_exn 1_000_000 in
-            let amount = Amount.of_mina_int_exn 10 in
-            let test_spec : Spec.t =
-              { sender = (new_kp, Mina_base.Account.Nonce.zero)
-              ; fee
-              ; fee_payer = None
-              ; receivers = []
-              ; amount
-              ; zkapp_account_keypairs = [ new_kp ]
-              ; memo
-              ; new_zkapp_account = false
-              ; snapp_update
-              ; current_auth = Permissions.Auth_required.Proof
-              ; call_data = Snark_params.Tick.Field.zero
-              ; events = []
-              ; actions = []
-              ; preconditions = None
-              }
-            in
-            U.test_snapp_update
-              ~snapp_permissions:
-                (U.permissions_from_update snapp_update ~auth:Proof)
-              test_spec ~init_ledger ~vk ~zkapp_prover
-              ~snapp_pk:(Public_key.compress new_kp.public_key) )
+    let%test_unit "update a snapp account with proof and fee paid by the snapp \
+                   account" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let test_spec : Spec.t =
+            { sender = (new_kp, Mina_base.Account.Nonce.zero)
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Proof
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update
+            ~snapp_permissions:
+              (U.permissions_from_update snapp_update ~auth:Proof)
+            test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-      let%test_unit "update a snapp account with proof and fee paid by a \
-                     non-snapp account" =
-        Quickcheck.test ~trials:1 U.gen_snapp_ledger
-          ~f:(fun ({ init_ledger; specs }, new_kp) ->
-            let fee = Fee.of_nanomina_int_exn 1_000_000 in
-            let amount = Amount.of_mina_int_exn 10 in
-            let spec = List.hd_exn specs in
-            let test_spec : Spec.t =
-              { sender = spec.sender
-              ; fee
-              ; fee_payer = None
-              ; receivers = []
-              ; amount
-              ; zkapp_account_keypairs = [ new_kp ]
-              ; memo
-              ; new_zkapp_account = false
-              ; snapp_update
-              ; current_auth = Permissions.Auth_required.Proof
-              ; call_data = Snark_params.Tick.Field.zero
-              ; events = []
-              ; actions = []
-              ; preconditions = None
-              }
-            in
-            U.test_snapp_update
-              ~snapp_permissions:
-                (U.permissions_from_update snapp_update ~auth:Proof)
-              test_spec ~init_ledger ~vk ~zkapp_prover
-              ~snapp_pk:(Public_key.compress new_kp.public_key) )
+    let%test_unit "update a snapp account with proof and fee paid by a \
+                   non-snapp account" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let spec = List.hd_exn specs in
+          let test_spec : Spec.t =
+            { sender = spec.sender
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Proof
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update
+            ~snapp_permissions:
+              (U.permissions_from_update snapp_update ~auth:Proof)
+            test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-      let%test_unit "snapp transaction with non-existent fee payer account" =
-        let open Mina_transaction_logic.For_tests in
-        Quickcheck.test ~trials:1
-          Quickcheck.Generator.(tuple2 U.gen_snapp_ledger small_positive_int)
-          ~f:(fun (({ init_ledger; specs }, new_kp), global_slot) ->
-            Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
-                let spec = List.hd_exn specs in
-                let fee = Fee.of_nanomina_int_exn 1_000_000 in
-                let amount = Amount.of_mina_int_exn 10 in
-                (*making new_kp the fee-payer for this to fail*)
-                let test_spec : Transaction_snark.For_tests.Deploy_snapp_spec.t =
-                  { sender = (new_kp, Account.Nonce.zero)
-                  ; fee
-                  ; fee_payer = None
-                  ; amount
-                  ; zkapp_account_keypairs = [ fst spec.sender ]
-                  ; memo
-                  ; new_zkapp_account = true
-                  ; snapp_update
-                  ; preconditions = None
-                  ; authorization_kind = Signature
-                  }
-                in
-                let zkapp_command =
-                  Transaction_snark.For_tests.deploy_snapp test_spec
-                    ~constraint_constants
-                in
-                let txn_state_view =
-                  Mina_state.Protocol_state.Body.view U.genesis_state_body
-                in
-                let global_slot = Mina_numbers.Global_slot.of_int global_slot in
-                Init_ledger.init (module Ledger.Ledger_inner) init_ledger ledger ;
-                ( match
-                    let mask = Ledger.Mask.create ~depth:U.ledger_depth () in
-                    let ledger0 = Ledger.register_mask ledger mask in
-                    Ledger.apply_transactions ledger0 ~constraint_constants
-                      ~global_slot ~txn_state_view
-                      [ Transaction.Command (Zkapp_command zkapp_command) ]
-                  with
-                | Error _ ->
-                    (*TODO : match on exact error*) ()
-                | Ok _ ->
-                    failwith "Ledger.apply_transaction should have failed" ) ;
-                (*Sparse ledger application fails*)
-                match
-                  let sparse_ledger =
-                    Sparse_ledger.of_any_ledger
-                      (Ledger.Any_ledger.cast
-                         (module Ledger.Mask.Attached)
-                         ledger )
-                  in
-                  Sparse_ledger.apply_transaction_first_pass ~constraint_constants
-                    ~global_slot ~txn_state_view sparse_ledger
-                    (Mina_transaction.Transaction.Command
-                       (Zkapp_command zkapp_command) )
+    let%test_unit "snapp transaction with non-existent fee payer account" =
+      let open Mina_transaction_logic.For_tests in
+      Quickcheck.test ~trials:1
+        Quickcheck.Generator.(tuple2 U.gen_snapp_ledger small_positive_int)
+        ~f:(fun (({ init_ledger; specs }, new_kp), global_slot) ->
+          Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
+              let spec = List.hd_exn specs in
+              let fee = Fee.of_nanomina_int_exn 1_000_000 in
+              let amount = Amount.of_mina_int_exn 10 in
+              (*making new_kp the fee-payer for this to fail*)
+              let test_spec : Transaction_snark.For_tests.Deploy_snapp_spec.t =
+                { sender = (new_kp, Account.Nonce.zero)
+                ; fee
+                ; fee_payer = None
+                ; amount
+                ; zkapp_account_keypairs = [ fst spec.sender ]
+                ; memo
+                ; new_zkapp_account = true
+                ; snapp_update
+                ; preconditions = None
+                ; authorization_kind = Signature
+                }
+              in
+              let zkapp_command =
+                Transaction_snark.For_tests.deploy_snapp test_spec
+                  ~constraint_constants
+              in
+              let txn_state_view =
+                Mina_state.Protocol_state.Body.view U.genesis_state_body
+              in
+              let global_slot = Mina_numbers.Global_slot.of_int global_slot in
+              Init_ledger.init (module Ledger.Ledger_inner) init_ledger ledger ;
+              ( match
+                  let mask = Ledger.Mask.create ~depth:U.ledger_depth () in
+                  let ledger0 = Ledger.register_mask ledger mask in
+                  Ledger.apply_transactions ledger0 ~constraint_constants
+                    ~global_slot ~txn_state_view
+                    [ Transaction.Command (Zkapp_command zkapp_command) ]
                 with
-                | Ok _a ->
-                    failwith "Expected sparse ledger application to fail"
-                | Error _e ->
-                    () ) )
+              | Error _ ->
+                  (*TODO : match on exact error*) ()
+              | Ok _ ->
+                  failwith "Ledger.apply_transaction should have failed" ) ;
+              (*Sparse ledger application fails*)
+              match
+                let sparse_ledger =
+                  Sparse_ledger.of_any_ledger
+                    (Ledger.Any_ledger.cast
+                       (module Ledger.Mask.Attached)
+                       ledger )
+                in
+                Sparse_ledger.apply_transaction_first_pass ~constraint_constants
+                  ~global_slot ~txn_state_view sparse_ledger
+                  (Mina_transaction.Transaction.Command
+                     (Zkapp_command zkapp_command) )
+              with
+              | Ok _a ->
+                  failwith "Expected sparse ledger application to fail"
+              | Error _e ->
+                  () ) )
 
     let test_empty_update ?(new_account = true) test_spec init_ledger
         (zkapp_kp : Keypair.t) =

--- a/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
+++ b/src/lib/transaction_snark/test/fee_payer/fee_payer.ml
@@ -16,182 +16,262 @@ let%test_module "Fee payer tests" =
     let constraint_constants = U.constraint_constants
 
     let snapp_update : Account_update.Update.t =
-      { Account_update.Update.dummy with
-        app_state =
-          Pickles_types.Vector.init Zkapp_state.Max_state_size.n ~f:(fun i ->
-              Zkapp_basic.Set_or_keep.Set (Pickles.Backend.Tick.Field.of_int i) )
-      }
+        { Account_update.Update.dummy with
+          app_state =
+            Pickles_types.Vector.init Zkapp_state.Max_state_size.n ~f:(fun i ->
+                Zkapp_basic.Set_or_keep.Set (Pickles.Backend.Tick.Field.of_int i) )
+        }
 
-    let%test_unit "update a snapp account with signature and fee paid by the \
-                   snapp account" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let test_spec : Spec.t =
-            { sender = (new_kp, Mina_base.Account.Nonce.zero)
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Signature
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+      let%test_unit "update a snapp account with signature and fee paid by the \
+                     snapp account" =
+        Quickcheck.test ~trials:1 U.gen_snapp_ledger
+          ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
+            let fee = Fee.of_nanomina_int_exn 1_000_000 in
+            let amount = Amount.of_mina_int_exn 10 in
+            let test_spec : Spec.t =
+              { sender = (new_kp, Mina_base.Account.Nonce.zero)
+              ; fee
+              ; fee_payer = None
+              ; receivers = []
+              ; amount
+              ; zkapp_account_keypairs = [ new_kp ]
+              ; memo
+              ; new_zkapp_account = false
+              ; snapp_update
+              ; current_auth = Permissions.Auth_required.Signature
+              ; call_data = Snark_params.Tick.Field.zero
+              ; events = []
+              ; actions = []
+              ; preconditions = None
+              }
+            in
+            U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
+              ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with signature and fee paid by a \
-                   non-snapp account" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.zero in
-          let spec = List.hd_exn specs in
-          let test_spec : Spec.t =
-            { sender = spec.sender
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Signature
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+      let%test_unit "update a snapp account with signature and fee paid by a \
+                     non-snapp account" =
+        Quickcheck.test ~trials:1 U.gen_snapp_ledger
+          ~f:(fun ({ init_ledger; specs }, new_kp) ->
+            let fee = Fee.of_nanomina_int_exn 1_000_000 in
+            let amount = Amount.zero in
+            let spec = List.hd_exn specs in
+            let test_spec : Spec.t =
+              { sender = spec.sender
+              ; fee
+              ; fee_payer = None
+              ; receivers = []
+              ; amount
+              ; zkapp_account_keypairs = [ new_kp ]
+              ; memo
+              ; new_zkapp_account = false
+              ; snapp_update
+              ; current_auth = Permissions.Auth_required.Signature
+              ; call_data = Snark_params.Tick.Field.zero
+              ; events = []
+              ; actions = []
+              ; preconditions = None
+              }
+            in
+            U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
+              ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with proof and fee paid by the snapp \
-                   account" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let test_spec : Spec.t =
-            { sender = (new_kp, Mina_base.Account.Nonce.zero)
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Proof
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update
-            ~snapp_permissions:
-              (U.permissions_from_update snapp_update ~auth:Proof)
-            test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+      let%test_unit "update a snapp account with proof and fee paid by the snapp \
+                     account" =
+        Quickcheck.test ~trials:1 U.gen_snapp_ledger
+          ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
+            let fee = Fee.of_nanomina_int_exn 1_000_000 in
+            let amount = Amount.of_mina_int_exn 10 in
+            let test_spec : Spec.t =
+              { sender = (new_kp, Mina_base.Account.Nonce.zero)
+              ; fee
+              ; fee_payer = None
+              ; receivers = []
+              ; amount
+              ; zkapp_account_keypairs = [ new_kp ]
+              ; memo
+              ; new_zkapp_account = false
+              ; snapp_update
+              ; current_auth = Permissions.Auth_required.Proof
+              ; call_data = Snark_params.Tick.Field.zero
+              ; events = []
+              ; actions = []
+              ; preconditions = None
+              }
+            in
+            U.test_snapp_update
+              ~snapp_permissions:
+                (U.permissions_from_update snapp_update ~auth:Proof)
+              test_spec ~init_ledger ~vk ~zkapp_prover
+              ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with proof and fee paid by a \
-                   non-snapp account" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let spec = List.hd_exn specs in
-          let test_spec : Spec.t =
-            { sender = spec.sender
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Proof
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update
-            ~snapp_permissions:
-              (U.permissions_from_update snapp_update ~auth:Proof)
-            test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+      let%test_unit "update a snapp account with proof and fee paid by a \
+                     non-snapp account" =
+        Quickcheck.test ~trials:1 U.gen_snapp_ledger
+          ~f:(fun ({ init_ledger; specs }, new_kp) ->
+            let fee = Fee.of_nanomina_int_exn 1_000_000 in
+            let amount = Amount.of_mina_int_exn 10 in
+            let spec = List.hd_exn specs in
+            let test_spec : Spec.t =
+              { sender = spec.sender
+              ; fee
+              ; fee_payer = None
+              ; receivers = []
+              ; amount
+              ; zkapp_account_keypairs = [ new_kp ]
+              ; memo
+              ; new_zkapp_account = false
+              ; snapp_update
+              ; current_auth = Permissions.Auth_required.Proof
+              ; call_data = Snark_params.Tick.Field.zero
+              ; events = []
+              ; actions = []
+              ; preconditions = None
+              }
+            in
+            U.test_snapp_update
+              ~snapp_permissions:
+                (U.permissions_from_update snapp_update ~auth:Proof)
+              test_spec ~init_ledger ~vk ~zkapp_prover
+              ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "snapp transaction with non-existent fee payer account" =
-      let open Mina_transaction_logic.For_tests in
-      Quickcheck.test ~trials:1
-        Quickcheck.Generator.(tuple2 U.gen_snapp_ledger small_positive_int)
-        ~f:(fun (({ init_ledger; specs }, new_kp), global_slot) ->
-          Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
-              let spec = List.hd_exn specs in
-              let fee = Fee.of_nanomina_int_exn 1_000_000 in
-              let amount = Amount.of_mina_int_exn 10 in
-              (*making new_kp the fee-payer for this to fail*)
-              let test_spec : Transaction_snark.For_tests.Deploy_snapp_spec.t =
-                { sender = (new_kp, Account.Nonce.zero)
-                ; fee
-                ; fee_payer = None
-                ; amount
-                ; zkapp_account_keypairs = [ fst spec.sender ]
-                ; memo
-                ; new_zkapp_account = true
-                ; snapp_update
-                ; preconditions = None
-                ; authorization_kind = Signature
-                }
-              in
-              let zkapp_command =
-                Transaction_snark.For_tests.deploy_snapp test_spec
-                  ~constraint_constants
-              in
-              let txn_state_view =
-                Mina_state.Protocol_state.Body.view U.genesis_state_body
-              in
-              let global_slot = Mina_numbers.Global_slot.of_int global_slot in
-              Init_ledger.init (module Ledger.Ledger_inner) init_ledger ledger ;
-              ( match
-                  let mask = Ledger.Mask.create ~depth:U.ledger_depth () in
-                  let ledger0 = Ledger.register_mask ledger mask in
-                  Ledger.apply_transactions ledger0 ~constraint_constants
-                    ~global_slot ~txn_state_view
-                    [ Transaction.Command (Zkapp_command zkapp_command) ]
-                with
-              | Error _ ->
-                  (*TODO : match on exact error*) ()
-              | Ok _ ->
-                  failwith "Ledger.apply_transaction should have failed" ) ;
-              (*Sparse ledger application fails*)
-              match
-                let sparse_ledger =
-                  Sparse_ledger.of_any_ledger
-                    (Ledger.Any_ledger.cast
-                       (module Ledger.Mask.Attached)
-                       ledger )
+      let%test_unit "snapp transaction with non-existent fee payer account" =
+        let open Mina_transaction_logic.For_tests in
+        Quickcheck.test ~trials:1
+          Quickcheck.Generator.(tuple2 U.gen_snapp_ledger small_positive_int)
+          ~f:(fun (({ init_ledger; specs }, new_kp), global_slot) ->
+            Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
+                let spec = List.hd_exn specs in
+                let fee = Fee.of_nanomina_int_exn 1_000_000 in
+                let amount = Amount.of_mina_int_exn 10 in
+                (*making new_kp the fee-payer for this to fail*)
+                let test_spec : Transaction_snark.For_tests.Deploy_snapp_spec.t =
+                  { sender = (new_kp, Account.Nonce.zero)
+                  ; fee
+                  ; fee_payer = None
+                  ; amount
+                  ; zkapp_account_keypairs = [ fst spec.sender ]
+                  ; memo
+                  ; new_zkapp_account = true
+                  ; snapp_update
+                  ; preconditions = None
+                  ; authorization_kind = Signature
+                  }
                 in
-                Sparse_ledger.apply_transaction_first_pass ~constraint_constants
-                  ~global_slot ~txn_state_view sparse_ledger
-                  (Mina_transaction.Transaction.Command
-                     (Zkapp_command zkapp_command) )
-              with
-              | Ok _a ->
-                  failwith "Expected sparse ledger application to fail"
-              | Error _e ->
-                  () ) )
+                let zkapp_command =
+                  Transaction_snark.For_tests.deploy_snapp test_spec
+                    ~constraint_constants
+                in
+                let txn_state_view =
+                  Mina_state.Protocol_state.Body.view U.genesis_state_body
+                in
+                let global_slot = Mina_numbers.Global_slot.of_int global_slot in
+                Init_ledger.init (module Ledger.Ledger_inner) init_ledger ledger ;
+                ( match
+                    let mask = Ledger.Mask.create ~depth:U.ledger_depth () in
+                    let ledger0 = Ledger.register_mask ledger mask in
+                    Ledger.apply_transactions ledger0 ~constraint_constants
+                      ~global_slot ~txn_state_view
+                      [ Transaction.Command (Zkapp_command zkapp_command) ]
+                  with
+                | Error _ ->
+                    (*TODO : match on exact error*) ()
+                | Ok _ ->
+                    failwith "Ledger.apply_transaction should have failed" ) ;
+                (*Sparse ledger application fails*)
+                match
+                  let sparse_ledger =
+                    Sparse_ledger.of_any_ledger
+                      (Ledger.Any_ledger.cast
+                         (module Ledger.Mask.Attached)
+                         ledger )
+                  in
+                  Sparse_ledger.apply_transaction_first_pass ~constraint_constants
+                    ~global_slot ~txn_state_view sparse_ledger
+                    (Mina_transaction.Transaction.Command
+                       (Zkapp_command zkapp_command) )
+                with
+                | Ok _a ->
+                    failwith "Expected sparse ledger application to fail"
+                | Error _e ->
+                    () ) )
+
+    let test_empty_update ?(new_account = true) test_spec init_ledger
+        (zkapp_kp : Keypair.t) =
+      let open Mina_transaction_logic.For_tests in
+      let get_account ledger id =
+        let location =
+          Option.value_exn (Ledger.location_of_account ledger id)
+        in
+        Option.value_exn (Ledger.get ledger location)
+      in
+      Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
+          Async.Thread_safe.block_on_async_exn (fun () ->
+              let open Async.Deferred.Let_syntax in
+              (*Create non-zkapp accounts*)
+              Init_ledger.init ~zkapp:false
+                (module Ledger.Ledger_inner)
+                init_ledger ledger ;
+              let zkapp_acc_id =
+                Account_id.create
+                  (Public_key.compress zkapp_kp.public_key)
+                  Token_id.default
+              in
+              let%bind zkapp_command =
+                let zkapp_prover_and_vk = (zkapp_prover, vk) in
+                Transaction_snark.For_tests.update_states ~zkapp_prover_and_vk
+                  ~constraint_constants test_spec
+              in
+              ( if new_account then
+                ignore
+                  ( Option.value_map
+                      ~f:(fun location ->
+                        Some (Option.value_exn (Ledger.get ledger location)) )
+                      ~default:None
+                      (Ledger.location_of_account ledger zkapp_acc_id)
+                    : Account.t option )
+              else
+                let account = get_account ledger zkapp_acc_id in
+                assert (Option.is_none account.zkapp) ) ;
+              let%map () =
+                U.check_zkapp_command_with_merges_exn ledger [ zkapp_command ]
+              in
+
+              let account = get_account ledger zkapp_acc_id in
+              assert (Option.is_none account.zkapp) ) )
+
+    let%test_unit "unchanged zkapp field when zkapp update is noop" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount =
+            Amount.of_fee U.constraint_constants.account_creation_fee
+          in
+          let spec = List.hd_exn specs in
+          let new_account_spec : Spec.t =
+            { sender = spec.sender
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = true
+            ; snapp_update = Account_update.Update.dummy
+            ; current_auth = Permissions.Auth_required.Signature
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          test_empty_update new_account_spec init_ledger new_kp ;
+          let existing_account_spec =
+            { new_account_spec with
+              amount = Amount.zero
+            ; zkapp_account_keypairs = [ fst spec.sender ]
+            ; new_zkapp_account = false
+            }
+          in
+          test_empty_update ~new_account:false existing_account_spec init_ledger
+            (fst spec.sender) )
   end )

--- a/src/lib/transaction_snark/test/permissions/permissions.ml
+++ b/src/lib/transaction_snark/test/permissions/permissions.ml
@@ -19,6 +19,8 @@ struct
           ; set_voting_for = Proof
           }
     }
+
+  let is_non_zkapp_update = true
 end
 
 let%test_module "Update account permissions" =

--- a/src/lib/transaction_snark/test/test_zkapp_update.ml
+++ b/src/lib/transaction_snark/test/test_zkapp_update.ml
@@ -13,6 +13,8 @@ module type Input_intf = sig
   val test_description : string
 
   val failure_expected : Mina_base.Transaction_status.Failure.t * U.pass_number
+
+  val is_non_zkapp_update : bool
 end
 
 module Make (Input : Input_intf) = struct
@@ -23,63 +25,320 @@ module Make (Input : Input_intf) = struct
   let memo = Signed_command_memo.create_from_string_exn test_description
 
   let%test_unit "update a snapp account with signature" =
-    Quickcheck.test ~trials:1 U.gen_snapp_ledger
-      ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-        let fee = Fee.of_nanomina_int_exn 1_000_000 in
-        let amount = Amount.of_mina_int_exn 10 in
-        let test_spec : Spec.t =
-          { sender = (new_kp, Mina_base.Account.Nonce.zero)
-          ; fee
-          ; fee_payer = None
-          ; receivers = []
-          ; amount
-          ; zkapp_account_keypairs = [ new_kp ]
-          ; memo
-          ; new_zkapp_account = false
-          ; snapp_update
-          ; current_auth = Permissions.Auth_required.Signature
-          ; call_data = Snark_params.Tick.Field.zero
-          ; events = []
-          ; actions = []
-          ; preconditions = None
-          }
-        in
-        U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
-          ~snapp_pk:(Public_key.compress new_kp.public_key) )
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let test_spec : Spec.t =
+            { sender = (new_kp, Mina_base.Account.Nonce.zero)
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Signature
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-  let%test_unit "update a snapp account with proof" =
-    Quickcheck.test ~trials:1 U.gen_snapp_ledger
-      ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-        let fee = Fee.of_nanomina_int_exn 1_000_000 in
-        let amount = Amount.of_mina_int_exn 10 in
-        let test_spec : Spec.t =
-          { sender = (new_kp, Mina_base.Account.Nonce.zero)
-          ; fee
-          ; fee_payer = None
-          ; receivers = []
-          ; amount
-          ; zkapp_account_keypairs = [ new_kp ]
-          ; memo
-          ; new_zkapp_account = false
-          ; snapp_update
-          ; current_auth = Permissions.Auth_required.Proof
-          ; call_data = Snark_params.Tick.Field.zero
-          ; events = []
-          ; actions = []
-          ; preconditions = None
-          }
-        in
-        U.test_snapp_update
-          ~snapp_permissions:
-            (U.permissions_from_update snapp_update ~auth:Proof)
-          test_spec ~init_ledger ~vk ~zkapp_prover
-          ~snapp_pk:(Public_key.compress new_kp.public_key) )
+    let%test_unit "update a snapp account with proof" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let test_spec : Spec.t =
+            { sender = (new_kp, Mina_base.Account.Nonce.zero)
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Proof
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update
+            ~snapp_permissions:
+              (U.permissions_from_update snapp_update ~auth:Proof)
+            test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-  let%test_unit "update a snapp account with None permission" =
+    let%test_unit "update a snapp account with None permission" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let spec = List.hd_exn specs in
+          let test_spec : Spec.t =
+            { sender = spec.sender
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.None
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update
+            ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
+            test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+
+    let%test_unit "update a snapp account with None permission and Signature auth"
+        =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let spec = List.hd_exn specs in
+          let test_spec : Spec.t =
+            { sender = spec.sender
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Signature
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update
+            ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
+            test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+
+    let%test_unit "update a snapp account with None permission and Proof auth" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let spec = List.hd_exn specs in
+          let test_spec : Spec.t =
+            { sender = spec.sender
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Proof
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update
+            ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
+            test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+
+    let%test_unit "update a snapp account with Either permission and Signature \
+                   auth" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let spec = List.hd_exn specs in
+          let test_spec : Spec.t =
+            { sender = spec.sender
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Signature
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update
+            ~snapp_permissions:
+              (U.permissions_from_update snapp_update ~auth:Either)
+            test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+
+    let%test_unit "update a snapp account with Either permission and Proof auth" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let spec = List.hd_exn specs in
+          let test_spec : Spec.t =
+            { sender = spec.sender
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.Proof
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update
+            ~snapp_permissions:
+              (U.permissions_from_update snapp_update ~auth:Either)
+            test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+
+    let%test_unit "update a snapp account with Either permission and None auth" =
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          let fee = Fee.of_nanomina_int_exn 1_000_000 in
+          let amount = Amount.of_mina_int_exn 10 in
+          let spec = List.hd_exn specs in
+          let test_spec : Spec.t =
+            { sender = spec.sender
+            ; fee
+            ; fee_payer = None
+            ; receivers = []
+            ; amount
+            ; zkapp_account_keypairs = [ new_kp ]
+            ; memo
+            ; new_zkapp_account = false
+            ; snapp_update
+            ; current_auth = Permissions.Auth_required.None
+            ; call_data = Snark_params.Tick.Field.zero
+            ; events = []
+            ; actions = []
+            ; preconditions = None
+            }
+          in
+          U.test_snapp_update ~expected_failure:failure_expected
+            ~snapp_permissions:
+              (U.permissions_from_update snapp_update ~auth:Either)
+            test_spec ~init_ledger ~vk ~zkapp_prover
+            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+
+    let%test_unit "Update when not permitted but transaction is applied" =
+      let open Mina_transaction_logic.For_tests in
+      Quickcheck.test ~trials:1 U.gen_snapp_ledger
+        ~f:(fun ({ init_ledger; specs }, new_kp) ->
+          Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
+              let spec = List.hd_exn specs in
+              let fee = Fee.of_nanomina_int_exn 1_000_000 in
+              let amount = Amount.of_mina_int_exn 10 in
+              let test_spec : Spec.t =
+                { sender = spec.sender
+                ; fee
+                ; fee_payer = None
+                ; receivers = []
+                ; amount
+                ; zkapp_account_keypairs = [ new_kp ]
+                ; memo
+                ; new_zkapp_account = false
+                ; snapp_update
+                ; current_auth = Permissions.Auth_required.Signature
+                ; call_data = Snark_params.Tick.Field.zero
+                ; events = []
+                ; actions = []
+                ; preconditions = None
+                }
+              in
+              let snapp_pk = Public_key.compress new_kp.public_key in
+              Init_ledger.init (module Ledger.Ledger_inner) init_ledger ledger ;
+              (*Create snapp transaction*)
+              Transaction_snark.For_tests.create_trivial_zkapp_account
+                ~permissions:(U.permissions_from_update snapp_update ~auth:Proof)
+                ~vk ~ledger snapp_pk ;
+              (*Ledger.apply_transaction should be successful if fee payer update
+                is successful*)
+              U.test_snapp_update ~expected_failure:failure_expected
+                ~snapp_permissions:
+                  (U.permissions_from_update snapp_update ~auth:Proof)
+                ~vk ~zkapp_prover test_spec ~init_ledger ~snapp_pk ) )
+
+  let test_non_zkapp_to_zkapp ?(new_account = true) test_spec init_ledger
+      (zkapp_kp : Keypair.t) =
+    let open Mina_transaction_logic.For_tests in
+    let get_account ledger id =
+      let location = Option.value_exn (Ledger.location_of_account ledger id) in
+      Option.value_exn (Ledger.get ledger location)
+    in
+    Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
+        Async.Thread_safe.block_on_async_exn (fun () ->
+            let open Async.Deferred.Let_syntax in
+            (*Create non-zkapp accounts*)
+            Init_ledger.init ~zkapp:false
+              (module Ledger.Ledger_inner)
+              init_ledger ledger ;
+            let zkapp_acc_id =
+              Account_id.create
+                (Public_key.compress zkapp_kp.public_key)
+                Token_id.default
+            in
+            let%bind zkapp_command =
+              let zkapp_prover_and_vk = (zkapp_prover, vk) in
+              Transaction_snark.For_tests.update_states ~zkapp_prover_and_vk
+                ~constraint_constants:U.constraint_constants test_spec
+            in
+            ( if new_account then
+              ignore
+                ( Option.value_map
+                    ~f:(fun location ->
+                      Some (Option.value_exn (Ledger.get ledger location)) )
+                    ~default:None
+                    (Ledger.location_of_account ledger zkapp_acc_id)
+                  : Account.t option )
+            else
+              let account = get_account ledger zkapp_acc_id in
+              assert (Option.is_none account.zkapp) ) ;
+            let%map () =
+              U.check_zkapp_command_with_merges_exn ledger [ zkapp_command ]
+            in
+            let account = get_account ledger zkapp_acc_id in
+            if is_non_zkapp_update then
+              (*zkapp field should be not be set*)
+              assert (Option.is_none account.zkapp)
+            else assert (Option.is_some account.zkapp) ) )
+
+  let%test_unit "update a new non-zkapp account specified update" =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
       ~f:(fun ({ init_ledger; specs }, new_kp) ->
         let fee = Fee.of_nanomina_int_exn 1_000_000 in
-        let amount = Amount.of_mina_int_exn 10 in
+        let amount =
+          Amount.of_fee U.constraint_constants.account_creation_fee
+        in
         let spec = List.hd_exn specs in
         let test_spec : Spec.t =
           { sender = spec.sender
@@ -89,26 +348,23 @@ module Make (Input : Input_intf) = struct
           ; amount
           ; zkapp_account_keypairs = [ new_kp ]
           ; memo
-          ; new_zkapp_account = false
+          ; new_zkapp_account = true
           ; snapp_update
-          ; current_auth = Permissions.Auth_required.None
+          ; current_auth = Permissions.Auth_required.Signature
           ; call_data = Snark_params.Tick.Field.zero
           ; events = []
           ; actions = []
           ; preconditions = None
           }
         in
-        U.test_snapp_update
-          ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
-          test_spec ~init_ledger ~vk ~zkapp_prover
-          ~snapp_pk:(Public_key.compress new_kp.public_key) )
+        test_non_zkapp_to_zkapp test_spec init_ledger new_kp )
 
-  let%test_unit "update a snapp account with None permission and Signature auth"
+  let%test_unit "Update an existing non-zkapp account with the specified update"
       =
     Quickcheck.test ~trials:1 U.gen_snapp_ledger
-      ~f:(fun ({ init_ledger; specs }, new_kp) ->
+      ~f:(fun ({ init_ledger; specs }, _new_kp) ->
         let fee = Fee.of_nanomina_int_exn 1_000_000 in
-        let amount = Amount.of_mina_int_exn 10 in
+        let amount = Amount.zero in
         let spec = List.hd_exn specs in
         let test_spec : Spec.t =
           { sender = spec.sender
@@ -116,7 +372,7 @@ module Make (Input : Input_intf) = struct
           ; fee_payer = None
           ; receivers = []
           ; amount
-          ; zkapp_account_keypairs = [ new_kp ]
+          ; zkapp_account_keypairs = [ fst spec.sender ]
           ; memo
           ; new_zkapp_account = false
           ; snapp_update
@@ -127,162 +383,6 @@ module Make (Input : Input_intf) = struct
           ; preconditions = None
           }
         in
-        U.test_snapp_update
-          ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
-          test_spec ~init_ledger ~vk ~zkapp_prover
-          ~snapp_pk:(Public_key.compress new_kp.public_key) )
-
-  let%test_unit "update a snapp account with None permission and Proof auth" =
-    Quickcheck.test ~trials:1 U.gen_snapp_ledger
-      ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_nanomina_int_exn 1_000_000 in
-        let amount = Amount.of_mina_int_exn 10 in
-        let spec = List.hd_exn specs in
-        let test_spec : Spec.t =
-          { sender = spec.sender
-          ; fee
-          ; fee_payer = None
-          ; receivers = []
-          ; amount
-          ; zkapp_account_keypairs = [ new_kp ]
-          ; memo
-          ; new_zkapp_account = false
-          ; snapp_update
-          ; current_auth = Permissions.Auth_required.Proof
-          ; call_data = Snark_params.Tick.Field.zero
-          ; events = []
-          ; actions = []
-          ; preconditions = None
-          }
-        in
-        U.test_snapp_update
-          ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
-          test_spec ~init_ledger ~vk ~zkapp_prover
-          ~snapp_pk:(Public_key.compress new_kp.public_key) )
-
-  let%test_unit "update a snapp account with Either permission and Signature \
-                 auth" =
-    Quickcheck.test ~trials:1 U.gen_snapp_ledger
-      ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_nanomina_int_exn 1_000_000 in
-        let amount = Amount.of_mina_int_exn 10 in
-        let spec = List.hd_exn specs in
-        let test_spec : Spec.t =
-          { sender = spec.sender
-          ; fee
-          ; fee_payer = None
-          ; receivers = []
-          ; amount
-          ; zkapp_account_keypairs = [ new_kp ]
-          ; memo
-          ; new_zkapp_account = false
-          ; snapp_update
-          ; current_auth = Permissions.Auth_required.Signature
-          ; call_data = Snark_params.Tick.Field.zero
-          ; events = []
-          ; actions = []
-          ; preconditions = None
-          }
-        in
-        U.test_snapp_update
-          ~snapp_permissions:
-            (U.permissions_from_update snapp_update ~auth:Either)
-          test_spec ~init_ledger ~vk ~zkapp_prover
-          ~snapp_pk:(Public_key.compress new_kp.public_key) )
-
-  let%test_unit "update a snapp account with Either permission and Proof auth" =
-    Quickcheck.test ~trials:1 U.gen_snapp_ledger
-      ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_nanomina_int_exn 1_000_000 in
-        let amount = Amount.of_mina_int_exn 10 in
-        let spec = List.hd_exn specs in
-        let test_spec : Spec.t =
-          { sender = spec.sender
-          ; fee
-          ; fee_payer = None
-          ; receivers = []
-          ; amount
-          ; zkapp_account_keypairs = [ new_kp ]
-          ; memo
-          ; new_zkapp_account = false
-          ; snapp_update
-          ; current_auth = Permissions.Auth_required.Proof
-          ; call_data = Snark_params.Tick.Field.zero
-          ; events = []
-          ; actions = []
-          ; preconditions = None
-          }
-        in
-        U.test_snapp_update
-          ~snapp_permissions:
-            (U.permissions_from_update snapp_update ~auth:Either)
-          test_spec ~init_ledger ~vk ~zkapp_prover
-          ~snapp_pk:(Public_key.compress new_kp.public_key) )
-
-  let%test_unit "update a snapp account with Either permission and None auth" =
-    Quickcheck.test ~trials:1 U.gen_snapp_ledger
-      ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        let fee = Fee.of_nanomina_int_exn 1_000_000 in
-        let amount = Amount.of_mina_int_exn 10 in
-        let spec = List.hd_exn specs in
-        let test_spec : Spec.t =
-          { sender = spec.sender
-          ; fee
-          ; fee_payer = None
-          ; receivers = []
-          ; amount
-          ; zkapp_account_keypairs = [ new_kp ]
-          ; memo
-          ; new_zkapp_account = false
-          ; snapp_update
-          ; current_auth = Permissions.Auth_required.None
-          ; call_data = Snark_params.Tick.Field.zero
-          ; events = []
-          ; actions = []
-          ; preconditions = None
-          }
-        in
-        U.test_snapp_update ~expected_failure:failure_expected
-          ~snapp_permissions:
-            (U.permissions_from_update snapp_update ~auth:Either)
-          test_spec ~init_ledger ~vk ~zkapp_prover
-          ~snapp_pk:(Public_key.compress new_kp.public_key) )
-
-  let%test_unit "Update when not permitted but transaction is applied" =
-    let open Mina_transaction_logic.For_tests in
-    Quickcheck.test ~trials:1 U.gen_snapp_ledger
-      ~f:(fun ({ init_ledger; specs }, new_kp) ->
-        Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
-            let spec = List.hd_exn specs in
-            let fee = Fee.of_nanomina_int_exn 1_000_000 in
-            let amount = Amount.of_mina_int_exn 10 in
-            let test_spec : Spec.t =
-              { sender = spec.sender
-              ; fee
-              ; fee_payer = None
-              ; receivers = []
-              ; amount
-              ; zkapp_account_keypairs = [ new_kp ]
-              ; memo
-              ; new_zkapp_account = false
-              ; snapp_update
-              ; current_auth = Permissions.Auth_required.Signature
-              ; call_data = Snark_params.Tick.Field.zero
-              ; events = []
-              ; actions = []
-              ; preconditions = None
-              }
-            in
-            let snapp_pk = Public_key.compress new_kp.public_key in
-            Init_ledger.init (module Ledger.Ledger_inner) init_ledger ledger ;
-            (*Create snapp transaction*)
-            Transaction_snark.For_tests.create_trivial_zkapp_account
-              ~permissions:(U.permissions_from_update snapp_update ~auth:Proof)
-              ~vk ~ledger snapp_pk ;
-            (*Ledger.apply_transaction should be successful if fee payer update
-              is successful*)
-            U.test_snapp_update ~expected_failure:failure_expected
-              ~snapp_permissions:
-                (U.permissions_from_update snapp_update ~auth:Proof)
-              ~vk ~zkapp_prover test_spec ~init_ledger ~snapp_pk ) )
+        test_non_zkapp_to_zkapp ~new_account:false test_spec init_ledger
+          (fst spec.sender) )
 end

--- a/src/lib/transaction_snark/test/test_zkapp_update.ml
+++ b/src/lib/transaction_snark/test/test_zkapp_update.ml
@@ -25,268 +25,268 @@ module Make (Input : Input_intf) = struct
   let memo = Signed_command_memo.create_from_string_exn test_description
 
   let%test_unit "update a snapp account with signature" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let test_spec : Spec.t =
-            { sender = (new_kp, Mina_base.Account.Nonce.zero)
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Signature
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+    Quickcheck.test ~trials:1 U.gen_snapp_ledger
+      ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
+        let fee = Fee.of_nanomina_int_exn 1_000_000 in
+        let amount = Amount.of_mina_int_exn 10 in
+        let test_spec : Spec.t =
+          { sender = (new_kp, Mina_base.Account.Nonce.zero)
+          ; fee
+          ; fee_payer = None
+          ; receivers = []
+          ; amount
+          ; zkapp_account_keypairs = [ new_kp ]
+          ; memo
+          ; new_zkapp_account = false
+          ; snapp_update
+          ; current_auth = Permissions.Auth_required.Signature
+          ; call_data = Snark_params.Tick.Field.zero
+          ; events = []
+          ; actions = []
+          ; preconditions = None
+          }
+        in
+        U.test_snapp_update test_spec ~init_ledger ~vk ~zkapp_prover
+          ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with proof" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let test_spec : Spec.t =
-            { sender = (new_kp, Mina_base.Account.Nonce.zero)
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Proof
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update
-            ~snapp_permissions:
-              (U.permissions_from_update snapp_update ~auth:Proof)
-            test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+  let%test_unit "update a snapp account with proof" =
+    Quickcheck.test ~trials:1 U.gen_snapp_ledger
+      ~f:(fun ({ init_ledger; specs = _ }, new_kp) ->
+        let fee = Fee.of_nanomina_int_exn 1_000_000 in
+        let amount = Amount.of_mina_int_exn 10 in
+        let test_spec : Spec.t =
+          { sender = (new_kp, Mina_base.Account.Nonce.zero)
+          ; fee
+          ; fee_payer = None
+          ; receivers = []
+          ; amount
+          ; zkapp_account_keypairs = [ new_kp ]
+          ; memo
+          ; new_zkapp_account = false
+          ; snapp_update
+          ; current_auth = Permissions.Auth_required.Proof
+          ; call_data = Snark_params.Tick.Field.zero
+          ; events = []
+          ; actions = []
+          ; preconditions = None
+          }
+        in
+        U.test_snapp_update
+          ~snapp_permissions:
+            (U.permissions_from_update snapp_update ~auth:Proof)
+          test_spec ~init_ledger ~vk ~zkapp_prover
+          ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with None permission" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let spec = List.hd_exn specs in
-          let test_spec : Spec.t =
-            { sender = spec.sender
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.None
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update
-            ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
-            test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+  let%test_unit "update a snapp account with None permission" =
+    Quickcheck.test ~trials:1 U.gen_snapp_ledger
+      ~f:(fun ({ init_ledger; specs }, new_kp) ->
+        let fee = Fee.of_nanomina_int_exn 1_000_000 in
+        let amount = Amount.of_mina_int_exn 10 in
+        let spec = List.hd_exn specs in
+        let test_spec : Spec.t =
+          { sender = spec.sender
+          ; fee
+          ; fee_payer = None
+          ; receivers = []
+          ; amount
+          ; zkapp_account_keypairs = [ new_kp ]
+          ; memo
+          ; new_zkapp_account = false
+          ; snapp_update
+          ; current_auth = Permissions.Auth_required.None
+          ; call_data = Snark_params.Tick.Field.zero
+          ; events = []
+          ; actions = []
+          ; preconditions = None
+          }
+        in
+        U.test_snapp_update
+          ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
+          test_spec ~init_ledger ~vk ~zkapp_prover
+          ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with None permission and Signature auth"
-        =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let spec = List.hd_exn specs in
-          let test_spec : Spec.t =
-            { sender = spec.sender
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Signature
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update
-            ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
-            test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+  let%test_unit "update a snapp account with None permission and Signature auth"
+      =
+    Quickcheck.test ~trials:1 U.gen_snapp_ledger
+      ~f:(fun ({ init_ledger; specs }, new_kp) ->
+        let fee = Fee.of_nanomina_int_exn 1_000_000 in
+        let amount = Amount.of_mina_int_exn 10 in
+        let spec = List.hd_exn specs in
+        let test_spec : Spec.t =
+          { sender = spec.sender
+          ; fee
+          ; fee_payer = None
+          ; receivers = []
+          ; amount
+          ; zkapp_account_keypairs = [ new_kp ]
+          ; memo
+          ; new_zkapp_account = false
+          ; snapp_update
+          ; current_auth = Permissions.Auth_required.Signature
+          ; call_data = Snark_params.Tick.Field.zero
+          ; events = []
+          ; actions = []
+          ; preconditions = None
+          }
+        in
+        U.test_snapp_update
+          ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
+          test_spec ~init_ledger ~vk ~zkapp_prover
+          ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with None permission and Proof auth" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let spec = List.hd_exn specs in
-          let test_spec : Spec.t =
-            { sender = spec.sender
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Proof
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update
-            ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
-            test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+  let%test_unit "update a snapp account with None permission and Proof auth" =
+    Quickcheck.test ~trials:1 U.gen_snapp_ledger
+      ~f:(fun ({ init_ledger; specs }, new_kp) ->
+        let fee = Fee.of_nanomina_int_exn 1_000_000 in
+        let amount = Amount.of_mina_int_exn 10 in
+        let spec = List.hd_exn specs in
+        let test_spec : Spec.t =
+          { sender = spec.sender
+          ; fee
+          ; fee_payer = None
+          ; receivers = []
+          ; amount
+          ; zkapp_account_keypairs = [ new_kp ]
+          ; memo
+          ; new_zkapp_account = false
+          ; snapp_update
+          ; current_auth = Permissions.Auth_required.Proof
+          ; call_data = Snark_params.Tick.Field.zero
+          ; events = []
+          ; actions = []
+          ; preconditions = None
+          }
+        in
+        U.test_snapp_update
+          ~snapp_permissions:(U.permissions_from_update snapp_update ~auth:None)
+          test_spec ~init_ledger ~vk ~zkapp_prover
+          ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with Either permission and Signature \
-                   auth" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let spec = List.hd_exn specs in
-          let test_spec : Spec.t =
-            { sender = spec.sender
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Signature
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update
-            ~snapp_permissions:
-              (U.permissions_from_update snapp_update ~auth:Either)
-            test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+  let%test_unit "update a snapp account with Either permission and Signature \
+                 auth" =
+    Quickcheck.test ~trials:1 U.gen_snapp_ledger
+      ~f:(fun ({ init_ledger; specs }, new_kp) ->
+        let fee = Fee.of_nanomina_int_exn 1_000_000 in
+        let amount = Amount.of_mina_int_exn 10 in
+        let spec = List.hd_exn specs in
+        let test_spec : Spec.t =
+          { sender = spec.sender
+          ; fee
+          ; fee_payer = None
+          ; receivers = []
+          ; amount
+          ; zkapp_account_keypairs = [ new_kp ]
+          ; memo
+          ; new_zkapp_account = false
+          ; snapp_update
+          ; current_auth = Permissions.Auth_required.Signature
+          ; call_data = Snark_params.Tick.Field.zero
+          ; events = []
+          ; actions = []
+          ; preconditions = None
+          }
+        in
+        U.test_snapp_update
+          ~snapp_permissions:
+            (U.permissions_from_update snapp_update ~auth:Either)
+          test_spec ~init_ledger ~vk ~zkapp_prover
+          ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with Either permission and Proof auth" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let spec = List.hd_exn specs in
-          let test_spec : Spec.t =
-            { sender = spec.sender
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.Proof
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update
-            ~snapp_permissions:
-              (U.permissions_from_update snapp_update ~auth:Either)
-            test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+  let%test_unit "update a snapp account with Either permission and Proof auth" =
+    Quickcheck.test ~trials:1 U.gen_snapp_ledger
+      ~f:(fun ({ init_ledger; specs }, new_kp) ->
+        let fee = Fee.of_nanomina_int_exn 1_000_000 in
+        let amount = Amount.of_mina_int_exn 10 in
+        let spec = List.hd_exn specs in
+        let test_spec : Spec.t =
+          { sender = spec.sender
+          ; fee
+          ; fee_payer = None
+          ; receivers = []
+          ; amount
+          ; zkapp_account_keypairs = [ new_kp ]
+          ; memo
+          ; new_zkapp_account = false
+          ; snapp_update
+          ; current_auth = Permissions.Auth_required.Proof
+          ; call_data = Snark_params.Tick.Field.zero
+          ; events = []
+          ; actions = []
+          ; preconditions = None
+          }
+        in
+        U.test_snapp_update
+          ~snapp_permissions:
+            (U.permissions_from_update snapp_update ~auth:Either)
+          test_spec ~init_ledger ~vk ~zkapp_prover
+          ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "update a snapp account with Either permission and None auth" =
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          let fee = Fee.of_nanomina_int_exn 1_000_000 in
-          let amount = Amount.of_mina_int_exn 10 in
-          let spec = List.hd_exn specs in
-          let test_spec : Spec.t =
-            { sender = spec.sender
-            ; fee
-            ; fee_payer = None
-            ; receivers = []
-            ; amount
-            ; zkapp_account_keypairs = [ new_kp ]
-            ; memo
-            ; new_zkapp_account = false
-            ; snapp_update
-            ; current_auth = Permissions.Auth_required.None
-            ; call_data = Snark_params.Tick.Field.zero
-            ; events = []
-            ; actions = []
-            ; preconditions = None
-            }
-          in
-          U.test_snapp_update ~expected_failure:failure_expected
-            ~snapp_permissions:
-              (U.permissions_from_update snapp_update ~auth:Either)
-            test_spec ~init_ledger ~vk ~zkapp_prover
-            ~snapp_pk:(Public_key.compress new_kp.public_key) )
+  let%test_unit "update a snapp account with Either permission and None auth" =
+    Quickcheck.test ~trials:1 U.gen_snapp_ledger
+      ~f:(fun ({ init_ledger; specs }, new_kp) ->
+        let fee = Fee.of_nanomina_int_exn 1_000_000 in
+        let amount = Amount.of_mina_int_exn 10 in
+        let spec = List.hd_exn specs in
+        let test_spec : Spec.t =
+          { sender = spec.sender
+          ; fee
+          ; fee_payer = None
+          ; receivers = []
+          ; amount
+          ; zkapp_account_keypairs = [ new_kp ]
+          ; memo
+          ; new_zkapp_account = false
+          ; snapp_update
+          ; current_auth = Permissions.Auth_required.None
+          ; call_data = Snark_params.Tick.Field.zero
+          ; events = []
+          ; actions = []
+          ; preconditions = None
+          }
+        in
+        U.test_snapp_update ~expected_failure:failure_expected
+          ~snapp_permissions:
+            (U.permissions_from_update snapp_update ~auth:Either)
+          test_spec ~init_ledger ~vk ~zkapp_prover
+          ~snapp_pk:(Public_key.compress new_kp.public_key) )
 
-    let%test_unit "Update when not permitted but transaction is applied" =
-      let open Mina_transaction_logic.For_tests in
-      Quickcheck.test ~trials:1 U.gen_snapp_ledger
-        ~f:(fun ({ init_ledger; specs }, new_kp) ->
-          Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
-              let spec = List.hd_exn specs in
-              let fee = Fee.of_nanomina_int_exn 1_000_000 in
-              let amount = Amount.of_mina_int_exn 10 in
-              let test_spec : Spec.t =
-                { sender = spec.sender
-                ; fee
-                ; fee_payer = None
-                ; receivers = []
-                ; amount
-                ; zkapp_account_keypairs = [ new_kp ]
-                ; memo
-                ; new_zkapp_account = false
-                ; snapp_update
-                ; current_auth = Permissions.Auth_required.Signature
-                ; call_data = Snark_params.Tick.Field.zero
-                ; events = []
-                ; actions = []
-                ; preconditions = None
-                }
-              in
-              let snapp_pk = Public_key.compress new_kp.public_key in
-              Init_ledger.init (module Ledger.Ledger_inner) init_ledger ledger ;
-              (*Create snapp transaction*)
-              Transaction_snark.For_tests.create_trivial_zkapp_account
-                ~permissions:(U.permissions_from_update snapp_update ~auth:Proof)
-                ~vk ~ledger snapp_pk ;
-              (*Ledger.apply_transaction should be successful if fee payer update
-                is successful*)
-              U.test_snapp_update ~expected_failure:failure_expected
-                ~snapp_permissions:
-                  (U.permissions_from_update snapp_update ~auth:Proof)
-                ~vk ~zkapp_prover test_spec ~init_ledger ~snapp_pk ) )
+  let%test_unit "Update when not permitted but transaction is applied" =
+    let open Mina_transaction_logic.For_tests in
+    Quickcheck.test ~trials:1 U.gen_snapp_ledger
+      ~f:(fun ({ init_ledger; specs }, new_kp) ->
+        Ledger.with_ledger ~depth:U.ledger_depth ~f:(fun ledger ->
+            let spec = List.hd_exn specs in
+            let fee = Fee.of_nanomina_int_exn 1_000_000 in
+            let amount = Amount.of_mina_int_exn 10 in
+            let test_spec : Spec.t =
+              { sender = spec.sender
+              ; fee
+              ; fee_payer = None
+              ; receivers = []
+              ; amount
+              ; zkapp_account_keypairs = [ new_kp ]
+              ; memo
+              ; new_zkapp_account = false
+              ; snapp_update
+              ; current_auth = Permissions.Auth_required.Signature
+              ; call_data = Snark_params.Tick.Field.zero
+              ; events = []
+              ; actions = []
+              ; preconditions = None
+              }
+            in
+            let snapp_pk = Public_key.compress new_kp.public_key in
+            Init_ledger.init (module Ledger.Ledger_inner) init_ledger ledger ;
+            (*Create snapp transaction*)
+            Transaction_snark.For_tests.create_trivial_zkapp_account
+              ~permissions:(U.permissions_from_update snapp_update ~auth:Proof)
+              ~vk ~ledger snapp_pk ;
+            (*Ledger.apply_transaction should be successful if fee payer update
+              is successful*)
+            U.test_snapp_update ~expected_failure:failure_expected
+              ~snapp_permissions:
+                (U.permissions_from_update snapp_update ~auth:Proof)
+              ~vk ~zkapp_prover test_spec ~init_ledger ~snapp_pk ) )
 
   let test_non_zkapp_to_zkapp ?(new_account = true) test_spec init_ledger
       (zkapp_kp : Keypair.t) =

--- a/src/lib/transaction_snark/test/token_symbol/token_symbol.ml
+++ b/src/lib/transaction_snark/test/token_symbol/token_symbol.ml
@@ -12,6 +12,8 @@ struct
     { Account_update.Update.dummy with
       token_symbol = Zkapp_basic.Set_or_keep.Set "Zoozoo"
     }
+
+  let is_non_zkapp_update = true
 end
 
 let%test_module "Update account token symbol" =

--- a/src/lib/transaction_snark/test/verification_key/verification_key.ml
+++ b/src/lib/transaction_snark/test/verification_key/verification_key.ml
@@ -19,6 +19,8 @@ struct
     { Account_update.Update.dummy with
       verification_key = Zkapp_basic.Set_or_keep.Set new_verification_key
     }
+
+  let is_non_zkapp_update = false
 end
 
 let%test_module "Update account verification key" =

--- a/src/lib/transaction_snark/test/voting_for/voting_for.ml
+++ b/src/lib/transaction_snark/test/voting_for/voting_for.ml
@@ -14,6 +14,8 @@ struct
         Zkapp_basic.Set_or_keep.Set
           (Async.Quickcheck.random_value State_hash.gen)
     }
+
+  let is_non_zkapp_update = true
 end
 
 let%test_module "Update account voting-for" =

--- a/src/lib/transaction_snark/test/zkapp_uri/zkapp_uri.ml
+++ b/src/lib/transaction_snark/test/zkapp_uri/zkapp_uri.ml
@@ -12,6 +12,8 @@ struct
     { Account_update.Update.dummy with
       zkapp_uri = Zkapp_basic.Set_or_keep.Set "https://www.minaprotocol.com"
     }
+
+  let is_non_zkapp_update = false
 end
 
 let%test_module "Update account snapp URI" =


### PR DESCRIPTION
`unmake_zkapp` sets the zkapp part of an account to `None` if it's the same as the default zkapp account.

In `Zkapp_transaction_logic`, the call to `unmake_zkapp` preceded the code that can update the zkApp URI. That made sense when the zkApp URI was not in the zkapp part of accounts.

Now that the zkApp URI is in the zkapp part of accounts, call `unmake_zkapp` after that URI is set.



