### PR TITLE
ITN GraphQL, check sequence number in Authorization

### DIFF
--- a/src/app/cli/src/init/dune
+++ b/src/app/cli/src/init/dune
@@ -20,7 +20,9 @@
    async_unix
    uri
    core_kernel
+   core_kernel.uuid
    core
+   core.uuid
    base
    async
    cohttp

--- a/src/app/cli/src/init/graphql_internal.ml
+++ b/src/app/cli/src/init/graphql_internal.ml
@@ -324,6 +324,12 @@ struct
                       (* can omit sequence information for `auth` query *)
                       match Itn_crypto.pubkey_of_base64 pk_str with
                       | Ok pk ->
+                          (* setting state in Mina_graphql is safe, as long as this GraphQL callback
+                             can't be preempted by another call to it
+                          *)
+                          Mina_graphql.Itn_sequencing
+                          .set_sequence_number_for_auth pk ;
+                          (* don't increment sequence no for an auth query *)
                           verify_signature_and_respond pk signature
                       | Error _ ->
                           (* not a base64-encoded key *)

--- a/src/app/cli/src/init/graphql_internal.ml
+++ b/src/app/cli/src/init/graphql_internal.ml
@@ -297,15 +297,17 @@ struct
                         (* not a valid Uuid *)
                         invalid_uuid ()
                     | Ok pk, Ok uuid ->
-                        let seq_no = Int.of_string seq_no_str in
+                        let seq_no = Unsigned.UInt32.of_string seq_no_str in
+                        let seq_no_check = Unsigned.UInt32.to_string seq_no in
                         if
-                          not
-                          @@ Mina_graphql.Itn_sequencing.valid_sequence_number
+                          (not @@ String.equal seq_no_check seq_no_str)
+                          && Mina_graphql.Itn_sequencing.valid_sequence_number
                                uuid pk seq_no
                         then invalid_sequence_no ()
                         else
                           let msg =
-                            sprintf "%s%04d%s" uuid_str (seq_no mod 10_000)
+                            sprintf "%s%08x%s" uuid_str
+                              (Unsigned.UInt32.to_int seq_no)
                               body_str
                           in
                           verify_signature_and_respond ~increment_seq_no:true

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -512,8 +512,8 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
           Deferred.unit )
     ]
   in
-  let create_graphql_server ?auth_keys ~bind_to_address ~schema
-      ~server_description ~require_auth port =
+  let create_graphql_server_with_auth ~mk_context ?auth_keys ~bind_to_address
+      ~schema ~server_description ~require_auth port =
     if require_auth && Option.is_none auth_keys then
       failwith
         "Could not create GraphQL server, authentication is required, but no \
@@ -530,7 +530,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
                     pk_str () ) )
     in
     let graphql_callback =
-      Graphql_cohttp_async.make_callback ?auth_keys (fun _req -> mina) schema
+      Graphql_cohttp_async.make_callback ?auth_keys mk_context schema
     in
     Cohttp_async.(
       Server.create_expert
@@ -579,6 +579,11 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
              !"Created %s at: http://localhost:%i/graphql"
              server_description port )
   in
+  let create_graphql_server =
+    create_graphql_server_with_auth
+      ~mk_context:(fun ~with_seq_no:_ _req -> mina)
+      ?auth_keys:None
+  in
   Option.iter rest_server_port ~f:(fun rest_server_port ->
       O1trace.background_thread "serve_graphql" (fun () ->
           create_graphql_server
@@ -601,7 +606,9 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
     (* Third graphql server with ITN-particular queries exposed *)
     Option.iter itn_graphql_port ~f:(fun rest_server_port ->
         O1trace.background_thread "serve_itn_graphql" (fun () ->
-            create_graphql_server ?auth_keys
+            create_graphql_server_with_auth
+              ~mk_context:(fun ~with_seq_no _req -> (with_seq_no, mina))
+              ?auth_keys
               ~bind_to_address:
                 Tcp.Bind_to_address.(
                   if insecure_rest_server then All_addresses else Localhost)

--- a/src/app/itn_orchestrator/genqlient.graphql
+++ b/src/app/itn_orchestrator/genqlient.graphql
@@ -1,5 +1,8 @@
 query auth() {
-    auth
+    auth {
+        serverUuid
+        signerSequenceNumber
+    }
 }
 
 mutation schedulePayments($input: PaymentsDetails!) {

--- a/src/app/itn_orchestrator/genqlient.yaml
+++ b/src/app/itn_orchestrator/genqlient.yaml
@@ -18,3 +18,7 @@ bindings:
     type: itn_json_types.MinaPublicKey
   PrivateKey:
     type: itn_json_types.MinaPrivateKey
+  UInt16:
+    type: uint16
+    marshaler: itn_json_types.MarshalUint16
+    unmarshaler: itn_json_types.UnmarshalUint16

--- a/src/app/itn_orchestrator/json_types/types.go
+++ b/src/app/itn_orchestrator/json_types/types.go
@@ -30,6 +30,22 @@ func MarshalUint64(v *uint64) ([]byte, error) {
 	return encloseInQuotes(strconv.FormatUint(*v, 10)), nil
 }
 
+func UnmarshalUint16(data []byte, v *uint16) error {
+	if data[0] == '"' && data[len(data)-1] == '"' {
+		res, err := strconv.ParseUint(string(data[1:len(data)-1]), 10, 16)
+		if err != nil {
+			return err
+		}
+		*v = uint16(res)
+		return nil
+	}
+	return errors.New("not a string token")
+}
+
+func MarshalUint16(v *uint16) ([]byte, error) {
+	return encloseInQuotes(strconv.FormatUint(uint64(*v), 10)), nil
+}
+
 func UnmarshalBase64(data []byte, v *[]byte) error {
 	if data[0] == '"' && data[len(data)-1] == '"' {
 		res, err := base64.StdEncoding.DecodeString(string(data[1 : len(data)-1]))

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -8,6 +8,17 @@ scalar CurrencyAmount
 
 """uint64 encoded as a json string representing a fee"""
 scalar Fee
+ 
+"""String representing a uint16 number in base 10"""
+scalar UInt16
+
+type ItnAuth {
+  """Uuid of the ITN GraphQL server"""
+  serverUuid: String!
+
+  """Sequence number for the signer of the auth query"""
+  signerSequenceNumber: UInt16!
+}
 
 type mutation {
   schedulePayments(
@@ -54,6 +65,6 @@ scalar PrivateKey
 scalar PublicKey
 
 type query {
-  """Returns true if query is authorized"""
-  auth: Boolean
+  """Uuid for GraphQL server, sequence number for signing public key"""
+  auth: ItnAuth!
 }

--- a/src/app/itn_orchestrator/src/go.mod
+++ b/src/app/itn_orchestrator/src/go.mod
@@ -15,6 +15,9 @@ require (
 
 require (
 	cloud.google.com/go v0.84.0 // indirect
+	github.com/agnivade/levenshtein v1.1.1 // indirect
+	github.com/alexflint/go-arg v1.4.2 // indirect
+	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
@@ -35,6 +38,7 @@ require (
 	google.golang.org/genproto v0.0.0-20210624174822-c5cf32407d0a // indirect
 	google.golang.org/grpc v1.38.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 replace itn_json_types => ../json_types

--- a/src/app/itn_orchestrator/src/go.sum
+++ b/src/app/itn_orchestrator/src/go.sum
@@ -50,8 +50,11 @@ github.com/Khan/genqlient v0.5.0/go.mod h1:EpIvDVXYm01GP6AXzjA7dKriPTH6GmtpmvTAw
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/agnivade/levenshtein v1.1.0/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
+github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
+github.com/alexflint/go-arg v1.4.2 h1:lDWZAXxpAnZUq4qwb86p/3rIJJ2Li81EoMbTMujhVa0=
 github.com/alexflint/go-arg v1.4.2/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
+github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
 github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/src/app/itn_orchestrator/src/itn_orchestrator/main.go
+++ b/src/app/itn_orchestrator/src/itn_orchestrator/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"itn_json_types"
-	"net/http"
 	"os"
 
 	"cloud.google.com/go/storage"
@@ -81,12 +80,11 @@ func main() {
 		os.Exit(4)
 		return
 	}
-	authClient := lib.NewAuthenticatedClient(ed25519.PrivateKey(appConfig.Key), http.DefaultClient)
 	clientCache := make(map[lib.NodeAddress]graphql.Client)
 	config := lib.Config{
 		Ctx:          ctx,
 		UptimeBucket: client.Bucket(appConfig.UptimeBucket),
-		GetGqlClient: lib.GetGqlClient(authClient, clientCache),
+		GetGqlClient: lib.GetGqlClient(ed25519.PrivateKey(appConfig.Key), clientCache),
 		Log:          log,
 		Daemon:       appConfig.Daemon,
 		MinaExec:     appConfig.MinaExec,

--- a/src/lib/graphql_basic_scalars/graphql_basic_scalars.ml
+++ b/src/lib/graphql_basic_scalars/graphql_basic_scalars.ml
@@ -36,6 +36,17 @@ module Make (Schema : Schema) = struct
         "Cannot parse string starting with a minus as an unsigned integer"
     else f s
 
+  module UInt16 : Json_intf with type t = Unsigned.UInt16.t = struct
+    type t = Unsigned.UInt16.t
+
+    let parse = parse_uinteger ~f:Unsigned.UInt16.of_string
+
+    let serialize value = `String (Unsigned.UInt16.to_string value)
+
+    let typ () =
+      unsigned_scalar_scalar ~to_string:Unsigned.UInt16.to_string "UInt16"
+  end
+
   module UInt32 : Json_intf with type t = Unsigned.UInt32.t = struct
     type t = Unsigned.UInt32.t
 

--- a/src/lib/mina_graphql/dune
+++ b/src/lib/mina_graphql/dune
@@ -25,6 +25,7 @@
    mina_wire_types
    network_pool
    cli_lib
+   itn_crypto
    kimchi_backend.pasta
    kimchi_backend.pasta.basic
    mina_base.util

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -542,7 +542,7 @@ module Types = struct
   module Itn = struct
     let auth =
       obj "ItnAuth" ~fields:(fun _ ->
-          [ field "uuid"
+          [ field "serverUuid"
               ~args:Arg.[]
               ~doc:"Uuid of the ITN GraphQL server" ~typ:(non_null string)
               ~resolve:(fun _ (uuid, _) -> uuid)


### PR DESCRIPTION
Added replay check code to the ITN GraphQL server.  When loading the daemon, the ITN GraphQL server gets assigned a fresh Uuid.

The `Authorization` header now looks like:
```
Signature pubkey signature ; Sequencing uuid sequence-no
```
The `uuid` is checked for syntactic validity (i.e., it decodes to the relevant OCaml type). If that check fails, or the uuid and sequence number are not as expected, return `Precondition_failed` (HTTP code 412). Otherwise, check the signature as before. If the sequence check passes, the sequence number is incremented, regardless of what happens with the signature check and the actual GraphQL query.

The `auth` query now returns the Uuid of the GraphQL server. That query can omit the `Sequencing` part of the header.

Removed the code that checks for auto-generated queries from the browser GraphQL interface, since the server won't be used that way.

Tested a bit with `curl`; the server needs more testing with real workloads.

Closes #12885.
