### PR TITLE
Cumulative nonce map in archive processor

### DIFF
--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -1465,8 +1465,7 @@ module Block = struct
                 (* This is the only place we adjust the nonce_map -- we want to modify the public key associated with the fee_payer for this user-command to increment its nonce.
                    Note: Intentionally shadowing `nonce_map` here as we want to pass the updated map. *)
                 let nonce_map =
-                  Signature_lib.Public_key.Compressed.Map.change
-                    initial_nonce_map
+                  Signature_lib.Public_key.Compressed.Map.change nonce_map
                     ( Mina_base.User_command.fee_payer command
                     |> Account_id.public_key )
                     ~f:(fun _ ->

--- a/src/app/replayer/dune
+++ b/src/app/replayer/dune
@@ -1,7 +1,6 @@
 (executable
  (package replayer)
  (name replayer)
- (flags -w -32-34)
  (public_name replayer)
  (libraries
    ;; opam libraries


### PR DESCRIPTION
When processing transactions in a block, the archive processor would update the initial nonce map, instead of cumulatively updating the nonce map passed through the fold accumulator. That meant if a fee payer was involved in more than one transaction in a block, the nonce would be wrong. If a transaction involved a public key not in the initial nonce map, the nonce would be missing.

In the replayer, instead of looking for `slot % interval = 0`, which often fails because not all slots have blocks, set a target slot. Issue a checkpoint file if the target is exceeded, and reset the target. Tested that feature by running the replayer on the mainnet db.

Also, remove warning flags from dune which hid some unused types and variables. Remove those unused items.

Closes #13401.
