### PR TITLE
Set delegate in new accounts

### DIFF
--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -1227,6 +1227,7 @@ module Make (Inputs : Inputs_intf) = struct
       Account.set_delegate
         (Public_key.if_ self_delegate ~then_:(Account.public_key a)
            ~else_:(Account.delegate a) )
+        a
     in
     let matching_verification_key_hashes =
       Inputs.Bool.(

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -1218,17 +1218,15 @@ module Make (Inputs : Inputs_intf) = struct
     in
     (* delegate to public key if new account using default token *)
     let self_delegate =
-      let account_update_token_id =
-        Account_update.token_id account_update
-      in
-      Bool.(account_is_new &&&
-            Token_id.equal account_update_token_id Token_id.default)
+      let account_update_token_id = Account_update.token_id account_update in
+      Bool.(
+        account_is_new
+        &&& Token_id.equal account_update_token_id Token_id.default)
     in
     let a =
       Account.set_delegate
-        (Public_key.if_ self_delegate
-        ~then_:(Account.public_key a)
-        ~else_:(Account.delegate a))
+        (Public_key.if_ self_delegate ~then_:(Account.public_key a)
+           ~else_:(Account.delegate a) )
     in
     let matching_verification_key_hashes =
       Inputs.Bool.(

--- a/src/lib/transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/transaction_logic/zkapp_command_logic.ml
@@ -1216,6 +1216,20 @@ module Make (Inputs : Inputs_intf) = struct
         (Account_update.token_id account_update)
         (a, inclusion_proof)
     in
+    (* delegate to public key if new account using default token *)
+    let self_delegate =
+      let account_update_token_id =
+        Account_update.token_id account_update
+      in
+      Bool.(account_is_new &&&
+            Token_id.equal account_update_token_id Token_id.default)
+    in
+    let a =
+      Account.set_delegate
+        (Public_key.if_ self_delegate
+        ~then_:(Account.public_key a)
+        ~else_:(Account.delegate a))
+    in
     let matching_verification_key_hashes =
       Inputs.Bool.(
         (not (Account_update.is_proved account_update))


### PR DESCRIPTION
For new accounts created by zkApps, set the delegate to be the public key, if the account token is the default. That matches the strategy used when creating new accounts out-of-SNARK.

We were seeing SNARK failures for new accounts with delegate preconditions, because the delegate had not been set.
