### PR TITLE
Batch transactions on persistent frontier writing

### DIFF
--- a/src/lib/rocksdb/key_intf.ml
+++ b/src/lib/rocksdb/key_intf.ml
@@ -1,0 +1,25 @@
+module type S = sig
+  type 'a t
+
+  val to_string : 'a t -> string
+
+  val binable_key_type : 'a t -> 'a t Bin_prot.Type_class.t
+
+  val binable_data_type : 'a t -> 'a Bin_prot.Type_class.t
+end
+
+module type Some_key_intf = sig
+  type 'a unwrapped_t
+
+  type t = Some_key : 'a unwrapped_t -> t
+
+  type with_value = Some_key_value : 'a unwrapped_t * 'a -> with_value
+end
+
+module Some_key (K : sig
+  type 'a t
+end) : Some_key_intf with type 'a unwrapped_t := 'a K.t = struct
+  type t = Some_key : 'a K.t -> t
+
+  type with_value = Some_key_value : 'a K.t * 'a -> with_value
+end

--- a/src/lib/rocksdb/serializable.ml
+++ b/src/lib/rocksdb/serializable.ml
@@ -67,6 +67,8 @@ module GADT = struct
   module type S = sig
     include Database_intf
 
+    module Some_key : Key_intf.Some_key_intf with type 'a unwrapped_t := 'a g
+
     module T : sig
       type nonrec t = t
     end
@@ -79,6 +81,8 @@ module GADT = struct
 
     val get_raw : t -> key:'a g -> Bigstring.t option
 
+    val get_batch : t -> keys:Some_key.t list -> Some_key.with_value option list
+
     module Batch : sig
       include Database_intf with type 'a g := 'a g
 
@@ -86,17 +90,7 @@ module GADT = struct
     end
   end
 
-  module type Key_intf = sig
-    type 'a t
-
-    val to_string : 'a t -> string
-
-    val binable_key_type : 'a t -> 'a t Bin_prot.Type_class.t
-
-    val binable_data_type : 'a t -> 'a Bin_prot.Type_class.t
-  end
-
-  module Make (Key : Key_intf) : S with type 'a g := 'a Key.t = struct
+  module Make (Key : Key_intf.S) : S with type 'a g := 'a Key.t = struct
     let bin_key_dump (key : 'a Key.t) =
       Bin_prot.Utils.bin_dump (Key.binable_key_type key).writer key
 
@@ -132,10 +126,27 @@ module GADT = struct
     let get_raw t ~(key : 'a Key.t) = Database.get t ~key:(bin_key_dump key)
 
     let get t ~(key : 'a Key.t) =
-      let open Option.Let_syntax in
-      let%map serialized_value = Database.get t ~key:(bin_key_dump key) in
-      let bin_key = Key.binable_data_type key in
-      bin_key.reader.read serialized_value ~pos_ref:(ref 0)
+      let%map.Option serialized_value =
+        Database.get t ~key:(bin_key_dump key)
+      in
+      let bin_data = Key.binable_data_type key in
+      bin_data.reader.read serialized_value ~pos_ref:(ref 0)
+
+    module Some_key = Key_intf.Some_key (Key)
+
+    let get_batch t ~keys =
+      let open Some_key in
+      let skeys = List.map keys ~f:(fun (Some_key k) -> bin_key_dump k) in
+      let serialized_value_opts = Database.get_batch ~keys:skeys t in
+      let f (Some_key k) =
+        Option.map ~f:(fun serialized_value ->
+            let bin_data = Key.binable_data_type k in
+            let value =
+              bin_data.reader.read serialized_value ~pos_ref:(ref 0)
+            in
+            Some_key_value (k, value) )
+      in
+      List.map2_exn keys serialized_value_opts ~f
 
     module Batch = struct
       include Make_Serializer (Database.Batch)

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -359,11 +359,7 @@ let add ~arcs_cache ~transition =
 
 let move_root ~old_root ~new_root ~garbage =
   let open Root_data.Limited in
-  (* let%map old_root =
-       get t.db ~key:Root ~error:(`Not_found `Old_root_transition)
-     in *)
   let old_root_hash = Root_data.Minimal.hash old_root in
-  (* TODO: Result compatible rocksdb batch transaction *)
   fun batch ->
     Batch.set batch ~key:Root ~data:(Root_data.Minimal.of_limited new_root) ;
     Batch.set batch ~key:Protocol_states_for_root_scan_state

--- a/src/lib/transition_frontier/persistent_frontier/database.mli
+++ b/src/lib/transition_frontier/persistent_frontier/database.mli
@@ -69,22 +69,26 @@ val check :
 
 val initialize : t -> root_data:Root_data.Limited.t -> unit
 
+val find_arcs_and_root :
+     t
+  -> arcs_cache:State_hash.t list State_hash.Table.t
+  -> parent_hashes:State_hash.t list
+  -> ( Root_data.Minimal.t
+     , [> `Not_found of [> `Arcs of State_hash.t | `Old_root_transition ] ] )
+     result
+
 val add :
      arcs_cache:State_hash.t list State_hash.Table.t
-  -> t
   -> transition:Mina_block.Validated.t
-  -> ( batch_t -> unit
-     , [> `Not_found of
-          [> `Parent_transition of State_hash.t | `Arcs of State_hash.t ] ] )
-     Result.t
+  -> batch_t
+  -> unit
 
 val move_root :
-     t
+     old_root:Root_data.Minimal.t
   -> new_root:Root_data.Limited.t
   -> garbage:State_hash.t list
-  -> ( batch_t -> unit
-     , [> `Not_found of [> `New_root_transition | `Old_root_transition ] ] )
-     Result.t
+  -> batch_t
+  -> unit
 
 val get_transition :
      t
@@ -112,7 +116,7 @@ val get_root_hash : t -> (State_hash.t, [> `Not_found of [> `Root ] ]) Result.t
 val get_best_tip :
   t -> (State_hash.t, [> `Not_found of [> `Best_tip ] ]) Result.t
 
-val set_best_tip : t -> State_hash.t -> batch_t -> unit
+val set_best_tip : State_hash.t -> batch_t -> unit
 
 val crawl_successors :
      t

--- a/src/lib/transition_frontier/persistent_frontier/database.mli
+++ b/src/lib/transition_frontier/persistent_frontier/database.mli
@@ -14,6 +14,10 @@ open Frontier_base
 
 type t
 
+type batch_t
+
+val with_batch : t -> f:(batch_t -> 'a) -> 'a
+
 module Error : sig
   type not_found_member =
     [ `Root
@@ -66,9 +70,10 @@ val check :
 val initialize : t -> root_data:Root_data.Limited.t -> unit
 
 val add :
-     t
+     arcs_cache:State_hash.t list State_hash.Table.t
+  -> t
   -> transition:Mina_block.Validated.t
-  -> ( unit
+  -> ( batch_t -> unit
      , [> `Not_found of
           [> `Parent_transition of State_hash.t | `Arcs of State_hash.t ] ] )
      Result.t
@@ -77,7 +82,7 @@ val move_root :
      t
   -> new_root:Root_data.Limited.t
   -> garbage:State_hash.t list
-  -> ( State_hash.t
+  -> ( batch_t -> unit
      , [> `Not_found of [> `New_root_transition | `Old_root_transition ] ] )
      Result.t
 
@@ -107,10 +112,7 @@ val get_root_hash : t -> (State_hash.t, [> `Not_found of [> `Root ] ]) Result.t
 val get_best_tip :
   t -> (State_hash.t, [> `Not_found of [> `Best_tip ] ]) Result.t
 
-val set_best_tip :
-     t
-  -> State_hash.t
-  -> (State_hash.t, [> `Not_found of [> `Best_tip ] ]) Result.t
+val set_best_tip : t -> State_hash.t -> batch_t -> unit
 
 val crawl_successors :
      t

--- a/src/lib/transition_frontier/persistent_frontier/dune
+++ b/src/lib/transition_frontier/persistent_frontier/dune
@@ -13,6 +13,7 @@
    base.caml
    sexplib0
    extlib
+   async_unix
    ;;local libraries
    o1trace
    mina_metrics


### PR DESCRIPTION
Problem: during testing on a private cluster, persistent frontier writes caused a series of consequent long async cycles of length 8s and 9 x 13s (total of > 100s). Long async cycles of more than 10s is a bad sign on its own, but even more so when combined in consequent groups. 

Cycles are caused by a job in persistent frontier that dumps 10 blocks into RocksDB.

Explain your changes:
* Submit changes to RocksDB in a single batch for all 10 blocks

Explain how you tested your changes:
* Tested on a private cluster

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
