### PR TITLE
Change shebang for MF CI compatibility

### DIFF
--- a/buildkite/scripts/generate-diff.sh
+++ b/buildkite/scripts/generate-diff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Base against origin/compatible by default, but use pull-request base otherwise
 BASE=${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-compatible}


### PR DESCRIPTION
The MF CI OS (NixOS) doesn't use /bin/bash