### PR TITLE
[Berkeley] Update bindings to expose lookup selector commitments

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -186,7 +186,12 @@ module VerifierIndex = struct
     type nonrec lookup_info =
       { max_per_row : int; max_joint_size : int; features : lookup_features }
 
-    type nonrec 't lookup_selectors = { lookup : 't option } [@@boxed]
+    type nonrec 't lookup_selectors =
+      { lookup : 't option
+      ; xor : 't option
+      ; range_check : 't option
+      ; ffmul : 't option
+      }
 
     type nonrec 'poly_comm t =
       { joint_lookup_used : bool

--- a/src/lib/crypto/kimchi_bindings/stubs/src/plonk_verifier_index.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/plonk_verifier_index.rs
@@ -31,6 +31,9 @@ pub enum CamlLookupsUsed {
 #[derive(ocaml::IntoValue, ocaml::FromValue, ocaml_gen::Struct)]
 pub struct CamlLookupSelectors<T> {
     pub lookup: Option<T>,
+    pub xor: Option<T>,
+    pub range_check: Option<T>,
+    pub ffmul: Option<T>,
 }
 
 impl<G, CamlPolyComm> From<LookupSelectors<PolyComm<G>>> for CamlLookupSelectors<CamlPolyComm>
@@ -40,13 +43,16 @@ where
 {
     fn from(val: LookupSelectors<PolyComm<G>>) -> Self {
         let LookupSelectors {
-            xor: _,
+            xor,
             lookup,
-            range_check: _,
-            ffmul: _,
+            range_check,
+            ffmul,
         } = val;
         CamlLookupSelectors {
             lookup: lookup.map(From::from),
+            xor: xor.map(From::from),
+            range_check: range_check.map(From::from),
+            ffmul: ffmul.map(From::from),
         }
     }
 }
@@ -57,12 +63,17 @@ where
     PolyComm<G>: From<CamlPolyComm>,
 {
     fn from(val: CamlLookupSelectors<CamlPolyComm>) -> Self {
-        let CamlLookupSelectors { lookup } = val;
+        let CamlLookupSelectors {
+            xor,
+            lookup,
+            range_check,
+            ffmul,
+        } = val;
         LookupSelectors {
-            xor: None,
             lookup: lookup.map(From::from),
-            range_check: None,
-            ffmul: None,
+            xor: xor.map(From::from),
+            range_check: range_check.map(From::from),
+            ffmul: ffmul.map(From::from),
         }
     }
 }

--- a/src/lib/pickles/verification_key.ml
+++ b/src/lib/pickles/verification_key.ml
@@ -7,7 +7,11 @@ module Verifier_index_json = struct
   module Lookup = struct
     type 't lookup_selectors =
           't Kimchi_types.VerifierIndex.Lookup.lookup_selectors =
-      { lookup : 't option }
+      { lookup : 't option
+      ; xor : 't option
+      ; range_check : 't option
+      ; ffmul : 't option
+      }
     [@@deriving yojson]
 
     type lookup_pattern = Kimchi_types.lookup_pattern =


### PR DESCRIPTION
This PR exposes the lookup selector commitments from the rust backend. These commitments are required for the custom gates that use lookup tables, and proofs using those gates cannot be handled by pickles without them.

This PR is part of the work towards https://github.com/MinaProtocol/mina/issues/13482.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them