### PR TITLE
Demote network pool batch size logs to debug

### DIFF
--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -271,7 +271,7 @@ module Transaction_pool = struct
   let create verifier : t =
     let logger = Logger.create () in
     create ~compare_init:compare_envelope ~logger (fun (ds : input list) ->
-        [%log info]
+        [%log debug]
           "Dispatching $num_proofs transaction pool proofs to verifier"
           ~metadata:[ ("num_proofs", `Int (List.length ds)) ] ;
         let open Deferred.Or_error.Let_syntax in
@@ -367,7 +367,7 @@ module Snark_pool = struct
            (Sys.getenv_opt "MAX_VERIFIER_BATCH_SIZE") )
       ~compare_init:compare_envelope ~logger
       (fun ps0 ->
-        [%log info] "Dispatching $num_proofs snark pool proofs to verifier"
+        [%log debug] "Dispatching $num_proofs snark pool proofs to verifier"
           ~metadata:[ ("num_proofs", `Int (List.length ps0)) ] ;
         let ps =
           List.concat_map ps0 ~f:(function


### PR DESCRIPTION
As requested by @lk86, this PR demotes the noisy network pool batcher logs from `info` to `debug`, to help clean up the daemon log output.


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them