### PR TITLE
Add snark pool information to the status metrics query results

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -12264,6 +12264,54 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "snarkPoolDiffReceived",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snarkPoolDiffBroadcasted",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pendingSnarkWork",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snarkPoolSize",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": { "kind": "SCALAR", "name": "Int", "ofType": null }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/src/lib/daemon_rpcs/types.ml
+++ b/src/lib/daemon_rpcs/types.ml
@@ -191,6 +191,10 @@ module Status = struct
       ; transaction_pool_diff_broadcasted : int
       ; transactions_added_to_pool : int
       ; transaction_pool_size : int
+      ; snark_pool_diff_received : int
+      ; snark_pool_diff_broadcasted : int
+      ; pending_snark_work : int
+      ; snark_pool_size : int
       }
     [@@deriving to_yojson, bin_io_unversioned, fields]
   end
@@ -423,9 +427,19 @@ module Status = struct
         let transaction_pool_size =
           fmt_field "transaction_pool_size" string_of_int
         in
+        let snark_pool_diff_received =
+          fmt_field "snark_pool_diff_received" string_of_int
+        in
+        let snark_pool_diff_broadcasted =
+          fmt_field "snark_pool_diff_broadcasted" string_of_int
+        in
+        let pending_snark_work = fmt_field "pending_snark_work" string_of_int in
+        let snark_pool_size = fmt_field "snark_pool_size" string_of_int in
         Metrics.Fields.to_list ~block_production_delay
           ~transaction_pool_diff_received ~transaction_pool_diff_broadcasted
           ~transactions_added_to_pool ~transaction_pool_size
+          ~snark_pool_diff_received ~snark_pool_diff_broadcasted
+          ~pending_snark_work ~snark_pool_size
         |> List.concat
         |> List.map ~f:(fun (s, v) -> ("\t" ^ s, v))
         |> digest_entries ~title:""

--- a/src/lib/mina_commands/mina_commands.ml
+++ b/src/lib/mina_commands/mina_commands.ml
@@ -458,6 +458,13 @@ let get_status ~flag t =
       ; transactions_added_to_pool =
           Float.to_int
           @@ Counter.value Transaction_pool.transactions_added_to_pool
+      ; snark_pool_diff_received =
+          Float.to_int @@ Gauge.value Network.snark_pool_diff_received
+      ; snark_pool_diff_broadcasted =
+          Float.to_int @@ Gauge.value Network.snark_pool_diff_broadcasted
+      ; snark_pool_size = Float.to_int @@ Gauge.value Snark_work.snark_pool_size
+      ; pending_snark_work =
+          Float.to_int @@ Gauge.value Snark_work.pending_snark_work
       }
   in
   { Daemon_rpcs.Types.Status.num_accounts

--- a/src/lib/mina_graphql/mina_graphql.ml
+++ b/src/lib/mina_graphql/mina_graphql.ml
@@ -520,7 +520,10 @@ module Types = struct
                ~block_production_delay:nn_int_list
                ~transaction_pool_diff_received:nn_int
                ~transaction_pool_diff_broadcasted:nn_int
-               ~transactions_added_to_pool:nn_int ~transaction_pool_size:nn_int )
+               ~transactions_added_to_pool:nn_int ~transaction_pool_size:nn_int
+               ~snark_pool_diff_received:nn_int
+               ~snark_pool_diff_broadcasted:nn_int ~pending_snark_work:nn_int
+               ~snark_pool_size:nn_int )
 
     let t : (_, Daemon_rpcs.Types.Status.t option) typ =
       obj "DaemonStatus" ~fields:(fun _ ->


### PR DESCRIPTION
This small change adds some data to a Graphql query output that allows VS dashboard (when run on a private cluster) to show useful metrics like size of the snark pool.

Explain how you tested your changes:
* Tested on a private cluster in conjunction with VS dashboard

Checklist:

- [x] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [x] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? None
