### PR TITLE
Unbox slot types

### DIFF
--- a/src/lib/mina_numbers/global_slot_since_genesis.ml
+++ b/src/lib/mina_numbers/global_slot_since_genesis.ml
@@ -25,7 +25,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     module Stable = struct
       module V1 = struct
         type t = Wire_types.global_slot = Since_genesis of T.Stable.V1.t
-        [@@deriving hash, sexp, compare, equal, yojson]
+        [@@unboxed] [@@deriving hash, sexp, compare, equal, yojson]
 
         let to_latest = Fn.id
       end

--- a/src/lib/mina_numbers/global_slot_since_hard_fork.ml
+++ b/src/lib/mina_numbers/global_slot_since_hard_fork.ml
@@ -25,7 +25,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
     module Stable = struct
       module V1 = struct
         type t = Wire_types.global_slot = Since_hard_fork of T.Stable.V1.t
-        [@@deriving hash, sexp, compare, equal, yojson]
+        [@@unboxed] [@@deriving hash, sexp, compare, equal, yojson]
 
         let to_latest = Fn.id
       end

--- a/src/lib/mina_numbers/global_slot_span.ml
+++ b/src/lib/mina_numbers/global_slot_span.ml
@@ -20,7 +20,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
   module Stable = struct
     module V1 = struct
       type t = Wire_types.global_slot_span = Global_slot_span of T.Stable.V1.t
-      [@@deriving hash, sexp, compare, equal, yojson]
+      [@@unboxed] [@@deriving hash, sexp, compare, equal, yojson]
 
       let to_latest = Fn.id
     end

--- a/src/lib/mina_wire_types/mina_numbers.ml
+++ b/src/lib/mina_wire_types/mina_numbers.ml
@@ -47,7 +47,7 @@ module Global_slot_since_genesis = struct
     module type S = V1S0
   end
 
-  type global_slot = Since_genesis of Unsigned.UInt32.t
+  type global_slot = Since_genesis of Unsigned.UInt32.t [@@unboxed]
 
   module type Concrete = Types.S with type V1.t = global_slot
 
@@ -70,7 +70,7 @@ module Global_slot_since_hard_fork = struct
     module type S = V1S0
   end
 
-  type global_slot = Since_hard_fork of Unsigned.UInt32.t
+  type global_slot = Since_hard_fork of Unsigned.UInt32.t [@@unboxed]
 
   module type Concrete = Types.S with type V1.t = global_slot
 
@@ -93,7 +93,7 @@ module Global_slot_span = struct
     module type S = V1S0
   end
 
-  type global_slot_span = Global_slot_span of Unsigned.UInt32.t
+  type global_slot_span = Global_slot_span of Unsigned.UInt32.t [@@unboxed]
 
   module type Concrete = Types.S with type V1.t = global_slot_span
 


### PR DESCRIPTION
Unbox the types `Global_slot_since_genesis.t`, `Global_slot_since_hard_fork.t`, and `Global_slot_span.t`. Those types have a single constructor, so the variant tag conveys no information, hence the run-time representation of the type can be the same as the constructor argument. This change saves some space, because the type tag is elided, and some time, boxing and unboxing values is not needed.

For generality, `ppx_version` is changed so that if a type is unboxed, a generated `With_top_tag` or `With_version_tags` module will also have an unboxed type. That part of this PR was tested when the slot types had such modules, though they do not now.
