### PR TITLE
Fix hash table nits

### DIFF
--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -110,11 +110,7 @@ struct
     { uuid = Uuid_unix.create (); table = Bigstring_frozen.Table.create () }
 
   let create_checkpoint t _ =
-    { uuid = Uuid_unix.create ()
-    ; table =
-        Bigstring_frozen.Table.of_alist_exn
-        @@ Bigstring_frozen.Table.to_alist t.table
-    }
+    { uuid = Uuid_unix.create (); table = Bigstring_frozen.Table.copy t.table }
 
   let close _ = ()
 

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -168,10 +168,6 @@ module Make (Inputs : Inputs_intf.S) = struct
       assert_is_attached t ;
       Location_binable.Table.find t.account_tbl location
 
-    let self_find_all_accounts t =
-      assert_is_attached t ;
-      Location_binable.Table.data t.account_tbl
-
     let self_set_account t location account =
       assert_is_attached t ;
       Location_binable.Table.set t.account_tbl ~key:location ~data:account ;

--- a/src/lib/network_pool/priced_proof.ml
+++ b/src/lib/network_pool/priced_proof.ml
@@ -8,12 +8,12 @@ module Stable = struct
   module V1 = struct
     type 'proof t = 'proof Mina_wire_types.Network_pool.Priced_proof.V1.t =
       { proof : 'proof; fee : Fee_with_prover.Stable.V1.t }
-    [@@deriving compare, fields, sexp, yojson, hash]
+    [@@deriving compare, fields, sexp, yojson, hash, equal]
   end
 end]
 
 type 'proof t = 'proof Stable.Latest.t =
   { proof : 'proof; fee : Fee_with_prover.t }
-[@@deriving compare, fields, sexp, yojson, hash]
+[@@deriving compare, fields, sexp, yojson, hash, equal]
 
 let map t ~f = { t with proof = f t.proof }

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -30,18 +30,7 @@ module Snark_tables = struct
         (Ledger_proof.t One_or_two.t Priced_proof.t * Core.Time.t)
         Transaction_snark_work.Statement.Table.t
     }
-  [@@deriving sexp]
-
-  let compare t1 t2 =
-    let p t = (Hashtbl.to_alist t.all, Hashtbl.to_alist t.rebroadcastable) in
-    [%compare:
-      ( Transaction_snark_work.Statement.t
-      * Ledger_proof.t One_or_two.t Priced_proof.t )
-      list
-      * ( Transaction_snark_work.Statement.t
-        * (Ledger_proof.t One_or_two.t Priced_proof.t * Core.Time.t) )
-        list]
-      (p t1) (p t2)
+  [@@deriving sexp, equal]
 
   let of_serializable (t : Serializable.t) : t =
     { all = Hashtbl.map t ~f:fst
@@ -856,7 +845,7 @@ let%test_module "random set test" =
       let s1 =
         Snark_tables.to_serializable s0 |> Snark_tables.of_serializable
       in
-      [%test_eq: Snark_tables.t] s0 s1
+      assert (Snark_tables.equal s0 s1)
 
     let%test_unit "Invalid proofs are not accepted" =
       let open Quickcheck.Generator.Let_syntax in


### PR DESCRIPTION
Fix some small issues found during hash table audit:

- remove dead code
- replace `to_alist`, `of_alist` composition with simpler `Table.copy`
- replace `compare` with `equal` for snark pool test