### PR TITLE
[develop] Bindings - pass runtime table parameter to proof creation

### DIFF
--- a/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
+++ b/src/lib/crypto/kimchi_backend/common/plonk_dlog_proof.ml
@@ -94,26 +94,29 @@ module type Inputs_intf = sig
 
     val create :
          Index.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.t array
-      -> Curve.Affine.Backend.t array
+      -> primary:Scalar_field.Vector.t
+      -> auxiliary:Scalar_field.Vector.t
+      -> runtime_tables:Scalar_field.t Kimchi_types.runtime_table array
+      -> prev_chals:Scalar_field.t array
+      -> prev_comms:Curve.Affine.Backend.t array
       -> t
 
     val create_async :
          Index.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.t array
-      -> Curve.Affine.Backend.t array
+      -> primary:Scalar_field.Vector.t
+      -> auxiliary:Scalar_field.Vector.t
+      -> runtime_tables:Scalar_field.t Kimchi_types.runtime_table array
+      -> prev_chals:Scalar_field.t array
+      -> prev_comms:Curve.Affine.Backend.t array
       -> t Promise.t
 
     val create_and_verify_async :
          Index.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.t array
-      -> Curve.Affine.Backend.t array
+      -> primary:Scalar_field.Vector.t
+      -> auxiliary:Scalar_field.Vector.t
+      -> runtime_tables:Scalar_field.t Kimchi_types.runtime_table array
+      -> prev_chals:Scalar_field.t array
+      -> prev_comms:Curve.Affine.Backend.t array
       -> t Promise.t
 
     val verify : Verifier_index.t -> t -> bool
@@ -220,7 +223,8 @@ module Make (Inputs : Inputs_intf) = struct
     Array.iter arr ~f:(fun fe -> Fq.Vector.emplace_back vec fe) ;
     vec
 
-  (** Note that this function will panic if any of the points are points at infinity *)
+  (** Note that this function will panic if any of the points are points at
+      infinity *)
   let opening_proof_of_backend_exn (t : Opening_proof_backend.t) =
     let g (x : G.Affine.Backend.t) : G.Affine.t =
       G.Affine.of_backend x |> Pickles_types.Or_infinity.finite_exn
@@ -437,7 +441,7 @@ module Make (Inputs : Inputs_intf) = struct
   let to_backend chal_polys primary_input t =
     to_backend' chal_polys (List.to_array primary_input) t
 
-  let create ?message pk ~primary ~auxiliary =
+  let create ?message pk ~primary ~auxiliary ~runtime_tables =
     let chal_polys =
       match (message : message option) with Some s -> s | None -> []
     in
@@ -451,10 +455,13 @@ module Make (Inputs : Inputs_intf) = struct
         ~f:(fun { Challenge_polynomial.commitment; _ } ->
           G.Affine.to_backend (Finite commitment) )
     in
-    let res = Backend.create pk primary auxiliary challenges commitments in
+    let res =
+      Backend.create pk ~primary ~auxiliary ~runtime_tables
+        ~prev_chals:challenges ~prev_comms:commitments
+    in
     of_backend res
 
-  let create_async ?message pk ~primary ~auxiliary =
+  let create_async ?message pk ~primary ~auxiliary ~runtime_tables =
     let chal_polys =
       match (message : message option) with Some s -> s | None -> []
     in
@@ -469,11 +476,12 @@ module Make (Inputs : Inputs_intf) = struct
           G.Affine.to_backend (Finite commitment) )
     in
     let%map.Promise res =
-      Backend.create_async pk primary auxiliary challenges commitments
+      Backend.create_async pk ~primary ~auxiliary ~runtime_tables
+        ~prev_chals:challenges ~prev_comms:commitments
     in
     of_backend res
 
-  let create_and_verify_async ?message pk ~primary ~auxiliary =
+  let create_and_verify_async ?message pk ~primary ~auxiliary ~runtime_tables =
     let chal_polys =
       match (message : message option) with Some s -> s | None -> []
     in
@@ -488,8 +496,8 @@ module Make (Inputs : Inputs_intf) = struct
           G.Affine.to_backend (Finite commitment) )
     in
     let%map.Promise res =
-      Backend.create_and_verify_async pk primary auxiliary challenges
-        commitments
+      Backend.create_and_verify_async pk ~primary ~auxiliary ~runtime_tables
+        ~prev_chals:challenges ~prev_comms:commitments
     in
     of_backend res
 

--- a/src/lib/crypto/kimchi_backend/gadgets/runner/runner.ml
+++ b/src/lib/crypto/kimchi_backend/gadgets/runner/runner.ml
@@ -24,8 +24,10 @@ let generate_and_verify_proof ?cs circuit =
         let proof =
           (* Only block_on_async for testing; do not do this in production!! *)
           Promise.block_on_async_exn (fun () ->
+              (* TODO(dw) pass runtime tables *)
               Tick.Proof.create_and_verify_async ~primary:public_inputs
-                ~auxiliary:auxiliary_inputs ~message:[] prover_index )
+                ~auxiliary:auxiliary_inputs ~runtime_tables:[||] ~message:[]
+                prover_index )
         in
         (proof, next_statement_hashed) )
       ~input_typ:Impl.Typ.unit ~return_typ:Impl.Typ.unit

--- a/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/pallas_based_plonk.ml
@@ -82,8 +82,8 @@ module Proof = Plonk_dlog_proof.Make (struct
     let batch_verify vks ts =
       Promise.run_in_thread (fun () -> batch_verify vks ts)
 
-    let create_aux ~f:create (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
+    let create_aux ~f:create (pk : Keypair.t) ~primary ~auxiliary
+        ~runtime_tables ~prev_chals ~prev_comms =
       (* external values contains [1, primary..., auxiliary ] *)
       let external_values i =
         let open Field.Vector in
@@ -106,21 +106,24 @@ module Proof = Plonk_dlog_proof.Make (struct
             done ;
             witness )
       in
-      create pk.index witness_cols prev_chals prev_comms
+      create pk.index witness_cols runtime_tables prev_chals prev_comms
 
-    let create_async (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms
-        ~f:(fun pk auxiliary_input prev_challenges prev_sgs ->
+    let create_async (pk : Keypair.t) ~primary ~auxiliary ~runtime_tables
+        ~prev_chals ~prev_comms =
+      create_aux pk ~primary ~auxiliary ~runtime_tables ~prev_chals ~prev_comms
+        ~f:(fun pk auxiliary_input runtime_tables prev_challenges prev_sgs ->
           Promise.run_in_thread (fun () ->
-              create pk auxiliary_input prev_challenges prev_sgs ) )
+              create pk auxiliary_input runtime_tables prev_challenges prev_sgs ) )
 
-    let create_and_verify_async (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
+    let create_and_verify_async (pk : Keypair.t) ~primary ~auxiliary
+        ~runtime_tables ~prev_chals ~prev_comms =
       failwith "not implemented"
     (* TODO: Remove this function when vesta_based_plonk.create_and_verify_async is removed *)
 
-    let create (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms ~f:create
+    let create (pk : Keypair.t) ~primary ~auxiliary ~runtime_tables ~prev_chals
+        ~prev_comms =
+      create_aux pk ~primary ~auxiliary ~runtime_tables ~prev_chals ~prev_comms
+        ~f:create
   end
 
   module Verifier_index = Kimchi_bindings.Protocol.VerifierIndex.Fq

--- a/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
+++ b/src/lib/crypto/kimchi_backend/pasta/vesta_based_plonk.ml
@@ -81,8 +81,8 @@ module Proof = Plonk_dlog_proof.Make (struct
     let batch_verify vks ts =
       Promise.run_in_thread (fun () -> batch_verify vks ts)
 
-    let create_aux ~f:create (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
+    let create_aux ~f:create (pk : Keypair.t) primary auxiliary runtime_tables
+        prev_chals prev_comms =
       (* external values contains [1, primary..., auxiliary ] *)
       let external_values i =
         let open Field.Vector in
@@ -105,23 +105,27 @@ module Proof = Plonk_dlog_proof.Make (struct
             done ;
             witness )
       in
-      create pk.index witness_cols prev_chals prev_comms
+      create pk.index witness_cols runtime_tables prev_chals prev_comms
 
-    let create_async (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms
-        ~f:(fun pk auxiliary_input prev_challenges prev_sgs ->
+    let create_async (pk : Keypair.t) ~primary ~auxiliary ~runtime_tables
+        ~prev_chals ~prev_comms =
+      create_aux pk primary auxiliary runtime_tables prev_chals prev_comms
+        ~f:(fun pk auxiliary_input runtime_tables prev_challenges prev_sgs ->
           Promise.run_in_thread (fun () ->
-              create pk auxiliary_input prev_challenges prev_sgs ) )
+              create pk auxiliary_input runtime_tables prev_challenges prev_sgs ) )
 
-    let create_and_verify_async (pk : Keypair.t) primary auxiliary prev_chals
-        prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms
-        ~f:(fun pk auxiliary_input prev_challenges prev_sgs ->
+    let create_and_verify_async (pk : Keypair.t) ~primary ~auxiliary
+        ~runtime_tables ~prev_chals ~prev_comms =
+      create_aux pk primary auxiliary runtime_tables prev_chals prev_comms
+        ~f:(fun pk auxiliary_input runtime_tables prev_challenges prev_sgs ->
           Promise.run_in_thread (fun () ->
-              create_and_verify pk auxiliary_input prev_challenges prev_sgs ) )
+              create_and_verify pk auxiliary_input runtime_tables
+                prev_challenges prev_sgs ) )
 
-    let create (pk : Keypair.t) primary auxiliary prev_chals prev_comms =
-      create_aux pk primary auxiliary prev_chals prev_comms ~f:create
+    let create (pk : Keypair.t) ~primary ~auxiliary ~runtime_tables ~prev_chals
+        ~prev_comms =
+      create_aux pk primary auxiliary runtime_tables prev_chals prev_comms
+        ~f:create
   end
 
   module Verifier_index = Kimchi_bindings.Protocol.VerifierIndex.Fp

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_bindings.ml
@@ -371,6 +371,7 @@ module Protocol = struct
       external create :
            Index.Fp.t
         -> FieldVectors.Fp.t array
+        -> Pasta_bindings.Fp.t Kimchi_types.runtime_table array
         -> Pasta_bindings.Fp.t array
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
@@ -380,6 +381,7 @@ module Protocol = struct
       external create_and_verify :
            Index.Fp.t
         -> FieldVectors.Fp.t array
+        -> Pasta_bindings.Fp.t Kimchi_types.runtime_table array
         -> Pasta_bindings.Fp.t array
         -> Pasta_bindings.Fq.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fq.t Kimchi_types.or_infinity
@@ -490,6 +492,7 @@ module Protocol = struct
       external create :
            Index.Fq.t
         -> FieldVectors.Fq.t array
+        -> Pasta_bindings.Fq.t Kimchi_types.runtime_table array
         -> Pasta_bindings.Fq.t array
         -> Pasta_bindings.Fp.t Kimchi_types.or_infinity array
         -> ( Pasta_bindings.Fp.t Kimchi_types.or_infinity

--- a/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
+++ b/src/lib/crypto/kimchi_bindings/stubs/kimchi_types.ml
@@ -103,6 +103,8 @@ type nonrec 'caml_f runtime_table_cfg =
 
 type nonrec 'caml_f lookup_table = { id : int32; data : 'caml_f array array }
 
+type nonrec 'caml_f runtime_table = { id : int32; data : 'caml_f array }
+
 type nonrec 'caml_g prover_commitments =
   { w_comm :
       'caml_g poly_comm

--- a/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/main.rs
@@ -2,7 +2,7 @@ use kimchi::circuits::{
     expr::FeatureFlag,
     lookup::{
         lookups::{LookupFeatures, LookupPattern, LookupPatterns},
-        runtime_tables::caml::CamlRuntimeTableCfg,
+        runtime_tables::caml::{CamlRuntimeTable, CamlRuntimeTableCfg},
         tables::caml::CamlLookupTable,
     },
 };
@@ -104,9 +104,10 @@ fn generate_types_bindings(mut w: impl std::io::Write, env: &mut Env) {
     decl_type!(w, env, CamlRecursionChallenge::<T1, T2> => "recursion_challenge");
     decl_type!(w, env, CamlOpeningProof::<T1, T2> => "opening_proof");
     decl_type!(w, env, CamlLookupCommitments::<T1> => "lookup_commitments");
+
     decl_type!(w, env, CamlRuntimeTableCfg::<T1> => "runtime_table_cfg");
     decl_type!(w, env, CamlLookupTable::<T1> => "lookup_table");
-
+    decl_type!(w, env, CamlRuntimeTable::<T1> => "runtime_table");
     decl_type!(w, env, CamlProverCommitments::<T1> => "prover_commitments");
     decl_type!(w, env, CamlProverProof<T1, T2> => "prover_proof");
 

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fp_plonk_proof.rs
@@ -9,8 +9,11 @@ use ark_ec::AffineCurve;
 use ark_ff::One;
 use array_init::array_init;
 use groupmap::GroupMap;
-use kimchi::prover_index::ProverIndex;
 use kimchi::verifier::verify;
+use kimchi::{
+    circuits::lookup::runtime_tables::{caml::CamlRuntimeTable, RuntimeTable},
+    prover_index::ProverIndex,
+};
 use kimchi::{circuits::polynomial::COLUMNS, verifier::batch_verify};
 use kimchi::{
     proof::{
@@ -37,6 +40,7 @@ type EFrSponge = DefaultFrSponge<Fp, PlonkSpongeConstantsKimchi>;
 pub fn caml_pasta_fp_plonk_proof_create(
     index: CamlPastaFpPlonkIndexPtr<'static>,
     witness: Vec<CamlFpVector>,
+    runtime_tables: Vec<CamlRuntimeTable<CamlFp>>,
     prev_challenges: Vec<CamlFp>,
     prev_sgs: Vec<CamlGVesta>,
 ) -> Result<CamlProverProof<CamlGVesta, CamlFp>, ocaml::Error> {
@@ -72,6 +76,8 @@ pub fn caml_pasta_fp_plonk_proof_create(
         .try_into()
         .map_err(|_| ocaml::Error::Message("the witness should be a column of 15 vectors"))?;
     let index: &ProverIndex<Vesta> = &index.as_ref().0;
+    let runtime_tables: Vec<RuntimeTable<Fp>> =
+        runtime_tables.into_iter().map(Into::into).collect();
 
     // public input
     let public_input = witness[0][0..index.cs.public].to_vec();
@@ -87,7 +93,7 @@ pub fn caml_pasta_fp_plonk_proof_create(
         let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
             &group_map,
             witness,
-            &[],
+            &runtime_tables,
             index,
             prev,
             None,
@@ -102,6 +108,7 @@ pub fn caml_pasta_fp_plonk_proof_create(
 pub fn caml_pasta_fp_plonk_proof_create_and_verify(
     index: CamlPastaFpPlonkIndexPtr<'static>,
     witness: Vec<CamlFpVector>,
+    runtime_tables: Vec<CamlRuntimeTable<CamlFp>>,
     prev_challenges: Vec<CamlFp>,
     prev_sgs: Vec<CamlGVesta>,
 ) -> Result<CamlProverProof<CamlGVesta, CamlFp>, ocaml::Error> {
@@ -137,6 +144,8 @@ pub fn caml_pasta_fp_plonk_proof_create_and_verify(
         .try_into()
         .map_err(|_| ocaml::Error::Message("the witness should be a column of 15 vectors"))?;
     let index: &ProverIndex<Vesta> = &index.as_ref().0;
+    let runtime_tables: Vec<RuntimeTable<Fp>> =
+        runtime_tables.into_iter().map(Into::into).collect();
 
     // public input
     let public_input = witness[0][0..index.cs.public].to_vec();
@@ -152,7 +161,7 @@ pub fn caml_pasta_fp_plonk_proof_create_and_verify(
         let proof = ProverProof::create_recursive::<EFqSponge, EFrSponge>(
             &group_map,
             witness,
-            &[],
+            &runtime_tables,
             index,
             prev,
             None,

--- a/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
+++ b/src/lib/crypto/kimchi_bindings/stubs/src/pasta_fq_plonk_proof.rs
@@ -8,7 +8,10 @@ use ark_ec::AffineCurve;
 use ark_ff::One;
 use array_init::array_init;
 use groupmap::GroupMap;
-use kimchi::prover_index::ProverIndex;
+use kimchi::{
+    circuits::lookup::runtime_tables::{caml::CamlRuntimeTable, RuntimeTable},
+    prover_index::ProverIndex,
+};
 use kimchi::{circuits::polynomial::COLUMNS, verifier::batch_verify};
 use kimchi::{
     proof::{
@@ -32,6 +35,7 @@ use std::convert::TryInto;
 pub fn caml_pasta_fq_plonk_proof_create(
     index: CamlPastaFqPlonkIndexPtr<'static>,
     witness: Vec<CamlFqVector>,
+    runtime_tables: Vec<CamlRuntimeTable<CamlFq>>,
     prev_challenges: Vec<CamlFq>,
     prev_sgs: Vec<CamlGPallas>,
 ) -> Result<CamlProverProof<CamlGPallas, CamlFq>, ocaml::Error> {
@@ -68,6 +72,9 @@ pub fn caml_pasta_fq_plonk_proof_create(
         .expect("the witness should be a column of 15 vectors");
     let index: &ProverIndex<Pallas> = &index.as_ref().0;
 
+    let runtime_tables: Vec<RuntimeTable<Fq>> =
+        runtime_tables.into_iter().map(Into::into).collect();
+
     // public input
     let public_input = witness[0][0..index.cs.public].to_vec();
 
@@ -82,7 +89,7 @@ pub fn caml_pasta_fq_plonk_proof_create(
         let proof = ProverProof::create_recursive::<
             DefaultFqSponge<PallasParameters, PlonkSpongeConstantsKimchi>,
             DefaultFrSponge<Fq, PlonkSpongeConstantsKimchi>,
-        >(&group_map, witness, &[], index, prev, None)
+        >(&group_map, witness, &runtime_tables, index, prev, None)
         .map_err(|e| ocaml::Error::Error(e.into()))?;
         Ok((proof, public_input).into())
     })

--- a/src/lib/pickles/pickles.ml
+++ b/src/lib/pickles/pickles.ml
@@ -1733,9 +1733,11 @@ module Make_str (_ : Wire_types.Concrete) = struct
                             ~f:(fun { Impls.Wrap.Proof_inputs.auxiliary_inputs
                                     ; public_inputs
                                     } () ->
+                              (* TODO(dw): pass runtime tables information *)
                               Backend.Tock.Proof.create_async
                                 ~primary:public_inputs
                                 ~auxiliary:auxiliary_inputs pk
+                                ~runtime_tables:[||]
                                 ~message:
                                   ( Vector.map2
                                       (Vector.extend_front_exn

--- a/src/lib/pickles/step.ml
+++ b/src/lib/pickles/step.ml
@@ -819,8 +819,9 @@ struct
                           } next_statement_hashed ->
                     [%log internal] "Backend_tick_proof_create_async" ;
                     let%map.Promise proof =
+                      (* TODO(dw) pass runtime tables *)
                       Backend.Tick.Proof.create_async ~primary:public_inputs
-                        ~auxiliary:auxiliary_inputs
+                        ~auxiliary:auxiliary_inputs ~runtime_tables:[||]
                         ~message:
                           (Lazy.force prev_challenge_polynomial_commitments)
                         pk

--- a/src/lib/pickles/wrap.ml
+++ b/src/lib/pickles/wrap.ml
@@ -862,8 +862,10 @@ let wrap
           ~f:(fun { Impls.Wrap.Proof_inputs.auxiliary_inputs; public_inputs } () ->
             [%log internal] "Backend_tock_proof_create_async" ;
             let%map.Promise proof =
+              (* TODO(dw) pass runtime tables *)
               Backend.Tock.Proof.create_async ~primary:public_inputs
-                ~auxiliary:auxiliary_inputs pk ~message:next_accumulator
+                ~auxiliary:auxiliary_inputs ~runtime_tables:[||] pk
+                ~message:next_accumulator
             in
             [%log internal] "Backend_tock_proof_create_async_done" ;
             proof )


### PR DESCRIPTION
Explain your changes:
* This PR, with their counterparts in https://github.com/o1-labs/snarkyjs/pull/1031 and https://github.com/o1-labs/snarkyjs-bindings/pull/85 add the parameter "runtime_tables" to the proof creation. For the moment, an empty array is given.
* See PR train : https://github.com/MinaProtocol/mina/issues/13086#issuecomment-1630930227

It will be followed by a PR adding runtime tables to the proof inputs. A WIP is already available in [this branch](https://github.com/MinaProtocol/mina/commits/dannywillems/track-runtime-table-cfg) and [here](https://github.com/o1-labs/snarky/pull/828). Please do not have a look now.

Explain how you tested your changes:
* locally running `./run-ci-tests` and relying on the CI in snarkyjs. The current expectation is to have the current tests running without any error. No semantic is added.

Checklist:

- [ ] Dependency versions are unchanged
  - Notify Velocity team if dependencies must change in CI
- [ ] Modified the current draft of release notes with details on what is completed or incomplete within this project
- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them

* Closes #0000
