### PR TITLE
Do not block pool processing on rebroadcast

### DIFF
--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -136,7 +136,7 @@ module type Broadcast_callback = sig
          -> unit )
     | External of Mina_net2.Validation_callback.t
 
-  val drop : resource_pool_diff -> rejected_diff -> t -> unit Deferred.t
+  val drop : resource_pool_diff -> rejected_diff -> t -> unit
 end
 
 (** A [Network_pool_base_intf] is the core implementation of a
@@ -215,7 +215,7 @@ module type Network_pool_base_intf = sig
        t
     -> resource_pool_diff_verified Envelope.Incoming.t
     -> Broadcast_callback.t
-    -> unit Deferred.t
+    -> unit
 end
 
 (** A [Snark_resource_pool_intf] is a superset of a

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -23,8 +23,7 @@ module type Resource_pool_base_intf = sig
   end
 
   (** Diff from a transition frontier extension that would update the resource pool*)
-  val handle_transition_frontier_diff :
-    transition_frontier_diff -> t -> unit Deferred.t
+  val handle_transition_frontier_diff : transition_frontier_diff -> t -> unit
 
   val create :
        constraint_constants:Genesis_constants.Constraint_constants.t
@@ -93,7 +92,7 @@ module type Resource_pool_diff_intf = sig
     -> verified Envelope.Incoming.t
     -> ( [ `Accept | `Reject ] * t * rejected
        , [ `Locally_generated of t * rejected | `Other of Error.t ] )
-       Deferred.Result.t
+       Result.t
 
   val is_empty : t -> bool
 
@@ -236,7 +235,7 @@ module type Snark_resource_pool_intf = sig
     -> work:Transaction_snark_work.Statement.t
     -> proof:Ledger_proof.t One_or_two.t
     -> fee:Fee_with_prover.t
-    -> [ `Added | `Statement_not_referenced ] Deferred.t
+    -> [ `Added | `Statement_not_referenced ]
 
   val request_proof :
        t

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -137,7 +137,7 @@ end)
         forward t.write_broadcasts diff' rejected cb )
     in
     O1trace.sync_thread apply_and_broadcast_thread_label (fun () ->
-        match%bind Resource_pool.Diff.unsafe_apply t.resource_pool diff with
+        match Resource_pool.Diff.unsafe_apply t.resource_pool diff with
         | Ok (`Accept, accepted, rejected) ->
             rebroadcast (accepted, rejected)
         | Ok (`Reject, accepted, rejected) ->
@@ -203,11 +203,12 @@ end)
                    O1trace.thread processing_diffs_thread_label (fun () ->
                        apply_and_broadcast network_pool verified_diff cb )
                | Transition_frontier_extension diff ->
-                   O1trace.thread
+                   O1trace.sync_thread
                      processing_transition_frontier_diffs_thread_label
                      (fun () ->
                        Resource_pool.handle_transition_frontier_diff diff
-                         resource_pool ) ) ) ) ;
+                         resource_pool ) ;
+                   Deferred.unit ) ) ) ;
     (network_pool, remote_w, local_w)
 
   (* Rebroadcast locally generated pool items every 10 minutes. Do so for 50

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -49,34 +49,30 @@ end)
 
     open Mina_net2.Validation_callback
 
-    let error err =
-      Fn.compose Deferred.return (function
-        | Local f ->
-            f (Error err)
-        | External cb ->
-            fire_if_not_already_fired cb `Reject )
+    let error err = function
+      | Local f ->
+          f (Error err)
+      | External cb ->
+          fire_if_not_already_fired cb `Reject
 
-    let reject accepted rejected =
-      Fn.compose Deferred.return (function
-        | Local f ->
-            f (Ok (`Not_broadcasted, accepted, rejected))
-        | External cb ->
-            fire_if_not_already_fired cb `Reject )
+    let reject accepted rejected = function
+      | Local f ->
+          f (Ok (`Not_broadcasted, accepted, rejected))
+      | External cb ->
+          fire_if_not_already_fired cb `Reject
 
-    let drop accepted rejected =
-      Fn.compose Deferred.return (function
-        | Local f ->
-            f (Ok (`Not_broadcasted, accepted, rejected))
-        | External cb ->
-            fire_if_not_already_fired cb `Ignore )
+    let drop accepted rejected = function
+      | Local f ->
+          f (Ok (`Not_broadcasted, accepted, rejected))
+      | External cb ->
+          fire_if_not_already_fired cb `Ignore
 
     let forward broadcast_pipe accepted rejected = function
       | Local f ->
           f (Ok (`Broadcasted, accepted, rejected)) ;
-          Linear_pipe.write broadcast_pipe accepted
+          Linear_pipe.write broadcast_pipe accepted |> don't_wait_for
       | External cb ->
-          fire_if_not_already_fired cb `Accept ;
-          Deferred.unit
+          fire_if_not_already_fired cb `Accept
   end
 
   module Remote_sink =
@@ -191,7 +187,7 @@ end)
     (*priority: Transition frontier diffs > local diffs > incoming diffs*)
     Deferred.don't_wait_for
       (O1trace.thread Resource_pool.label (fun () ->
-           Strict_pipe.Reader.Merge.iter
+           Strict_pipe.Reader.Merge.iter_sync
              [ Strict_pipe.Reader.map tf_diffs ~f:(fun diff ->
                    Transition_frontier_extension diff )
              ; remote_r
@@ -200,15 +196,14 @@ end)
              ~f:(fun diff_source ->
                match diff_source with
                | Diff ((verified_diff, cb) : Remote_sink.unwrapped_t) ->
-                   O1trace.thread processing_diffs_thread_label (fun () ->
+                   O1trace.sync_thread processing_diffs_thread_label (fun () ->
                        apply_and_broadcast network_pool verified_diff cb )
                | Transition_frontier_extension diff ->
                    O1trace.sync_thread
                      processing_transition_frontier_diffs_thread_label
                      (fun () ->
                        Resource_pool.handle_transition_frontier_diff diff
-                         resource_pool ) ;
-                   Deferred.unit ) ) ) ;
+                         resource_pool ) ) ) ) ;
     (network_pool, remote_w, local_w)
 
   (* Rebroadcast locally generated pool items every 10 minutes. Do so for 50

--- a/src/lib/network_pool/pool_sink.ml
+++ b/src/lib/network_pool/pool_sink.ml
@@ -8,7 +8,7 @@ module type BC_ext = sig
 
   val is_expired : t -> bool
 
-  val error : Error.t -> t -> unit Deferred.t
+  val error : Error.t -> t -> unit
 end
 
 module type Pool_sink = sig
@@ -83,7 +83,8 @@ module Base
         let diff = Envelope.Incoming.data env in
         [%log' warn logger] "Dropping verified diff $diff due to pipe overflow"
           ~metadata:[ ("diff", Diff.verified_to_yojson diff) ] ;
-        BC.drop Diff.empty (Diff.reject_overloaded_diff diff) cb
+        BC.drop Diff.empty (Diff.reject_overloaded_diff diff) cb ;
+        Deferred.unit
 
   let verify_impl ~logger ~trace_label resource_pool rl env cb :
       Diff.verified Envelope.Incoming.t option Deferred.t =
@@ -110,11 +111,11 @@ module Base
                   ; ("diff", summary)
                   ]
                 "exceeded capacity from $sender" ;
-              BC.error (Error.of_string "exceeded capacity") cb
-              >>| fun _ -> None
+              BC.error (Error.of_string "exceeded capacity") cb ;
+              Deferred.return None
           | `Within_capacity ->
               O1trace.thread verify_diffs_thread_label (fun () ->
-                  match%bind Diff.verify resource_pool env with
+                  match%map Diff.verify resource_pool env with
                   | Error err ->
                       [%log' debug logger]
                         "Refusing to rebroadcast $diff. Verification error: \
@@ -124,7 +125,8 @@ module Base
                           ; ("error", Error_json.error_to_yojson err)
                           ] ;
                       (*reject incoming messages*)
-                      BC.error err cb >>| fun _ -> None
+                      BC.error err cb ;
+                      None
                   | Ok verified_diff ->
                       [%log' debug logger] "Verified diff: $verified_diff"
                         ~metadata:
@@ -135,7 +137,7 @@ module Base
                             , Envelope.Sender.to_yojson
                               @@ Envelope.Incoming.sender verified_diff )
                           ] ;
-                      Deferred.return (Some verified_diff) ) )
+                      Some verified_diff ) )
 
   let push t (msg, cb) =
     match t with

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -844,7 +844,8 @@ let%test_module "random set test" =
                  Deferred.unit ) ;
           Mock_snark_pool.apply_and_broadcast network_pool
             (Envelope.Incoming.local command)
-            (Mock_snark_pool.Broadcast_callback.Local (Fn.const ())) )
+            (Mock_snark_pool.Broadcast_callback.Local (Fn.const ())) ;
+          Deferred.unit )
 
     let%test_unit "when creating a network, the incoming diffs and locally \
                    generated diffs in reader pipes will automatically get \

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -107,7 +107,6 @@ struct
 
       type t =
         { snark_tables : Snark_tables.t ref
-        ; snark_table_lock : (unit Throttle.Sequencer.t[@sexp.opaque])
         ; frontier : (unit -> Transition_frontier.t option[@sexp.opaque])
         ; config : Config.t
         ; logger : (Logger.t[@sexp.opaque])
@@ -166,65 +165,35 @@ struct
       let handle_new_best_tip_ledger t ledger =
         let open Mina_base in
         let open Signature_lib in
-        Throttle.enqueue t.snark_table_lock (fun () ->
-            let%map _ =
-              let open Interruptible.Deferred_let_syntax in
-              Interruptible.force
-                (let%bind.Interruptible () =
-                   Interruptible.lift (Deferred.return ())
-                     (Base_ledger.detached_signal ledger)
-                 in
-                 let%bind prover_account_ids =
-                   let account_ids =
-                     !(t.snark_tables).all |> Map.data
-                     |> List.map
-                          ~f:(fun { Priced_proof.fee = { prover; _ }; _ } ->
-                            prover )
-                     |> List.dedup_and_sort
-                          ~compare:Public_key.Compressed.compare
-                     |> List.map ~f:(fun prover ->
-                            (prover, Account_id.create prover Token_id.default) )
-                     |> Public_key.Compressed.Map.of_alist_exn
-                   in
-                   Deferred.map (Scheduler.yield ()) ~f:(Fn.const account_ids)
-                 in
-                 (* if this is still starving the scheduler, we can make `location_of_account_batch` yield while it traverses the masks *)
-                 let%bind prover_account_locations =
-                   let account_locations =
-                     prover_account_ids |> Map.data
-                     |> Base_ledger.location_of_account_batch ledger
-                     |> Account_id.Map.of_alist_exn
-                   in
-                   Deferred.map (Scheduler.yield ())
-                     ~f:(Fn.const account_locations)
-                 in
-                 let yield = Staged.unstage (Scheduler.yield_every ~n:50) in
-                 let%map () =
-                   let open Deferred.Let_syntax in
-                   Map.fold ~init:Deferred.unit !(t.snark_tables).all
-                     ~f:(fun ~key ~data:{ fee = { fee; prover }; _ } acc ->
-                       let%bind () = acc in
-                       let%map () = yield () in
-                       let prover_account_exists =
-                         prover
-                         |> Map.find_exn prover_account_ids
-                         |> Map.find_exn prover_account_locations
-                         |> Option.is_some
-                       in
-                       let keep =
-                         fee_is_sufficient t ~fee
-                           ~account_exists:prover_account_exists
-                       in
-                       if not keep then
-                         t.snark_tables :=
-                           { all = Map.remove !(t.snark_tables).all key
-                           ; rebroadcastable =
-                               Map.remove !(t.snark_tables).rebroadcastable key
-                           } )
-                 in
-                 () )
+        let account_ids =
+          !(t.snark_tables).all |> Map.data
+          |> List.map ~f:(fun { Priced_proof.fee = { prover; _ }; _ } ->
+                 prover )
+          |> List.dedup_and_sort ~compare:Public_key.Compressed.compare
+          |> List.map ~f:(fun prover ->
+                 (prover, Account_id.create prover Token_id.default) )
+          |> Public_key.Compressed.Map.of_alist_exn
+        in
+        (* if this is still starving the scheduler, we can make `location_of_account_batch` yield while it traverses the masks *)
+        let account_locations =
+          account_ids |> Map.data
+          |> Base_ledger.location_of_account_batch ledger
+          |> Account_id.Map.of_alist_exn
+        in
+        Map.iteri !(t.snark_tables).all
+          ~f:(fun ~key ~data:{ fee = { fee; prover }; _ } ->
+            let account_exists =
+              prover |> Map.find_exn account_ids
+              |> Map.find_exn account_locations
+              |> Option.is_some
             in
-            () )
+            let keep = fee_is_sufficient t ~fee ~account_exists in
+            if not keep then
+              t.snark_tables :=
+                { all = Map.remove !(t.snark_tables).all key
+                ; rebroadcastable =
+                    Map.remove !(t.snark_tables).rebroadcastable key
+                } )
 
       let handle_refcount_update t
           ({ removed_work } : Extensions.Snark_pool_refcount.view) =
@@ -245,12 +214,11 @@ struct
       let handle_transition_frontier_diff u t =
         match u with
         | `New_best_tip ledger ->
-            O1trace.thread "apply_new_best_tip_ledger_to_snark_pool" (fun () ->
-                handle_new_best_tip_ledger t ledger )
+            O1trace.sync_thread "apply_new_best_tip_ledger_to_snark_pool"
+              (fun () -> handle_new_best_tip_ledger t ledger)
         | `Refcount_update refcount_update ->
             O1trace.sync_thread "apply_refcount_update_to_snark_pool" (fun () ->
-                handle_refcount_update t refcount_update ) ;
-            Deferred.unit
+                handle_refcount_update t refcount_update )
 
       (*TODO? add referenced statements from the transition frontier to ref_table here otherwise the work referenced in the root and not in any of the successor blocks will never be included. This may not be required because the chances of a new block from the root is very low (root's existing successor is 1 block away from finality)*)
       let listen_to_frontier_broadcast_pipe frontier_broadcast_pipe
@@ -286,7 +254,6 @@ struct
                 { Snark_tables.all = Transaction_snark_work.Statement.Map.empty
                 ; rebroadcastable = Transaction_snark_work.Statement.Map.empty
                 }
-          ; snark_table_lock = Throttle.Sequencer.create ()
           ; frontier =
               (fun () -> Broadcast_pipe.Reader.peek frontier_broadcast_pipe)
           ; batcher = Batcher.Snark_pool.create config.verifier
@@ -307,50 +274,43 @@ struct
 
       let add_snark ?(is_local = false) t ~work
           ~(proof : Ledger_proof.t One_or_two.t) ~fee =
-        Throttle.enqueue t.snark_table_lock (fun () ->
-            Deferred.return
-              ( if work_is_referenced t work then (
-                (*Note: fee against existing proofs and the new proofs are checked in
-                  Diff.unsafe_apply which calls this function*)
-                t.snark_tables :=
-                  { all =
-                      Map.set !(t.snark_tables).all ~key:work
-                        ~data:{ proof; fee }
-                  ; rebroadcastable =
-                      ( if is_local then
-                        Map.set !(t.snark_tables).rebroadcastable ~key:work
-                          ~data:({ proof; fee }, Time.now ())
-                      else
-                        (* Stop rebroadcasting locally generated snarks if they are
-                           overwritten. No-op if there is no rebroadcastable SNARK with that
-                           statement. *)
-                        Map.remove !(t.snark_tables).rebroadcastable work )
-                  } ;
-                (*when snark work is added to the pool*)
-                Mina_metrics.(
-                  Gauge.set Snark_work.useful_snark_work_received_time_sec
-                    Time.(
-                      let x = now () |> to_span_since_epoch |> Span.to_sec in
-                      x -. Mina_metrics.time_offset_sec) ;
-                  Gauge.set Snark_work.snark_pool_size
-                    (Float.of_int @@ Map.length !(t.snark_tables).all) ;
-                  Snark_work.Snark_fee_histogram.observe Snark_work.snark_fee
-                    ( fee.Mina_base.Fee_with_prover.fee
-                    |> Currency.Fee.to_nanomina_int |> Float.of_int )) ;
-                `Added )
-              else
-                let origin =
-                  if is_local then "locally generated" else "gossiped"
-                in
-                [%log' warn t.logger]
-                  "Rejecting %s snark work $stmt, statement not referenced"
-                  origin
-                  ~metadata:
-                    [ ( "stmt"
-                      , One_or_two.to_yojson
-                          Transaction_snark.Statement.to_yojson work )
-                    ] ;
-                `Statement_not_referenced ) )
+        if work_is_referenced t work then (
+          (*Note: fee against existing proofs and the new proofs are checked in
+            Diff.unsafe_apply which calls this function*)
+          t.snark_tables :=
+            { all = Map.set !(t.snark_tables).all ~key:work ~data:{ proof; fee }
+            ; rebroadcastable =
+                ( if is_local then
+                  Map.set !(t.snark_tables).rebroadcastable ~key:work
+                    ~data:({ proof; fee }, Time.now ())
+                else
+                  (* Stop rebroadcasting locally generated snarks if they are
+                     overwritten. No-op if there is no rebroadcastable SNARK with that
+                     statement. *)
+                  Map.remove !(t.snark_tables).rebroadcastable work )
+            } ;
+          (*when snark work is added to the pool*)
+          Mina_metrics.(
+            Gauge.set Snark_work.useful_snark_work_received_time_sec
+              Time.(
+                let x = now () |> to_span_since_epoch |> Span.to_sec in
+                x -. Mina_metrics.time_offset_sec) ;
+            Gauge.set Snark_work.snark_pool_size
+              (Float.of_int @@ Map.length !(t.snark_tables).all) ;
+            Snark_work.Snark_fee_histogram.observe Snark_work.snark_fee
+              ( fee.Mina_base.Fee_with_prover.fee
+              |> Currency.Fee.to_nanomina_int |> Float.of_int )) ;
+          `Added )
+        else
+          let origin = if is_local then "locally generated" else "gossiped" in
+          [%log' warn t.logger]
+            "Rejecting %s snark work $stmt, statement not referenced" origin
+            ~metadata:
+              [ ( "stmt"
+                , One_or_two.to_yojson Transaction_snark.Statement.to_yojson
+                    work )
+              ] ;
+          `Statement_not_referenced
 
       let verify_and_act t ~work ~sender =
         let statements, priced_proof = work in
@@ -650,14 +610,14 @@ let%test_module "random set test" =
           (work, { Priced_proof.Stable.Latest.proof = proof work; fee })
       in
       let enveloped_diff = Envelope.Incoming.wrap ~data:diff ~sender in
-      match%bind
+      match%map
         Mock_snark_pool.Resource_pool.Diff.verify resource_pool enveloped_diff
       with
       | Ok _ ->
           Mock_snark_pool.Resource_pool.Diff.unsafe_apply resource_pool
             enveloped_diff
       | Error _ ->
-          Deferred.return (Error (`Other (Error.of_string "Invalid diff")))
+          Error (`Other (Error.of_string "Invalid diff"))
 
     let config =
       Mock_snark_pool.Resource_pool.make_config ~verifier ~trust_system

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -69,10 +69,9 @@ let%test_module "network pool test" =
             Mock_snark_pool.Resource_pool.Diff.Add_solved_work
               (work, priced_proof)
           in
-          don't_wait_for
-            (Mock_snark_pool.apply_and_broadcast network_pool
-               (Envelope.Incoming.local command)
-               (Mock_snark_pool.Broadcast_callback.Local (Fn.const ())) ) ;
+          Mock_snark_pool.apply_and_broadcast network_pool
+            (Envelope.Incoming.local command)
+            (Mock_snark_pool.Broadcast_callback.Local (Fn.const ())) ;
           let%map _ =
             Linear_pipe.read (Mock_snark_pool.broadcasts network_pool)
           in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -758,8 +758,7 @@ struct
       Mina_metrics.(
         Gauge.set Transaction_pool.pool_size
           (Float.of_int (Indexed_pool.size pool))) ;
-      t.pool <- pool ;
-      Deferred.unit
+      t.pool <- pool
 
     let create ~constraint_constants ~consensus_constants ~time_controller
         ~frontier_broadcast_pipe ~config ~logger ~tf_diff_writer =
@@ -1366,7 +1365,7 @@ struct
         in
         (decision, accepted, rejected)
 
-      let unsafe_apply' (t : pool) (diff : verified Envelope.Incoming.t) :
+      let unsafe_apply (t : pool) (diff : verified Envelope.Incoming.t) :
           ([ `Accept | `Reject ] * t * rejected, _) Result.t =
         match apply t diff with
         | Ok (decision, accepted, rejected) ->
@@ -1386,8 +1385,6 @@ struct
               , List.map ~f:(Tuple2.map_fst ~f:forget_cmd) rejected )
         | Error e ->
             Error (`Other e)
-
-      let unsafe_apply t diff = Deferred.return (unsafe_apply' t diff)
 
       type Structured_log_events.t +=
         | Transactions_received of { txns : t; sender : Envelope.Sender.t }
@@ -2024,14 +2021,14 @@ let%test_module _ =
                ~libp2p_port:8302 )
       in
       let tm0 = Time.now () in
-      let%bind verified =
+      let%map verified =
         Test.Resource_pool.Diff.verify test.txn_pool
           (Envelope.Incoming.wrap
              ~data:(List.map ~f:User_command.forget_check cs)
              ~sender )
         >>| Or_error.ok_exn
       in
-      let%map result =
+      let result =
         Test.Resource_pool.Diff.unsafe_apply test.txn_pool verified
       in
       let tm1 = Time.now () in


### PR DESCRIPTION
Problem: in certain conditions processing of a pool item may stall block processing. This happens because transition frontier extension event is written to a synchronous pipe which is read from the merged reader of a few items:

```
Strict_pipe.Reader.Merge.iter_sync
             [ Strict_pipe.Reader.map tf_diffs ~f:(fun diff ->
                   Transition_frontier_extension diff )
             ; remote_r
             ; local_r
             ]
```

Despite remote and local pool items being given a lower priority, processing of them may block transition frontier extension handling. It leads to a significant (multiple seconds) delay on one block, but also leads to accumulation of unprocessed blocks. If the delay repeats a few times (which is probabilistic), block delay may start growing as an avalanche, leading to hundreds of seconds of delays in block processing.

Explain your changes:
* Wrap broadcasting of a pool item into `don't_wait_for`

Explain how you tested your changes:
* Tested on a private cluster

PR is built on top of #13550 because that contains [Remove snark tables lock](https://github.com/MinaProtocol/mina/pull/13550/commits/f2bd54b26fa3631b77b3ea2926882c88b02dbb98) change which significantly simplifies pool processing code and makes implementation of this PR easier.

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues?