### PR TITLE
Add functionalities to Keccak interface after discussion of RFC

### DIFF
--- a/src/lib/crypto/kimchi_backend/gadgets/foreign_field.mli
+++ b/src/lib/crypto/kimchi_backend/gadgets/foreign_field.mli
@@ -336,9 +336,13 @@ val mul :
   -> 'f Element.Standard.t
 (* product *)
 
+(** Gadget to constrain conversion of bytes list (output of Keccak gadget)
+   into foreign field element with standard limbs (input of ECDSA gadget).
+   Include the endianness of the bytes list. *)
 val bytes_to_standard_element :
      (module Snark_intf.Run with type field = 'f)
-  -> 'f Snarky_backendless.Cvar.t array
+  -> endian:Keccak.endianness
+  -> 'f Snarky_backendless.Cvar.t list
   -> 'f standard_limbs
   -> int
   -> 'f Element.Standard.t

--- a/src/lib/crypto/kimchi_backend/gadgets/keccak.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/keccak.ml
@@ -4,6 +4,9 @@ module Snark_intf = Snarky_backendless.Snark_intf
 
 let tests_enabled = true
 
+(* Endianness type *)
+type endianness = Big | Little
+
 (* DEFINITIONS OF CONSTANTS FOR KECCAK *)
 
 (* Length of the square matrix side of Keccak states *)
@@ -535,12 +538,17 @@ let check_bytes (type f)
 *)
 let hash (type f)
     (module Circuit : Snarky_backendless.Snark_intf.Run with type field = f)
-    (message : Circuit.Field.t list) ~(length : int) ~(capacity : int)
-    (nist_version : bool) : Circuit.Field.t list =
+    ?(inp_endian = Big) ?(out_endian = Big) (message : Circuit.Field.t list)
+    ~(length : int) ~(capacity : int) (nist_version : bool) :
+    Circuit.Field.t list =
   assert (capacity > 0) ;
   assert (capacity < keccak_state_length) ;
   assert (length > 0) ;
   assert (length mod 8 = 0) ;
+  (* Set input to Big Endian format *)
+  let message =
+    match inp_endian with Big -> message | Little -> List.rev message
+  in
   (* Check each cvar input is 8 bits at most *)
   check_bytes (module Circuit) message ;
   let rate = keccak_state_length - capacity in
@@ -553,50 +561,75 @@ let hash (type f)
   in
   let hash = sponge (module Circuit) padded ~length ~capacity ~rate in
   check_bytes (module Circuit) hash ;
+  (* Set input to desired endianness *)
+  let hash = match out_endian with Big -> hash | Little -> List.rev hash in
   (* Check each cvar output is 8 bits at most *)
   hash
 
-(* Gagdet for NIST SHA-3 function for output lengths 224/256/384/512 *)
+(* Gagdet for NIST SHA-3 function for output lengths 224/256/384/512.
+ * Input and output endianness can be specified. Default is big endian.
+ *)
 let nist_sha3 (type f)
     (module Circuit : Snarky_backendless.Snark_intf.Run with type field = f)
-    (len : int) (message : Circuit.Field.t list) : Circuit.Field.t array =
+    ?(inp_endian = Big) ?(out_endian = Big) (len : int)
+    (message : Circuit.Field.t list) : Circuit.Field.t list =
   let hash =
     match len with
     | 224 ->
-        hash (module Circuit) message ~length:224 ~capacity:448 true
+        hash
+          (module Circuit)
+          message ~length:224 ~capacity:448 true ~inp_endian ~out_endian
     | 256 ->
-        hash (module Circuit) message ~length:256 ~capacity:512 true
+        hash
+          (module Circuit)
+          message ~length:256 ~capacity:512 true ~inp_endian ~out_endian
     | 384 ->
-        hash (module Circuit) message ~length:384 ~capacity:768 true
+        hash
+          (module Circuit)
+          message ~length:384 ~capacity:768 true ~inp_endian ~out_endian
     | 512 ->
-        hash (module Circuit) message ~length:512 ~capacity:1024 true
+        hash
+          (module Circuit)
+          message ~length:512 ~capacity:1024 true ~inp_endian ~out_endian
     | _ ->
         assert false
   in
-  Array.of_list hash
+  hash
 
-(* Gadget for Keccak hash function for the parameters used in Ethereum *)
+(* Gadget for Keccak hash function for the parameters used in Ethereum.
+ * Input and output endianness can be specified. Default is big endian.
+ *)
 let ethereum (type f)
     (module Circuit : Snarky_backendless.Snark_intf.Run with type field = f)
-    (message : Circuit.Field.t list) : Circuit.Field.t array =
-  Array.of_list @@ hash (module Circuit) message ~length:256 ~capacity:512 false
-
+    ?(inp_endian = Big) ?(out_endian = Big) (message : Circuit.Field.t list) :
+    Circuit.Field.t list =
+  hash
+    (module Circuit)
+    message ~length:256 ~capacity:512 false ~inp_endian ~out_endian
 
 (* Gagdet for pre-NIST SHA-3 function for output lengths 224/256/384/512.
+ * Input and output endianness can be specified. Default is big endian.
  * Note that when calling with output length 256 this is equivalent to the ethereum function 
  *)
 let pre_nist (type f)
-(module Circuit : Snarky_backendless.Snark_intf.Run with type field = f)
-(len : int) (message : Circuit.Field.t list) : Circuit.Field.t array =
+    (module Circuit : Snarky_backendless.Snark_intf.Run with type field = f)
+    ?(inp_endian = Big) ?(out_endian = Big) (len : int)
+    (message : Circuit.Field.t list) : Circuit.Field.t list =
   match len with
   | 224 ->
-    Array.of_list @@ hash (module Circuit) message ~length:224 ~capacity:448 false
+      hash
+        (module Circuit)
+        message ~length:224 ~capacity:448 false ~inp_endian ~out_endian
   | 256 ->
-      ethereum (module Circuit) message
+      ethereum (module Circuit) message ~inp_endian ~out_endian
   | 384 ->
-    Array.of_list @@ hash (module Circuit) message ~length:384 ~capacity:768 false
+      hash
+        (module Circuit)
+        message ~length:384 ~capacity:768 false ~inp_endian ~out_endian
   | 512 ->
-    Array.of_list @@ hash (module Circuit) message ~length:512 ~capacity:1024 false
+      hash
+        (module Circuit)
+        message ~length:512 ~capacity:1024 false ~inp_endian ~out_endian
   | _ ->
       assert false
 
@@ -611,7 +644,7 @@ let%test_unit "keccak gadget" =
       try Kimchi_pasta.Vesta_based_plonk.Keypair.set_urs_info [] with _ -> ()
     in
 
-    let test_keccak ?cs ~nist ~len message expected =
+    let test_keccak ?cs ?inp_endian ?out_endian ~nist ~len message expected =
       let cs, _proof_keypair, _proof =
         Runner.generate_and_verify_proof ?cs (fun () ->
             let open Runner.Impl in
@@ -626,11 +659,17 @@ let%test_unit "keccak gadget" =
                      )
             in
             let hashed =
+              Array.of_list
+              @@
               match nist with
               | true ->
-                  nist_sha3 (module Runner.Impl) len message
+                  nist_sha3
+                    (module Runner.Impl)
+                    len message ?inp_endian ?out_endian
               | false ->
-                  pre_nist (module Runner.Impl) len message
+                  pre_nist
+                    (module Runner.Impl)
+                    len message ?inp_endian ?out_endian
             in
 
             let expected =
@@ -724,6 +763,11 @@ let%test_unit "keccak gadget" =
     in
 
     (* Reusing *)
+    let _cs =
+      test_keccak ~cs:cs_eth256_1byte ~nist:false ~len:256 "00"
+        "bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a"
+    in
+
     let cs2 =
       test_keccak ~nist:false ~len:256 "a2c0"
         "9856642c690c036527b8274db1b6f58c0429a88d9f3b9298597645991f4f58f0"
@@ -734,9 +778,11 @@ let%test_unit "keccak gadget" =
         "295b48ad49eff61c3abfd399c672232434d89a4ef3ca763b9dbebb60dbb32a8b"
     in
 
+    (* Endianness *)
     let _cs =
-      test_keccak ~cs:cs_eth256_1byte ~nist:false ~len:256 "00"
-        "bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a"
+      test_keccak ~nist:false ~len:256 ~inp_endian:Little ~out_endian:Little
+        "2c0a"
+        "8b2ab3db60bbbe9d3b76caf34e9ad834242372c699d3bf3a1cf6ef49ad485b29"
     in
 
     (* Negative tests *)
@@ -764,6 +810,13 @@ let%test_unit "keccak gadget" =
           test_keccak ~cs:cs_eth256_1byte ~nist:true ~len:256
             "4920616d20746865206f776e6572206f6620746865204e465420776974682069642058206f6e2074686520457468657265756d20636861696e"
             "63858e0487687c3eeb30796a3e9307680e1b81b860b01c88ff74545c2c314e36" ) ) ;
+
+    (* Cannot reuse cs with different endianness *)
+    assert (
+      Common.is_error (fun () ->
+          test_keccak ~cs:cs2 ~nist:false ~len:256 ~inp_endian:Little
+            ~out_endian:Little "2c0a"
+            "8b2ab3db60bbbe9d3b76caf34e9ad834242372c699d3bf3a1cf6ef49ad485b29" ) ) ;
 
     () ) ;
 

--- a/src/lib/crypto/kimchi_backend/gadgets/keccak.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/keccak.ml
@@ -549,7 +549,7 @@ let hash (type f)
   let message =
     match inp_endian with Big -> message | Little -> List.rev message
   in
-  (* Check each cvar input is 8 bits at most *)
+  (* Check each cvar input is 8 bits at most if it was not done before at creation time*)
   if byte_checks then check_bytes (module Circuit) message ;
   let rate = keccak_state_length - capacity in
   let padded =
@@ -560,8 +560,8 @@ let hash (type f)
         pad_101 (module Circuit) message rate
   in
   let hash = sponge (module Circuit) padded ~length ~capacity ~rate in
-  (* Check each cvar output is 8 bits at most *)
-  if byte_checks then check_bytes (module Circuit) hash ;
+  (* Check each cvar output is 8 bits at most. Always because they are created here *)
+  check_bytes (module Circuit) hash ;
   (* Set input to desired endianness *)
   let hash = match out_endian with Big -> hash | Little -> List.rev hash in
   (* Check each cvar output is 8 bits at most *)

--- a/src/lib/crypto/kimchi_backend/gadgets/keccak.mli
+++ b/src/lib/crypto/kimchi_backend/gadgets/keccak.mli
@@ -5,6 +5,7 @@ type endianness = Big | Little
  * Input:
  * - Endianness of the input (default is Big). 
  * - Endianness of the output (default is Big).
+ * - Flag to enable byte checks (default is false)
  * - int representing the output length of the hash function (224|256|384|512)
  * - Arbitrary length list of Cvars representing the input to the hash function where each of them is a byte 
  * Output:
@@ -14,6 +15,7 @@ val nist_sha3 :
      (module Snarky_backendless.Snark_intf.Run with type field = 'f)
   -> ?inp_endian:endianness
   -> ?out_endian:endianness
+  -> ?byte_checks:bool
   -> int
   -> 'f Snarky_backendless.Cvar.t list
   -> 'f Snarky_backendless.Cvar.t list
@@ -22,6 +24,7 @@ val nist_sha3 :
  * Input:
  * - Endianness of the input (default is Big). 
  * - Endianness of the output (default is Big).
+ * - Flag to enable byte checks (default is false)
  * - Arbitrary length list of Cvars representing the input to the hash function where each of them is a byte 
  * Output: 
  * - List of 256 Cvars representing the output of the hash function where each of them is a byte 
@@ -30,6 +33,7 @@ val ethereum :
      (module Snarky_backendless.Snark_intf.Run with type field = 'f)
   -> ?inp_endian:endianness
   -> ?out_endian:endianness
+  -> ?byte_checks:bool
   -> 'f Snarky_backendless.Cvar.t list
   -> 'f Snarky_backendless.Cvar.t list
 
@@ -38,6 +42,7 @@ val ethereum :
  * Input:
  * - Endianness of the input (default is Big). 
  * - Endianness of the output (default is Big).
+ * - Flag to enable byte checks (default is false)
  * - int representing the output length of the hash function (224|256|384|512)
  * - Arbitrary length list of Cvars Cvars representing the input to the hash function where each of them is a byte 
  * Output:
@@ -47,6 +52,7 @@ val pre_nist :
      (module Snarky_backendless.Snark_intf.Run with type field = 'f)
   -> ?inp_endian:endianness
   -> ?out_endian:endianness
+  -> ?byte_checks:bool
   -> int
   -> 'f Snarky_backendless.Cvar.t list
   -> 'f Snarky_backendless.Cvar.t list

--- a/src/lib/crypto/kimchi_backend/gadgets/keccak.mli
+++ b/src/lib/crypto/kimchi_backend/gadgets/keccak.mli
@@ -1,40 +1,52 @@
 (* Endianness type *)
-type endian = Big | Little
+type endianness = Big | Little
 
-(** Gagdet for NIST SHA-3 function for output lengths 224/256/384/512 
+(** Gagdet for NIST SHA-3 function for output lengths 224/256/384/512
  * Input:
+ * - Endianness of the input (default is Big). 
+ * - Endianness of the output (default is Big).
  * - int representing the output length of the hash function (224|256|384|512)
- * - List of Cvars representing the input to the hash function where each of them is a byte 
+ * - Arbitrary length list of Cvars representing the input to the hash function where each of them is a byte 
  * Output:
- * - Array of `int` Cvars representing the output of the hash function where each of them is a byte
+ * - List of `int` Cvars representing the output of the hash function where each of them is a byte
  *)
 val nist_sha3 :
      (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> ?inp_endian:endianness
+  -> ?out_endian:endianness
   -> int
   -> 'f Snarky_backendless.Cvar.t list
-  -> 'f Snarky_backendless.Cvar.t array
+  -> 'f Snarky_backendless.Cvar.t list
 
 (** Gadget for Keccak hash function for the parameters used in Ethereum 
  * Input:
- * - List of Cvars representing the input to the hash function where each of them is a byte 
+ * - Endianness of the input (default is Big). 
+ * - Endianness of the output (default is Big).
+ * - Arbitrary length list of Cvars representing the input to the hash function where each of them is a byte 
  * Output: 
- * - Array of 256 Cvars representing the output of the hash function where each of them is a byte 
+ * - List of 256 Cvars representing the output of the hash function where each of them is a byte 
  *)
 val ethereum :
      (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> ?inp_endian:endianness
+  -> ?out_endian:endianness
   -> 'f Snarky_backendless.Cvar.t list
-  -> 'f Snarky_backendless.Cvar.t array
+  -> 'f Snarky_backendless.Cvar.t list
 
 (*** Gagdet for pre-NIST SHA-3 function for output lengths 224/256/384/512.
  * Note that when calling with output length 256 this is equivalent to the ethereum function 
  * Input:
+ * - Endianness of the input (default is Big). 
+ * - Endianness of the output (default is Big).
  * - int representing the output length of the hash function (224|256|384|512)
- * - List of Cvars representing the input to the hash function where each of them is a byte 
+ * - Arbitrary length list of Cvars Cvars representing the input to the hash function where each of them is a byte 
  * Output:
- * - Array of `int` Cvars representing the output of the hash function where each of them is a byte
+ * - List of `int` Cvars representing the output of the hash function where each of them is a byte
  *)
- val pre_nist :
+val pre_nist :
      (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> ?inp_endian:endianness
+  -> ?out_endian:endianness
   -> int
   -> 'f Snarky_backendless.Cvar.t list
-  -> 'f Snarky_backendless.Cvar.t array
+  -> 'f Snarky_backendless.Cvar.t list

--- a/src/lib/crypto/kimchi_backend/gadgets/keccak.mli
+++ b/src/lib/crypto/kimchi_backend/gadgets/keccak.mli
@@ -5,7 +5,7 @@ type endianness = Big | Little
  * Input:
  * - Endianness of the input (default is Big). 
  * - Endianness of the output (default is Big).
- * - Flag to enable byte checks (default is false)
+ * - Flag to enable input byte checks (default is false). Outputs are always constrained.
  * - int representing the output length of the hash function (224|256|384|512)
  * - Arbitrary length list of Cvars representing the input to the hash function where each of them is a byte 
  * Output:
@@ -24,7 +24,7 @@ val nist_sha3 :
  * Input:
  * - Endianness of the input (default is Big). 
  * - Endianness of the output (default is Big).
- * - Flag to enable byte checks (default is false)
+ * - Flag to enable input byte checks (default is false). Outputs are always constrained.
  * - Arbitrary length list of Cvars representing the input to the hash function where each of them is a byte 
  * Output: 
  * - List of 256 Cvars representing the output of the hash function where each of them is a byte 
@@ -42,7 +42,7 @@ val ethereum :
  * Input:
  * - Endianness of the input (default is Big). 
  * - Endianness of the output (default is Big).
- * - Flag to enable byte checks (default is false)
+ * - Flag to enable input byte checks (default is false). Outputs are always constrained.
  * - int representing the output length of the hash function (224|256|384|512)
  * - Arbitrary length list of Cvars Cvars representing the input to the hash function where each of them is a byte 
  * Output:

--- a/src/lib/crypto/kimchi_backend/gadgets/keccak.mli
+++ b/src/lib/crypto/kimchi_backend/gadgets/keccak.mli
@@ -1,3 +1,6 @@
+(* Endianness type *)
+type endian = Big | Little
+
 (** Gagdet for NIST SHA-3 function for output lengths 224/256/384/512 
  * Input:
  * - int representing the output length of the hash function (224|256|384|512)
@@ -19,5 +22,19 @@ val nist_sha3 :
  *)
 val ethereum :
      (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> 'f Snarky_backendless.Cvar.t list
+  -> 'f Snarky_backendless.Cvar.t array
+
+(*** Gagdet for pre-NIST SHA-3 function for output lengths 224/256/384/512.
+ * Note that when calling with output length 256 this is equivalent to the ethereum function 
+ * Input:
+ * - int representing the output length of the hash function (224|256|384|512)
+ * - List of Cvars representing the input to the hash function where each of them is a byte 
+ * Output:
+ * - Array of `int` Cvars representing the output of the hash function where each of them is a byte
+ *)
+ val pre_nist :
+     (module Snarky_backendless.Snark_intf.Run with type field = 'f)
+  -> int
   -> 'f Snarky_backendless.Cvar.t list
   -> 'f Snarky_backendless.Cvar.t array


### PR DESCRIPTION
This PR adds 3 functionalities discussed in the RFC for Keccak in SnarkyJS (https://github.com/o1-labs/rfcs/pull/9)

1. Add support for different output lengths corresponding to pre-NIST's variant. SnarkyJS can decide if they implement them or not, but at least they have access to them now.
2. Enables customization in the endianness of both the input and the output of the hash (now both are lists)
3. Adds a flag to enable byte checks (default is `false`, assuming users could use `UInt8` most times)