### PR TITLE
[BUGFIX] Require that user commands be signed by the source.

### DIFF
--- a/src/lib/mina_base/transaction_status.ml
+++ b/src/lib/mina_base/transaction_status.ml
@@ -38,6 +38,7 @@ module Failure = struct
         | Zkapp_command_replay_check_failed
         | Fee_payer_nonce_must_increase
         | Fee_payer_must_be_signed
+        | Source_must_be_signed
         | Account_balance_precondition_unsatisfied
         | Account_nonce_precondition_unsatisfied
         | Account_receipt_chain_hash_precondition_unsatisfied
@@ -121,6 +122,7 @@ module Failure = struct
       ~update_not_permitted_voting_for:add
       ~zkapp_command_replay_check_failed:add ~fee_payer_nonce_must_increase:add
       ~fee_payer_must_be_signed:add
+      ~source_must_be_signed:add
       ~account_balance_precondition_unsatisfied:add
       ~account_nonce_precondition_unsatisfied:add
       ~account_receipt_chain_hash_precondition_unsatisfied:add
@@ -199,7 +201,9 @@ module Failure = struct
     | Fee_payer_nonce_must_increase ->
         "Fee_payer_nonce_must_increase"
     | Fee_payer_must_be_signed ->
-        "Fee_payer_must_be_signed"
+       "Fee_payer_must_be_signed"
+    | Source_must_be_signed ->
+       "Source_must_be_signed"
     | Account_balance_precondition_unsatisfied ->
         "Account_balance_precondition_unsatisfied"
     | Account_nonce_precondition_unsatisfied ->
@@ -432,7 +436,9 @@ module Failure = struct
     | Fee_payer_nonce_must_increase ->
         "Fee payer account update must increment its nonce"
     | Fee_payer_must_be_signed ->
-        "Fee payer account update must have a valid signature"
+       "Fee payer account update must have a valid signature"
+    | Source_must_be_signed ->
+        "A user command must be signed by the source"
     | Account_balance_precondition_unsatisfied ->
         "The account update's account balance precondition was unsatisfied"
     | Account_nonce_precondition_unsatisfied ->

--- a/src/lib/mina_wire_types/mina_base/mina_base_transaction_status.ml
+++ b/src/lib/mina_wire_types/mina_base/mina_base_transaction_status.ml
@@ -32,6 +32,7 @@ module Failure = struct
       | Zkapp_command_replay_check_failed
       | Fee_payer_nonce_must_increase
       | Fee_payer_must_be_signed
+      | Source_must_be_signed
       | Account_balance_precondition_unsatisfied
       | Account_nonce_precondition_unsatisfied
       | Account_receipt_chain_hash_precondition_unsatisfied

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -904,6 +904,15 @@ module Make (L : Ledger_intf.S) :
       (* Compute the necessary changes to apply the command, failing if any of
          the conditions are not met.
       *)
+      let%bind () =
+        if
+          Public_key.Compressed.equal
+            (Account_id.public_key source)
+            signer_pk
+        then return ()
+        else
+          Error Transaction_status.Failure.Source_must_be_signed
+      in
       match payload.body with
       | Stake_delegation _ ->
           let receiver_location, _receiver_account =


### PR DESCRIPTION
At the moment on `berkeley` and on `develop` it is possible to forge a payment which is not signed by the source, but by some arbitrary account, as long as that account pays the fee. This opens a possibility to steal funds from arbitrary accounts. In the current state the daemon will not create such payments, but it's trivial to patch it to do otherwise. This only requires changes to GraphQL API, so the rest of the network will happily accept transactions generated by such a rouge node.

To prevent this, it is necessary to add a check in the transaction logic to make sure that the signer of the transaction is also the source. This is what this PR does.

The patch to allow forging malicious transactions can be found [here](https://github.com/MinaProtocol/mina/commit/5b3551a808059a00f1dc99503c83aae4a077a2bc).

Explain how you tested your changes:
* Set up a sandboxed patched as described above; observed how malicious payments are applied;
* Added the check in the transaction logic;
* Observed that the exploit does not work anymore (transaction is being accepted, the fee is paid, but money is not transferred).

Unit tests to guard against regression in the regard will be added in #13218.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
