### PR TITLE
Lints for system proofs commit ancestor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,9 @@ check-format: ocaml_checks
 check-snarky-submodule:
 	./scripts/check-snarky-submodule.sh
 
+check-proof-systems-submodule:
+	./scripts/check-proof-systems-submodule.sh
+
 #######################################
 ## Environment setup
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ genesis_ledger: ocaml_checks
 	ulimit -s 65532 && (ulimit -n 10240 || true) && env MINA_COMMIT_SHA1=$(GITLONGHASH) dune exec --profile=$(DUNE_PROFILE) src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe -- --genesis-dir $(GENESIS_DIR)
 	$(info Genesis ledger and genesis proof generated)
 
-# checks that every OCaml packages in the project build without issues
+# Checks that every OCaml packages in the project build without issues
 check: ocaml_checks libp2p_helper
 	dune build @src/check
 

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -22,6 +22,7 @@ let commands =
       [ Cmd.run "./scripts/lint_codeowners.sh"
       , Cmd.run "./scripts/lint_rfcs.sh"
       , Cmd.run "make check-snarky-submodule"
+      , Cmd.run "make check-proof-systems-submodule"
       , Cmd.run "./scripts/lint_preprocessor_deps.sh"
       ]
 

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -30,6 +30,7 @@ in  Pipeline.build
       Pipeline.Config::{
         spec = JobSpec::{
         , dirtyWhen = [
+            S.strictly (S.contains "Makefile"),
             S.strictlyStart (S.contains "src/"),
             S.strictlyStart (S.contains "rfcs/")
           ]

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -41,7 +41,7 @@ in  Pipeline.build
             Command.Config::{
             , commands = commands
             , label =
-                "Fast lint steps; CODEOWNERs, RFCs, Check Snarky Submodule, Preprocessor Deps"
+                "Fast lint steps; CODEOWNERs, RFCs, Check Snarky & Proof-Systems submodules, Preprocessor Deps"
             , key = "lint"
             , target = Size.Small
             , docker = Some Docker::{

--- a/scripts/check-proof-systems-submodule.sh
+++ b/scripts/check-proof-systems-submodule.sh
@@ -10,6 +10,13 @@ git config http.sslVerify false
 git fetch origin
 git config http.sslVerify true
 
+declare -A BRANCH_MAPPING=(
+  ["rampup"]="compatible" 
+  ["berkeley"]="berkeley"
+  ["develop"]="develop"
+  ["izmir"]="master"
+)
+
 function in_branch {
   if git rev-list origin/$1 | grep -q $CURR; then
     echo "Proof systems submodule commit is an ancestor of $1"
@@ -19,8 +26,9 @@ function in_branch {
   fi
 }
 
-if (! in_branch "berkeley"); then
-  echo "Proof-systems submodule commit is NOT an ancestor of berkeley branch"
+BRANCH="${BRANCH_MAPPING[${BUILDKITE_PULL_REQUEST_BASE_BRANCH}]}"
+
+if (! in_branch ${BRANCH}); then
+  echo "Proof-systems submodule commit is NOT an ancestor of ${BRANCH} branch"
   exit 1
 fi
-

--- a/scripts/check-proof-systems-submodule.sh
+++ b/scripts/check-proof-systems-submodule.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+cd src/lib/crypto/proof-systems
+
+CURR=$(git rev-parse HEAD)
+# temporarily skip SSL verification (for CI)
+git config http.sslVerify false
+git fetch origin
+git config http.sslVerify true
+
+function in_branch {
+  if git rev-list origin/$1 | grep -q $CURR; then
+    echo "Proof systems submodule commit is an ancestor of $1"
+    true
+  else
+    false
+  fi
+}
+
+if (! in_branch "berkeley"); then
+  echo "Proof-systems submodule commit is NOT an ancestor of berkeley branch"
+  exit 1
+fi
+


### PR DESCRIPTION
Explain your changes:
Added new job to CI for checking if current commit in `src/lib/crypto/proof-system` submodule is ancestor of particular branch. As already discussed, we need that kind of verification for all major mina branches (compatible/berkeley/develop/izmir). Due to the problems with merging back changes between mentioned branches ,@mrmr1993 have this idea that it's better to commit the same script everywhere and control it by base branch variable from buildkite. Thanks to than we don't need to have painful merging back changes between develop/berkeley/compatible.

Explain how you tested your changes:

By running CI

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
