### PR TITLE
Test for supply_increase in mina_transaction_logic

### DIFF
--- a/src/lib/transaction_logic/test/dune
+++ b/src/lib/transaction_logic/test/dune
@@ -1,28 +1,38 @@
 (library
-  (name transaction_logic_tests)
+ (name transaction_logic_tests)
  (libraries
-   ;; opam libraries
-   ppx_inline_test.config
-   core
-   base
-   core_kernel
-   base64
-   integers
-   sexplib0
-   yojson
-   ;; local libraries
-   currency
-   mina_base
-   mina_transaction
-   mina_transaction_logic
-   mina_numbers
-   mina_wire_types
-   random_oracle
-   sgn
-   sgn_type
-   )
-  (library_flags -linkall)
-  (inline_tests)
-  (preprocess
-    (pps ppx_snarky ppx_version ppx_jane ppx_sexp_conv ppx_inline_test ppx_assert))
-  (instrumentation (backend bisect_ppx)))
+  ;; opam libraries
+  ppx_inline_test.config
+  core
+  base
+  core_kernel
+  base64
+  integers
+  sexplib0
+  yojson
+  ;; local libraries
+  currency
+  mina_base
+  mina_transaction
+  mina_transaction_logic
+  mina_numbers
+  mina_wire_types
+  random_oracle
+  sgn
+  sgn_type
+  snark_params
+  signature_lib
+  mina_base_import
+  pasta_bindings)
+ (library_flags -linkall)
+ (inline_tests)
+ (preprocess
+  (pps
+   ppx_snarky
+   ppx_version
+   ppx_jane
+   ppx_sexp_conv
+   ppx_inline_test
+   ppx_assert))
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/lib/transaction_logic/test/supply_increase.ml
+++ b/src/lib/transaction_logic/test/supply_increase.ml
@@ -47,59 +47,6 @@ let%test_module "supply_increase" =
       and previous_hash_input = return @@ Field.of_int prev_hash_input_gen in
       { varying = varying_input; previous_hash = previous_hash_input }
 
-    (* let stable_type_generator =
-       let open Snark_params.Tick in
-       let payload : Signed_command_payload.t =
-         { common =
-             { Signed_command_payload.Common.Poly.fee = Currency.Fee.one
-             ; fee_payer_pk =
-                 { Signature_lib.Public_key.Compressed.Poly.x = Field.of_int 1
-                 ; is_odd = false
-                 }
-             ; nonce = Unsigned.UInt32.of_int 1
-             ; valid_until = Mina_transaction_logic.Global_slot.of_int 1
-             ; memo = Signed_command_memo.empty
-             }
-         ; body =
-             Signed_command_payload.Body.Payment
-               { source_pk =
-                   { Signature_lib.Public_key.Compressed.Poly.x = Field.of_int 1
-                   ; is_odd = false
-                   }
-               ; receiver_pk =
-                   { Signature_lib.Public_key.Compressed.Poly.x = Field.of_int 1
-                   ; is_odd = false
-                   }
-               ; amount = Currency.Amount.of_mina_int_exn 100
-               }
-         }
-       and signer : Mina_base_import.Public_key.t =
-         (Field.of_int 1, Field.of_int 1)
-       and signature : Signature.t =
-         (Field.of_int 1, Pasta_bindings.Fq.of_int 1)
-       in
-       let data_input : Signed_command.Stable.V2.t =
-         { Signed_command.Poly.payload
-         ; Signed_command.Poly.signer
-         ; Signed_command.Poly.signature
-         }
-       in
-       let user_command_input : Signed_command.t With_status.t =
-         { data = data_input; status = Transaction_status.Applied }
-       in
-       let common_input : Signed_command_applied.Common.t =
-         { user_command = user_command_input }
-       in
-       let signed_command_input : Signed_command_applied.t =
-         { common = common_input
-         ; body = Signed_command_applied.Body.Payment { new_accounts = [] }
-         }
-       in
-       let command_input = Command_applied.Signed_command signed_command_input in
-       let varying_input = Varying.Command command_input
-       and previous_hash_input = Field.of_int 1 in
-       { varying = varying_input; previous_hash = previous_hash_input } *)
-
     type signed_amount = Currency.Amount.Signed.t
     [@@deriving equal, sexp, compare]
 

--- a/src/lib/transaction_logic/test/supply_increase.ml
+++ b/src/lib/transaction_logic/test/supply_increase.ml
@@ -1,0 +1,115 @@
+open! Core
+open Mina_transaction_logic.Transaction_applied
+open Mina_base
+
+let%test_module "supply_increase" =
+  ( module struct
+    let generator =
+      let open Snark_params.Tick in
+      let open Quickcheck.Generator.Let_syntax in
+      let%bind prev_hash_input_gen = Int.quickcheck_generator in
+      let%bind account_id_gen = List.gen_with_length 0 Account_id.gen in
+      let%bind payload = Signed_command_payload.gen
+      and signer = Mina_base_import.Public_key.gen
+      and signature : Signature.t Quickcheck.Generator.t =
+        return Signature.dummy
+      in
+      let%bind data_input : Signed_command.t Quickcheck.Generator.t =
+        return
+          { Signed_command.Poly.payload
+          ; Signed_command.Poly.signer
+          ; Signed_command.Poly.signature
+          }
+      in
+      let%bind user_command_input :
+          Signed_command.t With_status.t Quickcheck.Generator.t =
+        return
+          { With_status.data = data_input; status = Transaction_status.Applied }
+      in
+      let%bind common_input :
+          Signed_command_applied.Common.t Quickcheck.Generator.t =
+        return
+          { Signed_command_applied.Common.user_command = user_command_input }
+      in
+      let%bind signed_command_input :
+          Signed_command_applied.t Quickcheck.Generator.t =
+        return
+          { Signed_command_applied.common = common_input
+          ; body =
+              Signed_command_applied.Body.Payment
+                { new_accounts = account_id_gen }
+          }
+      in
+      let%bind command_input : Command_applied.t Quickcheck.Generator.t =
+        return @@ Command_applied.Signed_command signed_command_input
+      in
+      let%map varying_input = return @@ Varying.Command command_input
+      and previous_hash_input = return @@ Field.of_int prev_hash_input_gen in
+      { varying = varying_input; previous_hash = previous_hash_input }
+
+    (* let stable_type_generator =
+       let open Snark_params.Tick in
+       let payload : Signed_command_payload.t =
+         { common =
+             { Signed_command_payload.Common.Poly.fee = Currency.Fee.one
+             ; fee_payer_pk =
+                 { Signature_lib.Public_key.Compressed.Poly.x = Field.of_int 1
+                 ; is_odd = false
+                 }
+             ; nonce = Unsigned.UInt32.of_int 1
+             ; valid_until = Mina_transaction_logic.Global_slot.of_int 1
+             ; memo = Signed_command_memo.empty
+             }
+         ; body =
+             Signed_command_payload.Body.Payment
+               { source_pk =
+                   { Signature_lib.Public_key.Compressed.Poly.x = Field.of_int 1
+                   ; is_odd = false
+                   }
+               ; receiver_pk =
+                   { Signature_lib.Public_key.Compressed.Poly.x = Field.of_int 1
+                   ; is_odd = false
+                   }
+               ; amount = Currency.Amount.of_mina_int_exn 100
+               }
+         }
+       and signer : Mina_base_import.Public_key.t =
+         (Field.of_int 1, Field.of_int 1)
+       and signature : Signature.t =
+         (Field.of_int 1, Pasta_bindings.Fq.of_int 1)
+       in
+       let data_input : Signed_command.Stable.V2.t =
+         { Signed_command.Poly.payload
+         ; Signed_command.Poly.signer
+         ; Signed_command.Poly.signature
+         }
+       in
+       let user_command_input : Signed_command.t With_status.t =
+         { data = data_input; status = Transaction_status.Applied }
+       in
+       let common_input : Signed_command_applied.Common.t =
+         { user_command = user_command_input }
+       in
+       let signed_command_input : Signed_command_applied.t =
+         { common = common_input
+         ; body = Signed_command_applied.Body.Payment { new_accounts = [] }
+         }
+       in
+       let command_input = Command_applied.Signed_command signed_command_input in
+       let varying_input = Varying.Command command_input
+       and previous_hash_input = Field.of_int 1 in
+       { varying = varying_input; previous_hash = previous_hash_input } *)
+
+    type signed_amount = Currency.Amount.Signed.t
+    [@@deriving equal, sexp, compare]
+
+    let%test_unit "supply_increase_command_input_always_gives_zero_when_no_account_ids"
+        =
+      Quickcheck.test generator ~f:(fun payload ->
+          [%test_eq: signed_amount Or_error.t]
+            ( Or_error.return
+            @@ Currency.Amount.Signed.create
+                 ~magnitude:(Currency.Amount.of_mina_int_exn 0)
+                 ~sgn:Sgn.Pos )
+            (supply_increase payload) )
+  end )

--- a/src/lib/transaction_logic/test/supply_increase.ml
+++ b/src/lib/transaction_logic/test/supply_increase.ml
@@ -7,56 +7,46 @@ let%test_module "supply_increase" =
     let generator =
       let open Snark_params.Tick in
       let open Quickcheck.Generator.Let_syntax in
-      let%bind prev_hash_input_gen = Int.quickcheck_generator in
-      let%bind account_id_gen = List.gen_with_length 0 Account_id.gen in
+      let%bind prev_hash_input = Int.quickcheck_generator in
+      let account_id = [] in
       let%bind payload = Signed_command_payload.gen
       and signer = Mina_base_import.Public_key.gen
       and signature : Signature.t Quickcheck.Generator.t =
         return Signature.dummy
       in
-      let%bind data_input : Signed_command.t Quickcheck.Generator.t =
-        return
-          { Signed_command.Poly.payload
-          ; Signed_command.Poly.signer
-          ; Signed_command.Poly.signature
+      let data_input : Signed_command.t =
+        Signed_command.Poly.{ payload; signer; signature }
+      in
+      let user_command_input : Signed_command.t With_status.t =
+        { With_status.data = data_input; status = Transaction_status.Applied }
+      in
+      let common_input : Signed_command_applied.Common.t =
+        { Signed_command_applied.Common.user_command = user_command_input }
+      in
+      let signed_command_input =
+        Signed_command_applied.
+          { common = common_input
+          ; body = Body.Payment { new_accounts = account_id }
           }
       in
-      let%bind user_command_input :
-          Signed_command.t With_status.t Quickcheck.Generator.t =
-        return
-          { With_status.data = data_input; status = Transaction_status.Applied }
-      in
-      let%bind common_input :
-          Signed_command_applied.Common.t Quickcheck.Generator.t =
-        return
-          { Signed_command_applied.Common.user_command = user_command_input }
-      in
-      let%bind signed_command_input :
-          Signed_command_applied.t Quickcheck.Generator.t =
-        return
-          { Signed_command_applied.common = common_input
-          ; body =
-              Signed_command_applied.Body.Payment
-                { new_accounts = account_id_gen }
-          }
-      in
-      let%bind command_input : Command_applied.t Quickcheck.Generator.t =
-        return @@ Command_applied.Signed_command signed_command_input
+      let command_input : Command_applied.t =
+        Command_applied.Signed_command signed_command_input
       in
       let%map varying_input = return @@ Varying.Command command_input
-      and previous_hash_input = return @@ Field.of_int prev_hash_input_gen in
+      and previous_hash_input = return @@ Field.of_int prev_hash_input in
       { varying = varying_input; previous_hash = previous_hash_input }
 
     type signed_amount = Currency.Amount.Signed.t
     [@@deriving equal, sexp, compare]
 
+    (* Note that the function supply_increase can return results other than zero, but I've specifically chosen the case when the accounts list is empty.
+       When it's non-empty, the values are different and thus difficult to confirm using property-based testing.
+       Also, because of the particular input type chosen (of data type command ) this also simplifies things somewhat,
+       whereas other types (i.e. fee_transfer and coinbase) produce numerical values other than zero in the calculation. *)
     let%test_unit "supply_increase_command_input_always_gives_zero_when_no_account_ids"
         =
       Quickcheck.test generator ~f:(fun payload ->
           [%test_eq: signed_amount Or_error.t]
-            ( Or_error.return
-            @@ Currency.Amount.Signed.create
-                 ~magnitude:(Currency.Amount.of_mina_int_exn 0)
-                 ~sgn:Sgn.Pos )
+            (Or_error.return @@ Currency.Amount.Signed.zero)
             (supply_increase payload) )
   end )


### PR DESCRIPTION
A property-based test has been added for the `supply_increase` function in `mina_transaction_logic.ml`. Due to the inability to create some of the private types the function takes, only the Command data type was modelled for the input.

* Closes #12573 
