### PR TITLE
Update bindings to enable chunking

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
@@ -7,7 +7,7 @@ use kimchi::{
 pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
 ) -> (String, Vec<(String, String)>) {
     let evaluated_cols = linearization_columns::<F>(None);
-    let (linearization, _powers_of_alpha) = constraints_expr::<F>(None, true);
+    let (linearization, _powers_of_alpha) = constraints_expr::<F>(None, true, 3);
 
     let Linearization {
         constant_term,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
@@ -146,7 +146,7 @@ pub fn caml_pasta_fp_plonk_index_read(
     let mut t = ProverIndex::<Vesta>::deserialize(&mut rmp_serde::Deserializer::new(r))?;
     t.srs = srs.clone();
 
-    let (linearization, powers_of_alpha) = expr_linearization(Some(&t.cs.feature_flags), true);
+    let (linearization, powers_of_alpha) = expr_linearization(Some(&t.cs.feature_flags), true, 3);
     t.linearization = linearization;
     t.powers_of_alpha = powers_of_alpha;
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -10,7 +10,7 @@ use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use kimchi::circuits::constraints::FeatureFlags;
 use kimchi::circuits::lookup::lookups::{LookupFeatures, LookupPatterns};
 use kimchi::circuits::polynomials::permutation::Shifts;
-use kimchi::circuits::polynomials::permutation::{zk_polynomial, zk_w3};
+use kimchi::circuits::polynomials::permutation::{permutation_vanishing_polynomial, zk_w};
 use kimchi::circuits::wires::{COLUMNS, PERMUTS};
 use kimchi::{linearization::expr_linearization, verifier_index::VerifierIndex};
 use mina_curves::pasta::{Fp, Pallas, Vesta};
@@ -95,7 +95,7 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<Vesta> {
         };
 
         // TODO dummy_lookup_value ?
-        let (linearization, powers_of_alpha) = expr_linearization(Some(&feature_flags), true);
+        let (linearization, powers_of_alpha) = expr_linearization(Some(&feature_flags), true, 3);
 
         VerifierIndex::<Vesta> {
             domain,
@@ -108,6 +108,8 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<Vesta> {
                 res.set(index.srs.0).unwrap();
                 res
             },
+
+            zk_rows: 3,
 
             sigma_comm,
             coefficients_comm,
@@ -129,14 +131,14 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<Vesta> {
             rot_comm: None,
 
             shift,
-            zkpm: {
+            permutation_vanishing_polynomial_m: {
                 let res = once_cell::sync::OnceCell::new();
-                res.set(zk_polynomial(domain)).unwrap();
+                res.set(permutation_vanishing_polynomial(domain, 3)).unwrap();
                 res
             },
             w: {
                 let res = once_cell::sync::OnceCell::new();
-                res.set(zk_w3(domain)).unwrap();
+                res.set(zk_w(domain, 3)).unwrap();
                 res
             },
             endo: endo_q,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
@@ -146,7 +146,7 @@ pub fn caml_pasta_fq_plonk_index_read(
     let mut t = ProverIndex::<Pallas>::deserialize(&mut rmp_serde::Deserializer::new(r))?;
     t.srs = srs.clone();
 
-    let (linearization, powers_of_alpha) = expr_linearization(Some(&t.cs.feature_flags), true);
+    let (linearization, powers_of_alpha) = expr_linearization(Some(&t.cs.feature_flags), true, 3);
     t.linearization = linearization;
     t.powers_of_alpha = powers_of_alpha;
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
@@ -10,7 +10,7 @@ use ark_poly::{EvaluationDomain, Radix2EvaluationDomain as Domain};
 use kimchi::circuits::constraints::FeatureFlags;
 use kimchi::circuits::lookup::lookups::{LookupFeatures, LookupPatterns};
 use kimchi::circuits::polynomials::permutation::Shifts;
-use kimchi::circuits::polynomials::permutation::{zk_polynomial, zk_w3};
+use kimchi::circuits::polynomials::permutation::{permutation_vanishing_polynomial, zk_w};
 use kimchi::circuits::wires::{COLUMNS, PERMUTS};
 use kimchi::{linearization::expr_linearization, verifier_index::VerifierIndex};
 use mina_curves::pasta::{Fq, Pallas, Vesta};
@@ -95,7 +95,7 @@ impl From<CamlPastaFqPlonkVerifierIndex> for VerifierIndex<Pallas> {
         };
 
         // TODO dummy_lookup_value ?
-        let (linearization, powers_of_alpha) = expr_linearization(Some(&feature_flags), true);
+        let (linearization, powers_of_alpha) = expr_linearization(Some(&feature_flags), true, 3);
 
         VerifierIndex::<Pallas> {
             domain,
@@ -108,6 +108,8 @@ impl From<CamlPastaFqPlonkVerifierIndex> for VerifierIndex<Pallas> {
                 res.set(index.srs.0).unwrap();
                 res
             },
+
+            zk_rows: 3,
 
             sigma_comm,
             coefficients_comm,
@@ -129,14 +131,14 @@ impl From<CamlPastaFqPlonkVerifierIndex> for VerifierIndex<Pallas> {
             rot_comm: None,
 
             shift,
-            zkpm: {
+            permutation_vanishing_polynomial_m: {
                 let res = once_cell::sync::OnceCell::new();
-                res.set(zk_polynomial(domain)).unwrap();
+                res.set(permutation_vanishing_polynomial(domain, 3)).unwrap();
                 res
             },
             w: {
                 let res = once_cell::sync::OnceCell::new();
-                res.set(zk_w3(domain)).unwrap();
+                res.set(zk_w(domain, 3)).unwrap();
                 res
             },
             endo: endo_q,

--- a/src/lib/pickles/plonk_checks/gen_scalars/gen_scalars.ml
+++ b/src/lib/pickles/plonk_checks/gen_scalars/gen_scalars.ml
@@ -101,7 +101,7 @@ module Env = struct
     ; endo_coefficient : 'a
     ; mds : int * int -> 'a
     ; srs_length_log2 : int
-    ; vanishes_on_last_4_rows : 'a
+    ; vanishes_on_zero_knowledge_and_previous_rows : 'a
     ; joint_combiner : 'a
     ; beta : 'a
     ; gamma : 'a
@@ -135,7 +135,7 @@ module Tick : S = struct
        ; omega_to_minus_3 = _
        ; zeta_to_n_minus_1 = _
        ; srs_length_log2 = _
-       ; vanishes_on_last_4_rows
+       ; vanishes_on_zero_knowledge_and_previous_rows
        ; joint_combiner = _
        ; beta
        ; gamma
@@ -173,7 +173,7 @@ let () =
        ; mds = _
        ; endo_coefficient
        ; srs_length_log2 = _
-       ; vanishes_on_last_4_rows
+       ; vanishes_on_zero_knowledge_and_previous_rows
        ; joint_combiner
        ; beta
        ; gamma
@@ -222,7 +222,7 @@ module Tock : S = struct
        ; omega_to_minus_3 = _
        ; zeta_to_n_minus_1 = _
        ; srs_length_log2 = _
-       ; vanishes_on_last_4_rows
+       ; vanishes_on_zero_knowledge_and_previous_rows
        ; joint_combiner = _
        ; beta
        ; gamma
@@ -260,7 +260,7 @@ let () =
        ; mds = _
        ; endo_coefficient
        ; srs_length_log2 = _
-       ; vanishes_on_last_4_rows
+       ; vanishes_on_zero_knowledge_and_previous_rows
        ; joint_combiner
        ; beta
        ; gamma

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -354,7 +354,7 @@ let scalars_env (type boolean t) (module B : Bool_intf with type t = boolean)
   ; endo_coefficient = endo
   ; mds = (fun (row, col) -> mds.(row).(col))
   ; srs_length_log2
-  ; vanishes_on_last_4_rows =
+  ; vanishes_on_zero_knowledge_and_previous_rows =
       ( match joint_combiner with
       | None ->
           (* No need to compute anything when not using lookups *)

--- a/src/lib/pickles/plonk_checks/scalars.ml
+++ b/src/lib/pickles/plonk_checks/scalars.ml
@@ -89,7 +89,7 @@ module Env = struct
     ; endo_coefficient : 'a
     ; mds : int * int -> 'a
     ; srs_length_log2 : int
-    ; vanishes_on_last_4_rows : 'a
+    ; vanishes_on_zero_knowledge_and_previous_rows : 'a
     ; joint_combiner : 'a
     ; beta : 'a
     ; gamma : 'a
@@ -123,7 +123,7 @@ module Tick : S = struct
        ; omega_to_minus_3 = _
        ; zeta_to_n_minus_1 = _
        ; srs_length_log2 = _
-       ; vanishes_on_last_4_rows
+       ; vanishes_on_zero_knowledge_and_previous_rows
        ; joint_combiner = _
        ; beta
        ; gamma
@@ -316,7 +316,7 @@ module Tick : S = struct
         ( LookupTables
         , (fun () ->
             alpha_pow 24
-            * ( vanishes_on_last_4_rows
+            * ( vanishes_on_zero_knowledge_and_previous_rows
               * ( cell (var (LookupAggreg, Next))
                   * ( if_feature
                         ( LookupsPerRow 0
@@ -628,7 +628,7 @@ module Tick : S = struct
        ; mds = _
        ; endo_coefficient
        ; srs_length_log2 = _
-       ; vanishes_on_last_4_rows
+       ; vanishes_on_zero_knowledge_and_previous_rows
        ; joint_combiner
        ; beta
        ; gamma
@@ -643,7 +643,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -802,7 +802,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -1004,7 +1004,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -1207,7 +1207,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -3943,7 +3943,7 @@ module Tock : S = struct
        ; omega_to_minus_3 = _
        ; zeta_to_n_minus_1 = _
        ; srs_length_log2 = _
-       ; vanishes_on_last_4_rows
+       ; vanishes_on_zero_knowledge_and_previous_rows
        ; joint_combiner = _
        ; beta
        ; gamma
@@ -4136,7 +4136,7 @@ module Tock : S = struct
         ( LookupTables
         , (fun () ->
             alpha_pow 24
-            * ( vanishes_on_last_4_rows
+            * ( vanishes_on_zero_knowledge_and_previous_rows
               * ( cell (var (LookupAggreg, Next))
                   * ( if_feature
                         ( LookupsPerRow 0
@@ -4448,7 +4448,7 @@ module Tock : S = struct
        ; mds = _
        ; endo_coefficient
        ; srs_length_log2 = _
-       ; vanishes_on_last_4_rows
+       ; vanishes_on_zero_knowledge_and_previous_rows
        ; joint_combiner
        ; beta
        ; gamma
@@ -4463,7 +4463,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -4622,7 +4622,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -4824,7 +4824,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -5027,7 +5027,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))


### PR DESCRIPTION
This PR is a counterpart to https://github.com/o1-labs/proof-systems/pull/1033, which enables chunked proving in kimchi, and https://github.com/o1-labs/proof-systems/pull/1045, which tweaks the constraints to achieve zero-knowledge in chunked proofs, while retaining compatibility with Berkeley proofs.

This PR builds upon #13285, which contains the tweaks necessary for this PR to work. Note that this *does not* actually enable chunking, but it does unlock the possibility of receiving chunked proofs in OCaml, in preparation for the remaining pickles work.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them