### PR TITLE
[REBASED] add a cache for recently used accounts

### DIFF
--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -96,4 +96,6 @@ input ZkappCommandsDetails {
   feePayers: [PrivateKey!]!
 
   noPrecondition: Boolean!
+
+  maxSize: Boolean!
 }

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -98,4 +98,9 @@ input ZkappCommandsDetails {
   noPrecondition: Boolean!
 
   maxSize: Boolean!
+
+  """
+  Avoid recently used accounts when generating new zkapp commands
+  """
+  recentlyUsedAccounts: Int!
 }

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -15,6 +15,7 @@ type ZkappCommandParams struct {
 	FeePayers         []itn_json_types.MinaPrivateKey
 	Nodes             []NodeAddress
 	NoPrecondition    bool
+	MaxSize           bool
 }
 
 type ScheduledZkappCommandsReceipt struct {
@@ -33,6 +34,7 @@ func SendZkappCommands(config Config, params ZkappCommandParams, output func(Sch
 			NumNewAccounts:        params.NewAccounts,
 			FeePayers:             params.FeePayers[nodeIx*feePayersPerNode : (nodeIx+1)*feePayersPerNode],
 			NoPrecondition:        params.NoPrecondition,
+			MaxSize:               params.MaxSize,
 		}
 		client, err := config.GetGqlClient(config.Ctx, nodeAddress)
 		if err != nil {

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -7,15 +7,16 @@ import (
 )
 
 type ZkappCommandParams struct {
-	ExperimentName    string
-	Tps               float64
-	DurationInMinutes int
-	ZkappsToDeploy    int
-	NewAccounts       int
-	FeePayers         []itn_json_types.MinaPrivateKey
-	Nodes             []NodeAddress
-	NoPrecondition    bool
-	MaxSize           bool
+	ExperimentName       string
+	Tps                  float64
+	DurationInMinutes    int
+	ZkappsToDeploy       int
+	NewAccounts          int
+	FeePayers            []itn_json_types.MinaPrivateKey
+	Nodes                []NodeAddress
+	NoPrecondition       bool
+	MaxSize              bool
+	RecentlyUsedAccounts int
 }
 
 type ScheduledZkappCommandsReceipt struct {
@@ -35,6 +36,7 @@ func SendZkappCommands(config Config, params ZkappCommandParams, output func(Sch
 			FeePayers:             params.FeePayers[nodeIx*feePayersPerNode : (nodeIx+1)*feePayersPerNode],
 			NoPrecondition:        params.NoPrecondition,
 			MaxSize:               params.MaxSize,
+			RecentlyUsedAccounts:  params.RecentlyUsedAccounts,
 		}
 		client, err := config.GetGqlClient(config.Ctx, nodeAddress)
 		if err != nil {

--- a/src/lib/mina_generators/zkapp_command_generators.mli
+++ b/src/lib/mina_generators/zkapp_command_generators.mli
@@ -48,6 +48,8 @@ val gen_protocol_state_precondition :
 val gen_zkapp_command_from :
      ?global_slot:Mina_numbers.Global_slot.t
   -> ?memo:string
+  -> ?max_size:bool
+  -> ?genesis_constants:Genesis_constants.t
   -> ?no_account_precondition:bool
   -> ?ignore_sequence_events_precond:bool
   -> ?no_token_accounts:bool

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3164,7 +3164,7 @@ module Types = struct
                     ~typ:(non_null bool)
                 ; arg "maxSize" ~doc:"Generate max size zkapp transactions"
                     ~typ:(non_null bool)
-                ; arg "recently_used_accounts"
+                ; arg "recentlyUsedAccounts"
                     ~doc:
                       "Avoid recently used accounts when generating new zkApp \
                        commands"

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3114,6 +3114,7 @@ module Types = struct
           ; duration_in_minutes : int
           ; memo_prefix : string
           ; no_precondition : bool
+          ; max_size : bool
           }
 
         let arg_typ =
@@ -3121,7 +3122,7 @@ module Types = struct
             ~doc:"Keys and other information for scheduling zkapp commands"
             ~coerce:(fun fee_payers num_zkapps_to_deploy num_new_accounts
                          transactions_per_second duration_in_minutes memo_prefix
-                         no_precondition ->
+                         no_precondition max_size ->
               Result.return
                 { fee_payers
                 ; num_zkapps_to_deploy
@@ -3130,11 +3131,12 @@ module Types = struct
                 ; duration_in_minutes
                 ; memo_prefix
                 ; no_precondition
+                ; max_size
                 } )
             ~split:(fun f (t : input) ->
               f t.fee_payers t.num_zkapps_to_deploy t.num_new_accounts
                 t.transactions_per_second t.duration_in_minutes t.memo_prefix
-                t.no_precondition )
+                t.no_precondition t.max_size )
             ~fields:
               Arg.
                 [ arg "feePayers"
@@ -3157,6 +3159,8 @@ module Types = struct
                 ; arg "memoPrefix" ~doc:"Prefix of memo" ~typ:(non_null string)
                 ; arg "noPrecondition"
                     ~doc:"Disable the precondition in account updates"
+                    ~typ:(non_null bool)
+                ; arg "maxSize" ~doc:"Generate max size zkapp transactions"
                     ~typ:(non_null bool)
                 ]
       end
@@ -4689,7 +4693,13 @@ module Mutations = struct
                                            ~no_token_accounts:true ~limited:true
                                            ~fee_payer_keypair:fee_payer ~keymap
                                            ~account_state_tbl
-                                           ~generate_new_accounts ~ledger ~vk () )
+                                           ~generate_new_accounts ~ledger ~vk
+                                           ~max_size:
+                                             zkapp_command_details.max_size
+                                           ~genesis_constants:
+                                             (Mina_lib.config mina)
+                                               .precomputed_values
+                                               .genesis_constants () )
                                         ~size:1
                                         ~random:
                                           (Splittable_random.State.create

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4642,11 +4642,11 @@ module Mutations = struct
                               Queue.length recently_used_accounts
                               > zkapp_command_details.recently_used_accounts
                             then
-                              let a =
+                              let a, role =
                                 Queue.dequeue_exn recently_used_accounts
                               in
-                              Account_id.Table.add_exn account_state_tbl ~key:id
-                                ~data:a
+                              Account_id.Table.add_exn account_state_tbl
+                                ~key:(Account.identifier a) ~data:(a, role)
                             else ()
                           in
                           let rec go ~vk ~prover ~account_state_tbl ~ndx
@@ -4684,6 +4684,7 @@ module Mutations = struct
                                 | Some (ledger, _) -> (
                                     let number_of_accounts_generated =
                                       Account_id.Table.data account_state_tbl
+                                      @ Queue.to_list recently_used_accounts
                                       |> List.filter ~f:(function
                                            | _, `New_account ->
                                                true
@@ -4691,6 +4692,7 @@ module Mutations = struct
                                                false )
                                       |> List.length
                                     in
+
                                     let generate_new_accounts =
                                       number_of_accounts_generated
                                       < zkapp_command_details.num_new_accounts

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -3115,6 +3115,7 @@ module Types = struct
           ; memo_prefix : string
           ; no_precondition : bool
           ; max_size : bool
+          ; recently_used_accounts : int
           }
 
         let arg_typ =
@@ -3122,7 +3123,7 @@ module Types = struct
             ~doc:"Keys and other information for scheduling zkapp commands"
             ~coerce:(fun fee_payers num_zkapps_to_deploy num_new_accounts
                          transactions_per_second duration_in_minutes memo_prefix
-                         no_precondition max_size ->
+                         no_precondition max_size recently_used_accounts ->
               Result.return
                 { fee_payers
                 ; num_zkapps_to_deploy
@@ -3132,11 +3133,12 @@ module Types = struct
                 ; memo_prefix
                 ; no_precondition
                 ; max_size
+                ; recently_used_accounts
                 } )
             ~split:(fun f (t : input) ->
               f t.fee_payers t.num_zkapps_to_deploy t.num_new_accounts
                 t.transactions_per_second t.duration_in_minutes t.memo_prefix
-                t.no_precondition t.max_size )
+                t.no_precondition t.max_size t.recently_used_accounts )
             ~fields:
               Arg.
                 [ arg "feePayers"
@@ -3162,6 +3164,11 @@ module Types = struct
                     ~typ:(non_null bool)
                 ; arg "maxSize" ~doc:"Generate max size zkapp transactions"
                     ~typ:(non_null bool)
+                ; arg "recently_used_accounts"
+                    ~doc:
+                      "Avoid recently used accounts when generating new zkApp \
+                       commands"
+                    ~typ:(non_null int)
                 ]
       end
     end
@@ -4623,8 +4630,27 @@ module Mutations = struct
                                 (Public_key.compress public_key, private_key) )
                             |> Public_key.Compressed.Map.of_alist_exn
                           in
-                          let rec go ~vk ~prover account_state_tbl ndx tm_next
-                              counter =
+                          let insert_recently_used_accounts
+                              ~recently_used_accounts ~account_state_tbl id =
+                            let a =
+                              Account_id.Table.find_and_remove account_state_tbl
+                                id
+                            in
+                            Queue.enqueue recently_used_accounts
+                              (Option.value_exn a) ;
+                            if
+                              Queue.length recently_used_accounts
+                              > zkapp_command_details.recently_used_accounts
+                            then
+                              let a =
+                                Queue.dequeue_exn recently_used_accounts
+                              in
+                              Account_id.Table.add_exn account_state_tbl ~key:id
+                                ~data:a
+                            else ()
+                          in
+                          let rec go ~vk ~prover ~account_state_tbl ~ndx
+                              ~tm_next ~counter ~recently_used_accounts =
                             if Time.( >= ) (Time.now ()) tm_end then (
                               [%log info]
                                 "Scheduled zkApp commands with handle %s has \
@@ -4705,6 +4731,15 @@ module Mutations = struct
                                           (Splittable_random.State.create
                                              Random.State.default )
                                     in
+                                    let accounts =
+                                      Zkapp_command.accounts_referenced
+                                        zkapp_command_with_dummy_auth
+                                    in
+                                    List.iter accounts
+                                      ~f:
+                                        (insert_recently_used_accounts
+                                           ~recently_used_accounts
+                                           ~account_state_tbl ) ;
                                     let%bind zkapp_command =
                                       Zkapp_command_builder
                                       .replace_authorizations ~prover ~keymap
@@ -4733,9 +4768,10 @@ module Mutations = struct
                               in
                               let%bind () = Async_unix.at tm_next in
                               let next_tm_next = Time.add tm_next wait_span in
-                              go ~vk ~prover account_state_tbl
-                                ((ndx + 1) mod num_fee_payers)
-                                next_tm_next (counter + 1)
+                              go ~vk ~prover ~account_state_tbl
+                                ~ndx:((ndx + 1) mod num_fee_payers)
+                                ~tm_next:next_tm_next ~counter:(counter + 1)
+                                ~recently_used_accounts
                           in
                           upon
                             (wait_until_zkapps_deployed ~mina ~ledger
@@ -4753,6 +4789,7 @@ module Mutations = struct
                                       List.map ids ~f:(fun id ->
                                           (id, (account_of_id id ledger, role)) )
                                     in
+
                                     Account_id.Table.of_alist_exn
                                       ( get_account fee_payer_ids `Fee_payer
                                       @ get_account zkapp_account_ids
@@ -4766,9 +4803,13 @@ module Mutations = struct
                                   let tm_next =
                                     Time.add (Time.now ()) wait_span
                                   in
+                                  let recently_used_accounts =
+                                    Queue.create ()
+                                  in
                                   don't_wait_for
-                                  @@ go account_state_tbl ~vk ~prover 0 tm_next
-                                       0 ) ;
+                                  @@ go ~account_state_tbl ~vk ~prover ~ndx:0
+                                       ~tm_next ~counter:0
+                                       ~recently_used_accounts ) ;
 
                           Ok (Uuid.to_string uuid) ) ) )
 


### PR DESCRIPTION
Explain your changes:
This PR adds a cache for recently used accounts for zkApp scheduler. When generating new zkApp commands we would try to avoid using these accounts.

Explain how you tested your changes:
It's tested against Viable System's cluster

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
