### PR TITLE
Broadcast produced transition immediately

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -610,7 +610,7 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
     ~trust_system ~get_completed_work ~transaction_resource_pool
     ~time_controller ~consensus_local_state ~coinbase_receiver ~frontier_reader
     ~transition_writer ~set_next_producer_timing ~log_block_creation
-    ~block_reward_threshold ~block_produced_bvar ~vrf_evaluation_state =
+    ~block_reward_threshold ~block_produced_bvar ~vrf_evaluation_state ~net =
   let open Context in
   O1trace.sync_thread "produce_blocks" (fun () ->
       let genesis_breadcrumb =
@@ -959,7 +959,9 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                         [%log info] ~metadata
                           "Generated transition $state_hash was accepted into \
                            transition frontier" ;
-                        return ()
+                        Deferred.map ~f:Result.return
+                          (Mina_networking.broadcast_state net
+                             (Breadcrumb.block_with_hash breadcrumb) )
                     | `Timed_out ->
                         (* FIXME #3167: this should be fatal, and more
                            importantly, shouldn't happen.

--- a/src/lib/block_producer/dune
+++ b/src/lib/block_producer/dune
@@ -68,6 +68,7 @@
    kimchi_backend.pasta
    kimchi_backend.pasta.basic
    internal_tracing
+   mina_networking
  )
  (preprocess
   (pps ppx_mina ppx_version ppx_jane ppx_register_event))

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1344,7 +1344,7 @@ let start t =
       ~log_block_creation:t.config.log_block_creation
       ~block_reward_threshold:t.config.block_reward_threshold
       ~block_produced_bvar:t.components.block_produced_bvar
-      ~vrf_evaluation_state:t.vrf_evaluation_state ;
+      ~vrf_evaluation_state:t.vrf_evaluation_state ~net:t.components.net ;
   perform_compaction t ;
   let () =
     match t.config.node_status_url with
@@ -2056,9 +2056,6 @@ let create ?wallets (config : Config.t) =
                             valid_cb
                       | `Internal ->
                           (*Send callback to publish the new block. Don't log rebroadcast message if it is internally generated; There is a broadcast log*)
-                          don't_wait_for
-                            (Mina_networking.broadcast_state net
-                               (Mina_block.Validated.forget transition) ) ;
                           Option.iter
                             ~f:
                               (Fn.flip


### PR DESCRIPTION
This PR addresses two conditions related to block processing/production.

First problem is that after block is produced, it is scheduled for broadcast only in next cycle (or even in the cycle after next). If some long async job appears in between (and this is what happens in Berkeley now), broadcast will be delayed, potentially causing block to appear later-than-needed on other nodes (especially on clusters using block window below 1 minute).

Second problem appears when node goes to bootstrap while a block is being processed in `add_and_finalize`. It happens very infrequently, but shuts the node down when happens.

Solution: broadcast produced transition immediately after it's added to frontier and check for pipe not being closed before writing to it.

Explain how you tested your changes:
* Tested on a private cluster (45s block window, epoch length 288, `k=12`), monitoring long async cycles and ensuring cluster's health

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues?

Closes #13508 with the help of #13550 