### PR TITLE
Fix bootstrap error- did not connect with snarked fee payment ledger hash

### DIFF
--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2572,13 +2572,21 @@ let%test_module "staged ledger tests" =
                 Ledger.Maskable.register_mask casted
                   (Ledger.Mask.create ~depth:(Ledger.depth snarked_ledger) ())
               in
-              let%map _first_pass_ledger_target =
-                Scan_state.get_staged_ledger_async
-                  ~async_batch_size:transaction_application_scheduler_batch_size
-                  ~ledger:sl_of_snarked_ledger ~get_protocol_state:get_state
-                  ~apply_first_pass ~apply_second_pass
-                  ~apply_first_pass_sparse_ledger !sl.scan_state
+              let expected_staged_ledger_merkle_root =
+                Ledger.merkle_root !sl.ledger
               in
+              let%map construction_result =
+                Sl.of_scan_state_pending_coinbases_and_snarked_ledger ~logger
+                  ~snarked_local_state:
+                    Mina_state.(
+                      Protocol_state.blockchain_state current_state
+                      |> Blockchain_state.snarked_local_state)
+                  ~verifier ~constraint_constants ~scan_state:!sl.scan_state
+                  ~snarked_ledger:sl_of_snarked_ledger
+                  ~expected_merkle_root:expected_staged_ledger_merkle_root
+                  ~pending_coinbases:!sl.pending_coinbase_collection ~get_state
+              in
+              let _result = Or_error.ok_exn construction_result in
               [%test_eq: Ledger_hash.t]
                 (Ledger.merkle_root sl_of_snarked_ledger)
                 (Ledger.merkle_root !sl.ledger) ;

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -895,7 +895,7 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
   let rec apply_txns_first_pass ?(acc = []) ~k txns =
     match txns with
     | [] ->
-        k (List.rev acc)
+        k (Ledger.merkle_root ledger) (List.rev acc)
     | txn :: txns' ->
         let transaction, state_hash, block_global_slot =
           extract_txn_and_global_slot txn
@@ -1033,7 +1033,8 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
         apply_txns_second_pass partially_applied_txns ~k
   in
   let rec apply_txns (previous_incomplete : Previous_incomplete_txns.t)
-      (ordered_txns : _ Transactions_ordered.Poly.t list) =
+      (ordered_txns : _ Transactions_ordered.Poly.t list)
+      ~first_pass_ledger_hash =
     let previous_incomplete =
       (*filter out any non-zkapp transactions for second pass application*)
       match previous_incomplete with
@@ -1057,18 +1058,18 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
     match ordered_txns with
     | [] ->
         apply_previous_incomplete_txns previous_incomplete ~k:(fun () ->
-            Ok (`Complete (Ledger.merkle_root ledger)) )
+            Ok (`Complete first_pass_ledger_hash) )
     | [ txns_per_block ] when stop_at_first_pass ->
         (*Last block; don't apply second pass. This is for snarked ledgers which are first pass ledgers*)
         apply_txns_first_pass txns_per_block.first_pass
-          ~k:(fun _partially_applied_txns ->
+          ~k:(fun first_pass_ledger_hash _partially_applied_txns ->
             (*Apply second pass of previous tree's transactions, if any*)
             apply_previous_incomplete_txns previous_incomplete ~k:(fun () ->
-                apply_txns (Unapplied []) [] ) )
+                apply_txns (Unapplied []) [] ~first_pass_ledger_hash ) )
     | txns_per_block :: ordered_txns' ->
         (*Apply first pass of a blocks transactions either new or continued from previous tree*)
         apply_txns_first_pass txns_per_block.first_pass
-          ~k:(fun partially_applied_txns ->
+          ~k:(fun first_pass_ledger_hash partially_applied_txns ->
             (*Apply second pass of previous tree's transactions, if any*)
             apply_previous_incomplete_txns previous_incomplete ~k:(fun () ->
                 let continue_previous_tree's_txns =
@@ -1090,11 +1091,12 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
                 in
                 if do_second_pass then
                   apply_txns_second_pass partially_applied_txns ~k:(fun () ->
-                      apply_txns (Unapplied []) ordered_txns' )
+                      apply_txns (Unapplied []) ordered_txns'
+                        ~first_pass_ledger_hash )
                 else
                   (*Transactions not completed in this tree, so second pass after first pass of remaining transactions for the same block in the next tree*)
                   apply_txns (Partially_applied partially_applied_txns)
-                    ordered_txns' ) )
+                    ordered_txns' ~first_pass_ledger_hash ) )
   in
   let previous_incomplete =
     Option.value_map (List.hd ordered_txns)
@@ -1102,7 +1104,10 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
       ~f:(fun (first_block : Transactions_ordered.t) ->
         Unapplied first_block.previous_incomplete )
   in
-  apply_txns previous_incomplete ordered_txns
+  (*Assuming this function is called on snarked ledger and snarked ledger is the
+    first pass ledger*)
+  let first_pass_ledger_hash = Ledger.merkle_root ledger in
+  apply_txns previous_incomplete ordered_txns ~first_pass_ledger_hash
 
 let apply_ordered_txns_sync ?stop_at_first_pass ordered_txns ~ledger
     ~get_protocol_state ~apply_first_pass ~apply_second_pass


### PR DESCRIPTION
The final first pass ledger hash returned when getting staged ledger from snarked ledger during bootstrap was incorrect.

Updated staged ledger tests to execute `of_scan_state_pending_coinbases_and_snarked_ledger` which is called during boostrap

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
