### PR TITLE
Test reporter  in Lucy (berkeley)

### DIFF
--- a/buildkite/scripts/run-test-executive.sh
+++ b/buildkite/scripts/run-test-executive.sh
@@ -28,4 +28,9 @@ mina-test-executive cloud "$TEST_NAME" \
   --archive-image "$ARCHIVE_IMAGE" \
   --mina-automation-location ./automation \
   | tee "$TEST_NAME.test.log" \
-  | mina-logproc -i inline -f '!(.level in ["Debug", "Spam"])'
+  | mina-logproc.exe -i inline -f '!(.level in ["Debug", "Spam"])' 
+
+EXIT_CODE="$?"
+
+./buildkite/scripts/upload-test-results.sh ${testName}
+

--- a/buildkite/scripts/run-test-executive.sh
+++ b/buildkite/scripts/run-test-executive.sh
@@ -2,6 +2,7 @@
 set -o pipefail -x
 
 TEST_NAME="$1"
+
 MINA_IMAGE="gcr.io/o1labs-192920/mina-daemon:$MINA_DOCKER_TAG-berkeley"
 ARCHIVE_IMAGE="gcr.io/o1labs-192920/mina-archive:$MINA_DOCKER_TAG"
 

--- a/buildkite/scripts/run-test-executive.sh
+++ b/buildkite/scripts/run-test-executive.sh
@@ -32,5 +32,5 @@ mina-test-executive cloud "$TEST_NAME" \
 
 EXIT_CODE="$?"
 
-./buildkite/scripts/upload-test-results.sh ${testName}
+./buildkite/scripts/upload-test-results.sh $TEST_NAME
 

--- a/buildkite/scripts/upload-test-results.sh
+++ b/buildkite/scripts/upload-test-results.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -o pipefail -x
+
+TEST_NAME="$1"
+
+if [[ "${TEST_NAME:0:15}" == "block-prod-prio" ]]; then
+  echo "Skipping $TEST_NAME"
+  exit 0
+fi
+
+./test_reporter.exe test-result generate --log-file "$TEST_NAME.test.log" --format junit --output-file test_result.xml
+
+curl -X POST https://analytics-api.buildkite.com/v1/uploads -sv \
+  -H "Authorization: Token token=\"$BUILDKITE_TEST_ANALYTICS_TOKEN\"" \
+  -F "data=@test_result.xml" \
+  -F "format=junit" \
+  -F "run_env[CI]=buildkite" \
+  -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+  -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+  -F "run_env[branch]=$BUILDKITE_BRANCH" \
+  -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+  -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+  -F "run_env[message]=$BUILDKITE_MESSAGE"

--- a/buildkite/scripts/upload-test-results.sh
+++ b/buildkite/scripts/upload-test-results.sh
@@ -16,8 +16,9 @@ curl -X POST https://analytics-api.buildkite.com/v1/uploads -sv \
   -F "format=junit" \
   -F "run_env[CI]=buildkite" \
   -F "run_env[key]=$BUILDKITE_BUILD_ID" \
-  -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+  -F "run_env[url]=$BUILDKITE_BUILD_URL" \
   -F "run_env[branch]=$BUILDKITE_BRANCH" \
   -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
-  -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+  -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+  -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
   -F "run_env[message]=$BUILDKITE_MESSAGE"

--- a/buildkite/scripts/upload-test-results.sh
+++ b/buildkite/scripts/upload-test-results.sh
@@ -3,16 +3,11 @@ set -o pipefail -x
 
 TEST_NAME="$1"
 
-if [[ "${TEST_NAME:0:15}" == "block-prod-prio" ]]; then
-  echo "Skipping $TEST_NAME"
-  exit 0
-fi
-
-./test_reporter.exe test-result generate --log-file "$TEST_NAME.test.log" --format junit --output-file test_result.xml
+./test_reporter.exe test-result generate --log-file "$TEST_NAME.test.log" --format junit --output-file $TEST_NAME.junit.xml
 
 curl -X POST https://analytics-api.buildkite.com/v1/uploads -sv \
   -H "Authorization: Token token=\"$BUILDKITE_TEST_ANALYTICS_TOKEN\"" \
-  -F "data=@test_result.xml" \
+  -F "data=@$TEST_NAME.junit.xml" \
   -F "format=junit" \
   -F "run_env[CI]=buildkite" \
   -F "run_env[key]=$BUILDKITE_BUILD_ID" \

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -25,8 +25,8 @@ in
             ],
         artifact_paths = 
             [
-              SelectFiles.contains "${testName}.test.log",
-              SelectFiles.contains "test_result.xml"
+              SelectFiles.contains "${testName}",
+              SelectFiles.contains "test_result"
             ],
         label = "${testName} integration test",
         key = "integration-test-${testName}",

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -21,7 +21,7 @@ in
         commands =
             [
               -- Execute test based on BUILD image
-              Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName}"
+              Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName} && ./buildkite/scripts/upload-test-results.sh ${testName} "
             ],
         artifact_paths = [SelectFiles.exactly "." "${testName}.test.log"],
         label = "${testName} integration test",
@@ -56,7 +56,10 @@ in
               Cmd.run "artifact-cache-helper.sh snarkyjs_test.tar.gz && tar -xzf snarkyjs_test.tar.gz",
 
               -- Execute test based on BUILD image
-              Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName}"
+              Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName}",
+                          
+              -- Upload test report
+              Cmd.run "./buildkite/scripts/upload-test-results.sh ${testName}"
             ],
         artifact_paths = [SelectFiles.exactly "." "${testName}.test.log"],
         label = "${testName} integration test",

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -23,7 +23,11 @@ in
               -- Execute test based on BUILD image
               Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName} && ./buildkite/scripts/upload-test-results.sh ${testName} "
             ],
-        artifact_paths = [SelectFiles.exactly "." "${testName}.test.log"],
+        artifact_paths = 
+            [
+              SelectFiles.contains "${testName}.test.log",
+              SelectFiles.contains "test_result.xml"
+            ],
         label = "${testName} integration test",
         key = "integration-test-${testName}",
         target = Size.Integration,

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -21,7 +21,7 @@ in
         commands =
             [
               -- Execute test based on BUILD image
-              Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName} && ./buildkite/scripts/upload-test-results.sh ${testName} "
+              Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName} && ls -al && ls -al ./buildkite/scripts && ./buildkite/scripts/upload-test-results.sh ${testName} "
             ],
         artifact_paths = 
             [

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -21,12 +21,12 @@ in
         commands =
             [
               -- Execute test based on BUILD image
-              Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName} && ls -al && ls -al ./buildkite/scripts && ./buildkite/scripts/upload-test-results.sh ${testName} "
+              Cmd.run "MINA_DEB_CODENAME=bullseye ; source ./buildkite/scripts/export-git-env-vars.sh && ./buildkite/scripts/run-test-executive.sh ${testName} -upload"
             ],
         artifact_paths = 
             [
-              SelectFiles.contains "${testName}",
-              SelectFiles.contains "test_result"
+              SelectFiles.exactly "../../" "${testName}.test.log",
+              SelectFiles.exactly "../../" "${testName}.junit.xml"
             ],
         label = "${testName} integration test",
         key = "integration-test-${testName}",

--- a/opam.export
+++ b/opam.export
@@ -131,6 +131,7 @@ installed: [
   "js_of_ocaml-compiler.4.0.0"
   "js_of_ocaml-ppx.4.0.0"
   "js_of_ocaml-toplevel.4.0.0"
+  "junit.2.0.2"
   "jsonm.1.0.1"
   "jst-config.v0.14.1"
   "lambda-term.3.1.0"

--- a/src/app/logproc/logproc.ml
+++ b/src/app/logproc/logproc.ml
@@ -34,6 +34,8 @@ let level_color =
       orange
   | Fatal ->
       bright_red
+  | Span ->
+      blue
 
 let format_msg ~interpolation_config ~timezone msg =
   let open Logger.Message in

--- a/src/app/test_executive/snarkyjs.ml
+++ b/src/app/test_executive/snarkyjs.ml
@@ -50,7 +50,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
     let%bind () =
       [%log info] "Waiting for nodes to be initialized" ;
       let%bind () = wait_for t (Wait_condition.node_to_initialize node) in
-      [%log info] "Running test script" ;
+      [%log info] "Running script" ;
       let%bind.Deferred result =
         let%bind.Deferred process =
           Async_unix.Process.create_exn

--- a/src/app/test_executive/test_result.ml
+++ b/src/app/test_executive/test_result.ml
@@ -1,0 +1,243 @@
+open Core
+open Async
+open Integration_test_lib
+open Test_error
+open Test_error.Set
+
+module Test_Result_Evaluator = struct
+  type t =
+    { log_error_set :
+        Integration_test_lib.Test_error.remote_error
+        Integration_test_lib.Test_error.Set.t
+    ; internal_error_set :
+        Integration_test_lib.Test_error.internal_error
+        Integration_test_lib.Test_error.Set.t
+    }
+
+  let max_sev a b =
+    match (a, b) with
+    | `Hard, _ | _, `Hard ->
+        `Hard
+    | `Soft, _ | _, `Soft ->
+        `Soft
+    | _ ->
+        `None
+
+  let max_severity_of_list severities =
+    List.fold severities ~init:`None ~f:max_sev
+
+  let combine_errors error_set =
+    Error_accumulator.combine
+      [ Error_accumulator.map error_set.soft_errors ~f:(fun err -> (`Soft, err))
+      ; Error_accumulator.map error_set.hard_errors ~f:(fun err -> (`Hard, err))
+      ]
+
+  let internal_errors t = combine_errors t.internal_error_set
+
+  let internal_errors_severity t = max_severity t.internal_error_set
+
+  let log_errors t = combine_errors t.log_error_set
+
+  let log_errors_severity t = max_severity t.log_error_set
+
+  let test_failed t =
+    match (log_errors_severity t, internal_errors_severity t) with
+    | _, `Hard | _, `Soft ->
+        true
+    (* TODO: re-enable log error checks after libp2p logs are cleaned up *)
+    | `Hard, _ | `Soft, _ | `None, `None ->
+        false
+
+  let exit_code t =
+    match (t.internal_error_set.exit_code, t.log_error_set.exit_code) with
+    | None, None ->
+        1
+    | Some exit_code, _ | None, Some exit_code ->
+        exit_code
+end
+
+let failure_text = "The test has failed. See the above errors for details"
+
+let success_text = "The test has completed successfully"
+
+let printout_test_result (test_eval : Test_Result_Evaluator.t) =
+  (* TODO: we should be able to show which sections passed as well *)
+  let open Test_error in
+  let color_eprintf color =
+    Printf.ksprintf (fun s -> Print.eprintf "%s%s%s" color s Bash_colors.none)
+  in
+  let color_of_severity = function
+    | `None ->
+        Bash_colors.green
+    | `Soft ->
+        Bash_colors.yellow
+    | `Hard ->
+        Bash_colors.red
+  in
+  let category_prefix_of_severity = function
+    | `None ->
+        "✓"
+    | `Soft ->
+        "-"
+    | `Hard ->
+        "×"
+  in
+  let print_category_header severity =
+    Printf.ksprintf
+      (color_eprintf
+         (color_of_severity severity)
+         "%s %s\n"
+         (category_prefix_of_severity severity) )
+  in
+  let report_log_errors log_type =
+    color_eprintf
+      (color_of_severity (Test_Result_Evaluator.log_errors_severity test_eval))
+      "=== Log %ss ===\n" log_type ;
+    Test_Result_Evaluator.log_errors test_eval
+    |> Error_accumulator.iter_contexts ~f:(fun node_id log_errors ->
+           color_eprintf Bash_colors.light_magenta "    %s:\n" node_id ;
+           List.iter log_errors ~f:(fun (severity, { error_message; _ }) ->
+               color_eprintf
+                 (color_of_severity severity)
+                 "        [%s] %s\n"
+                 (Time.to_string error_message.timestamp)
+                 (Yojson.Safe.to_string
+                    (Logger.Message.to_yojson error_message) ) ) ;
+           Print.eprintf "\n" )
+  in
+  (* check invariants *)
+  match (Test_Result_Evaluator.log_errors test_eval).from_current_context with
+  | _ :: _ ->
+      failwith "all error logs should be contextualized by node id"
+  | [] ->
+      (* report log errors *)
+      Print.eprintf "\n" ;
+      ( match Test_Result_Evaluator.log_errors_severity test_eval with
+      | `None ->
+          ()
+      | `Soft ->
+          report_log_errors "Warning"
+      | `Hard ->
+          report_log_errors "Error" ) ;
+      (* report contextualized internal errors *)
+      color_eprintf Bash_colors.magenta "=== Test Results ===\n" ;
+      Test_Result_Evaluator.internal_errors test_eval
+      |> Error_accumulator.iter_contexts ~f:(fun context errors ->
+             print_category_header
+               (Test_Result_Evaluator.max_severity_of_list
+                  (List.map errors ~f:fst) )
+               "%s" context ;
+             List.iter errors ~f:(fun (severity, { occurrence_time; error }) ->
+                 color_eprintf
+                   (color_of_severity severity)
+                   "    [%s] %s\n"
+                   (Time.to_string occurrence_time)
+                   (Error.to_string_hum error) ) ) ;
+      (* report non-contextualized internal errors *)
+      List.iter
+        (Test_Result_Evaluator.internal_errors test_eval).from_current_context
+        ~f:(fun (severity, { occurrence_time; error }) ->
+          color_eprintf
+            (color_of_severity severity)
+            "[%s] %s\n"
+            (Time.to_string occurrence_time)
+            (Error.to_string_hum error) ) ;
+      (* determine if test is passed/failed and exit accordingly *)
+      Print.eprintf "\n" ;
+      if Test_Result_Evaluator.test_failed test_eval then
+        color_eprintf Bash_colors.red "%s\n\n" failure_text
+      else color_eprintf Bash_colors.green "%s\n\n" success_text ;
+      Writer.(flushed (Lazy.force stderr))
+
+let write_test_result_to_log ~test_eval ~logger =
+  let severity_to_string severity =
+    match severity with `None -> "Ok" | `Soft -> "Warning" | `Hard -> "Error"
+  in
+  [%log span] "Test result generation $event"
+    ~metadata:[ ("event", `String "start") ] ;
+  let report_log_errors log_type =
+    [%log span] "Node logs analysis $event for "
+      ~metadata:[ ("event", `String "start"); ("severity", `String log_type) ] ;
+    Test_Result_Evaluator.log_errors test_eval
+    |> Error_accumulator.iter_contexts ~f:(fun node_id log_errors ->
+           List.iter log_errors ~f:(fun (severity, { error_message; _ }) ->
+               [%log error] "Incident found: $message"
+                 ~metadata:
+                   [ ("time", `String (Time.to_string error_message.timestamp))
+                   ; ("node_is", `String node_id)
+                   ; ("severity", `String (severity_to_string severity))
+                   ; ( "message"
+                     , `String
+                         (Yojson.Safe.to_string
+                            (Logger.Message.to_yojson error_message) ) )
+                   ] ) )
+  in
+  ( match Test_Result_Evaluator.log_errors_severity test_eval with
+  | `None ->
+      ()
+  | `Soft ->
+      report_log_errors "Warning"
+  | `Hard ->
+      report_log_errors "Error" ) ;
+  [%log span] "Node logs analysis $event"
+    ~metadata:[ ("event", `String "finish") ] ;
+  [%log span] "Test result analysis $event"
+    ~metadata:[ ("event", `String "start") ] ;
+  [%log span] "Contextualized result analysis $event"
+    ~metadata:[ ("event", `String "start") ] ;
+  Test_Result_Evaluator.internal_errors test_eval
+  |> Error_accumulator.iter_contexts ~f:(fun context errors ->
+         [%log span] "Analysis for context: $context"
+           ~metadata:
+             [ ("event", `String "start"); ("context", `String context) ] ;
+         List.iter errors ~f:(fun (severity, { occurrence_time; error }) ->
+             [%log error] "Contextualized Incident found"
+               ~metadata:
+                 [ ("time", `String (Time.to_string occurrence_time))
+                 ; ("severity", `String (severity_to_string severity))
+                 ; ("message", `String (Error.to_string_hum error))
+                 ] ) ;
+         [%log span] "Analysis for context: $context"
+           ~metadata:
+             [ ("event", `String "finish"); ("context", `String context) ] ) ;
+  [%log span] "Contextualized result analysis $event"
+    ~metadata:[ ("event", `String "finish") ] ;
+  [%log span] "Non-Contextualized result analysis $event"
+    ~metadata:[ ("event", `String "start") ] ;
+  List.iter
+    (Test_Result_Evaluator.internal_errors test_eval).from_current_context
+    ~f:(fun (severity, { occurrence_time; error }) ->
+      [%log error] "Non-Contextualized Incident found: $message"
+        ~metadata:
+          [ ("time", `String (Time.to_string occurrence_time))
+          ; ("severity", `String (severity_to_string severity))
+          ; ("message", `String (Error.to_string_hum error))
+          ] ) ;
+  [%log span] "Non-Contextualized result analysis $event"
+    ~metadata:[ ("event", `String "finish") ] ;
+  if Test_Result_Evaluator.test_failed test_eval then (
+    [%log fatal] "Test Result: $result. $failure_text"
+      ~metadata:
+        [ ("result", `String "failed"); ("failure_text", `String failure_text) ] ;
+    [%log fatal] "Exit Code: $exit_code."
+      ~metadata:
+        [ ("exit_code", `Int (Test_Result_Evaluator.exit_code test_eval)) ] )
+  else
+    [%log fatal] "Test Result: $result. $success_text"
+      ~metadata:
+        [ ("result", `String "passed"); ("success_text", `String success_text) ] ;
+  [%log span] "Test result generation $event"
+    ~metadata:[ ("event", `String "finish") ]
+
+let calculate_test_result ~log_error_set ~internal_error_set ~logger =
+  let test_eval : Test_Result_Evaluator.t =
+    { log_error_set; internal_error_set }
+  in
+  let exit_code =
+    if Test_Result_Evaluator.test_failed test_eval then
+      Some (Test_Result_Evaluator.exit_code test_eval)
+    else None
+  in
+  let () = write_test_result_to_log ~test_eval ~logger in
+  let%bind () = printout_test_result test_eval in
+  return exit_code

--- a/src/app/test_executive/test_result.mli
+++ b/src/app/test_executive/test_result.mli
@@ -1,0 +1,14 @@
+(* Function responsible to printout test results into stdout but also log all necessary data
+   for post-mortem test result analysis. In order to allow easier navigation in log it uses
+   'span' log type whit corresponding metadata attributes like stop and start to indicate which
+   step of test result is performed
+*)
+val calculate_test_result :
+     log_error_set:
+       Integration_test_lib.Test_error.remote_error
+       Integration_test_lib.Test_error.Set.t
+  -> internal_error_set:
+       Integration_test_lib.Test_error.internal_error
+       Integration_test_lib.Test_error.Set.t
+  -> logger:Logger.t
+  -> int option Async_kernel__Types.Deferred.t

--- a/src/app/test_reporter/buildkite_result.ml
+++ b/src/app/test_reporter/buildkite_result.ml
@@ -1,0 +1,132 @@
+open Test_log
+open Core
+
+module Outcome = struct
+  type t = Passed | Failed | Skipped | Unknown
+  [@@deriving sexp, equal, compare, show { with_path = false }, enumerate]
+
+  let to_yojson t = `String (show t)
+
+  let of_string str =
+    try Ok (t_of_sexp (Sexp.Atom str))
+    with Sexp.Of_sexp_error (err, _) -> Error (Exn.to_string err)
+
+  let of_test_result test_result =
+    match test_result with
+    | TestResult.Passed ->
+        Passed
+    | TestResult.Failed ->
+        Failed
+    | TestResult.Skipped ->
+        Skipped
+end
+
+module Section = struct
+  type t = Http | Sql | Sleep | Annotation
+  [@@deriving sexp, equal, compare, show { with_path = false }, enumerate]
+
+  let to_yojson t = `String (show t)
+end
+
+module HttpMethod = struct
+  type t =
+    | GET
+    | POST
+    | PUT
+    | DELETE
+    | PATCH
+    | HEAD
+    | CONNECT
+    | OPTIONS
+    | TRACE
+  [@@deriving sexp, equal, compare, show { with_path = false }, enumerate]
+
+  let to_yojson t = `String (show t)
+end
+
+module BuildkiteTestResult = struct
+  type detail_t =
+    { m : HttpMethod.t option [@default None] [@key "method"]
+    ; url : string option
+    ; lib : string option
+    ; query : string option
+    }
+  [@@deriving to_yojson]
+
+  type span_t =
+    { section : Section.t
+    ; start_at : float
+    ; end_at : float
+    ; duration : float option
+    ; detail : detail_t option
+    }
+  [@@deriving to_yojson]
+
+  type history_t =
+    { start_at : float
+    ; end_at : float option
+    ; duration : float
+    ; children : span_t list option
+    }
+  [@@deriving to_yojson]
+
+  type test_result =
+    { id : string option
+    ; scope : string option
+    ; name : string option
+    ; identifier : string
+    ; file_name : string option
+    ; result : Outcome.t option
+    ; failure_reason : string option
+    ; failure_expanded : string list option
+    ; history : history_t list
+    }
+  [@@deriving to_yojson]
+
+  let from_test_log ~(test_log : TestLogInfo.t) =
+    let history =
+      List.map test_log.perf_measurements
+        ~f:(fun (measurement : PerfMeasurement.t) ->
+          { start_at = measurement.start
+          ; end_at = Some (measurement.start +. measurement.duration)
+          ; duration = measurement.duration
+          ; children =
+              Some
+                [ { section = Section.Annotation
+                  ; start_at = measurement.start
+                  ; end_at = measurement.start +. measurement.duration
+                  ; duration = Some measurement.duration
+                  ; detail =
+                      Some
+                        { m = None
+                        ; url = None
+                        ; lib = Some measurement.name
+                        ; query = None
+                        }
+                  }
+                ]
+          } )
+    in
+    let identifier =
+      match test_log.test_name with Some name -> name | None -> "undefined"
+    in
+    { id = None
+    ; scope = Some "Test executive integration test"
+    ; name = test_log.test_name
+    ; identifier
+    ; file_name = Some "src/app/test_executive/test_executive.ml"
+    ; result = Some (Outcome.of_test_result test_log.test_result)
+    ; failure_reason = test_log.failure_reason
+    ; failure_expanded = TestLogInfo.get_maybe_failure_expanded test_log
+    ; history
+    }
+
+  let write_to_json t ~output_file =
+    Out_channel.with_file ~fail_if_exists:true output_file ~f:(fun ch ->
+        test_result_to_yojson t |> Yojson.Safe.pretty_to_string
+        |> Out_channel.output_string ch )
+end
+
+let write_to_json ~(test_log : TestLogInfo.t) ~output_file =
+  BuildkiteTestResult.from_test_log ~test_log
+  |> BuildkiteTestResult.write_to_json ~output_file

--- a/src/app/test_reporter/dune
+++ b/src/app/test_reporter/dune
@@ -1,0 +1,31 @@
+(executable
+ (name test_reporter)
+ (libraries
+   ;;opam libraries
+   result
+   stdio
+   core
+   yojson
+   cmdliner
+   core_kernel
+   ppx_deriving_yojson.runtime
+   sexplib0
+   cohttp
+   lwt
+   async_kernel
+   integration_test_lib
+   integration_test_cloud_engine
+   uri
+   cohttp-async
+   async
+   async_unix
+   junit
+   ptime
+   ;;local libraries
+   logger
+   logproc_lib
+   bash_colors
+   interpolator_lib
+ )
+ (instrumentation (backend bisect_ppx))
+ (preprocess (pps ppx_version ppx_jane ppx_mina ppx_deriving.std)))

--- a/src/app/test_reporter/junit_result.ml
+++ b/src/app/test_reporter/junit_result.ml
@@ -1,0 +1,57 @@
+open Core
+open Test_log
+
+let build_report (log_info : TestLogInfo.t) =
+  let test_name =
+    match log_info.test_name with
+    | Some test_name ->
+        test_name
+    | None ->
+        failwith "cannot find test name in log file"
+  in
+  let suite =
+    let properties =
+      [ Junit.Property.make ~name:"test.name" ~value:test_name
+      ; Junit.Property.make ~name:"testnet.name"
+          ~value:(Option.value ~default:"unknown" log_info.testnet_name)
+      ; Junit.Property.make ~name:"mina.image"
+          ~value:(Option.value ~default:"unknown" log_info.mina_image)
+      ; Junit.Property.make ~name:"coverage.files"
+          ~value:(String.concat ~sep:"," log_info.coverage_files)
+      ]
+    in
+    let classname = sprintf "Test_executive.%s_test" test_name in
+    let testcase =
+      match log_info.test_result with
+      | Passed ->
+          Junit.Testcase.pass ~name:test_name ~classname
+            ~time:(log_info.test_end -. log_info.test_start)
+      | Failed ->
+          let message =
+            Option.value log_info.failure_reason ~default:"no message"
+          in
+          Junit.Testcase.failure ~name:test_name ~classname
+            ~time:(log_info.test_end -. log_info.test_start)
+            ~message ~typ:"Test Failure"
+            (String.concat ~sep:"\n" log_info.failure_expanded)
+      | Skipped ->
+          Junit.Testcase.skipped ~name:test_name ~classname
+            ~time:(log_info.test_end -. log_info.test_start)
+    in
+
+    let timestamp =
+      match Ptime.of_date_time ((2013, 5, 24), ((10, 23, 58), 0)) with
+      | Some t ->
+          t
+      | None ->
+          assert false
+    in
+    Junit.Testsuite.make ~timestamp ~name:test_name ()
+    |> Junit.Testsuite.add_testcases [ testcase ]
+    |> Junit.Testsuite.add_properties properties
+  in
+  Junit.make [ suite ]
+
+let write_to_xml ~(test_log : TestLogInfo.t) ~output_file =
+  let report = build_report test_log in
+  Junit.to_file report output_file

--- a/src/app/test_reporter/junit_result.ml
+++ b/src/app/test_reporter/junit_result.ml
@@ -9,6 +9,18 @@ let build_report (log_info : TestLogInfo.t) =
     | None ->
         failwith "cannot find test name in log file"
   in
+  let duration =
+    match log_info.test_end with
+    | Some test_end -> (
+        match log_info.test_start with
+        | Some test_start ->
+            let span = Time.diff test_end test_start in
+            Time.Span.to_sec span
+        | None ->
+            0.0 )
+    | None ->
+        0.0
+  in
   let suite =
     let properties =
       [ Junit.Property.make ~name:"test.name" ~value:test_name
@@ -24,25 +36,34 @@ let build_report (log_info : TestLogInfo.t) =
     let testcase =
       match log_info.test_result with
       | Passed ->
-          Junit.Testcase.pass ~name:test_name ~classname
-            ~time:(log_info.test_end -. log_info.test_start)
+          Junit.Testcase.pass ~name:test_name ~classname ~time:duration
       | Failed ->
           let message =
             Option.value log_info.failure_reason ~default:"no message"
           in
-          Junit.Testcase.failure ~name:test_name ~classname
-            ~time:(log_info.test_end -. log_info.test_start)
+          Junit.Testcase.failure ~name:test_name ~classname ~time:duration
             ~message ~typ:"Test Failure"
             (String.concat ~sep:"\n" log_info.failure_expanded)
       | Skipped ->
-          Junit.Testcase.skipped ~name:test_name ~classname
-            ~time:(log_info.test_end -. log_info.test_start)
+          Junit.Testcase.skipped ~name:test_name ~classname ~time:duration
     in
 
     let timestamp =
-      match Ptime.of_date_time ((2013, 5, 24), ((10, 23, 58), 0)) with
-      | Some t ->
-          t
+      match log_info.test_start with
+      | Some time -> (
+          let date, of_day = Time.to_date_ofday ~zone:Time.Zone.utc time in
+          let year = Date.year date in
+          let month = Month.to_int (Date.month date) in
+          let day = Date.day date in
+          let time_in_day = Time.Ofday.to_parts of_day in
+          match
+            Ptime.of_date_time
+              ((year, month, day), ((time_in_day.hr, time_in_day.min, 0), 0))
+          with
+          | Some t ->
+              t
+          | None ->
+              assert false )
       | None ->
           assert false
     in

--- a/src/app/test_reporter/test_log.ml
+++ b/src/app/test_reporter/test_log.ml
@@ -1,0 +1,144 @@
+open Core
+module CoverageFiles = Map.Make (String)
+
+module PerfMeasurement = struct
+  type t = { name : string; start : float; duration : float }
+end
+
+module TestResult = struct
+  type t = Passed | Failed | Skipped
+  [@@deriving sexp, equal, compare, show { with_path = false }, enumerate]
+
+  let to_yojson t = `String (show t)
+
+  let of_string str =
+    try Ok (t_of_sexp (Sexp.Atom str))
+    with Sexp.Of_sexp_error (err, _) -> Error (Exn.to_string err)
+end
+
+module TestLogInfo = struct
+  type t =
+    { mutable testnet_name : string option
+    ; mutable test_name : string option
+    ; mutable mina_image : string option
+    ; mutable coverage_files : string list
+    ; mutable perf_measurements : PerfMeasurement.t list
+    ; mutable test_result : TestResult.t
+    ; mutable test_start : float
+    ; mutable test_end : float
+    ; mutable failure_reason : string option
+    ; mutable failure_expanded : string list
+    }
+
+  let get_metadata_key_or_fail metadata key =
+    match Map.find_exn metadata key with
+    | `String p ->
+        p
+    | _ ->
+        failwith (Printf.sprintf "Expected '%s' key in metadata " key)
+
+  let get_maybe_failure_expanded t =
+    if List.length t.failure_expanded > 0 then Some t.failure_expanded else None
+
+  let empty =
+    { testnet_name = None
+    ; test_name = None
+    ; mina_image = None
+    ; coverage_files = []
+    ; perf_measurements = []
+    ; test_result = TestResult.Skipped
+    ; failure_reason = None
+    ; failure_expanded = []
+    ; test_start = 0.0
+    ; test_end = 0.0
+    }
+
+  let from_logs ~logger ~log_file =
+    let coverage_manager_ref : t ref = ref empty in
+    let log_lines = In_channel.read_lines log_file in
+    List.iter log_lines ~f:(fun line ->
+        let json = Yojson.Safe.from_string line in
+        let msg = Logger.Message.of_yojson json in
+        match msg with
+        | Ok msg ->
+            if
+              String.is_substring msg.message
+                ~substring:"Coverage files downloaded"
+            then
+              let coverage_files_metadata =
+                get_metadata_key_or_fail msg.metadata "files"
+              in
+              !coverage_manager_ref.coverage_files <-
+                String.split ~on:',' coverage_files_metadata
+            else if String.is_substring msg.message ~substring:"Running test"
+            then (
+              let testnet_name =
+                get_metadata_key_or_fail msg.metadata "testnet_name"
+              in
+              let test_name =
+                get_metadata_key_or_fail msg.metadata "test_name"
+              in
+              let mina_image = get_metadata_key_or_fail msg.metadata "image" in
+              !coverage_manager_ref.testnet_name <- Some testnet_name ;
+              !coverage_manager_ref.test_name <- Some test_name ;
+              !coverage_manager_ref.mina_image <- Some mina_image )
+            else if
+              String.is_substring msg.message
+                ~substring:"Contextualized Incident found"
+            then
+              !coverage_manager_ref.failure_expanded <-
+                !coverage_manager_ref.failure_expanded
+                @ [ get_metadata_key_or_fail msg.metadata "message" ]
+            else if String.is_substring msg.message ~substring:"Test Result:"
+            then
+              let result_str = get_metadata_key_or_fail msg.metadata "result" in
+              let result =
+                match TestResult.of_string result_str with
+                | Ok test_result -> (
+                    match test_result with
+                    | TestResult.Failed ->
+                        let failure_text =
+                          get_metadata_key_or_fail msg.metadata "failure_text"
+                        in
+                        !coverage_manager_ref.failure_reason <-
+                          Some failure_text ;
+                        test_result
+                    | _ ->
+                        test_result )
+                | Error _ ->
+                    [%log warn]
+                      "cannot determine test result.. set Skipped by default" ;
+                    TestResult.Skipped
+              in
+              !coverage_manager_ref.test_result <- result
+            else if
+              String.is_substring msg.message
+                ~substring:"Performance measurement"
+            then
+              let description =
+                get_metadata_key_or_fail msg.metadata "description"
+              in
+              let soft_timeout =
+                get_metadata_key_or_fail msg.metadata "soft_timeout"
+              in
+              let hard_timeout =
+                get_metadata_key_or_fail msg.metadata "hard_timeout"
+              in
+              let name =
+                Printf.sprintf "%s with timeouts (%s/%s)" description
+                  soft_timeout hard_timeout
+              in
+              let duration = get_metadata_key_or_fail msg.metadata "duration" in
+              let start = get_metadata_key_or_fail msg.metadata "start" in
+              !coverage_manager_ref.perf_measurements <-
+                !coverage_manager_ref.perf_measurements
+                @ [ { name
+                    ; start = float_of_string start
+                    ; duration = float_of_string duration
+                    }
+                  ]
+            else ()
+        | Error str ->
+            [%log error] "%s" str ) ;
+    !coverage_manager_ref
+end

--- a/src/app/test_reporter/test_reporter.ml
+++ b/src/app/test_reporter/test_reporter.ml
@@ -1,0 +1,14 @@
+open Core
+
+let test_result_commands = [ ("generate", Test_result.generate_test_result) ]
+
+let commands =
+  [ ( "test-result"
+    , Command.group ~summary:"Test artifacts related commands"
+        test_result_commands )
+  ]
+
+let () =
+  Command.run
+    (Command.group ~summary:"Test reporter main commands"
+       ~preserve_subcommand_order:() commands )

--- a/src/app/test_reporter/test_result.ml
+++ b/src/app/test_reporter/test_result.ml
@@ -1,0 +1,42 @@
+open Core
+open Test_log
+
+type format = Junit | Buildkite
+
+let format_arg =
+  Command.Arg_type.create (fun format ->
+      let lowercase_format = String.lowercase format in
+      match String.lowercase format with
+      | "junit" ->
+          Junit
+      | "buildkite" ->
+          Buildkite
+      | _ ->
+          eprintf "Invalid format: %s" lowercase_format ;
+          exit 1 )
+
+let generate_test_result =
+  Command.basic
+    ~summary:
+      "Generates test report compatible with buildkite test analysis JSON \
+       format"
+    Command.Let_syntax.(
+      let%map_open log_file =
+        flag "--log-file" ~aliases:[ "-l" ] (required string)
+          ~doc:"input log file from test execution"
+      and output_file =
+        flag "--output-file" ~aliases:[ "-o" ] (required string)
+          ~doc:"output report file"
+      and format =
+        flag "--format" ~aliases:[ "-f" ] (required format_arg)
+          ~doc:"output format type (Junit|Buildkite)"
+      in
+      fun () ->
+        let logger = Logger.create () in
+        [%log info] "Processing log file: %s" log_file ;
+        let test_log = TestLogInfo.from_logs ~logger ~log_file in
+        match format with
+        | Junit ->
+            Junit_result.write_to_xml ~test_log ~output_file
+        | Buildkite ->
+            Buildkite_result.write_to_json ~test_log ~output_file)

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -136,7 +136,12 @@ module Network_config = struct
     let git_commit = Mina_version.commit_id_short in
     (* see ./src/app/test_executive/README.md for information regarding the namespace name format and length restrictions *)
     let testnet_name = "it-" ^ user ^ "-" ^ git_commit ^ "-" ^ test_name in
-
+    [%log info] "Running test"
+      ~metadata:
+        [ ("image", `String images.mina)
+        ; ("testnet_name", `String testnet_name)
+        ; ("test_name", `String test_name)
+        ] ;
     (* check to make sure the test writer hasn't accidentally created duplicate names of accounts and keys *)
     let key_names_list =
       List.map genesis_ledger ~f:(fun acct -> acct.account_name)

--- a/src/lib/integration_test_lib/util.ml
+++ b/src/lib/integration_test_lib/util.ml
@@ -90,3 +90,8 @@ let rec prompt_continue prompt_string =
   print_newline () ;
   if Char.equal c 'y' || Char.equal c 'Y' then Deferred.unit
   else prompt_continue prompt_string
+
+let write_to_file file_name content =
+  let file = Out_channel.create file_name in
+  Out_channel.output_string file content ;
+  Malleable_error.ok_unit

--- a/src/lib/logger/fake/logger.ml
+++ b/src/lib/logger/fake/logger.ml
@@ -9,6 +9,7 @@ module Level = struct
     | Internal
     | Spam
     | Trace
+    | Span
     | Debug
     | Info
     | Warn
@@ -162,6 +163,8 @@ type 'a log_function =
   -> ?event_id:Structured_log_events.id
   -> ('a, unit, string, unit) format4
   -> 'a
+
+let span = log ~level:Level.Span
 
 let trace = log ~level:Level.Trace
 

--- a/src/lib/logger/logger.mli
+++ b/src/lib/logger/logger.mli
@@ -12,6 +12,7 @@ module Level : sig
     | Internal
     | Spam
     | Trace
+    | Span
     | Debug
     | Info
     | Warn
@@ -161,6 +162,8 @@ val spam :
   -> ?metadata:(string, Yojson.Safe.t) List.Assoc.t
   -> ('a, unit, string, unit) format4
   -> 'a
+
+val span : _ log_function
 
 val faulty_peer : _ log_function [@@deprecated "use Trust_system.record"]
 

--- a/src/lib/logger/native/logger.ml
+++ b/src/lib/logger/native/logger.ml
@@ -7,6 +7,7 @@ module Level = struct
     | Internal
     | Spam
     | Trace
+    | Span
     | Debug
     | Info
     | Warn
@@ -422,6 +423,8 @@ let warn = log ~level:Warn
 let error = log ~level:Error
 
 let fatal = log ~level:Fatal
+
+let span = log ~level:Span
 
 let faulty_peer_without_punishment = log ~level:Faulty_peer
 


### PR DESCRIPTION
Explain your changes:

Introduced test reported module, which is responsible for converting test executive log into `junit.xml` format which then can be consumed by buildkite test analytics module: https://buildkite.com/docs/test-analytics#main. I had to make some changes in Lucy code as well to correctly determined what is test result. For this purpose I've added new log level (Span), which is a common way to inform reader that about inner scope of logs. 

Currently only `junit.xml` is supported (preferred was buildkite json file, but buildkite api has issues on uploading.. resolving it with buildkite support team).

Link to rfc: https://github.com/o1-labs/rfcs/pull/15

Checklist:

- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

