### PR TITLE
Zkapp scheduler: avoid recently used accounts

### DIFF
--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -154,6 +154,11 @@ input ZkappCommandsDetails {
   maxFee: String! 
 
   deploymentFee: String!
+
+  """
+  Avoid recently used accounts when generating new zkapp commands
+  """
+  recentlyUsedAccounts: Int!
 }
 
 """String representing a uint16 number in base 10"""

--- a/src/app/itn_orchestrator/schema.graphql
+++ b/src/app/itn_orchestrator/schema.graphql
@@ -155,10 +155,7 @@ input ZkappCommandsDetails {
 
   deploymentFee: String!
 
-  """
-  Avoid recently used accounts when generating new zkapp commands
-  """
-  recentlyUsedAccounts: Int!
+  accountQueueSize: Int!
 }
 
 """String representing a uint16 number in base 10"""

--- a/src/app/itn_orchestrator/src/discovery.go
+++ b/src/app/itn_orchestrator/src/discovery.go
@@ -24,8 +24,9 @@ type Node struct {
 }
 
 type DiscoveryParams struct {
-	OffsetMin int
-	Limit     int
+	OffsetMin          int
+	Limit              int
+	OnlyBlockProducers bool `json:"omitempty"`
 }
 
 func DiscoverParticipants(config Config, params DiscoveryParams, output func(NodeAddress)) error {
@@ -66,6 +67,9 @@ func DiscoverParticipants(config Config, params DiscoveryParams, output func(Nod
 		_, err = config.GetGqlClient(ctx, addr)
 		if err != nil {
 			log.Errorf("Error on auth for %s: %v", addr, err)
+			continue
+		}
+		if !config.NodeData[addr].IsBlockProducer && params.OnlyBlockProducers {
 			continue
 		}
 		cache[addr] = struct{}{}

--- a/src/app/itn_orchestrator/src/go.mod
+++ b/src/app/itn_orchestrator/src/go.mod
@@ -16,9 +16,6 @@ require (
 
 require (
 	cloud.google.com/go v0.84.0 // indirect
-	github.com/agnivade/levenshtein v1.1.1 // indirect
-	github.com/alexflint/go-arg v1.4.2 // indirect
-	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -41,7 +38,6 @@ require (
 	google.golang.org/genproto v0.0.0-20210624174822-c5cf32407d0a // indirect
 	google.golang.org/grpc v1.38.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 

--- a/src/app/itn_orchestrator/src/go.sum
+++ b/src/app/itn_orchestrator/src/go.sum
@@ -50,11 +50,8 @@ github.com/Khan/genqlient v0.5.0/go.mod h1:EpIvDVXYm01GP6AXzjA7dKriPTH6GmtpmvTAw
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/agnivade/levenshtein v1.1.0/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
-github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
-github.com/alexflint/go-arg v1.4.2 h1:lDWZAXxpAnZUq4qwb86p/3rIJJ2Li81EoMbTMujhVa0=
 github.com/alexflint/go-arg v1.4.2/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
-github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
 github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -7,21 +7,21 @@ import (
 )
 
 type ZkappCommandParams struct {
-	ExperimentName       string
-	Tps                  float64
-	DurationInMinutes    int
-	ZkappsToDeploy       int
-	NewAccounts          int
-	FeePayers            []itn_json_types.MinaPrivateKey
-	Nodes                []NodeAddress
-	NoPrecondition       bool
-	MinBalanceChange     string
-	MaxBalanceChange     string
-	InitBalance          string
-	MinFee               string
-	MaxFee               string
-	DeploymentFee        string
-	RecentlyUsedAccounts int
+	ExperimentName    string
+	Tps               float64
+	DurationInMinutes int
+	ZkappsToDeploy    int
+	NewAccounts       int
+	FeePayers         []itn_json_types.MinaPrivateKey
+	Nodes             []NodeAddress
+	NoPrecondition    bool
+	MinBalanceChange  string
+	MaxBalanceChange  string
+	InitBalance       string
+	MinFee            string
+	MaxFee            string
+	DeploymentFee     string
+	AccountQueueSize  int
 }
 
 type ScheduledZkappCommandsReceipt struct {
@@ -46,7 +46,7 @@ func SendZkappCommands(config Config, params ZkappCommandParams, output func(Sch
 			MinFee:                params.MinFee,
 			MaxFee:                params.MaxFee,
 			DeploymentFee:         params.DeploymentFee,
-			RecentlyUsedAccounts:  params.RecentlyUsedAccounts,
+			AccountQueueSize:      params.AccountQueueSize,
 		}
 		client, err := config.GetGqlClient(config.Ctx, nodeAddress)
 		if err != nil {

--- a/src/app/itn_orchestrator/src/zkapp.go
+++ b/src/app/itn_orchestrator/src/zkapp.go
@@ -7,20 +7,21 @@ import (
 )
 
 type ZkappCommandParams struct {
-	ExperimentName    string
-	Tps               float64
-	DurationInMinutes int
-	ZkappsToDeploy    int
-	NewAccounts       int
-	FeePayers         []itn_json_types.MinaPrivateKey
-	Nodes             []NodeAddress
-	NoPrecondition    bool
-	MinBalanceChange  string 
-	MaxBalanceChange  string 
-	InitBalance       string
-	MinFee            string 
-	MaxFee            string 
-	DeploymentFee     string
+	ExperimentName       string
+	Tps                  float64
+	DurationInMinutes    int
+	ZkappsToDeploy       int
+	NewAccounts          int
+	FeePayers            []itn_json_types.MinaPrivateKey
+	Nodes                []NodeAddress
+	NoPrecondition       bool
+	MinBalanceChange     string
+	MaxBalanceChange     string
+	InitBalance          string
+	MinFee               string
+	MaxFee               string
+	DeploymentFee        string
+	RecentlyUsedAccounts int
 }
 
 type ScheduledZkappCommandsReceipt struct {
@@ -39,12 +40,13 @@ func SendZkappCommands(config Config, params ZkappCommandParams, output func(Sch
 			NumNewAccounts:        params.NewAccounts,
 			FeePayers:             params.FeePayers[nodeIx*feePayersPerNode : (nodeIx+1)*feePayersPerNode],
 			NoPrecondition:        params.NoPrecondition,
-			MinBalanceChange:      params.MinBalanceChange, 
-			MaxBalanceChange:      params.MaxBalanceChange, 
+			MinBalanceChange:      params.MinBalanceChange,
+			MaxBalanceChange:      params.MaxBalanceChange,
 			InitBalance:           params.InitBalance,
-			MinFee:                params.MinFee, 
+			MinFee:                params.MinFee,
 			MaxFee:                params.MaxFee,
 			DeploymentFee:         params.DeploymentFee,
+			RecentlyUsedAccounts:  params.RecentlyUsedAccounts,
 		}
 		client, err := config.GetGqlClient(config.Ctx, nodeAddress)
 		if err != nil {

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4787,11 +4787,11 @@ module Mutations = struct
                               Queue.length recently_used_accounts
                               > zkapp_command_details.recently_used_accounts
                             then
-                              let a =
+                              let a, role =
                                 Queue.dequeue_exn recently_used_accounts
                               in
-                              Account_id.Table.add_exn account_state_tbl ~key:id
-                                ~data:a
+                              Account_id.Table.add_exn account_state_tbl
+                                ~key:(Account.identifier a) ~data:(a, role)
                             else ()
                           in
                           let rec go account_state_tbl ndx tm_next counter
@@ -4829,6 +4829,7 @@ module Mutations = struct
                                 | Some (ledger, _) -> (
                                     let number_of_accounts_generated =
                                       Account_id.Table.data account_state_tbl
+                                      @ Queue.to_list recently_used_accounts
                                       |> List.filter ~f:(function
                                            | _, `New_account ->
                                                true
@@ -4836,6 +4837,7 @@ module Mutations = struct
                                                false )
                                       |> List.length
                                     in
+
                                     let generate_new_accounts =
                                       number_of_accounts_generated
                                       < zkapp_command_details.num_new_accounts

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4789,8 +4789,7 @@ module Mutations = struct
                                 ~key:(Account.identifier a) ~data:(a, role)
                             else ()
                           in
-                          let rec go account_state_tbl ndx tm_next counter
-                              ~recently_used_accounts =
+                          let rec go ~account_state_tbl ~ndx ~tm_next ~counter =
                             if Time.( >= ) (Time.now ()) tm_end then (
                               [%log info]
                                 "Scheduled zkApp commands with handle %s has \
@@ -4910,11 +4909,11 @@ module Mutations = struct
                               in
                               let%bind () = Async_unix.at tm_next in
                               let next_tm_next = Time.add tm_next wait_span in
-                              go account_state_tbl
-                                ((ndx + 1) mod num_fee_payers)
-                                next_tm_next (counter + 1)
-                                ~recently_used_accounts
+                              go ~account_state_tbl
+                                ~ndx:((ndx + 1) mod num_fee_payers)
+                                ~tm_next:next_tm_next ~counter:(counter + 1)
                           in
+
                           upon
                             (wait_until_zkapps_deployed ~mina ~ledger
                                ~deployment_fee:
@@ -4943,12 +4942,9 @@ module Mutations = struct
                                   let tm_next =
                                     Time.add (Time.now ()) wait_span
                                   in
-                                  let recently_used_accounts =
-                                    Queue.create ()
-                                  in
                                   don't_wait_for
-                                  @@ go account_state_tbl 0 tm_next 0
-                                       ~recently_used_accounts ) ;
+                                  @@ go ~account_state_tbl ~ndx:0 ~tm_next
+                                       ~counter:0 ) ;
 
                           Ok (Uuid.to_string uuid) ) ) )
 


### PR DESCRIPTION
Explain your changes:
This PR adds a recently used accounts cache to the zkapp scheduler. When generating new zkapp commands, we would try to avoid using recently used accounts to avoid dependency between zkapp commands.
```
mutation ($input: ZkappCommandsInput!) {
  scheduleZkappCommands(input: $input){
    handle
  }
}
```
where input is of type
```
        type input =
          { fee_payers : Signature_lib.Private_key.t list
          ; num_zkapps_to_deploy : int
          ; num_new_accounts : int
          ; transactions_per_second : float
          ; duration_in_minutes : int
          ; memo_prefix : string
          ; no_precondition : bool
          ; account_queue_size : int
          ; min_balance_change : string
          ; max_balance_change : string
          ; init_balance : string
          ; min_fee : string
          ; max_fee : string
          ; deployment_fee : string
          }
```

Explain how you tested your changes:
*

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
