### PR TITLE
Fix snark pool long async cycles

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1598,8 +1598,8 @@ let create ?wallets (config : Config.t) =
               ~trust_system:config.trust_system
               ~disk_location:config.snark_pool_disk_location
           in
-          let%bind snark_pool, snark_remote_sink, snark_local_sink =
-            Network_pool.Snark_pool.load ~config:snark_pool_config
+          let snark_pool, snark_remote_sink, snark_local_sink =
+            Network_pool.Snark_pool.create ~config:snark_pool_config
               ~constraint_constants ~consensus_constants
               ~time_controller:config.time_controller ~logger:config.logger
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r

--- a/src/lib/network_pool/mocks.ml
+++ b/src/lib/network_pool/mocks.ml
@@ -67,11 +67,7 @@ module Transition_frontier = struct
     let best_tip_table = Transaction_snark_work.Statement.Hash_set.create () in
     (*add_statements table stmts ;*)
     let diff_reader, diff_writer =
-      Broadcast_pipe.create
-        { Extensions.Snark_pool_refcount.removed = 0
-        ; refcount_table
-        ; best_tip_table
-        }
+      Broadcast_pipe.create { Extensions.Snark_pool_refcount.removed_work = [] }
     in
     { refcount_table
     ; best_tip_table
@@ -93,6 +89,10 @@ module Transition_frontier = struct
     let r, _ = Broadcast_pipe.create () in
     r
 
+  let work_is_referenced t = Hashtbl.mem t.refcount_table
+
+  let best_tip_table t = t.best_tip_table
+
   (*Adds statements to the table of referenced work. Snarks for only the referenced statements are added to the pool*)
   let refer_statements (t : t) stmts =
     let open Deferred.Let_syntax in
@@ -100,10 +100,7 @@ module Transition_frontier = struct
     List.iter ~f:(Hash_set.add t.best_tip_table) stmts ;
     let%bind () =
       Broadcast_pipe.Writer.write t.diff_writer
-        { Transition_frontier.Extensions.Snark_pool_refcount.removed = 0
-        ; refcount_table = t.refcount_table
-        ; best_tip_table = t.best_tip_table
-        }
+        { Transition_frontier.Extensions.Snark_pool_refcount.removed_work = [] }
     in
     Async.Scheduler.yield_until_no_jobs_remain ()
 
@@ -111,10 +108,7 @@ module Transition_frontier = struct
     List.iter ~f:(Hash_set.remove t.best_tip_table) stmts ;
     let%bind () =
       Broadcast_pipe.Writer.write t.diff_writer
-        { Transition_frontier.Extensions.Snark_pool_refcount.removed = 0
-        ; refcount_table = t.refcount_table
-        ; best_tip_table = t.best_tip_table
-        }
+        { Transition_frontier.Extensions.Snark_pool_refcount.removed_work = [] }
     in
     Async.Scheduler.yield_until_no_jobs_remain ()
 end

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -5,23 +5,6 @@ open Network_peer
 module Statement_table = Transaction_snark_work.Statement.Table
 
 module Snark_tables = struct
-  module Serializable = struct
-    [%%versioned
-    module Stable = struct
-      module V1 = struct
-        type t =
-          ( Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
-            Priced_proof.Stable.V1.t
-          * [ `Rebroadcastable of Core.Time.Stable.With_utc_sexp.V2.t
-            | `Not_rebroadcastable ] )
-          Transaction_snark_work.Statement.Stable.V1.Table.t
-        [@@deriving sexp]
-
-        let to_latest = Fn.id
-      end
-    end]
-  end
-
   type t =
     { all :
         Ledger_proof.t One_or_two.t Priced_proof.t
@@ -31,34 +14,6 @@ module Snark_tables = struct
         Transaction_snark_work.Statement.Table.t
     }
   [@@deriving sexp]
-
-  let compare t1 t2 =
-    let p t = (Hashtbl.to_alist t.all, Hashtbl.to_alist t.rebroadcastable) in
-    [%compare:
-      ( Transaction_snark_work.Statement.t
-      * Ledger_proof.t One_or_two.t Priced_proof.t )
-      list
-      * ( Transaction_snark_work.Statement.t
-        * (Ledger_proof.t One_or_two.t Priced_proof.t * Core.Time.t) )
-        list]
-      (p t1) (p t2)
-
-  let of_serializable (t : Serializable.t) : t =
-    { all = Hashtbl.map t ~f:fst
-    ; rebroadcastable =
-        Hashtbl.filter_map t ~f:(fun (x, r) ->
-            match r with
-            | `Rebroadcastable time ->
-                Some (x, time)
-            | `Not_rebroadcastable ->
-                None )
-    }
-
-  let to_serializable (t : t) : Serializable.t =
-    let res = Hashtbl.map t.all ~f:(fun x -> (x, `Not_rebroadcastable)) in
-    Hashtbl.iteri t.rebroadcastable ~f:(fun ~key ~data:(x, r) ->
-        Hashtbl.set res ~key ~data:(x, `Rebroadcastable r) ) ;
-    res
 end
 
 module type S = sig
@@ -96,18 +51,6 @@ module type S = sig
        t
     -> Transaction_snark_work.Statement.t
     -> Transaction_snark_work.Checked.t option
-
-  val load :
-       config:Resource_pool.Config.t
-    -> logger:Logger.t
-    -> constraint_constants:Genesis_constants.Constraint_constants.t
-    -> consensus_constants:Consensus.Constants.t
-    -> time_controller:Block_time.Controller.t
-    -> frontier_broadcast_pipe:
-         transition_frontier option Broadcast_pipe.Reader.t
-    -> log_gossip_heard:bool
-    -> on_remote_push:(unit -> unit Deferred.t)
-    -> (t * Remote_sink.t * Local_sink.t) Deferred.t
 end
 
 module type Transition_frontier_intf = sig
@@ -166,7 +109,7 @@ struct
       type t =
         { snark_tables : Snark_tables.t
         ; snark_table_lock : (unit Throttle.Sequencer.t[@sexp.opaque])
-        ; frontier : (unit -> Transition_frontier.t option [@sexp.opaque])
+        ; frontier : (unit -> Transition_frontier.t option[@sexp.opaque])
         ; config : Config.t
         ; logger : (Logger.t[@sexp.opaque])
         ; account_creation_fee : Currency.Fee.t
@@ -174,24 +117,7 @@ struct
         }
       [@@deriving sexp]
 
-      type serializable = Snark_tables.Serializable.Stable.Latest.t
-      [@@deriving bin_io_unversioned]
-
       let make_config = Config.make
-
-      let of_serializable tables ~constraint_constants ~frontier_broadcast_pipe
-          ~config ~logger : t =
-        { snark_tables = Snark_tables.of_serializable tables
-        ; snark_table_lock = Throttle.Sequencer.create ()
-        ; frontier =
-            (fun () -> Broadcast_pipe.Reader.peek frontier_broadcast_pipe)
-        ; batcher = Batcher.Snark_pool.create config.verifier
-        ; account_creation_fee =
-            constraint_constants
-              .Genesis_constants.Constraint_constants.account_creation_fee
-        ; config
-        ; logger
-        }
 
       let best_tip_ledger t =
         t.frontier ()
@@ -299,7 +225,7 @@ struct
             () )
 
       let handle_refcount_update t
-          ({ removed_work } : Extensions.Snark_pool_refcount.view ) =
+          ({ removed_work } : Extensions.Snark_pool_refcount.view) =
         [%log' trace t.logger]
           "Handling snark refcount table: $num_removed works were removed"
           ~metadata:[ ("num_removed", `Int (List.length removed_work)) ] ;
@@ -575,8 +501,6 @@ struct
 
   module For_tests = struct
     let get_rebroadcastable = Resource_pool.get_rebroadcastable
-
-    let snark_tables (t : Resource_pool.t) = t.snark_tables
   end
 
   let get_completed_work t statement =
@@ -585,60 +509,6 @@ struct
       ~f:(fun Priced_proof.{ proof; fee = { fee; prover } } ->
         Transaction_snark_work.Checked.create_unsafe
           { Transaction_snark_work.fee; proofs = proof; prover } )
-
-  (* This causes a snark pool to never be GC'd. This is fine as it should live as long as the daemon lives. *)
-  let store_periodically (t : Resource_pool.t) =
-    Clock.every' (Time.Span.of_min 3.) (fun () ->
-        let before = Time.now () in
-        let%map () =
-          Writer.save_bin_prot t.config.disk_location
-            Snark_tables.Serializable.Stable.Latest.bin_writer_t
-            (Snark_tables.to_serializable t.snark_tables)
-        in
-        let elapsed = Time.(diff (now ()) before |> Span.to_ms) in
-        Mina_metrics.(
-          Snark_work.Snark_pool_serialization_ms_histogram.observe
-            Snark_work.snark_pool_serialization_ms elapsed) ;
-        [%log' debug t.logger] "SNARK pool serialization took $time ms"
-          ~metadata:[ ("time", `Float elapsed) ] )
-
-  let loaded = ref false
-
-  let load ~config ~logger ~constraint_constants ~consensus_constants
-      ~time_controller ~frontier_broadcast_pipe ~log_gossip_heard
-      ~on_remote_push =
-    if !loaded then
-      failwith
-        "Snark_pool.load should only be called once. It has been called twice." ;
-    loaded := true ;
-    let tf_diff_reader, tf_diff_writer =
-      Strict_pipe.(
-        create ~name:"Snark pool Transition frontier diffs" Synchronous)
-    in
-    let%map pool, r_sink, l_sink =
-      match%map
-        Async.Reader.load_bin_prot config.Resource_pool.Config.disk_location
-          Snark_tables.Serializable.Stable.Latest.bin_reader_t
-      with
-      | Ok snark_table ->
-          let pool =
-            Resource_pool.of_serializable snark_table ~constraint_constants
-              ~config ~logger ~frontier_broadcast_pipe
-          in
-          let res =
-            of_resource_pool_and_diffs pool ~logger ~constraint_constants
-              ~tf_diffs:tf_diff_reader ~log_gossip_heard ~on_remote_push
-          in
-          Resource_pool.listen_to_frontier_broadcast_pipe
-            frontier_broadcast_pipe ~tf_diff_writer ;
-          res
-      | Error _e ->
-          create ~config ~logger ~constraint_constants ~consensus_constants
-            ~time_controller ~frontier_broadcast_pipe ~log_gossip_heard
-            ~on_remote_push
-    in
-    store_periodically (resource_pool pool) ;
-    (pool, r_sink, l_sink)
 end
 
 (* TODO: defunctor or remove monkey patching (#3731) *)
@@ -785,17 +655,6 @@ let%test_module "random set test" =
             assert (Result.is_ok res) )
       in
       (pool, tf)
-
-    let%test_unit "serialization" =
-      let t, _tf =
-        Async.Thread_safe.block_on_async_exn (fun () ->
-            Quickcheck.random_value (gen ~length:100 ()) )
-      in
-      let s0 = Mock_snark_pool.For_tests.snark_tables t in
-      let s1 =
-        Snark_tables.to_serializable s0 |> Snark_tables.of_serializable
-      in
-      [%test_eq: Snark_tables.t] s0 s1
 
     let%test_unit "Invalid proofs are not accepted" =
       let open Quickcheck.Generator.Let_syntax in

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -72,6 +72,10 @@ module type Transition_frontier_intf = sig
        t
     -> Transition_frontier.Extensions.Snark_pool_refcount.view
        Pipe_lib.Broadcast_pipe.Reader.t
+
+  val work_is_referenced : t -> Transaction_snark_work.Statement.t -> bool
+
+  val best_tip_table : t -> Transaction_snark_work.Statement.Hash_set.t
 end
 
 module Make

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -1,4 +1,3 @@
-open Async_kernel
 open Pipe_lib
 open Core_kernel
 
@@ -37,18 +36,6 @@ module type S = sig
        t
     -> Transaction_snark_work.Statement.t
     -> Transaction_snark_work.Checked.t option
-
-  val load :
-       config:Resource_pool.Config.t
-    -> logger:Logger.t
-    -> constraint_constants:Genesis_constants.Constraint_constants.t
-    -> consensus_constants:Consensus.Constants.t
-    -> time_controller:Block_time.Controller.t
-    -> frontier_broadcast_pipe:
-         transition_frontier option Broadcast_pipe.Reader.t
-    -> log_gossip_heard:bool
-    -> on_remote_push:(unit -> unit Deferred.t)
-    -> (t * Remote_sink.t * Local_sink.t) Deferred.t
 end
 
 module type Transition_frontier_intf = sig

--- a/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
+++ b/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
@@ -1,15 +1,8 @@
-type view =
-  { removed: int
-  ; refcount_table: int Transaction_snark_work.Statement.Table.t
-        (** Tracks the number of blocks that have each work statement in their
-            scan state.
-            Work is included iff it is a member of some block scan state.
-        *)
-  ; best_tip_table: Transaction_snark_work.Statement.Hash_set.t
-        (** The set of all snark work statements present in the scan state for
-            the last 10 blocks in the best chain.
-        *)
-  }
+type view = { removed_work: Transaction_snark_work.Statement.t list }
 [@@deriving sexp]
 
 include Intf.Extension_intf with type view := view
+
+val work_is_referenced : t -> Transaction_snark_work.Statement.t -> bool
+
+val best_tip_table : t -> Transaction_snark_work.Statement.Hash_set.t

--- a/src/lib/transition_frontier/frontier_base/diff.mli
+++ b/src/lib/transition_frontier/frontier_base/diff.mli
@@ -59,9 +59,14 @@ end
  *  by transitioning the root.
  *)
 module Root_transition : sig
+  type 'repr root_transition_scan_state =
+    | Lite : lite root_transition_scan_state
+    | Full : Staged_ledger.Scan_state.t -> full root_transition_scan_state
+
   type 'repr t =
     { new_root: Root_data.Limited.Stable.V2.t
     ; garbage: 'repr Node_list.t
+    ; old_root_scan_state: 'repr root_transition_scan_state
     ; just_emitted_a_proof: bool }
 
   type 'repr root_transition = 'repr t

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -328,6 +328,7 @@ let calculate_root_transition_diff t heir =
     (Root_transitioned
        { new_root= new_root_data
        ; garbage= Full garbage_nodes
+       ; old_root_scan_state= Full (Breadcrumb.staged_ledger root |> Staged_ledger.scan_state)
        ; just_emitted_a_proof })
 
 let move_root t ~new_root_hash ~new_root_protocol_states ~garbage


### PR DESCRIPTION
As part of investigating #13324, it was discovered that the primary underlying issue was that the snark pool was leaking. The issue causing the leak was that the snark pool refcount frontier extension was not properly decrementing entries when the frontier root transitions. Additionally, when the extension would compute the removed entries, it would only count the number of scan state that caused entries to be removed, which negatively impacted the garbage collection logic in the snark pool as the implementation relied on this count.

Fixing the snark pool refcount leak would have caused another issue in that the snark pool garbage collection logic, which is now triggered properly with the fix, was wildly inefficient. The worst case number of works in the snark pool is about `2*720*128*0.75=138240` (`fork_factor*k*works_per_block*f`), which was large enough to warrant addressing this.

The following changes are included in this PR:
- snark pool persistence was removed
- fixed bug in snark pool refcount table where old root scan state works were not decremented
- optimized snark pool garbage collection by changing snark pool refcount to send a negative diff when works are invalidated
- optimize snark pool refcount view broadcast logic not send irrelevant diffs
- removed unnecessary references to snark pool refcount internal tables within the snark pool

Closes #13324.