### PR TITLE
Use X-Forwarded-For header to fetch remote IP address

### DIFF
--- a/src/app/delegation_backend/src/submit.go
+++ b/src/app/delegation_backend/src/submit.go
@@ -180,6 +180,12 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ps, blockHash := makePaths(submittedAt, &req)
 
+	remoteAddr := r.Header.Get("X-Forwarded-For")
+	if remoteAddr == "" {
+		// If there is no X-Forwarded-For header, use the remote address
+		remoteAddr = r.RemoteAddr
+	}
+
 	meta := MetaToBeSaved{
 		CreatedAt:          req.Data.CreatedAt.Format(time.RFC3339),
 		PeerId:             req.Data.PeerId,


### PR DESCRIPTION
Use the `X-Forwarded-For` header to fetch the remote IP address of a node when running the delegation backend service behind a proxy.

Fixes #12964 