### PR TITLE
Precomputed block writer with updateable settings

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -11406,16 +11406,6 @@
         },
         {
           "kind": "SCALAR",
-          "name": "Boolean",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
           "name": "ChainHash",
           "description": "Base58Check-encoded chain hash",
           "fields": null,
@@ -12031,6 +12021,118 @@
                     "ofType": null
                   }
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PrecomputedBlockDumping",
+          "description": null,
+          "fields": [
+            {
+              "name": "dir",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "network",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PrecomputedBlockWriter",
+          "description": null,
+          "fields": [
+            {
+              "name": "appending",
+              "description": null,
+              "args": [],
+              "type": { "kind": "SCALAR", "name": "String", "ofType": null },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dumping",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PrecomputedBlockDumping",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "logging",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uploading",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PrecomputedBlockDumping",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -13340,6 +13442,18 @@
                   "name": "Metrics",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "precomputedBlockWriter",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PrecomputedBlockWriter",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -12077,6 +12077,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "number",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -72,6 +72,7 @@
    snarky.backendless
    o1trace
    ppx_version.runtime
+   daemon_rpcs
  )
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -386,16 +386,14 @@ let setup_daemon logger =
       (optional string)
       ~doc:
         "PATH Path to write precomputed blocks to, for replay or archiving. If \
-         PATH is a directory, precomputed blocks will be logged to individual \
-         files within this directory. Otherwise, they will be appended to the \
-         same file."
+         path is a directory, precomputed blocks will be logged to individual \
+         files within this directory. If path is a file, they will be appended \
+         to this file. Otherwise, precomputed blocks will not be dumped."
   and log_precomputed_blocks =
     flag "--log-precomputed-blocks"
       ~aliases:[ "log-precomputed-blocks" ]
       (optional_with_default false bool)
-      ~doc:
-        "true|false Include precomputed blocks in the log (default: false). \
-         See also --precomputed-block-path for additional functionality."
+      ~doc:"true|false Include precomputed blocks in the log (default: false)"
   and block_reward_threshold =
     flag "--minimum-block-reward" ~aliases:[ "minimum-block-reward" ]
       ~doc:

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1310,6 +1310,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                     "Precomputed blocks will be dumped to individual files in \
                      $path" ;
                   { Precomputed_block_writer.Dumping.dir
+                  ; number = 0
                   ; network =
                       Precomputed_blocks.Initial.network ~logger
                         ~upload_blocks_to_gcloud ~precomputed_blocks_dir
@@ -1337,6 +1338,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                     Some
                       { Precomputed_block_writer.Uploading.bucket
                       ; keyfile
+                      ; number = 0
                       ; network =
                           network ~logger ~upload_blocks_to_gcloud
                             ~precomputed_blocks_dir ~precomputed_blocks_file

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -389,14 +389,11 @@ let setup_daemon logger =
     flag "--precomputed-blocks-file"
       ~aliases:[ "precomputed-blocks-file" ]
       (optional string)
-      ~doc:
-        "PATH File to append precomputed blocks to, for replay or archiving."
+      ~doc:"PATH File to append precomputed blocks to, for replay or archiving."
   and precomputed_blocks_dir =
     flag "--precomputed-blocks-dir"
       ~aliases:[ "precomputed-blocks-dir" ]
-      (optional string)
-      ~doc:
-        "PATH Directory to dump precomputed blocks to."
+      (optional string) ~doc:"PATH Directory to dump precomputed blocks to."
   and block_reward_threshold =
     flag "--minimum-block-reward" ~aliases:[ "minimum-block-reward" ]
       ~doc:
@@ -1325,9 +1322,9 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                  ~work_reassignment_wait ~archive_process_location
                  ~log_block_creation ~precomputed_values ~start_time
                  ?precomputed_blocks_file ?precomputed_blocks_dir
-                 ~log_precomputed_blocks
-                 ~upload_blocks_to_gcloud ~block_reward_threshold ~uptime_url
-                 ~uptime_submitter_keypair ~stop_time ~node_status_url
+                 ~log_precomputed_blocks ~upload_blocks_to_gcloud
+                 ~block_reward_threshold ~uptime_url ~uptime_submitter_keypair
+                 ~stop_time ~node_status_url
                  ~graphql_control_port:itn_graphql_port ()
                  ~precomputed_block_writer:Mina_lib.empty )
           in
@@ -1442,8 +1439,8 @@ let replay_blocks logger =
                    In_channel.close blocks_file ;
                    None )
          in
-         let%bind coda = setup_daemon () in
-         let%bind () = Mina_lib.start_with_precomputed_blocks coda blocks in
+         let%bind mina = setup_daemon () in
+         let%bind () = Mina_lib.start_with_precomputed_blocks mina blocks in
          [%log info]
            "Daemon is ready, replayed precomputed blocks. Clients can now \
             connect" ;

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -381,15 +381,21 @@ let setup_daemon logger =
          dummy proofs (none)"
   and plugins = plugin_flag
   and precomputed_blocks_path =
-    flag "--precomputed-blocks-file"
-      ~aliases:[ "precomputed-blocks-file" ]
+    flag "--precomputed-blocks-path"
+      ~aliases:[ "precomputed-blocks-path" ]
       (optional string)
-      ~doc:"PATH Path to write precomputed blocks to, for replay or archiving"
+      ~doc:
+        "PATH Path to write precomputed blocks to, for replay or archiving. If \
+         PATH is a directory, precomputed blocks will be logged to individual \
+         files within this directory. Otherwise, they will be appended to the \
+         same file."
   and log_precomputed_blocks =
     flag "--log-precomputed-blocks"
       ~aliases:[ "log-precomputed-blocks" ]
       (optional_with_default false bool)
-      ~doc:"true|false Include precomputed blocks in the log (default: false)"
+      ~doc:
+        "true|false Include precomputed blocks in the log (default: false). \
+         See also --precomputed-block-path for additional functionality."
   and block_reward_threshold =
     flag "--minimum-block-reward" ~aliases:[ "minimum-block-reward" ]
       ~doc:

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -380,20 +380,23 @@ let setup_daemon logger =
          with full proving (full), snark-testing with dummy proofs (check), or \
          dummy proofs (none)"
   and plugins = plugin_flag
-  and precomputed_blocks_path =
-    flag "--precomputed-blocks-path"
-      ~aliases:[ "precomputed-blocks-path" ]
-      (optional string)
-      ~doc:
-        "PATH Path to write precomputed blocks to, for replay or archiving. If \
-         path is a directory, precomputed blocks will be logged to individual \
-         files within this directory. If path is a file, they will be appended \
-         to this file. Otherwise, precomputed blocks will not be dumped."
   and log_precomputed_blocks =
     flag "--log-precomputed-blocks"
       ~aliases:[ "log-precomputed-blocks" ]
       (optional_with_default false bool)
       ~doc:"true|false Include precomputed blocks in the log (default: false)"
+  and precomputed_blocks_file =
+    flag "--precomputed-blocks-file"
+      ~aliases:[ "precomputed-blocks-file" ]
+      (optional string)
+      ~doc:
+        "PATH File to append precomputed blocks to, for replay or archiving."
+  and precomputed_blocks_dir =
+    flag "--precomputed-blocks-dir"
+      ~aliases:[ "precomputed-blocks-dir" ]
+      (optional string)
+      ~doc:
+        "PATH Directory to dump precomputed blocks to."
   and block_reward_threshold =
     flag "--minimum-block-reward" ~aliases:[ "minimum-block-reward" ]
       ~doc:
@@ -1321,10 +1324,12 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                  ~consensus_local_state ~is_archive_rocksdb
                  ~work_reassignment_wait ~archive_process_location
                  ~log_block_creation ~precomputed_values ~start_time
-                 ?precomputed_blocks_path ~log_precomputed_blocks
+                 ?precomputed_blocks_file ?precomputed_blocks_dir
+                 ~log_precomputed_blocks
                  ~upload_blocks_to_gcloud ~block_reward_threshold ~uptime_url
                  ~uptime_submitter_keypair ~stop_time ~node_status_url
-                 ~graphql_control_port:itn_graphql_port () )
+                 ~graphql_control_port:itn_graphql_port ()
+                 ~precomputed_block_writer:Mina_lib.empty )
           in
           { mina
           ; client_trustlist

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -260,8 +260,7 @@ let set_precomputed_dump_dir =
   let open Command.Param in
   let path_flag =
     flag "--path" ~aliases:[ "path" ]
-      ~doc:"PATH Set precomputed block dump directory"
-      (required string)
+      ~doc:"PATH Set precomputed block dump directory" (required string)
   in
   let network_flag =
     flag "--network" ~aliases:[ "network" ]
@@ -269,19 +268,22 @@ let set_precomputed_dump_dir =
       (optional string)
   in
   Command.async ~summary:"Set precomputed block dump directory"
-    (Cli_lib.Background_daemon.rpc_init
-      (Args.zip2 path_flag network_flag)
-      ~f:(fun port (path, network_opt) ->
-         let%map res = Daemon_rpcs.Client.dispatch Set_dump_dir.rpc (path, network_opt) port in
+    (Cli_lib.Background_daemon.rpc_init (Args.zip2 path_flag network_flag)
+       ~f:(fun port (path, network_opt) ->
+         let%map res =
+           Daemon_rpcs.Client.dispatch Set_dump_dir.rpc (path, network_opt) port
+         in
          match res with
          | Ok _ -> (
-            match network_opt with
-            | Some network ->
-                printf "Precomputed block dump dir set to %s with network %s\n" path network
-            | None ->
-                printf "Precomputed block dump dir set to %s\n" path )
+             match network_opt with
+             | Some network ->
+                 printf "Precomputed block dump dir set to %s with network %s\n"
+                   path network
+             | None ->
+                 printf "Precomputed block dump dir set to %s\n" path )
          | Error e ->
-              printf "Failed to set dump dir with path %s\n" (Error.to_string_hum e) ) )
+             printf "Failed to set dump dir with path %s\n"
+               (Error.to_string_hum e) ) )
 
 let set_precomputed_dump_file =
   let open Deferred.Let_syntax in
@@ -294,82 +296,44 @@ let set_precomputed_dump_file =
   in
   Command.async ~summary:"Set precomputed block dump file for replaying"
     (Cli_lib.Background_daemon.rpc_init path_flag ~f:(fun port path ->
-         let%map res = Daemon_rpcs.Client.dispatch Set_dump_file.rpc path port in
+         let%map res =
+           Daemon_rpcs.Client.dispatch Set_dump_file.rpc path port
+         in
          match res with
          | Ok _ ->
-              printf "Precomputed block will now be dumped to %s\n" path
+             printf "Precomputed block will now be dumped to %s\n" path
          | Error e ->
-              printf "Failed to set dump path %s\n" (Error.to_string_hum e) ) )
+             printf "Failed to set dump path %s\n" (Error.to_string_hum e) ) )
 
-let start_logging =
+let start_precomputed_logging =
   let open Deferred.Let_syntax in
   let open Daemon_rpcs in
   let open Command.Param in
-  Command.async ~summary:"Start logging precomputed block"
+  Command.async ~summary:"Set precomputed block logging"
     (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
          let%map res = Daemon_rpcs.Client.dispatch Start_logging.rpc () port in
          match res with
          | Ok _ ->
-              print_endline "Precomputed blocks will now be logged"
+             print_endline "Precomputed blocks will now be logged"
          | Error e ->
-              printf "Failed to set precomputed block logging %s\n" (Error.to_string_hum e) ) )
+             printf "Failed to set precomputed block logging %s\n"
+               (Error.to_string_hum e) ) )
 
-let set_precomputed_uploading =
+let deactivate_precomputed_file =
   let open Deferred.Let_syntax in
   let open Daemon_rpcs in
   let open Command.Param in
-  let bucket_flag =
-    flag "--bucket" ~aliases:[ "bucket" ]
-      ~doc:"BUCKET Gcloud bucket"
-      (required string)
-  in
-  let keyfile_flag =
-    flag "--keyfile" ~aliases:[ "keyfile" ]
-      ~doc:"KEYFILE Gcloud keyfile"
-      (required string)
-  in
-  let network_flag =
-    flag "--network" ~aliases:[ "network" ]
-      ~doc:"NETWORK Network name for precomputed block uploading"
-      (optional string)
-  in
-  Command.async ~summary:"Set precomputed block gcloud uploading"
-    (Cli_lib.Background_daemon.rpc_init
-      (Args.zip3 bucket_flag keyfile_flag network_flag)
-      ~f:(fun port (bucket, keyfile, network_opt) ->
-         let%map res = Daemon_rpcs.Client.dispatch Set_uploading.rpc (bucket, keyfile, network_opt) port in
-         match res with
-         | Ok _ ->
-              (match network_opt with
-               | Some network ->
-                  printf
-                    !"Precomputed blocks will now be uploaded to gcloud\n\
-                     - bucket:  %s\n
-                     - network: %s\n
-                     - keyfile: %s\n"
-                     bucket network keyfile
-              | None ->
-                  printf
-                    "Precomputed blocks will be uploaded to gcloud\n\
-                     - bucket:  %s\n\
-                     - keyfile: %s\n"
-                     bucket keyfile )
-         | Error e ->
-              printf "Failed to set dump path %s\n" (Error.to_string_hum e) ) )
-let stop_appending =
-  let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
-  let open Command.Param in
-  Command.async ~summary:"Stop appending precomputed blocks to a single file"
+  Command.async ~summary:"Stop appending precomputed blocks to replay file"
     (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
          let%map res = Daemon_rpcs.Client.dispatch Stop_appending.rpc () port in
          match res with
          | Ok _ ->
-              print_endline "Precomputed block appending deactivated"
+             print_endline "Precomputed block file writing deactivated"
          | Error e ->
-              printf "Failed to deactivate block appending %s\n" (Error.to_string_hum e) ) )
+             printf "Failed to deactivate block file writing %s\n"
+               (Error.to_string_hum e) ) )
 
-let stop_dumping =
+let deactivate_precomputed_dir =
   let open Deferred.Let_syntax in
   let open Daemon_rpcs in
   let open Command.Param in
@@ -378,11 +342,12 @@ let stop_dumping =
          let%map res = Daemon_rpcs.Client.dispatch Stop_dumping.rpc () port in
          match res with
          | Ok _ ->
-              print_endline "Precomputed block writing deactivated"
+             print_endline "Precomputed block dumping deactivated"
          | Error e ->
-              printf "Failed to deactivate block dumping %s\n" (Error.to_string_hum e) ) )
+             printf "Failed to deactivate block dumping %s\n"
+               (Error.to_string_hum e) ) )
 
-let stop_logging =
+let deactivate_precomputed_logging =
   let open Deferred.Let_syntax in
   let open Daemon_rpcs in
   let open Command.Param in
@@ -391,22 +356,10 @@ let stop_logging =
          let%map res = Daemon_rpcs.Client.dispatch Stop_logging.rpc () port in
          match res with
          | Ok _ ->
-              print_endline "Precomputed block logging deactivated"
+             print_endline "Precomputed block logging deactivated"
          | Error e ->
-              printf "Failed to deactivate block logging %s\n" (Error.to_string_hum e) ) )
-
-let stop_uploading =
-  let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
-  let open Command.Param in
-  Command.async ~summary:"Stop uploading precomputed blocks to gcloud"
-    (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
-         let%map res = Daemon_rpcs.Client.dispatch Stop_uploading.rpc () port in
-         match res with
-         | Ok _ ->
-              print_endline "Precomputed block uploading deactivated"
-         | Error e ->
-              printf "Failed to deactivate block uploading %s\n" (Error.to_string_hum e) ) )
+             printf "Failed to deactivate block logging %s\n"
+               (Error.to_string_hum e) ) )
 
 let get_public_keys =
   let open Daemon_rpcs in
@@ -2394,14 +2347,12 @@ let client =
     ; ("export-local-logs", Export_logs.export_locally)
     ; ("stop-daemon", stop_daemon)
     ; ("status", status)
-    ; ("set-precomputed-file", set_precomputed_dump_file)
-    ; ("set-precomputed-dir", set_precomputed_dump_dir)
-    ; ("set-precomputed-uploading", set_precomputed_uploading)
-    ; ("set-precomputed-logging", start_logging)
-    ; ("deactivate-precomputed-appending", stop_appending)
-    ; ("deactivate-precomputed-dumping", stop_dumping)
-    ; ("deactivate-precomputed-logging", stop_logging)
-    ; ("deactivate-precomputed-uploading", stop_uploading)
+    ; ("set-block-dir", set_precomputed_dump_dir)
+    ; ("set-block-file", set_precomputed_dump_file)
+    ; ("set-block-logging", start_precomputed_logging)
+    ; ("deactivate-block-dir", deactivate_precomputed_dir)
+    ; ("deactivate-block-file", deactivate_precomputed_file)
+    ; ("deactivate-block-logging", deactivate_precomputed_logging)
     ]
 
 let client_trustlist_group =

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -253,113 +253,130 @@ let reset_trust_status =
              printf "Failed to reset trust status %s\n" (Error.to_string_hum e) )
     )
 
-(* precomputed block writer *)
-let set_precomputed_dump_dir =
-  let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
-  let open Command.Param in
-  let path_flag =
-    flag "--path" ~aliases:[ "path" ]
-      ~doc:"PATH Set precomputed block dump directory" (required string)
-  in
-  let network_flag =
-    flag "--network" ~aliases:[ "network" ]
-      ~doc:"NETWORK Network name for precomputed block dumping"
-      (optional string)
-  in
-  Command.async ~summary:"Set precomputed block dump directory"
-    (Cli_lib.Background_daemon.rpc_init (Args.zip2 path_flag network_flag)
-       ~f:(fun port (path, network_opt) ->
-         let%map res =
-           Daemon_rpcs.Client.dispatch Set_dump_dir.rpc (path, network_opt) port
-         in
-         match res with
-         | Ok _ -> (
-             match network_opt with
-             | Some network ->
-                 printf "Precomputed block dump dir set to %s with network %s\n"
-                   path network
-             | None ->
-                 printf "Precomputed block dump dir set to %s\n" path )
-         | Error e ->
-             printf "Failed to set dump dir with path %s\n"
-               (Error.to_string_hum e) ) )
+module Precomputed_blocks = struct
+  let set_precomputed_dump_dir =
+    let open Deferred.Let_syntax in
+    let open Daemon_rpcs in
+    let open Command.Param in
+    let path_flag =
+      flag "--path" ~aliases:[ "path" ]
+        ~doc:"PATH Set precomputed block dump directory" (required string)
+    in
+    let network_flag =
+      flag "--network" ~aliases:[ "network" ]
+        ~doc:"NETWORK Network name for precomputed block dumping"
+        (optional string)
+    in
+    Command.async ~summary:"Set precomputed block dump directory"
+      (Cli_lib.Background_daemon.rpc_init (Args.zip2 path_flag network_flag)
+         ~f:(fun port (path, network_opt) ->
+           let%map res =
+             Daemon_rpcs.Client.dispatch Precomputed_blocks.Set_dump_dir.rpc
+               (path, network_opt) port
+           in
+           match res with
+           | Ok _ -> (
+               match network_opt with
+               | Some network ->
+                   printf
+                     "Precomputed block dump dir set to %s with network %s\n"
+                     path network
+               | None ->
+                   printf "Precomputed block dump dir set to %s\n" path )
+           | Error e ->
+               printf "Failed to set dump dir with path %s\n"
+                 (Error.to_string_hum e) ) )
 
-let set_precomputed_dump_file =
-  let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
-  let open Command.Param in
-  let path_flag =
-    flag "--path" ~aliases:[ "path" ]
-      ~doc:"PATH Precomputed block dump file path for replaying"
-      (required string)
-  in
-  Command.async ~summary:"Set precomputed block dump file for replaying"
-    (Cli_lib.Background_daemon.rpc_init path_flag ~f:(fun port path ->
-         let%map res =
-           Daemon_rpcs.Client.dispatch Set_dump_file.rpc path port
-         in
-         match res with
-         | Ok _ ->
-             printf "Precomputed block will now be dumped to %s\n" path
-         | Error e ->
-             printf "Failed to set dump path %s\n" (Error.to_string_hum e) ) )
+  let set_precomputed_dump_file =
+    let open Deferred.Let_syntax in
+    let open Daemon_rpcs in
+    let open Command.Param in
+    let path_flag =
+      flag "--path" ~aliases:[ "path" ]
+        ~doc:"PATH Precomputed block dump file path for replaying"
+        (required string)
+    in
+    Command.async ~summary:"Set precomputed block dump file for replaying"
+      (Cli_lib.Background_daemon.rpc_init path_flag ~f:(fun port path ->
+           let%map res =
+             Daemon_rpcs.Client.dispatch Precomputed_blocks.Set_dump_file.rpc
+               path port
+           in
+           match res with
+           | Ok _ ->
+               printf "Precomputed block will now be dumped to %s\n" path
+           | Error e ->
+               printf "Failed to set dump path %s\n" (Error.to_string_hum e) )
+      )
 
-let start_precomputed_logging =
-  let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
-  let open Command.Param in
-  Command.async ~summary:"Set precomputed block logging"
-    (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
-         let%map res = Daemon_rpcs.Client.dispatch Start_logging.rpc () port in
-         match res with
-         | Ok _ ->
-             print_endline "Precomputed blocks will now be logged"
-         | Error e ->
-             printf "Failed to set precomputed block logging %s\n"
-               (Error.to_string_hum e) ) )
+  let start_precomputed_logging =
+    let open Deferred.Let_syntax in
+    let open Daemon_rpcs in
+    let open Command.Param in
+    Command.async ~summary:"Set precomputed block logging"
+      (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
+           let%map res =
+             Daemon_rpcs.Client.dispatch Precomputed_blocks.Start_logging.rpc ()
+               port
+           in
+           match res with
+           | Ok _ ->
+               print_endline "Precomputed blocks will now be logged"
+           | Error e ->
+               printf "Failed to set precomputed block logging %s\n"
+                 (Error.to_string_hum e) ) )
 
-let deactivate_precomputed_file =
-  let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
-  let open Command.Param in
-  Command.async ~summary:"Stop appending precomputed blocks to replay file"
-    (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
-         let%map res = Daemon_rpcs.Client.dispatch Stop_appending.rpc () port in
-         match res with
-         | Ok _ ->
-             print_endline "Precomputed block file writing deactivated"
-         | Error e ->
-             printf "Failed to deactivate block file writing %s\n"
-               (Error.to_string_hum e) ) )
+  let deactivate_precomputed_file =
+    let open Deferred.Let_syntax in
+    let open Daemon_rpcs in
+    let open Command.Param in
+    Command.async ~summary:"Stop appending precomputed blocks to replay file"
+      (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
+           let%map res =
+             Daemon_rpcs.Client.dispatch Precomputed_blocks.Stop_appending.rpc
+               () port
+           in
+           match res with
+           | Ok _ ->
+               print_endline "Precomputed block file writing deactivated"
+           | Error e ->
+               printf "Failed to deactivate block file writing %s\n"
+                 (Error.to_string_hum e) ) )
 
-let deactivate_precomputed_dir =
-  let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
-  let open Command.Param in
-  Command.async ~summary:"Stop dumping precomputed blocks"
-    (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
-         let%map res = Daemon_rpcs.Client.dispatch Stop_dumping.rpc () port in
-         match res with
-         | Ok _ ->
-             print_endline "Precomputed block dumping deactivated"
-         | Error e ->
-             printf "Failed to deactivate block dumping %s\n"
-               (Error.to_string_hum e) ) )
+  let deactivate_precomputed_dir =
+    let open Deferred.Let_syntax in
+    let open Daemon_rpcs in
+    let open Command.Param in
+    Command.async ~summary:"Stop dumping precomputed blocks"
+      (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
+           let%map res =
+             Daemon_rpcs.Client.dispatch Precomputed_blocks.Stop_dumping.rpc ()
+               port
+           in
+           match res with
+           | Ok _ ->
+               print_endline "Precomputed block dumping deactivated"
+           | Error e ->
+               printf "Failed to deactivate block dumping %s\n"
+                 (Error.to_string_hum e) ) )
 
-let deactivate_precomputed_logging =
-  let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
-  let open Command.Param in
-  Command.async ~summary:"Stop logging precomputed blocks"
-    (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
-         let%map res = Daemon_rpcs.Client.dispatch Stop_logging.rpc () port in
-         match res with
-         | Ok _ ->
-             print_endline "Precomputed block logging deactivated"
-         | Error e ->
-             printf "Failed to deactivate block logging %s\n"
-               (Error.to_string_hum e) ) )
+  let deactivate_precomputed_logging =
+    let open Deferred.Let_syntax in
+    let open Daemon_rpcs in
+    let open Command.Param in
+    Command.async ~summary:"Stop logging precomputed blocks"
+      (Cli_lib.Background_daemon.rpc_init (return ()) ~f:(fun port () ->
+           let%map res =
+             Daemon_rpcs.Client.dispatch Precomputed_blocks.Stop_logging.rpc ()
+               port
+           in
+           match res with
+           | Ok _ ->
+               print_endline "Precomputed block logging deactivated"
+           | Error e ->
+               printf "Failed to deactivate block logging %s\n"
+                 (Error.to_string_hum e) ) )
+end
 
 let get_public_keys =
   let open Daemon_rpcs in
@@ -2347,12 +2364,13 @@ let client =
     ; ("export-local-logs", Export_logs.export_locally)
     ; ("stop-daemon", stop_daemon)
     ; ("status", status)
-    ; ("set-block-dir", set_precomputed_dump_dir)
-    ; ("set-block-file", set_precomputed_dump_file)
-    ; ("set-block-logging", start_precomputed_logging)
-    ; ("deactivate-block-dir", deactivate_precomputed_dir)
-    ; ("deactivate-block-file", deactivate_precomputed_file)
-    ; ("deactivate-block-logging", deactivate_precomputed_logging)
+    ; ("set-block-dir", Precomputed_blocks.set_precomputed_dump_dir)
+    ; ("set-block-file", Precomputed_blocks.set_precomputed_dump_file)
+    ; ("set-block-logging", Precomputed_blocks.start_precomputed_logging)
+    ; ("deactivate-block-dir", Precomputed_blocks.deactivate_precomputed_dir)
+    ; ("deactivate-block-file", Precomputed_blocks.deactivate_precomputed_file)
+    ; ( "deactivate-block-logging"
+      , Precomputed_blocks.deactivate_precomputed_logging )
     ]
 
 let client_trustlist_group =

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -321,21 +321,17 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
             ( Mina_commands.get_public_keys mina
             |> Participating_state.active_error ) )
     ; implement Daemon_rpcs.Set_dump_dir.rpc (fun () (path, network) ->
-        return (Mina_commands.set_dump_dir ?network ~path mina ) )
+          return (Mina_commands.set_dump_dir ?network ~path mina) )
     ; implement Daemon_rpcs.Set_dump_file.rpc (fun () path ->
-        return (Mina_commands.set_dump_file mina ~path) )
+          return (Mina_commands.set_dump_file mina ~path) )
     ; implement Daemon_rpcs.Start_logging.rpc (fun () () ->
-        return (Mina_commands.start_logging mina) )
-    ; implement Daemon_rpcs.Set_uploading.rpc (fun () (bucket, keyfile, network) ->
-        return (Mina_commands.set_uploading ?network ~bucket ~keyfile mina) )
+          return (Mina_commands.start_logging mina) )
     ; implement Daemon_rpcs.Stop_appending.rpc (fun () () ->
-        return (Mina_commands.stop_appending mina) )
+          return (Mina_commands.stop_appending mina) )
     ; implement Daemon_rpcs.Stop_dumping.rpc (fun () () ->
-        return (Mina_commands.stop_dumping mina) )
+          return (Mina_commands.stop_dumping mina) )
     ; implement Daemon_rpcs.Stop_logging.rpc (fun () () ->
-        return (Mina_commands.stop_logging mina) )
-    ; implement Daemon_rpcs.Stop_uploading.rpc (fun () () ->
-        return (Mina_commands.stop_uploading mina) )
+          return (Mina_commands.stop_logging mina) )
     ; implement Daemon_rpcs.Get_nonce.rpc (fun () aid ->
           return
             ( Mina_commands.get_nonce mina aid

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -321,17 +321,18 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
             ( Mina_commands.get_public_keys mina
             |> Participating_state.active_error ) )
     ; implement Daemon_rpcs.Set_dump_dir.rpc (fun () (path, network) ->
-          return (Mina_commands.set_dump_dir ?network ~path mina) )
+          return
+            (Mina_commands.Precomputed_blocks.set_dump_dir ?network ~path mina) )
     ; implement Daemon_rpcs.Set_dump_file.rpc (fun () path ->
-          return (Mina_commands.set_dump_file mina ~path) )
+          return (Mina_commands.Precomputed_blocks.set_dump_file mina ~path) )
     ; implement Daemon_rpcs.Start_logging.rpc (fun () () ->
-          return (Mina_commands.start_logging mina) )
+          return (Mina_commands.Precomputed_blocks.start_logging mina) )
     ; implement Daemon_rpcs.Stop_appending.rpc (fun () () ->
-          return (Mina_commands.stop_appending mina) )
+          return (Mina_commands.Precomputed_blocks.stop_appending mina) )
     ; implement Daemon_rpcs.Stop_dumping.rpc (fun () () ->
-          return (Mina_commands.stop_dumping mina) )
+          return (Mina_commands.Precomputed_blocks.stop_dumping mina) )
     ; implement Daemon_rpcs.Stop_logging.rpc (fun () () ->
-          return (Mina_commands.stop_logging mina) )
+          return (Mina_commands.Precomputed_blocks.stop_logging mina) )
     ; implement Daemon_rpcs.Get_nonce.rpc (fun () aid ->
           return
             ( Mina_commands.get_nonce mina aid

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -320,6 +320,22 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
           return
             ( Mina_commands.get_public_keys mina
             |> Participating_state.active_error ) )
+    ; implement Daemon_rpcs.Set_dump_dir.rpc (fun () (path, network) ->
+        return (Mina_commands.set_dump_dir ?network ~path mina ) )
+    ; implement Daemon_rpcs.Set_dump_file.rpc (fun () path ->
+        return (Mina_commands.set_dump_file mina ~path) )
+    ; implement Daemon_rpcs.Start_logging.rpc (fun () () ->
+        return (Mina_commands.start_logging mina) )
+    ; implement Daemon_rpcs.Set_uploading.rpc (fun () (bucket, keyfile, network) ->
+        return (Mina_commands.set_uploading ?network ~bucket ~keyfile mina) )
+    ; implement Daemon_rpcs.Stop_appending.rpc (fun () () ->
+        return (Mina_commands.stop_appending mina) )
+    ; implement Daemon_rpcs.Stop_dumping.rpc (fun () () ->
+        return (Mina_commands.stop_dumping mina) )
+    ; implement Daemon_rpcs.Stop_logging.rpc (fun () () ->
+        return (Mina_commands.stop_logging mina) )
+    ; implement Daemon_rpcs.Stop_uploading.rpc (fun () () ->
+        return (Mina_commands.stop_uploading mina) )
     ; implement Daemon_rpcs.Get_nonce.rpc (fun () aid ->
           return
             ( Mina_commands.get_nonce mina aid

--- a/src/app/cli/src/init/mina_run.ml
+++ b/src/app/cli/src/init/mina_run.ml
@@ -320,18 +320,19 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
           return
             ( Mina_commands.get_public_keys mina
             |> Participating_state.active_error ) )
-    ; implement Daemon_rpcs.Set_dump_dir.rpc (fun () (path, network) ->
+    ; implement Daemon_rpcs.Precomputed_blocks.Set_dump_dir.rpc
+        (fun () (path, network) ->
           return
             (Mina_commands.Precomputed_blocks.set_dump_dir ?network ~path mina) )
-    ; implement Daemon_rpcs.Set_dump_file.rpc (fun () path ->
+    ; implement Daemon_rpcs.Precomputed_blocks.Set_dump_file.rpc (fun () path ->
           return (Mina_commands.Precomputed_blocks.set_dump_file mina ~path) )
-    ; implement Daemon_rpcs.Start_logging.rpc (fun () () ->
+    ; implement Daemon_rpcs.Precomputed_blocks.Start_logging.rpc (fun () () ->
           return (Mina_commands.Precomputed_blocks.start_logging mina) )
-    ; implement Daemon_rpcs.Stop_appending.rpc (fun () () ->
+    ; implement Daemon_rpcs.Precomputed_blocks.Stop_appending.rpc (fun () () ->
           return (Mina_commands.Precomputed_blocks.stop_appending mina) )
-    ; implement Daemon_rpcs.Stop_dumping.rpc (fun () () ->
+    ; implement Daemon_rpcs.Precomputed_blocks.Stop_dumping.rpc (fun () () ->
           return (Mina_commands.Precomputed_blocks.stop_dumping mina) )
-    ; implement Daemon_rpcs.Stop_logging.rpc (fun () () ->
+    ; implement Daemon_rpcs.Precomputed_blocks.Stop_logging.rpc (fun () () ->
           return (Mina_commands.Precomputed_blocks.stop_logging mina) )
     ; implement Daemon_rpcs.Get_nonce.rpc (fun () aid ->
           return

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -503,7 +503,13 @@ module T = struct
                    (Option.map archive_process_location ~f:(fun host_and_port ->
                         Cli_lib.Flag.Types.
                           { name = "dummy"; value = host_and_port } ) )
-                 ~log_precomputed_blocks:false ~stop_time:48 () )
+                 ~log_precomputed_blocks:false ~stop_time:48 ()
+                 ~precomputed_block_writer:
+                  { Mina_lib.Precomputed_block_writer.appending = None
+                  ; dumping = None
+                  ; logging = false
+                  ; uploading = None
+                  } )
           in
           let coda_ref : Mina_lib.t option ref = ref None in
           Mina_run.handle_shutdown ~monitor ~time_controller ~conf_dir

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -505,11 +505,11 @@ module T = struct
                           { name = "dummy"; value = host_and_port } ) )
                  ~log_precomputed_blocks:false ~stop_time:48 ()
                  ~precomputed_block_writer:
-                  { Mina_lib.Precomputed_block_writer.appending = None
-                  ; dumping = None
-                  ; logging = false
-                  ; uploading = None
-                  } )
+                   { Mina_lib.Precomputed_block_writer.appending = None
+                   ; dumping = None
+                   ; logging = false
+                   ; uploading = None
+                   } )
           in
           let coda_ref : Mina_lib.t option ref = ref None in
           Mina_run.handle_shutdown ~monitor ~time_controller ~conf_dir

--- a/src/app/cli/src/tests/dune
+++ b/src/app/cli/src/tests/dune
@@ -76,6 +76,7 @@
    pickles
    kimchi_backend.pasta
    kimchi_backend.pasta.basic
+   daemon_rpcs
  )
 
  (preprocessor_deps ../../../../config.mlh)

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -343,15 +343,6 @@ module Start_logging = struct
     Rpc.Rpc.create ~name:"Start_logging" ~version:0 ~bin_query ~bin_response
 end
 
-module Set_uploading = struct
-  type query = string * string * string option [@@deriving bin_io_unversioned]
-
-  type response = unit [@@deriving bin_io_unversioned]
-
-  let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Set_uploading" ~version:0 ~bin_query ~bin_response
-end
-
 module Stop_appending = struct
   type query = unit [@@deriving bin_io_unversioned]
 
@@ -377,13 +368,4 @@ module Stop_logging = struct
 
   let rpc : (query, response) Rpc.Rpc.t =
     Rpc.Rpc.create ~name:"Stop_logging" ~version:0 ~bin_query ~bin_response
-end
-
-module Stop_uploading = struct
-  type query = unit [@@deriving bin_io_unversioned]
-
-  type response = unit [@@deriving bin_io_unversioned]
-
-  let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Stop_uploading" ~version:0 ~bin_query ~bin_response
 end

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -313,3 +313,77 @@ module Get_object_lifetime_statistics = struct
     Rpc.Rpc.create ~name:"Get_object_lifetime_statistics" ~version:0 ~bin_query
       ~bin_response
 end
+
+(* Precomputed block writer *)
+
+module Set_dump_dir = struct
+  type query = string * string option [@@deriving bin_io_unversioned]
+
+  type response = unit [@@deriving bin_io_unversioned]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Set_dump_dir" ~version:0 ~bin_query ~bin_response
+end
+
+module Set_dump_file = struct
+  type query = string [@@deriving bin_io_unversioned]
+
+  type response = unit [@@deriving bin_io_unversioned]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Set_dump_file" ~version:0 ~bin_query ~bin_response
+end
+
+module Start_logging = struct
+  type query = unit [@@deriving bin_io_unversioned]
+
+  type response = unit [@@deriving bin_io_unversioned]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Start_logging" ~version:0 ~bin_query ~bin_response
+end
+
+module Set_uploading = struct
+  type query = string * string * string option [@@deriving bin_io_unversioned]
+
+  type response = unit [@@deriving bin_io_unversioned]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Set_uploading" ~version:0 ~bin_query ~bin_response
+end
+
+module Stop_appending = struct
+  type query = unit [@@deriving bin_io_unversioned]
+
+  type response = unit [@@deriving bin_io_unversioned]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Stop_appending" ~version:0 ~bin_query ~bin_response
+end
+
+module Stop_dumping = struct
+  type query = unit [@@deriving bin_io_unversioned]
+
+  type response = unit [@@deriving bin_io_unversioned]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Stop_dumping" ~version:0 ~bin_query ~bin_response
+end
+
+module Stop_logging = struct
+  type query = unit [@@deriving bin_io_unversioned]
+
+  type response = unit [@@deriving bin_io_unversioned]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Stop_logging" ~version:0 ~bin_query ~bin_response
+end
+
+module Stop_uploading = struct
+  type query = unit [@@deriving bin_io_unversioned]
+
+  type response = unit [@@deriving bin_io_unversioned]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Stop_uploading" ~version:0 ~bin_query ~bin_response
+end

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -314,58 +314,58 @@ module Get_object_lifetime_statistics = struct
       ~bin_response
 end
 
-(* Precomputed block writer *)
+module Precomputed_blocks = struct
+  module Set_dump_dir = struct
+    type query = string * string option [@@deriving bin_io_unversioned]
 
-module Set_dump_dir = struct
-  type query = string * string option [@@deriving bin_io_unversioned]
+    type response = unit [@@deriving bin_io_unversioned]
 
-  type response = unit [@@deriving bin_io_unversioned]
+    let rpc : (query, response) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Set_dump_dir" ~version:0 ~bin_query ~bin_response
+  end
 
-  let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Set_dump_dir" ~version:0 ~bin_query ~bin_response
-end
+  module Set_dump_file = struct
+    type query = string [@@deriving bin_io_unversioned]
 
-module Set_dump_file = struct
-  type query = string [@@deriving bin_io_unversioned]
+    type response = unit [@@deriving bin_io_unversioned]
 
-  type response = unit [@@deriving bin_io_unversioned]
+    let rpc : (query, response) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Set_dump_file" ~version:0 ~bin_query ~bin_response
+  end
 
-  let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Set_dump_file" ~version:0 ~bin_query ~bin_response
-end
+  module Start_logging = struct
+    type query = unit [@@deriving bin_io_unversioned]
 
-module Start_logging = struct
-  type query = unit [@@deriving bin_io_unversioned]
+    type response = unit [@@deriving bin_io_unversioned]
 
-  type response = unit [@@deriving bin_io_unversioned]
+    let rpc : (query, response) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Start_logging" ~version:0 ~bin_query ~bin_response
+  end
 
-  let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Start_logging" ~version:0 ~bin_query ~bin_response
-end
+  module Stop_appending = struct
+    type query = unit [@@deriving bin_io_unversioned]
 
-module Stop_appending = struct
-  type query = unit [@@deriving bin_io_unversioned]
+    type response = unit [@@deriving bin_io_unversioned]
 
-  type response = unit [@@deriving bin_io_unversioned]
+    let rpc : (query, response) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Stop_appending" ~version:0 ~bin_query ~bin_response
+  end
 
-  let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Stop_appending" ~version:0 ~bin_query ~bin_response
-end
+  module Stop_dumping = struct
+    type query = unit [@@deriving bin_io_unversioned]
 
-module Stop_dumping = struct
-  type query = unit [@@deriving bin_io_unversioned]
+    type response = unit [@@deriving bin_io_unversioned]
 
-  type response = unit [@@deriving bin_io_unversioned]
+    let rpc : (query, response) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Stop_dumping" ~version:0 ~bin_query ~bin_response
+  end
 
-  let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Stop_dumping" ~version:0 ~bin_query ~bin_response
-end
+  module Stop_logging = struct
+    type query = unit [@@deriving bin_io_unversioned]
 
-module Stop_logging = struct
-  type query = unit [@@deriving bin_io_unversioned]
+    type response = unit [@@deriving bin_io_unversioned]
 
-  type response = unit [@@deriving bin_io_unversioned]
-
-  let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Stop_logging" ~version:0 ~bin_query ~bin_response
+    let rpc : (query, response) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Stop_logging" ~version:0 ~bin_query ~bin_response
+  end
 end

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -193,6 +193,32 @@ module Status = struct
     [@@deriving to_yojson, bin_io_unversioned, fields]
   end
 
+  module Precomputed_block_writer = struct
+    module Dumping = struct
+      type t = { dir : string; network : string }
+      [@@deriving to_yojson, bin_io_unversioned, fields]
+    end
+  
+    module Uploading = struct
+      type t =
+        { bucket : string
+        ; keyfile : string
+        ; network : string
+        }
+      [@@deriving to_yojson, bin_io_unversioned, fields]
+    end
+    
+    type t =
+      { mutable appending : string option
+      ; mutable dumping : Dumping.t option
+      ; mutable logging : bool
+      ; mutable uploading : Uploading.t option
+      }
+    [@@deriving to_yojson, bin_io_unversioned, fields]
+
+    let uploading t = t.uploading
+  end
+
   module Make_entries (FieldT : sig
     type 'a t
 
@@ -427,6 +453,35 @@ module Status = struct
         |> digest_entries ~title:""
       in
       map_entry "Metrics" ~f:render
+
+    let precomputed_block_writer =
+      let render conf =
+        let fmt_field name op field = [ (name, op (Field.get field conf)) ] in
+        let open Printf in
+        let open Precomputed_block_writer in
+        let dumping =
+          let open Dumping in
+          fmt_field "dump_dir" (function
+            | Some dump -> sprintf "{ network: %s, dir: %s }" dump.network dump.dir
+            | None -> "...not dumping" )
+        in
+        let appending = fmt_field "appending" (function
+            | Some path -> path
+            | None -> "...not appending")
+        in
+        let logging = fmt_field "logging" Bool.to_string in
+        let uploading =
+          let open Uploading in
+          fmt_field "uploading" (function
+            | Some upload -> sprintf "{ network: %s, bucket: %s }" upload.network upload.bucket
+            | None -> "...not uploading")
+        in
+        Fields.to_list ~appending ~dumping ~logging ~uploading
+        |> List.concat
+        |> List.map ~f:(fun (s, v) -> ("\t" ^ s, v))
+        |> digest_entries ~title:""
+      in
+      option_entry "Precomputed block writing" ~f:render
   end
 
   type t =
@@ -460,6 +515,7 @@ module Status = struct
     ; consensus_configuration : Consensus.Configuration.Stable.Latest.t
     ; addrs_and_ports : Node_addrs_and_ports.Display.Stable.Latest.t
     ; metrics : Metrics.t
+    ; precomputed_block_writer : Precomputed_block_writer.t option
     }
   [@@deriving to_yojson, bin_io_unversioned, fields]
 
@@ -477,7 +533,7 @@ module Status = struct
       ~coinbase_receiver ~histograms ~consensus_time_best_tip
       ~global_slot_since_genesis_best_tip ~consensus_time_now
       ~consensus_mechanism ~consensus_configuration ~next_block_production
-      ~snark_work_fee ~addrs_and_ports ~catchup_status ~metrics
+      ~snark_work_fee ~addrs_and_ports ~catchup_status ~metrics ~precomputed_block_writer
     |> List.filter_map ~f:Fn.id
 
   let to_text (t : t) =

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -195,13 +195,22 @@ module Status = struct
 
   module Precomputed_block_writer = struct
     module Dumping = struct
-      type t = { dir : string; network : string }
+      type t = { dir : string; network : string; mutable number : int }
       [@@deriving to_yojson, bin_io_unversioned, fields]
+
+      let inc_one t = t.number <- t.number + 1
     end
 
     module Uploading = struct
-      type t = { bucket : string; keyfile : string; network : string }
+      type t =
+        { bucket : string
+        ; keyfile : string
+        ; network : string
+        ; mutable number : int
+        }
       [@@deriving to_yojson, bin_io_unversioned, fields]
+
+      let inc_one t = t.number <- t.number + 1
     end
 
     type t =
@@ -462,7 +471,11 @@ module Status = struct
         let open Precomputed_block_writer in
         let dumping =
           let open Dumping in
-          fmt_field_opt "dir" (function Some dump -> Some dump.dir | _ -> None)
+          fmt_field_opt "dir" (function
+            | Some dump ->
+                Some (sprintf "{ path: %s, quantity: %d }" dump.dir dump.number)
+            | _ ->
+                None )
         in
         let appending = fmt_field_opt "file" Fn.id in
         let logging =
@@ -473,8 +486,8 @@ module Status = struct
           fmt_field_opt "upload" (function
             | Some upload ->
                 Some
-                  (sprintf "{ network: %s, bucket: %s }" upload.network
-                     upload.bucket )
+                  (sprintf "{ bucket: %s, quantity: %d }" upload.bucket
+                     upload.number )
             | _ ->
                 None )
         in

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -462,11 +462,7 @@ module Status = struct
         let open Precomputed_block_writer in
         let dumping =
           let open Dumping in
-          fmt_field_opt "dir" (function
-            | Some dump ->
-                Some dump.dir
-            | _ ->
-                None )
+          fmt_field_opt "dir" (function Some dump -> Some dump.dir | _ -> None)
         in
         let appending = fmt_field_opt "file" Fn.id in
         let logging =

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -47,6 +47,23 @@ let get_balance t (addr : Account_id.t) =
   let%map account = get_account t addr in
   account.Account.Poly.balance
 
+(* precomputed block writer *)
+let set_dump_dir ?network ~path t = Mina_lib.set_dump_dir ?network ~path t
+
+let set_dump_file ~path t = Mina_lib.set_dump_file ~path t
+
+let start_logging t = Mina_lib.start_logging t
+
+let set_uploading ?network ~bucket ~keyfile t = Mina_lib.set_uploading ?network ~bucket ~keyfile t
+
+let stop_appending t = Mina_lib.stop_appending t
+
+let stop_dumping t = Mina_lib.stop_dumping t
+
+let stop_logging t = Mina_lib.stop_logging t
+
+let stop_uploading t = Mina_lib.stop_uploading t
+
 let get_trust_status t (ip_address : Unix.Inet_addr.Blocking_sexp.t) =
   let config = Mina_lib.config t in
   let trust_system = config.trust_system in
@@ -452,6 +469,18 @@ let get_status ~flag t =
           @@ Counter.value Transaction_pool.transactions_added_to_pool
       }
   in
+  (* TODO *)
+  let precomputed_block_writer =
+    let open Mina_lib in
+    if is_some (appending t) || logging t || is_some (dumping t) || is_some (uploading t) then
+      Some
+        { Daemon_rpcs.Types.Status.Precomputed_block_writer.appending = appending t
+        ; dumping = dumping t
+        ; logging = logging t
+        ; uploading = uploading t
+        }
+    else None
+  in
   { Daemon_rpcs.Types.Status.num_accounts
   ; sync_status
   ; catchup_status
@@ -485,6 +514,7 @@ let get_status ~flag t =
   ; consensus_configuration
   ; addrs_and_ports
   ; metrics
+  ; precomputed_block_writer
   }
 
 let clear_hist_status ~flag t = Perf_histograms.wipe () ; get_status ~flag t

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -5,6 +5,7 @@ open Async
 open Signature_lib
 open Mina_numbers
 open Mina_base
+module Precomputed_blocks = Mina_lib.Precomputed_blocks
 
 (** For status *)
 let txn_count = ref 0
@@ -46,19 +47,6 @@ let get_balance t (addr : Account_id.t) =
   let open Participating_state.Option.Let_syntax in
   let%map account = get_account t addr in
   account.Account.Poly.balance
-
-(* precomputed block writer *)
-let set_dump_dir ?network ~path t = Mina_lib.set_dump_dir ?network ~path t
-
-let set_dump_file ~path t = Mina_lib.set_dump_file ~path t
-
-let start_logging t = Mina_lib.start_logging t
-
-let stop_appending t = Mina_lib.stop_appending t
-
-let stop_dumping t = Mina_lib.stop_dumping t
-
-let stop_logging t = Mina_lib.stop_logging t
 
 let get_trust_status t (ip_address : Unix.Inet_addr.Blocking_sexp.t) =
   let config = Mina_lib.config t in
@@ -466,7 +454,7 @@ let get_status ~flag t =
       }
   in
   let precomputed_block_writer =
-    let open Mina_lib in
+    let open Precomputed_blocks in
     if
       is_some (appending t)
       || logging t

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -54,15 +54,11 @@ let set_dump_file ~path t = Mina_lib.set_dump_file ~path t
 
 let start_logging t = Mina_lib.start_logging t
 
-let set_uploading ?network ~bucket ~keyfile t = Mina_lib.set_uploading ?network ~bucket ~keyfile t
-
 let stop_appending t = Mina_lib.stop_appending t
 
 let stop_dumping t = Mina_lib.stop_dumping t
 
 let stop_logging t = Mina_lib.stop_logging t
-
-let stop_uploading t = Mina_lib.stop_uploading t
 
 let get_trust_status t (ip_address : Unix.Inet_addr.Blocking_sexp.t) =
   let config = Mina_lib.config t in
@@ -469,12 +465,17 @@ let get_status ~flag t =
           @@ Counter.value Transaction_pool.transactions_added_to_pool
       }
   in
-  (* TODO *)
   let precomputed_block_writer =
     let open Mina_lib in
-    if is_some (appending t) || logging t || is_some (dumping t) || is_some (uploading t) then
+    if
+      is_some (appending t)
+      || logging t
+      || is_some (dumping t)
+      || is_some (uploading t)
+    then
       Some
-        { Daemon_rpcs.Types.Status.Precomputed_block_writer.appending = appending t
+        { Daemon_rpcs.Types.Status.Precomputed_block_writer.appending =
+            appending t
         ; dumping = dumping t
         ; logging = logging t
         ; uploading = uploading t

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -460,27 +460,35 @@ module Types = struct
                ~transaction_pool_diff_broadcasted:nn_int
                ~transactions_added_to_pool:nn_int ~transaction_pool_size:nn_int )
 
-    let precomputed_block_dumping : (_, Daemon_rpcs.Types.Status.Precomputed_block_writer.Dumping.t option) typ =
+    let precomputed_block_dumping :
+        ( _
+        , Daemon_rpcs.Types.Status.Precomputed_block_writer.Dumping.t option )
+        typ =
       obj "PrecomputedBlockDumping" ~fields:(fun _ ->
-        let open Reflection.Shorthand in
-        let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
-        List.rev
-        @@ Dumping.Fields.fold ~init:[] ~dir:nn_string ~network:nn_string )
+          let open Reflection.Shorthand in
+          let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
+          List.rev
+          @@ Dumping.Fields.fold ~init:[] ~dir:nn_string ~network:nn_string )
 
-    let precomputed_block_uploading : (_, Daemon_rpcs.Types.Status.Precomputed_block_writer.Uploading.t option) typ =
+    let precomputed_block_uploading :
+        ( _
+        , Daemon_rpcs.Types.Status.Precomputed_block_writer.Uploading.t option
+        )
+        typ =
       obj "PrecomputedBlockDumping" ~fields:(fun _ ->
-        let open Reflection.Shorthand in
-        let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
-        List.rev
-        @@ Uploading.Fields.fold ~init:[] ~bucket:nn_string ~keyfile:nn_string ~network:nn_string )
+          let open Reflection.Shorthand in
+          let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
+          List.rev
+          @@ Uploading.Fields.fold ~init:[] ~bucket:nn_string ~keyfile:nn_string
+               ~network:nn_string )
 
-    let precomputed_block_writer : (_, Daemon_rpcs.Types.Status.Precomputed_block_writer.t option) typ =
+    let precomputed_block_writer :
+        (_, Daemon_rpcs.Types.Status.Precomputed_block_writer.t option) typ =
       obj "PrecomputedBlockWriter" ~fields:(fun _ ->
           let open Reflection.Shorthand in
           let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
           List.rev
-          @@ Fields.fold ~init:[]
-               ~appending:string ~logging:nn_bool
+          @@ Fields.fold ~init:[] ~appending:string ~logging:nn_bool
                ~dumping:(id ~typ:precomputed_block_dumping)
                ~uploading:(id ~typ:precomputed_block_uploading) )
 

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -460,6 +460,30 @@ module Types = struct
                ~transaction_pool_diff_broadcasted:nn_int
                ~transactions_added_to_pool:nn_int ~transaction_pool_size:nn_int )
 
+    let precomputed_block_dumping : (_, Daemon_rpcs.Types.Status.Precomputed_block_writer.Dumping.t option) typ =
+      obj "PrecomputedBlockDumping" ~fields:(fun _ ->
+        let open Reflection.Shorthand in
+        let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
+        List.rev
+        @@ Dumping.Fields.fold ~init:[] ~dir:nn_string ~network:nn_string )
+
+    let precomputed_block_uploading : (_, Daemon_rpcs.Types.Status.Precomputed_block_writer.Uploading.t option) typ =
+      obj "PrecomputedBlockDumping" ~fields:(fun _ ->
+        let open Reflection.Shorthand in
+        let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
+        List.rev
+        @@ Uploading.Fields.fold ~init:[] ~bucket:nn_string ~keyfile:nn_string ~network:nn_string )
+
+    let precomputed_block_writer : (_, Daemon_rpcs.Types.Status.Precomputed_block_writer.t option) typ =
+      obj "PrecomputedBlockWriter" ~fields:(fun _ ->
+          let open Reflection.Shorthand in
+          let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
+          List.rev
+          @@ Fields.fold ~init:[]
+               ~appending:string ~logging:nn_bool
+               ~dumping:(id ~typ:precomputed_block_dumping)
+               ~uploading:(id ~typ:precomputed_block_uploading) )
+
     let t : (_, Daemon_rpcs.Types.Status.t option) typ =
       obj "DaemonStatus" ~fields:(fun _ ->
           let open Reflection.Shorthand in
@@ -487,7 +511,8 @@ module Types = struct
                  (id ~typ:(non_null consensus_configuration))
                ~highest_block_length_received:nn_int
                ~highest_unvalidated_block_length_received:nn_int
-               ~metrics:(id ~typ:(non_null metrics)) )
+               ~metrics:(id ~typ:(non_null metrics))
+               ~precomputed_block_writer:(id ~typ:precomputed_block_writer) )
   end
 
   let fee_transfer =

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -468,7 +468,8 @@ module Types = struct
           let open Reflection.Shorthand in
           let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
           List.rev
-          @@ Dumping.Fields.fold ~init:[] ~dir:nn_string ~network:nn_string )
+          @@ Dumping.Fields.fold ~init:[] ~dir:nn_string ~network:nn_string
+               ~number:nn_int )
 
     let precomputed_block_uploading :
         ( _
@@ -480,7 +481,7 @@ module Types = struct
           let open Daemon_rpcs.Types.Status.Precomputed_block_writer in
           List.rev
           @@ Uploading.Fields.fold ~init:[] ~bucket:nn_string ~keyfile:nn_string
-               ~network:nn_string )
+               ~network:nn_string ~number:nn_int )
 
     let precomputed_block_writer :
         (_, Daemon_rpcs.Types.Status.Precomputed_block_writer.t option) typ =

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -12,6 +12,14 @@ module Snark_worker_config = struct
     }
 end
 
+module Precomputed_block_writer = Daemon_rpcs.Types.Status.Precomputed_block_writer
+(* type precomputed_block_writer = Daemon_rpcs.Types.Status.Precomputed_block_writer.t =
+  { appending : string option
+  ; dumping : Dumping.t option
+  ; logging : bool
+  ; uploading : Uploading.t option
+  } *)
+
 (** If ledger_db_location is None, will auto-generate a db based on a UUID *)
 type t =
   { conf_dir : string
@@ -51,7 +59,8 @@ type t =
   ; log_block_creation : bool [@default false]
   ; precomputed_values : Precomputed_values.t
   ; start_time : Time.t
-  ; precomputed_blocks_path : string option
+  ; precomputed_blocks_file : string option
+  ; precomputed_blocks_dir : string option
   ; log_precomputed_blocks : bool
   ; upload_blocks_to_gcloud : bool
   ; block_reward_threshold : Currency.Amount.t option [@default None]
@@ -60,5 +69,6 @@ type t =
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; stop_time : int
   ; graphql_control_port : int option [@default None]
+  ; precomputed_block_writer : Precomputed_block_writer.t
   }
 [@@deriving make]

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -12,13 +12,8 @@ module Snark_worker_config = struct
     }
 end
 
-module Precomputed_block_writer = Daemon_rpcs.Types.Status.Precomputed_block_writer
-(* type precomputed_block_writer = Daemon_rpcs.Types.Status.Precomputed_block_writer.t =
-  { appending : string option
-  ; dumping : Dumping.t option
-  ; logging : bool
-  ; uploading : Uploading.t option
-  } *)
+module Precomputed_block_writer =
+  Daemon_rpcs.Types.Status.Precomputed_block_writer
 
 (** If ledger_db_location is None, will auto-generate a db based on a UUID *)
 type t =

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -201,12 +201,16 @@ module Precomputed_blocks = struct
       | None ->
           Initial.get_network t.config.logger false
     in
+    let number =
+      Option.value_map t.precomputed_block_writer.dumping ~default:0
+        ~f:(fun dump -> dump.number)
+    in
     Option.iter dir_opt ~f:(fun dir ->
         [%log' info t.config.logger]
           ~metadata:[ ("dir", `String dir); ("network", `String network) ]
           "Set $network precomputed block dumping to $dir" ;
         t.precomputed_block_writer.dumping <-
-          Some { Precomputed_block_writer.Dumping.network; dir } )
+          Some { Precomputed_block_writer.Dumping.dir; network; number } )
 
   let set_dump_file ~path t =
     let file_opt =

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -217,11 +217,17 @@ let start_logging t =
   [%log' info t.config.logger] "Precomputed block logging started" ;
   t.precomputed_block_writer.logging <- true
 
-let stop_appending t = t.precomputed_block_writer.appending <- None
+let stop_appending t =
+  [%log' info t.config.logger] "Precomputed block appending stopped" ;
+  t.precomputed_block_writer.appending <- None
 
-let stop_dumping t = t.precomputed_block_writer.dumping <- None
+let stop_dumping t =
+  [%log' info t.config.logger] "Precomputed block dumping stopped" ;
+  t.precomputed_block_writer.dumping <- None
 
-let stop_logging t = t.precomputed_block_writer.logging <- false
+let stop_logging t =
+  [%log' info t.config.logger] "Precomputed block logging stopped" ;
+  t.precomputed_block_writer.logging <- false
 
 let empty : Precomputed_block_writer.t =
   { appending = None; dumping = None; logging = false; uploading = None }

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -14,6 +14,7 @@ module Conf_dir = Conf_dir
 module Subscriptions = Mina_subscriptions
 module Snark_worker_lib = Snark_worker
 module Timeout = Timeout_lib.Core_time
+module Precomputed_block_writer = Config.Precomputed_block_writer
 
 let daemon_start_time = Time_ns.now ()
 
@@ -113,8 +114,7 @@ type t =
       Daemon_rpcs.Types.Status.Next_producer_timing.t option
   ; subscriptions : Mina_subscriptions.t
   ; sync_status : Sync_status.t Mina_incremental.Status.Observer.t
-  ; precomputed_block_writer :
-      ([ `Path of string | `Path_dir of string ] option * [ `Log ] option) ref
+  ; precomputed_block_writer : Precomputed_block_writer.t
   ; block_production_status :
       [ `Producing | `Producing_in_ms of float | `Free ] ref
   }
@@ -136,6 +136,161 @@ let client_port t =
     t.config.gossip_net_params.addrs_and_ports
   in
   client_port
+
+(* precomputed_block_writer *)
+let init_network (config : Config.t) =
+  let need_network =
+    config.upload_blocks_to_gcloud || is_some config.precomputed_blocks_file || is_some config.precomputed_blocks_dir
+  in
+  match Core.Sys.getenv "NETWORK_NAME" with
+  | Some network ->
+      if need_network then
+        [%log' info config.logger]
+          "NETWORK_NAME environment variable set to %s" network ;
+      network
+  | _ ->
+      if need_network then
+        [%log' warn config.logger]
+          "NETWORK_NAME environment variable not set. Default to 'berkeley'" ;
+      "berkeley"
+
+let gcloud_keyfile = Core.Sys.getenv "GCLOUD_KEYFILE"
+let gcloud_bucket = Core.Sys.getenv "GCLOUD_BLOCK_UPLOAD_BUCKET"
+
+let check_path path =
+  try
+    match Core.Unix.(lstat path).st_kind with
+    | S_REG -> Some (`File path)
+    | S_DIR -> Some (`Dir path)
+    | _ -> failwith "irregular path"
+  with _ -> None
+
+let appending t = t.precomputed_block_writer.appending
+
+let dumping t = t.precomputed_block_writer.dumping
+
+let logging t = t.precomputed_block_writer.logging
+
+let uploading t = t.precomputed_block_writer.uploading
+
+let set_dump_dir ?network ~path t =
+  let dir_opt =
+    match check_path path with
+    | Some (`Dir dir) -> Some dir
+    | _ ->
+        [%log' error t.config.logger] "Invalid dump directory" ;
+        None
+  in
+  let network =
+    match network with
+    | Some network -> network
+    | None -> init_network t.config
+  in
+  Option.iter dir_opt ~f:(fun dir ->
+      [%log' info t.config.logger]
+        ~metadata:
+          [ ("dir", `String dir)
+          ; ("network", `String network)
+          ]
+        "Set $network precomputed block dumping to $dir" ;
+      t.precomputed_block_writer.dumping <- Some {
+          Precomputed_block_writer.Dumping.network = network;
+          dir
+        } )
+
+let set_dump_file ~path t =
+  let file_opt =
+    match check_path path with
+    | Some (`File file) -> Some file
+    | _ ->
+        [%log' error t.config.logger] "Invalid dump file" ;
+        None
+  in
+  Option.iter file_opt ~f:(fun file ->
+      [%log' info t.config.logger]
+        ~metadata:[ ("file", `String file) ]
+        "Set precomputed block appending to $file" ;
+      t.precomputed_block_writer.appending <- Some file )
+
+let start_logging t =
+  [%log' info t.config.logger] "Precomputed block logging started" ;
+  t.precomputed_block_writer.logging <- true
+
+let set_uploading ?network ~bucket ~keyfile t =
+  let net =
+      let open Precomputed_block_writer.Uploading in
+      Option.map t.precomputed_block_writer.uploading ~f:(fun up -> up.network)
+    in
+  match network, net with
+  | Some network, _ | _, Some network ->
+      [%log' info t.config.logger]
+        ~metadata:
+          [ ("network", `String network)
+          ; ("bucket", `String bucket)
+          ; ("keyfile", `String keyfile)
+          ]
+        "Gcloud uploading $network precomputed blocks to $bucket with $keyfile" ;
+      t.precomputed_block_writer.uploading <- Some { network; bucket; keyfile }
+  | _ ->
+      [%log' error t.config.logger] "Attempted to set uploading without network"
+
+let stop_appending t =
+  t.precomputed_block_writer.appending <- None
+
+let stop_dumping t =
+  t.precomputed_block_writer.dumping <- None
+
+let stop_logging t =
+  t.precomputed_block_writer.logging <- false
+
+let stop_uploading t =
+  t.precomputed_block_writer.uploading <- None
+
+(* TODO *)
+let empty : Precomputed_block_writer.t =
+  { appending = None
+  ; dumping = None
+  ; logging = false
+  ; uploading = None
+  }
+
+let mk_appending ~path =
+  let open Precomputed_block_writer in
+  match check_path path with
+  | Some (`File path) ->
+      { appending = Some path
+      ; dumping = None
+      ; logging = false
+      ; uploading = None
+      }
+  | _ -> empty
+
+let mk_dumping ~network ~path =
+  let open Precomputed_block_writer in
+  match check_path path with
+  | Some (`Dir path) ->
+      { appending = None
+      ; dumping = Some { Dumping.dir = path; network }
+      ; logging = false
+      ; uploading = None
+      }
+  | _ -> empty
+
+let mk_logging () =
+  let open Precomputed_block_writer in
+  { appending = None
+  ; dumping = None
+  ; logging = true
+  ; uploading = None
+  }
+
+let mk_uploading ~network ~bucket ~keyfile =
+  let open Precomputed_block_writer in
+  { appending = None
+  ; dumping = None
+  ; logging = false
+  ; uploading = Some { Uploading.network; bucket; keyfile }
+  }
 
 (* Get the most recently set public keys  *)
 let block_production_pubkeys t : Public_key.Compressed.Set.t =
@@ -1392,6 +1547,52 @@ let send_resource_pool_diff_or_wait ~rl ~diff_score ~max_per_15_seconds diff =
   able_to_send_or_wait ()
 
 let create ?wallets (config : Config.t) =
+  let _precomputed_block_writer_setup =
+    let open Option in
+    (* appending *)
+    iter config.precomputed_blocks_file ~f:(fun file ->
+      [%log' info config.logger]
+        ~metadata:[ ("path", `String file) ]
+        "Precomputed blocks will be appended to the same file $path" ) ;
+    config.precomputed_block_writer.appending <- config.precomputed_blocks_file ;
+    (* logging *)
+    (if config.log_precomputed_blocks then
+      [%log' info config.logger] "Precomputed blocks will be logged") ;
+    config.precomputed_block_writer.logging <- config.log_precomputed_blocks ;
+    (* local dumping *)
+    match config.precomputed_blocks_dir with
+    | Some dir ->
+        [%log' info config.logger]
+          ~metadata:[ ("path", `String dir) ]
+          "Precomputed blocks will be dumped to individual files in $path" ;
+        config.precomputed_block_writer.dumping <- Some { dir; network = init_network config }
+    | None ->
+        config.precomputed_block_writer.dumping <- None ;
+    (* uploading *)
+    if config.upload_blocks_to_gcloud then
+      match gcloud_bucket, gcloud_keyfile with
+      | Some bucket, Some keyfile ->
+          [%log' info config.logger]
+            ~metadata:
+              [ ("bucket", `String bucket)
+              ; ("keyfile", `String keyfile)
+              ]
+            "GCLOUD_KEYFILE environment variable set to $keyfile\n\
+             GCLOUD_BLOCK_UPLOAD_BUCKET environment variable set to $bucket" ;
+          config.precomputed_block_writer.uploading <- Some { bucket; keyfile; network = init_network config }
+      | bucket, keyfile ->
+          if is_none bucket then
+            [%log' warn config.logger]
+              "GCLOUD_BLOCK_UPLOAD_BUCKET environment variable not set. Must be \
+               set in order to upload blocks to gcloud" ;
+          if is_none keyfile then
+            [%log' warn config.logger]
+              "GCLOUD_KEYFILE environment variable not set. Must be set in \
+               order to upload blocks to gcloud" ;
+          config.precomputed_block_writer.uploading <- None
+    else
+      config.precomputed_block_writer.uploading <- None
+  in
   let module Context = (val context config) in
   let catchup_mode = if config.super_catchup then `Super else `Normal in
   let constraint_constants = config.precomputed_values.constraint_constants in
@@ -2081,42 +2282,13 @@ let create ?wallets (config : Config.t) =
                 ~precomputed_values:config.precomputed_values
                 ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
                 archive_process_port ) ;
-          (* To log precomputed blocks to individual files, set both
-             --precomputed-blocks-path DIR and --log-precomputed-blocks true *)
-          let precomputed_block_writer =
-            let block_path_opt =
-              try
-                Option.map config.precomputed_blocks_path ~f:(fun path ->
-                    match Core.Unix.(lstat path).st_kind with
-                    | S_DIR ->
-                        `Path_dir path
-                    | S_REG ->
-                        `Path path
-                    | _ ->
-                        [%log' error config.logger]
-                          ~metadata:[ ("path", `String path) ]
-                          "$path is not a regular Unix file or directory. \
-                           Local precomputed block logging disabled." ;
-                        failwith "No precomputed block logging" )
-              with _ -> None
-            in
-            let log_opt =
-              match block_path_opt with
-              | None ->
-                  if config.log_precomputed_blocks then Some `Log else None
-              | _ ->
-                  None
-            in
-            ref (block_path_opt, log_opt)
-          in
           let subscriptions =
             Mina_subscriptions.create ~logger:config.logger
               ~constraint_constants ~new_blocks ~wallets
               ~transition_frontier:frontier_broadcast_pipe_r
               ~is_storing_all:config.is_archive_rocksdb
-              ~upload_blocks_to_gcloud:config.upload_blocks_to_gcloud
-              ~time_controller:config.time_controller ~precomputed_block_writer
-              ~log_precomputed_blocks:config.log_precomputed_blocks
+              ~time_controller:config.time_controller
+              ~precomputed_block_writer:config.precomputed_block_writer
           in
           let open Mina_incremental.Status in
           let transition_frontier_incr =
@@ -2177,7 +2349,7 @@ let create ?wallets (config : Config.t) =
             ; snark_job_state = snark_jobs_state
             ; subscriptions
             ; sync_status
-            ; precomputed_block_writer
+            ; precomputed_block_writer = config.precomputed_block_writer
             ; block_production_status = ref `Free
             } ) )
 

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -239,20 +239,8 @@ val stop_dumping : t -> unit
 
 val stop_logging : t -> unit
 
-val stop_uploading : t -> unit
-
 val set_dump_dir : ?network:string -> path:string -> t -> unit
 
 val set_dump_file : path:string -> t -> unit
 
-val set_uploading : ?network:string -> bucket:string -> keyfile:string -> t -> unit
-
 val empty : Precomputed_block_writer.t
-
-val mk_appending : path:string -> Precomputed_block_writer.t
-
-val mk_dumping : network:string -> path:string -> Precomputed_block_writer.t
-
-val mk_logging : unit -> Precomputed_block_writer.t
-
-val mk_uploading : network:string -> bucket:string -> keyfile:string -> Precomputed_block_writer.t

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -8,6 +8,7 @@ module Archive_client = Archive_client
 module Config = Config
 module Conf_dir = Conf_dir
 module Subscriptions = Mina_subscriptions
+module Precomputed_block_writer = Config.Precomputed_block_writer
 
 type t
 
@@ -220,3 +221,38 @@ val runtime_config : t -> Runtime_config.t
 val verifier : t -> Verifier.t
 
 val genesis_ledger : t -> Mina_ledger.Ledger.t Lazy.t
+
+(** Precomputed block writer *)
+val appending : t -> string option
+
+val dumping : t -> Precomputed_block_writer.Dumping.t option
+
+val logging : t -> bool
+
+val uploading : t -> Precomputed_block_writer.Uploading.t option
+
+val start_logging : t -> unit
+
+val stop_appending : t -> unit
+
+val stop_dumping : t -> unit
+
+val stop_logging : t -> unit
+
+val stop_uploading : t -> unit
+
+val set_dump_dir : ?network:string -> path:string -> t -> unit
+
+val set_dump_file : path:string -> t -> unit
+
+val set_uploading : ?network:string -> bucket:string -> keyfile:string -> t -> unit
+
+val empty : Precomputed_block_writer.t
+
+val mk_appending : path:string -> Precomputed_block_writer.t
+
+val mk_dumping : network:string -> path:string -> Precomputed_block_writer.t
+
+val mk_logging : unit -> Precomputed_block_writer.t
+
+val mk_uploading : network:string -> bucket:string -> keyfile:string -> Precomputed_block_writer.t

--- a/src/lib/mina_lib/mina_lib.mli
+++ b/src/lib/mina_lib/mina_lib.mli
@@ -222,25 +222,39 @@ val verifier : t -> Verifier.t
 
 val genesis_ledger : t -> Mina_ledger.Ledger.t Lazy.t
 
-(** Precomputed block writer *)
-val appending : t -> string option
+module Precomputed_blocks : sig
+  module Initial : sig
+    val network :
+         logger:Logger.t
+      -> upload_blocks_to_gcloud:bool
+      -> precomputed_blocks_dir:string option
+      -> precomputed_blocks_file:string option
+      -> string
 
-val dumping : t -> Precomputed_block_writer.Dumping.t option
+    val gcloud_bucket : string option
 
-val logging : t -> bool
+    val gcloud_keyfile : string option
+  end
 
-val uploading : t -> Precomputed_block_writer.Uploading.t option
+  val appending : t -> string option
 
-val start_logging : t -> unit
+  val dumping : t -> Precomputed_block_writer.Dumping.t option
 
-val stop_appending : t -> unit
+  val logging : t -> bool
 
-val stop_dumping : t -> unit
+  val uploading : t -> Precomputed_block_writer.Uploading.t option
 
-val stop_logging : t -> unit
+  val start_logging : t -> unit
 
-val set_dump_dir : ?network:string -> path:string -> t -> unit
+  val stop_appending : t -> unit
 
-val set_dump_file : path:string -> t -> unit
+  val stop_dumping : t -> unit
 
-val empty : Precomputed_block_writer.t
+  val stop_logging : t -> unit
+
+  val set_dump_dir : ?network:string -> path:string -> t -> unit
+
+  val set_dump_file : path:string -> t -> unit
+
+  val empty : Precomputed_block_writer.t
+end

--- a/src/lib/mina_lib/mina_subscriptions.ml
+++ b/src/lib/mina_lib/mina_subscriptions.ml
@@ -42,7 +42,7 @@ let add_new_subscription (t : t) ~pk =
 
 let create ~logger ~constraint_constants ~wallets ~new_blocks
     ~transition_frontier ~is_storing_all ~time_controller
-    ~upload_blocks_to_gcloud ~precomputed_block_writer ~log_precomputed_blocks =
+    ~precomputed_block_writer =
   let subscribed_block_users =
     Optional_public_key.Table.of_alist_multi
     @@ List.map (Secrets.Wallets.pks wallets) ~f:(fun wallet ->
@@ -98,70 +98,18 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
               Pipe.write_without_pushback writer { With_hash.data; hash } ) )
       ~if_not_found:ignore
   in
-  let dump_precomputed_blocks =
-    Option.is_some (fst !precomputed_block_writer)
-  in
-  let network =
-    match Core.Sys.getenv "NETWORK_NAME" with
-    | Some network ->
-        if upload_blocks_to_gcloud || dump_precomputed_blocks then
-          [%log info] "NETWORK_NAME environment variable set to %s" network ;
-        network
-    | _ ->
-        if upload_blocks_to_gcloud || dump_precomputed_blocks then
-          [%log warn]
-            "NETWORK_NAME environment variable not set. Default to 'berkeley'" ;
-        "berkeley"
-  in
-  let gcloud_keyfile =
-    match Core.Sys.getenv "GCLOUD_KEYFILE" with
-    | Some keyfile ->
-        if upload_blocks_to_gcloud then
-          [%log info] "GCLOUD_KEYFILE environment variable set to %s" keyfile ;
-        Some keyfile
-    | _ ->
-        if upload_blocks_to_gcloud then
-          [%log warn]
-            "GCLOUD_KEYFILE environment variable not set. Must be set to use \
-             upload_blocks_to_gcloud" ;
-        None
-  in
-  let gcloud_bucket =
-    match Core.Sys.getenv "GCLOUD_BLOCK_UPLOAD_BUCKET" with
-    | Some bucket ->
-        if upload_blocks_to_gcloud then
-          [%log info]
-            "GCLOUD_BLOCK_UPLOAD_BUCKET environment variable set to %s" bucket ;
-        Some bucket
-    | _ ->
-        if upload_blocks_to_gcloud then
-          [%log warn]
-            "GCLOUD_BLOCK_UPLOAD_BUCKET environment variable not set. Must be \
-             set to use upload_blocks_to_gcloud" ;
-        None
-  in
-  Option.iter (fst !precomputed_block_writer) ~f:(fun path ->
-      match path with
-      | `Path_dir path ->
-          [%log info]
-            ~metadata:[ ("path", `String path) ]
-            "Precomputed blocks will be logged to individual files in $path"
-      | `Path path ->
-          [%log info]
-            ~metadata:[ ("path", `String path) ]
-            "Precomputed blocks will be logged to the same file $path" ) ;
-  Option.iter gcloud_keyfile ~f:(fun path ->
+  Option.iter (Daemon_rpcs.Types.Status.Precomputed_block_writer.uploading precomputed_block_writer) ~f:(fun { keyfile; _ } ->
       ignore
         ( Core.Sys.command
-            (sprintf "gcloud auth activate-service-account --key-file=%s" path)
+            (sprintf "gcloud auth activate-service-account --key-file=%s" keyfile)
           : int ) ) ;
   O1trace.background_thread "process_new_block_subscriptions" (fun () ->
       Strict_pipe.Reader.iter new_blocks ~f:(fun new_block_validated ->
           let new_block = Mina_block.Validated.forget new_block_validated in
           let new_block_no_hash = With_hash.data new_block in
           let hash = State_hash.With_state_hashes.state_hash new_block in
-          (let path, log = !precomputed_block_writer in
-           match Broadcast_pipe.Reader.peek transition_frontier with
+          (let { Daemon_rpcs.Types.Status.Precomputed_block_writer.appending; dumping; logging; uploading } = precomputed_block_writer in
+            match Broadcast_pipe.Reader.peek transition_frontier with
            | None ->
                [%log warn]
                  "Transition frontier not available when creating precomputed \
@@ -201,26 +149,26 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                         Mina_block.Precomputed.to_yojson precomputed_block )
                    in
                    (* Upload precomputed blocks to gcloud *)
-                   ( if upload_blocks_to_gcloud then
+                   (* TODO Option.iter uploading ~f:... *)
+                   Option.iter uploading ~f:(fun info ->
                      let json =
                        Yojson.Safe.to_string (Lazy.force precomputed_block)
                      in
-                     match (gcloud_keyfile, gcloud_bucket) with
-                     | Some _, Some bucket ->
-                         let hash_string = State_hash.to_base58_check hash in
-                         [%log info]
-                           ~metadata:
-                             [ ("hash", `String hash_string)
-                             ; ("bucket", `String bucket)
-                             ]
-                           "Uploading precomputed block with $hash to gcloud \
-                            $bucket" ;
+                     let hash_string = State_hash.to_base58_check hash in
                          let height =
                            Mina_block.blockchain_length new_block_no_hash
                            |> Mina_numbers.Length.to_string
                          in
+                         [%log info]
+                           ~metadata:
+                             [ ("hash", `String hash_string)
+                             ; ("bucket", `String info.bucket)
+                             ; ("height", `String height)
+                             ]
+                           "Uploading precomputed block with $height and $hash to gcloud \
+                            $bucket" ;
                          let name =
-                           sprintf "%s-%s-%s.json" network height hash_string
+                           sprintf "%s-%s-%s.json" info.network height hash_string
                          in
                          (* TODO: Use a pipe to queue this if these are building up *)
                          don't_wait_for
@@ -237,7 +185,7 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                              Stdlib.close_out f ;
                              let command =
                                Printf.sprintf "gsutil cp -n %s gs://%s/%s"
-                                 tmp_file bucket name
+                                 tmp_file info.bucket name
                              in
                              let%map output =
                                (* This double-wrapping of [try_with]s is protection
@@ -273,56 +221,58 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                              Mina_metrics.(
                                Gauge.dec_one
                                  Block_latency.Upload_to_gcloud
-                                 .upload_to_gcloud_blocks) )
-                     | _ ->
-                         () ) ;
-                   (* Log precomputed blocks locally *)
-                   Option.iter path ~f:(fun path ->
-                       let json =
-                         Yojson.Safe.to_string (Lazy.force precomputed_block)
-                       in
-                       match path with
-                       | `Path path ->
-                           (* original logging functionality, appends to single file *)
-                           Out_channel.with_file ~append:true path
-                             ~f:(fun out_channel ->
-                               Out_channel.output_lines out_channel [ json ] )
-                       | `Path_dir path ->
-                           (* log precomputed blocks to individual files in the directory *)
-                           let hash_string = State_hash.to_base58_check hash in
-                           let height =
-                             Mina_block.blockchain_length new_block_no_hash
-                             |> Mina_numbers.Length.to_string
-                           in
-                           let name =
-                             sprintf "%s-%s-%s.json" network height hash_string
-                           in
-                           let fpath =
-                             Core.Filename.(parts path @ [ name ] |> of_parts)
-                           in
-                           Out_channel.with_file ~append:false fpath
-                             ~f:(fun out_channel ->
-                               Out_channel.output_lines out_channel [ json ] ) ;
-                           [%log info]
-                             ~metadata:
-                               [ ("block", `String name)
-                               ; ("path", `String path)
-                               ]
-                             "Logged precomputed $block to $path" ) ;
-                   if log_precomputed_blocks then
+                                 .upload_to_gcloud_blocks) ) ) ;
+                   (* original logging functionality, appends to single file *)
+                   Option.iter appending ~f:(fun path ->
+                      let json =
+                        Yojson.Safe.to_string (Lazy.force precomputed_block)
+                      in
+                      Out_channel.with_file ~append:true path
+                        ~f:(fun out_channel ->
+                          Out_channel.output_lines out_channel [ json ] ) ) ;
+                   (* dump precomputed blocks to local directory *)
+                   Option.iter dumping ~f:(fun { dir; network } ->
+                        let json =
+                          Yojson.Safe.to_string (Lazy.force precomputed_block)
+                        in
+                        (* log precomputed blocks to individual files in the directory *)
+                            let hash_string = State_hash.to_base58_check hash in
+                            let height =
+                              Mina_block.blockchain_length new_block_no_hash
+                              |> Mina_numbers.Length.to_string
+                            in
+                            let name =
+                              sprintf "%s-%s-%s.json" network height hash_string
+                            in
+                            let path =
+                              Core.Filename.(parts dir @ [ name ] |> of_parts)
+                            in
+                            Out_channel.with_file ~append:false path
+                              ~f:(fun out_channel ->
+                                Out_channel.output_lines out_channel [ json ] ) ;
+                            Mina_metrics.(
+                               Counter.inc_one
+                                 Block_latency.Precomputed_block_dump.count ;
+                               Counter.inc
+                                 Block_latency.Precomputed_block_dump.bytes_written
+                                 (Float.of_int Bytes.(of_string json |> length) ) ) ;
+                            [%log info]
+                              ~metadata:
+                                [ ("height", `String height)
+                                ; ("hash", `String hash_string)
+                                ; ("dir", `String dir)
+                                ]
+                              "Logged precomputed block with $height and $hash to $dir" ) ;
+                   if logging then
                      [%log info] "Saw block with state hash $state_hash"
                        ~metadata:
-                         (let state_hash_data =
-                            [ ( "state_hash"
-                              , `String (State_hash.to_base58_check hash) )
-                            ]
-                          in
-                          if is_some log then
-                            state_hash_data
-                            @ [ ( "precomputed_block"
-                                , Lazy.force precomputed_block )
-                              ]
-                          else state_hash_data ) ) ) ;
+                         [ ( "state_hash", `String (State_hash.to_base58_check hash) )
+                         ; ( "precomputed_block", Lazy.force precomputed_block )
+                         ] ;
+                   if is_none appending && is_none dumping && not logging then
+                     [%log info] "Saw block with state hash $state_hash"
+                       ~metadata:
+                         [ ( "state_hash", `String (State_hash.to_base58_check hash) ) ] ) ) ;
           match
             Filtered_external_transition.validate_transactions
               ~constraint_constants new_block_no_hash

--- a/src/lib/mina_lib/mina_subscriptions.ml
+++ b/src/lib/mina_lib/mina_subscriptions.ml
@@ -98,6 +98,15 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
               Pipe.write_without_pushback writer { With_hash.data; hash } ) )
       ~if_not_found:ignore
   in
+  let network =
+    match Core.Sys.getenv "NETWORK_NAME" with
+    | Some network ->
+        Some network
+    | _ ->
+        [%log warn]
+          "NETWORK_NAME environment variable not set. Default to 'berkeley'" ;
+        Some "berkeley"
+  in
   let gcloud_keyfile =
     match Core.Sys.getenv "GCLOUD_KEYFILE" with
     | Some keyfile ->
@@ -175,16 +184,6 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                    ( if upload_blocks_to_gcloud then
                      let json =
                        Yojson.Safe.to_string (Lazy.force precomputed_block)
-                     in
-                     let network =
-                       match Core.Sys.getenv "NETWORK_NAME" with
-                       | Some network ->
-                           Some network
-                       | _ ->
-                           [%log warn]
-                             "NETWORK_NAME environment variable not set. Must \
-                              be set to use upload_blocks_to_gcloud" ;
-                           None
                      in
                      let bucket =
                        match Core.Sys.getenv "GCLOUD_BLOCK_UPLOAD_BUCKET" with
@@ -282,16 +281,6 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                                  Out_channel.output_lines out_channel [ json ] )
                          | `Path_dir path -> (
                              (* log precomputed blocks to individual files in the directory *)
-                             let network =
-                               match Core.Sys.getenv "NETWORK_NAME" with
-                               | Some network ->
-                                   Some network
-                               | _ ->
-                                   [%log warn]
-                                     "NETWORK_NAME environment variable not \
-                                      set. Default to 'mainnet'" ;
-                                   Some "mainnet"
-                             in
                              match network with
                              | Some network ->
                                  let hash_string =

--- a/src/lib/mina_lib/mina_subscriptions.ml
+++ b/src/lib/mina_lib/mina_subscriptions.ml
@@ -42,7 +42,7 @@ let add_new_subscription (t : t) ~pk =
 
 let create ~logger ~constraint_constants ~wallets ~new_blocks
     ~transition_frontier ~is_storing_all ~time_controller
-    ~upload_blocks_to_gcloud ~precomputed_block_writer =
+    ~upload_blocks_to_gcloud ~precomputed_block_writer ~log_precomputed_blocks =
   let subscribed_block_users =
     Optional_public_key.Table.of_alist_multi
     @@ List.map (Secrets.Wallets.pks wallets) ~f:(fun wallet ->
@@ -101,13 +101,26 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
   let gcloud_keyfile =
     match Core.Sys.getenv "GCLOUD_KEYFILE" with
     | Some keyfile ->
+        if upload_blocks_to_gcloud then
+          [%log info] "GCLOUD_KEYFILE environment variable set to %s" keyfile ;
         Some keyfile
     | _ ->
-        [%log warn]
-          "GCLOUD_KEYFILE environment variable not set. Must be set to use \
-           upload_blocks_to_gcloud" ;
+        if upload_blocks_to_gcloud then
+          [%log warn]
+            "GCLOUD_KEYFILE environment variable not set. Must be set to use \
+             upload_blocks_to_gcloud" ;
         None
   in
+  Option.iter (fst !precomputed_block_writer) ~f:(fun path ->
+      match path with
+      | `Path_dir path ->
+          [%log info]
+            ~metadata:[ ("path", `String path) ]
+            "Precomputed blocks will be logged to individual files in $path"
+      | `Path path ->
+          [%log info]
+            ~metadata:[ ("path", `String path) ]
+            "Precomputed blocks will be logged to the same file $path" ) ;
   Option.iter gcloud_keyfile ~f:(fun path ->
       ignore
         ( Core.Sys.command
@@ -118,7 +131,7 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
           let new_block = Mina_block.Validated.forget new_block_validated in
           let new_block_no_hash = With_hash.data new_block in
           let hash = State_hash.With_state_hashes.state_hash new_block in
-          (let path, log = !precomputed_block_writer in
+          (let path, _log = !precomputed_block_writer in
            match Broadcast_pipe.Reader.peek transition_frontier with
            | None ->
                [%log warn]
@@ -158,8 +171,8 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                             ] ;
                         Mina_block.Precomputed.to_yojson precomputed_block )
                    in
-                   if upload_blocks_to_gcloud then (
-                     [%log info] "log" ;
+                   (* Upload precomputed blocks to gcloud *)
+                   ( if upload_blocks_to_gcloud then
                      let json =
                        Yojson.Safe.to_string (Lazy.force precomputed_block)
                      in
@@ -187,6 +200,13 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                      match (gcloud_keyfile, network, bucket) with
                      | Some _, Some network, Some bucket ->
                          let hash_string = State_hash.to_base58_check hash in
+                         [%log info]
+                           ~metadata:
+                             [ ("hash", `String hash_string)
+                             ; ("bucket", `String bucket)
+                             ]
+                           "Uploading precomputed block with $hash to gcloud \
+                            $bucket" ;
                          let height =
                            Mina_block.blockchain_length new_block_no_hash
                            |> Mina_numbers.Length.to_string
@@ -248,25 +268,73 @@ let create ~logger ~constraint_constants ~wallets ~new_blocks
                                  .upload_to_gcloud_blocks) )
                      | _ ->
                          () ) ;
-                   Option.iter path ~f:(fun (`Path path) ->
-                       Out_channel.with_file ~append:true path
-                         ~f:(fun out_channel ->
-                           Out_channel.output_lines out_channel
-                             [ Yojson.Safe.to_string
-                                 (Lazy.force precomputed_block)
-                             ] ) ) ;
-                   [%log info] "Saw block with state hash $state_hash"
-                     ~metadata:
-                       (let state_hash_data =
-                          [ ( "state_hash"
-                            , `String (State_hash.to_base58_check hash) )
-                          ]
-                        in
-                        if is_some log then
-                          state_hash_data
-                          @ [ ("precomputed_block", Lazy.force precomputed_block)
-                            ]
-                        else state_hash_data ) ) ) ;
+                   (* Log precomputed blocks locally *)
+                   Option.iter path ~f:(fun path ->
+                       if log_precomputed_blocks then
+                         let json =
+                           Yojson.Safe.to_string (Lazy.force precomputed_block)
+                         in
+                         match path with
+                         | `Path path ->
+                             (* original logging functionality, appends to single file *)
+                             Out_channel.with_file ~append:true path
+                               ~f:(fun out_channel ->
+                                 Out_channel.output_lines out_channel [ json ] )
+                         | `Path_dir path -> (
+                             (* log precomputed blocks to individual files in the directory *)
+                             let network =
+                               match Core.Sys.getenv "NETWORK_NAME" with
+                               | Some network ->
+                                   Some network
+                               | _ ->
+                                   [%log warn]
+                                     "NETWORK_NAME environment variable not \
+                                      set. Default to 'mainnet'" ;
+                                   Some "mainnet"
+                             in
+                             match network with
+                             | Some network ->
+                                 let hash_string =
+                                   State_hash.to_base58_check hash
+                                 in
+                                 let height =
+                                   Mina_block.blockchain_length
+                                     new_block_no_hash
+                                   |> Mina_numbers.Length.to_string
+                                 in
+                                 let name =
+                                   sprintf "%s-%s-%s.json" network height
+                                     hash_string
+                                 in
+                                 let fpath =
+                                   Core.Filename.(
+                                     parts path @ [ name ] |> of_parts)
+                                 in
+                                 Out_channel.with_file ~append:false fpath
+                                   ~f:(fun out_channel ->
+                                     Out_channel.output_lines out_channel
+                                       [ json ] ) ;
+                                 [%log info]
+                                   ~metadata:
+                                     [ ("block", `String name)
+                                     ; ("path", `String path)
+                                     ; ( "time"
+                                       , `String
+                                           Time.(
+                                             now ()
+                                             |> to_string_iso8601_basic
+                                                  ~zone:Zone.utc) )
+                                     ]
+                                   "Logged precomputed $block to $path at $time"
+                             | None ->
+                                 () )
+                       else
+                         [%log info]
+                           ~metadata:
+                             [ ( "state_hash"
+                               , `String (State_hash.to_base58_check hash) )
+                             ]
+                           "Saw block with state hash $state_hash" ) ) ) ;
           match
             Filtered_external_transition.validate_transactions
               ~constraint_constants new_block_no_hash

--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -482,7 +482,7 @@ module Block_latency : sig
 
   module Precomputed_block_dump : sig
     val count : Counter.t
-  
+
     val bytes_written : Counter.t
   end
 

--- a/src/lib/mina_metrics/mina_metrics.mli
+++ b/src/lib/mina_metrics/mina_metrics.mli
@@ -480,6 +480,12 @@ module Block_latency : sig
     val upload_to_gcloud_blocks : Gauge.t
   end
 
+  module Precomputed_block_dump : sig
+    val count : Counter.t
+  
+    val bytes_written : Counter.t
+  end
+
   module Gossip_slots : sig
     val v : Gauge.t
 

--- a/src/lib/mina_metrics/no_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/no_metrics/mina_metrics.ml
@@ -492,6 +492,12 @@ module Block_latency = struct
     let upload_to_gcloud_blocks : Gauge.t = ()
   end
 
+  module Precomputed_block_dump = struct
+    let count : Counter.t = ()
+
+    let bytes_written : Counter.t = ()
+  end
+
   module Gossip_slots = struct
     let v : Gauge.t = ()
 

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -1448,10 +1448,11 @@ module Block_latency = struct
     let count : Counter.t =
       let help = "Number of precomputed blocks written to disk" in
       Counter.v "precomputed_block_dump_count" ~help ~namespace ~subsystem
-    
+
     let bytes_written : Counter.t =
       let help = "Number of precomputed block bytes written to disk" in
-      Counter.v "precomputed_block_dump_bytes_written" ~help ~namespace ~subsystem
+      Counter.v "precomputed_block_dump_bytes_written" ~help ~namespace
+        ~subsystem
   end
 
   module Latency_time_spec = struct

--- a/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
+++ b/src/lib/mina_metrics/prometheus_metrics/mina_metrics.ml
@@ -1444,6 +1444,16 @@ module Block_latency = struct
       Gauge.v "upload_to_gcloud_blocks" ~help ~namespace ~subsystem
   end
 
+  module Precomputed_block_dump = struct
+    let count : Counter.t =
+      let help = "Number of precomputed blocks written to disk" in
+      Counter.v "precomputed_block_dump_count" ~help ~namespace ~subsystem
+    
+    let bytes_written : Counter.t =
+      let help = "Number of precomputed block bytes written to disk" in
+      Counter.v "precomputed_block_dump_bytes_written" ~help ~namespace ~subsystem
+  end
+
   module Latency_time_spec = struct
     let tick_interval =
       Core.Time.Span.of_ms (Int.to_float (block_window_duration / 2))


### PR DESCRIPTION
Explain your changes:

- add fully adjustable precomputed block writer
- add client commands and RPCs to change settings
- add --precomputed-blocks-dir cli flag
- improve logging wrt precomputed block writing

New client commands
```
set-block-dir             Set precomputed block dump directory
set-block-file            Set precomputed block dump file for replaying
set-block-logging         Set precomputed block logging
deactivate-block-dir      Stop dumping precomputed blocks
deactivate-block-file     Stop appending precomputed blocks to replay file
deactivate-block-logging  Stop logging precomputed blocks
```

Explain how you tested your changes:

The cli was built and connected to the berkeley rampup network. Each command was manually tested to verify functionality.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204615033157553