### PR TITLE
Fix Wasm build BERKELEY

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -290,7 +290,7 @@
             mina mina_tests mina-ocaml-format test_executive;
           inherit (pkgs)
             libp2p_helper kimchi_bindings_stubs snarky_js leaderboard
-            mina-signer validation trace-tool zkapp-cli;
+            validation trace-tool zkapp-cli;
           inherit (dockerImages)
             mina-image-slim mina-image-full mina-archive-image-full;
           mina-deb = debianPackages.mina;


### PR DESCRIPTION
merges rampup -> berkeley as a side effect of bringing the wasm fix https://github.com/MinaProtocol/mina/pull/13341 to berkeley