### PR TITLE
Remove warnings from Plonk_dlog_proof in Kimchi_backend

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/dune
+++ b/src/lib/crypto/kimchi_backend/common/dune
@@ -36,7 +36,6 @@
   kimchi_types
   pasta_bindings
   sponge
-  allocation_functor
   snarky.intf
   promise
   logger

--- a/src/lib/crypto/kimchi_backend/pasta/dune
+++ b/src/lib/crypto/kimchi_backend/pasta/dune
@@ -6,12 +6,13 @@
  (instrumentation
   (backend bisect_ppx))
  (preprocess
-  (pps ppx_version ppx_jane ppx_deriving_yojson ppx_deriving.std))
+  (pps ppx_version ppx_mina ppx_jane ppx_deriving_yojson ppx_deriving.std))
  (libraries
-  ;; opam libraries
+   ;; opam libraries
   ppx_inline_test.config
   sexplib0
   core_kernel
+  allocation_functor
   bin_prot.shape
   base.caml
   ;; local libraries

--- a/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
@@ -232,7 +232,7 @@ module Proving_key = struct
   type t = Keypair.t
 
   include
-    Core_kernel.Binable.Of_binable
+    Core_kernel.Binable.Of_binable_with_uuid
       (Core_kernel.Unit)
       (struct
         type nonrec t = t
@@ -240,6 +240,8 @@ module Proving_key = struct
         let to_binable _ = ()
 
         let of_binable () = failwith "TODO"
+
+        let caller_identity = Bin_prot.Shape.Uuid.of_string "TODO"
       end)
 
   let is_initialized _ = `Yes

--- a/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
@@ -65,78 +65,109 @@ module Keypair = Dlog_plonk_based_keypair.Make (struct
   module Constraint_system = R1CS_constraint_system
 end)
 
-module Proof = Plonk_dlog_proof.Make (struct
-  let id = "pasta_pallas"
+module Proof = struct
+  module Challenge_polynomial = struct
+    [%%versioned
+    module Stable = struct
+      module V1 = struct
+        type t =
+          ( Curve.Affine.Stable.V1.t
+          , Field.Stable.V1.t )
+          Plonk_dlog_proof.Challenge_polynomial.Stable.V1.t
+        [@@deriving sexp, compare, yojson]
 
-  module Scalar_field = Field
-  module Base_field = Fp
+        let to_latest = Fn.id
+      end
+    end]
 
-  module Backend = struct
-    type t =
-      ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
-      , Pasta_bindings.Fq.t )
-      Kimchi_types.prover_proof
+    type ('g, 'fq) t_ = ('g, 'fq) Plonk_dlog_proof.Challenge_polynomial.t =
+      { challenges : 'fq array; commitment : 'g }
 
-    include Kimchi_bindings.Protocol.Proof.Fq
+    type ty = (Curve.Affine.t, Field.t) Plonk_dlog_proof.Challenge_polynomial.t
 
-    let batch_verify vks ts =
-      Promise.run_in_thread (fun () -> batch_verify vks ts)
+    let challenges { Plonk_dlog_proof.Challenge_polynomial.challenges; _ } =
+      challenges
 
-    let create_aux ~f:create (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
-      (* external values contains [1, primary..., auxiliary ] *)
-      let external_values i =
-        let open Field.Vector in
-        if i < length primary then get primary i
-        else get auxiliary (i - length primary)
-      in
-
-      (* compute witness *)
-      let computed_witness =
-        R1CS_constraint_system.compute_witness pk.cs external_values
-      in
-      let num_rows = Array.length computed_witness.(0) in
-
-      (* convert to Rust vector *)
-      let witness_cols =
-        Array.init Kimchi_backend_common.Constants.columns ~f:(fun col ->
-            let witness = Field.Vector.create () in
-            for row = 0 to num_rows - 1 do
-              Field.Vector.emplace_back witness computed_witness.(col).(row)
-            done ;
-            witness )
-      in
-      create pk.index witness_cols prev_chals prev_comms
-
-    let create_async (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms
-        ~f:(fun pk auxiliary_input prev_challenges prev_sgs ->
-          Promise.run_in_thread (fun () ->
-              create pk auxiliary_input prev_challenges prev_sgs ) )
-
-    let create_and_verify_async (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
-      failwith "not implemented"
-    (* TODO: Remove this function when vesta_based_plonk.create_and_verify_async is removed *)
-
-    let create (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms ~f:create
+    let commitment { Plonk_dlog_proof.Challenge_polynomial.commitment; _ } =
+      commitment
   end
 
-  module Verifier_index = Kimchi_bindings.Protocol.VerifierIndex.Fq
-  module Index = Keypair
+  include Plonk_dlog_proof.Make (struct
+    let id = "pasta_pallas"
 
-  module Evaluations_backend = struct
-    type t = Scalar_field.t Kimchi_types.proof_evaluations
-  end
+    module Scalar_field = Field
+    module Base_field = Fp
+    module Challenge_polynomial = Challenge_polynomial
 
-  module Opening_proof_backend = struct
-    type t = (Curve.Affine.Backend.t, Scalar_field.t) Kimchi_types.opening_proof
-  end
+    module Backend = struct
+      type t =
+        ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
+        , Pasta_bindings.Fq.t )
+        Kimchi_types.prover_proof
 
-  module Poly_comm = Fq_poly_comm
-  module Curve = Curve
-end)
+      include Kimchi_bindings.Protocol.Proof.Fq
+
+      let batch_verify vks ts =
+        Promise.run_in_thread (fun () -> batch_verify vks ts)
+
+      let create_aux ~f:create (pk : Keypair.t) primary auxiliary prev_chals
+          prev_comms =
+        (* external values contains [1, primary..., auxiliary ] *)
+        let external_values i =
+          let open Field.Vector in
+          if i < length primary then get primary i
+          else get auxiliary (i - length primary)
+        in
+
+        (* compute witness *)
+        let computed_witness =
+          R1CS_constraint_system.compute_witness pk.cs external_values
+        in
+        let num_rows = Array.length computed_witness.(0) in
+
+        (* convert to Rust vector *)
+        let witness_cols =
+          Array.init Kimchi_backend_common.Constants.columns ~f:(fun col ->
+              let witness = Field.Vector.create () in
+              for row = 0 to num_rows - 1 do
+                Field.Vector.emplace_back witness computed_witness.(col).(row)
+              done ;
+              witness )
+        in
+        create pk.index witness_cols prev_chals prev_comms
+
+      let create_async (pk : Keypair.t) primary auxiliary prev_chals prev_comms
+          =
+        create_aux pk primary auxiliary prev_chals prev_comms
+          ~f:(fun pk auxiliary_input prev_challenges prev_sgs ->
+            Promise.run_in_thread (fun () ->
+                create pk auxiliary_input prev_challenges prev_sgs ) )
+
+      let create_and_verify_async (pk : Keypair.t) primary auxiliary prev_chals
+          prev_comms =
+        failwith "not implemented"
+      (* TODO: Remove this function when vesta_based_plonk.create_and_verify_async is removed *)
+
+      let create (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
+        create_aux pk primary auxiliary prev_chals prev_comms ~f:create
+    end
+
+    module Verifier_index = Kimchi_bindings.Protocol.VerifierIndex.Fq
+    module Index = Keypair
+
+    module Evaluations_backend = struct
+      type t = Scalar_field.t Kimchi_types.proof_evaluations
+    end
+
+    module Opening_proof_backend = struct
+      type t =
+        (Curve.Affine.Backend.t, Scalar_field.t) Kimchi_types.opening_proof
+    end
+
+    module Poly_comm = Fq_poly_comm
+    module Curve = Curve
+  end)
+end
 
 module Proving_key = struct
   type t = Keypair.t

--- a/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
@@ -91,12 +91,69 @@ module Proof = struct
       commitment
   end
 
-  include Plonk_dlog_proof.Make (struct
+  module T = struct
     let id = "pasta_vesta"
 
+    let hash_fold_array f s x = hash_fold_list f s (Array.to_list x)
+
+    [%%versioned
+    module Stable = struct
+      module V2 = struct
+        module T = struct
+          type t =
+            ( Curve.Affine.Stable.V1.t
+            , Field.Stable.V1.t
+            , Field.Stable.V1.t array )
+            Pickles_types.Plonk_types.Proof.Stable.V2.t
+          [@@deriving compare, sexp, yojson, hash, equal]
+
+          let id = "plong_dlog_proof_" ^ id
+
+          type 'a creator =
+               messages:
+                 Curve.Affine.t Pickles_types.Plonk_types.Messages.Stable.V2.t
+            -> openings:
+                 ( Curve.Affine.t
+                 , Field.t
+                 , Field.t array )
+                 Pickles_types.Plonk_types.Openings.Stable.V2.t
+            -> 'a
+
+          let map_creator c ~f ~messages ~openings = f (c ~messages ~openings)
+
+          let create ~messages ~openings =
+            let open Pickles_types.Plonk_types.Proof in
+            { messages; openings }
+        end
+
+        include T
+
+        include (
+          Allocation_functor.Make.Full
+            (T) :
+              Allocation_functor.Intf.Output.Full_intf
+                with type t := t
+                 and type 'a creator := 'a creator )
+
+        let to_latest = Fn.id
+      end
+    end]
+
+    include (
+      Stable.Latest :
+        sig
+          type t [@@deriving compare, sexp, yojson, hash, equal, bin_io]
+        end
+        with type t := t )
+
+    [%%define_locally Stable.Latest.(create)]
+  end
+
+  include Plonk_dlog_proof.Make (struct
     module Scalar_field = Field
     module Base_field = Fq
     module Challenge_polynomial = Challenge_polynomial
+    include T
 
     module Backend = struct
       type t =
@@ -168,6 +225,8 @@ module Proof = struct
     module Poly_comm = Fp_poly_comm
     module Curve = Curve
   end)
+
+  include T
 end
 
 module Proving_key = struct

--- a/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
@@ -233,7 +233,7 @@ module Proving_key = struct
   type t = Keypair.t
 
   include
-    Core_kernel.Binable.Of_binable
+    Core_kernel.Binable.Of_binable_with_uuid
       (Core_kernel.Unit)
       (struct
         type nonrec t = t
@@ -241,6 +241,8 @@ module Proving_key = struct
         let to_binable _ = ()
 
         let of_binable () = failwith "TODO"
+
+        let caller_identity = Bin_prot.Shape.Uuid.of_string "TODO"
       end)
 
   let is_initialized _ = `Yes


### PR DESCRIPTION
This PR fixes the following
- 2 preprocessor warnings from the creation of versioned modules in functors
- a `Binable` deprecation warning in `(vesta|pallas)_based_plonk`