### PR TITLE
Pass runtime tables information to the prover and lookup tables to bindings when creating cs

### DIFF
--- a/src/lib/crypto/README.md
+++ b/src/lib/crypto/README.md
@@ -8,3 +8,25 @@ crypto/
 ├── kimchi_bindings/  # the glue between ocaml and kimchi (the proof system in rust) # TODO: rename to kimchi
 └── proof-systems     # a submodule pointing to the Rust implementation of kimchi
 ```
+
+<!--
+TODO: this should go in a README-dev.md, or somwewhere else where the mina
+documentation for developers is.
+At least, it should be a scripts in src/scripts where we mention the commit hash
+of the proof-systems repository.
+-->
+## Update proof-systems
+
+[proof-systems](https://github.com/o1-labs/proof-systems/) is a git submodule.
+To update, make your changes upstream. After that, run in this repository:
+```
+COMMIT_HASH=yourcommithash
+cd proof-systems
+git fetch
+git checkout ${COMMIT_HASH}
+cd ../
+git add proof-systems
+git commit -m "Deps: bump up proof-systems to ${COMMIT_HASH}"
+```
+
+

--- a/src/lib/crypto/kimchi_backend/README.md
+++ b/src/lib/crypto/kimchi_backend/README.md
@@ -14,7 +14,7 @@ There are three things to convert here:
 2. common (or generic) low-level types: polynomial commitments (Poly_comm), gates (Gates), etc. that are instantiated separately for the two curves (Fq_poly_comm, Fp_poly_comm).
 3. high-level types that describe the constraint system, the indexes, etc. that are instantiated separately for the two curves as well.
 
-For the most part, you can find these types defined in `kimchi_backend_common/*` and instantiated in `pasta/basic.ml` and `pasta/{pallas,vesta}_based_plonk.ml`.
+For the most part, you can find these types defined in `kimchi_backend/common/*` and instantiated in `pasta/basic.ml` and `pasta/{pallas,vesta}_based_plonk.ml`.
 
 ## File structure
 

--- a/src/lib/crypto/kimchi_backend/common/README.md
+++ b/src/lib/crypto/kimchi_backend/common/README.md
@@ -1,0 +1,18 @@
+## Glue between Snarky and Kimchi
+
+### Inventory
+
+- Setup
+  - [`dlog_plonk_based_keypair`](dlog_plonk_based_keypair.ml)
+  - [`dlog_urs`](dlog_urs.ml)
+
+- Prover
+  - [`plonk_dlog_proof`](plonk_dlog_proof.ml)
+  - [`poly_comm`](poly_comm.ml)
+
+- Optimisations
+  - [`endoscale_round`](endoscale_round.ml)
+  - [`endoscale_scalar_round`](endoscale_scalar_round.ml)
+
+- Fiat Shamir
+  - [`scalar_challenge`](scalar_challenge.ml)

--- a/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
+++ b/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
@@ -59,11 +59,18 @@ module type Inputs_intf = sig
   module Index : sig
     type t
 
-    (** [create gates nb_public lookup_tables nb_prev_challanges srs] *)
+    (** [create
+          gates
+          nb_public
+          lookup_tables
+          runtime_tables_cfg
+          nb_prev_challanges
+          srs] *)
     val create :
          Gate_vector.t
       -> int
       -> Scalar_field.t Kimchi_types.lookup_table array
+      -> Scalar_field.t Kimchi_types.runtime_table_cfg array
       -> int
       -> Urs.t
       -> t
@@ -178,10 +185,11 @@ module Make (Inputs : Inputs_intf) = struct
     in
     (* TODO pass lookup tables info *)
     let lookup_tables = [||] in
+    let runtime_table_cfg = [||] in
     let index =
       (* This is the corresponding caml_pasta_fp_plonk_index_create *)
-      Inputs.Index.create gates public_input_size lookup_tables prev_challenges
-        (load_urs ())
+      Inputs.Index.create gates public_input_size lookup_tables
+        runtime_table_cfg prev_challenges (load_urs ())
     in
     { index; cs }
 

--- a/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
+++ b/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
@@ -169,6 +169,7 @@ module Make (Inputs : Inputs_intf) = struct
     in
     (set_urs_info, load)
 
+  (* TODO(dw): here we must pass the lookup information *)
   let create ~prev_challenges cs =
     let gates = Inputs.Constraint_system.finalize_and_get_gates cs in
     let public_input_size =

--- a/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
+++ b/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml
@@ -59,7 +59,14 @@ module type Inputs_intf = sig
   module Index : sig
     type t
 
-    val create : Gate_vector.t -> int -> int -> Urs.t -> t
+    (** [create gates nb_public lookup_tables nb_prev_challanges srs] *)
+    val create :
+         Gate_vector.t
+      -> int
+      -> Scalar_field.t Kimchi_types.lookup_table array
+      -> int
+      -> Urs.t
+      -> t
   end
 
   module Curve : sig
@@ -169,8 +176,12 @@ module Make (Inputs : Inputs_intf) = struct
           assert (prev_challenges = prev_challenges') ;
           prev_challenges'
     in
+    (* TODO pass lookup tables info *)
+    let lookup_tables = [||] in
     let index =
-      Inputs.Index.create gates public_input_size prev_challenges (load_urs ())
+      (* This is the corresponding caml_pasta_fp_plonk_index_create *)
+      Inputs.Index.create gates public_input_size lookup_tables prev_challenges
+        (load_urs ())
     in
     { index; cs }
 

--- a/src/lib/crypto/kimchi_backend/common/field.ml
+++ b/src/lib/crypto/kimchi_backend/common/field.ml
@@ -1,3 +1,10 @@
+(** This module provides a generic interface {{ Input_intf }} to represent
+    finite fields.
+
+    A functor {{ Make }} is provided to instantiate a concrete field
+    implementation.
+*)
+
 open Intf
 open Core_kernel
 module Bignum_bigint = Snarky_backendless.Backend_extended.Bignum_bigint

--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -30,8 +30,6 @@ end
 
 (** A gate interface, parameterized by a field. *)
 module type Gate_vector_intf = sig
-  open Unsigned
-
   type field
 
   type t

--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -1,5 +1,4 @@
 (* TODO: remove these openings *)
-open Sponge
 open Unsigned.Size_t
 
 (* TODO: open Core here instead of opening it multiple times below *)
@@ -764,7 +763,7 @@ module Make
     *)
     (Gates : Gate_vector_intf with type field := Fp.t)
     (Params : sig
-      val params : Fp.t Params.t
+      val params : Fp.t Sponge.Params.t
     end) : sig
   open Core_kernel
 

--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -95,7 +95,8 @@ module Position = struct
     Array.append cols padding
 
   (** Converts an array of [Constants.columns] to [Constants.permutation_cols].
-    This is useful to truncate arrays of cells to the ones that only matter for the permutation argument.
+      This is useful to truncate arrays of cells to the ones that only matter for
+      the permutation argument.
     *)
   let cols_to_perms cols = Array.slice cols 0 Constants.permutation_cols
 
@@ -110,7 +111,10 @@ module Gate_spec = struct
 
   (* TODO: split kind/coeffs from row/wired_to *)
 
-  (** A gate/row/constraint consists of a type (kind), a row, the other cells its columns/cells are connected to (wired_to), and the selector polynomial associated with the gate. *)
+  (** A gate/row/constraint consists of a type (kind), a row, the other cells
+      its columns/cells are connected to (wired_to), and the selector polynomial
+      associated with the gate.
+    *)
   type ('row, 'f) t =
     { kind : Kimchi_gate_type.t
     ; wired_to : 'row Position.t array
@@ -148,7 +152,17 @@ end
 module Plonk_constraint = struct
   open Core_kernel
 
-  (** A PLONK constraint (or gate) can be [Basic], [Poseidon], [EC_add_complete], [EC_scale], [EC_endoscale], [EC_endoscalar], [RangeCheck0], [RangeCheck1], [Xor] *)
+  (** A PLONK constraint (or gate) can be
+      - [Basic]
+      - [Poseidon]
+      - [EC_add_complete]
+      - [EC_scale]
+      - [EC_endoscale]
+      - [EC_endoscalar]
+      - [RangeCheck0]
+      - [RangeCheck1]
+      - [Xor]
+  *)
   module T = struct
     type ('v, 'f) t =
       | Basic of { l : 'f * 'v; r : 'f * 'v; o : 'f * 'v; m : 'f; c : 'f }

--- a/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_constraint_system.ml
@@ -1,6 +1,3 @@
-(* TODO: remove these openings *)
-open Unsigned.Size_t
-
 (* TODO: open Core here instead of opening it multiple times below *)
 
 module Kimchi_gate_type = struct

--- a/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
@@ -94,26 +94,29 @@ module type Inputs_intf = sig
 
     val create :
          Index.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.t array
-      -> Curve.Affine.Backend.t array
+      -> primary:Scalar_field.Vector.t
+      -> auxiliary:Scalar_field.Vector.t
+      -> runtime_tables:Scalar_field.t Kimchi_types.runtime_table array
+      -> prev_chals:Scalar_field.t array
+      -> prev_comms:Curve.Affine.Backend.t array
       -> t
 
     val create_async :
          Index.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.t array
-      -> Curve.Affine.Backend.t array
+      -> primary:Scalar_field.Vector.t
+      -> auxiliary:Scalar_field.Vector.t
+      -> runtime_tables:Scalar_field.t Kimchi_types.runtime_table array
+      -> prev_chals:Scalar_field.t array
+      -> prev_comms:Curve.Affine.Backend.t array
       -> t Promise.t
 
     val create_and_verify_async :
          Index.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.t array
-      -> Curve.Affine.Backend.t array
+      -> primary:Scalar_field.Vector.t
+      -> auxiliary:Scalar_field.Vector.t
+      -> runtime_tables:Scalar_field.t Kimchi_types.runtime_table array
+      -> prev_chals:Scalar_field.t array
+      -> prev_comms:Curve.Affine.Backend.t array
       -> t Promise.t
 
     val verify : Verifier_index.t -> t -> bool
@@ -220,7 +223,8 @@ module Make (Inputs : Inputs_intf) = struct
     Array.iter arr ~f:(fun fe -> Fq.Vector.emplace_back vec fe) ;
     vec
 
-  (** Note that this function will panic if any of the points are points at infinity *)
+  (** Note that this function will panic if any of the points are points at
+      infinity *)
   let opening_proof_of_backend_exn (t : Opening_proof_backend.t) =
     let g (x : G.Affine.Backend.t) : G.Affine.t =
       G.Affine.of_backend x |> Pickles_types.Or_infinity.finite_exn
@@ -366,7 +370,7 @@ module Make (Inputs : Inputs_intf) = struct
   let to_backend chal_polys primary_input t =
     to_backend' chal_polys (List.to_array primary_input) t
 
-  let create ?message pk ~primary ~auxiliary =
+  let create ?message pk ~primary ~auxiliary ~runtime_tables =
     let chal_polys =
       match (message : message option) with Some s -> s | None -> []
     in
@@ -380,10 +384,13 @@ module Make (Inputs : Inputs_intf) = struct
         ~f:(fun { Challenge_polynomial.commitment; _ } ->
           G.Affine.to_backend (Finite commitment) )
     in
-    let res = Backend.create pk primary auxiliary challenges commitments in
+    let res =
+      Backend.create pk ~primary ~auxiliary ~runtime_tables
+        ~prev_chals:challenges ~prev_comms:commitments
+    in
     of_backend res
 
-  let create_async ?message pk ~primary ~auxiliary =
+  let create_async ?message pk ~primary ~auxiliary ~runtime_tables =
     let chal_polys =
       match (message : message option) with Some s -> s | None -> []
     in
@@ -398,11 +405,12 @@ module Make (Inputs : Inputs_intf) = struct
           G.Affine.to_backend (Finite commitment) )
     in
     let%map.Promise res =
-      Backend.create_async pk primary auxiliary challenges commitments
+      Backend.create_async pk ~primary ~auxiliary ~runtime_tables
+        ~prev_chals:challenges ~prev_comms:commitments
     in
     of_backend res
 
-  let create_and_verify_async ?message pk ~primary ~auxiliary =
+  let create_and_verify_async ?message pk ~primary ~auxiliary ~runtime_tables =
     let chal_polys =
       match (message : message option) with Some s -> s | None -> []
     in
@@ -417,8 +425,8 @@ module Make (Inputs : Inputs_intf) = struct
           G.Affine.to_backend (Finite commitment) )
     in
     let%map.Promise res =
-      Backend.create_and_verify_async pk primary auxiliary challenges
-        commitments
+      Backend.create_and_verify_async pk ~primary ~auxiliary ~runtime_tables
+        ~prev_chals:challenges ~prev_comms:commitments
     in
     of_backend res
 

--- a/src/lib/crypto/kimchi_backend/gadgets/runner/runner.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/runner/runner.ml
@@ -24,8 +24,10 @@ let generate_and_verify_proof ?cs circuit =
         let proof =
           (* Only block_on_async for testing; do not do this in production!! *)
           Promise.block_on_async_exn (fun () ->
+              (* TODO(dw) pass runtime tables *)
               Tick.Proof.create_and_verify_async ~primary:public_inputs
-                ~auxiliary:auxiliary_inputs ~message:[] prover_index )
+                ~auxiliary:auxiliary_inputs ~runtime_tables:[||] ~message:[]
+                prover_index )
         in
         (proof, next_statement_hashed) )
       ~input_typ:Impl.Typ.unit ~return_typ:Impl.Typ.unit

--- a/src/lib/crypto/kimchi_backend/gadgets/test/dune
+++ b/src/lib/crypto/kimchi_backend/gadgets/test/dune
@@ -1,0 +1,12 @@
+(tests
+  (names runtime_table)
+  (libraries
+    alcotest
+    ;; local libraries
+    kimchi_backend.common
+    kimchi_backend.pasta
+    kimchi_gadgets_test_runner
+    mina_stdlib
+    snarky.backendless
+  )
+)

--- a/src/lib/crypto/kimchi_backend/gadgets/test/runtime_table.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/test/runtime_table.ml
@@ -1,0 +1,12 @@
+let test_with_one_runtime_table_no_fixed_lookup_table () =
+  let open Kimchi_pasta.Pallas_based_plonk in
+  ()
+
+let () =
+  let open Alcotest in
+  run "Runtime table"
+    [ ( "Scenarii"
+      , [ test_case "One runtime table, no fixed lookup table" `Quick
+            test_with_one_runtime_table_no_fixed_lookup_table
+        ] )
+    ]

--- a/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
@@ -82,8 +82,8 @@ module Proof = Plonk_dlog_proof.Make (struct
     let batch_verify vks ts =
       Promise.run_in_thread (fun () -> batch_verify vks ts)
 
-    let create_aux ~f:create (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
+    let create_aux ~f:create (pk : Keypair.t) ~primary ~auxiliary
+        ~runtime_tables ~prev_chals ~prev_comms =
       (* external values contains [1, primary..., auxiliary ] *)
       let external_values i =
         let open Field.Vector in
@@ -106,21 +106,24 @@ module Proof = Plonk_dlog_proof.Make (struct
             done ;
             witness )
       in
-      create pk.index witness_cols prev_chals prev_comms
+      create pk.index witness_cols runtime_tables prev_chals prev_comms
 
-    let create_async (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms
-        ~f:(fun pk auxiliary_input prev_challenges prev_sgs ->
+    let create_async (pk : Keypair.t) ~primary ~auxiliary ~runtime_tables
+        ~prev_chals ~prev_comms =
+      create_aux pk ~primary ~auxiliary ~runtime_tables ~prev_chals ~prev_comms
+        ~f:(fun pk auxiliary_input runtime_tables prev_challenges prev_sgs ->
           Promise.run_in_thread (fun () ->
-              create pk auxiliary_input prev_challenges prev_sgs ) )
+              create pk auxiliary_input runtime_tables prev_challenges prev_sgs ) )
 
-    let create_and_verify_async (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
+    let create_and_verify_async (pk : Keypair.t) ~primary ~auxiliary
+        ~runtime_tables ~prev_chals ~prev_comms =
       failwith "not implemented"
     (* TODO: Remove this function when vesta_based_plonk.create_and_verify_async is removed *)
 
-    let create (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms ~f:create
+    let create (pk : Keypair.t) ~primary ~auxiliary ~runtime_tables ~prev_chals
+        ~prev_comms =
+      create_aux pk ~primary ~auxiliary ~runtime_tables ~prev_chals ~prev_comms
+        ~f:create
   end
 
   module Verifier_index = Kimchi_bindings.Protocol.VerifierIndex.Fq

--- a/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
@@ -81,8 +81,8 @@ module Proof = Plonk_dlog_proof.Make (struct
     let batch_verify vks ts =
       Promise.run_in_thread (fun () -> batch_verify vks ts)
 
-    let create_aux ~f:create (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
+    let create_aux ~f:create (pk : Keypair.t) primary auxiliary runtime_tables
+        prev_chals prev_comms =
       (* external values contains [1, primary..., auxiliary ] *)
       let external_values i =
         let open Field.Vector in
@@ -105,23 +105,27 @@ module Proof = Plonk_dlog_proof.Make (struct
             done ;
             witness )
       in
-      create pk.index witness_cols prev_chals prev_comms
+      create pk.index witness_cols runtime_tables prev_chals prev_comms
 
-    let create_async (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms
-        ~f:(fun pk auxiliary_input prev_challenges prev_sgs ->
+    let create_async (pk : Keypair.t) ~primary ~auxiliary ~runtime_tables
+        ~prev_chals ~prev_comms =
+      create_aux pk primary auxiliary runtime_tables prev_chals prev_comms
+        ~f:(fun pk auxiliary_input runtime_tables prev_challenges prev_sgs ->
           Promise.run_in_thread (fun () ->
-              create pk auxiliary_input prev_challenges prev_sgs ) )
+              create pk auxiliary_input runtime_tables prev_challenges prev_sgs ) )
 
-    let create_and_verify_async (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms
-        ~f:(fun pk auxiliary_input prev_challenges prev_sgs ->
+    let create_and_verify_async (pk : Keypair.t) ~primary ~auxiliary
+        ~runtime_tables ~prev_chals ~prev_comms =
+      create_aux pk primary auxiliary runtime_tables prev_chals prev_comms
+        ~f:(fun pk auxiliary_input runtime_tables prev_challenges prev_sgs ->
           Promise.run_in_thread (fun () ->
-              create_and_verify pk auxiliary_input prev_challenges prev_sgs ) )
+              create_and_verify pk auxiliary_input runtime_tables
+                prev_challenges prev_sgs ) )
 
-    let create (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms ~f:create
+    let create (pk : Keypair.t) ~primary ~auxiliary ~runtime_tables ~prev_chals
+        ~prev_comms =
+      create_aux pk primary auxiliary runtime_tables prev_chals prev_comms
+        ~f:create
   end
 
   module Verifier_index = Kimchi_bindings.Protocol.VerifierIndex.Fp

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -194,15 +194,15 @@ module Protocol = struct
     module Fp = struct
       type nonrec t
 
-      external create : Gates.Vector.Fp.t -> int -> int -> SRS.Fp.t -> t
-        = "caml_pasta_fp_plonk_index_create"
+      external create :
            Gates.Vector.Fp.t
         -> int
+        -> Pasta_bindings.Fp.t Kimchi_types.lookup_table array
         -> Pasta_bindings.Fp.t Kimchi_types.runtime_table_cfg array
         -> int
         -> SRS.Fp.t
         -> t
-        = "caml_pasta_fp_plonk_index_create"
+        = "caml_pasta_fp_plonk_index_create_bytecode" "caml_pasta_fp_plonk_index_create"
 
       external max_degree : t -> int = "caml_pasta_fp_plonk_index_max_degree"
 
@@ -231,11 +231,12 @@ module Protocol = struct
       external create :
            Gates.Vector.Fq.t
         -> int
+        -> Pasta_bindings.Fq.t Kimchi_types.lookup_table array
         -> Pasta_bindings.Fq.t Kimchi_types.runtime_table_cfg array
         -> int
         -> SRS.Fq.t
         -> t
-        = "caml_pasta_fq_plonk_index_create"
+        = "caml_pasta_fq_plonk_index_create_bytecode" "caml_pasta_fq_plonk_index_create"
 
       external max_degree : t -> int = "caml_pasta_fq_plonk_index_max_degree"
 

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -196,6 +196,13 @@ module Protocol = struct
 
       external create : Gates.Vector.Fp.t -> int -> int -> SRS.Fp.t -> t
         = "caml_pasta_fp_plonk_index_create"
+           Gates.Vector.Fp.t
+        -> int
+        -> Pasta_bindings.Fp.t Kimchi_types.runtime_table_cfg array
+        -> int
+        -> SRS.Fp.t
+        -> t
+        = "caml_pasta_fp_plonk_index_create"
 
       external max_degree : t -> int = "caml_pasta_fp_plonk_index_max_degree"
 
@@ -221,7 +228,13 @@ module Protocol = struct
     module Fq = struct
       type nonrec t
 
-      external create : Gates.Vector.Fq.t -> int -> int -> SRS.Fq.t -> t
+      external create :
+           Gates.Vector.Fq.t
+        -> int
+        -> Pasta_bindings.Fq.t Kimchi_types.runtime_table_cfg array
+        -> int
+        -> SRS.Fq.t
+        -> t
         = "caml_pasta_fq_plonk_index_create"
 
       external max_degree : t -> int = "caml_pasta_fq_plonk_index_max_degree"
@@ -377,7 +390,6 @@ module Protocol = struct
 
       external example_with_lookup :
            SRS.Fp.t
-        -> bool
         -> Index.Fp.t
            * Pasta_bindings.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -357,6 +357,7 @@ module Protocol = struct
       external create :
            Index.Fp.t
         -> FieldVectors.Fp.t array
+        -> Pasta_bindings.Fp.t Kimchi_types.runtime_table array
         -> Pasta_bindings.Fp.t array
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
@@ -366,6 +367,7 @@ module Protocol = struct
       external create_and_verify :
            Index.Fp.t
         -> FieldVectors.Fp.t array
+        -> Pasta_bindings.Fp.t Kimchi_types.runtime_table array
         -> Pasta_bindings.Fp.t array
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
@@ -477,6 +479,7 @@ module Protocol = struct
       external create :
            Index.Fq.t
         -> FieldVectors.Fq.t array
+        -> Pasta_bindings.Fq.t Kimchi_types.runtime_table array
         -> Pasta_bindings.Fq.t array
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -94,6 +94,8 @@ type nonrec runtime_table_spec = { id : int32; len : int }
 type nonrec 'caml_f runtime_table_cfg =
   { id : int32; first_column : 'caml_f array }
 
+type nonrec 'caml_f lookup_table = { id : int32; data : 'caml_f array array }
+
 type nonrec 'caml_g prover_commitments =
   { w_comm :
       'caml_g poly_comm

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -89,6 +89,11 @@ type nonrec 'caml_g lookup_commitments =
 
 type nonrec 'caml_f runtime_table = { id : int32; data : 'caml_f array }
 
+type nonrec runtime_table_spec = { id : int32; len : int }
+
+type nonrec 'caml_f runtime_table_cfg =
+  { id : int32; first_column : 'caml_f array }
+
 type nonrec 'caml_g prover_commitments =
   { w_comm :
       'caml_g poly_comm

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -87,6 +87,8 @@ type nonrec 'caml_g lookup_commitments =
   ; runtime : 'caml_g poly_comm option
   }
 
+type nonrec 'caml_f runtime_table = { id : int32; data : 'caml_f array }
+
 type nonrec 'caml_g prover_commitments =
   { w_comm :
       'caml_g poly_comm

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -1,9 +1,9 @@
 use kimchi::circuits::{
     expr::FeatureFlag,
-    lookup::{lookups::{LookupFeatures, LookupPattern, LookupPatterns}, runtime_tables::caml::CamlRuntimeTable},
     lookup::{
         lookups::{LookupFeatures, LookupPattern, LookupPatterns},
         runtime_tables::caml::{CamlRuntimeTable, CamlRuntimeTableCfg, CamlRuntimeTableSpec},
+        tables::caml::CamlLookupTable,
     },
 };
 use kimchi::proof::{caml::CamlRecursionChallenge, PointEvaluations};
@@ -111,6 +111,7 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
     decl_type!(w, env, CamlRuntimeTableSpec => "runtime_table_spec");
     decl_type!(w, env, CamlRuntimeTableCfg::<T1> => "runtime_table_cfg");
 
+    decl_type!(w, env, CamlLookupTable::<T1> => "lookup_table");
     decl_type!(w, env, CamlProverCommitments::<T1> => "prover_commitments");
     decl_type!(w, env, CamlProverProof<T1, T2> => "prover_proof");
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -1,6 +1,6 @@
 use kimchi::circuits::{
     expr::FeatureFlag,
-    lookup::lookups::{LookupFeatures, LookupPattern, LookupPatterns},
+    lookup::{lookups::{LookupFeatures, LookupPattern, LookupPatterns}, runtime_tables::caml::CamlRuntimeTable},
 };
 use kimchi::proof::{caml::CamlRecursionChallenge, PointEvaluations};
 use ocaml_gen::{decl_fake_generic, decl_func, decl_module, decl_type, decl_type_alias, Env};
@@ -102,6 +102,7 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
     decl_type!(w, env, CamlRecursionChallenge::<T1, T2> => "recursion_challenge");
     decl_type!(w, env, CamlOpeningProof::<T1, T2> => "opening_proof");
     decl_type!(w, env, CamlLookupCommitments::<T1> => "lookup_commitments");
+    decl_type!(w, env, CamlRuntimeTable::<T1> => "runtime_table");
     decl_type!(w, env, CamlProverCommitments::<T1> => "prover_commitments");
     decl_type!(w, env, CamlProverProof<T1, T2> => "prover_proof");
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -1,6 +1,10 @@
 use kimchi::circuits::{
     expr::FeatureFlag,
     lookup::{lookups::{LookupFeatures, LookupPattern, LookupPatterns}, runtime_tables::caml::CamlRuntimeTable},
+    lookup::{
+        lookups::{LookupFeatures, LookupPattern, LookupPatterns},
+        runtime_tables::caml::{CamlRuntimeTable, CamlRuntimeTableCfg, CamlRuntimeTableSpec},
+    },
 };
 use kimchi::proof::{caml::CamlRecursionChallenge, PointEvaluations};
 use ocaml_gen::{decl_fake_generic, decl_func, decl_module, decl_type, decl_type_alias, Env};
@@ -103,6 +107,10 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
     decl_type!(w, env, CamlOpeningProof::<T1, T2> => "opening_proof");
     decl_type!(w, env, CamlLookupCommitments::<T1> => "lookup_commitments");
     decl_type!(w, env, CamlRuntimeTable::<T1> => "runtime_table");
+    // Runtime table spec/cfg
+    decl_type!(w, env, CamlRuntimeTableSpec => "runtime_table_spec");
+    decl_type!(w, env, CamlRuntimeTableCfg::<T1> => "runtime_table_cfg");
+
     decl_type!(w, env, CamlProverCommitments::<T1> => "prover_commitments");
     decl_type!(w, env, CamlProverProof<T1, T2> => "prover_proof");
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
@@ -1,6 +1,8 @@
 use crate::arkworks::CamlFp;
 use crate::{gate_vector::fp::CamlPastaFpPlonkGateVectorPtr, srs::fp::CamlFpSrs};
 use ark_poly::EvaluationDomain;
+use kimchi::circuits::lookup::runtime_tables::caml::*;
+use kimchi::circuits::lookup::runtime_tables::RuntimeTableCfg;
 use kimchi::circuits::lookup::tables::caml::CamlLookupTable;
 use kimchi::circuits::{constraints::ConstraintSystem, gate::CircuitGate};
 use kimchi::{linearization::expr_linearization, prover_index::ProverIndex};
@@ -42,6 +44,7 @@ pub fn caml_pasta_fp_plonk_index_create(
     gates: CamlPastaFpPlonkGateVectorPtr,
     public: ocaml::Int,
     lookup_tables: Vec<CamlLookupTable<CamlFp>>,
+    runtime_tables: Vec<CamlRuntimeTableCfg<CamlFp>>,
     prev_challenges: ocaml::Int,
     srs: CamlFpSrs,
 ) -> Result<CamlPastaFpPlonkIndex, ocaml::Error> {
@@ -58,11 +61,19 @@ pub fn caml_pasta_fp_plonk_index_create(
 
     let lookup_tables = lookup_tables.into_iter().map(Into::into).collect();
 
+    let runtime_tables: Vec<RuntimeTableCfg<Fp>> =
+        runtime_tables.into_iter().map(Into::into).collect();
+
     // create constraint system
     let cs = match ConstraintSystem::<Fp>::create(gates)
         .public(public as usize)
         .prev_challenges(prev_challenges as usize)
         .lookup(lookup_tables)
+        .runtime(if runtime_tables.is_empty() {
+            None
+        } else {
+            Some(runtime_tables)
+        })
         .build()
     {
         Err(_) => {

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_index.rs
@@ -1,5 +1,7 @@
+use crate::arkworks::CamlFp;
 use crate::{gate_vector::fp::CamlPastaFpPlonkGateVectorPtr, srs::fp::CamlFpSrs};
 use ark_poly::EvaluationDomain;
+use kimchi::circuits::lookup::tables::caml::CamlLookupTable;
 use kimchi::circuits::{constraints::ConstraintSystem, gate::CircuitGate};
 use kimchi::{linearization::expr_linearization, prover_index::ProverIndex};
 use mina_curves::pasta::{Fp, Pallas, Vesta, VestaParameters};
@@ -39,6 +41,7 @@ impl ocaml::custom::Custom for CamlPastaFpPlonkIndex {
 pub fn caml_pasta_fp_plonk_index_create(
     gates: CamlPastaFpPlonkGateVectorPtr,
     public: ocaml::Int,
+    lookup_tables: Vec<CamlLookupTable<CamlFp>>,
     prev_challenges: ocaml::Int,
     srs: CamlFpSrs,
 ) -> Result<CamlPastaFpPlonkIndex, ocaml::Error> {
@@ -53,10 +56,13 @@ pub fn caml_pasta_fp_plonk_index_create(
         })
         .collect();
 
+    let lookup_tables = lookup_tables.into_iter().map(Into::into).collect();
+
     // create constraint system
     let cs = match ConstraintSystem::<Fp>::create(gates)
         .public(public as usize)
         .prev_challenges(prev_challenges as usize)
+        .lookup(lookup_tables)
         .build()
     {
         Err(_) => {

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -180,7 +180,6 @@ pub fn caml_pasta_fp_plonk_proof_create_and_verify(
 #[ocaml::func]
 pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
     srs: CamlFpSrs,
-    indexed: bool,
 ) -> (
     CamlPastaFpPlonkIndex,
     CamlFp,
@@ -190,7 +189,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
     use kimchi::circuits::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, GateType},
-        lookup::runtime_tables::{RuntimeTable, RuntimeTableCfg, RuntimeTableSpec},
+        lookup::runtime_tables::{RuntimeTable, RuntimeTableCfg},
         polynomial::COLUMNS,
         wires::Wire,
     };
@@ -201,16 +200,9 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
 
     let mut runtime_tables_setup = vec![];
     for table_id in 0..num_tables {
-        let cfg = if indexed {
-            RuntimeTableCfg::Indexed(RuntimeTableSpec {
-                id: table_id as i32,
-                len: 5,
-            })
-        } else {
-            RuntimeTableCfg::Custom {
-                id: table_id as i32,
-                first_column: [8u32, 9, 8, 7, 1].into_iter().map(Into::into).collect(),
-            }
+        let cfg = RuntimeTableCfg {
+            id: table_id as i32,
+            first_column: [8u32, 9, 8, 7, 1].into_iter().map(Into::into).collect(),
         };
         runtime_tables_setup.push(cfg);
     }
@@ -248,7 +240,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
             // create queries into our runtime lookup table
             let lookup_cols = &mut lookup_cols[1..];
             for chunk in lookup_cols.chunks_mut(2) {
-                chunk[0][row] = if indexed { 1u32.into() } else { 9u32.into() }; // index
+                chunk[0][row] = 9u32.into(); // index
                 chunk[1][row] = 2u32.into(); // value
             }
         }

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -9,8 +9,11 @@ use ark_ec::AffineCurve;
 use ark_ff::One;
 use array_init::array_init;
 use groupmap::GroupMap;
-use kimchi::prover_index::ProverIndex;
 use kimchi::verifier::verify;
+use kimchi::{
+    circuits::lookup::runtime_tables::{caml::CamlRuntimeTable, RuntimeTable},
+    prover_index::ProverIndex,
+};
 use kimchi::{circuits::polynomial::COLUMNS, verifier::batch_verify};
 use kimchi::{
     proof::{
@@ -36,6 +39,7 @@ type EFrSponge = DefaultFrSponge<Fp, PlonkSpongeConstantsKimchi>;
 pub fn caml_pasta_fp_plonk_proof_create(
     index: CamlPastaFpPlonkIndexPtr<'static>,
     witness: Vec<CamlFpVector>,
+    runtime_tables: Vec<CamlRuntimeTable<CamlFp>>,
     prev_challenges: Vec<CamlFp>,
     prev_sgs: Vec<CamlGVesta>,
 ) -> Result<CamlProverProof<CamlGVesta, CamlFp>, ocaml::Error> {
@@ -71,6 +75,8 @@ pub fn caml_pasta_fp_plonk_proof_create(
         .try_into()
         .map_err(|_| ocaml::Error::Message("the witness should be a column of 15 vectors"))?;
     let index: &ProverIndex<Vesta> = &index.as_ref().0;
+    let runtime_tables: Vec<RuntimeTable<Fp>> =
+        runtime_tables.into_iter().map(Into::into).collect();
 
     // public input
     let public_input = witness[0][0..index.cs.public].to_vec();
@@ -86,7 +92,7 @@ pub fn caml_pasta_fp_plonk_proof_create(
         let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
             &group_map,
             witness,
-            &[],
+            &runtime_tables,
             index,
             prev,
             None,
@@ -101,6 +107,7 @@ pub fn caml_pasta_fp_plonk_proof_create(
 pub fn caml_pasta_fp_plonk_proof_create_and_verify(
     index: CamlPastaFpPlonkIndexPtr<'static>,
     witness: Vec<CamlFpVector>,
+    runtime_tables: Vec<CamlRuntimeTable<CamlFp>>,
     prev_challenges: Vec<CamlFp>,
     prev_sgs: Vec<CamlGVesta>,
 ) -> Result<CamlProverProof<CamlGVesta, CamlFp>, ocaml::Error> {
@@ -136,6 +143,8 @@ pub fn caml_pasta_fp_plonk_proof_create_and_verify(
         .try_into()
         .map_err(|_| ocaml::Error::Message("the witness should be a column of 15 vectors"))?;
     let index: &ProverIndex<Vesta> = &index.as_ref().0;
+    let runtime_tables: Vec<RuntimeTable<Fp>> =
+        runtime_tables.into_iter().map(Into::into).collect();
 
     // public input
     let public_input = witness[0][0..index.cs.public].to_vec();
@@ -151,7 +160,7 @@ pub fn caml_pasta_fp_plonk_proof_create_and_verify(
         let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
             &group_map,
             witness,
-            &[],
+            &runtime_tables,
             index,
             prev,
             None,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -201,7 +201,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
     let mut runtime_tables_setup = vec![];
     for table_id in 0..num_tables {
         let cfg = RuntimeTableCfg {
-            id: table_id as i32,
+            id: table_id,
             first_column: [8u32, 9, 8, 7, 1].into_iter().map(Into::into).collect(),
         };
         runtime_tables_setup.push(cfg);

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_index.rs
@@ -1,6 +1,8 @@
-use crate::{gate_vector::fq::CamlPastaFqPlonkGateVectorPtr, srs::fq::CamlFqSrs};
 use crate::arkworks::CamlFq;
+use crate::{gate_vector::fq::CamlPastaFqPlonkGateVectorPtr, srs::fq::CamlFqSrs};
 use ark_poly::EvaluationDomain;
+use kimchi::circuits::lookup::runtime_tables::caml::CamlRuntimeTableCfg;
+use kimchi::circuits::lookup::runtime_tables::RuntimeTableCfg;
 use kimchi::circuits::lookup::tables::caml::CamlLookupTable;
 use kimchi::circuits::{constraints::ConstraintSystem, gate::CircuitGate};
 use kimchi::{linearization::expr_linearization, prover_index::ProverIndex};
@@ -42,6 +44,7 @@ pub fn caml_pasta_fq_plonk_index_create(
     gates: CamlPastaFqPlonkGateVectorPtr,
     public: ocaml::Int,
     lookup_tables: Vec<CamlLookupTable<CamlFq>>,
+    runtime_tables: Vec<CamlRuntimeTableCfg<CamlFq>>,
     prev_challenges: ocaml::Int,
     srs: CamlFqSrs,
 ) -> Result<CamlPastaFqPlonkIndex, ocaml::Error> {
@@ -58,11 +61,19 @@ pub fn caml_pasta_fq_plonk_index_create(
 
     let lookup_tables = lookup_tables.into_iter().map(Into::into).collect();
 
+    let runtime_tables: Vec<RuntimeTableCfg<Fq>> =
+        runtime_tables.into_iter().map(Into::into).collect();
+
     // create constraint system
     let cs = match ConstraintSystem::<Fq>::create(gates)
         .public(public as usize)
         .prev_challenges(prev_challenges as usize)
         .lookup(lookup_tables)
+        .runtime(if runtime_tables.is_empty() {
+            None
+        } else {
+            Some(runtime_tables)
+        })
         .build()
     {
         Err(_) => {

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -8,7 +8,10 @@ use ark_ec::AffineCurve;
 use ark_ff::One;
 use array_init::array_init;
 use groupmap::GroupMap;
-use kimchi::prover_index::ProverIndex;
+use kimchi::{
+    circuits::lookup::runtime_tables::{caml::CamlRuntimeTable, RuntimeTable},
+    prover_index::ProverIndex,
+};
 use kimchi::{circuits::polynomial::COLUMNS, verifier::batch_verify};
 use kimchi::{
     proof::{
@@ -31,6 +34,7 @@ use std::convert::TryInto;
 pub fn caml_pasta_fq_plonk_proof_create(
     index: CamlPastaFqPlonkIndexPtr<'static>,
     witness: Vec<CamlFqVector>,
+    runtime_tables: Vec<CamlRuntimeTable<CamlFq>>,
     prev_challenges: Vec<CamlFq>,
     prev_sgs: Vec<CamlGPallas>,
 ) -> Result<CamlProverProof<CamlGPallas, CamlFq>, ocaml::Error> {
@@ -67,6 +71,9 @@ pub fn caml_pasta_fq_plonk_proof_create(
         .expect("the witness should be a column of 15 vectors");
     let index: &ProverIndex<Pallas> = &index.as_ref().0;
 
+    let runtime_tables: Vec<RuntimeTable<Fq>> =
+        runtime_tables.into_iter().map(Into::into).collect();
+
     // public input
     let public_input = witness[0][0..index.cs.public].to_vec();
 
@@ -81,7 +88,7 @@ pub fn caml_pasta_fq_plonk_proof_create(
         let proof = ProverProof::create_recursive::<
             DefaultFqSponge<PallasParameters, PlonkSpongeConstantsKimchi>,
             DefaultFrSponge<Fq, PlonkSpongeConstantsKimchi>,
-        >(&group_map, witness, &[], index, prev, None)
+        >(&group_map, witness, &runtime_tables, index, prev, None)
         .map_err(|e| ocaml::Error::Error(e.into()))?;
         Ok((proof, public_input).into())
     })

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1732,9 +1732,11 @@ module Make_str (_ : Wire_types.Concrete) = struct
                             ~f:(fun { Impls.Wrap.Proof_inputs.auxiliary_inputs
                                     ; public_inputs
                                     } () ->
+                              (* TODO(dw) pas runtime tables information *)
                               Backend.Tock.Proof.create_async
                                 ~primary:public_inputs
                                 ~auxiliary:auxiliary_inputs pk
+                                ~runtime_tables:[||]
                                 ~message:
                                   ( Vector.map2
                                       (Vector.extend_front_exn

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -821,8 +821,9 @@ struct
                           } next_statement_hashed ->
                     [%log internal] "Backend_tick_proof_create_async" ;
                     let%map.Promise proof =
+                      (* TODO(dw) pass runtime tables *)
                       Backend.Tick.Proof.create_async ~primary:public_inputs
-                        ~auxiliary:auxiliary_inputs
+                        ~auxiliary:auxiliary_inputs ~runtime_tables:[||]
                         ~message:
                           (Lazy.force prev_challenge_polynomial_commitments)
                         pk

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -875,8 +875,10 @@ let wrap
           ~f:(fun { Impls.Wrap.Proof_inputs.auxiliary_inputs; public_inputs } () ->
             [%log internal] "Backend_tock_proof_create_async" ;
             let%map.Promise proof =
+              (* TODO(dw) pass runtime tables *)
               Backend.Tock.Proof.create_async ~primary:public_inputs
-                ~auxiliary:auxiliary_inputs pk ~message:next_accumulator
+                ~auxiliary:auxiliary_inputs ~runtime_tables:[||] pk
+                ~message:next_accumulator
             in
             [%log internal] "Backend_tock_proof_create_async_done" ;
             proof )

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -543,7 +543,7 @@ let%test_module "gate finalization" =
       ( module Make (struct
         let example =
           public_input_1 (fun srs ->
-              Kimchi_bindings.Protocol.Proof.Fp.example_with_lookup srs true )
+              Kimchi_bindings.Protocol.Proof.Fp.example_with_lookup srs )
 
         let actual_feature_flags =
           { Plonk_types.Features.none_bool with


### PR DESCRIPTION
Explain your changes:
* Depends on [this PR (commenting pickles)](https://github.com/MinaProtocol/mina/pull/13386).
* Depends on [this PR (proof-systems: runtime tables)](https://github.com/o1-labs/proof-systems/pull/1070)
* Depends on [This PR (snarky-js-bindings)](https://github.com/o1-labs/snarkyjs-bindings/pull/55).
* Part of [Exposing runtime tables to SnarkyJS](https://github.com/MinaProtocol/mina/issues/13086)


Explain how you tested your changes:


Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes [#13089](https://github.com/MinaProtocol/mina/issues/13089)
* Closes [#13090](https://github.com/MinaProtocol/mina/issues/13090)