### PR TITLE
Support graphql control port in uptime backend

### DIFF
--- a/src/app/delegation_backend/src/constants.go
+++ b/src/app/delegation_backend/src/constants.go
@@ -21,8 +21,8 @@ const TEST_WHITELIST_SPREADSHEET_ID = "1NODwwcVxLNnCI4XnIrGdGBSjointN4MZ8QZ7wqgt
 const TEST_CLOUD_BUCKET_NAME = "georgeee-uptime-itn-test-1"
 
 // Incentivized testnet
-const ITN_WHITELIST_SPREADSHEET_ID = "<todo>"
-const ITN_CLOUD_BUCKET_NAME = "<todo>"
+const ITN_WHITELIST_SPREADSHEET_ID = "13ljZysTrRINd-pBz70SnSPBJ817fGJ0ETOcjHMppXow"
+const ITN_CLOUD_BUCKET_NAME = "georgeee-uptime-itn-test-2"
 
 func CloudBucketName() string {
 	if os.Getenv("TEST") == "" {

--- a/src/app/delegation_backend/src/constants.go
+++ b/src/app/delegation_backend/src/constants.go
@@ -18,10 +18,17 @@ const PROD_WHITELIST_SPREADSHEET_ID = "1xiKppb0BFUo8IKM2itIx2EWIQbBzUlFxgtZlKdnr
 const PROD_CLOUD_BUCKET_NAME = "foundation-delegation-uptime"
 
 const TEST_WHITELIST_SPREADSHEET_ID = "1NODwwcVxLNnCI4XnIrGdGBSjointN4MZ8QZ7wqgtSTQ"
-const TEST_CLOUD_BUCKET_NAME = "georgeee-delegation-test-1"
+const TEST_CLOUD_BUCKET_NAME = "georgeee-uptime-itn-test-1"
+
+// Incentivized testnet
+const ITN_WHITELIST_SPREADSHEET_ID = "<todo>"
+const ITN_CLOUD_BUCKET_NAME = "<todo>"
 
 func CloudBucketName() string {
 	if os.Getenv("TEST") == "" {
+		if os.Getenv("NETWORK") == "ITN" {
+			return ITN_CLOUD_BUCKET_NAME
+		}
 		return PROD_CLOUD_BUCKET_NAME
 	} else {
 		return TEST_CLOUD_BUCKET_NAME
@@ -30,17 +37,25 @@ func CloudBucketName() string {
 
 func WhitelistSpreadsheetId() string {
 	if os.Getenv("TEST") == "" {
+		if os.Getenv("NETWORK") == "ITN" {
+			return ITN_WHITELIST_SPREADSHEET_ID
+		}
 		return PROD_WHITELIST_SPREADSHEET_ID
-	} else {
-		return TEST_WHITELIST_SPREADSHEET_ID
 	}
+	return TEST_WHITELIST_SPREADSHEET_ID
 }
 
 var PK_PREFIX = [...]byte{1, 1}
 var SIG_PREFIX = [...]byte{1}
 var BLOCK_HASH_PREFIX = [...]byte{1}
 
-const NETWORK_ID = 1  // mainnet
+func NetworkId() uint8 {
+	if os.Getenv("NETWORK") == "" {
+		return 1
+	}
+	return 0
+}
+
 const PK_LENGTH = 33  // one field element (32B) + 1 bit (encoded as full byte)
 const SIG_LENGTH = 64 // one field element (32B) and one scalar (32B)
 

--- a/src/app/delegation_backend/src/data.go
+++ b/src/app/delegation_backend/src/data.go
@@ -128,10 +128,11 @@ func (boe *BufferOrError) Write(b []byte) {
 }
 
 type submitRequestData struct {
-	PeerId    string    `json:"peer_id"`
-	Block     *Base64   `json:"block"`
-	SnarkWork *Base64   `json:"snark_work,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	PeerId             string    `json:"peer_id"`
+	Block              *Base64   `json:"block"`
+	SnarkWork          *Base64   `json:"snark_work,omitempty"`
+	GraphqlControlPort uint16    `json:"graphql_control_port,omitempty"`
+	CreatedAt          time.Time `json:"created_at"`
 }
 type submitRequest struct {
 	Data      submitRequestData `json:"data"`
@@ -139,10 +140,11 @@ type submitRequest struct {
 	Sig       Sig               `json:"signature"`
 }
 type MetaToBeSaved struct {
-	CreatedAt  string  `json:"created_at"`
-	PeerId     string  `json:"peer_id"`
-	SnarkWork  *Base64 `json:"snark_work,omitempty"`
-	RemoteAddr string  `json:"remote_addr"`
-	Submitter  Pk      `json:"submitter"`  // is base58check-encoded submitter's public key
-	BlockHash  string  `json:"block_hash"` // is base58check-encoded hash of a block
+	CreatedAt          string  `json:"created_at"`
+	PeerId             string  `json:"peer_id"`
+	SnarkWork          *Base64 `json:"snark_work,omitempty"`
+	GraphqlControlPort uint16  `json:"graphql_control_port,omitempty"`
+	RemoteAddr         string  `json:"remote_addr"`
+	Submitter          Pk      `json:"submitter"`  // is base58check-encoded submitter's public key
+	BlockHash          string  `json:"block_hash"` // is base58check-encoded hash of a block
 }

--- a/src/app/delegation_backend/src/submit.go
+++ b/src/app/delegation_backend/src/submit.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -20,6 +21,7 @@ type errorResponse struct {
 }
 
 func writeErrorResponse(app *App, w *http.ResponseWriter, msg string) {
+	app.Log.Debugf("Responding with error: %s", msg)
 	bs, err := json.Marshal(errorResponse{msg})
 	if err == nil {
 		_, err2 := io.Copy(*w, bytes.NewReader(bs))
@@ -98,6 +100,10 @@ func makeSignPayload(req *submitRequestData) ([]byte, error) {
 		signPayload.WriteString(",\"snark_work\":")
 		signPayload.Write(req.SnarkWork.json)
 	}
+	if req.GraphqlControlPort != 0 {
+		signPayload.WriteString(",\"graphql_control_port\":")
+		signPayload.WriteString(fmt.Sprintf("%d", req.GraphqlControlPort))
+	}
 	signPayload.WriteString("}")
 	return signPayload.Buf.Bytes(), signPayload.Err
 }
@@ -159,7 +165,7 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	hash := blake2b.Sum256(payload)
-	if !verifySig(&req.Submitter, &req.Sig, hash[:], NETWORK_ID) {
+	if !verifySig(&req.Submitter, &req.Sig, hash[:], NetworkId()) {
 		w.WriteHeader(401)
 		writeErrorResponse(h.app, &w, "Invalid signature")
 		return
@@ -175,12 +181,13 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ps, blockHash := makePaths(submittedAt, &req)
 
 	meta := MetaToBeSaved{
-		CreatedAt:  req.Data.CreatedAt.Format(time.RFC3339),
-		PeerId:     req.Data.PeerId,
-		SnarkWork:  req.Data.SnarkWork,
-		RemoteAddr: r.RemoteAddr,
-		BlockHash:  blockHash,
-		Submitter:  req.Submitter,
+		CreatedAt:          req.Data.CreatedAt.Format(time.RFC3339),
+		PeerId:             req.Data.PeerId,
+		SnarkWork:          req.Data.SnarkWork,
+		RemoteAddr:         r.RemoteAddr,
+		BlockHash:          blockHash,
+		Submitter:          req.Submitter,
+		GraphqlControlPort: req.Data.GraphqlControlPort,
 	}
 
 	metaBytes, err1 := json.Marshal(meta)


### PR DESCRIPTION
Update uptime service backend with graphql control port.

Explain your changes:
* Update `constants.go` with new test bucket
* Support non-mainnet network (via setting a `NETWORK` environment variable)
* Support graphql control port in JSON payload and save it to bucket

Explain how you tested your changes:
* Manual testing of a Mina node from #12828 together with the uptime service

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #12825 
