### PR TITLE
allow to run connect to mainnet on release branches

### DIFF
--- a/buildkite/scripts/connect-to-mainnet-on-compatible.sh
+++ b/buildkite/scripts/connect-to-mainnet-on-compatible.sh
@@ -32,6 +32,7 @@ mina daemon \
   --peer-list-url "https://storage.googleapis.com/seed-lists/${TESTNET_NAME}_seeds.txt" \
 & # -background
 
+
 # Attempt to connect to the GraphQL client every 10s for up to 4 minutes
 num_status_retries=24
 for ((i=1;i<=$num_status_retries;i++)); do

--- a/buildkite/scripts/connect-to-mainnet-on-compatible.sh
+++ b/buildkite/scripts/connect-to-mainnet-on-compatible.sh
@@ -2,11 +2,14 @@
 
 set -eo pipefail
 
-
-if [ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" = "compatible" ] && [ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" = release/* ]; then
-  echo "Not pulling against compatible or not in release branch. Therefore, not running the connect test"
-  exit 0
-fi
+case "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" in
+    compatible|release/*)
+      echo "Not pulling against compatible or not in release branch. Therefore, not running the connect test"
+      exit 0
+      ;;
+    *) 
+      ;;
+esac
 
 # Don't prompt for answers during apt-get install
 export DEBIAN_FRONTEND=noninteractive

--- a/buildkite/scripts/connect-to-mainnet-on-compatible.sh
+++ b/buildkite/scripts/connect-to-mainnet-on-compatible.sh
@@ -2,8 +2,9 @@
 
 set -eo pipefail
 
-if [ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" = "compatible" ]; then
-  echo "Not pulling against compatible, not running the connect test"
+
+if [ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" = "compatible" ] && [ ! "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" = release/* ]; then
+  echo "Not pulling against compatible or not in release branch. Therefore, not running the connect test"
   exit 0
 fi
 

--- a/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
@@ -23,3 +23,4 @@ in Pipeline.build Pipeline.Config::{
     ConnectToTestnet.step dependsOn
   ]
 }
+

--- a/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
+++ b/buildkite/src/Jobs/Test/ConnectToMainnet.dhall
@@ -23,4 +23,3 @@ in Pipeline.build Pipeline.Config::{
     ConnectToTestnet.step dependsOn
   ]
 }
-


### PR DESCRIPTION
Explain your changes:

Add or maintain connect to mainnet test on compatible branch

Explain how you tested your changes:

Running CI and observing results

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #13366
