### PR TITLE
add generation of max-size zkapp commands

### DIFF
--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -96,4 +96,6 @@ input ZkappCommandsDetails {
   feePayers: [PrivateKey!]!
 
   noPrecondition: Boolean!
+
+  maxSize: Boolean!
 }

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -15,6 +15,7 @@ type ZkappCommandParams struct {
 	FeePayers         []itn_json_types.MinaPrivateKey
 	Nodes             []NodeAddress
 	NoPrecondition    bool
+	MaxSize           bool
 }
 
 type ScheduledZkappCommandsReceipt struct {
@@ -33,6 +34,7 @@ func SendZkappCommands(config Config, params ZkappCommandParams, output func(Sch
 			NumNewAccounts:        params.NewAccounts,
 			FeePayers:             params.FeePayers[nodeIx*feePayersPerNode : (nodeIx+1)*feePayersPerNode],
 			NoPrecondition:        params.NoPrecondition,
+			MaxSize:               params.MaxSize,
 		}
 		client, err := config.GetGqlClient(config.Ctx, nodeAddress)
 		if err != nil {

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -48,6 +48,8 @@ val gen_protocol_state_precondition :
 val gen_zkapp_command_from :
      ?global_slot:Mina_numbers.Global_slot.t
   -> ?memo:string
+  -> ?max_size:bool
+  -> ?genesis_constants:Genesis_constants.t
   -> ?no_account_precondition:bool
   -> ?ignore_sequence_events_precond:bool
   -> ?no_token_accounts:bool

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3114,6 +3114,7 @@ module Types = struct
           ; duration_in_minutes : int
           ; memo_prefix : string
           ; no_precondition : bool
+          ; max_size : bool
           }
 
         let arg_typ =
@@ -3121,7 +3122,7 @@ module Types = struct
             ~doc:"Keys and other information for scheduling zkapp commands"
             ~coerce:(fun fee_payers num_zkapps_to_deploy num_new_accounts
                          transactions_per_second duration_in_minutes memo_prefix
-                         no_precondition ->
+                         no_precondition max_size ->
               Result.return
                 { fee_payers
                 ; num_zkapps_to_deploy
@@ -3130,11 +3131,12 @@ module Types = struct
                 ; duration_in_minutes
                 ; memo_prefix
                 ; no_precondition
+                ; max_size
                 } )
             ~split:(fun f (t : input) ->
               f t.fee_payers t.num_zkapps_to_deploy t.num_new_accounts
                 t.transactions_per_second t.duration_in_minutes t.memo_prefix
-                t.no_precondition )
+                t.no_precondition t.max_size )
             ~fields:
               Arg.
                 [ arg "feePayers"
@@ -3157,6 +3159,8 @@ module Types = struct
                 ; arg "memoPrefix" ~doc:"Prefix of memo" ~typ:(non_null string)
                 ; arg "noPrecondition"
                     ~doc:"Disable the precondition in account updates"
+                    ~typ:(non_null bool)
+                ; arg "maxSize" ~doc:"Generate max size zkapp transactions"
                     ~typ:(non_null bool)
                 ]
       end
@@ -4689,7 +4693,13 @@ module Mutations = struct
                                            ~no_token_accounts:true ~limited:true
                                            ~fee_payer_keypair:fee_payer ~keymap
                                            ~account_state_tbl
-                                           ~generate_new_accounts ~ledger ~vk () )
+                                           ~generate_new_accounts ~ledger ~vk
+                                           ~max_size:
+                                             zkapp_command_details.max_size
+                                           ~genesis_constants:
+                                             (Mina_lib.config mina)
+                                               .precomputed_values
+                                               .genesis_constants () )
                                         ~size:1
                                         ~random:
                                           (Splittable_random.State.create


### PR DESCRIPTION
Explain your changes:
This PR adds an parameter for the zkApp command generator that allows it to generate max-size zkapp commands.
To get max-size zkapp command, we need to populate as much events and actions as possible. So I made one of account updates to include the max amount of events and actions and other account updates to have 0 of them. I also fixed the number account updates to be 5 which reach the cost limit. But this is not the most expensive zkapp commands. Under the current cost limit, the most expensive zkapp commands would consist of a fee payer + 5 account updates with proof authorization. In current implementation, there would be at most 2 account updates with proof authorization (this is limited by how authorization is handled in the generator itself, we could change that, but it's a little complicated). 

Explain how you tested your changes:
*


Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #12895 
