### PR TITLE
Simpler Logger outputs

### DIFF
--- a/src/lib/logger/impl.ml
+++ b/src/lib/logger/impl.ml
@@ -24,7 +24,7 @@ module Time = struct
   let of_yojson json =
     json |> Yojson.Safe.Util.to_string |> fun s -> Ok (Time.of_string s)
 
-  let pretty_to_string timestamp =
+  let pp ppf timestamp =
     (* This used to be
        [Core.Time.format timestamp "%Y-%m-%d %H:%M:%S UTC"
         ~zone:Time.Zone.utc]
@@ -35,14 +35,11 @@ module Time = struct
     let zone = Time.Zone.utc in
     let date, time = Time.to_date_ofday ~zone timestamp in
     let time_parts = Time.Ofday.to_parts time in
-    let fmt_2_chars () i =
-      let s = string_of_int i in
-      if Int.(i < 10) then "0" ^ s else s
-    in
-    Stdlib.Format.sprintf "%i-%a-%a %a:%a:%a UTC" (Date.year date) fmt_2_chars
+    Format.fprintf ppf "%i-%02d-%02d %02d:%02d:%02d UTC" (Date.year date)
       (Date.month date |> Month.to_int)
-      fmt_2_chars (Date.day date) fmt_2_chars time_parts.hr fmt_2_chars
-      time_parts.min fmt_2_chars time_parts.sec
+      (Date.day date) time_parts.hr time_parts.min time_parts.sec
+
+  let pretty_to_string timestamp = Format.asprintf "%a" pp timestamp
 
   let pretty_to_string_ref = ref pretty_to_string
 

--- a/src/lib/logger/impl.ml
+++ b/src/lib/logger/impl.ml
@@ -182,14 +182,15 @@ module Processor = struct
                   err ) ;
             None
         | Ok (str, extra) ->
-            let formatted_extra =
-              extra
-              |> List.map ~f:(fun (k, v) -> "\n\t" ^ k ^ ": " ^ v)
-              |> String.concat ~sep:""
+            let msg =
+              (* The previously existing \t has been changed to 2 spaces. *)
+              Format.asprintf "@[<v 2>%a [%a] %s@,%a@]" Time.pp msg.timestamp
+                Level.pp msg.level str
+                (Format.pp_print_list ~pp_sep:Format.pp_print_cut
+                   (fun ppf (k, v) -> Format.fprintf ppf "%s: %s" k v) )
+                extra
             in
-            let time = Time.pretty_to_string msg.timestamp in
-            Some
-              (time ^ " [" ^ Level.show msg.level ^ "] " ^ str ^ formatted_extra)
+            Some msg
   end
 
   let raw ?(log_level = Level.Spam) () = T ((module Raw), Raw.create ~log_level)

--- a/src/lib/logger/impl.mli
+++ b/src/lib/logger/impl.mli
@@ -25,6 +25,8 @@ module Time : sig
 
   val of_yojson : Yojson.Safe.t -> (t, string) Result.t
 
+  val pp : Format.formatter -> t -> unit
+
   val pretty_to_string : t -> string
 
   val set_pretty_to_string : (t -> string) -> unit


### PR DESCRIPTION
This small PR simplifies a number of elements within Logger.Impl
- Use built-in format directives to print 2-digits number
- Define a pp function and use it in `Processor.Pretty.process`
- Remove some list iterations and some string allocations in `Processor.Pretty.process`