### PR TITLE
Carry multiple chunks in the verifier index commitments

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
+++ b/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
@@ -182,11 +182,11 @@ module Make (Inputs : Inputs_intf) = struct
 
   (** does this convert a backend.verifier_index to a pickles_types.verifier_index? *)
   let vk_commitments (t : Inputs.Verifier_index.t) :
-      Inputs.Curve.Affine.t Pickles_types.Plonk_verification_key_evals.t =
-    let g c : Inputs.Curve.Affine.t =
+      Inputs.Curve.Affine.t array Pickles_types.Plonk_verification_key_evals.t =
+    let g c : Inputs.Curve.Affine.t array =
       match Inputs.Poly_comm.of_backend_without_degree_bound c with
       | `Without_degree_bound x ->
-          x.(0)
+          x
       | `With_degree_bound _ ->
           assert false
     in

--- a/src/lib/pickles/common.mli
+++ b/src/lib/pickles/common.mli
@@ -42,7 +42,7 @@ val ft_comm :
   -> scale:('a -> 'b -> 'a)
   -> endoscale:('a -> 'c -> 'a)
   -> negate:('a -> 'a)
-  -> verification_key:'a Pickles_types.Plonk_verification_key_evals.t
+  -> verification_key:'a array Pickles_types.Plonk_verification_key_evals.t
   -> alpha:'c
   -> plonk:
        ( 'd

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -154,7 +154,7 @@ type ('max_proofs_verified, 'branches, 'prev_varss) wrap_main_generic =
          , 'max_local_max_proofs_verifieds )
          Full_signature.t
       -> ('prev_varss, 'branches) Hlist.Length.t
-      -> ( Wrap_main_inputs.Inner_curve.Constant.t Wrap_verifier.index'
+      -> ( Wrap_main_inputs.Inner_curve.Constant.t array Wrap_verifier.index'
          , 'branches )
          Vector.t
          Lazy.t

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -647,7 +647,7 @@ module Wrap : sig
             (** The actual application-level state (e.g., for Mina, this is the
                 protocol state which contains the merkle root of the ledger,
                 state related to consensus, etc.) *)
-      ; dlog_plonk_index : 'g Plonk_verification_key_evals.t
+      ; dlog_plonk_index : 'g array Plonk_verification_key_evals.t
             (** The verification key corresponding to the wrap-circuit for this
                 recursive proof system.  It gets threaded through all the
                 circuits so that the step circuits can verify proofs against
@@ -671,7 +671,8 @@ module Wrap : sig
       -> 'f Core_kernel.Array.t
 
     val typ :
-         ('a, 'b, 'c) Snarky_backendless.Typ.t
+         num_step_chunks:int
+      -> ('a, 'b, 'c) Snarky_backendless.Typ.t
       -> ('d, 'e, 'c) Snarky_backendless.Typ.t
       -> ( 'f
          , 'g

--- a/src/lib/pickles/reduced_messages_for_next_proof_over_same_field.mli
+++ b/src/lib/pickles/reduced_messages_for_next_proof_over_same_field.mli
@@ -35,7 +35,7 @@ module Step : sig
   [@@deriving sexp, yojson, sexp, compare, hash, equal]
 
   val prepare :
-       dlog_plonk_index:'a Pickles_types.Plonk_verification_key_evals.t
+       dlog_plonk_index:'a array Pickles_types.Plonk_verification_key_evals.t
     -> ( 'b
        , 'c
        , ( ( Import.Challenge.Constant.t Import.Scalar_challenge.t

--- a/src/lib/pickles/requests.ml
+++ b/src/lib/pickles/requests.ml
@@ -138,7 +138,7 @@ module Step = struct
           , local_branches )
           H3.T(Per_proof_witness.Constant.No_app_state).t
           t
-      | Wrap_index : Tock.Curve.Affine.t Plonk_verification_key_evals.t t
+      | Wrap_index : Tock.Curve.Affine.t array Plonk_verification_key_evals.t t
       | App_state : statement t
       | Return_value : return_value -> unit t
       | Auxiliary_value : auxiliary_value -> unit t
@@ -192,7 +192,8 @@ module Step = struct
             , local_branches )
             H3.T(Per_proof_witness.Constant.No_app_state).t
             t
-        | Wrap_index : Tock.Curve.Affine.t Plonk_verification_key_evals.t t
+        | Wrap_index :
+            Tock.Curve.Affine.t array Plonk_verification_key_evals.t t
         | App_state : statement t
         | Return_value : return_value -> unit t
         | Auxiliary_value : auxiliary_value -> unit t

--- a/src/lib/pickles/requests.mli
+++ b/src/lib/pickles/requests.mli
@@ -31,7 +31,7 @@ module Step : sig
           Hlist.H3.T(Per_proof_witness.Constant.No_app_state).t
           Snarky_backendless.Request.t
       | Wrap_index :
-          Backend.Tock.Curve.Affine.t Plonk_verification_key_evals.t
+          Backend.Tock.Curve.Affine.t array Plonk_verification_key_evals.t
           Snarky_backendless.Request.t
       | App_state : statement Snarky_backendless.Request.t
       | Return_value : return_value -> unit Snarky_backendless.Request.t

--- a/src/lib/pickles/step.mli
+++ b/src/lib/pickles/step.mli
@@ -32,7 +32,7 @@ module Make
     -> step_domains:(Import.Domains.t, 'self_branches) Pickles_types.Vector.t
     -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
     -> self_dlog_plonk_index:
-         Backend.Tick.Inner_curve.Affine.t
+         Backend.Tick.Inner_curve.Affine.t array
          Pickles_types.Plonk_verification_key_evals.t
     -> public_input:
          ( 'var

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -357,7 +357,8 @@ let step_main :
         let dlog_plonk_index =
           exists
             ~request:(fun () -> Req.Wrap_index)
-            (Plonk_verification_key_evals.typ Inner_curve.typ)
+            (Plonk_verification_key_evals.typ
+               (Typ.array ~length:basic.num_wrap_chunks Inner_curve.typ) )
         and prevs =
           exists (Prev_typ.f prev_proof_typs) ~request:(fun () ->
               Req.Proof_with_datas )

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -572,12 +572,10 @@ struct
           let without_degree_bound =
             Vector.append
               (Vector.map sg_old ~f:(fun g -> [| g |]))
-              ( [| x_hat |] :: [| ft_comm |] :: z_comm :: [| m.generic_comm |]
-              :: [| m.psm_comm |]
+              ( [| x_hat |] :: [| ft_comm |] :: z_comm :: m.generic_comm
+              :: m.psm_comm
               :: Vector.append w_comm
-                   (Vector.append
-                      (Vector.map m.coefficients_comm ~f:(fun g -> [| g |]))
-                      (Vector.map sigma_comm_init ~f:(fun g -> [| g |]))
+                   (Vector.append m.coefficients_comm sigma_comm_init
                       (snd Plonk_types.(Columns.add Permuts_minus_1.n)) )
                    (snd
                       Plonk_types.(
@@ -1081,8 +1079,9 @@ struct
     let sponge = Sponge.create sponge_params in
     Array.iter
       (Types.index_to_field_elements
-         ~g:(fun (z : Inputs.Inner_curve.t) ->
-           List.to_array (Inner_curve.to_field_elements z) )
+         ~g:(fun (z : Inputs.Inner_curve.t array) ->
+           Array.concat_map z ~f:(fun z ->
+               List.to_array (Inner_curve.to_field_elements z) ) )
          index )
       ~f:(fun x -> Sponge.absorb sponge (`Field x)) ;
     sponge

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -80,7 +80,7 @@ val finalize_other_proof :
 
 val hash_messages_for_next_step_proof :
      index:
-       Step_main_inputs.Inner_curve.t
+       Step_main_inputs.Inner_curve.t array
        Pickles_types.Plonk_verification_key_evals.t
   -> ('s -> Step_main_inputs.Impl.Field.t array)
   -> (   ( 'a
@@ -95,7 +95,7 @@ val hash_messages_for_next_step_proof :
 
 val hash_messages_for_next_step_proof_opt :
      index:
-       Step_main_inputs.Inner_curve.t
+       Step_main_inputs.Inner_curve.t array
        Pickles_types.Plonk_verification_key_evals.t
   -> ('s -> Step_main_inputs.Impl.Field.t array)
   -> Step_main_inputs.Sponge.t
@@ -136,7 +136,7 @@ val verify :
          Step_main_inputs.Impl.field
          Composition_types.Branch_data.Proofs_verified.One_hot.Checked.t ]
   -> wrap_verification_key:
-       Step_main_inputs.Inner_curve.t
+       Step_main_inputs.Inner_curve.t array
        Pickles_types.Plonk_verification_key_evals.t
   -> ( Step_main_inputs.Impl.field Limb_vector.Challenge.t
      , Step_main_inputs.Impl.field Limb_vector.Challenge.t

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -16,7 +16,7 @@ module Basic = struct
     ; public_input : ('var, 'value) Impls.Step.Typ.t
     ; branches : 'n2 Nat.t
     ; wrap_domains : Domains.t
-    ; wrap_key : Tick.Inner_curve.Affine.t Plonk_verification_key_evals.t
+    ; wrap_key : Tick.Inner_curve.Affine.t array Plonk_verification_key_evals.t
     ; wrap_vk : Impls.Wrap.Verification_key.t
     ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
     ; num_step_chunks : int
@@ -80,7 +80,7 @@ module Side_loaded = struct
     ; public_input
     ; branches
     ; wrap_domains = Common.wrap_domains ~proofs_verified
-    ; wrap_key
+    ; wrap_key = Plonk_verification_key_evals.map ~f:(fun x -> [| x |]) wrap_key
     ; feature_flags
     ; num_step_chunks
     ; num_wrap_chunks
@@ -109,7 +109,8 @@ module Compiled = struct
     ; proofs_verifieds : (int, 'branches) Vector.t
           (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; public_input : ('a_var, 'a_value) Impls.Step.Typ.t
-    ; wrap_key : Tick.Inner_curve.Affine.t Plonk_verification_key_evals.t Lazy.t
+    ; wrap_key :
+        Tick.Inner_curve.Affine.t array Plonk_verification_key_evals.t Lazy.t
     ; wrap_vk : Impls.Wrap.Verification_key.t Lazy.t
     ; wrap_domains : Domains.t
     ; step_domains : (Domains.t, 'branches) Vector.t
@@ -154,7 +155,7 @@ module For_step = struct
     ; proofs_verifieds :
         [ `Known of (Impls.Step.Field.t, 'branches) Vector.t | `Side_loaded ]
     ; public_input : ('a_var, 'a_value) Impls.Step.Typ.t
-    ; wrap_key : inner_curve_var Plonk_verification_key_evals.t
+    ; wrap_key : inner_curve_var array Plonk_verification_key_evals.t
     ; wrap_domain :
         [ `Known of Domain.t
         | `Side_loaded of
@@ -189,7 +190,8 @@ module For_step = struct
     ; max_proofs_verified
     ; public_input
     ; proofs_verifieds = `Side_loaded
-    ; wrap_key = index.wrap_index
+    ; wrap_key =
+        Plonk_verification_key_evals.map ~f:(fun x -> [| x |]) index.wrap_index
     ; wrap_domain = `Side_loaded index.actual_wrap_domain_size
     ; step_domains = `Side_loaded
     ; feature_flags
@@ -218,7 +220,7 @@ module For_step = struct
     ; public_input
     ; wrap_key =
         Plonk_verification_key_evals.map (Lazy.force wrap_key)
-          ~f:Step_main_inputs.Inner_curve.constant
+          ~f:(Array.map ~f:Step_main_inputs.Inner_curve.constant)
     ; wrap_domain = `Known wrap_domains.h
     ; step_domains = `Known step_domains
     ; feature_flags

--- a/src/lib/pickles/types_map.mli
+++ b/src/lib/pickles/types_map.mli
@@ -11,7 +11,7 @@ module Basic : sig
     ; branches : 'n2 Pickles_types.Nat.t
     ; wrap_domains : Import.Domains.t
     ; wrap_key :
-        Backend.Tick.Inner_curve.Affine.t
+        Backend.Tick.Inner_curve.Affine.t array
         Pickles_types.Plonk_verification_key_evals.t
     ; wrap_vk : Impls.Wrap.Verification_key.t
     ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
@@ -75,7 +75,7 @@ module Compiled : sig
           (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; public_input : ('a_var, 'a_value) Impls.Step.Typ.t
     ; wrap_key :
-        Backend.Tick.Inner_curve.Affine.t
+        Backend.Tick.Inner_curve.Affine.t array
         Pickles_types.Plonk_verification_key_evals.t
         Lazy.t
     ; wrap_vk : Impls.Wrap.Verification_key.t Lazy.t
@@ -96,7 +96,8 @@ module For_step : sig
         [ `Known of (Impls.Step.Field.t, 'branches) Pickles_types.Vector.t
         | `Side_loaded ]
     ; public_input : ('a_var, 'a_value) Impls.Step.Typ.t
-    ; wrap_key : inner_curve_var Pickles_types.Plonk_verification_key_evals.t
+    ; wrap_key :
+        inner_curve_var array Pickles_types.Plonk_verification_key_evals.t
     ; wrap_domain :
         [ `Known of Import.Domain.t
         | `Side_loaded of

--- a/src/lib/pickles/verification_key.ml
+++ b/src/lib/pickles/verification_key.ml
@@ -124,7 +124,8 @@ end
 module Stable = struct
   module V2 = struct
     type t =
-      { commitments : Backend.Tock.Curve.Affine.t Plonk_verification_key_evals.t
+      { commitments :
+          Backend.Tock.Curve.Affine.t array Plonk_verification_key_evals.t
       ; index :
           (Impls.Wrap.Verification_key.t
           [@to_yojson
@@ -172,7 +173,10 @@ module Stable = struct
         ; lookup_index = None
         }
       in
-      { commitments = c; data = d; index = t }
+      { commitments = Plonk_verification_key_evals.map ~f:(fun x -> [| x |]) c
+      ; data = d
+      ; index = t
+      }
 
     include
       Binable.Of_binable
@@ -180,8 +184,11 @@ module Stable = struct
         (struct
           type nonrec t = t
 
-          let to_binable { commitments; data; index = _ } =
-            { Repr.commitments; data }
+          let to_binable { commitments = c; data; index = _ } =
+            { Repr.commitments =
+                Plonk_verification_key_evals.map ~f:(fun x -> x.(0)) c
+            ; data
+            }
 
           let of_binable r = of_repr (Backend.Tock.Keypair.load_urs ()) r
         end)

--- a/src/lib/pickles/verification_key.mli
+++ b/src/lib/pickles/verification_key.mli
@@ -14,7 +14,7 @@ module Stable : sig
   module V2 : sig
     type t =
       { commitments :
-          Backend.Tock.Curve.Affine.t
+          Backend.Tock.Curve.Affine.t array
           Pickles_types.Plonk_verification_key_evals.t
       ; index : Impls.Wrap.Verification_key.t
       ; data : Data.t
@@ -29,7 +29,8 @@ end
 
 type t = Stable.Latest.t =
   { commitments :
-      Backend.Tock.Curve.Affine.t Pickles_types.Plonk_verification_key_evals.t
+      Backend.Tock.Curve.Affine.t array
+      Pickles_types.Plonk_verification_key_evals.t
   ; index : Impls.Wrap.Verification_key.t
   ; data : Data.t
   }

--- a/src/lib/pickles/wrap.mli
+++ b/src/lib/pickles/wrap.mli
@@ -7,7 +7,8 @@ val wrap :
          and type ns = 'max_local_max_proofs_verifieds )
   -> ('max_proofs_verified, 'max_local_max_proofs_verifieds) Requests.Wrap.t
   -> dlog_plonk_index:
-       Backend.Tock.Curve.Affine.t Pickles_types.Plonk_verification_key_evals.t
+       Backend.Tock.Curve.Affine.t array
+       Pickles_types.Plonk_verification_key_evals.t
   -> (   ( Impls.Wrap.Impl.Field.t
          , Impls.Wrap.Impl.Field.t Composition_types.Scalar_challenge.t
          , Impls.Wrap.Impl.Field.t Pickles_types.Shifted_value.Type1.t

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -29,7 +29,7 @@ struct
       lazy
         (Vector.init num_choices ~f:(fun _ ->
              let g = Backend.Tock.Inner_curve.(to_affine_exn one) in
-             Verification_key.dummy_commitments g ) )
+             Verification_key.dummy_commitments [| g |] ) )
     in
     Timer.clock __LOC__ ;
     let srs = Backend.Tick.Keypair.load_urs () in

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -98,7 +98,7 @@ let wrap_main
       , max_local_max_proofs_verifieds )
       Full_signature.t ) (pi_branches : (prev_varss, branches) Hlist.Length.t)
     (step_keys :
-      ( Wrap_main_inputs.Inner_curve.Constant.t Wrap_verifier.index'
+      ( Wrap_main_inputs.Inner_curve.Constant.t array Wrap_verifier.index'
       , branches )
       Vector.t
       Lazy.t ) (step_widths : (int, branches) Vector.t)
@@ -219,7 +219,9 @@ let wrap_main
           with_label __LOC__ (fun () ->
               Wrap_verifier.choose_key which_branch
                 (Vector.map (Lazy.force step_keys)
-                   ~f:(Plonk_verification_key_evals.map ~f:Inner_curve.constant) ) )
+                   ~f:
+                     (Plonk_verification_key_evals.map
+                        ~f:(Array.map ~f:Inner_curve.constant) ) ) )
         in
         let prev_step_accs =
           with_label __LOC__ (fun () ->

--- a/src/lib/pickles/wrap_main.mli
+++ b/src/lib/pickles/wrap_main.mli
@@ -11,7 +11,7 @@ val wrap_main :
      , 'max_local_max_proofs_verifieds )
      Full_signature.t
   -> ('prev_varss, 'branches) Pickles_types.Hlist.Length.t
-  -> ( Wrap_main_inputs.Inner_curve.Constant.t Wrap_verifier.index'
+  -> ( Wrap_main_inputs.Inner_curve.Constant.t array Wrap_verifier.index'
      , 'branches )
      Pickles_types.Vector.t
      Core_kernel.Lazy.t

--- a/src/lib/pickles/wrap_verifier.mli
+++ b/src/lib/pickles/wrap_verifier.mli
@@ -61,7 +61,7 @@ val incrementally_verify_proof :
   -> step_domains:(Import.Domains.t, 'a) Pickles_types.Vector.t
   -> srs:Kimchi_bindings.Protocol.SRS.Fp.t
   -> verification_key:
-       Wrap_main_inputs.Inner_curve.t
+       Wrap_main_inputs.Inner_curve.t array
        Pickles_types.Plonk_verification_key_evals.t
   -> xi:Scalar_challenge.t
   -> sponge:Opt.t
@@ -145,5 +145,5 @@ val finalize_other_proof :
 val choose_key :
   'n.
      'n One_hot_vector.t
-  -> (Wrap_main_inputs.Inner_curve.t index', 'n) Pickles_types.Vector.t
-  -> Wrap_main_inputs.Inner_curve.t index'
+  -> (Wrap_main_inputs.Inner_curve.t array index', 'n) Pickles_types.Vector.t
+  -> Wrap_main_inputs.Inner_curve.t array index'


### PR DESCRIPTION
This PR builds upon #13358, routing the multiple chunks in the backend kimchi verification key through to pickles, and updating the logic for the `ft_comm` along the way.

Fixes #13014 and (partly) #13015 

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them