### PR TITLE
add softfail to "merges into compatible" test for Berkeley branch

### DIFF
--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -1,4 +1,5 @@
 let Prelude = ../../External/Prelude.dhall
+let B = ../../External/Buildkite.dhall
 
 let SelectFiles = ../../Lib/SelectFiles.dhall
 
@@ -9,6 +10,8 @@ let Cmd = ../../Lib/Cmds.dhall
 let Command = ../../Command/Base.dhall
 let Docker = ../../Command/Docker/Type.dhall
 let Size = ../../Command/Size.dhall
+
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
 
 in
 
@@ -25,6 +28,7 @@ Pipeline.build
           commands = [ Cmd.run "buildkite/scripts/merges-cleanly.sh compatible"]
           , label = "Check merges cleanly into compatible"
           , key = "clean-merge-compatible"
+          , soft_fail = Some (B/SoftFail.Boolean True)
           , target = Size.Small
           , docker = Some Docker::{
               image = (../../Constants/ContainerImages.dhall).toolchainBase


### PR DESCRIPTION
Explain your changes:
* This edit adds a softfail status to the test "merges cleanup into compatible" for the Berkeley test branch

Explain how you tested your changes:
* This change has been tested within Buildkite CI to confirm the test change behaves as expected.


Checklist:

- NA Modified the current draft of release notes with details on what is completed or incomplete within this project
- NA Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- NA Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- NA Serialized types are in stable-versioned modules
- NA Does this close issues? List them
