### PR TITLE
Internal tracing for prover and verifier (internal tracing PR 2 of 3)

### DIFF
--- a/src/app/archive/lib/test.ml
+++ b/src/app/archive/lib/test.ml
@@ -20,7 +20,8 @@ let%test_module "Archive node unit tests" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     module Genesis_ledger = (val Genesis_ledger.for_unit_tests)
 

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1707,7 +1707,7 @@ let internal_commands logger =
               ~proof_level:Genesis_constants.Proof_level.compiled
               ~constraint_constants:
                 Genesis_constants.Constraint_constants.compiled
-              ~pids:(Pid.Table.create ()) ~conf_dir:(Some conf_dir)
+              ~pids:(Pid.Table.create ()) ~conf_dir:(Some conf_dir) ()
           in
           let%bind result =
             match input with

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1151,8 +1151,11 @@ let setup_daemon logger =
               ~default:Cli_lib.Default.stop_time stop_time
           in
           if enable_tracing then Mina_tracing.start conf_dir |> don't_wait_for ;
-          if enable_internal_tracing then
-            Internal_tracing.toggle ~logger `Enabled ;
+          let%bind () =
+            if enable_internal_tracing then
+              Internal_tracing.toggle ~logger `Enabled
+            else Deferred.unit
+          in
           let seed_peer_list_url =
             Option.value_map seed_peer_list_url ~f:Option.some
               ~default:

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1609,7 +1609,7 @@ let internal_commands logger =
                      ~proof_level:Genesis_constants.Proof_level.compiled
                      ~constraint_constants:
                        Genesis_constants.Constraint_constants.compiled
-                     ~pids:(Pid.Table.create ()) ~conf_dir
+                     ~pids:(Pid.Table.create ()) ~conf_dir ()
                  in
                  Prover.prove_from_input_sexp prover sexp >>| ignore
              | `Eof ->

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -382,11 +382,9 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
     ; implement Daemon_rpcs.Stop_tracing.rpc (fun () () ->
           Mina_tracing.stop () ; Deferred.unit )
     ; implement Daemon_rpcs.Start_internal_tracing.rpc (fun () () ->
-          Internal_tracing.toggle ~logger `Enabled ;
-          Deferred.unit )
+          Internal_tracing.toggle ~logger `Enabled )
     ; implement Daemon_rpcs.Stop_internal_tracing.rpc (fun () () ->
-          Internal_tracing.toggle ~logger `Disabled ;
-          Deferred.unit )
+          Internal_tracing.toggle ~logger `Disabled )
     ; implement Daemon_rpcs.Visualization.Frontier.rpc (fun () filename ->
           return (Mina_lib.visualize_frontier ~filename mina) )
     ; implement Daemon_rpcs.Visualization.Registered_masks.rpc

--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -16,7 +16,8 @@ let run ~user_command_profiler ~zkapp_profiler num_transactions ~max_num_updates
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
     in
     let rec go n =
       if n <= 0 then ()

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -693,7 +693,8 @@ let%test_module "Bootstrap_controller tests" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     module Genesis_ledger = (val precomputed_values.genesis_ledger)
 

--- a/src/lib/crypto/kimchi_backend/common/dune
+++ b/src/lib/crypto/kimchi_backend/common/dune
@@ -39,6 +39,8 @@
   allocation_functor
   snarky.intf
   promise
+  logger
+  internal_tracing.context_logger
   ppx_version.runtime))
 
 (rule

--- a/src/lib/internal_tracing/context_call/dune
+++ b/src/lib/internal_tracing/context_call/dune
@@ -1,0 +1,16 @@
+(library
+ (name internal_tracing_context_call)
+ (public_name internal_tracing.context_call)
+ (library_flags -linkall)
+ (inline_tests)
+ (libraries
+  ;; opam libraries
+  base.base_internalhash_types
+  core_kernel
+  sexplib0
+  async_kernel)
+ (preprocess
+  (pps ppx_jane ppx_mina ppx_version ppx_deriving_yojson))
+ (instrumentation
+  (backend bisect_ppx))
+ (synopsis "Internal tracing context call ID helper"))

--- a/src/lib/internal_tracing/context_call/internal_tracing_context_call.ml
+++ b/src/lib/internal_tracing/context_call/internal_tracing_context_call.ml
@@ -1,0 +1,13 @@
+open Core_kernel
+
+let last_call_id = ref 0
+
+let key = Univ_map.Key.create ~name:"call_id" sexp_of_int
+
+let with_call_id f =
+  incr last_call_id ;
+  Async_kernel.Async_kernel_scheduler.with_local key (Some !last_call_id) ~f
+
+let get_opt () = Async_kernel.Async_kernel_scheduler.find_local key
+
+let get () = Option.value (get_opt ()) ~default:0

--- a/src/lib/internal_tracing/context_call/internal_tracing_context_call.mli
+++ b/src/lib/internal_tracing/context_call/internal_tracing_context_call.mli
@@ -1,0 +1,12 @@
+(** Helper module for setting the execution context call ID.
+
+    Useful for being able to detect context switches when
+    there are concurrent verifier/prover calls. *)
+
+(** [with_call_id f] runs [f] in a context in which
+    an unique identifier has been associated to the current call. *)
+val with_call_id : (unit -> 'a) -> 'a
+
+(** [get ()] returns current call ID bound to the current context (if any),
+    or 0 *)
+val get : unit -> int

--- a/src/lib/internal_tracing/context_logger/dune
+++ b/src/lib/internal_tracing/context_logger/dune
@@ -1,0 +1,18 @@
+(library
+ (name internal_tracing_context_logger)
+ (public_name internal_tracing.context_logger)
+ (library_flags -linkall)
+ (inline_tests)
+ (libraries
+  ;; opam libraries
+  base.base_internalhash_types
+  core_kernel
+  sexplib0
+  async_kernel
+  ;; local libraries
+  logger)
+ (preprocess
+  (pps ppx_jane ppx_mina ppx_version ppx_deriving_yojson))
+ (instrumentation
+  (backend bisect_ppx))
+ (synopsis "Internal tracing context logger helper"))

--- a/src/lib/internal_tracing/context_logger/internal_tracing_context_logger.ml
+++ b/src/lib/internal_tracing/context_logger/internal_tracing_context_logger.ml
@@ -1,0 +1,10 @@
+open Core_kernel
+
+let key = Univ_map.Key.create ~name:"logger" sexp_of_opaque
+
+let with_logger logger f =
+  Async_kernel.Async_kernel_scheduler.with_local key logger ~f
+
+let get_opt () = Async_kernel.Async_kernel_scheduler.find_local key
+
+let get () = Option.value (get_opt ()) ~default:(Logger.null ())

--- a/src/lib/internal_tracing/context_logger/internal_tracing_context_logger.mli
+++ b/src/lib/internal_tracing/context_logger/internal_tracing_context_logger.mli
@@ -1,0 +1,12 @@
+(** Helper module for setting the execution context logger.
+
+    Useful for very deep call-stack where adding a logger parameter
+    to all the functions in the call-chain is too cumbersome. *)
+
+(** [with_logger logger f] runs [f] in a context in which
+    a call to [get] will return [logger]. *)
+val with_logger : Logger.t option -> (unit -> 'a) -> 'a
+
+(** [get ()] returns the logger bound to the current context (if any),
+    or the null logger otherwise. *)
+val get : unit -> Logger.t

--- a/src/lib/internal_tracing/dune
+++ b/src/lib/internal_tracing/dune
@@ -15,7 +15,10 @@
   logger
   mina_base
   mina_version
-  mina_numbers)
+  mina_numbers
+  internal_tracing.context_call
+  internal_tracing.context_logger
+  )
  (preprocess
   (pps ppx_jane ppx_mina ppx_version ppx_deriving_yojson))
  (instrumentation

--- a/src/lib/internal_tracing/internal_tracing.mli
+++ b/src/lib/internal_tracing/internal_tracing.mli
@@ -57,6 +57,8 @@
 
      - ["@current_block"]: used to notify of a execution context change that
        brings a different block into context.
+     - ["@current_call_id"]: used to notify of a execution context change that
+       brings a different concurrent verifier or prover call into context.
      - ["@internal_tracing_enabled"]: issued whenever internal tracing is enabled.
      - ["@internal_tracing_disabled"]: issued whenever internal tracing is disabled.
      - ["@mina_node_metadata"]: associates global metadata about the current node
@@ -145,4 +147,12 @@ module For_logger : sig
 
   (** Processor for the "internal" log level used to record checkpoints *)
   val processor : Logger.Processor.t
+end
+
+module Context_logger : sig
+  include module type of Internal_tracing_context_logger
+end
+
+module Context_call : sig
+  include module type of Internal_tracing_context_call
 end

--- a/src/lib/internal_tracing/internal_tracing.mli
+++ b/src/lib/internal_tracing/internal_tracing.mli
@@ -90,12 +90,30 @@
 (** [is_enabled ()] returns [true] if internal tracing is enabled, and [false] otherwise. *)
 val is_enabled : unit -> bool
 
+(** [register_toggle_callback callback] will register [callback] to be called whenever
+    internal tracing is toggled.
+
+    This is useful to syncronize internal tracing done by subprocesses like the verifier
+    and prover.
+
+    [callback] will be called with [true] if internal tracing must be enabled, and with
+    [false] if it must be disabled. It must return a [Deferred.t] that will be resolved
+    once the call completes. *)
+val register_toggle_callback : (bool -> unit Async_kernel.Deferred.t) -> unit
+
 (** [toggle `Enabled] will enable tracing.
     [toggle `Disabled] will disable tracing.
 
     If [force] is [false] (the default), and if tracing is already active,
-    then trying to enable tracing is a noop. *)
-val toggle : logger:Logger.t -> ?force:bool -> [ `Enabled | `Disabled ] -> unit
+    then trying to enable tracing is a noop.
+
+    The returned promise will be resolved when all the calls to the registered toggle
+    callbacks have been resolved. *)
+val toggle :
+     logger:Logger.t
+  -> ?force:bool
+  -> [ `Enabled | `Disabled ]
+  -> unit Async_kernel.Deferred.t
 
 (** [with_state_hash state_hash f] runs [f] in a context in which checkpoints
     and metadata will be associated to a block with state hash equal to [state_hash].

--- a/src/lib/internal_tracing/internal_tracing.mli
+++ b/src/lib/internal_tracing/internal_tracing.mli
@@ -95,7 +95,7 @@ val is_enabled : unit -> bool
 (** [register_toggle_callback callback] will register [callback] to be called whenever
     internal tracing is toggled.
 
-    This is useful to syncronize internal tracing done by subprocesses like the verifier
+    This is useful to synchronize internal tracing done by subprocesses like the verifier
     and prover.
 
     [callback] will be called with [true] if internal tracing must be enabled, and with
@@ -121,7 +121,7 @@ val toggle :
     and metadata will be associated to a block with state hash equal to [state_hash].
 
     Any context in which checkpoints or metadata are recorded must be wrapped
-    in either [with_state_hash] or [with_slot] for the checkpoints to be
+    in either {!val:with_state_hash} or {!val:with_slot} for the checkpoints to be
     properly associated to the block being processed/produced. *)
 val with_state_hash : Mina_base.State_hash.t -> (unit -> 'a) -> 'a
 
@@ -130,7 +130,7 @@ val with_state_hash : Mina_base.State_hash.t -> (unit -> 'a) -> 'a
     equal to [global_slot].
 
     Any context in which checkpoints or metadata are recorded must be wrapped
-    in either [with_state_hash] or [with_slot] for the checkpoints to be
+    in either {!val:with_state_hash} or {!val:with_slot} for the checkpoints to be
     properly associated to the block being processed/produced. *)
 val with_slot : Mina_numbers.Global_slot.t -> (unit -> 'a) -> 'a
 
@@ -149,10 +149,6 @@ module For_logger : sig
   val processor : Logger.Processor.t
 end
 
-module Context_logger : sig
-  include module type of Internal_tracing_context_logger
-end
+module Context_logger : module type of Internal_tracing_context_logger
 
-module Context_call : sig
-  include module type of Internal_tracing_context_call
-end
+module Context_call : module type of Internal_tracing_context_call

--- a/src/lib/ledger_catchup/normal_catchup.ml
+++ b/src/lib/ledger_catchup/normal_catchup.ml
@@ -878,7 +878,8 @@ let%test_module "Ledger_catchup tests" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     module Context = struct
       let logger = logger

--- a/src/lib/ledger_catchup/super_catchup.ml
+++ b/src/lib/ledger_catchup/super_catchup.ml
@@ -1408,7 +1408,8 @@ let%test_module "Ledger_catchup tests" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     module Context = struct
       let logger = logger

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -101,6 +101,7 @@
    kimchi_backend.pasta
    kimchi_backend.pasta.basic
    mina_wire_types
+   internal_tracing
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_mina ppx_version ppx_inline_test ppx_deriving.std))

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1439,6 +1439,22 @@ let create ?wallets (config : Config.t) =
                       ~pids:config.pids ~conf_dir:(Some config.conf_dir) () ) )
             >>| Result.ok_exn
           in
+          (* This setup is required for the dynamic enabling/disabling of internal
+             tracing to also work with the verifier and prover sub-processes. *)
+          Internal_tracing.register_toggle_callback (fun enabled ->
+              let%map result =
+                Verifier.toggle_internal_tracing verifier enabled
+              in
+              Or_error.iter_error result ~f:(fun error ->
+                  [%log' warn config.logger]
+                    "Failed to toggle verifier internal tracing: $error"
+                    ~metadata:[ ("error", `String (Error.to_string_hum error)) ] ) ) ;
+          Internal_tracing.register_toggle_callback (fun enabled ->
+              let%map result = Prover.toggle_internal_tracing prover enabled in
+              Or_error.iter_error result ~f:(fun error ->
+                  [%log' warn config.logger]
+                    "Failed to toggle prover internal tracing: $error"
+                    ~metadata:[ ("error", `String (Error.to_string_hum error)) ] ) ) ;
           let%bind vrf_evaluator =
             Monitor.try_with ~here:[%here]
               ~rest:

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1429,10 +1429,12 @@ let create ?wallets (config : Config.t) =
               (fun () ->
                 O1trace.thread "manage_verifier_subprocess" (fun () ->
                     Verifier.create ~logger:config.logger
+                      ~enable_internal_tracing:(Internal_tracing.is_enabled ())
+                      ~internal_trace_filename:"verifier-internal-trace.jsonl"
                       ~proof_level:config.precomputed_values.proof_level
                       ~constraint_constants:
                         config.precomputed_values.constraint_constants
-                      ~pids:config.pids ~conf_dir:(Some config.conf_dir) ) )
+                      ~pids:config.pids ~conf_dir:(Some config.conf_dir) () ) )
             >>| Result.ok_exn
           in
           let%bind vrf_evaluator =

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1411,9 +1411,11 @@ let create ?wallets (config : Config.t) =
               (fun () ->
                 O1trace.thread "manage_prover_subprocess" (fun () ->
                     Prover.create ~logger:config.logger
+                      ~enable_internal_tracing:(Internal_tracing.is_enabled ())
+                      ~internal_trace_filename:"prover-internal-trace.jsonl"
                       ~proof_level:config.precomputed_values.proof_level
                       ~constraint_constants ~pids:config.pids
-                      ~conf_dir:config.conf_dir ) )
+                      ~conf_dir:config.conf_dir () ) )
             >>| Result.ok_exn
           in
           let%bind verifier =

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -87,6 +87,7 @@ let%test_module "Epoch ledger sync tests" =
         Verifier.create ~logger ~proof_level:precomputed_values.proof_level
           ~constraint_constants:precomputed_values.constraint_constants ~pids
           ~conf_dir:(Some (make_dirname "verifier"))
+          ()
       in
       let _transaction_pool, tx_remote_sink, _tx_local_sink =
         let config =

--- a/src/lib/network_pool/batcher.ml
+++ b/src/lib/network_pool/batcher.ml
@@ -500,7 +500,8 @@ module Snark_pool = struct
         Async.Thread_safe.block_on_async_exn (fun () ->
             Verifier.create ~logger ~proof_level ~constraint_constants
               ~conf_dir:None
-              ~pids:(Child_processes.Termination.create_pid_table ()) )
+              ~pids:(Child_processes.Termination.create_pid_table ())
+              () )
 
       let gen_proofs =
         let open Quickcheck.Generator.Let_syntax in

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -783,7 +783,8 @@ let%test_module "random set test" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     module Mock_snark_pool =
       Make (Mocks.Base_ledger) (Mocks.Staged_ledger) (Mocks.Transition_frontier)

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -26,7 +26,8 @@ let%test_module "network pool test" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     module Mock_snark_pool =
       Snark_pool.Make (Mocks.Base_ledger) (Mocks.Staged_ledger)

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1567,7 +1567,8 @@ let%test_module _ =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     let `VK vk, `Prover prover =
       Transaction_snark.For_tests.create_trivial_snapp ~constraint_constants ()

--- a/src/lib/pickles/dune
+++ b/src/lib/pickles/dune
@@ -66,6 +66,7 @@
    promise
    kimchi_backend.common
    logger
+   internal_tracing.context_logger
    ppx_version.runtime
    error_json
 ))

--- a/src/lib/pickles/dune
+++ b/src/lib/pickles/dune
@@ -65,6 +65,7 @@
    tuple_lib
    promise
    kimchi_backend.common
+   logger
    ppx_version.runtime
    error_json
 ))

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -276,6 +276,7 @@ let step_main :
   let main () : _ Types.Step.Statement.t =
     let open Requests.Step in
     let open Impls.Step in
+    let logger = Internal_tracing_context_logger.get () in
     with_label "step_main" (fun () ->
         let module Max_proofs_verified = ( val max_proofs_verified : Nat.Add.Intf
                                              with type n = max_proofs_verified
@@ -386,6 +387,7 @@ let step_main :
           go prevs previous_proof_statements
         in
         let srs = Backend.Tock.Keypair.load_urs () in
+        [%log internal] "Step_compute_bulletproof_challenges" ;
         let bulletproof_challenges =
           with_label "prevs_verified" (fun () ->
               let rec go :
@@ -520,6 +522,7 @@ let step_main :
               in
               Boolean.Assert.all vs ; chalss )
         in
+        [%log internal] "Step_compute_bulletproof_challenges_done" ;
         let messages_for_next_step_proof =
           let challenge_polynomial_commitments =
             let module M =

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -30,6 +30,9 @@ end
 let verify_heterogenous (ts : Instance.t list) =
   let module Plonk = Types.Wrap.Proof_state.Deferred_values.Plonk in
   let module Tick_field = Backend.Tick.Field in
+  let logger = Internal_tracing_context_logger.get () in
+  [%log internal] "Verify_heterogenous"
+    ~metadata:[ ("count", `Int (List.length ts)) ] ;
   let tick_field : _ Plonk_checks.field = (module Tick_field) in
   let check, result =
     let r = ref [] in
@@ -45,6 +48,7 @@ let verify_heterogenous (ts : Instance.t list) =
     in
     ((fun (lab, b) -> if not b then r := lab :: !r), result)
   in
+  [%log internal] "Compute_plonks_and_chals" ;
   let in_circuit_plonks, computed_bp_chals =
     List.map ts
       ~f:(fun
@@ -295,8 +299,10 @@ let verify_heterogenous (ts : Instance.t list) =
         (plonk, bulletproof_challenges) )
     |> List.unzip
   in
+  [%log internal] "Compute_plonks_and_chals_done" ;
   let open Backend.Tock.Proof in
   let open Promise.Let_syntax in
+  [%log internal] "Accumulator_check" ;
   let%bind accumulator_check =
     Ipa.Step.accumulator_check
       (List.map ts ~f:(fun (T (_, _, _, _, T t)) ->
@@ -306,64 +312,65 @@ let verify_heterogenous (ts : Instance.t list) =
                t.statement.proof_state.deferred_values.bulletproof_challenges ) )
       )
   in
+  [%log internal] "Accumulator_check_done" ;
   Common.time "batch_step_dlog_check" (fun () ->
       check (lazy "batch_step_dlog_check", accumulator_check) ) ;
-  let%map dlog_check =
-    batch_verify
-      (List.map2_exn ts in_circuit_plonks
-         ~f:(fun
-              (T
-                ( (module Max_proofs_verified)
-                , (module A_value)
-                , key
-                , app_state
-                , T t ) )
-              plonk
-            ->
-           let prepared_statement : _ Types.Wrap.Statement.In_circuit.t =
-             { messages_for_next_step_proof =
-                 Common.hash_messages_for_next_step_proof
-                   ~app_state:A_value.to_field_elements
-                   (Reduced_messages_for_next_proof_over_same_field.Step.prepare
-                      ~dlog_plonk_index:key.commitments
-                      { t.statement.messages_for_next_step_proof with
-                        app_state
-                      } )
-             ; proof_state =
-                 { t.statement.proof_state with
-                   deferred_values =
-                     { t.statement.proof_state.deferred_values with plonk }
-                 ; messages_for_next_wrap_proof =
-                     Wrap_hack.hash_messages_for_next_wrap_proof
-                       Max_proofs_verified.n
-                       (Reduced_messages_for_next_proof_over_same_field.Wrap
-                        .prepare
-                          t.statement.proof_state.messages_for_next_wrap_proof )
-                 }
-             }
-           in
-           let input =
-             tock_unpadded_public_input_of_statement prepared_statement
-           in
-           ( key.index
-           , t.proof
-           , input
-           , Some
-               (Wrap_hack.pad_accumulator
-                  (Vector.map2
-                     ~f:(fun g cs ->
-                       { Challenge_polynomial.challenges =
-                           Vector.to_array (Ipa.Wrap.compute_challenges cs)
-                       ; commitment = g
-                       } )
-                     (Vector.extend_front_exn
-                        t.statement.messages_for_next_step_proof
-                          .challenge_polynomial_commitments
-                        Max_proofs_verified.n
-                        (Lazy.force Dummy.Ipa.Wrap.sg) )
-                     t.statement.proof_state.messages_for_next_wrap_proof
-                       .old_bulletproof_challenges ) ) ) ) )
+  [%log internal] "Compute_batch_verify_inputs" ;
+  let batch_verify_inputs =
+    List.map2_exn ts in_circuit_plonks
+      ~f:(fun
+           (T
+             ( (module Max_proofs_verified)
+             , (module A_value)
+             , key
+             , app_state
+             , T t ) )
+           plonk
+         ->
+        let prepared_statement : _ Types.Wrap.Statement.In_circuit.t =
+          { messages_for_next_step_proof =
+              Common.hash_messages_for_next_step_proof
+                ~app_state:A_value.to_field_elements
+                (Reduced_messages_for_next_proof_over_same_field.Step.prepare
+                   ~dlog_plonk_index:key.commitments
+                   { t.statement.messages_for_next_step_proof with app_state } )
+          ; proof_state =
+              { t.statement.proof_state with
+                deferred_values =
+                  { t.statement.proof_state.deferred_values with plonk }
+              ; messages_for_next_wrap_proof =
+                  Wrap_hack.hash_messages_for_next_wrap_proof
+                    Max_proofs_verified.n
+                    (Reduced_messages_for_next_proof_over_same_field.Wrap
+                     .prepare
+                       t.statement.proof_state.messages_for_next_wrap_proof )
+              }
+          }
+        in
+        let input =
+          tock_unpadded_public_input_of_statement prepared_statement
+        in
+        let message =
+          Wrap_hack.pad_accumulator
+            (Vector.map2
+               ~f:(fun g cs ->
+                 { Challenge_polynomial.challenges =
+                     Vector.to_array (Ipa.Wrap.compute_challenges cs)
+                 ; commitment = g
+                 } )
+               (Vector.extend_front_exn
+                  t.statement.messages_for_next_step_proof
+                    .challenge_polynomial_commitments Max_proofs_verified.n
+                  (Lazy.force Dummy.Ipa.Wrap.sg) )
+               t.statement.proof_state.messages_for_next_wrap_proof
+                 .old_bulletproof_challenges )
+        in
+        (key.index, t.proof, input, Some message) )
   in
+  [%log internal] "Compute_batch_verify_inputs_done" ;
+  [%log internal] "Dlog_check_batch_verify" ;
+  let%map dlog_check = batch_verify batch_verify_inputs in
+  [%log internal] "Dlog_check_batch_verify_done" ;
   Common.time "dlog_check" (fun () -> check (lazy "dlog_check", dlog_check)) ;
   result ()
 

--- a/src/lib/prover/dune
+++ b/src/lib/prover/dune
@@ -32,7 +32,6 @@
    mina_base
    logger
    internal_tracing
-   internal_tracing.context_logger
    genesis_constants
    ledger_proof
    consensus

--- a/src/lib/prover/dune
+++ b/src/lib/prover/dune
@@ -31,6 +31,8 @@
    mina_state
    mina_base
    logger
+   internal_tracing
+   internal_tracing.context_logger
    genesis_constants
    ledger_proof
    consensus

--- a/src/lib/prover/intf.ml
+++ b/src/lib/prover/intf.ml
@@ -17,10 +17,13 @@ module type S = sig
 
   val create :
        logger:Logger.t
+    -> ?enable_internal_tracing:bool
+    -> ?internal_trace_filename:string
     -> pids:Child_processes.Termination.t
     -> conf_dir:string
     -> proof_level:Genesis_constants.Proof_level.t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
+    -> unit
     -> t Deferred.t
 
   val initialized : t -> [ `Initialized ] Deferred.Or_error.t

--- a/src/lib/prover/intf.ml
+++ b/src/lib/prover/intf.ml
@@ -49,4 +49,6 @@ module type S = sig
 
   val create_genesis_block :
     t -> Genesis_proof.Inputs.t -> Blockchain.t Deferred.Or_error.t
+
+  val toggle_internal_tracing : t -> bool -> unit Deferred.Or_error.t
 end

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -107,13 +107,15 @@ module Worker_state = struct
                    (next_state : Protocol_state.Value.t)
                    (block : Snark_transition.value) (t : Ledger_proof.t option)
                    state_for_handler pending_coinbase =
+                 Internal_tracing.Context_call.with_call_id
+                 @@ fun () ->
                  [%log internal] "Prover_extend_blockchain" ;
                  let%map.Async.Deferred res =
                    Deferred.Or_error.try_with ~here:[%here] (fun () ->
                        let txn_snark_statement, txn_snark_proof =
                          ledger_proof_opt next_state t
                        in
-                       Internal_tracing_context_logger.with_logger (Some logger)
+                       Internal_tracing.Context_logger.with_logger (Some logger)
                        @@ fun () ->
                        let%map.Async.Deferred (), (), proof =
                          B.step
@@ -142,6 +144,8 @@ module Worker_state = struct
                  res
 
                let verify state proof =
+                 Internal_tracing.Context_call.with_call_id
+                 @@ fun () ->
                  [%log internal] "Prover_verify" ;
                  let%map result = B.Proof.verify [ (state, proof) ] in
                  [%log internal] "Prover_verify_done" ;

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -133,7 +133,11 @@ module Worker_state = struct
                        "Prover threw an error while extending block: $error" ) ;
                  res
 
-               let verify state proof = B.Proof.verify [ (state, proof) ]
+               let verify state proof =
+                 [%log internal] "Prover_verify" ;
+                 let%map result = B.Proof.verify [ (state, proof) ] in
+                 [%log internal] "Prover_verify_done" ;
+                 result
              end : S )
          | Check ->
              ( module struct

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2167,7 +2167,8 @@ let%test_module "staged ledger tests" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     let supercharge_coinbase ~ledger ~winner ~global_slot =
       (*using staged ledger to confirm coinbase amount is correctly generated*)

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -91,7 +91,8 @@ let%test_module "transaction_status" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     let key_gen =
       let open Quickcheck.Generator in

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -62,6 +62,7 @@
    merkle_ledger
    mina_base.util
    ppx_version.runtime
+   logger
  )
  (preprocess
   (pps ppx_snarky ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson h_list.ppx))

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -960,7 +960,8 @@ module For_tests = struct
     Async.Thread_safe.block_on_async_exn (fun () ->
         Verifier.create ~logger ~proof_level ~constraint_constants
           ~conf_dir:None
-          ~pids:(Child_processes.Termination.create_pid_table ()) )
+          ~pids:(Child_processes.Termination.create_pid_table ())
+          () )
 
   module Genesis_ledger = (val precomputed_values.genesis_ledger)
 

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -333,7 +333,7 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
     let verifier =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
-            ~conf_dir:None ~pids )
+            ~conf_dir:None ~pids () )
 
     (* cast a breadcrumb into a cached, enveloped, partially validated transition *)
     let downcast_breadcrumb breadcrumb =

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -454,7 +454,8 @@ let%test_module "Transition_handler.Processor tests" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
             ~conf_dir:None
-            ~pids:(Child_processes.Termination.create_pid_table ()) )
+            ~pids:(Child_processes.Termination.create_pid_table ())
+            () )
 
     module Context = struct
       let logger = logger

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -13,7 +13,8 @@ let invalid_to_error = Common.invalid_to_error
 
 type ledger_proof = Ledger_proof.t
 
-let create ~logger:_ ~proof_level ~constraint_constants ~pids:_ ~conf_dir:_ =
+let create ~logger:_ ?enable_internal_tracing:_ ?internal_trace_filename:_
+    ~proof_level ~constraint_constants ~pids:_ ~conf_dir:_ () =
   match proof_level with
   | Genesis_constants.Proof_level.Full ->
       failwith "Unable to handle proof-level=Full"

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -89,3 +89,5 @@ let get_blockchain_verification_key { proof_level; constraint_constants } =
         let proof_level = proof_level
       end) in
       Deferred.return @@ Lazy.force B.Proof.verification_key )
+
+let toggle_internal_tracing _ _ = Deferred.Or_error.ok_unit

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -39,7 +39,6 @@
    with_hash
    snarky.backendless
    internal_tracing
-   internal_tracing.context_logger
    )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_custom_printf ppx_version ppx_compare ppx_hash ppx_mina ppx_version ppx_here ppx_bin_prot ppx_let

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -38,7 +38,9 @@
    kimchi_backend.pasta.basic
    with_hash
    snarky.backendless
-   internal_tracing)
+   internal_tracing
+   internal_tracing.context_logger
+   )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_custom_printf ppx_version ppx_compare ppx_hash ppx_mina ppx_version ppx_here ppx_bin_prot ppx_let
                   ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv)))

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -112,7 +112,9 @@ module Worker_state = struct
                      `Mismatched_authorization_kind keys )
 
              let verify_commands cs =
-               Internal_tracing_context_logger.with_logger (Some logger)
+               Internal_tracing.Context_logger.with_logger (Some logger)
+               @@ fun () ->
+               Internal_tracing.Context_call.with_call_id
                @@ fun () ->
                [%log internal] "Verifier_verify_commands" ;
                let%map result = verify_commands cs in
@@ -122,7 +124,9 @@ module Worker_state = struct
              let verify_blockchain_snarks = B.Proof.verify
 
              let verify_blockchain_snarks bs =
-               Internal_tracing_context_logger.with_logger (Some logger)
+               Internal_tracing.Context_logger.with_logger (Some logger)
+               @@ fun () ->
+               Internal_tracing.Context_call.with_call_id
                @@ fun () ->
                [%log internal] "Verifier_verify_blockchain_snarks" ;
                let%map result = verify_blockchain_snarks bs in
@@ -141,7 +145,9 @@ module Worker_state = struct
                    failwith "Verifier crashed"
 
              let verify_transaction_snarks ts =
-               Internal_tracing_context_logger.with_logger (Some logger)
+               Internal_tracing.Context_logger.with_logger (Some logger)
+               @@ fun () ->
+               Internal_tracing.Context_call.with_call_id
                @@ fun () ->
                [%log internal] "Verifier_verify_transaction_snarks" ;
                let%map result = verify_transaction_snarks ts in

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -47,6 +47,8 @@ module Base = struct
 
     val get_blockchain_verification_key :
       t -> Pickles.Verification_key.t Or_error.t Deferred.t
+
+    val toggle_internal_tracing : t -> bool -> unit Or_error.t Deferred.t
   end
 end
 

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -55,9 +55,12 @@ module type S = sig
 
   val create :
        logger:Logger.t
+    -> ?enable_internal_tracing:bool
+    -> ?internal_trace_filename:string
     -> proof_level:Genesis_constants.Proof_level.t
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> pids:Child_processes.Termination.t
     -> conf_dir:string option
+    -> unit
     -> t Deferred.t
 end


### PR DESCRIPTION
In addition to the tracing output generated by the first PR, here two new output files are added, one for the verifier process used by the transition frontier (other verifier processes are not currently traced), and another one for the prover process used by the block producer. If the node is launched with internal tracing enabled, those two subprocesses will be launched with internal tracing enabled too. When the mina client is used to toggle internal tracing, an RPC call will be made to those subprocesses to toggle internal tracing too.

### Explain your changes:

This PR implements internal tracing for the prover and verifier. Builds on top of https://github.com/MinaProtocol/mina/pull/12703

### Explain how you tested your changes:
By consuming the traces with https://github.com/openmina/internal-trace-consumer and running it on our cluster.

Example of a structured trace generated by the trace consumer:

https://gist.github.com/tizoc/aab4d1dcf9d6b1d6857b0ac8ce094f03

### Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
