### PR TITLE
Bump up ocaml-gen to 0.1.5

### DIFF
--- a/buildkite/scripts/run-snark-transaction-profiler.sh
+++ b/buildkite/scripts/run-snark-transaction-profiler.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Don't prompt for answers during apt-get install
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y git apt-transport-https ca-certificates tzdata curl python3
+
+case "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" in
+  rampup|berkeley|release/2.0.0|develop)
+    TESTNET_NAME="berkeley"
+  ;;
+  *)
+    TESTNET_NAME="mainnet"
+esac
+
+git config --global --add safe.directory /workdir
+
+source buildkite/scripts/export-git-env-vars.sh
+
+echo "Installing mina daemon package: mina-${TESTNET_NAME}=${MINA_DEB_VERSION}"
+echo "deb [trusted=yes] http://packages.o1test.net $MINA_DEB_CODENAME $MINA_DEB_RELEASE" | tee /etc/apt/sources.list.d/mina.list
+apt-get update
+apt-get install --allow-downgrades -y "mina-${TESTNET_NAME}=${MINA_DEB_VERSION}"
+
+K=1
+MAX_NUM_UPDATES=4
+MIN_NUM_UPDATES=2   
+
+echo "--- Run Snark Transaction Profiler with parameters: --zkapps --k ${K} --max-num-updates ${MAX_NUM_UPDATES} --min-num-updates ${MIN_NUM_UPDATES}"
+python3 ./scripts/snark_transaction_profiler.py ${K} ${MAX_NUM_UPDATES} ${MIN_NUM_UPDATES}

--- a/buildkite/src/Command/TestExecutive.dhall
+++ b/buildkite/src/Command/TestExecutive.dhall
@@ -72,7 +72,7 @@ in
             ],
         label = "Build JS integration tests",
         key = "build-js-tests",
-        target = Size.Integration,
+        target = Size.XLarge,
         `if` = Some "build.branch != 'develop' && build.branch != 'compatible' && build.branch != 'develop-next'"
       },
 

--- a/buildkite/src/Jobs/Test/RunSnarkProfiler.dhall
+++ b/buildkite/src/Jobs/Test/RunSnarkProfiler.dhall
@@ -1,0 +1,62 @@
+let Prelude = ../../External/Prelude.dhall
+
+let Cmd = ../../Lib/Cmds.dhall
+let S = ../../Lib/SelectFiles.dhall
+let D = S.PathPattern
+
+let Pipeline = ../../Pipeline/Dsl.dhall
+let JobSpec = ../../Pipeline/JobSpec.dhall
+
+let Command = ../../Command/Base.dhall
+let RunInToolchain = ../../Command/RunInToolchain.dhall
+let Docker = ../../Command/Docker/Type.dhall
+let Size = ../../Command/Size.dhall
+
+
+let dependsOn = [
+    { name = "MinaArtifactBullseye", key = "build-deb-pkg" }
+]
+
+in 
+
+let buildTestCmd : Size -> List Command.TaggedKey.Type -> Command.Type = \(cmd_target : Size) -> \(dependsOn : List Command.TaggedKey.Type) ->
+  Command.build
+    Command.Config::{
+      commands = [
+        Cmd.runInDocker
+            Cmd.Docker::{
+              image = (../../Constants/ContainerImages.dhall).ubuntu2004
+            }
+            "buildkite/scripts/run-snark-transaction-profiler.sh"
+      ],
+      label = "Snark Transaction Profiler",
+      key = "snark-transaction-profiler",
+      target = cmd_target,
+      docker = None Docker.Type,
+      artifact_paths = [ S.contains "core_dumps/*" ],
+      depends_on = dependsOn
+    }
+
+in
+
+Pipeline.build
+  Pipeline.Config::{
+    spec =
+      let lintDirtyWhen = [
+        S.strictlyStart (S.contains "src/lib"),
+        S.exactly "buildkite/src/Jobs/Test/RunSnarkProfiler" "dhall",
+        S.exactly "buildkite/scripts/run-snark-transaction-profiler" "sh",
+        S.exactly "scripts/snark_transaction_profiler" "py"
+      ]
+
+      in
+
+      JobSpec::{
+        dirtyWhen = lintDirtyWhen,
+        path = "Test",
+        name = "RunSnarkProfiler"
+      },
+    steps = [
+      buildTestCmd Size.Small dependsOn
+    ]
+  }

--- a/helm/cron_jobs/berkeley-dump-archive-cronjob.yml
+++ b/helm/cron_jobs/berkeley-dump-archive-cronjob.yml
@@ -27,7 +27,7 @@ spec:
             DATE="$(date +%F_%H%M)";
             FILENAME=berkeley-archive-dump-"${DATE}".sql;
 
-            pg_dump --no-owner --create postgres://postgres:foobar@archive-1-postgresql:5432/archive > $FILENAME;
+            pg_dump --no-owner --create postgres://mina:$password@archive-1-postgresql:5432/archive > $FILENAME;
 
             tar -czvf $FILENAME.tar.gz $FILENAME;
 
@@ -38,10 +38,13 @@ spec:
             echo "archive database uploaded to bucket";
 
             '
+            envFrom:
+            - secretRef:
+                name: archive-1-postgresql
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: postgres:11-alpine
+            image: postgres:15-alpine
             imagePullPolicy: IfNotPresent
             name: berkeley-dump-archive-cronjob
             resources: {}

--- a/scripts/snark_transaction_profiler.py
+++ b/scripts/snark_transaction_profiler.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# script run transaction snark profiler
+
+import subprocess
+import sys
+import os
+import argparse
+import json
+import re
+
+exit_code=0
+prog = 'mina'
+
+def set_error():
+  global exit_code
+  exit_code=1
+
+def parse_stats (output) :
+
+    print(output)
+
+    lines = output.split ('\n')
+
+    stats = []
+
+    for line in lines :
+        if line == '' :
+            continue
+
+        compile = 'Generated zkapp transactions with (?P<updates>\d+) updates and (?P<proof>\d+) proof updates in (?P<time>[0-9]*[.]?[0-9]+) secs'
+
+        match = re.match(compile, line)
+
+        if match :
+            updates = int(match.group('updates'))
+            proof = int(match.group('proof'))
+            time = float(match.group('time'))
+
+            stats.append((updates, proof, time))
+       
+    return stats
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4 :
+        print("Usage: %s k max-num-updates min-num-updates" % sys.argv[0], file=sys.stderr)
+        sys.exit(1)
+
+    k=sys.argv[1]
+    max_num_updates=sys.argv[2]
+    min_num_updates=sys.argv[3]
+
+    args = " ".join([prog, 
+        "transaction-snark-profiler",
+        "--zkapps",
+        "--k",
+        k,
+        "--max-num-updates",
+        max_num_updates,
+        "--min-num-updates", 
+        min_num_updates])
+
+
+    print(f'running snark transaction profiler: {args}')
+    (process_exit_code,output) = subprocess.getstatusoutput(args)
+    stats = parse_stats (output)
+    #TODO: add code to check against some threshold
+    print(stats)
+    
+
+    if not process_exit_code == 0:
+        print('non-zero exit code from program, failing build')
+        sys.exit(process_exit_code)
+    else:
+        sys.exit(exit_code)

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -294,13 +294,19 @@ module Make_str (A : Wire_types.Concrete) = struct
                 File_system.rmrf location
 
           let ledger_subset keys ledger =
+            let open Mina_ledger in
             match ledger with
             | Genesis_epoch_ledger ledger ->
-                Mina_ledger.Sparse_ledger.of_ledger_subset_exn ledger keys
-            | Ledger_db ledger ->
-                Mina_ledger.(
-                  Sparse_ledger.of_any_ledger
-                  @@ Ledger.Any_ledger.cast (module Ledger.Db) ledger)
+                Sparse_ledger.of_ledger_subset_exn ledger keys
+            | Ledger_db db_ledger ->
+                let ledger = Ledger.of_database db_ledger in
+                let subset_ledger =
+                  Sparse_ledger.of_ledger_subset_exn ledger keys
+                in
+                ignore
+                  ( Ledger.unregister_mask_exn ~loc:__LOC__ ledger
+                    : Ledger.unattached_mask ) ;
+                subset_ledger
         end
 
         type t =

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.lock
@@ -373,9 +373,9 @@ checksum = "d102f1a462fdcdddce88d6d46c06c074a2d2749b262230333726b06c52bb7585"
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "fnv"
@@ -439,12 +439,23 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "internal-tracing"
+version = "0.1.0"
+dependencies = [
+ "ocaml",
+ "ocaml-gen",
+]
 
 [[package]]
 name = "itertools"
@@ -473,6 +484,7 @@ dependencies = [
  "disjoint-set",
  "groupmap",
  "hex",
+ "internal-tracing",
  "itertools",
  "mina-curves",
  "mina-poseidon",
@@ -488,7 +500,7 @@ dependencies = [
  "rand",
  "rand_core",
  "rayon",
- "rmp-serde 1.1.1",
+ "rmp-serde 1.1.2",
  "serde",
  "serde_with",
  "strum",
@@ -622,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
@@ -781,6 +793,7 @@ dependencies = [
  "rand",
  "rand_core",
  "rayon",
+ "rmp-serde 1.1.2",
  "serde",
  "serde_with",
  "thiserror",
@@ -809,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -876,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -898,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
 dependencies = [
  "byteorder",
  "rmp",
@@ -954,29 +967,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "5d25439cd7397d044e2748a6fe2432b5e85db703d6d097bd014b3c0ad1ebff0b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1087,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1110,22 +1123,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -1234,5 +1247,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.27",
 ]

--- a/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
+++ b/src/lib/crypto/kimchi_bindings/stubs/Cargo.toml
@@ -40,4 +40,4 @@ kimchi = { path = "../../proof-systems/kimchi", features = ["ocaml_types"] }
 
 # ocaml-specific
 ocaml = { version = "0.22.2", features = ["no-caml-startup"] }
-ocaml-gen = "0.1.0"
+ocaml-gen = "0.1.5"

--- a/src/lib/monad_lib/monad_lib.ml
+++ b/src/lib/monad_lib/monad_lib.ml
@@ -26,6 +26,12 @@ module Make_ext (M : Monad.S) = struct
         List.append acc ys )
 
   let iter_m ~f xs = fold_m ~f:(fun () x -> f x) ~init:() xs
+
+  let sequence ms =
+    fold_m ms ~init:[] ~f:(fun acc m ->
+        let open M.Let_syntax in
+        let%map x = m in
+        x :: acc )
 end
 
 module Make_ext2 (M : Monad.S2) = struct
@@ -53,4 +59,10 @@ module Make_ext2 (M : Monad.S2) = struct
         List.append acc ys )
 
   let iter_m ~f xs = fold_m ~f:(fun () x -> f x) ~init:() xs
+
+  let sequence ms =
+    fold_m ms ~init:[] ~f:(fun acc m ->
+        let open M.Let_syntax in
+        let%map x = m in
+        x :: acc )
 end

--- a/src/lib/monad_lib/monad_lib.mli
+++ b/src/lib/monad_lib/monad_lib.mli
@@ -12,6 +12,8 @@ module Make_ext : functor (M : Monad.S) -> sig
   val concat_map_m : f:('a -> 'b list t) -> 'a list -> 'b list t
 
   val iter_m : f:('a -> unit t) -> 'a list -> unit t
+
+  val sequence : 'a t list -> 'a list t
 end
 
 module Make_ext2 : functor (M : Monad.S2) -> sig
@@ -24,4 +26,6 @@ module Make_ext2 : functor (M : Monad.S2) -> sig
   val concat_map_m : f:('a -> ('b list, 'c) t) -> 'a list -> ('b list, 'c) t
 
   val iter_m : f:('a -> (unit, 'b) t) -> 'a list -> (unit, 'b) t
+
+  val sequence : ('a, 'b) t list -> ('a list, 'b) t
 end

--- a/src/lib/monad_lib/state.ml
+++ b/src/lib/monad_lib/state.ml
@@ -57,3 +57,42 @@ let filter_map_m ~(f : 'a -> ('b option, 's) t) (xs : 'a list) : ('b list, 's) t
 
 let concat_map_m ~(f : 'a -> ('b list, 's) t) (xs : 'a list) : ('b list, 's) t =
   fold_m ~init:[] ~f:(fun acc x -> map ~f:(List.append acc) (f x)) xs
+
+module Trans (M : Monad.S) = struct
+  module Base = struct
+    type ('a, 's) t = 's -> ('a * 's) M.t
+
+    let return a s = M.return (a, s)
+
+    let map =
+      `Custom
+        (fun m ~f s ->
+          let open M.Let_syntax in
+          let%map a, s' = m s in
+          (f a, s') )
+
+    let bind m ~f s =
+      let open M.Let_syntax in
+      let%bind a, s' = m s in
+      f a s'
+  end
+
+  include Base
+  include Monad.Make2 (Base)
+
+  let get : ('s, 's) t = fun s -> M.return (s, s)
+
+  let getf f s = M.map ~f:(fun (a, s) -> (f a, s)) @@ get s
+
+  let put s : (unit, 's) t = fun _ -> M.return ((), s)
+
+  let modify ~f s = M.return ((), f s)
+
+  let run_state (type a s) (m : (a, s) t) (s : s) : (a * s) M.t = m s
+
+  let eval_state m s = M.map ~f:fst (run_state m s)
+
+  let exec_state m s = M.map ~f:snd (run_state m s)
+
+  let lift : 'a M.t -> ('a, 's) t = fun m s -> M.map m ~f:(fun a -> (a, s))
+end

--- a/src/lib/monad_lib/state.mli
+++ b/src/lib/monad_lib/state.mli
@@ -25,3 +25,23 @@ val map_m : f:('a -> ('b, 's) t) -> 'a list -> ('b list, 's) t
 val filter_map_m : f:('a -> ('b option, 's) t) -> 'a list -> ('b list, 's) t
 
 val concat_map_m : f:('a -> ('b list, 's) t) -> 'a list -> ('b list, 's) t
+
+module Trans : functor (M : Monad.S) -> sig
+  include Monad.S2 with type ('a, 's) t = 's -> ('a * 's) M.t
+
+  val run_state : ('a, 's) t -> 's -> ('a * 's) M.t
+
+  val eval_state : ('a, 's) t -> 's -> 'a M.t
+
+  val exec_state : ('a, 's) t -> 's -> 's M.t
+
+  val get : ('s, 's) t
+
+  val getf : ('s -> 'a) -> ('a, 's) t
+
+  val put : 's -> (unit, 's) t
+
+  val modify : f:('s -> 's) -> (unit, 's) t
+
+  val lift : 'a M.t -> ('a, 's) t
+end

--- a/src/lib/network_pool/command_error.ml
+++ b/src/lib/network_pool/command_error.ml
@@ -1,0 +1,32 @@
+open Mina_base
+
+(* IMPORTANT! Do not change the names of these errors as to adjust the
+ * to_yojson output without updating Rosetta's construction API to handle the
+ * changes *)
+type t =
+  | Invalid_nonce of
+      [ `Expected of Account.Nonce.t
+      | `Between of Account.Nonce.t * Account.Nonce.t ]
+      * Account.Nonce.t
+  | Insufficient_funds of [ `Balance of Currency.Amount.t ] * Currency.Amount.t
+  | (* NOTE: don't punish for this, attackers can induce nodes to banlist
+        each other that way! *)
+      Insufficient_replace_fee of
+      [ `Replace_fee of Currency.Fee.t ] * Currency.Fee.t
+  | Overflow
+  | Bad_token
+  | Expired of
+      [ `Valid_until of Mina_numbers.Global_slot_since_genesis.t ]
+      * [ `Global_slot_since_genesis of Mina_numbers.Global_slot_since_genesis.t
+        ]
+  | Unwanted_fee_token of Token_id.t
+[@@deriving sexp, to_yojson]
+
+let grounds_for_diff_rejection : t -> bool = function
+  | Expired _
+  | Invalid_nonce _
+  | Insufficient_funds _
+  | Insufficient_replace_fee _ ->
+      false
+  | Overflow | Bad_token | Unwanted_fee_token _ ->
+      true

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -3,7 +3,6 @@ open Core
 open Mina_base
 open Mina_transaction
 open Mina_numbers
-open Signature_lib
 
 (* Fee increase required to replace a transaction. *)
 let replace_fee : Currency.Fee.t = Currency.Fee.of_nanomina_int_exn 1
@@ -63,40 +62,6 @@ type t =
 
 let config t = t.config
 
-module Command_error = struct
-  (* IMPORTANT! Do not change the names of these errors as to adjust the
-   * to_yojson output without updating Rosetta's construction API to handle the
-   * changes *)
-  type t =
-    | Invalid_nonce of
-        [ `Expected of Account.Nonce.t
-        | `Between of Account.Nonce.t * Account.Nonce.t ]
-        * Account.Nonce.t
-    | Insufficient_funds of
-        [ `Balance of Currency.Amount.t ] * Currency.Amount.t
-    | (* NOTE: don't punish for this, attackers can induce nodes to banlist
-          each other that way! *)
-        Insufficient_replace_fee of
-        [ `Replace_fee of Currency.Fee.t ] * Currency.Fee.t
-    | Overflow
-    | Bad_token
-    | Expired of
-        [ `Valid_until of Mina_numbers.Global_slot_since_genesis.t ]
-        * [ `Global_slot_since_genesis of
-            Mina_numbers.Global_slot_since_genesis.t ]
-    | Unwanted_fee_token of Token_id.t
-  [@@deriving sexp, to_yojson]
-
-  let grounds_for_diff_rejection : t -> bool = function
-    | Expired _
-    | Invalid_nonce _
-    | Insufficient_funds _
-    | Insufficient_replace_fee _ ->
-        false
-    | Overflow | Bad_token | Unwanted_fee_token _ ->
-        true
-end
-
 (* Compute the total currency required from the sender to execute a command.
    Returns None in case of overflow.
 *)
@@ -136,146 +101,112 @@ let currency_consumed' :
   |> Result.of_option ~error:Command_error.Overflow
 
 module For_tests = struct
-  (* Check the invariants of the pool structure as listed in the comment above.
-  *)
-  let assert_invariants : t -> unit =
-   fun { applicable_by_fee
-       ; all_by_sender
-       ; all_by_fee
-       ; all_by_hash
-       ; size
-       ; config = { constraint_constants; _ }
-       ; _
-       } ->
-    let assert_all_by_fee tx =
-      if
-        Set.mem
-          (Map.find_exn all_by_fee
-             ( Transaction_hash.User_command_with_valid_signature.command tx
-             |> User_command.fee_per_wu ) )
-          tx
-      then ()
-      else
-        failwith
-        @@ sprintf
-             !"Not found in all_by_fee: %{sexp: \
-               Transaction_hash.User_command_with_valid_signature.t }"
-             tx
+  open Currency
+
+  let currency_consumed = currency_consumed
+
+  let applicable_by_fee { applicable_by_fee; _ } = applicable_by_fee
+
+  let all_by_sender { all_by_sender; _ } = all_by_sender
+
+  let assert_pool_consistency (pool : t) =
+    let map_to_set (type k w)
+        (module Map : Map.S
+          with type Key.t = k
+           and type Key.comparator_witness = w ) map =
+      List.fold_left (Map.data map)
+        ~init:Transaction_hash.User_command_with_valid_signature.Set.empty
+        ~f:Set.union
     in
-    let assert_all_by_hash tx =
-      [%test_eq: Transaction_hash.User_command_with_valid_signature.t] tx
-        (Map.find_exn all_by_hash
-           (Transaction_hash.User_command_with_valid_signature.hash tx) )
+    let open Transaction_hash.User_command_with_valid_signature in
+    let all_by_sender =
+      Set.of_list
+        (List.bind
+           ~f:(fun (cmds, _) -> F_sequence.to_list cmds)
+           (Account_id.Map.data pool.all_by_sender) )
     in
-    Map.iteri applicable_by_fee ~f:(fun ~key ~data ->
-        Set.iter data ~f:(fun tx ->
-            let unchecked =
-              Transaction_hash.User_command_with_valid_signature.command tx
-            in
-            [%test_eq: Currency.Fee_rate.t] key
-              (User_command.fee_per_wu unchecked) ;
-            let tx' =
-              Map.find_exn all_by_sender (User_command.fee_payer unchecked)
-              |> Tuple2.get1 |> F_sequence.head_exn
-            in
-            [%test_eq: Transaction_hash.User_command_with_valid_signature.t] tx
-              tx' ;
-            assert_all_by_fee tx ;
-            assert_all_by_hash tx ) ) ;
-    Map.iteri all_by_sender
-      ~f:(fun ~key:fee_payer ~data:(tx_seq, currency_reserved) ->
-        assert (F_sequence.length tx_seq > 0) ;
-        let check_consistent tx =
-          [%test_eq: Account_id.t]
-            ( Transaction_hash.User_command_with_valid_signature.command tx
-            |> User_command.fee_payer )
-            fee_payer ;
-          assert_all_by_fee tx ;
-          assert_all_by_hash tx
-        in
-        let applicable, inapplicables =
-          Option.value_exn (F_sequence.uncons tx_seq)
-        in
-        let applicable_unchecked =
-          Transaction_hash.User_command_with_valid_signature.command applicable
-        in
-        check_consistent applicable ;
-        assert (
-          Set.mem
-            (Map.find_exn applicable_by_fee
-               (User_command.fee_per_wu applicable_unchecked) )
-            applicable ) ;
-        let _last_nonce, currency_reserved' =
+    let all_by_fee = map_to_set (module Fee_rate.Map) pool.all_by_fee in
+    let all_by_hash =
+      Set.of_list @@ Transaction_hash.Map.data pool.all_by_hash
+    in
+    let by_expiration =
+      map_to_set
+        (module Global_slot_since_genesis.Map)
+        pool.transactions_with_expiration
+    in
+    let applicable_by_fee =
+      map_to_set (module Fee_rate.Map) pool.applicable_by_fee
+    in
+    let all_txns =
+      List.fold_left ~f:Set.union ~init:all_by_sender
+        [ all_by_fee; all_by_hash; by_expiration; applicable_by_fee ]
+    in
+    [%test_eq: int] pool.size Set.(length all_txns) ;
+    [%test_eq: Set.t] all_by_hash all_txns ;
+    [%test_eq: Set.t] all_by_sender all_txns ;
+    [%test_eq: Set.t] all_by_fee all_txns ;
+    [%test_eq: Set.t]
+      ( Account_id.Map.data pool.all_by_sender
+      |> List.map ~f:(fun (cmds, _) -> F_sequence.head_exn cmds)
+      |> Set.of_list )
+      applicable_by_fee ;
+    (* In each sender's queue nonces should be strictly increasing and the
+       reserved currency should be equal to the sum of amounts and fees of
+       all the commands in the queue. *)
+    Account_id.Map.iteri pool.all_by_sender
+      ~f:(fun ~key ~data:(queue, reserved_currency) ->
+        [%test_pred:
+          Transaction_hash.User_command_with_valid_signature.t F_sequence.t]
+          (Fn.compose not F_sequence.is_empty)
+          queue ;
+        let _, reserved_currency' =
           F_sequence.foldl
-            (fun (curr_nonce, currency_acc) tx ->
-              let unchecked =
-                Transaction_hash.User_command_with_valid_signature.command tx
+            (fun (last_nonce, reserved) cmd ->
+              let sender =
+                Transaction_hash.User_command_with_valid_signature.command cmd
+                |> User_command.fee_payer
               in
-              [%test_eq: Account_nonce.t]
-                (User_command.applicable_at_nonce unchecked)
-                curr_nonce ;
-              check_consistent tx ;
-              ( User_command.expected_target_nonce unchecked
-              , Option.value_exn
-                  Currency.Amount.(
-                    Option.value_exn
-                      (currency_consumed ~constraint_constants tx)
-                    + currency_acc) ) )
-            ( User_command.expected_target_nonce applicable_unchecked
-            , Option.value_exn
-                (currency_consumed ~constraint_constants applicable) )
-            inapplicables
+              [%test_eq: Account_id.t] sender key ;
+              let nonce =
+                Transaction_hash.User_command_with_valid_signature.command cmd
+                |> User_command.applicable_at_nonce
+              in
+              [%test_pred: Account_nonce.t]
+                (* Last nonce is None only at the very beginning. *)
+                  (fun n ->
+                  Option.value_map last_nonce ~default:true
+                    ~f:Account_nonce.(( > ) n) )
+                nonce ;
+              let consumed =
+                currency_consumed_unchecked
+                  ~constraint_constants:pool.config.constraint_constants
+                  (Transaction_hash.User_command_with_valid_signature.command
+                     cmd )
+                |> Option.value_exn
+              in
+              (Some nonce, Option.value_exn Amount.(reserved + consumed)) )
+            (None, Currency.Amount.zero)
+            queue
         in
-        [%test_eq: Currency.Amount.t] currency_reserved currency_reserved' ) ;
-    let check_sender_applicable fee tx =
-      let unchecked =
-        Transaction_hash.User_command_with_valid_signature.command tx
-      in
-      [%test_eq: Currency.Fee.t] fee (User_command.fee unchecked) ;
-      let sender_txs, _currency_reserved =
-        Map.find_exn all_by_sender (User_command.fee_payer unchecked)
-      in
-      let applicable, _inapplicables =
-        Option.value_exn (F_sequence.uncons sender_txs)
-      in
-      assert (
-        Set.mem
-          (Map.find_exn applicable_by_fee
-             ( applicable
-             |> Transaction_hash.User_command_with_valid_signature.command
-             |> User_command.fee_per_wu ) )
-          applicable ) ;
-      let tx' =
-        F_sequence.find sender_txs ~f:(fun cmd ->
-            let applicable_at_nonce =
-              cmd |> Transaction_hash.User_command_with_valid_signature.command
-              |> User_command.applicable_at_nonce
-            in
-            Account_nonce.equal applicable_at_nonce
-            @@ User_command.applicable_at_nonce unchecked )
-        |> Option.value_exn
-      in
-      [%test_eq: Transaction_hash.User_command_with_valid_signature.t] tx tx'
+        [%test_eq: Currency.Amount.t] reserved_currency reserved_currency' ) ;
+    (* Check that commands are placed under correct keys. *)
+    let check_fee fee cmd =
+      [%test_eq: Currency.Fee_rate.t]
+        (User_command.fee_per_wu
+           (Transaction_hash.User_command_with_valid_signature.command cmd) )
+        fee
     in
-    Map.iteri all_by_fee ~f:(fun ~key:fee_per_wu ~data:tx_set ->
-        Set.iter tx_set ~f:(fun tx ->
-            let command =
-              Transaction_hash.User_command_with_valid_signature.command tx
-            in
-            let wu = User_command.weight command in
-            let fee =
-              Currency.Fee_rate.scale_exn fee_per_wu wu
-              |> Currency.Fee_rate.to_uint64_exn |> Currency.Fee.of_uint64
-            in
-            check_sender_applicable fee tx ;
-            assert_all_by_hash tx ) ) ;
-    Map.iter all_by_hash ~f:(fun tx ->
-        check_sender_applicable
-          (User_command.fee
-             (Transaction_hash.User_command_with_valid_signature.command tx) )
-          tx ;
-        assert_all_by_fee tx ) ;
-    [%test_eq: int] (Map.length all_by_hash) size
+    let is_not_empty = Fn.compose not Set.is_empty in
+    Currency.Fee_rate.Map.iteri pool.applicable_by_fee ~f:(fun ~key ~data ->
+        [%test_pred: Set.t] is_not_empty data ;
+        Set.iter data ~f:(check_fee key) ) ;
+    Currency.Fee_rate.Map.iteri pool.all_by_fee ~f:(fun ~key ~data ->
+        [%test_pred: Set.t] is_not_empty data ;
+        Set.iter data ~f:(check_fee key) ) ;
+    Transaction_hash.Map.iteri pool.all_by_hash ~f:(fun ~key ~data ->
+        [%test_eq: Transaction_hash.t]
+          (Transaction_hash.User_command_with_valid_signature.hash data)
+          key )
 end
 
 let empty ~constraint_constants ~consensus_constants ~time_controller : t =
@@ -1281,707 +1212,3 @@ let add_from_backtrack :
       }
 
 let global_slot_since_genesis t = global_slot_since_genesis t.config
-
-(* Only show stdout for failed inline tests. *)
-open Inline_test_quiet_logs
-
-let%test_module _ =
-  ( module struct
-    open For_tests
-
-    let test_keys = Array.init 10 ~f:(fun _ -> Signature_lib.Keypair.create ())
-
-    let gen_cmd ?sign_type ?nonce () =
-      User_command.Valid.Gen.payment_with_random_participants ~keys:test_keys
-        ~max_amount:1000 ~fee_range:10 ?sign_type ?nonce ()
-      |> Quickcheck.Generator.map
-           ~f:Transaction_hash.User_command_with_valid_signature.create
-
-    let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
-
-    let constraint_constants = precomputed_values.constraint_constants
-
-    let consensus_constants = precomputed_values.consensus_constants
-
-    let logger = Logger.null ()
-
-    let time_controller = Block_time.Controller.basic ~logger
-
-    let empty =
-      empty ~constraint_constants ~consensus_constants ~time_controller
-
-    let%test_unit "empty invariants" = assert_invariants empty
-
-    let%test_unit "singleton properties" =
-      Quickcheck.test (gen_cmd ()) ~f:(fun cmd ->
-          let pool = empty in
-          let add_res =
-            add_from_gossip_exn pool cmd Account_nonce.zero
-              (Currency.Amount.of_nanomina_int_exn 500)
-          in
-          if
-            Option.value_exn (currency_consumed ~constraint_constants cmd)
-            |> Currency.Amount.to_nanomina_int > 500
-          then
-            match add_res with
-            | Error (Insufficient_funds _) ->
-                ()
-            | _ ->
-                failwith "should've returned insufficient_funds"
-          else
-            match add_res with
-            | Ok (_, pool', dropped) ->
-                assert_invariants pool' ;
-                assert (Sequence.is_empty dropped) ;
-                [%test_eq: int] (size pool') 1 ;
-                [%test_eq:
-                  Transaction_hash.User_command_with_valid_signature.t option]
-                  (get_highest_fee pool') (Some cmd) ;
-                let dropped', pool'' = remove_lowest_fee pool' in
-                [%test_eq:
-                  Transaction_hash.User_command_with_valid_signature.t
-                  Sequence.t] dropped' (Sequence.singleton cmd) ;
-                [%test_eq: t] ~equal pool pool''
-            | _ ->
-                failwith "should've succeeded" )
-
-    let%test_unit "sequential adds (all valid)" =
-      let gen :
-          ( Mina_ledger.Ledger.init_state
-          * Transaction_hash.User_command_with_valid_signature.t list )
-          Quickcheck.Generator.t =
-        let open Quickcheck.Generator.Let_syntax in
-        let%bind ledger_init = Mina_ledger.Ledger.gen_initial_ledger_state in
-        let%map cmds = User_command.Valid.Gen.sequence ledger_init in
-        ( ledger_init
-        , List.map ~f:Transaction_hash.User_command_with_valid_signature.create
-            cmds )
-      in
-      let shrinker :
-          ( Mina_ledger.Ledger.init_state
-          * Transaction_hash.User_command_with_valid_signature.t list )
-          Quickcheck.Shrinker.t =
-        Quickcheck.Shrinker.create (fun (init_state, cmds) ->
-            Sequence.singleton
-              (init_state, List.take cmds (List.length cmds - 1)) )
-      in
-      Quickcheck.test gen ~trials:1000
-        ~sexp_of:
-          [%sexp_of:
-            Mina_ledger.Ledger.init_state
-            * Transaction_hash.User_command_with_valid_signature.t list]
-        ~shrinker ~shrink_attempts:`Exhaustive ~seed:(`Deterministic "d")
-        ~sizes:(Sequence.repeat 10) ~f:(fun (ledger_init, cmds) ->
-          let account_init_states_seq = Array.to_sequence ledger_init in
-          let balances = Hashtbl.create (module Public_key.Compressed) in
-          let nonces = Hashtbl.create (module Public_key.Compressed) in
-          Sequence.iter account_init_states_seq
-            ~f:(fun (kp, balance, nonce, _) ->
-              let compressed = Public_key.compress kp.public_key in
-              Hashtbl.add_exn balances ~key:compressed ~data:balance ;
-              Hashtbl.add_exn nonces ~key:compressed ~data:nonce ) ;
-          let pool = ref empty in
-          let rec go cmds_acc =
-            match cmds_acc with
-            | [] ->
-                ()
-            | cmd :: rest -> (
-                let unchecked =
-                  Transaction_hash.User_command_with_valid_signature.command cmd
-                in
-                let account_id = User_command.fee_payer unchecked in
-                let pk = Account_id.public_key account_id in
-                let add_res =
-                  add_from_gossip_exn !pool cmd
-                    (Hashtbl.find_exn nonces pk)
-                    (Hashtbl.find_exn balances pk)
-                in
-                match add_res with
-                | Ok (_, pool', dropped) ->
-                    [%test_eq:
-                      Transaction_hash.User_command_with_valid_signature.t
-                      Sequence.t] dropped Sequence.empty ;
-                    assert_invariants pool' ;
-                    pool := pool' ;
-                    go rest
-                | Error (Invalid_nonce (`Expected want, got)) ->
-                    failwithf
-                      !"Bad nonce. Expected: %{sexp: Account.Nonce.t}. Got: \
-                        %{sexp: Account.Nonce.t}"
-                      want got ()
-                | Error (Invalid_nonce (`Between (low, high), got)) ->
-                    failwithf
-                      !"Bad nonce. Expected between %{sexp: Account.Nonce.t} \
-                        and %{sexp:Account.Nonce.t}. Got: %{sexp: \
-                        Account.Nonce.t}"
-                      low high got ()
-                | Error (Insufficient_funds (`Balance bal, amt)) ->
-                    failwithf
-                      !"Insufficient funds. Balance: %{sexp: \
-                        Currency.Amount.t}. Amount: %{sexp: Currency.Amount.t}"
-                      bal amt ()
-                | Error (Insufficient_replace_fee (`Replace_fee rfee, fee)) ->
-                    failwithf
-                      !"Insufficient fee for replacement. Needed at least \
-                        %{sexp: Currency.Fee.t} but got \
-                        %{sexp:Currency.Fee.t}."
-                      rfee fee ()
-                | Error Overflow ->
-                    failwith "Overflow."
-                | Error Bad_token ->
-                    failwith "Token is incompatible with the command."
-                | Error (Unwanted_fee_token fee_token) ->
-                    failwithf
-                      !"Bad fee token. The fees are paid in token %{sexp: \
-                        Token_id.t}, which we are not accepting fees in."
-                      fee_token ()
-                | Error
-                    (Expired
-                      ( `Valid_until valid_until
-                      , `Global_slot_since_genesis global_slot_since_genesis )
-                      ) ->
-                    failwithf
-                      !"Expired user command. Current global slot is \
-                        %{sexp:Mina_numbers.Global_slot_since_genesis.t} but \
-                        user command is only valid until \
-                        %{sexp:Mina_numbers.Global_slot_since_genesis.t}"
-                      global_slot_since_genesis valid_until () )
-          in
-          go cmds )
-
-    let%test_unit "replacement" =
-      let modify_payment (c : User_command.t) ~sender ~common:fc ~body:fb =
-        let modified_payload : Signed_command.Payload.t =
-          match c with
-          | Signed_command
-              { payload = { body = Payment payment_payload; common }; _ } ->
-              { common = fc common
-              ; body = Signed_command.Payload.Body.Payment (fb payment_payload)
-              }
-          | _ ->
-              failwith "generated user command that wasn't a payment"
-        in
-        Signed_command
-          (Signed_command.For_tests.fake_sign sender modified_payload)
-        |> Transaction_hash.User_command_with_valid_signature.create
-      in
-      let gen :
-          ( Account_nonce.t
-          * Currency.Amount.t
-          * Transaction_hash.User_command_with_valid_signature.t list
-          * Transaction_hash.User_command_with_valid_signature.t )
-          Quickcheck.Generator.t =
-        let open Quickcheck.Generator.Let_syntax in
-        let%bind sender_index = Int.gen_incl 0 9 in
-        let sender = test_keys.(sender_index) in
-        let%bind init_nonce =
-          Quickcheck.Generator.map ~f:Account_nonce.of_int
-          @@ Int.gen_incl 0 1000
-        in
-        let init_balance = Currency.Amount.of_mina_int_exn 100_000 in
-        let%bind size = Quickcheck.Generator.size in
-        let%bind amounts =
-          Quickcheck.Generator.map ~f:Array.of_list
-          @@ Quickcheck_lib.gen_division_currency init_balance (size + 1)
-        in
-        let rec go current_nonce current_balance n =
-          if n > 0 then
-            let%bind cmd =
-              let key_gen =
-                Quickcheck.Generator.tuple2 (return sender)
-                  (Quickcheck_lib.of_array test_keys)
-              in
-              Mina_generators.User_command_generators.payment ~sign_type:`Fake
-                ~key_gen ~nonce:current_nonce ~max_amount:1 ~fee_range:0 ()
-            in
-            let cmd_currency = amounts.(n - 1) in
-            let%bind fee =
-              Currency.Amount.(
-                gen_incl zero (min (of_nanomina_int_exn 10) cmd_currency))
-            in
-            let amount =
-              Option.value_exn Currency.Amount.(cmd_currency - fee)
-            in
-            let cmd' =
-              modify_payment cmd ~sender
-                ~common:(fun c -> { c with fee = Currency.Amount.to_fee fee })
-                ~body:(fun b -> { b with amount })
-            in
-            let consumed =
-              Option.value_exn (currency_consumed ~constraint_constants cmd')
-            in
-            let%map rest =
-              go
-                (Account_nonce.succ current_nonce)
-                (Option.value_exn Currency.Amount.(current_balance - consumed))
-                (n - 1)
-            in
-            cmd' :: rest
-          else return []
-        in
-        let%bind setup_cmds = go init_nonce init_balance (size + 1) in
-        let init_nonce_int = Account.Nonce.to_int init_nonce in
-        let%bind replaced_nonce =
-          Int.gen_incl init_nonce_int
-            (init_nonce_int + List.length setup_cmds - 1)
-        in
-        let%map replace_cmd_skeleton =
-          let key_gen =
-            Quickcheck.Generator.tuple2 (return sender)
-              (Quickcheck_lib.of_array test_keys)
-          in
-          Mina_generators.User_command_generators.payment ~sign_type:`Fake
-            ~key_gen
-            ~nonce:(Account_nonce.of_int replaced_nonce)
-            ~max_amount:(Currency.Amount.to_nanomina_int init_balance)
-            ~fee_range:0 ()
-        in
-        let replace_cmd =
-          modify_payment replace_cmd_skeleton ~sender ~body:Fn.id
-            ~common:(fun c ->
-              { c with
-                fee = Currency.Fee.of_mina_int_exn (10 + (5 * (size + 1)))
-              } )
-        in
-        (init_nonce, init_balance, setup_cmds, replace_cmd)
-      in
-      Quickcheck.test ~trials:20 gen
-        ~sexp_of:
-          [%sexp_of:
-            Account_nonce.t
-            * Currency.Amount.t
-            * Transaction_hash.User_command_with_valid_signature.t list
-            * Transaction_hash.User_command_with_valid_signature.t]
-        ~f:(fun (init_nonce, init_balance, setup_cmds, replace_cmd) ->
-          let t =
-            List.fold_left setup_cmds ~init:empty ~f:(fun t cmd ->
-                match add_from_gossip_exn t cmd init_nonce init_balance with
-                | Ok (_, t', removed) ->
-                    [%test_eq:
-                      Transaction_hash.User_command_with_valid_signature.t
-                      Sequence.t] removed Sequence.empty ;
-                    t'
-                | _ ->
-                    failwith
-                    @@ sprintf
-                         !"adding command %{sexp: \
-                           Transaction_hash.User_command_with_valid_signature.t} \
-                           failed"
-                         cmd )
-          in
-          let replaced_idx, _ =
-            let replace_nonce =
-              replace_cmd
-              |> Transaction_hash.User_command_with_valid_signature.command
-              |> User_command.applicable_at_nonce
-            in
-            List.findi setup_cmds ~f:(fun _i cmd ->
-                let cmd_nonce =
-                  cmd
-                  |> Transaction_hash.User_command_with_valid_signature.command
-                  |> User_command.applicable_at_nonce
-                in
-                Account_nonce.compare replace_nonce cmd_nonce <= 0 )
-            |> Option.value_exn
-          in
-          let currency_consumed_pre_replace =
-            List.fold_left
-              (List.take setup_cmds (replaced_idx + 1))
-              ~init:Currency.Amount.zero
-              ~f:(fun consumed_so_far cmd ->
-                Option.value_exn
-                  Option.(
-                    currency_consumed ~constraint_constants cmd
-                    >>= fun consumed ->
-                    Currency.Amount.(consumed + consumed_so_far)) )
-          in
-          assert (
-            Currency.Amount.(currency_consumed_pre_replace <= init_balance) ) ;
-          let currency_consumed_post_replace =
-            Option.value_exn
-              (let open Option.Let_syntax in
-              let%bind replaced_currency_consumed =
-                currency_consumed ~constraint_constants
-                @@ List.nth_exn setup_cmds replaced_idx
-              in
-              let%bind replacer_currency_consumed =
-                currency_consumed ~constraint_constants replace_cmd
-              in
-              let%bind a =
-                Currency.Amount.(
-                  currency_consumed_pre_replace - replaced_currency_consumed)
-              in
-              Currency.Amount.(a + replacer_currency_consumed))
-          in
-          let add_res =
-            add_from_gossip_exn t replace_cmd init_nonce init_balance
-          in
-          if Currency.Amount.(currency_consumed_post_replace <= init_balance)
-          then
-            match add_res with
-            | Ok (_, t', dropped) ->
-                assert (not (Sequence.is_empty dropped)) ;
-                assert_invariants t'
-            | Error _ ->
-                failwith "adding command failed"
-          else
-            match add_res with
-            | Error (Insufficient_funds _) ->
-                ()
-            | _ ->
-                failwith "should've returned insufficient_funds" )
-
-    let%test_unit "remove_lowest_fee" =
-      let cmds =
-        gen_cmd () |> Quickcheck.random_sequence |> Fn.flip Sequence.take 4
-        |> Sequence.to_list
-      in
-      let compare cmd0 cmd1 : int =
-        let open Transaction_hash.User_command_with_valid_signature in
-        Currency.Fee_rate.compare
-          (User_command.fee_per_wu @@ command cmd0)
-          (User_command.fee_per_wu @@ command cmd1)
-      in
-      let cmds_sorted_by_fee_per_wu = List.sort ~compare cmds in
-      let cmd_lowest_fee, commands_to_keep =
-        ( List.hd_exn cmds_sorted_by_fee_per_wu
-        , List.tl_exn cmds_sorted_by_fee_per_wu )
-      in
-      let insert_cmd pool cmd =
-        add_from_gossip_exn pool cmd Account_nonce.zero
-          (Currency.Amount.of_mina_int_exn 5)
-        |> Result.ok |> Option.value_exn
-        |> fun (_, pool, _) -> pool
-      in
-      let cmd_equal =
-        Transaction_hash.User_command_with_valid_signature.equal
-      in
-      let removed, pool =
-        List.fold_left cmds ~init:empty ~f:insert_cmd |> remove_lowest_fee
-      in
-      (* check that the lowest fee per wu command is returned *)
-      assert (Sequence.(equal cmd_equal removed @@ return cmd_lowest_fee))
-      |> fun () ->
-      (* check that the lowest fee per wu command is removed from
-         applicable_by_fee *)
-      pool.applicable_by_fee |> Map.data
-      |> List.concat_map ~f:Set.to_list
-      |> fun applicable_by_fee_cmds ->
-      assert (List.(equal cmd_equal applicable_by_fee_cmds commands_to_keep))
-      |> fun () ->
-      (* check that the lowest fee per wu command is removed from
-         all_by_fee *)
-      pool.applicable_by_fee |> Map.data
-      |> List.concat_map ~f:Set.to_list
-      |> fun all_by_fee_cmds ->
-      assert (List.(equal cmd_equal all_by_fee_cmds commands_to_keep))
-
-    let%test_unit "get_highest_fee" =
-      let cmds =
-        gen_cmd () |> Quickcheck.random_sequence |> Fn.flip Sequence.take 4
-        |> Sequence.to_list
-      in
-      let compare cmd0 cmd1 : int =
-        let open Transaction_hash.User_command_with_valid_signature in
-        Currency.Fee_rate.compare
-          (User_command.fee_per_wu @@ command cmd0)
-          (User_command.fee_per_wu @@ command cmd1)
-      in
-      let max_by_fee_per_wu = List.max_elt ~compare cmds |> Option.value_exn in
-      let insert_cmd pool cmd =
-        add_from_gossip_exn pool cmd Account_nonce.zero
-          (Currency.Amount.of_mina_int_exn 5)
-        |> Result.ok |> Option.value_exn
-        |> fun (_, pool, _) -> pool
-      in
-      let pool = List.fold_left cmds ~init:empty ~f:insert_cmd in
-      let cmd_equal =
-        Transaction_hash.User_command_with_valid_signature.equal
-      in
-      get_highest_fee pool |> Option.value_exn
-      |> fun highest_fee -> assert (cmd_equal highest_fee max_by_fee_per_wu)
-
-    let dummy_state_view =
-      let state_body =
-        let consensus_constants =
-          let genesis_constants = Genesis_constants.for_unit_tests in
-          Consensus.Constants.create ~constraint_constants
-            ~protocol_constants:genesis_constants.protocol
-        in
-        let compile_time_genesis =
-          (*not using Precomputed_values.for_unit_test because of dependency cycle*)
-          Mina_state.Genesis_protocol_state.t
-            ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
-            ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
-            ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
-            ~constraint_constants ~consensus_constants
-        in
-        compile_time_genesis.data |> Mina_state.Protocol_state.body
-      in
-      { (Mina_state.Protocol_state.Body.view state_body) with
-        global_slot_since_genesis = Mina_numbers.Global_slot_since_genesis.zero
-      }
-
-    let add_to_pool ~nonce ~balance pool cmd =
-      let _, pool', dropped =
-        add_from_gossip_exn pool cmd nonce balance
-        |> Result.map_error
-             ~f:(Fn.compose Sexp.to_string Command_error.sexp_of_t)
-        |> Result.ok_or_failwith
-      in
-      [%test_eq:
-        Transaction_hash.User_command_with_valid_signature.t Sequence.t] dropped
-        Sequence.empty ;
-      assert_invariants pool' ;
-      pool'
-
-    let init_permissionless_ledger ledger account_info =
-      let open Currency in
-      let open Mina_ledger.Ledger.Ledger_inner in
-      List.iter account_info ~f:(fun (public_key, amount) ->
-          let account_id =
-            Account_id.create (Public_key.compress public_key) Token_id.default
-          in
-          let balance =
-            Balance.of_nanomina_int_exn @@ Amount.to_nanomina_int amount
-          in
-          let _tag, account, location =
-            Or_error.ok_exn (get_or_create ledger account_id)
-          in
-          set ledger location
-            { account with balance; permissions = Permissions.empty } )
-
-    let apply_to_ledger ledger cmd =
-      match Transaction_hash.User_command_with_valid_signature.command cmd with
-      | User_command.Signed_command c ->
-          let (`If_this_is_used_it_should_have_a_comment_justifying_it v) =
-            Signed_command.to_valid_unsafe c
-          in
-          ignore
-            ( Mina_ledger.Ledger.apply_user_command ~constraint_constants
-                ~txn_global_slot:Mina_numbers.Global_slot_since_genesis.zero
-                ledger v
-              |> Or_error.ok_exn
-              : Mina_transaction_logic.Transaction_applied
-                .Signed_command_applied
-                .t )
-      | User_command.Zkapp_command p -> (
-          let applied, _ =
-            Mina_ledger.Ledger.apply_zkapp_command_unchecked
-              ~constraint_constants
-              ~global_slot:dummy_state_view.global_slot_since_genesis
-              ~state_view:dummy_state_view ledger p
-            |> Or_error.ok_exn
-          in
-          match With_status.status applied.command with
-          | Transaction_status.Applied ->
-              ()
-          | Transaction_status.Failed failure ->
-              failwithf
-                "failed to apply zkapp_command transaction to ledger: [%s]"
-                ( String.concat ~sep:", "
-                @@ List.bind
-                     ~f:(List.map ~f:Transaction_status.Failure.to_string)
-                     failure )
-                () )
-
-    let commit_to_pool ledger pool cmd expected_drops =
-      apply_to_ledger ledger cmd ;
-      let accounts_to_check =
-        Transaction_hash.User_command_with_valid_signature.command cmd
-        |> User_command.accounts_referenced |> Account_id.Set.of_list
-      in
-      let pool, dropped =
-        revalidate pool ~logger (`Subset accounts_to_check) (fun sender ->
-            match Mina_ledger.Ledger.location_of_account ledger sender with
-            | None ->
-                Account.empty
-            | Some loc ->
-                Option.value_exn
-                  ~message:"Somehow a public key has a location but no account"
-                  (Mina_ledger.Ledger.get ledger loc) )
-      in
-      let lower =
-        List.map ~f:Transaction_hash.User_command_with_valid_signature.hash
-      in
-      [%test_eq: Transaction_hash.t list]
-        (lower (Sequence.to_list dropped))
-        (lower expected_drops) ;
-      assert_invariants pool ;
-      pool
-
-    let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
-        ~double_increment_sender ~increment_receiver ~amount ~fee nonce_int =
-      let open Currency in
-      let nonce = Account.Nonce.of_int nonce_int in
-      let sender_pk = Public_key.compress sender.public_key in
-      let receiver_pk = Public_key.compress receiver.public_key in
-      let zkapp_command_wire : Zkapp_command.Stable.Latest.Wire.t =
-        { fee_payer =
-            { Account_update.Fee_payer.body =
-                { public_key = sender_pk; fee; nonce; valid_until = None }
-                (* Real signature added in below *)
-            ; authorization = Signature.dummy
-            }
-        ; account_updates =
-            Zkapp_command.Call_forest.of_account_updates
-              ~account_update_depth:(Fn.const 0)
-              [ { Account_update.body =
-                    { public_key = sender_pk
-                    ; update = Account_update.Update.noop
-                    ; token_id = Token_id.default
-                    ; balance_change =
-                        Amount.Signed.(negate @@ of_unsigned amount)
-                    ; increment_nonce = double_increment_sender
-                    ; events = []
-                    ; actions = []
-                    ; call_data = Snark_params.Tick.Field.zero
-                    ; preconditions =
-                        { Account_update.Preconditions.network =
-                            Zkapp_precondition.Protocol_state.accept
-                        ; account =
-                            Account_update.Account_precondition.Nonce
-                              (Account.Nonce.succ nonce)
-                        ; valid_while = Ignore
-                        }
-                    ; may_use_token = No
-                    ; use_full_commitment = not double_increment_sender
-                    ; implicit_account_creation_fee = false
-                    ; authorization_kind = None_given
-                    }
-                ; authorization = None_given
-                }
-              ; { Account_update.body =
-                    { public_key = receiver_pk
-                    ; update = Account_update.Update.noop
-                    ; token_id = Token_id.default
-                    ; balance_change = Amount.Signed.of_unsigned amount
-                    ; increment_nonce = increment_receiver
-                    ; events = []
-                    ; actions = []
-                    ; call_data = Snark_params.Tick.Field.zero
-                    ; preconditions =
-                        { Account_update.Preconditions.network =
-                            Zkapp_precondition.Protocol_state.accept
-                        ; account = Account_update.Account_precondition.Accept
-                        ; valid_while = Ignore
-                        }
-                    ; may_use_token = No
-                    ; implicit_account_creation_fee = false
-                    ; use_full_commitment = not increment_receiver
-                    ; authorization_kind = None_given
-                    }
-                ; authorization = None_given
-                }
-              ]
-        ; memo = Signed_command_memo.empty
-        }
-      in
-      let zkapp_command = Zkapp_command.of_wire zkapp_command_wire in
-      (* We skip signing the commitment and updating the authorization as it is not necessary to have a valid transaction for these tests. *)
-      let (`If_this_is_used_it_should_have_a_comment_justifying_it cmd) =
-        User_command.to_valid_unsafe (User_command.Zkapp_command zkapp_command)
-      in
-      Transaction_hash.User_command_with_valid_signature.create cmd
-
-    let%test_unit "support for zkapp_command commands" =
-      let open Currency in
-      (* let open Mina_transaction_logic.For_tests in *)
-      let fee = Currency.Fee.minimum_user_command_fee in
-      let amount = Amount.of_nanomina_int_exn @@ Fee.to_nanomina_int fee in
-      let balance = Option.value_exn (Amount.scale amount 100) in
-      let kp1 =
-        Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
-      in
-      let kp2 =
-        Quickcheck.random_value ~seed:(`Deterministic "orange") Keypair.gen
-      in
-      let add_cmd = add_to_pool ~nonce:Account_nonce.zero ~balance in
-      let make_cmd =
-        make_zkapp_command_payment ~sender:kp1 ~receiver:kp2
-          ~increment_receiver:false ~amount ~fee
-      in
-      Mina_ledger.Ledger.with_ledger ~depth:4 ~f:(fun ledger ->
-          init_permissionless_ledger ledger
-            [ (kp1.public_key, balance); (kp2.public_key, Amount.zero) ] ;
-          let commit = commit_to_pool ledger in
-          let cmd1 = make_cmd ~double_increment_sender:false 0 in
-          let cmd2 = make_cmd ~double_increment_sender:false 1 in
-          let cmd3 = make_cmd ~double_increment_sender:false 2 in
-          let cmd4 = make_cmd ~double_increment_sender:false 3 in
-          (* used to break the sequence *)
-          let cmd3' = make_cmd ~double_increment_sender:true 2 in
-          let pool =
-            List.fold_left [ cmd1; cmd2; cmd3; cmd4 ] ~init:empty ~f:add_cmd
-          in
-          let pool = commit pool cmd1 [ cmd1 ] in
-          let pool = commit pool cmd2 [ cmd2 ] in
-          let _pool = commit pool cmd3' [ cmd3; cmd4 ] in
-          () )
-
-    let%test_unit "nonce increment side effects from other zkapp_command are \
-                   handled properly" =
-      let open Currency in
-      let fee = Currency.Fee.minimum_user_command_fee in
-      let amount = Amount.of_nanomina_int_exn @@ Fee.to_nanomina_int fee in
-      let balance = Option.value_exn (Amount.scale amount 100) in
-      let kp1 =
-        Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
-      in
-      let kp2 =
-        Quickcheck.random_value ~seed:(`Deterministic "orange") Keypair.gen
-      in
-      let add_cmd = add_to_pool ~nonce:Account_nonce.zero ~balance in
-      let make_cmd = make_zkapp_command_payment ~amount ~fee in
-      Mina_ledger.Ledger.with_ledger ~depth:4 ~f:(fun ledger ->
-          init_permissionless_ledger ledger
-            [ (kp1.public_key, balance); (kp2.public_key, balance) ] ;
-          let kp1_cmd1 =
-            make_cmd ~sender:kp1 ~receiver:kp2 ~double_increment_sender:false
-              ~increment_receiver:true 0
-          in
-          let kp2_cmd1 =
-            make_cmd ~sender:kp2 ~receiver:kp1 ~double_increment_sender:false
-              ~increment_receiver:false 0
-          in
-          let kp2_cmd2 =
-            make_cmd ~sender:kp2 ~receiver:kp1 ~double_increment_sender:false
-              ~increment_receiver:false 1
-          in
-          let pool =
-            List.fold_left
-              [ kp1_cmd1; kp2_cmd1; kp2_cmd2 ]
-              ~init:empty ~f:add_cmd
-          in
-          let _pool =
-            commit_to_pool ledger pool kp1_cmd1 [ kp2_cmd1; kp1_cmd1 ]
-          in
-          () )
-
-    let%test_unit "nonce invariant violations on committed transactions does \
-                   not trigger a crash" =
-      let open Currency in
-      let fee = Currency.Fee.minimum_user_command_fee in
-      let amount = Amount.of_nanomina_int_exn @@ Fee.to_nanomina_int fee in
-      let balance = Option.value_exn (Amount.scale amount 100) in
-      let kp1 =
-        Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
-      in
-      let kp2 =
-        Quickcheck.random_value ~seed:(`Deterministic "orange") Keypair.gen
-      in
-      let add_cmd = add_to_pool ~nonce:Account_nonce.zero ~balance in
-      let make_cmd =
-        make_zkapp_command_payment ~sender:kp1 ~receiver:kp2
-          ~double_increment_sender:false ~increment_receiver:false ~amount ~fee
-      in
-      Mina_ledger.Ledger.with_ledger ~depth:4 ~f:(fun ledger ->
-          init_permissionless_ledger ledger
-            [ (kp1.public_key, balance); (kp2.public_key, Amount.zero) ] ;
-          let cmd1 = make_cmd 0 in
-          let cmd2 = make_cmd 1 in
-          let pool = List.fold_left [ cmd1; cmd2 ] ~init:empty ~f:add_cmd in
-          apply_to_ledger ledger cmd1 ;
-          let _pool = commit_to_pool ledger pool cmd2 [ cmd1; cmd2 ] in
-          () )
-  end )

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -9,30 +9,6 @@ open Mina_base
 open Mina_transaction
 open Mina_numbers
 
-module Command_error : sig
-  type t =
-    | Invalid_nonce of
-        [ `Expected of Account.Nonce.t
-        | `Between of Account.Nonce.t * Account.Nonce.t ]
-        * Account.Nonce.t
-    | Insufficient_funds of
-        [ `Balance of Currency.Amount.t ] * Currency.Amount.t
-    | (* NOTE: don't punish for this, attackers can induce nodes to banlist
-          each other that way! *)
-        Insufficient_replace_fee of
-        [ `Replace_fee of Currency.Fee.t ] * Currency.Fee.t
-    | Overflow
-    | Bad_token
-    | Expired of
-        [ `Valid_until of Mina_numbers.Global_slot_since_genesis.t ]
-        * [ `Global_slot_since_genesis of
-            Mina_numbers.Global_slot_since_genesis.t ]
-    | Unwanted_fee_token of Mina_base.Token_id.t
-  [@@deriving sexp, to_yojson]
-
-  val grounds_for_diff_rejection : t -> bool
-end
-
 val replace_fee : Currency.Fee.t
 
 module Config : sig
@@ -48,7 +24,7 @@ module Sender_local_state : sig
 end
 
 (** Transaction pool. This is a purely functional data structure. *)
-type t [@@deriving sexp_of]
+type t [@@deriving equal, compare, sexp_of]
 
 val config : t -> Config.t
 
@@ -160,5 +136,21 @@ val global_slot_since_genesis : t -> Mina_numbers.Global_slot_since_genesis.t
 module For_tests : sig
   (** Checks the invariants of the data structure. If this throws an exception
       there is a bug. *)
-  val assert_invariants : t -> unit
+  val assert_pool_consistency : t -> unit
+
+  val applicable_by_fee :
+       t
+    -> Transaction_hash.User_command_with_valid_signature.Set.t
+       Currency.Fee_rate.Map.t
+
+  val all_by_sender :
+       t
+    -> ( Transaction_hash.User_command_with_valid_signature.t F_sequence.t
+       * Currency.Amount.t )
+       Account_id.Map.t
+
+  val currency_consumed :
+       constraint_constants:Genesis_constants.Constraint_constants.t
+    -> Transaction_hash.User_command_with_valid_signature.t
+    -> Currency.Amount.t option
 end

--- a/src/lib/network_pool/test/dune
+++ b/src/lib/network_pool/test/dune
@@ -1,0 +1,50 @@
+(tests
+ (names main)
+ (libraries
+  ;; opam libraries
+  alcotest
+  async_kernel
+  async_unix
+  base
+  base.caml
+  base.base_internalhash_types
+  core_kernel
+  core
+  integers
+  sexplib0
+  ;; local libraries
+  block_time
+  consensus
+  currency
+  data_hash_lib
+  genesis_constants
+  genesis_ledger
+  logger
+  mina_base
+  mina_base.import
+  mina_generators
+  mina_ledger
+  mina_numbers
+  mina_state
+  mina_transaction_logic
+  mina_wire_types
+  monad_lib
+  network_pool
+  non_zero_curve_point
+  pickles
+  precomputed_values
+  quickcheck_lib
+  signature_lib
+  snark_params
+  staged_ledger_diff
+  mina_transaction
+  with_hash)
+ (preprocess
+  (pps
+   ppx_base
+   ppx_let
+   ppx_custom_printf
+   ppx_assert))
+ (instrumentation
+  (backend bisect_ppx)))
+

--- a/src/lib/network_pool/test/indexed_pool_tests.ml
+++ b/src/lib/network_pool/test/indexed_pool_tests.ml
@@ -1,0 +1,943 @@
+(** Testing
+    -------
+    Component:  Network pool
+    Invocation: dune exec src/lib/network_pool/test/main.exe -- \
+                  test '^indexed pool$'
+    Subject:    Test the indexed pool.
+ *)
+
+open Core_kernel
+open Currency
+open Mina_base
+open Mina_numbers
+open Mina_transaction
+open Signature_lib
+open Network_pool
+open Indexed_pool
+open For_tests
+open Transaction_gen
+
+let logger = Logger.null ()
+
+let time_controller = Block_time.Controller.basic ~logger
+
+let empty = empty ~constraint_constants ~consensus_constants ~time_controller
+
+let empty_invariants () = assert_pool_consistency empty
+
+let singleton_properties () =
+  Quickcheck.test (gen_cmd ()) ~f:(fun cmd ->
+      let pool = empty in
+      let add_res =
+        add_from_gossip_exn pool cmd Account_nonce.zero
+          (Amount.of_nanomina_int_exn 500)
+      in
+      if
+        Option.value_exn (currency_consumed ~constraint_constants cmd)
+        |> Amount.to_nanomina_int > 500
+      then
+        match add_res with
+        | Error (Insufficient_funds _) ->
+            ()
+        | _ ->
+            failwith "should've returned insufficient_funds"
+      else
+        match add_res with
+        | Ok (_, pool', dropped) ->
+            assert_pool_consistency pool' ;
+            assert (Sequence.is_empty dropped) ;
+            [%test_eq: int] (size pool') 1 ;
+            [%test_eq:
+              Transaction_hash.User_command_with_valid_signature.t option]
+              (get_highest_fee pool') (Some cmd) ;
+            let dropped', pool'' = remove_lowest_fee pool' in
+            [%test_eq:
+              Transaction_hash.User_command_with_valid_signature.t Sequence.t]
+              dropped' (Sequence.singleton cmd) ;
+            [%test_eq: t] ~equal pool pool''
+        | _ ->
+            failwith "should've succeeded" )
+
+let sequential_adds_all_valid () =
+  let gen :
+      ( Mina_ledger.Ledger.init_state
+      * Transaction_hash.User_command_with_valid_signature.t list )
+      Quickcheck.Generator.t =
+    let open Quickcheck.Generator.Let_syntax in
+    let%bind ledger_init = Mina_ledger.Ledger.gen_initial_ledger_state in
+    let%map cmds = User_command.Valid.Gen.sequence ledger_init in
+    ( ledger_init
+    , List.map ~f:Transaction_hash.User_command_with_valid_signature.create cmds
+    )
+  in
+  let shrinker :
+      ( Mina_ledger.Ledger.init_state
+      * Transaction_hash.User_command_with_valid_signature.t list )
+      Quickcheck.Shrinker.t =
+    Quickcheck.Shrinker.create (fun (init_state, cmds) ->
+        Sequence.singleton (init_state, List.take cmds (List.length cmds - 1)) )
+  in
+  Quickcheck.test gen ~trials:1000
+    ~sexp_of:
+      [%sexp_of:
+        Mina_ledger.Ledger.init_state
+        * Transaction_hash.User_command_with_valid_signature.t list]
+    ~shrinker ~shrink_attempts:`Exhaustive ~seed:(`Deterministic "d")
+    ~sizes:(Sequence.repeat 10) ~f:(fun (ledger_init, cmds) ->
+      let account_init_states_seq = Array.to_sequence ledger_init in
+      let balances = Hashtbl.create (module Public_key.Compressed) in
+      let nonces = Hashtbl.create (module Public_key.Compressed) in
+      Sequence.iter account_init_states_seq ~f:(fun (kp, balance, nonce, _) ->
+          let compressed = Public_key.compress kp.public_key in
+          Hashtbl.add_exn balances ~key:compressed ~data:balance ;
+          Hashtbl.add_exn nonces ~key:compressed ~data:nonce ) ;
+      let pool = ref empty in
+      let rec go cmds_acc =
+        match cmds_acc with
+        | [] ->
+            ()
+        | cmd :: rest -> (
+            let unchecked =
+              Transaction_hash.User_command_with_valid_signature.command cmd
+            in
+            let account_id = User_command.fee_payer unchecked in
+            let pk = Account_id.public_key account_id in
+            let add_res =
+              add_from_gossip_exn !pool cmd
+                (Hashtbl.find_exn nonces pk)
+                (Hashtbl.find_exn balances pk)
+            in
+            match add_res with
+            | Ok (_, pool', dropped) ->
+                [%test_eq:
+                  Transaction_hash.User_command_with_valid_signature.t
+                  Sequence.t] dropped Sequence.empty ;
+                assert_pool_consistency pool' ;
+                pool := pool' ;
+                go rest
+            | Error (Invalid_nonce (`Expected want, got)) ->
+                failwithf
+                  !"Bad nonce. Expected: %{sexp: Account.Nonce.t}. Got: \
+                    %{sexp: Account.Nonce.t}"
+                  want got ()
+            | Error (Invalid_nonce (`Between (low, high), got)) ->
+                failwithf
+                  !"Bad nonce. Expected between %{sexp: Account.Nonce.t} and \
+                    %{sexp:Account.Nonce.t}. Got: %{sexp: Account.Nonce.t}"
+                  low high got ()
+            | Error (Insufficient_funds (`Balance bal, amt)) ->
+                failwithf
+                  !"Insufficient funds. Balance: %{sexp: Amount.t}. Amount: \
+                    %{sexp: Amount.t}"
+                  bal amt ()
+            | Error (Insufficient_replace_fee (`Replace_fee rfee, fee)) ->
+                failwithf
+                  !"Insufficient fee for replacement. Needed at least %{sexp: \
+                    Fee.t} but got %{sexp:Fee.t}."
+                  rfee fee ()
+            | Error Overflow ->
+                failwith "Overflow."
+            | Error Bad_token ->
+                failwith "Token is incompatible with the command."
+            | Error (Unwanted_fee_token fee_token) ->
+                failwithf
+                  !"Bad fee token. The fees are paid in token %{sexp: \
+                    Token_id.t}, which we are not accepting fees in."
+                  fee_token ()
+            | Error
+                (Expired
+                  ( `Valid_until valid_until
+                  , `Global_slot_since_genesis global_slot_since_genesis ) ) ->
+                failwithf
+                  !"Expired user command. Current global slot is \
+                    %{sexp:Mina_numbers.Global_slot_since_genesis.t} but user \
+                    command is only valid until \
+                    %{sexp:Mina_numbers.Global_slot_since_genesis.t}"
+                  global_slot_since_genesis valid_until () )
+      in
+      go cmds )
+
+let replacement () =
+  let modify_payment (c : User_command.t) ~sender ~common:fc ~body:fb =
+    let modified_payload : Signed_command.Payload.t =
+      match c with
+      | Signed_command
+          { payload = { body = Payment payment_payload; common }; _ } ->
+          { common = fc common
+          ; body = Signed_command.Payload.Body.Payment (fb payment_payload)
+          }
+      | _ ->
+          failwith "generated user command that wasn't a payment"
+    in
+    Signed_command (Signed_command.For_tests.fake_sign sender modified_payload)
+    |> Transaction_hash.User_command_with_valid_signature.create
+  in
+  let gen :
+      ( Account_nonce.t
+      * Amount.t
+      * Transaction_hash.User_command_with_valid_signature.t list
+      * Transaction_hash.User_command_with_valid_signature.t )
+      Quickcheck.Generator.t =
+    let open Quickcheck.Generator.Let_syntax in
+    let%bind sender_index = Int.gen_incl 0 9 in
+    let sender = test_keys.(sender_index) in
+    let%bind init_nonce =
+      Quickcheck.Generator.map ~f:Account_nonce.of_int @@ Int.gen_incl 0 1000
+    in
+    let init_balance = Amount.of_mina_int_exn 100_000 in
+    let%bind size = Quickcheck.Generator.size in
+    let%bind amounts =
+      Quickcheck.Generator.map ~f:Array.of_list
+      @@ Quickcheck_lib.gen_division_currency init_balance (size + 1)
+    in
+    let rec go current_nonce current_balance n =
+      if n > 0 then
+        let%bind cmd =
+          let key_gen =
+            Quickcheck.Generator.tuple2 (return sender)
+              (Quickcheck_lib.of_array test_keys)
+          in
+          Mina_generators.User_command_generators.payment ~sign_type:`Fake
+            ~key_gen ~nonce:current_nonce ~max_amount:1 ~fee_range:0 ()
+        in
+        let cmd_currency = amounts.(n - 1) in
+        let%bind fee =
+          Amount.(gen_incl zero (min (of_nanomina_int_exn 10) cmd_currency))
+        in
+        let amount = Option.value_exn Amount.(cmd_currency - fee) in
+        let cmd' =
+          modify_payment cmd ~sender
+            ~common:(fun c -> { c with fee = Amount.to_fee fee })
+            ~body:(fun b -> { b with amount })
+        in
+        let consumed =
+          Option.value_exn (currency_consumed ~constraint_constants cmd')
+        in
+        let%map rest =
+          go
+            (Account_nonce.succ current_nonce)
+            (Option.value_exn Amount.(current_balance - consumed))
+            (n - 1)
+        in
+        cmd' :: rest
+      else return []
+    in
+    let%bind setup_cmds = go init_nonce init_balance (size + 1) in
+    let init_nonce_int = Account.Nonce.to_int init_nonce in
+    let%bind replaced_nonce =
+      Int.gen_incl init_nonce_int (init_nonce_int + List.length setup_cmds - 1)
+    in
+    let%map replace_cmd_skeleton =
+      let key_gen =
+        Quickcheck.Generator.tuple2 (return sender)
+          (Quickcheck_lib.of_array test_keys)
+      in
+      Mina_generators.User_command_generators.payment ~sign_type:`Fake ~key_gen
+        ~nonce:(Account_nonce.of_int replaced_nonce)
+        ~max_amount:(Amount.to_nanomina_int init_balance)
+        ~fee_range:0 ()
+    in
+    let replace_cmd =
+      modify_payment replace_cmd_skeleton ~sender ~body:Fn.id ~common:(fun c ->
+          { c with fee = Fee.of_mina_int_exn (10 + (5 * (size + 1))) } )
+    in
+    (init_nonce, init_balance, setup_cmds, replace_cmd)
+  in
+  Quickcheck.test ~trials:20 gen
+    ~sexp_of:
+      [%sexp_of:
+        Account_nonce.t
+        * Amount.t
+        * Transaction_hash.User_command_with_valid_signature.t list
+        * Transaction_hash.User_command_with_valid_signature.t]
+    ~f:(fun (init_nonce, init_balance, setup_cmds, replace_cmd) ->
+      let t =
+        List.fold_left setup_cmds ~init:empty ~f:(fun t cmd ->
+            match add_from_gossip_exn t cmd init_nonce init_balance with
+            | Ok (_, t', removed) ->
+                assert_pool_consistency t' ;
+                [%test_eq:
+                  Transaction_hash.User_command_with_valid_signature.t
+                  Sequence.t] removed Sequence.empty ;
+                t'
+            | _ ->
+                failwith
+                @@ sprintf
+                     !"adding command %{sexp: \
+                       Transaction_hash.User_command_with_valid_signature.t} \
+                       failed"
+                     cmd )
+      in
+      let replaced_idx, _ =
+        let replace_nonce =
+          replace_cmd
+          |> Transaction_hash.User_command_with_valid_signature.command
+          |> User_command.applicable_at_nonce
+        in
+        List.findi setup_cmds ~f:(fun _i cmd ->
+            let cmd_nonce =
+              cmd |> Transaction_hash.User_command_with_valid_signature.command
+              |> User_command.applicable_at_nonce
+            in
+            Account_nonce.compare replace_nonce cmd_nonce <= 0 )
+        |> Option.value_exn
+      in
+      let currency_consumed_pre_replace =
+        List.fold_left
+          (List.take setup_cmds (replaced_idx + 1))
+          ~init:Amount.zero
+          ~f:(fun consumed_so_far cmd ->
+            Option.value_exn
+              Option.(
+                currency_consumed ~constraint_constants cmd
+                >>= fun consumed -> Amount.(consumed + consumed_so_far)) )
+      in
+      assert (Amount.(currency_consumed_pre_replace <= init_balance)) ;
+      let currency_consumed_post_replace =
+        Option.value_exn
+          (let open Option.Let_syntax in
+          let%bind replaced_currency_consumed =
+            currency_consumed ~constraint_constants
+            @@ List.nth_exn setup_cmds replaced_idx
+          in
+          let%bind replacer_currency_consumed =
+            currency_consumed ~constraint_constants replace_cmd
+          in
+          let%bind a =
+            Amount.(currency_consumed_pre_replace - replaced_currency_consumed)
+          in
+          Amount.(a + replacer_currency_consumed))
+      in
+      let add_res = add_from_gossip_exn t replace_cmd init_nonce init_balance in
+      if Amount.(currency_consumed_post_replace <= init_balance) then
+        match add_res with
+        | Ok (_, t', dropped) ->
+            assert (not (Sequence.is_empty dropped)) ;
+            assert_pool_consistency t'
+        | Error e ->
+            Command_error.sexp_of_t e |> Sexp.to_string_hum |> failwith
+      else
+        match add_res with
+        | Error (Insufficient_funds _) ->
+            ()
+        | _ ->
+            failwith "should've returned insufficient_funds" )
+
+let remove_lowest_fee () =
+  let cmds =
+    gen_cmd () |> Quickcheck.random_sequence |> Fn.flip Sequence.take 4
+    |> Sequence.to_list
+  in
+  let compare cmd0 cmd1 : int =
+    let open Transaction_hash.User_command_with_valid_signature in
+    Fee_rate.compare
+      (User_command.fee_per_wu @@ command cmd0)
+      (User_command.fee_per_wu @@ command cmd1)
+  in
+  let cmds_sorted_by_fee_per_wu = List.sort ~compare cmds in
+  let cmd_lowest_fee, commands_to_keep =
+    ( List.hd_exn cmds_sorted_by_fee_per_wu
+    , List.tl_exn cmds_sorted_by_fee_per_wu )
+  in
+  let insert_cmd pool cmd =
+    add_from_gossip_exn pool cmd Account_nonce.zero (Amount.of_mina_int_exn 5)
+    |> Result.ok |> Option.value_exn
+    |> fun (_, pool, _) -> pool
+  in
+  let cmd_equal = Transaction_hash.User_command_with_valid_signature.equal in
+  let removed, pool =
+    List.fold_left cmds ~init:empty ~f:insert_cmd |> remove_lowest_fee
+  in
+  (* check that the lowest fee per wu command is returned *)
+  assert (Sequence.(equal cmd_equal removed @@ return cmd_lowest_fee))
+  |> fun () ->
+  (* check that the lowest fee per wu command is removed from
+     applicable_by_fee *)
+  applicable_by_fee pool |> Map.data
+  |> List.concat_map ~f:Set.to_list
+  |> fun applicable_by_fee_cmds ->
+  assert (List.(equal cmd_equal applicable_by_fee_cmds commands_to_keep))
+  |> fun () ->
+  (* check that the lowest fee per wu command is removed from
+     all_by_fee *)
+  applicable_by_fee pool |> Map.data
+  |> List.concat_map ~f:Set.to_list
+  |> fun all_by_fee_cmds ->
+  assert (List.(equal cmd_equal all_by_fee_cmds commands_to_keep))
+
+let insert_cmd pool cmd =
+  add_from_gossip_exn pool cmd Account_nonce.zero (Amount.of_mina_int_exn 5)
+  |> Result.map_error ~f:(fun e ->
+         let sexp = Command_error.sexp_of_t e in
+         Failure (Sexp.to_string sexp) )
+  |> Result.ok_exn
+  |> fun (_, pool, _) -> pool
+
+(** Picking a transaction to include in a block, choose the one with
+    highest fee. *)
+let pick_highest_fee_for_application () =
+  Quickcheck.test
+    (* This should be replaced with a proper generator, but for the moment it
+       generates inputs which fail the test. *)
+    ( gen_cmd () |> Quickcheck.random_sequence |> Fn.flip Sequence.take 4
+    |> Sequence.to_list |> Quickcheck.Generator.return )
+    ~f:(fun cmds ->
+      let compare cmd0 cmd1 : int =
+        let open Transaction_hash.User_command_with_valid_signature in
+        Fee_rate.compare
+          (User_command.fee_per_wu @@ command cmd0)
+          (User_command.fee_per_wu @@ command cmd1)
+      in
+      let pool = List.fold_left cmds ~init:empty ~f:insert_cmd in
+      [%test_eq: Transaction_hash.User_command_with_valid_signature.t option]
+        (get_highest_fee pool)
+        (List.max_elt ~compare cmds) )
+
+let command_nonce (txn : Transaction_hash.User_command_with_valid_signature.t) =
+  let open Transaction_hash.User_command_with_valid_signature in
+  match (forget_check txn).data with
+  | Signed_command sc ->
+      Signed_command.nonce sc
+  | Zkapp_command zk ->
+      zk.fee_payer.body.nonce
+
+let dummy_state_view =
+  let state_body =
+    let consensus_constants =
+      let genesis_constants = Genesis_constants.for_unit_tests in
+      Consensus.Constants.create ~constraint_constants
+        ~protocol_constants:genesis_constants.protocol
+    in
+    let compile_time_genesis =
+      (*not using Precomputed_values.for_unit_test because of dependency cycle*)
+      Mina_state.Genesis_protocol_state.t
+        ~genesis_ledger:Genesis_ledger.(Packed.t for_unit_tests)
+        ~genesis_epoch_data:Consensus.Genesis_epoch_data.for_unit_tests
+        ~genesis_body_reference:Staged_ledger_diff.genesis_body_reference
+        ~constraint_constants ~consensus_constants
+    in
+    compile_time_genesis.data |> Mina_state.Protocol_state.body
+  in
+  { (Mina_state.Protocol_state.Body.view state_body) with
+    global_slot_since_genesis = Mina_numbers.Global_slot_since_genesis.zero
+  }
+
+let add_to_pool ~nonce ~balance pool cmd =
+  let _, pool', dropped =
+    add_from_gossip_exn pool cmd nonce balance
+    |> Result.map_error ~f:(Fn.compose Sexp.to_string Command_error.sexp_of_t)
+    |> Result.ok_or_failwith
+  in
+  [%test_eq: Transaction_hash.User_command_with_valid_signature.t Sequence.t]
+    dropped Sequence.empty ;
+  assert_pool_consistency pool' ;
+  pool'
+
+let init_permissionless_ledger ledger account_info =
+  let open Mina_ledger.Ledger.Ledger_inner in
+  List.iter account_info ~f:(fun (public_key, amount) ->
+      let account_id =
+        Account_id.create (Public_key.compress public_key) Token_id.default
+      in
+      let balance =
+        Balance.of_nanomina_int_exn @@ Amount.to_nanomina_int amount
+      in
+      let _tag, account, location =
+        Or_error.ok_exn (get_or_create ledger account_id)
+      in
+      set ledger location
+        { account with balance; permissions = Permissions.empty } )
+
+let apply_to_ledger ledger cmd =
+  match Transaction_hash.User_command_with_valid_signature.command cmd with
+  | User_command.Signed_command c ->
+      let (`If_this_is_used_it_should_have_a_comment_justifying_it v) =
+        Signed_command.to_valid_unsafe c
+      in
+      ignore
+        ( Mina_ledger.Ledger.apply_user_command ~constraint_constants
+            ~txn_global_slot:Mina_numbers.Global_slot_since_genesis.zero ledger
+            v
+          |> Or_error.ok_exn
+          : Mina_transaction_logic.Transaction_applied.Signed_command_applied.t
+          )
+  | User_command.Zkapp_command p -> (
+      let applied, _ =
+        Mina_ledger.Ledger.apply_zkapp_command_unchecked ~constraint_constants
+          ~global_slot:dummy_state_view.global_slot_since_genesis
+          ~state_view:dummy_state_view ledger p
+        |> Or_error.ok_exn
+      in
+      match With_status.status applied.command with
+      | Transaction_status.Applied ->
+          ()
+      | Transaction_status.Failed failure ->
+          failwithf "failed to apply zkapp_command transaction to ledger: [%s]"
+            ( String.concat ~sep:", "
+            @@ List.bind
+                 ~f:(List.map ~f:Transaction_status.Failure.to_string)
+                 failure )
+            () )
+
+let commit_to_pool ledger pool cmd expected_drops =
+  apply_to_ledger ledger cmd ;
+  let accounts_to_check =
+    Transaction_hash.User_command_with_valid_signature.command cmd
+    |> User_command.accounts_referenced |> Account_id.Set.of_list
+  in
+  let pool, dropped =
+    revalidate pool ~logger (`Subset accounts_to_check) (fun sender ->
+        match Mina_ledger.Ledger.location_of_account ledger sender with
+        | None ->
+            Account.empty
+        | Some loc ->
+            Option.value_exn
+              ~message:"Somehow a public key has a location but no account"
+              (Mina_ledger.Ledger.get ledger loc) )
+  in
+  let lower =
+    List.map ~f:Transaction_hash.User_command_with_valid_signature.hash
+  in
+  [%test_eq: Transaction_hash.t list]
+    (lower (Sequence.to_list dropped))
+    (lower expected_drops) ;
+  assert_pool_consistency pool ;
+  pool
+
+let make_zkapp_command_payment ~(sender : Keypair.t) ~(receiver : Keypair.t)
+    ~double_increment_sender ~increment_receiver ~amount ~fee nonce_int =
+  let nonce = Account.Nonce.of_int nonce_int in
+  let sender_pk = Public_key.compress sender.public_key in
+  let receiver_pk = Public_key.compress receiver.public_key in
+  let zkapp_command_wire : Zkapp_command.Stable.Latest.Wire.t =
+    { fee_payer =
+        { Account_update.Fee_payer.body =
+            { public_key = sender_pk; fee; nonce; valid_until = None }
+            (* Real signature added in below *)
+        ; authorization = Signature.dummy
+        }
+    ; account_updates =
+        Zkapp_command.Call_forest.of_account_updates
+          ~account_update_depth:(Fn.const 0)
+          [ { Account_update.body =
+                { public_key = sender_pk
+                ; update = Account_update.Update.noop
+                ; token_id = Token_id.default
+                ; balance_change = Amount.Signed.(negate @@ of_unsigned amount)
+                ; increment_nonce = double_increment_sender
+                ; events = []
+                ; actions = []
+                ; call_data = Snark_params.Tick.Field.zero
+                ; preconditions =
+                    { Account_update.Preconditions.network =
+                        Zkapp_precondition.Protocol_state.accept
+                    ; account =
+                        Account_update.Account_precondition.Nonce
+                          (Account.Nonce.succ nonce)
+                    ; valid_while = Ignore
+                    }
+                ; may_use_token = No
+                ; use_full_commitment = not double_increment_sender
+                ; implicit_account_creation_fee = false
+                ; authorization_kind = None_given
+                }
+            ; authorization = None_given
+            }
+          ; { Account_update.body =
+                { public_key = receiver_pk
+                ; update = Account_update.Update.noop
+                ; token_id = Token_id.default
+                ; balance_change = Amount.Signed.of_unsigned amount
+                ; increment_nonce = increment_receiver
+                ; events = []
+                ; actions = []
+                ; call_data = Snark_params.Tick.Field.zero
+                ; preconditions =
+                    { Account_update.Preconditions.network =
+                        Zkapp_precondition.Protocol_state.accept
+                    ; account = Account_update.Account_precondition.Accept
+                    ; valid_while = Ignore
+                    }
+                ; may_use_token = No
+                ; implicit_account_creation_fee = false
+                ; use_full_commitment = not increment_receiver
+                ; authorization_kind = None_given
+                }
+            ; authorization = None_given
+            }
+          ]
+    ; memo = Signed_command_memo.empty
+    }
+  in
+  let zkapp_command = Zkapp_command.of_wire zkapp_command_wire in
+  (* We skip signing the commitment and updating the authorization as it is not necessary to have a valid transaction for these tests. *)
+  let (`If_this_is_used_it_should_have_a_comment_justifying_it cmd) =
+    User_command.to_valid_unsafe (User_command.Zkapp_command zkapp_command)
+  in
+  Transaction_hash.User_command_with_valid_signature.create cmd
+
+let support_for_zkapp_command_commands () =
+  let fee = Fee.minimum_user_command_fee in
+  let amount = Amount.of_nanomina_int_exn @@ Fee.to_nanomina_int fee in
+  let balance = Option.value_exn (Amount.scale amount 100) in
+  let kp1 =
+    Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
+  in
+  let kp2 =
+    Quickcheck.random_value ~seed:(`Deterministic "orange") Keypair.gen
+  in
+  let add_cmd = add_to_pool ~nonce:Account_nonce.zero ~balance in
+  let make_cmd =
+    make_zkapp_command_payment ~sender:kp1 ~receiver:kp2
+      ~increment_receiver:false ~amount ~fee
+  in
+  Mina_ledger.Ledger.with_ledger ~depth:4 ~f:(fun ledger ->
+      init_permissionless_ledger ledger
+        [ (kp1.public_key, balance); (kp2.public_key, Amount.zero) ] ;
+      let commit = commit_to_pool ledger in
+      let cmd1 = make_cmd ~double_increment_sender:false 0 in
+      let cmd2 = make_cmd ~double_increment_sender:false 1 in
+      let cmd3 = make_cmd ~double_increment_sender:false 2 in
+      let cmd4 = make_cmd ~double_increment_sender:false 3 in
+      (* used to break the sequence *)
+      let cmd3' = make_cmd ~double_increment_sender:true 2 in
+      let pool =
+        List.fold_left [ cmd1; cmd2; cmd3; cmd4 ] ~init:empty ~f:add_cmd
+      in
+      let pool = commit pool cmd1 [ cmd1 ] in
+      let pool = commit pool cmd2 [ cmd2 ] in
+      let _pool = commit pool cmd3' [ cmd3; cmd4 ] in
+      () )
+
+let nonce_increment_side_effects () =
+  let fee = Fee.minimum_user_command_fee in
+  let amount = Amount.of_nanomina_int_exn @@ Fee.to_nanomina_int fee in
+  let balance = Option.value_exn (Amount.scale amount 100) in
+  let kp1 =
+    Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
+  in
+  let kp2 =
+    Quickcheck.random_value ~seed:(`Deterministic "orange") Keypair.gen
+  in
+  let add_cmd = add_to_pool ~nonce:Account_nonce.zero ~balance in
+  let make_cmd = make_zkapp_command_payment ~amount ~fee in
+  Mina_ledger.Ledger.with_ledger ~depth:4 ~f:(fun ledger ->
+      init_permissionless_ledger ledger
+        [ (kp1.public_key, balance); (kp2.public_key, balance) ] ;
+      let kp1_cmd1 =
+        make_cmd ~sender:kp1 ~receiver:kp2 ~double_increment_sender:false
+          ~increment_receiver:true 0
+      in
+      let kp2_cmd1 =
+        make_cmd ~sender:kp2 ~receiver:kp1 ~double_increment_sender:false
+          ~increment_receiver:false 0
+      in
+      let kp2_cmd2 =
+        make_cmd ~sender:kp2 ~receiver:kp1 ~double_increment_sender:false
+          ~increment_receiver:false 1
+      in
+      let pool =
+        List.fold_left [ kp1_cmd1; kp2_cmd1; kp2_cmd2 ] ~init:empty ~f:add_cmd
+      in
+      let _pool = commit_to_pool ledger pool kp1_cmd1 [ kp2_cmd1; kp1_cmd1 ] in
+      () )
+
+let nonce_invariant_violation () =
+  let fee = Fee.minimum_user_command_fee in
+  let amount = Amount.of_nanomina_int_exn @@ Fee.to_nanomina_int fee in
+  let balance = Option.value_exn (Amount.scale amount 100) in
+  let kp1 =
+    Quickcheck.random_value ~seed:(`Deterministic "apple") Keypair.gen
+  in
+  let kp2 =
+    Quickcheck.random_value ~seed:(`Deterministic "orange") Keypair.gen
+  in
+  let add_cmd = add_to_pool ~nonce:Account_nonce.zero ~balance in
+  let make_cmd =
+    make_zkapp_command_payment ~sender:kp1 ~receiver:kp2
+      ~double_increment_sender:false ~increment_receiver:false ~amount ~fee
+  in
+  Mina_ledger.Ledger.with_ledger ~depth:4 ~f:(fun ledger ->
+      init_permissionless_ledger ledger
+        [ (kp1.public_key, balance); (kp2.public_key, Amount.zero) ] ;
+      let cmd1 = make_cmd 0 in
+      let cmd2 = make_cmd 1 in
+      let pool = List.fold_left [ cmd1; cmd2 ] ~init:empty ~f:add_cmd in
+      apply_to_ledger ledger cmd1 ;
+      let _pool = commit_to_pool ledger pool cmd2 [ cmd1; cmd2 ] in
+      () )
+
+(* Check that when commands from a single sender are added into the mempool
+   and then lowest fee commands are dropped, remaining commands are returned
+   for application in the order of increasing nonces without a gap. *)
+let transactions_from_single_sender_ordered_by_nonce () =
+  Quickcheck.test
+    (let open Quickcheck.Generator.Let_syntax in
+    let%bind sender = Account.gen in
+    let%bind receiver = Account.gen in
+    let%map txns =
+      Stateful_gen.eval_state
+        (gen_txns_from_single_sender_to receiver.public_key)
+        sender
+    in
+    (sender, txns))
+    ~f:(fun (sender, txns) ->
+      let account_map = accounts_map [ sender ] in
+      let pool =
+        pool_of_transactions ~init:empty ~account_map txns |> rem_lowest_fee 5
+      in
+      assert_pool_consistency pool ;
+      let txns = Sequence.to_list @@ Indexed_pool.transactions ~logger pool in
+      with_accounts txns ~init:() ~account_map ~f:(fun () a t ->
+          [%test_eq: Account_nonce.t] (txn_nonce t) a.nonce |> Result.return )
+      |> Result.ok_or_failwith ;
+      assert_pool_consistency pool )
+
+let rec interleave_at_random queues =
+  let open Quickcheck in
+  let open Generator.Let_syntax in
+  if Array.is_empty queues then return []
+  else
+    let%bind i = Int.gen_incl 0 (Array.length queues - 1) in
+    match queues.(i) with
+    | [] ->
+        Array.filter queues ~f:(fun q -> not @@ List.is_empty q)
+        |> interleave_at_random
+    | t :: ts ->
+        Array.set queues i ts ;
+        let%map more = interleave_at_random queues in
+        t :: more
+
+let gen_accounts_and_transactions =
+  let open Quickcheck.Generator.Let_syntax in
+  let module Gen_ext = Monad_lib.Make_ext (Quickcheck.Generator) in
+  let%bind senders = List.gen_non_empty Account.gen in
+  let%bind receiver = Account.gen in
+  let%bind txns =
+    List.map senders
+      ~f:
+        (Stateful_gen.eval_state
+           (gen_txns_from_single_sender_to receiver.public_key) )
+    |> Gen_ext.sequence
+  in
+  let%map shuffled = interleave_at_random @@ Array.of_list txns in
+  (accounts_map senders, shuffled)
+
+let transactions_from_many_senders_no_nonce_gaps () =
+  Quickcheck.test gen_accounts_and_transactions ~f:(fun (account_map, txns) ->
+      let pool =
+        pool_of_transactions ~init:empty ~account_map txns |> rem_lowest_fee 5
+      in
+      let txns = Sequence.to_list @@ Indexed_pool.transactions ~logger pool in
+      with_accounts txns ~init:() ~account_map ~f:(fun () a t ->
+          [%test_eq: Account_nonce.t] (txn_nonce t) a.nonce |> Result.return )
+      |> Result.ok_or_failwith ;
+      assert_pool_consistency pool )
+
+let revalidation_drops_nothing_unless_ledger_changed () =
+  Quickcheck.test gen_accounts_and_transactions ~f:(fun (account_map, txns) ->
+      let pool = pool_of_transactions ~init:empty ~account_map txns in
+      let pool', dropped =
+        Indexed_pool.revalidate pool ~logger `Entire_pool (fun aid ->
+            Public_key.Compressed.Map.find_exn account_map
+              (Account_id.public_key aid) )
+      in
+      [%test_eq:
+        Transaction_hash.User_command_with_valid_signature.t Sequence.t] dropped
+        Sequence.empty ;
+      [%test_eq: Indexed_pool.t] pool pool' ;
+      let to_apply = Indexed_pool.transactions ~logger pool in
+      let to_apply' = Indexed_pool.transactions ~logger pool' in
+      assert_pool_consistency pool ;
+      [%test_eq:
+        Transaction_hash.User_command_with_valid_signature.t Sequence.t]
+        to_apply to_apply' )
+
+let apply_transactions txns accounts =
+  List.fold txns ~init:accounts ~f:(fun m t ->
+      let txn = Signed_command.forget_check t in
+      let sender = Public_key.compress txn.signer in
+      Public_key.Compressed.Map.update m sender ~f:(function
+        | None ->
+            failwith "sender not found"
+        | Some a ->
+            let open Account.Poly in
+            let nonce = Account.Nonce.succ a.nonce in
+            let balance =
+              let amt =
+                Signed_command.amount txn |> Option.value ~default:Amount.zero
+              in
+              Balance.(sub_amount a.balance amt)
+              |> Option.value ~default:Balance.zero
+            in
+            { a with nonce; balance } ) )
+
+let txn_hash = Transaction_hash.User_command_with_valid_signature.hash
+
+let application_invalidates_applied_transactions () =
+  Quickcheck.test
+    (let open Quickcheck.Generator.Let_syntax in
+    let%bind accounts, txns = gen_accounts_and_transactions in
+    (* Simulate application of some transactions in order to invalidate them. *)
+    let%map app_count = Int.gen_incl 0 (List.length txns) in
+    let updated_accounts =
+      apply_transactions (List.take txns app_count) accounts
+    in
+    (accounts, updated_accounts, txns, app_count))
+    ~f:(fun (initial_accounts, updated_accounts, txns, app_count) ->
+      let pool =
+        pool_of_transactions ~init:empty ~account_map:initial_accounts txns
+      in
+      let _pool', dropped =
+        Indexed_pool.revalidate ~logger pool `Entire_pool (fun aid ->
+            Public_key.Compressed.Map.find_exn updated_accounts
+              (Account_id.public_key aid) )
+      in
+      assert_pool_consistency pool ;
+      [%test_eq: Transaction_hash.Set.t]
+        ( Sequence.to_list dropped |> List.map ~f:txn_hash
+        |> Transaction_hash.Set.of_list )
+        ( List.take txns app_count
+        |> List.map ~f:(Fn.compose txn_hash sgn_cmd_to_txn)
+        |> Transaction_hash.Set.of_list ) )
+
+let update_fee (txn : Signed_command.t) fee =
+  { txn with
+    payload = { txn.payload with common = { txn.payload.common with fee } }
+  }
+
+(* Generate a sequence of transactions, then choose one of them and replace
+   it with the same transaction, just with a higher fee. *)
+let transaction_replacement () =
+  Quickcheck.test
+    (let open Quickcheck in
+    let open Generator.Let_syntax in
+    (* Make sure we can increase the balance later. *)
+    let high = Balance.(sub_amount max_int Amount.one) |> Option.value_exn in
+    let%bind sender =
+      Account.gen_with_constrained_balance ~low:Balance.one ~high
+    in
+    let%bind receiver = Account.gen in
+    let%bind txns =
+      Stateful_gen.eval_state
+        (gen_txns_from_single_sender_to receiver.public_key)
+        sender
+    in
+    let%map to_replace = Generator.of_list txns in
+    (sender, txns, Signed_command.forget_check to_replace))
+    ~f:(fun (sender, txns, to_replace) ->
+      let account_map = accounts_map [ sender ] in
+      let pool = pool_of_transactions ~init:empty ~account_map txns in
+      let old_fee = to_replace.payload.common.fee in
+      let fee = Currency.Fee.(old_fee + one) |> Option.value_exn in
+      let cmd = update_fee to_replace fee in
+      (* We don't care about signatures in these tests. *)
+      let (`If_this_is_used_it_should_have_a_comment_justifying_it replacement)
+          =
+        Signed_command.to_valid_unsafe cmd
+      in
+      let t =
+        User_command.Signed_command replacement
+        |> Transaction_hash.User_command_with_valid_signature.create
+      in
+      let balance =
+        Balance.to_amount sender.balance |> Amount.(add one) |> Option.value_exn
+      in
+      let _, pool', _ =
+        Indexed_pool.add_from_gossip_exn pool t sender.nonce balance
+        |> Result.map_error ~f:(fun e ->
+               Sexp.to_string @@ Command_error.sexp_of_t e )
+        |> Result.ok_or_failwith
+      in
+      assert_pool_consistency pool ;
+      let queue, _ =
+        let open Account.Poly in
+        Public_key.decompress sender.public_key
+        |> Option.value_exn |> Account_id.of_public_key
+        |> Account_id.Map.find_exn (Indexed_pool.For_tests.all_by_sender pool')
+      in
+      let eq = Transaction_hash.User_command_with_valid_signature.equal in
+      let repl =
+        Signed_command replacement
+        |> Transaction_hash.User_command_with_valid_signature.create
+      in
+      List.iteri (F_sequence.to_list queue) ~f:(fun i txn ->
+          [%test_pred: Transaction_hash.User_command_with_valid_signature.t]
+            (fun t ->
+              let ith =
+                Signed_command (List.nth_exn txns i)
+                |> Transaction_hash.User_command_with_valid_signature.create
+              in
+              eq t ith || eq t repl )
+            txn ) ;
+      [%test_eq: int] (Indexed_pool.size pool) (Indexed_pool.size pool') ;
+      [%test_eq: int]
+        (Indexed_pool.transactions ~logger pool |> Sequence.length)
+        (Indexed_pool.transactions ~logger pool' |> Sequence.length) )
+
+let transaction_replacement_insufficient_balance () =
+  Quickcheck.test
+    (let open Quickcheck.Generator.Let_syntax in
+    let%bind a = Account.gen in
+    let sender = { a with balance = Balance.of_mina_int_exn 31 } in
+    let%map recv = Account.gen in
+    let cmds =
+      List.init 3 ~f:(fun n ->
+          let open Signed_command.Payload in
+          let (`If_this_is_used_it_should_have_a_comment_justifying_it cmd) =
+            Signed_command.Poly.
+              { payload =
+                  Poly.
+                    { common =
+                        Common.Poly.
+                          { fee =
+                              Fee.of_nanomina_int_exn 300_000_000 (* 0.3 Mina *)
+                          ; fee_payer_pk = sender.public_key
+                          ; nonce = Account_nonce.(add sender.nonce @@ of_int n)
+                          ; valid_until = Global_slot_since_genesis.max_value
+                          ; memo = Signed_command_memo.dummy
+                          }
+                    ; body =
+                        Body.Payment
+                          Payment_payload.Poly.
+                            { receiver_pk = recv.public_key
+                            ; amount = Amount.of_mina_int_exn 10
+                            }
+                    }
+              ; signer =
+                  Option.value_exn @@ Public_key.decompress sender.public_key
+              ; signature = Signature.dummy
+              }
+            |> Signed_command.to_valid_unsafe
+          in
+          cmd )
+    in
+    (sender, cmds))
+    ~f:(fun (sender, txns) ->
+      let account_map = accounts_map [ sender ] in
+      let pool = pool_of_transactions ~init:empty ~account_map txns in
+      let t = List.nth_exn txns 1 |> Signed_command.forget_check in
+      let updated =
+        update_fee t (Currency.Fee.of_nanomina_int_exn 700_000_000)
+        (* 0.7 Mina *)
+      in
+      let (`If_this_is_used_it_should_have_a_comment_justifying_it replacement)
+          =
+        Signed_command.to_valid_unsafe updated
+      in
+      let t =
+        User_command.Signed_command replacement
+        |> Transaction_hash.User_command_with_valid_signature.create
+      in
+      let balance = Balance.to_amount sender.balance in
+      let _, pool', _ =
+        Indexed_pool.add_from_gossip_exn pool t sender.nonce balance
+        |> Result.map_error ~f:(fun e ->
+               Sexp.to_string @@ Command_error.sexp_of_t e )
+        |> Result.ok_or_failwith
+      in
+      (* The last transaction gets discarded, because after the replacement,
+         the account can't afford it anymore. *)
+      assert_pool_consistency pool ;
+      [%test_eq: int] (Indexed_pool.size pool) 3 ;
+      [%test_eq: int] (Indexed_pool.size pool') 2 )

--- a/src/lib/network_pool/test/main.ml
+++ b/src/lib/network_pool/test/main.ml
@@ -1,0 +1,45 @@
+open Alcotest
+
+let () =
+  run "Test the network pool."
+    [ Indexed_pool_tests.
+        ( "indexed pool"
+        , [ test_case "Test invariants hold on empty data structure" `Quick
+              empty_invariants
+          ; test_case "Test properties of a singleton pool" `Quick
+              singleton_properties
+          ; test_case "Test a sequence of valid additions" `Quick
+              sequential_adds_all_valid
+          ; test_case "Test replacement" `Quick replacement
+          ; test_case "Txn with lowest fee rate is removed" `Quick
+              remove_lowest_fee
+          ; test_case "For application pick the txn with the highest fee rate"
+              `Quick pick_highest_fee_for_application
+          ; test_case "Test support for zkApp commands." `Quick
+              support_for_zkapp_command_commands
+          ; test_case
+              "Transactions from single source should be ordered by nonce"
+              `Quick transactions_from_single_sender_ordered_by_nonce
+          ; test_case
+              "Transactions for application should not contain nonce gaps"
+              `Quick transactions_from_many_senders_no_nonce_gaps
+          ; test_case
+              "Nonce increment side effects from other zkapp_command are \
+               handled properly"
+              `Quick nonce_increment_side_effects
+          ; test_case
+              "Nonce invariant violations on committed transactions does not \
+               trigger a crash "
+              `Quick nonce_invariant_violation
+          ; test_case "Revalidation drops nothing unsless ledger changed" `Quick
+              revalidation_drops_nothing_unless_ledger_changed
+          ; test_case "Applying transactions invalidates them" `Quick
+              application_invalidates_applied_transactions
+          ; test_case "Transaction can be replaced by one with higher fee"
+              `Quick transaction_replacement
+          ; test_case
+              "After a replacement, later transactions are discarded, if  \
+               account's balance can't support them anymore"
+              `Quick transaction_replacement_insufficient_balance
+          ] )
+    ]

--- a/src/lib/network_pool/test/transaction_gen.ml
+++ b/src/lib/network_pool/test/transaction_gen.ml
@@ -1,0 +1,140 @@
+open Core_kernel
+open Currency
+open Mina_base
+open Mina_numbers
+open Mina_transaction
+open Network_pool
+open Signature_lib
+
+let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
+
+let constraint_constants = precomputed_values.constraint_constants
+
+let consensus_constants = precomputed_values.consensus_constants
+
+let test_keys = Array.init 10 ~f:(fun _ -> Keypair.create ())
+
+let gen_cmd ?(keys = test_keys) ?sign_type ?nonce () =
+  User_command.Valid.Gen.payment_with_random_participants ~keys ~max_amount:1000
+    ~fee_range:100 ?sign_type ?nonce ()
+  |> Quickcheck.Generator.map
+       ~f:Transaction_hash.User_command_with_valid_signature.create
+
+let txn_nonce txn =
+  let unchecked =
+    Transaction_hash.User_command_with_valid_signature.forget_check txn
+  in
+  match unchecked.data with
+  | Signed_command cmd ->
+      cmd.payload.common.nonce
+  | Zkapp_command cmd ->
+      cmd.fee_payer.body.nonce
+
+let sender_pk txn =
+  let unchecked =
+    Transaction_hash.User_command_with_valid_signature.forget_check txn
+  in
+  match unchecked.data with
+  | Signed_command cmd ->
+      cmd.payload.common.fee_payer_pk
+  | Zkapp_command cmd ->
+      cmd.fee_payer.body.public_key
+
+let rec rem_lowest_fee count pool =
+  if count > 0 then
+    rem_lowest_fee (count - 1) (Indexed_pool.remove_lowest_fee pool |> snd)
+  else pool
+
+module Stateful_gen = Monad_lib.State.Trans (Quickcheck.Generator)
+module Stateful_gen_ext = Monad_lib.Make_ext2 (Stateful_gen)
+module Result_ext = Monad_lib.Make_ext2 (Result)
+
+let sgn_cmd_to_txn cmd =
+  Signed_command cmd
+  |> Transaction_hash.User_command_with_valid_signature.create
+
+let gen_amount : (uint64, Account.t) Stateful_gen.t =
+  let open Stateful_gen in
+  let open Let_syntax in
+  let open Account.Poly in
+  let%bind balance = getf (fun a -> a.balance) in
+  let%bind amt = lift @@ Amount.(gen_incl zero @@ Balance.to_amount balance) in
+  let%map () =
+    modify ~f:(fun a ->
+        { a with balance = Option.value_exn @@ Balance.sub_amount balance amt } )
+  in
+  Amount.to_uint64 amt
+
+let accounts_map accounts =
+  List.map accounts ~f:Account.Poly.(fun a -> (a.public_key, a))
+  |> Public_key.Compressed.Map.of_alist_exn
+
+let with_accounts ~f ~account_map ~init txns =
+  Result_ext.fold_m txns ~init:(account_map, init)
+    ~f:(fun (accounts, accum) t ->
+      let open Result.Let_syntax in
+      let pk = sender_pk t in
+      let a = Public_key.Compressed.Map.find_exn accounts pk in
+      let%map accum' = f accum a t in
+      let accounts' =
+        Public_key.Compressed.Map.set accounts ~key:pk
+          ~data:Account.Poly.{ a with nonce = Account_nonce.succ a.nonce }
+      in
+      (accounts', accum') )
+  |> Result.map ~f:snd
+
+let pool_of_transactions ~init ~account_map txns =
+  Result_ext.fold_m
+    (List.map txns ~f:(fun t ->
+         Transaction_hash.User_command_with_valid_signature.create
+           (Signed_command t) ) )
+    ~init
+    ~f:(fun p t ->
+      let open Account.Poly in
+      Indexed_pool.For_tests.assert_pool_consistency p ;
+      let a = Public_key.Compressed.Map.find_exn account_map (sender_pk t) in
+      Indexed_pool.add_from_gossip_exn p t a.nonce (Balance.to_amount a.balance)
+      |> Result.map ~f:Tuple3.get2 )
+  |> Result.map_error ~f:(fun e -> Sexp.to_string @@ Command_error.sexp_of_t e)
+  |> Result.ok_or_failwith
+
+let rec gen_txns_from_single_sender_to receiver_public_key =
+  let open Stateful_gen in
+  let open Let_syntax in
+  let open Account.Poly in
+  let%bind sender = get in
+  if Balance.(sender.balance = zero) then return []
+  else
+    let%bind () =
+      modify ~f:(fun a -> { a with nonce = Account_nonce.succ a.nonce })
+    in
+    let%bind txn_amt = map ~f:Amount.of_uint64 gen_amount in
+    let%bind txn_fee = map ~f:Fee.of_uint64 gen_amount in
+    let cmd =
+      let open Signed_command.Payload in
+      Signed_command.Poly.
+        { payload =
+            Poly.
+              { common =
+                  Common.Poly.
+                    { fee = txn_fee
+                    ; fee_payer_pk = sender.public_key
+                    ; nonce = sender.nonce
+                    ; valid_until = Global_slot_since_genesis.max_value
+                    ; memo = Signed_command_memo.dummy
+                    }
+              ; body =
+                  Body.Payment
+                    Payment_payload.Poly.
+                      { receiver_pk = receiver_public_key; amount = txn_amt }
+              }
+        ; signer = Option.value_exn @@ Public_key.decompress sender.public_key
+        ; signature = Signature.dummy
+        }
+    in
+    let%map more = gen_txns_from_single_sender_to receiver_public_key in
+    (* Signatures don't matter in these tests. *)
+    let (`If_this_is_used_it_should_have_a_comment_justifying_it valid_cmd) =
+      Signed_command.to_valid_unsafe cmd
+    in
+    valid_cmd :: more

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -433,7 +433,7 @@ struct
           else true
 
     let diff_error_of_indexed_pool_error :
-        Indexed_pool.Command_error.t -> Diff_versioned.Diff_error.t = function
+        Command_error.t -> Diff_versioned.Diff_error.t = function
       | Invalid_nonce _ ->
           Invalid_nonce
       | Insufficient_funds _ ->
@@ -450,7 +450,7 @@ struct
           Expired
 
     let indexed_pool_error_metadata = function
-      | Indexed_pool.Command_error.Invalid_nonce (`Between (low, hi), nonce) ->
+      | Command_error.Invalid_nonce (`Between (low, hi), nonce) ->
           let nonce_json = Account.Nonce.to_yojson in
           [ ( "between"
             , `Assoc [ ("low", nonce_json low); ("hi", nonce_json hi) ] )
@@ -991,8 +991,8 @@ struct
       let of_indexed_pool_error e =
         (diff_error_of_indexed_pool_error e, indexed_pool_error_metadata e)
 
-      let report_command_error ~logger ~is_sender_local tx
-          (e : Indexed_pool.Command_error.t) =
+      let report_command_error ~logger ~is_sender_local tx (e : Command_error.t)
+          =
         let diff_err, error_extra = of_indexed_pool_error e in
         if is_sender_local then
           [%str_log error]
@@ -1757,7 +1757,7 @@ let%test_module _ =
       assert (List.is_sorted txns ~compare)
 
     let assert_pool_txs test txs =
-      Indexed_pool.For_tests.assert_invariants test.txn_pool.pool ;
+      Indexed_pool.For_tests.assert_pool_consistency test.txn_pool.pool ;
       assert_locally_generated test.txn_pool ;
       assert_fee_wu_ordering test.txn_pool ;
       assert_user_command_sets_equal

--- a/src/lib/snark_profiler_lib/snark_profiler_lib.ml
+++ b/src/lib/snark_profiler_lib/snark_profiler_lib.ml
@@ -718,10 +718,11 @@ let profile_zkapps ~verifier ledger zkapp_commands =
         let tm_zkapp0 = Core.Unix.gettimeofday () in
         (*verify*)
         let%map () =
+          let mask = Mina_ledger.Ledger.copy ledger in
           match%map
             Async_kernel.Monitor.try_with ~here:[%here] (fun () ->
                 Transaction_snark_tests.Util.check_zkapp_command_with_merges_exn
-                  ~ignore_outside_snark:true ledger [ zkapp_command ] )
+                  ~ignore_outside_snark:true mask [ zkapp_command ] )
           with
           | Ok () ->
               ()


### PR DESCRIPTION
I included https://github.com/MinaProtocol/mina/pull/13739

Explain your changes:
* Bump up ocaml-gen to 0.1.5. Required for https://github.com/o1-labs/proof-systems/pull/1112, see related MR in proof-systems https://github.com/o1-labs/proof-systems/pull/1113.
* ocaml-gen 0.1.5 includes some fixes including bindings with more than 5 parameters, a bug related to array conversions and implement OCamlDesc for i32

Built on top of https://github.com/MinaProtocol/mina/pull/13532

Explain how you tested your changes:
* from dannywillems/lookup branch, CI, and in https://github.com/o1-labs/proof-systems/pull/1112.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] N/A Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] N/A Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] N/A Serialized types are in stable-versioned modules
- [ ] N/A Does this close issues? List them

* Closes #0000
