### PR TITLE
Add last VRF output and subwindow densities to blocks in archive

### DIFF
--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -132,6 +132,7 @@ CREATE TABLE epoch_data
 
 CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned', 'pending');
 
+/* last_vrf_output is a sequence of hex-digit pairs derived from a bitstring */
 CREATE TABLE blocks
 ( id                           serial   PRIMARY KEY
 , state_hash                   text     NOT NULL UNIQUE

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -133,22 +133,24 @@ CREATE TABLE epoch_data
 CREATE TYPE chain_status_type AS ENUM ('canonical', 'orphaned', 'pending');
 
 CREATE TABLE blocks
-( id                           serial PRIMARY KEY
-, state_hash                   text   NOT NULL UNIQUE
-, parent_id                    int                    REFERENCES blocks(id)
-, parent_hash                  text   NOT NULL
-, creator_id                   int    NOT NULL        REFERENCES public_keys(id)
-, block_winner_id              int    NOT NULL        REFERENCES public_keys(id)
-, snarked_ledger_hash_id       int    NOT NULL        REFERENCES snarked_ledger_hashes(id)
-, staking_epoch_data_id        int    NOT NULL        REFERENCES epoch_data(id)
-, next_epoch_data_id           int    NOT NULL        REFERENCES epoch_data(id)
-, min_window_density           bigint NOT NULL
-, total_currency               text   NOT NULL
-, ledger_hash                  text   NOT NULL
-, height                       bigint NOT NULL
-, global_slot_since_hard_fork  bigint NOT NULL
-, global_slot_since_genesis    bigint NOT NULL
-, timestamp                    text   NOT NULL
+( id                           serial   PRIMARY KEY
+, state_hash                   text     NOT NULL UNIQUE
+, parent_id                    int                      REFERENCES blocks(id)
+, parent_hash                  text     NOT NULL
+, creator_id                   int      NOT NULL        REFERENCES public_keys(id)
+, block_winner_id              int      NOT NULL        REFERENCES public_keys(id)
+, last_vrf_output              text     NOT NULL
+, snarked_ledger_hash_id       int      NOT NULL        REFERENCES snarked_ledger_hashes(id)
+, staking_epoch_data_id        int      NOT NULL        REFERENCES epoch_data(id)
+, next_epoch_data_id           int      NOT NULL        REFERENCES epoch_data(id)
+, min_window_density           bigint   NOT NULL
+, sub_window_densities         bigint[] NOT NULL
+, total_currency               text     NOT NULL
+, ledger_hash                  text     NOT NULL
+, height                       bigint   NOT NULL
+, global_slot_since_hard_fork  bigint   NOT NULL
+, global_slot_since_genesis    bigint   NOT NULL
+, timestamp                    text     NOT NULL
 , chain_status                 chain_status_type NOT NULL
 );
 

--- a/src/app/archive/lib/dune
+++ b/src/app/archive/lib/dune
@@ -28,6 +28,7 @@
    precomputed_values
    coda_genesis_ledger
    mina_runtime_config
+   hex
    sgn
    mina_base.util
    kimchi_backend.pasta

--- a/src/app/archive/lib/extensional.ml
+++ b/src/app/archive/lib/extensional.ml
@@ -14,7 +14,7 @@ module User_command = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      (* for `typ` and `status`, a string is enough
+      (* for `command_type` and `status`, a string is enough
          in any case, there aren't existing string conversions for the
          original OCaml types
 
@@ -50,7 +50,7 @@ module Internal_command = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      (* for `typ`, a string is enough
+      (* for `command_type`, a string is enough
          no existing string conversion for the original OCaml type
       *)
       type t =
@@ -110,11 +110,13 @@ module Block = struct
         ; parent_hash : State_hash.Stable.V1.t
         ; creator : Public_key.Compressed.Stable.V1.t
         ; block_winner : Public_key.Compressed.Stable.V1.t
+        ; last_vrf_output : string
         ; snarked_ledger_hash : Frozen_ledger_hash.Stable.V1.t
         ; staking_epoch_data : Mina_base.Epoch_data.Value.Stable.V1.t
         ; next_epoch_data : Mina_base.Epoch_data.Value.Stable.V1.t
         ; min_window_density : Mina_numbers.Length.Stable.V1.t
         ; total_currency : Currency.Amount.Stable.V1.t
+        ; sub_window_densities : Mina_numbers.Length.Stable.V1.t list
         ; ledger_hash : Ledger_hash.Stable.V1.t
         ; height : Unsigned_extended.UInt32.Stable.V1.t
         ; global_slot_since_hard_fork : Mina_numbers.Global_slot.Stable.V1.t

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -2678,10 +2678,12 @@ module Block = struct
     ; parent_hash : string
     ; creator_id : int
     ; block_winner_id : int
+    ; last_vrf_output : string
     ; snarked_ledger_hash_id : int
     ; staking_epoch_data_id : int
     ; next_epoch_data_id : int
     ; min_window_density : int64
+    ; sub_window_densities : int64 array
     ; total_currency : string
     ; ledger_hash : string
     ; height : int64
@@ -2700,10 +2702,12 @@ module Block = struct
         ; string
         ; int
         ; int
+        ; string
         ; int
         ; int
         ; int
         ; int64
+        ; Mina_caqti.array_int64_typ
         ; string
         ; string
         ; int64
@@ -2755,6 +2759,9 @@ module Block = struct
             (module Conn)
             (Consensus.Data.Consensus_state.block_stake_winner consensus_state)
         in
+        let last_vrf_output =
+          Consensus.Data.Consensus_state.last_vrf_output consensus_state
+        in
         let%bind snarked_ledger_hash_id =
           Snarked_ledger_hash.add_if_doesn't_exist
             (module Conn)
@@ -2801,6 +2808,8 @@ module Block = struct
             Chain_status.(to_string Canonical)
           else Chain_status.(to_string Pending)
         in
+        let consensus_state = Protocol_state.consensus_state protocol_state in
+        let blockchain_state = Protocol_state.blockchain_state protocol_state in
         let%bind block_id =
           Conn.find
             (Caqti_request.find typ Caqti_type.int
@@ -2815,20 +2824,26 @@ module Block = struct
                 |> State_hash.to_base58_check
             ; creator_id
             ; block_winner_id
+            ; last_vrf_output
             ; snarked_ledger_hash_id
             ; staking_epoch_data_id
             ; next_epoch_data_id
             ; min_window_density =
-                Protocol_state.consensus_state protocol_state
+                consensus_state
                 |> Consensus.Data.Consensus_state.min_window_density
                 |> Mina_numbers.Length.to_uint32 |> Unsigned.UInt32.to_int64
+            ; sub_window_densities =
+                consensus_state
+                |> Consensus.Data.Consensus_state.sub_window_densities
+                |> List.map ~f:(fun length ->
+                       Mina_numbers.Length.to_uint32 length
+                       |> Unsigned.UInt32.to_int64 )
+                |> Array.of_list
             ; total_currency =
-                Protocol_state.consensus_state protocol_state
-                |> Consensus.Data.Consensus_state.total_currency
+                consensus_state |> Consensus.Data.Consensus_state.total_currency
                 |> Currency.Amount.to_string
             ; ledger_hash =
-                Protocol_state.blockchain_state protocol_state
-                |> Blockchain_state.staged_ledger_hash
+                blockchain_state |> Blockchain_state.staged_ledger_hash
                 |> Staged_ledger_hash.ledger_hash |> Ledger_hash.to_base58_check
             ; height
             ; global_slot_since_hard_fork
@@ -2837,8 +2852,8 @@ module Block = struct
                 |> Consensus.Data.Consensus_state.global_slot_since_genesis
                 |> Unsigned.UInt32.to_int64
             ; timestamp =
-                Protocol_state.blockchain_state protocol_state
-                |> Blockchain_state.timestamp |> Block_time.to_string_exn
+                blockchain_state |> Blockchain_state.timestamp
+                |> Block_time.to_string_exn
             ; chain_status
             }
         in
@@ -3113,6 +3128,7 @@ module Block = struct
           let%bind block_winner_id =
             Public_key.add_if_doesn't_exist (module Conn) block.block_winner
           in
+          let last_vrf_output = block.last_vrf_output in
           let%bind snarked_ledger_hash_id =
             Snarked_ledger_hash.add_if_doesn't_exist
               (module Conn)
@@ -3130,13 +3146,13 @@ module Block = struct
             (Caqti_request.find typ Caqti_type.int
                {sql| INSERT INTO blocks
                      (state_hash, parent_id, parent_hash,
-                      creator_id, block_winner_id,
+                      creator_id, block_winner_id,last_vrf_output,
                       snarked_ledger_hash_id, staking_epoch_data_id,
                       next_epoch_data_id,
-                      min_window_density, total_currency,
+                      min_window_density, sub_window_densities, total_currency,
                       ledger_hash, height, global_slot_since_hard_fork,
                       global_slot_since_genesis, timestamp, chain_status)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::chain_status_type)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::chain_status_type)
                      RETURNING id
                |sql} )
             { state_hash = block.state_hash |> State_hash.to_base58_check
@@ -3144,12 +3160,19 @@ module Block = struct
             ; parent_hash = block.parent_hash |> State_hash.to_base58_check
             ; creator_id
             ; block_winner_id
+            ; last_vrf_output
             ; snarked_ledger_hash_id
             ; staking_epoch_data_id
             ; next_epoch_data_id
             ; min_window_density =
                 block.min_window_density |> Mina_numbers.Length.to_uint32
                 |> Unsigned.UInt32.to_int64
+            ; sub_window_densities =
+                block.sub_window_densities
+                |> List.map ~f:(fun length ->
+                       Mina_numbers.Length.to_uint32 length
+                       |> Unsigned.UInt32.to_int64 )
+                |> Array.of_list
             ; total_currency = Currency.Amount.to_string block.total_currency
             ; ledger_hash = block.ledger_hash |> Ledger_hash.to_base58_check
             ; height = block.height |> Unsigned.UInt32.to_int64

--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -281,11 +281,6 @@ let%test_module "Archive node unit tests" =
             Strict_pipe.create ~name:"archive"
               (Buffered (`Capacity 100, `Overflow Crash))
           in
-          let processor_deferred_computation =
-            Processor.run
-              ~constraint_constants:precomputed_values.constraint_constants pool
-              reader ~logger ~delete_older_than:None
-          in
           let diffs =
             List.map
               ~f:(fun breadcrumb ->
@@ -296,7 +291,11 @@ let%test_module "Archive node unit tests" =
           in
           List.iter diffs ~f:(Strict_pipe.Writer.write writer) ;
           Strict_pipe.Writer.close writer ;
-          let%bind () = processor_deferred_computation in
+          let%bind () =
+            Processor.run
+              ~constraint_constants:precomputed_values.constraint_constants pool
+              reader ~logger ~delete_older_than:None
+          in
           match%map
             Mina_caqti.deferred_result_list_fold breadcrumbs ~init:()
               ~f:(fun () breadcrumb ->

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -47,7 +47,10 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
   let open Deferred.Let_syntax in
   let%bind creator = pk_of_id block.creator_id in
   let%bind block_winner = pk_of_id block.block_winner_id in
-  let last_vrf_output = block.last_vrf_output in
+  let last_vrf_output =
+    (* keep hex encoding *)
+    block.last_vrf_output
+  in
   let%bind snarked_ledger_hash_str =
     query_db ~f:(fun db ->
         Processor.Snarked_ledger_hash.find_by_id db block.snarked_ledger_hash_id )

--- a/src/app/extract_blocks/extract_blocks.ml
+++ b/src/app/extract_blocks/extract_blocks.ml
@@ -47,6 +47,7 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
   let open Deferred.Let_syntax in
   let%bind creator = pk_of_id block.creator_id in
   let%bind block_winner = pk_of_id block.block_winner_id in
+  let last_vrf_output = block.last_vrf_output in
   let%bind snarked_ledger_hash_str =
     query_db ~f:(fun db ->
         Processor.Snarked_ledger_hash.find_by_id db block.snarked_ledger_hash_id )
@@ -72,6 +73,12 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
     block.min_window_density |> Unsigned.UInt32.of_int64
     |> Mina_numbers.Length.of_uint32
   in
+  let sub_window_densities =
+    block.sub_window_densities
+    |> Array.map ~f:(fun length ->
+           Unsigned.UInt32.of_int64 length |> Mina_numbers.Length.of_uint32 )
+    |> Array.to_list
+  in
   let total_currency = Currency.Amount.of_string block.total_currency in
   let ledger_hash = Ledger_hash.of_base58_check_exn block.ledger_hash in
   let height = Unsigned.UInt32.of_int64 block.height in
@@ -89,10 +96,12 @@ let fill_in_block pool (block : Archive_lib.Processor.Block.t) :
     ; parent_hash
     ; creator
     ; block_winner
+    ; last_vrf_output
     ; snarked_ledger_hash
     ; staking_epoch_data
     ; next_epoch_data
     ; min_window_density
+    ; sub_window_densities
     ; total_currency
     ; ledger_hash
     ; height

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -534,7 +534,11 @@ module type S = sig
 
       val min_window_density : Value.t -> Length.t
 
+      val sub_window_densities : Value.t -> Length.t list
+
       val block_stake_winner : Value.t -> Public_key.Compressed.t
+
+      val last_vrf_output : Value.t -> string
 
       val block_creator : Value.t -> Public_key.Compressed.t
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2411,9 +2411,11 @@ module Make_str (A : Wire_types.Concrete) = struct
       Poly.
         ( blockchain_length
         , min_window_density
+        , sub_window_densities
         , total_currency
         , global_slot_since_genesis
         , block_stake_winner
+        , last_vrf_output
         , block_creator
         , coinbase_receiver )]
 

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -109,6 +109,22 @@ let () =
   in
   define_coding Array_nullable_int { get_coding }
 
+(* register coding for nullable int64 arrays *)
+let () =
+  let open Caqti_type.Field in
+  let rep = Caqti_type.String in
+  let encode, decode =
+    make_coding ~elem_to_string:Int64.to_string ~elem_of_string:Int64.of_string
+  in
+  let get_coding : type a. _ -> a t -> a coding =
+   fun _ -> function
+    | Array_nullable_int64 ->
+        Coding { rep; encode; decode }
+    | _ ->
+        assert false
+  in
+  define_coding Array_nullable_int64 { get_coding }
+
 (* register coding for nullable string arrays *)
 let () =
   let open Caqti_type.Field in
@@ -154,7 +170,7 @@ let array_int64_typ : int64 array Caqti_type.t =
   let decode xs =
     Option.all (Array.to_list xs)
     |> Result.of_option
-         ~error:"Failed to decode int array, encountered NULL value"
+         ~error:"Failed to decode int64 array, encountered NULL value"
     >>| Array.of_list
   in
   Caqti_type.custom array_nullable_int64_typ ~encode ~decode

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -143,7 +143,7 @@ let array_int_typ : int array Caqti_type.t =
   Caqti_type.custom array_nullable_int_typ ~encode ~decode
 
 (* this type may require type annotations in queries, eg.
-   `SELECT id FROM zkapp_states WHERE element_ids = ?::int[]`
+   `SELECT id FROM zkapp_states WHERE element_ids = ?::int64[]`
 *)
 let array_nullable_int64_typ : int64 option array Caqti_type.t =
   Caqti_type.field Array_nullable_int64

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -9,6 +9,9 @@ type _ Caqti_type.field +=
   | Array_nullable_int : int option array Caqti_type.field
 
 type _ Caqti_type.field +=
+  | Array_nullable_int64 : int64 option array Caqti_type.field
+
+type _ Caqti_type.field +=
   | Array_nullable_string : string option array Caqti_type.field
 
 module Type_spec = struct
@@ -138,6 +141,23 @@ let array_int_typ : int array Caqti_type.t =
     >>| Array.of_list
   in
   Caqti_type.custom array_nullable_int_typ ~encode ~decode
+
+(* this type may require type annotations in queries, eg.
+   `SELECT id FROM zkapp_states WHERE element_ids = ?::int[]`
+*)
+let array_nullable_int64_typ : int64 option array Caqti_type.t =
+  Caqti_type.field Array_nullable_int64
+
+let array_int64_typ : int64 array Caqti_type.t =
+  let open Result.Let_syntax in
+  let encode xs = return @@ Array.map ~f:Option.some xs in
+  let decode xs =
+    Option.all (Array.to_list xs)
+    |> Result.of_option
+         ~error:"Failed to decode int array, encountered NULL value"
+    >>| Array.of_list
+  in
+  Caqti_type.custom array_nullable_int64_typ ~encode ~decode
 
 (* this type may require type annotations in queries, e.g.
    `SELECT id FROM zkapp_states WHERE element_ids = ?::string[]`


### PR DESCRIPTION
These fields will be useful for chain selection by the archive API . See #12690.