### PR TITLE
Track `num_step_chunks` and `num_wrap_chunks` in pickles, use for proof `Typ.t`s

### DIFF
--- a/src/lib/pickles/commitment_lengths.ml
+++ b/src/lib/pickles/commitment_lengths.ml
@@ -1,10 +1,10 @@
 open Pickles_types
 open Plonk_types
 
-let create (type a) ~(of_int : int -> a) :
+let create (type a) ~num_chunks ~(of_int : int -> a) :
     (a Columns_vec.t, a, a) Messages.Poly.t =
-  let one = of_int 1 in
+  let one = of_int num_chunks in
   { w = Vector.init Plonk_types.Columns.n ~f:(fun _ -> one)
   ; z = one
-  ; t = of_int 7
+  ; t = of_int (7 * num_chunks)
   }

--- a/src/lib/pickles/commitment_lengths.mli
+++ b/src/lib/pickles/commitment_lengths.mli
@@ -2,7 +2,8 @@
 
 (** [create] *)
 val create :
-     of_int:(int -> 'a)
+     num_chunks:int
+  -> of_int:(int -> 'a)
   -> ( 'a Pickles_types.Plonk_types.Columns_vec.t
      , 'a
      , 'a )

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -462,7 +462,7 @@ struct
               (Auxiliary_value)
           in
           M.f full_signature prev_varss_n prev_varss_length ~max_proofs_verified
-            ~num_step_chunks ~feature_flags
+            ~num_step_chunks ~num_wrap_chunks ~feature_flags
       | Some override ->
           Common.wrap_domains
             ~proofs_verified:(Pickles_base.Proofs_verified.to_int override)
@@ -627,8 +627,8 @@ struct
       match override_wrap_main with
       | None ->
           let srs = Tick.Keypair.load_urs () in
-          Wrap_main.wrap_main ~num_step_chunks ~feature_flags ~srs
-            full_signature prev_varss_length step_vks proofs_verifieds
+          Wrap_main.wrap_main ~num_step_chunks ~num_wrap_chunks ~feature_flags
+            ~srs full_signature prev_varss_length step_vks proofs_verifieds
             step_domains max_proofs_verified
       | Some { wrap_main; tweak_statement = _ } ->
           (* Instead of creating a proof using the pickles wrap circuit, we

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -118,6 +118,8 @@ module Side_loaded : sig
        name:string
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'n1)
     -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> num_step_chunks:int
+    -> num_wrap_chunks:int
     -> typ:('var, 'value) Impls.Step.Typ.t
     -> ('var, 'value, 'n1, Verification_key.Max_branches.n) Tag.t
 
@@ -292,6 +294,8 @@ val compile_with_wrap_main_override_promise :
        , 'ret_value )
        Inductive_rule.public_input
   -> auxiliary_typ:('auxiliary_var, 'auxiliary_value) Impls.Step.Typ.t
+  -> num_step_chunks:int
+  -> num_wrap_chunks:int
   -> branches:(module Nat.Intf with type n = 'branches)
   -> max_proofs_verified:(module Nat.Add.Intf with type n = 'max_proofs_verified)
   -> name:string

--- a/src/lib/pickles/dummy.ml
+++ b/src/lib/pickles/dummy.ml
@@ -6,10 +6,12 @@ open Common
 
 let _wrap_domains = Common.wrap_domains
 
-let evals =
+let evals ~num_wrap_chunks =
   let open Plonk_types in
   let e =
-    Evals.map (Evaluation_lengths.create ~of_int:Fn.id) ~f:(fun n ->
+    Evals.map
+      (Evaluation_lengths.create ~num_chunks:num_wrap_chunks ~of_int:Fn.id)
+      ~f:(fun n ->
         let a () = Array.create ~len:n (Ro.tock ()) in
         (a (), a ()) )
   in
@@ -21,7 +23,7 @@ let evals =
   { All_evals.ft_eval1 = Ro.tock (); evals = ex }
 
 let evals_combined =
-  Plonk_types.All_evals.map evals ~f1:Fn.id
+  Plonk_types.All_evals.map (evals ~num_wrap_chunks:1) ~f1:Fn.id
     ~f2:(Array.reduce_exn ~f:Backend.Tock.Field.( + ))
 
 module Ipa = struct

--- a/src/lib/pickles/dummy.mli
+++ b/src/lib/pickles/dummy.mli
@@ -40,9 +40,10 @@ end
 
 (** [evals] is a constant *)
 val evals :
-  ( Backend.Tock.Field.t
-  , Backend.Tock.Field.t array )
-  Pickles_types.Plonk_types.All_evals.t
+     num_wrap_chunks:int
+  -> ( Backend.Tock.Field.t
+     , Backend.Tock.Field.t array )
+     Pickles_types.Plonk_types.All_evals.t
 
 (** [evals_combined] is a constant *)
 val evals_combined :

--- a/src/lib/pickles/evaluation_lengths.ml
+++ b/src/lib/pickles/evaluation_lengths.ml
@@ -1,5 +1,5 @@
-let create ~of_int =
-  let one = of_int 1 in
+let create ~num_chunks ~of_int =
+  let one = of_int num_chunks in
   let open Pickles_types in
   let open Plonk_types in
   Evals.

--- a/src/lib/pickles/evaluation_lengths.mli
+++ b/src/lib/pickles/evaluation_lengths.mli
@@ -2,4 +2,4 @@
 
 type 'a t := 'a Pickles_types.Plonk_types.Evals.t
 
-val create : of_int:(int -> 'a) -> 'a t
+val create : num_chunks:int -> of_int:(int -> 'a) -> 'a t

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -139,7 +139,7 @@ module Constant = struct
   end
 end
 
-let typ (type n avar aval) ~feature_flags ~num_wrap_chunks
+let typ (type n avar aval) ~feature_flags ~num_step_chunks ~num_wrap_chunks
     (statement : (avar, aval) Impls.Step.Typ.t) (max_proofs_verified : n Nat.t)
     =
   let module Sc = Scalar_challenge in
@@ -162,7 +162,7 @@ let typ (type n avar aval) ~feature_flags ~num_wrap_chunks
         (Branch_data.typ
            (module Impl)
            ~assert_16_bits:(Step_verifier.assert_n_bits ~n:16) )
-    ; Plonk_types.All_evals.typ
+    ; Plonk_types.All_evals.typ ~num_chunks:num_step_chunks
         (module Impl)
         (* Assume we have lookup iff we have runtime tables *)
         feature_flags

--- a/src/lib/pickles/per_proof_witness.ml
+++ b/src/lib/pickles/per_proof_witness.ml
@@ -139,7 +139,7 @@ module Constant = struct
   end
 end
 
-let typ (type n avar aval) ~feature_flags
+let typ (type n avar aval) ~feature_flags ~num_wrap_chunks
     (statement : (avar, aval) Impls.Step.Typ.t) (max_proofs_verified : n Nat.t)
     =
   let module Sc = Scalar_challenge in
@@ -150,7 +150,7 @@ let typ (type n avar aval) ~feature_flags
     ~var_of_hlist:of_hlist ~value_to_hlist:Constant.to_hlist
     ~value_of_hlist:Constant.of_hlist
     [ statement
-    ; Wrap_proof.typ
+    ; Wrap_proof.typ ~num_wrap_chunks
     ; Types.Wrap.Proof_state.In_circuit.typ
         (module Impl)
         ~challenge:Challenge.typ ~scalar_challenge:Challenge.typ ~feature_flags

--- a/src/lib/pickles/per_proof_witness.mli
+++ b/src/lib/pickles/per_proof_witness.mli
@@ -118,6 +118,7 @@ end
 
 val typ :
      feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> num_step_chunks:int
   -> num_wrap_chunks:int
   -> ('avar, 'aval) Impl.Typ.t
   -> 'n Pickles_types.Nat.t

--- a/src/lib/pickles/per_proof_witness.mli
+++ b/src/lib/pickles/per_proof_witness.mli
@@ -118,6 +118,7 @@ end
 
 val typ :
      feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> num_wrap_chunks:int
   -> ('avar, 'aval) Impl.Typ.t
   -> 'n Pickles_types.Nat.t
   -> (('avar, 'n, _) t, ('aval, 'n) Constant.t) Impl.Typ.t

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1147,7 +1147,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
               Wrap_domains.Make (A) (A_value) (A) (A_value) (A) (A_value)
             in
             M.f full_signature prev_varss_n prev_varss_length ~feature_flags
-              ~num_step_chunks
+              ~num_step_chunks ~num_wrap_chunks
               ~max_proofs_verified:(module Max_proofs_verified)
           in
           let module Branch_data = struct

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -77,7 +77,8 @@ module type S = sig
     type ('max_width, 'mlmb) t
 
     val dummy :
-         ?num_wrap_chunks:int
+         ?num_step_chunks:int
+      -> ?num_wrap_chunks:int
       -> 'w Nat.t
       -> 'm Nat.t
       -> _ Nat.t

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -76,7 +76,13 @@ module type S = sig
   module Proof : sig
     type ('max_width, 'mlmb) t
 
-    val dummy : 'w Nat.t -> 'm Nat.t -> _ Nat.t -> domain_log2:int -> ('w, 'm) t
+    val dummy :
+         ?num_wrap_chunks:int
+      -> 'w Nat.t
+      -> 'm Nat.t
+      -> _ Nat.t
+      -> domain_log2:int
+      -> ('w, 'm) t
 
     module Make (W : Nat.Intf) (MLMB : Nat.Intf) : sig
       type nonrec t = (W.n, MLMB.n) t [@@deriving sexp, compare, yojson, hash]
@@ -334,6 +340,8 @@ module type S = sig
          name:string
       -> max_proofs_verified:(module Nat.Add.Intf with type n = 'n1)
       -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+      -> num_step_chunks:int
+      -> num_wrap_chunks:int
       -> typ:('var, 'value) Impls.Step.Typ.t
       -> ('var, 'value, 'n1, Verification_key.Max_branches.n) Tag.t
 
@@ -397,6 +405,8 @@ module type S = sig
              , 'auxiliary_var
              , 'auxiliary_value )
              H4_6.T(Inductive_rule).t )
+    -> ?num_step_chunks:int
+    -> ?num_wrap_chunks:int
     -> unit
     -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
        * Cache_handle.t
@@ -450,6 +460,8 @@ module type S = sig
              , 'auxiliary_var
              , 'auxiliary_value )
              H4_6.T(Inductive_rule).t )
+    -> ?num_step_chunks:int
+    -> ?num_wrap_chunks:int
     -> unit
     -> ('var, 'value, 'max_proofs_verified, 'branches) Tag.t
        * Cache_handle.t

--- a/src/lib/pickles/proof.ml
+++ b/src/lib/pickles/proof.ml
@@ -110,13 +110,15 @@ end
 
 type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) With_data.t
 
-let dummy (type w h r) (_w : w Nat.t) (h : h Nat.t)
+let dummy (type w h r) ?(num_wrap_chunks = 1) (_w : w Nat.t) (h : h Nat.t)
     (most_recent_width : r Nat.t) ~domain_log2 : (w, h) t =
   let open Ro in
   let g0 = Tock.Curve.(to_affine_exn one) in
   let g len = Array.create ~len g0 in
   let tick_arr len = Array.init len ~f:(fun _ -> tick ()) in
-  let lengths = Commitment_lengths.create ~of_int:Fn.id in
+  let lengths =
+    Commitment_lengths.create ~num_chunks:num_wrap_chunks ~of_int:Fn.id
+  in
   T
     { statement =
         { proof_state =

--- a/src/lib/pickles/proof.mli
+++ b/src/lib/pickles/proof.mli
@@ -105,7 +105,8 @@ type ('s, 'mlmb, 'c) with_data =
 type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) with_data
 
 val dummy :
-     'w Pickles_types.Nat.t
+     ?num_wrap_chunks:int
+  -> 'w Pickles_types.Nat.t
   -> 'h Pickles_types.Nat.t
   -> 'r Pickles_types.Nat.t
   -> domain_log2:int

--- a/src/lib/pickles/proof.mli
+++ b/src/lib/pickles/proof.mli
@@ -105,7 +105,8 @@ type ('s, 'mlmb, 'c) with_data =
 type ('max_width, 'mlmb) t = (unit, 'mlmb, 'max_width) with_data
 
 val dummy :
-     ?num_wrap_chunks:int
+     ?num_step_chunks:int
+  -> ?num_wrap_chunks:int
   -> 'w Pickles_types.Nat.t
   -> 'h Pickles_types.Nat.t
   -> 'r Pickles_types.Nat.t

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -872,6 +872,14 @@ struct
       }
     in
     [%log internal] "Pickles_step_proof_done" ;
+    let dummy_evals =
+      (* TODO: This isn't really right, because we don't necessarily have
+         homogeneity any more if the num_wrap_chunks != 1. We only really need
+         this for proofs that will be side-loaded (e.g. zkApps) anyway, we
+         should make this padding opt-out-able.
+      *)
+      Dummy.evals ~num_wrap_chunks:1
+    in
     ( { Proof.Base.Step.proof = next_proof.proof
       ; statement = next_statement
       ; index = branch_data.index
@@ -884,7 +892,7 @@ struct
                    ; evals =
                        { With_public_input.evals = es; public_input = x_hat }
                    } ) )
-            lte Max_proofs_verified.n Dummy.evals
+            lte Max_proofs_verified.n dummy_evals
       }
     , Option.value_exn !return_value
     , Option.value_exn !auxiliary_value

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -75,6 +75,7 @@ let create
     ~wrap_domains
     ~(feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t)
     ~(actual_feature_flags : bool Plonk_types.Features.t)
+    ~(num_step_chunks : int) ~(num_wrap_chunks : int)
     ~(max_proofs_verified : max_proofs_verified Nat.t)
     ~(proofs_verifieds : (int, branches) Vector.t) ~(branches : branches Nat.t)
     ~(public_input :
@@ -142,6 +143,8 @@ let create
         ; wrap_domains
         ; step_domains
         ; feature_flags
+        ; num_step_chunks
+        ; num_wrap_chunks
         }
       ~public_input ~auxiliary_typ ~self_branches:branches ~proofs_verified
       ~local_signature:widths ~local_signature_length ~local_branches:heights

--- a/src/lib/pickles/step_branch_data.mli
+++ b/src/lib/pickles/step_branch_data.mli
@@ -72,6 +72,8 @@ val create :
   -> wrap_domains:Import.Domains.t
   -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
   -> actual_feature_flags:bool Plonk_types.Features.t
+  -> num_step_chunks:int
+  -> num_wrap_chunks:int
   -> max_proofs_verified:'max_proofs_verified Pickles_types.Nat.t
   -> proofs_verifieds:(int, 'branches) Pickles_types.Vector.t
   -> branches:'branches Pickles_types.Nat.t

--- a/src/lib/pickles/types_map.mli
+++ b/src/lib/pickles/types_map.mli
@@ -15,6 +15,8 @@ module Basic : sig
         Pickles_types.Plonk_verification_key_evals.t
     ; wrap_vk : Impls.Wrap.Verification_key.t
     ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; num_step_chunks : int
+    ; num_wrap_chunks : int
     }
 end
 
@@ -37,6 +39,8 @@ module Side_loaded : sig
       ; public_input : ('var, 'value) Impls.Step.Typ.t
       ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
       ; branches : 'n2 Pickles_types.Nat.t
+      ; num_step_chunks : int
+      ; num_wrap_chunks : int
       }
   end
 
@@ -59,6 +63,8 @@ module Compiled : sig
     ; wrap_domains : Import.Domains.t
     ; step_domains : (Import.Domains.t, 'branches) Pickles_types.Vector.t
     ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; num_step_chunks : int
+    ; num_wrap_chunks : int
     }
 
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) t =
@@ -76,6 +82,8 @@ module Compiled : sig
     ; wrap_domains : Import.Domains.t
     ; step_domains : (Import.Domains.t, 'branches) Pickles_types.Vector.t
     ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; num_step_chunks : int
+    ; num_wrap_chunks : int
     }
 end
 
@@ -97,6 +105,8 @@ module For_step : sig
         [ `Known of (Import.Domains.t, 'branches) Pickles_types.Vector.t
         | `Side_loaded ]
     ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; num_step_chunks : int
+    ; num_wrap_chunks : int
     }
 
   val of_side_loaded : ('a, 'b, 'c, 'd) Side_loaded.t -> ('a, 'b, 'c, 'd) t
@@ -134,3 +144,7 @@ val add_exn :
 val set_ephemeral : _ Tag.t -> Side_loaded.Ephemeral.t -> unit
 
 val public_input : ('var, 'value, _, _) Tag.t -> ('var, 'value) Impls.Step.Typ.t
+
+val num_step_chunks : _ Tag.t -> int
+
+val num_wrap_chunks : _ Tag.t -> int

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -429,7 +429,9 @@ let%test_module "gate finalization" =
          for use in the circuit *)
       and evals =
         constant
-          (Plonk_types.All_evals.typ (module Impls.Step) feature_flags)
+          (Plonk_types.All_evals.typ ~num_chunks:1
+             (module Impls.Step)
+             feature_flags )
           { evals = { public_input = x_hat_evals; evals = proof.openings.evals }
           ; ft_eval1 = proof.openings.ft_eval1
           }

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -15,8 +15,8 @@ module Make
     (Auxiliary_var : T0)
     (Auxiliary_value : T0) =
 struct
-  let f_debug full_signature _num_choices choices_length ~feature_flags
-      ~max_proofs_verified =
+  let f_debug full_signature _num_choices choices_length ~num_step_chunks
+      ~feature_flags ~max_proofs_verified =
     let num_choices = Hlist.Length.to_nat choices_length in
     let dummy_step_domains =
       Vector.init num_choices ~f:(fun _ -> Fix_domains.rough_domains)
@@ -34,8 +34,9 @@ struct
     Timer.clock __LOC__ ;
     let srs = Backend.Tick.Keypair.load_urs () in
     let _, main =
-      Wrap_main.wrap_main ~feature_flags ~srs full_signature choices_length
-        dummy_step_keys dummy_step_widths dummy_step_domains max_proofs_verified
+      Wrap_main.wrap_main ~num_step_chunks ~feature_flags ~srs full_signature
+        choices_length dummy_step_keys dummy_step_widths dummy_step_domains
+        max_proofs_verified
     in
     Timer.clock __LOC__ ;
     let t =
@@ -47,16 +48,16 @@ struct
     in
     Timer.clock __LOC__ ; t
 
-  let f full_signature num_choices choices_length ~feature_flags
-      ~max_proofs_verified =
+  let f full_signature num_choices choices_length ~num_step_chunks
+      ~feature_flags ~max_proofs_verified =
     let res =
       Common.wrap_domains
         ~proofs_verified:(Nat.to_int (Nat.Add.n max_proofs_verified))
     in
     ( if debug then
       let res' =
-        f_debug full_signature num_choices choices_length ~feature_flags
-          ~max_proofs_verified
+        f_debug full_signature num_choices choices_length ~num_step_chunks
+          ~feature_flags ~max_proofs_verified
       in
       [%test_eq: Domains.t] res res' ) ;
     res

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -16,7 +16,7 @@ module Make
     (Auxiliary_value : T0) =
 struct
   let f_debug full_signature _num_choices choices_length ~num_step_chunks
-      ~feature_flags ~max_proofs_verified =
+      ~num_wrap_chunks ~feature_flags ~max_proofs_verified =
     let num_choices = Hlist.Length.to_nat choices_length in
     let dummy_step_domains =
       Vector.init num_choices ~f:(fun _ -> Fix_domains.rough_domains)
@@ -34,9 +34,9 @@ struct
     Timer.clock __LOC__ ;
     let srs = Backend.Tick.Keypair.load_urs () in
     let _, main =
-      Wrap_main.wrap_main ~num_step_chunks ~feature_flags ~srs full_signature
-        choices_length dummy_step_keys dummy_step_widths dummy_step_domains
-        max_proofs_verified
+      Wrap_main.wrap_main ~num_step_chunks ~num_wrap_chunks ~feature_flags ~srs
+        full_signature choices_length dummy_step_keys dummy_step_widths
+        dummy_step_domains max_proofs_verified
     in
     Timer.clock __LOC__ ;
     let t =
@@ -49,7 +49,7 @@ struct
     Timer.clock __LOC__ ; t
 
   let f full_signature num_choices choices_length ~num_step_chunks
-      ~feature_flags ~max_proofs_verified =
+      ~num_wrap_chunks ~feature_flags ~max_proofs_verified =
     let res =
       Common.wrap_domains
         ~proofs_verified:(Nat.to_int (Nat.Add.n max_proofs_verified))
@@ -57,7 +57,7 @@ struct
     ( if debug then
       let res' =
         f_debug full_signature num_choices choices_length ~num_step_chunks
-          ~feature_flags ~max_proofs_verified
+          ~num_wrap_chunks ~feature_flags ~max_proofs_verified
       in
       [%test_eq: Domains.t] res res' ) ;
     res

--- a/src/lib/pickles/wrap_domains.mli
+++ b/src/lib/pickles/wrap_domains.mli
@@ -13,6 +13,7 @@ module Make
        ('a, 'b, 'c) Full_signature.t
     -> 'd
     -> ('e, 'b) Hlist.Length.t
+    -> num_step_chunks:int
     -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'a)
     -> Import.Domains.t
@@ -21,6 +22,7 @@ module Make
        ('a, 'b, 'c) Full_signature.t
     -> 'd
     -> ('e, 'b) Hlist.Length.t
+    -> num_step_chunks:int
     -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'a)
     -> Import.Domains.Stable.V2.t

--- a/src/lib/pickles/wrap_domains.mli
+++ b/src/lib/pickles/wrap_domains.mli
@@ -14,6 +14,7 @@ module Make
     -> 'd
     -> ('e, 'b) Hlist.Length.t
     -> num_step_chunks:int
+    -> num_wrap_chunks:int
     -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'a)
     -> Import.Domains.t
@@ -23,6 +24,7 @@ module Make
     -> 'd
     -> ('e, 'b) Hlist.Length.t
     -> num_step_chunks:int
+    -> num_wrap_chunks:int
     -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'a)
     -> Import.Domains.Stable.V2.t

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -91,7 +91,7 @@ let lookup_config_for_pack =
 (* The SNARK function for wrapping any proof coming from the given set of keys *)
 let wrap_main
     (type max_proofs_verified branches prev_varss max_local_max_proofs_verifieds)
-    ~feature_flags
+    ~feature_flags ~num_step_chunks
     (full_signature :
       ( max_proofs_verified
       , branches
@@ -418,7 +418,8 @@ let wrap_main
                      Inner_curve.typ ~bool:Boolean.typ feature_flags
                      ~dummy:Inner_curve.Params.one
                      ~commitment_lengths:
-                       (Commitment_lengths.create ~of_int:Fn.id) )
+                       (Commitment_lengths.create ~num_chunks:num_step_chunks
+                          ~of_int:Fn.id ) )
                   ~request:(fun () -> Req.Messages) )
           in
           let sponge = Wrap_verifier.Opt.create sponge_params in

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -91,7 +91,7 @@ let lookup_config_for_pack =
 (* The SNARK function for wrapping any proof coming from the given set of keys *)
 let wrap_main
     (type max_proofs_verified branches prev_varss max_local_max_proofs_verifieds)
-    ~feature_flags ~num_step_chunks
+    ~feature_flags ~num_step_chunks ~num_wrap_chunks
     (full_signature :
       ( max_proofs_verified
       , branches
@@ -263,7 +263,9 @@ let wrap_main
               let evals =
                 let ty =
                   let ty =
-                    Plonk_types.All_evals.typ (module Impl) feature_flags
+                    Plonk_types.All_evals.typ
+                      (module Impl)
+                      ~num_chunks:num_wrap_chunks feature_flags
                   in
                   Vector.typ ty Max_proofs_verified.n
                 in

--- a/src/lib/pickles/wrap_main.mli
+++ b/src/lib/pickles/wrap_main.mli
@@ -5,6 +5,7 @@ open Pickles_types
 val wrap_main :
      feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
   -> num_step_chunks:int
+  -> num_wrap_chunks:int
   -> ( 'max_proofs_verified
      , 'branches
      , 'max_local_max_proofs_verifieds )

--- a/src/lib/pickles/wrap_main.mli
+++ b/src/lib/pickles/wrap_main.mli
@@ -4,6 +4,7 @@ open Pickles_types
     keys **)
 val wrap_main :
      feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> num_step_chunks:int
   -> ( 'max_proofs_verified
      , 'branches
      , 'max_local_max_proofs_verifieds )

--- a/src/lib/pickles/wrap_proof.ml
+++ b/src/lib/pickles/wrap_proof.ml
@@ -30,7 +30,7 @@ end
 
 open Impls.Step
 
-let typ : (Checked.t, Constant.t) Typ.t =
+let typ ~num_wrap_chunks : (Checked.t, Constant.t) Typ.t =
   let shift = Shifted_value.Type2.Shift.create (module Tock.Field) in
   Typ.of_hlistable ~var_to_hlist:Checked.to_hlist ~var_of_hlist:Checked.of_hlist
     ~value_to_hlist:Constant.to_hlist ~value_of_hlist:Constant.of_hlist
@@ -38,7 +38,9 @@ let typ : (Checked.t, Constant.t) Typ.t =
         (module Impl)
         Inner_curve.typ Plonk_types.Features.none ~bool:Boolean.typ
         ~dummy:Inner_curve.Params.one
-        ~commitment_lengths:(Commitment_lengths.create ~of_int:(fun x -> x))
+        ~commitment_lengths:
+          (Commitment_lengths.create ~num_chunks:num_wrap_chunks
+             ~of_int:(fun x -> x) )
     ; Types.Step.Bulletproof.typ ~length:(Nat.to_int Tock.Rounds.n)
         ( Typ.transport Other_field.typ
             ~there:(fun x ->

--- a/src/lib/pickles/wrap_proof.mli
+++ b/src/lib/pickles/wrap_proof.mli
@@ -28,4 +28,4 @@ module Checked : sig
   [@@deriving hlist]
 end
 
-val typ : (Checked.t, Constant.t) Impls.Step.Typ.t
+val typ : num_wrap_chunks:int -> (Checked.t, Constant.t) Impls.Step.Typ.t

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -690,9 +690,9 @@ module All_evals = struct
 
   let typ (type f)
       (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
-      lookup_config =
+      ~num_chunks lookup_config =
     let open Impl.Typ in
-    let single = array ~length:1 field in
+    let single = array ~length:num_chunks field in
     let evals =
       With_public_input.typ
         (module Impl)

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -362,6 +362,7 @@ module All_evals : sig
 
   val typ :
        (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+    -> num_chunks:int
     -> Opt.Flag.t Features.t
     -> ( ( 'f Snarky_backendless.Cvar.t
          , 'f Snarky_backendless.Cvar.t array

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -620,7 +620,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         (fun i ->
           let open Zkapp_statement in
           Pickles.Side_loaded.create ~typ ~name:(sprintf "zkapp_%d" i)
-            ~feature_flags
+            ~feature_flags ~num_step_chunks:1 ~num_wrap_chunks:1
             ~max_proofs_verified:
               (module Pickles.Side_loaded.Verification_key.Max_width) )
 


### PR DESCRIPTION
This PR builds on #13357.

This PR adds tracking for user-specified `num_step_chunks` and `num_wrap_chunks` in the pickles `Type_map`. These values are then used to alter the number of chunks for evaluations and commitments in the `Typ.t`s.

This PR is a no-op when `num_step_chunks` and `num_wrap_chunks` are unchanged.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
