### PR TITLE
Deployment according to tps

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -4577,7 +4577,8 @@ module Mutations = struct
 
     let deploy_zkapps ~mina ~ledger ~deployment_fee ~max_cost ~init_balance
         ~(fee_payer_array : Signature_lib.Keypair.t Array.t)
-        ~constraint_constants ~logger ~memo_prefix keypairs =
+        ~constraint_constants ~logger ~memo_prefix ~wait_span ~stop_signal
+        ~stop_time ~uuid keypairs =
       let fee_payer_accounts =
         Array.map fee_payer_array ~f:(fun key -> account_of_kp key ledger)
       in
@@ -4587,55 +4588,73 @@ module Mutations = struct
       let ndx = ref 0 in
       let num_fee_payers = Array.length fee_payer_array in
       Deferred.List.iter keypairs ~f:(fun kp ->
-          let fee_payer_keypair = fee_payer_array.(!ndx) in
-          let memo = sprintf "%s-%s" memo_prefix (Int.to_string !ndx) in
-          let spec =
-            { Transaction_snark.For_tests.Deploy_snapp_spec.sender =
-                (fee_payer_keypair, !(fee_payer_nonces.(!ndx)))
-            ; fee = Currency.Fee.of_mina_string_exn deployment_fee
-            ; fee_payer = None
-            ; amount = Currency.Amount.of_mina_string_exn init_balance
-            ; zkapp_account_keypairs = [ kp ]
-            ; memo = Signed_command_memo.create_from_string_exn memo
-            ; new_zkapp_account = true
-            ; snapp_update = Account_update.Update.dummy
-            ; preconditions = None
-            ; authorization_kind = Account_update.Authorization_kind.Signature
-            }
-          in
-          let zkapp_command =
-            Transaction_snark.For_tests.deploy_snapp ~constraint_constants
-              ~permissions:
-                ( if max_cost then
-                  { Permissions.user_default with
-                    set_verification_key = Permissions.Auth_required.Proof
-                  ; edit_state = Permissions.Auth_required.Proof
-                  ; edit_action_state = Proof
-                  }
-                else Permissions.user_default )
-              spec
-          in
-          let rec go () =
-            match%bind send_zkapp_command mina zkapp_command with
-            | Ok _ ->
-                fee_payer_nonces.(!ndx) :=
-                  Account.Nonce.succ !(fee_payer_nonces.(!ndx)) ;
-                ndx := (!ndx + 1) mod num_fee_payers ;
-                [%log info]
-                  "Successfully submitted zkApp command that creates a zkApp \
-                   account"
-                  ~metadata:
-                    [ ("zkapp_command", Zkapp_command.to_yojson zkapp_command) ] ;
-                Deferred.unit
-            | Error err ->
-                [%log info] "Failed to setup a zkApp account, try again"
-                  ~metadata:
-                    [ ("zkapp_command", Zkapp_command.to_yojson zkapp_command)
-                    ; ("error", `String err)
-                    ] ;
-                go ()
-          in
-          go () )
+          if Time.(now () >= stop_time) then (
+            [%log info]
+              "Scheduled zkapp commands with handle %s has expired, stop \
+               deployment of zkapp accounts"
+              (Uuid.to_string uuid) ;
+            Uuid.Table.remove scheduler_tbl uuid ;
+            return () )
+          else if Ivar.is_full stop_signal then (
+            [%log info]
+              "Scheduled zkapp commands with handle %s received stop signal, \
+               stop deployment of zkapp accounts"
+              (Uuid.to_string uuid) ;
+            Uuid.Table.remove scheduler_tbl uuid ;
+            return () )
+          else
+            let fee_payer_keypair = fee_payer_array.(!ndx) in
+            let memo = sprintf "%s-%s" memo_prefix (Int.to_string !ndx) in
+            let spec =
+              { Transaction_snark.For_tests.Deploy_snapp_spec.sender =
+                  (fee_payer_keypair, !(fee_payer_nonces.(!ndx)))
+              ; fee = Currency.Fee.of_mina_string_exn deployment_fee
+              ; fee_payer = None
+              ; amount = Currency.Amount.of_mina_string_exn init_balance
+              ; zkapp_account_keypairs = [ kp ]
+              ; memo = Signed_command_memo.create_from_string_exn memo
+              ; new_zkapp_account = true
+              ; snapp_update = Account_update.Update.dummy
+              ; preconditions = None
+              ; authorization_kind = Account_update.Authorization_kind.Signature
+              }
+            in
+            let zkapp_command =
+              Transaction_snark.For_tests.deploy_snapp ~constraint_constants
+                ~permissions:
+                  ( if max_cost then
+                    { Permissions.user_default with
+                      set_verification_key = Permissions.Auth_required.Proof
+                    ; edit_state = Permissions.Auth_required.Proof
+                    ; edit_action_state = Proof
+                    }
+                  else Permissions.user_default )
+                spec
+            in
+            let%bind () = after wait_span in
+            let rec go () =
+              match%bind send_zkapp_command mina zkapp_command with
+              | Ok _ ->
+                  fee_payer_nonces.(!ndx) :=
+                    Account.Nonce.succ !(fee_payer_nonces.(!ndx)) ;
+                  ndx := (!ndx + 1) mod num_fee_payers ;
+                  [%log info]
+                    "Successfully submitted zkApp command that creates a zkApp \
+                     account"
+                    ~metadata:
+                      [ ("zkapp_command", Zkapp_command.to_yojson zkapp_command)
+                      ] ;
+                  Deferred.unit
+              | Error err ->
+                  [%log info] "Failed to setup a zkApp account, try again"
+                    ~metadata:
+                      [ ("zkapp_command", Zkapp_command.to_yojson zkapp_command)
+                      ; ("error", `String err)
+                      ] ;
+                  let%bind () = after wait_span in
+                  go ()
+            in
+            go () )
 
     let is_zkapp_deployed kp ledger =
       match
@@ -4656,7 +4675,7 @@ module Mutations = struct
         ~deployment_fee ~max_cost ~init_balance
         ~(fee_payer_array : Signature_lib.Keypair.t Array.t)
         ~constraint_constants ~logger ~uuid ~stop_signal ~stop_time ~memo_prefix
-        (keypairs : Signature_lib.Keypair.t list) =
+        ~wait_span (keypairs : Signature_lib.Keypair.t list) =
       if Time.( >= ) (Time.now ()) stop_time then (
         [%log info] "Scheduled zkApp commands with handle %s has expired"
           (Uuid.to_string uuid) ;
@@ -4676,7 +4695,7 @@ module Mutations = struct
             [%log info] "Start deploying zkApp accounts" ;
             deploy_zkapps ~mina ~ledger ~deployment_fee ~max_cost ~init_balance
               ~fee_payer_array ~constraint_constants ~logger ~memo_prefix
-              keypairs )
+              ~wait_span ~stop_signal ~stop_time ~uuid keypairs )
           else return ()
         in
         [%log debug] "The accounts were not in the best tip $ledger, try again"
@@ -4696,7 +4715,7 @@ module Mutations = struct
         in
         wait_until_zkapps_deployed ~deployed:true ~mina ~ledger ~deployment_fee
           ~max_cost ~init_balance ~fee_payer_array ~constraint_constants ~logger
-          ~uuid ~stop_signal ~stop_time ~memo_prefix keypairs
+          ~uuid ~stop_signal ~stop_time ~memo_prefix ~wait_span keypairs
 
     let schedule_zkapp_commands =
       io_field "scheduleZkappCommands"
@@ -4962,8 +4981,8 @@ module Mutations = struct
                                ~fee_payer_array ~constraint_constants
                                zkapp_account_keypairs ~logger ~uuid
                                ~stop_signal:ivar ~stop_time:tm_end
-                               ~memo_prefix:zkapp_command_details.memo_prefix )
-                            (fun result ->
+                               ~memo_prefix:zkapp_command_details.memo_prefix
+                               ~wait_span ) (fun result ->
                               match result with
                               | None ->
                                   ()


### PR DESCRIPTION
Explain your changes:
Make the deployment of zkapp accounts in zkapp scheduler respect the `transactions_per_second` of the graphql config

Explain how you tested your changes:
*

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #13145
