### PR TITLE
Change checkout path to corresponding environment variable

### DIFF
--- a/buildkite/scripts/helm-ci.sh
+++ b/buildkite/scripts/helm-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
+++ b/buildkite/src/Jobs/Test/ArchiveNodeUnitTest.dhall
@@ -29,7 +29,7 @@ Pipeline.build
         }
     , steps =
     let outerDir : Text =
-            "/var/buildkite/builds/\\\$BUILDKITE_AGENT_NAME/\\\$BUILDKITE_ORGANIZATION_SLUG/\\\$BUILDKITE_PIPELINE_SLUG"
+            "\\\$BUILDKITE_BUILD_CHECKOUT_PATH"
     in
       [ Command.build
           Command.Config::

--- a/buildkite/src/Lib/Cmds.dhall
+++ b/buildkite/src/Lib/Cmds.dhall
@@ -46,7 +46,7 @@ let module = \(environment : List Text) ->
         (\(var : Text) -> " --env ${var}")
         (docker.extraEnv # environment)
     let outerDir : Text =
-      "/var/buildkite/builds/\\\$BUILDKITE_AGENT_NAME/\\\$BUILDKITE_ORGANIZATION_SLUG/\\\$BUILDKITE_PIPELINE_SLUG"
+      "\\\$BUILDKITE_BUILD_CHECKOUT_PATH"
     let sharedDir : Text = "/var/buildkite/shared"
     in
     { line = "docker run -it --rm --init --volume ${sharedDir}:/shared --volume ${outerDir}:/workdir --workdir /workdir${envVars}${if docker.privileged then " --privileged" else ""}${docker.entrypoint} ${docker.image} /bin/sh -c '${inner.line}'"
@@ -110,7 +110,7 @@ let tests =
 
   let dockerExample = assert :
   { line =
-"docker run -it --rm --init --volume /var/buildkite/shared:/shared --volume /var/buildkite/builds/\\\$BUILDKITE_AGENT_NAME/\\\$BUILDKITE_ORGANIZATION_SLUG/\\\$BUILDKITE_PIPELINE_SLUG:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag /bin/sh -c 'echo hello'"
+"docker run -it --rm --init --volume /var/buildkite/shared:/shared --volume \\\$BUILDKITE_BUILD_CHECKOUT_PATH:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag /bin/sh -c 'echo hello'"
   , readable =
     Some "Docker@foo/bar:tag ( echo hello )"
   }
@@ -124,7 +124,7 @@ let tests =
 
   let cacheExample = assert :
 ''
-  ./buildkite/scripts/cache-through.sh data.tar "docker run -it --rm --init --volume /var/buildkite/shared:/shared --volume /var/buildkite/builds/\$BUILDKITE_AGENT_NAME/\$BUILDKITE_ORGANIZATION_SLUG/\$BUILDKITE_PIPELINE_SLUG:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag /bin/sh -c 'echo hello > /tmp/data/foo.txt && tar cvf data.tar /tmp/data'"''
+  ./buildkite/scripts/cache-through.sh data.tar "docker run -it --rm --init --volume /var/buildkite/shared:/shared --volume \$BUILDKITE_BUILD_CHECKOUT_PATH:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag /bin/sh -c 'echo hello > /tmp/data/foo.txt && tar cvf data.tar /tmp/data'"''
   ===
   M.format (
     M.cacheThrough


### PR DESCRIPTION
Decided to use the environment variable for the checkout path to make the job commands more agnostic to different buildkite agent configurations.