### PR TITLE
Update proof-systems to pass through zk_rows

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/linearization.rs
@@ -7,7 +7,7 @@ use kimchi::{
 pub fn linearization_strings<F: ark_ff::PrimeField + ark_ff::SquareRootField>(
 ) -> (String, Vec<(String, String)>) {
     let evaluated_cols = linearization_columns::<F>(None);
-    let (linearization, _powers_of_alpha) = constraints_expr::<F>(None, true, 3);
+    let (linearization, _powers_of_alpha) = constraints_expr::<F>(None, true);
 
     let Linearization {
         constant_term,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
@@ -146,7 +146,7 @@ pub fn caml_pasta_fp_plonk_index_read(
     let mut t = ProverIndex::<Vesta>::deserialize(&mut rmp_serde::Deserializer::new(r))?;
     t.srs = srs.clone();
 
-    let (linearization, powers_of_alpha) = expr_linearization(Some(&t.cs.feature_flags), true, 3);
+    let (linearization, powers_of_alpha) = expr_linearization(Some(&t.cs.feature_flags), true);
     t.linearization = linearization;
     t.powers_of_alpha = powers_of_alpha;
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_verifier_index.rs
@@ -95,7 +95,7 @@ impl From<CamlPastaFpPlonkVerifierIndex> for VerifierIndex<Vesta> {
         };
 
         // TODO dummy_lookup_value ?
-        let (linearization, powers_of_alpha) = expr_linearization(Some(&feature_flags), true, 3);
+        let (linearization, powers_of_alpha) = expr_linearization(Some(&feature_flags), true);
 
         VerifierIndex::<Vesta> {
             domain,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
@@ -146,7 +146,7 @@ pub fn caml_pasta_fq_plonk_index_read(
     let mut t = ProverIndex::<Pallas>::deserialize(&mut rmp_serde::Deserializer::new(r))?;
     t.srs = srs.clone();
 
-    let (linearization, powers_of_alpha) = expr_linearization(Some(&t.cs.feature_flags), true, 3);
+    let (linearization, powers_of_alpha) = expr_linearization(Some(&t.cs.feature_flags), true);
     t.linearization = linearization;
     t.powers_of_alpha = powers_of_alpha;
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_verifier_index.rs
@@ -95,7 +95,7 @@ impl From<CamlPastaFqPlonkVerifierIndex> for VerifierIndex<Pallas> {
         };
 
         // TODO dummy_lookup_value ?
-        let (linearization, powers_of_alpha) = expr_linearization(Some(&feature_flags), true, 3);
+        let (linearization, powers_of_alpha) = expr_linearization(Some(&feature_flags), true);
 
         VerifierIndex::<Pallas> {
             domain,

--- a/src/lib/pickles/plonk_checks/gen_scalars/gen_scalars.ml
+++ b/src/lib/pickles/plonk_checks/gen_scalars/gen_scalars.ml
@@ -105,7 +105,7 @@ module Env = struct
     ; joint_combiner : 'a
     ; beta : 'a
     ; gamma : 'a
-    ; unnormalized_lagrange_basis : int -> 'a
+    ; unnormalized_lagrange_basis : bool * int -> 'a
     ; if_feature : Kimchi_types.feature_flag * (unit -> 'a) * (unit -> 'a) -> 'a
     }
 end

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -365,7 +365,12 @@ let scalars_env (type boolean t) (module B : Bool_intf with type t = boolean)
   ; beta
   ; gamma
   ; unnormalized_lagrange_basis =
-      (fun i ->
+      (fun (use_zk_rows, i) ->
+        let zk_rows = 3 in
+        let i =
+          let open Int in
+          if use_zk_rows then -zk_rows + i else i
+        in
         let w_to_i =
           match i with
           | 0 ->

--- a/src/lib/pickles/plonk_checks/scalars.ml
+++ b/src/lib/pickles/plonk_checks/scalars.ml
@@ -93,7 +93,7 @@ module Env = struct
     ; joint_combiner : 'a
     ; beta : 'a
     ; gamma : 'a
-    ; unnormalized_lagrange_basis : int -> 'a
+    ; unnormalized_lagrange_basis : bool * int -> 'a
     ; if_feature : Kimchi_types.feature_flag * (unit -> 'a) * (unit -> 'a) -> 'a
     }
 end
@@ -540,13 +540,13 @@ module Tick : S = struct
                       + cell (var (LookupTable, Curr))
                       + (beta * cell (var (LookupTable, Next))) ) ) ) )
             + alpha_pow 25
-              * ( unnormalized_lagrange_basis 0
+              * ( unnormalized_lagrange_basis (false, 0)
                 * ( cell (var (LookupAggreg, Curr))
                   - field
                       "0x0000000000000000000000000000000000000000000000000000000000000001"
                   ) )
             + alpha_pow 26
-              * ( unnormalized_lagrange_basis (-4)
+              * ( unnormalized_lagrange_basis (true, -1)
                 * ( cell (var (LookupAggreg, Curr))
                   - field
                       "0x0000000000000000000000000000000000000000000000000000000000000001"
@@ -555,7 +555,7 @@ module Tick : S = struct
               * if_feature
                   ( LookupsPerRow 1
                   , (fun () ->
-                      unnormalized_lagrange_basis (-4)
+                      unnormalized_lagrange_basis (true, -1)
                       * ( cell (var (LookupSorted 0, Curr))
                         - cell (var (LookupSorted 1, Curr)) ) )
                   , fun () ->
@@ -566,7 +566,7 @@ module Tick : S = struct
               * if_feature
                   ( LookupsPerRow 2
                   , (fun () ->
-                      unnormalized_lagrange_basis 0
+                      unnormalized_lagrange_basis (false, 0)
                       * ( cell (var (LookupSorted 1, Curr))
                         - cell (var (LookupSorted 2, Curr)) ) )
                   , fun () ->
@@ -577,7 +577,7 @@ module Tick : S = struct
               * if_feature
                   ( LookupsPerRow 3
                   , (fun () ->
-                      unnormalized_lagrange_basis (-4)
+                      unnormalized_lagrange_basis (true, -1)
                       * ( cell (var (LookupSorted 2, Curr))
                         - cell (var (LookupSorted 3, Curr)) ) )
                   , fun () ->
@@ -588,7 +588,7 @@ module Tick : S = struct
               * if_feature
                   ( LookupsPerRow 4
                   , (fun () ->
-                      unnormalized_lagrange_basis 0
+                      unnormalized_lagrange_basis (false, 0)
                       * ( cell (var (LookupSorted 3, Curr))
                         - cell (var (LookupSorted 4, Curr)) ) )
                   , fun () ->
@@ -4360,13 +4360,13 @@ module Tock : S = struct
                       + cell (var (LookupTable, Curr))
                       + (beta * cell (var (LookupTable, Next))) ) ) ) )
             + alpha_pow 25
-              * ( unnormalized_lagrange_basis 0
+              * ( unnormalized_lagrange_basis (false, 0)
                 * ( cell (var (LookupAggreg, Curr))
                   - field
                       "0x0000000000000000000000000000000000000000000000000000000000000001"
                   ) )
             + alpha_pow 26
-              * ( unnormalized_lagrange_basis (-4)
+              * ( unnormalized_lagrange_basis (true, -1)
                 * ( cell (var (LookupAggreg, Curr))
                   - field
                       "0x0000000000000000000000000000000000000000000000000000000000000001"
@@ -4375,7 +4375,7 @@ module Tock : S = struct
               * if_feature
                   ( LookupsPerRow 1
                   , (fun () ->
-                      unnormalized_lagrange_basis (-4)
+                      unnormalized_lagrange_basis (true, -1)
                       * ( cell (var (LookupSorted 0, Curr))
                         - cell (var (LookupSorted 1, Curr)) ) )
                   , fun () ->
@@ -4386,7 +4386,7 @@ module Tock : S = struct
               * if_feature
                   ( LookupsPerRow 2
                   , (fun () ->
-                      unnormalized_lagrange_basis 0
+                      unnormalized_lagrange_basis (false, 0)
                       * ( cell (var (LookupSorted 1, Curr))
                         - cell (var (LookupSorted 2, Curr)) ) )
                   , fun () ->
@@ -4397,7 +4397,7 @@ module Tock : S = struct
               * if_feature
                   ( LookupsPerRow 3
                   , (fun () ->
-                      unnormalized_lagrange_basis (-4)
+                      unnormalized_lagrange_basis (true, -1)
                       * ( cell (var (LookupSorted 2, Curr))
                         - cell (var (LookupSorted 3, Curr)) ) )
                   , fun () ->
@@ -4408,7 +4408,7 @@ module Tock : S = struct
               * if_feature
                   ( LookupsPerRow 4
                   , (fun () ->
-                      unnormalized_lagrange_basis 0
+                      unnormalized_lagrange_basis (false, 0)
                       * ( cell (var (LookupSorted 3, Curr))
                         - cell (var (LookupSorted 4, Curr)) ) )
                   , fun () ->


### PR DESCRIPTION
This PR builds upon https://github.com/MinaProtocol/mina/pull/13286, updating the plonk scalar checks for the `zk_rows` added in https://github.com/o1-labs/proof-systems/pull/1087.

This PR is a no-op, with `zk_rows` currently hard-coded to 3.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
