### PR TITLE
Migrate Fee excess tests to alcotest.

### DIFF
--- a/src/lib/mina_base/fee_excess.ml
+++ b/src/lib/mina_base/fee_excess.ml
@@ -378,16 +378,18 @@ let rebalance_checked { fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } =
 
 (** Combine the fee excesses from two transitions. *)
 let combine
-    { fee_token_l = fee_token1_l
-    ; fee_excess_l = fee_excess1_l
-    ; fee_token_r = fee_token1_r
-    ; fee_excess_r = fee_excess1_r
-    }
-    { fee_token_l = fee_token2_l
-    ; fee_excess_l = fee_excess2_l
-    ; fee_token_r = fee_token2_r
-    ; fee_excess_r = fee_excess2_r
-    } =
+    ({ fee_token_l = fee_token1_l
+     ; fee_excess_l = fee_excess1_l
+     ; fee_token_r = fee_token1_r
+     ; fee_excess_r = fee_excess1_r
+     } :
+      t )
+    ({ fee_token_l = fee_token2_l
+     ; fee_excess_l = fee_excess2_l
+     ; fee_token_r = fee_token2_r
+     ; fee_excess_r = fee_excess2_r
+     } :
+      t ) : t Or_error.t =
   let open Or_error.Let_syntax in
   (* Eliminate fee_excess1_r. *)
   let%bind (fee_token1_l, fee_excess1_l), (fee_token2_l, fee_excess2_l) =
@@ -555,7 +557,7 @@ let to_one_or_two ({ fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } : t)
 
 [%%ifdef consensus_mechanism]
 
-let gen =
+let gen : t Quickcheck.Generator.t =
   let open Quickcheck.Generator.Let_syntax in
   let%map excesses =
     One_or_two.gen (Quickcheck.Generator.tuple2 Token_id.gen Fee.Signed.gen)
@@ -573,51 +575,5 @@ let gen =
           ; fee_token_r = Token_id.default
           ; fee_excess_r = Fee.Signed.zero
           } )
-
-let%test_unit "Checked and unchecked behaviour is consistent" =
-  Quickcheck.test (Quickcheck.Generator.tuple2 gen gen) ~f:(fun (fe1, fe2) ->
-      let fe = combine fe1 fe2 in
-      let fe_checked =
-        Or_error.try_with (fun () ->
-            Test_util.checked_to_unchecked
-              Typ.(typ * typ)
-              typ
-              (fun (fe1, fe2) -> combine_checked fe1 fe2)
-              (fe1, fe2) )
-      in
-      match (fe, fe_checked) with
-      | Ok fe, Ok fe_checked ->
-          [%test_eq: t] fe fe_checked
-      | Error _, Error _ ->
-          ()
-      | _ ->
-          [%test_eq: t Or_error.t] fe fe_checked )
-
-let%test_unit "Combine succeeds when the middle excess is zero" =
-  Quickcheck.test
-    Quickcheck.Generator.(
-      filter (tuple3 gen Token_id.gen Fee.Signed.gen)
-        ~f:(fun (fe1, tid, _excess) ->
-          (* The tokens before and after should be distinct. Especially in this
-             scenario, we may get an overflow error otherwise.
-          *)
-          not (Token_id.equal fe1.fee_token_l tid) ))
-    ~f:(fun (fe1, tid, excess) ->
-      let fe2 =
-        if Fee.Signed.(equal zero) fe1.fee_excess_r then of_single (tid, excess)
-        else
-          match
-            of_one_or_two
-              (`Two
-                ( (fe1.fee_token_r, Fee.Signed.negate fe1.fee_excess_r)
-                , (tid, excess) ) )
-          with
-          | Ok fe2 ->
-              fe2
-          | Error _ ->
-              (* The token is the same, and rebalancing causes an overflow. *)
-              of_single (fe1.fee_token_r, Fee.Signed.negate fe1.fee_excess_r)
-      in
-      ignore @@ Or_error.ok_exn (combine fe1 fe2) )
 
 [%%endif]

--- a/src/lib/mina_base/fee_excess.ml
+++ b/src/lib/mina_base/fee_excess.ml
@@ -557,11 +557,13 @@ let to_one_or_two ({ fee_token_l; fee_excess_l; fee_token_r; fee_excess_r } : t)
 
 [%%ifdef consensus_mechanism]
 
+let gen_single ?(token_id = Token_id.gen) ?(excess = Fee.Signed.gen) () :
+    (Token_id.t * Fee.Signed.t) Quickcheck.Generator.t =
+  Quickcheck.Generator.tuple2 token_id excess
+
 let gen : t Quickcheck.Generator.t =
   let open Quickcheck.Generator.Let_syntax in
-  let%map excesses =
-    One_or_two.gen (Quickcheck.Generator.tuple2 Token_id.gen Fee.Signed.gen)
-  in
+  let%map excesses = One_or_two.gen @@ gen_single () in
   match of_one_or_two excesses with
   | Ok ret ->
       ret

--- a/src/lib/mina_base/test/fee_excess/dune
+++ b/src/lib/mina_base/test/fee_excess/dune
@@ -1,0 +1,30 @@
+(tests
+ (names fee_excess)
+ (libraries
+  ;; opam libraries
+  alcotest
+  base
+  base.caml
+  core_kernel
+  integers
+  ppx_inline_test.config
+  sexplib0
+  ;; local libraries
+  currency
+  mina_base
+  mina_numbers
+  mina_wire_types
+  pickles
+  ppx_version.runtime
+  sgn
+  snark_params
+  snarky.backendless
+  test_util)
+ (preprocess
+  (pps
+   ppx_base
+   ppx_let
+   ppx_assert))
+ (instrumentation
+  (backend bisect_ppx)))
+

--- a/src/lib/mina_base/test/fee_excess/fee_excess.ml
+++ b/src/lib/mina_base/test/fee_excess/fee_excess.ml
@@ -1,0 +1,62 @@
+open Core_kernel
+open Currency
+open Mina_base
+open Snark_params.Tick
+open Fee_excess
+
+let combine_checked_unchecked_consistent () =
+  Quickcheck.test (Quickcheck.Generator.tuple2 gen gen) ~f:(fun (fe1, fe2) ->
+      let fe = combine fe1 fe2 in
+      let fe_checked =
+        Or_error.try_with (fun () ->
+            Test_util.checked_to_unchecked
+              Typ.(typ * typ)
+              typ
+              (fun (fe1, fe2) -> combine_checked fe1 fe2)
+              (fe1, fe2) )
+      in
+      match (fe, fe_checked) with
+      | Ok fe, Ok fe_checked ->
+          [%test_eq: t] fe fe_checked
+      | Error _, Error _ ->
+          ()
+      | _ ->
+          [%test_eq: t Or_error.t] fe fe_checked )
+
+let combine_succeed_with_0_middle () =
+  Quickcheck.test
+    Quickcheck.Generator.(
+      filter (tuple3 gen Token_id.gen Fee.Signed.gen)
+        ~f:(fun (fe1, tid, _excess) ->
+          (* The tokens before and after should be distinct.
+             Especially in this scenario, we may get an overflow error
+             otherwise. *)
+          not (Token_id.equal fe1.fee_token_l tid) ))
+    ~f:(fun (fe1, tid, excess) ->
+      let fe2 =
+        if Fee.Signed.(equal zero) fe1.fee_excess_r then of_single (tid, excess)
+        else
+          match
+            of_one_or_two
+              (`Two
+                ( (fe1.fee_token_r, Fee.Signed.negate fe1.fee_excess_r)
+                , (tid, excess) ) )
+          with
+          | Ok fe2 ->
+              fe2
+          | Error _ ->
+              (* The token is the same, and rebalancing causes an overflow. *)
+              of_single (fe1.fee_token_r, Fee.Signed.negate fe1.fee_excess_r)
+      in
+      ignore @@ Or_error.ok_exn (combine fe1 fe2) )
+
+let () =
+  let open Alcotest in
+  run "Test fee excesses."
+    [ ( "fee-excess"
+      , [ test_case "Checked and unchecked behaviour consistent." `Quick
+            combine_checked_unchecked_consistent
+        ; test_case "Combine succeeds when the middle excess is zero." `Quick
+            combine_succeed_with_0_middle
+        ] )
+    ]


### PR DESCRIPTION
Explain your changes:
* Inline tests written with Jane Street's PPX have a couple of problems. They're intermingled with production code and on top of that they produce no output if all the tests pass, which makes it difficult to sort out if certain tests were or were not actually run in the CI for instance.
* In order to properly separate tests from the production code and also to make it clear which tests are being run when, I migrated the tests in `mina_base/fee_excess.ml` module to Alcotest testing framework, which always displays a summary of the tests it has run. 
* This is an experimental change to demonstrate the viability of of this approach to unit testing and to see how will the results appear in the CI. If it is accepted, we can migrate other unit tests that we have to Alcotest as well.

Explain how you tested your changes:
- [x] Make sure these tests are being run in the CI and that output is visible even if all the tests pass.

Checklist:

- [x] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
