### PR TITLE
Make the ordering of accounts in the result of a zkApp txn application explicit

### DIFF
--- a/src/lib/transaction_logic/mina_transaction_logic.ml
+++ b/src/lib/transaction_logic/mina_transaction_logic.ml
@@ -2006,19 +2006,22 @@ module Make (L : Ledger_intf.S) :
       (*get the original states of all the accounts in each pass.
         If an account updated in the first pass is referenced in account
         updates, then retain the value before first pass application*)
-      let account_states = Account_id.Table.create () in
-      List.iter
-        ~f:(fun (id, acc_opt) ->
-          Account_id.Table.update account_states id
-            ~f:(Option.value ~default:acc_opt) )
-        ( c.original_first_pass_account_states
-        @ List.map (Zkapp_command.accounts_referenced c.command) ~f:(fun id ->
-              ( id
-              , Option.Let_syntax.(
-                  let%bind loc = L.location_of_account ledger id in
-                  let%map a = L.get ledger loc in
-                  (loc, a)) ) ) ) ;
-      Account_id.Table.to_alist account_states
+      (* IMPORTANT: this account list must be sorted by Account_id in increasing order,
+         if this ordering changes the scan state hash will be affected and made
+         incompatible. *)
+      Account_id.Map.to_alist ~key_order:`Increasing
+      @@ List.fold ~init:Account_id.Map.empty
+           ~f:(fun account_states (id, acc_opt) ->
+             Account_id.Map.update account_states id
+               ~f:(Option.value ~default:acc_opt) )
+           ( c.original_first_pass_account_states
+           @ List.map (Zkapp_command.accounts_referenced c.command)
+               ~f:(fun id ->
+                 ( id
+                 , Option.Let_syntax.(
+                     let%bind loc = L.location_of_account ledger id in
+                     let%map a = L.get ledger loc in
+                     (loc, a)) ) ) )
     in
     let rec step_all (user_acc : user_acc)
         ( (g_state : Inputs.Global_state.t)


### PR DESCRIPTION
### Explain your changes:

The current version implicitly depends on the ordering provided  by the `Hashtbl` implementation in the `base` library, which is not explicit. This order my change either by changes to the `Hashtbl` implementation, or because of changes to this function, so it is important to make the ordering explicit and stable.

**IMPORTANT** this change introduces an incompatibility with the current `berkeleynet`, because the order of these accounts in the result will change, affecting the hashing of the scan state.

### Explain how you tested your changes:
Not tested yet

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
