### PR TITLE
Recreate schema in local network script when archive and reset parameter (develop)

### DIFF
--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -247,6 +247,21 @@ check-db-connection() {
   printf "\n"
 }
 
+recreate-schema() {
+  echo "Recreating database '${PG_DB}'..."
+  
+  psql -c "DROP DATABASE ${PG_DB}" -U ${PG_USER} -h ${PG_HOST} -p ${PG_PORT} >&/dev/null
+  
+  psql -c "CREATE DATABASE ${PG_DB}" -U ${PG_USER} -h ${PG_HOST} -p ${PG_PORT} >&/dev/null
+  # We need to change our working directory as script has relation to others subscripts 
+  # and calling them from local folder
+  cd ./src/app/archive 
+  psql ${PG_DB} < create_schema.sql  -U ${PG_USER} -h ${PG_HOST} -p ${PG_PORT} >&/dev/null
+
+  echo "Schema '${PG_DB}' created successfully."
+  printf "\n"
+}
+
 # ================================================
 # Parse inputs from arguments
 
@@ -439,6 +454,9 @@ LEDGER_FOLDER="${HOME}/.mina-network/mina-local-network-${WHALES}-${FISH}-${NODE
 
 if ${RESET}; then
   rm -rf ${LEDGER_FOLDER}
+  if ${ARCHIVE}; then
+    recreate-schema
+  fi
 fi
 
 if [ ! -d "${LEDGER_FOLDER}" ]; then

--- a/scripts/mina-local-network/mina-local-network.sh
+++ b/scripts/mina-local-network/mina-local-network.sh
@@ -250,13 +250,15 @@ check-db-connection() {
 recreate-schema() {
   echo "Recreating database '${PG_DB}'..."
   
-  psql -c "DROP DATABASE ${PG_DB}" -U ${PG_USER} -h ${PG_HOST} -p ${PG_PORT} >&/dev/null
+  psql postgresql://${PG_USER}:${PG_PASSWD}@${PG_HOST}:${PG_PORT} -c "DROP DATABASE IF EXISTS ${PG_DB};"
   
-  psql -c "CREATE DATABASE ${PG_DB}" -U ${PG_USER} -h ${PG_HOST} -p ${PG_PORT} >&/dev/null
+  psql postgresql://${PG_USER}:${PG_PASSWD}@${PG_HOST}:${PG_PORT} -c "CREATE DATABASE ${PG_DB};"
+  
   # We need to change our working directory as script has relation to others subscripts 
   # and calling them from local folder
   cd ./src/app/archive 
-  psql ${PG_DB} < create_schema.sql  -U ${PG_USER} -h ${PG_HOST} -p ${PG_PORT} >&/dev/null
+  psql postgresql://${PG_USER}:${PG_PASSWD}@${PG_HOST}:${PG_PORT} ${PG_DB} < create_schema.sql
+  cd ../../../
 
   echo "Schema '${PG_DB}' created successfully."
   printf "\n"


### PR DESCRIPTION
Explain your changes:
Small improvement for local network script, which i found useful. Then -reset and -archive parameter is set database schema is recreated

Explain how you tested your changes:
By running script with mentioned parameters and ensured that there is fresh schema 

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

