### PR TITLE
Remove snark-test from CI

### DIFF
--- a/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
+++ b/buildkite/src/Jobs/Test/TestnetIntegrationTests.dhall
@@ -39,7 +39,6 @@ in Pipeline.build Pipeline.Config::{
     TestExecutive.execute "gossip-consis" dependsOn,
     TestExecutive.execute "opt-block-prod" dependsOn,
     TestExecutive.execute "medium-bootstrap" dependsOn,
-    TestExecutive.execute "snark" dependsOn,
     TestExecutive.execute "block-reward" dependsOn,
     TestExecutive.execute "zkapps" dependsOn,
     TestExecutive.execute "zkapps-timing" dependsOn,


### PR DESCRIPTION
The `snark` integration test only tests features tested in other integration tests. Removing it to lower cloud resource usage.
