### PR TITLE
Public keys only when default token implicit

### DIFF
--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -69,9 +69,9 @@ CREATE TYPE transaction_status AS ENUM ('applied', 'failed');
 CREATE TABLE user_commands
 ( id             serial              PRIMARY KEY
 , command_type   user_command_type   NOT NULL
-, fee_payer_id   int                 NOT NULL REFERENCES account_identifiers(id)
-, source_id      int                 NOT NULL REFERENCES account_identifiers(id)
-, receiver_id    int                 NOT NULL REFERENCES account_identifiers(id)
+, fee_payer_id   int                 NOT NULL REFERENCES public_keys(id)
+, source_id      int                 NOT NULL REFERENCES public_keys(id)
+, receiver_id    int                 NOT NULL REFERENCES public_keys(id)
 , nonce          bigint              NOT NULL
 , amount         text
 , fee            text                NOT NULL
@@ -85,7 +85,7 @@ CREATE TYPE internal_command_type AS ENUM ('fee_transfer_via_coinbase', 'fee_tra
 CREATE TABLE internal_commands
 ( id            serial                PRIMARY KEY
 , command_type  internal_command_type NOT NULL
-, receiver_id   int                   NOT NULL REFERENCES account_identifiers(id)
+, receiver_id   int                   NOT NULL REFERENCES public_keys(id)
 , fee           text                  NOT NULL
 , hash          text                  NOT NULL
 , UNIQUE (hash,command_type)

--- a/src/app/archive/lib/extensional.ml
+++ b/src/app/archive/lib/extensional.ml
@@ -25,9 +25,9 @@ module User_command = struct
       type t =
         { sequence_no : int
         ; command_type : string
-        ; fee_payer : Account_id.Stable.V2.t
-        ; source : Account_id.Stable.V2.t
-        ; receiver : Account_id.Stable.V2.t
+        ; fee_payer : Public_key.Compressed.Stable.V1.t
+        ; source : Public_key.Compressed.Stable.V1.t
+        ; receiver : Public_key.Compressed.Stable.V1.t
         ; nonce : Account.Nonce.Stable.V1.t
         ; amount : Currency.Amount.Stable.V1.t option
         ; fee : Currency.Fee.Stable.V1.t
@@ -57,7 +57,7 @@ module Internal_command = struct
         { sequence_no : int
         ; secondary_sequence_no : int
         ; command_type : string
-        ; receiver : Account_id.Stable.V2.t
+        ; receiver : Public_key.Compressed.Stable.V1.t
         ; fee : Currency.Fee.Stable.V1.t
         ; hash : Transaction_hash.Stable.V1.t
               [@to_yojson Transaction_hash.to_yojson]

--- a/src/app/archive/lib/load_data.ml
+++ b/src/app/archive/lib/load_data.ml
@@ -396,11 +396,15 @@ let load_events pool id =
 
 let get_fee_payer_body ~pool body_id =
   let query_db ~f = Mina_caqti.query ~f pool in
-  let%bind { account_identifier_id; fee; valid_until; nonce } =
+  let%bind { public_key_id; fee; valid_until; nonce } =
     query_db ~f:(fun db -> Processor.Zkapp_fee_payer_body.load db body_id)
   in
-  let%bind account_id = account_identifier_of_id pool account_identifier_id in
-  let public_key = Account_id.public_key account_id in
+  let%bind public_key_str =
+    query_db ~f:(fun db -> Processor.Public_key.find_by_id db public_key_id)
+  in
+  let public_key =
+    Signature_lib.Public_key.Compressed.of_base58_check_exn public_key_str
+  in
   let fee = Currency.Fee.of_string fee in
   let valid_until =
     let open Option.Let_syntax in

--- a/src/app/archive/lib/load_data.ml
+++ b/src/app/archive/lib/load_data.ml
@@ -399,12 +399,7 @@ let get_fee_payer_body ~pool body_id =
   let%bind { public_key_id; fee; valid_until; nonce } =
     query_db ~f:(fun db -> Processor.Zkapp_fee_payer_body.load db body_id)
   in
-  let%bind public_key_str =
-    query_db ~f:(fun db -> Processor.Public_key.find_by_id db public_key_id)
-  in
-  let public_key =
-    Signature_lib.Public_key.Compressed.of_base58_check_exn public_key_str
-  in
+  let%bind public_key = pk_of_id pool public_key_id in
   let fee = Currency.Fee.of_string fee in
   let valid_until =
     let open Option.Let_syntax in

--- a/src/app/archive/zkapp_tables.sql
+++ b/src/app/archive/zkapp_tables.sql
@@ -243,7 +243,7 @@ CREATE TABLE zkapp_network_precondition
 
 CREATE TABLE zkapp_fee_payer_body
 ( id                                    serial    PRIMARY KEY
-, account_identifier_id                 int       NOT NULL REFERENCES account_identifiers(id)
+, public_key_id                         int       NOT NULL REFERENCES public_keys(id)
 , fee                                   text      NOT NULL
 , valid_until                           bigint
 , nonce                                 bigint    NOT NULL


### PR DESCRIPTION
In archive db schema, revert uses of account identifiers where the token is implicitly the default; use just the public key. Using account identifiers introduces the possibility of error, and increases friction between the OCaml code and the archive database -- the default token has to be manually added.

Leave account identifiers where there is the possibility of a custom token, such as in the `accounts_accessed` table.