### PR TITLE
Experimental: preserve hashes in snark pool

### DIFF
--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -5770,7 +5770,8 @@ module Queries = struct
             Option.map (snark_worker_key mina) ~f:(fun _ -> snark_work_fee mina))
         in
         let (module S) = Mina_lib.work_selection_method mina in
-        S.pending_work_statements ~snark_pool ~fee_opt snark_job_state )
+        S.pending_work_statements ~snark_pool ~fee_opt snark_job_state
+        |> List.map ~f:Transaction_snark_work.With_hash.data )
 
   let genesis_constants =
     field "genesisConstants"

--- a/src/lib/mina_lib/dune
+++ b/src/lib/mina_lib/dune
@@ -102,6 +102,8 @@
    kimchi_backend.pasta.basic
    mina_wire_types
    internal_tracing
+   transaction_snark_work
+   one_or_two
  )
  (instrumentation (backend bisect_ppx))
  (preprocess (pps ppx_jane ppx_mina ppx_version ppx_inline_test ppx_deriving.std))

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -892,6 +892,7 @@ let request_work t =
       ~snark_pool:(snark_pool t) (snark_job_state t)
   in
   Option.map instances_opt ~f:(fun instances ->
+      let instances = Transaction_snark_work.With_hash.data instances in
       { Snark_work_lib.Work.Spec.instances; fee } )
 
 let work_selection_method t = t.config.work_selection_method
@@ -916,7 +917,10 @@ let add_work t (work : Snark_worker_lib.Work.Result.t) =
     (* remove it from seen jobs after attempting to adding it to the pool to avoid this work being reassigned
      * If the diff is accepted then remove it from the seen jobs.
      * If not then the work should have already been in the pool with a lower fee or the statement isn't referenced anymore or any other error. In any case remove it from the seen jobs so that it can be picked up if needed *)
-    Work_selection_method.remove t.snark_job_state spec
+    Work_selection_method.remove t.snark_job_state
+      (Transaction_snark_work.With_hash.create
+         ~f:(One_or_two.map ~f:Snark_work_lib.Work.Single.Spec.statement)
+         spec )
   in
   ignore (Or_error.try_with (fun () -> update_metrics ()) : unit Or_error.t) ;
   Network_pool.Snark_pool.Local_sink.push t.pipes.snark_local_sink
@@ -1331,7 +1335,9 @@ let start t =
         (Network_pool.Transaction_pool.resource_pool
            t.components.transaction_pool )
       ~get_completed_work:
-        (Network_pool.Snark_pool.get_completed_work t.components.snark_pool)
+        (Fn.compose
+           (Network_pool.Snark_pool.get_completed_work t.components.snark_pool)
+           Transaction_snark_work.Statement_with_hash.create )
       ~time_controller:t.config.time_controller
       ~coinbase_receiver:t.coinbase_receiver
       ~consensus_local_state:t.config.consensus_local_state

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -233,14 +233,14 @@ module type Snark_resource_pool_intf = sig
   val add_snark :
        ?is_local:bool
     -> t
-    -> work:Transaction_snark_work.Statement.t
+    -> work:Transaction_snark_work.Statement_with_hash.t
     -> proof:Ledger_proof.t One_or_two.t
     -> fee:Fee_with_prover.t
     -> [ `Added | `Statement_not_referenced ] Deferred.t
 
   val request_proof :
        t
-    -> Transaction_snark_work.Statement.t
+    -> Transaction_snark_work.Statement_with_hash.t
     -> Ledger_proof.t One_or_two.t Priced_proof.t option
 
   val verify_and_act :

--- a/src/lib/network_pool/mocks.ml
+++ b/src/lib/network_pool/mocks.ml
@@ -14,7 +14,8 @@ module Staged_ledger = struct
 end
 
 module Transition_frontier = struct
-  type table = int Transaction_snark_work.Statement.Table.t [@@deriving sexp]
+  type table = int Transaction_snark_work.Statement_with_hash.Table.t
+  [@@deriving sexp]
 
   type diff = Extensions.Snark_pool_refcount.view [@@deriving sexp]
 
@@ -28,7 +29,7 @@ module Transition_frontier = struct
 
   type t =
     { refcount_table : table
-    ; best_tip_table : Transaction_snark_work.Statement.Hash_set.t
+    ; best_tip_table : Transaction_snark_work.Statement_with_hash.Hash_set.t
     ; mutable ledger : Base_ledger.t
     ; diff_writer : (diff Broadcast_pipe.Writer.t[@sexp.opaque])
     ; diff_reader : (diff Broadcast_pipe.Reader.t[@sexp.opaque])
@@ -37,7 +38,8 @@ module Transition_frontier = struct
 
   let add_statements table stmts =
     List.iter stmts ~f:(fun s ->
-        Transaction_snark_work.Statement.Table.change table s ~f:(function
+        Transaction_snark_work.Statement_with_hash.Table.change table s
+          ~f:(function
           | None ->
               Some 1
           | Some count ->
@@ -45,8 +47,12 @@ module Transition_frontier = struct
 
   (*Create tf with some statements referenced to be able to add snark work for those statements to the pool*)
   let create _stmts : t =
-    let refcount_table = Transaction_snark_work.Statement.Table.create () in
-    let best_tip_table = Transaction_snark_work.Statement.Hash_set.create () in
+    let refcount_table =
+      Transaction_snark_work.Statement_with_hash.Table.create ()
+    in
+    let best_tip_table =
+      Transaction_snark_work.Statement_with_hash.Hash_set.create ()
+    in
     (*add_statements table stmts ;*)
     let diff_reader, diff_writer =
       Broadcast_pipe.create
@@ -78,6 +84,9 @@ module Transition_frontier = struct
   (*Adds statements to the table of referenced work. Snarks for only the referenced statements are added to the pool*)
   let refer_statements (t : t) stmts =
     let open Deferred.Let_syntax in
+    let stmts =
+      List.map ~f:Transaction_snark_work.Statement_with_hash.create stmts
+    in
     add_statements t.refcount_table stmts ;
     List.iter ~f:(Hash_set.add t.best_tip_table) stmts ;
     let%bind () =

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -10,7 +10,8 @@ module type S = sig
       Intf.Snark_resource_pool_intf
         with type transition_frontier := transition_frontier
 
-    val remove_solved_work : t -> Transaction_snark_work.Statement.t -> unit
+    val remove_solved_work :
+      t -> Transaction_snark_work.Statement_with_hash.t -> unit
 
     module Diff : Intf.Snark_pool_diff_intf with type resource_pool := t
   end
@@ -35,7 +36,7 @@ module type S = sig
 
   val get_completed_work :
        t
-    -> Transaction_snark_work.Statement.t
+    -> Transaction_snark_work.Statement_with_hash.t
     -> Transaction_snark_work.Checked.t option
 
   val load :

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -100,6 +100,7 @@ module Make
           ] ;
       Or_error.error_string reason
     in
+    let work = Transaction_snark_work.Statement_with_hash.create work in
     match Pool.request_proof pool work with
     | None ->
         Ok ()
@@ -151,6 +152,7 @@ module Make
         in
         match has_lower_fee pool work ~fee:fee.fee ~sender with
         | Ok () ->
+            let work = Transaction_snark_work.Statement_with_hash.create work in
             let%map.Deferred.Result accepted, rejected =
               Pool.add_snark ~is_local pool ~work ~proof ~fee >>| to_or_error
             in

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -77,6 +77,7 @@ let%test_module "network pool test" =
             Linear_pipe.read (Mock_snark_pool.broadcasts network_pool)
           in
           let pool = Mock_snark_pool.resource_pool network_pool in
+          let work = Transaction_snark_work.Statement_with_hash.create work in
           match Mock_snark_pool.Resource_pool.request_proof pool work with
           | Some { proof; fee = _ } ->
               assert (

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -2,6 +2,24 @@ open Core_kernel
 open Currency
 open Signature_lib
 
+module With_hash = struct
+  type 'a t = { hash : int; data : 'a }
+
+  let create ~f data =
+    { hash =
+        Ppx_hash_lib.Std.Hash.of_fold
+          (One_or_two.hash_fold_t Transaction_snark.Statement.hash_fold_t)
+          (f data)
+    ; data
+    }
+
+  let hash { hash; _ } = hash
+
+  let map ~f { hash; data } = { hash; data = f data }
+
+  let data { data; _ } = data
+end
+
 module Statement = struct
   module Arg = struct
     [%%versioned
@@ -44,6 +62,37 @@ module Statement = struct
 
   let work_ids t : int One_or_two.t =
     One_or_two.map t ~f:Transaction_snark.Statement.hash
+end
+
+module Statement_with_hash = struct
+  module T = struct
+    type t = Statement.t With_hash.t
+
+    let hash = With_hash.hash
+
+    let hash_fold_t st With_hash.{ hash; _ } = Int.hash_fold_t st hash
+
+    let equal With_hash.{ data = d1; _ } With_hash.{ data = d2; _ } =
+      Statement.equal d1 d2
+
+    let compare With_hash.{ data = d1; _ } With_hash.{ data = d2; _ } =
+      Statement.compare d1 d2
+
+    let create = With_hash.create ~f:Fn.id
+
+    let t_of_sexp =
+      Fn.compose create
+        (One_or_two.t_of_sexp Transaction_snark.Statement.t_of_sexp)
+
+    let sexp_of_t With_hash.{ data; _ } =
+      One_or_two.sexp_of_t Transaction_snark.Statement.sexp_of_t data
+
+    let to_yojson With_hash.{ data; _ } =
+      One_or_two.to_yojson Transaction_snark.Statement.to_yojson data
+  end
+
+  include T
+  include Hashable.Make (T)
 end
 
 module Info = struct

--- a/src/lib/transaction_snark_work/transaction_snark_work.mli
+++ b/src/lib/transaction_snark_work/transaction_snark_work.mli
@@ -2,6 +2,19 @@ open Core_kernel
 open Currency
 open Signature_lib
 
+module With_hash : sig
+  type 'a t = { hash : int; data : 'a }
+
+  val create :
+    f:('a -> Transaction_snark.Statement.t One_or_two.t) -> 'a -> 'a t
+
+  val hash : 'a t -> int
+
+  val map : f:('a -> 'b) -> 'a t -> 'b t
+
+  val data : 'a t -> 'a
+end
+
 module Statement : sig
   type t = Transaction_snark.Statement.t One_or_two.t
   [@@deriving compare, sexp, yojson, equal]
@@ -22,6 +35,15 @@ module Statement : sig
   val compact_json : t -> Yojson.Safe.t
 
   val work_ids : t -> int One_or_two.t
+end
+
+module Statement_with_hash : sig
+  type t = Transaction_snark.Statement.t One_or_two.t With_hash.t
+  [@@deriving compare, sexp, to_yojson, equal]
+
+  val create : Statement.t -> t
+
+  include Hashable.S with type t := t
 end
 
 module Info : sig

--- a/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
+++ b/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
@@ -1,11 +1,11 @@
 type view =
   { removed : int
-  ; refcount_table : int Transaction_snark_work.Statement.Table.t
+  ; refcount_table : int Transaction_snark_work.Statement_with_hash.Table.t
         (** Tracks the number of blocks that have each work statement in their
             scan state.
             Work is included iff it is a member of some block scan state.
         *)
-  ; best_tip_table : Transaction_snark_work.Statement.Hash_set.t
+  ; best_tip_table : Transaction_snark_work.Statement_with_hash.Hash_set.t
         (** The set of all snark work statements present in the scan state for
             the last 10 blocks in the best chain.
         *)

--- a/src/lib/work_selector/test.ml
+++ b/src/lib/work_selector/test.ml
@@ -12,6 +12,8 @@ struct
   module Lib = Work_lib.Make (T)
   module Selection_method = Make_selection_method (T) (Lib)
 
+  let stmt_of_work_spec = One_or_two.map ~f:Lib.Work_spec.statement
+
   let gen_staged_ledger =
     (*Staged_ledger for tests is a list of work specs*)
     Quickcheck.Generator.list
@@ -61,7 +63,9 @@ struct
         | None ->
             all_work
         | Some work ->
-            go (One_or_two.to_list work @ all_work)
+            go
+              ( One_or_two.to_list (T.Transaction_snark_work.With_hash.data work)
+              @ all_work )
       in
       go []
     in
@@ -93,7 +97,12 @@ struct
           add_works rest
     in
     let%map () =
-      add_works (List.map ~f:(One_or_two.map ~f:Lib.Work_spec.statement) works)
+      add_works
+        (List.map
+           ~f:
+             (Fn.compose T.Transaction_snark_work.Statement_with_hash.create
+                stmt_of_work_spec )
+           works )
     in
     snark_pool
 
@@ -119,8 +128,10 @@ struct
     Quickcheck.test g
       ~sexp_of:
         [%sexp_of:
-          (int, Fee.t) Lib.Work_spec.t list * Fee.t T.Snark_pool.Work.Table.t]
-      ~trials:100 ~f:(fun (sl, snark_pool) ->
+          (int, Fee.t) Lib.Work_spec.t list
+          * ( T.Transaction_snark_work.Statement_with_hash.t
+            , Currency.Fee.t )
+            Hashtbl.t] ~trials:100 ~f:(fun (sl, snark_pool) ->
         Async.Thread_safe.block_on_async_exn (fun () ->
             let open Deferred.Let_syntax in
             let%bind work_state = init_state sl reassignment_wait logger in
@@ -135,11 +146,14 @@ struct
               | None ->
                   return ()
               | Some job ->
+                  let job' =
+                    T.Transaction_snark_work.With_hash.map ~f:stmt_of_work_spec
+                      job
+                  in
                   [%test_result: Bool.t]
                     ~message:"Should not get any cheap jobs" ~expect:true
                     (Lib.For_tests.does_not_have_better_fee ~snark_pool
-                       ~fee:my_fee
-                       (One_or_two.map job ~f:Lib.Work_spec.statement) ) ;
+                       ~fee:my_fee job' ) ;
                   go (i + 1)
             in
             go 0 ) )


### PR DESCRIPTION
Problem: snark coordinator has hard time serving RPCs to snark workers. Major slowness source is usage of hashtable with snark work statement as a key.

Solution: preserve hash along with statement for Hashtable key.

Explain how you tested your changes:

Tested with a cluster of 20 snark workers, 1 coordinator and 11 other Mina nodes.

* Using O1trace tracing and chrome's trace viewer, traces were recorded before and after the fix
  * After the fix, snark coordination related RPCs started to take insignificant amount of total, whereas before fix coordinator with 20 snark workers had 100% CPU occupied with serving these RPCs
* Snark coordinator with 20 workers was always out-of-sync with the network before the fix and became totally healthy after the fix

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None