### PR TITLE
[CI] Lints for system proofs commit ancestor COMPATIBLE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,9 @@ check-format: ocaml_checks
 check-snarky-submodule:
 	./scripts/check-snarky-submodule.sh
 
+check-proof-systems-submodule:
+	./scripts/check-proof-systems-submodule.sh
+
 #######################################
 ## Environment setup
 

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -22,7 +22,6 @@ let commands =
       [ Cmd.run "./scripts/lint_codeowners.sh"
       , Cmd.run "./scripts/lint_rfcs.sh"
       , Cmd.run "make check-snarky-submodule"
-      , Cmd.run "make check-proof-systems-submodule"
       , Cmd.run "./scripts/lint_preprocessor_deps.sh"
       ]
 
@@ -31,7 +30,11 @@ in  Pipeline.build
         spec = JobSpec::{
         , dirtyWhen = [
             S.strictly (S.contains "Makefile"),
-            S.strictlyStart (S.contains "src/")
+            S.strictlyStart (S.contains "src/"),
+            S.strictlyStart (S.contains "rfcs/"),
+            S.exactly "scripts/compare_ci_diff_types" "sh",
+            S.exactly "scripts/compare_ci_diff_binables" "sh",
+            S.exactly "scripts/check-snarky-submodule" "sh"
           ]
         , path = "Lint"
         , name = "Fast"

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -22,13 +22,17 @@ let commands =
       [ Cmd.run "./scripts/lint_codeowners.sh"
       , Cmd.run "./scripts/lint_rfcs.sh"
       , Cmd.run "make check-snarky-submodule"
+      , Cmd.run "make check-proof-systems-submodule"
       , Cmd.run "./scripts/lint_preprocessor_deps.sh"
       ]
 
 in  Pipeline.build
       Pipeline.Config::{
         spec = JobSpec::{
-        , dirtyWhen = [ S.strictlyStart (S.contains "src/") ]
+        , dirtyWhen = [
+            S.strictly (S.contains "Makefile"),
+            S.strictlyStart (S.contains "src/")
+          ]
         , path = "Lint"
         , name = "Fast"
         }
@@ -37,7 +41,7 @@ in  Pipeline.build
             Command.Config::{
             , commands = commands
             , label =
-                "Fast lint steps; CODEOWNERs, RFCs, Check Snarky Submodule, Preprocessor Deps"
+                "Fast lint steps; CODEOWNERs, RFCs, Check Snarky & Proof-Systems submodules, Preprocessor Deps"
             , key = "lint"
             , target = Size.Small
             , docker = Some Docker::{

--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -1,5 +1,8 @@
 let Prelude = ../../External/Prelude.dhall
 
+let B = ../../External/Buildkite.dhall
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+
 let SelectFiles = ../../Lib/SelectFiles.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall

--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -49,6 +49,50 @@ Pipeline.build
           , docker = Some Docker::{
               image = (../../Constants/ContainerImages.dhall).toolchainBase
             }
+        },
+      Command.build
+        Command.Config::{
+          commands = [ Cmd.run "scripts/merged-to-proof-systems.sh compatible"]
+          , label = "[proof-systems] Check merges cleanly into proof-systems compatible branch"
+          , key = "merged-to-proof-systems-compatible"
+          , soft_fail = Some (B/SoftFail.Boolean True)
+          , target = Size.Small
+          , docker = Some Docker::{
+              image = (../../Constants/ContainerImages.dhall).toolchainBase
+            }
+        },
+      Command.build
+        Command.Config::{
+          commands = [ Cmd.run "scripts/merged-to-proof-systems.sh berkeley"]
+          , label = "[proof-systems] Check merges cleanly into proof-systems berkeley branch"
+          , key = "merged-to-proof-systems-berkeley"
+          , soft_fail = Some (B/SoftFail.Boolean True)
+          , target = Size.Small
+          , docker = Some Docker::{
+              image = (../../Constants/ContainerImages.dhall).toolchainBase
+            }
+        },
+      Command.build
+        Command.Config::{
+          commands = [ Cmd.run "scripts/merged-to-proof-systems.sh develop"]
+          , label = "[proof-systems] Check merges cleanly into proof-systems develop branch"
+          , key = "merged-to-proof-systems-develop"
+          , soft_fail = Some (B/SoftFail.Boolean True)
+          , target = Size.Small
+          , docker = Some Docker::{
+              image = (../../Constants/ContainerImages.dhall).toolchainBase
+            }
+        },
+      Command.build
+        Command.Config::{
+          commands = [ Cmd.run "scripts/merged-to-proof-systems.sh master"]
+          , label = "[proof-systems] Check merges cleanly into proof-systems master branch"
+          , key = "merged-to-proof-systems-master"
+          , soft_fail = Some (B/SoftFail.Boolean True)
+          , target = Size.Small
+          , docker = Some Docker::{
+              image = (../../Constants/ContainerImages.dhall).toolchainBase
+            }
         }
     ]
   }

--- a/scripts/check-proof-systems-submodule.sh
+++ b/scripts/check-proof-systems-submodule.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eu
+
+cd src/lib/crypto/proof-systems
+
+CURR=$(git rev-parse HEAD)
+# temporarily skip SSL verification (for CI)
+git config http.sslVerify false
+git fetch origin
+git config http.sslVerify true
+
+declare -A BRANCH_MAPPING=(
+  ["rampup"]="compatible" 
+  ["berkeley"]="berkeley"
+  ["develop"]="develop"
+  ["izmir"]="master"
+)
+
+function in_branch {
+  if git rev-list origin/$1 | grep -q $CURR; then
+    echo "Proof systems submodule commit is an ancestor of $1"
+    true
+  else
+    false
+  fi
+}
+
+BRANCH="${BRANCH_MAPPING[${BUILDKITE_PULL_REQUEST_BASE_BRANCH}]}"
+
+if (! in_branch ${BRANCH}); then
+  echo "Proof-systems submodule commit is NOT an ancestor of ${BRANCH} branch"
+  exit 1
+fi


### PR DESCRIPTION
Explain your changes:
Added new job to CI for checking if current commit in `src/lib/crypto/proof-system` submodule is ancestor of particular branch. As already discussed, we need that kind of verification for all major mina branches (compatible/berkeley/develop/izmir). Due to the problems with merging back changes between mentioned branches ,@mrmr1993 have this idea that it's better to commit the same script everywhere and control it by base branch variable from buildkite. Thanks to than we don't need to have painful merging back changes between develop/berkeley/compatible.

Explain how you tested your changes:

By running CI

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
