### PR TITLE
Add internal logging to track pool items

### DIFF
--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1031,11 +1031,15 @@ let setup_daemon logger =
             ~f:(fun (span, context) ->
               let secs = Time_ns.Span.to_sec span in
               let monitor_infos = get_monitor_infos context.monitor in
+              let o1trace = o1trace context in
+              [%log internal] "Long_async_cycle"
+                ~metadata:
+                  [ ("duration", `Float secs); ("trace", `List o1trace) ] ;
               [%log debug]
                 ~metadata:
                   [ ("long_async_cycle", `Float secs)
                   ; ("monitors", `List monitor_infos)
-                  ; ("o1trace", `List (o1trace context))
+                  ; ("o1trace", `List o1trace)
                   ]
                 "Long async cycle, $long_async_cycle seconds, $monitors, \
                  $o1trace" ;
@@ -1046,11 +1050,15 @@ let setup_daemon logger =
             ~f:(fun (context, span) ->
               let secs = Time_ns.Span.to_sec span in
               let monitor_infos = get_monitor_infos context.monitor in
+              let o1trace = o1trace context in
+              [%log internal] "Long_async_job"
+                ~metadata:
+                  [ ("duration", `Float secs); ("trace", `List o1trace) ] ;
               [%log debug]
                 ~metadata:
                   [ ("long_async_job", `Float secs)
                   ; ("monitors", `List monitor_infos)
-                  ; ("o1trace", `List (o1trace context))
+                  ; ("o1trace", `List o1trace)
                   ; ( "most_recent_2_backtrace"
                     , `String
                         (String.concat ~sep:"␤"

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -344,7 +344,8 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          the old key v1"
         (send_invalid_zkapp ~logger
            (Network.Node.get_ingress_uri whale1)
-           zkapp_command_update_vk2_refers_vk1 "invalid" )
+           zkapp_command_update_vk2_refers_vk1
+           "Expected vk hash doesn't match hash in vk we received" )
     in
     let%bind () =
       section

--- a/src/app/test_executive/verification_key_update.ml
+++ b/src/app/test_executive/verification_key_update.ml
@@ -344,7 +344,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
          the old key v1"
         (send_invalid_zkapp ~logger
            (Network.Node.get_ingress_uri whale1)
-           zkapp_command_update_vk2_refers_vk1 "Verification_failed" )
+           zkapp_command_update_vk2_refers_vk1 "invalid" )
     in
     let%bind () =
       section

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -775,7 +775,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section_hard "Send a zkapp with an invalid proof"
         (send_invalid_zkapp ~logger
            (Network.Node.get_ingress_uri node)
-           zkapp_command_invalid_proof "invalid" )
+           zkapp_command_invalid_proof "Invalid_proof" )
     in
     let%bind () =
       section_hard "Send a zkapp with an insufficient replace fee"
@@ -800,7 +800,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section_hard "Send a zkApp transaction with an invalid signature"
         (send_invalid_zkapp ~logger
            (Network.Node.get_ingress_uri node)
-           zkapp_command_invalid_signature "invalid" )
+           zkapp_command_invalid_signature "Invalid_signature" )
     in
     let%bind () =
       section_hard "Send a zkApp transaction with a nonexistent fee payer"

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -775,7 +775,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section_hard "Send a zkapp with an invalid proof"
         (send_invalid_zkapp ~logger
            (Network.Node.get_ingress_uri node)
-           zkapp_command_invalid_proof "Verification_failed" )
+           zkapp_command_invalid_proof "invalid" )
     in
     let%bind () =
       section_hard "Send a zkapp with an insufficient replace fee"
@@ -800,7 +800,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section_hard "Send a zkApp transaction with an invalid signature"
         (send_invalid_zkapp ~logger
            (Network.Node.get_ingress_uri node)
-           zkapp_command_invalid_signature "Verification_failed" )
+           zkapp_command_invalid_signature "invalid" )
     in
     let%bind () =
       section_hard "Send a zkApp transaction with a nonexistent fee payer"

--- a/src/app/test_executive/zkapps.ml
+++ b/src/app/test_executive/zkapps.ml
@@ -756,7 +756,7 @@ module Make (Inputs : Intf.Test.Inputs_intf) = struct
       section_hard "Send a zkapp with a different chain id"
         (send_invalid_zkapp ~logger
            (Network.Node.get_ingress_uri node)
-           zkapp_command_cross_network_replay "Verification_failed" )
+           zkapp_command_cross_network_replay "Invalid_proof" )
     in
     let%bind () =
       section_hard "Send a zkapp with an insufficient fee"

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -897,12 +897,18 @@ let run ~context:(module Context : CONTEXT) ~vrf_evaluator ~prover ~verifier
                              | `Prover_error _ ) as err ->
                                err )
                     in
+                    let txs =
+                      Mina_block.transactions ~constraint_constants
+                        (Breadcrumb.block breadcrumb)
+                      |> List.map ~f:Transaction.yojson_summary_with_status
+                    in
                     [%log internal] "@block_metadata"
                       ~metadata:
                         [ ( "blockchain_length"
                           , Mina_numbers.Length.to_yojson
                             @@ Mina_block.blockchain_length
                             @@ Breadcrumb.block breadcrumb )
+                        ; ("transactions", `List txs)
                         ] ;
                     [%str_log info]
                       ~metadata:

--- a/src/lib/mina_base/signed_command.ml
+++ b/src/lib/mina_base/signed_command.ml
@@ -127,6 +127,8 @@ module Make_str (_ : Wire_types.Concrete) = struct
 
   include (Stable.Latest : module type of Stable.Latest with type t := t)
 
+  let signature Poly.{ signature; _ } = signature
+
   let payload Poly.{ payload; _ } = payload
 
   let fee = Fn.compose Payload.fee payload

--- a/src/lib/mina_base/signed_command_intf.ml
+++ b/src/lib/mina_base/signed_command_intf.ml
@@ -84,6 +84,8 @@ module type S = sig
 
   include Hashable.S with type t := t
 
+  val signature : t -> Signature.t
+
   val payload : t -> Signed_command_payload.t
 
   val fee : t -> Currency.Fee.t

--- a/src/lib/mina_lib/mina_lib.ml
+++ b/src/lib/mina_lib/mina_lib.ml
@@ -1843,8 +1843,9 @@ let create ?wallets (config : Config.t) =
               ; on_push = notify_online
               ; log_gossip_heard = config.net_config.log_gossip_heard.new_state
               ; time_controller = config.net_config.time_controller
-              ; consensus_constants = config.net_config.consensus_constants
+              ; consensus_constants
               ; genesis_constants = config.precomputed_values.genesis_constants
+              ; constraint_constants
               }
           in
           let sinks = (block_sink, tx_remote_sink, snark_remote_sink) in

--- a/src/lib/mina_lib/tests/tests.ml
+++ b/src/lib/mina_lib/tests/tests.ml
@@ -80,6 +80,7 @@ let%test_module "Epoch ledger sync tests" =
           ; time_controller
           ; consensus_constants
           ; genesis_constants = precomputed_values.genesis_constants
+          ; constraint_constants
           }
       in
       let pids = Child_processes.Termination.create_pid_table () in

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -41,6 +41,39 @@ module type Resource_pool_base_intf = sig
     -> t
 end
 
+module Verification_error = struct
+  type t =
+    | Fee_higher
+    | Fee_equal
+    | Recently_seen
+    | Invalid of Error.t
+    | Failure of Error.t
+
+  let to_error = function
+    | Fee_equal ->
+        Error.of_string "fee equal to cheapest work we have"
+    | Fee_higher ->
+        Error.of_string "fee higher than cheapest work we have"
+    | Invalid err ->
+        Error.tag err ~tag:"invalid"
+    | Failure err ->
+        Error.tag err ~tag:"failure"
+    | Recently_seen ->
+        Error.of_string "recently seen"
+
+  let to_short_string = function
+    | Recently_seen ->
+        "recently_seen"
+    | Fee_equal ->
+        "fee_equal"
+    | Fee_higher ->
+        "fee_higher"
+    | Invalid _ ->
+        "invalid"
+    | Failure _ ->
+        "failure"
+end
+
 (** A [Resource_pool_diff_intf] is a representation of a mutation to
  *  perform on a [Resource_pool_base_intf]. It includes the logic for
  *  processing this mutation and applying it to an underlying
@@ -82,7 +115,7 @@ module type Resource_pool_diff_intf = sig
   val verify :
        pool
     -> t Envelope.Incoming.t
-    -> verified Envelope.Incoming.t Deferred.Or_error.t
+    -> (verified Envelope.Incoming.t, Verification_error.t) Deferred.Result.t
 
   (** Warning: Using this directly could corrupt the resource pool if it
       conincides with applying locally generated diffs or diffs from the network
@@ -97,10 +130,16 @@ module type Resource_pool_diff_intf = sig
   val is_empty : t -> bool
 
   val update_metrics :
-       t Envelope.Incoming.t
+       logger:Logger.t
+    -> log_gossip_heard:bool
+    -> t Envelope.Incoming.t
     -> Mina_net2.Validation_callback.t
-    -> Logger.t option
     -> unit
+
+  val log_internal :
+    ?reason:string -> logger:Logger.t -> string -> t Envelope.Incoming.t -> unit
+
+  val t_of_verified : verified -> t
 end
 
 (** A [Resource_pool_intf] ties together an associated pair of
@@ -248,7 +287,7 @@ module type Snark_resource_pool_intf = sig
          Transaction_snark_work.Statement.t
          * Ledger_proof.t One_or_two.t Priced_proof.t
     -> sender:Envelope.Sender.t
-    -> bool Deferred.t
+    -> (unit, Verification_error.t) Deferred.Result.t
 
   val snark_pool_json : t -> Yojson.Safe.t
 

--- a/src/lib/network_pool/pool_sink.ml
+++ b/src/lib/network_pool/pool_sink.ml
@@ -95,7 +95,7 @@ module Base
         if BC.is_expired cb then Deferred.return None
         else
           let summary = `String (Diff.summary @@ Envelope.Incoming.data env) in
-          [%log' debug logger] "Verifying $diff from $sender"
+          [%log debug] "Verifying $diff from $sender"
             ~metadata:
               [ ("diff", summary)
               ; ("sender", Envelope.Sender.to_yojson env.sender)
@@ -105,19 +105,25 @@ module Base
               ~score:(Diff.score env.data)
           with
           | `Capacity_exceeded ->
-              [%log' debug logger]
+              [%log debug]
                 ~metadata:
                   [ ("sender", Envelope.Sender.to_yojson env.sender)
                   ; ("diff", summary)
                   ]
                 "exceeded capacity from $sender" ;
               BC.error (Error.of_string "exceeded capacity") cb ;
+              Diff.log_internal ~logger "rejected" ~reason:"rate_limit" env ;
               Deferred.return None
           | `Within_capacity ->
               O1trace.thread verify_diffs_thread_label (fun () ->
                   match%map Diff.verify resource_pool env with
-                  | Error err ->
-                      [%log' debug logger]
+                  | Error ver_err ->
+                      Diff.log_internal ~logger "rejected"
+                        ~reason:
+                          (Intf.Verification_error.to_short_string ver_err)
+                        env ;
+                      let err = Intf.Verification_error.to_error ver_err in
+                      [%log debug]
                         "Refusing to rebroadcast $diff. Verification error: \
                          $error"
                         ~metadata:
@@ -128,7 +134,7 @@ module Base
                       BC.error err cb ;
                       None
                   | Ok verified_diff ->
-                      [%log' debug logger] "Verified diff: $verified_diff"
+                      [%log debug] "Verified diff: $verified_diff"
                         ~metadata:
                           [ ( "verified_diff"
                             , Diff.verified_to_yojson
@@ -157,10 +163,10 @@ module Base
         let%bind () = on_push () in
         let env' = Msg.convert msg in
         let cb' = Msg.convert_callback cb in
+        Diff.log_internal ~logger "received" env' ;
         ( match cb' with
         | BC.External cb'' ->
-            Diff.update_metrics env' cb''
-              (Option.some_if log_gossip_heard logger) ;
+            Diff.update_metrics env' cb'' ~log_gossip_heard ~logger ;
             don't_wait_for
               ( match%map Mina_net2.Validation_callback.await cb'' with
               | None ->
@@ -173,8 +179,9 @@ module Base
                   () )
         | _ ->
             () ) ;
-        if Throttle.num_jobs_waiting_to_start throttle > max_waiting_jobs then
-          [%log warn] "Ignoring push to %s: throttle is full" trace_label
+        if Throttle.num_jobs_waiting_to_start throttle > max_waiting_jobs then (
+          Diff.log_internal ~logger "rejected" ~reason:"throttle_full" env' ;
+          [%log warn] "Ignoring push to %s: throttle is full" trace_label )
         else
           don't_wait_for
             (Throttle.enqueue throttle (fun () ->

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -313,6 +313,7 @@ struct
           `Statement_not_referenced
 
       let verify_and_act t ~work ~sender =
+        let open Intf.Verification_error in
         let statements, priced_proof = work in
         let { Priced_proof.proof = proofs; fee = { prover; fee } } =
           priced_proof
@@ -346,11 +347,11 @@ struct
         let message = Mina_base.Sok_message.create ~fee ~prover in
         let verify proofs =
           let open Deferred.Let_syntax in
-          let%bind statement_check =
+          let statement_check () =
             One_or_two.Deferred_result.map proofs ~f:(fun (p, s) ->
                 let proof_statement = Ledger_proof.statement p in
                 if Transaction_snark.Statement.( = ) proof_statement s then
-                  Deferred.Or_error.ok_unit
+                  Deferred.Result.return ()
                 else
                   let e = Error.of_string "Statement and proof do not match" in
                   if is_local then
@@ -360,7 +361,7 @@ struct
                         %{sexp: Transaction_snark.Statement.t}"
                       proof_statement s ;
                   let%map () = log_and_punish s e in
-                  Error e )
+                  Error (Invalid e) )
           in
           let work = One_or_two.map proofs ~f:snd in
           let account_opt =
@@ -385,14 +386,15 @@ struct
             && Mina_base.Account.has_permission
                  ~control:Mina_base.Control.Tag.None_given ~to_:`Receive account
           in
+          let invalid s = Deferred.Result.fail @@ Invalid (Error.of_string s) in
           if
             not (fee_is_sufficient t ~fee ~account_exists:prover_account_exists)
           then (
             [%log' debug t.logger]
               "Snark work did not have sufficient fee to create prover $prover \
-               acccount"
+               account"
               ~metadata ;
-            return false )
+            invalid "fee not sufficient to create prover account" )
           else if
             Option.value_map ~default:false ~f:not prover_permitted_to_receive
           then (
@@ -407,7 +409,7 @@ struct
                          ~f:(fun (a : Mina_base.Account.t) -> a.permissions) )
                         .receive )
                 :: metadata ) ;
-            return false )
+            invalid "prover not permitted to receive fees" )
           else if not (work_is_referenced t work) then (
             [%log' debug t.logger] "Work $stmt not referenced"
               ~metadata:
@@ -415,49 +417,42 @@ struct
                   , One_or_two.to_yojson Transaction_snark.Statement.to_yojson
                       work )
                 :: metadata ) ;
-            return false )
+            invalid "work not referenced" )
           else
-            match statement_check with
-            | Error _ ->
-                return false
-            | Ok _ -> (
-                let log ?punish e =
-                  Deferred.List.iter (One_or_two.to_list proofs)
-                    ~f:(fun (_, s) -> log_and_punish ?punish s e)
-                in
-                let proof_env =
-                  Envelope.Incoming.wrap
-                    ~data:(One_or_two.map proofs ~f:fst, message)
-                    ~sender
-                in
-                match Signature_lib.Public_key.decompress prover with
-                | None ->
-                    (* We may need to decompress the key when paying the fee
-                       transfer, so check that we can do it now.
-                    *)
-                    [%log' error t.logger]
-                      "Proof had an invalid key: $public_key"
-                      ~metadata:
-                        [ ( "public_key"
-                          , Signature_lib.Public_key.Compressed.to_yojson prover
-                          )
-                        ] ;
-                    Deferred.return false
-                | Some _ -> (
-                    match%bind
-                      Batcher.Snark_pool.verify t.batcher proof_env
-                    with
-                    | Ok true ->
-                        return true
-                    | Ok false ->
-                        (* if this proof is in the set of invalid proofs*)
-                        let e = Error.of_string "Invalid proof" in
-                        let%map () = log e in
-                        false
-                    | Error e ->
-                        (* Verifier crashed or other errors at our end. Don't punish the peer*)
-                        let%map () = log ~punish:false e in
-                        false ) )
+            let%bind.Deferred.Result _ = statement_check () in
+            let log ?punish e =
+              Deferred.List.iter (One_or_two.to_list proofs) ~f:(fun (_, s) ->
+                  log_and_punish ?punish s e )
+            in
+            let proof_env =
+              Envelope.Incoming.wrap
+                ~data:(One_or_two.map proofs ~f:fst, message)
+                ~sender
+            in
+            match Signature_lib.Public_key.decompress prover with
+            | None ->
+                (* We may need to decompress the key when paying the fee
+                   transfer, so check that we can do it now.
+                *)
+                [%log' error t.logger] "Proof had an invalid key: $public_key"
+                  ~metadata:
+                    [ ( "public_key"
+                      , Signature_lib.Public_key.Compressed.to_yojson prover )
+                    ] ;
+                invalid "invalid key"
+            | Some _ -> (
+                match%bind Batcher.Snark_pool.verify t.batcher proof_env with
+                | Ok true ->
+                    Deferred.Result.return ()
+                | Ok false ->
+                    (* if this proof is in the set of invalid proofs*)
+                    let e = Error.of_string "Invalid proof" in
+                    let%bind () = log e in
+                    invalid "invalid proof"
+                | Error e ->
+                    (* Verifier crashed or other errors at our end. Don't punish the peer*)
+                    let%map () = log ~punish:false e in
+                    Error (Failure e) )
         in
         match One_or_two.zip proofs statements with
         | Ok pairs ->
@@ -472,7 +467,8 @@ struct
                   ]
                 @ metadata )
               "One_or_two length mismatch: $error" ;
-            Deferred.return false
+            Deferred.Result.fail
+            @@ Invalid (Error.tag ~tag:"One_or_two length mismatch" e)
     end
 
     include T

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -32,6 +32,8 @@ module Make
 
   type verified = t [@@deriving compare, sexp, to_yojson]
 
+  let t_of_verified = ident
+
   type rejected = Rejected.t [@@deriving sexp, yojson]
 
   let label = Pool.label
@@ -89,50 +91,49 @@ module Make
         ; fee = { fee = res.spec.fee; prover = res.prover }
         } )
 
-  let has_lower_fee pool work ~fee ~sender =
+  (** Check whether there is a proof with lower fee in the pool.
+      Returns [Ok ()] is the [~fee] would be the lowest in pool.
+  *)
+  let has_no_lower_fee pool work ~fee ~sender =
     let reject_and_log_if_local reason =
       [%log' trace (Pool.get_logger pool)]
         "Rejecting snark work $work from $sender: $reason"
         ~metadata:
           [ ("work", Work.compact_json work)
           ; ("sender", Envelope.Sender.to_yojson sender)
-          ; ("reason", `String reason)
+          ; ( "reason"
+            , Error_json.error_to_yojson
+              @@ Intf.Verification_error.to_error reason )
           ] ;
-      Or_error.error_string reason
+      Result.fail reason
     in
     match Pool.request_proof pool work with
     | None ->
         Ok ()
-    | Some { fee = { fee = prev; _ }; _ } -> (
-        match Currency.Fee.compare fee prev with
-        | -1 ->
-            Ok ()
-        | 0 ->
-            reject_and_log_if_local "fee equal to cheapest work we have"
-        | 1 ->
-            reject_and_log_if_local "fee higher than cheapest work we have"
-        | _ ->
-            failwith "compare didn't return -1, 0, or 1!" )
+    | Some { fee = { fee = prev; _ }; _ } ->
+        let cmp_res = Currency.Fee.compare fee prev in
+        if cmp_res < 0 then Ok ()
+        else if cmp_res = 0 then
+          reject_and_log_if_local Intf.Verification_error.Fee_equal
+        else reject_and_log_if_local Intf.Verification_error.Fee_higher
 
   let verify pool ({ data; sender; _ } as t : t Envelope.Incoming.t) =
     match data with
     | Empty ->
-        Deferred.Or_error.error_string "cannot verify empty snark pool diff"
-    | Add_solved_work (work, ({ Priced_proof.fee; _ } as p)) -> (
+        Deferred.Result.fail
+        @@ Intf.Verification_error.Invalid
+             (Error.of_string "empty snark pool diff")
+    | Add_solved_work (work, ({ Priced_proof.fee; _ } as p)) ->
         let is_local = match sender with Local -> true | _ -> false in
+        let open Deferred.Result in
         let verify () =
-          if%map Pool.verify_and_act pool ~work:(work, p) ~sender then
-            Or_error.return t
-          else Or_error.error_string "failed to verify snark pool diff"
+          Pool.verify_and_act pool ~work:(work, p) ~sender >>| const t
         in
         (*reject higher priced gossiped proofs*)
         if is_local then verify ()
         else
-          match has_lower_fee pool work ~fee:fee.fee ~sender with
-          | Ok () ->
-              verify ()
-          | Error e ->
-              Deferred.return (Error e) )
+          Deferred.return (has_no_lower_fee pool work ~fee:fee.fee ~sender)
+          >>= verify
 
   (* This is called after verification has occurred.*)
   let unsafe_apply (pool : Pool.t) (t : t Envelope.Incoming.t) =
@@ -148,7 +149,7 @@ module Make
           | `Added ->
               Ok (diff, ())
         in
-        match has_lower_fee pool work ~fee:fee.fee ~sender with
+        match has_no_lower_fee pool work ~fee:fee.fee ~sender with
         | Ok () ->
             let%map.Result accepted, rejected =
               Pool.add_snark ~is_local pool ~work ~proof ~fee |> to_or_error
@@ -156,22 +157,47 @@ module Make
             (`Accept, accepted, rejected)
         | Error e ->
             if is_local then Error (`Locally_generated (diff, ()))
-            else Error (`Other e) )
+            else Error (`Other (Intf.Verification_error.to_error e)) )
 
   type Structured_log_events.t +=
     | Snark_work_received of { work : compact; sender : Envelope.Sender.t }
     [@@deriving
       register_event { msg = "Received Snark-pool diff $work from $sender" }]
 
-  let update_metrics envelope valid_cb gossip_heard_logger_option =
+  let update_metrics ~logger ~log_gossip_heard
+      (Envelope.Incoming.{ data = diff; sender; _ } : t Envelope.Incoming.t)
+      valid_cb =
     Mina_metrics.(Counter.inc_one Network.gossip_messages_received) ;
     Mina_metrics.(Gauge.inc_one Network.snark_pool_diff_received) ;
-    let diff = Envelope.Incoming.data envelope in
-    Option.iter gossip_heard_logger_option ~f:(fun logger ->
-        Option.iter (to_compact diff) ~f:(fun work ->
-            [%str_log debug]
-              (Snark_work_received
-                 { work; sender = Envelope.Incoming.sender envelope } ) ) ) ;
+    if log_gossip_heard then
+      Option.iter (to_compact diff) ~f:(fun work ->
+          [%str_log debug] (Snark_work_received { work; sender }) ) ;
     Mina_metrics.(Counter.inc_one Network.Snark_work.received) ;
     Mina_net2.Validation_callback.set_message_type valid_cb `Snark_work
+
+  let log_internal ?reason ~logger msg = function
+    | { Envelope.Incoming.data = Empty; _ } ->
+        ()
+    | { data = Add_solved_work (work, { fee = { fee; prover }; _ }); sender; _ }
+      ->
+        let metadata =
+          [ ("work_ids", Transaction_snark_work.Statement.compact_json work)
+          ; ("fee", Currency.Fee.to_yojson fee)
+          ; ("prover", Signature_lib.Public_key.Compressed.to_yojson prover)
+          ]
+        in
+        let metadata =
+          match sender with
+          | Remote addr ->
+              ("sender", `String (Core.Unix.Inet_addr.to_string @@ Peer.ip addr))
+              :: metadata
+          | Local ->
+              metadata
+        in
+        let metadata =
+          Option.value_map reason
+            ~f:(fun r -> List.cons ("reason", `String r))
+            ~default:ident metadata
+        in
+        [%log internal] "%s" ("Snark_work_" ^ msg) ~metadata
 end

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -3015,9 +3015,8 @@ let%test_module _ =
                    ]
                  ~sender:Envelope.Sender.Local )
           with
-          | Error e ->
-              String.is_substring (Error.to_string_hum e)
-                ~substring:"Invalid_proof"
-          | Ok _ ->
+          | Error (Intf.Verification_error.Invalid e) ->
+              String.is_substring (Error.to_string_hum e) ~substring:"proof"
+          | _ ->
               false )
   end )

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1020,23 +1020,23 @@ struct
 
       (** DO NOT mutate any transaction pool state in this function, you may only mutate in the synchronous `apply` function. *)
       let verify (t : pool) (diff : t Envelope.Incoming.t) :
-          verified Envelope.Incoming.t Deferred.Or_error.t =
-        let open Deferred.Or_error.Let_syntax in
-        let ok_if_true cond ~error =
-          Deferred.return
-            (Result.ok_if_true cond ~error:(Error.of_string error))
-        in
+          ( verified Envelope.Incoming.t
+          , Intf.Verification_error.t )
+          Deferred.Result.t =
+        let open Deferred.Result.Let_syntax in
         let is_sender_local =
           Envelope.Sender.(equal Local) (Envelope.Incoming.sender diff)
         in
+        let open Intf.Verification_error in
         let%bind () =
           (* TODO: we should probably remove this -- the libp2p gossip cache should cover this already (#11704) *)
           let (`Already_mem already_mem) =
             Lru_cache.add t.recently_seen (Lru_cache.T.hash diff.data)
           in
-          ok_if_true
-            (not (already_mem && not is_sender_local))
-            ~error:"Recently seen"
+          Deferred.return
+          @@ Result.ok_if_true
+               (not (already_mem && not is_sender_local))
+               ~error:Recently_seen
         in
         let%bind () =
           let well_formedness_errors =
@@ -1070,16 +1070,18 @@ struct
               ~compare:User_command.Well_formedness_error.compare
           with
           | [] ->
-              Deferred.Or_error.return ()
+              return ()
           | errs ->
               let err_str =
                 List.map errs ~f:User_command.Well_formedness_error.to_string
                 |> String.concat ~sep:","
               in
-              Deferred.Or_error.fail
-              @@ Error.createf
-                   "Some commands have one or more well-formedness errors: %s "
-                   err_str
+              Deferred.Result.fail
+              @@ Invalid
+                   (Error.createf
+                      "Some commands have one or more well-formedness errors: \
+                       %s "
+                      err_str )
         in
         (* TODO: batch `to_verifiable` (#11705) *)
         let%bind ledger =
@@ -1087,9 +1089,11 @@ struct
           | Some ledger ->
               return ledger
           | None ->
-              Deferred.Or_error.error_string
-                "We don't have a transition frontier at the moment, so we're \
-                 unable to verify any transactions."
+              Deferred.Result.fail
+              @@ Failure
+                   (Error.of_string
+                      "We don't have a transition frontier at the moment, so \
+                       we're unable to verify any transactions." )
         in
 
         let%bind diff' =
@@ -1114,7 +1118,7 @@ struct
           |> Envelope.Incoming.lift_error
           |> Result.map
                ~f:(Envelope.Incoming.map ~f:(List.map ~f:With_status.data))
-          |> Result.map_error ~f:(Error.tag ~tag:"Verification_failed")
+          |> Result.map_error ~f:(fun e -> Invalid e)
           |> Deferred.return
         in
         match%bind.Deferred
@@ -1130,7 +1134,7 @@ struct
                 [ ( "transaction_pool_diff"
                   , Diff_versioned.to_yojson (Envelope.Incoming.data diff) )
                 ] ;
-            Deferred.return (Error (Error.tag e ~tag:"Internal_error"))
+            Deferred.Result.fail (Failure e)
         | Ok (Error invalid) ->
             let err = Verifier.invalid_to_error invalid in
             [%log' error t.logger]
@@ -1144,20 +1148,19 @@ struct
                     ( "rejecting command because had invalid signature or proof"
                     , [] ) )
             in
-            Error (Error.tag err ~tag:"Verification_failed")
+            Error (Invalid err)
         | Ok (Ok commands) ->
             (* TODO: avoid duplicate hashing (#11706) *)
             O1trace.sync_thread "hashing_transactions_after_verification"
               (fun () ->
-                Deferred.return
-                  (Ok
-                     { diff with
-                       data =
-                         List.map commands
-                           ~f:
-                             Transaction_hash.User_command_with_valid_signature
-                             .create
-                     } ) )
+                return
+                  { diff with
+                    data =
+                      List.map commands
+                        ~f:
+                          Transaction_hash.User_command_with_valid_signature
+                          .create
+                  } )
 
       let register_locally_generated t txn =
         Hashtbl.update t.locally_generated_uncommitted txn ~f:(function
@@ -1392,16 +1395,45 @@ struct
           register_event
             { msg = "Received transaction-pool diff $txns from $sender" }]
 
-      let update_metrics envelope valid_cb gossip_heard_logger_option =
+      let update_metrics ~logger ~log_gossip_heard envelope valid_cb =
         Mina_metrics.(Counter.inc_one Network.gossip_messages_received) ;
         Mina_metrics.(Gauge.inc_one Network.transaction_pool_diff_received) ;
         let diff = Envelope.Incoming.data envelope in
-        Option.iter gossip_heard_logger_option ~f:(fun logger ->
-            [%str_log debug]
-              (Transactions_received
-                 { txns = diff; sender = Envelope.Incoming.sender envelope } ) ) ;
+        if log_gossip_heard then
+          [%str_log debug]
+            (Transactions_received
+               { txns = diff; sender = Envelope.Incoming.sender envelope } ) ;
         Mina_net2.Validation_callback.set_message_type valid_cb `Transaction ;
         Mina_metrics.(Counter.inc_one Network.Transaction.received)
+
+      let log_internal ?reason ~logger msg
+          { Envelope.Incoming.data = diff; sender; _ } =
+        let metadata =
+          [ ( "diff"
+            , `List
+                (List.map diff
+                   ~f:Mina_transaction.Transaction.yojson_summary_of_command )
+            )
+          ]
+        in
+        let metadata =
+          match sender with
+          | Remote addr ->
+              ("sender", `String (Core.Unix.Inet_addr.to_string @@ Peer.ip addr))
+              :: metadata
+          | Local ->
+              metadata
+        in
+        let metadata =
+          Option.value_map reason
+            ~f:(fun r -> List.cons ("reason", `String r))
+            ~default:ident metadata
+        in
+        if not (is_empty diff) then
+          [%log internal] "%s" ("Transaction_diff_" ^ msg) ~metadata
+
+      let t_of_verified =
+        List.map ~f:Transaction_hash.User_command_with_valid_signature.command
     end
 
     let get_rebroadcastable (t : t) ~has_timed_out =
@@ -2066,7 +2098,8 @@ let%test_module _ =
           (Envelope.Incoming.wrap
              ~data:(List.map ~f:User_command.forget_check cs)
              ~sender )
-        >>| Or_error.ok_exn
+        >>| Fn.compose Or_error.ok_exn
+              (Result.map_error ~f:Intf.Verification_error.to_error)
       in
       let result =
         Test.Resource_pool.Diff.unsafe_apply test.txn_pool verified

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1994,7 +1994,7 @@ module T = struct
                               , `String
                                   "Snark fee insufficient to create snark \
                                    worker account" )
-                            ; ( "interrupt_get_completed_work_work_ids"
+                            ; ( "interrupt_get_completed_work_ids"
                               , Transaction_snark_work.Statement.compact_json w
                               )
                             ] ;
@@ -2014,7 +2014,7 @@ module T = struct
                           [ ("interrupt_get_completed_work_at", `Int count)
                           ; ( "interrupt_get_completed_work_reason"
                             , `String "Snark work for statement not found" )
-                          ; ( "interrupt_get_completed_work_work_ids"
+                          ; ( "interrupt_get_completed_work_ids"
                             , Transaction_snark_work.Statement.compact_json w )
                           ] ;
                       Stop (seq, count) )

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1994,6 +1994,9 @@ module T = struct
                               , `String
                                   "Snark fee insufficient to create snark \
                                    worker account" )
+                            ; ( "interrupt_get_completed_work_work_ids"
+                              , Transaction_snark_work.Statement.compact_json w
+                              )
                             ] ;
                         Stop (seq, count) )
                   | None ->
@@ -2011,6 +2014,8 @@ module T = struct
                           [ ("interrupt_get_completed_work_at", `Int count)
                           ; ( "interrupt_get_completed_work_reason"
                             , `String "Snark work for statement not found" )
+                          ; ( "interrupt_get_completed_work_work_ids"
+                            , Transaction_snark_work.Statement.compact_json w )
                           ] ;
                       Stop (seq, count) )
                 ~finish:Fn.id

--- a/src/lib/transaction/transaction.ml
+++ b/src/lib/transaction/transaction.ml
@@ -152,20 +152,21 @@ let check_well_formedness ~genesis_constants (t : t) =
       Ok ()
 
 let yojson_summary_of_command =
-  let mk_record type_ memo hash =
+  let mk_record type_ memo signature =
     `List
       [ `String type_
-      ; `String (Transaction_hash.to_base58_check hash)
+      ; `String (Signature.to_base58_check signature)
       ; `String (Signed_command_memo.to_string_hum memo)
       ]
   in
   function
-  | User_command.Zkapp_command cmd as ucmd ->
+  | User_command.Zkapp_command cmd ->
       mk_record "zkapp" (Zkapp_command.memo cmd)
-        (Transaction_hash.hash_command ucmd)
-  | Signed_command cmd as ucmd ->
+        ( Zkapp_command.fee_payer_account_update cmd
+        |> Account_update.Fee_payer.authorization )
+  | Signed_command cmd ->
       mk_record "payment" (Signed_command.memo cmd)
-        (Transaction_hash.hash_command ucmd)
+        (Signed_command.signature cmd)
 
 let yojson_summary = function
   | Command cmd ->

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -40,9 +40,8 @@ module Statement = struct
   let gen = One_or_two.gen Transaction_snark.Statement.gen
 
   let compact_json t =
-    `List
-      ( One_or_two.map ~f:(fun s -> `Int (Transaction_snark.Statement.hash s)) t
-      |> One_or_two.to_list )
+    let f s = `Int (Transaction_snark.Statement.hash s) in
+    `List (One_or_two.map ~f t |> One_or_two.to_list)
 
   let work_ids t : int One_or_two.t =
     One_or_two.map t ~f:Transaction_snark.Statement.hash

--- a/src/lib/transition_handler/block_sink.ml
+++ b/src/lib/transition_handler/block_sink.ml
@@ -18,6 +18,7 @@ type block_sink_config =
   ; log_gossip_heard : bool
   ; consensus_constants : Consensus.Constants.t
   ; genesis_constants : Genesis_constants.t
+  ; constraint_constants : Genesis_constants.Constraint_constants.t
   }
 
 type t =
@@ -30,6 +31,7 @@ type t =
       ; log_gossip_heard : bool
       ; consensus_constants : Consensus.Constants.t
       ; genesis_constants : Genesis_constants.t
+      ; constraint_constants : Genesis_constants.Constraint_constants.t
       }
   | Void
 
@@ -50,6 +52,7 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
       ; log_gossip_heard
       ; consensus_constants
       ; genesis_constants
+      ; constraint_constants
       } ->
       O1trace.sync_thread "handle_block_gossip"
       @@ fun () ->
@@ -65,11 +68,17 @@ let push sink (`Transition e, `Time_received tm, `Valid_cb cb) =
       @@ fun () ->
       Internal_tracing.with_state_hash state_hash
       @@ fun () ->
+      let open Mina_transaction in
+      let txs =
+        Mina_block.transactions ~constraint_constants state
+        |> List.map ~f:Transaction.yojson_summary_with_status
+      in
       [%log internal] "@block_metadata"
         ~metadata:
           [ ( "blockchain_length"
             , Mina_numbers.Length.to_yojson (Mina_block.blockchain_length state)
             )
+          ; ("transactions", `List txs)
           ] ;
       [%log internal] "External_block_received" ;
       let processing_start_time =
@@ -197,6 +206,7 @@ let create
     ; log_gossip_heard
     ; consensus_constants
     ; genesis_constants
+    ; constraint_constants
     } =
   let rate_limiter =
     Network_pool.Rate_limiter.create
@@ -217,6 +227,7 @@ let create
       ; log_gossip_heard
       ; consensus_constants
       ; genesis_constants
+      ; constraint_constants
       } )
 
 let void = Void

--- a/src/lib/transition_handler/block_sink.mli
+++ b/src/lib/transition_handler/block_sink.mli
@@ -20,6 +20,7 @@ type block_sink_config =
   ; log_gossip_heard : bool
   ; consensus_constants : Consensus.Constants.t
   ; genesis_constants : Genesis_constants.t
+  ; constraint_constants : Genesis_constants.Constraint_constants.t
   }
 
 val create :


### PR DESCRIPTION
Add internal logs to allow to track lifecycle of a transaction or snark work from its receival through validation down to inclusion into a block.

Explain your changes:
* Add internal logs to track transaction and snark work lifecycle

Explain how you tested your changes:
* Tested on a private cluster

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
