### PR TITLE
[Berkeley] Distinguish lightnet and standard dockers

### DIFF
--- a/buildkite/src/Command/DockerImage.dhall
+++ b/buildkite/src/Command/DockerImage.dhall
@@ -1,6 +1,9 @@
 -- Execute Docker artifact release script according to build scoped DOCKER_DEPLOY_ENV
 
 let Prelude = ../External/Prelude.dhall
+let B = ../External/Buildkite.dhall
+
+let B/If = B.definitions/commandStep/properties/if/Type
 
 let Command = ./Base.dhall
 let Size = ./Size.dhall
@@ -22,7 +25,8 @@ let ReleaseSpec = {
     deb_version: Text,
     deb_profile: Text,
     extra_args: Text,
-    step_key: Text
+    step_key: Text,
+    `if`: Optional B/If
   },
   default = {
     deps = [] : List Command.TaggedKey.Type,
@@ -35,7 +39,8 @@ let ReleaseSpec = {
     deb_release = "\\\${MINA_DEB_RELEASE}",
     deb_version = "\\\${MINA_DEB_VERSION}",
     extra_args = "",
-    step_key = "daemon-standard-docker-image"
+    step_key = "daemon-standard-docker-image",
+    `if` = None B/If
   }
 }
 
@@ -58,7 +63,8 @@ let generateStep = \(spec : ReleaseSpec.Type) ->
         key = spec.step_key,
         target = Size.XLarge,
         docker_login = Some DockerLogin::{=},
-        depends_on = spec.deps
+        depends_on = spec.deps,
+        `if` = spec.`if`
       }
 
 in

--- a/buildkite/src/Command/MinaArtifact.dhall
+++ b/buildkite/src/Command/MinaArtifact.dhall
@@ -1,4 +1,6 @@
 let Prelude = ../External/Prelude.dhall
+let B = ../External/Buildkite.dhall
+let B/If = B.definitions/commandStep/properties/if/Type
 
 let Cmd = ../Lib/Cmds.dhall
 let S = ../Lib/SelectFiles.dhall
@@ -62,7 +64,7 @@ let pipeline : DebianVersions.DebVersion -> Profiles.Type ->  PipelineMode.Type 
           network="berkeley",
           deb_codename="${DebianVersions.lowerName debVersion}",
           deb_profile="${Profiles.lowerName profile}",
-          step_key="daemon-berkeley-${DebianVersions.lowerName debVersion}-docker-image"
+          step_key="daemon-berkeley-${DebianVersions.lowerName debVersion}${Profiles.toLabelSegment profile}-docker-image"
         }
 
         in
@@ -74,7 +76,8 @@ let pipeline : DebianVersions.DebVersion -> Profiles.Type ->  PipelineMode.Type 
           deps=DebianVersions.dependsOn debVersion profile,
           service="mina-test-executive",
           deb_codename="${DebianVersions.lowerName debVersion}",
-          step_key="test-executive-${DebianVersions.lowerName debVersion}-docker-image"
+          step_key="test-executive-${DebianVersions.lowerName debVersion}-docker-image",
+          `if`=Some "'${Profiles.lowerName profile}' == 'standard'"
         }
         in
         DockerImage.generateStep testExecutiveSpec,
@@ -85,7 +88,8 @@ let pipeline : DebianVersions.DebVersion -> Profiles.Type ->  PipelineMode.Type 
           service="mina-batch-txn",
           network="berkeley",
           deb_codename="${DebianVersions.lowerName debVersion}",
-          step_key="batch-txn-${DebianVersions.lowerName debVersion}-docker-image"
+          step_key="batch-txn-${DebianVersions.lowerName debVersion}-docker-image",
+          `if`=Some "'${Profiles.lowerName profile}' == 'standard'"
         }
         in
         DockerImage.generateStep batchTxnSpec,
@@ -96,7 +100,7 @@ let pipeline : DebianVersions.DebVersion -> Profiles.Type ->  PipelineMode.Type 
           service="mina-archive",
           deb_codename="${DebianVersions.lowerName debVersion}",
           deb_profile="${Profiles.lowerName profile}",
-          step_key="archive-${DebianVersions.lowerName debVersion}-docker-image"
+          step_key="archive-${DebianVersions.lowerName debVersion}${Profiles.toLabelSegment profile}-docker-image"
         }
         in
         DockerImage.generateStep archiveSpec,
@@ -107,7 +111,8 @@ let pipeline : DebianVersions.DebVersion -> Profiles.Type ->  PipelineMode.Type 
           service="mina-rosetta",
           network="berkeley",
           deb_codename="${DebianVersions.lowerName debVersion}",
-          step_key="rosetta-${DebianVersions.lowerName debVersion}-docker-image"
+          step_key="rosetta-${DebianVersions.lowerName debVersion}-docker-image",
+          `if`=Some "'${Profiles.lowerName profile}' == 'standard'"
         }
         in
         DockerImage.generateStep rosettaSpec,
@@ -117,7 +122,8 @@ let pipeline : DebianVersions.DebVersion -> Profiles.Type ->  PipelineMode.Type 
           deps=DebianVersions.dependsOn debVersion profile,
           service="mina-zkapp-test-transaction",
           deb_codename="${DebianVersions.lowerName debVersion}",
-          step_key="zkapp-test-transaction-${DebianVersions.lowerName debVersion}-docker-image"
+          step_key="zkapp-test-transaction-${DebianVersions.lowerName debVersion}${Profiles.toLabelSegment profile}-docker-image",
+          `if`=Some "'${Profiles.lowerName profile}' == 'standard'"
         }
 
         in

--- a/buildkite/src/Constants/Profiles.dhall
+++ b/buildkite/src/Constants/Profiles.dhall
@@ -32,6 +32,12 @@ let toSuffixLowercase = \(profile : Profile) ->
     , Lightnet = "lightnet"
   } profile
 
+let toLabelSegment = \(profile : Profile) ->
+  merge {
+    Standard = ""
+    , Lightnet = "-lightnet"
+  } profile
+
 
 
 in
@@ -43,4 +49,5 @@ in
   , duneProfile = duneProfile
   , toSuffixUppercase = toSuffixUppercase
   , toSuffixLowercase = toSuffixLowercase
+  , toLabelSegment = toLabelSegment
 }

--- a/dockerfiles/Dockerfile-mina-archive
+++ b/dockerfiles/Dockerfile-mina-archive
@@ -16,7 +16,6 @@ ENV SUFFIX=${deb_profile:+-${deb_profile}}
 ENV MINA_DEB=mina-archive${SUFFIX}
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_FRONTEND noninteractive
 RUN echo "Building image with version $deb_codename $deb_release $deb_version"
 
 COPY scripts/archive-entrypoint.sh /entrypoint.sh

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -57,13 +57,15 @@ case "${DEB_CODENAME##*=}" in
 esac
 IMAGE="--build-arg image=${IMAGE}"
 
-# Determina profile for mina name. To preserve backward compatibility standard profile is default. 
+# Determine profile for mina name. To preserve backward compatibility standard profile is default. 
 case "${DEB_PROFILE}" in
   standard)
     DEB_PROFILE=""
+    SERVICE_SUFFIX=""
     ;;
   *)
     DEB_PROFILE="--build-arg deb_profile=${DEB_PROFILE}"
+    SERVICE_SUFFIX="-${DEB_PROFILE}"
     ;;
 esac
 
@@ -84,6 +86,7 @@ case "${SERVICE}" in
 mina-archive)
   DOCKERFILE_PATH="dockerfiles/Dockerfile-mina-archive"
   DOCKER_CONTEXT="dockerfiles/"
+  SERVICE=${SERVICE}${SERVICE_SUFFIX}
   ;;
 bot)
   DOCKERFILE_PATH="frontend/bot/Dockerfile"

--- a/scripts/release-docker.sh
+++ b/scripts/release-docker.sh
@@ -60,11 +60,11 @@ IMAGE="--build-arg image=${IMAGE}"
 # Determine profile for mina name. To preserve backward compatibility standard profile is default. 
 case "${DEB_PROFILE}" in
   standard)
-    DEB_PROFILE=""
+    DOCKER_DEB_PROFILE=""
     SERVICE_SUFFIX=""
     ;;
   *)
-    DEB_PROFILE="--build-arg deb_profile=${DEB_PROFILE}"
+    DOCKER_DEB_PROFILE="--build-arg deb_profile=${DEB_PROFILE}"
     SERVICE_SUFFIX="-${DEB_PROFILE}"
     ;;
 esac
@@ -72,7 +72,7 @@ esac
 
 # Debug prints for visability
 # Substring removal to cut the --build-arg arguments on the = so that the output is exactly the input flags https://wiki.bash-hackers.org/syntax/pe#substring_removal
-echo "--service ${SERVICE} --version ${VERSION} --branch ${BRANCH##*=} --deb-version ${DEB_VERSION##*=} --deb-profile ${DEB_PROFILE##*=} --deb-release ${DEB_RELEASE##*=} --deb-codename ${DEB_CODENAME##*=}"
+echo "--service ${SERVICE} --version ${VERSION} --branch ${BRANCH##*=} --deb-version ${DEB_VERSION##*=} --deb-profile ${DOCKER_DEB_PROFILE##*=} --deb-release ${DEB_RELEASE##*=} --deb-codename ${DEB_CODENAME##*=}"
 echo ${EXTRA}
 echo "docker image: ${IMAGE}"
 
@@ -151,9 +151,9 @@ HASHTAG="${DOCKER_REGISTRY}/${SERVICE}:${GITHASH}-${DEB_CODENAME##*=}-${NETWORK#
 # If DOCKER_CONTEXT is not specified, assume none and just pipe the dockerfile into docker build
 extra_build_args=$(echo ${EXTRA} | tr -d '"')
 if [[ -z "${DOCKER_CONTEXT}" ]]; then
-  cat $DOCKERFILE_PATH | docker build $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DEB_PROFILE $BRANCH $REPO $extra_build_args -t "$TAG" -
+  cat $DOCKERFILE_PATH | docker build $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_PROFILE $BRANCH $REPO $extra_build_args -t "$TAG" -
 else
-  docker build $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DEB_PROFILE $BRANCH $REPO $extra_build_args $DOCKER_CONTEXT -t "$TAG" -f $DOCKERFILE_PATH
+  docker build $CACHE $NETWORK $IMAGE $DEB_CODENAME $DEB_RELEASE $DEB_VERSION $DOCKER_DEB_PROFILE $BRANCH $REPO $extra_build_args $DOCKER_CONTEXT -t "$TAG" -f $DOCKERFILE_PATH
 fi
 
 if [[ -z "$NOUPLOAD" ]] || [[ "$NOUPLOAD" -eq 0 ]]; then


### PR DESCRIPTION
Explain your changes:

Build separate dockers for lightnet and standard profile. Do not build test-executive/batch-txn/rosetta for non-devnet profiles
