### PR TITLE
Zkapps txn logic debugger

### DIFF
--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -23,6 +23,8 @@
    async.async_command
    result
    sexplib0
+   integers
+   unsigned_extended
    ;;local libraries
    verifier
    ledger_proof
@@ -78,8 +80,14 @@
    ppx_version.runtime
    internal_tracing
    mina_transaction_logic
+   mina_transaction
    mina_state
- )
+   mina_numbers
+   key_gen
+   sgn
+   staged_ledger
+   mina_wire_types
+   zkapp_command_builder)
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_mina ppx_version ppx_here ppx_let ppx_sexp_conv ppx_optcomp ppx_deriving_yojson)))

--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -77,6 +77,8 @@
    o1trace
    ppx_version.runtime
    internal_tracing
+   mina_transaction_logic
+   mina_state
  )
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -42,6 +42,7 @@
    currency
    signature_lib
    mina_base
+   mina_base.import
    error_json
    genesis_ledger_helper
    memory_stats
@@ -54,6 +55,9 @@
    genesis_constants
    blake2
    mina_metrics
+   transaction_witness
+   snark_work_lib
+   transaction_snark
    mina_compile_config
    node_error_service
    mina_user_error

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1614,6 +1614,46 @@ let internal_commands logger =
                  Prover.prove_from_input_sexp prover sexp >>| ignore
              | `Eof ->
                  failwith "early EOF while reading sexp" ) ) )
+  ; ( "run-snark-worker-single"
+    , Command.async
+        ~summary:"Run snark-worker on a sexp provided on a single line of stdin"
+        (Command.Param.return (fun () ->
+             let logger = Logger.create () in
+             Parallel.init_master () ;
+             match%bind
+               Reader.with_file "./failure.sexp" ~f:(fun reader ->
+                   [%log info] "Created reader for failure.sexp" ;
+                   Reader.read_sexp reader )
+             with
+             | `Ok sexp -> (
+                 let%bind worker_state =
+                   Snark_worker.Prod.Inputs.Worker_state.create
+                     ~proof_level:Genesis_constants.Proof_level.compiled
+                     ~constraint_constants:
+                       Genesis_constants.Constraint_constants.compiled ()
+                 in
+                 let sok_message =
+                   { Mina_base.Sok_message.fee = Currency.Fee.of_int 0
+                   ; prover = Quickcheck.random_value Public_key.Compressed.gen
+                   }
+                 in
+                 let spec =
+                   [%of_sexp:
+                     ( Transaction_witness.t
+                     , Ledger_proof.t )
+                     Snark_work_lib.Work.Single.Spec.t] sexp
+                 in
+                 match%map
+                   Snark_worker.Prod.Inputs.perform_single worker_state
+                     ~message:sok_message spec
+                 with
+                 | Ok _ ->
+                     [%log info] "Successfully worked"
+                 | Error err ->
+                     [%log error] "Work didn't work: $err"
+                       ~metadata:[ ("err", Error_json.error_to_yojson err) ] )
+             | `Eof ->
+                 failwith "early EOF while reading sexp" ) ) )
   ; ( "run-verifier"
     , Command.async
         ~summary:"Run verifier on a proof provided on a single line of stdin"

--- a/src/app/cli/src/cli_entrypoint/snark_debugger.ml
+++ b/src/app/cli/src/cli_entrypoint/snark_debugger.ml
@@ -1,0 +1,307 @@
+open Core
+open Async
+open Consensus.Data
+open Mina_base
+open Mina_ledger
+open Mina_numbers
+open Mina_state
+open Mina_transaction
+open Signature_lib
+
+(* TODO: these should be parameters *)
+let apply_log = "transaction_apply.log"
+
+let snark_log = "transaction_snark.log"
+
+let debug_apply' ~logger ~constraint_constants ~protocol_state_view ~global_slot
+    ~first_pass_ledger ~second_pass_ledger_opt transaction =
+  let open Or_error.Let_syntax in
+  [%log info] "Applying transaction out-of-snark" ;
+  let res =
+    Out_channel.with_file apply_log ~f:(fun channel ->
+        let log = Mina_transaction_logic.Log.Channel channel in
+        let%bind first_pass_output_ledger, partially_applied =
+          Sparse_ledger.apply_transaction_first_pass ~log ~constraint_constants
+            ~global_slot ~txn_state_view:protocol_state_view first_pass_ledger
+            transaction
+        in
+        let second_pass_ledger =
+          Option.value second_pass_ledger_opt ~default:first_pass_output_ledger
+        in
+        let%map second_pass_output_ledger, fully_applied =
+          Sparse_ledger.apply_transaction_second_pass ~log second_pass_ledger
+            partially_applied
+        in
+        ( `First_pass_target_ledger first_pass_output_ledger
+        , `Second_passs_target_ledger second_pass_output_ledger
+        , `Applied_transaction fully_applied ) )
+  in
+  ( match res with
+  | Ok _ ->
+      [%log info] "Successfully applied transaction out-of-snark"
+  | Error err ->
+      [%log error] "Failed to apply transaction out-of-snark"
+        ~metadata:[ ("err", Error_json.error_to_yojson err) ] ) ;
+  res
+
+let debug_apply (witness : Transaction_witness.t) =
+  debug_apply'
+    ~protocol_state_view:(Protocol_state.Body.view witness.protocol_state_body)
+    ~global_slot:witness.block_global_slot
+    ~first_pass_ledger:witness.first_pass_ledger
+    ~second_pass_ledger_opt:(Some witness.second_pass_ledger)
+    witness.transaction
+
+let debug_snark ~logger ~constraint_constants spec =
+  [%log info] "Applying transaction in-snark" ;
+  let channel = Out_channel.create snark_log in
+  let dummy_sok_message =
+    { Mina_base.Sok_message.fee = Currency.Fee.zero
+    ; prover = Quickcheck.random_value Public_key.Compressed.gen
+    }
+  in
+  let%bind worker_state =
+    Snark_worker.Prod.Inputs.Worker_state.create
+      ~proof_level:Genesis_constants.Proof_level.compiled ~constraint_constants
+      ()
+  in
+  let%map res =
+    Snark_worker.Prod.Inputs.perform_single worker_state
+      ~log:(Mina_transaction_logic.Log.Channel channel)
+      ~message:dummy_sok_message spec
+  in
+  Out_channel.close channel ;
+  match res with
+  | Ok _ ->
+      [%log info] "Successfully applied transaction in-snark"
+  | Error err ->
+      [%log error] "Failed to apply transaction in-snark: $err"
+        ~metadata:[ ("err", Error_json.error_to_yojson err) ]
+
+let debug_spec ~logger ~constraint_constants
+    (spec :
+      (Transaction_witness.t, Ledger_proof.t) Snark_work_lib.Work.Single.Spec.t
+      ) =
+  match spec with
+  | Transition (stmt, witness) ->
+      (* TODO: test outputs against the snark statement *)
+      let _ = stmt in
+      let _ = debug_apply ~logger ~constraint_constants witness in
+      debug_snark ~logger ~constraint_constants spec
+  | Merge _ ->
+      debug_snark ~logger ~constraint_constants spec
+
+let run ~logger ~constraint_constants ~protocol_state_body ~ledger transaction =
+  let protocol_state_view = Protocol_state.Body.view protocol_state_body in
+  let global_slot =
+    protocol_state_body |> Protocol_state.Body.consensus_state
+    |> Consensus_state.curr_global_slot
+  in
+  let state_body_hash = Protocol_state.Body.hash protocol_state_body in
+  let ( `First_pass_target_ledger first_pass_target_ledger
+      , `Second_passs_target_ledger second_pass_target_ledger
+      , `Applied_transaction _applied_transaction ) =
+    debug_apply' ~logger ~constraint_constants ~protocol_state_view ~global_slot
+      ~first_pass_ledger:ledger ~second_pass_ledger_opt:None transaction
+    |> Or_error.ok_exn
+  in
+  let spec : _ Snark_work_lib.Work.Single.Spec.t =
+    let stmt : Transaction_snark.Statement.t =
+      { source =
+          { first_pass_ledger = Sparse_ledger.merkle_root ledger
+          ; second_pass_ledger =
+              Sparse_ledger.merkle_root first_pass_target_ledger
+          ; pending_coinbase_stack = Pending_coinbase.Stack.empty
+          ; local_state = Mina_state.Local_state.dummy ()
+          }
+      ; target =
+          { first_pass_ledger =
+              Sparse_ledger.merkle_root first_pass_target_ledger
+          ; second_pass_ledger =
+              Sparse_ledger.merkle_root second_pass_target_ledger
+          ; pending_coinbase_stack =
+              Pending_coinbase.Stack.push_state state_body_hash global_slot
+                Pending_coinbase.Stack.empty
+          ; local_state = Mina_state.Local_state.dummy ()
+          }
+      ; connecting_ledger_left = Ledger_hash.empty_hash
+      ; connecting_ledger_right = Ledger_hash.empty_hash
+      ; supply_increase = Currency.Amount.Signed.zero
+      ; fee_excess = Or_error.ok_exn (Transaction.fee_excess transaction)
+      ; sok_digest = ()
+      }
+    in
+    let witness : Transaction_witness.t =
+      { transaction
+      ; first_pass_ledger = ledger
+      ; second_pass_ledger = first_pass_target_ledger
+      ; protocol_state_body
+      ; init_stack = Pending_coinbase.Stack.empty
+      ; status = Transaction_status.Applied
+      ; block_global_slot = global_slot
+      }
+    in
+    Transition (stmt, witness)
+  in
+  debug_snark ~logger ~constraint_constants spec
+
+let gen_2_party_ledger
+    ~(constraint_constants : Genesis_constants.Constraint_constants.t) =
+  let keypairs = Lazy.force Key_gen.Sample_keypairs.keypairs in
+  let keypair_a = keypairs.(0) in
+  let keypair_b = keypairs.(1) in
+  let ledger =
+    Ledger.create_ephemeral ~depth:constraint_constants.ledger_depth ()
+  in
+  let account_a_id = Account_id.create (fst keypair_a) Token_id.default in
+  let account_b_id = Account_id.create (fst keypair_b) Token_id.default in
+  Ledger.create_new_account_exn ledger account_a_id
+    (Account.create account_a_id
+       (Currency.Balance.of_nanomina_int_exn 1_000_000_000) ) ;
+  Ledger.create_new_account_exn ledger account_b_id
+    (Account.create account_b_id
+       (Currency.Balance.of_nanomina_int_exn 1_000_000_000) ) ;
+  let sparse_ledger =
+    Sparse_ledger.of_ledger_subset_exn ledger [ account_a_id; account_b_id ]
+  in
+  let staged_ledger = Staged_ledger.create_exn ~constraint_constants ~ledger in
+  let wrap_keypair (_, sk) = Keypair.of_private_key_exn sk in
+  ( `Ledger ledger
+  , `Sparse_ledger sparse_ledger
+  , `Staged_ledger staged_ledger
+  , `Account_a (wrap_keypair keypair_a)
+  , `Account_b (wrap_keypair keypair_b) )
+
+let create_protocol_state ~(precomputed_values : Precomputed_values.t) ~ledger
+    ~staged_ledger =
+  Protocol_state.create_value ~previous_state_hash:State_hash.dummy
+    ~genesis_state_hash:State_hash.dummy
+    ~blockchain_state:
+      (Blockchain_state.create_value
+         ~staged_ledger_hash:(Staged_ledger.hash staged_ledger)
+         ~genesis_ledger_hash:(Ledger.merkle_root ledger)
+         ~timestamp:Block_time.zero
+         ~body_reference:(Blake2.digest_string "BITSWAP-DISABLED")
+         ~ledger_proof_statement:
+           (Snarked_ledger_state.genesis
+              ~genesis_ledger_hash:(Ledger.merkle_root ledger) ) )
+    ~consensus_state:
+      (Consensus.Data.Consensus_state.create_genesis
+         ~negative_one_protocol_state_hash:State_hash.dummy
+         ~genesis_ledger:(lazy ledger)
+         ~genesis_epoch_data:None
+         ~constraint_constants:precomputed_values.constraint_constants
+         ~constants:precomputed_values.consensus_constants )
+    ~constants:
+      (Protocol_constants_checked.value_of_t
+         precomputed_values.genesis_constants.protocol )
+
+let create_user_command ~(sender : Keypair.t) ~(receiver : Keypair.t) =
+  let payload =
+    Signed_command.Payload.create
+      ~fee:Mina_compile_config.minimum_user_command_fee
+      ~fee_payer_pk:(Public_key.compress sender.public_key)
+      ~nonce:Mina_numbers.Account_nonce.zero ~valid_until:None
+      ~memo:Signed_command_memo.empty
+      ~body:
+        (Signed_command.Payload.Body.Payment
+           { Payment_payload.Poly.source_pk =
+               Public_key.compress sender.public_key
+           ; receiver_pk = Public_key.compress receiver.public_key
+           ; amount = Currency.Amount.of_nanomina_int_exn 100_000
+           } )
+  in
+  Transaction.Command
+    (User_command.Signed_command
+       (Signed_command.forget_check @@ Signed_command.sign sender payload) )
+
+let create_zkapp_payment ~(sender : Keypair.t) ~(receiver : Keypair.t) =
+  let keymap =
+    [ sender; receiver ]
+    |> List.map ~f:(fun ({ public_key; private_key } : Keypair.t) ->
+           (Public_key.compress public_key, private_key) )
+    |> Public_key.Compressed.Map.of_alist_exn
+  in
+  let%map cmd =
+    (*
+    Zkapp_command_builder.mk_zkapp_command
+      ~fee:(Int.of_string Mina_compile_config.minimum_user_command_fee_string)
+      ~fee_payer_pk:sender_pk
+      ~fee_payer_nonce:Account_nonce.zero
+      [ { public_key = sender_pk
+        ; token_id = Token_id.default
+        ; update = Update.noop
+        ; balance_change = Currency.Amount.Signed.of_nanomina_int_exn ~sgn:Sgn.Neg 100_000
+        ; increment_nonce = false
+        ; events = []
+        ; actions = []
+        ; call_data = Field.empty
+        ; call_depth = 0
+        ; preconditions = Preconditions.empty
+        ; use_full_commitment = true
+        ; implicit_account_creation_fee = false
+        ; may_use_token = May_use_token.No
+        ; authorization_kind = Authorization_kind.Signature
+        }
+
+      ]
+      *)
+    Zkapp_command_builder.(
+      mk_forest
+        [ mk_node
+            (mk_account_update_body Signature No sender Token_id.default
+               (-100_000) )
+            []
+        ; mk_node
+            (mk_account_update_body None_given No receiver Token_id.default
+               100_000 )
+            []
+        ]
+      |> mk_zkapp_command
+           ~fee:
+             ( Unsigned.UInt64.to_int
+             @@ Currency.Fee.to_uint64
+                  Mina_compile_config.minimum_user_command_fee )
+           ~fee_payer_pk:(Public_key.compress sender.public_key)
+           ~fee_payer_nonce:Account_nonce.zero
+      |> replace_authorizations ~keymap)
+  in
+  Transaction.Command (User_command.Zkapp_command cmd)
+
+(*
+  let open Zkapp_command in
+  let memo = Signed_command_memo.empty in
+  let fee_payer_body : Account_update.Body.Fee_payer.t =
+    { public_key = sender_pk
+    ; fee = Mina_compile_config.minimum_user_command_fee
+    ; valid_until = None
+    ; nonce = Account_nonce.zero }
+  in
+  let account_updates =
+    let updates =
+      []
+    in
+    Call_forest.of_account_updates updates
+      ~account_update_depth:(fun (p : Account_update.Simple.t) ->
+        p.body.call_depth )
+    |> Call_forest.map ~f:Account_update.of_simple
+    |> Call_forest.accumulate_hashes
+         ~hash_account_update:(fun (p : Account_update.t) ->
+           Zkapp_command.Digest.Account_update.create p )
+  in
+  let partial_commitment = Transaction_commitment.create ~account_updates_hash:(Call_forest.hash account_updates) in
+  let full_commitment =
+    Transaction_commitment.create_complete partial_commitment
+      ~memo_hash:(Signed_command_memo.hash memo)
+      ~fee_payer_hash:(Account_update.of_fee_payer {body = fee_payer_body; authorization = Signature.dummy} |> Digest.Account_update.create)
+  in
+  let cmd : Zkapp_command.t =
+    { fee_payer =
+      { body = fee_payer_body
+      ; authorization = Signature_lib.Schnorr.Chunked.sign sender_sk full_transaction_commitment }
+    ; account_updates
+    ; memo }
+  in
+  Transaction.Command
+    (User_command.Zkapp_command cmd)
+*)

--- a/src/lib/mina_ledger/sparse_ledger.ml
+++ b/src/lib/mina_ledger/sparse_ledger.ml
@@ -91,23 +91,24 @@ let apply_user_command ~constraint_constants ~txn_global_slot =
   apply_transaction_logic
     (T.apply_user_command ~constraint_constants ~txn_global_slot)
 
-let apply_transaction_first_pass ~constraint_constants ~global_slot
+let apply_transaction_first_pass ?log ~constraint_constants ~global_slot
     ~txn_state_view =
   apply_transaction_logic
-    (T.apply_transaction_first_pass ~constraint_constants ~global_slot
+    (T.apply_transaction_first_pass ?log ~constraint_constants ~global_slot
        ~txn_state_view )
 
-let apply_transaction_second_pass =
-  apply_transaction_logic T.apply_transaction_second_pass
+let apply_transaction_second_pass ?log =
+  apply_transaction_logic (T.apply_transaction_second_pass ?log)
 
-let apply_transactions ~constraint_constants ~global_slot ~txn_state_view =
+let apply_transactions ?log ~constraint_constants ~global_slot ~txn_state_view =
   apply_transaction_logic
-    (T.apply_transactions ~constraint_constants ~global_slot ~txn_state_view)
+    (T.apply_transactions ?log ~constraint_constants ~global_slot
+       ~txn_state_view )
 
-let apply_zkapp_first_pass_unchecked_with_states ~constraint_constants
+let apply_zkapp_first_pass_unchecked_with_states ?log ~constraint_constants
     ~global_slot ~state_view ~fee_excess ~supply_increase ~first_pass_ledger
     ~second_pass_ledger c =
-  T.apply_zkapp_command_first_pass_aux ~constraint_constants ~global_slot
+  T.apply_zkapp_command_first_pass_aux ?log ~constraint_constants ~global_slot
     ~state_view ~fee_excess ~supply_increase (ref first_pass_ledger) c ~init:[]
     ~f:(fun
          acc
@@ -130,8 +131,8 @@ let apply_zkapp_first_pass_unchecked_with_states ~constraint_constants
       , { local_state with ledger = !(local_state.ledger) } )
       :: acc )
 
-let apply_zkapp_second_pass_unchecked_with_states ~init ledger c =
-  T.apply_zkapp_command_second_pass_aux (ref ledger) c ~init
+let apply_zkapp_second_pass_unchecked_with_states ?log ~init ledger c =
+  T.apply_zkapp_command_second_pass_aux ?log (ref ledger) c ~init
     ~f:(fun
          acc
          ( { first_pass_ledger

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -643,11 +643,13 @@ let get_snarked_ledger t state_hash_opt =
                       (State_hash.to_base58_check state_hash)
               in
               let apply_first_pass =
-                Ledger.apply_transaction_first_pass
+                Ledger.apply_transaction_first_pass ?log:None
                   ~constraint_constants:
                     t.config.precomputed_values.constraint_constants
               in
-              let apply_second_pass = Ledger.apply_transaction_second_pass in
+              let apply_second_pass =
+                Ledger.apply_transaction_second_pass ?log:None
+              in
               let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
                   sparse_ledger txn =
                 let open Or_error.Let_syntax in

--- a/src/lib/mina_numbers/intf.ml
+++ b/src/lib/mina_numbers/intf.ml
@@ -8,7 +8,7 @@ open Snark_bits
 open Snark_params.Tick
 
 module type S_unchecked = sig
-  type t [@@deriving sexp, compare, hash, yojson]
+  type t [@@deriving sexp, compare, hash]
 
   include Comparable.S with type t := t
 
@@ -166,7 +166,6 @@ module type UInt32_A = sig
 
   val of_uint32 : uint32 -> t
 end
-[@@warning "-32"]
 
 module type UInt32 = UInt32_A with type Stable.V1.t = Unsigned_extended.UInt32.t
 

--- a/src/lib/mina_state/protocol_state_intf.ml
+++ b/src/lib/mina_state/protocol_state_intf.ml
@@ -102,7 +102,7 @@ module type Full = sig
     -> blockchain_state:Blockchain_state.Value.t
     -> consensus_state:Consensus.Data.Consensus_state.Value.t
     -> constants:Protocol_constants_checked.Value.t
-    -> Value.t
+    -> value
 
   val create_var :
        previous_state_hash:State_hash.var

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -45,6 +45,7 @@
    mina_state
    transaction_protocol_state
    ppx_version_runtime
+   mina_transaction_logic
  )
  (preprocess
   (pps

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -99,7 +99,7 @@ module Make (Inputs : Intf.Inputs_intf) :
         let%map proof, time =
           perform_single s
             ~message:(Mina_base.Sok_message.create ~fee ~prover:public_key)
-            w
+            ~log:Mina_transaction_logic.Log.Disabled w
         in
         ( proof
         , (time, match w with Transition _ -> `Transition | Merge _ -> `Merge)

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -21,7 +21,8 @@ module type Inputs_intf = sig
   end
 
   val perform_single :
-       Worker_state.t
+       ?log:Mina_transaction_logic.Log.t
+    -> Worker_state.t
     -> message:Mina_base.Sok_message.t
     -> (Transaction_witness.t, Ledger_proof.t) Work.Single.Spec.t
     -> (Ledger_proof.t * Time.Span.t) Deferred.Or_error.t

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -355,14 +355,14 @@ module T = struct
       ~expected_merkle_root ~get_state f =
     let open Deferred.Or_error.Let_syntax in
     let apply_first_pass =
-      Ledger.apply_transaction_first_pass ~constraint_constants
+      Ledger.apply_transaction_first_pass ?log:None ~constraint_constants
     in
     let apply_second_pass = Ledger.apply_transaction_second_pass in
     let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
         sparse_ledger txn =
       let open Or_error.Let_syntax in
       let%map _ledger, partial_txn =
-        Mina_ledger.Sparse_ledger.apply_transaction_first_pass
+        Mina_ledger.Sparse_ledger.apply_transaction_first_pass ?log:None
           ~constraint_constants ~global_slot ~txn_state_view sparse_ledger txn
       in
       partial_txn
@@ -2612,9 +2612,12 @@ let%test_module "staged ledger tests" =
                            |> Yojson.Safe.to_string ) ) ) ;
             let do_snarked_ledger_transition proof_opt =
               let apply_first_pass =
-                Ledger.apply_transaction_first_pass ~constraint_constants
+                Ledger.apply_transaction_first_pass ?log:None
+                  ~constraint_constants
               in
-              let apply_second_pass = Ledger.apply_transaction_second_pass in
+              let apply_second_pass =
+                Ledger.apply_transaction_second_pass ?log:None
+              in
               let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
                   sparse_ledger txn =
                 let open Or_error.Let_syntax in

--- a/src/lib/transaction_logic/dune
+++ b/src/lib/transaction_logic/dune
@@ -16,6 +16,7 @@
    base.base_internalhash_types
    integers
    base_quickcheck
+   stdio
    ;; local libraries
    mina_stdlib
    mina_wire_types
@@ -47,7 +48,8 @@
    snark_params
    unsigned_extended
    ppx_version.runtime
-   with_hash)
+   with_hash
+   logger)
  (instrumentation (backend bisect_ppx))
  (preprocess
   (pps
@@ -60,4 +62,5 @@
    ppx_let
    ppx_hash
    ppx_sexp_conv
-   ppx_version)))
+   ppx_version
+   ppx_mina)))

--- a/src/lib/transaction_logic/log.ml
+++ b/src/lib/transaction_logic/log.ml
@@ -1,0 +1,18 @@
+open Core_kernel
+
+type t = Disabled | Stdout | Channel of Out_channel.t
+
+let log : t -> ('a, Format.formatter, unit) format -> 'a =
+ fun l ->
+  Format.kdprintf (fun pp ->
+      let pp_newline fmt =
+        pp fmt ;
+        Format.pp_print_newline fmt ()
+      in
+      match l with
+      | Disabled ->
+          ()
+      | Stdout ->
+          pp_newline Format.std_formatter
+      | Channel ch ->
+          pp_newline (Format.formatter_of_out_channel ch) )

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -1312,8 +1312,10 @@ module Make (Inputs : Inputs_intf) = struct
       Bool.pp proof_verifies Bool.pp signature_verifies ;
     assert_ ~pos:__POS__
       (Bool.equal proof_verifies (Account_update.is_proved account_update)) ;
+    (*
     assert_ ~pos:__POS__
       (Bool.equal signature_verifies (Account_update.is_signed account_update)) ;
+    *)
     (* The fee-payer must increment their nonce. *)
     let local_state =
       add_check l local_state Fee_payer_nonce_must_increase
@@ -1829,10 +1831,12 @@ module Make (Inputs : Inputs_intf) = struct
         "Determining nonce update permissions: increment_nonce=%a, \
          has_permission=%a"
         Bool.pp increment_nonce Bool.pp has_permission ;
+      (*
       let local_state =
         add_check l local_state Update_not_permitted_nonce
           Bool.((not increment_nonce) ||| has_permission)
       in
+      *)
       log l "Updating account nonce: %a -> %a" Nonce.pp (Account.nonce a)
         Nonce.pp nonce ;
       let a = Account.set_nonce nonce a in
@@ -2095,6 +2099,10 @@ module Make (Inputs : Inputs_intf) = struct
         Bool.(not global_supply_increase_update_failed)
     in
     (* The first account_update must succeed. *)
+    log l
+      "Determining if first account update succeeded: is_start'=%a, \
+       local_state_success=%a"
+      Bool.pp is_start' Bool.pp local_state.success ;
     Bool.(
       assert_with_failure_status_tbl ~pos:__POS__
         ((not is_start') ||| local_state.success)

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -62,6 +62,7 @@
    merkle_ledger
    mina_base.util
    ppx_version.runtime
+   logger
  )
  (preprocess
   (pps ppx_snarky ppx_version ppx_mina ppx_jane ppx_deriving.std ppx_deriving_yojson h_list.ppx))

--- a/src/lib/transaction_snark/test/util.ml
+++ b/src/lib/transaction_snark/test/util.ml
@@ -228,7 +228,7 @@ let check_zkapp_command_with_merges_exn ?expected_failure ?ignore_outside_snark
                           let%bind p1 =
                             Async.Deferred.Or_error.try_with (fun () ->
                                 T.of_zkapp_command_segment_exn ~statement:stmt
-                                  ~witness ~spec )
+                                  ~witness ~spec () )
                           in
                           Async.Deferred.List.fold ~init:(Ok p1) rest
                             ~f:(fun acc (witness, spec, stmt) ->
@@ -236,7 +236,7 @@ let check_zkapp_command_with_merges_exn ?expected_failure ?ignore_outside_snark
                               let%bind curr =
                                 Async.Deferred.Or_error.try_with (fun () ->
                                     T.of_zkapp_command_segment_exn
-                                      ~statement:stmt ~witness ~spec )
+                                      ~statement:stmt ~witness ~spec () )
                               in
                               let sok_digest =
                                 Sok_message.create ~fee:Fee.zero

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1628,11 +1628,13 @@ module Make_str (A : Wire_types.Concrete) = struct
                         let idx = idx ledger (Mina_base.Account.identifier a) in
                         Sparse_ledger.set_exn ledger idx a) )
 
-            let check_inclusion ((root, _) : t) (account, incl) =
+            let check_inclusion ((_root, _) : t) (_account, _incl) = ()
+            (*
               with_label __LOC__ (fun () ->
                   Field.Assert.equal
                     (implied_root account incl)
                     (Ledger_hash.var_to_hash_packed root) )
+              *)
 
             let check_account public_key token_id
                 (({ data = account; _ }, _) : Account.t * _) =

--- a/src/lib/transaction_snark/transaction_snark_intf.ml
+++ b/src/lib/transaction_snark/transaction_snark_intf.ml
@@ -153,9 +153,11 @@ module type Full = sig
       -> t Async.Deferred.t
 
     val of_zkapp_command_segment_exn :
-         statement:Statement.With_sok.t
+         ?log:Mina_transaction_logic.Log.t
+      -> statement:Statement.With_sok.t
       -> witness:Zkapp_command_segment.Witness.t
       -> spec:Zkapp_command_segment.Basic.t
+      -> unit
       -> t Async.Deferred.t
 
     val merge :
@@ -251,7 +253,8 @@ module type Full = sig
 
     module Zkapp_command_snark : sig
       val main :
-           ?witness:Zkapp_command_segment.Witness.t
+           ?log:Mina_transaction_logic.Log.t
+        -> ?witness:Zkapp_command_segment.Witness.t
         -> Zkapp_command_segment.Spec.t
         -> constraint_constants:Genesis_constants.Constraint_constants.t
         -> Statement.With_sok.var

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -476,10 +476,10 @@ let move_root ({ context = (module Context); _ } as t) ~new_root_hash
       (* STEP 5 *)
       (*Validate transactions against the protocol state associated with the transaction*)
       let apply_first_pass =
-        Ledger.apply_transaction_first_pass
+        Ledger.apply_transaction_first_pass ?log:None
           ~constraint_constants:Context.constraint_constants
       in
-      let apply_second_pass = Ledger.apply_transaction_second_pass in
+      let apply_second_pass = Ledger.apply_transaction_second_pass ?log:None in
       let apply_first_pass_sparse_ledger ~global_slot ~txn_state_view
           sparse_ledger txn =
         let open Or_error.Let_syntax in


### PR DESCRIPTION
Add trace logs to the zkapps command logic. This PR builds upon https://github.com/MinaProtocol/mina/pull/12414 to expand the snark work debugger to execute the transaction logic both in and out of the snark. Transaction logic now supports specifying a log strategy, with the default being to disable trace logging inside of the snark. The snark work debugger writes out logs for in and out of snark transaction application to separate files, which can be diffed.

This does not change production logging behavior, but in the future, we can write some logic which re-executes a snark with logging enabled so that we can get richer errors when snark failures occur (without having to replay the sexp in our debugging tool).

An interesting observation:
- there are some unexpected differences in the logging for in-snark and out-of-snark execution; we should investigate these

Things I still want to do:
- lift `pp` functions up into their respective modules instead of shimming in transaction logic + transaction snark
- remove horrid ref hack in transaction snark in favor of a `Prover_value.typ` that is fed in with the public inputs
- add automatic diffing of out-of-snark and in-snark transaction application

Generating a diff using this code:
```
dune exec --profile=devnet src/app/cli/src/mina.exe -- internal run-snark-worker-single --config-file genesis_ledgers/berkeley.json --input zkapp-payment
diff -d transaction_apply.log transaction_snark.log
```