### PR TITLE
Add local precomputed block logging to individual files

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -353,15 +353,21 @@ let setup_daemon logger =
          dummy proofs (none)"
   and plugins = plugin_flag
   and precomputed_blocks_path =
-    flag "--precomputed-blocks-file"
-      ~aliases:[ "precomputed-blocks-file" ]
+    flag "--precomputed-blocks-path"
+      ~aliases:[ "precomputed-blocks-path" ]
       (optional string)
-      ~doc:"PATH Path to write precomputed blocks to, for replay or archiving"
+      ~doc:
+        "PATH Path to write precomputed blocks to, for replay or archiving. If \
+         PATH is a directory, precomputed blocks will be logged to individual \
+         files within this directory. Otherwise, they will be appended to the \
+         same file."
   and log_precomputed_blocks =
     flag "--log-precomputed-blocks"
       ~aliases:[ "log-precomputed-blocks" ]
       (optional_with_default false bool)
-      ~doc:"true|false Include precomputed blocks in the log (default: false)"
+      ~doc:
+        "true|false Include precomputed blocks in the log (default: false). \
+         See also --precomputed-block-path for additional functionality."
   and block_reward_threshold =
     flag "--minimum-block-reward" ~aliases:[ "minimum-block-reward" ]
       ~doc:

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -105,7 +105,7 @@ type t =
   ; subscriptions : Coda_subscriptions.t
   ; sync_status : Sync_status.t Mina_incremental.Status.Observer.t
   ; precomputed_block_writer :
-      ([ `Path of string ] option * [ `Log ] option) ref
+      ([ `Path of string | `Path_dir of string ] option * [ `Log ] option) ref
   ; block_production_status :
       [ `Producing | `Producing_in_ms of float | `Free ] ref
   }
@@ -1945,10 +1945,16 @@ let create ?wallets (config : Config.t) =
               Archive_client.run ~logger:config.logger
                 ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
                 archive_process_port ) ;
+          (* To log precomputed blocks to individual files, set both
+             --precomputed-blocks-path DIR and --log-precomputed-blocks true *)
           let precomputed_block_writer =
             ref
               ( Option.map config.precomputed_blocks_path ~f:(fun path ->
-                    `Path path )
+                    match Core.Unix.(stat path).st_kind with
+                    | S_DIR ->
+                        `Path_dir path
+                    | _ ->
+                        `Path path )
               , if config.log_precomputed_blocks then Some `Log else None )
           in
           let subscriptions =
@@ -1958,6 +1964,7 @@ let create ?wallets (config : Config.t) =
               ~is_storing_all:config.is_archive_rocksdb
               ~upload_blocks_to_gcloud:config.upload_blocks_to_gcloud
               ~time_controller:config.time_controller ~precomputed_block_writer
+              ~log_precomputed_blocks:config.log_precomputed_blocks
           in
           let open Mina_incremental.Status in
           let transition_frontier_incr =


### PR DESCRIPTION
Explain your changes:

* This PR adds a local precomputed block logging functionality to the daemon. To use it, simply set the flags `--precomputed-blocks-path PATH` and `--log-precomputed-blocks true` when you run the daemon. Block names are consistent with the gcloud naming convention `{network}-{height}-{state_hash}.json`.

* The *new* functionality is only triggered when `PATH` is a Unix directory. Otherwise, precomputed blocks will be appended to a single file as before.

* The `--precomputed-blocks-file` flag is changed to `--precomputed-blocks-path`.

Explain how you tested your changes:

* I built the mainnet daemon, connected to the network, and confirmed that precomputed blocks were logged to the provided directory as expected.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
