### PR TITLE
Account precondition equality fix

### DIFF
--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1052,8 +1052,28 @@ module Account_precondition = struct
     [%test_eq: t] account_precondition
       (account_precondition |> Fd.to_json full |> Fd.of_json full)
 
+  let%test_unit "json roundtrip Full with ignore" =
+    let account_precondition = Full Zkapp_precondition.Account.accept in
+    let module Fd = Fields_derivers_zkapps.Derivers in
+    let full = deriver (Fd.o ()) in
+    [%test_eq: t] account_precondition
+      (account_precondition |> Fd.to_json full |> Fd.of_json full)
+
   let%test_unit "json roundtrip nonce" =
     let account_precondition : t = Nonce (Account_nonce.of_int 928472) in
+    let module Fd = Fields_derivers_zkapps.Derivers in
+    let full = deriver (Fd.o ()) in
+    [%test_eq: t] account_precondition
+      (account_precondition |> Fd.to_json full |> Fd.of_json full)
+
+  let%test_unit "json roundtrip Full with nonce" =
+    let n = Account_nonce.of_int 4321 in
+    let account_precondition : t =
+      Full
+        { Zkapp_precondition.Account.accept with
+          nonce = Check { lower = n; upper = n }
+        }
+    in
     let module Fd = Fields_derivers_zkapps.Derivers in
     let full = deriver (Fd.o ()) in
     [%test_eq: t] account_precondition

--- a/src/lib/mina_base/account_update.ml
+++ b/src/lib/mina_base/account_update.ml
@@ -1052,11 +1052,11 @@ module Account_precondition = struct
     [%test_eq: t] account_precondition
       (account_precondition |> Fd.to_json full |> Fd.of_json full)
 
-  let%test_unit "json roundtrip Full with ignore" =
+  let%test "json roundtrip Full with ignore" =
     let account_precondition = Full Zkapp_precondition.Account.accept in
     let module Fd = Fields_derivers_zkapps.Derivers in
     let full = deriver (Fd.o ()) in
-    [%test_eq: t] account_precondition
+    equal account_precondition
       (account_precondition |> Fd.to_json full |> Fd.of_json full)
 
   let%test_unit "json roundtrip nonce" =
@@ -1066,7 +1066,7 @@ module Account_precondition = struct
     [%test_eq: t] account_precondition
       (account_precondition |> Fd.to_json full |> Fd.of_json full)
 
-  let%test_unit "json roundtrip Full with nonce" =
+  let%test "json roundtrip Full with nonce" =
     let n = Account_nonce.of_int 4321 in
     let account_precondition : t =
       Full
@@ -1076,7 +1076,7 @@ module Account_precondition = struct
     in
     let module Fd = Fields_derivers_zkapps.Derivers in
     let full = deriver (Fd.o ()) in
-    [%test_eq: t] account_precondition
+    equal account_precondition
       (account_precondition |> Fd.to_json full |> Fd.of_json full)
 
   let%test_unit "json roundtrip full" =


### PR DESCRIPTION
Explain your changes:
This PR makes `Account_update.Account_precondition.equal` treats equivalence as equality. 

Explain how you tested your changes:
I added 2 unit tests that would fail without my changes.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
