### PR TITLE
Use nonce for snark work and tx gossips

### DIFF
--- a/src/lib/gossip_net/any.ml
+++ b/src/lib/gossip_net/any.ml
@@ -65,11 +65,12 @@ module Make (Rpc_intf : Network_peer.Rpc_intf.Rpc_interface_intf) :
   let broadcast_state ?origin_topic (Any ((module M), t)) =
     M.broadcast_state ?origin_topic t
 
-  let broadcast_transaction_pool_diff ?origin_topic (Any ((module M), t)) =
-    M.broadcast_transaction_pool_diff ?origin_topic t
+  let broadcast_transaction_pool_diff ?origin_topic ?nonce (Any ((module M), t))
+      =
+    M.broadcast_transaction_pool_diff ?origin_topic ?nonce t
 
-  let broadcast_snark_pool_diff ?origin_topic (Any ((module M), t)) =
-    M.broadcast_snark_pool_diff ?origin_topic t
+  let broadcast_snark_pool_diff ?origin_topic ?nonce (Any ((module M), t)) =
+    M.broadcast_snark_pool_diff ?origin_topic ?nonce t
 
   let on_first_connect (Any ((module M), t)) = M.on_first_connect t
 

--- a/src/lib/gossip_net/dune
+++ b/src/lib/gossip_net/dune
@@ -20,7 +20,9 @@
    async_unix
    base.base_internalhash_types
    ppx_hash.runtime-lib
+   integers
    ;; local libraries
+   ppx_version.runtime
    network_peer
    logger
    pipe_lib

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -270,15 +270,17 @@ module Make (Rpc_intf : Network_peer.Rpc_intf.Rpc_interface_intf) :
           M.Block_sink.push sink_block
             (`Transition env, `Time_received time, `Valid_cb vc) )
 
-    let broadcast_snark_pool_diff ?origin_topic t diff =
+    let broadcast_snark_pool_diff ?origin_topic ?nonce t diff =
       ignore origin_topic ;
+      ignore nonce ;
       Network.broadcast t.network ~sender:t.me diff
         (fun (Any_sinks (sinksM, (_, _, sink_snark_work))) ->
           let module M = (val sinksM) in
           M.Snark_sink.push sink_snark_work )
 
-    let broadcast_transaction_pool_diff ?origin_topic t diff =
+    let broadcast_transaction_pool_diff ?origin_topic ?nonce t diff =
       ignore origin_topic ;
+      ignore nonce ;
       Network.broadcast t.network ~sender:t.me diff
         (fun (Any_sinks (sinksM, (_, sink_tx, _))) ->
           let module M = (val sinksM) in

--- a/src/lib/gossip_net/intf.ml
+++ b/src/lib/gossip_net/intf.ml
@@ -75,12 +75,17 @@ module type Gossip_net_intf = sig
 
   val broadcast_transaction_pool_diff :
        ?origin_topic:string
+    -> ?nonce:int
     -> t
     -> Message.transaction_pool_diff_msg
     -> unit Deferred.t
 
   val broadcast_snark_pool_diff :
-    ?origin_topic:string -> t -> Message.snark_pool_diff_msg -> unit Deferred.t
+       ?origin_topic:string
+    -> ?nonce:int
+    -> t
+    -> Message.snark_pool_diff_msg
+    -> unit Deferred.t
 
   val on_first_connect : t -> f:(unit -> 'a) -> 'a Deferred.t
 

--- a/src/lib/gossip_net/message.ml
+++ b/src/lib/gossip_net/message.ml
@@ -7,8 +7,10 @@ module Master = struct
   module T = struct
     type msg =
       | New_state of Mina_block.t
-      | Snark_pool_diff of Snark_pool.Resource_pool.Diff.t
-      | Transaction_pool_diff of Transaction_pool.Resource_pool.Diff.t
+      | Snark_pool_diff of
+          Snark_pool.Resource_pool.Diff.t Network_pool.With_nonce.t
+      | Transaction_pool_diff of
+          Transaction_pool.Resource_pool.Diff.t Network_pool.With_nonce.t
     [@@deriving sexp, to_yojson]
 
     type state_msg = Mina_block.t
@@ -31,8 +33,12 @@ module V2 = struct
   module T = struct
     type msg =
       | New_state of Mina_block.Stable.V2.t
-      | Snark_pool_diff of Snark_pool.Diff_versioned.Stable.V2.t
-      | Transaction_pool_diff of Transaction_pool.Diff_versioned.Stable.V2.t
+      | Snark_pool_diff of
+          Snark_pool.Diff_versioned.Stable.V2.t
+          Network_pool.With_nonce.Stable.V1.t
+      | Transaction_pool_diff of
+          Transaction_pool.Diff_versioned.Stable.V2.t
+          Network_pool.With_nonce.Stable.V1.t
     [@@deriving bin_io, sexp, version { rpc }]
 
     type state_msg = Mina_block.Stable.V2.t

--- a/src/lib/mina_networking/mina_networking.ml
+++ b/src/lib/mina_networking/mina_networking.ml
@@ -1482,21 +1482,25 @@ let broadcast_state t state =
   Mina_metrics.(Gauge.inc_one Network.new_state_broadcasted) ;
   Gossip_net.Any.broadcast_state t.gossip_net msg
 
-let broadcast_transaction_pool_diff t diff =
-  log_gossip t.logger (Gossip_net.Message.Transaction_pool_diff diff)
+let broadcast_transaction_pool_diff ?nonce t diff =
+  log_gossip t.logger
+    (Gossip_net.Message.Transaction_pool_diff
+       { message = diff; nonce = Option.value ~default:0 nonce } )
     ~log_msg:(Gossip_transaction_pool_diff { txns = diff }) ;
   Mina_metrics.(Gauge.inc_one Network.transaction_pool_diff_broadcasted) ;
-  Gossip_net.Any.broadcast_transaction_pool_diff t.gossip_net diff
+  Gossip_net.Any.broadcast_transaction_pool_diff ?nonce t.gossip_net diff
 
-let broadcast_snark_pool_diff t diff =
+let broadcast_snark_pool_diff ?nonce t diff =
   Mina_metrics.(Gauge.inc_one Network.snark_pool_diff_broadcasted) ;
-  log_gossip t.logger (Gossip_net.Message.Snark_pool_diff diff)
+  log_gossip t.logger
+    (Gossip_net.Message.Snark_pool_diff
+       { message = diff; nonce = Option.value ~default:0 nonce } )
     ~log_msg:
       (Gossip_snark_pool_diff
          { work =
              Option.value_exn (Snark_pool.Resource_pool.Diff.to_compact diff)
          } ) ;
-  Gossip_net.Any.broadcast_snark_pool_diff t.gossip_net diff
+  Gossip_net.Any.broadcast_snark_pool_diff ?nonce t.gossip_net diff
 
 let find_map xs ~f =
   let open Async in

--- a/src/lib/mina_networking/mina_networking.mli
+++ b/src/lib/mina_networking/mina_networking.mli
@@ -242,10 +242,10 @@ val broadcast_state :
   t -> Mina_block.t State_hash.With_state_hashes.t -> unit Deferred.t
 
 val broadcast_snark_pool_diff :
-  t -> Snark_pool.Resource_pool.Diff.t -> unit Deferred.t
+  ?nonce:int -> t -> Snark_pool.Resource_pool.Diff.t -> unit Deferred.t
 
 val broadcast_transaction_pool_diff :
-  t -> Transaction_pool.Resource_pool.Diff.t -> unit Deferred.t
+  ?nonce:int -> t -> Transaction_pool.Resource_pool.Diff.t -> unit Deferred.t
 
 val glue_sync_ledger :
      t

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -207,7 +207,7 @@ module type Network_pool_base_intf = sig
 
   val resource_pool : t -> resource_pool
 
-  val broadcasts : t -> resource_pool_diff Linear_pipe.Reader.t
+  val broadcasts : t -> resource_pool_diff With_nonce.t Linear_pipe.Reader.t
 
   val create_rate_limiter : unit -> Rate_limiter.t
 

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -70,7 +70,9 @@ end)
     let forward broadcast_pipe accepted rejected = function
       | Local f ->
           f (Ok (`Broadcasted, accepted, rejected)) ;
-          Linear_pipe.write broadcast_pipe accepted |> don't_wait_for
+          Linear_pipe.write broadcast_pipe
+            { With_nonce.message = accepted; nonce = 0 }
+          |> don't_wait_for
       | External cb ->
           fire_if_not_already_fired cb `Accept
   end
@@ -100,8 +102,8 @@ end)
   type t =
     { resource_pool : Resource_pool.t
     ; logger : Logger.t
-    ; write_broadcasts : Resource_pool.Diff.t Linear_pipe.Writer.t
-    ; read_broadcasts : Resource_pool.Diff.t Linear_pipe.Reader.t
+    ; write_broadcasts : Resource_pool.Diff.t With_nonce.t Linear_pipe.Writer.t
+    ; read_broadcasts : Resource_pool.Diff.t With_nonce.t Linear_pipe.Reader.t
     ; constraint_constants : Genesis_constants.Constraint_constants.t
     }
 
@@ -243,9 +245,10 @@ end)
                      ~f:(fun d -> `String (Resource_pool.Diff.summary d))
                      rebroadcastable ) )
             ] ;
+      let nonce = Time_ns.to_int_ns_since_epoch (Time_ns.now ()) in
       let%bind () =
-        Deferred.List.iter rebroadcastable
-          ~f:(Linear_pipe.write t.write_broadcasts)
+        Deferred.List.iter rebroadcastable ~f:(fun message ->
+            Linear_pipe.write t.write_broadcasts With_nonce.{ message; nonce } )
       in
       let%bind () = Async.after rebroadcast_interval in
       go ()

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -898,7 +898,7 @@ let%test_module "random set test" =
                    |> Deferred.don't_wait_for ) ;
             don't_wait_for
             @@ Linear_pipe.iter (Mock_snark_pool.broadcasts network_pool)
-                 ~f:(fun work_command ->
+                 ~f:(fun With_nonce.{ message = work_command; _ } ->
                    let work =
                      match work_command with
                      | Mock_snark_pool.Resource_pool.Diff.Add_solved_work

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -130,7 +130,7 @@ let%test_module "network pool test" =
         let%bind () = Mocks.Transition_frontier.refer_statements tf works in
         don't_wait_for
         @@ Linear_pipe.iter (Mock_snark_pool.broadcasts network_pool)
-             ~f:(fun work_command ->
+             ~f:(fun With_nonce.{ message = work_command; _ } ->
                let work =
                  match work_command with
                  | Mock_snark_pool.Resource_pool.Diff.Add_solved_work (work, _)

--- a/src/lib/network_pool/with_nonce.ml
+++ b/src/lib/network_pool/with_nonce.ml
@@ -1,5 +1,10 @@
 open Core_kernel
 
+(*
+  Appending a nonce to messages emitted by transaction and snark pools allows to circumvent
+  libp2p's gossip deduplication logic and allow broadcasts to be broadcasted over and over again.
+*)
+
 [%%versioned
 module Stable = struct
   module V1 = struct

--- a/src/lib/network_pool/with_nonce.ml
+++ b/src/lib/network_pool/with_nonce.ml
@@ -1,0 +1,8 @@
+open Core_kernel
+
+[%%versioned
+module Stable = struct
+  module V1 = struct
+    type 'a t = { message : 'a; nonce : int } [@@deriving compare, sexp, yojson]
+  end
+end]

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -126,7 +126,7 @@ let%test_module "transaction_status" =
       in
       don't_wait_for
       @@ Linear_pipe.iter (Transaction_pool.broadcasts transaction_pool)
-           ~f:(fun transactions ->
+           ~f:(fun Network_pool.With_nonce.{ message = transactions; _ } ->
              [%log trace]
                "Transactions have been applied successfully and is propagated \
                 throughout the 'network'"


### PR DESCRIPTION
Problem: with hash-based message ids rebroadcast mechanism became invalid.

Solution: add integer nonce to snark/tx gossip messages in the old topic.

Explain how you tested your changes:
* Tested on a private cluster, rebroadcast seems to work
* Requires additional testing to confirm rebroadcast works not worse than on mainnet 

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues?
  * Closes #13451