### PR TITLE
 Update the Pickles.Composition_types scalars to use arrays of field elements instead of single field elements.

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -114,12 +114,14 @@ module Protocol = struct
            t
         -> int
         -> Pasta_bindings.Fp.t array
+        -> int
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity Kimchi_types.poly_comm
         = "caml_fp_srs_commit_evaluations"
 
       external b_poly_commitment :
            t
         -> Pasta_bindings.Fp.t array
+        -> int
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity Kimchi_types.poly_comm
         = "caml_fp_srs_b_poly_commitment"
 
@@ -163,12 +165,14 @@ module Protocol = struct
            t
         -> int
         -> Pasta_bindings.Fq.t array
+        -> int
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity Kimchi_types.poly_comm
         = "caml_fq_srs_commit_evaluations"
 
       external b_poly_commitment :
            t
         -> Pasta_bindings.Fq.t array
+        -> int
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity Kimchi_types.poly_comm
         = "caml_fq_srs_b_poly_commitment"
 
@@ -315,6 +319,19 @@ module Protocol = struct
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
            Kimchi_types.prover_proof
+        -> t = "fp_oracles_create_no_public"
+
+      external create_with_public_evals :
+           Pasta_bindings.Fq.t Kimchi_types.or_infinity Kimchi_types.poly_comm
+           array
+        -> ( Pasta_bindings.Fp.t
+           , SRS.Fp.t
+           , Pasta_bindings.Fq.t Kimchi_types.or_infinity Kimchi_types.poly_comm
+           )
+           Kimchi_types.VerifierIndex.verifier_index
+        -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
+           , Pasta_bindings.Fp.t )
+           Kimchi_types.proof_with_public
         -> t = "fp_oracles_create"
 
       external dummy : unit -> Pasta_bindings.Fp.t Kimchi_types.random_oracles
@@ -340,6 +357,19 @@ module Protocol = struct
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
            Kimchi_types.prover_proof
+        -> t = "fq_oracles_create_no_public"
+
+      external create_with_public_evals :
+           Pasta_bindings.Fp.t Kimchi_types.or_infinity Kimchi_types.poly_comm
+           array
+        -> ( Pasta_bindings.Fq.t
+           , SRS.Fq.t
+           , Pasta_bindings.Fp.t Kimchi_types.or_infinity Kimchi_types.poly_comm
+           )
+           Kimchi_types.VerifierIndex.verifier_index
+        -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
+           , Pasta_bindings.Fq.t )
+           Kimchi_types.proof_with_public
         -> t = "fq_oracles_create"
 
       external dummy : unit -> Pasta_bindings.Fq.t Kimchi_types.random_oracles
@@ -361,7 +391,7 @@ module Protocol = struct
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.prover_proof = "caml_pasta_fp_plonk_proof_create"
+           Kimchi_types.proof_with_public = "caml_pasta_fp_plonk_proof_create"
 
       external create_and_verify :
            Index.Fp.t
@@ -370,7 +400,7 @@ module Protocol = struct
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.prover_proof
+           Kimchi_types.proof_with_public
         = "caml_pasta_fp_plonk_proof_create_and_verify"
 
       external example_with_lookup :
@@ -380,7 +410,7 @@ module Protocol = struct
            * Pasta_bindings.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.prover_proof
+             Kimchi_types.proof_with_public
         = "caml_pasta_fp_plonk_proof_example_with_lookup"
 
       external example_with_ffadd :
@@ -389,7 +419,7 @@ module Protocol = struct
            * Pasta_bindings.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.prover_proof
+             Kimchi_types.proof_with_public
         = "caml_pasta_fp_plonk_proof_example_with_ffadd"
 
       external example_with_xor :
@@ -398,7 +428,7 @@ module Protocol = struct
            * (Pasta_bindings.Fp.t * Pasta_bindings.Fp.t)
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.prover_proof
+             Kimchi_types.proof_with_public
         = "caml_pasta_fp_plonk_proof_example_with_xor"
 
       external example_with_rot :
@@ -407,7 +437,7 @@ module Protocol = struct
            * (Pasta_bindings.Fp.t * Pasta_bindings.Fp.t)
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.prover_proof
+             Kimchi_types.proof_with_public
         = "caml_pasta_fp_plonk_proof_example_with_rot"
 
       external example_with_foreign_field_mul :
@@ -415,7 +445,7 @@ module Protocol = struct
         -> Index.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.prover_proof
+             Kimchi_types.proof_with_public
         = "caml_pasta_fp_plonk_proof_example_with_foreign_field_mul"
 
       external example_with_range_check :
@@ -423,7 +453,7 @@ module Protocol = struct
         -> Index.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.prover_proof
+             Kimchi_types.proof_with_public
         = "caml_pasta_fp_plonk_proof_example_with_range_check"
 
       external example_with_range_check0 :
@@ -431,7 +461,7 @@ module Protocol = struct
         -> Index.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.prover_proof
+             Kimchi_types.proof_with_public
         = "caml_pasta_fp_plonk_proof_example_with_range_check0"
 
       external verify :
@@ -442,7 +472,7 @@ module Protocol = struct
            Kimchi_types.VerifierIndex.verifier_index
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.prover_proof
+           Kimchi_types.proof_with_public
         -> bool = "caml_pasta_fp_plonk_proof_verify"
 
       external batch_verify :
@@ -454,7 +484,7 @@ module Protocol = struct
            array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.prover_proof
+           Kimchi_types.proof_with_public
            array
         -> bool = "caml_pasta_fp_plonk_proof_batch_verify"
 
@@ -462,15 +492,16 @@ module Protocol = struct
            unit
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.prover_proof = "caml_pasta_fp_plonk_proof_dummy"
+           Kimchi_types.proof_with_public = "caml_pasta_fp_plonk_proof_dummy"
 
       external deep_copy :
            ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.prover_proof
+           Kimchi_types.proof_with_public
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.prover_proof = "caml_pasta_fp_plonk_proof_deep_copy"
+           Kimchi_types.proof_with_public
+        = "caml_pasta_fp_plonk_proof_deep_copy"
     end
 
     module Fq = struct
@@ -481,7 +512,7 @@ module Protocol = struct
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.prover_proof = "caml_pasta_fq_plonk_proof_create"
+           Kimchi_types.proof_with_public = "caml_pasta_fq_plonk_proof_create"
 
       external verify :
            ( Pasta_bindings.Fq.t
@@ -491,7 +522,7 @@ module Protocol = struct
            Kimchi_types.VerifierIndex.verifier_index
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.prover_proof
+           Kimchi_types.proof_with_public
         -> bool = "caml_pasta_fq_plonk_proof_verify"
 
       external batch_verify :
@@ -503,7 +534,7 @@ module Protocol = struct
            array
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.prover_proof
+           Kimchi_types.proof_with_public
            array
         -> bool = "caml_pasta_fq_plonk_proof_batch_verify"
 
@@ -511,15 +542,16 @@ module Protocol = struct
            unit
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.prover_proof = "caml_pasta_fq_plonk_proof_dummy"
+           Kimchi_types.proof_with_public = "caml_pasta_fq_plonk_proof_dummy"
 
       external deep_copy :
            ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.prover_proof
+           Kimchi_types.proof_with_public
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.prover_proof = "caml_pasta_fq_plonk_proof_deep_copy"
+           Kimchi_types.proof_with_public
+        = "caml_pasta_fq_plonk_proof_deep_copy"
     end
   end
 end

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -114,14 +114,12 @@ module Protocol = struct
            t
         -> int
         -> Pasta_bindings.Fp.t array
-        -> int
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity Kimchi_types.poly_comm
         = "caml_fp_srs_commit_evaluations"
 
       external b_poly_commitment :
            t
         -> Pasta_bindings.Fp.t array
-        -> int
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity Kimchi_types.poly_comm
         = "caml_fp_srs_b_poly_commitment"
 
@@ -165,14 +163,12 @@ module Protocol = struct
            t
         -> int
         -> Pasta_bindings.Fq.t array
-        -> int
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity Kimchi_types.poly_comm
         = "caml_fq_srs_commit_evaluations"
 
       external b_poly_commitment :
            t
         -> Pasta_bindings.Fq.t array
-        -> int
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity Kimchi_types.poly_comm
         = "caml_fq_srs_b_poly_commitment"
 
@@ -319,19 +315,6 @@ module Protocol = struct
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
            Kimchi_types.prover_proof
-        -> t = "fp_oracles_create_no_public"
-
-      external create_with_public_evals :
-           Pasta_bindings.Fq.t Kimchi_types.or_infinity Kimchi_types.poly_comm
-           array
-        -> ( Pasta_bindings.Fp.t
-           , SRS.Fp.t
-           , Pasta_bindings.Fq.t Kimchi_types.or_infinity Kimchi_types.poly_comm
-           )
-           Kimchi_types.VerifierIndex.verifier_index
-        -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
-           , Pasta_bindings.Fp.t )
-           Kimchi_types.proof_with_public
         -> t = "fp_oracles_create"
 
       external dummy : unit -> Pasta_bindings.Fp.t Kimchi_types.random_oracles
@@ -357,19 +340,6 @@ module Protocol = struct
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
            Kimchi_types.prover_proof
-        -> t = "fq_oracles_create_no_public"
-
-      external create_with_public_evals :
-           Pasta_bindings.Fp.t Kimchi_types.or_infinity Kimchi_types.poly_comm
-           array
-        -> ( Pasta_bindings.Fq.t
-           , SRS.Fq.t
-           , Pasta_bindings.Fp.t Kimchi_types.or_infinity Kimchi_types.poly_comm
-           )
-           Kimchi_types.VerifierIndex.verifier_index
-        -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
-           , Pasta_bindings.Fq.t )
-           Kimchi_types.proof_with_public
         -> t = "fq_oracles_create"
 
       external dummy : unit -> Pasta_bindings.Fq.t Kimchi_types.random_oracles
@@ -391,7 +361,7 @@ module Protocol = struct
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.proof_with_public = "caml_pasta_fp_plonk_proof_create"
+           Kimchi_types.prover_proof = "caml_pasta_fp_plonk_proof_create"
 
       external create_and_verify :
            Index.Fp.t
@@ -400,7 +370,7 @@ module Protocol = struct
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.proof_with_public
+           Kimchi_types.prover_proof
         = "caml_pasta_fp_plonk_proof_create_and_verify"
 
       external example_with_lookup :
@@ -410,7 +380,7 @@ module Protocol = struct
            * Pasta_bindings.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.proof_with_public
+             Kimchi_types.prover_proof
         = "caml_pasta_fp_plonk_proof_example_with_lookup"
 
       external example_with_ffadd :
@@ -419,7 +389,7 @@ module Protocol = struct
            * Pasta_bindings.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.proof_with_public
+             Kimchi_types.prover_proof
         = "caml_pasta_fp_plonk_proof_example_with_ffadd"
 
       external example_with_xor :
@@ -428,7 +398,7 @@ module Protocol = struct
            * (Pasta_bindings.Fp.t * Pasta_bindings.Fp.t)
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.proof_with_public
+             Kimchi_types.prover_proof
         = "caml_pasta_fp_plonk_proof_example_with_xor"
 
       external example_with_rot :
@@ -437,7 +407,7 @@ module Protocol = struct
            * (Pasta_bindings.Fp.t * Pasta_bindings.Fp.t)
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.proof_with_public
+             Kimchi_types.prover_proof
         = "caml_pasta_fp_plonk_proof_example_with_rot"
 
       external example_with_foreign_field_mul :
@@ -445,7 +415,7 @@ module Protocol = struct
         -> Index.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.proof_with_public
+             Kimchi_types.prover_proof
         = "caml_pasta_fp_plonk_proof_example_with_foreign_field_mul"
 
       external example_with_range_check :
@@ -453,7 +423,7 @@ module Protocol = struct
         -> Index.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.proof_with_public
+             Kimchi_types.prover_proof
         = "caml_pasta_fp_plonk_proof_example_with_range_check"
 
       external example_with_range_check0 :
@@ -461,7 +431,7 @@ module Protocol = struct
         -> Index.Fp.t
            * ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
              , Pasta_bindings.Fp.t )
-             Kimchi_types.proof_with_public
+             Kimchi_types.prover_proof
         = "caml_pasta_fp_plonk_proof_example_with_range_check0"
 
       external verify :
@@ -472,7 +442,7 @@ module Protocol = struct
            Kimchi_types.VerifierIndex.verifier_index
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.proof_with_public
+           Kimchi_types.prover_proof
         -> bool = "caml_pasta_fp_plonk_proof_verify"
 
       external batch_verify :
@@ -484,7 +454,7 @@ module Protocol = struct
            array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.proof_with_public
+           Kimchi_types.prover_proof
            array
         -> bool = "caml_pasta_fp_plonk_proof_batch_verify"
 
@@ -492,16 +462,15 @@ module Protocol = struct
            unit
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.proof_with_public = "caml_pasta_fp_plonk_proof_dummy"
+           Kimchi_types.prover_proof = "caml_pasta_fp_plonk_proof_dummy"
 
       external deep_copy :
            ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.proof_with_public
+           Kimchi_types.prover_proof
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
            , Pasta_bindings.Fp.t )
-           Kimchi_types.proof_with_public
-        = "caml_pasta_fp_plonk_proof_deep_copy"
+           Kimchi_types.prover_proof = "caml_pasta_fp_plonk_proof_deep_copy"
     end
 
     module Fq = struct
@@ -512,7 +481,7 @@ module Protocol = struct
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.proof_with_public = "caml_pasta_fq_plonk_proof_create"
+           Kimchi_types.prover_proof = "caml_pasta_fq_plonk_proof_create"
 
       external verify :
            ( Pasta_bindings.Fq.t
@@ -522,7 +491,7 @@ module Protocol = struct
            Kimchi_types.VerifierIndex.verifier_index
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.proof_with_public
+           Kimchi_types.prover_proof
         -> bool = "caml_pasta_fq_plonk_proof_verify"
 
       external batch_verify :
@@ -534,7 +503,7 @@ module Protocol = struct
            array
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.proof_with_public
+           Kimchi_types.prover_proof
            array
         -> bool = "caml_pasta_fq_plonk_proof_batch_verify"
 
@@ -542,16 +511,15 @@ module Protocol = struct
            unit
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.proof_with_public = "caml_pasta_fq_plonk_proof_dummy"
+           Kimchi_types.prover_proof = "caml_pasta_fq_plonk_proof_dummy"
 
       external deep_copy :
            ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.proof_with_public
+           Kimchi_types.prover_proof
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity
            , Pasta_bindings.Fq.t )
-           Kimchi_types.proof_with_public
-        = "caml_pasta_fq_plonk_proof_deep_copy"
+           Kimchi_types.prover_proof = "caml_pasta_fq_plonk_proof_deep_copy"
     end
   end
 end

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -118,11 +118,6 @@ type nonrec ('caml_g, 'caml_f) prover_proof =
   ; prev_challenges : ('caml_g, 'caml_f) recursion_challenge array
   }
 
-type nonrec ('caml_g, 'caml_f) proof_with_public =
-  { public_evals : 'caml_f array point_evaluations option
-  ; proof : ('caml_g, 'caml_f) prover_proof
-  }
-
 type nonrec wire = { row : int; col : int }
 
 type nonrec gate_type =
@@ -219,7 +214,6 @@ module VerifierIndex = struct
   type nonrec ('fr, 'srs, 'poly_comm) verifier_index =
     { domain : 'fr domain
     ; max_poly_size : int
-    ; zk_rows : int
     ; public : int
     ; prev_challenges : int
     ; srs : 'srs

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -118,6 +118,11 @@ type nonrec ('caml_g, 'caml_f) prover_proof =
   ; prev_challenges : ('caml_g, 'caml_f) recursion_challenge array
   }
 
+type nonrec ('caml_g, 'caml_f) proof_with_public =
+  { public_evals : 'caml_f array point_evaluations option
+  ; proof : ('caml_g, 'caml_f) prover_proof
+  }
+
 type nonrec wire = { row : int; col : int }
 
 type nonrec gate_type =
@@ -214,6 +219,7 @@ module VerifierIndex = struct
   type nonrec ('fr, 'srs, 'poly_comm) verifier_index =
     { domain : 'fr domain
     ; max_poly_size : int
+    ; zk_rows : int
     ; public : int
     ; prev_challenges : int
     ; srs : 'srs

--- a/src/lib/pickles/common.mli
+++ b/src/lib/pickles/common.mli
@@ -158,7 +158,7 @@ val hash_messages_for_next_step_proof :
 
 val tick_public_input_of_statement :
      max_proofs_verified:'a Pickles_types.Nat.t
-  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> feature_flags:Plonk_types.Features.chunked_options
   -> ( ( ( Impls.Step.Challenge.Constant.t
          , Impls.Step.Challenge.Constant.t Composition_types.Scalar_challenge.t
          , Impls.Step.Other_field.Constant.t Pickles_types.Shifted_value.Type2.t

--- a/src/lib/pickles/compile.ml
+++ b/src/lib/pickles/compile.ml
@@ -424,9 +424,8 @@ struct
     Timer.clock __LOC__ ;
     let feature_flags =
       let rec go :
-          type a b c d.
-             (a, b, c, d) H4.T(IR).t
-          -> Plonk_types.Opt.Flag.t Plonk_types.Features.t =
+          type a b c d. (a, b, c, d) H4.T(IR).t -> Plonk_types.Features.options
+          =
        fun rules ->
         match rules with
         | [] ->
@@ -449,7 +448,7 @@ struct
                 | _, Maybe | true, No | false, Yes ->
                     Maybe )
       in
-      go choices
+      go choices |> Plonk_types.Features.chunk
     in
     let wrap_domains =
       match override_wrap_domain with

--- a/src/lib/pickles/compile.mli
+++ b/src/lib/pickles/compile.mli
@@ -117,7 +117,7 @@ module Side_loaded : sig
   val create :
        name:string
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'n1)
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Features.chunked_options
     -> typ:('var, 'value) Impls.Step.Typ.t
     -> ('var, 'value, 'n1, Verification_key.Max_branches.n) Tag.t
 

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -351,7 +351,8 @@ module Wrap = struct
           let typ (type f fp)
               (module Impl : Snarky_backendless.Snark_intf.Run
                 with type field = f ) ~dummy_scalar ~dummy_scalar_challenge
-              ~challenge ~scalar_challenge ~bool ~feature_flags
+              ~challenge ~scalar_challenge ~bool
+              ~(feature_flags : Plonk_types.Features.chunked_options)
               (fp : (fp, _, f) Snarky_backendless.Typ.t) =
             Snarky_backendless.Typ.of_hlistable
               [ Scalar_challenge.typ scalar_challenge

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -237,6 +237,7 @@ module Wrap = struct
                 (* ((module Impl) : f impl) *) (zero : _ Zero_values.t)
                 (feature_flags : Plonk_types.Features.chunked_options) =
               let opt_spec flag =
+                let flag = flag.(0) in
                 let opt_spec =
                   Spec.T.Opt_unflagged
                     { inner = B Field

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -944,7 +944,8 @@ module Wrap = struct
           ; feature_flags_spec
           ; Lookup_parameters.opt_spec impl lookup
           ; Proof_state.Deferred_values.Plonk.In_circuit.Optional_column_scalars
-            .spec impl lookup.zero feature_flags
+            .spec impl lookup.zero
+              (Plonk_types.Features.chunk feature_flags)
           ]
 
       (** Convert a statement (as structured data) into the flat data-based representation. *)

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -235,8 +235,7 @@ module Wrap = struct
 
             let spec (* (type f) *) _
                 (* ((module Impl) : f impl) *) (zero : _ Zero_values.t)
-                (feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t)
-                =
+                (feature_flags : Plonk_types.Features.chunked_options) =
               let opt_spec flag =
                 let opt_spec =
                   Spec.T.Opt_unflagged
@@ -269,8 +268,7 @@ module Wrap = struct
             let typ (type f fp)
                 (module Impl : Snarky_backendless.Snark_intf.Run
                   with type field = f ) (fp : (fp, _) Impl.Typ.t) ~dummy_scalar
-                (feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t)
-                =
+                (feature_flags : Plonk_types.Features.chunked_options) =
               let opt_typ flag =
                 Plonk_types.Opt.typ Impl.Boolean.typ flag fp ~dummy:dummy_scalar
               in
@@ -1497,8 +1495,8 @@ module Step = struct
     let[@warning "-60"] typ (type n f)
         ( (module Impl : Snarky_backendless.Snark_intf.Run with type field = f)
         as impl ) zero ~assert_16_bits
-        (proofs_verified :
-          (Plonk_types.Opt.Flag.t Plonk_types.Features.t, n) Vector.t ) fq :
+        (proofs_verified : (Plonk_types.Features.chunked_options, n) Vector.t)
+        fq :
         ( ((_, _) Vector.t, _) t
         , ((_, _) Vector.t, _) t
         , _ )

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -100,6 +100,8 @@ module Wrap = struct
               }
             [@@deriving sexp, compare, yojson, hlist, hash, equal, fields]
 
+            type 'a chunks = 'a array t
+
             let map ~f
                 { range_check0
                 ; range_check1
@@ -119,6 +121,10 @@ module Wrap = struct
               ; lookup_gate = f lookup_gate
               ; runtime_tables = f runtime_tables
               }
+
+            let chunk t = map ~f:(Array.create ~len:1) t
+
+            let unchunk t = map ~f:(fun a -> Array.get a 0) t
 
             let map2 ~f t1 t2 =
               { range_check0 = f t1.range_check0 t2.range_check0

--- a/src/lib/pickles/composition_types/composition_types.ml
+++ b/src/lib/pickles/composition_types/composition_types.ml
@@ -1313,9 +1313,10 @@ module Step = struct
             ; Vector (B Bool, Nat.N1.n)
             ; feature_flags_spec
             ; Wrap.Lookup_parameters.opt_spec impl lookup
-            ; Wrap.Proof_state.Deferred_values.Plonk.In_circuit
-              .Optional_column_scalars
-              .spec impl lookup.zero feature_flags
+            ; (let feature_flags = Plonk_types.Features.chunk feature_flags in
+               Wrap.Proof_state.Deferred_values.Plonk.In_circuit
+               .Optional_column_scalars
+               .spec impl lookup.zero feature_flags )
             ]
 
         let[@warning "-45"] to_data
@@ -1505,6 +1506,7 @@ module Step = struct
         , _ )
         Snarky_backendless.Typ.t =
       let per_proof feature_flags =
+        let feature_flags = Plonk_types.Features.unchunk feature_flags in
         Per_proof.typ impl fq ~feature_flags ~assert_16_bits ~zero
       in
       let unfinalized_proofs =

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -188,7 +188,7 @@ module Wrap : sig
                  , bool
                  , 'f )
                  Snarky_backendless.Typ.t
-            -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+            -> feature_flags:Plonk_types.Features.chunked_options
             -> ('fp, 'a, 'f) Snarky_backendless.Typ.t
             -> ( ( 'c
                  , 'e Scalar_challenge.t
@@ -345,7 +345,7 @@ module Wrap : sig
                  Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
                snarky_typ
           -> scalar_challenge:('e, 'b, 'f) Snarky_backendless.Typ.t
-          -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+          -> feature_flags:Plonk_types.Features.chunked_options
           -> ('fp, 'a, 'f) Snarky_backendless.Typ.t
           -> ( 'g
              , 'h
@@ -575,7 +575,7 @@ module Wrap : sig
                Snarky_backendless.Checked_runner.Simple.Types.Checked.t )
              snarky_typ
         -> scalar_challenge:('e, 'b, 'f) Snarky_backendless.Typ.t
-        -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+        -> feature_flags:Plonk_types.Features.chunked_options
         -> ('fp, 'a, 'f) Snarky_backendless.Typ.t
         -> ( 'g
            , 'h
@@ -910,7 +910,7 @@ module Wrap : sig
            , 'field1 Hlist0.Id.t
            , 'field2 Hlist0.Id.t )
            Lookup_parameters.t
-        -> Plonk_types.Opt.Flag.t Plonk_types.Features.t
+        -> Plonk_types.Features.chunked_options
         -> ( ( 'field1
              , 'challenge1
              , 'challenge1 Scalar_challenge.t
@@ -1197,7 +1197,7 @@ module Step : sig
              , 'field1 Hlist0.Id.t
              , 'field2 Hlist0.Id.t )
              Wrap.Lookup_parameters.t
-          -> Plonk_types.Opt.Flag.t Plonk_types.Features.t
+          -> Plonk_types.Features.chunked_options
           -> ( ( 'field1
                , 'digest1
                , 'challenge1
@@ -1292,7 +1292,7 @@ module Step : sig
              , 'c Hlist0.Id.t
              , 'b Hlist0.Id.t )
              Zero_values.t
-        -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+        -> feature_flags:Plonk_types.Features.chunked_options
         -> ( ( 'a Limb_vector.Challenge.t
              , 'a Limb_vector.Challenge.t Scalar_challenge.t
              , 'b
@@ -1359,7 +1359,7 @@ module Step : sig
          , 'b Hlist0.Id.t )
          Zero_values.t
       -> assert_16_bits:('f Snarky_backendless.Cvar.t -> unit)
-      -> (Plonk_types.Opt.Flag.t Plonk_types.Features.t, 'n) Vector.t
+      -> (Plonk_types.Features.chunked_options, 'n) Vector.t
       -> ( 'b
          , 'a
          , 'f
@@ -1508,7 +1508,7 @@ module Step : sig
       -> 'b Nat.t
       -> 'c Nat.t
       -> ('d, 'e, 'f Hlist0.Id.t, 'g Hlist0.Id.t) Wrap.Lookup_parameters.t
-      -> Plonk_types.Opt.Flag.t Plonk_types.Features.t
+      -> Plonk_types.Features.chunked_options
       -> ( ( ( ( ('f, Nat.N9.n) Vector.t
                * ( ('h, Nat.N1.n) Vector.t
                  * ( ('d, Nat.N2.n) Vector.t

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -967,9 +967,7 @@ module Wrap : sig
       (** Construct a statement (as structured data) from the flat data-based representation. *)
       val of_data :
            ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'fp option, 'bool) flat_repr
-        -> feature_flags:
-             Pickles_types.Plonk_types.Opt.Flag.t
-             Pickles_types.Plonk_types.Features.t
+        -> feature_flags:Pickles_types.Plonk_types.Features.chunked_options
         -> option_map:
              (   'g Hlist0.Id.t
               -> f:

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -109,6 +109,12 @@ module Wrap : sig
               }
             [@@deriving sexp, compare, yojson, hlist, hash, equal, fields]
 
+            type 'a chunked = 'a array t
+
+            val chunk : 'a t -> 'a chunked
+
+            val unchunk : 'a chunked -> 'a t
+
             val to_list : 'fp t -> 'fp list
 
             val map : f:('a -> 'b) -> 'a t -> 'b t

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -1476,9 +1476,7 @@ module Step : sig
            Vector.t
          * ('i * ('j * unit)) )
          Hlist.HlistId.t
-      -> feature_flags:
-           Pickles_types.Plonk_types.Opt.Flag.t
-           Pickles_types.Plonk_types.Features.t
+      -> feature_flags:Pickles_types.Plonk_types.Features.chunked_options
       -> option_map:
            (   'g Hlist0.Id.t
             -> f:

--- a/src/lib/pickles/composition_types/composition_types.mli
+++ b/src/lib/pickles/composition_types/composition_types.mli
@@ -966,17 +966,52 @@ module Wrap : sig
 
       (** Construct a statement (as structured data) from the flat data-based representation. *)
       val of_data :
-           ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'fp option, 'bool) flat_repr
-        -> feature_flags:Pickles_types.Plonk_types.Features.chunked_options
+           ( ( 'a
+             , Nat.z Nat.s Nat.s Nat.s Nat.s Nat.s Nat.s Nat.s Nat.s Nat.s )
+             Vector.vec
+           * ( ('b, Nat.z Nat.s Nat.s) Vector.vec
+             * ( ('c, Nat.z Nat.s Nat.s Nat.s) Vector.vec
+               * ( ('d, Nat.z Nat.s Nat.s Nat.s) Vector.vec
+                 * ( 'e
+                   * ( ('f, Nat.z Nat.s) Vector.vec
+                     * ( ( 'g
+                         * ('g * ('g * ('g * ('g * ('g * ('g * ('g * unit)))))))
+                         )
+                         Hlist0.HlistId.t
+                       * ( 'h
+                         * ( ( 'i option
+                             * ( 'i option
+                               * ( 'i option
+                                 * ( 'i option
+                                   * ( 'i option
+                                     * ( 'i option
+                                       * ('i option * ('i option * unit)) ) ) )
+                                 ) ) )
+                             Hlist0.HlistId.t
+                           * unit ) ) ) ) ) ) ) ) )
+           Hlist0.HlistId.t
+        -> feature_flags:Opt.Flag.t Plonk_types.Features.chunked
         -> option_map:
-             (   'g Hlist0.Id.t
+             (   'h
               -> f:
-                   (   ('h * unit) Hlist.HlistId.t
-                    -> 'h Proof_state.Deferred_values.Plonk.In_circuit.Lookup.t
+                   (   ('j * unit) Hlist0.HlistId.t
+                    -> 'j Proof_state.Deferred_values.Plonk.In_circuit.Lookup.t
                    )
-              -> 'j )
-        -> of_opt:(('fp, 'bool) Pickles_types.Plonk_types.Opt.t -> 'fp_opt2)
-        -> ('b, 'c, 'a, 'fp_opt2, 'j, 'bool, 'd, 'd, 'd, 'e, 'f) t
+              -> 'k )
+        -> of_opt:(('i, 'g) Opt.t -> 'l)
+        -> ('b, 'c, 'a, 'l, 'k, 'g, 'd, 'd, 'd, 'e, 'f) t
+      (* ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'fp option, 'bool) flat_repr
+         -> feature_flags:Pickles_types.Plonk_types.Features.chunked_options
+         -> option_map:
+              (   'g Hlist0.Id.t
+               -> f:
+                    (   ('h * unit) Hlist.HlistId.t
+                     -> 'h Proof_state.Deferred_values.Plonk.In_circuit.Lookup.t
+                    )
+               -> 'j )
+         -> of_opt:
+              (('fp, 'bool) Pickles_types.Plonk_types.Opt.t array -> 'fp_opt2)
+         -> ('b, 'c, 'a, 'fp_opt2, 'j, 'bool, 'd, 'd, 'd, 'e, 'f) t *)
     end
 
     val to_minimal :
@@ -1195,7 +1230,7 @@ module Step : sig
              , 'field1 Hlist0.Id.t
              , 'field2 Hlist0.Id.t )
              Wrap.Lookup_parameters.t
-          -> Plonk_types.Features.chunked_options
+          -> Plonk_types.Features.options
           -> ( ( 'field1
                , 'digest1
                , 'challenge1

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -283,7 +283,7 @@ module Wrap = struct
         (* Wrap circuit: no features needed. *)
         (In_circuit.spec (module Impl) lookup Plonk_types.Features.none_chunked)
     in
-    let feature_flags = Plonk_types.Features.none in
+    let feature_flags = Plonk_types.Features.none_chunked in
     let typ =
       Typ.transport typ
         ~there:(In_circuit.to_data ~option_map:Option.map ~to_opt:Fn.id)

--- a/src/lib/pickles/impls.ml
+++ b/src/lib/pickles/impls.ml
@@ -281,7 +281,7 @@ module Wrap = struct
                t )
            , Fn.id ) )
         (* Wrap circuit: no features needed. *)
-        (In_circuit.spec (module Impl) lookup Plonk_types.Features.none)
+        (In_circuit.spec (module Impl) lookup Plonk_types.Features.none_chunked)
     in
     let feature_flags = Plonk_types.Features.none in
     let typ =

--- a/src/lib/pickles/impls.mli
+++ b/src/lib/pickles/impls.mli
@@ -39,7 +39,7 @@ module Step : sig
   val input :
        proofs_verified:'a Pickles_types.Nat.t
     -> wrap_rounds:'b Pickles_types.Nat.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Features.chunked_options
     -> ( ( ( ( Impl.Field.t
              , Impl.Field.t Composition_types.Scalar_challenge.t
              , Other_field.t Pickles_types.Shifted_value.Type2.t

--- a/src/lib/pickles/per_proof_witness.mli
+++ b/src/lib/pickles/per_proof_witness.mli
@@ -117,7 +117,7 @@ module Constant : sig
 end
 
 val typ :
-     feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+     feature_flags:Plonk_types.Features.chunked_options
   -> ('avar, 'aval) Impl.Typ.t
   -> 'n Pickles_types.Nat.t
   -> (('avar, 'n, _) t, ('aval, 'n) Constant.t) Impl.Typ.t

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1134,7 +1134,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
           let full_signature =
             { Full_signature.padded; maxes = (module Maxes) }
           in
-          let feature_flags = Plonk_types.Features.none in
+          let feature_flags = Plonk_types.Features.none_chunked in
           let actual_feature_flags = Plonk_types.Features.none_bool in
           let wrap_domains =
             let module M =

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1423,7 +1423,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                     let module O = Tick.Oracles in
                     let public_input =
                       tick_public_input_of_statement ~max_proofs_verified
-                        ~feature_flags:Plonk_types.Features.none
+                        ~feature_flags:Plonk_types.Features.none_chunked
                         prev_statement_with_hashes
                     in
                     let prev_challenges =

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -2575,7 +2575,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
         let side_loaded_tag =
           Side_loaded.create ~name:"foo"
             ~max_proofs_verified:(Nat.Add.create Nat.N2.n)
-            ~feature_flags:maybe_features ~typ:Field.typ
+            ~feature_flags:(Plonk_types.Features.chunk maybe_features)
+            ~typ:Field.typ
 
         let[@warning "-45"] _tag, _, p, Provers.[ step ] =
           Common.time "compile" (fun () ->

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1654,7 +1654,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
                         end in
                         Wrap.Type1.derive_plonk
                           (module Field)
-                          ~feature_flags:Plonk_types.Features.none
+                          ~feature_flags:Plonk_types.Features.none_chunked
                           ~shift:Shifts.tick1 ~env:tick_env tick_plonk_minimal
                           tick_combined_evals
                       in
@@ -2224,7 +2224,7 @@ module Make_str (_ : Wire_types.Concrete) = struct
         let side_loaded_tag =
           Side_loaded.create ~name:"foo"
             ~max_proofs_verified:(Nat.Add.create Nat.N2.n)
-            ~feature_flags:Plonk_types.Features.none ~typ:Field.typ
+            ~feature_flags:Plonk_types.Features.none_chunked ~typ:Field.typ
 
         let[@warning "-45"] _tag, _, p, Provers.[ step ] =
           Common.time "compile" (fun () ->

--- a/src/lib/pickles/pickles_intf.mli
+++ b/src/lib/pickles/pickles_intf.mli
@@ -333,7 +333,7 @@ module type S = sig
     val create :
          name:string
       -> max_proofs_verified:(module Nat.Add.Intf with type n = 'n1)
-      -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+      -> feature_flags:Plonk_types.Features.chunked_options
       -> typ:('var, 'value) Impls.Step.Typ.t
       -> ('var, 'value, 'n1, Verification_key.Max_branches.n) Tag.t
 

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -510,35 +510,35 @@ module Make (Shifted_value : Shifted_value.S) (Sc : Scalars.S) = struct
             | Some joint_combiner ->
                 Some { joint_combiner } )
         ; optional_column_scalars =
-             { range_check0 =
-                 compute_feature (Index RangeCheck0) feature_flags.range_check0
-                   actual_feature_flags.range_check0
-             ; range_check1 =
-                 compute_feature (Index RangeCheck1) feature_flags.range_check1
-                   actual_feature_flags.range_check1
-             ; foreign_field_add =
-                 compute_feature (Index ForeignFieldAdd)
-                   feature_flags.foreign_field_add
-                   actual_feature_flags.foreign_field_add
-             ; foreign_field_mul =
-                 compute_feature (Index ForeignFieldMul)
-                   feature_flags.foreign_field_mul
-                   actual_feature_flags.foreign_field_mul
-             ; xor =
-                 compute_feature (Index Xor16) feature_flags.xor
-                   actual_feature_flags.xor
-             ; rot =
-                 compute_feature (Index Rot64) feature_flags.rot
-                   actual_feature_flags.rot
-             ; lookup_gate =
-                 compute_feature (LookupKindIndex Lookup) feature_flags.lookup
-                   actual_feature_flags.lookup
-             ; runtime_tables =
-                 compute_feature LookupRuntimeSelector
-                   feature_flags.runtime_tables
-                   actual_feature_flags.runtime_tables
-             } ;
-             feature_flags = actual_feature_flags )
+            { range_check0 =
+                compute_feature (Index RangeCheck0) feature_flags.range_check0
+                  actual_feature_flags.range_check0
+            ; range_check1 =
+                compute_feature (Index RangeCheck1) feature_flags.range_check1
+                  actual_feature_flags.range_check1
+            ; foreign_field_add =
+                compute_feature (Index ForeignFieldAdd)
+                  feature_flags.foreign_field_add
+                  actual_feature_flags.foreign_field_add
+            ; foreign_field_mul =
+                compute_feature (Index ForeignFieldMul)
+                  feature_flags.foreign_field_mul
+                  actual_feature_flags.foreign_field_mul
+            ; xor =
+                compute_feature (Index Xor16) feature_flags.xor
+                  actual_feature_flags.xor
+            ; rot =
+                compute_feature (Index Rot64) feature_flags.rot
+                  actual_feature_flags.rot
+            ; lookup_gate =
+                compute_feature (LookupKindIndex Lookup) feature_flags.lookup
+                  actual_feature_flags.lookup
+            ; runtime_tables =
+                compute_feature LookupRuntimeSelector
+                  feature_flags.runtime_tables
+                  actual_feature_flags.runtime_tables
+            }
+        ; feature_flags = actual_feature_flags
         }
 
   (** Check that computed proof scalars match the expected ones,

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -213,6 +213,8 @@ let lookup_tables_used feature_flags =
 
     let any = List.fold_left ~f:( ||| ) ~init:false_
   end in
+  let feature_flags = Plonk_types.Features.unchunk feature_flags in
+  (* FIXME: Chunk *)
   let all_feature_flags = expand_feature_flags (module Bool) feature_flags in
   Lazy.force all_feature_flags.lookup_tables
 

--- a/src/lib/pickles/plonk_checks/plonk_checks.ml
+++ b/src/lib/pickles/plonk_checks/plonk_checks.ml
@@ -450,7 +450,7 @@ module Make (Shifted_value : Shifted_value.S) (Sc : Scalars.S) = struct
   (** Computes the list of scalars used in the linearization. *)
   let derive_plonk (type t) ?(with_label = fun _ (f : unit -> t) -> f ())
       (module F : Field_intf with type t = t) ~(env : t Scalars.Env.t) ~shift
-      ~(feature_flags : _ Plonk_types.Features.t) =
+      ~(feature_flags : Plonk_types.Features.chunked_options) =
     let _ = with_label in
     let open F in
     fun ({ alpha
@@ -478,6 +478,7 @@ module Make (Shifted_value : Shifted_value.S) (Sc : Scalars.S) = struct
             |> negate )
       in
       let compute_feature column feature_flag actual_feature_flag =
+        let feature_flag = feature_flag.(0) in
         match feature_flag with
         | Opt.Flag.Yes ->
             Opt.Some (Lazy.force (Hashtbl.find_exn index_terms column))
@@ -509,35 +510,35 @@ module Make (Shifted_value : Shifted_value.S) (Sc : Scalars.S) = struct
             | Some joint_combiner ->
                 Some { joint_combiner } )
         ; optional_column_scalars =
-            { range_check0 =
-                compute_feature (Index RangeCheck0) feature_flags.range_check0
-                  actual_feature_flags.range_check0
-            ; range_check1 =
-                compute_feature (Index RangeCheck1) feature_flags.range_check1
-                  actual_feature_flags.range_check1
-            ; foreign_field_add =
-                compute_feature (Index ForeignFieldAdd)
-                  feature_flags.foreign_field_add
-                  actual_feature_flags.foreign_field_add
-            ; foreign_field_mul =
-                compute_feature (Index ForeignFieldMul)
-                  feature_flags.foreign_field_mul
-                  actual_feature_flags.foreign_field_mul
-            ; xor =
-                compute_feature (Index Xor16) feature_flags.xor
-                  actual_feature_flags.xor
-            ; rot =
-                compute_feature (Index Rot64) feature_flags.rot
-                  actual_feature_flags.rot
-            ; lookup_gate =
-                compute_feature (LookupKindIndex Lookup) feature_flags.lookup
-                  actual_feature_flags.lookup
-            ; runtime_tables =
-                compute_feature LookupRuntimeSelector
-                  feature_flags.runtime_tables
-                  actual_feature_flags.runtime_tables
-            }
-        ; feature_flags = actual_feature_flags
+             { range_check0 =
+                 compute_feature (Index RangeCheck0) feature_flags.range_check0
+                   actual_feature_flags.range_check0
+             ; range_check1 =
+                 compute_feature (Index RangeCheck1) feature_flags.range_check1
+                   actual_feature_flags.range_check1
+             ; foreign_field_add =
+                 compute_feature (Index ForeignFieldAdd)
+                   feature_flags.foreign_field_add
+                   actual_feature_flags.foreign_field_add
+             ; foreign_field_mul =
+                 compute_feature (Index ForeignFieldMul)
+                   feature_flags.foreign_field_mul
+                   actual_feature_flags.foreign_field_mul
+             ; xor =
+                 compute_feature (Index Xor16) feature_flags.xor
+                   actual_feature_flags.xor
+             ; rot =
+                 compute_feature (Index Rot64) feature_flags.rot
+                   actual_feature_flags.rot
+             ; lookup_gate =
+                 compute_feature (LookupKindIndex Lookup) feature_flags.lookup
+                   actual_feature_flags.lookup
+             ; runtime_tables =
+                 compute_feature LookupRuntimeSelector
+                   feature_flags.runtime_tables
+                   actual_feature_flags.runtime_tables
+             } ;
+             feature_flags = actual_feature_flags )
         }
 
   (** Check that computed proof scalars match the expected ones,

--- a/src/lib/pickles/plonk_checks/plonk_checks.mli
+++ b/src/lib/pickles/plonk_checks/plonk_checks.mli
@@ -59,7 +59,7 @@ end
 type 'f field = (module Field_intf with type t = 'f)
 
 val lookup_tables_used :
-  Plonk_types.Opt.Flag.t Plonk_types.Features.t -> Plonk_types.Opt.Flag.t
+  Plonk_types.Features.chunked_options -> Plonk_types.Opt.Flag.t
 
 val domain :
      't field
@@ -109,7 +109,7 @@ module Make (Shifted_value : Pickles_types.Shifted_value.S) (_ : Scalars.S) : si
     -> (module Field_intf with type t = 't)
     -> env:'t Scalars.Env.t
     -> shift:'t Shifted_value.Shift.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Features.chunked_options
     -> ( 't
        , 't
        , 'b )
@@ -132,7 +132,7 @@ module Make (Shifted_value : Pickles_types.Shifted_value.S) (_ : Scalars.S) : si
        (module Snarky_backendless.Snark_intf.Run with type field = 't)
     -> shift:'t Snarky_backendless.Cvar.t Shifted_value.Shift.t
     -> env:'t Snarky_backendless.Cvar.t Scalars.Env.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Features.chunked_options
     -> ( 't Snarky_backendless.Cvar.t
        , 't Snarky_backendless.Cvar.t
        , 't Snarky_backendless.Cvar.t Shifted_value.t

--- a/src/lib/pickles/plonk_checks/scalars.ml
+++ b/src/lib/pickles/plonk_checks/scalars.ml
@@ -316,7 +316,7 @@ module Tick : S = struct
         ( LookupTables
         , (fun () ->
             alpha_pow 24
-            * ( vanishes_on_last_4_rows
+            * ( vanishes_on_zero_knowledge_and_previous_rows
               * ( cell (var (LookupAggreg, Next))
                   * ( if_feature
                         ( LookupsPerRow 0
@@ -643,7 +643,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -802,7 +802,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -1004,7 +1004,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -1207,7 +1207,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -1405,29 +1405,29 @@ module Tick : S = struct
                ) ) )
       ; ( Index CompleteAdd
         , lazy
-            (let x_0 =
+            (let x_30 =
                cell (var (Witness 2, Curr)) - cell (var (Witness 0, Curr))
              in
-             let x_1 =
+             let x_31 =
                cell (var (Witness 3, Curr)) - cell (var (Witness 1, Curr))
              in
-             let x_2 =
+             let x_32 =
                cell (var (Witness 0, Curr)) * cell (var (Witness 0, Curr))
              in
-             (cell (var (Witness 10, Curr)) * x_0)
+             (cell (var (Witness 10, Curr)) * x_30)
              - ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                - cell (var (Witness 7, Curr)) )
-             + (alpha_pow 1 * (cell (var (Witness 7, Curr)) * x_0))
+             + (alpha_pow 1 * (cell (var (Witness 7, Curr)) * x_30))
              + alpha_pow 2
                * ( cell (var (Witness 7, Curr))
                    * ( double (cell (var (Witness 8, Curr)))
                        * cell (var (Witness 1, Curr))
-                     - double x_2 - x_2 )
+                     - double x_32 - x_32 )
                  + ( field
                        "0x0000000000000000000000000000000000000000000000000000000000000001"
                    - cell (var (Witness 7, Curr)) )
-                   * ((x_0 * cell (var (Witness 8, Curr))) - x_1) )
+                   * ((x_30 * cell (var (Witness 8, Curr))) - x_31) )
              + alpha_pow 3
                * ( cell (var (Witness 0, Curr))
                  + cell (var (Witness 2, Curr))
@@ -1441,138 +1441,138 @@ module Tick : S = struct
                  - cell (var (Witness 1, Curr))
                  - cell (var (Witness 5, Curr)) )
              + alpha_pow 5
-               * ( x_1
+               * ( x_31
                  * (cell (var (Witness 7, Curr)) - cell (var (Witness 6, Curr)))
                  )
              + alpha_pow 6
-               * ( (x_1 * cell (var (Witness 9, Curr)))
+               * ( (x_31 * cell (var (Witness 9, Curr)))
                  - cell (var (Witness 6, Curr)) ) ) )
       ; ( Index VarBaseMul
         , lazy
-            (let x_0 =
+            (let x_15 =
                cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
              in
-             let x_1 =
-               let x_0 =
+             let x_16 =
+               let x_15 =
                  cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
                in
                cell (var (Witness 2, Curr))
-               - ( x_0
+               - ( x_15
                  - cell (var (Witness 2, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_2 =
-               let x_1 =
-                 let x_0 =
+             let x_17 =
+               let x_16 =
+                 let x_15 =
                    cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
                  in
                  cell (var (Witness 2, Curr))
-                 - ( x_0
+                 - ( x_15
                    - cell (var (Witness 2, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 3, Curr)))
-               - (x_1 * cell (var (Witness 7, Next)))
+               - (x_16 * cell (var (Witness 7, Next)))
              in
-             let x_3 =
+             let x_18 =
                cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
              in
-             let x_4 =
-               let x_3 =
+             let x_19 =
+               let x_18 =
                  cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
                in
                cell (var (Witness 7, Curr))
-               - ( x_3
+               - ( x_18
                  - cell (var (Witness 7, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_5 =
-               let x_4 =
-                 let x_3 =
+             let x_20 =
+               let x_19 =
+                 let x_18 =
                    cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
                  in
                  cell (var (Witness 7, Curr))
-                 - ( x_3
+                 - ( x_18
                    - cell (var (Witness 7, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 8, Curr)))
-               - (x_4 * cell (var (Witness 8, Next)))
+               - (x_19 * cell (var (Witness 8, Next)))
              in
-             let x_6 =
+             let x_21 =
                cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
              in
-             let x_7 =
-               let x_6 =
+             let x_22 =
+               let x_21 =
                  cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
                in
                cell (var (Witness 9, Curr))
-               - ( x_6
+               - ( x_21
                  - cell (var (Witness 9, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_8 =
-               let x_7 =
-                 let x_6 =
+             let x_23 =
+               let x_22 =
+                 let x_21 =
                    cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
                  in
                  cell (var (Witness 9, Curr))
-                 - ( x_6
+                 - ( x_21
                    - cell (var (Witness 9, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 10, Curr)))
-               - (x_7 * cell (var (Witness 9, Next)))
+               - (x_22 * cell (var (Witness 9, Next)))
              in
-             let x_9 =
+             let x_24 =
                cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
              in
-             let x_10 =
-               let x_9 =
+             let x_25 =
+               let x_24 =
                  cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
                in
                cell (var (Witness 11, Curr))
-               - ( x_9
+               - ( x_24
                  - cell (var (Witness 11, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_11 =
-               let x_10 =
-                 let x_9 =
+             let x_26 =
+               let x_25 =
+                 let x_24 =
                    cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
                  in
                  cell (var (Witness 11, Curr))
-                 - ( x_9
+                 - ( x_24
                    - cell (var (Witness 11, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 12, Curr)))
-               - (x_10 * cell (var (Witness 10, Next)))
+               - (x_25 * cell (var (Witness 10, Next)))
              in
-             let x_12 =
+             let x_27 =
                cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
              in
-             let x_13 =
-               let x_12 =
+             let x_28 =
+               let x_27 =
                  cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
                in
                cell (var (Witness 13, Curr))
-               - ( x_12
+               - ( x_27
                  - cell (var (Witness 13, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_14 =
-               let x_13 =
-                 let x_12 =
+             let x_29 =
+               let x_28 =
+                 let x_27 =
                    cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
                  in
                  cell (var (Witness 13, Curr))
-                 - ( x_12
+                 - ( x_27
                    - cell (var (Witness 13, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 14, Curr)))
-               - (x_13 * cell (var (Witness 11, Next)))
+               - (x_28 * cell (var (Witness 11, Next)))
              in
              cell (var (Witness 5, Curr))
              - ( cell (var (Witness 6, Next))
@@ -1599,16 +1599,16 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 3
-               * ( (x_2 * x_2)
-                 - x_1 * x_1
+               * ( (x_17 * x_17)
+                 - x_16 * x_16
                    * ( cell (var (Witness 7, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_0 ) )
+                     + x_15 ) )
              + alpha_pow 4
                * ( (cell (var (Witness 8, Curr)) + cell (var (Witness 3, Curr)))
-                   * x_1
+                   * x_16
                  - (cell (var (Witness 2, Curr)) - cell (var (Witness 7, Curr)))
-                   * x_2 )
+                   * x_17 )
              + alpha_pow 5
                * ( square (cell (var (Witness 3, Next)))
                  - cell (var (Witness 3, Next)) )
@@ -1622,16 +1622,16 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 7
-               * ( (x_5 * x_5)
-                 - x_4 * x_4
+               * ( (x_20 * x_20)
+                 - x_19 * x_19
                    * ( cell (var (Witness 9, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_3 ) )
+                     + x_18 ) )
              + alpha_pow 8
                * ( (cell (var (Witness 10, Curr)) + cell (var (Witness 8, Curr)))
-                   * x_4
+                   * x_19
                  - (cell (var (Witness 7, Curr)) - cell (var (Witness 9, Curr)))
-                   * x_5 )
+                   * x_20 )
              + alpha_pow 9
                * ( square (cell (var (Witness 4, Next)))
                  - cell (var (Witness 4, Next)) )
@@ -1645,17 +1645,17 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 11
-               * ( (x_8 * x_8)
-                 - x_7 * x_7
+               * ( (x_23 * x_23)
+                 - x_22 * x_22
                    * ( cell (var (Witness 11, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_6 ) )
+                     + x_21 ) )
              + alpha_pow 12
                * ( ( cell (var (Witness 12, Curr))
                    + cell (var (Witness 10, Curr)) )
-                   * x_7
+                   * x_22
                  - (cell (var (Witness 9, Curr)) - cell (var (Witness 11, Curr)))
-                   * x_8 )
+                   * x_23 )
              + alpha_pow 13
                * ( square (cell (var (Witness 5, Next)))
                  - cell (var (Witness 5, Next)) )
@@ -1669,18 +1669,18 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 15
-               * ( (x_11 * x_11)
-                 - x_10 * x_10
+               * ( (x_26 * x_26)
+                 - x_25 * x_25
                    * ( cell (var (Witness 13, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_9 ) )
+                     + x_24 ) )
              + alpha_pow 16
                * ( ( cell (var (Witness 14, Curr))
                    + cell (var (Witness 12, Curr)) )
-                   * x_10
+                   * x_25
                  - ( cell (var (Witness 11, Curr))
                    - cell (var (Witness 13, Curr)) )
-                   * x_11 )
+                   * x_26 )
              + alpha_pow 17
                * ( square (cell (var (Witness 6, Next)))
                  - cell (var (Witness 6, Next)) )
@@ -1694,19 +1694,19 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 19
-               * ( (x_14 * x_14)
-                 - x_13 * x_13
+               * ( (x_29 * x_29)
+                 - x_28 * x_28
                    * ( cell (var (Witness 0, Next))
                      - cell (var (Witness 0, Curr))
-                     + x_12 ) )
+                     + x_27 ) )
              + alpha_pow 20
                * ( (cell (var (Witness 1, Next)) + cell (var (Witness 14, Curr)))
-                   * x_13
+                   * x_28
                  - (cell (var (Witness 13, Curr)) - cell (var (Witness 0, Next)))
-                   * x_14 ) ) )
+                   * x_29 ) ) )
       ; ( Index EndoMul
         , lazy
-            (let x_0 =
+            (let x_33 =
                ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                + cell (var (Witness 11, Curr))
@@ -1716,7 +1716,7 @@ module Tick : S = struct
                    ) )
                * cell (var (Witness 0, Curr))
              in
-             let x_1 =
+             let x_34 =
                ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                + cell (var (Witness 13, Curr))
@@ -1726,18 +1726,18 @@ module Tick : S = struct
                    ) )
                * cell (var (Witness 0, Curr))
              in
-             let x_2 = square (cell (var (Witness 9, Curr))) in
-             let x_3 = square (cell (var (Witness 10, Curr))) in
-             let x_4 =
+             let x_35 = square (cell (var (Witness 9, Curr))) in
+             let x_36 = square (cell (var (Witness 10, Curr))) in
+             let x_37 =
                cell (var (Witness 4, Curr)) - cell (var (Witness 7, Curr))
              in
-             let x_5 =
+             let x_38 =
                cell (var (Witness 7, Curr)) - cell (var (Witness 4, Next))
              in
-             let x_6 =
+             let x_39 =
                cell (var (Witness 5, Next)) + cell (var (Witness 8, Curr))
              in
-             let x_7 =
+             let x_40 =
                cell (var (Witness 8, Curr)) + cell (var (Witness 5, Curr))
              in
              square (cell (var (Witness 11, Curr)))
@@ -1752,7 +1752,7 @@ module Tick : S = struct
                * ( square (cell (var (Witness 14, Curr)))
                  - cell (var (Witness 14, Curr)) )
              + alpha_pow 4
-               * ( (x_0 - cell (var (Witness 4, Curr)))
+               * ( (x_33 - cell (var (Witness 4, Curr)))
                    * cell (var (Witness 9, Curr))
                  - ( ( double (cell (var (Witness 12, Curr)))
                      - field
@@ -1761,14 +1761,15 @@ module Tick : S = struct
                      * cell (var (Witness 1, Curr))
                    - cell (var (Witness 5, Curr)) ) )
              + alpha_pow 5
-               * ( (double (cell (var (Witness 4, Curr))) - x_2 + x_0)
-                   * ((x_4 * cell (var (Witness 9, Curr))) + x_7)
-                 - (double (cell (var (Witness 5, Curr))) * x_4) )
+               * ( (double (cell (var (Witness 4, Curr))) - x_35 + x_33)
+                   * ((x_37 * cell (var (Witness 9, Curr))) + x_40)
+                 - (double (cell (var (Witness 5, Curr))) * x_37) )
              + alpha_pow 6
-               * ( square x_7
-                 - (square x_4 * (x_2 - x_0 + cell (var (Witness 7, Curr)))) )
+               * ( square x_40
+                 - (square x_37 * (x_35 - x_33 + cell (var (Witness 7, Curr))))
+                 )
              + alpha_pow 7
-               * ( (x_1 - cell (var (Witness 7, Curr)))
+               * ( (x_34 - cell (var (Witness 7, Curr)))
                    * cell (var (Witness 10, Curr))
                  - ( ( double (cell (var (Witness 14, Curr)))
                      - field
@@ -1777,12 +1778,13 @@ module Tick : S = struct
                      * cell (var (Witness 1, Curr))
                    - cell (var (Witness 8, Curr)) ) )
              + alpha_pow 8
-               * ( (double (cell (var (Witness 7, Curr))) - x_3 + x_1)
-                   * ((x_5 * cell (var (Witness 10, Curr))) + x_6)
-                 - (double (cell (var (Witness 8, Curr))) * x_5) )
+               * ( (double (cell (var (Witness 7, Curr))) - x_36 + x_34)
+                   * ((x_38 * cell (var (Witness 10, Curr))) + x_39)
+                 - (double (cell (var (Witness 8, Curr))) * x_38) )
              + alpha_pow 9
-               * ( square x_6
-                 - (square x_5 * (x_3 - x_1 + cell (var (Witness 4, Next)))) )
+               * ( square x_39
+                 - (square x_38 * (x_36 - x_34 + cell (var (Witness 4, Next))))
+                 )
              + alpha_pow 10
                * ( double
                      ( double
@@ -1795,7 +1797,7 @@ module Tick : S = struct
                  - cell (var (Witness 6, Next)) ) ) )
       ; ( Index EndoMulScalar
         , lazy
-            (let x_0 =
+            (let x_41 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 6, Curr))
@@ -1808,7 +1810,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 6, Curr))
              in
-             let x_1 =
+             let x_42 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 7, Curr))
@@ -1821,7 +1823,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 7, Curr))
              in
-             let x_2 =
+             let x_43 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 8, Curr))
@@ -1834,7 +1836,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 8, Curr))
              in
-             let x_3 =
+             let x_44 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 9, Curr))
@@ -1847,7 +1849,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 9, Curr))
              in
-             let x_4 =
+             let x_45 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 10, Curr))
@@ -1860,7 +1862,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 10, Curr))
              in
-             let x_5 =
+             let x_46 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 11, Curr))
@@ -1873,7 +1875,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 11, Curr))
              in
-             let x_6 =
+             let x_47 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 12, Curr))
@@ -1886,7 +1888,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 12, Curr))
              in
-             let x_7 =
+             let x_48 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 13, Curr))
@@ -1945,14 +1947,14 @@ module Tick : S = struct
                                          ( double
                                              ( double
                                                  (cell (var (Witness 2, Curr)))
-                                             + x_0 )
-                                         + x_1 )
-                                     + x_2 )
-                                 + x_3 )
-                             + x_4 )
-                         + x_5 )
-                     + x_6 )
-                 + x_7
+                                             + x_41 )
+                                         + x_42 )
+                                     + x_43 )
+                                 + x_44 )
+                             + x_45 )
+                         + x_46 )
+                     + x_47 )
+                 + x_48
                  - cell (var (Witness 4, Curr)) )
              + alpha_pow 2
                * ( double
@@ -1964,7 +1966,7 @@ module Tick : S = struct
                                          ( double
                                              ( double
                                                  (cell (var (Witness 3, Curr)))
-                                             + ( x_0
+                                             + ( x_41
                                                + ( ( field
                                                        "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                                      * cell
@@ -1977,7 +1979,7 @@ module Tick : S = struct
                                                  + field
                                                      "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                                  ) ) )
-                                         + ( x_1
+                                         + ( x_42
                                            + ( ( field
                                                    "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                                  * cell (var (Witness 7, Curr))
@@ -1988,7 +1990,7 @@ module Tick : S = struct
                                              + field
                                                  "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                              ) ) )
-                                     + ( x_2
+                                     + ( x_43
                                        + ( ( field
                                                "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                              * cell (var (Witness 8, Curr))
@@ -1999,7 +2001,7 @@ module Tick : S = struct
                                          + field
                                              "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                          ) ) )
-                                 + ( x_3
+                                 + ( x_44
                                    + ( ( field
                                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                          * cell (var (Witness 9, Curr))
@@ -2010,7 +2012,7 @@ module Tick : S = struct
                                      + field
                                          "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                      ) ) )
-                             + ( x_4
+                             + ( x_45
                                + ( ( field
                                        "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                      * cell (var (Witness 10, Curr))
@@ -2021,7 +2023,7 @@ module Tick : S = struct
                                  + field
                                      "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                  ) ) )
-                         + ( x_5
+                         + ( x_46
                            + ( ( field
                                    "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                  * cell (var (Witness 11, Curr))
@@ -2032,7 +2034,7 @@ module Tick : S = struct
                              + field
                                  "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                              ) ) )
-                     + ( x_6
+                     + ( x_47
                        + ( ( field
                                "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                              * cell (var (Witness 12, Curr))
@@ -2043,7 +2045,7 @@ module Tick : S = struct
                          + field
                              "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                          ) ) )
-                 + ( x_7
+                 + ( x_48
                    + ( ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                          * cell (var (Witness 13, Curr))
@@ -4134,7 +4136,7 @@ module Tock : S = struct
         ( LookupTables
         , (fun () ->
             alpha_pow 24
-            * ( vanishes_on_last_4_rows
+            * ( vanishes_on_zero_knowledge_and_previous_rows
               * ( cell (var (LookupAggreg, Next))
                   * ( if_feature
                         ( LookupsPerRow 0
@@ -4461,7 +4463,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -4620,7 +4622,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -4822,7 +4824,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -5025,7 +5027,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_last_4_rows
+                   * ( vanishes_on_zero_knowledge_and_previous_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -5223,29 +5225,29 @@ module Tock : S = struct
                ) ) )
       ; ( Index CompleteAdd
         , lazy
-            (let x_0 =
+            (let x_30 =
                cell (var (Witness 2, Curr)) - cell (var (Witness 0, Curr))
              in
-             let x_1 =
+             let x_31 =
                cell (var (Witness 3, Curr)) - cell (var (Witness 1, Curr))
              in
-             let x_2 =
+             let x_32 =
                cell (var (Witness 0, Curr)) * cell (var (Witness 0, Curr))
              in
-             (cell (var (Witness 10, Curr)) * x_0)
+             (cell (var (Witness 10, Curr)) * x_30)
              - ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                - cell (var (Witness 7, Curr)) )
-             + (alpha_pow 1 * (cell (var (Witness 7, Curr)) * x_0))
+             + (alpha_pow 1 * (cell (var (Witness 7, Curr)) * x_30))
              + alpha_pow 2
                * ( cell (var (Witness 7, Curr))
                    * ( double (cell (var (Witness 8, Curr)))
                        * cell (var (Witness 1, Curr))
-                     - double x_2 - x_2 )
+                     - double x_32 - x_32 )
                  + ( field
                        "0x0000000000000000000000000000000000000000000000000000000000000001"
                    - cell (var (Witness 7, Curr)) )
-                   * ((x_0 * cell (var (Witness 8, Curr))) - x_1) )
+                   * ((x_30 * cell (var (Witness 8, Curr))) - x_31) )
              + alpha_pow 3
                * ( cell (var (Witness 0, Curr))
                  + cell (var (Witness 2, Curr))
@@ -5259,138 +5261,138 @@ module Tock : S = struct
                  - cell (var (Witness 1, Curr))
                  - cell (var (Witness 5, Curr)) )
              + alpha_pow 5
-               * ( x_1
+               * ( x_31
                  * (cell (var (Witness 7, Curr)) - cell (var (Witness 6, Curr)))
                  )
              + alpha_pow 6
-               * ( (x_1 * cell (var (Witness 9, Curr)))
+               * ( (x_31 * cell (var (Witness 9, Curr)))
                  - cell (var (Witness 6, Curr)) ) ) )
       ; ( Index VarBaseMul
         , lazy
-            (let x_0 =
+            (let x_15 =
                cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
              in
-             let x_1 =
-               let x_0 =
+             let x_16 =
+               let x_15 =
                  cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
                in
                cell (var (Witness 2, Curr))
-               - ( x_0
+               - ( x_15
                  - cell (var (Witness 2, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_2 =
-               let x_1 =
-                 let x_0 =
+             let x_17 =
+               let x_16 =
+                 let x_15 =
                    cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
                  in
                  cell (var (Witness 2, Curr))
-                 - ( x_0
+                 - ( x_15
                    - cell (var (Witness 2, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 3, Curr)))
-               - (x_1 * cell (var (Witness 7, Next)))
+               - (x_16 * cell (var (Witness 7, Next)))
              in
-             let x_3 =
+             let x_18 =
                cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
              in
-             let x_4 =
-               let x_3 =
+             let x_19 =
+               let x_18 =
                  cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
                in
                cell (var (Witness 7, Curr))
-               - ( x_3
+               - ( x_18
                  - cell (var (Witness 7, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_5 =
-               let x_4 =
-                 let x_3 =
+             let x_20 =
+               let x_19 =
+                 let x_18 =
                    cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
                  in
                  cell (var (Witness 7, Curr))
-                 - ( x_3
+                 - ( x_18
                    - cell (var (Witness 7, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 8, Curr)))
-               - (x_4 * cell (var (Witness 8, Next)))
+               - (x_19 * cell (var (Witness 8, Next)))
              in
-             let x_6 =
+             let x_21 =
                cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
              in
-             let x_7 =
-               let x_6 =
+             let x_22 =
+               let x_21 =
                  cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
                in
                cell (var (Witness 9, Curr))
-               - ( x_6
+               - ( x_21
                  - cell (var (Witness 9, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_8 =
-               let x_7 =
-                 let x_6 =
+             let x_23 =
+               let x_22 =
+                 let x_21 =
                    cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
                  in
                  cell (var (Witness 9, Curr))
-                 - ( x_6
+                 - ( x_21
                    - cell (var (Witness 9, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 10, Curr)))
-               - (x_7 * cell (var (Witness 9, Next)))
+               - (x_22 * cell (var (Witness 9, Next)))
              in
-             let x_9 =
+             let x_24 =
                cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
              in
-             let x_10 =
-               let x_9 =
+             let x_25 =
+               let x_24 =
                  cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
                in
                cell (var (Witness 11, Curr))
-               - ( x_9
+               - ( x_24
                  - cell (var (Witness 11, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_11 =
-               let x_10 =
-                 let x_9 =
+             let x_26 =
+               let x_25 =
+                 let x_24 =
                    cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
                  in
                  cell (var (Witness 11, Curr))
-                 - ( x_9
+                 - ( x_24
                    - cell (var (Witness 11, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 12, Curr)))
-               - (x_10 * cell (var (Witness 10, Next)))
+               - (x_25 * cell (var (Witness 10, Next)))
              in
-             let x_12 =
+             let x_27 =
                cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
              in
-             let x_13 =
-               let x_12 =
+             let x_28 =
+               let x_27 =
                  cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
                in
                cell (var (Witness 13, Curr))
-               - ( x_12
+               - ( x_27
                  - cell (var (Witness 13, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_14 =
-               let x_13 =
-                 let x_12 =
+             let x_29 =
+               let x_28 =
+                 let x_27 =
                    cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
                  in
                  cell (var (Witness 13, Curr))
-                 - ( x_12
+                 - ( x_27
                    - cell (var (Witness 13, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 14, Curr)))
-               - (x_13 * cell (var (Witness 11, Next)))
+               - (x_28 * cell (var (Witness 11, Next)))
              in
              cell (var (Witness 5, Curr))
              - ( cell (var (Witness 6, Next))
@@ -5417,16 +5419,16 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 3
-               * ( (x_2 * x_2)
-                 - x_1 * x_1
+               * ( (x_17 * x_17)
+                 - x_16 * x_16
                    * ( cell (var (Witness 7, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_0 ) )
+                     + x_15 ) )
              + alpha_pow 4
                * ( (cell (var (Witness 8, Curr)) + cell (var (Witness 3, Curr)))
-                   * x_1
+                   * x_16
                  - (cell (var (Witness 2, Curr)) - cell (var (Witness 7, Curr)))
-                   * x_2 )
+                   * x_17 )
              + alpha_pow 5
                * ( square (cell (var (Witness 3, Next)))
                  - cell (var (Witness 3, Next)) )
@@ -5440,16 +5442,16 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 7
-               * ( (x_5 * x_5)
-                 - x_4 * x_4
+               * ( (x_20 * x_20)
+                 - x_19 * x_19
                    * ( cell (var (Witness 9, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_3 ) )
+                     + x_18 ) )
              + alpha_pow 8
                * ( (cell (var (Witness 10, Curr)) + cell (var (Witness 8, Curr)))
-                   * x_4
+                   * x_19
                  - (cell (var (Witness 7, Curr)) - cell (var (Witness 9, Curr)))
-                   * x_5 )
+                   * x_20 )
              + alpha_pow 9
                * ( square (cell (var (Witness 4, Next)))
                  - cell (var (Witness 4, Next)) )
@@ -5463,17 +5465,17 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 11
-               * ( (x_8 * x_8)
-                 - x_7 * x_7
+               * ( (x_23 * x_23)
+                 - x_22 * x_22
                    * ( cell (var (Witness 11, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_6 ) )
+                     + x_21 ) )
              + alpha_pow 12
                * ( ( cell (var (Witness 12, Curr))
                    + cell (var (Witness 10, Curr)) )
-                   * x_7
+                   * x_22
                  - (cell (var (Witness 9, Curr)) - cell (var (Witness 11, Curr)))
-                   * x_8 )
+                   * x_23 )
              + alpha_pow 13
                * ( square (cell (var (Witness 5, Next)))
                  - cell (var (Witness 5, Next)) )
@@ -5487,18 +5489,18 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 15
-               * ( (x_11 * x_11)
-                 - x_10 * x_10
+               * ( (x_26 * x_26)
+                 - x_25 * x_25
                    * ( cell (var (Witness 13, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_9 ) )
+                     + x_24 ) )
              + alpha_pow 16
                * ( ( cell (var (Witness 14, Curr))
                    + cell (var (Witness 12, Curr)) )
-                   * x_10
+                   * x_25
                  - ( cell (var (Witness 11, Curr))
                    - cell (var (Witness 13, Curr)) )
-                   * x_11 )
+                   * x_26 )
              + alpha_pow 17
                * ( square (cell (var (Witness 6, Next)))
                  - cell (var (Witness 6, Next)) )
@@ -5512,19 +5514,19 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 19
-               * ( (x_14 * x_14)
-                 - x_13 * x_13
+               * ( (x_29 * x_29)
+                 - x_28 * x_28
                    * ( cell (var (Witness 0, Next))
                      - cell (var (Witness 0, Curr))
-                     + x_12 ) )
+                     + x_27 ) )
              + alpha_pow 20
                * ( (cell (var (Witness 1, Next)) + cell (var (Witness 14, Curr)))
-                   * x_13
+                   * x_28
                  - (cell (var (Witness 13, Curr)) - cell (var (Witness 0, Next)))
-                   * x_14 ) ) )
+                   * x_29 ) ) )
       ; ( Index EndoMul
         , lazy
-            (let x_0 =
+            (let x_33 =
                ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                + cell (var (Witness 11, Curr))
@@ -5534,7 +5536,7 @@ module Tock : S = struct
                    ) )
                * cell (var (Witness 0, Curr))
              in
-             let x_1 =
+             let x_34 =
                ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                + cell (var (Witness 13, Curr))
@@ -5544,18 +5546,18 @@ module Tock : S = struct
                    ) )
                * cell (var (Witness 0, Curr))
              in
-             let x_2 = square (cell (var (Witness 9, Curr))) in
-             let x_3 = square (cell (var (Witness 10, Curr))) in
-             let x_4 =
+             let x_35 = square (cell (var (Witness 9, Curr))) in
+             let x_36 = square (cell (var (Witness 10, Curr))) in
+             let x_37 =
                cell (var (Witness 4, Curr)) - cell (var (Witness 7, Curr))
              in
-             let x_5 =
+             let x_38 =
                cell (var (Witness 7, Curr)) - cell (var (Witness 4, Next))
              in
-             let x_6 =
+             let x_39 =
                cell (var (Witness 5, Next)) + cell (var (Witness 8, Curr))
              in
-             let x_7 =
+             let x_40 =
                cell (var (Witness 8, Curr)) + cell (var (Witness 5, Curr))
              in
              square (cell (var (Witness 11, Curr)))
@@ -5570,7 +5572,7 @@ module Tock : S = struct
                * ( square (cell (var (Witness 14, Curr)))
                  - cell (var (Witness 14, Curr)) )
              + alpha_pow 4
-               * ( (x_0 - cell (var (Witness 4, Curr)))
+               * ( (x_33 - cell (var (Witness 4, Curr)))
                    * cell (var (Witness 9, Curr))
                  - ( ( double (cell (var (Witness 12, Curr)))
                      - field
@@ -5579,14 +5581,15 @@ module Tock : S = struct
                      * cell (var (Witness 1, Curr))
                    - cell (var (Witness 5, Curr)) ) )
              + alpha_pow 5
-               * ( (double (cell (var (Witness 4, Curr))) - x_2 + x_0)
-                   * ((x_4 * cell (var (Witness 9, Curr))) + x_7)
-                 - (double (cell (var (Witness 5, Curr))) * x_4) )
+               * ( (double (cell (var (Witness 4, Curr))) - x_35 + x_33)
+                   * ((x_37 * cell (var (Witness 9, Curr))) + x_40)
+                 - (double (cell (var (Witness 5, Curr))) * x_37) )
              + alpha_pow 6
-               * ( square x_7
-                 - (square x_4 * (x_2 - x_0 + cell (var (Witness 7, Curr)))) )
+               * ( square x_40
+                 - (square x_37 * (x_35 - x_33 + cell (var (Witness 7, Curr))))
+                 )
              + alpha_pow 7
-               * ( (x_1 - cell (var (Witness 7, Curr)))
+               * ( (x_34 - cell (var (Witness 7, Curr)))
                    * cell (var (Witness 10, Curr))
                  - ( ( double (cell (var (Witness 14, Curr)))
                      - field
@@ -5595,12 +5598,13 @@ module Tock : S = struct
                      * cell (var (Witness 1, Curr))
                    - cell (var (Witness 8, Curr)) ) )
              + alpha_pow 8
-               * ( (double (cell (var (Witness 7, Curr))) - x_3 + x_1)
-                   * ((x_5 * cell (var (Witness 10, Curr))) + x_6)
-                 - (double (cell (var (Witness 8, Curr))) * x_5) )
+               * ( (double (cell (var (Witness 7, Curr))) - x_36 + x_34)
+                   * ((x_38 * cell (var (Witness 10, Curr))) + x_39)
+                 - (double (cell (var (Witness 8, Curr))) * x_38) )
              + alpha_pow 9
-               * ( square x_6
-                 - (square x_5 * (x_3 - x_1 + cell (var (Witness 4, Next)))) )
+               * ( square x_39
+                 - (square x_38 * (x_36 - x_34 + cell (var (Witness 4, Next))))
+                 )
              + alpha_pow 10
                * ( double
                      ( double
@@ -5613,7 +5617,7 @@ module Tock : S = struct
                  - cell (var (Witness 6, Next)) ) ) )
       ; ( Index EndoMulScalar
         , lazy
-            (let x_0 =
+            (let x_41 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 6, Curr))
@@ -5626,7 +5630,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 6, Curr))
              in
-             let x_1 =
+             let x_42 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 7, Curr))
@@ -5639,7 +5643,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 7, Curr))
              in
-             let x_2 =
+             let x_43 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 8, Curr))
@@ -5652,7 +5656,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 8, Curr))
              in
-             let x_3 =
+             let x_44 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 9, Curr))
@@ -5665,7 +5669,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 9, Curr))
              in
-             let x_4 =
+             let x_45 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 10, Curr))
@@ -5678,7 +5682,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 10, Curr))
              in
-             let x_5 =
+             let x_46 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 11, Curr))
@@ -5691,7 +5695,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 11, Curr))
              in
-             let x_6 =
+             let x_47 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 12, Curr))
@@ -5704,7 +5708,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 12, Curr))
              in
-             let x_7 =
+             let x_48 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 13, Curr))
@@ -5763,14 +5767,14 @@ module Tock : S = struct
                                          ( double
                                              ( double
                                                  (cell (var (Witness 2, Curr)))
-                                             + x_0 )
-                                         + x_1 )
-                                     + x_2 )
-                                 + x_3 )
-                             + x_4 )
-                         + x_5 )
-                     + x_6 )
-                 + x_7
+                                             + x_41 )
+                                         + x_42 )
+                                     + x_43 )
+                                 + x_44 )
+                             + x_45 )
+                         + x_46 )
+                     + x_47 )
+                 + x_48
                  - cell (var (Witness 4, Curr)) )
              + alpha_pow 2
                * ( double
@@ -5782,7 +5786,7 @@ module Tock : S = struct
                                          ( double
                                              ( double
                                                  (cell (var (Witness 3, Curr)))
-                                             + ( x_0
+                                             + ( x_41
                                                + ( ( field
                                                        "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                                      * cell
@@ -5795,7 +5799,7 @@ module Tock : S = struct
                                                  + field
                                                      "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                                  ) ) )
-                                         + ( x_1
+                                         + ( x_42
                                            + ( ( field
                                                    "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                                  * cell (var (Witness 7, Curr))
@@ -5806,7 +5810,7 @@ module Tock : S = struct
                                              + field
                                                  "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                              ) ) )
-                                     + ( x_2
+                                     + ( x_43
                                        + ( ( field
                                                "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                              * cell (var (Witness 8, Curr))
@@ -5817,7 +5821,7 @@ module Tock : S = struct
                                          + field
                                              "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                          ) ) )
-                                 + ( x_3
+                                 + ( x_44
                                    + ( ( field
                                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                          * cell (var (Witness 9, Curr))
@@ -5828,7 +5832,7 @@ module Tock : S = struct
                                      + field
                                          "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                      ) ) )
-                             + ( x_4
+                             + ( x_45
                                + ( ( field
                                        "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                      * cell (var (Witness 10, Curr))
@@ -5839,7 +5843,7 @@ module Tock : S = struct
                                  + field
                                      "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                  ) ) )
-                         + ( x_5
+                         + ( x_46
                            + ( ( field
                                    "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                  * cell (var (Witness 11, Curr))
@@ -5850,7 +5854,7 @@ module Tock : S = struct
                              + field
                                  "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                              ) ) )
-                     + ( x_6
+                     + ( x_47
                        + ( ( field
                                "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                              * cell (var (Witness 12, Curr))
@@ -5861,7 +5865,7 @@ module Tock : S = struct
                          + field
                              "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                          ) ) )
-                 + ( x_7
+                 + ( x_48
                    + ( ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                          * cell (var (Witness 13, Curr))

--- a/src/lib/pickles/plonk_checks/scalars.ml
+++ b/src/lib/pickles/plonk_checks/scalars.ml
@@ -316,7 +316,7 @@ module Tick : S = struct
         ( LookupTables
         , (fun () ->
             alpha_pow 24
-            * ( vanishes_on_zero_knowledge_and_previous_rows
+            * ( vanishes_on_last_4_rows
               * ( cell (var (LookupAggreg, Next))
                   * ( if_feature
                         ( LookupsPerRow 0
@@ -643,7 +643,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_zero_knowledge_and_previous_rows
+                   * ( vanishes_on_last_4_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -802,7 +802,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_zero_knowledge_and_previous_rows
+                   * ( vanishes_on_last_4_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -1004,7 +1004,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_zero_knowledge_and_previous_rows
+                   * ( vanishes_on_last_4_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -1207,7 +1207,7 @@ module Tick : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_zero_knowledge_and_previous_rows
+                   * ( vanishes_on_last_4_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -1405,29 +1405,29 @@ module Tick : S = struct
                ) ) )
       ; ( Index CompleteAdd
         , lazy
-            (let x_30 =
+            (let x_0 =
                cell (var (Witness 2, Curr)) - cell (var (Witness 0, Curr))
              in
-             let x_31 =
+             let x_1 =
                cell (var (Witness 3, Curr)) - cell (var (Witness 1, Curr))
              in
-             let x_32 =
+             let x_2 =
                cell (var (Witness 0, Curr)) * cell (var (Witness 0, Curr))
              in
-             (cell (var (Witness 10, Curr)) * x_30)
+             (cell (var (Witness 10, Curr)) * x_0)
              - ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                - cell (var (Witness 7, Curr)) )
-             + (alpha_pow 1 * (cell (var (Witness 7, Curr)) * x_30))
+             + (alpha_pow 1 * (cell (var (Witness 7, Curr)) * x_0))
              + alpha_pow 2
                * ( cell (var (Witness 7, Curr))
                    * ( double (cell (var (Witness 8, Curr)))
                        * cell (var (Witness 1, Curr))
-                     - double x_32 - x_32 )
+                     - double x_2 - x_2 )
                  + ( field
                        "0x0000000000000000000000000000000000000000000000000000000000000001"
                    - cell (var (Witness 7, Curr)) )
-                   * ((x_30 * cell (var (Witness 8, Curr))) - x_31) )
+                   * ((x_0 * cell (var (Witness 8, Curr))) - x_1) )
              + alpha_pow 3
                * ( cell (var (Witness 0, Curr))
                  + cell (var (Witness 2, Curr))
@@ -1441,138 +1441,138 @@ module Tick : S = struct
                  - cell (var (Witness 1, Curr))
                  - cell (var (Witness 5, Curr)) )
              + alpha_pow 5
-               * ( x_31
+               * ( x_1
                  * (cell (var (Witness 7, Curr)) - cell (var (Witness 6, Curr)))
                  )
              + alpha_pow 6
-               * ( (x_31 * cell (var (Witness 9, Curr)))
+               * ( (x_1 * cell (var (Witness 9, Curr)))
                  - cell (var (Witness 6, Curr)) ) ) )
       ; ( Index VarBaseMul
         , lazy
-            (let x_15 =
+            (let x_0 =
                cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
              in
-             let x_16 =
-               let x_15 =
+             let x_1 =
+               let x_0 =
                  cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
                in
                cell (var (Witness 2, Curr))
-               - ( x_15
+               - ( x_0
                  - cell (var (Witness 2, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_17 =
-               let x_16 =
-                 let x_15 =
+             let x_2 =
+               let x_1 =
+                 let x_0 =
                    cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
                  in
                  cell (var (Witness 2, Curr))
-                 - ( x_15
+                 - ( x_0
                    - cell (var (Witness 2, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 3, Curr)))
-               - (x_16 * cell (var (Witness 7, Next)))
+               - (x_1 * cell (var (Witness 7, Next)))
              in
-             let x_18 =
+             let x_3 =
                cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
              in
-             let x_19 =
-               let x_18 =
+             let x_4 =
+               let x_3 =
                  cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
                in
                cell (var (Witness 7, Curr))
-               - ( x_18
+               - ( x_3
                  - cell (var (Witness 7, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_20 =
-               let x_19 =
-                 let x_18 =
+             let x_5 =
+               let x_4 =
+                 let x_3 =
                    cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
                  in
                  cell (var (Witness 7, Curr))
-                 - ( x_18
+                 - ( x_3
                    - cell (var (Witness 7, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 8, Curr)))
-               - (x_19 * cell (var (Witness 8, Next)))
+               - (x_4 * cell (var (Witness 8, Next)))
              in
-             let x_21 =
+             let x_6 =
                cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
              in
-             let x_22 =
-               let x_21 =
+             let x_7 =
+               let x_6 =
                  cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
                in
                cell (var (Witness 9, Curr))
-               - ( x_21
+               - ( x_6
                  - cell (var (Witness 9, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_23 =
-               let x_22 =
-                 let x_21 =
+             let x_8 =
+               let x_7 =
+                 let x_6 =
                    cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
                  in
                  cell (var (Witness 9, Curr))
-                 - ( x_21
+                 - ( x_6
                    - cell (var (Witness 9, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 10, Curr)))
-               - (x_22 * cell (var (Witness 9, Next)))
+               - (x_7 * cell (var (Witness 9, Next)))
              in
-             let x_24 =
+             let x_9 =
                cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
              in
-             let x_25 =
-               let x_24 =
+             let x_10 =
+               let x_9 =
                  cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
                in
                cell (var (Witness 11, Curr))
-               - ( x_24
+               - ( x_9
                  - cell (var (Witness 11, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_26 =
-               let x_25 =
-                 let x_24 =
+             let x_11 =
+               let x_10 =
+                 let x_9 =
                    cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
                  in
                  cell (var (Witness 11, Curr))
-                 - ( x_24
+                 - ( x_9
                    - cell (var (Witness 11, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 12, Curr)))
-               - (x_25 * cell (var (Witness 10, Next)))
+               - (x_10 * cell (var (Witness 10, Next)))
              in
-             let x_27 =
+             let x_12 =
                cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
              in
-             let x_28 =
-               let x_27 =
+             let x_13 =
+               let x_12 =
                  cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
                in
                cell (var (Witness 13, Curr))
-               - ( x_27
+               - ( x_12
                  - cell (var (Witness 13, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_29 =
-               let x_28 =
-                 let x_27 =
+             let x_14 =
+               let x_13 =
+                 let x_12 =
                    cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
                  in
                  cell (var (Witness 13, Curr))
-                 - ( x_27
+                 - ( x_12
                    - cell (var (Witness 13, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 14, Curr)))
-               - (x_28 * cell (var (Witness 11, Next)))
+               - (x_13 * cell (var (Witness 11, Next)))
              in
              cell (var (Witness 5, Curr))
              - ( cell (var (Witness 6, Next))
@@ -1599,16 +1599,16 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 3
-               * ( (x_17 * x_17)
-                 - x_16 * x_16
+               * ( (x_2 * x_2)
+                 - x_1 * x_1
                    * ( cell (var (Witness 7, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_15 ) )
+                     + x_0 ) )
              + alpha_pow 4
                * ( (cell (var (Witness 8, Curr)) + cell (var (Witness 3, Curr)))
-                   * x_16
+                   * x_1
                  - (cell (var (Witness 2, Curr)) - cell (var (Witness 7, Curr)))
-                   * x_17 )
+                   * x_2 )
              + alpha_pow 5
                * ( square (cell (var (Witness 3, Next)))
                  - cell (var (Witness 3, Next)) )
@@ -1622,16 +1622,16 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 7
-               * ( (x_20 * x_20)
-                 - x_19 * x_19
+               * ( (x_5 * x_5)
+                 - x_4 * x_4
                    * ( cell (var (Witness 9, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_18 ) )
+                     + x_3 ) )
              + alpha_pow 8
                * ( (cell (var (Witness 10, Curr)) + cell (var (Witness 8, Curr)))
-                   * x_19
+                   * x_4
                  - (cell (var (Witness 7, Curr)) - cell (var (Witness 9, Curr)))
-                   * x_20 )
+                   * x_5 )
              + alpha_pow 9
                * ( square (cell (var (Witness 4, Next)))
                  - cell (var (Witness 4, Next)) )
@@ -1645,17 +1645,17 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 11
-               * ( (x_23 * x_23)
-                 - x_22 * x_22
+               * ( (x_8 * x_8)
+                 - x_7 * x_7
                    * ( cell (var (Witness 11, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_21 ) )
+                     + x_6 ) )
              + alpha_pow 12
                * ( ( cell (var (Witness 12, Curr))
                    + cell (var (Witness 10, Curr)) )
-                   * x_22
+                   * x_7
                  - (cell (var (Witness 9, Curr)) - cell (var (Witness 11, Curr)))
-                   * x_23 )
+                   * x_8 )
              + alpha_pow 13
                * ( square (cell (var (Witness 5, Next)))
                  - cell (var (Witness 5, Next)) )
@@ -1669,18 +1669,18 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 15
-               * ( (x_26 * x_26)
-                 - x_25 * x_25
+               * ( (x_11 * x_11)
+                 - x_10 * x_10
                    * ( cell (var (Witness 13, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_24 ) )
+                     + x_9 ) )
              + alpha_pow 16
                * ( ( cell (var (Witness 14, Curr))
                    + cell (var (Witness 12, Curr)) )
-                   * x_25
+                   * x_10
                  - ( cell (var (Witness 11, Curr))
                    - cell (var (Witness 13, Curr)) )
-                   * x_26 )
+                   * x_11 )
              + alpha_pow 17
                * ( square (cell (var (Witness 6, Next)))
                  - cell (var (Witness 6, Next)) )
@@ -1694,19 +1694,19 @@ module Tick : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 19
-               * ( (x_29 * x_29)
-                 - x_28 * x_28
+               * ( (x_14 * x_14)
+                 - x_13 * x_13
                    * ( cell (var (Witness 0, Next))
                      - cell (var (Witness 0, Curr))
-                     + x_27 ) )
+                     + x_12 ) )
              + alpha_pow 20
                * ( (cell (var (Witness 1, Next)) + cell (var (Witness 14, Curr)))
-                   * x_28
+                   * x_13
                  - (cell (var (Witness 13, Curr)) - cell (var (Witness 0, Next)))
-                   * x_29 ) ) )
+                   * x_14 ) ) )
       ; ( Index EndoMul
         , lazy
-            (let x_33 =
+            (let x_0 =
                ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                + cell (var (Witness 11, Curr))
@@ -1716,7 +1716,7 @@ module Tick : S = struct
                    ) )
                * cell (var (Witness 0, Curr))
              in
-             let x_34 =
+             let x_1 =
                ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                + cell (var (Witness 13, Curr))
@@ -1726,18 +1726,18 @@ module Tick : S = struct
                    ) )
                * cell (var (Witness 0, Curr))
              in
-             let x_35 = square (cell (var (Witness 9, Curr))) in
-             let x_36 = square (cell (var (Witness 10, Curr))) in
-             let x_37 =
+             let x_2 = square (cell (var (Witness 9, Curr))) in
+             let x_3 = square (cell (var (Witness 10, Curr))) in
+             let x_4 =
                cell (var (Witness 4, Curr)) - cell (var (Witness 7, Curr))
              in
-             let x_38 =
+             let x_5 =
                cell (var (Witness 7, Curr)) - cell (var (Witness 4, Next))
              in
-             let x_39 =
+             let x_6 =
                cell (var (Witness 5, Next)) + cell (var (Witness 8, Curr))
              in
-             let x_40 =
+             let x_7 =
                cell (var (Witness 8, Curr)) + cell (var (Witness 5, Curr))
              in
              square (cell (var (Witness 11, Curr)))
@@ -1752,7 +1752,7 @@ module Tick : S = struct
                * ( square (cell (var (Witness 14, Curr)))
                  - cell (var (Witness 14, Curr)) )
              + alpha_pow 4
-               * ( (x_33 - cell (var (Witness 4, Curr)))
+               * ( (x_0 - cell (var (Witness 4, Curr)))
                    * cell (var (Witness 9, Curr))
                  - ( ( double (cell (var (Witness 12, Curr)))
                      - field
@@ -1761,15 +1761,14 @@ module Tick : S = struct
                      * cell (var (Witness 1, Curr))
                    - cell (var (Witness 5, Curr)) ) )
              + alpha_pow 5
-               * ( (double (cell (var (Witness 4, Curr))) - x_35 + x_33)
-                   * ((x_37 * cell (var (Witness 9, Curr))) + x_40)
-                 - (double (cell (var (Witness 5, Curr))) * x_37) )
+               * ( (double (cell (var (Witness 4, Curr))) - x_2 + x_0)
+                   * ((x_4 * cell (var (Witness 9, Curr))) + x_7)
+                 - (double (cell (var (Witness 5, Curr))) * x_4) )
              + alpha_pow 6
-               * ( square x_40
-                 - (square x_37 * (x_35 - x_33 + cell (var (Witness 7, Curr))))
-                 )
+               * ( square x_7
+                 - (square x_4 * (x_2 - x_0 + cell (var (Witness 7, Curr)))) )
              + alpha_pow 7
-               * ( (x_34 - cell (var (Witness 7, Curr)))
+               * ( (x_1 - cell (var (Witness 7, Curr)))
                    * cell (var (Witness 10, Curr))
                  - ( ( double (cell (var (Witness 14, Curr)))
                      - field
@@ -1778,13 +1777,12 @@ module Tick : S = struct
                      * cell (var (Witness 1, Curr))
                    - cell (var (Witness 8, Curr)) ) )
              + alpha_pow 8
-               * ( (double (cell (var (Witness 7, Curr))) - x_36 + x_34)
-                   * ((x_38 * cell (var (Witness 10, Curr))) + x_39)
-                 - (double (cell (var (Witness 8, Curr))) * x_38) )
+               * ( (double (cell (var (Witness 7, Curr))) - x_3 + x_1)
+                   * ((x_5 * cell (var (Witness 10, Curr))) + x_6)
+                 - (double (cell (var (Witness 8, Curr))) * x_5) )
              + alpha_pow 9
-               * ( square x_39
-                 - (square x_38 * (x_36 - x_34 + cell (var (Witness 4, Next))))
-                 )
+               * ( square x_6
+                 - (square x_5 * (x_3 - x_1 + cell (var (Witness 4, Next)))) )
              + alpha_pow 10
                * ( double
                      ( double
@@ -1797,7 +1795,7 @@ module Tick : S = struct
                  - cell (var (Witness 6, Next)) ) ) )
       ; ( Index EndoMulScalar
         , lazy
-            (let x_41 =
+            (let x_0 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 6, Curr))
@@ -1810,7 +1808,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 6, Curr))
              in
-             let x_42 =
+             let x_1 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 7, Curr))
@@ -1823,7 +1821,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 7, Curr))
              in
-             let x_43 =
+             let x_2 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 8, Curr))
@@ -1836,7 +1834,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 8, Curr))
              in
-             let x_44 =
+             let x_3 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 9, Curr))
@@ -1849,7 +1847,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 9, Curr))
              in
-             let x_45 =
+             let x_4 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 10, Curr))
@@ -1862,7 +1860,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 10, Curr))
              in
-             let x_46 =
+             let x_5 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 11, Curr))
@@ -1875,7 +1873,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 11, Curr))
              in
-             let x_47 =
+             let x_6 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 12, Curr))
@@ -1888,7 +1886,7 @@ module Tick : S = struct
                )
                * cell (var (Witness 12, Curr))
              in
-             let x_48 =
+             let x_7 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADC45309330F104F00000001"
                    * cell (var (Witness 13, Curr))
@@ -1947,14 +1945,14 @@ module Tick : S = struct
                                          ( double
                                              ( double
                                                  (cell (var (Witness 2, Curr)))
-                                             + x_41 )
-                                         + x_42 )
-                                     + x_43 )
-                                 + x_44 )
-                             + x_45 )
-                         + x_46 )
-                     + x_47 )
-                 + x_48
+                                             + x_0 )
+                                         + x_1 )
+                                     + x_2 )
+                                 + x_3 )
+                             + x_4 )
+                         + x_5 )
+                     + x_6 )
+                 + x_7
                  - cell (var (Witness 4, Curr)) )
              + alpha_pow 2
                * ( double
@@ -1966,7 +1964,7 @@ module Tick : S = struct
                                          ( double
                                              ( double
                                                  (cell (var (Witness 3, Curr)))
-                                             + ( x_41
+                                             + ( x_0
                                                + ( ( field
                                                        "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                                      * cell
@@ -1979,7 +1977,7 @@ module Tick : S = struct
                                                  + field
                                                      "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                                  ) ) )
-                                         + ( x_42
+                                         + ( x_1
                                            + ( ( field
                                                    "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                                  * cell (var (Witness 7, Curr))
@@ -1990,7 +1988,7 @@ module Tick : S = struct
                                              + field
                                                  "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                              ) ) )
-                                     + ( x_43
+                                     + ( x_2
                                        + ( ( field
                                                "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                              * cell (var (Witness 8, Curr))
@@ -2001,7 +1999,7 @@ module Tick : S = struct
                                          + field
                                              "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                          ) ) )
-                                 + ( x_44
+                                 + ( x_3
                                    + ( ( field
                                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                          * cell (var (Witness 9, Curr))
@@ -2012,7 +2010,7 @@ module Tick : S = struct
                                      + field
                                          "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                      ) ) )
-                             + ( x_45
+                             + ( x_4
                                + ( ( field
                                        "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                      * cell (var (Witness 10, Curr))
@@ -2023,7 +2021,7 @@ module Tick : S = struct
                                  + field
                                      "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                  ) ) )
-                         + ( x_46
+                         + ( x_5
                            + ( ( field
                                    "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                                  * cell (var (Witness 11, Curr))
@@ -2034,7 +2032,7 @@ module Tick : S = struct
                              + field
                                  "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                              ) ) )
-                     + ( x_47
+                     + ( x_6
                        + ( ( field
                                "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                              * cell (var (Witness 12, Curr))
@@ -2045,7 +2043,7 @@ module Tick : S = struct
                          + field
                              "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                          ) ) )
-                 + ( x_48
+                 + ( x_7
                    + ( ( field
                            "0x40000000000000000000000000000000224698FC094CF91B992D30ED00000000"
                          * cell (var (Witness 13, Curr))
@@ -4136,7 +4134,7 @@ module Tock : S = struct
         ( LookupTables
         , (fun () ->
             alpha_pow 24
-            * ( vanishes_on_zero_knowledge_and_previous_rows
+            * ( vanishes_on_last_4_rows
               * ( cell (var (LookupAggreg, Next))
                   * ( if_feature
                         ( LookupsPerRow 0
@@ -4463,7 +4461,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_zero_knowledge_and_previous_rows
+                   * ( vanishes_on_last_4_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -4622,7 +4620,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_zero_knowledge_and_previous_rows
+                   * ( vanishes_on_last_4_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -4824,7 +4822,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_zero_knowledge_and_previous_rows
+                   * ( vanishes_on_last_4_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -5027,7 +5025,7 @@ module Tock : S = struct
                ( LookupTables
                , (fun () ->
                    alpha_pow 24
-                   * ( vanishes_on_zero_knowledge_and_previous_rows
+                   * ( vanishes_on_last_4_rows
                      * ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                        * ( cell (var (LookupAggreg, Curr))
@@ -5225,29 +5223,29 @@ module Tock : S = struct
                ) ) )
       ; ( Index CompleteAdd
         , lazy
-            (let x_30 =
+            (let x_0 =
                cell (var (Witness 2, Curr)) - cell (var (Witness 0, Curr))
              in
-             let x_31 =
+             let x_1 =
                cell (var (Witness 3, Curr)) - cell (var (Witness 1, Curr))
              in
-             let x_32 =
+             let x_2 =
                cell (var (Witness 0, Curr)) * cell (var (Witness 0, Curr))
              in
-             (cell (var (Witness 10, Curr)) * x_30)
+             (cell (var (Witness 10, Curr)) * x_0)
              - ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                - cell (var (Witness 7, Curr)) )
-             + (alpha_pow 1 * (cell (var (Witness 7, Curr)) * x_30))
+             + (alpha_pow 1 * (cell (var (Witness 7, Curr)) * x_0))
              + alpha_pow 2
                * ( cell (var (Witness 7, Curr))
                    * ( double (cell (var (Witness 8, Curr)))
                        * cell (var (Witness 1, Curr))
-                     - double x_32 - x_32 )
+                     - double x_2 - x_2 )
                  + ( field
                        "0x0000000000000000000000000000000000000000000000000000000000000001"
                    - cell (var (Witness 7, Curr)) )
-                   * ((x_30 * cell (var (Witness 8, Curr))) - x_31) )
+                   * ((x_0 * cell (var (Witness 8, Curr))) - x_1) )
              + alpha_pow 3
                * ( cell (var (Witness 0, Curr))
                  + cell (var (Witness 2, Curr))
@@ -5261,138 +5259,138 @@ module Tock : S = struct
                  - cell (var (Witness 1, Curr))
                  - cell (var (Witness 5, Curr)) )
              + alpha_pow 5
-               * ( x_31
+               * ( x_1
                  * (cell (var (Witness 7, Curr)) - cell (var (Witness 6, Curr)))
                  )
              + alpha_pow 6
-               * ( (x_31 * cell (var (Witness 9, Curr)))
+               * ( (x_1 * cell (var (Witness 9, Curr)))
                  - cell (var (Witness 6, Curr)) ) ) )
       ; ( Index VarBaseMul
         , lazy
-            (let x_15 =
+            (let x_0 =
                cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
              in
-             let x_16 =
-               let x_15 =
+             let x_1 =
+               let x_0 =
                  cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
                in
                cell (var (Witness 2, Curr))
-               - ( x_15
+               - ( x_0
                  - cell (var (Witness 2, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_17 =
-               let x_16 =
-                 let x_15 =
+             let x_2 =
+               let x_1 =
+                 let x_0 =
                    cell (var (Witness 7, Next)) * cell (var (Witness 7, Next))
                  in
                  cell (var (Witness 2, Curr))
-                 - ( x_15
+                 - ( x_0
                    - cell (var (Witness 2, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 3, Curr)))
-               - (x_16 * cell (var (Witness 7, Next)))
+               - (x_1 * cell (var (Witness 7, Next)))
              in
-             let x_18 =
+             let x_3 =
                cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
              in
-             let x_19 =
-               let x_18 =
+             let x_4 =
+               let x_3 =
                  cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
                in
                cell (var (Witness 7, Curr))
-               - ( x_18
+               - ( x_3
                  - cell (var (Witness 7, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_20 =
-               let x_19 =
-                 let x_18 =
+             let x_5 =
+               let x_4 =
+                 let x_3 =
                    cell (var (Witness 8, Next)) * cell (var (Witness 8, Next))
                  in
                  cell (var (Witness 7, Curr))
-                 - ( x_18
+                 - ( x_3
                    - cell (var (Witness 7, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 8, Curr)))
-               - (x_19 * cell (var (Witness 8, Next)))
+               - (x_4 * cell (var (Witness 8, Next)))
              in
-             let x_21 =
+             let x_6 =
                cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
              in
-             let x_22 =
-               let x_21 =
+             let x_7 =
+               let x_6 =
                  cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
                in
                cell (var (Witness 9, Curr))
-               - ( x_21
+               - ( x_6
                  - cell (var (Witness 9, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_23 =
-               let x_22 =
-                 let x_21 =
+             let x_8 =
+               let x_7 =
+                 let x_6 =
                    cell (var (Witness 9, Next)) * cell (var (Witness 9, Next))
                  in
                  cell (var (Witness 9, Curr))
-                 - ( x_21
+                 - ( x_6
                    - cell (var (Witness 9, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 10, Curr)))
-               - (x_22 * cell (var (Witness 9, Next)))
+               - (x_7 * cell (var (Witness 9, Next)))
              in
-             let x_24 =
+             let x_9 =
                cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
              in
-             let x_25 =
-               let x_24 =
+             let x_10 =
+               let x_9 =
                  cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
                in
                cell (var (Witness 11, Curr))
-               - ( x_24
+               - ( x_9
                  - cell (var (Witness 11, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_26 =
-               let x_25 =
-                 let x_24 =
+             let x_11 =
+               let x_10 =
+                 let x_9 =
                    cell (var (Witness 10, Next)) * cell (var (Witness 10, Next))
                  in
                  cell (var (Witness 11, Curr))
-                 - ( x_24
+                 - ( x_9
                    - cell (var (Witness 11, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 12, Curr)))
-               - (x_25 * cell (var (Witness 10, Next)))
+               - (x_10 * cell (var (Witness 10, Next)))
              in
-             let x_27 =
+             let x_12 =
                cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
              in
-             let x_28 =
-               let x_27 =
+             let x_13 =
+               let x_12 =
                  cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
                in
                cell (var (Witness 13, Curr))
-               - ( x_27
+               - ( x_12
                  - cell (var (Witness 13, Curr))
                  - cell (var (Witness 0, Curr)) )
              in
-             let x_29 =
-               let x_28 =
-                 let x_27 =
+             let x_14 =
+               let x_13 =
+                 let x_12 =
                    cell (var (Witness 11, Next)) * cell (var (Witness 11, Next))
                  in
                  cell (var (Witness 13, Curr))
-                 - ( x_27
+                 - ( x_12
                    - cell (var (Witness 13, Curr))
                    - cell (var (Witness 0, Curr)) )
                in
                double (cell (var (Witness 14, Curr)))
-               - (x_28 * cell (var (Witness 11, Next)))
+               - (x_13 * cell (var (Witness 11, Next)))
              in
              cell (var (Witness 5, Curr))
              - ( cell (var (Witness 6, Next))
@@ -5419,16 +5417,16 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 3
-               * ( (x_17 * x_17)
-                 - x_16 * x_16
+               * ( (x_2 * x_2)
+                 - x_1 * x_1
                    * ( cell (var (Witness 7, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_15 ) )
+                     + x_0 ) )
              + alpha_pow 4
                * ( (cell (var (Witness 8, Curr)) + cell (var (Witness 3, Curr)))
-                   * x_16
+                   * x_1
                  - (cell (var (Witness 2, Curr)) - cell (var (Witness 7, Curr)))
-                   * x_17 )
+                   * x_2 )
              + alpha_pow 5
                * ( square (cell (var (Witness 3, Next)))
                  - cell (var (Witness 3, Next)) )
@@ -5442,16 +5440,16 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 7
-               * ( (x_20 * x_20)
-                 - x_19 * x_19
+               * ( (x_5 * x_5)
+                 - x_4 * x_4
                    * ( cell (var (Witness 9, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_18 ) )
+                     + x_3 ) )
              + alpha_pow 8
                * ( (cell (var (Witness 10, Curr)) + cell (var (Witness 8, Curr)))
-                   * x_19
+                   * x_4
                  - (cell (var (Witness 7, Curr)) - cell (var (Witness 9, Curr)))
-                   * x_20 )
+                   * x_5 )
              + alpha_pow 9
                * ( square (cell (var (Witness 4, Next)))
                  - cell (var (Witness 4, Next)) )
@@ -5465,17 +5463,17 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 11
-               * ( (x_23 * x_23)
-                 - x_22 * x_22
+               * ( (x_8 * x_8)
+                 - x_7 * x_7
                    * ( cell (var (Witness 11, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_21 ) )
+                     + x_6 ) )
              + alpha_pow 12
                * ( ( cell (var (Witness 12, Curr))
                    + cell (var (Witness 10, Curr)) )
-                   * x_22
+                   * x_7
                  - (cell (var (Witness 9, Curr)) - cell (var (Witness 11, Curr)))
-                   * x_23 )
+                   * x_8 )
              + alpha_pow 13
                * ( square (cell (var (Witness 5, Next)))
                  - cell (var (Witness 5, Next)) )
@@ -5489,18 +5487,18 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 15
-               * ( (x_26 * x_26)
-                 - x_25 * x_25
+               * ( (x_11 * x_11)
+                 - x_10 * x_10
                    * ( cell (var (Witness 13, Curr))
                      - cell (var (Witness 0, Curr))
-                     + x_24 ) )
+                     + x_9 ) )
              + alpha_pow 16
                * ( ( cell (var (Witness 14, Curr))
                    + cell (var (Witness 12, Curr)) )
-                   * x_25
+                   * x_10
                  - ( cell (var (Witness 11, Curr))
                    - cell (var (Witness 13, Curr)) )
-                   * x_26 )
+                   * x_11 )
              + alpha_pow 17
                * ( square (cell (var (Witness 6, Next)))
                  - cell (var (Witness 6, Next)) )
@@ -5514,19 +5512,19 @@ module Tock : S = struct
                      )
                      * cell (var (Witness 1, Curr)) ) )
              + alpha_pow 19
-               * ( (x_29 * x_29)
-                 - x_28 * x_28
+               * ( (x_14 * x_14)
+                 - x_13 * x_13
                    * ( cell (var (Witness 0, Next))
                      - cell (var (Witness 0, Curr))
-                     + x_27 ) )
+                     + x_12 ) )
              + alpha_pow 20
                * ( (cell (var (Witness 1, Next)) + cell (var (Witness 14, Curr)))
-                   * x_28
+                   * x_13
                  - (cell (var (Witness 13, Curr)) - cell (var (Witness 0, Next)))
-                   * x_29 ) ) )
+                   * x_14 ) ) )
       ; ( Index EndoMul
         , lazy
-            (let x_33 =
+            (let x_0 =
                ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                + cell (var (Witness 11, Curr))
@@ -5536,7 +5534,7 @@ module Tock : S = struct
                    ) )
                * cell (var (Witness 0, Curr))
              in
-             let x_34 =
+             let x_1 =
                ( field
                    "0x0000000000000000000000000000000000000000000000000000000000000001"
                + cell (var (Witness 13, Curr))
@@ -5546,18 +5544,18 @@ module Tock : S = struct
                    ) )
                * cell (var (Witness 0, Curr))
              in
-             let x_35 = square (cell (var (Witness 9, Curr))) in
-             let x_36 = square (cell (var (Witness 10, Curr))) in
-             let x_37 =
+             let x_2 = square (cell (var (Witness 9, Curr))) in
+             let x_3 = square (cell (var (Witness 10, Curr))) in
+             let x_4 =
                cell (var (Witness 4, Curr)) - cell (var (Witness 7, Curr))
              in
-             let x_38 =
+             let x_5 =
                cell (var (Witness 7, Curr)) - cell (var (Witness 4, Next))
              in
-             let x_39 =
+             let x_6 =
                cell (var (Witness 5, Next)) + cell (var (Witness 8, Curr))
              in
-             let x_40 =
+             let x_7 =
                cell (var (Witness 8, Curr)) + cell (var (Witness 5, Curr))
              in
              square (cell (var (Witness 11, Curr)))
@@ -5572,7 +5570,7 @@ module Tock : S = struct
                * ( square (cell (var (Witness 14, Curr)))
                  - cell (var (Witness 14, Curr)) )
              + alpha_pow 4
-               * ( (x_33 - cell (var (Witness 4, Curr)))
+               * ( (x_0 - cell (var (Witness 4, Curr)))
                    * cell (var (Witness 9, Curr))
                  - ( ( double (cell (var (Witness 12, Curr)))
                      - field
@@ -5581,15 +5579,14 @@ module Tock : S = struct
                      * cell (var (Witness 1, Curr))
                    - cell (var (Witness 5, Curr)) ) )
              + alpha_pow 5
-               * ( (double (cell (var (Witness 4, Curr))) - x_35 + x_33)
-                   * ((x_37 * cell (var (Witness 9, Curr))) + x_40)
-                 - (double (cell (var (Witness 5, Curr))) * x_37) )
+               * ( (double (cell (var (Witness 4, Curr))) - x_2 + x_0)
+                   * ((x_4 * cell (var (Witness 9, Curr))) + x_7)
+                 - (double (cell (var (Witness 5, Curr))) * x_4) )
              + alpha_pow 6
-               * ( square x_40
-                 - (square x_37 * (x_35 - x_33 + cell (var (Witness 7, Curr))))
-                 )
+               * ( square x_7
+                 - (square x_4 * (x_2 - x_0 + cell (var (Witness 7, Curr)))) )
              + alpha_pow 7
-               * ( (x_34 - cell (var (Witness 7, Curr)))
+               * ( (x_1 - cell (var (Witness 7, Curr)))
                    * cell (var (Witness 10, Curr))
                  - ( ( double (cell (var (Witness 14, Curr)))
                      - field
@@ -5598,13 +5595,12 @@ module Tock : S = struct
                      * cell (var (Witness 1, Curr))
                    - cell (var (Witness 8, Curr)) ) )
              + alpha_pow 8
-               * ( (double (cell (var (Witness 7, Curr))) - x_36 + x_34)
-                   * ((x_38 * cell (var (Witness 10, Curr))) + x_39)
-                 - (double (cell (var (Witness 8, Curr))) * x_38) )
+               * ( (double (cell (var (Witness 7, Curr))) - x_3 + x_1)
+                   * ((x_5 * cell (var (Witness 10, Curr))) + x_6)
+                 - (double (cell (var (Witness 8, Curr))) * x_5) )
              + alpha_pow 9
-               * ( square x_39
-                 - (square x_38 * (x_36 - x_34 + cell (var (Witness 4, Next))))
-                 )
+               * ( square x_6
+                 - (square x_5 * (x_3 - x_1 + cell (var (Witness 4, Next)))) )
              + alpha_pow 10
                * ( double
                      ( double
@@ -5617,7 +5613,7 @@ module Tock : S = struct
                  - cell (var (Witness 6, Next)) ) ) )
       ; ( Index EndoMulScalar
         , lazy
-            (let x_41 =
+            (let x_0 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 6, Curr))
@@ -5630,7 +5626,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 6, Curr))
              in
-             let x_42 =
+             let x_1 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 7, Curr))
@@ -5643,7 +5639,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 7, Curr))
              in
-             let x_43 =
+             let x_2 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 8, Curr))
@@ -5656,7 +5652,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 8, Curr))
              in
-             let x_44 =
+             let x_3 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 9, Curr))
@@ -5669,7 +5665,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 9, Curr))
              in
-             let x_45 =
+             let x_4 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 10, Curr))
@@ -5682,7 +5678,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 10, Curr))
              in
-             let x_46 =
+             let x_5 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 11, Curr))
@@ -5695,7 +5691,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 11, Curr))
              in
-             let x_47 =
+             let x_6 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 12, Curr))
@@ -5708,7 +5704,7 @@ module Tock : S = struct
                )
                * cell (var (Witness 12, Curr))
              in
-             let x_48 =
+             let x_7 =
                ( ( field
                      "0x1555555555555555555555555555555560C232FEADDC3849D96CF90B00000001"
                    * cell (var (Witness 13, Curr))
@@ -5767,14 +5763,14 @@ module Tock : S = struct
                                          ( double
                                              ( double
                                                  (cell (var (Witness 2, Curr)))
-                                             + x_41 )
-                                         + x_42 )
-                                     + x_43 )
-                                 + x_44 )
-                             + x_45 )
-                         + x_46 )
-                     + x_47 )
-                 + x_48
+                                             + x_0 )
+                                         + x_1 )
+                                     + x_2 )
+                                 + x_3 )
+                             + x_4 )
+                         + x_5 )
+                     + x_6 )
+                 + x_7
                  - cell (var (Witness 4, Curr)) )
              + alpha_pow 2
                * ( double
@@ -5786,7 +5782,7 @@ module Tock : S = struct
                                          ( double
                                              ( double
                                                  (cell (var (Witness 3, Curr)))
-                                             + ( x_41
+                                             + ( x_0
                                                + ( ( field
                                                        "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                                      * cell
@@ -5799,7 +5795,7 @@ module Tock : S = struct
                                                  + field
                                                      "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                                  ) ) )
-                                         + ( x_42
+                                         + ( x_1
                                            + ( ( field
                                                    "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                                  * cell (var (Witness 7, Curr))
@@ -5810,7 +5806,7 @@ module Tock : S = struct
                                              + field
                                                  "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                              ) ) )
-                                     + ( x_43
+                                     + ( x_2
                                        + ( ( field
                                                "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                              * cell (var (Witness 8, Curr))
@@ -5821,7 +5817,7 @@ module Tock : S = struct
                                          + field
                                              "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                          ) ) )
-                                 + ( x_44
+                                 + ( x_3
                                    + ( ( field
                                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                          * cell (var (Witness 9, Curr))
@@ -5832,7 +5828,7 @@ module Tock : S = struct
                                      + field
                                          "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                      ) ) )
-                             + ( x_45
+                             + ( x_4
                                + ( ( field
                                        "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                      * cell (var (Witness 10, Curr))
@@ -5843,7 +5839,7 @@ module Tock : S = struct
                                  + field
                                      "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                  ) ) )
-                         + ( x_46
+                         + ( x_5
                            + ( ( field
                                    "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                                  * cell (var (Witness 11, Curr))
@@ -5854,7 +5850,7 @@ module Tock : S = struct
                              + field
                                  "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                              ) ) )
-                     + ( x_47
+                     + ( x_6
                        + ( ( field
                                "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                              * cell (var (Witness 12, Curr))
@@ -5865,7 +5861,7 @@ module Tock : S = struct
                          + field
                              "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                          ) ) )
-                 + ( x_48
+                 + ( x_7
                    + ( ( field
                            "0x40000000000000000000000000000000224698FC0994A8DD8C46EB2100000000"
                          * cell (var (Witness 13, Curr))

--- a/src/lib/pickles/side_loaded_verification_key.ml
+++ b/src/lib/pickles/side_loaded_verification_key.ml
@@ -41,7 +41,7 @@ let input_size ~of_int ~add ~mul w =
   let size a =
     let (T (Typ typ, _conv, _conv_inv)) =
       Impls.Step.input ~proofs_verified:a ~wrap_rounds:Backend.Tock.Rounds.n
-        ~feature_flags:Plonk_types.Features.none
+        ~feature_flags:Plonk_types.Features.none_chunked
     in
     typ.size_in_field_elements
   in
@@ -358,7 +358,7 @@ let%test_unit "input_size" =
          let (T (Typ typ, _conv, _conv_inv)) =
            Impls.Step.input ~proofs_verified:a
              ~wrap_rounds:Backend.Tock.Rounds.n
-             ~feature_flags:Plonk_types.Features.none
+             ~feature_flags:Plonk_types.Features.none_chunked
          in
          typ.size_in_field_elements ) )
 

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -503,7 +503,8 @@ struct
           include Tock.Field
         end in
         (* Wrap proof, no features *)
-        Plonk_checks.Type2.derive_plonk ~feature_flags:Plonk_types.Features.none
+        Plonk_checks.Type2.derive_plonk
+          ~feature_flags:Plonk_types.Features.none_chunked
           (module Field)
           ~env:tock_env ~shift:Shifts.tock2 tock_plonk_minimal
           tock_combined_evals

--- a/src/lib/pickles/step.mli
+++ b/src/lib/pickles/step.mli
@@ -30,7 +30,7 @@ module Make
     -> prevs_length:('prev_vars, 'prevs_length) Pickles_types.Hlist.Length.t
     -> self:('a, 'b, 'c, 'd) Tag.t
     -> step_domains:(Import.Domains.t, 'self_branches) Pickles_types.Vector.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Features.chunked_options
     -> self_dlog_plonk_index:
          Backend.Tick.Inner_curve.Affine.t
          Pickles_types.Plonk_verification_key_evals.t

--- a/src/lib/pickles/step_branch_data.ml
+++ b/src/lib/pickles/step_branch_data.ml
@@ -73,7 +73,7 @@ let create
     (type branches max_proofs_verified var value a_var a_value ret_var ret_value)
     ~index ~(self : (var, value, max_proofs_verified, branches) Tag.t)
     ~wrap_domains
-    ~(feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t)
+    ~(feature_flags : Plonk_types.Features.chunked_options)
     ~(actual_feature_flags : bool Plonk_types.Features.t)
     ~(max_proofs_verified : max_proofs_verified Nat.t)
     ~(proofs_verifieds : (int, branches) Vector.t) ~(branches : branches Nat.t)

--- a/src/lib/pickles/step_branch_data.mli
+++ b/src/lib/pickles/step_branch_data.mli
@@ -70,7 +70,7 @@ val create :
      index:int
   -> self:('var, 'value, 'max_proofs_verified, 'branches) Tag.t
   -> wrap_domains:Import.Domains.t
-  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> feature_flags:Plonk_types.Features.chunked_options
   -> actual_feature_flags:bool Plonk_types.Features.t
   -> max_proofs_verified:'max_proofs_verified Pickles_types.Nat.t
   -> proofs_verifieds:(int, 'branches) Pickles_types.Vector.t

--- a/src/lib/pickles/step_main.ml
+++ b/src/lib/pickles/step_main.ml
@@ -197,7 +197,7 @@ let step_main :
         type pvars pvals ns1 ns2 br.
            (pvars, pvals, ns1, ns2) H4.T(Tag).t
         -> (pvars, br) Length.t
-        -> (Plonk_types.Opt.Flag.t Plonk_types.Features.t, br) Vector.t =
+        -> (Plonk_types.Features.chunked_options, br) Vector.t =
      fun ds ld ->
       match[@warning "-4"] (ds, ld) with
       | [], Z ->
@@ -220,7 +220,7 @@ let step_main :
         -> (pvars, br) Length.t
         -> (ns1, br) Length.t
         -> (ns2, br) Length.t
-        -> (Plonk_types.Opt.Flag.t Plonk_types.Features.t, br) Vector.t
+        -> (Plonk_types.Features.chunked_options, br) Vector.t
         -> (pvars, pvals, ns1, ns2) H4.T(Typ_with_max_proofs_verified).t =
      fun ds ns1 ns2 ld ln1 ln2 feature_flagss ->
       match[@warning "-4"] (ds, ns1, ns2, ld, ln1, ln2, feature_flagss) with

--- a/src/lib/pickles/step_verifier.ml
+++ b/src/lib/pickles/step_verifier.ml
@@ -852,7 +852,7 @@ struct
      Meaning it needs opt sponge. *)
   let finalize_other_proof (type b branches)
       (module Proofs_verified : Nat.Add.Intf with type n = b)
-      ~(feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t)
+      ~(feature_flags : Plonk_types.Features.chunked_options)
       ~(step_domains :
          [ `Known of (Domains.t, branches) Vector.t | `Side_loaded ] )
       ~(* TODO: Add "actual proofs verified" so that proofs don't

--- a/src/lib/pickles/step_verifier.mli
+++ b/src/lib/pickles/step_verifier.mli
@@ -40,7 +40,7 @@ val assert_n_bits :
 
 val finalize_other_proof :
      (module Pickles_types.Nat.Add.Intf with type n = 'b)
-  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> feature_flags:Plonk_types.Features.chunked_options
   -> step_domains:
        [ `Known of (Import.Domains.t, 'branches) Pickles_types.Vector.t
        | `Side_loaded ]
@@ -127,7 +127,7 @@ val verify :
        , Step_main_inputs.Impl.Field.t Pickles_types.Shifted_value.Type1.t
          Pickles_types.Hlist0.Id.t )
        Composition_types.Wrap.Lookup_parameters.t
-  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> feature_flags:Plonk_types.Features.chunked_options
   -> proof:Wrap_proof.Checked.t
   -> srs:Kimchi_bindings.Protocol.SRS.Fq.t
   -> wrap_domain:

--- a/src/lib/pickles/types_map.ml
+++ b/src/lib/pickles/types_map.ml
@@ -18,7 +18,7 @@ module Basic = struct
     ; wrap_domains : Domains.t
     ; wrap_key : Tick.Inner_curve.Affine.t Plonk_verification_key_evals.t
     ; wrap_vk : Impls.Wrap.Verification_key.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Features.chunked_options
     }
 end
 
@@ -38,7 +38,7 @@ module Side_loaded = struct
     type ('var, 'value, 'n1, 'n2) t =
       { max_proofs_verified : (module Nat.Add.Intf with type n = 'n1)
       ; public_input : ('var, 'value) Impls.Step.Typ.t
-      ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+      ; feature_flags : Plonk_types.Features.chunked_options
       ; branches : 'n2 Nat.t
       }
   end
@@ -82,7 +82,7 @@ module Compiled = struct
           (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; wrap_domains : Domains.t
     ; step_domains : (Domains.t, 'branches) Vector.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Features.chunked_options
     }
 
   (* This is the data associated to an inductive proof system with statement type
@@ -99,7 +99,7 @@ module Compiled = struct
     ; wrap_vk : Impls.Wrap.Verification_key.t Lazy.t
     ; wrap_domains : Domains.t
     ; step_domains : (Domains.t, 'branches) Vector.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Features.chunked_options
     }
 
   type packed =
@@ -140,7 +140,7 @@ module For_step = struct
         | `Side_loaded of
           Impls.Step.field Pickles_base.Proofs_verified.One_hot.Checked.t ]
     ; step_domains : [ `Known of (Domains.t, 'branches) Vector.t | `Side_loaded ]
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Features.chunked_options
     }
 
   let of_side_loaded (type a b c d)
@@ -251,7 +251,7 @@ let public_input :
 
 let feature_flags :
     type var value.
-    (var, value, _, _) Tag.t -> Plonk_types.Opt.Flag.t Plonk_types.Features.t =
+    (var, value, _, _) Tag.t -> Plonk_types.Features.chunked_options =
  fun tag ->
   match tag.kind with
   | Compiled ->

--- a/src/lib/pickles/types_map.mli
+++ b/src/lib/pickles/types_map.mli
@@ -14,7 +14,7 @@ module Basic : sig
         Backend.Tick.Inner_curve.Affine.t
         Pickles_types.Plonk_verification_key_evals.t
     ; wrap_vk : Impls.Wrap.Verification_key.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Features.chunked_options
     }
 end
 
@@ -35,7 +35,7 @@ module Side_loaded : sig
       { max_proofs_verified :
           (module Pickles_types.Nat.Add.Intf with type n = 'n1)
       ; public_input : ('var, 'value) Impls.Step.Typ.t
-      ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+      ; feature_flags : Plonk_types.Features.chunked_options
       ; branches : 'n2 Pickles_types.Nat.t
       }
   end
@@ -58,7 +58,7 @@ module Compiled : sig
           (* For each branch in this rule, how many predecessor proofs does it have? *)
     ; wrap_domains : Import.Domains.t
     ; step_domains : (Import.Domains.t, 'branches) Pickles_types.Vector.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Features.chunked_options
     }
 
   type ('a_var, 'a_value, 'max_proofs_verified, 'branches) t =
@@ -75,7 +75,7 @@ module Compiled : sig
     ; wrap_vk : Impls.Wrap.Verification_key.t Lazy.t
     ; wrap_domains : Import.Domains.t
     ; step_domains : (Import.Domains.t, 'branches) Pickles_types.Vector.t
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Features.chunked_options
     }
 end
 
@@ -96,7 +96,7 @@ module For_step : sig
     ; step_domains :
         [ `Known of (Import.Domains.t, 'branches) Pickles_types.Vector.t
         | `Side_loaded ]
-    ; feature_flags : Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    ; feature_flags : Plonk_types.Features.chunked_options
     }
 
   val of_side_loaded : ('a, 'b, 'c, 'd) Side_loaded.t -> ('a, 'b, 'c, 'd) t
@@ -126,7 +126,7 @@ val max_proofs_verified :
      ('a, 'b, 'n1, 'c) Tag.t
   -> (module Pickles_types.Nat.Add.Intf with type n = 'n1)
 
-val feature_flags : _ Tag.t -> Plonk_types.Opt.Flag.t Plonk_types.Features.t
+val feature_flags : _ Tag.t -> Plonk_types.Features.chunked_options
 
 val add_exn :
   ('var, 'value, 'c, 'd) Tag.t -> ('var, 'value, 'c, 'd) Compiled.t -> unit

--- a/src/lib/pickles/unfinalized.ml
+++ b/src/lib/pickles/unfinalized.ml
@@ -156,7 +156,7 @@ let dummy : unit -> t =
   Memo.unit (fun () ->
       let (Typ { var_of_fields; value_to_fields; _ }) =
         typ ~wrap_rounds:Backend.Tock.Rounds.n
-          ~feature_flags:Plonk_types.Features.none
+          ~feature_flags:Plonk_types.Features.none_chunked
       in
       let xs, aux = value_to_fields (Lazy.force Constant.dummy) in
       var_of_fields (Array.map ~f:Field.constant xs, aux) )

--- a/src/lib/pickles/unfinalized.ml
+++ b/src/lib/pickles/unfinalized.ml
@@ -113,7 +113,8 @@ module Constant = struct
          end in
          Plonk_checks.derive_plonk
            (module Field) (* Wrap proof, no features needed *)
-           ~env ~shift ~feature_flags:Plonk_types.Features.none chals evals
+           ~env ~shift ~feature_flags:Plonk_types.Features.none_chunked chals
+           evals
        in
        { deferred_values =
            { plonk =

--- a/src/lib/pickles/unfinalized.mli
+++ b/src/lib/pickles/unfinalized.mli
@@ -40,8 +40,7 @@ type t =
 
 val typ :
      wrap_rounds:'a
-  -> feature_flags:
-       Pickles_types.Plonk_types.Opt.Flag.t Pickles_types.Plonk_types.Features.t
+  -> feature_flags:Pickles_types.Plonk_types.Features.chunked_options
   -> (t, Constant.t) Impls.Step.Typ.t
 
 val dummy : unit -> t

--- a/src/lib/pickles/verify.ml
+++ b/src/lib/pickles/verify.ml
@@ -124,6 +124,7 @@ let verify_heterogenous (ts : Instance.t list) =
               | true ->
                   Plonk_types.Opt.Flag.Yes )
             plonk0.feature_flags
+          |> Plonk_types.Features.chunk
         in
         let tick_env =
           let module Env_bool = struct

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -287,9 +287,9 @@ let deferred_values (type n) ~(sgs : (Backend.Tick.Curve.Affine.t, n) Vector.t)
 let%test_module "gate finalization" =
   ( module struct
     type test_options =
-      { true_is_yes : Plonk_types.Features.options
-      ; true_is_maybe : Plonk_types.Features.options
-      ; all_maybes : Plonk_types.Features.options
+      { true_is_yes : Plonk_types.Features.chunked_options
+      ; true_is_maybe : Plonk_types.Features.chunked_options
+      ; all_maybes : Plonk_types.Features.chunked_options
       }
 
     (* Helper function to convert actual feature flags into 3 test configurations of feature flags
@@ -310,12 +310,14 @@ let%test_module "gate finalization" =
       let compute_feature_flags
           (actual_feature_flags : Plonk_types.Features.flags)
           (true_opt : Plonk_types.Opt.Flag.t)
-          (false_opt : Plonk_types.Opt.Flag.t) : Plonk_types.Features.options =
+          (false_opt : Plonk_types.Opt.Flag.t) :
+          Plonk_types.Features.chunked_options =
         Plonk_types.Features.map actual_feature_flags ~f:(function
           | true ->
               true_opt
           | false ->
               false_opt )
+        |> Plonk_types.Features.chunk
       in
 
       (* Generate the 3 configurations of the actual feature flags using

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -338,7 +338,7 @@ let%test_module "gate finalization" =
     *)
     let run_recursive_proof_test
         (actual_feature_flags : Plonk_types.Features.flags)
-        (feature_flags : Plonk_types.Features.options)
+        (feature_flags : Plonk_types.Features.chunked_options)
         (public_input : Pasta_bindings.Fp.t list)
         (vk : Kimchi_bindings.Protocol.VerifierIndex.Fp.t)
         (proof : Backend.Tick.Proof.t) : Impls.Step.Boolean.value =

--- a/src/lib/pickles/wrap.mli
+++ b/src/lib/pickles/wrap.mli
@@ -39,7 +39,7 @@ val wrap :
   -> step_vk:Kimchi_bindings.Protocol.VerifierIndex.Fp.t
   -> actual_wrap_domains:(Core_kernel.Int.t, 'c) Pickles_types.Vector.t
   -> step_plonk_indices:'d
-  -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+  -> feature_flags:Plonk_types.Features.chunked_options
   -> actual_feature_flags:bool Plonk_types.Features.t
   -> ?tweak_statement:
        (   ( Import.Challenge.Constant.t

--- a/src/lib/pickles/wrap_domains.ml
+++ b/src/lib/pickles/wrap_domains.ml
@@ -33,10 +33,11 @@ struct
     in
     Timer.clock __LOC__ ;
     let srs = Backend.Tick.Keypair.load_urs () in
-    let _, main =
+    let _, _main =
       Wrap_main.wrap_main ~feature_flags ~srs full_signature choices_length
         dummy_step_keys dummy_step_widths dummy_step_domains max_proofs_verified
     in
+    let main = assert false in
     Timer.clock __LOC__ ;
     let t =
       Fix_domains.domains

--- a/src/lib/pickles/wrap_domains.mli
+++ b/src/lib/pickles/wrap_domains.mli
@@ -13,7 +13,7 @@ module Make
        ('a, 'b, 'c) Full_signature.t
     -> 'd
     -> ('e, 'b) Hlist.Length.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Features.chunked_options
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'a)
     -> Import.Domains.t
 
@@ -21,7 +21,7 @@ module Make
        ('a, 'b, 'c) Full_signature.t
     -> 'd
     -> ('e, 'b) Hlist.Length.t
-    -> feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+    -> feature_flags:Plonk_types.Features.chunked_options
     -> max_proofs_verified:(module Nat.Add.Intf with type n = 'a)
     -> Import.Domains.Stable.V2.t
 end

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -36,7 +36,8 @@ module Old_bulletproof_chals = struct
         -> t
 end
 
-let pack_statement max_proofs_verified ~lookup ~feature_flags t =
+let pack_statement max_proofs_verified ~lookup
+    ~(feature_flags : Plonk_types.Features.chunked_options) t =
   let open Types.Step in
   Spec.pack
     (module Impl)

--- a/src/lib/pickles/wrap_main.ml
+++ b/src/lib/pickles/wrap_main.ml
@@ -210,7 +210,7 @@ let wrap_main
                   Common.Lookup_parameters.tock_zero
                   ~assert_16_bits:(Wrap_verifier.assert_n_bits ~n:16)
                   (Vector.init Max_proofs_verified.n ~f:(fun _ ->
-                       Plonk_types.Features.none ) )
+                       Plonk_types.Features.none_chunked ) )
                   (Shifted_value.Type2.typ Field.typ)
               in
               exists typ ~request:(fun () -> Req.Proof_state) )

--- a/src/lib/pickles/wrap_main.mli
+++ b/src/lib/pickles/wrap_main.mli
@@ -3,7 +3,7 @@ open Pickles_types
 (** [wrap_main] is the SNARK function for wrapping any proof coming from the given set of
     keys **)
 val wrap_main :
-     feature_flags:Plonk_types.Opt.Flag.t Plonk_types.Features.t
+     feature_flags:Plonk_types.Features.chunked_options
   -> ( 'max_proofs_verified
      , 'branches
      , 'max_local_max_proofs_verifieds )

--- a/src/lib/pickles/wrap_proof.ml
+++ b/src/lib/pickles/wrap_proof.ml
@@ -37,7 +37,7 @@ let typ : (Checked.t, Constant.t) Typ.t =
     ~value_to_hlist:Constant.to_hlist ~value_of_hlist:Constant.of_hlist
     [ Plonk_types.Messages.typ
         (module Impl)
-        Inner_curve.typ Plonk_types.Features.none ~bool:Boolean.typ
+        Inner_curve.typ Plonk_types.Features.none_chunked ~bool:Boolean.typ
         ~dummy:Inner_curve.Params.one ~commitment_lengths
     ; Types.Step.Bulletproof.typ ~length:(Nat.to_int Tock.Rounds.n)
         ( Typ.transport Other_field.typ

--- a/src/lib/pickles/wrap_verifier.ml
+++ b/src/lib/pickles/wrap_verifier.ml
@@ -1010,7 +1010,7 @@ struct
     let plonk_checks_passed =
       with_label __LOC__ (fun () ->
           (* This proof is a wrap proof; no need to consider features. *)
-          Plonk_checks.checked ~feature_flags:Plonk_types.Features.none
+          Plonk_checks.checked ~feature_flags:Plonk_types.Features.none_chunked
             (module Impl)
             ~env ~shift:shift2 plonk combined_evals )
     in

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -428,10 +428,8 @@ module Evals = struct
 
     let opt_typ impl ({ lookup; runtime_tables; _ } : Features.chunked_options)
         ~dummy:z elt =
-      let runtime_tables = runtime_tables.(0) in
-      let lookup = lookup.(0) in
       Opt.typ impl lookup
-        ~dummy:(dummy z ~runtime:(not (Opt.Flag.equal runtime_tables No)))
+        ~dummy:(dummy z ~runtime:(not (Opt.Flag.equal runtime_tables.(0) No)))
         (typ impl ~runtime_tables ~dummy:z elt)
   end
 
@@ -842,11 +840,11 @@ module Messages = struct
         ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
         ~var_to_hlist:In_circuit.to_hlist ~var_of_hlist:In_circuit.of_hlist
 
-    let opt_typ bool_typ ~(lookup : Opt.Flag.t) ~(runtime_tables : Opt.Flag.t)
-        ~dummy:z elt =
+    let opt_typ bool_typ ~(lookup : Opt.Flag.t array)
+        ~(runtime_tables : Opt.Flag.t array) ~dummy:z elt =
       Opt.typ bool_typ lookup
         ~dummy:
-          (dummy z ~runtime_tables:Opt.Flag.(not (equal runtime_tables No)))
+          (dummy z ~runtime_tables:Opt.Flag.(not (equal runtime_tables.(0) No)))
         (typ bool_typ ~runtime_tables ~dummy:z elt)
   end
 

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -425,8 +425,10 @@ module Evals = struct
         ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
         ~var_to_hlist:In_circuit.to_hlist ~var_of_hlist:In_circuit.of_hlist
 
-    let opt_typ impl ({ lookup; runtime_tables; _ } : Opt.Flag.t Features.t)
+    let opt_typ impl ({ lookup; runtime_tables; _ } : Features.chunked_options)
         ~dummy:z elt =
+      let runtime_tables = runtime_tables.(0) in
+      let lookup = lookup.(0) in
       Opt.typ impl lookup
         ~dummy:(dummy z ~runtime:(not (Opt.Flag.equal runtime_tables No)))
         (typ impl ~runtime_tables ~dummy:z elt)

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -199,6 +199,12 @@ module Features = struct
 
   type flags = bool t
 
+  type 'a chunked = 'a array t
+
+  type chunked_options = Opt.Flag.t chunked
+
+  type chunked_flags = bool chunked
+
   let to_data
       { range_check0
       ; range_check1

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -340,6 +340,14 @@ module Features = struct
     ; runtime_tables = f runtime_tables
     }
 
+  let chunk v = map ~f:(Array.create ~len:1) v
+
+  let unchunk v = map ~f:(fun e -> e.(0)) v
+
+  let none_chunked = chunk none
+
+  let none_bool_chunked = chunk none_bool
+
   let map2 x1 x2 ~f =
     { range_check0 = f x1.range_check0 x2.range_check0
     ; range_check1 = f x1.range_check1 x2.range_check1

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -274,7 +274,9 @@ module Features = struct
       |> transport ~there ~back:(fun () -> value)
       |> transport_var ~there:(fun _ -> ()) ~back:(fun () -> constant bool value)
     in
-    let bool_typ_of_flag = function
+    let bool_typ_of_flag flag =
+      let flag = flag.(0) in
+      match flag with
       | Opt.Flag.Yes ->
           constant_typ
             ~there:(function true -> () | false -> assert false)

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -140,8 +140,9 @@ module Opt = struct
          ~back:(fun (b, x) ->
            match flag with No -> None | Yes -> Some x | Maybe -> Maybe (b, x) )
 
-  let typ (type a a_var f) bool_typ (flag : Flag.t)
+  let typ (type a a_var f) bool_typ (flag : Flag.t array)
       (a_typ : (a_var, a, f) Typ.t) ~(dummy : a) =
+    let flag = flag.(0) in
     match flag with
     | Yes ->
         some_typ a_typ
@@ -875,7 +876,7 @@ module Messages = struct
 
   let typ (type n f)
       (module Impl : Snarky_backendless.Snark_intf.Run with type field = f) g
-      ({ lookup; runtime_tables; _ } : Opt.Flag.t Features.t) ~dummy
+      ({ lookup; runtime_tables; _ } : Features.chunked_options) ~dummy
       ~(commitment_lengths : (((int, n) Vector.t as 'v), int, int) Poly.t) ~bool
       =
     let open Snarky_backendless.Typ in
@@ -888,6 +889,7 @@ module Messages = struct
         ~dummy_group_element:dummy ~bool
     in
     let lookup =
+      let lookup = lookup.(0) and runtime_tables = runtime_tables.(0) in
       Lookup.opt_typ Impl.Boolean.typ ~lookup ~runtime_tables ~dummy:[| dummy |]
         (wo [ 1 ])
     in

--- a/src/lib/pickles_types/plonk_types.ml
+++ b/src/lib/pickles_types/plonk_types.ml
@@ -887,7 +887,6 @@ module Messages = struct
         ~dummy_group_element:dummy ~bool
     in
     let lookup =
-      let lookup = lookup.(0) and runtime_tables = runtime_tables.(0) in
       Lookup.opt_typ Impl.Boolean.typ ~lookup ~runtime_tables ~dummy:[| dummy |]
         (wo [ 1 ])
     in

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -113,7 +113,7 @@ module Features : sig
 
   val typ :
        ('var, bool, 'f) Snarky_backendless.Typ.t
-    -> feature_flags:options
+    -> feature_flags:chunked_options
     -> ('var t, bool t, 'f) Snarky_backendless.Typ.t
 
   (** {2 Iterators} *)

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -37,7 +37,7 @@ module Opt : sig
 
   val typ :
        ('b, bool, 'f) Snarky_backendless.Typ.t
-    -> Flag.t
+    -> Flag.t array
     -> ('a_var, 'a, 'f) Snarky_backendless.Typ.t
     -> dummy:'a
     -> (('a_var, 'b) t, 'a option, 'f) Snarky_backendless.Typ.t

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -89,6 +89,18 @@ module Features : sig
 
   type chunked_flags = bool chunked
 
+  (** {2 Constants}*)
+
+  val none : options
+
+  val none_chunked : chunked_options
+
+  val none_bool : flags
+
+  val none_bool_chunked : chunked_flags
+
+  (** {2 Conversion functions and serializers} *)
+
   val to_data :
        'a t
     -> ('a * ('a * ('a * ('a * ('a * ('a * ('a * ('a * unit))))))))
@@ -104,11 +116,14 @@ module Features : sig
     -> feature_flags:options
     -> ('var t, bool t, 'f) Snarky_backendless.Typ.t
 
-  val none : options
-
-  val none_bool : flags
+  (** {2 Iterators} *)
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
+
+  (** [chunk] is [map ~f:(Array.create ~len:1)] *)
+  val chunk : 'a t -> 'a chunked
+
+  val unchunk : 'a chunked -> 'a t
 
   val map2 : 'a t -> 'b t -> f:('a -> 'b -> 'c) -> 'c t
 end
@@ -370,7 +385,7 @@ module All_evals : sig
 
   val typ :
        (module Snarky_backendless.Snark_intf.Run with type field = 'f)
-    -> Opt.Flag.t Features.t
+    -> Features.chunked_options
     -> ( ( 'f Snarky_backendless.Cvar.t
          , 'f Snarky_backendless.Cvar.t array
          , 'f Snarky_backendless.Cvar.t Snarky_backendless.Boolean.t )

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -81,6 +81,14 @@ module Features : sig
 
   type flags = bool t
 
+  (** {3 Aliases for chunked elements} *)
+
+  type 'a chunked = 'a array t
+
+  type chunked_options = Opt.Flag.t chunked
+
+  type chunked_flags = bool chunked
+
   val to_data :
        'a t
     -> ('a * ('a * ('a * ('a * ('a * ('a * ('a * ('a * unit))))))))

--- a/src/lib/pickles_types/plonk_types.mli
+++ b/src/lib/pickles_types/plonk_types.mli
@@ -201,7 +201,7 @@ module Messages : sig
   val typ :
        (module Snarky_backendless.Snark_intf.Run with type field = 'f)
     -> ('a, 'b, 'f) Snarky_backendless.Typ.t
-    -> Opt.Flag.t Features.t
+    -> Features.chunked_options
     -> dummy:'b
     -> commitment_lengths:((int, 'n) Vector.vec, int, int) Poly.t
     -> bool:('c, bool, 'f) Snarky_backendless.Typ.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -614,6 +614,7 @@ module Make_str (A : Wire_types.Concrete) = struct
         ; lookup = Opt.Flag.Maybe
         ; runtime_tables = Opt.Flag.Maybe
         }
+        |> Features.chunk
       in
       Memo.of_comparable
         (module Int)


### PR DESCRIPTION
[DO NOT REVIEW] 
Fix #13013

* Description 

This PR first builds new types and utilities to talk about chunked representations of scalars.
Then these abstractions are propagated throughout the code, updating it as needed.

* Needs to do
- [ ] Finish propagation the `chunked_options` type
- [ ] Clean up the history (Wave commits https://github.com/MinaProtocol/mina/pull/13400/commits/d42230c494bdb9828a10e120f5e209da11ed3a8f are not super useful)