### PR TITLE
Delegate precondition, fix SNARK failure, tests

### DIFF
--- a/src/lib/transaction_snark/test/zkapp_preconditions/dune
+++ b/src/lib/transaction_snark/test/zkapp_preconditions/dune
@@ -37,7 +37,7 @@
    transaction_snark_tests
    random_oracle
    random_oracle_input
-   )
+   zkapp_command_builder)
   (library_flags -linkall)
   (inline_tests)
   (preprocess


### PR DESCRIPTION
The fix in #13043 for SNARK failures seen when new accounts have a `delegate` precondition wasn't quite right. In-SNARK, the account has an empty public key, so setting the delegate to that key is incorrect. The fix is to set the delegate to the account update's public key.

Remove the redundant code that conditionally sets the `base_delegate` based on whether the account is new, and the token is the default. The fix has already set the account delegate using the same criteria.

Add two tests using the `delegate` account precondition, one with the default token (the zkApp succeeds), another with a custom token (the zkApp gets the expected failure). Neither should trigger a SNARK failure.

Rename `party_preconditions` to `zkapp_preconditions` (while `account_update_preconditions` is more accurate, it's too long).

Closes #13040. Closes #13051.
