### PR TITLE
Blocking SnarkyJS CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,12 @@ snarkyjs: ocaml_checks
 	&& bash ./src/lib/snarkyjs/src/bindings/scripts/build-snarkyjs-node.sh
 	$(info Build complete)
 
+snarkyjs_no_types: ocaml_checks
+	$(info Starting Build)
+	((ulimit -s 65532) || true) && (ulimit -n 10240 || true) \
+	&& bash ./src/lib/snarkyjs/src/bindings/scripts/build-snarkyjs-node-artifacts.sh
+	$(info Build complete)
+
 rosetta_lib_encodings: ocaml_checks
 	$(info Starting Build)
 	(ulimit -s 65532 || true) && (ulimit -n 10240 || true) && dune build src/lib/rosetta_lib/test/test_encodings.exe --profile=mainnet

--- a/buildkite/scripts/test-snarkyjs-bindings-minimal.sh
+++ b/buildkite/scripts/test-snarkyjs-bindings-minimal.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export NODE_OPTIONS="--enable-source-maps --stack-trace-limit=1000"
+
+set -eo pipefail
+source ~/.profile
+
+echo "Node version:"
+node --version
+
+echo "Build SnarkyJS (w/o TS)..."
+make snarkyjs_no_types
+
+echo "Run bare minimum SnarkyJS tests..."
+./run-mina-integration-tests.sh

--- a/buildkite/scripts/test-snarkyjs-bindings-minimal.sh
+++ b/buildkite/scripts/test-snarkyjs-bindings-minimal.sh
@@ -12,4 +12,5 @@ echo "Build SnarkyJS (w/o TS)..."
 make snarkyjs_no_types
 
 echo "Run bare minimum SnarkyJS tests..."
-./run-mina-integration-tests.sh
+cd src/lib/snarkyjs
+./run-minimal-mina-tests.sh

--- a/buildkite/src/Jobs/Test/SnarkyJSTest.dhall
+++ b/buildkite/src/Jobs/Test/SnarkyJSTest.dhall
@@ -20,7 +20,7 @@ Pipeline.build
         dirtyWhen = [
           S.strictlyStart (S.contains "buildkite/src/Jobs/Test/SnarkyJSTest"),
           S.strictlyStart (S.contains "buildkite/scripts/test-snarkyjs-bindings.sh"),
-          S.strictlyStart (S.contains "src")
+          S.strictlyStart (S.contains "src/lib")
         ],
         path = "Test",
         name = "SnarkyJSTest"

--- a/buildkite/src/Jobs/Test/SnarkyJSTest.dhall
+++ b/buildkite/src/Jobs/Test/SnarkyJSTest.dhall
@@ -34,6 +34,14 @@ Pipeline.build
           , target = Size.XLarge
           , docker = None Docker.Type
           , soft_fail = Some (B/SoftFail.Boolean True)
+        },
+      Command.build
+        Command.Config::{
+            commands = RunInToolchain.runInToolchainBuster ([] : List Text) "buildkite/scripts/test-snarkyjs-bindings-minimal.sh"
+          , label = "SnarkyJS minimal tests"
+          , key = "snarkyjs-minimal-test"
+          , target = Size.XLarge
+          , docker = None Docker.Type
         }
     ]
   }


### PR DESCRIPTION
snarkyjs: https://github.com/o1-labs/snarkyjs/pull/997
bindings: https://github.com/o1-labs/snarkyjs-bindings/pull/50

closes https://github.com/o1-labs/snarkyjs/issues/971
closes https://github.com/o1-labs/snarkyjs/issues/972

RFC: https://github.com/o1-labs/rfcs/pull/5

* Adds a new make target `snarkyjs_no_types` which builds snarkyjs from source without also compiling TS to JS
* Adds a new, required buildkite job which runs a minimal snarkyjs test without type checking
  * The TS code base is bundled to JS on the fly with `esbuild`, which doesn't do type-checking and is very fast

![image](https://github.com/MinaProtocol/mina/assets/20989968/138a9bf1-dbf7-4f60-84a4-4303c7ae627e)
