### PR TITLE
Update opam-reposiroty for nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1675103944,
-        "narHash": "sha256-V5Nnh0bPP+1oRpxAoY8Ps+pzTj/y3pIU4qJ/RHKy/Ms=",
+        "lastModified": 1679605525,
+        "narHash": "sha256-cjlntSxRnR/WO43uskM1vVkfXTim2DDGIkbVBSORjAw=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "3d52404962379752da1a2ff28a5ec1d2b7c33771",
+        "rev": "5811dd220f885cf73c1431ffcebd0eb1b0844cd5",
         "type": "github"
       },
       "original": {

--- a/opam.export
+++ b/opam.export
@@ -151,6 +151,8 @@ installed: [
   "mew_vi.0.5.0"
   "minicli.5.0.2"
   "mirage-crypto-ec.0.11.0"
+  "mirage-crypto.0.11.0"
+  "mirage-crypto-rng.0.11.0"
   "mirage-crypto-rng-async.0.11.0"
   "mmap.1.1.0"
   "num.1.1"


### PR DESCRIPTION
Problem: some dependencies in `opam.export` require use of the latest opam repository to be resolved by nix.

Solution: update `flake.lock` and `opam.export` files to resolve the issue.

Explain how you tested your changes: nix builds!


Checklist:

- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None