### PR TITLE
Modest simplification by introducting `Vector.nth_exn`

### DIFF
--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -799,9 +799,7 @@ struct
         Impls.Step.input ~proofs_verified:Max_proofs_verified.n
           ~wrap_rounds:Tock.Rounds.n ~feature_flags
       in
-      let { Domains.h } =
-        List.nth_exn (Vector.to_list step_domains) branch_data.index
-      in
+      let { Domains.h } = Vector.nth_exn step_domains branch_data.index in
       ksprintf Common.time "step-prover %d (%d)" branch_data.index
         (Domain.size h)
         (fun () ->

--- a/src/lib/pickles_types/vector.ml
+++ b/src/lib/pickles_types/vector.ml
@@ -31,6 +31,31 @@ let iteri (type a n) (t : (a, n) t) ~(f : int -> a -> unit) : unit =
   in
   go 0 t
 
+let rec length : type a n. (a, n) t -> n Nat.t = function
+  | [] ->
+      Z
+  | _ :: xs ->
+      S (length xs)
+
+let nth v i =
+  let rec loop : type a n. int -> (a, n) t -> a option =
+   fun j -> function
+    | [] ->
+        None
+    | x :: xs ->
+        if Int.equal i j then Some x else loop (j + 1) xs
+  in
+  loop 0 v
+
+let nth_exn v i =
+  match nth v i with
+  | None ->
+      invalid_argf "Vector.nth_exn %d called on a vector of length %d" i
+        (length v |> Nat.to_int)
+        ()
+  | Some e ->
+      e
+
 let rec iter2 : type a b n. (a, n) t -> (b, n) t -> f:(a -> b -> unit) -> unit =
  fun t1 t2 ~f ->
   match (t1, t2) with
@@ -83,12 +108,6 @@ let rec to_list : type a n. (a, n) t -> a list =
 let sexp_of_t a _ v = List.sexp_of_t a (to_list v)
 
 let to_array t = Array.of_list (to_list t)
-
-let rec length : type a n. (a, n) t -> n Nat.t = function
-  | [] ->
-      Z
-  | _ :: xs ->
-      S (length xs)
 
 let rec init : type a n. int -> n Nat.t -> f:(int -> a) -> (a, n) t =
  fun i n ~f -> match n with Z -> [] | S n -> f i :: init (i + 1) n ~f

--- a/src/lib/pickles_types/vector.mli
+++ b/src/lib/pickles_types/vector.mli
@@ -178,3 +178,16 @@ val extend_front :
 val extend_front_exn : 'a 'n 'm. ('a, 'n) vec -> 'm Nat.t -> 'a -> ('a, 'm) vec
 
 val transpose : 'a 'n 'm. (('a, 'n) vec, 'm) vec -> (('a, 'm) vec, 'n) vec
+
+(** [nth v i] returns the [i]-th element [e] of vector [v]. The first element is
+    at position 0.
+
+    @return [None] if [i] is not a valid index for vector [v]
+*)
+val nth : ('a, 'n) vec -> int -> 'a option
+
+(** [nth_exn v i] returns the [i]-th element of vector [v]. The first element is
+    at position 0.
+
+    @raise Invalid_argument if [i] is not a valid index for vector [v] *)
+val nth_exn : ('a, 'n) vec -> int -> 'a


### PR DESCRIPTION
Avoid calling `Vector.to_list` followed by `List.nth_exn` and directly use `Vector.nth_exn`