### PR TITLE
use global-slot-since-genesis for vrf evaluation

### DIFF
--- a/src/app/test_executive/block_production_priority.ml
+++ b/src/app/test_executive/block_production_priority.ml
@@ -54,6 +54,16 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
           }
     ; txpool_max_size = 10_000_000
     ; snark_worker_fee = "0.0001"
+    ; proof_config =
+        { proof_config_default with
+          fork =
+            Some
+              { previous_state_hash =
+                  "3NK7737N7wtHWHqCLsXbtHb5c3UWpPvGyhBBj9QJcAtqGtaXC1AA"
+              ; previous_length = 50234
+              ; previous_global_slot = 66978
+              }
+        }
     }
 
   let fee = Currency.Fee.of_nanomina_int_exn 10_000_000

--- a/src/lib/cli_lib/commands.ml
+++ b/src/lib/cli_lib/commands.ml
@@ -158,8 +158,9 @@ module Vrf = struct
          that a 3rd account_update can use to verify a vrf evaluation."
       (let open Command.Let_syntax in
       let%map_open privkey_path = Flag.privkey_read_path
-      and global_slot =
-        flag "--global-slot" ~doc:"NUM Global slot to evaluate the VRF for"
+      and global_slot_since_genesis =
+        flag "--global-slot"
+          ~doc:"NUM Global slot since genesis to evaluate the VRF for"
           (required int)
       and epoch_seed =
         flag "--epoch-seed" ~doc:"SEED Epoch seed to evaluate the VRF with"
@@ -204,7 +205,8 @@ module Vrf = struct
             let open Consensus_vrf.Layout in
             let evaluation =
               Evaluation.of_message_and_sk ~constraint_constants
-                { global_slot = Mina_numbers.Global_slot.of_int global_slot
+                { global_slot_since_genesis =
+                    Mina_numbers.Global_slot.of_int global_slot_since_genesis
                 ; epoch_seed =
                     Mina_base.Epoch_seed.of_base58_check_exn epoch_seed
                 ; delegator_index

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -373,7 +373,7 @@ module type S = sig
     module Vrf : sig
       val check :
            context:(module CONTEXT)
-        -> global_slot:Mina_numbers.Global_slot.t
+        -> global_slot_since_genesis:Mina_numbers.Global_slot.t
         -> seed:Mina_base.Epoch_seed.t
         -> producer_private_key:Signature_lib.Private_key.t
         -> producer_public_key:Signature_lib.Public_key.Compressed.t

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -2666,8 +2666,8 @@ module Types = struct
 
       let arg_typ =
         obj "VrfMessageInput" ~doc:"The inputs to a vrf evaluation"
-          ~coerce:(fun global_slot epoch_seed delegator_index ->
-            { Consensus_vrf.Layout.Message.global_slot
+          ~coerce:(fun global_slot_since_genesis epoch_seed delegator_index ->
+            { Consensus_vrf.Layout.Message.global_slot_since_genesis
             ; epoch_seed = Mina_base.Epoch_seed.of_base58_check_exn epoch_seed
             ; delegator_index
             } )
@@ -2680,7 +2680,7 @@ module Types = struct
                 ~typ:(non_null int)
             ]
           ~split:(fun f (t : input) ->
-            f t.global_slot
+            f t.global_slot_since_genesis
               (Mina_base.Epoch_seed.to_base58_check t.epoch_seed)
               t.delegator_index )
     end
@@ -3223,7 +3223,8 @@ module Types = struct
     obj "VrfMessage" ~doc:"The inputs to a vrf evaluation" ~fields:(fun _ ->
         [ field "globalSlot" ~typ:(non_null global_slot)
             ~args:Arg.[]
-            ~resolve:(fun _ { global_slot; _ } -> global_slot)
+            ~resolve:(fun _ { global_slot_since_genesis; _ } ->
+              global_slot_since_genesis )
         ; field "epochSeed" ~typ:(non_null epoch_seed)
             ~args:Arg.[]
             ~resolve:(fun _ { epoch_seed; _ } -> epoch_seed)

--- a/src/lib/vrf_evaluator/vrf_evaluator.ml
+++ b/src/lib/vrf_evaluator/vrf_evaluator.ml
@@ -203,7 +203,7 @@ module Worker_state = struct
                 match%bind
                   Consensus.Data.Vrf.check
                     ~context:(module Context)
-                    ~global_slot ~seed:epoch_data.epoch_seed
+                    ~global_slot_since_genesis ~seed:epoch_data.epoch_seed
                     ~get_delegators:
                       (Public_key.Compressed.Table.find delegatee_table)
                     ~producer_private_key:keypair.private_key


### PR DESCRIPTION
Explain your changes:
* Use global slot since genesis for VRF evaluation. After a hard fork, this value will be offset by the global slot at the fork point

Explain how you tested your changes:
* Updated block production test to include a random fork point

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
