### PR TITLE
rm feature_snapps, feature_tokens

### DIFF
--- a/src/config/features/dev.mlh
+++ b/src/config/features/dev.mlh
@@ -1,3 +1,1 @@
-[%%define feature_tokens true]
-[%%define feature_snapps true]
 [%%define mainnet false]

--- a/src/config/features/mainnet.mlh
+++ b/src/config/features/mainnet.mlh
@@ -1,3 +1,1 @@
-[%%define feature_tokens false]
-[%%define feature_snapps false]
 [%%define mainnet true]

--- a/src/config/features/public_testnet.mlh
+++ b/src/config/features/public_testnet.mlh
@@ -1,3 +1,1 @@
-[%%define feature_tokens false]
-[%%define feature_snapps false]
 [%%define mainnet false]

--- a/src/lib/mina_base/signed_command_payload.ml
+++ b/src/lib/mina_base/signed_command_payload.ml
@@ -33,27 +33,6 @@ module Common = struct
     end]
   end
 
-  [%%if feature_tokens]
-
-  [%%versioned
-  module Stable = struct
-    module V1 = struct
-      type t =
-        ( Currency.Fee.Stable.V1.t
-        , Public_key.Compressed.Stable.V1.t
-        , Token_id.Stable.V1.t
-        , Account_nonce.Stable.V1.t
-        , Global_slot.Stable.V1.t
-        , Memo.Stable.V1.t )
-        Poly.Stable.V1.t
-      [@@deriving compare, equal, sexp, hash, yojson]
-
-      let to_latest = Fn.id
-    end
-  end]
-
-  [%%else]
-
   module Binable_arg = struct
     [%%versioned
     module Stable = struct
@@ -97,8 +76,6 @@ module Common = struct
       let to_latest = Fn.id
     end
   end]
-
-  [%%endif]
 
   let to_input ({ fee; fee_token; fee_payer_pk; nonce; valid_until; memo } : t)
       =
@@ -207,25 +184,6 @@ module Body = struct
     end]
   end
 
-  [%%if feature_tokens]
-
-  [%%versioned
-  module Stable = struct
-    module V1 = struct
-      type t = Binable_arg.Stable.V1.t =
-        | Payment of Payment_payload.Stable.V1.t
-        | Stake_delegation of Stake_delegation.Stable.V1.t
-        | Create_new_token of New_token_payload.Stable.V1.t
-        | Create_token_account of New_account_payload.Stable.V1.t
-        | Mint_tokens of Minting_payload.Stable.V1.t
-      [@@deriving compare, equal, sexp, hash, yojson]
-
-      let to_latest = Fn.id
-    end
-  end]
-
-  [%%else]
-
   let check (t : Binable_arg.t) =
     let fail () =
       failwithf !"Tokens disabled. Read %{sexp:Binable_arg.t}" t ()
@@ -263,8 +221,6 @@ module Body = struct
       let to_latest = Fn.id
     end
   end]
-
-  [%%endif]
 
   module Tag = Transaction_union_tag
 

--- a/src/lib/mina_base/snapp_command.ml
+++ b/src/lib/mina_base/snapp_command.ml
@@ -396,12 +396,6 @@ module Binable_arg = struct
   end]
 end
 
-[%%if feature_snapps]
-
-include Binable_arg
-
-[%%else]
-
 [%%versioned_binable
 module Stable = struct
   module V1 = struct
@@ -446,8 +440,6 @@ module Stable = struct
     let version_byte = Base58_check.Version_bytes.snapp_command
   end
 end]
-
-[%%endif]
 
 type transfer =
   { source : Public_key.Compressed.t

--- a/src/lib/mina_base/token_id.ml
+++ b/src/lib/mina_base/token_id.ml
@@ -26,19 +26,6 @@ let next = T.succ
 
 let invalid = T.of_uint64 Unsigned.UInt64.zero
 
-[%%if feature_tokens]
-
-[%%versioned
-module Stable = struct
-  module V1 = struct
-    type t = T.Stable.V1.t [@@deriving sexp, equal, compare, hash, yojson]
-
-    let to_latest = Fn.id
-  end
-end]
-
-[%%else]
-
 let check x =
   if T.equal x default || T.equal x (next default) then x
   else failwith "Non-default tokens are disabled"
@@ -65,15 +52,13 @@ module Stable = struct
   end
 end]
 
-[%%endif]
+let gen = Quickcheck.Generator.return default
 
 let gen_ge minimum =
   Quickcheck.Generator.map
     Int64.(gen_incl (min_value + minimum) max_value)
     ~f:(fun x ->
       Int64.(x - min_value) |> Unsigned.UInt64.of_int64 |> T.of_uint64 )
-
-let gen = gen_ge 1L
 
 let gen_non_default = gen_ge 2L
 


### PR DESCRIPTION
Remove `feature_tokens` and `feature_snapps` config items, and code that depended on them.

`Account.check` always looks for a nondefault token and an instantiated `snapp` field. It can now report both errors, where before it would fail for at most one error; in the `dev` profile, it wasn't reporting either error.

`Token_id.gen` always returns the default token. There are existing generators that can generate an invalid or nondefault token, if those are needed.

The unit tests in `merkle_ledger_tests` pass using the `devnet` profile, which they did not before.

Closes #13344.