### PR TITLE
Force flag when creating a generic gate

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -151,7 +151,8 @@ module Plonk_constraint = struct
   (** A PLONK constraint (or gate) can be [Basic], [Poseidon], [EC_add_complete], [EC_scale], [EC_endoscale], [EC_endoscalar], [RangeCheck0], [RangeCheck1], [Xor] *)
   module T = struct
     type ('v, 'f) t =
-      | Basic of { l : 'f * 'v; r : 'f * 'v; o : 'f * 'v; m : 'f; c : 'f }
+      | Basic of
+          { force : 'f; l : 'f * 'v; r : 'f * 'v; o : 'f * 'v; m : 'f; c : 'f }
           (** the Poseidon state is an array of states (and states are arrays of size 3). *)
       | Poseidon of { state : 'v array array }
       | EC_add_complete of
@@ -321,9 +322,9 @@ module Plonk_constraint = struct
     let map (type a b f) (t : (a, f) t) ~(f : a -> b) =
       let fp (x, y) = (f x, f y) in
       match t with
-      | Basic { l; r; o; m; c } ->
+      | Basic { force; l; r; o; m; c } ->
           let p (x, y) = (x, f y) in
-          Basic { l = p l; r = p r; o = p o; m; c }
+          Basic { force; l = p l; r = p r; o = p o; m; c }
       | Poseidon { state } ->
           Poseidon { state = Array.map ~f:(fun x -> Array.map ~f x) state }
       | EC_add_complete { p1; p2; p3; inf; same_x; slope; inf_z; x21_inv } ->
@@ -644,7 +645,7 @@ module Plonk_constraint = struct
         (eval_one : v -> f) (t : (v, f) t) =
       match t with
       (* cl * vl + cr * vr + co * vo + m * vl*vr + c = 0 *)
-      | Basic { l = cl, vl; r = cr, vr; o = co, vo; m; c } ->
+      | Basic { force = b; l = cl, vl; r = cr, vr; o = co, vo; m; c } ->
           let vl = eval_one vl in
           let vr = eval_one vr in
           let vo = eval_one vo in
@@ -1145,18 +1146,20 @@ end = struct
 
   (** Adds a generic constraint to the constraint system.
       As there are two generic gates per row, we queue
-      every other generic gate.
+      every other generic gate, unless force is set to true.
       *)
-  let add_generic_constraint ?l ?r ?o coeffs sys : unit =
-    match sys.pending_generic_gate with
-    (* if the queue of generic gate is empty, queue this *)
-    | None ->
-        sys.pending_generic_gate <- Some (l, r, o, coeffs)
-    (* otherwise empty the queue and create the row  *)
-    | Some (l2, r2, o2, coeffs2) ->
-        let coeffs = Array.append coeffs coeffs2 in
-        add_row sys [| l; r; o; l2; r2; o2 |] Generic coeffs ;
-        sys.pending_generic_gate <- None
+  let add_generic_constraint ?(force = false) ?l ?r ?o coeffs sys : unit =
+    if force then add_row sys [| l; r; o |] Generic coeffs
+    else
+      match sys.pending_generic_gate with
+      (* if the queue of generic gate is empty, queue this *)
+      | None ->
+          sys.pending_generic_gate <- Some (l, r, o, coeffs)
+      (* otherwise empty the queue and create the row  *)
+      | Some (l2, r2, o2, coeffs2) ->
+          let coeffs = Array.append coeffs coeffs2 in
+          add_row sys [| l; r; o; l2; r2; o2 |] Generic coeffs ;
+          sys.pending_generic_gate <- None
 
   (** Converts a number of scaled additions \sum s_i * x_i
       to as many constraints as needed,
@@ -1394,7 +1397,7 @@ end = struct
                 Hashtbl.set sys.cached_constants ~key:ratio ~data:x2 )
         | `Constant, `Constant ->
             assert (Fp.(equal s1 s2)) )
-    | Plonk_constraint.T (Basic { l; r; o; m; c }) ->
+    | Plonk_constraint.T (Basic { force; l; r; o; m; c }) ->
         (* 0
            = l.s * l.x
            + r.s * r.x
@@ -1451,7 +1454,10 @@ end = struct
               (* TODO: Figure this out later. *)
               failwith "Must use non-constant cvar in plonk constraints"
         in
-        add_generic_constraint ?l:(var l) ?r:(var r) ?o:(var o)
+        (* create a flag that is false if `force` is zero, true otherwise *)
+        let force = not Fp.(equal force Fp.zero) in
+        add_generic_constraint ?force:(Some force) ?l:(var l) ?r:(var r)
+          ?o:(var o)
           [| coeff l; coeff r; coeff o; m; !c |]
           sys
     (* | w0 | w1 | w2 | w3 | w4 | w5

--- a/src/lib/crypto/kimchi_backend/gadgets/generic.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/generic.ml
@@ -23,7 +23,8 @@ let add (type f)
         ; basic =
             Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
               (Basic
-                 { l = (Field.Constant.one, left_input)
+                 { force = Field.Constant.zero 
+                 ; l = (Field.Constant.one, left_input)
                  ; r = (Field.Constant.one, right_input)
                  ; o = (Option.value_exn Field.(to_constant (negate one)), sum)
                  ; m = Field.Constant.zero
@@ -53,7 +54,8 @@ let mul (type f)
         ; basic =
             Kimchi_backend_common.Plonk_constraint_system.Plonk_constraint.T
               (Basic
-                 { l = (Field.Constant.zero, left_input)
+                 { force = Field.Constant.zero
+                 ; l = (Field.Constant.zero, left_input)
                  ; r = (Field.Constant.zero, right_input)
                  ; o = (Option.value_exn Field.(to_constant (negate one)), prod)
                  ; m = Field.Constant.one

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -779,7 +779,8 @@ struct
                   ; basic =
                       T
                         (Basic
-                           { l = (one, y)
+                           { force = zero
+                           ; l = (one, y)
                            ; r = (one, pt_n_acc)
                            ; o = (negate one, acc')
                            ; m = zero


### PR DESCRIPTION
This is to force the creation of the generic gate row immediately when calling `Basic`. This is useful for Xor gadget, where necessarily you need a series of Xor gates followed by a generic gate with all zeros. I am not sure if this change is required, or if there are different ways to deal with it, so feel free to give feedback.