### PR TITLE
Toolset for experiment 2

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -280,6 +280,15 @@
           "description": null,
           "fields": [
             {
+              "name": "cleanAddedPeers",
+              "description":
+                "If true, resets added peers to an empty list (including seeds)",
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "isolate",
               "description":
                 "If true, no connections will be allowed unless they are from a trusted peer",
@@ -347,6 +356,13 @@
             }
           ],
           "inputFields": [
+            {
+              "name": "cleanAddedPeers",
+              "description":
+                "If true, resets added peers to an empty list (including seeds)",
+              "type": { "kind": "SCALAR", "name": "Boolean", "ofType": null },
+              "defaultValue": null
+            },
             {
               "name": "isolate",
               "description":

--- a/src/app/itn_orchestrator/Makefile
+++ b/src/app/itn_orchestrator/Makefile
@@ -10,4 +10,7 @@ orchestrator: src/graphql_generated.go $(shell find src/ -type f)
 clean:
 	rm -f orchestrator src/graphql_generated.go
 
-.PHONY: clean tidy
+test:
+	cd src && go test
+
+.PHONY: clean tidy test

--- a/src/app/itn_orchestrator/genqlient.graphql
+++ b/src/app/itn_orchestrator/genqlient.graphql
@@ -2,6 +2,9 @@ query auth() {
     auth {
         serverUuid
         signerSequenceNumber
+        libp2pPort
+        peerId
+        isBlockProducer
     }
 }
 
@@ -11,4 +14,12 @@ mutation schedulePayments($input: PaymentsDetails!) {
 
 mutation stopPayments($handle: String!) {
     stopPayments(handle: $handle) 
+}
+
+query slotsWon() {
+    slotsWon
+}
+
+mutation updateGating($input: GatingUpdate!) {
+    updateGating(input: $input)
 }

--- a/src/app/itn_orchestrator/json_types/types.go
+++ b/src/app/itn_orchestrator/json_types/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"strconv"
+	"time"
 )
 
 type MinaPublicKey string
@@ -79,6 +80,24 @@ func (v *Ed25519Privkey) UnmarshalJSON(data []byte) error {
 func (v *Ed25519Privkey) MarshalJSON() ([]byte, error) {
 	seed := ed25519.PrivateKey(*v).Seed()
 	return MarshalBase64(&seed)
+}
+
+type Time time.Time
+
+func (v *Time) UnmarshalJSON(data []byte) error {
+	if data[0] == '"' && data[len(data)-1] == '"' {
+		res, err := time.Parse(time.RFC3339, string(data[1:len(data)-1]))
+		if err != nil {
+			return err
+		}
+		*v = Time(res)
+		return nil
+	}
+	return errors.New("not a string token")
+}
+
+func (v *Time) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + time.Time(*v).Format(time.RFC3339) + "\""), nil
 }
 
 // func UnmarshalPublicKey(data []byte, v *ed25519.PublicKey) error {

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -20,6 +20,28 @@ type ItnAuth {
   signerSequenceNumber: UInt16!
 }
 
+"""Update to gating config and added peers"""
+input GatingUpdate {
+  """Peers to connect to"""
+  addedPeers: [NetworkPeer!]!
+
+  """If true, resets added peers to an empty list (including seeds)"""
+  cleanAddedPeers: Boolean!
+
+  """
+  If true, no connections will be allowed unless they are from a trusted peer
+  """
+  isolate: Boolean!
+
+  """
+  Peers we will never allow connections from (unless they are also trusted!)
+  """
+  bannedPeers: [NetworkPeer!]!
+
+  """Peers we will always allow connections from"""
+  trustedPeers: [NetworkPeer!]!
+}
+
 type mutation {
   schedulePayments(
     """Payments details"""
@@ -29,6 +51,21 @@ type mutation {
     """Payment scheduler handle"""
     handle: String!
   ): String!
+  updateGating(
+    """Gating update"""
+    input: GatingUpdate!
+  ): String!
+}
+
+"""Network identifiers for another protocol participant"""
+input NetworkPeer {
+  libp2pPort: Int!
+
+  """IP address of the remote host"""
+  host: String!
+
+  """base58-encoded peer ID"""
+  peerId: String!
 }
 
 """Keys and other information for scheduling payments"""
@@ -67,4 +104,7 @@ scalar PublicKey
 type query {
   """Uuid for GraphQL server, sequence number for signing public key"""
   auth: ItnAuth!
+
+  """Slots won by a block producer for current epoch"""
+  slotsWon: [Int!]!
 }

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -43,6 +43,9 @@ type ItnAuth {
 
   """Peer id"""
   peerId: String!
+
+  """Is the node a block producer"""
+  isBlockProducer: Boolean!
 }
 
 type mutation {

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -8,17 +8,6 @@ scalar CurrencyAmount
 
 """uint64 encoded as a json string representing a fee"""
 scalar Fee
- 
-"""String representing a uint16 number in base 10"""
-scalar UInt16
-
-type ItnAuth {
-  """Uuid of the ITN GraphQL server"""
-  serverUuid: String!
-
-  """Sequence number for the signer of the auth query"""
-  signerSequenceNumber: UInt16!
-}
 
 """Update to gating config and added peers"""
 input GatingUpdate {
@@ -40,6 +29,20 @@ input GatingUpdate {
 
   """Peers we will always allow connections from"""
   trustedPeers: [NetworkPeer!]!
+}
+
+type ItnAuth {
+  """Uuid of the ITN GraphQL server"""
+  serverUuid: String!
+
+  """Sequence number for the signer of the auth query"""
+  signerSequenceNumber: UInt16!
+
+  """Libp2p port"""
+  libp2pPort: UInt16!
+
+  """Peer id"""
+  peerId: String!
 }
 
 type mutation {
@@ -108,3 +111,6 @@ type query {
   """Slots won by a block producer for current epoch"""
   slotsWon: [Int!]!
 }
+
+"""String representing a uint16 number in base 10"""
+scalar UInt16

--- a/src/app/itn_orchestrator/src/data.go
+++ b/src/app/itn_orchestrator/src/data.go
@@ -3,8 +3,10 @@ package itn_orchestrator
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/Khan/genqlient/graphql"
 	logging "github.com/ipfs/go-log/v2"
 )
 
@@ -27,13 +29,25 @@ type Command struct {
 
 type Scenario = []Command
 
+type NodeAddress string
+
+type NodeEntry struct {
+	Client          graphql.Client
+	Libp2pPort      uint16
+	PeerId          string
+	IsBlockProducer bool
+}
+
 type Config struct {
-	Ctx          context.Context
-	UptimeBucket *storage.BucketHandle
-	GetGqlClient GetGqlClientF
-	Log          logging.StandardLogger
-	Daemon       string
-	MinaExec     string
+	Ctx              context.Context
+	UptimeBucket     *storage.BucketHandle
+	GetGqlClient     GetGqlClientF
+	Log              logging.StandardLogger
+	Daemon           string
+	MinaExec         string
+	NodeData         map[NodeAddress]NodeEntry
+	SlotDurationMs   int
+	GenesisTimestamp time.Time
 }
 
 type OutputF = func(name string, value any, multiple bool, sensitive bool)

--- a/src/app/itn_orchestrator/src/discovery.go
+++ b/src/app/itn_orchestrator/src/discovery.go
@@ -1,11 +1,8 @@
 package itn_orchestrator
 
 import (
-	"context"
-	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -21,8 +18,6 @@ func prefixByTime(t time.Time) string {
 	return strings.Join([]string{"submissions", dStr, tStr}, "/")
 }
 
-type NodeAddress string
-
 type Node struct {
 	Address NodeAddress
 	Client  graphql.Client
@@ -31,25 +26,6 @@ type Node struct {
 type DiscoveryParams struct {
 	OffsetMin int
 	Limit     int
-}
-
-type GetGqlClientF = func(context.Context, NodeAddress) (graphql.Client, error)
-
-func GetGqlClient(sk ed25519.PrivateKey, cache map[NodeAddress]graphql.Client) GetGqlClientF {
-	authenticator := NewAuthenticator(sk, http.DefaultClient)
-	return func(ctx context.Context, addr NodeAddress) (graphql.Client, error) {
-		if client, has := cache[addr]; has {
-			return client, nil
-		}
-		url := "http://" + string(addr) + "/graphql"
-		authClient := graphql.NewClient(url, authenticator)
-		uuid, seqno, err := Auth(ctx, authClient)
-		if err != nil {
-			return nil, fmt.Errorf("failed to authorize client %s: %v", addr, err)
-		}
-		seqAuthenticator := NewSequentialAuthenticator(uuid, seqno, authenticator)
-		return graphql.NewClient(url, seqAuthenticator), nil
-	}
 }
 
 func DiscoverParticipants(config Config, params DiscoveryParams, output func(NodeAddress)) error {
@@ -94,7 +70,7 @@ func DiscoverParticipants(config Config, params DiscoveryParams, output func(Nod
 		}
 		cache[addr] = struct{}{}
 		output(addr)
-		if len(cache) >= params.Limit {
+		if params.Limit > 0 && len(cache) >= params.Limit {
 			break
 		}
 	}

--- a/src/app/itn_orchestrator/src/gating.go
+++ b/src/app/itn_orchestrator/src/gating.go
@@ -1,0 +1,149 @@
+package itn_orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"strings"
+)
+
+type IsolateParams struct {
+	Participants []NodeAddress
+}
+
+func Isolate(config Config, params IsolateParams) error {
+	peers := make([]NetworkPeer, len(params.Participants))
+	for i, address := range params.Participants {
+		host := string(address[:strings.IndexRune(string(address), ':')])
+		nd, has := config.NodeData[address]
+		if !has {
+			_, err := config.GetGqlClient(config.Ctx, address)
+			if err != nil {
+				return fmt.Errorf("failed to authenticate peer %s: %v", address, err)
+			}
+			nd = config.NodeData[address]
+		}
+		peers[i] = NetworkPeer{
+			Libp2pPort: int(nd.Libp2pPort),
+			PeerId:     nd.PeerId,
+			Host:       host,
+		}
+	}
+	for i, address := range params.Participants {
+		client, err := config.GetGqlClient(config.Ctx, address)
+		if err != nil {
+			return fmt.Errorf("failed to create a client for %s: %v", address, err)
+		}
+		addedPeers := make([]NetworkPeer, len(peers)-1)
+		copy(addedPeers, peers[:i])
+		copy(addedPeers[i:], peers[i+1:])
+		_, err = UpdateGatingGql(config.Ctx, client, GatingUpdate{
+			AddedPeers:      addedPeers,
+			Isolate:         true,
+			CleanAddedPeers: true,
+			BannedPeers:     make([]NetworkPeer, 0),
+			TrustedPeers:    addedPeers,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update gating for %s: %v", address, err)
+		}
+	}
+	return nil
+}
+
+type IsolateAction struct{}
+
+func (IsolateAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
+	var params IsolateParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return err
+	}
+	return Isolate(config, params)
+}
+
+var _ Action = IsolateAction{}
+
+type ResetGatingParams struct {
+	Participants   []NodeAddress
+	AddRandomPeers int
+}
+
+func ResetGating(config Config, params ResetGatingParams) error {
+	peers := make([]NetworkPeer, 0, len(config.NodeData))
+	for address, nd := range config.NodeData {
+		host := string(address[:strings.IndexRune(string(address), ':')])
+		peers = append(peers, NetworkPeer{
+			Libp2pPort: int(nd.Libp2pPort),
+			PeerId:     nd.PeerId,
+			Host:       host,
+		})
+	}
+	for _, address := range params.Participants {
+		client, err := config.GetGqlClient(config.Ctx, address)
+		if err != nil {
+			return fmt.Errorf("failed to create a client for %s: %v", address, err)
+		}
+		_, err = UpdateGatingGql(config.Ctx, client, GatingUpdate{
+			AddedPeers:      make([]NetworkPeer, 0),
+			Isolate:         false,
+			CleanAddedPeers: false,
+			BannedPeers:     make([]NetworkPeer, 0),
+			TrustedPeers:    make([]NetworkPeer, 0),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update gating for %s: %v", address, err)
+		}
+	}
+	for _, address := range params.Participants {
+		client, err := config.GetGqlClient(config.Ctx, address)
+		if err != nil {
+			return fmt.Errorf("failed to create a client for %s: %v", address, err)
+		}
+		var somePeers []NetworkPeer
+		if params.AddRandomPeers >= len(peers)-1 {
+			somePeers = peers
+		} else {
+			somePeers = make([]NetworkPeer, 0, params.AddRandomPeers)
+			ixs := make([]int, params.AddRandomPeers)
+			for i := 0; i < params.AddRandomPeers; i++ {
+			outerLoop:
+				ix := rand.Intn(len(peers))
+				if peers[ix].Host == string(address[:strings.IndexRune(string(address), ':')]) {
+					goto outerLoop
+				}
+				for j := 0; j < i; j++ {
+					if ixs[j] == ix {
+						goto outerLoop
+					}
+				}
+				ixs[i] = ix
+			}
+			for _, ix := range ixs {
+				somePeers = append(somePeers, peers[ix])
+			}
+		}
+		_, err = UpdateGatingGql(config.Ctx, client, GatingUpdate{
+			AddedPeers:      somePeers,
+			Isolate:         false,
+			CleanAddedPeers: false,
+			BannedPeers:     make([]NetworkPeer, 0),
+			TrustedPeers:    make([]NetworkPeer, 0),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update gating for %s: %v", address, err)
+		}
+	}
+	return nil
+}
+
+type ResetGatingAction struct{}
+
+func (ResetGatingAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
+	var params ResetGatingParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return err
+	}
+	return ResetGating(config, params)
+}
+
+var _ Action = ResetGatingAction{}

--- a/src/app/itn_orchestrator/src/go.mod
+++ b/src/app/itn_orchestrator/src/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Khan/genqlient v0.5.0
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/ipfs/go-log/v2 v2.1.3
+	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	google.golang.org/api v0.49.0
@@ -15,13 +16,12 @@ require (
 
 require (
 	cloud.google.com/go v0.84.0 // indirect
-	github.com/agnivade/levenshtein v1.1.1 // indirect
-	github.com/alexflint/go-arg v1.4.2 // indirect
-	github.com/alexflint/go-scalar v1.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.4.5 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
@@ -38,7 +38,7 @@ require (
 	google.golang.org/genproto v0.0.0-20210624174822-c5cf32407d0a // indirect
 	google.golang.org/grpc v1.38.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 
 replace itn_json_types => ../json_types

--- a/src/app/itn_orchestrator/src/go.sum
+++ b/src/app/itn_orchestrator/src/go.sum
@@ -50,11 +50,8 @@ github.com/Khan/genqlient v0.5.0/go.mod h1:EpIvDVXYm01GP6AXzjA7dKriPTH6GmtpmvTAw
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/agnivade/levenshtein v1.1.0/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
-github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
-github.com/alexflint/go-arg v1.4.2 h1:lDWZAXxpAnZUq4qwb86p/3rIJJ2Li81EoMbTMujhVa0=
 github.com/alexflint/go-arg v1.4.2/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
-github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
 github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
@@ -182,8 +179,10 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/kevinmbeaulieu/eq-go v1.0.0/go.mod h1:G3S8ajA56gKBZm4UB9AOyoOS37JO3roToPzKNM8dtdM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/matryer/moq v0.2.3/go.mod h1:9RtPYjTnH1bSBIkpvtHkFN7nbWAnO7oRpdJkEIn6UtE=
@@ -592,6 +591,7 @@ google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/l
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/src/app/itn_orchestrator/src/graphql.go
+++ b/src/app/itn_orchestrator/src/graphql.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -12,14 +13,6 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 )
-
-func Auth(ctx context.Context, client graphql.Client) (string, uint16, error) {
-	resp, err := auth(ctx, client)
-	if err != nil {
-		return "", 0, err
-	}
-	return resp.Auth.ServerUuid, resp.Auth.SignerSequenceNumber, nil
-}
 
 type Authenticator struct {
 	sk    ed25519.PrivateKey
@@ -97,7 +90,33 @@ func (client *SequentialAuthenticator) Do(req *http.Request) (*http.Response, er
 
 var _ graphql.Doer = (*SequentialAuthenticator)(nil)
 
-func SchedulePayments(ctx context.Context, client graphql.Client, input PaymentsDetails) (string, error) {
+type GetGqlClientF = func(context.Context, NodeAddress) (graphql.Client, error)
+
+func GetGqlClient(sk ed25519.PrivateKey, nodes map[NodeAddress]NodeEntry) GetGqlClientF {
+	authenticator := NewAuthenticator(sk, http.DefaultClient)
+	return func(ctx context.Context, addr NodeAddress) (graphql.Client, error) {
+		if entry, has := nodes[addr]; has {
+			return entry.Client, nil
+		}
+		url := "http://" + string(addr) + "/graphql"
+		authClient := graphql.NewClient(url, authenticator)
+		resp, err := auth(ctx, authClient)
+		if err != nil {
+			return nil, fmt.Errorf("failed to authorize client %s: %v", addr, err)
+		}
+		seqAuthenticator := NewSequentialAuthenticator(resp.Auth.ServerUuid, resp.Auth.SignerSequenceNumber, authenticator)
+		client := graphql.NewClient(url, seqAuthenticator)
+		nodes[addr] = NodeEntry{
+			Client:          client,
+			Libp2pPort:      resp.Auth.Libp2pPort,
+			PeerId:          resp.Auth.PeerId,
+			IsBlockProducer: resp.Auth.IsBlockProducer,
+		}
+		return client, nil
+	}
+}
+
+func SchedulePaymentsGql(ctx context.Context, client graphql.Client, input PaymentsDetails) (string, error) {
 	resp, err := schedulePayments(ctx, client, input)
 	if err != nil {
 		return "", err
@@ -105,10 +124,26 @@ func SchedulePayments(ctx context.Context, client graphql.Client, input Payments
 	return resp.SchedulePayments, nil
 }
 
-func StopPayments(ctx context.Context, client graphql.Client, handle string) (string, error) {
+func StopTransactionsGql(ctx context.Context, client graphql.Client, handle string) (string, error) {
 	resp, err := stopPayments(ctx, client, handle)
 	if err != nil {
 		return "", err
 	}
 	return resp.StopPayments, nil
+}
+
+func SlotsWonGql(ctx context.Context, client graphql.Client) ([]int, error) {
+	resp, err := slotsWon(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	return resp.SlotsWon, nil
+}
+
+func UpdateGatingGql(ctx context.Context, client graphql.Client, input GatingUpdate) (string, error) {
+	resp, err := updateGating(ctx, client, input)
+	if err != nil {
+		return "", err
+	}
+	return resp.UpdateGating, nil
 }

--- a/src/app/itn_orchestrator/src/itn_orchestrator/main.go
+++ b/src/app/itn_orchestrator/src/itn_orchestrator/main.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"itn_json_types"
 	"os"
+	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/Khan/genqlient/graphql"
 	logging "github.com/ipfs/go-log/v2"
 	"go.uber.org/zap/zapcore"
 
@@ -21,22 +21,28 @@ var actions map[string]lib.Action
 
 func init() {
 	actions = map[string]lib.Action{
-		"discovery": lib.DiscoverParticipantsAction{},
-		"payments":  lib.PaymentsAction{},
-		"load-keys": lib.KeyloaderAction{},
-		"stop":      lib.StopAction{},
-		"wait":      lib.WaitAction{},
-		"fund-keys": lib.FundAction{},
+		"discovery":      lib.DiscoverParticipantsAction{},
+		"payments":       lib.PaymentsAction{},
+		"load-keys":      lib.KeyloaderAction{},
+		"stop":           lib.StopAction{},
+		"wait":           lib.WaitAction{},
+		"fund-keys":      lib.FundAction{},
+		"slots-won":      lib.SlotsWonAction{},
+		"reset-gating":   lib.ResetGatingAction{},
+		"isolate":        lib.IsolateAction{},
+		"allocate-slots": lib.AllocateSlotsAction{},
 	}
 }
 
 type AppConfig struct {
-	LogLevel     zapcore.Level `json:",omitempty"`
-	LogFile      string        `json:",omitempty"`
-	Key          itn_json_types.Ed25519Privkey
-	UptimeBucket string
-	Daemon       string `json:",omitempty"`
-	MinaExec     string `json:",omitempty"`
+	LogLevel         zapcore.Level `json:",omitempty"`
+	LogFile          string        `json:",omitempty"`
+	Key              itn_json_types.Ed25519Privkey
+	UptimeBucket     string
+	Daemon           string `json:",omitempty"`
+	MinaExec         string `json:",omitempty"`
+	SlotDurationMs   int
+	GenesisTimestamp itn_json_types.Time
 }
 
 func loadAppConfig() (res AppConfig) {
@@ -80,14 +86,17 @@ func main() {
 		os.Exit(4)
 		return
 	}
-	clientCache := make(map[lib.NodeAddress]graphql.Client)
+	nodeData := make(map[lib.NodeAddress]lib.NodeEntry)
 	config := lib.Config{
-		Ctx:          ctx,
-		UptimeBucket: client.Bucket(appConfig.UptimeBucket),
-		GetGqlClient: lib.GetGqlClient(ed25519.PrivateKey(appConfig.Key), clientCache),
-		Log:          log,
-		Daemon:       appConfig.Daemon,
-		MinaExec:     appConfig.MinaExec,
+		Ctx:              ctx,
+		UptimeBucket:     client.Bucket(appConfig.UptimeBucket),
+		GetGqlClient:     lib.GetGqlClient(ed25519.PrivateKey(appConfig.Key), nodeData),
+		Log:              log,
+		Daemon:           appConfig.Daemon,
+		MinaExec:         appConfig.MinaExec,
+		NodeData:         nodeData,
+		SlotDurationMs:   appConfig.SlotDurationMs,
+		GenesisTimestamp: time.Time(appConfig.GenesisTimestamp),
 	}
 	if config.MinaExec == "" {
 		config.MinaExec = "mina"

--- a/src/app/itn_orchestrator/src/misc.go
+++ b/src/app/itn_orchestrator/src/misc.go
@@ -2,11 +2,14 @@ package itn_orchestrator
 
 import (
 	"encoding/json"
+	"sort"
 	"time"
 )
 
 type WaitParams struct {
 	Minutes int
+	Slot    int
+	Seconds int
 }
 
 type WaitAction struct{}
@@ -16,8 +19,61 @@ func (WaitAction) Run(config Config, rawParams json.RawMessage, output OutputF) 
 	if err := json.Unmarshal(rawParams, &params); err != nil {
 		return err
 	}
-	time.Sleep(time.Minute * time.Duration(params.Minutes))
+	delay := time.Minute*time.Duration(params.Minutes) + time.Second*time.Duration(params.Seconds)
+	if params.Slot > 0 {
+		at := config.GenesisTimestamp.Add(time.Millisecond*time.Duration(config.SlotDurationMs)*time.Duration(params.Slot) + delay)
+		delay = time.Until(at)
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+	} else {
+		time.Sleep(delay)
+	}
 	return nil
 }
 
 var _ Action = WaitAction{}
+
+// NextPermutation generates the next permutation of the
+// sortable collection x in lexical order.  It returns false
+// if the permutations are exhausted.
+//
+// Knuth, Donald (2011), "Section 7.2.1.2: Generating All Permutations",
+// The Art of Computer Programming, volume 4A.
+func NextPermutation(x sort.Interface) bool {
+	n := x.Len() - 1
+	if n < 1 {
+		return false
+	}
+	j := n - 1
+	for ; !x.Less(j, j+1); j-- {
+		if j == 0 {
+			return false
+		}
+	}
+	l := n
+	for !x.Less(j, l) {
+		l--
+	}
+	x.Swap(j, l)
+	for k, l := j+1, n; k < l; {
+		x.Swap(k, l)
+		k++
+		l--
+	}
+	return true
+}
+
+func filterLte(s []int, n int) []int {
+	for len(s) > 0 && s[len(s)-1] > n {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+func filterGt(s []int, n int) []int {
+	for len(s) > 0 && s[0] <= n {
+		s = s[1:]
+	}
+	return s
+}

--- a/src/app/itn_orchestrator/src/payments.go
+++ b/src/app/itn_orchestrator/src/payments.go
@@ -21,7 +21,7 @@ type ScheduledPaymentsReceipt struct {
 	Handle  string      `json:"handle"`
 }
 
-func SendPayments(config Config, params PaymentParams, output func(ScheduledPaymentsReceipt)) error {
+func SchedulePayments(config Config, params PaymentParams, output func(ScheduledPaymentsReceipt)) error {
 	sendersPerNode := len(params.Senders) / len(params.Nodes)
 	for nodeIx, nodeAddress := range params.Nodes {
 		paymentInput := PaymentsDetails{
@@ -38,7 +38,7 @@ func SendPayments(config Config, params PaymentParams, output func(ScheduledPaym
 		if err != nil {
 			return fmt.Errorf("error allocating client for %s: %v", nodeAddress, err)
 		}
-		handle, err := SchedulePayments(config.Ctx, client, paymentInput)
+		handle, err := SchedulePaymentsGql(config.Ctx, client, paymentInput)
 		if err != nil {
 			return fmt.Errorf("error scheduling payments to %s: %v", nodeAddress, err)
 		}
@@ -58,7 +58,7 @@ func (PaymentsAction) Run(config Config, rawParams json.RawMessage, output Outpu
 	if err := json.Unmarshal(rawParams, &params); err != nil {
 		return err
 	}
-	return SendPayments(config, params, func(receipt ScheduledPaymentsReceipt) {
+	return SchedulePayments(config, params, func(receipt ScheduledPaymentsReceipt) {
 		output("receipt", receipt, true, false)
 	})
 }

--- a/src/app/itn_orchestrator/src/slots_allocation.go
+++ b/src/app/itn_orchestrator/src/slots_allocation.go
@@ -1,0 +1,301 @@
+package itn_orchestrator
+
+import (
+	"container/heap"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type AllocateSlotsParams struct {
+	Groups []int
+
+	SlotsWon []SlotsWonOutput
+
+	// Minimum number of slots to split equally among groups
+	MinSlots int
+	// Maximum number of slots to split equally among groups
+	MaxSlots int
+}
+
+type slotEntry struct {
+	slots []int
+	ips   []string
+}
+
+type slotTuple struct {
+	// List of length equaling the number of groups
+	// Entries are sorted by length of their slot lists (ASC order)
+	entries slotEntries
+
+	// Difference in slot lengths between last and first entries
+	diff int
+}
+
+type slotEntries []slotEntry
+
+func (h slotEntries) Len() int { return len(h) }
+func (h slotEntries) Less(i, j int) bool {
+	return len(h[i].slots) < len(h[j].slots)
+}
+
+func (pq slotEntries) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func mergeSlotTuplesDo(x, y slotTuple) slotTuple {
+	groups := len(y.entries)
+	entries := make(slotEntries, groups)
+	for i := 0; i < groups; i++ {
+		ips := make([]string, len(x.entries[i].ips)+len(y.entries[i].ips))
+		copy(ips, x.entries[i].ips)
+		copy(ips[len(x.entries[i].ips):], y.entries[i].ips)
+		entries[i] = slotEntry{
+			ips:   ips,
+			slots: joinSlots(x.entries[i].slots, y.entries[i].slots),
+		}
+	}
+	sort.Sort(entries)
+	diff := len(entries[len(entries)-1].slots) - len(entries[0].slots)
+	return slotTuple{entries: entries, diff: diff}
+}
+
+func (x slotTuple) mergeWith(y slotTuple) (res slotTuple) {
+	ys := slotEntries(y.entries)
+	groups := len(ys)
+	if groups <= 5 {
+		// Small enough to run through all permutations to find the best
+		r := mergeSlotTuplesDo(x, y)
+		if r.diff == 0 {
+			return r
+		}
+		for NextPermutation(y.entries) {
+			c := mergeSlotTuplesDo(x, y)
+			if c.diff == 0 {
+				return c
+			} else if c.diff < r.diff {
+				r = c
+			}
+		}
+		return r
+	} else {
+		for i, j := 0, len(ys)-1; i < j; i, j = i+1, j-1 {
+			ys[i], ys[j] = ys[j], ys[i]
+		}
+		return mergeSlotTuplesDo(x, y)
+	}
+}
+
+type slotHeap []slotTuple
+
+func (h slotHeap) Len() int { return len(h) }
+func (h slotHeap) Less(i, j int) bool {
+	return h[i].diff > h[j].diff
+}
+
+func (pq slotHeap) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func (pq *slotHeap) Push(x interface{}) {
+	*pq = append(*pq, x.(slotTuple))
+}
+
+func (h *slotHeap) PopTuple() (l slotTuple, has bool) {
+	if h.Len() > 0 {
+		l = heap.Pop(h).(slotTuple)
+		has = true
+	}
+	return
+}
+func (pq *slotHeap) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	*pq = old[0 : n-1]
+	return item
+}
+
+// Implements a variant of Karmarkar–Karp algorithm (also known as Largest differencing method).
+//
+// It takes slot sets organized by the string id (ipToSLots map), number of groups to split to and
+// the maximum slot value.
+//
+// Algorithm runs O(n) iterations (each of `O(logn + n)` complexity) trying to heauristically construct
+// such partition of string ids into groups that their joint slot sets are of roghly equal size.
+//
+// Note that complexity of whole algorithm is `O(n * (logn + n))` but can be reduced to `O(nlogn)` with
+// the use of balanced tree (and wasn't done so because performance for expected sample size should be
+// fine even with quadratic algorithm)
+func partitionNumSets(ipToSlots map[string][]int, groups, endSlot int) slotTuple {
+	tuples := make(slotHeap, 0, len(ipToSlots))
+	for ip, slots := range ipToSlots {
+		slots = filterLte(slots, endSlot)
+		if len(slots) == 0 {
+			continue
+		}
+		entries := make([]slotEntry, groups)
+		entries[groups-1] = slotEntry{
+			slots: slots,
+			ips:   []string{ip},
+		}
+		tuples = append(tuples, slotTuple{
+			entries: entries,
+			diff:    len(slots),
+		})
+	}
+	heap.Init(&tuples)
+	for {
+		x, hasX := tuples.PopTuple()
+		if !hasX {
+			panic("partitionNumSets: empty heap")
+		}
+		y, hasY := tuples.PopTuple()
+		if !hasY {
+			return x
+		}
+		heap.Push(&tuples, x.mergeWith(y))
+	}
+}
+
+// Takes two asc-ordered int slices and merges them into a single
+// one, also sorted and without duplicates.
+func joinSlots(a, b []int) []int {
+	r := make([]int, 0, len(a)+len(b))
+	i := 0
+	j := 0
+	for i < len(a) && j < len(b) {
+		if len(r) > 0 && a[i] == r[len(r)-1] {
+			i++
+		} else if len(r) > 0 && b[j] == r[len(r)-1] {
+			j++
+		} else if a[i] <= b[j] {
+			r = append(r, a[i])
+			i++
+		} else {
+			r = append(r, b[j])
+			j++
+		}
+	}
+	for ; i < len(a); i++ {
+		if len(r) == 0 || a[i] != r[len(r)-1] {
+			r = append(r, a[i])
+		}
+	}
+	for ; j < len(b); j++ {
+		if len(r) == 0 || b[j] != r[len(r)-1] {
+			r = append(r, b[j])
+		}
+	}
+	return r
+}
+
+// Given mapping from ip to addresses, allocation of ips to groups of roughly-equal slot allocation
+// and `groups` slice of integers summing up to the number of groups, joins the groups in larger
+// groups according to what's specified in the `groups`.
+func arrangeGroups(ipToAddrs map[string][]NodeAddress, tuple slotTuple, groups []int, outputGroup func(int, []NodeAddress, []int)) {
+	i := 0
+	for j, n := range groups {
+		addrs := make([]NodeAddress, 0)
+		slots := make([]int, 0)
+		for _, entry := range tuple.entries[i : i+n] {
+			for _, ip := range entry.ips {
+				addrs = append(addrs, ipToAddrs[ip]...)
+			}
+			slots = joinSlots(slots, entry.slots)
+		}
+		outputGroup(j, addrs, slots)
+		i += n
+	}
+}
+
+// Iterates through slots from `endSlot` to `maxEndSlot` and calls `partitionNumSets` to find
+// the allocation of minimal slot difference between groups in allocation.
+func allocateSlotsDo(groups, endSlot, maxEndSlot int, ipToSlots map[string][]int) (slotTuple, int) {
+	bestTuple := partitionNumSets(ipToSlots, groups, endSlot)
+	bestSlot := endSlot
+	if bestTuple.diff > 0 {
+		for endSlot++; endSlot <= maxEndSlot; endSlot++ {
+			t := partitionNumSets(ipToSlots, groups, endSlot)
+			if t.diff == 0 {
+				bestTuple, bestSlot = t, endSlot
+				break
+			} else if t.diff < bestTuple.diff {
+				bestTuple, bestSlot = t, endSlot
+			}
+		}
+	}
+	return bestTuple, bestSlot
+}
+
+// Given slots won for different nodes, calculate node groups s.t. each group collectively wins a roughly equal number of slots
+//
+// Function finds the first empty slot `E` (not present in any node) and from that slot it tries to find minimal sequence of
+// slots for which there exists a perfectly equal split among nodes (s.t. each group collectively won equal number of slots).
+//
+// The sequence in question has maximal slot between `E + MinSlots` and `E + MaxSlots`. If no sequence with perfectly equal split is found,
+// the sequence with minimal relative slot difference between groups is chosen.
+func AllocateSlots(config Config, params AllocateSlotsParams, outputGroup func(int, []NodeAddress), outputNextEmptySlot func(int), outputLastSlot func(int)) error {
+	groups := 0
+	for _, n := range params.Groups {
+		groups += n
+		if n <= 0 {
+			return errors.New("groups should be positive")
+		}
+	}
+	ipToAddrs := make(map[string][]NodeAddress)
+	ipToSlots := make(map[string][]int)
+	var allSlots []int
+	for _, sw := range params.SlotsWon {
+		if len(sw.SlotsWon) == 0 {
+			continue
+		}
+		addr := string(sw.Address)
+		ip := addr[:strings.IndexRune(addr, ':')]
+		ipToAddrs[ip] = append(ipToAddrs[ip], sw.Address)
+		ipToSlots[ip] = joinSlots(ipToSlots[ip], sw.SlotsWon)
+		allSlots = joinSlots(allSlots, sw.SlotsWon)
+	}
+	if len(ipToSlots) == 0 {
+		return errors.New("no slots won provided")
+	}
+	emptySlot := allSlots[0]
+	for _, slot := range allSlots[1:] {
+		emptySlot++
+		if slot > emptySlot {
+			break
+		}
+	}
+	outputNextEmptySlot(emptySlot)
+	for ip := range ipToAddrs {
+		ipToSlots[ip] = filterGt(ipToSlots[ip], emptySlot)
+	}
+	bestTuple, bestEndSlot := allocateSlotsDo(groups, emptySlot+params.MinSlots, emptySlot+params.MaxSlots, ipToSlots)
+	outputLastSlot(bestEndSlot)
+	config.Log.Infof("Split to %d groups: %d difference, last slot %d", groups, bestTuple.diff, bestEndSlot)
+	arrangeGroups(ipToAddrs, bestTuple, params.Groups, func(i int, addrs []NodeAddress, slots []int) {
+		outputGroup(i, addrs)
+		config.Log.Infof("Slots for group %d: %v", i, slots)
+	})
+	return nil
+}
+
+type AllocateSlotsAction struct{}
+
+func (AllocateSlotsAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
+	var params AllocateSlotsParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return err
+	}
+	return AllocateSlots(config, params, func(groupId int, nodeGroup []NodeAddress) {
+		output("group"+strconv.Itoa(groupId), nodeGroup, false, false)
+	}, func(nextSlot int) {
+		output("nextEmptySlot", nextSlot, false, false)
+	}, func(lastSlot int) {
+		output("lastSlot", lastSlot, false, false)
+	})
+}
+
+var _ Action = AllocateSlotsAction{}

--- a/src/app/itn_orchestrator/src/slots_allocation_test.go
+++ b/src/app/itn_orchestrator/src/slots_allocation_test.go
@@ -1,0 +1,204 @@
+package itn_orchestrator
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func dedup(s []int) []int {
+	dups := -1 // number of duplicates - 1
+	for i, x := range s[1:] {
+		if x == s[i] {
+			dups++
+		} else {
+			s[i-dups] = x
+		}
+	}
+	return s[:len(s)-dups-1]
+}
+
+func sortAndDedup(s []int) []int {
+	sort.Ints(s)
+	return dedup(s)
+}
+
+func checkSortedNoDups(s []int) bool {
+	if len(s) == 0 {
+		return true
+	}
+	for i, x := range s[1:] {
+		if x <= s[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func genIp(i int) string {
+	return fmt.Sprintf("109.93.%d.%d", i/253+1, i%253+1)
+}
+
+func testcase(r *rand.Rand, n, minSlot int, sparsity float32, stakeDistribution []int) map[string][]int {
+	n_ := int(sparsity * float32(n))
+	totalStake := 0
+	for _, st := range stakeDistribution {
+		totalStake += st
+	}
+	res := make(map[string][]int)
+	for pi, stake := range stakeDistribution {
+		m := n * stake / totalStake
+		if m == 0 {
+			m = 1
+		}
+		slots := make([]int, m)
+		for i := range slots {
+			slots[i] = r.Intn(n_) + minSlot
+		}
+		res[genIp(pi)] = sortAndDedup(slots)
+	}
+	return res
+}
+
+func uniform(participants int) []int {
+	res := make([]int, participants)
+	for i := range res {
+		res[i] = 1
+	}
+	return res
+}
+
+func checkSlots(ipToSlots map[string][]int, entries slotEntries, maxSlot int) int {
+	allIps := map[string]struct{}{}
+	lastSlotLen := 0
+	for _, entry := range entries {
+		if !checkSortedNoDups(entry.slots) {
+			return -1
+		}
+		// Check all slots from ips are in the entry.slots and vice versa
+		mCalc := make(map[int]struct{})
+		mRet := make(map[int]struct{})
+		for _, s := range entry.slots {
+			mRet[s] = struct{}{}
+		}
+		for _, ip := range entry.ips {
+			allIps[ip] = struct{}{}
+			for _, s := range ipToSlots[ip] {
+				if s <= maxSlot {
+					mCalc[s] = struct{}{}
+				}
+			}
+		}
+		if len(mRet) != len(mCalc) {
+			return -2
+		}
+		for s := range mRet {
+			if _, has := mCalc[s]; !has {
+				return -3
+			}
+			if s > maxSlot {
+				return -4
+			}
+		}
+		if lastSlotLen > len(mCalc) {
+			return -5
+		}
+		lastSlotLen = len(mCalc)
+	}
+	expectedIps := map[string]struct{}{}
+	for ip, slots := range ipToSlots {
+		for _, s := range slots {
+			if s <= maxSlot {
+				expectedIps[ip] = struct{}{}
+			}
+		}
+	}
+	if len(allIps) != len(expectedIps) {
+		return -6
+	}
+	for ip := range allIps {
+		if _, has := expectedIps[ip]; !has {
+			return -7
+		}
+	}
+	return len(entries[len(entries)-1].slots) - len(entries[0].slots)
+}
+
+func TestPartitionNumSets3(t *testing.T) {
+	seed := rand.Int63()
+	t.Logf("Seed %d", seed)
+	r := rand.New(rand.NewSource(seed))
+	for i := 0; i < 100; i++ {
+		for _, n := range []int{30, 100, 1000, 10000} {
+			ipToSlots := testcase(r, 100, 1002, 2, uniform(3))
+			for i, entry := range ipToSlots {
+				require.True(t, checkSortedNoDups(entry), i)
+			}
+			tuple := partitionNumSets(ipToSlots, 3, 2000)
+			for i, entry := range tuple.entries {
+				require.Equal(t, 1, len(entry.ips), i)
+				require.Equal(t, ipToSlots[entry.ips[0]], entry.slots, i)
+			}
+			require.Less(t, tuple.diff, n/10+10)
+		}
+	}
+}
+
+func normal(r *rand.Rand, n int) []int {
+	res := make([]int, n)
+	for i := range res {
+		res[i] = int(math.Exp(-4.5*r.Float64()) * 1000.0)
+	}
+	return res
+}
+
+func TestParticipants(t *testing.T) {
+	minSlot := 1002
+	var wg sync.WaitGroup
+	for j := 0; j < 10; j++ {
+		seed := rand.Int63()
+		t.Logf("Seed %d: %d", j, seed)
+		r := rand.New(rand.NewSource(seed))
+		wg.Add(1)
+		go func(j int) {
+			defer wg.Done()
+			for _, sparsity := range []float32{2, 3, 0.5} {
+				for _, participants := range []int{10, 100, 1000} {
+					for _, groups := range []int{2, 3, 4} {
+						for _, n := range []int{30, 100, 1000} {
+							n_ := int(sparsity * float32(n))
+							minEndSlot := minSlot + n_/4
+							maxEndSlot := minSlot + n_*3/4
+							var dist []int
+							if j&1 > 0 {
+								dist = uniform(participants)
+							} else {
+								dist = normal(r, participants)
+							}
+							ipToSlots := testcase(r, n, minSlot, sparsity, dist)
+							for i, entry := range ipToSlots {
+								require.True(t, checkSortedNoDups(entry), "i=%d groups=%d n=%d", i, groups, n)
+							}
+							{
+								tuple := partitionNumSets(ipToSlots, groups, minEndSlot)
+								require.GreaterOrEqualf(t, tuple.diff, 0, "groups=%d n=%d", groups, n)
+								require.Equalf(t, checkSlots(ipToSlots, tuple.entries, minEndSlot), tuple.diff, "groups=%d n=%d", groups, n)
+								require.Lessf(t, tuple.diff, n/5+10, "groups=%d n=%d", groups, n)
+							}
+							tuple, lastSlot := allocateSlotsDo(groups, minEndSlot, maxEndSlot, ipToSlots)
+							require.GreaterOrEqualf(t, tuple.diff, 0, "groups=%d n=%d", groups, n)
+							require.Equalf(t, checkSlots(ipToSlots, tuple.entries, lastSlot), tuple.diff, "groups=%d n=%d", groups, n)
+							require.Lessf(t, tuple.diff, n/5+5, "groups=%d n=%d", groups, n)
+						}
+					}
+				}
+			}
+		}(j)
+	}
+	wg.Wait()
+}

--- a/src/app/itn_orchestrator/src/slots_won.go
+++ b/src/app/itn_orchestrator/src/slots_won.go
@@ -1,0 +1,48 @@
+package itn_orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type SlotsWonParams struct {
+	Participants []NodeAddress
+}
+
+type SlotsWonOutput struct {
+	Address  NodeAddress `json:"address"`
+	SlotsWon []int       `json:"slots"`
+}
+
+func SlotsWon(config Config, params SlotsWonParams, output func(SlotsWonOutput)) error {
+	for _, address := range params.Participants {
+		client, err := config.GetGqlClient(config.Ctx, address)
+		if err != nil {
+			return fmt.Errorf("failed to create a client for %s: %v", address, err)
+		}
+		if config.NodeData[address].IsBlockProducer {
+			resp, err := SlotsWonGql(config.Ctx, client)
+			if err != nil {
+				return fmt.Errorf("failed to get slots for %s: %v", address, err)
+			}
+			output(SlotsWonOutput{SlotsWon: resp, Address: address})
+		} else {
+			config.Log.Infof("not querying slots won for node %s", address)
+		}
+	}
+	return nil
+}
+
+type SlotsWonAction struct{}
+
+func (SlotsWonAction) Run(config Config, rawParams json.RawMessage, output OutputF) error {
+	var params SlotsWonParams
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return err
+	}
+	return SlotsWon(config, params, func(swo SlotsWonOutput) {
+		output("slotsWon", swo, true, false)
+	})
+}
+
+var _ Action = SlotsWonAction{}

--- a/src/app/itn_orchestrator/src/stop.go
+++ b/src/app/itn_orchestrator/src/stop.go
@@ -9,14 +9,14 @@ type StopParams struct {
 	Receipts []ScheduledPaymentsReceipt
 }
 
-func StopScheduledTransactions(config Config, params StopParams) error {
+func StopTransactions(config Config, params StopParams) error {
 	for _, receipt := range params.Receipts {
 		client, err := config.GetGqlClient(config.Ctx, receipt.Address)
 		if err != nil {
-			return fmt.Errorf("failed to created client for %s: %v", receipt.Address, err)
+			return fmt.Errorf("failed to create a client for %s: %v", receipt.Address, err)
 		}
-		resp, err := StopPayments(config.Ctx, client, receipt.Handle)
-		config.Log.Infof("stopPayments on %s: %s (%v)", receipt.Address, resp, err)
+		resp, err := StopTransactionsGql(config.Ctx, client, receipt.Handle)
+		config.Log.Infof("stop scheduled transactions on %s: %s (%v)", receipt.Address, resp, err)
 	}
 	return nil
 }
@@ -28,7 +28,7 @@ func (StopAction) Run(config Config, rawParams json.RawMessage, output OutputF) 
 	if err := json.Unmarshal(rawParams, &params); err != nil {
 		return err
 	}
-	return StopScheduledTransactions(config, params)
+	return StopTransactions(config, params)
 }
 
 var _ Action = StopAction{}

--- a/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/config_msg.go
@@ -376,6 +376,9 @@ func (msg ConfigureReq) handle(app *app, seqno uint64) *capnp.Message {
 	if err != nil {
 		return mkRpcRespError(seqno, badRPC(err))
 	}
+	if gc.CleanAddedPeers() {
+		app.AddedPeers = nil
+	}
 
 	stateDir, err := m.Statedir()
 	if err != nil {
@@ -595,7 +598,9 @@ func (m SetGatingConfigReq) handle(app *app, seqno uint64) *capnp.Message {
 	if err != nil {
 		return mkRpcRespError(seqno, badRPC(err))
 	}
-
+	if gc.CleanAddedPeers() {
+		app.AddedPeers = nil
+	}
 	app.P2p.SetGatingState(gatingConfig)
 
 	return mkRpcRespSuccess(seqno, func(m *ipc.Libp2pHelperInterface_RpcResponseSuccess) {

--- a/src/app/libp2p_helper/src/libp2p_helper/msg.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/msg.go
@@ -177,8 +177,10 @@ func readGatingConfig(gc ipc.GatingConfig, addedPeers []peer.AddrInfo) (*codanet
 	if err != nil {
 		return nil, err
 	}
-	for _, peer := range addedPeers {
-		trustedPeers.Add(peer.ID)
+	if !gc.CleanAddedPeers() {
+		for _, peer := range addedPeers {
+			trustedPeers.Add(peer.ID)
+		}
 	}
 
 	return &codanet.CodaGatingConfig{

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -606,7 +606,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
     ~trust_system ~get_completed_work ~transaction_resource_pool
     ~time_controller ~consensus_local_state ~coinbase_receiver ~frontier_reader
     ~transition_writer ~set_next_producer_timing ~log_block_creation
-    ~block_reward_threshold ~block_produced_bvar =
+    ~block_reward_threshold ~block_produced_bvar ~vrf_evaluation_state =
   let open Context in
   O1trace.sync_thread "produce_blocks" (fun () ->
       let genesis_breadcrumb =
@@ -994,7 +994,6 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
       in
       let production_supervisor = Singleton_supervisor.create ~task:produce in
       let scheduler = Singleton_scheduler.create time_controller in
-      let vrf_evaluation_state = Vrf_evaluation_state.create () in
       let rec check_next_block_timing slot i () =
         O1trace.sync_thread "check_next_block_timing" (fun () ->
             (* Begin checking for the ability to produce a block *)

--- a/src/lib/gossip_net/any.ml
+++ b/src/lib/gossip_net/any.ml
@@ -81,8 +81,8 @@ module Make (Rpc_intf : Network_peer.Rpc_intf.Rpc_interface_intf) :
 
   let connection_gating (Any ((module M), t)) = M.connection_gating t
 
-  let set_connection_gating (Any ((module M), t)) config =
-    M.set_connection_gating t config
+  let set_connection_gating ?clean_added_peers (Any ((module M), t)) config =
+    M.set_connection_gating ?clean_added_peers t config
 
   let restart_helper (Any ((module M), t)) = M.restart_helper t
 end

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -286,7 +286,7 @@ module Make (Rpc_intf : Network_peer.Rpc_intf.Rpc_interface_intf) :
 
     let connection_gating t = Deferred.return !(t.connection_gating)
 
-    let set_connection_gating t config =
+    let set_connection_gating ?clean_added_peers:_ t config =
       t.connection_gating := config ;
       Deferred.return config
   end

--- a/src/lib/gossip_net/intf.ml
+++ b/src/lib/gossip_net/intf.ml
@@ -34,7 +34,10 @@ module type Gossip_net_intf = sig
   val connection_gating : t -> Mina_net2.connection_gating Deferred.t
 
   val set_connection_gating :
-    t -> Mina_net2.connection_gating -> Mina_net2.connection_gating Deferred.t
+       ?clean_added_peers:bool
+    -> t
+    -> Mina_net2.connection_gating
+    -> Mina_net2.connection_gating Deferred.t
 
   val random_peers : t -> int -> Peer.t list Deferred.t
 

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -951,9 +951,9 @@ module Make (Rpc_intf : Network_peer.Rpc_intf.Rpc_interface_intf) :
       let%map net2 = !(t.net2) in
       Mina_net2.connection_gating_config net2
 
-    let set_connection_gating t config =
+    let set_connection_gating ?clean_added_peers t config =
       let%bind net2 = !(t.net2) in
-      Mina_net2.set_connection_gating_config net2 config
+      Mina_net2.set_connection_gating_config ?clean_added_peers net2 config
 
     let restart_helper t = t.restart_helper ()
   end

--- a/src/lib/mina_graphql/dune
+++ b/src/lib/mina_graphql/dune
@@ -100,6 +100,7 @@
    kimchi_backend
    sgn_type
    mina_transaction_logic
+   gossip_net
  )
  (instrumentation (backend bisect_ppx))
  (preprocessor_deps ../../config.mlh)

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3024,17 +3024,19 @@ module Types = struct
     end
 
     module SetConnectionGatingConfigInput = struct
-      type input = Mina_net2.connection_gating
+      type input =
+        Mina_net2.connection_gating * [ `Clean_added_peers of bool option ]
 
       let arg_typ =
         obj "SetConnectionGatingConfigInput"
-          ~coerce:(fun trusted_peers banned_peers isolate ->
+          ~coerce:(fun trusted_peers banned_peers isolate clean_added_peers ->
             let open Result.Let_syntax in
             let%bind trusted_peers = Result.all trusted_peers in
             let%map banned_peers = Result.all banned_peers in
-            Mina_net2.{ isolate; trusted_peers; banned_peers } )
-          ~split:(fun f (t : input) ->
-            f t.trusted_peers t.banned_peers t.isolate )
+            ( Mina_net2.{ isolate; trusted_peers; banned_peers }
+            , `Clean_added_peers clean_added_peers ) )
+          ~split:(fun f ((t, `Clean_added_peers clean_added_peers) : input) ->
+            f t.trusted_peers t.banned_peers t.isolate clean_added_peers )
           ~fields:
             Arg.
               [ arg "trustedPeers"
@@ -3049,6 +3051,10 @@ module Types = struct
                   ~doc:
                     "If true, no connections will be allowed unless they are \
                      from a trusted peer"
+              ; arg "cleanAddedPeers" ~typ:bool
+                  ~doc:
+                    "If true, resets added peers to an empty list (including \
+                     seeds)"
               ]
     end
 
@@ -3102,6 +3108,55 @@ module Types = struct
                     ~typ:(non_null float)
                 ; arg "durationInMinutes" ~doc:"Length of scheduler run"
                     ~typ:(non_null int)
+                ]
+      end
+
+      module GatingUpdate = struct
+        type input =
+          { trusted_peers : Network_peer.Peer.t list
+          ; banned_peers : Network_peer.Peer.t list
+          ; isolate : bool
+          ; clean_added_peers : bool
+          ; added_peers : Network_peer.Peer.t list
+          }
+
+        let arg_typ =
+          obj "GatingUpdate" ~doc:"Update to gating config and added peers"
+            ~coerce:(fun trusted_peers banned_peers isolate clean_added_peers
+                         added_peers ->
+              let%bind.Result trusted_peers = Result.all trusted_peers in
+              let%bind.Result banned_peers = Result.all banned_peers in
+              let%map.Result added_peers = Result.all added_peers in
+              { trusted_peers
+              ; banned_peers
+              ; isolate
+              ; clean_added_peers
+              ; added_peers
+              } )
+            ~split:(fun f (t : input) ->
+              f t.trusted_peers t.banned_peers t.isolate t.clean_added_peers
+                t.added_peers )
+            ~fields:
+              Arg.
+                [ arg "trustedPeers"
+                    ~typ:(non_null (list (non_null NetworkPeer.arg_typ)))
+                    ~doc:"Peers we will always allow connections from"
+                ; arg "bannedPeers"
+                    ~typ:(non_null (list (non_null NetworkPeer.arg_typ)))
+                    ~doc:
+                      "Peers we will never allow connections from (unless they \
+                       are also trusted!)"
+                ; arg "isolate" ~typ:(non_null bool)
+                    ~doc:
+                      "If true, no connections will be allowed unless they are \
+                       from a trusted peer"
+                ; arg "cleanAddedPeers" ~typ:(non_null bool)
+                    ~doc:
+                      "If true, resets added peers to an empty list (including \
+                       seeds)"
+                ; arg "addedPeers"
+                    ~typ:(non_null (list (non_null NetworkPeer.arg_typ)))
+                    ~doc:"Peers to connect to"
                 ]
       end
     end
@@ -4008,9 +4063,12 @@ module Mutations = struct
       ~typ:(non_null Types.Payload.set_connection_gating_config)
       ~resolve:(fun { ctx = mina; _ } () config ->
         let open Deferred.Result.Let_syntax in
-        let%bind config = Deferred.return config in
+        let%bind config, `Clean_added_peers clean_added_peers =
+          Deferred.return config
+        in
         let open Deferred.Let_syntax in
-        Mina_networking.set_connection_gating_config (Mina_lib.net mina) config
+        Mina_networking.set_connection_gating_config ?clean_added_peers
+          (Mina_lib.net mina) config
         >>| Result.return )
 
   let add_peer =
@@ -4378,7 +4436,48 @@ module Mutations = struct
                    (sprintf "Not a valid scheduled payments handle: %s" handle)
           )
 
-    let commands = [ schedule_payments; stop_payments ]
+    let update_gating =
+      io_field "updateGating"
+        ~args:
+          Arg.
+            [ arg "input" ~doc:"Gating update"
+                ~typ:(non_null Types.Input.Itn.GatingUpdate.arg_typ)
+            ]
+        ~typ:(non_null string)
+        ~resolve:(fun { ctx = with_seq_no, mina; _ } () input ->
+          if not with_seq_no then return @@ Error "Missing sequence information"
+          else
+            let%bind.Deferred.Result { trusted_peers
+                                     ; banned_peers
+                                     ; isolate
+                                     ; clean_added_peers
+                                     ; added_peers
+                                     } =
+              Deferred.return input
+            in
+            let config = Mina_net2.{ trusted_peers; banned_peers; isolate } in
+            let net = Mina_lib.net mina in
+            let%bind _new_gating_config =
+              Mina_networking.set_connection_gating_config ~clean_added_peers
+                net config
+            in
+            let%bind failures =
+              (* Add all peers *)
+              Deferred.List.filter_map added_peers ~f:(fun peer ->
+                  match%map.Deferred
+                    Mina_networking.add_peer net peer ~is_seed:false
+                  with
+                  | Ok () ->
+                      None
+                  | Error err ->
+                      Some (Error.to_string_hum err) )
+            in
+            if List.is_empty failures then Deferred.Result.return "success"
+            else
+              Deferred.Result.failf "failed to add peers: %s"
+                (String.concat ~sep:", " failures) )
+
+    let commands = [ schedule_payments; stop_payments; update_gating ]
   end
 end
 

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -117,8 +117,11 @@ type t =
       ([ `Path of string ] option * [ `Log ] option) ref
   ; block_production_status :
       [ `Producing | `Producing_in_ms of float | `Free ] ref
+  ; vrf_evaluation_state : Block_producer.Vrf_evaluation_state.t
   }
 [@@deriving fields]
+
+let vrf_evaluation_state t = t.vrf_evaluation_state
 
 let time_controller t = t.config.time_controller
 
@@ -1313,7 +1316,8 @@ let start t =
       ~transition_writer:t.pipes.producer_transition_writer
       ~log_block_creation:t.config.log_block_creation
       ~block_reward_threshold:t.config.block_reward_threshold
-      ~block_produced_bvar:t.components.block_produced_bvar ;
+      ~block_produced_bvar:t.components.block_produced_bvar
+      ~vrf_evaluation_state:t.vrf_evaluation_state ;
   perform_compaction t ;
   let () =
     match t.config.node_status_url with
@@ -2176,6 +2180,8 @@ let create ?wallets (config : Config.t) =
             ; sync_status
             ; precomputed_block_writer
             ; block_production_status = ref `Free
+            ; vrf_evaluation_state =
+                Block_producer.Vrf_evaluation_state.create ()
             } ) )
 
 let net { components = { net; _ }; _ } = net

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -222,3 +222,5 @@ val verifier : t -> Verifier.t
 val vrf_evaluator : t -> Vrf_evaluator.t
 
 val genesis_ledger : t -> Mina_ledger.Ledger.t Lazy.t
+
+val vrf_evaluation_state : t -> Block_producer.Vrf_evaluation_state.t

--- a/src/lib/mina_net2/mina_net2.mli
+++ b/src/lib/mina_net2/mina_net2.mli
@@ -371,7 +371,10 @@ val shutdown : t -> unit Deferred.t
 
     This will fail if any of the trusted or banned peers are on IPv6. *)
 val set_connection_gating_config :
-  t -> connection_gating -> connection_gating Deferred.t
+     t
+  -> ?clean_added_peers:bool
+  -> connection_gating
+  -> connection_gating Deferred.t
 
 val connection_gating_config : t -> connection_gating
 

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -1463,8 +1463,8 @@ include struct
 
   let connection_gating_config t = lift connection_gating t
 
-  let set_connection_gating_config t config =
-    lift set_connection_gating t config
+  let set_connection_gating_config t ?clean_added_peers config =
+    lift (set_connection_gating ?clean_added_peers) t config
 end
 
 (* TODO: Have better pushback behavior *)

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -273,7 +273,10 @@ val initial_peers : t -> Mina_net2.Multiaddr.t list
 val connection_gating_config : t -> Mina_net2.connection_gating Deferred.t
 
 val set_connection_gating_config :
-  t -> Mina_net2.connection_gating -> Mina_net2.connection_gating Deferred.t
+     t
+  -> ?clean_added_peers:bool
+  -> Mina_net2.connection_gating
+  -> Mina_net2.connection_gating Deferred.t
 
 val ban_notification_reader :
   t -> Gossip_net.ban_notification Linear_pipe.Reader.t

--- a/src/libp2p_ipc/libp2p_ipc.capnp
+++ b/src/libp2p_ipc/libp2p_ipc.capnp
@@ -59,6 +59,7 @@ struct GatingConfig {
   trustedIps @2 :List(Text);
   trustedPeerIds @3 :List(PeerId);
   isolate @4 :Bool;
+  cleanAddedPeers @5 :Bool;
 }
 
 struct TopicLevel {

--- a/src/libp2p_ipc/libp2p_ipc.ml
+++ b/src/libp2p_ipc/libp2p_ipc.ml
@@ -163,7 +163,7 @@ let create_libp2p_config ~private_key ~statedir ~listen_on ?metrics_port
            (List.map ~f:create_topic_level topic_config))
 
 let create_gating_config ~banned_ips ~banned_peers ~trusted_ips ~trusted_peers
-    ~isolate =
+    ~isolate ~clean_added_peers =
   build
     (module Builder.GatingConfig)
     Builder.GatingConfig.(
@@ -171,7 +171,8 @@ let create_gating_config ~banned_ips ~banned_peers ~trusted_ips ~trusted_peers
       *> list_op banned_peer_ids_set_list banned_peers
       *> list_op trusted_ips_set_list trusted_ips
       *> list_op trusted_peer_ids_set_list trusted_peers
-      *> op isolate_set isolate)
+      *> op isolate_set isolate
+      *> op clean_added_peers_set clean_added_peers)
 
 let create_rpc_header ~sequence_number =
   build'

--- a/src/libp2p_ipc/libp2p_ipc.mli
+++ b/src/libp2p_ipc/libp2p_ipc.mli
@@ -80,6 +80,7 @@ val create_gating_config :
   -> trusted_ips:string list
   -> trusted_peers:Builder.PeerId.t list
   -> isolate:bool
+  -> clean_added_peers:bool
   -> gating_config
 
 val create_rpc_request :


### PR DESCRIPTION
This PR updates ITN toolset with the following commands:

- `slots-won`: to query slots won by a node
- `reset-gating`: to reset gating config of a node
- `isolate`: to isolate a set of nodes to form an isolated cluster
- `allocate-slots`: to split block producers into distinct groups of nodes with roughly equal occupation of slot per group (or a desired proportion)

Explain how you tested your changes:
* Slot allocation algorithm is covered with test
* Tooling was tested manually on a private cluster

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #12829
* Closes #12843 
