### PR TITLE
[zkapp_command] Tests for the Zkapp_command.Verified module

### DIFF
--- a/src/lib/mina_base/test/zkapp_command/dune
+++ b/src/lib/mina_base/test/zkapp_command/dune
@@ -1,7 +1,6 @@
 (library
  (name zkapp_command_test)
  (modules call_forest fee_related transaction_commitments valid_size)
- (modules call_forest)
  (inline_tests)
  (library_flags -linkall)
  (flags -w -22)

--- a/src/lib/mina_base/test/zkapp_command/dune
+++ b/src/lib/mina_base/test/zkapp_command/dune
@@ -1,6 +1,7 @@
 (library
  (name zkapp_command_test)
- (modules fee_related transaction_commitments valid_size)
+ (modules call_forest fee_related transaction_commitments valid_size)
+ (modules call_forest)
  (inline_tests)
  (library_flags -linkall)
  (flags -w -22)
@@ -101,15 +102,15 @@
  (instrumentation
   (backend bisect_ppx)))
 
-(test
- (name nonce_related)
+(tests
+ (names nonce_related verifiable)
+ (modules nonce_related verifiable)
  (flags -w -22)
- (modules nonce_related)
  (libraries
   ;; opam libraries
+  alcotest
   async_kernel
   async_unix
-  alcotest
   result
   bin_prot.shape
   ppx_inline_test.config
@@ -126,6 +127,7 @@
   base_quickcheck.ppx_quickcheck
   core_kernel.uuid
   ;; local libraries
+  zkapp_command_test
   mina_wire_types
   run_in_thread
   kimchi_backend_common
@@ -172,8 +174,7 @@
   kimchi_backend
   hex
   snark_bits
-  ppx_version.runtime
-  zkapp_command_test)
+  ppx_version.runtime)
  (preprocessor_deps ../../../../config.mlh)
  (preprocess
   (pps

--- a/src/lib/mina_base/test/zkapp_command/verifiable.ml
+++ b/src/lib/mina_base/test/zkapp_command/verifiable.ml
@@ -1,67 +1,130 @@
 open Core_kernel
 open Signature_lib
 
-let call_forest_gen = Call_forest.gen
+let call_forest_gen = Zkapp_command_test.Call_forest.gen
 
 open Mina_base
 open Zkapp_command
 open Zkapp_command.Verifiable
 
-let%test_unit "check verifiable property" =
-  let find_vk _ _ = Or_error.error "" () Unit.sexp_of_t in
-  (* TODO: *)
-  let transaction_status_gen =
-    Quickcheck.Generator.of_list
-      [ Transaction_status.Applied; Transaction_status.Failed [] ]
+let check_verifiable_property () =
+  let find_vk _ _ =
+    Ok
+      { With_hash.data = Side_loaded_verification_key.dummy
+      ; hash =
+          Verification_key_wire.digest_vk Side_loaded_verification_key.dummy
+      }
   in
-  Quickcheck.test
-    (Quickcheck.Generator.tuple2 T.Stable.V1.Wire.gen transaction_status_gen)
-    ~f:(fun (cmd, status) ->
+  (* TODO: *)
+  let gen_authorization_kind account_id authorization =
+    let open Quickcheck.Generator.Let_syntax in
+    let vk_hash =
+      Verification_key_wire.digest_vk Side_loaded_verification_key.dummy
+    in
+    match authorization with
+    | Control.None_given ->
+        Quickcheck.Generator.return Account_update.Authorization_kind.None_given
+    | Proof p ->
+        Quickcheck.Generator.return
+          (Account_update.Authorization_kind.Proof vk_hash)
+    | Signature _ ->
+        Quickcheck.Generator.return Account_update.Authorization_kind.Signature
+  in
+  let gen_account_upd =
+    let open Quickcheck.Generator.Let_syntax in
+    let%bind body = Account_update.Body.gen
+    and authorization = Control.gen_with_dummies in
+    let account_upd = { Account_update.body; authorization } in
+    let%map authorization_kind =
+      gen_authorization_kind
+        (Account_update.account_id account_upd)
+        authorization
+    in
+    let body = { body with authorization_kind } in
+    { account_upd with body }
+  in
+  let gen_cmd =
+    let open Quickcheck.Generator in
+    let open Let_syntax in
+    let gen_call_forest =
+      fixed_point (fun self ->
+          let%bind calls_length = small_non_negative_int in
+          list_with_length calls_length
+            (let%map account_update = gen_account_upd and calls = self in
+             { With_stack_hash.stack_hash = ()
+             ; elt =
+                 { Call_forest.Tree.account_update
+                 ; account_update_digest = ()
+                 ; calls
+                 }
+             } ) )
+    in
+    let open Quickcheck.Let_syntax in
+    let%map fee_payer = Account_update.Fee_payer.gen
+    and account_updates = gen_call_forest
+    and memo = Signed_command_memo.gen in
+    { Zkapp_command.T.Stable.V1.Wire.fee_payer; account_updates; memo }
+  in
+  Quickcheck.test ~trials:100 gen_cmd ~f:(fun cmd ->
       let status = Transaction_status.Applied in
       let cmd = T.Stable.V1.of_wire cmd in
       match create cmd ~status ~find_vk with
       | Ok verifiable_cmd ->
-          let _, check_result =
+          let (_ : Verification_key_wire.t option Account_id.Map.t) =
             Call_forest.fold verifiable_cmd.account_updates
-              ~init:(Account_id.Map.empty, true)
-              ~f:(fun (vks_overridden, acc) (p, vk) ->
-                if not acc then (vks_overridden, false)
-                else
-                  let account_id = Account_update.account_id p in
-                  let vks_overridden' =
-                    match
-                      Account_update.verification_key_update_to_option p
-                    with
-                    | Zkapp_basic.Set_or_keep.Keep ->
-                        vks_overridden
-                    | Zkapp_basic.Set_or_keep.Set vk_next ->
-                        Account_id.Map.set vks_overridden ~key:account_id
-                          ~data:vk_next
-                  in
-                  let acc' =
-                    match (p.body.authorization_kind, vk) with
-                    | Proof _, None | (Signature | None_given), Some _ ->
-                        false
-                    | (Signature | None_given), None ->
-                        acc
-                    | Proof vk_hash, Some vk' -> (
-                        match Account_id.Map.find vks_overridden account_id with
-                        | Some (Some vk_overridden) ->
+              ~init:Account_id.Map.empty ~f:(fun vks_overridden (p, vk) ->
+                let account_id = Account_update.account_id p in
+                let vks_overridden' =
+                  match Account_update.verification_key_update_to_option p with
+                  | Zkapp_basic.Set_or_keep.Keep ->
+                      vks_overridden
+                  | Zkapp_basic.Set_or_keep.Set vk_next ->
+                      Account_id.Map.set vks_overridden ~key:account_id
+                        ~data:vk_next
+                in
+
+                let () =
+                  match (p.body.authorization_kind, vk) with
+                  | Proof _, None | (Signature | None_given), Some _ ->
+                      Alcotest.failf "Verification key update failed\n"
+                  | (Signature | None_given), None ->
+                      ()
+                  | Proof vk_hash, Some vk' -> (
+                      match Account_id.Map.find vks_overridden account_id with
+                      | Some (Some vk_overridden) ->
+                          if
                             Zkapp_basic.F.equal
                               (With_hash.hash vk_overridden)
                               vk_hash
                             && Zkapp_basic.F.equal (With_hash.hash vk') vk_hash
-                        | Some None ->
-                            false
-                        | None -> (
-                            match find_vk vk_hash account_id with
-                            | Ok ledger_vk ->
+                          then ()
+                          else Alcotest.failf "Verification key update failed\n"
+                      | Some None ->
+                          Alcotest.failf "Verification key update failed\n"
+                      | None -> (
+                          match find_vk vk_hash account_id with
+                          | Ok ledger_vk ->
+                              if
                                 Zkapp_basic.F.equal (With_hash.hash vk') vk_hash
-                            | Error _ ->
-                                false ) )
-                  in
-                  (vks_overridden', acc') )
+                              then ()
+                              else
+                                Alcotest.failf
+                                  "Verification key update failed\n"
+                          | Error _ ->
+                              Alcotest.failf "Verification key update failed\n"
+                          ) )
+                in
+                vks_overridden' )
           in
-          if not check_result then failwith "Verification key update failed"
-      | Error _ ->
-          () )
+          ()
+      | Error s ->
+          Alcotest.failf "Create failed. %s\n" @@ Error.to_string_hum s )
+
+let () =
+  let open Alcotest in
+  run "Zkapp command verifiable module" ~verbose:true
+    [ ( "verifiable property"
+      , [ test_case "check property after create" `Quick
+            check_verifiable_property
+        ] )
+    ]

--- a/src/lib/mina_base/test/zkapp_command/verifiable.ml
+++ b/src/lib/mina_base/test/zkapp_command/verifiable.ml
@@ -1,0 +1,67 @@
+open Core_kernel
+open Signature_lib
+
+let call_forest_gen = Call_forest.gen
+
+open Mina_base
+open Zkapp_command
+open Zkapp_command.Verifiable
+
+let%test_unit "check verifiable property" =
+  let find_vk _ _ = Or_error.error "" () Unit.sexp_of_t in
+  (* TODO: *)
+  let transaction_status_gen =
+    Quickcheck.Generator.of_list
+      [ Transaction_status.Applied; Transaction_status.Failed [] ]
+  in
+  Quickcheck.test
+    (Quickcheck.Generator.tuple2 T.Stable.V1.Wire.gen transaction_status_gen)
+    ~f:(fun (cmd, status) ->
+      let status = Transaction_status.Applied in
+      let cmd = T.Stable.V1.of_wire cmd in
+      match create cmd ~status ~find_vk with
+      | Ok verifiable_cmd ->
+          let _, check_result =
+            Call_forest.fold verifiable_cmd.account_updates
+              ~init:(Account_id.Map.empty, true)
+              ~f:(fun (vks_overridden, acc) (p, vk) ->
+                if not acc then (vks_overridden, false)
+                else
+                  let account_id = Account_update.account_id p in
+                  let vks_overridden' =
+                    match
+                      Account_update.verification_key_update_to_option p
+                    with
+                    | Zkapp_basic.Set_or_keep.Keep ->
+                        vks_overridden
+                    | Zkapp_basic.Set_or_keep.Set vk_next ->
+                        Account_id.Map.set vks_overridden ~key:account_id
+                          ~data:vk_next
+                  in
+                  let acc' =
+                    match (p.body.authorization_kind, vk) with
+                    | Proof _, None | (Signature | None_given), Some _ ->
+                        false
+                    | (Signature | None_given), None ->
+                        acc
+                    | Proof vk_hash, Some vk' -> (
+                        match Account_id.Map.find vks_overridden account_id with
+                        | Some (Some vk_overridden) ->
+                            Zkapp_basic.F.equal
+                              (With_hash.hash vk_overridden)
+                              vk_hash
+                            && Zkapp_basic.F.equal (With_hash.hash vk') vk_hash
+                        | Some None ->
+                            false
+                        | None -> (
+                            match find_vk vk_hash account_id with
+                            | Ok ledger_vk ->
+                                Zkapp_basic.F.equal (With_hash.hash vk') vk_hash
+                            | Error _ ->
+                                false ) )
+                  in
+                  (vks_overridden', acc') )
+          in
+          if not check_result then failwith "Verification key update failed"
+      | Error _ ->
+          () )


### PR DESCRIPTION
Adds a test to check the expected properties of the output of the `create` function in `Zkapp_command.Verified` module. 

Closes #12679