### PR TITLE
Remove "indexed" runtime table configuration

### DIFF
--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -181,7 +181,7 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
     use kimchi::circuits::{
         constraints::ConstraintSystem,
         gate::{CircuitGate, GateType},
-        lookup::runtime_tables::{RuntimeTable, RuntimeTableCfg, RuntimeTableSpec},
+        lookup::runtime_tables::{RuntimeTable, RuntimeTableCfg},
         polynomial::COLUMNS,
         wires::Wire,
     };
@@ -192,16 +192,9 @@ pub fn caml_pasta_fp_plonk_proof_example_with_lookup(
 
     let mut runtime_tables_setup = vec![];
     for table_id in 0..num_tables {
-        let cfg = if indexed {
-            RuntimeTableCfg::Indexed(RuntimeTableSpec {
-                id: table_id as i32,
-                len: 5,
-            })
-        } else {
-            RuntimeTableCfg::Custom {
-                id: table_id as i32,
-                first_column: [8u32, 9, 8, 7, 1].into_iter().map(Into::into).collect(),
-            }
+        let cfg = RuntimeTableCfg {
+            id: table_id,
+            first_column: [8u32, 9, 8, 7, 1].into_iter().map(Into::into).collect(),
         };
         runtime_tables_setup.push(cfg);
     }


### PR DESCRIPTION
Depends on https://github.com/o1-labs/proof-systems/pull/1108

Explain your changes:
* Remove "indexed" runtime table configuration

Explain how you tested your changes:
* The feature is not used yet.

Checklist:

- [ ] N/A Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] N/A Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] N/A Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] N/A Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] N/A Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes https://github.com/MinaProtocol/mina/issues/13512
