### PR TITLE
All columns for block subchain query

### DIFF
--- a/src/app/archive/archive.ml
+++ b/src/app/archive/archive.ml
@@ -1,5 +1,16 @@
+open Core_kernel
 open Async
 
 let () =
-  Command.run
-    (Command.group ~summary:"Archive node commands" Archive_cli.commands)
+  (* intercept command-line processing for "version", because we don't
+     use the Jane Street scripts that generate their version information
+  *)
+  let is_version_cmd s =
+    List.mem [ "version"; "-version"; "--version" ] s ~equal:String.equal
+  in
+  match Async_unix.Sys.get_argv () with
+  | [| _archive_exe; version |] when is_version_cmd version ->
+      Mina_version.print_version ()
+  | _ ->
+      Command.run
+        (Command.group ~summary:"Archive node commands" Archive_cli.commands)

--- a/src/app/archive/dune
+++ b/src/app/archive/dune
@@ -4,7 +4,7 @@
  (public_name archive)
  (modules archive)
  (modes native)
- (libraries archive_cli async core_kernel base)
+ (libraries archive_cli async async_unix core_kernel base mina_version)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version)))
 
@@ -14,7 +14,7 @@
  (public_name archive-testnet)
  (modules archive_testnet_signatures)
  (modes native)
- (libraries archive_cli mina_signature_kind.testnet async core_kernel base)
+ (libraries archive_cli mina_signature_kind.testnet async async_unix core_kernel base mina_version)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version)))
 
@@ -24,6 +24,6 @@
  (public_name archive-mainnet)
  (modules archive_mainnet_signatures)
  (modes native)
- (libraries archive_cli mina_signature_kind.mainnet async core_kernel base)
+ (libraries archive_cli mina_signature_kind.mainnet async async_unix core_kernel base mina_version)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_version)))

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -3277,9 +3277,11 @@ module Block = struct
                       snarked_ledger_hash_id, staking_epoch_data_id,
                       next_epoch_data_id,
                       min_window_density, sub_window_densities, total_currency,
-                      ledger_hash, height, global_slot_since_hard_fork,
-                      global_slot_since_genesis, protocol_version, timestamp, chain_status)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::chain_status_type)
+                      ledger_hash, height,
+                      global_slot_since_hard_fork, global_slot_since_genesis,
+                      protocol_version, proposed_protocol_version,
+                      timestamp, chain_status)
+                      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::bigint[], ?, ?, ?, ?, ?, ?, ?, ?, ?::chain_status_type)
                      RETURNING id
                |sql} )
             { state_hash = block.state_hash |> State_hash.to_base58_check
@@ -3443,19 +3445,23 @@ module Block = struct
          Caqti_type.(tup2 int int)
          typ
          {sql| WITH RECURSIVE chain AS (
-              SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,
+              SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,
+                     last_vrf_output,snarked_ledger_hash_id,
                      staking_epoch_data_id,next_epoch_data_id,
-                     min_window_density,total_currency,
+                     min_window_density,sub_window_densities,total_currency,
                      ledger_hash,height,global_slot_since_hard_fork,global_slot_since_genesis,
+                     protocol_version_id, proposed_protocol_version_id,
                      timestamp,chain_status
               FROM blocks b WHERE b.id = $1
 
               UNION ALL
 
-              SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,b.snarked_ledger_hash_id,
+              SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,
+                     b.last_vrf_output,b.snarked_ledger_hash_id,
                      b.staking_epoch_data_id,b.next_epoch_data_id,
-                     b.min_window_density,b.total_currency,
+                     b.min_window_density,b.sub_window_densities,b.total_currency,
                      b.ledger_hash,b.height,b.global_slot_since_hard_fork,b.global_slot_since_genesis,
+                     b.protocol_version_id, b.proposed_protocol_version_id,
                      b.timestamp,b.chain_status
               FROM blocks b
 
@@ -3465,11 +3471,13 @@ module Block = struct
 
            )
 
-           SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,snarked_ledger_hash_id,
+           SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,
+                  last_vrf_output,snarked_ledger_hash_id,
                   staking_epoch_data_id, next_epoch_data_id,
-                  min_window_density, total_currency,
+                  min_window_density,sub_window_densities,total_currency,
                   ledger_hash,height,
                   global_slot_since_hard_fork,global_slot_since_genesis,
+                  protocol_version_id, proposed_protocol_version_id,
                   timestamp,chain_status
            FROM chain ORDER BY height ASC
       |sql} )

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -3440,29 +3440,25 @@ module Block = struct
       (parent_id, State_hash.to_base58_check parent_hash)
 
   let get_subchain (module Conn : CONNECTION) ~start_block_id ~end_block_id =
+    (* derive query from type `t` *)
+    let concat = String.concat ~sep:"," in
+    let columns_with_id = concat ("id" :: Fields.names) in
+    let b_columns_with_id =
+      concat (List.map ("id" :: Fields.names) ~f:(fun s -> "b." ^ s))
+    in
+    let columns = concat Fields.names in
     Conn.collect_list
       (Caqti_request.collect
          Caqti_type.(tup2 int int)
          typ
-         {sql| WITH RECURSIVE chain AS (
-              SELECT id,state_hash,parent_id,parent_hash,creator_id,block_winner_id,
-                     last_vrf_output,snarked_ledger_hash_id,
-                     staking_epoch_data_id,next_epoch_data_id,
-                     min_window_density,sub_window_densities,total_currency,
-                     ledger_hash,height,global_slot_since_hard_fork,global_slot_since_genesis,
-                     protocol_version_id, proposed_protocol_version_id,
-                     timestamp,chain_status
+         (sprintf
+            {sql| WITH RECURSIVE chain AS (
+              SELECT %s
               FROM blocks b WHERE b.id = $1
 
               UNION ALL
 
-              SELECT b.id,b.state_hash,b.parent_id,b.parent_hash,b.creator_id,b.block_winner_id,
-                     b.last_vrf_output,b.snarked_ledger_hash_id,
-                     b.staking_epoch_data_id,b.next_epoch_data_id,
-                     b.min_window_density,b.sub_window_densities,b.total_currency,
-                     b.ledger_hash,b.height,b.global_slot_since_hard_fork,b.global_slot_since_genesis,
-                     b.protocol_version_id, b.proposed_protocol_version_id,
-                     b.timestamp,b.chain_status
+              SELECT %s
               FROM blocks b
 
               INNER JOIN chain
@@ -3471,16 +3467,10 @@ module Block = struct
 
            )
 
-           SELECT state_hash,parent_id,parent_hash,creator_id,block_winner_id,
-                  last_vrf_output,snarked_ledger_hash_id,
-                  staking_epoch_data_id, next_epoch_data_id,
-                  min_window_density,sub_window_densities,total_currency,
-                  ledger_hash,height,
-                  global_slot_since_hard_fork,global_slot_since_genesis,
-                  protocol_version_id, proposed_protocol_version_id,
-                  timestamp,chain_status
+           SELECT %s
            FROM chain ORDER BY height ASC
-      |sql} )
+         |sql}
+            columns_with_id b_columns_with_id columns ) )
       (end_block_id, start_block_id)
 
   let get_highest_canonical_block_opt (module Conn : CONNECTION) =

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1787,25 +1787,6 @@ let mina_commands logger =
 
 [%%endif]
 
-let print_version_help coda_exe version =
-  (* mimic Jane Street command help *)
-  let lines =
-    [ "print version information"
-    ; ""
-    ; sprintf "  %s %s" (Filename.basename coda_exe) version
-    ; ""
-    ; "=== flags ==="
-    ; ""
-    ; "  [-help]  print this help text and exit"
-    ; "           (alias: -?)"
-    ]
-  in
-  List.iter lines ~f:(Core.printf "%s\n%!")
-
-let print_version_info () =
-  Core.printf "Commit %s on branch %s\n" Mina_version.commit_id
-    Mina_version.branch
-
 let () =
   Random.self_init () ;
   let logger = Logger.create () in
@@ -1815,15 +1796,12 @@ let () =
   (* intercept command-line processing for "version", because we don't
      use the Jane Street scripts that generate their version information
   *)
-  (let make_list_mem ss s = List.mem ss s ~equal:String.equal in
-   let is_version_cmd = make_list_mem [ "version"; "-version"; "--version" ] in
-   let is_help_flag = make_list_mem [ "-help"; "-?" ] in
+  (let is_version_cmd s =
+     List.mem [ "version"; "-version"; "--version" ] s ~equal:String.equal
+   in
    match Sys.get_argv () with
-   | [| _coda_exe; version |] when is_version_cmd version ->
+   | [| _mina_exe; version |] when is_version_cmd version ->
        Mina_version.print_version ()
-   | [| coda_exe; version; help |]
-     when is_version_cmd version && is_help_flag help ->
-       print_version_help coda_exe version
    | _ ->
        Command.run
          (Command.group ~summary:"Mina" ~preserve_subcommand_order:()

--- a/src/lib/mina_caqti/mina_caqti.ml
+++ b/src/lib/mina_caqti/mina_caqti.ml
@@ -159,7 +159,7 @@ let array_int_typ : int array Caqti_type.t =
   Caqti_type.custom array_nullable_int_typ ~encode ~decode
 
 (* this type may require type annotations in queries, eg.
-   `SELECT id FROM zkapp_states WHERE element_ids = ?::int64[]`
+   `SELECT id FROM zkapp_states WHERE element_ids = ?::bigint[]`
 *)
 let array_nullable_int64_typ : int64 option array Caqti_type.t =
   Caqti_type.field Array_nullable_int64


### PR DESCRIPTION
We had added columns `last_vrf_output, `protocol_version_id`, and `proposed_protocol_version_id` to the `blocks` table in the archive schema.

There's a subchain query on that table that's used to update the chain status (canonical, etc.). Unlike the main query to insert blocks, that query was not derived automatically from the OCaml type associated with the table.  This PR updates the query to include all fields, automatically derived from the OCaml type.

I was able to reproduce the problem using a db from Gareth, and a precomputed block. After the changes made here, I was able to archive the block to his db.

Also added a `version` flag to `archive.exe`, like the one for `mina.exe`. Removed some not-so-helpful code for `mina.exe` (not too useful to run `mina version -help`, the `version` flag should be self-explanatory).

Also fixed a comment in `Mina_caqti`.

Closes #12995. Note that `archive.exe` already logs a commit, didn't need to add that.