### PR TITLE
Account delegate is required

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11786,9 +11786,13 @@
                 "The public key to which you are delegating - if you are not delegating to anybody, this would return your public key",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "PublicKey",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "PublicKey",
+                  "ofType": null
+                }
               },
               "isDeprecated": true,
               "deprecationReason": "use delegateAccount instead"
@@ -11798,7 +11802,15 @@
               "description":
                 "The account to which you are delegating - if you are not delegating to anybody, this would return your public key",
               "args": [],
-              "type": { "kind": "OBJECT", "name": "Account", "ofType": null },
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "PublicKey",
+                  "ofType": null
+                }
+              },
               "isDeprecated": false,
               "deprecationReason": null
             },

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -181,7 +181,7 @@ CREATE TABLE accounts_accessed
 , balance                 text    NOT NULL
 , nonce                   bigint  NOT NULL
 , receipt_chain_hash      text    NOT NULL
-, delegate_id             int               REFERENCES public_keys(id)
+, delegate_id             int     NOT NULL  REFERENCES public_keys(id)
 , voting_for_id           int     NOT NULL  REFERENCES voting_for(id)
 , timing_id               int               REFERENCES timing_info(id)
 , permissions_id          int     NOT NULL  REFERENCES zkapp_permissions(id)

--- a/src/app/archive/lib/load_data.ml
+++ b/src/app/archive/lib/load_data.ml
@@ -686,14 +686,7 @@ let get_account_accessed ~pool (account : Processor.Accounts_accessed.t) :
   let receipt_chain_hash =
     receipt_chain_hash |> Receipt.Chain_hash.of_base58_check_exn
   in
-  let%bind delegate =
-    let%map pk_str_opt =
-      Mina_caqti.get_opt_item delegate_id
-        ~f:(with_pool ~f:Processor.Public_key.find_by_id)
-    in
-    Option.map pk_str_opt
-      ~f:Signature_lib.Public_key.Compressed.of_base58_check_exn
-  in
+  let%bind delegate = pk_of_id delegate_id in
   let%bind voting_for =
     let%map hash_str =
       query_db ~f:(fun db -> Processor.Voting_for.load db voting_for_id)

--- a/src/app/archive/lib/processor.ml
+++ b/src/app/archive/lib/processor.ml
@@ -2537,7 +2537,7 @@ module Accounts_accessed = struct
     ; balance : string
     ; nonce : int64
     ; receipt_chain_hash : string
-    ; delegate_id : int option
+    ; delegate_id : int
     ; voting_for_id : int
     ; timing_id : int
     ; permissions_id : int
@@ -2555,7 +2555,7 @@ module Accounts_accessed = struct
         ; string
         ; int64
         ; string
-        ; option int
+        ; int
         ; int
         ; int
         ; int
@@ -2601,9 +2601,7 @@ module Accounts_accessed = struct
           account.receipt_chain_hash |> Receipt.Chain_hash.to_base58_check
         in
         let%bind delegate_id =
-          Mina_caqti.add_if_some
-            (Public_key.add_if_doesn't_exist (module Conn))
-            account.delegate
+          Public_key.add_if_doesn't_exist (module Conn) account.delegate
         in
         let%bind voting_for_id =
           Voting_for.add_if_doesn't_exist (module Conn) account.voting_for

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -54,14 +54,9 @@ module Make_str (A : Wire_types.Concrete) = struct
     let open Mina_base in
     let outer_table = Public_key.Compressed.Table.create () in
     iter_accounts (fun i (acct : Account.t) ->
-        if
-          Option.is_some acct.delegate
-          (* Only default tokens may delegate. *)
-          && Token_id.equal acct.token_id Token_id.default
-          && Public_key.Compressed.Set.mem keys (Option.value_exn acct.delegate)
-        then
-          Public_key.Compressed.Table.update outer_table
-            (Option.value_exn acct.delegate) ~f:(function
+        if Public_key.Compressed.Set.mem keys acct.delegate then
+          Public_key.Compressed.Table.update outer_table acct.delegate
+            ~f:(function
             | None ->
                 Account.Index.Table.of_alist_exn [ (i, acct) ]
             | Some table ->

--- a/src/lib/mina_base/account.ml
+++ b/src/lib/mina_base/account.ml
@@ -288,7 +288,7 @@ module Binable_arg = struct
         , Balance.Stable.V1.t
         , Nonce.Stable.V1.t
         , Receipt.Chain_hash.Stable.V1.t
-        , Public_key.Compressed.Stable.V1.t option
+        , Public_key.Compressed.Stable.V1.t
         , State_hash.Stable.V1.t
         , Timing.Stable.V1.t
         , Permissions.Stable.V2.t
@@ -341,7 +341,7 @@ type value =
   , Balance.t
   , Nonce.t
   , Receipt.Chain_hash.t
-  , Public_key.Compressed.t option
+  , Public_key.Compressed.t
   , State_hash.t
   , Timing.t
   , Permissions.t
@@ -354,10 +354,7 @@ let key_gen = Public_key.Compressed.gen
 let initialize account_id : t =
   let public_key = Account_id.public_key account_id in
   let token_id = Account_id.token_id account_id in
-  let delegate =
-    (* Only allow delegation if this account is for the default token. *)
-    if Token_id.(equal default token_id) then Some public_key else None
-  in
+  let delegate = public_key in
   { public_key
   ; token_id
   ; token_symbol = ""
@@ -387,7 +384,7 @@ let to_input (t : t) =
     ~token_id:(f Token_id.to_input) ~balance:(f Balance.to_input)
     ~token_symbol:(f Token_symbol.to_input) ~nonce:(f Nonce.to_input)
     ~receipt_chain_hash:(f Receipt.Chain_hash.to_input)
-    ~delegate:(f (Fn.compose Public_key.Compressed.to_input delegate_opt))
+    ~delegate:(f Public_key.Compressed.to_input)
     ~voting_for:(f State_hash.to_input) ~timing:(f Timing.to_input)
     ~zkapp:(f (Fn.compose field hash_zkapp_account_opt))
     ~permissions:(f Permissions.to_input)
@@ -427,10 +424,7 @@ let typ' zkapp =
     ; Balance.typ
     ; Nonce.typ
     ; Receipt.Chain_hash.typ
-    ; Typ.transport Public_key.Compressed.typ ~there:delegate_opt
-        ~back:(fun delegate ->
-          if Public_key.Compressed.(equal empty) delegate then None
-          else Some delegate )
+    ; Public_key.Compressed.typ
     ; State_hash.typ
     ; Timing.typ
     ; Permissions.typ
@@ -473,7 +467,7 @@ let var_of_t
   ; balance = Balance.var_of_t balance
   ; nonce = Nonce.Checked.constant nonce
   ; receipt_chain_hash = Receipt.Chain_hash.var_of_t receipt_chain_hash
-  ; delegate = Public_key.Compressed.var_of_t (delegate_opt delegate)
+  ; delegate = Public_key.Compressed.var_of_t delegate
   ; voting_for = State_hash.var_of_t voting_for
   ; timing = Timing.var_of_t timing
   ; permissions = Permissions.Checked.constant permissions
@@ -628,7 +622,7 @@ let empty =
   ; balance = Balance.zero
   ; nonce = Nonce.zero
   ; receipt_chain_hash = Receipt.Chain_hash.empty
-  ; delegate = None
+  ; delegate = Public_key.Compressed.empty
   ; voting_for = State_hash.dummy
   ; timing = Timing.Untimed
   ; permissions =
@@ -642,10 +636,7 @@ let empty_digest = digest empty
 let create account_id balance =
   let public_key = Account_id.public_key account_id in
   let token_id = Account_id.token_id account_id in
-  let delegate =
-    (* Only allow delegation if this account is for the default token. *)
-    if Token_id.(equal default) token_id then Some public_key else None
-  in
+  let delegate = public_key in
   { Poly.public_key
   ; token_id
   ; token_symbol = Token_symbol.default
@@ -669,10 +660,7 @@ let create_timed account_id balance ~initial_minimum_balance ~cliff_time
   else
     let public_key = Account_id.public_key account_id in
     let token_id = Account_id.token_id account_id in
-    let delegate =
-      (* Only allow delegation if this account is for the default token. *)
-      if Token_id.(equal default) token_id then Some public_key else None
-    in
+    let delegate = public_key in
     Or_error.return
       { Poly.public_key
       ; token_id

--- a/src/lib/mina_base/sparse_ledger_base.ml
+++ b/src/lib/mina_base/sparse_ledger_base.ml
@@ -86,9 +86,9 @@ module L = struct
       let public_key = Account_id.public_key id in
       let account' : Account.t =
         { account with
-          delegate = Some public_key
-        ; public_key
+          public_key
         ; token_id = Account_id.token_id id
+        ; delegate = public_key
         }
       in
       set t loc account' ;
@@ -163,11 +163,7 @@ let get_or_initialize_exn account_id t idx =
   let account = get_exn t idx in
   if Public_key.Compressed.(equal empty account.public_key) then
     let public_key = Account_id.public_key account_id in
-    let token_id = Account_id.token_id account_id in
-    let delegate =
-      (* Only allow delegation if this account is for the default token. *)
-      if Token_id.(equal default) token_id then Some public_key else None
-    in
+    let delegate = public_key in
     ( `Added
     , { account with
         delegate

--- a/src/lib/mina_base/zkapp_precondition.ml
+++ b/src/lib/mina_base/zkapp_precondition.ml
@@ -718,9 +718,7 @@ module Account = struct
             receipt_chain_hash a.receipt_chain_hash) )
     ; ( Transaction_status.Failure.Account_delegate_precondition_unsatisfied
       , let tc = Eq_data.Tc.public_key () in
-        Eq_data.(
-          check ~label:"delegate" tc delegate
-            (Option.value ~default:tc.default a.delegate)) )
+        Eq_data.(check ~label:"delegate" tc delegate a.delegate) )
     ]
     @
     let zkapp = Option.value ~default:Zkapp_account.default a.zkapp in

--- a/src/lib/mina_generators/zkapp_command_generators.ml
+++ b/src/lib/mina_generators/zkapp_command_generators.ml
@@ -85,13 +85,7 @@ let gen_account_precondition_from_account ?failure
         if first_use_of_account then Or_ignore.Check receipt_chain_hash
         else Or_ignore.Ignore
       in
-      let%bind delegate =
-        match delegate with
-        | None ->
-            return Or_ignore.Ignore
-        | Some pk ->
-            Or_ignore.gen (return pk)
-      in
+      let%bind delegate = Or_ignore.gen (return delegate) in
       let%bind state, action_state, proved_state, is_new =
         match zkapp with
         | None ->
@@ -868,11 +862,7 @@ let gen_account_update_body_components (type a b c d) ?global_slot
    in
    let delegate (account : Account.t) =
      if is_fee_payer then account.delegate
-     else
-       Option.map
-         ~f:(fun delegate ->
-           value_to_be_updated update.delegate ~default:delegate )
-         account.delegate
+     else value_to_be_updated update.delegate ~default:account.delegate
    in
    let zkapp (account : Account.t) =
      if is_fee_payer then account.zkapp

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -1066,7 +1066,7 @@ module Types = struct
               ; token_id = Account_id.token_id account_id
               ; token_symbol = None
               ; nonce = None
-              ; delegate = None
+              ; delegate = Account_id.public_key account_id
               ; balance =
                   { AnnotatedBalance.total = Balance.zero
                   ; unknown = Balance.zero
@@ -1092,7 +1092,7 @@ module Types = struct
           , AnnotatedBalance.t
           , Account.Nonce.t option
           , Receipt.Chain_hash.t option
-          , Public_key.Compressed.t option
+          , Public_key.Compressed.t
           , State_hash.t option
           , Account.Timing.t
           , Permissions.t option
@@ -1334,7 +1334,7 @@ module Types = struct
                  ~args:Arg.[]
                  ~resolve:(fun _ { account; _ } ->
                    account.Account.Poly.receipt_chain_hash )
-             ; field "delegate" ~typ:public_key
+             ; field "delegate" ~typ:(non_null public_key)
                  ~doc:
                    "The public key to which you are delegating - if you are \
                     not delegating to anybody, this would return your public \
@@ -1342,15 +1342,12 @@ module Types = struct
                  ~args:Arg.[]
                  ~deprecated:(Deprecated (Some "use delegateAccount instead"))
                  ~resolve:(fun _ { account; _ } -> account.Account.Poly.delegate)
-             ; field "delegateAccount" ~typ:(Lazy.force account)
+             ; field "delegateAccount" ~typ:(non_null public_key)
                  ~doc:
                    "The account to which you are delegating - if you are not \
                     delegating to anybody, this would return your public key"
                  ~args:Arg.[]
-                 ~resolve:(fun { ctx = mina; _ } { account; _ } ->
-                   Option.map
-                     ~f:(get_best_ledger_account_pk mina)
-                     account.Account.Poly.delegate )
+                 ~resolve:(fun _ { account; _ } -> account.Account.Poly.delegate)
              ; field "delegators"
                  ~typ:(list @@ non_null @@ Lazy.force account)
                  ~doc:

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -27,7 +27,7 @@ module Transaction_applied = struct
     module Body = struct
       [%%versioned
       module Stable = struct
-        module V3 = struct
+        module V2 = struct
           type t =
             | Payment of { new_accounts : Account_id.Stable.V2.t list }
             | Stake_delegation of
@@ -42,8 +42,8 @@ module Transaction_applied = struct
 
     [%%versioned
     module Stable = struct
-      module V3 = struct
-        type t = { common : Common.Stable.V2.t; body : Body.Stable.V3.t }
+      module V2 = struct
+        type t = { common : Common.Stable.V2.t; body : Body.Stable.V2.t }
         [@@deriving sexp, to_yojson]
 
         let to_latest = Fn.id
@@ -80,7 +80,7 @@ module Transaction_applied = struct
     module Stable = struct
       module V2 = struct
         type t =
-          | Signed_command of Signed_command_applied.Stable.V3.t
+          | Signed_command of Signed_command_applied.Stable.V2.t
           | Zkapp_command of Zkapp_command_applied.Stable.V1.t
         [@@deriving sexp, to_yojson]
 

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -1616,14 +1616,10 @@ module Make (Inputs : Inputs_intf) = struct
     let a, local_state =
       let delegate = Account_update.Update.delegate account_update in
       let base_delegate =
-        let should_set_new_account_delegate =
-          (* Only accounts for the default token may delegate. *)
-          Bool.(account_is_new &&& account_update_token_is_default)
-        in
         (* New accounts should have the delegate equal to the public key of the
            account.
         *)
-        Public_key.if_ should_set_new_account_delegate
+        Public_key.if_ account_is_new
           ~then_:(Account_update.public_key account_update)
           ~else_:(Account.delegate a)
       in
@@ -1632,11 +1628,8 @@ module Make (Inputs : Inputs_intf) = struct
           (Account.Permissions.set_delegate a)
       in
       let local_state =
-        (* Note: only accounts for the default token can delegate. *)
         Local_state.add_check local_state Update_not_permitted_delegate
-          Bool.(
-            Set_or_keep.is_keep delegate
-            ||| (has_permission &&& account_update_token_is_default))
+          Bool.(Set_or_keep.is_keep delegate ||| has_permission)
       in
       let delegate =
         Set_or_keep.set_or_keep ~if_:Public_key.if_ delegate base_delegate


### PR DESCRIPTION
Make the `delegate` field in `Account.t` required. For new accounts, it's always the same as the public key, even if the token is not the default.

This change is meant to align in-and-out-of-SNARK use of the delegate field.