### PR TITLE
fix and editorial grooming for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,36 @@
 # Contributing to Mina
 
-Thank you for your interest in contributing to Mina. This file outlines
-various parts of our process. Mina is still very young, so things might be a
-little bumpy while we figure out how to smoothly run the project!
+Mina is an open source project. Thank you for your interest in contributing to Mina. This file outlines
+various parts of our process. Mina is always evolving and in active development, so things might be a
+little bumpy while we work together to provide the best experience for you to contribute!
 
-If you haven't seen it yet, the [developer README](README-dev.md) has the
+See the [developer README](README-dev.md) for the
 basic setup you need to get up and running to build and edit Mina.
 
 Here's the summary if you want to contribute code:
 
 1. Learn some OCaml. The [Real World OCaml](https://dev.realworldocaml.org/toc.html) book is good. Jane Street also has [some exercises](https://github.com/janestreet/learn-ocaml-workshop).
-2. Learn how we use OCaml. We have [a style guide](https://docs.minaprotocol.com/node-developers/style-guide) that goes over the important things.
-3. Fork and clone the repo, then set up your development environment. See the [developer README](README-dev.md) for details.
-4. Find a good first issue. The best issues to start with are those tagged [`easy`](https://github.com/MinaProtocol/mina/labels/easy).
+2. Learn how we use OCaml, see the [style guide](https://docs.minaprotocol.com/node-developers/style-guide) that goes over the important things. 
+3. Fork and clone the repo, then set up your development environment. See the [Mina README-dev](README-dev.md) for details.
+4. Find a good first issue. The best issues to start with have the [`easy`](https://github.com/MinaProtocol/mina/labels/easy) label.
 5. Create a branch in your local clone and implement the solution.
 6. Push the branch to your GitHub fork and create a pull request.
 7. 🙌
 
 ## Bug reports
 
-Bug reports should include, at minimal, the `mina -version` output and
+Bug reports must include, at minimal, the `mina -version` output and
 a description of the error. See the [bug report
-template](.github/ISSUE_TEMPLATE/1-BUG_REPORT.yml). Documentation
-issues and failing tests should be reported using respective templates.
+template](.github/ISSUE_TEMPLATE/1-BUG_REPORT.yml). Report documentation
+issues and failing tests using those issue templates.
 
 All bugs need to be reproduced before they can be fixed. Anyone can try and
-reproduce a bug! If you have trouble reproducing a bug, please comment with what
-you tried. If it doesn't reproduce using exactly the steps in the issue report,
-please write a comment describing your new steps to reproduce, or what environment
+reproduce a bug. If you have trouble reproducing a bug, please comment with what
+you tried. If it doesn't reproduce using exactly the steps in the issue report, 
+write a comment describing your new steps to reproduce or what environment
 setup you had to do to reproduce.
 
-Maintainers should label bug reports with `bug`, and any other relevant labels.
+Code maintainers must label bug reports with `bug` and all other relevant labels.
 
 ## Feature requests
 
@@ -38,7 +38,7 @@ We'll consider any feature requests, although the most successful feature
 requests usually aren't immediately posted to the issue tracker. The most
 successful feature requests start with discussion in the community!
 
-Maintainers should label feature requests with `feature`, and any other relevant
+Maintainers label feature requests with `feature` and other relevant
 labels.
 
 ## Pull Requests
@@ -46,31 +46,34 @@ labels.
 ### Branching workflow
 
 Make sure to read about the [branching workflow](README-branching.md) to
-understand on which branch (`compatible` or `develop`) you should be working,
+understand on which branch (`compatible` or `develop`) to work in
 and how to manage simultaneous PRs to both branches.
 
 ### Continuous integration
 
-All pull requests go through Buildkite CI, which makes sure the code doesn't need to
+All pull requests go through Buildkite CI to make sure the code doesn't need to
 be reformatted, builds Mina in its various configurations, and runs all the
 tests.
 
 All pull requests must get _code reviewed_. Anyone can do a code
 review! Check out the [code review
 guide](https://docs.minaprotocol.com/node-developers/code-review-guidelines) for
-what to look for. Just leave comments on the "Files changed" view.
+what to look for. Just leave comments on the **Files changed** view.
 
 All pull requests must be approved by at least one _code owner_ for the
 source code they touch. See the [CODEOWNERS](./CODEOWNERS) file to
-find out who they are.
+find out who the maintainers are.
 
-Maintainers should assign reviewers to pull requests, and tag them with any
-relevant labels. If you happen to have access to the development slack,
+Maintainers assign reviewers to pull requests and tag the pull requests with 
+relevant labels. If you happen to have access to the development Slack,
 you can skip this step by asking reviewers directly in the #review-requests channel.
 
-If you are PRing from the main remote, add `ci-build-me` label when you want to run CI. If you are PRing from a fork, ask a core contributor to `!ci-build-me` when you're ready for CI to run. Note: You will need the `!ci-build-me` comment for each and every run of CI.
+- If you are PRing from the main remote branch, add the **ci-build-me** label when you want to run CI. 
+- If you are PRing from a fork, ask a core contributor to add the `!ci-build-me` comment to your PR when you're ready for CI to run. 
 
-Once a PR has been reviewed and approved, and all CI tests have passed, it can be merged
+**Note:** The `!ci-build-me` comment is required for each and every run of CI.
+
+After a PR has been reviewed and approved and all CI tests have passed, the PR can be merged
 by a maintainer (or by you, if you have this access).
 
 If you encounter problems with the CI, read [CI FAILURES](README-ci-failures.md)
@@ -80,16 +83,14 @@ for common troubleshooting steps.
 
 There are three main pieces of Mina documentation:
 
-1. The [`docs`](docs/) directory, which has prose documentation of various sorts.
-2. The `README.md` files in various directories. These explain the contents of that
+1. The [https://github.com/o1-labs/docs2)](https://github.com/o1-labs/docs2) repository for the [Mina Protocol](https://docs.minaprotocol.com/) docs website.
+2. The `README.md` files in various directories explain the contents of that
    directory at a high level: the purpose of the library, design constraints, anything else
    specific to that directory.
-3. Inline code comments. There are unfortunately very few of these currently,
-   but this will slowly change. We are now running `ocamldoc` and the generated
-   documentation is browsable
-   [online](https://mina-docs.storage.googleapis.com/index.html).
+3. Inline code comments. We are working to provide more comments. We run `ocamldoc` and the generated 
+   [OCaml package documentation](https://mina-docs.storage.googleapis.com/index.html) is browsable.
 
-Changes to the software should come with changes to the documentation.
+Changes to the software require changes to the documentation. The Mina Docs use a docs-as-code workflow to develop and publish product documentation using the same tools and processes as software code development. All user-impacting updates on the codebase require corresponding updates to the relevant documentation in the docs repo. See the [Docs Contributing Guidelines](https://github.com/o1-labs/docs2/blob/main/CONTRIBUTING.md). 
 
 ## RFCs
 
@@ -104,9 +105,9 @@ implement.
 This process isn't final, but in general:
 
 1. RFCs will be open for at least a week for discussion.
-2. Once discussion has slowed down or there is consensus, the core eng team
+2. After discussion has slowed down or there is consensus, the core eng team
    will initiate a "Final Comment Period". This will include the core eng's
-   "merge disposition" (merge/don't merge). The FCP comment should be based
+   "merge disposition" (merge/don't merge). The FCP comment must be based
    on information and arguments already present in the RFC thread. At the
    end of the FCP, the core eng team decides to do another FCP, leave the FCP
    state for continued discussion, or resolve the RFC by merging/closing
@@ -119,11 +120,11 @@ RFCs generally describe the design of a feature. As the code corresponding to
 the RFC changes, the RFC should be updated to reflect the current state of the
 code.
 
-This is loosely inspired by the Rust RFC process, Python PEPs, and IETF RFCs.
+This RFC process is loosely inspired by the Rust RFC process, Python PEPs, and IETF RFCs.
 
 ## Release process
 
-Create a PR to merge master into testnet. Once that is approved by CI and checked in...
+Create a PR to merge `master` into `testnet`. After that PR is approved by CI and checked in...
 
 ```
 git checkout testnet
@@ -131,12 +132,11 @@ git tag testnet-v0.$WHATEVER_IS_NEXT
 git push testnet-v0.$WHATEVER_IS_NEXT
 ```
 
-Previously we used `stable` branch and after that a couple `release/mainnet-X.X.X`
-branches, but currently we just create a branch `release/X.X.X` for each new release
-and all the changes that go into that release should be merged into the appropriate
+We create a branch `release/X.X.X` for each new release. 
+All of the changes that go into that release must be merged into the appropriate
 release branch.
 
-Create a PR to merge testnet into the current release branch. Once that is
+Create a PR to merge testnet into the current release branch. After that is
 approved by CI and checked in...
 
 ```
@@ -145,10 +145,10 @@ git tag v1.$WHATEVER_IS_NEXT
 git push v1.$WHATEVER_IS_NEXT
 ```
 
-And then do the above steps for testnet. Don't forget to deploy!
+And then do the steps again for `testnet`. Don't forget to deploy!
 
 ## Issue/PR label guide
 
-We use them, although currently in a somewhat ad-hoc way. Please see
+We use labels to provide important content. See
 https://github.com/MinaProtocol/mina/labels for the list of labels and their
-short descriptions. Any "complicated" labels should be described here.
+short descriptions. Any "complicated" labels are described here.


### PR DESCRIPTION
This PR improves the developer experience and reduces friction for open-source contributors. 
As we work together to bring Mina to the world, let's continue to iteratively improve essential user-facing content. 

This PR updates the [CONTRIBUTING](https://github.com/MinaProtocol/mina/blob/develop/CONTRIBUTING.md) file.

---

Explain your changes:
* Updates to content for a first level editorial cleanup and grooming
* Provides a correct link to the https://github.com/o1-labs/docs2 repository
* Applies editorial styles, mostly changing "should" to "must", "once" to "after", and other non-technical updates and clarifications 

Explain how you tested your changes:
* No technical tests, just eyeballs on the words

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
