### PR TITLE
Disable coverage instrumentation on broken expression

### DIFF
--- a/src/lib/mina_state/snarked_ledger_state.ml
+++ b/src/lib/mina_state/snarked_ledger_state.ml
@@ -477,6 +477,7 @@ module Make_str (A : Wire_types.Concrete) = struct
     let all bs = Tick.(Run.run_checked (Boolean.all bs))
 
     let ( || ) b1 b2 = Tick.(Run.run_checked Boolean.(b1 || b2))
+      [@@coverage off]
 
     let equal t t' = Tick.Run.run_checked (Frozen_ledger_hash.equal_var t t')
 


### PR DESCRIPTION
When instrumenting the code with `bisect_ppx` there is an expression that fails to compile, thus preventing us from generating a coverage report (#12802).

Since it's not obvious what's causing that, we are disabling coverage instrumentation on that single expression.