### PR TITLE
remove gcloud capacity check

### DIFF
--- a/src/lib/integration_test_cloud_engine/cli_inputs.ml
+++ b/src/lib/integration_test_cloud_engine/cli_inputs.ml
@@ -1,11 +1,6 @@
 open Cmdliner
 
-type t =
-  { mina_automation_location : string
-  ; check_capacity : bool
-  ; check_capacity_delay : int
-  ; check_capacity_retries : int
-  }
+type t = { mina_automation_location : string }
 
 let term =
   let mina_automation_location =
@@ -20,36 +15,6 @@ let term =
           [ "mina-automation-location" ]
           ~env ~docv:"MINA_AUTOMATION_LOCATION" ~doc)
   in
-  let check_capacity =
-    let doc =
-      "Whether or not to check the capacity of the cloud cluster before \
-       execution.  Default: true"
-    in
-    Arg.(value & opt bool true & info [ "capacity-check" ] ~doc)
-  in
-  let check_capacity_delay =
-    let doc =
-      "Upon a failed capacity check, how much time in seconds to wait before \
-       trying.  Only holds meaning if check-capacity is true.  Default: 60"
-    in
-    Arg.(value & opt int 60 & info [ "capacity-check-delay" ] ~doc)
-  in
-  let check_capacity_retries =
-    let doc =
-      "Upon a failed capacity check, how many times to retry before giving \
-       up.  Only holds meaning if check-capacity is true.  Default: 10"
-    in
-    Arg.(value & opt int 10 & info [ "capacity-check-retries" ] ~doc)
-  in
-  let cons_inputs mina_automation_location check_capacity check_capacity_delay
-      check_capacity_retries =
-    { mina_automation_location
-    ; check_capacity
-    ; check_capacity_delay
-    ; check_capacity_retries
-    }
-  in
+  let cons_inputs mina_automation_location = { mina_automation_location } in
 
-  Term.(
-    const cons_inputs $ mina_automation_location $ check_capacity
-    $ check_capacity_delay $ check_capacity_retries)
+  Term.(const cons_inputs $ mina_automation_location)

--- a/src/lib/integration_test_cloud_engine/mina_automation.ml
+++ b/src/lib/integration_test_cloud_engine/mina_automation.ml
@@ -65,9 +65,6 @@ module Network_config = struct
   type t =
     { mina_automation_location : string
     ; debug_arg : bool
-    ; check_capacity : bool
-    ; check_capacity_delay : int
-    ; check_capacity_retries : int
     ; genesis_keypairs :
         (Network_keypair.t Core.String.Map.t
         [@to_yojson
@@ -326,9 +323,6 @@ module Network_config = struct
     (* NETWORK CONFIG *)
     { mina_automation_location = cli_inputs.mina_automation_location
     ; debug_arg = debug
-    ; check_capacity = cli_inputs.check_capacity
-    ; check_capacity_delay = cli_inputs.check_capacity_delay
-    ; check_capacity_retries = cli_inputs.check_capacity_retries
     ; genesis_keypairs
     ; constants
     ; terraform =
@@ -427,101 +421,6 @@ module Network_manager = struct
 
   let run_cmd_or_hard_error t prog args =
     Util.run_cmd_or_hard_error t.testnet_dir prog args
-
-  let rec check_kube_capacity t ~logger ~(retries : int) ~(delay : float) :
-      unit Malleable_error.t =
-    let open Malleable_error.Let_syntax in
-    let%bind () =
-      Malleable_error.return ([%log info] "Running capacity check")
-    in
-    let%bind kubectl_top_nodes_output =
-      Util.run_cmd_or_hard_error "/" "kubectl"
-        [ "top"; "nodes"; "--sort-by=cpu"; "--no-headers" ]
-    in
-    let num_kube_nodes =
-      String.split_on_chars kubectl_top_nodes_output ~on:[ '\n' ] |> List.length
-    in
-    let%bind gcloud_descr_output =
-      Util.run_cmd_or_hard_error "/" "gcloud"
-        [ "container"
-        ; "clusters"
-        ; "describe"
-        ; cluster_name
-        ; "--project"
-        ; "o1labs-192920"
-        ; "--region"
-        ; cluster_region
-        ]
-    in
-    (* gcloud container clusters describe mina-integration-west1 --project o1labs-192920 --region us-west1
-        this command gives us lots of information, including the max number of nodes per node pool.
-    *)
-    let%bind max_node_count_str =
-      Util.run_cmd_or_hard_error "/" "bash"
-        [ "-c"
-        ; Format.sprintf "echo \"%s\" | grep \"maxNodeCount\" "
-            gcloud_descr_output
-        ]
-    in
-    let max_node_count_by_node_pool =
-      Re2.find_all_exn (Re2.of_string "[0-9]+") max_node_count_str
-      |> List.map ~f:(fun str -> Int.of_string str)
-    in
-    (* We can have any number of node_pools.  this string parsing will yield a list of ints, each int represents the
-        max_node_count for each node pool *)
-    let max_nodes =
-      List.fold max_node_count_by_node_pool ~init:0 ~f:(fun accum max_nodes ->
-          accum + (max_nodes * 3) )
-      (*
-        the max_node_count_by_node_pool is per zone.  us-west1 has 3 zones (we assume this never changes).
-          therefore to get the actual number of nodes a node_pool has, we multiply by 3.
-          then we sum up the number of nodes in all our node_pools to get the actual total maximum number of nodes that we can scale up to *)
-    in
-    let nodes_available = max_nodes - num_kube_nodes in
-    let cpus_needed_estimate =
-      6
-      * ( Core.Map.length t.seed_workloads
-        + Core.Map.length t.block_producer_workloads
-        + Core.Map.length t.snark_coordinator_workloads )
-      (* as of 2022/07, the seed, bps, and the snark coordinator use 6 cpus.  this is just a rough heuristic so we're not bothering to calculate memory needed *)
-    in
-    let cluster_nodes_needed =
-      Int.of_float
-        (Float.round_up (Float.( / ) (Float.of_int cpus_needed_estimate) 64.0))
-      (* assuming that each node on the cluster has 64 cpus, as we've configured it to be in GCP as of *)
-    in
-    if nodes_available >= cluster_nodes_needed then
-      let%bind () =
-        Malleable_error.return
-          ([%log info]
-             "Capacity check passed.  %d nodes are provisioned, the cluster \
-              can scale up to a max of %d nodes.  This test needs at least 1 \
-              node to be unprovisioned."
-             num_kube_nodes max_nodes )
-      in
-      Malleable_error.return ()
-    else if retries <= 0 then
-      let%bind () =
-        Malleable_error.return
-          ([%log info]
-             "Capacity check failed.  %d nodes are provisioned, the cluster \
-              can scale up to a max of %d nodes.  This test needs at least 1 \
-              node to be unprovisioned.  no more retries, thus exiting"
-             num_kube_nodes max_nodes )
-      in
-      exit 7
-    else
-      let%bind () =
-        Malleable_error.return
-          ([%log info]
-             "Capacity check failed.  %d nodes are provisioned, the cluster \
-              can scale up to a max of %d nodes.  This test needs at least 1 \
-              node to be unprovisioned.  sleeping for 60 seconds before \
-              retrying.  will retry %d more times"
-             num_kube_nodes max_nodes (retries - 1) )
-      in
-      let%bind () = Malleable_error.return (Thread.delay delay) in
-      check_kube_capacity t ~logger ~retries:(retries - 1) ~delay
 
   let create ~logger (network_config : Network_config.t) =
     let open Malleable_error.Let_syntax in
@@ -677,14 +576,6 @@ module Network_manager = struct
       ; deployed = false
       ; genesis_keypairs = network_config.genesis_keypairs
       }
-    in
-    (* check capacity *)
-    let%bind () =
-      if network_config.check_capacity then
-        check_kube_capacity t ~logger
-          ~delay:(Float.of_int network_config.check_capacity_delay)
-          ~retries:network_config.check_capacity_retries
-      else Malleable_error.return ()
     in
     (* making the main.tf.json *)
     let open Deferred.Let_syntax in


### PR DESCRIPTION
Explain your changes:
Removes capacity checks when running test executive

Explain how you tested your changes:
Run tests and analyzed logs. There is no entry regarding cancelling tests due to insufficient resources on gcloud

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #13269 
