### PR TITLE
lk86/push-daemon-images Print debian releases

### DIFF
--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -135,11 +135,13 @@ if [[ -z "$NOUPLOAD" ]] || [[ "$NOUPLOAD" -eq 0 ]]; then
   docker tag "${TAG}" "${HASHTAG}"
   docker push "${HASHTAG}"
 
-  echo "Release Env Var: \'${DEB_RELEASE}\'"
+  echo "Release Env Var: ${DEB_RELEASE}"
   echo "Release: ${DEB_RELEASE##*=}"
 
-  if [[ "${DEB_RELEASE##*=}" = "stable" ]]; then
-
+  if [[ "${DEB_RELEASE##*=}" = "unstable" ]]; then
+    echo "Release is unstable: not pushing to docker hub"
+  else
+    echo "Release is public (alpha, beta, berkeley, or stable): pushing image to docker hub"
     # tag and push to dockerhub
     docker tag "${TAG}" "minaprotocol/${SERVICE}:${VERSION}"
     docker push "minaprotocol/${SERVICE}:${VERSION}"

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -135,7 +135,10 @@ if [[ -z "$NOUPLOAD" ]] || [[ "$NOUPLOAD" -eq 0 ]]; then
   docker tag "${TAG}" "${HASHTAG}"
   docker push "${HASHTAG}"
 
-  if [[ "${DEB_RELEASE##*=}" = 'stable' ]]; then
+  echo "Release Env Var: \'${DEB_RELEASE}\'"
+  echo "Release: ${DEB_RELEASE##*=}"
+
+  if [[ "${DEB_RELEASE##*=}" = "stable" ]]; then
 
     # tag and push to dockerhub
     docker tag "${TAG}" "minaprotocol/${SERVICE}:${VERSION}"


### PR DESCRIPTION
Fixes an issue in the logic to push images to docker hub, changing from "only publish stable builds" to "don't publish unstable builds", which now means alpha and beta and rampup and whatever other tagged releases will end up on docker hub like they always have.