### PR TITLE
Feature/kimchi internal tracing (internal tracing PR 3 of 3)

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
@@ -98,7 +98,7 @@ module type Inputs_intf = sig
       -> Scalar_field.Vector.t
       -> Scalar_field.t array
       -> Curve.Affine.Backend.t array
-      -> t
+      -> t * Kimchi_types.prover_traces
 
     val create_async :
          Index.t
@@ -106,7 +106,7 @@ module type Inputs_intf = sig
       -> Scalar_field.Vector.t
       -> Scalar_field.t array
       -> Curve.Affine.Backend.t array
-      -> t Promise.t
+      -> (t * Kimchi_types.prover_traces) Promise.t
 
     val verify : Verifier_index.t -> t -> bool
 
@@ -372,8 +372,10 @@ module Make (Inputs : Inputs_intf) = struct
         ~f:(fun { Challenge_polynomial.commitment; _ } ->
           G.Affine.to_backend (Finite commitment) )
     in
-    let res = Backend.create pk primary auxiliary challenges commitments in
-    of_backend res
+    let proof, traces =
+      Backend.create pk primary auxiliary challenges commitments
+    in
+    (of_backend proof, traces)
 
   let create_async ?message pk ~primary ~auxiliary =
     let chal_polys =
@@ -389,10 +391,10 @@ module Make (Inputs : Inputs_intf) = struct
         ~f:(fun { Challenge_polynomial.commitment; _ } ->
           G.Affine.to_backend (Finite commitment) )
     in
-    let%map.Promise res =
+    let%map.Promise proof, traces =
       Backend.create_async pk primary auxiliary challenges commitments
     in
-    of_backend res
+    (of_backend proof, traces)
 
   let batch_verify' (conv : 'a -> Fq.t array)
       (ts : (Verifier_index.t * t * 'a * message option) list) =

--- a/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
@@ -110,7 +110,8 @@ module Proof = Plonk_dlog_proof.Make (struct
 
     let create_traced ?tracing_output pk auxiliary_input prev_challenges
         prev_sgs =
-      let proof, traces = create pk auxiliary_input prev_challenges prev_sgs in
+      let proof = create pk auxiliary_input prev_challenges prev_sgs in
+      let traces = take_trace () in
       Option.iter tracing_output ~f:(fun tracing_output ->
           tracing_output := traces.inner ) ;
       proof

--- a/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
@@ -109,7 +109,8 @@ module Proof = Plonk_dlog_proof.Make (struct
 
     let create_traced ?tracing_output pk auxiliary_input prev_challenges
         prev_sgs =
-      let proof, traces = create pk auxiliary_input prev_challenges prev_sgs in
+      let proof = create pk auxiliary_input prev_challenges prev_sgs in
+      let traces = take_trace () in
       Option.iter tracing_output ~f:(fun tracing_output ->
           tracing_output := traces.inner ) ;
       proof

--- a/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
@@ -107,14 +107,25 @@ module Proof = Plonk_dlog_proof.Make (struct
       in
       create pk.index witness_cols prev_chals prev_comms
 
-    let create_async (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
+    let create_traced ?tracing_output pk auxiliary_input prev_challenges
+        prev_sgs =
+      let proof, traces = create pk auxiliary_input prev_challenges prev_sgs in
+      Option.iter tracing_output ~f:(fun tracing_output ->
+          tracing_output := traces.inner ) ;
+      proof
+
+    let create_async ?tracing_output (pk : Keypair.t) primary auxiliary
+        prev_chals prev_comms =
       create_aux pk primary auxiliary prev_chals prev_comms
         ~f:(fun pk auxiliary_input prev_challenges prev_sgs ->
           Promise.run_in_thread (fun () ->
-              create pk auxiliary_input prev_challenges prev_sgs ) )
+              create_traced ?tracing_output pk auxiliary_input prev_challenges
+                prev_sgs ) )
 
-    let create (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms ~f:create
+    let create ?tracing_output (pk : Keypair.t) primary auxiliary prev_chals
+        prev_comms =
+      create_aux pk primary auxiliary prev_chals prev_comms
+        ~f:(create_traced ?tracing_output)
   end
 
   module Verifier_index = Kimchi_bindings.Protocol.VerifierIndex.Fp

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
@@ -450,6 +450,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "internal-tracing"
+version = "0.1.0"
+dependencies = [
+ "ocaml",
+ "ocaml-gen",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +486,7 @@ dependencies = [
  "disjoint-set",
  "groupmap",
  "hex",
+ "internal-tracing",
  "itertools",
  "mina-curves",
  "mina-poseidon",
@@ -1189,6 +1200,7 @@ dependencies = [
  "ark-serialize",
  "array-init",
  "groupmap",
+ "internal-tracing",
  "kimchi",
  "libc",
  "mina-curves",

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
@@ -36,8 +36,10 @@ groupmap = { path = "../../proof-systems/groupmap" }
 mina-curves = { path = "../../proof-systems/curves" }
 o1-utils = { path = "../../proof-systems/utils" }
 mina-poseidon = { path = "../../proof-systems/poseidon" }
-kimchi = { path = "../../proof-systems/kimchi", features = ["ocaml_types"] }
+kimchi = { path = "../../proof-systems/kimchi", features = ["ocaml_types", "internal_tracing"] }
 
 # ocaml-specific
 ocaml = { version = "0.22.2", features = ["no-caml-startup"] }
 ocaml-gen = "0.1.0"
+
+internal-tracing = { git = "https://github.com/openmina/internal-tracing-rs", rev = "32f700e200faa8cf528589e7ef6a8e61f3a8d15e" }

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
@@ -37,9 +37,8 @@ mina-curves = { path = "../../proof-systems/curves" }
 o1-utils = { path = "../../proof-systems/utils" }
 mina-poseidon = { path = "../../proof-systems/poseidon" }
 kimchi = { path = "../../proof-systems/kimchi", features = ["ocaml_types", "internal_tracing"] }
+internal-tracing = { path = "../../proof-systems/internal-tracing" }
 
 # ocaml-specific
 ocaml = { version = "0.22.2", features = ["no-caml-startup"] }
 ocaml-gen = "0.1.0"
-
-internal-tracing = { git = "https://github.com/openmina/internal-tracing-rs", rev = "32f700e200faa8cf528589e7ef6a8e61f3a8d15e" }

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -361,7 +361,8 @@ module Protocol = struct
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.prover_proof = "caml_pasta_fp_plonk_proof_create"
+           Kimchi_types.prover_proof
+           * Kimchi_types.prover_traces = "caml_pasta_fp_plonk_proof_create"
 
       external example_with_lookup :
            SRS.Fp.t
@@ -471,7 +472,8 @@ module Protocol = struct
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.prover_proof = "caml_pasta_fq_plonk_proof_create"
+           Kimchi_types.prover_proof
+           * Kimchi_types.prover_traces = "caml_pasta_fq_plonk_proof_create"
 
       external verify :
            ( Pasta_bindings.Fq.t

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -361,8 +361,10 @@ module Protocol = struct
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.prover_proof
-           * Kimchi_types.prover_traces = "caml_pasta_fp_plonk_proof_create"
+           Kimchi_types.prover_proof = "caml_pasta_fp_plonk_proof_create"
+
+      external take_trace : unit -> Kimchi_types.prover_traces
+        = "caml_pasta_fp_plonk_proof_take_trace"
 
       external example_with_lookup :
            SRS.Fp.t
@@ -472,8 +474,10 @@ module Protocol = struct
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.prover_proof
-           * Kimchi_types.prover_traces = "caml_pasta_fq_plonk_proof_create"
+           Kimchi_types.prover_proof = "caml_pasta_fq_plonk_proof_create"
+
+      external take_trace : unit -> Kimchi_types.prover_traces
+        = "caml_pasta_fq_plonk_proof_take_trace"
 
       external verify :
            ( Pasta_bindings.Fq.t

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -118,6 +118,8 @@ type nonrec ('caml_g, 'caml_f) prover_proof =
   ; prev_challenges : ('caml_g, 'caml_f) recursion_challenge array
   }
 
+type nonrec prover_traces = { inner : string } [@@boxed]
+
 type nonrec wire = { row : int; col : int }
 
 type nonrec gate_type =

--- a/src/lib/crypto/kimchi_bindings/stubs/src/lib.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/lib.rs
@@ -61,7 +61,7 @@ pub use {
         wires::caml::CamlWire,
     },
     kimchi::proof::caml::{CamlLookupEvaluations, CamlProofEvaluations},
-    kimchi::prover::caml::{CamlLookupCommitments, CamlProverCommitments, CamlProverProof},
+    kimchi::prover::caml::{CamlLookupCommitments, CamlProverCommitments, CamlProverProof, CamlProverTraces},
     mina_poseidon::sponge::caml::CamlScalarChallenge,
     poly_commitment::commitment::caml::{CamlOpeningProof, CamlPolyComm},
 };

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -32,6 +32,7 @@ use wires_15_stubs::{
     CamlProofEvaluations,
     CamlProverCommitments,
     CamlProverProof,
+    CamlProverTraces,
     CamlRandomOracles,
     CamlScalarChallenge,
     CamlWire,
@@ -104,6 +105,7 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
     decl_type!(w, env, CamlLookupCommitments::<T1> => "lookup_commitments");
     decl_type!(w, env, CamlProverCommitments::<T1> => "prover_commitments");
     decl_type!(w, env, CamlProverProof<T1, T2> => "prover_proof");
+    decl_type!(w, env, CamlProverTraces => "prover_traces");
 
     decl_type!(w, env, CamlWire => "wire");
     decl_type!(w, env, GateType => "gate_type");

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -452,6 +452,7 @@ fn generate_kimchi_bindings(mut w: impl std::io::Write, env: &mut Env) {
         decl_module!(w, env, "Proof", {
             decl_module!(w, env, "Fp", {
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_create => "create");
+                decl_func!(w, env, caml_pasta_fp_plonk_proof_take_trace => "take_trace");
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_lookup => "example_with_lookup");
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_ffadd => "example_with_ffadd");
                 decl_func!(w, env, caml_pasta_fp_plonk_proof_example_with_xor => "example_with_xor");
@@ -467,6 +468,7 @@ fn generate_kimchi_bindings(mut w: impl std::io::Write, env: &mut Env) {
 
             decl_module!(w, env, "Fq", {
                 decl_func!(w, env, caml_pasta_fq_plonk_proof_create => "create");
+                decl_func!(w, env, caml_pasta_fq_plonk_proof_take_trace => "take_trace");
                 decl_func!(w, env, caml_pasta_fq_plonk_proof_verify => "verify");
                 decl_func!(w, env, caml_pasta_fq_plonk_proof_batch_verify => "batch_verify");
                 decl_func!(w, env, caml_pasta_fq_plonk_proof_dummy => "dummy");

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -18,7 +18,10 @@ use kimchi::{
     },
     verifier::Context,
 };
-use kimchi::{prover::caml::{CamlProverProof, CamlProverTraces}, verifier_index::VerifierIndex};
+use kimchi::{
+    prover::caml::{CamlProverProof, CamlProverTraces},
+    verifier_index::VerifierIndex,
+};
 use mina_curves::pasta::{Fp, Fq, Pallas, Vesta, VestaParameters};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
@@ -38,7 +41,7 @@ pub fn caml_pasta_fp_plonk_proof_create(
     witness: Vec<CamlFpVector>,
     prev_challenges: Vec<CamlFp>,
     prev_sgs: Vec<CamlGVesta>,
-) -> Result<(CamlProverProof<CamlGVesta, CamlFp>, CamlProverTraces), ocaml::Error> {
+) -> Result<CamlProverProof<CamlGVesta, CamlFp>, ocaml::Error> {
     internal_traces::start_tracing();
     internal_tracing::checkpoint!(internal_traces; pasta_fp_plonk_proof_create);
     {
@@ -94,11 +97,14 @@ pub fn caml_pasta_fp_plonk_proof_create(
             None,
         )
         .map_err(|e| ocaml::Error::Error(e.into()))?;
-        Ok((
-            (proof, public_input).into(),
-            internal_traces::take_traces().into(),
-        ))
+        Ok((proof, public_input).into())
     })
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn caml_pasta_fp_plonk_proof_take_trace() -> CamlProverTraces {
+    internal_traces::take_traces().into()
 }
 
 #[ocaml_gen::func]

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -17,7 +17,10 @@ use kimchi::{
     },
     verifier::Context,
 };
-use kimchi::{prover::caml::{CamlProverProof, CamlProverTraces}, verifier_index::VerifierIndex};
+use kimchi::{
+    prover::caml::{CamlProverProof, CamlProverTraces},
+    verifier_index::VerifierIndex,
+};
 use mina_curves::pasta::{Fp, Fq, Pallas, PallasParameters};
 use mina_poseidon::{
     constants::PlonkSpongeConstantsKimchi,
@@ -34,7 +37,7 @@ pub fn caml_pasta_fq_plonk_proof_create(
     witness: Vec<CamlFqVector>,
     prev_challenges: Vec<CamlFq>,
     prev_sgs: Vec<CamlGPallas>,
-) -> Result<(CamlProverProof<CamlGPallas, CamlFq>, CamlProverTraces), ocaml::Error> {
+) -> Result<CamlProverProof<CamlGPallas, CamlFq>, ocaml::Error> {
     internal_traces::start_tracing();
     internal_tracing::checkpoint!(internal_traces; pasta_fq_plonk_proof_create);
     {
@@ -86,11 +89,14 @@ pub fn caml_pasta_fq_plonk_proof_create(
             DefaultFrSponge<Fq, PlonkSpongeConstantsKimchi>,
         >(&group_map, witness, &[], index, prev, None)
         .map_err(|e| ocaml::Error::Error(e.into()))?;
-        Ok((
-            (proof, public_input).into(),
-            internal_traces::take_traces().into(),
-        ))
+        Ok((proof, public_input).into())
     })
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn caml_pasta_fq_plonk_proof_take_trace() -> CamlProverTraces {
+    internal_traces::take_traces().into()
 }
 
 #[ocaml_gen::func]

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1791,7 +1791,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                       .prepare
                         next_statement.proof_state.messages_for_next_wrap_proof
                     in
-                    let%map.Promise next_proof =
+                    let%map.Promise next_proof, _ =
                       let (T (input, conv, _conv_inv)) = Impls.Wrap.input () in
                       Common.time "wrap proof" (fun () ->
                           Impls.Wrap.generate_witness_conv

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1791,7 +1791,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                       .prepare
                         next_statement.proof_state.messages_for_next_wrap_proof
                     in
-                    let%map.Promise next_proof, _ =
+                    let%map.Promise next_proof =
                       let (T (input, conv, _conv_inv)) = Impls.Wrap.input () in
                       Common.time "wrap proof" (fun () ->
                           Impls.Wrap.generate_witness_conv

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -826,13 +826,15 @@ struct
                           ; public_inputs
                           } next_statement_hashed ->
                     [%log internal] "Backend_tick_proof_create_async" ;
-                    let%map.Promise proof =
+                    let%map.Promise proof, traces =
                       Backend.Tick.Proof.create_async ~primary:public_inputs
                         ~auxiliary:auxiliary_inputs
                         ~message:
                           (Lazy.force prev_challenge_polynomial_commitments)
                         pk
                     in
+                    [%log internal] "@metadata"
+                      ~metadata:[ ("traces", `String traces.inner) ] ;
                     [%log internal] "Backend_tick_proof_create_async_done" ;
                     (proof, next_statement_hashed) )
                   ~input_typ:Impls.Step.Typ.unit ~return_typ:input

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -826,15 +826,16 @@ struct
                           ; public_inputs
                           } next_statement_hashed ->
                     [%log internal] "Backend_tick_proof_create_async" ;
-                    let%map.Promise proof, traces =
-                      Backend.Tick.Proof.create_async ~primary:public_inputs
-                        ~auxiliary:auxiliary_inputs
+                    let tracing_output = ref "" in
+                    let%map.Promise proof =
+                      Backend.Tick.Proof.create_async ~tracing_output
+                        ~primary:public_inputs ~auxiliary:auxiliary_inputs
                         ~message:
                           (Lazy.force prev_challenge_polynomial_commitments)
                         pk
                     in
                     [%log internal] "@metadata"
-                      ~metadata:[ ("traces", `String traces.inner) ] ;
+                      ~metadata:[ ("traces", `String !tracing_output) ] ;
                     [%log internal] "Backend_tick_proof_create_async_done" ;
                     (proof, next_statement_hashed) )
                   ~input_typ:Impls.Step.Typ.unit ~return_typ:input

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -880,10 +880,12 @@ let wrap
         Impls.Wrap.generate_witness_conv
           ~f:(fun { Impls.Wrap.Proof_inputs.auxiliary_inputs; public_inputs } () ->
             [%log internal] "Backend_tock_proof_create_async" ;
-            let%map.Promise proof =
+            let%map.Promise proof, traces =
               Backend.Tock.Proof.create_async ~primary:public_inputs
                 ~auxiliary:auxiliary_inputs pk ~message:next_accumulator
             in
+            [%log internal] "@metadata"
+              ~metadata:[ ("traces", `String traces.inner) ] ;
             [%log internal] "Backend_tock_proof_create_async_done" ;
             proof )
           ~input_typ:input

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -880,12 +880,14 @@ let wrap
         Impls.Wrap.generate_witness_conv
           ~f:(fun { Impls.Wrap.Proof_inputs.auxiliary_inputs; public_inputs } () ->
             [%log internal] "Backend_tock_proof_create_async" ;
-            let%map.Promise proof, traces =
-              Backend.Tock.Proof.create_async ~primary:public_inputs
-                ~auxiliary:auxiliary_inputs pk ~message:next_accumulator
+            let tracing_output = ref "" in
+            let%map.Promise proof =
+              Backend.Tock.Proof.create_async ~tracing_output
+                ~primary:public_inputs ~auxiliary:auxiliary_inputs pk
+                ~message:next_accumulator
             in
             [%log internal] "@metadata"
-              ~metadata:[ ("traces", `String traces.inner) ] ;
+              ~metadata:[ ("traces", `String !tracing_output) ] ;
             [%log internal] "Backend_tock_proof_create_async_done" ;
             proof )
           ~input_typ:input


### PR DESCRIPTION
The changes in this PR are in the last commit. We need some feedback here about how to properly integrate the changes that relate to `proof-systems`. The current version as implemented by @binier (who also implemented the other parts of the prover tracing) depends on a modified version of `proof-systems` that depends on https://github.com/openmina/internal-tracing-rs, but it is probably better to add that directly to `proof-systems` ?

### Explain your changes:

Extends the prover tracing implemented in #12874 with tracing internal to kimchi

### Explain how you tested your changes:
By consuming the traces with https://github.com/openmina/internal-trace-consumer and running it on our cluster.

Example of a structured trace generated by the trace consumer:

https://gist.github.com/tizoc/aab4d1dcf9d6b1d6857b0ac8ce094f03


### Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
