### PR TITLE
Lints for system proofs commit ancestor DEVELOP

### DIFF
--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -22,7 +22,6 @@ let commands =
       [ Cmd.run "./scripts/lint_codeowners.sh"
       , Cmd.run "./scripts/lint_rfcs.sh"
       , Cmd.run "make check-snarky-submodule"
-      , Cmd.run "make check-proof-systems-submodule"
       , Cmd.run "./scripts/lint_preprocessor_deps.sh"
       ]
 
@@ -32,7 +31,10 @@ in  Pipeline.build
         , dirtyWhen = [
             S.strictly (S.contains "Makefile"),
             S.strictlyStart (S.contains "src/"),
-            S.strictlyStart (S.contains "rfcs/")
+            S.strictlyStart (S.contains "rfcs/"),
+            S.exactly "scripts/compare_ci_diff_types" "sh",
+            S.exactly "scripts/compare_ci_diff_binables" "sh",
+            S.exactly "scripts/check-snarky-submodule" "sh"
           ]
         , path = "Lint"
         , name = "Fast"

--- a/buildkite/src/Jobs/Lint/Merge.dhall
+++ b/buildkite/src/Jobs/Lint/Merge.dhall
@@ -54,6 +54,50 @@ Pipeline.build
           , docker = Some Docker::{
               image = (../../Constants/ContainerImages.dhall).toolchainBase
             }
+        },
+      Command.build
+        Command.Config::{
+          commands = [ Cmd.run "scripts/merged-to-proof-systems.sh compatible"]
+          , label = "[proof-systems] Check merges cleanly into proof-systems compatible branch"
+          , key = "merged-to-proof-systems-compatible"
+          , soft_fail = Some (B/SoftFail.Boolean True)
+          , target = Size.Small
+          , docker = Some Docker::{
+              image = (../../Constants/ContainerImages.dhall).toolchainBase
+            }
+        },
+      Command.build
+        Command.Config::{
+          commands = [ Cmd.run "scripts/merged-to-proof-systems.sh berkeley"]
+          , label = "[proof-systems] Check merges cleanly into proof-systems berkeley branch"
+          , key = "merged-to-proof-systems-berkeley"
+          , soft_fail = Some (B/SoftFail.Boolean True)
+          , target = Size.Small
+          , docker = Some Docker::{
+              image = (../../Constants/ContainerImages.dhall).toolchainBase
+            }
+        },
+      Command.build
+        Command.Config::{
+          commands = [ Cmd.run "scripts/merged-to-proof-systems.sh develop"]
+          , label = "[proof-systems] Check merges cleanly into proof-systems develop branch"
+          , key = "merged-to-proof-systems-develop"
+          , soft_fail = Some (B/SoftFail.Boolean True)
+          , target = Size.Small
+          , docker = Some Docker::{
+              image = (../../Constants/ContainerImages.dhall).toolchainBase
+            }
+        },
+      Command.build
+        Command.Config::{
+          commands = [ Cmd.run "scripts/merged-to-proof-systems.sh master"]
+          , label = "[proof-systems] Check merges cleanly into proof-systems master branch"
+          , key = "merged-to-proof-systems-master"
+          , soft_fail = Some (B/SoftFail.Boolean True)
+          , target = Size.Small
+          , docker = Some Docker::{
+              image = (../../Constants/ContainerImages.dhall).toolchainBase
+            }
         }
     ]
   }

--- a/scripts/merged-to-proof-systems.sh
+++ b/scripts/merged-to-proof-systems.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <target-branch>"
+  exit 1
+fi
+
 cd src/lib/crypto/proof-systems
 
 CURR=$(git rev-parse HEAD)
@@ -14,12 +19,8 @@ then
     git config http.sslVerify true
 fi
 
-declare -A BRANCH_MAPPING=(
-  ["rampup"]="compatible"
-  ["berkeley"]="berkeley"
-  ["develop"]="develop"
-  ["izmir"]="master"
-)
+
+BRANCH=$1
 
 function in_branch {
   if git rev-list origin/$1 | grep -q $CURR; then
@@ -29,8 +30,6 @@ function in_branch {
     false
   fi
 }
-
-BRANCH="${BRANCH_MAPPING[${BUILDKITE_PULL_REQUEST_BASE_BRANCH}]}"
 
 if (! in_branch ${BRANCH}); then
   echo "Proof-systems submodule commit is NOT an ancestor of ${BRANCH} branch"


### PR DESCRIPTION
Explain your changes:
Added new job to CI for checking if current commit in `src/lib/crypto/proof-system` submodule is ancestor of particular branch. As already discussed, we need that kind of verification for all major mina branches (compatible/berkeley/develop/izmir). Due to the problems with merging back changes between mentioned branches ,@mrmr1993 have this idea that it's better to commit the same script everywhere and control it by base branch variable from buildkite. Thanks to than we don't need to have painful merging back changes between develop/berkeley/compatible.

Explain how you tested your changes:

By running CI

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
