### PR TITLE
Log the monitor stack for long async jobs

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -986,8 +986,11 @@ let setup_daemon logger =
             in
             let monitors = get_monitors [ monitor ] monitor in
             List.map monitors ~f:(fun monitor ->
-                Async_kernel.Monitor.sexp_of_t monitor
-                |> Error_json.sexp_record_to_yojson )
+                match Async_kernel.Monitor.sexp_of_t monitor with
+                | Sexp.List sexps ->
+                    `List (List.map ~f:Error_json.sexp_record_to_yojson sexps)
+                | Sexp.Atom _ ->
+                    failwith "Expeted a sexp list" )
           in
           Stream.iter
             (Async_kernel.Async_kernel_scheduler.long_cycles_with_context

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -976,24 +976,25 @@ let setup_daemon logger =
             | None, None ->
                 client_trustlist
           in
+          let get_monitor_infos monitor =
+            let rec get_monitors accum monitor =
+              match Async_kernel.Monitor.parent monitor with
+              | None ->
+                  List.rev accum
+              | Some parent ->
+                  get_monitors (parent :: accum) parent
+            in
+            let monitors = get_monitors [ monitor ] monitor in
+            List.map monitors ~f:(fun monitor ->
+                Async_kernel.Monitor.sexp_of_t monitor
+                |> Error_json.sexp_to_yojson )
+          in
           Stream.iter
             (Async_kernel.Async_kernel_scheduler.long_cycles_with_context
                ~at_least:(sec 0.5 |> Time_ns.Span.of_span_float_round_nearest) )
             ~f:(fun (span, context) ->
               let secs = Time_ns.Span.to_sec span in
-              let rec get_monitors accum monitor =
-                match Async_kernel.Monitor.parent monitor with
-                | None ->
-                    List.rev accum
-                | Some parent ->
-                    get_monitors (parent :: accum) parent
-              in
-              let monitors = get_monitors [ context.monitor ] context.monitor in
-              let monitor_infos =
-                List.map monitors ~f:(fun monitor ->
-                    Async_kernel.Monitor.sexp_of_t monitor
-                    |> Error_json.sexp_to_yojson )
-              in
+              let monitor_infos = get_monitor_infos context.monitor in
               [%log debug]
                 ~metadata:
                   [ ("long_async_cycle", `Float secs)
@@ -1006,9 +1007,11 @@ let setup_daemon logger =
           Stream.iter Async_kernel.Async_kernel_scheduler.long_jobs_with_context
             ~f:(fun (context, span) ->
               let secs = Time_ns.Span.to_sec span in
+              let monitor_infos = get_monitor_infos context.monitor in
               [%log debug]
                 ~metadata:
                   [ ("long_async_job", `Float secs)
+                  ; ("monitors", `List monitor_infos)
                   ; ( "most_recent_2_backtrace"
                     , `String
                         (String.concat ~sep:"␤"

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -987,7 +987,7 @@ let setup_daemon logger =
             let monitors = get_monitors [ monitor ] monitor in
             List.map monitors ~f:(fun monitor ->
                 Async_kernel.Monitor.sexp_of_t monitor
-                |> Error_json.sexp_to_yojson )
+                |> Error_json.sexp_record_to_yojson )
           in
           Stream.iter
             (Async_kernel.Async_kernel_scheduler.long_cycles_with_context

--- a/src/lib/error_json/error_json.ml
+++ b/src/lib/error_json/error_json.ml
@@ -7,6 +7,23 @@ let rec sexp_to_yojson (sexp : Sexp.t) : Yojson.Safe.t =
   | List sexps ->
       `List (List.map ~f:sexp_to_yojson sexps)
 
+let sexp_record_to_yojson (sexp : Sexp.t) : Yojson.Safe.t =
+  let fail () =
+    failwith
+      "sexp_record_to_yojson called on an s-expression with a non-record \
+       structure"
+  in
+  match sexp with
+  | Atom _ ->
+      fail ()
+  | List fields ->
+      `Assoc
+        (List.map fields ~f:(function
+          | List [ Atom label; value ] ->
+              (label, sexp_to_yojson value)
+          | _ ->
+              fail () ) )
+
 let rec sexp_of_yojson (json : Yojson.Safe.t) : (Sexp.t, string) Result.t =
   match json with
   | `String str ->


### PR DESCRIPTION
This PR adds logging for the async monitor stack, to help track the source of long async jobs.

This also tweaks the JSON printing to be more legible in the logs.

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them