### PR TITLE
ITN slotsWon GraphQL query

### DIFF
--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -157,7 +157,7 @@ module Vrf = struct
          threshold_met = true in the JSON output), or to generate a witness \
          that a 3rd account_update can use to verify a vrf evaluation."
       (let open Command.Let_syntax in
-      let%map_open privkey_path = Flag.privkey_write_path
+      let%map_open privkey_path = Flag.privkey_read_path
       and global_slot =
         flag "--global-slot" ~doc:"NUM Global slot to evaluate the VRF for"
           (required int)
@@ -249,7 +249,7 @@ module Vrf = struct
          \"epochSeed\": _, \"delegatorIndex\": _} JSON message objects read on \
          stdin"
       (let open Command.Let_syntax in
-      let%map_open privkey_path = Flag.privkey_write_path in
+      let%map_open privkey_path = Flag.privkey_read_path in
       Exceptions.handle_nicely
       @@ fun () ->
       let env = Secrets.Keypair.env in

--- a/src/lib/mina_graphql/dune
+++ b/src/lib/mina_graphql/dune
@@ -29,6 +29,7 @@
    kimchi_backend.pasta.basic
    mina_base.util
    mina_ledger
+   block_producer
    pickles
    pickles_unix
    mina_incremental
@@ -37,6 +38,7 @@
    error_json
    mina_networking
    consensus.vrf
+   vrf_evaluator
    trust_system
    with_hash
    data_hash_lib

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -5108,9 +5108,35 @@ module Queries = struct
       field "auth" ~typ:bool
         ~args:Arg.[]
         ~doc:"Returns true if query is authorized"
-        ~resolve:(fun _ _ -> Some true)
+        ~resolve:(fun _ () -> Some true)
 
-    let commands = [ auth ]
+    let slots_won =
+      io_field "slotsWon"
+        ~typ:(list (non_null int))
+        ~args:Arg.[]
+        ~doc:"Slots won by a block producer for current epoch"
+        ~resolve:(fun { ctx = mina; _ } () ->
+          let bp_keys = Mina_lib.block_production_pubkeys mina in
+          if Public_key.Compressed.Set.is_empty bp_keys then
+            return @@ Error "Not a block producing node"
+          else
+            let vrf_evaluator = Mina_lib.vrf_evaluator mina in
+            let logger = Mina_lib.top_level_logger mina in
+            let%map vrf_result =
+              Block_producer.Vrf_evaluation_state.poll_vrf_evaluator ~logger
+                vrf_evaluator
+            in
+            match vrf_result.evaluator_status with
+            | Completed ->
+                let slots_since_hard_fork =
+                  List.map vrf_result.slots_won ~f:(fun { global_slot; _ } ->
+                      Unsigned.UInt32.to_int global_slot )
+                in
+                Ok (Some slots_since_hard_fork)
+            | _ ->
+                Error "Vrf evaluation not completed for current epoch" )
+
+    let commands = [ auth; slots_won ]
   end
 end
 

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -2165,4 +2165,6 @@ let runtime_config { config = { precomputed_values; _ }; _ } =
 
 let verifier { processes = { verifier; _ }; _ } = verifier
 
+let vrf_evaluator { processes = { vrf_evaluator; _ }; _ } = vrf_evaluator
+
 let genesis_ledger t = Genesis_proof.genesis_ledger t.config.precomputed_values

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -219,4 +219,6 @@ val runtime_config : t -> Runtime_config.t
 
 val verifier : t -> Verifier.t
 
+val vrf_evaluator : t -> Vrf_evaluator.t
+
 val genesis_ledger : t -> Mina_ledger.Ledger.t Lazy.t


### PR DESCRIPTION
Make list of slots won in the current epoch from `Vrf_evaluator` processor available via an ITN GraphQL query.

Tested a bit with curl and local network, needs more testing.

The result is the list of slots for the current epoch only. The epoch seed for the next epoch is not available until the current epoch is 2/3 done. We could compute the slots then, but it doesn't seem worth the effort.

Closes #12831.