### PR TITLE
add softfail to berkeley testnet test

### DIFF
--- a/buildkite/src/Command/ConnectToTestnet.dhall
+++ b/buildkite/src/Command/ConnectToTestnet.dhall
@@ -1,4 +1,5 @@
 let Prelude = ../External/Prelude.dhall
+let B = ../../External/Buildkite.dhall
 
 let Command = ./Base.dhall
 let Docker = ./Docker/Type.dhall

--- a/buildkite/src/Command/ConnectToTestnet.dhall
+++ b/buildkite/src/Command/ConnectToTestnet.dhall
@@ -4,6 +4,8 @@ let Command = ./Base.dhall
 let Docker = ./Docker/Type.dhall
 let Size = ./Size.dhall
 
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+
 let Cmd = ../Lib/Cmds.dhall in
 
 { step = \(dependsOn : List Command.TaggedKey.Type) ->
@@ -17,6 +19,7 @@ let Cmd = ../Lib/Cmds.dhall in
             "./buildkite/scripts/connect-to-berkeley.sh"
         ],
         label = "Connect to Berkeley",
+        soft_fail = Some (B/SoftFail.Boolean True),
         key = "connect-to-berkeley",
         target = Size.Large,
         depends_on = dependsOn

--- a/buildkite/src/Command/ConnectToTestnet.dhall
+++ b/buildkite/src/Command/ConnectToTestnet.dhall
@@ -1,5 +1,5 @@
 let Prelude = ../External/Prelude.dhall
-let B = ../../External/Buildkite.dhall
+let B = ../External/Buildkite.dhall
 
 let Command = ./Base.dhall
 let Docker = ./Docker/Type.dhall


### PR DESCRIPTION
Explain your changes:
* This PR makes the "connect to Berkeley" CI test optional. This allows the test to fail without blockchain PRs.
* Documentation of the softfail behavior ca be found here: https://buildkite.com/docs/pipelines/command-step#soft-fail-attributes

Explain how you tested your changes:
* This change is being test by running within Buildkite CI.


Checklist:

- [NA] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [NA] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [NA] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #12896
