### PR TITLE
Remove token_id from local state

### DIFF
--- a/src/app/heap_usage/values.ml
+++ b/src/app/heap_usage/values.ml
@@ -310,7 +310,6 @@ let protocol_state =
             "call_stack": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "full_transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
             "excess": {
               "magnitude": "0",
               "sgn": [
@@ -345,7 +344,6 @@ let protocol_state =
             "call_stack": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
             "full_transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
             "excess": {
               "magnitude": "0",
               "sgn": [

--- a/src/lib/crypto/snarky_tests/snarky_tests.ml
+++ b/src/lib/crypto/snarky_tests/snarky_tests.ml
@@ -216,9 +216,9 @@ end
 module InvalidWitness = struct
   open Impl
 
-  (** A bit of a contrived circuit. 
+  (** A bit of a contrived circuit.
       Here only a single constraint will be generated (due to constant unification),
-      but we still want all [compute] closures to be checked when generating the witness. 
+      but we still want all [compute] closures to be checked when generating the witness.
       Thus, this circuit should fail due to an invalid witness. *)
   let circuit _ =
     let one = constant Field.typ Field.Constant.one in
@@ -611,7 +611,7 @@ module Protocol_circuits = struct
     ()
 
   let blockchain () : unit =
-    let expected = "ffd9c62ea5e15076a6fff9fdbd87ffa0" in
+    let expected = "c62239158c01b3ca9ebfa5bb38fa1a69" in
 
     let digest =
       Blockchain_snark.Blockchain_snark_state.constraint_system_digests
@@ -627,8 +627,8 @@ module Protocol_circuits = struct
     ()
 
   let transaction () : unit =
-    let expected1 = "31e96945d5bf7c8d4b1089c59c3b878b" in
-    let expected2 = "b86983bc4810294fc6e1d972f040d1cd" in
+    let expected1 = "198acebc60e3d2fc163c4c12baa71948" in
+    let expected2 = "e9789a1cfcd2089f1b27f925222ac485" in
 
     let digest =
       Transaction_snark.constraint_system_digests ~constraint_constants ()

--- a/src/lib/crypto/snarky_tests/snarky_tests.ml
+++ b/src/lib/crypto/snarky_tests/snarky_tests.ml
@@ -611,7 +611,7 @@ module Protocol_circuits = struct
     ()
 
   let blockchain () : unit =
-    let expected = "c62239158c01b3ca9ebfa5bb38fa1a69" in
+    let expected = "234ab6add22368c3dba20bff6df78e01" in
 
     let digest =
       Blockchain_snark.Blockchain_snark_state.constraint_system_digests
@@ -628,7 +628,7 @@ module Protocol_circuits = struct
 
   let transaction () : unit =
     let expected1 = "198acebc60e3d2fc163c4c12baa71948" in
-    let expected2 = "e9789a1cfcd2089f1b27f925222ac485" in
+    let expected2 = "9aaecfee3b4bcc5ec9101cbb41136a0f" in
 
     let digest =
       Transaction_snark.constraint_system_digests ~constraint_constants ()

--- a/src/lib/mina_block/sample_precomputed_block.ml
+++ b/src/lib/mina_block/sample_precomputed_block.ml
@@ -45,8 +45,6 @@ let sample_block_sexp =
               0x0000000000000000000000000000000000000000000000000000000000000000)
              (full_transaction_commitment
               0x0000000000000000000000000000000000000000000000000000000000000000)
-             (token_id
-              0x0000000000000000000000000000000000000000000000000000000000000001)
              (excess ((magnitude 0) (sgn Pos)))
              (supply_increase ((magnitude 0) (sgn Pos))) (ledger 0)
              (success true) (account_update_index 0) (failure_status_tbl ())
@@ -69,8 +67,6 @@ let sample_block_sexp =
               0x0000000000000000000000000000000000000000000000000000000000000000)
              (full_transaction_commitment
               0x0000000000000000000000000000000000000000000000000000000000000000)
-             (token_id
-              0x0000000000000000000000000000000000000000000000000000000000000001)
              (excess ((magnitude 0) (sgn Pos)))
              (supply_increase ((magnitude 0) (sgn Pos))) (ledger 0)
              (success true) (account_update_index 0) (failure_status_tbl ())
@@ -526,7 +522,6 @@ let sample_block_json =
                 "call_stack": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "full_transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
                 "excess": {
                   "magnitude": "0",
                   "sgn": [
@@ -561,7 +556,6 @@ let sample_block_json =
                 "call_stack": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
                 "full_transaction_commitment": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "token_id": "wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf",
                 "excess": {
                   "magnitude": "0",
                   "sgn": [

--- a/src/lib/mina_state/local_state.ml
+++ b/src/lib/mina_state/local_state.ml
@@ -10,7 +10,6 @@ type display =
   , string
   , string
   , string
-  , string
   , bool
   , string
   , int
@@ -23,7 +22,6 @@ let display
      ; call_stack
      ; transaction_commitment
      ; full_transaction_commitment
-     ; token_id
      ; excess
      ; supply_increase
      ; ledger
@@ -47,7 +45,6 @@ let display
   ; call_stack = f (call_stack :> Fp.t)
   ; transaction_commitment = f transaction_commitment
   ; full_transaction_commitment = f full_transaction_commitment
-  ; token_id = Token_id.to_string token_id
   ; excess = signed_amount_to_string excess
   ; supply_increase = signed_amount_to_string supply_increase
   ; ledger =
@@ -68,7 +65,6 @@ let dummy : unit -> t =
       ; call_stack = Call_stack_digest.empty
       ; transaction_commitment = Zkapp_command.Transaction_commitment.empty
       ; full_transaction_commitment = Zkapp_command.Transaction_commitment.empty
-      ; token_id = Token_id.default
       ; excess = Amount.(Signed.of_unsigned zero)
       ; supply_increase = Amount.(Signed.of_unsigned zero)
       ; ledger = Frozen_ledger_hash.empty_hash
@@ -88,7 +84,6 @@ let gen : t Quickcheck.Generator.t =
   and transaction_commitment = Impl.Field.Constant.gen
   and stack_frame = Stack_frame.Digest.gen
   and call_stack = Call_stack_digest.gen
-  and token_id = Token_id.gen
   and success = Bool.quickcheck_generator
   and account_update_index = Mina_numbers.Index.gen
   and will_succeed =
@@ -103,7 +98,6 @@ let gen : t Quickcheck.Generator.t =
   ; call_stack
   ; transaction_commitment
   ; full_transaction_commitment = transaction_commitment
-  ; token_id
   ; ledger
   ; excess
   ; supply_increase
@@ -118,7 +112,6 @@ let to_input
      ; call_stack
      ; transaction_commitment
      ; full_transaction_commitment
-     ; token_id
      ; excess
      ; supply_increase
      ; ledger
@@ -135,7 +128,6 @@ let to_input
      ; field (call_stack :> Field.Constant.t)
      ; field transaction_commitment
      ; field full_transaction_commitment
-     ; Token_id.to_input token_id
      ; Amount.Signed.to_input excess
      ; Amount.Signed.to_input supply_increase
      ; Ledger_hash.to_input ledger
@@ -160,7 +152,6 @@ module Checked = struct
       ~call_stack:(f Call_stack_digest.Checked.Assert.equal)
       ~transaction_commitment:(f Field.Assert.equal)
       ~full_transaction_commitment:(f Field.Assert.equal)
-      ~token_id:(f Token_id.Checked.Assert.equal)
       ~excess:(f !Currency.Amount.Signed.Checked.assert_equal)
       ~supply_increase:(f !Currency.Amount.Signed.Checked.assert_equal)
       ~ledger:(f !Ledger_hash.assert_equal)
@@ -177,7 +168,6 @@ module Checked = struct
       ~call_stack:(f Call_stack_digest.Checked.equal)
       ~transaction_commitment:(f Field.equal)
       ~full_transaction_commitment:(f Field.equal)
-      ~token_id:(f Token_id.Checked.equal)
       ~excess:(f !Currency.Amount.Signed.Checked.equal)
       ~supply_increase:(f !Currency.Amount.Signed.Checked.equal)
       ~ledger:(f !Ledger_hash.equal_var) ~success:(f Impl.Boolean.equal)
@@ -190,7 +180,6 @@ module Checked = struct
        ; call_stack
        ; transaction_commitment
        ; full_transaction_commitment
-       ; token_id
        ; excess
        ; supply_increase
        ; ledger
@@ -208,7 +197,6 @@ module Checked = struct
        ; field (call_stack :> t)
        ; field transaction_commitment
        ; field full_transaction_commitment
-       ; Token_id.Checked.to_input token_id
        ; run_checked (Amount.Signed.Checked.to_input excess)
        ; run_checked (Amount.Signed.Checked.to_input supply_increase)
        ; Ledger_hash.var_to_input ledger
@@ -237,7 +225,6 @@ let typ : (Checked.t, t) Impl.Typ.t =
     ; Call_stack_digest.typ
     ; Field.typ
     ; Field.typ
-    ; Token_id.typ
     ; Amount.Signed.typ
     ; Amount.Signed.typ
     ; Ledger_hash.typ

--- a/src/lib/mina_state/snarked_ledger_state_intf.ml
+++ b/src/lib/mina_state/snarked_ledger_state_intf.ml
@@ -134,7 +134,6 @@ module type Full = sig
          , ( _
            , _
            , _
-           , _
            , 'a
            , _
            , _

--- a/src/lib/mina_wire_types/mina_transaction_logic/zkapp_command_logic.ml
+++ b/src/lib/mina_wire_types/mina_transaction_logic/zkapp_command_logic.ml
@@ -2,7 +2,6 @@ module Local_state = struct
   module V1 = struct
     type ( 'stack_frame
          , 'call_stack
-         , 'token_id
          , 'signed_amount
          , 'ledger
          , 'bool
@@ -14,7 +13,6 @@ module Local_state = struct
       ; call_stack : 'call_stack
       ; transaction_commitment : 'comm
       ; full_transaction_commitment : 'comm
-      ; token_id : 'token_id
       ; excess : 'signed_amount
       ; supply_increase : 'signed_amount
       ; ledger : 'ledger
@@ -30,7 +28,6 @@ module Local_state = struct
       type t =
         ( Mina_base.Stack_frame.Digest.V1.t
         , Mina_base.Call_stack_digest.V1.t
-        , Mina_base.Token_id.V2.t
         , (Currency.Amount.V1.t, Sgn_type.Sgn.V1.t) Signed_poly.V1.t
         , Mina_base.Ledger_hash.V1.t
         , bool

--- a/src/lib/mina_wire_types/test/type_equalities.ml
+++ b/src/lib/mina_wire_types/test/type_equalities.ml
@@ -60,18 +60,11 @@ module Assert_equal4V1
     (W : V1S4 with type ('a, 'b, 'c, 'd) V1.t = ('a, 'b, 'c, 'd) O.V1.t) =
 struct end
 
-module Assert_equal9V1
-    (O : V1S9)
-    (W : V1S9
-           with type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) V1.t =
-             ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) O.V1.t) =
-struct end
-
-module Assert_equal9V2
-    (O : V2S9)
-    (W : V2S9
-           with type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) V2.t =
-             ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) O.V2.t) =
+module Assert_equal8V1
+    (O : V1S8)
+    (W : V1S8
+           with type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) V1.t =
+             ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) O.V1.t) =
 struct end
 
 (** {2 Actual tests}
@@ -358,7 +351,7 @@ module Mina_transaction_logic = struct
   module O = Mina_transaction_logic
   module W = WT.Mina_transaction_logic
   include
-    Assert_equal9V1
+    Assert_equal8V1
       (O.Zkapp_command_logic.Local_state.Stable)
       (W.Zkapp_command_logic.Local_state)
   include

--- a/src/lib/mina_wire_types/utils.ml
+++ b/src/lib/mina_wire_types/utils.ml
@@ -32,8 +32,8 @@ module type S4 = sig
   type ('a, 'b, 'c, 'd) t
 end
 
-module type S9 = sig
-  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) t
+module type S8 = sig
+  type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h) t
 end
 
 (** {2 Same, for versioned types} *)
@@ -58,8 +58,8 @@ module type V1S4 = sig
   module V1 : S4
 end
 
-module type V1S9 = sig
-  module V1 : S9
+module type V1S8 = sig
+  module V1 : S8
 end
 
 module type V2S0 = sig
@@ -76,8 +76,4 @@ end
 
 module type V2S3 = sig
   module V2 : S3
-end
-
-module type V2S9 = sig
-  module V2 : S9
 end

--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -355,7 +355,6 @@ module type S = sig
         ; local_state :
             ( Stack_frame.value
             , Stack_frame.value list
-            , Token_id.t
             , Amount.Signed.t
             , ledger
             , bool
@@ -410,7 +409,6 @@ module type S = sig
     -> ( Transaction_applied.Zkapp_command_applied.t
        * ( ( Stack_frame.value
            , Stack_frame.value list
-           , Token_id.t
            , Amount.Signed.t
            , ledger
            , bool
@@ -445,7 +443,6 @@ module type S = sig
           -> Global_state.t
              * ( Stack_frame.value
                , Stack_frame.value list
-               , Token_id.t
                , Amount.Signed.t
                , ledger
                , bool
@@ -470,7 +467,6 @@ module type S = sig
           -> Global_state.t
              * ( Stack_frame.value
                , Stack_frame.value list
-               , Token_id.t
                , Amount.Signed.t
                , ledger
                , bool
@@ -493,7 +489,6 @@ module type S = sig
           -> Global_state.t
              * ( Stack_frame.value
                , Stack_frame.value list
-               , Token_id.t
                , Amount.Signed.t
                , ledger
                , bool
@@ -1110,7 +1105,6 @@ module Make (L : Ledger_intf.S) :
         ; local_state :
             ( Stack_frame.value
             , Stack_frame.value list
-            , Token_id.t
             , Amount.Signed.t
             , L.t
             , bool
@@ -1792,7 +1786,6 @@ module Make (L : Ledger_intf.S) :
       type t =
         ( Stack_frame.t
         , Call_stack.t
-        , Token_id.t
         , Amount.Signed.t
         , Ledger.t
         , Bool.t
@@ -1846,7 +1839,6 @@ module Make (L : Ledger_intf.S) :
       ; local_state :
           ( Stack_frame.t
           , Call_stack.t
-          , Token_id.t
           , Amount.Signed.t
           , L.t
           , bool
@@ -1951,7 +1943,6 @@ module Make (L : Ledger_intf.S) :
         ; call_stack = []
         ; transaction_commitment = Inputs.Transaction_commitment.empty
         ; full_transaction_commitment = Inputs.Transaction_commitment.empty
-        ; token_id = Token_id.default
         ; excess = Currency.Amount.(Signed.of_unsigned zero)
         ; supply_increase = Currency.Amount.(Signed.of_unsigned zero)
         ; ledger = L.empty ~depth:0 ()

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1370,7 +1370,6 @@ module Make_str (A : Wire_types.Concrete) = struct
           type t =
             ( Stack_frame.t
             , Call_stack.t
-            , Token_id.t
             , Amount.Signed.t
             , Ledger_hash.var * Sparse_ledger.t V.t
             , Bool.t
@@ -1740,7 +1739,6 @@ module Make_str (A : Wire_types.Concrete) = struct
             ; local_state :
                 ( Stack_frame.t
                 , Call_stack.t
-                , Token_id.t
                 , Amount.Signed.t
                 , Ledger.t
                 , Bool.t
@@ -1884,7 +1882,6 @@ module Make_str (A : Wire_types.Concrete) = struct
                 statement.source.local_state.transaction_commitment
             ; full_transaction_commitment =
                 statement.source.local_state.full_transaction_commitment
-            ; token_id = statement.source.local_state.token_id
             ; excess = statement.source.local_state.excess
             ; supply_increase = statement.source.local_state.supply_increase
             ; ledger =
@@ -3530,7 +3527,6 @@ module Make_str (A : Wire_types.Concrete) = struct
     type local_state =
       ( Stack_frame.value
       , Stack_frame.value list
-      , Token_id.t
       , Currency.Amount.Signed.t
       , Sparse_ledger.t
       , bool
@@ -3797,7 +3793,6 @@ module Make_str (A : Wire_types.Concrete) = struct
             (local :
               ( Stack_frame.value
               , Stack_frame.value list
-              , _
               , _
               , _
               , _

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -969,7 +969,6 @@ let apply_ordered_txns_stepwise ?(stop_at_first_pass = false) ordered_txns
             ; transaction_commitment = t.local_state.transaction_commitment
             ; full_transaction_commitment =
                 t.local_state.full_transaction_commitment
-            ; token_id = t.local_state.token_id
             ; excess = t.local_state.excess
             ; supply_increase = t.local_state.supply_increase
             ; ledger

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -24,7 +24,6 @@ module Zkapp_command_segment_witness = struct
               , Call_stack_digest.Stable.V1.t )
               With_stack_hash.Stable.V1.t
               list
-            , Token_id.Stable.V2.t
             , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
             , Sparse_ledger.Stable.V2.t
             , bool

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -23,7 +23,6 @@ module Zkapp_command_segment_witness : sig
               , Call_stack_digest.Stable.V1.t )
               With_stack_hash.Stable.V1.t
               list
-            , Token_id.Stable.V2.t
             , (Amount.Stable.V1.t, Sgn.Stable.V1.t) Signed_poly.Stable.V1.t
             , Sparse_ledger.Stable.V2.t
             , bool


### PR DESCRIPTION
The `token_id` field of local state was always the default token, and never updated to a different token in the zkApps transaction logic.  Remove that field.

Software engineering: rename the inner `is_start'` in the zkApp transaction logic to `is_empty_call_forest`, to avoid confusion with the outer one.
