### PR TITLE
Fix Stream deprecation warning

### DIFF
--- a/buildkite/src/Constants/ContainerImages.dhall
+++ b/buildkite/src/Constants/ContainerImages.dhall
@@ -4,10 +4,10 @@
 -- NOTE: minaToolchainBookworm is also used for building Ubuntu Jammy packages in CI
 {
   toolchainBase = "codaprotocol/ci-toolchain-base:v3",
-  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:45fee6cb346a6f6364133cc473d47a5c51797b923a6b6809fbe8d067cce8d8d5",
-  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:97e90e9962c3378e97966b939064c834d8f75b3b7e312bbbaf499bb0493733a5",
-  minaToolchainBookworm = "gcr.io/o1labs-192920/mina-toolchain@sha256:97e90e9962c3378e97966b939064c834d8f75b3b7e312bbbaf499bb0493733a5",
-  minaToolchain = "gcr.io/o1labs-192920/mina-toolchain@sha256:97e90e9962c3378e97966b939064c834d8f75b3b7e312bbbaf499bb0493733a5",
+  minaToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:d27c15e3143a99b86155ba57696020c00e2a296b388499b3e6fb364478ddda3a",
+  minaToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:966863de43c72c294e14762ae567404005f99654c54338a9a89b999476a36d1f",
+  minaToolchainBookworm = "gcr.io/o1labs-192920/mina-toolchain@sha256:966863de43c72c294e14762ae567404005f99654c54338a9a89b999476a36d1f",
+  minaToolchain = "gcr.io/o1labs-192920/mina-toolchain@sha256:966863de43c72c294e14762ae567404005f99654c54338a9a89b999476a36d1f",
   minaCaqtiToolchainBuster = "gcr.io/o1labs-192920/mina-toolchain@sha256:900320a7063bf686d2e5a8fa67a111479b3274f3439beae88f96364e209b7a0d",
   minaCaqtiToolchainBullseye = "gcr.io/o1labs-192920/mina-toolchain@sha256:609210748ee04b2926b86d6590e29b5a32d4709eefdf907f83b819f38cce8f46",
   minaCaqtiToolchainBookworm = "gcr.io/o1labs-192920/mina-toolchain@sha256:609210748ee04b2926b86d6590e29b5a32d4709eefdf907f83b819f38cce8f46",

--- a/opam.export
+++ b/opam.export
@@ -69,6 +69,7 @@ installed: [
   "bisect_ppx.2.8.1"
   "bitstring.4.1.0"
   "camlp4.4.14+1"
+  "camlp-streams.5.0.1"
   "camomile.1.0.2"
   "capnp.3.4.0"
   "caqti.1.5.0"

--- a/opam.export
+++ b/opam.export
@@ -1,16 +1,15 @@
 opam-version: "2.0"
+compiler: ["ocaml.4.14.0"]
 roots: [
   "alcotest.1.1.0"
   "alcotest-async.1.1.0"
   "angstrom.0.15.0"
-  "async_ssl.v0.14.0"
-  "bignum.v0.14.0"
   "bisect_ppx.2.8.1"
   "bitstring.4.1.0"
+  "camlp-streams.5.0.1"
   "camlp4.4.14+1"
   "capnp.3.4.0"
   "check_opam_switch.~dev"
-  "cohttp-async.5.0.0"
   "core_extended.v0.14.0"
   "extlib.1.7.8"
   "graphql-async.0.13.0"

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -1,4 +1,8 @@
 open Signature_lib
+
+(* Alias ocamlp-streams before it's hidden by open
+   Core_kernel *)
+module Streams = Stream
 open Core_kernel
 open Async
 
@@ -104,9 +108,9 @@ let validate_transaction =
     (* TODO upgrade to yojson 2.0.0 when possible to use seq_from_channel
      * instead of the deprecated stream interface *)
     let jsons = Yojson.Safe.stream_from_channel In_channel.stdin in
-    ( match[@alert "-deprecated"]
+    ( match
         Or_error.try_with (fun () ->
-            Caml.Stream.iter
+            Streams.iter
               (fun transaction_json ->
                 match
                   Rosetta_lib.Transaction.to_mina_signed transaction_json
@@ -139,7 +143,7 @@ let validate_transaction =
       Format.printf "Some transactions failed to verify@." ;
       exit 1 )
     else
-      let[@alert "-deprecated"] first = Caml.Stream.peek jsons in
+      let first = Streams.peek jsons in
       match first with
       | None ->
           Format.printf "Could not parse any transactions@." ;

--- a/src/lib/cli_lib/dune
+++ b/src/lib/cli_lib/dune
@@ -5,47 +5,48 @@
  (inline_tests (flags -verbose -show-counts))
  (libraries
    ;; opam libraries
-   result
-   sexplib0
-   async.async_command
-   base.caml
-   async_kernel
-   async.async_rpc
-   core_kernel
-   yojson
-   sodium
-   core
-   async_unix
-   ppx_deriving_yojson.runtime
-   async
-   uri
-   async_rpc_kernel
-   bin_prot.shape
-   stdio
-   ;; local libraries
-   genesis_constants
-   random_oracle
-   pickles
-   mina_numbers
-   signature_lib
-   currency
-   rosetta_lib
-   secrets
-   mina_base
-   work_selector
-   rosetta_coding
-   logger
-   interpolator_lib
-   mina_compile_config
-   snark_params
-   pickles.backend
-   consensus.vrf
-   error_json
-   kimchi_backend.pasta
-   kimchi_backend.pasta.basic
-   ppx_version.runtime
-   gossip_net)
+  result
+  sexplib0
+  async.async_command
+  base.caml
+  async_kernel
+  async.async_rpc
+  camlp-streams
+  core_kernel
+  yojson
+  sodium
+  core
+  async_unix
+  ppx_deriving_yojson.runtime
+  async
+  uri
+  async_rpc_kernel
+  bin_prot.shape
+  stdio
+  ;; local libraries
+  genesis_constants
+  random_oracle
+  pickles
+  mina_numbers
+  signature_lib
+  currency
+  rosetta_lib
+  secrets
+  mina_base
+  work_selector
+  rosetta_coding
+  logger
+  interpolator_lib
+  mina_compile_config
+  snark_params
+  pickles.backend
+  consensus.vrf
+  error_json
+  kimchi_backend.pasta
+  kimchi_backend.pasta.basic
+  ppx_version.runtime
+  gossip_net)
  (preprocess
   (pps ppx_version ppx_jane ppx_deriving_yojson ppx_deriving.make))
  (instrumentation (backend bisect_ppx))
- (synopsis "Library to communicate with Coda as cli as the front-end"))
+ (synopsis "Library to communicate with Mina as cli as the front-end"))


### PR DESCRIPTION
This PR removes the deprecation warning yielded by the use of `Caml.Stream` by depending on package `camlp-streams`. 

This needed https://github.com/MinaProtocol/mina/pull/15683 to work correctly.
