### PR TITLE
Don't check ledger hash at start; restore final checkpoint

### DIFF
--- a/helm/cron_jobs/mainnet-replayer-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-replayer-cronjob.yaml
@@ -30,12 +30,12 @@ spec:
                echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list;
                curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - ;
                apt-get update && apt-get install -y google-cloud-cli ;
-               ARCHIVE_DUMP_URI=$(gsutil ls gs://mina-archive-dumps/mainnet-archive-dump-*.sql.tar.gz | sort -r | head -n 1);
+               ARCHIVE_DUMP_URI=$(gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json ls gs://mina-archive-dumps/mainnet-archive-dump-*.sql.tar.gz | sort -r | head -n 1);
                ARCHIVE_DUMP=$(basename $ARCHIVE_DUMP_URI);
                ARCHIVE_SQL=$(basename $ARCHIVE_DUMP_URI .tar.gz);
                echo "Getting archive dump" $ARCHIVE_DUMP_URI;
                gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $ARCHIVE_DUMP_URI . ;
-               MOST_RECENT_CHECKPOINT_URI=$(gsutil ls gs://mainnet-replayer-checkpoints/replayer-checkpoint-*.json | sort -r | head -n 1);
+               MOST_RECENT_CHECKPOINT_URI=$(gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json ls gs://mainnet-replayer-checkpoints/replayer-checkpoint-*.json | sort -r | head -n 1);
                MOST_RECENT_CHECKPOINT=$(basename $MOST_RECENT_CHECKPOINT_URI);
                echo "Getting replayer checkpoint file" $MOST_RECENT_CHECKPOINT;
                gsutil -o Credentials:gs_service_key_file=/gcloud/keyfile.json cp $MOST_RECENT_CHECKPOINT_URI . ;

--- a/helm/cron_jobs/mainnet-replayer-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-replayer-cronjob.yaml
@@ -73,7 +73,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-start-ledger-hash-5727c0e-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-start-ledger-hash-c912ce3-bullseye
             imagePullPolicy: IfNotPresent
             name: mainnet-replayer-cronjob
             resources:

--- a/helm/cron_jobs/mainnet-replayer-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-replayer-cronjob.yaml
@@ -73,7 +73,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-no-final-checkpoint-5af6dba-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-start-ledger-hash-5727c0e-bullseye
             imagePullPolicy: IfNotPresent
             name: mainnet-replayer-cronjob
             resources:

--- a/helm/cron_jobs/mainnet-replayer-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-replayer-cronjob.yaml
@@ -73,7 +73,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-start-ledger-hash-c912ce3-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-start-ledger-hash-8d41295-bullseye
             imagePullPolicy: IfNotPresent
             name: mainnet-replayer-cronjob
             resources:

--- a/helm/cron_jobs/mainnet-replayer-cronjob.yaml
+++ b/helm/cron_jobs/mainnet-replayer-cronjob.yaml
@@ -73,7 +73,7 @@ spec:
             env:
             - name: GCLOUD_KEYFILE
               value: /gcloud/keyfile.json
-            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-start-ledger-hash-8d41295-bullseye
+            image: gcr.io/o1labs-192920/mina-rosetta:1.4.0beta2-fix-replayer-start-ledger-hash-2627643-bullseye
             imagePullPolicy: IfNotPresent
             name: mainnet-replayer-cronjob
             resources:

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -107,7 +107,7 @@ module Block = struct
       |sql}
 
   let get_max_canonical_slot (module Conn : Caqti_async.CONNECTION) () =
-    Conn.find max_slot_query ()
+    Conn.find max_canonical_slot_query ()
 
   let next_slot_query =
     Caqti_request.find_opt Caqti_type.int64 Caqti_type.int64

--- a/src/app/replayer/sql.ml
+++ b/src/app/replayer/sql.ml
@@ -25,7 +25,7 @@ module Block_info = struct
       typ
       {sql| WITH RECURSIVE chain AS (
 
-              SELECT id,parent_id,global_slot_since_genesis,state_hash,ledger_hash FROM blocks b 
+              SELECT id,parent_id,global_slot_since_genesis,state_hash,ledger_hash FROM blocks b
               WHERE b.state_hash = $1
 
               UNION ALL
@@ -55,8 +55,8 @@ let find_command_ids_query s =
     {sql| WITH RECURSIVE chain AS (
 
             SELECT id,parent_id,global_slot_since_genesis FROM blocks b
-            WHERE b.state_hash = $1 
-            
+            WHERE b.state_hash = $1
+
             UNION ALL
 
             SELECT b.id,b.parent_id,b.global_slot_since_genesis FROM blocks b
@@ -94,10 +94,19 @@ module Block = struct
     Conn.find get_height_query block_id
 
   let max_slot_query =
-    Caqti_request.find Caqti_type.unit Caqti_type.int
+    Caqti_request.find Caqti_type.unit Caqti_type.int64
       {sql| SELECT MAX(global_slot_since_genesis) FROM blocks |sql}
 
   let get_max_slot (module Conn : Caqti_async.CONNECTION) () =
+    Conn.find max_slot_query ()
+
+  let max_canonical_slot_query =
+    Caqti_request.find Caqti_type.unit Caqti_type.int64
+      {sql| SELECT MAX(global_slot_since_genesis) FROM blocks
+            WHERE chain_status = 'canonical'
+      |sql}
+
+  let get_max_canonical_slot (module Conn : Caqti_async.CONNECTION) () =
     Conn.find max_slot_query ()
 
   let next_slot_query =
@@ -131,7 +140,7 @@ module Block = struct
     Conn.find genesis_block_id_query ()
 
   let state_hashes_by_slot_query =
-    Caqti_request.collect Caqti_type.int Caqti_type.string
+    Caqti_request.collect Caqti_type.int64 Caqti_type.string
       {sql| SELECT state_hash FROM blocks WHERE global_slot_since_genesis = $1 |sql}
 
   let get_state_hashes_by_slot (module Conn : Caqti_async.CONNECTION) slot =


### PR DESCRIPTION
After loading the blocks it's going to replay, the replayer builds a table from global slots to ledger and state hashes. If the start slot did not contain a block, it would search backwards and never find the most recent hashes, because only the blocks to be replayed are loaded, no blocks before the start slot. So don't look for the ledger hash at the start slot -- we haven't yet replayed anything. We didn't see this issue until we started using checkpoint files.

Also, restore the checkpoint file dumped at the finish, but only write a checkpoint file if the block at a slot is canonical.

Updated the cron job to use image from this PR.