### PR TITLE
Add more tests to zkapp command logic

### DIFF
--- a/src/lib/mina_base/account_timing.ml
+++ b/src/lib/mina_base/account_timing.ml
@@ -67,7 +67,7 @@ module As_record = struct
     ; vesting_period : 'slot
     ; vesting_increment : 'amount
     }
-  [@@deriving hlist, fields, annot]
+  [@@deriving equal, hlist, fields, annot]
 
   let deriver obj =
     let open Fields_derivers_zkapps.Derivers in

--- a/src/lib/mina_base/account_timing.ml
+++ b/src/lib/mina_base/account_timing.ml
@@ -78,6 +78,13 @@ module As_record = struct
     |> finish "AccountTiming" ~t_toplevel_annots
 end
 
+type as_record =
+  ( bool
+  , Global_slot.Stable.V1.t
+  , Balance.Stable.V1.t
+  , Amount.Stable.V1.t )
+  As_record.t
+
 (* convert sum type to record format, useful for to_bits and typ *)
 let to_record t =
   match t with
@@ -123,6 +130,17 @@ let of_record
       ; cliff_amount
       ; vesting_period
       ; vesting_increment
+      }
+  else Untimed
+
+let of_record (r : as_record) : t =
+  if r.is_timed then
+    Timed
+      { initial_minimum_balance = r.initial_minimum_balance
+      ; cliff_time = r.cliff_time
+      ; cliff_amount = r.cliff_amount
+      ; vesting_period = r.vesting_period
+      ; vesting_increment = r.vesting_increment
       }
   else Untimed
 

--- a/src/lib/mina_base/zkapp_account.ml
+++ b/src/lib/mina_base/zkapp_account.ml
@@ -497,8 +497,7 @@ let gen : t Quickcheck.Generator.t =
   { app_state
   ; verification_key = None
   ; zkapp_version
-  ; action_state =
-      Pickles_types.(Vector.of_list_and_length_exn seq_state five)
+  ; action_state = Pickles_types.(Vector.of_list_and_length_exn seq_state five)
   ; last_action_slot = Mina_numbers.Global_slot.zero
   ; proved_state = false
   ; zkapp_uri

--- a/src/lib/mina_base/zkapp_account.ml
+++ b/src/lib/mina_base/zkapp_account.ml
@@ -18,6 +18,10 @@ module Event = struct
     Random_oracle.Checked.hash ~init:Hash_prefix_states.zkapp_event x
 
   [%%endif]
+
+  let gen : t Quickcheck.Generator.t =
+    let open Quickcheck in
+    Generator.map ~f:Array.of_list @@ Generator.list Field.gen
 end
 
 module Make_events (Inputs : sig
@@ -468,3 +472,34 @@ let deriver obj =
        ~zkapp_version:!.uint32 ~action_state:!.action_state_deriver
        ~last_action_slot:!.global_slot ~proved_state:!.bool ~zkapp_uri:!.string
        obj
+
+let gen_uri =
+  let open Quickcheck in
+  let open Generator.Let_syntax in
+  let%bind parts =
+    String.gen_with_length 8 Char.gen_alphanum |> Generator.list_with_length 3
+  in
+  let%map domain = Generator.of_list [ "com"; "org"; "net"; "info" ] in
+  Printf.sprintf "https://%s.%s" (String.concat ~sep:"." parts) domain
+
+let gen : t Quickcheck.Generator.t =
+  let open Quickcheck in
+  let open Generator.Let_syntax in
+  let app_state =
+    Pickles_types.Vector.init Zkapp_state.Max_state_size.n ~f:(fun _ ->
+        F.random () )
+  in
+  let%bind zkapp_version = Mina_numbers.Zkapp_version.gen in
+  let%bind seq_state = Generator.list_with_length 5 Field.gen in
+  let%bind last_sequence_slot = Mina_numbers.Global_slot.gen in
+  let%map zkapp_uri = gen_uri in
+  let five = Pickles_types.Nat.(S (S (S (S (S Z))))) in
+  { app_state
+  ; verification_key = None
+  ; zkapp_version
+  ; action_state =
+      Pickles_types.(Vector.of_list_and_length_exn seq_state five)
+  ; last_action_slot = Mina_numbers.Global_slot.zero
+  ; proved_state = false
+  ; zkapp_uri
+  }

--- a/src/lib/monad_lib/monad_lib.ml
+++ b/src/lib/monad_lib/monad_lib.ml
@@ -19,6 +19,12 @@ module Make_ext (M : Monad.S) = struct
         y :: acc )
     |> M.map ~f:List.rev
 
+  let concat_map_m ~f xs =
+    let open M.Let_syntax in
+    fold_m xs ~init:[] ~f:(fun acc x ->
+        let%map ys = f x in
+        List.append acc ys )
+
   let iter_m ~f xs = fold_m ~f:(fun () x -> f x) ~init:() xs
 end
 
@@ -39,6 +45,12 @@ module Make_ext2 (M : Monad.S2) = struct
         let%map y = f x in
         y :: acc )
     |> M.map ~f:List.rev
+
+  let concat_map_m ~f xs =
+    let open M.Let_syntax in
+    fold_m xs ~init:[] ~f:(fun acc x ->
+        let%map ys = f x in
+        List.append acc ys )
 
   let iter_m ~f xs = fold_m ~f:(fun () x -> f x) ~init:() xs
 end

--- a/src/lib/monad_lib/monad_lib.mli
+++ b/src/lib/monad_lib/monad_lib.mli
@@ -9,6 +9,8 @@ module Make_ext : functor (M : Monad.S) -> sig
 
   val map_m : f:('a -> 'b t) -> 'a list -> 'b list t
 
+  val concat_map_m : f:('a -> 'b list t) -> 'a list -> 'b list t
+
   val iter_m : f:('a -> unit t) -> 'a list -> unit t
 end
 
@@ -18,6 +20,8 @@ module Make_ext2 : functor (M : Monad.S2) -> sig
   val fold_m : f:('a -> 'b -> ('a, 'c) t) -> init:'a -> 'b list -> ('a, 'c) t
 
   val map_m : f:('a -> ('b, 'c) t) -> 'a list -> ('b list, 'c) t
+
+  val concat_map_m : f:('a -> ('b list, 'c) t) -> 'a list -> ('b list, 'c) t
 
   val iter_m : f:('a -> (unit, 'b) t) -> 'a list -> (unit, 'b) t
 end

--- a/src/lib/transaction_logic/test/dune
+++ b/src/lib/transaction_logic/test/dune
@@ -30,6 +30,7 @@
    pasta_bindings
    pickles
    pickles.backend
+   pickles_types
    random_oracle
    sgn
    sgn_type

--- a/src/lib/transaction_logic/test/helpers.ml
+++ b/src/lib/transaction_logic/test/helpers.ml
@@ -33,8 +33,8 @@ let test_ledger accounts =
   let%map () =
     R.iter_m accounts ~f:(fun a ->
         let acc_id = account_id a in
-        let account = Account.initialize acc_id in
+        let account : Account.t = Account.initialize acc_id in
         Ledger.create_new_account ledger acc_id
-          { account with balance = a.balance; nonce = a.nonce } )
+          { account with balance = a.balance; nonce = a.nonce; zkapp = a.zkapp } )
   in
   ledger

--- a/src/lib/transaction_logic/test/predicates.ml
+++ b/src/lib/transaction_logic/test/predicates.ml
@@ -43,13 +43,15 @@ let verify_account_updates ~(ledger : Helpers.Ledger.t)
     Call_forest.fold txn.command.data.account_updates ~init:Amount.Signed.zero
       ~f:(fun acc upd ->
         if Public_key.Compressed.equal account.pk upd.body.public_key then
-          Option.value_exn @@ Amount.Signed.add acc upd.body.balance_change
+          let open Amount.Signed in
+          Option.value ~default:zero @@ add acc upd.body.balance_change
         else acc )
   in
   let balance_change =
     Amount.Signed.(balance_updates + fee) |> Option.value_exn
   in
   f balance_change (outdated, updated)
+  
 
 let add_to_balance balance amount =
   let open Option.Let_syntax in
@@ -76,3 +78,29 @@ let verify_balance_changes ~txn ~ledger accounts =
              verify_balance_change ~balance_change orig updt
          | _ ->
              false ) )
+
+let verify_balances_unchanged ~(ledger : Helpers.Ledger.t)
+    ~(txn :
+       Helpers.Transaction_logic.Transaction_applied.Zkapp_command_applied.t )
+    (accounts : Test_account.t list) =
+  let is_fee_payer account =
+    Public_key.Compressed.equal account.Test_account.pk txn.command.data.fee_payer.body.public_key
+  in
+  let fee =
+    let open Amount in
+    of_fee txn.command.data.fee_payer.body.fee
+    |> Signed.of_unsigned |> Signed.negate
+  in
+  List.for_all accounts ~f:(fun account ->
+      verify_account_updates account ~ledger ~txn ~f:(fun _amt -> function
+          | (Some orig, Some updt) when is_fee_payer account ->
+             add_to_balance orig.balance fee 
+             |> Option.value_map
+                  ~default:Balance.(equal updt.balance zero)
+                  ~f:(fun b -> Balance.equal updt.balance b)
+          | (Some orig, Some updt) ->
+             Balance.equal updt.balance orig.balance
+          | (None, None) ->
+             true
+          | _ -> (* Account could have been neither created or destroyed. *)
+             false))

--- a/src/lib/transaction_logic/test/test_account.ml
+++ b/src/lib/transaction_logic/test/test_account.ml
@@ -35,3 +35,9 @@ let gen_with_zkapp =
   let open Quickcheck.Generator.Let_syntax in
   let%map account = gen and zkapp = Zkapp_account.gen in
   { account with zkapp = Some zkapp }
+
+let gen_empty =
+  let open Quickcheck.Generator.Let_syntax in
+  let%bind pk = Public_key.Compressed.gen in
+  let%map nonce = Account_nonce.gen in
+  { pk; nonce; balance = Balance.zero; zkapp = None }

--- a/src/lib/transaction_logic/test/test_account.ml
+++ b/src/lib/transaction_logic/test/test_account.ml
@@ -31,7 +31,7 @@ let gen =
   let%map nonce = Account_nonce.gen in
   { pk; nonce; balance; zkapp = None }
 
-let gen_constrained_balance ?(min = Balance.zero) ?(max = Balance.max_int) ()=
+let gen_constrained_balance ?(min = Balance.zero) ?(max = Balance.max_int) () =
   let open Quickcheck.Generator.Let_syntax in
   let%bind pk = Public_key.Compressed.gen in
   let%bind balance = Balance.gen_incl min max in

--- a/src/lib/transaction_logic/test/test_account.ml
+++ b/src/lib/transaction_logic/test/test_account.ml
@@ -31,6 +31,13 @@ let gen =
   let%map nonce = Account_nonce.gen in
   { pk; nonce; balance; zkapp = None }
 
+let gen_constrained_balance ?(min = Balance.zero) ?(max = Balance.max_int) ()=
+  let open Quickcheck.Generator.Let_syntax in
+  let%bind pk = Public_key.Compressed.gen in
+  let%bind balance = Balance.gen_incl min max in
+  let%map nonce = Account_nonce.gen in
+  { pk; balance; nonce; zkapp = None }
+
 let gen_with_zkapp =
   let open Quickcheck.Generator.Let_syntax in
   let%map account = gen and zkapp = Zkapp_account.gen in

--- a/src/lib/transaction_logic/test/test_account.ml
+++ b/src/lib/transaction_logic/test/test_account.ml
@@ -5,14 +5,19 @@ open Mina_numbers
 open Signature_lib
 
 type t =
-  { pk : Public_key.Compressed.t; nonce : Account_nonce.t; balance : Balance.t }
+  { pk : Public_key.Compressed.t
+  ; nonce : Account_nonce.t
+  ; balance : Balance.t
+  ; zkapp : Zkapp_account.t option
+  }
 [@@deriving equal]
 
-let make ?nonce ?(balance = Balance.zero) pk =
+let make ?zkapp ?nonce ?(balance = Balance.zero) pk =
   { pk = Public_key.Compressed.of_base58_check_exn pk
   ; balance
   ; nonce =
       Option.value_map ~f:Account_nonce.of_int ~default:Account_nonce.zero nonce
+  ; zkapp
   }
 
 let non_empty { balance; _ } = Balance.(balance > zero)
@@ -24,4 +29,9 @@ let gen =
   let%bind pk = Public_key.Compressed.gen in
   let%bind balance = Balance.gen in
   let%map nonce = Account_nonce.gen in
-  { pk; nonce; balance }
+  { pk; nonce; balance; zkapp = None }
+
+let gen_with_zkapp =
+  let open Quickcheck.Generator.Let_syntax in
+  let%map account = gen and zkapp = Zkapp_account.gen in
+  { account with zkapp = Some zkapp }


### PR DESCRIPTION
Explain your changes:
* Add more unit tests to zkapp command logic.
* These tests exercise the function, which applies zkApp commands to a ledger. They verify important properties, like the order in which updates are applied, in what ways they change the accounts in the ledger and what are failure conditions for different types of updates.

Explain how you tested your changes:
* The CI runs these tests.
- [x] Make sure the tests are actually being run in the CI.

Checklist:

- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #12530 
