### PR TITLE
Implement `--file-log-rotations` flag

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -219,6 +219,7 @@ let setup_daemon logger =
   and log_json = Flag.Log.json
   and log_level = Flag.Log.level
   and file_log_level = Flag.Log.file_log_level
+  and file_log_rotations = Flag.Log.file_log_rotations
   and snark_work_fee =
     flag "--snark-worker-fee" ~aliases:[ "snark-worker-fee" ]
       ~doc:
@@ -508,13 +509,12 @@ let setup_daemon logger =
         Stdout_log.setup log_json log_level ;
         (* 512MB logrotate max size = 1GB max filesystem usage *)
         let logrotate_max_size = 1024 * 1024 * 10 in
-        let logrotate_num_rotate = 50 in
         Logger.Consumer_registry.register ~id:Logger.Logger_id.mina
           ~processor:(Logger.Processor.raw ~log_level:file_log_level ())
           ~transport:
             (Logger_file_system.dumb_logrotate ~directory:conf_dir
                ~log_filename:"mina.log" ~max_size:logrotate_max_size
-               ~num_rotate:logrotate_num_rotate ) ;
+               ~num_rotate:file_log_rotations ) ;
         let best_tip_diff_log_size = 1024 * 1024 * 5 in
         Logger.Consumer_registry.register ~id:Logger.Logger_id.best_tip_diff
           ~processor:(Logger.Processor.raw ())
@@ -534,7 +534,7 @@ let setup_daemon logger =
           ~transport:
             (Logger_file_system.dumb_logrotate ~directory:conf_dir
                ~log_filename:"mina-oversized-logs.log"
-               ~max_size:logrotate_max_size ~num_rotate:logrotate_num_rotate ) ;
+               ~max_size:logrotate_max_size ~num_rotate:file_log_rotations ) ;
         (* Consumer for `[%log internal]` logging used for internal tracing *)
         Itn_logger.set_message_postprocessor
           Internal_tracing.For_itn_logger.post_process_message ;

--- a/src/lib/cli_lib/default.ml
+++ b/src/lib/cli_lib/default.ml
@@ -21,3 +21,5 @@ let receiver_key_warning =
 (* let pubsub_v1 = Gossip_net.Libp2p.RW *)
 
 let pubsub_v0 = Gossip_net.Libp2p.RW
+
+let file_log_rotations = 50

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -324,6 +324,16 @@ module Log = struct
     in
     flag "--file-log-level" ~aliases:[ "file-log-level" ] ~doc
       (optional_with_default Logger.Level.Trace log_level)
+
+  let file_log_rotations =
+    let open Command.Param in
+    flag "--file-log-rotations"
+      ~doc:
+        (Printf.sprintf
+           "Number of file log rotations before overwriting old logs (default: \
+            %d)"
+           Default.file_log_rotations )
+      (optional_with_default Default.file_log_rotations int)
 end
 
 type signed_command_common =

--- a/src/lib/cli_lib/flag.mli
+++ b/src/lib/cli_lib/flag.mli
@@ -73,6 +73,8 @@ module Log : sig
   val level : Logger.Level.t Command.Param.t
 
   val file_log_level : Logger.Level.t Command.Param.t
+
+  val file_log_rotations : int Command.Param.t
 end
 
 type signed_command_common =


### PR DESCRIPTION
Explain your changes:

Make file log rotations configurable via CLI.

Explain how you tested your changes:

* Ran `--help` command

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
