### PR TITLE
Fix snark pool long async jobs

### DIFF
--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1784,14 +1784,14 @@ let create ?wallets (config : Config.t) =
               ~trust_system:config.trust_system
               ~disk_location:config.snark_pool_disk_location
           in
-          let%bind snark_pool, snark_remote_sink, snark_local_sink =
-            Network_pool.Snark_pool.load ~config:snark_pool_config
+          let snark_pool, snark_remote_sink, snark_local_sink =
+            Network_pool.Snark_pool.create ~config:snark_pool_config
               ~constraint_constants ~consensus_constants
               ~time_controller:config.time_controller ~logger:config.logger
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
               ~on_remote_push:notify_online
               ~log_gossip_heard:
-                config.net_config.log_gossip_heard.snark_pool_diff ()
+                config.net_config.log_gossip_heard.snark_pool_diff
           in
           let block_reader, block_sink =
             Transition_handler.Block_sink.create

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -23,8 +23,7 @@ module type Resource_pool_base_intf = sig
   end
 
   (** Diff from a transition frontier extension that would update the resource pool*)
-  val handle_transition_frontier_diff :
-    transition_frontier_diff -> t -> unit Deferred.t
+  val handle_transition_frontier_diff : transition_frontier_diff -> t -> unit
 
   val create :
        constraint_constants:Genesis_constants.Constraint_constants.t
@@ -93,7 +92,7 @@ module type Resource_pool_diff_intf = sig
     -> verified Envelope.Incoming.t
     -> ( [ `Accept | `Reject ] * t * rejected
        , [ `Locally_generated of t * rejected | `Other of Error.t ] )
-       Deferred.Result.t
+       Result.t
 
   val is_empty : t -> bool
 
@@ -236,7 +235,7 @@ module type Snark_resource_pool_intf = sig
     -> work:Transaction_snark_work.Statement.t
     -> proof:Ledger_proof.t One_or_two.t
     -> fee:Fee_with_prover.t
-    -> [ `Added | `Statement_not_referenced ] Deferred.t
+    -> [ `Added | `Statement_not_referenced ]
 
   val request_proof :
        t

--- a/src/lib/network_pool/mocks.ml
+++ b/src/lib/network_pool/mocks.ml
@@ -49,11 +49,7 @@ module Transition_frontier = struct
     let best_tip_table = Transaction_snark_work.Statement.Hash_set.create () in
     (*add_statements table stmts ;*)
     let diff_reader, diff_writer =
-      Broadcast_pipe.create
-        { Extensions.Snark_pool_refcount.removed = 0
-        ; refcount_table
-        ; best_tip_table
-        }
+      Broadcast_pipe.create { Extensions.Snark_pool_refcount.removed_work = [] }
     in
     { refcount_table
     ; best_tip_table
@@ -75,6 +71,10 @@ module Transition_frontier = struct
     let r, _ = Broadcast_pipe.create () in
     r
 
+  let work_is_referenced t = Hashtbl.mem t.refcount_table
+
+  let best_tip_table t = t.best_tip_table
+
   (*Adds statements to the table of referenced work. Snarks for only the referenced statements are added to the pool*)
   let refer_statements (t : t) stmts =
     let open Deferred.Let_syntax in
@@ -82,10 +82,7 @@ module Transition_frontier = struct
     List.iter ~f:(Hash_set.add t.best_tip_table) stmts ;
     let%bind () =
       Broadcast_pipe.Writer.write t.diff_writer
-        { Transition_frontier.Extensions.Snark_pool_refcount.removed = 0
-        ; refcount_table = t.refcount_table
-        ; best_tip_table = t.best_tip_table
-        }
+        { Transition_frontier.Extensions.Snark_pool_refcount.removed_work = [] }
     in
     Async.Scheduler.yield_until_no_jobs_remain ()
 
@@ -93,10 +90,7 @@ module Transition_frontier = struct
     List.iter ~f:(Hash_set.remove t.best_tip_table) stmts ;
     let%bind () =
       Broadcast_pipe.Writer.write t.diff_writer
-        { Transition_frontier.Extensions.Snark_pool_refcount.removed = 0
-        ; refcount_table = t.refcount_table
-        ; best_tip_table = t.best_tip_table
-        }
+        { Transition_frontier.Extensions.Snark_pool_refcount.removed_work = [] }
     in
     Async.Scheduler.yield_until_no_jobs_remain ()
 end

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -137,7 +137,7 @@ end)
         forward t.write_broadcasts diff' rejected cb )
     in
     O1trace.sync_thread apply_and_broadcast_thread_label (fun () ->
-        match%bind Resource_pool.Diff.unsafe_apply t.resource_pool diff with
+        match Resource_pool.Diff.unsafe_apply t.resource_pool diff with
         | Ok (`Accept, accepted, rejected) ->
             rebroadcast (accepted, rejected)
         | Ok (`Reject, accepted, rejected) ->
@@ -203,11 +203,12 @@ end)
                    O1trace.thread processing_diffs_thread_label (fun () ->
                        apply_and_broadcast network_pool verified_diff cb )
                | Transition_frontier_extension diff ->
-                   O1trace.thread
+                   O1trace.sync_thread
                      processing_transition_frontier_diffs_thread_label
                      (fun () ->
                        Resource_pool.handle_transition_frontier_diff diff
-                         resource_pool ) ) ) ) ;
+                         resource_pool ) ;
+                   Deferred.unit ) ) ) ;
     (network_pool, remote_w, local_w)
 
   (* Rebroadcast locally generated pool items every 10 minutes. Do so for 50

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -5,23 +5,6 @@ open Network_peer
 module Statement_table = Transaction_snark_work.Statement.Table
 
 module Snark_tables = struct
-  module Serializable = struct
-    [%%versioned
-    module Stable = struct
-      module V2 = struct
-        type t =
-          ( Ledger_proof.Stable.V2.t One_or_two.Stable.V1.t
-            Priced_proof.Stable.V1.t
-          * [ `Rebroadcastable of Core.Time.Stable.With_utc_sexp.V2.t
-            | `Not_rebroadcastable ] )
-          Transaction_snark_work.Statement.Stable.V2.Table.t
-        [@@deriving sexp]
-
-        let to_latest = Fn.id
-      end
-    end]
-  end
-
   type t =
     { all :
         Ledger_proof.t One_or_two.t Priced_proof.t
@@ -30,24 +13,7 @@ module Snark_tables = struct
         (Ledger_proof.t One_or_two.t Priced_proof.t * Core.Time.t)
         Transaction_snark_work.Statement.Table.t
     }
-  [@@deriving sexp, equal]
-
-  let of_serializable (t : Serializable.t) : t =
-    { all = Hashtbl.map t ~f:fst
-    ; rebroadcastable =
-        Hashtbl.filter_map t ~f:(fun (x, r) ->
-            match r with
-            | `Rebroadcastable time ->
-                Some (x, time)
-            | `Not_rebroadcastable ->
-                None )
-    }
-
-  let to_serializable (t : t) : Serializable.t =
-    let res = Hashtbl.map t.all ~f:(fun x -> (x, `Not_rebroadcastable)) in
-    Hashtbl.iteri t.rebroadcastable ~f:(fun ~key ~data:(x, r) ->
-        Hashtbl.set res ~key ~data:(x, `Rebroadcastable r) ) ;
-    res
+  [@@deriving sexp]
 end
 
 module type S = sig
@@ -85,20 +51,6 @@ module type S = sig
        t
     -> Transaction_snark_work.Statement.t
     -> Transaction_snark_work.Checked.t option
-
-  val load :
-       ?allow_multiple_instances_for_tests:bool
-    -> config:Resource_pool.Config.t
-    -> logger:Logger.t
-    -> constraint_constants:Genesis_constants.Constraint_constants.t
-    -> consensus_constants:Consensus.Constants.t
-    -> time_controller:Block_time.Controller.t
-    -> frontier_broadcast_pipe:
-         transition_frontier option Broadcast_pipe.Reader.t
-    -> log_gossip_heard:bool
-    -> on_remote_push:(unit -> unit Deferred.t)
-    -> unit
-    -> (t * Remote_sink.t * Local_sink.t) Deferred.t
 end
 
 module type Transition_frontier_intf = sig
@@ -165,24 +117,7 @@ struct
         }
       [@@deriving sexp]
 
-      type serializable = Snark_tables.Serializable.Stable.Latest.t
-      [@@deriving bin_io_unversioned]
-
       let make_config = Config.make
-
-      let of_serializable tables ~constraint_constants ~frontier_broadcast_pipe
-          ~config ~logger : t =
-        { snark_tables = Snark_tables.of_serializable tables
-        ; snark_table_lock = Throttle.Sequencer.create ()
-        ; frontier =
-            (fun () -> Broadcast_pipe.Reader.peek frontier_broadcast_pipe)
-        ; batcher = Batcher.Snark_pool.create config.verifier
-        ; account_creation_fee =
-            constraint_constants
-              .Genesis_constants.Constraint_constants.account_creation_fee
-        ; config
-        ; logger
-        }
 
       let best_tip_ledger t =
         t.frontier ()
@@ -594,8 +529,6 @@ struct
 
   module For_tests = struct
     let get_rebroadcastable = Resource_pool.get_rebroadcastable
-
-    let snark_tables (t : Resource_pool.t) = t.snark_tables
   end
 
   let get_completed_work t statement =
@@ -604,60 +537,6 @@ struct
       ~f:(fun Priced_proof.{ proof; fee = { fee; prover } } ->
         Transaction_snark_work.Checked.create_unsafe
           { Transaction_snark_work.fee; proofs = proof; prover } )
-
-  (* This causes a snark pool to never be GC'd. This is fine as it should live as long as the daemon lives. *)
-  let store_periodically (t : Resource_pool.t) =
-    Clock.every' (Time.Span.of_min 3.) (fun () ->
-        let before = Time.now () in
-        let%map () =
-          Writer.save_bin_prot t.config.disk_location
-            Snark_tables.Serializable.Stable.Latest.bin_writer_t
-            (Snark_tables.to_serializable t.snark_tables)
-        in
-        let elapsed = Time.(diff (now ()) before |> Span.to_ms) in
-        Mina_metrics.(
-          Snark_work.Snark_pool_serialization_ms_histogram.observe
-            Snark_work.snark_pool_serialization_ms elapsed) ;
-        [%log' debug t.logger] "SNARK pool serialization took $time ms"
-          ~metadata:[ ("time", `Float elapsed) ] )
-
-  let loaded = ref false
-
-  let load ?(allow_multiple_instances_for_tests = false) ~config ~logger
-      ~constraint_constants ~consensus_constants ~time_controller
-      ~frontier_broadcast_pipe ~log_gossip_heard ~on_remote_push () =
-    if (not allow_multiple_instances_for_tests) && !loaded then
-      failwith
-        "Snark_pool.load should only be called once. It has been called twice." ;
-    loaded := true ;
-    let tf_diff_reader, tf_diff_writer =
-      Strict_pipe.(
-        create ~name:"Snark pool Transition frontier diffs" Synchronous)
-    in
-    let%map pool, r_sink, l_sink =
-      match%map
-        Async.Reader.load_bin_prot config.Resource_pool.Config.disk_location
-          Snark_tables.Serializable.Stable.Latest.bin_reader_t
-      with
-      | Ok snark_table ->
-          let pool =
-            Resource_pool.of_serializable snark_table ~constraint_constants
-              ~config ~logger ~frontier_broadcast_pipe
-          in
-          let res =
-            of_resource_pool_and_diffs pool ~logger ~constraint_constants
-              ~tf_diffs:tf_diff_reader ~log_gossip_heard ~on_remote_push
-          in
-          Resource_pool.listen_to_frontier_broadcast_pipe
-            frontier_broadcast_pipe ~tf_diff_writer ;
-          res
-      | Error _e ->
-          create ~config ~logger ~constraint_constants ~consensus_constants
-            ~time_controller ~frontier_broadcast_pipe ~log_gossip_heard
-            ~on_remote_push
-    in
-    store_periodically (resource_pool pool) ;
-    (pool, r_sink, l_sink)
 end
 
 (* TODO: defunctor or remove monkey patching (#3731) *)
@@ -805,17 +684,6 @@ let%test_module "random set test" =
             assert (Result.is_ok res) )
       in
       (pool, tf)
-
-    let%test_unit "serialization" =
-      let t, _tf =
-        Async.Thread_safe.block_on_async_exn (fun () ->
-            Quickcheck.random_value (gen ~length:100 ()) )
-      in
-      let s0 = Mock_snark_pool.For_tests.snark_tables t in
-      let s1 =
-        Snark_tables.to_serializable s0 |> Snark_tables.of_serializable
-      in
-      assert (Snark_tables.equal s0 s1)
 
     let%test_unit "Invalid proofs are not accepted" =
       let open Quickcheck.Generator.Let_syntax in

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -122,6 +122,10 @@ module type Transition_frontier_intf = sig
        t
     -> Transition_frontier.Extensions.Snark_pool_refcount.view
        Pipe_lib.Broadcast_pipe.Reader.t
+
+  val work_is_referenced : t -> Transaction_snark_work.Statement.t -> bool
+
+  val best_tip_table : t -> Transaction_snark_work.Statement.Hash_set.t
 end
 
 module Make
@@ -147,34 +151,15 @@ struct
       end
 
       type transition_frontier_diff =
-        [ `New_refcount_table of Extensions.Snark_pool_refcount.view
+        [ `Refcount_update of Extensions.Snark_pool_refcount.view
         | `New_best_tip of Base_ledger.t ]
 
       type t =
         { snark_tables : Snark_tables.t
         ; snark_table_lock : (unit Throttle.Sequencer.t[@sexp.opaque])
-        ; best_tip_ledger : (unit -> Base_ledger.t option[@sexp.opaque])
-        ; mutable ref_table : int Statement_table.t option
-              (** Tracks the number of blocks that have each work statement in
-                  their scan state.
-                  Work is included iff it is a member of some block scan state.
-                  Used to filter the pool, ensuring that only work referenced
-                  within the frontier is kept.
-              *)
-        ; mutable best_tip_table :
-            Transaction_snark_work.Statement.Hash_set.t option
-              (** The set of all snark work statements present in the scan
-                  state for the last 10 blocks in the best chain.
-                  Used to filter broadcasts of locally produced work, so that
-                  irrelevant work is not broadcast.
-              *)
+        ; frontier : (unit -> Transition_frontier.t option[@sexp.opaque])
         ; config : Config.t
         ; logger : (Logger.t[@sexp.opaque])
-        ; mutable removed_counter : int
-              (** A counter for transition frontier breadcrumbs removed. When
-                  this reaches a certain value, unreferenced snark work is
-                  removed from ref_table
-              *)
         ; account_creation_fee : Currency.Fee.t
         ; batcher : Batcher.Snark_pool.t
         }
@@ -185,30 +170,34 @@ struct
 
       let make_config = Config.make
 
-      let removed_breadcrumb_wait = 10
-
-      let get_best_tip_ledger ~frontier_broadcast_pipe () =
-        Option.map (Broadcast_pipe.Reader.peek frontier_broadcast_pipe)
-          ~f:(fun tf ->
-            Transition_frontier.best_tip tf
-            |> Transition_frontier.Breadcrumb.staged_ledger
-            |> Staged_ledger.ledger )
-
       let of_serializable tables ~constraint_constants ~frontier_broadcast_pipe
           ~config ~logger : t =
         { snark_tables = Snark_tables.of_serializable tables
         ; snark_table_lock = Throttle.Sequencer.create ()
-        ; best_tip_ledger = get_best_tip_ledger ~frontier_broadcast_pipe
+        ; frontier =
+            (fun () -> Broadcast_pipe.Reader.peek frontier_broadcast_pipe)
         ; batcher = Batcher.Snark_pool.create config.verifier
         ; account_creation_fee =
             constraint_constants
               .Genesis_constants.Constraint_constants.account_creation_fee
-        ; ref_table = None
-        ; best_tip_table = None
         ; config
         ; logger
-        ; removed_counter = removed_breadcrumb_wait
         }
+
+      let best_tip_ledger t =
+        t.frontier ()
+        |> Option.map ~f:(fun tf ->
+               Transition_frontier.best_tip tf
+               |> Transition_frontier.Breadcrumb.staged_ledger
+               |> Staged_ledger.ledger )
+
+      let best_tip_table t =
+        t.frontier () |> Option.map ~f:Transition_frontier.best_tip_table
+
+      let work_is_referenced t work =
+        t.frontier ()
+        |> Option.value_map ~default:false ~f:(fun tf ->
+               Transition_frontier.work_is_referenced tf work )
 
       let snark_pool_json t : Yojson.Safe.t =
         `List
@@ -236,19 +225,6 @@ struct
             ; prover
             }
             :: acc )
-
-      (** false when there is no active transition_frontier or
-          when the refcount for the given work is 0 *)
-      let work_is_referenced t work =
-        match t.ref_table with
-        | None ->
-            false
-        | Some ref_table -> (
-            match Statement_table.find ref_table work with
-            | None ->
-                false
-            | Some _ ->
-                true )
 
       let fee_is_sufficient t ~fee ~account_exists =
         Currency.Fee.(fee >= t.account_creation_fee) || account_exists
@@ -313,48 +289,39 @@ struct
             in
             () )
 
-      let handle_new_refcount_table t
-          ({ removed; refcount_table; best_tip_table } :
-            Extensions.Snark_pool_refcount.view ) =
-        t.ref_table <- Some refcount_table ;
-        t.best_tip_table <- Some best_tip_table ;
-        t.removed_counter <- t.removed_counter + removed ;
-        if t.removed_counter >= removed_breadcrumb_wait then (
-          t.removed_counter <- 0 ;
-          Statement_table.filter_keys_inplace t.snark_tables.all ~f:(fun k ->
-              let keep = work_is_referenced t k in
-              if not keep then Hashtbl.remove t.snark_tables.rebroadcastable k ;
-              keep ) ;
-          Mina_metrics.(
-            Gauge.set Snark_work.snark_pool_size
-              (Float.of_int @@ Hashtbl.length t.snark_tables.all)) )
+      let handle_refcount_update t
+          ({ removed_work } : Extensions.Snark_pool_refcount.view) =
+        [%log' trace t.logger]
+          "Handling snark refcount table: $num_removed works were removed"
+          ~metadata:[ ("num_removed", `Int (List.length removed_work)) ] ;
+        List.iter removed_work ~f:(fun work ->
+            Hashtbl.remove t.snark_tables.rebroadcastable work ;
+            Hashtbl.remove t.snark_tables.all work ) ;
+        Mina_metrics.(
+          Gauge.set Snark_work.snark_pool_size
+            (Float.of_int @@ Hashtbl.length t.snark_tables.all))
 
       let handle_transition_frontier_diff u t =
         match u with
         | `New_best_tip ledger ->
             O1trace.thread "apply_new_best_tip_ledger_to_snark_pool" (fun () ->
                 handle_new_best_tip_ledger t ledger )
-        | `New_refcount_table refcount_table ->
-            O1trace.sync_thread "apply_refcount_table_to_snark_pool" (fun () ->
-                handle_new_refcount_table t refcount_table ) ;
+        | `Refcount_update refcount_update ->
+            O1trace.sync_thread "apply_refcount_update_to_snark_pool" (fun () ->
+                handle_refcount_update t refcount_update ) ;
             Deferred.unit
 
       (*TODO? add referenced statements from the transition frontier to ref_table here otherwise the work referenced in the root and not in any of the successor blocks will never be included. This may not be required because the chances of a new block from the root is very low (root's existing successor is 1 block away from finality)*)
-      let listen_to_frontier_broadcast_pipe frontier_broadcast_pipe (t : t)
+      let listen_to_frontier_broadcast_pipe frontier_broadcast_pipe
           ~tf_diff_writer =
-        (* start with empty ref table *)
-        t.ref_table <- None ;
-        t.best_tip_table <- None ;
         let tf_deferred =
           Broadcast_pipe.Reader.iter frontier_broadcast_pipe ~f:(function
             | Some tf ->
                 (* Start the count at the max so we flush after reconstructing
                    the transition_frontier *)
-                t.removed_counter <- removed_breadcrumb_wait ;
                 Broadcast_pipe.Reader.iter
                   (Transition_frontier.snark_pool_refcount_pipe tf) ~f:(fun x ->
-                    Strict_pipe.Writer.write tf_diff_writer
-                      (`New_refcount_table x) )
+                    Strict_pipe.Writer.write tf_diff_writer (`Refcount_update x) )
                 |> Deferred.don't_wait_for ;
                 Broadcast_pipe.Reader.iter
                   (Transition_frontier.best_tip_diff_pipe tf) ~f:(fun _ ->
@@ -366,8 +333,6 @@ struct
                 |> Deferred.don't_wait_for ;
                 return ()
             | None ->
-                t.ref_table <- None ;
-                t.best_tip_table <- None ;
                 return () )
         in
         Deferred.don't_wait_for tf_deferred
@@ -380,19 +345,17 @@ struct
               ; rebroadcastable = Statement_table.create ()
               }
           ; snark_table_lock = Throttle.Sequencer.create ()
-          ; best_tip_ledger = get_best_tip_ledger ~frontier_broadcast_pipe
+          ; frontier =
+              (fun () -> Broadcast_pipe.Reader.peek frontier_broadcast_pipe)
           ; batcher = Batcher.Snark_pool.create config.verifier
           ; logger
           ; config
-          ; ref_table = None
-          ; best_tip_table = None
           ; account_creation_fee =
               constraint_constants
                 .Genesis_constants.Constraint_constants.account_creation_fee
-          ; removed_counter = removed_breadcrumb_wait
           }
         in
-        listen_to_frontier_broadcast_pipe frontier_broadcast_pipe t
+        listen_to_frontier_broadcast_pipe frontier_broadcast_pipe
           ~tf_diff_writer ;
         t
 
@@ -496,7 +459,7 @@ struct
           let account_opt =
             let open Mina_base in
             let open Option.Let_syntax in
-            let%bind ledger = t.best_tip_ledger () in
+            let%bind ledger = best_tip_ledger t in
             if Deferred.is_determined (Base_ledger.detached_signal ledger) then
               None
             else
@@ -612,18 +575,15 @@ struct
         This is limited to recent work which is yet to appear in a block.
     *)
     let get_rebroadcastable t ~has_timed_out:_ =
-      let in_best_tip_table =
-        match t.best_tip_table with
-        | Some best_tip_table ->
-            Hash_set.mem best_tip_table
-        | None ->
-            Fn.const false
-      in
-      Hashtbl.to_alist t.snark_tables.rebroadcastable
-      |> List.filter_map ~f:(fun (stmt, (snark, _time)) ->
-             if in_best_tip_table stmt then
-               Some (Diff.Add_solved_work (stmt, snark))
-             else None )
+      match best_tip_table t with
+      | None ->
+          []
+      | Some best_tips ->
+          Hashtbl.to_alist t.snark_tables.rebroadcastable
+          |> List.filter_map ~f:(fun (stmt, (snark, _time)) ->
+                 if Hash_set.mem best_tips stmt then
+                   Some (Diff.Add_solved_work (stmt, snark))
+                 else None )
 
     let remove_solved_work t work =
       Statement_table.remove t.snark_tables.all work ;
@@ -689,7 +649,7 @@ struct
               ~tf_diffs:tf_diff_reader ~log_gossip_heard ~on_remote_push
           in
           Resource_pool.listen_to_frontier_broadcast_pipe
-            frontier_broadcast_pipe pool ~tf_diff_writer ;
+            frontier_broadcast_pipe ~tf_diff_writer ;
           res
       | Error _e ->
           create ~config ~logger ~constraint_constants ~consensus_constants
@@ -713,6 +673,16 @@ include
 
       let snark_pool_refcount_pipe t =
         Extensions.(get_view_pipe (extensions t) Snark_pool_refcount)
+
+      let snark_pool_refcount t =
+        Extensions.(get_extension (extensions t) Snark_pool_refcount)
+
+      let work_is_referenced t =
+        Extensions.Snark_pool_refcount.work_is_referenced
+          (snark_pool_refcount t)
+
+      let best_tip_table t =
+        Extensions.Snark_pool_refcount.best_tip_table (snark_pool_refcount t)
     end)
 
 module Diff_versioned = struct

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -76,7 +76,7 @@ module type Transition_frontier_intf = sig
 
   val work_is_referenced : t -> Transaction_snark_work.Statement.t -> bool
 
-  val best_tip_table : t -> Transaction_snark_work.Statement.Hash_set.t
+  val best_tip_table : t -> Transaction_snark_work.Statement.Set.t
 end
 
 module Make
@@ -491,7 +491,7 @@ struct
       | Some best_tips ->
           Map.to_alist !(t.snark_tables).rebroadcastable
           |> List.filter_map ~f:(fun (stmt, (snark, _time)) ->
-                 if Hash_set.mem best_tips stmt then
+                 if Set.mem best_tips stmt then
                    Some (Diff.Add_solved_work (stmt, snark))
                  else None )
 

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -2,16 +2,15 @@ open Core_kernel
 open Async
 open Pipe_lib
 open Network_peer
-module Statement_table = Transaction_snark_work.Statement.Table
 
 module Snark_tables = struct
   type t =
     { all :
         Ledger_proof.t One_or_two.t Priced_proof.t
-        Transaction_snark_work.Statement.Table.t
+        Transaction_snark_work.Statement.Map.t
     ; rebroadcastable :
         (Ledger_proof.t One_or_two.t Priced_proof.t * Core.Time.t)
-        Transaction_snark_work.Statement.Table.t
+        Transaction_snark_work.Statement.Map.t
     }
   [@@deriving sexp]
 end
@@ -107,7 +106,7 @@ struct
         | `New_best_tip of Base_ledger.t ]
 
       type t =
-        { snark_tables : Snark_tables.t
+        { snark_tables : Snark_tables.t ref
         ; frontier : (unit -> Transition_frontier.t option[@sexp.opaque])
         ; config : Config.t
         ; logger : (Logger.t[@sexp.opaque])
@@ -135,7 +134,7 @@ struct
 
       let snark_pool_json t : Yojson.Safe.t =
         `List
-          (Statement_table.fold ~init:[] t.snark_tables.all
+          (Map.fold ~init:[] !(t.snark_tables).all
              ~f:(fun ~key ~data:{ proof = _; fee = { fee; prover } } acc ->
                let work_ids =
                  Transaction_snark_work.Statement.compact_json key
@@ -150,7 +149,7 @@ struct
                :: acc ) )
 
       let all_completed_work (t : t) : Transaction_snark_work.Info.t list =
-        Statement_table.fold ~init:[] t.snark_tables.all
+        Map.fold ~init:[] !(t.snark_tables).all
           ~f:(fun ~key ~data:{ proof = _; fee = { fee; prover } } acc ->
             let work_ids = Transaction_snark_work.Statement.work_ids key in
             { Transaction_snark_work.Info.statements = key
@@ -167,7 +166,7 @@ struct
         let open Mina_base in
         let open Signature_lib in
         let prover_account_ids =
-          t.snark_tables.all |> Statement_table.data
+          !(t.snark_tables).all |> Map.data
           |> List.map ~f:(fun { Priced_proof.fee = { prover; _ }; _ } ->
                  prover )
           |> List.dedup_and_sort ~compare:Public_key.Compressed.compare
@@ -181,7 +180,7 @@ struct
           |> Base_ledger.location_of_account_batch ledger
           |> Account_id.Map.of_alist_exn
         in
-        Statement_table.iteri t.snark_tables.all
+        Map.iteri !(t.snark_tables).all
           ~f:(fun ~key ~data:{ fee = { fee; prover }; _ } ->
             let prover_account_exists =
               prover
@@ -192,21 +191,28 @@ struct
             let keep =
               fee_is_sufficient t ~fee ~account_exists:prover_account_exists
             in
-            if not keep then (
-              Hashtbl.remove t.snark_tables.all key ;
-              Hashtbl.remove t.snark_tables.rebroadcastable key ) )
+            if not keep then
+              t.snark_tables :=
+                { all = Map.remove !(t.snark_tables).all key
+                ; rebroadcastable =
+                    Map.remove !(t.snark_tables).rebroadcastable key
+                } )
 
       let handle_refcount_update t
           ({ removed_work } : Extensions.Snark_pool_refcount.view) =
         [%log' trace t.logger]
           "Handling snark refcount table: $num_removed works were removed"
           ~metadata:[ ("num_removed", `Int (List.length removed_work)) ] ;
-        List.iter removed_work ~f:(fun work ->
-            Hashtbl.remove t.snark_tables.rebroadcastable work ;
-            Hashtbl.remove t.snark_tables.all work ) ;
+        t.snark_tables :=
+          { all =
+              List.fold ~init:!(t.snark_tables).all ~f:Map.remove removed_work
+          ; rebroadcastable =
+              List.fold ~init:!(t.snark_tables).rebroadcastable ~f:Map.remove
+                removed_work
+          } ;
         Mina_metrics.(
           Gauge.set Snark_work.snark_pool_size
-            (Float.of_int @@ Hashtbl.length t.snark_tables.all))
+            (Float.of_int @@ Map.length !(t.snark_tables).all))
 
       let handle_transition_frontier_diff u t =
         match u with
@@ -247,9 +253,10 @@ struct
           ~frontier_broadcast_pipe ~config ~logger ~tf_diff_writer =
         let t =
           { snark_tables =
-              { all = Statement_table.create ()
-              ; rebroadcastable = Statement_table.create ()
-              }
+              ref
+                { Snark_tables.all = Transaction_snark_work.Statement.Map.empty
+                ; rebroadcastable = Transaction_snark_work.Statement.Map.empty
+                }
           ; frontier =
               (fun () -> Broadcast_pipe.Reader.peek frontier_broadcast_pipe)
           ; batcher = Batcher.Snark_pool.create config.verifier
@@ -266,22 +273,25 @@ struct
 
       let get_logger t = t.logger
 
-      let request_proof t = Statement_table.find t.snark_tables.all
+      let request_proof t = Map.find !(t.snark_tables).all
 
       let add_snark ?(is_local = false) t ~work
           ~(proof : Ledger_proof.t One_or_two.t) ~fee =
         if work_is_referenced t work then (
           (*Note: fee against existing proofs and the new proofs are checked in
             Diff.unsafe_apply which calls this function*)
-          Hashtbl.set t.snark_tables.all ~key:work ~data:{ proof; fee } ;
-          if is_local then
-            Hashtbl.set t.snark_tables.rebroadcastable ~key:work
-              ~data:({ proof; fee }, Time.now ())
-          else
-            (* Stop rebroadcasting locally generated snarks if they are
-               overwritten. No-op if there is no rebroadcastable SNARK with that
-               statement. *)
-            Hashtbl.remove t.snark_tables.rebroadcastable work ;
+          t.snark_tables :=
+            { all = Map.set !(t.snark_tables).all ~key:work ~data:{ proof; fee }
+            ; rebroadcastable =
+                ( if is_local then
+                  Map.set !(t.snark_tables).rebroadcastable ~key:work
+                    ~data:({ proof; fee }, Time.now ())
+                else
+                  (* Stop rebroadcasting locally generated snarks if they are
+                     overwritten. No-op if there is no rebroadcastable SNARK with that
+                     statement. *)
+                  Map.remove !(t.snark_tables).rebroadcastable work )
+            } ;
           (*when snark work is added to the pool*)
           Mina_metrics.(
             Gauge.set Snark_work.useful_snark_work_received_time_sec
@@ -289,7 +299,7 @@ struct
                 let x = now () |> to_span_since_epoch |> Span.to_sec in
                 x -. Mina_metrics.time_offset_sec) ;
             Gauge.set Snark_work.snark_pool_size
-              (Float.of_int @@ Hashtbl.length t.snark_tables.all) ;
+              (Float.of_int @@ Map.length !(t.snark_tables).all) ;
             Snark_work.Snark_fee_histogram.observe Snark_work.snark_fee
               ( fee.Mina_base.Fee_with_prover.fee
               |> Currency.Fee.to_nanomina_int |> Float.of_int )) ;
@@ -479,15 +489,17 @@ struct
       | None ->
           []
       | Some best_tips ->
-          Hashtbl.to_alist t.snark_tables.rebroadcastable
+          Map.to_alist !(t.snark_tables).rebroadcastable
           |> List.filter_map ~f:(fun (stmt, (snark, _time)) ->
                  if Hash_set.mem best_tips stmt then
                    Some (Diff.Add_solved_work (stmt, snark))
                  else None )
 
     let remove_solved_work t work =
-      Statement_table.remove t.snark_tables.all work ;
-      Statement_table.remove t.snark_tables.rebroadcastable work
+      t.snark_tables :=
+        { all = Map.remove !(t.snark_tables).all work
+        ; rebroadcastable = Map.remove !(t.snark_tables).rebroadcastable work
+        }
   end
 
   include Network_pool_base.Make (Transition_frontier) (Resource_pool)

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -62,7 +62,7 @@ module type Transition_frontier_intf = sig
 
   val work_is_referenced : t -> Transaction_snark_work.Statement.t -> bool
 
-  val best_tip_table : t -> Transaction_snark_work.Statement.Hash_set.t
+  val best_tip_table : t -> Transaction_snark_work.Statement.Set.t
 end
 
 module Make

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -1,4 +1,3 @@
-open Async_kernel
 open Pipe_lib
 open Core_kernel
 
@@ -37,20 +36,6 @@ module type S = sig
        t
     -> Transaction_snark_work.Statement.t
     -> Transaction_snark_work.Checked.t option
-
-  val load :
-       ?allow_multiple_instances_for_tests:bool
-    -> config:Resource_pool.Config.t
-    -> logger:Logger.t
-    -> constraint_constants:Genesis_constants.Constraint_constants.t
-    -> consensus_constants:Consensus.Constants.t
-    -> time_controller:Block_time.Controller.t
-    -> frontier_broadcast_pipe:
-         transition_frontier option Broadcast_pipe.Reader.t
-    -> log_gossip_heard:bool
-    -> on_remote_push:(unit -> unit Deferred.t)
-    -> unit
-    -> (t * Remote_sink.t * Local_sink.t) Deferred.t
 end
 
 module type Transition_frontier_intf = sig

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -74,6 +74,10 @@ module type Transition_frontier_intf = sig
        t
     -> Transition_frontier.Extensions.Snark_pool_refcount.view
        Pipe_lib.Broadcast_pipe.Reader.t
+
+  val work_is_referenced : t -> Transaction_snark_work.Statement.t -> bool
+
+  val best_tip_table : t -> Transaction_snark_work.Statement.Hash_set.t
 end
 
 module Make

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -758,8 +758,7 @@ struct
       Mina_metrics.(
         Gauge.set Transaction_pool.pool_size
           (Float.of_int (Indexed_pool.size pool))) ;
-      t.pool <- pool ;
-      Deferred.unit
+      t.pool <- pool
 
     let create ~constraint_constants ~consensus_constants ~time_controller
         ~frontier_broadcast_pipe ~config ~logger ~tf_diff_writer =
@@ -1366,7 +1365,7 @@ struct
         in
         (decision, accepted, rejected)
 
-      let unsafe_apply' (t : pool) (diff : verified Envelope.Incoming.t) :
+      let unsafe_apply (t : pool) (diff : verified Envelope.Incoming.t) :
           ([ `Accept | `Reject ] * t * rejected, _) Result.t =
         match apply t diff with
         | Ok (decision, accepted, rejected) ->
@@ -1386,8 +1385,6 @@ struct
               , List.map ~f:(Tuple2.map_fst ~f:forget_cmd) rejected )
         | Error e ->
             Error (`Other e)
-
-      let unsafe_apply t diff = Deferred.return (unsafe_apply' t diff)
 
       type Structured_log_events.t +=
         | Transactions_received of { txns : t; sender : Envelope.Sender.t }
@@ -2024,14 +2021,14 @@ let%test_module _ =
                ~libp2p_port:8302 )
       in
       let tm0 = Time.now () in
-      let%bind verified =
+      let%map verified =
         Test.Resource_pool.Diff.verify test.txn_pool
           (Envelope.Incoming.wrap
              ~data:(List.map ~f:User_command.forget_check cs)
              ~sender )
         >>| Or_error.ok_exn
       in
-      let%map result =
+      let result =
         Test.Resource_pool.Diff.unsafe_apply test.txn_pool verified
       in
       let tm1 = Time.now () in

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -28,11 +28,13 @@ module Statement = struct
       let (_ : (t, Arg.Stable.V2.t) Type_equal.t) = Type_equal.T
 
       include Hashable.Make_binable (Arg.Stable.V2)
+      include Comparable.Make_binable (Arg.Stable.V2)
     end
   end]
 
   type t = Stable.Latest.t [@@deriving sexp, hash, compare, yojson, equal]
 
+  include Comparable.Make_binable (Stable.Latest)
   include Hashable.Make (Stable.Latest)
 
   let gen = One_or_two.gen Transaction_snark.Statement.gen

--- a/src/lib/transaction_snark_work/transaction_snark_work.mli
+++ b/src/lib/transaction_snark_work/transaction_snark_work.mli
@@ -6,11 +6,15 @@ module Statement : sig
   type t = Transaction_snark.Statement.t One_or_two.t
   [@@deriving compare, sexp, yojson, equal]
 
+  include Comparable.S with type t := t
+
   include Hashable.S with type t := t
 
   module Stable : sig
     module V2 : sig
       type t [@@deriving bin_io, compare, sexp, version, yojson, equal]
+
+      include Comparable.S with type t := t
 
       include Hashable.S_binable with type t := t
     end

--- a/src/lib/transition_frontier/extensions/snark_pool_refcount.ml
+++ b/src/lib/transition_frontier/extensions/snark_pool_refcount.ml
@@ -8,12 +8,12 @@ module T = struct
   type view = { removed_work : Work.t list } [@@deriving sexp]
 
   type t =
-    { refcount_table : int Work.Table.t
+    { mutable refcount_map : int Work.Map.t
           (** Tracks the number of blocks that have each work statement in
               their scan state.
               Work is included iff it is a member of some block scan state.
           *)
-    ; best_tip_table : Work.Hash_set.t
+    ; mutable best_tip_table : Work.Set.t
           (** The set of all snark work statements present in the scan state
               for the last 10 blocks in the best chain.
           *)
@@ -23,38 +23,40 @@ module T = struct
 
   let get_work = Staged_ledger.Scan_state.all_work_statements_exn
 
-  let work_is_referenced t work = Hashtbl.mem t.refcount_table work
+  let work_is_referenced t work = Map.mem t.refcount_map work
 
   let best_tip_table t = t.best_tip_table
 
-  let add_to_table table t =
-    List.iter (get_work t)
-      ~f:(Work.Table.update table ~f:(Option.value_map ~default:1 ~f:(( + ) 1)))
+  let add_to_table t scan_state =
+    t.refcount_map <-
+      List.fold (get_work scan_state) ~init:t.refcount_map
+        ~f:(Work.Map.update ~f:(Option.value_map ~default:1 ~f:(( + ) 1)))
 
   (** Returns the elements that were removed from the table. *)
-  let remove_from_table table t : Work.t list =
-    List.filter_map (get_work t) ~f:(fun work ->
-        match Work.Table.find table work with
-        | Some 1 ->
-            Work.Table.remove table work ;
-            Some work
-        | Some count ->
-            Work.Table.set table ~key:work ~data:(count - 1) ;
-            None
-        | None ->
-            failwith "Removed a breadcrumb we didn't know about" )
+  let remove_from_table t scan_state : Work.t list =
+    let res, refc =
+      List.fold (get_work scan_state) ~init:([], t.refcount_map)
+        ~f:(fun (res, refc) work ->
+          match Work.Map.find refc work with
+          | Some 1 ->
+              (work :: res, Work.Map.remove refc work)
+          | Some count ->
+              (res, Work.Map.set refc ~key:work ~data:(count - 1))
+          | None ->
+              failwith "Removed a breadcrumb we didn't know about" )
+    in
+    t.refcount_map <- refc ;
+    res
 
   let create ~logger:_ frontier =
     let t =
-      { refcount_table = Work.Table.create ()
-      ; best_tip_table = Work.Hash_set.create ()
-      }
+      { refcount_map = Work.Map.empty; best_tip_table = Work.Set.empty }
     in
     let breadcrumb = Full_frontier.root frontier in
     let scan_state =
       Breadcrumb.staged_ledger breadcrumb |> Staged_ledger.scan_state
     in
-    add_to_table t.refcount_table scan_state ;
+    add_to_table t scan_state ;
     (t, { removed_work = [] })
 
   let handle_diffs t frontier diffs_with_mutants =
@@ -65,8 +67,7 @@ module T = struct
             let scan_state =
               Breadcrumb.staged_ledger breadcrumb |> Staged_ledger.scan_state
             in
-            add_to_table t.refcount_table scan_state ;
-            removals
+            add_to_table t scan_state ; removals
         | E
             ( Root_transitioned
                 { garbage = Full garbage_nodes
@@ -79,8 +80,7 @@ module T = struct
               :: List.map garbage_nodes ~f:(fun node -> node.scan_state)
             in
             let removed_works =
-              List.bind removed_scan_states
-                ~f:(remove_from_table t.refcount_table)
+              List.bind removed_scan_states ~f:(remove_from_table t)
             in
             removed_works :: removals
         | E (Best_tip_changed new_best_tip_hash, _) ->
@@ -95,13 +95,14 @@ module T = struct
                       |> Staged_ledger.all_work_statements_exn
                     with _ -> []
                   in
-                  List.iter ~f:(Hash_set.add t.best_tip_table) statements ;
+                  t.best_tip_table <-
+                    List.fold ~f:Set.add ~init:t.best_tip_table statements ;
                   if blocks_remaining > 0 then
                     update_best_tip_table (blocks_remaining - 1)
                       (Breadcrumb.parent_hash breadcrumb)
             in
             let num_blocks_to_include = 3 in
-            Hash_set.clear t.best_tip_table ;
+            t.best_tip_table <- Work.Set.empty ;
             update_best_tip_table num_blocks_to_include new_best_tip_hash ;
             removals )
     in

--- a/src/lib/transition_frontier/extensions/snark_pool_refcount.ml
+++ b/src/lib/transition_frontier/extensions/snark_pool_refcount.ml
@@ -2,20 +2,10 @@ open Core_kernel
 open Frontier_base
 module Work = Transaction_snark_work.Statement
 
+(* TODO: best tip table should be a separate extension *)
+
 module T = struct
-  type view =
-    { removed : int
-    ; refcount_table : int Work.Table.t
-          (** Tracks the number of blocks that have each work statement in
-              their scan state.
-              Work is included iff it is a member of some block scan state.
-          *)
-    ; best_tip_table : Work.Hash_set.t
-          (** The set of all snark work statements present in the scan state
-              for the last 10 blocks in the best chain.
-          *)
-    }
-  [@@deriving sexp]
+  type view = { removed_work : Work.t list } [@@deriving sexp]
 
   type t =
     { refcount_table : int Work.Table.t
@@ -33,39 +23,26 @@ module T = struct
 
   let get_work = Staged_ledger.Scan_state.all_work_statements_exn
 
-  (** Returns true if this update changed which elements are in the table
-      (but not if the same elements exist with a different reference count) *)
-  let add_to_table ~get_work ~get_statement table t : bool =
-    let res = ref false in
-    List.iter (get_work t) ~f:(fun work ->
-        Work.Table.update table (get_statement work) ~f:(function
-          | Some count ->
-              count + 1
-          | None ->
-              res := true ;
-              1 ) ) ;
-    !res
+  let work_is_referenced t work = Hashtbl.mem t.refcount_table work
 
-  (** Returns true if this update changed which elements are in the table
-      (but not if the same elements exist with a different reference count) *)
-  let remove_from_table ~get_work ~get_statement table t : bool =
-    let res = ref false in
-    List.iter (get_work t) ~f:(fun work ->
-        Work.Table.change table (get_statement work) ~f:(function
-          | Some 1 ->
-              res := true ;
-              None
-          | Some count ->
-              Some (count - 1)
-          | None ->
-              failwith "Removed a breadcrumb we didn't know about" ) ) ;
-    !res
+  let best_tip_table t = t.best_tip_table
 
-  let add_scan_state_to_ref_table table scan_state : bool =
-    add_to_table ~get_work ~get_statement:Fn.id table scan_state
+  let add_to_table table t =
+    List.iter (get_work t)
+      ~f:(Work.Table.update table ~f:(Option.value_map ~default:1 ~f:(( + ) 1)))
 
-  let remove_scan_state_from_ref_table table scan_state : bool =
-    remove_from_table ~get_work ~get_statement:Fn.id table scan_state
+  (** Returns the elements that were removed from the table. *)
+  let remove_from_table table t : Work.t list =
+    List.filter_map (get_work t) ~f:(fun work ->
+        match Work.Table.find table work with
+        | Some 1 ->
+            Work.Table.remove table work ;
+            Some work
+        | Some count ->
+            Work.Table.set table ~key:work ~data:(count - 1) ;
+            None
+        | None ->
+            failwith "Removed a breadcrumb we didn't know about" )
 
   let create ~logger:_ frontier =
     let t =
@@ -73,50 +50,39 @@ module T = struct
       ; best_tip_table = Work.Hash_set.create ()
       }
     in
-    let () =
-      let breadcrumb = Full_frontier.root frontier in
-      let scan_state =
-        Breadcrumb.staged_ledger breadcrumb |> Staged_ledger.scan_state
-      in
-      ignore (add_scan_state_to_ref_table t.refcount_table scan_state : bool)
+    let breadcrumb = Full_frontier.root frontier in
+    let scan_state =
+      Breadcrumb.staged_ledger breadcrumb |> Staged_ledger.scan_state
     in
-    ( t
-    , { removed = 0
-      ; refcount_table = t.refcount_table
-      ; best_tip_table = t.best_tip_table
-      } )
-
-  type diff_update = { num_removed : int; is_added : bool }
+    add_to_table t.refcount_table scan_state ;
+    (t, { removed_work = [] })
 
   let handle_diffs t frontier diffs_with_mutants =
     let open Diff.Full.With_mutant in
-    let { num_removed; is_added } =
-      List.fold diffs_with_mutants ~init:{ num_removed = 0; is_added = false }
-        ~f:(fun { num_removed; is_added } -> function
+    let removals =
+      List.fold diffs_with_mutants ~init:[] ~f:(fun removals -> function
         | E (New_node (Full breadcrumb), _) ->
             let scan_state =
               Breadcrumb.staged_ledger breadcrumb |> Staged_ledger.scan_state
             in
-            let added_scan_state =
-              add_scan_state_to_ref_table t.refcount_table scan_state
-            in
-            { num_removed; is_added = is_added || added_scan_state }
+            add_to_table t.refcount_table scan_state ;
+            removals
         | E
-            ( Root_transitioned { new_root = _; garbage = Full garbage_nodes; _ }
+            ( Root_transitioned
+                { garbage = Full garbage_nodes
+                ; old_root_scan_state = Full old_root_scan_state
+                ; _
+                }
             , _ ) ->
-            let open Diff.Node_list in
-            let extra_num_removed =
-              List.fold garbage_nodes ~init:0 ~f:(fun acc node ->
-                  let delta =
-                    if
-                      remove_scan_state_from_ref_table t.refcount_table
-                        node.scan_state
-                    then 1
-                    else 0
-                  in
-                  acc + delta )
+            let removed_scan_states =
+              old_root_scan_state
+              :: List.map garbage_nodes ~f:(fun node -> node.scan_state)
             in
-            { num_removed = num_removed + extra_num_removed; is_added }
+            let removed_works =
+              List.bind removed_scan_states
+                ~f:(remove_from_table t.refcount_table)
+            in
+            removed_works :: removals
         | E (Best_tip_changed new_best_tip_hash, _) ->
             let rec update_best_tip_table blocks_remaining state_hash =
               match Full_frontier.find frontier state_hash with
@@ -137,15 +103,10 @@ module T = struct
             let num_blocks_to_include = 3 in
             Hash_set.clear t.best_tip_table ;
             update_best_tip_table num_blocks_to_include new_best_tip_hash ;
-            { num_removed; is_added = true } )
+            removals )
     in
-    if num_removed > 0 || is_added then
-      Some
-        { removed = num_removed
-        ; refcount_table = t.refcount_table
-        ; best_tip_table = t.best_tip_table
-        }
-    else None
+    let removed_work = List.concat removals in
+    if not (List.is_empty removed_work) then Some { removed_work } else None
 end
 
 include T

--- a/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
+++ b/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
@@ -5,4 +5,4 @@ include Intf.Extension_intf with type view := view
 
 val work_is_referenced : t -> Transaction_snark_work.Statement.t -> bool
 
-val best_tip_table : t -> Transaction_snark_work.Statement.Hash_set.t
+val best_tip_table : t -> Transaction_snark_work.Statement.Set.t

--- a/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
+++ b/src/lib/transition_frontier/extensions/snark_pool_refcount.mli
@@ -1,15 +1,8 @@
-type view =
-  { removed : int
-  ; refcount_table : int Transaction_snark_work.Statement.Table.t
-        (** Tracks the number of blocks that have each work statement in their
-            scan state.
-            Work is included iff it is a member of some block scan state.
-        *)
-  ; best_tip_table : Transaction_snark_work.Statement.Hash_set.t
-        (** The set of all snark work statements present in the scan state for
-            the last 10 blocks in the best chain.
-        *)
-  }
+type view = { removed_work : Transaction_snark_work.Statement.t list }
 [@@deriving sexp]
 
 include Intf.Extension_intf with type view := view
+
+val work_is_referenced : t -> Transaction_snark_work.Statement.t -> bool
+
+val best_tip_table : t -> Transaction_snark_work.Statement.Hash_set.t

--- a/src/lib/transition_frontier/frontier_base/diff.ml
+++ b/src/lib/transition_frontier/frontier_base/diff.ml
@@ -109,9 +109,14 @@ module Node_list = struct
 end
 
 module Root_transition = struct
+  type 'repr root_transition_scan_state =
+    | Lite : lite root_transition_scan_state
+    | Full : Staged_ledger.Scan_state.t -> full root_transition_scan_state
+
   type 'repr t =
     { new_root : Root_data.Limited.t
     ; garbage : 'repr Node_list.t
+    ; old_root_scan_state : 'repr root_transition_scan_state
     ; just_emitted_a_proof : bool
     }
 
@@ -163,7 +168,11 @@ module Root_transition = struct
           let of_binable
               ({ new_root; garbage; just_emitted_a_proof } :
                 Binable_arg.Stable.V4.t ) : t =
-            { new_root; garbage; just_emitted_a_proof }
+            { new_root
+            ; garbage
+            ; old_root_scan_state = Lite
+            ; just_emitted_a_proof
+            }
         end
 
         include Binable.Of_binable (Binable_arg.Stable.V4) (T_nonbinable)
@@ -238,10 +247,15 @@ let to_lite (type mutant) (diff : (full, mutant) t) : (lite, mutant) t =
       let external_transition = Breadcrumb.validated_transition breadcrumb in
       New_node (Lite external_transition)
   | Root_transitioned
-      { new_root; garbage = Full garbage_nodes; just_emitted_a_proof } ->
+      { new_root
+      ; garbage = Full garbage_nodes
+      ; old_root_scan_state = Full _
+      ; just_emitted_a_proof
+      } ->
       Root_transitioned
         { new_root
         ; garbage = Lite (Node_list.to_lite garbage_nodes)
+        ; old_root_scan_state = Lite
         ; just_emitted_a_proof
         }
   | Best_tip_changed b ->

--- a/src/lib/transition_frontier/frontier_base/diff.mli
+++ b/src/lib/transition_frontier/frontier_base/diff.mli
@@ -63,9 +63,14 @@ end
  *  by transitioning the root.
  *)
 module Root_transition : sig
+  type 'repr root_transition_scan_state =
+    | Lite : lite root_transition_scan_state
+    | Full : Staged_ledger.Scan_state.t -> full root_transition_scan_state
+
   type 'repr t =
     { new_root : Root_data.Limited.t
     ; garbage : 'repr Node_list.t
+    ; old_root_scan_state : 'repr root_transition_scan_state
     ; just_emitted_a_proof : bool
     }
 

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -344,6 +344,8 @@ let calculate_root_transition_diff t heir =
     (Root_transitioned
        { new_root = new_root_data
        ; garbage = Full garbage_nodes
+       ; old_root_scan_state =
+           Full (Breadcrumb.staged_ledger root |> Staged_ledger.scan_state)
        ; just_emitted_a_proof
        } )
 


### PR DESCRIPTION
Related to PR #13409

Explain your changes:
* Fix snark pool leak (cherry-picked from #13409)
* Optimize snark pool garbage collection  (cherry-picked from #13409)
* Remove snark pool persistence (cherry-picked from #13409)
* Map based snark pool tables (cherry-picked from #13409)
* Remove snark tables lock
   * Lock was introduced to split long async job to a few smaller jobs, but is no longer needed as with optimizations of this PR there is no more long async job to split
* Use Map for snark pool refcount

Explain how you tested your changes:
* Tested on a private cluster (45s slot window, epoch length 288 and `k=12`)

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them

* Closes #13324


Partially fixes #13508
