### PR TITLE
[compatible] Add parameter to stop the chain after given slot

### DIFF
--- a/src/app/cli/src/cli_entrypoint/dune
+++ b/src/app/cli/src/cli_entrypoint/dune
@@ -64,6 +64,7 @@
    blockchain_snark
    snarky.backendless
    o1trace
+   mina_numbers
  )
  (preprocessor_deps ../../../../config.mlh)
  (instrumentation (backend bisect_ppx))

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1277,7 +1277,9 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                   "Cannot provide both uptime submitter public key and uptime \
                    submitter keyfile"
           in
-          let slot_tx_end = Option.map ~f:Mina_numbers.Account_nonce.of_int slot_tx_end in
+          let slot_tx_end =
+            Option.map ~f:Mina_numbers.Global_slot.of_int slot_tx_end
+          in
           let start_time = Time.now () in
           let%map coda =
             Mina_lib.create ~wallets

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -430,6 +430,12 @@ let setup_daemon logger =
          for the associated private key that is being tracked by this daemon. \
          You cannot provide both `uptime-submitter-key` and \
          `uptime-submitter-pubkey`."
+  and slot_tx_end =
+    flag "--slot-tx-end" ~aliases:[ "slot-tx-end" ]
+      ~doc:
+        "Slot after which the node will stop accepting transactions. (default: \
+         disabled)"
+      (optional int)
   in
   let to_pubsub_topic_mode_option =
     let open Gossip_net.Libp2p in
@@ -1301,7 +1307,8 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                  ~log_block_creation ~precomputed_values ~start_time
                  ?precomputed_blocks_path ~log_precomputed_blocks
                  ~upload_blocks_to_gcloud ~block_reward_threshold ~uptime_url
-                 ~uptime_submitter_keypair ~stop_time ~node_status_url () )
+                 ~uptime_submitter_keypair ~stop_time ~node_status_url ()
+                 ~slot_tx_end )
           in
           { Coda_initialization.coda
           ; client_trustlist

--- a/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
+++ b/src/app/cli/src/cli_entrypoint/mina_cli_entrypoint.ml
@@ -1277,6 +1277,7 @@ Pass one of -peer, -peer-list-file, -seed, -peer-list-url.|} ;
                   "Cannot provide both uptime submitter public key and uptime \
                    submitter keyfile"
           in
+          let slot_tx_end = Option.map ~f:Mina_numbers.Account_nonce.of_int slot_tx_end in
           let start_time = Time.now () in
           let%map coda =
             Mina_lib.create ~wallets

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -654,15 +654,14 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                   @@ Mina_block.header (With_hash.data previous_transition) )
             in
             let slot =
-              Mina_numbers.Account_nonce.to_int
-              @@ Consensus.Data.Consensus_time.to_global_slot
+              Consensus.Data.Consensus_time.to_global_slot
                    (Consensus.Data.Consensus_time.of_time_exn
                       ~constants:consensus_constants
                       (Block_time.now time_controller) )
             in
             let transactions =
               match slot_tx_end with
-              | Some slot_tx_end' when slot >= slot_tx_end' ->
+              | Some slot_tx_end' when Mina_numbers.Account_nonce.(slot >= slot_tx_end') ->
                   Sequence.empty
               | Some _ | None ->
                   Network_pool.Transaction_pool.Resource_pool.transactions

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -653,15 +653,17 @@ let run ~logger ~vrf_evaluator ~prover ~verifier ~trust_system
                   ( Header.protocol_state_proof
                   @@ Mina_block.header (With_hash.data previous_transition) )
             in
-            let slot =
-              Consensus.Data.Consensus_time.to_global_slot
-                   (Consensus.Data.Consensus_time.of_time_exn
-                      ~constants:consensus_constants
-                      (Block_time.now time_controller) )
+            let current_global_slot =
+              Consensus.Data.Consensus_time.(
+                to_global_slot
+                  (of_time_exn ~constants:consensus_constants
+                     (Block_time.now time_controller) ))
             in
             let transactions =
               match slot_tx_end with
-              | Some slot_tx_end' when Mina_numbers.Account_nonce.(slot >= slot_tx_end') ->
+              | Some slot_tx_end'
+                when Mina_numbers.Global_slot.(
+                       current_global_slot >= slot_tx_end') ->
                   Sequence.empty
               | Some _ | None ->
                   Network_pool.Transaction_pool.Resource_pool.transactions

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -68,19 +68,22 @@ let setup_and_submit_user_command t (user_command_input : User_command_input.t)
   let open Participating_state.Let_syntax in
   (* hack to get types to work out *)
   let%map () = return () in
-  let slot =
-    Consensus.Data.Consensus_time.to_global_slot
-         (Consensus.Data.Consensus_time.of_time_exn
-            ~constants:
-              (Mina_lib.config t).precomputed_values.consensus_constants
-            (Block_time.now (Mina_lib.config t).time_controller) )
+  let current_global_slot =
+    let config = Mina_lib.config t in
+    Consensus.Data.Consensus_time.(
+      to_global_slot
+        (of_time_exn ~constants:config.precomputed_values.consensus_constants
+           (Block_time.now config.time_controller) ))
   in
   let open Deferred.Let_syntax in
   match (Mina_lib.config t).slot_tx_end with
-  | Some slot_tx_end when Account_nonce.(slot >= slot_tx_end) ->
+  | Some slot_tx_end when Global_slot.(current_global_slot >= slot_tx_end) ->
       [%log' warn (Mina_lib.top_level_logger t)]
         "can't produce transaction in slot $slot, tx production ends at $end"
-        ~metadata:[ ("slot", `Int (Account_nonce.to_int slot)); ("end", `Int (Account_nonce.to_int slot_tx_end)) ] ;
+        ~metadata:
+          [ ("slot", `Int (Global_slot.to_int current_global_slot))
+          ; ("end", `Int (Global_slot.to_int slot_tx_end))
+          ] ;
       Deferred.return (Error (Error.of_string "tx production has ended"))
   | Some _ | None -> (
       let%map result = Mina_lib.add_transactions t [ user_command_input ] in
@@ -122,18 +125,21 @@ let setup_and_submit_user_command t (user_command_input : User_command_input.t)
 let setup_and_submit_user_commands t user_command_list =
   let open Participating_state.Let_syntax in
   let%map _is_active = Mina_lib.active_or_bootstrapping t in
-  let slot =
-    Consensus.Data.Consensus_time.to_global_slot
-         (Consensus.Data.Consensus_time.of_time_exn
-            ~constants:
-              (Mina_lib.config t).precomputed_values.consensus_constants
-            (Block_time.now (Mina_lib.config t).time_controller) )
+  let config = Mina_lib.config t in
+  let current_global_slot =
+    Consensus.Data.Consensus_time.(
+      to_global_slot
+        (of_time_exn ~constants:config.precomputed_values.consensus_constants
+           (Block_time.now config.time_controller) ))
   in
-  match (Mina_lib.config t).slot_tx_end with
-  | Some slot_tx_end when Account_nonce.(slot >= slot_tx_end) ->
+  match config.slot_tx_end with
+  | Some slot_tx_end when Global_slot.(current_global_slot >= slot_tx_end) ->
       [%log' warn (Mina_lib.top_level_logger t)]
         "can't produce transactions in slot $slot, tx production ends at $end"
-        ~metadata:[ ("slot", `Int (Account_nonce.to_int slot)); ("end", `Int (Account_nonce.to_int slot_tx_end)) ] ;
+        ~metadata:
+          [ ("slot", `Int (Global_slot.to_int current_global_slot))
+          ; ("end", `Int (Global_slot.to_int slot_tx_end))
+          ] ;
       Deferred.return (Error (Error.of_string "tx production has ended"))
   | Some _ | None ->
       [%log' warn (Mina_lib.top_level_logger t)]

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -59,6 +59,6 @@ type t =
   ; uptime_url : Uri.t option [@default None]
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; stop_time : int
-  ; slot_tx_end : int option [@default None]
+  ; slot_tx_end : Mina_numbers.Account_nonce.t option [@default None]
   }
 [@@deriving make]

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -59,6 +59,6 @@ type t =
   ; uptime_url : Uri.t option [@default None]
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; stop_time : int
-  ; slot_tx_end : Mina_numbers.Account_nonce.t option [@default None]
+  ; slot_tx_end : Mina_numbers.Global_slot.t option [@default None]
   }
 [@@deriving make]

--- a/src/lib/mina_lib/config.ml
+++ b/src/lib/mina_lib/config.ml
@@ -59,5 +59,6 @@ type t =
   ; uptime_url : Uri.t option [@default None]
   ; uptime_submitter_keypair : Keypair.t option [@default None]
   ; stop_time : int
+  ; slot_tx_end : int option [@default None]
   }
 [@@deriving make]

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -43,7 +43,7 @@ val empty :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> consensus_constants:Consensus.Constants.t
   -> time_controller:Block_time.Controller.t
-  -> slot_tx_end:Account_nonce.t option
+  -> slot_tx_end:Global_slot.t option
   -> t
 
 (** How many transactions are currently in the pool *)
@@ -141,7 +141,7 @@ val revalidate :
 val current_global_slot : t -> Mina_numbers.Global_slot.t
 
 (** Get the slot at which transactions are no longer accepted. *)
-val slot_tx_end : t -> Account_nonce.t option
+val slot_tx_end : t -> Global_slot.t option
 
 (** Empties the pool *)
 val drop_all : t -> t

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -27,6 +27,7 @@ module Command_error : sig
         * [ `Current_global_slot of Mina_numbers.Global_slot.t ]
     | Unwanted_fee_token of Token_id.t
     | Invalid_transaction
+    | After_slot_tx_end
   [@@deriving sexp_of, to_yojson]
 end
 
@@ -42,6 +43,7 @@ val empty :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> consensus_constants:Consensus.Constants.t
   -> time_controller:Block_time.Controller.t
+  -> slot_tx_end:Account_nonce.t option
   -> t
 
 (** How many transactions are currently in the pool *)
@@ -137,6 +139,12 @@ val revalidate :
 
 (** Get the current global slot according to the pool's time controller. *)
 val current_global_slot : t -> Mina_numbers.Global_slot.t
+
+(** Get the slot at which transactions are no longer accepted. *)
+val slot_tx_end : t -> Account_nonce.t option
+
+(** Empties the pool *)
+val drop_all : t -> t
 
 module For_tests : sig
   (** Checks the invariants of the data structure. If this throws an exception

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -29,6 +29,7 @@ module type Resource_pool_base_intf = sig
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
+    -> slot_tx_end:Mina_numbers.Account_nonce.t option
     -> frontier_broadcast_pipe:
          transition_frontier Option.t Broadcast_pipe.Reader.t
     -> config:Config.t
@@ -179,6 +180,7 @@ module type Network_pool_base_intf = sig
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
+    -> slot_tx_end:Mina_numbers.Account_nonce.t option
     -> frontier_broadcast_pipe:
          transition_frontier Option.t Broadcast_pipe.Reader.t
     -> logger:Logger.t
@@ -309,6 +311,7 @@ module type Transaction_pool_diff_intf = sig
       | Unwanted_fee_token
       | Expired
       | Overloaded
+      | After_slot_tx_end
     [@@deriving sexp, yojson]
 
     val to_string_hum : t -> string

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -29,7 +29,7 @@ module type Resource_pool_base_intf = sig
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
-    -> slot_tx_end:Mina_numbers.Account_nonce.t option
+    -> slot_tx_end:Mina_numbers.Global_slot.t option
     -> frontier_broadcast_pipe:
          transition_frontier Option.t Broadcast_pipe.Reader.t
     -> config:Config.t
@@ -180,7 +180,7 @@ module type Network_pool_base_intf = sig
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
-    -> slot_tx_end:Mina_numbers.Account_nonce.t option
+    -> slot_tx_end:Mina_numbers.Global_slot.t option
     -> frontier_broadcast_pipe:
          transition_frontier Option.t Broadcast_pipe.Reader.t
     -> logger:Logger.t

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -253,7 +253,8 @@ end)
     go ()
 
   let create ~config ~constraint_constants ~consensus_constants ~time_controller
-      ~frontier_broadcast_pipe ~logger ~log_gossip_heard ~on_remote_push =
+      ~slot_tx_end ~frontier_broadcast_pipe ~logger ~log_gossip_heard
+      ~on_remote_push =
     (*Diffs from tansition frontier extensions*)
     let tf_diff_reader, tf_diff_writer =
       Strict_pipe.(
@@ -262,8 +263,8 @@ end)
     let t, locals, remotes =
       of_resource_pool_and_diffs
         (Resource_pool.create ~constraint_constants ~consensus_constants
-           ~time_controller ~config ~logger ~frontier_broadcast_pipe
-           ~tf_diff_writer )
+           ~time_controller ~slot_tx_end ~config ~logger
+           ~frontier_broadcast_pipe ~tf_diff_writer )
         ~constraint_constants ~logger ~tf_diffs:tf_diff_reader ~log_gossip_heard
         ~on_remote_push
     in

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -103,7 +103,7 @@ module type S = sig
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
-    -> slot_tx_end:Mina_numbers.Account_nonce.t option
+    -> slot_tx_end:Mina_numbers.Global_slot.t option
     -> frontier_broadcast_pipe:
          transition_frontier option Broadcast_pipe.Reader.t
     -> log_gossip_heard:bool
@@ -382,8 +382,9 @@ struct
         in
         Deferred.don't_wait_for tf_deferred
 
-      let create ~constraint_constants ~consensus_constants:_ ~time_controller:_ ~slot_tx_end:_
-          ~frontier_broadcast_pipe ~config ~logger ~tf_diff_writer =
+      let create ~constraint_constants ~consensus_constants:_ ~time_controller:_
+          ~slot_tx_end:_ ~frontier_broadcast_pipe ~config ~logger
+          ~tf_diff_writer =
         let t =
           { snark_tables =
               { all = Statement_table.create ()
@@ -675,8 +676,8 @@ struct
           res
       | Error _e ->
           create ~config ~logger ~constraint_constants ~consensus_constants
-            ~time_controller ~slot_tx_end ~frontier_broadcast_pipe ~log_gossip_heard
-            ~on_remote_push
+            ~time_controller ~slot_tx_end ~frontier_broadcast_pipe
+            ~log_gossip_heard ~on_remote_push
     in
     store_periodically (resource_pool pool) ;
     (pool, r_sink, l_sink)
@@ -1133,8 +1134,8 @@ let%test_module "random set test" =
           let open Deferred.Let_syntax in
           let network_pool, _, _ =
             Mock_snark_pool.create ~logger:(Logger.null ()) ~config
-              ~constraint_constants ~consensus_constants ~time_controller ~slot_tx_end
-              ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
+              ~constraint_constants ~consensus_constants ~time_controller
+              ~slot_tx_end ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
               ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
           in
           let resource_pool = Mock_snark_pool.resource_pool network_pool in

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -44,6 +44,7 @@ module type S = sig
     -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> consensus_constants:Consensus.Constants.t
     -> time_controller:Block_time.Controller.t
+    -> slot_tx_end:Mina_numbers.Account_nonce.t option
     -> frontier_broadcast_pipe:
          transition_frontier option Broadcast_pipe.Reader.t
     -> log_gossip_heard:bool

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -22,6 +22,8 @@ let%test_module "network pool test" =
 
     let time_controller = Block_time.Controller.basic ~logger
 
+    let slot_tx_end = None
+
     let verifier =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Verifier.create ~logger ~proof_level ~constraint_constants
@@ -57,7 +59,7 @@ let%test_module "network pool test" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           let network_pool, _, _ =
             Mock_snark_pool.create ~config ~logger ~constraint_constants
-              ~consensus_constants ~time_controller
+              ~consensus_constants ~time_controller ~slot_tx_end
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
               ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
           in
@@ -112,7 +114,7 @@ let%test_module "network pool test" =
         let frontier_broadcast_pipe_r, _ = Broadcast_pipe.create (Some tf) in
         let network_pool, remote_sink, local_sink =
           Mock_snark_pool.create ~config ~logger ~constraint_constants
-            ~consensus_constants ~time_controller
+            ~consensus_constants ~time_controller ~slot_tx_end
             ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
             ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
         in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -65,7 +65,7 @@ module Diff_versioned = struct
     module Stable = struct
       [@@@no_toplevel_latest_type]
 
-      module V1 = struct
+      module V2 = struct
         type t =
           | Insufficient_replace_fee
           | Invalid_signature
@@ -83,6 +83,49 @@ module Diff_versioned = struct
         [@@deriving sexp, yojson]
 
         let to_latest = Fn.id
+      end
+
+      module V1 = struct
+        type t =
+          | Insufficient_replace_fee
+          | Invalid_signature
+          | Duplicate
+          | Sender_account_does_not_exist
+          | Invalid_nonce
+          | Insufficient_funds
+          | Insufficient_fee
+          | Overflow
+          | Bad_token
+          | Unwanted_fee_token
+          | Expired
+          | Overloaded
+        [@@deriving sexp, yojson]
+
+        let to_latest = function
+          | Insufficient_replace_fee ->
+              V2.Insufficient_replace_fee
+          | Invalid_signature ->
+              V2.Invalid_signature
+          | Duplicate ->
+              V2.Duplicate
+          | Sender_account_does_not_exist ->
+              V2.Sender_account_does_not_exist
+          | Invalid_nonce ->
+              V2.Invalid_nonce
+          | Insufficient_funds ->
+              V2.Insufficient_funds
+          | Insufficient_fee ->
+              V2.Insufficient_fee
+          | Overflow ->
+              V2.Overflow
+          | Bad_token ->
+              V2.Bad_token
+          | Unwanted_fee_token ->
+              V2.Unwanted_fee_token
+          | Expired ->
+              V2.Expired
+          | Overloaded ->
+              V2.Overloaded
       end
     end]
 
@@ -145,11 +188,20 @@ module Diff_versioned = struct
     module Stable = struct
       [@@@no_toplevel_latest_type]
 
+      module V2 = struct
+        type t = (User_command.Stable.V1.t * Diff_error.Stable.V2.t) list
+        [@@deriving sexp, yojson]
+
+        let to_latest = Fn.id
+      end
+
       module V1 = struct
         type t = (User_command.Stable.V1.t * Diff_error.Stable.V1.t) list
         [@@deriving sexp, yojson]
 
-        let to_latest = Fn.id
+        let to_latest =
+          List.map ~f:(fun (cmds, diff) ->
+              (cmds, Diff_error.Stable.V1.to_latest diff) )
       end
     end]
 

--- a/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
+++ b/src/lib/transaction_inclusion_status/transaction_inclusion_status.ml
@@ -76,6 +76,8 @@ let%test_module "transaction_status" =
 
     let time_controller = Block_time.Controller.basic ~logger
 
+    let slot_tx_end = None
+
     let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
     let proof_level = precomputed_values.proof_level
@@ -120,7 +122,7 @@ let%test_module "transaction_status" =
         Transaction_pool.create ~config
           ~constraint_constants:precomputed_values.constraint_constants
           ~consensus_constants:precomputed_values.consensus_constants
-          ~time_controller ~logger ~frontier_broadcast_pipe
+          ~time_controller ~slot_tx_end ~logger ~frontier_broadcast_pipe
           ~log_gossip_heard:false ~on_remote_push:(Fn.const Deferred.unit)
       in
       don't_wait_for


### PR DESCRIPTION
This PR introduces an optional parameter to the CLI (`slot-tx-end`), that defines the slot after which the node should reject new transactions and stop including any in blocks (in case the node is a BP). This functionality is part of the hard fork mechanism.

Summary of changes:

- Add optional `slot-tx-end` parameter to CLI.
- BP always uses an empty set of transactions to produce blocks after the `slot-tx-end` slot instead of fetching them from the transaction pool.
- The RPC function for sending user commands rejects commands after the `slot-tx-end` slot.
- The node doesn't try to add incoming transactions to the network pool after the `slot-tx-end` slot.
- The transaction pool drops all transactions when the `slot-tx-end` slot is reached.

Some unit tests (specifically, for the transaction pool) were added. The complete set of expected behaviors was demonstrated in a sandbox network.